### PR TITLE
fix reuse memory of global variables after restart

### DIFF
--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -118,6 +118,7 @@ namespace das
             exception = nullptr;
             stack.reset();
             heap.setWatermark(heapWatermark);
+            runInitScript();
         }
 
         __forceinline vec4f eval ( SimFunction * fnPtr, vec4f * args = nullptr, void * res = nullptr ) {

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -942,8 +942,6 @@ namespace das
         context.globalInitStackSize = globalInitStackSize;
         context.simEnd();
         context.restart();
-        context.runInitScript();
-        context.restart();
         if (options.getOption("logMem")) {
             logs << "code  " << context.code.bytesAllocated()       << " of " << context.code.bytesTotal() << "\n";
             logs << "debug " << context.debugInfo.bytesAllocated()  << " of " << context.debugInfo.bytesTotal() << "\n";


### PR DESCRIPTION
global variable must be reallocated and reinited at every restart of context