### PR TITLE
fix linux gcc and clang compilation

### DIFF
--- a/examples/profile/main.cpp
+++ b/examples/profile/main.cpp
@@ -27,12 +27,16 @@ void operator delete(void * p) throw()
 
 MAKE_TYPE_FACTORY(Object, Object)
 
+namespace das {
+
 template <>
 struct typeName<ObjectArray> {
     static string name() {
         return "ObjectArray";
     }
 };
+
+}
 
 TextPrinter tout;
 

--- a/include/daScript/misc/arraytype.h
+++ b/include/daScript/misc/arraytype.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional> // std::hash
+
 namespace das
 {
     struct SimNode;

--- a/include/daScript/misc/smart_ptr.h
+++ b/include/daScript/misc/smart_ptr.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional> // std::hash
+
 namespace das {
 
     template<typename T, typename TP>

--- a/include/ska/flat_hash_map.hpp
+++ b/include/ska/flat_hash_map.hpp
@@ -15,6 +15,13 @@
 #define SKA_NOINLINE(...) __VA_ARGS__ __attribute__((noinline))
 #endif
 
+#include <stdexcept>
+
+namespace das
+{
+  using out_of_range = std::out_of_range;
+}
+
 namespace das_ska
 {
 struct power_of_two_hash_policy;


### PR DESCRIPTION
- std::hash is not visible when compiling with clang 10.0.0
- std::out_of_range is not visible on both clang 10.0.0 and gcc 10.1.0
- template specilization must be placed in namespace where template is
defined (gcc with -fpermissive)

error: explicit specialization of ‘template<class TT> struct das::typeName’ outside its namespace must use a nested-name-specifier [-fpermissive]
   33 | struct typeName<ObjectArray> {