### PR TITLE
crash fixes

### DIFF
--- a/include/daScript/misc/memory_model.h
+++ b/include/daScript/misc/memory_model.h
@@ -259,7 +259,12 @@ namespace das {
         }
         ~HeapChunk() {
             das_aligned_free16(data);
-            if ( next ) delete next;
+            while (next) {
+                HeapChunk * toDelete = next;
+                next = toDelete->next;
+                toDelete->next = nullptr;
+                delete toDelete;
+            }
         }
         __forceinline char * allocate ( uint32_t s ) {
             if ( offset + s > size ) return nullptr;

--- a/src/simulate/runtime_string.cpp
+++ b/src/simulate/runtime_string.cpp
@@ -279,6 +279,7 @@ namespace das
             walker.walk(argValues[i], types[i]);
         }
         int length = writer.tellp();
+        writer.writeChars('\0', 1);
         if ( length ) {
             auto pStr = context.stringHeap->allocateString(writer.c_str(), length);
             if ( !pStr  ) {


### PR DESCRIPTION
- recursive deletion of HeapChunk list leads to stack overflow
- passing a non-ASCIIZ string to allocateString() leads to buffer overflow in internMap.find() which ignores the length