### PR TITLE
corrections of typos

### DIFF
--- a/doc/source/reference/language/arrays.rst
+++ b/doc/source/reference/language/arrays.rst
@@ -52,7 +52,7 @@ Which infers to ::
 
 Dynamic arrays can also be constructed inline::
 
-	let arr = [{auto "one"; "two"; "three"}]
+	let arr <- [{auto "one"; "two"; "three"}]
 
 Which is syntactic equivalent to::
 

--- a/doc/source/reference/language/builtin_functions.rst
+++ b/doc/source/reference/language/builtin_functions.rst
@@ -36,7 +36,7 @@ Misc
 .. das:function:: verify(x, str)
 
     verify will cause application defined assert if `x` argument is false.
-    verify check can be removed from release builds, but execution of `x` argument staus.
+    verify check can be removed from release builds, but execution of `x` argument stays.
     That's why verify, unlike assert can have side effects in evaluating `x`
 
 .. das:function:: static_assert(x, str)

--- a/doc/source/reference/language/clone.rst
+++ b/doc/source/reference/language/clone.rst
@@ -129,10 +129,10 @@ expands to::
         if src is i
             set_variant_index(dest,0)
             dest.i = src.i
-        else if src is a
+        elif src is a
             set_variant_index(dest,1)
             dest.a := src.a
-        else if src is s
+        elif src is s
             set_variant_index(dest,2)
             dest.s = src.s
 

--- a/doc/source/reference/language/expressions.rst
+++ b/doc/source/reference/language/expressions.rst
@@ -173,7 +173,7 @@ Arithmetic
 
 daScript supports the standard arithmetic operators ``+, -, *, / and %``.
 Other than that is also supports compact operators (``+=, -=, *=, /=, %=``) and
-increment and decrement operators(++ and --);::
+increment and decrement operators(``++ and --``)::
 
     a += 2
     // is the same as writing
@@ -212,7 +212,7 @@ Logical
     exp := exp op exp
     exp := '!' exp
 
-Logical operators in daScript are : ``&&, |, ^^, !, &&=, ||=, ^^=``
+Logical operators in daScript are : ``&&, ||, ^^, !, &&=, ||=, ^^=``
 
 The operator ``&&`` (logical and) returns false if its first argument is false, otherwise returns
 its second argument.
@@ -271,7 +271,7 @@ daScript supports pipe operators. Pipe operator is similar to 'call' expression 
         return a + 1
 
     def test
-        let t =  addOne <| 2
+        let t =  addOne() <| 2
         assert(t == 3)
 
 ^^^^^^^^^^^^^^^^^^^^^
@@ -339,7 +339,7 @@ Array Initializer
 Creates a new fixed size array::
 
     let a = [[int[] 1; 2]]     // creates array of two elements
-    let a = [[int[2] 1, 2]]    // creates array of two elements
+    let a = [[int[2] 1; 2]]    // creates array of two elements
     var a = [[auto 1; 2]]      // creates which fully infers its own type
     let a = [[int[2] 1; 2; 3]] // error, too many initializers
     var a = [[auto 1]]         // int

--- a/doc/source/reference/language/functions.rst
+++ b/doc/source/reference/language/functions.rst
@@ -266,9 +266,9 @@ However, code can be easily written "OOP style" by using right pipe operator ``|
     struct Foo
         x, y: int = 0
 
-    def setXY(var this: Foo; x, y: int)
-        this.x = x
-        this.y = y
+    def setXY(var thisFoo: Foo; x, y: int)
+        thisFoo.x = x
+        thisFoo.y = y
     ...
     var foo:Foo
     foo |> setXY(10, 11)   // this is syntactic sugar for setXY(foo, 10, 11)

--- a/doc/source/reference/language/lambdas.rst
+++ b/doc/source/reference/language/lambdas.rst
@@ -37,7 +37,7 @@ Lambda is typically declared via pipe syntax::
     let t = invoke(counter,13)
 
 There are a lot of similarities between lambda and block declarations.
-Main difference is that bocks are specified with ``$`` symbol, where lambda is specified with ``@`` symbol.
+Main difference is that blocks are specified with ``$`` symbol, where lambda is specified with ``@`` symbol.
 Lambda can also be declared via inline syntax.
 There is similar simplified syntax for the lambdas containing return expression only.
 If lambda is sufficiently specified in the generic or function,

--- a/doc/source/reference/language/statements.rst
+++ b/doc/source/reference/language/statements.rst
@@ -131,7 +131,7 @@ Executes a loop body statement for every element/iterator in expression, in sequ
 
     // or
 
-    var a: table<string; int>
+    var tab: table<string; int>
     for k, v in keys(tab), values(tab)
         print("{k}:{v}")   // will print content of table, in form key:value
 

--- a/doc/source/reference/language/string_builder.rst
+++ b/doc/source/reference/language/string_builder.rst
@@ -21,6 +21,6 @@ But generally, that can be run-time compiled as well.
 Expression in {} can be of any type, including handled extern type, provided that said type implements DataWalker.
 All PODs in daScript do have DataWalker 'to string' implementation.
 
-In order to make string with {} inside, one has to escape it with '\\\\' ::
+In order to make string with {} inside, one has to escape curly brackets with '\\' ::
 
     print("Curly brackets=\{\}")  // prints Curly brackets={}

--- a/doc/source/reference/language/structs.rst
+++ b/doc/source/reference/language/structs.rst
@@ -50,9 +50,9 @@ Structure fields are also initialized as zero by default, regardless of 'initial
 
 Structure field types are inferred, where possible::
 
-	stryct Foo
+	struct Foo
 		x = 1	// inferred as int
-		y = 2	// inferred as float
+		y = 2.0	// inferred as float
 
 Explicit structure initialization during creation will leave all uninitialized members zeroed::
 
@@ -84,8 +84,8 @@ For ease of Objected Oriented Programming non-virtual member functions can be ea
     struct Foo
         x, y: int = 0
 
-    def setXY(var this: Foo; X, Y: int)
-        with this
+    def setXY(var thisFoo: Foo; X, Y: int)
+        with thisFoo
             x = X
             y = Y
 
@@ -97,10 +97,10 @@ Since function pointer is a thing, one can emulate 'virtual' functions by storin
 
     struct Foo
         x, y: int = 0
-        set = @setXY
+        set = @@setXY
 
-    def setXY(var this: Foo; X, Y: int)
-        with this
+    def setXY(var thisFoo: Foo; X, Y: int)
+        with thisFoo
             x = X
             y = Y
     ...
@@ -166,7 +166,7 @@ Here an example: ::
 
     struct Foo
         x, y: int = 0
-        set = @Foo_setXY
+        set = @@Foo_setXY
 
     def Foo_setXY(var this: Foo; x, y: int)
         this.x = x
@@ -174,12 +174,12 @@ Here an example: ::
 
     struct Foo3D: Foo
         z: int = 3
-        override set = cast<auto> @Foo3D_setXY
+        override set = cast<auto> @@Foo3D_setXY
 
-    def Foo3D_setXY(var this: Foo3D; x, y: int)
-        this.x = x
-        this.y = y
-        this.z = -1
+    def Foo3D_setXY(var thisFoo: Foo3D; x, y: int)
+        thisFoo.x = x
+        thisFoo.y = y
+        thisFoo.z = -1
 
 It is safe to use 'cast' keyword to cast derived structure instance to reference to it's parent type::
 

--- a/doc/source/reference/language/tables.rst
+++ b/doc/source/reference/language/tables.rst
@@ -22,7 +22,7 @@ for safety, find doesn't return anything. Instead it works with block as last ar
 
     var tab: table<string; int>
     tab["some"] = 10
-    find(tab,"some") <| $(var pValue: int?)
+    find(tab,"some") <| $(var pValue: int? const)
         if pValue != null
             assert(deref(pValue) == 10)
 
@@ -54,11 +54,11 @@ Table key can be not only string, but any other 'workhorse' type as well.
 
 Tables can be constructed inline ::
 
-	let tab = {{ "one"=>1; "two"=>2 }}
+	let tab <- {{ "one"=>1; "two"=>2 }}
 
 Which is syntax sugar for ::
 
-	let tab : table<string;int> = to_table_move([[tuple<string;int>[2] "one"=>1; "two"=>2]])
+	let tab : table<string;int> <- to_table_move([[tuple<string;int>[2] "one"=>1; "two"=>2]])
 
 
 


### PR DESCRIPTION
- this - видимо зарезервировано, хотя не указано в списке зарезервированных слов, выдает ошибку при попытке использования

- некоторые присваивания копированием невозможны (динамические массивы и таблицы), заменены на move

- поправлены обнаруженные опечатки 