### PR TITLE
Annotate each_enum function with unused_argument(tt)

### DIFF
--- a/src/builtin/builtin.das
+++ b/src/builtin/builtin.das
@@ -271,6 +271,7 @@ def each_ref ( lam : lambda<(var arg:auto(argT)?):bool> ) : iterator<argT &>
     _builtin_make_lambda_iterator(it, lam)
     return <- it
 
+[unused_argument(tt)]
 def each_enum(tt:auto(TT)) : iterator<TT -const -&>
     concept_assert(typeinfo(is_enum tt),"expecting each_enum(any enum value)")
     var iter : iterator<TT -const -&>


### PR DESCRIPTION
Annotate each_enum function with unused_argument(tt) because tt is not used in function's body.
tt is used only for getting its type.