### PR TITLE
improve numerical parsers

### DIFF
--- a/examples/test/unit_tests/string.das
+++ b/examples/test/unit_tests/string.das
@@ -4,6 +4,37 @@
 
 require strings
 
+def failUint(val: string)
+    try
+        debug(uint(val), "=")
+        assert(false, "can't convert non uint string without exception")
+    recover {}
+
+def failInt(val: string)
+    try
+        debug(int(val), "=")
+        assert(false, "can't convert non int string without exception")
+    recover {}
+
+
+def failFloat(val: string)
+    try
+        debug(float(val), "=")
+        assert(false, "can't convert non float string without exception")
+    recover {}
+
+def failDouble(val: string)
+    try
+        debug(double(val), "=")
+        assert(false, "can't convert non double string without exception")
+    recover {}
+
+def failAll(val: string)
+    failUint(val)
+    failInt(val)
+    failFloat(val)
+    failDouble(val)
+
 [export]
 def test:bool
     let s:string = "hello, world!"
@@ -34,13 +65,21 @@ def test:bool
     assert(slice(s, 6, 7) == " ")
     assert(int("11") == 11)
     assert(int("-12") == -12)
+    assert(int("-12  ") == -12)
+    assert(int("  -12") == -12)
+    assert(int("  -12  ") == -12)
     assert(uint("11") == 11U)
+    assert(uint("  12  ") == 12U)
+    assert(uint("  12") == 12U)
     assert(float("-12") == -12.)
     assert(float("1e1") == 10.)
-    try
-        debug(int("11abc"), "=")
-        assert(false, "can't convert non int string without exception")
-    recover {}
+    assert(float("  12") == 12.)
+    assert(float("12   ") == 12.)
+    assert(float("  12   ") == 12.)
+    failAll("")
+    failAll("abc")
+    assert(to_int("") == 0)
+    assert(to_float("") == 0f)
     assert(to_int("11abc") == 11)
     assert(to_float("11.1abc") == 11.1)
     let a_slash_slash = "ab\\xy"

--- a/src/builtin/module_builtin_string.cpp
+++ b/src/builtin/module_builtin_string.cpp
@@ -190,10 +190,15 @@ namespace das
 
 
     unsigned string_to_uint ( const char *str, Context * context ) {
+        const uint32_t strLen = stringLengthSafe(*context, str);
+        if (strLen == 0)
+        {
+            context->throw_error("string-to-uint conversion failed. String is not an uint number");
+            return 0;
+        }
         char *endptr;
         unsigned long int ret = strtoul(str, &endptr, 10);
-        const uint32_t strLen = stringLengthSafe ( *context, str );
-        if (endptr != str + strLen || strLen == 0)
+        if (endptr == str)
         {
             context->throw_error("string-to-uint conversion failed. String is not an uint number");
             return 0;
@@ -202,10 +207,15 @@ namespace das
     }
 
     int string_to_int ( const char *str, Context * context ) {
+        const uint32_t strLen = stringLengthSafe(*context, str);
+        if (strLen == 0)
+        {
+            context->throw_error("string-to-int conversion failed. String is not an integer number");
+            return 0;
+        }
         char *endptr;
         long int ret = strtol(str, &endptr, 10);
-        const uint32_t strLen = stringLengthSafe ( *context, str );
-        if (endptr != str + strLen || strLen == 0)
+        if (endptr == str)
         {
             context->throw_error("string-to-int conversion failed. String is not an integer number");
             return 0;
@@ -214,10 +224,15 @@ namespace das
     }
 
     float string_to_float ( const char *str, Context * context ) {
+        const uint32_t strLen = stringLengthSafe(*context, str);
+        if (strLen == 0)
+        {
+            context->throw_error("string-to-float conversion failed. String is not an float number");
+            return 0.f;
+        }
         char *endptr;
         float ret = strtof(str, &endptr);
-        const uint32_t strLen = stringLengthSafe ( *context, str );
-        if (endptr != str + strLen || strLen == 0)
+        if (endptr == str)
         {
             context->throw_error("string-to-float conversion failed. String is not an float number");
             return 0.f;
@@ -226,13 +241,18 @@ namespace das
     }
 
     double string_to_double ( const char *str, Context * context ) {
+        const uint32_t strLen = stringLengthSafe(*context, str);
+        if (strLen == 0)
+        {
+            context->throw_error("string-to-float conversion failed. String is not an double number");
+            return 0.0;
+        }
         char *endptr;
         double ret = strtod(str, &endptr);
-        const uint32_t strLen = stringLengthSafe ( *context, str );
-        if (endptr != str + strLen || strLen == 0)
+        if (endptr == str)
         {
-            context->throw_error("string-to-dobule conversion failed. String is not an dobule number");
-            return 0.f;
+            context->throw_error("string-to-dobule conversion failed. String is not an double number");
+            return 0.0;
         }
         return ret;
     }


### PR DESCRIPTION
- fix crash when pass empty line (`float("")` for example)
- strings with additional spaces are valid for now ("  12" or "12  ")
- more tests