### PR TITLE
Revert "add missing pinvoke with 6 args"

### DIFF
--- a/src/builtin/module_builtin_debugger.cpp
+++ b/src/builtin/module_builtin_debugger.cpp
@@ -777,8 +777,6 @@ namespace debugapi {
                 SideEffects::worstDefault,"pinvoke_impl")->unsafeOperation = true;
             addInterop<pinvoke_impl,void,vec4f,const char *,vec4f,vec4f,vec4f,vec4f,vec4f,vec4f>(*this,lib,"invoke_in_context",
                 SideEffects::worstDefault,"pinvoke_impl")->unsafeOperation = true;
-            addInterop<pinvoke_impl, void, vec4f, const char*, vec4f, vec4f, vec4f, vec4f, vec4f, vec4f>(*this, lib, "invoke_in_context",
-                SideEffects::worstDefault, "pinvoke_impl")->unsafeOperation = true;
             addInterop<pinvoke_impl, void, vec4f, const char*, vec4f, vec4f, vec4f, vec4f, vec4f, vec4f, vec4f>(*this, lib, "invoke_in_context",
                 SideEffects::worstDefault, "pinvoke_impl")->unsafeOperation = true;
             addInterop<pinvoke_impl, void, vec4f, const char*, vec4f, vec4f, vec4f, vec4f, vec4f, vec4f, vec4f, vec4f>(*this, lib, "invoke_in_context",


### PR DESCRIPTION
This reverts commit 61564cf687365d93067243489a5810e30de20406.

This binding already exists