### PR TITLE
Add missing include for ref_time_ticks and get_time_usec

### DIFF
--- a/doc/source/reference/language/datatypes.rst
+++ b/doc/source/reference/language/datatypes.rst
@@ -192,7 +192,7 @@ Reference
 
 References are types that 'references' (points) some other data::
 
-    def twice(a: int&)
+    def twice(var a: int&)
         a = a + a
     var a = 1
     twice(a) // a value is now 2
@@ -210,9 +210,9 @@ dereference will panic, if null pointer is passed to it.
 Pointers can be created using new operator, or with C++ environment.
 ::
 
-    def twice(a: int&)
+    def twice(var a: int&)
         a = a + a
-    def twicePointer(a: int?)
+    def twicePointer(var a: int?)
         twice(*a)
 
     struct Foo

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -439,6 +439,7 @@ namespace das {
             verifyAotReady();
         }
         virtual ModuleAotType aotRequire ( TextWriter & tw ) const override {
+            tw << "#include \"daScript/misc/performance_time.h\"\n";
             tw << "#include \"daScript/simulate/aot_builtin_fio.h\"\n";
             return ModuleAotType::cpp;
         }


### PR DESCRIPTION
module_builtin_fio binds ref_time_ticks and get_time_usec functions.
These functions fail to AOT compile due to missing definitions.
The include has to be added somewhere.