### PR TITLE
fio: fix sleep time on non-windows platforms

### DIFF
--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -122,7 +122,7 @@ namespace das {
 #if defined(_MSC_VER)
         _sleep(msec);
 #else
-        usleep(msec);
+        usleep(1000 * msec);
 #endif
     }
 


### PR DESCRIPTION
 usleep requires usec as parameter