### PR TITLE
builtin_find_first_char_of2 added to aot header

### DIFF
--- a/include/daScript/simulate/aot_builtin_string.h
+++ b/include/daScript/simulate/aot_builtin_string.h
@@ -27,6 +27,7 @@ namespace das {
     int builtin_string_find2 (const char *str, const char *substr);
     int builtin_find_first_of ( const char * str, const char * substr, Context * context );
     int builtin_find_first_char_of ( const char * str, int Ch, Context * context );
+    int builtin_find_first_char_of2 ( const char * str, int Ch, int start, Context * context );
     int builtin_string_length ( const char *str, Context * context );
     char* builtin_string_slice1 ( const char *str, int start, int end, Context * context );
     char* builtin_string_slice2 ( const char *str, int start, Context * context );


### PR DESCRIPTION
builtin_find_first_char_of2 function wasn't present in the header file, which made it impossible to use it in AOT mode