### PR TITLE
string: starts_with func overload with settable length of cmp str

### DIFF
--- a/include/daScript/simulate/aot_builtin_string.h
+++ b/include/daScript/simulate/aot_builtin_string.h
@@ -20,7 +20,7 @@ namespace das {
 
     bool builtin_string_endswith ( const char * str, const char * cmp, Context * context );
     bool builtin_string_startswith ( const char * str, const char * cmp, Context * context );
-    bool builtin_string_startswith2 ( const char * str, const char * cmp, uint32_t cmp_len, Context * context );
+    bool builtin_string_startswith2 ( const char * str, const char * cmp, uint32_t cmpLen, Context * context );
     char* builtin_string_strip ( const char *str, Context * context );
     char* builtin_string_strip_left ( const char *str, Context * context );
     char* builtin_string_strip_right ( const char *str, Context * context );

--- a/include/daScript/simulate/aot_builtin_string.h
+++ b/include/daScript/simulate/aot_builtin_string.h
@@ -20,6 +20,7 @@ namespace das {
 
     bool builtin_string_endswith ( const char * str, const char * cmp, Context * context );
     bool builtin_string_startswith ( const char * str, const char * cmp, Context * context );
+    bool builtin_string_startswith2 ( const char * str, const char * cmp, uint32_t cmp_len, Context * context );
     char* builtin_string_strip ( const char *str, Context * context );
     char* builtin_string_strip_left ( const char *str, Context * context );
     char* builtin_string_strip_right ( const char *str, Context * context );

--- a/src/builtin/module_builtin_string.cpp
+++ b/src/builtin/module_builtin_string.cpp
@@ -41,9 +41,9 @@ namespace das
         return (cmpLen > strLen) ? false : memcmp(str, cmp, cmpLen) == 0;
     }
 
-    bool builtin_string_startswith2 ( const char * str, const char * cmp, uint32_t cmp_len, Context * context ) {
+    bool builtin_string_startswith2 ( const char * str, const char * cmp, uint32_t cmpLen, Context * context ) {
         const uint32_t strLen = stringLengthSafe ( *context, str );
-        const uint32_t cmpLen = min(cmp_len, stringLengthSafe ( *context, cmp ));
+        cmpLen = min(cmpLen, stringLengthSafe ( *context, cmp ));
         return (cmpLen > strLen) ? false : memcmp(str, cmp, cmpLen) == 0;
     }
 
@@ -677,7 +677,7 @@ namespace das
             addExtern<DAS_BIND_FUN(builtin_string_startswith)>(*this, lib, "starts_with",
                 SideEffects::none, "builtin_string_startswith")->args({"str","cmp","context"});
             addExtern<DAS_BIND_FUN(builtin_string_startswith2)>(*this, lib, "starts_with",
-                SideEffects::none, "builtin_string_startswith2")->args({"str","cmp","cmp_len","context"});
+                SideEffects::none, "builtin_string_startswith2")->args({"str","cmp","cmpLen","context"});
             addExtern<DAS_BIND_FUN(builtin_string_strip)>(*this, lib, "strip",
                 SideEffects::none, "builtin_string_strip")->args({"str","context"});
             addExtern<DAS_BIND_FUN(builtin_string_strip_right)>(*this, lib, "strip_right",

--- a/src/builtin/module_builtin_string.cpp
+++ b/src/builtin/module_builtin_string.cpp
@@ -41,6 +41,12 @@ namespace das
         return (cmpLen > strLen) ? false : memcmp(str, cmp, cmpLen) == 0;
     }
 
+    bool builtin_string_startswith2 ( const char * str, const char * cmp, uint32_t cmp_len, Context * context ) {
+        const uint32_t strLen = stringLengthSafe ( *context, str );
+        const uint32_t cmpLen = min(cmp_len, stringLengthSafe ( *context, cmp ));
+        return (cmpLen > strLen) ? false : memcmp(str, cmp, cmpLen) == 0;
+    }
+
     static inline const char* strip_l(const char *str) {
         const char *t = str;
         while (((*t) != '\0') && isspace(*t))
@@ -670,6 +676,8 @@ namespace das
                 SideEffects::none, "builtin_string_ends_with")->args({"str","cmp","context"});
             addExtern<DAS_BIND_FUN(builtin_string_startswith)>(*this, lib, "starts_with",
                 SideEffects::none, "builtin_string_startswith")->args({"str","cmp","context"});
+            addExtern<DAS_BIND_FUN(builtin_string_startswith2)>(*this, lib, "starts_with",
+                SideEffects::none, "builtin_string_startswith2")->args({"str","cmp","cmp_len","context"});
             addExtern<DAS_BIND_FUN(builtin_string_strip)>(*this, lib, "strip",
                 SideEffects::none, "builtin_string_strip")->args({"str","context"});
             addExtern<DAS_BIND_FUN(builtin_string_strip_right)>(*this, lib, "strip_right",


### PR DESCRIPTION
There are situations when you need to set the length of the comparable string