### PR TITLE
add fixedFloatingPoint printflag for debug printer

### DIFF
--- a/include/daScript/simulate/debug_info.h
+++ b/include/daScript/simulate/debug_info.h
@@ -392,6 +392,7 @@ namespace das
     ,   refAddresses =          (1<<3)
     ,   humanReadable =         (1<<4)
     ,   singleLine =            (1<<5)
+    ,   fixedFloatingPoint =    (1<<6)
 
     ,   string_builder  =   PrintFlags::none
     ,   debugger        =   PrintFlags::escapeString | PrintFlags::namesAndDimensions

--- a/include/daScript/simulate/debug_print.h
+++ b/include/daScript/simulate/debug_print.h
@@ -305,13 +305,19 @@ namespace das {
             }
         }
         virtual void Float ( float & f ) override {
-            ss << FIXEDFP << f << SCIENTIFIC;
+            if ( int(flags) & int(PrintFlags::fixedFloatingPoint) )
+                ss << FIXEDFP << f << SCIENTIFIC;
+            else
+                ss << f;
             if ( int(flags) & int(PrintFlags::typeQualifiers) ) {
                 ss << "f";
             }
         }
         virtual void Double ( double & f ) override {
-            ss << FIXEDFP << f << SCIENTIFIC;
+            if ( int(flags) & int(PrintFlags::fixedFloatingPoint) )
+                ss << FIXEDFP << f << SCIENTIFIC;
+            else
+                ss << f;
             if ( int(flags) & int(PrintFlags::typeQualifiers) ) {
                 ss << "lf";
             }


### PR DESCRIPTION
Added a flag to be able to print both fixed size and scientific styles for float and double numbers.
