### PR TITLE
SideEffects combinations

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -635,6 +635,13 @@ namespace das
     ,   inferredSideEffects = uint32_t(SideEffects::modifyArgument) | uint32_t(SideEffects::accessGlobal) | uint32_t(SideEffects::invoke)
     };
 
+    inline SideEffects operator |(SideEffects lhs, SideEffects rhs)
+    {
+      return static_cast<SideEffects>(
+          static_cast<std::underlying_type<SideEffects>::type>(lhs) |
+          static_cast<std::underlying_type<SideEffects>::type>(rhs));
+    }
+
     struct InferHistory {
         LineInfo    at;
         Function *  func = nullptr;


### PR DESCRIPTION
Explicit bitwise OR operation will help you easily write combinations of SideEffects flags like:
`das::SideEffects::modifyArgument | das::SideEffects::invoke`
instead of
`das::SideEffects(uint32_t(das::SideEffects::modifyArgument) | uint32_t(das::SideEffects::invoke))`