### PR TITLE
daScript: Improve Time api

### DIFF
--- a/daslib/live.das
+++ b/daslib/live.das
@@ -123,7 +123,7 @@ def public invoke_live ( fn:string; a1; a2; a3; a4 )
 
 def public watch_files
     var clk = get_clock()
-    if (clk - watchTime) <= 0.
+    if (clk - watchTime) <= 0.0lf
         return false
     watchTime = clk
     var any = false

--- a/examples/test/unit_tests/time.das
+++ b/examples/test/unit_tests/time.das
@@ -5,7 +5,7 @@ def testClockArg(c:clock):clock
 [export]
 def test
     var a1,a2:clock
-    var dt:float
+    var dt:double
     a1 = get_clock()
     for z in range(3) // nada on my laptop
         var a,b:int[3]
@@ -16,5 +16,5 @@ def test
     let a3 = testClockArg(a2)
     assert(a2 == a3)
     dt = a2 - a1
-    assert(dt <= 1.0)
+    assert(dt <= 1.0lf)
     return true

--- a/include/daScript/simulate/aot_builtin_time.h
+++ b/include/daScript/simulate/aot_builtin_time.h
@@ -37,11 +37,12 @@ namespace das {
         static __forceinline bool Less  ( vec4f a, vec4f b, Context &, LineInfo * ) {
             return to_time(a) < to_time(b);
         }
-        static __forceinline float Sub  ( vec4f a, vec4f b, Context &, LineInfo * ) {
-            return float(difftime(to_time(a), to_time(b)));
+        static __forceinline double Sub  ( vec4f a, vec4f b, Context &, LineInfo * ) {
+            return difftime(to_time(a), to_time(b));
         }
     };
 
+    static inline int64_t cast_int64(Time t) { return int64_t(t.time); }
     Time builtin_clock();
     void builtin_sleep ( uint32_t msec );
     void builtin_exit ( int32_t ec );

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -63,13 +63,15 @@ namespace das {
         addAnnotation(make_smart<TimeAnnotation>());
         addFunctionBasic<Time>(*this,lib);
         addFunctionOrdered<Time>(*this,lib);
-        addFunction( make_smart<BuiltInFn<Sim_Sub<Time>,float,Time,Time>>("-",lib,"Sub"));
+        addFunction( make_smart<BuiltInFn<Sim_Sub<Time>,double,Time,Time>>("-",lib,"Sub"));
         addExtern<DAS_BIND_FUN(builtin_clock)>(*this, lib, "get_clock", SideEffects::modifyExternal, "builtin_clock");
         // TODO: move to upstream das
         addExtern<DAS_BIND_FUN(ref_time_ticks)>(*this, lib, "ref_time_ticks",
             SideEffects::accessExternal, "ref_time_ticks");
         addExtern<DAS_BIND_FUN(get_time_usec)>(*this, lib, "get_time_usec",
             SideEffects::accessExternal, "get_time_usec");
+        addExtern<DAS_BIND_FUN(cast_int64)>(*this, lib, "int64",
+            SideEffects::none, "cast_int64");
     }
 }
 


### PR DESCRIPTION
1) Added cast Time to int64
2) Now Time Sub method return a double, not a float