### PR TITLE
improve uint64/int64 immediate consts gen (aot)

### DIFF
--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -1978,7 +1978,7 @@ namespace das {
             return Visitor::visit(c);
         }
         virtual ExpressionPtr visit ( ExprConstInt64 * c ) override {
-            ss << c->getValue() << "ll";
+            ss << "INT64_C(" << c->getValue() << ")";
             return Visitor::visit(c);
         }
         virtual ExpressionPtr visit ( ExprConstUInt8 * c ) override {
@@ -1990,7 +1990,7 @@ namespace das {
             return Visitor::visit(c);
         }
         virtual ExpressionPtr visit ( ExprConstUInt64 * c ) override {
-            ss << "0x" << HEX << c->getValue() << DEC << "ull";
+            ss << "UINT64_C(0x" << HEX << c->getValue() << DEC << ")";
             return Visitor::visit(c);
         }
         virtual ExpressionPtr visit ( ExprConstUInt * c ) override {


### PR DESCRIPTION
Use proper macroses ([U]INT64_C()) instead of hardcode suffixes.
This is required since this suffixes are actually platform specific
(depend on sizeof [u]int64 - it might be long (posix) or long long
(MS-based platforms)), macroses are more portable way to do it