### PR TITLE
Set BasicStructureAnnotation parent annotation by pointer

### DIFF
--- a/include/daScript/ast/ast_handle.h
+++ b/include/daScript/ast/ast_handle.h
@@ -115,6 +115,7 @@ namespace das
         StructureField & addFieldEx(const string & na, const string & cppNa, off_t offset, TypeDeclPtr pT);
         virtual void walk(DataWalker & walker, void * data) override;
         int32_t fieldCount() const { return int32_t(fields.size()); }
+        void from(BasicStructureAnnotation * ann);
         void from(const char* parentName);
         das_map<string,StructureField> fields;
         vector<string>                 fieldsInOrder;

--- a/src/ast/ast_handle.cpp
+++ b/src/ast/ast_handle.cpp
@@ -228,13 +228,16 @@ namespace das {
         walker.walk_struct((char *)data, sti);
     }
 
-    void BasicStructureAnnotation::from(const char* parentName) {
-        auto pann = (BasicStructureAnnotation*)(this->module->findAnnotation(parentName).get());
-        parents.reserve(pann->parents.size() + 1);
-        parents.push_back(pann);
-        for (auto pp : pann->parents) {
+    void BasicStructureAnnotation::from ( BasicStructureAnnotation * ann ) {
+        parents.reserve(ann->parents.size() + 1);
+        parents.push_back(ann);
+        for (auto pp : ann->parents) {
             parents.push_back(pp);
         }
+    }
+
+    void BasicStructureAnnotation::from ( const char * parentName ) {
+        from((BasicStructureAnnotation*)(this->module->findAnnotation(parentName).get()));
     }
 
     void Program::validateAotCpp ( TextWriter & logs, Context & ) {


### PR DESCRIPTION
For the more correct initialization of inherited type annotations, we need to be able to pass the parent annotation to the BasicStructureAnnotation directly and not by its name (avoiding unnecessary findAnnotation by name call).