### PR TITLE
cast<float3>::from and cast<int3>::from TSAN data race warning fix

### DIFF
--- a/include/daScript/simulate/cast.h
+++ b/include/daScript/simulate/cast.h
@@ -289,6 +289,14 @@ namespace das
             return prune<TT,vec4f>::from(x);
         }
         static __forceinline vec4f from ( const TT & x )       {
+#if __SANITIZE_THREAD__
+            if ( sizeof(TT) != sizeof(float) * 4 )
+            {
+              vec4f v;
+              memcpy(&v, &x, sizeof(x));
+              return v;
+            }
+#endif
             return v_ldu((const float*)&x);
         }
     };
@@ -313,6 +321,14 @@ namespace das
             return prune<TT,vec4f>::from(x);
         }
         static __forceinline vec4f from ( const TT & x ) {
+#if __SANITIZE_THREAD__
+            if ( sizeof(TT) != sizeof(int) * 4 )
+            {
+              vec4f v;
+              memcpy(&v, &x, sizeof(x));
+              return v;
+            }
+#endif
             return  v_cast_vec4f(v_ldui((const int*)&x));
         }
     };


### PR DESCRIPTION
cast::from<float3> and cast::from<int3> functions uses _mm_loadu_ps(v_ldu) instruction to load data, which load 16 bytes instead of 12 required and as a consequence - it creates possible data race on last 4 bytes.
So in thread sanitizing mode, we will read exactly 12 bytes via memcpy in order to avoid TSAN data race warnings, and in production mode - will keep _mm_loadu_ps(v_ldu) for the best performance.