### PR TITLE
worker contexts feature

### DIFF
--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -258,6 +258,8 @@ namespace das
         void strip();
         void logMemInfo(TextWriter & tw);
 
+        void makeWorkerFor(const Context & ctx);
+
         uint32_t getGlobalSize() const {
             return globalsSize;
         }
@@ -656,6 +658,7 @@ namespace das
 #endif
     protected:
         GlobalVariable * globalVariables = nullptr;
+        bool     globalsOwner = true;
         uint32_t sharedSize = 0;
         bool     sharedOwner = true;
         uint32_t globalsSize = 0;


### PR DESCRIPTION
This commit implements a functionality of daScript "worker" contexts.
The main task of these contexts is to perform part of the work in worker threads for the daScript entity component system queries(One worker context per one worker thread).
These contexts can be created in advance, can have their own local stack and heap, and can share global constants with origin context(read only).
So during the MT execution, all we need is to choose the worker context corresponding to the current worker thread and execute for it makeWorkerFor method by passing there a pointer to the origin context. In the main thread, we just use the origin context.