### PR TITLE
dascript utility always set is_in_aot

### DIFF
--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -411,6 +411,7 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     require_project_specific_modules();
     #include "modules/external_need.inc"
     Module::Initialize();
+    daScriptEnvironment::bound->g_isInAot = true;
     // compile and run
     int failedFiles = 0;
     for ( auto & fn : files ) {


### PR DESCRIPTION
useful flag to determine when the dascript utility was used