### PR TITLE
Improve CMake Config, set DASCRIPT_MAIN_SRC as global

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,23 +606,25 @@ DAS_AOT("daslib/utf8_utils.das" AOT_GENERATED_SRC dasAotStub daScript)
 SOURCE_GROUP_FILES("aot stub" AOT_GENERATED_SRC)
 #UNITIZE_BUILD("daslib" AOT_GENERATED_SRC)
 
+SET(DAS_DASCRIPT_MAIN_SRC
+    ${PROJECT_SOURCE_DIR}/utils/daScript/main.cpp
+    ${DAS_MODULES_NEED_INC}
+    CACHE INTERNAL "DAS_DASCRIPT_MAIN_SRC"
+)
+
 if (NOT ${DAS_BUILD_TOOLS} MATCHES NO)
 # Stand alone command line compiler
 
-  SET(DASCRIPT_MAIN_SRC
-  utils/daScript/main.cpp
-  ${DAS_MODULES_NEED_INC}
-  )
-  SOURCE_GROUP_FILES("main" DASCRIPT_MAIN_SRC)
+  SOURCE_GROUP_FILES("main" DAS_DASCRIPT_MAIN_SRC)
 
-  add_executable(daScript ${DASCRIPT_MAIN_SRC})
+  add_executable(daScript ${DAS_DASCRIPT_MAIN_SRC})
   TARGET_LINK_LIBRARIES(daScript libDaScript libDaScriptProfile libDaScriptTest Threads::Threads ${DAS_MODULES_LIBS})
   # ADD_DEPENDENCIES(daScript libDaScript libDaScriptProfile libDaScriptTest ${DAS_MODULES_LIBS})
   SETUP_CPP11(daScript)
   SETUP_LTO(daScript)
 
   #IF(APPLE)
-  #  add_executable(daScriptOsx MACOSX_BUNDLE ${DASCRIPT_MAIN_SRC})
+  #  add_executable(daScriptOsx MACOSX_BUNDLE ${DAS_DASCRIPT_MAIN_SRC})
   #  TARGET_LINK_LIBRARIES(daScriptOsx libDaScript libDaScriptProfile libDaScriptTest Threads::Threads ${DAS_MODULES_LIBS})
   #  ADD_DEPENDENCIES(daScriptOsx libDaScript libDaScriptProfile libDaScriptTest  need_and_resolve ${DAS_MODULES_LIBS})
   #  SETUP_CPP11(daScriptOsx)

--- a/examples/tutorial/CMakeLists.txt
+++ b/examples/tutorial/CMakeLists.txt
@@ -41,7 +41,7 @@ SET(TUTORIAL_02_DASAOT_MAIN_SRC
 ${CMAKE_SOURCE_DIR}/examples/tutorial/tutorial02_dasaot.cpp
 ${CMAKE_SOURCE_DIR}/examples/tutorial/tutorial02aot.h
 ${CMAKE_SOURCE_DIR}/examples/tutorial/tutorial02module.cpp
-${PROJECT_SOURCE_DIR}/utils/daScript/main.cpp
+${DAS_DASCRIPT_MAIN_SRC}
 )
 add_executable(tutorial02_dasAot ${TUTORIAL_02_DASAOT_MAIN_SRC} )
 target_compile_definitions(tutorial02_dasAot PUBLIC MAIN_FUNC_NAME=dascript_dummy_main) # dascript_dummy_main is here to rename main function from daScript


### PR DESCRIPTION
- Rename DASCRIPT_MAIN_SRC to DAS_DASCRIPT_MAIN_SRC,
for make same prefix for all external options or defition
- Make DAS_DASCRIPT_MAIN_SRC as global (visible outside) to
avoid write native aot src files path by hand