### PR TITLE
builtin/fio: fix compilation with non std calling convention

### DIFF
--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -25,6 +25,9 @@ MAKE_TYPE_FACTORY(clock, das::Time)// use MAKE_TYPE_FACTORY out of namespace. So
     #define MAP_PRIVATE 0x02        /* Changes are private.  */
     void* mmap(void* start, size_t length, int prot, int flags, int fd, off_t offset);
     int munmap(void* start, size_t length);
+    static int getchar_wrapper(void) { return getchar(); } // workaround for non-std callconv (fastcall, vectorcall...)
+#else
+#define getchar_wrapper getchar
 #endif
 
 namespace das {
@@ -525,7 +528,7 @@ namespace das {
             addExtern<DAS_BIND_FUN(builtin_sleep)>(*this, lib, "sleep",
                 SideEffects::modifyExternal, "builtin_sleep")
                     ->arg("msec");
-            addExtern<DAS_BIND_FUN(getchar)>(*this, lib, "getchar",
+            addExtern<DAS_BIND_FUN(getchar_wrapper)>(*this, lib, "getchar",
                 SideEffects::modifyExternal, "getchar");
             addExtern<DAS_BIND_FUN(builtin_exit)>(*this, lib, "exit",
                 SideEffects::modifyExternal, "builtin_exit")


### PR DESCRIPTION
MS-specific. getchar is declared as __cdecl so when building with
fastcall (x86) or vectorcall (x64) it can't be binded as is, so use
wrapper/ship to workaournd it