### PR TITLE
explicit hash class for smart_ptr

### DIFF
--- a/include/daScript/misc/smart_ptr.h
+++ b/include/daScript/misc/smart_ptr.h
@@ -354,11 +354,9 @@ namespace das {
     private:
         unsigned int ref_count = 0;
     };
-}
 
-namespace std {
-    template <typename TT>
-    struct hash<das::smart_ptr<TT>> {
+    struct smart_ptr_hash {
+        template<typename TT>
         std::size_t operator() ( const das::smart_ptr<TT> & k ) const {
             return hash<void *>()(k.get());
         }

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -27,9 +27,9 @@ namespace das {
                 }
             }
         }
-        das_hash_set<VariablePtr>   scope;
-        safe_var_set                capt;
-        bool                        fail = false;
+        das_hash_set<VariablePtr, smart_ptr_hash> scope;
+        safe_var_set                              capt;
+        bool                                      fail = false;
     };
 
 // type inference


### PR DESCRIPTION
...instead of std specialization. Compatible both with std & eastl.

PS: old implementation was accidently dependand on bug of eastl's hash implementation