### PR TITLE
Fix unmatched Server::shutdown calls

### DIFF
--- a/src/builtin/module_builtin_jobque.cpp
+++ b/src/builtin/module_builtin_jobque.cpp
@@ -194,8 +194,8 @@ namespace das {
         }, 0, JobPriority::Default);
     }
 
-    atomic<int32_t> g_jobQueAvailable{0};
-    atomic<int32_t> g_jobQueTotalThreads;
+    static atomic<int32_t> g_jobQueAvailable{0};
+    static atomic<int32_t> g_jobQueTotalThreads{0};
 
     bool is_job_que_shutting_down () {
         return g_jobQueAvailable == 0;
@@ -288,7 +288,6 @@ namespace das {
         Module_JobQue() : Module("jobque") {
             DAS_PROFILE_SECTION("Module_JobQue");
             g_jobQueAvailable++;
-            g_jobQueTotalThreads = 0;
             // libs
             ModuleLibrary lib;
             lib.addModule(this);


### PR DESCRIPTION
Server::shutdown used to be called more often, than Server::startup. Because needShutdown was set to true once and was never unset. This resulted in fatal error on Windows.

Also, g_jobQueTotalThreads shouldn't be zeroed because it screws up the counter logic.