### PR TITLE
channel_create/channel_remove

### DIFF
--- a/include/daScript/simulate/aot_builtin_jobque.h
+++ b/include/daScript/simulate/aot_builtin_jobque.h
@@ -66,6 +66,8 @@ namespace das {
     int channelAppend ( Channel * ch, int size, Context * context, LineInfoArg * at );
     void withChannel ( const TBlock<void,Channel *> & blk, Context * context, LineInfoArg * lineinfo );
     void withChannelEx ( int32_t count, const TBlock<void,Channel *> & blk, Context * context, LineInfoArg * lineinfo );
+    Channel* channelCreate( Context * context, LineInfoArg * at);
+    void channelRemove(Channel * ch, Context * context, LineInfoArg * at);
     void channelAddRef ( Channel * ch, Context * context, LineInfoArg * at );
     void channelReleaseRef ( Channel * & ch, Context * context, LineInfoArg * at );
     void waitForChannel ( Channel * status, Context * context, LineInfoArg * at );

--- a/src/builtin/module_builtin_jobque.cpp
+++ b/src/builtin/module_builtin_jobque.cpp
@@ -125,6 +125,19 @@ namespace das {
         }
     }
 
+    Channel * channelCreate( Context * context, LineInfoArg * at ) {
+        Channel * ch = new Channel(context);
+        ch->addRef();
+        return ch;
+    }
+
+    void channelRemove( Channel * ch, Context * context, LineInfoArg * at ) {
+        if (ch->releaseRef()) {
+            context->throw_error_at(*at, "channel beeing deleted while being used");
+        }
+        delete ch;
+    }
+
     void channelAddRef ( Channel * ch, Context * context, LineInfoArg * at ) {
         if ( !ch ) context->throw_error_at(*at, "channelAddRef: channel is null");
         ch->addRef();
@@ -309,6 +322,12 @@ namespace das {
             addExtern<DAS_BIND_FUN(withChannelEx)>(*this, lib,  "with_channel",
                 SideEffects::invoke, "withChannelEx")
                     ->args({"count","block","context","line"});
+            addExtern<DAS_BIND_FUN(channelCreate)>(*this, lib, "channel_create",
+                SideEffects::invoke, "channelCreate")
+                    ->args({ "context","line" })->unsafeOperation = true;
+            addExtern<DAS_BIND_FUN(channelRemove)>(*this, lib, "channel_remove",
+                SideEffects::invoke, "channelRemove")
+                    ->args({ "channel", "context","line" })->unsafeOperation = true;;
             addExtern<DAS_BIND_FUN(channelAddRef)>(*this, lib,  "add_ref",
                 SideEffects::modifyArgumentAndAccessExternal, "channelAddRef")
                     ->args({"channel","context","line"});


### PR DESCRIPTION
Added channel_create/channel_remove unsafe functions (require for using channels with coroutine macro + threads - otherwise if channel lives only inside block, there is no way to yield from this block)

Example of using:
https://gist.github.com/spiiin/b924517f1c0db7f1e08d9f7e9e2512fa
