### PR TITLE
push_empty method for vector bindings

### DIFF
--- a/include/daScript/ast/ast_handle.h
+++ b/include/daScript/ast/ast_handle.h
@@ -504,6 +504,13 @@ namespace das
                 addExtern<DAS_BIND_FUN((das_vector_push_back<TT>)),SimNode_ExtFuncCall,permanentArgFn>(*mod, lib, "push",
                     SideEffects::modifyArgument, "das_vector_push_back")->generated = true;
             }
+            if constexpr ( std::is_default_constructible_v<typename TT::value_type> )
+            {
+                addExtern<DAS_BIND_FUN((das_vector_push_empty<TT>)),SimNode_ExtFuncCall,permanentArgFn>(*mod, lib, "push_empty",
+                    SideEffects::modifyArgument, "das_vector_push_empty")->generated = true;
+                addExtern<DAS_BIND_FUN((das_vector_push_back_empty<TT>)),SimNode_ExtFuncCall,permanentArgFn>(*mod, lib, "push_empty",
+                    SideEffects::modifyArgument, "das_vector_push_back_empty")->generated = true;
+            }
             addExtern<DAS_BIND_FUN(das_vector_pop<TT>)>(*mod, lib, "pop",
                 SideEffects::modifyArgument, "das_vector_pop")->generated = true;
             addExtern<DAS_BIND_FUN(das_vector_clear<TT>)>(*mod, lib, "clear",
@@ -539,6 +546,15 @@ namespace das
                 addExtern<DAS_BIND_FUN((das_vector_push_back_value<TT>))>(*mod, lib, "push",
                     SideEffects::modifyArgument, "das_vector_push_back_value")
                         ->args({"vec","value"})->generated = true;
+            }
+            if constexpr ( std::is_default_constructible_v<typename TT::value_type> )
+            {
+              addExtern<DAS_BIND_FUN((das_vector_push_empty<TT>))>(*mod, lib, "push_empty",
+                  SideEffects::modifyArgument, "das_vector_push_empty")
+                      ->args({"vec","at","context"})->generated = true;
+              addExtern<DAS_BIND_FUN((das_vector_push_back_empty<TT>))>(*mod, lib, "push_empty",
+                    SideEffects::modifyArgument, "das_vector_push_back_empty")
+                        ->args({"vec"})->generated = true;
             }
             addExtern<DAS_BIND_FUN(das_vector_pop<TT>)>(*mod, lib, "pop",
                 SideEffects::modifyArgument, "das_vector_pop")

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -2414,6 +2414,14 @@ namespace das {
         vec.insert(vec.begin() + at, value);
     }
 
+    template <typename TT>
+    __forceinline void das_vector_push_empty ( TT & vec, int32_t at, Context * context ) {
+        if ( uint32_t(at)>vec.size() ) {
+            context->throw_error_ex("insert index out of range, %i of %u", at, uint32_t(vec.size()));
+        }
+        vec.emplace(vec.begin() + at);
+    }
+
     template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_emplace ( TT & vec, QQ & value, int32_t at ) {
         vec.emplace(vec.begin()+at, move(value));
@@ -2427,6 +2435,11 @@ namespace das {
     template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_push_back_value ( TT & vec, QQ value ) {
         vec.push_back(value);
+    }
+
+    template <typename TT>
+    __forceinline void das_vector_push_back_empty ( TT & vec ) {
+        vec.emplace_back();
     }
 
     template <typename TT, typename QQ = typename TT::value_type>


### PR DESCRIPTION
Method allows to push default-constructible, but non-local elements into CPP vectors