### PR TITLE
fixing array construction - moveable elements need to be moved

### DIFF
--- a/daslib/templates_boost.das
+++ b/daslib/templates_boost.das
@@ -714,7 +714,7 @@ class private  AstQCallMacro : AstCallMacro
             arguments := [{ExpressionPtr
                 new [[ExprQuote()
                     at=call.at,
-                    arguments := [{ExpressionPtr[1] move_to_local(qclone)}]
+                    arguments := [{ExpressionPtr[1] qclone}]
                 ]];
                 new [[ExprMakeBlock() _block<-qblk, at=call.at]]
             }]
@@ -804,7 +804,7 @@ class private AstQNamedMacro : AstCallMacro
                 clone_expression(call.arguments[0]);
                 new [[ExprQuote()
                     at=call.at,
-                    arguments := [{ExpressionPtr move_to_local(qclone)}]
+                    arguments := [{ExpressionPtr[1] qclone}]
                 ]];
                 new [[ExprMakeBlock() _block<-qblk, at=call.at]]
             }]
@@ -842,7 +842,7 @@ class private AstQNamedClassMacro : AstCallMacro
                 clone_expression(call.arguments[1]);
                 new [[ExprQuote()
                     at=call.at,
-                    arguments := [{ExpressionPtr move_to_local(qclone)}]
+                    arguments := [{ExpressionPtr[1] qclone}]
                 ]];
                 new [[ExprMakeBlock() _block<-qblk, at=call.at]]
             }]

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -7564,7 +7564,7 @@ namespace das {
                 auto initl = static_cast<ExprMakeLocal *>(init);
                 expr->initAllFields &= initl->initAllFields;
             }
-            return Expression::autoDereference( Visitor::visitMakeArrayIndex(expr,index,init,last) );
+            return Visitor::visitMakeArrayIndex(expr,index,init,last);
         }
         virtual ExpressionPtr visit ( ExprMakeArray * expr ) override {
             if ( expr->makeType && expr->makeType->isExprType() ) {


### PR DESCRIPTION
    var b <- new [[ExprOp2() op:="+"]]
    var a <- [{ExpressionPtr[1] b}]

b should be null