### PR TITLE
Excluded 2 warning types from Code analysis action

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           cmakeBuildDirectory: ${{ env.CONFIG_DIR }}
           # Ruleset file that will determine what checks will be run
-          ruleset: NativeRecommendedRules.ruleset
+          ruleset: CustomRules.ruleset
 
       # Upload SARIF file to GitHub Code Scanning Alerts
       - name: Upload SARIF to GitHub

--- a/CustomRules.ruleset
+++ b/CustomRules.ruleset
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Example" Description="Enable Warnings" ToolsVersion="10.0">
+  <!-- Default rules available in Visual Studio -->
+  <Include Path="NativeRecommendedRules.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis"
+         RuleNamespace="Microsoft.Rules.Native">
+    <Rule Id="C26451" Action="None" /> <!-- Exclude: Declare noexcept -->
+    <Rule Id="C26495" Action="None" /> <!-- Include: No const_cast<> -->
+  </Rules>
+</RuleSet>


### PR DESCRIPTION
Code analysis now excluding some warning types (C26451 and C26495)