### PR TITLE
global variable initialization order check

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -4785,6 +4785,13 @@ namespace das {
             auto vars = findMatchingVar(expr->name, false);
             if ( vars.size()==1 ) {
                 auto var = vars.back();
+                if ( var->type && var->type->constant && var->init ) {  // try folding global variable values
+                    auto cvar = getConstExpr(var->init.get());
+                    if ( cvar ) {
+                        reportAstChanged();
+                        return cvar;
+                    }
+                }
                 expr->variable = var;
                 expr->type = make_smart<TypeDecl>(*var->type);
                 expr->type->ref = true;

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -2948,7 +2948,7 @@ namespace das
                     if (!pvar->used)
                         return;
                     if ( pvar->index<0 ) {
-                        error("Internalc compiler errors. Simulating variable which is not used" + pvar->name,
+                        error("Internal compiler errors. Simulating variable which is not used" + pvar->name,
                             "", "", LineInfo());
                         return;
                     }

--- a/tests/language/global_variable_order.das
+++ b/tests/language/global_variable_order.das
@@ -1,0 +1,16 @@
+expect 30305:2
+
+require dastest/testing_boost public
+
+let a = x                   //  this is fine, constant will fold
+let x = 1234
+
+var g_b := g_a              //  30305: global variable g_a is initialized after g_b
+var g_a : array<int> <- g_a //  30305: global variable g_a cant't be initialized with itself
+
+[test]
+def test_global_variable_init_order( t: T? )
+    t |> equal(1234, a)
+    t |> equal(1234, x)
+
+


### PR DESCRIPTION
some global constants fold immediately