### PR TITLE
Small fix to workflows skipping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5
         with:
           # All of these options are optional, so you can remove them if you are happy with the defaults
-          concurrent_skipping: 'same_content_newer'
-          do_not_skip: '["workflow_dispatch"]'
+          concurrent_skipping: 'same_content'
+          do_not_skip: '["pull_request", "workflow_dispatch"]'
 
   ###########################################################
   build:

--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -24,8 +24,8 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5
         with:
           # All of these options are optional, so you can remove them if you are happy with the defaults
-          concurrent_skipping: 'same_content_newer'
-          do_not_skip: '["workflow_dispatch"]'
+          concurrent_skipping: 'same_content'
+          do_not_skip: '["pull_request", "workflow_dispatch"]'
 
   ###########################################################
   wasm_build:


### PR DESCRIPTION
Now if we have two workflow rans from pull-request and push at the same time, then only the push one will be skipped.