### PR TITLE
cxx flag changed in web build CMakeLists

### DIFF
--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -109,7 +109,6 @@ jobs:
         set -eux
         cd web
         cp ../CMakeXxdImpl.txt .
-        rm -r -f cmake_temp
         mkdir cmake_temp
         cd cmake_temp
         cmake -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake_preset }} -G Ninja -DCMAKE_TOOLCHAIN_FILE=../emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake ../

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -27,7 +27,7 @@ add_link_options(-fwasm-exceptions)
 add_compile_definitions(DAS_ENABLE_EXCEPTIONS)
 add_compile_definitions(_EMSCRIPTEN_VER)
 
-set(CMAKE_CXX_FLAGS "-s TOTAL_MEMORY=128MB")
+set(CMAKE_CXX_FLAGS_RELEASE "-s TOTAL_MEMORY=128MB")
 
 INCLUDE(../CMakeCommon.txt)
 


### PR DESCRIPTION
Fixed issue when emscripten linker setting "TOTAL_MEMORY" was ignored during compilation