### PR TITLE
added enum_names typeinfo macro for enums

### DIFF
--- a/daslib/enum_trait.das
+++ b/daslib/enum_trait.das
@@ -21,3 +21,21 @@ class TypeInfoGetEnumLength : AstTypeInfoMacro
             return <- new [[ExprConstInt() at=expr.at, value=sz]]
         errors := "type is missing or not inferred"
         return <- [[ExpressionPtr]]
+
+[typeinfo_macro(name="enum_names")]
+class TypeInfoGetEnumNames : AstTypeInfoMacro
+    //! Implements typeinfo(enum_names EnumOrEnumType) which returns array of strings with enumValue names.
+    def override getAstChange ( expr:smart_ptr<ExprTypeInfo>; var errors:das_string ) : ExpressionPtr
+        if expr.typeexpr == null
+            errors := "type is missing or not inferred"
+            return <- [[ExpressionPtr]]
+        if !expr.typeexpr.isEnum
+            errors := "expecting enumeration"
+            return <- [[ExpressionPtr]]
+        var inscope arr <- new [[ExprMakeArray() at=expr.at, makeType <- typeinfo(ast_typedecl type<string>)]]
+        for i in iter_range(expr.typeexpr.enumType.list)
+            if true
+                assume name = expr.typeexpr.enumType.list[i].name
+                var inscope nameExpr <- new [[ExprConstString() at=expr.at, value:=name]]
+                arr.values |> emplace <| nameExpr
+        return <- arr


### PR DESCRIPTION
to get an array with strings of all names from enum. This is useful to print stuff for cases when actual enum value is stored as an int. we dont have a way to convert ints to enum fastly right now