### PR TITLE
allow to build with exceptions only one module (mixed mode)

### DIFF
--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -675,9 +675,7 @@ namespace das
         const char *    exception = nullptr;
         const char *    last_exception = nullptr;
         LineInfo        exceptionAt;
-#if !DAS_ENABLE_EXCEPTIONS
         jmp_buf *       throwBuf = nullptr;
-#endif
     protected:
         GlobalVariable * globalVariables = nullptr;
         bool     globalsOwner = true;


### PR DESCRIPTION
This commit fixes binary incompatibility of das::Context structure in mixed mode (when only simulate_exceptions.cpp is built with exceptions incl. DAS_ENABLE_EXCEPTIONS=1)

Follow-up to https://github.com/GaijinEntertainment/daScript/pull/529