### PR TITLE
fix Prologue::block native member name

### DIFF
--- a/src/builtin/module_builtin_debugger.cpp
+++ b/src/builtin/module_builtin_debugger.cpp
@@ -21,7 +21,7 @@ namespace das
     struct PrologueAnnotation : ManagedStructureAnnotation<Prologue,false> {
         PrologueAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation ("Prologue", ml) {
             addField<DAS_BIND_MANAGED_FIELD(info)>("info");
-            addField<DAS_BIND_MANAGED_FIELD(block)>("_block");
+            addField<DAS_BIND_MANAGED_FIELD(block)>("_block", "block");
             addField<DAS_BIND_MANAGED_FIELD(fileName)>("fileName");
             addField<DAS_BIND_MANAGED_FIELD(stackSize)>("stackSize");
             addField<DAS_BIND_MANAGED_FIELD(arguments)>("arguments");


### PR DESCRIPTION
Native name is different from das one. This fixes aot builds