### PR TITLE
mark all exception catching functions with noinline

### DIFF
--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -2293,7 +2293,7 @@ namespace das {
         }
     };
 
-    void das_try_recover ( Context * __context__, const callable<void()> & try_block, const callable<void()> & catch_block );
+    void ___noinline das_try_recover ( Context * __context__, const callable<void()> & try_block, const callable<void()> & catch_block );
 
     template <typename TT>
     struct das_call_interop {
@@ -2985,7 +2985,7 @@ namespace das {
         return -1;
     }
 
-    void builtin_try_recover ( const Block & try_block, const Block & catch_block, Context * context, LineInfoArg * at );
+    void ___noinline builtin_try_recover ( const Block & try_block, const Block & catch_block, Context * context, LineInfoArg * at );
 }
 
 #if defined(_MSC_VER)

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -337,9 +337,9 @@ namespace das
             unlock();
         }
 
-        vec4f DAS_EVAL_ABI evalWithCatch ( SimFunction * fnPtr, vec4f * args = nullptr, void * res = nullptr );
-        vec4f DAS_EVAL_ABI evalWithCatch ( SimNode * node );
-        bool  runWithCatch ( const callable<void()> & subexpr );
+        vec4f DAS_EVAL_ABI ___noinline evalWithCatch ( SimFunction * fnPtr, vec4f * args = nullptr, void * res = nullptr );
+        vec4f DAS_EVAL_ABI ___noinline evalWithCatch ( SimNode * node );
+        bool ___noinline runWithCatch ( const callable<void()> & subexpr );
         DAS_NORETURN_PREFIX void throw_error ( const char * message ) DAS_NORETURN_SUFFIX;
         DAS_NORETURN_PREFIX void throw_error_ex ( DAS_FORMAT_STRING_PREFIX const char * message, ... ) DAS_NORETURN_SUFFIX DAS_FORMAT_PRINT_ATTRIBUTE(2,3);
         DAS_NORETURN_PREFIX void throw_error_at ( const LineInfo & at, DAS_FORMAT_STRING_PREFIX const char * message, ... ) DAS_NORETURN_SUFFIX DAS_FORMAT_PRINT_ATTRIBUTE(3,4);


### PR DESCRIPTION
To prevent it being inlined in LTO/WPO mode (which breaks exceptions)