### PR TITLE
skip lock checks in sub contexts too

### DIFF
--- a/src/simulate/simulate.cpp
+++ b/src/simulate/simulate.cpp
@@ -999,6 +999,8 @@ namespace das
         tabMnLookup = ctx.tabMnLookup;
         tabGMnLookup = ctx.tabGMnLookup;
         tabAdLookup = ctx.tabAdLookup;
+        // lockcheck
+        skipLockChecks = ctx.skipLockChecks;
     }
 
     uint64_t Context::getSharedMemorySize() const {


### PR DESCRIPTION
pass skipLockChecks flag to workers