### PR TITLE
can't capture 'self' in the class initializer (it will be moved afterwards)

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -315,6 +315,7 @@ namespace das
                 bool    tag : 1;
                 bool    global : 1;
                 bool    inScope : 1;
+                bool    no_capture : 1;
             };
             uint32_t flags = 0;
         };

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -2561,6 +2561,12 @@ namespace das {
                         return false;
                     }
                 }
+                if ( cV->no_capture ) {
+                    error("can't capture variable " + cV->name,
+                        cV->name=="self" ? "can't capture `self` in the class initializer" :  "it is marked as no_capture",
+                            "", at, CompilationError::invalid_capture);
+                    return false;
+                }
             }
             return true;
         }

--- a/src/ast/ast_print.cpp
+++ b/src/ast/ast_print.cpp
@@ -318,6 +318,7 @@ namespace das {
             }
             if ( !arg->type->isConst() ) ss << "var ";
             if ( arg->isAccessUnused() ) ss << " /*unused*/ ";
+            if ( arg->no_capture ) ss << " /*no_capture*/ ";
             if ( printVarAccess && !arg->access_ref ) ss << "$";
             if ( printVarAccess && !arg->access_pass ) ss << "%";
             ss << arg->name;

--- a/src/builtin/module_builtin_ast_flags.cpp
+++ b/src/builtin/module_builtin_ast_flags.cpp
@@ -210,8 +210,8 @@ namespace das {
         auto ft = make_smart<TypeDecl>(Type::tBitfield);
         ft->alias = "VariableFlags";
         ft->argNames = { "init_via_move", "init_via_clone", "used", "aliasCMRES",
-            "marked_used", "global_shared", "do_not_delete", "generated",
-            "capture_as_ref", "can_shadow", "private_variable", "tag", "global", "inScope" };
+            "marked_used", "global_shared", "do_not_delete", "generated", "capture_as_ref",
+            "can_shadow", "private_variable", "tag", "global", "inScope", "no_capture" };
         return ft;
     }
 

--- a/src/builtin/module_builtin_debugger.cpp
+++ b/src/builtin/module_builtin_debugger.cpp
@@ -831,7 +831,7 @@ namespace debugapi {
                 exText = string("pinvoke can't find ") + fn + " function";
                 return;
             }
-            if ( simFn->debugInfo->count!=call->nArguments-2 ) {
+            if ( simFn->debugInfo->count!=uint32_t(call->nArguments-2) ) {
                 exAt = call->debugInfo;
                 exText = string("pinvoke ") + fn + " function expects " + to_string(simFn->debugInfo->count)
                     + " arguments, but " + to_string(call->nArguments-2) + " provided";
@@ -864,7 +864,7 @@ namespace debugapi {
         auto simFn = fn.PTR;
         if ( !simFn ) context.throw_error_at(call->debugInfo, "pinvoke can't find function #%p", (void *)simFn);
         if ( !invCtx->contextMutex ) context.throw_error_at(call->debugInfo,"threadlock_context is not set");
-        if ( simFn->debugInfo->count!=call->nArguments-2 ) context.throw_error_at(call->debugInfo,
+        if ( simFn->debugInfo->count!=uint32_t(call->nArguments-2) ) context.throw_error_at(call->debugInfo,
             "pinvoke function expects %u arguments, but %u provided", simFn->debugInfo->count, call->nArguments-2);
         vec4f res = v_zero();
         LineInfo exAt;
@@ -897,7 +897,7 @@ namespace debugapi {
         if (!fnMnh) context.throw_error_at(call->debugInfo, "invoke null lambda");
         SimFunction * simFn = *fnMnh;
         if ( !simFn ) context.throw_error_at(call->debugInfo, "pinvoke can't find function #%p", (void*)simFn);
-        if ( simFn->debugInfo->count!=call->nArguments-1 ) context.throw_error_at(call->debugInfo,
+        if ( simFn->debugInfo->count!=uint32_t(call->nArguments-1) ) context.throw_error_at(call->debugInfo,
             "pinvoke function expects %u arguments, but %u provided", simFn->debugInfo->count, call->nArguments-2);
         if ( !invCtx->contextMutex ) context.throw_error_at(call->debugInfo,"threadlock_context is not set");
         vec4f res = v_zero();

--- a/src/parser/parser_impl.cpp
+++ b/src/parser/parser_impl.cpp
@@ -564,6 +564,7 @@ namespace das {
                     }
                     func->name = yyextra->g_thisStructure->name + "`" + yyextra->g_thisStructure->name;
                     modifyToClassMember(func, yyextra->g_thisStructure, false, false);
+                    func->arguments[0]->no_capture = true;  // we can't capture self in the class c-tor
                 } else {
                     modifyToClassMember(func, yyextra->g_thisStructure, true, false);
                 }

--- a/tests/language/failed_capture_self.das
+++ b/tests/language/failed_capture_self.das
@@ -1,0 +1,16 @@
+expect 30508, 30124
+
+class A
+    private onLog: lambda
+    private y : int
+    def A
+        onLog <- @ <|           //  30508: can't move from a constant value, lambda<>& <- lambda<void> const
+            y --                //  30124: can't capture variable self
+            print("onLog\n")
+    def bang
+        if onLog != null
+            onLog |> invoke()
+    def operator delete
+        y ++
+
+


### PR DESCRIPTION
we may revisit the problem later, if it indeed becomes a serious limiter
its possible to do ctor in the ascended memory, and not to do the move. probably