### PR TITLE
Fix compile time warning for POD test.

### DIFF
--- a/include/daScript/ast/ast_handle.h
+++ b/include/daScript/ast/ast_handle.h
@@ -243,7 +243,7 @@ namespace das
                 ||  !is_trivially_copy_constructible<OT>::value;
         }
         virtual bool isPod() const override {
-            return is_pod<OT>::value;
+            return is_standard_layout<OT>::value && is_trivial<OT>::value;
         }
         virtual bool isRawPod() const override {
             return false;   // can we detect this?


### PR DESCRIPTION
This is a warning generated when building with `-std=gnu++20`
[build] warning: ‘template<class _Tp> struct std::is_pod’ is deprecated: use is_standard_layout && is_trivial instead [-Wdeprecated-declarations]
[build]   246 |             return is_pod<OT>::value;
[build]       |                    ^~~~~~