### PR TITLE
das_source_formatter: fix format after 'match_type'

### DIFF
--- a/daslib/das_source_formatter.das
+++ b/daslib/das_source_formatter.das
@@ -22,7 +22,7 @@ let dont_need_space_around <- [[auto "("; ")"; "["; "]"; "\{"; "\}";
     "."; ";"; ","; "`"; "::"; "++"; "--"; "?."; "?["; "@@"; "!"; "~"; "#"; "->"
     ]]
 
-let type_after_keyword <- [[auto "generator"; "cast"; "upcast"; "smart_ptr";
+let type_after_keyword <- [[auto "generator"; "cast"; "upcast"; "smart_ptr"; "match_type";
     "type"; "reinterpret"; "variant"; "variant_index"; "function"
     ]]
 


### PR DESCRIPTION
no spaces required