### PR TITLE
Vectorcall fix for XCode

### DIFF
--- a/include/daScript/ast/ast_handle.h
+++ b/include/daScript/ast/ast_handle.h
@@ -382,7 +382,7 @@ namespace das
                 V_ARG_THIS(range);
                 V_END();
             }
-            virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+            DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
                 OOT * pR = (OOT *) SimNode_AtStdVector::compute(context);
                 DAS_ASSERT(pR);
                 return cast<OOT>::from(*pR);

--- a/include/daScript/ast/ast_visitor.h
+++ b/include/daScript/ast/ast_visitor.h
@@ -319,7 +319,7 @@ namespace das {
         Context         ctx;
         DebugInfoHelper helper;
     protected:
-        vec4f DAS_EVAL_ABI eval ( Expression * expr, bool & failed );
+        DAS_EVAL_ABI vec4f eval ( Expression * expr, bool & failed );
         ExpressionPtr evalAndFold ( Expression * expr );
         ExpressionPtr evalAndFoldString ( Expression * expr );
         ExpressionPtr evalAndFoldStringBuilder ( ExprStringBuilder * expr );

--- a/include/daScript/misc/hal.h
+++ b/include/daScript/misc/hal.h
@@ -12,9 +12,9 @@ __forceinline void * v_extract_ptr(vec4i a) {
 }
 
 #if defined(_MSC_VER) && !defined(__clang__) && INTPTR_MAX == INT32_MAX//MSVC generates flawed code, for example in _builtin_binary_save, so make it out of line
-extern vec4i VECTORCALL v_ldu_ptr(const void * a);
+extern VECTORCALL vec4i v_ldu_ptr(const void * a);
 #else
-__forceinline vec4i VECTORCALL v_ldu_ptr(const void * a) {
+VECTORCALL __forceinline vec4i v_ldu_ptr(const void * a) {
 #if INTPTR_MAX == INT32_MAX
     return v_seti_x((int32_t)a);
 #else

--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -73,7 +73,9 @@
 #include <float.h>
 #include <daScript/das_config.h>
 
-#if (defined(_MSC_VER) || defined(__clang__)) && __SSE__
+#if _TARGET_PC_MACOSX && __SSE__
+   #define DAS_EVAL_ABI [[clang::vectorcall]]
+#elif (defined(_MSC_VER) || defined(__clang__)) && __SSE__
     #define DAS_EVAL_ABI __vectorcall
 #else
     #define DAS_EVAL_ABI

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -1744,7 +1744,7 @@ namespace das {
         __forceinline SimNode_Aot ( ) : SimNode_CallBase(LineInfo()) {
             aotFunction = (void*) fn;
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f * aa = context.abiArg;
             vec4f stub[1];
@@ -1759,7 +1759,7 @@ namespace das {
     template <typename FuncT, FuncT fn>
     struct SimNode_AotCMRES : SimNode_CallBase {
         __forceinline SimNode_AotCMRES ( ) : SimNode_CallBase(LineInfo()) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f * aa = context.abiArg;
             vec4f stub[1];
@@ -1778,7 +1778,7 @@ namespace das {
 
     struct SimNode_AotInteropBase : SimNode_CallBase {
         __forceinline SimNode_AotInteropBase() : SimNode_CallBase(LineInfo()) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             return v_zero();
         };
@@ -1883,7 +1883,7 @@ namespace das {
         __forceinline resType callBlockFunction(vec4f * args, index_sequence<I...>) {
             return blockFunction((cast<argType>::to(args[I]))...);
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f ** arguments = (vec4f **)(context.stack.bottom() + argumentsOffset);
             using Indices = make_index_sequence<sizeof...(argType)>;
@@ -1905,7 +1905,7 @@ namespace das {
                 : das_make_block_base(context,argStackTop,ann,fi), blockFunction(func) {
             aotFunction = &blockFunction;
         };
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             return cast<resType>::from(blockFunction());
         }
@@ -1920,7 +1920,7 @@ namespace das {
                 : das_make_block_base(context,argStackTop,ann,fi), blockFunction(func) {
             aotFunction = &blockFunction;
         };
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             blockFunction ( );
             return v_zero();
@@ -1944,7 +1944,7 @@ namespace das {
         __forceinline void callBlockFunction(vec4f * args, index_sequence<I...>) {
             blockFunction((cast<argType>::to(args[I]))...);
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f ** arguments = (vec4f **)(context.stack.bottom() + argumentsOffset);
             using Indices = make_index_sequence<sizeof...(argType)>;
@@ -1966,7 +1966,7 @@ namespace das {
         __forceinline resType callBlockFunction(vec4f * args, index_sequence<I...>) {
             return blockFunction((cast<argType>::to(args[I]))...);
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto ba = (BlockArguments *) ( context.stack.bottom() + argumentsOffset );
             using ResultType = typename remove_const<resType>::type;
@@ -1986,7 +1986,7 @@ namespace das {
                 : das_make_block_base(context,argStackTop,ann,fi), blockFunction(func) {
             aotFunction = &blockFunction;
         };
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto ba = (BlockArguments *) ( context.stack.bottom() + argumentsOffset );
             using ResultType = typename remove_const<resType>::type;

--- a/include/daScript/simulate/interop.h
+++ b/include/daScript/simulate/interop.h
@@ -221,7 +221,7 @@ namespace das
         SimNode_ExtFuncCall ( const LineInfo & at, const char * fnName )
             : SimNode_ExtFuncCallBase(at,fnName) { }
 #endif
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             return ImplCallStaticFunction<FuncT>::call(*fn, context, arguments);
         }
@@ -251,7 +251,7 @@ namespace das
         SimNode_ExtFuncCallAndCopyOrMove ( const LineInfo & at, const char * fnName )
             : SimNode_ExtFuncCallBase(at,fnName) { }
 #endif
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             void * cmres = cmresEval->evalPtr(context);
             ImplCallStaticFunctionAndCopy<FuncT>::call(*fn, context, cmres, arguments);
@@ -275,7 +275,7 @@ namespace das
             (void)args;     // to avoid compiler warning when no arguments
             new (cmres) CType(cast_arg<Args>::to(ctx,args[I])...);
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             auto cmres = cmresEval->evalPtr(context);
             CallPlacementNew(cmres,context,arguments,make_index_sequence<sizeof...(Args)>());
             return cast<void *>::from(cmres);
@@ -294,7 +294,7 @@ namespace das
             bargs[0] = cast<CType *>::from(&value);
             ctx.invoke(blk,bargs,nullptr,&debugInfo);
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_ASSERT(nArguments == (sizeof...(Args) + 1) );
             auto pblock = cast_arg<const Block *>::to(context,arguments[nArguments-1]);
             CallUsing(*pblock,context,arguments,make_index_sequence<sizeof...(Args)>());
@@ -340,7 +340,7 @@ namespace das
     struct SimNode_InteropFuncCall : SimNode_ExtFuncCallBase {
         SimNode_InteropFuncCall ( const LineInfo & at, const char * fnName )
             : SimNode_ExtFuncCallBase(at,fnName) { }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f * args = (vec4f *)(alloca(nArguments * sizeof(vec4f)));
             evalArgs(context, args);

--- a/include/daScript/simulate/runtime_array.h
+++ b/include/daScript/simulate/runtime_array.h
@@ -37,7 +37,7 @@ namespace das
             V_ARG(offset);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             TT * pR = (TT *) compute(context);
             return cast<TT>::from(*pR);
@@ -82,7 +82,7 @@ namespace das
         SimNode_GoodArrayIterator ( const LineInfo & at, SimNode * s, uint32_t st )
             : SimNode(at), source(s), stride(st) { }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode *   source;
         uint32_t    stride;
     };
@@ -102,7 +102,7 @@ namespace das
         SimNode_FixedArrayIterator ( const LineInfo & at, SimNode * s, uint32_t sz, uint32_t st )
             : SimNode(at), source(s), size(sz), stride(st) { }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode *   source;
         uint32_t    size;
         uint32_t    stride;
@@ -112,7 +112,7 @@ namespace das
         SimNode_DeleteArray ( const LineInfo & a, SimNode * s, uint32_t t, uint32_t st )
             : SimNode_Delete(a,s,t), stride(st) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         uint32_t stride;
     };
 
@@ -126,7 +126,7 @@ namespace das
         virtual SimNode * visit ( SimVisitor & vis ) override {
             return visitFor(vis, totalCount, "ForGoodArray");
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             Array * __restrict pha[totalCount];
             char * __restrict ph[totalCount];
@@ -173,7 +173,7 @@ namespace das
             V_FINAL();
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             evalFinal(context);
             return v_zero();
@@ -186,7 +186,7 @@ namespace das
         virtual SimNode * visit ( SimVisitor & vis ) override {
             return visitFor(vis, 1, "ForGoodArray");
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             Array * __restrict pha;
             char * __restrict ph;
@@ -222,7 +222,7 @@ namespace das
         virtual SimNode * visit ( SimVisitor & vis ) override {
             return visitFor(vis, totalCount, "ForGoodArray1");
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             Array * __restrict pha[totalCount];
             char * __restrict ph[totalCount];
@@ -265,7 +265,7 @@ namespace das
             V_FINAL();
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             evalFinal(context);
             return v_zero();
@@ -278,7 +278,7 @@ namespace das
         virtual SimNode * visit ( SimVisitor & vis ) override {
             return visitFor(vis, 1, "ForGoodArray1");
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             Array * __restrict pha;
             char * __restrict ph;
@@ -313,7 +313,7 @@ namespace das
     template <int totalCount>
     struct SimNodeDebug_ForGoodArray : public SimNode_ForGoodArray<totalCount> {
         SimNodeDebug_ForGoodArray ( const LineInfo & at ) : SimNode_ForGoodArray<totalCount>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             Array * __restrict pha[totalCount];
             char * __restrict ph[totalCount];
@@ -360,7 +360,7 @@ namespace das
     template <>
     struct SimNodeDebug_ForGoodArray<1> : public SimNode_ForGoodArray<1> {
         SimNodeDebug_ForGoodArray ( const LineInfo & at ) : SimNode_ForGoodArray<1>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             Array * __restrict pha;
             char * __restrict ph;
@@ -394,7 +394,7 @@ namespace das
     template <int totalCount>
     struct SimNodeDebug_ForGoodArray1 : public SimNode_ForGoodArray1<totalCount> {
         SimNodeDebug_ForGoodArray1 ( const LineInfo & at ) : SimNode_ForGoodArray1<totalCount>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             Array * __restrict pha[totalCount];
             char * __restrict ph[totalCount];
@@ -437,7 +437,7 @@ namespace das
     template <>
     struct SimNodeDebug_ForGoodArray1<1> : public SimNode_ForGoodArray1<1> {
         SimNodeDebug_ForGoodArray1 ( const LineInfo & at ) : SimNode_ForGoodArray1<1>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             Array * __restrict pha;
             char * __restrict ph;
@@ -477,7 +477,7 @@ namespace das
         virtual SimNode * visit ( SimVisitor & vis ) override {
             return visitFor(vis, totalCount, "ForFixedArray");
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * __restrict ph[totalCount];
             for ( int t=0; t!=totalCount; ++t ) {
@@ -516,7 +516,7 @@ namespace das
             V_FINAL();
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             evalFinal(context);
             return v_zero();
@@ -529,7 +529,7 @@ namespace das
         virtual SimNode * visit ( SimVisitor & vis ) override {
             return visitFor(vis, 1, "ForFixedArray");
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * __restrict ph = cast<char *>::to(sources[0]->eval(context));
             char ** __restrict pi = (char **)(context.stack.sp() + stackTop[0]);
@@ -559,7 +559,7 @@ namespace das
         virtual SimNode * visit ( SimVisitor & vis ) override {
             return visitFor(vis, totalCount, "ForFixedArray1");
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * __restrict ph[totalCount];
             for ( int t=0; t!=totalCount; ++t ) {
@@ -594,7 +594,7 @@ namespace das
             V_FINAL();
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             evalFinal(context);
             return v_zero();
@@ -607,7 +607,7 @@ namespace das
         virtual SimNode * visit ( SimVisitor & vis ) override {
             return visitFor(vis, 1, "ForFixedArray1");
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * __restrict ph = cast<char *>::to(sources[0]->eval(context));
             char ** __restrict pi = (char **)(context.stack.sp() + stackTop[0]);
@@ -636,7 +636,7 @@ namespace das
     template <int totalCount>
     struct SimNodeDebug_ForFixedArray : SimNode_ForFixedArray<totalCount> {
         SimNodeDebug_ForFixedArray ( const LineInfo & at ) : SimNode_ForFixedArray<totalCount>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * __restrict ph[totalCount];
             for ( int t=0; t!=totalCount; ++t ) {
@@ -675,7 +675,7 @@ namespace das
     template <>
     struct SimNodeDebug_ForFixedArray<1> : SimNode_ForFixedArray<1> {
         SimNodeDebug_ForFixedArray ( const LineInfo & at ) : SimNode_ForFixedArray<1>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * __restrict ph = cast<char *>::to(sources[0]->eval(context));
             char ** __restrict pi = (char **)(context.stack.sp() + stackTop[0]);
@@ -703,7 +703,7 @@ namespace das
     template <int totalCount>
     struct SimNodeDebug_ForFixedArray1 : SimNode_ForFixedArray1<totalCount> {
         SimNodeDebug_ForFixedArray1 ( const LineInfo & at ) : SimNode_ForFixedArray1<totalCount>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * __restrict ph[totalCount];
             for ( int t=0; t!=totalCount; ++t ) {
@@ -738,7 +738,7 @@ namespace das
     template <>
     struct SimNodeDebug_ForFixedArray1<1> : SimNode_ForFixedArray1<1> {
         SimNodeDebug_ForFixedArray1 ( const LineInfo & at ) : SimNode_ForFixedArray1<1>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * __restrict ph = cast<char *>::to(sources[0]->eval(context));
             char ** __restrict pi = (char **)(context.stack.sp() + stackTop[0]);

--- a/include/daScript/simulate/runtime_range.h
+++ b/include/daScript/simulate/runtime_range.h
@@ -34,7 +34,7 @@ namespace das
         SimNode_RangeIterator ( const LineInfo & at, SimNode * rng )
             : SimNode(at), subexpr(rng) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f ll = subexpr->eval(context);
             TRange r = cast<TRange>::to(ll);
@@ -61,7 +61,7 @@ namespace das
         SimNode_ForRange ( const LineInfo & at )
             : SimNode_ForRangeBase(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     template <typename TRange>
@@ -69,7 +69,7 @@ namespace das
         SimNode_ForRangeNF ( const LineInfo & at )
             : SimNode_ForRangeBase(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     template <typename TRange>
@@ -77,7 +77,7 @@ namespace das
         SimNode_ForRange1 ( const LineInfo & at )
             : SimNode_ForRangeBase(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     template <typename TRange>
@@ -85,7 +85,7 @@ namespace das
         SimNode_ForRangeNF1 ( const LineInfo & at )
             : SimNode_ForRangeBase(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     //////////////////
@@ -98,28 +98,28 @@ namespace das
     struct SimNodeDebug_ForRange : SimNode_ForRange<TRange>  {
         SimNodeDebug_ForRange ( const LineInfo & at )
             : SimNode_ForRange<TRange>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     template <typename TRange>
     struct SimNodeDebug_ForRangeNF : SimNode_ForRangeNF<TRange>  {
         SimNodeDebug_ForRangeNF ( const LineInfo & at )
             : SimNode_ForRangeNF<TRange>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     template <typename TRange>
     struct SimNodeDebug_ForRange1 : SimNode_ForRange1<TRange>  {
         SimNodeDebug_ForRange1 ( const LineInfo & at )
             : SimNode_ForRange1<TRange>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     template <typename TRange>
     struct SimNodeDebug_ForRangeNF1 : SimNode_ForRangeNF1<TRange>  {
         SimNodeDebug_ForRangeNF1 ( const LineInfo & at )
             : SimNode_ForRangeNF1<TRange>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
 #endif

--- a/include/daScript/simulate/runtime_string_delete.h
+++ b/include/daScript/simulate/runtime_string_delete.h
@@ -17,7 +17,7 @@ namespace das
         SimNode_StringIterator ( const LineInfo & at, SimNode * s )
             : SimNode(at), source(s) { }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode *   source;
     };
 }

--- a/include/daScript/simulate/runtime_table_nodes.h
+++ b/include/daScript/simulate/runtime_table_nodes.h
@@ -105,7 +105,7 @@ namespace das
         virtual SimNode * visit ( SimVisitor & vis ) override {
             return visitTable(vis,"TableSetInsert");
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             Table * tab = (Table *) tabExpr->evalPtr(context);
             if ( tab->isLocked() ) context.throw_error_at(debugInfo, "can't insert to a locked table");
@@ -183,7 +183,7 @@ namespace das
         SimNode_DeleteTable ( const LineInfo & a, SimNode * s, uint32_t t, uint32_t va )
             : SimNode_Delete(a,s,t), vts_add_kts(va) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         uint32_t vts_add_kts;
     };
 }

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -97,7 +97,7 @@ namespace das
     struct SimNode {
         SimNode ( const LineInfo & at ) : debugInfo(at) {}
         virtual SimNode * copyNode ( Context & context, NodeAllocator * code );
-        virtual vec4f DAS_EVAL_ABI eval ( Context & ) = 0;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & ) = 0;
         virtual SimNode * visit ( SimVisitor & vis );
         virtual char *      evalPtr ( Context & context );
         virtual bool        evalBool ( Context & context );
@@ -328,7 +328,7 @@ namespace das
             return insideContext --;
         }
 
-        __forceinline vec4f DAS_EVAL_ABI eval ( const SimFunction * fnPtr, vec4f * args = nullptr, void * res = nullptr ) {
+        DAS_EVAL_ABI __forceinline vec4f eval ( const SimFunction * fnPtr, vec4f * args = nullptr, void * res = nullptr ) {
             return callWithCopyOnReturn(fnPtr, args, res, 0);
         }
 
@@ -341,8 +341,8 @@ namespace das
             unlock();
         }
 
-        vec4f DAS_EVAL_ABI ___noinline evalWithCatch ( SimFunction * fnPtr, vec4f * args = nullptr, void * res = nullptr );
-        vec4f DAS_EVAL_ABI ___noinline evalWithCatch ( SimNode * node );
+        DAS_EVAL_ABI vec4f ___noinline evalWithCatch ( SimFunction * fnPtr, vec4f * args = nullptr, void * res = nullptr );
+        DAS_EVAL_ABI vec4f ___noinline evalWithCatch ( SimNode * node );
         bool ___noinline runWithCatch ( const callable<void()> & subexpr );
         DAS_NORETURN_PREFIX void throw_error ( const char * message ) DAS_NORETURN_SUFFIX;
         DAS_NORETURN_PREFIX void throw_error_ex ( DAS_FORMAT_STRING_PREFIX const char * message, ... ) DAS_NORETURN_SUFFIX DAS_FORMAT_PRINT_ATTRIBUTE(2,3);
@@ -406,7 +406,7 @@ namespace das
             return (char *) abiCMRES;
         }
 
-        __forceinline vec4f DAS_EVAL_ABI call(const SimFunction * fn, vec4f * args, LineInfo * line) {
+        DAS_EVAL_ABI __forceinline vec4f call(const SimFunction * fn, vec4f * args, LineInfo * line) {
             // PUSH
             char * EP, *SP;
             if (!stack.push(fn->stackSize, EP, SP)) {
@@ -435,7 +435,7 @@ namespace das
             return result;
         }
 
-        __forceinline vec4f DAS_EVAL_ABI callOrFastcall(const SimFunction * fn, vec4f * args, LineInfo * line) {
+        DAS_EVAL_ABI __forceinline vec4f callOrFastcall(const SimFunction * fn, vec4f * args, LineInfo * line) {
             if ( fn->fastcall ) {
                 auto aa = abiArg;
                 abiArg = args;
@@ -472,7 +472,7 @@ namespace das
             }
         }
 
-        __forceinline vec4f DAS_EVAL_ABI callWithCopyOnReturn(const SimFunction * fn, vec4f * args, void * cmres, LineInfo * line) {
+        DAS_EVAL_ABI __forceinline vec4f callWithCopyOnReturn(const SimFunction * fn, vec4f * args, void * cmres, LineInfo * line) {
             // PUSH
             char * EP, *SP;
             if (!stack.push(fn->stackSize, EP, SP)) {
@@ -506,7 +506,7 @@ namespace das
 #pragma warning(disable:4324)
 #endif
 
-        __forceinline vec4f DAS_EVAL_ABI invoke(const Block &block, vec4f * args, void * cmres, LineInfo * line ) {
+        DAS_EVAL_ABI __forceinline vec4f invoke(const Block &block, vec4f * args, void * cmres, LineInfo * line ) {
             char * EP, *SP;
             vec4f * TBA = nullptr;
             char * STB = stack.bottom();
@@ -549,10 +549,10 @@ namespace das
 #endif
 
         template <typename Fn>
-        vec4f DAS_EVAL_ABI invokeEx(const Block &block, vec4f * args, void * cmres, Fn && when, LineInfo * line);
+        DAS_EVAL_ABI vec4f invokeEx(const Block &block, vec4f * args, void * cmres, Fn && when, LineInfo * line);
 
         template <typename Fn>
-        vec4f DAS_EVAL_ABI callEx(const SimFunction * fn, vec4f *args, void * cmres, LineInfo * line, Fn && when) {
+        DAS_EVAL_ABI vec4f callEx(const SimFunction * fn, vec4f *args, void * cmres, LineInfo * line, Fn && when) {
             // PUSH
             char * EP, *SP;
             if(!stack.push(fn->stackSize,EP,SP)) {
@@ -796,7 +796,7 @@ __forceinline void profileNode ( SimNode * node ) {
     EVAL_NODE(Bool,bool);
 
 #define DAS_NODE(TYPE,CTYPE)                                         \
-    virtual vec4f DAS_EVAL_ABI eval ( das::Context & context ) override {         \
+    DAS_EVAL_ABI virtual vec4f eval ( das::Context & context ) override {         \
         return das::cast<CTYPE>::from(compute(context));             \
     }                                                                \
     virtual CTYPE eval##TYPE ( das::Context & context ) override {   \
@@ -908,7 +908,7 @@ __forceinline void profileNode ( SimNode * node ) {
         void visitBlock ( SimVisitor & vis );
         void visitLabels ( SimVisitor & vis );
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode ** list = nullptr;
         uint32_t total = 0;
         uint64_t annotationDataSid = 0;
@@ -918,28 +918,28 @@ __forceinline void profileNode ( SimNode * node ) {
 
     struct SimNodeDebug_Block : SimNode_Block {
         SimNodeDebug_Block ( const LineInfo & at ) : SimNode_Block(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     struct SimNode_BlockNF : SimNode_Block {
         SimNode_BlockNF ( const LineInfo & at ) : SimNode_Block(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     struct SimNodeDebug_BlockNF : SimNode_BlockNF {
         SimNodeDebug_BlockNF ( const LineInfo & at ) : SimNode_BlockNF(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     struct SimNode_BlockWithLabels : SimNode_Block {
         SimNode_BlockWithLabels ( const LineInfo & at ) : SimNode_Block(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     struct SimNodeDebug_BlockWithLabels : SimNode_BlockWithLabels {
         SimNodeDebug_BlockWithLabels ( const LineInfo & at ) : SimNode_BlockWithLabels(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     struct SimNode_ForBase : SimNode_Block {
@@ -969,7 +969,7 @@ __forceinline void profileNode ( SimNode * node ) {
                 this->code0 = c0;
             }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         uint64_t annotationData = 0;
         union {
             uint32_t flags;
@@ -983,7 +983,7 @@ __forceinline void profileNode ( SimNode * node ) {
     struct SimNodeDebug_ClosureBlock : SimNode_ClosureBlock {
         SimNodeDebug_ClosureBlock ( const LineInfo & at, bool nr, bool c0, uint64_t ad )
             : SimNode_ClosureBlock(at,nr,c0,ad) { }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
 #ifdef _MSC_VER
@@ -992,7 +992,7 @@ __forceinline void profileNode ( SimNode * node ) {
 #pragma warning(disable:4324)
 #endif
     template <typename Fn>
-    vec4f DAS_EVAL_ABI Context::invokeEx(const Block &block, vec4f * args, void * cmres, Fn && when, LineInfo * line ) {
+    DAS_EVAL_ABI vec4f Context::invokeEx(const Block &block, vec4f * args, void * cmres, Fn && when, LineInfo * line ) {
         char * EP, *SP;
         vec4f * TBA = nullptr;
         char * STB = stack.bottom();

--- a/include/daScript/simulate/simulate_fusion_op2.h
+++ b/include/daScript/simulate/simulate_fusion_op2.h
@@ -7,7 +7,7 @@
 
 #define IMPLEMENT_OP2_SET_NODE_ANY(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL) \
     struct SimNode_##OPNAME##_##COMPUTEL##_Any : SimNode_Op2Fusion { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto pl = FUSION_OP2_PTR(CTYPE,l.compute##COMPUTEL(context)); \
             auto rr = r.subexpr->eval##TYPE(context); \
@@ -18,7 +18,7 @@
 
 #define IMPLEMENT_OP2_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL,COMPUTER) \
     struct SimNode_##OPNAME##_##COMPUTEL##_##COMPUTER : SimNode_Op2Fusion { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto pl = FUSION_OP2_PTR(CTYPE,l.compute##COMPUTEL(context)); \
             auto rr = FUSION_OP2_RVALUE_RIGHT(CTYPE,r.compute##COMPUTER(context)); \

--- a/include/daScript/simulate/simulate_nodes.h
+++ b/include/daScript/simulate/simulate_nodes.h
@@ -199,7 +199,7 @@ namespace das {
         SimNode_Jit ( const LineInfo & at, JitFunction eval )
             : SimNode(at), func(eval) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         virtual bool rtti_node_isJit() const override { return true; }
         JitFunction func = nullptr;
         // saved original node
@@ -218,7 +218,7 @@ namespace das {
         SimNode_JitBlock ( const LineInfo & at, JitBlockFunction eval )
             : SimNode(at), func(eval) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         JitBlockFunction func = nullptr;
     };
     static_assert(sizeof(SimNode_JitBlock)<=(3*16),"jit block node must fit under 3 vec4f");
@@ -233,7 +233,7 @@ namespace das {
 
     struct SimNode_NOP : SimNode {
         SimNode_NOP ( const LineInfo & s ) : SimNode(s) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         virtual SimNode * visit ( SimVisitor & vis ) override;
     };
 
@@ -241,7 +241,7 @@ namespace das {
     struct SimNode_DeleteStructPtr : SimNode_Delete {
         SimNode_DeleteStructPtr ( const LineInfo & a, SimNode * s, uint32_t t, uint32_t ss, bool ps, bool isL )
             : SimNode_Delete(a,s,t), structSize(ss), persistent(ps), isLambda(isL) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         virtual SimNode * visit ( SimVisitor & vis ) override;
         uint32_t    structSize;
         bool        persistent;
@@ -251,7 +251,7 @@ namespace das {
     struct SimNode_DeleteClassPtr : SimNode_Delete {
         SimNode_DeleteClassPtr ( const LineInfo & a, SimNode * s, uint32_t t, SimNode * se, bool ps )
             : SimNode_Delete(a,s,t), sizeexpr(se), persistent(ps) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         virtual SimNode * visit ( SimVisitor & vis ) override;
         SimNode * sizeexpr;
         bool persistent;
@@ -261,7 +261,7 @@ namespace das {
     struct SimNode_DeleteLambda : SimNode_Delete {
         SimNode_DeleteLambda ( const LineInfo & a, SimNode * s, uint32_t t )
             : SimNode_Delete(a,s,t) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         virtual SimNode * visit ( SimVisitor & vis ) override;
     };
 
@@ -314,7 +314,7 @@ namespace das {
         SimNode_DeleteHandlePtr ( const LineInfo & a, SimNode * s, uint32_t t )
             : SimNode_Delete(a,s,t) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto pH = (TT **) subexpr->evalPtr(context);
             for ( uint32_t i=0, is=total; i!=is; ++i, pH++ ) {
@@ -332,7 +332,7 @@ namespace das {
         SimNode_DeleteHandlePtr ( const LineInfo & a, SimNode * s, uint32_t t )
             : SimNode_Delete(a,s,t) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto pH = (TT **) subexpr->evalPtr(context);
             for ( uint32_t i=0, is=total; i!=is; ++i, pH++ ) {
@@ -351,7 +351,7 @@ namespace das {
         SimNode_MakeBlock ( const LineInfo & at, SimNode * s, uint32_t a, uint32_t spp, FuncInfo * fi )
             : SimNode(at), subexpr(s), argStackTop(a), stackTop(spp), info(fi) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode *       subexpr;
         uint32_t        argStackTop;
         uint32_t        stackTop;
@@ -363,7 +363,7 @@ namespace das {
         SimNode_Assert ( const LineInfo & at, SimNode * s, const char * m )
             : SimNode(at), subexpr(s), message(m) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode *       subexpr;
         const char *    message;
     };
@@ -379,7 +379,7 @@ namespace das {
                 fields[3] = fi[3];
             }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode *   value;
         uint8_t     fields[4];
     };
@@ -392,7 +392,7 @@ namespace das {
                 fields[2] = fi[2];
                 fields[3] = fi[3];
             }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     // FIELD .
@@ -414,7 +414,7 @@ namespace das {
         SimNode_FieldDerefR2V ( const LineInfo & at, SimNode * rv, uint32_t of )
             : SimNode_FieldDeref(at,rv,of) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto prv = value->evalPtr(context);
             TT * pR = (TT *)( prv + offset );
@@ -484,7 +484,7 @@ namespace das {
         SimNode_VariantFieldDerefR2V ( const LineInfo & at, SimNode * rv, uint32_t of, int32_t v )
             : SimNode_VariantFieldDeref(at,rv,of,v) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto prv = value->evalPtr(context);
             int32_t cv = *(int *)prv;
@@ -530,7 +530,7 @@ namespace das {
         SimNode_PtrFieldDerefR2V(const LineInfo & at, SimNode * rv, uint32_t of)
             : SimNode_PtrFieldDeref(at, rv, of) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             TT * pR = (TT *)compute(context);
             return cast<TT>::from(*pR);
         }
@@ -607,7 +607,7 @@ namespace das {
         SimNode_AtR2V ( const LineInfo & at, SimNode * rv, SimNode * idx, uint32_t strd, uint32_t o, uint32_t rng )
             : SimNode_At(at,rv,idx,strd,o,rng) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *) compute(context);
             return cast<TT>::from(*pR);
         }
@@ -698,7 +698,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     template <int argCount>
     struct SimNode_FastCall : SimNode_FastCallAny {
         SimNode_FastCall ( const LineInfo & at ) : SimNode_FastCallAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f argValues[argCount ? argCount : 1];
             EvalBlock<argCount>::eval(context, arguments, argValues);
@@ -728,7 +728,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     template <>
     struct SimNode_FastCall<-1> : SimNode_FastCallAny {
         SimNode_FastCall(const LineInfo& at) : SimNode_FastCallAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval(Context& context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context& context) override {
             DAS_PROFILE_NODE
             vec4f argValues[DAS_MAX_FUNCTION_ARGUMENTS];
             evalArgs(context, argValues);
@@ -765,7 +765,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     template <int argCount>
     struct SimNode_Call : SimNode_CallAny {
         SimNode_Call ( const LineInfo & at ) : SimNode_CallAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f argValues[argCount ? argCount : 1];
             EvalBlock<argCount>::eval(context, arguments, argValues);
@@ -785,7 +785,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     template <>
     struct SimNode_Call<-1> : SimNode_CallAny {
         SimNode_Call ( const LineInfo & at ) : SimNode_CallAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f argValues[DAS_MAX_FUNCTION_ARGUMENTS];
             evalArgs(context, argValues);
@@ -846,7 +846,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_Invoke : SimNode_InvokeAny {
         SimNode_Invoke ( const LineInfo & at)
             : SimNode_InvokeAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f argValues[argCount ? argCount : 1];
             EvalBlock<argCount>::eval(context, arguments, argValues);
@@ -877,7 +877,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_Invoke<-1> : SimNode_InvokeAny {
         SimNode_Invoke(const LineInfo& at)
             : SimNode_InvokeAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval(Context& context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context& context) override {
             DAS_PROFILE_NODE
             vec4f argValues[DAS_MAX_FUNCTION_ARGUMENTS];
             evalArgs(context, argValues);
@@ -907,7 +907,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_InvokeAndCopyOrMove : SimNode_InvokeAndCopyOrMoveAny {
         SimNode_InvokeAndCopyOrMove ( const LineInfo & at, SimNode * spCMRES )
             : SimNode_InvokeAndCopyOrMoveAny(at) { cmresEval = spCMRES; }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto cmres = cmresEval->evalPtr(context);
             vec4f argValues[argCount ? argCount : 1];
@@ -942,7 +942,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             : SimNode_InvokeAndCopyOrMoveAny(at) {
             cmresEval = spCMRES;
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context& context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context& context) override {
             DAS_PROFILE_NODE
             auto cmres = cmresEval->evalPtr(context);
             vec4f argValues[DAS_MAX_FUNCTION_ARGUMENTS];
@@ -973,7 +973,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     template <int argCount>
     struct SimNode_InvokeFn : SimNode_InvokeFnAny {
         SimNode_InvokeFn ( const LineInfo & at ) : SimNode_InvokeFnAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE \
             vec4f argValues[argCount ? argCount : 1];
             EvalBlock<argCount>::eval(context, arguments, argValues);
@@ -1005,7 +1005,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     template <>
     struct SimNode_InvokeFn<-1> : SimNode_InvokeFnAny {
         SimNode_InvokeFn(const LineInfo& at) : SimNode_InvokeFnAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval(Context& context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context& context) override {
             DAS_PROFILE_NODE
             vec4f argValues[DAS_MAX_FUNCTION_ARGUMENTS];
             evalArgs(context, argValues);
@@ -1036,7 +1036,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     template <int argCount>
     struct SimNode_InvokeFnByName : SimNode_InvokeFnByNameAny {
         SimNode_InvokeFnByName ( const LineInfo & at ) : SimNode_InvokeFnByNameAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE \
             vec4f argValues[argCount ? argCount : 1];
             EvalBlock<argCount>::eval(context, arguments, argValues);
@@ -1080,7 +1080,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     template <>
     struct SimNode_InvokeFnByName<-1> : SimNode_InvokeFnByNameAny {
         SimNode_InvokeFnByName(const LineInfo& at) : SimNode_InvokeFnByNameAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval(Context& context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context& context) override {
             DAS_PROFILE_NODE
             vec4f argValues[DAS_MAX_FUNCTION_ARGUMENTS];
             evalArgs(context, argValues);
@@ -1124,7 +1124,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     template <int argCount>
     struct SimNode_InvokeLambda : SimNode_InvokeLambdaAny {
         SimNode_InvokeLambda ( const LineInfo & at ) : SimNode_InvokeLambdaAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE \
             vec4f argValues[argCount ? argCount : 1];
             EvalBlock<argCount>::eval(context, arguments, argValues);
@@ -1152,7 +1152,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     template <>
     struct SimNode_InvokeLambda<-1> : SimNode_InvokeLambdaAny {
         SimNode_InvokeLambda(const LineInfo& at) : SimNode_InvokeLambdaAny(at) {}
-        virtual vec4f DAS_EVAL_ABI eval(Context& context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context& context) override {
             DAS_PROFILE_NODE
             vec4f argValues[DAS_MAX_FUNCTION_ARGUMENTS];
             evalArgs(context, argValues);
@@ -1189,7 +1189,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_InvokeAndCopyOrMoveFn : SimNode_InvokeAndCopyOrMoveFnAny {
         SimNode_InvokeAndCopyOrMoveFn ( const LineInfo & at, SimNode * spEval )
             : SimNode_InvokeAndCopyOrMoveFnAny(at) { cmresEval = spEval; }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE \
             auto cmres = cmresEval->evalPtr(context);
             vec4f argValues[argCount ? argCount : 1];
@@ -1226,7 +1226,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             : SimNode_InvokeAndCopyOrMoveFnAny(at) {
             cmresEval = spEval;
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context& context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context& context) override {
             DAS_PROFILE_NODE
             auto cmres = cmresEval->evalPtr(context);
             vec4f argValues[DAS_MAX_FUNCTION_ARGUMENTS];
@@ -1260,7 +1260,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_InvokeAndCopyOrMoveLambda : SimNode_InvokeAndCopyOrMoveLambdaAny {
         SimNode_InvokeAndCopyOrMoveLambda ( const LineInfo & at, SimNode * spEval )
             : SimNode_InvokeAndCopyOrMoveLambdaAny(at) { cmresEval = spEval; }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto cmres = cmresEval->evalPtr(context);
             vec4f argValues[argCount ? argCount : 1];
@@ -1293,7 +1293,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             : SimNode_InvokeAndCopyOrMoveLambdaAny(at) {
             cmresEval = spEval;
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context& context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context& context) override {
             DAS_PROFILE_NODE
             auto cmres = cmresEval->evalPtr(context);
             vec4f argValues[DAS_MAX_FUNCTION_ARGUMENTS];
@@ -1324,7 +1324,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_StringBuilder : SimNode_CallBase {
         SimNode_StringBuilder ( const LineInfo & at ) : SimNode_CallBase(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     // CAST
@@ -1332,7 +1332,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_Cast : SimNode_CallBase {
         SimNode_Cast ( const LineInfo & at ) : SimNode_CallBase(at) { }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f res = arguments[0]->eval(context);
             CastTo value = (CastTo) cast<CastFrom>::to(res);
@@ -1345,7 +1345,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_LexicalCast : SimNode_CallBase {
         SimNode_LexicalCast ( const LineInfo & at ) : SimNode_CallBase(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f res = arguments[0]->eval(context);
             auto str = to_string ( cast<CastFrom>::to(res) );
@@ -1363,7 +1363,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_Debug ( const LineInfo & at, SimNode * s, TypeInfo * ti, char * msg )
             : SimNode(at), subexpr(s), typeInfo(ti), message(msg) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode *       subexpr;
         TypeInfo *      typeInfo;
         const char *    message;
@@ -1401,7 +1401,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_GetCMResOfsR2V(const LineInfo & at, uint32_t o)
             : SimNode_GetCMResOfs(at,o)  {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *)compute(context);
             return cast<TT>::from(*pR);
         }
@@ -1446,7 +1446,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_GetLocalR2V(const LineInfo & at, uint32_t sp)
             : SimNode_GetLocal(at,sp)  {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *)compute(context);
             return cast<TT>::from(*pR);
         }
@@ -1477,7 +1477,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_GetLocalRefOffR2V(const LineInfo & at, uint32_t sp, uint32_t o)
             : SimNode_GetLocalRefOff(at,sp,o) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *) compute(context);
             return cast<TT>::from(*pR);
         }
@@ -1512,7 +1512,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_MemZero(const LineInfo & at, SimNode * se, uint32_t sz)
             : SimNode(at), subexpr(se), size(sz) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto refV = subexpr->evalPtr(context);
             memset(refV, 0, size);
@@ -1527,7 +1527,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_InitLocal(const LineInfo & at, uint32_t sp, uint32_t sz)
             : SimNode(at), stackTop(sp), size(sz) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             memset(context.stack.sp() + stackTop, 0, size);
             return v_zero();
@@ -1540,7 +1540,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_InitLocalCMRes(const LineInfo & at, uint32_t o, uint32_t sz)
             : SimNode(at), offset(o), size(sz) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             memset(context.abiCopyOrMoveResult() + offset, 0, size);
             return v_zero();
@@ -1552,7 +1552,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_InitLocalCMResN : SimNode_InitLocalCMRes {
         SimNode_InitLocalCMResN(const LineInfo & at, uint32_t o)
             : SimNode_InitLocalCMRes(at, o, SIB) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             memset(context.abiCopyOrMoveResult() + offset, 0, SIB);
             return v_zero();
@@ -1564,7 +1564,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_InitLocalRef(const LineInfo & at, uint32_t sp, uint32_t o, uint32_t sz)
             : SimNode(at), stackTop(sp), offset(o), size(sz) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * pI = *((char **)(context.stack.sp() + stackTop)) + offset;
             memset(pI, 0, size);
@@ -1584,7 +1584,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             DAS_PROFILE_NODE
             return subexpr.computeArgument(context);
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             return *(vec4f *)compute(context);
         }
 #define EVAL_NODE(TYPE,CTYPE)                                       \
@@ -1613,7 +1613,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             DAS_PROFILE_NODE
             return subexpr.computeArgumentRef(context);
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *)compute(context);
             return cast<TT>::from(*pR);
         }
@@ -1643,7 +1643,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_GetArgumentRefOffR2V ( const LineInfo & at, int32_t i, uint32_t o )
             : SimNode_GetArgumentRefOff(at,i, o) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *)compute(context);
             return cast<TT>::from(*pR);
         }
@@ -1666,7 +1666,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             DAS_PROFILE_NODE
             return subexpr.computeBlockArgument(context);
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             return *(vec4f *)compute(context);
         }
 #define EVAL_NODE(TYPE,CTYPE)                                       \
@@ -1695,7 +1695,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             DAS_PROFILE_NODE
             return subexpr.computeBlockArgumentRef(context);
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *)compute(context);
             return cast<TT>::from(*pR);
         }
@@ -1718,7 +1718,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             DAS_PROFILE_NODE
             return subexpr.computeThisBlockArgument(context);
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             return *(vec4f *)compute(context);
         }
 #define EVAL_NODE(TYPE,CTYPE)                                       \
@@ -1747,7 +1747,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             DAS_PROFILE_NODE
             return subexpr.computeThisBlockArgumentRef(context);
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *)compute(context);
             return cast<TT>::from(*pR);
         }
@@ -1778,7 +1778,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_GetGlobalR2V ( const LineInfo & at, uint32_t o, uint64_t mnh )
             : SimNode_GetGlobal(at,o,mnh) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *)compute(context);
             return cast<TT>::from(*pR);
         }
@@ -1809,7 +1809,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_GetGlobalMnhR2V ( const LineInfo & at, uint32_t o, uint64_t mnh )
             : SimNode_GetGlobalMnh(at,o,mnh) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *)compute(context);
             return cast<TT>::from(*pR);
         }
@@ -1840,7 +1840,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_GetSharedR2V ( const LineInfo & at, uint32_t o, uint64_t mnh )
             : SimNode_GetShared(at,o,mnh) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *)compute(context);
             return cast<TT>::from(*pR);
         }
@@ -1871,7 +1871,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_GetSharedMnhR2V ( const LineInfo & at, uint32_t o, uint64_t mnh )
             : SimNode_GetSharedMnh(at,o,mnh) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             TT * pR = (TT *)compute(context);
             return cast<TT>::from(*pR);
         }
@@ -1888,7 +1888,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_TryCatch ( const LineInfo & at, SimNode * t, SimNode * c )
             : SimNode(at), try_block(t), catch_block(c) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode * try_block, * catch_block;
     };
 
@@ -1896,7 +1896,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNodeDebug_TryCatch : SimNode_TryCatch {
         SimNodeDebug_TryCatch ( const LineInfo & at, SimNode * t, SimNode * c )
             : SimNode_TryCatch(at,t,c) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 #endif
 
@@ -1905,7 +1905,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_Return ( const LineInfo & at, SimNode * s )
             : SimNode(at), subexpr(s) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode * subexpr;
     };
 
@@ -1915,7 +1915,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_ReturnAndMoveR2V ( const LineInfo & at, SimNode * s )
             : SimNode_Return(at,s) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             TT * pR = (TT *) subexpr->evalPtr(context);
             context.abiResult() = cast<TT>::from(*pR);
@@ -1929,14 +1929,14 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_ReturnNothing ( const LineInfo & at )
             : SimNode(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     struct SimNode_ReturnConst : SimNode {
         SimNode_ReturnConst ( const LineInfo & at, vec4f v )
         : SimNode(at), value(v) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         vec4f value;
     };
 
@@ -1944,7 +1944,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_ReturnConstString ( const LineInfo & at, char * v )
         : SimNode(at), value(v) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         char * value;
     };
 
@@ -1952,7 +1952,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_ReturnAndCopy ( const LineInfo & at, SimNode * s, uint32_t sz )
             : SimNode_Return(at,s), size(sz) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         uint32_t size;
     };
 
@@ -1960,7 +1960,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_ReturnRefAndEval ( const LineInfo & at, SimNode * s, uint32_t sp )
             : SimNode_Return(at,s), stackTop(sp) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         uint32_t stackTop;
     };
 
@@ -1968,21 +1968,21 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_ReturnAndMove ( const LineInfo & at, SimNode * s, uint32_t sz )
             : SimNode_ReturnAndCopy(at,s,sz) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     struct SimNode_ReturnReference : SimNode_Return {
         SimNode_ReturnReference ( const LineInfo & at, SimNode * s )
             : SimNode_Return(at,s) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     struct SimNode_ReturnRefAndEvalFromBlock : SimNode_Return {
         SimNode_ReturnRefAndEvalFromBlock ( const LineInfo & at, SimNode * s, uint32_t sp, uint32_t asp )
             : SimNode_Return(at,s), stackTop(sp), argStackTop(asp) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         uint32_t stackTop, argStackTop;
     };
 
@@ -1990,7 +1990,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_ReturnAndCopyFromBlock ( const LineInfo & at, SimNode * s, uint32_t sz, uint32_t asp )
             : SimNode_ReturnAndCopy(at,s,sz), argStackTop(asp) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         uint32_t argStackTop;
     };
 
@@ -1998,21 +1998,21 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_ReturnAndMoveFromBlock ( const LineInfo & at, SimNode * s, uint32_t sz, uint32_t asp )
             : SimNode_ReturnAndCopyFromBlock(at,s,sz, asp) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     struct SimNode_ReturnReferenceFromBlock : SimNode_Return {
         SimNode_ReturnReferenceFromBlock ( const LineInfo & at, SimNode * s )
             : SimNode_Return(at,s) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     // GOTO LABEL
     struct SimNode_GotoLabel : SimNode {
         SimNode_GotoLabel ( const LineInfo & at, uint32_t lab ) : SimNode(at), label(lab) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             context.stopFlags |= EvalFlags::jumpToLabel;
             context.gotoLabel = label;
@@ -2025,7 +2025,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_Goto : SimNode {
         SimNode_Goto ( const LineInfo & at, SimNode * lab ) : SimNode(at), subexpr(lab) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             context.gotoLabel = subexpr->evalInt(context);
             context.stopFlags |= EvalFlags::jumpToLabel;
@@ -2038,7 +2038,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_Break : SimNode {
         SimNode_Break ( const LineInfo & at ) : SimNode(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             context.stopFlags |= EvalFlags::stopForBreak;
             return v_zero();
@@ -2049,7 +2049,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_Continue : SimNode {
         SimNode_Continue ( const LineInfo & at ) : SimNode(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             context.stopFlags |= EvalFlags::stopForContinue;
             return v_zero();
@@ -2062,7 +2062,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_Ref2Value ( const LineInfo & at, SimNode * s )
             : SimNode(at), subexpr(s) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             TT * pR = (TT *) subexpr->evalPtr(context);
             return cast<TT>::from(*pR);
@@ -2126,7 +2126,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_NullCoalescing ( const LineInfo & at, SimNode * s, SimNode * dv )
             : SimNode_Ptr2Ref(at,s), value(dv) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             TT * pR = (TT *) subexpr->evalPtr(context);
             return pR ? cast<TT>::from(*pR) : value->eval(context);
@@ -2378,7 +2378,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             subexpr.setConstValuePtr(c);
         }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context )      override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context )      override {
             DAS_PROFILE_NODE
             return subexpr.value;
         }
@@ -2395,7 +2395,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             subexpr.setConstValue(c);
         }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             return subexpr.value;
         }
@@ -2440,7 +2440,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             subexpr.setConstValue(c);
         }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             DAS_ASSERTF(subexpr.valueU<uint32_t(context.totalFunctions),
                 "Function address index is out of range. "
@@ -2464,7 +2464,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             subexpr.setConstValue(c);
         }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             SimFunction * fun = context.fnByMangledName(subexpr.valueU64);
             DAS_ASSERT(fun==nullptr || fun->mangledNameHash==subexpr.valueU64);
@@ -2483,7 +2483,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_Zero : SimNode_CallBase {
         SimNode_Zero(const LineInfo & at) : SimNode_CallBase(at) { }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             return v_zero();
         }
@@ -2504,7 +2504,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_CopyReference(const LineInfo & at, SimNode * ll, SimNode * rr)
             : SimNode(at), l(ll), r(rr) {};
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char  ** pl = (char **) l->evalPtr(context);
             char * pr = r->evalPtr(context);
@@ -2520,7 +2520,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_Set(const LineInfo & at, SimNode * ll, SimNode * rr)
             : SimNode(at), l(ll), r(rr) {};
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             TT * pl = (TT *) l->evalPtr(context);
             *pl = EvalTT<TT>::eval(context, r);
@@ -2534,7 +2534,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_CopyRefValue(const LineInfo & at, SimNode * ll, SimNode * rr, size_t sz)
             : SimNode(at), l(ll), r(rr), size(uint32_t(sz)) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode * l, * r;
         uint32_t size;
     };
@@ -2544,7 +2544,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_CloneRefValueT(const LineInfo & at, SimNode * ll, SimNode * rr)
             : SimNode(at), l(ll), r(rr) {};
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             TT * pl = (TT *) l->evalPtr(context);
             TT * pr = (TT *) r->evalPtr(context);
@@ -2559,7 +2559,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_MoveRefValue(const LineInfo & at, SimNode * ll, SimNode * rr, uint32_t sz)
             : SimNode(at), l(ll), r(rr), size(sz) {};
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode * l, * r;
         uint32_t size;
     };
@@ -2603,14 +2603,14 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_ReturnLocalCMRes ( const LineInfo & at )
             : SimNode_Block(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     // LET
     struct SimNode_Let : SimNode_Block {
         SimNode_Let ( const LineInfo & at ) : SimNode_Block(at) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     struct SimNode_IfTheElseAny : SimNode {
@@ -2625,7 +2625,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_IfThenElse ( const LineInfo & at, SimNode * c, SimNode * t, SimNode * f )
             : SimNode_IfTheElseAny(at,c,t,f) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             bool cmp = cond->evalBool(context);
             if ( cmp ) {
@@ -2655,7 +2655,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             : SimNode(at), subexpr(se) {}
         virtual bool rtti_node_isInstrument() const override { return true; }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             context.instrumentCallback(subexpr->debugInfo);
             return subexpr->eval(context);
@@ -2676,7 +2676,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             : SimNode(at), func(simF), fnMnh(mnh), subexpr(se), userData(ud) {}
         virtual bool rtti_node_isInstrumentFunction() const override { return true; }
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             context.instrumentFunctionCallback(func, true, userData);
             auto res = subexpr->eval(context);
@@ -2702,7 +2702,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNodeDebug_InstrumentFunctionThreadLocal : SimNodeDebug_InstrumentFunction {
         SimNodeDebug_InstrumentFunctionThreadLocal ( const LineInfo & at, SimFunction * simF, int64_t mnh, SimNode * se, uint64_t ud )
             : SimNodeDebug_InstrumentFunction(at,simF,mnh,se,ud) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             context.instrumentFunctionCallbackThreadLocal(func, true, userData);
             auto res = subexpr->eval(context);
@@ -2725,7 +2725,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNodeDebug_IfThenElse : SimNode_IfThenElse {
         SimNodeDebug_IfThenElse ( const LineInfo & at, SimNode * c, SimNode * t, SimNode * f )
             : SimNode_IfThenElse(at,c,t,f) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             DAS_SINGLE_STEP(context,cond->debugInfo,false);
             bool cmp = cond->evalBool(context);
@@ -2761,7 +2761,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_IfZeroThenElse ( const LineInfo & at, SimNode * c, SimNode * t, SimNode * f )
             : SimNode_IfTheElseAny(at,c,t,f) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto res = EvalTT<TT>::eval(context,cond);
             if ( res == 0 ) {
@@ -2790,7 +2790,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNodeDebug_IfZeroThenElse : SimNode_IfZeroThenElse<TT> {
         SimNodeDebug_IfZeroThenElse ( const LineInfo & at, SimNode * c, SimNode * t, SimNode * f )
             : SimNode_IfZeroThenElse<TT>(at,c,t,f) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             DAS_SINGLE_STEP(context,this->cond->debugInfo,false);
             auto res = EvalTT<TT>::eval(context,this->cond);
@@ -2826,7 +2826,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_IfNotZeroThenElse ( const LineInfo & at, SimNode * c, SimNode * t, SimNode * f )
             : SimNode_IfTheElseAny(at,c,t,f) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto res = EvalTT<TT>::eval(context,cond);
             if ( res != 0 ) {
@@ -2858,7 +2858,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNodeDebug_IfNotZeroThenElse : SimNode_IfNotZeroThenElse<TT> {
         SimNodeDebug_IfNotZeroThenElse ( const LineInfo & at, SimNode * c, SimNode * t, SimNode * f )
             : SimNode_IfNotZeroThenElse<TT>(at,c,t,f) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             DAS_SINGLE_STEP(context,this->cond->debugInfo,false);
             auto res = EvalTT<TT>::eval(context,this->cond);
@@ -2894,7 +2894,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_IfThen ( const LineInfo & at, SimNode * c, SimNode * t )
             : SimNode_IfTheElseAny(at,c,t,nullptr) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             bool cmp = cond->evalBool(context);
             if ( cmp ) {
@@ -2910,7 +2910,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNodeDebug_IfThen : SimNode_IfThen {
         SimNodeDebug_IfThen ( const LineInfo & at, SimNode * c, SimNode * t )
             : SimNode_IfThen(at,c,t) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             DAS_SINGLE_STEP(context,cond->debugInfo,false);
             bool cmp = cond->evalBool(context);
@@ -2930,7 +2930,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_IfZeroThen ( const LineInfo & at, SimNode * c, SimNode * t )
             : SimNode_IfTheElseAny(at,c,t,nullptr) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto res = EvalTT<TT>::eval(context,cond);
             if ( res==0 ) {
@@ -2947,7 +2947,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNodeDebug_IfZeroThen : SimNode_IfZeroThen<TT> {
         SimNodeDebug_IfZeroThen ( const LineInfo & at, SimNode * c, SimNode * t )
             : SimNode_IfZeroThen<TT>(at,c,t) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             DAS_SINGLE_STEP(context,this->cond->debugInfo,false);
             auto res = EvalTT<TT>::eval(context,this->cond);
@@ -2967,7 +2967,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_IfNotZeroThen ( const LineInfo & at, SimNode * c, SimNode * t )
             : SimNode_IfTheElseAny(at,c,t,nullptr) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             auto res = EvalTT<TT>::eval(context,cond);
             if ( res != 0 ) {
@@ -2984,7 +2984,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNodeDebug_IfNotZeroThen : SimNode_IfNotZeroThen<TT> {
         SimNodeDebug_IfNotZeroThen ( const LineInfo & at, SimNode * c, SimNode * t )
             : SimNode_IfNotZeroThen<TT>(at,c,t) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             DAS_SINGLE_STEP(context,this->cond->debugInfo,false);
             auto res = EvalTT<TT>::eval(context,this->cond);
@@ -3004,7 +3004,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_While ( const LineInfo & at, SimNode * c )
             : SimNode_Block(at), cond(c) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode * cond;
     };
 
@@ -3013,7 +3013,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNodeDebug_While : SimNode_While {
         SimNodeDebug_While ( const LineInfo & at, SimNode * c )
             : SimNode_While(at,c) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
 #endif
@@ -3025,7 +3025,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         virtual SimNode * copyNode ( Context & context, NodeAllocator * code ) override;
         SimNode * visitFor ( SimVisitor & vis, int total );
         virtual SimNode * visit ( SimVisitor & vis ) override;
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
         SimNode **  source_iterators = nullptr;
         uint32_t *  stackTop = nullptr;
         uint32_t    size = 0;
@@ -3043,7 +3043,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         virtual SimNode * visit ( SimVisitor & vis ) override {
             return visitFor(vis, totalCount);
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * pi[totalCount];
             for ( int t=0; t!=totalCount; ++t ) {
@@ -3094,7 +3094,7 @@ SIM_NODE_AT_VECTOR(Float, float)
             V_FINAL();
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             evalFinal(context);
             return v_zero();
@@ -3108,7 +3108,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         virtual SimNode * visit ( SimVisitor & vis ) override {
             return visitFor(vis, 1);
         }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * pi = (context.stack.sp() + stackTop[0]);
             Iterator * sources;
@@ -3146,14 +3146,14 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNodeDebug_ForWithIteratorBase : SimNode_ForWithIteratorBase {
         SimNodeDebug_ForWithIteratorBase ( const LineInfo & at )
             : SimNode_ForWithIteratorBase(at) { }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override;
     };
 
     template <int totalCount>
     struct SimNodeDebug_ForWithIterator : SimNode_ForWithIterator<totalCount> {
         SimNodeDebug_ForWithIterator ( const LineInfo & at )
             : SimNode_ForWithIterator<totalCount>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * pi[totalCount];
             for ( int t=0; t!=totalCount; ++t ) {
@@ -3205,7 +3205,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNodeDebug_ForWithIterator<1> : SimNode_ForWithIterator<1> {
         SimNodeDebug_ForWithIterator ( const LineInfo & at )
             : SimNode_ForWithIterator<1>(at) {}
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             char * pi = (context.stack.sp() + stackTop[0]);
             Iterator * sources;
@@ -3243,7 +3243,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     struct SimNode_AnyIterator : SimNode {
         SimNode_AnyIterator ( const LineInfo & at, SimNode * s )
             : SimNode(at), source(s) { }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f ll = source->eval(context);
             TT * array = cast<TT *>::to(ll);
@@ -3441,7 +3441,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         virtual SimNode * visit ( SimVisitor & vis ) override {         \
             return visitOp1(vis, #CALL, sizeof(CTYPE), typeName<CTYPE>::name());    \
         }                                                               \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {             \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {             \
             DAS_PROFILE_NODE \
             auto val = x->eval(context);                                \
             return cast_result(SimPolicy<CTYPE>::CALL(val,context,&debugInfo)); \
@@ -3455,7 +3455,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         virtual SimNode * visit ( SimVisitor & vis ) override {         \
             return visitOp1(vis, #CALL, sizeof(CTYPE), typeName<CTYPE>::name());    \
         }                                                               \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {             \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {             \
             DAS_PROFILE_NODE \
             auto val = arguments[0]->eval(context);                     \
             return cast_result(SimPolicy<CTYPE>::CALL(val,context,&debugInfo)); \
@@ -3560,7 +3560,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         virtual SimNode * visit ( SimVisitor & vis ) override {         \
             return visitOp2(vis, #CALL, sizeof(CTYPE), typeName<CTYPE>::name());    \
         }                                                               \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {             \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {             \
             DAS_PROFILE_NODE \
             auto lv = l->eval(context);                                 \
             auto rv = r->eval(context);                                 \
@@ -3575,7 +3575,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         virtual SimNode * visit ( SimVisitor & vis ) override {         \
             return visitOp2(vis, #CALL, sizeof(CTYPE), typeName<CTYPE>::name());    \
         }                                                               \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {             \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {             \
             DAS_PROFILE_NODE \
             auto lv = arguments[0]->eval(context);                      \
             auto rv = arguments[1]->eval(context);                      \
@@ -3590,7 +3590,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         virtual SimNode * visit ( SimVisitor & vis ) override {         \
             return visitOp2(vis, #CALL, sizeof(CTYPE), typeName<CTYPE>::name());    \
         }                                                               \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {             \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {             \
             DAS_PROFILE_NODE \
             auto lv = l->evalPtr(context);                              \
             auto rv = r->eval(context);                                 \
@@ -3727,7 +3727,7 @@ SIM_NODE_AT_VECTOR(Float, float)
         virtual SimNode * visit ( SimVisitor & vis ) override {             \
             return visitOp3(vis, #CALL, sizeof(CTYPE), typeName<CTYPE>::name());    \
         }                                                                   \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {                 \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {                 \
             DAS_PROFILE_NODE \
             auto a0 = arguments[0]->eval(context);                          \
             auto a1 = arguments[1]->eval(context);                          \

--- a/src/builtin/module_builtin_dasbind.cpp
+++ b/src/builtin/module_builtin_dasbind.cpp
@@ -165,7 +165,7 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
             });
             V_END();
         }
-        vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI vec4f eval ( Context & context ) override {
             context.result = wrapper(fnptr, context.abiArg);
             return context.result;
         }
@@ -198,7 +198,7 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
             });
             if ( !crash_and_burn.empty() ) context.throw_error_at(debugInfo, "%s",crash_and_burn.c_str());
         }
-        vec4f DAS_EVAL_ABI eval ( Context & context ) {
+        DAS_EVAL_ABI vec4f eval ( Context & context ) {
             if ( !fnptr ) bind(context);
             context.result = wrapper(fnptr, context.abiArg);
             return context.result;

--- a/src/builtin/module_builtin_math.cpp
+++ b/src/builtin/module_builtin_math.cpp
@@ -315,7 +315,7 @@ namespace das {
             V_CALL();
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             auto cmres = cmresEval->evalPtr(context);
             memset ( cmres, 0, sizeof(MatT) );
             return cast<void *>::from(cmres);

--- a/src/builtin/module_builtin_vector_ctor.cpp
+++ b/src/builtin/module_builtin_vector_ctor.cpp
@@ -28,7 +28,7 @@ namespace das
             V_SUB(arguments[0]);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_PROFILE_NODE
             vec4f argValue;
             evalArgs(context, &argValue);
@@ -46,7 +46,7 @@ namespace das
             V_SUB(arguments[1]);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_PROFILE_NODE
             vec4f argValues[2];
             evalArgs(context, argValues);
@@ -68,7 +68,7 @@ namespace das
             V_SUB(arguments[2]);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_PROFILE_NODE
             vec4f argValues[3];
             evalArgs(context, argValues);
@@ -93,7 +93,7 @@ namespace das
             V_SUB(arguments[3]);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_PROFILE_NODE
             vec4f argValues[4];
             evalArgs(context, argValues);
@@ -115,7 +115,7 @@ namespace das
             V_SUB(arguments[0]);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_PROFILE_NODE
             vec4f argValue;
             evalArgs(context, &argValue);
@@ -134,7 +134,7 @@ namespace das
             V_SUB(arguments[0]);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_PROFILE_NODE
             vec4f argValue;
             evalArgs(context, &argValue);
@@ -196,7 +196,7 @@ addFunction ( make_smart<BuiltInFn<SimNode_VecCtor<uint32_t,SimPolicy<VTYPE>,4>,
             V_SUB(arguments[0]);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_PROFILE_NODE
             vec4f i4 = arguments[0]->eval(context);
             return v_cvt_vec4f(v_cast_vec4i(i4));
@@ -211,7 +211,7 @@ addFunction ( make_smart<BuiltInFn<SimNode_VecCtor<uint32_t,SimPolicy<VTYPE>,4>,
             V_SUB(arguments[0]);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_PROFILE_NODE
             vec4f i4 = arguments[0]->eval(context);
             return v_cvtu_vec4f_ieee(v_cast_vec4i(i4));
@@ -226,7 +226,7 @@ addFunction ( make_smart<BuiltInFn<SimNode_VecCtor<uint32_t,SimPolicy<VTYPE>,4>,
             V_SUB(arguments[0]);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_PROFILE_NODE
             vec4f f4 = arguments[0]->eval(context);
             return v_cast_vec4f(v_cvt_vec4i(f4));
@@ -241,7 +241,7 @@ addFunction ( make_smart<BuiltInFn<SimNode_VecCtor<uint32_t,SimPolicy<VTYPE>,4>,
             V_SUB(arguments[0]);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_PROFILE_NODE
             vec4f f4 = arguments[0]->eval(context);
             return v_cast_vec4f(v_cvtu_vec4i_ieee(f4));
@@ -256,7 +256,7 @@ addFunction ( make_smart<BuiltInFn<SimNode_VecCtor<uint32_t,SimPolicy<VTYPE>,4>,
             V_SUB(arguments[0]);
             V_END();
         }
-        virtual vec4f DAS_EVAL_ABI eval(Context & context) override {
+        DAS_EVAL_ABI virtual vec4f eval(Context & context) override {
             DAS_PROFILE_NODE
             return arguments[0]->eval(context);
         }

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -9,7 +9,7 @@ namespace das {
     struct SimNode_CFuncCall : SimNode_ExtFuncCallBase {
         SimNode_CFuncCall ( const LineInfo & at, const char * fnName, das_interop_function * FN )
             : SimNode_ExtFuncCallBase(at,fnName) { fn = FN; }
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
             vec4f * args = (vec4f *)(alloca(nArguments * sizeof(vec4f)));
             evalArgs(context, args);

--- a/src/simulate/simulate.cpp
+++ b/src/simulate/simulate.cpp
@@ -1867,5 +1867,5 @@ namespace das
 
 //workaround compiler bug in MSVC 32 bit
 #if defined(_MSC_VER) && !defined(__clang__) && INTPTR_MAX == INT32_MAX
-vec4i VECTORCALL v_ldu_ptr(const void * a) {return v_seti_x((int32_t)a);}
+VECTORCALL vec4i v_ldu_ptr(const void * a) {return v_seti_x((int32_t)a);}
 #endif

--- a/src/simulate/simulate_fusion_at.cpp
+++ b/src/simulate/simulate_fusion_at.cpp
@@ -81,7 +81,7 @@ namespace das {
 #undef IMPLEMENT_OP2_SET_NODE_ANY
 #define IMPLEMENT_OP2_SET_NODE_ANY(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL) \
     struct SimNode_##OPNAME##_##COMPUTEL##_Any : SimNode_Op2At { \
-         virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto pl = l.compute##COMPUTEL(context); \
             auto rr = uint32_t(r.subexpr->evalInt(context)); \
@@ -93,7 +93,7 @@ namespace das {
 #undef IMPLEMENT_OP2_SET_NODE
 #define IMPLEMENT_OP2_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL,COMPUTER) \
     struct SimNode_##OPNAME##_##COMPUTEL##_##COMPUTER : SimNode_Op2At { \
-         virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto pl = l.compute##COMPUTEL(context); \
             auto rr = *((uint32_t *)r.compute##COMPUTER(context)); \

--- a/src/simulate/simulate_fusion_at_array.cpp
+++ b/src/simulate/simulate_fusion_at_array.cpp
@@ -80,7 +80,7 @@ namespace das {
 #undef IMPLEMENT_OP2_SET_NODE_ANY
 #define IMPLEMENT_OP2_SET_NODE_ANY(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL) \
     struct SimNode_##OPNAME##_##COMPUTEL##_Any : SimNode_Op2ArrayAt { \
-         virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = uint32_t(r.subexpr->evalInt(context)); \
@@ -92,7 +92,7 @@ namespace das {
 #undef IMPLEMENT_OP2_SET_NODE
 #define IMPLEMENT_OP2_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL,COMPUTER) \
     struct SimNode_##OPNAME##_##COMPUTEL##_##COMPUTER : SimNode_Op2ArrayAt { \
-         virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = *((uint32_t *)r.compute##COMPUTER(context)); \

--- a/src/simulate/simulate_fusion_call1.cpp
+++ b/src/simulate/simulate_fusion_call1.cpp
@@ -97,7 +97,7 @@ __forceinline SimNode * safeArg1 ( SimNode * node, int index ) {
             context.abiArg = aa; \
             return res; \
         } \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             return compute(context); \
         } \
         DAS_EVAL_NODE \
@@ -119,7 +119,7 @@ __forceinline SimNode * safeArg1 ( SimNode * node, int index ) {
             argValues[0] = v_ldu((const float *)subexpr.compute##COMPUTE(context)); \
             return context.call(fnPtr, argValues, &debugInfo); \
         } \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             return compute(context); \
         } \
         DAS_EVAL_NODE \

--- a/src/simulate/simulate_fusion_call2.cpp
+++ b/src/simulate/simulate_fusion_call2.cpp
@@ -74,7 +74,7 @@ namespace das {
             argValues[1] = v_ldu((const float *)r.compute##COMPUTEL(context)); \
             return context.call(fnPtr, argValues, &debugInfo); \
         } \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             return compute(context); \
         } \
         DAS_EVAL_NODE \
@@ -91,7 +91,7 @@ namespace das {
             argValues[1] = r.subexpr->eval(context); \
             return context.call(fnPtr, argValues, &debugInfo); \
         } \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             return compute(context); \
         } \
         DAS_EVAL_NODE \
@@ -108,7 +108,7 @@ namespace das {
             argValues[1] = v_ldu((const float *)r.compute##COMPUTER(context)); \
             return context.call(fnPtr, argValues, &debugInfo); \
         } \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             return compute(context); \
         } \
         DAS_EVAL_NODE \
@@ -203,7 +203,7 @@ IMPLEMENT_ANY_OP2(__forceinline, CallAndCopyOrMove, Ptr, StringPtr)
             context.abiArg = aa; \
             return res; \
         } \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             return compute(context); \
         } \
         DAS_EVAL_NODE \
@@ -225,7 +225,7 @@ IMPLEMENT_ANY_OP2(__forceinline, CallAndCopyOrMove, Ptr, StringPtr)
             context.abiArg = aa; \
             return res; \
         } \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             return compute(context); \
         } \
         DAS_EVAL_NODE \
@@ -247,7 +247,7 @@ IMPLEMENT_ANY_OP2(__forceinline, CallAndCopyOrMove, Ptr, StringPtr)
             context.abiArg = aa; \
             return res; \
         } \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             return compute(context); \
         } \
         DAS_EVAL_NODE \

--- a/src/simulate/simulate_fusion_if.cpp
+++ b/src/simulate/simulate_fusion_if.cpp
@@ -40,7 +40,7 @@ namespace das {
 #undef IMPLEMENT_ANY_OP1_NODE
 #define IMPLEMENT_ANY_OP1_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,COMPUTE) \
     struct SimNode_Op1##COMPUTE : SimNode_Op1If { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto res =  *(CTYPE *)(subexpr.compute##COMPUTE(context)); \
             if ( res == 0 ) { \
@@ -81,7 +81,7 @@ namespace das {
 #undef IMPLEMENT_ANY_OP1_NODE
 #define IMPLEMENT_ANY_OP1_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,COMPUTE) \
     struct SimNode_Op1##COMPUTE : SimNode_Op1If { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto res =  *(CTYPE *)(subexpr.compute##COMPUTE(context)); \
             if ( res ) { \
@@ -112,7 +112,7 @@ namespace das {
 #undef IMPLEMENT_ANY_OP1_NODE
 #define IMPLEMENT_ANY_OP1_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,COMPUTE) \
     struct SimNode_Op1##COMPUTE : SimNode_Op1If { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto res =  *(CTYPE *)(subexpr.compute##COMPUTE(context)); \
             if ( res == 0 ) { \
@@ -133,7 +133,7 @@ namespace das {
 #undef IMPLEMENT_ANY_OP1_NODE
 #define IMPLEMENT_ANY_OP1_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,COMPUTE) \
     struct SimNode_Op1##COMPUTE : SimNode_Op1If { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto res =  *(CTYPE *)(subexpr.compute##COMPUTE(context)); \
             if ( res ) { \

--- a/src/simulate/simulate_fusion_misc_copy.cpp
+++ b/src/simulate/simulate_fusion_misc_copy.cpp
@@ -19,7 +19,7 @@ namespace das {
     //  &a = b
     struct FusionPoint_MiscCopyReference : FusionPointOp2 {
         struct SimNode_CopyReferenceLocAny : SimNode_Op2Fusion {
-            virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override {
+            DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
                 DAS_PROFILE_NODE
                 char  ** pl = (char **)l.computeLocal(context);
                 char * pr   = r.computeAnyPtr(context);
@@ -48,7 +48,7 @@ namespace das {
 #define IMPLEMENT_OP2_COPYREF_NODE(COMPUTEL,COMPUTER) \
     template <int typeSize> \
     struct SimNode_CopyRefValueFixed_##COMPUTEL##_##COMPUTER : SimNode_Op2FusionCopyRef { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto pl = l.compute##COMPUTEL(context); \
             auto pr = r.compute##COMPUTER(context); \
@@ -57,7 +57,7 @@ namespace das {
         } \
     }; \
     struct SimNode_CopyRefValue_##COMPUTEL##_##COMPUTER : SimNode_Op2FusionCopyRef { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto pl = l.compute##COMPUTEL(context); \
             auto pr = r.compute##COMPUTER(context); \

--- a/src/simulate/simulate_fusion_op1_return.cpp
+++ b/src/simulate/simulate_fusion_op1_return.cpp
@@ -19,7 +19,7 @@ namespace das {
 #undef IMPLEMENT_ANY_OP1_NODE
 #define IMPLEMENT_ANY_OP1_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,COMPUTE) \
     struct SimNode_Op1##COMPUTE : SimNode_Op1Fusion { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto lv =  subexpr.compute##COMPUTE(context); \
             context.stopFlags |= EvalFlags::stopForReturn; \
@@ -45,7 +45,7 @@ IMPLEMENT_ANY_OP1_FUSION_POINT(__forceinline,Return,,vec4f,vec4f)
 #undef IMPLEMENT_ANY_OP1_NODE
 #define IMPLEMENT_ANY_OP1_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,COMPUTE) \
     struct SimNode_Op1##COMPUTE : SimNode_Op1Fusion { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto lv =  FUSION_OP_PTR_VALUE(CTYPE,subexpr.compute##COMPUTE(context)); \
             context.stopFlags |= EvalFlags::stopForReturn; \
@@ -64,7 +64,7 @@ IMPLEMENT_ANY_OP1_FUSION_POINT(__forceinline,Return,,vec4f,vec4f)
 #undef IMPLEMENT_ANY_OP1_NODE
 #define IMPLEMENT_ANY_OP1_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,COMPUTE) \
     struct SimNode_Op1##COMPUTE : SimNode_Op1Fusion { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto lv =  subexpr.compute##COMPUTE(context); \
             context.stopFlags |= EvalFlags::stopForReturn; \

--- a/src/simulate/simulate_fusion_op2_bin_vec.cpp
+++ b/src/simulate/simulate_fusion_op2_bin_vec.cpp
@@ -17,7 +17,7 @@
 #undef DAS_NODE
 #undef DAS_NODE
 #define DAS_NODE(TYPE,CTYPE)                                    \
-    virtual vec4f DAS_EVAL_ABI eval ( das::Context & context ) override {    \
+    DAS_EVAL_ABI virtual vec4f eval ( das::Context & context ) override {    \
         return compute(context);                                \
     }
 

--- a/src/simulate/simulate_fusion_op2_bool.cpp
+++ b/src/simulate/simulate_fusion_op2_bool.cpp
@@ -18,7 +18,7 @@
     virtual bool evalBool ( das::Context & context ) override { \
         return compute(context);                                \
     }                                                           \
-    virtual vec4f DAS_EVAL_ABI eval ( das::Context & context ) override {    \
+    DAS_EVAL_ABI virtual vec4f eval ( das::Context & context ) override {    \
         return cast<bool>::from(compute(context));              \
     }
 

--- a/src/simulate/simulate_fusion_op2_bool_vec.cpp
+++ b/src/simulate/simulate_fusion_op2_bool_vec.cpp
@@ -19,7 +19,7 @@
     virtual bool evalBool ( das::Context & context ) override { \
         return compute(context);                                \
     }                                                           \
-    virtual vec4f DAS_EVAL_ABI eval ( das::Context & context ) override {    \
+    DAS_EVAL_ABI virtual vec4f eval ( das::Context & context ) override {    \
         return cast<bool>::from(compute(context));              \
     }
 

--- a/src/simulate/simulate_fusion_op2_scalar_vec.cpp
+++ b/src/simulate/simulate_fusion_op2_scalar_vec.cpp
@@ -16,7 +16,7 @@
 // fake DAS_NODE to support regular eval
 #undef DAS_NODE
 #define DAS_NODE(TYPE,CTYPE)                                    \
-    virtual vec4f DAS_EVAL_ABI eval ( das::Context & context ) override {    \
+    DAS_EVAL_ABI virtual vec4f eval ( das::Context & context ) override {    \
         return compute(context);                                \
     }
 

--- a/src/simulate/simulate_fusion_op2_vec.cpp
+++ b/src/simulate/simulate_fusion_op2_vec.cpp
@@ -16,7 +16,7 @@
 // fake DAS_NODE to support regular eval
 #undef DAS_NODE
 #define DAS_NODE(TYPE,CTYPE)                                    \
-    virtual vec4f DAS_EVAL_ABI eval ( das::Context & context ) override {    \
+    DAS_EVAL_ABI virtual vec4f eval ( das::Context & context ) override {    \
         return compute(context);                                \
     }
 

--- a/src/simulate/simulate_fusion_ptrfdr.cpp
+++ b/src/simulate/simulate_fusion_ptrfdr.cpp
@@ -129,7 +129,7 @@ namespace das {
 #undef IMPLEMENT_ANY_OP1_NODE
 #define IMPLEMENT_ANY_OP1_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,COMPUTE) \
     struct SimNode_Op1##COMPUTE : SimNode_Op1PtrFdr { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto prv = (char **) subexpr.compute##COMPUTE(context); \
             if ( !prv || !*prv ) context.throw_error_at(debugInfo,"dereferencing null pointer"); \
@@ -147,7 +147,7 @@ namespace das {
 #undef IMPLEMENT_ANY_OP1_NODE
 #define IMPLEMENT_ANY_OP1_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,COMPUTE) \
     struct SimNode_Op1##COMPUTE : SimNode_Op1PtrFdr { \
-        virtual vec4f DAS_EVAL_ABI eval ( Context & context ) override { \
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto prv = (char **) subexpr.compute##COMPUTE(context); \
             return v_ldu((const float *) ((*prv)+offset)); \


### PR DESCRIPTION
using __vectorcall calling convention caused code generation issues of XCode fork of clang.
On macOS use [[clang::vectorcall]] attribute instead.
The clang attributes must come before the decflaration the msvc compliant __vectorcall calling convention is more flexible.
Changed the position of VECTORCALL macro in definitions in order to accept the clang attribute.