### PR TITLE
support suppressing warning for LCC compiler (__EDG__, for e2k arch)

### DIFF
--- a/include/daScript/ast/ast_visitor.h
+++ b/include/daScript/ast/ast_visitor.h
@@ -10,6 +10,8 @@ namespace das {
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable:4100)    // unreferenced formal parameter
+#elif defined(__EDG__)
+#pragma diag_suppress 826
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -276,6 +278,8 @@ namespace das {
     };
 #if defined(_MSC_VER)
 #pragma warning(pop)
+#elif defined(__EDG__)
+#pragma diag_default 826
 #elif defined(__GNUC__)
 #pragma GCC diagnostic pop
 #elif defined(__clang__)

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -1774,6 +1774,8 @@ namespace das {
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4100)
+#elif defined(__EDG__)
+#pragma diag_suppress 826
 #endif
 
     struct SimNode_AotInteropBase : SimNode_CallBase {
@@ -1787,6 +1789,8 @@ namespace das {
 
 #ifdef _MSC_VER
 #pragma warning(pop)
+#elif defined(__EDG__)
+#pragma diag_default 826
 #endif
 
     template <int argumentCount>
@@ -1895,6 +1899,8 @@ namespace das {
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4100)
+#elif defined(__EDG__)
+#pragma diag_suppress 826
 #endif
 
     template <typename resType>
@@ -1930,6 +1936,8 @@ namespace das {
 
 #ifdef _MSC_VER
 #pragma warning(pop)
+#elif defined(__EDG__)
+#pragma diag_default 826
 #endif
 
     template <typename ...argType>

--- a/include/daScript/simulate/data_walker.h
+++ b/include/daScript/simulate/data_walker.h
@@ -13,6 +13,8 @@ namespace das {
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable:4100)    // unreferenced formal parameter
+#elif defined(__EDG__)
+#pragma diag_suppress 826
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -128,6 +130,8 @@ namespace das {
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
+#elif defined(__EDG__)
+#pragma diag_default 826
 #elif defined(__GNUC__)
 #pragma GCC diagnostic pop
 #elif defined(__clang__)

--- a/include/daScript/simulate/interop.h
+++ b/include/daScript/simulate/interop.h
@@ -43,6 +43,8 @@ namespace das
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4100)
+#elif defined(__EDG__)
+#pragma diag_suppress 826,3327
 #endif
 
     template <typename R, typename ...Args, size_t... I>
@@ -185,6 +187,8 @@ namespace das
 
 #ifdef _MSC_VER
 #pragma warning(pop)
+#elif defined(__EDG__)
+#pragma diag_default 826,3327
 #endif
 
     struct SimNode_ExtFuncCallBase : SimNode_CallBase {

--- a/include/daScript/simulate/simulate_nodes.h
+++ b/include/daScript/simulate/simulate_nodes.h
@@ -269,6 +269,8 @@ namespace das {
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4100)
+#elif defined(__EDG__)
+#pragma diag_suppress 826
 #endif
 
     // New handle, default
@@ -304,6 +306,8 @@ namespace das {
 
 #ifdef _MSC_VER
 #pragma warning(pop)
+#elif defined(__EDG__)
+#pragma diag_default 826
 #endif
 
     // Delete handle, default
@@ -2370,6 +2374,8 @@ SIM_NODE_AT_VECTOR(Float, float)
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4100)
+#elif defined(__EDG__)
+#pragma diag_suppress 826
 #endif
 
     // CONST-VALUE
@@ -2498,6 +2504,8 @@ SIM_NODE_AT_VECTOR(Float, float)
     };
 #ifdef _MSC_VER
 #pragma warning(pop)
+#elif defined(__EDG__)
+#pragma diag_default 826
 #endif
 
     // COPY REFERENCE (int & a = b)

--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -3705,7 +3705,9 @@ namespace das {
             ss << "#pragma warning(disable:4269)   // 'const' automatic data initialized with compiler generated default constructor produces unreliable results\n";
             ss << "#pragma warning(disable:4555)   // result of expression not used\n";
             ss << "#endif\n";
-            ss << "#if defined(__GNUC__) && !defined(__clang__)\n";
+            ss << "#if defined(__EDG__)\n";
+            ss << "#pragma diag_suppress 826\n";
+            ss << "#elif defined(__GNUC__) && !defined(__clang__)\n";
             ss << "#pragma GCC diagnostic push\n";
             ss << "#pragma GCC diagnostic ignored \"-Wunused-parameter\"\n";
             ss << "#pragma GCC diagnostic ignored \"-Wunused-variable\"\n";
@@ -3732,7 +3734,9 @@ namespace das {
             ss << "#if defined(_MSC_VER)\n";
             ss << "#pragma warning(pop)\n";
             ss << "#endif\n";
-            ss << "#if defined(__GNUC__) && !defined(__clang__)\n";
+            ss << "#if defined(__EDG__)\n";
+            ss << "#pragma diag_default 826\n";
+            ss << "#elif defined(__GNUC__) && !defined(__clang__)\n";
             ss << "#pragma GCC diagnostic pop\n";
             ss << "#endif\n";
             ss << "#if defined(__clang__)\n";

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -116,7 +116,9 @@ bool compile ( const string & fn, const string & cppFn, bool dryRun ) {
                 tw << "#pragma warning(disable:4269)   // 'const' automatic data initialized with compiler generated default constructor produces unreliable results\n";
                 tw << "#pragma warning(disable:4555)   // result of expression not used\n";
                 tw << "#endif\n";
-                tw << "#if defined(__GNUC__) && !defined(__clang__)\n";
+                tw << "#if defined(__EDG__)\n";
+                tw << "#pragma diag_suppress 826\n";
+                tw << "#elif defined(__GNUC__) && !defined(__clang__)\n";
                 tw << "#pragma GCC diagnostic push\n";
                 tw << "#pragma GCC diagnostic ignored \"-Wunused-parameter\"\n";
                 tw << "#pragma GCC diagnostic ignored \"-Wunused-variable\"\n";
@@ -161,7 +163,9 @@ bool compile ( const string & fn, const string & cppFn, bool dryRun ) {
                 tw << "#if defined(_MSC_VER)\n";
                 tw << "#pragma warning(pop)\n";
                 tw << "#endif\n";
-                tw << "#if defined(__GNUC__) && !defined(__clang__)\n";
+                tw << "#if defined(__EDG__)\n";
+                tw << "#pragma diag_default 826\n";
+                tw << "#elif defined(__GNUC__) && !defined(__clang__)\n";
                 tw << "#pragma GCC diagnostic pop\n";
                 tw << "#endif\n";
                 tw << "#if defined(__clang__)\n";


### PR DESCRIPTION
LCC is special compiler for Elbrus2000 (e2k) CPU architecture which mimics GCC but doesn't support all pragmas, so we have to disable/restore warnings with pragmas unique to __EDG__