### PR TITLE
add functions for jit dll loading

### DIFF
--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -3253,6 +3253,11 @@ namespace das
                 }
             }
         }
+        for ( int i=0, is=context.totalFunctions; i!=is; ++i ) {
+            Function * func = indexToFunction[i];
+            SimFunction & fn = context.functions[i];
+            func->hash = getFunctionHash(func, fn.code, &context);
+        }
         for (auto pm : library.modules) {
             pm->structures.foreach([&](auto st){
                 for ( auto & ann : st->annotations ) {

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -867,6 +867,10 @@ namespace das {
         addExtern<DAS_BIND_FUN(addModuleOption)>(*this, lib,  "add_module_option",
             SideEffects::modifyExternal, "addModuleOption")
                 ->args({"module","option","type","context","at"});
+        // hash
+        addExtern<DAS_BIND_FUN(getFunctionAotHash)>(*this, lib,  "get_function_aot_hash",
+            SideEffects::none, "getFunctionAotHash")
+                ->args({"fun"});
     }
 
     ModuleAotType Module_Ast::aotRequire ( TextWriter & tw ) const {


### PR DESCRIPTION
- set hashes for functions and bind aot hash
- bind platform's dlopen and dlsym
- add extern "C" for jit_exception, this needs to be done for all das functions used in jit