### PR TITLE
Fix compilation module jit

### DIFF
--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -15,6 +15,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 namespace das {
 
@@ -261,7 +262,7 @@ extern "C" {
         if ( !context->thisProgram ) context->throw_error_at(at, "can't get ast_typeinfo, no program. is 'options rtti' missing?");
         auto ti = context->thisProgram->astTypeInfo.find(hash);
         if ( ti==context->thisProgram->astTypeInfo.end() ) {
-            context->throw_error_at(at, "can't find ast_typeinfo for hash %llx", hash);
+            context->throw_error_at(at, "can't find ast_typeinfo for hash %" PRIx64, hash);
         }
         auto info = ti->second;
         info->addRef();


### PR DESCRIPTION
Replace hardcoded llx with PRIx64

why: uint64_t not always a unsigned long long