### PR TITLE
Inherited 'operator dot' is not callable when declared in separate file

### DIFF
--- a/tests/language/operators.das
+++ b/tests/language/operators.das
@@ -2,6 +2,8 @@ require dastest/testing_boost public
 
 require daslib/strings_boost
 
+require operators_derived
+
 struct Foo
     a : int
 
@@ -83,4 +85,7 @@ def test_operators ( t : T? )
         t |> equal("hard no",HARD_NO)
         t |> equal(5,T.length)
         t |> equal(6,T?.length)
+
+        var bar : BarOp? <- new [[BarOp() a=42]]
+        t |> equal(42, bar.Prop)
 

--- a/tests/language/operators_derived.das
+++ b/tests/language/operators_derived.das
@@ -1,0 +1,7 @@
+module operators_derived public
+
+require operators_parent
+
+class BarOp : FooOp
+    def BarOp()
+        pass

--- a/tests/language/operators_parent.das
+++ b/tests/language/operators_parent.das
@@ -1,0 +1,7 @@
+module operators_parent public
+
+class FooOp
+    a : int = 42
+
+    def operator . Prop : int
+        return a


### PR DESCRIPTION
Hi!

I run upon a case where you are not able to call inherited `operator .` function because of `field not found in (30503)`.
I have added test case for the issue in this PR.

The case seems to be like this:

File_A: declare base `class (A)` with `operator .`
File_B: declare derived `class B` from `class A`
File_C: `require File_B`, declare variable of type `class B` and call  `operator .` (it should be there because `class B` is derived from `class A`)

It is fixable by requiring `File_A` in `File_C` (along with `File_B`) but I suppose it is not how it was intended to work.
