### PR TITLE
improve error messages when block is not fully inferred

### DIFF
--- a/include/daScript/ast/ast_generate.h
+++ b/include/daScript/ast/ast_generate.h
@@ -11,8 +11,8 @@ namespace das {
     // ExprConstPtr, where value is nullptr
     bool isExpressionNull(const ExpressionPtr & expr);
 
-    // check if block is inferred enough to be promoted to lambda\local_function
-    bool isFullyInferredBlock ( ExprBlock * block );
+    // check if block is inferred enough to be promoted to lambda\local_function, return uninferred value or nullptr
+    TypeDecl *isFullyInferredBlock ( ExprBlock * block );
 
     // make sure generated code contains line information etc
     void verifyGenerated ( const ExpressionPtr & expr );

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -229,12 +229,12 @@ namespace das {
         if (this == &castS) {
             return true;
         }
-        auto *parent = castS.parent;
-        while ( parent ) {
-            if ( parent == this ) {
+        auto *parentS = castS.parent;
+        while ( parentS ) {
+            if ( parentS == this ) {
                 return true;
             }
-            parent = parent->parent;
+            parentS = parentS->parent;
         }
         return false;
     }
@@ -1575,28 +1575,30 @@ namespace das {
 
     ExpressionPtr ExprBlock::visit(Visitor & vis) {
         vis.preVisit(this);
-        for ( auto it = arguments.begin(); it != arguments.end(); ) {
-            auto & arg = *it;
-            vis.preVisitBlockArgument(this, arg, arg==arguments.back());
-            if ( arg->type ) {
-                vis.preVisit(arg->type.get());
-                arg->type = arg->type->visit(vis);
-                arg->type = vis.visit(arg->type.get());
-            }
-            if ( arg->init ) {
-                vis.preVisitBlockArgumentInit(this, arg, arg->init.get());
-                arg->init = arg->init->visit(vis);
-                if ( arg->init ) {
-                    arg->init = vis.visitBlockArgumentInit(this, arg, arg->init.get());
-                }
-            }
-            arg = vis.visitBlockArgument(this, arg, arg==arguments.back());
-            if ( arg ) ++it; else it = arguments.erase(it);
-        }
-        if ( returnType ) {
-            vis.preVisit(returnType.get());
-            returnType = returnType->visit(vis);
-            returnType = vis.visit(returnType.get());
+        if ( isClosure ) {
+          for ( auto it = arguments.begin(); it != arguments.end(); ) {
+              auto & arg = *it;
+              vis.preVisitBlockArgument(this, arg, arg==arguments.back());
+              if ( arg->type ) {
+                  vis.preVisit(arg->type.get());
+                  arg->type = arg->type->visit(vis);
+                  arg->type = vis.visit(arg->type.get());
+              }
+              if ( arg->init ) {
+                  vis.preVisitBlockArgumentInit(this, arg, arg->init.get());
+                  arg->init = arg->init->visit(vis);
+                  if ( arg->init ) {
+                      arg->init = vis.visitBlockArgumentInit(this, arg, arg->init.get());
+                  }
+              }
+              arg = vis.visitBlockArgument(this, arg, arg==arguments.back());
+              if ( arg ) ++it; else it = arguments.erase(it);
+          }
+          if ( returnType ) {
+              vis.preVisit(returnType.get());
+              returnType = returnType->visit(vis);
+              returnType = vis.visit(returnType.get());
+          }
         }
         if ( finallyBeforeBody ) {
             visitFinally(vis);

--- a/src/ast/ast_generate.cpp
+++ b/src/ast/ast_generate.cpp
@@ -95,18 +95,18 @@ namespace das {
     }
 
     struct CheckFullyInferred : Visitor {
-        bool fullyInferred = true;
+        TypeDecl * unInferredType = nullptr;
         virtual void preVisit ( TypeDecl * td ) {
-            if ( td->isAutoOrAlias() ) {
-                fullyInferred = false;
+            if ( !unInferredType && td->isAutoOrAlias() ) {
+                unInferredType = td;
             }
         }
     };
 
-    bool isFullyInferredBlock ( ExprBlock * block ) {
+    TypeDecl *isFullyInferredBlock ( ExprBlock * block ) {
         CheckFullyInferred vis;
         block->visit(vis);
-        return vis.fullyInferred;
+        return vis.unInferredType;
     }
 
     // array comprehension

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -2776,25 +2776,29 @@ namespace das {
                 // TODO: verify
                 // if ( isFullySealedType(expr->type) ) {
                 if ( !expr->type->isAutoOrAlias() ) {
-                    if ( isFullyInferredBlock(block.get()) ) {
+                    if ( auto unInferred = isFullyInferredBlock(block.get()) ) {
+                        TextWriter tt;
+                        tt << unInferred->at.describe() << ": " << unInferred->describe() << " is not fully inferred yet";
+                        error("block is not fully inferred yet", tt.str(), "",
+                            expr->at, CompilationError::invalid_block);
+                    } else {
                         if ( auto btl = convertBlockToLambda(expr) ) {
                             return btl;
                         }
-                    } else {
-                        error("block is not fully inferred yet",  "", "",
-                            expr->at, CompilationError::invalid_block);
                     }
                 }
             } else if ( expr->isLocalFunction ) {
                 expr->type->baseType = Type::tFunction;
                 if ( !expr->type->isAutoOrAlias() ) {
-                    if ( isFullyInferredBlock(block.get()) ) {
+                    if ( auto unInferred = isFullyInferredBlock(block.get()) ) {
+                        TextWriter tt;
+                        tt << unInferred->at.describe() << ": " << unInferred->describe() << " is not fully inferred yet";
+                        error("block is not fully inferred yet", tt.str(), "",
+                            expr->at, CompilationError::invalid_block);
+                    } else {
                         if ( auto btl = convertBlockToLocalFunction(expr) ) {
                             return btl;
                         }
-                    } else {
-                        error("block is not fully inferred yet",  "", "",
-                            expr->at, CompilationError::invalid_block);
                     }
                 }
             }


### PR DESCRIPTION
walk block arguments and return type only for closures