### PR TITLE
Update sim_policy.h

### DIFF
--- a/include/daScript/simulate/sim_policy.h
+++ b/include/daScript/simulate/sim_policy.h
@@ -768,8 +768,10 @@ namespace  das {
     struct SimPolicy;
 
     template <> struct SimPolicy<bool> : SimPolicy_Bool {};
+#if DAS_FAST_INTEGER_MOD
     template <> struct SimPolicy<int32_t> : SimPolicy_Int {};
     template <> struct SimPolicy<uint32_t> : SimPolicy_UInt {};
+#endif
     template <> struct SimPolicy<int64_t> : SimPolicy_Int64 {};
     template <> struct SimPolicy<uint64_t> : SimPolicy_UInt64 {};
     template <> struct SimPolicy<float> : SimPolicy_Float, SimPolicy_MathFloat {};


### PR DESCRIPTION
Fix compile error if DAS_FAST_INTEGER_MOD = 0

Related to: https://github.com/GaijinEntertainment/daScript/commit/54647b3e7901d574f2db30f325a0b69191ad2ad6