### PR TITLE
allow building for arm64 for windows platform (vc2019, vc2022 and clang)

### DIFF
--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -166,11 +166,17 @@
         return uint64_t(r);
     }
     __forceinline uint32_t das_popcount(uint32_t x) {
+    #if defined(_M_ARM64)
+        return vaddlv_u8(vcnt_u8(vdup_n_u64(x)));
+    #else
         return uint32_t(__popcnt(x));
+    #endif
     }
     __forceinline uint64_t das_popcount64(uint64_t x) {
     #if defined(__i386__) || defined(_M_IX86)
         return uint64_t(__popcnt(uint32_t(x)) + __popcnt(uint32_t(x >> 32)));
+    #elif defined(_M_ARM64)
+        return vaddlv_u8(vcnt_u8(vdup_n_u64(x)));
     #else
         return uint64_t(__popcnt64(x));
     #endif

--- a/src/misc/sysos.cpp
+++ b/src/misc/sysos.cpp
@@ -17,6 +17,7 @@
             dw = (dw & ~(mask << lowBit)) | (DWORD(newValue) << lowBit);
         }
 
+#if !defined(_M_ARM64)
         bool g_isVHSet = false;
         void ( * g_HwBpHandler ) ( int, void * ) = nullptr;
 
@@ -77,6 +78,11 @@
             if (!SetThreadContext(thisThread, &cxt)) return false;
             return true;
         }
+#else
+        void hwSetBreakpointHandler(void (*) (int, void *)) {}
+        int hwBreakpointSet(void *, int, int) { return -1; }
+        bool hwBreakpointClear(int) { return false; }
+#endif
 
         size_t getExecutablePathName(char* pathName, size_t pathNameCapacity) {
             return GetModuleFileNameA(NULL, pathName, (DWORD)pathNameCapacity);


### PR DESCRIPTION
To build for Windows-on-ARM64 with VC that doesn't have some X64-related intrinsics and X64 registers