### PR TITLE
verify that module names are unique

### DIFF
--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -638,7 +638,6 @@ namespace das {
 
     bool verifyModuleNamesUnique ( const vector<ModuleInfo> & req, TextWriter & logs ) {
         das_hash_map<string, string> fullName;
-        auto program = make_smart<Program>();
         for ( auto & r : req ) {
             if ( fullName.find(r.moduleName) != fullName.end() ) {
                 logs << "several modules with the name " << r.moduleName << "\n" <<


### PR DESCRIPTION
In big projects there might be multiple files with the same module name. Currently we just silently ignore the second file.