### PR TITLE
Add canBeRequired method to ModuleFileAccess

### DIFF
--- a/include/daScript/simulate/debug_info.h
+++ b/include/daScript/simulate/debug_info.h
@@ -149,6 +149,7 @@ namespace das
         virtual ModuleInfo getModuleInfo ( const string & req, const string & from ) const;
         virtual bool isModuleAllowed ( const string &, const string & ) const { return true; };
         virtual bool canModuleBeUnsafe ( const string &, const string & ) const { return true; };
+        virtual bool canBeRequired ( const string &, const string & ) const { return true; };
         virtual bool addFsRoot ( const string & , const string & ) { return false; }
         virtual void serialize ( AstSerializer & ser );
     protected:
@@ -172,6 +173,7 @@ namespace das
         virtual string getIncludeFileName ( const string & fileName, const string & incFileName ) const override;
         virtual bool isModuleAllowed ( const string &, const string & ) const override;
         virtual bool canModuleBeUnsafe ( const string &, const string & ) const override;
+        virtual bool canBeRequired ( const string &, const string & ) const override;
         virtual void serialize ( AstSerializer & ser ) override;
     protected:
         Context *           context = nullptr;
@@ -179,6 +181,7 @@ namespace das
         SimFunction *       includeGet = nullptr;
         SimFunction *       moduleAllowed = nullptr;
         SimFunction *       moduleUnsafe = nullptr;
+        SimFunction *       canModuleBeRequired = nullptr;
     };
     template <> struct isCloneable<ModuleFileAccess> : false_type {};
 

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -194,6 +194,13 @@ namespace das {
                 if ( log ) {
                     *log << string(tab,'\t') << "require " << mod << "\n";
                 }
+                if ( !access->canBeRequired(mod, fileName) )
+                {
+                    if ( log ) {
+                        *log << string(tab,'\t') << "from " << fileName << " require " << mod << " - CAN'T BE REQUIRED\n";
+                    }
+                    return false;
+                }
                 auto module = Module::requireEx(mod, allowPromoted); // try native with that name
                 if ( !module ) {
                     auto info = access->getModuleInfo(mod, fileName);

--- a/src/builtin/module_file_access.cpp
+++ b/src/builtin/module_file_access.cpp
@@ -42,6 +42,7 @@ namespace das {
                 includeGet = context->findFunction("include_get");          // note, this one CAN be null
                 moduleAllowed = context->findFunction("module_allowed");    // note, this one CAN be null
                 moduleUnsafe = context->findFunction("module_allowed_unsafe");    // note, this one CAN be null
+                canModuleBeRequired = context->findFunction("can_module_be_required");    // note, this one CAN be null
                 // get it ready
                 context->restart();
                 context->runInitScript();   // note: we assume sane init stack size here
@@ -87,6 +88,17 @@ namespace das {
         auto res = context->evalWithCatch(moduleUnsafe, args, nullptr);
         auto exc = context->getException(); exc;
         DAS_ASSERTF(!exc, "exception failed in `module_unsafe`: %s", exc);
+        return cast<bool>::to(res);
+    }
+
+    bool ModuleFileAccess::canBeRequired ( const string & mod, const string & fileName ) const {
+        if(failed() || !canModuleBeRequired) return FileAccess::canBeRequired(mod,fileName);
+        vec4f args[2];
+        args[0] = cast<const char *>::from(mod.c_str());
+        args[1] = cast<const char *>::from(fileName.c_str());
+        auto res = context->evalWithCatch(canModuleBeRequired, args, nullptr);
+        auto exc = context->getException(); exc;
+        DAS_ASSERTF(!exc, "exception failed in `can_module_be_required`: %s", exc);
         return cast<bool>::to(res);
     }
 


### PR DESCRIPTION
comparing to isModuleAllowed this function calls before resolving the native/shared modules