### PR TITLE
compute cumulative hash for native builtin modules

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1131,6 +1131,7 @@ namespace das
         CommentReaderPtr                            commentReader;      // /* blah */ or // blah
         vector<pair<string,bool>>                   keywords;           // keywords (and if they need oxford comma)
         das_hash_map<string,Type>                   options;            // options
+        uint64_t                                    cumulativeHash = 0; // hash of all mangled names in this module (for builtin modules)
         string  name;
         union {
             struct {

--- a/src/ast/ast_module.cpp
+++ b/src/ast/ast_module.cpp
@@ -420,6 +420,9 @@ namespace das {
         if ( fn->builtIn && fn->sideEffectFlags==uint32_t(SideEffects::none) && fn->result->isVoid() ) {
             DAS_FATAL_ERROR("can't add function %s to module %s; it has no side effects and no return type\n", mangledName.c_str(), name.c_str() );
         }
+        if ( fn->builtIn ) {
+            cumulativeHash = wyhash(mangledName.c_str(), mangledName.size(), cumulativeHash);
+        }
         if ( fn->builtIn && fn->sideEffectFlags==uint32_t(SideEffects::modifyArgument)  ) {
             bool anyRW = false;
             for ( const auto & arg : fn->arguments ) {

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2047,6 +2047,7 @@ namespace das {
                 *this << m->name;
 
                 if ( m->builtIn && !m->promoted ) {
+                    *this << m->cumulativeHash;
                     continue;
                 }
 
@@ -2069,6 +2070,16 @@ namespace das {
 
                 if ( builtin && !promoted ) {
                     auto m = Module::require(name);
+                    uint64_t savedHash = 0, moduleHash = m->cumulativeHash;
+                    *this << savedHash;
+
+                    if ( moduleHash != savedHash ) {
+                        LOG(LogLevel::warning) << "das: ser: cumulative hash for module " << m->name
+                                               << " differs" << " ( " << moduleHash << " vs " << savedHash << " ) ";
+                        program->failToCompile = true;
+                        return;
+                    }
+
                     program->library.addModule(m);
                     continue;
                 }
@@ -2094,7 +2105,7 @@ namespace das {
     }
 
     uint32_t AstSerializer::getVersion () {
-        static constexpr uint32_t currentVersion = 14;
+        static constexpr uint32_t currentVersion = 15;
         return currentVersion;
     }
 


### PR DESCRIPTION
This allows us to check for changes in bindings in builtin modules