### PR TITLE
Fix lower_bound algorithm

### DIFF
--- a/daslib/algorithm.das
+++ b/daslib/algorithm.das
@@ -139,7 +139,7 @@ def lower_bound ( a; f, l : int; val:auto(TT); less : block<(a, b:TT const-&):bo
         return -1
     else
         unsafe
-            return lower_bound(temp_array(a), f, l, value, less)
+            return lower_bound(temp_array(a), f, l, val, less)
 
 [expect_any_array(a)]
 def lower_bound ( a; val:auto(TT); less : block<(a, b:TT const-&):bool> )

--- a/examples/test/misc/any_alg.das
+++ b/examples/test/misc/any_alg.das
@@ -13,3 +13,5 @@ def main
 
     print("lba(5)={lba} lbb(5)={lbb}\n")
 
+    let lba2 = lower_bound ( b, 5 ) <| $(x, y: int) { return x < y; }
+    print("lba2(5)={lba2}\n")


### PR DESCRIPTION
Fix an error:
```
Compilation error: daScript/daslib/algorithm.das:142:52:
            return lower_bound(temp_array(a), f, l, value, less)
                                                    ^^^^^
142:52 - 142:57
30305: can't locate variable value
```