### PR TITLE
Fix: format not a constant expression

### DIFF
--- a/include/daScript/misc/string_writer.h
+++ b/include/daScript/misc/string_writer.h
@@ -99,7 +99,7 @@ namespace das {
         template <typename TT>
         StringWriter & format(const char * format, TT value) {
             char buf[128];
-            auto tail = fmt::format_to(buf, format, value);
+            auto tail = fmt::format_to(buf, fmt::runtime(format), value);
             auto realL = tail - buf;
             if ( auto at = this->allocate(int(realL)) ) {
                 memcpy(at, buf, realL);

--- a/include/daScript/simulate/aot_builtin_string.h
+++ b/include/daScript/simulate/aot_builtin_string.h
@@ -108,7 +108,7 @@ namespace das {
         }
         *head++ = '}'; *head = 0;
         try {
-            auto result = fmt::format_to(buf, ffmt, value);
+            auto result = fmt::format_to(buf, fmt::runtime(ffmt), value);
             *result= 0;
             return context->allocateString(buf, uint32_t(result-buf), at);
         } catch (const std::exception & e) {
@@ -136,7 +136,7 @@ namespace das {
         }
         *head++ = '}'; *head = 0;
         try {
-            auto result = fmt::format_to(buf, ffmt, value);
+            auto result = fmt::format_to(buf, fmt::runtime(ffmt), value);
             *result = 0;
             writer.writeStr(buf, result - buf);
         } catch ( const std::exception & e ) {


### PR DESCRIPTION
We should use fmt::runtime for non constant string or we will get a compile error if the string cannot be evaluated in constexpr

I use fmt::runtime in StringWriter::format, due it public and can be used anywhere in user code. But that possible to make it consteval by using fmt::format_string as argument instead of char*

Example: https://godbolt.org/z/zjTefj5eM