### PR TITLE
"require operators_parent public" is important (vs "require operators…

### DIFF
--- a/tests/language/_operators_derived.das
+++ b/tests/language/_operators_derived.das
@@ -1,0 +1,7 @@
+module _operators_derived public
+
+require _operators_parent public    // public is very important here, to make sure stuff in _operators_parent is visible here
+
+class BarOp : FooOp
+    def BarOp()
+        pass

--- a/tests/language/_operators_parent.das
+++ b/tests/language/_operators_parent.das
@@ -1,4 +1,4 @@
-module operators_parent public
+module _operators_parent public
 
 class FooOp
     a : int = 42

--- a/tests/language/operators.das
+++ b/tests/language/operators.das
@@ -2,7 +2,7 @@ require dastest/testing_boost public
 
 require daslib/strings_boost
 
-require operators_derived
+require _operators_derived
 
 struct Foo
     a : int

--- a/tests/language/operators_derived.das
+++ b/tests/language/operators_derived.das
@@ -1,7 +1,0 @@
-module operators_derived public
-
-require operators_parent
-
-class BarOp : FooOp
-    def BarOp()
-        pass


### PR DESCRIPTION
…_parent"). it makes stuff in operators_parent visibile