### PR TITLE
Add split_by_chars_with_quotes function to ignore part of string for …

### DIFF
--- a/daslib/strings_boost.das
+++ b/daslib/strings_boost.das
@@ -72,6 +72,15 @@ def split_by_chars ( text, delim : string implicit ) : array<string>
         res := arr
     return <- res
 
+def split_by_chars_with_quotes ( text, delim, quotes : string implicit; blk : block< (arg:array<string>#) > )
+    builtin_string_split_by_char_with_quotes ( text, delim, quotes, blk )
+
+def split_by_chars_with_quotes ( text, delim, quotes: string implicit ) : array<string>
+    var res : array<string>
+    builtin_string_split_by_char_with_quotes (text, delim, quotes) <| $ ( arr : array<string># ) : void
+        res := arr
+    return <- res
+
 [generic]
 def is_character_at(foo:array<uint8> implicit; idx:int; ch:int)
     return int(foo[idx])==ch

--- a/include/daScript/simulate/aot_builtin_string.h
+++ b/include/daScript/simulate/aot_builtin_string.h
@@ -80,6 +80,7 @@ namespace das {
     StringBuilderWriter & write_string_chars(StringBuilderWriter & writer, int32_t ch, int32_t count);
     StringBuilderWriter & write_escape_string ( StringBuilderWriter & writer, char * str );
     void builtin_string_split_by_char ( const char * str, const char * delim, const Block & sblk, Context * context, LineInfoArg * lineinfo );
+    void builtin_string_split_by_char_with_quotes ( const char * str, const char * delim, const char * quotes, const Block & sblk, Context * context, LineInfoArg * lineinfo );
     void builtin_string_split ( const char * str, const char * delim, const Block & sblk, Context * context, LineInfoArg * lineinfo );
     char * builtin_string_from_array ( const TArray<uint8_t> & bytes, Context * context, LineInfoArg * at );
     char * builtin_string_replace ( const char * str, const char * toSearch, const char * replaceStr, Context * context, LineInfoArg * at );


### PR DESCRIPTION
…splitting

split_by_chars version which stops splitting if we are inside
some other specified delimiter.

Useful when we want to split a string like
`some.cmd "param with space" 123`
into
[[ some.cmd; "param with space"; 123]]

for example above call looks like `input |> split_by_chars_with_quotes(" ", "\"")`