### PR TITLE
a.PROPERTY = value now promotes to a.PROPERTY := value automatically

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -641,6 +641,8 @@ namespace das
         virtual bool rtti_isAscend() const { return false; }
         virtual bool rtti_isTypeDecl() const { return false; }
         virtual bool rtti_isNullPtr() const { return false; }
+        virtual bool rtti_isCopy() const { return false; }
+        virtual bool rtti_isClone() const { return false; }
         virtual Expression * tail() { return this; }
         virtual bool swap_tail ( Expression *, Expression * ) { return false; }
         virtual uint32_t getEvalFlags() const { return 0; }

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1404,6 +1404,7 @@ namespace das
         bool report_invisible_functions = true;         // report invisible functions (report functions not visible from current module)
         bool report_private_functions = true;           // report private functions (report functions which are not accessible due to private module)
         bool no_unsafe_uninitialized_structures = true; // if true, then unsafe uninitialized structures are not allowed
+        bool strict_properties = false;                 // if true, then properties are strict, i.e. a.prop = b does not get promoted to a.prop := b
     // environment
         bool no_optimizations = false;                  // disable optimizations, regardless of settings
         bool fail_on_no_aot = true;                     // AOT link failure is error

--- a/include/daScript/ast/ast_expressions.h
+++ b/include/daScript/ast/ast_expressions.h
@@ -214,6 +214,8 @@ namespace das
                                                             // is a workaround of a compiler bug in 32-bit MVSC 2015
     };
 
+    struct ExprOp2;
+
     struct ExprVar : Expression {
         ExprVar () { __rtti = "ExprVar"; };
         ExprVar ( const LineInfo & a, const string & n )
@@ -228,7 +230,7 @@ namespace das
         string              name;
         VariablePtr         variable;
         ExprBlock *         pBlock = nullptr;
-        ExprClone *         underClone = nullptr;
+        ExprOp2 *           underClone = nullptr;
         int                 argumentIndex = -1;
         union {
             struct {
@@ -279,7 +281,7 @@ namespace das
         const Structure::FieldDeclaration * field = nullptr;
         int             fieldIndex = -1;
         TypeAnnotationPtr annotation;
-        ExprClone *     underClone = nullptr;
+        ExprOp2 *       underClone = nullptr;
         union {
             struct {
                 bool        unsafeDeref : 1;
@@ -462,10 +464,12 @@ namespace das
         virtual SimNode * simulate (Context & context) const override;
         virtual ExpressionPtr visit(Visitor & vis) override;
         virtual void serialize( AstSerializer & ser ) override;
+        virtual bool rtti_isCopy() const override { return true; }
         union {
             struct {
                 bool allowCopyTemp : 1;
                 bool takeOverRightStack : 1;
+                bool promoteToClone : 1;
             };
             uint32_t copyFlags = 0;
         };
@@ -498,6 +502,7 @@ namespace das
         virtual SimNode * simulate (Context & context) const override;
         virtual ExpressionPtr visit(Visitor & vis) override;
         virtual void serialize( AstSerializer & ser ) override;
+        virtual bool rtti_isClone() const override { return true; }
         ExpressionPtr cloneSet;
     };
 

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -55,6 +55,7 @@ namespace das {
             reportInvisibleFunctions = prog->options.getBoolOption("report_invisible_functions", prog->policies.report_invisible_functions);
             reportPrivateFunctions = prog->options.getBoolOption("report_private_functions", prog->policies.report_private_functions);
             noUnsafeUninitializedStructs = prog->options.getBoolOption("no_unsafe_uninitialized_structures", prog->policies.no_unsafe_uninitialized_structures);
+            strictProperties = prog->options.getBoolOption("strict_properties", prog->policies.strict_properties);
         }
         bool finished() const { return !needRestart; }
         bool verbose = true;
@@ -92,6 +93,7 @@ namespace das {
         bool                    reportInvisibleFunctions = false;
         bool                    reportPrivateFunctions = false;
         bool                    noUnsafeUninitializedStructs = false;
+        bool                    strictProperties = false;
     public:
         vector<FunctionPtr>     extraFunctions;
         das_hash_map<Function *,uint64_t> refreshFunctions;
@@ -5824,12 +5826,14 @@ namespace das {
         }
         void preVisit ( ExprCopy * expr ) override {
             Visitor::preVisit(expr);
-            if ( expr->left->rtti_isField() ) {
-                auto field = static_pointer_cast<ExprField>(expr->left);
-                field->underClone = expr;
-            } else if ( expr->left->rtti_isVar() ) {
-                auto var = static_pointer_cast<ExprVar>(expr->left);
-                var->underClone = expr;
+            if ( !strictProperties ) {
+                if ( expr->left->rtti_isField() ) {
+                    auto field = static_pointer_cast<ExprField>(expr->left);
+                    field->underClone = expr;
+                } else if ( expr->left->rtti_isVar() ) {
+                    auto var = static_pointer_cast<ExprVar>(expr->left);
+                    var->underClone = expr;
+                }
             }
             markNoDiscard(expr->right.get());
         }

--- a/src/ast/ast_lint.cpp
+++ b/src/ast/ast_lint.cpp
@@ -771,6 +771,7 @@ namespace das {
         "no_local_class_members",       Type::tBool,
         "report_invisible_functions",   Type::tBool,
         "report_private_functions",     Type::tBool,
+        "strict_properties",            Type::tBool,
     // memory
         "stack",                        Type::tInt,
         "intern_strings",               Type::tBool,

--- a/src/builtin/module_builtin_ast_flags.cpp
+++ b/src/builtin/module_builtin_ast_flags.cpp
@@ -234,7 +234,7 @@ namespace das {
     TypeDeclPtr makeExprCopyFlags() {
         auto ft = make_smart<TypeDecl>(Type::tBitfield);
         ft->alias = "CopyFlags";
-        ft->argNames = { "allowCopyTemp", "takeOverRightStack" };
+        ft->argNames = { "allowCopyTemp", "takeOverRightStack", "promoteToClone" };
         return ft;
     }
 

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2166,7 +2166,7 @@ namespace das {
     }
 
     uint32_t AstSerializer::getVersion () {
-        static constexpr uint32_t currentVersion = 29;
+        static constexpr uint32_t currentVersion = 30;
         return currentVersion;
     }
 

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -735,6 +735,7 @@ namespace das {
             addField<DAS_BIND_MANAGED_FIELD(no_local_class_members)>("no_local_class_members");
             addField<DAS_BIND_MANAGED_FIELD(report_invisible_functions)>("report_invisible_functions");
             addField<DAS_BIND_MANAGED_FIELD(report_private_functions)>("report_private_functions");
+            addField<DAS_BIND_MANAGED_FIELD(strict_properties)>("strict_properties");
         // environment
             addField<DAS_BIND_MANAGED_FIELD(no_optimizations)>("no_optimizations");
             addField<DAS_BIND_MANAGED_FIELD(fail_on_no_aot)>("fail_on_no_aot");


### PR DESCRIPTION
```
struct Box
    min, max : float2

def operator . size ( var self:Box )
    return self.max - self.min

def operator . center := ( var self:Box; at:float2 )
    var size = self.size
    self.min = at - size * 0.5
    self.max = at + size * 0.5

[export]
def main
    var box = [[Box min=float2(-1,-1), max=float2(1,1)]]
    box.center = float2(2,2) // note: NOT A CLONE
    print("box = {box}\n")
```

assumming "options strict_properties" or policy is not set