### PR TITLE
Fix AOT for structures with special chars in names

### DIFF
--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -1063,9 +1063,9 @@ namespace das {
         virtual StructurePtr visit ( Structure * that ) override {
             ss << "};\n";   // structure
             if ( that->fields.size() ) {
-                ss << "static_assert(sizeof(" << that->name << ")==" << that->getSizeOf() << ",\"structure size mismatch with DAS\");\n";
+                ss << "static_assert(sizeof(" << aotStructName(that) << ")==" << that->getSizeOf() << ",\"structure size mismatch with DAS\");\n";
                 for ( auto & tf : that->fields ) {
-                    ss << "static_assert(offsetof(" << that->name << "," << tf.name << ")=="
+                    ss << "static_assert(offsetof(" << aotStructName(that) << "," << tf.name << ")=="
                         << tf.offset << ",\"structure field offset mismatch with DAS\");\n";
                 }
             }


### PR DESCRIPTION
When generating size/offset static_asserts for AOT, the raw das name of structs which can contain stuff like grave and tildae. Instead, we have to use aotStructureName to get the mangled name with no special characters.