### PR TITLE
Fix block invoke AOT codegen not compiling sometimes

### DIFF
--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -2125,8 +2125,8 @@ namespace das {
                 return result;
             }
         }
-        template <typename BLK, typename ...ArgType>
-        static __forceinline ResType invoke_cmres ( Context *, LineInfo *, const BLK & blk, ArgType ...arg ) {
+        template <typename ...ArgType, typename BLK>
+        static __forceinline enable_if_t<is_invocable_v<BLK, ArgType...>, ResType> invoke_cmres ( Context *, LineInfo *, const BLK & blk, ArgType ...arg ) {
             return blk(das::forward<ArgType>(arg)...);
         }
     };
@@ -2173,8 +2173,8 @@ namespace das {
                 __context__->invoke(blk, arguments, nullptr, __lineinfo__);
             }
         }
-        template <typename BLK, typename ...ArgType>
-        static __forceinline void invoke ( Context *, LineInfo *, const BLK & blk, ArgType ...arg ) {
+        template <typename ...ArgType, typename BLK>
+        static __forceinline enable_if_t<is_invocable_v<BLK, ArgType...>, void> invoke ( Context *, LineInfo *, const BLK & blk, ArgType ...arg ) {
             return blk(das::forward<ArgType>(arg)...);
         }
     };


### PR DESCRIPTION
One of the possible forms of invoking a block from AOT codegen code is das_invoke<ResType>::invoke<ArgTypes...> (or same with invoke_cmres). What we actually pass to this function can be different depending on the context: an actual Block object, OR a **C++ lambda**.

When passing a lambda, we have no choice but to use template argument deduction. But that was completely broken, as the lambda type BLK was specified as the first template argument for invoke/invoke_cmres and so AOT codegen tried to specify the lambda type as some argument type instead.

Moving the BLK template parameter to be the last one seems to fix the problem. BUT! It brings a new problem, now the templated overload becomes preferable over regular overloads when upcasting the block to a parent type.

To fight the new issue, a cheeky enable_if was employed.