### PR TITLE
disable fastcall with option or COP

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1411,6 +1411,7 @@ namespace das
         bool fail_on_lack_of_aot_export = false;        // remove_unused_symbols = false is missing in the module, which is passed to AOT
         bool log_compile_time = false;                  // if true, then compile time will be printed at the end of the compilation
         bool log_total_compile_time = false;            // if true, then detailed compile time will be printed at the end of the compilation
+        bool no_fast_call = false;                      // disable fastcall
     // debugger
         //  when enabled
         //      1. disables [fastcall]

--- a/src/ast/ast_allocate_stack.cpp
+++ b/src/ast/ast_allocate_stack.cpp
@@ -82,6 +82,7 @@ namespace das {
             log = prog->options.getBoolOption("log_stack");
             log_var_scope = prog->options.getBoolOption("log_var_scope");
             optimize = prog->getOptimize();
+            noFastCall = prog->options.getBoolOption("no_fast_call", prog->policies.no_fast_call);
             if( log ) {
                 logs << "\nSTACK INFORMATION in " << prog->thisModule->name << ":\n";
             }
@@ -98,6 +99,7 @@ namespace das {
         bool                    optimize = false;
         TextWriter &            logs;
         bool                    inStruct = false;
+        bool                    noFastCall = false;
     protected:
         uint32_t allocateStack ( uint32_t size ) {
             auto result = stackTop;
@@ -164,7 +166,7 @@ namespace das {
             func->totalStackSize = das::max(func->totalStackSize, stackTop);
             // detecting fastcall
             func->fastCall = false;
-            if ( !program->getDebugger() && !program->getProfiler() ) {
+            if ( !program->getDebugger() && !program->getProfiler() && !noFastCall ) {
                 if ( !func->exports && !func->addr && func->totalStackSize==sizeof(Prologue) && func->arguments.size()<=32 ) {
                     if (func->body->rtti_isBlock()) {
                         auto block = static_pointer_cast<ExprBlock>(func->body);

--- a/src/ast/ast_lint.cpp
+++ b/src/ast/ast_lint.cpp
@@ -819,6 +819,7 @@ namespace das {
         "optimize",                     Type::tBool,
         "fusion",                       Type::tBool,
         "remove_unused_symbols",        Type::tBool,
+        "no_fast_call",                 Type::tBool,
     // language
         "always_export_initializer",    Type::tBool,
         "infer_time_folding",           Type::tBool,

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2084,6 +2084,7 @@ namespace das {
               << value.no_optimizations
               << value.fail_on_no_aot
               << value.fail_on_lack_of_aot_export
+              << value.no_fast_call
               << value.debugger
               << value.debug_module
               << value.profiler
@@ -2180,7 +2181,7 @@ namespace das {
     }
 
     uint32_t AstSerializer::getVersion () {
-        static constexpr uint32_t currentVersion = 33;
+        static constexpr uint32_t currentVersion = 34;
         return currentVersion;
     }
 

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -740,6 +740,7 @@ namespace das {
             addField<DAS_BIND_MANAGED_FIELD(no_optimizations)>("no_optimizations");
             addField<DAS_BIND_MANAGED_FIELD(fail_on_no_aot)>("fail_on_no_aot");
             addField<DAS_BIND_MANAGED_FIELD(fail_on_lack_of_aot_export)>("fail_on_lack_of_aot_export");
+            addField<DAS_BIND_MANAGED_FIELD(no_fast_call)>("no_fast_call");
         // debugger
             addField<DAS_BIND_MANAGED_FIELD(debugger)>("debugger");
             addField<DAS_BIND_MANAGED_FIELD(debug_module)>("debug_module");


### PR DESCRIPTION
```
options no_fast_call

def fib ( n ) // no longer [fastcall] via option
	if n <= 1
		return n
	return fib(n-1) + fib(n-2)
```