### PR TITLE
Fix invalid $t reification type error message

### DIFF
--- a/daslib/templates_boost.das
+++ b/daslib/templates_boost.das
@@ -423,9 +423,11 @@ def public add_type_ptr_ref ( var st : Structure?; flags:TypeDeclFlags ) : TypeD
     //! Implementation details for the reification. This adds any array to the rules.
     return <- new [[TypeDecl() at=st.at, baseType=Type tStructure, structType = st, flags=flags]]
 
-def public add_type_ptr_ref ( anything; flags:TypeDeclFlags ) : TypeDeclPtr
+[unused_argument(anything), unused_argument(flags)]
+def public add_type_ptr_ref ( anything : auto(TT); flags:TypeDeclFlags ) : TypeDeclPtr
     //! Implementation details for the reification. This adds any array to the rules.
-    concept_assert(false,"$t reification only supports TypeDeclPtr, StructurePtr, or Structure?")
+    concept_assert(false,"$t reification expected type `TypeDeclPtr`, `StructurePtr`, or `Structure?`, but received {typeinfo(typename type<TT>)}")
+    return <- new [[TypeDecl()]]
 
 def private generatedExpr( var expr : ExpressionPtr ) : ExpressionPtr
     expr.genFlags |= ExprGenFlags generated


### PR DESCRIPTION
Oops, I messed it up previously, the compiler didn't even try executing the concept_assert because of missing return and unused arguments. Also added printing of the type.