### PR TITLE
apply now assumes name. there is no variable

### DIFF
--- a/daslib/apply.das
+++ b/daslib/apply.das
@@ -25,12 +25,12 @@ def for_each_subrange ( total:int; blk:block<(r:range):void> )
 
 /*
     def apply`Foo(self:Foo;arg_field1:block<(name:string,value:field1-type):void>;arg_field2:...)
-        invoke(arg_field1,"field1",self.field1)
-        invoke(arg_field2,"field2",self.field2)
+        invoke(arg_field1,self.field1)
+        invoke(arg_field2,self.field2)
         ...
 */
 [macro_function]
-def generateApplyVisitStruct ( stype:TypeDeclPtr; frange:range; fnname:string; at:LineInfo )
+def generateApplyVisitStruct ( stype:TypeDeclPtr; frange:range; fnname:string; at:LineInfo; var names:array<string> )
     assert(stype.baseType==Type tStructure)
     assert(stype.dim |> length==0)
     var inscope selfT <- clone_type(stype)
@@ -41,9 +41,9 @@ def generateApplyVisitStruct ( stype:TypeDeclPtr; frange:range; fnname:string; a
     for fldi in frange
         if true
             let fld & = unsafe(stype.structType.fields[fldi])
-            blkList |> emplace_new <|  qmacro(invoke($i("__arg_{fld.name}"),$v(string(fld.name)),_`_self.$f(fld.name)))
-            var inscope argT <- new [[TypeDecl() baseType=Type tBlock, at=at]]                         // block<(name:string;x:field1type)>
-            emplace_new(argT.argTypes, new [[TypeDecl() baseType=Type tString, at=at]])
+            names |> push(string(fld.name))
+            blkList |> emplace_new <|  qmacro(invoke($i("__arg_{fld.name}"),_`_self.$f(fld.name)))
+            var inscope argT <- new [[TypeDecl() baseType=Type tBlock, at=at]]                         // block<(x:field1type)>
             var inscope fldT <- clone_type(fld._type)
             if stype.flags.constant
                 fldT.flags |= TypeDeclFlags constant
@@ -59,18 +59,20 @@ def generateApplyVisitStruct ( stype:TypeDeclPtr; frange:range; fnname:string; a
     compiling_module() |> add_function(fn)
 
 [macro_function]
-def generateApplyVisitStruct ( stype:TypeDeclPtr; fnname:string; at:LineInfo )
+def generateApplyVisitStruct ( stype:TypeDeclPtr; fnname:string; at:LineInfo ) : array<string>
+    var names : array<string>
     for_each_subrange(length(stype.structType.fields)) <| $ ( frange )
-        generateApplyVisitStruct(stype,frange,"{fnname}`{frange.x}`{frange.y}",at)
+        generateApplyVisitStruct(stype,frange,"{fnname}`{frange.x}`{frange.y}",at,names)
+    return <- names
 
 /*
     def apply`Foo(self:Foo;arg_field1:block<(name:string,value:field1-type):void>;arg_field2:...)
-        invoke(arg_field1,"field1",self.field1)
-        invoke(arg_field2,"field2",self.field2)
+        invoke(arg_field1,self.field1)
+        invoke(arg_field2,self.field2)
         ...
 */
 [macro_function]
-def generateApplyVisitTuple ( stype:TypeDeclPtr; frange:range; fnname:string; at:LineInfo )
+def generateApplyVisitTuple ( stype:TypeDeclPtr; frange:range; fnname:string; at:LineInfo; var names:array<string> )
     assert(stype.baseType==Type tTuple)
     assert(stype.dim |> length==0)
     var inscope selfT <- clone_type(stype)
@@ -81,9 +83,9 @@ def generateApplyVisitTuple ( stype:TypeDeclPtr; frange:range; fnname:string; at
         if true
             assume flda = stype.argTypes[fldi]
             let fldname = length(stype.argNames)==length(stype.argTypes) ? string(stype.argNames[fldi]) : "_{fldi}"
-            blkList |> emplace_new <|  qmacro(invoke($i("__arg_{fldname}"),$v(fldname),_`_self.$f(fldname)))
-            var inscope argT <- new [[TypeDecl() baseType=Type tBlock, at=at]]                         // block<(name:string;x:field1type)>
-            emplace_new(argT.argTypes, new [[TypeDecl() baseType=Type tString, at=at]])
+            names |> push(fldname)
+            blkList |> emplace_new <|  qmacro(invoke($i("__arg_{fldname}"),_`_self.$f(fldname)))
+            var inscope argT <- new [[TypeDecl() baseType=Type tBlock, at=at]]                         // block<(x:field1type)>
             var inscope fldT <- clone_type(flda)
             if stype.flags.constant
                 fldT.flags |= TypeDeclFlags constant
@@ -99,22 +101,24 @@ def generateApplyVisitTuple ( stype:TypeDeclPtr; frange:range; fnname:string; at
     compiling_module() |> add_function(fn)
 
 [macro_function]
-def generateApplyVisitTuple ( stype:TypeDeclPtr; fnname:string; at:LineInfo )
+def generateApplyVisitTuple ( stype:TypeDeclPtr; fnname:string; at:LineInfo ) : array<string>
+    var names : array<string>
     for_each_subrange(length(stype.argTypes)) <| $ ( frange )
-        generateApplyVisitTuple(stype,frange,"{fnname}`{frange.x}`{frange.y}",at)
+        generateApplyVisitTuple(stype,frange,"{fnname}`{frange.x}`{frange.y}",at,names)
+    return <- names
 
 /*
     def apply`Foo(self:Foo;arg_field1:block<(name:string,value:field1-type):void>;arg_field2:...)
         if variant_index(self)==0
-            invoke(arg_field1,"field1",self.field1)
+            invoke(arg_field1,self.field1)
             return
         if variant_idnex(self)==2
-            invoke(arg_field2,"field2",self.field2)
+            invoke(arg_field2,self.field2)
             return
         ...
 */
 [macro_function]
-def generateApplyVisitVariant ( stype:TypeDeclPtr; frange:range; fnname:string; at:LineInfo )
+def generateApplyVisitVariant ( stype:TypeDeclPtr; frange:range; fnname:string; at:LineInfo; var names:array<string> )
     assert(stype.baseType==Type tVariant)
     assert(stype.dim |> length==0)
     var inscope selfT <- clone_type(stype)
@@ -125,13 +129,13 @@ def generateApplyVisitVariant ( stype:TypeDeclPtr; frange:range; fnname:string; 
         if true
             assume flda = stype.argTypes[fldi]
             let fldname = length(stype.argNames)==length(stype.argTypes) ? string(stype.argNames[fldi]) : "_{fldi}"
+            names |> push(fldname)
             var inscope vexpr <- qmacro_block <|
                 if variant_index(_`_self)==$v(fldi)
-                    invoke($i("__arg_{fldname}"),$v(fldname),_`_self as $f(fldname))
+                    invoke($i("__arg_{fldname}"),_`_self as $f(fldname))
                     return
             blkList |> emplace(vexpr)
-            var inscope argT <- new [[TypeDecl() baseType=Type tBlock, at=at]]                         // block<(name:string;x:field1type)>
-            emplace_new(argT.argTypes, new [[TypeDecl() baseType=Type tString, at=at]])
+            var inscope argT <- new [[TypeDecl() baseType=Type tBlock, at=at]]                         // block<(x:field1type)>
             var inscope fldT <- clone_type(flda)
             if stype.flags.constant
                 fldT.flags |= TypeDeclFlags constant
@@ -147,9 +151,27 @@ def generateApplyVisitVariant ( stype:TypeDeclPtr; frange:range; fnname:string; 
     compiling_module() |> add_function(fn)
 
 [macro_function]
-def generateApplyVisitVariant ( stype:TypeDeclPtr; fnname:string; at:LineInfo )
+def generateApplyVisitVariant ( stype:TypeDeclPtr; fnname:string; at:LineInfo ) : array<string>
+    var names : array<string>
     for_each_subrange(length(stype.argTypes)) <| $ ( frange )
-        generateApplyVisitVariant(stype,frange,"{fnname}`{frange.x}`{frange.y}",at)
+        generateApplyVisitVariant(stype,frange,"{fnname}`{frange.x}`{frange.y}",at, names)
+    return <- names
+
+[macro_function]
+def clone_block_with_name ( name:string; blk:ExpressionPtr )
+    macro_verify(blk is ExprMakeBlock,this_program(),blk.at,"expecting make block, i.e. $(..)")
+    var inscope res <- clone_expression(blk)
+    var imb = res as ExprMakeBlock
+    var rblk = imb._block as ExprBlock
+    macro_verify(rblk!=null,this_program(),blk.at,"expecting block")
+    macro_verify(rblk.arguments |> length == 2,this_program(),blk.at,"expecting block with 2 arguments")
+    var inscope eassume <- new [[ExprAssume() at=blk.at,
+        alias := rblk.arguments[0].name,
+        subexpr <- new [[ExprConstString() at=blk.at, value := name]]
+    ]]
+    rblk.arguments |> erase(0)
+    rblk.list |> emplace(eassume,0)
+    return <- res
 
 [call_macro(name="apply")]  // apply(value, block)
 class ApplyMacro : AstCallMacro
@@ -173,18 +195,19 @@ class ApplyMacro : AstCallMacro
             macro_verify(expr.arguments[1] is ExprMakeBlock,prog,expr.at,"expecting make block, i.e. $(..)")
             var callName : string
             var nfields : int
+            var names : array<string>
             if argT.baseType == Type tStructure
                 callName = "apply`struct`{argT.structType.name}`{expr.at.line}"
                 nfields = argT.structType.fields |> length
-                generateApplyVisitStruct(expr.arguments[0]._type,callName,expr.at)
+                names <- generateApplyVisitStruct(expr.arguments[0]._type,callName,expr.at)
             elif argT.baseType == Type tTuple
                 callName = "apply`tuple`{intptr(expr)}`{expr.at.line}"
                 nfields = length(argT.argTypes)
-                generateApplyVisitTuple(expr.arguments[0]._type,callName,expr.at)
+                names <- generateApplyVisitTuple(expr.arguments[0]._type,callName,expr.at)
             elif argT.baseType == Type tVariant
                 callName = "apply`variant`{intptr(expr)}`{expr.at.line}"
                 nfields = length(argT.argTypes)
-                generateApplyVisitVariant(expr.arguments[0]._type,callName,expr.at)
+                names <- generateApplyVisitVariant(expr.arguments[0]._type,callName,expr.at)
             else
                 macro_error(prog,expr.at,"internal error. can't apply to {describe(argT)}")
                 return <- [[ExpressionPtr]]
@@ -193,8 +216,8 @@ class ApplyMacro : AstCallMacro
             for_each_subrange(nfields) <| $ ( frange )
                 var inscope call <- new [[ExprCall() name:="_::{callName}`{frange.x}`{frange.y}", at=expr.at]]
                 emplace_new(call.arguments,clone_expression(expr.arguments[0]))
-                for _ in frange
-                    emplace_new(call.arguments,clone_expression(expr.arguments[1]))
+                for idx in frange
+                    emplace_new(call.arguments,clone_block_with_name(names[idx], expr.arguments[1]))
                 calls |> emplace(call)
             if length(calls)==1
                 return <- calls[0]

--- a/tests/apply/test_apply.das
+++ b/tests/apply/test_apply.das
@@ -75,3 +75,48 @@ def test_apply_named_tuple ( t:T? )
     apply(foo) <| $ ( name, field )
         if name!="a" && name!="b"
             t->fatal("unknown field")
+
+struct Foos
+    a : int
+    b : float
+
+tuple Foot
+	a : int
+	b : float
+
+variant Foov
+	a : int
+	b : float
+
+[test]
+def test_static_assert_on_name ( t:T? )
+	var f = Foos(a=1, b=2.0)
+	apply(f) <| $ ( name, value )
+		static_if name=="a"
+			assert( value == 1 )
+		else
+			assert( value == 2.0 )
+	var g  = tuple(1, 2.0)
+	apply(g) <| $ ( name, value )
+		static_if name=="_0"
+			assert( value == 1 )
+        else
+            assert( value == 2.0 )
+	var gg = [[Foot a=1, b=2.0]]
+	apply(gg) <| $ ( name, value )
+		static_if name=="a"
+			assert( value == 1 )
+        else
+            assert( value == 2.0 )
+	var h = Foov(a=1)
+	apply(h) <| $ ( name, value )
+		static_if name=="a"
+			assert( value == 1 )
+        else
+            assert( value == 0.0 )
+	var h2 = Foov(b=2.0)
+	apply(h2) <| $ ( name, value )
+		static_if name=="b"
+			assert( value == 2.0 )
+        else
+            assert( value == 0 )


### PR DESCRIPTION
adds assume argName = name at the front of the block, remove first argument of the block. that way name is constexpr