### PR TITLE
fix windows sysos.cpp compilation in case of non-std vector usage

### DIFF
--- a/src/misc/sysos.cpp
+++ b/src/misc/sysos.cpp
@@ -20,7 +20,7 @@
 #if !defined(_M_ARM64)
         int GetLogicalProcessorCountInWindows() {
             DWORD returnLength = 0;
-            std::vector<unsigned char> buffer;
+            vector<unsigned char> buffer;
             PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX info = nullptr;
             // First, call to get the size of the data needed.
             GetLogicalProcessorInformationEx(RelationAll, NULL, &returnLength);


### PR DESCRIPTION
Do use just `vector` instead of `std::vector` as later may be unavailable due to global config alias.

Downsteam Change-Id: I0e3e7e625ec6b7b954dce90df97b303b4ea9bcc9