### PR TITLE
at least some infer for type macros

### DIFF
--- a/examples/test/misc/padd.das
+++ b/examples/test/misc/padd.das
@@ -4,22 +4,26 @@ require daslib/ast_boost
 require daslib/macro_boost
 require daslib/templates_boost
 
-[type_macro(name="padd_structure")]
-class PaddStructureMacro : AstTypeMacro
+[type_macro(name="padd_dim")]
+class PaddDimMacro : AstTypeMacro
     def override visit ( prog:ProgramPtr; mod:Module?; td:TypeDeclPtr ) : TypeDeclPtr
-        if length(td.dimExpr) != 2
-            macro_error(compiling_program(), td.at, "expecting 1 argument")
+        if length(td.dimExpr) != 3
+            macro_error(compiling_program(), td.at, "expecting 2 arguments")
             return <- [[TypeDeclPtr()]]
-        if !(td.dimExpr[1] is ExprConstInt)
+        if !(td.dimExpr[2] is ExprConstInt)
             macro_error(compiling_program(), td.at, "expecting constant integer (size)")
             return <- [[TypeDeclPtr()]]
-        let bytes = (td.dimExpr[1] as ExprConstInt).value
-        var inscope st <- new [[Structure() at=td.at, name := "PaddStructure_{bytes}_at_{td.at.line}"]] // TODO: unique name
-        st.flags |= StructureFlags privateStructure | StructureFlags generated
-        var inscope st_type <- new [[TypeDecl() at=td.at, baseType=Type tInt8]]
-        st_type.dim |> push(bytes)
-        st |> add_structure_field ( "bytes", clone_type(st_type), [[ExpressionPtr]])
-        var inscope retType <- new [[TypeDecl() at=td.at, baseType=Type tStructure, structType=get_ptr(st)]]
-        mod |> add_structure(st)
-        return <- retType
+        let count = (td.dimExpr[2] as ExprConstInt).value
+        if td.dimExpr[1]._type == null
+            // type is not inferred, which means we are inferring generic type
+            var inscope auto_type : TypeDeclPtr
+            if td.dimExpr[1] is ExprTypeDecl
+                auto_type |> move_new <| clone_type((td.dimExpr[1] as ExprTypeDecl).typeexpr)
+            else
+                auto_type |> move_new <| new [[TypeDecl() baseType=Type autoinfer]]
+            auto_type.dim |> push(count)
+            return <- auto_type
+        var inscope final_type <- clone_type(td.dimExpr[1]._type)
+        final_type.dim |> push(count)
+        return <- final_type
 

--- a/examples/test/misc/padd_example.das
+++ b/examples/test/misc/padd_example.das
@@ -1,9 +1,11 @@
 require padd
 
+def take_foo ( foo : $padd_dim(type<auto(TT)>,14) ) : TT
+	debug(foo)
+	return [[TT]]
+
 [export]
 def main
-	var foo : $padd_structure(14)
+	var foo : $padd_dim(type<float>,14)
     print("foo = {foo}\n")
-
-options log
-
+	take_foo(foo)

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -566,6 +566,22 @@ namespace das {
                         td->typeexpr = inferPartialAliases(td->typeexpr,fptr,aliases);
                     }
                 }
+                if ( decl->baseType==Type::typeMacro ) {
+                    auto tmn = decl->typeMacroName();
+                    auto tms = findTypeMacro(tmn);
+                    if ( tms.size() == 0 ) {
+                        return decl;
+                    } else if ( tms.size() > 1 ) {
+                        return decl;
+                    } else {
+                        auto resType = tms[0]->visit(program,program->thisModule.get(), decl);
+                        if ( !resType ) {
+                            return decl;
+                        }
+                        TypeDecl::applyAutoContracts(resType,decl);
+                        return resType;
+                    }
+                }
                 return decl;
             }
             if ( decl->baseType==Type::autoinfer ) {

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -1743,7 +1743,11 @@ namespace das
     bool TypeDecl::isAliasOrA2A(bool a2a) const {
         a2a |= autoToAlias;
         // auto is auto.... or auto....?
-        if ( baseType==Type::autoinfer && a2a ) {
+        if ( baseType==Type::typeDecl ) {
+            return true;
+        } else if ( baseType==Type::typeMacro ) {
+            return true;
+        } else if ( baseType==Type::autoinfer && a2a ) {
             return true;
         } else if ( baseType==Type::alias ) {
             return true;


### PR DESCRIPTION
```
require padd

def take_foo ( foo : $padd_dim(type<auto(TT)>,14) ) : TT
	debug(foo)
	return [[TT]]

[export]
def main
	var foo : $padd_dim(type<float>,14)
    print("foo = {foo}\n")
	take_foo(foo)
```