### PR TITLE
less stack

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1533,6 +1533,7 @@ namespace das
         EnumerationPtr visitEnumeration(Visitor & vis, Enumeration *);
         void visitModule(Visitor & vis, Module * thatModule, bool visitGenerics = false);
         void visitModulesInOrder(Visitor & vis, bool visitGenerics = false);
+        void visitModules(Visitor & vis, bool visitGenerics = false);
         void visit(Visitor & vis, bool visitGenerics = false);
         void setPrintFlags();
         void aotCpp ( Context & context, TextWriter & logs );

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -2989,6 +2989,15 @@ namespace das {
         return vis.visit(penum);
     }
 
+    void Program::visitModules(Visitor & vis, bool visitGenerics) {
+        vis.preVisitProgram(this);
+        library.foreach([&](Module * pm) -> bool {
+            visitModule(vis, pm, visitGenerics);
+            return true;
+        }, "*");
+        vis.visitProgram(this);
+    }
+
     void Program::visitModulesInOrder(Visitor & vis, bool visitGenerics) {
         vis.preVisitProgram(this);
         library.foreach_in_order([&](Module * pm) -> bool {

--- a/src/ast/ast_allocate_stack.cpp
+++ b/src/ast/ast_allocate_stack.cpp
@@ -101,6 +101,9 @@ namespace das {
         bool                    inStruct = false;
         bool                    noFastCall = false;
     protected:
+        virtual bool canVisitGlobalVariable ( Variable * var ) override { return var->used; }
+        virtual bool canVisitFunction ( Function * fun ) override { return fun->used; }
+    protected:
         uint32_t allocateStack ( uint32_t size ) {
             auto result = stackTop;
             stackTop += (size + 0xf) & ~0xf;
@@ -648,10 +651,10 @@ namespace das {
         globalStringHeapSize = vstr.bytesTotal;
         // move some variables to CMRES
         VarCMRes vcm(this);
-        visit(vcm);
+        visitModules(vcm);
         // allocate stack for the rest of them
         AllocateStack context(this, logs);
-        visit(context);
+        visitModules(context);
         // adjust stack size for all the used variables
         for (auto & pm : library.modules) {
             for ( auto & var : pm->globals.each() ) {

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -470,10 +470,12 @@ namespace das {
                 }
                 if (!program->failed())
                     program->fixupAnnotations();
+                /*
                 if (!program->failed())
                     program->deriveAliases(logs);
                 if (!program->failed())
                     program->allocateStack(logs);
+                */
                 if (!program->failed())
                     program->finalizeAnnotations();
                 if ( policies.macro_context_collect ) libGroup.collectMacroContexts();
@@ -496,6 +498,8 @@ namespace das {
                     auto timeM = ref_time_ticks();
                     if (!program->failed())
                         program->markMacroSymbolUse();
+                    if (!program->failed())
+                        program->deriveAliases(logs);
                     if (!program->failed())
                         program->allocateStack(logs);
                     if (!program->failed())
@@ -770,6 +774,8 @@ namespace das {
                 if (!res->failed() && !exportAll)
                     res->removeUnusedSymbols();
                 if (!res->failed())
+                    res->deriveAliases(logs);
+                if (!res->failed())
                     res->allocateStack(logs);
             } else {
                 if (!res->failed())
@@ -778,6 +784,8 @@ namespace das {
                     addRttiRequireVariable(res, fileName);
                 if (!res->failed())
                     res->removeUnusedSymbols();
+                if (!res->failed())
+                    res->deriveAliases(logs);
                 if (!res->failed())
                     res->allocateStack(logs);
             }

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -1688,6 +1688,7 @@ namespace das {
     // create the module macro state
         program->isCompiling = false;
         program->markMacroSymbolUse();
+        program->deriveAliases(ignore_logs);
         program->allocateStack(ignore_logs);
         program->makeMacroModule(ignore_logs);
     // unbind the module from the program


### PR DESCRIPTION
this changes stack allocation strategy
its not longer 'all functions in the module, once the module is compiled'
its no only once per program (and once per macro module) - and only used functions and variables