### PR TITLE
Make possible to set custom stack size to copied context

### DIFF
--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -289,8 +289,15 @@ namespace das
         friend class Program;
         friend class Module;
     public:
+        struct CopyOptions
+        {
+            uint32_t category = 0;
+            uint32_t stackSize = 0;
+        };
+
         Context(uint32_t stackSize = 16*1024, bool ph = false);
         Context(const Context &, uint32_t category_);
+        Context(const Context & ctx, const CopyOptions & opts);
         Context(const Context &) = delete;
         Context & operator = (const Context &) = delete;
         virtual ~Context();

--- a/src/simulate/simulate.cpp
+++ b/src/simulate/simulate.cpp
@@ -1056,7 +1056,12 @@ namespace das
     }
 
 
-    Context::Context(const Context & ctx, uint32_t category_): stack(ctx.stack.size()) {
+    Context::Context(const Context & ctx, uint32_t category_)
+        : Context(ctx, CopyOptions{category_, 0}) {
+    }
+
+    Context::Context(const Context & ctx, const CopyOptions & opts)
+        : stack(opts.stackSize ? opts.stackSize : ctx.stack.size()) {
         persistent = ctx.persistent;
         code = ctx.code;
         constStringHeap = ctx.constStringHeap;
@@ -1064,7 +1069,7 @@ namespace das
         thisProgram = ctx.thisProgram;
         thisHelper = ctx.thisHelper;
         name = "clone of " + ctx.name;
-        category.value = category_;
+        category.value = opts.category;
         ownStack = (ctx.stack.size() != 0);
         if ( persistent ) {
             heap = make_smart<PersistentHeapAllocator>();


### PR DESCRIPTION
Why: This is very useful when we have a main context that does a lot of initialization and needs a large stack, but the copies use pre-prepared data so they don't need as much stack.