### PR TITLE
array<FOO> and table<FOO> no longer circular dependency

### DIFF
--- a/examples/test/compilation_fail_tests/circular_dependency.das
+++ b/examples/test/compilation_fail_tests/circular_dependency.das
@@ -1,4 +1,4 @@
-expect 30101:2
+expect 30101:1
 
 // this one creates circular dependency
 struct Foo
@@ -8,7 +8,7 @@ struct Foo
 struct Node
     left, right : Node?
 
-// this one has fancy circular dependency
+// this one is not circular dependency. sizeof(array<Bar>) does not deppend on Bar
 struct Bar
     a : array<Bar>
 

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -2676,8 +2676,8 @@ namespace das
         if ( type->baseType==Type::tPointer ) {
             return false;
         }
-        if ( type->firstType && isCircularType(type->firstType, all) ) return true;
-        if ( type->secondType && isCircularType(type->secondType, all) ) return true;
+        // if ( type->firstType && isCircularType(type->firstType, all) ) return true;
+        // if ( type->secondType && isCircularType(type->secondType, all) ) return true;
         auto pt = type.get();
         for (auto it : all) {
             if ( it == pt ) return true;


### PR DESCRIPTION
```
struct Foo
  a : array<Foo>
```
is now ok