### PR TITLE
Fixed crash when quoting enum value from enum with non-sequential values

### DIFF
--- a/daslib/ast_boost.das
+++ b/daslib/ast_boost.das
@@ -576,18 +576,20 @@ def private walk_and_convert_basic ( data : uint8?; info:TypeDeclPtr; at:LineInf
             return [[ExpressionPtr]]
 
 def private walk_and_convert_enumeration ( data : uint8?; info:TypeDeclPtr; at:LineInfo ) : ExpressionPtr
-    var eval = 0
+    var eval = 0l
     if info.baseType == Type tEnumeration
-        eval = * unsafe(reinterpret<int?> data)
+        eval = int64(*unsafe(reinterpret<int?> data))
     elif info.baseType == Type tEnumeration8
-        eval = int(*data)
+        eval = int64(*data)
     elif info.baseType == Type tEnumeration16
-        eval = int(*unsafe(reinterpret<int16?> data))
+        eval = int64(*unsafe(reinterpret<int16?> data))
     elif info.baseType == Type tEnumeration64
-        eval = int(*unsafe(reinterpret<int64?> data))
+        eval = *unsafe(reinterpret<int64?> data)
     else
         panic("unsupported enumeration")
-    return <- new [[ExprConstEnumeration() enumType:=info.enumType, value:=info.enumType.list[eval].name]]
+    let name = info.enumType |> find_enum_name(eval)
+    panic("can't find name of enum value {eval} in {describe(info)}")  if name == ""
+    return <- new [[ExprConstEnumeration() enumType:=info.enumType, value:=name]]
 
 def private walk_and_convert ( data : uint8?; info:TypeDeclPtr; at:LineInfo ) : ExpressionPtr
 	// print("0x{intptr(data)} {describe(info)}\n")

--- a/include/daScript/simulate/aot_builtin_ast.h
+++ b/include/daScript/simulate/aot_builtin_ast.h
@@ -10,6 +10,7 @@ namespace das {
     char * ast_describe_function ( smart_ptr_raw<Function> t, Context * context, LineInfoArg * at );
     char * ast_das_to_string ( Type bt, Context * context, LineInfoArg * at );
     char * ast_find_bitfield_name ( smart_ptr_raw<TypeDecl> bft, Bitfield value, Context * context, LineInfoArg * at );
+    char * ast_find_enum_name ( Enumeration * enu, int64_t value, Context * context, LineInfoArg * at );
     int64_t ast_find_enum_value ( EnumerationPtr enu, const char * value );
     int64_t ast_find_enum_value_ex ( Enumeration * enu, const char * value );
 

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -283,6 +283,10 @@ namespace das {
         return ast_find_enum_value_ex(enu.get(), value);
     }
 
+    char * ast_find_enum_name ( Enumeration *enu, int64_t value, Context * context, LineInfoArg * at ) {
+        return context->allocateString(enu->find(value, string()), at);
+    }
+
     void ast_error ( ProgramPtr prog, const LineInfo & at, const char * message, Context * context, LineInfoArg * lineInfo ) {
         if ( !prog ) context->throw_error_at(lineInfo,"program can't be null (expecting compiling_program())");
         prog->error(message ? message : "macro error","","",at,CompilationError::macro_failed);
@@ -789,6 +793,9 @@ namespace das {
         addExtern<DAS_BIND_FUN(ast_find_bitfield_name)>(*this, lib,  "find_bitfield_name",
             SideEffects::none, "find_bitfield_name")
                 ->args({"bit","value","context","lineinfo"});
+        addExtern<DAS_BIND_FUN(ast_find_enum_name)>(*this, lib,  "find_enum_name",
+            SideEffects::none, "ast_find_enum_name")
+                ->args({"enum","value","context","lineinfo"});
         addExtern<DAS_BIND_FUN(ast_find_enum_value)>(*this, lib,  "find_enum_value",
             SideEffects::none, "ast_find_enum_value")
                 ->args({"enum","value"});


### PR DESCRIPTION
walk_and_convert_enumeration() used enum integer value as list index directly.