### PR TITLE
Added wrapper to simplify iteration over das::Table in c++

### DIFF
--- a/include/daScript/misc/runtime_table_utils.h
+++ b/include/daScript/misc/runtime_table_utils.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "daScript/misc/arraytype.h"
+#include "daScript/simulate/aot_builtin.h"
+
+namespace das
+{
+  class Context;
+  struct LineInfoArg;
+
+  template<typename T, typename CB>
+  void for_each_table(const T & table, CB && callback, das::Context * context, das::LineInfoArg * at)
+  {
+    das::Sequence keysSequence;
+    das::Sequence valueSequence;
+    das::builtin_table_keys(keysSequence, table, sizeof(typename T::KeyType), context, at);
+    das::builtin_table_values(valueSequence, table, sizeof(typename T::ValueType), context, at);
+
+    typename T::KeyType keyData;
+    typename T::ValueType * valueData;
+    bool hasData = false;
+    do
+    {
+      hasData = das::builtin_iterator_iterate(keysSequence, &keyData, context);
+      hasData = das::builtin_iterator_iterate(valueSequence, &valueData, context) && hasData;
+      if (hasData && !callback(keyData, *valueData))
+      {
+        break;
+      }
+    } while(hasData);
+    das::builtin_iterator_close(keysSequence, &keyData, context);
+    das::builtin_iterator_close(valueSequence, &valueData, context);
+  }
+}

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -943,7 +943,9 @@ namespace das {
     template <typename TK, typename TV>
     struct TTable : Table {
         // static_assert(is_workhorse_type<TK>::value,"only supported for `workhorse` types");
-        using THIS_TYPE = TTable<TK, TV>;
+        using KeyType = TK;
+        using ValueType = TV;
+        using THIS_TYPE = TTable<KeyType, ValueType>;
         TTable()  {}
         TTable(TTable & arr) { moveT(arr); }
         TTable(TTable && arr ) { moveT(arr); }


### PR DESCRIPTION
Usage:

```
  static void test_string_string_table(const das::TTable<char *, char *> & table,
                                       das::Context * context,
                                       das::LineInfoArg * at)
  {
    das::for_each_table(table, [](const char * key, const char * value)
    {
      printf("%s -> %s", key, value);
      return true;
    }, context, at);
  }
```