### PR TITLE
lockcheck returns path to where the issue is

### DIFF
--- a/src/builtin/module_builtin_runtime_lockcheck.cpp
+++ b/src/builtin/module_builtin_runtime_lockcheck.cpp
@@ -30,7 +30,8 @@ namespace das
             return false;
         }
         virtual bool canVisitPointer ( TypeInfo * ) override {
-            return false; }
+            return false;
+        }
         virtual bool canVisitLambda ( TypeInfo * ) override {
             return false;
         }
@@ -54,6 +55,174 @@ namespace das
         }
     };
 
+    struct LockErrorReporter : DataWalker {
+
+        enum class PathType {
+            field
+        ,   tuple
+        ,   array_element
+        ,   table_element
+        ,   variant
+        };
+
+        struct PathChunk {
+            PathType type;
+            const char * name;
+            TypeInfo * ti = nullptr;
+            TypeInfo * vi = nullptr;
+            int32_t index = 0;
+            PathChunk ( const char * name ) {
+                this->type = PathType::field;
+                this->name = name;
+            }
+            PathChunk ( TypeInfo * TI, TypeInfo * VI ) {
+                this->type = PathType::tuple;
+                this->ti = TI;
+                this->vi = VI;
+            }
+            PathChunk ( int32_t index ) {
+                this->type = PathType::array_element;
+                this->index = index;
+            }
+            PathChunk ( TypeInfo * TI, int32_t index ) {
+                this->type = PathType::table_element;
+                this->ti = TI;
+                this->index = index;
+            }
+            PathChunk ( int32_t index, TypeInfo * TI ) {
+                this->type = PathType::variant;
+                this->index = index;
+                this->ti = TI;
+            }
+        };
+        vector<PathChunk> path;
+        string pathStr;
+        bool locked = false;
+        virtual bool canVisitArray ( Array * ar, TypeInfo * ) override {
+            return !ar->forego_lock_check;
+        }
+        virtual bool canVisitArrayData ( TypeInfo * ti, uint32_t ) override {
+            return (ti->flags & TypeInfo::flag_lockCheck) == TypeInfo::flag_lockCheck;
+        }
+        virtual bool canVisitTable ( char * pa, TypeInfo * ) override {
+            return !((Table *)pa)->forego_lock_check;
+        }
+        virtual bool canVisitTableData ( TypeInfo * ti ) override {
+            if ( ti->secondType ) {
+                return (ti->secondType->flags & TypeInfo::flag_lockCheck) == TypeInfo::flag_lockCheck;
+            } else {
+                return false;
+            }
+        }
+        virtual bool canVisitHandle ( char *, TypeInfo * ) override {
+            return false;
+        }
+        virtual bool canVisitPointer ( TypeInfo * ) override {
+            return false;
+        }
+        virtual bool canVisitLambda ( TypeInfo * ) override {
+            return false;
+        }
+        virtual bool canVisitIterator ( TypeInfo * ) override {
+            return false;
+        }
+        virtual bool canVisitStructure ( char *, StructInfo * si ) override {
+            return (si->flags & StructInfo::flag_lockCheck) == StructInfo::flag_lockCheck;
+        }
+        void collectPath ( void ) {
+            pathStr.clear();
+            for ( auto & pc : path ) {
+                switch ( pc.type ) {
+                    case PathType::field:
+                        pathStr += ".";
+                        pathStr += pc.name ? pc.name : "???";
+                        break;
+                    case PathType::tuple:
+                    {
+                        int32_t idx = -1u;
+                        for ( int32_t i=0, is=pc.ti->argCount; i!=is; ++i ) {
+                            if ( pc.ti->argTypes[i]==pc.vi ) {
+                                idx = i;
+                                break;
+                            }
+                        }
+                        pathStr += ".";
+                        if ( pc.ti->argNames && pc.ti->argNames[idx] ) {
+                            pathStr += pc.ti->argNames[idx];
+                        } else {
+                            pathStr += to_string(idx);
+                        }
+                        break;
+                    }
+                    case PathType::array_element:
+                        pathStr += "[";
+                        pathStr += to_string(pc.index);
+                        pathStr += "]";
+                        break;
+                    case PathType::table_element:
+                        pathStr += "[";
+                        pathStr += to_string(pc.index);
+                        pathStr += "]";
+                        break;
+                    case PathType::variant:
+                    {
+                        pathStr += " as ";
+                        if ( pc.ti->argNames && pc.ti->argNames[pc.index] ) {
+                            pathStr += pc.ti->argNames[pc.index];
+                        } else {
+                            pathStr += to_string(pc.index);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        virtual void beforeArray ( Array * pa, TypeInfo * ) override {
+            if ( pa->lock ) {
+                locked = true;
+                _cancel = true;
+
+            }
+        }
+        virtual void beforeTable ( Table * pa, TypeInfo * ) override {
+            if ( pa->lock ) {
+                locked = true;
+                _cancel = true;
+            }
+        }
+        virtual void beforeStructureField ( char *, StructInfo *, char *, VarInfo * vi, bool ) override {
+            path.emplace_back(PathChunk(vi->name));
+        }
+        virtual void afterStructureField ( char *, StructInfo *, char *, VarInfo *, bool ) override {
+            path.pop_back();
+        }
+        virtual void beforeTupleEntry ( char *, TypeInfo * ti, char *, TypeInfo * vi, bool ) override {
+            path.emplace_back(PathChunk(ti,vi));
+        }
+        virtual void afterTupleEntry ( char *, TypeInfo *, char *, TypeInfo *, bool ) override {
+            path.pop_back();
+        }
+        virtual void beforeArrayElement ( char *, TypeInfo *, char *, uint32_t index, bool ) override {
+            path.emplace_back(PathChunk(index));
+        }
+        virtual void afterArrayElement ( char *, TypeInfo *, char *, uint32_t, bool ) override {
+            path.pop_back();
+        }
+        virtual void beforeTableValue ( Table *, TypeInfo *, char *, TypeInfo * kv, uint32_t index, bool ) override {
+            path.emplace_back(PathChunk(kv,index));
+        }
+        virtual void afterTableValue ( Table *, TypeInfo *, char *, TypeInfo *, uint32_t, bool ) override {
+            path.pop_back();
+        }
+        virtual void beforeVariant ( char * ps, TypeInfo * ti ) override {
+            int32_t fidx = *((int32_t *)ps);
+            path.emplace_back(PathChunk(fidx,ti));
+        }
+        virtual void afterVariant ( char *, TypeInfo * ) override {
+            path.pop_back();
+        }
+    };
+
     LineInfo rtti_get_line_info ( int depth, Context * context, LineInfoArg * at );
 
     vec4f builtin_verify_locks ( Context & context, SimNode_CallBase * node, vec4f * args ) {
@@ -68,7 +237,15 @@ namespace das
         }
         if ( failed ) {
             LineInfo atProblem = rtti_get_line_info(1,&context,(LineInfoArg *) &node->debugInfo);
-            context.throw_error_at(&atProblem, "object <%s> contains locked elements and can't be resized", debug_type(typeInfo).c_str());
+            string errorPath;
+            {
+                LockErrorReporter reporter;
+                reporter.walk(value,typeInfo);
+                reporter.collectPath();
+                errorPath = reporter.pathStr;
+            }
+            context.throw_error_at(&atProblem, "object type<%s>%s contains locked elements and can't be modified (resized, pushed to, erased from, cleared, deleted, moved, or returned via move)",
+                debug_type(typeInfo).c_str(), errorPath.c_str());
         }
         return v_zero();
     }


### PR DESCRIPTION
```
struct Foo
	a : array<int>

struct Bar
	b : array<Foo>

def fail_field
	var a <- [[Foo a <- [1,2,3,4] ]]
	for b in a.a
		return <- a	// EXCEPTION: object type<Foo>.a contains locked elements and can't be modified (resized, pushed to, erased from, cleared, deleted, moved, or returned via move)
	return <- a

def fail_array_index
	var b : Bar
	b.b |> emplace ( [[Foo a <- [1,2,3,4] ]] )
	for a in b.b[0].a
		return <- b	// EXCEPTION: object type<Bar>.b[0].a contains locked elements and can't be modified (resized, pushed to, erased from, cleared, deleted, moved, or returned via move)
	return <- b

def fail_tuple_index
	var b : tuple<Foo>
	b._0 <- [[Foo a <- [1,2,3,4] ]]
	for a in b._0.a
		return <- b	// EXCEPTION: object type<tuple<Foo>>._0.a contains locked elements and can't be modified (resized, pushed to, erased from, cleared, deleted, moved, or returned via move)
	return <- b

def fail_variant
	var b : variant<b:Foo>
	b as b <- [[Foo a <- [1,2,3,4] ]]
	for a in (b as b).a
		return <- b // EXCEPTION: object type<variant<b:Foo>> as b.a contains locked elements and can't be modified (resized, pushed to, erased from, cleared, deleted, moved, or returned via move)
	return <- b
```