### PR TITLE
function-like named tuple initialization

### DIFF
--- a/examples/test/misc/hello_world.das
+++ b/examples/test/misc/hello_world.das
@@ -189,11 +189,13 @@ tuple Tup {
 
 [export]
 def test_tuples {
-	let a : tuple<int;float;string> = (1,2.,"3");
-	let b : tuple<int;float;string> = tuple(1,2.,"3");
-	let c : tuple<int;float;string> = tuple<Tup>(a=1,b=2.,c="3");
-	let e : tuple<int;float;string> = tuple<Tup>(uninitialized a=1);	// a=1,b=0.0,c=""
-	let f : tuple<int;float;string>* = new tuple(1,2.,"3");	// on heap
+	let a : tuple<int;float;string> = (1,2.,"3");	debug(a);
+	let b : tuple<int;float;string> = tuple(1,2.,"3");	debug(b);
+	let c : tuple<int;float;string> = Tup(1,2.,"3");	debug(c);
+	let d : tuple<int;float;string> = Tup(a=1,b=2.,c="3");	debug(d);
+	let e : tuple<int;float;string> = tuple<Tup>(a=1,b=2.,c="3");	debug(e);
+	let f : tuple<int;float;string> = tuple<Tup>(uninitialized a=1);	debug(f);	// a=1,b=0.0,c=""
+	let g : tuple<int;float;string>* = new tuple(1,2.,"3");	debug(g); // on heap
 }
 
 ///////////

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -8154,7 +8154,20 @@ namespace das {
                 ecast->reinterpret = true;
                 ecast->alwaysSafe = true;
                 expr->aliasSubstitution.reset();
+                reportAstChanged();
                 return ecast;
+            }
+            if ( !expr->func ) {
+                auto aliasT = findAlias(expr->name);
+                if ( aliasT && aliasT->isTuple() ) {
+                    auto mkt = make_smart<ExprMakeTuple>(expr->at);
+                    mkt->type = make_smart<TypeDecl>(*aliasT);
+                    for ( auto & arg : expr->arguments ) {
+                        mkt->values.push_back(arg->clone());
+                    }
+                    reportAstChanged();
+                    return mkt;
+                }
             }
             if ( func && !expr->func && func->isClassMethod && func->arguments.size()>=1 ) {
                 auto bt = func->arguments[0]->type;


### PR DESCRIPTION
```
tuple Tup {
	a : int;
	b : float;
	c : string;
}
let c : tuple<int;float;string> = Tup(1,2.,"3");
```
in both syntaxes