### PR TITLE
allow substitute

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -9097,7 +9097,7 @@ namespace das {
                     error("unknown value type", "", "",
                         expr->at, CompilationError::invalid_type);
                     return Visitor::visit(expr);
-                } else if ( !expr->recordType->isSameType(*(eval->type),RefMatters::no,ConstMatters::no,TemporaryMatters::no,AllowSubstitute::no) ) {
+                } else if ( !expr->recordType->isSameType(*(eval->type),RefMatters::no,ConstMatters::no,TemporaryMatters::no,AllowSubstitute::yes) ) {
                     error("incompatible value type. expecting " + describeType(expr->recordType) + " vs " + describeType(eval->type), "", "",
                         eval->at, CompilationError::invalid_type);
                     return Visitor::visit(expr);


### PR DESCRIPTION
```
class A
class B : A
[export]
def test()
    var b <- [{A? [1] new B()}] // ok
    var c <- [{A? [] new B()}] // ok
    var a <- array<A?>(new B()) // now compatible
    var d <- [{A ? new B()}] // now compatible
```