### PR TITLE
cast for single element array making

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -9111,6 +9111,11 @@ namespace das {
                         mkt->recordType = make_smart<TypeDecl>(*expr->recordType);
                         mkt->makeType.reset();
                     }
+                    if ( !expr->recordType->isSameType(*(eval->type),RefMatters::no,ConstMatters::no,TemporaryMatters::no,AllowSubstitute::no) ) { // disable substitue
+                        // we need a cast
+                        auto cast = make_smart<ExprCast>(expr->at, resExpr, make_smart<TypeDecl>(*expr->recordType));
+                        resExpr = cast;
+                    }
                     return resExpr;
                 }
             }


### PR DESCRIPTION
```
class A
class B : A
[export]
def test()
    var a : array<A?> <- array<A?>(new B()) 
    var d : array<A?> <- [{A ? new B()}] 
```
now ok, because
```
  var a : array<A?> <- to_array_move(cast<A?> new B)
```