### PR TITLE
allow relaxed assignment syntax

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1418,7 +1418,8 @@ namespace das
         bool rtti = false;                              // create extended RTTI
     // language
         bool version_2_syntax = false;                  // use syntax version 2
-        bool gen2_make_syntax = false;                   // only new make syntax is allowed (no [[...]] or [{...}])
+        bool gen2_make_syntax = false;                  // only new make syntax is allowed (no [[...]] or [{...}])
+        bool relaxed_assign = true;                     // allow = to <- substitution, in certain expressions
         bool no_unsafe = false;
         bool local_ref_is_unsafe = true;                // var a & = ... unsafe. should be
         bool no_global_variables = false;

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -719,6 +719,7 @@ namespace das {
         // language
             addField<DAS_BIND_MANAGED_FIELD(version_2_syntax)>("version_2_syntax");
             addField<DAS_BIND_MANAGED_FIELD(gen2_make_syntax)>("gen2_make_syntax");
+            addField<DAS_BIND_MANAGED_FIELD(relaxed_assign)>("relaxed_assign");
             addField<DAS_BIND_MANAGED_FIELD(no_unsafe)>("no_unsafe");
             addField<DAS_BIND_MANAGED_FIELD(local_ref_is_unsafe)>("local_ref_is_unsafe");
             addField<DAS_BIND_MANAGED_FIELD(no_global_variables)>("no_global_variables");


### PR DESCRIPTION
```
def return_array
	return [1,2,3,4]    // auto-promotion to return <-
var q = [1,2,3,4]          // auto-promotion to q <- 
[export]
def main
	var a = [1,2,3,4]		// allowing auto-promotion to a <-
	a = [5,6,7,8]			// allowing auto-promotion to a <-
	var blk = $ <|
		return [1,2,3,4]	       // allowing auto-promotion to return <-
```