### PR TITLE
relocated variables can be uninitialized

### DIFF
--- a/src/ast/ast_allocate_stack.cpp
+++ b/src/ast/ast_allocate_stack.cpp
@@ -804,6 +804,7 @@ namespace das {
                         }
                     }
                     auto elet = static_pointer_cast<ExprLet>(expr->clone());
+                    elet->alwaysSafe = true;
                     elet->variables = std::move(expr->variables);
                     for ( auto & evar : elet->variables ) {
                         evar->init = nullptr;


### PR DESCRIPTION
```
struct Foo
    a : int = 10

def get() : Foo
    return <- Foo()

[export]
def test(a : int?)
    if a == null
        return
    var inscope foo <- get() // this one gets relocated on top of the block as uninitialized variable
    debug(foo)
```