### PR TITLE
unaligned interop for the languages which do not support vec4f abi

### DIFF
--- a/examples/tutorial/CMakeLists.txt
+++ b/examples/tutorial/CMakeLists.txt
@@ -128,6 +128,11 @@ ${CMAKE_SOURCE_DIR}/examples/tutorial/tutorial07.das
 )
 DAS_TUTORIAL(tutorial07 "${TUTORIAL_07_SRC}")
 
+SET(TUTORIAL_07_UNALIGNED_SRC
+${CMAKE_SOURCE_DIR}/examples/tutorial/tutorial07unaligned.c
+)
+DAS_TUTORIAL(tutorial07unaligned "${TUTORIAL_07_UNALIGNED_SRC}")
+
 # "C" interface, loading from source file text
 SET(TUTORIAL_07A_SRC
 ${CMAKE_SOURCE_DIR}/examples/tutorial/tutorial07a.c

--- a/examples/tutorial/tutorial07.das
+++ b/examples/tutorial/tutorial07.das
@@ -3,6 +3,10 @@ options log
 require tutorial_07
 
 [export]
+def take_2 ( a : int; b : float )
+    print("take_2 a = {a} b = {b}\n")
+
+[export]
 def test
     print("this tutorial implements C interfaces\n")
     das_c_func(13)

--- a/examples/tutorial/tutorial07unaligned.c
+++ b/examples/tutorial/tutorial07unaligned.c
@@ -1,0 +1,140 @@
+#include <stdio.h>
+#include <string.h>
+#include <stddef.h>
+#include <assert.h>
+
+#include "daScript/daScriptC.h"
+
+#define TUTORIAL_NAME   "/examples/tutorial/tutorial07.das"
+
+void tutorial () {
+    das_text_writer * tout = das_text_make_printer();               // output stream for all compiler messages (stdout. for stringstream use TextWriter)
+    das_module_group * dummyLibGroup = das_modulegroup_make();      // module group for compiled program
+    das_file_access * fAccess = das_fileaccess_make_default();      // default file access
+    das_context * ctx = NULL;
+    // get path to tutorial
+    char fileName[256];
+    das_get_root(fileName, sizeof(fileName));
+    int charsLeft = ((int)sizeof(fileName)) - ((int)strlen(fileName)) - 1;
+    assert(charsLeft>=0 && "fileName buffer is too small ");
+    strncat ( fileName, TUTORIAL_NAME, (size_t)charsLeft);
+    // compile program
+    das_program * program = das_program_compile(fileName, fAccess, tout, dummyLibGroup);
+    int err_count = das_program_err_count(program);
+    if ( err_count ) {
+        // if compilation failed, report errors
+        das_text_output(tout, "failed to compile\n");
+        for ( int ei=0; ei!=err_count; ++ei ) {
+            das_error * error = das_program_get_error(program, ei);
+            das_error_output(error, tout);
+        }
+        goto shutdown;
+    }
+    // create daScript context
+    ctx = das_context_make(das_program_context_stack_size(program));
+    if ( !das_program_simulate(program,ctx,tout) ) {
+        // if interpretation failed, report errors
+        das_text_output(tout, "failed to simulate\n");
+        err_count = das_program_err_count(program);
+        for ( int ei=0; ei!=err_count; ++ei ) {
+            das_error * error = das_program_get_error(program, ei);
+            das_error_output(error, tout);
+        }
+
+        goto shutdown;
+    }
+    // find function 'test' in the context
+    das_function * fnTest = das_context_find_function(ctx,"test");
+    if ( !fnTest ) {
+        das_text_output(tout, "function 'test' not found\n");
+        goto shutdown;
+    }
+    // evaluate 'test' function in the context
+    vec4f_unaligned result;
+    das_context_eval_with_catch_unaligned(ctx, fnTest, NULL, 0, &result);
+    char * ex = das_context_get_exception(ctx);
+    if ( ex!=NULL ) {
+        das_text_output(tout, "exception: ");
+        das_text_output(tout, ex);
+        das_text_output(tout, "\n");
+        goto shutdown;
+    }
+
+    // find function 'take_2' in the context
+    das_function * fnTake2 = das_context_find_function(ctx,"take_2");
+    if ( !fnTake2 ) {
+        das_text_output(tout, "function 'take_2' not found\n");
+        goto shutdown;
+    }
+    // evaluate 'take_2' function in the context
+    vec4f_unaligned args[2];
+    das_result_int_unaligned(args + 0, 42);
+    das_result_float_unaligned(args + 1, 3.14);
+    das_context_eval_with_catch_unaligned(ctx, fnTake2, args, 2, &result);
+    ex = das_context_get_exception(ctx);
+    if ( ex!=NULL ) {
+        das_text_output(tout, "exception: ");
+        das_text_output(tout, ex);
+        das_text_output(tout, "\n");
+        goto shutdown;
+    }
+shutdown:;
+    das_program_release(program);
+    das_fileaccess_release(fAccess);
+    das_modulegroup_release(dummyLibGroup);
+    das_text_release(tout);
+}
+
+// this is test function
+void das_c_func ( das_context * ctx, das_node * node, vec4f_unaligned * args, vec4f_unaligned * result ) {
+    (void)ctx; (void)node;
+    printf("from das_c_func(%i)\n", das_argument_int_unaligned(args + 0));      // access argument
+    das_result_void_unaligned(result);                                          // return result
+}
+
+typedef struct {
+    int     foo;
+    float   bar;
+} FooBar;
+
+typedef enum {
+    OneTwo_one = 1,
+    OneTwo_two = 2
+} OneTwo;
+
+das_module * register_module_tutorial_07() {
+    // create module and library
+    das_module * mod = das_module_create ("tutorial_07");
+    das_module_group * lib = das_modulegroup_make();
+    das_modulegroup_add_module(lib, mod);
+    // alias
+    das_module_bind_alias (mod, lib, "intarray", "1<i>A" );
+    // enumeration
+    das_enumeration * en = das_enumeration_make("OneTwo", "OneTwo", 1);
+    das_enumeration_add_value(en, "one", "OneTwo_one", OneTwo_one);
+    das_enumeration_add_value(en, "two", "OneTwo_two", OneTwo_two);
+    das_module_bind_enumeration(mod, en);
+    // handled structure
+    das_structure * st = das_structure_make(lib, "FooBar", "FooBar", sizeof(FooBar), _Alignof(FooBar));
+    das_structure_add_field(st, mod, lib, "foo", "foo", offsetof(FooBar,foo), "i");
+    das_structure_add_field(st, mod, lib, "bar", "bar", offsetof(FooBar,bar), "f");
+    das_module_bind_structure(mod, st);
+    // bind das_c_func
+    das_module_bind_interop_function_unaligned(mod, lib, &das_c_func, "das_c_func", "das_c_func", SIDEEFFECTS_modifyExternal, "v i");
+    // cleanup
+    das_modulegroup_release(lib);
+    return mod;
+}
+
+int main( int argc, char ** argv ) {
+    (void)argc; (void)argv;
+    // Initialize all default modules
+    das_initialize();
+    // register modules
+    register_module_tutorial_07();
+    // run the tutorial
+    tutorial();
+    // shut-down daScript, free all memory
+    das_shutdown();
+    return 0;
+}

--- a/include/daScript/daScriptC.h
+++ b/include/daScript/daScriptC.h
@@ -59,7 +59,13 @@ typedef struct dasNode das_node;
 typedef struct dasStructure das_structure;
 typedef struct dasEnumeration das_enumeration;
 
+typedef struct {
+    float x, y, z, w;
+} vec4f_unaligned;
+
 typedef vec4f (das_interop_function) ( das_context * ctx, das_node * node, vec4f * arguments );
+
+typedef void (das_interop_function_unaligned) ( das_context * ctx, das_node * node, vec4f_unaligned * arguments, vec4f_unaligned * result );
 
 void das_initialize();
 void das_shutdown();
@@ -94,6 +100,7 @@ das_context * das_context_make ( int stackSize );
 void das_context_release ( das_context * context );
 das_function * das_context_find_function ( das_context * context, char * name );
 vec4f das_context_eval_with_catch ( das_context * context, das_function * fun, vec4f * arguments );
+void das_context_eval_with_catch_unaligned ( das_context * context, das_function * fun, vec4f_unaligned * arguments, int narguments, vec4f_unaligned * result );
 char * das_context_get_exception ( das_context * context );
 
 das_structure * das_structure_make ( das_module_group * lib, const char * name, const char * cppname, int sz, int al );
@@ -104,6 +111,7 @@ void das_enumeration_add_value ( das_enumeration * enu, const char * name, const
 
 das_module * das_module_create ( char * name );
 void das_module_bind_interop_function ( das_module * mod, das_module_group * lib, das_interop_function * fun, char * name, char * cppName, uint32_t sideffects, char* args );
+void das_module_bind_interop_function_unaligned ( das_module * mod, das_module_group * lib, das_interop_function_unaligned * fun, char * name, char * cppName, uint32_t sideffects, char* args );
 void das_module_bind_alias ( das_module * mod, das_module_group * lib, char * aname, char * tname );
 void das_module_bind_structure ( das_module * mod, das_structure * st );
 void das_module_bind_enumeration ( das_module * mod, das_enumeration * en );
@@ -114,12 +122,25 @@ double das_argument_double ( vec4f arg );
 char * das_argument_string ( vec4f arg );
 void * das_argument_ptr ( vec4f arg );
 
+int das_argument_int_unaligned ( vec4f_unaligned * arg );
+float das_argument_float_unaligned ( vec4f_unaligned * arg );
+double das_argument_double_unaligned ( vec4f_unaligned * arg );
+char * das_argument_string_unaligned ( vec4f_unaligned * arg );
+void * das_argument_ptr_unaligned ( vec4f_unaligned * arg );
+
 vec4f das_result_void ();
 vec4f das_result_int ( int r );
 vec4f das_result_float ( float r );
 vec4f das_result_double ( double r );
 vec4f das_result_string ( char * r );
 vec4f das_result_ptr ( void * r );
+
+void das_result_void_unaligned ( vec4f_unaligned * result );
+void das_result_int_unaligned ( vec4f_unaligned * result, int r );
+void das_result_float_unaligned ( vec4f_unaligned * result, float r );
+void das_result_double_unaligned ( vec4f_unaligned * result, double r );
+void das_result_string_unaligned ( vec4f_unaligned * result, char * r );
+void das_result_ptr_unaligned ( vec4f_unaligned * result, void * r );
 
 #ifdef __cplusplus
 }

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -33,6 +33,35 @@ namespace das {
         das_interop_function * fn;
     };
 
+    struct SimNode_CFuncCall_Unaligned : SimNode_ExtFuncCallBase {
+        SimNode_CFuncCall_Unaligned ( const LineInfo & at, const char * fnName, das_interop_function_unaligned * FN )
+            : SimNode_ExtFuncCallBase(at,fnName) { fn = FN; }
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
+            DAS_PROFILE_NODE
+            vec4f * args = (vec4f *)(alloca(nArguments * sizeof(vec4f)));
+            evalArgs(context, args);
+            vec4f result;
+            (*fn)((das_context *)&context,(das_node *)this,(vec4f_unaligned *)args,(vec4f_unaligned *)&result);
+            return result;
+        }
+        das_interop_function_unaligned * fn;
+    };
+
+    class CFunction_Unaligned : public BuiltInFunction {
+    public:
+        __forceinline CFunction_Unaligned(const char * name, const ModuleLibrary &, const char * cppName, das_interop_function_unaligned * FN )
+            : BuiltInFunction(name,cppName) {
+            this->callBased = true;
+            this->interopFn = true;
+            fn = FN;
+        }
+        virtual SimNode * makeSimNode ( Context & context, const vector<ExpressionPtr> & ) override {
+            const char * fnName = context.code->allocateName(this->name);
+            return context.code->makeNode<SimNode_CFuncCall_Unaligned>(BuiltInFunction::at,fnName,fn);
+        }
+        das_interop_function_unaligned * fn;
+    };
+
     struct CStructureAnnotation : BasicStructureAnnotation {
         uint32_t    sizeOf = 0;
         uint32_t    alignOf = 0;
@@ -186,6 +215,23 @@ das_function * das_context_find_function ( das_context * context, char * name ) 
     return (das_function *) ((Context *)context)->findFunction(name);
 }
 
+void das_context_eval_with_catch_unaligned ( das_context * context, das_function * fun, vec4f_unaligned * arguments, int narguments, vec4f_unaligned * result ) {
+    vec4f * args = nullptr;
+    if ( narguments ) {
+        if ( intptr_t(arguments) & 0xf ) {
+            args = (vec4f *) alloca(narguments * sizeof(vec4f));
+            DAS_ASSERT((intptr_t(args) & 0xf) == 0);
+            for ( int i=0; i!=narguments; ++i ) {
+                args[i] = v_ldu((const float *)(arguments + i));
+            }
+        } else {
+            args = (vec4f *) arguments;
+        }
+    }
+    vec4f res = ((Context *)context)->evalWithCatch((SimFunction *)fun,args);
+    v_stu((float *)result, res);
+}
+
 vec4f das_context_eval_with_catch ( das_context * context, das_function * fun, vec4f * arguments ) {
     return ((Context *)context)->evalWithCatch((SimFunction *)fun,(vec4f *)arguments);
 }
@@ -211,6 +257,21 @@ das_module * das_module_create ( char * name ) {
 
 void das_module_bind_interop_function ( das_module * mod, das_module_group * lib, das_interop_function * fun, char * name, char * cppName, uint32_t sideffects, char* args ) {
     auto fn = make_smart<CFunction>(name, *(ModuleLibrary *)lib, cppName, fun);
+    fn->setSideEffects((das::SideEffects) sideffects);
+    vector <TypeDeclPtr> arguments;
+    MangledNameParser parser;
+    const char * arg = args;
+    while ( *arg ) {
+        auto tt = parser.parseTypeFromMangledName(arg, *(ModuleLibrary*)lib,(Module *)mod);
+        arguments.push_back(tt);
+        while (*arg==' ') arg ++;
+    }
+    fn->constructInterop(arguments);
+    ((Module *)mod)->addFunction(fn, false);
+}
+
+void das_module_bind_interop_function_unaligned ( das_module * mod, das_module_group * lib, das_interop_function_unaligned * fun, char * name, char * cppName, uint32_t sideffects, char* args ) {
+    auto fn = make_smart<CFunction_Unaligned>(name, *(ModuleLibrary *)lib, cppName, fun);
     fn->setSideEffects((das::SideEffects) sideffects);
     vector <TypeDeclPtr> arguments;
     MangledNameParser parser;
@@ -278,5 +339,19 @@ vec4f das_result_float ( float r ) { return cast<float>::from(r); }
 vec4f das_result_double ( double r ) { return cast<double>::from(r); }
 vec4f das_result_string ( char * r ) { return cast<char *>::from(r); }
 vec4f das_result_ptr ( void * r ) { return cast<void *>::from(r); }
+
+int das_argument_int_unaligned ( vec4f_unaligned * arg ) { return cast<int>::to(v_ldu((const float *)arg)); }
+float das_argument_float_unaligned ( vec4f_unaligned * arg ) { return cast<float>::to(v_ldu((const float *)arg)); }
+double das_argument_double_unaligned ( vec4f_unaligned * arg ) { return cast<double>::to(v_ldu((const float *)arg)); }
+char * das_argument_string_unaligned ( vec4f_unaligned * arg ) { char * a = cast<char *>::to(v_ldu((const float *)arg)); return a ? a : ((char *)""); }
+void * das_argument_ptr_unaligned ( vec4f_unaligned * arg ) { return cast<void *>::to(v_ldu((const float *)arg)); }
+
+void das_result_void_unaligned ( vec4f_unaligned * result ) { v_stu((float *)result, v_zero()); }
+void das_result_int_unaligned ( vec4f_unaligned * result, int r ) { v_stu((float *)result, cast<int>::from(r)); }
+void das_result_float_unaligned ( vec4f_unaligned * result, float r ) { v_stu((float *)result, cast<float>::from(r)); }
+void das_result_double_unaligned ( vec4f_unaligned * result, double r ) { v_stu((float *)result, cast<double>::from(r)); }
+void das_result_string_unaligned ( vec4f_unaligned * result, char * r ) { v_stu((float *)result, cast<char *>::from(r)); }
+void das_result_ptr_unaligned ( vec4f_unaligned * result, void * r ) { v_stu((float *)result, cast<void *>::from(r)); }
+
 
 }


### PR DESCRIPTION
in some languages vec4f is not part of the C interop ABI.
use _unaligned version of the interfaces of those. 
some performance penalties may happen if arguments are not aligned.