### PR TITLE
Rework dasException

### DIFF
--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -203,16 +203,12 @@ namespace das
     } }
 
 #if DAS_ENABLE_EXCEPTIONS
-    class dasException final : public std::exception {
+    class dasException final : public std::runtime_error {
     public:
         dasException ( const char * why, const LineInfo & at )
-            : exceptionAt(at), exceptionWhat(why) {}
-        virtual char const* what() const noexcept override {
-            return exceptionWhat ? exceptionWhat : "unknown exception";
-        }
+            : exceptionAt(at), std::runtime_error(why) {}
     public:
         LineInfo exceptionAt;
-        const char * exceptionWhat = nullptr;
     };
 #endif
 

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -203,12 +203,16 @@ namespace das
     } }
 
 #if DAS_ENABLE_EXCEPTIONS
-    class dasException final : public std::runtime_error {
+    class dasException final : public std::exception {
     public:
         dasException ( const char * why, const LineInfo & at )
-            : exceptionAt(at), std::runtime_error(why) {}
+            : exceptionAt(at), exceptionWhat(why ? why : "") {}
+        virtual char const* what() const noexcept override {
+            return exceptionWhat.empty() ? "unknown exception" : exceptionWhat.c_str();
+        }
     public:
         LineInfo exceptionAt;
+        std::string exceptionWhat;
     };
 #endif
 


### PR DESCRIPTION
There a problem with exception if we catch it outside of das::Context scope we can get broken memory for 'what' pointer due the fact we storage exception message inside das::Context and put only pointer to exception

Because of that i would like to copy exception message to dasException I decide to use runtime_error, because:
`It reports errors that are due to events beyond the scope of the program and cannot be easily predicted.`