### PR TITLE
const correctness for lambda fields. better error reporting

### DIFF
--- a/examples/test/compilation_fail_tests/const_ref.das
+++ b/examples/test/compilation_fail_tests/const_ref.das
@@ -2,11 +2,12 @@ require UnitTest
 
 // expect 30102     // once we disable relaxed_pointer_const, we can't pass const to non-const
 expect 30106
-expect 30303:4    // operator_not_found
+expect 30303:1    // operator_not_found
 expect 30304:2    // function_not_found
 expect 30504:5    // cant_write_to_const
 expect 30505:2    // cant_move_to_const
-expect 30507      // cant_copy
+expect 30507:3    // cant_copy
+expect 30508:1    // cant_move
 
 def const_iter(var a:table<string;int>)
     for k,v in keys(a),values(a)

--- a/tests/language/named_call.das
+++ b/tests/language/named_call.das
@@ -1,4 +1,4 @@
-expect 30304:12,  30101:2
+expect 30304:12,  30101:1, 30507:1
 
 require dastest/testing_boost public
 require daslib/contracts
@@ -6,7 +6,7 @@ require daslib/contracts
 def func(a:int=1; b:int; c:int=3)
     print("{a},{b},{c}\n")
 
-def gen(a;b;c=1)
+def gen(a;b;c=1)                // that one is bellow - 30101: function argument default value type mismatch 'string const explicit' vs 'int const'
     print("{a},{b},{c}\n")
 
 [expect_any_tuple(a)]
@@ -16,13 +16,13 @@ def contract(a)
 [test]
 def test_invalid_types ( t : T? )
     func(1, [a=5, c=6])         //30304: no matching functions or generics func
-    func(1,1,1, [a=5, b=6])     
+    func(1,1,1, [a=5, b=6])
     func(1,1,1,1, [a=5, b=6])   //30304: no matching functions or generics func
     func(3, [a=5, b=6])
     func(3, [b=6])
     func(3, [a=5])              //30304: no matching functions or generics func
     func("hello", [a=5, b=6])   //30304: no matching functions or generics func
-    1 |> func(1,1, [b=6]) 
+    1 |> func(1,1, [b=6])
     "hello" |> func([a=5, b=6]) //30304: no matching functions or generics func
 
     gen(1, [a=5, c=6])          //30304: no matching functions or generics gen
@@ -40,8 +40,7 @@ def test_invalid_types ( t : T? )
     gen("hello", [a=5, b=6, c="ttt"])  //30101: function argument default value type mismatch string const explicit vs int const
 
     contract(1, [a=[[auto 1,"ttt"]]]) //30304: no matching functions or generics contract
-    contract([[auto 1;"ttt"]], [a=1]) //<--(check error in infer non named argumets)
-                                      //30101: can't initialize array element 1; expecting int, passing string const 
+    contract([[auto 1;"ttt"]], [a=1]) //30507: can't initialize array element; int = string const
                                       //30304: no matching functions or generics contract ( int const )
     contract([[auto 1,"ttt"]], [a=1]) //30304: no matching functions or generics contract ( int const )
     contract([[auto 1, "ttt"]], [a=[[auto "ttt", 1]]])


### PR DESCRIPTION
relaxed_pointer_const can now be disabled in CodeOfPolicies