### PR TITLE
Add missing include to simulate.h

### DIFF
--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -213,7 +213,7 @@ namespace das
         }
     public:
         LineInfo exceptionAt;
-        std::string exceptionWhat;
+        das::string exceptionWhat;
     };
 #endif
 

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "daScript/misc/platform.h"
 #include "daScript/misc/vectypes.h"
 #include "daScript/misc/type_name.h"
 #include "daScript/misc/arraytype.h"


### PR DESCRIPTION
Simulate.h uses std::string but doesn't include it directly which causes a compilation error with fresh libstdc++. Included misc/platform.h which seems to be the way to include das_config.h which includes & defines string stuff AND changed it to be das::string.