### PR TITLE
we report mismatching functions better

### DIFF
--- a/include/daScript/simulate/runtime_string.h
+++ b/include/daScript/simulate/runtime_string.h
@@ -15,5 +15,6 @@ namespace das
         const string & fixme, CompilationError erc = CompilationError::unspecified );
     string reportError ( const char * st, uint32_t stlen, const char * fileName, int row, int col, int lrow, int lcol, int tabSize, const string & message,
         const string & extra, const string & fixme, CompilationError erc = CompilationError::unspecified );
+    int32_t levenshtein_distance ( const char * s1, const char * s2 );
 }
 

--- a/src/simulate/runtime_string.cpp
+++ b/src/simulate/runtime_string.cpp
@@ -510,6 +510,25 @@ namespace das
         }
     }
 
+    int32_t levenshtein_distance ( const char * s1, const char * s2 ) {
+        int len1 = int(strlen(s1));
+        int len2 = int(strlen(s2));
+        if ( len1==0 ) return len2;
+        if ( len2==0 ) return len1;
+        int * v0 = (int *) alloca(sizeof(int)*(len2+1));
+        int * v1 = (int *) alloca(sizeof(int)*(len2+1));
+        for ( int i=0; i<=len2; ++i ) v0[i] = i;
+        for ( int i=0; i<len1; ++i ) {
+            v1[0] = i+1;
+            for ( int j=0; j<len2; ++j ) {
+                int cost = s1[i]==s2[j] ? 0 : 1;
+                v1[j+1] = min(v1[j]+1, min(v0[j+1]+1, v0[j]+cost));
+            }
+            for ( int j=0; j<=len2; ++j ) v0[j] = v1[j];
+        }
+        return v1[len2];
+    }
+
     string to_cpp_float ( float val ) {
         if ( val==FLT_MIN ) return "FLT_MIN";
         else if ( val==-FLT_MIN ) return "(-FLT_MIN)";


### PR DESCRIPTION
```
error[30304]: no matching functions or generics: COOL(int const)
D:\Work\daScript/examples/test/misc/hello_world.das:26:1
    COOL(1);
    ^^^^
COOL(int const)
while compiling: main: void

candidate function:
        cool(a: int const): int at D:\Work\daScript/examples/test/misc/hello_world.das:20:4
                name is similar, typo?


error[30503]: can only safe dereference a pointer to a tuple, a structure or a handle UnitTest::EntityId&
D:\Work\daScript/examples/test/misc/hello_world.das:29:14
    var bar = eid?.Baz;
                 ^^
?.`Baz(UnitTest::EntityId&) or (UnitTest::EntityId&, string)
while compiling: main: void
candidates:
        operator ?.`Bar(e: UnitTest::EntityId const): int const at D:\Work\daScript/examples/test/misc/hello_world.das:8:4
                name is similar, typo?
        operator ?.`Baz(e: UnitTest::EntityId? const): int const at D:\Work\daScript/examples/test/misc/hello_world.das:12:4
                invalid argument 'e' (0). expecting 'UnitTest::EntityId? const', passing 'UnitTest::EntityId&'


error[30503]: field not found, goo
D:\Work\daScript/examples/test/misc/hello_world.das:37:18
    var a = new A(goo=13);
                  ^^^
property name foo is similar, typo?
        float const can't be initialized with int const


error[30503]: field 'goo' not found in A?
D:\Work\daScript/examples/test/misc/hello_world.das:38:10
    print("{a.goo}\n");
             ^
.`goo(A?) or (A?, string)
while compiling: f: void

candidate function:
        operator .`foo(self: A const): float at D:\Work\daScript/examples/test/misc/hello_world.das:33:14
                name is similar, typo?
                invalid argument 'self' (0). expecting 'A const', passing 'A?'
                can't pass non-ref to ref
```