### PR TITLE
bug in vector folding

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -6718,14 +6718,16 @@ namespace das {
                             if ( baseType!=Type::tInt64 && baseType!=Type::tUInt64 ) {
                                 int32_t * res = (int32_t *)&resData;
                                 int32_t * src = (int32_t *)&data;
+                                int outI = 0;
                                 for ( auto f : fields ) {
-                                    res[f] = src[f];
+                                    res[outI++] = src[f];
                                 }
                             } else {
                                 int64_t * res = (int64_t *)&resData;
                                 int64_t * src = (int64_t *)&data;
+                                int outI = 0;
                                 for ( auto f : fields ) {
-                                    res[f] = src[f];
+                                    res[outI++] = src[f];
                                 }
                             }
                             auto vecType = swz->type->getVectorType(baseType, fields.size());


### PR DESCRIPTION
```
let TILE_SIZE = int2(100);

[export]
def main
    let w = TILE_SIZE.x * 10;
    let h = TILE_SIZE.y * 10;
    print("w: {w}, h: {h}"); // was w: 1000, h: 0 !!, now w: 1000, h:1000
```