### PR TITLE
fix GCC -Wwuninitialized warning/build in TSAN mode

### DIFF
--- a/include/daScript/simulate/cast.h
+++ b/include/daScript/simulate/cast.h
@@ -342,9 +342,9 @@ namespace das
         }
         static __forceinline vec4f from ( const TT & x )       {
 #if __SANITIZE_THREAD__
-            if ( sizeof(TT) != sizeof(float) * 4 )
+            if constexpr ( sizeof(TT) != sizeof(vec4f) )
             {
-              vec4f v;
+              vec4f v = v_zero(); // Init to prevent uninitialized warnings
               memcpy(&v, &x, sizeof(x));
               return v;
             }
@@ -374,9 +374,9 @@ namespace das
         }
         static __forceinline vec4f from ( const TT & x ) {
 #if __SANITIZE_THREAD__
-            if ( sizeof(TT) != sizeof(int) * 4 )
+            if constexpr ( sizeof(TT) != sizeof(vec4f) )
             {
-              vec4f v;
+              vec4f v = v_zero(); // Init to prevent uninitialized warnings
               memcpy(&v, &x, sizeof(x));
               return v;
             }


### PR DESCRIPTION
Do init temp register as otherwise GCC 15 complains and fails to build in -Werror mode with

/usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:33: error: `v` is used uninitialized [-Werror=uninitialized]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~