### PR TITLE
lets not crash on alias derivations

### DIFF
--- a/src/ast/ast_derive_alias.cpp
+++ b/src/ast/ast_derive_alias.cpp
@@ -308,6 +308,9 @@ namespace das {
         bool isPermanent = false;
         bool isEverything = false;
     protected:
+        virtual bool canVisitStructureFieldInit ( Structure * ) override { return false; }
+        virtual bool canVisitArgumentInit ( Function * , const VariablePtr &, Expression * ) override { return false; }
+        virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
         virtual bool canVisitGlobalVariable ( Variable * var ) override {
             if ( var->aliasesResolved ) return false;
             if ( !var->used && !isEverything ) return false;


### PR DESCRIPTION
```
options gen2;

struct PlayerSetup {
    forwardSpeed : float = 1.0;
};

struct PlayerState {
    setup : PlayerSetup = PlayerSetup();
};

var player : PlayerState = PlayerState();
```