### PR TITLE
doc: support sphinx versions 7.3.0 and above

### DIFF
--- a/doc/source/daslang.py
+++ b/doc/source/daslang.py
@@ -14,10 +14,15 @@
 from docutils import nodes
 from docutils.parsers.rst import directives
 
+from sphinx import version_info
+
 from sphinx import addnodes
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
-from sphinx.domains.python import _pseudo_parse_arglist
+if version_info >= (7, 3, 0):
+    from sphinx.domains.python._annotations import _pseudo_parse_arglist
+else:
+    from sphinx.domains.python import _pseudo_parse_arglist
 from sphinx.locale import _
 from sphinx.roles import XRefRole
 from sphinx.util.docfields import Field, GroupedField, TypedField
@@ -114,9 +119,8 @@ class DASObject(ObjectDescription):
             objects = self.env.domaindata['das']['objects']
             if fullname in objects:
                 self.state_machine.reporter.warning(
-                    'duplicate object description of %s, ' % fullname +
-                    'other instance in ' +
-                    self.env.doc2path(objects[fullname][0]),
+                    f'duplicate object description of {fullname}, ' +
+                    f'other instance in {self.env.doc2path(objects[fullname][0])}',
                     line=self.lineno)
             objects[fullname] = self.env.docname, self.objtype
 


### PR DESCRIPTION
sphinx rearranged code for python domain splitting it into smaller parts, so versions newer or equal 7.3.0 have this function in different place. Dagor has moved to sphinx 8+ for documentation and we need this change.

Sphinx8 has mostly deprecated string-like paths and is now (almost everywhere) using PathLike objects for which addition with strings is not possible, so f-strings are now required