### PR TITLE
fix c++20 string formatting

### DIFF
--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -405,11 +405,11 @@ extern "C" {
         }
 
         #if defined(_WIN32) || defined(_WIN64)
-            auto result = fmt::format_to(cmd, "clang-cl {} {} -link -DLL -OUT:{} 2>&1", objFilePath, jitModuleObj, libraryName);
+            auto result = fmt::format_to(cmd, FMT_STRING("clang-cl {} {} -link -DLL -OUT:{} 2>&1"), objFilePath, jitModuleObj, libraryName);
         #elif defined(__APPLE__)
-            auto result = fmt::format_to(cmd, "clang -shared -o {} {} {} 2>&1", libraryName, objFilePath, jitModuleObj);
+            auto result = fmt::format_to(cmd, FMT_STRING("clang -shared -o {} {} {} 2>&1"), libraryName, objFilePath, jitModuleObj);
         #else
-            auto result = fmt::format_to(cmd, "gcc -shared -o {} {} {} 2>&1", libraryName, objFilePath, jitModuleObj);
+            auto result = fmt::format_to(cmd, FMT_STRING("gcc -shared -o {} {} {} 2>&1"), libraryName, objFilePath, jitModuleObj);
         #endif
             *result = '\0';
 

--- a/src/simulate/runtime_string.cpp
+++ b/src/simulate/runtime_string.cpp
@@ -169,9 +169,9 @@ namespace das
         char buffer[128];
         char * result;
         if ( hex ) {
-            result = fmt::format_to(buffer,"{:#x}",x);
+            result = fmt::format_to(buffer,FMT_STRING("{:#x}"),x);
         } else {
-            result = fmt::format_to(buffer,"{}",x);
+            result = fmt::format_to(buffer,FMT_STRING("{}"),x);
         }
         *result = 0;
         return __context__->allocateString(buffer,uint32_t(result-buffer),at);
@@ -205,7 +205,7 @@ namespace das
     template <typename TT>
     __forceinline char * das_lexical_cast_fp_T ( TT x, Context * __context__, LineInfoArg * at ) {
         char buffer[128];
-        auto result = fmt::format_to(buffer,"{}",x);
+        auto result = fmt::format_to(buffer,FMT_STRING("{}"),x);
         *result = 0;
         return __context__->allocateString(buffer,uint32_t(result-buffer),at);
     }
@@ -504,7 +504,7 @@ namespace das
         else if ( val==-DBL_MAX ) return "(-DBL_MAX)";
         else {
             char buf[256];
-            auto result = fmt::format_to(buf, "{:e}", val);
+            auto result = fmt::format_to(buf, FMT_STRING("{:e}"), val);
             *result = 0;
             return buf;
         }
@@ -536,7 +536,7 @@ namespace das
         else if ( val==-FLT_MAX ) return "(-FLT_MAX)";
         else {
             char buf[256];
-            auto result = fmt::format_to(buf, "{:e}f", val);
+            auto result = fmt::format_to(buf, FMT_STRING("{:e}f"), val);
             *result = 0;
             return buf;
         }

--- a/src/simulate/simulate.cpp
+++ b/src/simulate/simulate.cpp
@@ -1905,7 +1905,7 @@ namespace das
                     char total[20];
                     if ( fi->profileData.size()>size_t(line) && fi->profileData[line] ) {
                         uint64_t samples = fi->profileData[line];
-                        auto result = fmt::format_to(total, "{:6.2f}", samples*100.0/totalGoo); *result = 0;
+                        auto result = fmt::format_to(total, FMT_STRING("{:6.2f}"), samples*100.0/totalGoo); *result = 0;
                         tout << total;
                     } else {
                         tout << "      ";

--- a/src/simulate/simulate_visit.cpp
+++ b/src/simulate/simulate_visit.cpp
@@ -825,7 +825,7 @@ namespace das {
             for ( uint32_t i=0, is=totalLabels; i!=is; ++i ) {
                 if ( labels[i]!=-1U ) {
                     char name[32];
-                    auto result = fmt::format_to(name, "label_{}", i);
+                    auto result = fmt::format_to(name, FMT_STRING("label_{}"), i);
                     *result = 0;
                     vis.arg(labels[i], name);
                 }
@@ -940,12 +940,12 @@ namespace das {
     SimNode * SimNode_ForBase::visitFor ( SimVisitor & vis, int totalC, const char * loopName ) {
         char nbuf[32];
         V_BEGIN_CR();
-        auto result = fmt::format_to(nbuf, "{}_{}", loopName, total); *result = 0;
+        auto result = fmt::format_to(nbuf, FMT_STRING("{}_{}"), loopName, total); *result = 0;
         vis.op(nbuf);
         for ( int t=0; t!=totalC; ++t ) {
-            result = fmt::format_to(nbuf, "stackTop[{}]", t); *result = 0;
+            result = fmt::format_to(nbuf, FMT_STRING("stackTop[{}]"), t); *result = 0;
             vis.sp(stackTop[t],nbuf);
-            result = fmt::format_to(nbuf, "strides[{}]", t); *result = 0;
+            result = fmt::format_to(nbuf, FMT_STRING("strides[{}]"), t); *result = 0;
             vis.arg(strides[t],nbuf);
             sources[t] = vis.sub(sources[t]);
         }
@@ -957,10 +957,10 @@ namespace das {
     SimNode * SimNode_ForWithIteratorBase::visitFor ( SimVisitor & vis, int totalC ) {
         char nbuf[32];
         V_BEGIN_CR();
-        auto result = fmt::format_to(nbuf, "ForWithIterator_{}", total); *result = 0;
+        auto result = fmt::format_to(nbuf, FMT_STRING("ForWithIterator_{}"), total); *result = 0;
         vis.op(nbuf);
         for ( int t=0; t!=totalC; ++t ) {
-            result = fmt::format_to(nbuf, "stackTop[{}]", t); *result = 0;
+            result = fmt::format_to(nbuf, FMT_STRING("stackTop[{}]"), t); *result = 0;
             vis.sp(stackTop[t],nbuf);
             source_iterators[t] = vis.sub(source_iterators[t]);
         }


### PR DESCRIPTION
Wrap compile-time known string literals into `FMT_STRING` macro in order make code more portable - i.e. it would work even with absence of <string_view> header