### PR TITLE
fix DAS_AOT_INLINE_LAMBDA in clang-cl + c++20 mode

### DIFF
--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -370,7 +370,7 @@ inline size_t das_aligned_memsize(void * ptr){
 #endif
 
 #ifndef DAS_AOT_INLINE_LAMBDA
-    #ifdef _MSC_VER
+    #if defined(_MSC_VER) && !defined(__clang__)
         #if __cplusplus >= 202002L
             #define DAS_AOT_INLINE_LAMBDA [[msvc::forceinline]]
         #else


### PR DESCRIPTION
Do use `__attribute__((always_inline))` for subj macro in clang mode as it seems that `[[msvc::forceinline]]` is supported clang-cl