### PR TITLE
member variables for structures and classes can be unsafe when uninitialized.

### DIFF
--- a/examples/test/unit_tests/dummy.das
+++ b/examples/test/unit_tests/dummy.das
@@ -2,7 +2,7 @@ require UnitTest
 
 struct MyStruct
     a : int8
-    b : SomeDummyType   // { int; float }
+    @safe_when_uninitialized b : SomeDummyType   // { int; float }
 
 [export]
 def test

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -2056,6 +2056,21 @@ namespace das {
                 error("structure field type can't be declared a reference", "", "",
                     decl.at,CompilationError::invalid_structure_field_type);
             }
+
+            if ( noUnsafeUninitializedStructs && !st->isLambda && !decl.init && decl.type->unsafeInit() ) {
+                bool safeWhenUninitialized = false;
+                for ( auto & ann : decl.annotation ) {
+                    if ( ann.name=="safe_when_uninitialized" ) {
+                        safeWhenUninitialized = true;
+                        break;
+                    }
+                }
+                if ( !safeWhenUninitialized ) {
+                    error("Uninitialized field " + decl.name + " is unsafe. Use initializer syntax or @safe_when_uninitialized when intended.", "", "",
+                        decl.at, CompilationError::unsafe);
+                }
+            }
+
             if ( decl.init ) {
                 if ( decl.init->type ) {
                     if ( !canCopyOrMoveType(decl.type,decl.init->type,TemporaryMatters::yes, decl.init.get(),

--- a/tests/language/local_classes_failed.das
+++ b/tests/language/local_classes_failed.das
@@ -1,4 +1,4 @@
-expect 30104:2
+expect 31300:1
 options no_local_class_members
 
 class A


### PR DESCRIPTION
```
options gen2;
struct Foo {
    def take() {
        debug("foo")
    }
}
class Bar {
    foo : Foo // error
    foo = Foo() // ok
   @safe_when_uninitialized foo : Foo // ok
    def test() {
        foo.take()
    }
}
[export]
def main() {
    var a = new Bar()
    a.test()
}
```