### PR TITLE
do not clone_to_move workhorse types

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -7510,7 +7510,13 @@ namespace das {
                 }
             } else {
                 if ( var->init_via_clone ) {
-                    return promoteToCloneToMove(var);
+                    if ( var->init->type->isWorkhorseType() ) {
+                        var->init_via_clone = false;
+                        var->init_via_move = false;
+                        reportAstChanged();
+                    } else {
+                        return promoteToCloneToMove(var);
+                    }
                 }
             }
             return Visitor::visitLetInit(expr, var, init);


### PR DESCRIPTION
```
[export]
def main
    var a = "13"
    a += "4"
    var b := a // this is now same as b = a
    debug(b)
```