### PR TITLE
not calling default initializer is now a valid case for 'not initialized'

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -304,6 +304,7 @@ namespace das
                 bool    hasInitFields : 1;
                 bool    safeWhenUninitialized : 1;
                 bool    isTemplate : 1;
+                bool    hasDefaultInitializer : 1;
             };
             uint32_t    flags = 0;
         };

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -401,6 +401,7 @@ namespace das {
 
     bool Structure::unsafeInit ( das_set<Structure *> & dep ) const {
         if ( safeWhenUninitialized ) return false;
+        if ( hasDefaultInitializer ) return true;
         for ( const auto & fd : fields ) {
             if ( fd.init ) return true;
             if ( fd.type && fd.type->unsafeInit(dep) ) return true;

--- a/src/ast/ast_print.cpp
+++ b/src/ast/ast_print.cpp
@@ -176,6 +176,7 @@ namespace das {
         virtual void preVisit ( Structure * that ) override {
             Visitor::preVisit(that);
             logAnnotations(that->annotations);
+            if ( that->hasDefaultInitializer ) ss << "// has default initializer " << that->name << "()\n";
             if ( that->macroInterface ) ss << "[macro_interface]\n";
             if ( that->isTemplate ) ss << "template ";
             ss << (that->isClass ? "class " : "struct ");

--- a/src/builtin/module_builtin_ast_flags.cpp
+++ b/src/builtin/module_builtin_ast_flags.cpp
@@ -176,7 +176,7 @@ namespace das {
             "generated", "persistent", "isLambda", "privateStructure",
             "macroInterface", "_sealed", "skipLockCheck", "circular",
             "_generator", "hasStaticMembers", "hasStaticFunctions",
-            "hasInitFields", "safeWhenUninitialized", "isTemplate" };
+            "hasInitFields", "safeWhenUninitialized", "isTemplate", "hasDefaultInitializer" };
         return ft;
     }
 

--- a/src/parser/parser_impl.cpp
+++ b/src/parser/parser_impl.cpp
@@ -695,6 +695,9 @@ namespace das {
                     func->name = yyextra->g_thisStructure->name + "`" + yyextra->g_thisStructure->name;
                     modifyToClassMember(func, yyextra->g_thisStructure, false, false);
                     func->arguments[0]->no_capture = true;  // we can't capture self in the class c-tor
+                    if ( func->arguments.size() == 1 ) {
+                        yyextra->g_thisStructure->hasDefaultInitializer = true;
+                    }
                 } else {
                     modifyToClassMember(func, yyextra->g_thisStructure, true, false);
                 }


### PR DESCRIPTION
```
struct Foo
    a,b : int
    def Foo
        a = 1
        b = 2

struct Bar
    c : int
    d : Foo // = Foo()

[export]
def main
    var a = [[Bar() c=1]] // error[31300]: Uninitialized field d is unsafe.
    debug(a)
```