### PR TITLE
support for global variable export annotation

### DIFF
--- a/src/ast/ast_export.cpp
+++ b/src/ast/ast_export.cpp
@@ -75,10 +75,13 @@ namespace das {
             }
             pop();
         }
+        bool isVarExported ( const VariablePtr & var ) const {
+            return var->annotation.getBoolOption("export",false);
+        }
         void markVarsUsed( ModuleLibrary & lib, bool forceAll ){
             lib.foreach([&](Module * pm) {
                 for ( auto & var : pm->globals.each() ) {
-                    if ( forceAll || var->used ) {
+                    if ( forceAll || var->used || isVarExported(var) ) {
                         var->used = false;
                         propageteVarUse(var);
                     }


### PR DESCRIPTION
```
[sideeffects]
def init_with_sideeffects
    return 1

var @export a = init_with_sideeffects() // notice @export, variable is now forced to be 'used'

[export]
def main()
    print("Hello, World!\n")
```