### PR TITLE
Syntax formatter v1 v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,8 @@ FLEX(src/parser/ds_lexer.lpp)
 FLEX(src/parser/ds2_lexer.lpp)
 BISON(src/parser/ds_parser.ypp)
 BISON(src/parser/ds2_parser.ypp)
+FLEX(utils/dasFsormatter/ds_lexer.lpp)
+BISON(utils/dasFormatter/ds_parser.ypp)
 
 SET(PARSER_GENERATED_SRC
 # 1st parser
@@ -742,8 +744,10 @@ if (NOT ${DAS_TOOLS_DISABLED})
 
     SOURCE_GROUP_FILES("main" DAS_DASCRIPT_MAIN_SRC)
 
+    SET(SRC_LIBRARIES libDaScript libDaScriptTest Threads::Threads ${DAS_MODULES_LIBS})
+
     add_executable(daslang ${DAS_DASCRIPT_MAIN_SRC})
-    TARGET_LINK_LIBRARIES(daslang libDaScript libDaScriptTest Threads::Threads ${DAS_MODULES_LIBS})
+    TARGET_LINK_LIBRARIES(daslang ${SRC_LIBRARIES})
     # ADD_DEPENDENCIES(daslang libDaScript libDaScriptTest ${DAS_MODULES_LIBS})
     SETUP_CPP11(daslang)
     SETUP_LTO(daslang)
@@ -757,6 +761,25 @@ if (NOT ${DAS_TOOLS_DISABLED})
     )
     install(FILES ${DASLIB_SOURCES}
         DESTINATION ${DAS_INSTALL_DASLIBDIR}
+    )
+
+# das formatter
+    SET(DAS_DASCRIPT_FMT_SRC
+        ${PROJECT_SOURCE_DIR}/utils/dasFormatter/main.cpp
+        ${PROJECT_SOURCE_DIR}/utils/dasFormatter/formatter.cpp
+        ${PROJECT_SOURCE_DIR}/utils/dasFormatter/ds_parser.cpp
+        ${DAS_MODULES_NEED_INC}
+        CACHE INTERNAL "DAS_DASCRIPT_FMT_SRC"
+    )
+
+    add_executable(das-fmt ${DAS_DASCRIPT_FMT_SRC})
+    TARGET_LINK_LIBRARIES(das-fmt ${SRC_LIBRARIES})
+
+    SETUP_CPP11(das-fmt)
+    SETUP_LTO(das-fmt)
+
+    INSTALL(TARGETS das-fmt
+        RUNTIME DESTINATION ${DAS_INSTALL_BINDIR}
     )
 
     #IF(APPLE)

--- a/src/parser/ds_lexer.cpp
+++ b/src/parser/ds_lexer.cpp
@@ -1,6 +1,6 @@
-#line 1 "ds_lexer.cpp"
+#line 2 "ds_lexer.cpp"
 
-#line 3 "ds_lexer.cpp"
+#line 4 "ds_lexer.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1307,11 +1307,11 @@ void das_accept_cpp_comment ( vector<CommentReader *> & crdi, yyscan_t scanner, 
 
 #define YY_EXTRA_TYPE das::DasParserState *
 
-#line 1310 "ds_lexer.cpp"
+#line 1311 "ds_lexer.cpp"
 #define YY_NO_UNISTD_H 1
 /* %option debug */
 
-#line 1314 "ds_lexer.cpp"
+#line 1315 "ds_lexer.cpp"
 
 #define INITIAL 0
 #define indent 1
@@ -1595,7 +1595,7 @@ YY_DECL
 #line 76 "ds_lexer.lpp"
 
 
-#line 1598 "ds_lexer.cpp"
+#line 1599 "ds_lexer.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -3220,49 +3220,49 @@ case 200:
 /* rule 200 can match eol */
 YY_RULE_SETUP
 #line 817 "ds_lexer.lpp"
-unput(yytext[yyleng-1]); return MTAG_E;
+unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_E;
 	YY_BREAK
 case 201:
 /* rule 201 can match eol */
 YY_RULE_SETUP
 #line 818 "ds_lexer.lpp"
-unput(yytext[yyleng-1]); return MTAG_I;
+unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_I;
 	YY_BREAK
 case 202:
 /* rule 202 can match eol */
 YY_RULE_SETUP
 #line 819 "ds_lexer.lpp"
-unput(yytext[yyleng-1]); return MTAG_V;
+unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_V;
 	YY_BREAK
 case 203:
 /* rule 203 can match eol */
 YY_RULE_SETUP
 #line 820 "ds_lexer.lpp"
-unput(yytext[yyleng-1]); return MTAG_B;
+unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_B;
 	YY_BREAK
 case 204:
 /* rule 204 can match eol */
 YY_RULE_SETUP
 #line 821 "ds_lexer.lpp"
-unput(yytext[yyleng-1]); return MTAG_A;
+unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_A;
 	YY_BREAK
 case 205:
 /* rule 205 can match eol */
 YY_RULE_SETUP
 #line 822 "ds_lexer.lpp"
-unput(yytext[yyleng-1]); return MTAG_T;
+unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_T;
 	YY_BREAK
 case 206:
 /* rule 206 can match eol */
 YY_RULE_SETUP
 #line 823 "ds_lexer.lpp"
-unput(yytext[yyleng-1]); return MTAG_C;
+unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_C;
 	YY_BREAK
 case 207:
 /* rule 207 can match eol */
 YY_RULE_SETUP
 #line 824 "ds_lexer.lpp"
-unput(yytext[yyleng-1]); return MTAG_F;
+unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_F;
 	YY_BREAK
 case 208:
 YY_RULE_SETUP
@@ -3661,7 +3661,7 @@ YY_RULE_SETUP
 #line 1021 "ds_lexer.lpp"
 ECHO;
 	YY_BREAK
-#line 3664 "ds_lexer.cpp"
+#line 3665 "ds_lexer.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(include):
 	yyterminate();

--- a/src/parser/ds_lexer.lpp
+++ b/src/parser/ds_lexer.lpp
@@ -814,14 +814,14 @@ void das_accept_cpp_comment ( vector<CommentReader *> & crdi, yyscan_t scanner, 
 }
 <normal>"\<\|"                              return LPIPE;
 <normal>"\$\$"                              return MTAG_E;
-<normal>\$e([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); return MTAG_E;
-<normal>\$i([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); return MTAG_I;
-<normal>\$v([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); return MTAG_V;
-<normal>\$b([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); return MTAG_B;
-<normal>\$a([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); return MTAG_A;
-<normal>\$t([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); return MTAG_T;
-<normal>\$c([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); return MTAG_C;
-<normal>\$f([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); return MTAG_F;
+<normal>\$e([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_E;
+<normal>\$i([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_I;
+<normal>\$v([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_V;
+<normal>\$b([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_B;
+<normal>\$a([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_A;
+<normal>\$t([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_T;
+<normal>\$c([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_C;
+<normal>\$f([^a-zA-Z0-9_])                  unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_F;
 <normal>"\?\?"                              return QQ;
 <normal>"\?\["                              {
     yyextra->das_nested_square_braces ++;

--- a/src/parser/lex.yy.h
+++ b/src/parser/lex.yy.h
@@ -2,9 +2,9 @@
 #define das_yyHEADER_H 1
 #define das_yyIN_HEADER 1
 
-#line 5 "lex.yy.h"
+#line 6 "lex.yy.h"
 
-#line 7 "lex.yy.h"
+#line 8 "lex.yy.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -722,6 +722,6 @@ extern int yylex \
 #line 1021 "ds_lexer.lpp"
 
 
-#line 725 "lex.yy.h"
+#line 726 "lex.yy.h"
 #undef das_yyIN_HEADER
 #endif /* das_yyHEADER_H */

--- a/utils/daScript/dasFormatter/ds_parser.ypp
+++ b/utils/daScript/dasFormatter/ds_parser.ypp
@@ -1,0 +1,3850 @@
+%define api.prefix {das_yy}
+
+/*
+    how to write error messages (style guidelines)
+
+    1. start with lower case
+    2. no . at the end
+    3. no , before any names                    ("invalid name "+blah)
+    4. 'use' word macro for the annotation
+    5. give options where possible              ("try <- instead")
+*/
+
+%code requires {
+    #include "daScript/misc/platform.h"
+    #include "daScript/ast/ast.h"
+    #include "daScript/ast/ast_generate.h"
+    #include "daScript/ast/ast_expressions.h"
+
+    #include "parser_state.h"
+
+#if defined(_MSC_VER) && !defined(__clang__)
+    #if defined(DAS_RELWITHDEBINFO)
+        #pragma optimize( "s", on )
+    #endif
+#endif
+
+    enum {
+        CorM_COPY   = 0,
+        CorM_MOVE   = (1<<0),
+        CorM_CLONE  = (1<<1)
+    };
+
+    enum {
+        CorS_Struct = 0,
+        CorS_Class  = 1,
+        CorS_StructTemplate = 2,
+        CorS_ClassTemplate  = 3
+    };
+
+    using namespace das;
+
+    #include "parser_impl.h"
+
+    LineInfo tokAt ( yyscan_t scanner, const struct DAS_YYLTYPE & li );
+    LineInfo tokRangeAt ( yyscan_t scanner, const struct DAS_YYLTYPE & li, const struct DAS_YYLTYPE & lie );
+
+    struct TypePair {
+        TypeDecl * firstType;
+        TypeDecl * secondType;
+    };
+}
+
+%{
+    #include "daScript/misc/platform.h"
+    #include "daScript/simulate/debug_info.h"
+    #include "daScript/ast/compilation_errors.h"
+
+    #ifdef _MSC_VER
+    #pragma warning(disable:4262)
+    #pragma warning(disable:4127)
+    #pragma warning(disable:4702)
+    #endif
+
+    using namespace das;
+
+    union DAS_YYSTYPE;
+    struct DAS_YYLTYPE;
+
+    #define YY_NO_UNISTD_H
+    #include "lex.yy.h"
+
+    void das_yyerror ( DAS_YYLTYPE * lloc, yyscan_t scanner, const string & error );
+    void das_yyfatalerror ( DAS_YYLTYPE * lloc, yyscan_t scanner, const string & error, CompilationError cerr );
+    int yylex ( DAS_YYSTYPE *lvalp, DAS_YYLTYPE *llocp, yyscan_t scanner );
+    void yybegin ( const char * str );
+
+    void das_yybegin_reader ( yyscan_t yyscanner );
+    void das_yyend_reader ( yyscan_t yyscanner );
+    void das_accept_sequence ( yyscan_t yyscanner, const char * seq, size_t seqLen, int lineNo, FileInfo * info );
+
+    namespace das { class Module; }
+    void das_collect_keywords ( das::Module * mod, yyscan_t yyscanner );
+
+    #undef yyextra
+    #define yyextra (*((das::DasParserState **)(scanner)))
+%}
+
+%define api.pure full
+
+%lex-param {yyscan_t scanner}
+%parse-param {yyscan_t scanner}
+
+%locations
+%verbose
+%no-lines
+// %debug
+
+%define parse.error verbose
+
+%union {
+    char                            ch;
+    bool                            b;
+    int32_t                         i;
+    uint32_t                        ui;
+    int64_t                         i64;
+    uint64_t                        ui64;
+    double                          d;
+    double                          fd;
+    string *                        s;
+    vector<string> *                pNameList;
+    vector<VariableNameAndPosition> * pNameWithPosList;
+    VariableDeclaration *           pVarDecl;
+    vector<VariableDeclaration*> *  pVarDeclList;
+    TypeDecl *                      pTypeDecl;
+    vector<Expression *> *          pTypeDeclList;
+    Expression *                    pExpression;
+    Type                            type;
+    AnnotationArgument *            aa;
+    AnnotationArgumentList *        aaList;
+    AnnotationDeclaration *         fa;
+    AnnotationList *                faList;
+    MakeStruct *                    pMakeStruct;
+    Enumeration *                   pEnum;
+    Structure *                     pStructure;
+    Function *                      pFuncDecl;
+    CaptureEntry *                  pCapt;
+    vector<CaptureEntry> *          pCaptList;
+    TypePair                        aTypePair;
+}
+
+%destructor { delete $$; } <s>
+%destructor { delete $$; } <pNameList>
+%destructor { delete $$; } <pNameWithPosList>
+%destructor { delete $$; } <pVarDecl>
+%destructor { deleteVariableDeclarationList($$); } <pVarDeclList>
+%destructor { delete $$; } <pTypeDecl>
+%destructor { deleteTypeDeclarationList($$); } <pTypeDeclList>
+%destructor { delete $$; } <pExpression>
+%destructor { delete $$; } <aa>
+%destructor { delete $$; } <aaList>
+%destructor { delete $$; } <fa>
+%destructor { delete $$; } <faList>
+%destructor { delete $$; } <pMakeStruct>
+%destructor { if ( $$->use_count()==1 ) delete $$; } <pEnum>
+%destructor { delete $$; } <pCapt>
+%destructor { delete $$; } <pCaptList>
+%destructor { delete $$.firstType; delete $$.secondType; } <aTypePair>
+%destructor { $$->delRef(); } <pFuncDecl>
+
+%token  LEXER_ERROR         "lexer error"
+
+/* keywords */
+%token  DAS_CAPTURE         "capture"
+%token  DAS_STRUCT          "struct"
+%token  DAS_CLASS           "class"
+%token  DAS_LET             "let"
+%token  DAS_DEF             "def"
+%token  DAS_WHILE           "while"
+%token  DAS_IF              "if"
+%token  DAS_STATIC_IF       "static_if"
+%token  DAS_ELSE            "else"
+%token  DAS_FOR             "for"
+%token  DAS_CATCH           "recover"
+%token  DAS_TRUE            "true"
+%token  DAS_FALSE           "false"
+%token  DAS_NEWT            "new"
+%token  DAS_TYPEINFO        "typeinfo"
+%token  DAS_TYPE            "type"
+%token  DAS_IN              "in"
+%token  DAS_IS              "is"
+%token  DAS_AS              "as"
+%token  DAS_ELIF            "elif"
+%token  DAS_STATIC_ELIF     "static_elif"
+%token  DAS_ARRAY           "array"
+%token  DAS_RETURN          "return"
+%token  DAS_NULL            "null"
+%token  DAS_BREAK           "break"
+%token  DAS_TRY             "try"
+%token  DAS_OPTIONS         "options"
+%token  DAS_TABLE           "table"
+%token  DAS_EXPECT          "expect"
+%token  DAS_CONST           "const"
+%token  DAS_REQUIRE         "require"
+%token  DAS_OPERATOR        "operator"
+%token  DAS_ENUM            "enum"
+%token  DAS_FINALLY         "finally"
+%token  DAS_DELETE          "delete"
+%token  DAS_DEREF           "deref"
+%token  DAS_TYPEDEF         "typedef"
+%token  DAS_TYPEDECL        "typedecl"
+%token  DAS_WITH            "with"
+%token  DAS_AKA             "aka"
+%token  DAS_ASSUME          "assume"
+%token  DAS_CAST            "cast"
+%token  DAS_OVERRIDE        "override"
+%token  DAS_ABSTRACT        "abstract"
+%token  DAS_UPCAST          "upcast"
+%token  DAS_ITERATOR        "iterator"
+%token  DAS_VAR             "var"
+%token  DAS_ADDR            "addr"
+%token  DAS_CONTINUE        "continue"
+%token  DAS_WHERE           "where"
+%token  DAS_PASS            "pass"
+%token  DAS_REINTERPRET     "reinterpret"
+%token  DAS_MODULE          "module"
+%token  DAS_PUBLIC          "public"
+%token  DAS_LABEL           "label"
+%token  DAS_GOTO            "goto"
+%token  DAS_IMPLICIT        "implicit"
+%token  DAS_EXPLICIT        "explicit"
+%token  DAS_SHARED          "shared"
+%token  DAS_PRIVATE         "private"
+%token  DAS_SMART_PTR       "smart_ptr"
+%token  DAS_UNSAFE          "unsafe"
+%token  DAS_INSCOPE         "inscope"
+%token  DAS_STATIC          "static"
+%token  DAS_FIXED_ARRAY     "fixed_array"
+%token  DAS_DEFAULT         "default"
+%token  DAS_UNINITIALIZED   "uninitialized"
+
+/* basic types */
+%token  DAS_TBOOL           "bool"
+%token  DAS_TVOID           "void"
+%token  DAS_TSTRING         "string"
+%token  DAS_TAUTO           "auto"
+%token  DAS_TINT            "int"
+%token  DAS_TINT2           "int2"
+%token  DAS_TINT3           "int3"
+%token  DAS_TINT4           "int4"
+%token  DAS_TUINT           "uint"
+%token  DAS_TBITFIELD       "bitfield"
+%token  DAS_TUINT2          "uint2"
+%token  DAS_TUINT3          "uint3"
+%token  DAS_TUINT4          "uint4"
+%token  DAS_TFLOAT          "float"
+%token  DAS_TFLOAT2         "float2"
+%token  DAS_TFLOAT3         "float3"
+%token  DAS_TFLOAT4         "float4"
+%token  DAS_TRANGE          "range"
+%token  DAS_TURANGE         "urange"
+%token  DAS_TRANGE64        "range64"
+%token  DAS_TURANGE64       "urange64"
+%token  DAS_TBLOCK          "block"
+%token  DAS_TINT64          "int64"
+%token  DAS_TUINT64         "uint64"
+%token  DAS_TDOUBLE         "double"
+%token  DAS_TFUNCTION       "function"
+%token  DAS_TLAMBDA         "lambda"
+%token  DAS_TINT8           "int8"
+%token  DAS_TUINT8          "uint8"
+%token  DAS_TINT16          "int16"
+%token  DAS_TUINT16         "uint16"
+%token  DAS_TTUPLE          "tuple"
+%token  DAS_TVARIANT        "variant"
+%token  DAS_GENERATOR       "generator"
+%token  DAS_YIELD           "yield"
+%token  DAS_SEALED          "sealed"
+%token  DAS_TEMPLATE        "template"
+
+/* operators */
+%token  ADDEQU              "+="
+%token  SUBEQU              "-="
+%token  DIVEQU              "/="
+%token  MULEQU              "*="
+%token  MODEQU              "%="
+%token  ANDEQU              "&="
+%token  OREQU               "|="
+%token  XOREQU              "^="
+%token  SHL                 "<<"
+%token  SHR                 ">>"
+%token  ADDADD              "++"
+%token  SUBSUB              "--"
+%token  LEEQU               "<="
+%token  SHLEQU              "<<="
+%token  SHREQU              ">>="
+%token  GREQU               ">="
+%token  EQUEQU              "=="
+%token  NOTEQU              "!="
+%token  RARROW              "->"
+%token  LARROW              "<-"
+%token  QQ                  "??"
+%token  QDOT                "?."
+%token  QBRA                "?["
+%token  LPIPE               "<|"
+%token  LBPIPE              " <|"
+%token  LLPIPE              "$ <|"
+%token  LAPIPE              "@ <|"
+%token  LFPIPE              "@@ <|"
+%token  RPIPE               "|>"
+%token  CLONEEQU            ":="
+%token  ROTL                "<<<"
+%token  ROTR                ">>>"
+%token  ROTLEQU             "<<<="
+%token  ROTREQU             ">>>="
+%token  MAPTO               "=>"
+%token  COLCOL              "::"
+%token  ANDAND              "&&"
+%token  OROR                "||"
+%token  XORXOR              "^^"
+%token  ANDANDEQU           "&&="
+%token  OROREQU             "||="
+%token  XORXOREQU           "^^="
+%token  DOTDOT              ".."
+%token  MTAG_E              "$$"
+%token  MTAG_I              "$i"
+%token  MTAG_V              "$v"
+%token  MTAG_B              "$b"
+%token  MTAG_A              "$a"
+%token  MTAG_T              "$t"
+%token  MTAG_C              "$c"
+%token  MTAG_F              "$f"
+%token  MTAG_DOTDOTDOT      "..."
+
+%token  BRABRAB             "[["    /* [[ */
+%token  BRACBRB             "[{"    /* [{ */
+%token  CBRCBRB             "{{"    /* {{ */
+
+%token<i>       INTEGER                 "integer constant"
+%token<i64>     LONG_INTEGER            "long integer constant"
+%token<ui>      UNSIGNED_INTEGER        "unsigned integer constant"
+%token<ui64>    UNSIGNED_LONG_INTEGER   "unsigned long integer constant"
+%token<ui>      UNSIGNED_INT8           "unsigned int8 constant"
+%token<fd>      FLOAT                   "floating point constant"
+%token<d>       DOUBLE                  "double constant"
+%token<s>       NAME                    "name"
+%token<s>       KEYWORD                 "keyword"
+%token<s>       TYPE_FUNCTION           "type function"
+
+/* %printer { fprintf (yyo, "%i", $$); } <i> */
+
+%token      BEGIN_STRING            "start of the string"
+%token<ch>  STRING_CHARACTER
+%token      STRING_CHARACTER_ESC
+%token      END_STRING              "end of the string"
+%token      BEGIN_STRING_EXPR       "{"
+%token      END_STRING_EXPR         "}"
+%token      END_OF_READ             "end of failed eader macro"
+
+%token      '{'                     "begin of code block"
+%token      '}'                     "end of code block"
+%token      ';'                     "end of expression"
+
+%token      SEMICOLON_CUR_CUR       ";}}"
+%token      SEMICOLON_CUR_SQR       ";}]"
+%token      SEMICOLON_SQR_SQR       ";]]"
+%token      COMMA_SQR_SQR           ",]]"
+%token      COMMA_CUR_SQR           ",}]"
+
+
+%type <pEnum>           enum_name
+%type <pNameList>       bitfield_bits
+%type <pNameList>       bitfield_alias_bits
+%type <pNameList>       tuple_expansion
+%type <pNameWithPosList>variable_name_with_pos_list
+%type <pNameWithPosList>let_variable_name_with_pos_list
+%type <type>            basic_type_declaration
+%type <type>            enum_basic_type_declaration
+%type <pTypeDecl>       type_declaration
+%type <pTypeDecl>       type_declaration_no_options
+%type <pTypeDecl>       new_type_declaration
+%type <pTypeDecl>       auto_type_declaration
+%type <pTypeDecl>       bitfield_type_declaration
+%type <pTypeDecl>       optional_function_type
+%type <pTypeDecl>       structure_type_declaration
+%type <pTypeDecl>       dim_list
+%type <pTypeDeclList>   type_declaration_no_options_list
+%type <pVarDeclList>    struct_variable_declaration_list
+%type <pVarDeclList>    optional_struct_variable_declaration_list
+%type <pVarDeclList>    global_variable_declaration_list
+%type <pVarDeclList>    optional_function_argument_list
+%type <pVarDeclList>    function_argument_list
+%type <pVarDecl>        variable_declaration
+%type <pVarDecl>        function_argument_declaration
+%type <pVarDecl>        structure_variable_declaration
+%type <pVarDecl>        let_variable_declaration
+%type <pVarDecl>        tuple_expansion_variable_declaration
+%type <pVarDecl>        tuple_type
+%type <pVarDeclList>    tuple_type_list
+%type <pVarDeclList>    tuple_alias_type_list
+%type <pVarDecl>        variant_type
+%type <pVarDeclList>    variant_type_list
+%type <pVarDeclList>    variant_alias_type_list
+%type <s>               keyword_or_name
+%type <s>               name_in_namespace
+%type <s>               annotation_declaration_name
+%type <s>               function_name
+%type <s>               optional_structure_parent
+%type <s>               require_module_name
+%type <s>               annotation_argument_name
+%type <aa>              annotation_argument
+%type <aa>              annotation_argument_value
+%type <aaList>          annotation_argument_list
+%type <aaList>          metadata_argument_list
+%type <aaList>          annotation_argument_value_list
+%type <aaList>          optional_field_annotation
+%type <fa>              annotation_declaration_basic
+%type <fa>              annotation_declaration
+%type <faList>          annotation_list
+%type <faList>          optional_annotation_list
+%type <pStructure>      structure_name
+%type <aTypePair>       table_type_pair
+
+%type <i>               class_or_struct
+%type <b>               copy_or_move
+%type <i>               optional_override
+%type <b>               optional_constant
+%type <b>               kwd_let
+%type <b>               kwd_let_var_or_nothing
+%type <b>               is_public_module
+%type <b>               optional_shared
+%type <b>               optional_sealed
+%type <i>               block_or_lambda
+%type <b>               optional_ref
+%type <b>               optional_public_or_private_module
+%type <b>               optional_public_or_private_variable
+%type <b>               optional_public_or_private_structure
+%type <b>               optional_public_or_private_function
+%type <b>               optional_public_or_private_member_variable
+%type <b>               optional_public_or_private_alias
+%type <b>               optional_static_member_variable
+%type <b>               optional_public_or_private_enum
+%type <b>               optional_in_scope
+%type <b>               optional_comma
+%type <b>               use_initializer
+%type <b>               if_or_static_if
+%type <b>               elif_or_static_elif
+
+%type <i>               copy_or_move_or_clone
+
+%type <pEnum>           enum_list
+
+%type <pExpression>     expr
+%type <pExpression>     expr_mtag
+%type <pExpression>     expr_field
+%type <pExpression>     expr_assign
+%type <pExpression>     expr_assign_pipe
+%type <pExpression>     expr_assign_pipe_right
+%type <pExpression>     expr_list
+%type <pExpression>     optional_expr_list
+%type <pExpression>     optional_expr_list_in_braces
+%type <pExpression>     optional_expr_map_tuple_list
+%type <pExpression>     expr_map_tuple_list
+%type <pExpression>     expression_label
+%type <pExpression>     expression_goto
+%type <pExpression>     expression_let
+%type <pExpression>     expressions
+%type <pExpression>     expression_block
+%type <pExpression>     expression_with
+%type <pExpression>     expression_with_alias
+%type <pExpression>     expression_while_loop
+%type <pExpression>     expression_unsafe
+%type <pExpression>     expression_for_loop
+%type <pExpression>     expression_break
+%type <pExpression>     expression_continue
+%type <pExpression>     expression_delete
+%type <pExpression>     expression_return
+%type <pExpression>     expression_return_no_pipe
+%type <pExpression>     expression_yield
+%type <pExpression>     expression_yield_no_pipe
+%type <pExpression>     expression_else
+%type <pExpression>     expression_if_then_else
+%type <pExpression>     expression_if_one_liner
+%type <pExpression>     expression_else_one_liner
+%type <pExpression>     expression_try_catch
+%type <pExpression>     expression_keyword
+%type <pExpression>     expr_new
+%type <pExpression>     expr_pipe
+%type <pExpression>     expr_keyword
+%type <pExpression>     expr_type_info
+%type <pExpression>     expr_type_decl
+%type <pExpression>     expr_cast
+%type <pExpression>     expr_block
+%type <pExpression>     expr_full_block
+%type <pExpression>     expr_full_block_assumed_piped
+%type <pExpression>     expr_named_call
+%type <pExpression>     expression_any
+%type <pExpression>     expr_numeric_const
+%type <pExpression>     string_builder_body
+%type <pExpression>     string_builder
+%type <pExpression>     expr_reader
+%type <pExpression>     make_decl
+%type <pMakeStruct>     make_struct_fields
+%type <pExpression>     make_struct_decl
+%type <pExpression>     make_struct_dim
+%type <pExpression>     make_struct_dim_list
+%type <pExpression>     make_struct_dim_decl
+%type <pExpression>     optional_make_struct_dim_decl
+%type <pExpression>     make_variant_dim
+%type <pExpression>     make_struct_single
+%type <pExpression>     make_tuple
+%type <pExpression>     make_map_tuple
+%type <pExpression>     make_dim
+%type <pExpression>     make_dim_decl
+%type <pExpression>     make_tuple_call
+%type <pExpression>     make_table
+%type <pExpression>     make_table_decl
+%type <pExpression>     array_comprehension_where
+%type <pExpression>     array_comprehension
+%type <pExpression>     expr_method_call
+%type <pExpression>     block_or_simple_block
+%type <pExpression>     func_addr_expr
+%type <pExpression>     func_addr_name
+%type <pExpression>     expr_call
+%type <pExpression>     expr_call_pipe
+
+%type <pExpression>     optional_block
+
+%type <pFuncDecl>       function_declaration
+%type <pFuncDecl>       function_declaration_header
+
+%type <pCapt>           capture_entry
+%type <pCaptList>       capture_list
+%type <pCaptList>       optional_capture_list
+
+%type <s>               character_sequence
+%type <s>               string_constant
+%type <s>               module_name
+
+/* operation precedence*/
+%left       ','
+%nonassoc    DOTDOT MAPTO
+%right      '=' ADDEQU SUBEQU DIVEQU MULEQU MODEQU ANDEQU OREQU XOREQU LARROW SHLEQU SHREQU ROTLEQU ROTREQU ANDANDEQU XORXOREQU OROREQU
+%right      '?' ':'
+%left       OROR
+%left       XORXOR
+%left       ANDAND
+%left       '|'
+%left       '^'
+%left       '&'
+%left       EQUEQU NOTEQU
+%left       '<' '>' LEEQU GREQU
+%left       SHL SHR ROTL ROTR
+%left       '-' '+'
+%left       '*' '/' '%'
+%right      QQ
+%right      UNARY_MINUS UNARY_PLUS '~' '!' PRE_INC PRE_DEC ADDADD SUBSUB
+%left       DAS_IS DAS_AS
+%left       LPIPE RPIPE LBPIPE LAPIPE LFPIPE LLPIPE
+%left       POST_INC POST_DEC RARROW DEREF
+%left       '.'
+%nonassoc  '[' ']' '(' ')' QDOT QBRA BRABRAB BRACBRB CBRCBRB
+%nonassoc   '$' '@'
+%nonassoc   COLCOL
+
+%right STRING_CHARACTER STRING_CHARACTER_ESC
+%right BEGIN_STRING_EXPR END_STRING_EXPR
+
+%%
+
+program
+    :
+    |   program module_declaration {
+            if ( yyextra->das_has_type_declarations ) {
+                das_yyerror(scanner,"module name has to be first declaration",tokAt(scanner,@module_declaration), CompilationError::syntax_error);
+            }
+        }
+    |   program structure_declaration           { yyextra->das_has_type_declarations = true; }
+    |   program enum_declaration                { yyextra->das_has_type_declarations = true; }
+    |   program global_let                      { yyextra->das_has_type_declarations = true; }
+    |   program global_function_declaration     { yyextra->das_has_type_declarations = true; }
+    |   program expect_declaration
+    |   program require_declaration
+    |   program options_declaration
+    |   program alias_declaration               { yyextra->das_has_type_declarations = true; }
+    |   program variant_alias_declaration       { yyextra->das_has_type_declarations = true; }
+    |   program tuple_alias_declaration         { yyextra->das_has_type_declarations = true; }
+    |   program bitfield_alias_declaration      { yyextra->das_has_type_declarations = true; }
+    |   program top_level_reader_macro
+    |   program ';'
+    ;
+
+top_level_reader_macro
+    :   expr_reader[rdr] ';' {
+        delete $rdr;    // we do nothing, we don't even attemp to 'visit'
+    }
+    ;
+
+optional_public_or_private_module
+    :                   { $$ = yyextra->g_Program->policies.default_module_public; }
+    |   DAS_PUBLIC      { $$ = true; }
+    |   DAS_PRIVATE     { $$ = false; }
+    ;
+
+module_name
+    :   '$'         { $$ = new string("$"); }
+    |   NAME[name]  { $$ = $name; }
+    ;
+
+module_declaration
+    :   DAS_MODULE  module_name[name] optional_shared[mtype] optional_public_or_private_module[ispub] {
+        yyextra->g_Program->thisModuleName = *$name;
+        yyextra->g_Program->thisModule->isPublic = $ispub;
+        yyextra->g_Program->thisModule->isModule = true;
+        if ( yyextra->g_Program->thisModule->name.empty() ) {
+            yyextra->g_Program->thisModule->name = *$name;
+        } else if ( yyextra->g_Program->thisModule->name != *$name ){
+            das_yyerror(scanner,"this module already has a name " + yyextra->g_Program->thisModule->name,tokAt(scanner,@name),
+                CompilationError::module_already_has_a_name);
+        }
+        if ( !yyextra->g_Program->policies.ignore_shared_modules ) {
+            yyextra->g_Program->promoteToBuiltin = $mtype;
+        }
+        delete $name;
+    }
+    ;
+
+character_sequence
+    :   STRING_CHARACTER[char]                                                    { $$ = new string(); *$$ += $char; }
+    |   STRING_CHARACTER_ESC                                                      { $$ = new string(); *$$ += "\\\\"; }
+    |   character_sequence[elem]  STRING_CHARACTER[char] %prec STRING_CHARACTER   { $$ = $elem; *$elem += $char; }
+    |   character_sequence[elem]  STRING_CHARACTER_ESC   %prec STRING_CHARACTER   { $$ = $elem; *$elem += "\\\\"; }
+    ;
+
+string_constant
+    :   BEGIN_STRING character_sequence[seq] END_STRING    { $$ = $seq; }
+    |   BEGIN_STRING END_STRING                            { $$ = new string(); }
+    ;
+
+string_builder_body
+    :   {
+        $$ = new ExprStringBuilder();
+        $$->at = LineInfo(yyextra->g_FileAccessStack.back(),
+            yylloc.first_column,yylloc.first_line,yylloc.last_column,yylloc.last_line);
+    }
+    |   string_builder_body[sb] character_sequence[sconst] %prec STRING_CHARACTER {
+        bool err;
+        auto esconst = unescapeString(*$sconst,&err);
+        if ( err ) das_yyerror(scanner,"invalid escape sequence",tokAt(scanner,@sb), CompilationError::invalid_escape_sequence);
+        auto sc = make_smart<ExprConstString>(tokAt(scanner,@sconst),esconst);
+        delete $sconst;
+        static_cast<ExprStringBuilder *>($sb)->elements.push_back(sc);
+        $$ = $sb;
+    }
+    |   string_builder_body[sb] BEGIN_STRING_EXPR expr[subexpr] END_STRING_EXPR %prec BEGIN_STRING_EXPR {
+        auto se = ExpressionPtr($subexpr);
+        static_cast<ExprStringBuilder *>($sb)->elements.push_back(se);
+        $$ = $sb;
+    }
+    ;
+
+string_builder
+    :   BEGIN_STRING[sfrm] string_builder_body[sb] END_STRING[sto] {
+        auto strb = static_cast<ExprStringBuilder *>($sb);
+        if ( strb->elements.size()==0 ) {
+            $$ = new ExprConstString(tokRangeAt(scanner,@sfrm,@sto),"");
+            delete $sb;
+        } else if ( strb->elements.size()==1 && strb->elements[0]->rtti_isStringConstant() ) {
+            auto sconst = static_pointer_cast<ExprConstString>(strb->elements[0]);
+            $$ = new ExprConstString(tokRangeAt(scanner,@sfrm,@sto),sconst->text);
+            delete $sb;
+        } else {
+            $$ = $sb;
+        }
+    }
+    ;
+
+reader_character_sequence
+    :   STRING_CHARACTER[char] {
+        if ( !yyextra->g_ReaderMacro->accept(yyextra->g_Program.get(), yyextra->g_Program->thisModule.get(), yyextra->g_ReaderExpr, $char, tokAt(scanner,@char)) ) {
+            das_yyend_reader(scanner);
+        }
+    }
+    |   reader_character_sequence[elem]  STRING_CHARACTER[char] {
+        if ( !yyextra->g_ReaderMacro->accept(yyextra->g_Program.get(), yyextra->g_Program->thisModule.get(), yyextra->g_ReaderExpr, $char, tokAt(scanner,@char)) ) {
+            das_yyend_reader(scanner);
+        }
+    }
+    ;
+
+expr_reader
+    : '%' [loc] name_in_namespace[mark] {
+        auto macros = yyextra->g_Program->getReaderMacro(*$mark);
+        if ( macros.size()==0 ) {
+            das_yyerror(scanner,"reader macro " + *$mark + " not found",tokAt(scanner,@mark),
+                CompilationError::unsupported_read_macro);
+        } else if ( macros.size()>1 ) {
+            string options;
+            for ( auto & x : macros ) {
+                options += "\t" + x->module->name + "::" + x->name + "\n";
+            }
+            das_yyerror(scanner,"too many options for the reader macro " + *$mark +  "\n" + options, tokAt(scanner,@mark),
+                CompilationError::unsupported_read_macro);
+        } else if ( yychar != '~' ) {
+            das_yyerror(scanner,"expecting ~ after the reader macro", tokAt(scanner,@mark),
+                CompilationError::syntax_error);
+        } else {
+            yyextra->g_ReaderMacro = macros.back().get();
+            yyextra->g_ReaderExpr = new ExprReader(tokAt(scanner,@loc),yyextra->g_ReaderMacro);
+            yyclearin ;
+            das_yybegin_reader(scanner);
+        }
+    } reader_character_sequence[seq] {
+        yyextra->g_ReaderExpr->at = tokRangeAt(scanner,@loc,@seq);
+        $$ = yyextra->g_ReaderExpr;
+        int thisLine = 0;
+        FileInfo * info = nullptr;
+        if ( auto seqt = yyextra->g_ReaderMacro->suffix(yyextra->g_Program.get(), yyextra->g_Program->thisModule.get(), yyextra->g_ReaderExpr, thisLine, info, tokAt(scanner,@seq)) ) {
+            das_accept_sequence(scanner,seqt,strlen(seqt),thisLine,info);
+            yylloc.first_column = @seq.first_column;
+            yylloc.first_line = @seq.first_line;
+            yylloc.last_column = @seq.last_column;
+            yylloc.last_line = @seq.last_line;
+        }
+        delete $mark;
+        yyextra->g_ReaderMacro = nullptr;
+        yyextra->g_ReaderExpr = nullptr;
+    }
+
+options_declaration
+    :   DAS_OPTIONS annotation_argument_list[list] {
+        for ( auto & opt : *$list ) {
+            if ( opt.name=="indenting" && opt.type==Type::tInt ) {
+                if (opt.iValue != 0 && opt.iValue != 2 && opt.iValue != 4 && opt.iValue != 8) { //this is error
+                    yyextra->das_tab_size = yyextra->das_def_tab_size;
+                } else {
+                    yyextra->das_tab_size = opt.iValue ? opt.iValue : yyextra->das_def_tab_size;//0 is default
+                }
+                yyextra->g_FileAccessStack.back()->tabSize = yyextra->das_tab_size;
+            } else if ( opt.name=="gen2_make_syntax" && opt.type==Type::tBool ) {
+                yyextra->das_gen2_make_syntax = opt.bValue;
+            }
+        }
+        if ( yyextra->g_Program->options.size() ) {
+            for ( auto & opt : *$list ) {
+                if ( yyextra->g_Access->isOptionAllowed(opt.name, yyextra->g_Program->thisModuleName) ) {
+                    yyextra->g_Program->options.push_back(opt);
+                } else {
+                    das_yyerror(scanner,"option " + opt.name + " is not allowed here",
+                        tokAt(scanner,@list), CompilationError::invalid_option);
+                }
+            }
+        } else {
+            swap ( yyextra->g_Program->options, *$list );
+        }
+        delete $list;
+    }
+    ;
+
+require_declaration
+    :   DAS_REQUIRE require_module
+    ;
+
+keyword_or_name
+    :   NAME[name]          { $$ = $name; }
+    |   KEYWORD[name]       { $$ = $name; }
+    |   TYPE_FUNCTION[name] { $$ = $name; }
+    ;
+
+require_module_name
+    :   keyword_or_name[name] {
+        $$ = $name;
+    }
+    |   '%' require_module_name[req] {
+        *$req = "%" + *$req;
+        $$ = $req;
+    }
+    |   require_module_name[req] '.' keyword_or_name[name] {
+        *$req += ".";
+        *$req += *$name;
+        delete $name;
+        $$ = $req;
+    }
+    |   require_module_name[req] '/' keyword_or_name[name] {
+        *$req += "/";
+        *$req += *$name;
+        delete $name;
+        $$ = $req;
+    }
+    ;
+
+require_module
+    :   require_module_name[name]  is_public_module[pub] {
+        ast_requireModule(scanner,$name,nullptr,$pub,tokAt(scanner,@name));
+    }
+    |   require_module_name[name] DAS_AS NAME[modalias] is_public_module[pub] {
+        ast_requireModule(scanner,$name,$modalias,$pub,tokAt(scanner,@name));
+    }
+    ;
+
+is_public_module
+    :               { $$ = false; }
+    |   DAS_PUBLIC  { $$ = true; }
+    ;
+
+expect_declaration
+    :   DAS_EXPECT expect_list
+    ;
+
+expect_list
+    :   expect_error
+    |   expect_list ',' expect_error
+    ;
+
+expect_error
+    : INTEGER[err] {
+        yyextra->g_Program->expectErrors[CompilationError($err)] ++;
+    }
+    | INTEGER[err] ':' INTEGER[count] {
+        yyextra->g_Program->expectErrors[CompilationError($err)] += $count;
+    }
+    ;
+
+expression_label
+    : DAS_LABEL[loc] INTEGER[labname] ':' {
+        $$ = new ExprLabel(tokAt(scanner,@loc),$labname);
+    }
+    ;
+
+expression_goto
+    : DAS_GOTO[loc] DAS_LABEL INTEGER[labname]  {
+        $$ = new ExprGoto(tokAt(scanner,@loc),$labname);
+    }
+    | DAS_GOTO[loc] expr[lab]  {
+        $$ = new ExprGoto(tokAt(scanner,@loc),ExpressionPtr($lab));
+    }
+    ;
+
+elif_or_static_elif
+    :   DAS_ELIF          { $$ = false; }
+    |   DAS_STATIC_ELIF   { $$ = true; }
+    ;
+
+expression_else
+    :                                                      { $$ = nullptr; }
+    |   DAS_ELSE expression_block[block]                   { $$ = $block; }
+    |   elif_or_static_elif[loc] expr[cond] expression_block[block] expression_else[then] {
+        auto eite = new ExprIfThenElse(tokAt(scanner,@loc),ExpressionPtr($cond),
+            ExpressionPtr($block),ExpressionPtr($then));
+        eite->isStatic = $loc;
+        $$ = eite;
+    }
+    ;
+
+if_or_static_if
+    :   DAS_IF          { $$ = false; }
+    |   DAS_STATIC_IF   { $$ = true; }
+    ;
+
+expression_else_one_liner
+    :   { $$ = nullptr; }
+    |   DAS_ELSE[loc] { yyextra->das_need_oxford_comma = true; } expression_if_one_liner[result] {
+            $$ = $result;
+    }
+    ;
+
+expression_if_one_liner
+    :   expr[result]                        { $$ = $result; }
+    |   expression_return_no_pipe[result]   { $$ = $result; }
+    |   expression_yield_no_pipe[result]    { $$ = $result; }
+    |   expression_break[result]            { $$ = $result; }
+    |   expression_continue[result]         { $$ = $result; }
+    ;
+
+expression_if_then_else
+    :   if_or_static_if[loc] expr[cond] expression_block[block] expression_else[then] {
+        auto eite = new ExprIfThenElse(tokAt(scanner,@loc),ExpressionPtr($cond),
+            ExpressionPtr($block),ExpressionPtr($then));
+        eite->isStatic = $loc;
+        $$ = eite;
+    }
+    |   expression_if_one_liner[if_true] DAS_IF[loc] { yyextra->das_need_oxford_comma = true; } expr[cond] expression_else_one_liner[if_false] ';' {
+        $$ = new ExprIfThenElse(tokAt(scanner,@loc),ExpressionPtr($cond),ExpressionPtr(ast_wrapInBlock($if_true)),$if_false ? ExpressionPtr(ast_wrapInBlock($if_false)) : nullptr);
+    }
+    ;
+
+expression_for_loop
+    :   DAS_FOR[loc] { yyextra->das_need_oxford_comma=false; } variable_name_with_pos_list[iters] DAS_IN expr_list[srcs] expression_block[block] {
+        $$ = ast_forLoop(scanner,$iters,$srcs,$block,tokAt(scanner,@loc),tokAt(scanner,@block));
+    }
+    ;
+
+expression_unsafe
+    :   DAS_UNSAFE[loc]  expression_block[block] {
+        auto pUnsafe = new ExprUnsafe(tokAt(scanner,@loc));
+        pUnsafe->body = ExpressionPtr($block);
+        $$ = pUnsafe;
+    }
+    ;
+
+expression_while_loop
+    :   DAS_WHILE[loc] expr[condition] expression_block[block] {
+        auto pWhile = new ExprWhile(tokAt(scanner,@loc));
+        pWhile->cond = ExpressionPtr($condition);
+        pWhile->body = ExpressionPtr($block);
+        ((ExprBlock *)$block)->inTheLoop = true;
+        $$ = pWhile;
+    }
+    ;
+
+expression_with
+    :   DAS_WITH[loc] expr[with] expression_block[block] {
+        auto pWith = new ExprWith(tokAt(scanner,@loc));
+        pWith->with = ExpressionPtr($with);
+        pWith->body = ExpressionPtr($block);
+        $$ = pWith;
+    }
+    ;
+
+expression_with_alias
+    :   DAS_ASSUME[loc] NAME[aname] '=' { yyextra->das_need_oxford_comma=true; } expr[subexpr] {
+        $$ = new ExprAssume(tokAt(scanner,@loc), *$aname, $subexpr );
+        delete $aname;
+    }
+    ;
+
+annotation_argument_value
+    :   string_constant[value]   { $$ = new AnnotationArgument("",*$value); delete $value; }
+    |   NAME[value]              { $$ = new AnnotationArgument("",*$value); delete $value; }
+    |   INTEGER[value]           { $$ = new AnnotationArgument("",$value); }
+    |   FLOAT[value]             { $$ = new AnnotationArgument("",float($value)); }
+    |   DAS_TRUE                 { $$ = new AnnotationArgument("",true); }
+    |   DAS_FALSE                { $$ = new AnnotationArgument("",false); }
+    ;
+
+annotation_argument_value_list
+    :   annotation_argument_value[arg] {
+        $$ = new AnnotationArgumentList();
+        $$->push_back(*$arg);
+        delete $arg;
+    }
+    |   annotation_argument_value_list[argL] ',' annotation_argument_value[arg] {
+            $$ = $argL;
+            $$->push_back(*$arg);
+            delete $arg;
+    }
+    ;
+
+annotation_argument_name
+    :   NAME[name]  { $$ = $name; }
+    |   DAS_TYPE    { $$ = new string("type"); }
+    |   DAS_IN      { $$ = new string("in"); }
+    ;
+
+annotation_argument
+    :   annotation_argument_name[name] '=' string_constant[value]   { $$ = new AnnotationArgument(*$name,*$value,tokAt(scanner,@name)); delete $value; delete $name; }
+    |   annotation_argument_name[name] '=' NAME[value]              { $$ = new AnnotationArgument(*$name,*$value,tokAt(scanner,@name)); delete $value; delete $name; }
+    |   annotation_argument_name[name] '=' INTEGER[value]           { $$ = new AnnotationArgument(*$name,$value,tokAt(scanner,@name)); delete $name; }
+    |   annotation_argument_name[name] '=' FLOAT[value]             { $$ = new AnnotationArgument(*$name,float($value),tokAt(scanner,@name)); delete $name; }
+    |   annotation_argument_name[name] '=' DAS_TRUE                 { $$ = new AnnotationArgument(*$name,true,tokAt(scanner,@name)); delete $name; }
+    |   annotation_argument_name[name] '=' DAS_FALSE                { $$ = new AnnotationArgument(*$name,false,tokAt(scanner,@name)); delete $name; }
+    |   annotation_argument_name[name]                              { $$ = new AnnotationArgument(*$name,true,tokAt(scanner,@name)); delete $name; }
+    |   annotation_argument_name[name] '=' '(' annotation_argument_value_list[values] ')' {
+        { $$ = new AnnotationArgument(*$name,$values,tokAt(scanner,@name)); delete $name; }
+    }
+    ;
+
+annotation_argument_list
+    :   annotation_argument[arg]  {
+        $$ = ast_annotationArgumentListEntry(scanner,new AnnotationArgumentList(),$arg);
+    }
+    |   annotation_argument_list[argL] ',' annotation_argument[arg] {
+        $$ = ast_annotationArgumentListEntry(scanner,$argL,$arg);
+    }
+    ;
+
+metadata_argument_list
+    :   '@' annotation_argument[arg]  {
+        $$ = ast_annotationArgumentListEntry(scanner,new AnnotationArgumentList(),$arg);
+    }
+    |   metadata_argument_list[argL] '@' annotation_argument[arg] {
+        $$ = ast_annotationArgumentListEntry(scanner,$argL,$arg);
+    }
+    |   metadata_argument_list[argL] ';' {
+        $$ = $argL;
+    }
+    ;
+
+annotation_declaration_name
+    :   name_in_namespace[name]     { $$ = $name; }
+    |   DAS_REQUIRE                 { $$ = new string("require"); }
+    |   DAS_PRIVATE                 { $$ = new string("private"); }
+    |   DAS_TEMPLATE                { $$ = new string("template"); }
+    ;
+
+annotation_declaration_basic
+    :   annotation_declaration_name[name] {
+        $$ = new AnnotationDeclaration();
+        $$->at = tokAt(scanner,@name);
+        if ( yyextra->g_Access->isAnnotationAllowed(*$name, yyextra->g_Program->thisModuleName) ) {
+            if ( auto ann = findAnnotation(scanner,*$name,tokAt(scanner,@name)) ) {
+                $$->annotation = ann;
+            }
+        } else {
+            das_yyerror(scanner,"annotation " + *$name + " is not allowed here",
+                        tokAt(scanner,@name), CompilationError::invalid_annotation);
+        }
+        delete $name;
+    }
+    |   annotation_declaration_name[name] '(' annotation_argument_list[argL] ')' {
+        $$ = new AnnotationDeclaration();
+        $$->at = tokAt(scanner,@name);
+        if ( yyextra->g_Access->isAnnotationAllowed(*$name, yyextra->g_Program->thisModuleName) ) {
+            if ( auto ann = findAnnotation(scanner,*$name,tokAt(scanner,@name)) ) {
+                $$->annotation = ann;
+            }
+        } else {
+            das_yyerror(scanner,"annotation " + *$name + " is not allowed here",
+                        tokAt(scanner,@name), CompilationError::invalid_annotation);
+        }
+        swap ( $$->arguments, *$argL );
+        delete $argL;
+        delete $name;
+    }
+    ;
+
+annotation_declaration
+    :   annotation_declaration_basic[ann] {
+        $$ = $ann;
+    }
+    |   '!'[nott] annotation_declaration[ann] {
+        if ( !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
+                CompilationError::invalid_annotation); }
+        $$ = new AnnotationDeclaration();
+        $$->at = tokAt(scanner, @nott);
+        $$->annotation = newLogicAnnotation(LogicAnnotationOp::Not,$ann,nullptr);
+    }
+    |   annotation_declaration[ann] ANDAND[andd] annotation_declaration[ann2] {
+        if ( !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
+                CompilationError::invalid_annotation); }
+        if ( !$ann2->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann2->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann2),
+                CompilationError::invalid_annotation); }
+        $$ = new AnnotationDeclaration();
+        $$->at = tokAt(scanner, @andd);
+        $$->annotation = newLogicAnnotation(LogicAnnotationOp::And,$ann,$ann2);
+    }
+    |   annotation_declaration[ann] OROR[andd] annotation_declaration[ann2] {
+        if ( !$ann->annotation || !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
+                CompilationError::invalid_annotation); }
+        if ( !$ann2->annotation || !$ann2->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann2->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann2),
+                CompilationError::invalid_annotation); }
+        $$ = new AnnotationDeclaration();
+        $$->at = tokAt(scanner, @andd);
+        $$->annotation = newLogicAnnotation(LogicAnnotationOp::Or,$ann,$ann2);
+    }
+    |   annotation_declaration[ann] XORXOR[andd] annotation_declaration[ann2] {
+        if ( !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
+                CompilationError::invalid_annotation); }
+        if ( !$ann2->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann2->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann2),
+                CompilationError::invalid_annotation); }
+        $$ = new AnnotationDeclaration();
+        $$->at = tokAt(scanner, @andd);
+        $$->annotation = newLogicAnnotation(LogicAnnotationOp::Xor,$ann,$ann2);
+    }
+    |   '(' annotation_declaration[ann] ')' {
+        $$ = $ann;
+    }
+    |   RPIPE annotation_declaration[ann] {
+        $$ = $ann;
+        $ann->inherited = true;
+    }
+    ;
+
+annotation_list
+    :   annotation_declaration[ann] {
+            $$ = new AnnotationList();
+            $$->push_back(AnnotationDeclarationPtr($ann));
+    }
+    |   annotation_list[annL] ',' annotation_declaration[ann] {
+        $$ = $annL;
+        $$->push_back(AnnotationDeclarationPtr($ann));
+    }
+    ;
+
+optional_annotation_list
+    :                                   { $$ = nullptr; }
+    |   '[' annotation_list[annL] ']'   { $$ = $annL; }
+    ;
+
+optional_function_argument_list
+    :                                           { $$ = nullptr; }
+    |   '(' ')'                                 { $$ = nullptr; }
+    |   '(' function_argument_list[list] ')'    { $$ = $list; }
+    ;
+
+optional_function_type
+    :   {
+        $$ = new TypeDecl(Type::autoinfer);
+    }
+    |   ':' type_declaration[typeDecl]  {
+        $$ = $typeDecl;
+        $$->at = tokAt(scanner,@typeDecl);
+    }
+    ;
+
+function_name
+    :   NAME[name]        {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        $$ = $name;
+    }
+    |   DAS_OPERATOR '!'     { $$ = new string("!"); }
+    |   DAS_OPERATOR '~'     { $$ = new string("~"); }
+    |   DAS_OPERATOR ADDEQU  { $$ = new string("+="); }
+    |   DAS_OPERATOR SUBEQU  { $$ = new string("-="); }
+    |   DAS_OPERATOR MULEQU  { $$ = new string("*="); }
+    |   DAS_OPERATOR DIVEQU  { $$ = new string("/="); }
+    |   DAS_OPERATOR MODEQU  { $$ = new string("%="); }
+    |   DAS_OPERATOR ANDEQU  { $$ = new string("&="); }
+    |   DAS_OPERATOR OREQU   { $$ = new string("|="); }
+    |   DAS_OPERATOR XOREQU  { $$ = new string("^="); }
+    |   DAS_OPERATOR ANDANDEQU  { $$ = new string("&&="); }
+    |   DAS_OPERATOR OROREQU    { $$ = new string("||="); }
+    |   DAS_OPERATOR XORXOREQU  { $$ = new string("^^="); }
+    |   DAS_OPERATOR ANDAND  { $$ = new string("&&"); }
+    |   DAS_OPERATOR OROR    { $$ = new string("||"); }
+    |   DAS_OPERATOR XORXOR  { $$ = new string("^^"); }
+    |   DAS_OPERATOR '+'     { $$ = new string("+"); }
+    |   DAS_OPERATOR '-'     { $$ = new string("-"); }
+    |   DAS_OPERATOR '*'     { $$ = new string("*"); }
+    |   DAS_OPERATOR '/'     { $$ = new string("/"); }
+    |   DAS_OPERATOR '%'     { $$ = new string("%"); }
+    |   DAS_OPERATOR '<'     { $$ = new string("<"); }
+    |   DAS_OPERATOR '>'     { $$ = new string(">"); }
+    |   DAS_OPERATOR DOTDOT  { $$ = new string("interval"); }
+    |   DAS_OPERATOR EQUEQU  { $$ = new string("=="); }
+    |   DAS_OPERATOR NOTEQU  { $$ = new string("!="); }
+    |   DAS_OPERATOR LEEQU   { $$ = new string("<="); }
+    |   DAS_OPERATOR GREQU   { $$ = new string(">="); }
+    |   DAS_OPERATOR '&'     { $$ = new string("&"); }
+    |   DAS_OPERATOR '|'     { $$ = new string("|"); }
+    |   DAS_OPERATOR '^'     { $$ = new string("^"); }
+    |   ADDADD DAS_OPERATOR  { $$ = new string("++"); }
+    |   SUBSUB DAS_OPERATOR  { $$ = new string("--"); }
+    |   DAS_OPERATOR ADDADD  { $$ = new string("+++"); }
+    |   DAS_OPERATOR SUBSUB  { $$ = new string("---"); }
+    |   DAS_OPERATOR SHL     { $$ = new string("<<"); }
+    |   DAS_OPERATOR SHR     { $$ = new string(">>"); }
+    |   DAS_OPERATOR SHLEQU  { $$ = new string("<<="); }
+    |   DAS_OPERATOR SHREQU  { $$ = new string(">>="); }
+    |   DAS_OPERATOR ROTL    { $$ = new string("<<<"); }
+    |   DAS_OPERATOR ROTR    { $$ = new string(">>>"); }
+    |   DAS_OPERATOR ROTLEQU { $$ = new string("<<<="); }
+    |   DAS_OPERATOR ROTREQU { $$ = new string(">>>="); }
+    |   DAS_OPERATOR '[' ']' { $$ = new string("[]"); }
+    |   DAS_OPERATOR QBRA ']'   { $$ = new string("?[]"); }
+    |   DAS_OPERATOR '.'     { $$ = new string("."); }
+    |   DAS_OPERATOR QDOT    { $$ = new string("?."); }
+    |   DAS_OPERATOR '.' NAME[name]    { $$ = new string(".`"+*$name); delete $name; }
+    |   DAS_OPERATOR '.' NAME[name] CLONEEQU { $$ = new string(".`"+*$name+"`clone"); delete $name; }
+    |   DAS_OPERATOR QDOT NAME[name]   { $$ = new string("?.`"+*$name); delete $name;}
+    |   DAS_OPERATOR CLONEEQU   { $$ = new string("clone"); }
+    |   DAS_OPERATOR DAS_DELETE { $$ = new string("finalize"); }
+    |   DAS_OPERATOR QQ    { $$ = new string("??"); }
+    |   DAS_OPERATOR DAS_IS { $$ = new string("`is"); }
+    |   DAS_OPERATOR DAS_AS { $$ = new string("`as"); }
+    |   DAS_OPERATOR DAS_IS NAME[name] { $$ = $name; *$name = "`is`" + *$name; }
+    |   DAS_OPERATOR DAS_AS NAME[name] { $$ = $name; *$name = "`as`" + *$name; }
+    |   DAS_OPERATOR '?' DAS_AS { $$ = new string("?as"); }
+    |   DAS_OPERATOR '?' DAS_AS NAME[name] { $$ = $name; *$name = "?as`" + *$name; }
+    |   DAS_TBOOL    { $$ = new string("bool"); }
+    |   DAS_TSTRING  { $$ = new string("string"); }
+    |   DAS_TINT     { $$ = new string("int"); }
+    |   DAS_TINT2    { $$ = new string("int2"); }
+    |   DAS_TINT3    { $$ = new string("int3"); }
+    |   DAS_TINT4    { $$ = new string("int4"); }
+    |   DAS_TUINT    { $$ = new string("uint"); }
+    |   DAS_TUINT2   { $$ = new string("uint2"); }
+    |   DAS_TUINT3   { $$ = new string("uint3"); }
+    |   DAS_TUINT4   { $$ = new string("uint4"); }
+    |   DAS_TFLOAT   { $$ = new string("float"); }
+    |   DAS_TFLOAT2  { $$ = new string("float2"); }
+    |   DAS_TFLOAT3  { $$ = new string("float3"); }
+    |   DAS_TFLOAT4  { $$ = new string("float4"); }
+    |   DAS_TRANGE   { $$ = new string("range"); }
+    |   DAS_TURANGE  { $$ = new string("urange"); }
+    |   DAS_TRANGE64 { $$ = new string("range64"); }
+    |   DAS_TURANGE64{ $$ = new string("urange64"); }
+    |   DAS_TINT64   { $$ = new string("int64"); }
+    |   DAS_TUINT64  { $$ = new string("uint64"); }
+    |   DAS_TDOUBLE  { $$ = new string("double"); }
+    |   DAS_TINT8    { $$ = new string("int8"); }
+    |   DAS_TUINT8   { $$ = new string("uint8"); }
+    |   DAS_TINT16   { $$ = new string("int16"); }
+    |   DAS_TUINT16  { $$ = new string("uint16"); }
+
+    ;
+
+global_function_declaration
+    :   optional_annotation_list[annL] DAS_DEF[from] function_declaration[func] {
+        $func->atDecl = tokRangeAt(scanner,@from,@func);
+        assignDefaultArguments($func);
+        runFunctionAnnotations(scanner, yyextra, $func, $annL, tokAt(scanner,@annL));
+        if ( $func->isGeneric() ) {
+            implAddGenericFunction(scanner,$func);
+        } else {
+            if ( !yyextra->g_Program->addFunction($func) ) {
+                das_yyerror(scanner,"function is already defined " +
+                    $func->getMangledName(),$func->at,
+                        CompilationError::function_already_declared);
+            }
+        }
+        $func->delRef();
+    }
+    ;
+
+optional_public_or_private_function
+    :                   { $$ = yyextra->g_thisStructure ? !yyextra->g_thisStructure->privateStructure : yyextra->g_Program->thisModule->isPublic; }
+    |   DAS_PRIVATE     { $$ = false; }
+    |   DAS_PUBLIC      { $$ = true; }
+    ;
+
+function_declaration_header
+    :  function_name[name] optional_function_argument_list[list] optional_function_type[result] {
+        $$ = ast_functionDeclarationHeader(scanner,$name,$list,$result,tokAt(scanner,@name));
+    }
+    ;
+
+function_declaration
+    :  optional_public_or_private_function[pub_func] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@pub_func);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeFunction(tak);
+        }
+    } function_declaration_header[func] expression_block[block] {
+        $func->body = ExpressionPtr($block);
+        $func->privateFunction = !$pub_func;
+        $$ = $func;
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@block);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterFunction($func,tak);
+        }
+    }
+    ;
+
+expression_block
+    :   '{' [bbegin] expressions[block] '}' [bend] {
+        $$ = $block;
+        $$->at = tokRangeAt(scanner,@bbegin,@bend);
+    }
+    |   '{' [bbegin] expressions[block] '}' DAS_FINALLY '{' expressions[final] '}' [bend] {
+        auto pB = (ExprBlock *) $block;
+        auto pF = (ExprBlock *) $final;
+        swap ( pB->finalList, pF->list );
+        $$ = $block;
+        $$->at = tokRangeAt(scanner,@bbegin,@bend);
+        delete $final;
+    }
+    ;
+
+expr_call_pipe
+    : expr[call] expr_full_block_assumed_piped[block] {
+        if ( $call->rtti_isCallLikeExpr() ) {
+            ((ExprLooksLikeCall *)$call)->arguments.push_back(ExpressionPtr($block));
+            $$ = $call;
+        } else {
+            $$ = $call;
+            delete $block;
+        }
+    }
+    | expression_keyword[call] expr_full_block_assumed_piped[block] {
+        if ( $call->rtti_isCallLikeExpr() ) {
+            ((ExprLooksLikeCall *)$call)->arguments.push_back(ExpressionPtr($block));
+            $$ = $call;
+        } else {
+            $$ = $call;
+            delete $block;
+        }
+    }
+    |   DAS_GENERATOR[loc] '<' type_declaration_no_options[typeDecl] '>' optional_capture_list[clist] expr_full_block_assumed_piped[subexpr] {
+        $$ = ast_makeGenerator(scanner,$typeDecl,$clist,$subexpr,tokAt(scanner,@loc));
+    }
+    ;
+
+expression_any
+    :   ';'                                 { $$ = nullptr; }
+    |   expr_pipe[subexpr]                  { $$ = $subexpr; }
+    |   expr_keyword[subexpr]               { $$ = $subexpr; }
+    |   expr_assign_pipe[subexpr]           { $$ = $subexpr; }
+    |   expr_assign[subexpr] ';'            { $$ = $subexpr; }
+    |   expression_delete[subexpr] ';'      { $$ = $subexpr; }
+    |   expression_let[subexpr]             { $$ = $subexpr; }
+    |   expression_while_loop[subexpr]      { $$ = $subexpr; }
+    |   expression_unsafe[subexpr]          { $$ = $subexpr; }
+    |   expression_with[subexpr]            { $$ = $subexpr; }
+    |   expression_with_alias[subexpr]      { $$ = $subexpr; }
+    |   expression_for_loop[subexpr]        { $$ = $subexpr; }
+    |   expression_break[subexpr] ';'       { $$ = $subexpr; }
+    |   expression_continue[subexpr] ';'    { $$ = $subexpr; }
+    |   expression_return[subexpr]          { $$ = $subexpr; }
+    |   expression_yield[subexpr]           { $$ = $subexpr; }
+    |   expression_if_then_else[subexpr]    { $$ = $subexpr; }
+    |   expression_try_catch[subexpr]       { $$ = $subexpr; }
+    |   expression_label[subexpr] ';'       { $$ = $subexpr; }
+    |   expression_goto[subexpr] ';'        { $$ = $subexpr; }
+    |   DAS_PASS ';'                        { $$ = nullptr; }
+    ;
+
+expressions
+    :   {
+        $$ = new ExprBlock();
+        $$->at = LineInfo(yyextra->g_FileAccessStack.back(),
+            yylloc.first_column,yylloc.first_line,yylloc.last_column,yylloc.last_line);
+    }
+    |   expressions[block] expression_any[subexpr]      {
+        $$ = $block;
+        if ( $subexpr ) {
+            static_cast<ExprBlock*>($block)->list.push_back(ExpressionPtr($subexpr));
+        }
+    }
+    |   expressions[block] error {
+        delete $block; $$ = nullptr; YYABORT;
+    }
+    ;
+
+expr_keyword
+    :   KEYWORD[kwd] expr[subexpr] expression_block[block] {
+        auto pCall = yyextra->g_Program->makeCall(tokAt(scanner,@kwd),*$kwd);
+        pCall->arguments.push_back(ExpressionPtr($subexpr));
+        auto resT = new TypeDecl(Type::autoinfer);
+        auto blk = ast_makeBlock(scanner,0,nullptr,nullptr,nullptr,resT,$block,tokAt(scanner,@block),tokAt(scanner,@block));
+        pCall->arguments.push_back(ExpressionPtr(blk));
+        delete $kwd;
+        $$ = pCall;
+    };
+
+optional_expr_list
+    :   { $$ = nullptr; }
+    |   expr_list[arguments] optional_comma { $$ = $arguments; }
+    ;
+
+optional_expr_list_in_braces
+    :   { $$ = nullptr; }
+    |   '(' optional_expr_list[arguments] optional_comma ')' { $$ = $arguments; }
+    ;
+
+optional_expr_map_tuple_list
+    :   { $$ = nullptr; }
+    |   expr_map_tuple_list[arguments] optional_comma { $$ = $arguments; }
+    ;
+
+type_declaration_no_options_list
+    :   type_declaration[decl] {
+        $$ = new vector<Expression *>();
+        $$->push_back(new ExprTypeDecl(tokAt(scanner,@decl),$decl));
+    }
+    |   type_declaration_no_options_list[declL] c_or_s type_declaration[decl] {
+        $$ = $declL;
+        $$->push_back(new ExprTypeDecl(tokAt(scanner,@decl),$decl));
+    }
+    ;
+
+expression_keyword
+    :   KEYWORD[kwd] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options_list[declL] '>' { yyextra->das_arrow_depth --; } expr[subexpr] {
+        auto pCall = yyextra->g_Program->makeCall(tokAt(scanner,@kwd),tokAt(scanner,@subexpr),*$kwd);
+        pCall->arguments = typesAndSequenceToList($declL,$subexpr);
+        delete $kwd;
+        $$ = pCall;
+    }
+    |   TYPE_FUNCTION[kwd] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options_list[declL] '>' { yyextra->das_arrow_depth --; } optional_expr_list_in_braces[subexpr] {
+        auto pCall = yyextra->g_Program->makeCall(tokAt(scanner,@kwd),tokAt(scanner,@subexpr),*$kwd);
+        pCall->arguments = typesAndSequenceToList($declL,$subexpr);
+        delete $kwd;
+        $$ = pCall;
+    }
+    ;
+
+expr_pipe
+    :   expr_assign[fncall] LBPIPE[loc] expr_block[arg] {
+        Expression * pipeCall = $fncall->tail();
+        if ( pipeCall->rtti_isCallLikeExpr() ) {
+            auto pCall = (ExprLooksLikeCall *) pipeCall;
+            pCall->arguments.push_back(ExpressionPtr($arg));
+            $$ = $fncall;
+        } else if ( pipeCall->rtti_isVar() ) {
+            // a += b <| c
+            auto pVar = (ExprVar *) pipeCall;
+            auto pCall = yyextra->g_Program->makeCall(pVar->at,pVar->name);
+            pCall->arguments.push_back(ExpressionPtr($arg));
+            if ( !$fncall->swap_tail(pVar,pCall) ) {
+                delete pVar;
+                $$ = pCall;
+            } else {
+                $$ = $fncall;
+            }
+        } else if ( pipeCall->rtti_isMakeStruct() ) {
+            auto pMS = (ExprMakeStruct *) pipeCall;
+            if ( pMS->block ) {
+                das_yyerror(scanner,"can't pipe into [[ make structure ]]. it already has where closure",
+                    tokAt(scanner,@loc),CompilationError::cant_pipe);
+                delete $arg;
+            } else {
+                pMS->block = $arg;
+            }
+            $$ = $fncall;
+        } else {
+            das_yyerror(scanner,"can only pipe into function call or [[ make structure ]]",
+                tokAt(scanner,@loc),CompilationError::cant_pipe);
+            delete $arg;
+            $$ = $fncall;
+        }
+    }
+    |   LAPIPE expr_block[arg] {
+        $$ = $arg;
+    }
+    |   LFPIPE expr_block[arg] {
+        $$ = $arg;
+    }
+    |   LLPIPE expr_block[arg] {
+        $$ = $arg;
+    }
+    |   expr_call_pipe[call] {
+        $$ = $call;
+    }
+    ;
+
+name_in_namespace
+    :   NAME[name]                             { $$ = $name; }
+    |   NAME[namespace] COLCOL NAME[name]      {
+            auto ita = yyextra->das_module_alias.find(*$namespace);
+            if ( ita == yyextra->das_module_alias.end() ) {
+                *$namespace += "::";
+            } else {
+                *$namespace = ita->second + "::";
+            }
+            *$namespace += *$name;
+            delete $name;
+            $$ = $namespace;
+        }
+    |   COLCOL NAME[name]                      { *$name = "::" + *$name; $$ = $name; }
+    ;
+
+expression_delete
+    :   DAS_DELETE[loc] expr[subexpr] {
+        $$ = new ExprDelete(tokAt(scanner,@loc), ExpressionPtr($subexpr));
+    }
+    |   DAS_DELETE[loc] DAS_EXPLICIT expr[subexpr] {
+        auto delExpr = new ExprDelete(tokAt(scanner,@loc), ExpressionPtr($subexpr));
+        delExpr->native = true;
+        $$ = delExpr;
+    }
+    ;
+
+new_type_declaration
+    :  '<' { yyextra->das_arrow_depth ++; } type_declaration[typeDecl] '>' { yyextra->das_arrow_depth --; } {
+        $$ = $typeDecl;
+    }
+    |   structure_type_declaration[typeDecl]   {
+        $$ = $typeDecl;
+    }
+    ;
+
+expr_new
+    :   DAS_NEWT[loc] new_type_declaration[typeDecl]   {
+        $$ = new ExprNew(tokAt(scanner,@loc),TypeDeclPtr($typeDecl),false);
+    }
+    |   DAS_NEWT[loc] new_type_declaration[typeDecl] '(' use_initializer[init] ')'   {
+        $$ = new ExprNew(tokAt(scanner,@loc),TypeDeclPtr($typeDecl),true);
+        ((ExprNew *)$$)->initializer = $init;
+    }
+    |   DAS_NEWT[loc] new_type_declaration[typeDecl] '(' expr_list[arguments] ')'   {
+        auto pNew = new ExprNew(tokAt(scanner,@loc),TypeDeclPtr($typeDecl),true);
+        $$ = parseFunctionArguments(pNew,$arguments);
+    }
+    |   DAS_NEWT[loc] new_type_declaration[typeDecl] '(' make_struct_single[dd] ')'   {
+        ((ExprMakeStruct *)$dd)->at = tokAt(scanner,@typeDecl);
+        ((ExprMakeStruct *)$dd)->makeType = $typeDecl;
+        ((ExprMakeStruct *)$dd)->useInitializer = true; // $init;
+        ((ExprMakeStruct *)$dd)->alwaysUseInitializer = true;
+        $$ = new ExprAscend(tokAt(scanner,@loc),ExpressionPtr($dd));
+    }
+    |   DAS_NEWT[loc] new_type_declaration[typeDecl] '(' DAS_UNINITIALIZED make_struct_single[dd] ')'   {
+        ((ExprMakeStruct *)$dd)->at = tokAt(scanner,@typeDecl);
+        ((ExprMakeStruct *)$dd)->makeType = $typeDecl;
+        ((ExprMakeStruct *)$dd)->useInitializer = false; // $init;
+        ((ExprMakeStruct *)$dd)->alwaysUseInitializer = true;
+        $$ = new ExprAscend(tokAt(scanner,@loc),ExpressionPtr($dd));
+    }
+    |   DAS_NEWT[loc] make_decl[md] {
+        $$ = new ExprAscend(tokAt(scanner,@loc),ExpressionPtr($md));
+    }
+    ;
+
+expression_break
+    :   DAS_BREAK[loc] { $$ = new ExprBreak(tokAt(scanner,@loc)); }
+    ;
+
+expression_continue
+    :   DAS_CONTINUE[loc] { $$ = new ExprContinue(tokAt(scanner,@loc)); }
+    ;
+
+expression_return_no_pipe
+    :   DAS_RETURN[loc] {
+        $$ = new ExprReturn(tokAt(scanner,@loc),nullptr);
+    }
+    |   DAS_RETURN[loc] expr_list[subexpr] {
+        $$ = new ExprReturn(tokAt(scanner,@loc),sequenceToTuple($subexpr));
+    }
+    |   DAS_RETURN[loc] LARROW expr_list[subexpr] {
+        auto pRet = new ExprReturn(tokAt(scanner,@loc),sequenceToTuple($subexpr));
+        pRet->moveSemantics = true;
+        $$ = pRet;
+    }
+    ;
+
+expression_return
+    :   expression_return_no_pipe[result] ';' {
+        $$ = $result;
+    }
+    |   DAS_RETURN[loc] expr_pipe[subexpr] {
+        $$ = new ExprReturn(tokAt(scanner,@loc),ExpressionPtr($subexpr));
+    }
+    |   DAS_RETURN[loc] LARROW expr_pipe[subexpr] {
+        auto pRet = new ExprReturn(tokAt(scanner,@loc),ExpressionPtr($subexpr));
+        pRet->moveSemantics = true;
+        $$ = pRet;
+    }
+    ;
+
+expression_yield_no_pipe
+    :   DAS_YIELD[loc] expr[subexpr] {
+        $$ = new ExprYield(tokAt(scanner,@loc),ExpressionPtr($subexpr));
+    }
+    |   DAS_YIELD[loc] LARROW expr[subexpr] {
+        auto pRet = new ExprYield(tokAt(scanner,@loc),ExpressionPtr($subexpr));
+        pRet->moveSemantics = true;
+        $$ = pRet;
+    }
+    ;
+
+expression_yield
+    :   expression_yield_no_pipe[result] ';' {
+        $$ = $result;
+    }
+    |   DAS_YIELD[loc] expr_pipe[subexpr] {
+        $$ = new ExprYield(tokAt(scanner,@loc),ExpressionPtr($subexpr));
+    }
+    |   DAS_YIELD[loc] LARROW expr_pipe[subexpr] {
+        auto pRet = new ExprYield(tokAt(scanner,@loc),ExpressionPtr($subexpr));
+        pRet->moveSemantics = true;
+        $$ = pRet;
+    }
+    ;
+
+expression_try_catch
+    :   DAS_TRY[loc] expression_block[tryBlock] DAS_CATCH expression_block[catchBlock] {
+        $$ = new ExprTryCatch(tokAt(scanner,@loc),ExpressionPtr($tryBlock),ExpressionPtr($catchBlock));
+    }
+    ;
+
+kwd_let_var_or_nothing
+    :   DAS_LET  { $$ = true; }
+    |   DAS_VAR  { $$ = false; }
+    |   /* empty */ { $$ = true; }
+    ;
+
+kwd_let
+    :   DAS_LET  { $$ = true; }
+    |   DAS_VAR  { $$ = false; }
+    ;
+
+optional_in_scope
+    :   DAS_INSCOPE { $$ = true; }
+    |   /* empty */  { $$ = false; }
+    ;
+
+tuple_expansion
+    :   NAME [name] {
+        $$ = new vector<string>();
+        $$->push_back(*$name);
+        delete $name;
+    }
+    |   tuple_expansion[list] ',' NAME[name] {
+        $list->push_back(*$name);
+        delete $name;
+        $$ = $list;
+    }
+    ;
+
+tuple_expansion_variable_declaration
+    :   BRABRAB tuple_expansion[list] ']' ']' ':' type_declaration_no_options[typeDecl] copy_or_move_or_clone[com] expr[init] ';' {
+        $$ = new VariableDeclaration($list,tokAt(scanner,@list),$typeDecl,$init);
+        $$->init_via_move  = ($com & CorM_MOVE) !=0;
+        $$->init_via_clone = ($com & CorM_CLONE) !=0;
+        $$->isTupleExpansion = true;
+    }
+    |   '(' tuple_expansion[list] ')' ':' type_declaration_no_options[typeDecl] copy_or_move_or_clone[com] expr[init] ';' {
+        $$ = new VariableDeclaration($list,tokAt(scanner,@list),$typeDecl,$init);
+        $$->init_via_move  = ($com & CorM_MOVE) !=0;
+        $$->init_via_clone = ($com & CorM_CLONE) !=0;
+        $$->isTupleExpansion = true;
+    }
+    |   BRABRAB tuple_expansion[list] ']' ']' optional_ref[ref] copy_or_move_or_clone[com] expr[init] ';' {
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,@list);
+        typeDecl->ref = $ref;
+        $$ = new VariableDeclaration($list,tokAt(scanner,@list),typeDecl,$init);
+        $$->init_via_move  = ($com & CorM_MOVE) !=0;
+        $$->init_via_clone = ($com & CorM_CLONE) !=0;
+        $$->isTupleExpansion = true;
+    }
+    |   '(' tuple_expansion[list] ')' optional_ref[ref] copy_or_move_or_clone[com] expr[init] ';' {
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,@list);
+        typeDecl->ref = $ref;
+        $$ = new VariableDeclaration($list,tokAt(scanner,@list),typeDecl,$init);
+        $$->init_via_move  = ($com & CorM_MOVE) !=0;
+        $$->init_via_clone = ($com & CorM_CLONE) !=0;
+        $$->isTupleExpansion = true;
+    }
+    ;
+
+expression_let
+    :   kwd_let optional_in_scope let_variable_declaration[decl] {
+        $$ = ast_Let(scanner,$kwd_let,$optional_in_scope,$decl,tokAt(scanner,@kwd_let),tokAt(scanner,@decl));
+    }
+    |   kwd_let optional_in_scope tuple_expansion_variable_declaration[decl] {
+        $$ = ast_Let(scanner,$kwd_let,$optional_in_scope,$decl,tokAt(scanner,@kwd_let),tokAt(scanner,@decl));
+    }
+    ;
+
+expr_cast
+    :   DAS_CAST[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options[decl] '>' { yyextra->das_arrow_depth --; } expr[subexpr] {
+        $$ = new ExprCast(tokAt(scanner,@loc),ExpressionPtr($subexpr),TypeDeclPtr($decl));
+    }
+    |   DAS_UPCAST[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options[decl] '>' { yyextra->das_arrow_depth --; } expr[subexpr] {
+        auto pCast = new ExprCast(tokAt(scanner,@loc),ExpressionPtr($subexpr),TypeDeclPtr($decl));
+        pCast->upcast = true;
+        $$ = pCast;
+    }
+    |   DAS_REINTERPRET[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options[decl] '>' { yyextra->das_arrow_depth --; } expr[subexpr] {
+        auto pCast = new ExprCast(tokAt(scanner,@loc),ExpressionPtr($subexpr),TypeDeclPtr($decl));
+        pCast->reinterpret = true;
+        $$ = pCast;
+    }
+    ;
+
+expr_type_decl
+    :  DAS_TYPE[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[decl] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new ExprTypeDecl(tokAt(scanner,@loc),TypeDeclPtr($decl));
+    }
+    ;
+
+expr_type_info
+    :   DAS_TYPEINFO[loc] '(' name_in_namespace[trait] expr[subexpr] ')' {
+            if ( $subexpr->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)$subexpr;
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ptd->typeexpr);
+                delete $subexpr;
+            } else {
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ExpressionPtr($subexpr));
+            }
+            delete $trait;
+    }
+    |   DAS_TYPEINFO[loc] '(' name_in_namespace[trait] '<' NAME[subtrait] '>' expr[subexpr] ')' {
+            if ( $subexpr->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)$subexpr;
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ptd->typeexpr,*$subtrait);
+                delete $subexpr;
+            } else {
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ExpressionPtr($subexpr),*$subtrait);
+            }
+            delete $trait;
+            delete $subtrait;
+    }
+    |   DAS_TYPEINFO[loc] '(' name_in_namespace[trait] '<' NAME[subtrait] c_or_s NAME[extratrait] '>' expr[subexpr] ')' {
+            if ( $subexpr->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)$subexpr;
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ptd->typeexpr,*$subtrait,*$extratrait);
+                delete $subexpr;
+            } else {
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ExpressionPtr($subexpr),*$subtrait,*$extratrait);
+            }
+            delete $trait;
+            delete $subtrait;
+            delete $extratrait;
+    }
+/* also new syntax */
+    |   DAS_TYPEINFO[loc] name_in_namespace[trait] '('  expr[subexpr] ')' {
+            if ( $subexpr->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)$subexpr;
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ptd->typeexpr);
+                delete $subexpr;
+            } else {
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ExpressionPtr($subexpr));
+            }
+            delete $trait;
+    }
+    |   DAS_TYPEINFO[loc] name_in_namespace[trait] '<' NAME[subtrait] '>' '(' expr[subexpr] ')' {
+            if ( $subexpr->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)$subexpr;
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ptd->typeexpr,*$subtrait);
+                delete $subexpr;
+            } else {
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ExpressionPtr($subexpr),*$subtrait);
+            }
+            delete $trait;
+            delete $subtrait;
+    }
+    |   DAS_TYPEINFO[loc] name_in_namespace[trait] '<' NAME[subtrait] ';' NAME[extratrait] '>' '(' expr[subexpr] ')' {
+            if ( $subexpr->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)$subexpr;
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ptd->typeexpr,*$subtrait,*$extratrait);
+                delete $subexpr;
+            } else {
+                $$ = new ExprTypeInfo(tokAt(scanner,@loc),*$trait,ExpressionPtr($subexpr),*$subtrait,*$extratrait);
+            }
+            delete $trait;
+            delete $subtrait;
+            delete $extratrait;
+    }
+    ;
+
+expr_list
+    :   expr[subexpr] {
+        $$ = $subexpr;
+    }
+    |   expr_list[left] ',' expr[right]     {
+            $$ = new ExprSequence(tokAt(scanner,@left),ExpressionPtr($left),ExpressionPtr($right));
+    }
+    ;
+
+block_or_simple_block
+    :   expression_block[block]     { $$ = $block; }
+    |   MAPTO[loc] expr[subexpr]        {
+            auto retE = make_smart<ExprReturn>(tokAt(scanner,@loc), ExpressionPtr($subexpr));
+            auto blkE = new ExprBlock();
+            blkE->at = tokAt(scanner,@loc);
+            blkE->list.push_back(retE);
+            $$ = blkE;
+    }
+    |   MAPTO[loc] LARROW expr[subexpr]        {
+            auto retE = make_smart<ExprReturn>(tokAt(scanner,@loc), ExpressionPtr($subexpr));
+            retE->moveSemantics = true;
+            auto blkE = new ExprBlock();
+            blkE->at = tokAt(scanner,@loc);
+            blkE->list.push_back(retE);
+            $$ = blkE;
+    }
+    ;
+
+block_or_lambda
+    :   '$'     { $$ = 0;   /* block */  }
+    |   '@'     { $$ = 1;   /* lambda */ }
+    |   '@' '@' { $$ = 2;   /* local function */ }
+    ;
+
+capture_entry
+    :   '&' NAME[name]              { $$ = new CaptureEntry(*$name,CaptureMode::capture_by_reference); delete $name; }
+    |   '=' NAME[name]              { $$ = new CaptureEntry(*$name,CaptureMode::capture_by_copy); delete $name; }
+    |   LARROW NAME[name]           { $$ = new CaptureEntry(*$name,CaptureMode::capture_by_move); delete $name; }
+    |   CLONEEQU NAME[name]         { $$ = new CaptureEntry(*$name,CaptureMode::capture_by_clone); delete $name; }
+    |   NAME[op] '(' NAME[name] ')' { $$ = ast_makeCaptureEntry(scanner,tokAt(scanner,@op),*$op,*$name); delete $op; delete $name; }
+    ;
+
+capture_list
+    :  capture_entry[ce] {
+        $$ = new vector<CaptureEntry>();
+        $$->push_back(*$ce);
+        delete $ce;
+    }
+    |   capture_list[cl] ',' capture_entry[ce] {
+        $cl->push_back(*$ce);
+        delete $ce;
+        $$ = $cl;
+    }
+    ;
+
+optional_capture_list
+    :   { $$ = nullptr; }
+    |   BRABRAB capture_list[cl] ']' ']' { $$ = $cl; }
+    |   DAS_CAPTURE '(' capture_list[cl] ')' { $$ = $cl; }
+    ;
+
+expr_block
+    :   expression_block[block]             {
+        ExprBlock * closure = (ExprBlock *) $block;
+        $$ = new ExprMakeBlock(tokAt(scanner,@block),ExpressionPtr($block));
+        closure->returnType = make_smart<TypeDecl>(Type::autoinfer);
+    }
+    |   block_or_lambda[bal] optional_annotation_list[annL] optional_capture_list[clist] optional_function_argument_list[list]
+                                optional_function_type[result] block_or_simple_block[block] {
+        $$ = ast_makeBlock(scanner,$bal,$annL,$clist,$list,$result,$block,tokAt(scanner,@block),tokAt(scanner,@annL));
+    }
+    ;
+
+expr_full_block
+    :   block_or_lambda[bal] optional_annotation_list[annL] optional_capture_list[clist] optional_function_argument_list[list]
+                                optional_function_type[result] block_or_simple_block[block] {
+        $$ = ast_makeBlock(scanner,$bal,$annL,$clist,$list,$result,$block,tokAt(scanner,@block),tokAt(scanner,@annL));
+    }
+    ;
+
+expr_full_block_assumed_piped
+    :   block_or_lambda[bal] {  yyextra->das_need_oxford_comma = false; }
+            optional_annotation_list[annL] optional_capture_list[clist] optional_function_argument_list[list]
+                                optional_function_type[result] expression_block[block] {
+        $$ = ast_makeBlock(scanner,$bal,$annL,$clist,$list,$result,$block,tokAt(scanner,@block),tokAt(scanner,@annL));
+    }
+    ;
+
+
+expr_numeric_const
+    :   INTEGER[const]                        { $$ = new ExprConstInt(tokAt(scanner,@const),(int32_t)$const); }
+    |   UNSIGNED_INTEGER[const]               { $$ = new ExprConstUInt(tokAt(scanner,@const),(uint32_t)$const); }
+    |   LONG_INTEGER[const]                   { $$ = new ExprConstInt64(tokAt(scanner,@const),(int64_t)$const); }
+    |   UNSIGNED_LONG_INTEGER[const]          { $$ = new ExprConstUInt64(tokAt(scanner,@const),(uint64_t)$const); }
+    |   UNSIGNED_INT8[const]                  { $$ = new ExprConstUInt8(tokAt(scanner,@const),(uint8_t)$const); }
+    |   FLOAT[const]                          { $$ = new ExprConstFloat(tokAt(scanner,@const),(float)$const); }
+    |   DOUBLE[const]                         { $$ = new ExprConstDouble(tokAt(scanner,@const),(double)$const); }
+    ;
+
+expr_assign
+    :   expr[ex]                             { $$ = $ex; }
+    |   expr[left] '='[loc]    expr[right]   { $$ = new ExprCopy(tokAt(scanner,@loc),ExpressionPtr($left),ExpressionPtr($right)); }
+    |   expr[left] LARROW[loc] expr[right]   { $$ = new ExprMove(tokAt(scanner,@loc),ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] CLONEEQU[loc] expr[right] { $$ = new ExprClone(tokAt(scanner,@loc),ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ANDEQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"&=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] OREQU[loc] expr[right]    { $$ = new ExprOp2(tokAt(scanner,@loc),"|=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] XOREQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"^=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ANDANDEQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"&&=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] OROREQU[loc] expr[right]     { $$ = new ExprOp2(tokAt(scanner,@loc),"||=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] XORXOREQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"^^=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ADDEQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"+=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] SUBEQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"-=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] MULEQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"*=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] DIVEQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"/=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] MODEQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"%=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] SHLEQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"<<=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] SHREQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),">>=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ROTLEQU[loc] expr[right]  { $$ = new ExprOp2(tokAt(scanner,@loc),"<<<=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ROTREQU[loc] expr[right]  { $$ = new ExprOp2(tokAt(scanner,@loc),">>>=", ExpressionPtr($left), ExpressionPtr($right)); }
+    ;
+
+expr_assign_pipe_right
+    :   LAPIPE expr_block[right]   { $$ = $right; }
+    |   LFPIPE expr_block[right]   { $$ = $right; }
+    |   LLPIPE expr_block[right]   { $$ = $right; }
+    |   expr_call_pipe[right]      { $$ = $right; }
+    ;
+
+
+expr_assign_pipe
+    :   expr[left] '='[loc]       expr_assign_pipe_right[right]   { $$ = new ExprCopy(tokAt(scanner,@loc),ExpressionPtr($left),ExpressionPtr($right)); }
+    |   expr[left] LARROW[loc]    expr_assign_pipe_right[right]   { $$ = new ExprMove(tokAt(scanner,@loc),ExpressionPtr($left),ExpressionPtr($right)); }
+    |   expr[left] ANDEQU[loc]    expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"&=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] OREQU[loc]     expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"|=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] XOREQU[loc]    expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"^=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ANDANDEQU[loc] expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"&&=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] OROREQU[loc]   expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"||=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] XORXOREQU[loc] expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"^^=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ADDEQU[loc]    expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"+=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] SUBEQU[loc]    expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"-=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] MULEQU[loc]    expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"*=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] DIVEQU[loc]    expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"/=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] MODEQU[loc]    expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"%=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] SHLEQU[loc]    expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"<<=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] SHREQU[loc]    expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),">>=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ROTLEQU[loc]   expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"<<<=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ROTREQU[loc]   expr_assign_pipe_right[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),">>>=", ExpressionPtr($left), ExpressionPtr($right)); }
+
+    ;
+
+expr_named_call
+    :   name_in_namespace[name] '(' '[' make_struct_fields[list] ']' ')' {
+        auto nc = new ExprNamedCall(tokAt(scanner,@name),*$name);
+        nc->arguments = *$list;
+        delete $list;
+        delete $name;
+        $$ = nc;
+    }
+    |   name_in_namespace[name] '(' expr_list[arguments] ',' '[' make_struct_fields[list] ']' ')' {
+        auto nc = new ExprNamedCall(tokAt(scanner,@name),*$name);
+        nc->nonNamedArguments = sequenceToList($arguments);
+        nc->arguments = *$list;
+        delete $list;
+        delete $name;
+        $$ = nc;
+    }
+    ;
+
+/* a->b(args) is short for invoke(a.b, a, args)  */
+expr_method_call
+    :   expr[left] RARROW[loc] NAME[method_name] '(' ')' {
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,@loc), $left, *$method_name);
+        delete $method_name;
+        $$ = pInvoke;
+    }
+    |   expr[left] RARROW[loc] NAME[method_name] '(' expr_list[arguments] ')' {
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,@loc), $left, *$method_name);
+        auto callArgs = sequenceToList($arguments);
+        pInvoke->arguments.insert ( pInvoke->arguments.end(), callArgs.begin(), callArgs.end() );
+        delete $method_name;
+        $$ = pInvoke;
+    }
+    ;
+
+func_addr_name
+    :   name_in_namespace[name]     {
+        $$ = new ExprAddr(tokAt(scanner,@name),*$name);
+        delete $name;
+    }
+    |   MTAG_I[loc] '(' expr[subexpr] ')' {
+        auto expr = new ExprAddr(tokAt(scanner,@loc),"``MACRO``TAG``ADDR``");
+        $$ = new ExprTag(tokAt(scanner,@subexpr),$subexpr, expr, "i");
+    }
+    ;
+
+func_addr_expr
+    :   '@' '@' func_addr_name[faddr]     {
+        $$ = $faddr;
+    }
+    |   '@' '@' '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options[blockType] '>' { yyextra->das_arrow_depth --; } func_addr_name[faddr] {
+        auto expr = (ExprAddr *) ($faddr->rtti_isAddr() ? $faddr : (((ExprTag *) $faddr)->value.get()));
+        expr->funcType = TypeDeclPtr($blockType);
+        $$ = $faddr;
+    }
+    |   '@' '@' '<' { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } func_addr_name[faddr] {
+        auto expr = (ExprAddr *) ($faddr->rtti_isAddr() ? $faddr : (((ExprTag *) $faddr)->value.get()));
+        expr->funcType = make_smart<TypeDecl>(Type::tFunction);
+        expr->funcType->firstType = TypeDeclPtr($result);
+        if ( $list ) {
+            varDeclToTypeDecl(scanner, expr->funcType.get(), $list);
+            deleteVariableDeclarationList($list);
+        }
+        $$ = $faddr;
+    }
+    ;
+
+expr_field
+    :   expr[subexpr] '.'[loc] NAME[name]     {
+        $$ = new ExprField(tokAt(scanner,@loc), tokAt(scanner,@name), ExpressionPtr($subexpr), *$name);
+        delete $name;
+    }
+    |   expr[subexpr] '.' '.'[loc] NAME[name]     {
+        $$ = new ExprField(tokAt(scanner,@loc), tokAt(scanner,@name), ExpressionPtr($subexpr), *$name, true);
+        delete $name;
+    }
+    |   expr[left] '.'[loc] NAME[method_name] '(' ')' {
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,@loc), $left, *$method_name);
+        delete $method_name;
+        $$ = pInvoke;
+    }
+    |   expr[left] '.'[loc] NAME[method_name] '(' expr_list[arguments] ')' {
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,@loc), $left, *$method_name);
+        auto callArgs = sequenceToList($arguments);
+        pInvoke->arguments.insert ( pInvoke->arguments.end(), callArgs.begin(), callArgs.end() );
+        delete $method_name;
+        $$ = pInvoke;
+    }
+    |   expr[left] '.'[loc] NAME[method_name] '(' '[' make_struct_fields[list] ']' ')' {
+        auto nc = new ExprNamedCall(tokAt(scanner,@method_name),*$method_name);
+        nc->methodCall = true;
+        nc->arguments = *$list;
+        nc->nonNamedArguments.push_back(ExpressionPtr($left));
+        delete $list;
+        delete $method_name;
+        $$ = nc;
+    }
+    |   expr[left] '.'[loc] basic_type_declaration[method_type] '(' ')' {
+        auto method_name = das_to_string($method_type);
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,@loc), $left, method_name);
+        $$ = pInvoke;
+    }
+    |   expr[left] '.'[loc] basic_type_declaration[method_type] '(' expr_list[arguments] ')' {
+        auto method_name = das_to_string($method_type);
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,@loc), $left, method_name);
+        auto callArgs = sequenceToList($arguments);
+        pInvoke->arguments.insert ( pInvoke->arguments.end(), callArgs.begin(), callArgs.end() );
+        $$ = pInvoke;
+    }
+    |   expr[subexpr] '.'[loc] { yyextra->das_suppress_errors=true; } error { yyextra->das_suppress_errors=false; } {
+        $$ = new ExprField(tokAt(scanner,@loc), tokAt(scanner,@loc), ExpressionPtr($subexpr), "");
+        yyerrok;
+    }
+    ;
+
+expr_call
+    :   name_in_namespace[name] '(' ')'[atend] {
+            $$ = yyextra->g_Program->makeCall(tokAt(scanner,@name),tokAt(scanner,@atend),*$name);
+            delete $name;
+    }
+    |   name_in_namespace[name] '(' DAS_UNINITIALIZED ')' {
+            auto dd = new ExprMakeStruct(tokAt(scanner,@name));
+            dd->at = tokAt(scanner,@name);
+            dd->makeType = new TypeDecl(Type::alias);
+            dd->makeType->alias = *$name;
+            dd->useInitializer = false;
+            dd->alwaysUseInitializer = true;
+            delete $name;
+            $$ = dd;
+    }
+    |   name_in_namespace[name] '(' make_struct_single[dd] ')' {
+            ((ExprMakeStruct *)$dd)->at = tokAt(scanner,@name);
+            ((ExprMakeStruct *)$dd)->makeType = new TypeDecl(Type::alias);
+            ((ExprMakeStruct *)$dd)->makeType->alias = *$name;
+            ((ExprMakeStruct *)$dd)->useInitializer = true;
+            ((ExprMakeStruct *)$dd)->alwaysUseInitializer = true;
+            delete $name;
+            $$ = $dd;
+    }
+    |   name_in_namespace[name] '(' DAS_UNINITIALIZED make_struct_single[dd] ')' {
+            ((ExprMakeStruct *)$dd)->at = tokAt(scanner,@name);
+            ((ExprMakeStruct *)$dd)->makeType = new TypeDecl(Type::alias);
+            ((ExprMakeStruct *)$dd)->makeType->alias = *$name;
+            ((ExprMakeStruct *)$dd)->useInitializer = false;
+            ((ExprMakeStruct *)$dd)->alwaysUseInitializer = true;
+            delete $name;
+            $$ = $dd;
+    }
+    |   name_in_namespace[name] '(' expr_list[arguments] ')'[atend] {
+            $$ = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,@name),tokAt(scanner,@atend),*$name),$arguments);
+            delete $name;
+    }
+    |   basic_type_declaration[type] '(' ')'[atend] {
+        $$ = yyextra->g_Program->makeCall(tokAt(scanner,@type),tokAt(scanner,@atend),das_to_string($type));
+    }
+    |   basic_type_declaration[type] '(' expr_list[arguments] ')'[atend] {
+        $$ = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,@type),tokAt(scanner,@atend),das_to_string($type)),$arguments);
+    }
+    ;
+
+expr
+    :   DAS_NULL[loc]                         { $$ = new ExprConstPtr(tokAt(scanner,@loc),nullptr); }
+    |   name_in_namespace[name]               { $$ = new ExprVar(tokAt(scanner,@name),*$name); delete $name; }
+    |   expr_numeric_const[nc]                { $$ = $nc; }
+    |   expr_reader[rdr]                      { $$ = $rdr; }
+    |   string_builder[sb]                    { $$ = $sb; }
+    |   make_decl[md]                         { $$ = $md; }
+    |   DAS_TRUE[loc]                         { $$ = new ExprConstBool(tokAt(scanner,@loc),true); }
+    |   DAS_FALSE[loc]                        { $$ = new ExprConstBool(tokAt(scanner,@loc),false); }
+    |   expr_field[subexpr]                   { $$ = $subexpr; }
+    |   expr_mtag[subexpr]                    { $$ = $subexpr; }
+    |   '!'[loc] expr[subexpr]                { $$ = new ExprOp1(tokAt(scanner,@loc),"!",ExpressionPtr($subexpr)); }
+    |   '~'[loc] expr[subexpr]                { $$ = new ExprOp1(tokAt(scanner,@loc),"~",ExpressionPtr($subexpr)); }
+    |   '+'[loc] expr[subexpr] %prec  UNARY_PLUS  { $$ = new ExprOp1(tokAt(scanner,@loc),"+",ExpressionPtr($subexpr)); }
+    |   '-'[loc] expr[subexpr] %prec  UNARY_MINUS { $$ = new ExprOp1(tokAt(scanner,@loc),"-",ExpressionPtr($subexpr)); }
+    |   expr[left] SHL[loc]    expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"<<", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] SHR[loc]    expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),">>", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ROTL[loc]    expr[right]  { $$ = new ExprOp2(tokAt(scanner,@loc),"<<<", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ROTR[loc]    expr[right]  { $$ = new ExprOp2(tokAt(scanner,@loc),">>>", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] '+'[loc]    expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"+", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] '-'[loc]    expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"-", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] '*'[loc]    expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"*", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] '/'[loc]    expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"/", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] '%'[loc]    expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"%", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] '<'[loc]    expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"<", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] '>'[loc]    expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),">", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] EQUEQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"==", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] NOTEQU[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"!=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] LEEQU[loc]  expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"<=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] GREQU[loc]  expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),">=", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] '&'[loc] expr[right]      { $$ = new ExprOp2(tokAt(scanner,@loc),"&", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] '|'[loc] expr[right]      { $$ = new ExprOp2(tokAt(scanner,@loc),"|", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] '^'[loc] expr[right]      { $$ = new ExprOp2(tokAt(scanner,@loc),"^", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] ANDAND[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"&&", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] OROR[loc] expr[right]     { $$ = new ExprOp2(tokAt(scanner,@loc),"||", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] XORXOR[loc] expr[right]   { $$ = new ExprOp2(tokAt(scanner,@loc),"^^", ExpressionPtr($left), ExpressionPtr($right)); }
+    |   expr[left] DOTDOT[loc] expr[right]   {
+        auto itv = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"interval");
+        itv->arguments.push_back(ExpressionPtr($left));
+        itv->arguments.push_back(ExpressionPtr($right));
+        $$ = itv;
+    }
+    |   ADDADD[loc] expr[subexpr] %prec PRE_INC  { $$ = new ExprOp1(tokAt(scanner,@loc),"++", ExpressionPtr($subexpr)); }
+    |   SUBSUB[loc] expr[subexpr] %prec PRE_DEC  { $$ = new ExprOp1(tokAt(scanner,@loc),"--", ExpressionPtr($subexpr)); }
+    |   expr[subexpr] ADDADD[loc] %prec POST_INC { $$ = new ExprOp1(tokAt(scanner,@loc),"+++", ExpressionPtr($subexpr)); }
+    |   expr[subexpr] SUBSUB[loc] %prec POST_DEC { $$ = new ExprOp1(tokAt(scanner,@loc),"---", ExpressionPtr($subexpr)); }
+    |   '(' expr_list[subexpr] optional_comma[comma] ')' {
+            if ( $subexpr->rtti_isSequence() ) {
+                auto mkt = new ExprMakeTuple(tokAt(scanner,@subexpr));
+                mkt->values = sequenceToList($subexpr);
+                $$ = mkt;
+            } else if ( $comma ) {
+                auto mkt = new ExprMakeTuple(tokAt(scanner,@subexpr));
+                mkt->values.push_back($subexpr);
+                $$ = mkt;
+            } else {
+                $$ = $subexpr;
+            }
+        }
+    |   expr[subexpr] '['[loc] expr[index] ']'   { $$ = new ExprAt(tokAt(scanner,@loc), ExpressionPtr($subexpr), ExpressionPtr($index)); }
+    |   expr[subexpr] '.' '['[loc] expr[index] ']'   { $$ = new ExprAt(tokAt(scanner,@loc), ExpressionPtr($subexpr), ExpressionPtr($index), true); }
+    |   expr[subexpr] QBRA[loc] expr[index] ']'  { $$ = new ExprSafeAt(tokAt(scanner,@loc), ExpressionPtr($subexpr), ExpressionPtr($index)); }
+    |   expr[subexpr] '.' QBRA[loc] expr[index] ']'  { $$ = new ExprSafeAt(tokAt(scanner,@loc), ExpressionPtr($subexpr), ExpressionPtr($index), true); }
+    |   expr[subexpr] QDOT[loc] NAME[name]       { $$ = new ExprSafeField(tokAt(scanner,@loc), tokAt(scanner,@name), ExpressionPtr($subexpr), *$name); delete $name; }
+    |   expr[subexpr] '.' QDOT[loc] NAME[name]       { $$ = new ExprSafeField(tokAt(scanner,@loc), tokAt(scanner,@name), ExpressionPtr($subexpr), *$name, true); delete $name; }
+    |   func_addr_expr[subexpr]                  { $$ = $subexpr; }
+    |   expr_call[call] { $$ = $call; }
+    |   '*'[loc] expr[subexpr] %prec DEREF         { $$ = new ExprPtr2Ref(tokAt(scanner,@loc),ExpressionPtr($subexpr)); }
+    |   DAS_DEREF[loc] '(' expr[subexpr] ')'       { $$ = new ExprPtr2Ref(tokAt(scanner,@loc),ExpressionPtr($subexpr)); }
+    |   DAS_ADDR[loc] '(' expr[subexpr] ')'        { $$ = new ExprRef2Ptr(tokAt(scanner,@loc),ExpressionPtr($subexpr)); }
+    |   DAS_GENERATOR[loc] '<' type_declaration_no_options[typeDecl] '>' optional_capture_list[clist] '(' ')' {
+        $$ = ast_makeGenerator(scanner,$typeDecl,$clist,nullptr,tokAt(scanner,@loc));
+    }
+    |   DAS_GENERATOR[loc] '<' type_declaration_no_options[typeDecl] '>' optional_capture_list[clist] '(' expr[subexpr] ')' {
+        $$ = ast_makeGenerator(scanner,$typeDecl,$clist,$subexpr,tokAt(scanner,@loc));
+    }
+    |   expr[subexpr] QQ[loc] expr[dval]           { $$ = new ExprNullCoalescing(tokAt(scanner,@loc),ExpressionPtr($subexpr),ExpressionPtr($dval)); }
+    |   expr[subexpr] '?'[loc] expr[left] ':' expr[right] {
+            $$ = new ExprOp3(tokAt(scanner,@loc),"?",ExpressionPtr($subexpr),ExpressionPtr($left),ExpressionPtr($right));
+        }
+    |   expr[subexpr] DAS_IS[loc] DAS_TYPE '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options[decl] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new ExprIs(tokAt(scanner,@loc),ExpressionPtr($subexpr),TypeDeclPtr($decl));
+    }
+    |   expr[subexpr] DAS_IS[loc] basic_type_declaration[decl] {
+        auto vdecl = new TypeDecl($decl);
+        vdecl->at = tokAt(scanner,@decl);
+        $$ = new ExprIs(tokAt(scanner,@loc),ExpressionPtr($subexpr),vdecl);
+    }
+    |   expr[subexpr] DAS_IS[loc] NAME[vname] {
+        $$ = new ExprIsVariant(tokAt(scanner,@loc),ExpressionPtr($subexpr),*$vname);
+        delete $vname;
+    }
+    |   expr[subexpr] DAS_AS[loc] NAME[vname] {
+        $$ = new ExprAsVariant(tokAt(scanner,@loc),ExpressionPtr($subexpr),*$vname);
+        delete $vname;
+    }
+    |   expr[subexpr] DAS_AS[loc] DAS_TYPE '<' { yyextra->das_arrow_depth ++; } type_declaration[decl] '>' { yyextra->das_arrow_depth --; } {
+        auto vname = $decl->describe();
+        $$ = new ExprAsVariant(tokAt(scanner,@loc),ExpressionPtr($subexpr),vname);
+        delete $decl;
+    }
+    |   expr[subexpr] DAS_AS[loc] basic_type_declaration[decl] {
+        $$ = new ExprAsVariant(tokAt(scanner,@loc),ExpressionPtr($subexpr),das_to_string($decl));
+    }
+    |   expr[subexpr] '?' DAS_AS[loc] NAME[vname] {
+        $$ = new ExprSafeAsVariant(tokAt(scanner,@loc),ExpressionPtr($subexpr),*$vname);
+        delete $vname;
+    }
+    |   expr[subexpr] '?' DAS_AS[loc] DAS_TYPE '<' { yyextra->das_arrow_depth ++; } type_declaration[decl] '>' { yyextra->das_arrow_depth --; } {
+        auto vname = $decl->describe();
+        $$ = new ExprSafeAsVariant(tokAt(scanner,@loc),ExpressionPtr($subexpr),vname);
+        delete $decl;
+    }
+    |   expr[subexpr] '?' DAS_AS[loc] basic_type_declaration[decl] {
+        $$ = new ExprSafeAsVariant(tokAt(scanner,@loc),ExpressionPtr($subexpr),das_to_string($decl));
+    }
+    |   expr_type_info[subexpr]                 { $$ = $subexpr; }
+    |   expr_type_decl[subexpr]                 { $$ = $subexpr; }
+    |   expr_cast[subexpr]                      { $$ = $subexpr; }
+    |   expr_new[subexpr]                       { $$ = $subexpr; }
+    |   expr_method_call[subexpr]               { $$ = $subexpr; }
+    |   expr_named_call[subexpr]                { $$ = $subexpr; }
+    |   expr_full_block[subexpr]                { $$ = $subexpr; }
+    |   expr[fncall] LPIPE[loc] expr[arg]       { $$ = ast_lpipe(scanner,$fncall,$arg,tokAt(scanner,@loc)); }
+    |   expr[arg] RPIPE[loc] expr[fncall]       { $$ = ast_rpipe(scanner,$arg,$fncall,tokAt(scanner,@loc)); }
+
+    |   expr[arg] RPIPE[loc] basic_type_declaration[type] {
+        auto fncall = yyextra->g_Program->makeCall(tokAt(scanner,@type),tokAt(scanner,@type),das_to_string($type));
+        $$ = ast_rpipe(scanner,$arg,fncall,tokAt(scanner,@loc));
+    }
+    | name_in_namespace[ena] NAME[eni]          { $$ = ast_NameName(scanner,$ena,$eni,tokAt(scanner,@ena),tokAt(scanner,@eni)); }
+    |   DAS_UNSAFE '(' expr[subexpr] ')' {
+        $subexpr->alwaysSafe = true;
+        $subexpr->userSaidItsSafe = true;
+        $$ = $subexpr;
+    }
+    |   expression_keyword[kwd] { $$ = $kwd; }
+    ;
+
+expr_mtag
+    :   MTAG_E '(' expr[subexpr] ')'                 { $$ = new ExprTag(tokAt(scanner,@subexpr),$subexpr,"e"); }
+    |   MTAG_I '(' expr[subexpr] ')'                 { $$ = new ExprTag(tokAt(scanner,@subexpr),$subexpr,"i"); }
+    |   MTAG_V '(' expr[subexpr] ')'                 { $$ = new ExprTag(tokAt(scanner,@subexpr),$subexpr,"v"); }
+    |   MTAG_B '(' expr[subexpr] ')'                 { $$ = new ExprTag(tokAt(scanner,@subexpr),$subexpr,"b"); }
+    |   MTAG_A '(' expr[subexpr] ')'                 { $$ = new ExprTag(tokAt(scanner,@subexpr),$subexpr,"a"); }
+    |   MTAG_DOTDOTDOT[subexpr]                      { $$ = new ExprTag(tokAt(scanner,@subexpr),nullptr,"..."); }
+    |   MTAG_C[cname] '(' expr[subexpr] ')' '(' ')' [atend] {
+            auto ccall = yyextra->g_Program->makeCall(tokAt(scanner,@cname),tokAt(scanner,@atend),"``MACRO``TAG``CALL``");
+            $$ = new ExprTag(tokAt(scanner,@cname),$subexpr,ccall,"c");
+        }
+    |   MTAG_C[cname] '(' expr[subexpr] ')' '(' expr_list[arguments] ')'[atend] {
+            auto ccall = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,@cname),tokAt(scanner,@atend),"``MACRO``TAG``CALL``"),$arguments);
+            $$ = new ExprTag(tokAt(scanner,@cname),$subexpr,ccall,"c");
+        }
+    |   expr[subexpr] '.'[loc] MTAG_F[cname] '(' expr[name] ')' {
+        auto cfield = new ExprField(tokAt(scanner,@loc), tokAt(scanner,@name), ExpressionPtr($subexpr), "``MACRO``TAG``FIELD``");
+        $$ = new ExprTag(tokAt(scanner,@name),$name,cfield,"f");
+    }
+    |   expr[subexpr] QDOT[loc] MTAG_F[cname] '(' expr[name] ')' {
+        auto cfield = new ExprSafeField(tokAt(scanner,@loc), tokAt(scanner,@name), ExpressionPtr($subexpr), "``MACRO``TAG``FIELD``");
+        $$ = new ExprTag(tokAt(scanner,@name),$name,cfield,"f");
+    }
+    |   expr[subexpr] '.' '.'[loc] MTAG_F[cname] '(' expr[name] ')' {
+        auto cfield = new ExprField(tokAt(scanner,@loc), tokAt(scanner,@name), ExpressionPtr($subexpr), "``MACRO``TAG``FIELD``", true);
+        $$ = new ExprTag(tokAt(scanner,@name),$name,cfield,"f");
+    }
+    |   expr[subexpr] '.' QDOT[loc] MTAG_F[cname] '(' expr[name] ')' {
+        auto cfield = new ExprSafeField(tokAt(scanner,@loc), tokAt(scanner,@name), ExpressionPtr($subexpr), "``MACRO``TAG``FIELD``", true);
+        $$ = new ExprTag(tokAt(scanner,@name),$name,cfield,"f");
+    }
+    |   expr[subexpr] DAS_AS[loc] MTAG_F[cname] '(' expr[name] ')' {
+        auto cfield = new ExprAsVariant(tokAt(scanner,@loc),ExpressionPtr($subexpr),"``MACRO``TAG``FIELD``");
+        $$ = new ExprTag(tokAt(scanner,@name),$name,cfield,"f");
+    }
+    |   expr[subexpr] '?' DAS_AS[loc] MTAG_F[cname] '(' expr[name] ')' {
+        auto cfield = new ExprSafeAsVariant(tokAt(scanner,@loc),ExpressionPtr($subexpr),"``MACRO``TAG``FIELD``");
+        $$ = new ExprTag(tokAt(scanner,@name),$name,cfield,"f");
+    }
+    |   expr[subexpr] DAS_IS[loc] MTAG_F[cname] '(' expr[name] ')' {
+        auto cfield = new ExprIsVariant(tokAt(scanner,@loc),ExpressionPtr($subexpr),"``MACRO``TAG``FIELD``");
+        $$ = new ExprTag(tokAt(scanner,@name),$name,cfield,"f");
+    }
+    |   '@' '@'[loc] MTAG_C[cname] '(' expr[subexpr] ')' {
+        auto ccall = new ExprAddr(tokAt(scanner,@loc),"``MACRO``TAG``ADDR``");
+        $$ = new ExprTag(tokAt(scanner,@cname),$subexpr,ccall,"c");
+    }
+    ;
+
+optional_field_annotation
+    :                                                   { $$ = nullptr; }
+    |   BRABRAB annotation_argument_list[alist] ']' ']' { $$ = $alist; /*this one is gone when BRABRA is disabled*/ }
+    |   metadata_argument_list[alist]                   { $$ = $alist; }
+    ;
+
+optional_override
+    :                 { $$ = OVERRIDE_NONE; }
+    |   DAS_OVERRIDE  { $$ = OVERRIDE_OVERRIDE; }
+    |   DAS_SEALED    { $$ = OVERRIDE_SEALED; }
+    ;
+
+optional_constant
+    :                   { $$ = false; }
+    |   DAS_CONST       { $$ = true; }
+    ;
+
+optional_public_or_private_member_variable
+    :                   { $$ = false; }
+    |   DAS_PUBLIC      { $$ = false; }
+    |   DAS_PRIVATE     { $$ = true; }
+    ;
+
+optional_static_member_variable
+    :                   { $$ = false; }
+    |   DAS_STATIC      { $$ = true; }
+    ;
+
+structure_variable_declaration
+    :   optional_field_annotation[alist] optional_static_member_variable[sta] optional_override[ovr] optional_public_or_private_member_variable[isPrivate] variable_declaration[decl] {
+        $decl->override = $ovr == OVERRIDE_OVERRIDE;
+        $decl->sealed = $ovr == OVERRIDE_SEALED;
+        $decl->annotation = $alist;
+        $decl->isPrivate = $isPrivate;
+        $decl->isStatic = $sta;
+        $$ = $decl;
+    }
+    ;
+
+struct_variable_declaration_list
+    :   {
+        $$ = new vector<VariableDeclaration*>();
+    }
+    |   struct_variable_declaration_list[list] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@list);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeStructureFields(tak);
+        }
+    } structure_variable_declaration[decl] ';' {
+        $$ = $list;
+        if ( $decl ) $list->push_back($decl);
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@list);
+            for ( auto & crd : yyextra->g_CommentReaders ) {
+                for ( const auto & nl : *($decl->pNameList) ) {
+                    crd->afterStructureField(nl.name.c_str(), nl.at);
+                }
+            }
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterStructureFields(tak);
+        }
+    }
+    |   struct_variable_declaration_list[list] optional_annotation_list[annL]
+            DAS_DEF[from] optional_public_or_private_member_variable[isPrivate] DAS_ABSTRACT optional_constant[cnst] {
+                yyextra->das_force_oxford_comma=true;
+                if ( !yyextra->g_CommentReaders.empty() ) {
+                    auto tak = tokAt(scanner,@isPrivate);
+                    for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeFunction(tak);
+                }
+            } function_declaration_header[func] ';' {
+                if ( !yyextra->g_CommentReaders.empty() ) {
+                    auto tak = tokAt(scanner,@func);
+                    for ( auto & crd : yyextra->g_CommentReaders ) crd->afterFunction($func,tak);
+                }
+                $func->isTemplate = yyextra->g_thisStructure->isTemplate;
+                $$ = ast_structVarDefAbstract(scanner,$list,$annL,$isPrivate,$cnst, $func);
+            }
+    |   struct_variable_declaration_list[list] optional_annotation_list[annL]
+            DAS_DEF[from] optional_public_or_private_member_variable[isPrivate] optional_static_member_variable[isStatic] optional_override[ovr] optional_constant[cnst] {
+                if ( !yyextra->g_CommentReaders.empty() ) {
+                    auto tak = tokAt(scanner,@cnst);
+                    for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeFunction(tak);
+                }
+            } function_declaration_header[func] expression_block[block] {
+                if ( !yyextra->g_CommentReaders.empty() ) {
+                    auto tak = tokAt(scanner,@block);
+                    for ( auto & crd : yyextra->g_CommentReaders ) crd->afterFunction($func,tak);
+                }
+                $func->isTemplate = yyextra->g_thisStructure->isTemplate;
+                $$ = ast_structVarDef(scanner,$list,$annL,$isStatic,$isPrivate,$ovr,$cnst,$func,$block,tokRangeAt(scanner,@from,@block),tokAt(scanner,@annL));
+            }
+    |   struct_variable_declaration_list[list] '[' annotation_list[annL] ']' ';' {
+        das_yyerror(scanner,"structure field or class method annotation expected to remain on the same line with the field or the class",
+            tokAt(scanner,@annL), CompilationError::syntax_error);
+        delete $annL;
+        $$ = $list;
+    }
+    ;
+
+function_argument_declaration
+    :   optional_field_annotation[ann] kwd_let_var_or_nothing[is_let] variable_declaration[decl]  {
+            $$ = $decl;
+            if ( $is_let ) {
+                $decl->pTypeDecl->constant = true;
+            } else {
+                $decl->pTypeDecl->removeConstant = true;
+            }
+            $decl->annotation = $ann;
+        }
+    |   MTAG_A '(' expr[subexpr] ')' {
+            auto na = new vector<VariableNameAndPosition>();
+            na->push_back(VariableNameAndPosition{"``MACRO``TAG``","",tokAt(scanner,@subexpr)});
+            auto decl = new VariableDeclaration(na, new TypeDecl(Type::none), $subexpr);
+            decl->pTypeDecl->isTag = true;
+            $$ = decl;
+        }
+    ;
+
+function_argument_list
+    :   function_argument_declaration[decl]                                      { $$ = new vector<VariableDeclaration*>(); $$->push_back($decl); }
+    |   function_argument_list[list] ';' function_argument_declaration[decl]     { $$ = $list; $list->push_back($decl); }
+    ;
+
+tuple_type
+    :   type_declaration [typeDecl] {
+        $$ = new VariableDeclaration(nullptr,$typeDecl,nullptr);
+    }
+    |   NAME[name] ':' type_declaration [typeDecl] {
+        auto na = new vector<VariableNameAndPosition>();
+        na->push_back(VariableNameAndPosition{*$name,"",tokAt(scanner,@name)});
+        $$ = new VariableDeclaration(na,$typeDecl,nullptr);
+        delete $name;
+    }
+    ;
+
+tuple_type_list
+    :   tuple_type[decl]                               { $$ = new vector<VariableDeclaration*>(); $$->push_back($decl); }
+    |   tuple_type_list[list] c_or_s tuple_type[decl]     { $$ = $list; $list->push_back($decl); }
+    ;
+
+tuple_alias_type_list
+    :   {
+        $$ = new vector<VariableDeclaration*>();
+    }
+    | tuple_alias_type_list[list] c_or_s {
+        $$ = $list;
+    }
+    |   tuple_alias_type_list[list] tuple_type[decl] c_or_s {
+        $$ = $list; $list->push_back($decl);
+        /*
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tokName = tokAt(scanner,@decl);
+            for ( auto & crd : yyextra->g_CommentReaders ) {
+                for ( const auto & nl : *($decl->pNameList) ) {
+                    crd->afterVariantEntry(nl.name.c_str(), nl.at);
+                }
+            }
+        }
+        */
+    }
+    ;
+
+variant_type
+    :   NAME[name] ':' type_declaration [typeDecl] {
+        auto na = new vector<VariableNameAndPosition>();
+        na->push_back(VariableNameAndPosition{*$name,"",tokAt(scanner,@name)});
+        $$ = new VariableDeclaration(na,$typeDecl,nullptr);
+        delete $name;
+    }
+    ;
+
+variant_type_list
+    :   variant_type[decl]                               { $$ = new vector<VariableDeclaration*>(); $$->push_back($decl); }
+    |   variant_type_list[list] c_or_s variant_type[decl]   { $$ = $list; $list->push_back($decl); }
+    ;
+
+variant_alias_type_list
+    :   {
+        $$ = new vector<VariableDeclaration*>();
+    }
+    | variant_alias_type_list[list] c_or_s {
+        $$ = $list;
+    }
+    |   variant_alias_type_list[list] variant_type[decl] c_or_s {
+        $$ = $list; $list->push_back($decl);
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tokName = tokAt(scanner,@decl);
+            for ( auto & crd : yyextra->g_CommentReaders ) {
+                for ( const auto & nl : *($decl->pNameList) ) {
+                    crd->afterVariantEntry(nl.name.c_str(), nl.at);
+                }
+            }
+        }
+    }
+    ;
+
+copy_or_move
+    :   '='         { $$ = false; }
+    |   LARROW      { $$ = true; }
+    ;
+
+variable_declaration        /* this one can have uninitialized variable which has no type */
+    :   variable_name_with_pos_list[list] {
+        auto autoT = new TypeDecl(Type::autoinfer);
+        autoT->at = tokAt(scanner,@list);
+        autoT->ref = false;
+        $$ = new VariableDeclaration($list,autoT,nullptr);
+    }
+    |   variable_name_with_pos_list[list] '&' {
+        auto autoT = new TypeDecl(Type::autoinfer);
+        autoT->at = tokAt(scanner,@list);
+        autoT->ref = true;
+        $$ = new VariableDeclaration($list,autoT,nullptr);
+    }
+    |   variable_name_with_pos_list[list] ':' type_declaration[typeDecl]  {
+        $$ = new VariableDeclaration($list,$typeDecl,nullptr);
+    }
+    |   variable_name_with_pos_list[list] ':' type_declaration[typeDecl] copy_or_move[com] expr[init] {
+        $$ = new VariableDeclaration($list,$typeDecl,$init);
+        $$->init_via_move = $com;
+    }
+    |   variable_name_with_pos_list[list] copy_or_move[com] expr[init] {
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,@list);
+        $$ = new VariableDeclaration($list,typeDecl,$init);
+        $$->init_via_move = $com;
+    }
+    |   variable_name_with_pos_list[list] copy_or_move[com] expr_pipe[init] {
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,@list);
+        $$ = new VariableDeclaration($list,typeDecl,$init);
+        $$->init_via_move = $com;
+    }
+    ;
+
+copy_or_move_or_clone
+    :   '='         { $$ = CorM_COPY; }
+    |   LARROW      { $$ = CorM_MOVE; }
+    |   CLONEEQU    { $$ = CorM_CLONE; }
+    ;
+
+optional_ref
+    :       { $$ = false; }
+    |   '&' { $$ = true; }
+    ;
+
+let_variable_name_with_pos_list
+    :   NAME[name]  {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{*$name,"",tokAt(scanner,@name)});
+        $$ = pSL;
+        delete $name;
+    }
+    |   MTAG_I '(' expr[subexpr] ')' {
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{"``MACRO``TAG``","",tokAt(scanner,@subexpr),ExpressionPtr($subexpr)});
+        $$ = pSL;
+    }
+    |   NAME[name] DAS_AKA NAME[akaname] {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        das_checkName(scanner,*$akaname,tokAt(scanner,@akaname));
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{*$name,*$akaname,tokAt(scanner,@name)});
+        $$ = pSL;
+        delete $name;
+        delete $akaname;
+    }
+    |   let_variable_name_with_pos_list[list] ',' NAME[name] {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        $list->push_back(VariableNameAndPosition{*$name,"",tokAt(scanner,@name)});
+        $$ = $list;
+        delete $name;
+    }
+    |   let_variable_name_with_pos_list[list] ',' NAME[name] DAS_AKA NAME[akaname] {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        das_checkName(scanner,*$akaname,tokAt(scanner,@akaname));
+        $list->push_back(VariableNameAndPosition{*$name,*$akaname,tokAt(scanner,@name)});
+        $$ = $list;
+        delete $name;
+        delete $akaname;
+    }
+    ;
+
+let_variable_declaration    /* let x; is prohibited. this one can't have uninitialized variable which has no type */
+    :   let_variable_name_with_pos_list[list] ':' type_declaration_no_options[typeDecl] ';' {
+        $$ = new VariableDeclaration($list,$typeDecl,nullptr);
+    }
+    |   let_variable_name_with_pos_list[list] ':' type_declaration_no_options[typeDecl] copy_or_move_or_clone[com] expr[init] ';' {
+        $$ = new VariableDeclaration($list,$typeDecl,$init);
+        $$->init_via_move  = ($com & CorM_MOVE) !=0;
+        $$->init_via_clone = ($com & CorM_CLONE) !=0;
+    }
+    |   let_variable_name_with_pos_list[list] ':' type_declaration_no_options[typeDecl] copy_or_move_or_clone[com] expr_pipe[init] {
+        $$ = new VariableDeclaration($list,$typeDecl,$init);
+        $$->init_via_move  = ($com & CorM_MOVE) !=0;
+        $$->init_via_clone = ($com & CorM_CLONE) !=0;
+    }
+    |   let_variable_name_with_pos_list[list] optional_ref[ref] copy_or_move_or_clone[com] expr[init] ';' {
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,@list);
+        typeDecl->ref = $ref;
+        $$ = new VariableDeclaration($list,typeDecl,$init);
+        $$->init_via_move  = ($com & CorM_MOVE) !=0;
+        $$->init_via_clone = ($com & CorM_CLONE) !=0;
+    }
+    |   let_variable_name_with_pos_list[list] optional_ref[ref] copy_or_move_or_clone[com] expr_pipe[init] {
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,@list);
+        typeDecl->ref = $ref;
+        $$ = new VariableDeclaration($list,typeDecl,$init);
+        $$->init_via_move  = ($com & CorM_MOVE) !=0;
+        $$->init_via_clone = ($com & CorM_CLONE) !=0;
+    }
+    ;
+
+global_variable_declaration_list
+    :   {
+        $$ = new vector<VariableDeclaration*>();
+    }
+    |   global_variable_declaration_list[list] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@list);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeGlobalVariables(tak);
+        }
+    }   optional_field_annotation[ann] let_variable_declaration[decl] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@decl);
+            for ( auto & crd : yyextra->g_CommentReaders )
+                for ( auto & nl : *($decl->pNameList) )
+                    crd->afterGlobalVariable(nl.name.c_str(),tak);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterGlobalVariables(tak);
+        }
+        $$ = $list;
+        $decl->annotation = $ann;
+        $list->push_back($decl);
+    }
+    ;
+
+optional_shared
+    :                { $$ = false; }
+    |   DAS_SHARED   { $$ = true; }
+    ;
+
+optional_public_or_private_variable
+    :                { $$ = yyextra->g_Program->thisModule->isPublic; }
+    |   DAS_PRIVATE  { $$ = false; }
+    |   DAS_PUBLIC   { $$ = true; }
+    ;
+
+global_let
+    :   kwd_let optional_shared[glob_shar] optional_public_or_private_variable[pub_var] '{' global_variable_declaration_list[list] '}' {
+        ast_globalLetList(scanner,$kwd_let,$glob_shar,$pub_var,$list);
+    }
+    |   kwd_let optional_shared[glob_shar] optional_public_or_private_variable[pub_var] {
+        yyextra->das_force_oxford_comma=true;
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@pub_var);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeGlobalVariables(tak);
+        }
+    } optional_field_annotation[ann] let_variable_declaration[decl] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@decl);
+            for ( auto & crd : yyextra->g_CommentReaders )
+                for ( auto & nl : *($decl->pNameList) )
+                    crd->afterGlobalVariable(nl.name.c_str(),tak);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterGlobalVariables(tak);
+        }
+        ast_globalLet(scanner,$kwd_let,$glob_shar,$pub_var,$ann,$decl);
+    }
+    ;
+
+enum_list
+    :   {
+        $$ = new Enumeration();
+    }
+    |   enum_list[pE] ';' {
+        $$ = $pE;
+    }
+    |   enum_list[pE] NAME[name] ';' {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        if ( !$pE->add(*$name,nullptr,tokAt(scanner,@name)) ) {
+            das_yyerror(scanner,"enumeration already declared " + *$name, tokAt(scanner,@name),
+                CompilationError::enumeration_value_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tokName = tokAt(scanner,@name);
+            for ( auto & crd : yyextra->g_CommentReaders ) {
+                crd->afterEnumerationEntry($name->c_str(), tokName);
+            }
+        }
+        delete $name;
+        $$ = $pE;
+    }
+    |   enum_list[pE] NAME[name] '=' expr[value] ';' {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        if ( !$pE->add(*$name,ExpressionPtr($value),tokAt(scanner,@name)) ) {
+            das_yyerror(scanner,"enumeration value already declared " + *$name, tokAt(scanner,@name),
+                CompilationError::enumeration_value_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tokName = tokAt(scanner,@name);
+            for ( auto & crd : yyextra->g_CommentReaders ) {
+                crd->afterEnumerationEntry($name->c_str(), tokName);
+            }
+        }
+        delete $name;
+        $$ = $pE;
+    }
+    ;
+
+
+optional_public_or_private_alias
+    :                { $$ = yyextra->g_Program->thisModule->isPublic; }
+    |   DAS_PRIVATE  { $$ = false; }
+    |   DAS_PUBLIC   { $$ = true; }
+    ;
+
+
+single_alias
+    :  optional_public_or_private_alias[pubA] NAME[name] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto pubename = tokAt(scanner,@name);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeAlias(pubename);
+        }
+    } '=' type_declaration[tdecl] {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        $tdecl->isPrivateAlias = !$pubA;
+        if ( $tdecl->baseType == Type::alias ) {
+            das_yyerror(scanner,"alias cannot be defined in terms of another alias "+*$name,tokAt(scanner,@name),
+                CompilationError::invalid_type);
+        }
+        $tdecl->alias = *$name;
+        if ( !yyextra->g_Program->addAlias(TypeDeclPtr($tdecl)) ) {
+            das_yyerror(scanner,"type alias is already defined "+*$name,tokAt(scanner,@name),
+                CompilationError::type_alias_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto pubename = tokAt(scanner,@tdecl);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterAlias($name->c_str(),pubename);
+        }
+        delete $name;
+    }
+    ;
+
+alias_list
+    :   single_alias ';'
+    |   alias_list single_alias ';'
+    ;
+
+alias_declaration
+    :   DAS_TYPEDEF '{' alias_list '}'
+    |   DAS_TYPEDEF { yyextra->das_force_oxford_comma=true;} single_alias ';'
+    ;
+
+optional_public_or_private_enum
+    :                { $$ = yyextra->g_Program->thisModule->isPublic; }
+    |   DAS_PRIVATE  { $$ = false; }
+    |   DAS_PUBLIC   { $$ = true; }
+    ;
+
+enum_name
+    :   NAME[name] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto pubename = tokAt(scanner,@name);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeEnumeration(pubename);
+        }
+        $$ = ast_addEmptyEnum(scanner, $name, tokAt(scanner,@name));
+    }
+    ;
+
+enum_declaration
+    :   optional_annotation_list[annL] DAS_ENUM[loc] optional_public_or_private_enum[pubE] enum_name[edecl] '{' {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@edecl);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeEnumerationEntries(tak);
+        }
+    } enum_list[pE] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@pE);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterEnumerationEntries(tak);
+        }
+    } '}' {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto pubename = tokAt(scanner,@pE);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterEnumeration($edecl->name.c_str(),pubename);
+        }
+        ast_enumDeclaration(scanner,$annL,tokAt(scanner,@annL),$pubE,$edecl,$pE,Type::tInt);
+    }
+    |   optional_annotation_list[annL] DAS_ENUM[loc] optional_public_or_private_enum[pubE] enum_name[edecl] ':' enum_basic_type_declaration[ebt] '{' {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@edecl);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeEnumerationEntries(tak);
+        }
+    } enum_list[pE] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@pE);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterEnumerationEntries(tak);
+        }
+    } '}' {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto pubename = tokAt(scanner,@pE);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterEnumeration($edecl->name.c_str(),pubename);
+        }
+        ast_enumDeclaration(scanner,$annL,tokAt(scanner,@annL),$pubE,$edecl,$pE,$ebt);
+    }
+    ;
+
+optional_structure_parent
+    :                                   { $$ = nullptr; }
+    |   ':' name_in_namespace[name]     { $$ = $name; }
+    ;
+
+optional_sealed
+    :                   { $$ = false; }
+    |   DAS_SEALED      { $$ = true; }
+    ;
+
+structure_name
+    : optional_sealed[sealed] NAME[name] optional_structure_parent[parent] {
+        $$ = ast_structureName(scanner,$sealed,$name,tokAt(scanner,@name),$parent,tokAt(scanner,@parent));
+    }
+    ;
+
+class_or_struct
+    :   DAS_CLASS   { $$ = CorS_Class; }
+    |   DAS_STRUCT  { $$ = CorS_Struct; }
+    |   DAS_TEMPLATE DAS_CLASS   { $$ = CorS_ClassTemplate; }
+    |   DAS_TEMPLATE DAS_STRUCT  { $$ = CorS_StructTemplate; }
+    ;
+
+optional_public_or_private_structure
+    :                { $$ = yyextra->g_Program->thisModule->isPublic; }
+    |   DAS_PRIVATE  { $$ = false; }
+    |   DAS_PUBLIC   { $$ = true; }
+    ;
+
+optional_struct_variable_declaration_list
+    :   {
+        $$ = new vector<VariableDeclaration*>();
+    }
+    |   '{' struct_variable_declaration_list[list] '}' {
+        $$ = $list;
+    }
+    ;
+
+structure_declaration
+    : optional_annotation_list[annL] class_or_struct[loc] optional_public_or_private_structure[pub_str] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,@loc);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeStructure(tak);
+        }
+    } structure_name[ps] {
+        if ( $ps ) {
+            $ps->isClass = $loc==CorS_Class || $loc==CorS_ClassTemplate;
+            $ps->isTemplate = $loc==CorS_ClassTemplate || $loc==CorS_StructTemplate;
+            $ps->privateStructure = !$pub_str;
+        }
+    } optional_struct_variable_declaration_list[list] {
+        if ( $ps ) {
+            ast_structureDeclaration ( scanner, $annL, tokAt(scanner,@loc), $ps, tokAt(scanner,@ps), $list );
+            if ( !yyextra->g_CommentReaders.empty() ) {
+                auto tak = tokAt(scanner,@loc);
+                for ( auto & crd : yyextra->g_CommentReaders ) crd->afterStructure($ps,tak);
+            }
+        } else {
+            deleteVariableDeclarationList($list);
+        }
+    }
+    ;
+
+variable_name_with_pos_list
+    :   NAME[name]  {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{*$name,"",tokAt(scanner,@name)});
+        $$ = pSL;
+        delete $name;
+    }
+    |   MTAG_I '(' expr[subexpr] ')' {
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{"``MACRO``TAG``","",tokAt(scanner,@subexpr),$subexpr});
+        $$ = pSL;
+    }
+    |   NAME[name] DAS_AKA NAME[akaname] {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        das_checkName(scanner,*$akaname,tokAt(scanner,@akaname));
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{*$name,*$akaname,tokAt(scanner,@name)});
+        $$ = pSL;
+        delete $name;
+        delete $akaname;
+    }
+    |   variable_name_with_pos_list[list] ',' NAME[name] {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        $list->push_back(VariableNameAndPosition{*$name,"",tokAt(scanner,@name)});
+        $$ = $list;
+        delete $name;
+    }
+    |   variable_name_with_pos_list[list] ',' NAME[name] DAS_AKA NAME[akaname] {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        das_checkName(scanner,*$akaname,tokAt(scanner,@akaname));
+        $list->push_back(VariableNameAndPosition{*$name,*$akaname,tokAt(scanner,@name)});
+        $$ = $list;
+        delete $name;
+        delete $akaname;
+    }
+    ;
+
+basic_type_declaration
+    :   DAS_TBOOL       { $$ = Type::tBool; }
+    |   DAS_TSTRING     { $$ = Type::tString; }
+    |   DAS_TINT        { $$ = Type::tInt; }
+    |   DAS_TINT8       { $$ = Type::tInt8; }
+    |   DAS_TINT16      { $$ = Type::tInt16; }
+    |   DAS_TINT64      { $$ = Type::tInt64; }
+    |   DAS_TINT2       { $$ = Type::tInt2; }
+    |   DAS_TINT3       { $$ = Type::tInt3; }
+    |   DAS_TINT4       { $$ = Type::tInt4; }
+    |   DAS_TUINT       { $$ = Type::tUInt; }
+    |   DAS_TUINT8      { $$ = Type::tUInt8; }
+    |   DAS_TUINT16     { $$ = Type::tUInt16; }
+    |   DAS_TUINT64     { $$ = Type::tUInt64; }
+    |   DAS_TUINT2      { $$ = Type::tUInt2; }
+    |   DAS_TUINT3      { $$ = Type::tUInt3; }
+    |   DAS_TUINT4      { $$ = Type::tUInt4; }
+    |   DAS_TFLOAT      { $$ = Type::tFloat; }
+    |   DAS_TFLOAT2     { $$ = Type::tFloat2; }
+    |   DAS_TFLOAT3     { $$ = Type::tFloat3; }
+    |   DAS_TFLOAT4     { $$ = Type::tFloat4; }
+    |   DAS_TVOID       { $$ = Type::tVoid; }
+    |   DAS_TRANGE      { $$ = Type::tRange; }
+    |   DAS_TURANGE     { $$ = Type::tURange; }
+    |   DAS_TRANGE64    { $$ = Type::tRange64; }
+    |   DAS_TURANGE64   { $$ = Type::tURange64; }
+    |   DAS_TDOUBLE     { $$ = Type::tDouble; }
+    |   DAS_TBITFIELD   { $$ = Type::tBitfield; }
+    ;
+
+enum_basic_type_declaration
+    :   DAS_TINT        { $$ = Type::tInt; }
+    |   DAS_TINT8       { $$ = Type::tInt8; }
+    |   DAS_TINT16      { $$ = Type::tInt16; }
+    |   DAS_TUINT       { $$ = Type::tUInt; }
+    |   DAS_TUINT8      { $$ = Type::tUInt8; }
+    |   DAS_TUINT16     { $$ = Type::tUInt16; }
+    |   DAS_TINT64      { $$ = Type::tInt64; }
+    |   DAS_TUINT64     { $$ = Type::tUInt64; }
+    ;
+
+structure_type_declaration
+    :   name_in_namespace[name]  {
+        $$ = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,@name),*$name);
+        if ( !$$ ) {
+            $$ = new TypeDecl(Type::tVoid);
+            $$->at = tokAt(scanner,@name);
+        }
+        delete $name;
+    }
+    ;
+
+auto_type_declaration
+    :   DAS_TAUTO[loc] {
+        $$ = new TypeDecl(Type::autoinfer);
+        $$->at = tokAt(scanner,@loc);
+    }
+    |   DAS_TAUTO[loc] '(' NAME[alias] ')'  {
+        das_checkName(scanner,*$alias,tokAt(scanner,@alias));
+        $$ = new TypeDecl(Type::autoinfer);
+        $$->at = tokAt(scanner,@loc);
+        $$->alias = *$alias;
+        delete $alias;
+    }
+    |   MTAG_T[loc] '(' expr[subexpr] ')' {
+        $$ = new TypeDecl(Type::alias);
+        $$->at = tokAt(scanner,@loc);
+        $$->alias = "``MACRO``TAG``";
+        $$->isTag = true;
+        $$->firstType = new TypeDecl(Type::autoinfer);
+        $$->firstType->at = tokAt(scanner, @subexpr);
+        $$->firstType->dimExpr.push_back($subexpr);
+    }
+    ;
+
+bitfield_bits
+    :   NAME[name]  {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        auto pSL = new vector<string>();
+        pSL->push_back(*$name);
+        $$ = pSL;
+        delete $name;
+    }
+    |   bitfield_bits[list] ';' NAME[name] {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        $list->push_back(*$name);
+        $$ = $list;
+        delete $name;
+    }
+    ;
+
+bitfield_alias_bits
+    :   {
+        auto pSL = new vector<string>();
+        $$ = pSL;
+
+    }
+    |   bitfield_alias_bits[list] ';' {
+        $$ = $list;
+    }
+    |   bitfield_alias_bits[list] NAME[name] ';' {
+        das_checkName(scanner,*$name,tokAt(scanner,@name));
+        $list->push_back(*$name);
+        $$ = $list;
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@name);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterBitfieldEntry($name->c_str(),atvname);
+        }
+        delete $name;
+    }
+    ;
+
+bitfield_type_declaration
+    :   DAS_TBITFIELD[basicType] '<' { yyextra->das_arrow_depth ++; } bitfield_bits[nl] '>' { yyextra->das_arrow_depth --; } {
+            $$ = new TypeDecl(Type::tBitfield);
+            $$->argNames = *$nl;
+            if ( $$->argNames.size()>32 ) {
+                das_yyerror(scanner,"only 32 different bits are allowed in a bitfield",tokAt(scanner,@basicType),
+                    CompilationError::invalid_type);
+            }
+            $$->at = tokAt(scanner,@basicType);
+            delete $nl;
+    }
+    ;
+
+c_or_s
+    :   ','
+    |   ';'
+    ;
+
+table_type_pair
+    :   type_declaration[keyTypeDecl] {
+        $$.firstType = $keyTypeDecl;
+        $$.secondType = new TypeDecl(Type::tVoid);
+    }
+    |   type_declaration[keyTypeDecl] c_or_s type_declaration[valueTypeDecl] {
+        $$.firstType = $keyTypeDecl;
+        $$.secondType = $valueTypeDecl;
+    }
+    ;
+
+dim_list
+    :  '[' expr[dimExpr] ']' {
+        $$ = new TypeDecl(Type::autoinfer);
+        appendDimExpr($$, $dimExpr);
+    }
+    |  dim_list[list] '[' expr[dimExpr] ']' {
+        $$ = $list;
+        appendDimExpr($$, $dimExpr);
+    }
+    ;
+
+type_declaration_no_options
+    :   basic_type_declaration[basicType]                   { $$ = new TypeDecl($basicType); $$->at = tokAt(scanner,@basicType); }
+    |   auto_type_declaration[typeDecl]                     { $$ = $typeDecl; }
+    |   bitfield_type_declaration[typeDecl]                 { $$ = $typeDecl; }
+    |   structure_type_declaration[typeDecl]                { $$ = $typeDecl; }
+    |   type_declaration_no_options[typeDecl] dim_list[dimlist] {
+        if ( $typeDecl->baseType==Type::typeDecl ) {
+            das_yyerror(scanner,"type declaration can`t be used as array base type",tokAt(scanner,@typeDecl),
+                CompilationError::invalid_type);
+        } else if ( $typeDecl->baseType==Type::typeMacro ) {
+            das_yyerror(scanner,"macro can`t be used as array base type",tokAt(scanner,@typeDecl),
+                CompilationError::invalid_type);
+        }
+        $typeDecl->dim.insert($typeDecl->dim.begin(), $dimlist->dim.begin(), $dimlist->dim.end());
+        $typeDecl->dimExpr.insert($typeDecl->dimExpr.begin(), $dimlist->dimExpr.begin(), $dimlist->dimExpr.end());
+        $typeDecl->removeDim = false;
+        $$ = $typeDecl;
+        $dimlist->dimExpr.clear();
+        delete $dimlist;
+    }
+    |   type_declaration_no_options[typeDecl] '[' ']' {
+        $typeDecl->dim.push_back(TypeDecl::dimAuto);
+        $typeDecl->dimExpr.push_back(nullptr);
+        $typeDecl->removeDim = false;
+        $$ = $typeDecl;
+    }
+    |   DAS_TYPE '<' { yyextra->das_arrow_depth ++; } type_declaration[typeDecl] '>' { yyextra->das_arrow_depth --; } {
+        $typeDecl->autoToAlias = true;
+        $$ = $typeDecl;
+    }
+    |   DAS_TYPEDECL[td] '(' expr[subexpr] ')' {
+        $$ = new TypeDecl(Type::typeDecl);
+        $$->at = tokRangeAt(scanner,@td,@subexpr);
+        $$->dimExpr.push_back($subexpr);
+    }
+    |   '$' name_in_namespace[name] '(' optional_expr_list[arguments] ')' {
+        $$ = new TypeDecl(Type::typeMacro);
+        $$->at = tokRangeAt(scanner,@name, @arguments);
+        $$->dimExpr = sequenceToList($arguments);
+        $$->dimExpr.insert($$->dimExpr.begin(), new ExprConstString(tokAt(scanner,@name), *$name));
+        delete $name;
+    }
+    |   '$' name_in_namespace[name] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options_list[declL] '>' '(' optional_expr_list[arguments] ')' {
+        $$ = new TypeDecl(Type::typeMacro);
+        $$->at = tokRangeAt(scanner,@name, @arguments);
+        $$->dimExpr = typesAndSequenceToList($declL,$arguments);
+        $$->dimExpr.insert($$->dimExpr.begin(), new ExprConstString(tokAt(scanner,@name), *$name));
+        delete $name;
+    }
+    |   type_declaration_no_options[typeDecl] '-' '[' ']' {
+        $typeDecl->removeDim = true;
+        $$ = $typeDecl;
+    }
+    |   type_declaration_no_options[typeDecl] DAS_EXPLICIT {
+        $typeDecl->isExplicit = true;
+        $$ = $typeDecl;
+    }
+    |   type_declaration_no_options[typeDecl] DAS_CONST {
+        $typeDecl->constant = true;
+        $typeDecl->removeConstant = false;
+        $$ = $typeDecl;
+    }
+    |   type_declaration_no_options[typeDecl] '-' DAS_CONST {
+        $typeDecl->constant = false;
+        $typeDecl->removeConstant = true;
+        $$ = $typeDecl;
+    }
+    |   type_declaration_no_options[typeDecl] '&' {
+        $typeDecl->ref = true;
+        $typeDecl->removeRef = false;
+        $$ = $typeDecl;
+    }
+    |   type_declaration_no_options[typeDecl] '-' '&' {
+        $typeDecl->ref = false;
+        $typeDecl->removeRef = true;
+        $$ = $typeDecl;
+    }
+    |   type_declaration_no_options[typeDecl] '#' {
+        $$ = $typeDecl;
+        $$->temporary = true;
+    }
+    |   type_declaration_no_options[typeDecl] DAS_IMPLICIT {
+        $$ = $typeDecl;
+        $$->implicit = true;
+    }
+    |   type_declaration_no_options[typeDecl] '-' '#' {
+        $typeDecl->temporary = false;
+        $typeDecl->removeTemporary = true;
+        $$ = $typeDecl;
+    }
+    |   type_declaration_no_options[typeDecl] EQUEQU DAS_CONST {
+        $typeDecl->explicitConst = true;
+        $$ = $typeDecl;
+    }
+    |   type_declaration_no_options[typeDecl] EQUEQU '&' {
+        $typeDecl->explicitRef = true;
+        $$ = $typeDecl;
+    }
+    |   type_declaration_no_options[typeDecl] '?' {
+        $$ = new TypeDecl(Type::tPointer);
+        $$->at = tokAt(scanner,@typeDecl);
+        $$->firstType = TypeDeclPtr($typeDecl);
+    }
+    |   DAS_SMART_PTR[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[typeDecl] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tPointer);
+        $$->at = tokAt(scanner,@loc);
+        $$->smartPtr = true;
+        $$->firstType = TypeDeclPtr($typeDecl);
+    }
+    |   type_declaration_no_options[typeDecl] QQ {
+        $$ = new TypeDecl(Type::tPointer);
+        $$->at = tokAt(scanner,@typeDecl);
+        $$->firstType = make_smart<TypeDecl>(Type::tPointer);
+        $$->firstType->at = tokAt(scanner,@typeDecl);
+        $$->firstType->firstType = TypeDeclPtr($typeDecl);
+    }
+    |   DAS_ARRAY[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[typeDecl] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tArray);
+        $$->at = tokAt(scanner,@loc);
+        $$->firstType = TypeDeclPtr($typeDecl);
+    }
+    |   DAS_TABLE[loc] '<' { yyextra->das_arrow_depth ++; } table_type_pair[ttp] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tTable);
+        $$->at = tokAt(scanner,@loc);
+        $$->firstType = TypeDeclPtr($ttp.firstType);
+        $$->secondType = TypeDeclPtr($ttp.secondType);
+    }
+    |   DAS_ITERATOR[loc] '<'  { yyextra->das_arrow_depth ++; } type_declaration[itTypeDecl] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tIterator);
+        $$->at = tokAt(scanner,@loc);
+        $$->firstType = TypeDeclPtr($itTypeDecl);
+    }
+    |   DAS_TBLOCK[loc] {
+        $$ = new TypeDecl(Type::tBlock);
+        $$->at = tokAt(scanner,@loc);
+    }
+    |   DAS_TBLOCK[loc] '<'  { yyextra->das_arrow_depth ++; } type_declaration[blockType] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tBlock);
+        $$->at = tokAt(scanner,@loc);
+        $$->firstType = TypeDeclPtr($blockType);
+    }
+    |   DAS_TBLOCK[loc] '<'  { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tBlock);
+        $$->at = tokAt(scanner,@loc);
+        $$->firstType = TypeDeclPtr($result);
+        if ( $list ) {
+            varDeclToTypeDecl(scanner, $$, $list);
+            deleteVariableDeclarationList($list);
+        }
+    }
+    |   DAS_TFUNCTION[loc] {
+        $$ = new TypeDecl(Type::tFunction);
+        $$->at = tokAt(scanner,@loc);
+    }
+    |   DAS_TFUNCTION[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[blockType] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tFunction);
+        $$->at = tokAt(scanner,@loc);
+        $$->firstType = TypeDeclPtr($blockType);
+    }
+    |   DAS_TFUNCTION[loc] '<' { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tFunction);
+        $$->at = tokAt(scanner,@loc);
+        $$->firstType = TypeDeclPtr($result);
+        if ( $list ) {
+            varDeclToTypeDecl(scanner, $$, $list);
+            deleteVariableDeclarationList($list);
+        }
+    }
+    |   DAS_TLAMBDA[loc] {
+        $$ = new TypeDecl(Type::tLambda);
+        $$->at = tokAt(scanner,@loc);
+    }
+    |   DAS_TLAMBDA[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[blockType] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tLambda);
+        $$->at = tokAt(scanner,@loc);
+        $$->firstType = TypeDeclPtr($blockType);
+    }
+    |   DAS_TLAMBDA[loc] '<' { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tLambda);
+        $$->at = tokAt(scanner,@loc);
+        $$->firstType = TypeDeclPtr($result);
+        if ( $list ) {
+            varDeclToTypeDecl(scanner, $$, $list);
+            deleteVariableDeclarationList($list);
+        }
+    }
+    |   DAS_TTUPLE[loc] '<' { yyextra->das_arrow_depth ++; } tuple_type_list[list] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tTuple);
+        $$->at = tokAt(scanner,@loc);
+        varDeclToTypeDecl(scanner, $$, $list, true);
+        deleteVariableDeclarationList($list);
+    }
+    |   DAS_TVARIANT[loc] '<' { yyextra->das_arrow_depth ++; } variant_type_list[list] '>' { yyextra->das_arrow_depth --; } {
+        $$ = new TypeDecl(Type::tVariant);
+        $$->at = tokAt(scanner,@loc);
+        varDeclToTypeDecl(scanner, $$, $list, true);
+        deleteVariableDeclarationList($list);
+    }
+    ;
+
+type_declaration
+    :   type_declaration_no_options[td] {
+        $$ = $td;
+    }
+    |   type_declaration[list] '|' type_declaration_no_options[rest] {
+        if ( $list->baseType==Type::option ) {
+            $$ = $list;
+            $$->argTypes.push_back($rest);
+        } else {
+            $$ = new TypeDecl(Type::option);
+            $$->at = tokRangeAt(scanner,@list,@rest);
+            $$->argTypes.push_back($list);
+            $$->argTypes.push_back($rest);
+        }
+    }
+    |   type_declaration[list] '|' '#'[rest] {
+        if ( $list->baseType==Type::option ) {
+            $$ = $list;
+            $$->argTypes.push_back(make_smart<TypeDecl>(*$list->argTypes.back()));
+            $list->argTypes.back()->temporary ^= true;
+        } else {
+            $$ = new TypeDecl(Type::option);
+            $$->at = tokRangeAt(scanner,@list,@rest);
+            $$->argTypes.push_back($list);
+            $$->argTypes.push_back(make_smart<TypeDecl>(*$list));
+            $$->argTypes.back()->temporary ^= true;
+        }
+    }
+    ;
+
+tuple_alias_declaration
+    :   DAS_TTUPLE optional_public_or_private_alias[pubA] { yyextra->das_need_oxford_comma=false; } NAME[vname] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeTuple(atvname);
+        }
+    } '{' {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeTupleEntries(atvname);
+        }
+    } tuple_alias_type_list[list] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterTupleEntries(atvname);
+        }
+    } '}' {
+        auto vtype = make_smart<TypeDecl>(Type::tTuple);
+        vtype->alias = *$vname;
+        vtype->at = tokAt(scanner,@vname);
+        vtype->isPrivateAlias = !$pubA;
+        varDeclToTypeDecl(scanner, vtype.get(), $list, true);
+        deleteVariableDeclarationList($list);
+        if ( !yyextra->g_Program->addAlias(vtype) ) {
+            das_yyerror(scanner,"type alias is already defined "+*$vname,tokAt(scanner,@vname),
+                CompilationError::type_alias_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterTuple($vname->c_str(),atvname);
+        }
+        delete $vname;
+    }
+    ;
+
+variant_alias_declaration
+    :   DAS_TVARIANT optional_public_or_private_alias[pubA] { yyextra->das_need_oxford_comma=false; } NAME[vname] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeVariant(atvname);
+        }
+    } '{' {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeVariantEntries(atvname);
+        }
+
+    } variant_alias_type_list[list] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterVariantEntries(atvname);
+        }
+    } '}' {
+        auto vtype = make_smart<TypeDecl>(Type::tVariant);
+        vtype->alias = *$vname;
+        vtype->at = tokAt(scanner,@vname);
+        vtype->isPrivateAlias = !$pubA;
+        varDeclToTypeDecl(scanner, vtype.get(), $list, true);
+        deleteVariableDeclarationList($list);
+        if ( !yyextra->g_Program->addAlias(vtype) ) {
+            das_yyerror(scanner,"type alias is already defined "+*$vname,tokAt(scanner,@vname),
+                CompilationError::type_alias_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterVariant($vname->c_str(),atvname);
+        }
+        delete $vname;
+    }
+    ;
+
+bitfield_alias_declaration
+    :   DAS_TBITFIELD optional_public_or_private_alias[pubA] { yyextra->das_need_oxford_comma=false; } NAME[vname] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeBitfield(atvname);
+        }
+    } '{' {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeBitfieldEntries(atvname);
+        }
+    } bitfield_alias_bits[list] {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterBitfieldEntries(atvname);
+        }
+    } '}' {
+        auto btype = make_smart<TypeDecl>(Type::tBitfield);
+        btype->alias = *$vname;
+        btype->at = tokAt(scanner,@vname);
+        btype->argNames = *$list;
+        btype->isPrivateAlias = !$pubA;
+        if ( btype->argNames.size()>32 ) {
+            das_yyerror(scanner,"only 32 different bits are allowed in a bitfield",tokAt(scanner,@vname),
+                CompilationError::invalid_type);
+        }
+        if ( !yyextra->g_Program->addAlias(btype) ) {
+            das_yyerror(scanner,"type alias is already defined "+*$vname,tokAt(scanner,@vname),
+                CompilationError::type_alias_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,@vname);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterBitfield($vname->c_str(),atvname);
+        }
+        delete $vname;
+        delete $list;
+    }
+    ;
+
+
+make_decl
+    :   make_struct_decl[msd]    { $$ = $msd; }
+    |   make_dim_decl[mdd]       { $$ = $mdd; }
+    |   make_table_decl[mtd]     { $$ = $mtd; }
+    |   array_comprehension[mac] { $$ = $mac; }
+    |   make_tuple_call[mtc]     { $$ = $mtc; }
+    ;
+
+make_struct_fields
+    :   NAME[fn] copy_or_move[com] expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@fn),*$fn,ExpressionPtr($value),$com,false);
+        delete $fn;
+        auto msd = new MakeStruct();
+        msd->push_back(mfd);
+        $$ = msd;
+    }
+    |   NAME[fn] CLONEEQU expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@fn),*$fn,ExpressionPtr($value),false,true);
+        delete $fn;
+        auto msd = new MakeStruct();
+        msd->push_back(mfd);
+        $$ = msd;
+    }
+    |   make_struct_fields[msd] ',' NAME[fn] copy_or_move[com] expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@fn),*$fn,ExpressionPtr($value),$com,false);
+        delete $fn;
+        ((MakeStruct *)$msd)->push_back(mfd);
+        $$ = $msd;
+    }
+    |   make_struct_fields[msd] ',' NAME[fn] CLONEEQU expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@fn),*$fn,ExpressionPtr($value),false,true);
+        delete $fn;
+        ((MakeStruct *)$msd)->push_back(mfd);
+        $$ = $msd;
+    }
+    |   MTAG_F '(' expr[subexpr] ')' copy_or_move[com] expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@subexpr),"``MACRO``TAG``FIELD``",ExpressionPtr($value),$com,false);
+        mfd->tag = ExpressionPtr($subexpr);
+        auto msd = new MakeStruct();
+        msd->push_back(mfd);
+        $$ = msd;
+    }
+    |   MTAG_F '(' expr[subexpr] ')' CLONEEQU expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@subexpr),"``MACRO``TAG``FIELD``",ExpressionPtr($value),false,true);
+        mfd->tag = ExpressionPtr($subexpr);
+        auto msd = new MakeStruct();
+        msd->push_back(mfd);
+        $$ = msd;
+    }
+    |   make_struct_fields[msd] ',' MTAG_F '(' expr[subexpr] ')' copy_or_move[com] expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@subexpr),"``MACRO``TAG``FIELD``",ExpressionPtr($value),$com,false);
+        mfd->tag = ExpressionPtr($subexpr);
+        ((MakeStruct *)$msd)->push_back(mfd);
+        $$ = $msd;
+    }
+    |   make_struct_fields[msd] ',' MTAG_F '(' expr[subexpr] ')' CLONEEQU expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@subexpr),"``MACRO``TAG``FIELD``",ExpressionPtr($value),false,true);
+        mfd->tag = ExpressionPtr($subexpr);
+        ((MakeStruct *)$msd)->push_back(mfd);
+        $$ = $msd;
+    }
+    ;
+
+make_variant_dim
+    :   make_struct_fields[msd] {
+        $$ = ast_makeStructToMakeVariant($msd, tokAt(scanner,@msd));
+    }
+    ;
+
+make_struct_single
+    :   make_struct_fields[msf] {
+        auto msd = new ExprMakeStruct();
+        msd->structs.push_back(MakeStructPtr($msf));
+        $$ = msd;
+    }
+    ;
+
+make_struct_dim
+    :   make_struct_fields[msf] {
+        auto msd = new ExprMakeStruct();
+        msd->structs.push_back(MakeStructPtr($msf));
+        $$ = msd;
+    }
+    |   make_struct_dim[msd] ';' make_struct_fields[msf] {
+        ((ExprMakeStruct *) $msd)->structs.push_back(MakeStructPtr($msf));
+        $$ = $msd;
+    }
+    ;
+
+make_struct_dim_list
+    :   '(' make_struct_fields[msf] ')' {
+        auto msd = new ExprMakeStruct();
+        msd->structs.push_back(MakeStructPtr($msf));
+        $$ = msd;
+    }
+    |  make_struct_dim_list[msd] ',' '(' make_struct_fields[msf] ')' {
+        ((ExprMakeStruct *) $msd)->structs.push_back(MakeStructPtr($msf));
+        $$ = $msd;
+    }
+    ;
+
+make_struct_dim_decl
+    :   make_struct_fields[msf] {
+        auto msd = new ExprMakeStruct();
+        msd->structs.push_back(MakeStructPtr($msf));
+        $$ = msd;
+    }
+    |   make_struct_dim_list[msd] optional_comma {
+        $$ = $msd;
+    }
+    ;
+
+optional_make_struct_dim_decl
+    :   make_struct_dim_decl[msd] { $$ = $msd;  }
+    |   {   $$ = new ExprMakeStruct(); }
+    ;
+
+optional_block
+    :   { $$ = nullptr; }
+    |   DAS_WHERE expr_block[blk] { $$ = $blk; }
+    ;
+
+
+optional_trailing_semicolon_cur_cur
+    : '}' '}'
+    | SEMICOLON_CUR_CUR
+    ;
+
+optional_trailing_semicolon_cur_sqr
+    : '}' ']'
+    | SEMICOLON_CUR_SQR
+    ;
+
+optional_trailing_semicolon_sqr_sqr
+    : ']' ']'
+    | SEMICOLON_SQR_SQR
+    ;
+
+optional_trailing_delim_sqr_sqr
+    : ']' ']'
+    | SEMICOLON_SQR_SQR
+    | COMMA_SQR_SQR
+    ;
+
+optional_trailing_delim_cur_sqr
+    : '}' ']'
+    | SEMICOLON_CUR_SQR
+    | COMMA_CUR_SQR
+    ;
+
+use_initializer
+    :                       { $$ = true; }
+    |   DAS_UNINITIALIZED   { $$ = false; }
+    ;
+
+make_struct_decl
+    :   BRABRAB [loc] type_declaration_no_options[mkt] make_struct_dim[msd] optional_block[blk] optional_trailing_delim_sqr_sqr {
+        ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
+        ((ExprMakeStruct *)$msd)->block = $blk;
+        $msd->at = tokAt(scanner,@loc);
+        $$ = $msd;
+    }
+    |   BRABRAB [loc] type_declaration_no_options[mkt] optional_block[blk] optional_trailing_delim_sqr_sqr {
+        auto msd = new ExprMakeStruct();
+        msd->makeType = TypeDeclPtr($mkt);
+        msd->block = $blk;
+        msd->at = tokAt(scanner,@loc);
+        $$ = msd;
+    }
+    |   BRABRAB [loc] type_declaration_no_options[mkt] '(' ')' optional_block[blk] optional_trailing_delim_sqr_sqr {
+        auto msd = new ExprMakeStruct();
+        msd->makeType = TypeDeclPtr($mkt);
+        msd->useInitializer = true;
+        msd->block = $blk;
+        msd->at = tokAt(scanner,@loc);
+        $$ = msd;
+    }
+    |   BRABRAB [loc] type_declaration_no_options[mkt] '(' ')' make_struct_dim[msd] optional_block[blk] optional_trailing_delim_sqr_sqr {
+        ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
+        ((ExprMakeStruct *)$msd)->useInitializer = true;
+        ((ExprMakeStruct *)$msd)->block = $blk;
+        $msd->at = tokAt(scanner,@loc);
+        $$ = $msd;
+    }
+    |   BRACBRB [loc] type_declaration_no_options[mkt] make_struct_dim[msd] optional_block[blk] optional_trailing_delim_cur_sqr {
+        ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
+        ((ExprMakeStruct *)$msd)->block = $blk;
+        $msd->at = tokAt(scanner,@loc);
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
+        tam->arguments.push_back(ExpressionPtr($msd));
+        $$ = tam;
+    }
+    |   BRACBRB [loc] type_declaration_no_options[mkt] '(' ')' make_struct_dim[msd] optional_block[blk] optional_trailing_delim_cur_sqr {
+        ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
+        ((ExprMakeStruct *)$msd)->useInitializer = true;
+        ((ExprMakeStruct *)$msd)->block = $blk;
+        $msd->at = tokAt(scanner,@loc);
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
+        tam->arguments.push_back(ExpressionPtr($msd));
+        $$ = tam;
+    }
+    |   DAS_STRUCT [loc] '<' { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; } type_declaration_no_options[mkt] '>' { yyextra->das_arrow_depth --; } '(' use_initializer[init] optional_make_struct_dim_decl[msd] ')'  {
+        $msd->at = tokAt(scanner,@loc);
+        ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
+        ((ExprMakeStruct *)$msd)->useInitializer = $init;
+        ((ExprMakeStruct *)$msd)->forceStruct = true;
+        ((ExprMakeStruct *)$msd)->alwaysUseInitializer = true;
+        $$ = $msd;
+    }
+    |   DAS_CLASS [loc] '<' { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; } type_declaration_no_options[mkt] '>' { yyextra->das_arrow_depth --; } '('use_initializer[init] optional_make_struct_dim_decl[msd] ')'  {
+        $msd->at = tokAt(scanner,@loc);
+        ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
+        ((ExprMakeStruct *)$msd)->useInitializer = $init;
+        ((ExprMakeStruct *)$msd)->forceClass = true;
+        $$ = $msd;
+    }
+    |   DAS_TVARIANT [loc] '<' { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; } type_declaration_no_options[mkt] '>' { yyextra->das_arrow_depth --; } '(' make_variant_dim[msd] ')'  {
+        $msd->at = tokAt(scanner,@loc);
+        ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
+        ((ExprMakeStruct *)$msd)->useInitializer = true;
+        ((ExprMakeStruct *)$msd)->forceVariant = true;
+        $$ = $msd;
+    }
+    |   DAS_DEFAULT [loc] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options[mkt] '>' { yyextra->das_arrow_depth --; } use_initializer[init] {
+        auto msd = new ExprMakeStruct();
+        msd->at = tokAt(scanner,@loc);
+        msd->makeType = TypeDeclPtr($mkt);
+        msd->useInitializer = $init;
+        msd->alwaysUseInitializer = true;
+        $$ = msd;
+    }
+    ;
+
+make_tuple
+    :   expr[val] {
+        $$ = $val;
+    }
+    |   expr[kval] MAPTO[mkt] expr[vval] {
+        ExprMakeTuple * mt = new ExprMakeTuple(tokAt(scanner,@mkt));
+        mt->values.push_back(ExpressionPtr($kval));
+        mt->values.push_back(ExpressionPtr($vval));
+        $$ = mt;
+    }
+    |   make_tuple[mkt] ',' expr[val] {
+        ExprMakeTuple * mt;
+        if ( $mkt->rtti_isMakeTuple() ) {
+            mt = static_cast<ExprMakeTuple *>($mkt);
+        } else {
+            mt = new ExprMakeTuple(tokAt(scanner,@mkt));
+            mt->values.push_back(ExpressionPtr($mkt));
+        }
+        mt->values.push_back(ExpressionPtr($val));
+        $$ = mt;
+    }
+    ;
+
+make_map_tuple
+    :   expr[kval] MAPTO[mkt] expr[vval] {
+        ExprMakeTuple * mt = new ExprMakeTuple(tokAt(scanner,@mkt));
+        mt->values.push_back(ExpressionPtr($kval));
+        mt->values.push_back(ExpressionPtr($vval));
+        $$ = mt;
+    }
+    | expr[kval] {
+        $$ = $kval;
+    }
+    ;
+
+make_tuple_call
+    :   DAS_TTUPLE[loc] '(' expr_list[arguments] optional_comma ')' {
+        auto mkt = new ExprMakeTuple(tokAt(scanner,@loc));
+        mkt->values = sequenceToList($arguments);
+        mkt->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        $$ = mkt;
+    }
+    |   DAS_TTUPLE [loc] '<' { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; } type_declaration_no_options[mkt] '>' { yyextra->das_arrow_depth --; } '(' use_initializer[init] optional_make_struct_dim_decl[msd] ')'  {
+        $msd->at = tokAt(scanner,@loc);
+        ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
+        ((ExprMakeStruct *)$msd)->useInitializer = $init;
+        ((ExprMakeStruct *)$msd)->forceTuple = true;
+        $$ = $msd;
+    }
+    ;
+
+make_dim
+    :   make_tuple[val] {
+        auto mka = new ExprMakeArray();
+        mka->values.push_back(ExpressionPtr($val));
+        $$ = mka;
+    }
+    |   make_dim[mka] ';' make_tuple[val] {
+        ((ExprMakeArray *) $mka)->values.push_back(ExpressionPtr($val));
+        $$ = $mka;
+    }
+    ;
+
+make_dim_decl
+    :   '[' [loc] expr_list[arguments] optional_comma ']' {
+        auto mka = make_smart<ExprMakeArray>(tokAt(scanner,@loc));
+        mka->values = sequenceToList($arguments);
+        mka->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        mka->gen2 = true;
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
+        tam->arguments.push_back(mka);
+        $$ = tam;
+    }
+    |   BRABRAB [loc] type_declaration_no_options[mkt] make_dim[mka] optional_trailing_semicolon_sqr_sqr {
+        ((ExprMakeArray *)$mka)->makeType = TypeDeclPtr($mkt);
+        $mka->at = tokAt(scanner,@loc);
+        $$ = $mka;
+    }
+    |   BRACBRB [loc] type_declaration_no_options[mkt] make_dim[mka] optional_trailing_semicolon_cur_sqr {
+        ((ExprMakeArray *)$mka)->makeType = TypeDeclPtr($mkt);
+        $mka->at = tokAt(scanner,@loc);
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
+        tam->arguments.push_back(ExpressionPtr($mka));
+        $$ = tam;
+    }
+    |   DAS_ARRAY [loc] DAS_STRUCT '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options[mkt] '>' { yyextra->das_arrow_depth --; } '(' use_initializer[init] optional_make_struct_dim_decl[msd] ')'  {
+        $msd->at = tokAt(scanner,@loc);
+        ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
+        ((ExprMakeStruct *)$msd)->useInitializer = $init;
+        ((ExprMakeStruct *)$msd)->forceStruct = true;
+        ((ExprMakeStruct *)$msd)->alwaysUseInitializer = true;
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
+        tam->arguments.push_back($msd);
+        $$ = tam;
+    }
+    |   DAS_ARRAY [loc] DAS_TTUPLE '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options[mkt] '>' { yyextra->das_arrow_depth --; } '(' use_initializer[init] optional_make_struct_dim_decl[msd] ')'  {
+        $msd->at = tokAt(scanner,@loc);
+        ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
+        ((ExprMakeStruct *)$msd)->useInitializer = $init;
+        ((ExprMakeStruct *)$msd)->forceTuple = true;
+        ((ExprMakeStruct *)$msd)->alwaysUseInitializer = true;
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
+        tam->arguments.push_back($msd);
+        $$ = tam;
+    }
+    |   DAS_ARRAY [loc] DAS_TVARIANT '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options[mkt] '>' { yyextra->das_arrow_depth --; } '(' make_variant_dim[msd] ')'  {
+        $msd->at = tokAt(scanner,@loc);
+        ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
+        ((ExprMakeStruct *)$msd)->useInitializer = true;
+        ((ExprMakeStruct *)$msd)->forceVariant = true;
+        ((ExprMakeStruct *)$msd)->alwaysUseInitializer = true;
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
+        tam->arguments.push_back($msd);
+        $$ = tam;
+    }
+    |   DAS_ARRAY[loc] '(' expr_list[arguments] optional_comma ')' {
+        auto mka = make_smart<ExprMakeArray>(tokAt(scanner,@loc));
+        mka->values = sequenceToList($arguments);
+        mka->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        mka->gen2 = true;
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
+        tam->arguments.push_back(mka);
+        $$ = tam;
+    }
+    |   DAS_ARRAY[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options[mkt] '>' { yyextra->das_arrow_depth --; } '(' optional_expr_list[arguments] ')' {
+        if ( $arguments ) {
+            auto mka = make_smart<ExprMakeArray>(tokAt(scanner,@loc));
+            mka->values = sequenceToList($arguments);
+            mka->makeType = TypeDeclPtr($mkt);
+            mka->gen2 = true;
+            auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
+            tam->arguments.push_back(mka);
+            $$ = tam;
+        } else {
+            auto msd = new ExprMakeStruct();
+            msd->at = tokAt(scanner,@loc);
+            msd->makeType = make_smart<TypeDecl>(Type::tArray);
+            msd->makeType->firstType = TypeDeclPtr($mkt);
+            msd->at = tokAt(scanner,@mkt);
+            msd->useInitializer = true;
+            msd->alwaysUseInitializer = true;
+            $$ = msd;
+        }
+    }
+    |   DAS_FIXED_ARRAY[loc] '(' expr_list[arguments] optional_comma ')' {
+        auto mka = new ExprMakeArray(tokAt(scanner,@loc));
+        mka->values = sequenceToList($arguments);
+        mka->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        mka->gen2 = true;
+        $$ = mka;
+    }
+    |   DAS_FIXED_ARRAY[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options[mkt] '>' { yyextra->das_arrow_depth --; } '(' expr_list[arguments] optional_comma ')' {
+        auto mka = new ExprMakeArray(tokAt(scanner,@loc));
+        mka->values = sequenceToList($arguments);
+        mka->makeType = TypeDeclPtr($mkt);
+        mka->gen2 = true;
+        $$ = mka;
+    }
+    ;
+
+make_table
+    :   make_map_tuple[val] {
+        auto mka = new ExprMakeArray();
+        mka->values.push_back(ExpressionPtr($val));
+        $$ = mka;
+    }
+    |   make_table[mka] ';' make_map_tuple[val] {
+        ((ExprMakeArray *) $mka)->values.push_back(ExpressionPtr($val));
+        $$ = $mka;
+    }
+    ;
+
+expr_map_tuple_list
+    :   make_map_tuple[subexpr] {
+        $$ = $subexpr;
+    }
+    |   expr_map_tuple_list[left] ',' make_map_tuple[right]     {
+            $$ = new ExprSequence(tokAt(scanner,@left),ExpressionPtr($left),ExpressionPtr($right));
+    }
+    ;
+
+make_table_decl
+    :   '{' [loc] expr_map_tuple_list[arguments] optional_comma '}' {
+        auto mka = make_smart<ExprMakeArray>(tokAt(scanner,@loc));
+        mka->values = sequenceToList($arguments);
+        mka->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
+        ttm->arguments.push_back(mka);
+        $$ = ttm;
+    }
+    |   CBRCBRB [loc] make_table[mka] optional_trailing_semicolon_cur_cur {
+        auto mkt = make_smart<TypeDecl>(Type::autoinfer);
+        mkt->dim.push_back(TypeDecl::dimAuto);
+        ((ExprMakeArray *)$mka)->makeType = mkt;
+        $mka->at = tokAt(scanner,@loc);
+        auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
+        ttm->arguments.push_back(ExpressionPtr($mka));
+        $$ = ttm;
+    }
+    |   DAS_TABLE[loc] '(' optional_expr_map_tuple_list[arguments] ')' {
+        auto mka = make_smart<ExprMakeArray>(tokAt(scanner,@loc));
+        mka->values = sequenceToList($arguments);
+        mka->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
+        ttm->arguments.push_back(mka);
+        $$ = ttm;
+    }
+    |   DAS_TABLE[loc] '<' type_declaration_no_options[decl] '>' '(' optional_expr_map_tuple_list[arguments] ')' {
+        if ( $arguments ) {
+            auto mka = make_smart<ExprMakeArray>(tokAt(scanner,@loc));
+            mka->values = sequenceToList($arguments);
+            mka->makeType = TypeDeclPtr($decl);
+            auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
+            ttm->arguments.push_back(mka);
+            $$ = ttm;
+        } else {
+            auto msd = new ExprMakeStruct();
+            msd->at = tokAt(scanner,@loc);
+            msd->makeType = make_smart<TypeDecl>(Type::tTable);
+            msd->makeType->firstType = TypeDeclPtr($decl);
+            msd->makeType->secondType = make_smart<TypeDecl>(Type::tVoid);
+            msd->at = tokAt(scanner,@loc);
+            msd->useInitializer = true;
+            msd->alwaysUseInitializer = true;
+            $$ = msd;
+        }
+    }
+    |   DAS_TABLE[loc] '<' type_declaration_no_options[decl] c_or_s type_declaration_no_options[to_decl] '>' '(' optional_expr_map_tuple_list[arguments] ')' {
+        if ( $arguments ) {
+            auto mka = make_smart<ExprMakeArray>(tokAt(scanner,@loc));
+            mka->values = sequenceToList($arguments);
+            mka->makeType = make_smart<TypeDecl>(Type::tTuple);
+            mka->makeType->argTypes.push_back($decl);
+            mka->makeType->argTypes.push_back($to_decl);
+            auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
+            ttm->arguments.push_back(mka);
+            $$ = ttm;
+        } else {
+            auto msd = new ExprMakeStruct();
+            msd->at = tokAt(scanner,@loc);
+            msd->makeType = make_smart<TypeDecl>(Type::tTable);
+            msd->makeType->firstType = TypeDeclPtr($decl);
+            msd->makeType->secondType = TypeDeclPtr($to_decl);
+            msd->at = tokAt(scanner,@loc);
+            msd->useInitializer = true;
+            msd->alwaysUseInitializer = true;
+            $$ = msd;
+        }
+    }
+    ;
+
+array_comprehension_where
+    :                               { $$ = nullptr; }
+    |   ';' DAS_WHERE expr[clause]  { $$ = $clause; }
+    ;
+
+optional_comma
+    :           { $$ = false; }
+    |   ','     { $$ = true; }
+    ;
+
+
+array_comprehension
+    :   '[' DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' expr[subexpr] array_comprehension_where[where] ']' [forend] {
+        $$ = ast_arrayComprehension(scanner,tokAt(scanner,@loc),$iters,$srcs,$subexpr,$where,tokRangeAt(scanner,@subexpr,@forend),false,false);
+    }
+    |   '[' DAS_ITERATOR DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' expr[subexpr] array_comprehension_where[where] ']' [forend] {
+        $$ = ast_arrayComprehension(scanner,tokAt(scanner,@loc),$iters,$srcs,$subexpr,$where,tokRangeAt(scanner,@subexpr,@forend),true,false);
+    }
+    |   BRABRAB DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' expr[subexpr] array_comprehension_where[where] ']' ']' [forend] {
+        $$ = ast_arrayComprehension(scanner,tokAt(scanner,@loc),$iters,$srcs,$subexpr,$where,tokRangeAt(scanner,@subexpr,@forend),true,false);
+    }
+    |   BRACBRB DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' expr[subexpr] array_comprehension_where[where] '}' ']' [forend] {
+        $$ = ast_arrayComprehension(scanner,tokAt(scanner,@loc),$iters,$srcs,$subexpr,$where,tokRangeAt(scanner,@subexpr,@forend),false,false);
+    }
+    |   '{' DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' make_map_tuple[subexpr] array_comprehension_where[where] '}' [forend] {
+        $$ = ast_arrayComprehension(scanner,tokAt(scanner,@loc),$iters,$srcs,$subexpr,$where,tokRangeAt(scanner,@subexpr,@forend),false,true);
+    }
+    | CBRCBRB DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' make_map_tuple[subexpr] array_comprehension_where[where] '}' '}' [forend] {
+        $$ = ast_arrayComprehension(scanner,tokAt(scanner,@loc),$iters,$srcs,$subexpr,$where,tokRangeAt(scanner,@subexpr,@forend),true,true);
+    }
+    ;
+
+%%
+
+void das_yyfatalerror ( DAS_YYLTYPE * lloc, yyscan_t scanner, const string & error, CompilationError cerr ) {
+    yyextra->g_Program->error(error,"","",LineInfo(yyextra->g_FileAccessStack.back(),
+        lloc->first_column,lloc->first_line,lloc->last_column,lloc->last_line),cerr);
+}
+
+void das_yyerror ( DAS_YYLTYPE * lloc, yyscan_t scanner, const string & error ) {
+    if ( !yyextra->das_suppress_errors ) {
+        yyextra->g_Program->error(error,"","",LineInfo(yyextra->g_FileAccessStack.back(),
+            lloc->first_column,lloc->first_line,lloc->last_column,lloc->last_line),
+                CompilationError::syntax_error);
+    }
+}
+
+LineInfo tokAt ( yyscan_t scanner, const struct DAS_YYLTYPE & li ) {
+    return LineInfo(yyextra->g_FileAccessStack.back(),
+        li.first_column,li.first_line,
+        li.last_column,li.last_line);
+}
+
+LineInfo tokRangeAt ( yyscan_t scanner, const struct DAS_YYLTYPE & li, const struct DAS_YYLTYPE & lie ) {
+    return LineInfo(yyextra->g_FileAccessStack.back(),
+        li.first_column,li.first_line,
+        lie.last_column,lie.last_line);
+}
+
+

--- a/utils/dasFormatter/Readme.md
+++ b/utils/dasFormatter/Readme.md
@@ -1,0 +1,27 @@
+# Utility to convert syntax from v1 to v2
+## Key differences
+First of all, you may want to check this [article about initialization](https://borisbat.github.io/dascf-blog/2024/07/23/data-initialization/). Here described most initialization expressions  in old and new syntax.
+However there are some corner cases missed, like 
+```
+// old
+var a = new [[Foo#()]]
+// will be converted to new
+var a = new struct<Foo#>()
+```
+
+## How it works
+Generally formatter tools can work on token-level or AST-level. 
+AST-level looks much easier to maintain so I decided to use it.
+
+There's copy of bison grammar corresponding to v1 syntax. For required non terminals I edited action on match.
+
+We will maintain `last_printed` position and once rule, 
+which should be replaced is matched everything from `last_printed` to this rule
+will go directly to `output` 
+this rule will be modified and position updated.
+
+## Usage:
+I used this command to inplace transform all `.das` files syntax in current folder:
+```
+find . -name "*.das" | tr '\n' ' ' | xargs ./bin/das-fmt -i
+```

--- a/utils/dasFormatter/ds_parser.cpp
+++ b/utils/dasFormatter/ds_parser.cpp
@@ -1,0 +1,12416 @@
+/* A Bison parser, made by GNU Bison 3.8.2.  */
+
+/* Bison implementation for Yacc-like parsers in C
+
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+/* As a special exception, you may create a larger work that contains
+   part or all of the Bison parser skeleton and distribute that work
+   under terms of your choice, so long as that work isn't itself a
+   parser generator using the skeleton or a modified version thereof
+   as a parser skeleton.  Alternatively, if you modify or redistribute
+   the parser skeleton itself, you may (at your option) remove this
+   special exception, which will cause the skeleton and the resulting
+   Bison output files to be licensed under the GNU General Public
+   License without this special exception.
+
+   This special exception was added by the Free Software Foundation in
+   version 2.2 of Bison.  */
+
+/* C LALR(1) parser skeleton written by Richard Stallman, by
+   simplifying the original so-called "semantic" parser.  */
+
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
+/* All symbols defined below should begin with yy or YY, to avoid
+   infringing on user name space.  This should be done even for local
+   variables, as they might otherwise be expanded by user macros.
+   There are some unavoidable exceptions within include files to
+   define necessary library symbols; they are noted "INFRINGES ON
+   USER NAME SPACE" below.  */
+
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
+
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
+
+/* Skeleton name.  */
+#define YYSKELETON_NAME "yacc.c"
+
+/* Pure parsers.  */
+#define YYPURE 2
+
+/* Push parsers.  */
+#define YYPUSH 0
+
+/* Pull parsers.  */
+#define YYPULL 1
+
+/* Substitute the type names.  */
+#define YYSTYPE         DAS_YYSTYPE
+#define YYLTYPE         DAS_YYLTYPE
+/* Substitute the variable and function names.  */
+#define yyparse         das_yyparse
+#define yylex           das_yylex
+#define yyerror         das_yyerror
+#define yydebug         das_yydebug
+#define yynerrs         das_yynerrs
+
+/* First part of user prologue.  */
+
+    #include "daScript/misc/platform.h"
+    #include "daScript/simulate/debug_info.h"
+    #include "daScript/ast/compilation_errors.h"
+
+    #ifdef _MSC_VER
+    #pragma warning(disable:4262)
+    #pragma warning(disable:4127)
+    #pragma warning(disable:4702)
+    #endif
+
+    using namespace das;
+
+    union DAS_YYSTYPE;
+    struct DAS_YYLTYPE;
+
+    #define YY_NO_UNISTD_H
+    #include "../src/parser/lex.yy.h"
+
+    void das_yyerror ( DAS_YYLTYPE * lloc, yyscan_t scanner, const string & error );
+    void das_yyfatalerror ( DAS_YYLTYPE * lloc, yyscan_t scanner, const string & error, CompilationError cerr );
+    int yylex ( DAS_YYSTYPE *lvalp, DAS_YYLTYPE *llocp, yyscan_t scanner );
+    void yybegin ( const char * str );
+
+    void das_yybegin_reader ( yyscan_t yyscanner );
+    void das_yyend_reader ( yyscan_t yyscanner );
+    void das_accept_sequence ( yyscan_t yyscanner, const char * seq, size_t seqLen, int lineNo, FileInfo * info );
+
+    namespace das { class Module; }
+    void das_collect_keywords ( das::Module * mod, yyscan_t yyscanner );
+
+    #undef yyextra
+    #define yyextra (*((das::DasParserState **)(scanner)))
+
+
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
+#  else
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
+#  endif
+# endif
+
+#include "ds_parser.hpp"
+/* Symbol kind.  */
+enum yysymbol_kind_t
+{
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_LEXER_ERROR = 3,                /* "lexer error"  */
+  YYSYMBOL_DAS_CAPTURE = 4,                /* "capture"  */
+  YYSYMBOL_DAS_STRUCT = 5,                 /* "struct"  */
+  YYSYMBOL_DAS_CLASS = 6,                  /* "class"  */
+  YYSYMBOL_DAS_LET = 7,                    /* "let"  */
+  YYSYMBOL_DAS_DEF = 8,                    /* "def"  */
+  YYSYMBOL_DAS_WHILE = 9,                  /* "while"  */
+  YYSYMBOL_DAS_IF = 10,                    /* "if"  */
+  YYSYMBOL_DAS_STATIC_IF = 11,             /* "static_if"  */
+  YYSYMBOL_DAS_ELSE = 12,                  /* "else"  */
+  YYSYMBOL_DAS_FOR = 13,                   /* "for"  */
+  YYSYMBOL_DAS_CATCH = 14,                 /* "recover"  */
+  YYSYMBOL_DAS_TRUE = 15,                  /* "true"  */
+  YYSYMBOL_DAS_FALSE = 16,                 /* "false"  */
+  YYSYMBOL_DAS_NEWT = 17,                  /* "new"  */
+  YYSYMBOL_DAS_TYPEINFO = 18,              /* "typeinfo"  */
+  YYSYMBOL_DAS_TYPE = 19,                  /* "type"  */
+  YYSYMBOL_DAS_IN = 20,                    /* "in"  */
+  YYSYMBOL_DAS_IS = 21,                    /* "is"  */
+  YYSYMBOL_DAS_AS = 22,                    /* "as"  */
+  YYSYMBOL_DAS_ELIF = 23,                  /* "elif"  */
+  YYSYMBOL_DAS_STATIC_ELIF = 24,           /* "static_elif"  */
+  YYSYMBOL_DAS_ARRAY = 25,                 /* "array"  */
+  YYSYMBOL_DAS_RETURN = 26,                /* "return"  */
+  YYSYMBOL_DAS_NULL = 27,                  /* "null"  */
+  YYSYMBOL_DAS_BREAK = 28,                 /* "break"  */
+  YYSYMBOL_DAS_TRY = 29,                   /* "try"  */
+  YYSYMBOL_DAS_OPTIONS = 30,               /* "options"  */
+  YYSYMBOL_DAS_TABLE = 31,                 /* "table"  */
+  YYSYMBOL_DAS_EXPECT = 32,                /* "expect"  */
+  YYSYMBOL_DAS_CONST = 33,                 /* "const"  */
+  YYSYMBOL_DAS_REQUIRE = 34,               /* "require"  */
+  YYSYMBOL_DAS_OPERATOR = 35,              /* "operator"  */
+  YYSYMBOL_DAS_ENUM = 36,                  /* "enum"  */
+  YYSYMBOL_DAS_FINALLY = 37,               /* "finally"  */
+  YYSYMBOL_DAS_DELETE = 38,                /* "delete"  */
+  YYSYMBOL_DAS_DEREF = 39,                 /* "deref"  */
+  YYSYMBOL_DAS_TYPEDEF = 40,               /* "typedef"  */
+  YYSYMBOL_DAS_TYPEDECL = 41,              /* "typedecl"  */
+  YYSYMBOL_DAS_WITH = 42,                  /* "with"  */
+  YYSYMBOL_DAS_AKA = 43,                   /* "aka"  */
+  YYSYMBOL_DAS_ASSUME = 44,                /* "assume"  */
+  YYSYMBOL_DAS_CAST = 45,                  /* "cast"  */
+  YYSYMBOL_DAS_OVERRIDE = 46,              /* "override"  */
+  YYSYMBOL_DAS_ABSTRACT = 47,              /* "abstract"  */
+  YYSYMBOL_DAS_UPCAST = 48,                /* "upcast"  */
+  YYSYMBOL_DAS_ITERATOR = 49,              /* "iterator"  */
+  YYSYMBOL_DAS_VAR = 50,                   /* "var"  */
+  YYSYMBOL_DAS_ADDR = 51,                  /* "addr"  */
+  YYSYMBOL_DAS_CONTINUE = 52,              /* "continue"  */
+  YYSYMBOL_DAS_WHERE = 53,                 /* "where"  */
+  YYSYMBOL_DAS_PASS = 54,                  /* "pass"  */
+  YYSYMBOL_DAS_REINTERPRET = 55,           /* "reinterpret"  */
+  YYSYMBOL_DAS_MODULE = 56,                /* "module"  */
+  YYSYMBOL_DAS_PUBLIC = 57,                /* "public"  */
+  YYSYMBOL_DAS_LABEL = 58,                 /* "label"  */
+  YYSYMBOL_DAS_GOTO = 59,                  /* "goto"  */
+  YYSYMBOL_DAS_IMPLICIT = 60,              /* "implicit"  */
+  YYSYMBOL_DAS_EXPLICIT = 61,              /* "explicit"  */
+  YYSYMBOL_DAS_SHARED = 62,                /* "shared"  */
+  YYSYMBOL_DAS_PRIVATE = 63,               /* "private"  */
+  YYSYMBOL_DAS_SMART_PTR = 64,             /* "smart_ptr"  */
+  YYSYMBOL_DAS_UNSAFE = 65,                /* "unsafe"  */
+  YYSYMBOL_DAS_INSCOPE = 66,               /* "inscope"  */
+  YYSYMBOL_DAS_STATIC = 67,                /* "static"  */
+  YYSYMBOL_DAS_FIXED_ARRAY = 68,           /* "fixed_array"  */
+  YYSYMBOL_DAS_DEFAULT = 69,               /* "default"  */
+  YYSYMBOL_DAS_UNINITIALIZED = 70,         /* "uninitialized"  */
+  YYSYMBOL_DAS_TBOOL = 71,                 /* "bool"  */
+  YYSYMBOL_DAS_TVOID = 72,                 /* "void"  */
+  YYSYMBOL_DAS_TSTRING = 73,               /* "string"  */
+  YYSYMBOL_DAS_TAUTO = 74,                 /* "auto"  */
+  YYSYMBOL_DAS_TINT = 75,                  /* "int"  */
+  YYSYMBOL_DAS_TINT2 = 76,                 /* "int2"  */
+  YYSYMBOL_DAS_TINT3 = 77,                 /* "int3"  */
+  YYSYMBOL_DAS_TINT4 = 78,                 /* "int4"  */
+  YYSYMBOL_DAS_TUINT = 79,                 /* "uint"  */
+  YYSYMBOL_DAS_TBITFIELD = 80,             /* "bitfield"  */
+  YYSYMBOL_DAS_TUINT2 = 81,                /* "uint2"  */
+  YYSYMBOL_DAS_TUINT3 = 82,                /* "uint3"  */
+  YYSYMBOL_DAS_TUINT4 = 83,                /* "uint4"  */
+  YYSYMBOL_DAS_TFLOAT = 84,                /* "float"  */
+  YYSYMBOL_DAS_TFLOAT2 = 85,               /* "float2"  */
+  YYSYMBOL_DAS_TFLOAT3 = 86,               /* "float3"  */
+  YYSYMBOL_DAS_TFLOAT4 = 87,               /* "float4"  */
+  YYSYMBOL_DAS_TRANGE = 88,                /* "range"  */
+  YYSYMBOL_DAS_TURANGE = 89,               /* "urange"  */
+  YYSYMBOL_DAS_TRANGE64 = 90,              /* "range64"  */
+  YYSYMBOL_DAS_TURANGE64 = 91,             /* "urange64"  */
+  YYSYMBOL_DAS_TBLOCK = 92,                /* "block"  */
+  YYSYMBOL_DAS_TINT64 = 93,                /* "int64"  */
+  YYSYMBOL_DAS_TUINT64 = 94,               /* "uint64"  */
+  YYSYMBOL_DAS_TDOUBLE = 95,               /* "double"  */
+  YYSYMBOL_DAS_TFUNCTION = 96,             /* "function"  */
+  YYSYMBOL_DAS_TLAMBDA = 97,               /* "lambda"  */
+  YYSYMBOL_DAS_TINT8 = 98,                 /* "int8"  */
+  YYSYMBOL_DAS_TUINT8 = 99,                /* "uint8"  */
+  YYSYMBOL_DAS_TINT16 = 100,               /* "int16"  */
+  YYSYMBOL_DAS_TUINT16 = 101,              /* "uint16"  */
+  YYSYMBOL_DAS_TTUPLE = 102,               /* "tuple"  */
+  YYSYMBOL_DAS_TVARIANT = 103,             /* "variant"  */
+  YYSYMBOL_DAS_GENERATOR = 104,            /* "generator"  */
+  YYSYMBOL_DAS_YIELD = 105,                /* "yield"  */
+  YYSYMBOL_DAS_SEALED = 106,               /* "sealed"  */
+  YYSYMBOL_DAS_TEMPLATE = 107,             /* "template"  */
+  YYSYMBOL_ADDEQU = 108,                   /* "+="  */
+  YYSYMBOL_SUBEQU = 109,                   /* "-="  */
+  YYSYMBOL_DIVEQU = 110,                   /* "/="  */
+  YYSYMBOL_MULEQU = 111,                   /* "*="  */
+  YYSYMBOL_MODEQU = 112,                   /* "%="  */
+  YYSYMBOL_ANDEQU = 113,                   /* "&="  */
+  YYSYMBOL_OREQU = 114,                    /* "|="  */
+  YYSYMBOL_XOREQU = 115,                   /* "^="  */
+  YYSYMBOL_SHL = 116,                      /* "<<"  */
+  YYSYMBOL_SHR = 117,                      /* ">>"  */
+  YYSYMBOL_ADDADD = 118,                   /* "++"  */
+  YYSYMBOL_SUBSUB = 119,                   /* "--"  */
+  YYSYMBOL_LEEQU = 120,                    /* "<="  */
+  YYSYMBOL_SHLEQU = 121,                   /* "<<="  */
+  YYSYMBOL_SHREQU = 122,                   /* ">>="  */
+  YYSYMBOL_GREQU = 123,                    /* ">="  */
+  YYSYMBOL_EQUEQU = 124,                   /* "=="  */
+  YYSYMBOL_NOTEQU = 125,                   /* "!="  */
+  YYSYMBOL_RARROW = 126,                   /* "->"  */
+  YYSYMBOL_LARROW = 127,                   /* "<-"  */
+  YYSYMBOL_QQ = 128,                       /* "??"  */
+  YYSYMBOL_QDOT = 129,                     /* "?."  */
+  YYSYMBOL_QBRA = 130,                     /* "?["  */
+  YYSYMBOL_LPIPE = 131,                    /* "<|"  */
+  YYSYMBOL_LBPIPE = 132,                   /* " <|"  */
+  YYSYMBOL_LLPIPE = 133,                   /* "$ <|"  */
+  YYSYMBOL_LAPIPE = 134,                   /* "@ <|"  */
+  YYSYMBOL_LFPIPE = 135,                   /* "@@ <|"  */
+  YYSYMBOL_RPIPE = 136,                    /* "|>"  */
+  YYSYMBOL_CLONEEQU = 137,                 /* ":="  */
+  YYSYMBOL_ROTL = 138,                     /* "<<<"  */
+  YYSYMBOL_ROTR = 139,                     /* ">>>"  */
+  YYSYMBOL_ROTLEQU = 140,                  /* "<<<="  */
+  YYSYMBOL_ROTREQU = 141,                  /* ">>>="  */
+  YYSYMBOL_MAPTO = 142,                    /* "=>"  */
+  YYSYMBOL_COLCOL = 143,                   /* "::"  */
+  YYSYMBOL_ANDAND = 144,                   /* "&&"  */
+  YYSYMBOL_OROR = 145,                     /* "||"  */
+  YYSYMBOL_XORXOR = 146,                   /* "^^"  */
+  YYSYMBOL_ANDANDEQU = 147,                /* "&&="  */
+  YYSYMBOL_OROREQU = 148,                  /* "||="  */
+  YYSYMBOL_XORXOREQU = 149,                /* "^^="  */
+  YYSYMBOL_DOTDOT = 150,                   /* ".."  */
+  YYSYMBOL_MTAG_E = 151,                   /* "$$"  */
+  YYSYMBOL_MTAG_I = 152,                   /* "$i"  */
+  YYSYMBOL_MTAG_V = 153,                   /* "$v"  */
+  YYSYMBOL_MTAG_B = 154,                   /* "$b"  */
+  YYSYMBOL_MTAG_A = 155,                   /* "$a"  */
+  YYSYMBOL_MTAG_T = 156,                   /* "$t"  */
+  YYSYMBOL_MTAG_C = 157,                   /* "$c"  */
+  YYSYMBOL_MTAG_F = 158,                   /* "$f"  */
+  YYSYMBOL_MTAG_DOTDOTDOT = 159,           /* "..."  */
+  YYSYMBOL_BRABRAB = 160,                  /* "[["  */
+  YYSYMBOL_BRACBRB = 161,                  /* "[{"  */
+  YYSYMBOL_CBRCBRB = 162,                  /* "{{"  */
+  YYSYMBOL_INTEGER = 163,                  /* "integer constant"  */
+  YYSYMBOL_LONG_INTEGER = 164,             /* "long integer constant"  */
+  YYSYMBOL_UNSIGNED_INTEGER = 165,         /* "unsigned integer constant"  */
+  YYSYMBOL_UNSIGNED_LONG_INTEGER = 166,    /* "unsigned long integer constant"  */
+  YYSYMBOL_UNSIGNED_INT8 = 167,            /* "unsigned int8 constant"  */
+  YYSYMBOL_FLOAT = 168,                    /* "floating point constant"  */
+  YYSYMBOL_DOUBLE = 169,                   /* "double constant"  */
+  YYSYMBOL_NAME = 170,                     /* "name"  */
+  YYSYMBOL_KEYWORD = 171,                  /* "keyword"  */
+  YYSYMBOL_TYPE_FUNCTION = 172,            /* "type function"  */
+  YYSYMBOL_BEGIN_STRING = 173,             /* "start of the string"  */
+  YYSYMBOL_STRING_CHARACTER = 174,         /* STRING_CHARACTER  */
+  YYSYMBOL_STRING_CHARACTER_ESC = 175,     /* STRING_CHARACTER_ESC  */
+  YYSYMBOL_END_STRING = 176,               /* "end of the string"  */
+  YYSYMBOL_BEGIN_STRING_EXPR = 177,        /* "{"  */
+  YYSYMBOL_END_STRING_EXPR = 178,          /* "}"  */
+  YYSYMBOL_END_OF_READ = 179,              /* "end of failed eader macro"  */
+  YYSYMBOL_180_begin_of_code_block_ = 180, /* "begin of code block"  */
+  YYSYMBOL_181_end_of_code_block_ = 181,   /* "end of code block"  */
+  YYSYMBOL_182_end_of_expression_ = 182,   /* "end of expression"  */
+  YYSYMBOL_SEMICOLON_CUR_CUR = 183,        /* ";}}"  */
+  YYSYMBOL_SEMICOLON_CUR_SQR = 184,        /* ";}]"  */
+  YYSYMBOL_SEMICOLON_SQR_SQR = 185,        /* ";]]"  */
+  YYSYMBOL_COMMA_SQR_SQR = 186,            /* ",]]"  */
+  YYSYMBOL_COMMA_CUR_SQR = 187,            /* ",}]"  */
+  YYSYMBOL_188_ = 188,                     /* ','  */
+  YYSYMBOL_189_ = 189,                     /* '='  */
+  YYSYMBOL_190_ = 190,                     /* '?'  */
+  YYSYMBOL_191_ = 191,                     /* ':'  */
+  YYSYMBOL_192_ = 192,                     /* '|'  */
+  YYSYMBOL_193_ = 193,                     /* '^'  */
+  YYSYMBOL_194_ = 194,                     /* '&'  */
+  YYSYMBOL_195_ = 195,                     /* '<'  */
+  YYSYMBOL_196_ = 196,                     /* '>'  */
+  YYSYMBOL_197_ = 197,                     /* '-'  */
+  YYSYMBOL_198_ = 198,                     /* '+'  */
+  YYSYMBOL_199_ = 199,                     /* '*'  */
+  YYSYMBOL_200_ = 200,                     /* '/'  */
+  YYSYMBOL_201_ = 201,                     /* '%'  */
+  YYSYMBOL_UNARY_MINUS = 202,              /* UNARY_MINUS  */
+  YYSYMBOL_UNARY_PLUS = 203,               /* UNARY_PLUS  */
+  YYSYMBOL_204_ = 204,                     /* '~'  */
+  YYSYMBOL_205_ = 205,                     /* '!'  */
+  YYSYMBOL_PRE_INC = 206,                  /* PRE_INC  */
+  YYSYMBOL_PRE_DEC = 207,                  /* PRE_DEC  */
+  YYSYMBOL_POST_INC = 208,                 /* POST_INC  */
+  YYSYMBOL_POST_DEC = 209,                 /* POST_DEC  */
+  YYSYMBOL_DEREF = 210,                    /* DEREF  */
+  YYSYMBOL_211_ = 211,                     /* '.'  */
+  YYSYMBOL_212_ = 212,                     /* '['  */
+  YYSYMBOL_213_ = 213,                     /* ']'  */
+  YYSYMBOL_214_ = 214,                     /* '('  */
+  YYSYMBOL_215_ = 215,                     /* ')'  */
+  YYSYMBOL_216_ = 216,                     /* '$'  */
+  YYSYMBOL_217_ = 217,                     /* '@'  */
+  YYSYMBOL_218_ = 218,                     /* '#'  */
+  YYSYMBOL_YYACCEPT = 219,                 /* $accept  */
+  YYSYMBOL_program = 220,                  /* program  */
+  YYSYMBOL_top_level_reader_macro = 221,   /* top_level_reader_macro  */
+  YYSYMBOL_optional_public_or_private_module = 222, /* optional_public_or_private_module  */
+  YYSYMBOL_module_name = 223,              /* module_name  */
+  YYSYMBOL_module_declaration = 224,       /* module_declaration  */
+  YYSYMBOL_character_sequence = 225,       /* character_sequence  */
+  YYSYMBOL_string_constant = 226,          /* string_constant  */
+  YYSYMBOL_string_builder_body = 227,      /* string_builder_body  */
+  YYSYMBOL_string_builder = 228,           /* string_builder  */
+  YYSYMBOL_reader_character_sequence = 229, /* reader_character_sequence  */
+  YYSYMBOL_expr_reader = 230,              /* expr_reader  */
+  YYSYMBOL_231_1 = 231,                    /* $@1  */
+  YYSYMBOL_options_declaration = 232,      /* options_declaration  */
+  YYSYMBOL_require_declaration = 233,      /* require_declaration  */
+  YYSYMBOL_keyword_or_name = 234,          /* keyword_or_name  */
+  YYSYMBOL_require_module_name = 235,      /* require_module_name  */
+  YYSYMBOL_require_module = 236,           /* require_module  */
+  YYSYMBOL_is_public_module = 237,         /* is_public_module  */
+  YYSYMBOL_expect_declaration = 238,       /* expect_declaration  */
+  YYSYMBOL_expect_list = 239,              /* expect_list  */
+  YYSYMBOL_expect_error = 240,             /* expect_error  */
+  YYSYMBOL_expression_label = 241,         /* expression_label  */
+  YYSYMBOL_expression_goto = 242,          /* expression_goto  */
+  YYSYMBOL_elif_or_static_elif = 243,      /* elif_or_static_elif  */
+  YYSYMBOL_expression_else = 244,          /* expression_else  */
+  YYSYMBOL_if_or_static_if = 245,          /* if_or_static_if  */
+  YYSYMBOL_expression_else_one_liner = 246, /* expression_else_one_liner  */
+  YYSYMBOL_247_2 = 247,                    /* $@2  */
+  YYSYMBOL_expression_if_one_liner = 248,  /* expression_if_one_liner  */
+  YYSYMBOL_expression_if_then_else = 249,  /* expression_if_then_else  */
+  YYSYMBOL_250_3 = 250,                    /* $@3  */
+  YYSYMBOL_expression_for_loop = 251,      /* expression_for_loop  */
+  YYSYMBOL_252_4 = 252,                    /* $@4  */
+  YYSYMBOL_expression_unsafe = 253,        /* expression_unsafe  */
+  YYSYMBOL_expression_while_loop = 254,    /* expression_while_loop  */
+  YYSYMBOL_expression_with = 255,          /* expression_with  */
+  YYSYMBOL_expression_with_alias = 256,    /* expression_with_alias  */
+  YYSYMBOL_257_5 = 257,                    /* $@5  */
+  YYSYMBOL_annotation_argument_value = 258, /* annotation_argument_value  */
+  YYSYMBOL_annotation_argument_value_list = 259, /* annotation_argument_value_list  */
+  YYSYMBOL_annotation_argument_name = 260, /* annotation_argument_name  */
+  YYSYMBOL_annotation_argument = 261,      /* annotation_argument  */
+  YYSYMBOL_annotation_argument_list = 262, /* annotation_argument_list  */
+  YYSYMBOL_metadata_argument_list = 263,   /* metadata_argument_list  */
+  YYSYMBOL_annotation_declaration_name = 264, /* annotation_declaration_name  */
+  YYSYMBOL_annotation_declaration_basic = 265, /* annotation_declaration_basic  */
+  YYSYMBOL_annotation_declaration = 266,   /* annotation_declaration  */
+  YYSYMBOL_annotation_list = 267,          /* annotation_list  */
+  YYSYMBOL_optional_annotation_list = 268, /* optional_annotation_list  */
+  YYSYMBOL_optional_function_argument_list = 269, /* optional_function_argument_list  */
+  YYSYMBOL_optional_function_type = 270,   /* optional_function_type  */
+  YYSYMBOL_function_name = 271,            /* function_name  */
+  YYSYMBOL_global_function_declaration = 272, /* global_function_declaration  */
+  YYSYMBOL_optional_public_or_private_function = 273, /* optional_public_or_private_function  */
+  YYSYMBOL_function_declaration_header = 274, /* function_declaration_header  */
+  YYSYMBOL_function_declaration = 275,     /* function_declaration  */
+  YYSYMBOL_276_6 = 276,                    /* $@6  */
+  YYSYMBOL_expression_block = 277,         /* expression_block  */
+  YYSYMBOL_expr_call_pipe = 278,           /* expr_call_pipe  */
+  YYSYMBOL_expression_any = 279,           /* expression_any  */
+  YYSYMBOL_expressions = 280,              /* expressions  */
+  YYSYMBOL_expr_keyword = 281,             /* expr_keyword  */
+  YYSYMBOL_optional_expr_list = 282,       /* optional_expr_list  */
+  YYSYMBOL_optional_expr_list_in_braces = 283, /* optional_expr_list_in_braces  */
+  YYSYMBOL_optional_expr_map_tuple_list = 284, /* optional_expr_map_tuple_list  */
+  YYSYMBOL_type_declaration_no_options_list = 285, /* type_declaration_no_options_list  */
+  YYSYMBOL_expression_keyword = 286,       /* expression_keyword  */
+  YYSYMBOL_287_7 = 287,                    /* $@7  */
+  YYSYMBOL_288_8 = 288,                    /* $@8  */
+  YYSYMBOL_289_9 = 289,                    /* $@9  */
+  YYSYMBOL_290_10 = 290,                   /* $@10  */
+  YYSYMBOL_expr_pipe = 291,                /* expr_pipe  */
+  YYSYMBOL_name_in_namespace = 292,        /* name_in_namespace  */
+  YYSYMBOL_expression_delete = 293,        /* expression_delete  */
+  YYSYMBOL_new_type_declaration = 294,     /* new_type_declaration  */
+  YYSYMBOL_295_11 = 295,                   /* $@11  */
+  YYSYMBOL_296_12 = 296,                   /* $@12  */
+  YYSYMBOL_expr_new = 297,                 /* expr_new  */
+  YYSYMBOL_expression_break = 298,         /* expression_break  */
+  YYSYMBOL_expression_continue = 299,      /* expression_continue  */
+  YYSYMBOL_expression_return_no_pipe = 300, /* expression_return_no_pipe  */
+  YYSYMBOL_expression_return = 301,        /* expression_return  */
+  YYSYMBOL_expression_yield_no_pipe = 302, /* expression_yield_no_pipe  */
+  YYSYMBOL_expression_yield = 303,         /* expression_yield  */
+  YYSYMBOL_expression_try_catch = 304,     /* expression_try_catch  */
+  YYSYMBOL_kwd_let_var_or_nothing = 305,   /* kwd_let_var_or_nothing  */
+  YYSYMBOL_kwd_let = 306,                  /* kwd_let  */
+  YYSYMBOL_optional_in_scope = 307,        /* optional_in_scope  */
+  YYSYMBOL_tuple_expansion = 308,          /* tuple_expansion  */
+  YYSYMBOL_tuple_expansion_variable_declaration = 309, /* tuple_expansion_variable_declaration  */
+  YYSYMBOL_expression_let = 310,           /* expression_let  */
+  YYSYMBOL_expr_cast = 311,                /* expr_cast  */
+  YYSYMBOL_312_13 = 312,                   /* $@13  */
+  YYSYMBOL_313_14 = 313,                   /* $@14  */
+  YYSYMBOL_314_15 = 314,                   /* $@15  */
+  YYSYMBOL_315_16 = 315,                   /* $@16  */
+  YYSYMBOL_316_17 = 316,                   /* $@17  */
+  YYSYMBOL_317_18 = 317,                   /* $@18  */
+  YYSYMBOL_expr_type_decl = 318,           /* expr_type_decl  */
+  YYSYMBOL_319_19 = 319,                   /* $@19  */
+  YYSYMBOL_320_20 = 320,                   /* $@20  */
+  YYSYMBOL_expr_type_info = 321,           /* expr_type_info  */
+  YYSYMBOL_expr_list = 322,                /* expr_list  */
+  YYSYMBOL_block_or_simple_block = 323,    /* block_or_simple_block  */
+  YYSYMBOL_block_or_lambda = 324,          /* block_or_lambda  */
+  YYSYMBOL_capture_entry = 325,            /* capture_entry  */
+  YYSYMBOL_capture_list = 326,             /* capture_list  */
+  YYSYMBOL_optional_capture_list = 327,    /* optional_capture_list  */
+  YYSYMBOL_expr_block = 328,               /* expr_block  */
+  YYSYMBOL_expr_full_block = 329,          /* expr_full_block  */
+  YYSYMBOL_expr_full_block_assumed_piped = 330, /* expr_full_block_assumed_piped  */
+  YYSYMBOL_331_21 = 331,                   /* $@21  */
+  YYSYMBOL_expr_numeric_const = 332,       /* expr_numeric_const  */
+  YYSYMBOL_expr_assign = 333,              /* expr_assign  */
+  YYSYMBOL_expr_assign_pipe_right = 334,   /* expr_assign_pipe_right  */
+  YYSYMBOL_expr_assign_pipe = 335,         /* expr_assign_pipe  */
+  YYSYMBOL_expr_named_call = 336,          /* expr_named_call  */
+  YYSYMBOL_expr_method_call = 337,         /* expr_method_call  */
+  YYSYMBOL_func_addr_name = 338,           /* func_addr_name  */
+  YYSYMBOL_func_addr_expr = 339,           /* func_addr_expr  */
+  YYSYMBOL_340_22 = 340,                   /* $@22  */
+  YYSYMBOL_341_23 = 341,                   /* $@23  */
+  YYSYMBOL_342_24 = 342,                   /* $@24  */
+  YYSYMBOL_343_25 = 343,                   /* $@25  */
+  YYSYMBOL_expr_field = 344,               /* expr_field  */
+  YYSYMBOL_345_26 = 345,                   /* $@26  */
+  YYSYMBOL_346_27 = 346,                   /* $@27  */
+  YYSYMBOL_expr_call = 347,                /* expr_call  */
+  YYSYMBOL_expr = 348,                     /* expr  */
+  YYSYMBOL_349_28 = 349,                   /* $@28  */
+  YYSYMBOL_350_29 = 350,                   /* $@29  */
+  YYSYMBOL_351_30 = 351,                   /* $@30  */
+  YYSYMBOL_352_31 = 352,                   /* $@31  */
+  YYSYMBOL_353_32 = 353,                   /* $@32  */
+  YYSYMBOL_354_33 = 354,                   /* $@33  */
+  YYSYMBOL_expr_mtag = 355,                /* expr_mtag  */
+  YYSYMBOL_optional_field_annotation = 356, /* optional_field_annotation  */
+  YYSYMBOL_optional_override = 357,        /* optional_override  */
+  YYSYMBOL_optional_constant = 358,        /* optional_constant  */
+  YYSYMBOL_optional_public_or_private_member_variable = 359, /* optional_public_or_private_member_variable  */
+  YYSYMBOL_optional_static_member_variable = 360, /* optional_static_member_variable  */
+  YYSYMBOL_structure_variable_declaration = 361, /* structure_variable_declaration  */
+  YYSYMBOL_struct_variable_declaration_list = 362, /* struct_variable_declaration_list  */
+  YYSYMBOL_363_34 = 363,                   /* $@34  */
+  YYSYMBOL_364_35 = 364,                   /* $@35  */
+  YYSYMBOL_365_36 = 365,                   /* $@36  */
+  YYSYMBOL_function_argument_declaration = 366, /* function_argument_declaration  */
+  YYSYMBOL_function_argument_list = 367,   /* function_argument_list  */
+  YYSYMBOL_tuple_type = 368,               /* tuple_type  */
+  YYSYMBOL_tuple_type_list = 369,          /* tuple_type_list  */
+  YYSYMBOL_tuple_alias_type_list = 370,    /* tuple_alias_type_list  */
+  YYSYMBOL_variant_type = 371,             /* variant_type  */
+  YYSYMBOL_variant_type_list = 372,        /* variant_type_list  */
+  YYSYMBOL_variant_alias_type_list = 373,  /* variant_alias_type_list  */
+  YYSYMBOL_copy_or_move = 374,             /* copy_or_move  */
+  YYSYMBOL_variable_declaration = 375,     /* variable_declaration  */
+  YYSYMBOL_copy_or_move_or_clone = 376,    /* copy_or_move_or_clone  */
+  YYSYMBOL_optional_ref = 377,             /* optional_ref  */
+  YYSYMBOL_let_variable_name_with_pos_list = 378, /* let_variable_name_with_pos_list  */
+  YYSYMBOL_let_variable_declaration = 379, /* let_variable_declaration  */
+  YYSYMBOL_global_variable_declaration_list = 380, /* global_variable_declaration_list  */
+  YYSYMBOL_381_37 = 381,                   /* $@37  */
+  YYSYMBOL_optional_shared = 382,          /* optional_shared  */
+  YYSYMBOL_optional_public_or_private_variable = 383, /* optional_public_or_private_variable  */
+  YYSYMBOL_global_let = 384,               /* global_let  */
+  YYSYMBOL_385_38 = 385,                   /* $@38  */
+  YYSYMBOL_enum_list = 386,                /* enum_list  */
+  YYSYMBOL_optional_public_or_private_alias = 387, /* optional_public_or_private_alias  */
+  YYSYMBOL_single_alias = 388,             /* single_alias  */
+  YYSYMBOL_389_39 = 389,                   /* $@39  */
+  YYSYMBOL_alias_list = 390,               /* alias_list  */
+  YYSYMBOL_alias_declaration = 391,        /* alias_declaration  */
+  YYSYMBOL_392_40 = 392,                   /* $@40  */
+  YYSYMBOL_optional_public_or_private_enum = 393, /* optional_public_or_private_enum  */
+  YYSYMBOL_enum_name = 394,                /* enum_name  */
+  YYSYMBOL_enum_declaration = 395,         /* enum_declaration  */
+  YYSYMBOL_396_41 = 396,                   /* $@41  */
+  YYSYMBOL_397_42 = 397,                   /* $@42  */
+  YYSYMBOL_398_43 = 398,                   /* $@43  */
+  YYSYMBOL_399_44 = 399,                   /* $@44  */
+  YYSYMBOL_optional_structure_parent = 400, /* optional_structure_parent  */
+  YYSYMBOL_optional_sealed = 401,          /* optional_sealed  */
+  YYSYMBOL_structure_name = 402,           /* structure_name  */
+  YYSYMBOL_class_or_struct = 403,          /* class_or_struct  */
+  YYSYMBOL_optional_public_or_private_structure = 404, /* optional_public_or_private_structure  */
+  YYSYMBOL_optional_struct_variable_declaration_list = 405, /* optional_struct_variable_declaration_list  */
+  YYSYMBOL_structure_declaration = 406,    /* structure_declaration  */
+  YYSYMBOL_407_45 = 407,                   /* $@45  */
+  YYSYMBOL_408_46 = 408,                   /* $@46  */
+  YYSYMBOL_variable_name_with_pos_list = 409, /* variable_name_with_pos_list  */
+  YYSYMBOL_basic_type_declaration = 410,   /* basic_type_declaration  */
+  YYSYMBOL_enum_basic_type_declaration = 411, /* enum_basic_type_declaration  */
+  YYSYMBOL_structure_type_declaration = 412, /* structure_type_declaration  */
+  YYSYMBOL_auto_type_declaration = 413,    /* auto_type_declaration  */
+  YYSYMBOL_bitfield_bits = 414,            /* bitfield_bits  */
+  YYSYMBOL_bitfield_alias_bits = 415,      /* bitfield_alias_bits  */
+  YYSYMBOL_bitfield_type_declaration = 416, /* bitfield_type_declaration  */
+  YYSYMBOL_417_47 = 417,                   /* $@47  */
+  YYSYMBOL_418_48 = 418,                   /* $@48  */
+  YYSYMBOL_c_or_s = 419,                   /* c_or_s  */
+  YYSYMBOL_table_type_pair = 420,          /* table_type_pair  */
+  YYSYMBOL_dim_list = 421,                 /* dim_list  */
+  YYSYMBOL_type_declaration_no_options = 422, /* type_declaration_no_options  */
+  YYSYMBOL_423_49 = 423,                   /* $@49  */
+  YYSYMBOL_424_50 = 424,                   /* $@50  */
+  YYSYMBOL_425_51 = 425,                   /* $@51  */
+  YYSYMBOL_426_52 = 426,                   /* $@52  */
+  YYSYMBOL_427_53 = 427,                   /* $@53  */
+  YYSYMBOL_428_54 = 428,                   /* $@54  */
+  YYSYMBOL_429_55 = 429,                   /* $@55  */
+  YYSYMBOL_430_56 = 430,                   /* $@56  */
+  YYSYMBOL_431_57 = 431,                   /* $@57  */
+  YYSYMBOL_432_58 = 432,                   /* $@58  */
+  YYSYMBOL_433_59 = 433,                   /* $@59  */
+  YYSYMBOL_434_60 = 434,                   /* $@60  */
+  YYSYMBOL_435_61 = 435,                   /* $@61  */
+  YYSYMBOL_436_62 = 436,                   /* $@62  */
+  YYSYMBOL_437_63 = 437,                   /* $@63  */
+  YYSYMBOL_438_64 = 438,                   /* $@64  */
+  YYSYMBOL_439_65 = 439,                   /* $@65  */
+  YYSYMBOL_440_66 = 440,                   /* $@66  */
+  YYSYMBOL_441_67 = 441,                   /* $@67  */
+  YYSYMBOL_442_68 = 442,                   /* $@68  */
+  YYSYMBOL_443_69 = 443,                   /* $@69  */
+  YYSYMBOL_444_70 = 444,                   /* $@70  */
+  YYSYMBOL_445_71 = 445,                   /* $@71  */
+  YYSYMBOL_446_72 = 446,                   /* $@72  */
+  YYSYMBOL_447_73 = 447,                   /* $@73  */
+  YYSYMBOL_448_74 = 448,                   /* $@74  */
+  YYSYMBOL_449_75 = 449,                   /* $@75  */
+  YYSYMBOL_type_declaration = 450,         /* type_declaration  */
+  YYSYMBOL_tuple_alias_declaration = 451,  /* tuple_alias_declaration  */
+  YYSYMBOL_452_76 = 452,                   /* $@76  */
+  YYSYMBOL_453_77 = 453,                   /* $@77  */
+  YYSYMBOL_454_78 = 454,                   /* $@78  */
+  YYSYMBOL_455_79 = 455,                   /* $@79  */
+  YYSYMBOL_variant_alias_declaration = 456, /* variant_alias_declaration  */
+  YYSYMBOL_457_80 = 457,                   /* $@80  */
+  YYSYMBOL_458_81 = 458,                   /* $@81  */
+  YYSYMBOL_459_82 = 459,                   /* $@82  */
+  YYSYMBOL_460_83 = 460,                   /* $@83  */
+  YYSYMBOL_bitfield_alias_declaration = 461, /* bitfield_alias_declaration  */
+  YYSYMBOL_462_84 = 462,                   /* $@84  */
+  YYSYMBOL_463_85 = 463,                   /* $@85  */
+  YYSYMBOL_464_86 = 464,                   /* $@86  */
+  YYSYMBOL_465_87 = 465,                   /* $@87  */
+  YYSYMBOL_make_decl = 466,                /* make_decl  */
+  YYSYMBOL_make_struct_fields = 467,       /* make_struct_fields  */
+  YYSYMBOL_make_variant_dim = 468,         /* make_variant_dim  */
+  YYSYMBOL_make_struct_single = 469,       /* make_struct_single  */
+  YYSYMBOL_make_struct_dim = 470,          /* make_struct_dim  */
+  YYSYMBOL_make_struct_dim_list = 471,     /* make_struct_dim_list  */
+  YYSYMBOL_make_struct_dim_decl = 472,     /* make_struct_dim_decl  */
+  YYSYMBOL_optional_make_struct_dim_decl = 473, /* optional_make_struct_dim_decl  */
+  YYSYMBOL_optional_block = 474,           /* optional_block  */
+  YYSYMBOL_optional_trailing_semicolon_cur_cur = 475, /* optional_trailing_semicolon_cur_cur  */
+  YYSYMBOL_optional_trailing_semicolon_cur_sqr = 476, /* optional_trailing_semicolon_cur_sqr  */
+  YYSYMBOL_optional_trailing_semicolon_sqr_sqr = 477, /* optional_trailing_semicolon_sqr_sqr  */
+  YYSYMBOL_optional_trailing_delim_sqr_sqr = 478, /* optional_trailing_delim_sqr_sqr  */
+  YYSYMBOL_optional_trailing_delim_cur_sqr = 479, /* optional_trailing_delim_cur_sqr  */
+  YYSYMBOL_use_initializer = 480,          /* use_initializer  */
+  YYSYMBOL_make_struct_decl = 481,         /* make_struct_decl  */
+  YYSYMBOL_482_88 = 482,                   /* $@88  */
+  YYSYMBOL_483_89 = 483,                   /* $@89  */
+  YYSYMBOL_484_90 = 484,                   /* $@90  */
+  YYSYMBOL_485_91 = 485,                   /* $@91  */
+  YYSYMBOL_486_92 = 486,                   /* $@92  */
+  YYSYMBOL_487_93 = 487,                   /* $@93  */
+  YYSYMBOL_488_94 = 488,                   /* $@94  */
+  YYSYMBOL_489_95 = 489,                   /* $@95  */
+  YYSYMBOL_make_tuple = 490,               /* make_tuple  */
+  YYSYMBOL_make_map_tuple = 491,           /* make_map_tuple  */
+  YYSYMBOL_make_tuple_call = 492,          /* make_tuple_call  */
+  YYSYMBOL_493_96 = 493,                   /* $@96  */
+  YYSYMBOL_494_97 = 494,                   /* $@97  */
+  YYSYMBOL_make_dim = 495,                 /* make_dim  */
+  YYSYMBOL_make_dim_decl = 496,            /* make_dim_decl  */
+  YYSYMBOL_497_98 = 497,                   /* $@98  */
+  YYSYMBOL_498_99 = 498,                   /* $@99  */
+  YYSYMBOL_499_100 = 499,                  /* $@100  */
+  YYSYMBOL_500_101 = 500,                  /* $@101  */
+  YYSYMBOL_501_102 = 501,                  /* $@102  */
+  YYSYMBOL_502_103 = 502,                  /* $@103  */
+  YYSYMBOL_503_104 = 503,                  /* $@104  */
+  YYSYMBOL_504_105 = 504,                  /* $@105  */
+  YYSYMBOL_505_106 = 505,                  /* $@106  */
+  YYSYMBOL_506_107 = 506,                  /* $@107  */
+  YYSYMBOL_make_table = 507,               /* make_table  */
+  YYSYMBOL_expr_map_tuple_list = 508,      /* expr_map_tuple_list  */
+  YYSYMBOL_make_table_decl = 509,          /* make_table_decl  */
+  YYSYMBOL_array_comprehension_where = 510, /* array_comprehension_where  */
+  YYSYMBOL_optional_comma = 511,           /* optional_comma  */
+  YYSYMBOL_array_comprehension = 512       /* array_comprehension  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
+
+
+
+
+#ifdef short
+# undef short
+#endif
+
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
+#endif
+
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
+#else
+typedef signed char yytype_int8;
+#endif
+
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
+#else
+typedef short yytype_int16;
+#endif
+
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
+#else
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
+#endif
+
+#ifndef YYSIZE_T
+# ifdef __SIZE_TYPE__
+#  define YYSIZE_T __SIZE_TYPE__
+# elif defined size_t
+#  define YYSIZE_T size_t
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  define YYSIZE_T size_t
+# else
+#  define YYSIZE_T unsigned
+# endif
+#endif
+
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int16 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
+
+#ifndef YY_
+# if defined YYENABLE_NLS && YYENABLE_NLS
+#  if ENABLE_NLS
+#   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
+#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
+#  endif
+# endif
+# ifndef YY_
+#  define YY_(Msgid) Msgid
+# endif
+#endif
+
+
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
+# else
+#  define YY_ATTRIBUTE_PURE
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
+# else
+#  define YY_ATTRIBUTE_UNUSED
+# endif
+#endif
+
+/* Suppress unused-variable warnings by "using" E.  */
+#if ! defined lint || defined __GNUC__
+# define YY_USE(E) ((void) (E))
+#else
+# define YY_USE(E) /* empty */
+#endif
+
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
+    _Pragma ("GCC diagnostic pop")
+#else
+# define YY_INITIAL_VALUE(Value) Value
+#endif
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
+#endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
+#endif
+
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
+
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
+
+#if 1
+
+/* The parser invokes alloca or malloc; define the necessary symbols.  */
+
+# ifdef YYSTACK_USE_ALLOCA
+#  if YYSTACK_USE_ALLOCA
+#   ifdef __GNUC__
+#    define YYSTACK_ALLOC __builtin_alloca
+#   elif defined __BUILTIN_VA_ARG_INCR
+#    include <alloca.h> /* INFRINGES ON USER NAME SPACE */
+#   elif defined _AIX
+#    define YYSTACK_ALLOC __alloca
+#   elif defined _MSC_VER
+#    include <malloc.h> /* INFRINGES ON USER NAME SPACE */
+#    define alloca _alloca
+#   else
+#    define YYSTACK_ALLOC alloca
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
+#     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+      /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
+#     ifndef EXIT_SUCCESS
+#      define EXIT_SUCCESS 0
+#     endif
+#    endif
+#   endif
+#  endif
+# endif
+
+# ifdef YYSTACK_ALLOC
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
+#  ifndef YYSTACK_ALLOC_MAXIMUM
+    /* The OS might guarantee only one guard page at the bottom of the stack,
+       and a page size can be as small as 4096 bytes.  So we cannot safely
+       invoke alloca (N) if N exceeds 4096.  Use a slightly smaller number
+       to allow for a few compiler-allocated temporary stack slots.  */
+#   define YYSTACK_ALLOC_MAXIMUM 4032 /* reasonable circa 2006 */
+#  endif
+# else
+#  define YYSTACK_ALLOC YYMALLOC
+#  define YYSTACK_FREE YYFREE
+#  ifndef YYSTACK_ALLOC_MAXIMUM
+#   define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
+#  endif
+#  if (defined __cplusplus && ! defined EXIT_SUCCESS \
+       && ! ((defined YYMALLOC || defined malloc) \
+             && (defined YYFREE || defined free)))
+#   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#   ifndef EXIT_SUCCESS
+#    define EXIT_SUCCESS 0
+#   endif
+#  endif
+#  ifndef YYMALLOC
+#   define YYMALLOC malloc
+#   if ! defined malloc && ! defined EXIT_SUCCESS
+void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
+#   endif
+#  endif
+#  ifndef YYFREE
+#   define YYFREE free
+#   if ! defined free && ! defined EXIT_SUCCESS
+void free (void *); /* INFRINGES ON USER NAME SPACE */
+#   endif
+#  endif
+# endif
+#endif /* 1 */
+
+#if (! defined yyoverflow \
+     && (! defined __cplusplus \
+         || (defined DAS_YYLTYPE_IS_TRIVIAL && DAS_YYLTYPE_IS_TRIVIAL \
+             && defined DAS_YYSTYPE_IS_TRIVIAL && DAS_YYSTYPE_IS_TRIVIAL)))
+
+/* A type that is properly aligned for any stack member.  */
+union yyalloc
+{
+  yy_state_t yyss_alloc;
+  YYSTYPE yyvs_alloc;
+  YYLTYPE yyls_alloc;
+};
+
+/* The size of the maximum gap between one aligned stack and the next.  */
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
+
+/* The size of an array large to enough to hold all stacks, each with
+   N elements.  */
+# define YYSTACK_BYTES(N) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE) \
+             + YYSIZEOF (YYLTYPE)) \
+      + 2 * YYSTACK_GAP_MAXIMUM)
+
+# define YYCOPY_NEEDED 1
+
+/* Relocate STACK from its old location to the new one.  The
+   local variables YYSIZE and YYSTACKSIZE give the old and new number of
+   elements in the stack, and YYPTR gives the new location of the
+   stack.  Advance YYPTR to a properly aligned location for the next
+   stack.  */
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYPTRDIFF_T yynewbytes;                                         \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
+      }                                                                 \
+    while (0)
+
+#endif
+
+#if defined YYCOPY_NEEDED && YYCOPY_NEEDED
+/* Copy COUNT objects from SRC to DST.  The source and destination do
+   not overlap.  */
+# ifndef YYCOPY
+#  if defined __GNUC__ && 1 < __GNUC__
+#   define YYCOPY(Dst, Src, Count) \
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
+#  else
+#   define YYCOPY(Dst, Src, Count)              \
+      do                                        \
+        {                                       \
+          YYPTRDIFF_T yyi;                      \
+          for (yyi = 0; yyi < (Count); yyi++)   \
+            (Dst)[yyi] = (Src)[yyi];            \
+        }                                       \
+      while (0)
+#  endif
+# endif
+#endif /* !YYCOPY_NEEDED */
+
+/* YYFINAL -- State number of the termination state.  */
+#define YYFINAL  2
+/* YYLAST -- Last index in YYTABLE.  */
+#define YYLAST   15571
+
+/* YYNTOKENS -- Number of terminals.  */
+#define YYNTOKENS  219
+/* YYNNTS -- Number of nonterminals.  */
+#define YYNNTS  294
+/* YYNRULES -- Number of rules.  */
+#define YYNRULES  894
+/* YYNSTATES -- Number of states.  */
+#define YYNSTATES  1698
+
+/* YYMAXUTOK -- Last valid token kind.  */
+#define YYMAXUTOK   446
+
+
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
+
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex.  */
+static const yytype_uint8 yytranslate[] =
+{
+       0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,   205,     2,   218,   216,   201,   194,     2,
+     214,   215,   199,   198,   188,   197,   211,   200,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,   191,   182,
+     195,   189,   196,   190,   217,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,   212,     2,   213,   193,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,   180,   192,   181,   204,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
+       5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
+      15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
+      25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
+      35,    36,    37,    38,    39,    40,    41,    42,    43,    44,
+      45,    46,    47,    48,    49,    50,    51,    52,    53,    54,
+      55,    56,    57,    58,    59,    60,    61,    62,    63,    64,
+      65,    66,    67,    68,    69,    70,    71,    72,    73,    74,
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
+      85,    86,    87,    88,    89,    90,    91,    92,    93,    94,
+      95,    96,    97,    98,    99,   100,   101,   102,   103,   104,
+     105,   106,   107,   108,   109,   110,   111,   112,   113,   114,
+     115,   116,   117,   118,   119,   120,   121,   122,   123,   124,
+     125,   126,   127,   128,   129,   130,   131,   132,   133,   134,
+     135,   136,   137,   138,   139,   140,   141,   142,   143,   144,
+     145,   146,   147,   148,   149,   150,   151,   152,   153,   154,
+     155,   156,   157,   158,   159,   160,   161,   162,   163,   164,
+     165,   166,   167,   168,   169,   170,   171,   172,   173,   174,
+     175,   176,   177,   178,   179,   183,   184,   185,   186,   187,
+     202,   203,   206,   207,   208,   209,   210
+};
+
+#if DAS_YYDEBUG
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+static const yytype_int16 yyrline[] =
+{
+       0,   554,   554,   555,   560,   561,   562,   563,   564,   565,
+     566,   567,   568,   569,   570,   571,   572,   576,   582,   583,
+     584,   588,   589,   593,   611,   612,   613,   614,   618,   619,
+     623,   628,   637,   645,   661,   666,   674,   674,   715,   745,
+     749,   750,   751,   755,   758,   762,   768,   777,   780,   786,
+     787,   791,   795,   796,   800,   803,   809,   815,   818,   824,
+     825,   829,   830,   831,   840,   841,   845,   846,   846,   852,
+     853,   854,   855,   856,   860,   866,   866,   872,   872,   878,
+     886,   896,   905,   905,   912,   913,   914,   915,   916,   917,
+     921,   926,   934,   935,   936,   940,   941,   942,   943,   944,
+     945,   946,   947,   953,   956,   962,   965,   968,   974,   975,
+     976,   977,   981,   994,  1012,  1015,  1023,  1034,  1045,  1056,
+    1059,  1066,  1070,  1077,  1078,  1082,  1083,  1084,  1088,  1091,
+    1098,  1102,  1103,  1104,  1105,  1106,  1107,  1108,  1109,  1110,
+    1111,  1112,  1113,  1114,  1115,  1116,  1117,  1118,  1119,  1120,
+    1121,  1122,  1123,  1124,  1125,  1126,  1127,  1128,  1129,  1130,
+    1131,  1132,  1133,  1134,  1135,  1136,  1137,  1138,  1139,  1140,
+    1141,  1142,  1143,  1144,  1145,  1146,  1147,  1148,  1149,  1150,
+    1151,  1152,  1153,  1154,  1155,  1156,  1157,  1158,  1159,  1160,
+    1161,  1162,  1163,  1164,  1165,  1166,  1167,  1168,  1169,  1170,
+    1171,  1172,  1173,  1174,  1175,  1176,  1177,  1178,  1179,  1180,
+    1181,  1182,  1183,  1184,  1185,  1190,  1208,  1209,  1210,  1214,
+    1220,  1220,  1237,  1249,  1268,  1277,  1286,  1292,  1293,  1294,
+    1295,  1296,  1297,  1298,  1299,  1300,  1301,  1302,  1303,  1304,
+    1305,  1306,  1307,  1308,  1309,  1310,  1311,  1312,  1316,  1321,
+    1327,  1333,  1344,  1345,  1349,  1350,  1354,  1355,  1359,  1363,
+    1370,  1370,  1370,  1376,  1376,  1376,  1385,  1419,  1422,  1425,
+    1428,  1434,  1435,  1446,  1450,  1453,  1461,  1461,  1461,  1464,
+    1470,  1473,  1477,  1481,  1488,  1495,  1501,  1505,  1509,  1512,
+    1515,  1523,  1526,  1529,  1537,  1540,  1548,  1551,  1554,  1562,
+    1568,  1569,  1570,  1574,  1575,  1579,  1580,  1584,  1589,  1597,
+    1609,  1615,  1631,  1643,  1646,  1652,  1652,  1652,  1655,  1655,
+    1655,  1660,  1660,  1660,  1668,  1668,  1668,  1674,  1684,  1695,
+    1708,  1718,  1729,  1744,  1747,  1753,  1754,  1761,  1772,  1773,
+    1774,  1778,  1779,  1780,  1781,  1782,  1786,  1791,  1799,  1800,
+    1801,  1805,  1810,  1817,  1824,  1824,  1833,  1834,  1835,  1836,
+    1837,  1838,  1839,  1843,  1844,  1845,  1846,  1847,  1848,  1849,
+    1850,  1851,  1852,  1853,  1854,  1855,  1856,  1857,  1858,  1859,
+    1860,  1861,  1865,  1866,  1867,  1868,  1873,  1874,  1875,  1876,
+    1877,  1878,  1879,  1880,  1881,  1882,  1883,  1884,  1885,  1886,
+    1887,  1888,  1889,  1894,  1901,  1913,  1918,  1928,  1932,  1939,
+    1942,  1942,  1942,  1947,  1947,  1947,  1960,  1964,  1968,  1973,
+    1980,  1989,  1994,  2001,  2001,  2001,  2008,  2012,  2022,  2031,
+    2040,  2044,  2047,  2053,  2054,  2055,  2056,  2057,  2058,  2059,
+    2060,  2061,  2062,  2063,  2064,  2065,  2066,  2067,  2068,  2069,
+    2070,  2071,  2072,  2073,  2074,  2075,  2076,  2077,  2078,  2079,
+    2080,  2081,  2082,  2083,  2084,  2085,  2086,  2087,  2088,  2094,
+    2095,  2096,  2097,  2098,  2111,  2112,  2113,  2114,  2115,  2116,
+    2117,  2118,  2119,  2120,  2121,  2122,  2125,  2128,  2129,  2132,
+    2132,  2132,  2135,  2140,  2144,  2148,  2148,  2148,  2153,  2156,
+    2160,  2160,  2160,  2165,  2168,  2169,  2170,  2171,  2172,  2173,
+    2174,  2175,  2176,  2178,  2182,  2183,  2188,  2192,  2193,  2194,
+    2195,  2196,  2197,  2198,  2202,  2206,  2210,  2214,  2218,  2222,
+    2226,  2230,  2234,  2241,  2242,  2243,  2247,  2248,  2249,  2253,
+    2254,  2258,  2259,  2260,  2264,  2265,  2269,  2280,  2283,  2283,
+    2302,  2301,  2317,  2316,  2330,  2339,  2348,  2358,  2359,  2363,
+    2366,  2375,  2376,  2380,  2383,  2386,  2402,  2411,  2412,  2416,
+    2419,  2422,  2436,  2437,  2441,  2447,  2453,  2456,  2460,  2466,
+    2475,  2476,  2477,  2481,  2482,  2486,  2493,  2498,  2507,  2513,
+    2524,  2527,  2532,  2537,  2545,  2556,  2559,  2559,  2579,  2580,
+    2584,  2585,  2586,  2590,  2593,  2593,  2612,  2615,  2618,  2633,
+    2652,  2653,  2654,  2659,  2659,  2685,  2686,  2690,  2691,  2691,
+    2695,  2696,  2697,  2701,  2711,  2716,  2711,  2728,  2733,  2728,
+    2748,  2749,  2753,  2754,  2758,  2764,  2765,  2766,  2767,  2771,
+    2772,  2773,  2777,  2780,  2795,  2800,  2795,  2820,  2827,  2832,
+    2841,  2847,  2858,  2859,  2860,  2861,  2862,  2863,  2864,  2865,
+    2866,  2867,  2868,  2869,  2870,  2871,  2872,  2873,  2874,  2875,
+    2876,  2877,  2878,  2879,  2880,  2881,  2882,  2883,  2884,  2888,
+    2889,  2890,  2891,  2892,  2893,  2894,  2895,  2899,  2910,  2914,
+    2921,  2933,  2940,  2949,  2954,  2957,  2970,  2970,  2970,  2983,
+    2984,  2988,  2992,  2999,  3003,  3010,  3011,  3012,  3013,  3014,
+    3029,  3035,  3035,  3035,  3039,  3044,  3051,  3051,  3058,  3062,
+    3066,  3071,  3076,  3081,  3086,  3090,  3094,  3099,  3103,  3107,
+    3112,  3112,  3112,  3118,  3125,  3125,  3125,  3130,  3130,  3130,
+    3136,  3136,  3136,  3141,  3145,  3145,  3145,  3150,  3150,  3150,
+    3159,  3163,  3163,  3163,  3168,  3168,  3168,  3177,  3181,  3181,
+    3181,  3186,  3186,  3186,  3195,  3195,  3195,  3201,  3201,  3201,
+    3210,  3213,  3224,  3240,  3240,  3245,  3250,  3240,  3275,  3275,
+    3280,  3286,  3275,  3311,  3311,  3316,  3321,  3311,  3351,  3352,
+    3353,  3354,  3355,  3359,  3366,  3373,  3379,  3385,  3392,  3399,
+    3405,  3414,  3420,  3428,  3433,  3440,  3445,  3452,  3457,  3463,
+    3464,  3468,  3469,  3474,  3475,  3479,  3480,  3484,  3485,  3489,
+    3490,  3491,  3495,  3496,  3497,  3501,  3502,  3506,  3531,  3563,
+    3576,  3593,  3608,  3626,  3626,  3626,  3634,  3634,  3634,  3641,
+    3641,  3641,  3648,  3648,  3648,  3659,  3663,  3669,  3685,  3691,
+    3697,  3703,  3703,  3703,  3713,  3718,  3725,  3734,  3755,  3772,
+    3772,  3772,  3782,  3782,  3782,  3792,  3792,  3792,  3802,  3811,
+    3811,  3811,  3831,  3838,  3838,  3838,  3848,  3853,  3860,  3863,
+    3869,  3877,  3892,  3900,  3920,  3945,  3946,  3950,  3951,  3956,
+    3959,  3962,  3971,  3981,  3984
+};
+#endif
+
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if 1
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
+/* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
+   First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
+static const char *const yytname[] =
+{
+  "\"end of file\"", "error", "\"invalid token\"", "\"lexer error\"",
+  "\"capture\"", "\"struct\"", "\"class\"", "\"let\"", "\"def\"",
+  "\"while\"", "\"if\"", "\"static_if\"", "\"else\"", "\"for\"",
+  "\"recover\"", "\"true\"", "\"false\"", "\"new\"", "\"typeinfo\"",
+  "\"type\"", "\"in\"", "\"is\"", "\"as\"", "\"elif\"", "\"static_elif\"",
+  "\"array\"", "\"return\"", "\"null\"", "\"break\"", "\"try\"",
+  "\"options\"", "\"table\"", "\"expect\"", "\"const\"", "\"require\"",
+  "\"operator\"", "\"enum\"", "\"finally\"", "\"delete\"", "\"deref\"",
+  "\"typedef\"", "\"typedecl\"", "\"with\"", "\"aka\"", "\"assume\"",
+  "\"cast\"", "\"override\"", "\"abstract\"", "\"upcast\"", "\"iterator\"",
+  "\"var\"", "\"addr\"", "\"continue\"", "\"where\"", "\"pass\"",
+  "\"reinterpret\"", "\"module\"", "\"public\"", "\"label\"", "\"goto\"",
+  "\"implicit\"", "\"explicit\"", "\"shared\"", "\"private\"",
+  "\"smart_ptr\"", "\"unsafe\"", "\"inscope\"", "\"static\"",
+  "\"fixed_array\"", "\"default\"", "\"uninitialized\"", "\"bool\"",
+  "\"void\"", "\"string\"", "\"auto\"", "\"int\"", "\"int2\"", "\"int3\"",
+  "\"int4\"", "\"uint\"", "\"bitfield\"", "\"uint2\"", "\"uint3\"",
+  "\"uint4\"", "\"float\"", "\"float2\"", "\"float3\"", "\"float4\"",
+  "\"range\"", "\"urange\"", "\"range64\"", "\"urange64\"", "\"block\"",
+  "\"int64\"", "\"uint64\"", "\"double\"", "\"function\"", "\"lambda\"",
+  "\"int8\"", "\"uint8\"", "\"int16\"", "\"uint16\"", "\"tuple\"",
+  "\"variant\"", "\"generator\"", "\"yield\"", "\"sealed\"",
+  "\"template\"", "\"+=\"", "\"-=\"", "\"/=\"", "\"*=\"", "\"%=\"",
+  "\"&=\"", "\"|=\"", "\"^=\"", "\"<<\"", "\">>\"", "\"++\"", "\"--\"",
+  "\"<=\"", "\"<<=\"", "\">>=\"", "\">=\"", "\"==\"", "\"!=\"", "\"->\"",
+  "\"<-\"", "\"??\"", "\"?.\"", "\"?[\"", "\"<|\"", "\" <|\"", "\"$ <|\"",
+  "\"@ <|\"", "\"@@ <|\"", "\"|>\"", "\":=\"", "\"<<<\"", "\">>>\"",
+  "\"<<<=\"", "\">>>=\"", "\"=>\"", "\"::\"", "\"&&\"", "\"||\"", "\"^^\"",
+  "\"&&=\"", "\"||=\"", "\"^^=\"", "\"..\"", "\"$$\"", "\"$i\"", "\"$v\"",
+  "\"$b\"", "\"$a\"", "\"$t\"", "\"$c\"", "\"$f\"", "\"...\"", "\"[[\"",
+  "\"[{\"", "\"{{\"", "\"integer constant\"", "\"long integer constant\"",
+  "\"unsigned integer constant\"", "\"unsigned long integer constant\"",
+  "\"unsigned int8 constant\"", "\"floating point constant\"",
+  "\"double constant\"", "\"name\"", "\"keyword\"", "\"type function\"",
+  "\"start of the string\"", "STRING_CHARACTER", "STRING_CHARACTER_ESC",
+  "\"end of the string\"", "\"{\"", "\"}\"",
+  "\"end of failed eader macro\"", "\"begin of code block\"",
+  "\"end of code block\"", "\"end of expression\"", "\";}}\"", "\";}]\"",
+  "\";]]\"", "\",]]\"", "\",}]\"", "','", "'='", "'?'", "':'", "'|'",
+  "'^'", "'&'", "'<'", "'>'", "'-'", "'+'", "'*'", "'/'", "'%'",
+  "UNARY_MINUS", "UNARY_PLUS", "'~'", "'!'", "PRE_INC", "PRE_DEC",
+  "POST_INC", "POST_DEC", "DEREF", "'.'", "'['", "']'", "'('", "')'",
+  "'$'", "'@'", "'#'", "$accept", "program", "top_level_reader_macro",
+  "optional_public_or_private_module", "module_name", "module_declaration",
+  "character_sequence", "string_constant", "string_builder_body",
+  "string_builder", "reader_character_sequence", "expr_reader", "$@1",
+  "options_declaration", "require_declaration", "keyword_or_name",
+  "require_module_name", "require_module", "is_public_module",
+  "expect_declaration", "expect_list", "expect_error", "expression_label",
+  "expression_goto", "elif_or_static_elif", "expression_else",
+  "if_or_static_if", "expression_else_one_liner", "$@2",
+  "expression_if_one_liner", "expression_if_then_else", "$@3",
+  "expression_for_loop", "$@4", "expression_unsafe",
+  "expression_while_loop", "expression_with", "expression_with_alias",
+  "$@5", "annotation_argument_value", "annotation_argument_value_list",
+  "annotation_argument_name", "annotation_argument",
+  "annotation_argument_list", "metadata_argument_list",
+  "annotation_declaration_name", "annotation_declaration_basic",
+  "annotation_declaration", "annotation_list", "optional_annotation_list",
+  "optional_function_argument_list", "optional_function_type",
+  "function_name", "global_function_declaration",
+  "optional_public_or_private_function", "function_declaration_header",
+  "function_declaration", "$@6", "expression_block", "expr_call_pipe",
+  "expression_any", "expressions", "expr_keyword", "optional_expr_list",
+  "optional_expr_list_in_braces", "optional_expr_map_tuple_list",
+  "type_declaration_no_options_list", "expression_keyword", "$@7", "$@8",
+  "$@9", "$@10", "expr_pipe", "name_in_namespace", "expression_delete",
+  "new_type_declaration", "$@11", "$@12", "expr_new", "expression_break",
+  "expression_continue", "expression_return_no_pipe", "expression_return",
+  "expression_yield_no_pipe", "expression_yield", "expression_try_catch",
+  "kwd_let_var_or_nothing", "kwd_let", "optional_in_scope",
+  "tuple_expansion", "tuple_expansion_variable_declaration",
+  "expression_let", "expr_cast", "$@13", "$@14", "$@15", "$@16", "$@17",
+  "$@18", "expr_type_decl", "$@19", "$@20", "expr_type_info", "expr_list",
+  "block_or_simple_block", "block_or_lambda", "capture_entry",
+  "capture_list", "optional_capture_list", "expr_block", "expr_full_block",
+  "expr_full_block_assumed_piped", "$@21", "expr_numeric_const",
+  "expr_assign", "expr_assign_pipe_right", "expr_assign_pipe",
+  "expr_named_call", "expr_method_call", "func_addr_name",
+  "func_addr_expr", "$@22", "$@23", "$@24", "$@25", "expr_field", "$@26",
+  "$@27", "expr_call", "expr", "$@28", "$@29", "$@30", "$@31", "$@32",
+  "$@33", "expr_mtag", "optional_field_annotation", "optional_override",
+  "optional_constant", "optional_public_or_private_member_variable",
+  "optional_static_member_variable", "structure_variable_declaration",
+  "struct_variable_declaration_list", "$@34", "$@35", "$@36",
+  "function_argument_declaration", "function_argument_list", "tuple_type",
+  "tuple_type_list", "tuple_alias_type_list", "variant_type",
+  "variant_type_list", "variant_alias_type_list", "copy_or_move",
+  "variable_declaration", "copy_or_move_or_clone", "optional_ref",
+  "let_variable_name_with_pos_list", "let_variable_declaration",
+  "global_variable_declaration_list", "$@37", "optional_shared",
+  "optional_public_or_private_variable", "global_let", "$@38", "enum_list",
+  "optional_public_or_private_alias", "single_alias", "$@39", "alias_list",
+  "alias_declaration", "$@40", "optional_public_or_private_enum",
+  "enum_name", "enum_declaration", "$@41", "$@42", "$@43", "$@44",
+  "optional_structure_parent", "optional_sealed", "structure_name",
+  "class_or_struct", "optional_public_or_private_structure",
+  "optional_struct_variable_declaration_list", "structure_declaration",
+  "$@45", "$@46", "variable_name_with_pos_list", "basic_type_declaration",
+  "enum_basic_type_declaration", "structure_type_declaration",
+  "auto_type_declaration", "bitfield_bits", "bitfield_alias_bits",
+  "bitfield_type_declaration", "$@47", "$@48", "c_or_s", "table_type_pair",
+  "dim_list", "type_declaration_no_options", "$@49", "$@50", "$@51",
+  "$@52", "$@53", "$@54", "$@55", "$@56", "$@57", "$@58", "$@59", "$@60",
+  "$@61", "$@62", "$@63", "$@64", "$@65", "$@66", "$@67", "$@68", "$@69",
+  "$@70", "$@71", "$@72", "$@73", "$@74", "$@75", "type_declaration",
+  "tuple_alias_declaration", "$@76", "$@77", "$@78", "$@79",
+  "variant_alias_declaration", "$@80", "$@81", "$@82", "$@83",
+  "bitfield_alias_declaration", "$@84", "$@85", "$@86", "$@87",
+  "make_decl", "make_struct_fields", "make_variant_dim",
+  "make_struct_single", "make_struct_dim", "make_struct_dim_list",
+  "make_struct_dim_decl", "optional_make_struct_dim_decl",
+  "optional_block", "optional_trailing_semicolon_cur_cur",
+  "optional_trailing_semicolon_cur_sqr",
+  "optional_trailing_semicolon_sqr_sqr", "optional_trailing_delim_sqr_sqr",
+  "optional_trailing_delim_cur_sqr", "use_initializer", "make_struct_decl",
+  "$@88", "$@89", "$@90", "$@91", "$@92", "$@93", "$@94", "$@95",
+  "make_tuple", "make_map_tuple", "make_tuple_call", "$@96", "$@97",
+  "make_dim", "make_dim_decl", "$@98", "$@99", "$@100", "$@101", "$@102",
+  "$@103", "$@104", "$@105", "$@106", "$@107", "make_table",
+  "expr_map_tuple_list", "make_table_decl", "array_comprehension_where",
+  "optional_comma", "array_comprehension", YY_NULLPTR
+};
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
+#endif
+
+#define YYPACT_NINF (-1497)
+
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
+
+#define YYTABLE_NINF (-762)
+
+#define yytable_value_is_error(Yyn) \
+  ((Yyn) == YYTABLE_NINF)
+
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
+static const yytype_int16 yypact[] =
+{
+   -1497,    41, -1497, -1497,    79,   -80,   215,   -34, -1497,    71,
+     647,   647,   647, -1497,   196,    42, -1497, -1497,   -11, -1497,
+   -1497, -1497,    74, -1497,   218, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497,   101, -1497,    15,   137,   157,
+   -1497, -1497, -1497, -1497,   215, -1497,    50, -1497,   647,   647,
+   -1497, -1497,   218, -1497, -1497, -1497, -1497, -1497,   220,   269,
+   -1497, -1497, -1497, -1497,    42,    42,    42,   224, -1497,   665,
+     -16, -1497, -1497, -1497, -1497,   664,   667,   423,   671, -1497,
+     675,    43,    79,   295,   -80,   264,   326, -1497,   642,   642,
+   -1497,   330,   360,     7,   371,   676,   394,   404,   426, -1497,
+     460,   415, -1497, -1497,   -15,    79,    42,    42,    42,    42,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497,   467, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497,   479, -1497, -1497, -1497, -1497,
+   -1497,   645,   132, -1497, -1497, -1497, -1497,   616, -1497, -1497,
+   -1497, -1497, -1497,   507, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497,   518, -1497,   203, -1497,   683,   579,   665,
+   15401, -1497,   349,   608, -1497,   -57, -1497, -1497, -1497,   648,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497,   208, -1497,   560,
+   -1497,   581,   586,   598, -1497, -1497, 13679, -1497, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497,   748,   768, -1497,   594,   654, -1497,   456, -1497,
+     656, -1497,   658,    79,    79,    96,    99, -1497, -1497, -1497,
+     132, -1497, 10160, -1497, -1497, -1497,   672,   673, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,   677,   635,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497,   829, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497,   685,   644, -1497, -1497,   119,
+     669, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497,   678,   670,   688, -1497,   -57,   171, -1497, -1497,
+      79,   657,   836,   397, -1497, -1497,   686,   687,   690,   684,
+     692,   694, -1497, -1497, -1497,   689, -1497, -1497, -1497, -1497,
+   -1497,   696, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497,   699, -1497, -1497, -1497,   702,   704, -1497,
+   -1497, -1497, -1497,   706,   707,   691,   196, -1497, -1497, -1497,
+   -1497, -1497,  2009,   712, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497,   710,   735, -1497,   693, -1497,   333, -1497,     9, 10160,
+   -1497,  2232,   243, -1497,   196, -1497, -1497, -1497,    99,   698,
+   -1497,  9363,   736,   739, 10160, -1497,   -12, -1497, -1497, -1497,
+    9363, -1497, -1497,   742, -1497,   345,   352,   367, -1497, -1497,
+    9363,   294, -1497, -1497, -1497,    33, -1497, -1497, -1497,    14,
+    5502, -1497,   705,  9914,   422, 10014,   427, -1497, -1497,  9363,
+   -1497, -1497,   290,   -19, -1497,   712, -1497,   721,   723,  9363,
+   -1497, -1497, -1497, -1497, -1497,   161,   -58,   724,    30,  3261,
+   -1497, -1497,   654,   372,  5705,   708,  9363,   750,   728,   730,
+     713, -1497,   746,   734,   770,  5908,   -64,   376,   740, -1497,
+     380,   741,   745,  3464,  9363,  9363,   109,   109,   109,   720,
+     731,   732,   743,   744,   747, -1497,  1846,  9728,  6113, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497,  6316,   749, -1497,  6521,
+     904, -1497,  9363,  9363,  9363,  9363,  9363,  5096,  9363, -1497,
+     751, -1497, -1497,   766,   767,  9363,   946, -1497, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497,   519, -1497,    -7,   777,
+   -1497,   781,   782,   783, -1497,   784, -1497, -1497,   901, -1497,
+   -1497, -1497, -1497,   757, -1497, -1497,   -21, -1497, -1497, -1497,
+   -1497, -1497, -1497,  1650, -1497,   756, -1497, -1497, -1497, -1497,
+   -1497, -1497,   210, -1497,   790, -1497, -1497,    28, -1497, -1497,
+     758,   778,   779, -1497, 10713, -1497,   932,  1169, -1497, -1497,
+   -1497,  3870, 10160, 10160, 10160, 10748, 10160, 10160,   761,   807,
+   10160,   594, 10160,   594, 10160,   594, 10260,   808, 10848, -1497,
+    9363, -1497, -1497, -1497, -1497,   772, -1497, -1497, 13198,  9363,
+   -1497,  2009,   797, -1497,   799,   -69, -1497, -1497,   351, -1497,
+     712,   800,   792,   351, -1497,   805, 10948,   774,   947, -1497,
+     -49, -1497, -1497, -1497, 13714,   290, -1497,   775, -1497, -1497,
+     196,   389, -1497,   796,   798,   803, -1497,  9363,  3870, -1497,
+     804,   862, 10343,   981, 10160,  9363,  9363, 14619,  9363, 13714,
+     810, -1497, -1497,  9363, -1497, -1497,   809,   839, 14619,  9363,
+   -1497, -1497,  9363, -1497, -1497,  9363, -1497, 10160,  3870, -1497,
+   10343,   136,   136,   786, -1497,   757, -1497, -1497, -1497,  9363,
+    9363,  9363,  9363,  9363,  9363,   290,  2649,   290,  2853,   290,
+   13814, -1497,   649, -1497, 13714, -1497,   624,   290, -1497,   816,
+     825,   136,   136,   -10,   136,   136,   290,   993,   821, 14619,
+     821,   287, -1497, -1497, 13714, -1497, -1497, -1497, -1497,  4073,
+   -1497, -1497, -1497, -1497, -1497, -1497,   141,    59,   109, -1497,
+   15165, 15196,  4276,  4276,  4276,  4276,  4276,  4276,  4276,  4276,
+    9363,  9363, -1497, -1497,  9363,  4276,  4276,  9363,  9363,  9363,
+     841,  4276,  9363,   449,  9363,  9363,  9363,  9363,  9363,  9363,
+    4276,  4276,  9363,  9363,  9363,  4276,  4276,  4276,  9363,  4276,
+    6724,  9363,  9363,  9363,  9363,  9363,  9363,  9363,  9363,  9363,
+    9363, 15323,  9363, -1497,  6927, -1497,  9363, -1497,   243, -1497,
+      42,  1004,   -57, 10160, -1497,   843, -1497,  3870, -1497, 10456,
+     465,   509,   818,   514, -1497,   520,   567, -1497, -1497,   313,
+     568,   669,   575,   669,   576,   669, -1497,   435, -1497,   453,
+   -1497, 10160,   811,   821, -1497, -1497, 13298, -1497, -1497, 10160,
+   -1497, -1497, 10160, -1497, -1497, -1497,  9363,   863, -1497,   868,
+   -1497, 10160, -1497,  3870, 10160, 10160, -1497,    26, 10160,  5299,
+    7130,   869,  9363, 10160, -1497, -1497, -1497, 10160,   821, -1497,
+     804,  9363,  9363,  9363,  9363,  9363,  9363,  9363,  9363,  9363,
+    9363,  9363,  9363,  9363,  9363,  9363,  9363,  9363,  9363,   654,
+    1504,   817,   816, 14619, 10983, -1497, -1497, 10160, 10160, 11083,
+   10160, -1497, -1497, 11183, 10160,   821, 10160, 10160,   821, 10160,
+     225, -1497, 10343, -1497,    59, 11218, 11318, 11418, 11453, 11553,
+   11653,    29,   109,   826,   172,  3057,  4481,  7333, 13914,   853,
+       2,   165,   854,   175,    34,  7536,     2,   606,    40,  9363,
+     870,  9363, -1497, -1497, 10160, -1497, 10160, -1497,  9363,   431,
+      45,  9363,   872, -1497,    47,   290,  9363,   832,   840,   844,
+     845,   369, -1497, -1497,   610,  9363,   757,   -62,  4686, -1497,
+     212,   853,   842,   884,   884, -1497, -1497,   848,   144,   594,
+   -1497,   873,   849, -1497, -1497,   874,   850, -1497, -1497,   109,
+     109,   109, -1497, -1497, 10602, -1497, 10602, -1497, 10602, -1497,
+   10602, -1497, 10602, -1497, 10602, -1497, 10602, -1497, 10602,   666,
+     666,   482, -1497, 10602, -1497, 10602,   482,  1039,  1039,   851,
+   -1497, 10602,  1070,   856, -1497, 13333,   -42,   -42,   756, 14619,
+     666,   666, -1497, 10602, -1497, 10602, 14875, 14785,  1948, -1497,
+   10602, -1497, 10602, -1497, 10602, 14654, -1497, 10602, 15292, 13949,
+   14904, 14994, 15023,   482,   482,   824,   824,  1070,  1070,  1070,
+     474,  9363,   858,   859,   481,  9363,  1066,   860, 13433, -1497,
+     226, 14049,   895,   258,   680,  1010,   896,  1247, -1497, -1497,
+   10567, -1497, -1497, -1497, -1497, 10160, -1497, -1497,   909, -1497,
+   -1497,   885, -1497,   886, -1497,   888, -1497, 10260, -1497,   808,
+     464,   712, -1497, -1497, -1497,   712,   712, 11688, -1497,  1043,
+     -37, -1497, 10343,  1423,  1509,  9363,   577,   497,   246,   875,
+     878,   918, 11788,   342, 11888,   578, 10160, 10160, 10160,  1535,
+     879, 14619, 14619, 14619, 14619, 14619, 14619, 14619, 14619, 14619,
+   14619, 14619, 14619, 14619, 14619, 14619, 14619, 14619, 14619, -1497,
+     883, 10160, -1497, -1497, -1497,  9363,  1616,  1760, -1497,  1839,
+   -1497,  1979,   889,  2028,  2151,   890,  2378,    59,   594, -1497,
+   -1497, -1497, -1497, -1497,   892,  9363, -1497,  9363,  9363,  9363,
+    4891, 13198,   112,  9363,   498,   497,   165, -1497, -1497,   894,
+   -1497,  9363,  9363, -1497,   897, -1497,  9363,   497,   516,   910,
+   -1497, -1497,  9363, 14619, -1497, -1497,   476,   488, 14149,  9363,
+   -1497, -1497,  2446,  9363,    49, -1497, -1497,  9363,  9363, 10160,
+     594,   654, -1497, -1497,  9363, -1497,  9730,    59,   169, -1497,
+     893,   286,  9566, -1497, -1497, -1497,   289,   247,   144,   928,
+     929,   908,   933,   939, -1497,   304,   669, -1497,  9363, -1497,
+    9363, -1497, -1497, -1497,  7739,  9363, -1497,   930,   913, -1497,
+   -1497,  9363,   914, -1497, 13533,  9363,  7942,   915, -1497, 13568,
+   -1497,  8145, -1497, -1497, -1497, -1497,   942, -1497, -1497,   296,
+   -1497,    31, -1497,    59, -1497, -1497, -1497, -1497,   712, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497,   916, 10160, -1497,   961,  9363, -1497, -1497,
+     271, -1497,   917, -1497, -1497, -1497,   489, -1497,   963,   921,
+   -1497, -1497,  2772,  2976,  2995, -1497, -1497,  9363,  4273, 14619,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,   590,
+     669,  8348,   562, 11923, 14619, 14619,     2,   165, 14619,   922,
+     192,   853, -1497, -1497, 14619,   854, -1497,   563,     2,   925,
+   -1497, -1497, -1497, -1497,   565, -1497, -1497, -1497,   566, -1497,
+     570,  9363, 12023, 12123,  4399,   669, -1497, 13714, -1497,   957,
+     594, -1497,   926,  4686,   970,   931,   133,   248, -1497, -1497,
+     973, -1497, -1497,   144,   934,    68, 10160, 12158, 10160, 12258,
+   -1497,   261, 12358, -1497,  9363, 14754,  9363, -1497, 12393,  4686,
+   -1497,   265,  9363, -1497, -1497, -1497,   276, -1497,  1113,    31,
+   -1497, -1497,   680,   940, -1497, -1497, -1497,  9363,   712, -1497,
+   14619,   950,   958, -1497, -1497, -1497,  9363,   983,   964,  9363,
+   -1497, -1497, -1497, -1497,   959,   956,   960,  9363,  9363,  9363,
+     962,  1109,   966,   971,  8551, -1497,    68, -1497,   279,  9363,
+     193,   165, -1497,  9363,  9363,  9363,  9363,   516, -1497,  9363,
+    9363,   972,  9363,  9363,   574, -1497, -1497, -1497,   991,   610,
+    3667, -1497,   669, -1497,   317, -1497,   588, 10160,   -12, -1497,
+     976, -1497, -1497,  8754, -1497, -1497,  4478, -1497,   584, -1497,
+   -1497, -1497, 10160, 12493, 12593, -1497,   319, -1497, 12628, -1497,
+   -1497, -1497,  1113,   290,   977,  1109,  1109, 12728,   998,   989,
+   12828,   990,   994,   997,  9363, -1497,  9363,   482,   482,   482,
+    9363, -1497, -1497,  1109,   497, -1497, 12863, -1497, -1497, 14184,
+    9363,  9363, -1497, 12963, 14619, 14619, 14184, -1497,  1013,   482,
+    9363, -1497,  1013, 14184,  9363,   194, -1497, -1497,  8957,  9160,
+   -1497, -1497, -1497, -1497, -1497, 14619,   654,   982, 10160,   -12,
+     501,  9363, -1497,  9363, 14654, -1497, -1497,   585, -1497, -1497,
+     999, -1497, 15401, -1497, -1497, -1497,   -32,   -32, -1497,  9363,
+    9363, -1497,  1109,  1109,   497,  1000,  1001,   821,   -32,   853,
+    1002, -1497,  1159,  1006, 14619, 14619,   217,  1032,  1040,  1034,
+    1042,  1007, 14184, -1497,   194,  9363,  9363, 14619, -1497, -1497,
+     501,  9363,  9363, 14284, 14754, -1497, -1497, -1497, -1497,  1044,
+   15401,   497,   853,  1036, -1497,  1016,  1017, 13063, 13098,   -32,
+     -32,  1018, -1497, -1497,  1026,  1028, -1497,  9363,  1012,  9363,
+    9363,  1015,  1063, -1497,  1030, -1497, -1497,  1033, -1497, 14619,
+    9363, 14384, 14419, -1497, -1497, -1497,   654,   282,  1035, -1497,
+   -1497, -1497, -1497, -1497,  1037,  1038, -1497, -1497, -1497, 14619,
+   -1497, 14619, 14619, -1497, -1497, -1497, -1497, 14519, -1497, -1497,
+   -1497, -1497,   497, -1497, -1497, -1497,   291, -1497
+};
+
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
+static const yytype_int16 yydefact[] =
+{
+       2,   123,     1,   303,     0,     0,     0,   618,   304,     0,
+     610,   610,   610,    16,     0,     0,    15,     3,     0,    10,
+       9,     8,     0,     7,   598,     6,    11,     5,     4,    13,
+      12,    14,    93,    94,    92,   101,   103,    38,    54,    51,
+      52,    40,    41,    42,     0,    43,    49,    39,   610,   610,
+      22,    21,   598,   612,   611,   783,   773,   778,     0,   271,
+      36,   109,   110,   111,     0,     0,     0,   112,   114,   121,
+       0,   108,    17,   636,   635,   216,   620,     0,   639,   599,
+     600,     0,     0,     0,     0,    44,     0,    50,     0,     0,
+      47,     0,     0,   610,     0,    18,     0,     0,     0,   273,
+       0,     0,   120,   115,     0,     0,     0,     0,     0,     0,
+     124,   218,   217,   220,   215,   622,   621,     0,   638,   637,
+     641,   640,   644,   602,   601,   604,    99,   100,    97,    98,
+      96,     0,     0,    95,   104,    55,    53,    49,    46,    45,
+     613,   615,   617,     0,   619,    19,    20,    23,   784,   774,
+     779,   272,    34,    37,   119,     0,   116,   117,   118,   122,
+       0,   623,     0,   632,   595,   533,    24,    25,    29,     0,
+      88,    89,    86,    87,    85,    84,    90,     0,    48,     0,
+     616,     0,     0,     0,    35,   113,     0,   190,   191,   192,
+     193,   194,   195,   196,   197,   198,   199,   200,   201,   202,
+     203,   204,   205,   206,   207,   208,   209,   210,   211,   212,
+     213,   214,     0,     0,   130,   125,     0,   624,     0,   633,
+       0,   645,   596,     0,     0,   535,     0,    26,    27,    28,
+       0,   102,     0,   785,   775,   780,   184,   185,   182,   133,
+     134,   136,   135,   137,   138,   139,   140,   166,   167,   164,
+     165,   157,   168,   169,   158,   155,   156,   183,   177,     0,
+     181,   170,   171,   172,   173,   144,   145,   146,   141,   142,
+     143,   154,     0,   160,   161,   159,   152,   153,   148,   147,
+     149,   150,   151,   132,   131,   176,     0,   162,   163,   533,
+     128,   248,   221,   606,   679,   682,   685,   686,   680,   683,
+     681,   684,     0,   630,   642,   603,   533,     0,   105,   107,
+       0,     0,   585,   583,   605,    91,     0,     0,     0,     0,
+       0,     0,   652,   672,   653,   688,   654,   658,   659,   660,
+     661,   678,   665,   666,   667,   668,   669,   670,   671,   673,
+     674,   675,   676,   743,   657,   664,   677,   750,   757,   655,
+     662,   656,   663,     0,     0,     0,     0,   687,   705,   708,
+     706,   707,   770,   614,   693,   563,   569,   186,   187,   180,
+     175,   188,   178,   174,     0,   126,   302,   557,     0,     0,
+     219,     0,   625,   627,     0,   634,   547,   646,     0,     0,
+     106,     0,     0,     0,     0,   584,     0,   711,   734,   737,
+       0,   740,   730,     0,   696,   744,   751,   758,   764,   767,
+       0,     0,   720,   725,   719,     0,   733,   729,   722,     0,
+       0,   724,   709,     0,   786,   776,   781,   189,   179,     0,
+     300,   301,     0,   533,   127,   129,   250,     0,     0,     0,
+      64,    65,    77,   439,   440,     0,     0,     0,     0,   288,
+     433,   286,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   287,     0,     0,     0,     0,     0,     0,     0,   678,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   522,     0,     0,     0,   356,
+     358,   357,   359,   360,   361,   362,     0,     0,    30,     0,
+     222,   227,     0,     0,     0,     0,     0,     0,     0,   338,
+     339,   437,   436,     0,     0,     0,     0,   243,   238,   235,
+     234,   236,   237,   270,   249,   229,   516,   228,   434,     0,
+     507,    72,    73,    70,   241,    71,   242,   244,   306,   233,
+     506,   505,   504,   123,   510,   435,     0,   230,   509,   508,
+     480,   441,   481,   363,   442,     0,   438,   788,   792,   789,
+     790,   791,     0,   607,     0,   606,   631,   548,   597,   534,
+       0,     0,     0,   516,     0,   587,   588,     0,   581,   582,
+     580,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   125,     0,   125,     0,   125,     0,     0,     0,   716,
+     252,   727,   728,   721,   723,     0,   726,   710,     0,     0,
+     772,   771,     0,   694,     0,   271,   700,   699,     0,   564,
+     559,     0,     0,     0,   570,     0,     0,     0,   647,   555,
+     574,   558,   833,   836,     0,     0,   276,   280,   279,   285,
+       0,     0,   324,     0,     0,     0,   869,     0,     0,   292,
+     289,     0,   333,     0,     0,   256,     0,   274,     0,     0,
+       0,   315,   318,     0,   247,   321,     0,     0,    58,     0,
+      79,   873,     0,   842,   851,     0,   839,     0,     0,   297,
+     294,   469,   470,   339,   351,   123,   269,   267,   268,     0,
+       0,     0,     0,     0,     0,     0,   811,     0,     0,     0,
+     849,   876,     0,   260,     0,   263,     0,     0,   878,   887,
+       0,   446,   445,   482,   444,   443,     0,     0,   887,   333,
+     887,   340,   245,   246,     0,    75,   354,   225,   514,     0,
+     232,   239,   240,   291,   296,   305,     0,   348,     0,   231,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   471,   472,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   423,     0,   224,     0,   608,     0,   626,   628,   643,
+       0,     0,   533,     0,   586,     0,   590,     0,   594,   363,
+       0,     0,     0,   701,   714,     0,     0,   689,   691,     0,
+       0,   128,     0,   128,     0,   128,   561,     0,   567,     0,
+     690,     0,     0,   887,   718,   703,     0,   695,   787,     0,
+     565,   777,     0,   571,   782,   556,     0,     0,   573,     0,
+     572,     0,   575,     0,     0,     0,    80,     0,     0,   825,
+       0,     0,     0,     0,   859,   862,   865,     0,   887,   293,
+     290,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   887,   275,     0,    81,    82,     0,     0,     0,
+       0,    56,    57,     0,     0,   887,     0,     0,   887,     0,
+       0,   298,   295,   340,   348,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   271,     0,     0,     0,   845,   803,
+     811,     0,   854,     0,     0,     0,   811,     0,     0,     0,
+       0,     0,   814,   881,     0,   251,     0,    33,     0,    31,
+       0,   888,     0,   248,     0,     0,   888,     0,     0,     0,
+       0,   410,   407,   409,    61,     0,   123,     0,     0,   426,
+       0,   802,     0,     0,     0,   314,   313,     0,     0,   125,
+     266,     0,     0,   493,   492,     0,     0,   494,   498,     0,
+       0,     0,   385,   394,   373,   395,   374,   397,   376,   396,
+     375,   398,   377,   388,   367,   389,   368,   390,   369,   447,
+     448,   460,   399,   378,   400,   379,   461,   458,   459,     0,
+     387,   365,   487,     0,   478,     0,   511,   512,   513,   366,
+     449,   450,   401,   380,   402,   381,   465,   466,   467,   391,
+     370,   392,   371,   393,   372,   468,   386,   364,     0,     0,
+     463,   464,   462,   456,   457,   452,   451,   453,   454,   455,
+       0,     0,     0,   416,     0,     0,     0,     0,     0,   431,
+       0,     0,     0,     0,   541,   544,     0,     0,   589,   592,
+     363,   593,   712,   735,   738,     0,   741,   731,     0,   697,
+     745,     0,   752,     0,   759,     0,   765,     0,   768,     0,
+       0,   258,   715,   253,   704,   560,   566,     0,   649,   650,
+     576,   579,   578,     0,     0,     0,     0,   826,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   334,   373,   374,   376,   375,   377,   367,   368,   369,
+     378,   379,   365,   380,   381,   370,   371,   372,   364,   299,
+       0,     0,   882,   257,   483,     0,     0,     0,   484,     0,
+     515,     0,     0,     0,     0,     0,     0,   348,   125,   517,
+     518,   519,   520,   521,     0,     0,   812,     0,     0,     0,
+       0,   333,   811,     0,     0,     0,     0,   820,   821,     0,
+     828,     0,     0,   818,     0,   857,     0,     0,     0,     0,
+     816,   858,     0,   848,   813,   877,     0,     0,     0,     0,
+     879,   880,     0,     0,     0,   856,   473,     0,     0,     0,
+     125,     0,    59,    60,     0,    74,    66,   348,     0,   427,
+       0,     0,     0,   430,   428,   307,     0,     0,     0,     0,
+       0,     0,     0,     0,   346,     0,   128,   489,     0,   495,
+       0,   384,   382,   383,     0,     0,   476,     0,     0,   499,
+     503,     0,     0,   479,     0,     0,     0,     0,   417,     0,
+     424,     0,   474,   432,   609,   629,   124,   542,   543,   544,
+     545,   536,   549,   348,   591,   713,   736,   739,   702,   742,
+     732,   692,   698,   746,   748,   753,   755,   760,   762,   766,
+     562,   769,   568,     0,     0,   648,     0,     0,   834,   837,
+       0,   277,     0,   282,   283,   281,     0,   327,     0,     0,
+     330,   325,     0,     0,     0,   870,   868,   256,     0,    83,
+     316,   319,   322,   874,   872,   843,   852,   850,   840,     0,
+     128,     0,     0,     0,   794,   793,   811,     0,   846,     0,
+       0,   804,   827,   819,   847,   855,   817,     0,   811,     0,
+     823,   824,   831,   815,     0,   261,   264,    32,     0,   223,
+       0,     0,     0,     0,     0,   128,    62,     0,    67,     0,
+     125,   429,     0,     0,     0,     0,   583,     0,   343,   344,
+       0,   342,   341,     0,     0,     0,     0,     0,     0,     0,
+     405,     0,     0,   500,     0,   488,     0,   477,     0,     0,
+     418,     0,     0,   475,   425,   421,     0,   554,   539,   536,
+     537,   538,   541,     0,   749,   756,   763,   252,   259,   651,
+     577,     0,     0,    78,   278,   284,     0,     0,     0,     0,
+     326,   860,   863,   866,     0,     0,     0,     0,     0,     0,
+       0,   825,     0,     0,     0,   226,     0,   523,     0,     0,
+       0,     0,   829,     0,     0,     0,     0,     0,   822,     0,
+       0,   254,     0,     0,     0,   408,   532,   411,     0,    61,
+       0,    76,   128,   403,     0,   308,   583,     0,     0,   350,
+       0,   347,   349,     0,   335,   353,     0,   531,     0,   529,
+     406,   526,     0,     0,     0,   525,     0,   419,     0,   422,
+     540,   550,   539,     0,     0,   825,   825,     0,     0,     0,
+       0,     0,     0,     0,   252,   883,   256,   317,   320,   323,
+       0,   826,   844,   825,     0,   485,     0,   352,   524,   885,
+       0,     0,   830,     0,   796,   795,   885,   832,   885,   262,
+     252,   265,   885,   885,     0,     0,   414,    63,   288,     0,
+      68,    72,    73,    70,    71,    69,     0,     0,     0,     0,
+       0,     0,   345,     0,   336,   490,   496,     0,   530,   528,
+       0,   527,     0,   552,   546,   717,   810,   810,   328,     0,
+       0,   331,   825,   825,     0,     0,     0,   887,   810,   801,
+       0,   486,     0,     0,   798,   797,     0,     0,     0,   887,
+       0,     0,   885,   412,     0,     0,     0,   294,   355,   404,
+       0,     0,     0,     0,   337,   491,   497,   501,   420,     0,
+       0,     0,   807,   887,   809,     0,     0,     0,     0,   810,
+     810,     0,   871,   884,     0,     0,   841,     0,     0,     0,
+       0,     0,     0,   888,     0,   893,   889,     0,   415,   295,
+       0,     0,     0,   312,   502,   551,     0,     0,   888,   808,
+     835,   838,   329,   332,     0,     0,   867,   875,   853,   886,
+     891,   800,   799,   892,   894,   255,   890,     0,   311,   310,
+     553,   805,     0,   861,   864,   309,     0,   806
+};
+
+/* YYPGOTO[NTERM-NUM].  */
+static const yytype_int16 yypgoto[] =
+{
+   -1497, -1497, -1497, -1497, -1497, -1497,   541,  1167, -1497, -1497,
+   -1497,  1253, -1497, -1497, -1497,   727,  1212, -1497,  1120, -1497,
+   -1497,  1174, -1497, -1497, -1497,  -220, -1497, -1497, -1497,  -219,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,  1041,
+   -1497, -1497,   -51,   -44, -1497, -1497, -1497,   419,   462,  -511,
+    -575,  -796, -1497, -1497, -1497, -1496, -1497, -1497,  -214,  -360,
+   -1497,   307, -1497, -1370, -1497, -1287,  -153,   273, -1497, -1497,
+   -1497, -1497,  -405,   -14, -1497, -1497, -1497, -1497, -1497,  -217,
+    -216,  -213, -1497,  -212, -1497, -1497, -1497,  1264, -1497,   292,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497,  -340,  -187,   640,  -123,    35,  -875,  -444,
+   -1497,  -521, -1497, -1497,  -374,  1238, -1497, -1497, -1497, -1427,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,   646,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497,  -155,  -147,  -238,
+    -146,    -2, -1497, -1497, -1497, -1497, -1497,   846, -1497,  -581,
+   -1497, -1497,  -584, -1497, -1497,  -624,  -235,  -573, -1324, -1497,
+    -362, -1497, -1497,  1231, -1497, -1497, -1497,   719,   864,   182,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+    -593,  -189, -1497,   855, -1497, -1497, -1497, -1497, -1497, -1497,
+    -403, -1497, -1497,  -386, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497,  -215, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497,   865,  -684,  -309,
+    -840,  -660, -1497, -1497, -1394,  -906, -1497, -1497, -1497, -1158,
+    -181, -1398, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,
+   -1497,    97,  -485, -1497, -1497, -1497,   593, -1497, -1497, -1497,
+   -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497, -1497,   789,
+   -1497, -1236,  -709, -1497
+};
+
+/* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_int16 yydefgoto[] =
+{
+       0,     1,    16,   147,    52,    17,   169,   175,   706,   511,
+     153,   512,   101,    19,    20,    45,    46,    47,    90,    21,
+      39,    40,   513,   514,  1224,  1225,   515,  1379,  1480,   516,
+     517,   965,   518,   635,   519,   520,   521,   522,  1155,   176,
+     177,    35,    36,    37,   225,    67,    68,    69,    70,    22,
+     290,   380,   215,    23,   113,   216,   114,   160,   684,   992,
+     524,   381,   525,   832,  1551,   891,  1100,   573,   944,  1470,
+     946,  1471,   527,   528,   529,   637,   858,  1434,   530,   531,
+     532,   533,   534,   535,   536,   537,   432,   538,   736,  1236,
+     975,   539,   540,   897,  1447,   898,  1448,   900,  1449,   541,
+     863,  1440,   542,   718,  1495,   543,  1244,  1245,   979,   686,
+     544,   793,   966,   545,   651,   993,   547,   548,   549,   963,
+     550,  1219,  1555,  1220,  1614,   551,  1066,  1414,   552,   719,
+    1396,  1625,  1398,  1626,  1502,  1664,   554,   376,  1422,  1511,
+    1279,  1281,  1076,   567,   802,  1582,  1630,   377,   378,   618,
+     827,   425,   623,   829,   426,  1179,   629,   581,   396,   313,
+     314,   222,   306,    80,   125,    25,   165,   382,    91,    92,
+     179,    93,    26,    49,   117,   162,    27,   293,   564,   565,
+    1072,   385,   220,   221,    78,   122,   387,    28,   163,   304,
+     630,   555,   302,   359,   360,   819,   424,   361,   589,  1292,
+    1304,   812,   422,   362,   582,  1285,   831,   587,  1290,   583,
+    1286,   584,  1287,   586,  1289,   590,  1293,   591,  1424,   592,
+    1295,   593,  1425,   594,  1297,   595,  1426,   596,  1299,   597,
+    1301,   620,    29,    97,   182,   365,   621,    30,    98,   183,
+     366,   625,    31,    96,   181,   364,   614,   556,  1632,  1600,
+     972,   930,  1633,  1634,  1635,   931,   943,  1201,  1195,  1190,
+    1362,  1120,   557,   854,  1431,   855,  1432,   909,  1453,   906,
+    1451,   932,   708,   558,   907,  1452,   933,   559,  1126,  1521,
+    1127,  1522,  1128,  1523,   867,  1444,   904,  1450,   702,   892,
+     560,  1603,   952,   561
+};
+
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
+static const yytype_int16 yytable[] =
+{
+      60,    71,   292,   701,   807,   727,   853,   546,   577,   957,
+     226,   958,   929,   828,   929,   826,   821,   363,   823,  1119,
+     825,   523,   619,   624,  1186,  1091,   568,  1093,  1352,  1095,
+    1198,   134,   737,   687,   688,   643,  -123,   611,   936,  1168,
+    1445,     2,   857,   358,   649,   971,  1115,   603,     3,  1175,
+      71,    71,    71,  1532,  1196,   922,   801,  1514,   126,   127,
+    1202,   155,  1488,   977,    53,  1209,   601,  1213,   679,  1371,
+      54,     4,    86,     5,   100,     6,    61,  1420,   848,    73,
+      74,     7,    75,    38,   760,    58,  1629,   763,   764,   523,
+     848,     8,    71,    71,    71,    71,   923,     9,    32,    33,
+     696,   698,   921,   223,   934,    62,   938,    87,  1228,   650,
+      76,   738,    59,   523,   950,   578,   291,  1586,  1587,   763,
+     764,    10,   839,   954,  1103,   579,   923,  1230,  1613,   106,
+     107,   108,   644,   645,  1666,  1598,   374,  1421,  1228,   849,
+     850,   223,   851,    11,    12,   852,    48,   170,   171,    63,
+     669,   388,   850,  1229,  1595,   423,   640,   740,   741,  1130,
+     224,   739,  1569,   728,   435,   922,   437,   438,   720,   791,
+     792,    72,   109,   308,   914,   971,   808,   580,    64,   307,
+    1609,    77,  1631,  1153,  1185,    58,   448,  1658,   142,  1462,
+     358,   433,   453,  1636,  1639,  1640,  1162,   110,   224,  1165,
+     154,   791,   792,    82,  1645,   358,   128,   729,   604,   799,
+    1493,   129,    59,   130,   849,   840,   131,   849,   357,   978,
+     843,   523,   849,    13,   434,   646,   605,   602,   849,   467,
+     468,    94,   606,   849,   358,   849,   358,   849,   653,  1596,
+     800,    50,    14,   869,   647,  1674,  1675,    65,   291,    34,
+      88,   311,   670,    15,   752,   753,    66,   132,   412,   390,
+     833,    89,   760,   470,   471,   763,   764,   765,   890,   312,
+     923,  1239,   766,   911,   374,   143,  1347,  1312,   309,   223,
+      79,  1240,  1228,   971,  1231,   413,   414,    51,   523,   291,
+      81,   910,  1339,   311,   980,   172,   848,   358,   358,   848,
+     173,   973,   174,  1542,    58,   131,  1178,   868,   870,  1178,
+    1607,   312,  1608,   310,  1241,   100,  1610,  1611,   523,   848,
+     848,   486,   487,   488,  1487,   509,   683,   395,    83,  1464,
+    1540,    59,   905,  1242,   375,   908,   224,    58,  1243,    58,
+     430,   499,   411,  1418,   848,    84,   959,   791,   792,   415,
+    1187,  1188,  1380,   416,  1649,   974,   636,  1192,   850,    82,
+    1193,   850,  1214,  1280,    59,   357,    59,   810,   811,   813,
+     566,   815,   816,   507,   976,   820,  1657,   822,  1189,   824,
+     357,   850,   850,   431,   389,    41,    42,    43,  1194,   970,
+      99,    82,   795,   358,   358,   358,   230,   358,   358,   796,
+    1232,   358,  1079,   358,  1246,   358,   850,   358,  1423,   357,
+    1085,   357,   100,   562,   871,   417,    44,  1077,   185,   418,
+     856,  1167,   419,   231,  1097,   563,  1099,  1233,   118,   119,
+      58,   357,   641,   971,   871,  1384,  1393,   420,   105,   959,
+    1461,  1273,   627,   421,   960,   895,   109,   523,  1111,   871,
+    1395,   291,  1467,   871,  1070,  1227,  1205,    59,   135,   871,
+     628,  1313,  1386,  1489,   871,   358,  1210,   871,  1113,  1114,
+    1184,  1276,   357,   357,  1184,    89,  1500,  1384,  1176,  1184,
+    1507,  1129,   961,   102,   103,   104,  1307,  1151,   358,   599,
+     945,  1509,  1393,   523,  1538,  1088,   137,  1691,   929,  1382,
+     140,  1351,  1385,   740,   741,  1184,  1697,  1184,   600,  1089,
+     964,  1156,  1157,   929,  1159,  1302,  1300,  1394,  1161,  1118,
+    1163,  1164,  1346,  1166,  1318,   156,   157,   158,   159,   217,
+    1567,   294,  1580,   616,   412,   295,  -747,  1358,  1319,   617,
+     218,  -747,   141,  -754,  1456,  1251,  1252,  1253,  -754,   296,
+     297,   984,   988,   144,   298,   299,   300,   301,  -761,  -747,
+    -413,   413,   414,  -761,   148,  -413,  -754,   654,   357,   357,
+     357,   671,   357,   357,   149,   674,   357,  1028,   357,  1478,
+     357,  -761,   357,  -413,   861,   393,   655,   720,   394,   152,
+     672,   395,   612,  1340,   675,   720,   150,   622,   750,   751,
+     752,   753,  1067,   862,   613,   227,   228,  1023,   760,   616,
+     762,   763,   764,   765,   358,   617,  1101,   616,   766,  1024,
+     768,   769,  1221,   617,  1105,   415,   860,  1106,   578,   416,
+     151,  1096,  1262,  1222,  1223,   616,  1110,   161,   579,  1267,
+     357,   617,   358,  1116,  1263,  1375,   616,  1075,  1125,  1098,
+     358,  1268,   617,   358,   526,   923,  1349,   423,   616,   164,
+    1303,  1082,   358,   357,   617,   358,   358,  1228,  1350,   358,
+     616,   616,  1365,    87,   358,  1149,   617,   617,   358,   786,
+     787,   788,   789,   790,  1366,  1436,  1566,   740,   741,   180,
+     580,   417,   184,   791,   792,   418,   616,  1359,   419,  1484,
+    1360,   423,   617,  1361,    53,  1083,   423,   962,   358,   358,
+      54,   358,   423,   420,   219,   358,  1086,   358,   358,   421,
+     358,   111,   526,   106,   115,  1506,  1465,   112,   120,  1101,
+     116,  1101,   123,   145,   121,   509,   683,  1277,   124,   146,
+    1322,  1323,  1324,  1278,  1459,  1466,   526,  1469,  1472,   232,
+     871,   871,  1473,   871,   871,   358,  1554,   358,   871,   423,
+     423,   233,   871,  1087,  1090,  1328,   234,   423,   423,   423,
+     423,  1092,  1094,  1311,  1321,  1310,   423,   423,   235,  1568,
+    1576,  1627,   395,   287,   752,   753,    71,  1199,  1192,   357,
+    1200,  1206,   760,  1207,   762,   763,   764,   765,   166,   167,
+     947,   948,   766,   288,  1454,  1482,   509,   683,   289,   106,
+     107,   108,    41,    42,    43,   138,   139,   357,  1455,   166,
+     167,   168,   227,   228,   229,   357,   303,   106,   357,   108,
+     940,   941,   942,  1374,   291,  1342,  1541,   357,   546,   305,
+     357,   357,   367,   368,   357,   740,   741,   369,   370,   357,
+    1599,   371,   523,   357,   526,   372,  1357,   373,   383,  1260,
+     379,   384,  1364,   786,   787,   788,   789,   790,   386,  1368,
+    1288,   391,   428,  1370,    55,    56,    57,   791,   792,   392,
+     427,   397,   398,   357,   357,   399,   357,   401,  1644,   402,
+     357,   404,   357,   357,   405,   357,   358,   406,   400,   407,
+    1654,   408,   409,   403,   423,   410,   575,   429,   358,   576,
+    1599,   569,   588,  1437,  1401,  1571,   632,   609,   633,   642,
+     660,   526,   658,   661,  1669,   662,  1411,   663,   664,   665,
+     357,  1416,   357,   666,   689,   673,   676,   358,   358,   358,
+     677,   710,   752,   753,   705,   690,   691,  1667,   722,   723,
+     760,   526,   762,   763,   764,   765,   725,   692,   693,   730,
+     766,   694,   358,   731,   732,   733,   734,   735,   721,    15,
+     794,   797,   669,   803,   703,   805,   817,   818,   622,   837,
+     838,   841,  1650,   842,  1548,   834,   844,  1552,   846,   859,
+     847,   864,   871,   865,   738,   889,  1621,  1622,   866,   896,
+     901,  1458,   902,   913,   951,   953,   955,  1376,  1696,   956,
+    1496,  1019,  1074,  1078,  1084,   526,   526,   526,   526,   526,
+     526,   526,   526,   788,   789,   790,  1102,   553,   526,   526,
+     358,  1474,  1152,  1108,   526,   791,   792,   574,  1109,  1123,
+    1177,  1184,  1191,   526,   526,  1215,   585,  1660,   526,   526,
+     526,  1204,   526,  1211,  1235,  1216,   598,  1234,  1217,  1218,
+     740,   741,  1238,  1248,  1250,  1254,   608,  1270,  1247,  1249,
+    1255,   357,  1265,  1266,  1271,   626,  1275,  1280,  1282,  1291,
+     526,  1294,  1296,   357,  1298,   634,  1306,   833,  1316,  1428,
+    1314,   740,   741,  1315,  1326,   652,  1433,  1327,  1388,  1389,
+     657,  1570,   659,  1391,  1334,  1337,  1341,  1353,  1381,  1392,
+    1356,   668,   357,   357,   357,   358,   685,   685,   685,   680,
+     681,   682,  1390,  1363,  1417,  1403,   526,  1404,  1406,  1412,
+    1427,  1429,  1435,  1438,   700,  1439,  1463,   357,  1468,  1481,
+    1485,  1483,   704,  1490,  1486,   700,  1510,  1492,   711,   712,
+     713,   714,   715,  1518,  1454,   750,   751,   752,   753,   754,
+    1519,   724,   757,  1479,  1515,   760,   726,   762,   763,   764,
+     765,  1525,  1516,  1524,  1526,   766,  1530,   768,   769,  1531,
+    1533,  1494,  1620,  1498,   833,  1534,  1550,  1556,   752,   753,
+    1597,  1572,  1585,   726,  1589,  1602,   760,  1619,   762,   763,
+     764,   765,   412,  1590,  1592,   357,   766,   358,  1593,   358,
+     833,  1594,  1647,  1651,  1628,  1642,  1643,  1646,   650,  1648,
+    1656,  1652,  1653,  1655,  1668,  1680,  1665,   809,  1683,   413,
+     414,  1670,  1671,  1676,   784,   785,   786,   787,   788,   789,
+     790,  1677,  1494,  1678,  1684,  1685,  1686,   949,   133,  1692,
+     791,   792,  1693,  1694,    18,   836,    85,   178,   136,  1557,
+    1212,  1560,  1073,  1561,  1562,    24,  1237,  1563,  1564,  1537,
+    1491,   315,  1512,  1387,  1583,   870,  1513,  1419,  1584,   631,
+     412,   791,   792,    95,   798,  1641,  1547,  1577,   709,  1355,
+     357,   937,   726,   415,   652,     0,   578,   416,   358,     0,
+     638,   700,   893,     0,   894,     0,   579,   413,   414,   899,
+     639,     0,     0,   358,     0,   903,     0,     0,     0,     0,
+     726,     0,     0,     0,   912,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   915,   916,   917,   918,   919,
+     920,     0,   928,     0,   928,     0,     0,     0,     0,     0,
+       0,   806,  1618,     0,     0,     0,     0,     0,   580,   417,
+       0,     0,     0,   418,     0,     0,   419,     0,     0,     0,
+       0,   415,     0,     0,     0,   416,     0,     0,   685,   358,
+       0,   420,   357,     0,   357,     0,     0,   421,   994,   996,
+     998,  1000,  1002,  1004,  1006,  1008,  1009,  1010,     0,     0,
+    1011,  1013,  1015,  1016,  1017,  1018,     0,  1021,  1022,     0,
+    1025,  1026,  1027,  1029,  1030,  1031,  1033,  1035,  1036,  1037,
+    1038,  1040,  1042,  1044,  1045,  1047,  1049,  1050,  1051,  1052,
+    1053,  1054,  1055,  1056,  1057,  1058,  1059,   417,  1068,     0,
+       0,   418,  1071,  1283,   419,     0,     0,     0,     0,   726,
+       0,     0,  1690,  1080,     0,     0,   412,     0,     0,   420,
+       0,     0,     0,     0,     0,   421,     0,     0,     0,     0,
+       0,     0,     0,   357,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   413,   414,   526,     0,     0,   357,     0,
+       0,     0,  1107,     0,     0,     0,     0,     0,     0,  1112,
+       0,     0,     0,     0,     0,     0,  1122,     0,  1124,     0,
+       0,     0,     0,     0,     0,     0,     0,  1131,  1132,  1133,
+    1134,  1135,  1136,  1137,  1138,  1139,  1140,  1141,  1142,  1143,
+    1144,  1145,  1146,  1147,  1148,     0,     0,   412,     0,     0,
+       0,   962,   412,     0,     0,     0,     0,   415,     0,     0,
+       0,   416,   726,     0,   357,     0,     0,     0,     0,     0,
+       0,     0,   685,     0,   413,   414,     0,     0,   412,   413,
+     414,   711,  1181,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,  1203,     0,   700,     0,     0,
+       0,     0,     0,     0,  1208,   413,   414,   700,     0,     0,
+     962,     0,  1131,     0,     0,     0,     0,     0,     0,     0,
+       0,  1226,     0,   417,     0,     0,     0,   418,     0,  1308,
+     419,     0,     0,     0,     0,     0,     0,     0,   415,   685,
+     685,   685,   416,   415,   726,   420,   726,   416,   726,     0,
+     726,   421,   726,     0,   726,     0,   726,     0,   726,   412,
+       0,     0,     0,   726,     0,   726,     0,     0,     0,   415,
+     -69,   726,     0,   416,     0,     0,     0,     0,     0,     0,
+       0,   740,   741,   726,     0,   726,   413,   414,     0,     0,
+     726,     0,   726,     0,   726,     0,   616,   726,     0,     0,
+       0,     0,   617,     0,   417,     0,     0,     0,   418,   417,
+    1150,   419,     0,   418,     0,  1309,   419,  1264,     0,     0,
+       0,  1269,     0,     0,     0,     0,   420,     0,     0,     0,
+     726,   420,   421,     0,     0,   417,     0,   421,     0,   418,
+       0,  1325,   419,     0,     0,     0,     0,     0,     0,     0,
+     415,     0,     0,     0,   416,     0,     0,   420,     0,     0,
+       0,     0,   726,   421,     0,     0,     0,     0,   742,   743,
+     744,   745,   746,   747,   748,   749,   750,   751,   752,   753,
+     754,   755,   756,   757,   758,   759,   760,   761,   762,   763,
+     764,   765,     0,     0,     0,     0,   766,   767,   768,   769,
+     770,   771,     0,   412,   772,   773,   774,   775,   776,   777,
+     778,  1329,     0,     0,     0,     0,   417,     0,     0,     0,
+     418,     0,  1330,   419,     0,     0,     0,     0,     0,     0,
+     413,   414,     0,  1343,  1344,  1345,     0,     0,   420,  1348,
+       0,     0,     0,     0,   421,     0,     0,  1354,   928,   779,
+     780,     0,   781,   782,   783,   784,   785,   786,   787,   788,
+     789,   790,     0,     0,     0,     0,     0,     0,   553,   695,
+       0,   791,   792,  1372,  1373,   316,   509,   683,     0,     0,
+    1377,   317,   412,     0,     0,     0,     0,   318,  1131,     0,
+       0,     0,     0,     0,   415,     0,     0,   319,   416,     0,
+       0,     0,     0,     0,  1397,   320,  1399,     0,     0,   413,
+     414,  1402,     0,     0,     0,     0,     0,  1405,     0,     0,
+     321,  1408,     0,     0,     0,     0,     0,   322,   323,   324,
+     325,   326,   327,   328,   329,   330,   331,   332,   333,   334,
+     335,   336,   337,   338,   339,   340,   341,   342,   343,   344,
+     345,   346,   347,   348,   349,   350,   351,   352,   353,   354,
+     417,     0,     0,  1430,   418,     0,  1331,   419,     0,     0,
+       0,     0,     0,   415,     0,     0,     0,   416,     0,   740,
+     741,     0,   420,   700,     0,     0,     0,     0,   421,   726,
+       0,   995,   997,   999,  1001,  1003,  1005,  1007,     0,    58,
+       0,     0,     0,  1012,  1014,     0,     0,     0,     0,  1020,
+       0,     0,   355,     0,     0,     0,     0,     0,  1032,  1034,
+       0,     0,   412,  1039,  1041,  1043,    59,  1046,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   417,
+       0,     0,     0,   418,     0,  1332,   419,     0,     0,   413,
+     414,     0,   412,     0,     0,     0,     0,     0,     0,     0,
+    1503,   420,  1504,     0,     0,     0,     0,   421,  1508,     0,
+       0,   412,   356,     0,   750,   751,   752,   753,   754,   413,
+     414,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,  1517,     0,   766,  1520,   768,   769,   413,   414,
+       0,     0,   772,  1527,  1528,  1529,     0,     0,     0,     0,
+    1536,     0,     0,   415,     0,  1539,     0,   416,     0,  1543,
+    1544,  1545,  1546,     0,     0,   700,  1549,     0,   700,  1553,
+       0,     0,     0,     0,     0,     0,  1565,     0,     0,     0,
+       0,     0,     0,   415,     0,     0,     0,   416,     0,  1574,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,   415,     0,     0,     0,   416,     0,     0,   791,
+     792,     0,     0,     0,     0,     0,     0,     0,     0,   417,
+       0,     0,   700,   418,     0,  1333,   419,     0,     0,     0,
+       0,     0,     0,     0,   412,     0,  1604,  1605,     0,     0,
+       0,   420,     0,     0,     0,     0,     0,   421,     0,   417,
+    1612,     0,     0,   418,     0,  1617,   419,     0,     0,     0,
+       0,   413,   414,     0,     0,     0,     0,  1623,   417,  1624,
+       0,   420,   418,     0,  1335,   419,     0,   421,     0,     0,
+       0,     0,     0,   436,     0,  1637,  1638,   437,   438,     3,
+     420,   439,   440,   441,     0,   442,   421,   443,   444,   445,
+     446,   447,     0,     0,     0,     0,     0,   448,   449,   450,
+     451,   452,  1659,   453,     0,     0,     0,  1661,  1662,     0,
+     454,   455,     0,     0,   456,   415,   457,   458,     0,   416,
+     459,     0,     8,   460,   461,     0,   462,   463,     0,     0,
+     464,   465,     0,  1679,     0,  1681,  1682,   466,     0,     0,
+     467,   468,     0,   322,   323,   324,  1687,   326,   327,   328,
+     329,   330,   469,   332,   333,   334,   335,   336,   337,   338,
+     339,   340,   341,   342,     0,   344,   345,   346,     0,     0,
+     349,   350,   351,   352,   470,   471,   472,   473,     0,     0,
+       0,   417,     0,     0,     0,   418,     0,  1336,   419,     0,
+     474,   475,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   420,     0,   476,   477,   478,     0,   421,
+       0,     0,     0,     0,     0,    58,     0,     0,     0,     0,
+       0,     0,     0,   479,   480,   481,   482,   483,     0,   484,
+       0,   485,   486,   487,   488,   489,   490,   491,   492,   493,
+     494,   495,    59,   496,   497,   498,     0,     0,     0,     0,
+       0,   412,   499,   500,   501,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   502,
+     503,   504,     0,    14,     0,     0,   505,   506,   413,   414,
+       0,     0,     0,     0,   507,     0,   508,   436,   509,   510,
+       0,   437,   438,     3,     0,   439,   440,   441,     0,   442,
+       0,   443,   444,   445,   446,   447,     0,     0,     0,     0,
+       0,   448,   449,   450,   451,   452,     0,   453,     0,     0,
+       0,     0,     0,     0,   454,   455,     0,     0,   456,     0,
+     457,   458,     0,     0,   459,     0,     8,   460,   461,     0,
+     462,   463,   415,     0,   464,   465,   416,     0,     0,     0,
+       0,   466,     0,     0,   467,   468,     0,   322,   323,   324,
+       0,   326,   327,   328,   329,   330,   469,   332,   333,   334,
+     335,   336,   337,   338,   339,   340,   341,   342,     0,   344,
+     345,   346,     0,     0,   349,   350,   351,   352,   470,   471,
+     472,   473,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   474,   475,     0,     0,   417,     0,
+       0,     0,   418,     0,  1338,   419,     0,     0,     0,   476,
+     477,   478,     0,     0,     0,     0,     0,     0,     0,    58,
+     420,     0,     0,     0,     0,     0,   421,   479,   480,   481,
+     482,   483,     0,   484,     0,   485,   486,   487,   488,   489,
+     490,   491,   492,   493,   494,   495,    59,   496,   497,   498,
+       0,     0,     0,     0,     0,     0,   499,  1369,   501,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   502,   503,   504,     0,    14,     0,     0,
+     505,   506,     0,     0,   437,   438,     0,     0,   507,     0,
+     508,     0,   509,   510,   443,   444,   445,   446,   447,     0,
+       0,     0,     0,     0,   448,     0,   450,     0,     0,     0,
+     453,     0,   412,     0,     0,     0,     0,     0,   455,     0,
+       0,     0,     0,     0,   458,     0,     0,   459,     0,     0,
+     460,     0,   922,     0,   463,     0,     0,     0,     0,   413,
+     414,     0,     0,     0,   570,     0,     0,   467,   468,     0,
+     322,   323,   324,     0,   326,   327,   328,   329,   330,   469,
+     332,   333,   334,   335,   336,   337,   338,   339,   340,   341,
+     342,     0,   344,   345,   346,     0,     0,   349,   350,   351,
+     352,   470,   471,   571,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   474,   475,     0,
+       0,     0,     0,   415,     0,     0,     0,   416,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    58,     0,     0,     0,     0,     0,     0,     0,
+     479,   480,   481,   482,   483,   412,   484,   923,   485,   486,
+     487,   488,   489,   490,   491,   492,   493,   494,   495,   924,
+     572,   497,   498,     0,     0,     0,     0,     0,     0,   499,
+       0,     0,   413,   414,     0,     0,     0,     0,     0,   417,
+       0,     0,     0,   418,     0,     0,   925,   503,   504,     0,
+      14,     0,     0,   505,   506,     0,     0,     0,   437,   438,
+       0,   926,     0,   927,     0,   509,   510,   421,   443,   444,
+     445,   446,   447,     0,     0,     0,     0,     0,   448,     0,
+     450,     0,     0,     0,   453,     0,   412,     0,     0,     0,
+       0,     0,   455,     0,     0,     0,   415,     0,   458,     0,
+     416,   459,     0,     0,   460,     0,     0,     0,   463,     0,
+       0,     0,     0,   413,   414,     0,     0,     0,   570,     0,
+       0,   467,   468,     0,   322,   323,   324,     0,   326,   327,
+     328,   329,   330,   469,   332,   333,   334,   335,   336,   337,
+     338,   339,   340,   341,   342,     0,   344,   345,   346,     0,
+       0,   349,   350,   351,   352,   470,   471,   571,     0,     0,
+       0,     0,   417,     0,     0,     0,   418,     0,  1441,   419,
+       0,   474,   475,     0,     0,     0,     0,   415,     0,     0,
+       0,   416,     0,     0,   420,     0,     0,     0,     0,     0,
+     421,     0,     0,     0,     0,     0,    58,     0,     0,     0,
+       0,     0,     0,     0,   479,   480,   481,   482,   483,   412,
+     484,   923,   485,   486,   487,   488,   489,   490,   491,   492,
+     493,   494,   495,   924,   572,   497,   498,     0,   412,     0,
+       0,     0,     0,   499,     0,     0,   413,   414,     0,     0,
+       0,     0,     0,   417,     0,     0,     0,   418,     0,     0,
+     925,   503,   504,     0,    14,   413,   414,   505,   506,     0,
+       0,     0,   437,   438,     0,   926,     0,   935,     0,   509,
+     510,   421,   443,   444,   445,   446,   447,     0,     0,     0,
+       0,     0,   448,     0,   450,     0,     0,     0,   453,     0,
+     603,     0,     0,     0,     0,     0,   455,     0,     0,     0,
+     415,     0,   458,     0,   416,   459,     0,     0,   460,     0,
+       0,     0,   463,     0,     0,     0,     0,     0,     0,   415,
+       0,     0,   570,   416,     0,   467,   468,     0,   322,   323,
+     324,     0,   326,   327,   328,   329,   330,   469,   332,   333,
+     334,   335,   336,   337,   338,   339,   340,   341,   342,     0,
+     344,   345,   346,     0,     0,   349,   350,   351,   352,   470,
+     471,   571,     0,     0,     0,     0,   417,     0,     0,     0,
+     418,     0,  1442,   419,     0,   474,   475,     0,     0,     0,
+       0,     0,     0,     0,     0,   417,     0,     0,   420,   418,
+       0,  1443,   419,     0,   421,     0,     0,     0,     0,     0,
+      58,     0,     0,     0,     0,     0,     0,   420,   479,   480,
+     481,   482,   483,   421,   484,     0,   485,   486,   487,   488,
+     489,   490,   491,   492,   493,   494,   495,    59,   572,   497,
+     498,     0,     0,     0,     0,     0,     0,   499,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   604,     0,     0,   502,   503,   504,     0,    14,     0,
+       0,   505,   506,     0,     0,     0,   437,   438,     0,  1180,
+       0,   508,     0,   509,   510,   606,   443,   444,   445,   446,
+     447,     0,     0,     0,     0,     0,   448,     0,   450,     0,
+       0,     0,   453,     0,     0,     0,     0,     0,     0,     0,
+     455,     0,     0,     0,     0,     0,   458,     0,     0,   459,
+       0,     0,   460,     0,     0,     0,   463,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   570,     0,     0,   467,
+     468,     0,   322,   323,   324,     0,   326,   327,   328,   329,
+     330,   469,   332,   333,   334,   335,   336,   337,   338,   339,
+     340,   341,   342,     0,   344,   345,   346,     0,     0,   349,
+     350,   351,   352,   470,   471,   472,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   474,
+     475,     0,     0,     0,     0,     0,     0,     0,   648,     0,
+       0,     0,     0,     0,   476,   477,   478,     0,     0,     0,
+       0,     0,     0,     0,    58,     0,     0,     0,     0,     0,
+       0,     0,   479,   480,   481,   482,   483,     0,   484,     0,
+     485,   486,   487,   488,   489,   490,   491,   492,   493,   494,
+     495,    59,   572,   497,   498,     0,     0,     0,     0,     0,
+       0,   499,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   502,   503,
+     504,     0,    14,     0,     0,   505,   506,     0,     0,   437,
+     438,     0,     0,   507,     0,   508,     0,   509,   510,   443,
+     444,   445,   446,   447,     0,     0,     0,     0,     0,   448,
+       0,   450,     0,     0,     0,   453,     0,     0,     0,     0,
+       0,     0,     0,   455,     0,     0,     0,     0,     0,   458,
+       0,     0,   459,     0,     0,   460,     0,     0,     0,   463,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   570,
+       0,     0,   467,   468,     0,   322,   323,   324,     0,   326,
+     327,   328,   329,   330,   469,   332,   333,   334,   335,   336,
+     337,   338,   339,   340,   341,   342,     0,   344,   345,   346,
+       0,     0,   349,   350,   351,   352,   470,   471,   472,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   474,   475,     0,     0,     0,     0,     0,     0,
+       0,   678,     0,     0,     0,     0,     0,   476,   477,   478,
+       0,     0,     0,     0,     0,     0,     0,    58,     0,     0,
+       0,     0,     0,     0,     0,   479,   480,   481,   482,   483,
+       0,   484,     0,   485,   486,   487,   488,   489,   490,   491,
+     492,   493,   494,   495,    59,   572,   497,   498,     0,     0,
+       0,     0,     0,     0,   499,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   502,   503,   504,     0,    14,     0,     0,   505,   506,
+       0,     0,   437,   438,     0,     0,   507,     0,   508,     0,
+     509,   510,   443,   444,   445,   446,   447,     0,     0,     0,
+       0,     0,   448,  1558,   450,   451,     0,     0,   453,     0,
+       0,     0,     0,     0,     0,     0,   455,     0,     0,     0,
+       0,     0,   458,     0,     0,   459,     0,     0,   460,   461,
+       0,     0,   463,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   570,     0,     0,   467,   468,     0,   322,   323,
+     324,     0,   326,   327,   328,   329,   330,   469,   332,   333,
+     334,   335,   336,   337,   338,   339,   340,   341,   342,     0,
+     344,   345,   346,     0,     0,   349,   350,   351,   352,   470,
+     471,   571,  1559,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   474,   475,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+      58,     0,     0,     0,     0,     0,     0,     0,   479,   480,
+     481,   482,   483,     0,   484,     0,   485,   486,   487,   488,
+     489,   490,   491,   492,   493,   494,   495,    59,   572,   497,
+     498,     0,     0,     0,     0,     0,     0,   499,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   502,   503,   504,     0,    14,     0,
+       0,   505,   506,     0,     0,   437,   438,     0,     0,   507,
+       0,   508,     0,   509,   510,   443,   444,   445,   446,   447,
+       0,     0,     0,     0,     0,   448,     0,   450,     0,     0,
+       0,   453,     0,     0,     0,     0,     0,     0,     0,   455,
+       0,     0,     0,     0,     0,   458,     0,     0,   459,     0,
+       0,   460,     0,     0,     0,   463,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   570,     0,     0,   467,   468,
+       0,   322,   323,   324,     0,   326,   327,   328,   329,   330,
+     469,   332,   333,   334,   335,   336,   337,   338,   339,   340,
+     341,   342,     0,   344,   345,   346,     0,     0,   349,   350,
+     351,   352,   470,   471,   472,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   474,   475,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   476,   477,   478,     0,     0,     0,     0,
+       0,     0,     0,    58,     0,     0,     0,     0,     0,     0,
+       0,   479,   480,   481,   482,   483,     0,   484,     0,   485,
+     486,   487,   488,   489,   490,   491,   492,   493,   494,   495,
+      59,   572,   497,   498,     0,     0,     0,     0,     0,     0,
+     499,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   502,   503,   504,
+       0,    14,     0,     0,   505,   506,     0,     0,   437,   438,
+       0,     0,   507,     0,   508,     0,   509,   510,   443,   444,
+     445,   446,   447,     0,     0,     0,     0,     0,   448,     0,
+     450,     0,     0,     0,   453,     0,     0,     0,     0,     0,
+       0,     0,   455,     0,     0,     0,     0,     0,   458,     0,
+       0,   459,     0,     0,   460,     0,     0,     0,   463,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   570,     0,
+       0,   467,   468,   967,   322,   323,   324,     0,   326,   327,
+     328,   329,   330,   469,   332,   333,   334,   335,   336,   337,
+     338,   339,   340,   341,   342,     0,   344,   345,   346,     0,
+       0,   349,   350,   351,   352,   470,   471,   571,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   474,   475,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    58,     0,     0,     0,
+       0,     0,     0,     0,   479,   480,   481,   482,   483,     0,
+     484,   923,   485,   486,   487,   488,   489,   490,   491,   492,
+     493,   494,   495,   924,   572,   497,   498,     0,     0,     0,
+       0,     0,     0,   499,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     502,   503,   504,     0,    14,     0,     0,   505,   506,     0,
+       0,   437,   438,     0,     0,   968,     0,   508,   969,   509,
+     510,   443,   444,   445,   446,   447,     0,     0,     0,     0,
+       0,   448,     0,   450,     0,     0,   412,   453,     0,     0,
+       0,     0,     0,     0,     0,   455,     0,     0,     0,     0,
+       0,   458,     0,     0,   459,     0,     0,   460,     0,     0,
+       0,   463,     0,   413,   414,     0,     0,     0,     0,     0,
+       0,   570,     0,     0,   467,   468,     0,   322,   323,   324,
+       0,   326,   327,   328,   329,   330,   469,   332,   333,   334,
+     335,   336,   337,   338,   339,   340,   341,   342,     0,   344,
+     345,   346,     0,     0,   349,   350,   351,   352,   470,   471,
+     472,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   474,   475,     0,   415,     0,     0,
+       0,   416,     0,     0,     0,     0,     0,     0,     0,   989,
+     990,   991,     0,     0,     0,     0,     0,     0,     0,    58,
+       0,     0,     0,     0,     0,     0,     0,   479,   480,   481,
+     482,   483,   412,   484,     0,   485,   486,   487,   488,   489,
+     490,   491,   492,   493,   494,   495,    59,   572,   497,   498,
+       0,     0,     0,     0,     0,     0,   499,     0,     0,   413,
+     414,     0,     0,   417,     0,     0,     0,   418,     0,  1446,
+     419,     0,     0,   502,   503,   504,     0,    14,     0,     0,
+     505,   506,     0,     0,     0,   420,   437,   438,   507,     0,
+     508,   421,   509,   510,   716,     0,   443,   444,   445,   446,
+     447,     0,     0,     0,     0,     0,   448,     0,   450,     0,
+       0,   412,   453,     0,     0,     0,     0,     0,     0,     0,
+     455,     0,     0,   415,     0,     0,   458,   416,     0,   459,
+     717,     0,   460,     0,     0,     0,   463,     0,   413,   414,
+       0,     0,     0,     0,     0,     0,   570,     0,     0,   467,
+     468,     0,   322,   323,   324,     0,   326,   327,   328,   329,
+     330,   469,   332,   333,   334,   335,   336,   337,   338,   339,
+     340,   341,   342,     0,   344,   345,   346,     0,     0,   349,
+     350,   351,   352,   470,   471,   571,     0,     0,     0,   417,
+       0,     0,     0,   418,     0,  1477,   419,     0,     0,   474,
+     475,     0,   415,     0,     0,     0,   416,     0,     0,     0,
+       0,   420,     0,     0,     0,     0,     0,   421,     0,     0,
+       0,     0,     0,     0,    58,     0,     0,     0,     0,     0,
+       0,     0,   479,   480,   481,   482,   483,     0,   484,     0,
+     485,   486,   487,   488,   489,   490,   491,   492,   493,   494,
+     495,    59,   572,   497,   498,     0,     0,     0,     0,     0,
+       0,   499,     0,     0,     0,     0,     0,     0,   417,     0,
+       0,     0,   418,     0,  1575,   419,     0,     0,   502,   503,
+     504,     0,    14,     0,     0,   505,   506,     0,     0,     0,
+     420,   437,   438,   507,   607,   508,   421,   509,   510,   716,
+       0,   443,   444,   445,   446,   447,     0,     0,     0,     0,
+       0,   448,     0,   450,     0,     0,     0,   453,     0,     0,
+       0,     0,     0,     0,     0,   455,     0,     0,     0,     0,
+       0,   458,     0,     0,   459,   717,     0,   460,     0,     0,
+       0,   463,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   570,     0,     0,   467,   468,     0,   322,   323,   324,
+       0,   326,   327,   328,   329,   330,   469,   332,   333,   334,
+     335,   336,   337,   338,   339,   340,   341,   342,     0,   344,
+     345,   346,     0,     0,   349,   350,   351,   352,   470,   471,
+     571,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   474,   475,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    58,
+       0,     0,     0,     0,     0,     0,     0,   479,   480,   481,
+     482,   483,     0,   484,   923,   485,   486,   487,   488,   489,
+     490,   491,   492,   493,   494,   495,   924,   572,   497,   498,
+       0,     0,     0,     0,     0,     0,   499,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   502,   503,   504,     0,    14,     0,     0,
+     505,   506,     0,     0,     0,     0,   437,   438,   507,     0,
+     508,     0,   509,   510,   716,     0,   443,   444,   445,   446,
+     447,     0,     0,     0,     0,     0,   448,     0,   450,     0,
+       0,     0,   453,     0,     0,     0,     0,     0,     0,     0,
+     455,     0,     0,     0,     0,     0,   458,     0,     0,   459,
+     717,     0,   460,     0,     0,     0,   463,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   570,     0,     0,   467,
+     468,     0,   322,   323,   324,     0,   326,   327,   328,   329,
+     330,   469,   332,   333,   334,   335,   336,   337,   338,   339,
+     340,   341,   342,     0,   344,   345,   346,     0,     0,   349,
+     350,   351,   352,   470,   471,   571,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   474,
+     475,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    58,     0,     0,     0,     0,     0,
+       0,     0,   479,   480,   481,   482,   483,     0,   484,     0,
+     485,   486,   487,   488,   489,   490,   491,   492,   493,   494,
+     495,    59,   572,   497,   498,     0,     0,     0,     0,     0,
+       0,   499,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   502,   503,
+     504,     0,    14,     0,     0,   505,   506,     0,     0,     0,
+       0,   437,   438,   507,   834,   508,     0,   509,   510,   716,
+       0,   443,   444,   445,   446,   447,     0,     0,     0,     0,
+       0,   448,     0,   450,     0,     0,     0,   453,     0,     0,
+       0,     0,     0,     0,     0,   455,     0,     0,     0,     0,
+       0,   458,     0,     0,   459,   717,     0,   460,     0,     0,
+       0,   463,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   570,     0,     0,   467,   468,     0,   322,   323,   324,
+       0,   326,   327,   328,   329,   330,   469,   332,   333,   334,
+     335,   336,   337,   338,   339,   340,   341,   342,     0,   344,
+     345,   346,     0,     0,   349,   350,   351,   352,   470,   471,
+     571,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   474,   475,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    58,
+       0,     0,     0,     0,     0,     0,     0,   479,   480,   481,
+     482,   483,     0,   484,     0,   485,   486,   487,   488,   489,
+     490,   491,   492,   493,   494,   495,    59,   572,   497,   498,
+       0,     0,     0,     0,     0,     0,   499,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   502,   503,   504,     0,    14,     0,     0,
+     505,   506,     0,     0,   437,   438,     0,     0,   507,     0,
+     508,     0,   509,   510,   443,   444,   445,   446,   447,     0,
+       0,     0,     0,     0,   448,     0,   450,     0,     0,     0,
+     453,     0,     0,     0,     0,     0,     0,     0,   455,     0,
+       0,     0,     0,     0,   458,     0,     0,   459,     0,     0,
+     460,     0,     0,     0,   463,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   570,     0,     0,   467,   468,  1117,
+     322,   323,   324,     0,   326,   327,   328,   329,   330,   469,
+     332,   333,   334,   335,   336,   337,   338,   339,   340,   341,
+     342,     0,   344,   345,   346,     0,     0,   349,   350,   351,
+     352,   470,   471,   571,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   474,   475,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    58,     0,     0,     0,     0,     0,     0,     0,
+     479,   480,   481,   482,   483,     0,   484,   923,   485,   486,
+     487,   488,   489,   490,   491,   492,   493,   494,   495,   924,
+     572,   497,   498,     0,     0,     0,     0,     0,     0,   499,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   502,   503,   504,     0,
+      14,     0,     0,   505,   506,     0,     0,   437,   438,     0,
+       0,   507,     0,   508,     0,   509,   510,   443,   444,   445,
+     446,   447,     0,     0,     0,     0,     0,   448,     0,   450,
+       0,     0,     0,   453,     0,     0,     0,     0,     0,     0,
+       0,   455,     0,     0,     0,     0,     0,   458,     0,     0,
+     459,     0,     0,   460,     0,     0,     0,   463,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   570,     0,     0,
+     467,   468,     0,   322,   323,   324,     0,   326,   327,   328,
+     329,   330,   469,   332,   333,   334,   335,   336,   337,   338,
+     339,   340,   341,   342,     0,   344,   345,   346,     0,     0,
+     349,   350,   351,   352,   470,   471,   571,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     474,   475,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,    58,     0,     0,     0,     0,
+       0,     0,     0,   479,   480,   481,   482,   483,     0,   484,
+       0,   485,   486,   487,   488,   489,   490,   491,   492,   493,
+     494,   495,    59,   572,   497,   498,     0,     0,     0,     0,
+       0,     0,   499,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   502,
+     503,   504,     0,    14,     0,     0,   505,   506,     0,     0,
+     437,   438,     0,     0,   507,   607,   508,     0,   509,   510,
+     443,   444,   445,   446,   447,     0,     0,     0,     0,     0,
+     448,     0,   450,     0,     0,     0,   453,     0,     0,     0,
+       0,     0,     0,     0,   455,     0,     0,     0,     0,     0,
+     458,     0,     0,   459,     0,     0,   460,     0,     0,     0,
+     463,     0,     0,     0,     0,     0,   656,     0,     0,     0,
+     570,     0,     0,   467,   468,     0,   322,   323,   324,     0,
+     326,   327,   328,   329,   330,   469,   332,   333,   334,   335,
+     336,   337,   338,   339,   340,   341,   342,     0,   344,   345,
+     346,     0,     0,   349,   350,   351,   352,   470,   471,   571,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   474,   475,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    58,     0,
+       0,     0,     0,     0,     0,     0,   479,   480,   481,   482,
+     483,     0,   484,     0,   485,   486,   487,   488,   489,   490,
+     491,   492,   493,   494,   495,    59,   572,   497,   498,     0,
+       0,     0,     0,     0,     0,   499,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   502,   503,   504,     0,    14,     0,     0,   505,
+     506,     0,     0,   437,   438,     0,     0,   507,     0,   508,
+       0,   509,   510,   443,   444,   445,   446,   447,     0,     0,
+       0,     0,     0,   448,     0,   450,     0,     0,     0,   453,
+       0,     0,     0,     0,     0,     0,     0,   455,     0,     0,
+       0,     0,     0,   458,     0,     0,   459,     0,     0,   460,
+       0,     0,     0,   463,     0,     0,   667,     0,     0,     0,
+       0,     0,     0,   570,     0,     0,   467,   468,     0,   322,
+     323,   324,     0,   326,   327,   328,   329,   330,   469,   332,
+     333,   334,   335,   336,   337,   338,   339,   340,   341,   342,
+       0,   344,   345,   346,     0,     0,   349,   350,   351,   352,
+     470,   471,   571,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   474,   475,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,    58,     0,     0,     0,     0,     0,     0,     0,   479,
+     480,   481,   482,   483,     0,   484,     0,   485,   486,   487,
+     488,   489,   490,   491,   492,   493,   494,   495,    59,   572,
+     497,   498,     0,     0,     0,     0,     0,     0,   499,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   502,   503,   504,     0,    14,
+       0,     0,   505,   506,     0,     0,     0,     0,   437,   438,
+     507,     0,   508,     0,   509,   510,   699,     0,   443,   444,
+     445,   446,   447,     0,     0,     0,     0,     0,   448,     0,
+     450,     0,     0,     0,   453,     0,     0,     0,     0,     0,
+       0,     0,   455,     0,     0,     0,     0,     0,   458,     0,
+       0,   459,     0,     0,   460,     0,     0,     0,   463,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   570,     0,
+       0,   467,   468,     0,   322,   323,   324,     0,   326,   327,
+     328,   329,   330,   469,   332,   333,   334,   335,   336,   337,
+     338,   339,   340,   341,   342,     0,   344,   345,   346,     0,
+       0,   349,   350,   351,   352,   470,   471,   571,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   474,   475,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    58,     0,     0,     0,
+       0,     0,     0,     0,   479,   480,   481,   482,   483,     0,
+     484,     0,   485,   486,   487,   488,   489,   490,   491,   492,
+     493,   494,   495,    59,   572,   497,   498,     0,     0,     0,
+       0,     0,     0,   499,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     502,   503,   504,     0,    14,     0,     0,   505,   506,     0,
+       0,   437,   438,     0,     0,   507,     0,   508,     0,   509,
+     510,   443,   444,   445,   446,   447,     0,     0,     0,     0,
+       0,   448,     0,   450,     0,     0,     0,   453,     0,     0,
+       0,     0,     0,     0,     0,   455,     0,     0,     0,     0,
+       0,   458,     0,     0,   459,     0,     0,   460,     0,     0,
+       0,   463,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   570,     0,     0,   467,   468,     0,   322,   323,   324,
+       0,   326,   327,   328,   329,   330,   469,   332,   333,   334,
+     335,   336,   337,   338,   339,   340,   341,   342,     0,   344,
+     345,   346,     0,     0,   349,   350,   351,   352,   470,   471,
+     571,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   474,   475,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    58,
+       0,     0,     0,     0,     0,     0,     0,   479,   480,   481,
+     482,   483,     0,   484,     0,   485,   486,   487,   488,   489,
+     490,   491,   492,   493,   494,   495,    59,   572,   497,   498,
+       0,     0,     0,     0,     0,     0,   499,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   703,     0,   502,   503,   504,     0,    14,     0,     0,
+     505,   506,     0,     0,     0,     0,   437,   438,   507,     0,
+     508,     0,   509,   510,   707,     0,   443,   444,   445,   446,
+     447,     0,     0,     0,     0,     0,   448,     0,   450,     0,
+       0,     0,   453,     0,     0,     0,     0,     0,     0,     0,
+     455,     0,     0,     0,     0,     0,   458,     0,     0,   459,
+       0,     0,   460,     0,     0,     0,   463,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   570,     0,     0,   467,
+     468,     0,   322,   323,   324,     0,   326,   327,   328,   329,
+     330,   469,   332,   333,   334,   335,   336,   337,   338,   339,
+     340,   341,   342,     0,   344,   345,   346,     0,     0,   349,
+     350,   351,   352,   470,   471,   571,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   474,
+     475,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    58,     0,     0,     0,     0,     0,
+       0,     0,   479,   480,   481,   482,   483,     0,   484,     0,
+     485,   486,   487,   488,   489,   490,   491,   492,   493,   494,
+     495,    59,   572,   497,   498,     0,     0,     0,     0,     0,
+       0,   499,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   502,   503,
+     504,     0,    14,     0,     0,   505,   506,     0,     0,   437,
+     438,     0,     0,   507,     0,   508,     0,   509,   510,   443,
+     444,   445,   446,   447,     0,     0,  1048,     0,     0,   448,
+       0,   450,     0,     0,     0,   453,     0,     0,     0,     0,
+       0,     0,     0,   455,     0,     0,     0,     0,     0,   458,
+       0,     0,   459,     0,     0,   460,     0,     0,     0,   463,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   570,
+       0,     0,   467,   468,     0,   322,   323,   324,     0,   326,
+     327,   328,   329,   330,   469,   332,   333,   334,   335,   336,
+     337,   338,   339,   340,   341,   342,     0,   344,   345,   346,
+       0,     0,   349,   350,   351,   352,   470,   471,   571,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   474,   475,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    58,     0,     0,
+       0,     0,     0,     0,     0,   479,   480,   481,   482,   483,
+       0,   484,     0,   485,   486,   487,   488,   489,   490,   491,
+     492,   493,   494,   495,    59,   572,   497,   498,     0,     0,
+       0,     0,     0,     0,   499,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   502,   503,   504,     0,    14,     0,     0,   505,   506,
+       0,     0,   437,   438,     0,     0,   507,     0,   508,     0,
+     509,   510,   443,   444,   445,   446,   447,     0,     0,     0,
+       0,     0,   448,     0,   450,     0,     0,     0,   453,     0,
+       0,     0,     0,     0,     0,     0,   455,     0,     0,     0,
+       0,     0,   458,     0,     0,   459,     0,     0,   460,     0,
+       0,     0,   463,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   570,     0,     0,   467,   468,     0,   322,   323,
+     324,     0,   326,   327,   328,   329,   330,   469,   332,   333,
+     334,   335,   336,   337,   338,   339,   340,   341,   342,     0,
+     344,   345,   346,     0,     0,   349,   350,   351,   352,   470,
+     471,   571,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   474,   475,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+      58,     0,     0,     0,     0,     0,     0,     0,   479,   480,
+     481,   482,   483,     0,   484,     0,   485,   486,   487,   488,
+     489,   490,   491,   492,   493,   494,   495,    59,   572,   497,
+     498,     0,     0,     0,     0,     0,     0,   499,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   502,   503,   504,     0,    14,     0,
+       0,   505,   506,     0,     0,   437,   438,     0,     0,   507,
+       0,   508,  1069,   509,   510,   443,   444,   445,   446,   447,
+       0,     0,     0,     0,     0,   448,     0,   450,     0,     0,
+       0,   453,     0,     0,     0,     0,     0,     0,     0,   455,
+       0,     0,     0,     0,     0,   458,     0,     0,   459,     0,
+       0,   460,     0,     0,     0,   463,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   570,     0,     0,   467,   468,
+       0,   322,   323,   324,     0,   326,   327,   328,   329,   330,
+     469,   332,   333,   334,   335,   336,   337,   338,   339,   340,
+     341,   342,     0,   344,   345,   346,     0,     0,   349,   350,
+     351,   352,   470,   471,   571,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   474,   475,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,    58,     0,     0,     0,     0,     0,     0,
+       0,   479,   480,   481,   482,   483,     0,   484,     0,   485,
+     486,   487,   488,   489,   490,   491,   492,   493,   494,   495,
+      59,   572,   497,   498,     0,     0,     0,     0,     0,     0,
+     499,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,  1121,     0,   502,   503,   504,
+       0,    14,     0,     0,   505,   506,     0,     0,   437,   438,
+       0,     0,   507,     0,   508,     0,   509,   510,   443,   444,
+     445,   446,   447,     0,     0,     0,     0,     0,   448,     0,
+     450,     0,     0,     0,   453,     0,     0,     0,     0,     0,
+       0,     0,   455,     0,     0,     0,     0,     0,   458,     0,
+       0,   459,     0,     0,   460,     0,     0,     0,   463,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   570,     0,
+       0,   467,   468,     0,   322,   323,   324,     0,   326,   327,
+     328,   329,   330,   469,   332,   333,   334,   335,   336,   337,
+     338,   339,   340,   341,   342,     0,   344,   345,   346,     0,
+       0,   349,   350,   351,   352,   470,   471,   571,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   474,   475,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    58,     0,     0,     0,
+       0,     0,     0,     0,   479,   480,   481,   482,   483,     0,
+     484,     0,   485,   486,   487,   488,   489,   490,   491,   492,
+     493,   494,   495,    59,   572,   497,   498,     0,     0,     0,
+       0,     0,     0,   499,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     502,   503,   504,     0,    14,     0,     0,   505,   506,     0,
+       0,   437,   438,     0,     0,   507,     0,   508,  1182,   509,
+     510,   443,   444,   445,   446,   447,     0,     0,     0,     0,
+       0,   448,     0,   450,     0,     0,     0,   453,     0,     0,
+       0,     0,     0,     0,     0,   455,     0,     0,     0,     0,
+       0,   458,     0,     0,   459,     0,     0,   460,     0,     0,
+       0,   463,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   570,     0,     0,   467,   468,     0,   322,   323,   324,
+       0,   326,   327,   328,   329,   330,   469,   332,   333,   334,
+     335,   336,   337,   338,   339,   340,   341,   342,     0,   344,
+     345,   346,     0,     0,   349,   350,   351,   352,   470,   471,
+     571,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   474,   475,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    58,
+       0,     0,     0,     0,     0,     0,     0,   479,   480,   481,
+     482,   483,     0,   484,     0,   485,   486,   487,   488,   489,
+     490,   491,   492,   493,   494,   495,    59,   572,   497,   498,
+       0,     0,     0,     0,     0,     0,   499,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   502,   503,   504,     0,    14,     0,     0,
+     505,   506,     0,     0,   437,   438,     0,     0,   507,     0,
+     508,  1197,   509,   510,   443,   444,   445,   446,   447,     0,
+       0,     0,     0,     0,   448,     0,   450,     0,     0,     0,
+     453,     0,     0,     0,     0,     0,     0,     0,   455,     0,
+       0,     0,     0,     0,   458,     0,     0,   459,     0,     0,
+     460,     0,     0,     0,   463,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   570,     0,     0,   467,   468,     0,
+     322,   323,   324,     0,   326,   327,   328,   329,   330,   469,
+     332,   333,   334,   335,   336,   337,   338,   339,   340,   341,
+     342,     0,   344,   345,   346,     0,     0,   349,   350,   351,
+     352,   470,   471,   571,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   474,   475,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    58,     0,     0,     0,     0,     0,     0,     0,
+     479,   480,   481,   482,   483,     0,   484,     0,   485,   486,
+     487,   488,   489,   490,   491,   492,   493,   494,   495,    59,
+     572,   497,   498,     0,     0,     0,     0,     0,     0,   499,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   502,   503,   504,     0,
+      14,     0,     0,   505,   506,     0,     0,   437,   438,     0,
+       0,   507,     0,   508,  1400,   509,   510,   443,   444,   445,
+     446,   447,     0,     0,     0,     0,     0,   448,     0,   450,
+       0,     0,     0,   453,     0,     0,     0,     0,     0,     0,
+       0,   455,     0,     0,     0,     0,     0,   458,     0,     0,
+     459,     0,     0,   460,     0,     0,     0,   463,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   570,     0,     0,
+     467,   468,     0,   322,   323,   324,     0,   326,   327,   328,
+     329,   330,   469,   332,   333,   334,   335,   336,   337,   338,
+     339,   340,   341,   342,     0,   344,   345,   346,     0,     0,
+     349,   350,   351,   352,   470,   471,   571,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     474,   475,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,    58,     0,     0,     0,     0,
+       0,     0,     0,   479,   480,   481,   482,   483,     0,   484,
+       0,   485,   486,   487,   488,   489,   490,   491,   492,   493,
+     494,   495,    59,   572,   497,   498,     0,     0,     0,     0,
+       0,     0,   499,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   502,
+     503,   504,     0,    14,     0,     0,   505,   506,     0,     0,
+     437,   438,     0,     0,  1409,     0,   508,  1410,   509,   510,
+     443,   444,   445,   446,   447,     0,     0,     0,     0,     0,
+     448,     0,   450,     0,     0,     0,   453,     0,     0,     0,
+       0,     0,     0,     0,   455,     0,     0,     0,     0,     0,
+     458,     0,     0,   459,     0,     0,   460,     0,     0,     0,
+     463,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     570,     0,     0,   467,   468,     0,   322,   323,   324,     0,
+     326,   327,   328,   329,   330,   469,   332,   333,   334,   335,
+     336,   337,   338,   339,   340,   341,   342,     0,   344,   345,
+     346,     0,     0,   349,   350,   351,   352,   470,   471,   571,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   474,   475,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    58,     0,
+       0,     0,     0,     0,     0,     0,   479,   480,   481,   482,
+     483,     0,   484,     0,   485,   486,   487,   488,   489,   490,
+     491,   492,   493,   494,   495,    59,   572,   497,   498,     0,
+       0,     0,     0,     0,     0,   499,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   502,   503,   504,     0,    14,     0,     0,   505,
+     506,     0,     0,   437,   438,     0,     0,   507,     0,   508,
+    1415,   509,   510,   443,   444,   445,   446,   447,     0,     0,
+       0,     0,     0,   448,     0,   450,     0,     0,     0,   453,
+       0,     0,     0,     0,     0,     0,     0,   455,     0,     0,
+       0,     0,     0,   458,     0,     0,   459,     0,     0,   460,
+       0,     0,     0,   463,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   570,     0,     0,   467,   468,     0,   322,
+     323,   324,     0,   326,   327,   328,   329,   330,   469,   332,
+     333,   334,   335,   336,   337,   338,   339,   340,   341,   342,
+       0,   344,   345,   346,     0,     0,   349,   350,   351,   352,
+     470,   471,   571,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   474,   475,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,    58,     0,     0,     0,     0,     0,     0,     0,   479,
+     480,   481,   482,   483,     0,   484,     0,   485,   486,   487,
+     488,   489,   490,   491,   492,   493,   494,   495,    59,   572,
+     497,   498,     0,     0,     0,     0,     0,     0,   499,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   502,   503,   504,     0,    14,
+       0,     0,   505,   506,     0,     0,   437,   438,     0,     0,
+     507,     0,   508,  1457,   509,   510,   443,   444,   445,   446,
+     447,     0,     0,     0,     0,     0,   448,     0,   450,     0,
+       0,     0,   453,     0,     0,     0,     0,     0,     0,     0,
+     455,     0,     0,     0,     0,     0,   458,     0,     0,   459,
+       0,     0,   460,     0,     0,     0,   463,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   570,     0,     0,   467,
+     468,     0,   322,   323,   324,     0,   326,   327,   328,   329,
+     330,   469,   332,   333,   334,   335,   336,   337,   338,   339,
+     340,   341,   342,     0,   344,   345,   346,     0,     0,   349,
+     350,   351,   352,   470,   471,   571,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   474,
+     475,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    58,     0,     0,     0,     0,     0,
+       0,     0,   479,   480,   481,   482,   483,     0,   484,     0,
+     485,   486,   487,   488,   489,   490,   491,   492,   493,   494,
+     495,    59,   572,   497,   498,     0,     0,     0,     0,     0,
+       0,   499,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   502,   503,
+     504,     0,    14,     0,     0,   505,   506,     0,     0,   437,
+     438,     0,     0,   507,     0,   508,  1535,   509,   510,   443,
+     444,   445,   446,   447,     0,     0,     0,     0,     0,   448,
+       0,   450,     0,     0,     0,   453,     0,     0,     0,     0,
+       0,     0,     0,   455,     0,     0,     0,     0,     0,   458,
+       0,     0,   459,     0,     0,   460,     0,     0,     0,   463,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   570,
+       0,     0,   467,   468,     0,   322,   323,   324,     0,   326,
+     327,   328,   329,   330,   469,   332,   333,   334,   335,   336,
+     337,   338,   339,   340,   341,   342,     0,   344,   345,   346,
+       0,     0,   349,   350,   351,   352,   470,   471,   571,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   474,   475,     0,     0,     0,     0,     0,     0,
+       0,  1573,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    58,     0,     0,
+       0,     0,     0,     0,     0,   479,   480,   481,   482,   483,
+       0,   484,     0,   485,   486,   487,   488,   489,   490,   491,
+     492,   493,   494,   495,    59,   572,   497,   498,     0,     0,
+       0,     0,     0,     0,   499,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   502,   503,   504,     0,    14,     0,     0,   505,   506,
+       0,     0,   437,   438,     0,     0,   507,     0,   508,     0,
+     509,   510,   443,   444,   445,   446,   447,     0,     0,     0,
+       0,     0,   448,     0,   450,     0,     0,     0,   453,     0,
+       0,     0,     0,     0,     0,     0,   455,     0,     0,     0,
+       0,     0,   458,     0,     0,   459,     0,     0,   460,     0,
+       0,     0,   463,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   570,     0,     0,   467,   468,     0,   322,   323,
+     324,     0,   326,   327,   328,   329,   330,   469,   332,   333,
+     334,   335,   336,   337,   338,   339,   340,   341,   342,     0,
+     344,   345,   346,     0,     0,   349,   350,   351,   352,   470,
+     471,   571,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   474,   475,     0,     0,     0,
+       0,     0,     0,     0,  1615,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+      58,     0,     0,     0,     0,     0,     0,     0,   479,   480,
+     481,   482,   483,     0,   484,     0,   485,   486,   487,   488,
+     489,   490,   491,   492,   493,   494,   495,    59,   572,   497,
+     498,     0,     0,     0,     0,     0,     0,   499,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   502,   503,   504,     0,    14,     0,
+       0,   505,   506,     0,     0,   437,   438,     0,     0,   507,
+       0,   508,     0,   509,   510,   443,   444,   445,   446,   447,
+       0,     0,     0,     0,     0,   448,     0,   450,     0,     0,
+       0,   453,     0,     0,     0,     0,     0,     0,     0,   455,
+       0,     0,     0,     0,     0,   458,     0,     0,   459,     0,
+       0,   460,     0,     0,     0,   463,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   570,     0,     0,   467,   468,
+       0,   322,   323,   324,     0,   326,   327,   328,   329,   330,
+     469,   332,   333,   334,   335,   336,   337,   338,   339,   340,
+     341,   342,     0,   344,   345,   346,     0,     0,   349,   350,
+     351,   352,   470,   471,   571,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   474,   475,
+       0,     0,     0,     0,     0,     0,     0,  1616,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,    58,     0,     0,     0,     0,     0,     0,
+       0,   479,   480,   481,   482,   483,     0,   484,     0,   485,
+     486,   487,   488,   489,   490,   491,   492,   493,   494,   495,
+      59,   572,   497,   498,     0,     0,     0,     0,     0,     0,
+     499,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   502,   503,   504,
+       0,    14,     0,     0,   505,   506,     0,     0,   437,   438,
+       0,     0,   507,     0,   508,     0,   509,   510,   443,   444,
+     445,   446,   447,     0,     0,     0,     0,     0,   448,     0,
+     450,     0,     0,     0,   453,     0,     0,     0,     0,     0,
+       0,     0,   455,     0,     0,     0,     0,     0,   458,     0,
+       0,   459,     0,     0,   460,     0,     0,     0,   463,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   570,     0,
+       0,   467,   468,     0,   322,   323,   324,     0,   326,   327,
+     328,   329,   330,   469,   332,   333,   334,   335,   336,   337,
+     338,   339,   340,   341,   342,     0,   344,   345,   346,     0,
+       0,   349,   350,   351,   352,   470,   471,   571,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   474,   475,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    58,     0,     0,     0,
+       0,     0,     0,     0,   479,   480,   481,   482,   483,     0,
+     484,     0,   485,   486,   487,   488,   489,   490,   491,   492,
+     493,   494,   495,    59,   572,   497,   498,     0,     0,     0,
+       0,     0,     0,   499,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     502,   503,   504,     0,    14,     0,     0,   505,   506,     0,
+       0,   437,   438,     0,     0,   507,     0,   508,     0,   509,
+     510,   443,   444,   445,   446,   447,     0,     0,     0,     0,
+       0,   448,     0,   450,     0,     0,     0,   453,     0,     0,
+       0,     0,     0,     0,     0,   455,     0,     0,     0,     0,
+       0,   458,     0,     0,   459,     0,     0,   460,     0,     0,
+       0,   463,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   570,     0,     0,   467,   468,     0,   322,   323,   324,
+       0,   326,   327,   328,   329,   330,   469,   332,   333,   334,
+     335,   336,   337,   338,   339,   340,   341,   342,     0,   344,
+     345,   346,     0,     0,   349,   350,   351,   352,   470,   471,
+     571,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   474,   475,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    58,
+       0,     0,     0,     0,     0,     0,     0,   479,   480,   481,
+     482,   483,     0,   484,     0,   485,   486,   487,   488,   489,
+     490,   491,   492,   493,   494,   495,    59,   572,   497,   498,
+       0,   697,  1378,     0,     0,     0,   499,   316,     0,     0,
+       0,   740,   741,   317,     0,     0,     0,     0,     0,   318,
+       0,     0,     0,   502,   503,   504,     0,    14,     0,   319,
+     505,   506,     0,     0,     0,     0,     0,   320,  1383,     0,
+     508,     0,   509,   510,     0,     0,     0,     0,     0,     0,
+       0,     0,   321,     0,     0,     0,     0,     0,     0,   322,
+     323,   324,   325,   326,   327,   328,   329,   330,   331,   332,
+     333,   334,   335,   336,   337,   338,   339,   340,   341,   342,
+     343,   344,   345,   346,   347,   348,   349,   350,   351,   352,
+     353,   354,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   750,   751,   752,   753,
+     754,     0,     0,   757,   758,   759,   760,     0,   762,   763,
+     764,   765,     0,     0,     0,     0,   766,     0,   768,   769,
+       0,    58,     0,     0,   772,   773,   774,     0,     0,     0,
+     778,     0,     0,     0,   355,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    59,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     780,     0,   781,   782,   783,   784,   785,   786,   787,   788,
+     789,   790,     0,   316,     0,     0,     0,     0,     0,   317,
+       0,   791,   792,     0,   356,   318,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   319,     0,     0,     0,     0,
+       0,     0,     0,   320,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   321,     0,
+       0,     0,     0,     0,     0,   322,   323,   324,   325,   326,
+     327,   328,   329,   330,   331,   332,   333,   334,   335,   336,
+     337,   338,   339,   340,   341,   342,   343,   344,   345,   346,
+     347,   348,   349,   350,   351,   352,   353,   354,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   316,     0,     0,     0,     0,     0,   317,
+       0,     0,     0,     0,     0,   318,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   319,     0,    58,     0,     0,
+       0,     0,     0,   320,     0,     0,     0,     0,     0,     0,
+     355,     0,     0,     0,     0,     0,     0,     0,   321,     0,
+       0,     0,     0,     0,    59,   322,   323,   324,   325,   326,
+     327,   328,   329,   330,   331,   332,   333,   334,   335,   336,
+     337,   338,   339,   340,   341,   342,   343,   344,   345,   346,
+     347,   348,   349,   350,   351,   352,   353,   354,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     356,     0,   610,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    58,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     355,     0,     0,     0,     0,     0,     0,     0,     0,   316,
+       0,     0,     0,     0,   615,   317,     0,     0,     0,     0,
+       0,   318,     0,     0,     0,     0,   616,     0,     0,     0,
+       0,   319,   617,     0,     0,     0,     0,     0,     0,   320,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   321,     0,     0,     0,     0,     0,
+     356,   322,   323,   324,   325,   326,   327,   328,   329,   330,
+     331,   332,   333,   334,   335,   336,   337,   338,   339,   340,
+     341,   342,   343,   344,   345,   346,   347,   348,   349,   350,
+     351,   352,   353,   354,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   316,
+       0,     0,     0,     0,     0,   317,     0,     0,     0,     0,
+       0,   318,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   319,     0,    58,     0,     0,     0,     0,     0,   320,
+       0,     0,     0,     0,     0,     0,   355,     0,     0,     0,
+       0,     0,     0,     0,   321,     0,     0,     0,     0,     0,
+      59,   322,   323,   324,   325,   326,   327,   328,   329,   330,
+     331,   332,   333,   334,   335,   336,   337,   338,   339,   340,
+     341,   342,   343,   344,   345,   346,   347,   348,   349,   350,
+     351,   352,   353,   354,   740,   741,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   356,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,    58,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   355,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     615,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   872,   873,   874,   875,   876,   877,   878,   879,   750,
+     751,   752,   753,   754,   880,   881,   757,   758,   759,   760,
+     882,   762,   763,   764,   765,  -363,   356,   740,   741,   766,
+     767,   768,   769,   883,   884,     0,     0,   772,   773,   774,
+     885,   886,   887,   778,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   888,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,     0,   509,
+     683,     0,     0,     0,   872,   873,   874,   875,   876,   877,
+     878,   879,   750,   751,   752,   753,   754,   880,   881,   757,
+     758,   759,   760,   882,   762,   763,   764,   765,   740,   741,
+       0,     0,   766,   767,   768,   769,   883,   884,     0,     0,
+     772,   773,   774,   885,   886,   887,   778,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   740,   741,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,  1081,     0,
+       0,     0,     0,     0,     0,   888,   780,     0,   781,   782,
+     783,   784,   785,   786,   787,   788,   789,   790,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   791,   792,     0,
+       0,     0,   509,   683,     0,   872,   873,   874,   875,   876,
+     877,   878,   879,   750,   751,   752,   753,   754,   880,   881,
+     757,   758,   759,   760,   882,   762,   763,   764,   765,     0,
+       0,     0,     0,   766,   767,   768,   769,   883,   884,     0,
+       0,   772,   773,   774,   885,   886,   887,   778,   750,   751,
+     752,   753,   754,     0,     0,   757,   758,   759,   760,     0,
+     762,   763,   764,   765,   740,   741,     0,     0,   766,     0,
+     768,   769,     0,     0,     0,     0,   772,   773,   774,  1284,
+       0,     0,   778,     0,     0,     0,   888,   780,     0,   781,
+     782,   783,   784,   785,   786,   787,   788,   789,   790,   740,
+     741,     0,     0,     0,     0,     0,     0,     0,   791,   792,
+       0,     0,     0,   509,   683,     0,     0,     0,     0,     0,
+       0,     0,   780,     0,   781,   782,   783,   784,   785,   786,
+     787,   788,   789,   790,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   791,   792,     0,     0,     0,   509,   683,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   750,
+     751,   752,   753,   754,     0,     0,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,   804,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,   814,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,     0,   740,   741,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,   830,   750,   751,   752,   753,   754,     0,
+       0,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,   845,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1154,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,     0,   740,
+     741,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1158,   750,
+     751,   752,   753,   754,     0,     0,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1160,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1169,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,     0,   740,   741,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1170,   750,   751,   752,   753,   754,     0,
+       0,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1171,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1172,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,     0,   740,
+     741,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1173,   750,
+     751,   752,   753,   754,     0,     0,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1174,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1305,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,     0,   740,   741,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1317,   750,   751,   752,   753,   754,     0,
+       0,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1320,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1460,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,     0,   740,
+     741,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1475,   750,
+     751,   752,   753,   754,     0,     0,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1476,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1497,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,     0,   740,   741,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1499,   750,   751,   752,   753,   754,     0,
+       0,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1501,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1505,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,     0,   740,
+     741,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1578,   750,
+     751,   752,   753,   754,     0,     0,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1579,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1581,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,     0,   740,   741,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1588,   750,   751,   752,   753,   754,     0,
+       0,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1591,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1601,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,     0,   740,
+     741,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1606,   750,
+     751,   752,   753,   754,     0,     0,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,     0,     0,  1672,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,     0,     0,  1673,   750,   751,   752,   753,   754,   740,
+     741,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,     0,
+       0,     0,     0,     0,   740,   741,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,   835,     0,     0,   750,   751,   752,   753,   754,     0,
+       0,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+       0,     0,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,     0,   778,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,  1104,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,  1256,     0,     0,   750,
+     751,   752,   753,   754,   740,   741,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,     0,     0,     0,     0,     0,   740,
+     741,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,  1272,     0,     0,   750,
+     751,   752,   753,   754,     0,     0,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,   772,   773,   774,
+       0,     0,     0,   778,   750,   751,   752,   753,   754,     0,
+       0,   757,   758,   759,   760,     0,   762,   763,   764,   765,
+     236,   237,     0,     0,   766,     0,   768,   769,     0,     0,
+       0,     0,   772,   773,   774,     0,     0,   238,   778,     0,
+       0,     0,     0,   780,     0,   781,   782,   783,   784,   785,
+     786,   787,   788,   789,   790,   740,   741,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,  1407,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   780,     0,
+     781,   782,   783,   784,   785,   786,   787,   788,   789,   790,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   791,
+     792,  1413,     0,     0,     0,     0,     0,   239,   240,   241,
+     242,   243,   244,   245,   246,   247,   248,   249,   250,   251,
+     252,   253,   254,   255,   256,     0,     0,   257,   258,   259,
+       0,     0,     0,     0,     0,     0,   260,   261,   262,   263,
+     264,     0,     0,   265,   266,   267,   268,   269,   270,   271,
+     750,   751,   752,   753,   754,   740,   741,   757,   758,   759,
+     760,     0,   762,   763,   764,   765,     0,     0,     0,     0,
+     766,     0,   768,   769,     0,     0,     0,     0,   772,   773,
+     774,     0,     0,     0,   778,     0,     0,     0,     0,   272,
+       0,   273,   274,   275,   276,   277,   278,   279,   280,   281,
+     282,     0,     0,   283,   284,     0,     0,     0,     0,     0,
+     285,   286,     0,     0,   291,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   780,     0,   781,   782,   783,   784,
+     785,   786,   787,   788,   789,   790,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   791,   792,     0,     0,     0,
+     750,   751,   752,   753,   754,   740,   741,   757,   758,   759,
+     760,     0,   762,   763,   764,   765,     0,     0,     0,     0,
+     766,     0,   768,   769,     0,     0,   939,     0,   772,   773,
+     774,     0,     0,     0,   778,     0,     0,     0,     0,     0,
+     740,   741,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   780,     0,   781,   782,   783,   784,
+     785,   786,   787,   788,   789,   790,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   791,   792,     0,     0,     0,
+     750,   751,   752,   753,   754,     0,     0,   757,   758,   759,
+     760,     0,   762,   763,   764,   765,     0,     0,     0,     0,
+     766,     0,   768,   769,     0,     0,  1183,     0,   772,   773,
+     774,     0,     0,     0,   778,   750,   751,   752,   753,   754,
+     740,   741,   757,   758,   759,   760,     0,   762,   763,   764,
+     765,     0,     0,     0,     0,   766,     0,   768,   769,     0,
+       0,     0,     0,   772,   773,   774,     0,     0,     0,   778,
+       0,     0,     0,     0,   780,     0,   781,   782,   783,   784,
+     785,   786,   787,   788,   789,   790,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   791,   792,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   780,
+    1261,   781,   782,   783,   784,   785,   786,   787,   788,   789,
+     790,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     791,   792,     0,     0,     0,   750,   751,   752,   753,   754,
+     740,   741,   757,   758,   759,   760,     0,   762,   763,   764,
+     765,     0,     0,     0,     0,   766,     0,   768,   769,     0,
+       0,     0,     0,   772,   773,   774,     0,     0,     0,   778,
+       0,     0,     0,     0,     0,   740,   741,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,  1274,     0,     0,     0,     0,     0,     0,     0,   780,
+       0,   781,   782,   783,   784,   785,   786,   787,   788,   789,
+     790,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     791,   792,     0,     0,     0,   750,   751,   752,   753,   754,
+       0,     0,   757,   758,   759,   760,     0,   762,   763,   764,
+     765,     0,     0,     0,     0,   766,     0,   768,   769,     0,
+       0,     0,     0,   772,   773,   774,     0,     0,     0,   778,
+     750,   751,   752,   753,   754,   740,   741,   757,   758,   759,
+     760,     0,   762,   763,   764,   765,     0,     0,     0,     0,
+     766,     0,   768,   769,     0,     0,     0,  1367,   772,   773,
+     774,     0,     0,     0,   778,     0,     0,     0,     0,   780,
+       0,   781,   782,   783,   784,   785,   786,   787,   788,   789,
+     790,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     791,   792,     0,     0,     0,     0,  1602,     0,     0,     0,
+       0,     0,     0,     0,   780,     0,   781,   782,   783,   784,
+     785,   786,   787,   788,   789,   790,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   791,   792,     0,     0,     0,
+     750,   751,   752,   753,   754,   740,   741,   757,   758,   759,
+     760,     0,   762,   763,   764,   765,     0,     0,     0,     0,
+     766,     0,   768,   769,     0,     0,     0,     0,   772,   773,
+     774,     0,     0,     0,   778,     0,     0,     0,     0,     0,
+     740,   741,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,  1663,     0,     0,     0,
+       0,     0,     0,     0,   780,     0,   781,   782,   783,   784,
+     785,   786,   787,   788,   789,   790,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   791,   792,     0,     0,     0,
+     750,   751,   752,   753,   754,     0,     0,   757,   758,   759,
+     760,     0,   762,   763,   764,   765,     0,     0,     0,     0,
+     766,     0,   768,   769,     0,     0,     0,     0,   772,   773,
+     774,     0,     0,     0,   778,   750,   751,   752,   753,   754,
+     740,   741,   757,   758,   759,   760,     0,   762,   763,   764,
+     765,     0,     0,     0,     0,   766,     0,   768,   769,     0,
+       0,     0,     0,   772,   773,   774,  1688,     0,     0,   778,
+       0,     0,     0,     0,   780,     0,   781,   782,   783,   784,
+     785,   786,   787,   788,   789,   790,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   791,   792,     0,     0,     0,
+       0,  1689,     0,     0,     0,     0,     0,     0,     0,   780,
+       0,   781,   782,   783,   784,   785,   786,   787,   788,   789,
+     790,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     791,   792,     0,     0,     0,   750,   751,   752,   753,   754,
+     740,   741,   757,   758,   759,   760,     0,   762,   763,   764,
+     765,     0,     0,     0,     0,   766,     0,   768,   769,     0,
+       0,     0,     0,   772,   773,   774,     0,     0,     0,   778,
+       0,     0,     0,     0,     0,   740,   741,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,  1695,     0,     0,     0,     0,     0,     0,     0,   780,
+       0,   781,   782,   783,   784,   785,   786,   787,   788,   789,
+     790,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     791,   792,     0,     0,     0,   750,   751,   752,   753,   754,
+       0,     0,   757,   758,   759,   760,     0,   762,   763,   764,
+     765,     0,     0,     0,     0,   766,     0,   768,   769,     0,
+       0,     0,     0,   772,   773,   774,     0,     0,     0,   778,
+     750,   751,   752,   753,   754,   740,   741,   757,   758,   759,
+     760,     0,   762,   763,   764,   765,     0,     0,     0,     0,
+     766,     0,   768,   769,     0,     0,     0,     0,   772,   773,
+     774,     0,     0,     0,  -762,     0,   740,   741,     0,   780,
+       0,   781,   782,   783,   784,   785,   786,   787,   788,   789,
+     790,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     791,   792,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   780,     0,   781,   782,   783,   784,
+     785,   786,   787,   788,   789,   790,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   791,   792,     0,     0,     0,
+     750,   751,   752,   753,   754,     0,     0,   757,   758,   759,
+     760,     0,   762,   763,   764,   765,     0,     0,     0,     0,
+     766,     0,   768,   769,     0,     0,   740,   741,   772,   773,
+     774,   750,   751,   752,   753,   754,     0,     0,   757,   758,
+     759,   760,     0,   762,   763,   764,   765,     0,     0,     0,
+       0,   766,     0,   768,   769,   740,   741,     0,     0,   772,
+       0,   774,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   780,     0,   781,   782,   783,   784,
+     785,   786,   787,   788,   789,   790,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   791,   792,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   781,   782,   783,
+     784,   785,   786,   787,   788,   789,   790,     0,     0,     0,
+       0,   750,   751,   752,   753,   754,   791,   792,   757,   758,
+     759,   760,     0,   762,   763,   764,   765,     0,     0,     0,
+       0,   766,     0,   768,   769,   740,   741,     0,     0,     0,
+     750,   751,   752,   753,   754,     0,     0,   757,   758,   759,
+     760,     0,   762,   763,   764,   765,     0,     0,     0,     0,
+     766,     0,   768,   769,   740,   741,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   781,   782,   783,
+     784,   785,   786,   787,   788,   789,   790,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   791,   792,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   782,   783,   784,
+     785,   786,   787,   788,   789,   790,     0,     0,     0,     0,
+     750,   751,   752,   753,   754,   791,   792,   757,   758,   759,
+     760,     0,   762,   763,   764,   765,     0,     0,     0,     0,
+     766,     0,   768,   769,     0,     0,     0,     0,     0,   750,
+     751,   752,   753,   754,     0,     0,   757,   758,   759,   760,
+       0,   762,   763,   764,   765,     0,     0,     0,     0,   766,
+       0,   768,   769,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   981,     0,     0,     0,   783,   784,
+     785,   786,   787,   788,   789,   790,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   791,   792,     0,     0,     0,
+       0,     0,     0,     0,     0,   985,     0,     0,   784,   785,
+     786,   787,   788,   789,   790,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   791,   792,   322,   323,   324,     0,
+     326,   327,   328,   329,   330,   469,   332,   333,   334,   335,
+     336,   337,   338,   339,   340,   341,   342,     0,   344,   345,
+     346,     0,     0,   349,   350,   351,   352,   322,   323,   324,
+       0,   326,   327,   328,   329,   330,   469,   332,   333,   334,
+     335,   336,   337,   338,   339,   340,   341,   342,     0,   344,
+     345,   346,     0,     0,   349,   350,   351,   352,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,  1257,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   982,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   983,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   986,     0,     0,     0,     0,     0,
+       0,     0,     0,   322,   323,   324,   987,   326,   327,   328,
+     329,   330,   469,   332,   333,   334,   335,   336,   337,   338,
+     339,   340,   341,   342,     0,   344,   345,   346,     0,     0,
+     349,   350,   351,   352,   322,   323,   324,     0,   326,   327,
+     328,   329,   330,   469,   332,   333,   334,   335,   336,   337,
+     338,   339,   340,   341,   342,     0,   344,   345,   346,     0,
+       0,   349,   350,   351,   352,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   186,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+    1258,     0,  1060,  1061,     0,     0,     0,     0,     0,     0,
+       0,     0,  1259,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   187,     0,   188,     0,   189,   190,   191,   192,
+     193,  1062,   194,   195,   196,   197,   198,   199,   200,   201,
+     202,   203,   204,  1063,   205,   206,   207,     0,     0,   208,
+     209,   210,   211,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   212,
+     213,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,  1064,  1065,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   214
+};
+
+static const yytype_int16 yycheck[] =
+{
+      14,    15,   216,   488,   577,   526,   630,   381,   394,   718,
+     165,   720,   696,   597,   698,   596,   591,   232,   593,   859,
+     595,   381,   425,   426,   930,   821,   388,   823,  1186,   825,
+     936,    82,   543,   477,   478,     5,     8,   423,   698,   914,
+    1327,     0,   635,   232,   449,   729,    20,    33,     7,    20,
+      64,    65,    66,  1451,    20,    53,   567,  1427,    15,    16,
+      20,   105,  1386,     4,    57,    20,    33,    20,   473,    20,
+      63,    30,    22,    32,   143,    34,    34,    46,   127,     5,
+       6,    40,     8,   163,   126,   143,  1582,   129,   130,   449,
+     127,    50,   106,   107,   108,   109,   158,    56,    19,    20,
+     486,   487,   695,   160,   697,    63,   699,    57,   170,   449,
+      36,   132,   170,   473,   707,   127,   180,  1515,  1516,   129,
+     130,    80,   191,   716,   833,   137,   158,   967,  1555,   144,
+     145,   146,   102,   103,  1630,  1533,   155,   106,   170,   188,
+     189,   160,   191,   102,   103,   194,   180,    15,    16,   107,
+     214,   306,   189,   215,  1524,   192,   214,    21,    22,   868,
+     217,   182,  1486,   170,   379,    53,     5,     6,   508,   211,
+     212,   182,   188,   224,   685,   859,   581,   189,   136,   223,
+    1550,   107,   214,   892,   182,   143,    25,  1614,   181,  1347,
+     379,   182,    31,  1587,  1592,  1593,   905,   213,   217,   908,
+     215,   211,   212,   188,  1598,   394,   163,   214,   194,   181,
+     142,   168,   170,   170,   188,   618,   173,   188,   232,   160,
+     623,   581,   188,   182,   215,   195,   212,   194,   188,    68,
+      69,    49,   218,   188,   423,   188,   425,   188,   452,  1526,
+     212,   170,   201,   648,   214,  1639,  1640,   205,   180,   170,
+     200,   152,   466,   212,   118,   119,   214,   214,    33,   310,
+     600,   211,   126,   102,   103,   129,   130,   131,   654,   170,
+     158,   127,   136,   678,   155,    93,  1182,  1117,   182,   160,
+      62,   137,   170,   967,   968,    60,    61,   216,   648,   180,
+     189,   677,  1167,   152,   738,   163,   127,   486,   487,   127,
+     168,   160,   170,  1461,   143,   173,   137,   647,   648,   137,
+    1546,   170,  1548,   217,   170,   143,  1552,  1553,   678,   127,
+     127,   160,   161,   162,   191,   216,   217,   194,   191,   137,
+     137,   170,   672,   189,   215,   675,   217,   143,   194,   143,
+       7,   180,   356,    47,   127,   188,   152,   211,   212,   124,
+     185,   186,  1227,   128,   137,   214,   195,   182,   189,   188,
+     185,   189,   955,    67,   170,   379,   170,   582,   583,   584,
+     384,   586,   587,   212,   736,   590,  1612,   592,   213,   594,
+     394,   189,   189,    50,   213,   170,   171,   172,   213,   729,
+     170,   188,   182,   582,   583,   584,   188,   586,   587,   189,
+     188,   590,   807,   592,   979,   594,   189,   596,  1283,   423,
+     813,   425,   143,   170,   188,   190,   201,   803,   215,   194,
+     634,   196,   197,   215,   827,   182,   829,   215,     5,     6,
+     143,   445,   446,  1117,   188,   188,   188,   212,   214,   152,
+    1346,   215,   152,   218,   157,   659,   188,   807,   853,   188,
+    1246,   180,  1358,   188,   794,   966,   941,   170,   163,   188,
+     170,   215,   215,   215,   188,   654,   951,   188,   854,   855,
+     188,   213,   486,   487,   188,   211,   215,   188,   922,   188,
+     215,   867,   195,    64,    65,    66,  1110,   890,   677,   195,
+     704,   215,   188,   853,   215,   182,   170,   215,  1182,   213,
+     170,  1185,   213,    21,    22,   188,   215,   188,   214,   196,
+     724,   897,   898,  1197,   900,  1099,  1097,   213,   904,   859,
+     906,   907,  1182,   909,   182,   106,   107,   108,   109,   180,
+     213,    75,   213,   182,    33,    79,   191,  1197,   196,   188,
+     191,   196,   182,   191,  1340,   989,   990,   991,   196,    93,
+      94,   740,   741,   182,    98,    99,   100,   101,   191,   214,
+     191,    60,    61,   196,   170,   196,   214,   195,   582,   583,
+     584,   195,   586,   587,   170,   195,   590,   766,   592,  1375,
+     594,   214,   596,   214,   195,   188,   214,   927,   191,   174,
+     214,   194,   170,  1168,   214,   935,   170,   170,   116,   117,
+     118,   119,   791,   214,   182,   174,   175,   158,   126,   182,
+     128,   129,   130,   131,   803,   188,   831,   182,   136,   170,
+     138,   139,    12,   188,   839,   124,   640,   842,   127,   128,
+     170,   196,   158,    23,    24,   182,   851,   170,   137,   158,
+     654,   188,   831,   858,   170,  1220,   182,   802,   863,   196,
+     839,   170,   188,   842,   381,   158,   158,   192,   182,   180,
+     196,   196,   851,   677,   188,   854,   855,   170,   170,   858,
+     182,   182,   196,    57,   863,   889,   188,   188,   867,   197,
+     198,   199,   200,   201,   196,   196,  1482,    21,    22,   182,
+     189,   190,   174,   211,   212,   194,   182,   181,   197,  1383,
+     184,   192,   188,   187,    57,   196,   192,   721,   897,   898,
+      63,   900,   192,   212,   106,   904,   196,   906,   907,   218,
+     909,    57,   449,   144,    57,  1409,  1350,    63,    57,   944,
+      63,   946,    57,    57,    63,   216,   217,    57,    63,    63,
+    1126,  1127,  1128,    63,   182,   182,   473,   182,   182,   189,
+     188,   188,   182,   188,   188,   944,   182,   946,   188,   192,
+     192,   180,   188,   196,   196,  1151,   180,   192,   192,   192,
+     192,   196,   196,   196,   196,  1115,   192,   192,   180,   191,
+     196,   196,   194,    35,   118,   119,   800,   181,   182,   803,
+     184,   944,   126,   946,   128,   129,   130,   131,   174,   175,
+     176,   177,   136,    35,   214,  1380,   216,   217,   214,   144,
+     145,   146,   170,   171,   172,    88,    89,   831,  1339,   174,
+     175,   176,   174,   175,   176,   839,   170,   144,   842,   146,
+     181,   182,   183,  1219,   180,  1175,  1460,   851,  1212,   181,
+     854,   855,   170,   170,   858,    21,    22,   170,   213,   863,
+    1534,    22,  1212,   867,   581,   170,  1196,   213,   180,  1048,
+     191,   191,  1202,   197,   198,   199,   200,   201,   180,  1209,
+    1085,   214,   137,  1213,    10,    11,    12,   211,   212,    43,
+     170,   195,   195,   897,   898,   195,   900,   195,  1597,   195,
+     904,   195,   906,   907,   195,   909,  1085,   195,   214,   195,
+    1609,   195,   195,   214,   192,   214,   170,   214,  1097,   170,
+    1594,   213,   170,  1316,  1254,  1488,   195,   212,   195,   195,
+     170,   648,   214,   195,  1633,   195,  1266,   214,   182,   195,
+     944,  1271,   946,   163,   214,   195,   195,  1126,  1127,  1128,
+     195,    37,   118,   119,   195,   214,   214,  1631,   182,   182,
+     126,   678,   128,   129,   130,   131,    10,   214,   214,   182,
+     136,   214,  1151,   182,   182,   182,   182,    66,   217,   212,
+     214,   181,   214,   195,   195,    43,   215,   170,   170,   182,
+     181,   181,  1606,   191,  1469,   213,   181,  1472,   214,   214,
+      43,   195,   188,   195,   132,    14,  1569,  1570,   195,   189,
+     191,  1341,   163,   217,   188,   180,    13,  1221,  1692,   188,
+    1396,   170,     8,   170,   196,   742,   743,   744,   745,   746,
+     747,   748,   749,   199,   200,   201,   215,   381,   755,   756,
+    1219,  1371,   215,   170,   761,   211,   212,   391,   170,   170,
+     214,   188,   188,   770,   771,   213,   400,  1620,   775,   776,
+     777,   181,   779,   181,   170,   215,   410,   215,   214,   214,
+      21,    22,   214,   214,   214,   214,   420,     1,   195,   195,
+     214,  1085,   214,   214,   214,   429,   181,    67,   182,   170,
+     807,   196,   196,  1097,   196,   439,    43,  1427,   170,  1304,
+     215,    21,    22,   215,   215,   449,  1310,   214,   170,   170,
+     454,  1487,   456,   170,   215,   215,   214,   213,   215,   170,
+     213,   465,  1126,  1127,  1128,  1304,   476,   477,   478,   473,
+     474,   475,   214,   213,   182,   195,   853,   214,   214,   214,
+     214,   170,   215,   170,   488,   214,   214,  1151,   213,   182,
+     170,   215,   496,   170,   213,   499,    33,   213,   502,   503,
+     504,   505,   506,   170,   214,   116,   117,   118,   119,   120,
+     196,   515,   123,  1377,   214,   126,   526,   128,   129,   130,
+     131,   215,   214,   214,   214,   136,   214,   138,   139,    70,
+     214,  1395,  1568,  1398,  1524,   214,   214,   196,   118,   119,
+    1530,   215,   215,   553,   196,   182,   126,   215,   128,   129,
+     130,   131,    33,   214,   214,  1219,   136,  1396,   214,  1398,
+    1550,   214,    53,   181,   215,   215,   215,   215,  1558,   213,
+     213,   181,   188,   181,   188,   213,   182,   581,   213,    60,
+      61,   215,   215,   215,   195,   196,   197,   198,   199,   200,
+     201,   215,  1456,   215,   181,   215,   213,   706,    81,   214,
+     211,   212,   215,   215,     1,   609,    44,   137,    84,  1479,
+     953,  1480,   800,  1480,  1480,     1,   974,  1480,  1480,  1456,
+    1393,   230,  1419,  1238,  1512,  1615,  1422,  1279,  1513,   433,
+      33,   211,   212,    52,   565,  1594,  1467,  1502,   499,  1192,
+    1304,   698,   652,   124,   648,    -1,   127,   128,  1487,    -1,
+     445,   655,   656,    -1,   658,    -1,   137,    60,    61,   663,
+     445,    -1,    -1,  1502,    -1,   669,    -1,    -1,    -1,    -1,
+     680,    -1,    -1,    -1,   678,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   689,   690,   691,   692,   693,
+     694,    -1,   696,    -1,   698,    -1,    -1,    -1,    -1,    -1,
+      -1,   182,  1566,    -1,    -1,    -1,    -1,    -1,   189,   190,
+      -1,    -1,    -1,   194,    -1,    -1,   197,    -1,    -1,    -1,
+      -1,   124,    -1,    -1,    -1,   128,    -1,    -1,   738,  1568,
+      -1,   212,  1396,    -1,  1398,    -1,    -1,   218,   742,   743,
+     744,   745,   746,   747,   748,   749,   750,   751,    -1,    -1,
+     754,   755,   756,   757,   758,   759,    -1,   761,   762,    -1,
+     764,   765,   766,   767,   768,   769,   770,   771,   772,   773,
+     774,   775,   776,   777,   778,   779,   780,   781,   782,   783,
+     784,   785,   786,   787,   788,   789,   790,   190,   792,    -1,
+      -1,   194,   796,   196,   197,    -1,    -1,    -1,    -1,   809,
+      -1,    -1,  1666,   807,    -1,    -1,    33,    -1,    -1,   212,
+      -1,    -1,    -1,    -1,    -1,   218,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,  1487,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    60,    61,  1212,    -1,    -1,  1502,    -1,
+      -1,    -1,   846,    -1,    -1,    -1,    -1,    -1,    -1,   853,
+      -1,    -1,    -1,    -1,    -1,    -1,   860,    -1,   862,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   871,   872,   873,
+     874,   875,   876,   877,   878,   879,   880,   881,   882,   883,
+     884,   885,   886,   887,   888,    -1,    -1,    33,    -1,    -1,
+      -1,  1555,    33,    -1,    -1,    -1,    -1,   124,    -1,    -1,
+      -1,   128,   912,    -1,  1568,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   922,    -1,    60,    61,    -1,    -1,    33,    60,
+      61,   925,   926,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   939,    -1,   941,    -1,    -1,
+      -1,    -1,    -1,    -1,   948,    60,    61,   951,    -1,    -1,
+    1614,    -1,   956,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   965,    -1,   190,    -1,    -1,    -1,   194,    -1,   196,
+     197,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   124,   989,
+     990,   991,   128,   124,   994,   212,   996,   128,   998,    -1,
+    1000,   218,  1002,    -1,  1004,    -1,  1006,    -1,  1008,    33,
+      -1,    -1,    -1,  1013,    -1,  1015,    -1,    -1,    -1,   124,
+      10,  1021,    -1,   128,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    21,    22,  1033,    -1,  1035,    60,    61,    -1,    -1,
+    1040,    -1,  1042,    -1,  1044,    -1,   182,  1047,    -1,    -1,
+      -1,    -1,   188,    -1,   190,    -1,    -1,    -1,   194,   190,
+     196,   197,    -1,   194,    -1,   196,   197,  1061,    -1,    -1,
+      -1,  1065,    -1,    -1,    -1,    -1,   212,    -1,    -1,    -1,
+    1080,   212,   218,    -1,    -1,   190,    -1,   218,    -1,   194,
+      -1,   196,   197,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     124,    -1,    -1,    -1,   128,    -1,    -1,   212,    -1,    -1,
+      -1,    -1,  1112,   218,    -1,    -1,    -1,    -1,   108,   109,
+     110,   111,   112,   113,   114,   115,   116,   117,   118,   119,
+     120,   121,   122,   123,   124,   125,   126,   127,   128,   129,
+     130,   131,    -1,    -1,    -1,    -1,   136,   137,   138,   139,
+     140,   141,    -1,    33,   144,   145,   146,   147,   148,   149,
+     150,  1155,    -1,    -1,    -1,    -1,   190,    -1,    -1,    -1,
+     194,    -1,   196,   197,    -1,    -1,    -1,    -1,    -1,    -1,
+      60,    61,    -1,  1177,  1178,  1179,    -1,    -1,   212,  1183,
+      -1,    -1,    -1,    -1,   218,    -1,    -1,  1191,  1192,   189,
+     190,    -1,   192,   193,   194,   195,   196,   197,   198,   199,
+     200,   201,    -1,    -1,    -1,    -1,    -1,    -1,  1212,    13,
+      -1,   211,   212,  1217,  1218,    19,   216,   217,    -1,    -1,
+    1224,    25,    33,    -1,    -1,    -1,    -1,    31,  1232,    -1,
+      -1,    -1,    -1,    -1,   124,    -1,    -1,    41,   128,    -1,
+      -1,    -1,    -1,    -1,  1248,    49,  1250,    -1,    -1,    60,
+      61,  1255,    -1,    -1,    -1,    -1,    -1,  1261,    -1,    -1,
+      64,  1265,    -1,    -1,    -1,    -1,    -1,    71,    72,    73,
+      74,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    92,    93,
+      94,    95,    96,    97,    98,    99,   100,   101,   102,   103,
+     190,    -1,    -1,  1307,   194,    -1,   196,   197,    -1,    -1,
+      -1,    -1,    -1,   124,    -1,    -1,    -1,   128,    -1,    21,
+      22,    -1,   212,  1327,    -1,    -1,    -1,    -1,   218,  1339,
+      -1,   743,   744,   745,   746,   747,   748,   749,    -1,   143,
+      -1,    -1,    -1,   755,   756,    -1,    -1,    -1,    -1,   761,
+      -1,    -1,   156,    -1,    -1,    -1,    -1,    -1,   770,   771,
+      -1,    -1,    33,   775,   776,   777,   170,   779,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,
+      -1,    -1,    -1,   194,    -1,   196,   197,    -1,    -1,    60,
+      61,    -1,    33,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+    1404,   212,  1406,    -1,    -1,    -1,    -1,   218,  1412,    -1,
+      -1,    33,   216,    -1,   116,   117,   118,   119,   120,    60,
+      61,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,  1436,    -1,   136,  1439,   138,   139,    60,    61,
+      -1,    -1,   144,  1447,  1448,  1449,    -1,    -1,    -1,    -1,
+    1454,    -1,    -1,   124,    -1,  1459,    -1,   128,    -1,  1463,
+    1464,  1465,  1466,    -1,    -1,  1469,  1470,    -1,  1472,  1473,
+      -1,    -1,    -1,    -1,    -1,    -1,  1480,    -1,    -1,    -1,
+      -1,    -1,    -1,   124,    -1,    -1,    -1,   128,    -1,  1493,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,   124,    -1,    -1,    -1,   128,    -1,    -1,   211,
+     212,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,
+      -1,    -1,  1526,   194,    -1,   196,   197,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    33,    -1,  1540,  1541,    -1,    -1,
+      -1,   212,    -1,    -1,    -1,    -1,    -1,   218,    -1,   190,
+    1554,    -1,    -1,   194,    -1,  1559,   197,    -1,    -1,    -1,
+      -1,    60,    61,    -1,    -1,    -1,    -1,  1571,   190,  1573,
+      -1,   212,   194,    -1,   196,   197,    -1,   218,    -1,    -1,
+      -1,    -1,    -1,     1,    -1,  1589,  1590,     5,     6,     7,
+     212,     9,    10,    11,    -1,    13,   218,    15,    16,    17,
+      18,    19,    -1,    -1,    -1,    -1,    -1,    25,    26,    27,
+      28,    29,  1616,    31,    -1,    -1,    -1,  1621,  1622,    -1,
+      38,    39,    -1,    -1,    42,   124,    44,    45,    -1,   128,
+      48,    -1,    50,    51,    52,    -1,    54,    55,    -1,    -1,
+      58,    59,    -1,  1647,    -1,  1649,  1650,    65,    -1,    -1,
+      68,    69,    -1,    71,    72,    73,  1660,    75,    76,    77,
+      78,    79,    80,    81,    82,    83,    84,    85,    86,    87,
+      88,    89,    90,    91,    -1,    93,    94,    95,    -1,    -1,
+      98,    99,   100,   101,   102,   103,   104,   105,    -1,    -1,
+      -1,   190,    -1,    -1,    -1,   194,    -1,   196,   197,    -1,
+     118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   212,    -1,   133,   134,   135,    -1,   218,
+      -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   151,   152,   153,   154,   155,    -1,   157,
+      -1,   159,   160,   161,   162,   163,   164,   165,   166,   167,
+     168,   169,   170,   171,   172,   173,    -1,    -1,    -1,    -1,
+      -1,    33,   180,   181,   182,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,
+     198,   199,    -1,   201,    -1,    -1,   204,   205,    60,    61,
+      -1,    -1,    -1,    -1,   212,    -1,   214,     1,   216,   217,
+      -1,     5,     6,     7,    -1,     9,    10,    11,    -1,    13,
+      -1,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
+      -1,    25,    26,    27,    28,    29,    -1,    31,    -1,    -1,
+      -1,    -1,    -1,    -1,    38,    39,    -1,    -1,    42,    -1,
+      44,    45,    -1,    -1,    48,    -1,    50,    51,    52,    -1,
+      54,    55,   124,    -1,    58,    59,   128,    -1,    -1,    -1,
+      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
+      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
+      94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
+     104,   105,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   118,   119,    -1,    -1,   190,    -1,
+      -1,    -1,   194,    -1,   196,   197,    -1,    -1,    -1,   133,
+     134,   135,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,
+     212,    -1,    -1,    -1,    -1,    -1,   218,   151,   152,   153,
+     154,   155,    -1,   157,    -1,   159,   160,   161,   162,   163,
+     164,   165,   166,   167,   168,   169,   170,   171,   172,   173,
+      -1,    -1,    -1,    -1,    -1,    -1,   180,   181,   182,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   197,   198,   199,    -1,   201,    -1,    -1,
+     204,   205,    -1,    -1,     5,     6,    -1,    -1,   212,    -1,
+     214,    -1,   216,   217,    15,    16,    17,    18,    19,    -1,
+      -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    -1,
+      31,    -1,    33,    -1,    -1,    -1,    -1,    -1,    39,    -1,
+      -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,
+      51,    -1,    53,    -1,    55,    -1,    -1,    -1,    -1,    60,
+      61,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,
+      71,    72,    73,    -1,    75,    76,    77,    78,    79,    80,
+      81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
+      91,    -1,    93,    94,    95,    -1,    -1,    98,    99,   100,
+     101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,
+      -1,    -1,    -1,   124,    -1,    -1,    -1,   128,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     151,   152,   153,   154,   155,    33,   157,   158,   159,   160,
+     161,   162,   163,   164,   165,   166,   167,   168,   169,   170,
+     171,   172,   173,    -1,    -1,    -1,    -1,    -1,    -1,   180,
+      -1,    -1,    60,    61,    -1,    -1,    -1,    -1,    -1,   190,
+      -1,    -1,    -1,   194,    -1,    -1,   197,   198,   199,    -1,
+     201,    -1,    -1,   204,   205,    -1,    -1,    -1,     5,     6,
+      -1,   212,    -1,   214,    -1,   216,   217,   218,    15,    16,
+      17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,
+      27,    -1,    -1,    -1,    31,    -1,    33,    -1,    -1,    -1,
+      -1,    -1,    39,    -1,    -1,    -1,   124,    -1,    45,    -1,
+     128,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,
+      -1,    -1,    -1,    60,    61,    -1,    -1,    -1,    65,    -1,
+      -1,    68,    69,    -1,    71,    72,    73,    -1,    75,    76,
+      77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
+      87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
+      -1,    98,    99,   100,   101,   102,   103,   104,    -1,    -1,
+      -1,    -1,   190,    -1,    -1,    -1,   194,    -1,   196,   197,
+      -1,   118,   119,    -1,    -1,    -1,    -1,   124,    -1,    -1,
+      -1,   128,    -1,    -1,   212,    -1,    -1,    -1,    -1,    -1,
+     218,    -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   151,   152,   153,   154,   155,    33,
+     157,   158,   159,   160,   161,   162,   163,   164,   165,   166,
+     167,   168,   169,   170,   171,   172,   173,    -1,    33,    -1,
+      -1,    -1,    -1,   180,    -1,    -1,    60,    61,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,    -1,    -1,   194,    -1,    -1,
+     197,   198,   199,    -1,   201,    60,    61,   204,   205,    -1,
+      -1,    -1,     5,     6,    -1,   212,    -1,   214,    -1,   216,
+     217,   218,    15,    16,    17,    18,    19,    -1,    -1,    -1,
+      -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,
+      33,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,
+     124,    -1,    45,    -1,   128,    48,    -1,    -1,    51,    -1,
+      -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,   124,
+      -1,    -1,    65,   128,    -1,    68,    69,    -1,    71,    72,
+      73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
+      83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
+      93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
+     103,   104,    -1,    -1,    -1,    -1,   190,    -1,    -1,    -1,
+     194,    -1,   196,   197,    -1,   118,   119,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   190,    -1,    -1,   212,   194,
+      -1,   196,   197,    -1,   218,    -1,    -1,    -1,    -1,    -1,
+     143,    -1,    -1,    -1,    -1,    -1,    -1,   212,   151,   152,
+     153,   154,   155,   218,   157,    -1,   159,   160,   161,   162,
+     163,   164,   165,   166,   167,   168,   169,   170,   171,   172,
+     173,    -1,    -1,    -1,    -1,    -1,    -1,   180,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   194,    -1,    -1,   197,   198,   199,    -1,   201,    -1,
+      -1,   204,   205,    -1,    -1,    -1,     5,     6,    -1,   212,
+      -1,   214,    -1,   216,   217,   218,    15,    16,    17,    18,
+      19,    -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,
+      -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,
+      -1,    -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,
+      69,    -1,    71,    72,    73,    -1,    75,    76,    77,    78,
+      79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
+      89,    90,    91,    -1,    93,    94,    95,    -1,    -1,    98,
+      99,   100,   101,   102,   103,   104,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,
+     119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   127,    -1,
+      -1,    -1,    -1,    -1,   133,   134,   135,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   151,   152,   153,   154,   155,    -1,   157,    -1,
+     159,   160,   161,   162,   163,   164,   165,   166,   167,   168,
+     169,   170,   171,   172,   173,    -1,    -1,    -1,    -1,    -1,
+      -1,   180,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,   198,
+     199,    -1,   201,    -1,    -1,   204,   205,    -1,    -1,     5,
+       6,    -1,    -1,   212,    -1,   214,    -1,   216,   217,    15,
+      16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,
+      -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,
+      -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,
+      -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,    75,
+      76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
+      86,    87,    88,    89,    90,    91,    -1,    93,    94,    95,
+      -1,    -1,    98,    99,   100,   101,   102,   103,   104,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   127,    -1,    -1,    -1,    -1,    -1,   133,   134,   135,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   151,   152,   153,   154,   155,
+      -1,   157,    -1,   159,   160,   161,   162,   163,   164,   165,
+     166,   167,   168,   169,   170,   171,   172,   173,    -1,    -1,
+      -1,    -1,    -1,    -1,   180,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   197,   198,   199,    -1,   201,    -1,    -1,   204,   205,
+      -1,    -1,     5,     6,    -1,    -1,   212,    -1,   214,    -1,
+     216,   217,    15,    16,    17,    18,    19,    -1,    -1,    -1,
+      -1,    -1,    25,    26,    27,    28,    -1,    -1,    31,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,
+      -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,    52,
+      -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,
+      73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
+      83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
+      93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
+     103,   104,   105,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     143,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   151,   152,
+     153,   154,   155,    -1,   157,    -1,   159,   160,   161,   162,
+     163,   164,   165,   166,   167,   168,   169,   170,   171,   172,
+     173,    -1,    -1,    -1,    -1,    -1,    -1,   180,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   197,   198,   199,    -1,   201,    -1,
+      -1,   204,   205,    -1,    -1,     5,     6,    -1,    -1,   212,
+      -1,   214,    -1,   216,   217,    15,    16,    17,    18,    19,
+      -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,
+      -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,
+      -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,
+      -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,
+      -1,    71,    72,    73,    -1,    75,    76,    77,    78,    79,
+      80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
+      90,    91,    -1,    93,    94,    95,    -1,    -1,    98,    99,
+     100,   101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   133,   134,   135,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   151,   152,   153,   154,   155,    -1,   157,    -1,   159,
+     160,   161,   162,   163,   164,   165,   166,   167,   168,   169,
+     170,   171,   172,   173,    -1,    -1,    -1,    -1,    -1,    -1,
+     180,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,   198,   199,
+      -1,   201,    -1,    -1,   204,   205,    -1,    -1,     5,     6,
+      -1,    -1,   212,    -1,   214,    -1,   216,   217,    15,    16,
+      17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,
+      27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,
+      -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,
+      -1,    68,    69,    70,    71,    72,    73,    -1,    75,    76,
+      77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
+      87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
+      -1,    98,    99,   100,   101,   102,   103,   104,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   151,   152,   153,   154,   155,    -1,
+     157,   158,   159,   160,   161,   162,   163,   164,   165,   166,
+     167,   168,   169,   170,   171,   172,   173,    -1,    -1,    -1,
+      -1,    -1,    -1,   180,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     197,   198,   199,    -1,   201,    -1,    -1,   204,   205,    -1,
+      -1,     5,     6,    -1,    -1,   212,    -1,   214,   215,   216,
+     217,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
+      -1,    25,    -1,    27,    -1,    -1,    33,    31,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
+      -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,
+      -1,    55,    -1,    60,    61,    -1,    -1,    -1,    -1,    -1,
+      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
+      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
+      94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
+     104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   118,   119,    -1,   124,    -1,    -1,
+      -1,   128,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   133,
+     134,   135,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   151,   152,   153,
+     154,   155,    33,   157,    -1,   159,   160,   161,   162,   163,
+     164,   165,   166,   167,   168,   169,   170,   171,   172,   173,
+      -1,    -1,    -1,    -1,    -1,    -1,   180,    -1,    -1,    60,
+      61,    -1,    -1,   190,    -1,    -1,    -1,   194,    -1,   196,
+     197,    -1,    -1,   197,   198,   199,    -1,   201,    -1,    -1,
+     204,   205,    -1,    -1,    -1,   212,     5,     6,   212,    -1,
+     214,   218,   216,   217,    13,    -1,    15,    16,    17,    18,
+      19,    -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,
+      -1,    33,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      39,    -1,    -1,   124,    -1,    -1,    45,   128,    -1,    48,
+      49,    -1,    51,    -1,    -1,    -1,    55,    -1,    60,    61,
+      -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,
+      69,    -1,    71,    72,    73,    -1,    75,    76,    77,    78,
+      79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
+      89,    90,    91,    -1,    93,    94,    95,    -1,    -1,    98,
+      99,   100,   101,   102,   103,   104,    -1,    -1,    -1,   190,
+      -1,    -1,    -1,   194,    -1,   196,   197,    -1,    -1,   118,
+     119,    -1,   124,    -1,    -1,    -1,   128,    -1,    -1,    -1,
+      -1,   212,    -1,    -1,    -1,    -1,    -1,   218,    -1,    -1,
+      -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   151,   152,   153,   154,   155,    -1,   157,    -1,
+     159,   160,   161,   162,   163,   164,   165,   166,   167,   168,
+     169,   170,   171,   172,   173,    -1,    -1,    -1,    -1,    -1,
+      -1,   180,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+      -1,    -1,   194,    -1,   196,   197,    -1,    -1,   197,   198,
+     199,    -1,   201,    -1,    -1,   204,   205,    -1,    -1,    -1,
+     212,     5,     6,   212,   213,   214,   218,   216,   217,    13,
+      -1,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
+      -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
+      -1,    45,    -1,    -1,    48,    49,    -1,    51,    -1,    -1,
+      -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
+      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
+      94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
+     104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   151,   152,   153,
+     154,   155,    -1,   157,   158,   159,   160,   161,   162,   163,
+     164,   165,   166,   167,   168,   169,   170,   171,   172,   173,
+      -1,    -1,    -1,    -1,    -1,    -1,   180,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   197,   198,   199,    -1,   201,    -1,    -1,
+     204,   205,    -1,    -1,    -1,    -1,     5,     6,   212,    -1,
+     214,    -1,   216,   217,    13,    -1,    15,    16,    17,    18,
+      19,    -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,
+      -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,
+      49,    -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,
+      69,    -1,    71,    72,    73,    -1,    75,    76,    77,    78,
+      79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
+      89,    90,    91,    -1,    93,    94,    95,    -1,    -1,    98,
+      99,   100,   101,   102,   103,   104,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,
+     119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   151,   152,   153,   154,   155,    -1,   157,    -1,
+     159,   160,   161,   162,   163,   164,   165,   166,   167,   168,
+     169,   170,   171,   172,   173,    -1,    -1,    -1,    -1,    -1,
+      -1,   180,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,   198,
+     199,    -1,   201,    -1,    -1,   204,   205,    -1,    -1,    -1,
+      -1,     5,     6,   212,   213,   214,    -1,   216,   217,    13,
+      -1,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
+      -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
+      -1,    45,    -1,    -1,    48,    49,    -1,    51,    -1,    -1,
+      -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
+      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
+      94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
+     104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   151,   152,   153,
+     154,   155,    -1,   157,    -1,   159,   160,   161,   162,   163,
+     164,   165,   166,   167,   168,   169,   170,   171,   172,   173,
+      -1,    -1,    -1,    -1,    -1,    -1,   180,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   197,   198,   199,    -1,   201,    -1,    -1,
+     204,   205,    -1,    -1,     5,     6,    -1,    -1,   212,    -1,
+     214,    -1,   216,   217,    15,    16,    17,    18,    19,    -1,
+      -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    -1,
+      31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,
+      -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,
+      51,    -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,    70,
+      71,    72,    73,    -1,    75,    76,    77,    78,    79,    80,
+      81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
+      91,    -1,    93,    94,    95,    -1,    -1,    98,    99,   100,
+     101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     151,   152,   153,   154,   155,    -1,   157,   158,   159,   160,
+     161,   162,   163,   164,   165,   166,   167,   168,   169,   170,
+     171,   172,   173,    -1,    -1,    -1,    -1,    -1,    -1,   180,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   197,   198,   199,    -1,
+     201,    -1,    -1,   204,   205,    -1,    -1,     5,     6,    -1,
+      -1,   212,    -1,   214,    -1,   216,   217,    15,    16,    17,
+      18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,    27,
+      -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,
+      48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,
+      68,    69,    -1,    71,    72,    73,    -1,    75,    76,    77,
+      78,    79,    80,    81,    82,    83,    84,    85,    86,    87,
+      88,    89,    90,    91,    -1,    93,    94,    95,    -1,    -1,
+      98,    99,   100,   101,   102,   103,   104,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   151,   152,   153,   154,   155,    -1,   157,
+      -1,   159,   160,   161,   162,   163,   164,   165,   166,   167,
+     168,   169,   170,   171,   172,   173,    -1,    -1,    -1,    -1,
+      -1,    -1,   180,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,
+     198,   199,    -1,   201,    -1,    -1,   204,   205,    -1,    -1,
+       5,     6,    -1,    -1,   212,   213,   214,    -1,   216,   217,
+      15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,
+      25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,
+      45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,
+      55,    -1,    -1,    -1,    -1,    -1,    61,    -1,    -1,    -1,
+      65,    -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
+      85,    86,    87,    88,    89,    90,    91,    -1,    93,    94,
+      95,    -1,    -1,    98,    99,   100,   101,   102,   103,   104,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   151,   152,   153,   154,
+     155,    -1,   157,    -1,   159,   160,   161,   162,   163,   164,
+     165,   166,   167,   168,   169,   170,   171,   172,   173,    -1,
+      -1,    -1,    -1,    -1,    -1,   180,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   197,   198,   199,    -1,   201,    -1,    -1,   204,
+     205,    -1,    -1,     5,     6,    -1,    -1,   212,    -1,   214,
+      -1,   216,   217,    15,    16,    17,    18,    19,    -1,    -1,
+      -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,
+      -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,
+      -1,    -1,    -1,    55,    -1,    -1,    58,    -1,    -1,    -1,
+      -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,
+      72,    73,    -1,    75,    76,    77,    78,    79,    80,    81,
+      82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
+      -1,    93,    94,    95,    -1,    -1,    98,    99,   100,   101,
+     102,   103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   143,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   151,
+     152,   153,   154,   155,    -1,   157,    -1,   159,   160,   161,
+     162,   163,   164,   165,   166,   167,   168,   169,   170,   171,
+     172,   173,    -1,    -1,    -1,    -1,    -1,    -1,   180,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   197,   198,   199,    -1,   201,
+      -1,    -1,   204,   205,    -1,    -1,    -1,    -1,     5,     6,
+     212,    -1,   214,    -1,   216,   217,    13,    -1,    15,    16,
+      17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,
+      27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,
+      -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,
+      -1,    68,    69,    -1,    71,    72,    73,    -1,    75,    76,
+      77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
+      87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
+      -1,    98,    99,   100,   101,   102,   103,   104,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   151,   152,   153,   154,   155,    -1,
+     157,    -1,   159,   160,   161,   162,   163,   164,   165,   166,
+     167,   168,   169,   170,   171,   172,   173,    -1,    -1,    -1,
+      -1,    -1,    -1,   180,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     197,   198,   199,    -1,   201,    -1,    -1,   204,   205,    -1,
+      -1,     5,     6,    -1,    -1,   212,    -1,   214,    -1,   216,
+     217,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
+      -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
+      -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,
+      -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
+      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
+      94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
+     104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   151,   152,   153,
+     154,   155,    -1,   157,    -1,   159,   160,   161,   162,   163,
+     164,   165,   166,   167,   168,   169,   170,   171,   172,   173,
+      -1,    -1,    -1,    -1,    -1,    -1,   180,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   195,    -1,   197,   198,   199,    -1,   201,    -1,    -1,
+     204,   205,    -1,    -1,    -1,    -1,     5,     6,   212,    -1,
+     214,    -1,   216,   217,    13,    -1,    15,    16,    17,    18,
+      19,    -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,
+      -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,
+      -1,    -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,
+      69,    -1,    71,    72,    73,    -1,    75,    76,    77,    78,
+      79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
+      89,    90,    91,    -1,    93,    94,    95,    -1,    -1,    98,
+      99,   100,   101,   102,   103,   104,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,
+     119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   151,   152,   153,   154,   155,    -1,   157,    -1,
+     159,   160,   161,   162,   163,   164,   165,   166,   167,   168,
+     169,   170,   171,   172,   173,    -1,    -1,    -1,    -1,    -1,
+      -1,   180,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,   198,
+     199,    -1,   201,    -1,    -1,   204,   205,    -1,    -1,     5,
+       6,    -1,    -1,   212,    -1,   214,    -1,   216,   217,    15,
+      16,    17,    18,    19,    -1,    -1,    22,    -1,    -1,    25,
+      -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,
+      -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,
+      -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,    75,
+      76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
+      86,    87,    88,    89,    90,    91,    -1,    93,    94,    95,
+      -1,    -1,    98,    99,   100,   101,   102,   103,   104,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   151,   152,   153,   154,   155,
+      -1,   157,    -1,   159,   160,   161,   162,   163,   164,   165,
+     166,   167,   168,   169,   170,   171,   172,   173,    -1,    -1,
+      -1,    -1,    -1,    -1,   180,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   197,   198,   199,    -1,   201,    -1,    -1,   204,   205,
+      -1,    -1,     5,     6,    -1,    -1,   212,    -1,   214,    -1,
+     216,   217,    15,    16,    17,    18,    19,    -1,    -1,    -1,
+      -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,
+      -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,
+      -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,
+      73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
+      83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
+      93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
+     103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     143,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   151,   152,
+     153,   154,   155,    -1,   157,    -1,   159,   160,   161,   162,
+     163,   164,   165,   166,   167,   168,   169,   170,   171,   172,
+     173,    -1,    -1,    -1,    -1,    -1,    -1,   180,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   197,   198,   199,    -1,   201,    -1,
+      -1,   204,   205,    -1,    -1,     5,     6,    -1,    -1,   212,
+      -1,   214,   215,   216,   217,    15,    16,    17,    18,    19,
+      -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,
+      -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,
+      -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,
+      -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,
+      -1,    71,    72,    73,    -1,    75,    76,    77,    78,    79,
+      80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
+      90,    91,    -1,    93,    94,    95,    -1,    -1,    98,    99,
+     100,   101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   151,   152,   153,   154,   155,    -1,   157,    -1,   159,
+     160,   161,   162,   163,   164,   165,   166,   167,   168,   169,
+     170,   171,   172,   173,    -1,    -1,    -1,    -1,    -1,    -1,
+     180,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   195,    -1,   197,   198,   199,
+      -1,   201,    -1,    -1,   204,   205,    -1,    -1,     5,     6,
+      -1,    -1,   212,    -1,   214,    -1,   216,   217,    15,    16,
+      17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,
+      27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,
+      -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,
+      -1,    68,    69,    -1,    71,    72,    73,    -1,    75,    76,
+      77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
+      87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
+      -1,    98,    99,   100,   101,   102,   103,   104,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   151,   152,   153,   154,   155,    -1,
+     157,    -1,   159,   160,   161,   162,   163,   164,   165,   166,
+     167,   168,   169,   170,   171,   172,   173,    -1,    -1,    -1,
+      -1,    -1,    -1,   180,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     197,   198,   199,    -1,   201,    -1,    -1,   204,   205,    -1,
+      -1,     5,     6,    -1,    -1,   212,    -1,   214,   215,   216,
+     217,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
+      -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
+      -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,
+      -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
+      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
+      94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
+     104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   151,   152,   153,
+     154,   155,    -1,   157,    -1,   159,   160,   161,   162,   163,
+     164,   165,   166,   167,   168,   169,   170,   171,   172,   173,
+      -1,    -1,    -1,    -1,    -1,    -1,   180,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   197,   198,   199,    -1,   201,    -1,    -1,
+     204,   205,    -1,    -1,     5,     6,    -1,    -1,   212,    -1,
+     214,   215,   216,   217,    15,    16,    17,    18,    19,    -1,
+      -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    -1,
+      31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,
+      -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,
+      51,    -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,
+      71,    72,    73,    -1,    75,    76,    77,    78,    79,    80,
+      81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
+      91,    -1,    93,    94,    95,    -1,    -1,    98,    99,   100,
+     101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     151,   152,   153,   154,   155,    -1,   157,    -1,   159,   160,
+     161,   162,   163,   164,   165,   166,   167,   168,   169,   170,
+     171,   172,   173,    -1,    -1,    -1,    -1,    -1,    -1,   180,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   197,   198,   199,    -1,
+     201,    -1,    -1,   204,   205,    -1,    -1,     5,     6,    -1,
+      -1,   212,    -1,   214,   215,   216,   217,    15,    16,    17,
+      18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,    27,
+      -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,
+      48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,
+      68,    69,    -1,    71,    72,    73,    -1,    75,    76,    77,
+      78,    79,    80,    81,    82,    83,    84,    85,    86,    87,
+      88,    89,    90,    91,    -1,    93,    94,    95,    -1,    -1,
+      98,    99,   100,   101,   102,   103,   104,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   151,   152,   153,   154,   155,    -1,   157,
+      -1,   159,   160,   161,   162,   163,   164,   165,   166,   167,
+     168,   169,   170,   171,   172,   173,    -1,    -1,    -1,    -1,
+      -1,    -1,   180,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,
+     198,   199,    -1,   201,    -1,    -1,   204,   205,    -1,    -1,
+       5,     6,    -1,    -1,   212,    -1,   214,   215,   216,   217,
+      15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,
+      25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,
+      45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,
+      55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      65,    -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
+      85,    86,    87,    88,    89,    90,    91,    -1,    93,    94,
+      95,    -1,    -1,    98,    99,   100,   101,   102,   103,   104,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   151,   152,   153,   154,
+     155,    -1,   157,    -1,   159,   160,   161,   162,   163,   164,
+     165,   166,   167,   168,   169,   170,   171,   172,   173,    -1,
+      -1,    -1,    -1,    -1,    -1,   180,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   197,   198,   199,    -1,   201,    -1,    -1,   204,
+     205,    -1,    -1,     5,     6,    -1,    -1,   212,    -1,   214,
+     215,   216,   217,    15,    16,    17,    18,    19,    -1,    -1,
+      -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,
+      -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,
+      -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,
+      72,    73,    -1,    75,    76,    77,    78,    79,    80,    81,
+      82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
+      -1,    93,    94,    95,    -1,    -1,    98,    99,   100,   101,
+     102,   103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   143,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   151,
+     152,   153,   154,   155,    -1,   157,    -1,   159,   160,   161,
+     162,   163,   164,   165,   166,   167,   168,   169,   170,   171,
+     172,   173,    -1,    -1,    -1,    -1,    -1,    -1,   180,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   197,   198,   199,    -1,   201,
+      -1,    -1,   204,   205,    -1,    -1,     5,     6,    -1,    -1,
+     212,    -1,   214,   215,   216,   217,    15,    16,    17,    18,
+      19,    -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,
+      -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,
+      -1,    -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,
+      69,    -1,    71,    72,    73,    -1,    75,    76,    77,    78,
+      79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
+      89,    90,    91,    -1,    93,    94,    95,    -1,    -1,    98,
+      99,   100,   101,   102,   103,   104,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,
+     119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   151,   152,   153,   154,   155,    -1,   157,    -1,
+     159,   160,   161,   162,   163,   164,   165,   166,   167,   168,
+     169,   170,   171,   172,   173,    -1,    -1,    -1,    -1,    -1,
+      -1,   180,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,   198,
+     199,    -1,   201,    -1,    -1,   204,   205,    -1,    -1,     5,
+       6,    -1,    -1,   212,    -1,   214,   215,   216,   217,    15,
+      16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,
+      -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,
+      -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,
+      -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,    75,
+      76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
+      86,    87,    88,    89,    90,    91,    -1,    93,    94,    95,
+      -1,    -1,    98,    99,   100,   101,   102,   103,   104,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   151,   152,   153,   154,   155,
+      -1,   157,    -1,   159,   160,   161,   162,   163,   164,   165,
+     166,   167,   168,   169,   170,   171,   172,   173,    -1,    -1,
+      -1,    -1,    -1,    -1,   180,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   197,   198,   199,    -1,   201,    -1,    -1,   204,   205,
+      -1,    -1,     5,     6,    -1,    -1,   212,    -1,   214,    -1,
+     216,   217,    15,    16,    17,    18,    19,    -1,    -1,    -1,
+      -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,
+      -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,
+      -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,
+      73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
+      83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
+      93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
+     103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     143,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   151,   152,
+     153,   154,   155,    -1,   157,    -1,   159,   160,   161,   162,
+     163,   164,   165,   166,   167,   168,   169,   170,   171,   172,
+     173,    -1,    -1,    -1,    -1,    -1,    -1,   180,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   197,   198,   199,    -1,   201,    -1,
+      -1,   204,   205,    -1,    -1,     5,     6,    -1,    -1,   212,
+      -1,   214,    -1,   216,   217,    15,    16,    17,    18,    19,
+      -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,
+      -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,
+      -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,
+      -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,
+      -1,    71,    72,    73,    -1,    75,    76,    77,    78,    79,
+      80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
+      90,    91,    -1,    93,    94,    95,    -1,    -1,    98,    99,
+     100,   101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   127,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   151,   152,   153,   154,   155,    -1,   157,    -1,   159,
+     160,   161,   162,   163,   164,   165,   166,   167,   168,   169,
+     170,   171,   172,   173,    -1,    -1,    -1,    -1,    -1,    -1,
+     180,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,   198,   199,
+      -1,   201,    -1,    -1,   204,   205,    -1,    -1,     5,     6,
+      -1,    -1,   212,    -1,   214,    -1,   216,   217,    15,    16,
+      17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,
+      27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,
+      -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,
+      -1,    68,    69,    -1,    71,    72,    73,    -1,    75,    76,
+      77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
+      87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
+      -1,    98,    99,   100,   101,   102,   103,   104,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   151,   152,   153,   154,   155,    -1,
+     157,    -1,   159,   160,   161,   162,   163,   164,   165,   166,
+     167,   168,   169,   170,   171,   172,   173,    -1,    -1,    -1,
+      -1,    -1,    -1,   180,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     197,   198,   199,    -1,   201,    -1,    -1,   204,   205,    -1,
+      -1,     5,     6,    -1,    -1,   212,    -1,   214,    -1,   216,
+     217,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
+      -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
+      -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,
+      -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
+      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
+      94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
+     104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   151,   152,   153,
+     154,   155,    -1,   157,    -1,   159,   160,   161,   162,   163,
+     164,   165,   166,   167,   168,   169,   170,   171,   172,   173,
+      -1,    13,    12,    -1,    -1,    -1,   180,    19,    -1,    -1,
+      -1,    21,    22,    25,    -1,    -1,    -1,    -1,    -1,    31,
+      -1,    -1,    -1,   197,   198,   199,    -1,   201,    -1,    41,
+     204,   205,    -1,    -1,    -1,    -1,    -1,    49,   212,    -1,
+     214,    -1,   216,   217,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    64,    -1,    -1,    -1,    -1,    -1,    -1,    71,
+      72,    73,    74,    75,    76,    77,    78,    79,    80,    81,
+      82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
+      92,    93,    94,    95,    96,    97,    98,    99,   100,   101,
+     102,   103,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   116,   117,   118,   119,
+     120,    -1,    -1,   123,   124,   125,   126,    -1,   128,   129,
+     130,   131,    -1,    -1,    -1,    -1,   136,    -1,   138,   139,
+      -1,   143,    -1,    -1,   144,   145,   146,    -1,    -1,    -1,
+     150,    -1,    -1,    -1,   156,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   170,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     190,    -1,   192,   193,   194,   195,   196,   197,   198,   199,
+     200,   201,    -1,    19,    -1,    -1,    -1,    -1,    -1,    25,
+      -1,   211,   212,    -1,   216,    31,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    41,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    49,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    64,    -1,
+      -1,    -1,    -1,    -1,    -1,    71,    72,    73,    74,    75,
+      76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
+      86,    87,    88,    89,    90,    91,    92,    93,    94,    95,
+      96,    97,    98,    99,   100,   101,   102,   103,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    19,    -1,    -1,    -1,    -1,    -1,    25,
+      -1,    -1,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    41,    -1,   143,    -1,    -1,
+      -1,    -1,    -1,    49,    -1,    -1,    -1,    -1,    -1,    -1,
+     156,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    64,    -1,
+      -1,    -1,    -1,    -1,   170,    71,    72,    73,    74,    75,
+      76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
+      86,    87,    88,    89,    90,    91,    92,    93,    94,    95,
+      96,    97,    98,    99,   100,   101,   102,   103,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     216,    -1,   218,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   143,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     156,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    19,
+      -1,    -1,    -1,    -1,   170,    25,    -1,    -1,    -1,    -1,
+      -1,    31,    -1,    -1,    -1,    -1,   182,    -1,    -1,    -1,
+      -1,    41,   188,    -1,    -1,    -1,    -1,    -1,    -1,    49,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    64,    -1,    -1,    -1,    -1,    -1,
+     216,    71,    72,    73,    74,    75,    76,    77,    78,    79,
+      80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
+      90,    91,    92,    93,    94,    95,    96,    97,    98,    99,
+     100,   101,   102,   103,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    19,
+      -1,    -1,    -1,    -1,    -1,    25,    -1,    -1,    -1,    -1,
+      -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    41,    -1,   143,    -1,    -1,    -1,    -1,    -1,    49,
+      -1,    -1,    -1,    -1,    -1,    -1,   156,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    64,    -1,    -1,    -1,    -1,    -1,
+     170,    71,    72,    73,    74,    75,    76,    77,    78,    79,
+      80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
+      90,    91,    92,    93,    94,    95,    96,    97,    98,    99,
+     100,   101,   102,   103,    21,    22,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   216,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   143,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   156,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     170,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   108,   109,   110,   111,   112,   113,   114,   115,   116,
+     117,   118,   119,   120,   121,   122,   123,   124,   125,   126,
+     127,   128,   129,   130,   131,   132,   216,    21,    22,   136,
+     137,   138,   139,   140,   141,    -1,    -1,   144,   145,   146,
+     147,   148,   149,   150,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   189,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,    -1,   216,
+     217,    -1,    -1,    -1,   108,   109,   110,   111,   112,   113,
+     114,   115,   116,   117,   118,   119,   120,   121,   122,   123,
+     124,   125,   126,   127,   128,   129,   130,   131,    21,    22,
+      -1,    -1,   136,   137,   138,   139,   140,   141,    -1,    -1,
+     144,   145,   146,   147,   148,   149,   150,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    21,    22,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,    -1,
+      -1,    -1,    -1,    -1,    -1,   189,   190,    -1,   192,   193,
+     194,   195,   196,   197,   198,   199,   200,   201,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,   212,    -1,
+      -1,    -1,   216,   217,    -1,   108,   109,   110,   111,   112,
+     113,   114,   115,   116,   117,   118,   119,   120,   121,   122,
+     123,   124,   125,   126,   127,   128,   129,   130,   131,    -1,
+      -1,    -1,    -1,   136,   137,   138,   139,   140,   141,    -1,
+      -1,   144,   145,   146,   147,   148,   149,   150,   116,   117,
+     118,   119,   120,    -1,    -1,   123,   124,   125,   126,    -1,
+     128,   129,   130,   131,    21,    22,    -1,    -1,   136,    -1,
+     138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,   182,
+      -1,    -1,   150,    -1,    -1,    -1,   189,   190,    -1,   192,
+     193,   194,   195,   196,   197,   198,   199,   200,   201,    21,
+      22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,   212,
+      -1,    -1,    -1,   216,   217,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   190,    -1,   192,   193,   194,   195,   196,   197,
+     198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   211,   212,    -1,    -1,    -1,   216,   217,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   116,
+     117,   118,   119,   120,    -1,    -1,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,    -1,    21,    22,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,   116,   117,   118,   119,   120,    -1,
+      -1,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,    -1,    21,
+      22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,   116,
+     117,   118,   119,   120,    -1,    -1,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,    -1,    21,    22,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,   116,   117,   118,   119,   120,    -1,
+      -1,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,    -1,    21,
+      22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,   116,
+     117,   118,   119,   120,    -1,    -1,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,    -1,    21,    22,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,   116,   117,   118,   119,   120,    -1,
+      -1,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,    -1,    21,
+      22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,   116,
+     117,   118,   119,   120,    -1,    -1,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,    -1,    21,    22,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,   116,   117,   118,   119,   120,    -1,
+      -1,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,    -1,    21,
+      22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,   116,
+     117,   118,   119,   120,    -1,    -1,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,    -1,    21,    22,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,   116,   117,   118,   119,   120,    -1,
+      -1,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,    -1,    21,
+      22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,   116,
+     117,   118,   119,   120,    -1,    -1,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,   215,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,    -1,    -1,   215,   116,   117,   118,   119,   120,    21,
+      22,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,    -1,
+      -1,    -1,    -1,    -1,    21,    22,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,   213,    -1,    -1,   116,   117,   118,   119,   120,    -1,
+      -1,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,   213,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,   213,    -1,    -1,   116,
+     117,   118,   119,   120,    21,    22,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,    -1,    21,
+      22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,   213,    -1,    -1,   116,
+     117,   118,   119,   120,    -1,    -1,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,   146,
+      -1,    -1,    -1,   150,   116,   117,   118,   119,   120,    -1,
+      -1,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+      21,    22,    -1,    -1,   136,    -1,   138,   139,    -1,    -1,
+      -1,    -1,   144,   145,   146,    -1,    -1,    38,   150,    -1,
+      -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,   196,
+     197,   198,   199,   200,   201,    21,    22,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,   213,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,    -1,
+     192,   193,   194,   195,   196,   197,   198,   199,   200,   201,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   211,
+     212,   213,    -1,    -1,    -1,    -1,    -1,   108,   109,   110,
+     111,   112,   113,   114,   115,   116,   117,   118,   119,   120,
+     121,   122,   123,   124,   125,    -1,    -1,   128,   129,   130,
+      -1,    -1,    -1,    -1,    -1,    -1,   137,   138,   139,   140,
+     141,    -1,    -1,   144,   145,   146,   147,   148,   149,   150,
+     116,   117,   118,   119,   120,    21,    22,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,
+     136,    -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,
+     146,    -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,   190,
+      -1,   192,   193,   194,   195,   196,   197,   198,   199,   200,
+     201,    -1,    -1,   204,   205,    -1,    -1,    -1,    -1,    -1,
+     211,   212,    -1,    -1,   180,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,
+     196,   197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   211,   212,    -1,    -1,    -1,
+     116,   117,   118,   119,   120,    21,    22,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,
+     136,    -1,   138,   139,    -1,    -1,   142,    -1,   144,   145,
+     146,    -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,    -1,
+      21,    22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,
+     196,   197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   211,   212,    -1,    -1,    -1,
+     116,   117,   118,   119,   120,    -1,    -1,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,
+     136,    -1,   138,   139,    -1,    -1,   142,    -1,   144,   145,
+     146,    -1,    -1,    -1,   150,   116,   117,   118,   119,   120,
+      21,    22,   123,   124,   125,   126,    -1,   128,   129,   130,
+     131,    -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,
+      -1,    -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,
+      -1,    -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,
+     196,   197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   211,   212,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,
+     191,   192,   193,   194,   195,   196,   197,   198,   199,   200,
+     201,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     211,   212,    -1,    -1,    -1,   116,   117,   118,   119,   120,
+      21,    22,   123,   124,   125,   126,    -1,   128,   129,   130,
+     131,    -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,
+      -1,    -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,
+      -1,    -1,    -1,    -1,    -1,    21,    22,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   182,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,
+      -1,   192,   193,   194,   195,   196,   197,   198,   199,   200,
+     201,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     211,   212,    -1,    -1,    -1,   116,   117,   118,   119,   120,
+      -1,    -1,   123,   124,   125,   126,    -1,   128,   129,   130,
+     131,    -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,
+      -1,    -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,
+     116,   117,   118,   119,   120,    21,    22,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,
+     136,    -1,   138,   139,    -1,    -1,    -1,   178,   144,   145,
+     146,    -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,   190,
+      -1,   192,   193,   194,   195,   196,   197,   198,   199,   200,
+     201,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     211,   212,    -1,    -1,    -1,    -1,   182,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,
+     196,   197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   211,   212,    -1,    -1,    -1,
+     116,   117,   118,   119,   120,    21,    22,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,
+     136,    -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,
+     146,    -1,    -1,    -1,   150,    -1,    -1,    -1,    -1,    -1,
+      21,    22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   182,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,
+     196,   197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   211,   212,    -1,    -1,    -1,
+     116,   117,   118,   119,   120,    -1,    -1,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,
+     136,    -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,
+     146,    -1,    -1,    -1,   150,   116,   117,   118,   119,   120,
+      21,    22,   123,   124,   125,   126,    -1,   128,   129,   130,
+     131,    -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,
+      -1,    -1,    -1,   144,   145,   146,   182,    -1,    -1,   150,
+      -1,    -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,
+     196,   197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   211,   212,    -1,    -1,    -1,
+      -1,   182,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,
+      -1,   192,   193,   194,   195,   196,   197,   198,   199,   200,
+     201,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     211,   212,    -1,    -1,    -1,   116,   117,   118,   119,   120,
+      21,    22,   123,   124,   125,   126,    -1,   128,   129,   130,
+     131,    -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,
+      -1,    -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,
+      -1,    -1,    -1,    -1,    -1,    21,    22,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   182,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   190,
+      -1,   192,   193,   194,   195,   196,   197,   198,   199,   200,
+     201,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     211,   212,    -1,    -1,    -1,   116,   117,   118,   119,   120,
+      -1,    -1,   123,   124,   125,   126,    -1,   128,   129,   130,
+     131,    -1,    -1,    -1,    -1,   136,    -1,   138,   139,    -1,
+      -1,    -1,    -1,   144,   145,   146,    -1,    -1,    -1,   150,
+     116,   117,   118,   119,   120,    21,    22,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,
+     136,    -1,   138,   139,    -1,    -1,    -1,    -1,   144,   145,
+     146,    -1,    -1,    -1,   150,    -1,    21,    22,    -1,   190,
+      -1,   192,   193,   194,   195,   196,   197,   198,   199,   200,
+     201,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     211,   212,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,
+     196,   197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   211,   212,    -1,    -1,    -1,
+     116,   117,   118,   119,   120,    -1,    -1,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,
+     136,    -1,   138,   139,    -1,    -1,    21,    22,   144,   145,
+     146,   116,   117,   118,   119,   120,    -1,    -1,   123,   124,
+     125,   126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,
+      -1,   136,    -1,   138,   139,    21,    22,    -1,    -1,   144,
+      -1,   146,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   190,    -1,   192,   193,   194,   195,
+     196,   197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   211,   212,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   192,   193,   194,
+     195,   196,   197,   198,   199,   200,   201,    -1,    -1,    -1,
+      -1,   116,   117,   118,   119,   120,   211,   212,   123,   124,
+     125,   126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,
+      -1,   136,    -1,   138,   139,    21,    22,    -1,    -1,    -1,
+     116,   117,   118,   119,   120,    -1,    -1,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,
+     136,    -1,   138,   139,    21,    22,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   192,   193,   194,
+     195,   196,   197,   198,   199,   200,   201,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   211,   212,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   193,   194,   195,
+     196,   197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,
+     116,   117,   118,   119,   120,   211,   212,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,
+     136,    -1,   138,   139,    -1,    -1,    -1,    -1,    -1,   116,
+     117,   118,   119,   120,    -1,    -1,   123,   124,   125,   126,
+      -1,   128,   129,   130,   131,    -1,    -1,    -1,    -1,   136,
+      -1,   138,   139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    19,    -1,    -1,    -1,   194,   195,
+     196,   197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   211,   212,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    19,    -1,    -1,   195,   196,
+     197,   198,   199,   200,   201,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    71,    72,    73,    -1,
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
+      85,    86,    87,    88,    89,    90,    91,    -1,    93,    94,
+      95,    -1,    -1,    98,    99,   100,   101,    71,    72,    73,
+      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
+      94,    95,    -1,    -1,    98,    99,   100,   101,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    19,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   158,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   170,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   158,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    71,    72,    73,   170,    75,    76,    77,
+      78,    79,    80,    81,    82,    83,    84,    85,    86,    87,
+      88,    89,    90,    91,    -1,    93,    94,    95,    -1,    -1,
+      98,    99,   100,   101,    71,    72,    73,    -1,    75,    76,
+      77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
+      87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
+      -1,    98,    99,   100,   101,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    35,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     158,    -1,   129,   130,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   170,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    71,    -1,    73,    -1,    75,    76,    77,    78,
+      79,   158,    81,    82,    83,    84,    85,    86,    87,    88,
+      89,    90,    91,   170,    93,    94,    95,    -1,    -1,    98,
+      99,   100,   101,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,
+     119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   211,   212,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   170
+};
+
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
+static const yytype_int16 yystos[] =
+{
+       0,   220,     0,     7,    30,    32,    34,    40,    50,    56,
+      80,   102,   103,   182,   201,   212,   221,   224,   230,   232,
+     233,   238,   268,   272,   306,   384,   391,   395,   406,   451,
+     456,   461,    19,    20,   170,   260,   261,   262,   163,   239,
+     240,   170,   171,   172,   201,   234,   235,   236,   180,   392,
+     170,   216,   223,    57,    63,   387,   387,   387,   143,   170,
+     292,    34,    63,   107,   136,   205,   214,   264,   265,   266,
+     267,   292,   182,     5,     6,     8,    36,   107,   403,    62,
+     382,   189,   188,   191,   188,   235,    22,    57,   200,   211,
+     237,   387,   388,   390,   388,   382,   462,   452,   457,   170,
+     143,   231,   266,   266,   266,   214,   144,   145,   146,   188,
+     213,    57,    63,   273,   275,    57,    63,   393,     5,     6,
+      57,    63,   404,    57,    63,   383,    15,    16,   163,   168,
+     170,   173,   214,   226,   261,   163,   240,   170,   234,   234,
+     170,   182,   181,   388,   182,    57,    63,   222,   170,   170,
+     170,   170,   174,   229,   215,   262,   266,   266,   266,   266,
+     276,   170,   394,   407,   180,   385,   174,   175,   176,   225,
+      15,    16,   163,   168,   170,   226,   258,   259,   237,   389,
+     182,   463,   453,   458,   174,   215,    35,    71,    73,    75,
+      76,    77,    78,    79,    81,    82,    83,    84,    85,    86,
+      87,    88,    89,    90,    91,    93,    94,    95,    98,    99,
+     100,   101,   118,   119,   170,   271,   274,   180,   191,   106,
+     401,   402,   380,   160,   217,   263,   356,   174,   175,   176,
+     188,   215,   189,   180,   180,   180,    21,    22,    38,   108,
+     109,   110,   111,   112,   113,   114,   115,   116,   117,   118,
+     119,   120,   121,   122,   123,   124,   125,   128,   129,   130,
+     137,   138,   139,   140,   141,   144,   145,   146,   147,   148,
+     149,   150,   190,   192,   193,   194,   195,   196,   197,   198,
+     199,   200,   201,   204,   205,   211,   212,    35,    35,   214,
+     269,   180,   277,   396,    75,    79,    93,    94,    98,    99,
+     100,   101,   411,   170,   408,   181,   381,   262,   261,   182,
+     217,   152,   170,   378,   379,   258,    19,    25,    31,    41,
+      49,    64,    71,    72,    73,    74,    75,    76,    77,    78,
+      79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
+      89,    90,    91,    92,    93,    94,    95,    96,    97,    98,
+      99,   100,   101,   102,   103,   156,   216,   292,   410,   412,
+     413,   416,   422,   450,   464,   454,   459,   170,   170,   170,
+     213,    22,   170,   213,   155,   215,   356,   366,   367,   191,
+     270,   280,   386,   180,   191,   400,   180,   405,   356,   213,
+     261,   214,    43,   188,   191,   194,   377,   195,   195,   195,
+     214,   195,   195,   214,   195,   195,   195,   195,   195,   195,
+     214,   292,    33,    60,    61,   124,   128,   190,   194,   197,
+     212,   218,   421,   192,   415,   370,   373,   170,   137,   214,
+       7,    50,   305,   182,   215,   450,     1,     5,     6,     9,
+      10,    11,    13,    15,    16,    17,    18,    19,    25,    26,
+      27,    28,    29,    31,    38,    39,    42,    44,    45,    48,
+      51,    52,    54,    55,    58,    59,    65,    68,    69,    80,
+     102,   103,   104,   105,   118,   119,   133,   134,   135,   151,
+     152,   153,   154,   155,   157,   159,   160,   161,   162,   163,
+     164,   165,   166,   167,   168,   169,   171,   172,   173,   180,
+     181,   182,   197,   198,   199,   204,   205,   212,   214,   216,
+     217,   228,   230,   241,   242,   245,   248,   249,   251,   253,
+     254,   255,   256,   278,   279,   281,   286,   291,   292,   293,
+     297,   298,   299,   300,   301,   302,   303,   304,   306,   310,
+     311,   318,   321,   324,   329,   332,   333,   335,   336,   337,
+     339,   344,   347,   348,   355,   410,   466,   481,   492,   496,
+     509,   512,   170,   182,   397,   398,   292,   362,   379,   213,
+      65,   104,   171,   286,   348,   170,   170,   422,   127,   137,
+     189,   376,   423,   428,   430,   348,   432,   426,   170,   417,
+     434,   436,   438,   440,   442,   444,   446,   448,   348,   195,
+     214,    33,   194,    33,   194,   212,   218,   213,   348,   212,
+     218,   422,   170,   182,   465,   170,   182,   188,   368,   419,
+     450,   455,   170,   371,   419,   460,   348,   152,   170,   375,
+     409,   366,   195,   195,   348,   252,   195,   294,   412,   466,
+     214,   292,   195,     5,   102,   103,   195,   214,   127,   291,
+     322,   333,   348,   277,   195,   214,    61,   348,   214,   348,
+     170,   195,   195,   214,   182,   195,   163,    58,   348,   214,
+     277,   195,   214,   195,   195,   214,   195,   195,   127,   291,
+     348,   348,   348,   217,   277,   324,   328,   328,   328,   214,
+     214,   214,   214,   214,   214,    13,   422,    13,   422,    13,
+     348,   491,   507,   195,   348,   195,   227,    13,   491,   508,
+      37,   348,   348,   348,   348,   348,    13,    49,   322,   348,
+     322,   217,   182,   182,   348,    10,   324,   330,   170,   214,
+     182,   182,   182,   182,   182,    66,   307,   268,   132,   182,
+      21,    22,   108,   109,   110,   111,   112,   113,   114,   115,
+     116,   117,   118,   119,   120,   121,   122,   123,   124,   125,
+     126,   127,   128,   129,   130,   131,   136,   137,   138,   139,
+     140,   141,   144,   145,   146,   147,   148,   149,   150,   189,
+     190,   192,   193,   194,   195,   196,   197,   198,   199,   200,
+     201,   211,   212,   330,   214,   182,   189,   181,   386,   181,
+     212,   268,   363,   195,   215,    43,   182,   376,   291,   348,
+     450,   450,   420,   450,   215,   450,   450,   215,   170,   414,
+     450,   269,   450,   269,   450,   269,   368,   369,   371,   372,
+     215,   425,   282,   322,   213,   213,   348,   182,   181,   191,
+     419,   181,   191,   419,   181,   215,   214,    43,   127,   188,
+     189,   191,   194,   374,   482,   484,   277,   409,   295,   214,
+     292,   195,   214,   319,   195,   195,   195,   503,   322,   291,
+     322,   188,   108,   109,   110,   111,   112,   113,   114,   115,
+     121,   122,   127,   140,   141,   147,   148,   149,   189,    14,
+     422,   284,   508,   348,   348,   277,   189,   312,   314,   348,
+     316,   191,   163,   348,   505,   322,   488,   493,   322,   486,
+     422,   291,   348,   217,   268,   348,   348,   348,   348,   348,
+     348,   409,    53,   158,   170,   197,   212,   214,   348,   467,
+     470,   474,   490,   495,   409,   214,   470,   495,   409,   142,
+     181,   182,   183,   475,   287,   277,   289,   176,   177,   225,
+     409,   188,   511,   180,   409,    13,   188,   511,   511,   152,
+     157,   195,   292,   338,   277,   250,   331,    70,   212,   215,
+     322,   467,   469,   160,   214,   309,   379,     4,   160,   327,
+     328,    19,   158,   170,   410,    19,   158,   170,   410,   133,
+     134,   135,   278,   334,   348,   334,   348,   334,   348,   334,
+     348,   334,   348,   334,   348,   334,   348,   334,   348,   348,
+     348,   348,   334,   348,   334,   348,   348,   348,   348,   170,
+     334,   348,   348,   158,   170,   348,   348,   348,   410,   348,
+     348,   348,   334,   348,   334,   348,   348,   348,   348,   334,
+     348,   334,   348,   334,   348,   348,   334,   348,    22,   348,
+     348,   348,   348,   348,   348,   348,   348,   348,   348,   348,
+     129,   130,   158,   170,   211,   212,   345,   410,   348,   215,
+     322,   348,   399,   267,     8,   356,   361,   422,   170,   291,
+     348,   182,   196,   196,   196,   419,   196,   196,   182,   196,
+     196,   270,   196,   270,   196,   270,   196,   419,   196,   419,
+     285,   450,   215,   511,   213,   450,   450,   348,   170,   170,
+     450,   291,   348,   422,   422,    20,   450,    70,   322,   469,
+     480,   195,   348,   170,   348,   450,   497,   499,   501,   422,
+     511,   348,   348,   348,   348,   348,   348,   348,   348,   348,
+     348,   348,   348,   348,   348,   348,   348,   348,   348,   277,
+     196,   419,   215,   511,   215,   257,   422,   422,   215,   422,
+     215,   422,   511,   422,   422,   511,   422,   196,   327,   215,
+     215,   215,   215,   215,   215,    20,   328,   214,   137,   374,
+     212,   348,   215,   142,   188,   182,   474,   185,   186,   213,
+     478,   188,   182,   185,   213,   477,    20,   215,   474,   181,
+     184,   476,    20,   348,   181,   491,   285,   285,   348,    20,
+     491,   181,   280,    20,   409,   213,   215,   214,   214,   340,
+     342,    12,    23,    24,   243,   244,   348,   268,   170,   215,
+     469,   467,   188,   215,   215,   170,   308,   308,   214,   127,
+     137,   170,   189,   194,   325,   326,   269,   195,   214,   195,
+     214,   328,   328,   328,   214,   214,   213,    19,   158,   170,
+     410,   191,   158,   170,   348,   214,   214,   158,   170,   348,
+       1,   214,   213,   215,   182,   181,   213,    57,    63,   359,
+      67,   360,   182,   196,   182,   424,   429,   431,   450,   433,
+     427,   170,   418,   435,   196,   439,   196,   443,   196,   447,
+     368,   449,   371,   196,   419,   215,    43,   374,   196,   196,
+     322,   196,   469,   215,   215,   215,   170,   215,   182,   196,
+     215,   196,   422,   422,   422,   196,   215,   214,   422,   348,
+     196,   196,   196,   196,   215,   196,   196,   215,   196,   327,
+     269,   214,   322,   348,   348,   348,   470,   474,   348,   158,
+     170,   467,   478,   213,   348,   490,   213,   322,   470,   181,
+     184,   187,   479,   213,   322,   196,   196,   178,   322,   181,
+     322,    20,   348,   348,   422,   269,   277,   348,    12,   246,
+     327,   215,   213,   212,   188,   213,   215,   326,   170,   170,
+     214,   170,   170,   188,   213,   270,   349,   348,   351,   348,
+     215,   322,   348,   195,   214,   348,   214,   213,   348,   212,
+     215,   322,   214,   213,   346,   215,   322,   182,    47,   360,
+      46,   106,   357,   327,   437,   441,   445,   214,   450,   170,
+     348,   483,   485,   277,   296,   215,   196,   419,   170,   214,
+     320,   196,   196,   196,   504,   284,   196,   313,   315,   317,
+     506,   489,   494,   487,   214,   330,   270,   215,   322,   182,
+     215,   474,   478,   214,   137,   374,   182,   474,   213,   182,
+     288,   290,   182,   182,   322,   215,   215,   196,   270,   277,
+     247,   182,   269,   215,   467,   170,   213,   191,   377,   215,
+     170,   325,   213,   142,   277,   323,   422,   215,   450,   215,
+     215,   215,   353,   348,   348,   215,   467,   215,   348,   215,
+      33,   358,   357,   359,   282,   214,   214,   348,   170,   196,
+     348,   498,   500,   502,   214,   215,   214,   348,   348,   348,
+     214,    70,   480,   214,   214,   215,   348,   323,   215,   348,
+     137,   374,   478,   348,   348,   348,   348,   479,   491,   348,
+     214,   283,   491,   348,   182,   341,   196,   244,    26,   105,
+     248,   298,   299,   300,   302,   348,   270,   213,   191,   377,
+     422,   376,   215,   127,   348,   196,   196,   450,   215,   215,
+     213,   215,   364,   358,   375,   215,   480,   480,   215,   196,
+     214,   215,   214,   214,   214,   282,   284,   322,   480,   467,
+     468,   215,   182,   510,   348,   348,   215,   510,   510,   282,
+     510,   510,   348,   338,   343,   127,   127,   348,   277,   215,
+     422,   376,   376,   348,   348,   350,   352,   196,   215,   274,
+     365,   214,   467,   471,   472,   473,   473,   348,   348,   480,
+     480,   468,   215,   215,   511,   473,   215,    53,   213,   137,
+     374,   181,   181,   188,   511,   181,   213,   510,   338,   348,
+     376,   348,   348,   182,   354,   182,   274,   467,   188,   511,
+     215,   215,   215,   215,   473,   473,   215,   215,   215,   348,
+     213,   348,   348,   213,   181,   215,   213,   348,   182,   182,
+     277,   215,   214,   215,   215,   182,   467,   215
+};
+
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int16 yyr1[] =
+{
+       0,   219,   220,   220,   220,   220,   220,   220,   220,   220,
+     220,   220,   220,   220,   220,   220,   220,   221,   222,   222,
+     222,   223,   223,   224,   225,   225,   225,   225,   226,   226,
+     227,   227,   227,   228,   229,   229,   231,   230,   232,   233,
+     234,   234,   234,   235,   235,   235,   235,   236,   236,   237,
+     237,   238,   239,   239,   240,   240,   241,   242,   242,   243,
+     243,   244,   244,   244,   245,   245,   246,   247,   246,   248,
+     248,   248,   248,   248,   249,   250,   249,   252,   251,   253,
+     254,   255,   257,   256,   258,   258,   258,   258,   258,   258,
+     259,   259,   260,   260,   260,   261,   261,   261,   261,   261,
+     261,   261,   261,   262,   262,   263,   263,   263,   264,   264,
+     264,   264,   265,   265,   266,   266,   266,   266,   266,   266,
+     266,   267,   267,   268,   268,   269,   269,   269,   270,   270,
+     271,   271,   271,   271,   271,   271,   271,   271,   271,   271,
+     271,   271,   271,   271,   271,   271,   271,   271,   271,   271,
+     271,   271,   271,   271,   271,   271,   271,   271,   271,   271,
+     271,   271,   271,   271,   271,   271,   271,   271,   271,   271,
+     271,   271,   271,   271,   271,   271,   271,   271,   271,   271,
+     271,   271,   271,   271,   271,   271,   271,   271,   271,   271,
+     271,   271,   271,   271,   271,   271,   271,   271,   271,   271,
+     271,   271,   271,   271,   271,   271,   271,   271,   271,   271,
+     271,   271,   271,   271,   271,   272,   273,   273,   273,   274,
+     276,   275,   277,   277,   278,   278,   278,   279,   279,   279,
+     279,   279,   279,   279,   279,   279,   279,   279,   279,   279,
+     279,   279,   279,   279,   279,   279,   279,   279,   280,   280,
+     280,   281,   282,   282,   283,   283,   284,   284,   285,   285,
+     287,   288,   286,   289,   290,   286,   291,   291,   291,   291,
+     291,   292,   292,   292,   293,   293,   295,   296,   294,   294,
+     297,   297,   297,   297,   297,   297,   298,   299,   300,   300,
+     300,   301,   301,   301,   302,   302,   303,   303,   303,   304,
+     305,   305,   305,   306,   306,   307,   307,   308,   308,   309,
+     309,   309,   309,   310,   310,   312,   313,   311,   314,   315,
+     311,   316,   317,   311,   319,   320,   318,   321,   321,   321,
+     321,   321,   321,   322,   322,   323,   323,   323,   324,   324,
+     324,   325,   325,   325,   325,   325,   326,   326,   327,   327,
+     327,   328,   328,   329,   331,   330,   332,   332,   332,   332,
+     332,   332,   332,   333,   333,   333,   333,   333,   333,   333,
+     333,   333,   333,   333,   333,   333,   333,   333,   333,   333,
+     333,   333,   334,   334,   334,   334,   335,   335,   335,   335,
+     335,   335,   335,   335,   335,   335,   335,   335,   335,   335,
+     335,   335,   335,   336,   336,   337,   337,   338,   338,   339,
+     340,   341,   339,   342,   343,   339,   344,   344,   344,   344,
+     344,   344,   344,   345,   346,   344,   347,   347,   347,   347,
+     347,   347,   347,   348,   348,   348,   348,   348,   348,   348,
+     348,   348,   348,   348,   348,   348,   348,   348,   348,   348,
+     348,   348,   348,   348,   348,   348,   348,   348,   348,   348,
+     348,   348,   348,   348,   348,   348,   348,   348,   348,   348,
+     348,   348,   348,   348,   348,   348,   348,   348,   348,   348,
+     348,   348,   348,   348,   348,   348,   348,   348,   348,   349,
+     350,   348,   348,   348,   348,   351,   352,   348,   348,   348,
+     353,   354,   348,   348,   348,   348,   348,   348,   348,   348,
+     348,   348,   348,   348,   348,   348,   348,   355,   355,   355,
+     355,   355,   355,   355,   355,   355,   355,   355,   355,   355,
+     355,   355,   355,   356,   356,   356,   357,   357,   357,   358,
+     358,   359,   359,   359,   360,   360,   361,   362,   363,   362,
+     364,   362,   365,   362,   362,   366,   366,   367,   367,   368,
+     368,   369,   369,   370,   370,   370,   371,   372,   372,   373,
+     373,   373,   374,   374,   375,   375,   375,   375,   375,   375,
+     376,   376,   376,   377,   377,   378,   378,   378,   378,   378,
+     379,   379,   379,   379,   379,   380,   381,   380,   382,   382,
+     383,   383,   383,   384,   385,   384,   386,   386,   386,   386,
+     387,   387,   387,   389,   388,   390,   390,   391,   392,   391,
+     393,   393,   393,   394,   396,   397,   395,   398,   399,   395,
+     400,   400,   401,   401,   402,   403,   403,   403,   403,   404,
+     404,   404,   405,   405,   407,   408,   406,   409,   409,   409,
+     409,   409,   410,   410,   410,   410,   410,   410,   410,   410,
+     410,   410,   410,   410,   410,   410,   410,   410,   410,   410,
+     410,   410,   410,   410,   410,   410,   410,   410,   410,   411,
+     411,   411,   411,   411,   411,   411,   411,   412,   413,   413,
+     413,   414,   414,   415,   415,   415,   417,   418,   416,   419,
+     419,   420,   420,   421,   421,   422,   422,   422,   422,   422,
+     422,   423,   424,   422,   422,   422,   425,   422,   422,   422,
+     422,   422,   422,   422,   422,   422,   422,   422,   422,   422,
+     426,   427,   422,   422,   428,   429,   422,   430,   431,   422,
+     432,   433,   422,   422,   434,   435,   422,   436,   437,   422,
+     422,   438,   439,   422,   440,   441,   422,   422,   442,   443,
+     422,   444,   445,   422,   446,   447,   422,   448,   449,   422,
+     450,   450,   450,   452,   453,   454,   455,   451,   457,   458,
+     459,   460,   456,   462,   463,   464,   465,   461,   466,   466,
+     466,   466,   466,   467,   467,   467,   467,   467,   467,   467,
+     467,   468,   469,   470,   470,   471,   471,   472,   472,   473,
+     473,   474,   474,   475,   475,   476,   476,   477,   477,   478,
+     478,   478,   479,   479,   479,   480,   480,   481,   481,   481,
+     481,   481,   481,   482,   483,   481,   484,   485,   481,   486,
+     487,   481,   488,   489,   481,   490,   490,   490,   491,   491,
+     492,   493,   494,   492,   495,   495,   496,   496,   496,   497,
+     498,   496,   499,   500,   496,   501,   502,   496,   496,   503,
+     504,   496,   496,   505,   506,   496,   507,   507,   508,   508,
+     509,   509,   509,   509,   509,   510,   510,   511,   511,   512,
+     512,   512,   512,   512,   512
+};
+
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
+{
+       0,     2,     0,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     0,     1,
+       1,     1,     1,     4,     1,     1,     2,     2,     3,     2,
+       0,     2,     4,     3,     1,     2,     0,     4,     2,     2,
+       1,     1,     1,     1,     2,     3,     3,     2,     4,     0,
+       1,     2,     1,     3,     1,     3,     3,     3,     2,     1,
+       1,     0,     2,     4,     1,     1,     0,     0,     3,     1,
+       1,     1,     1,     1,     4,     0,     6,     0,     6,     2,
+       3,     3,     0,     5,     1,     1,     1,     1,     1,     1,
+       1,     3,     1,     1,     1,     3,     3,     3,     3,     3,
+       3,     1,     5,     1,     3,     2,     3,     2,     1,     1,
+       1,     1,     1,     4,     1,     2,     3,     3,     3,     3,
+       2,     1,     3,     0,     3,     0,     2,     3,     0,     2,
+       1,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     3,     3,     2,     2,     3,     4,
+       3,     2,     2,     2,     2,     2,     3,     3,     3,     4,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     3,     0,     1,     1,     3,
+       0,     4,     3,     7,     2,     2,     6,     1,     1,     1,
+       1,     2,     2,     1,     1,     1,     1,     1,     1,     2,
+       2,     1,     1,     1,     1,     2,     2,     2,     0,     2,
+       2,     3,     0,     2,     0,     4,     0,     2,     1,     3,
+       0,     0,     7,     0,     0,     7,     3,     2,     2,     2,
+       1,     1,     3,     2,     2,     3,     0,     0,     5,     1,
+       2,     5,     5,     5,     6,     2,     1,     1,     1,     2,
+       3,     2,     2,     3,     2,     3,     2,     2,     3,     4,
+       1,     1,     0,     1,     1,     1,     0,     1,     3,     9,
+       8,     8,     7,     3,     3,     0,     0,     7,     0,     0,
+       7,     0,     0,     7,     0,     0,     6,     5,     8,    10,
+       5,     8,    10,     1,     3,     1,     2,     3,     1,     1,
+       2,     2,     2,     2,     2,     4,     1,     3,     0,     4,
+       4,     1,     6,     6,     0,     7,     1,     1,     1,     1,
+       1,     1,     1,     1,     3,     3,     3,     3,     3,     3,
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
+       3,     3,     2,     2,     2,     1,     3,     3,     3,     3,
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
+       3,     3,     3,     6,     8,     5,     6,     1,     4,     3,
+       0,     0,     8,     0,     0,     9,     3,     4,     5,     6,
+       8,     5,     6,     0,     0,     5,     3,     4,     4,     5,
+       4,     3,     4,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     2,     2,     2,     2,     3,     3,     3,
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     2,
+       2,     2,     2,     4,     4,     5,     4,     5,     3,     4,
+       1,     1,     2,     4,     4,     7,     8,     3,     5,     0,
+       0,     8,     3,     3,     3,     0,     0,     8,     3,     4,
+       0,     0,     9,     4,     1,     1,     1,     1,     1,     1,
+       1,     3,     3,     3,     2,     4,     1,     4,     4,     4,
+       4,     4,     1,     6,     7,     6,     6,     7,     7,     6,
+       7,     6,     6,     0,     4,     1,     0,     1,     1,     0,
+       1,     0,     1,     1,     0,     1,     5,     0,     0,     4,
+       0,     9,     0,    10,     5,     3,     4,     1,     3,     1,
+       3,     1,     3,     0,     2,     3,     3,     1,     3,     0,
+       2,     3,     1,     1,     1,     2,     3,     5,     3,     3,
+       1,     1,     1,     0,     1,     1,     4,     3,     3,     5,
+       4,     6,     5,     5,     4,     0,     0,     4,     0,     1,
+       0,     1,     1,     6,     0,     6,     0,     2,     3,     5,
+       0,     1,     1,     0,     5,     2,     3,     4,     0,     4,
+       0,     1,     1,     1,     0,     0,     9,     0,     0,    11,
+       0,     2,     0,     1,     3,     1,     1,     2,     2,     0,
+       1,     1,     0,     3,     0,     0,     7,     1,     4,     3,
+       3,     5,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     4,
+       4,     1,     3,     0,     2,     3,     0,     0,     6,     1,
+       1,     1,     3,     3,     4,     1,     1,     1,     1,     2,
+       3,     0,     0,     6,     4,     5,     0,     9,     4,     2,
+       2,     3,     2,     3,     2,     2,     3,     3,     3,     2,
+       0,     0,     6,     2,     0,     0,     6,     0,     0,     6,
+       0,     0,     6,     1,     0,     0,     6,     0,     0,     7,
+       1,     0,     0,     6,     0,     0,     7,     1,     0,     0,
+       6,     0,     0,     7,     0,     0,     6,     0,     0,     6,
+       1,     3,     3,     0,     0,     0,     0,    10,     0,     0,
+       0,     0,    10,     0,     0,     0,     0,    10,     1,     1,
+       1,     1,     1,     3,     3,     5,     5,     6,     6,     8,
+       8,     1,     1,     1,     3,     3,     5,     1,     2,     1,
+       0,     0,     2,     2,     1,     2,     1,     2,     1,     2,
+       1,     1,     2,     1,     1,     0,     1,     5,     4,     6,
+       7,     5,     7,     0,     0,    10,     0,     0,    10,     0,
+       0,     9,     0,     0,     7,     1,     3,     3,     3,     1,
+       5,     0,     0,    10,     1,     3,     4,     4,     4,     0,
+       0,    11,     0,     0,    11,     0,     0,    10,     5,     0,
+       0,     9,     5,     0,     0,    10,     1,     3,     1,     3,
+       4,     3,     4,     7,     9,     0,     3,     0,     1,     9,
+      10,    10,    10,     9,    10
+};
+
+
+enum { YYENOMEM = -2 };
+
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = DAS_YYEMPTY)
+
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
+
+
+#define YYRECOVERING()  (!!yyerrstatus)
+
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == DAS_YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (&yylloc, scanner, YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
+
+/* Backward compatibility with an undocumented macro.
+   Use DAS_YYerror or DAS_YYUNDEF. */
+#define YYERRCODE DAS_YYUNDEF
+
+/* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
+   If N is 0, then set CURRENT to the empty location which ends
+   the previous symbol: RHS[0] (always defined).  */
+
+#ifndef YYLLOC_DEFAULT
+# define YYLLOC_DEFAULT(Current, Rhs, N)                                \
+    do                                                                  \
+      if (N)                                                            \
+        {                                                               \
+          (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;        \
+          (Current).first_column = YYRHSLOC (Rhs, 1).first_column;      \
+          (Current).last_line    = YYRHSLOC (Rhs, N).last_line;         \
+          (Current).last_column  = YYRHSLOC (Rhs, N).last_column;       \
+        }                                                               \
+      else                                                              \
+        {                                                               \
+          (Current).first_line   = (Current).last_line   =              \
+            YYRHSLOC (Rhs, 0).last_line;                                \
+          (Current).first_column = (Current).last_column =              \
+            YYRHSLOC (Rhs, 0).last_column;                              \
+        }                                                               \
+    while (0)
+#endif
+
+#define YYRHSLOC(Rhs, K) ((Rhs)[K])
+
+
+/* Enable debugging if requested.  */
+#if DAS_YYDEBUG
+
+# ifndef YYFPRINTF
+#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
+#  define YYFPRINTF fprintf
+# endif
+
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
+
+
+/* YYLOCATION_PRINT -- Print the location on the stream.
+   This macro was not mandated originally: define only if we know
+   we won't break user code: when these are the locations we know.  */
+
+# ifndef YYLOCATION_PRINT
+
+#  if defined YY_LOCATION_PRINT
+
+   /* Temporary convenience wrapper in case some people defined the
+      undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YYLOCATION_PRINT(File, Loc)  YY_LOCATION_PRINT(File, *(Loc))
+
+#  elif defined DAS_YYLTYPE_IS_TRIVIAL && DAS_YYLTYPE_IS_TRIVIAL
+
+/* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
+
+YY_ATTRIBUTE_UNUSED
+static int
+yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
+{
+  int res = 0;
+  int end_col = 0 != yylocp->last_column ? yylocp->last_column - 1 : 0;
+  if (0 <= yylocp->first_line)
+    {
+      res += YYFPRINTF (yyo, "%d", yylocp->first_line);
+      if (0 <= yylocp->first_column)
+        res += YYFPRINTF (yyo, ".%d", yylocp->first_column);
+    }
+  if (0 <= yylocp->last_line)
+    {
+      if (yylocp->first_line < yylocp->last_line)
+        {
+          res += YYFPRINTF (yyo, "-%d", yylocp->last_line);
+          if (0 <= end_col)
+            res += YYFPRINTF (yyo, ".%d", end_col);
+        }
+      else if (0 <= end_col && yylocp->first_column < end_col)
+        res += YYFPRINTF (yyo, "-%d", end_col);
+    }
+  return res;
+}
+
+#   define YYLOCATION_PRINT  yy_location_print_
+
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT(File, Loc)  YYLOCATION_PRINT(File, &(Loc))
+
+#  else
+
+#   define YYLOCATION_PRINT(File, Loc) ((void) 0)
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT  YYLOCATION_PRINT
+
+#  endif
+# endif /* !defined YYLOCATION_PRINT */
+
+
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Kind, Value, Location, scanner); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
+
+
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
+
+static void
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner)
+{
+  FILE *yyoutput = yyo;
+  YY_USE (yyoutput);
+  YY_USE (yylocationp);
+  YY_USE (scanner);
+  if (!yyvaluep)
+    return;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
+}
+
+
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
+
+static void
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner)
+{
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
+
+  YYLOCATION_PRINT (yyo, yylocationp);
+  YYFPRINTF (yyo, ": ");
+  yy_symbol_value_print (yyo, yykind, yyvaluep, yylocationp, scanner);
+  YYFPRINTF (yyo, ")");
+}
+
+/*------------------------------------------------------------------.
+| yy_stack_print -- Print the state stack from its BOTTOM up to its |
+| TOP (included).                                                   |
+`------------------------------------------------------------------*/
+
+static void
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
+{
+  YYFPRINTF (stderr, "Stack now");
+  for (; yybottom <= yytop; yybottom++)
+    {
+      int yybot = *yybottom;
+      YYFPRINTF (stderr, " %d", yybot);
+    }
+  YYFPRINTF (stderr, "\n");
+}
+
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
+
+
+/*------------------------------------------------.
+| Report that the YYRULE is going to be reduced.  |
+`------------------------------------------------*/
+
+static void
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp,
+                 int yyrule, yyscan_t scanner)
+{
+  int yylno = yyrline[yyrule];
+  int yynrhs = yyr2[yyrule];
+  int yyi;
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
+             yyrule - 1, yylno);
+  /* The symbols being reduced.  */
+  for (yyi = 0; yyi < yynrhs; yyi++)
+    {
+      YYFPRINTF (stderr, "   $%d = ", yyi + 1);
+      yy_symbol_print (stderr,
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)],
+                       &(yylsp[(yyi + 1) - (yynrhs)]), scanner);
+      YYFPRINTF (stderr, "\n");
+    }
+}
+
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, yylsp, Rule, scanner); \
+} while (0)
+
+/* Nonzero means print parse trace.  It is left uninitialized so that
+   multiple parsers can coexist.  */
+int yydebug;
+#else /* !DAS_YYDEBUG */
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
+# define YY_STACK_PRINT(Bottom, Top)
+# define YY_REDUCE_PRINT(Rule)
+#endif /* !DAS_YYDEBUG */
+
+
+/* YYINITDEPTH -- initial size of the parser's stacks.  */
+#ifndef YYINITDEPTH
+# define YYINITDEPTH 200
+#endif
+
+/* YYMAXDEPTH -- maximum size the stacks can grow to (effective only
+   if the built-in stack extension method is used).
+
+   Do not make this value too large; the results are undefined if
+   YYSTACK_ALLOC_MAXIMUM < YYSTACK_BYTES (YYMAXDEPTH)
+   evaluated with infinite-precision integer arithmetic.  */
+
+#ifndef YYMAXDEPTH
+# define YYMAXDEPTH 10000
+#endif
+
+
+/* Context of a parse error.  */
+typedef struct
+{
+  yy_state_t *yyssp;
+  yysymbol_kind_t yytoken;
+  YYLTYPE *yylloc;
+} yypcontext_t;
+
+/* Put in YYARG at most YYARGN of the expected tokens given the
+   current YYCTX, and return the number of tokens stored in YYARG.  If
+   YYARG is null, return the number of expected tokens (guaranteed to
+   be less than YYNTOKENS).  Return YYENOMEM on memory exhaustion.
+   Return 0 if there are more than YYARGN expected tokens, yet fill
+   YYARG up to YYARGN. */
+static int
+yypcontext_expected_tokens (const yypcontext_t *yyctx,
+                            yysymbol_kind_t yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  int yyn = yypact[+*yyctx->yyssp];
+  if (!yypact_value_is_default (yyn))
+    {
+      /* Start YYX at -YYN if negative to avoid negative indexes in
+         YYCHECK.  In other words, skip the first -YYN actions for
+         this state because they are default actions.  */
+      int yyxbegin = yyn < 0 ? -yyn : 0;
+      /* Stay within bounds of both yycheck and yytname.  */
+      int yychecklim = YYLAST - yyn + 1;
+      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+      int yyx;
+      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_YYerror
+            && !yytable_value_is_error (yytable[yyx + yyn]))
+          {
+            if (!yyarg)
+              ++yycount;
+            else if (yycount == yyargn)
+              return 0;
+            else
+              yyarg[yycount++] = YY_CAST (yysymbol_kind_t, yyx);
+          }
+    }
+  if (yyarg && yycount == 0 && 0 < yyargn)
+    yyarg[0] = YYSYMBOL_YYEMPTY;
+  return yycount;
+}
+
+
+
+
+#ifndef yystrlen
+# if defined __GLIBC__ && defined _STRING_H
+#  define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
+# else
+/* Return the length of YYSTR.  */
+static YYPTRDIFF_T
+yystrlen (const char *yystr)
+{
+  YYPTRDIFF_T yylen;
+  for (yylen = 0; yystr[yylen]; yylen++)
+    continue;
+  return yylen;
+}
+# endif
+#endif
+
+#ifndef yystpcpy
+# if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
+#  define yystpcpy stpcpy
+# else
+/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
+   YYDEST.  */
+static char *
+yystpcpy (char *yydest, const char *yysrc)
+{
+  char *yyd = yydest;
+  const char *yys = yysrc;
+
+  while ((*yyd++ = *yys++) != '\0')
+    continue;
+
+  return yyd - 1;
+}
+# endif
+#endif
+
+#ifndef yytnamerr
+/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
+   quotes and backslashes, so that it's suitable for yyerror.  The
+   heuristic is that double-quoting is unnecessary unless the string
+   contains an apostrophe, a comma, or backslash (other than
+   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
+   null, do not copy; instead, return the length of what the result
+   would have been.  */
+static YYPTRDIFF_T
+yytnamerr (char *yyres, const char *yystr)
+{
+  if (*yystr == '"')
+    {
+      YYPTRDIFF_T yyn = 0;
+      char const *yyp = yystr;
+      for (;;)
+        switch (*++yyp)
+          {
+          case '\'':
+          case ',':
+            goto do_not_strip_quotes;
+
+          case '\\':
+            if (*++yyp != '\\')
+              goto do_not_strip_quotes;
+            else
+              goto append;
+
+          append:
+          default:
+            if (yyres)
+              yyres[yyn] = *yyp;
+            yyn++;
+            break;
+
+          case '"':
+            if (yyres)
+              yyres[yyn] = '\0';
+            return yyn;
+          }
+    do_not_strip_quotes: ;
+    }
+
+  if (yyres)
+    return yystpcpy (yyres, yystr) - yyres;
+  else
+    return yystrlen (yystr);
+}
+#endif
+
+
+static int
+yy_syntax_error_arguments (const yypcontext_t *yyctx,
+                           yysymbol_kind_t yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  /* There are many possibilities here to consider:
+     - If this state is a consistent state with a default action, then
+       the only way this function was invoked is if the default action
+       is an error action.  In that case, don't check for expected
+       tokens because there are none.
+     - The only way there can be no lookahead present (in yychar) is if
+       this state is a consistent state with a default action.  Thus,
+       detecting the absence of a lookahead is sufficient to determine
+       that there is no unexpected or expected token to report.  In that
+       case, just report a simple "syntax error".
+     - Don't assume there isn't a lookahead just because this state is a
+       consistent state with a default action.  There might have been a
+       previous inconsistent state, consistent state with a non-default
+       action, or user semantic action that manipulated yychar.
+     - Of course, the expected token list depends on states to have
+       correct lookahead information, and it depends on the parser not
+       to perform extra reductions after fetching a lookahead from the
+       scanner and before detecting a syntax error.  Thus, state merging
+       (from LALR or IELR) and default reductions corrupt the expected
+       token list.  However, the list is correct for canonical LR with
+       one exception: it will still contain any token that will not be
+       accepted due to an error action in a later state.
+  */
+  if (yyctx->yytoken != YYSYMBOL_YYEMPTY)
+    {
+      int yyn;
+      if (yyarg)
+        yyarg[yycount] = yyctx->yytoken;
+      ++yycount;
+      yyn = yypcontext_expected_tokens (yyctx,
+                                        yyarg ? yyarg + 1 : yyarg, yyargn - 1);
+      if (yyn == YYENOMEM)
+        return YYENOMEM;
+      else
+        yycount += yyn;
+    }
+  return yycount;
+}
+
+/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
+   about the unexpected token YYTOKEN for the state stack whose top is
+   YYSSP.
+
+   Return 0 if *YYMSG was successfully written.  Return -1 if *YYMSG is
+   not large enough to hold the message.  In that case, also set
+   *YYMSG_ALLOC to the required number of bytes.  Return YYENOMEM if the
+   required number of bytes is too large to store.  */
+static int
+yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
+                const yypcontext_t *yyctx)
+{
+  enum { YYARGS_MAX = 5 };
+  /* Internationalized format string. */
+  const char *yyformat = YY_NULLPTR;
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
+  yysymbol_kind_t yyarg[YYARGS_MAX];
+  /* Cumulated lengths of YYARG.  */
+  YYPTRDIFF_T yysize = 0;
+
+  /* Actual size of YYARG. */
+  int yycount = yy_syntax_error_arguments (yyctx, yyarg, YYARGS_MAX);
+  if (yycount == YYENOMEM)
+    return YYENOMEM;
+
+  switch (yycount)
+    {
+#define YYCASE_(N, S)                       \
+      case N:                               \
+        yyformat = S;                       \
+        break
+    default: /* Avoid compiler warnings. */
+      YYCASE_(0, YY_("syntax error"));
+      YYCASE_(1, YY_("syntax error, unexpected %s"));
+      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
+      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
+      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
+      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
+#undef YYCASE_
+    }
+
+  /* Compute error message size.  Don't count the "%s"s, but reserve
+     room for the terminator.  */
+  yysize = yystrlen (yyformat) - 2 * yycount + 1;
+  {
+    int yyi;
+    for (yyi = 0; yyi < yycount; ++yyi)
+      {
+        YYPTRDIFF_T yysize1
+          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
+        if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+          yysize = yysize1;
+        else
+          return YYENOMEM;
+      }
+  }
+
+  if (*yymsg_alloc < yysize)
+    {
+      *yymsg_alloc = 2 * yysize;
+      if (! (yysize <= *yymsg_alloc
+             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
+        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
+      return -1;
+    }
+
+  /* Avoid sprintf, as that infringes on the user's name space.
+     Don't have undefined behavior even if the translation
+     produced a string with the wrong number of "%s"s.  */
+  {
+    char *yyp = *yymsg;
+    int yyi = 0;
+    while ((*yyp = *yyformat) != '\0')
+      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
+        {
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
+          yyformat += 2;
+        }
+      else
+        {
+          ++yyp;
+          ++yyformat;
+        }
+  }
+  return 0;
+}
+
+
+/*-----------------------------------------------.
+| Release the memory associated to this symbol.  |
+`-----------------------------------------------*/
+
+static void
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, yyscan_t scanner)
+{
+  YY_USE (yyvaluep);
+  YY_USE (yylocationp);
+  YY_USE (scanner);
+  if (!yymsg)
+    yymsg = "Deleting";
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
+
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  switch (yykind)
+    {
+    case YYSYMBOL_NAME: /* "name"  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_KEYWORD: /* "keyword"  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_TYPE_FUNCTION: /* "type function"  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_module_name: /* module_name  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_character_sequence: /* character_sequence  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_string_constant: /* string_constant  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_string_builder_body: /* string_builder_body  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_string_builder: /* string_builder  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_reader: /* expr_reader  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_keyword_or_name: /* keyword_or_name  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_require_module_name: /* require_module_name  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_expression_label: /* expression_label  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_goto: /* expression_goto  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_else: /* expression_else  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_else_one_liner: /* expression_else_one_liner  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_if_one_liner: /* expression_if_one_liner  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_if_then_else: /* expression_if_then_else  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_for_loop: /* expression_for_loop  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_unsafe: /* expression_unsafe  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_while_loop: /* expression_while_loop  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_with: /* expression_with  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_with_alias: /* expression_with_alias  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_annotation_argument_value: /* annotation_argument_value  */
+            { delete ((*yyvaluep).aa); }
+        break;
+
+    case YYSYMBOL_annotation_argument_value_list: /* annotation_argument_value_list  */
+            { delete ((*yyvaluep).aaList); }
+        break;
+
+    case YYSYMBOL_annotation_argument_name: /* annotation_argument_name  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_annotation_argument: /* annotation_argument  */
+            { delete ((*yyvaluep).aa); }
+        break;
+
+    case YYSYMBOL_annotation_argument_list: /* annotation_argument_list  */
+            { delete ((*yyvaluep).aaList); }
+        break;
+
+    case YYSYMBOL_metadata_argument_list: /* metadata_argument_list  */
+            { delete ((*yyvaluep).aaList); }
+        break;
+
+    case YYSYMBOL_annotation_declaration_name: /* annotation_declaration_name  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_annotation_declaration_basic: /* annotation_declaration_basic  */
+            { delete ((*yyvaluep).fa); }
+        break;
+
+    case YYSYMBOL_annotation_declaration: /* annotation_declaration  */
+            { delete ((*yyvaluep).fa); }
+        break;
+
+    case YYSYMBOL_annotation_list: /* annotation_list  */
+            { delete ((*yyvaluep).faList); }
+        break;
+
+    case YYSYMBOL_optional_annotation_list: /* optional_annotation_list  */
+            { delete ((*yyvaluep).faList); }
+        break;
+
+    case YYSYMBOL_optional_function_argument_list: /* optional_function_argument_list  */
+            { deleteVariableDeclarationList(((*yyvaluep).pVarDeclList)); }
+        break;
+
+    case YYSYMBOL_optional_function_type: /* optional_function_type  */
+            { delete ((*yyvaluep).pTypeDecl); }
+        break;
+
+    case YYSYMBOL_function_name: /* function_name  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_function_declaration_header: /* function_declaration_header  */
+            { ((*yyvaluep).pFuncDecl)->delRef(); }
+        break;
+
+    case YYSYMBOL_function_declaration: /* function_declaration  */
+            { ((*yyvaluep).pFuncDecl)->delRef(); }
+        break;
+
+    case YYSYMBOL_expression_block: /* expression_block  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_call_pipe: /* expr_call_pipe  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_any: /* expression_any  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expressions: /* expressions  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_keyword: /* expr_keyword  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_optional_expr_list: /* optional_expr_list  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_optional_expr_list_in_braces: /* optional_expr_list_in_braces  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_optional_expr_map_tuple_list: /* optional_expr_map_tuple_list  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_type_declaration_no_options_list: /* type_declaration_no_options_list  */
+            { deleteTypeDeclarationList(((*yyvaluep).pTypeDeclList)); }
+        break;
+
+    case YYSYMBOL_expression_keyword: /* expression_keyword  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_pipe: /* expr_pipe  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_name_in_namespace: /* name_in_namespace  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_expression_delete: /* expression_delete  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_new_type_declaration: /* new_type_declaration  */
+            { delete ((*yyvaluep).pTypeDecl); }
+        break;
+
+    case YYSYMBOL_expr_new: /* expr_new  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_break: /* expression_break  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_continue: /* expression_continue  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_return_no_pipe: /* expression_return_no_pipe  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_return: /* expression_return  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_yield_no_pipe: /* expression_yield_no_pipe  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_yield: /* expression_yield  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expression_try_catch: /* expression_try_catch  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_tuple_expansion: /* tuple_expansion  */
+            { delete ((*yyvaluep).pNameList); }
+        break;
+
+    case YYSYMBOL_tuple_expansion_variable_declaration: /* tuple_expansion_variable_declaration  */
+            { delete ((*yyvaluep).pVarDecl); }
+        break;
+
+    case YYSYMBOL_expression_let: /* expression_let  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_cast: /* expr_cast  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_type_decl: /* expr_type_decl  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_type_info: /* expr_type_info  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_list: /* expr_list  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_block_or_simple_block: /* block_or_simple_block  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_capture_entry: /* capture_entry  */
+            { delete ((*yyvaluep).pCapt); }
+        break;
+
+    case YYSYMBOL_capture_list: /* capture_list  */
+            { delete ((*yyvaluep).pCaptList); }
+        break;
+
+    case YYSYMBOL_optional_capture_list: /* optional_capture_list  */
+            { delete ((*yyvaluep).pCaptList); }
+        break;
+
+    case YYSYMBOL_expr_block: /* expr_block  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_full_block: /* expr_full_block  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_full_block_assumed_piped: /* expr_full_block_assumed_piped  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_numeric_const: /* expr_numeric_const  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_assign: /* expr_assign  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_assign_pipe_right: /* expr_assign_pipe_right  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_assign_pipe: /* expr_assign_pipe  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_named_call: /* expr_named_call  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_method_call: /* expr_method_call  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_func_addr_name: /* func_addr_name  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_func_addr_expr: /* func_addr_expr  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_field: /* expr_field  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_call: /* expr_call  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr: /* expr  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_mtag: /* expr_mtag  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_optional_field_annotation: /* optional_field_annotation  */
+            { delete ((*yyvaluep).aaList); }
+        break;
+
+    case YYSYMBOL_structure_variable_declaration: /* structure_variable_declaration  */
+            { delete ((*yyvaluep).pVarDecl); }
+        break;
+
+    case YYSYMBOL_struct_variable_declaration_list: /* struct_variable_declaration_list  */
+            { deleteVariableDeclarationList(((*yyvaluep).pVarDeclList)); }
+        break;
+
+    case YYSYMBOL_function_argument_declaration: /* function_argument_declaration  */
+            { delete ((*yyvaluep).pVarDecl); }
+        break;
+
+    case YYSYMBOL_function_argument_list: /* function_argument_list  */
+            { deleteVariableDeclarationList(((*yyvaluep).pVarDeclList)); }
+        break;
+
+    case YYSYMBOL_tuple_type: /* tuple_type  */
+            { delete ((*yyvaluep).pVarDecl); }
+        break;
+
+    case YYSYMBOL_tuple_type_list: /* tuple_type_list  */
+            { deleteVariableDeclarationList(((*yyvaluep).pVarDeclList)); }
+        break;
+
+    case YYSYMBOL_tuple_alias_type_list: /* tuple_alias_type_list  */
+            { deleteVariableDeclarationList(((*yyvaluep).pVarDeclList)); }
+        break;
+
+    case YYSYMBOL_variant_type: /* variant_type  */
+            { delete ((*yyvaluep).pVarDecl); }
+        break;
+
+    case YYSYMBOL_variant_type_list: /* variant_type_list  */
+            { deleteVariableDeclarationList(((*yyvaluep).pVarDeclList)); }
+        break;
+
+    case YYSYMBOL_variant_alias_type_list: /* variant_alias_type_list  */
+            { deleteVariableDeclarationList(((*yyvaluep).pVarDeclList)); }
+        break;
+
+    case YYSYMBOL_variable_declaration: /* variable_declaration  */
+            { delete ((*yyvaluep).pVarDecl); }
+        break;
+
+    case YYSYMBOL_let_variable_name_with_pos_list: /* let_variable_name_with_pos_list  */
+            { delete ((*yyvaluep).pNameWithPosList); }
+        break;
+
+    case YYSYMBOL_let_variable_declaration: /* let_variable_declaration  */
+            { delete ((*yyvaluep).pVarDecl); }
+        break;
+
+    case YYSYMBOL_global_variable_declaration_list: /* global_variable_declaration_list  */
+            { deleteVariableDeclarationList(((*yyvaluep).pVarDeclList)); }
+        break;
+
+    case YYSYMBOL_enum_list: /* enum_list  */
+            { if ( ((*yyvaluep).pEnum)->use_count()==1 ) delete ((*yyvaluep).pEnum); }
+        break;
+
+    case YYSYMBOL_enum_name: /* enum_name  */
+            { if ( ((*yyvaluep).pEnum)->use_count()==1 ) delete ((*yyvaluep).pEnum); }
+        break;
+
+    case YYSYMBOL_optional_structure_parent: /* optional_structure_parent  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_optional_struct_variable_declaration_list: /* optional_struct_variable_declaration_list  */
+            { deleteVariableDeclarationList(((*yyvaluep).pVarDeclList)); }
+        break;
+
+    case YYSYMBOL_variable_name_with_pos_list: /* variable_name_with_pos_list  */
+            { delete ((*yyvaluep).pNameWithPosList); }
+        break;
+
+    case YYSYMBOL_structure_type_declaration: /* structure_type_declaration  */
+            { delete ((*yyvaluep).pTypeDecl); }
+        break;
+
+    case YYSYMBOL_auto_type_declaration: /* auto_type_declaration  */
+            { delete ((*yyvaluep).pTypeDecl); }
+        break;
+
+    case YYSYMBOL_bitfield_bits: /* bitfield_bits  */
+            { delete ((*yyvaluep).pNameList); }
+        break;
+
+    case YYSYMBOL_bitfield_alias_bits: /* bitfield_alias_bits  */
+            { delete ((*yyvaluep).pNameList); }
+        break;
+
+    case YYSYMBOL_bitfield_type_declaration: /* bitfield_type_declaration  */
+            { delete ((*yyvaluep).pTypeDecl); }
+        break;
+
+    case YYSYMBOL_table_type_pair: /* table_type_pair  */
+            { delete ((*yyvaluep).aTypePair).firstType; delete ((*yyvaluep).aTypePair).secondType; }
+        break;
+
+    case YYSYMBOL_dim_list: /* dim_list  */
+            { delete ((*yyvaluep).pTypeDecl); }
+        break;
+
+    case YYSYMBOL_type_declaration_no_options: /* type_declaration_no_options  */
+            { delete ((*yyvaluep).pTypeDecl); }
+        break;
+
+    case YYSYMBOL_type_declaration: /* type_declaration  */
+            { delete ((*yyvaluep).pTypeDecl); }
+        break;
+
+    case YYSYMBOL_make_decl: /* make_decl  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_struct_fields: /* make_struct_fields  */
+            { delete ((*yyvaluep).pMakeStruct); }
+        break;
+
+    case YYSYMBOL_make_variant_dim: /* make_variant_dim  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_struct_single: /* make_struct_single  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_struct_dim: /* make_struct_dim  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_struct_dim_list: /* make_struct_dim_list  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_struct_dim_decl: /* make_struct_dim_decl  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_optional_make_struct_dim_decl: /* optional_make_struct_dim_decl  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_optional_block: /* optional_block  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_struct_decl: /* make_struct_decl  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_tuple: /* make_tuple  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_map_tuple: /* make_map_tuple  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_tuple_call: /* make_tuple_call  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_dim: /* make_dim  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_dim_decl: /* make_dim_decl  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_table: /* make_table  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_expr_map_tuple_list: /* expr_map_tuple_list  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_make_table_decl: /* make_table_decl  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_array_comprehension_where: /* array_comprehension_where  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+    case YYSYMBOL_array_comprehension: /* array_comprehension  */
+            { delete ((*yyvaluep).pExpression); }
+        break;
+
+      default:
+        break;
+    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
+}
+
+
+
+
+
+
+/*----------.
+| yyparse.  |
+`----------*/
+
+int
+yyparse (yyscan_t scanner)
+{
+/* Lookahead token kind.  */
+int yychar;
+
+
+/* The semantic value of the lookahead symbol.  */
+/* Default value used for initialization, for pacifying older GCCs
+   or non-GCC compilers.  */
+YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
+YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
+
+/* Location data for the lookahead symbol.  */
+static YYLTYPE yyloc_default
+# if defined DAS_YYLTYPE_IS_TRIVIAL && DAS_YYLTYPE_IS_TRIVIAL
+  = { 1, 1, 1, 1 }
+# endif
+;
+YYLTYPE yylloc = yyloc_default;
+
+    /* Number of syntax errors so far.  */
+    int yynerrs = 0;
+
+    yy_state_fast_t yystate = 0;
+    /* Number of tokens to shift before error messages enabled.  */
+    int yyerrstatus = 0;
+
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
+       to reallocate them elsewhere.  */
+
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
+
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
+
+    /* The semantic value stack: array, bottom, top.  */
+    YYSTYPE yyvsa[YYINITDEPTH];
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
+
+    /* The location stack: array, bottom, top.  */
+    YYLTYPE yylsa[YYINITDEPTH];
+    YYLTYPE *yyls = yylsa;
+    YYLTYPE *yylsp = yyls;
+
+  int yyn;
+  /* The return value of yyparse.  */
+  int yyresult;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
+  /* The variables used to return semantic value and location from the
+     action routines.  */
+  YYSTYPE yyval;
+  YYLTYPE yyloc;
+
+  /* The locations where the error started and ended.  */
+  YYLTYPE yyerror_range[3];
+
+  /* Buffer for error messages, and its allocated size.  */
+  char yymsgbuf[128];
+  char *yymsg = yymsgbuf;
+  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
+
+#define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N), yylsp -= (N))
+
+  /* The number of symbols on the RHS of the reduced rule.
+     Keep to zero when no symbol should be popped.  */
+  int yylen = 0;
+
+  YYDPRINTF ((stderr, "Starting parse\n"));
+
+  yychar = DAS_YYEMPTY; /* Cause a token to be read.  */
+
+  yylsp[0] = yylloc;
+  goto yysetstate;
+
+
+/*------------------------------------------------------------.
+| yynewstate -- push a new state, which is found in yystate.  |
+`------------------------------------------------------------*/
+yynewstate:
+  /* In all cases, when you get here, the value and location stacks
+     have just been pushed.  So pushing a state here evens the stacks.  */
+  yyssp++;
+
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
+
+  if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    YYNOMEM;
+#else
+    {
+      /* Get the current used size of the three stacks, in elements.  */
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
+
+# if defined yyoverflow
+      {
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        yy_state_t *yyss1 = yyss;
+        YYSTYPE *yyvs1 = yyvs;
+        YYLTYPE *yyls1 = yyls;
+
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
+                    &yyls1, yysize * YYSIZEOF (*yylsp),
+                    &yystacksize);
+        yyss = yyss1;
+        yyvs = yyvs1;
+        yyls = yyls1;
+      }
+# else /* defined YYSTACK_RELOCATE */
+      /* Extend the stack our own way.  */
+      if (YYMAXDEPTH <= yystacksize)
+        YYNOMEM;
+      yystacksize *= 2;
+      if (YYMAXDEPTH < yystacksize)
+        yystacksize = YYMAXDEPTH;
+
+      {
+        yy_state_t *yyss1 = yyss;
+        union yyalloc *yyptr =
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
+        if (! yyptr)
+          YYNOMEM;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+        YYSTACK_RELOCATE (yyls_alloc, yyls);
+#  undef YYSTACK_RELOCATE
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
+      }
+# endif
+
+      yyssp = yyss + yysize - 1;
+      yyvsp = yyvs + yysize - 1;
+      yylsp = yyls + yysize - 1;
+
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
+
+      if (yyss + yystacksize - 1 <= yyssp)
+        YYABORT;
+    }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
+
+
+  if (yystate == YYFINAL)
+    YYACCEPT;
+
+  goto yybackup;
+
+
+/*-----------.
+| yybackup.  |
+`-----------*/
+yybackup:
+  /* Do appropriate processing given the current state.  Read a
+     lookahead token if we need one and don't already have one.  */
+
+  /* First try to decide what to do without reference to lookahead token.  */
+  yyn = yypact[yystate];
+  if (yypact_value_is_default (yyn))
+    goto yydefault;
+
+  /* Not known => get a lookahead token if don't already have one.  */
+
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
+  if (yychar == DAS_YYEMPTY)
+    {
+      YYDPRINTF ((stderr, "Reading a token\n"));
+      yychar = yylex (&yylval, &yylloc, scanner);
+    }
+
+  if (yychar <= DAS_YYEOF)
+    {
+      yychar = DAS_YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
+      YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == DAS_YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = DAS_YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      yyerror_range[1] = yylloc;
+      goto yyerrlab1;
+    }
+  else
+    {
+      yytoken = YYTRANSLATE (yychar);
+      YY_SYMBOL_PRINT ("Next token is", yytoken, &yylval, &yylloc);
+    }
+
+  /* If the proper action on seeing token YYTOKEN is to reduce or to
+     detect an error, take that action.  */
+  yyn += yytoken;
+  if (yyn < 0 || YYLAST < yyn || yycheck[yyn] != yytoken)
+    goto yydefault;
+  yyn = yytable[yyn];
+  if (yyn <= 0)
+    {
+      if (yytable_value_is_error (yyn))
+        goto yyerrlab;
+      yyn = -yyn;
+      goto yyreduce;
+    }
+
+  /* Count tokens shifted since error; after three, turn off error
+     status.  */
+  if (yyerrstatus)
+    yyerrstatus--;
+
+  /* Shift the lookahead token.  */
+  YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
+  yystate = yyn;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
+  *++yylsp = yylloc;
+
+  /* Discard the shifted token.  */
+  yychar = DAS_YYEMPTY;
+  goto yynewstate;
+
+
+/*-----------------------------------------------------------.
+| yydefault -- do the default action for the current state.  |
+`-----------------------------------------------------------*/
+yydefault:
+  yyn = yydefact[yystate];
+  if (yyn == 0)
+    goto yyerrlab;
+  goto yyreduce;
+
+
+/*-----------------------------.
+| yyreduce -- do a reduction.  |
+`-----------------------------*/
+yyreduce:
+  /* yyn is the number of a rule to reduce with.  */
+  yylen = yyr2[yyn];
+
+  /* If YYLEN is nonzero, implement the default value of the action:
+     '$$ = $1'.
+
+     Otherwise, the following line sets YYVAL to garbage.
+     This behavior is undocumented and Bison
+     users should not rely upon it.  Assigning to YYVAL
+     unconditionally makes the parser a bit smaller, and it avoids a
+     GCC warning that YYVAL may be used uninitialized.  */
+  yyval = yyvsp[1-yylen];
+
+  /* Default location. */
+  YYLLOC_DEFAULT (yyloc, (yylsp - yylen), yylen);
+  yyerror_range[1] = yyloc;
+  YY_REDUCE_PRINT (yyn);
+  switch (yyn)
+    {
+  case 3: /* program: program module_declaration  */
+                                   {
+            if ( yyextra->das_has_type_declarations ) {
+                das_yyerror(scanner,"module name has to be first declaration",tokAt(scanner,(yylsp[0])), CompilationError::syntax_error);
+            }
+        }
+    break;
+
+  case 4: /* program: program structure_declaration  */
+                                                { yyextra->das_has_type_declarations = true; }
+    break;
+
+  case 5: /* program: program enum_declaration  */
+                                                { yyextra->das_has_type_declarations = true; }
+    break;
+
+  case 6: /* program: program global_let  */
+                                                { yyextra->das_has_type_declarations = true; }
+    break;
+
+  case 7: /* program: program global_function_declaration  */
+                                                { yyextra->das_has_type_declarations = true; }
+    break;
+
+  case 11: /* program: program alias_declaration  */
+                                                { yyextra->das_has_type_declarations = true; }
+    break;
+
+  case 12: /* program: program variant_alias_declaration  */
+                                                { yyextra->das_has_type_declarations = true; }
+    break;
+
+  case 13: /* program: program tuple_alias_declaration  */
+                                                { yyextra->das_has_type_declarations = true; }
+    break;
+
+  case 14: /* program: program bitfield_alias_declaration  */
+                                                { yyextra->das_has_type_declarations = true; }
+    break;
+
+  case 17: /* top_level_reader_macro: expr_reader "end of expression"  */
+                             {
+        delete (yyvsp[-1].pExpression);    // we do nothing, we don't even attemp to 'visit'
+    }
+    break;
+
+  case 18: /* optional_public_or_private_module: %empty  */
+                        { (yyval.b) = yyextra->g_Program->policies.default_module_public; }
+    break;
+
+  case 19: /* optional_public_or_private_module: "public"  */
+                        { (yyval.b) = true; }
+    break;
+
+  case 20: /* optional_public_or_private_module: "private"  */
+                        { (yyval.b) = false; }
+    break;
+
+  case 21: /* module_name: '$'  */
+                    { (yyval.s) = new string("$"); }
+    break;
+
+  case 22: /* module_name: "name"  */
+                    { (yyval.s) = (yyvsp[0].s); }
+    break;
+
+  case 23: /* module_declaration: "module" module_name optional_shared optional_public_or_private_module  */
+                                                                                                      {
+        yyextra->g_Program->thisModuleName = *(yyvsp[-2].s);
+        yyextra->g_Program->thisModule->isPublic = (yyvsp[0].b);
+        yyextra->g_Program->thisModule->isModule = true;
+        if ( yyextra->g_Program->thisModule->name.empty() ) {
+            yyextra->g_Program->thisModule->name = *(yyvsp[-2].s);
+        } else if ( yyextra->g_Program->thisModule->name != *(yyvsp[-2].s) ){
+            das_yyerror(scanner,"this module already has a name " + yyextra->g_Program->thisModule->name,tokAt(scanner,(yylsp[-2])),
+                CompilationError::module_already_has_a_name);
+        }
+        if ( !yyextra->g_Program->policies.ignore_shared_modules ) {
+            yyextra->g_Program->promoteToBuiltin = (yyvsp[-1].b);
+        }
+        delete (yyvsp[-2].s);
+    }
+    break;
+
+  case 24: /* character_sequence: STRING_CHARACTER  */
+                                                                                  { (yyval.s) = new string(); *(yyval.s) += (yyvsp[0].ch); }
+    break;
+
+  case 25: /* character_sequence: STRING_CHARACTER_ESC  */
+                                                                                  { (yyval.s) = new string(); *(yyval.s) += "\\\\"; }
+    break;
+
+  case 26: /* character_sequence: character_sequence STRING_CHARACTER  */
+                                                                                  { (yyval.s) = (yyvsp[-1].s); *(yyvsp[-1].s) += (yyvsp[0].ch); }
+    break;
+
+  case 27: /* character_sequence: character_sequence STRING_CHARACTER_ESC  */
+                                                                                  { (yyval.s) = (yyvsp[-1].s); *(yyvsp[-1].s) += "\\\\"; }
+    break;
+
+  case 28: /* string_constant: "start of the string" character_sequence "end of the string"  */
+                                                           { (yyval.s) = (yyvsp[-1].s); }
+    break;
+
+  case 29: /* string_constant: "start of the string" "end of the string"  */
+                                                           { (yyval.s) = new string(); }
+    break;
+
+  case 30: /* string_builder_body: %empty  */
+        {
+        (yyval.pExpression) = new ExprStringBuilder();
+        (yyval.pExpression)->at = LineInfo(yyextra->g_FileAccessStack.back(),
+            yylloc.first_column,yylloc.first_line,yylloc.last_column,yylloc.last_line);
+    }
+    break;
+
+  case 31: /* string_builder_body: string_builder_body character_sequence  */
+                                                                                  {
+        bool err;
+        auto esconst = unescapeString(*(yyvsp[0].s),&err);
+        if ( err ) das_yyerror(scanner,"invalid escape sequence",tokAt(scanner,(yylsp[-1])), CompilationError::invalid_escape_sequence);
+        auto sc = make_smart<ExprConstString>(tokAt(scanner,(yylsp[0])),esconst);
+        delete (yyvsp[0].s);
+        static_cast<ExprStringBuilder *>((yyvsp[-1].pExpression))->elements.push_back(sc);
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 32: /* string_builder_body: string_builder_body "{" expr "}"  */
+                                                                                                        {
+        auto se = ExpressionPtr((yyvsp[-1].pExpression));
+        static_cast<ExprStringBuilder *>((yyvsp[-3].pExpression))->elements.push_back(se);
+        (yyval.pExpression) = (yyvsp[-3].pExpression);
+    }
+    break;
+
+  case 33: /* string_builder: "start of the string" string_builder_body "end of the string"  */
+                                                                   {
+        auto strb = static_cast<ExprStringBuilder *>((yyvsp[-1].pExpression));
+        if ( strb->elements.size()==0 ) {
+            (yyval.pExpression) = new ExprConstString(tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])),"");
+            delete (yyvsp[-1].pExpression);
+        } else if ( strb->elements.size()==1 && strb->elements[0]->rtti_isStringConstant() ) {
+            auto sconst = static_pointer_cast<ExprConstString>(strb->elements[0]);
+            (yyval.pExpression) = new ExprConstString(tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])),sconst->text);
+            delete (yyvsp[-1].pExpression);
+        } else {
+            (yyval.pExpression) = (yyvsp[-1].pExpression);
+        }
+    }
+    break;
+
+  case 34: /* reader_character_sequence: STRING_CHARACTER  */
+                               {
+        if ( !yyextra->g_ReaderMacro->accept(yyextra->g_Program.get(), yyextra->g_Program->thisModule.get(), yyextra->g_ReaderExpr, (yyvsp[0].ch), tokAt(scanner,(yylsp[0]))) ) {
+            das_yyend_reader(scanner);
+        }
+    }
+    break;
+
+  case 35: /* reader_character_sequence: reader_character_sequence STRING_CHARACTER  */
+                                                                {
+        if ( !yyextra->g_ReaderMacro->accept(yyextra->g_Program.get(), yyextra->g_Program->thisModule.get(), yyextra->g_ReaderExpr, (yyvsp[0].ch), tokAt(scanner,(yylsp[0]))) ) {
+            das_yyend_reader(scanner);
+        }
+    }
+    break;
+
+  case 36: /* $@1: %empty  */
+                                        {
+        auto macros = yyextra->g_Program->getReaderMacro(*(yyvsp[0].s));
+        if ( macros.size()==0 ) {
+            das_yyerror(scanner,"reader macro " + *(yyvsp[0].s) + " not found",tokAt(scanner,(yylsp[0])),
+                CompilationError::unsupported_read_macro);
+        } else if ( macros.size()>1 ) {
+            string options;
+            for ( auto & x : macros ) {
+                options += "\t" + x->module->name + "::" + x->name + "\n";
+            }
+            das_yyerror(scanner,"too many options for the reader macro " + *(yyvsp[0].s) +  "\n" + options, tokAt(scanner,(yylsp[0])),
+                CompilationError::unsupported_read_macro);
+        } else if ( yychar != '~' ) {
+            das_yyerror(scanner,"expecting ~ after the reader macro", tokAt(scanner,(yylsp[0])),
+                CompilationError::syntax_error);
+        } else {
+            yyextra->g_ReaderMacro = macros.back().get();
+            yyextra->g_ReaderExpr = new ExprReader(tokAt(scanner,(yylsp[-1])),yyextra->g_ReaderMacro);
+            yyclearin ;
+            das_yybegin_reader(scanner);
+        }
+    }
+    break;
+
+  case 37: /* expr_reader: '%' name_in_namespace $@1 reader_character_sequence  */
+                                     {
+        yyextra->g_ReaderExpr->at = tokRangeAt(scanner,(yylsp[-3]),(yylsp[0]));
+        (yyval.pExpression) = yyextra->g_ReaderExpr;
+        int thisLine = 0;
+        FileInfo * info = nullptr;
+        if (!format::is_enabled()) {
+        if ( auto seqt = yyextra->g_ReaderMacro->suffix(yyextra->g_Program.get(), yyextra->g_Program->thisModule.get(), yyextra->g_ReaderExpr, thisLine, info, tokAt(scanner,(yylsp[0]))) ) {
+            das_accept_sequence(scanner,seqt,strlen(seqt),thisLine,info);
+            yylloc.first_column = (yylsp[0]).first_column;
+            yylloc.first_line = (yylsp[0]).first_line;
+            yylloc.last_column = (yylsp[0]).last_column;
+            yylloc.last_line = (yylsp[0]).last_line;
+        }
+        }
+        delete (yyvsp[-2].s);
+        yyextra->g_ReaderMacro = nullptr;
+        yyextra->g_ReaderExpr = nullptr;
+    }
+    break;
+
+  case 38: /* options_declaration: "options" annotation_argument_list  */
+                                                   {
+        for ( auto & opt : *(yyvsp[0].aaList) ) {
+            if ( opt.name=="indenting" && opt.type==Type::tInt ) {
+                if (opt.iValue != 0 && opt.iValue != 2 && opt.iValue != 4 && opt.iValue != 8) { //this is error
+                    yyextra->das_tab_size = yyextra->das_def_tab_size;
+                } else {
+                    yyextra->das_tab_size = opt.iValue ? opt.iValue : yyextra->das_def_tab_size;//0 is default
+                }
+                yyextra->g_FileAccessStack.back()->tabSize = yyextra->das_tab_size;
+            } else if ( opt.name=="gen2_make_syntax" && opt.type==Type::tBool ) {
+                yyextra->das_gen2_make_syntax = opt.bValue;
+            }
+        }
+        if ( yyextra->g_Program->options.size() ) {
+            for ( auto & opt : *(yyvsp[0].aaList) ) {
+                if ( yyextra->g_Access->isOptionAllowed(opt.name, yyextra->g_Program->thisModuleName) ) {
+                    yyextra->g_Program->options.push_back(opt);
+                } else {
+                    das_yyerror(scanner,"option " + opt.name + " is not allowed here",
+                        tokAt(scanner,(yylsp[0])), CompilationError::invalid_option);
+                }
+            }
+        } else {
+            swap ( yyextra->g_Program->options, *(yyvsp[0].aaList) );
+        }
+        delete (yyvsp[0].aaList);
+    }
+    break;
+
+  case 40: /* keyword_or_name: "name"  */
+                            { (yyval.s) = (yyvsp[0].s); }
+    break;
+
+  case 41: /* keyword_or_name: "keyword"  */
+                            { (yyval.s) = (yyvsp[0].s); }
+    break;
+
+  case 42: /* keyword_or_name: "type function"  */
+                            { (yyval.s) = (yyvsp[0].s); }
+    break;
+
+  case 43: /* require_module_name: keyword_or_name  */
+                              {
+        (yyval.s) = (yyvsp[0].s);
+    }
+    break;
+
+  case 44: /* require_module_name: '%' require_module_name  */
+                                     {
+        *(yyvsp[0].s) = "%" + *(yyvsp[0].s);
+        (yyval.s) = (yyvsp[0].s);
+    }
+    break;
+
+  case 45: /* require_module_name: require_module_name '.' keyword_or_name  */
+                                                           {
+        *(yyvsp[-2].s) += ".";
+        *(yyvsp[-2].s) += *(yyvsp[0].s);
+        delete (yyvsp[0].s);
+        (yyval.s) = (yyvsp[-2].s);
+    }
+    break;
+
+  case 46: /* require_module_name: require_module_name '/' keyword_or_name  */
+                                                           {
+        *(yyvsp[-2].s) += "/";
+        *(yyvsp[-2].s) += *(yyvsp[0].s);
+        delete (yyvsp[0].s);
+        (yyval.s) = (yyvsp[-2].s);
+    }
+    break;
+
+  case 47: /* require_module: require_module_name is_public_module  */
+                                                         {
+        ast_requireModule(scanner,(yyvsp[-1].s),nullptr,(yyvsp[0].b),tokAt(scanner,(yylsp[-1])));
+    }
+    break;
+
+  case 48: /* require_module: require_module_name "as" "name" is_public_module  */
+                                                                              {
+        ast_requireModule(scanner,(yyvsp[-3].s),(yyvsp[-1].s),(yyvsp[0].b),tokAt(scanner,(yylsp[-3])));
+    }
+    break;
+
+  case 49: /* is_public_module: %empty  */
+                    { (yyval.b) = false; }
+    break;
+
+  case 50: /* is_public_module: "public"  */
+                    { (yyval.b) = true; }
+    break;
+
+  case 54: /* expect_error: "integer constant"  */
+                   {
+        yyextra->g_Program->expectErrors[CompilationError((yyvsp[0].i))] ++;
+    }
+    break;
+
+  case 55: /* expect_error: "integer constant" ':' "integer constant"  */
+                                      {
+        yyextra->g_Program->expectErrors[CompilationError((yyvsp[-2].i))] += (yyvsp[0].i);
+    }
+    break;
+
+  case 56: /* expression_label: "label" "integer constant" ':'  */
+                                          {
+        (yyval.pExpression) = new ExprLabel(tokAt(scanner,(yylsp[-2])),(yyvsp[-1].i));
+    }
+    break;
+
+  case 57: /* expression_goto: "goto" "label" "integer constant"  */
+                                                {
+        (yyval.pExpression) = new ExprGoto(tokAt(scanner,(yylsp[-2])),(yyvsp[0].i));
+    }
+    break;
+
+  case 58: /* expression_goto: "goto" expr  */
+                               {
+        (yyval.pExpression) = new ExprGoto(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[0].pExpression)));
+    }
+    break;
+
+  case 59: /* elif_or_static_elif: "elif"  */
+                          { (yyval.b) = false; }
+    break;
+
+  case 60: /* elif_or_static_elif: "static_elif"  */
+                          { (yyval.b) = true; }
+    break;
+
+  case 61: /* expression_else: %empty  */
+                                                           { (yyval.pExpression) = nullptr; }
+    break;
+
+  case 62: /* expression_else: "else" expression_block  */
+                                                           { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 63: /* expression_else: elif_or_static_elif expr expression_block expression_else  */
+                                                                                          {
+        auto eite = new ExprIfThenElse(tokAt(scanner,(yylsp[-3])),ExpressionPtr((yyvsp[-2].pExpression)),
+            ExpressionPtr((yyvsp[-1].pExpression)),ExpressionPtr((yyvsp[0].pExpression)));
+        eite->isStatic = (yyvsp[-3].b);
+        (yyval.pExpression) = eite;
+    }
+    break;
+
+  case 64: /* if_or_static_if: "if"  */
+                        { (yyval.b) = false; }
+    break;
+
+  case 65: /* if_or_static_if: "static_if"  */
+                        { (yyval.b) = true; }
+    break;
+
+  case 66: /* expression_else_one_liner: %empty  */
+        { (yyval.pExpression) = nullptr; }
+    break;
+
+  case 67: /* $@2: %empty  */
+                      { yyextra->das_need_oxford_comma = true; }
+    break;
+
+  case 68: /* expression_else_one_liner: "else" $@2 expression_if_one_liner  */
+                                                                                                 {
+            (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 69: /* expression_if_one_liner: expr  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 70: /* expression_if_one_liner: expression_return_no_pipe  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 71: /* expression_if_one_liner: expression_yield_no_pipe  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 72: /* expression_if_one_liner: expression_break  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 73: /* expression_if_one_liner: expression_continue  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 74: /* expression_if_then_else: if_or_static_if expr expression_block expression_else  */
+                                                                                      {
+        auto eite = new ExprIfThenElse(tokAt(scanner,(yylsp[-3])),ExpressionPtr((yyvsp[-2].pExpression)),
+            ExpressionPtr((yyvsp[-1].pExpression)),ExpressionPtr((yyvsp[0].pExpression)));
+        eite->isStatic = (yyvsp[-3].b);
+        (yyval.pExpression) = eite;
+    }
+    break;
+
+  case 75: /* $@3: %empty  */
+                                                     { yyextra->das_need_oxford_comma = true; }
+    break;
+
+  case 76: /* expression_if_then_else: expression_if_one_liner "if" $@3 expr expression_else_one_liner "end of expression"  */
+                                                                                                                                                   {
+        (yyval.pExpression) = new ExprIfThenElse(tokAt(scanner,(yylsp[-4])),ExpressionPtr((yyvsp[-2].pExpression)),ExpressionPtr(ast_wrapInBlock((yyvsp[-5].pExpression))),(yyvsp[-1].pExpression) ? ExpressionPtr(ast_wrapInBlock((yyvsp[-1].pExpression))) : nullptr);
+    }
+    break;
+
+  case 77: /* $@4: %empty  */
+                     { yyextra->das_need_oxford_comma=false; }
+    break;
+
+  case 78: /* expression_for_loop: "for" $@4 variable_name_with_pos_list "in" expr_list expression_block  */
+                                                                                                                                                 {
+        (yyval.pExpression) = ast_forLoop(scanner,(yyvsp[-3].pNameWithPosList),(yyvsp[-1].pExpression),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-5])),tokAt(scanner,(yylsp[0])));
+    }
+    break;
+
+  case 79: /* expression_unsafe: "unsafe" expression_block  */
+                                                 {
+        auto pUnsafe = new ExprUnsafe(tokAt(scanner,(yylsp[-1])));
+        pUnsafe->body = ExpressionPtr((yyvsp[0].pExpression));
+        (yyval.pExpression) = pUnsafe;
+    }
+    break;
+
+  case 80: /* expression_while_loop: "while" expr expression_block  */
+                                                               {
+        auto pWhile = new ExprWhile(tokAt(scanner,(yylsp[-2])));
+        pWhile->cond = ExpressionPtr((yyvsp[-1].pExpression));
+        pWhile->body = ExpressionPtr((yyvsp[0].pExpression));
+        ((ExprBlock *)(yyvsp[0].pExpression))->inTheLoop = true;
+        (yyval.pExpression) = pWhile;
+    }
+    break;
+
+  case 81: /* expression_with: "with" expr expression_block  */
+                                                         {
+        auto pWith = new ExprWith(tokAt(scanner,(yylsp[-2])));
+        pWith->with = ExpressionPtr((yyvsp[-1].pExpression));
+        pWith->body = ExpressionPtr((yyvsp[0].pExpression));
+        (yyval.pExpression) = pWith;
+    }
+    break;
+
+  case 82: /* $@5: %empty  */
+                                        { yyextra->das_need_oxford_comma=true; }
+    break;
+
+  case 83: /* expression_with_alias: "assume" "name" '=' $@5 expr  */
+                                                                                               {
+        (yyval.pExpression) = new ExprAssume(tokAt(scanner,(yylsp[-4])), *(yyvsp[-3].s), (yyvsp[0].pExpression) );
+        delete (yyvsp[-3].s);
+    }
+    break;
+
+  case 84: /* annotation_argument_value: string_constant  */
+                                 { (yyval.aa) = new AnnotationArgument("",*(yyvsp[0].s)); delete (yyvsp[0].s); }
+    break;
+
+  case 85: /* annotation_argument_value: "name"  */
+                                 { (yyval.aa) = new AnnotationArgument("",*(yyvsp[0].s)); delete (yyvsp[0].s); }
+    break;
+
+  case 86: /* annotation_argument_value: "integer constant"  */
+                                 { (yyval.aa) = new AnnotationArgument("",(yyvsp[0].i)); }
+    break;
+
+  case 87: /* annotation_argument_value: "floating point constant"  */
+                                 { (yyval.aa) = new AnnotationArgument("",float((yyvsp[0].fd))); }
+    break;
+
+  case 88: /* annotation_argument_value: "true"  */
+                                 { (yyval.aa) = new AnnotationArgument("",true); }
+    break;
+
+  case 89: /* annotation_argument_value: "false"  */
+                                 { (yyval.aa) = new AnnotationArgument("",false); }
+    break;
+
+  case 90: /* annotation_argument_value_list: annotation_argument_value  */
+                                       {
+        (yyval.aaList) = new AnnotationArgumentList();
+        (yyval.aaList)->push_back(*(yyvsp[0].aa));
+        delete (yyvsp[0].aa);
+    }
+    break;
+
+  case 91: /* annotation_argument_value_list: annotation_argument_value_list ',' annotation_argument_value  */
+                                                                                {
+            (yyval.aaList) = (yyvsp[-2].aaList);
+            (yyval.aaList)->push_back(*(yyvsp[0].aa));
+            delete (yyvsp[0].aa);
+    }
+    break;
+
+  case 92: /* annotation_argument_name: "name"  */
+                    { (yyval.s) = (yyvsp[0].s); }
+    break;
+
+  case 93: /* annotation_argument_name: "type"  */
+                    { (yyval.s) = new string("type"); }
+    break;
+
+  case 94: /* annotation_argument_name: "in"  */
+                    { (yyval.s) = new string("in"); }
+    break;
+
+  case 95: /* annotation_argument: annotation_argument_name '=' string_constant  */
+                                                                    { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),*(yyvsp[0].s),tokAt(scanner,(yylsp[-2]))); delete (yyvsp[0].s); delete (yyvsp[-2].s); }
+    break;
+
+  case 96: /* annotation_argument: annotation_argument_name '=' "name"  */
+                                                                    { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),*(yyvsp[0].s),tokAt(scanner,(yylsp[-2]))); delete (yyvsp[0].s); delete (yyvsp[-2].s); }
+    break;
+
+  case 97: /* annotation_argument: annotation_argument_name '=' "integer constant"  */
+                                                                    { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),(yyvsp[0].i),tokAt(scanner,(yylsp[-2]))); delete (yyvsp[-2].s); }
+    break;
+
+  case 98: /* annotation_argument: annotation_argument_name '=' "floating point constant"  */
+                                                                    { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),float((yyvsp[0].fd)),tokAt(scanner,(yylsp[-2]))); delete (yyvsp[-2].s); }
+    break;
+
+  case 99: /* annotation_argument: annotation_argument_name '=' "true"  */
+                                                                    { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),true,tokAt(scanner,(yylsp[-2]))); delete (yyvsp[-2].s); }
+    break;
+
+  case 100: /* annotation_argument: annotation_argument_name '=' "false"  */
+                                                                    { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),false,tokAt(scanner,(yylsp[-2]))); delete (yyvsp[-2].s); }
+    break;
+
+  case 101: /* annotation_argument: annotation_argument_name  */
+                                                                    { (yyval.aa) = new AnnotationArgument(*(yyvsp[0].s),true,tokAt(scanner,(yylsp[0]))); delete (yyvsp[0].s); }
+    break;
+
+  case 102: /* annotation_argument: annotation_argument_name '=' '(' annotation_argument_value_list ')'  */
+                                                                                          {
+        { (yyval.aa) = new AnnotationArgument(*(yyvsp[-4].s),(yyvsp[-1].aaList),tokAt(scanner,(yylsp[-4]))); delete (yyvsp[-4].s); }
+    }
+    break;
+
+  case 103: /* annotation_argument_list: annotation_argument  */
+                                  {
+        (yyval.aaList) = ast_annotationArgumentListEntry(scanner,new AnnotationArgumentList(),(yyvsp[0].aa));
+    }
+    break;
+
+  case 104: /* annotation_argument_list: annotation_argument_list ',' annotation_argument  */
+                                                                    {
+        (yyval.aaList) = ast_annotationArgumentListEntry(scanner,(yyvsp[-2].aaList),(yyvsp[0].aa));
+    }
+    break;
+
+  case 105: /* metadata_argument_list: '@' annotation_argument  */
+                                      {
+        (yyval.aaList) = ast_annotationArgumentListEntry(scanner,new AnnotationArgumentList(),(yyvsp[0].aa));
+    }
+    break;
+
+  case 106: /* metadata_argument_list: metadata_argument_list '@' annotation_argument  */
+                                                                  {
+        (yyval.aaList) = ast_annotationArgumentListEntry(scanner,(yyvsp[-2].aaList),(yyvsp[0].aa));
+    }
+    break;
+
+  case 107: /* metadata_argument_list: metadata_argument_list "end of expression"  */
+                                         {
+        (yyval.aaList) = (yyvsp[-1].aaList);
+    }
+    break;
+
+  case 108: /* annotation_declaration_name: name_in_namespace  */
+                                    { (yyval.s) = (yyvsp[0].s); }
+    break;
+
+  case 109: /* annotation_declaration_name: "require"  */
+                                    { (yyval.s) = new string("require"); }
+    break;
+
+  case 110: /* annotation_declaration_name: "private"  */
+                                    { (yyval.s) = new string("private"); }
+    break;
+
+  case 111: /* annotation_declaration_name: "template"  */
+                                    { (yyval.s) = new string("template"); }
+    break;
+
+  case 112: /* annotation_declaration_basic: annotation_declaration_name  */
+                                          {
+        (yyval.fa) = new AnnotationDeclaration();
+        (yyval.fa)->at = tokAt(scanner,(yylsp[0]));
+        if ( yyextra->g_Access->isAnnotationAllowed(*(yyvsp[0].s), yyextra->g_Program->thisModuleName) ) {
+            if ( auto ann = findAnnotation(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0]))) ) {
+                (yyval.fa)->annotation = ann;
+            }
+        } else {
+            das_yyerror(scanner,"annotation " + *(yyvsp[0].s) + " is not allowed here",
+                        tokAt(scanner,(yylsp[0])), CompilationError::invalid_annotation);
+        }
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 113: /* annotation_declaration_basic: annotation_declaration_name '(' annotation_argument_list ')'  */
+                                                                                 {
+        (yyval.fa) = new AnnotationDeclaration();
+        (yyval.fa)->at = tokAt(scanner,(yylsp[-3]));
+        if ( yyextra->g_Access->isAnnotationAllowed(*(yyvsp[-3].s), yyextra->g_Program->thisModuleName) ) {
+            if ( auto ann = findAnnotation(scanner,*(yyvsp[-3].s),tokAt(scanner,(yylsp[-3]))) ) {
+                (yyval.fa)->annotation = ann;
+            }
+        } else {
+            das_yyerror(scanner,"annotation " + *(yyvsp[-3].s) + " is not allowed here",
+                        tokAt(scanner,(yylsp[-3])), CompilationError::invalid_annotation);
+        }
+        swap ( (yyval.fa)->arguments, *(yyvsp[-1].aaList) );
+        delete (yyvsp[-1].aaList);
+        delete (yyvsp[-3].s);
+    }
+    break;
+
+  case 114: /* annotation_declaration: annotation_declaration_basic  */
+                                          {
+        (yyval.fa) = (yyvsp[0].fa);
+    }
+    break;
+
+  case 115: /* annotation_declaration: '!' annotation_declaration  */
+                                              {
+        if ( !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
+                CompilationError::invalid_annotation); }
+        (yyval.fa) = new AnnotationDeclaration();
+        (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));
+        (yyval.fa)->annotation = newLogicAnnotation(LogicAnnotationOp::Not,(yyvsp[0].fa),nullptr);
+    }
+    break;
+
+  case 116: /* annotation_declaration: annotation_declaration "&&" annotation_declaration  */
+                                                                              {
+        if ( !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
+                CompilationError::invalid_annotation); }
+        if ( !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
+                CompilationError::invalid_annotation); }
+        (yyval.fa) = new AnnotationDeclaration();
+        (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));
+        (yyval.fa)->annotation = newLogicAnnotation(LogicAnnotationOp::And,(yyvsp[-2].fa),(yyvsp[0].fa));
+    }
+    break;
+
+  case 117: /* annotation_declaration: annotation_declaration "||" annotation_declaration  */
+                                                                            {
+        if ( !(yyvsp[-2].fa)->annotation || !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
+                CompilationError::invalid_annotation); }
+        if ( !(yyvsp[0].fa)->annotation || !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
+                CompilationError::invalid_annotation); }
+        (yyval.fa) = new AnnotationDeclaration();
+        (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));
+        (yyval.fa)->annotation = newLogicAnnotation(LogicAnnotationOp::Or,(yyvsp[-2].fa),(yyvsp[0].fa));
+    }
+    break;
+
+  case 118: /* annotation_declaration: annotation_declaration "^^" annotation_declaration  */
+                                                                              {
+        if ( !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
+                CompilationError::invalid_annotation); }
+        if ( !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation.get()))->isSpecialized() ) {
+            das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
+                CompilationError::invalid_annotation); }
+        (yyval.fa) = new AnnotationDeclaration();
+        (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));
+        (yyval.fa)->annotation = newLogicAnnotation(LogicAnnotationOp::Xor,(yyvsp[-2].fa),(yyvsp[0].fa));
+    }
+    break;
+
+  case 119: /* annotation_declaration: '(' annotation_declaration ')'  */
+                                            {
+        (yyval.fa) = (yyvsp[-1].fa);
+    }
+    break;
+
+  case 120: /* annotation_declaration: "|>" annotation_declaration  */
+                                          {
+        (yyval.fa) = (yyvsp[0].fa);
+        (yyvsp[0].fa)->inherited = true;
+    }
+    break;
+
+  case 121: /* annotation_list: annotation_declaration  */
+                                    {
+            (yyval.faList) = new AnnotationList();
+            (yyval.faList)->push_back(AnnotationDeclarationPtr((yyvsp[0].fa)));
+    }
+    break;
+
+  case 122: /* annotation_list: annotation_list ',' annotation_declaration  */
+                                                              {
+        (yyval.faList) = (yyvsp[-2].faList);
+        (yyval.faList)->push_back(AnnotationDeclarationPtr((yyvsp[0].fa)));
+    }
+    break;
+
+  case 123: /* optional_annotation_list: %empty  */
+                                        { (yyval.faList) = nullptr; }
+    break;
+
+  case 124: /* optional_annotation_list: '[' annotation_list ']'  */
+                                        { (yyval.faList) = (yyvsp[-1].faList); }
+    break;
+
+  case 125: /* optional_function_argument_list: %empty  */
+                                                { (yyval.pVarDeclList) = nullptr; }
+    break;
+
+  case 126: /* optional_function_argument_list: '(' ')'  */
+                                                { (yyval.pVarDeclList) = nullptr; }
+    break;
+
+  case 127: /* optional_function_argument_list: '(' function_argument_list ')'  */
+                                                { (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList); }
+    break;
+
+  case 128: /* optional_function_type: %empty  */
+        {
+        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
+    }
+    break;
+
+  case 129: /* optional_function_type: ':' type_declaration  */
+                                        {
+        (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
+    }
+    break;
+
+  case 130: /* function_name: "name"  */
+                          {
+        das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+        (yyval.s) = (yyvsp[0].s);
+    }
+    break;
+
+  case 131: /* function_name: "operator" '!'  */
+                             { (yyval.s) = new string("!"); }
+    break;
+
+  case 132: /* function_name: "operator" '~'  */
+                             { (yyval.s) = new string("~"); }
+    break;
+
+  case 133: /* function_name: "operator" "+="  */
+                             { (yyval.s) = new string("+="); }
+    break;
+
+  case 134: /* function_name: "operator" "-="  */
+                             { (yyval.s) = new string("-="); }
+    break;
+
+  case 135: /* function_name: "operator" "*="  */
+                             { (yyval.s) = new string("*="); }
+    break;
+
+  case 136: /* function_name: "operator" "/="  */
+                             { (yyval.s) = new string("/="); }
+    break;
+
+  case 137: /* function_name: "operator" "%="  */
+                             { (yyval.s) = new string("%="); }
+    break;
+
+  case 138: /* function_name: "operator" "&="  */
+                             { (yyval.s) = new string("&="); }
+    break;
+
+  case 139: /* function_name: "operator" "|="  */
+                             { (yyval.s) = new string("|="); }
+    break;
+
+  case 140: /* function_name: "operator" "^="  */
+                             { (yyval.s) = new string("^="); }
+    break;
+
+  case 141: /* function_name: "operator" "&&="  */
+                                { (yyval.s) = new string("&&="); }
+    break;
+
+  case 142: /* function_name: "operator" "||="  */
+                                { (yyval.s) = new string("||="); }
+    break;
+
+  case 143: /* function_name: "operator" "^^="  */
+                                { (yyval.s) = new string("^^="); }
+    break;
+
+  case 144: /* function_name: "operator" "&&"  */
+                             { (yyval.s) = new string("&&"); }
+    break;
+
+  case 145: /* function_name: "operator" "||"  */
+                             { (yyval.s) = new string("||"); }
+    break;
+
+  case 146: /* function_name: "operator" "^^"  */
+                             { (yyval.s) = new string("^^"); }
+    break;
+
+  case 147: /* function_name: "operator" '+'  */
+                             { (yyval.s) = new string("+"); }
+    break;
+
+  case 148: /* function_name: "operator" '-'  */
+                             { (yyval.s) = new string("-"); }
+    break;
+
+  case 149: /* function_name: "operator" '*'  */
+                             { (yyval.s) = new string("*"); }
+    break;
+
+  case 150: /* function_name: "operator" '/'  */
+                             { (yyval.s) = new string("/"); }
+    break;
+
+  case 151: /* function_name: "operator" '%'  */
+                             { (yyval.s) = new string("%"); }
+    break;
+
+  case 152: /* function_name: "operator" '<'  */
+                             { (yyval.s) = new string("<"); }
+    break;
+
+  case 153: /* function_name: "operator" '>'  */
+                             { (yyval.s) = new string(">"); }
+    break;
+
+  case 154: /* function_name: "operator" ".."  */
+                             { (yyval.s) = new string("interval"); }
+    break;
+
+  case 155: /* function_name: "operator" "=="  */
+                             { (yyval.s) = new string("=="); }
+    break;
+
+  case 156: /* function_name: "operator" "!="  */
+                             { (yyval.s) = new string("!="); }
+    break;
+
+  case 157: /* function_name: "operator" "<="  */
+                             { (yyval.s) = new string("<="); }
+    break;
+
+  case 158: /* function_name: "operator" ">="  */
+                             { (yyval.s) = new string(">="); }
+    break;
+
+  case 159: /* function_name: "operator" '&'  */
+                             { (yyval.s) = new string("&"); }
+    break;
+
+  case 160: /* function_name: "operator" '|'  */
+                             { (yyval.s) = new string("|"); }
+    break;
+
+  case 161: /* function_name: "operator" '^'  */
+                             { (yyval.s) = new string("^"); }
+    break;
+
+  case 162: /* function_name: "++" "operator"  */
+                             { (yyval.s) = new string("++"); }
+    break;
+
+  case 163: /* function_name: "--" "operator"  */
+                             { (yyval.s) = new string("--"); }
+    break;
+
+  case 164: /* function_name: "operator" "++"  */
+                             { (yyval.s) = new string("+++"); }
+    break;
+
+  case 165: /* function_name: "operator" "--"  */
+                             { (yyval.s) = new string("---"); }
+    break;
+
+  case 166: /* function_name: "operator" "<<"  */
+                             { (yyval.s) = new string("<<"); }
+    break;
+
+  case 167: /* function_name: "operator" ">>"  */
+                             { (yyval.s) = new string(">>"); }
+    break;
+
+  case 168: /* function_name: "operator" "<<="  */
+                             { (yyval.s) = new string("<<="); }
+    break;
+
+  case 169: /* function_name: "operator" ">>="  */
+                             { (yyval.s) = new string(">>="); }
+    break;
+
+  case 170: /* function_name: "operator" "<<<"  */
+                             { (yyval.s) = new string("<<<"); }
+    break;
+
+  case 171: /* function_name: "operator" ">>>"  */
+                             { (yyval.s) = new string(">>>"); }
+    break;
+
+  case 172: /* function_name: "operator" "<<<="  */
+                             { (yyval.s) = new string("<<<="); }
+    break;
+
+  case 173: /* function_name: "operator" ">>>="  */
+                             { (yyval.s) = new string(">>>="); }
+    break;
+
+  case 174: /* function_name: "operator" '[' ']'  */
+                             { (yyval.s) = new string("[]"); }
+    break;
+
+  case 175: /* function_name: "operator" "?[" ']'  */
+                                { (yyval.s) = new string("?[]"); }
+    break;
+
+  case 176: /* function_name: "operator" '.'  */
+                             { (yyval.s) = new string("."); }
+    break;
+
+  case 177: /* function_name: "operator" "?."  */
+                             { (yyval.s) = new string("?."); }
+    break;
+
+  case 178: /* function_name: "operator" '.' "name"  */
+                                       { (yyval.s) = new string(".`"+*(yyvsp[0].s)); delete (yyvsp[0].s); }
+    break;
+
+  case 179: /* function_name: "operator" '.' "name" ":="  */
+                                             { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`clone"); delete (yyvsp[-1].s); }
+    break;
+
+  case 180: /* function_name: "operator" "?." "name"  */
+                                       { (yyval.s) = new string("?.`"+*(yyvsp[0].s)); delete (yyvsp[0].s);}
+    break;
+
+  case 181: /* function_name: "operator" ":="  */
+                                { (yyval.s) = new string("clone"); }
+    break;
+
+  case 182: /* function_name: "operator" "delete"  */
+                                { (yyval.s) = new string("finalize"); }
+    break;
+
+  case 183: /* function_name: "operator" "??"  */
+                           { (yyval.s) = new string("??"); }
+    break;
+
+  case 184: /* function_name: "operator" "is"  */
+                            { (yyval.s) = new string("`is"); }
+    break;
+
+  case 185: /* function_name: "operator" "as"  */
+                            { (yyval.s) = new string("`as"); }
+    break;
+
+  case 186: /* function_name: "operator" "is" "name"  */
+                                       { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "`is`" + *(yyvsp[0].s); }
+    break;
+
+  case 187: /* function_name: "operator" "as" "name"  */
+                                       { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "`as`" + *(yyvsp[0].s); }
+    break;
+
+  case 188: /* function_name: "operator" '?' "as"  */
+                                { (yyval.s) = new string("?as"); }
+    break;
+
+  case 189: /* function_name: "operator" '?' "as" "name"  */
+                                           { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "?as`" + *(yyvsp[0].s); }
+    break;
+
+  case 190: /* function_name: "bool"  */
+                     { (yyval.s) = new string("bool"); }
+    break;
+
+  case 191: /* function_name: "string"  */
+                     { (yyval.s) = new string("string"); }
+    break;
+
+  case 192: /* function_name: "int"  */
+                     { (yyval.s) = new string("int"); }
+    break;
+
+  case 193: /* function_name: "int2"  */
+                     { (yyval.s) = new string("int2"); }
+    break;
+
+  case 194: /* function_name: "int3"  */
+                     { (yyval.s) = new string("int3"); }
+    break;
+
+  case 195: /* function_name: "int4"  */
+                     { (yyval.s) = new string("int4"); }
+    break;
+
+  case 196: /* function_name: "uint"  */
+                     { (yyval.s) = new string("uint"); }
+    break;
+
+  case 197: /* function_name: "uint2"  */
+                     { (yyval.s) = new string("uint2"); }
+    break;
+
+  case 198: /* function_name: "uint3"  */
+                     { (yyval.s) = new string("uint3"); }
+    break;
+
+  case 199: /* function_name: "uint4"  */
+                     { (yyval.s) = new string("uint4"); }
+    break;
+
+  case 200: /* function_name: "float"  */
+                     { (yyval.s) = new string("float"); }
+    break;
+
+  case 201: /* function_name: "float2"  */
+                     { (yyval.s) = new string("float2"); }
+    break;
+
+  case 202: /* function_name: "float3"  */
+                     { (yyval.s) = new string("float3"); }
+    break;
+
+  case 203: /* function_name: "float4"  */
+                     { (yyval.s) = new string("float4"); }
+    break;
+
+  case 204: /* function_name: "range"  */
+                     { (yyval.s) = new string("range"); }
+    break;
+
+  case 205: /* function_name: "urange"  */
+                     { (yyval.s) = new string("urange"); }
+    break;
+
+  case 206: /* function_name: "range64"  */
+                     { (yyval.s) = new string("range64"); }
+    break;
+
+  case 207: /* function_name: "urange64"  */
+                     { (yyval.s) = new string("urange64"); }
+    break;
+
+  case 208: /* function_name: "int64"  */
+                     { (yyval.s) = new string("int64"); }
+    break;
+
+  case 209: /* function_name: "uint64"  */
+                     { (yyval.s) = new string("uint64"); }
+    break;
+
+  case 210: /* function_name: "double"  */
+                     { (yyval.s) = new string("double"); }
+    break;
+
+  case 211: /* function_name: "int8"  */
+                     { (yyval.s) = new string("int8"); }
+    break;
+
+  case 212: /* function_name: "uint8"  */
+                     { (yyval.s) = new string("uint8"); }
+    break;
+
+  case 213: /* function_name: "int16"  */
+                     { (yyval.s) = new string("int16"); }
+    break;
+
+  case 214: /* function_name: "uint16"  */
+                     { (yyval.s) = new string("uint16"); }
+    break;
+
+  case 215: /* global_function_declaration: optional_annotation_list "def" function_declaration  */
+                                                                                {
+        (yyvsp[0].pFuncDecl)->atDecl = tokRangeAt(scanner,(yylsp[-1]),(yylsp[0]));
+        assignDefaultArguments((yyvsp[0].pFuncDecl));
+        runFunctionAnnotations(scanner, yyextra, (yyvsp[0].pFuncDecl), (yyvsp[-2].faList), tokAt(scanner,(yylsp[-2])));
+        if ( (yyvsp[0].pFuncDecl)->isGeneric() ) {
+            implAddGenericFunction(scanner,(yyvsp[0].pFuncDecl));
+        } else {
+            if ( !yyextra->g_Program->addFunction((yyvsp[0].pFuncDecl)) ) {
+                das_yyerror(scanner,"function is already defined " +
+                    (yyvsp[0].pFuncDecl)->getMangledName(),(yyvsp[0].pFuncDecl)->at,
+                        CompilationError::function_already_declared);
+            }
+        }
+        (yyvsp[0].pFuncDecl)->delRef();
+    }
+    break;
+
+  case 216: /* optional_public_or_private_function: %empty  */
+                        { (yyval.b) = yyextra->g_thisStructure ? !yyextra->g_thisStructure->privateStructure : yyextra->g_Program->thisModule->isPublic; }
+    break;
+
+  case 217: /* optional_public_or_private_function: "private"  */
+                        { (yyval.b) = false; }
+    break;
+
+  case 218: /* optional_public_or_private_function: "public"  */
+                        { (yyval.b) = true; }
+    break;
+
+  case 219: /* function_declaration_header: function_name optional_function_argument_list optional_function_type  */
+                                                                                                {
+        (yyval.pFuncDecl) = ast_functionDeclarationHeader(scanner,(yyvsp[-2].s),(yyvsp[-1].pVarDeclList),(yyvsp[0].pTypeDecl),tokAt(scanner,(yylsp[-2])));
+    }
+    break;
+
+  case 220: /* $@6: %empty  */
+                                                     {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeFunction(tak);
+        }
+    }
+    break;
+
+  case 221: /* function_declaration: optional_public_or_private_function $@6 function_declaration_header expression_block  */
+                                                                {
+        (yyvsp[-1].pFuncDecl)->body = ExpressionPtr((yyvsp[0].pExpression));
+        (yyvsp[-1].pFuncDecl)->privateFunction = !(yyvsp[-3].b);
+        (yyval.pFuncDecl) = (yyvsp[-1].pFuncDecl);
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterFunction((yyvsp[-1].pFuncDecl),tak);
+        }
+    }
+    break;
+
+  case 222: /* expression_block: "begin of code block" expressions "end of code block"  */
+                                                   {
+        if (format::is_replace_braces() &&
+            format::prepare_rule(format::Pos::from_end_prev_line(tokAt(scanner,(yylsp[-2]))))) {
+            const auto internal = format::get_substring(format::Pos::from_end_prev_line(tokAt(scanner,(yylsp[-2]))),
+                                                          format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+            format::get_writer() << "{\n" << internal << "}\n";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+        (yyval.pExpression)->at = tokRangeAt(scanner,(yylsp[-2]),(yylsp[0]));
+    }
+    break;
+
+  case 223: /* expression_block: "begin of code block" expressions "end of code block" "finally" "begin of code block" expressions "end of code block"  */
+                                                                                          {
+        if (format::is_replace_braces() &&
+            format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-6]))))) {
+            const auto internal = format::get_substring(format::Pos::from(tokAt(scanner,(yylsp[-6]))),
+                                                          format::Pos::from(tokAt(scanner,(yylsp[0]))));
+            format::get_writer() << " {" << internal << "\n}";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+
+        auto pB = (ExprBlock *) (yyvsp[-5].pExpression);
+        auto pF = (ExprBlock *) (yyvsp[-1].pExpression);
+        swap ( pB->finalList, pF->list );
+        (yyval.pExpression) = (yyvsp[-5].pExpression);
+        (yyval.pExpression)->at = tokRangeAt(scanner,(yylsp[-6]),(yylsp[0]));
+        delete (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 224: /* expr_call_pipe: expr expr_full_block_assumed_piped  */
+                                                      {
+        if ( (yyvsp[-1].pExpression)->rtti_isCallLikeExpr() ) {
+            ((ExprLooksLikeCall *)(yyvsp[-1].pExpression))->arguments.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+            (yyval.pExpression) = (yyvsp[-1].pExpression);
+        } else {
+            (yyval.pExpression) = (yyvsp[-1].pExpression);
+            delete (yyvsp[0].pExpression);
+        }
+    }
+    break;
+
+  case 225: /* expr_call_pipe: expression_keyword expr_full_block_assumed_piped  */
+                                                                    {
+        if ( (yyvsp[-1].pExpression)->rtti_isCallLikeExpr() ) {
+            ((ExprLooksLikeCall *)(yyvsp[-1].pExpression))->arguments.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+            (yyval.pExpression) = (yyvsp[-1].pExpression);
+        } else {
+            (yyval.pExpression) = (yyvsp[-1].pExpression);
+            delete (yyvsp[0].pExpression);
+        }
+    }
+    break;
+
+  case 226: /* expr_call_pipe: "generator" '<' type_declaration_no_options '>' optional_capture_list expr_full_block_assumed_piped  */
+                                                                                                                                             {
+        (yyval.pExpression) = ast_makeGenerator(scanner,(yyvsp[-3].pTypeDecl),(yyvsp[-1].pCaptList),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-5])));
+    }
+    break;
+
+  case 227: /* expression_any: "end of expression"  */
+                                            { (yyval.pExpression) = nullptr; }
+    break;
+
+  case 228: /* expression_any: expr_pipe  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 229: /* expression_any: expr_keyword  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 230: /* expression_any: expr_assign_pipe  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 231: /* expression_any: expr_assign "end of expression"  */
+                                            { (yyval.pExpression) = (yyvsp[-1].pExpression); }
+    break;
+
+  case 232: /* expression_any: expression_delete "end of expression"  */
+                                            { (yyval.pExpression) = (yyvsp[-1].pExpression); }
+    break;
+
+  case 233: /* expression_any: expression_let  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 234: /* expression_any: expression_while_loop  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 235: /* expression_any: expression_unsafe  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 236: /* expression_any: expression_with  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 237: /* expression_any: expression_with_alias  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 238: /* expression_any: expression_for_loop  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 239: /* expression_any: expression_break "end of expression"  */
+                                            { (yyval.pExpression) = (yyvsp[-1].pExpression); }
+    break;
+
+  case 240: /* expression_any: expression_continue "end of expression"  */
+                                            { (yyval.pExpression) = (yyvsp[-1].pExpression); }
+    break;
+
+  case 241: /* expression_any: expression_return  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 242: /* expression_any: expression_yield  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 243: /* expression_any: expression_if_then_else  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 244: /* expression_any: expression_try_catch  */
+                                            { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 245: /* expression_any: expression_label "end of expression"  */
+                                            { (yyval.pExpression) = (yyvsp[-1].pExpression); }
+    break;
+
+  case 246: /* expression_any: expression_goto "end of expression"  */
+                                            { (yyval.pExpression) = (yyvsp[-1].pExpression); }
+    break;
+
+  case 247: /* expression_any: "pass" "end of expression"  */
+                                            { (yyval.pExpression) = nullptr; }
+    break;
+
+  case 248: /* expressions: %empty  */
+        {
+        (yyval.pExpression) = new ExprBlock();
+        (yyval.pExpression)->at = LineInfo(yyextra->g_FileAccessStack.back(),
+            yylloc.first_column,yylloc.first_line,yylloc.last_column,yylloc.last_line);
+    }
+    break;
+
+  case 249: /* expressions: expressions expression_any  */
+                                                        {
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+        if ( (yyvsp[0].pExpression) ) {
+            static_cast<ExprBlock*>((yyvsp[-1].pExpression))->list.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+        }
+    }
+    break;
+
+  case 250: /* expressions: expressions error  */
+                                 {
+        delete (yyvsp[-1].pExpression); (yyval.pExpression) = nullptr; YYABORT;
+    }
+    break;
+
+  case 251: /* expr_keyword: "keyword" expr expression_block  */
+                                                           {
+        auto pCall = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),*(yyvsp[-2].s));
+        pCall->arguments.push_back(ExpressionPtr((yyvsp[-1].pExpression)));
+        auto resT = new TypeDecl(Type::autoinfer);
+        auto blk = ast_makeBlock(scanner,0,nullptr,nullptr,nullptr,resT,(yyvsp[0].pExpression),tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[0])));
+        pCall->arguments.push_back(ExpressionPtr(blk));
+        delete (yyvsp[-2].s);
+        (yyval.pExpression) = pCall;
+    }
+    break;
+
+  case 252: /* optional_expr_list: %empty  */
+        { (yyval.pExpression) = nullptr; }
+    break;
+
+  case 253: /* optional_expr_list: expr_list optional_comma  */
+                                            { (yyval.pExpression) = (yyvsp[-1].pExpression); }
+    break;
+
+  case 254: /* optional_expr_list_in_braces: %empty  */
+        { (yyval.pExpression) = nullptr; }
+    break;
+
+  case 255: /* optional_expr_list_in_braces: '(' optional_expr_list optional_comma ')'  */
+                                                             { (yyval.pExpression) = (yyvsp[-2].pExpression); }
+    break;
+
+  case 256: /* optional_expr_map_tuple_list: %empty  */
+        { (yyval.pExpression) = nullptr; }
+    break;
+
+  case 257: /* optional_expr_map_tuple_list: expr_map_tuple_list optional_comma  */
+                                                      { (yyval.pExpression) = (yyvsp[-1].pExpression); }
+    break;
+
+  case 258: /* type_declaration_no_options_list: type_declaration  */
+                               {
+        (yyval.pTypeDeclList) = new vector<Expression *>();
+        (yyval.pTypeDeclList)->push_back(new ExprTypeDecl(tokAt(scanner,(yylsp[0])),(yyvsp[0].pTypeDecl)));
+    }
+    break;
+
+  case 259: /* type_declaration_no_options_list: type_declaration_no_options_list c_or_s type_declaration  */
+                                                                              {
+        (yyval.pTypeDeclList) = (yyvsp[-2].pTypeDeclList);
+        (yyval.pTypeDeclList)->push_back(new ExprTypeDecl(tokAt(scanner,(yylsp[0])),(yyvsp[0].pTypeDecl)));
+    }
+    break;
+
+  case 260: /* $@7: %empty  */
+                         { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 261: /* $@8: %empty  */
+                                                                                                      { yyextra->das_arrow_depth --; }
+    break;
+
+  case 262: /* expression_keyword: "keyword" '<' $@7 type_declaration_no_options_list '>' $@8 expr  */
+                                                                                                                                                     {
+        auto pCall = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-6])),tokAt(scanner,(yylsp[0])),*(yyvsp[-6].s));
+        pCall->arguments = typesAndSequenceToList((yyvsp[-3].pTypeDeclList),(yyvsp[0].pExpression));
+        delete (yyvsp[-6].s);
+        (yyval.pExpression) = pCall;
+    }
+    break;
+
+  case 263: /* $@9: %empty  */
+                               { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 264: /* $@10: %empty  */
+                                                                                                            { yyextra->das_arrow_depth --; }
+    break;
+
+  case 265: /* expression_keyword: "type function" '<' $@9 type_declaration_no_options_list '>' $@10 optional_expr_list_in_braces  */
+                                                                                                                                                                                   {
+        auto pCall = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-6])),tokAt(scanner,(yylsp[0])),*(yyvsp[-6].s));
+        pCall->arguments = typesAndSequenceToList((yyvsp[-3].pTypeDeclList),(yyvsp[0].pExpression));
+        delete (yyvsp[-6].s);
+        (yyval.pExpression) = pCall;
+    }
+    break;
+
+  case 266: /* expr_pipe: expr_assign " <|" expr_block  */
+                                                        {
+        Expression * pipeCall = (yyvsp[-2].pExpression)->tail();
+        if ( pipeCall->rtti_isCallLikeExpr() ) {
+            auto pCall = (ExprLooksLikeCall *) pipeCall;
+            pCall->arguments.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+            (yyval.pExpression) = (yyvsp[-2].pExpression);
+        } else if ( pipeCall->rtti_isVar() ) {
+            // a += b <| c
+            auto pVar = (ExprVar *) pipeCall;
+            auto pCall = yyextra->g_Program->makeCall(pVar->at,pVar->name);
+            pCall->arguments.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+            if ( !(yyvsp[-2].pExpression)->swap_tail(pVar,pCall) ) {
+                delete pVar;
+                (yyval.pExpression) = pCall;
+            } else {
+                (yyval.pExpression) = (yyvsp[-2].pExpression);
+            }
+        } else if ( pipeCall->rtti_isMakeStruct() ) {
+            auto pMS = (ExprMakeStruct *) pipeCall;
+            if ( pMS->block ) {
+                das_yyerror(scanner,"can't pipe into [[ make structure ]]. it already has where closure",
+                    tokAt(scanner,(yylsp[-1])),CompilationError::cant_pipe);
+                delete (yyvsp[0].pExpression);
+            } else {
+                pMS->block = (yyvsp[0].pExpression);
+            }
+            (yyval.pExpression) = (yyvsp[-2].pExpression);
+        } else {
+            das_yyerror(scanner,"can only pipe into function call or [[ make structure ]]",
+                tokAt(scanner,(yylsp[-1])),CompilationError::cant_pipe);
+            delete (yyvsp[0].pExpression);
+            (yyval.pExpression) = (yyvsp[-2].pExpression);
+        }
+    }
+    break;
+
+  case 267: /* expr_pipe: "@ <|" expr_block  */
+                               {
+        (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 268: /* expr_pipe: "@@ <|" expr_block  */
+                               {
+        (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 269: /* expr_pipe: "$ <|" expr_block  */
+                               {
+        (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 270: /* expr_pipe: expr_call_pipe  */
+                             {
+        (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 271: /* name_in_namespace: "name"  */
+                                               { (yyval.s) = (yyvsp[0].s); }
+    break;
+
+  case 272: /* name_in_namespace: "name" "::" "name"  */
+                                               {
+            auto ita = yyextra->das_module_alias.find(*(yyvsp[-2].s));
+            if ( ita == yyextra->das_module_alias.end() ) {
+                *(yyvsp[-2].s) += "::";
+            } else {
+                *(yyvsp[-2].s) = ita->second + "::";
+            }
+            *(yyvsp[-2].s) += *(yyvsp[0].s);
+            delete (yyvsp[0].s);
+            (yyval.s) = (yyvsp[-2].s);
+        }
+    break;
+
+  case 273: /* name_in_namespace: "::" "name"  */
+                                               { *(yyvsp[0].s) = "::" + *(yyvsp[0].s); (yyval.s) = (yyvsp[0].s); }
+    break;
+
+  case 274: /* expression_delete: "delete" expr  */
+                                      {
+        (yyval.pExpression) = new ExprDelete(tokAt(scanner,(yylsp[-1])), ExpressionPtr((yyvsp[0].pExpression)));
+    }
+    break;
+
+  case 275: /* expression_delete: "delete" "explicit" expr  */
+                                                   {
+        auto delExpr = new ExprDelete(tokAt(scanner,(yylsp[-2])), ExpressionPtr((yyvsp[0].pExpression)));
+        delExpr->native = true;
+        (yyval.pExpression) = delExpr;
+    }
+    break;
+
+  case 276: /* $@11: %empty  */
+           { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 277: /* $@12: %empty  */
+                                                                           { yyextra->das_arrow_depth --; }
+    break;
+
+  case 278: /* new_type_declaration: '<' $@11 type_declaration '>' $@12  */
+                                                                                                            {
+        (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
+    }
+    break;
+
+  case 279: /* new_type_declaration: structure_type_declaration  */
+                                               {
+        (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
+    }
+    break;
+
+  case 280: /* expr_new: "new" new_type_declaration  */
+                                                       {
+        (yyval.pExpression) = new ExprNew(tokAt(scanner,(yylsp[-1])),TypeDeclPtr((yyvsp[0].pTypeDecl)),false);
+    }
+    break;
+
+  case 281: /* expr_new: "new" new_type_declaration '(' use_initializer ')'  */
+                                                                                     {
+        (yyval.pExpression) = new ExprNew(tokAt(scanner,(yylsp[-4])),TypeDeclPtr((yyvsp[-3].pTypeDecl)),true);
+        ((ExprNew *)(yyval.pExpression))->initializer = (yyvsp[-1].b);
+    }
+    break;
+
+  case 282: /* expr_new: "new" new_type_declaration '(' expr_list ')'  */
+                                                                                    {
+        auto pNew = new ExprNew(tokAt(scanner,(yylsp[-4])),TypeDeclPtr((yyvsp[-3].pTypeDecl)),true);
+        (yyval.pExpression) = parseFunctionArguments(pNew,(yyvsp[-1].pExpression));
+    }
+    break;
+
+  case 283: /* expr_new: "new" new_type_declaration '(' make_struct_single ')'  */
+                                                                                      {
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-3]));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-3].pTypeDecl);
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->useInitializer = true; // $init;
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->alwaysUseInitializer = true;
+        (yyval.pExpression) = new ExprAscend(tokAt(scanner,(yylsp[-4])),ExpressionPtr((yyvsp[-1].pExpression)));
+    }
+    break;
+
+  case 284: /* expr_new: "new" new_type_declaration '(' "uninitialized" make_struct_single ')'  */
+                                                                                                        {
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-4]));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-4].pTypeDecl);
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->useInitializer = false; // $init;
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->alwaysUseInitializer = true;
+        (yyval.pExpression) = new ExprAscend(tokAt(scanner,(yylsp[-5])),ExpressionPtr((yyvsp[-1].pExpression)));
+    }
+    break;
+
+  case 285: /* expr_new: "new" make_decl  */
+                                    {
+        (yyval.pExpression) = new ExprAscend(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[0].pExpression)));
+    }
+    break;
+
+  case 286: /* expression_break: "break"  */
+                       { (yyval.pExpression) = new ExprBreak(tokAt(scanner,(yylsp[0]))); }
+    break;
+
+  case 287: /* expression_continue: "continue"  */
+                          { (yyval.pExpression) = new ExprContinue(tokAt(scanner,(yylsp[0]))); }
+    break;
+
+  case 288: /* expression_return_no_pipe: "return"  */
+                        {
+        (yyval.pExpression) = new ExprReturn(tokAt(scanner,(yylsp[0])),nullptr);
+    }
+    break;
+
+  case 289: /* expression_return_no_pipe: "return" expr_list  */
+                                           {
+        (yyval.pExpression) = new ExprReturn(tokAt(scanner,(yylsp[-1])),sequenceToTuple((yyvsp[0].pExpression)));
+    }
+    break;
+
+  case 290: /* expression_return_no_pipe: "return" "<-" expr_list  */
+                                                  {
+        auto pRet = new ExprReturn(tokAt(scanner,(yylsp[-2])),sequenceToTuple((yyvsp[0].pExpression)));
+        pRet->moveSemantics = true;
+        (yyval.pExpression) = pRet;
+    }
+    break;
+
+  case 291: /* expression_return: expression_return_no_pipe "end of expression"  */
+                                              {
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 292: /* expression_return: "return" expr_pipe  */
+                                           {
+        (yyval.pExpression) = new ExprReturn(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[0].pExpression)));
+    }
+    break;
+
+  case 293: /* expression_return: "return" "<-" expr_pipe  */
+                                                  {
+        auto pRet = new ExprReturn(tokAt(scanner,(yylsp[-2])),ExpressionPtr((yyvsp[0].pExpression)));
+        pRet->moveSemantics = true;
+        (yyval.pExpression) = pRet;
+    }
+    break;
+
+  case 294: /* expression_yield_no_pipe: "yield" expr  */
+                                     {
+        (yyval.pExpression) = new ExprYield(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[0].pExpression)));
+    }
+    break;
+
+  case 295: /* expression_yield_no_pipe: "yield" "<-" expr  */
+                                            {
+        auto pRet = new ExprYield(tokAt(scanner,(yylsp[-2])),ExpressionPtr((yyvsp[0].pExpression)));
+        pRet->moveSemantics = true;
+        (yyval.pExpression) = pRet;
+    }
+    break;
+
+  case 296: /* expression_yield: expression_yield_no_pipe "end of expression"  */
+                                             {
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 297: /* expression_yield: "yield" expr_pipe  */
+                                          {
+        (yyval.pExpression) = new ExprYield(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[0].pExpression)));
+    }
+    break;
+
+  case 298: /* expression_yield: "yield" "<-" expr_pipe  */
+                                                 {
+        auto pRet = new ExprYield(tokAt(scanner,(yylsp[-2])),ExpressionPtr((yyvsp[0].pExpression)));
+        pRet->moveSemantics = true;
+        (yyval.pExpression) = pRet;
+    }
+    break;
+
+  case 299: /* expression_try_catch: "try" expression_block "recover" expression_block  */
+                                                                                       {
+        (yyval.pExpression) = new ExprTryCatch(tokAt(scanner,(yylsp[-3])),ExpressionPtr((yyvsp[-2].pExpression)),ExpressionPtr((yyvsp[0].pExpression)));
+    }
+    break;
+
+  case 300: /* kwd_let_var_or_nothing: "let"  */
+                 { (yyval.b) = true; }
+    break;
+
+  case 301: /* kwd_let_var_or_nothing: "var"  */
+                 { (yyval.b) = false; }
+    break;
+
+  case 302: /* kwd_let_var_or_nothing: %empty  */
+                    { (yyval.b) = true; }
+    break;
+
+  case 303: /* kwd_let: "let"  */
+                 { (yyval.b) = true; }
+    break;
+
+  case 304: /* kwd_let: "var"  */
+                 { (yyval.b) = false; }
+    break;
+
+  case 305: /* optional_in_scope: "inscope"  */
+                    { (yyval.b) = true; }
+    break;
+
+  case 306: /* optional_in_scope: %empty  */
+                     { (yyval.b) = false; }
+    break;
+
+  case 307: /* tuple_expansion: "name"  */
+                    {
+        (yyval.pNameList) = new vector<string>();
+        (yyval.pNameList)->push_back(*(yyvsp[0].s));
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 308: /* tuple_expansion: tuple_expansion ',' "name"  */
+                                             {
+        (yyvsp[-2].pNameList)->push_back(*(yyvsp[0].s));
+        delete (yyvsp[0].s);
+        (yyval.pNameList) = (yyvsp[-2].pNameList);
+    }
+    break;
+
+  case 309: /* tuple_expansion_variable_declaration: "[[" tuple_expansion ']' ']' ':' type_declaration_no_options copy_or_move_or_clone expr "end of expression"  */
+                                                                                                                                                            {
+        //std::cout << "case11" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-8]))))) {
+            const auto internal = format::get_substring(tokAt(scanner,(yylsp[-7])));
+            format::get_writer() << "(" << internal << ")";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[-5]))));
+        }
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-7].pNameList),tokAt(scanner,(yylsp[-7])),(yyvsp[-3].pTypeDecl),(yyvsp[-1].pExpression));
+        (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
+        (yyval.pVarDecl)->init_via_clone = ((yyvsp[-2].i) & CorM_CLONE) !=0;
+        (yyval.pVarDecl)->isTupleExpansion = true;
+    }
+    break;
+
+  case 310: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' ':' type_declaration_no_options copy_or_move_or_clone expr "end of expression"  */
+                                                                                                                          {
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-6].pNameList),tokAt(scanner,(yylsp[-6])),(yyvsp[-3].pTypeDecl),(yyvsp[-1].pExpression));
+        (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
+        (yyval.pVarDecl)->init_via_clone = ((yyvsp[-2].i) & CorM_CLONE) !=0;
+        (yyval.pVarDecl)->isTupleExpansion = true;
+    }
+    break;
+
+  case 311: /* tuple_expansion_variable_declaration: "[[" tuple_expansion ']' ']' optional_ref copy_or_move_or_clone expr "end of expression"  */
+                                                                                                                                {
+        //std::cout << "case12" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-7]))))) {
+            const auto internal = format::get_substring(tokAt(scanner,(yylsp[-6])));
+            format::get_writer() << "(" << internal << ")";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[-4]))));
+        }
+
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,(yylsp[-6]));
+        typeDecl->ref = (yyvsp[-3].b);
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-6].pNameList),tokAt(scanner,(yylsp[-6])),typeDecl,(yyvsp[-1].pExpression));
+        (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
+        (yyval.pVarDecl)->init_via_clone = ((yyvsp[-2].i) & CorM_CLONE) !=0;
+        (yyval.pVarDecl)->isTupleExpansion = true;
+    }
+    break;
+
+  case 312: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' optional_ref copy_or_move_or_clone expr "end of expression"  */
+                                                                                                  {
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,(yylsp[-5]));
+        typeDecl->ref = (yyvsp[-3].b);
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-5].pNameList),tokAt(scanner,(yylsp[-5])),typeDecl,(yyvsp[-1].pExpression));
+        (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
+        (yyval.pVarDecl)->init_via_clone = ((yyvsp[-2].i) & CorM_CLONE) !=0;
+        (yyval.pVarDecl)->isTupleExpansion = true;
+    }
+    break;
+
+  case 313: /* expression_let: kwd_let optional_in_scope let_variable_declaration  */
+                                                                 {
+        (yyval.pExpression) = ast_Let(scanner,(yyvsp[-2].b),(yyvsp[-1].b),(yyvsp[0].pVarDecl),tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])));
+    }
+    break;
+
+  case 314: /* expression_let: kwd_let optional_in_scope tuple_expansion_variable_declaration  */
+                                                                             {
+        (yyval.pExpression) = ast_Let(scanner,(yyvsp[-2].b),(yyvsp[-1].b),(yyvsp[0].pVarDecl),tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])));
+    }
+    break;
+
+  case 315: /* $@13: %empty  */
+                          { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 316: /* $@14: %empty  */
+                                                                                                 { yyextra->das_arrow_depth --; }
+    break;
+
+  case 317: /* expr_cast: "cast" '<' $@13 type_declaration_no_options '>' $@14 expr  */
+                                                                                                                                                {
+        (yyval.pExpression) = new ExprCast(tokAt(scanner,(yylsp[-6])),ExpressionPtr((yyvsp[0].pExpression)),TypeDeclPtr((yyvsp[-3].pTypeDecl)));
+    }
+    break;
+
+  case 318: /* $@15: %empty  */
+                            { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 319: /* $@16: %empty  */
+                                                                                                   { yyextra->das_arrow_depth --; }
+    break;
+
+  case 320: /* expr_cast: "upcast" '<' $@15 type_declaration_no_options '>' $@16 expr  */
+                                                                                                                                                  {
+        auto pCast = new ExprCast(tokAt(scanner,(yylsp[-6])),ExpressionPtr((yyvsp[0].pExpression)),TypeDeclPtr((yyvsp[-3].pTypeDecl)));
+        pCast->upcast = true;
+        (yyval.pExpression) = pCast;
+    }
+    break;
+
+  case 321: /* $@17: %empty  */
+                                 { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 322: /* $@18: %empty  */
+                                                                                                        { yyextra->das_arrow_depth --; }
+    break;
+
+  case 323: /* expr_cast: "reinterpret" '<' $@17 type_declaration_no_options '>' $@18 expr  */
+                                                                                                                                                       {
+        auto pCast = new ExprCast(tokAt(scanner,(yylsp[-6])),ExpressionPtr((yyvsp[0].pExpression)),TypeDeclPtr((yyvsp[-3].pTypeDecl)));
+        pCast->reinterpret = true;
+        (yyval.pExpression) = pCast;
+    }
+    break;
+
+  case 324: /* $@19: %empty  */
+                         { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 325: /* $@20: %empty  */
+                                                                                     { yyextra->das_arrow_depth --; }
+    break;
+
+  case 326: /* expr_type_decl: "type" '<' $@19 type_declaration '>' $@20  */
+                                                                                                                      {
+        (yyval.pExpression) = new ExprTypeDecl(tokAt(scanner,(yylsp[-5])),TypeDeclPtr((yyvsp[-2].pTypeDecl)));
+    }
+    break;
+
+  case 327: /* expr_type_info: "typeinfo" '(' name_in_namespace expr ')'  */
+                                                                         {
+            if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-4])),*(yyvsp[-2].s),ptd->typeexpr);
+                delete (yyvsp[-1].pExpression);
+            } else {
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-4])),*(yyvsp[-2].s),ExpressionPtr((yyvsp[-1].pExpression)));
+            }
+            delete (yyvsp[-2].s);
+    }
+    break;
+
+  case 328: /* expr_type_info: "typeinfo" '(' name_in_namespace '<' "name" '>' expr ')'  */
+                                                                                                {
+            if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-7])),*(yyvsp[-5].s),ptd->typeexpr,*(yyvsp[-3].s));
+                delete (yyvsp[-1].pExpression);
+            } else {
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-7])),*(yyvsp[-5].s),ExpressionPtr((yyvsp[-1].pExpression)),*(yyvsp[-3].s));
+            }
+            delete (yyvsp[-5].s);
+            delete (yyvsp[-3].s);
+    }
+    break;
+
+  case 329: /* expr_type_info: "typeinfo" '(' name_in_namespace '<' "name" c_or_s "name" '>' expr ')'  */
+                                                                                                                        {
+            if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-9])),*(yyvsp[-7].s),ptd->typeexpr,*(yyvsp[-5].s),*(yyvsp[-3].s));
+                delete (yyvsp[-1].pExpression);
+            } else {
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-9])),*(yyvsp[-7].s),ExpressionPtr((yyvsp[-1].pExpression)),*(yyvsp[-5].s),*(yyvsp[-3].s));
+            }
+            delete (yyvsp[-7].s);
+            delete (yyvsp[-5].s);
+            delete (yyvsp[-3].s);
+    }
+    break;
+
+  case 330: /* expr_type_info: "typeinfo" name_in_namespace '(' expr ')'  */
+                                                                          {
+            if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-4])),*(yyvsp[-3].s),ptd->typeexpr);
+                delete (yyvsp[-1].pExpression);
+            } else {
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-4])),*(yyvsp[-3].s),ExpressionPtr((yyvsp[-1].pExpression)));
+            }
+            delete (yyvsp[-3].s);
+    }
+    break;
+
+  case 331: /* expr_type_info: "typeinfo" name_in_namespace '<' "name" '>' '(' expr ')'  */
+                                                                                                {
+            if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-7])),*(yyvsp[-6].s),ptd->typeexpr,*(yyvsp[-4].s));
+                delete (yyvsp[-1].pExpression);
+            } else {
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-7])),*(yyvsp[-6].s),ExpressionPtr((yyvsp[-1].pExpression)),*(yyvsp[-4].s));
+            }
+            delete (yyvsp[-6].s);
+            delete (yyvsp[-4].s);
+    }
+    break;
+
+  case 332: /* expr_type_info: "typeinfo" name_in_namespace '<' "name" "end of expression" "name" '>' '(' expr ')'  */
+                                                                                                                     {
+            if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
+                auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-9])),*(yyvsp[-8].s),ptd->typeexpr,*(yyvsp[-6].s),*(yyvsp[-4].s));
+                delete (yyvsp[-1].pExpression);
+            } else {
+                (yyval.pExpression) = new ExprTypeInfo(tokAt(scanner,(yylsp[-9])),*(yyvsp[-8].s),ExpressionPtr((yyvsp[-1].pExpression)),*(yyvsp[-6].s),*(yyvsp[-4].s));
+            }
+            delete (yyvsp[-8].s);
+            delete (yyvsp[-6].s);
+            delete (yyvsp[-4].s);
+    }
+    break;
+
+  case 333: /* expr_list: expr  */
+                      {
+        (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 334: /* expr_list: expr_list ',' expr  */
+                                            {
+            (yyval.pExpression) = new ExprSequence(tokAt(scanner,(yylsp[-2])),ExpressionPtr((yyvsp[-2].pExpression)),ExpressionPtr((yyvsp[0].pExpression)));
+    }
+    break;
+
+  case 335: /* block_or_simple_block: expression_block  */
+                                    { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 336: /* block_or_simple_block: "=>" expr  */
+                                        {
+            auto retE = make_smart<ExprReturn>(tokAt(scanner,(yylsp[-1])), ExpressionPtr((yyvsp[0].pExpression)));
+            auto blkE = new ExprBlock();
+            blkE->at = tokAt(scanner,(yylsp[-1]));
+            blkE->list.push_back(retE);
+            (yyval.pExpression) = blkE;
+    }
+    break;
+
+  case 337: /* block_or_simple_block: "=>" "<-" expr  */
+                                               {
+            auto retE = make_smart<ExprReturn>(tokAt(scanner,(yylsp[-2])), ExpressionPtr((yyvsp[0].pExpression)));
+            retE->moveSemantics = true;
+            auto blkE = new ExprBlock();
+            blkE->at = tokAt(scanner,(yylsp[-2]));
+            blkE->list.push_back(retE);
+            (yyval.pExpression) = blkE;
+    }
+    break;
+
+  case 338: /* block_or_lambda: '$'  */
+                { (yyval.i) = 0;   /* block */  }
+    break;
+
+  case 339: /* block_or_lambda: '@'  */
+                { (yyval.i) = 1;   /* lambda */ }
+    break;
+
+  case 340: /* block_or_lambda: '@' '@'  */
+                { (yyval.i) = 2;   /* local function */ }
+    break;
+
+  case 341: /* capture_entry: '&' "name"  */
+                                    { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_reference); delete (yyvsp[0].s); }
+    break;
+
+  case 342: /* capture_entry: '=' "name"  */
+                                    { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_copy); delete (yyvsp[0].s); }
+    break;
+
+  case 343: /* capture_entry: "<-" "name"  */
+                                    { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_move); delete (yyvsp[0].s); }
+    break;
+
+  case 344: /* capture_entry: ":=" "name"  */
+                                    { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_clone); delete (yyvsp[0].s); }
+    break;
+
+  case 345: /* capture_entry: "name" '(' "name" ')'  */
+                                    { (yyval.pCapt) = ast_makeCaptureEntry(scanner,tokAt(scanner,(yylsp[-3])),*(yyvsp[-3].s),*(yyvsp[-1].s)); delete (yyvsp[-3].s); delete (yyvsp[-1].s); }
+    break;
+
+  case 346: /* capture_list: capture_entry  */
+                         {
+        (yyval.pCaptList) = new vector<CaptureEntry>();
+        (yyval.pCaptList)->push_back(*(yyvsp[0].pCapt));
+        delete (yyvsp[0].pCapt);
+    }
+    break;
+
+  case 347: /* capture_list: capture_list ',' capture_entry  */
+                                               {
+        (yyvsp[-2].pCaptList)->push_back(*(yyvsp[0].pCapt));
+        delete (yyvsp[0].pCapt);
+        (yyval.pCaptList) = (yyvsp[-2].pCaptList);
+    }
+    break;
+
+  case 348: /* optional_capture_list: %empty  */
+        { (yyval.pCaptList) = nullptr; }
+    break;
+
+  case 349: /* optional_capture_list: "[[" capture_list ']' ']'  */
+                                         {         /* I guess remains the same */; (yyval.pCaptList) = (yyvsp[-2].pCaptList); }
+    break;
+
+  case 350: /* optional_capture_list: "capture" '(' capture_list ')'  */
+                                             { (yyval.pCaptList) = (yyvsp[-1].pCaptList); }
+    break;
+
+  case 351: /* expr_block: expression_block  */
+                                            {
+        ExprBlock * closure = (ExprBlock *) (yyvsp[0].pExpression);
+        (yyval.pExpression) = new ExprMakeBlock(tokAt(scanner,(yylsp[0])),ExpressionPtr((yyvsp[0].pExpression)));
+        closure->returnType = make_smart<TypeDecl>(Type::autoinfer);
+    }
+    break;
+
+  case 352: /* expr_block: block_or_lambda optional_annotation_list optional_capture_list optional_function_argument_list optional_function_type block_or_simple_block  */
+                                                                                            {
+        (yyval.pExpression) = ast_makeBlock(scanner,(yyvsp[-5].i),(yyvsp[-4].faList),(yyvsp[-3].pCaptList),(yyvsp[-2].pVarDeclList),(yyvsp[-1].pTypeDecl),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[-4])));
+    }
+    break;
+
+  case 353: /* expr_full_block: block_or_lambda optional_annotation_list optional_capture_list optional_function_argument_list optional_function_type block_or_simple_block  */
+                                                                                            {
+        (yyval.pExpression) = ast_makeBlock(scanner,(yyvsp[-5].i),(yyvsp[-4].faList),(yyvsp[-3].pCaptList),(yyvsp[-2].pVarDeclList),(yyvsp[-1].pTypeDecl),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[-4])));
+    }
+    break;
+
+  case 354: /* $@21: %empty  */
+                             {  yyextra->das_need_oxford_comma = false; }
+    break;
+
+  case 355: /* expr_full_block_assumed_piped: block_or_lambda $@21 optional_annotation_list optional_capture_list optional_function_argument_list optional_function_type expression_block  */
+                                                                                       {
+        (yyval.pExpression) = ast_makeBlock(scanner,(yyvsp[-6].i),(yyvsp[-4].faList),(yyvsp[-3].pCaptList),(yyvsp[-2].pVarDeclList),(yyvsp[-1].pTypeDecl),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[-4])));
+    }
+    break;
+
+  case 356: /* expr_numeric_const: "integer constant"  */
+                                              { (yyval.pExpression) = new ExprConstInt(tokAt(scanner,(yylsp[0])),(int32_t)(yyvsp[0].i)); }
+    break;
+
+  case 357: /* expr_numeric_const: "unsigned integer constant"  */
+                                              { (yyval.pExpression) = new ExprConstUInt(tokAt(scanner,(yylsp[0])),(uint32_t)(yyvsp[0].ui)); }
+    break;
+
+  case 358: /* expr_numeric_const: "long integer constant"  */
+                                              { (yyval.pExpression) = new ExprConstInt64(tokAt(scanner,(yylsp[0])),(int64_t)(yyvsp[0].i64)); }
+    break;
+
+  case 359: /* expr_numeric_const: "unsigned long integer constant"  */
+                                              { (yyval.pExpression) = new ExprConstUInt64(tokAt(scanner,(yylsp[0])),(uint64_t)(yyvsp[0].ui64)); }
+    break;
+
+  case 360: /* expr_numeric_const: "unsigned int8 constant"  */
+                                              { (yyval.pExpression) = new ExprConstUInt8(tokAt(scanner,(yylsp[0])),(uint8_t)(yyvsp[0].ui)); }
+    break;
+
+  case 361: /* expr_numeric_const: "floating point constant"  */
+                                              { (yyval.pExpression) = new ExprConstFloat(tokAt(scanner,(yylsp[0])),(float)(yyvsp[0].fd)); }
+    break;
+
+  case 362: /* expr_numeric_const: "double constant"  */
+                                              { (yyval.pExpression) = new ExprConstDouble(tokAt(scanner,(yylsp[0])),(double)(yyvsp[0].d)); }
+    break;
+
+  case 363: /* expr_assign: expr  */
+                                             { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 364: /* expr_assign: expr '=' expr  */
+                                             { (yyval.pExpression) = new ExprCopy(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-2].pExpression)),ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 365: /* expr_assign: expr "<-" expr  */
+                                             { (yyval.pExpression) = new ExprMove(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 366: /* expr_assign: expr ":=" expr  */
+                                             { (yyval.pExpression) = new ExprClone(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 367: /* expr_assign: expr "&=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 368: /* expr_assign: expr "|=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"|=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 369: /* expr_assign: expr "^=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 370: /* expr_assign: expr "&&=" expr  */
+                                                { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&&=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 371: /* expr_assign: expr "||=" expr  */
+                                                { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"||=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 372: /* expr_assign: expr "^^=" expr  */
+                                                { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^^=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 373: /* expr_assign: expr "+=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"+=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 374: /* expr_assign: expr "-=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"-=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 375: /* expr_assign: expr "*=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"*=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 376: /* expr_assign: expr "/=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"/=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 377: /* expr_assign: expr "%=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"%=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 378: /* expr_assign: expr "<<=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 379: /* expr_assign: expr ">>=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 380: /* expr_assign: expr "<<<=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<<=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 381: /* expr_assign: expr ">>>=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>>=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 382: /* expr_assign_pipe_right: "@ <|" expr_block  */
+                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 383: /* expr_assign_pipe_right: "@@ <|" expr_block  */
+                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 384: /* expr_assign_pipe_right: "$ <|" expr_block  */
+                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 385: /* expr_assign_pipe_right: expr_call_pipe  */
+                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 386: /* expr_assign_pipe: expr '=' expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprCopy(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-2].pExpression)),ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 387: /* expr_assign_pipe: expr "<-" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprMove(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-2].pExpression)),ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 388: /* expr_assign_pipe: expr "&=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 389: /* expr_assign_pipe: expr "|=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"|=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 390: /* expr_assign_pipe: expr "^=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 391: /* expr_assign_pipe: expr "&&=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&&=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 392: /* expr_assign_pipe: expr "||=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"||=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 393: /* expr_assign_pipe: expr "^^=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^^=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 394: /* expr_assign_pipe: expr "+=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"+=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 395: /* expr_assign_pipe: expr "-=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"-=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 396: /* expr_assign_pipe: expr "*=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"*=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 397: /* expr_assign_pipe: expr "/=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"/=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 398: /* expr_assign_pipe: expr "%=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"%=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 399: /* expr_assign_pipe: expr "<<=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 400: /* expr_assign_pipe: expr ">>=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 401: /* expr_assign_pipe: expr "<<<=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<<=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 402: /* expr_assign_pipe: expr ">>>=" expr_assign_pipe_right  */
+                                                                  { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>>=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 403: /* expr_named_call: name_in_namespace '(' '[' make_struct_fields ']' ')'  */
+                                                                         {
+        auto nc = new ExprNamedCall(tokAt(scanner,(yylsp[-5])),*(yyvsp[-5].s));
+        nc->arguments = *(yyvsp[-2].pMakeStruct);
+        delete (yyvsp[-2].pMakeStruct);
+        delete (yyvsp[-5].s);
+        (yyval.pExpression) = nc;
+    }
+    break;
+
+  case 404: /* expr_named_call: name_in_namespace '(' expr_list ',' '[' make_struct_fields ']' ')'  */
+                                                                                                  {
+        auto nc = new ExprNamedCall(tokAt(scanner,(yylsp[-7])),*(yyvsp[-7].s));
+        nc->nonNamedArguments = sequenceToList((yyvsp[-5].pExpression));
+        nc->arguments = *(yyvsp[-2].pMakeStruct);
+        delete (yyvsp[-2].pMakeStruct);
+        delete (yyvsp[-7].s);
+        (yyval.pExpression) = nc;
+    }
+    break;
+
+  case 405: /* expr_method_call: expr "->" "name" '(' ')'  */
+                                                         {
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-3])), (yyvsp[-4].pExpression), *(yyvsp[-2].s));
+        delete (yyvsp[-2].s);
+        (yyval.pExpression) = pInvoke;
+    }
+    break;
+
+  case 406: /* expr_method_call: expr "->" "name" '(' expr_list ')'  */
+                                                                              {
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-4])), (yyvsp[-5].pExpression), *(yyvsp[-3].s));
+        auto callArgs = sequenceToList((yyvsp[-1].pExpression));
+        pInvoke->arguments.insert ( pInvoke->arguments.end(), callArgs.begin(), callArgs.end() );
+        delete (yyvsp[-3].s);
+        (yyval.pExpression) = pInvoke;
+    }
+    break;
+
+  case 407: /* func_addr_name: name_in_namespace  */
+                                    {
+        (yyval.pExpression) = new ExprAddr(tokAt(scanner,(yylsp[0])),*(yyvsp[0].s));
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 408: /* func_addr_name: "$i" '(' expr ')'  */
+                                          {
+        auto expr = new ExprAddr(tokAt(scanner,(yylsp[-3])),"``MACRO``TAG``ADDR``");
+        (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression), expr, "i");
+    }
+    break;
+
+  case 409: /* func_addr_expr: '@' '@' func_addr_name  */
+                                          {
+        (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 410: /* $@22: %empty  */
+                    { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 411: /* $@23: %empty  */
+                                                                                                { yyextra->das_arrow_depth --; }
+    break;
+
+  case 412: /* func_addr_expr: '@' '@' '<' $@22 type_declaration_no_options '>' $@23 func_addr_name  */
+                                                                                                                                                       {
+        auto expr = (ExprAddr *) ((yyvsp[0].pExpression)->rtti_isAddr() ? (yyvsp[0].pExpression) : (((ExprTag *) (yyvsp[0].pExpression))->value.get()));
+        expr->funcType = TypeDeclPtr((yyvsp[-3].pTypeDecl));
+        (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 413: /* $@24: %empty  */
+                    { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 414: /* $@25: %empty  */
+                                                                                                                              { yyextra->das_arrow_depth --; }
+    break;
+
+  case 415: /* func_addr_expr: '@' '@' '<' $@24 optional_function_argument_list optional_function_type '>' $@25 func_addr_name  */
+                                                                                                                                                                                     {
+        auto expr = (ExprAddr *) ((yyvsp[0].pExpression)->rtti_isAddr() ? (yyvsp[0].pExpression) : (((ExprTag *) (yyvsp[0].pExpression))->value.get()));
+        expr->funcType = make_smart<TypeDecl>(Type::tFunction);
+        expr->funcType->firstType = TypeDeclPtr((yyvsp[-3].pTypeDecl));
+        if ( (yyvsp[-4].pVarDeclList) ) {
+            varDeclToTypeDecl(scanner, expr->funcType.get(), (yyvsp[-4].pVarDeclList));
+            deleteVariableDeclarationList((yyvsp[-4].pVarDeclList));
+        }
+        (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 416: /* expr_field: expr '.' "name"  */
+                                              {
+        (yyval.pExpression) = new ExprField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), ExpressionPtr((yyvsp[-2].pExpression)), *(yyvsp[0].s));
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 417: /* expr_field: expr '.' '.' "name"  */
+                                                  {
+        (yyval.pExpression) = new ExprField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), ExpressionPtr((yyvsp[-3].pExpression)), *(yyvsp[0].s), true);
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 418: /* expr_field: expr '.' "name" '(' ')'  */
+                                                      {
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-3])), (yyvsp[-4].pExpression), *(yyvsp[-2].s));
+        delete (yyvsp[-2].s);
+        (yyval.pExpression) = pInvoke;
+    }
+    break;
+
+  case 419: /* expr_field: expr '.' "name" '(' expr_list ')'  */
+                                                                           {
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-4])), (yyvsp[-5].pExpression), *(yyvsp[-3].s));
+        auto callArgs = sequenceToList((yyvsp[-1].pExpression));
+        pInvoke->arguments.insert ( pInvoke->arguments.end(), callArgs.begin(), callArgs.end() );
+        delete (yyvsp[-3].s);
+        (yyval.pExpression) = pInvoke;
+    }
+    break;
+
+  case 420: /* expr_field: expr '.' "name" '(' '[' make_struct_fields ']' ')'  */
+                                                                                       {
+        auto nc = new ExprNamedCall(tokAt(scanner,(yylsp[-5])),*(yyvsp[-5].s));
+        nc->methodCall = true;
+        nc->arguments = *(yyvsp[-2].pMakeStruct);
+        nc->nonNamedArguments.push_back(ExpressionPtr((yyvsp[-7].pExpression)));
+        delete (yyvsp[-2].pMakeStruct);
+        delete (yyvsp[-5].s);
+        (yyval.pExpression) = nc;
+    }
+    break;
+
+  case 421: /* expr_field: expr '.' basic_type_declaration '(' ')'  */
+                                                                        {
+        auto method_name = das_to_string((yyvsp[-2].type));
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-3])), (yyvsp[-4].pExpression), method_name);
+        (yyval.pExpression) = pInvoke;
+    }
+    break;
+
+  case 422: /* expr_field: expr '.' basic_type_declaration '(' expr_list ')'  */
+                                                                                             {
+        auto method_name = das_to_string((yyvsp[-3].type));
+        auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-4])), (yyvsp[-5].pExpression), method_name);
+        auto callArgs = sequenceToList((yyvsp[-1].pExpression));
+        pInvoke->arguments.insert ( pInvoke->arguments.end(), callArgs.begin(), callArgs.end() );
+        (yyval.pExpression) = pInvoke;
+    }
+    break;
+
+  case 423: /* $@26: %empty  */
+                               { yyextra->das_suppress_errors=true; }
+    break;
+
+  case 424: /* $@27: %empty  */
+                                                                            { yyextra->das_suppress_errors=false; }
+    break;
+
+  case 425: /* expr_field: expr '.' $@26 error $@27  */
+                                                                                                                    {
+        (yyval.pExpression) = new ExprField(tokAt(scanner,(yylsp[-3])), tokAt(scanner,(yylsp[-3])), ExpressionPtr((yyvsp[-4].pExpression)), "");
+        yyerrok;
+    }
+    break;
+
+  case 426: /* expr_call: name_in_namespace '(' ')'  */
+                                               {
+            (yyval.pExpression) = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])),*(yyvsp[-2].s));
+            delete (yyvsp[-2].s);
+    }
+    break;
+
+  case 427: /* expr_call: name_in_namespace '(' "uninitialized" ')'  */
+                                                          {
+            auto dd = new ExprMakeStruct(tokAt(scanner,(yylsp[-3])));
+            dd->at = tokAt(scanner,(yylsp[-3]));
+            dd->makeType = new TypeDecl(Type::alias);
+            dd->makeType->alias = *(yyvsp[-3].s);
+            dd->useInitializer = false;
+            dd->alwaysUseInitializer = true;
+            delete (yyvsp[-3].s);
+            (yyval.pExpression) = dd;
+    }
+    break;
+
+  case 428: /* expr_call: name_in_namespace '(' make_struct_single ')'  */
+                                                               {
+            ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-3]));
+            ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = new TypeDecl(Type::alias);
+            ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType->alias = *(yyvsp[-3].s);
+            ((ExprMakeStruct *)(yyvsp[-1].pExpression))->useInitializer = true;
+            ((ExprMakeStruct *)(yyvsp[-1].pExpression))->alwaysUseInitializer = true;
+            delete (yyvsp[-3].s);
+            (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 429: /* expr_call: name_in_namespace '(' "uninitialized" make_struct_single ')'  */
+                                                                                 {
+            ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-4]));
+            ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = new TypeDecl(Type::alias);
+            ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType->alias = *(yyvsp[-4].s);
+            ((ExprMakeStruct *)(yyvsp[-1].pExpression))->useInitializer = false;
+            ((ExprMakeStruct *)(yyvsp[-1].pExpression))->alwaysUseInitializer = true;
+            delete (yyvsp[-4].s);
+            (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 430: /* expr_call: name_in_namespace '(' expr_list ')'  */
+                                                                    {
+            (yyval.pExpression) = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-3])),tokAt(scanner,(yylsp[0])),*(yyvsp[-3].s)),(yyvsp[-1].pExpression));
+            delete (yyvsp[-3].s);
+    }
+    break;
+
+  case 431: /* expr_call: basic_type_declaration '(' ')'  */
+                                                    {
+        (yyval.pExpression) = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])),das_to_string((yyvsp[-2].type)));
+    }
+    break;
+
+  case 432: /* expr_call: basic_type_declaration '(' expr_list ')'  */
+                                                                         {
+        (yyval.pExpression) = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-3])),tokAt(scanner,(yylsp[0])),das_to_string((yyvsp[-3].type))),(yyvsp[-1].pExpression));
+    }
+    break;
+
+  case 433: /* expr: "null"  */
+                                              { (yyval.pExpression) = new ExprConstPtr(tokAt(scanner,(yylsp[0])),nullptr); }
+    break;
+
+  case 434: /* expr: name_in_namespace  */
+                                              { (yyval.pExpression) = new ExprVar(tokAt(scanner,(yylsp[0])),*(yyvsp[0].s)); delete (yyvsp[0].s); }
+    break;
+
+  case 435: /* expr: expr_numeric_const  */
+                                              { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 436: /* expr: expr_reader  */
+                                              { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 437: /* expr: string_builder  */
+                                              { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 438: /* expr: make_decl  */
+                                              { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 439: /* expr: "true"  */
+                                              { (yyval.pExpression) = new ExprConstBool(tokAt(scanner,(yylsp[0])),true); }
+    break;
+
+  case 440: /* expr: "false"  */
+                                              { (yyval.pExpression) = new ExprConstBool(tokAt(scanner,(yylsp[0])),false); }
+    break;
+
+  case 441: /* expr: expr_field  */
+                                              { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 442: /* expr: expr_mtag  */
+                                              { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 443: /* expr: '!' expr  */
+                                              { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"!",ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 444: /* expr: '~' expr  */
+                                              { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"~",ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 445: /* expr: '+' expr  */
+                                                  { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"+",ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 446: /* expr: '-' expr  */
+                                                  { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"-",ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 447: /* expr: expr "<<" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 448: /* expr: expr ">>" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 449: /* expr: expr "<<<" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<<", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 450: /* expr: expr ">>>" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>>", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 451: /* expr: expr '+' expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"+", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 452: /* expr: expr '-' expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"-", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 453: /* expr: expr '*' expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"*", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 454: /* expr: expr '/' expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"/", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 455: /* expr: expr '%' expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"%", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 456: /* expr: expr '<' expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 457: /* expr: expr '>' expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 458: /* expr: expr "==" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"==", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 459: /* expr: expr "!=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"!=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 460: /* expr: expr "<=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 461: /* expr: expr ">=" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">=", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 462: /* expr: expr '&' expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 463: /* expr: expr '|' expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"|", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 464: /* expr: expr '^' expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 465: /* expr: expr "&&" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&&", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 466: /* expr: expr "||" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"||", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 467: /* expr: expr "^^" expr  */
+                                             { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^^", ExpressionPtr((yyvsp[-2].pExpression)), ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 468: /* expr: expr ".." expr  */
+                                             {
+        auto itv = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-1])),"interval");
+        itv->arguments.push_back(ExpressionPtr((yyvsp[-2].pExpression)));
+        itv->arguments.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+        (yyval.pExpression) = itv;
+    }
+    break;
+
+  case 469: /* expr: "++" expr  */
+                                                 { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"++", ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 470: /* expr: "--" expr  */
+                                                 { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"--", ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 471: /* expr: expr "++"  */
+                                                 { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[0])),"+++", ExpressionPtr((yyvsp[-1].pExpression))); }
+    break;
+
+  case 472: /* expr: expr "--"  */
+                                                 { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[0])),"---", ExpressionPtr((yyvsp[-1].pExpression))); }
+    break;
+
+  case 473: /* expr: '(' expr_list optional_comma ')'  */
+                                                         {
+            if ( (yyvsp[-2].pExpression)->rtti_isSequence() ) {
+                auto mkt = new ExprMakeTuple(tokAt(scanner,(yylsp[-2])));
+                mkt->values = sequenceToList((yyvsp[-2].pExpression));
+                (yyval.pExpression) = mkt;
+            } else if ( (yyvsp[-1].b) ) {
+                auto mkt = new ExprMakeTuple(tokAt(scanner,(yylsp[-2])));
+                mkt->values.push_back((yyvsp[-2].pExpression));
+                (yyval.pExpression) = mkt;
+            } else {
+                (yyval.pExpression) = (yyvsp[-2].pExpression);
+            }
+        }
+    break;
+
+  case 474: /* expr: expr '[' expr ']'  */
+                                                 { (yyval.pExpression) = new ExprAt(tokAt(scanner,(yylsp[-2])), ExpressionPtr((yyvsp[-3].pExpression)), ExpressionPtr((yyvsp[-1].pExpression))); }
+    break;
+
+  case 475: /* expr: expr '.' '[' expr ']'  */
+                                                     { (yyval.pExpression) = new ExprAt(tokAt(scanner,(yylsp[-2])), ExpressionPtr((yyvsp[-4].pExpression)), ExpressionPtr((yyvsp[-1].pExpression)), true); }
+    break;
+
+  case 476: /* expr: expr "?[" expr ']'  */
+                                                 { (yyval.pExpression) = new ExprSafeAt(tokAt(scanner,(yylsp[-2])), ExpressionPtr((yyvsp[-3].pExpression)), ExpressionPtr((yyvsp[-1].pExpression))); }
+    break;
+
+  case 477: /* expr: expr '.' "?[" expr ']'  */
+                                                     { (yyval.pExpression) = new ExprSafeAt(tokAt(scanner,(yylsp[-2])), ExpressionPtr((yyvsp[-4].pExpression)), ExpressionPtr((yyvsp[-1].pExpression)), true); }
+    break;
+
+  case 478: /* expr: expr "?." "name"  */
+                                                 { (yyval.pExpression) = new ExprSafeField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), ExpressionPtr((yyvsp[-2].pExpression)), *(yyvsp[0].s)); delete (yyvsp[0].s); }
+    break;
+
+  case 479: /* expr: expr '.' "?." "name"  */
+                                                     { (yyval.pExpression) = new ExprSafeField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), ExpressionPtr((yyvsp[-3].pExpression)), *(yyvsp[0].s), true); delete (yyvsp[0].s); }
+    break;
+
+  case 480: /* expr: func_addr_expr  */
+                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 481: /* expr: expr_call  */
+                        { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 482: /* expr: '*' expr  */
+                                                   { (yyval.pExpression) = new ExprPtr2Ref(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 483: /* expr: "deref" '(' expr ')'  */
+                                                   { (yyval.pExpression) = new ExprPtr2Ref(tokAt(scanner,(yylsp[-3])),ExpressionPtr((yyvsp[-1].pExpression))); }
+    break;
+
+  case 484: /* expr: "addr" '(' expr ')'  */
+                                                   { (yyval.pExpression) = new ExprRef2Ptr(tokAt(scanner,(yylsp[-3])),ExpressionPtr((yyvsp[-1].pExpression))); }
+    break;
+
+  case 485: /* expr: "generator" '<' type_declaration_no_options '>' optional_capture_list '(' ')'  */
+                                                                                                              {
+        (yyval.pExpression) = ast_makeGenerator(scanner,(yyvsp[-4].pTypeDecl),(yyvsp[-2].pCaptList),nullptr,tokAt(scanner,(yylsp[-6])));
+    }
+    break;
+
+  case 486: /* expr: "generator" '<' type_declaration_no_options '>' optional_capture_list '(' expr ')'  */
+                                                                                                                            {
+        (yyval.pExpression) = ast_makeGenerator(scanner,(yyvsp[-5].pTypeDecl),(yyvsp[-3].pCaptList),(yyvsp[-1].pExpression),tokAt(scanner,(yylsp[-7])));
+    }
+    break;
+
+  case 487: /* expr: expr "??" expr  */
+                                                   { (yyval.pExpression) = new ExprNullCoalescing(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-2].pExpression)),ExpressionPtr((yyvsp[0].pExpression))); }
+    break;
+
+  case 488: /* expr: expr '?' expr ':' expr  */
+                                                          {
+            (yyval.pExpression) = new ExprOp3(tokAt(scanner,(yylsp[-3])),"?",ExpressionPtr((yyvsp[-4].pExpression)),ExpressionPtr((yyvsp[-2].pExpression)),ExpressionPtr((yyvsp[0].pExpression)));
+        }
+    break;
+
+  case 489: /* $@28: %empty  */
+                                               { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 490: /* $@29: %empty  */
+                                                                                                                      { yyextra->das_arrow_depth --; }
+    break;
+
+  case 491: /* expr: expr "is" "type" '<' $@28 type_declaration_no_options '>' $@29  */
+                                                                                                                                                       {
+        (yyval.pExpression) = new ExprIs(tokAt(scanner,(yylsp[-6])),ExpressionPtr((yyvsp[-7].pExpression)),TypeDeclPtr((yyvsp[-2].pTypeDecl)));
+    }
+    break;
+
+  case 492: /* expr: expr "is" basic_type_declaration  */
+                                                               {
+        auto vdecl = new TypeDecl((yyvsp[0].type));
+        vdecl->at = tokAt(scanner,(yylsp[0]));
+        (yyval.pExpression) = new ExprIs(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-2].pExpression)),vdecl);
+    }
+    break;
+
+  case 493: /* expr: expr "is" "name"  */
+                                              {
+        (yyval.pExpression) = new ExprIsVariant(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-2].pExpression)),*(yyvsp[0].s));
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 494: /* expr: expr "as" "name"  */
+                                              {
+        (yyval.pExpression) = new ExprAsVariant(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-2].pExpression)),*(yyvsp[0].s));
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 495: /* $@30: %empty  */
+                                               { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 496: /* $@31: %empty  */
+                                                                                                           { yyextra->das_arrow_depth --; }
+    break;
+
+  case 497: /* expr: expr "as" "type" '<' $@30 type_declaration '>' $@31  */
+                                                                                                                                            {
+        auto vname = (yyvsp[-2].pTypeDecl)->describe();
+        (yyval.pExpression) = new ExprAsVariant(tokAt(scanner,(yylsp[-6])),ExpressionPtr((yyvsp[-7].pExpression)),vname);
+        delete (yyvsp[-2].pTypeDecl);
+    }
+    break;
+
+  case 498: /* expr: expr "as" basic_type_declaration  */
+                                                               {
+        (yyval.pExpression) = new ExprAsVariant(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-2].pExpression)),das_to_string((yyvsp[0].type)));
+    }
+    break;
+
+  case 499: /* expr: expr '?' "as" "name"  */
+                                                  {
+        (yyval.pExpression) = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-3].pExpression)),*(yyvsp[0].s));
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 500: /* $@32: %empty  */
+                                                   { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 501: /* $@33: %empty  */
+                                                                                                               { yyextra->das_arrow_depth --; }
+    break;
+
+  case 502: /* expr: expr '?' "as" "type" '<' $@32 type_declaration '>' $@33  */
+                                                                                                                                                {
+        auto vname = (yyvsp[-2].pTypeDecl)->describe();
+        (yyval.pExpression) = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-6])),ExpressionPtr((yyvsp[-8].pExpression)),vname);
+        delete (yyvsp[-2].pTypeDecl);
+    }
+    break;
+
+  case 503: /* expr: expr '?' "as" basic_type_declaration  */
+                                                                   {
+        (yyval.pExpression) = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-3].pExpression)),das_to_string((yyvsp[0].type)));
+    }
+    break;
+
+  case 504: /* expr: expr_type_info  */
+                                                { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 505: /* expr: expr_type_decl  */
+                                                { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 506: /* expr: expr_cast  */
+                                                { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 507: /* expr: expr_new  */
+                                                { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 508: /* expr: expr_method_call  */
+                                                { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 509: /* expr: expr_named_call  */
+                                                { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 510: /* expr: expr_full_block  */
+                                                { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 511: /* expr: expr "<|" expr  */
+                                                { (yyval.pExpression) = ast_lpipe(scanner,(yyvsp[-2].pExpression),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-1]))); }
+    break;
+
+  case 512: /* expr: expr "|>" expr  */
+                                                { (yyval.pExpression) = ast_rpipe(scanner,(yyvsp[-2].pExpression),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-1]))); }
+    break;
+
+  case 513: /* expr: expr "|>" basic_type_declaration  */
+                                                          {
+        auto fncall = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[0])),das_to_string((yyvsp[0].type)));
+        (yyval.pExpression) = ast_rpipe(scanner,(yyvsp[-2].pExpression),fncall,tokAt(scanner,(yylsp[-1])));
+    }
+    break;
+
+  case 514: /* expr: name_in_namespace "name"  */
+                                                { (yyval.pExpression) = ast_NameName(scanner,(yyvsp[-1].s),(yyvsp[0].s),tokAt(scanner,(yylsp[-1])),tokAt(scanner,(yylsp[0]))); }
+    break;
+
+  case 515: /* expr: "unsafe" '(' expr ')'  */
+                                         {
+        (yyvsp[-1].pExpression)->alwaysSafe = true;
+        (yyvsp[-1].pExpression)->userSaidItsSafe = true;
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 516: /* expr: expression_keyword  */
+                                { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 517: /* expr_mtag: "$$" '(' expr ')'  */
+                                                     { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"e"); }
+    break;
+
+  case 518: /* expr_mtag: "$i" '(' expr ')'  */
+                                                     { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"i"); }
+    break;
+
+  case 519: /* expr_mtag: "$v" '(' expr ')'  */
+                                                     { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"v"); }
+    break;
+
+  case 520: /* expr_mtag: "$b" '(' expr ')'  */
+                                                     { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"b"); }
+    break;
+
+  case 521: /* expr_mtag: "$a" '(' expr ')'  */
+                                                     { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"a"); }
+    break;
+
+  case 522: /* expr_mtag: "..."  */
+                                                     { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[0])),nullptr,"..."); }
+    break;
+
+  case 523: /* expr_mtag: "$c" '(' expr ')' '(' ')'  */
+                                                            {
+            auto ccall = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-5])),tokAt(scanner,(yylsp[0])),"``MACRO``TAG``CALL``");
+            (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-5])),(yyvsp[-3].pExpression),ccall,"c");
+        }
+    break;
+
+  case 524: /* expr_mtag: "$c" '(' expr ')' '(' expr_list ')'  */
+                                                                                {
+            auto ccall = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-6])),tokAt(scanner,(yylsp[0])),"``MACRO``TAG``CALL``"),(yyvsp[-1].pExpression));
+            (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-6])),(yyvsp[-4].pExpression),ccall,"c");
+        }
+    break;
+
+  case 525: /* expr_mtag: expr '.' "$f" '(' expr ')'  */
+                                                                {
+        auto cfield = new ExprField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), ExpressionPtr((yyvsp[-5].pExpression)), "``MACRO``TAG``FIELD``");
+        (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
+    }
+    break;
+
+  case 526: /* expr_mtag: expr "?." "$f" '(' expr ')'  */
+                                                                 {
+        auto cfield = new ExprSafeField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), ExpressionPtr((yyvsp[-5].pExpression)), "``MACRO``TAG``FIELD``");
+        (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
+    }
+    break;
+
+  case 527: /* expr_mtag: expr '.' '.' "$f" '(' expr ')'  */
+                                                                    {
+        auto cfield = new ExprField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), ExpressionPtr((yyvsp[-6].pExpression)), "``MACRO``TAG``FIELD``", true);
+        (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
+    }
+    break;
+
+  case 528: /* expr_mtag: expr '.' "?." "$f" '(' expr ')'  */
+                                                                     {
+        auto cfield = new ExprSafeField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), ExpressionPtr((yyvsp[-6].pExpression)), "``MACRO``TAG``FIELD``", true);
+        (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
+    }
+    break;
+
+  case 529: /* expr_mtag: expr "as" "$f" '(' expr ')'  */
+                                                                   {
+        auto cfield = new ExprAsVariant(tokAt(scanner,(yylsp[-4])),ExpressionPtr((yyvsp[-5].pExpression)),"``MACRO``TAG``FIELD``");
+        (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
+    }
+    break;
+
+  case 530: /* expr_mtag: expr '?' "as" "$f" '(' expr ')'  */
+                                                                       {
+        auto cfield = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-4])),ExpressionPtr((yyvsp[-6].pExpression)),"``MACRO``TAG``FIELD``");
+        (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
+    }
+    break;
+
+  case 531: /* expr_mtag: expr "is" "$f" '(' expr ')'  */
+                                                                   {
+        auto cfield = new ExprIsVariant(tokAt(scanner,(yylsp[-4])),ExpressionPtr((yyvsp[-5].pExpression)),"``MACRO``TAG``FIELD``");
+        (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
+    }
+    break;
+
+  case 532: /* expr_mtag: '@' '@' "$c" '(' expr ')'  */
+                                                         {
+        auto ccall = new ExprAddr(tokAt(scanner,(yylsp[-4])),"``MACRO``TAG``ADDR``");
+        (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-3])),(yyvsp[-1].pExpression),ccall,"c");
+    }
+    break;
+
+  case 533: /* optional_field_annotation: %empty  */
+                                                        { (yyval.aaList) = nullptr; }
+    break;
+
+  case 534: /* optional_field_annotation: "[[" annotation_argument_list ']' ']'  */
+                                                        { (yyval.aaList) = (yyvsp[-2].aaList); /*this one is gone when BRABRA is disabled*/ }
+    break;
+
+  case 535: /* optional_field_annotation: metadata_argument_list  */
+                                                        { (yyval.aaList) = (yyvsp[0].aaList); }
+    break;
+
+  case 536: /* optional_override: %empty  */
+                      { (yyval.i) = OVERRIDE_NONE; }
+    break;
+
+  case 537: /* optional_override: "override"  */
+                      { (yyval.i) = OVERRIDE_OVERRIDE; }
+    break;
+
+  case 538: /* optional_override: "sealed"  */
+                      { (yyval.i) = OVERRIDE_SEALED; }
+    break;
+
+  case 539: /* optional_constant: %empty  */
+                        { (yyval.b) = false; }
+    break;
+
+  case 540: /* optional_constant: "const"  */
+                        { (yyval.b) = true; }
+    break;
+
+  case 541: /* optional_public_or_private_member_variable: %empty  */
+                        { (yyval.b) = false; }
+    break;
+
+  case 542: /* optional_public_or_private_member_variable: "public"  */
+                        { (yyval.b) = false; }
+    break;
+
+  case 543: /* optional_public_or_private_member_variable: "private"  */
+                        { (yyval.b) = true; }
+    break;
+
+  case 544: /* optional_static_member_variable: %empty  */
+                        { (yyval.b) = false; }
+    break;
+
+  case 545: /* optional_static_member_variable: "static"  */
+                        { (yyval.b) = true; }
+    break;
+
+  case 546: /* structure_variable_declaration: optional_field_annotation optional_static_member_variable optional_override optional_public_or_private_member_variable variable_declaration  */
+                                                                                                                                                                                      {
+        (yyvsp[0].pVarDecl)->override = (yyvsp[-2].i) == OVERRIDE_OVERRIDE;
+        (yyvsp[0].pVarDecl)->sealed = (yyvsp[-2].i) == OVERRIDE_SEALED;
+        (yyvsp[0].pVarDecl)->annotation = (yyvsp[-4].aaList);
+        (yyvsp[0].pVarDecl)->isPrivate = (yyvsp[-1].b);
+        (yyvsp[0].pVarDecl)->isStatic = (yyvsp[-3].b);
+        (yyval.pVarDecl) = (yyvsp[0].pVarDecl);
+    }
+    break;
+
+  case 547: /* struct_variable_declaration_list: %empty  */
+        {
+        (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
+    }
+    break;
+
+  case 548: /* $@34: %empty  */
+                                               {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeStructureFields(tak);
+        }
+    }
+    break;
+
+  case 549: /* struct_variable_declaration_list: struct_variable_declaration_list $@34 structure_variable_declaration "end of expression"  */
+                                               {
+        (yyval.pVarDeclList) = (yyvsp[-3].pVarDeclList);
+        if ( (yyvsp[-1].pVarDecl) ) (yyvsp[-3].pVarDeclList)->push_back((yyvsp[-1].pVarDecl));
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[-3]));
+            for ( auto & crd : yyextra->g_CommentReaders ) {
+                for ( const auto & nl : *((yyvsp[-1].pVarDecl)->pNameList) ) {
+                    crd->afterStructureField(nl.name.c_str(), nl.at);
+                }
+            }
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterStructureFields(tak);
+        }
+    }
+    break;
+
+  case 550: /* $@35: %empty  */
+                                                                                                                     {
+                yyextra->das_force_oxford_comma=true;
+                if ( !yyextra->g_CommentReaders.empty() ) {
+                    auto tak = tokAt(scanner,(yylsp[-2]));
+                    for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeFunction(tak);
+                }
+            }
+    break;
+
+  case 551: /* struct_variable_declaration_list: struct_variable_declaration_list optional_annotation_list "def" optional_public_or_private_member_variable "abstract" optional_constant $@35 function_declaration_header "end of expression"  */
+                                                    {
+                if ( !yyextra->g_CommentReaders.empty() ) {
+                    auto tak = tokAt(scanner,(yylsp[-1]));
+                    for ( auto & crd : yyextra->g_CommentReaders ) crd->afterFunction((yyvsp[-1].pFuncDecl),tak);
+                }
+                (yyvsp[-1].pFuncDecl)->isTemplate = yyextra->g_thisStructure->isTemplate;
+                (yyval.pVarDeclList) = ast_structVarDefAbstract(scanner,(yyvsp[-8].pVarDeclList),(yyvsp[-7].faList),(yyvsp[-5].b),(yyvsp[-3].b), (yyvsp[-1].pFuncDecl));
+            }
+    break;
+
+  case 552: /* $@36: %empty  */
+                                                                                                                                                                         {
+                if ( !yyextra->g_CommentReaders.empty() ) {
+                    auto tak = tokAt(scanner,(yylsp[0]));
+                    for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeFunction(tak);
+                }
+            }
+    break;
+
+  case 553: /* struct_variable_declaration_list: struct_variable_declaration_list optional_annotation_list "def" optional_public_or_private_member_variable optional_static_member_variable optional_override optional_constant $@36 function_declaration_header expression_block  */
+                                                                        {
+                if ( !yyextra->g_CommentReaders.empty() ) {
+                    auto tak = tokAt(scanner,(yylsp[0]));
+                    for ( auto & crd : yyextra->g_CommentReaders ) crd->afterFunction((yyvsp[-1].pFuncDecl),tak);
+                }
+                (yyvsp[-1].pFuncDecl)->isTemplate = yyextra->g_thisStructure->isTemplate;
+                (yyval.pVarDeclList) = ast_structVarDef(scanner,(yyvsp[-9].pVarDeclList),(yyvsp[-8].faList),(yyvsp[-5].b),(yyvsp[-6].b),(yyvsp[-4].i),(yyvsp[-3].b),(yyvsp[-1].pFuncDecl),(yyvsp[0].pExpression),tokRangeAt(scanner,(yylsp[-7]),(yylsp[0])),tokAt(scanner,(yylsp[-8])));
+            }
+    break;
+
+  case 554: /* struct_variable_declaration_list: struct_variable_declaration_list '[' annotation_list ']' "end of expression"  */
+                                                                                 {
+        das_yyerror(scanner,"structure field or class method annotation expected to remain on the same line with the field or the class",
+            tokAt(scanner,(yylsp[-2])), CompilationError::syntax_error);
+        delete (yyvsp[-2].faList);
+        (yyval.pVarDeclList) = (yyvsp[-4].pVarDeclList);
+    }
+    break;
+
+  case 555: /* function_argument_declaration: optional_field_annotation kwd_let_var_or_nothing variable_declaration  */
+                                                                                                  {
+            (yyval.pVarDecl) = (yyvsp[0].pVarDecl);
+            if ( (yyvsp[-1].b) ) {
+                (yyvsp[0].pVarDecl)->pTypeDecl->constant = true;
+            } else {
+                (yyvsp[0].pVarDecl)->pTypeDecl->removeConstant = true;
+            }
+            (yyvsp[0].pVarDecl)->annotation = (yyvsp[-2].aaList);
+        }
+    break;
+
+  case 556: /* function_argument_declaration: "$a" '(' expr ')'  */
+                                     {
+            auto na = new vector<VariableNameAndPosition>();
+            na->push_back(VariableNameAndPosition{"``MACRO``TAG``","",tokAt(scanner,(yylsp[-1]))});
+            auto decl = new VariableDeclaration(na, new TypeDecl(Type::none), (yyvsp[-1].pExpression));
+            decl->pTypeDecl->isTag = true;
+            (yyval.pVarDecl) = decl;
+        }
+    break;
+
+  case 557: /* function_argument_list: function_argument_declaration  */
+                                                                                 { (yyval.pVarDeclList) = new vector<VariableDeclaration*>(); (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
+    break;
+
+  case 558: /* function_argument_list: function_argument_list "end of expression" function_argument_declaration  */
+                                                                                 { (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
+    break;
+
+  case 559: /* tuple_type: type_declaration  */
+                                    {
+        (yyval.pVarDecl) = new VariableDeclaration(nullptr,(yyvsp[0].pTypeDecl),nullptr);
+    }
+    break;
+
+  case 560: /* tuple_type: "name" ':' type_declaration  */
+                                                   {
+        auto na = new vector<VariableNameAndPosition>();
+        na->push_back(VariableNameAndPosition{*(yyvsp[-2].s),"",tokAt(scanner,(yylsp[-2]))});
+        (yyval.pVarDecl) = new VariableDeclaration(na,(yyvsp[0].pTypeDecl),nullptr);
+        delete (yyvsp[-2].s);
+    }
+    break;
+
+  case 561: /* tuple_type_list: tuple_type  */
+                                                       { (yyval.pVarDeclList) = new vector<VariableDeclaration*>(); (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
+    break;
+
+  case 562: /* tuple_type_list: tuple_type_list c_or_s tuple_type  */
+                                                          { (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
+    break;
+
+  case 563: /* tuple_alias_type_list: %empty  */
+        {
+        (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
+    }
+    break;
+
+  case 564: /* tuple_alias_type_list: tuple_alias_type_list c_or_s  */
+                                         {
+        (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList);
+    }
+    break;
+
+  case 565: /* tuple_alias_type_list: tuple_alias_type_list tuple_type c_or_s  */
+                                                            {
+        (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[-1].pVarDecl));
+        /*
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tokName = tokAt(scanner,@decl);
+            for ( auto & crd : yyextra->g_CommentReaders ) {
+                for ( const auto & nl : *($decl->pNameList) ) {
+                    crd->afterVariantEntry(nl.name.c_str(), nl.at);
+                }
+            }
+        }
+        */
+    }
+    break;
+
+  case 566: /* variant_type: "name" ':' type_declaration  */
+                                                   {
+        auto na = new vector<VariableNameAndPosition>();
+        na->push_back(VariableNameAndPosition{*(yyvsp[-2].s),"",tokAt(scanner,(yylsp[-2]))});
+        (yyval.pVarDecl) = new VariableDeclaration(na,(yyvsp[0].pTypeDecl),nullptr);
+        delete (yyvsp[-2].s);
+    }
+    break;
+
+  case 567: /* variant_type_list: variant_type  */
+                                                         { (yyval.pVarDeclList) = new vector<VariableDeclaration*>(); (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
+    break;
+
+  case 568: /* variant_type_list: variant_type_list c_or_s variant_type  */
+                                                            { (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
+    break;
+
+  case 569: /* variant_alias_type_list: %empty  */
+        {
+        (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
+    }
+    break;
+
+  case 570: /* variant_alias_type_list: variant_alias_type_list c_or_s  */
+                                           {
+        (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList);
+    }
+    break;
+
+  case 571: /* variant_alias_type_list: variant_alias_type_list variant_type c_or_s  */
+                                                                {
+        (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[-1].pVarDecl));
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tokName = tokAt(scanner,(yylsp[-1]));
+            for ( auto & crd : yyextra->g_CommentReaders ) {
+                for ( const auto & nl : *((yyvsp[-1].pVarDecl)->pNameList) ) {
+                    crd->afterVariantEntry(nl.name.c_str(), nl.at);
+                }
+            }
+        }
+    }
+    break;
+
+  case 572: /* copy_or_move: '='  */
+                    { (yyval.b) = false; }
+    break;
+
+  case 573: /* copy_or_move: "<-"  */
+                    { (yyval.b) = true; }
+    break;
+
+  case 574: /* variable_declaration: variable_name_with_pos_list  */
+                                          {
+        auto autoT = new TypeDecl(Type::autoinfer);
+        autoT->at = tokAt(scanner,(yylsp[0]));
+        autoT->ref = false;
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[0].pNameWithPosList),autoT,nullptr);
+    }
+    break;
+
+  case 575: /* variable_declaration: variable_name_with_pos_list '&'  */
+                                              {
+        auto autoT = new TypeDecl(Type::autoinfer);
+        autoT->at = tokAt(scanner,(yylsp[-1]));
+        autoT->ref = true;
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-1].pNameWithPosList),autoT,nullptr);
+    }
+    break;
+
+  case 576: /* variable_declaration: variable_name_with_pos_list ':' type_declaration  */
+                                                                          {
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-2].pNameWithPosList),(yyvsp[0].pTypeDecl),nullptr);
+    }
+    break;
+
+  case 577: /* variable_declaration: variable_name_with_pos_list ':' type_declaration copy_or_move expr  */
+                                                                                                      {
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-4].pNameWithPosList),(yyvsp[-2].pTypeDecl),(yyvsp[0].pExpression));
+        (yyval.pVarDecl)->init_via_move = (yyvsp[-1].b);
+    }
+    break;
+
+  case 578: /* variable_declaration: variable_name_with_pos_list copy_or_move expr  */
+                                                                       {
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,(yylsp[-2]));
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-2].pNameWithPosList),typeDecl,(yyvsp[0].pExpression));
+        (yyval.pVarDecl)->init_via_move = (yyvsp[-1].b);
+    }
+    break;
+
+  case 579: /* variable_declaration: variable_name_with_pos_list copy_or_move expr_pipe  */
+                                                                            {
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,(yylsp[-2]));
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-2].pNameWithPosList),typeDecl,(yyvsp[0].pExpression));
+        (yyval.pVarDecl)->init_via_move = (yyvsp[-1].b);
+    }
+    break;
+
+  case 580: /* copy_or_move_or_clone: '='  */
+                    { (yyval.i) = CorM_COPY; }
+    break;
+
+  case 581: /* copy_or_move_or_clone: "<-"  */
+                    { (yyval.i) = CorM_MOVE; }
+    break;
+
+  case 582: /* copy_or_move_or_clone: ":="  */
+                    { (yyval.i) = CorM_CLONE; }
+    break;
+
+  case 583: /* optional_ref: %empty  */
+            { (yyval.b) = false; }
+    break;
+
+  case 584: /* optional_ref: '&'  */
+            { (yyval.b) = true; }
+    break;
+
+  case 585: /* let_variable_name_with_pos_list: "name"  */
+                    {
+        das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{*(yyvsp[0].s),"",tokAt(scanner,(yylsp[0]))});
+        (yyval.pNameWithPosList) = pSL;
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 586: /* let_variable_name_with_pos_list: "$i" '(' expr ')'  */
+                                     {
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{"``MACRO``TAG``","",tokAt(scanner,(yylsp[-1])),ExpressionPtr((yyvsp[-1].pExpression))});
+        (yyval.pNameWithPosList) = pSL;
+    }
+    break;
+
+  case 587: /* let_variable_name_with_pos_list: "name" "aka" "name"  */
+                                         {
+        das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
+        das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{*(yyvsp[-2].s),*(yyvsp[0].s),tokAt(scanner,(yylsp[-2]))});
+        (yyval.pNameWithPosList) = pSL;
+        delete (yyvsp[-2].s);
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 588: /* let_variable_name_with_pos_list: let_variable_name_with_pos_list ',' "name"  */
+                                                             {
+        das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+        (yyvsp[-2].pNameWithPosList)->push_back(VariableNameAndPosition{*(yyvsp[0].s),"",tokAt(scanner,(yylsp[0]))});
+        (yyval.pNameWithPosList) = (yyvsp[-2].pNameWithPosList);
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 589: /* let_variable_name_with_pos_list: let_variable_name_with_pos_list ',' "name" "aka" "name"  */
+                                                                                   {
+        das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
+        das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+        (yyvsp[-4].pNameWithPosList)->push_back(VariableNameAndPosition{*(yyvsp[-2].s),*(yyvsp[0].s),tokAt(scanner,(yylsp[-2]))});
+        (yyval.pNameWithPosList) = (yyvsp[-4].pNameWithPosList);
+        delete (yyvsp[-2].s);
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 590: /* let_variable_declaration: let_variable_name_with_pos_list ':' type_declaration_no_options "end of expression"  */
+                                                                                            {
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-3].pNameWithPosList),(yyvsp[-1].pTypeDecl),nullptr);
+    }
+    break;
+
+  case 591: /* let_variable_declaration: let_variable_name_with_pos_list ':' type_declaration_no_options copy_or_move_or_clone expr "end of expression"  */
+                                                                                                                                  {
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-5].pNameWithPosList),(yyvsp[-3].pTypeDecl),(yyvsp[-1].pExpression));
+        (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
+        (yyval.pVarDecl)->init_via_clone = ((yyvsp[-2].i) & CorM_CLONE) !=0;
+    }
+    break;
+
+  case 592: /* let_variable_declaration: let_variable_name_with_pos_list ':' type_declaration_no_options copy_or_move_or_clone expr_pipe  */
+                                                                                                                                   {
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-4].pNameWithPosList),(yyvsp[-2].pTypeDecl),(yyvsp[0].pExpression));
+        (yyval.pVarDecl)->init_via_move  = ((yyvsp[-1].i) & CorM_MOVE) !=0;
+        (yyval.pVarDecl)->init_via_clone = ((yyvsp[-1].i) & CorM_CLONE) !=0;
+    }
+    break;
+
+  case 593: /* let_variable_declaration: let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr "end of expression"  */
+                                                                                                          {
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,(yylsp[-4]));
+        typeDecl->ref = (yyvsp[-3].b);
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-4].pNameWithPosList),typeDecl,(yyvsp[-1].pExpression));
+        (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
+        (yyval.pVarDecl)->init_via_clone = ((yyvsp[-2].i) & CorM_CLONE) !=0;
+    }
+    break;
+
+  case 594: /* let_variable_declaration: let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr_pipe  */
+                                                                                                           {
+        auto typeDecl = new TypeDecl(Type::autoinfer);
+        typeDecl->at = tokAt(scanner,(yylsp[-3]));
+        typeDecl->ref = (yyvsp[-2].b);
+        (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-3].pNameWithPosList),typeDecl,(yyvsp[0].pExpression));
+        (yyval.pVarDecl)->init_via_move  = ((yyvsp[-1].i) & CorM_MOVE) !=0;
+        (yyval.pVarDecl)->init_via_clone = ((yyvsp[-1].i) & CorM_CLONE) !=0;
+    }
+    break;
+
+  case 595: /* global_variable_declaration_list: %empty  */
+        {
+        (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
+    }
+    break;
+
+  case 596: /* $@37: %empty  */
+                                               {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeGlobalVariables(tak);
+        }
+    }
+    break;
+
+  case 597: /* global_variable_declaration_list: global_variable_declaration_list $@37 optional_field_annotation let_variable_declaration  */
+                                                                      {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders )
+                for ( auto & nl : *((yyvsp[0].pVarDecl)->pNameList) )
+                    crd->afterGlobalVariable(nl.name.c_str(),tak);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterGlobalVariables(tak);
+        }
+        (yyval.pVarDeclList) = (yyvsp[-3].pVarDeclList);
+        (yyvsp[0].pVarDecl)->annotation = (yyvsp[-1].aaList);
+        (yyvsp[-3].pVarDeclList)->push_back((yyvsp[0].pVarDecl));
+    }
+    break;
+
+  case 598: /* optional_shared: %empty  */
+                     { (yyval.b) = false; }
+    break;
+
+  case 599: /* optional_shared: "shared"  */
+                     { (yyval.b) = true; }
+    break;
+
+  case 600: /* optional_public_or_private_variable: %empty  */
+                     { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
+    break;
+
+  case 601: /* optional_public_or_private_variable: "private"  */
+                     { (yyval.b) = false; }
+    break;
+
+  case 602: /* optional_public_or_private_variable: "public"  */
+                     { (yyval.b) = true; }
+    break;
+
+  case 603: /* global_let: kwd_let optional_shared optional_public_or_private_variable "begin of code block" global_variable_declaration_list "end of code block"  */
+                                                                                                                                       {
+        ast_globalLetList(scanner,(yyvsp[-5].b),(yyvsp[-4].b),(yyvsp[-3].b),(yyvsp[-1].pVarDeclList));
+    }
+    break;
+
+  case 604: /* $@38: %empty  */
+                                                                                        {
+        yyextra->das_force_oxford_comma=true;
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeGlobalVariables(tak);
+        }
+    }
+    break;
+
+  case 605: /* global_let: kwd_let optional_shared optional_public_or_private_variable $@38 optional_field_annotation let_variable_declaration  */
+                                                                    {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders )
+                for ( auto & nl : *((yyvsp[0].pVarDecl)->pNameList) )
+                    crd->afterGlobalVariable(nl.name.c_str(),tak);
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterGlobalVariables(tak);
+        }
+        ast_globalLet(scanner,(yyvsp[-5].b),(yyvsp[-4].b),(yyvsp[-3].b),(yyvsp[-1].aaList),(yyvsp[0].pVarDecl));
+    }
+    break;
+
+  case 606: /* enum_list: %empty  */
+        {
+        (yyval.pEnum) = new Enumeration();
+    }
+    break;
+
+  case 607: /* enum_list: enum_list "end of expression"  */
+                          {
+        (yyval.pEnum) = (yyvsp[-1].pEnum);
+    }
+    break;
+
+  case 608: /* enum_list: enum_list "name" "end of expression"  */
+                                     {
+        das_checkName(scanner,*(yyvsp[-1].s),tokAt(scanner,(yylsp[-1])));
+        if ( !(yyvsp[-2].pEnum)->add(*(yyvsp[-1].s),nullptr,tokAt(scanner,(yylsp[-1]))) ) {
+            das_yyerror(scanner,"enumeration already declared " + *(yyvsp[-1].s), tokAt(scanner,(yylsp[-1])),
+                CompilationError::enumeration_value_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tokName = tokAt(scanner,(yylsp[-1]));
+            for ( auto & crd : yyextra->g_CommentReaders ) {
+                crd->afterEnumerationEntry((yyvsp[-1].s)->c_str(), tokName);
+            }
+        }
+        delete (yyvsp[-1].s);
+        (yyval.pEnum) = (yyvsp[-2].pEnum);
+    }
+    break;
+
+  case 609: /* enum_list: enum_list "name" '=' expr "end of expression"  */
+                                                     {
+        das_checkName(scanner,*(yyvsp[-3].s),tokAt(scanner,(yylsp[-3])));
+        if ( !(yyvsp[-4].pEnum)->add(*(yyvsp[-3].s),ExpressionPtr((yyvsp[-1].pExpression)),tokAt(scanner,(yylsp[-3]))) ) {
+            das_yyerror(scanner,"enumeration value already declared " + *(yyvsp[-3].s), tokAt(scanner,(yylsp[-3])),
+                CompilationError::enumeration_value_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tokName = tokAt(scanner,(yylsp[-3]));
+            for ( auto & crd : yyextra->g_CommentReaders ) {
+                crd->afterEnumerationEntry((yyvsp[-3].s)->c_str(), tokName);
+            }
+        }
+        delete (yyvsp[-3].s);
+        (yyval.pEnum) = (yyvsp[-4].pEnum);
+    }
+    break;
+
+  case 610: /* optional_public_or_private_alias: %empty  */
+                     { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
+    break;
+
+  case 611: /* optional_public_or_private_alias: "private"  */
+                     { (yyval.b) = false; }
+    break;
+
+  case 612: /* optional_public_or_private_alias: "public"  */
+                     { (yyval.b) = true; }
+    break;
+
+  case 613: /* $@39: %empty  */
+                                                         {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto pubename = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeAlias(pubename);
+        }
+    }
+    break;
+
+  case 614: /* single_alias: optional_public_or_private_alias "name" $@39 '=' type_declaration  */
+                                  {
+        das_checkName(scanner,*(yyvsp[-3].s),tokAt(scanner,(yylsp[-3])));
+        (yyvsp[0].pTypeDecl)->isPrivateAlias = !(yyvsp[-4].b);
+        if ( (yyvsp[0].pTypeDecl)->baseType == Type::alias ) {
+            das_yyerror(scanner,"alias cannot be defined in terms of another alias "+*(yyvsp[-3].s),tokAt(scanner,(yylsp[-3])),
+                CompilationError::invalid_type);
+        }
+        (yyvsp[0].pTypeDecl)->alias = *(yyvsp[-3].s);
+        if ( !yyextra->g_Program->addAlias(TypeDeclPtr((yyvsp[0].pTypeDecl))) ) {
+            das_yyerror(scanner,"type alias is already defined "+*(yyvsp[-3].s),tokAt(scanner,(yylsp[-3])),
+                CompilationError::type_alias_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto pubename = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterAlias((yyvsp[-3].s)->c_str(),pubename);
+        }
+        delete (yyvsp[-3].s);
+    }
+    break;
+
+  case 618: /* $@40: %empty  */
+                    { yyextra->das_force_oxford_comma=true;}
+    break;
+
+  case 620: /* optional_public_or_private_enum: %empty  */
+                     { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
+    break;
+
+  case 621: /* optional_public_or_private_enum: "private"  */
+                     { (yyval.b) = false; }
+    break;
+
+  case 622: /* optional_public_or_private_enum: "public"  */
+                     { (yyval.b) = true; }
+    break;
+
+  case 623: /* enum_name: "name"  */
+                   {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto pubename = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeEnumeration(pubename);
+        }
+        (yyval.pEnum) = ast_addEmptyEnum(scanner, (yyvsp[0].s), tokAt(scanner,(yylsp[0])));
+    }
+    break;
+
+  case 624: /* $@41: %empty  */
+                                                                                                                {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[-1]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeEnumerationEntries(tak);
+        }
+    }
+    break;
+
+  case 625: /* $@42: %empty  */
+                    {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterEnumerationEntries(tak);
+        }
+    }
+    break;
+
+  case 626: /* enum_declaration: optional_annotation_list "enum" optional_public_or_private_enum enum_name "begin of code block" $@41 enum_list $@42 "end of code block"  */
+          {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto pubename = tokAt(scanner,(yylsp[-2]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterEnumeration((yyvsp[-5].pEnum)->name.c_str(),pubename);
+        }
+        ast_enumDeclaration(scanner,(yyvsp[-8].faList),tokAt(scanner,(yylsp[-8])),(yyvsp[-6].b),(yyvsp[-5].pEnum),(yyvsp[-2].pEnum),Type::tInt);
+    }
+    break;
+
+  case 627: /* $@43: %empty  */
+                                                                                                                                                     {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[-3]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeEnumerationEntries(tak);
+        }
+    }
+    break;
+
+  case 628: /* $@44: %empty  */
+                    {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterEnumerationEntries(tak);
+        }
+    }
+    break;
+
+  case 629: /* enum_declaration: optional_annotation_list "enum" optional_public_or_private_enum enum_name ':' enum_basic_type_declaration "begin of code block" $@43 enum_list $@44 "end of code block"  */
+          {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto pubename = tokAt(scanner,(yylsp[-2]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterEnumeration((yyvsp[-7].pEnum)->name.c_str(),pubename);
+        }
+        ast_enumDeclaration(scanner,(yyvsp[-10].faList),tokAt(scanner,(yylsp[-10])),(yyvsp[-8].b),(yyvsp[-7].pEnum),(yyvsp[-2].pEnum),(yyvsp[-5].type));
+    }
+    break;
+
+  case 630: /* optional_structure_parent: %empty  */
+                                        { (yyval.s) = nullptr; }
+    break;
+
+  case 631: /* optional_structure_parent: ':' name_in_namespace  */
+                                        { (yyval.s) = (yyvsp[0].s); }
+    break;
+
+  case 632: /* optional_sealed: %empty  */
+                        { (yyval.b) = false; }
+    break;
+
+  case 633: /* optional_sealed: "sealed"  */
+                        { (yyval.b) = true; }
+    break;
+
+  case 634: /* structure_name: optional_sealed "name" optional_structure_parent  */
+                                                                           {
+        (yyval.pStructure) = ast_structureName(scanner,(yyvsp[-2].b),(yyvsp[-1].s),tokAt(scanner,(yylsp[-1])),(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+    }
+    break;
+
+  case 635: /* class_or_struct: "class"  */
+                    { (yyval.i) = CorS_Class; }
+    break;
+
+  case 636: /* class_or_struct: "struct"  */
+                    { (yyval.i) = CorS_Struct; }
+    break;
+
+  case 637: /* class_or_struct: "template" "class"  */
+                                 { (yyval.i) = CorS_ClassTemplate; }
+    break;
+
+  case 638: /* class_or_struct: "template" "struct"  */
+                                 { (yyval.i) = CorS_StructTemplate; }
+    break;
+
+  case 639: /* optional_public_or_private_structure: %empty  */
+                     { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
+    break;
+
+  case 640: /* optional_public_or_private_structure: "private"  */
+                     { (yyval.b) = false; }
+    break;
+
+  case 641: /* optional_public_or_private_structure: "public"  */
+                     { (yyval.b) = true; }
+    break;
+
+  case 642: /* optional_struct_variable_declaration_list: %empty  */
+        {
+        (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
+    }
+    break;
+
+  case 643: /* optional_struct_variable_declaration_list: "begin of code block" struct_variable_declaration_list "end of code block"  */
+                                                                       {
+        if (format::is_replace_braces() &&
+            format::prepare_rule(format::Pos::from_end_prev_line(tokAt(scanner,(yylsp[-2]))))) {
+            const auto internal = format::get_substring(format::Pos::from_end_prev_line(tokAt(scanner,(yylsp[-2]))),
+                                                          format::Pos::from(tokAt(scanner,(yylsp[0])))); // should be from_last, but location little bit incorrect
+            format::get_writer() << " {" << internal
+                                   << std::string(yyextra->das_indent_level, '\t') // emit tabs
+                                   << "}\n"; // new line
+            format::finish_rule(format::Pos::from(tokAt(scanner,(yylsp[0]))));
+        }
+        (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList);
+    }
+    break;
+
+  case 644: /* $@45: %empty  */
+                                                                                                        {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto tak = tokAt(scanner,(yylsp[-1]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeStructure(tak);
+        }
+    }
+    break;
+
+  case 645: /* $@46: %empty  */
+                         {
+        if ( (yyvsp[0].pStructure) ) {
+            (yyvsp[0].pStructure)->isClass = (yyvsp[-3].i)==CorS_Class || (yyvsp[-3].i)==CorS_ClassTemplate;
+            (yyvsp[0].pStructure)->isTemplate = (yyvsp[-3].i)==CorS_ClassTemplate || (yyvsp[-3].i)==CorS_StructTemplate;
+            (yyvsp[0].pStructure)->privateStructure = !(yyvsp[-2].b);
+        }
+    }
+    break;
+
+  case 646: /* structure_declaration: optional_annotation_list class_or_struct optional_public_or_private_structure $@45 structure_name $@46 optional_struct_variable_declaration_list  */
+                                                      {
+        if ( (yyvsp[-2].pStructure) ) {
+            ast_structureDeclaration ( scanner, (yyvsp[-6].faList), tokAt(scanner,(yylsp[-5])), (yyvsp[-2].pStructure), tokAt(scanner,(yylsp[-2])), (yyvsp[0].pVarDeclList) );
+            if ( !yyextra->g_CommentReaders.empty() ) {
+                auto tak = tokAt(scanner,(yylsp[-5]));
+                for ( auto & crd : yyextra->g_CommentReaders ) crd->afterStructure((yyvsp[-2].pStructure),tak);
+            }
+        } else {
+            deleteVariableDeclarationList((yyvsp[0].pVarDeclList));
+        }
+    }
+    break;
+
+  case 647: /* variable_name_with_pos_list: "name"  */
+                    {
+        das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{*(yyvsp[0].s),"",tokAt(scanner,(yylsp[0]))});
+        (yyval.pNameWithPosList) = pSL;
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 648: /* variable_name_with_pos_list: "$i" '(' expr ')'  */
+                                     {
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{"``MACRO``TAG``","",tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression)});
+        (yyval.pNameWithPosList) = pSL;
+    }
+    break;
+
+  case 649: /* variable_name_with_pos_list: "name" "aka" "name"  */
+                                         {
+        das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
+        das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+        auto pSL = new vector<VariableNameAndPosition>();
+        pSL->push_back(VariableNameAndPosition{*(yyvsp[-2].s),*(yyvsp[0].s),tokAt(scanner,(yylsp[-2]))});
+        (yyval.pNameWithPosList) = pSL;
+        delete (yyvsp[-2].s);
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 650: /* variable_name_with_pos_list: variable_name_with_pos_list ',' "name"  */
+                                                         {
+        das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+        (yyvsp[-2].pNameWithPosList)->push_back(VariableNameAndPosition{*(yyvsp[0].s),"",tokAt(scanner,(yylsp[0]))});
+        (yyval.pNameWithPosList) = (yyvsp[-2].pNameWithPosList);
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 651: /* variable_name_with_pos_list: variable_name_with_pos_list ',' "name" "aka" "name"  */
+                                                                               {
+        das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
+        das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+        (yyvsp[-4].pNameWithPosList)->push_back(VariableNameAndPosition{*(yyvsp[-2].s),*(yyvsp[0].s),tokAt(scanner,(yylsp[-2]))});
+        (yyval.pNameWithPosList) = (yyvsp[-4].pNameWithPosList);
+        delete (yyvsp[-2].s);
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 652: /* basic_type_declaration: "bool"  */
+                        { (yyval.type) = Type::tBool; }
+    break;
+
+  case 653: /* basic_type_declaration: "string"  */
+                        { (yyval.type) = Type::tString; }
+    break;
+
+  case 654: /* basic_type_declaration: "int"  */
+                        { (yyval.type) = Type::tInt; }
+    break;
+
+  case 655: /* basic_type_declaration: "int8"  */
+                        { (yyval.type) = Type::tInt8; }
+    break;
+
+  case 656: /* basic_type_declaration: "int16"  */
+                        { (yyval.type) = Type::tInt16; }
+    break;
+
+  case 657: /* basic_type_declaration: "int64"  */
+                        { (yyval.type) = Type::tInt64; }
+    break;
+
+  case 658: /* basic_type_declaration: "int2"  */
+                        { (yyval.type) = Type::tInt2; }
+    break;
+
+  case 659: /* basic_type_declaration: "int3"  */
+                        { (yyval.type) = Type::tInt3; }
+    break;
+
+  case 660: /* basic_type_declaration: "int4"  */
+                        { (yyval.type) = Type::tInt4; }
+    break;
+
+  case 661: /* basic_type_declaration: "uint"  */
+                        { (yyval.type) = Type::tUInt; }
+    break;
+
+  case 662: /* basic_type_declaration: "uint8"  */
+                        { (yyval.type) = Type::tUInt8; }
+    break;
+
+  case 663: /* basic_type_declaration: "uint16"  */
+                        { (yyval.type) = Type::tUInt16; }
+    break;
+
+  case 664: /* basic_type_declaration: "uint64"  */
+                        { (yyval.type) = Type::tUInt64; }
+    break;
+
+  case 665: /* basic_type_declaration: "uint2"  */
+                        { (yyval.type) = Type::tUInt2; }
+    break;
+
+  case 666: /* basic_type_declaration: "uint3"  */
+                        { (yyval.type) = Type::tUInt3; }
+    break;
+
+  case 667: /* basic_type_declaration: "uint4"  */
+                        { (yyval.type) = Type::tUInt4; }
+    break;
+
+  case 668: /* basic_type_declaration: "float"  */
+                        { (yyval.type) = Type::tFloat; }
+    break;
+
+  case 669: /* basic_type_declaration: "float2"  */
+                        { (yyval.type) = Type::tFloat2; }
+    break;
+
+  case 670: /* basic_type_declaration: "float3"  */
+                        { (yyval.type) = Type::tFloat3; }
+    break;
+
+  case 671: /* basic_type_declaration: "float4"  */
+                        { (yyval.type) = Type::tFloat4; }
+    break;
+
+  case 672: /* basic_type_declaration: "void"  */
+                        { (yyval.type) = Type::tVoid; }
+    break;
+
+  case 673: /* basic_type_declaration: "range"  */
+                        { (yyval.type) = Type::tRange; }
+    break;
+
+  case 674: /* basic_type_declaration: "urange"  */
+                        { (yyval.type) = Type::tURange; }
+    break;
+
+  case 675: /* basic_type_declaration: "range64"  */
+                        { (yyval.type) = Type::tRange64; }
+    break;
+
+  case 676: /* basic_type_declaration: "urange64"  */
+                        { (yyval.type) = Type::tURange64; }
+    break;
+
+  case 677: /* basic_type_declaration: "double"  */
+                        { (yyval.type) = Type::tDouble; }
+    break;
+
+  case 678: /* basic_type_declaration: "bitfield"  */
+                        { (yyval.type) = Type::tBitfield; }
+    break;
+
+  case 679: /* enum_basic_type_declaration: "int"  */
+                        { (yyval.type) = Type::tInt; }
+    break;
+
+  case 680: /* enum_basic_type_declaration: "int8"  */
+                        { (yyval.type) = Type::tInt8; }
+    break;
+
+  case 681: /* enum_basic_type_declaration: "int16"  */
+                        { (yyval.type) = Type::tInt16; }
+    break;
+
+  case 682: /* enum_basic_type_declaration: "uint"  */
+                        { (yyval.type) = Type::tUInt; }
+    break;
+
+  case 683: /* enum_basic_type_declaration: "uint8"  */
+                        { (yyval.type) = Type::tUInt8; }
+    break;
+
+  case 684: /* enum_basic_type_declaration: "uint16"  */
+                        { (yyval.type) = Type::tUInt16; }
+    break;
+
+  case 685: /* enum_basic_type_declaration: "int64"  */
+                        { (yyval.type) = Type::tInt64; }
+    break;
+
+  case 686: /* enum_basic_type_declaration: "uint64"  */
+                        { (yyval.type) = Type::tUInt64; }
+    break;
+
+  case 687: /* structure_type_declaration: name_in_namespace  */
+                                 {
+        (yyval.pTypeDecl) = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,(yylsp[0])),*(yyvsp[0].s));
+        if ( !(yyval.pTypeDecl) ) {
+            (yyval.pTypeDecl) = new TypeDecl(Type::tVoid);
+            (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
+        }
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 688: /* auto_type_declaration: "auto"  */
+                       {
+        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
+    }
+    break;
+
+  case 689: /* auto_type_declaration: "auto" '(' "name" ')'  */
+                                            {
+        das_checkName(scanner,*(yyvsp[-1].s),tokAt(scanner,(yylsp[-1])));
+        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-3]));
+        (yyval.pTypeDecl)->alias = *(yyvsp[-1].s);
+        delete (yyvsp[-1].s);
+    }
+    break;
+
+  case 690: /* auto_type_declaration: "$t" '(' expr ')'  */
+                                          {
+        (yyval.pTypeDecl) = new TypeDecl(Type::alias);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-3]));
+        (yyval.pTypeDecl)->alias = "``MACRO``TAG``";
+        (yyval.pTypeDecl)->isTag = true;
+        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::autoinfer);
+        (yyval.pTypeDecl)->firstType->at = tokAt(scanner, (yylsp[-1]));
+        (yyval.pTypeDecl)->firstType->dimExpr.push_back((yyvsp[-1].pExpression));
+    }
+    break;
+
+  case 691: /* bitfield_bits: "name"  */
+                    {
+        das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+        auto pSL = new vector<string>();
+        pSL->push_back(*(yyvsp[0].s));
+        (yyval.pNameList) = pSL;
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 692: /* bitfield_bits: bitfield_bits "end of expression" "name"  */
+                                           {
+        das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
+        (yyvsp[-2].pNameList)->push_back(*(yyvsp[0].s));
+        (yyval.pNameList) = (yyvsp[-2].pNameList);
+        delete (yyvsp[0].s);
+    }
+    break;
+
+  case 693: /* bitfield_alias_bits: %empty  */
+        {
+        auto pSL = new vector<string>();
+        (yyval.pNameList) = pSL;
+
+    }
+    break;
+
+  case 694: /* bitfield_alias_bits: bitfield_alias_bits "end of expression"  */
+                                      {
+        (yyval.pNameList) = (yyvsp[-1].pNameList);
+    }
+    break;
+
+  case 695: /* bitfield_alias_bits: bitfield_alias_bits "name" "end of expression"  */
+                                                 {
+        das_checkName(scanner,*(yyvsp[-1].s),tokAt(scanner,(yylsp[-1])));
+        (yyvsp[-2].pNameList)->push_back(*(yyvsp[-1].s));
+        (yyval.pNameList) = (yyvsp[-2].pNameList);
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[-1]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterBitfieldEntry((yyvsp[-1].s)->c_str(),atvname);
+        }
+        delete (yyvsp[-1].s);
+    }
+    break;
+
+  case 696: /* $@47: %empty  */
+                                     { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 697: /* $@48: %empty  */
+                                                                                            { yyextra->das_arrow_depth --; }
+    break;
+
+  case 698: /* bitfield_type_declaration: "bitfield" '<' $@47 bitfield_bits '>' $@48  */
+                                                                                                                             {
+            (yyval.pTypeDecl) = new TypeDecl(Type::tBitfield);
+            (yyval.pTypeDecl)->argNames = *(yyvsp[-2].pNameList);
+            if ( (yyval.pTypeDecl)->argNames.size()>32 ) {
+                das_yyerror(scanner,"only 32 different bits are allowed in a bitfield",tokAt(scanner,(yylsp[-5])),
+                    CompilationError::invalid_type);
+            }
+            (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
+            delete (yyvsp[-2].pNameList);
+    }
+    break;
+
+  case 701: /* table_type_pair: type_declaration  */
+                                      {
+        (yyval.aTypePair).firstType = (yyvsp[0].pTypeDecl);
+        (yyval.aTypePair).secondType = new TypeDecl(Type::tVoid);
+    }
+    break;
+
+  case 702: /* table_type_pair: type_declaration c_or_s type_declaration  */
+                                                                             {
+        (yyval.aTypePair).firstType = (yyvsp[-2].pTypeDecl);
+        (yyval.aTypePair).secondType = (yyvsp[0].pTypeDecl);
+    }
+    break;
+
+  case 703: /* dim_list: '[' expr ']'  */
+                             {
+        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
+        appendDimExpr((yyval.pTypeDecl), (yyvsp[-1].pExpression));
+    }
+    break;
+
+  case 704: /* dim_list: dim_list '[' expr ']'  */
+                                            {
+        (yyval.pTypeDecl) = (yyvsp[-3].pTypeDecl);
+        appendDimExpr((yyval.pTypeDecl), (yyvsp[-1].pExpression));
+    }
+    break;
+
+  case 705: /* type_declaration_no_options: basic_type_declaration  */
+                                                            { (yyval.pTypeDecl) = new TypeDecl((yyvsp[0].type)); (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0])); }
+    break;
+
+  case 706: /* type_declaration_no_options: auto_type_declaration  */
+                                                            { (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl); }
+    break;
+
+  case 707: /* type_declaration_no_options: bitfield_type_declaration  */
+                                                            { (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl); }
+    break;
+
+  case 708: /* type_declaration_no_options: structure_type_declaration  */
+                                                            { (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl); }
+    break;
+
+  case 709: /* type_declaration_no_options: type_declaration_no_options dim_list  */
+                                                                {
+        if ( (yyvsp[-1].pTypeDecl)->baseType==Type::typeDecl ) {
+            das_yyerror(scanner,"type declaration can`t be used as array base type",tokAt(scanner,(yylsp[-1])),
+                CompilationError::invalid_type);
+        } else if ( (yyvsp[-1].pTypeDecl)->baseType==Type::typeMacro ) {
+            das_yyerror(scanner,"macro can`t be used as array base type",tokAt(scanner,(yylsp[-1])),
+                CompilationError::invalid_type);
+        }
+        (yyvsp[-1].pTypeDecl)->dim.insert((yyvsp[-1].pTypeDecl)->dim.begin(), (yyvsp[0].pTypeDecl)->dim.begin(), (yyvsp[0].pTypeDecl)->dim.end());
+        (yyvsp[-1].pTypeDecl)->dimExpr.insert((yyvsp[-1].pTypeDecl)->dimExpr.begin(), (yyvsp[0].pTypeDecl)->dimExpr.begin(), (yyvsp[0].pTypeDecl)->dimExpr.end());
+        (yyvsp[-1].pTypeDecl)->removeDim = false;
+        (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
+        (yyvsp[0].pTypeDecl)->dimExpr.clear();
+        delete (yyvsp[0].pTypeDecl);
+    }
+    break;
+
+  case 710: /* type_declaration_no_options: type_declaration_no_options '[' ']'  */
+                                                      {
+        (yyvsp[-2].pTypeDecl)->dim.push_back(TypeDecl::dimAuto);
+        (yyvsp[-2].pTypeDecl)->dimExpr.push_back(nullptr);
+        (yyvsp[-2].pTypeDecl)->removeDim = false;
+        (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
+    }
+    break;
+
+  case 711: /* $@49: %empty  */
+                     { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 712: /* $@50: %empty  */
+                                                                                     { yyextra->das_arrow_depth --; }
+    break;
+
+  case 713: /* type_declaration_no_options: "type" '<' $@49 type_declaration '>' $@50  */
+                                                                                                                      {
+        (yyvsp[-2].pTypeDecl)->autoToAlias = true;
+        (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
+    }
+    break;
+
+  case 714: /* type_declaration_no_options: "typedecl" '(' expr ')'  */
+                                               {
+        (yyval.pTypeDecl) = new TypeDecl(Type::typeDecl);
+        (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-3]),(yylsp[-1]));
+        (yyval.pTypeDecl)->dimExpr.push_back((yyvsp[-1].pExpression));
+    }
+    break;
+
+  case 715: /* type_declaration_no_options: '$' name_in_namespace '(' optional_expr_list ')'  */
+                                                                          {
+        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
+        (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-3]), (yylsp[-1]));
+        (yyval.pTypeDecl)->dimExpr = sequenceToList((yyvsp[-1].pExpression));
+        (yyval.pTypeDecl)->dimExpr.insert((yyval.pTypeDecl)->dimExpr.begin(), new ExprConstString(tokAt(scanner,(yylsp[-3])), *(yyvsp[-3].s)));
+        delete (yyvsp[-3].s);
+    }
+    break;
+
+  case 716: /* $@51: %empty  */
+                                        { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 717: /* type_declaration_no_options: '$' name_in_namespace '<' $@51 type_declaration_no_options_list '>' '(' optional_expr_list ')'  */
+                                                                                                                                                           {
+        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
+        (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-7]), (yylsp[-1]));
+        (yyval.pTypeDecl)->dimExpr = typesAndSequenceToList((yyvsp[-4].pTypeDeclList),(yyvsp[-1].pExpression));
+        (yyval.pTypeDecl)->dimExpr.insert((yyval.pTypeDecl)->dimExpr.begin(), new ExprConstString(tokAt(scanner,(yylsp[-7])), *(yyvsp[-7].s)));
+        delete (yyvsp[-7].s);
+    }
+    break;
+
+  case 718: /* type_declaration_no_options: type_declaration_no_options '-' '[' ']'  */
+                                                          {
+        (yyvsp[-3].pTypeDecl)->removeDim = true;
+        (yyval.pTypeDecl) = (yyvsp[-3].pTypeDecl);
+    }
+    break;
+
+  case 719: /* type_declaration_no_options: type_declaration_no_options "explicit"  */
+                                                           {
+        (yyvsp[-1].pTypeDecl)->isExplicit = true;
+        (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
+    }
+    break;
+
+  case 720: /* type_declaration_no_options: type_declaration_no_options "const"  */
+                                                        {
+        (yyvsp[-1].pTypeDecl)->constant = true;
+        (yyvsp[-1].pTypeDecl)->removeConstant = false;
+        (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
+    }
+    break;
+
+  case 721: /* type_declaration_no_options: type_declaration_no_options '-' "const"  */
+                                                            {
+        (yyvsp[-2].pTypeDecl)->constant = false;
+        (yyvsp[-2].pTypeDecl)->removeConstant = true;
+        (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
+    }
+    break;
+
+  case 722: /* type_declaration_no_options: type_declaration_no_options '&'  */
+                                                  {
+        (yyvsp[-1].pTypeDecl)->ref = true;
+        (yyvsp[-1].pTypeDecl)->removeRef = false;
+        (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
+    }
+    break;
+
+  case 723: /* type_declaration_no_options: type_declaration_no_options '-' '&'  */
+                                                      {
+        (yyvsp[-2].pTypeDecl)->ref = false;
+        (yyvsp[-2].pTypeDecl)->removeRef = true;
+        (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
+    }
+    break;
+
+  case 724: /* type_declaration_no_options: type_declaration_no_options '#'  */
+                                                  {
+        (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
+        (yyval.pTypeDecl)->temporary = true;
+    }
+    break;
+
+  case 725: /* type_declaration_no_options: type_declaration_no_options "implicit"  */
+                                                           {
+        (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
+        (yyval.pTypeDecl)->implicit = true;
+    }
+    break;
+
+  case 726: /* type_declaration_no_options: type_declaration_no_options '-' '#'  */
+                                                      {
+        (yyvsp[-2].pTypeDecl)->temporary = false;
+        (yyvsp[-2].pTypeDecl)->removeTemporary = true;
+        (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
+    }
+    break;
+
+  case 727: /* type_declaration_no_options: type_declaration_no_options "==" "const"  */
+                                                               {
+        (yyvsp[-2].pTypeDecl)->explicitConst = true;
+        (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
+    }
+    break;
+
+  case 728: /* type_declaration_no_options: type_declaration_no_options "==" '&'  */
+                                                         {
+        (yyvsp[-2].pTypeDecl)->explicitRef = true;
+        (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
+    }
+    break;
+
+  case 729: /* type_declaration_no_options: type_declaration_no_options '?'  */
+                                                  {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-1]));
+        (yyval.pTypeDecl)->firstType = TypeDeclPtr((yyvsp[-1].pTypeDecl));
+    }
+    break;
+
+  case 730: /* $@52: %empty  */
+                               { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 731: /* $@53: %empty  */
+                                                                                               { yyextra->das_arrow_depth --; }
+    break;
+
+  case 732: /* type_declaration_no_options: "smart_ptr" '<' $@52 type_declaration '>' $@53  */
+                                                                                                                                {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
+        (yyval.pTypeDecl)->smartPtr = true;
+        (yyval.pTypeDecl)->firstType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+    }
+    break;
+
+  case 733: /* type_declaration_no_options: type_declaration_no_options "??"  */
+                                                 {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-1]));
+        (yyval.pTypeDecl)->firstType = make_smart<TypeDecl>(Type::tPointer);
+        (yyval.pTypeDecl)->firstType->at = tokAt(scanner,(yylsp[-1]));
+        (yyval.pTypeDecl)->firstType->firstType = TypeDeclPtr((yyvsp[-1].pTypeDecl));
+    }
+    break;
+
+  case 734: /* $@54: %empty  */
+                           { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 735: /* $@55: %empty  */
+                                                                                           { yyextra->das_arrow_depth --; }
+    break;
+
+  case 736: /* type_declaration_no_options: "array" '<' $@54 type_declaration '>' $@55  */
+                                                                                                                            {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tArray);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
+        (yyval.pTypeDecl)->firstType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+    }
+    break;
+
+  case 737: /* $@56: %empty  */
+                           { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 738: /* $@57: %empty  */
+                                                                                     { yyextra->das_arrow_depth --; }
+    break;
+
+  case 739: /* type_declaration_no_options: "table" '<' $@56 table_type_pair '>' $@57  */
+                                                                                                                      {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tTable);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
+        (yyval.pTypeDecl)->firstType = TypeDeclPtr((yyvsp[-2].aTypePair).firstType);
+        (yyval.pTypeDecl)->secondType = TypeDeclPtr((yyvsp[-2].aTypePair).secondType);
+    }
+    break;
+
+  case 740: /* $@58: %empty  */
+                               { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 741: /* $@59: %empty  */
+                                                                                                 { yyextra->das_arrow_depth --; }
+    break;
+
+  case 742: /* type_declaration_no_options: "iterator" '<' $@58 type_declaration '>' $@59  */
+                                                                                                                                  {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tIterator);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
+        (yyval.pTypeDecl)->firstType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+    }
+    break;
+
+  case 743: /* type_declaration_no_options: "block"  */
+                        {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
+    }
+    break;
+
+  case 744: /* $@60: %empty  */
+                             { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 745: /* $@61: %empty  */
+                                                                                              { yyextra->das_arrow_depth --; }
+    break;
+
+  case 746: /* type_declaration_no_options: "block" '<' $@60 type_declaration '>' $@61  */
+                                                                                                                               {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
+        (yyval.pTypeDecl)->firstType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+    }
+    break;
+
+  case 747: /* $@62: %empty  */
+                             { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 748: /* $@63: %empty  */
+                                                                                                                                       { yyextra->das_arrow_depth --; }
+    break;
+
+  case 749: /* type_declaration_no_options: "block" '<' $@62 optional_function_argument_list optional_function_type '>' $@63  */
+                                                                                                                                                                        {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
+        (yyval.pTypeDecl)->firstType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+        if ( (yyvsp[-3].pVarDeclList) ) {
+            varDeclToTypeDecl(scanner, (yyval.pTypeDecl), (yyvsp[-3].pVarDeclList));
+            deleteVariableDeclarationList((yyvsp[-3].pVarDeclList));
+        }
+    }
+    break;
+
+  case 750: /* type_declaration_no_options: "function"  */
+                           {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
+    }
+    break;
+
+  case 751: /* $@64: %empty  */
+                               { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 752: /* $@65: %empty  */
+                                                                                                { yyextra->das_arrow_depth --; }
+    break;
+
+  case 753: /* type_declaration_no_options: "function" '<' $@64 type_declaration '>' $@65  */
+                                                                                                                                 {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
+        (yyval.pTypeDecl)->firstType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+    }
+    break;
+
+  case 754: /* $@66: %empty  */
+                               { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 755: /* $@67: %empty  */
+                                                                                                                                         { yyextra->das_arrow_depth --; }
+    break;
+
+  case 756: /* type_declaration_no_options: "function" '<' $@66 optional_function_argument_list optional_function_type '>' $@67  */
+                                                                                                                                                                          {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
+        (yyval.pTypeDecl)->firstType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+        if ( (yyvsp[-3].pVarDeclList) ) {
+            varDeclToTypeDecl(scanner, (yyval.pTypeDecl), (yyvsp[-3].pVarDeclList));
+            deleteVariableDeclarationList((yyvsp[-3].pVarDeclList));
+        }
+    }
+    break;
+
+  case 757: /* type_declaration_no_options: "lambda"  */
+                         {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
+    }
+    break;
+
+  case 758: /* $@68: %empty  */
+                             { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 759: /* $@69: %empty  */
+                                                                                              { yyextra->das_arrow_depth --; }
+    break;
+
+  case 760: /* type_declaration_no_options: "lambda" '<' $@68 type_declaration '>' $@69  */
+                                                                                                                               {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
+        (yyval.pTypeDecl)->firstType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+    }
+    break;
+
+  case 761: /* $@70: %empty  */
+                             { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 762: /* $@71: %empty  */
+                                                                                                                                       { yyextra->das_arrow_depth --; }
+    break;
+
+  case 763: /* type_declaration_no_options: "lambda" '<' $@70 optional_function_argument_list optional_function_type '>' $@71  */
+                                                                                                                                                                        {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
+        (yyval.pTypeDecl)->firstType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+        if ( (yyvsp[-3].pVarDeclList) ) {
+            varDeclToTypeDecl(scanner, (yyval.pTypeDecl), (yyvsp[-3].pVarDeclList));
+            deleteVariableDeclarationList((yyvsp[-3].pVarDeclList));
+        }
+    }
+    break;
+
+  case 764: /* $@72: %empty  */
+                            { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 765: /* $@73: %empty  */
+                                                                                       { yyextra->das_arrow_depth --; }
+    break;
+
+  case 766: /* type_declaration_no_options: "tuple" '<' $@72 tuple_type_list '>' $@73  */
+                                                                                                                        {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tTuple);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
+        varDeclToTypeDecl(scanner, (yyval.pTypeDecl), (yyvsp[-2].pVarDeclList), true);
+        deleteVariableDeclarationList((yyvsp[-2].pVarDeclList));
+    }
+    break;
+
+  case 767: /* $@74: %empty  */
+                              { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 768: /* $@75: %empty  */
+                                                                                           { yyextra->das_arrow_depth --; }
+    break;
+
+  case 769: /* type_declaration_no_options: "variant" '<' $@74 variant_type_list '>' $@75  */
+                                                                                                                            {
+        (yyval.pTypeDecl) = new TypeDecl(Type::tVariant);
+        (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
+        varDeclToTypeDecl(scanner, (yyval.pTypeDecl), (yyvsp[-2].pVarDeclList), true);
+        deleteVariableDeclarationList((yyvsp[-2].pVarDeclList));
+    }
+    break;
+
+  case 770: /* type_declaration: type_declaration_no_options  */
+                                        {
+        (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
+    }
+    break;
+
+  case 771: /* type_declaration: type_declaration '|' type_declaration_no_options  */
+                                                                     {
+        if ( (yyvsp[-2].pTypeDecl)->baseType==Type::option ) {
+            (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
+            (yyval.pTypeDecl)->argTypes.push_back((yyvsp[0].pTypeDecl));
+        } else {
+            (yyval.pTypeDecl) = new TypeDecl(Type::option);
+            (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-2]),(yylsp[0]));
+            (yyval.pTypeDecl)->argTypes.push_back((yyvsp[-2].pTypeDecl));
+            (yyval.pTypeDecl)->argTypes.push_back((yyvsp[0].pTypeDecl));
+        }
+    }
+    break;
+
+  case 772: /* type_declaration: type_declaration '|' '#'  */
+                                             {
+        if ( (yyvsp[-2].pTypeDecl)->baseType==Type::option ) {
+            (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
+            (yyval.pTypeDecl)->argTypes.push_back(make_smart<TypeDecl>(*(yyvsp[-2].pTypeDecl)->argTypes.back()));
+            (yyvsp[-2].pTypeDecl)->argTypes.back()->temporary ^= true;
+        } else {
+            (yyval.pTypeDecl) = new TypeDecl(Type::option);
+            (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-2]),(yylsp[0]));
+            (yyval.pTypeDecl)->argTypes.push_back((yyvsp[-2].pTypeDecl));
+            (yyval.pTypeDecl)->argTypes.push_back(make_smart<TypeDecl>(*(yyvsp[-2].pTypeDecl)));
+            (yyval.pTypeDecl)->argTypes.back()->temporary ^= true;
+        }
+    }
+    break;
+
+  case 773: /* $@76: %empty  */
+                                                          { yyextra->das_need_oxford_comma=false; }
+    break;
+
+  case 774: /* $@77: %empty  */
+                                                                                                                {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeTuple(atvname);
+        }
+    }
+    break;
+
+  case 775: /* $@78: %empty  */
+          {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[-2]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeTupleEntries(atvname);
+        }
+    }
+    break;
+
+  case 776: /* $@79: %empty  */
+                                  {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[-4]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterTupleEntries(atvname);
+        }
+    }
+    break;
+
+  case 777: /* tuple_alias_declaration: "tuple" optional_public_or_private_alias $@76 "name" $@77 "begin of code block" $@78 tuple_alias_type_list $@79 "end of code block"  */
+          {
+        auto vtype = make_smart<TypeDecl>(Type::tTuple);
+        vtype->alias = *(yyvsp[-6].s);
+        vtype->at = tokAt(scanner,(yylsp[-6]));
+        vtype->isPrivateAlias = !(yyvsp[-8].b);
+        varDeclToTypeDecl(scanner, vtype.get(), (yyvsp[-2].pVarDeclList), true);
+        deleteVariableDeclarationList((yyvsp[-2].pVarDeclList));
+        if ( !yyextra->g_Program->addAlias(vtype) ) {
+            das_yyerror(scanner,"type alias is already defined "+*(yyvsp[-6].s),tokAt(scanner,(yylsp[-6])),
+                CompilationError::type_alias_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[-6]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterTuple((yyvsp[-6].s)->c_str(),atvname);
+        }
+        delete (yyvsp[-6].s);
+    }
+    break;
+
+  case 778: /* $@80: %empty  */
+                                                            { yyextra->das_need_oxford_comma=false; }
+    break;
+
+  case 779: /* $@81: %empty  */
+                                                                                                                  {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeVariant(atvname);
+        }
+    }
+    break;
+
+  case 780: /* $@82: %empty  */
+          {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[-2]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeVariantEntries(atvname);
+        }
+
+    }
+    break;
+
+  case 781: /* $@83: %empty  */
+                                    {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[-4]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterVariantEntries(atvname);
+        }
+    }
+    break;
+
+  case 782: /* variant_alias_declaration: "variant" optional_public_or_private_alias $@80 "name" $@81 "begin of code block" $@82 variant_alias_type_list $@83 "end of code block"  */
+          {
+        auto vtype = make_smart<TypeDecl>(Type::tVariant);
+        vtype->alias = *(yyvsp[-6].s);
+        vtype->at = tokAt(scanner,(yylsp[-6]));
+        vtype->isPrivateAlias = !(yyvsp[-8].b);
+        varDeclToTypeDecl(scanner, vtype.get(), (yyvsp[-2].pVarDeclList), true);
+        deleteVariableDeclarationList((yyvsp[-2].pVarDeclList));
+        if ( !yyextra->g_Program->addAlias(vtype) ) {
+            das_yyerror(scanner,"type alias is already defined "+*(yyvsp[-6].s),tokAt(scanner,(yylsp[-6])),
+                CompilationError::type_alias_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[-6]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterVariant((yyvsp[-6].s)->c_str(),atvname);
+        }
+        delete (yyvsp[-6].s);
+    }
+    break;
+
+  case 783: /* $@84: %empty  */
+                                                             { yyextra->das_need_oxford_comma=false; }
+    break;
+
+  case 784: /* $@85: %empty  */
+                                                                                                                   {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[0]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeBitfield(atvname);
+        }
+    }
+    break;
+
+  case 785: /* $@86: %empty  */
+          {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[-2]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->beforeBitfieldEntries(atvname);
+        }
+    }
+    break;
+
+  case 786: /* $@87: %empty  */
+                                {
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[-4]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterBitfieldEntries(atvname);
+        }
+    }
+    break;
+
+  case 787: /* bitfield_alias_declaration: "bitfield" optional_public_or_private_alias $@84 "name" $@85 "begin of code block" $@86 bitfield_alias_bits $@87 "end of code block"  */
+          {
+        auto btype = make_smart<TypeDecl>(Type::tBitfield);
+        btype->alias = *(yyvsp[-6].s);
+        btype->at = tokAt(scanner,(yylsp[-6]));
+        btype->argNames = *(yyvsp[-2].pNameList);
+        btype->isPrivateAlias = !(yyvsp[-8].b);
+        if ( btype->argNames.size()>32 ) {
+            das_yyerror(scanner,"only 32 different bits are allowed in a bitfield",tokAt(scanner,(yylsp[-6])),
+                CompilationError::invalid_type);
+        }
+        if ( !yyextra->g_Program->addAlias(btype) ) {
+            das_yyerror(scanner,"type alias is already defined "+*(yyvsp[-6].s),tokAt(scanner,(yylsp[-6])),
+                CompilationError::type_alias_already_declared);
+        }
+        if ( !yyextra->g_CommentReaders.empty() ) {
+            auto atvname = tokAt(scanner,(yylsp[-6]));
+            for ( auto & crd : yyextra->g_CommentReaders ) crd->afterBitfield((yyvsp[-6].s)->c_str(),atvname);
+        }
+        delete (yyvsp[-6].s);
+        delete (yyvsp[-2].pNameList);
+    }
+    break;
+
+  case 788: /* make_decl: make_struct_decl  */
+                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 789: /* make_decl: make_dim_decl  */
+                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 790: /* make_decl: make_table_decl  */
+                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 791: /* make_decl: array_comprehension  */
+                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 792: /* make_decl: make_tuple_call  */
+                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 793: /* make_struct_fields: "name" copy_or_move expr  */
+                                               {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,(yylsp[-2]), (yylsp[0])),*(yyvsp[-2].s),ExpressionPtr((yyvsp[0].pExpression)),(yyvsp[-1].b),false);
+        delete (yyvsp[-2].s);
+        auto msd = new MakeStruct();
+        msd->push_back(mfd);
+        (yyval.pMakeStruct) = msd;
+    }
+    break;
+
+  case 794: /* make_struct_fields: "name" ":=" expr  */
+                                      {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,(yylsp[-2]), (yylsp[0])),*(yyvsp[-2].s),ExpressionPtr((yyvsp[0].pExpression)),false,true);
+        delete (yyvsp[-2].s);
+        auto msd = new MakeStruct();
+        msd->push_back(mfd);
+        (yyval.pMakeStruct) = msd;
+    }
+    break;
+
+  case 795: /* make_struct_fields: make_struct_fields ',' "name" copy_or_move expr  */
+                                                                           {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,(yylsp[-2]), (yylsp[0])),*(yyvsp[-2].s),ExpressionPtr((yyvsp[0].pExpression)),(yyvsp[-1].b),false);
+        delete (yyvsp[-2].s);
+        ((MakeStruct *)(yyvsp[-4].pMakeStruct))->push_back(mfd);
+        (yyval.pMakeStruct) = (yyvsp[-4].pMakeStruct);
+    }
+    break;
+
+  case 796: /* make_struct_fields: make_struct_fields ',' "name" ":=" expr  */
+                                                                  {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,(yylsp[-2]), (yylsp[0])),*(yyvsp[-2].s),ExpressionPtr((yyvsp[0].pExpression)),false,true);
+        delete (yyvsp[-2].s);
+        ((MakeStruct *)(yyvsp[-4].pMakeStruct))->push_back(mfd);
+        (yyval.pMakeStruct) = (yyvsp[-4].pMakeStruct);
+    }
+    break;
+
+  case 797: /* make_struct_fields: "$f" '(' expr ')' copy_or_move expr  */
+                                                                           {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,(yylsp[-5]), (yylsp[0])),"``MACRO``TAG``FIELD``",ExpressionPtr((yyvsp[0].pExpression)),(yyvsp[-1].b),false);
+        mfd->tag = ExpressionPtr((yyvsp[-3].pExpression));
+        auto msd = new MakeStruct();
+        msd->push_back(mfd);
+        (yyval.pMakeStruct) = msd;
+    }
+    break;
+
+  case 798: /* make_struct_fields: "$f" '(' expr ')' ":=" expr  */
+                                                                  {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner, (yylsp[-5]), (yylsp[0])),"``MACRO``TAG``FIELD``",ExpressionPtr((yyvsp[0].pExpression)),false,true);
+        mfd->tag = ExpressionPtr((yyvsp[-3].pExpression));
+        auto msd = new MakeStruct();
+        msd->push_back(mfd);
+        (yyval.pMakeStruct) = msd;
+    }
+    break;
+
+  case 799: /* make_struct_fields: make_struct_fields ',' "$f" '(' expr ')' copy_or_move expr  */
+                                                                                                       {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,(yylsp[-5]),(yylsp[0])),"``MACRO``TAG``FIELD``",ExpressionPtr((yyvsp[0].pExpression)),(yyvsp[-1].b),false);
+        mfd->tag = ExpressionPtr((yyvsp[-3].pExpression));
+        ((MakeStruct *)(yyvsp[-7].pMakeStruct))->push_back(mfd);
+        (yyval.pMakeStruct) = (yyvsp[-7].pMakeStruct);
+    }
+    break;
+
+  case 800: /* make_struct_fields: make_struct_fields ',' "$f" '(' expr ')' ":=" expr  */
+                                                                                              {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,(yylsp[-5]), (yylsp[0])),"``MACRO``TAG``FIELD``",ExpressionPtr((yyvsp[0].pExpression)),false,true);
+        mfd->tag = ExpressionPtr((yyvsp[-3].pExpression));
+        ((MakeStruct *)(yyvsp[-7].pMakeStruct))->push_back(mfd);
+        (yyval.pMakeStruct) = (yyvsp[-7].pMakeStruct);
+    }
+    break;
+
+  case 801: /* make_variant_dim: make_struct_fields  */
+                                {
+        (yyval.pExpression) = ast_makeStructToMakeVariant((yyvsp[0].pMakeStruct), tokAt(scanner,(yylsp[0])));
+    }
+    break;
+
+  case 802: /* make_struct_single: make_struct_fields  */
+                                {
+        auto msd = new ExprMakeStruct();
+        msd->structs.push_back(MakeStructPtr((yyvsp[0].pMakeStruct)));
+        (yyval.pExpression) = msd;
+    }
+    break;
+
+  case 803: /* make_struct_dim: make_struct_fields  */
+                                {
+        auto msd = new ExprMakeStruct();
+        msd->structs.push_back(MakeStructPtr((yyvsp[0].pMakeStruct)));
+        (yyval.pExpression) = msd;
+    }
+    break;
+
+  case 804: /* make_struct_dim: make_struct_dim "end of expression" make_struct_fields  */
+                                                         {
+        ((ExprMakeStruct *) (yyvsp[-2].pExpression))->structs.push_back(MakeStructPtr((yyvsp[0].pMakeStruct)));
+        (yyval.pExpression) = (yyvsp[-2].pExpression);
+    }
+    break;
+
+  case 805: /* make_struct_dim_list: '(' make_struct_fields ')'  */
+                                        {
+        auto msd = new ExprMakeStruct();
+        msd->structs.push_back(MakeStructPtr((yyvsp[-1].pMakeStruct)));
+        (yyval.pExpression) = msd;
+    }
+    break;
+
+  case 806: /* make_struct_dim_list: make_struct_dim_list ',' '(' make_struct_fields ')'  */
+                                                                     {
+        ((ExprMakeStruct *) (yyvsp[-4].pExpression))->structs.push_back(MakeStructPtr((yyvsp[-1].pMakeStruct)));
+        (yyval.pExpression) = (yyvsp[-4].pExpression);
+    }
+    break;
+
+  case 807: /* make_struct_dim_decl: make_struct_fields  */
+                                {
+        auto msd = new ExprMakeStruct();
+        msd->structs.push_back(MakeStructPtr((yyvsp[0].pMakeStruct)));
+        (yyval.pExpression) = msd;
+    }
+    break;
+
+  case 808: /* make_struct_dim_decl: make_struct_dim_list optional_comma  */
+                                                 {
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 809: /* optional_make_struct_dim_decl: make_struct_dim_decl  */
+                                  { (yyval.pExpression) = (yyvsp[0].pExpression);  }
+    break;
+
+  case 810: /* optional_make_struct_dim_decl: %empty  */
+        {   (yyval.pExpression) = new ExprMakeStruct(); }
+    break;
+
+  case 811: /* optional_block: %empty  */
+        { (yyval.pExpression) = nullptr; }
+    break;
+
+  case 812: /* optional_block: "where" expr_block  */
+                                  { (yyvsp[0].pExpression)->at = tokAt(scanner, (yylsp[0])); (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 825: /* use_initializer: %empty  */
+                            { (yyval.b) = true; }
+    break;
+
+  case 826: /* use_initializer: "uninitialized"  */
+                            { (yyval.b) = false; }
+    break;
+
+  case 827: /* make_struct_decl: "[[" type_declaration_no_options make_struct_dim optional_block optional_trailing_delim_sqr_sqr  */
+                                                                                                                                     {
+        //std::cout << "case1" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-4]))))) {
+            auto type = format::type_to_string((yyvsp[-3].pTypeDecl), tokAt(scanner,(yylsp[-3]))).value_or("");
+            const bool is_initialized = false;
+            const auto internal = format::handle_msd(static_cast<ExprMakeStruct*>((yyvsp[-2].pExpression)), type, is_initialized);
+            if (static_cast<ExprMakeStruct*>((yyvsp[-2].pExpression))->structs.size() == 1) {
+                // single struct
+                format::get_writer() << internal;
+                if ((yyvsp[-1].pExpression) != nullptr) {
+                    format::get_writer() << " <| " << format::get_substring((yyvsp[-1].pExpression)->at);
+                }
+            } else {
+                // array of structs
+    //            const auto internal = format::get_substring(format::Pos::from(tokAt(scanner,@msd)),
+    //                                                          format::Pos::from(tokAt(scanner,@end)));
+                format::get_writer() << "[" << internal << "]";
+            }
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+        ((ExprMakeStruct *)(yyvsp[-2].pExpression))->makeType = TypeDeclPtr((yyvsp[-3].pTypeDecl));
+        ((ExprMakeStruct *)(yyvsp[-2].pExpression))->block = (yyvsp[-1].pExpression);
+        (yyvsp[-2].pExpression)->at = tokAt(scanner,(yylsp[-4]));
+        (yyval.pExpression) = (yyvsp[-2].pExpression);
+    }
+    break;
+
+  case 828: /* make_struct_decl: "[[" type_declaration_no_options optional_block optional_trailing_delim_sqr_sqr  */
+                                                                                                                {
+        // std::cout << "case2" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-3]))))) {
+            auto type = format::type_to_string((yyvsp[-2].pTypeDecl), tokAt(scanner,(yylsp[-2])));
+            std::unordered_set<std::string> always_init = {
+                // Is there a method to describe all this types?
+                "struct<array<",
+                "array<",
+                "bitfield",
+                "string",
+                "int",
+                "float",
+                "variant",
+                "tuple",
+            };
+            if ((yyvsp[-2].pTypeDecl)->isPointer()) {
+                format::get_writer() << "default<" << type.value() << ">";
+            } else if (std::any_of(always_init.begin(), always_init.end(),
+                            [&type](auto t){ return type.value_or("").find(t) == 0; })) {
+                format::get_writer() << type.value_or("") << "()";
+            } else {
+                format::get_writer() << type.value_or("") << "(uninitialized)";
+            }
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+
+        auto msd = new ExprMakeStruct();
+        msd->makeType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+        msd->block = (yyvsp[-1].pExpression);
+        msd->at = tokAt(scanner,(yylsp[-3]));
+        (yyval.pExpression) = msd;
+    }
+    break;
+
+  case 829: /* make_struct_decl: "[[" type_declaration_no_options '(' ')' optional_block optional_trailing_delim_sqr_sqr  */
+                                                                                                                             {
+        //std::cout << "case3" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-5]))))) {
+            format::get_writer() << format::type_to_string((yyvsp[-4].pTypeDecl), tokAt(scanner,(yylsp[-4]))).value_or("") << "()";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+        auto msd = new ExprMakeStruct();
+        msd->makeType = TypeDeclPtr((yyvsp[-4].pTypeDecl));
+        msd->useInitializer = true;
+        msd->block = (yyvsp[-1].pExpression);
+        msd->at = tokAt(scanner,(yylsp[-5]));
+        (yyval.pExpression) = msd;
+    }
+    break;
+
+  case 830: /* make_struct_decl: "[[" type_declaration_no_options '(' ')' make_struct_dim optional_block optional_trailing_delim_sqr_sqr  */
+                                                                                                                                                  {
+        //std::cout << "case4" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-6]))))) {
+            auto type_name = format::type_to_string((yyvsp[-5].pTypeDecl), tokAt(scanner,(yylsp[-5]))).value_or("");
+            const auto internal = format::handle_msd(static_cast<ExprMakeStruct*>((yyvsp[-2].pExpression)), type_name);
+//            auto internal = format::get_substring(format::Pos::from(tokAt(scanner,@msd)),
+//                                                    format::Pos::from_last(tokAt(scanner,@blk)));
+            format::get_writer() << internal;
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+
+        ((ExprMakeStruct *)(yyvsp[-2].pExpression))->makeType = TypeDeclPtr((yyvsp[-5].pTypeDecl));
+        ((ExprMakeStruct *)(yyvsp[-2].pExpression))->useInitializer = true;
+        ((ExprMakeStruct *)(yyvsp[-2].pExpression))->block = (yyvsp[-1].pExpression);
+        (yyvsp[-2].pExpression)->at = tokAt(scanner,(yylsp[-6]));
+        (yyval.pExpression) = (yyvsp[-2].pExpression);
+    }
+    break;
+
+  case 831: /* make_struct_decl: "[{" type_declaration_no_options make_struct_dim optional_block optional_trailing_delim_cur_sqr  */
+                                                                                                                                          {
+        //std::cout << "case6" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-4]))))) {
+            auto type_name = format::type_to_string((yyvsp[-3].pTypeDecl), tokAt(scanner,(yylsp[-3]))).value_or("");
+            format::get_writer() << "[" << format::handle_msd(static_cast<ExprMakeStruct*>((yyvsp[-2].pExpression)), type_name) << "]";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+
+        ((ExprMakeStruct *)(yyvsp[-2].pExpression))->makeType = TypeDeclPtr((yyvsp[-3].pTypeDecl));
+        ((ExprMakeStruct *)(yyvsp[-2].pExpression))->block = (yyvsp[-1].pExpression);
+        (yyvsp[-2].pExpression)->at = tokAt(scanner,(yylsp[-4]));
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-4])),"to_array_move");
+        tam->arguments.push_back(ExpressionPtr((yyvsp[-2].pExpression)));
+        (yyval.pExpression) = tam;
+    }
+    break;
+
+  case 832: /* make_struct_decl: "[{" type_declaration_no_options '(' ')' make_struct_dim optional_block optional_trailing_delim_cur_sqr  */
+                                                                                                                                                  {
+        //std::cout << "case7" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-6]))))) {
+            auto type_name = format::type_to_string((yyvsp[-5].pTypeDecl), tokAt(scanner,(yylsp[-5]))).value_or("");
+            format::get_writer() << "["
+                                   << format::handle_msd(static_cast<ExprMakeStruct*>((yyvsp[-2].pExpression)), type_name)
+                                   << "]";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+
+        ((ExprMakeStruct *)(yyvsp[-2].pExpression))->makeType = TypeDeclPtr((yyvsp[-5].pTypeDecl));
+        ((ExprMakeStruct *)(yyvsp[-2].pExpression))->useInitializer = true;
+        ((ExprMakeStruct *)(yyvsp[-2].pExpression))->block = (yyvsp[-1].pExpression);
+        (yyvsp[-2].pExpression)->at = tokAt(scanner,(yylsp[-6]));
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-6])),"to_array_move");
+        tam->arguments.push_back(ExpressionPtr((yyvsp[-2].pExpression)));
+        (yyval.pExpression) = tam;
+    }
+    break;
+
+  case 833: /* $@88: %empty  */
+                             { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; }
+    break;
+
+  case 834: /* $@89: %empty  */
+                                                                                                                                         { yyextra->das_arrow_depth --; }
+    break;
+
+  case 835: /* make_struct_decl: "struct" '<' $@88 type_declaration_no_options '>' $@89 '(' use_initializer optional_make_struct_dim_decl ')'  */
+                                                                                                                                                                                                                                            {
+        (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = TypeDeclPtr((yyvsp[-6].pTypeDecl));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->useInitializer = (yyvsp[-2].b);
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->forceStruct = true;
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->alwaysUseInitializer = true;
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 836: /* $@90: %empty  */
+                            { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; }
+    break;
+
+  case 837: /* $@91: %empty  */
+                                                                                                                                        { yyextra->das_arrow_depth --; }
+    break;
+
+  case 838: /* make_struct_decl: "class" '<' $@90 type_declaration_no_options '>' $@91 '(' use_initializer optional_make_struct_dim_decl ')'  */
+                                                                                                                                                                                                                                          {
+        (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = TypeDeclPtr((yyvsp[-6].pTypeDecl));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->useInitializer = (yyvsp[-2].b);
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->forceClass = true;
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 839: /* $@92: %empty  */
+                               { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; }
+    break;
+
+  case 840: /* $@93: %empty  */
+                                                                                                                                           { yyextra->das_arrow_depth --; }
+    break;
+
+  case 841: /* make_struct_decl: "variant" '<' $@92 type_declaration_no_options '>' $@93 '(' make_variant_dim ')'  */
+                                                                                                                                                                                                           {
+        (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-8]));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = TypeDeclPtr((yyvsp[-5].pTypeDecl));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->useInitializer = true;
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->forceVariant = true;
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 842: /* $@94: %empty  */
+                              { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 843: /* $@95: %empty  */
+                                                                                                    { yyextra->das_arrow_depth --; }
+    break;
+
+  case 844: /* make_struct_decl: "default" '<' $@94 type_declaration_no_options '>' $@95 use_initializer  */
+                                                                                                                                                           {
+        auto msd = new ExprMakeStruct();
+        msd->at = tokAt(scanner,(yylsp[-6]));
+        msd->makeType = TypeDeclPtr((yyvsp[-3].pTypeDecl));
+        msd->useInitializer = (yyvsp[0].b);
+        msd->alwaysUseInitializer = true;
+        (yyval.pExpression) = msd;
+    }
+    break;
+
+  case 845: /* make_tuple: expr  */
+                  {
+        (yyvsp[0].pExpression)->at = tokAt(scanner,(yylsp[0]));
+        (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 846: /* make_tuple: expr "=>" expr  */
+                                         {
+        ExprMakeTuple * mt = new ExprMakeTuple(tokRangeAt(scanner,(yylsp[-2]), (yylsp[0])));
+        mt->values.push_back(ExpressionPtr((yyvsp[-2].pExpression)));
+        mt->values.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+        (yyval.pExpression) = mt;
+    }
+    break;
+
+  case 847: /* make_tuple: make_tuple ',' expr  */
+                                      {
+        (yyvsp[0].pExpression)->at = tokAt(scanner,(yylsp[0]));
+        ExprMakeTuple * mt;
+        if ( (yyvsp[-2].pExpression)->rtti_isMakeTuple() ) {
+            mt = static_cast<ExprMakeTuple *>((yyvsp[-2].pExpression));
+        } else {
+            mt = new ExprMakeTuple(tokAt(scanner,(yylsp[-2])));
+            mt->values.push_back(ExpressionPtr((yyvsp[-2].pExpression)));
+        }
+        mt->values.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+        mt->at = format::concat(mt->at, tokAt(scanner, (yylsp[0])));
+        (yyval.pExpression) = mt;
+    }
+    break;
+
+  case 848: /* make_map_tuple: expr "=>" expr  */
+                                         {
+        ExprMakeTuple * mt = new ExprMakeTuple(tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])));
+        mt->values.push_back(ExpressionPtr((yyvsp[-2].pExpression)));
+        mt->values.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+        (yyval.pExpression) = mt;
+    }
+    break;
+
+  case 849: /* make_map_tuple: expr  */
+                 {
+        (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 850: /* make_tuple_call: "tuple" '(' expr_list optional_comma ')'  */
+                                                                    {
+        auto mkt = new ExprMakeTuple(tokAt(scanner,(yylsp[-4])));
+        mkt->values = sequenceToList((yyvsp[-2].pExpression));
+        mkt->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        (yyval.pExpression) = mkt;
+    }
+    break;
+
+  case 851: /* $@96: %empty  */
+                             { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; }
+    break;
+
+  case 852: /* $@97: %empty  */
+                                                                                                                                         { yyextra->das_arrow_depth --; }
+    break;
+
+  case 853: /* make_tuple_call: "tuple" '<' $@96 type_declaration_no_options '>' $@97 '(' use_initializer optional_make_struct_dim_decl ')'  */
+                                                                                                                                                                                                                                            {
+        (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = TypeDeclPtr((yyvsp[-6].pTypeDecl));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->useInitializer = (yyvsp[-2].b);
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->forceTuple = true;
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 854: /* make_dim: make_tuple  */
+                        {
+        auto mka = new ExprMakeArray();
+        mka->values.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+        (yyval.pExpression) = mka;
+    }
+    break;
+
+  case 855: /* make_dim: make_dim "end of expression" make_tuple  */
+                                          {
+        ((ExprMakeArray *) (yyvsp[-2].pExpression))->values.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+        (yyval.pExpression) = (yyvsp[-2].pExpression);
+    }
+    break;
+
+  case 856: /* make_dim_decl: '[' expr_list optional_comma ']'  */
+                                                          {
+        auto mka = make_smart<ExprMakeArray>(tokAt(scanner,(yylsp[-3])));
+        mka->values = sequenceToList((yyvsp[-2].pExpression));
+        mka->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        mka->gen2 = true;
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-3])),"to_array_move");
+        tam->arguments.push_back(mka);
+        (yyval.pExpression) = tam;
+    }
+    break;
+
+  case 857: /* make_dim_decl: "[[" type_declaration_no_options make_dim optional_trailing_semicolon_sqr_sqr  */
+                                                                                                                   {
+        //std::cout << "case13" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-3]))))) {
+            auto type_name = format::type_to_string((yyvsp[-2].pTypeDecl), tokAt(scanner,(yylsp[-2])));
+            auto internal = format::handle_mka(static_cast<ExprMakeArray*>((yyvsp[-1].pExpression)));
+            if (static_cast<ExprMakeArray*>((yyvsp[-1].pExpression))->values.size() == 1) {
+                // single element
+                format::get_writer() << internal;
+            } else {
+                format::get_writer() << "fixed_array";
+                if (!(yyvsp[-2].pTypeDecl)->isAuto()) {
+                    format::get_writer() << "<" << type_name.value() << ">";
+                }
+                format::get_writer() << "(" << internal << ")";
+            }
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+        ((ExprMakeArray *)(yyvsp[-1].pExpression))->makeType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+        (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-3]));
+        (yyval.pExpression) = (yyvsp[-1].pExpression);
+    }
+    break;
+
+  case 858: /* make_dim_decl: "[{" type_declaration_no_options make_dim optional_trailing_semicolon_cur_sqr  */
+                                                                                                                   {
+        //std::cout << "case8" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-3]))))) {
+            format::get_writer() << "array";
+            if (!(yyvsp[-2].pTypeDecl)->isAuto()) {
+                format::get_writer() << "<" << format::get_substring(tokAt(scanner,(yylsp[-2]))) << ">";
+            }
+            format::get_writer() << "(" << format::handle_mka(static_cast<ExprMakeArray*>((yyvsp[-1].pExpression))) << ")";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+
+        ((ExprMakeArray *)(yyvsp[-1].pExpression))->makeType = TypeDeclPtr((yyvsp[-2].pTypeDecl));
+        (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-3]));
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-3])),"to_array_move");
+        tam->arguments.push_back(ExpressionPtr((yyvsp[-1].pExpression)));
+        (yyval.pExpression) = tam;
+    }
+    break;
+
+  case 859: /* $@98: %empty  */
+                                       { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 860: /* $@99: %empty  */
+                                                                                                             { yyextra->das_arrow_depth --; }
+    break;
+
+  case 861: /* make_dim_decl: "array" "struct" '<' $@98 type_declaration_no_options '>' $@99 '(' use_initializer optional_make_struct_dim_decl ')'  */
+                                                                                                                                                                                                                {
+        (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-10]));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = TypeDeclPtr((yyvsp[-6].pTypeDecl));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->useInitializer = (yyvsp[-2].b);
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->forceStruct = true;
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->alwaysUseInitializer = true;
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-10])),"to_array_move");
+        tam->arguments.push_back((yyvsp[-1].pExpression));
+        (yyval.pExpression) = tam;
+    }
+    break;
+
+  case 862: /* $@100: %empty  */
+                                       { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 863: /* $@101: %empty  */
+                                                                                                             { yyextra->das_arrow_depth --; }
+    break;
+
+  case 864: /* make_dim_decl: "array" "tuple" '<' $@100 type_declaration_no_options '>' $@101 '(' use_initializer optional_make_struct_dim_decl ')'  */
+                                                                                                                                                                                                                {
+        (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-10]));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = TypeDeclPtr((yyvsp[-6].pTypeDecl));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->useInitializer = (yyvsp[-2].b);
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->forceTuple = true;
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->alwaysUseInitializer = true;
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-10])),"to_array_move");
+        tam->arguments.push_back((yyvsp[-1].pExpression));
+        (yyval.pExpression) = tam;
+    }
+    break;
+
+  case 865: /* $@102: %empty  */
+                                         { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 866: /* $@103: %empty  */
+                                                                                                               { yyextra->das_arrow_depth --; }
+    break;
+
+  case 867: /* make_dim_decl: "array" "variant" '<' $@102 type_declaration_no_options '>' $@103 '(' make_variant_dim ')'  */
+                                                                                                                                                                               {
+        (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = TypeDeclPtr((yyvsp[-5].pTypeDecl));
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->useInitializer = true;
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->forceVariant = true;
+        ((ExprMakeStruct *)(yyvsp[-1].pExpression))->alwaysUseInitializer = true;
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-9])),"to_array_move");
+        tam->arguments.push_back((yyvsp[-1].pExpression));
+        (yyval.pExpression) = tam;
+    }
+    break;
+
+  case 868: /* make_dim_decl: "array" '(' expr_list optional_comma ')'  */
+                                                                   {
+        auto mka = make_smart<ExprMakeArray>(tokAt(scanner,(yylsp[-4])));
+        mka->values = sequenceToList((yyvsp[-2].pExpression));
+        mka->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        mka->gen2 = true;
+        auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-4])),"to_array_move");
+        tam->arguments.push_back(mka);
+        (yyval.pExpression) = tam;
+    }
+    break;
+
+  case 869: /* $@104: %empty  */
+                           { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 870: /* $@105: %empty  */
+                                                                                                 { yyextra->das_arrow_depth --; }
+    break;
+
+  case 871: /* make_dim_decl: "array" '<' $@104 type_declaration_no_options '>' $@105 '(' optional_expr_list ')'  */
+                                                                                                                                                                        {
+        if ( (yyvsp[-1].pExpression) ) {
+            auto mka = make_smart<ExprMakeArray>(tokAt(scanner,(yylsp[-8])));
+            mka->values = sequenceToList((yyvsp[-1].pExpression));
+            mka->makeType = TypeDeclPtr((yyvsp[-5].pTypeDecl));
+            mka->gen2 = true;
+            auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-8])),"to_array_move");
+            tam->arguments.push_back(mka);
+            (yyval.pExpression) = tam;
+        } else {
+            auto msd = new ExprMakeStruct();
+            msd->at = tokAt(scanner,(yylsp[-8]));
+            msd->makeType = make_smart<TypeDecl>(Type::tArray);
+            msd->makeType->firstType = TypeDeclPtr((yyvsp[-5].pTypeDecl));
+            msd->at = tokAt(scanner,(yylsp[-5]));
+            msd->useInitializer = true;
+            msd->alwaysUseInitializer = true;
+            (yyval.pExpression) = msd;
+        }
+    }
+    break;
+
+  case 872: /* make_dim_decl: "fixed_array" '(' expr_list optional_comma ')'  */
+                                                                         {
+        auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
+        mka->values = sequenceToList((yyvsp[-2].pExpression));
+        mka->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        mka->gen2 = true;
+        (yyval.pExpression) = mka;
+    }
+    break;
+
+  case 873: /* $@106: %empty  */
+                                 { yyextra->das_arrow_depth ++; }
+    break;
+
+  case 874: /* $@107: %empty  */
+                                                                                                       { yyextra->das_arrow_depth --; }
+    break;
+
+  case 875: /* make_dim_decl: "fixed_array" '<' $@106 type_declaration_no_options '>' $@107 '(' expr_list optional_comma ')'  */
+                                                                                                                                                                                    {
+        auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-9])));
+        mka->values = sequenceToList((yyvsp[-2].pExpression));
+        mka->makeType = TypeDeclPtr((yyvsp[-6].pTypeDecl));
+        mka->gen2 = true;
+        (yyval.pExpression) = mka;
+    }
+    break;
+
+  case 876: /* make_table: make_map_tuple  */
+                            {
+        auto mka = new ExprMakeArray();
+        mka->values.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+        (yyval.pExpression) = mka;
+    }
+    break;
+
+  case 877: /* make_table: make_table "end of expression" make_map_tuple  */
+                                                {
+        ((ExprMakeArray *) (yyvsp[-2].pExpression))->values.push_back(ExpressionPtr((yyvsp[0].pExpression)));
+        (yyval.pExpression) = (yyvsp[-2].pExpression);
+    }
+    break;
+
+  case 878: /* expr_map_tuple_list: make_map_tuple  */
+                                {
+        (yyval.pExpression) = (yyvsp[0].pExpression);
+    }
+    break;
+
+  case 879: /* expr_map_tuple_list: expr_map_tuple_list ',' make_map_tuple  */
+                                                                {
+            (yyval.pExpression) = new ExprSequence(tokAt(scanner,(yylsp[-2])),ExpressionPtr((yyvsp[-2].pExpression)),ExpressionPtr((yyvsp[0].pExpression)));
+    }
+    break;
+
+  case 880: /* make_table_decl: "begin of code block" expr_map_tuple_list optional_comma "end of code block"  */
+                                                                    {
+        auto mka = make_smart<ExprMakeArray>(tokAt(scanner,(yylsp[-3])));
+        mka->values = sequenceToList((yyvsp[-2].pExpression));
+        mka->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-3])),"to_table_move");
+        ttm->arguments.push_back(mka);
+        (yyval.pExpression) = ttm;
+    }
+    break;
+
+  case 881: /* make_table_decl: "{{" make_table optional_trailing_semicolon_cur_cur  */
+                                                                                {
+        //std::cout << "case10" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-2]))))) {
+            format::get_writer() << "{" << format::convert_to_string(((ExprMakeArray *)(yyvsp[-1].pExpression))->values) << "}";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+
+        auto mkt = make_smart<TypeDecl>(Type::autoinfer);
+        mkt->dim.push_back(TypeDecl::dimAuto);
+        ((ExprMakeArray *)(yyvsp[-1].pExpression))->makeType = mkt;
+        (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-2]));
+        auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),"to_table_move");
+        ttm->arguments.push_back(ExpressionPtr((yyvsp[-1].pExpression)));
+        (yyval.pExpression) = ttm;
+    }
+    break;
+
+  case 882: /* make_table_decl: "table" '(' optional_expr_map_tuple_list ')'  */
+                                                                       {
+        auto mka = make_smart<ExprMakeArray>(tokAt(scanner,(yylsp[-3])));
+        mka->values = sequenceToList((yyvsp[-1].pExpression));
+        mka->makeType = make_smart<TypeDecl>(Type::autoinfer);
+        auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-3])),"to_table_move");
+        ttm->arguments.push_back(mka);
+        (yyval.pExpression) = ttm;
+    }
+    break;
+
+  case 883: /* make_table_decl: "table" '<' type_declaration_no_options '>' '(' optional_expr_map_tuple_list ')'  */
+                                                                                                                 {
+        if ( (yyvsp[-1].pExpression) ) {
+            auto mka = make_smart<ExprMakeArray>(tokAt(scanner,(yylsp[-6])));
+            mka->values = sequenceToList((yyvsp[-1].pExpression));
+            mka->makeType = TypeDeclPtr((yyvsp[-4].pTypeDecl));
+            auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-6])),"to_table_move");
+            ttm->arguments.push_back(mka);
+            (yyval.pExpression) = ttm;
+        } else {
+            auto msd = new ExprMakeStruct();
+            msd->at = tokAt(scanner,(yylsp[-6]));
+            msd->makeType = make_smart<TypeDecl>(Type::tTable);
+            msd->makeType->firstType = TypeDeclPtr((yyvsp[-4].pTypeDecl));
+            msd->makeType->secondType = make_smart<TypeDecl>(Type::tVoid);
+            msd->at = tokAt(scanner,(yylsp[-6]));
+            msd->useInitializer = true;
+            msd->alwaysUseInitializer = true;
+            (yyval.pExpression) = msd;
+        }
+    }
+    break;
+
+  case 884: /* make_table_decl: "table" '<' type_declaration_no_options c_or_s type_declaration_no_options '>' '(' optional_expr_map_tuple_list ')'  */
+                                                                                                                                                             {
+        if ( (yyvsp[-1].pExpression) ) {
+            auto mka = make_smart<ExprMakeArray>(tokAt(scanner,(yylsp[-8])));
+            mka->values = sequenceToList((yyvsp[-1].pExpression));
+            mka->makeType = make_smart<TypeDecl>(Type::tTuple);
+            mka->makeType->argTypes.push_back((yyvsp[-6].pTypeDecl));
+            mka->makeType->argTypes.push_back((yyvsp[-4].pTypeDecl));
+            auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-8])),"to_table_move");
+            ttm->arguments.push_back(mka);
+            (yyval.pExpression) = ttm;
+        } else {
+            auto msd = new ExprMakeStruct();
+            msd->at = tokAt(scanner,(yylsp[-8]));
+            msd->makeType = make_smart<TypeDecl>(Type::tTable);
+            msd->makeType->firstType = TypeDeclPtr((yyvsp[-6].pTypeDecl));
+            msd->makeType->secondType = TypeDeclPtr((yyvsp[-4].pTypeDecl));
+            msd->at = tokAt(scanner,(yylsp[-8]));
+            msd->useInitializer = true;
+            msd->alwaysUseInitializer = true;
+            (yyval.pExpression) = msd;
+        }
+    }
+    break;
+
+  case 885: /* array_comprehension_where: %empty  */
+                                    { (yyval.pExpression) = nullptr; }
+    break;
+
+  case 886: /* array_comprehension_where: "end of expression" "where" expr  */
+                                    { (yyval.pExpression) = (yyvsp[0].pExpression); }
+    break;
+
+  case 887: /* optional_comma: %empty  */
+                { (yyval.b) = false; }
+    break;
+
+  case 888: /* optional_comma: ','  */
+                { (yyval.b) = true; }
+    break;
+
+  case 889: /* array_comprehension: '[' "for" variable_name_with_pos_list "in" expr_list "end of expression" expr array_comprehension_where ']'  */
+                                                                                                                                                    {
+        (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-7])),(yyvsp[-6].pNameWithPosList),(yyvsp[-4].pExpression),(yyvsp[-2].pExpression),(yyvsp[-1].pExpression),tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])),false,false);
+    }
+    break;
+
+  case 890: /* array_comprehension: '[' "iterator" "for" variable_name_with_pos_list "in" expr_list "end of expression" expr array_comprehension_where ']'  */
+                                                                                                                                                                 {
+        (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-7])),(yyvsp[-6].pNameWithPosList),(yyvsp[-4].pExpression),(yyvsp[-2].pExpression),(yyvsp[-1].pExpression),tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])),true,false);
+    }
+    break;
+
+  case 891: /* array_comprehension: "[[" "for" variable_name_with_pos_list "in" expr_list "end of expression" expr array_comprehension_where ']' ']'  */
+                                                                                                                                                                        {
+        //std::cout << "case5" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-9]))))) {
+            auto internal = format::get_substring(format::Pos::from(tokAt(scanner,(yylsp[-8]))), format::Pos::from_last(tokAt(scanner,(yylsp[-2]))));
+            format::get_writer() << "[iterator " << internal << "]";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+        (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-8])),(yyvsp[-7].pNameWithPosList),(yyvsp[-5].pExpression),(yyvsp[-3].pExpression),(yyvsp[-2].pExpression),tokRangeAt(scanner,(yylsp[-3]),(yylsp[0])),true,false);
+    }
+    break;
+
+  case 892: /* array_comprehension: "[{" "for" variable_name_with_pos_list "in" expr_list "end of expression" expr array_comprehension_where "end of code block" ']'  */
+                                                                                                                                                                        {
+        //std::cout << "case9" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-9]))))) {
+            auto internal = format::get_substring(format::Pos::from(tokAt(scanner,(yylsp[-8]))), format::Pos::from_last(tokAt(scanner,(yylsp[-2]))));
+            format::get_writer() << "[" << internal << "]";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+
+        (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-8])),(yyvsp[-7].pNameWithPosList),(yyvsp[-5].pExpression),(yyvsp[-3].pExpression),(yyvsp[-2].pExpression),tokRangeAt(scanner,(yylsp[-3]),(yylsp[0])),false,false);
+    }
+    break;
+
+  case 893: /* array_comprehension: "begin of code block" "for" variable_name_with_pos_list "in" expr_list "end of expression" make_map_tuple array_comprehension_where "end of code block"  */
+                                                                                                                                                              {
+        (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-7])),(yyvsp[-6].pNameWithPosList),(yyvsp[-4].pExpression),(yyvsp[-2].pExpression),(yyvsp[-1].pExpression),tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])),false,true);
+    }
+    break;
+
+  case 894: /* array_comprehension: "{{" "for" variable_name_with_pos_list "in" expr_list "end of expression" make_map_tuple array_comprehension_where "end of code block" "end of code block"  */
+                                                                                                                                                                               {
+        //std::cout << "case12" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,(yylsp[-9]))))) {
+            auto internal = format::get_substring(format::Pos::from(tokAt(scanner,(yylsp[-8]))), format::Pos::from_last(tokAt(scanner,(yylsp[-2]))));
+            format::get_writer() << "[" << internal << "]";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,(yylsp[0]))));
+        }
+        (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-8])),(yyvsp[-7].pNameWithPosList),(yyvsp[-5].pExpression),(yyvsp[-3].pExpression),(yyvsp[-2].pExpression),tokRangeAt(scanner,(yylsp[-3]),(yylsp[0])),true,true);
+    }
+    break;
+
+
+
+      default: break;
+    }
+  /* User semantic actions sometimes alter yychar, and that requires
+     that yytoken be updated with the new translation.  We take the
+     approach of translating immediately before every use of yytoken.
+     One alternative is translating here after every semantic action,
+     but that translation would be missed if the semantic action invokes
+     YYABORT, YYACCEPT, or YYERROR immediately after altering yychar or
+     if it invokes YYBACKUP.  In the case of YYABORT or YYACCEPT, an
+     incorrect destructor might then be invoked immediately.  In the
+     case of YYERROR or YYBACKUP, subsequent parser actions might lead
+     to an incorrect destructor call or verbose syntax error message
+     before the lookahead is translated.  */
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
+
+  YYPOPSTACK (yylen);
+  yylen = 0;
+
+  *++yyvsp = yyval;
+  *++yylsp = yyloc;
+
+  /* Now 'shift' the result of the reduction.  Determine what state
+     that goes to, based on the state we popped back to and the rule
+     number reduced by.  */
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
+
+  goto yynewstate;
+
+
+/*--------------------------------------.
+| yyerrlab -- here on detecting error.  |
+`--------------------------------------*/
+yyerrlab:
+  /* Make sure we have latest lookahead translation.  See comments at
+     user semantic actions for why this is necessary.  */
+  yytoken = yychar == DAS_YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
+  /* If not already recovering from an error, report this error.  */
+  if (!yyerrstatus)
+    {
+      ++yynerrs;
+      {
+        yypcontext_t yyctx
+          = {yyssp, yytoken, &yylloc};
+        char const *yymsgp = YY_("syntax error");
+        int yysyntax_error_status;
+        yysyntax_error_status = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
+        if (yysyntax_error_status == 0)
+          yymsgp = yymsg;
+        else if (yysyntax_error_status == -1)
+          {
+            if (yymsg != yymsgbuf)
+              YYSTACK_FREE (yymsg);
+            yymsg = YY_CAST (char *,
+                             YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
+            if (yymsg)
+              {
+                yysyntax_error_status
+                  = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
+                yymsgp = yymsg;
+              }
+            else
+              {
+                yymsg = yymsgbuf;
+                yymsg_alloc = sizeof yymsgbuf;
+                yysyntax_error_status = YYENOMEM;
+              }
+          }
+        yyerror (&yylloc, scanner, yymsgp);
+        if (yysyntax_error_status == YYENOMEM)
+          YYNOMEM;
+      }
+    }
+
+  yyerror_range[1] = yylloc;
+  if (yyerrstatus == 3)
+    {
+      /* If just tried and failed to reuse lookahead token after an
+         error, discard it.  */
+
+      if (yychar <= DAS_YYEOF)
+        {
+          /* Return failure if at end of input.  */
+          if (yychar == DAS_YYEOF)
+            YYABORT;
+        }
+      else
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval, &yylloc, scanner);
+          yychar = DAS_YYEMPTY;
+        }
+    }
+
+  /* Else will try to reuse lookahead token after shifting the error
+     token.  */
+  goto yyerrlab1;
+
+
+/*---------------------------------------------------.
+| yyerrorlab -- error raised explicitly by YYERROR.  |
+`---------------------------------------------------*/
+yyerrorlab:
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
+  ++yynerrs;
+
+  /* Do not reclaim the symbols of the rule whose action triggered
+     this YYERROR.  */
+  YYPOPSTACK (yylen);
+  yylen = 0;
+  YY_STACK_PRINT (yyss, yyssp);
+  yystate = *yyssp;
+  goto yyerrlab1;
+
+
+/*-------------------------------------------------------------.
+| yyerrlab1 -- common code for both syntax error and YYERROR.  |
+`-------------------------------------------------------------*/
+yyerrlab1:
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
+
+  /* Pop stack until we find a state that shifts the error token.  */
+  for (;;)
+    {
+      yyn = yypact[yystate];
+      if (!yypact_value_is_default (yyn))
+        {
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
+
+      /* Pop the current state because it cannot handle the error token.  */
+      if (yyssp == yyss)
+        YYABORT;
+
+      yyerror_range[1] = *yylsp;
+      yydestruct ("Error: popping",
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp, scanner);
+      YYPOPSTACK (1);
+      yystate = *yyssp;
+      YY_STACK_PRINT (yyss, yyssp);
+    }
+
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
+
+  yyerror_range[2] = yylloc;
+  ++yylsp;
+  YYLLOC_DEFAULT (*yylsp, yyerror_range, 2);
+
+  /* Shift the error token.  */
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
+
+  yystate = yyn;
+  goto yynewstate;
+
+
+/*-------------------------------------.
+| yyacceptlab -- YYACCEPT comes here.  |
+`-------------------------------------*/
+yyacceptlab:
+  yyresult = 0;
+  goto yyreturnlab;
+
+
+/*-----------------------------------.
+| yyabortlab -- YYABORT comes here.  |
+`-----------------------------------*/
+yyabortlab:
+  yyresult = 1;
+  goto yyreturnlab;
+
+
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
+yyexhaustedlab:
+  yyerror (&yylloc, scanner, YY_("memory exhausted"));
+  yyresult = 2;
+  goto yyreturnlab;
+
+
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
+  if (yychar != DAS_YYEMPTY)
+    {
+      /* Make sure we have latest lookahead translation.  See comments at
+         user semantic actions for why this is necessary.  */
+      yytoken = YYTRANSLATE (yychar);
+      yydestruct ("Cleanup: discarding lookahead",
+                  yytoken, &yylval, &yylloc, scanner);
+    }
+  /* Do not reclaim the symbols of the rule whose action triggered
+     this YYABORT or YYACCEPT.  */
+  YYPOPSTACK (yylen);
+  YY_STACK_PRINT (yyss, yyssp);
+  while (yyssp != yyss)
+    {
+      yydestruct ("Cleanup: popping",
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp, scanner);
+      YYPOPSTACK (1);
+    }
+#ifndef yyoverflow
+  if (yyss != yyssa)
+    YYSTACK_FREE (yyss);
+#endif
+  if (yymsg != yymsgbuf)
+    YYSTACK_FREE (yymsg);
+  return yyresult;
+}
+
+
+
+void das_yyfatalerror ( DAS_YYLTYPE * lloc, yyscan_t scanner, const string & error, CompilationError cerr ) {
+    yyextra->g_Program->error(error,"","",LineInfo(yyextra->g_FileAccessStack.back(),
+        lloc->first_column,lloc->first_line,lloc->last_column,lloc->last_line),cerr);
+}
+
+void das_yyerror ( DAS_YYLTYPE * lloc, yyscan_t scanner, const string & error ) {
+    if ( !yyextra->das_suppress_errors ) {
+        yyextra->g_Program->error(error,"","",LineInfo(yyextra->g_FileAccessStack.back(),
+            lloc->first_column,lloc->first_line,lloc->last_column,lloc->last_line),
+                CompilationError::syntax_error);
+    }
+}
+
+LineInfo tokAt ( yyscan_t scanner, const struct DAS_YYLTYPE & li ) {
+    return LineInfo(yyextra->g_FileAccessStack.back(),
+        li.first_column,li.first_line,
+        li.last_column,li.last_line);
+}
+
+LineInfo tokRangeAt ( yyscan_t scanner, const struct DAS_YYLTYPE & li, const struct DAS_YYLTYPE & lie ) {
+    return LineInfo(yyextra->g_FileAccessStack.back(),
+        li.first_column,li.first_line,
+        lie.last_column,lie.last_line);
+}
+
+

--- a/utils/dasFormatter/ds_parser.hpp
+++ b/utils/dasFormatter/ds_parser.hpp
@@ -1,0 +1,362 @@
+/* A Bison parser, made by GNU Bison 3.8.2.  */
+
+/* Bison interface for Yacc-like parsers in C
+
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+/* As a special exception, you may create a larger work that contains
+   part or all of the Bison parser skeleton and distribute that work
+   under terms of your choice, so long as that work isn't itself a
+   parser generator using the skeleton or a modified version thereof
+   as a parser skeleton.  Alternatively, if you modify or redistribute
+   the parser skeleton itself, you may (at your option) remove this
+   special exception, which will cause the skeleton and the resulting
+   Bison output files to be licensed under the GNU General Public
+   License without this special exception.
+
+   This special exception was added by the Free Software Foundation in
+   version 2.2 of Bison.  */
+
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
+#ifndef YY_DAS_YY_DS_PARSER_HPP_INCLUDED
+# define YY_DAS_YY_DS_PARSER_HPP_INCLUDED
+/* Debug traces.  */
+#ifndef DAS_YYDEBUG
+# if defined YYDEBUG
+#if YYDEBUG
+#   define DAS_YYDEBUG 1
+#  else
+#   define DAS_YYDEBUG 0
+#  endif
+# else /* ! defined YYDEBUG */
+#  define DAS_YYDEBUG 0
+# endif /* ! defined YYDEBUG */
+#endif  /* ! defined DAS_YYDEBUG */
+#if DAS_YYDEBUG
+extern int das_yydebug;
+#endif
+/* "%code requires" blocks.  */
+
+    #include "daScript/misc/platform.h"
+    #include "daScript/ast/ast.h"
+    #include "daScript/ast/ast_generate.h"
+    #include "daScript/ast/ast_expressions.h"
+
+    #include "../src/parser/parser_state.h"
+    #include "helpers.h"
+    #include "formatter.h"
+
+    #include <iostream>
+#if defined(_MSC_VER) && !defined(__clang__)
+    #if defined(DAS_RELWITHDEBINFO)
+        #pragma optimize( "s", on )
+    #endif
+#endif
+
+    enum {
+        CorM_COPY   = 0,
+        CorM_MOVE   = (1<<0),
+        CorM_CLONE  = (1<<1)
+    };
+
+    enum {
+        CorS_Struct = 0,
+        CorS_Class  = 1,
+        CorS_StructTemplate = 2,
+        CorS_ClassTemplate  = 3
+    };
+
+    using namespace das;
+
+    #include "../src/parser/parser_impl.h"
+
+    LineInfo tokAt ( yyscan_t scanner, const struct DAS_YYLTYPE & li );
+    LineInfo tokRangeAt ( yyscan_t scanner, const struct DAS_YYLTYPE & li, const struct DAS_YYLTYPE & lie );
+
+    struct TypePair {
+        TypeDecl * firstType;
+        TypeDecl * secondType;
+    };
+
+
+/* Token kinds.  */
+#ifndef DAS_YYTOKENTYPE
+# define DAS_YYTOKENTYPE
+  enum das_yytokentype
+  {
+    DAS_YYEMPTY = -2,
+    DAS_YYEOF = 0,                 /* "end of file"  */
+    DAS_YYerror = 256,             /* error  */
+    DAS_YYUNDEF = 257,             /* "invalid token"  */
+    LEXER_ERROR = 258,             /* "lexer error"  */
+    DAS_CAPTURE = 259,             /* "capture"  */
+    DAS_STRUCT = 260,              /* "struct"  */
+    DAS_CLASS = 261,               /* "class"  */
+    DAS_LET = 262,                 /* "let"  */
+    DAS_DEF = 263,                 /* "def"  */
+    DAS_WHILE = 264,               /* "while"  */
+    DAS_IF = 265,                  /* "if"  */
+    DAS_STATIC_IF = 266,           /* "static_if"  */
+    DAS_ELSE = 267,                /* "else"  */
+    DAS_FOR = 268,                 /* "for"  */
+    DAS_CATCH = 269,               /* "recover"  */
+    DAS_TRUE = 270,                /* "true"  */
+    DAS_FALSE = 271,               /* "false"  */
+    DAS_NEWT = 272,                /* "new"  */
+    DAS_TYPEINFO = 273,            /* "typeinfo"  */
+    DAS_TYPE = 274,                /* "type"  */
+    DAS_IN = 275,                  /* "in"  */
+    DAS_IS = 276,                  /* "is"  */
+    DAS_AS = 277,                  /* "as"  */
+    DAS_ELIF = 278,                /* "elif"  */
+    DAS_STATIC_ELIF = 279,         /* "static_elif"  */
+    DAS_ARRAY = 280,               /* "array"  */
+    DAS_RETURN = 281,              /* "return"  */
+    DAS_NULL = 282,                /* "null"  */
+    DAS_BREAK = 283,               /* "break"  */
+    DAS_TRY = 284,                 /* "try"  */
+    DAS_OPTIONS = 285,             /* "options"  */
+    DAS_TABLE = 286,               /* "table"  */
+    DAS_EXPECT = 287,              /* "expect"  */
+    DAS_CONST = 288,               /* "const"  */
+    DAS_REQUIRE = 289,             /* "require"  */
+    DAS_OPERATOR = 290,            /* "operator"  */
+    DAS_ENUM = 291,                /* "enum"  */
+    DAS_FINALLY = 292,             /* "finally"  */
+    DAS_DELETE = 293,              /* "delete"  */
+    DAS_DEREF = 294,               /* "deref"  */
+    DAS_TYPEDEF = 295,             /* "typedef"  */
+    DAS_TYPEDECL = 296,            /* "typedecl"  */
+    DAS_WITH = 297,                /* "with"  */
+    DAS_AKA = 298,                 /* "aka"  */
+    DAS_ASSUME = 299,              /* "assume"  */
+    DAS_CAST = 300,                /* "cast"  */
+    DAS_OVERRIDE = 301,            /* "override"  */
+    DAS_ABSTRACT = 302,            /* "abstract"  */
+    DAS_UPCAST = 303,              /* "upcast"  */
+    DAS_ITERATOR = 304,            /* "iterator"  */
+    DAS_VAR = 305,                 /* "var"  */
+    DAS_ADDR = 306,                /* "addr"  */
+    DAS_CONTINUE = 307,            /* "continue"  */
+    DAS_WHERE = 308,               /* "where"  */
+    DAS_PASS = 309,                /* "pass"  */
+    DAS_REINTERPRET = 310,         /* "reinterpret"  */
+    DAS_MODULE = 311,              /* "module"  */
+    DAS_PUBLIC = 312,              /* "public"  */
+    DAS_LABEL = 313,               /* "label"  */
+    DAS_GOTO = 314,                /* "goto"  */
+    DAS_IMPLICIT = 315,            /* "implicit"  */
+    DAS_EXPLICIT = 316,            /* "explicit"  */
+    DAS_SHARED = 317,              /* "shared"  */
+    DAS_PRIVATE = 318,             /* "private"  */
+    DAS_SMART_PTR = 319,           /* "smart_ptr"  */
+    DAS_UNSAFE = 320,              /* "unsafe"  */
+    DAS_INSCOPE = 321,             /* "inscope"  */
+    DAS_STATIC = 322,              /* "static"  */
+    DAS_FIXED_ARRAY = 323,         /* "fixed_array"  */
+    DAS_DEFAULT = 324,             /* "default"  */
+    DAS_UNINITIALIZED = 325,       /* "uninitialized"  */
+    DAS_TBOOL = 326,               /* "bool"  */
+    DAS_TVOID = 327,               /* "void"  */
+    DAS_TSTRING = 328,             /* "string"  */
+    DAS_TAUTO = 329,               /* "auto"  */
+    DAS_TINT = 330,                /* "int"  */
+    DAS_TINT2 = 331,               /* "int2"  */
+    DAS_TINT3 = 332,               /* "int3"  */
+    DAS_TINT4 = 333,               /* "int4"  */
+    DAS_TUINT = 334,               /* "uint"  */
+    DAS_TBITFIELD = 335,           /* "bitfield"  */
+    DAS_TUINT2 = 336,              /* "uint2"  */
+    DAS_TUINT3 = 337,              /* "uint3"  */
+    DAS_TUINT4 = 338,              /* "uint4"  */
+    DAS_TFLOAT = 339,              /* "float"  */
+    DAS_TFLOAT2 = 340,             /* "float2"  */
+    DAS_TFLOAT3 = 341,             /* "float3"  */
+    DAS_TFLOAT4 = 342,             /* "float4"  */
+    DAS_TRANGE = 343,              /* "range"  */
+    DAS_TURANGE = 344,             /* "urange"  */
+    DAS_TRANGE64 = 345,            /* "range64"  */
+    DAS_TURANGE64 = 346,           /* "urange64"  */
+    DAS_TBLOCK = 347,              /* "block"  */
+    DAS_TINT64 = 348,              /* "int64"  */
+    DAS_TUINT64 = 349,             /* "uint64"  */
+    DAS_TDOUBLE = 350,             /* "double"  */
+    DAS_TFUNCTION = 351,           /* "function"  */
+    DAS_TLAMBDA = 352,             /* "lambda"  */
+    DAS_TINT8 = 353,               /* "int8"  */
+    DAS_TUINT8 = 354,              /* "uint8"  */
+    DAS_TINT16 = 355,              /* "int16"  */
+    DAS_TUINT16 = 356,             /* "uint16"  */
+    DAS_TTUPLE = 357,              /* "tuple"  */
+    DAS_TVARIANT = 358,            /* "variant"  */
+    DAS_GENERATOR = 359,           /* "generator"  */
+    DAS_YIELD = 360,               /* "yield"  */
+    DAS_SEALED = 361,              /* "sealed"  */
+    DAS_TEMPLATE = 362,            /* "template"  */
+    ADDEQU = 363,                  /* "+="  */
+    SUBEQU = 364,                  /* "-="  */
+    DIVEQU = 365,                  /* "/="  */
+    MULEQU = 366,                  /* "*="  */
+    MODEQU = 367,                  /* "%="  */
+    ANDEQU = 368,                  /* "&="  */
+    OREQU = 369,                   /* "|="  */
+    XOREQU = 370,                  /* "^="  */
+    SHL = 371,                     /* "<<"  */
+    SHR = 372,                     /* ">>"  */
+    ADDADD = 373,                  /* "++"  */
+    SUBSUB = 374,                  /* "--"  */
+    LEEQU = 375,                   /* "<="  */
+    SHLEQU = 376,                  /* "<<="  */
+    SHREQU = 377,                  /* ">>="  */
+    GREQU = 378,                   /* ">="  */
+    EQUEQU = 379,                  /* "=="  */
+    NOTEQU = 380,                  /* "!="  */
+    RARROW = 381,                  /* "->"  */
+    LARROW = 382,                  /* "<-"  */
+    QQ = 383,                      /* "??"  */
+    QDOT = 384,                    /* "?."  */
+    QBRA = 385,                    /* "?["  */
+    LPIPE = 386,                   /* "<|"  */
+    LBPIPE = 387,                  /* " <|"  */
+    LLPIPE = 388,                  /* "$ <|"  */
+    LAPIPE = 389,                  /* "@ <|"  */
+    LFPIPE = 390,                  /* "@@ <|"  */
+    RPIPE = 391,                   /* "|>"  */
+    CLONEEQU = 392,                /* ":="  */
+    ROTL = 393,                    /* "<<<"  */
+    ROTR = 394,                    /* ">>>"  */
+    ROTLEQU = 395,                 /* "<<<="  */
+    ROTREQU = 396,                 /* ">>>="  */
+    MAPTO = 397,                   /* "=>"  */
+    COLCOL = 398,                  /* "::"  */
+    ANDAND = 399,                  /* "&&"  */
+    OROR = 400,                    /* "||"  */
+    XORXOR = 401,                  /* "^^"  */
+    ANDANDEQU = 402,               /* "&&="  */
+    OROREQU = 403,                 /* "||="  */
+    XORXOREQU = 404,               /* "^^="  */
+    DOTDOT = 405,                  /* ".."  */
+    MTAG_E = 406,                  /* "$$"  */
+    MTAG_I = 407,                  /* "$i"  */
+    MTAG_V = 408,                  /* "$v"  */
+    MTAG_B = 409,                  /* "$b"  */
+    MTAG_A = 410,                  /* "$a"  */
+    MTAG_T = 411,                  /* "$t"  */
+    MTAG_C = 412,                  /* "$c"  */
+    MTAG_F = 413,                  /* "$f"  */
+    MTAG_DOTDOTDOT = 414,          /* "..."  */
+    BRABRAB = 415,                 /* "[["  */
+    BRACBRB = 416,                 /* "[{"  */
+    CBRCBRB = 417,                 /* "{{"  */
+    INTEGER = 418,                 /* "integer constant"  */
+    LONG_INTEGER = 419,            /* "long integer constant"  */
+    UNSIGNED_INTEGER = 420,        /* "unsigned integer constant"  */
+    UNSIGNED_LONG_INTEGER = 421,   /* "unsigned long integer constant"  */
+    UNSIGNED_INT8 = 422,           /* "unsigned int8 constant"  */
+    FLOAT = 423,                   /* "floating point constant"  */
+    DOUBLE = 424,                  /* "double constant"  */
+    NAME = 425,                    /* "name"  */
+    KEYWORD = 426,                 /* "keyword"  */
+    TYPE_FUNCTION = 427,           /* "type function"  */
+    BEGIN_STRING = 428,            /* "start of the string"  */
+    STRING_CHARACTER = 429,        /* STRING_CHARACTER  */
+    STRING_CHARACTER_ESC = 430,    /* STRING_CHARACTER_ESC  */
+    END_STRING = 431,              /* "end of the string"  */
+    BEGIN_STRING_EXPR = 432,       /* "{"  */
+    END_STRING_EXPR = 433,         /* "}"  */
+    END_OF_READ = 434,             /* "end of failed eader macro"  */
+    SEMICOLON_CUR_CUR = 435,       /* ";}}"  */
+    SEMICOLON_CUR_SQR = 436,       /* ";}]"  */
+    SEMICOLON_SQR_SQR = 437,       /* ";]]"  */
+    COMMA_SQR_SQR = 438,           /* ",]]"  */
+    COMMA_CUR_SQR = 439,           /* ",}]"  */
+    UNARY_MINUS = 440,             /* UNARY_MINUS  */
+    UNARY_PLUS = 441,              /* UNARY_PLUS  */
+    PRE_INC = 442,                 /* PRE_INC  */
+    PRE_DEC = 443,                 /* PRE_DEC  */
+    POST_INC = 444,                /* POST_INC  */
+    POST_DEC = 445,                /* POST_DEC  */
+    DEREF = 446                    /* DEREF  */
+  };
+  typedef enum das_yytokentype das_yytoken_kind_t;
+#endif
+
+/* Value type.  */
+#if ! defined DAS_YYSTYPE && ! defined DAS_YYSTYPE_IS_DECLARED
+union DAS_YYSTYPE
+{
+
+    char                            ch;
+    bool                            b;
+    int32_t                         i;
+    uint32_t                        ui;
+    int64_t                         i64;
+    uint64_t                        ui64;
+    double                          d;
+    double                          fd;
+    string *                        s;
+    vector<string> *                pNameList;
+    vector<VariableNameAndPosition> * pNameWithPosList;
+    VariableDeclaration *           pVarDecl;
+    vector<VariableDeclaration*> *  pVarDeclList;
+    TypeDecl *                      pTypeDecl;
+    vector<Expression *> *          pTypeDeclList;
+    Expression *                    pExpression;
+    Type                            type;
+    AnnotationArgument *            aa;
+    AnnotationArgumentList *        aaList;
+    AnnotationDeclaration *         fa;
+    AnnotationList *                faList;
+    MakeStruct *                    pMakeStruct;
+    Enumeration *                   pEnum;
+    Structure *                     pStructure;
+    Function *                      pFuncDecl;
+    CaptureEntry *                  pCapt;
+    vector<CaptureEntry> *          pCaptList;
+    TypePair                        aTypePair;
+
+
+};
+typedef union DAS_YYSTYPE DAS_YYSTYPE;
+# define DAS_YYSTYPE_IS_TRIVIAL 1
+# define DAS_YYSTYPE_IS_DECLARED 1
+#endif
+
+/* Location type.  */
+#if ! defined DAS_YYLTYPE && ! defined DAS_YYLTYPE_IS_DECLARED
+typedef struct DAS_YYLTYPE DAS_YYLTYPE;
+struct DAS_YYLTYPE
+{
+  int first_line;
+  int first_column;
+  int last_line;
+  int last_column;
+};
+# define DAS_YYLTYPE_IS_DECLARED 1
+# define DAS_YYLTYPE_IS_TRIVIAL 1
+#endif
+
+
+
+
+int das_yyparse (yyscan_t scanner);
+
+
+#endif /* !YY_DAS_YY_DS_PARSER_HPP_INCLUDED  */

--- a/utils/dasFormatter/ds_parser.ypp
+++ b/utils/dasFormatter/ds_parser.ypp
@@ -16,8 +16,11 @@
     #include "daScript/ast/ast_generate.h"
     #include "daScript/ast/ast_expressions.h"
 
-    #include "parser_state.h"
+    #include "../src/parser/parser_state.h"
+    #include "helpers.h"
+    #include "formatter.h"
 
+    #include <iostream>
 #if defined(_MSC_VER) && !defined(__clang__)
     #if defined(DAS_RELWITHDEBINFO)
         #pragma optimize( "s", on )
@@ -39,7 +42,7 @@
 
     using namespace das;
 
-    #include "parser_impl.h"
+    #include "../src/parser/parser_impl.h"
 
     LineInfo tokAt ( yyscan_t scanner, const struct DAS_YYLTYPE & li );
     LineInfo tokRangeAt ( yyscan_t scanner, const struct DAS_YYLTYPE & li, const struct DAS_YYLTYPE & lie );
@@ -67,7 +70,7 @@
     struct DAS_YYLTYPE;
 
     #define YY_NO_UNISTD_H
-    #include "lex.yy.h"
+    #include "../src/parser/lex.yy.h"
 
     void das_yyerror ( DAS_YYLTYPE * lloc, yyscan_t scanner, const string & error );
     void das_yyfatalerror ( DAS_YYLTYPE * lloc, yyscan_t scanner, const string & error, CompilationError cerr );
@@ -694,12 +697,14 @@ expr_reader
         $$ = yyextra->g_ReaderExpr;
         int thisLine = 0;
         FileInfo * info = nullptr;
+        if (!format::is_enabled()) {
         if ( auto seqt = yyextra->g_ReaderMacro->suffix(yyextra->g_Program.get(), yyextra->g_Program->thisModule.get(), yyextra->g_ReaderExpr, thisLine, info, tokAt(scanner,@seq)) ) {
             das_accept_sequence(scanner,seqt,strlen(seqt),thisLine,info);
             yylloc.first_column = @seq.first_column;
             yylloc.first_line = @seq.first_line;
             yylloc.last_column = @seq.last_column;
             yylloc.last_line = @seq.last_line;
+        }
         }
         delete $mark;
         yyextra->g_ReaderMacro = nullptr;
@@ -1230,10 +1235,26 @@ function_declaration
 
 expression_block
     :   '{' [bbegin] expressions[block] '}' [bend] {
+        if (format::is_replace_braces() &&
+            format::prepare_rule(format::Pos::from_end_prev_line(tokAt(scanner,@bbegin)))) {
+            const auto internal = format::get_substring(format::Pos::from_end_prev_line(tokAt(scanner,@bbegin)),
+                                                          format::Pos::from_last(tokAt(scanner,@bend)));
+            format::get_writer() << "{\n" << internal << "}\n";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@bend)));
+        }
+
         $$ = $block;
         $$->at = tokRangeAt(scanner,@bbegin,@bend);
     }
     |   '{' [bbegin] expressions[block] '}' DAS_FINALLY '{' expressions[final] '}' [bend] {
+        if (format::is_replace_braces() &&
+            format::prepare_rule(format::Pos::from(tokAt(scanner,@bbegin)))) {
+            const auto internal = format::get_substring(format::Pos::from(tokAt(scanner,@bbegin)),
+                                                          format::Pos::from(tokAt(scanner,@bend)));
+            format::get_writer() << " {" << internal << "\n}";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@bend)));
+        }
+
         auto pB = (ExprBlock *) $block;
         auto pF = (ExprBlock *) $final;
         swap ( pB->finalList, pF->list );
@@ -1573,7 +1594,13 @@ tuple_expansion
     ;
 
 tuple_expansion_variable_declaration
-    :   BRABRAB tuple_expansion[list] ']' ']' ':' type_declaration_no_options[typeDecl] copy_or_move_or_clone[com] expr[init] ';' {
+    :   BRABRAB[loc] tuple_expansion[list] ']' ']' [end_expansion] ':' type_declaration_no_options[typeDecl] copy_or_move_or_clone[com] expr[init] ';'[end] {
+        //std::cout << "case11" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc)))) {
+            const auto internal = format::get_substring(tokAt(scanner,@list));
+            format::get_writer() << "(" << internal << ")";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@end_expansion)));
+        }
         $$ = new VariableDeclaration($list,tokAt(scanner,@list),$typeDecl,$init);
         $$->init_via_move  = ($com & CorM_MOVE) !=0;
         $$->init_via_clone = ($com & CorM_CLONE) !=0;
@@ -1585,7 +1612,14 @@ tuple_expansion_variable_declaration
         $$->init_via_clone = ($com & CorM_CLONE) !=0;
         $$->isTupleExpansion = true;
     }
-    |   BRABRAB tuple_expansion[list] ']' ']' optional_ref[ref] copy_or_move_or_clone[com] expr[init] ';' {
+    |   BRABRAB [loc] tuple_expansion[list] ']' ']' [end_expansion] optional_ref[ref] copy_or_move_or_clone[com] expr[init] ';' {
+        //std::cout << "case12" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc)))) {
+            const auto internal = format::get_substring(tokAt(scanner,@list));
+            format::get_writer() << "(" << internal << ")";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@end_expansion)));
+        }
+
         auto typeDecl = new TypeDecl(Type::autoinfer);
         typeDecl->at = tokAt(scanner,@list);
         typeDecl->ref = $ref;
@@ -1763,7 +1797,7 @@ capture_list
 
 optional_capture_list
     :   { $$ = nullptr; }
-    |   BRABRAB capture_list[cl] ']' ']' { $$ = $cl; }
+    |   BRABRAB capture_list[cl] ']' ']' {         /* I guess remains the same */; $$ = $cl; }
     |   DAS_CAPTURE '(' capture_list[cl] ')' { $$ = $cl; }
     ;
 
@@ -2743,7 +2777,16 @@ optional_struct_variable_declaration_list
     :   {
         $$ = new vector<VariableDeclaration*>();
     }
-    |   '{' struct_variable_declaration_list[list] '}' {
+    |   '{' [sbegin] struct_variable_declaration_list[list] '}' [send] {
+        if (format::is_replace_braces() &&
+            format::prepare_rule(format::Pos::from_end_prev_line(tokAt(scanner,@sbegin)))) {
+            const auto internal = format::get_substring(format::Pos::from_end_prev_line(tokAt(scanner,@sbegin)),
+                                                          format::Pos::from(tokAt(scanner,@send))); // should be from_last, but location little bit incorrect
+            format::get_writer() << " {" << internal
+                                   << std::string(yyextra->das_indent_level, '\t') // emit tabs
+                                   << "}\n"; // new line
+            format::finish_rule(format::Pos::from(tokAt(scanner,@send)));
+        }
         $$ = $list;
     }
     ;
@@ -3314,53 +3357,53 @@ make_decl
 
 make_struct_fields
     :   NAME[fn] copy_or_move[com] expr[value] {
-        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@fn),*$fn,ExpressionPtr($value),$com,false);
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,@fn, @value),*$fn,ExpressionPtr($value),$com,false);
         delete $fn;
         auto msd = new MakeStruct();
         msd->push_back(mfd);
         $$ = msd;
     }
     |   NAME[fn] CLONEEQU expr[value] {
-        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@fn),*$fn,ExpressionPtr($value),false,true);
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,@fn, @value),*$fn,ExpressionPtr($value),false,true);
         delete $fn;
         auto msd = new MakeStruct();
         msd->push_back(mfd);
         $$ = msd;
     }
     |   make_struct_fields[msd] ',' NAME[fn] copy_or_move[com] expr[value] {
-        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@fn),*$fn,ExpressionPtr($value),$com,false);
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,@fn, @value),*$fn,ExpressionPtr($value),$com,false);
         delete $fn;
         ((MakeStruct *)$msd)->push_back(mfd);
         $$ = $msd;
     }
     |   make_struct_fields[msd] ',' NAME[fn] CLONEEQU expr[value] {
-        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@fn),*$fn,ExpressionPtr($value),false,true);
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,@fn, @value),*$fn,ExpressionPtr($value),false,true);
         delete $fn;
         ((MakeStruct *)$msd)->push_back(mfd);
         $$ = $msd;
     }
-    |   MTAG_F '(' expr[subexpr] ')' copy_or_move[com] expr[value] {
-        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@subexpr),"``MACRO``TAG``FIELD``",ExpressionPtr($value),$com,false);
+    |   MTAG_F [begin] '(' expr[subexpr] ')' copy_or_move[com] expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,@begin, @value),"``MACRO``TAG``FIELD``",ExpressionPtr($value),$com,false);
         mfd->tag = ExpressionPtr($subexpr);
         auto msd = new MakeStruct();
         msd->push_back(mfd);
         $$ = msd;
     }
-    |   MTAG_F '(' expr[subexpr] ')' CLONEEQU expr[value] {
-        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@subexpr),"``MACRO``TAG``FIELD``",ExpressionPtr($value),false,true);
+    |   MTAG_F [begin] '(' expr[subexpr] ')' CLONEEQU expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner, @begin, @value),"``MACRO``TAG``FIELD``",ExpressionPtr($value),false,true);
         mfd->tag = ExpressionPtr($subexpr);
         auto msd = new MakeStruct();
         msd->push_back(mfd);
         $$ = msd;
     }
-    |   make_struct_fields[msd] ',' MTAG_F '(' expr[subexpr] ')' copy_or_move[com] expr[value] {
-        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@subexpr),"``MACRO``TAG``FIELD``",ExpressionPtr($value),$com,false);
+    |   make_struct_fields[msd] ',' MTAG_F [begin] '(' expr[subexpr] ')' copy_or_move[com] expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,@begin,@value),"``MACRO``TAG``FIELD``",ExpressionPtr($value),$com,false);
         mfd->tag = ExpressionPtr($subexpr);
         ((MakeStruct *)$msd)->push_back(mfd);
         $$ = $msd;
     }
-    |   make_struct_fields[msd] ',' MTAG_F '(' expr[subexpr] ')' CLONEEQU expr[value] {
-        auto mfd = make_smart<MakeFieldDecl>(tokAt(scanner,@subexpr),"``MACRO``TAG``FIELD``",ExpressionPtr($value),false,true);
+    |   make_struct_fields[msd] ',' MTAG_F [begin] '(' expr[subexpr] ')' CLONEEQU expr[value] {
+        auto mfd = make_smart<MakeFieldDecl>(tokRangeAt(scanner,@begin, @value),"``MACRO``TAG``FIELD``",ExpressionPtr($value),false,true);
         mfd->tag = ExpressionPtr($subexpr);
         ((MakeStruct *)$msd)->push_back(mfd);
         $$ = $msd;
@@ -3423,7 +3466,7 @@ optional_make_struct_dim_decl
 
 optional_block
     :   { $$ = nullptr; }
-    |   DAS_WHERE expr_block[blk] { $$ = $blk; }
+    |   DAS_WHERE expr_block[blk] { $blk->at = tokAt(scanner, @blk); $$ = $blk; }
     ;
 
 
@@ -3460,20 +3503,69 @@ use_initializer
     ;
 
 make_struct_decl
-    :   BRABRAB [loc] type_declaration_no_options[mkt] make_struct_dim[msd] optional_block[blk] optional_trailing_delim_sqr_sqr {
+    :   BRABRAB [loc] type_declaration_no_options[mkt] make_struct_dim[msd] optional_block[blk] optional_trailing_delim_sqr_sqr[end] {
+        //std::cout << "case1" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc)))) {
+            auto type = format::type_to_string($mkt, tokAt(scanner,@mkt)).value_or("");
+            const bool is_initialized = false;
+            const auto internal = format::handle_msd(static_cast<ExprMakeStruct*>($msd), type, is_initialized);
+            if (static_cast<ExprMakeStruct*>($msd)->structs.size() == 1) {
+                // single struct
+                format::get_writer() << internal;
+                if ($blk != nullptr) {
+                    format::get_writer() << " <| " << format::get_substring($blk->at);
+                }
+            } else {
+                // array of structs
+    //            const auto internal = format::get_substring(format::Pos::from(tokAt(scanner,@msd)),
+    //                                                          format::Pos::from(tokAt(scanner,@end)));
+                format::get_writer() << "[" << internal << "]";
+            }
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@end)));
+        }
         ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
         ((ExprMakeStruct *)$msd)->block = $blk;
         $msd->at = tokAt(scanner,@loc);
         $$ = $msd;
     }
-    |   BRABRAB [loc] type_declaration_no_options[mkt] optional_block[blk] optional_trailing_delim_sqr_sqr {
+    |   BRABRAB [loc] type_declaration_no_options[mkt] optional_block[blk] optional_trailing_delim_sqr_sqr[end] {
+        // std::cout << "case2" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc)))) {
+            auto type = format::type_to_string($mkt, tokAt(scanner,@mkt));
+            std::unordered_set<std::string> always_init = {
+                // Is there a method to describe all this types?
+                "struct<array<",
+                "array<",
+                "bitfield",
+                "string",
+                "int",
+                "float",
+                "variant",
+                "tuple",
+            };
+            if ($mkt->isPointer()) {
+                format::get_writer() << "default<" << type.value() << ">";
+            } else if (std::any_of(always_init.begin(), always_init.end(),
+                            [&type](auto t){ return type.value_or("").find(t) == 0; })) {
+                format::get_writer() << type.value_or("") << "()";
+            } else {
+                format::get_writer() << type.value_or("") << "(uninitialized)";
+            }
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@end)));
+        }
+
         auto msd = new ExprMakeStruct();
         msd->makeType = TypeDeclPtr($mkt);
         msd->block = $blk;
         msd->at = tokAt(scanner,@loc);
         $$ = msd;
     }
-    |   BRABRAB [loc] type_declaration_no_options[mkt] '(' ')' optional_block[blk] optional_trailing_delim_sqr_sqr {
+    |   BRABRAB [loc] type_declaration_no_options[mkt] '(' ')' optional_block[blk] optional_trailing_delim_sqr_sqr [end_loc] {
+        //std::cout << "case3" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc)))) {
+            format::get_writer() << format::type_to_string($mkt, tokAt(scanner,@mkt)).value_or("") << "()";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@end_loc)));
+        }
         auto msd = new ExprMakeStruct();
         msd->makeType = TypeDeclPtr($mkt);
         msd->useInitializer = true;
@@ -3481,14 +3573,31 @@ make_struct_decl
         msd->at = tokAt(scanner,@loc);
         $$ = msd;
     }
-    |   BRABRAB [loc] type_declaration_no_options[mkt] '(' ')' make_struct_dim[msd] optional_block[blk] optional_trailing_delim_sqr_sqr {
+    |   BRABRAB [loc] type_declaration_no_options[mkt] '(' ')' make_struct_dim[msd] optional_block[blk] optional_trailing_delim_sqr_sqr [end_loc] {
+        //std::cout << "case4" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc)))) {
+            auto type_name = format::type_to_string($mkt, tokAt(scanner,@mkt)).value_or("");
+            const auto internal = format::handle_msd(static_cast<ExprMakeStruct*>($msd), type_name);
+//            auto internal = format::get_substring(format::Pos::from(tokAt(scanner,@msd)),
+//                                                    format::Pos::from_last(tokAt(scanner,@blk)));
+            format::get_writer() << internal;
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@end_loc)));
+        }
+
         ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
         ((ExprMakeStruct *)$msd)->useInitializer = true;
         ((ExprMakeStruct *)$msd)->block = $blk;
         $msd->at = tokAt(scanner,@loc);
         $$ = $msd;
     }
-    |   BRACBRB [loc] type_declaration_no_options[mkt] make_struct_dim[msd] optional_block[blk] optional_trailing_delim_cur_sqr {
+    |   BRACBRB [loc] type_declaration_no_options[mkt] make_struct_dim[msd] optional_block[blk] optional_trailing_delim_cur_sqr [end_loc] {
+        //std::cout << "case6" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc)))) {
+            auto type_name = format::type_to_string($mkt, tokAt(scanner,@mkt)).value_or("");
+            format::get_writer() << "[" << format::handle_msd(static_cast<ExprMakeStruct*>($msd), type_name) << "]";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@end_loc)));
+        }
+
         ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
         ((ExprMakeStruct *)$msd)->block = $blk;
         $msd->at = tokAt(scanner,@loc);
@@ -3496,7 +3605,16 @@ make_struct_decl
         tam->arguments.push_back(ExpressionPtr($msd));
         $$ = tam;
     }
-    |   BRACBRB [loc] type_declaration_no_options[mkt] '(' ')' make_struct_dim[msd] optional_block[blk] optional_trailing_delim_cur_sqr {
+    |   BRACBRB [loc] type_declaration_no_options[mkt] '(' ')' make_struct_dim[msd] optional_block[blk] optional_trailing_delim_cur_sqr [end_loc] {
+        //std::cout << "case7" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc)))) {
+            auto type_name = format::type_to_string($mkt, tokAt(scanner,@mkt)).value_or("");
+            format::get_writer() << "["
+                                   << format::handle_msd(static_cast<ExprMakeStruct*>($msd), type_name)
+                                   << "]";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@end_loc)));
+        }
+
         ((ExprMakeStruct *)$msd)->makeType = TypeDeclPtr($mkt);
         ((ExprMakeStruct *)$msd)->useInitializer = true;
         ((ExprMakeStruct *)$msd)->block = $blk;
@@ -3539,15 +3657,17 @@ make_struct_decl
 
 make_tuple
     :   expr[val] {
+        $val->at = tokAt(scanner,@val);
         $$ = $val;
     }
     |   expr[kval] MAPTO[mkt] expr[vval] {
-        ExprMakeTuple * mt = new ExprMakeTuple(tokAt(scanner,@mkt));
+        ExprMakeTuple * mt = new ExprMakeTuple(tokRangeAt(scanner,@kval, @vval));
         mt->values.push_back(ExpressionPtr($kval));
         mt->values.push_back(ExpressionPtr($vval));
         $$ = mt;
     }
     |   make_tuple[mkt] ',' expr[val] {
+        $val->at = tokAt(scanner,@val);
         ExprMakeTuple * mt;
         if ( $mkt->rtti_isMakeTuple() ) {
             mt = static_cast<ExprMakeTuple *>($mkt);
@@ -3556,13 +3676,14 @@ make_tuple
             mt->values.push_back(ExpressionPtr($mkt));
         }
         mt->values.push_back(ExpressionPtr($val));
+        mt->at = format::concat(mt->at, tokAt(scanner, @val));
         $$ = mt;
     }
     ;
 
 make_map_tuple
     :   expr[kval] MAPTO[mkt] expr[vval] {
-        ExprMakeTuple * mt = new ExprMakeTuple(tokAt(scanner,@mkt));
+        ExprMakeTuple * mt = new ExprMakeTuple(tokRangeAt(scanner,@kval,@vval));
         mt->values.push_back(ExpressionPtr($kval));
         mt->values.push_back(ExpressionPtr($vval));
         $$ = mt;
@@ -3610,12 +3731,38 @@ make_dim_decl
         tam->arguments.push_back(mka);
         $$ = tam;
     }
-    |   BRABRAB [loc] type_declaration_no_options[mkt] make_dim[mka] optional_trailing_semicolon_sqr_sqr {
+    |   BRABRAB [loc] type_declaration_no_options[mkt] make_dim[mka] optional_trailing_semicolon_sqr_sqr [end_loc] {
+        //std::cout << "case13" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc)))) {
+            auto type_name = format::type_to_string($mkt, tokAt(scanner,@mkt));
+            auto internal = format::handle_mka(static_cast<ExprMakeArray*>($mka));
+            if (static_cast<ExprMakeArray*>($mka)->values.size() == 1) {
+                // single element
+                format::get_writer() << internal;
+            } else {
+                format::get_writer() << "fixed_array";
+                if (!$mkt->isAuto()) {
+                    format::get_writer() << "<" << type_name.value() << ">";
+                }
+                format::get_writer() << "(" << internal << ")";
+            }
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@end_loc)));
+        }
         ((ExprMakeArray *)$mka)->makeType = TypeDeclPtr($mkt);
         $mka->at = tokAt(scanner,@loc);
         $$ = $mka;
     }
-    |   BRACBRB [loc] type_declaration_no_options[mkt] make_dim[mka] optional_trailing_semicolon_cur_sqr {
+    |   BRACBRB [loc] type_declaration_no_options[mkt] make_dim[mka] optional_trailing_semicolon_cur_sqr [end_loc] {
+        //std::cout << "case8" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc)))) {
+            format::get_writer() << "array";
+            if (!$mkt->isAuto()) {
+                format::get_writer() << "<" << format::get_substring(tokAt(scanner,@mkt)) << ">";
+            }
+            format::get_writer() << "(" << format::handle_mka(static_cast<ExprMakeArray*>($mka)) << ")";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@end_loc)));
+        }
+
         ((ExprMakeArray *)$mka)->makeType = TypeDeclPtr($mkt);
         $mka->at = tokAt(scanner,@loc);
         auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
@@ -3727,7 +3874,13 @@ make_table_decl
         ttm->arguments.push_back(mka);
         $$ = ttm;
     }
-    |   CBRCBRB [loc] make_table[mka] optional_trailing_semicolon_cur_cur {
+    |   CBRCBRB [loc] make_table[mka] optional_trailing_semicolon_cur_cur [end] {
+        //std::cout << "case10" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc)))) {
+            format::get_writer() << "{" << format::convert_to_string(((ExprMakeArray *)$mka)->values) << "}";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@end)));
+        }
+
         auto mkt = make_smart<TypeDecl>(Type::autoinfer);
         mkt->dim.push_back(TypeDecl::dimAuto);
         ((ExprMakeArray *)$mka)->makeType = mkt;
@@ -3806,16 +3959,35 @@ array_comprehension
     |   '[' DAS_ITERATOR DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' expr[subexpr] array_comprehension_where[where] ']' [forend] {
         $$ = ast_arrayComprehension(scanner,tokAt(scanner,@loc),$iters,$srcs,$subexpr,$where,tokRangeAt(scanner,@subexpr,@forend),true,false);
     }
-    |   BRABRAB DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' expr[subexpr] array_comprehension_where[where] ']' ']' [forend] {
+    |   BRABRAB [loc_start] DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' expr[subexpr] array_comprehension_where[where] ']' ']' [forend] {
+        //std::cout << "case5" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc_start)))) {
+            auto internal = format::get_substring(format::Pos::from(tokAt(scanner,@loc)), format::Pos::from_last(tokAt(scanner,@where)));
+            format::get_writer() << "[iterator " << internal << "]";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@forend)));
+        }
         $$ = ast_arrayComprehension(scanner,tokAt(scanner,@loc),$iters,$srcs,$subexpr,$where,tokRangeAt(scanner,@subexpr,@forend),true,false);
     }
-    |   BRACBRB DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' expr[subexpr] array_comprehension_where[where] '}' ']' [forend] {
+    |   BRACBRB [loc_start] DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' expr[subexpr] array_comprehension_where[where] '}' ']' [forend] {
+        //std::cout << "case9" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc_start)))) {
+            auto internal = format::get_substring(format::Pos::from(tokAt(scanner,@loc)), format::Pos::from_last(tokAt(scanner,@where)));
+            format::get_writer() << "[" << internal << "]";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@forend)));
+        }
+
         $$ = ast_arrayComprehension(scanner,tokAt(scanner,@loc),$iters,$srcs,$subexpr,$where,tokRangeAt(scanner,@subexpr,@forend),false,false);
     }
     |   '{' DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' make_map_tuple[subexpr] array_comprehension_where[where] '}' [forend] {
         $$ = ast_arrayComprehension(scanner,tokAt(scanner,@loc),$iters,$srcs,$subexpr,$where,tokRangeAt(scanner,@subexpr,@forend),false,true);
     }
-    | CBRCBRB DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' make_map_tuple[subexpr] array_comprehension_where[where] '}' '}' [forend] {
+    | CBRCBRB[loc_start] DAS_FOR[loc] variable_name_with_pos_list[iters] DAS_IN expr_list[srcs]  ';' make_map_tuple[subexpr] array_comprehension_where[where] '}' '}' [forend] {
+        //std::cout << "case12" << std::endl;
+        if (format::prepare_rule(format::Pos::from(tokAt(scanner,@loc_start)))) {
+            auto internal = format::get_substring(format::Pos::from(tokAt(scanner,@loc)), format::Pos::from_last(tokAt(scanner,@where)));
+            format::get_writer() << "[" << internal << "]";
+            format::finish_rule(format::Pos::from_last(tokAt(scanner,@forend)));
+        }
         $$ = ast_arrayComprehension(scanner,tokAt(scanner,@loc),$iters,$srcs,$subexpr,$where,tokRangeAt(scanner,@subexpr,@forend),true,true);
     }
     ;

--- a/utils/dasFormatter/formatter.cpp
+++ b/utils/dasFormatter/formatter.cpp
@@ -1,0 +1,141 @@
+#include "formatter.h"
+
+#include <vector>
+#include <iostream>
+#include <sstream>
+
+namespace das::format {
+
+    struct State {
+        FormatOptions options;
+        vector<string> content_;
+        Pos last;
+        bool enabled = false;
+        stringstream *ss;
+    };
+
+    static State state;
+
+    optional<Pos> try_print_until(Pos info) {
+        if (!state.enabled) {
+            return nullopt;
+        }
+        if (info.line < state.last.line) {
+            return state.last;
+        }
+        get_writer() << get_substring(state.last, info);
+        state.last = info;
+        return nullopt;
+    }
+
+
+    void init(stringstream *ss, string content, FormatOptions options) {
+        string line;
+        content.push_back('\n'); // easiest way to flush the last line
+        for (const auto c: content) {
+            if (c != '\n') {
+                line.push_back(c);
+            } else {
+                state.content_.emplace_back(move(line));
+                line.clear();
+            }
+        }
+        state.ss = ss;
+        state.enabled = true;
+        state.last = {.line=1, .column=0};
+        state.options = move(options);
+    }
+
+    void destroy() {
+        if (!state.content_.empty()) {
+            try_print_until(Pos{static_cast<uint32_t>(state.content_.size()),
+                                static_cast<uint32_t>(state.content_.back().size())});
+        }
+        state.ss = nullptr;
+        state.enabled = false;
+        state.last = {};
+        state.content_ = {};
+    }
+
+    void set_to(Pos info) {
+        assert(state.last < info);
+        state.last = info;
+    }
+
+    string get_substring(Pos pos1, Pos pos2) {
+        if (!state.enabled || pos1 < state.last) {
+            return "";
+        }
+
+        string result;
+        for (; pos1.line < pos2.line; pos1.line++, pos1.column = 0) {
+            if (pos1.line > state.content_.size()) {
+                cerr << "Warning, location line out of range" << endl;
+                return "";
+            } else if (pos1.column > state.content_[pos1.line - 1].length()) {
+                cout << "incorrect location info, extra symbols "
+                          << pos1.column << " "
+                          << state.content_[pos1.line - 1].length() << endl;
+            } else {
+                result += state.content_[pos1.line - 1].substr(pos1.column);
+            }
+            result += '\n';
+        }
+        if (pos2.column < pos1.column || pos2.line < pos1.line) {
+            assert(result.empty());
+            assert(pos1.line == pos2.line);
+            return "";
+        }
+
+        if (pos1.line > state.content_.size()) {
+            cerr << "Warning, location line out of range" << endl;
+            return "";
+        }
+        if (pos1.column > state.content_[pos1.line - 1].size()) {
+            cerr << "Warning, location column out of range" << endl;
+            return "";
+        }
+        result += state.content_[pos1.line - 1].substr(pos1.column, pos2.column - pos1.column);
+        return result;
+    }
+
+    string get_substring(LineInfo info) {
+        return get_substring(Pos{info.line, info.column},
+                             Pos{info.last_line, info.last_column});
+    }
+
+    ostream& get_writer() {
+        return *state.ss;
+    }
+
+    bool prepare_rule(Pos pos) {
+        if (state.enabled && state.last < pos) {
+            try_print_until(pos);
+            return true;
+        }
+        return false;
+    }
+
+    void finish_rule(Pos pos) {
+        assert(state.enabled && state.last < pos);
+        set_to(pos);
+    }
+
+    Pos Pos::from_end_prev_line(LineInfo info) {
+        if (!state.enabled) {
+            return {};
+        }
+        const auto prev_line = info.line - 1;
+        return Pos{prev_line, static_cast<uint32_t>(state.content_.at(prev_line - 1).size())};
+    }
+
+    bool is_replace_braces() {
+        return state.options.contains(FormatOpt::AlwaysBraces);
+    }
+
+    bool is_enabled() {
+        return state.enabled;
+    }
+
+}
+

--- a/utils/dasFormatter/formatter.h
+++ b/utils/dasFormatter/formatter.h
@@ -1,0 +1,84 @@
+#ifndef DAS_FORMATTER_H
+#define DAS_FORMATTER_H
+
+#include <string>
+#include <optional>
+#include <utility>
+#include "daScript/daScript.h"
+
+namespace das::format {
+
+    // formatter config
+    enum class FormatOpt {
+        AlwaysBraces,
+    };
+
+    class FormatOptions {
+    public:
+        FormatOptions() = default;
+        FormatOptions(unordered_set<FormatOpt> options_) : options(move(options_)) {}
+
+        bool contains(FormatOpt opt) {
+            return options.count(opt);
+        }
+    private:
+        unordered_set<FormatOpt> options;
+    };
+
+    struct Pos {
+        uint32_t line;
+        uint32_t column;
+
+        static Pos from(LineInfo info) {
+            return Pos{info.line, info.column};
+        }
+
+        static Pos from_end_prev_line(LineInfo info);
+
+        static Pos from_last(LineInfo info) {
+            return Pos{info.last_line, info.last_column};
+        }
+
+        bool operator < (const Pos &rhs) const {
+            return line < rhs.line || (line == rhs.line && column < rhs.column);
+        }
+    };
+
+    // Should be called before and after each formatting operation. Maintains internal compiler state
+    void init(stringstream *ss, string content, FormatOptions options);
+    void destroy();
+
+    /**
+     * @return output stream
+     */
+    ostream& get_writer();
+
+    /**
+     * This function should be called before handling each rule
+     * @param pos beginning of the rule
+     * @return true if we can handle it now
+     *
+     * Ex: A(B()). Bison will parse in the following order: B(), A(  ).
+     * Due to simplicity of formatter, we can't handle rule, if some part of it was somehow modified.
+     * So if B() already handled we can't handle A(   ) in current iteration
+     */
+    bool prepare_rule(Pos pos);
+
+    /**
+     * Input file will be printed until current position.
+     * @param pos end of the rule
+     */
+    void finish_rule(Pos pos);
+
+    /**
+     * @return specified substring of input file
+     */
+    string get_substring(LineInfo info);
+    string get_substring(Pos pos1, Pos pos2);
+
+    // Maybe we should replace it with getConfig(), if there will be a lot of options
+    bool is_replace_braces();
+    bool is_enabled();
+}
+
+#endif //DAS_FORMATTER_H

--- a/utils/dasFormatter/helpers.h
+++ b/utils/dasFormatter/helpers.h
@@ -1,0 +1,88 @@
+#ifndef DAS_HELPERS_H
+#define DAS_HELPERS_H
+
+#include <algorithm>
+#include <numeric>
+#include <string>
+#include <vector>
+#include <daScript/ast/ast_typedecl.h>
+
+#include "formatter.h"
+
+namespace das::format {
+
+    template <typename T>
+    string convert_to_string(const vector<T> &vec, string sep = ", ") {
+        if (vec.empty()) {
+            return "";
+        }
+        return accumulate(
+            next(vec.begin()), vec.end(),
+            format::get_substring(vec.front()->at),
+            [sep] (const string& a, const T &b) {
+                return a + sep + format::get_substring(b->at);
+            }
+        );
+    }
+
+    optional<string> type_to_string(const TypeDecl *type_decl, LineInfo loc /* pass loc, since it's sometimes incorrect on type itself*/) {
+        if (type_decl->isTemp(false)) {
+            return "struct<" + format::get_substring(loc) + ">";
+        } else if (type_decl->isAuto() && !type_decl->isPointer()) {
+            return nullopt;
+        } else {
+            return format::get_substring(loc);
+        }
+    }
+
+    string handle_msd(ExprMakeStruct* msd, string type_name, bool is_initialized = true) {
+        auto structs = msd->structs;
+        if (structs.empty()) {
+            return "";
+        }
+        auto maybe_uninit = is_initialized ? "" : "uninitialized ";
+        auto converter = [&type_name, &maybe_uninit] (string a, MakeStructPtr tuple) {
+            a += ", " + type_name + "(" + maybe_uninit + das::format::convert_to_string(*tuple.get()) + ")";
+            return a;
+        };
+
+        return accumulate(
+            next(structs.begin()), structs.end(),
+            converter("", structs.front()).substr(2), // rid of ", "
+            converter
+        );
+    }
+
+    string handle_mka(ExprMakeArray* mka) {
+        const auto &values = mka->values;
+        if (values.empty()) {
+            return "";
+        }
+        auto converter = [] (string a, const ExpressionPtr &tuple) {
+            a += ", ";
+            if ( tuple->rtti_isMakeTuple() ) {
+                a += "(" + das::format::convert_to_string(static_cast<ExprMakeTuple *>(tuple.get())->values) + ")";
+            } else {
+                a += das::format::get_substring(tuple->at);
+            }
+            return a;
+        };
+
+        return accumulate(
+            next(values.begin()), values.end(),
+            converter("", values.front()).substr(2), // rid of ", "
+            converter
+        );
+    }
+
+    LineInfo concat(LineInfo first, LineInfo last) {
+        return LineInfo(
+            first.fileInfo,
+            first.column,
+            first.line,
+            last.last_column,
+            last.last_line);
+    }
+}
+
+#endif //DAS_HELPERS_H

--- a/utils/dasFormatter/main.cpp
+++ b/utils/dasFormatter/main.cpp
@@ -1,0 +1,361 @@
+#include "daScript/daScript.h"
+#include "daScript/simulate/fs_file_info.h"
+#include <iostream>
+#include <optional>
+
+#include "daScript/ast/ast.h"
+#include "daScript/misc/platform.h"
+
+#include "daScript/ast/ast.h"
+#include "daScript/ast/ast_serializer.h"
+
+#include "../src/parser/parser_state.h"
+
+typedef void * yyscan_t;
+union YYSTYPE;
+
+#define YY_EXTRA_TYPE das::DasParserState *
+
+#define YY_NO_UNISTD_H
+#include "../src/parser/lex.yy.h"
+#include "../src/parser/lex2.yy.h"
+#include "formatter.h"
+
+void das_yybegin(const char * str, uint32_t len, yyscan_t yyscanner);
+int das_yyparse(yyscan_t yyscanner);
+
+
+#include <vector>
+#include <string>
+#include <sstream>
+#include <fstream>
+
+typedef void * yyscan_t;
+int das_yyparse(yyscan_t yyscanner);
+
+using namespace das;
+
+
+void InitModules() {
+    // register modules
+    if (!Module::require("$")) {
+        NEED_MODULE(Module_BuiltIn);
+    }
+    if (!Module::require("math")) {
+        NEED_MODULE(Module_Math);
+    }
+    if (!Module::require("raster")) {
+        NEED_MODULE(Module_Raster);
+    }
+    if (!Module::require("strings")) {
+        NEED_MODULE(Module_Strings);
+    }
+    if (!Module::require("rtti")) {
+        NEED_MODULE(Module_Rtti);
+    }
+    if (!Module::require("ast")) {
+        NEED_MODULE(Module_Ast);
+    }
+    if (!Module::require("jit")) {
+        NEED_MODULE(Module_Jit);
+    }
+    if (!Module::require("debugapi")) {
+        NEED_MODULE(Module_Debugger);
+    }
+    NEED_MODULE(Module_Network);
+    NEED_MODULE(Module_UriParser);
+    NEED_MODULE(Module_JobQue);
+    NEED_MODULE(Module_FIO);
+    NEED_MODULE(Module_DASBIND);
+#include "modules/external_need.inc"
+    Module::Initialize();
+    // compile and run
+
+}
+
+das::FileAccessPtr get_file_access( char * pak );//link time resolved dependencies
+
+string help() {
+    return "Tool to convert dascript v1 syntax to v2\n"
+           "das-fmt {-i} filename1 {filename2} ...:\n"
+           "   -i inplace conversion, write to the same file. Multiple filenames only allowed in inplace mode\n"
+           "   --tests Run tests, no filenames required\n"
+           "";
+}
+
+struct Result {
+    struct ErrorInfo {
+        string content;
+        string what;
+    };
+    optional<string> ok;
+    optional<ErrorInfo> error;
+};
+
+void addNewModules ( ModuleGroup & libGroup, ProgramPtr program ) {
+    libGroup.addModule(program->thisModule.release());
+    program->library.foreach([&](Module * pm) -> bool {
+        if ( !pm->name.empty() && pm->name!="$" ) {
+            if ( !libGroup.findModule(pm->name) ) {
+                libGroup.addModule(pm);
+            }
+        }
+        return true;
+    }, "*");
+}
+
+Result transform_syntax(const string& filename, const string content, format::FormatOptions options = {}) {
+    auto src = content;
+    string prev;
+    vector<ModuleInfo> req;
+    vector<RequireRecord> missing, circular, notAllowed;
+    vector<FileInfo *> chain;
+    das_set<string> dependencies;
+    ModuleGroup libGroup;
+    CodeOfPolicies policies;
+    policies.aot = false;
+    policies.aot_module = false;
+    policies.fail_on_lack_of_aot_export = false;
+    policies.version_2_syntax = false;
+
+    uint64_t preqT = 0;
+    auto access = get_file_access(nullptr);
+    TextPrinter tout;
+    if ( getPrerequisits(filename, access, req, missing, circular, notAllowed, chain,
+                         dependencies, libGroup, nullptr, 1, !policies.ignore_shared_modules) ) {
+        for ( auto & mod : req ) {
+            if ( libGroup.findModule(mod.moduleName) ) {
+                continue;
+            }
+            auto program = parseDaScript(mod.fileName, mod.moduleName, access, tout, libGroup, true, true, policies);
+            policies.threadlock_context |= program->options.getBoolOption("threadlock_context",false);
+            if ( program->failed() ) {
+                return {};
+            }
+            if ( program->thisModule->name.empty() ) {
+                program->thisModule->name = mod.moduleName;
+                program->thisModule->wasParsedNameless = true;
+            }
+            program->thisModule->fileName = mod.fileName;
+            addNewModules(libGroup, program);
+        }
+    }
+
+    int iter = 0;
+    while (prev != src) {
+        prev = src;
+
+        stringstream ss;
+        format::init(&ss, src.c_str(), options);
+
+        // All initialization and parsing took from daslang source
+        yyscan_t scanner = nullptr;
+        ProgramPtr program = make_smart<Program>();
+        daScriptEnvironment::bound->g_Program = program;
+        daScriptEnvironment::bound->g_compilerLog = &tout;
+        program->promoteToBuiltin = false;
+        program->isCompiling = true;
+        program->isDependency = false;
+        program->needMacroModule = false;
+        program->policies = policies;
+        program->thisModuleGroup = &libGroup;
+        program->thisModuleName = program->thisModule->name;
+        libGroup.foreach([&](Module * pm){
+            program->library.addModule(pm);
+            return true;
+        },"*");
+
+
+        DasParserState parserState;
+        parserState.g_Access = access;
+        parserState.g_FileAccessStack.push_back(access->getFileInfo(filename));
+        parserState.g_Program = program;
+        parserState.das_def_tab_size = daScriptEnvironment::bound->das_def_tab_size;
+        parserState.das_gen2_make_syntax = false;
+        libGroup.foreach([&](Module * mod){
+            if ( mod->commentReader ) {
+                parserState.g_CommentReaders.push_back(mod->commentReader.get());
+            }
+            return true;
+        },"*");
+
+        das_yylex_init_extra(&parserState, &scanner);
+        das_yybegin(src.c_str(), src.size(), scanner);
+        auto err = das_yyparse(scanner);
+
+        // end of parsing
+
+        format::destroy();
+        das_yylex_destroy(scanner);
+        if (err != 0) {
+            if (iter == 0) {
+                return {};
+            }
+            return {.error=Result::ErrorInfo{prev, program->errors.front().what}};
+        }
+        src = ss.str();
+        iter++;
+    }
+    const auto tmp_name = "/tmp/tmp.das";
+    {
+        ofstream ostream(tmp_name);
+        ostream << src;
+    }
+    auto program = parseDaScript(tmp_name, "", access, tout, libGroup, true, true, policies);
+    if (!program->failed()) {
+        return {.ok=src};
+    } else {
+        return {.error=Result::ErrorInfo{prev, program->errors.front().what}};
+    }
+}
+
+struct TestData {
+    string original;
+    string expected;
+    format::FormatOptions options = {};
+};
+
+vector<TestData> test_cases() {
+    const string in_prefix = "struct Foo\n"
+                               "    a : int = 5\n"
+                               "    b : float = 3.0\n"
+                               "struct Bar\n"
+                               "    a : Foo\n"
+                               "var var1 = ";
+    const string out_prefix = in_prefix;
+
+    const string postfix = "\n";
+    vector<TestData> res = {
+        {"[[Foo a=1,b=2.0]]", "Foo(uninitialized a=1, b=2.0)"}, // 1
+        {"[[Foo]]", "Foo(uninitialized)"}, // 2
+        {"[[Foo()]]", "Foo()"}, // 3
+        {"[[Foo() a=1,b=2.0]]", "Foo(a=1, b=2.0)"}, // 4
+        {"[[auto 1,2]]", "(1, 2)"}, // 4
+        {"[[for i in [1, 2]; x*x; where x%2 == 0]]", "[iterator for i in [1, 2]; x*x; where x%2 == 0]"}, // 5
+        {"[{Foo a=1,b=2.;a=2,b=1.}]", "[Foo(a=1, b=2.), Foo(a=2, b=1.)]"}, // 6
+        {"[{Foo() a=1,b=2.;a=2,b=1.}]", "[Foo(a=1, b=2.), Foo(a=2, b=1.)]"}, // 7
+//        {"[{Foo a=1,b=2.;a=2,b=1. <optional_block>}]", "[Foo(a=1,b=2.),Foo(a=2,b=1.)]"}, // what about optional block in new syntax
+        {"[{auto 1;2;3;4}]", "array(1, 2, 3, 4)"}, // 8
+        {"[{auto 1,2.2}]", "array((1, 2.2))"}, // 8
+        {"[{for x in 0..10; x*x; where x%2==0}]", "[for x in 0..10; x*x; where x%2==0]"}, // 9
+        {"{{ 1; 2; 3; 4 }}", "{1, 2, 3, 4}"}, // 10
+        {R"({{ 1=>"a"; 2=>"b"; 3=>"c"; 4=>"d" }})", R"({1=>"a", 2=>"b", 3=>"c", 4=>"d"})"}, // 10
+        {"[[auto 1,2.,\"3\"; 1,4,\"2\"]]", "fixed_array((1, 2., \"3\"), (1, 4, \"2\"))"}, // 13
+
+        // anything
+        {"[[auto 1;\"ttt\"]]", "fixed_array(1, \"ttt\")"},
+        {"[[Foo?]]", "default<Foo?>"},
+        {"[[Foo#]]", "struct<Foo#>(uninitialized)"},
+        {"[[Foo]]", "Foo(uninitialized)"},
+
+        // nested
+
+        {"[[Bar a=[[Foo a=1,b=2.0]]]]", "Bar(uninitialized a=Foo(uninitialized a=1, b=2.0))"},
+    };
+    for (auto &[in, out, options]: res) {
+        in = in_prefix + in + postfix;
+        out = out_prefix + out + postfix;
+    }
+
+    vector<TestData> tuple_expansion = {
+        // tuple expansion (doesn't work in global scope!)
+        {"def main()\n    var [[a, b]] = (123, 321);",
+         "def main()\n    var (a, b) = (123, 321);"},
+        {"def main()\n    var [[a, b]]: tuple<int, int> = (123, 321);",
+         "def main()\n    var (a, b): tuple<int, int> = (123, 321);"},
+    };
+
+    vector<TestData> braces_tests = {
+        // test braces
+        {"def b()\n    let a = 5;", "def b() {\n    let a = 5;\n}"},
+        {"def b() {\n    let a = 5;\n}", "def b() {\n    let a = 5;\n}"},
+
+        {"def b()\n    let a = 5\n    if a<0\n        a = a + 1",
+         "def b() {\n    let a = 5\n    if a<0 {\n        a = a + 1\n    }\n}"},
+        {"def b() {\n    let a = 5\n}", "def b() {\n    let a = 5\n}"},
+        {"def b() {{\n    let a = 5\n}}", "def b() {{\n    let a = 5\n}"},
+    };
+    for (auto &[in, out, opt]: braces_tests) {
+        opt = format::FormatOptions({format::FormatOpt::AlwaysBraces});
+    }
+    res.insert(res.end(), tuple_expansion.begin(), tuple_expansion.end());
+//    res.insert(res.end(), braces_tests.begin(), braces_tests.end()); // do not implemented yet
+    return res;
+}
+
+int test() {
+    auto cases = test_cases();
+    int ret_code = 0;
+    for (const auto &[in, out, cfg]: cases) {
+        auto res = transform_syntax("test.das", in, cfg); // any filename
+        if (!res.ok) {
+            cout << "input:\n" << in << " \noutput:\n" << res.error->content << " \nerror:\n" << res.error->what << endl;
+            ret_code = -1;
+        } else if (res.ok != out) {
+            cout << " output:\n" << res.ok.value() << " expected:\n" << out << endl;
+            ret_code = -1;
+        }
+    }
+    return ret_code;
+}
+
+int main(int argc, char** argv) {
+    bool is_inplace = false;
+    bool is_tests = false;
+    vector<string> files;
+    if (argc < 2) {
+        cout << help();
+        return -1;
+    } else if (argc == 2) {
+        if (string(argv[1]) == "--tests") {
+            is_tests = true;
+        } else {
+            files = {string(argv[1])};
+        }
+    } else {
+        if (string(argv[1]) == "-i") {
+            is_inplace = true;
+        } else {
+            cout << help();
+            return -1;
+        }
+        for (size_t i = 2; i < argc; i++) {
+            files.emplace_back(argv[i]);
+        }
+    }
+    if (files.empty()) {
+        cout << "no files" << endl;
+    }
+    InitModules();
+    if (is_tests) {
+        return test();
+    }
+
+    int ret_code = 0;
+    for (const auto& file: files) {
+        cout << "input file=" << file << endl;
+        ifstream t(file);
+
+        string str((istreambuf_iterator<char>(t)),
+                        istreambuf_iterator<char>());
+
+        auto res = transform_syntax(file, str);
+        if (res.ok) {
+            if (is_inplace) {
+                ofstream out(file);
+                out << res.ok.value();
+            } else {
+                cout << res.ok.value();
+            }
+        } else if (res.error) {
+            if (!is_inplace) {
+                cout << res.error->content << endl;
+            }
+            cout << file << endl << res.error->what << endl;
+            ret_code = -1;
+        } else {
+            cout << "cant_compile=" << file << endl;
+        }
+    }
+    return ret_code;
+}


### PR DESCRIPTION
This PR creates tool to transform from syntax v1 to syntax v2.

Main logic are in second commit.

Right now there's one problem:
we'll lose all comments and spaces/linebreak inside initialization expression:
```
    [[A  /**/
         a = 1]]
    // will be converted to
    A(a=1)
```