### PR TITLE
Replace hardcoded SHOW_ARGUMENTS and SHOW_LOCAL_VARIABLES to context …

### DIFF
--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -789,6 +789,8 @@ namespace das
         bool                            breakOnException = false;
         bool                            alwaysErrorOnException = false;
         bool                            alwaysStackWalkOnException = false;
+        bool                            showLocalVariablesOnException = false;
+        bool                            showArgumentsOnException = false;
         bool                            instrumentAllocations = false;
         bool                            failed = false;
         bool                            verySafeContext = false;    // when true, array and table reserves don't free memory

--- a/src/simulate/simulate_exceptions.cpp
+++ b/src/simulate/simulate_exceptions.cpp
@@ -29,8 +29,6 @@ namespace das {
     }
 
     void Context::throw_fatal_error ( const char * message, const LineInfo & at ) {
-        constexpr bool SHOW_ARGUMENTS = false;
-        constexpr bool SHOW_LOCAL_VARIABLES = false;
         exceptionMessage = message ? message : "";
         exceptionMessage += "\n";
         exception = exceptionMessage.c_str();
@@ -40,7 +38,7 @@ namespace das {
             to_err(&at, exception);
         }
         if ( alwaysStackWalkOnException ) {
-            stackWalkToErr(*this, at, SHOW_ARGUMENTS, SHOW_LOCAL_VARIABLES);
+            stackWalkToErr(*this, at, showArgumentsOnException, showLocalVariablesOnException);
         }
         if ( breakOnException ) breakPoint(at, "exception", exception);
         throw dasException(exception, at);
@@ -50,7 +48,7 @@ namespace das {
                 to_err(&at, exception);
             }
             if ( alwaysStackWalkOnException ) {
-                stackWalkToErr(*this, at, SHOW_ARGUMENTS, SHOW_LOCAL_VARIABLES);
+                stackWalkToErr(*this, at, showArgumentsOnException, showLocalVariablesOnException);
             }
             if ( breakOnException ) breakPoint(at, "exception", exception);
 #if defined(WIN64) || defined(_WIN64)
@@ -63,7 +61,7 @@ namespace das {
             to_err(&at, "\nunhandled exception\n");
             string msg = exceptionAt.describe() + ": " + exception;
             to_err(&at, msg.c_str());
-            stackWalkToErr(*this, at, SHOW_ARGUMENTS, SHOW_LOCAL_VARIABLES);
+            stackWalkToErr(*this, at, showArgumentsOnException, showLocalVariablesOnException);
             breakPoint(at, "exception", exception);
         }
 #endif


### PR DESCRIPTION
…fields

Why: we want to disable/enable show arguments and local variables in stack trace in runtime