### PR TITLE
fix aot normalize(float3)

### DIFF
--- a/include/daScript/misc/vectypes.h
+++ b/include/daScript/misc/vectypes.h
@@ -49,8 +49,8 @@ namespace das
     __forceinline vec4f vec_loadu(const float *v) {return v_ldu(v);}
     __forceinline vec4f vec_loadu(const int *v) {return v_cast_vec4f(v_ldui(v));}
     __forceinline vec4f vec_loadu(const unsigned int *v) {return vec_loadu((const int *)v);}
-    __forceinline vec4f vec_loadu3(const float *v) {return v_ldu_p3(v);}
-    __forceinline vec4f vec_loadu3(const int *v) {return v_cast_vec4f(v_ldui_p3(v));}
+    __forceinline vec4f vec_loadu3(const float *v) {return v_ldu_p3_safe(v);}
+    __forceinline vec4f vec_loadu3(const int *v) {return v_cast_vec4f(v_ldui_p3_safe(v));}
     __forceinline vec4f vec_loadu3(const unsigned int *v) {return vec_loadu3((const int *)v);}
     __forceinline vec4f vec_loadu_half(const float *v) {return v_ldu_half(v);}
     __forceinline vec4f vec_loadu_half(const int *v) {return v_cast_vec4f(v_ldui_half(v));}
@@ -75,7 +75,7 @@ namespace das
         __forceinline vec2(vec4f t) : x(vec_extract<TT>::x(t)), y(vec_extract<TT>::y(t)) {}
         __forceinline vec2(TT X, TT Y) : x(X), y(Y) {}
         __forceinline vec2(TT t) : x(t), y(t) {}
-         __forceinline operator vec4f() const { return vec_loadu_half(&x); };
+        __forceinline operator vec4f() const { return vec_loadu_half(&x); };
     };
 
     template <typename TT>
@@ -98,7 +98,6 @@ namespace das
         __forceinline vec3(TT X, TT Y, TT Z) : x(X), y(Y), z(Z) {}
         __forceinline vec3(TT t) : x(t), y(t), z(t) {}
         __forceinline operator vec4f() const { return vec_loadu3(&x); };
-
     };
 
     template <typename TT>

--- a/include/daScript/simulate/aot_builtin_math.h
+++ b/include/daScript/simulate/aot_builtin_math.h
@@ -60,9 +60,9 @@ namespace das {
     __forceinline vec4f normalize2(vec4f a){return v_norm2(a); }
     __forceinline vec4f normalize3(vec4f a){return v_norm3(a); }
     __forceinline vec4f normalize4(vec4f a){return v_norm4(a); }
-    __forceinline vec4f safe_normalize2(vec4f a){return v_norm2_safe(a, v_make_vec4f(0.0f, 0.0f, 0.0f, 0.0f));}
-    __forceinline vec4f safe_normalize3(vec4f a){return v_norm3_safe(a, v_make_vec4f(0.0f, 0.0f, 0.0f, 0.0f));}
-    __forceinline vec4f safe_normalize4(vec4f a){return v_norm4_safe(a, v_make_vec4f(0.0f, 0.0f, 0.0f, 0.0f));}
+    __forceinline vec4f safe_normalize2(vec4f a){return v_norm2_safe(a, v_zero());}
+    __forceinline vec4f safe_normalize3(vec4f a){return v_norm3_safe(a, v_zero());}
+    __forceinline vec4f safe_normalize4(vec4f a){return v_norm4_safe(a, v_zero());}
 
     __forceinline vec4f cross3(vec4f a, vec4f b){vec4f v = v_cross3(a,b); return v;}
 


### PR DESCRIPTION
Apparently use of `v_ldu_p3` (which in the end is expanded in simple `_mm_loadu_ps`) causing some compilers (*) to mis-optimize subj code (I guessing b/c of load past vector instance?) so use safe version which works reliably.

(*) e.g. clang18

Somewhat related to
https://github.com/GaijinEntertainment/daScript/pull/1457