### PR TITLE
formatter: fix detection of string interpolation inside characters

### DIFF
--- a/daslib/das_source_formatter.das
+++ b/daslib/das_source_formatter.das
@@ -255,10 +255,10 @@ def parse_token(var ctx : FormatterCtx) {
         var depth = 0;
         ctx |> next_char();
         while (!ctx.eof && (ctx.c != openChar || depth > 0)) {
-            if (ctx.c == '{') {
+            if (ctx.c == '{' && openChar == '"') {
                 depth++;
             }
-            if (ctx.c == '}') {
+            if (ctx.c == '}' && openChar == '"') {
                 depth--;
             }
             if (ctx.c == '\\') {


### PR DESCRIPTION
fix this case:

let x = '{'
let y = '\t'