### PR TITLE
Remove copy/move constructors in TextWriter

### DIFF
--- a/include/daScript/misc/string_writer.h
+++ b/include/daScript/misc/string_writer.h
@@ -68,6 +68,17 @@ namespace das {
     class TextWriter : public StringWriter {
     public:
         TextWriter() {}
+
+        /*
+         * Copy and move constructors are not supported
+         * This helps prevent issues with `largeBuffer` ownership
+         * and keeps the code cleaner and simpler
+         */
+        TextWriter(const TextWriter&) = delete;
+        TextWriter(TextWriter&&) = delete;
+        TextWriter& operator=(const TextWriter&) = delete;
+        TextWriter& operator=(TextWriter&&) = delete;
+
         virtual ~TextWriter();
         virtual string str() const override;
         virtual uint64_t tellp() const override;

--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -3959,7 +3959,7 @@ namespace das {
                 writeAotFooter();
 
                 nameToOutput[mod->name] = ss.str();
-                ss = std::move(TextWriter{}); // clear the stream
+                ss.clear(); // clear the stream
                 return true;
             }, "*");
 


### PR DESCRIPTION
It's unclear how they should operate, which makes it easy to introduce bugs