### PR TITLE
Add macros for simplified bindings and auto stub generation

### DIFF
--- a/src/builtin/module_builtin_uriparser.cpp
+++ b/src/builtin/module_builtin_uriparser.cpp
@@ -5,6 +5,7 @@
 #include "daScript/simulate/aot_builtin_string.h"
 #include "daScript/simulate/aot_builtin_uriparser.h"
 
+#include "daScript/daScriptBind.h"
 #include "daScript/ast/ast.h"
 #include "daScript/ast/ast_interop.h"
 #include "daScript/ast/ast_handle.h"
@@ -187,21 +188,21 @@ struct UriTextRangeAAnnotation : ManagedStructureAnnotation<UriTextRangeA> {
 
 struct UriIp4StructAnnotation : ManagedStructureAnnotation<UriIp4Struct> {
     UriIp4StructAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation<UriIp4Struct>("UriIp4Struct",ml) {
-        addField<DAS_BIND_MANAGED_FIELD(data)>("data");
+        DAS_ADD_FIELD_BIND(data);
     }
 };
 
 struct UriIp6StructAnnotation : ManagedStructureAnnotation<UriIp6Struct> {
     UriIp6StructAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation<UriIp6Struct>("UriIp6Struct",ml) {
-        addField<DAS_BIND_MANAGED_FIELD(data)>("data");
+        DAS_ADD_FIELD_BIND(data);
     }
 };
 
 struct UriHostDataAAnnotation : ManagedStructureAnnotation<UriHostDataA> {
     UriHostDataAAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation<UriHostDataA>("UriHostDataA",ml) {
-        addField<DAS_BIND_MANAGED_FIELD(ip4)>("ip4");
-        addField<DAS_BIND_MANAGED_FIELD(ip6)>("ip6");
-        addField<DAS_BIND_MANAGED_FIELD(ipFuture)>("ipFuture");
+        DAS_ADD_FIELD_BIND(ip4);
+        DAS_ADD_FIELD_BIND(ip6);
+        DAS_ADD_FIELD_BIND(ipFuture);
     }
 };
 
@@ -209,33 +210,33 @@ struct UriPathSegmentStructAAnnotation : ManagedStructureAnnotation<UriPathSegme
     UriPathSegmentStructAAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation<UriPathSegmentStructA>("UriPathSegmentStructA",ml) {
     }
     void init () {
-        addField<DAS_BIND_MANAGED_FIELD(text)>("text");
-        addField<DAS_BIND_MANAGED_FIELD(next)>("next");
+        DAS_ADD_FIELD_BIND(text);
+        DAS_ADD_FIELD_BIND(next);
     }
 };
 
 struct UriUriAAnnotation  : ManagedStructureAnnotation<UriUriA> {
     UriUriAAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation<UriUriA>("UriUriA",ml) {
-        addField<DAS_BIND_MANAGED_FIELD(scheme)>("scheme");
-        addField<DAS_BIND_MANAGED_FIELD(userInfo)>("userInfo");
-        addField<DAS_BIND_MANAGED_FIELD(hostText)>("hostText");
-        addField<DAS_BIND_MANAGED_FIELD(hostData)>("hostData");
-        addField<DAS_BIND_MANAGED_FIELD(portText)>("portText");
-        addField<DAS_BIND_MANAGED_FIELD(pathHead)>("pathHead");
-        addField<DAS_BIND_MANAGED_FIELD(pathTail)>("pathTail");
-        addField<DAS_BIND_MANAGED_FIELD(query)>("query");
-        addField<DAS_BIND_MANAGED_FIELD(fragment)>("fragment");
-        addField<DAS_BIND_MANAGED_FIELD(absolutePath)>("absolutePath");
-        addField<DAS_BIND_MANAGED_FIELD(owner)>("owner");
+        DAS_ADD_FIELD_BIND(scheme);
+        DAS_ADD_FIELD_BIND(userInfo);
+        DAS_ADD_FIELD_BIND(hostText);
+        DAS_ADD_FIELD_BIND(hostData);
+        DAS_ADD_FIELD_BIND(portText);
+        DAS_ADD_FIELD_BIND(pathHead);
+        DAS_ADD_FIELD_BIND(pathTail);
+        DAS_ADD_FIELD_BIND(query);
+        DAS_ADD_FIELD_BIND(fragment);
+        DAS_ADD_FIELD_BIND(absolutePath);
+        DAS_ADD_FIELD_BIND(owner);
     }
 };
 
 struct UriAnnotation  : ManagedStructureAnnotation<Uri> {
     UriAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation<Uri>("Uri",ml) {
-        addProperty<DAS_BIND_MANAGED_PROP(empty)>("empty");
-        addProperty<DAS_BIND_MANAGED_PROP(size)>("size");
-        addProperty<DAS_BIND_MANAGED_PROP(status)>("status");
-        addField<DAS_BIND_MANAGED_FIELD(uri)>("uri");
+        DAS_ADD_PROP_BIND("empty", empty);
+        DAS_ADD_PROP_BIND("size", size);
+        DAS_ADD_PROP_BIND("status", status);
+        DAS_ADD_FIELD_BIND(uri);
     }
     virtual bool canMove() const override { return true; }
 };
@@ -316,95 +317,37 @@ public:
         addAnnotation(make_smart<UriAnnotation>(lib));
         addCtorAndUsing<Uri>(*this,lib,"Uri","Uri");
         addCtorAndUsing<Uri,const char *>(*this,lib,"Uri","Uri");
-        addExtern<DAS_BIND_FUN(delete_uri)> (*this, lib, "finalize",
-            SideEffects::modifyArgument, "delete_uri")
-                ->args({"uri"});
-        addExtern<DAS_BIND_FUN(clone_uri)> (*this, lib, "clone",
-            SideEffects::modifyArgument, "clone_uri")
-                ->args({"dest","src"});
-        using strip_uri_method = DAS_CALL_MEMBER(das::Uri::strip);
-        addExtern<DAS_CALL_METHOD(strip_uri_method),SimNode_ExtFuncCallAndCopyOrMove>(*this, lib, "strip_uri",
-            SideEffects::none, DAS_CALL_MEMBER_CPP(das::Uri::strip))
-                ->args({"uri","query","fragment"});
-        using add_base_uri_method = DAS_CALL_MEMBER(das::Uri::addBaseUri);
-        addExtern<DAS_CALL_METHOD(add_base_uri_method),SimNode_ExtFuncCallAndCopyOrMove>(*this, lib, "add_base_uri",
-            SideEffects::none, DAS_CALL_MEMBER_CPP(das::Uri::addBaseUri))
-                ->args({"base","relative"});
-        using remove_base_uri_method = DAS_CALL_MEMBER(das::Uri::removeBaseUri);
-        addExtern<DAS_CALL_METHOD(remove_base_uri_method),SimNode_ExtFuncCallAndCopyOrMove>(*this, lib, "remove_base_uri",
-            SideEffects::none, DAS_CALL_MEMBER_CPP(das::Uri::BaseUri))
-                ->args({"base","relative"});
-        using normalize_method = DAS_CALL_MEMBER(das::Uri::normalize);
-        addExtern<DAS_CALL_METHOD(normalize_method)>(*this, lib, "normalize",
-            SideEffects::modifyArgument, DAS_CALL_MEMBER_CPP(das::Uri::normalize))
-                ->args({"uri"});
-        addExtern<DAS_BIND_FUN(uri_to_string)>(*this, lib, "string",
-            SideEffects::none, "uri_to_string")
-                ->args({"uri","context","at"});
-        addExtern<DAS_BIND_FUN(text_range_to_string)>(*this, lib, "string",
-            SideEffects::none, "text_range_to_string")
-                ->args({"range","context","at"});
-        addExtern<DAS_BIND_FUN(to_unix_file_name)>(*this, lib, "to_unix_file_name",
-            SideEffects::none, "to_unix_file_name")
-                ->args({"uri","context","at"});
-        addExtern<DAS_BIND_FUN(to_windows_file_name)>(*this, lib, "to_windows_file_name",
-            SideEffects::none, "to_windows_file_name")
-                ->args({"uri","context","at"});
-        addExtern<DAS_BIND_FUN(to_file_name)>(*this, lib, "to_file_name",
-            SideEffects::none, "to_file_name")
-                ->args({"uri","context","at"});
-        addExtern<DAS_BIND_FUN(from_file_name),SimNode_ExtFuncCallAndCopyOrMove>(*this, lib, "uri_from_file_name",
-            SideEffects::none, "from_file_name")
-                ->args({"filename"});
-        addExtern<DAS_BIND_FUN(from_windows_file_name),SimNode_ExtFuncCallAndCopyOrMove>(*this, lib, "uri_from_windows_file_name",
-            SideEffects::none, "from_windows_file_name")
-                ->args({"filename"});
-        addExtern<DAS_BIND_FUN(from_unix_file_name),SimNode_ExtFuncCallAndCopyOrMove>(*this, lib, "uri_from_unix_file_name",
-            SideEffects::none, "from_unix_file_name")
-                ->args({"filename"});
-        addExtern<DAS_BIND_FUN(uri_for_each_query_kv)>(*this, lib, "uri_for_each_query_kv",
-            SideEffects::invoke, "uri_for_each_query_kv")
-                ->args({"uri","block","context","lineinfo"});
+        DAS_ADD_FUN_BIND("finalize", modifyArgument, das::delete_uri)->args({"uri"});
+        DAS_ADD_FUN_BIND("clone", modifyArgument, das::clone_uri)->args({"dest","src"});
+        DAS_ADD_METHOD_BIND_VALUE_RET("strip_uri", none, das::Uri::strip)->args({"uri","query","fragment"});
+        DAS_ADD_METHOD_BIND_VALUE_RET("add_base_uri", none, das::Uri::addBaseUri)->args({"base","relative"});
+        DAS_ADD_METHOD_BIND_VALUE_RET("remove_base_uri", none, das::Uri::removeBaseUri)->args({"base","relative"});
+        DAS_ADD_METHOD_BIND("normalize", modifyArgument, das::Uri::normalize)->args({"uri"});
+        DAS_ADD_FUN_BIND("string", none, das::uri_to_string)->args({"uri","context","at"});
+        DAS_ADD_FUN_BIND("string", none, das::text_range_to_string)->args({"range","context","at"});
+        DAS_ADD_FUN_BIND("to_unix_file_name", none, das::to_unix_file_name)->args({"uri","context","at"});
+        DAS_ADD_FUN_BIND("to_windows_file_name", none, das::to_windows_file_name)->args({"uri","context","at"});
+        DAS_ADD_FUN_BIND("to_file_name", none, das::to_file_name)->args({"uri","context","at"});
+        DAS_ADD_FUN_BIND_VALUE_RET("uri_from_file_name", none, das::from_file_name)->args({"filename"});
+        DAS_ADD_FUN_BIND_VALUE_RET("uri_from_windows_file_name", none, das::from_windows_file_name)->args({"filename"});
+        DAS_ADD_FUN_BIND_VALUE_RET("uri_from_unix_file_name", none, das::from_unix_file_name)->args({"filename"});
+        DAS_ADD_FUN_BIND("uri_for_each_query_kv", invoke, das::uri_for_each_query_kv)->args({"uri","block","context","lineinfo"});
         // guid
-        addExtern<DAS_BIND_FUN(makeNewGuid)> (*this, lib, "make_new_guid",
-            SideEffects::accessExternal, "makeNewGuid")
-                ->args({"context","at"});
-        addExtern<DAS_BIND_FUN(uri_to_unix_file_name)> (*this, lib, "uri_to_unix_file_name",
-            SideEffects::none, "uri_to_unix_file_name")
-                ->args({"uriStr","context","at"});
-        addExtern<DAS_BIND_FUN(uri_to_windows_file_name)> (*this, lib, "uri_to_windows_file_name",
-            SideEffects::none, "uri_to_windows_file_name")
-                ->args({"uriStr","context","at"});
-        addExtern<DAS_BIND_FUN(unix_file_name_to_uri)> (*this, lib, "unix_file_name_to_uri",
-            SideEffects::none, "unix_file_name_to_uri")
-                ->args({"uriStr","context","at"});
-        addExtern<DAS_BIND_FUN(windows_file_name_to_uri)> (*this, lib, "windows_file_name_to_uri",
-            SideEffects::none, "windows_file_name_to_uri")
-                ->args({"uriStr","context","at"});
+        DAS_ADD_FUN_BIND("make_new_guid", accessExternal, das::makeNewGuid)->args({"context","at"});
+        DAS_ADD_FUN_BIND("uri_to_unix_file_name", none, das::uri_to_unix_file_name)->args({"uriStr","context","at"});
+        DAS_ADD_FUN_BIND("uri_to_windows_file_name", none, das::uri_to_windows_file_name)->args({"uriStr","context","at"});
+        DAS_ADD_FUN_BIND("unix_file_name_to_uri", none, das::unix_file_name_to_uri)->args({"uriStr","context","at"});
+        DAS_ADD_FUN_BIND("windows_file_name_to_uri", none, das::windows_file_name_to_uri)->args({"uriStr","context","at"});
 #ifdef _WIN32
-        addExtern<DAS_BIND_FUN(uri_to_windows_file_name)> (*this, lib, "uri_to_file_name",
-            SideEffects::none, "uri_to_windows_file_name")
-                ->args({"uriStr","context","at"});
-        addExtern<DAS_BIND_FUN(windows_file_name_to_uri)> (*this, lib, "file_name_to_uri",
-            SideEffects::none, "windows_file_name_to_uri")
-                ->args({"uriStr","context","at"});
+        DAS_ADD_FUN_BIND("uri_to_file_name", none, das::uri_to_windows_file_name)->args({"uriStr","context","at"});
+        DAS_ADD_FUN_BIND("file_name_to_uri", none, das::windows_file_name_to_uri)->args({"uriStr","context","at"});
 #else
-        addExtern<DAS_BIND_FUN(uri_to_unix_file_name)> (*this, lib, "uri_to_file_name",
-            SideEffects::none, "uri_to_unix_file_name")
-                ->args({"uriStr","context","at"});
-        addExtern<DAS_BIND_FUN(unix_file_name_to_uri)> (*this, lib, "file_name_to_uri",
-            SideEffects::none, "unix_file_name_to_uri")
-                ->args({"uriStr","context","at"});
+        DAS_ADD_FUN_BIND("uri_to_file_name", none, das::uri_to_unix_file_name)->args({"uriStr","context","at"});
+        DAS_ADD_FUN_BIND("file_name_to_uri", none, das::unix_file_name_to_uri)->args({"uriStr","context","at"});
 #endif
-        addExtern<DAS_BIND_FUN(escape_uri)> (*this, lib, "escape_uri",
-            SideEffects::none, "escape_uri")
-                ->args({"uriStr","spaceToPlus","normalizeBreaks","context","at"});
-        addExtern<DAS_BIND_FUN(unescape_uri)> (*this, lib, "unescape_uri",
-            SideEffects::none, "unescape_uri")
-                ->args({"uriStr","context","at"});
-        addExtern<DAS_BIND_FUN(normalize_uri)> (*this, lib, "normalize_uri",
-            SideEffects::none, "normalize_uri")
-                ->args({"uriStr","context","at"});
+        DAS_ADD_FUN_BIND("escape_uri", none, das::escape_uri)->args({"uriStr","spaceToPlus","normalizeBreaks","context","at"});
+        DAS_ADD_FUN_BIND("unescape_uri", none, das::unescape_uri)->args({"uriStr","context","at"});
+        DAS_ADD_FUN_BIND("normalize_uri", none, das::normalize_uri)->args({"uriStr","context","at"});
     }
     virtual ModuleAotType aotRequire ( TextWriter & tw ) const override {
         tw << "#include \"daScript/simulate/aot_builtin_uriparser.h\"\n";


### PR DESCRIPTION
These macros cover most of the cases, when binding CPP functions and classes. They also don't require this functions to be linked, when building AOT compiler, only function declarations are required in this case, and stubs are generated and bound

In this commit:
- include/daScript/daScriptBind.h contains all new macros and instructions on how to use it
- module_builtin_uriparser.cpp is refactored as an example usage of some of new macros