### PR TITLE
formatter: fix spaces around <> after 'block'

### DIFF
--- a/daslib/das_source_formatter.das
+++ b/daslib/das_source_formatter.das
@@ -26,7 +26,7 @@ let dont_need_space_around <- fixed_array("(", ")", "[", "]", "\{", "\}",
 let type_after_keyword <- fixed_array("generator", "cast", "upcast", "smart_ptr", "match_type",
     "type", "reinterpret", "variant", "variant_index", "function", "has_field", "default",
     "array", "fixed_array", "table", "iterator", "tuple", "struct_get_annotation_argument",
-    "struct_has_annotation_argument", "class"
+    "struct_has_annotation_argument", "class", "block"
     )
 
 enum TokenType {


### PR DESCRIPTION
fix this case:
  def f(x : block<() : bool>)