### PR TITLE
match error reporting to be sane

### DIFF
--- a/daslib/match.das
+++ b/daslib/match.das
@@ -620,7 +620,7 @@ class MatchMacro : AstCallMacro {
         macro_verify(length(expr.arguments) == 2, prog, expr.at, "expecting match(what) <| block")
         assume what = expr.arguments[0]
         assume blk = expr.arguments[1]
-        macro_verify(what._type != null && !what._type.isAutoOrAlias, prog, expr.at, "match `what` argument did not resolve")
+        macro_verify(what._type != null && !what._type.isAutoOrAlias, prog, what.at, "match argument {what.describe()} failed to compile")
         macro_verify(blk._type.isGoodBlockType, prog, expr.at, "match `block` argument did not resolve")
         macro_verify(blk is ExprMakeBlock, prog, expr.at, "match `block` argument must be immediate block declaration")
         var eblk = ((blk as ExprMakeBlock)._block as ExprBlock)

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -7624,15 +7624,10 @@ namespace das {
         }
     // ExprCallMacro
         virtual void preVisit ( ExprCallMacro * expr ) override {
-            auto errc = ctx.thisProgram->errors.size();
             auto thisModule = ctx.thisProgram->thisModule.get();
             expr->inFunction = func.get();
             canFoldResult = expr->macro->canFoldReturnResult(expr) && canFoldResult;
-            expr->macro->preVisit(ctx.thisProgram, thisModule, expr);
-            if ( errc==ctx.thisProgram->errors.size() ) {
-                error("unsupported call macro " + expr->macro->name + "", "potentially missing require", "",
-                    expr->at, CompilationError::unsupported_call_macro);
-            }
+            expr->macro->preVisit(ctx.thisProgram, thisModule, expr); // pre-visit is allowed to do nothing and not report errors.
             return Visitor::preVisit(expr);
         }
         virtual ExpressionPtr visit ( ExprCallMacro * expr ) override {
@@ -7643,8 +7638,8 @@ namespace das {
                 reportAstChanged();
                 return substitute;
             }
-            if ( errc==ctx.thisProgram->errors.size() ) {
-                error("unsupported call macro " + expr->macro->name,  "", "",
+            if ( errc==ctx.thisProgram->errors.size() ) {   // this fail safe adds error if macro failed, but did not report any errors
+                error("call macro '" + expr->macro->name + "' failed to compile",  "possibly missing require", "",
                     expr->at, CompilationError::unsupported_call_macro);
             }
             return Visitor::visit(expr);

--- a/tests/decs/failed_test_arguments.das
+++ b/tests/decs/failed_test_arguments.das
@@ -1,4 +1,4 @@
-expect 33101:4, 40104:4, 30103:2
+expect 40104:4, 30103:2
 
 options persistent_heap = true
 options gc


### PR DESCRIPTION
```
error[40104]: match argument a.foo failed to compile
D:\Work\daScript/examples/test/misc/hello_world.das:10:11
    match a.foo
           ^
```