### PR TITLE
Stub constructor/using and vector functions if required

### DIFF
--- a/include/daScript/ast/ast_interop.h
+++ b/include/daScript/ast/ast_interop.h
@@ -132,7 +132,8 @@ namespace das
         }
         const char * fnName = nullptr;
         static void placementNewFunc ( CType * cmres, Args... args ) {
-            new (cmres) CType(args...);
+            if constexpr (!das::is_stub_type<CType>::value) new (cmres) CType(args...);
+            else { DAS_ASSERTF(false, "STUB!"); }
         }
         virtual void * getBuiltinAddress() const override { return (void *) &placementNewFunc; }
     };
@@ -160,10 +161,17 @@ namespace das
             return context.code->makeNode<SimNode_Using<CType,Args...>>(at);
         }
         static void usingFunc ( Args... args, TBlock<void,TTemporary<TExplicit<CType>>> && block, Context * context, LineInfo * at ) {
-            CType value(args...);
-            vec4f bargs[1];
-            bargs[0] = cast<CType *>::from(&value);
-            context->invoke(block,bargs,nullptr,at);
+            if constexpr (!is_stub_type<CType>::value)
+            {
+                CType value(args...);
+                vec4f bargs[1];
+                bargs[0] = cast<CType *>::from(&value);
+                context->invoke(block, bargs, nullptr, at);
+            }
+            else
+            {
+                DAS_ASSERTF(false, "STUB!");
+            }
         }
         virtual void * getBuiltinAddress() const override { return (void *) &usingFunc; }
     };

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -45,6 +45,12 @@ namespace das {
     void das_trycatch(callable<void()> tryBody, callable<void(const char * msg)> catchBody);
 #endif
 
+    template <typename>
+    struct is_stub_type
+    {
+      static constexpr bool value = false;
+    };
+
     template <typename TT>
     struct das_auto_cast {
         template <typename QQ>
@@ -2675,7 +2681,8 @@ namespace das {
         if ( uint32_t(at)>vec.size() ) {
             context->throw_error_ex("insert index out of range, %i of %u", at, uint32_t(vec.size()));
         }
-        vec.insert(vec.begin() + at, value);
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.insert(vec.begin() + at, value);
     }
 
     template <typename TT, typename QQ = typename TT::value_type>
@@ -2683,72 +2690,84 @@ namespace das {
         if ( uint32_t(at)>vec.size() ) {
             context->throw_error_ex("insert index out of range, %i of %u", at, uint32_t(vec.size()));
         }
-        vec.insert(vec.begin() + at, value);
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.insert(vec.begin() + at, value);
     }
 
-    template <typename TT>
+    template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_push_empty ( TT & vec, int32_t at, Context * context ) {
         if ( uint32_t(at)>vec.size() ) {
             context->throw_error_ex("insert index out of range, %i of %u", at, uint32_t(vec.size()));
         }
-        vec.emplace(vec.begin() + at);
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.emplace(vec.begin() + at);
     }
 
     template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_emplace ( TT & vec, QQ & value, int32_t at ) {
-        vec.emplace(vec.begin()+at, das::move(value));
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.emplace(vec.begin()+at, das::move(value));
     }
 
     template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_push_back ( TT & vec, const QQ & value ) {
-        vec.push_back(value);
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.push_back(value);
     }
 
     template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_push_back_value ( TT & vec, QQ value ) {
-        vec.push_back(value);
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.push_back(value);
     }
 
-    template <typename TT>
+    template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_push_back_empty ( TT & vec ) {
-        vec.emplace_back();
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.emplace_back();
     }
 
     template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_emplace_back ( TT & vec, QQ & value ) {
-        vec.emplace_back(das::move(value));
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.emplace_back(das::move(value));
     }
 
-    template <typename TT>
+    template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_pop ( TT & vec ) {
-        vec.pop_back();
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.pop_back();
     }
 
-    template <typename TT>
+    template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_clear ( TT & vec ) {
-        vec.clear();
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.clear();
     }
 
-    template <typename TT>
+    template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_resize ( TT & vec, int32_t newSize ) {
-        vec.resize(newSize);
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.resize(newSize);
     }
 
-    template <typename TT>
+    template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_erase ( TT & vec, int32_t index, Context * context ) {
         if ( uint32_t(index)>vec.size() ) {
             context->throw_error_ex("erasing vector index out of range %i of %i", index, int32_t(vec.size()));
         }
-        vec.erase(vec.begin() + index);
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.erase(vec.begin() + index);
     }
 
-    template <typename TT>
+    template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_erase_range ( TT & vec, int32_t index, int32_t count, Context * context ) {
         if ( index < 0 || count < 0 || uint32_t(index + count) > uint32_t(vec.size()) ) {
             context->throw_error_ex(
                 "erasing vector range is invalid: index=%i count=%i size=%i", index, count, int32_t(vec.size()));
         }
-        vec.erase(vec.begin() + index, vec.begin() + index + count);
+        if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
+        else vec.erase(vec.begin() + index, vec.begin() + index + count);
     }
 
     template <typename TT>


### PR DESCRIPTION
This commit enables automatic stubbing for addCtor/addCtorAndUsing and vector function bindings. It is also can be generalized for something else

- Added das::is_stub_type templated structure, that is meant to be used, to signal, if functions, related to the type, should be stubbed
- BuiltIn_PlacementNew, BuiltIn_Using for stubbed types will be stubbed
- das::das_vector_* functions for stubbed item types will be stubbed
- For types, bound with DAS_DECL_TYPE, specialize das::is_stub_type to be true in AOT compiler