### PR TITLE
Constructor/using bind fixes and improvements

### DIFF
--- a/include/daScript/ast/ast_interop.h
+++ b/include/daScript/ast/ast_interop.h
@@ -132,6 +132,8 @@ namespace das
         }
         const char * fnName = nullptr;
         static void placementNewFunc ( CType * cmres, Args... args ) {
+            (void)cmres;
+            ((void)args, ...);
             if constexpr (!das::is_stub_type<CType>::value) new (cmres) CType(args...);
             else { DAS_ASSERTF(false, "STUB!"); }
         }
@@ -161,6 +163,10 @@ namespace das
             return context.code->makeNode<SimNode_Using<CType,Args...>>(at);
         }
         static void usingFunc ( Args... args, TBlock<void,TTemporary<TExplicit<CType>>> && block, Context * context, LineInfo * at ) {
+            ((void)args, ...);
+            (void)block;
+            (void)context;
+            (void)at;
             if constexpr (!is_stub_type<CType>::value)
             {
                 CType value(args...);

--- a/include/daScript/daScriptBind.h
+++ b/include/daScript/daScriptBind.h
@@ -233,6 +233,10 @@ struct CallPropertyStubImpl
 #endif
 
 #undef DAS_STUB_IMPL
+
+template <typename ClassT, typename...>
+using ResolveCtorAot = ClassT;
+
 } // namespace das::detail
 
 
@@ -308,6 +312,16 @@ struct das::CallPropertyForType<ThisT, RetT (*)(ClassT &), Fn>
   DAS_ADD_METHOD_BIND_VALUE_RET(NAME, SIDE_EFFECTS_NON_CONST, DAS_METHOD_OVERLOAD_NON_CONST(__VA_ARGS__))
 #define DAS_ADD_METHOD_BIND_CONST_VALUE_RET(NAME, SIDE_EFFECTS, ...) \
   DAS_ADD_METHOD_BIND_CONST_VALUE_RET_EX(NAME, SIDE_EFFECTS, SIDE_EFFECTS, __VA_ARGS__)
+
+// ctor/using
+#define DAS_ADD_USING_BIND(...) das::addUsing<::__VA_ARGS__>(__VA_ARGS__, "::das::detail::ResolveCtorAot<::" #__VA_ARGS__ ">")
+#define DAS_ADD_CTOR_BIND_EX(NAME, ...) \
+  das::addCtor<::__VA_ARGS__>(*this, lib, NAME, "::das::detail::ResolveCtorAot<::" #__VA_ARGS__ ">")
+#define DAS_ADD_CTOR_BIND(...) DAS_ADD_CTOR_BIND_EX((das::typeName<das::detail::ResolveCtorAot<::__VA_ARGS__>>::name()), __VA_ARGS__)
+#define DAS_ADD_CTOR_AND_USING_BIND_EX(NAME, ...) \
+  das::addCtorAndUsing<::__VA_ARGS__>(*this, lib, NAME, "::das::detail::ResolveCtorAot<::" #__VA_ARGS__ ">")
+#define DAS_ADD_CTOR_AND_USING_BIND(...) \
+  DAS_ADD_CTOR_AND_USING_BIND_EX((das::typeName<das::detail::ResolveCtorAot<::__VA_ARGS__>>::name()), __VA_ARGS__)
 
 // type annotations
 #define DAS_TYPE_DECL_STUB(...)                               \

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -45,12 +45,6 @@ namespace das {
     void das_trycatch(callable<void()> tryBody, callable<void(const char * msg)> catchBody);
 #endif
 
-    template <typename>
-    struct is_stub_type
-    {
-      static constexpr bool value = false;
-    };
-
     template <typename TT>
     struct das_auto_cast {
         template <typename QQ>
@@ -2681,6 +2675,7 @@ namespace das {
         if ( uint32_t(at)>vec.size() ) {
             context->throw_error_ex("insert index out of range, %i of %u", at, uint32_t(vec.size()));
         }
+        (void)value;
         if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
         else vec.insert(vec.begin() + at, value);
     }
@@ -2690,6 +2685,7 @@ namespace das {
         if ( uint32_t(at)>vec.size() ) {
             context->throw_error_ex("insert index out of range, %i of %u", at, uint32_t(vec.size()));
         }
+        (void)value;
         if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
         else vec.insert(vec.begin() + at, value);
     }
@@ -2711,12 +2707,14 @@ namespace das {
 
     template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_push_back ( TT & vec, const QQ & value ) {
+        (void)value;
         if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
         else vec.push_back(value);
     }
 
     template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_push_back_value ( TT & vec, QQ value ) {
+        (void)value;
         if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
         else vec.push_back(value);
     }
@@ -2729,6 +2727,7 @@ namespace das {
 
     template <typename TT, typename QQ = typename TT::value_type>
     __forceinline void das_vector_emplace_back ( TT & vec, QQ & value ) {
+        (void)value;
         if constexpr (das::is_stub_type<QQ>::value) { DAS_ASSERTF(false, "STUB!"); }
         else vec.emplace_back(das::move(value));
     }


### PR DESCRIPTION
Follow up to PR #1549

1. Simulate nodes for new and using of stubbed types were not stubbed. Move declaration of das_is_stub to interop.h and add stubs for:
- SimNode_PlacementNew
- SimNode_Using
- ImplCallStaticFunctionAndCopy (if result type is stub)
2. Add (void) cast to parameters, that are not used due to `if constexpr (das::is_stub_type<...>)`, because MSVC does not consider the other branch of if constexpr for some reason, when emitting this warning
3. Add macros for constructor/using binding in daScriptBind.h. These avoid duplicating CPP name for constructor and addCtor/And/Using last parameter. It also sets constructor name to das::typeName for this type by default, but can be customized with _EX version of these macros: DAS_ADD_USING_BIND, DAS_ADD_CTOR_BIND[_EX], DAS_ADD_CTOR_AND_USING_BIND[_EX]
