### PR TITLE
Opt malloc

### DIFF
--- a/include/daScript/ast/ast_typedecl.h
+++ b/include/daScript/ast/ast_typedecl.h
@@ -232,6 +232,7 @@ namespace das {
         uint64_t getSemanticHash() const;
         uint64_t getSemanticHash(HashBuilder & hb) const;
         void getLookupHash(uint64_t & hash) const;
+        static void clone ( TypeDeclPtr & dest, const TypeDeclPtr & src );
     public:
         Type                    baseType = Type::tVoid;
         Structure *             structType = nullptr;

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -1806,7 +1806,7 @@ namespace das {
                         if ( eWT->isPointer() )
                         {
                             auto derefV = make_smart<ExprPtr2Ref>(expr->at, eW->with);
-                            derefV->type = eWT->firstType;
+                            derefV->type = make_smart<TypeDecl>(*eWT->firstType);
                             TypeDecl::applyAutoContracts(derefV->type,eWT->firstType);
                             derefV->type->ref = true;
                             derefV->type->constant |= eWT->constant;
@@ -2574,7 +2574,7 @@ namespace das {
             } else if ( c->baseType==Type::tBitfield ) {
                 auto cB = static_cast<ExprConstBitfield *>(c);
                 if ( cB->bitfieldType ) {
-                    c->type = make_smart<TypeDecl>(*cB->bitfieldType);
+                    TypeDecl::clone(c->type,cB->bitfieldType);
                     c->type->ref = false;
                 } else {
                     c->type = make_smart<TypeDecl>(Type::tBitfield);
@@ -2592,7 +2592,7 @@ namespace das {
                 }
             } else {
                 c->type = make_smart<TypeDecl>(c->baseType);
-                c->type->constant = isConstantType(c);;
+                c->type->constant = isConstantType(c);
             }
             return Visitor::visit(c);
         }
@@ -2685,7 +2685,7 @@ namespace das {
                 error("can only dereference value types, not a " + describeType(expr->subexpr->type),  "", "",
                     expr->at, CompilationError::invalid_type);
             } else {
-                expr->type = make_smart<TypeDecl>(*expr->subexpr->type);
+                TypeDecl::clone(expr->type,expr->subexpr->type);
                 expr->type->ref = false;
             }
             return Visitor::visit(expr);
@@ -2848,7 +2848,7 @@ namespace das {
                 error("can only dereference a pointer to something",  "", "",
                     expr->at, CompilationError::cant_dereference);
             } else {
-                expr->type = make_smart<TypeDecl>(*expr->subexpr->type->firstType);
+                TypeDecl::clone(expr->type,expr->subexpr->type->firstType);
                 expr->type->ref = true;
                 expr->type->constant |= expr->subexpr->type->constant;
                 propagateTempType(expr->subexpr->type, expr->type); // deref(Foo#?) is Foo#
@@ -2948,7 +2948,7 @@ namespace das {
                       + describeType(dvT),  "", "",
                     expr->at, CompilationError::cant_dereference);
             } else {
-                expr->type = make_smart<TypeDecl>(*seT->firstType);
+                TypeDecl::clone(expr->type,seT->firstType);
                 expr->type->constant |= expr->subexpr->type->constant | dvT->constant;
                 expr->type->ref = dvT->ref; // only ref if default value is ref
                 propagateTempType(expr->subexpr->type, expr->type); // t?# ?? def = #t
@@ -3038,7 +3038,7 @@ namespace das {
                 error("debug comment must be string constant",  "", "",
                     expr->at, CompilationError::invalid_argument_type);
             }
-            expr->type = make_smart<TypeDecl>(*expr->arguments[0]->type);
+            TypeDecl::clone(expr->type,expr->arguments[0]->type);
             return Visitor::visit(expr);
         }
     // ExprMemZero
@@ -3577,7 +3577,7 @@ namespace das {
                     expr->arguments[i+1] = Expression::autoDereference(expr->arguments[i+1]);
             }
             if ( blockT->firstType ) {
-                expr->type = make_smart<TypeDecl>(*blockT->firstType);
+                TypeDecl::clone(expr->type,blockT->firstType);
             } else {
                 expr->type = make_smart<TypeDecl>();
             }
@@ -3774,7 +3774,7 @@ namespace das {
             return Visitor::visit(expr);
         }
         verifyType(expr->typeexpr,true);
-        expr->type = make_smart<TypeDecl>(*expr->typeexpr);
+        TypeDecl::clone(expr->type,expr->typeexpr);
         return Visitor::visit(expr);
     }
 
@@ -4316,7 +4316,7 @@ namespace das {
                         } else {
                             auto ctype = expr->macro->getAstType(program->library, expr, errors);
                             if ( ctype ) {
-                                expr->type = ctype;
+                                TypeDecl::clone(expr->type,ctype);
                                 if ( func && expr->macro->noAot(expr) ) {
                                     func->noAot = true;
                                 }
@@ -4605,13 +4605,13 @@ namespace das {
                 return expr->subexpr;
             }
             if ( expr->reinterpret ) {
-                expr->type = make_smart<TypeDecl>(*expr->castType);
+                TypeDecl::clone(expr->type,expr->castType);
                 expr->type->ref = expr->subexpr->type->ref;
             } else if ( expr->castType->isGoodBlockType() ||  expr->castType->isGoodFunctionType() || expr->castType->isGoodLambdaType() ) {
                 expr->type = castFunc(expr->at, expr->subexpr->type, expr->castType, expr->upcast);
             } else if ( expr->castType->isHandle() ) {
                 if ( expr->castType->isSameType(*expr->subexpr->type, RefMatters::yes, ConstMatters::yes, TemporaryMatters::yes, AllowSubstitute::yes) ) {
-                    expr->type = make_smart<TypeDecl>(*expr->castType);
+                    TypeDecl::clone(expr->type,expr->castType);
                     expr->type->ref = expr->subexpr->type->ref;
                 } else {
                     expr->type = nullptr;
@@ -4674,7 +4674,7 @@ namespace das {
                 }
             }
             if ( expr->ascType ) {
-                expr->type = make_smart<TypeDecl>(*expr->ascType);
+                TypeDecl::clone(expr->type,expr->ascType);
             } else {
                 expr->type = make_smart<TypeDecl>(Type::tPointer);
                 expr->type->firstType = make_smart<TypeDecl>(*expr->subexpr->type);
@@ -4783,7 +4783,7 @@ namespace das {
                       expr->at, CompilationError::invalid_new_type);
             }
             if ( expr->type && expr->initializer && !expr->name.empty() ) {
-                auto resultType = expr->type;
+                auto resultType = make_smart<TypeDecl>(*expr->type);
                 expr->func = inferFunctionCall(expr, InferCallError::functionOrGeneric, nullptr, false).get();
                 if ( !expr->func && expr->typeexpr->baseType==Type::tStructure ) {
                     auto saveName = expr->name;
@@ -4855,7 +4855,7 @@ namespace das {
                     error("table index requires unsafe",  "use 'get_value', 'insert', 'insert_clone' or 'emplace' instead. consider 'get'", "",
                         expr->at, CompilationError::unsafe);
                 }
-                expr->type = make_smart<TypeDecl>(*seT->secondType);
+                TypeDecl::clone(expr->type,seT->secondType);
                 expr->type->ref = true;
                 expr->type->constant |= seT->constant;
             } else if ( seT->isHandle() ) {
@@ -4881,7 +4881,7 @@ namespace das {
                     return Visitor::visit(expr);
                 } else {
                     expr->subexpr = Expression::autoDereference(expr->subexpr);
-                    expr->type = make_smart<TypeDecl>(*seT->firstType);
+                    TypeDecl::clone(expr->type,seT->firstType);
                     expr->type->ref = true;
                     expr->type->constant |= seT->constant;
                 }
@@ -4903,7 +4903,7 @@ namespace das {
                     expr->type->ref = seT->ref;
                     expr->type->constant = seT->constant;
                 } else if ( seT->isGoodArrayType() ) {
-                    expr->type = make_smart<TypeDecl>(*seT->firstType);
+                    TypeDecl::clone(expr->type,seT->firstType);
                     expr->type->ref = true;
                     expr->type->constant |= seT->constant;
                 } else if ( !seT->dim.size() ) {
@@ -4915,7 +4915,7 @@ namespace das {
                         expr->subexpr->at, CompilationError::cant_index);
                     return Visitor::visit(expr);
                 } else {
-                    expr->type = make_smart<TypeDecl>(*seT);
+                    TypeDecl::clone(expr->type,seT);
                     expr->type->ref = true;
                     expr->type->dim.erase(expr->type->dim.begin());
                     if ( !expr->type->dimExpr.empty() ) {
@@ -5101,7 +5101,7 @@ namespace das {
             if ( block->isClosure ) {
                 if ( block->returnType ) {
                     blocks.push_back(block);
-                    block->type = make_smart<TypeDecl>(*block->returnType);
+                    TypeDecl::clone(block->type,block->returnType);
                 } else {
                     error("malformed AST, closure is missing return type",  "", "",
                         block->at, CompilationError::malformed_ast );
@@ -5345,7 +5345,7 @@ namespace das {
                 return Visitor::visit(expr);
             }
             expr->fieldIndex = index;
-            expr->type = make_smart<TypeDecl>(*valT->argTypes[expr->fieldIndex]);
+            TypeDecl::clone(expr->type,valT->argTypes[expr->fieldIndex]);
             expr->type->ref = true;
             expr->type->constant |= valT->constant;
             propagateTempType(expr->value->type, expr->type); // a# as foo = foo#
@@ -5398,7 +5398,7 @@ namespace das {
                 return Visitor::visit(expr);
             }
             expr->fieldIndex = index;
-            expr->type = make_smart<TypeDecl>(*valT->argTypes[expr->fieldIndex]);
+            TypeDecl::clone(expr->type,valT->argTypes[expr->fieldIndex]);
             expr->skipQQ = expr->type->isPointer();
             if ( !expr->skipQQ ) {
                 auto fieldType = expr->type;
@@ -5689,7 +5689,7 @@ namespace das {
             }
             // handle
             if ( expr->field ) {
-                expr->type = make_smart<TypeDecl>(*expr->field->type);
+                TypeDecl::clone(expr->type,expr->field->type);
                 expr->type->ref = true;
                 expr->type->constant |= valT->constant;
                 if ( valT->isPointer() && valT->firstType ) {
@@ -5703,7 +5703,7 @@ namespace das {
                     expr->type = make_smart<TypeDecl>(Type::tBool);
                 } else {
                     auto tupleT = valT->isPointer() ? valT->firstType : valT;
-                    expr->type = make_smart<TypeDecl>(*tupleT->argTypes[expr->fieldIndex]);
+                    TypeDecl::clone(expr->type,tupleT->argTypes[expr->fieldIndex]);
                     expr->type->ref = true;
                     expr->type->constant |= tupleT->constant;
                 }
@@ -5784,7 +5784,7 @@ namespace das {
                         expr->at, CompilationError::cant_get_field);
                     return Visitor::visit(expr);
                 }
-                expr->type = make_smart<TypeDecl>(*expr->field->type);
+                TypeDecl::clone(expr->type,expr->field->type);
             } else if ( valT->firstType->isHandle() ) {
                 expr->annotation = valT->firstType->annotation;
                 expr->type = expr->annotation->makeSafeFieldType(expr->name, valT->constant);
@@ -5801,7 +5801,7 @@ namespace das {
                     return Visitor::visit(expr);
                 }
                 expr->fieldIndex = index;
-                expr->type = make_smart<TypeDecl>(*valT->firstType->argTypes[expr->fieldIndex]);
+                TypeDecl::clone(expr->type,valT->firstType->argTypes[expr->fieldIndex]);
             } else {
                 error("can only safe dereference a pointer to a tuple, a structure or a handle " + describeType(valT), "", "",
                       expr->at, CompilationError::cant_get_field);
@@ -5869,7 +5869,7 @@ namespace das {
                 if ( var->name==expr->name || var->aka==expr->name ) {
                     expr->variable = var;
                     expr->local = true;
-                    expr->type = make_smart<TypeDecl>(*var->type);
+                    TypeDecl::clone(expr->type,var->type);
                     expr->type->ref = true;
                     var->used_in_finally = inFinally.empty() ? false : inFinally.back();
                     return Visitor::visit(expr);
@@ -5887,7 +5887,7 @@ namespace das {
                         if ( blocks.rbegin() == it ) {
                             expr->thisBlock = true;
                         }
-                        expr->type = make_smart<TypeDecl>(*arg->type);
+                        TypeDecl::clone(expr->type,arg->type);
                         if (!expr->type->isRefType())
                             expr->type->ref = true;
                         expr->type->sanitize();
@@ -5905,7 +5905,7 @@ namespace das {
                         expr->variable = arg;
                         expr->argumentIndex = argumentIndex;
                         expr->argument = true;
-                        expr->type = make_smart<TypeDecl>(*arg->type);
+                        TypeDecl::clone(expr->type,arg->type);
                         if (!expr->type->isRefType())
                             expr->type->ref = true;
                         expr->type->sanitize();
@@ -5944,7 +5944,7 @@ namespace das {
                     return Visitor::visit(expr);
                 }
                 expr->variable = var;
-                expr->type = make_smart<TypeDecl>(*var->type);
+                TypeDecl::clone(expr->type,var->type);
                 expr->type->ref = true;
                 return Visitor::visit(expr);
 
@@ -6047,10 +6047,10 @@ namespace das {
             }
             if ( expr->func ) {
                 if ( expr->func->firstArgReturnType ) {
-                    expr->type = make_smart<TypeDecl>(*expr->arguments[0]->type);
+                    TypeDecl::clone(expr->type,expr->arguments[0]->type);
                     expr->type->ref = false;
                 } else {
-                    expr->type = make_smart<TypeDecl>(*expr->func->result);
+                    TypeDecl::clone(expr->type,expr->func->result);
                 }
                 if ( !expr->func->arguments[0]->type->isRef() )
                     expr->subexpr = Expression::autoDereference(expr->subexpr);
@@ -6259,10 +6259,10 @@ namespace das {
             }
             if ( expr->func ) {
                 if ( expr->func->firstArgReturnType ) {
-                    expr->type = make_smart<TypeDecl>(*expr->arguments[0]->type);
+                    TypeDecl::clone(expr->type,expr->arguments[0]->type);
                     expr->type->ref = false;
                 } else {
-                    expr->type = make_smart<TypeDecl>(*expr->func->result);
+                    TypeDecl::clone(expr->type,expr->func->result);
                 }
                 if ( !expr->func->arguments[0]->type->isRef() )
                     expr->left = Expression::autoDereference(expr->left);
@@ -6309,7 +6309,7 @@ namespace das {
                     expr->left = Expression::autoDereference(expr->left);
                     expr->right = Expression::autoDereference(expr->right);
                 }
-                expr->type = make_smart<TypeDecl>(*expr->left->type);
+                TypeDecl::clone(expr->type,expr->left->type);
                 expr->type->constant |= expr->right->type->constant;
                 // lets try to fold it
                 if ( enableInferTimeFolding ) {
@@ -8397,10 +8397,10 @@ namespace das {
             if ( functions.size()==1 ) {
                 auto funcC = functions.back();
                 if ( funcC->firstArgReturnType ) {
-                    expr->type = make_smart<TypeDecl>(*expr->arguments[0]->type);
+                    TypeDecl::clone(expr->type, expr->arguments[0]->type);
                     expr->type->ref = false;
                 } else {
-                    expr->type = make_smart<TypeDecl>(*funcC->result);
+                    TypeDecl::clone(expr->type, funcC->result);
                 }
                 // infer FORWARD types
                 for ( size_t iF=0, iFs=expr->arguments.size(); iF!=iFs; ++iF ) {
@@ -9577,7 +9577,7 @@ namespace das {
                     }
                 }
             }
-            expr->type = make_smart<TypeDecl>(*expr->makeType);
+            TypeDecl::clone(expr->type,expr->makeType);
             verifyType(expr->type);
             if ( expr->isKeyValue ) {
                 auto keyType = expr->makeType->argTypes[0];

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -794,11 +794,10 @@ namespace das
             dest = nullptr;
             return;
         }
-        if ( !dest ) {
+        if ( !dest || dest->use_count()!=1 ) {
             dest = make_smart<TypeDecl>(*src);
             return;
         }
-        DAS_ASSERT(dest->use_count()==1);
         dest->baseType = src->baseType;
         dest->structType = src->structType;
         dest->enumType = src->enumType;

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -789,6 +789,42 @@ namespace das
         argNames = decl.argNames;
     }
 
+    void TypeDecl::clone ( TypeDeclPtr & dest, const TypeDeclPtr & src ) {
+        if ( src==nullptr ) {
+            dest = nullptr;
+            return;
+        }
+        if ( !dest ) {
+            dest = make_smart<TypeDecl>(*src);
+            return;
+        }
+        DAS_ASSERT(dest->use_count()==1);
+        dest->baseType = src->baseType;
+        dest->structType = src->structType;
+        dest->enumType = src->enumType;
+        dest->annotation = src->annotation;
+        dest->dim = src->dim;
+        dest->dimExpr.resize(src->dimExpr.size());
+        for ( size_t i=0; i!=src->dimExpr.size(); ++i ) {
+            if ( src->dimExpr[i] ) {
+                dest->dimExpr[i] = src->dimExpr[i]->clone();
+            } else {
+                dest->dimExpr[i] = nullptr;
+            }
+        }
+        dest->flags = src->flags;
+        dest->alias = src->alias;
+        dest->at = src->at;
+        dest->module = src->module;
+        clone(dest->firstType, src->firstType);
+        clone(dest->secondType, src->secondType);
+        dest->argTypes.resize(src->argTypes.size());
+        for ( size_t i=0; i!=src->argTypes.size(); ++i ) {
+            clone(dest->argTypes[i], src->argTypes[i]);
+        }
+        dest->argNames = src->argNames;
+    }
+
     TypeDecl * TypeDecl::findAlias ( const string & name, bool allowAuto ) {
         if (baseType == Type::alias) {
             return nullptr; // if it is another alias, can't find it


### PR DESCRIPTION
we can now always use
TypeDecl::clone ( a, b )
instead of
a = make_smart<TypeDecl>(*b)
in fact upcoming is full refactor like that