### PR TITLE
Custom unique hashes for functionsByName and function argument lookups

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -795,7 +795,7 @@ namespace das
           static_cast<std::underlying_type<SideEffects>::type>(rhs));
     }
 
-    typedef fragile_hash<bool> AstFuncLookup;
+    typedef fragile_bit_set AstFuncLookup;
 
     struct InferHistory {
         LineInfo    at;

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -795,7 +795,7 @@ namespace das
           static_cast<std::underlying_type<SideEffects>::type>(rhs));
     }
 
-    typedef safebox_map<bool> AstFuncLookup;
+    typedef fragile_hash<bool> AstFuncLookup;
 
     struct InferHistory {
         LineInfo    at;
@@ -1177,9 +1177,9 @@ namespace das
         safebox<Enumeration>                        enumerations;
         safebox<Variable>                           globals;
         safebox<Function>                           functions;          // mangled name 2 function name
-        safebox_map<vector<Function*>>              functionsByName;    // all functions of the same name
+        fragile_hash<vector<Function*>>             functionsByName;    // all functions of the same name
         safebox<Function>                           generics;           // mangled name 2 generic name
-        safebox_map<vector<Function*>>              genericsByName;     // all generics of the same name
+        fragile_hash<vector<Function*>>             genericsByName;     // all generics of the same name
         mutable das_map<string, ExprCallFactory>    callThis;
         das_map<string, TypeInfoMacroPtr>           typeInfoMacros;
         das_map<uint64_t, uint64_t>                 annotationData;

--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -397,7 +397,7 @@ inline size_t das_aligned_memsize(void * ptr){
     #endif
 #endif
 
-#ifdef DAS_SMART_PTR_DEBUG
+#if DAS_SMART_PTR_DEBUG==1
     #define DAS_SMART_PTR_TRACKER   1
     #define DAS_SMART_PTR_MAGIC     1
     #define DAS_SMART_PTR_ID        1

--- a/include/daScript/misc/safebox.h
+++ b/include/daScript/misc/safebox.h
@@ -4,6 +4,81 @@
 
 namespace das {
 
+    struct fragile_bit_set {    // key==hash, value = top bit of hash
+    public:
+        static constexpr uint64_t top_bit = 0x8000000000000000ull;
+        static constexpr uint64_t top_bit_mask = 0x7fffffffffffffffull;
+        static __forceinline uint64_t key ( uint64_t hash ) { return hash & top_bit_mask; } // up to user to call 'key'
+        static __forceinline uint64_t set_true ( uint64_t hash ) { return hash | top_bit; }
+        static __forceinline uint64_t set_false ( uint64_t hash ) { return hash & top_bit_mask; }
+        static __forceinline bool is_true ( uint64_t hash ) { return hash & top_bit; }
+    public:
+        fragile_bit_set() {
+            mask = 63;
+        }
+        ~fragile_bit_set() {
+            if ( objects ) delete [] objects;
+        }
+        void clear () {
+            if ( objects ) {
+                memset(objects,0,(mask+1)*sizeof(uint64_t));
+                occupancy = 0;
+            }
+        }
+        __forceinline uint64_t *  find_and_reserve ( uint64_t key ) { // its up to user to write both hash and value
+            if ( !objects ) allocate();
+            uint64_t index = key & mask;
+            for ( ;; ) {
+                auto hash = objects[index];
+                if ( hash==0 ) {
+                    occupancy ++;
+                    if ( occupancy*2 > mask ) {
+                        rehash(mask*2 + 1);
+                        index = key & mask;
+                        continue;
+                    }
+                    return objects + index;
+                } else if ( (hash & top_bit_mask)==key ) {
+                    return objects + index;
+                }
+                index = (index + 1) & mask;
+            }
+            return nullptr;
+        }
+    protected:
+        void allocate() {
+            objects = new uint64_t[mask+1];
+            memset(objects,0,(mask+1)*sizeof(uint64_t));
+        }
+        void rehash ( uint32_t newMask ) {
+            auto old_objects = objects;
+            auto old_mask = mask;
+            mask = newMask;
+            allocate();
+            if ( old_objects ) {
+                for ( uint32_t i=0; i<=old_mask; ++i ) {
+                    if ( auto hash = old_objects[i] ) {
+                        uint32_t index = hash & mask;
+                        for ( ;; ) {
+                            auto & new_kv = objects[index];
+                            if ( new_kv == 0 ) {
+                                new_kv = hash;
+                                break;
+                            }
+                            index = (index + 1) & mask;
+                        }
+                    }
+                }
+                delete [] old_objects;
+            }
+        }
+    protected:
+        uint64_t *  objects = nullptr;
+        uint32_t    mask = 0;
+        uint32_t    occupancy = 0;
+    };
+
+
     template <typename ValueType>
     struct fragile_hash {    // key==hash, no delete, lookup only
     public:
@@ -19,9 +94,6 @@ namespace das {
         ~fragile_hash() {
             if ( objects ) delete [] objects;
         }
-        void allocate() {
-            objects = new KV[mask+1];
-        }
         void clear () {
             if ( objects ) {
                 // i really don't care if we delete or not, as long as we delete at shutdown  of the table
@@ -31,34 +103,13 @@ namespace das {
                 occupancy = 0;
             }
         }
-        __forceinline KV * find ( uint64_t key ) const { // its up to user to write both hash and value
+        __forceinline KV * find ( uint64_t key ) const {
             if ( !objects ) return nullptr;
             uint64_t index = key & mask;
             for ( ;; ) {
                 auto hash = objects[index].hash;
                 if ( hash==0 ) {
                     return nullptr;
-                } else if ( hash==key ) {
-                    return objects + index;
-                }
-                index = (index + 1) & mask;
-            }
-            return nullptr;
-        }
-
-        __forceinline KV *  find_and_reserve ( uint64_t key ) { // its up to user to write both hash and value
-            if ( !objects ) allocate();
-            uint64_t index = key & mask;
-            for ( ;; ) {
-                auto hash = objects[index].hash;
-                if ( hash==0 ) {
-                    occupancy ++;
-                    if ( occupancy*2 > mask ) {
-                        rehash(mask*2 + 1);
-                        index = key & mask;
-                        continue;
-                    }
-                    return objects + index;
                 } else if ( hash==key ) {
                     return objects + index;
                 }
@@ -111,6 +162,9 @@ namespace das {
             return mask + 1;
         }
     protected:
+        void allocate() {
+            objects = new KV[mask+1];
+        }
         void rehash ( uint32_t newMask ) {
             auto old_objects = objects;
             auto old_mask = mask;

--- a/include/daScript/misc/safebox.h
+++ b/include/daScript/misc/safebox.h
@@ -31,12 +31,12 @@ namespace das {
             for ( ;; ) {
                 auto hash = objects[index];
                 if ( hash==0 ) {
-                    occupancy ++;
                     if ( occupancy*2 > mask ) {
                         rehash(mask*2 + 1);
                         index = key & mask;
                         continue;
                     }
+                    occupancy ++;
                     return objects + index;
                 } else if ( (hash & top_bit_mask)==key ) {
                     return objects + index;
@@ -123,12 +123,12 @@ namespace das {
             for ( ;; ) {
                 auto hash = objects[index].hash;
                 if ( hash==0 ) {
-                    occupancy ++;
                     if ( occupancy*2 > mask ) {
                         rehash(mask*2 + 1);
                         index = key & mask;
                         continue;
                     }
+                    occupancy ++;
                     objects[index].hash = key;
                     return objects[index].second;
                 } else if ( hash==key ) {

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -1267,20 +1267,20 @@ namespace das {
                             if ( !pFn->fromGeneric || thisModule->isVisibleDirectly(mod) ) {
                                 if ( canCallPrivate(pFn,inWhichModule,thisModule) ) {
                                     if ( !argHash ) {
-                                        argHash = getLookupHash(types);
+                                        argHash = fragile_bit_set::key(getLookupHash(types));
                                     }
                                     auto itLook = pFn->lookup.find_and_reserve(argHash);    // if found in lookup
-                                    if ( itLook->found() ) {
-                                        if ( itLook->second ) {
+                                    if ( *itLook ) {
+                                        if ( fragile_bit_set::is_true(*itLook) ) {
                                             result.push_back(pFn);
                                         }
                                         continue;
                                     }
                                     if ( isFunctionCompatible(pFn, types, false, inferBlock) ) {
                                         result.push_back(pFn);
-                                        *itLook = { argHash, true };
+                                        *itLook = fragile_bit_set::set_true(argHash);
                                     } else {
-                                        *itLook = { argHash, false };
+                                        *itLook = fragile_bit_set::set_false(argHash);
                                     }
                                 }
                             }
@@ -1344,7 +1344,7 @@ namespace das {
             auto inWhichModule = getSearchModule(moduleName);
             auto thisModule = program->thisModule.get();
             auto hFuncName = hash64z(funcName.c_str());
-            uint64_t argHash = getLookupHash(types);
+            uint64_t argHash = fragile_bit_set::key(getLookupHash(types));
             program->library.foreach([&](Module * mod) -> bool {
                 { // functions
                     auto itFnList = mod->functionsByName.find(hFuncName);
@@ -1357,17 +1357,17 @@ namespace das {
                                 if ( !pFn->fromGeneric || thisModule->isVisibleDirectly(mod) ) {
                                     if ( canCallPrivate(pFn,inWhichModule,thisModule) ) {
                                         auto itLook = pFn->lookup.find_and_reserve(argHash);    // if found in lookup
-                                        if ( itLook->found() ) {
-                                            if ( itLook->second ) {
+                                        if ( *itLook ) {
+                                            if ( fragile_bit_set::is_true(*itLook) ) {
                                                 resultFunctions.push_back(pFn);
                                             }
                                             continue;
                                         }
                                         if ( isFunctionCompatible(pFn, types, false, inferBlock) ) {
                                             resultFunctions.push_back(pFn);
-                                            *itLook = { argHash, true };
+                                            *itLook = fragile_bit_set::set_true(argHash);
                                         } else {
-                                            *itLook = { argHash, false };
+                                            *itLook = fragile_bit_set::set_false(argHash);
                                         }
                                     }
                                 }
@@ -1384,17 +1384,17 @@ namespace das {
                             if ( isVisibleFunc(inWhichModule,getFunctionVisModule(pFn)) ) {
                                 if ( canCallPrivate(pFn,inWhichModule,thisModule) ) {
                                     auto itLook = pFn->lookup.find_and_reserve(argHash);    // if found in lookup
-                                    if ( itLook->found() ) {
-                                        if ( itLook->second ) {
+                                    if ( *itLook ) {
+                                        if ( fragile_bit_set::is_true(*itLook) ) {
                                             resultGenerics.push_back(pFn);
                                         }
                                         continue;
                                     }
                                     if ( isFunctionCompatible(pFn, types, true, true) ) {   // infer block here?
                                         resultGenerics.push_back(pFn);
-                                        *itLook = { argHash, true };
+                                        *itLook = fragile_bit_set::set_true(argHash);
                                     } else {
-                                        *itLook = { argHash, false };
+                                        *itLook = fragile_bit_set::set_false(argHash);
                                     }
                                 }
                             }

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -2524,7 +2524,11 @@ namespace das {
     // any expression
         virtual void preVisitExpression ( Expression * expr ) override {
             Visitor::preVisitExpression(expr);
-            expr->type.reset();
+            // WARNING - this is potentially dangerous. In theory type should be set to nada, and then re-inferred
+            // the reason not to reset it is that usually once inferred it should not change. but in some cases it can.
+            // even more rare is that it changed, and then no longer can be inferred. all those cases are pathological
+            // and should be avoided. but if you see a bug, this is the first place to look.
+            // expr->type.reset();
         }
     // const
         vec4f getEnumerationValue( ExprConstEnumeration * expr, bool & inferred ) const {

--- a/src/ast/ast_module.cpp
+++ b/src/ast/ast_module.cpp
@@ -518,7 +518,7 @@ namespace das {
 
     FunctionPtr Module::findUniqueFunction ( const string & mangledName ) const {
         auto it = functionsByName.find(hash64z(mangledName.c_str()));
-        if ( it==functionsByName.end() ) return nullptr;
+        if ( !it ) return nullptr;
         if ( it->second.size()!=1 ) return nullptr;
         return it->second[0];
     }


### PR DESCRIPTION
fragile caches are used. they are faster due to not storing key, only hash of key, and assuming its unique. we already do that for functionsByName, so its only a real change for function lookups.