### PR TITLE
minor bugfix for is_subclass_of type trait

### DIFF
--- a/daslib/type_traits.das
+++ b/daslib/type_traits.das
@@ -67,6 +67,8 @@ class IsSubclassOf : AstCallMacro {
     //! Converts to 'true' if the first type is a subclass of the second type.
     def override visit(prog : ProgramPtr; mod : Module?; var call : smart_ptr<ExprCallMacro>) : ExpressionPtr {
         macro_verify(call.arguments |> length == 2, prog, call.at, "expecting is_subclass_of(classptr,typeexpr)")
+        macro_verify(call.arguments[0]._type != null, prog, call.at, "expecting is_subclass_of(classptr,typeexpr), classptr type is missing")
+        macro_verify(call.arguments[1]._type != null, prog, call.at, "expecting is_subclass_of(classptr,typeexpr), typeexpr type is missing")
         assume classType = call.arguments[0]._type
         if (!(classType.isStructure && classType.structType.flags.isClass)) {
             macro_error(prog, call.at, "expecting is_subclass_of(class,...)")


### PR DESCRIPTION
Here is the example
```
options gen2;

require daslib/type_traits;

class Base {
}

class B : Base {
}

class C : Base {

}

class D {}

def someThing ( blk : block < ( arg : auto(TT) ) : void > ) {
    static_if ( typeinfo is_class(type<TT>) ) {
        static_if ( is_subclass_of(type<TT>, type<Base>) ) {
            print("arg is {typeinfo typename(type<TT>)}\n")
        } else {
            concept_assert(false, "{typeinfo typename(type<TT>)} is not subclass of Base");
        }
    } else {
        concept_assert(false,"{typeinfo typename(type<TT>)} is not a class at all")
    }
}

[export]
def main {
    someThing($(arg:B){
    });
    someThing($(arg:C){
    });
    someThing($(arg:D){ // fails to compile with error "D const is not a subclass of Base"
    });
    someThing($(arg:int){ // fails to compile with error "int const is not a class at all"
    });
}
```