### PR TITLE
proof of concept, more detailed runtime error messages

### DIFF
--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -125,6 +125,7 @@ namespace das
         virtual bool rtti_node_isJit() const { return false; }
         virtual bool rtti_node_isKeepAlive() const { return false; }
         virtual bool rtti_node_isCallBase() const { return false; }
+        virtual bool rtti_node_isErrorMessage() const { return false; }
     protected:
         virtual ~SimNode() {}
     };

--- a/include/daScript/simulate/simulate_fusion.h
+++ b/include/daScript/simulate/simulate_fusion.h
@@ -35,8 +35,8 @@ namespace das {
 
     const char * getSimSourceName(SimSourceType st);
 
-    struct SimNode_Op1Fusion : SimNode {
-        SimNode_Op1Fusion() : SimNode(LineInfo()) {}
+    struct SimNode_Op1Fusion : SimNode_WithErrorMessage {
+        SimNode_Op1Fusion(const char * msg = nullptr) : SimNode_WithErrorMessage(LineInfo(),msg) {}
         void set(const char * opn, Type bt, const LineInfo & at) {
             op = opn;
             baseType = bt;
@@ -48,8 +48,8 @@ namespace das {
         SimSource       subexpr;
     };
 
-    struct SimNode_Op2Fusion : SimNode {
-        SimNode_Op2Fusion() : SimNode(LineInfo()) {}
+    struct SimNode_Op2Fusion : SimNode_WithErrorMessage {
+        SimNode_Op2Fusion(const char * msg = nullptr) : SimNode_WithErrorMessage(LineInfo(),msg) {}
         void set(const char * opn, Type bt, const LineInfo & at) {
             op = opn;
             baseType = bt;

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -2063,11 +2063,13 @@ namespace das
                 }
             } else {
                 auto simV = value->simulate(context);
+                TextWriter tw;
+                tw << "dereferencing null pointer, " << *value << " is null";
+                auto errorMessage = context.code->allocateName(tw.str());
                 if ( r2vType->baseType!=Type::none ) {
-                    return context.code->makeValueNode<SimNode_PtrFieldDerefR2V>(r2vType->baseType, at, simV, fieldOffset + extraOffset);
-                }
-                else {
-                    return context.code->makeNode<SimNode_PtrFieldDeref>(at, simV, fieldOffset + extraOffset);
+                    return context.code->makeValueNode<SimNode_PtrFieldDerefR2V>(r2vType->baseType, at, simV, fieldOffset + extraOffset, errorMessage);
+                } else {
+                    return context.code->makeNode<SimNode_PtrFieldDeref>(at, simV, fieldOffset + extraOffset, errorMessage);
                 }
             }
         } else {

--- a/src/simulate/simulate.cpp
+++ b/src/simulate/simulate.cpp
@@ -117,6 +117,14 @@ namespace das
         return cast<char *>::to(eval(context));
     }
 
+    SimNode * SimNode_WithErrorMessage::copyNode ( Context & context, NodeAllocator * code ) {
+        SimNode_WithErrorMessage * that = (SimNode_WithErrorMessage *) SimNode::copyNode(context, code);
+        if ( errorMessage ) {
+            that->errorMessage = code->allocateName(errorMessage);
+        }
+        return that;
+    }
+
     vec4f SimNode_Jit::eval ( Context & context ) {
         auto result = func(&context, context.abiArg, context.abiCMRES);
         context.result = result;

--- a/src/simulate/simulate_fusion.cpp
+++ b/src/simulate/simulate_fusion.cpp
@@ -64,6 +64,11 @@ namespace das {
         if (result) {
             set(result, node);
             result->subexpr = static_cast<SimNode_SourceBase *>(node_x)->subexpr;
+            if ( node->rtti_node_isErrorMessage() ) {
+                result->errorMessage = static_cast<SimNode_WithErrorMessage *>(node)->errorMessage;
+            } else if ( node_x->rtti_node_isErrorMessage() ) {
+                result->errorMessage = static_cast<SimNode_WithErrorMessage *>(node_x)->errorMessage;
+            }
             return result;
         } else {
             return node;
@@ -84,6 +89,11 @@ namespace das {
                 result->r = static_cast<SimNode_SourceBase *>(node_r)->subexpr;
             } else {
                 result->r.setSimNode(node_r);
+            }
+            if ( node_l && node_l->rtti_node_isErrorMessage() ) {
+                result->errorMessage = static_cast<SimNode_WithErrorMessage *>(node_l)->errorMessage;
+            } else if ( node_r && node_r->rtti_node_isErrorMessage() ) {
+                result->errorMessage = static_cast<SimNode_WithErrorMessage *>(node_r)->errorMessage;
             }
             return result;
         } else {

--- a/src/simulate/simulate_fusion_ptrfdr.cpp
+++ b/src/simulate/simulate_fusion_ptrfdr.cpp
@@ -52,7 +52,7 @@ namespace das {
         INLINE char * compute(Context & context) { \
             DAS_PROFILE_NODE \
             auto prv = (char **) subexpr.compute##COMPUTE(context); \
-            if ( !prv || !*prv ) context.throw_error_at(debugInfo,"dereferencing null pointer"); \
+            if ( !prv || !*prv ) context.throw_error_at(debugInfo,"%s",errorMessage ? errorMessage : "dereferencing null pointer"); \
             return (*prv) + offset; \
         } \
         DAS_PTR_NODE; \
@@ -95,7 +95,7 @@ namespace das {
         INLINE auto compute(Context & context) { \
             DAS_PROFILE_NODE \
             auto prv = (char **) subexpr.compute##COMPUTE(context); \
-            if ( !prv || !*prv ) context.throw_error_at(debugInfo,"dereferencing null pointer"); \
+            if ( !prv || !*prv ) context.throw_error_at(debugInfo,"%s",errorMessage ? errorMessage : "dereferencing null pointer"); \
             return *((RCTYPE *)((*prv) + offset)); \
         } \
         DAS_NODE(TYPE,RCTYPE); \
@@ -132,7 +132,7 @@ namespace das {
         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto prv = (char **) subexpr.compute##COMPUTE(context); \
-            if ( !prv || !*prv ) context.throw_error_at(debugInfo,"dereferencing null pointer"); \
+            if ( !prv || !*prv ) context.throw_error_at(debugInfo,"%s",errorMessage ? errorMessage : "dereferencing null pointer"); \
             return v_ldu((const float *) ((*prv)+offset)); \
         } \
     };


### PR DESCRIPTION
```
options gen2

struct Foo {
    a : int = 5
}

[export]
def main {
    var foo : Foo?
    let x = foo.a // used to produce EXCEPTION: dereferencing null pointer at D:\Work\daScript/examples/test/misc/hello_world.das:10:15
    print("x = {x}\n")
}
```

now produces

```
EXCEPTION: dereferencing null pointer, foo is null
 at D:\Work\daScript/examples/test/misc/hello_world.das:10:15
```