### PR TITLE
to_lower and to_upper now survives string interning

### DIFF
--- a/src/builtin/module_builtin_string.cpp
+++ b/src/builtin/module_builtin_string.cpp
@@ -182,9 +182,10 @@ namespace das
         const uint32_t strLen = stringLengthSafe ( *context, str );
         if (!strLen)
             return nullptr;
-        char * ret = context->allocateString(str, strLen, at);
+        char * ret = context->allocateString(nullptr, strLen, at);
         for (char *d = ret, *end = ret + strLen; d != end; ++str, ++d)
           *d = (char)to_lower(*str);
+        context->stringHeap->intern(ret, strLen);
         return ret;
     }
 
@@ -208,9 +209,10 @@ namespace das
         const uint32_t strLen = stringLengthSafe ( *context, str );
         if (!strLen)
             return nullptr;
-        char * ret = context->allocateString(str, strLen, at);
+        char * ret = context->allocateString(nullptr, strLen, at);
         for (char *d = ret, *end = ret + strLen; d != end; ++str, ++d)
           *d = (char)to_upper(*str);
+        context->stringHeap->intern(ret, strLen);
         return ret;
     }
 


### PR DESCRIPTION
```
options gen2
require strings
options intern_strings       // note
[export]
def main() {
    var a = "HELLO, WORLD"
    var b : string
    b = a
    b += "_"
    debug(b, "b before =")
    var c = to_lower(b)
    debug(b, "b=")                /// <---------- this used to be lower case due to interning bug
    debug(c, "c=")
}
```