### PR TITLE
skip lockchceck on generated c-tor

### DIFF
--- a/src/ast/ast_generate.cpp
+++ b/src/ast/ast_generate.cpp
@@ -315,6 +315,7 @@ namespace das {
         makeT->structs.push_back(make_smart<MakeStruct>());
         auto returnDecl = make_smart<ExprReturn>(str->at,makeT);
         returnDecl->moveSemantics = true;
+        returnDecl->skipLockCheck = true;
         block->list.push_back(returnDecl);
         fn->body = block;
         verifyGenerated(fn->body);
@@ -1768,6 +1769,7 @@ namespace das {
         auto returnDecl = make_smart<ExprReturn>(baseClass->at,selfV);
         returnDecl->at = func->at;
         returnDecl->moveSemantics = true;
+        returnDecl->skipLockCheck = true; // this is a constructor, there is no need lock-check
         block->list.push_back(returnDecl);
         // and done
         func->body = block;

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -6872,18 +6872,20 @@ namespace das {
             }
             if ( expr->moveSemantics && expr->subexpr && expr->subexpr->type && expr->subexpr->type->lockCheck() ) {
                 if ( !(expr->at.fileInfo && expr->at.fileInfo->name=="builtin.das") ) {
-                    bool checkIt = true;
-                    if ( expr->subexpr->rtti_isCall() ) {
-                        auto ccall = static_pointer_cast<ExprCall>(expr->subexpr);
-                        if ( ccall->name=="_return_with_lockcheck" || starts_with(ccall->name,"__::builtin`_return_with_lockcheck`") ) checkIt = false;
-                    }
-                    if ( checkIt && !expr->skipLockCheck && !(func && func->skipLockCheck) && !skipModuleLockChecks ) {
-                        reportAstChanged();
-                        auto pCall = make_smart<ExprCall>(expr->at,"_return_with_lockcheck");
-                        pCall->arguments.push_back(expr->subexpr->clone());
-                        auto pRet = expr->clone();
-                        static_pointer_cast<ExprReturn>(pRet)->subexpr = pCall;
-                        return pRet;
+                    if ( !expr->skipLockCheck && !(func && func->skipLockCheck) && !skipModuleLockChecks ) {
+                        bool checkIt = true;
+                        if ( expr->subexpr->rtti_isCall() ) {
+                            auto ccall = static_pointer_cast<ExprCall>(expr->subexpr);
+                            if ( ccall->name=="_return_with_lockcheck" || starts_with(ccall->name,"__::builtin`_return_with_lockcheck`") ) checkIt = false;
+                        }
+                        if ( checkIt ) {
+                            reportAstChanged();
+                            auto pCall = make_smart<ExprCall>(expr->at,"_return_with_lockcheck");
+                            pCall->arguments.push_back(expr->subexpr->clone());
+                            auto pRet = expr->clone();
+                            static_pointer_cast<ExprReturn>(pRet)->subexpr = pCall;
+                            return pRet;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
return with lockcheck prevents CMRES in class ctor, thus breaking addr(self)