### PR TITLE
catch typo in required module names (when the name is explicitly set)

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1704,7 +1704,7 @@ namespace das
                           const FileAccessPtr & access,
                           string &modName,
                           vector<ModuleInfo> & req,
-                          vector<RequireRecord> & missing,
+                          vector<MissingRecord> & missing,
                           vector<RequireRecord> & circular,
                           vector<RequireRecord> & notAllowed,
                           vector<FileInfo *> & chain,

--- a/include/daScript/simulate/debug_info.h
+++ b/include/daScript/simulate/debug_info.h
@@ -147,6 +147,10 @@ namespace das
         vector<FileInfo *>  chain;
     };
 
+    struct MissingRecord : RequireRecord {
+        string              hintName;
+    };
+
     struct NamelessModuleReq {
         string              moduleName;
         string              fileName;

--- a/utils/dasFormatter/fmt.cpp
+++ b/utils/dasFormatter/fmt.cpp
@@ -129,7 +129,8 @@ Result transform_syntax(const string &filename, const string content, format::Fo
     }
     string prev;
     vector<ModuleInfo> req;
-    vector<RequireRecord> missing, circular, notAllowed;
+    vector<MissingRecord> missing;
+    vector<RequireRecord> circular, notAllowed;
     vector<FileInfo *> chain;
     das_set<string> dependencies;
     ModuleGroup libGroup;


### PR DESCRIPTION
error example:
error[30901]: missing prerequisit 'testmodule'; did you mean 'testModule'?
        from /Users/deep/dev/cpp/daScript/examples/test/misc/hello_world.das