### PR TITLE
lambda capture errors and bugfixes

### DIFF
--- a/include/daScript/ast/ast_generate.h
+++ b/include/daScript/ast/ast_generate.h
@@ -46,7 +46,7 @@ namespace das {
         self.decl := decl.value or self[index].decl = decl.value
     */
     struct MakeFieldDecl;
-    ExpressionPtr convertToCloneExpr ( ExprMakeStruct * expr, int index, MakeFieldDecl * decl );
+    ExpressionPtr convertToCloneExpr ( ExprMakeStruct * expr, int index, MakeFieldDecl * decl, bool ignoreCaptureConst = false );
 
 
     /*

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1807,6 +1807,7 @@ namespace das {
         cexpr->field = field;
         cexpr->fieldIndex = fieldIndex;
         cexpr->unsafeDeref = unsafeDeref;
+        cexpr->ignoreCaptureConst = ignoreCaptureConst;
         cexpr->no_promotion = no_promotion;
         cexpr->atField = atField;
         return cexpr;

--- a/src/ast/ast_generate.cpp
+++ b/src/ast/ast_generate.cpp
@@ -1852,7 +1852,7 @@ namespace das {
         return func;
     }
 
-    ExpressionPtr convertToCloneExpr ( ExprMakeStruct * expr, int index, MakeFieldDecl * decl ) {
+    ExpressionPtr convertToCloneExpr ( ExprMakeStruct * expr, int index, MakeFieldDecl * decl, bool ignoreCaptureConst ) {
         bool needIndex = expr->structs.size()>1;
         DAS_ASSERT(expr->block->rtti_isMakeBlock());
         auto mkb = static_pointer_cast<ExprMakeBlock>(expr->block);
@@ -1863,6 +1863,7 @@ namespace das {
         if ( !needIndex ) {
             auto vself = make_smart<ExprVar>(decl->at, selfName);
             auto fdecl = make_smart<ExprField>(decl->at, vself, decl->name);
+            fdecl->ignoreCaptureConst = ignoreCaptureConst;
             auto op2c = make_smart<ExprClone>(decl->at, fdecl, decl->value->clone());
             return op2c;
         } else {


### PR DESCRIPTION
```
struct Foo
    x : int
    y : string
    z : table<string>

def f1(foo : Foo) : lambda<() : void>
    return <- @() { print("{foo}"); } // error[30124]: implicit capture by move requires unsafe, while capturing foo

def f11(foo : Foo) : lambda<() : void>
    unsafe
        return <- @() { print("{foo}"); } // error[30124]: can't implicitly capture constant variable foo by move

def f12(foo : Foo) : lambda<() : void>
    return <- @ capture(<-foo) () { print("{foo}"); }   // error[30124]: can't capture constant variable foo by move


def f2(foo : Foo) : lambda<() : void>
    return <- @ capture(:=foo) () { print("{foo}"); }   // Works fine

def f3(foo : Foo) : lambda<() : void>
    var tmpFoo := foo
    return <- @ capture(<-tmpFoo) () { print("{tmpFoo}"); } // Works fine
```