### PR TITLE
fix const in aot return

### DIFF
--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -2849,7 +2849,7 @@ namespace das {
                         ss << " = ";
                         auto call_func = expr->constructor;
                         if ( isHybridCall(call_func) ) {
-                            ss << "das_invoke_function<" << describeCppType(call_func->result) << ">::invoke_cmres";
+                            ss << "das_invoke_function<" << describeCppType(call_func->result, CpptSubstitureRef::no, CpptSkipRef::no, CpptSkipConst::yes) << ">::invoke_cmres";
                             auto mangledName = call_func->getMangledName();
                             uint64_t hash = call_func->getMangledNameHash();
                             ss << "(__context__,nullptr,";
@@ -2864,7 +2864,7 @@ namespace das {
                         ss << tabs() << mksName(expr) << " = ";
                         auto call_func = expr->constructor;
                         if ( isHybridCall(call_func) ) {
-                            ss << "das_invoke_function<" << describeCppType(call_func->result) << ">::invoke_cmres";
+                            ss << "das_invoke_function<" << describeCppType(call_func->result, CpptSubstitureRef::no, CpptSkipRef::no, CpptSkipConst::yes) << ">::invoke_cmres";
                             auto mangledName = call_func->getMangledName();
                             uint64_t hash = call_func->getMangledNameHash();
                             ss << "(__context__,nullptr,";
@@ -3123,7 +3123,7 @@ namespace das {
                 else if (bt == Type::tString) ss << "das_invoke_function_by_name";
                 else ss << "das_invoke /*unknown*/";
                 ExprInvoke * einv = static_cast<ExprInvoke *>(call);
-                ss << "<" << describeCppType(call->type);
+                ss << "<" << describeCppType(call->type, CpptSubstitureRef::no, CpptSkipRef::no, CpptSkipConst::yes);
                 if ( methodName ) {
                     if (crossPlatform) {
                         ss << ",offsetof(" << describeCppType(argType->argTypes.at(0),
@@ -3349,7 +3349,7 @@ namespace das {
                 }
             } else {
                 if ( isHybridCall(call->func) ) {
-                    ss << "das_invoke_function<" << describeCppType(call->func->result) << ">::invoke";
+                    ss << "das_invoke_function<" << describeCppType(call->func->result, CpptSubstitureRef::no, CpptSkipRef::no, CpptSkipConst::yes) << ">::invoke";
                     if ( call->func->result->isRefType() && !call->func->result->ref ) {
                         ss << "_cmres";
                     }

--- a/src/das/ast/ast_aot_cpp.das
+++ b/src/das/ast/ast_aot_cpp.das
@@ -2700,7 +2700,7 @@ class CppAot : AstVisitor {
                     write(*ss, " = ");
                     let call_func = expr.constructor;
                     if (isHybridCall(call_func)) {
-                        write(*ss, "das_invoke_function<{describeCppType(call_func.result,DescribeConfig(cross_platform=cross_platform))}>::invoke_cmres");
+                        write(*ss, "das_invoke_function<{describeCppType(call_func.result,DescribeConfig(skip_const=true,cross_platform=cross_platform))}>::invoke_cmres");
                         assume mangledName = call_func |> get_mangled_name();
                         let hash = call_func.getMangledNameHash;
                         write(*ss, "(__context__,nullptr,");
@@ -2716,7 +2716,7 @@ class CppAot : AstVisitor {
                     write(*ss, "{tabs()}{mksName(expr)} = ");
                     let call_func = expr.constructor;
                     if (isHybridCall(call_func)) {
-                        write(*ss, "das_invoke_function<{describeCppType(call_func.result, DescribeConfig(cross_platform=cross_platform))}>::invoke_cmres");
+                        write(*ss, "das_invoke_function<{describeCppType(call_func.result, DescribeConfig(skip_const=true,cross_platform=cross_platform))}>::invoke_cmres");
                         assume mangledName = call_func |> get_mangled_name();
                         let hash = call_func.getMangledNameHash;
                         write(*ss, "(__context__,nullptr,");
@@ -2968,7 +2968,7 @@ class CppAot : AstVisitor {
                 write(*ss, "das_invoke /*unknown*/");
             }
             let einv = call as ExprInvoke;
-            write(*ss, "<{describeCppType(call._type,DescribeConfig(cross_platform=cross_platform))}");
+            write(*ss, "<{describeCppType(call._type,DescribeConfig(skip_const=true,cross_platform=cross_platform))}");
             if (methodOffset != -1) {
                 assume argType = call.arguments[0]._type;
                 if (cross_platform) {
@@ -3193,7 +3193,7 @@ class CppAot : AstVisitor {
             }
         } else {
             if (isHybridCall(call.func)) {
-                write(*ss, "das_invoke_function<{describeCppType(call.func.result,DescribeConfig(cross_platform=cross_platform))}>::invoke");
+                write(*ss, "das_invoke_function<{describeCppType(call.func.result,DescribeConfig(skip_const=true,cross_platform=cross_platform))}>::invoke");
                 if (call.func.result.isRefType && !call.func.result.flags.ref) {
                     write(*ss, "_cmres");
                 }


### PR DESCRIPTION
Ignore consts in aot functions return