### PR TITLE
promote to bitfield set

### DIFF
--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -41,6 +41,10 @@ namespace das {
     void das_trycatch(callable<void()> tryBody, callable<void(const char * msg)> catchBody);
 #endif
 
+    __forceinline void __bit_set ( Bitfield & value, Bitfield mask, bool on ) {
+        value.value = on ? (value.value | mask.value) : (value.value & ~mask.value);
+    }
+
     template <typename TT>
     struct das_auto_cast {
         template <typename QQ>

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -2066,5 +2066,9 @@ namespace das
         addExtern<DAS_BIND_FUN(das_aot_enabled)>(*this, lib, "aot_enabled",
             SideEffects::none, "das_aot_enabled")
                 ->args({"context","at"});
+        // bitfield
+        addExtern<DAS_BIND_FUN(__bit_set)>(*this, lib, "__bit_set",
+            SideEffects::modifyArgument, "__bit_set")
+                ->args({"value","mask","on"});
     }
 }


### PR DESCRIPTION
```
bitfield OneTwoThree {
    one,
    two,
    three
}

[export]
def main {
    var a = OneTwoThree.one
    a.two = true // this is now ok
    debug(a)
    a.one = false // this is also ok
    debug(a)
}
```