### PR TITLE
add argNames to hash of bitfield

### DIFF
--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -416,6 +416,9 @@ namespace das
         if ( secondType ) {
             secondType->getLookupHash(hash);
         }
+        for ( auto & name : argNames ) {
+            hash = hashmix(hash, hash_block64(reinterpret_cast<const uint8_t *>(name.c_str()), name.size()));
+        }
         for ( auto & argT : argTypes ) {
             argT->getLookupHash(hash);
         }


### PR DESCRIPTION
```
def test(a) {
}
[export]
def main() {
    var arg1: bitfield<left;right>;
    var arg2: bitfield<up;down>;
    test(arg1)
    test(arg2);
}
```
Code like this doesn't work, because we cache result of the searching function by hash, however we got collision, because the only difference is argNames for bitfield type, which is not counted in lookup hash computation (so, we match same function during the search)