### PR TITLE
replace unsafe blocks with expressions

### DIFF
--- a/daslib/ast_debug.das
+++ b/daslib/ast_debug.das
@@ -104,9 +104,7 @@ class SampleStackWalker : DapiStackWalker {
     ctxid : Context?
     def override onArgument(info : FuncInfo; index : int; vinfo : VarInfo; arg : float4) : void {
         if (vinfo.flags.ref || vinfo.flags.refType) {
-            unsafe {
-                describe_arg(*ctxid, vinfo, *reinterpret<void ??>(addr(arg)))
-            }
+            describe_arg(*ctxid, vinfo, *unsafe(reinterpret<void ??>(unsafe(addr(arg)))))
         } else {
             describe_arg(*ctxid, vinfo, unsafe(addr(arg)))
         }
@@ -116,9 +114,7 @@ class SampleStackWalker : DapiStackWalker {
             return
         }
         if (vinfo.flags.ref || vinfo.flags.refType) {
-            unsafe {
-                describe_arg(*ctxid, vinfo, *reinterpret<void ??>(arg))
-            }
+            describe_arg(*ctxid, vinfo, *unsafe(reinterpret<void ??>(arg)))
         } else {
             describe_arg(*ctxid, vinfo, arg)
         }
@@ -133,9 +129,7 @@ class ContextStateAgent : DapiDebugAgent {
     walker : SampleStackWalker?
     def ContextStateAgent {
         walker = new SampleStackWalker()
-        unsafe {
-            walker_adapter <- make_stack_walker(walker)
-        }
+        move_new(walker_adapter, make_stack_walker(walker))
     }
     def operator delete {
         unsafe {

--- a/daslib/live.das
+++ b/daslib/live.das
@@ -74,7 +74,7 @@ def public go_main {
     delete decsLiveData
     appLive = false
     unsafe {
-        appPtr <- reinterpret<smart_ptr<Context>> addr(this_context())
+        move_new(appPtr) <| reinterpret<smart_ptr<Context>> addr(this_context())
     }
 }
 
@@ -195,19 +195,17 @@ def set_new_context(var ptr : smart_ptr<Context>; full_restart : bool = false) {
     to_log(LOG_TRACE, "LIVE: set new context {intptr(get_ptr(ptr))}\n")
     invoke_live("shutdown")
     if (appPtr != null) {
-        unsafe {
-            // fixup decs if its there
-            var pvar = get_context_global_variable(appPtr, "decsState")
-            if (pvar != null) {
-                var pstate : array<uint8>? = unsafe(reinterpret<array<uint8>?> get_context_global_variable(appPtr, "decsLiveData"))
-                assert(pstate != null)
-                var css <- @() {
-                    saveLiveContext()
-                }
-                invoke_in_context(appPtr, css)
-                decsLiveData := *pstate
-                delete css
+        // fixup decs if its there
+        var pvar = unsafe(get_context_global_variable(appPtr, "decsState"))
+        if (pvar != null) {
+            var pstate : array<uint8>? = unsafe(reinterpret<array<uint8>?>(unsafe(get_context_global_variable(appPtr, "decsLiveData"))))
+            assert(pstate != null)
+            var css <- @() {
+                saveLiveContext()
             }
+            unsafe(invoke_in_context(appPtr, css))
+            decsLiveData := *pstate
+            delete css
         }
     }
     appPtr := ptr

--- a/daslib/macro_boost.das
+++ b/daslib/macro_boost.das
@@ -45,9 +45,7 @@ class CaptureBlock : AstVisitor {
         }
         let vptr = get_ptr(expr.variable)
         if (!(scope |> key_exists(vptr))) {
-            unsafe {
-                captured[vptr] = reinterpret<ExprVar?> get_ptr(expr)
-            }
+            captured.insert(vptr, unsafe(reinterpret<ExprVar?>(get_ptr(expr))))
         }
     }
     def override preVisitExprLetVariable(expr : smart_ptr<ExprLet>; arg : VariablePtr; lastArg : bool) : void {

--- a/daslib/unroll.das
+++ b/daslib/unroll.das
@@ -30,35 +30,35 @@ class UnrollMacro : AstFunctionAnnotation {
     //!             n[i] = imageLoad(c_bloom_htex, xy + int2(0,i-4))
     def override transform(var call : smart_ptr<ExprCallFunc>; var errors : das_string) : ExpressionPtr {
         assert(call.arguments[0] is ExprMakeBlock)
-        unsafe {
-            var mblk = reinterpret<ExprMakeBlock?> call.arguments[0]
-            var blk = reinterpret<ExprBlock?> mblk._block
-            if (blk.finalList |> length != 0) {
-                errors := "not expecting finally section in the unroll"
-                return default<ExpressionPtr>
-            }
-            if (blk.list |> length != 1 || !(blk.list[0] is ExprFor)) {
-                errors := "expecting unroll <| for ..."
-                return default<ExpressionPtr>
-            }
-            let efor = reinterpret<ExprFor?> blk.list[0]
-            if (!(efor.sources[0] is ExprConstRange)) {
-                errors := "can only unroll for loop with range"
-                return default<ExpressionPtr>
-            }
-            let euc = reinterpret<ExprConstRange?> efor.sources[0]
-            let van = "{efor.iterators[0]}"
-            var nblk <- new ExprBlock(at = call.at)
-            for (i in euc.value) {
-                var iblk <- clone_expression(efor.body)
+        var mblk = unsafe(reinterpret<ExprMakeBlock?>(call.arguments[0]))
+        var blk = unsafe(reinterpret<ExprBlock?>(mblk._block))
+        if (blk.finalList |> length != 0) {
+            errors := "not expecting finally section in the unroll"
+            return <- default<ExpressionPtr>
+        }
+        if (blk.list |> length != 1 || !(blk.list[0] is ExprFor)) {
+            errors := "expecting unroll <| for ..."
+            return <- default<ExpressionPtr>
+        }
+        let efor = unsafe(reinterpret<ExprFor?>(blk.list[0]))
+        if (!(efor.sources[0] is ExprConstRange)) {
+            errors := "can only unroll for loop with range"
+            return <- default<ExpressionPtr>
+        }
+        let euc = unsafe(reinterpret<ExprConstRange?> efor.sources[0])
+        let van = "{efor.iterators[0]}"
+        var inscope nblk <- new ExprBlock(at = call.at)
+        for (i in euc.value) {
+            if (true) {
+                var inscope iblk <- clone_expression(efor.body)
                 remove_deref(van, iblk)
-                var rules : Template
+                var inscope rules : Template
                 rules |> replaceVariable(van) <| new ExprConstInt(at = call.at, value = i)
                 rules |> apply_template(call.at, iblk, false)
                 nblk.list |> emplace(iblk)
             }
-            return nblk
         }
+        return <- nblk
     }
 }
 

--- a/modules/dasPEG/peg/parse_macro.das
+++ b/modules/dasPEG/peg/parse_macro.das
@@ -266,35 +266,33 @@ var private failed_to_transform = false
 
 [macro_function]
 def transform(var rule : MacroRule) : Definition {
-    unsafe {
-        failed_to_transform = false
-        var name = rule.rule.variables[0].name |> string()
-        var inscope type_ <- rule.rule.variables[0]._type
+    failed_to_transform = false
+    var name = rule.rule.variables[0].name |> string()
+    var inscope type_ <- rule.rule.variables[0]._type
 
-        // Transform array<ExprCall?> into an array of Rules
+    // Transform array<ExprCall?> into an array of Rules
 
-        var inscope alternatives : array<Alternative>
+    var inscope alternatives : array<Alternative>
 
-        for (alt in rule.alternatives) {
-            if (true) {// creates scope for inscope
-                var inscope blk : ExpressionPtr <- clone_expression(alt.arguments |> back)
+    for (alt in rule.alternatives) {
+        if (true) {// creates scope for inscope
+            var inscope blk : ExpressionPtr <- clone_expression(alt.arguments |> back)
 
-                var sequence : array<Rule_?>
+            var sequence : array<Rule_?>
 
-                for (sequence_elem, _ in alt.arguments, range(length(alt.arguments) - 1)) {
-                    sequence |> push <| into_rule_(sequence_elem)
-                }
-
-                alternatives |> emplace <| Alternative(
-                                        rule <- new Rule_(rule <- Rule(seq <- sequence)),
-                                        action <- (blk as ExprMakeBlock)._block)
+            for (sequence_elem, _ in alt.arguments, range(length(alt.arguments) - 1)) {
+                sequence |> push <| into_rule_(sequence_elem)
             }
-        }
 
-        return <- Definition(name = "{name}",
-                    type_ <- type_,
-                    rule <- Rule(alt <- alternatives))
+            alternatives |> emplace <| Alternative(
+                                    rule <- new Rule_(rule <- Rule(seq <- sequence)),
+                                    action <- (blk as ExprMakeBlock)._block)
+        }
     }
+
+    return <- Definition(name = "{name}",
+                type_ <- type_,
+                rule <- Rule(alt <- alternatives))
 }
 
 

--- a/src/builtin/debugger.das
+++ b/src/builtin/debugger.das
@@ -38,9 +38,7 @@ def install_new_debug_agent(var agentPtr; category : string) {
     static_if (typeinfo is_class(*agentPtr)) {
         let agentInfo = class_info(*agentPtr)
         var inscope agentAdapter <- make_debug_agent(agentPtr, agentInfo)
-        unsafe {
-            agentPtr.thisAgent = reinterpret<DebugAgent?>(agentAdapter)
-        }
+        agentPtr.thisAgent = unsafe(reinterpret<DebugAgent?>(agentAdapter))
         install_debug_agent(agentAdapter, category)
         this_context().name := "debug agent {category}"
     } else {
@@ -52,9 +50,7 @@ def install_new_thread_local_debug_agent(var agentPtr) {
     static_if (typeinfo is_class(*agentPtr)) {
         let agentInfo = class_info(*agentPtr)
         var inscope agentAdapter <- make_debug_agent(agentPtr, agentInfo)
-        unsafe {
-            agentPtr.thisAgent = reinterpret<DebugAgent?>(agentAdapter)
-        }
+        agentPtr.thisAgent = unsafe(reinterpret<DebugAgent?>(agentAdapter))
         install_debug_agent_thread_local(agentAdapter)
         this_context().name := "thread local debug agent"
     } else {


### PR DESCRIPTION
There were a few memory leaks. It's hard to find memory leaks if we have huge `unsafe {}` blocks, let's use `unsafe()` instead.