### PR TITLE
fancier lookup for invoke foo.bar(...)

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -3482,6 +3482,9 @@ namespace das {
                                 // we build _::{field.name} ( field, arg1, arg2, ... )
                                 auto callName = "_::" + methodName;
                                 auto newCall = make_smart<ExprCall>(expr->at, callName);
+                                if ( value->rtti_isR2V() ) {
+                                    value = static_pointer_cast<ExprRef2Value>(value)->subexpr;
+                                }
                                 newCall->arguments.push_back(value);
                                 for ( size_t i=2; i!=expr->arguments.size(); ++i ) {
                                     newCall->arguments.push_back(expr->arguments[i]);

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -3482,6 +3482,7 @@ namespace das {
                                 // we build _::{field.name} ( field, arg1, arg2, ... )
                                 auto callName = "_::" + methodName;
                                 auto newCall = make_smart<ExprCall>(expr->at, callName);
+                                newCall->alwaysSafe = expr->alwaysSafe;
                                 if ( value->rtti_isR2V() ) {
                                     value = static_pointer_cast<ExprRef2Value>(value)->subexpr;
                                 }


### PR DESCRIPTION
```
options rtti
require ast
[export] def main {
    unsafe {
        var first : FieldDeclaration
        first._type.move_new(typeinfo ast_typedecl(type<bool>)) // now ok
    }
}
```
aslo
```
require strings

[export] def main {
    var name = "Hello, World!"
    var i = 0
    unsafe(name.character_uat(i)) // now ok
}
```