### PR TITLE
all aot fields now mutable

### DIFF
--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -1114,7 +1114,10 @@ namespace das {
                 ss << "    /* skipping " << decl.name << ", from " << from->name << " */";
                 return;
             }
-            ss << "    " << describeCppType(decl.type) << " " << decl.name << ";";
+            const auto typeStr = describeCppType(decl.type, CpptSubstitureRef::no,
+                CpptSkipRef::no, CpptSkipConst::yes);
+            // We can't have const fields in aot due to absence of default ctor for such classes.
+            ss << "    " << typeStr << " " << decl.name << ";";
             if ( decl.parentType ) {
                 ss << " /* from " << from->name << " */";
             }

--- a/src/das/ast/ast_aot_cpp.das
+++ b/src/das/ast/ast_aot_cpp.das
@@ -1083,7 +1083,7 @@ class CppAot : AstVisitor {
         if (that.flags.cppLayout && from != reinterpret<Structure const?>(that.get_ptr())) {
             write(*ss, "    /* skipping {decl.name}, from {from.name} */");
         } else {
-            write(*ss, "    {describeCppType(decl._type, DescribeConfig(cross_platform=cross_platform))} {decl.name};");
+            write(*ss, "    {describeCppType(decl._type, DescribeConfig(cross_platform=cross_platform,skip_const = true))} {decl.name};");
             if (decl.flags.parentType) {
                 write(*ss, " /* from {from.name} */");
             }


### PR DESCRIPTION
Code like:
```
class B { x: int = 0 }
class A1 { x: B const = B(); }
class A2 { x = "asd"; }
```
Fails to aot, because we don't generate constructors for aot classes. So on c++ side we get
```
struct A {
    char * const c;
};
```
Which doesn't have default ctor. We can generate ctor-s and initialize using them or make all fields mutable.