### PR TITLE
add linter checks for jit:

### DIFF
--- a/examples/test/unit_tests/div_by_zero.das
+++ b/examples/test/unit_tests/div_by_zero.das
@@ -1,5 +1,5 @@
 options gen2
-[sideeffects]
+[sideeffects, no_jit] // return inside try
 def div_by_zero(num : auto(numT)) {
     var ex = false
     try {
@@ -11,7 +11,7 @@ def div_by_zero(num : auto(numT)) {
     return num
 }
 
-[sideeffects]
+[sideeffects, no_jit] // return inside try
 def mod_by_zero(num : auto(numT)) {
     var ex = false
     try {

--- a/include/daScript/ast/ast_expressions.h
+++ b/include/daScript/ast/ast_expressions.h
@@ -211,6 +211,7 @@ namespace das
                 bool            hasMakeBlock : 1;           // if this block has make block inside
                 bool            hasEarlyOut : 1;            // this block has return, or other blocks with return
                 bool            forLoop : 1;                // this block is a for loop
+                bool            hasExitByLabel : 1;         // whether we have goto outside of block
             };
             uint32_t            blockFlags = 0;
         };

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -2716,6 +2716,16 @@ namespace das {
                     }
                 }
             }
+            scopes.back()->hasExitByLabel = true;
+            for ( const auto & scp : scopes.back()->list ) {
+                if ( scp->rtti_isLabel() ) {
+                    auto lab = static_pointer_cast<ExprLabel>(scp);
+                    if ( lab->label == expr->label ) {
+                        scopes.back()->hasExitByLabel = false;
+                        break;
+                    }
+                }
+            }
             if ( !expr->subexpr && !findLabel(expr->label) ) {
                 error("can't find label " + to_string(expr->label),  "", "",
                     expr->at, CompilationError::invalid_label);


### PR DESCRIPTION
- forbid `return` inside `try {} recover {}` blocks
- forbid usage of finally with goto outside of block