### PR TITLE
Enum traits expanded

### DIFF
--- a/daslib/enum_trait.das
+++ b/daslib/enum_trait.das
@@ -8,6 +8,40 @@ module enum_trait shared private
 
 require ast
 require daslib/ast_boost
+require daslib/contracts
+require daslib/templates
+
+[expect_any_enum(arg)]
+def public string(arg) {
+    //! converts enum value to string
+    //!  usage: let s = string(EnumValue)
+    return "{arg}"
+}
+
+[template(ent), unused_argument(ent)]
+def public to_enum(ent : auto(EnumT), name : string) : EnumT {
+    //! converts string to enum value, panics if not found
+    //!  usage: let e = to_enum(type<EnumType>,"EnumValueName")
+    for (e in each_enum(type<EnumT>)) {
+        if ("{e}" == name) {
+            return e
+        }
+    }
+    panic("to_enum: enum value '{name}' not found in enum '{typeinfo typename(type<EnumT>)}'")
+    return default<EnumT>
+}
+
+[template(ent), unused_argument(ent)]
+def public to_enum(ent : auto(EnumT), name : string; defaultValue : EnumT) : EnumT {
+    //! converts string to enum value, returns defaultValue if not found
+    //!  usage: let e = to_enum(type<EnumType>,"EnumValueName", EnumType.DefaultValue)
+    for (e in each_enum(type<EnumT>)) {
+        if ("{e}" == name) {
+            return e
+        }
+    }
+    return defaultValue
+}
 
 [typeinfo_macro(name="enum_length")]
 class TypeInfoGetEnumLength : AstTypeInfoMacro {

--- a/daslib/enum_trait.das
+++ b/daslib/enum_trait.das
@@ -44,19 +44,36 @@ def public to_enum(ent : auto(EnumT), name : string; defaultValue : EnumT) : Enu
     return defaultValue
 }
 
+[template(ent), unused_argument(ent), skip_lock_check]
+def public enum_to_table(ent : auto(EnumT)) : table<string, EnumT -const -&> {
+    //! converts enum type to array of tuples (name, value)
+    //!  usage: let t = enum_to_table(type<EnumType>)
+    var tab : table<string, EnumT -const -&>
+    for (e in each_enum(type<EnumT>)) {
+        unsafe(tab["{e}"]) = e
+    }
+    return <- tab
+}
+
 [enumeration_macro(name="string_to_enum")]
 class EnumFromStringConstruction : AstEnumerationAnnotation {
     def override apply(var enu : EnumerationPtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
         var inscope enumT <- new TypeDecl(baseType = Type.tEnumeration, enumType = enu.get_ptr())
-        // panicing one
-        var inscope enumFn <- qmacro_function("{enu.name}") <| $(src : string) {
-            return to_enum(type<$t(enumT)>, src)
+        // lets make a table variable
+        let varName = "_`enum`table`{enu.name}"
+        add_global_private_let(compiling_module(), varName, enu.at, qmacro(enum_to_table(type<$t(enumT)>)))
+        // panic one
+        var inscope enumFn <- qmacro_function("{enu.name}") <| $(src : string) : $t(enumT) {
+            if (!key_exists($i(varName), src)) {
+                panic("string_to_enum: enum value '{src}' not found in enum '{typeinfo typename(type<$t(enumT)>)}'")
+            }
+            return $i(varName)?[src] ?? default<$t(enumT)>
         }
         enumFn.flags &= ~FunctionFlags.privateFunction
         compiling_module() |> add_function(enumFn)
         // with default
-        var inscope enumFnDefault <- qmacro_function("{enu.name}") <| $(src : string; defaultValue : $t(enumT)) {
-            return to_enum(type<$t(enumT)>, src, defaultValue)
+        var inscope enumFnDefault <- qmacro_function("{enu.name}") <| $(src : string; defaultValue : $t(enumT)) : $t(enumT) {
+            return $i(varName)?[src] ?? defaultValue
         }
         enumFnDefault.flags &= ~FunctionFlags.privateFunction
         compiling_module() |> add_function(enumFnDefault)

--- a/daslib/enum_trait.das
+++ b/daslib/enum_trait.das
@@ -8,8 +8,9 @@ module enum_trait shared private
 
 require ast
 require daslib/ast_boost
-require daslib/contracts
+require daslib/templates_boost
 require daslib/templates
+require daslib/contracts
 
 [expect_any_enum(arg)]
 def public string(arg) {
@@ -41,6 +42,27 @@ def public to_enum(ent : auto(EnumT), name : string; defaultValue : EnumT) : Enu
         }
     }
     return defaultValue
+}
+
+[enumeration_macro(name="string_to_enum")]
+class EnumFromStringConstruction : AstEnumerationAnnotation {
+    def override apply(var enu : EnumerationPtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
+        var inscope enumT <- new TypeDecl(baseType = Type.tEnumeration, enumType = enu.get_ptr())
+        // panicing one
+        var inscope enumFn <- qmacro_function("{enu.name}") <| $(src : string) {
+            return to_enum(type<$t(enumT)>, src)
+        }
+        enumFn.flags &= ~FunctionFlags.privateFunction
+        compiling_module() |> add_function(enumFn)
+        // with default
+        var inscope enumFnDefault <- qmacro_function("{enu.name}") <| $(src : string; defaultValue : $t(enumT)) {
+            return to_enum(type<$t(enumT)>, src, defaultValue)
+        }
+        enumFnDefault.flags &= ~FunctionFlags.privateFunction
+        compiling_module() |> add_function(enumFnDefault)
+        return true
+
+    }
 }
 
 [typeinfo_macro(name="enum_length")]

--- a/tests/language/enumerations.das
+++ b/tests/language/enumerations.das
@@ -24,3 +24,27 @@ def test_enum_conversions(t : T?) {
         t |> equal(Foo.three, r)
     }
 }
+
+
+[string_to_enum]
+enum Bar {
+    one
+    two
+    three
+}
+
+[test]
+def test_enum_macro_conversions(t : T?) {
+    t |> run("enum macro") <| @(t : T?) {
+        let b = Bar("three")                // this conversion can panic
+        t |> equal(Bar.three, b)
+        let s = "{b}"
+        t |> equal("three", s)
+        let q = string(Bar.two)
+        t |> equal("two", q)
+        let r = to_enum(type<Bar>, "one")   // conversion via standard path
+        t |> equal(Bar.one, r)
+        let bb = Bar("five", Bar.two)       // conversion with the default value
+        t |> equal(Bar.two, bb)
+    }
+}

--- a/tests/language/enumerations.das
+++ b/tests/language/enumerations.das
@@ -1,0 +1,26 @@
+options gen2
+require dastest/testing_boost public
+
+require daslib/enum_trait
+
+enum Foo {
+    one
+    two
+    three
+}
+
+[test]
+def test_enum_conversions(t : T?) {
+    t |> run("enum to string") <| @(t : T?) {
+        let s = "{Foo.two}"
+        t |> equal("two", s)
+        let q = string(Foo.two)
+        t |> equal("two", q)
+    }
+    t |> run("string to enum") <| @(t : T?) {
+        let q = to_enum(type<Foo>, "two")
+        t |> equal(Foo.two, q)
+        let r = to_enum(type<Foo>, "five", Foo.three)
+        t |> equal(Foo.three, r)
+    }
+}


### PR DESCRIPTION
conversion functions
```
enum Foo {
    one
    two
    three
}
"{Foo.one}" // enum -> string
string(Foo.one) // enum ->string, same as previous line
to_enum(type<Foo>,"one") // can panic, if enum can't be converted
to_enum(type<Foo>,"five",Foo.one) // twith the default value
```

also conversion macro
```
[string_to_enum]
enum Bar {
    one
    two
    three
}

Bar("two") // can panic, if enum can't be converted
Bar("five", Bar.one) // with the default value
```