### PR TITLE
unqiue - removes matching sequential elements

### DIFF
--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -24,8 +24,10 @@ Set operations (*)
      union_by, union_by_to_array - Returns the union of two iterables (or by key)
      except, except_to_array - Returns elements from the first iterable that are not in the second iterable
      except_by, except_by_to_array - Returns elements from the first iterable that are not in the second iterable (or by key)
-     intersect - Returns elements that are present in both iterables (or by key)
-     intersect_by - Returns elements that are present in both iterables (or by key)
+     intersect, intersect_to_array - Returns elements that are present in both iterables
+     intersect_by, intersect_by_to_array - Returns elements that are present in both iterables (or by key)
+     unique, unique_inplace, unique_to_array - Returns unique elements from a sorted iterable (by compare function)
+     unique_by, unique_by_inplace, unique_by_to_array - Returns unique elements from a sorted iterable (or by key)
 Concatenation operations (*)
      append, append_to_array, append_inplace - Appends an element to the end of an iterable
      prepend, prepend_to_array, prepend_inplace - Prepends an element to the beginning of an iterable
@@ -272,6 +274,36 @@ def reverse_to_array(var a : iterator<auto(TT)>) : array<TT -const -&> {
     }
     reverse_inplace(buffer)
     return <- buffer
+}
+
+[skip_lock_check]
+def order_inplace(var buffer : array<auto(TT)>) {
+    //! Sorts an array in place
+    sort(buffer, $(a, b) => _::unique_key(a) < _::unique_key(b))
+}
+
+[skip_lock_check]
+def order(var a : iterator<auto(TT)>) : iterator<TT -const -&> {
+    //! Sorts an iterator
+    var arr <- to_array(a)
+    sort(arr, $(a, b) => _::unique_key(a) < _::unique_key(b))
+    return to_sequence_move(arr)
+}
+
+[skip_lock_check]
+def order(arr : array<auto(TT)>) : array<TT -const -&> {
+    //! Sorts an array
+    var brr := arr
+    sort(brr, $(a, b) => _::unique_key(a) < _::unique_key(b))
+    return <- brr
+}
+
+[skip_lock_check]
+def order_to_array(var a : iterator<auto(TT)>) : array<TT -const -&> {
+    //! Sorts an iterator and returns an array
+    var arr <- to_array(a)
+    sort(arr, $(a, b) => _::unique_key(a) < _::unique_key(b))
+    return <- arr
 }
 
 [skip_lock_check]
@@ -585,6 +617,92 @@ def distinct_by_inplace(var a : array<auto(TT)>; key : block<(arg : TT -&) : aut
         }
     }
     a.resize(to_index)
+    static_if (typeinfo need_lock_check(a)) {
+        set_verify_array_locks(a, true)
+    }
+}
+
+[skip_lock_check]
+def unique(a : iterator<auto(TT)>) : iterator<TT -const -&> {
+    //! sort and remove duplicate elements from an iterator
+    var inscope buffer <- to_array(a)
+    unique_inplace(buffer)
+    return to_sequence_move(buffer)
+}
+
+[skip_lock_check]
+def unique(a : array<auto(TT)>) : array<TT -const -&> {
+    //! sort and remove duplicate elements from an array
+    var b := a
+    unique_inplace(b)
+    return <- b
+}
+
+[skip_lock_check]
+def unique_to_array(a : iterator<auto(TT)>) : array<TT -const -&> {
+    //! sort and remove duplicate elements from an iterator and returns an array
+    var inscope buffer <- to_array(a)
+    unique_inplace(buffer)
+    return <- buffer
+}
+
+[skip_lock_check]
+def unique_inplace(var a : array<auto(TT)>) {
+    //! remove duplicate elements from sorted array in place
+    static_if (typeinfo need_lock_check(a)) {
+        _builtin_verify_locks(a)
+        set_verify_array_locks(a, false)
+    }
+    var write_index = 1
+    for (from_index in 1 .. length(a)) {
+        if (_::unique_key(a[from_index]) != _::unique_key(a[write_index - 1])) {
+            a[write_index++] <- a[from_index]
+        }
+    }
+    a.resize(write_index)
+    static_if (typeinfo need_lock_check(a)) {
+        set_verify_array_locks(a, true)
+    }
+}
+
+[skip_lock_check]
+def unique_by(a : iterator<auto(TT)>; key : block<(arg : TT -&) : auto>) : iterator<TT -const -&> {
+    //! sort and remove duplicate elements from an iterator based on a key
+    var inscope buffer <- to_array(a)
+    unique_by_inplace(buffer, key)
+    return to_sequence_move(buffer)
+}
+
+[skip_lock_check]
+def unique_by(a : array<auto(TT)>; key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
+    //! sort and remove duplicate elements from an array based on a key
+    var b := a
+    unique_by_inplace(b, key)
+    return <- b
+}
+
+[skip_lock_check]
+def unique_by_to_array(a : iterator<auto(TT)>; key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
+    //! sort and remove duplicate elements from an iterator based on a key and returns an array
+    var inscope buffer <- to_array(a)
+    unique_by_inplace(buffer, key)
+    return <- buffer
+}
+
+[skip_lock_check]
+def unique_by_inplace(var a : array<auto(TT)>; key : block<(arg : TT -&) : auto>) {
+    //! remove duplicate elements from an array based on a key in place
+    static_if (typeinfo need_lock_check(a)) {
+        _builtin_verify_locks(a)
+        set_verify_array_locks(a, false)
+    }
+    var write_index = 1
+    for (from_index in 1 .. length(a)) {
+        if (key(a[from_index]) != key(a[write_index - 1])) {
+            a[write_index++] <- a[from_index]
+        }
+    }
+    a.resize(write_index)
     static_if (typeinfo need_lock_check(a)) {
         set_verify_array_locks(a, true)
     }
@@ -2796,3 +2914,26 @@ def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; result_
     return <- zip_impl(a, type<TT -const -&>, b, type<UU -const -&>, result_selector)
 }
 
+[skip_lock_check]
+def public order_unique_folded(var a : array<auto(TT)>) : array<TT -const -&> {
+    //! sort and remove duplicate elements from an array
+    var arr <- order(a)
+    unique_inplace(arr)
+    return <- arr
+}
+
+[skip_lock_check]
+def public order_unique_folded(var a : iterator<auto(TT)>) : array<TT -const -&> {
+    //! sort and remove duplicate elements from an iterator
+    var arr <- to_array(a)
+    order_inplace(arr)
+    unique_inplace(arr)
+    return <- arr
+}
+
+[skip_lock_check]
+def public order_unique_folded_inplace(var a : array<auto(TT)>) {
+    //! sort and remove duplicate elements from an array
+    order_inplace(a)
+    unique_inplace(a)
+}

--- a/daslib/linq_boost.das
+++ b/daslib/linq_boost.das
@@ -30,6 +30,7 @@ Set operations
     _ _union_by(it1, it2, expr) => union_by(it1, it2, $(_) => expr)
     - _except_by(it1, it2, expr) => except_by(it1, it2, $(_) => expr)
     - _intersect_by(it1, it2, expr) => intersect_by(it1, it2, $(_) => expr)
+    - _unique_by(it, expr) => unique_by(it, $(_) => expr)
 Sorting data
     - _order_by(it, expr)       => order_by(it, $(_) => expr)
     - _order_by_descending(it, expr) => order_by_descending(it, $(_) => expr)
@@ -40,7 +41,6 @@ require daslib/linq public
 require daslib/ast_boost
 require daslib/templates_boost
 require daslib/macro_boost
-
 
 def private clone_iterator_type(it : TypeDeclPtr) : TypeDeclPtr {
     var inscope res <- clone_type(it.firstType)
@@ -128,6 +128,16 @@ class private LinqAll : AstCallMacro_LinqPred2 {
 [call_macro(name="_any")]
 class private LinqAny : AstCallMacro_LinqPred2 {
     override predName = "any"
+}
+
+[call_macro(name="_unique_by")]
+class private LinqUnique : AstCallMacro_LinqPred2 {
+    override predName = "unique_by"
+}
+
+[call_macro(name="_unique_by_to_array")]
+class private LinqUniqueToArray : AstCallMacro_LinqPred2 {
+    override predName = "unique_by_to_array"
 }
 
 [call_macro(name="_distinct_by")]
@@ -335,6 +345,10 @@ var private linqCalls = {
     "intersect_to_array" => LinqCall(name = "intersect", recursive = [1]),
     "intersect_by" => LinqCall(name = "intersect_by", recursive = [1]),
     "intersect_by_to_array" => LinqCall(name = "intersect_by", recursive = [1]),
+    "unique" => LinqCall(name = "unique", inplace = true),
+    "unique_to_array" => LinqCall(name = "unique", inplace = true),
+    "unique_by" => LinqCall(name = "unique_by", inplace = true),
+    "unique_by_to_array" => LinqCall(name = "unique_by", inplace = true),
 // element operations
     "element_at" => LinqCall(name = "element_at"),
     "element_at_or_default" => LinqCall(name = "element_at_or_default"),
@@ -423,6 +437,16 @@ struct private FoldSequence {
 }
 
 var private g_foldSeq = [               // those are applied in order
+// order and distinct (for both orders)
+    FoldSequence(
+        calls = ["order", "distinct" ],
+        folder = @@fold_order_distinct
+    ),
+    FoldSequence(
+        calls = ["distinct", "order" ],
+        folder = @@fold_order_distinct
+    ),
+// select and where
     FoldSequence(
         calls = ["where_", "select" ],
         folder = @@fold_where_select
@@ -442,7 +466,7 @@ var private g_foldSeq = [               // those are applied in order
 ]
 
 [macro_function]
-def private append_comprehension(argIndex : int; var comprehension : ExpressionPtr; var blk : ExprBlock?; at : LineInfo) : ExpressionPtr {
+def private append_comprehension(argIndex : int; var topValue : ExpressionPtr; var comprehension : ExpressionPtr; var blk : ExprBlock?; at : LineInfo) : ExpressionPtr {
     comprehension.force_at(at)
     comprehension.force_generated(true)
     let newArgName = "pass_{argIndex}"
@@ -450,7 +474,26 @@ def private append_comprehension(argIndex : int; var comprehension : ExpressionP
         var $i(newArgName) <- $e(comprehension)
     }
     (blk.list.back() as ExprLet).variables[0].flags |= VariableFlags.can_shadow
+    if (argIndex != 0) {
+        blk.list |> emplace_new <| qmacro_expr() {
+            delete $e(topValue)
+        }
+    }
     return <- qmacro($i(newArgName))
+}
+
+[macro_function]
+def private fold_order_distinct(argIndex : int; var topValue : ExpressionPtr; var blk : ExprBlock?; var calls : array<tuple<ExprCall?; LinqCall?>>) : ExpressionPtr {
+    //! replaces order + distinct into a single order + unique
+    var eOrder = calls[0]._0
+    var eDistinct = calls[1]._0
+    if (argIndex == 0) {
+        var inscope comprehension <- qmacro(order_unique_folded($e(topValue)))
+        return <- append_comprehension(argIndex, topValue, comprehension, blk, calls[0]._0.at)
+    } else {
+        blk.list |> emplace_new <| qmacro(order_unique_folded_inplace($e(topValue)))
+        return <- clone_expression(topValue)
+    }
 }
 
 [macro_function]
@@ -468,29 +511,27 @@ def private fold_where_select(argIndex : int; var topValue : ExpressionPtr; var 
         selectExpr |> move_new <| new ExprVar(name := "it", at = topValue.at, _type := iterType)
     }
     var inscope comprehension <- qmacro([for (it in $e(topValue)); $e(selectExpr); where $e(whereCond)])
-    return <- append_comprehension(argIndex, comprehension, blk, calls[0]._0.at)
+    return <- append_comprehension(argIndex, topValue, comprehension, blk, calls[0]._0.at)
 }
 
 [macro_function]
 def private fold_where(argIndex : int; var topValue : ExpressionPtr; var blk : ExprBlock?; var calls : array<tuple<ExprCall?; LinqCall?>>) : ExpressionPtr {
     //! folds where + select into a single comprehension
     var eWhere = calls[0]._0
-    var inscope iterType <- clone_type(eWhere.arguments[0]._type.firstType)
     var inscope whereCond : ExpressionPtr
     whereCond |> move_new <| fold_linq_cond(eWhere.arguments[1], "it")
     var inscope comprehension <- qmacro([for (it in $e(topValue)); it; where $e(whereCond)])
-    return <- append_comprehension(argIndex, comprehension, blk, calls[0]._0.at)
+    return <- append_comprehension(argIndex, topValue, comprehension, blk, calls[0]._0.at)
 }
 
 [macro_function]
 def private fold_select(argIndex : int; var topValue : ExpressionPtr; var blk : ExprBlock?; var calls : array<tuple<ExprCall?; LinqCall?>>) : ExpressionPtr {
     //! folds select into a single comprehension
     var eSelect = calls[0]._0
-    var inscope iterType <- clone_type(eSelect.arguments[0]._type.firstType)
     var inscope selectExpr : ExpressionPtr
     selectExpr |> move_new <| fold_linq_cond(eSelect.arguments[1], "it")
     var inscope comprehension <- qmacro([for (it in $e(topValue)); $e(selectExpr)])
-    return <- append_comprehension(argIndex, comprehension, blk, calls[0]._0.at)
+    return <- append_comprehension(argIndex, topValue, comprehension, blk, calls[0]._0.at)
 }
 
 [macro_function]
@@ -500,7 +541,6 @@ def private fold_select_where(argIndex : int; var topValue : ExpressionPtr; var 
     var eWhere = calls[1]._0
     var eSelect = calls[0]._0
     var inscope iterType <- clone_type(eWhere.arguments[0]._type.firstType)
-    iterType.flags &= ~TypeDeclFlags.ref
     var inscope whereCond : ExpressionPtr
     let srcName = "`source`{argIndex}`{eSelect.at.line}`{eSelect.at.column}"
     let valName = "`value`{argIndex}`{eSelect.at.line}`{eSelect.at.column}"
@@ -532,7 +572,7 @@ def private fold_select_where(argIndex : int; var topValue : ExpressionPtr; var 
             unsafe(set_verify_array_locks($i(arrName), true))
             return <- $i(arrName)
         }, $e(topValue)))
-    return <- append_comprehension(argIndex, comprehension, blk, calls[0]._0.at)
+    return <- append_comprehension(argIndex, topValue, comprehension, blk, calls[0]._0.at)
 }
 
 [macro_function]
@@ -585,7 +625,9 @@ def private fold_linq_default(var expr : ExpressionPtr) : ExpressionPtr {
             }
             if (found != null) {
                 var sub = subarray(calls, argIndex .. argIndex + found.calls |> length)
+                print("before topValue = {describe(topValue)}\n")
                 topValue |> move_new <| found.folder(argIndex, topValue, blk.get_ptr(), sub)
+                print("after topValue = {describe(topValue)}\n")
                 argIndex += found.calls |> length
             } else {
                 if (cll._0._type.isIterator || cll._0._type.isGoodArrayType) {
@@ -635,6 +677,7 @@ def private fold_linq_default(var expr : ExpressionPtr) : ExpressionPtr {
             return <- $e(topValue)
         }
     }
+    print("BLOCK IS\n{describe(blk)}\n")
     topExpr.genFlags |= ExprGenFlags.alwaysSafe
     var inscope res <- qmacro(invoke($(source : $t(topExprType)) { $e(blk); }, $e(topExpr)))
     (((res as ExprInvoke).arguments[0] as ExprMakeBlock)._block as ExprBlock).arguments[0].flags |= VariableFlags.can_shadow
@@ -649,7 +692,7 @@ class private LinqFold : AstCallMacro {
         macro_verify(call.arguments[0]._type != null, prog, call.at, "expecting linq expression")
         var inscope res : ExpressionPtr <- fold_linq_default(call.arguments[0])
         if (res == null) {
-            prog |> macro_error(call.at, "cannot fold LINQ expression")
+            prog |> macro_error(call.at, "cannot fold LINQ expression\n{describe(call.arguments[0])}")
             return <- res
         }
         return <- res

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -696,3 +696,31 @@ def test_zip(t : T?) {
         }
     }
 }
+
+[test]
+def test_order_distinct(t : T?) {
+    t |> run("basic order distinct") <| @(t : T?) {
+        var t7 = (
+            [5, 4, 4, 3, 4, 2, 1, 1, 4, 3]
+            ._select(_ * 10)
+            .order()
+            .distinct()
+            .min()
+            ._fold()
+        )
+        t |> equal(typeinfo typename(t7), "int")
+        t |> equal(10, t7)
+    }
+    t |> run("first position order distinct") <| @(t : T?) {
+        var t7 = (
+            [5, 4, 4, 3, 4, 2, 1, 1, 4, 3]
+            .order()
+            .distinct()
+            .min()
+            ._fold()
+        )
+        t |> equal(typeinfo typename(t7), "int")
+        t |> equal(1, t7)
+    }
+}
+

--- a/tests/linq/test_linq_sorting.das
+++ b/tests/linq/test_linq_sorting.das
@@ -189,3 +189,80 @@ def test_order(t : T?) {
     }
 }
 
+[test]
+def test_unique(t : T?) {
+    t |> run("basic unique") <| @(t : T?) {
+        var numbers = [
+            1, 1, 1, 2, 2, 3, 4, 5, 1, 4
+        ]
+        var query_n = unique(numbers)
+        var expected_n = [1, 2, 3, 4, 5, 1, 4]
+        t |> equal(length(query_n), length(expected_n))
+        for (q, e in query_n, expected_n) {
+            t |> equal(q, e)
+        }
+    }
+    t |> run("complex unique") <| @(t : T?) {
+        var complex_numbers = [
+            ComplexType(a = [1, 10]),
+            ComplexType(a = [1, 10]),
+            ComplexType(a = [2, 20]),
+            ComplexType(a = [2, 20]),
+            ComplexType(a = [3, 30]),
+            ComplexType(a = [1, 10])
+        ]
+        var query_c = unique(complex_numbers)
+        var expected_c = [
+            ComplexType(a = [1, 10]),
+            ComplexType(a = [2, 20]),
+            ComplexType(a = [3, 30]),
+            ComplexType(a = [1, 10])
+        ]
+        t |> equal(length(query_c), length(expected_c))
+        for (q, e in query_c, expected_c) {
+            t |> success(q == e)
+        }
+    }
+}
+
+[test]
+def test_unique_by(t : T?) {
+    t |> run("basic unique by") <| @(t : T?) {
+        var numbers = [
+            1, 1, 1, 2, 2, 3, 4, 5, 1, 4
+        ]
+        var query_n = _unique_by(
+            numbers,
+            _
+        )
+        var expected_n = [1, 2, 3, 4, 5, 1, 4]
+        t |> equal(length(query_n), length(expected_n))
+        for (q, e in query_n, expected_n) {
+            t |> equal(q, e)
+        }
+    }
+    t |> run("complex unique by") <| @(t : T?) {
+        var complex_numbers = [
+            ComplexType(a = [1, 10]),
+            ComplexType(a = [1, 10]),
+            ComplexType(a = [2, 20]),
+            ComplexType(a = [2, 20]),
+            ComplexType(a = [3, 30]),
+            ComplexType(a = [1, 10])
+        ]
+        var query_c = _unique_by(
+            complex_numbers,
+            _.a[0]
+        )
+        var expected_c = [
+            ComplexType(a = [1, 10]),
+            ComplexType(a = [2, 20]),
+            ComplexType(a = [3, 30]),
+            ComplexType(a = [1, 10])
+        ]
+        t |> equal(length(query_c), length(expected_c))
+        for (q, e in query_c, expected_c) {
+            t |> success(q == e)
+        }
+    }
+}


### PR DESCRIPTION
order without arguments now sorts by unique_key
order/distinct and distinct/order folded into order/unique aggregate

```
    var seq = (
        [5, 4, 4, 3, 4, 2, 1, 1, 4, 3]
        .distinct()
        .order()
        ._fold()
    )
```
is the same as
```
    var t7 = (
        [5, 4, 4, 3, 4, 2, 1, 1, 4, 3]
        .order()
        .unique() // fused operation
        ._fold()
    )
```
