### PR TITLE
finalize within lambda should now work

### DIFF
--- a/include/daScript/ast/ast_expressions.h
+++ b/include/daScript/ast/ast_expressions.h
@@ -212,6 +212,7 @@ namespace das
                 bool            hasEarlyOut : 1;            // this block has return, or other blocks with return
                 bool            forLoop : 1;                // this block is a for loop
                 bool            hasExitByLabel : 1;         // whether we have goto outside of block
+                bool            isLambdaBlock : 1;           // this block is a lambda block
             };
             uint32_t            blockFlags = 0;
         };
@@ -1041,7 +1042,9 @@ namespace das
             b->at = a;
             isLambda = isl;
             isLocalFunction = islf;
-            static_pointer_cast<ExprBlock>(b)->isClosure = true;
+            auto blk = (ExprBlock *)b.get();
+            blk->isClosure = true;
+            blk->isLambdaBlock = isl;
         }
         virtual SimNode * simulate (Context & context) const override;
         virtual ExpressionPtr visit(Visitor & vis) override;

--- a/src/ast/ast_generate.cpp
+++ b/src/ast/ast_generate.cpp
@@ -606,6 +606,7 @@ namespace das {
         with->with = make_smart<ExprVar>(block->at, "__this");
         with->with->generated = true;
         with->body = block->clone();
+        ((ExprBlock *) with->body.get())->isLambdaBlock = false;    // this is now a body of the function, not a lambda block
         static_pointer_cast<ExprBlock>(with->body)->finalList.clear();
         if ( genFlags & generator_needYield ) {
             pFunc->generator = true;

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -7856,6 +7856,11 @@ namespace das {
                                     return Visitor::visitLet(expr,var,last);
                                 }
 
+                            } else if ( scopes.back()->isLambdaBlock ) {
+                                var->inScope = false;
+                                error("internal error. in-scope variable in lambda gets converted as part of the lambda function", "", "",
+                                    var->at, CompilationError::invalid_variable_type);
+                                return Visitor::visitLet(expr,var,last);
                             } else {
                                 scopes.back()->finalList.insert(scopes.back()->finalList.begin(), exprDel);
                             }

--- a/src/builtin/module_builtin_ast_flags.cpp
+++ b/src/builtin/module_builtin_ast_flags.cpp
@@ -51,7 +51,7 @@ namespace das {
         ft->argNames = { "isClosure", "hasReturn", "copyOnReturn", "moveOnReturn",
             "inTheLoop", "finallyBeforeBody", "finallyDisabled","aotSkipMakeBlock",
             "aotDoNotSkipAnnotationData", "isCollapseable", "needCollapse", "hasMakeBlock",
-            "hasEarlyOut", "forLoop" };
+            "hasEarlyOut", "forLoop", "hasExitByLabel", "isLambdaBlock" };
         return ft;
     }
 

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2306,7 +2306,7 @@ namespace das {
     }
 
     uint32_t AstSerializer::getVersion () {
-        static constexpr uint32_t currentVersion = 61;
+        static constexpr uint32_t currentVersion = 62;
         return currentVersion;
     }
 


### PR DESCRIPTION
```
struct FooBar {}

def foo(a: lambda<(xx:array<FooBar>):void>) {}

[export]
def main() {
    foo(@(bar : array<FooBar>) {
        var inscope hitsPlayers : array<int> // no longer fails here
    })
}
```