### PR TITLE
no more bugs in alias substitution of bitfields

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -9183,7 +9183,7 @@ namespace das {
                         expr->at, CompilationError::invalid_cast);
                     return Visitor::visit(expr);
                 }
-                auto ecast = make_smart<ExprCast>(expr->at, expr->arguments[0]->clone(), expr->aliasSubstitution );
+                auto ecast = make_smart<ExprCast>(expr->at, expr->clone(), expr->aliasSubstitution );
                 ecast->reinterpret = true;
                 ecast->alwaysSafe = true;
                 expr->aliasSubstitution.reset();


### PR DESCRIPTION
```
def private construct_generic(a : double; val : auto(TT)) {
    return TT(a) // USED TO BE BROKEN
}
[export]
def main() {
    print("{int(construct_generic(double(1.321), default<bitfield>))}\n");
}
```