### PR TITLE
correct stride for the vector safe-index

### DIFF
--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -1776,7 +1776,7 @@ namespace das
                 auto prv = subexpr->simulate(context);
                 auto pidx = index->simulate(context);
                 uint32_t range = seT->getVectorDim();
-                uint32_t stride = type->getSizeOf();
+                uint32_t stride = getTypeBaseSize(seT->getVectorBaseType());
                 return context.code->makeNode<SimNode_SafeAt>(at, prv, pidx, stride, 0, range);
             } else {
                 DAS_VERIFY(0 && "TODO: safe-at not implemented");


### PR DESCRIPTION
```
[export]
def main() {
    var f2_x  = float2(1, 2)
    var f2_y = f2_x?[1] ?? float(-1) // no longer incorrect result due to incorrect stride
    print("f2_y = {f2_y}\n");
}
```