### PR TITLE
empty array or table inititalizations with type are now ok

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -7943,7 +7943,7 @@ namespace das {
             }
         }
         bool isEmptyInit ( const VariablePtr & var ) const {
-            if ( var->type && var->init && var->init_via_move ) {
+            if ( var->type && var->init ) {
                 if ( var->init->rtti_isMakeStruct() ) {
                     auto ma = (ExprMakeStruct *)(var->init.get());
                     if ( ma->structs.empty() && ma->makeType  ) {


### PR DESCRIPTION
this two are now ok
```
    let a : array<float> <- []
    let x : table<int, string> <- {}
```