### PR TITLE
Fix compiler error with copy elision

### DIFF
--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -3692,7 +3692,7 @@ namespace das {
         explicit ArgsConverter() {}
 
         string str() {
-            return std::move(ss.str());
+            return ss.str();
         }
 
         // function


### PR DESCRIPTION
Fix compiler error:
calling 'std::move' on a temporary object prevents copy elision