### PR TITLE
Added global skip lock check flag

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1471,6 +1471,7 @@ namespace das
         /*option*/ bool rtti = false;                              // create extended RTTI
     // language
         /*option*/ bool unsafe_table_lookup = true;                // table lookup (tab[key]) to be unsafe
+        /*option*/ bool skip_lock_check = false;                   // skip all lock check
         /*option*/ bool relaxed_pointer_const = false;             // allow const correctness to be relaxed on pointers
         bool version_2_syntax = false;                  // use syntax version 2
         bool gen2_make_syntax = false;                  // only new make syntax is allowed (no [[...]] or [{...}])

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -4060,6 +4060,7 @@ namespace das {
 
     // ExprTypeInfo
         bool skipLockCheck() const {
+            if ( program->policies.skip_lock_check ) return true;                   // if code of policy we should skip
             if ( program->thisModule->skipLockCheck ) return true;                  // if this module has options skip_lock_check - we skip
             if ( func ) {
                 if ( func->skipLockCheck ) return true;                             // if this function is [skip_lock_check] - we skip

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2182,6 +2182,7 @@ namespace das {
               << value.max_string_heap_allocated
               << value.rtti
               << value.unsafe_table_lookup
+              << value.skip_lock_check
               << value.relaxed_pointer_const
               << value.version_2_syntax
               << value.gen2_make_syntax
@@ -2316,7 +2317,7 @@ namespace das {
     }
 
     uint32_t AstSerializer::getVersion () {
-        static constexpr uint32_t currentVersion = 68;
+        static constexpr uint32_t currentVersion = 69;
         return currentVersion;
     }
 


### PR DESCRIPTION
Why: that really useful when we have a lot of table access in compile time and we want to speedup compilation time in dev mode