### PR TITLE
fix linux 32-bit (__ILP32__) compilation

### DIFF
--- a/include/daScript/ast/ast_typedecl.h
+++ b/include/daScript/ast/ast_typedecl.h
@@ -3,7 +3,7 @@
 #include "daScript/ast/ast_typefactory.h"
 #include "daScript/simulate/jit_abi.h"
 #include "daScript/misc/free_list.h"
-#include <limits.h> // ULLONG_MAX
+#include <limits.h> // ULONG_MAX
 
 namespace das {
 
@@ -334,7 +334,7 @@ namespace das {
     template<> struct ToBasicType<long double>      { enum { type = Type::tDouble }; };
     template<> struct ToBasicType<wchar_t>          { enum { type = Type::tUInt16 }; };
 #endif
-#if !defined(_MSC_VER) && !defined(__APPLE__) && !defined(_EMSCRIPTEN_VER) && defined(ULLONG_MAX) && ULLONG_MAX == 0xffffffffffffffffULL
+#if !defined(_MSC_VER) && !defined(__APPLE__) && !defined(_EMSCRIPTEN_VER) && defined(ULONG_MAX) && ULONG_MAX == UINT64_MAX
     template<> struct ToBasicType<long long int>      { enum { type = Type::tInt64 }; };
     template<> struct ToBasicType<unsigned long long int>     { enum { type = Type::tUInt64 }; };
 #endif

--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -408,7 +408,7 @@ inline size_t das_aligned_memsize(void * ptr){
 #define DAS_MACRO_SANITIZER 0
 #endif
 
-#if !_TARGET_64BIT && !defined(__clang__) && (_MSC_VER <= 1900)
+#if defined(_M_IX86) && defined(_MSC_VER) && !defined(__clang__) && _MSC_VER <= 1900
 #define _msc_inline_bug __declspec(noinline)
 #else
 #define _msc_inline_bug __forceinline

--- a/include/daScript/simulate/cast.h
+++ b/include/daScript/simulate/cast.h
@@ -3,7 +3,7 @@
 #include "daScript/misc/vectypes.h"
 #include "daScript/misc/arraytype.h"
 #include "daScript/misc/rangetype.h"
-#include <limits.h> // ULLONG_MAX
+#include <limits.h> // ULONG_MAX
 
 namespace das
 {
@@ -338,7 +338,7 @@ namespace das
         static __forceinline vec4f from ( uint64_t x )         { return v_cast_vec4f(v_ldui_half(&x)); }
     };
 
-#if !defined(_MSC_VER) && !defined(__APPLE__) && !defined(_EMSCRIPTEN_VER) && defined(ULLONG_MAX) && ULLONG_MAX == 0xffffffffffffffffULL
+#if !defined(_MSC_VER) && !defined(__APPLE__) && !defined(_EMSCRIPTEN_VER) && defined(ULONG_MAX) && ULONG_MAX == UINT64_MAX
     template <>
     struct cast <long long int> {
         static __forceinline long long int to ( vec4f x )            { return v_extract_xi64(v_cast_vec4i(x)); }


### PR DESCRIPTION
* Fix invalid check for ULLONG_MAX compilation, do check ULONG_MAX instead: there is no point to checking long long max as it's guaranteed to be (at least) 64 bit, see
https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models
* Fix invalid old msvc inline workaround bug, invalid #if conditions caused all 32-bit platforms to be treated as msvc compiler