### PR TITLE
minimal late shutdown support

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -966,6 +966,7 @@ namespace das
 
                 bool    unsafeWhenNotCloneArray : 1; // this one is used to mark functions which are unsafe when not cloning arrays
                 bool    stub : 1;                    // skip stack allocation, optimizations, etc
+                bool    lateShutdown : 1;
             };
             uint32_t moreFlags = 0;
         };

--- a/include/daScript/simulate/debug_info.h
+++ b/include/daScript/simulate/debug_info.h
@@ -437,6 +437,7 @@ namespace das
         ,   flag_private = (1<<2)
         ,   flag_shutdown = (1<<3)
         ,   flag_late_init = (1<<5)
+        ,   flag_late_shutdown = (1<<6)
         };
         const char *            name;
         const char *            cppName;

--- a/src/ast/ast_allocate_stack.cpp
+++ b/src/ast/ast_allocate_stack.cpp
@@ -972,6 +972,11 @@ namespace das {
                             if (func->lateInit ) logs << "(late)";
                             logs << "]";
                         }
+                        if ( func->shutdown ) {
+                            logs << " [finalize";
+                            if (func->lateShutdown ) logs << "(late)";
+                            logs << "]";
+                        }
                         logs << " // " << HEX << func->getMangledNameHash() << DEC;
                         logs << "\n";
                     }

--- a/src/ast/ast_debug_info_helper.cpp
+++ b/src/ast/ast_debug_info_helper.cpp
@@ -110,7 +110,10 @@ namespace das {
             fni->flags |= FuncInfo::flag_init;
             if ( fn.lateInit ) fni->flags |= FuncInfo::flag_late_init;
         }
-        if ( fn.shutdown ) fni->flags |= FuncInfo::flag_shutdown;
+        if ( fn.shutdown ) {
+            fni->flags |= FuncInfo::flag_shutdown;
+            if ( fn.lateShutdown ) fni->flags |= FuncInfo::flag_late_shutdown;
+        }
         if ( fn.builtIn ) fni->flags |= FuncInfo::flag_builtin;
         if ( fn.privateFunction ) fni->flags |= FuncInfo::flag_private;
         fni->result = makeTypeInfo(nullptr, fn.result);

--- a/src/ast/ast_print.cpp
+++ b/src/ast/ast_print.cpp
@@ -324,7 +324,7 @@ namespace das {
             if ( fn->init ) { ss << "[init" << (fn->lateInit ? "(late)" : "") << "]\n"; }
             if ( fn->macroInit ) { ss << "[macro_init]\n"; }
             if ( fn->macroFunction ) { ss << "[macro_function]\n"; }
-            if ( fn->shutdown ) { ss << "[finalize]\n"; }
+            if ( fn->shutdown ) { ss << "[finalize" << (fn->lateShutdown ? "(late)" : "") << "]\n"; }
             if ( fn->unsafeDeref ) { ss << "[unsafe_deref]\n"; }
             if ( fn->unsafeOperation ) { ss << "[unsafe_operation]\n"; }
             if ( fn->isClassMethod ) { ss << "[class_method(" << fn->classParent->getMangledName() << ")]\n"; }

--- a/src/builtin/module_builtin_ast_flags.cpp
+++ b/src/builtin/module_builtin_ast_flags.cpp
@@ -201,7 +201,7 @@ namespace das {
             "unsafeOutsideOfFor", "skipLockCheck", "safeImplicit", "deprecated", "aliasCMRES", "neverAliasCMRES",
             "addressTaken", "propertyFunction", "pinvoke", "jitOnly", "isStaticClassMethod", "requestNoJit",
             "jitContextAndLineInfo", "nodiscard", "captureString", "callCaptureString", "hasStringBuilder",
-            "recursive", "isTemplate", "unsafeWhenNotCloneArray", "stub"
+            "recursive", "isTemplate", "unsafeWhenNotCloneArray", "stub", "lateShutdown"
         };
         return ft;
     }

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2323,7 +2323,7 @@ namespace das {
     }
 
     uint32_t AstSerializer::getVersion () {
-        static constexpr uint32_t currentVersion = 69;
+        static constexpr uint32_t currentVersion = 70;
         return currentVersion;
     }
 

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -314,8 +314,13 @@ namespace das
 
     struct FinalizeFunctionAnnotation : MarkFunctionAnnotation {
         FinalizeFunctionAnnotation() : MarkFunctionAnnotation("finalize") { }
-        virtual bool apply(const FunctionPtr & func, ModuleGroup &, const AnnotationArgumentList &, string &) override {
+        virtual bool apply(const FunctionPtr & func, ModuleGroup &, const AnnotationArgumentList & args, string &) override {
             func->shutdown = true;
+            for ( auto & arg : args ) {
+                if ( arg.name=="late" && arg.type == Type::tBool ) {
+                    func->lateShutdown = arg.bValue;
+                }
+            }
             return true;
         };
         virtual bool finalize(const FunctionPtr & func, ModuleGroup &, const AnnotationArgumentList &, const AnnotationArgumentList &, string & errors) override {


### PR DESCRIPTION
```
[finalize] def a {
    print("a\n")
}
[finalize] def b {
    print("b\n")
}
[finalize(late)] def c {
    print("c\n")
}
[finalize] def d {
    print("d\n")
}
```
order is a,b,d,c