### PR TITLE
fixing let issues with relocate

### DIFF
--- a/include/daScript/ast/ast_expressions.h
+++ b/include/daScript/ast/ast_expressions.h
@@ -488,6 +488,7 @@ namespace das
             struct {
                 bool allowCopyTemp : 1;
                 bool takeOverRightStack : 1;
+                bool allowConstantLValue : 1;
             };
             uint32_t copyFlags = 0;
         };
@@ -506,6 +507,7 @@ namespace das
             struct {
                 bool skipLockCheck : 1;
                 bool takeOverRightStack : 1;
+                bool allowConstantLValue : 1;
             };
             uint32_t moveFlags = 0;
         };

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -6875,7 +6875,7 @@ namespace das {
             } else if ( !expr->right->type->isRef() && !expr->right->type->isMoveableValue() ) {
                 error("can only move to from a reference"+moveErrorInfo(expr), "", "",
                     expr->at, CompilationError::cant_write_to_non_reference);
-            } else if ( expr->left->type->constant ) {
+            } else if ( !expr->allowConstantLValue && expr->left->type->constant ) {
                 error("can't move to a constant value"+moveErrorInfo(expr), "", "",
                     expr->at, CompilationError::cant_move_to_const);
             } else if ( !expr->left->type->canMove() ) {
@@ -6946,7 +6946,7 @@ namespace das {
             } else if ( !expr->left->type->isRef() ) {
                 error("can only copy to a reference"+copyErrorInfo(expr), "", "",
                     expr->at, CompilationError::cant_write_to_non_reference);
-            } else if ( expr->left->type->constant ) {
+            } else if ( !expr->allowConstantLValue && expr->left->type->constant ) {
                 error("can't write to a constant value"+copyErrorInfo(expr), "", "",
                     expr->at, CompilationError::cant_write_to_const);
             } else if ( !expr->allowCopyTemp && expr->right->type->isTemp(true,false) ) {

--- a/src/builtin/module_builtin_ast_flags.cpp
+++ b/src/builtin/module_builtin_ast_flags.cpp
@@ -238,14 +238,14 @@ namespace das {
     TypeDeclPtr makeExprCopyFlags() {
         auto ft = make_smart<TypeDecl>(Type::tBitfield);
         ft->alias = "CopyFlags";
-        ft->argNames = { "allowCopyTemp", "takeOverRightStack", "promoteToClone" };
+        ft->argNames = { "allowCopyTemp", "takeOverRightStack", "allowConstantLValue" };
         return ft;
     }
 
     TypeDeclPtr makeExprMoveFlags() {
         auto ft = make_smart<TypeDecl>(Type::tBitfield);
         ft->alias = "MoveFlags";
-        ft->argNames = { "skipLockCheck", "takeOverRightStack" };
+        ft->argNames = { "skipLockCheck", "takeOverRightStack", "allowConstantLValue" };
         return ft;
     }
 


### PR DESCRIPTION
fixes 'let x <- foo' and 'let x = foo' when x needs to relocate due to initialization