### PR TITLE
pod delete optimization now creates temporary variables for the for-loop arrays

### DIFF
--- a/daslib/decs.das
+++ b/daslib/decs.das
@@ -706,6 +706,7 @@ def public for_each_archetype_find(hash : ComponentHash; var erq : function<() :
 }
 
 // [template(atype)]
+[unsafe_operation]
 def decs_array(atype : auto(TT); src : array<uint8>; capacity : int) {
     //! Low level function returns temporary array of component given specific type of component.
     assert(length(src) > 0)
@@ -724,6 +725,7 @@ def decs_array(atype : auto(TT); src : array<uint8>; capacity : int) {
     }
 }
 
+[unsafe_outside_of_for]
 def public get(arch : Archetype; name : string; value : auto(TT)) {
     //! Creates temporary array of component given specific name and type of component.
     //! If component is not found - panic.
@@ -759,7 +761,7 @@ def public get(arch : Archetype; name : string; value : auto(TT)) {
     }
 }
 
-[expect_dim(value)]
+[expect_dim(value), unsafe_outside_of_for]
 def public get_ro(arch : Archetype; name : string; value : auto(TT)[]) : array<TT[typeinfo sizeof(value)] -const -& -#> const {
     //! Returns const temporary array of component given specific name and type of component for array components.
     unsafe {
@@ -767,7 +769,7 @@ def public get_ro(arch : Archetype; name : string; value : auto(TT)[]) : array<T
     }
 }
 
-[!expect_dim(value)]
+[!expect_dim(value), unsafe_outside_of_for]
 def public get_ro(arch : Archetype; name : string; value : auto(TT)) : array<TT -const -& -#> const {
     //! Returns const temporary array of component given specific name and type of component for regular components.
     unsafe {

--- a/daslib/decs_boost.das
+++ b/daslib/decs_boost.das
@@ -216,7 +216,9 @@ def private append_index_lookup(arch_name : string; var qblock : smart_ptr<ExprB
         var inscope ftype <- clone_type(a._type)
         ftype.flags &= ~TypeDeclFlags.constant
         ftype.flags &= ~TypeDeclFlags.ref
-        move(iget, get_ptr(qmacro($c(getter)($i(arch_name), $v("{prefix}{a.name}"), unsafe(type<$t(ftype)>))[entity_index])))
+        var inscope getFn <- qmacro($c(getter)($i(arch_name), $v("{prefix}{a.name}"), unsafe(type<$t(ftype)>)))
+        getFn.genFlags |= ExprGenFlags.alwaysSafe
+        move(iget, get_ptr(qmacro($e(getFn)[entity_index])))
         force_generated(iget, true)
     }
     var inscope vlet <- new ExprLet(at = a.at, atInit = a.at)


### PR DESCRIPTION
```
options force_inscope_pod
def mk {
    return <- [1,2,3,4,5]
}
[export]
def main {
    for ( x in mk() ) { // contentsof a temporary array will be collected after the loop
        print("{x}\n")
    }
}
```