### PR TITLE
jit: fix llvm

### DIFF
--- a/examples/test/unit_tests/bitfields.das
+++ b/examples/test/unit_tests/bitfields.das
@@ -5,14 +5,38 @@ bitfield bits123 {
     three,
 }
 
+bitfield bits123_8 : uint8 {
+    one,
+    two,
+    three,
+}
+
+bitfield bits123_16 : uint16 {
+    one,
+    two,
+    three,
+}
+
+bitfield bits123_64 : uint64 {
+    one,
+    two,
+    three,
+}
+
 [sideeffects]
 def bit(b : int) {
     return bitfield(1 << b)
 }
 
+// Use global mutable variables to avoid optimizations.
+var t : bitfield < one; two; three > = bitfield(1 << 1) | bit(2)
+var bf_8 : bits123_8 = bits123_8.one
+var bf_16 : bits123_16 = bits123_16.two
+var bf : bits123 = bits123.three
+var bf_64 : bits123_64 = bits123_64.one
+
 [export]
 def test() {
-    var t : bitfield < one; two; three > = bitfield(1 << 1) | bit(2)
     assert(!t.one && t.two && t.three)
     assert("{t}" == "(two|three)")
     t ^= bitfield(1 << 1)
@@ -20,5 +44,10 @@ def test() {
     assert(t == bits123.three)
     t |= bitfield(1 << 0)
     assert(t.one && !t.two && t.three)
+
+    assert(bf_8.one && !bf_8.two)
+    assert(bf_16.two && !bf_8.three)
+    assert(bf.three && !bf.one)
+    assert(bf_64.one && !bf_64.two)
     return true
 }

--- a/modules/dasLLVM/daslib/llvm_boost.das
+++ b/modules/dasLLVM/daslib/llvm_boost.das
@@ -92,6 +92,14 @@ class PrimitiveTypes {
         return LLVMPointerType(t_int8, 0u)
     }
 
+    def ConstI8(val : int8) {
+        return LLVMConstInt(t_int8, val |> uint64(), 0);
+    }
+
+    def ConstI16(val : int16) {
+        return LLVMConstInt(t_int16, val |> uint64, 0);
+    }
+
     def ConstI32(val : uint64) {
         return LLVMConstInt(t_int32, val, 0);
     }

--- a/modules/dasLLVM/daslib/llvm_dll_utils.das
+++ b/modules/dasLLVM/daslib/llvm_dll_utils.das
@@ -95,6 +95,10 @@ class UidGen : AstVisitor {
         add(get_ptr(expr))
     }
 
+    def override preVisitExprMakeBlock(expr : smart_ptr<ExprMakeBlock>) {
+        add(get_ptr(expr))
+    }
+
 }
 
 class public UidNodes {
@@ -164,6 +168,10 @@ class public UidNodes {
 
     def public get_block_name(blk : smart_ptr<ExprBlock>) : DllName {
         return get_base(get_ptr(blk), "block_{get_mangled_name(blk)}")
+    }
+
+    def public get_block_ann(mk_blk : smart_ptr<ExprMakeBlock>) : DllName {
+        return get_base(get_ptr(mk_blk), "makeblock_ann")
     }
 
     def reset(var func : Function?) {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -4343,10 +4343,26 @@ class LlvmJitVisitor : AstVisitor {
 
     def override visitExprField(expr : smart_ptr<ExprField>) : ExpressionPtr {
         var field_ptr : LLVMOpaqueValue?;
-        if (expr.value._type.isBitfield) {
+        assume value_t = expr.value._type
+        if (value_t.isBitfield) {
             let mask = 1u << uint(expr.fieldIndex)
-            let mand = LLVMBuildAnd(g_builder, getE(expr.value), types.ConstI32(uint64(mask)), "")
-            let if_not_zero = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, mand, types.ConstI32(uint64(0)), "")
+            var llvm_mask : LLVMOpaqueValue? = null
+            var llvm_zero : LLVMOpaqueValue? = null
+            if (value_t.baseType == Type.tBitfield) {
+                llvm_mask = types.ConstI32(uint64(mask))
+                llvm_zero = types.ConstI32(uint64(0))
+            } elif (value_t.baseType == Type.tBitfield8) {
+                llvm_mask = types.ConstI8(mask |> int8)
+                llvm_zero = types.ConstI8(0 |> int8)
+            } elif (value_t.baseType == Type.tBitfield16) {
+                llvm_mask = types.ConstI16(mask |> int16)
+                llvm_zero = types.ConstI16(0 |> int16)
+            } elif (value_t.baseType == Type.tBitfield64) {
+                llvm_mask = types.ConstI64(uint64(mask))
+                llvm_zero = types.ConstI64(uint64(0))
+            }
+            let mand = LLVMBuildAnd(g_builder, getE(expr.value), llvm_mask, "")
+            let if_not_zero = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, mand, llvm_zero, "")
             var res_type = type_to_llvm_type(expr._type)
             var res = build_select(if_not_zero, res_type) <| $() {
                 return LLVMConstInt(types.t_int1, uint64(1), 0)
@@ -4954,14 +4970,21 @@ class LlvmJitVisitor : AstVisitor {
         // call jit_make_block
         var blk_ptr = LLVMBuildPointerCast(g_builder, blk, LLVMPointerType(g_t_block, 0u), "")
         let argStackTop = (expr._block as ExprBlock).stackTop
-        let annotationData = (expr._block as ExprBlock).annotationData
+        let annotationData = (expr._block as ExprBlock).annotationData |> uint64()
+        var ann_data_ptr : LLVMOpaqueValue? = null
+        if (annotationData != 0 |> uint64()) {
+            ann_data_ptr = LLVMBuildPtrToInt(g_builder, save_address_global(uid.get_block_ann(expr), unsafe(reinterpret<void?>(annotationData))), types.LLVMIntPtrType(), "")
+        } else {
+            // Just an optimization.
+            ann_data_ptr = LLVMConstInt(types.t_int64, 0 |> uint64(), 0)
+        }
         let null_ptr = LLVMConstPointerNull(types.LLVMVoidPtrType())
         let func_ptr = LLVMBuildPointerCast(g_builder, blk_make.func, types.LLVMVoidPtrType(), "")
         let impl_ptr = LLVMBuildPointerCast(g_builder, blk_make.impl, types.LLVMVoidPtrType(), "")
         var params = fixed_array(
             blk_ptr,                                                    // blk
-            types.ConstI32(uint64(argStackTop)),      // argStackTop
-            LLVMConstInt(types.t_int64, uint64(annotationData), 0),   // annotation data
+            types.ConstI32(uint64(argStackTop)),                        // argStackTop
+            ann_data_ptr,                                               // annotation data
             func_ptr,                                                   // bodyNode
             impl_ptr,                                                   // jitImpl
             null_ptr,                                                   // TODO: funcInfo
@@ -5012,13 +5035,14 @@ class LlvmJitVisitor : AstVisitor {
 
 // ExprConstInt8
     def override visitExprConstInt8(expr : smart_ptr<ExprConstInt8>) : ExpressionPtr {
+        setE(expr, types.ConstI8(expr.value))
         setE(expr, LLVMConstInt(types.t_int8, uint64(expr.value), 0))
         return expr
     }
 
 // ExprConstInt16
     def override visitExprConstInt16(expr : smart_ptr<ExprConstInt16>) : ExpressionPtr {
-        setE(expr, LLVMConstInt(types.t_int16, uint64(expr.value), 0))
+        setE(expr, types.ConstI16(expr.value))
         return expr
     }
 
@@ -5839,6 +5863,11 @@ class ResolveExternVisitor : AstVisitor {
 
     def override preVisitExprMakeBlock(expr : smart_ptr<ExprMakeBlock>) : void {
         thisBlock |> push <| get_ptr(unsafe(reinterpret<smart_ptr<ExprBlock>> expr._block))
+
+        let annotationData = (expr._block as ExprBlock).annotationData
+        if (annotationData != 0 |> uint64()) {
+            dll.set_glob_address(uid.get_block_ann(expr), unsafe(reinterpret<void?>(annotationData)))
+        }
     }
 
     def override visitExprMakeBlock(expr : smart_ptr<ExprMakeBlock>) : ExpressionPtr {


### PR DESCRIPTION
- Add tests for bitfields of different size
- Fix `annotationData` in dll mode in JIT. This was already tested in daScriptProfile, but we didn't run it in CI.