### PR TITLE
one macro to run them all

### DIFF
--- a/daslib/templates_boost.das
+++ b/daslib/templates_boost.das
@@ -1179,7 +1179,7 @@ class private AstQNamedMacro : AstCallMacro {
             macro_error(prog, call.at, "expecting 2 arguments, {macro_call}(name,expression)")
             return <- default<ExpressionPtr>
         }
-        if (!(call.arguments[0]._type.isString)) {
+        if (call.arguments[0]._type == null || !(call.arguments[0]._type.isString)) {
             macro_error(prog, call.at, "expecting function name, {macro_call}(NAME,expression)")
             return <- default<ExpressionPtr>
         }

--- a/daslib/typemacro_boost.das
+++ b/daslib/typemacro_boost.das
@@ -454,3 +454,58 @@ class TemplateTypeMacroMacro : AstFunctionAnnotation {
         return true
     }
 }
+
+[structure_macro(name="template_structure")]
+class TemplateStructure : AstStructureAnnotation {
+    //! This macro creates typemacro function and associates it with the structure.
+    //! It also creates the typemacro_template_function to associate with it.
+    //! For example:
+    //! [template_structure(KeyType,ValueType)] struct template TFlatHashTable { ... }
+    //! creates:
+    //! 1) [typemacro_function] def TFlatHashTable (macroArgument, passArgument : TypeDeclPtr; KeyType, ValueType : TypeDeclPtr) : TypeDeclPtr {
+    //!     return <- make`template`TFlatHashTable(macroArgument, passArgument, KeyType, ValueType)
+    //!  }
+    //! 2) [typemacro_template_function(TFlatHashTable)] def make`template`TFlatHashTable (macroArgument, passArgument : TypeDeclPtr; KeyType, ValueType : TypeDeclPtr) : TypeDeclPtr {
+    //!     return <- default<TypeDeclPtr>
+    //!  }
+    def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
+        if (length(args) == 0) {
+            errors := "expecting at least one template argument name"
+            return false
+        }
+        var inscope template_arguments <- [for (arg in args); string(arg.name)] // todo: support types?
+        let makeFuncName = "make`template`{st.name}"
+        var inscope ctxFnArguments : array<VariablePtr>
+        for (name in template_arguments) {
+            // let name = argName
+            ctxFnArguments |> emplace_new <| new Variable(
+                name := name,
+                _type <- new TypeDecl(baseType = Type.alias, alias := "TypeDeclPtr"),
+                at = st.at
+            )
+        }
+        var inscope makeFunction <- qmacro_function(makeFuncName) <| $(macroArgument, passArgument : TypeDeclPtr; $a(ctxFnArguments)) : TypeDeclPtr {
+            return <- default<TypeDeclPtr>
+        }
+        append_annotation(makeFunction, "typemacro_boost", "typemacro_template_function", [
+             (("{st.name}", RttiValue(tBool=true))
+        )])
+        if (!(compiling_module() |> add_function(makeFunction))) {
+            panic("can't add function {makeFuncName}")
+        }
+
+        let typeMacroFunctionName = string(st.name)
+        var inscope callMacroFunction <- qmacro($c(makeFuncName)(macroArgument, passArgument))
+        for (name in template_arguments) {
+            (callMacroFunction as ExprCall).arguments |> emplace_new <| qmacro($i(name))
+        }
+        var inscope typeMacroFunction <- qmacro_function(typeMacroFunctionName) <| $(macroArgument, passArgument : TypeDeclPtr; $a(ctxFnArguments)) : TypeDeclPtr {
+            return <- $e(callMacroFunction)
+        }
+        append_annotation(typeMacroFunction, "typemacro_boost", "typemacro_function", [])
+        if (!(compiling_module() |> add_function(typeMacroFunction))) {
+            panic("can't add function {typeMacroFunctionName}")
+        }
+        return true
+    }
+}

--- a/examples/profile/hash_test/slot_map.das
+++ b/examples/profile/hash_test/slot_map.das
@@ -10,16 +10,16 @@ require daslib/templates_boost
 require daslib/typemacro_boost
 require daslib/macro_boost
 
-[skip_field_lock_check]
-struct template TSlotMap {
+[skip_field_lock_check, template_structure(HashMapType)]
+struct template SlotMap {
     id : uint64
     hashMap : HashMapType
-    def TSlotMap {
+    def SlotMap {
         static_if (!typeinfo is_table(type<HashMapType>)) {
             hashMap <- HashMapType()
         }
     }
-    def static emplace(var self : TSlotMap explicit; val : int) {
+    def static emplace(var self : SlotMap explicit; val : int) {
         with (self) {
             let r = id
             unsafe(hashMap[id]) = val
@@ -28,15 +28,3 @@ struct template TSlotMap {
         }
     }
 }
-
-[typemacro_template_function(TSlotMap)]
-def private makeSlotMap(macroArgument, passArgument : TypeDeclPtr; HashMapType : TypeDeclPtr) : TypeDeclPtr {
-    //! generated template boilerplate for TSlotMap
-    return <- default<TypeDeclPtr>
-}
-
-[typemacro_function]
-def SlotMap(macroArgument, passArgument : TypeDeclPtr; HashMapType : TypeDeclPtr) : TypeDeclPtr {
-    return <- makeSlotMap(macroArgument, passArgument, HashMapType)
-}
-


### PR DESCRIPTION
this one automatically writes both typemacro and its implementation out of template
```
[template_structure(HashMapType)] // this is template with one argument (HashMapType)
struct template SlotMap {
   ...
```