### PR TITLE
default arguments for typemacros

### DIFF
--- a/daslib/cuckoo_hash_table.das
+++ b/daslib/cuckoo_hash_table.das
@@ -406,13 +406,7 @@ def private makeCuckooHashTable(macroArgument, passArgument : TypeDeclPtr; KeyTy
 }
 
 [typemacro_function]
-def CuckooHashTable(macroArgument, passArgument : TypeDeclPtr; KeyType, ValueType : TypeDeclPtr) : TypeDeclPtr {
-    //! CuckooHashTable<K;V> is a hash map that uses open addressing with linear probing and default hash function.
-    return <- makeCuckooHashTable(macroArgument, passArgument, KeyType, ValueType, "hash", "hash_extra")
-}
-
-[typemacro_function]
-def CuckooHashTableEx(macroArgument, passArgument : TypeDeclPtr; KeyType, ValueType : TypeDeclPtr; hashName, hash0name : string) : TypeDeclPtr {
+def CuckooHashTable(macroArgument, passArgument : TypeDeclPtr; KeyType, ValueType : TypeDeclPtr; hashName : string = "hash"; hash0name : string = "hash_extra") : TypeDeclPtr {
     //! CuckooHashTableEx<K;V;hashName> is a hash map that uses open addressing with linear probing and custom hash function.
     return <- makeCuckooHashTable(macroArgument, passArgument, KeyType, ValueType, hashName, hash0name)
 }

--- a/daslib/flat_hash_table.das
+++ b/daslib/flat_hash_table.das
@@ -353,13 +353,7 @@ def private makeFlatHashTable(macroArgument, passArgument : TypeDeclPtr; KeyType
 }
 
 [typemacro_function]
-def FlatHashTable(macroArgument, passArgument : TypeDeclPtr; KeyType, ValueType : TypeDeclPtr) : TypeDeclPtr {
-    //! FlatHashTable<K;V> is a hash map that uses open addressing with linear probing and default hash function.
-    return <- makeFlatHashTable(macroArgument, passArgument, KeyType, ValueType, "hash")
-}
-
-[typemacro_function]
-def FlatHashTableEx(macroArgument, passArgument : TypeDeclPtr; KeyType, ValueType : TypeDeclPtr; hashName : string) : TypeDeclPtr {
+def FlatHashTable(macroArgument, passArgument : TypeDeclPtr; KeyType, ValueType : TypeDeclPtr; hashName : string = "hash") : TypeDeclPtr {
     //! FlatHashTableEx<K;V;hashName> is a hash map that uses open addressing with linear probing and custom hash function.
     return <- makeFlatHashTable(macroArgument, passArgument, KeyType, ValueType, hashName)
 }

--- a/daslib/typemacro_boost.das
+++ b/daslib/typemacro_boost.das
@@ -55,6 +55,69 @@ def public get_string_const(expr : ExpressionPtr) : string {
     return ""
 }
 
+[macro_function]
+def public typemacro_argument(dimExpr; index : int; var constType : auto(ExprConstType); var defaultValue : auto(ValueT)) : ValueT {
+    if (index < length(dimExpr)) {
+        if (dimExpr[index].__rtti == typeinfo undecorated_typename(type<ExprConstType>)) {
+            defaultValue = unsafe(reinterpret<ExprConstType?>(dimExpr[index])).value
+        } else {
+            panic("expecting {typeinfo undecorated_typename(type<ExprConstType>)} constant")
+        }
+    }
+    return defaultValue
+}
+
+[macro_function]
+def public typemacro_argument(dimExpr; index : int; var constType : ExprConstString; var defaultValue : auto(ValueT)) : ValueT {
+    if (index < length(dimExpr)) {
+        if (dimExpr[index].__rtti == "ExprConstString") {
+            defaultValue := unsafe(reinterpret<ExprConstString?>(dimExpr[index])).value
+        } elif (dimExpr[index].__rtti == "ExprAddr") {
+            defaultValue := string(unsafe(reinterpret<ExprAddr?>(dimExpr[index])).target)
+        } else {
+            panic("expecting string constant or function address")
+        }
+    }
+    return defaultValue
+}
+
+[macro_function]
+def public typemacro_default_value(argDefaultValue : ExpressionPtr; var constType : auto(ExprConstType); var defaultValue : auto(TT)&; var errors : das_string) : bool {
+    if (argDefaultValue != null) {
+        if (argDefaultValue.__rtti == typeinfo undecorated_typename(type<ExprConstType>)) {
+            defaultValue = unsafe(reinterpret<ExprConstType?>(argDefaultValue)).value
+            return true
+        } else {
+            errors := "expecting {typeinfo undecorated_typename(type<ExprConstType>)} constant as default value"
+            return false
+        }
+        return true
+    } else {
+        defaultValue = default<TT>
+        return true
+    }
+}
+
+[macro_function]
+def public typemacro_default_value(argDefaultValue : ExpressionPtr; var constType : ExprConstString; var defaultValue : auto(TT)&; var errors : das_string) : bool {
+    if (argDefaultValue != null) {
+        if (argDefaultValue.__rtti == "ExprConstString") {
+            defaultValue := unsafe(reinterpret<ExprConstString?>(argDefaultValue)).value
+            return true
+        } elif (argDefaultValue.__rtti == "ExprAddr") {
+            defaultValue := string(unsafe(reinterpret<ExprAddr?>(argDefaultValue)).target)
+            return true
+        } else {
+            errors := "expecting string constant or function address as default value"
+            return false
+        }
+        return true
+    } else {
+        defaultValue = default<TT>
+        return true
+    }
+}
+
 [function_macro(name="typemacro_function")]
 class TypeMacroMacro : AstFunctionAnnotation {
     //! This macro converts function into a type macro.
@@ -90,7 +153,6 @@ class TypeMacroMacro : AstFunctionAnnotation {
         compiling_module() |> add_structure(cls)
         return true
     }
-
     def override patch(var func : FunctionPtr; var group : ModuleGroup; args, progArgs : AnnotationArgumentList; var errors : das_string; var astChanged : bool&) : bool {
         for (ann in func.annotations) {
             if (ann.annotation.name == "typemacro_function") {
@@ -112,85 +174,43 @@ class TypeMacroMacro : AstFunctionAnnotation {
         }
         var body = cvtFn.body as ExprBlock
         body.list |> clear
-        // we need to check, if there are enough arugments
-        let expectedArgs = length(func.arguments) - 1
-        var inscope checkE <- qmacro_block() <| $() {
-            if (length(td.dimExpr) != $v(expectedArgs)) {
-                macro_error(compiling_program(), td.at, "expecting {$v(expectedArgs)} arguments, got {length(td.dimExpr)}")
-                return <- TypeDeclPtr()
-            }
-        }
-        append_expressions(body, checkE)
         var inscope retCall <- qmacro($c(func.name)(td, passT))
         // allowed are basic types (int, float, string, @@function etc) and TypeDeclPtr
         for (ai in range(2, length(func.arguments))) {
             let argIndex = ai - 2
             let macroArgIndex = ai - 1
             assume argType = func.arguments[ai]._type
+            assume argDefaultValue = func.arguments[ai].init
             if (length(argType.dim) > 0) {
                 errors := "expecting non-array arguments"
                 return false
             }
+            if (argDefaultValue == null) {
+                var inscope checkE <- qmacro_block() <| $() {
+                    if ($v(macroArgIndex) >= length(td.dimExpr)) {
+                        macro_error(compiling_program(), td.at, "expecting {$v(string(func.arguments[ai].name))} argument")
+                        return <- TypeDeclPtr()
+                    }
+                }
+                append_expressions(body, checkE)
+            }
             if (argType.baseType == Type.tInt) {
-                var inscope expr <- qmacro_block() <| $() {
-                    if (!(td.dimExpr[$v(macroArgIndex)] is ExprConstInt)) {
-                        macro_error(compiling_program(), td.at, "expecting {$v(string(func.arguments[ai].name))} to be int const")
-                        return <- default<TypeDeclPtr>
-                    }
-                }
-                append_expressions(body, expr)
-                (retCall as ExprCall).arguments |> emplace_new <| qmacro((td.dimExpr[$v(macroArgIndex)] as ExprConstInt).value)
+                var defaultValue = 0
+                return false if (!typemacro_default_value(argDefaultValue, type<ExprConstInt>, defaultValue, errors))
+                (retCall as ExprCall).arguments |> emplace_new <| qmacro(typemacro_argument(td.dimExpr, $v(macroArgIndex), type<ExprConstInt>, $v(defaultValue)))
             } elif (argType.baseType == Type.tBool) {
-                var inscope expr <- qmacro_block() <| $() {
-                    if (!(td.dimExpr[$v(macroArgIndex)] is ExprConstBool)) {
-                        macro_error(compiling_program(), td.at, "expecting {$v(string(func.arguments[ai].name))} to be bool const")
-                        return <- default<TypeDeclPtr>
-                    }
-                }
-                append_expressions(body, expr)
-                (retCall as ExprCall).arguments |> emplace_new <| qmacro((td.dimExpr[$v(macroArgIndex)] as ExprConstBool).value)
+                var defaultValue = false
+                return false if (!typemacro_default_value(argDefaultValue, type<ExprConstBool>, defaultValue, errors))
+                (retCall as ExprCall).arguments |> emplace_new <| qmacro(typemacro_argument(td.dimExpr, $v(macroArgIndex), type<ExprConstBool>, $v(defaultValue)))
             } elif (argType.baseType == Type.tString) {
-                var inscope expr <- qmacro_block() <| $() {
-                    if (!(td.dimExpr[$v(macroArgIndex)] is ExprConstString) && !(td.dimExpr[$v(macroArgIndex)] is ExprAddr)) {
-                        macro_error(compiling_program(), td.at, "expecting {$v(string(func.arguments[ai].name))} to be string const or function address")
-                        return <- default<TypeDeclPtr>
-                    }
-                }
-                append_expressions(body, expr)
-                (retCall as ExprCall).arguments |> emplace_new <| qmacro(get_string_const((td.dimExpr[$v(macroArgIndex)])))
-            } elif (argType.baseType == Type.tBitfield || argType.baseType == Type.tBitfield8 || argType.baseType == Type.tBitfield16 || argType.baseType == Type.tBitfield64) {
-                var inscope expr <- qmacro_block() <| $() {
-                    if (!(td.dimExpr[$v(macroArgIndex)] is ExprConstBitfield)) {
-                        macro_error(compiling_program(), td.at, "expecting {$v(string(func.arguments[ai].name))} to be bool const")
-                        return <- default<TypeDeclPtr>
-                    }
-                }
-                append_expressions(body, expr)
-                var inscope valueConst : ExpressionPtr
-                if (argType.baseType == Type.tBitfield8) {
-                    valueConst |> move_new <| qmacro(bitfield8(uint8((td.dimExpr[$v(macroArgIndex)] as ExprConstBitfield).value)))
-                } elif (argType.baseType == Type.tBitfield16) {
-                    valueConst |> move_new <| qmacro(bitfield16(uint16((td.dimExpr[$v(macroArgIndex)] as ExprConstBitfield).value)))
-                } elif (argType.baseType == Type.tBitfield64) {
-                    valueConst |> move_new <| qmacro(bitfield64(uint64((td.dimExpr[$v(macroArgIndex)] as ExprConstBitfield).value)))
-                } else {
-                    valueConst |> move_new <| qmacro(bitfield((td.dimExpr[$v(macroArgIndex)] as ExprConstBitfield).value))
-                }
-                (retCall as ExprCall).arguments |> emplace <| valueConst
-            } elif (argType.baseType == Type.tEnumeration || argType.baseType == Type.tEnumeration16 || argType.baseType == Type.tEnumeration64 || argType.baseType == Type.tEnumeration8) {
-                let argTypeName = describe(argType)
-                var inscope expr <- qmacro_block() <| $() {
-                    if (!(td.dimExpr[$v(macroArgIndex)] is ExprConstEnumeration)) {
-                        macro_error(compiling_program(), td.at, "expecting {$v(string(func.arguments[ai].name))} to be {$v(argTypeName)}")
-                        return <- default<TypeDeclPtr>
-                    }
-                }
-                append_expressions(body, expr)
-                (retCall as ExprCall).arguments |> emplace_new <| qmacro(
-                    int64_to_enum(type<$t(argType)>,
-                        find_enum_value(td.dimExpr[$v(macroArgIndex)]._type.enumType,
-                            string((td.dimExpr[$v(macroArgIndex)] as ExprConstEnumeration).value))))
+                var defaultValue = ""
+                return false if (!typemacro_default_value(argDefaultValue, type<ExprConstString>, defaultValue, errors))
+                (retCall as ExprCall).arguments |> emplace_new <| qmacro(typemacro_argument(td.dimExpr, $v(macroArgIndex), type<ExprConstString>, $v(defaultValue)))
             } elif (is_typedecl_ptr(argType)) {
+                if (argDefaultValue != null) {
+                    errors := "TypeDeclPtr argument cannot have default value"
+                    return false
+                }
                 (retCall as ExprCall).arguments |> emplace_new <| qmacro(
                     (td.dimExpr[$v(macroArgIndex)] is ExprTypeDecl) ? (td.dimExpr[$v(macroArgIndex)] as ExprTypeDecl).typeexpr : td.dimExpr[$v(macroArgIndex)]._type)
             } else {
@@ -509,3 +529,4 @@ class TemplateStructure : AstStructureAnnotation {
         return true
     }
 }
+

--- a/examples/profile/hash_test/test02.das
+++ b/examples/profile/hash_test/test02.das
@@ -24,10 +24,10 @@ def test(hmap : auto(HashMapType); dummy) {
 }
 
 typedef CuckooHashMap_test = $CuckooHashTable < int; int >
-typedef CuckooHashMap_test_inline = $CuckooHashTableEx < int; int > (@@hash0, @@hash_inline)
+typedef CuckooHashMap_test_inline = $CuckooHashTable < int; int > (@@hash0, @@hash_inline)
 typedef FlatHashMap_test = $FlatHashTable < int; int >
-typedef FlatHashMap_test_inline = $FlatHashTableEx < int; int > (@@hash_inline)
-typedef FlatHashMap_test0 = $FlatHashTableEx < int; int > (@@hash0)
+typedef FlatHashMap_test_inline = $FlatHashTable < int; int > (@@hash_inline)
+typedef FlatHashMap_test0 = $FlatHashTable < int; int > (@@hash0)
 
 def hash_inline(i : int) : uint64 {
     let DAS_WYHASH_SEED = 0x1234567890abcdeful

--- a/examples/profile/hash_test/test11.das
+++ b/examples/profile/hash_test/test11.das
@@ -8,7 +8,7 @@ require slot_map
 
 typedef CuckooHashMap_uint64_int = $CuckooHashTable < uint64, int >
 typedef FlatHashMap_uint64_int = $FlatHashTable < uint64, int >
-typedef FlatHashMap0_uint64_int = $FlatHashTableEx < uint64, int > (@@hash0)
+typedef FlatHashMap0_uint64_int = $FlatHashTable < uint64, int > (@@hash0)
 
 typedef SlotTable = table<uint64; int>
 

--- a/examples/profile/hash_test/test12.das
+++ b/examples/profile/hash_test/test12.das
@@ -10,7 +10,7 @@ require daslib/cuckoo_hash_table
 
 typedef CuckooHashMap_test = $CuckooHashTable < int; int >
 typedef FlatHashMap_test = $FlatHashTable < int; int >
-typedef PathalogicalFlatHashMap_test = $FlatHashTableEx < int; int > (@@pathalogical)
+typedef PathalogicalFlatHashMap_test = $FlatHashTable < int; int > (@@pathalogical)
 
 [sideeffects]
 def test(hmap : auto(HashMapType); randomNumbers) {

--- a/examples/test/misc/t_counter.das
+++ b/examples/test/misc/t_counter.das
@@ -6,10 +6,11 @@ require daslib/ast_boost
 require daslib/templates_boost
 require daslib/typemacro_boost
 
-struct public TemplateCounterBase {}
-
-struct template TemplateCounter : TemplateCounterBase {
+struct template TemplateCounter {
     counter : CounterType   // we add this one in a typemacro (or we can use $t(counter_type))
+    def TemplateCounter {
+        counter = CounterType($v(initialValue))
+    }
     def next {
         counter ++
     }
@@ -23,27 +24,31 @@ def template print_counter(c : $t(resType)) {
 }
 
 [typemacro_function]
-def counter(macroArgument, passArgument : TypeDeclPtr; counter_type : TypeDeclPtr) : TypeDeclPtr {
-    if (passArgument != null) {
-        // this is a generic argument match, like $counter(type<auto(TT)>)
-        var inscope template_type <- qmacro_type(type<TemplateCounter>)
-        return <- TypeDeclPtr() if (!is_qmacro_template_instance(passArgument, template_type))
-        var inscope inferred_counter_type <- get_structure_alias(passArgument.structType, "CounterType")
-        return <- TypeDeclPtr() if (inferred_counter_type == null)
-        return <- infer_template_type(passArgument, counter_type, inferred_counter_type)
-    } else {
-        // we are instantiating concrete type here
-        var struct_name = "Counter<{describe(counter_type,false,false,true)}>"
-        var existing_struct = compiling_program().find_unique_structure(struct_name)
-        return <- new TypeDecl(baseType = Type.tStructure, structType = existing_struct, at = counter_type.at) if (existing_struct != null)
-        var inscope resType <- qmacro_template_class(struct_name, type<TemplateCounter>)
-        var inscope CounterType <- clone_type(counter_type)
-        add_structure_alias(resType.structType, "CounterType", CounterType)
-        // for demo purposes, we can add a print_counter function here
-        var inscope print_fn <- qmacro_template_function(@@print_counter)
-        add_function(compiling_module(), print_fn)
-        return <- resType
-    }
+def counter(macroArgument, passArgument : TypeDeclPtr; counter_type : TypeDeclPtr; initialValue : int = 123) : TypeDeclPtr {
+        var inscope template_type <- typeinfo ast_typedecl(type<TemplateCounter>)
+        var inscope template_arguments <- [
+            TypeMacroTemplateArgument(name="CounterType",  argument_type <- clone_type(counter_type))
+        ]
+        var extra_template_arguments <- [
+            ("initialValue", "{initialValue}")
+        ]
+        // code bellow can be auto-generated
+        if (passArgument != null) {
+            return <- TypeDeclPtr() if (!is_typemacro_template_instance(passArgument, template_type, extra_template_arguments))
+            return <- TypeDeclPtr() if (!infer_struct_aliases(passArgument.structType, template_arguments))
+            return <- infer_template_types(passArgument, template_arguments)
+        } else {
+            return <- TypeDeclPtr() if (!verify_arguments(template_arguments))
+            var struct_name = template_structure_name(template_type.structType, template_arguments, extra_template_arguments)
+            var existing_struct = compiling_program().find_unique_structure(struct_name)
+            return <- new TypeDecl(baseType = Type.tStructure, structType = existing_struct, at = template_type.at) if (existing_struct != null)
+            var inscope resType <- qmacro_template_class(struct_name, type<TemplateCounter>)
+            make_typemacro_template_instance(resType.structType, template_type.structType, extra_template_arguments)
+            add_structure_aliases(resType.structType, template_arguments)
+            // for demo purposes, we can add a print_counter function here
+            var inscope print_fn <- qmacro_template_function(@@print_counter)
+            add_function(compiling_module(), print_fn)
+            return <- resType
+        }
 }
-
 

--- a/tests/hash_map/all_hash_table.das
+++ b/tests/hash_map/all_hash_table.das
@@ -25,7 +25,7 @@ def take_any_hash_map(a) {
     return "nothing"
 }
 [sideeffects]
-def take_dict_map(a : $FlatHashTableEx < auto(TT); auto(TT) > (@@hash_string)) {
+def take_dict_map(a : $FlatHashTable < auto(TT); auto(TT) > (@@hash_string)) {
     return "dict_map"
 }
 
@@ -36,7 +36,7 @@ def take_any_hash_table(a : $CuckooHashTable < auto(TT); auto(QQ) >) {
 
 typedef FlatHashMap_int_Foo = $FlatHashTable < int; Foo >
 typedef FlatHashMap_string_int = $FlatHashTable < string; int >
-typedef DictMap = $FlatHashTableEx < string; int > (@@hash_string)   // vs @@hash
+typedef DictMap = $FlatHashTable < string; int > (@@hash_string)   // vs @@hash
 
 typedef CuckooHashMap_int_Foo = $CuckooHashTable < int; Foo >
 


### PR DESCRIPTION
```
def CuckooHashTable(macroArgument, passArgument : TypeDeclPtr; KeyType, ValueType : TypeDeclPtr; hashName : string = "hash"; hash0name : string = "hash_extra") : TypeDeclPtr {