### PR TITLE
aot: do not mark no_aot functions

### DIFF
--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -461,6 +461,12 @@ namespace das {
         virtual void preVisit ( TypeDecl * type ) override {
             Visitor::preVisit(type);
         }
+
+        // function
+        bool canVisitFunction(Function *f) override {
+            return !f->noAot;
+        }
+
         virtual void preVisitExpression ( Expression * expr ) override {
             Visitor::preVisitExpression(expr);
             mark(expr->type.get());
@@ -4159,11 +4165,6 @@ namespace das {
         for ( auto & pm : program->library.getModules() ) {
             pm->structures.foreach([&](auto ps){
                 aotVisitor.ss << "namespace " << aotModuleName(ps->module) << " { struct " << aotStructName(ps.get()) << "; };\n";
-            });
-            pm->functions.foreach([&](auto fn){
-                if (fn->index < 0 || !fn->used || fn->isTemplate)
-                    return;
-                fn->visit(utm);
             });
         }
         for ( auto & pm : program->library.getModules() ) {

--- a/src/das/ast/ast_aot_cpp.das
+++ b/src/das/ast/ast_aot_cpp.das
@@ -449,6 +449,10 @@ class UseTypeMarker : AstVisitor {
     def override preVisitTypeDecl(typeDecl : TypeDeclPtr) {
     }
 
+    def override canVisitFunction(fn : FunctionPtr) {
+        return !fn.flags.noAot;
+    }
+
     def override preVisitExpression(expr : ExpressionPtr) {
         mark(expr._type);
     }
@@ -3523,13 +3527,6 @@ def dumpDependencies(program : ProgramPtr; var aotVisitor : CppAot?) {
     program.get_ptr() |> for_each_module_no_order($(pm) {
         pm |> for_each_structure($(ps) {
             write(*aotVisitor.ss, "namespace {aotModuleName(ps._module)} \{ struct {aotStructName(ps.get_ptr())}; \};\n");
-        });
-        pm |> for_each_module_function($(fn) {
-            // If some functions from another module used we need to declare this type.
-            // Because we have to add debug info about this function signature in our module
-            if (fn.index < 0 || !fn.flags.used)
-                return ;
-            visit(fn, adapter);
         });
     });
     program.get_ptr() |> for_each_module_no_order($(pm) {


### PR DESCRIPTION
If function marked no_aot we shouldn't consider types inside it as used.

Also we were visiting dependencies incorrectly, we shouldn't do it nor in aot nor in standalone_contexts.

For example this `require daslib/ast_boost` was creating 1000 lines of structures from macros, that was never used.