### PR TITLE
fix: revert project_specific

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -805,6 +805,7 @@ MACRO(SETUP_LIBDASCRIPT library shared_lib)
                 ${MISC_SRC} ${SIMULATE_FUSION_SRC} ${MAIN_SRC}
                 ${DAGOR_NOISE_SRC} ${FLAT_HASH_MAP_SRC} ${FAST_FLOAT_SRC} ${DASCRIPT_FMT_SRC})
     ENDIF()
+    TARGET_COMPILE_DEFINITIONS(${library} PUBLIC DAS_ENABLE_DYN_INCLUDES=1)
     ADD_DEPENDENCIES(${library} need_and_resolve)
     ADD_TARGET_PROJECT_XXD_DEPENDS(${library} libDaScript)
     target_include_directories(${library} PUBLIC
@@ -922,12 +923,9 @@ if (NOT ${DAS_TOOLS_DISABLED})
     SETUP_COMPILER_BINARY(daslang libDaScript DAS_MODULES_LIBS "")
     INSTALL(TARGETS daslang RUNTIME DESTINATION ${DAS_INSTALL_BINDIR})
 
-    # Enable dynamic modules lookup.
-    TARGET_COMPILE_DEFINITIONS(daslang PRIVATE DAS_ENABLE_DYN_INCLUDES=1)
-
     # Add daslang-dyn target.
     SETUP_COMPILER_BINARY(daslang_dyn libDaScriptDyn "" DAS_DYN_MODULES_LIBS)
-    TARGET_COMPILE_DEFINITIONS(daslang_dyn PRIVATE DAS_ENABLE_DLL=1 DAS_ENABLE_DYN_INCLUDES=1)
+    TARGET_COMPILE_DEFINITIONS(daslang_dyn PRIVATE DAS_ENABLE_DLL=1)
     # relative RPATH from install location
     if(APPLE)
         SET_TARGET_PROPERTIES(daslang_dyn PROPERTIES

--- a/examples/test/main.cpp
+++ b/examples/test/main.cpp
@@ -23,7 +23,9 @@ bool g_collectSharedModules = true;
 bool g_failOnSmartPtrLeaks = true;
 
 //link time resolved dependencies
+#ifdef DAS_ENABLE_DYN_INCLUDES
 bool require_dynamic_modules(const string &, const string &, TextWriter&);
+#endif
 
 enum class RuntimeMode {
     Interpreter,
@@ -368,9 +370,11 @@ bool isolated_unit_test ( const string & fn, RuntimeMode mode, bool useSer ) {
     if (mode == RuntimeMode::JIT) {
         NEED_MODULE(Module_Jit);
     }
-    NEED_MODULE(Module_UnitTest);
+    #ifdef DAS_ENABLE_DYN_INCLUDES
+    // This adds JIT.
     daScriptEnvironment::ensure();
     require_dynamic_modules(getDasRoot(), getDasRoot(), tout);
+    #endif
     Module::Initialize();
     bool result = unit_test(fn,mode, useSer);
     // shutdown
@@ -516,8 +520,11 @@ int main( int argc, char * argv[] ) {
         NEED_MODULE(Module_Jit);
     }
     NEED_MODULE(Module_UnitTest);
+    #ifdef DAS_ENABLE_DYN_INCLUDES
+    // This adds JIT.
     daScriptEnvironment::ensure();
     require_dynamic_modules(getDasRoot(), getDasRoot(), tout);
+    #endif
     Module::Initialize();
     // aot library
 #if 0 // Debug this one test

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -645,7 +645,7 @@ namespace das {
         if (cur_mod == mod_resolve->end()) {
             // Add new module
             mod_resolve->emplace_back(DynamicModuleInfo{mod_name,{}});
-            cur_mod = (--mod_resolve->end());
+            cur_mod = prev(mod_resolve->end());
         }
         cur_mod->paths.emplace_back(src_path, dst_path);
     }

--- a/src/hal/project_specific.cpp
+++ b/src/hal/project_specific.cpp
@@ -120,6 +120,9 @@ static bool init_modules_for_folder(const das::string &path, das::TextWriter &to
 }
 }
 
+// Nothing by default.
+DAS_API void require_project_specific_modules() {}
+
 // Initializes dynamic modules from:
 // - das_root/modules
 // - project_root/modules

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -10,8 +10,12 @@ using namespace das;
 
 void use_utf8();
 
+void require_project_specific_modules();//link time resolved dependencies
 das::FileAccessPtr get_file_access( char * pak );//link time resolved dependencies
+
+#ifdef DAS_ENABLE_DYN_INCLUDES
 bool require_dynamic_modules(const das::string &, const das::string &, TextWriter&);//link time resolved dependencies
+#endif
 
 TextPrinter tout;
 
@@ -221,7 +225,7 @@ int das_aot_main ( int argc, char * argv[] ) {
                 }
                 setDasRoot(argv[ai+1]);
                 ai += 1;
-            } else if ( strcmp(argv[ai],"-project-root") ) {
+            } else if ( strcmp(argv[ai],"-project-root")==0 ) {
                 project_root = argv[ai + 1];
                 ai++;
             } else if ( strcmp(argv[ai],"-v2syntax")==0 ) {
@@ -279,6 +283,7 @@ int das_aot_main ( int argc, char * argv[] ) {
     if (!Module::require("dasbind")) {
         NEED_MODULE(Module_DASBIND);
     }
+    require_project_specific_modules();
     #if !defined(DAS_ENABLE_DLL) || !defined(DAS_ENABLE_DYN_INCLUDES)
     // Otherwises search for static modules.
     #include "modules/external_need.inc"
@@ -730,6 +735,7 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     NEED_MODULE(Module_FIO);
     NEED_MODULE(Module_DASBIND);
 
+    require_project_specific_modules();
     #if !defined(DAS_ENABLE_DLL) || !defined(DAS_ENABLE_DYN_INCLUDES)
     // Otherwises search for static modules.
     #include "modules/external_need.inc"


### PR DESCRIPTION
`project_specific` was accidentally removed, however it's actively used in projects.

Also there was a bug in project-root aot command line parsing.

And more safe back() iterator access.