### PR TITLE
dastest: add testing.B

### DIFF
--- a/benchmarks/core/hash/test02.das
+++ b/benchmarks/core/hash/test02.das
@@ -1,0 +1,94 @@
+options gen2
+options persistent_heap
+
+require dastest/testing_boost
+
+require daslib/flat_hash_table
+require daslib/cuckoo_hash_table
+
+typedef CuckooHashMap_test = $TCuckooHashTable < int; int >
+typedef CuckooHashMap_test_inline = $TCuckooHashTable < int; int > (@@hash0, @@hash_inline)
+typedef FlatHashMap_test = $TFlatHashTable < int; int >
+typedef FlatHashMap_test_inline = $TFlatHashTable < int; int > (@@hash_inline)
+typedef FlatHashMap_test0 = $TFlatHashTable < int; int > (@@hash0)
+
+[sideeffects]
+def read_map(b : B?; hmap : auto(HashMapType)) {
+    for (i in range(hmap.length())) {
+        let v = hmap?[i] ?? 0
+        if (v != -i) {
+            b->failNow()
+        }
+    }
+}
+
+[sideeffects]
+def fill_map(hmap : auto(HashMapType); size : int) : auto(HashMapType) {
+    var hashMap : HashMapType
+    static_if (!typeinfo is_table(type<HashMapType>)) {
+        hashMap <- HashMapType()
+    }
+    for (j in range(size)) {
+        unsafe(hashMap[j]) = -j
+    }
+    return <- hashMap
+}
+
+def run_write_bench(b : B?; hmap : auto(HashMapType)) {
+    b |> run("insert/{HASH_SIZE}", HASH_SIZE) <| $() {
+        fill_map(hmap, HASH_SIZE)
+    }
+}
+
+def run_read_bench(b : B?; hmap : auto(HashMapType)) {
+    let m = fill_map(hmap, HASH_SIZE)
+    b |> run("read/{HASH_SIZE}", HASH_SIZE) <| $() {
+        read_map(b, m)
+    }
+}
+
+def hash_inline(i : int) : uint64 {
+    let DAS_WYHASH_SEED = 0x1234567890abcdeful
+    let u = uint64(i)
+    let ab = mul128(u, DAS_WYHASH_SEED)
+    let h = ab.x ^ ab.y
+    return h <= 1ul ? 1099511628211ul : h
+}
+
+let HASH_SIZE = 600000
+
+[benchmark]
+def builtin_table(b : B?) {
+    run_write_bench(b, default<table<int; int>>)
+    run_read_bench(b, default<table<int; int>>)
+}
+
+[benchmark]
+def cuckoo_hashmap(b : B?) {
+    run_write_bench(b, default<CuckooHashMap_test>)
+    run_read_bench(b, default<CuckooHashMap_test>)
+}
+
+[benchmark]
+def cuckoo_hashmap_inlinehash(b : B?) {
+    run_write_bench(b, default<CuckooHashMap_test_inline>)
+    run_read_bench(b, default<CuckooHashMap_test_inline>)
+}
+
+[benchmark]
+def flat_hashmap(b : B?) {
+    run_write_bench(b, default<FlatHashMap_test>)
+    run_read_bench(b, default<FlatHashMap_test>)
+}
+
+[benchmark]
+def flat_hashmap_inlinehash(b : B?) {
+    run_write_bench(b, default<FlatHashMap_test_inline>)
+    run_read_bench(b, default<FlatHashMap_test_inline>)
+}
+
+[benchmark]
+def flat_hashmap_hash0(b : B?) {
+    run_write_bench(b, default<FlatHashMap_test0>)
+    run_read_bench(b, default<FlatHashMap_test0>)
+}

--- a/dastest/README.md
+++ b/dastest/README.md
@@ -6,9 +6,26 @@ Inspired by [Golang testing framework](https://pkg.go.dev/testing), this framewo
 
 ## Usage
 
-- `daslang dastest.das -- --test folderWithScriptsOrSingleScript [--test anotherPath]`
+In the examples below, `$target` refers to "folderWithScriptsOrSingleScript".
+
+Running all tests:
+
+- `daslang dastest.das -- --test $target [--test anotherPath]`
+
+Running all tests **and** benchmarks:
+
+- `daslang dastest.das -- --bench --test $target`
+
+Running benchmarks **only**:
+
+- `daslang dastest.das -- --bench --test $target --test-names none`
+
+Running only **some** selected benchmarks (uses `vector_alloc` as a filtering prefix):
+
+- `daslang dastest.das -- --bench --bench-names vector_alloc --test $target --test-names none`
 
 ### dastest.das arguments
+
 - `--test`: Path to the folder with scripts or single script to test
 - `--test-names <namePrefix>`: Run top-level tests matching "namePrefix", such as "namePrefix1"
 - `--test-project <path.das_project>`: Project file. Will be used to compile given tests
@@ -17,6 +34,42 @@ Inspired by [Golang testing framework](https://pkg.go.dev/testing), this framewo
 - `--verbose`: Print verbose output
 - `--timeout <seconds>`: If tests run longer than duration d, panic. If d is 0, the timeout is disabled. The default is 10 minutes
 - `--isolated-mode`: Run tests in isolated processes, useful to catch crashes
+- `--bench`: Enable benchmark execution (all of them)
+- `--bench-names <namePrefix>`: Run top-level benchmark matching "namePrefix"
+- `--bench-format <format>`: Specifies the benchmark output format ("native", "go" or "json")
+- `--count <n>`: Run all benchmarks this number of times (useful for sample collection)
+
+Note that benchmarks will be executed only if all module tests have already passed. If you want to run benchmarks only, skipping the tests, consider using something like `--test-names none`.
 
 #### Internal arguments
+
 - `--run`: Path to the single script file to run tests in isolated mode
+
+## Examples
+
+### Benchmarking
+
+```das
+options gen2
+require dastest/testing_boost public
+
+[benchmark]
+def dyn_array(b : B?) {
+    let size = 100
+
+    b |> run("fill_vec") <| $() {
+        var vec : array<int>
+        for (i in range(size)) {
+            vec |> push(i)
+        }
+    }
+
+    b |> run("fill_vec_reserve") <| $() {
+        var vec : array<int>
+        vec |> reserve(size)
+        for (i in range(size)) {
+            vec |> push(i)
+        }
+    }
+}
+```

--- a/dastest/dastest.das
+++ b/dastest/dastest.das
@@ -120,7 +120,7 @@ def main() {
     timingOutliers = args |> get_int_arg("--timing-outliers", 0)
 
     let isolatedMode = args |> has_value("--isolated-mode")
-    let ctx <- SuiteCtx(args)
+    var ctx <- SuiteCtx(args)
     if (!isolatedMode) {
         for (file in files) {
             let uri = ctx.uriPaths ? file_name_to_uri(file) : file

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -8,7 +8,10 @@ require ast
 require strings
 require debugapi
 require fio
+require daslib/strings_boost
+require daslib/json_boost
 require daslib/defer
+require math
 
 require log
 require testing
@@ -16,12 +19,35 @@ require suite_result public
 
 
 struct SuiteCtx {
+    // Shared options.
     dastestRoot : string
     projectPath : string
     uriPaths : bool = false
-    testNames : array<string>
     verbose : bool = false
     compile_only : bool = false
+
+    // Testing-related options.
+    testNames : array<string>
+
+    // Benchmarking-related options.
+    bench_count : int = 1
+    bench_format : BenchmarkOutputFormat = BenchmarkOutputFormat.native
+    bench_enabled : bool = false // whether to run benchmarks or not
+    bench_names : array<string> // filters the top-level benchmarks
+    queued_benchmarks : array<Benchmark> // filled with file-local benchmarks
+}
+
+enum BenchmarkOutputFormat {
+    native,
+    go_export, // https://golang.org/design/14313-benchmark-format
+    json,
+}
+
+// Benchmark holds everything we need to execute the
+// user benchmark later, after all the tests are passed.
+struct Benchmark {
+    name : string
+    fn : function<(b : B?) : void>
 }
 
 
@@ -30,12 +56,22 @@ def createSuiteCtx() : SuiteCtx {
 }
 
 
-def private collect_tests_names(args : array<string>; var names : array<string>) {
+def private collect_target_names(key : string, args : array<string>; var names : array<string>) {
     for (i in range(length(args) - 1)) {
-        if (args[i] == "--test-names") {
+        if (args[i] == key) {
             names |> push <| args[i + 1]
         }
     }
+}
+
+
+def private collect_tests_names(args : array<string>; var names : array<string>) {
+    collect_target_names("--test-names", args, names)
+}
+
+
+def private collect_bench_names(args : array<string>; var names : array<string>) {
+    collect_target_names("--bench-names", args, names)
 }
 
 
@@ -54,6 +90,17 @@ def SuiteCtx(args : array<string>) : SuiteCtx {
     ctx.projectPath = args |> get_str_arg("--test-project", "")
     ctx.compile_only = args |> has_value("--compile-only")
     collect_tests_names(args, ctx.testNames)
+
+    ctx.bench_enabled = args |> has_value("--bench")
+    collect_bench_names(args, ctx.bench_names)
+    let bench_format = args |> get_str_arg("--bench-format", "")
+    if (bench_format == "go") {
+        ctx.bench_format = BenchmarkOutputFormat.go_export
+    } elif (bench_format == "json") {
+        ctx.bench_format = BenchmarkOutputFormat.json
+    }
+    ctx.bench_count  = to_int(args.get_str_arg("--count", "1"))
+
     return <- ctx
 }
 
@@ -81,11 +128,14 @@ def private internalFileCtx(ctx : SuiteCtx) : FileCtx {
 }
 
 
-def private match_test_name(name : string; ctx : SuiteCtx) {
-    if (length(ctx.testNames) == 0) {
+// match_func_name may reject a test if explicit test list
+// was specified via --test-names parameter.
+// If it's empty, the test is always accepted and therefore executed.
+def private match_func_name(name : string; allowed : array<string>&) {
+    if (length(allowed) == 0) {
         return true
     }
-    for (match in ctx.testNames) {
+    for (match in allowed) {
         if (name |> starts_with(match)) {
             return true
         }
@@ -94,19 +144,20 @@ def private match_test_name(name : string; ctx : SuiteCtx) {
 }
 
 
-def test_file(file_name : string; ctx : SuiteCtx) : SuiteResult {
+def test_file(file_name : string; var ctx : SuiteCtx) : SuiteResult {
     var inscope fileCtx <- internalFileCtx(ctx)
     var res = test_file(file_name, ctx, fileCtx)
     return res
 }
 
 
-def test_file(file_name : string; ctx : SuiteCtx; file_ctx : FileCtx) : SuiteResult {
+def test_file(file_name : string; var ctx : SuiteCtx; var file_ctx : FileCtx) : SuiteResult {
     var res : SuiteResult
     var inscope access <- make_file_access(ctx.projectPath)
     access |> add_file_access_root("dastest", ctx.dastestRoot)
     using() $(var mg : ModuleGroup) {
         using() $(var cop : CodeOfPolicies) {
+            ctx.queued_benchmarks |> clear
             cop.aot_module = true
             cop.threadlock_context = true
             cop.jit_enabled = jit_enabled()
@@ -184,7 +235,11 @@ def test_file(file_name : string; ctx : SuiteCtx; file_ctx : FileCtx) : SuiteRes
                     }
                     var mod = program |> get_this_module()
                     if (mod != null && context != null) {
-                        res += test_module(*mod, *context, ctx, file_ctx)
+                        let module_result = test_module(*mod, *context, ctx, file_ctx)
+                        if (module_result.failed + module_result.errors == 0) {
+                            run_queued_benchmarks(ctx, file_ctx, res)
+                        }
+                        res += module_result
                     } else {
                         res.errors += 1
                         res.total += 1
@@ -205,14 +260,14 @@ def test_file(file_name : string; ctx : SuiteCtx; file_ctx : FileCtx) : SuiteRes
 }
 
 
-def test_module(var mod : rtti::Module; var context : rtti::Context; suite_ctx : SuiteCtx) : SuiteResult {
+def test_module(var mod : rtti::Module; var context : rtti::Context; var suite_ctx : SuiteCtx) : SuiteResult {
     var inscope fileCtx <- internalFileCtx(suite_ctx)
     var res = test_module(mod, context, suite_ctx, fileCtx)
     return res
 }
 
 
-def test_module(var mod : rtti::Module; var context : rtti::Context; suite_ctx : SuiteCtx; file_ctx : FileCtx) : SuiteResult {
+def test_module(var mod : rtti::Module; var context : rtti::Context; var suite_ctx : SuiteCtx; file_ctx : FileCtx) : SuiteResult {
     if (suite_ctx.compile_only) {
         return default<SuiteResult>
     }
@@ -232,19 +287,39 @@ def test_module(var mod : rtti::Module; var context : rtti::Context; suite_ctx :
         if (fn == null) {
             return
         }
+        var test_name = ""
+        var test_kind = ""
         for (ann in fn.annotations) {
-            if (ann.annotation.name == "test") {
-                var name = "{fn.name}"
-                for (arg in ann.arguments) {
-                    if (arg.name == "name") {
-                        name = "{arg.sValue}"
-                    }
-                }
-                if (match_test_name(name, suite_ctx)) {
-                    test_any(name, func, length(fn.arguments), fileCtx, res)
-                }
-                return
+            var tag = "{ann.annotation.name}"
+            if (tag != "test" && tag != "benchmark") {
+                continue
             }
+            test_kind = tag
+            var name = "{fn.name}"
+            // Both [test] and [benchmark] allow a form like [test(name=foo)]
+            // to override the default test name.
+            for (arg in ann.arguments) {
+                if (arg.name == "name") {
+                    name = "{arg.sValue}"
+                }
+            }
+            test_name = name
+            break
+        }
+        if (test_kind == "") {
+            // Not a test nor benchmark.
+            return
+        }
+        let allowed_list & = test_kind == "benchmark" ? suite_ctx.bench_names : suite_ctx.testNames
+        if (!match_func_name(test_name, allowed_list)) {
+            return
+        }
+        if (test_kind == "test") {
+            test_any(test_name, func, length(fn.arguments), fileCtx, res)
+        } elif (test_kind == "benchmark" && suite_ctx.bench_enabled) {
+            let bench_func = unsafe(reinterpret<function<(b : B?) : void>>(func))
+            let queued_bench = Benchmark(name = test_name, fn = bench_func)
+            suite_ctx.queued_benchmarks |> push(queued_bench)
         }
     }
     return res
@@ -408,6 +483,160 @@ def private test_any(name : string; func; args_num : int; var context : FileCtx;
     }
 }
 
+def private run_queued_benchmarks(var suite_ctx : SuiteCtx; var file_ctx : FileCtx, var res : SuiteResult&) {
+    for (q in suite_ctx.queued_benchmarks) {
+        let failed = res.failed
+        for (i in range(suite_ctx.bench_count)) {
+            run_benchmark(suite_ctx, file_ctx, res, q.name, q.fn)
+            if (res.failed > failed) {
+                break
+            }
+        }
+    }
+}
+
+def private run_benchmark(var suite_ctx : SuiteCtx; var file_ctx : FileCtx; var res : SuiteResult&; name : string; func : function<(b : B?) : void>) {
+    var benchmarking = new B(name = name)
+
+    let t0 = ref_time_ticks()
+    var deliberateRecover = false
+
+    var func_type = "INTERP"
+    if (is_in_aot()) {
+        func_type = "AOT"
+    } elif (is_jit_function(func)) {
+        func_type = "JIT"
+    }
+
+    try {
+        unsafe { // needed to capture &benchmarking &file_ctx
+            benchmarking.on_fail <- @ capture(& benchmarking, & deliberateRecover) (now : bool) {
+                deliberateRecover = now
+                benchmarking.failed = true
+            }
+
+            benchmarking.on_start <- @capture(& suite_ctx, & benchmarking, & file_ctx) (sub_name : string) {
+                let is_first_bench = !benchmarking.started
+                benchmarking.started = true
+                benchmarking.current_sub_name = sub_name
+
+                if (suite_ctx.bench_format == BenchmarkOutputFormat.native) {
+                    if (is_first_bench) {
+                        log::info("{file_ctx.indenting}=== RUN BENCHMARK '{benchmarking.name}' [{blue_str(func_type)}]")
+                    }
+                    let full_name = "\t{sub_name}"
+                    let padded_name = pad_right(full_name, 22, ' ')
+                    info_raw("{file_ctx.indenting}{padded_name} ")
+                    return
+                }
+
+                if (suite_ctx.bench_format == BenchmarkOutputFormat.go_export) {
+                    // This output format follows the https://golang.org/design/14313-benchmark-format
+                    // to allow 3rd-party tool usage.
+                    // One of such tools is https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
+                    // The format requires a name like "^Benchmark[A-Z].*",
+                    // hence the somewhat artificial Das injection.
+                    var go_name = name
+                    if (starts_with(name, "benchmark_")) {
+                        // Avoid stutter.
+                        go_name = slice(name, length("benchmark_"))
+                    }
+                    info_raw("BenchmarkDas_{go_name}/sub={sub_name}-1\t\t")
+                    return
+                }
+
+                if (suite_ctx.bench_format == BenchmarkOutputFormat.go_export) {
+                    // Print the whole row once it's ready.
+                    // This format is not intended for interactive use.
+                    return
+                }
+            }
+
+            benchmarking.on_finished <- @capture(& suite_ctx, & benchmarking) (stats : BenchmarkRunStats) {
+                let n = stats.n
+                let time_ns = stats.time_ns
+                let allocs = stats.allocs
+                let heap_bytes = stats.heap_bytes
+
+                benchmarking.finished = true
+
+                // TODO(quasilyte): don't cast to float when ceil can work on doubles.
+                let avg_time = double(time_ns) / double(n)
+                let avg_heap_bytes = double(ceil(float(heap_bytes) / float(n)))
+                let avg_num_allocs = double(ceil(float(allocs) / float(n)))
+                let avg_string_heap_bytes = double(ceil(float(stats.string_heap_bytes) / float(n)))
+                let avg_string_num_allocs = double(ceil(float(stats.string_allocs) / float(n)))
+
+                if (suite_ctx.bench_format == BenchmarkOutputFormat.native) {
+                    let entries = [
+                        (int64(avg_time), "ns/op", 18, false),
+                        (int64(avg_heap_bytes), "B/op", 14, true),
+                        (int64(avg_num_allocs), "allocs/op", 16, true),
+                        (int64(avg_string_heap_bytes), "SB/op", 14, true),
+                        (int64(avg_string_num_allocs), "strings/op", 16, true),
+                    ]
+                    let msg = build_string() $(var w) {
+                        for (i, (val, measure, width, is_alloc) in range(length(entries)), entries) {
+                            let val_s = "{val}"
+                            let printed_width = length(val_s + " " + measure)
+                            let sep = repeat(" ", max(width - printed_width, 1))
+                            let is_last = i == length(entries) - 1
+                            var colored_val = yellow_str(val_s)
+                            if (is_alloc && val == 0l) {
+                                colored_val = green_str(val_s)
+                            }
+                            w |> write(colored_val + " " + measure)
+                            if (!is_last) {
+                                w |> write(sep)
+                            }
+                        }
+                    }
+                    info_raw("{msg}\n")
+                    return
+                }
+
+                if (suite_ctx.bench_format == BenchmarkOutputFormat.go_export) {
+                    info_raw("{n}\t\t{avg_time:.1f} ns/op\t{avg_heap_bytes} B/op\t{avg_num_allocs} allocs/op\t{avg_string_heap_bytes} SB/op\t{avg_string_num_allocs} strings/op\n")
+                    return
+                }
+
+                if (suite_ctx.bench_format == BenchmarkOutputFormat.json) {
+                    var s = sprint_json(stats, false)
+                    info_raw("{s}\n")
+                    return
+                }
+            }
+        }
+
+        invoke(func, benchmarking)
+    } recover {
+        benchmarking.failed = true
+    }
+
+    // A failed bench increases the failure count and may
+    // print an exception if it wasn't a controlled panic via fail or failNow.
+    if (benchmarking.failed) {
+        let dt = get_time_usec(t0)
+        res.failed++
+        if (benchmarking.started && !benchmarking.finished) {
+            if (suite_ctx.bench_format != BenchmarkOutputFormat.json) {
+                print("\n")
+            }
+        }
+        log::error("{file_ctx.indenting}--- FAIL '{name}' in '{benchmarking.current_sub_name}' {time_dt_hr(dt)}")
+        if (!deliberateRecover) {
+            unsafe {
+                let context & = this_context()
+                if (!empty(context.exception)) {
+                    log::error("{file_info_hr(context.exceptionAt, file_ctx.uriPaths)}: {file_ctx.indenting}{context.exception}")
+                }
+                if (!empty(context.last_exception)) {
+                    log::error("{file_info_hr(context.exceptionAt, file_ctx.uriPaths)}: {file_ctx.indenting}{context.last_exception}")
+                }
+            }
+        }
+    }
+}
 
 def private errorOrBlue(expectFailure : bool; msg : string) {
     if (expectFailure) {

--- a/dastest/testing.das
+++ b/dastest/testing.das
@@ -7,6 +7,7 @@ require rtti
 require strings // to compare strings/das_strings
 require daslib/math_bits
 require math
+require daslib/unroll
 
 class T {
     name : string
@@ -82,6 +83,41 @@ class T {
     def const getTimeSec() : double {
         return double(getTimeUsec()) / 1000000.0lf
     }
+}
+
+class B {
+    name : string
+    current_sub_name : string
+    started : bool = false
+    finished : bool = false
+
+    on_fail : lambda<(now : bool) : void>
+    on_start : lambda<(sub_name : string) : void>
+    on_finished : lambda<(stats : BenchmarkRunStats) : void>
+
+    failed : bool = false
+
+    def const failNow() {
+        on_fail |> invoke(true)
+        panic("benchmark failed")
+    }
+
+    def const fail() {
+        on_fail |> invoke(false)
+    }
+}
+
+// BenchmarkRunStats is a structured result of a single benchmark executed.
+// A value of this type is serialized when json output format is used.
+struct BenchmarkRunStats {
+    name : string
+    sub_name : string
+    n : int
+    time_ns : int64
+    allocs : uint64
+    heap_bytes : uint64
+    string_allocs : uint64
+    string_heap_bytes : uint64
 }
 
 
@@ -292,4 +328,129 @@ def run(t : T?; name : string; var cb : lambda<(t : T?) : void>) {
 
 def run(t : T?; name : string; func : function<(t : T?) : void>) {
     t.onRun |> invoke(name, RunT(func1 = func))
+}
+
+
+def run(b : B?, name : string; op : block) {
+    //! run executes a benchmark of a given name and runs the block in the loop,
+    //! while collecting data like CPU time and heap allocations.
+    //! It assumes that every op invocation performs a single logical operation.
+    //! If op is a combined operation, consider using an overloaded version
+    //! with chunk_size parameter.
+    run_impl(b, name, 1l, op)
+}
+
+
+def run(b : B?, name : string; chunk_size : int; op : block) {
+    //! This overloading allows a custom chunk size configuration
+    //! to adjust the ns/op to it.
+    run_impl(b, name, int64(chunk_size), op)
+}
+
+
+def private run_impl(b : B?, name : string; chunk_size : int64; op : block) {
+    b.on_start(name)
+
+    let min_runs = 1
+    let max_runs = 1_000_000_000
+
+    // The first run serves two purposes: it will
+    // find the appropriate N (num_runs) for the op,
+    // plus it allows a warmup before we start measuring it.
+    let run1_start = ref_time_ticks()
+    op()
+    let op1_time_ns = max(double(get_time_nsec(run1_start)), 1.0lf)
+
+    let op_time_approx = op1_time_ns / 1000000000.0lf // In seconds
+
+    let n_probe = int64(1.0lf / op_time_approx)
+    var num_runs = int(clamp(n_probe, int64(min_runs), int64(max_runs)))
+
+    // We will unroll fast-running (small) benchmarks
+    // to decrease the loop's own time contribution.
+    // A value of 5 gives good results, 10 should be very safe.
+    let unroll_count = 10
+    let unroll_threshold = 100 * unroll_count
+
+    // Pre-compute all the stuff before the timer has started.
+    let do_unroll = num_runs > unroll_threshold
+    var loop_runs = num_runs
+    if (do_unroll) {
+        num_runs = int(round(float(num_runs) / float(unroll_count)) * float(unroll_count))
+        loop_runs = num_runs / unroll_count
+    }
+
+    // We could use a builtin profile() function here
+    // instead of doing loops in das directly.
+    // At any rate, the auto-inferred N (count) can be useful
+    // and even profile() can benefit from the unrolled statements.
+
+    let heap_stats_start = heap_allocation_stats()
+    let heap_bytes_start = heap_stats_start[0]
+    let num_allocs_start = heap_allocation_count()
+
+    let string_stats_start = string_heap_allocation_stats()
+    let string_bytes_start = string_stats_start[0]
+    let string_num_allocs_start = string_heap_allocation_count()
+
+    var time_total = 0l
+    if (do_unroll) {
+        // A fast/small benchmarking func - run the timers
+        // once, unroll the body to minimize the noise.
+        let start = ref_time_ticks()
+        for (i in range(loop_runs)) {
+            unroll <| $() {
+                for (_ in range(unroll_count)) {
+                    op()
+                }
+            }
+        }
+        time_total = get_time_nsec(start)
+    } else {
+        // A long-running benchmark that should not be unrolled.
+        // Its run time will not be dominated by the loop anyway.
+        for (i in range(loop_runs)) {
+            let start = ref_time_ticks()
+            op()
+            time_total += get_time_nsec(start)
+        }
+    }
+
+    let heap_stats_end = heap_allocation_stats()
+    let heap_bytes_end = heap_stats_end[0]
+    let num_allocs_end = heap_allocation_count()
+
+    let string_stats_end = string_heap_allocation_stats()
+    let string_bytes_end = string_stats_end[0]
+    let string_num_allocs_end = string_heap_allocation_count()
+
+    var stats = BenchmarkRunStats(
+        name = b.name,
+        sub_name = name,
+        n = num_runs,
+        time_ns = time_total,
+        allocs = num_allocs_end - num_allocs_start,
+        heap_bytes = heap_bytes_end - heap_bytes_start,
+        string_allocs = string_num_allocs_end - string_num_allocs_start,
+        string_heap_bytes = string_bytes_end - string_bytes_start,
+    )
+
+    if (chunk_size > 1l) {
+        stats.time_ns = max(stats.time_ns / chunk_size, 1l)
+        if (stats.allocs > 0ul) {
+            stats.allocs = max(stats.allocs / uint64(chunk_size), 1ul)
+        }
+        if (stats.heap_bytes > 0ul) {
+            stats.heap_bytes = max(stats.heap_bytes / uint64(chunk_size), 1ul)
+        }
+    }
+
+    b.on_finished(stats)
+}
+
+[sideeffects]
+def sink(v) {
+    //! Marks v as used, so the optimizer is not tempted
+    //! to remove the benchmark value evaluation.
+    return v
 }

--- a/dastest/testing_boost.das
+++ b/dastest/testing_boost.das
@@ -8,13 +8,13 @@ require daslib/ast_boost
 require testing public
 
 [macro_function]
-def private validate_arguments(args) : bool {
+def private validate_arguments(type_name : string, args) : bool {
     let len = length(args)
     if (len == 0) {
         return true
     }
     if (len == 1) {
-        return (args[0]._type.isPointer && args[0]._type.firstType.isStructure && args[0]._type.firstType.structType.name == "T"
+        return (args[0]._type.isPointer && args[0]._type.firstType.isStructure && args[0]._type.firstType.structType.name == type_name
                 && args[0]._type.firstType.structType._module != null && args[0]._type.firstType.structType._module.name == "testing")
     }
     return false
@@ -23,8 +23,20 @@ def private validate_arguments(args) : bool {
 [function_macro(name="test")]
 class TestFunctionAnnotation : AstFunctionAnnotation {
     [unused_argument(group, args, errors)] def override apply(var func : FunctionPtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
-        if (!validate_arguments(func.arguments)) {
+        if (!validate_arguments("T", func.arguments)) {
             errors := "Invalid arguments for test macro\nexpected function header: def {func.name}() or def {func.name}(t: testing::T?)"
+            return false
+        }
+        func.flags |= FunctionFlags.exports
+        return true
+    }
+}
+
+[function_macro(name="benchmark")]
+class BenchmarkFunctionAnnotation : AstFunctionAnnotation {
+    [unused_argument(group, args, errors)] def override apply(var func : FunctionPtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
+        if (!validate_arguments("B", func.arguments)) {
+            errors := "Invalid arguments for benchmark macro\nexpected function header: def {func.name}() or def {func.name}(b: testing::B?)"
             return false
         }
         func.flags |= FunctionFlags.exports

--- a/tests/language/variants.das
+++ b/tests/language/variants.das
@@ -5,18 +5,18 @@ struct A {
     a : int
 }
 
-struct B {
+struct BB {
     b : int
 }
 
 variant Foo {
     a : A
-    b : B
+    b : BB
 }
 
 let foo <- fixed_array<Foo>(
     Foo(a = A(a = 1)),
-    Foo(b = B(b = 2))
+    Foo(b = BB(b = 2))
 );
 
 [test]


### PR DESCRIPTION
Adds benchmarking API to the dastest testing framework.
If T is a `testing::T` version of Go's `testing.T`,
then B is like Go's `testing.B`.

Currently, it supports several output formats:

The default, "native" format - only for interactive use.
It is intended to be pretty and blend-in the most
with test-related output of dastest.

The second format is "go". It can be used to
produce go-compatible samples that can then be
consumed by any Go-related benchmark analysis tool.
An example of such tool is benchstat.

The third format is "json". It can be used
for any further data analysis (e.g. for our custom tools).