### PR TITLE
aot: write AOT generated file as "wb" when content changed

### DIFF
--- a/include/daScript/ast/ast_aot_cpp.h
+++ b/include/daScript/ast/ast_aot_cpp.h
@@ -6,7 +6,7 @@
 namespace das {
 
     inline bool saveToFile ( TextPrinter &tout, const string_view & fname, const string_view & str, bool quiet = false ) {
-        FILE * f = fopen ( fname.data(), "w" );
+        FILE * f = fopen ( fname.data(), "wb" );
         if ( !f ) {
             tout << "can't open " << fname.data() << "\n";
             return false;


### PR DESCRIPTION
In order to be matched when read with "rb" to preserve timestamps of .cpp files for incremental build.