### PR TITLE
Remove empty crash_handler.cpp stub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -692,7 +692,6 @@ include/daScript/misc/performance_time.h
 src/hal/debug_break.cpp
 src/hal/project_specific.cpp
 src/hal/project_specific_file_info.cpp
-src/hal/crash_handler.cpp
 include/daScript/misc/crash_handler.h
 include/daScript/misc/network.h
 src/misc/network.cpp

--- a/src/hal/crash_handler.cpp
+++ b/src/hal/crash_handler.cpp
@@ -1,1 +1,0 @@
-#include "daScript/misc/crash_handler.h"

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -481,7 +481,6 @@ SET(SIMULATE_SRC
 ../src/hal/debug_break.cpp
 ../src/hal/project_specific.cpp
 ../src/hal/project_specific_file_info.cpp
-../src/hal/crash_handler.cpp
 ../include/daScript/misc/crash_handler.h
 ../include/daScript/misc/network.h
 ../src/misc/network.cpp


### PR DESCRIPTION
The crash_handler.cpp only contained a single include of its header and provided no implementation. Remove it and its references from both CMakeLists.txt files.