### PR TITLE
Add design philosophy document and refactor CLAUDE.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,24 @@
 
 This is the [daslang](https://dascript.org/) programming language repository (GaijinEntertainment/daScript). daslang (formerly daScript) is a high-performance statically-typed scripting language designed for games and real-time applications. The language has been renamed to **daslang**, but the repository and many C++ API names still use the old "daScript" spelling.
 
+## What and Why
+
+daslang was created at Gaijin Entertainment to solve a concrete problem: **interop overhead** between scripting languages (Lua/LuaJIT, Squirrel) and C++ was killing frame budgets in their ECS game engine. The key insight is that daslang's data layout matches C++ — no marshaling, no boxing — making script↔C++ calls near-zero cost.
+
+**Core design principles:**
+- **Iteration speed is king** — full production game recompiles in ~5 sec; hot reload built in
+- **Explicit, not implicit** — no hidden conversions, no silent allocations; `options log` shows exactly what the compiler produces
+- **99% safe, not 100%** — eliminate real-world C++ bugs pragmatically, not at Rust-level cost; `unsafe` for the remaining 1%
+- **No data marshaling** — C++-compatible data layout; this is what makes ECS-scale scripting viable
+- **If it gets slow, you can fix it** — manual `delete` to reduce GC pressure, AOT compilation for native speed
+- **Language reflects the domain** — macros (FORTRAN+LISP inspiration) let libraries reshape syntax to match the problem
+
+**Three execution tiers** (all planned from day one): fast tree-based interpreter → AOT to C++ (required for consoles) → JIT via LLVM. Hybrid mode uses semantic hashing: unchanged functions stay AOT, changed ones fall back to the interpreter.
+
+**Audience:** game scripters (largest group — hot reload, fast compile, never rewrite to C++), engine/tools programmers (zero-cost interop, macros), and a growing standalone/ecosystem community (LLVM executables, package manager in development).
+
+See `doc/source/reference/design_philosophy.rst` for the full design philosophy document.
+
 ## Build & Run
 
 - **Build system:** CMake + MSVC (Visual Studio 2022)
@@ -19,8 +37,8 @@ This is the [daslang](https://dascript.org/) programming language repository (Ga
 
 - **Always check the exit code** after running `daslang.exe` — a crash may produce no output at all, looking like a silent success
 - On Windows, check `$LASTEXITCODE` in PowerShell after every run. Exit code `0` = success, non-zero = error
-- Exit code `-1073741819` (`0xC0000005`) = **Access Violation** — indicates a native crash (segfault), usually a dangling pointer or double-free in macro AST manipulation
-- If the program crashes with no error message, the bug is in native code (C++ bindings or smart pointer misuse), not in daScript logic — check exit code first before investigating script errors
+- Exit code `-1073741819` (`0xC0000005`) = **Access Violation** — indicates a native crash (segfault)
+- If the program crashes with no error message, the bug is in native code (C++ bindings or smart pointer misuse) — check exit code first
 
 ## GitHub Operations
 
@@ -34,183 +52,85 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 |---|---|
 | `skills/das_formatting.md` | Creating or modifying any `.das` file (tutorials, tests, daslib modules, utilities) |
 | `skills/writing_tests.md` | Writing or editing test files under `tests/` |
-| `skills/documentation_rst.md` | Editing RST files in `doc/source/`, editing `//!` doc-comments in `daslib/*.das`, writing tutorial RST pages, editing `doc/source/stdlib/handmade/` files, running `das2rst.das`, or regenerating stdlib module documentation |
+| `skills/documentation_rst.md` | Editing RST files in `doc/source/`, editing `//!` doc-comments in `daslib/*.das`, writing tutorial RST pages |
 | `skills/cpp_integration.md` | Writing or editing C++ files in `src/`, `modules/`, or `tutorials/integration/cpp/` |
-| `skills/daslib_modules.md` | Working with `daslib/` modules (linq, json, regex, functional, match, etc.) or extending the standard library |
-| `skills/writing_benchmarks.md` | Writing or running benchmark files under `benchmarks/`, porting benchmarks from `examples/profile/` |
-| `skills/dynamic_modules.md` | Creating or editing `.das_module` descriptors, adding new modules under `modules/`, fixing module resolution for the dynamic binary |
+| `skills/daslib_modules.md` | Working with `daslib/` modules (linq, json, regex, functional, match, etc.), channels, or extending the standard library |
+| `skills/das_macros.md` | Writing compile-time macros, AST manipulation, qmacro/quote code generation, smart_ptr ownership patterns |
+| `skills/writing_benchmarks.md` | Writing or running benchmark files under `benchmarks/` |
+| `skills/dynamic_modules.md` | Creating or editing `.das_module` descriptors, adding new modules under `modules/` |
 | `skills/install_instructions.md` | Creating or updating AI instruction files (`install/CLAUDE.md`, `install/skills/`) for the installed SDK |
 
 Multiple skill files may apply to a single task. For example, creating a new daslib module requires reading `skills/das_formatting.md`, `skills/daslib_modules.md`, and possibly `skills/documentation_rst.md`.
 
 ### Updating Instructions with New Knowledge
 
-When you discover something new about daslang syntax, semantics, or conventions — whether through compiler errors, user corrections, or experimentation — **update this file** (and its `.github/copilot-instructions.md` mirror) with the new knowledge. Add it to the appropriate section (gen2 syntax, common gotchas, etc.) so future sessions benefit. If it relates to a specific skill area, update the relevant `skills/*.md` file too.
+When you discover something new about daslang syntax, semantics, or conventions — whether through compiler errors, user corrections, or experimentation — **update this file** (and its `CLAUDE.md` mirror) with the new knowledge. If it relates to a specific skill area, update the relevant `skills/*.md` file instead.
 
 ## daslang Language — Gen2 Syntax (REQUIRED)
 
-All code examples and documentation MUST use gen2 syntax (add `options gen2` at the top of every file). Key rules:
+All code MUST use gen2 syntax (add `options gen2` at the top of every file). Key rules:
 
 - **Parentheses** on control flow: `if (x > 0)`, `for (i in range(10))`, `while (running)`
-- **Braces** on all blocks — no indentation-based blocks: `def foo() { ... }`, `if (x) { ... }`
+- **Braces** on all blocks: `def foo() { ... }`, `if (x) { ... }`
 - **Construction:** `new Type(field=val)` — NOT `new [[Type() field=val]]`
-- **Enum access:** `EnumName.EnumValue` with dot — NOT `EnumName EnumValue` without
-- **Array literals:** `[1, 2, 3]` (commas, square brackets) — NOT `[[int 1; 2; 3]]`. Note: this creates a **dynamic** `array<int>` — use `fixed_array(1, 2, 3)` for fixed-size arrays
+- **Enum access:** `EnumName.EnumValue` with dot — NOT `EnumName EnumValue`
+- **Array literals:** `[1, 2, 3]` — NOT `[[int 1; 2; 3]]`. Creates `array<int>`; use `fixed_array(1, 2, 3)` for fixed-size
 - **Struct init:** `Foo(a=1, b=2)` — NOT `[[Foo() a=1, b=2]]`
-- **No `[[ ]]` for `new`** — `new` always uses parentheses: `new Foo(x=1)`
-- **Table literals:** `{ "k" => v, "k2" => v2 }` (single braces, commas) — NOT `{{ "k" => v; "k2" => v2 }}`
-- **Named arguments:** `foo([name = value])` with square brackets — NOT `foo(name=value)`
-- **Block arguments:** a block or lambda after `func()` is automatically piped as the last argument — no `<|` needed. Parameterless blocks need no `$`: `defer() { ... }`. Blocks with parameters use `$`: `build_string() $(var writer) { ... }`. Lambdas use `@`: `emplace() @(x : int) { ... }`
+- **Table literals:** `{ "k" => v, "k2" => v2 }` — NOT `{{ "k" => v; "k2" => v2 }}`
+- **Named arguments:** `foo([name = value])` with square brackets
+- **Block arguments:** block/lambda after `func()` pipes as last arg. No `$` for parameterless blocks: `defer() { ... }`. With params: `build_string() $(var writer) { ... }`. Lambdas: `emplace() @(x : int) { ... }`
 - **Lambda:** `@(args) { body }` or `@@(args) { body }` (no-capture)
-- **Generator:** `$() { yield value; }` or `$ { yield value; }` — both are valid gen2 syntax
-- **Tuple `=>` operator:** `a => b` creates a `tuple<auto;auto>` — useful in LINQ, table construction, and ad-hoc pairs
-- **Bitfield variables** need explicit type for `.field` access and printing: `var f : MyBitfield`
-- **Bitfield dot access:** read with `f.flag` (returns bool), write with `f.flag = true/false`
-- **`typeinfo`** gen2 syntax: trait name goes **outside** parentheses — `typeinfo trait_name(type<T>)`, NOT `typeinfo(trait_name type<T>)`. With subtrait: `typeinfo has_method<name>(type<T>)`. With two traits: `typeinfo trait<sub;extra>(type<T>)`
-- **`static_if`:** `static_if (condition) { ... }` — parentheses required in gen2
-- **Type function call:** `take(type<int>, 1, 2)` — NOT `take < int > (1, 2)`. The `type<T>` is passed as a regular argument
+- **Generator:** `$() { yield value; }` or `$ { yield value; }`
+- **Tuple `=>`:** `a => b` creates `tuple<auto;auto>`
+- **`typeinfo`:** `typeinfo trait_name(type<T>)` — trait name outside parens
+- **`static_if`:** `static_if (condition) { ... }` — parentheses required
+- **Type function call:** `take(type<int>, 1, 2)` — NOT `take < int > (1, 2)`
 
 ### Important defaults
 
-- `strict_smart_pointers` is ON by default — smart_ptr variables require `var inscope` declaration
-- `smart_ptr<T>` only works with C++ handled types (not user structs)
+- `strict_smart_pointers` is ON — smart_ptr variables require `var inscope`
 - No implicit type promotion: `int + float` is a compile error — both sides must match
-- No `bool(int)` cast — use `x != 0`
-- `string(x)` works for numeric types; `string(bool)` does NOT work — use string interpolation `"{flag}"`
+- No `bool(int)` cast — use `x != 0`; no `string(bool)` — use `"{flag}"`
 - `int("123")` does NOT work — use `to_int` from `require strings`
-- Hex literals like `0x3F800000` are `uint` by default — use `int(0x3F)` for int
-- Float printing is compact: `3.14` not `3.140000`; uint prints as hex: `0xff` not `255`
+- Hex literals are `uint` by default — use `int(0x3F)` for int
 
-### Memory management
+### Memory and move semantics
 
 - daslang has garbage collection — `delete` is not required in most code
-- `delete` is available for explicit cleanup but requires `unsafe` for heap pointers
-- `var inscope` declares automatic cleanup in a `finally` block
-- Prefer omitting `delete` in tutorials and examples unless the topic is memory management
-- Struct fields without initializers require defaults or `@safe_when_uninitialized`
-
-### Move semantics (`<-` vs `move`)
-
-- **`<-` operator**: ALWAYS `memcpy(dest, src) + memset(src, 0)` — it is a raw memory operation, NOT smart_ptr-aware. It zeros the source regardless of type.
-- **`move` function**: Bound via C++ `builtin_smart_ptr_move*` family in `module_builtin_runtime.cpp` — proper smart pointer move with reference counting. Use `move(dest, src)` or `move(dest) src` for `smart_ptr<T>` transfers.
-- **`return <- expr`**: Moves value to return slot and zeroes `expr`. If `expr` is a `&` ref parameter, this zeroes the *caller's* variable since they share memory.
-- **Key subtlety**: When a function takes `var x : smart_ptr<T>&` (by reference) and internally calls a function that takes `var x : smart_ptr<T>` (by value/move), the `<-` inside `return` zeroes the `&` ref. Callers MUST capture the return value: `unsafe { expr <- apply_template(expr) $() { ... } }`
-- **Safe pattern**: `unsafe { variable <- function_returning_smart_ptr(variable) $() { ... } }` — captures return value back into the same variable
-
-### AST smart pointer ownership (macros)
-
-- Many AST functions take `smart_ptr<T>` **by value** — this **moves** the pointer from the caller. After the call, the caller's variable is null/zeroed.
-- **`var inscope` + move = double-free crash**: If you declare `var inscope p = make_something()` and pass `p` to a function that moves it, `p` is zeroed by the move. Then `inscope` destroys `p` at scope exit → double-free → Access Violation.
-- **`clone_type(typeExpr)`** — deep-copies a `TypeDeclPtr`. Use when passing a type to a consuming function while keeping the original, or when the source is a `var inscope` variable.
-- **`clone_expression(expr)`** — deep-copies an `ExpressionPtr`. Same ownership rules as `clone_type`.
-- **Safe pattern for `add_structure_field`**: pass temporaries directly — `st |> add_structure_field("name", clone_type(qmacro_type(type<int>)), qmacro($v(val)))` — the `clone_type` result is a temporary safely consumed by the move.
-- **`move_new`**: `field |> move_new <| expr` — idiomatic way to assign a newly created `smart_ptr<T>` into a field. Equivalent to `field <- expr` but does not require `unsafe`. Preferred over `field := null; unsafe { field <- expr }` when setting AST node fields (e.g. `cm.init |> move_new <| qmacro(...)`).
-- **`add_ptr_ref(raw_ptr)`** — wraps a raw pointer (`T?`) into a `smart_ptr<T>` by adding a reference. AST node fields are often raw pointers (e.g. `typeDecl.structType` is `Structure?`, `typeDecl.enumType` is `Enumeration?`), but many API functions expect `smart_ptr<T>`. Use `add_ptr_ref` to bridge: `var inscope st <- add_ptr_ref(pair_type.structType)` gives a `StructurePtr` from a `Structure?` field. Also accepts `smart_ptr<T>` input (adds a ref and returns a new smart_ptr). Always use `var inscope` for the result to manage lifetime.
-- **Rule of thumb**: if a function signature takes `var x : smart_ptr<T>` (not `&`), it **consumes** `x`. Pass a temporary, a clone, or accept that your variable will be null after the call.
-
-### Structure macros — generating types and functions
-
-- **`[structure_macro(name=foo)]`** — annotation on a class inheriting `AstStructureAnnotation`; the `apply` method runs at compile time when a struct has `[foo]`. Use to generate companion types, operators, and functions.
-- **`clone_structure(get_ptr(st))`** — deep-copies a `StructurePtr` for creating modified companion types (e.g., SOA layout where every field becomes `array<FieldType>`)
-- **`get_ptr(st)`** — extracts raw pointer from `smart_ptr<Structure>` for use in `TypeDecl.structType` fields
-- **`compiling_module() |> add_function(fn)`** — registers a concrete function in the current module
-- **`compiling_module() |> add_generic(fn)`** — registers a generic function (instanced per call site)
-- **`compiling_module() |> add_structure(st)`** — registers a generated struct
-- **`compiling_module() |> add_alias(tdef)`** — registers a type alias
-- **`fn.flags |= FunctionFlags.generated`** — marks a function as compiler-generated (suppresses "unused" warnings, enables special error messages)
-- **`ExprFieldFieldFlags.no_promotion`** / **`ExprAtFlags.no_promotion`** — prevent the compiler from promoting field access or index access to a different type; needed in generated AST to preserve exact types
-- **`[tag_function(tag_name)]`** on a function + **`[tag_function_macro(tag="tag_name")]`** on a class — intercepts calls to the tagged function and rewrites them in the `transform` method. Used for compile-time call rewriting (e.g., SOA `operator .` rewrites `soa[i].field` → `soa.field[i]`).
-- **`[for_loop_macro(name=foo)]`** on a class inheriting `AstForLoopMacro` — intercepts `for` loops whose source is a matching type. Override `visitExprFor` to rewrite the loop AST (e.g., SOA for-loop expands `for (it in soa)` into per-field array iteration).
-
-### `qmacro` vs `quote` (code generation)
-
-- **`qmacro(expr)`** — quasi-quote with reification splices (`$v()`, `$e()`, `$c()`, `$t()`, `$i()`, `$f()`, `$a()`, `$b()` etc.). Use when the generated code contains interpolated values.
-- **`qmacro_function("name") $(args) { body }`** — generates an entire `FunctionPtr` with spliced arguments/body. The `$t(typeExpr)` splice in the signature sets parameter/return types from `TypeDeclPtr` variables. Example: `qmacro_function("push") $(var st : $t(stypeT); var arg : $t(argT)) : void { $b(bodyExprs) }` generates a function with dynamic types and spliced body.
-- **`qmacro_expr(${ statement; })`** — generates a statement-level expression (e.g., assignment). The `${ }` block allows semicolons. Example: `qmacro_expr(${ soa_elem.$f(fieldName) := st.$f(fieldName)[soa_idx]; })`.
-- **`quote(expr)`** — plain quote with NO reification. Use when the expression is a simple literal or constant with no splices — e.g. `quote(true)`, `quote(false)`, `quote(0)`.
-- **Rule**: if the expression contains no `$…()` reification operators, prefer `quote()` over `qmacro()` — it is simpler, clearer, and avoids unnecessary reification overhead.
-
-#### Reification operators (inside `qmacro`)
-
-- **`$v(daslangVar)`** — splice the runtime **value** of a variable into the generated code
-- **`$e(exprPtr)`** — splice an `ExpressionPtr` as a sub-expression
-- **`$c(stringVar)`** — splice a `string` as a **call name** (function name). Example: `$c(callName)(arr, val)` generates a call to whatever function name `callName` holds
-- **`$t(typeDeclPtr)`** — splice a `TypeDeclPtr` as a type annotation in signatures or declarations
-- **`$i(stringVar)`** — splice a string as an **identifier** (variable name)
-- **`$f(stringVar)`** — splice a string as a **field name**. Example: `st.$f(fieldName)` becomes `st.x` when `fieldName="x"`
-- **`$a(arrayOfExprPtr)`** — splice an `array<ExpressionPtr>` as function call **arguments**
-- **`$b(arrayOfExprPtr)`** — splice an `array<ExpressionPtr>` as a **block body** (sequence of statements). Build the array with `emplace_new`, then `$b(bodyExprs)` inlines all statements into the function body
+- `var inscope` declares automatic cleanup; struct fields need defaults or `@safe_when_uninitialized`
+- `<-` is memcpy+memset(0), NOT smart_ptr-aware — see `skills/das_macros.md` for smart_ptr patterns
 
 ### Error handling
 
 - `try/recover` — NOT `try/catch` (`recover` is the keyword)
-- `panic("message")` — abort with message
-- `assert(condition)` / `assert(condition, "message")` — debug assertion
-- `verify(condition)` — assertion that remains in release builds
+- `panic("message")`, `assert(condition)`, `verify(condition)` (stays in release)
 
-### Class method modifiers
+### Generic function dispatch
 
-- **`def const`** — const method: `self` is `const`, cannot modify fields. Use for read-only methods.
-- **`def abstract const`** / **`def override const`** — abstract/override const methods in class hierarchies
-- **`def static`** — static method: no implicit `self`; called as `ClassName.method()` or `ClassName\`method()`
-- **`def static const`** — static method with const `self` parameter (used in template structures like `flat_hash_table.das`). The first explicit argument becomes const `self`.
-- **`[class_method]`** annotation (from `daslib/class_boost`) — transforms a `def static` into a proper class method by injecting `self` and wrapping body in `with (self) { ... }`. Const-ness follows `def static const`.
-- Method call syntax: `obj.method()` for value types, `obj->method()` for pointer types, `obj |> method()` pipe syntax
-
-### Generic function dispatch (`_::`, `__::`, unqualified)
-
-- Generic functions are instanced as private functions in the **calling** module
-- **Unqualified call** `foo(x)`: resolves in the module where the generic is **defined** — caller's overloads are NOT visible
-- **`_::foo(x)`**: resolves as if called implicitly in the **current** (calling) module — caller's overloads ARE visible
-- **`__::foo(x)`**: resolves strictly in the **defining** module only — nothing imported
-- This is why `:=` and `delete` emit `_::clone` / `_::finalize` — so user overloads are picked up in generics
-- When writing a library generic that should dispatch to user-provided overloads, use `_::` prefix
-- `mem_archive_save` does NOT use `_::serialize` — so user serialize overloads are invisible; use manual `Archive` + `MemSerializer` pattern instead
+- **`_::foo(x)`**: resolves in the **calling** module — caller's overloads visible. Use in library generics.
+- **Unqualified** `foo(x)`: resolves in the **defining** module — caller's overloads NOT visible.
+- This is why `:=` and `delete` emit `_::clone` / `_::finalize`
 
 ### Table operations
 
-- `table[key]` **inserts** a new default entry if `key` is missing — use only when you want insert-on-access
-- `table[key]` requires `unsafe` by default; add `options unsafe_table_lookup = false` to allow safe `[]` access
-- `table?[key] ?? default_value` — safe lookup with fallback, does NOT insert missing keys
-- `key_exists(table, key)` — check if a key is present without inserting
-- `table |> insert(key, value)` — insert into `table<K;V>`; `table |> insert(key)` — insert into set `table<K>`
-- `table |> erase(key)` — remove a key
-- **Never use two `[]` lookups on the same table in one expression** (e.g. `tab[k1] = tab[k2]`) — tables are unboxed containers and re-hashing on insert can invalidate the first reference
-- `get(table, key) $(pval) { ... }` — block-based lookup; block receives value reference if found
+- `table[key]` **inserts** a default entry if missing — use `table?[key] ?? default` for safe lookup
+- `key_exists(table, key)` — check without inserting
+- `table |> insert(key, value)` / `table |> erase(key)`
+- **Never use two `[]` lookups on the same table in one expression** — re-hashing can invalidate references
 
 ### Common gotchas
 
-- Lambda params can shadow function params — use distinct names (e.g., `$(lhs, rhs)` not `$(a, b)` when `a` is already in scope)
-- `struct Foo { ... }` requires braces in gen2 — empty struct is `struct Foo {}`
-- String builder: `build_string() $(var writer) { write(writer, "text") }` — requires `unsafe` or `options persistent_heap` if returned
-- `options persistent_heap` — needed when returning strings built with `build_string`
-- Tuple field access uses underscore prefix: `t._0`, `t._1`, `t._2`
-- Annotations: `[export]` for entry points, `[private]` for private functions, `[test]` for test functions
-- `options no_aot` — disable ahead-of-time compilation (common in test files)
-- `options rtti` — enable runtime type information (needed for some daslib features)
-- `require` uses forward slash paths: `require daslib/linq` — NOT `require daslib\linq`
-- `require foo public` — re-exports `foo` so that any module requiring the current module also sees `foo`'s symbols transitively. Example: `regex.das` has `require strings public`, so `require daslib/regex` automatically makes `slice`, `starts_with`, etc. visible without a separate `require strings`
-- `<-` is memcpy+memset(0), NOT a smart_ptr-aware move — see "Move semantics" section above
-- When calling `apply_template`, always capture the return value: `unsafe { expr <- apply_template(expr) $() { ... } }` — discarding the return loses the expression data
-- Iterator comprehension: `[iterator for(x in src); expression]` — semicolon separates generator from body
-- `to_array` (from `daslib/builtin`) converts any iterator to an array
-- Lambdas CAN be stored in arrays: `var fns : array<lambda<(x:int):int>>` + `fns |> emplace() @(x : int) : int { return x * 2; }` — move semantics, not copy
-- Blocks CANNOT be stored in containers, returned from functions, or captured — use lambdas or function pointers for those use cases
-- `match`, `multi_match`, `static_match` macros (from `daslib/match.das`) handle side effects automatically — do NOT add `[sideeffects]` annotations to functions that only use match
-- `[export] def main()` returns `void` — do NOT `return true` or return other values from main
-- **`feint` vs `print` in tests**: `feint` is a no-op with the same signature and `SideEffects::modifyExternal` as `print` — it won't be optimized out, but produces no output. Use `feint` in tests instead of `print` unless testing actual print/logging behavior
-- **`push` vs `emplace` vs `push_clone`** for arrays: `push(arr, val)` copies `val` into the array (fails for non-copyable types like `array<int>`); `emplace(arr, val)` **moves** `val` into the array (source is zeroed/destroyed after); `push_clone(arr, val)` **clones** `val` into the array (works for any type, preserves source). When generating code that operates on user structs with potentially non-copyable fields, prefer `push_clone` (preserves source) or `emplace` (when source consumption is intentional).
-- **Non-copyable types**: `array<T>`, `table<K;V>`, lambdas, and any struct containing them cannot be copied with `=` or `push`. Use `:=` (clone-assign), `push_clone`, or `<-` (move) instead. The compiler error is clear: "can't copy non-copyable type"
-
-### Channels and cross-context communication
-
-- `with_channel(N) $(ch) { ... }` — creates a channel expecting `N` notify calls before `for_each_clone` unblocks
-- **`notify` vs `notify_and_release`**: when a lambda captures a channel, the reference count is incremented; `notify_and_release` decrements the entry count AND releases that extra reference, setting the variable to `null`. When passing a channel as a plain argument (e.g. via `invoke_in_context`), no lambda capture occurs — no extra reference is added — so use plain `notify`
-- `notify_and_release` sets the channel/status variable to `null` after release
-- `push_clone(ch, value)` — push a clone of `value` into the channel
-- `for_each_clone(ch) $(val : T#) { ... }` — drain channel; data arrives as temporary type `T#`
-- `invoke_in_context(context, "func", ch)` — can pass `Channel?` directly to a child context
-- Child scripts that use channel operations need `require daslib/jobque_boost`; compile with `compile_file` + `make_file_access("")` so the child can resolve daslib modules from disk
+- Lambda params can shadow function params — use distinct names
+- String builder requires `unsafe` or `options persistent_heap` if returned
+- Tuple field access: `t._0`, `t._1`, `t._2`
+- Annotations: `[export]`, `[private]`, `[test]`; `options no_aot`, `options rtti`
+- `require` uses forward slash: `require daslib/linq` — NOT backslash
+- `require foo public` — re-exports `foo` transitively
+- `[export] def main()` returns `void` — do NOT return values from main
+- `push` copies (fails for non-copyable types), `emplace` moves (zeros source), `push_clone` clones (preserves source)
+- Non-copyable types (`array<T>`, `table<K;V>`, lambdas): use `:=`, `push_clone`, or `<-`
+- Blocks cannot be stored/returned/captured — use lambdas or function pointers
+- Class methods: `def const`, `def abstract const`, `def static`; call syntax `obj.method()`, `obj->method()`, `obj |> method()`
 
 ## Key Directories
 
@@ -218,20 +138,16 @@ All code examples and documentation MUST use gen2 syntax (add `options gen2` at 
 - `include/daScript/` — C++ headers
 - `daslib/` — Standard library modules (86 .das files)
 - `dastest/` — Test framework
-- `tests/` — Test suite (35 subdirectories, ~226 `.das` files). See `tests/README.md` for a full index of every test file, what it tests, and whether it expects compile errors.
-- `doc/source/reference/language/` — RST language documentation (36 files)
-- `doc/source/stdlib/` — RST standard library documentation (auto-generated + handmade)
-- `doc/reflections/` — Documentation generation tools (das2rst.das, rst.das, gen_module_examples.py)
-- `tutorials/language/` — Language tutorial `.das` files (42 progressive tutorials)
-- `tutorials/integration/cpp/` — C++ integration tutorials (embedding daslang in C++ host applications)
-- `tutorials/macros/` — Macro tutorials (call macros, reader macros, etc.)
-- `doc/source/reference/tutorials/` — RST companion pages for each tutorial
+- `tests/` — Test suite. See `tests/README.md` for full index
+- `doc/source/reference/language/` — RST language documentation
+- `tutorials/language/` — Language tutorial `.das` files
+- `tutorials/integration/cpp/` — C++ integration tutorials
 - `modules/` — External plugin modules
 
 ## Keywords Reference
 
-`aka` — variable name alias (`var a aka alpha = 42`, `for (x aka element in arr)`)
-`inscope` — declares variable owns smart_ptr lifetime (`var inscope p = ...`)
-`is type<T>` — compile-time type check (`a is type<int>` returns bool)
-`expect` — suppress specific compilation errors in test files (`expect 30507`)
+`aka` — variable name alias (`var a aka alpha = 42`)
+`inscope` — declares variable owns smart_ptr lifetime
+`is type<T>` — compile-time type check
+`expect` — suppress specific compilation errors in test files
 `template` — generic type constraint in function signatures

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,28 @@
 # daslang Project Instructions
 
-> **Keep in sync:** This file and `CLAUDE.md` (repo root) share identical content. Both reference skill files in the `skills/` directory at repo root — skill files are shared, not duplicated.
+> **Keep in sync:** This file and `.github/copilot-instructions.md` share identical content. Both reference skill files in the `skills/` directory at repo root — skill files are shared, not duplicated.
 
 ## Project Overview
 
 This is the [daslang](https://dascript.org/) programming language repository (GaijinEntertainment/daScript). daslang (formerly daScript) is a high-performance statically-typed scripting language designed for games and real-time applications. The language has been renamed to **daslang**, but the repository and many C++ API names still use the old "daScript" spelling.
+
+## What and Why
+
+daslang was created at Gaijin Entertainment to solve a concrete problem: **interop overhead** between scripting languages (Lua/LuaJIT, Squirrel) and C++ was killing frame budgets in their ECS game engine. The key insight is that daslang's data layout matches C++ — no marshaling, no boxing — making script↔C++ calls near-zero cost.
+
+**Core design principles:**
+- **Iteration speed is king** — full production game recompiles in ~5 sec; hot reload built in
+- **Explicit, not implicit** — no hidden conversions, no silent allocations; `options log` shows exactly what the compiler produces
+- **99% safe, not 100%** — eliminate real-world C++ bugs pragmatically, not at Rust-level cost; `unsafe` for the remaining 1%
+- **No data marshaling** — C++-compatible data layout; this is what makes ECS-scale scripting viable
+- **If it gets slow, you can fix it** — manual `delete` to reduce GC pressure, AOT compilation for native speed
+- **Language reflects the domain** — macros (FORTRAN+LISP inspiration) let libraries reshape syntax to match the problem
+
+**Three execution tiers** (all planned from day one): fast tree-based interpreter → AOT to C++ (required for consoles) → JIT via LLVM. Hybrid mode uses semantic hashing: unchanged functions stay AOT, changed ones fall back to the interpreter.
+
+**Audience:** game scripters (largest group — hot reload, fast compile, never rewrite to C++), engine/tools programmers (zero-cost interop, macros), and a growing standalone/ecosystem community (LLVM executables, package manager in development).
+
+See `doc/source/reference/design_philosophy.rst` for the full design philosophy document.
 
 ## Build & Run
 
@@ -19,8 +37,8 @@ This is the [daslang](https://dascript.org/) programming language repository (Ga
 
 - **Always check the exit code** after running `daslang.exe` — a crash may produce no output at all, looking like a silent success
 - On Windows, check `$LASTEXITCODE` in PowerShell after every run. Exit code `0` = success, non-zero = error
-- Exit code `-1073741819` (`0xC0000005`) = **Access Violation** — indicates a native crash (segfault), usually a dangling pointer or double-free in macro AST manipulation
-- If the program crashes with no error message, the bug is in native code (C++ bindings or smart pointer misuse), not in daScript logic — check exit code first before investigating script errors
+- Exit code `-1073741819` (`0xC0000005`) = **Access Violation** — indicates a native crash (segfault)
+- If the program crashes with no error message, the bug is in native code (C++ bindings or smart pointer misuse) — check exit code first
 
 ## GitHub Operations
 
@@ -34,183 +52,85 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 |---|---|
 | `skills/das_formatting.md` | Creating or modifying any `.das` file (tutorials, tests, daslib modules, utilities) |
 | `skills/writing_tests.md` | Writing or editing test files under `tests/` |
-| `skills/documentation_rst.md` | Editing RST files in `doc/source/`, editing `//!` doc-comments in `daslib/*.das`, writing tutorial RST pages, editing `doc/source/stdlib/handmade/` files, running `das2rst.das`, or regenerating stdlib module documentation |
+| `skills/documentation_rst.md` | Editing RST files in `doc/source/`, editing `//!` doc-comments in `daslib/*.das`, writing tutorial RST pages |
 | `skills/cpp_integration.md` | Writing or editing C++ files in `src/`, `modules/`, or `tutorials/integration/cpp/` |
-| `skills/daslib_modules.md` | Working with `daslib/` modules (linq, json, regex, functional, match, etc.) or extending the standard library |
-| `skills/writing_benchmarks.md` | Writing or running benchmark files under `benchmarks/`, porting benchmarks from `examples/profile/` |
-| `skills/dynamic_modules.md` | Creating or editing `.das_module` descriptors, adding new modules under `modules/`, fixing module resolution for the dynamic binary |
+| `skills/daslib_modules.md` | Working with `daslib/` modules (linq, json, regex, functional, match, etc.), channels, or extending the standard library |
+| `skills/das_macros.md` | Writing compile-time macros, AST manipulation, qmacro/quote code generation, smart_ptr ownership patterns |
+| `skills/writing_benchmarks.md` | Writing or running benchmark files under `benchmarks/` |
+| `skills/dynamic_modules.md` | Creating or editing `.das_module` descriptors, adding new modules under `modules/` |
 | `skills/install_instructions.md` | Creating or updating AI instruction files (`install/CLAUDE.md`, `install/skills/`) for the installed SDK |
 
 Multiple skill files may apply to a single task. For example, creating a new daslib module requires reading `skills/das_formatting.md`, `skills/daslib_modules.md`, and possibly `skills/documentation_rst.md`.
 
 ### Updating Instructions with New Knowledge
 
-When you discover something new about daslang syntax, semantics, or conventions — whether through compiler errors, user corrections, or experimentation — **update this file** (and its `.github/copilot-instructions.md` mirror) with the new knowledge. Add it to the appropriate section (gen2 syntax, common gotchas, etc.) so future sessions benefit. If it relates to a specific skill area, update the relevant `skills/*.md` file too.
+When you discover something new about daslang syntax, semantics, or conventions — whether through compiler errors, user corrections, or experimentation — **update this file** (and its `.github/copilot-instructions.md` mirror) with the new knowledge. If it relates to a specific skill area, update the relevant `skills/*.md` file instead.
 
 ## daslang Language — Gen2 Syntax (REQUIRED)
 
-All code examples and documentation MUST use gen2 syntax (add `options gen2` at the top of every file). Key rules:
+All code MUST use gen2 syntax (add `options gen2` at the top of every file). Key rules:
 
 - **Parentheses** on control flow: `if (x > 0)`, `for (i in range(10))`, `while (running)`
-- **Braces** on all blocks — no indentation-based blocks: `def foo() { ... }`, `if (x) { ... }`
+- **Braces** on all blocks: `def foo() { ... }`, `if (x) { ... }`
 - **Construction:** `new Type(field=val)` — NOT `new [[Type() field=val]]`
-- **Enum access:** `EnumName.EnumValue` with dot — NOT `EnumName EnumValue` without
-- **Array literals:** `[1, 2, 3]` (commas, square brackets) — NOT `[[int 1; 2; 3]]`. Note: this creates a **dynamic** `array<int>` — use `fixed_array(1, 2, 3)` for fixed-size arrays
+- **Enum access:** `EnumName.EnumValue` with dot — NOT `EnumName EnumValue`
+- **Array literals:** `[1, 2, 3]` — NOT `[[int 1; 2; 3]]`. Creates `array<int>`; use `fixed_array(1, 2, 3)` for fixed-size
 - **Struct init:** `Foo(a=1, b=2)` — NOT `[[Foo() a=1, b=2]]`
-- **No `[[ ]]` for `new`** — `new` always uses parentheses: `new Foo(x=1)`
-- **Table literals:** `{ "k" => v, "k2" => v2 }` (single braces, commas) — NOT `{{ "k" => v; "k2" => v2 }}`
-- **Named arguments:** `foo([name = value])` with square brackets — NOT `foo(name=value)`
-- **Block arguments:** a block or lambda after `func()` is automatically piped as the last argument — no `<|` needed. Parameterless blocks need no `$`: `defer() { ... }`. Blocks with parameters use `$`: `build_string() $(var writer) { ... }`. Lambdas use `@`: `emplace() @(x : int) { ... }`
+- **Table literals:** `{ "k" => v, "k2" => v2 }` — NOT `{{ "k" => v; "k2" => v2 }}`
+- **Named arguments:** `foo([name = value])` with square brackets
+- **Block arguments:** block/lambda after `func()` pipes as last arg. No `$` for parameterless blocks: `defer() { ... }`. With params: `build_string() $(var writer) { ... }`. Lambdas: `emplace() @(x : int) { ... }`
 - **Lambda:** `@(args) { body }` or `@@(args) { body }` (no-capture)
-- **Generator:** `$() { yield value; }` or `$ { yield value; }` — both are valid gen2 syntax
-- **Tuple `=>` operator:** `a => b` creates a `tuple<auto;auto>` — useful in LINQ, table construction, and ad-hoc pairs
-- **Bitfield variables** need explicit type for `.field` access and printing: `var f : MyBitfield`
-- **Bitfield dot access:** read with `f.flag` (returns bool), write with `f.flag = true/false`
-- **`typeinfo`** gen2 syntax: trait name goes **outside** parentheses — `typeinfo trait_name(type<T>)`, NOT `typeinfo(trait_name type<T>)`. With subtrait: `typeinfo has_method<name>(type<T>)`. With two traits: `typeinfo trait<sub;extra>(type<T>)`
-- **`static_if`:** `static_if (condition) { ... }` — parentheses required in gen2
-- **Type function call:** `take(type<int>, 1, 2)` — NOT `take < int > (1, 2)`. The `type<T>` is passed as a regular argument
+- **Generator:** `$() { yield value; }` or `$ { yield value; }`
+- **Tuple `=>`:** `a => b` creates `tuple<auto;auto>`
+- **`typeinfo`:** `typeinfo trait_name(type<T>)` — trait name outside parens
+- **`static_if`:** `static_if (condition) { ... }` — parentheses required
+- **Type function call:** `take(type<int>, 1, 2)` — NOT `take < int > (1, 2)`
 
 ### Important defaults
 
-- `strict_smart_pointers` is ON by default — smart_ptr variables require `var inscope` declaration
-- `smart_ptr<T>` only works with C++ handled types (not user structs)
+- `strict_smart_pointers` is ON — smart_ptr variables require `var inscope`
 - No implicit type promotion: `int + float` is a compile error — both sides must match
-- No `bool(int)` cast — use `x != 0`
-- `string(x)` works for numeric types; `string(bool)` does NOT work — use string interpolation `"{flag}"`
+- No `bool(int)` cast — use `x != 0`; no `string(bool)` — use `"{flag}"`
 - `int("123")` does NOT work — use `to_int` from `require strings`
-- Hex literals like `0x3F800000` are `uint` by default — use `int(0x3F)` for int
-- Float printing is compact: `3.14` not `3.140000`; uint prints as hex: `0xff` not `255`
+- Hex literals are `uint` by default — use `int(0x3F)` for int
 
-### Memory management
+### Memory and move semantics
 
 - daslang has garbage collection — `delete` is not required in most code
-- `delete` is available for explicit cleanup but requires `unsafe` for heap pointers
-- `var inscope` declares automatic cleanup in a `finally` block
-- Prefer omitting `delete` in tutorials and examples unless the topic is memory management
-- Struct fields without initializers require defaults or `@safe_when_uninitialized`
-
-### Move semantics (`<-` vs `move`)
-
-- **`<-` operator**: ALWAYS `memcpy(dest, src) + memset(src, 0)` — it is a raw memory operation, NOT smart_ptr-aware. It zeros the source regardless of type.
-- **`move` function**: Bound via C++ `builtin_smart_ptr_move*` family in `module_builtin_runtime.cpp` — proper smart pointer move with reference counting. Use `move(dest, src)` or `move(dest) src` for `smart_ptr<T>` transfers.
-- **`return <- expr`**: Moves value to return slot and zeroes `expr`. If `expr` is a `&` ref parameter, this zeroes the *caller's* variable since they share memory.
-- **Key subtlety**: When a function takes `var x : smart_ptr<T>&` (by reference) and internally calls a function that takes `var x : smart_ptr<T>` (by value/move), the `<-` inside `return` zeroes the `&` ref. Callers MUST capture the return value: `unsafe { expr <- apply_template(expr) $() { ... } }`
-- **Safe pattern**: `unsafe { variable <- function_returning_smart_ptr(variable) $() { ... } }` — captures return value back into the same variable
-
-### AST smart pointer ownership (macros)
-
-- Many AST functions take `smart_ptr<T>` **by value** — this **moves** the pointer from the caller. After the call, the caller's variable is null/zeroed.
-- **`var inscope` + move = double-free crash**: If you declare `var inscope p = make_something()` and pass `p` to a function that moves it, `p` is zeroed by the move. Then `inscope` destroys `p` at scope exit → double-free → Access Violation.
-- **`clone_type(typeExpr)`** — deep-copies a `TypeDeclPtr`. Use when passing a type to a consuming function while keeping the original, or when the source is a `var inscope` variable.
-- **`clone_expression(expr)`** — deep-copies an `ExpressionPtr`. Same ownership rules as `clone_type`.
-- **Safe pattern for `add_structure_field`**: pass temporaries directly — `st |> add_structure_field("name", clone_type(qmacro_type(type<int>)), qmacro($v(val)))` — the `clone_type` result is a temporary safely consumed by the move.
-- **`move_new`**: `field |> move_new <| expr` — idiomatic way to assign a newly created `smart_ptr<T>` into a field. Equivalent to `field <- expr` but does not require `unsafe`. Preferred over `field := null; unsafe { field <- expr }` when setting AST node fields (e.g. `cm.init |> move_new <| qmacro(...)`).
-- **`add_ptr_ref(raw_ptr)`** — wraps a raw pointer (`T?`) into a `smart_ptr<T>` by adding a reference. AST node fields are often raw pointers (e.g. `typeDecl.structType` is `Structure?`, `typeDecl.enumType` is `Enumeration?`), but many API functions expect `smart_ptr<T>`. Use `add_ptr_ref` to bridge: `var inscope st <- add_ptr_ref(pair_type.structType)` gives a `StructurePtr` from a `Structure?` field. Also accepts `smart_ptr<T>` input (adds a ref and returns a new smart_ptr). Always use `var inscope` for the result to manage lifetime.
-- **Rule of thumb**: if a function signature takes `var x : smart_ptr<T>` (not `&`), it **consumes** `x`. Pass a temporary, a clone, or accept that your variable will be null after the call.
-
-### Structure macros — generating types and functions
-
-- **`[structure_macro(name=foo)]`** — annotation on a class inheriting `AstStructureAnnotation`; the `apply` method runs at compile time when a struct has `[foo]`. Use to generate companion types, operators, and functions.
-- **`clone_structure(get_ptr(st))`** — deep-copies a `StructurePtr` for creating modified companion types (e.g., SOA layout where every field becomes `array<FieldType>`)
-- **`get_ptr(st)`** — extracts raw pointer from `smart_ptr<Structure>` for use in `TypeDecl.structType` fields
-- **`compiling_module() |> add_function(fn)`** — registers a concrete function in the current module
-- **`compiling_module() |> add_generic(fn)`** — registers a generic function (instanced per call site)
-- **`compiling_module() |> add_structure(st)`** — registers a generated struct
-- **`compiling_module() |> add_alias(tdef)`** — registers a type alias
-- **`fn.flags |= FunctionFlags.generated`** — marks a function as compiler-generated (suppresses "unused" warnings, enables special error messages)
-- **`ExprFieldFieldFlags.no_promotion`** / **`ExprAtFlags.no_promotion`** — prevent the compiler from promoting field access or index access to a different type; needed in generated AST to preserve exact types
-- **`[tag_function(tag_name)]`** on a function + **`[tag_function_macro(tag="tag_name")]`** on a class — intercepts calls to the tagged function and rewrites them in the `transform` method. Used for compile-time call rewriting (e.g., SOA `operator .` rewrites `soa[i].field` → `soa.field[i]`).
-- **`[for_loop_macro(name=foo)]`** on a class inheriting `AstForLoopMacro` — intercepts `for` loops whose source is a matching type. Override `visitExprFor` to rewrite the loop AST (e.g., SOA for-loop expands `for (it in soa)` into per-field array iteration).
-
-### `qmacro` vs `quote` (code generation)
-
-- **`qmacro(expr)`** — quasi-quote with reification splices (`$v()`, `$e()`, `$c()`, `$t()`, `$i()`, `$f()`, `$a()`, `$b()` etc.). Use when the generated code contains interpolated values.
-- **`qmacro_function("name") $(args) { body }`** — generates an entire `FunctionPtr` with spliced arguments/body. The `$t(typeExpr)` splice in the signature sets parameter/return types from `TypeDeclPtr` variables. Example: `qmacro_function("push") $(var st : $t(stypeT); var arg : $t(argT)) : void { $b(bodyExprs) }` generates a function with dynamic types and spliced body.
-- **`qmacro_expr(${ statement; })`** — generates a statement-level expression (e.g., assignment). The `${ }` block allows semicolons. Example: `qmacro_expr(${ soa_elem.$f(fieldName) := st.$f(fieldName)[soa_idx]; })`.
-- **`quote(expr)`** — plain quote with NO reification. Use when the expression is a simple literal or constant with no splices — e.g. `quote(true)`, `quote(false)`, `quote(0)`.
-- **Rule**: if the expression contains no `$…()` reification operators, prefer `quote()` over `qmacro()` — it is simpler, clearer, and avoids unnecessary reification overhead.
-
-#### Reification operators (inside `qmacro`)
-
-- **`$v(daslangVar)`** — splice the runtime **value** of a variable into the generated code
-- **`$e(exprPtr)`** — splice an `ExpressionPtr` as a sub-expression
-- **`$c(stringVar)`** — splice a `string` as a **call name** (function name). Example: `$c(callName)(arr, val)` generates a call to whatever function name `callName` holds
-- **`$t(typeDeclPtr)`** — splice a `TypeDeclPtr` as a type annotation in signatures or declarations
-- **`$i(stringVar)`** — splice a string as an **identifier** (variable name)
-- **`$f(stringVar)`** — splice a string as a **field name**. Example: `st.$f(fieldName)` becomes `st.x` when `fieldName="x"`
-- **`$a(arrayOfExprPtr)`** — splice an `array<ExpressionPtr>` as function call **arguments**
-- **`$b(arrayOfExprPtr)`** — splice an `array<ExpressionPtr>` as a **block body** (sequence of statements). Build the array with `emplace_new`, then `$b(bodyExprs)` inlines all statements into the function body
+- `var inscope` declares automatic cleanup; struct fields need defaults or `@safe_when_uninitialized`
+- `<-` is memcpy+memset(0), NOT smart_ptr-aware — see `skills/das_macros.md` for smart_ptr patterns
 
 ### Error handling
 
 - `try/recover` — NOT `try/catch` (`recover` is the keyword)
-- `panic("message")` — abort with message
-- `assert(condition)` / `assert(condition, "message")` — debug assertion
-- `verify(condition)` — assertion that remains in release builds
+- `panic("message")`, `assert(condition)`, `verify(condition)` (stays in release)
 
-### Class method modifiers
+### Generic function dispatch
 
-- **`def const`** — const method: `self` is `const`, cannot modify fields. Use for read-only methods.
-- **`def abstract const`** / **`def override const`** — abstract/override const methods in class hierarchies
-- **`def static`** — static method: no implicit `self`; called as `ClassName.method()` or `ClassName\`method()`
-- **`def static const`** — static method with const `self` parameter (used in template structures like `flat_hash_table.das`). The first explicit argument becomes const `self`.
-- **`[class_method]`** annotation (from `daslib/class_boost`) — transforms a `def static` into a proper class method by injecting `self` and wrapping body in `with (self) { ... }`. Const-ness follows `def static const`.
-- Method call syntax: `obj.method()` for value types, `obj->method()` for pointer types, `obj |> method()` pipe syntax
-
-### Generic function dispatch (`_::`, `__::`, unqualified)
-
-- Generic functions are instanced as private functions in the **calling** module
-- **Unqualified call** `foo(x)`: resolves in the module where the generic is **defined** — caller's overloads are NOT visible
-- **`_::foo(x)`**: resolves as if called implicitly in the **current** (calling) module — caller's overloads ARE visible
-- **`__::foo(x)`**: resolves strictly in the **defining** module only — nothing imported
-- This is why `:=` and `delete` emit `_::clone` / `_::finalize` — so user overloads are picked up in generics
-- When writing a library generic that should dispatch to user-provided overloads, use `_::` prefix
-- `mem_archive_save` does NOT use `_::serialize` — so user serialize overloads are invisible; use manual `Archive` + `MemSerializer` pattern instead
+- **`_::foo(x)`**: resolves in the **calling** module — caller's overloads visible. Use in library generics.
+- **Unqualified** `foo(x)`: resolves in the **defining** module — caller's overloads NOT visible.
+- This is why `:=` and `delete` emit `_::clone` / `_::finalize`
 
 ### Table operations
 
-- `table[key]` **inserts** a new default entry if `key` is missing — use only when you want insert-on-access
-- `table[key]` requires `unsafe` by default; add `options unsafe_table_lookup = false` to allow safe `[]` access
-- `table?[key] ?? default_value` — safe lookup with fallback, does NOT insert missing keys
-- `key_exists(table, key)` — check if a key is present without inserting
-- `table |> insert(key, value)` — insert into `table<K;V>`; `table |> insert(key)` — insert into set `table<K>`
-- `table |> erase(key)` — remove a key
-- **Never use two `[]` lookups on the same table in one expression** (e.g. `tab[k1] = tab[k2]`) — tables are unboxed containers and re-hashing on insert can invalidate the first reference
-- `get(table, key) $(pval) { ... }` — block-based lookup; block receives value reference if found
+- `table[key]` **inserts** a default entry if missing — use `table?[key] ?? default` for safe lookup
+- `key_exists(table, key)` — check without inserting
+- `table |> insert(key, value)` / `table |> erase(key)`
+- **Never use two `[]` lookups on the same table in one expression** — re-hashing can invalidate references
 
 ### Common gotchas
 
-- Lambda params can shadow function params — use distinct names (e.g., `$(lhs, rhs)` not `$(a, b)` when `a` is already in scope)
-- `struct Foo { ... }` requires braces in gen2 — empty struct is `struct Foo {}`
-- String builder: `build_string() $(var writer) { write(writer, "text") }` — requires `unsafe` or `options persistent_heap` if returned
-- `options persistent_heap` — needed when returning strings built with `build_string`
-- Tuple field access uses underscore prefix: `t._0`, `t._1`, `t._2`
-- Annotations: `[export]` for entry points, `[private]` for private functions, `[test]` for test functions
-- `options no_aot` — disable ahead-of-time compilation (common in test files)
-- `options rtti` — enable runtime type information (needed for some daslib features)
-- `require` uses forward slash paths: `require daslib/linq` — NOT `require daslib\linq`
-- `require foo public` — re-exports `foo` so that any module requiring the current module also sees `foo`'s symbols transitively. Example: `regex.das` has `require strings public`, so `require daslib/regex` automatically makes `slice`, `starts_with`, etc. visible without a separate `require strings`
-- `<-` is memcpy+memset(0), NOT a smart_ptr-aware move — see "Move semantics" section above
-- When calling `apply_template`, always capture the return value: `unsafe { expr <- apply_template(expr) $() { ... } }` — discarding the return loses the expression data
-- Iterator comprehension: `[iterator for(x in src); expression]` — semicolon separates generator from body
-- `to_array` (from `daslib/builtin`) converts any iterator to an array
-- Lambdas CAN be stored in arrays: `var fns : array<lambda<(x:int):int>>` + `fns |> emplace() @(x : int) : int { return x * 2; }` — move semantics, not copy
-- Blocks CANNOT be stored in containers, returned from functions, or captured — use lambdas or function pointers for those use cases
-- `match`, `multi_match`, `static_match` macros (from `daslib/match.das`) handle side effects automatically — do NOT add `[sideeffects]` annotations to functions that only use match
-- `[export] def main()` returns `void` — do NOT `return true` or return other values from main
-- **`feint` vs `print` in tests**: `feint` is a no-op with the same signature and `SideEffects::modifyExternal` as `print` — it won't be optimized out, but produces no output. Use `feint` in tests instead of `print` unless testing actual print/logging behavior
-- **`push` vs `emplace` vs `push_clone`** for arrays: `push(arr, val)` copies `val` into the array (fails for non-copyable types like `array<int>`); `emplace(arr, val)` **moves** `val` into the array (source is zeroed/destroyed after); `push_clone(arr, val)` **clones** `val` into the array (works for any type, preserves source). When generating code that operates on user structs with potentially non-copyable fields, prefer `push_clone` (preserves source) or `emplace` (when source consumption is intentional).
-- **Non-copyable types**: `array<T>`, `table<K;V>`, lambdas, and any struct containing them cannot be copied with `=` or `push`. Use `:=` (clone-assign), `push_clone`, or `<-` (move) instead. The compiler error is clear: "can't copy non-copyable type"
-
-### Channels and cross-context communication
-
-- `with_channel(N) $(ch) { ... }` — creates a channel expecting `N` notify calls before `for_each_clone` unblocks
-- **`notify` vs `notify_and_release`**: when a lambda captures a channel, the reference count is incremented; `notify_and_release` decrements the entry count AND releases that extra reference, setting the variable to `null`. When passing a channel as a plain argument (e.g. via `invoke_in_context`), no lambda capture occurs — no extra reference is added — so use plain `notify`
-- `notify_and_release` sets the channel/status variable to `null` after release
-- `push_clone(ch, value)` — push a clone of `value` into the channel
-- `for_each_clone(ch) $(val : T#) { ... }` — drain channel; data arrives as temporary type `T#`
-- `invoke_in_context(context, "func", ch)` — can pass `Channel?` directly to a child context
-- Child scripts that use channel operations need `require daslib/jobque_boost`; compile with `compile_file` + `make_file_access("")` so the child can resolve daslib modules from disk
+- Lambda params can shadow function params — use distinct names
+- String builder requires `unsafe` or `options persistent_heap` if returned
+- Tuple field access: `t._0`, `t._1`, `t._2`
+- Annotations: `[export]`, `[private]`, `[test]`; `options no_aot`, `options rtti`
+- `require` uses forward slash: `require daslib/linq` — NOT backslash
+- `require foo public` — re-exports `foo` transitively
+- `[export] def main()` returns `void` — do NOT return values from main
+- `push` copies (fails for non-copyable types), `emplace` moves (zeros source), `push_clone` clones (preserves source)
+- Non-copyable types (`array<T>`, `table<K;V>`, lambdas): use `:=`, `push_clone`, or `<-`
+- Blocks cannot be stored/returned/captured — use lambdas or function pointers
+- Class methods: `def const`, `def abstract const`, `def static`; call syntax `obj.method()`, `obj->method()`, `obj |> method()`
 
 ## Key Directories
 
@@ -218,20 +138,16 @@ All code examples and documentation MUST use gen2 syntax (add `options gen2` at 
 - `include/daScript/` — C++ headers
 - `daslib/` — Standard library modules (86 .das files)
 - `dastest/` — Test framework
-- `tests/` — Test suite (35 subdirectories, ~226 `.das` files). See `tests/README.md` for a full index of every test file, what it tests, and whether it expects compile errors.
-- `doc/source/reference/language/` — RST language documentation (36 files)
-- `doc/source/stdlib/` — RST standard library documentation (auto-generated + handmade)
-- `doc/reflections/` — Documentation generation tools (das2rst.das, rst.das, gen_module_examples.py)
-- `tutorials/language/` — Language tutorial `.das` files (42 progressive tutorials)
-- `tutorials/integration/cpp/` — C++ integration tutorials (embedding daslang in C++ host applications)
-- `tutorials/macros/` — Macro tutorials (call macros, reader macros, etc.)
-- `doc/source/reference/tutorials/` — RST companion pages for each tutorial
+- `tests/` — Test suite. See `tests/README.md` for full index
+- `doc/source/reference/language/` — RST language documentation
+- `tutorials/language/` — Language tutorial `.das` files
+- `tutorials/integration/cpp/` — C++ integration tutorials
 - `modules/` — External plugin modules
 
 ## Keywords Reference
 
-`aka` — variable name alias (`var a aka alpha = 42`, `for (x aka element in arr)`)
-`inscope` — declares variable owns smart_ptr lifetime (`var inscope p = ...`)
-`is type<T>` — compile-time type check (`a is type<int>` returns bool)
-`expect` — suppress specific compilation errors in test files (`expect 30507`)
+`aka` — variable name alias (`var a aka alpha = 42`)
+`inscope` — declares variable owns smart_ptr lifetime
+`is type<T>` — compile-time type check
+`expect` — suppress specific compilation errors in test files
 `template` — generic type constraint in function signatures

--- a/README.md
+++ b/README.md
@@ -1,16 +1,30 @@
 # Daslang
-Daslang - high-performance statically strongly typed programming language
 
-MacOS/linux/win32/win64 build status [![build](https://github.com/GaijinEntertainment/daScript/actions/workflows/build.yml/badge.svg)](https://github.com/GaijinEntertainment/daScript/actions/workflows/build.yml)\
-MacOS/linux/win64 wasm build status [![wasm_build](https://github.com/GaijinEntertainment/daScript/actions/workflows/wasm_build.yml/badge.svg)](https://github.com/GaijinEntertainment/daScript/actions/workflows/wasm_build.yml)
+Daslang (formerly daScript) is a high-performance, statically typed programming language built for games and real-time applications.
 
-Read my [BLOG](https://borisbat.github.io/dascf-blog)
+[![build](https://github.com/GaijinEntertainment/daScript/actions/workflows/build.yml/badge.svg)](https://github.com/GaijinEntertainment/daScript/actions/workflows/build.yml)
+[![wasm_build](https://github.com/GaijinEntertainment/daScript/actions/workflows/wasm_build.yml/badge.svg)](https://github.com/GaijinEntertainment/daScript/actions/workflows/wasm_build.yml)
 
-0.6 version is coming soon.
+[Website](https://dascript.org/) · [Documentation](https://dascript.org/doc/) · [Blog](https://borisbat.github.io/dascf-blog) · [Try Online](https://gaijinentertainment.github.io/try-dascript/)
 
-Serialization, JIT (via LLVM), and many more good language features are in.
-We are putting in last finishing touches, documentation, and all that jazz.
-See you soon...
+## Why Daslang?
+
+Daslang was created at [Gaijin Entertainment](https://gaijin.net/) to solve a real problem: **interop overhead** between scripting languages and C++ was eating the frame budget in their ECS game engine. Lua (via LuaJIT) and Squirrel both hit the same wall — marshaling data back and forth was too expensive.
+
+Daslang's data layout matches C++. There is no marshaling, no boxing, no conversion — script↔C++ calls are near-zero cost.
+
+**Core principles:**
+- **Iteration speed is king** — a full production game recompiles in ~5 seconds; hot reload is built in
+- **Explicit, not implicit** — no hidden type conversions, no silent allocations; `options log` shows exactly what the compiler produces
+- **99% safe, not 100%** — eliminates real-world C++ bugs pragmatically, without Rust-level restrictions
+- **If it gets slow, you can fix it** — manual `delete` to reduce GC pressure, AOT to C++ for native speed
+- **The language reflects the problem** — a compile-time macro system lets libraries reshape syntax to match the domain
+
+**Three execution tiers** (all planned from day one):
+fast tree-based **interpreter** → **AOT** compilation to C++ (required for consoles) → **JIT** via LLVM.
+Hybrid mode uses semantic hashing: unchanged functions stay AOT, changed ones fall back to the interpreter — ship a hotfix without a full rebuild.
+
+See the [design philosophy](doc/source/reference/design_philosophy.rst) for the full story.
 
 ## Installation
 

--- a/doc/source/reference/design_philosophy.rst
+++ b/doc/source/reference/design_philosophy.rst
@@ -1,0 +1,216 @@
+.. _design_philosophy:
+
+******************
+Design Philosophy
+******************
+
+.. index::
+    single: design philosophy
+
+This document describes the **why** behind daslang — the problems it was built to solve,
+the trade-offs it makes deliberately, and the principles that guide its evolution.
+
+++++++++++++++
+Origins
+++++++++++++++
+
+daslang was born out of concrete problems at `Gaijin Entertainment <https://gaijin.net/>`_.
+The studio had Lua (via LuaJIT) and their own fork of Squirrel integrated into a large C++ game engine.
+Both languages hit the same walls:
+
+- **Interop overhead.** Calling back and forth between the scripting language and C++ was so expensive
+  that it dominated the frame budget, especially in an Entity Component System (ECS) architecture
+  where scripts touch many small pieces of host data every frame.
+- **Console performance.** Consoles prohibit JIT and have weaker CPUs. No existing scripting language
+  interpreter was fast enough to run gameplay code at acceptable frame rates without JIT.
+- **The C++ vs. script dilemma.** Every feature brought the same painful question: write it in C++
+  (fast, but hard to iterate) or in script (convenient, but slow)? And when scripts inevitably got slow,
+  the only fix was rewriting them in C++ — negating the reason they were scripts in the first place.
+
+A prototype interpreter — tree-based rather than bytecode-based — was already outperforming
+LuaJIT's interpreter by a wide margin, simply because it did not marshal data.
+"Give it decent syntax and I'll integrate it tomorrow" was the challenge from the engineering side.
+daslang shipped its first production integration shortly after.
+
++++++++++++++++++
+Audience
++++++++++++++++++
+
+daslang serves three overlapping groups, in order of population size:
+
+1. **Game scripters** — the largest group. They write the bulk of the codebase but rarely use
+   advanced language features. For them, the priorities are hot reload, fast compilation (~5 seconds
+   for a full production game), clear error messages, and never needing to rewrite working script into C++
+   just because it got slow.
+
+2. **Engine / tools programmers** — they integrate daslang into C++ applications, bind native types
+   and functions, and build domain-specific modules. For them, the priorities are zero-cost interop,
+   C++-compatible data layout, and a powerful compile-time macro system.
+
+3. **Language enthusiasts and standalone users** — a growing group. They want modules, packages,
+   and standalone executables. LLVM-based standalone compilation is now mature enough for this audience.
+   Platforms like `edenspark.io <https://edenspark.io/>`_ (currently in early beta) aim to serve this community.
+
++++++++++++++++++++++++++++++++++++
+Core Design Principles
++++++++++++++++++++++++++++++++++++
+
+**Iteration speed is king.**
+A full production game recompiles in ~5 seconds on decent hardware. Hot reload is built in.
+The entire developer experience revolves around the idea that you should never have to wait.
+
+**Explicit, not implicit.**
+daslang does not do work "under the hood". There are no hidden type conversions (not even ``int`` to ``float``),
+no silent allocations, no auto-casting outside of type inference.
+If the code does not say it, it does not happen. ``options log`` prints the full output of the compiler —
+total transparency about what your code becomes. Macros can add behavior; the base language does not.
+
+**99% safe, not 100%.**
+The goal is to eliminate 99% of the bugs seen in real-world C++ code — use-after-free, null dereferences,
+type mismatches, off-by-one errors — without imposing the full cost of formal verification.
+This is not Rust-level safety; it is pragmatic safety for game developers who can handle an occasional crash
+but should never be chasing undefined behavior.
+Safe code is the default. ``unsafe`` blocks exist for the remaining 1% where you need direct memory access.
+
+**No data marshaling.**
+daslang's data layout is essentially identical to C++ (minus bitfields).
+Calling from C++ into daslang or from daslang into C++ does not copy, convert, or box data.
+This is the single most important performance decision in the language — it is what makes daslang viable
+as a per-frame ECS scripting language where Lua and C# are not.
+
+**If it gets slow, you can fix it.**
+Garbage collection exists but should rarely run per-frame. Manual ``delete`` is available
+to reduce GC pressure when needed. Ahead-of-time compilation (AOT) to C++ is always an option.
+The philosophy is: the fast path should be fast by default, and when it isn't, the language gives you tools
+to make it fast — deterministically, not hopefully.
+
+**The language should reflect the problem domain.**
+The compile-time macro system (inspired by FORTRAN + LISP, with HAXE-style reification) exists not to keep
+the language core small, but to let libraries reshape the language to match the problem they solve.
+Less verbose solutions are better solutions. Pattern matching, LINQ, JSON — all are implemented as macros
+that extend the language rather than burdening the core.
+
++++++++++++++++++++++++++++++++++++++++
+Performance Model
++++++++++++++++++++++++++++++++++++++++
+
+daslang has three execution tiers, all planned from day one:
+
+1. **Interpreter** — tree-based, not bytecode. Fast enough for production use even on consoles.
+   Recompiles in seconds, enabling hot reload during development.
+
+2. **AOT (Ahead-of-Time compilation to C++)** — produces code with performance comparable to C++11.
+   Required for platforms that prohibit JIT (consoles, iOS). Always available, always at least as fast
+   as the interpreter.
+
+3. **JIT (LLVM-based)** — produces native machine code at load time. Fastest tier when available.
+   Also enables standalone executable generation.
+
+The **hybrid mode** is the practical sweet spot: each function has a semantic hash. When the script changes
+and the hash still matches, the AOT-compiled version is used. When the hash changes, the interpreter takes over
+until the next AOT build. This means a December 31st hotfix can ship new script without a full rebuild — if the
+semantics didn't change, it stays native; if they did, the interpreter covers it at acceptable speed.
+
+++++++++++++++++++++++++++++++++++
+Type System
+++++++++++++++++++++++++++++++++++
+
+daslang is statically typed — **stricter than C++**. ``a = 0`` means ``a`` is an ``int``, full stop.
+Every expression has a type known at compile time.
+
+Static typing was chosen for two reasons:
+
+- **Performance.** Dynamic typing is fundamentally a runtime cost. Static types let the compiler
+  produce tight, unboxed code without runtime type checks.
+- **Bug prevention.** Restricting the input space eliminates whole classes of errors before the code runs.
+
+**Aggressive type inference** (``auto``) is a deliberate "best of both worlds" choice. You get the safety
+of static typing without the annotation burden of C++. Most intermediate types are irrelevant to the programmer —
+the compiler infers them, and ``static_if`` with ``typeinfo`` provides compile-time reflection when you need
+to branch on types.
+
+++++++++++++++++++++++++++++++++++++++++++++++++++
+Syntax: Gen1 and Gen2
+++++++++++++++++++++++++++++++++++++++++++++++++++
+
+daslang has two syntax modes:
+
+- **Gen1** — Python-like significant whitespace. The original syntax.
+- **Gen2** — C-like curly braces and mandatory parentheses on control flow. The current default.
+
+Gen2 was created entirely from user feedback. Two distinct groups of programmers prefer different styles.
+The intent is to eventually transition fully to gen2 (avoiding the maintenance cost of two parsers),
+but gen1 may persist indefinitely. Gen2 also has a simpler parser, which is a practical advantage.
+
+Even in gen2, some significant whitespace remains — for example, automatic semicolon insertion at end-of-line —
+so gen1's legacy is not entirely gone.
+
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+AI-Driven Syntax Evolution
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Since GitHub Copilot emerged, daslang's syntax has been actively shaped by AI code generation.
+Copilot frequently suggests code that borrows conventions from Python, TypeScript, or C++ — commas instead
+of semicolons in argument lists, ``->`` instead of ``:`` for return types, and so on. Rather than rejecting
+these suggestions, the parser was made flexible enough to accept them.
+
+For example, both of these are valid daslang::
+
+    def foo(a : int; b : float) : bool { return true; }
+    def foo(a : int, b : float) -> bool { return true; }
+
+The first form uses daslang's native separators (``;`` between arguments, ``:`` for return type).
+The second uses conventions AI models pick up from other languages (``,`` and ``->``).
+Both compile to exactly the same thing.
+
+This is a deliberate design choice: if AI writes code that *looks right*, the language should accept it.
+The alternative — fighting the AI — wastes the programmer's time, which violates the core principle
+that iteration speed is king.
+
++++++++++++++++++++++++++++++++++++++++++++++++
+Embedding and Beyond
++++++++++++++++++++++++++++++++++++++++++++++++
+
+daslang was born as an embedded scripting language and that remains its strongest use case.
+But the language is expanding:
+
+- **Modules and packages.** As the community grows, people want to write, share, and discover modules.
+  An NPM-like package manager is in development.
+- **Standalone executables.** LLVM integration is mature enough to produce native binaries.
+  daslang is no longer "just a scripting language" — hence the rename from daScript to daslang.
+- **Releases and distribution.** The build has many prerequisites.
+  Making daslang easy to download and run is an active priority.
+
+++++++++++++++++++++++++++++++++++++++++++++++++++++
+The Rename: daScript → daslang
+++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The original name "daScript" caused people to assume it was a scripting language in the traditional sense —
+interpreted, dynamically typed, slow. It is none of those things. The rename to **daslang** signals
+that this is a full programming language: statically typed, AOT-compiled, with JIT and standalone binary support.
+
+As the `blog post <https://borisbat.github.io/dascf-blog/2023/12/28/daslang-it-is/>`_ put it:
+"It's not a script, so renaming it was a matter of time."
+
+++++++++++++++++++++++++++++++++++++++++++++++++
+Competitive Landscape
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+daslang occupies a unique position among game-adjacent languages:
+
+- **Lua / LuaJIT** — interop overhead kills performance in ECS-heavy architectures.
+- **C# (Mono / IL2CPP)** — has interop, but the interpreter is slow.
+  Unity's Burst compiler makes C# viable for hot paths, but it is not open source and has limitations.
+- **Zig / Odin** — interesting systems languages, but lack daslang's iteration speed
+  (seconds, not minutes, to recompile a production game).
+- **daslang** — the combination of C++ data layout, near-zero interop cost, scripting-speed iteration,
+  and embeddability is unique. No other language in this space offers all four simultaneously.
+
++++++++++++++++++++++++++++++
+Summary
++++++++++++++++++++++++++++++
+
+daslang is a pragmatic language built by game developers for game developers.
+It trades theoretical purity for practical speed — in compilation, in execution, and in the
+daily workflow of the people who use it. Every design decision traces back to a real problem
+encountered in production game development at scale.

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -22,6 +22,7 @@ THE SOFTWARE.
    :numbered:
 
    introduction.rst
+   design_philosophy.rst
    language.rst
    embedding.rst
    tutorials.rst

--- a/install/CLAUDE.md
+++ b/install/CLAUDE.md
@@ -4,6 +4,22 @@
 
 [daslang](https://daslang.io/) (formerly daScript) is a high-performance statically-typed programming language designed for games and real-time applications, standalone or embedded. Many C++ API names still use the old "daScript" spelling.
 
+## What and Why
+
+daslang was created at Gaijin Entertainment to solve a concrete problem: **interop overhead** between scripting languages (Lua/LuaJIT, Squirrel) and C++ was killing frame budgets in their ECS game engine. The key insight is that daslang's data layout matches C++ — no marshaling, no boxing — making script↔C++ calls near-zero cost.
+
+**Core design principles:**
+- **Iteration speed is king** — full production game recompiles in ~5 sec; hot reload built in
+- **Explicit, not implicit** — no hidden conversions, no silent allocations; `options log` shows exactly what the compiler produces
+- **99% safe, not 100%** — eliminate real-world C++ bugs pragmatically, not at Rust-level cost; `unsafe` for the remaining 1%
+- **No data marshaling** — C++-compatible data layout; this is what makes ECS-scale scripting viable
+- **If it gets slow, you can fix it** — manual `delete` to reduce GC pressure, AOT compilation for native speed
+- **Language reflects the domain** — macros (FORTRAN+LISP inspiration) let libraries reshape syntax to match the problem
+
+**Three execution tiers** (all planned from day one): fast tree-based interpreter → AOT to C++ (required for consoles) → JIT via LLVM. Hybrid mode uses semantic hashing: unchanged functions stay AOT, changed ones fall back to the interpreter.
+
+**Audience:** game scripters (largest group — hot reload, fast compile, never rewrite to C++), engine/tools programmers (zero-cost interop, macros), and a growing standalone/ecosystem community (LLVM executables, package manager in development).
+
 ## Running Scripts
 
 - **Run a script:** `bin/daslang path/to/script.das`
@@ -14,8 +30,8 @@
 
 - **Always check the exit code** after running `daslang` — a crash may produce no output at all, looking like a silent success
 - On Windows, check `$LASTEXITCODE` in PowerShell after every run. Exit code `0` = success, non-zero = error
-- Exit code `-1073741819` (`0xC0000005`) = **Access Violation** — indicates a native crash (segfault), usually a dangling pointer or double-free in macro AST manipulation
-- If the program crashes with no error message, the bug is in native code (C++ bindings or smart pointer misuse), not in daScript logic — check exit code first before investigating script errors
+- Exit code `-1073741819` (`0xC0000005`) = **Access Violation** — indicates a native crash (segfault)
+- If the program crashes with no error message, the bug is in native code (C++ bindings or smart pointer misuse) — check exit code first
 
 ## Skill Files (REQUIRED)
 
@@ -25,7 +41,8 @@ Task-specific instructions are in skill files under `skills/`. Read the relevant
 |---|---|
 | `skills/das_formatting.md` | Creating or modifying any `.das` file |
 | `skills/cpp_integration.md` | Embedding daslang in C++ host applications, binding types/functions/enums |
-| `skills/daslib_modules.md` | Using `daslib/` modules (linq, json, regex, functional, match, etc.) |
+| `skills/daslib_modules.md` | Using `daslib/` modules (linq, json, regex, functional, match, etc.), channels |
+| `skills/das_macros.md` | Writing compile-time macros, AST manipulation, qmacro/quote code generation, smart_ptr ownership |
 
 Multiple skill files may apply to a single task. For example, embedding daslang and calling its standard library requires reading both `skills/cpp_integration.md` and `skills/daslib_modules.md`.
 
@@ -34,164 +51,66 @@ Multiple skill files may apply to a single task. For example, embedding daslang 
 All code MUST use gen2 syntax (add `options gen2` at the top of every file). Key rules:
 
 - **Parentheses** on control flow: `if (x > 0)`, `for (i in range(10))`, `while (running)`
-- **Braces** on all blocks — no indentation-based blocks: `def foo() { ... }`, `if (x) { ... }`
+- **Braces** on all blocks: `def foo() { ... }`, `if (x) { ... }`
 - **Construction:** `new Type(field=val)` — NOT `new [[Type() field=val]]`
-- **Enum access:** `EnumName.EnumValue` with dot — NOT `EnumName EnumValue` without
-- **Array literals:** `[1, 2, 3]` (commas, square brackets) — NOT `[[int 1; 2; 3]]`. Note: this creates a **dynamic** `array<int>` — use `fixed_array(1, 2, 3)` for fixed-size arrays
+- **Enum access:** `EnumName.EnumValue` with dot — NOT `EnumName EnumValue`
+- **Array literals:** `[1, 2, 3]` — NOT `[[int 1; 2; 3]]`. Creates `array<int>`; use `fixed_array(1, 2, 3)` for fixed-size
 - **Struct init:** `Foo(a=1, b=2)` — NOT `[[Foo() a=1, b=2]]`
-- **No `[[ ]]` for `new`** — `new` always uses parentheses: `new Foo(x=1)`
-- **Table literals:** `{ "k" => v, "k2" => v2 }` (single braces, commas) — NOT `{{ "k" => v; "k2" => v2 }}`
-- **Named arguments:** `foo([name = value])` with square brackets — NOT `foo(name=value)`
-- **Block arguments:** a block or lambda after `func()` is automatically piped as the last argument — no `<|` needed. Parameterless blocks need no `$`: `defer() { ... }`. Blocks with parameters use `$`: `build_string() $(var writer) { ... }`. Lambdas use `@`: `emplace() @(x : int) { ... }`
+- **Table literals:** `{ "k" => v, "k2" => v2 }` — NOT `{{ "k" => v; "k2" => v2 }}`
+- **Named arguments:** `foo([name = value])` with square brackets
+- **Block arguments:** block/lambda after `func()` pipes as last arg. No `$` for parameterless blocks: `defer() { ... }`. With params: `build_string() $(var writer) { ... }`. Lambdas: `emplace() @(x : int) { ... }`
 - **Lambda:** `@(args) { body }` or `@@(args) { body }` (no-capture)
-- **Generator:** `$() { yield value; }` or `$ { yield value; }` — both are valid gen2 syntax
-- **Tuple `=>` operator:** `a => b` creates a `tuple<auto;auto>` — useful in LINQ, table construction, and ad-hoc pairs
-- **Bitfield variables** need explicit type for `.field` access and printing: `var f : MyBitfield`
-- **Bitfield dot access:** read with `f.flag` (returns bool), write with `f.flag = true/false`
-- **`typeinfo`** gen2 syntax: trait name goes **outside** parentheses — `typeinfo trait_name(type<T>)`, NOT `typeinfo(trait_name type<T>)`. With subtrait: `typeinfo has_method<name>(type<T>)`. With two traits: `typeinfo trait<sub;extra>(type<T>)`
-- **`static_if`:** `static_if (condition) { ... }` — parentheses required in gen2
-- **Type function call:** `take(type<int>, 1, 2)` — NOT `take < int > (1, 2)`. The `type<T>` is passed as a regular argument
+- **Generator:** `$() { yield value; }` or `$ { yield value; }`
+- **Tuple `=>`:** `a => b` creates `tuple<auto;auto>`
+- **`typeinfo`:** `typeinfo trait_name(type<T>)` — trait name outside parens
+- **`static_if`:** `static_if (condition) { ... }` — parentheses required
+- **Type function call:** `take(type<int>, 1, 2)` — NOT `take < int > (1, 2)`
 
 ### Important defaults
 
-- `strict_smart_pointers` is ON by default — smart_ptr variables require `var inscope` declaration
-- `smart_ptr<T>` only works with C++ handled types (not user structs)
+- `strict_smart_pointers` is ON — smart_ptr variables require `var inscope`
 - No implicit type promotion: `int + float` is a compile error — both sides must match
-- No `bool(int)` cast — use `x != 0`
-- `string(x)` works for numeric types; `string(bool)` does NOT work — use string interpolation `"{flag}"`
+- No `bool(int)` cast — use `x != 0`; no `string(bool)` — use `"{flag}"`
 - `int("123")` does NOT work — use `to_int` from `require strings`
-- Hex literals like `0x3F800000` are `uint` by default — use `int(0x3F)` for int
-- Float printing is compact: `3.14` not `3.140000`; uint prints as hex: `0xff` not `255`
+- Hex literals are `uint` by default — use `int(0x3F)` for int
 
-### Memory management
+### Memory and move semantics
 
 - daslang has garbage collection — `delete` is not required in most code
-- `delete` is available for explicit cleanup but requires `unsafe` for heap pointers
-- `var inscope` declares automatic cleanup in a `finally` block
-- Prefer omitting `delete` unless the topic is memory management
-- Struct fields without initializers require defaults or `@safe_when_uninitialized`
-
-### Move semantics (`<-` vs `move`)
-
-- **`<-` operator**: ALWAYS `memcpy(dest, src) + memset(src, 0)` — it is a raw memory operation, NOT smart_ptr-aware. It zeros the source regardless of type.
-- **`move` function**: Proper smart pointer move with reference counting. Use `move(dest, src)` or `move(dest) src` for `smart_ptr<T>` transfers.
-- **`return <- expr`**: Moves value to return slot and zeroes `expr`. If `expr` is a `&` ref parameter, this zeroes the *caller's* variable since they share memory.
-- **Key subtlety**: When a function takes `var x : smart_ptr<T>&` (by reference) and internally calls a function that takes `var x : smart_ptr<T>` (by value/move), the `<-` inside `return` zeroes the `&` ref. Callers MUST capture the return value: `unsafe { expr <- apply_template(expr) $() { ... } }`
-- **Safe pattern**: `unsafe { variable <- function_returning_smart_ptr(variable) $() { ... } }` — captures return value back into the same variable
-
-### AST smart pointer ownership (macros)
-
-- Many AST functions take `smart_ptr<T>` **by value** — this **moves** the pointer from the caller. After the call, the caller's variable is null/zeroed.
-- **`var inscope` + move = double-free crash**: If you declare `var inscope p = make_something()` and pass `p` to a function that moves it, `p` is zeroed by the move. Then `inscope` destroys `p` at scope exit → double-free → Access Violation.
-- **`clone_type(typeExpr)`** — deep-copies a `TypeDeclPtr`. Use when passing a type to a consuming function while keeping the original, or when the source is a `var inscope` variable.
-- **`clone_expression(expr)`** — deep-copies an `ExpressionPtr`. Same ownership rules as `clone_type`.
-- **Safe pattern for `add_structure_field`**: pass temporaries directly — `st |> add_structure_field("name", clone_type(qmacro_type(type<int>)), qmacro($v(val)))` — the `clone_type` result is a temporary safely consumed by the move.
-- **`move_new`**: `field |> move_new <| expr` — idiomatic way to assign a newly created `smart_ptr<T>` into a field. Equivalent to `field <- expr` but does not require `unsafe`. Preferred over `field := null; unsafe { field <- expr }` when setting AST node fields (e.g. `cm.init |> move_new <| qmacro(...)`).
-- **`add_ptr_ref(raw_ptr)`** — wraps a raw pointer (`T?`) into a `smart_ptr<T>` by adding a reference. AST node fields are often raw pointers (e.g. `typeDecl.structType` is `Structure?`, `typeDecl.enumType` is `Enumeration?`), but many API functions expect `smart_ptr<T>`. Use `add_ptr_ref` to bridge: `var inscope st <- add_ptr_ref(pair_type.structType)` gives a `StructurePtr` from a `Structure?` field. Also accepts `smart_ptr<T>` input (adds a ref and returns a new smart_ptr). Always use `var inscope` for the result to manage lifetime.
-- **Rule of thumb**: if a function signature takes `var x : smart_ptr<T>` (not `&`), it **consumes** `x`. Pass a temporary, a clone, or accept that your variable will be null after the call.
-
-### Structure macros — generating types and functions
-
-- **`[structure_macro(name=foo)]`** — annotation on a class inheriting `AstStructureAnnotation`; the `apply` method runs at compile time when a struct has `[foo]`. Use to generate companion types, operators, and functions.
-- **`clone_structure(get_ptr(st))`** — deep-copies a `StructurePtr` for creating modified companion types (e.g., SOA layout where every field becomes `array<FieldType>`)
-- **`get_ptr(st)`** — extracts raw pointer from `smart_ptr<Structure>` for use in `TypeDecl.structType` fields
-- **`compiling_module() |> add_function(fn)`** — registers a concrete function in the current module
-- **`compiling_module() |> add_generic(fn)`** — registers a generic function (instanced per call site)
-- **`compiling_module() |> add_structure(st)`** — registers a generated struct
-- **`compiling_module() |> add_alias(tdef)`** — registers a type alias
-- **`fn.flags |= FunctionFlags.generated`** — marks a function as compiler-generated (suppresses "unused" warnings, enables special error messages)
-- **`ExprFieldFieldFlags.no_promotion`** / **`ExprAtFlags.no_promotion`** — prevent the compiler from promoting field access or index access to a different type; needed in generated AST to preserve exact types
-- **`[tag_function(tag_name)]`** on a function + **`[tag_function_macro(tag="tag_name")]`** on a class — intercepts calls to the tagged function and rewrites them in the `transform` method. Used for compile-time call rewriting (e.g., SOA `operator .` rewrites `soa[i].field` → `soa.field[i]`).
-- **`[for_loop_macro(name=foo)]`** on a class inheriting `AstForLoopMacro` — intercepts `for` loops whose source is a matching type. Override `visitExprFor` to rewrite the loop AST (e.g., SOA for-loop expands `for (it in soa)` into per-field array iteration).
-
-### `qmacro` vs `quote` (code generation)
-
-- **`qmacro(expr)`** — quasi-quote with reification splices (`$v()`, `$e()`, `$c()`, `$t()`, `$i()`, `$f()`, `$a()`, `$b()` etc.). Use when the generated code contains interpolated values.
-- **`qmacro_function("name") $(args) { body }`** — generates an entire `FunctionPtr` with spliced arguments/body. The `$t(typeExpr)` splice in the signature sets parameter/return types from `TypeDeclPtr` variables. Example: `qmacro_function("push") $(var st : $t(stypeT); var arg : $t(argT)) : void { $b(bodyExprs) }` generates a function with dynamic types and spliced body.
-- **`qmacro_expr(${ statement; })`** — generates a statement-level expression (e.g., assignment). The `${ }` block allows semicolons. Example: `qmacro_expr(${ soa_elem.$f(fieldName) := st.$f(fieldName)[soa_idx]; })`.
-- **`quote(expr)`** — plain quote with NO reification. Use when the expression is a simple literal or constant with no splices — e.g. `quote(true)`, `quote(false)`, `quote(0)`.
-- **Rule**: if the expression contains no `$…()` reification operators, prefer `quote()` over `qmacro()` — it is simpler, clearer, and avoids unnecessary reification overhead.
-
-#### Reification operators (inside `qmacro`)
-
-- **`$v(daslangVar)`** — splice the runtime **value** of a variable into the generated code
-- **`$e(exprPtr)`** — splice an `ExpressionPtr` as a sub-expression
-- **`$c(stringVar)`** — splice a `string` as a **call name** (function name). Example: `$c(callName)(arr, val)` generates a call to whatever function name `callName` holds
-- **`$t(typeDeclPtr)`** — splice a `TypeDeclPtr` as a type annotation in signatures or declarations
-- **`$i(stringVar)`** — splice a string as an **identifier** (variable name)
-- **`$f(stringVar)`** — splice a string as a **field name**. Example: `st.$f(fieldName)` becomes `st.x` when `fieldName="x"`
-- **`$a(arrayOfExprPtr)`** — splice an `array<ExpressionPtr>` as function call **arguments**
-- **`$b(arrayOfExprPtr)`** — splice an `array<ExpressionPtr>` as a **block body** (sequence of statements). Build the array with `emplace_new`, then `$b(bodyExprs)` inlines all statements into the function body
+- `var inscope` declares automatic cleanup; struct fields need defaults or `@safe_when_uninitialized`
+- `<-` is memcpy+memset(0), NOT smart_ptr-aware — see `skills/das_macros.md` for smart_ptr patterns
 
 ### Error handling
 
 - `try/recover` — NOT `try/catch` (`recover` is the keyword)
-- `panic("message")` — abort with message
-- `assert(condition)` / `assert(condition, "message")` — debug assertion
-- `verify(condition)` — assertion that remains in release builds
+- `panic("message")`, `assert(condition)`, `verify(condition)` (stays in release)
 
-### Class method modifiers
+### Generic function dispatch
 
-- **`def const`** — const method: `self` is `const`, cannot modify fields. Use for read-only methods.
-- **`def abstract const`** / **`def override const`** — abstract/override const methods in class hierarchies
-- **`def static`** — static method: no implicit `self`; called as `ClassName.method()` or `ClassName\`method()`
-- **`def static const`** — static method with const `self` parameter (used in template structures like `flat_hash_table.das`). The first explicit argument becomes const `self`.
-- **`[class_method]`** annotation (from `daslib/class_boost`) — transforms a `def static` into a proper class method by injecting `self` and wrapping body in `with (self) { ... }`. Const-ness follows `def static const`.
-- Method call syntax: `obj.method()` for value types, `obj->method()` for pointer types, `obj |> method()` pipe syntax
-
-### Generic function dispatch (`_::`, `__::`, unqualified)
-
-- Generic functions are instanced as private functions in the **calling** module
-- **Unqualified call** `foo(x)`: resolves in the module where the generic is **defined** — caller's overloads are NOT visible
-- **`_::foo(x)`**: resolves as if called implicitly in the **current** (calling) module — caller's overloads ARE visible
-- **`__::foo(x)`**: resolves strictly in the **defining** module only — nothing imported
-- This is why `:=` and `delete` emit `_::clone` / `_::finalize` — so user overloads are picked up in generics
-- When writing a library generic that should dispatch to user-provided overloads, use `_::` prefix
-- `mem_archive_save` does NOT use `_::serialize` — so user serialize overloads are invisible; use manual `Archive` + `MemSerializer` pattern instead
+- **`_::foo(x)`**: resolves in the **calling** module — caller's overloads visible. Use in library generics.
+- **Unqualified** `foo(x)`: resolves in the **defining** module — caller's overloads NOT visible.
+- This is why `:=` and `delete` emit `_::clone` / `_::finalize`
 
 ### Table operations
 
-- `table[key]` **inserts** a new default entry if `key` is missing — use only when you want insert-on-access
-- `table[key]` requires `unsafe` by default; add `options unsafe_table_lookup = false` to allow safe `[]` access
-- `table?[key] ?? default_value` — safe lookup with fallback, does NOT insert missing keys
-- `key_exists(table, key)` — check if a key is present without inserting
-- `table |> insert(key, value)` — insert into `table<K;V>`; `table |> insert(key)` — insert into set `table<K>`
-- `table |> erase(key)` — remove a key
-- **Never use two `[]` lookups on the same table in one expression** (e.g. `tab[k1] = tab[k2]`) — tables are unboxed containers and re-hashing on insert can invalidate the first reference
-- `get(table, key) $(pval) { ... }` — block-based lookup; block receives value reference if found
+- `table[key]` **inserts** a default entry if missing — use `table?[key] ?? default` for safe lookup
+- `key_exists(table, key)` — check without inserting
+- `table |> insert(key, value)` / `table |> erase(key)`
+- **Never use two `[]` lookups on the same table in one expression** — re-hashing can invalidate references
 
 ### Common gotchas
 
-- Lambda params can shadow function params — use distinct names (e.g., `$(lhs, rhs)` not `$(a, b)` when `a` is already in scope)
-- `struct Foo { ... }` requires braces in gen2 — empty struct is `struct Foo {}`
-- String builder: `build_string() $(var writer) { write(writer, "text") }` — requires `unsafe` or `options persistent_heap` if returned
-- `options persistent_heap` — needed when returning strings built with `build_string`
-- Tuple field access uses underscore prefix: `t._0`, `t._1`, `t._2`
-- Annotations: `[export]` for entry points, `[private]` for private functions, `[test]` for test functions
-- `options no_aot` — disable ahead-of-time compilation
-- `options rtti` — enable runtime type information (needed for some daslib features)
-- `require` uses forward slash paths: `require daslib/linq` — NOT `require daslib\linq`
-- `require foo public` — re-exports `foo` so that any module requiring the current module also sees `foo`'s symbols transitively. Example: `regex.das` has `require strings public`, so `require daslib/regex` automatically makes `slice`, `starts_with`, etc. visible without a separate `require strings`
-- `<-` is memcpy+memset(0), NOT a smart_ptr-aware move — see "Move semantics" section above
-- When calling `apply_template`, always capture the return value: `unsafe { expr <- apply_template(expr) $() { ... } }` — discarding the return loses the expression data
-- Iterator comprehension: `[iterator for(x in src); expression]` — semicolon separates generator from body
-- `to_array` (from `daslib/builtin`) converts any iterator to an array
-- Lambdas CAN be stored in arrays: `var fns : array<lambda<(x:int):int>>` + `fns |> emplace() @(x : int) : int { return x * 2; }` — move semantics, not copy
-- Blocks CANNOT be stored in containers, returned from functions, or captured — use lambdas or function pointers for those use cases
-- `match`, `multi_match`, `static_match` macros (from `daslib/match.das`) handle side effects automatically — do NOT add `[sideeffects]` annotations to functions that only use match
-- `[export] def main()` returns `void` — do NOT `return true` or return other values from main
-- **`push` vs `emplace` vs `push_clone`** for arrays: `push(arr, val)` copies `val` into the array (fails for non-copyable types like `array<int>`); `emplace(arr, val)` **moves** `val` into the array (source is zeroed/destroyed after); `push_clone(arr, val)` **clones** `val` into the array (works for any type, preserves source). When generating code that operates on user structs with potentially non-copyable fields, prefer `push_clone` (preserves source) or `emplace` (when source consumption is intentional).
-- **Non-copyable types**: `array<T>`, `table<K;V>`, lambdas, and any struct containing them cannot be copied with `=` or `push`. Use `:=` (clone-assign), `push_clone`, or `<-` (move) instead. The compiler error is clear: "can't copy non-copyable type"
-
-### Channels and cross-context communication
-
-- `with_channel(N) $(ch) { ... }` — creates a channel expecting `N` notify calls before `for_each_clone` unblocks
-- **`notify` vs `notify_and_release`**: when a lambda captures a channel, the reference count is incremented; `notify_and_release` decrements the entry count AND releases that extra reference, setting the variable to `null`. When passing a channel as a plain argument (e.g. via `invoke_in_context`), no lambda capture occurs — no extra reference is added — so use plain `notify`
-- `notify_and_release` sets the channel/status variable to `null` after release
-- `push_clone(ch, value)` — push a clone of `value` into the channel
-- `for_each_clone(ch) $(val : T#) { ... }` — drain channel; data arrives as temporary type `T#`
-- `invoke_in_context(context, "func", ch)` — can pass `Channel?` directly to a child context
-- Child scripts that use channel operations need `require daslib/jobque_boost`; compile with `compile_file` + `make_file_access("")` so the child can resolve daslib modules from disk
+- Lambda params can shadow function params — use distinct names
+- String builder requires `unsafe` or `options persistent_heap` if returned
+- Tuple field access: `t._0`, `t._1`, `t._2`
+- Annotations: `[export]`, `[private]`, `[test]`; `options no_aot`, `options rtti`
+- `require` uses forward slash: `require daslib/linq` — NOT backslash
+- `require foo public` — re-exports `foo` transitively
+- `[export] def main()` returns `void` — do NOT return values from main
+- `push` copies (fails for non-copyable types), `emplace` moves (zeros source), `push_clone` clones (preserves source)
+- Non-copyable types (`array<T>`, `table<K;V>`, lambdas): use `:=`, `push_clone`, or `<-`
+- Blocks cannot be stored/returned/captured — use lambdas or function pointers
+- Class methods: `def const`, `def abstract const`, `def static`; call syntax `obj.method()`, `obj->method()`, `obj |> method()`
 
 ## SDK Directory Layout
 
@@ -204,8 +123,8 @@ All code MUST use gen2 syntax (add `options gen2` at the top of every file). Key
 
 ## Keywords Reference
 
-`aka` — variable name alias (`var a aka alpha = 42`, `for (x aka element in arr)`)
-`inscope` — declares variable owns smart_ptr lifetime (`var inscope p = ...`)
-`is type<T>` — compile-time type check (`a is type<int>` returns bool)
-`expect` — suppress specific compilation errors (`expect 30507`)
+`aka` — variable name alias (`var a aka alpha = 42`)
+`inscope` — declares variable owns smart_ptr lifetime
+`is type<T>` — compile-time type check
+`expect` — suppress specific compilation errors
 `template` — generic type constraint in function signatures

--- a/install/skills/das_macros.md
+++ b/install/skills/das_macros.md
@@ -1,0 +1,55 @@
+# Macro & AST Programming
+
+Read this skill file before writing compile-time macros, AST manipulation code, structure macros, qmacro/quote code generation, or any code that uses `smart_ptr<T>` ownership patterns (e.g., `TypeDeclPtr`, `ExpressionPtr`, `FunctionPtr`, `StructurePtr`).
+
+## Move semantics for smart pointers (`<-` vs `move`)
+
+- **`<-` operator**: ALWAYS `memcpy(dest, src) + memset(src, 0)` — it is a raw memory operation, NOT smart_ptr-aware. It zeros the source regardless of type.
+- **`move` function**: Bound via C++ `builtin_smart_ptr_move*` family in `module_builtin_runtime.cpp` — proper smart pointer move with reference counting. Use `move(dest, src)` or `move(dest) src` for `smart_ptr<T>` transfers.
+- **`return <- expr`**: Moves value to return slot and zeroes `expr`. If `expr` is a `&` ref parameter, this zeroes the *caller's* variable since they share memory.
+- **Key subtlety**: When a function takes `var x : smart_ptr<T>&` (by reference) and internally calls a function that takes `var x : smart_ptr<T>` (by value/move), the `<-` inside `return` zeroes the `&` ref. Callers MUST capture the return value: `unsafe { expr <- apply_template(expr) $() { ... } }`
+- **Safe pattern**: `unsafe { variable <- function_returning_smart_ptr(variable) $() { ... } }` — captures return value back into the same variable
+
+## AST smart pointer ownership
+
+- Many AST functions take `smart_ptr<T>` **by value** — this **moves** the pointer from the caller. After the call, the caller's variable is null/zeroed.
+- **`var inscope` + move = double-free crash**: If you declare `var inscope p = make_something()` and pass `p` to a function that moves it, `p` is zeroed by the move. Then `inscope` destroys `p` at scope exit → double-free → Access Violation.
+- **`clone_type(typeExpr)`** — deep-copies a `TypeDeclPtr`. Use when passing a type to a consuming function while keeping the original, or when the source is a `var inscope` variable.
+- **`clone_expression(expr)`** — deep-copies an `ExpressionPtr`. Same ownership rules as `clone_type`.
+- **Safe pattern for `add_structure_field`**: pass temporaries directly — `st |> add_structure_field("name", clone_type(qmacro_type(type<int>)), qmacro($v(val)))` — the `clone_type` result is a temporary safely consumed by the move.
+- **`move_new`**: `field |> move_new <| expr` — idiomatic way to assign a newly created `smart_ptr<T>` into a field. Equivalent to `field <- expr` but does not require `unsafe`. Preferred over `field := null; unsafe { field <- expr }` when setting AST node fields (e.g. `cm.init |> move_new <| qmacro(...)`).
+- **`add_ptr_ref(raw_ptr)`** — wraps a raw pointer (`T?`) into a `smart_ptr<T>` by adding a reference. AST node fields are often raw pointers (e.g. `typeDecl.structType` is `Structure?`, `typeDecl.enumType` is `Enumeration?`), but many API functions expect `smart_ptr<T>`. Use `add_ptr_ref` to bridge: `var inscope st <- add_ptr_ref(pair_type.structType)` gives a `StructurePtr` from a `Structure?` field. Also accepts `smart_ptr<T>` input (adds a ref and returns a new smart_ptr). Always use `var inscope` for the result to manage lifetime.
+- **Rule of thumb**: if a function signature takes `var x : smart_ptr<T>` (not `&`), it **consumes** `x`. Pass a temporary, a clone, or accept that your variable will be null after the call.
+
+## Structure macros — generating types and functions
+
+- **`[structure_macro(name=foo)]`** — annotation on a class inheriting `AstStructureAnnotation`; the `apply` method runs at compile time when a struct has `[foo]`. Use to generate companion types, operators, and functions.
+- **`clone_structure(get_ptr(st))`** — deep-copies a `StructurePtr` for creating modified companion types (e.g., SOA layout where every field becomes `array<FieldType>`)
+- **`get_ptr(st)`** — extracts raw pointer from `smart_ptr<Structure>` for use in `TypeDecl.structType` fields
+- **`compiling_module() |> add_function(fn)`** — registers a concrete function in the current module
+- **`compiling_module() |> add_generic(fn)`** — registers a generic function (instanced per call site)
+- **`compiling_module() |> add_structure(st)`** — registers a generated struct
+- **`compiling_module() |> add_alias(tdef)`** — registers a type alias
+- **`fn.flags |= FunctionFlags.generated`** — marks a function as compiler-generated (suppresses "unused" warnings, enables special error messages)
+- **`ExprFieldFieldFlags.no_promotion`** / **`ExprAtFlags.no_promotion`** — prevent the compiler from promoting field access or index access to a different type; needed in generated AST to preserve exact types
+- **`[tag_function(tag_name)]`** on a function + **`[tag_function_macro(tag="tag_name")]`** on a class — intercepts calls to the tagged function and rewrites them in the `transform` method. Used for compile-time call rewriting (e.g., SOA `operator .` rewrites `soa[i].field` → `soa.field[i]`).
+- **`[for_loop_macro(name=foo)]`** on a class inheriting `AstForLoopMacro` — intercepts `for` loops whose source is a matching type. Override `visitExprFor` to rewrite the loop AST (e.g., SOA for-loop expands `for (it in soa)` into per-field array iteration).
+
+## `qmacro` vs `quote` (code generation)
+
+- **`qmacro(expr)`** — quasi-quote with reification splices (`$v()`, `$e()`, `$c()`, `$t()`, `$i()`, `$f()`, `$a()`, `$b()` etc.). Use when the generated code contains interpolated values.
+- **`qmacro_function("name") $(args) { body }`** — generates an entire `FunctionPtr` with spliced arguments/body. The `$t(typeExpr)` splice in the signature sets parameter/return types from `TypeDeclPtr` variables.
+- **`qmacro_expr(${ statement; })`** — generates a statement-level expression (e.g., assignment). The `${ }` block allows semicolons.
+- **`quote(expr)`** — plain quote with NO reification. Use when the expression is a simple literal or constant with no splices — e.g. `quote(true)`, `quote(false)`, `quote(0)`.
+- **Rule**: if the expression contains no `$…()` reification operators, prefer `quote()` over `qmacro()`.
+
+### Reification operators (inside `qmacro`)
+
+- **`$v(daslangVar)`** — splice the runtime **value** of a variable into the generated code
+- **`$e(exprPtr)`** — splice an `ExpressionPtr` as a sub-expression
+- **`$c(stringVar)`** — splice a `string` as a **call name** (function name). Example: `$c(callName)(arr, val)` generates a call to whatever function name `callName` holds
+- **`$t(typeDeclPtr)`** — splice a `TypeDeclPtr` as a type annotation in signatures or declarations
+- **`$i(stringVar)`** — splice a string as an **identifier** (variable name)
+- **`$f(stringVar)`** — splice a string as a **field name**. Example: `st.$f(fieldName)` becomes `st.x` when `fieldName="x"`
+- **`$a(arrayOfExprPtr)`** — splice an `array<ExpressionPtr>` as function call **arguments**
+- **`$b(arrayOfExprPtr)`** — splice an `array<ExpressionPtr>` as a **block body** (sequence of statements). Build the array with `emplace_new`, then `$b(bodyExprs)` inlines all statements into the function body

--- a/skills/das_macros.md
+++ b/skills/das_macros.md
@@ -1,0 +1,55 @@
+# Macro & AST Programming
+
+Read this skill file before writing compile-time macros, AST manipulation code, structure macros, qmacro/quote code generation, or any code that uses `smart_ptr<T>` ownership patterns (e.g., `TypeDeclPtr`, `ExpressionPtr`, `FunctionPtr`, `StructurePtr`).
+
+## Move semantics for smart pointers (`<-` vs `move`)
+
+- **`<-` operator**: ALWAYS `memcpy(dest, src) + memset(src, 0)` — it is a raw memory operation, NOT smart_ptr-aware. It zeros the source regardless of type.
+- **`move` function**: Bound via C++ `builtin_smart_ptr_move*` family in `module_builtin_runtime.cpp` — proper smart pointer move with reference counting. Use `move(dest, src)` or `move(dest) src` for `smart_ptr<T>` transfers.
+- **`return <- expr`**: Moves value to return slot and zeroes `expr`. If `expr` is a `&` ref parameter, this zeroes the *caller's* variable since they share memory.
+- **Key subtlety**: When a function takes `var x : smart_ptr<T>&` (by reference) and internally calls a function that takes `var x : smart_ptr<T>` (by value/move), the `<-` inside `return` zeroes the `&` ref. Callers MUST capture the return value: `unsafe { expr <- apply_template(expr) $() { ... } }`
+- **Safe pattern**: `unsafe { variable <- function_returning_smart_ptr(variable) $() { ... } }` — captures return value back into the same variable
+
+## AST smart pointer ownership
+
+- Many AST functions take `smart_ptr<T>` **by value** — this **moves** the pointer from the caller. After the call, the caller's variable is null/zeroed.
+- **`var inscope` + move = double-free crash**: If you declare `var inscope p = make_something()` and pass `p` to a function that moves it, `p` is zeroed by the move. Then `inscope` destroys `p` at scope exit → double-free → Access Violation.
+- **`clone_type(typeExpr)`** — deep-copies a `TypeDeclPtr`. Use when passing a type to a consuming function while keeping the original, or when the source is a `var inscope` variable.
+- **`clone_expression(expr)`** — deep-copies an `ExpressionPtr`. Same ownership rules as `clone_type`.
+- **Safe pattern for `add_structure_field`**: pass temporaries directly — `st |> add_structure_field("name", clone_type(qmacro_type(type<int>)), qmacro($v(val)))` — the `clone_type` result is a temporary safely consumed by the move.
+- **`move_new`**: `field |> move_new <| expr` — idiomatic way to assign a newly created `smart_ptr<T>` into a field. Equivalent to `field <- expr` but does not require `unsafe`. Preferred over `field := null; unsafe { field <- expr }` when setting AST node fields (e.g. `cm.init |> move_new <| qmacro(...)`).
+- **`add_ptr_ref(raw_ptr)`** — wraps a raw pointer (`T?`) into a `smart_ptr<T>` by adding a reference. AST node fields are often raw pointers (e.g. `typeDecl.structType` is `Structure?`, `typeDecl.enumType` is `Enumeration?`), but many API functions expect `smart_ptr<T>`. Use `add_ptr_ref` to bridge: `var inscope st <- add_ptr_ref(pair_type.structType)` gives a `StructurePtr` from a `Structure?` field. Also accepts `smart_ptr<T>` input (adds a ref and returns a new smart_ptr). Always use `var inscope` for the result to manage lifetime.
+- **Rule of thumb**: if a function signature takes `var x : smart_ptr<T>` (not `&`), it **consumes** `x`. Pass a temporary, a clone, or accept that your variable will be null after the call.
+
+## Structure macros — generating types and functions
+
+- **`[structure_macro(name=foo)]`** — annotation on a class inheriting `AstStructureAnnotation`; the `apply` method runs at compile time when a struct has `[foo]`. Use to generate companion types, operators, and functions.
+- **`clone_structure(get_ptr(st))`** — deep-copies a `StructurePtr` for creating modified companion types (e.g., SOA layout where every field becomes `array<FieldType>`)
+- **`get_ptr(st)`** — extracts raw pointer from `smart_ptr<Structure>` for use in `TypeDecl.structType` fields
+- **`compiling_module() |> add_function(fn)`** — registers a concrete function in the current module
+- **`compiling_module() |> add_generic(fn)`** — registers a generic function (instanced per call site)
+- **`compiling_module() |> add_structure(st)`** — registers a generated struct
+- **`compiling_module() |> add_alias(tdef)`** — registers a type alias
+- **`fn.flags |= FunctionFlags.generated`** — marks a function as compiler-generated (suppresses "unused" warnings, enables special error messages)
+- **`ExprFieldFieldFlags.no_promotion`** / **`ExprAtFlags.no_promotion`** — prevent the compiler from promoting field access or index access to a different type; needed in generated AST to preserve exact types
+- **`[tag_function(tag_name)]`** on a function + **`[tag_function_macro(tag="tag_name")]`** on a class — intercepts calls to the tagged function and rewrites them in the `transform` method. Used for compile-time call rewriting (e.g., SOA `operator .` rewrites `soa[i].field` → `soa.field[i]`).
+- **`[for_loop_macro(name=foo)]`** on a class inheriting `AstForLoopMacro` — intercepts `for` loops whose source is a matching type. Override `visitExprFor` to rewrite the loop AST (e.g., SOA for-loop expands `for (it in soa)` into per-field array iteration).
+
+## `qmacro` vs `quote` (code generation)
+
+- **`qmacro(expr)`** — quasi-quote with reification splices (`$v()`, `$e()`, `$c()`, `$t()`, `$i()`, `$f()`, `$a()`, `$b()` etc.). Use when the generated code contains interpolated values.
+- **`qmacro_function("name") $(args) { body }`** — generates an entire `FunctionPtr` with spliced arguments/body. The `$t(typeExpr)` splice in the signature sets parameter/return types from `TypeDeclPtr` variables.
+- **`qmacro_expr(${ statement; })`** — generates a statement-level expression (e.g., assignment). The `${ }` block allows semicolons.
+- **`quote(expr)`** — plain quote with NO reification. Use when the expression is a simple literal or constant with no splices — e.g. `quote(true)`, `quote(false)`, `quote(0)`.
+- **Rule**: if the expression contains no `$…()` reification operators, prefer `quote()` over `qmacro()`.
+
+### Reification operators (inside `qmacro`)
+
+- **`$v(daslangVar)`** — splice the runtime **value** of a variable into the generated code
+- **`$e(exprPtr)`** — splice an `ExpressionPtr` as a sub-expression
+- **`$c(stringVar)`** — splice a `string` as a **call name** (function name). Example: `$c(callName)(arr, val)` generates a call to whatever function name `callName` holds
+- **`$t(typeDeclPtr)`** — splice a `TypeDeclPtr` as a type annotation in signatures or declarations
+- **`$i(stringVar)`** — splice a string as an **identifier** (variable name)
+- **`$f(stringVar)`** — splice a string as a **field name**. Example: `st.$f(fieldName)` becomes `st.x` when `fieldName="x"`
+- **`$a(arrayOfExprPtr)`** — splice an `array<ExpressionPtr>` as function call **arguments**
+- **`$b(arrayOfExprPtr)`** — splice an `array<ExpressionPtr>` as a **block body** (sequence of statements). Build the array with `emplace_new`, then `$b(bodyExprs)` inlines all statements into the function body

--- a/skills/daslib_modules.md
+++ b/skills/daslib_modules.md
@@ -75,3 +75,13 @@ When generating per-field operations on user structs, fields may be non-copyable
 
 - **`add_function`** — registers a concrete, fully-typed function. Used when all types are known at macro expansion time.
 - **`add_generic`** — registers a generic function template that gets instanced at each call site. Use when the function needs to participate in overload resolution or when type inference is needed (e.g., `push` may need to resolve to the correct clone/copy overload depending on field types).
+
+## Channels and cross-context communication
+
+- `with_channel(N) $(ch) { ... }` — creates a channel expecting `N` notify calls before `for_each_clone` unblocks
+- **`notify` vs `notify_and_release`**: when a lambda captures a channel, the reference count is incremented; `notify_and_release` decrements the entry count AND releases that extra reference, setting the variable to `null`. When passing a channel as a plain argument (e.g. via `invoke_in_context`), no lambda capture occurs — no extra reference is added — so use plain `notify`
+- `notify_and_release` sets the channel/status variable to `null` after release
+- `push_clone(ch, value)` — push a clone of `value` into the channel
+- `for_each_clone(ch) $(val : T#) { ... }` — drain channel; data arrives as temporary type `T#`
+- `invoke_in_context(context, "func", ch)` — can pass `Channel?` directly to a child context
+- Child scripts that use channel operations need `require daslib/jobque_boost`; compile with `compile_file` + `make_file_access("")` so the child can resolve daslib modules from disk


### PR DESCRIPTION
Adds a design philosophy RST document and refactors AI instruction files with progressive disclosure via skill files. New: design_philosophy.rst (origins, audience, 6 core principles, performance model, type system, syntax history, rename, competitive landscape), skills/das_macros.md, install/skills/das_macros.md. Updated: CLAUDE.md, copilot-instructions.md, install/CLAUDE.md with What and Why section; daslib_modules.md with channels section; doc toctree.