### PR TITLE
Fix stale .shared_module cleanup and LNK4217 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,6 +396,18 @@ FOREACH(_module ${_modules})
     INCLUDE(modules/${_module}/CMakeLists.txt OPTIONAL)
 ENDFOREACH()
 
+# Clean stale .shared_module files. When a module is disabled, its .shared_module
+# from a previous build may remain and cause crashes at startup (the dynamic module
+# loader tries to load them even though the module code is no longer linked).
+FILE(GLOB_RECURSE _all_shared_modules "${PROJECT_SOURCE_DIR}/modules/*.shared_module")
+FOREACH(_sm ${_all_shared_modules})
+    GET_FILENAME_COMPONENT(_sm_name "${_sm}" NAME_WE)
+    IF(NOT TARGET ${_sm_name})
+        MESSAGE(STATUS "Removing stale ${_sm}")
+        FILE(REMOVE "${_sm}")
+    ENDIF()
+ENDFOREACH()
+
 FOREACH(_example ${DAS_ALL_EXAMPLES})
     MESSAGE("adding to ${_example} ${DAS_MODULES_LIBS}")
     TARGET_LINK_LIBRARIES(${_example} ${DAS_MODULES_LIBS})

--- a/include/daScript/daScriptModule.h
+++ b/include/daScript/daScriptModule.h
@@ -8,7 +8,7 @@ namespace das
 };
 
 #define NEED_MODULE(ClassName) \
-    extern DAS_IMPORT_DLL das::Module * register_##ClassName (); \
+    extern DAS_API das::Module * register_##ClassName (); \
     *das::ModuleKarma += unsigned(intptr_t(register_##ClassName()));
 
 #define NEED_ALL_DEFAULT_MODULES \


### PR DESCRIPTION
## Problem

Two build system issues:

1. **Crash on startup after disabling modules**: When modules are disabled via cmake options (e.g. \DAS_AUDIO_DISABLED=true\), their \.shared_module\ files from a previous build remain on disk. The dynamic module loader loads them at startup, causing heap corruption crashes.

2. **LNK4217 linker warnings**: \NEED_MODULE\ macro in \daScriptModule.h\ unconditionally uses \DAS_IMPORT_DLL\ (\__declspec(dllimport)\). When \daScriptC.cpp\ uses it inside \libDaScriptDyn\, the linker warns about importing symbols defined in the same DLL.

## Fix

- **CMakeLists.txt**: After processing all module subdirectories, glob all \.shared_module\ files and remove any whose name doesn't match an active build target. Runs at configure time with a status message.

- **daScriptModule.h**: Change \NEED_MODULE\ to declare \egister_*\ functions with \DAS_API\ instead of \DAS_IMPORT_DLL\. \DAS_API\ resolves to \dllexport\ inside the DLL and \dllimport\ from the exe  correct in both contexts.