### PR TITLE
Compiler and runtime bugfixes

### DIFF
--- a/include/daScript/ast/ast_infer_type.h
+++ b/include/daScript/ast/ast_infer_type.h
@@ -44,6 +44,7 @@ namespace das {
         vector<size_t> assumeStack;
         vector<size_t> assumeTypeStack;
         vector<bool> inFinally;
+        vector<Function *> inInfer;
         smart_ptr<ExprReturn> oneReturn;
         int32_t returnCount = 0;
         bool canFoldResult = true;

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -387,6 +387,8 @@ namespace das {
     }
 
     uint64_t Structure::getSizeOf64() const {
+        if ( circularGuard ) return 1;
+        circularGuard = true;
         uint64_t size = 0;
         const Structure * cppLayoutParent = nullptr;
         for ( const auto & fd : fields ) {
@@ -404,16 +406,20 @@ namespace das {
             size = (size + al) & ~al;
             size += fd.type->getSizeOf64();
         }
+        circularGuard = false;
         int al = getAlignOf() - 1;
         size = (size + al) & ~al;
         return size;
     }
 
     int Structure::getAlignOf() const {
+        if ( circularGuard ) return 1;
+        circularGuard = true;
         int align = 1;
         for ( const auto & fd : fields ) {
             align = das::max ( fd.type->getAlignOf(), align );
         }
+        circularGuard = false;
         return align;
     }
 

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -1502,7 +1502,7 @@ namespace das {
                                                       expr->at, CompilationError::invalid_argument_count);
                                             }
                                         } else {
-                                            error("'" + fnAddr->target + "' expecting class_ptr or cast<auto> class_ptr", "", "",
+                                            error("expecting class_ptr or cast<auto> class_ptr", "", "",
                                                   expr->at, CompilationError::invalid_argument_count);
                                         }
                                     } else {
@@ -4799,7 +4799,7 @@ namespace das {
                 varT->ref = false;
                 TypeDecl::applyAutoContracts(varT, var->type);
                 if (!relaxedPointerConst) { // var a = Foo? const -> var a : Foo const? = Foo? const
-                    if (varT->isPointer() && !varT->constant && var->init->type->constant) {
+                    if (varT->isPointer() && varT->firstType && !varT->constant && var->init->type->constant) {
                         varT->firstType->constant = true;
                     }
                 }
@@ -5020,7 +5020,7 @@ namespace das {
                         return Visitor::visit(expr);
                     }
                 } else if (func && func->isClassMethod && !func->isStaticClassMethod) { // if its a class method with 'self'
-                    auto selfStruct = func->arguments[0]->type->structType;
+                    auto selfStruct = func->arguments.size() > 0 ? func->arguments[0]->type->structType : nullptr;
                     if (!selfStruct) {
                         reportMissing(expr, nonNamedTypes, "no matching functions or generics: ", true);
                         return Visitor::visit(expr);

--- a/src/ast/ast_infer_type_function.cpp
+++ b/src/ast/ast_infer_type_function.cpp
@@ -1087,6 +1087,10 @@ namespace das {
                 error("recursive call in argument initializer is not allowed", "", "", expr->at);
                 return nullptr;
             }
+            if ( find(inInfer.begin(), inInfer.end(), funcC) != inInfer.end() ) {
+                error("recursive call in function is not allowed", "", "", expr->at);
+                return nullptr;
+            }
             if (funcC->firstArgReturnType) {
                 TypeDecl::clone(expr->type, expr->arguments[0]->type);
                 expr->type->ref = false;
@@ -1135,7 +1139,9 @@ namespace das {
                 auto newArg = funcC->arguments[iT]->init->clone();
                 if (!newArg->type) {
                     // recursive resolve???
+                    inInfer.push_back(funcC);
                     newArg = newArg->visit(*this);
+                    inInfer.pop_back();
                 }
                 if (newArg->type && newArg->type->baseType == Type::fakeLineInfo) {
                     newArg->at = expr->at;


### PR DESCRIPTION
## Fixes

### Compiler: circular recursion guard in Structure layout
- \getSizeOf64()\ and \getAlignOf()\ now use \circularGuard\ to prevent infinite recursion on malformed circular struct definitions

### Compiler: recursive call detection during inference
- Added \inInfer\ stack to detect and report recursive calls during function argument default-value inference, preventing infinite loops

### Compiler: null/bounds safety in type inference
- Check \irstType\ is non-null before accessing \irstType->constant\ on pointer types during auto-contract application  
- Check \rguments.size() > 0\ before accessing \rguments[0]\ on class methods with no self argument
- Cleaned up error message in class_ptr validation (removed redundant function name)

### Runtime: fmt buffer overflow protection
- Replaced unbounded \mt::format_to(buf, ...)\ with \mt::format_to_n(buf, sizeof(buf)-1, ...)\ in all 4 call sites
- Added overflow detection  reports as daScript runtime error when output exceeds buffer size