### PR TITLE
Fix recursive invoke and unresolved array comprehension type

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -1481,21 +1481,26 @@ namespace das {
                                         }
                                         if (fnAddr) {
                                             if (fnAddr->func) {
-                                                int fnArgSize = int(fnAddr->func->arguments.size());
-                                                int fromFnArgSize = int(expr->arguments.size() - 1);
-                                                bool allHaveInit = true;
-                                                for (int ai = fromFnArgSize; ai < fnArgSize; ++ai) {
-                                                    if (!fnAddr->func->arguments[ai]->init) {
-                                                        allHaveInit = false;
-                                                        break;
-                                                    }
-                                                }
-                                                if (allHaveInit) {
+                                                if ( inArgumentInit && fnAddr->func==func ) {
+                                                    error("recursive call in argument initializer", "", "",
+                                                        expr->at, CompilationError::invalid_argument_count);
+                                                } else {
+                                                    int fnArgSize = int(fnAddr->func->arguments.size());
+                                                    int fromFnArgSize = int(expr->arguments.size() - 1);
+                                                    bool allHaveInit = true;
                                                     for (int ai = fromFnArgSize; ai < fnArgSize; ++ai) {
-                                                        expr->arguments.emplace_back(fnAddr->func->arguments[ai]->init->clone());
+                                                        if (!fnAddr->func->arguments[ai]->init) {
+                                                            allHaveInit = false;
+                                                            break;
+                                                        }
                                                     }
-                                                    reportAstChanged();
-                                                    return Visitor::visit(expr);
+                                                    if (allHaveInit) {
+                                                        for (int ai = fromFnArgSize; ai < fnArgSize; ++ai) {
+                                                            expr->arguments.emplace_back(fnAddr->func->arguments[ai]->init->clone());
+                                                        }
+                                                        reportAstChanged();
+                                                        return Visitor::visit(expr);
+                                                    }
                                                 }
                                             } else {
                                                 error("'" + fnAddr->target + "' is not fully resolved yet", "", "",

--- a/src/ast/ast_infer_type_make.cpp
+++ b/src/ast/ast_infer_type_make.cpp
@@ -1393,6 +1393,10 @@ namespace das {
         }
         expr->type = resT;
         verifyType(expr->type);
+        if ( resT->isAutoOrAlias() ) {
+            error("array element type is not resolved", "", "",
+                  expr->at, CompilationError::invalid_type);
+        }
         return Visitor::visit(expr);
     }
     void InferTypes::preVisitArrayComprehensionSubexpr(ExprArrayComprehension *expr, Expression *subexpr) {


### PR DESCRIPTION
Fixes the remainder of #2157

## Changes

### Recursive invoke in argument initializer
When an \invoke\ expression references the function being inferred (self-referencing default argument), the compiler could loop infinitely. Added a guard that detects \nAddr->func == func\ while \inArgumentInit\ is true and reports a compilation error instead.

### Unresolved array comprehension element type  
Array comprehension could produce an \uto\/alias result type that was never caught, leading to downstream crashes. Added an explicit check after \erifyType\  if \esT->isAutoOrAlias()\, emit \invalid_type\ error.