### PR TITLE
fix: fuzzing bugs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,10 @@ See `doc/source/reference/design_philosophy.rst` for the full design philosophy 
 ## GitHub Operations
 
 - **Use `gh` CLI** for all GitHub operations (creating PRs, listing issues, etc.) — NOT GitKraken MCP tools
+- **PowerShell escaping:** Backticks (`` ` ``) are PowerShell's escape character. Any `gh` command with backticks in arguments (e.g., PR/issue bodies with markdown code spans) will be corrupted. **Always use `gh api` with `-f` flag or `--body-file`** instead of `gh pr create --body` / `gh pr edit --body` when the text contains backticks:
+  - Write body to a temp `.md` file, then: `gh api repos/OWNER/REPO/pulls/N -X PATCH -f body="$(Get-Content -Raw body.md)"`
+  - Or: `gh pr create --body-file body.md`
+- **`gh pr edit` may fail** with `GraphQL: Projects (classic) is being deprecated` error — use `gh api` REST endpoint as workaround
 
 ## Skill Files (REQUIRED)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,10 @@ See `doc/source/reference/design_philosophy.rst` for the full design philosophy 
 ## GitHub Operations
 
 - **Use `gh` CLI** for all GitHub operations (creating PRs, listing issues, etc.) — NOT GitKraken MCP tools
+- **PowerShell escaping:** Backticks (`` ` ``) are PowerShell's escape character. Any `gh` command with backticks in arguments (e.g., PR/issue bodies with markdown code spans) will be corrupted. **Always use `gh api` with `-f` flag or `--body-file`** instead of `gh pr create --body` / `gh pr edit --body` when the text contains backticks:
+  - Write body to a temp `.md` file, then: `gh api repos/OWNER/REPO/pulls/N -X PATCH -f body="$(Get-Content -Raw body.md)"`
+  - Or: `gh pr create --body-file body.md`
+- **`gh pr edit` may fail** with `GraphQL: Projects (classic) is being deprecated` error — use `gh api` REST endpoint as workaround
 
 ## Skill Files (REQUIRED)
 

--- a/include/daScript/ast/ast_infer_type.h
+++ b/include/daScript/ast/ast_infer_type.h
@@ -474,7 +474,7 @@ namespace das {
 
         virtual ExpressionPtr visit(ExprAssume *expr) override;
         // ExprWith
-        virtual void preVisit(ExprWith *expr) override;
+        virtual void preVisitWithBody(ExprWith *expr, Expression *body) override;
         virtual ExpressionPtr visit(ExprWith *expr) override;
         // ExprWhile
         virtual void preVisit(ExprWhile *expr) override;

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -407,7 +407,7 @@ namespace das {
                 varT->ref = false;
                 TypeDecl::applyAutoContracts(varT, var->type);
                 if (!relaxedPointerConst) { // var a = Foo? const -> var a : Foo const? = Foo? const
-                    if (varT->isPointer() && !varT->constant && var->init->type->constant) {
+                    if (varT->isPointer() && !varT->constant && var->init->type->constant && varT->firstType) {
                         varT->firstType->constant = true;
                     }
                 }
@@ -4290,8 +4290,8 @@ namespace das {
         }
         return expr;
     }
-    void InferTypes::preVisit(ExprWith *expr) {
-        Visitor::preVisit(expr);
+    void InferTypes::preVisitWithBody ( ExprWith * expr, Expression * body) {
+        Visitor::preVisitWithBody(expr, body);
         with.push_back(expr);
     }
     ExpressionPtr InferTypes::visit(ExprWith *expr) {


### PR DESCRIPTION
Two fixes from fuzzer-found issues in #2169:

1. **Null check `firstType` in pointer const inference** â€” When inferring `var x = null`, `varT->firstType` is null since null has no pointee type. The const propagation path dereferenced `firstType` without checking, causing a crash. (`let var2=null; var var3=var2;`)

2. **Fix `with`-expression scope** â€” Move `with`-expression scope push from `preVisit` to `preVisitWithBody` so that `with(foo) { bar }` only makes `foo` active for `bar`, not for the evaluation of `foo` itself (prevents folding on itself).
