### PR TITLE
utils/benchctl: added a new benchmark utility script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.DS_Store
 .DS_Store
 
+benchdata.db
+
 *.output
 *.temp
 

--- a/modules/dasSQLITE/tutorial/05-parametrized.das
+++ b/modules/dasSQLITE/tutorial/05-parametrized.das
@@ -8,7 +8,7 @@ def main {
     var db : sqlite3?
     var rc = sqlite3_open("test.db", unsafe(addr(db)))
     if (rc != SQLITE_OK) {
-        to_log(LOG_ERROR, "Cannot open database: sqlite3_errmsg(db)\n")
+        to_log(LOG_ERROR, "Cannot open database: {sqlite3_errmsg(db)}\n")
         sqlite3_close(db)
         return
     }

--- a/utils/benchctl/README.md
+++ b/utils/benchctl/README.md
@@ -1,0 +1,280 @@
+# benchctl
+
+A command-line tool for storing, querying, and comparing daslang benchmark results across commits.
+
+Can also be handy to do some incremental tests of performance by measuring the changes one after another (e.g. try algorithm 1, then compare it against algorithm 2 results).
+
+You can browse the data using SQLite3 client if you want to. Use SQLite3 dumping to analyze the data using external tools and/or scripts.
+
+## Overview
+
+benchctl stores benchmark output in a local SQLite database and provides statistical comparison between two sets of results. It integrates directly with the daslang benchmark runner (`dastest` with `--bench` argument).
+
+Key capabilities:
+
+- Insert benchmark JSON output files into a persistent database, tagged by commit hash (and optionally custom tags)
+- Query the database with raw SQL conditions (e.g. selecting by name or tags)
+- Compare two sets of results
+- Compute geometric mean deltas across all benchmarks in a comparison
+
+> benchctl uses a port of Go's benchstat command Welch's t-test for statistical significance implementation
+
+## Prerequisites
+
+- daslang compiler with `sqlite` module support
+
+> You will need to use a `-DDAS_SQLITE_DISABLED=off` when running a cmake
+
+## Usage
+
+```
+daslang utils/benchctl/main.das -- <command> [options...]
+```
+
+All commands accept `--db <path>` to specify the database file (default: `benchdata.db`) and `--colors false` to disable ANSI color output.
+
+Consider using an explicit name for a long-term database while using the default `benchdata.db` as a scratch db you can reset between the experiments.
+
+---
+
+### `reset`
+
+Initializes (or reinitializes) the benchmark database.
+
+> **Warning:** drops all existing data.
+
+```
+# The name is benchdata.db by default, so this explicit parameter
+# is only used for demonstrative purposes
+daslang utils/benchctl/main.das -- reset --db benchdata.db
+```
+
+> Note, running most other commands without an explicit `reset` on a non-existing database file would call a `reset` implicitly.
+
+---
+
+### `insert`
+
+Reads one or more benchmark JSON output files and inserts their records into the database.
+
+> Use `--bench-format json` to make dastest benchmarks output the JSON files.
+
+```
+daslang utils/benchctl/main.das -- insert [options...] <file>...
+```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--db <path>` | Database file path (default: `benchdata.db`) |
+| `--commit <hash>` | Git commit hash to tag results with (default: `git rev-parse HEAD`) |
+| `--tag <name>` | Tag label to attach to results - can be repeated |
+
+Input files must contain newline-delimited JSON records as produced by the dastest benchmark runner. Non-JSON lines are silently skipped.
+
+```
+# Adds all samples from result1.txt and result2.txt tagging them with 2 prodived tags,
+# the commit hash will be "git rev-parse HEAD" (use --commit to override that)
+daslang utils/benchctl/main.das -- insert --tag example1 --tag foo result1.txt result2.txt
+```
+
+**Example:**
+
+```sh
+# Run benchmarks and save output.
+# --test specifies the benchmarks (and tests) source dir or files
+# --bench tells dastest to run the benchmarks along with the tests (they're off by default)
+# --bench-format json selects the JSON export format
+# --count 10 specifies how many "samples" we want per every benchmarks
+# More samples - more precision, but also much more time for the benchmarking to finish.
+# Note: you need at least 5 samples for a benchmark to be analyzeable.
+daslang dastest/dastest.das -- --test benchmarks/ --bench --bench-format json --count 10 | tee results.txt
+
+# Insert these samples into the database (with no extra tags)
+daslang utils/benchctl/main.das -- insert results.txt
+```
+
+---
+
+### `query`
+
+Displays benchmark records from the database.
+
+```
+daslang utils/benchctl/main.das -- query [--db benchdata.db] [--select <condition>]
+```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--db <path>` | Database file path |
+| `--select <cond>` | SQL `WHERE` clause to filter records |
+
+This is mostly needed to debug the selection queries before using a more useful `compare` command.
+
+**Examples:**
+
+```sh
+# Show all records
+daslang utils/benchctl/main.das -- query
+
+# Show records for a specific commit
+daslang utils/benchctl/main.das -- query --select "commit_hash='abc12345'"
+
+# Show only string-allocation-heavy benchmarks
+daslang utils/benchctl/main.das -- query --select "string_allocs > 0"
+```
+
+You can use any columns from the `benchmarks` table to do the filtering.
+
+> Keep in mind: the table contains the samples, they are joined and analyzed together during the processing.
+
+```
+id INTEGER            -- an autoincrement ID of the sample
+
+commit_hash TEXT      -- a git commit hash
+tags TEXT             -- a list of tags bundled inside a string (see below)
+insert_date INTEGER   -- the date of the "insert" command being executed for this sample
+
+full_name TEXT        -- a full sample's benchmark identifier, "{name}/{sub_name}"
+name TEXT             -- a benchmark's function name
+sub_name TEXT         -- a benchmark's "run" argument which specifies the subtest
+
+mode TEXT             -- the execution mode ("JIT", "INTERP", or "AOT")
+
+n INTEGER             -- how many times the benchmarking function was executed
+
+time_ns INTEGER           -- nanosecs per every operation run (time)
+allocs INTEGER            -- a number of non-string heap allocs
+heap_bytes INTEGER        -- a number of heap bytes allocated (excluding the string bytes)
+string_allocs INTEGER     -- like allocs, but only for heap strings
+string_heap_bytes INTEGER -- like heap_bytes, but only for heap strings
+```
+
+Tags are stored as `[tag1][tag2]` strings, so you can filter by tag with `LIKE`:
+
+```sh
+daslang utils/benchctl/main.das -- query --select "tags LIKE '%[before]%'"
+```
+
+> "Has no tag" condition can be implemented using the `NOT LIKE` operation.
+
+---
+
+### `compare`
+
+Compares two sets of benchmark results using statistical analysis.
+
+```
+daslang utils/benchctl/main.das -- compare [options...]
+```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--db <path>` | Database file path |
+| `--select_old <cond>` | SQL `WHERE` clause for the baseline (old) results |
+| `--select_new <cond>` | SQL `WHERE` clause for the new results |
+| `--s <from=>to>` | Regex rename: rewrite old benchmark names to match new names |
+| `--colors false` | Disable colored output |
+
+> Both "select" arguments are abbreviated for convenience to `--old` and `--new`, but you're still encouraged to create an alias/shortcut for the most common use cases you might have.
+
+**Example - compare two commits:**
+
+```sh
+daslang utils/benchctl/main.das -- compare \
+    --select_old "commit_hash='abc12345'" \
+    --select_new "commit_hash='def67890'"
+```
+
+**Example - compare using tags:**
+
+```sh
+daslang utils/benchctl/main.das -- compare \
+    --select_old "tags LIKE '%[before]%'" \
+    --select_new "tags LIKE '%[after]%'"
+```
+
+Both sample sets (old and new) will be compared over the matching `full_name`. This means only the same benchmark results (but across different revisions) can be compared. Unless you use a renaming rule.
+
+**Example - rename benchmarks between two sets:**
+
+If benchmarks have different names, but logically can be compared to one another (e.g. "BenchmarkBad/foo" and "BenchmarkGood/foo"), you can use a renaming rule to make otherwise non-matching benchmarks match.
+
+```sh
+daslang utils/benchctl/main.das -- compare \
+    --select_old "..." \
+    --select_new "..." \
+    --s "BenchmarkBad=>BenchmarkGood"
+```
+
+The `--s` argument is a `from=>to` regex substitution applied to **old names** before trying to pair the names.
+
+---
+
+## Output format (`compare`)
+
+For each paired benchmark:
+
+```
+BenchmarkName/SubName
+    150.3 ns/op ±2%    148.1 ns/op ±1%    -1.47%    (p<0.001 n=10+10)
+```
+
+Column layout: `old value` | `new value` | `delta` | `significance`
+
+- **Green** delta: lower values (improvement for time/memory metrics)
+- **Red** delta: higher values (regression)
+- `~`: result not statistically significant (p ≥ 0.05)
+- **Yellow** variation: coefficient of variation exceeds 5% (noisy benchmark)
+
+A geometric mean summary across all benchmarks is printed at the end.
+
+Some general advice:
+
+* You want the `p` to be as low as possible (p<0.001 is perfect)
+* You want the `n` to be around 10 or higher, **5 is the bare minimum**
+* You want the sample variation (±value) to be less than 5%
+
+If all of the above are satisfied, you can generally consider the results legit and stable.
+
+---
+
+## Statistical methods
+
+| Method | Description |
+|--------|-------------|
+| Outlier filtering | Tukey's fences (1.5 × IQR) applied before any statistics |
+| Mean | Arithmetic mean of per-operation values |
+| Variation | Coefficient of variation (stddev / mean); highlighted yellow if > 5% |
+| Significance | Welch's t-test; p < 0.05 is considered significant |
+| Summary | Geometric mean of per-benchmark means |
+
+A minimum of 5 samples per benchmark is required for statistics to be computed.
+
+## Typical workflow
+
+```sh
+# 1. Initialize the database (once, or to wipe existing data).
+# You can usually skip this step as it can be executed implictly,
+# but it's a good place to test whether your benchctl is working properly.
+daslang utils/benchctl/main.das -- reset
+
+# 2. Run benchmarks on the baseline and insert results
+daslang dastest/dastest.das -- --test mybench.das --bench --bench-format json | tee old.json
+daslang utils/benchctl/main.das -- insert --tag before old.json
+
+# 3. Make your changes, then run benchmarks again
+daslang dastest/dastest.das -- --test mybench.das --bench --bench-format json | tee new.json
+daslang utils/benchctl/main.das -- insert --tag after new.json
+
+# 4. Compare the two runs
+# (note: using the aliased select_old and select_new)
+daslang utils/benchctl/main.das -- compare \
+    --old "tags LIKE '%[before]%'" \
+    --new "tags LIKE '%[after]%'"
+```

--- a/utils/benchctl/benchstat.das
+++ b/utils/benchctl/benchstat.das
@@ -1,0 +1,345 @@
+require dastest/testing_boost
+require daslib/strings_boost
+require daslib/json_boost
+require math
+
+struct BenchmarkEntry {
+    id : int64
+
+    commit_hash : string
+    tags : string
+    insert_date : int64
+
+    full_name : string
+    name : string
+    sub_name : string
+
+    mode : string
+
+    n : int64
+    time_ns : int64
+
+    allocs : int64
+    heap_bytes : int64
+    string_allocs : int64
+    string_heap_bytes : int64
+}
+
+struct BenchmarkSampleSet {
+    key : string
+    list : array<BenchmarkEntry>
+
+    // Assigned later, when stats are computed.
+    stats : BenchmarkStats? = null
+}
+
+struct BenchmarkStats {
+    time_ns : SampleStats? = new SampleStats()
+    allocs : SampleStats? = new SampleStats()
+    heap_bytes : SampleStats? = new SampleStats()
+    string_allocs : SampleStats? = new SampleStats()
+    string_heap_bytes : SampleStats? = new SampleStats()
+}
+
+def as_list(var stats : BenchmarkStats?) : array<SampleStats?> {
+    return [
+        stats.time_ns,
+        stats.allocs,
+        stats.heap_bytes,
+        stats.string_allocs,
+        stats.string_heap_bytes,
+    ]
+}
+
+struct SampleStats {
+    metric : BenchmarkMetric = BenchmarkMetric()
+    values : array<double>
+    mean_avg : double
+    stddev : double
+    variation_coeff : double
+    min_value : double
+    max_value  : double
+}
+
+struct BenchmarkMetric {
+    name : string = ""
+    header : string = ""
+    is_alloc : bool = false
+}
+
+def parse_bench_output(data : string) : array<BenchmarkRunStats> {
+    var entries : array<BenchmarkRunStats>
+    let lines <- split(data, "\n")
+    for (l in lines) {
+        if (!starts_with(l, "\{")) {
+            continue
+        }
+        var err : string
+        let parsed = read_json(l, err)
+        if (parsed == null) {
+            continue
+        }
+        let e = from_JV(parsed, type<BenchmarkRunStats>)
+        entries |> push(e)
+    }
+    return <- entries
+}
+
+def make_sample_sets(entries : array<BenchmarkEntry>) : table<string, BenchmarkSampleSet?> {
+    var result : table<string, BenchmarkSampleSet?>
+    for (e in entries) {
+        let key := e.name + "/" + e.sub_name
+        var samples : BenchmarkSampleSet?
+        if (key_exists(result, key)) {
+            samples = unsafe(result[key])
+        } else {
+            samples = new BenchmarkSampleSet()
+            result |> insert(key, samples)
+        }
+        if (samples.key == "") {
+            samples.key = key
+        }
+        samples.list |> push(e)
+    }
+    return <- result
+}
+
+// Fill the sample stats for the provided benchmark sample set.
+// It performs outlier fitlering and computes other metrics needed to compare
+// the sample sets later.
+def fill_sample_stats(var samples : BenchmarkSampleSet?) : string {
+    var stats = new BenchmarkStats()
+
+    // First, collect all values among every entry.
+    // An example: there can be N entries for "foo/bar" benchmark,
+    // every such entry is considered to be a single sample for analysis.
+    for (e in samples.list) {
+        if (e.n == 0l) {
+            continue
+        }
+        let n = double(e.n)
+        stats.time_ns.values |> push(double(e.time_ns) / n)
+        stats.heap_bytes.values |> push(double(e.heap_bytes) / n)
+        stats.allocs.values |> push(double(e.allocs) / n)
+        stats.string_heap_bytes.values |> push(double(e.string_heap_bytes) / n)
+        stats.string_allocs.values |> push(double(e.string_allocs) / n)
+    }
+
+    var process_list <- [
+        (stats.time_ns, BenchmarkMetric(name = "ns", header = "time")),
+        (stats.heap_bytes, BenchmarkMetric(name = "B", header = "heap bytes", is_alloc = true)),
+        (stats.allocs, BenchmarkMetric(name = "allocs", header = "heap alloc count", is_alloc = true)),
+        (stats.string_heap_bytes, BenchmarkMetric(name = "SB", header = "string heap bytes", is_alloc = true)),
+        (stats.string_allocs, BenchmarkMetric(name = "strings", header = "string heap alloc count", is_alloc = true)),
+    ]
+    for ((s, metric) in process_list) {
+        let err = calc_sample_stats(s)
+        if (err != "") {
+            return err
+        }
+        s.metric = metric
+    }
+
+    samples.stats <- stats
+    return ""
+}
+
+def private calc_sample_stats(var dst : SampleStats?) : string {
+    let min_sample_count = 5
+
+    if (length(dst.values) < min_sample_count) {
+        return "need more samples, have {length(dst.values)}, want at least {min_sample_count}"
+    }
+
+    dst.values = filter_outliers(<- dst.values)
+    if (length(dst.values) == 0) {
+        return "noisy samples"
+    }
+
+    dst.mean_avg = compute_mean_avg(dst.values)
+    dst.stddev = compute_stddev(dst.values, dst.mean_avg)
+    dst.variation_coeff = dst.mean_avg > 0.0lf ? dst.stddev / dst.mean_avg : 0.0lf
+
+    // Since values are sorted, it's easy to get min/max.
+    // We still put them to a separate field for convenience.
+    dst.min_value = dst.values[0]
+    dst.max_value = dst.values[length(dst.values) - 1]
+
+    return ""
+}
+
+def filter_outliers(var values : array<double>) : array<double> {
+    // The algorithm below requires values being sorted.
+    // https://en.wikipedia.org/wiki/Outlier ctrl+f Tukey's fences
+    sort(values) $(x, y) {
+        return x < y
+    }
+
+    let q1 = percentile(values, 0.25lf)
+    let q3 = percentile(values, 0.75lf)
+    let iqr = q3 - q1 // interquartile range
+    if (iqr == 0.0lf) {
+        return <- values
+    }
+
+    let lo_fence = q1 - 1.5lf * iqr
+    let hi_fence = q3 + 1.5lf * iqr
+    var filtered : array<double>
+    filtered |> reserve(length(values))
+    for (v in values) {
+        if (v >= lo_fence && v <= hi_fence) {
+            filtered |> push(v)
+        }
+    }
+
+    return <- filtered
+}
+
+def private percentile(values : array<double>; p : double) : double {
+    let n = length(values)
+    if (n == 0) {
+        return 0.0lf
+    }
+    if (n == 1) {
+        return values[0]
+    }
+
+    let idx = p * double(n - 1)
+    let lo = int(idx)
+    let hi = min(lo + 1, n - 1)
+    let frac = idx - double(lo)
+    return values[lo] * (1.0lf - frac) + values[hi] * frac
+}
+
+def private compute_mean_avg(values : array<double>) : double {
+    var sum = 0.0lf
+    for (v in values) {
+        sum += v
+    }
+    return sum / double(length(values))
+}
+
+def private compute_stddev(values : array<double>; mean_avg : double) : double {
+    let n = length(values)
+    if (n < 2) {
+        return 0.0lf
+    }
+    var variance = 0.0lf
+    for (v in values) {
+        let d = v - mean_avg
+        variance += d * d
+    }
+    return sqrt(variance / double(n - 1))
+}
+
+def geomean(values : array<double>) : double {
+    if (length(values) == 0) {
+        return 0.0lf
+    }
+    var log_sum = 0.0lf
+    for (v in values) {
+        if (v <= 0.0lf) {
+            return 0.0lf
+        }
+        log_sum += log(v)
+    }
+    return exp(log_sum / double(length(values)))
+}
+
+def welch_p_value(stats_old : SampleStats?; stats_new : SampleStats?) : double {
+    let n1 = double(length(stats_old.values))
+    let n2 = double(length(stats_new.values))
+    if (n1 < 2.0lf || n2 < 2.0lf) {
+        return 1.0lf
+    }
+    let se1_sq = stats_old.stddev * stats_old.stddev / n1
+    let se2_sq = stats_new.stddev * stats_new.stddev / n2
+    let se_sq = se1_sq + se2_sq
+    if (se_sq <= 0.0lf) {
+        return stats_old.mean_avg == stats_new.mean_avg ? 1.0lf : 0.0lf
+    }
+    let t = (stats_old.mean_avg - stats_new.mean_avg) / sqrt(se_sq)
+    let df_denom = se1_sq * se1_sq / (n1 - 1.0lf) + se2_sq * se2_sq / (n2 - 1.0lf)
+    if (df_denom <= 0.0lf) {
+        return 1.0lf
+    }
+    let df = se_sq * se_sq / df_denom
+    let x = df / (df + t * t)
+    return beta_i(df * 0.5lf, 0.5lf, x)
+}
+
+def private beta_i(a : double; b : double; x : double) : double {
+    if (x <= 0.0lf) {
+        return 0.0lf
+    }
+    if (x >= 1.0lf) {
+        return 1.0lf
+    }
+    let lbeta = lgamma_stirling(a + b) - lgamma_stirling(a) - lgamma_stirling(b)
+    let bt = exp(lbeta + a * log(x) + b * log(1.0lf - x))
+    if (x < (a + 1.0lf) / (a + b + 2.0lf)) {
+        return bt * betacf(a, b, x) / a
+    }
+    return 1.0lf - bt * betacf(b, a, 1.0lf - x) / b
+}
+
+def private lgamma_stirling(x : double) : double {
+    var xx = x
+    var adj = 0.0lf
+    while (xx < 7.0lf) {
+        adj -= log(xx)
+        xx += 1.0lf
+    }
+    let lx = log(xx)
+    var r = (xx - 0.5lf) * lx - xx + 0.9189385332046727lf
+    r += 1.0lf / (12.0lf * xx) - 1.0lf / (360.0lf * xx * xx * xx)
+    return r + adj
+}
+
+def private betacf(a : double; b : double; x : double) : double {
+    let FPMIN = 1.0e-30lf
+    let EPS = 3.0e-7lf
+    let qab = a + b
+    let qap = a + 1.0lf
+    let qam = a - 1.0lf
+    var c = 1.0lf
+    var d = 1.0lf - qab * x / qap
+    if (abs(d) < FPMIN) {
+        d = FPMIN
+    }
+    d = 1.0lf / d
+    var h = d
+    var mi = 0
+    while (mi < 200) {
+        let m = double(mi + 1)
+        let m2 = 2.0lf * m
+        var aa = m * (b - m) * x / ((qam + m2) * (a + m2))
+        d = 1.0lf + aa * d
+        if (abs(d) < FPMIN) {
+            d = FPMIN
+        }
+        c = 1.0lf + aa / c
+        if (abs(c) < FPMIN) {
+            c = FPMIN
+        }
+        d = 1.0lf / d
+        h *= d * c
+        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+        d = 1.0lf + aa * d
+        if (abs(d) < FPMIN) {
+            d = FPMIN
+        }
+        c = 1.0lf + aa / c
+        if (abs(c) < FPMIN) {
+            c = FPMIN
+        }
+        d = 1.0lf / d
+        let delta = d * c
+        h *= delta
+        if (abs(delta - 1.0lf) < EPS) {
+            break
+        }
+        mi++
+    }
+    return h
+}

--- a/utils/benchctl/flags.das
+++ b/utils/benchctl/flags.das
@@ -1,0 +1,51 @@
+require strings
+require daslib/strings_boost
+
+struct Flags {
+    tags : array<string>
+    argmap : table<string, string>
+    values : array<string>
+}
+
+def get_string_aliased_arg(flags : Flags; key : string; alias : string, default_value : string = "") : string {
+    return get_string_arg(flags, alias, get_string_arg(flags, key, default_value))
+}
+
+def get_string_arg(flags : Flags; key : string; default_value : string = "") : string {
+    return flags.argmap?[key] ?? default_value
+}
+
+def parse_flags(args : array<string>) : Flags {
+    var tags : array<string>
+    var values : array<string>
+    var argmap : table<string, string>
+    var i = 0
+    while (i < length(args)) {
+        if (args[i] == "--tag") {
+            i++
+            if (i < length(args)) {
+                let tag = args[i]
+                i++
+                tags |> push(tag)
+            }
+            continue
+        }
+        if (starts_with(args[i], "--")) {
+            let key = args[i]
+            i++
+            if (i < length(args)) {
+                let val = args[i]
+                i++
+                argmap |> insert(slice(key, 2), val)
+            }
+            continue
+        }
+        values |> push(args[i])
+        i++
+    }
+    return Flags(
+        values <- values,
+        argmap <- argmap,
+        tags <- tags,
+    )
+}

--- a/utils/benchctl/main.das
+++ b/utils/benchctl/main.das
@@ -1,0 +1,486 @@
+options gen2
+
+require sqlite/sqlite_boost
+
+require fio
+require math
+require daslib/defer
+require daslib/regex_boost
+require daslib/strings_boost
+
+require sql
+require utils
+require flags
+require benchstat
+require table_fmt
+
+[export]
+def main() {
+    let err := run_main()
+    var exit_code = 0
+    if (err != "") {
+        print("[{red_str("error")}] {err}\n")
+        exit_code = 1
+    }
+    unsafe {
+        exit(exit_code)
+    }
+}
+
+def run_main() : string {
+    var args <- get_command_line_arguments()
+    let arg_index = find_index(args, "--")
+    if (arg_index == -1) {
+        return "-- separator not found"
+    }
+    var script_args <- subarray(args, (arg_index + 1)..length(args))
+    if (length(script_args) == 0) {
+        return "expected a subcommand name"
+    }
+
+    let subcmd_name = script_args[0]
+    let subcmd_args <- subarray(script_args, 1..length(script_args))
+    let flags = parse_flags(subcmd_args)
+
+    if (get_string_arg(flags, "colors", "true") == "false") {
+        colored_output = false
+    }
+
+    if (subcmd_name == "help") {
+        return run_help_cmd()
+    }
+
+    let db_filename = get_string_arg(flags, "db", "benchdata.db")
+    var need_db_init = !file_exists(db_filename) && find_index([
+        "insert",
+        "query",
+        "compare",
+    ], subcmd_name) != -1
+
+    var db : sqlite3?
+    defer() {
+        sqlite3_close(db)
+    }
+    var rc = sqlite3_open(db_filename, unsafe(addr(db)))
+    if (rc != SQLITE_OK) {
+        return "open database: {sqlite3_errmsg(db)}"
+    }
+
+    if (need_db_init) {
+        let err = run_reset_cmd(db, flags)
+        if (err != "") {
+            return "implicit db creation: {err}"
+        }
+    }
+
+    if (subcmd_name == "reset") {
+        return run_reset_cmd(db, flags)
+    } elif (subcmd_name == "insert") {
+        return run_insert_cmd(db, flags)
+    } elif (subcmd_name == "query") {
+        return run_query_cmd(db, flags)
+    } elif (subcmd_name == "compare") {
+        return run_compare_cmd(db, flags)
+    } else {
+        return "unknown subcommand name: {subcmd_name}"
+    }
+
+    return ""
+}
+
+def run_help_cmd() : string {
+    // TODO: it would be better if we could get this help command for free
+    // using a command line library (e.g. like "flag" package in Go)
+
+    print("benchctl - benchmark database management tool\n\n")
+    print("Usage:\n")
+    print("  daslang benchctl/main.das -- <command> [options]\n\n")
+    print("Commands:\n")
+    print("  reset    Initialize or reinitialize the benchmark database (drops all data)\n")
+    print("  insert   Insert benchmark results from JSON output files\n")
+    print("  query    Query and display stored benchmark records\n")
+    print("  compare  Compare two sets of benchmark results statistically\n")
+    print("  help     Show this help message\n\n")
+    print("Common options:\n")
+    print("  --db <path>      SQLite3 database file path (default: benchdata.db)\n")
+    print("  --colors false   Disable colored terminal output\n\n")
+    print("insert options:\n")
+    print("  --commit <hash>  Git commit hash to tag results with (default: git rev-parse HEAD)\n")
+    print("  --tag <name>     Tag label to attach to results (can be repeated)\n")
+    print("  <file>...        Benchmark JSON output files to insert\n\n")
+    print("query options:\n")
+    print("  --select <cond>  SQL WHERE clause to filter records\n\n")
+    print("compare options:\n")
+    print("  --select_old <cond>  SQL WHERE clause for baseline (old) results\n")
+    print("  --select_new <cond>  SQL WHERE clause for new results\n")
+    print("  --s <from=>to>       Regex rename: map old benchmark names to new names\n")
+    print("  --old <cond>         --select_old alias\n")
+    print("  --new <cond>         --select_new aliass\n")
+    return ""
+}
+
+def query_benchmarks(db : sqlite3?; cond : string; exclude : table<int64> = default<table<int64>>) : tuple<array<BenchmarkEntry>, string> {
+    var result : array<BenchmarkEntry>
+
+    var sql_text = "SELECT * FROM benchmarks"
+    if (cond != "") {
+        sql_text += " WHERE {cond}"
+    }
+
+    var err_msg : string
+    defer() {
+        sqlite3_free(err_msg)
+    }
+    let rc = sqlite3_exec(db, sql_text, unsafe(addr(err_msg))) $(values, columns) {
+        var entry : BenchmarkEntry
+        for (v, c in values, columns) {
+            if (c == "id") {
+                entry.id = to_int64(v)
+            } elif (c == "commit_hash") {
+                entry.commit_hash := v
+            } elif (c == "tags") {
+                entry.tags := v
+            } elif (c == "insert_date") {
+                entry.insert_date = to_int64(v)
+            } elif (c == "full_name") {
+                entry.full_name := v
+            } elif (c == "name") {
+                entry.name := v
+            } elif (c == "sub_name") {
+                entry.sub_name := v
+            } elif (c == "mode") {
+                entry.mode := v
+            } elif (c == "n") {
+                entry.n = to_int64(v)
+            } elif (c == "time_ns") {
+                entry.time_ns = to_int64(v)
+            } elif (c == "allocs") {
+                entry.allocs = to_int64(v)
+            } elif (c == "heap_bytes") {
+                entry.heap_bytes = to_int64(v)
+            } elif (c == "string_allocs") {
+                entry.string_allocs = to_int64(v)
+            } elif (c == "string_heap_bytes") {
+                entry.string_heap_bytes = to_int64(v)
+            }
+        }
+        if (!key_exists(exclude, entry.id)) {
+            result |> push(entry)
+        }
+        return SQLITE_OK
+    }
+
+    var err = ""
+    if (rc != SQLITE_OK) {
+        err = clone_string(sqlite3_errmsg(db))
+    }
+
+    return (<- result, err)
+}
+
+def run_compare_cmd(db : sqlite3?; flags : Flags) : string {
+    var cond_old = get_string_aliased_arg(flags, "select_old", "old", "")
+    var cond_new = get_string_aliased_arg(flags, "select_new", "new", "")
+
+    var key_map = @(x : string) : string {
+        return x
+    }
+    var key_mapper = get_string_arg(flags, "s", "")
+    if (key_mapper != "") {
+        let parts <- split(key_mapper, "=>")
+        if (length(parts) != 2) {
+            return "invalid -s argument, expected 'from=>to' format"
+        }
+        var re <- regex_compile(parts[0])
+        key_map = @capture(:= re, := parts) (x : string) : string {
+            return regex_replace(re, x, parts[1])
+        }
+    }
+
+    let (old_entries, err) = query_benchmarks(db, cond_old)
+    if (err != "") {
+        return "query --old: {err}"
+    }
+    var old_ids : table<int64>
+    for (e in old_entries) {
+        old_ids |> insert(e.id)
+    }
+
+    let (new_entries, err) = query_benchmarks(db, cond_new, old_ids)
+    if (err != "") {
+        return "query --new: {err}"
+    }
+
+    var old_samples = make_sample_sets(old_entries)
+    var new_samples = make_sample_sets(new_entries)
+
+    var bench_order : array<string>
+    for (k in keys(old_samples)) {
+        bench_order |> push(k)
+    }
+    sort(bench_order) $(x, y) {
+        return x < y
+    }
+
+    var old_total_values = {
+        "ns" => array<double>(),
+        "B" => array<double>(),
+        "allocs" => array<double>(),
+        "SB" => array<double>(),
+        "strings" => array<double>(),
+    }
+    var new_total_values = {
+        "ns" => array<double>(),
+        "B" => array<double>(),
+        "allocs" => array<double>(),
+        "SB" => array<double>(),
+        "strings" => array<double>(),
+    }
+
+    for (s in values(old_samples)) {
+        let err2 = fill_sample_stats(s)
+        if (err2 != "") {
+            warning("old_samples: {blue_str(s.key)}: calc stats: {err2}")
+        }
+    }
+    for (s in values(new_samples)) {
+        let err2 = fill_sample_stats(s)
+        if (err2 != "") {
+            warning("new_samples: {blue_str(s.key)}: calc stats: {err2}")
+        }
+    }
+
+    let fmt_variation <- @(variation : double) : string {
+        let percent = variation * 100.0lf
+        let s = "{percent:.0f}"
+        if (percent < 5.0lf) {
+            return "±{s}%"
+        }
+        return "±{yellow_str(s)}%"
+    }
+    let fmt_delta <- @(old_v, new_v : double) : string {
+        if (old_v > 0.0lf && new_v <= 0.01lf) {
+            return green_str("-100%")
+        }
+        if (old_v == 0.0lf && new_v >= 1.0lf) {
+            return red_str("+inf%")
+        }
+        let delta_percent = (new_v - old_v) / old_v * 100.0lf
+        let sign = delta_percent >= 0.0lf ? "+" : ""
+        let delta_fmt = "{sign}{delta_percent:.2f}%"
+        if (delta_percent < 0.0lf) {
+            return green_str(delta_fmt)
+        } elif (delta_percent > 0.0lf) {
+            return red_str(delta_fmt)
+        } else {
+            return delta_fmt
+        }
+    }
+    for (k in bench_order) {
+        var s_old = unsafe(old_samples[k])
+        // The stats are null if an error occured when analyzing it.
+        if (s_old.stats == null) {
+            continue
+        }
+        let mapped_k = key_map(k)
+        if (!key_exists(new_samples, mapped_k)) {
+            if (k != mapped_k) {
+                warning("no pair found for {k} ({mapped_k})\n")
+            } else {
+                warning("no pair found for {k}\n")
+            }
+            continue
+        }
+
+        var s_new = unsafe(new_samples[mapped_k])
+        if (s_new.stats == null) {
+            continue
+        }
+
+        if (k != mapped_k) {
+            print("{blue_str(k)} vs {blue_str(mapped_k)}\n")
+        } else {
+            print("{blue_str(k)}\n")
+        }
+        var table_rows : array<TableRow?>
+        for (stat_old, stat_new in as_list(s_old.stats), as_list(s_new.stats)) {
+            if (stat_old.metric.is_alloc && stat_old.mean_avg == 0.0lf && stat_new.mean_avg == 0.0lf) {
+                continue
+            }
+            if (stat_old.metric.is_alloc && abs(stat_old.mean_avg - stat_new.mean_avg) < 1.0lf) {
+                continue
+            }
+
+            old_total_values[stat_old.metric.name] |> push(stat_old.mean_avg)
+            new_total_values[stat_new.metric.name] |> push(stat_new.mean_avg)
+
+            let p = welch_p_value(stat_old, stat_new)
+            let n_str = "{length(stat_old.values)}+{length(stat_new.values)}"
+            var p_str = ""
+            if (p < 0.001lf) {
+                p_str = "p<0.001"
+            } elif (p < 0.005lf) {
+                p_str = "p={p:.3f}"
+            } elif (p < 0.010lf) {
+                p_str = "p=" + yellow_str("{p:.3f}")
+            } else {
+                p_str = "p=" + red_str("{p:.3f}")
+            }
+            let cmp_str = "({p_str} n={n_str})"
+
+            let metric_name = stat_old.metric.name
+            let old_v = "{stat_old.mean_avg:.1f}"
+            let new_v = "{stat_new.mean_avg:.1f}"
+
+            var delta_str = "~"
+            if (p < 0.05lf) {
+                delta_str = fmt_delta(stat_old.mean_avg, stat_new.mean_avg)
+            }
+
+            table_rows |> push(new TableRow(columns <- [
+                "{yellow_str(old_v)} {metric_name}/op {fmt_variation(stat_old.variation_coeff)}",
+                "{yellow_str(new_v)} {metric_name}/op {fmt_variation(stat_new.variation_coeff)}",
+                delta_str,
+                cmp_str,
+            ]))
+        }
+        var tabspec = new TableData(
+            rows <- table_rows,
+            col_gap = 4,
+            indent = "    ",
+        )
+        print(format_table(tabspec))
+    }
+
+    var table_rows : array<TableRow?>
+    for (k, old_values in keys(old_total_values), values(old_total_values)) {
+        let new_values & = unsafe(new_total_values[k])
+        if (length(old_values) == 0 && length(new_values) == 0) {
+            continue
+        }
+        let gm_old = geomean(old_values)
+        let gm_new = geomean(new_values)
+        let gm_old_s = "{gm_old:.1f}"
+        let gm_new_s = "{gm_new:.1f}"
+        table_rows |> push(new TableRow(columns <- [
+            "{yellow_str(gm_old_s)} {k}",
+            "{yellow_str(gm_new_s)} {k}",
+            fmt_delta(gm_old, gm_new),
+        ]))
+    }
+    if (length(table_rows) > 0) {
+        print("\n")
+        print("GEOMEAN:\n\n")
+        var tabspec = new TableData(
+            rows <- table_rows,
+            col_gap = 4,
+            indent = "    ",
+        )
+        print(format_table(tabspec))
+    }
+
+    return ""
+}
+
+def run_query_cmd(db : sqlite3?; flags : Flags) : string {
+    var cond = get_string_arg(flags, "select", "")
+    let (entries, err) = query_benchmarks(db, cond)
+    if (err != "") {
+        return "run query: {err}"
+    }
+    if (length(entries) == 0) {
+        print("no results\n")
+        return ""
+    }
+    var table_rows : array<TableRow?>
+    for (e in entries) {
+        let commit_short = length(e.commit_hash) > 8 ? slice(e.commit_hash, 0, 8) : e.commit_hash
+        let ns_per_op = e.n > 0l ? double(e.time_ns) / double(e.n) : 0.0lf
+        table_rows |> push(new TableRow(columns <- [
+            e.full_name,
+            commit_short,
+            e.tags,
+            "{e.n}",
+            "{ns_per_op:.1f} ns/op",
+        ]))
+    }
+    print("  {yellow_str("benchmark")}  {yellow_str("commit")}  {yellow_str("tags")}  {yellow_str("n")}  {yellow_str("ns/op")}\n\n")
+    var tabspec = new TableData(
+        rows <- table_rows,
+        col_gap = 2,
+        indent = "  ",
+    )
+    print(format_table(tabspec))
+    return ""
+}
+
+def run_reset_cmd(db : sqlite3?; flags : Flags) : string {
+    var err = db_exec(db, sql_db_init)
+    if (err != "") {
+        return "run init query: {err}"
+    }
+
+    return ""
+}
+
+def run_insert_cmd(db : sqlite3?; flags : Flags) : string {
+    if (length(flags.values) == 0) {
+        return "missing targets to insert"
+    }
+
+    var commit_hash = get_string_arg(flags, "commit", "")
+    if (commit_hash == "") {
+        commit_hash = cmd_exec("git rev-parse HEAD")
+    }
+
+    var tag_string = ""
+    for (t in flags.tags) {
+        tag_string += "[{t}]"
+    }
+
+    var stmt : sqlite3_stmt?
+    let rc = sqlite3_prepare_v2(db, sql_bench_insert, -1, unsafe(addr(stmt)), null)
+    if (rc != SQLITE_OK) {
+        return "prepare insertion statement: {sqlite3_errmsg(db)}"
+    }
+    defer() {
+        sqlite3_finalize(stmt)
+    }
+
+    for (filename in flags.values) {
+        let data = read_file(filename)
+        if (data == "") {
+            print("{filename}: ignored\n")
+            continue
+        }
+        let entries = parse_bench_output(data)
+        var added = 0
+        for (e in entries) {
+            db_bind_text_param(stmt, "@commit_hash", commit_hash)
+            db_bind_text_param(stmt, "@tags", tag_string)
+            db_bind_text_param(stmt, "@name", e.name)
+            db_bind_text_param(stmt, "@sub_name", e.sub_name)
+            db_bind_text_param(stmt, "@mode", e.func_type)
+            db_bind_int64_param(stmt, "@n", int64(e.n))
+            db_bind_int64_param(stmt, "@time_ns", e.time_ns)
+            db_bind_int64_param(stmt, "@allocs", int64(e.allocs))
+            db_bind_int64_param(stmt, "@heap_bytes", int64(e.heap_bytes))
+            db_bind_int64_param(stmt, "@string_allocs", int64(e.string_allocs))
+            db_bind_int64_param(stmt, "@string_heap_bytes", int64(e.string_heap_bytes))
+            let step_rc = sqlite3_step(stmt)
+            if (step_rc != SQLITE_DONE) {
+                return "insert failed: {sqlite3_errmsg(db)}"
+            }
+            added++
+            sqlite3_reset(stmt);
+            sqlite3_clear_bindings(stmt);
+        }
+        print("{filename}: added {added} samples\n")
+    }
+
+    return ""
+}
+
+def warning(msg : string) {
+    print("{yellow_str("[warning]")} {msg}\n")
+}

--- a/utils/benchctl/sql.das
+++ b/utils/benchctl/sql.das
@@ -1,0 +1,82 @@
+require sqlite/sqlite_boost
+
+require daslib/stringify
+require daslib/defer
+
+def db_exec(db : sqlite3?; sql : string) : string {
+    var err_msg : string
+    defer() {
+        sqlite3_free(err_msg)
+    }
+    let rc = sqlite3_exec(db, sql, unsafe(addr(err_msg)))
+    return (rc != SQLITE_OK) ? clone_string(err_msg) : ""
+}
+
+def db_bind_text_param(stmt : sqlite3_stmt?; key : string; v : string) {
+    let idx = sqlite3_bind_parameter_index(stmt, key)
+    sqlite3_bind_text(stmt, idx, v)
+}
+
+def db_bind_int64_param(stmt : sqlite3_stmt?; key : string; v : int64) {
+    let idx = sqlite3_bind_parameter_index(stmt, key)
+    sqlite3_bind_int64(stmt, idx, v)
+}
+
+let sql_bench_insert = %stringify~
+    INSERT INTO benchmarks (
+        commit_hash,
+        tags,
+        insert_date,
+        full_name,
+        name,
+        sub_name,
+        mode,
+        n,
+        time_ns,
+        allocs,
+        heap_bytes,
+        string_allocs,
+        string_heap_bytes
+    )
+    VALUES (
+        @commit_hash,
+        @tags,
+        strftime('%s', 'now'),
+        @name || '/' || @sub_name,
+        @name,
+        @sub_name,
+        @mode,
+        @n,
+        @time_ns,
+        @allocs,
+        @heap_bytes,
+        @string_allocs,
+        @string_heap_bytes
+    );
+%%
+
+let sql_db_init = %stringify~
+    DROP TABLE IF EXISTS benchmarks;
+
+    CREATE TABLE benchmarks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+        commit_hash TEXT,
+        tags TEXT,
+        insert_date INTEGER,
+
+        full_name TEXT,
+        name TEXT,
+        sub_name TEXT,
+
+        mode TEXT,
+
+        n INTEGER,
+        time_ns INTEGER,
+
+        allocs INTEGER,
+        heap_bytes INTEGER,
+        string_allocs INTEGER,
+        string_heap_bytes INTEGER
+    );
+%%

--- a/utils/benchctl/table_fmt.das
+++ b/utils/benchctl/table_fmt.das
@@ -1,0 +1,43 @@
+require math
+require strings
+
+require utils
+
+struct TableData {
+    rows : array<TableRow?>
+    col_gap : int = 1
+    indent : string
+}
+
+struct TableRow {
+    columns : array<string>
+}
+
+def format_table(tab : TableData?) : string {
+    if (length(tab.rows) == 0) {
+        return ""
+    }
+
+    return build_string() $(var w) {
+        var col_widths : array<int>
+        for (col_index in range(length(tab.rows[0].columns))) {
+            var max_width = 0
+            for (row in tab.rows) {
+                max_width = max(max_width, length(bare_str(row.columns[col_index])))
+            }
+            col_widths |> push(max_width)
+        }
+
+        for (row in tab.rows) {
+            w |> write(tab.indent)
+            for (i, col in range(length(row.columns)), row.columns) {
+                let width = col_widths[i]
+                let col_width = length(bare_str(col))
+                let sep = repeat(" ", max(width - col_width, 0) + (tab.col_gap - 1))
+                w |> write(col)
+                w |> write(sep)
+            }
+            w |> write("\n")
+        }
+    }
+}

--- a/utils/benchctl/utils.das
+++ b/utils/benchctl/utils.das
@@ -1,0 +1,58 @@
+require fio
+require strings
+require daslib/strings_boost
+
+var colored_output = true
+
+def cmd_exec(cmd : string) : string {
+    var out = ""
+    unsafe {
+        popen(cmd) $(f) {
+            while (!feof(f)) {
+                out += fgets(f)
+            }
+        }
+    }
+    return trim(out)
+}
+
+def file_exists(filename : string) : bool {
+    return stat(filename).is_valid
+}
+
+def read_file(filename : string) : string {
+    var result = ""
+    fopen(filename, "r") $(f) {
+        if (f != null) {
+            result = fread(f)
+        }
+    }
+    return result
+}
+
+def bare_str(str : string) : string {
+    return replace_multiple(str, [
+        ("\x1B[0m", ""),
+
+        ("\x1B[31m", ""),
+        ("\x1B[32m", ""),
+        ("\x1B[33m", ""),
+        ("\x1B[34m", ""),
+    ])
+}
+
+def red_str(str : string) : string {
+    return colored_output ? "\x1B[31m{str}\x1B[0m" : str
+}
+
+def green_str(str : string) : string {
+    return colored_output ? "\x1B[32m{str}\x1B[0m" : str
+}
+
+def yellow_str(str : string) : string {
+    return colored_output ? "\x1B[33m{str}\x1B[0m" : str
+}
+
+def blue_str(str : string) : string {
+    return colored_output ? "\x1B[34m{str}\x1B[0m" : str
+}


### PR DESCRIPTION
The benchctl script allows statistical analysis over
the benchmark results obtained via dastest benchmarks.

It maintains a local SQLite3 db with benchmark samples
and allows querying and reliable comparisons of
benchmarking data.

See utils/benchctl/README.md for more details