### PR TITLE
compact options log output for gen2, remove extra semicolons

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,7 +310,7 @@ jobs:
             echo -e "leak:format_error\n" > suppressions.txt
             export LSAN_OPTIONS="suppressions='suppressions.txt'"
             # Use more time to pass UBSAN and disable leaks in JIT mode because we exit using exit(), and do not call destructors.
-            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- --color --test ../tests || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- --color --isolated-mode --timeout 4800 --test ../tests
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- --color --test ../tests || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- --color --isolated-mode --timeout 5600 --test ../tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --test ../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --isolated-mode --timeout 3600 --test ../tests
             ;;
            windows32)


### PR DESCRIPTION
Compact `options log` output for gen2 syntax.

In gen2 mode, the AST printer now uses compact brace style opening `{` on the same line as the keyword:

```
def public main {
    if ( a > 0 ) {
        print(yes);
    } else {
        print(no);
    }
    for ( x in range(0,3) ) {
        a += x;
    }
    while ( i < 3 ) {
        ++i;
    }
    try {
        panic(oops);
    } recover {
        print(recovered);
    }
    $(val:int const):int {
        return val * 2;
    }
}
```

Changes:
- No newline before `{` for `def`, `if`, `else`, `elif`, `for`, `while`, `with`, `try`, `recover`, `unsafe`, and closure/block arguments
- Remove trailing `;` after bare blocks, `try`/`recover`, and `unsafe` blocks in gen2 mode
- Non-gen2 output is unchanged
