### PR TITLE
Make DasThreadLocal::initCounter atomic (issue #2027)

### DIFF
--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -82,6 +82,7 @@
 
 #include <stdint.h>
 #include <float.h>
+#include <atomic>
 #include <daScript/das_config.h>
 #include <daScript/misc/hash.h>
 #include <daScript/misc/macro.h>
@@ -442,7 +443,7 @@ public:
     using SelfType = DasThreadLocal<T, TAG>;
 
     inline DasThreadLocal() {
-        if ( initCounter++ ) {
+        if ( initCounter.fetch_add(1, std::memory_order_relaxed) ) {
             DAS_ASSERTF(false, "Type with tag is already used, pls change tag!");
         }
     }
@@ -457,7 +458,7 @@ public:
 
 private:
     inline static thread_local T value_{};
-    inline static int initCounter = 0;
+    inline static std::atomic<int> initCounter{0};
 };
 
 #ifndef DAS_THREAD_LOCAL


### PR DESCRIPTION
Fix data race in `DasThreadLocal::initCounter` and improve concurrent init test.

Relates to #2027.

## Changes

### `include/daScript/misc/platform.h`
- `DasThreadLocal::initCounter` changed from `inline static int` to `inline static std::atomic<int>`
- Increment uses `fetch_add(1, std::memory_order_relaxed)` — correct for a uniqueness counter
- Added `#include <atomic>`

The old non-atomic `initCounter++` was a data race under C++ memory model when multiple threads construct `DasThreadLocal` instances concurrently (which happens during `NEED_ALL_DEFAULT_MODULES`). While the race didn't cause crashes on our test hardware, it is undefined behavior and may manifest on different compiler versions or platforms.

### `tests/threading/test_concurrent_init.cpp`
- Added `SpinBarrier` (C++17-compatible) to force all threads to start simultaneously for maximum contention
- Increased to 128 threads x 10 rounds (barrier-synced)
- Sequential test now also uses `numThreads` for consistency

## Testing
- Windows (MSVC 2022): build clean, 128 sequential + 10x128 concurrent all pass
- Linux (GCC 13, WSL2): 35+ full runs (each 10x128 threads) all pass
