### PR TITLE
Standalone CMake for integration tutorials + SDK build documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1216,6 +1216,17 @@ install(FILES
     DESTINATION include/vecmath
 )
 
+# Install dag_noise header (referenced by aot_builtin_math.h).
+install(FILES include/dag_noise/dag_uint_noise.h
+    DESTINATION include/dag_noise
+)
+
+# Install internal builtin headers (needed by integration tutorials like class adapters).
+file(GLOB DAS_BUILTIN_HEADERS ${PROJECT_SOURCE_DIR}/src/builtin/*.h)
+install(FILES ${DAS_BUILTIN_HEADERS}
+    DESTINATION include/daScript/builtin
+)
+
 # Install all modules and main library.
 install(TARGETS
     libDaScript libDaScriptDyn libUriParser libUriParserDyn

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -79,6 +79,19 @@ introduced in earlier tutorials.
    tutorials/49_async.rst
    tutorials/50_soa.rst
 
+.. _tutorials_building_from_sdk:
+
+Building from the Installed SDK
+================================
+
+Once daslang is installed, you can build the integration tutorials — or your
+own projects — against the SDK using CMake's ``find_package(DAS)``.
+
+.. toctree::
+   :maxdepth: 1
+
+   tutorials/building_from_sdk.rst
+
 .. _tutorials_integration_c:
 
 C Integration Tutorials
@@ -87,6 +100,10 @@ C Integration Tutorials
 These tutorials show how to embed daslang in a C application using the
 ``daScriptC.h`` API.  Each tutorial comes with a ``.c`` source file and a
 companion ``.das`` script in ``tutorials/integration/c/``.
+
+The installed SDK ships with a standalone ``CMakeLists.txt`` that lets you
+build all C tutorials directly against the SDK — see
+:ref:`tutorial_building_from_sdk`.
 
 .. toctree::
    :maxdepth: 1
@@ -110,6 +127,10 @@ C++ Integration Tutorials
 These tutorials show how to embed daslang in a C++ application using the
 native ``daScript.h`` API.  Each tutorial comes with a ``.cpp`` source file
 and a companion ``.das`` script in ``tutorials/integration/cpp/``.
+
+The installed SDK ships with a standalone ``CMakeLists.txt`` that lets you
+build all C++ tutorials directly against the SDK — see
+:ref:`tutorial_building_from_sdk`.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/reference/tutorials/building_from_sdk.rst
+++ b/doc/source/reference/tutorials/building_from_sdk.rst
@@ -1,0 +1,364 @@
+.. _tutorial_building_from_sdk:
+
+.. index::
+   single: Tutorial; Building from SDK
+   single: Tutorial; CMake; find_package
+   single: Tutorial; SDK; Installation
+   single: Tutorial; getDasRoot
+
+============================================
+ Building Projects Against the Installed SDK
+============================================
+
+This guide explains how to build your own C or C++ applications that embed
+daslang, using the installed SDK rather than building from the full source
+tree.  It also covers building the integration tutorials from the SDK.
+
+
+.. _building_from_sdk_prerequisites:
+
+Prerequisites
+=============
+
+* A daslang SDK installed via ``cmake --install``.  The default layout is::
+
+     <sdk-root>/
+       bin/             daslang.exe, libDaScript.dll
+       include/         daScript.h, daScriptC.h, etc.
+       lib/
+         cmake/DAS/     DASConfig.cmake, DASTargets.cmake
+       daslib/          Standard library modules
+       utils/           AOT tool scripts
+       tutorials/
+         integration/
+           cpp/         C++ tutorial sources + CMakeLists.txt
+           c/           C tutorial sources + CMakeLists.txt
+
+* CMake 3.16 or later.
+* A C++17 compiler (MSVC 2019+, GCC 9+, Clang 10+).
+
+
+.. _building_from_sdk_find_package:
+
+Using ``find_package(DAS)``
+===========================
+
+The SDK ships a CMake package configuration that provides imported targets.
+In your ``CMakeLists.txt``:
+
+.. code-block:: cmake
+
+   cmake_minimum_required(VERSION 3.16)
+   project(my_daslang_app CXX)
+
+   find_package(DAS REQUIRED)
+   find_package(Threads REQUIRED)
+
+Point CMake to the SDK root when configuring:
+
+.. code-block:: bash
+
+   cmake -DCMAKE_PREFIX_PATH=/path/to/daslang ..
+
+``find_package(DAS)`` sets the following:
+
+=========================  ==============================================
+Variable / Target          Description
+=========================  ==============================================
+``DAS::libDaScriptDyn``    Shared library (``libDaScript.dll`` / ``.so``)
+``DAS::libDaScript``       Static library
+``DAS::daslang``           The ``daslang`` executable (for AOT codegen)
+``DAS_VERSION``            SDK version string (e.g. ``0.6.0``)
+``DAS_DIR``                Path to ``lib/cmake/DAS/``
+=========================  ==============================================
+
+.. tip::
+
+   Always link against ``DAS::libDaScriptDyn`` (the shared library) for
+   tutorial and application builds.  This avoids having to rebuild the entire
+   engine and keeps binary size small.
+
+
+.. _building_from_sdk_minimal:
+
+A minimal project
+=================
+
+.. code-block:: cmake
+
+   cmake_minimum_required(VERSION 3.16)
+   project(hello_daslang CXX)
+
+   find_package(DAS REQUIRED)
+   find_package(Threads REQUIRED)
+
+   # Derive SDK root from the DAS package location.
+   get_filename_component(DAS_SDK_ROOT "${DAS_DIR}/../../.." ABSOLUTE)
+
+   # Place executables in <sdk>/bin/ so getDasRoot() resolves correctly.
+   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DAS_SDK_ROOT}/bin")
+
+   add_executable(hello_daslang main.cpp)
+   target_compile_definitions(hello_daslang PRIVATE DAS_MOD_EXPORTS)
+   target_link_libraries(hello_daslang PRIVATE DAS::libDaScriptDyn Threads::Threads)
+   target_compile_features(hello_daslang PRIVATE cxx_std_17)
+
+Key points:
+
+``DAS_MOD_EXPORTS``
+   Required preprocessor definition — ensures correct DLL import/export
+   declarations on Windows.
+
+``Threads::Threads``
+   Required on all platforms — daslang uses threading internally.
+
+``CMAKE_RUNTIME_OUTPUT_DIRECTORY``
+   Set to ``<sdk>/bin/`` so the executable lands next to ``daslang.exe``.
+   This is important because ``getDasRoot()`` auto-detects the SDK root by
+   walking up from the executable's location, looking for a ``bin/`` parent
+   directory.  If your executable is in a different location, ``getDasRoot()``
+   will return the wrong path and the runtime will fail to find ``daslib/``,
+   scripts, and other SDK resources.
+
+For C programs, the pattern is similar — use ``target_link_libraries`` with
+``DAS::libDaScriptDyn`` and set ``LINKER_LANGUAGE CXX`` since the daslang
+runtime is C++:
+
+.. code-block:: cmake
+
+   add_executable(hello_daslang_c main.c)
+   target_compile_definitions(hello_daslang_c PRIVATE DAS_MOD_EXPORTS)
+   target_link_libraries(hello_daslang_c PRIVATE DAS::libDaScriptDyn Threads::Threads)
+   set_target_properties(hello_daslang_c PROPERTIES
+       LINKER_LANGUAGE CXX
+       CXX_STANDARD 17
+   )
+
+
+.. _building_from_sdk_getdasroot:
+
+Understanding ``getDasRoot()``
+==============================
+
+``getDasRoot()`` is a function that returns the root directory of the
+daslang SDK as a string.  The integration tutorials use it to build paths to
+``.das`` scripts:
+
+.. code-block:: cpp
+
+   auto program = compileDaScript(getDasRoot() + "/tutorials/integration/cpp/01_hello_world.das",
+                                  fAccess, tout, dummyLibGroup);
+
+Internally, ``getDasRoot()`` locates the directory of the running executable,
+then walks up the path looking for a ``bin/`` parent.  When it finds one, it
+returns the parent of ``bin/`` as the SDK root.
+
+This means your executable **must** be placed in ``<sdk>/bin/`` for
+``getDasRoot()`` to work correctly.  The recommended CMake pattern is:
+
+.. code-block:: cmake
+
+   get_filename_component(DAS_SDK_ROOT "${DAS_DIR}/../../.." ABSOLUTE)
+   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DAS_SDK_ROOT}/bin")
+
+
+.. _building_from_sdk_aot:
+
+Adding AOT compilation
+======================
+
+AOT (Ahead-of-Time) compilation translates daslang functions into C++ source
+code at build time for near-native performance.  The SDK includes the AOT
+tool scripts in ``utils/aot/main.das``.
+
+To add AOT to your CMake project, define a macro that runs ``daslang`` as a
+build tool:
+
+.. code-block:: cmake
+
+   # Derive SDK root
+   get_filename_component(DAS_SDK_ROOT "${DAS_DIR}/../../.." ABSOLUTE)
+
+   macro(MY_AOT_GENERATE input out_var target_name)
+       get_filename_component(_abs "${input}" ABSOLUTE)
+       get_filename_component(_name "${input}" NAME)
+       set(_out_dir "${CMAKE_CURRENT_BINARY_DIR}/_aot_generated")
+       set(_out_src "${_out_dir}/${target_name}_${_name}.cpp")
+       file(MAKE_DIRECTORY "${_out_dir}")
+       add_custom_command(
+           OUTPUT  "${_out_src}"
+           DEPENDS "${_abs}"
+           COMMENT "AOT: ${_name}"
+           COMMAND $<TARGET_FILE:DAS::daslang>
+                   "${DAS_SDK_ROOT}/utils/aot/main.das"
+                   -- -aot "${_abs}" "${_out_src}"
+       )
+       set(${out_var} "${_out_src}")
+       set_source_files_properties("${_out_src}" PROPERTIES GENERATED TRUE)
+   endmacro()
+
+Then use it:
+
+.. code-block:: cmake
+
+   set(AOT_SRC)
+   MY_AOT_GENERATE("my_script.das" AOT_SRC my_app)
+
+   add_executable(my_app main.cpp "${AOT_SRC}")
+   target_compile_definitions(my_app PRIVATE DAS_MOD_EXPORTS)
+   target_link_libraries(my_app PRIVATE DAS::libDaScriptDyn Threads::Threads)
+   target_compile_features(my_app PRIVATE cxx_std_17)
+
+The command invoked is::
+
+   daslang.exe <sdk>/utils/aot/main.das -- -aot my_script.das output.cpp
+
+The ``-aot`` flag generates a ``.cpp`` file with C++ implementations of all
+daslang functions plus self-registration code.  At runtime, when
+``CodeOfPolicies::aot`` is set to ``true``, ``simulate()`` links the
+AOT-compiled functions automatically — no additional setup needed.
+
+For standalone-context generation (``-ctx`` mode), see
+:ref:`tutorial_integration_cpp_standalone_contexts`.
+
+
+.. _building_from_sdk_tutorials:
+
+Building the integration tutorials
+===================================
+
+The SDK ships with ready-to-use ``CMakeLists.txt`` files for all integration
+tutorials.  After installing, you can build them directly from the SDK.
+
+
+C++ tutorials
+-------------
+
+.. code-block:: bash
+
+   mkdir build_cpp && cd build_cpp
+   cmake -DCMAKE_PREFIX_PATH=/path/to/daslang /path/to/daslang/tutorials/integration/cpp
+   cmake --build . --config Release
+
+This builds all 22 C++ integration tutorials.  The executables are placed
+in ``<sdk>/bin/`` and can be run directly from there.
+
+On Windows with a typical install to ``D:\daslang``:
+
+.. code-block:: powershell
+
+   mkdir build_cpp; cd build_cpp
+   cmake -DCMAKE_PREFIX_PATH=D:\daslang D:\daslang\tutorials\integration\cpp
+   cmake --build . --config Release
+   D:\daslang\bin\integration_cpp_01.exe
+
+C tutorials
+-----------
+
+.. code-block:: bash
+
+   mkdir build_c && cd build_c
+   cmake -DCMAKE_PREFIX_PATH=/path/to/daslang /path/to/daslang/tutorials/integration/c
+   cmake --build . --config Release
+
+This builds all 10 C integration tutorials.  On Windows:
+
+.. code-block:: powershell
+
+   mkdir build_c; cd build_c
+   cmake -DCMAKE_PREFIX_PATH=D:\daslang D:\daslang\tutorials\integration\c
+   cmake --build . --config Release
+   D:\daslang\bin\integration_c_01.exe
+
+
+Individual targets
+------------------
+
+You can build a single tutorial by specifying its target name::
+
+   cmake --build . --config Release --target integration_cpp_01
+
+Target names follow the pattern ``integration_cpp_NN`` and
+``integration_c_NN``.
+
+
+AOT tutorials
+-------------
+
+The AOT tutorials (C++ tutorial 13, C tutorial 09) are included in the
+standalone builds.  CMake automatically runs ``daslang`` to generate the
+AOT C++ source from the ``.das`` script during the build.  No additional
+steps are needed — just build as shown above.
+
+For details on how AOT is integrated in CMake, see
+:ref:`tutorial_integration_cpp_aot` and :ref:`tutorial_integration_c_aot`.
+
+
+.. _building_from_sdk_targets:
+
+Available imported targets
+==========================
+
+The following CMake targets are available after ``find_package(DAS REQUIRED)``:
+
+``DAS::libDaScriptDyn``
+   The daslang shared library.  Use this for application builds.
+   Includes all necessary include directories and compile definitions
+   transitively — you do not need to add ``target_include_directories``
+   manually.
+
+``DAS::libDaScript``
+   The daslang static library.  Links the entire engine statically.
+   Produces larger binaries but removes the DLL dependency.
+
+``DAS::daslang``
+   The ``daslang`` command-line tool.  Use it in ``add_custom_command``
+   for AOT code generation.  Access via ``$<TARGET_FILE:DAS::daslang>``.
+
+
+.. _building_from_sdk_troubleshooting:
+
+Troubleshooting
+===============
+
+"Could not find a package configuration file provided by DAS"
+   Ensure ``CMAKE_PREFIX_PATH`` points to the SDK root (the directory
+   containing ``lib/cmake/DAS/``).
+
+Scripts not found at runtime
+   Make sure the executable is in ``<sdk>/bin/``.  Set
+   ``CMAKE_RUNTIME_OUTPUT_DIRECTORY`` to ``${DAS_SDK_ROOT}/bin``.
+   If you cannot place the executable there, you must modify the source
+   to set the DAS root explicitly instead of relying on ``getDasRoot()``.
+
+AOT header not found (``dag_noise/dag_uint_noise.h``, ``module_builtin_*.h``)
+   These headers are installed under ``<sdk>/include/``.  If your AOT-generated
+   code includes them and the compiler cannot find them, verify that
+   ``DAS::libDaScriptDyn`` is listed in ``target_link_libraries`` — it
+   provides the include directories transitively.
+
+Linker errors on Windows
+   Make sure you define ``DAS_MOD_EXPORTS`` on your target:
+   ``target_compile_definitions(my_app PRIVATE DAS_MOD_EXPORTS)``.
+
+Multi-config generators (Visual Studio)
+   If executables end up in ``bin/Release/`` instead of ``bin/``, set the
+   per-config output directory explicitly:
+
+   .. code-block:: cmake
+
+      foreach(cfg DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+          set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${cfg} "${DAS_SDK_ROOT}/bin")
+      endforeach()
+
+
+.. seealso::
+
+   :ref:`tutorial_integration_cpp_hello_world` — your first C++ daslang program
+
+   :ref:`tutorial_integration_c_hello_world` — your first C daslang program
+
+   :ref:`tutorial_integration_cpp_aot` — AOT compilation in depth (C++)
+
+   :ref:`tutorial_integration_c_aot` — AOT compilation in depth (C)
+

--- a/doc/source/reference/tutorials/integration_c_01_hello_world.rst
+++ b/doc/source/reference/tutorials/integration_c_01_hello_world.rst
@@ -203,6 +203,9 @@ Expected output::
 
    Hello from daslang!
 
+You can also build all C integration tutorials from the installed SDK
+— see :ref:`tutorial_building_from_sdk`.
+
 
 .. seealso::
 
@@ -211,6 +214,8 @@ Expected output::
    :download:`01_hello_world.das <../../../../tutorials/integration/c/01_hello_world.das>`
 
    Next tutorial: :ref:`tutorial_integration_c_calling_functions`
+
+   Building from the SDK: :ref:`tutorial_building_from_sdk`
 
    :ref:`type_mangling` — how types are encoded as strings in the C API
 

--- a/doc/source/reference/tutorials/integration_c_09_aot.rst
+++ b/doc/source/reference/tutorials/integration_c_09_aot.rst
@@ -102,6 +102,9 @@ Enum value                                CodeOfPolicies field
 Build & run
 ===========
 
+From the source tree
+--------------------
+
 Build::
 
    cmake --build build --config Release --target integration_c_09
@@ -110,7 +113,47 @@ Run::
 
    bin/Release/integration_c_09
 
-Expected output::
+From the installed SDK
+-----------------------
+
+The installed SDK includes a standalone ``CMakeLists.txt`` for all C
+integration tutorials.  Configure and build against the SDK:
+
+.. code-block:: bash
+
+   mkdir build_c && cd build_c
+   cmake -DCMAKE_PREFIX_PATH=/path/to/daslang /path/to/daslang/tutorials/integration/c
+   cmake --build . --config Release
+
+On Windows:
+
+.. code-block:: powershell
+
+   mkdir build_c; cd build_c
+   cmake -DCMAKE_PREFIX_PATH=D:\daslang D:\daslang\tutorials\integration\c
+   cmake --build . --config Release
+
+The standalone ``CMakeLists.txt`` handles AOT code generation automatically.
+It reuses the same ``13_aot.das`` script from the C++ tutorials:
+
+.. code-block:: cmake
+
+   set(AOT_C09_SRC)
+   DAS_TUTORIAL_AOT("${CPP_TUT_DIR}/13_aot.das" -aot AOT_C09_SRC integration_c_09)
+
+   DAS_C_TUTORIAL(integration_c_09
+       "${TUT_DIR}/09_aot.c"
+       "${AOT_C09_SRC}"
+   )
+
+See :ref:`tutorial_building_from_sdk` for the full guide on building your own
+projects with AOT support.
+
+
+Expected output
+----------------
+
+::
 
    === Interpreter mode ===
      test() is AOT: no
@@ -144,5 +187,7 @@ Expected output::
    Next tutorial: :ref:`tutorial_integration_c_threading`
 
    C++ equivalent: :ref:`tutorial_integration_cpp_aot`
+
+   Building from the SDK: :ref:`tutorial_building_from_sdk`
 
    daScriptC.h API header: ``include/daScript/daScriptC.h``

--- a/doc/source/reference/tutorials/integration_cpp_01_hello_world.rst
+++ b/doc/source/reference/tutorials/integration_cpp_01_hello_world.rst
@@ -242,12 +242,17 @@ Expected output::
 
    Hello from daslang!
 
+You can also build all C++ integration tutorials from the installed SDK
+— see :ref:`tutorial_building_from_sdk`.
+
 
 .. seealso::
 
    Full source:
    :download:`01_hello_world.cpp <../../../../tutorials/integration/cpp/01_hello_world.cpp>`,
    :download:`01_hello_world.das <../../../../tutorials/integration/cpp/01_hello_world.das>`
+
+   Building from the SDK: :ref:`tutorial_building_from_sdk`
 
    Next tutorial: :ref:`tutorial_integration_cpp_calling_functions`
 

--- a/tutorials/integration/c/CMakeLists.standalone.cmake
+++ b/tutorials/integration/c/CMakeLists.standalone.cmake
@@ -1,0 +1,113 @@
+###########################################################
+# C Integration Tutorials — standalone build against
+# an installed daslang SDK.
+#
+# Usage:
+#   cmake -DCMAKE_PREFIX_PATH=<sdk-root> <this-directory>
+#   cmake --build . --config Release
+#
+# Example (Windows):
+#   mkdir build && cd build
+#   cmake -DCMAKE_PREFIX_PATH=D:/daslang ..
+#   cmake --build . --config Release
+#
+# The built executables are placed into <sdk-root>/bin/ so
+# that getDasRoot() automatically resolves the SDK root at
+# runtime and finds daslib/, tutorials/, etc.
+###########################################################
+
+cmake_minimum_required(VERSION 3.16)
+project(daslang_c_tutorials C CXX)
+
+find_package(DAS REQUIRED)
+find_package(Threads REQUIRED)
+
+# Resolve the SDK root (two levels up from lib/cmake/DAS/).
+get_filename_component(DAS_SDK_ROOT "${DAS_DIR}/../../.." ABSOLUTE)
+message(STATUS "daslang SDK root: ${DAS_SDK_ROOT}")
+
+# Put executables into the SDK bin/ directory so getDasRoot()
+# finds daslib/, tutorials/, etc. without any source changes.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DAS_SDK_ROOT}/bin")
+foreach(cfg DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${cfg} "${DAS_SDK_ROOT}/bin")
+endforeach()
+
+# Source directory (where the tutorial .c/.das files live).
+set(TUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# The C++ integration tutorials directory (needed for 13_aot.das
+# which is shared with C tutorial 09).
+get_filename_component(CPP_TUT_DIR "${TUT_DIR}/../cpp" ABSOLUTE)
+
+###########################################################
+# Helper macro — standard C integration tutorial target.
+# C source is compiled as C but linked with C++ (the daScript
+# runtime is C++).
+###########################################################
+macro(DAS_C_TUTORIAL name)
+    add_executable(${name} ${ARGN})
+    target_compile_definitions(${name} PRIVATE DAS_MOD_EXPORTS)
+    target_link_libraries(${name} PRIVATE DAS::libDaScriptDyn Threads::Threads)
+    set_target_properties(${name} PROPERTIES
+        LINKER_LANGUAGE CXX
+        CXX_STANDARD 17
+    )
+    if(MSVC)
+        target_compile_options(${name} PRIVATE /wd4005)
+    endif()
+endmacro()
+
+###########################################################
+# Helper: AOT code generation (same as C++ variant).
+###########################################################
+macro(DAS_TUTORIAL_AOT input mode out_var target_name)
+    get_filename_component(_abs_input "${input}" ABSOLUTE)
+    get_filename_component(_input_name "${input}" NAME)
+    if("${mode}" STREQUAL "-ctx")
+        set(_out_dir "${CMAKE_CURRENT_BINARY_DIR}/_standalone_ctx_generated")
+        set(_out_arg "${_out_dir}/")
+        set(_out_src "${_out_dir}/${_input_name}.cpp")
+    else()
+        set(_out_dir "${CMAKE_CURRENT_BINARY_DIR}/_aot_generated")
+        set(_out_arg "${_out_dir}/${target_name}_${_input_name}.cpp")
+        set(_out_src "${_out_dir}/${target_name}_${_input_name}.cpp")
+    endif()
+    file(MAKE_DIRECTORY "${_out_dir}")
+    add_custom_command(
+        OUTPUT  "${_out_src}"
+        DEPENDS "${_abs_input}"
+        COMMENT "AOT: ${_input_name} (${mode})"
+        COMMAND $<TARGET_FILE:DAS::daslang>
+                "${DAS_SDK_ROOT}/utils/aot/main.das"
+                -- ${mode} "${_abs_input}" "${_out_arg}"
+    )
+    set(${out_var} "${_out_src}")
+    set_source_files_properties("${_out_src}" PROPERTIES GENERATED TRUE)
+endmacro()
+
+###########################################################
+# Simple tutorials (01–08, 10)
+###########################################################
+DAS_C_TUTORIAL(integration_c_01 "${TUT_DIR}/01_hello_world.c")
+DAS_C_TUTORIAL(integration_c_02 "${TUT_DIR}/02_calling_functions.c")
+DAS_C_TUTORIAL(integration_c_03 "${TUT_DIR}/03_binding_types.c")
+DAS_C_TUTORIAL(integration_c_04 "${TUT_DIR}/04_callbacks.c")
+DAS_C_TUTORIAL(integration_c_05 "${TUT_DIR}/05_unaligned_advanced.c")
+DAS_C_TUTORIAL(integration_c_06 "${TUT_DIR}/06_sandbox.c")
+DAS_C_TUTORIAL(integration_c_07 "${TUT_DIR}/07_context_variables.c")
+DAS_C_TUTORIAL(integration_c_08 "${TUT_DIR}/08_serialization.c")
+DAS_C_TUTORIAL(integration_c_10 "${TUT_DIR}/10_threading.c")
+
+###########################################################
+# Tutorial 09 — AOT (C)
+#
+# Reuses the same 13_aot.das script from the C++ tutorials.
+###########################################################
+set(AOT_C09_SRC)
+DAS_TUTORIAL_AOT("${CPP_TUT_DIR}/13_aot.das" -aot AOT_C09_SRC integration_c_09)
+
+DAS_C_TUTORIAL(integration_c_09
+    "${TUT_DIR}/09_aot.c"
+    "${AOT_C09_SRC}"
+)

--- a/tutorials/integration/c/CMakeLists.txt
+++ b/tutorials/integration/c/CMakeLists.txt
@@ -112,3 +112,10 @@ file(GLOB C_INTEGRATION_TUTORIAL_SOURCES
 install(FILES ${C_INTEGRATION_TUTORIAL_SOURCES}
     DESTINATION ${DAS_INSTALL_TUTORIALSDIR}/integration/c
 )
+
+# Install standalone CMakeLists.txt for building tutorials against the installed SDK.
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/integration/c/CMakeLists.standalone.cmake
+    DESTINATION ${DAS_INSTALL_TUTORIALSDIR}/integration/c
+    RENAME CMakeLists.txt
+)

--- a/tutorials/integration/cpp/CMakeLists.standalone.cmake
+++ b/tutorials/integration/cpp/CMakeLists.standalone.cmake
@@ -1,0 +1,149 @@
+###########################################################
+# C++ Integration Tutorials — standalone build against
+# an installed daslang SDK.
+#
+# Usage:
+#   cmake -DCMAKE_PREFIX_PATH=<sdk-root> <this-directory>
+#   cmake --build . --config Release
+#
+# Example (Windows):
+#   mkdir build && cd build
+#   cmake -DCMAKE_PREFIX_PATH=D:/daslang ..
+#   cmake --build . --config Release
+#
+# The built executables are placed into <sdk-root>/bin/ so
+# that getDasRoot() automatically resolves the SDK root at
+# runtime and finds daslib/, tutorials/, etc.
+###########################################################
+
+cmake_minimum_required(VERSION 3.16)
+project(daslang_cpp_tutorials CXX)
+
+find_package(DAS REQUIRED)
+find_package(Threads REQUIRED)
+
+# Resolve the SDK root (two levels up from lib/cmake/DAS/).
+get_filename_component(DAS_SDK_ROOT "${DAS_DIR}/../../.." ABSOLUTE)
+message(STATUS "daslang SDK root: ${DAS_SDK_ROOT}")
+
+# Put executables into the SDK bin/ directory so getDasRoot()
+# finds daslib/, tutorials/, etc. without any source changes.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DAS_SDK_ROOT}/bin")
+# Multi-config generators (Visual Studio) append a per-config subdirectory.
+# Force all configs into the same bin/ folder.
+foreach(cfg DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${cfg} "${DAS_SDK_ROOT}/bin")
+endforeach()
+
+# Source directory (where the tutorial .cpp/.das files live).
+set(TUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+###########################################################
+# Helper macro — standard C++ integration tutorial target.
+###########################################################
+macro(DAS_CPP_TUTORIAL name)
+    add_executable(${name} ${ARGN})
+    target_compile_definitions(${name} PRIVATE DAS_MOD_EXPORTS)
+    target_link_libraries(${name} PRIVATE DAS::libDaScriptDyn Threads::Threads)
+    target_compile_features(${name} PRIVATE cxx_std_17)
+    if(MSVC)
+        target_compile_options(${name} PRIVATE /wd4005)
+    endif()
+endmacro()
+
+###########################################################
+# Helper: AOT code generation.
+#
+# Runs:  daslang <sdk>/utils/aot/main.das -- <mode> <input> <output>
+#
+# mode is -aot (generates .cpp) or -ctx (generates dir/ with .h + .cpp)
+###########################################################
+macro(DAS_TUTORIAL_AOT input mode out_var target_name)
+    get_filename_component(_abs_input "${input}" ABSOLUTE)
+    get_filename_component(_input_name "${input}" NAME)
+    if("${mode}" STREQUAL "-ctx")
+        set(_out_dir "${CMAKE_CURRENT_BINARY_DIR}/_standalone_ctx_generated")
+        set(_out_arg "${_out_dir}/")
+        set(_out_src "${_out_dir}/${_input_name}.cpp")
+    else()
+        set(_out_dir "${CMAKE_CURRENT_BINARY_DIR}/_aot_generated")
+        set(_out_arg "${_out_dir}/${target_name}_${_input_name}.cpp")
+        set(_out_src "${_out_dir}/${target_name}_${_input_name}.cpp")
+    endif()
+    file(MAKE_DIRECTORY "${_out_dir}")
+    add_custom_command(
+        OUTPUT  "${_out_src}"
+        DEPENDS "${_abs_input}"
+        COMMENT "AOT: ${_input_name} (${mode})"
+        COMMAND $<TARGET_FILE:DAS::daslang>
+                "${DAS_SDK_ROOT}/utils/aot/main.das"
+                -- ${mode} "${_abs_input}" "${_out_arg}"
+    )
+    set(${out_var} "${_out_src}")
+    set_source_files_properties("${_out_src}" PROPERTIES GENERATED TRUE)
+endmacro()
+
+###########################################################
+# Simple tutorials (01–12, 14–18, 21–22)
+###########################################################
+DAS_CPP_TUTORIAL(integration_cpp_01 "${TUT_DIR}/01_hello_world.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_02 "${TUT_DIR}/02_calling_functions.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_03 "${TUT_DIR}/03_binding_functions.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_04 "${TUT_DIR}/04_binding_types.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_05 "${TUT_DIR}/05_binding_enums.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_06 "${TUT_DIR}/06_interop.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_07 "${TUT_DIR}/07_callbacks.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_08 "${TUT_DIR}/08_methods.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_09 "${TUT_DIR}/09_operators_and_properties.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_10 "${TUT_DIR}/10_custom_modules.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_11 "${TUT_DIR}/11_context_variables.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_12 "${TUT_DIR}/12_smart_pointers.cpp")
+
+DAS_CPP_TUTORIAL(integration_cpp_14 "${TUT_DIR}/14_serialization.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_15 "${TUT_DIR}/15_custom_annotations.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_16 "${TUT_DIR}/16_sandbox.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_17 "${TUT_DIR}/17_coroutines.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_18 "${TUT_DIR}/18_dynamic_scripts.cpp")
+
+DAS_CPP_TUTORIAL(integration_cpp_21 "${TUT_DIR}/21_threading.cpp")
+DAS_CPP_TUTORIAL(integration_cpp_22 "${TUT_DIR}/22_namespace_integration.cpp")
+
+###########################################################
+# Tutorial 13 — AOT
+###########################################################
+set(AOT_13_SRC)
+DAS_TUTORIAL_AOT("${TUT_DIR}/13_aot.das" -aot AOT_13_SRC integration_cpp_13)
+
+DAS_CPP_TUTORIAL(integration_cpp_13
+    "${TUT_DIR}/13_aot.cpp"
+    "${AOT_13_SRC}"
+)
+
+###########################################################
+# Tutorial 19 — Class Adapters
+#
+# Requires module_builtin_rtti.h (installed to
+# <sdk>/include/daScript/builtin/) and the pre-generated
+# .das.inc and _gen.inc files.
+###########################################################
+DAS_CPP_TUTORIAL(integration_cpp_19
+    "${TUT_DIR}/19_class_adapters.cpp"
+)
+target_include_directories(integration_cpp_19 PRIVATE
+    "${DAS_SDK_ROOT}/include/daScript/builtin"
+)
+
+###########################################################
+# Tutorial 20 — Standalone Context
+###########################################################
+set(AOT_20_SRC)
+DAS_TUTORIAL_AOT("${TUT_DIR}/standalone_context.das" -ctx AOT_20_SRC integration_cpp_20)
+
+# The -ctx generator also produces a .h header in the output dir.
+DAS_CPP_TUTORIAL(integration_cpp_20
+    "${TUT_DIR}/20_standalone_context.cpp"
+    "${AOT_20_SRC}"
+)
+target_include_directories(integration_cpp_20 PRIVATE
+    "${CMAKE_CURRENT_BINARY_DIR}"
+)

--- a/tutorials/integration/cpp/CMakeLists.txt
+++ b/tutorials/integration/cpp/CMakeLists.txt
@@ -203,8 +203,16 @@ file(GLOB CPP_INTEGRATION_TUTORIAL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/integration/cpp/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/integration/cpp/*.h
     ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/integration/cpp/*.das
-    ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/integration/cpp/*.das.inc
+    ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/integration/cpp/*.inc
+    ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/integration/cpp/*.das_project
 )
 install(FILES ${CPP_INTEGRATION_TUTORIAL_SOURCES}
     DESTINATION ${DAS_INSTALL_TUTORIALSDIR}/integration/cpp
+)
+
+# Install standalone CMakeLists.txt for building tutorials against the installed SDK.
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/integration/cpp/CMakeLists.standalone.cmake
+    DESTINATION ${DAS_INSTALL_TUTORIALSDIR}/integration/cpp
+    RENAME CMakeLists.txt
 )


### PR DESCRIPTION
## Summary

Add standalone CMake files so integration tutorials can be built from the installed SDK, fix install gaps, and add documentation on building projects against the SDK.

## Standalone CMake files

Two new `CMakeLists.standalone.cmake` files (installed as `CMakeLists.txt` into the SDK):

- **C++ tutorials** (`tutorials/integration/cpp/`) — builds all 22 tutorials via `find_package(DAS)`
- **C tutorials** (`tutorials/integration/c/`) — builds all 10 tutorials

Usage from the installed SDK:
```bash
mkdir build && cd build
cmake -DCMAKE_PREFIX_PATH=/path/to/daslang /path/to/daslang/tutorials/integration/cpp
cmake --build . --config Release
```

Both include AOT code generation macros that run `daslang` during the build (C++ tutorial 13, C tutorial 09). Executables are placed into `<sdk>/bin/` so `getDasRoot()` resolves correctly.

## Install gap fixes

- Install `dag_noise/dag_uint_noise.h` (needed by AOT-generated code)
- Install all `src/builtin/*.h` headers (needed by tutorial 19 class adapters)
- Fix tutorial install glob: `*.das.inc` → `*.inc` (catches `19_class_adapters_gen.inc`)
- Add `*.das_project` to tutorial install glob

## Documentation

- **New RST**: "Building Projects Against the Installed SDK" — covers `find_package(DAS)`, imported targets, minimal project template, `getDasRoot()`, AOT macro, building tutorials from SDK, troubleshooting
- **C++ AOT tutorial (13)**: expanded with SDK build instructions, standalone CMake snippets, and a reusable AOT macro for own projects
- **C AOT tutorial (09)**: expanded with SDK build instructions and standalone CMake snippets
- **Hello-world tutorials** (C and C++): added SDK build cross-references
- **tutorials.rst toctree**: new "Building from the Installed SDK" section

## Verified

- All 22 C++ tutorials build and run from the installed SDK
- All 10 C tutorials build and run from the installed SDK
- In-tree build unaffected
- Sphinx docs build with zero errors/warnings
