### PR TITLE
fix: skip zero-size init in ExprMakeArray for empty variant/struct/tuple

### DIFF
--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -862,7 +862,9 @@ namespace das
             int bytes = total * stride;
             SimNode * init0;
             if ( useCMRES ) {
-                if ( bytes <= 32 ) {
+                if ( bytes==0 ) {
+                    init0 = nullptr;
+                } else if ( bytes <= 32 ) {
                     init0 = context.code->makeNodeUnrollNZ<SimNode_InitLocalCMResN>(bytes, at,extraOffset);
                 } else {
                     init0 = context.code->makeNode<SimNode_InitLocalCMRes>(at,extraOffset,bytes);
@@ -872,7 +874,7 @@ namespace das
             } else {
                 init0 = context.code->makeNode<SimNode_InitLocal>(at,stackTop + extraOffset,stride * total);
             }
-            simlist.push_back(init0);
+            if ( init0 ) simlist.push_back(init0);
         }
         for ( int index=0; index != total; ++index ) {
             auto & val = values[index];


### PR DESCRIPTION
When `ExprMakeArray` simulates an array of empty variants, structures, or tuples (stride × total = 0 bytes), it would call `SimNode_InitLocalCMResN` with 0 bytes, which is invalid.

This patch adds a check: if `bytes == 0`, skip the init node entirely (set `init0 = nullptr` and guard the `simlist.push_back`). The individual element `make` nodes still run correctly — there's just nothing to zero-initialize.
