### PR TITLE
macOS: ad-hoc code sign installed binaries to prevent Gatekeeper quarantine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1395,3 +1395,33 @@ if(DAS_BUILD_DOCUMENTATION)
                         "Install Python 3 and run: pip install sphinx sphinx-rtd-theme")
     endif()
 endif()
+
+# macOS: ad-hoc code sign all installed binaries and shared libraries.
+# This prevents Gatekeeper from quarantining downloaded SDK artifacts
+# ("cannot be opened because the developer cannot be verified").
+if(APPLE)
+    install(CODE [[
+        message(STATUS "Ad-hoc code signing installed binaries...")
+        file(GLOB_RECURSE _sign_targets
+            "${CMAKE_INSTALL_PREFIX}/*.dylib"
+            "${CMAKE_INSTALL_PREFIX}/*.shared_module"
+            "${CMAKE_INSTALL_PREFIX}/bin/*"
+        )
+        foreach(_f IN LISTS _sign_targets)
+            if(IS_SYMLINK "${_f}")
+                continue()
+            endif()
+            execute_process(
+                COMMAND codesign --force --sign - "${_f}"
+                RESULT_VARIABLE _sign_result
+                ERROR_VARIABLE  _sign_err
+                OUTPUT_QUIET
+            )
+            if(_sign_result EQUAL 0)
+                message(STATUS "  Signed: ${_f}")
+            else()
+                message(WARNING "  Failed to sign ${_f}: ${_sign_err}")
+            endif()
+        endforeach()
+    ]])
+endif()

--- a/install/README.md
+++ b/install/README.md
@@ -70,6 +70,16 @@ cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
 cmake --build build --target daslang --config Release
 ```
 
+## macOS: Gatekeeper Quarantine
+
+If macOS blocks the downloaded SDK with errors like *"cannot be opened because the developer cannot be verified"* or *"is damaged and can't be opened"*, remove the quarantine attribute:
+
+```sh
+xattr -cr /path/to/daslang-sdk
+```
+
+Binaries produced by `cmake --install` are ad-hoc code signed automatically, which prevents this issue in most cases.
+
 ## License
 
 BSD 3-Clause License — Copyright (c) 2019-2026, Gaijin Entertainment.


### PR DESCRIPTION
## macOS: ad-hoc code sign installed binaries

When users download a pre-built daslang SDK on macOS, Gatekeeper quarantines the unsigned `.dylib` and `.shared_module` files, showing errors like:

- *"cannot be opened because the developer cannot be verified"*
- *"is damaged and can't be opened"*

### Changes

**CMakeLists.txt** — added an `install(CODE ...)` block at the end that runs on macOS during `cmake --install`. It finds all `.dylib`, `.shared_module`, and `bin/*` files in the install prefix and signs them with `codesign --force --sign -` (ad-hoc signature). This doesn't require an Apple Developer account.

**install/README.md** — added a "macOS: Gatekeeper Quarantine" section documenting the `xattr -cr` workaround for users who download pre-built archives.
