### PR TITLE
compiler: revert NO_ASAN

### DIFF
--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -110,26 +110,6 @@
     #define ___noinline __declspec(noinline)
 #endif
 
-#if defined(__SANITIZE_ADDRESS__)
-    #ifndef _MSC_VER
-        #define DAS_SUPPRESS_ASAN __attribute__((no_sanitize("address")))
-    #else
-        #define DAS_SUPPRESS_ASAN __declspec(no_sanitize_address)
-    #endif
-#elif defined(__has_feature)
-    #if __has_feature(address_sanitizer)
-        #ifndef _MSC_VER
-            #define DAS_SUPPRESS_ASAN __attribute__((no_sanitize("address")))
-        #else
-            #define DAS_SUPPRESS_ASAN __declspec(no_sanitize_address)
-        #endif
-    #else
-        #define DAS_SUPPRESS_ASAN
-    #endif
-#else
-    #define DAS_SUPPRESS_ASAN
-#endif
-
 #if defined(__has_feature)
     #if __has_feature(undefined_behavior_sanitizer)
         #define DAS_SUPPRESS_UB  __attribute__((no_sanitize("undefined")))

--- a/include/daScript/simulate/cast.h
+++ b/include/daScript/simulate/cast.h
@@ -13,17 +13,16 @@ namespace das
     template <typename TT> struct WrapRetType { typedef TT type; };
 
     // gcc fails to deduce auto field type. We should manually add it
-    // NO_ASAN_INLINE should be removed once vecmath adds it to the vec3->vec4 conversions.
     template <typename T, typename Element, Element T::*BaseField = &T::x>
     struct WrapVec2Arg : T {
         WrapVec2Arg(vec4f t) : T(vec_extract<Element>::x(t), vec_extract<Element>::y(t)) {}
-        NO_ASAN_INLINE operator vec4f() const { return das::vec_loadu(&(this->*BaseField)); }
+        operator vec4f() const { return das::vec_loadu(&(this->*BaseField)); }
     };
 
     template <typename T, typename Element, Element T::*BaseField = &T::x>
     struct WrapVec3Arg : T {
         WrapVec3Arg(vec4f t) : T(vec_extract<Element>::x(t), vec_extract<Element>::y(t), vec_extract<Element>::z(t)) {}
-        NO_ASAN_INLINE operator vec4f() const { return das::vec_loadu(&(this->*BaseField)); }
+        operator vec4f() const { return das::vec_loadu(&(this->*BaseField)); }
     };
 
     template <typename T, typename Element, Element T::*BaseField = &T::x>

--- a/src/builtin/module_builtin_math.cpp
+++ b/src/builtin/module_builtin_math.cpp
@@ -355,17 +355,15 @@ namespace das {
         matrix_identity<4,4>((float*)&mat);
     }
 
-    // All DAS_SUPPRESS_ASAN should be removed here once it's added
-    // to the vecmath master.
-    DAS_SUPPRESS_ASAN void float3x4_identity ( float3x4 & mat ) {
+    void float3x4_identity ( float3x4 & mat ) {
         matrix_identity<4,3>((float*)&mat);
     }
 
-    DAS_SUPPRESS_ASAN void float3x3_identity ( float3x3 & mat ) {
+    void float3x3_identity ( float3x3 & mat ) {
         matrix_identity<3,3>((float*)&mat);
     }
 
-    DAS_SUPPRESS_ASAN float3x3 float3x3_neg ( const float3x3 & mat ) {
+    float3x3 float3x3_neg ( const float3x3 & mat ) {
         float3x3 res;
         res.m[0] = v_neg(mat.m[0]);
         res.m[1] = v_neg(mat.m[1]);
@@ -373,12 +371,12 @@ namespace das {
         return res;
     }
 
-    DAS_SUPPRESS_ASAN float float3x3_det ( const float3x3 & a ) {
+    float float3x3_det ( const float3x3 & a ) {
         mat33f va;  va.col0 = a.m[0]; va.col1 = a.m[1]; va.col2 = a.m[2];
         return v_extract_x(v_mat33_det(va));
     }
 
-    DAS_SUPPRESS_ASAN float3x4 float3x4_neg ( const float3x4 & mat ) {
+    float3x4 float3x4_neg ( const float3x4 & mat ) {
         float3x4 res;
         res.m[0] = v_neg(mat.m[0]);
         res.m[1] = v_neg(mat.m[1]);
@@ -411,7 +409,7 @@ namespace das {
         return mat;
     }
 
-    DAS_SUPPRESS_ASAN float4x4 float4x4_translation(float3 xyz) {
+    float4x4 float4x4_translation(float3 xyz) {
         float4x4 mat;
         matrix_identity<4,4>((float*)&mat);
         mat.m[3].x = xyz.x;
@@ -428,7 +426,7 @@ namespace das {
         return reinterpret_cast<float4x4&>(res);
     }
 
-    DAS_SUPPRESS_ASAN float3x3 float3x3_mul(const float3x3 &a, const float3x3 &b) {
+    float3x3 float3x3_mul(const float3x3 &a, const float3x3 &b) {
         float3x3 res;
         mat33f va;  va.col0 = a.m[0]; va.col1 = a.m[1]; va.col2 = a.m[2];
         res.m[0] = v_mat33_mul_vec3(va, b.m[0]);
@@ -460,14 +458,14 @@ namespace das {
         return reinterpret_cast<float4x4&>(invMat);
     }
 
-    DAS_SUPPRESS_ASAN float3x3 float3x3_inverse( const float3x3 & src) {
+    float3x3 float3x3_inverse( const float3x3 & src) {
         mat33f mat, invMat;
         memcpy(&mat, &src, sizeof(float3x3));
         v_mat33_inverse(invMat, mat);
         return reinterpret_cast<float3x3&>(invMat);
     }
 
-    DAS_SUPPRESS_ASAN float3x3 float3x3_orthonormal_inverse( const float3x3 & src) {
+    float3x3 float3x3_orthonormal_inverse( const float3x3 & src) {
         mat33f mat, invMat;
         memcpy(&mat, &src, sizeof(float3x3));
         v_mat33_orthonormal_inverse(invMat, mat);
@@ -486,19 +484,19 @@ namespace das {
         return reinterpret_cast<float4x4&>(mat);
     }
 
-    DAS_SUPPRESS_ASAN float4x4 float4x4_look_at(float3 eye, float3 at, float3 up) {
+    float4x4 float4x4_look_at(float3 eye, float3 at, float3 up) {
         mat44f mat;
         v_mat44_make_look_at(mat, eye, at, up);
         return reinterpret_cast<float4x4&>(mat);
     }
 
-    DAS_SUPPRESS_ASAN float4x4 float4x4_compose(float3 pos, float4 rot, float3 scale) {
+    float4x4 float4x4_compose(float3 pos, float4 rot, float3 scale) {
         mat44f mat;
         v_mat44_compose(mat, pos, rot, scale);
         return reinterpret_cast<float4x4&>(mat);
     }
 
-    DAS_SUPPRESS_ASAN void float4x4_decompose(const float4x4 & mat, float3 & pos, float4 & rot, float3 & scale) {
+    void float4x4_decompose(const float4x4 & mat, float3 & pos, float4 & rot, float3 & scale) {
         mat44f gmat;
         memcpy(&gmat, &mat, sizeof(float4x4));
         vec3f gpos;
@@ -510,19 +508,19 @@ namespace das {
         scale = gscale;
     }
 
-    DAS_SUPPRESS_ASAN float4 quat_from_unit_arc(float3 v0, float3 v1) {
+    float4 quat_from_unit_arc(float3 v0, float3 v1) {
         return v_quat_from_unit_arc(v_ldu(&v0.x), v_ldu(&v1.x));
     }
 
-    DAS_SUPPRESS_ASAN float4 quat_from_unit_vec_ang(float3 v, float ang) {
+    float4 quat_from_unit_vec_ang(float3 v, float ang) {
         return v_quat_from_unit_vec_ang(v_ldu(&v.x), v_splats(ang));
     }
 
-    DAS_SUPPRESS_ASAN float4 quat_from_euler_vec(float3 v) {
+    float4 quat_from_euler_vec(float3 v) {
         return v_quat_from_euler(v_ldu(&v.x));
     }
 
-    DAS_SUPPRESS_ASAN float4 quat_from_euler(float x, float y, float z) {
+    float4 quat_from_euler(float x, float y, float z) {
         return v_quat_from_euler(v_make_vec4f(x, y, z, 0.f));
     }
 
@@ -530,11 +528,11 @@ namespace das {
         return v_euler_from_quat(v);
     }
 
-    DAS_SUPPRESS_ASAN float4 quat_from_float3x3(const float3x3 & a) {
+    float4 quat_from_float3x3(const float3x3 & a) {
         mat33f va;  va.col0 = a.m[0]; va.col1 = a.m[1]; va.col2 = a.m[2];
         return v_quat_from_mat33(va);
     }
-    DAS_SUPPRESS_ASAN float4 quat_from_float3x4(const float3x4 & a) {
+    float4 quat_from_float3x4(const float3x4 & a) {
         mat44f tm;
         v_mat44_make_from_43cu_unsafe(tm, &a.m[0].x);
         return v_quat_from_mat43(tm);
@@ -549,7 +547,7 @@ namespace das {
         return v_quat_mul_quat(q1, q2);
     }
 
-    DAS_SUPPRESS_ASAN float3 quat_mul_vec(float4 q, float3 v) {
+    float3 quat_mul_vec(float4 q, float3 v) {
         return v_quat_mul_vec3(q, v);
     }
 


### PR DESCRIPTION
This should be commited to vecmath. Until it isn't we will fail with ASAN on MAC

Revert "compiler: do not inline in NO_ASAN"

This reverts commit 9db96972296f046f88c3e42fff02e25ace690ac4.

Revert "compiler: add NO_ASAN to float3->float4 conversions"

This reverts commit 44a8b78ff30fd6876333b816168d699c92d9b1e3.

Track progress here: #2194