### PR TITLE
fix benchmark usage -- prefer a short form of a block passing

### DIFF
--- a/benchmarks/core/array_lock/test01.das
+++ b/benchmarks/core/array_lock/test01.das
@@ -33,7 +33,7 @@ def reserve_unlocked(var arr : array<auto(T)>; n : int) {
 
 [template(typ1), unused_argument(typ1), sideeffects]
 def run_emplace_bench(var typ1 : auto(ElemT), b : B?, n : int) {
-    b |> run("emplace/{n}", n) <| $() {
+    b |> run("emplace/{n}", n) {
         var arr : array<ElemT>
         reserve_unlocked(arr, n)
         for (i in range(n)) {
@@ -45,7 +45,7 @@ def run_emplace_bench(var typ1 : auto(ElemT), b : B?, n : int) {
 
 [template(typ1), unused_argument(typ1), sideeffects]
 def run_emplace_grow_bench(var typ1 : auto(ElemT), b : B?, n : int) {
-    b |> run("emplace_grow/{n}") <| $() {
+    b |> run("emplace_grow/{n}") {
         var arr : array<ElemT>
         for (i in range(n)) {
             arr |> emplace(default<ElemT>)
@@ -63,7 +63,7 @@ def run_reserve_bench(var typ1 : auto(ElemT), b : B?, n : int) {
     // measuring the entire reserve(), not the time it takes
     // to "touch" every element in arr.
     var arr <- [for (_ in range(n)); default<ElemT> ]
-    b |> run("reserve/{n}") <| $() {
+    b |> run("reserve/{n}") {
         reserve(arr, n)
     }
 }
@@ -71,7 +71,7 @@ def run_reserve_bench(var typ1 : auto(ElemT), b : B?, n : int) {
 [template(typ1), unused_argument(typ1), sideeffects]
 def run_move_bench(var typ1 : auto(ElemT), b : B?, n : int) {
     var arr <- [for (_ in range(n)); default<ElemT> ]
-    b |> run("move/{n}", n) <| $() {
+    b |> run("move/{n}", n) {
         for (i in range(n)) {
             var tmp <- arr
             strictEqual(b, length(arr), 0)

--- a/benchmarks/core/bool_array/test01.das
+++ b/benchmarks/core/bool_array/test01.das
@@ -22,7 +22,7 @@ def fill_array(dummy : auto(ArrayType)) {
 }
 
 def run_bench(b : B?; dummy : auto(ArrayType); name : string) {
-    b |> run("{name}/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) <| $() {
+    b |> run("{name}/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) {
         fill_array(dummy)
     }
 }

--- a/benchmarks/core/bool_array/test02.das
+++ b/benchmarks/core/bool_array/test02.das
@@ -29,7 +29,7 @@ def bool_array_access(b : B?) {
     for (i in 0 .. TOTAL_ELEMENTS) {
         a.push((i & 1) == 0)
     }
-    b |> run("access/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) <| $() {
+    b |> run("access/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) {
         let t = count_trues(a)
         if (t != TOTAL_ELEMENTS / 2) {
             b->failNow()
@@ -44,7 +44,7 @@ def array_bool_access(b : B?) {
     for (i in 0 .. TOTAL_ELEMENTS) {
         a.push((i & 1) == 0)
     }
-    b |> run("access/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) <| $() {
+    b |> run("access/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) {
         let t = count_trues(a)
         if (t != TOTAL_ELEMENTS / 2) {
             b->failNow()

--- a/benchmarks/core/bool_array/test03.das
+++ b/benchmarks/core/bool_array/test03.das
@@ -40,7 +40,7 @@ def bool_array_iterate(b : B?) {
     for (i in 0 .. TOTAL_ELEMENTS) {
         a.push((i & 1) == 0)
     }
-    b |> run("iterate/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) <| $() {
+    b |> run("iterate/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) {
         let t = count_trues_iter_ba(a)
         if (t != TOTAL_ELEMENTS / 2) {
             b->failNow()
@@ -55,7 +55,7 @@ def array_bool_iterate(b : B?) {
     for (i in 0 .. TOTAL_ELEMENTS) {
         a.push((i & 1) == 0)
     }
-    b |> run("iterate/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) <| $() {
+    b |> run("iterate/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) {
         let t = count_trues_iter_bool(a)
         if (t != TOTAL_ELEMENTS / 2) {
             b->failNow()

--- a/benchmarks/core/bool_array/test04.das
+++ b/benchmarks/core/bool_array/test04.das
@@ -47,7 +47,7 @@ def make_array_bool() : array<bool> {
 [benchmark]
 def bool_array_xor_compound(b : B?) {
     var a <- make_bool_array()
-    b |> run("flip_compound/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) <| $() {
+    b |> run("flip_compound/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) {
         flip_compound(a)
     }
     delete a
@@ -56,7 +56,7 @@ def bool_array_xor_compound(b : B?) {
 [benchmark]
 def bool_array_xor_simple(b : B?) {
     var a <- make_bool_array()
-    b |> run("flip_simple/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) <| $() {
+    b |> run("flip_simple/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) {
         flip_simple(a)
     }
     delete a
@@ -65,7 +65,7 @@ def bool_array_xor_simple(b : B?) {
 [benchmark]
 def array_bool_xor(b : B?) {
     var a <- make_array_bool()
-    b |> run("flip_compound/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) <| $() {
+    b |> run("flip_compound/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) {
         flip_compound(a)
     }
     delete a

--- a/benchmarks/core/bool_array/test05.das
+++ b/benchmarks/core/bool_array/test05.das
@@ -22,7 +22,7 @@ def fill_insert_at_0(dummy : auto(ArrayType)) {
 }
 
 def run_bench(b : B?; dummy : auto(ArrayType); name : string) {
-    b |> run("{name}/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) <| $() {
+    b |> run("{name}/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) {
         fill_insert_at_0(dummy)
     }
 }

--- a/benchmarks/core/bool_array/test06.das
+++ b/benchmarks/core/bool_array/test06.das
@@ -22,7 +22,7 @@ def erase_from_front(dummy : auto(ArrayType)) {
 }
 
 def run_bench(b : B?; dummy : auto(ArrayType); name : string) {
-    b |> run("{name}/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) <| $() {
+    b |> run("{name}/{TOTAL_ELEMENTS}", TOTAL_ELEMENTS) {
         erase_from_front(dummy)
     }
 }

--- a/benchmarks/core/hash/test02.das
+++ b/benchmarks/core/hash/test02.das
@@ -38,14 +38,14 @@ def fill_map(hmap : auto(HashMapType); size : int) : auto(HashMapType) {
 }
 
 def run_write_bench(b : B?; hmap : auto(HashMapType)) {
-    b |> run("insert/{HASH_SIZE}", HASH_SIZE) <| $() {
+    b |> run("insert/{HASH_SIZE}", HASH_SIZE) {
         fill_map(hmap, HASH_SIZE)
     }
 }
 
 def run_read_bench(b : B?; hmap : auto(HashMapType)) {
     let m = fill_map(hmap, HASH_SIZE)
-    b |> run("read/{HASH_SIZE}", HASH_SIZE) <| $() {
+    b |> run("read/{HASH_SIZE}", HASH_SIZE) {
         read_map(b, m)
     }
 }

--- a/benchmarks/core/hash/test03.das
+++ b/benchmarks/core/hash/test03.das
@@ -31,7 +31,7 @@ def fill_clear_fill(hmap : auto(HashMapType); randomNumbers : array<int>) {
 }
 
 def run_bench(b : B?; hmap : auto(HashMapType); randomNumbers : array<int>) {
-    b |> run("insert_clear_insert/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) <| $() {
+    b |> run("insert_clear_insert/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) {
         fill_clear_fill(hmap, randomNumbers)
     }
 }

--- a/benchmarks/core/hash/test04.das
+++ b/benchmarks/core/hash/test04.das
@@ -30,7 +30,7 @@ def fill_then_erase(hmap : auto(HashMapType); randomNumbers : array<int>) {
 }
 
 def run_bench(b : B?; hmap : auto(HashMapType); randomNumbers : array<int>) {
-    b |> run("insert_erase/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) <| $() {
+    b |> run("insert_erase/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) {
         fill_then_erase(hmap, randomNumbers)
     }
 }

--- a/benchmarks/core/hash/test05.das
+++ b/benchmarks/core/hash/test05.das
@@ -28,7 +28,7 @@ def overwrite_same_key(hmap : auto(HashMapType); count : int) {
 }
 
 def run_bench(b : B?; hmap : auto(HashMapType)) {
-    b |> run("overwrite_same_key/{OPS}", OPS) <| $() {
+    b |> run("overwrite_same_key/{OPS}", OPS) {
         overwrite_same_key(hmap, OPS)
     }
 }

--- a/benchmarks/core/hash/test06.das
+++ b/benchmarks/core/hash/test06.das
@@ -31,7 +31,7 @@ def insert_and_increment(hmap : auto(HashMapType); randomNumbers : array<int>) {
 }
 
 def run_bench(b : B?; hmap : auto(HashMapType); randomNumbers : array<int>) {
-    b |> run("insert_increment/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) <| $() {
+    b |> run("insert_increment/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) {
         insert_and_increment(hmap, randomNumbers)
     }
 }

--- a/benchmarks/core/hash/test07.das
+++ b/benchmarks/core/hash/test07.das
@@ -31,7 +31,7 @@ def insert_and_increment(hmap : auto(HashMapType); randomNumbers : array<int>) {
 }
 
 def run_bench(b : B?; hmap : auto(HashMapType); randomNumbers : array<int>) {
-    b |> run("insert_increment/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) <| $() {
+    b |> run("insert_increment/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) {
         insert_and_increment(hmap, randomNumbers)
     }
 }

--- a/benchmarks/core/hash/test08.das
+++ b/benchmarks/core/hash/test08.das
@@ -37,7 +37,7 @@ def lookup_all(hashMap : auto(HashMapType); randomNumbers : array<int>) {
 
 def run_bench(b : B?; hmap : auto(HashMapType); randomNumbers : array<int>) {
     let hashMap = fill_map(hmap, randomNumbers)
-    b |> run("key_exists/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) <| $() {
+    b |> run("key_exists/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) {
         lookup_all(hashMap, randomNumbers)
     }
 }

--- a/benchmarks/core/hash/test09.das
+++ b/benchmarks/core/hash/test09.das
@@ -46,7 +46,7 @@ def lookup_and_sum(hashMap : auto(HashMapType); randomNumbers : array<int>) {
 
 def run_bench(b : B?; hmap : auto(HashMapType); randomNumbers : array<int>) {
     let hashMap = fill_map(hmap, randomNumbers)
-    b |> run("get_sum/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) <| $() {
+    b |> run("get_sum/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) {
         lookup_and_sum(hashMap, randomNumbers)
     }
 }

--- a/benchmarks/core/hash/test10.das
+++ b/benchmarks/core/hash/test10.das
@@ -26,7 +26,7 @@ def fill_map(hmap : auto(HashMapType); randomNumbers : array<int>) {
 }
 
 def run_bench(b : B?; hmap : auto(HashMapType); randomNumbers : array<int>) {
-    b |> run("insert/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) <| $() {
+    b |> run("insert/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) {
         fill_map(hmap, randomNumbers)
     }
 }

--- a/benchmarks/core/hash/test11.das
+++ b/benchmarks/core/hash/test11.das
@@ -34,7 +34,7 @@ def fill_slotmap(smap : auto(SlotMapType); randomNumbers : array<int>) {
 }
 
 def run_bench(b : B?; smap : auto(SlotMapType); randomNumbers : array<int>) {
-    b |> run("emplace/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) <| $() {
+    b |> run("emplace/{TOTAL_RANDOM_NUMBERS}", TOTAL_RANDOM_NUMBERS) {
         fill_slotmap(smap, randomNumbers)
     }
 }

--- a/benchmarks/core/hash/test12.das
+++ b/benchmarks/core/hash/test12.das
@@ -54,7 +54,7 @@ def fill_clear_fill(hmap : auto(HashMapType); randomNumbers : array<int>) {
 }
 
 def run_bench(b : B?; hmap : auto(HashMapType); randomNumbers : array<int>) {
-    b |> run("insert_clear_insert/{PATHO_TOTAL}", PATHO_TOTAL) <| $() {
+    b |> run("insert_clear_insert/{PATHO_TOTAL}", PATHO_TOTAL) {
         fill_clear_fill(hmap, randomNumbers)
     }
 }

--- a/skills/writing_benchmarks.md
+++ b/skills/writing_benchmarks.md
@@ -65,7 +65,7 @@ require dastest/testing_boost
 
 [benchmark]
 def my_benchmark(b : B?) {
-    b |> run("sub_name", CHUNK_SIZE) <| $() {
+    b |> run("sub_name", CHUNK_SIZE) {
         // code to benchmark — this block runs in a loop
     }
 }
@@ -124,7 +124,7 @@ Old benchmarks in `examples/profile/` use `_framework.das` with `profile_test()`
 
 1. Replace `require _framework` with `require dastest/testing_boost`
 2. Replace `[export] def main` with `[benchmark] def benchmark_name(b : B?)`
-3. Convert `profile_test("name", default<Type>, args)` → `b |> run("name") <| $() { ... }`
+3. Convert `profile_test("name", default<Type>, args)` → `b |> run("name") { ... }`
 4. Move the benchmark loop body into the `run` block (dastest handles iteration automatically)
 5. Extract setup code (data generation, pre-filling) outside `run` — only the measured operation goes inside the block
 6. Use `b->failNow()` instead of `assert` for correctness checks
@@ -155,14 +155,14 @@ def fill_map(hmap : auto(HashMapType); size : int) : auto(HashMapType) {
 }
 
 def run_write_bench(b : B?; hmap : auto(HashMapType)) {
-    b |> run("insert/{HASH_SIZE}", HASH_SIZE) <| $() {
+    b |> run("insert/{HASH_SIZE}", HASH_SIZE) {
         fill_map(hmap, HASH_SIZE)
     }
 }
 
 def run_read_bench(b : B?; hmap : auto(HashMapType)) {
     let m = fill_map(hmap, HASH_SIZE)
-    b |> run("read/{HASH_SIZE}", HASH_SIZE) <| $() {
+    b |> run("read/{HASH_SIZE}", HASH_SIZE) {
         for (i in range(HASH_SIZE)) {
             let v = m?[i] ?? 0
             if (v != -i) {


### PR DESCRIPTION
While we still have limited benchmarks, let's not use an old way of passing blocks.
This change rewrites the existing calls for b.run and modifies the skills file to recommend the usage of a new syntax for blocks passing.