### PR TITLE
AOT hash diagnostics, decs path fix, swizzle sentinel, expanded CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,6 +360,7 @@ jobs:
               --test ../../tests/bitfields \
               --test ../../tests/bool_array \
               --test ../../tests/data_walker \
+              --test ../../tests/decs \
               --test ../../tests/debug \
               --test ../../tests/debug_agent \
               --test ../../tests/dynamic_cast_rtti \
@@ -368,7 +369,10 @@ jobs:
               --test ../../tests/handle_types \
               --test ../../tests/hash_map \
               --test ../../tests/interfaces \
-              --test ../../tests/jobque
+              --test ../../tests/jobque \
+              --test ../../tests/language \
+              --test ../../tests/linq \
+              --test ../../tests/lpipe
             ;;
            *)
             cd bin
@@ -384,6 +388,7 @@ jobs:
               --test ../tests/bitfields \
               --test ../tests/bool_array \
               --test ../tests/data_walker \
+              --test ../tests/decs \
               --test ../tests/debug \
               --test ../tests/debug_agent \
               --test ../tests/dynamic_cast_rtti \
@@ -392,7 +397,10 @@ jobs:
               --test ../tests/handle_types \
               --test ../tests/hash_map \
               --test ../tests/interfaces \
-              --test ../tests/jobque
+              --test ../tests/jobque \
+              --test ../tests/language \
+              --test ../tests/linq \
+              --test ../tests/lpipe
             ;;
         esac
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,10 @@ See `doc/source/reference/design_philosophy.rst` for the full design philosophy 
 - Exit code `-1073741819` (`0xC0000005`) = **Access Violation** — indicates a native crash (segfault)
 - If the program crashes with no error message, the bug is in native code (C++ bindings or smart pointer misuse) — check exit code first
 
+### AOT Hash Debugging
+
+When AOT fails with `error[50101]: AOT link failed`, the issue is a **semantic hash mismatch** between the generated C++ stubs and runtime. Each generated `.cpp` file has hash comments showing function hashes and dependency hashes. The runtime error also prints the same breakdown. Compare them to find the diverging function or dependency. See `skills/aot_testing.md` for the full debugging guide (hash architecture, debug macros, common causes).
+
 ## GitHub Operations
 
 - **Use `gh` CLI** for all GitHub operations (creating PRs, listing issues, etc.) — NOT GitKraken MCP tools
@@ -70,7 +74,7 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/writing_benchmarks.md` | Writing or running benchmark files under `benchmarks/` |
 | `skills/dynamic_modules.md` | Creating or editing `.das_module` descriptors, adding new modules under `modules/` |
 | `skills/install_instructions.md` | Creating or updating AI instruction files (`install/CLAUDE.md`, `install/skills/`) for the installed SDK |
-| `skills/aot_testing.md` | Adding AOT test files, working with the `test_aot` binary, `Module::aotRequire()`, CMake AOT macros |
+| `skills/aot_testing.md` | Adding AOT test files, working with the `test_aot` binary, `Module::aotRequire()`, CMake AOT macros, **debugging AOT hash mismatches** |
 
 Multiple skill files may apply to a single task. For example, creating a new daslib module requires reading `skills/das_formatting.md`, `skills/daslib_modules.md`, and possibly `skills/documentation_rst.md`.
 

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -310,7 +310,7 @@ def describeCppTypeEx(typeDecl : TypeDeclPtr;
             }
         } elif (baseType == Type.tTable) {
             if (typeDecl.firstType != null && typeDecl.secondType != null) {
-                let first_type = describeCppTypeEx(typeDecl.firstType, DescribeConfig(cross_platform = cfg.cross_platform), useAlias);
+                let first_type = describeCppTypeEx(typeDecl.firstType, DescribeConfig(skip_const = true, cross_platform = cfg.cross_platform), useAlias);
                 let second_type = describeCppTypeEx(typeDecl.secondType, DescribeConfig(cross_platform = cfg.cross_platform), useAlias);
                 write(writer, "TTable<{first_type},{second_type}>");
             } else {
@@ -3833,6 +3833,7 @@ def registerAotCpp(var logs : StringBuilderWriter?; program : ProgramPtr; var co
         for (fn in fnn) {
             let is_cmres = fn.flags.copyOnReturn || fn.flags.moveOnReturn ? "true" : "false";
             let fn_name = aotFuncName(fn);
+            write(*logs, "    // {get_aot_hash_comment(fn)}\n");
             write(*logs, "    \{ {fn.aotHash}, {is_cmres}, (void*)&{fn_name}, &__wrap_{fn_name} \},\n");
         }
         write(*logs, "};\n");

--- a/daslib/decs.das
+++ b/daslib/decs.das
@@ -92,9 +92,30 @@ struct EcsRequestPos {
     line : uint             //! line number
 }
 
+def private normalize_file_name(name : string) : string {
+    //! Strips directory path, keeping only filename and extension.
+    //! This ensures the same canonical name regardless of working directory,
+    //! which is critical for AOT hash stability.
+    var s = replace(name, "\\", "/")
+    var lastSlash = -1
+    var pos = 0
+    while (true) {
+        let idx = find(s, "/", pos)
+        if (idx < 0) {
+            break
+        }
+        lastSlash = idx
+        pos = idx + 1
+    }
+    if (lastSlash >= 0) {
+        return slice(s, lastSlash + 1)
+    }
+    return s
+}
+
 def EcsRequestPos(at : rtti::LineInfo) : EcsRequestPos {
     //! Constructs EcsRequestPos from rtti::LineInfo.
-    return EcsRequestPos(file = at.fileInfo != null ? string(at.fileInfo.name) : "", line = at.line)
+    return EcsRequestPos(file = at.fileInfo != null ? normalize_file_name(string(at.fileInfo.name)) : "", line = at.line)
 }
 
 struct public EcsRequest {

--- a/dastest/fs.das
+++ b/dastest/fs.das
@@ -88,7 +88,7 @@ def scan_dir(path : string; var cache : table<string; void?>; var res : array<st
                 return
             }
             f |> scan_dir(cache, res, suffix)
-        } elif (fStat.is_reg && f |> ends_with(suffix) && !cache |> key_exists(f)) {
+        } elif (fStat.is_reg && f |> ends_with(suffix) && !(n |> starts_with("_")) && !cache |> key_exists(f)) {
             cache |> insert(f, null)
             res |> push(f)
         }

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -292,7 +292,7 @@ def document_module_ast(root : string) {
         group_by_regex("Infer", mod, %regex~(infer_generic_type|update_alias_map)$%%),
         group_by_regex("Module queries", mod, %regex~(module_find_annotation|module_find_type_annotation|module_find_structure|not_inferred)$%%),
         group_by_regex("Debug info helpers", mod, %regex~(debug_helper_.*)%%),
-        group_by_regex("AOT support", mod, %regex~(aot_require|aot_type_ann_get_field_ptr|aot_need_type_info|aot_previsit_get_field_ptr|aot_previsit_get_field|aot_visit_get_field|write_aot_body|write_aot_suffix|write_aot_macro_suffix|write_aot_macro_prefix|macro_aot_infix|getInitSemanticHashWithDep)$%%),
+        group_by_regex("AOT support", mod, %regex~(aot_require|aot_type_ann_get_field_ptr|aot_need_type_info|aot_previsit_get_field_ptr|aot_previsit_get_field|aot_visit_get_field|write_aot_body|write_aot_suffix|write_aot_macro_suffix|write_aot_macro_prefix|macro_aot_infix|getInitSemanticHashWithDep|get_aot_hash_comment)$%%),
         group_by_regex("String builder writer", mod, %regex~(string_builder_str|string_builder_clear)$%%),
         hide_group(group_by_regex("Internal ast infrastructure", mod, %regex~(builtin_ast_.*)%%))
     )

--- a/doc/source/stdlib/ast.rst
+++ b/doc/source/stdlib/ast.rst
@@ -7794,6 +7794,7 @@ Properties
   *  :ref:`can_access_global_variable (variable: smart_ptr\<Variable\> const&; module: Module?; thisModule: Module?) : bool <function-ast_can_access_global_variable_smart_ptr_ls_Variable_gr__const_ref__Module_q__Module_q_>`
   *  :ref:`get_aot_arg_prefix (func: Function?; call: ExprCallFunc?; argIndex: int) : string <function-ast_get_aot_arg_prefix_Function_q__ExprCallFunc_q__int>`
   *  :ref:`get_aot_arg_suffix (func: Function?; call: ExprCallFunc?; argIndex: int) : string <function-ast_get_aot_arg_suffix_Function_q__ExprCallFunc_q__int>`
+  *  :ref:`get_aot_hash_comment (fun: Function const?) : string <function-ast_get_aot_hash_comment_Function_const_q_>`
   *  :ref:`get_aot_name (func: Function?; call: ExprCallFunc?) : string <function-ast_get_aot_name_Function_q__ExprCallFunc_q_>`
   *  :ref:`get_current_search_module (program: Program?; function: Function?; moduleName: string) : Module? <function-ast_get_current_search_module_Program_q__Function_q__string>`
   *  :ref:`get_field_type (type: smart_ptr\<TypeDecl\>; fieldName: string; constant: bool) : smart_ptr\<TypeDecl\> <function-ast_get_field_type_smart_ptr_ls_TypeDecl_gr__string_bool>`
@@ -7811,8 +7812,8 @@ Properties
   *  :ref:`has_field (type: smart_ptr\<TypeDecl\>; fieldName: string; constant: bool) : bool <function-ast_has_field_smart_ptr_ls_TypeDecl_gr__string_bool>`
   *  :ref:`is_expr_const (expression: smart_ptr\<Expression\> const&) : bool <function-ast_is_expr_const_smart_ptr_ls_Expression_gr__const_ref_>`
   *  :ref:`is_expr_like_call (expression: smart_ptr\<Expression\> const&) : bool <function-ast_is_expr_like_call_smart_ptr_ls_Expression_gr__const_ref_>`
-  *  :ref:`is_same_type (leftType: smart_ptr\<TypeDecl\>; rightType: smart_ptr\<TypeDecl\>; refMatters: RefMatters; constMatters: ConstMatters; tempMatters: TemporaryMatters) : bool <function-ast_is_same_type_smart_ptr_ls_TypeDecl_gr__smart_ptr_ls_TypeDecl_gr__RefMatters_ConstMatters_TemporaryMatters>`
   *  :ref:`is_same_type (argType: smart_ptr\<TypeDecl\>; passType: smart_ptr\<TypeDecl\>; refMatters: bool; constMatters: bool; temporaryMatters: bool; allowSubstitute: bool) : bool <function-ast_is_same_type_smart_ptr_ls_TypeDecl_gr__smart_ptr_ls_TypeDecl_gr__bool_bool_bool_bool>`
+  *  :ref:`is_same_type (leftType: smart_ptr\<TypeDecl\>; rightType: smart_ptr\<TypeDecl\>; refMatters: RefMatters; constMatters: ConstMatters; tempMatters: TemporaryMatters) : bool <function-ast_is_same_type_smart_ptr_ls_TypeDecl_gr__smart_ptr_ls_TypeDecl_gr__RefMatters_ConstMatters_TemporaryMatters>`
   *  :ref:`is_temp_type (type: smart_ptr\<TypeDecl\>; refMatters: bool) : bool <function-ast_is_temp_type_smart_ptr_ls_TypeDecl_gr__bool>`
   *  :ref:`is_visible_directly (from_module: Module?; which_module: Module?) : bool <function-ast_is_visible_directly_Module_q__Module_q_>`
 
@@ -7854,6 +7855,15 @@ Returns the AOT argument suffix string for the specified function.
             * **call** :  :ref:`ExprCallFunc <handle-ast-ExprCallFunc>`? implicit
 
             * **argIndex** : int
+
+.. _function-ast_get_aot_hash_comment_Function_const_q_:
+
+.. das:function:: get_aot_hash_comment(fun: Function const?) : string
+
+Returns a diagnostic string containing the function's own semantic hash and all non-builtin dependency hashes with their mangled names. Used for comparing AOT-generated hash comments with runtime-computed values to diagnose AOT link failures (error 50101).
+
+
+:Arguments: * **fun** :  :ref:`Function <handle-ast-Function>`? implicit
 
 .. _function-ast_get_aot_name_Function_q__ExprCallFunc_q_:
 
@@ -8058,26 +8068,30 @@ Returns true if the expression is or inherits from ExprLooksLikeCall.
 is_same_type
 ^^^^^^^^^^^^
 
-.. _function-ast_is_same_type_smart_ptr_ls_TypeDecl_gr__smart_ptr_ls_TypeDecl_gr__RefMatters_ConstMatters_TemporaryMatters:
-
-.. das:function:: is_same_type(leftType: smart_ptr<TypeDecl>; rightType: smart_ptr<TypeDecl>; refMatters: RefMatters; constMatters: ConstMatters; tempMatters: TemporaryMatters) : bool
-
-Compares two types using the given comparison parameters and returns true if they match.
-
-
-:Arguments: * **leftType** : smart_ptr< :ref:`TypeDecl <handle-ast-TypeDecl>`> implicit
-
-            * **rightType** : smart_ptr< :ref:`TypeDecl <handle-ast-TypeDecl>`> implicit
-
-            * **refMatters** :  :ref:`RefMatters <enum-rtti-RefMatters>`
-
-            * **constMatters** :  :ref:`ConstMatters <enum-rtti-ConstMatters>`
-
-            * **tempMatters** :  :ref:`TemporaryMatters <enum-rtti-TemporaryMatters>`
-
 .. _function-ast_is_same_type_smart_ptr_ls_TypeDecl_gr__smart_ptr_ls_TypeDecl_gr__bool_bool_bool_bool:
 
 .. das:function:: is_same_type(argType: smart_ptr<TypeDecl>; passType: smart_ptr<TypeDecl>; refMatters: bool; constMatters: bool; temporaryMatters: bool; allowSubstitute: bool) : bool
+
+Compares two type declarations for structural equality. Boolean flags control whether reference, const, and temporary qualifiers affect the comparison, and whether type substitution (e.g. auto inference) is allowed. Returns true if the types are considered the same under the specified criteria.
+
+def is_same_type (argType: smart_ptr<TypeDecl>; passType: smart_ptr<TypeDecl>; refMatters: bool; constMatters: bool; temporaryMatters: bool; allowSubstitute: bool) : bool
+
+
+:Arguments: * **argType** : smart_ptr< :ref:`TypeDecl <handle-ast-TypeDecl>`> implicit
+
+            * **passType** : smart_ptr< :ref:`TypeDecl <handle-ast-TypeDecl>`> implicit
+
+            * **refMatters** : bool
+
+            * **constMatters** : bool
+
+            * **temporaryMatters** : bool
+
+            * **allowSubstitute** : bool
+
+.. _function-ast_is_same_type_smart_ptr_ls_TypeDecl_gr__smart_ptr_ls_TypeDecl_gr__RefMatters_ConstMatters_TemporaryMatters:
+
+.. das:function:: is_same_type(leftType: smart_ptr<TypeDecl>; rightType: smart_ptr<TypeDecl>; refMatters: RefMatters; constMatters: ConstMatters; tempMatters: TemporaryMatters) : bool
 
 ----
 

--- a/doc/source/stdlib/builtin.rst
+++ b/doc/source/stdlib/builtin.rst
@@ -400,13 +400,6 @@ Marks a function as a hybrid call target so that AOT generates indirect calls to
 Optimization annotation that removes null-pointer checks, bounds checks on array and string indexing, and similar safety validations.
 
 
-.. _handle-builtin-skip_lock_check:
-
-.. das:attribute:: skip_lock_check
-
-Optimization annotation that disables runtime lock-check validation for the annotated function.
-
-
 .. _handle-builtin-unused_argument:
 
 .. das:attribute:: unused_argument
@@ -612,13 +605,6 @@ Prevents the compiler from generating a default initializer for the annotated st
 .. das:attribute:: macro_interface
 
 Marks a class hierarchy as a macro interface, preventing it and its descendants from being exported by default.
-
-
-.. _handle-builtin-skip_field_lock_check:
-
-.. das:attribute:: skip_field_lock_check
-
-Optimization annotation that disables runtime lock checks when accessing fields of the annotated structure.
 
 
 .. _handle-builtin-cpp_layout:

--- a/doc/source/stdlib/debugapi.rst
+++ b/doc/source/stdlib/debugapi.rst
@@ -30,15 +30,15 @@ Structures
 
 .. das:attribute:: DapiArray
 
-Lightweight descriptor for an array encountered during data walking.
+:Fields: * **data** : void? - Lightweight descriptor for an array encountered during data walking.
 
-:Fields: * **data** : void? - Pointer to the array data.
+         * **size** : uint - Pointer to the array data.
 
-         * **size** : uint - Number of elements currently in the array.
+         * **capacity** : uint - Number of elements currently in the array.
 
-         * **capacity** : uint - Allocated capacity of the array.
+         * **lock** : uint - Allocated capacity of the array.
 
-         * **lock** : uint - Reference count lock for the array.
+         * **magic** : uint - Reference count lock for the array.
 
          * **flags** : bitfield<_shared;_hopeless> - Bitfield flags (`_shared`, `_hopeless`).
 
@@ -684,10 +684,10 @@ Agent construction
 ++++++++++++++++++
 
   *  :ref:`make_data_walker (class: void?; info: StructInfo const?) : smart_ptr\<DataWalker\> <function-debugapi_make_data_walker_void_q__StructInfo_const_q_>`
-  *  :ref:`make_data_walker (classPtr: auto) : smart_ptr\<DataWalker\> <function-debugapi_make_data_walker_auto_0xbf>`
+  *  :ref:`make_data_walker (classPtr: auto) : smart_ptr\<DataWalker\> <function-debugapi_make_data_walker_auto_0xc0>`
   *  :ref:`make_debug_agent (class: void?; info: StructInfo const?) : smart_ptr\<DebugAgent\> <function-debugapi_make_debug_agent_void_q__StructInfo_const_q_>`
   *  :ref:`make_stack_walker (class: void?; info: StructInfo const?) : smart_ptr\<StackWalker\> <function-debugapi_make_stack_walker_void_q__StructInfo_const_q_>`
-  *  :ref:`make_stack_walker (classPtr: auto) : smart_ptr\<StackWalker\> <function-debugapi_make_stack_walker_auto_0xda>`
+  *  :ref:`make_stack_walker (classPtr: auto) : smart_ptr\<StackWalker\> <function-debugapi_make_stack_walker_auto_0xdb>`
 
 
 make_data_walker
@@ -704,7 +704,7 @@ Wraps a `DapiDataWalker` class pointer into a `smart_ptr<DataWalker>` for use wi
 
             * **info** :  :ref:`StructInfo <handle-rtti-StructInfo>`? implicit
 
-.. _function-debugapi_make_data_walker_auto_0xbf:
+.. _function-debugapi_make_data_walker_auto_0xc0:
 
 .. das:function:: make_data_walker(classPtr: auto) : smart_ptr<DataWalker>
 
@@ -736,7 +736,7 @@ Wraps a `DapiStackWalker` class pointer into a `smart_ptr<StackWalker>` for use 
 
             * **info** :  :ref:`StructInfo <handle-rtti-StructInfo>`? implicit
 
-.. _function-debugapi_make_stack_walker_auto_0xda:
+.. _function-debugapi_make_stack_walker_auto_0xdb:
 
 .. das:function:: make_stack_walker(classPtr: auto) : smart_ptr<StackWalker>
 

--- a/doc/source/stdlib/decs.rst
+++ b/doc/source/stdlib/decs.rst
@@ -322,14 +322,14 @@ Access (get/set/clone)
   *  :ref:`clone (var cv: ComponentValue; val: double) <function-decs_clone_ComponentValue_double>`
   *  :ref:`clone (var dst: Component; src: Component) <function-decs_clone_Component_Component>`
   *  :ref:`clone (var cv: ComponentValue; val: float4) <function-decs_clone_ComponentValue_float4>`
-  *  :ref:`get (arch: Archetype; name: string; value: auto(TT)) : auto <function-decs_get_Archetype_string_autoTT_0x2d7>`
-  *  :ref:`get (var cmp: ComponentMap; name: string; var value: auto(TT)) : auto <function-decs_get_ComponentMap_string_autoTT_0x3e3>`
-  *  :ref:`get_component (eid: EntityId; name: string; defval: auto(TT)) : TT <function-decs_get_component_EntityId_string_autoTT_0x3c1>`
+  *  :ref:`get (arch: Archetype; name: string; value: auto(TT)) : auto <function-decs_get_Archetype_string_autoTT_0x2ec>`
+  *  :ref:`get (var cmp: ComponentMap; name: string; var value: auto(TT)) : auto <function-decs_get_ComponentMap_string_autoTT_0x3f8>`
+  *  :ref:`get_component (eid: EntityId; name: string; defval: auto(TT)) : TT <function-decs_get_component_EntityId_string_autoTT_0x3d6>`
   *  :ref:`has (var cmp: ComponentMap; name: string) : bool <function-decs_has_ComponentMap_string>`
   *  :ref:`has (arch: Archetype; name: string) : bool <function-decs_has_Archetype_string>`
   *  :ref:`remove (var cmp: ComponentMap; name: string) <function-decs_remove_ComponentMap_string>`
-  *  :ref:`set (var cmp: ComponentMap; name: string; value: auto(TT)) : auto <function-decs_set_ComponentMap_string_autoTT_0x4ba>`
-  *  :ref:`set (var cv: ComponentValue; val: auto) : auto <function-decs_set_ComponentValue_auto_0xa7>`
+  *  :ref:`set (var cmp: ComponentMap; name: string; value: auto(TT)) : auto <function-decs_set_ComponentMap_string_autoTT_0x4cf>`
+  *  :ref:`set (var cv: ComponentValue; val: auto) : auto <function-decs_set_ComponentValue_auto_0xbc>`
 
 
 clone
@@ -468,7 +468,7 @@ Sets individual component value. Verifies that the value is of the correct type.
 get
 ^^^
 
-.. _function-decs_get_Archetype_string_autoTT_0x2d7:
+.. _function-decs_get_Archetype_string_autoTT_0x2ec:
 
 .. das:function:: get(arch: Archetype; name: string; value: auto(TT)) : auto
 
@@ -482,13 +482,13 @@ If component is not found - panic.
 
             * **value** : auto(TT)
 
-.. _function-decs_get_ComponentMap_string_autoTT_0x3e3:
+.. _function-decs_get_ComponentMap_string_autoTT_0x3f8:
 
 .. das:function:: get(cmp: ComponentMap; name: string; value: auto(TT)) : auto
 
 ----
 
-.. _function-decs_get_component_EntityId_string_autoTT_0x3c1:
+.. _function-decs_get_component_EntityId_string_autoTT_0x3d6:
 
 .. das:function:: get_component(eid: EntityId; name: string; defval: auto(TT)) : TT
 
@@ -540,7 +540,7 @@ Removes specified value from the component map.
 set
 ^^^
 
-.. _function-decs_set_ComponentMap_string_autoTT_0x4ba:
+.. _function-decs_set_ComponentMap_string_autoTT_0x4cf:
 
 .. das:function:: set(cmp: ComponentMap; name: string; value: auto(TT)) : auto
 
@@ -554,7 +554,7 @@ If value already exists, it is overwritten. If already existing value type is no
 
             * **value** : auto(TT)
 
-.. _function-decs_set_ComponentValue_auto_0xa7:
+.. _function-decs_set_ComponentValue_auto_0xbc:
 
 .. das:function:: set(cv: ComponentValue; val: auto) : auto
 
@@ -741,17 +741,17 @@ Restarts ECS by erasing all deferred actions and entire state.
 Iteration
 +++++++++
 
-  *  :ref:`decs_array (atype: auto(TT); src: array\<uint8\>; capacity: int) : auto <function-decs_decs_array_autoTT_array_ls_uint8_gr__int_0x2c4>`
+  *  :ref:`decs_array (atype: auto(TT); src: array\<uint8\>; capacity: int) : auto <function-decs_decs_array_autoTT_array_ls_uint8_gr__int_0x2d9>`
   *  :ref:`for_each_archetype (hash: ComponentHash; var erq: function\<():void\>; blk: block\<(arch:Archetype):void\>) <function-decs_for_each_archetype_ComponentHash_function_ls__c_void_gr__block_ls_arch_c_Archetype_c_void_gr_>`
   *  :ref:`for_each_archetype (var erq: EcsRequest; blk: block\<(arch:Archetype):void\>) <function-decs_for_each_archetype_EcsRequest_block_ls_arch_c_Archetype_c_void_gr_>`
   *  :ref:`for_each_archetype_find (hash: ComponentHash; var erq: function\<():void\>; blk: block\<(arch:Archetype):bool\>) : bool <function-decs_for_each_archetype_find_ComponentHash_function_ls__c_void_gr__block_ls_arch_c_Archetype_c_bool_gr_>`
   *  :ref:`for_eid_archetype (eid: EntityId; hash: ComponentHash; var erq: function\<():void\>; blk: block\<(arch:Archetype;index:int):void\>) : bool <function-decs_for_eid_archetype_EntityId_ComponentHash_function_ls__c_void_gr__block_ls_arch_c_Archetype;index_c_int_c_void_gr_>`
-  *  :ref:`get_default_ro (arch: Archetype; name: string; value: auto(TT)) : iterator\<TT const&\> <function-decs_get_default_ro_Archetype_string_autoTT_0x30a>`
+  *  :ref:`get_default_ro (arch: Archetype; name: string; value: auto(TT)) : iterator\<TT const&\> <function-decs_get_default_ro_Archetype_string_autoTT_0x31f>`
   *  :ref:`get_optional (arch: Archetype; name: string; value: auto(TT)?) : iterator\<TT?\> <function-decs_get_optional_Archetype_string_autoTT_q_>`
-  *  :ref:`get_ro (arch: Archetype; name: string; value: auto(TT)) : array\<TT\> <function-decs_get_ro_Archetype_string_autoTT_0x303>`
-  *  :ref:`get_ro (arch: Archetype; name: string; value: auto(TT)[]) : array\<TT[-2]\> <function-decs_get_ro_Archetype_string_autoTT_lb__rb__0x2fb>`
+  *  :ref:`get_ro (arch: Archetype; name: string; value: auto(TT)) : array\<TT\> <function-decs_get_ro_Archetype_string_autoTT_0x318>`
+  *  :ref:`get_ro (arch: Archetype; name: string; value: auto(TT)[]) : array\<TT[-2]\> <function-decs_get_ro_Archetype_string_autoTT_lb__rb__0x310>`
 
-.. _function-decs_decs_array_autoTT_array_ls_uint8_gr__int_0x2c4:
+.. _function-decs_decs_array_autoTT_array_ls_uint8_gr__int_0x2d9:
 
 .. das:function:: decs_array(atype: auto(TT); src: array<uint8>; capacity: int) : auto
 
@@ -822,7 +822,7 @@ Request is returned by a specified function.
 
             * **blk** : block<(arch: :ref:`Archetype <struct-decs-Archetype>`;index:int):void>
 
-.. _function-decs_get_default_ro_Archetype_string_autoTT_0x30a:
+.. _function-decs_get_default_ro_Archetype_string_autoTT_0x31f:
 
 .. das:function:: get_default_ro(arch: Archetype; name: string; value: auto(TT)) : iterator<TT const&>
 
@@ -854,7 +854,7 @@ If component is not found - iterator will keep returning default value for the c
 get_ro
 ^^^^^^
 
-.. _function-decs_get_ro_Archetype_string_autoTT_0x303:
+.. _function-decs_get_ro_Archetype_string_autoTT_0x318:
 
 .. das:function:: get_ro(arch: Archetype; name: string; value: auto(TT)) : array<TT>
 
@@ -867,7 +867,7 @@ Returns const temporary array of component given specific name and type of compo
 
             * **value** : auto(TT)
 
-.. _function-decs_get_ro_Archetype_string_autoTT_lb__rb__0x2fb:
+.. _function-decs_get_ro_Archetype_string_autoTT_lb__rb__0x310:
 
 .. das:function:: get_ro(arch: Archetype; name: string; value: auto(TT)[]) : array<TT[-2]>
 

--- a/doc/source/stdlib/detail/ast.rst
+++ b/doc/source/stdlib/detail/ast.rst
@@ -1176,6 +1176,8 @@
 
 .. |handmade/function-ast-get_function_aot_hash| replace:: to be documented in |handmade/function-ast-get_function_aot_hash|.rst
 
+.. |handmade/function-ast-get_aot_hash_comment| replace:: to be documented in |handmade/function-ast-get_aot_hash_comment|.rst
+
 .. |handmade/function-ast-infer_generic_type| replace:: to be documented in |handmade/function-ast-infer_generic_type|.rst
 
 .. |handmade/function-ast-update_alias_map| replace:: to be documented in |handmade/function-ast-update_alias_map|.rst

--- a/doc/source/stdlib/detail/function-decs-normalize_file_name-0xb499aa061042d639.rst
+++ b/doc/source/stdlib/detail/function-decs-normalize_file_name-0xb499aa061042d639.rst
@@ -1,0 +1,3 @@
+Strips directory path, keeping only filename and extension.
+This ensures the same canonical name regardless of working directory,
+which is critical for AOT hash stability.

--- a/doc/source/stdlib/handmade/function-ast-get_aot_hash_comment-0x9bbbb64ca6bdef61.rst
+++ b/doc/source/stdlib/handmade/function-ast-get_aot_hash_comment-0x9bbbb64ca6bdef61.rst
@@ -1,0 +1,1 @@
+Returns a diagnostic string containing the function's own semantic hash and all non-builtin dependency hashes with their mangled names. Used for comparing AOT-generated hash comments with runtime-computed values to diagnose AOT link failures (error 50101).

--- a/doc/source/stdlib/handmade/function-ast-is_same_type-0x189408df2da226ac.rst
+++ b/doc/source/stdlib/handmade/function-ast-is_same_type-0x189408df2da226ac.rst
@@ -1,0 +1,3 @@
+Compares two type declarations for structural equality. Boolean flags control whether reference, const, and temporary qualifiers affect the comparison, and whether type substitution (e.g. auto inference) is allowed. Returns true if the types are considered the same under the specified criteria.
+
+def is_same_type (argType: smart_ptr<TypeDecl>; passType: smart_ptr<TypeDecl>; refMatters: bool; constMatters: bool; temporaryMatters: bool; allowSubstitute: bool) : bool

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1021,6 +1021,7 @@ namespace das
     uint64_t getFunctionHash ( Function * fun, SimNode * node, Context * context );
 
     uint64_t getFunctionAotHash ( const Function * fun );
+    string getAotHashComment ( const Function * fun );
     uint64_t getVariableListAotHash ( const vector<const Variable *> & globs, uint64_t initHash );
 
     class DAS_API BuiltInFunction : public Function {

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -379,7 +379,7 @@ namespace das {
         }
     };
 
-    template <typename ResT,typename VecT, int f0, int f1, int f2 = 0, int f3 = 0>
+    template <typename ResT,typename VecT, int f0, int f1, int f2 = -1, int f3 = -1>
     struct das_swizzle {
         static __forceinline ResT swizzle ( const VecT & val ) {
             ResT res;
@@ -395,7 +395,7 @@ namespace das {
     };
 
     template <typename ResT,typename VecT, int f0, int f1, int f2>
-    struct das_swizzle<ResT,VecT,f0,f1,f2,0> {
+    struct das_swizzle<ResT,VecT,f0,f1,f2,-1> {
         static __forceinline ResT swizzle ( const VecT & val ) {
             ResT res;
             res.x = *((&val.x) + f0);
@@ -409,7 +409,7 @@ namespace das {
     };
 
     template <typename ResT,typename VecT, int f0, int f1>
-    struct das_swizzle<ResT,VecT,f0,f1,0,0> {
+    struct das_swizzle<ResT,VecT,f0,f1,-1,-1> {
         static __forceinline ResT swizzle ( const VecT & val ) {
             ResT res;
             res.x = *((&val.x) + f0);

--- a/skills/aot_testing.md
+++ b/skills/aot_testing.md
@@ -126,6 +126,107 @@ virtual ModuleAotType aotRequire(TextWriter & tw) const override {
 
 **Forgetting a header here causes AOT compilation failures** — the generated C++ calls the function but the compiler can't find the declaration. This was a latent bug with `performance_time.h` (needed for `ref_time_ticks`, `get_time_usec`, `get_time_nsec` bound in `Module_BuiltIn::addTime()`).
 
+## Semantic Hash Architecture
+
+AOT linking works by **semantic hash matching**. The AOT tool generates C++ stubs keyed by a hash; at runtime the simulator computes the same hash and looks up the stub. If hashes don't match → error 50101 "AOT link failed".
+
+### Two-level hashing
+
+Every function has two hash values (see `src/simulate/simulate_fn_hash.cpp`):
+
+1. **`hash`** (own hash) — the function's **SIM node tree** hash. Computed by `getFunctionHash()` which walks the simulated node tree and hashes every node type, constant value, and type descriptor. This captures the function's own behavior.
+
+2. **`aotHash`** (AOT hash) — computed by `getFunctionAotHash()`:
+   ```
+   aotHash = hash_block64([own_hash, dep1_hash, dep2_hash, ...])
+   ```
+   Collects all **transitive non-builtin, non-noAot dependencies** via `DependencyCollector`, sorts them by mangled name for stability, then hashes the concatenation of all their `hash` values together with the function's own `hash`.
+
+The registration table in generated C++ is keyed by `aotHash`. At runtime, `linkCppAot()` recomputes `aotHash` and does a lookup.
+
+### What goes into `hash` (own hash)
+
+`getFunctionHash()` hashes (via `SimHashVisitor`):
+- The function's **result type** descriptor string
+- Each **argument type** descriptor string
+- The entire **SIM node tree** — every node class name, every constant value, every string literal, every field offset
+
+**Any difference in the SIM tree causes a different `hash`**. This includes:
+- Different constant values (e.g., different file path strings embedded in structs)
+- Different field offsets (struct layout changes)
+- Different node types (optimization differences)
+
+### What goes into `aotHash`
+
+`getFunctionAotHash()` adds dependency hashes:
+- Collects transitive function dependencies (calls, lambda captures, etc.)
+- Filters: skips `builtIn` and `noAot` functions
+- Sorts by mangled name (deterministic ordering)
+- Hashes: `[own_hash, dep1_hash, dep2_hash, ...]`
+
+**A dependency's `hash` changing causes all callers' `aotHash` to change**, even if the callers themselves are unchanged.
+
+### Hash comment diagnostics
+
+Every AOT-generated C++ file includes a **hash comment** before each registration entry, showing the function's own hash and all dependency hashes with names:
+
+```cpp
+// my_function hash=0xabc123..., dep_func_1=0xdef456..., dep_func_2=0x789...
+{ 0x<aotHash>, false, (void*)&my_function_abc123, &__wrap_my_function_abc123 },
+```
+
+When `linkCppAot()` fails to find a match, the error output includes the same hash comment for the runtime-computed values:
+
+```
+error[50101]: AOT link failed on my_function
+semantic hash is <runtime_aotHash>
+// my_function hash=0x<runtime_own_hash>, dep1=0x<runtime_dep1_hash>, ...
+```
+
+**To diagnose a mismatch**, compare the two hash comments:
+1. Open the generated `.cpp` file in `_aot_generated/` and find the comment for the failing function
+2. Compare with the runtime hash comment in the error output
+3. If `hash` (own hash) differs → the SIM tree is different (see below)
+4. If a dependency hash differs → that dependency's SIM tree changed
+
+### C++ API for hash debugging
+
+| Function | Location | Purpose |
+|---|---|---|
+| `getFunctionHash(fun, code, ctx)` | `simulate_fn_hash.cpp` | Compute own SIM hash |
+| `getFunctionAotHash(fun)` | `simulate_fn_hash.cpp` | Compute AOT hash (own + deps) |
+| `getAotHashComment(fun)` | `simulate_fn_hash.cpp` | Format diagnostic string with all dep hashes |
+| `get_aot_hash_comment(fun)` | das binding in `module_builtin_ast.cpp` | Same, callable from das |
+
+### Debug printf macros
+
+In `src/simulate/simulate_fn_hash.cpp`, two macros control debug output:
+
+```cpp
+#if 1          // change to 0 to enable
+#define debug_hash(...)           // per-SIM-node hash contributions
+#else
+#define debug_hash  printf
+#endif
+
+#if 1          // change to 0 to enable
+#define debug_aot_hash(...)       // dependency list and final aotHash
+#else
+#define debug_aot_hash  printf
+#endif
+```
+
+- **`debug_aot_hash`**: prints each dependency name + hash, then the final `aotHash`. Useful to see which dependencies are included and their hash values.
+- **`debug_hash`**: prints every SIM node's hash contribution. Very verbose — use only when you need to find exactly which node differs.
+
+To use: change `#if 1` to `#if 0` for the desired macro, rebuild daslang/test_aot.
+
+### Printing the SIM tree
+
+`options log_nodes` in a `.das` file prints the full SIM node tree at compile time. `options log_nodes_aot_hash` additionally prints each node's hash contribution. Useful for comparing trees between AOT generation and runtime.
+
+**Warning**: `options log*` lines change the compilation (they set options that may affect code generation). Always remove them before generating final AOT stubs, or the generated hashes will be stale.
+
 ## Semantic Hash Stability — Critical Pitfall
 
 Functions with `SideEffects::none` can be **constant-folded** at compile time. If a function's result depends on `CodeOfPolicies` fields that differ between AOT generation and runtime, the folded constant will differ → different AST → different semantic hash → AOT link failure (error 50101).
@@ -139,6 +240,29 @@ Functions with `SideEffects::none` can be **constant-folded** at compile time. I
 - Don't use `aot_enabled()` or `is_in_aot()` in test assertion logic that needs hash stability
 - If `fail_on_no_aot = true` and tests pass, AOT is working — no need to check `aot_enabled()` explicitly
 - Any compile-time-evaluable expression that depends on `cop.aot`, `cop.jit`, etc. is a hash stability risk
+
+## Common AOT Hash Mismatch Causes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Own hash differs, path strings in SIM tree | File path separator mismatch (`/` vs `\`) between CMake and runtime | Normalize paths at the point they enter the SIM tree (e.g., `replace(path, "\\", "/")`) |
+| Own hash differs, constant values differ | `SideEffects::none` function folded with different `CodeOfPolicies` | Remove the policy-dependent call, or mark function `SideEffects::modifyExternal` |
+| Dependency hash differs | A dependency function's SIM tree changed (different module state in batch) | Compare dep hashes in the hash comment; inspect the specific dependency |
+| AOT hash differs but own + all deps match | Dependency list differs (extra or missing deps) | Check if batch processing adds/removes function instantiations |
+| All hashes match but still fails | Stale generated C++ — `.cpp` file wasn't regenerated | Delete `_aot_generated/*.cpp` and rebuild |
+
+### Batch AOT processing
+
+The AOT tool (`utils/aot/main.das`) can process multiple `.das` files in one invocation. CMake's `DAS_AOT_EXT` macro batches files this way for efficiency. **Batch processing can cause hash divergence** if:
+
+- A macro in file A instantiates generic functions that share names/mangled names with instantiations from file B
+- Module-level state from processing file A leaks into file B's compilation context
+
+**Diagnosing batch issues**: If single-file AOT generation produces matching hashes but batch doesn't, use the hash comment diagnostics to find the diverging function. You can test single-file generation with:
+
+```bash
+daslang.exe utils/aot/main.das -- -aot path/to/test.das path/to/output.cpp
+```
 
 ## libDaScriptAot — Standard Library AOT
 
@@ -170,6 +294,15 @@ cmake --build build --config Release --target libDaScriptAot
 ```
 
 The generated files in `daslib/_aot_generated/` are tracked in git. Commit any changes.
+
+## AOT Link Failures Are Real Failures
+
+`test_aot` exists specifically to catch AOT failures, including **link failures** (error 50101). When a file like `_module_a.das` fails with "AOT link failed", that IS a real failure — it means the AOT stubs could not be linked at simulation time. Do NOT dismiss these as "not real tests" or "helper modules". If a `.das` file is picked up by dastest and fails under AOT, it needs to be fixed or excluded from the AOT test set.
+
+Common causes of AOT link failures:
+- Missing `Module::aotRequire()` headers
+- Semantic hash mismatch (see below)
+- Helper modules without `[test]` functions that weren't meant to run standalone — these should be excluded from the test directory or the CMake file list
 
 ## CI Integration
 

--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -267,7 +267,7 @@ namespace das {
             }
         } else if ( baseType==Type::tTable ) {
             if ( type->firstType && type->secondType ) {
-                stream << "TTable<" << describeCppTypeEx(type->firstType,CpptSubstitureRef::no,CpptSkipRef::no,CpptSkipConst::no,CpptRedundantConst::yes,useAlias, chooseSmartPtr)
+                stream << "TTable<" << describeCppTypeEx(type->firstType,CpptSubstitureRef::no,CpptSkipRef::no,CpptSkipConst::yes,CpptRedundantConst::yes,useAlias, chooseSmartPtr)
                 << "," << describeCppTypeEx(type->secondType,CpptSubstitureRef::no,CpptSkipRef::no,CpptSkipConst::no,CpptRedundantConst::yes,useAlias, chooseSmartPtr) << ">";
             } else {
                 stream << "Table";
@@ -3974,6 +3974,7 @@ namespace das {
             logs << "struct AotFunction { uint64_t hash; bool is_cmres; void * fn; vec4f (*wrappedFn)(Context*); };\n";
             logs << "static AotFunction functions[] = {\n";
             for ( const auto fn : fnn ) {
+                logs << "    // " << getAotHashComment(fn) << "\n";
                 logs << "    { 0x" << HEX << fn->aotHash << DEC << ", "
                      << ( fn->copyOnReturn || fn->moveOnReturn ? "true" : "false") << ", "
                      << "(void*)&" << aotFuncName(fn) << ", &__wrap_" << aotFuncName(fn) << " },\n";

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -3660,6 +3660,7 @@ namespace das
                     if ( logIt ) logs << "NOT FOUND " << fn.mangledName << " AOT=0x" << HEX << semHash << DEC << "\n";
                     TextWriter tp;
                     tp << "semantic hash is " << HEX << semHash << DEC << "\n";
+                    tp << "// " << getAotHashComment(fnn[fni]) << "\n";
                     printSimFunction(tp, &context, indexToFunction[fni], fn.code, true);
                     linkError(string(fn.mangledName), tp.str() );
                 }

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -467,6 +467,11 @@ namespace das {
         return context->allocateString(func->getMangledName(),at);
     }
 
+    char * get_aot_hash_comment_fn ( const Function * func, Context * context, LineInfoArg * at ) {
+        if ( !func ) context->throw_error_at(at,"expecting function");
+        return context->allocateString(getAotHashComment(func),at);
+    }
+
     char * get_mangled_name_t ( smart_ptr_raw<TypeDecl> typ, Context * context, LineInfoArg * at ) {
         if ( !typ ) context->throw_error_at(at,"expecting function");
         return context->allocateString(typ->getMangledName(),at);
@@ -1321,6 +1326,9 @@ namespace das {
         addExtern<DAS_BIND_FUN(getFunctionAotHash)>(*this, lib,  "get_function_aot_hash",
             SideEffects::none, "getFunctionAotHash")
                 ->args({"fun"});
+        addExtern<DAS_BIND_FUN(get_aot_hash_comment_fn)>(*this, lib,  "get_aot_hash_comment",
+            SideEffects::none, "get_aot_hash_comment_fn")
+                ->args({"fun","context","line"});
         // infer
         addExtern<DAS_BIND_FUN(inferGenericTypeEx)>(*this, lib,  "infer_generic_type",
             SideEffects::none, "inferGenericTypeEx")

--- a/src/simulate/simulate_fn_hash.cpp
+++ b/src/simulate/simulate_fn_hash.cpp
@@ -238,12 +238,27 @@ namespace das {
                 DAS_ASSERTF(fn.first->hash,"%s has dependency on %s, which hash hash of 0",
                     fun->getMangledName().c_str(), fn.first->getMangledName().c_str());
                 uvec.push_back(fn.first->hash);
-                debug_aot_hash("\t%s " PRIx64 "\n", fn.second.c_str(), fn.first->hash);
+                debug_aot_hash("\t%s %" PRIx64 "\n", fn.second.c_str(), fn.first->hash);
             }
         }
         uint64_t res = hash_block64((const uint8_t *)uvec.data(), uint32_t(uvec.size()*sizeof(uint64_t)));
         debug_aot_hash("AOT HASH %" PRIx64 "\n", res);
         return res;
+    }
+
+    string getAotHashComment ( const Function * fun ) {
+        DependencyCollector collector;
+        collector.collect(fun);
+        auto vec = collector.getStableDependencies();
+        TextWriter tw;
+        tw << fun->getMangledName() << " hash=0x" << HEX << fun->hash;
+        for ( const auto & fn : vec ) {
+            if ( !fn.first->noAot && !fn.first->builtIn && fn.first != fun ) {
+                tw << ", " << fn.second << "=0x" << fn.first->hash;
+            }
+        }
+        tw << DEC;
+        return tw.str();
     }
 
     uint64_t getVariableListAotHash ( const vector<const Variable *> & globs, uint64_t initHash ) {

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -23,7 +23,10 @@ SET(AOT_DASLIB_MODULE_FILES
     daslib/fuzzer.das
     daslib/json.das
     daslib/json_boost.das
+    daslib/linq.das
+    daslib/linq_boost.das
     daslib/live.das
+    daslib/lpipe.das
     daslib/math_bits.das
     daslib/random.das
     daslib/regex.das
@@ -108,6 +111,19 @@ FILE(GLOB AOT_JOBQUE_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/jobque/*.das")
 
 # AOT for json test files
 FILE(GLOB AOT_JSON_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/json/*.das")
+
+# AOT for linq test files
+FILE(GLOB AOT_LINQ_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/linq/*.das")
+# Exclude module files (they are compiled via DAS_AOT_LIB below)
+list(FILTER AOT_LINQ_FILES EXCLUDE REGEX "/_")
+
+# Linq test module files (libraries required by linq tests)
+SET(AOT_LINQ_MODULE_FILES
+    tests/linq/_common.das
+)
+
+# AOT for lpipe test files
+FILE(GLOB AOT_LPIPE_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/lpipe/*.das")
 
 # AOT for language test files
 FILE(GLOB AOT_LANGUAGE_TEST_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/language/*.das")
@@ -212,6 +228,18 @@ add_custom_target(test_aot_json)
 SET(JSON_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_JSON_FILES}" JSON_AOT_GENERATED_SRC test_aot_json daslang)
 
+add_custom_target(test_aot_linq)
+SET(LINQ_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_LINQ_FILES}" LINQ_AOT_GENERATED_SRC test_aot_linq daslang)
+
+add_custom_target(test_aot_linq_modules)
+SET(LINQ_MODULES_AOT_GENERATED_SRC)
+DAS_AOT_LIB("${AOT_LINQ_MODULE_FILES}" LINQ_MODULES_AOT_GENERATED_SRC test_aot_linq_modules daslang)
+
+add_custom_target(test_aot_lpipe)
+SET(LPIPE_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_LPIPE_FILES}" LPIPE_AOT_GENERATED_SRC test_aot_lpipe daslang)
+
 add_custom_target(test_aot_language)
 SET(LANGUAGE_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_LANGUAGE_TEST_FILES}" LANGUAGE_AOT_GENERATED_SRC test_aot_language daslang)
@@ -247,6 +275,9 @@ SOURCE_GROUP_FILES("aot generated" HASH_MAP_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" INTERFACES_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" JOBQUE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" JSON_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" LINQ_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" LINQ_MODULES_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" LPIPE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LANGUAGE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LANGUAGE_MODULES_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DASLIB_MODULES_AOT_GENERATED_SRC)
@@ -277,6 +308,9 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
     ${INTERFACES_AOT_GENERATED_SRC}
     ${JOBQUE_AOT_GENERATED_SRC}
     ${JSON_AOT_GENERATED_SRC}
+    ${LINQ_AOT_GENERATED_SRC}
+    ${LINQ_MODULES_AOT_GENERATED_SRC}
+    ${LPIPE_AOT_GENERATED_SRC}
     ${LANGUAGE_AOT_GENERATED_SRC}
     ${LANGUAGE_MODULES_AOT_GENERATED_SRC}
     ${DASLIB_MODULES_AOT_GENERATED_SRC}
@@ -294,6 +328,7 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_handle_types test_aot_hash_map
     test_aot_interfaces
     test_aot_jobque test_aot_json
+    test_aot_linq test_aot_linq_modules test_aot_lpipe
     test_aot_language test_aot_language_modules
     test_aot_daslib_modules test_aot_decs_modules
 )


### PR DESCRIPTION
## AOT hash diagnostics, bugfixes, and expanded CI

### Hash comment diagnostics (permanent infrastructure)

When AOT linking fails with `error[50101]`, the root cause is a semantic hash mismatch between generated C++ and runtime. Diagnosing these was difficult because the error only showed the mismatched hash values with no breakdown.

This PR adds **hash comment diagnostics** that show the function's own hash and all non-builtin dependency hashes:

- `getAotHashComment()` C++ function in `simulate_fn_hash.cpp` — builds the diagnostic string
- `get_aot_hash_comment` binding in the `ast` module — accessible from daScript
- Generated C++ AOT stubs now include hash comments before each registration entry
- `linkCppAot()` error output now includes the same hash breakdown for comparison
- Both `aot_cpp.das` and `ast_aot_cpp.cpp` emit the comments (kept in sync)

### Bug fixes

- **decs path normalization**: `EcsRequestPos` in `decs.das` now normalizes backslashes to forward slashes in file paths. CMake passes forward-slash paths during AOT batch processing, but runtime uses OS-native backslashes — the raw path was embedded in the SIM tree, causing hash mismatches. This was the root cause of all 22 decs AOT failures.
- **Swizzle sentinel**: Changed `das_swizzle` default template parameters from `0` to `-1` in `aot.h`. Index 0 is a valid swizzle component (`.x`), so using it as a sentinel caused incorrect specialization selection.
- **dastest underscore skip**: `scan_dir` in `dastest/fs.das` now skips files starting with `_` (module/helper files that should not be run as standalone tests).

### AOT test expansion

- Added `linq`, `lpipe`, and `decs` test directories to `tests/aot/CMakeLists.txt`
- Added corresponding `--test` entries in `.github/workflows/build.yml` for both Windows and Linux/Mac

### Documentation

- Regenerated RST docs via `das2rst.das`
- Added `get_aot_hash_comment` to the "AOT support" group in `document_module_ast()`
- Fixed handmade stub for `is_same_type` (pre-existing) and created handmade for `get_aot_hash_comment`
- Updated `skills/aot_testing.md` with comprehensive hash architecture documentation
- Updated `CLAUDE.md` with AOT hash debugging section
