### PR TITLE
AOT: fix inf/nan codegen, topological struct sort, expand CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,7 +372,10 @@ jobs:
               --test ../../tests/jobque \
               --test ../../tests/language \
               --test ../../tests/linq \
-              --test ../../tests/lpipe
+              --test ../../tests/lpipe \
+              --test ../../tests/match \
+              --test ../../tests/math \
+              --test ../../tests/module_tests
             ;;
            *)
             cd bin
@@ -400,7 +403,10 @@ jobs:
               --test ../tests/jobque \
               --test ../tests/language \
               --test ../tests/linq \
-              --test ../tests/lpipe
+              --test ../tests/lpipe \
+              --test ../tests/match \
+              --test ../tests/math \
+              --test ../tests/module_tests
             ;;
         esac
 

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -4010,7 +4010,7 @@ def public run_aot(prog : Program?; var pctx : Context?; cop : CodeOfPolicies) :
                 var inscope adapter <- make_visitor(*cpp_aot)
                 cpp_aot.adapter := adapter
                 dumpDependencies(program, cpp_aot);
-                visit(program, cpp_aot.adapter)
+                visit(program, cpp_aot.adapter, true)
                 write(writer, "{cpp_aot.str()}");
                 delete cpp_aot.helper.helper
                 unsafe {

--- a/doc/source/stdlib/ast.rst
+++ b/doc/source/stdlib/ast.rst
@@ -5535,8 +5535,9 @@ Creates the appropriate call expression for a given function name in the program
 Visitor pattern
 +++++++++++++++
 
-  *  :ref:`visit (expression: smart_ptr\<TypeDecl\>; adapter: smart_ptr\<VisitorAdapter\>) : smart_ptr\<TypeDecl\> <function-ast_visit_smart_ptr_ls_TypeDecl_gr__smart_ptr_ls_VisitorAdapter_gr_>`
+  *  :ref:`visit (program: smart_ptr\<Program\>; adapter: smart_ptr\<VisitorAdapter\>; sortStructures: bool) <function-ast_visit_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr__bool>`
   *  :ref:`visit (program: smart_ptr\<Program\>; adapter: smart_ptr\<VisitorAdapter\>) <function-ast_visit_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr_>`
+  *  :ref:`visit (expression: smart_ptr\<TypeDecl\>; adapter: smart_ptr\<VisitorAdapter\>) : smart_ptr\<TypeDecl\> <function-ast_visit_smart_ptr_ls_TypeDecl_gr__smart_ptr_ls_VisitorAdapter_gr_>`
   *  :ref:`visit (function: smart_ptr\<Function\>; adapter: smart_ptr\<VisitorAdapter\>) <function-ast_visit_smart_ptr_ls_Function_gr__smart_ptr_ls_VisitorAdapter_gr_>`
   *  :ref:`visit (expression: smart_ptr\<Expression\>; adapter: smart_ptr\<VisitorAdapter\>) : smart_ptr\<Expression\> <function-ast_visit_smart_ptr_ls_Expression_gr__smart_ptr_ls_VisitorAdapter_gr_>`
   *  :ref:`visit_enumeration (program: smart_ptr\<Program\>; enumeration: smart_ptr\<Enumeration\>; adapter: smart_ptr\<VisitorAdapter\>) <function-ast_visit_enumeration_smart_ptr_ls_Program_gr__smart_ptr_ls_Enumeration_gr__smart_ptr_ls_VisitorAdapter_gr_>`
@@ -5549,20 +5550,26 @@ Visitor pattern
 visit
 ^^^^^
 
-.. _function-ast_visit_smart_ptr_ls_TypeDecl_gr__smart_ptr_ls_VisitorAdapter_gr_:
+.. _function-ast_visit_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr__bool:
 
-.. das:function:: visit(expression: smart_ptr<TypeDecl>; adapter: smart_ptr<VisitorAdapter>) : smart_ptr<TypeDecl>
+.. das:function:: visit(program: smart_ptr<Program>; adapter: smart_ptr<VisitorAdapter>; sortStructures: bool)
 
-Invokes an AST visitor on the given object.
+Visit the program with the given visitor adapter. When sortStructures is true, struct declarations are visited in topological (dependency) order, ensuring that structs used by value in fields are visited before the structs that contain them.
 
 
-:Arguments: * **expression** : smart_ptr< :ref:`TypeDecl <handle-ast-TypeDecl>`> implicit
+:Arguments: * **program** : smart_ptr< :ref:`Program <handle-rtti-Program>`> implicit
 
             * **adapter** : smart_ptr< :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`> implicit
+
+            * **sortStructures** : bool
 
 .. _function-ast_visit_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr_:
 
 .. das:function:: visit(program: smart_ptr<Program>; adapter: smart_ptr<VisitorAdapter>)
+
+.. _function-ast_visit_smart_ptr_ls_TypeDecl_gr__smart_ptr_ls_VisitorAdapter_gr_:
+
+.. das:function:: visit(expression: smart_ptr<TypeDecl>; adapter: smart_ptr<VisitorAdapter>) : smart_ptr<TypeDecl>
 
 .. _function-ast_visit_smart_ptr_ls_Function_gr__smart_ptr_ls_VisitorAdapter_gr_:
 

--- a/doc/source/stdlib/handmade/function-ast-visit-0xf59f9a04171d78f9.rst
+++ b/doc/source/stdlib/handmade/function-ast-visit-0xf59f9a04171d78f9.rst
@@ -1,0 +1,1 @@
+Visit the program with the given visitor adapter. When sortStructures is true, struct declarations are visited in topological (dependency) order, ensuring that structs used by value in fields are visited before the structs that contain them.

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1690,10 +1690,10 @@ namespace das
         TypeDecl * makeTypeDeclaration ( const LineInfo & at, const string & name );
         StructurePtr visitStructure(Visitor & vis, Structure *);
         EnumerationPtr visitEnumeration(Visitor & vis, Enumeration *);
-        void visitModule(Visitor & vis, Module * thatModule, bool visitGenerics = false);
+        void visitModule(Visitor & vis, Module * thatModule, bool visitGenerics = false, bool sortStructures = false);
         void visitModulesInOrder(Visitor & vis, bool visitGenerics = false);
         void visitModules(Visitor & vis, bool visitGenerics = false);
-        void visit(Visitor & vis, bool visitGenerics = false);
+        void visit(Visitor & vis, bool visitGenerics = false, bool sortStructures = false);
         void setPrintFlags();
         void aotCpp ( Context & context, TextWriter & logs, bool cross_platform = false );
         void registerAotCpp ( TextWriter & logs, Context & context, bool headers = true, bool allModules = false );

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -3231,13 +3231,82 @@ namespace das {
         vis.visitProgram(this);
     }
 
-    void Program::visit(Visitor & vis, bool visitGenerics ) {
+    void Program::visit(Visitor & vis, bool visitGenerics, bool sortStructures ) {
         vis.preVisitProgram(this);
-        visitModule(vis, thisModule.get(), visitGenerics);
+        visitModule(vis, thisModule.get(), visitGenerics, sortStructures);
         vis.visitProgram(this);
     }
 
-    void Program::visitModule(Visitor & vis, Module * thatModule, bool visitGenerics) {
+    static void collectStructDeps ( const TypeDeclPtr & type, Structure * owner, das_hash_set<Structure *> & deps ) {
+        if ( !type ) return;
+        if ( type->baseType == Type::tStructure && type->structType && type->structType != owner ) {
+            if ( type->isPointer() ) return;   // pointers don't need full definition
+            if ( !deps.insert(type->structType).second ) return;   // already visited
+            // recurse into the struct's own fields
+            for ( auto & field : type->structType->fields ) {
+                collectStructDeps(field.type, owner, deps);
+            }
+        }
+        // recurse into firstType / secondType for containers
+        if ( type->firstType ) collectStructDeps(type->firstType, owner, deps);
+        if ( type->secondType ) collectStructDeps(type->secondType, owner, deps);
+        // recurse into argTypes (e.g. tuple, variant element types)
+        for ( auto & argType : type->argTypes ) {
+            collectStructDeps(argType, owner, deps);
+        }
+    }
+
+    static void topoSortStructures ( vector<StructurePtr> & structs ) {
+        if ( structs.size() <= 1 ) return;
+        // build adjacency: struct -> set of structs it depends on (by value)
+        das_hash_map<Structure *, das_hash_set<Structure *>> deps;
+        das_hash_set<Structure *> allSet;
+        for ( auto & sp : structs ) {
+            allSet.insert(sp.get());
+        }
+        for ( auto & sp : structs ) {
+            auto & d = deps[sp.get()];
+            for ( auto & field : sp->fields ) {
+                collectStructDeps(field.type, sp.get(), d);
+            }
+            // only keep deps that are in our set
+            das_hash_set<Structure *> filtered;
+            for ( auto dep : d ) {
+                if ( allSet.count(dep) ) filtered.insert(dep);
+            }
+            d = das::move(filtered);
+        }
+        // Kahn's algorithm using vector as queue
+        das_hash_map<Structure *, int> inDegree;
+        for ( auto & [s, dd] : deps ) {
+            inDegree[s] = (int)dd.size();
+        }
+        vector<Structure *> sorted;
+        sorted.reserve(structs.size());
+        // seed with zero-dependency structs
+        for ( auto & sp : structs ) {
+            if ( inDegree[sp.get()] == 0 ) sorted.push_back(sp.get());
+        }
+        // process in FIFO order
+        for ( size_t qi = 0; qi < sorted.size(); qi++ ) {
+            auto s = sorted[qi];
+            for ( auto & [other, dd] : deps ) {
+                if ( dd.erase(s) ) {
+                    inDegree[other]--;
+                    if ( inDegree[other] == 0 ) sorted.push_back(other);
+                }
+            }
+        }
+        if ( sorted.size() != structs.size() ) return; // cycle - keep original order
+        // reorder structs to match sorted order
+        das_hash_map<Structure *, StructurePtr> byPtr;
+        for ( auto & sp : structs ) byPtr[sp.get()] = sp;
+        for ( size_t i = 0; i < sorted.size(); i++ ) {
+            structs[i] = byPtr[sorted[i]];
+        }
+    }
+
+    void Program::visitModule(Visitor & vis, Module * thatModule, bool visitGenerics, bool sortStructures) {
         vis.preVisitModule(thatModule);
         // enumerations
         thatModule->enumerations.foreach([&](auto & penum){
@@ -3250,16 +3319,34 @@ namespace das {
             }
         });
         // structures
-        thatModule->structures.foreach([&](auto & spst){
-            Structure * pst = spst.get();
-            if ( vis.canVisitStructure(pst) ) {
+        if ( sortStructures ) {
+            // collect, topologically sort, then visit
+            vector<StructurePtr> allStructs;
+            thatModule->structures.foreach([&](auto & spst){
+                if ( vis.canVisitStructure(spst.get()) ) {
+                    allStructs.push_back(spst);
+                }
+            });
+            topoSortStructures(allStructs);
+            for ( auto & spst : allStructs ) {
+                Structure * pst = spst.get();
                 StructurePtr pstn = visitStructure(vis, pst);
                 if ( pstn.get() != pst ) {
                     thatModule->structures.replace(pst->name, pstn);
-                    spst = pstn;
                 }
             }
-        });
+        } else {
+            thatModule->structures.foreach([&](auto & spst){
+                Structure * pst = spst.get();
+                if ( vis.canVisitStructure(pst) ) {
+                    StructurePtr pstn = visitStructure(vis, pst);
+                    if ( pstn.get() != pst ) {
+                        thatModule->structures.replace(pst->name, pstn);
+                        spst = pstn;
+                    }
+                }
+            });
+        }
         // aliases
         thatModule->aliasTypes.foreach([&](auto & alsv){
             vis.preVisitAlias(alsv.get(), alsv->alias);

--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -4428,7 +4428,7 @@ namespace das {
         visit(collector);
         dumpDependencies(this, aotVisitor);
         // now to the main body
-        visit(aotVisitor);
+        visit(aotVisitor, false, true);
         logs << aotVisitor.str();
     }
 }

--- a/src/builtin/module_builtin_ast_adapters.cpp
+++ b/src/builtin/module_builtin_ast_adapters.cpp
@@ -2462,6 +2462,14 @@ namespace das {
         program->visit(*adapter);
     }
 
+    void astVisitWithSort ( smart_ptr_raw<Program> program, smart_ptr_raw<VisitorAdapter> adapter, bool sortStructures, Context * context, LineInfoArg * line_info ) {
+        if (!adapter)
+            context->throw_error_at(line_info, "adapter is required");
+        if (!program)
+            context->throw_error_at(line_info, "program is required");
+        program->visit(*adapter, false, sortStructures);
+    }
+
     void astVisitModule ( smart_ptr_raw<Program> program, smart_ptr_raw<VisitorAdapter> adapter,
                           Module* module, Context * context, LineInfoArg * line_info ) {
         if (!adapter)
@@ -2540,6 +2548,9 @@ namespace das {
         addExtern<DAS_BIND_FUN(astVisit)>(*this, lib,  "visit",
             SideEffects::accessExternal, "astVisit")
                 ->args({"program","adapter","context","line"});
+        addExtern<DAS_BIND_FUN(astVisitWithSort)>(*this, lib,  "visit",
+            SideEffects::accessExternal, "astVisitWithSort")
+                ->args({"program","adapter","sortStructures","context","line"});
         addExtern<DAS_BIND_FUN(astVisitModulesInOrder)>(*this, lib,  "visit_modules",
             SideEffects::accessExternal, "astVisitModulesInOrder")
                 ->args({"program","adapter","context","line"});

--- a/src/simulate/runtime_string.cpp
+++ b/src/simulate/runtime_string.cpp
@@ -520,6 +520,8 @@ namespace das
         else if ( val==-DBL_MIN ) return "(-DBL_MIN)";
         else if ( val==DBL_MAX ) return "DBL_MAX";
         else if ( val==-DBL_MAX ) return "(-DBL_MAX)";
+        else if ( isinf(val) ) return val > 0 ? "((double)INFINITY)" : "((double)(-INFINITY))";
+        else if ( isnan(val) ) return "((double)NAN)";
         else {
             char buf[256];
             auto result = fmt::format_to(buf, FMT_STRING("{:.17e}"), val);
@@ -552,6 +554,8 @@ namespace das
         else if ( val==-FLT_MIN ) return "(-FLT_MIN)";
         else if ( val==FLT_MAX ) return "FLT_MAX";
         else if ( val==-FLT_MAX ) return "(-FLT_MAX)";
+        else if ( isinf(val) ) return val > 0 ? "INFINITY" : "(-INFINITY)";
+        else if ( isnan(val) ) return "NAN";
         else {
             char buf[256];
             auto result = fmt::format_to(buf, FMT_STRING("{:e}f"), val);

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -27,6 +27,7 @@ SET(AOT_DASLIB_MODULE_FILES
     daslib/linq_boost.das
     daslib/live.das
     daslib/lpipe.das
+    daslib/match.das
     daslib/math_bits.das
     daslib/random.das
     daslib/regex.das
@@ -121,6 +122,22 @@ list(FILTER AOT_LINQ_FILES EXCLUDE REGEX "/_")
 SET(AOT_LINQ_MODULE_FILES
     tests/linq/_common.das
 )
+
+# AOT for match test files
+FILE(GLOB AOT_MATCH_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/match/*.das")
+
+# AOT for math test files
+FILE(GLOB AOT_MATH_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/math/*.das")
+# Exclude module file (macro module, not a test)
+list(FILTER AOT_MATH_FILES EXCLUDE REGEX "fake_numeric")
+
+# Math test module files (libraries required by math tests)
+SET(AOT_MATH_MODULE_FILES
+    tests/math/fake_numeric.das
+)
+
+# AOT for module_tests test files
+FILE(GLOB AOT_MODULE_TESTS_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/module_tests/*.das")
 
 # AOT for lpipe test files
 FILE(GLOB AOT_LPIPE_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/lpipe/*.das")
@@ -236,6 +253,22 @@ add_custom_target(test_aot_linq_modules)
 SET(LINQ_MODULES_AOT_GENERATED_SRC)
 DAS_AOT_LIB("${AOT_LINQ_MODULE_FILES}" LINQ_MODULES_AOT_GENERATED_SRC test_aot_linq_modules daslang)
 
+add_custom_target(test_aot_match)
+SET(MATCH_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_MATCH_FILES}" MATCH_AOT_GENERATED_SRC test_aot_match daslang)
+
+add_custom_target(test_aot_math)
+SET(MATH_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_MATH_FILES}" MATH_AOT_GENERATED_SRC test_aot_math daslang)
+
+add_custom_target(test_aot_math_modules)
+SET(MATH_MODULES_AOT_GENERATED_SRC)
+DAS_AOT_LIB("${AOT_MATH_MODULE_FILES}" MATH_MODULES_AOT_GENERATED_SRC test_aot_math_modules daslang)
+
+add_custom_target(test_aot_module_tests)
+SET(MODULE_TESTS_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_MODULE_TESTS_FILES}" MODULE_TESTS_AOT_GENERATED_SRC test_aot_module_tests daslang)
+
 add_custom_target(test_aot_lpipe)
 SET(LPIPE_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_LPIPE_FILES}" LPIPE_AOT_GENERATED_SRC test_aot_lpipe daslang)
@@ -277,6 +310,10 @@ SOURCE_GROUP_FILES("aot generated" JOBQUE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" JSON_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LINQ_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LINQ_MODULES_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" MATCH_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" MATH_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" MATH_MODULES_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" MODULE_TESTS_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LPIPE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LANGUAGE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LANGUAGE_MODULES_AOT_GENERATED_SRC)
@@ -310,6 +347,10 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
     ${JSON_AOT_GENERATED_SRC}
     ${LINQ_AOT_GENERATED_SRC}
     ${LINQ_MODULES_AOT_GENERATED_SRC}
+    ${MATCH_AOT_GENERATED_SRC}
+    ${MATH_AOT_GENERATED_SRC}
+    ${MATH_MODULES_AOT_GENERATED_SRC}
+    ${MODULE_TESTS_AOT_GENERATED_SRC}
     ${LPIPE_AOT_GENERATED_SRC}
     ${LANGUAGE_AOT_GENERATED_SRC}
     ${LANGUAGE_MODULES_AOT_GENERATED_SRC}
@@ -328,7 +369,10 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_handle_types test_aot_hash_map
     test_aot_interfaces
     test_aot_jobque test_aot_json
-    test_aot_linq test_aot_linq_modules test_aot_lpipe
+    test_aot_linq test_aot_linq_modules
+    test_aot_match
+    test_aot_math test_aot_math_modules test_aot_module_tests
+    test_aot_lpipe
     test_aot_language test_aot_language_modules
     test_aot_daslib_modules test_aot_decs_modules
 )


### PR DESCRIPTION
## Summary

- **Fix MSVC AOT compilation of inf/nan**: `to_cpp_float`/`to_cpp_double` now emit `INFINITY`/`NAN` macros instead of `inff`/`nanf` which MSVC rejects
- **Topological sort for AOT struct declarations**: Added `sortStructures` flag to `Program::visitModule`/`Program::visit` that emits struct definitions in dependency order (Kahn's algorithm). Used by both `aot_cpp.das` and `ast_aot_cpp.cpp`
- **Re-enabled AOT tests**: `tests/math/inf_and_nan.das` and `tests/match/test_match_edge.das` now compile and pass under `test_aot`
- **CI expansion**: Added `match`, `math`, `module_tests` test directories to AOT test runs in `build.yml`
- **Doc regen**: Regenerated stdlib docs for the new `visit()` overload with `sortStructures` parameter

## Test plan

- [x] `test_aot` passes for match (51/51), math (86/86), module_tests (14/14)
- [x] CI build passes on all platforms (Linux, macOS, Windows 32/64)
