### PR TITLE
AOT: fix annotation_arguments, hash bugs, add 8 test dirs to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -375,7 +375,16 @@ jobs:
               --test ../../tests/lpipe \
               --test ../../tests/match \
               --test ../../tests/math \
-              --test ../../tests/module_tests
+              --test ../../tests/module_tests \
+              --test ../../tests/regex \
+              --test ../../tests/json \
+              --test ../../tests/safe_addr \
+              --test ../../tests/soa \
+              --test ../../tests/spoof \
+              --test ../../tests/strings \
+              --test ../../tests/template \
+              --test ../../tests/type_traits \
+              --test ../../tests/uri
             ;;
            *)
             cd bin
@@ -406,7 +415,16 @@ jobs:
               --test ../tests/lpipe \
               --test ../tests/match \
               --test ../tests/math \
-              --test ../tests/module_tests
+              --test ../tests/module_tests \
+              --test ../tests/regex \
+              --test ../tests/json \
+              --test ../tests/safe_addr \
+              --test ../tests/soa \
+              --test ../tests/spoof \
+              --test ../tests/strings \
+              --test ../tests/template \
+              --test ../tests/type_traits \
+              --test ../tests/uri
             ;;
         esac
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,10 @@ SETUP_COMPILER()
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+FILE(GLOB DAS_AOT_DASLIB_DEPENDS "${PROJECT_SOURCE_DIR}/daslib/*.das")
+
 MACRO(DAS_AOT_EXT input_files genList mainTarget dasAotTool dasAotToolArg)
-    set(all_depends ${dasAotTool})
+    set(all_depends ${dasAotTool} ${PROJECT_SOURCE_DIR}/utils/aot/main.das ${DAS_AOT_DASLIB_DEPENDS})
     set(all_outputs "")
     set(command_args "")
     list(LENGTH input_files num_files)

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -666,6 +666,15 @@ class public AotDebugInfoHelper {
             write(writer, "    for (auto& ann : annotations) \{\n")
             write(writer, "        ann.resolveAnnotation();\n")
             write(writer, "    \}\n")
+            helper |> debug_helper_iter_structs($(name, si) {
+                if (si.fields == null) { return ; }
+                for (fi in range(si.count)) {
+                    let fld & = unsafe(si.fields[fi])
+                    if (fld.annotation_arguments == null) { continue; }
+                    if (length(*fld.annotation_arguments) == 0) { continue; }
+                    write(writer, "    {structInfoName(si)}_field_{fi}.annotation_arguments = &{structInfoName(si)}_field_{fi}_ann;\n")
+                }
+            })
             write(writer, "\}\n\n")
             info2Name.clear();
             info2TypeName.clear();
@@ -702,6 +711,27 @@ class public AotDebugInfoHelper {
             writeArgNames(writer, fld, suffix);
             let prefix = (info.module_name |> length() > 0) ? "{info.module_name}::" : "";
             write(*writer, "VarInfo {structInfoName(info)}_field_{fi} =  \{ {describeCppVarInfo(prefix + info.name, fld,suffix)} \};\n");
+            if (fld.annotation_arguments != null) {
+                if (length(*fld.annotation_arguments) > 0) {
+                    let annArgs = build_string() $(var sb) {
+                        var first = true
+                        for (arg in *fld.annotation_arguments) {
+                            if (!first) { write(sb, ", "); }
+                            first = false
+                            if (arg.basicType == Type.tBool) {
+                                write(sb, "AnnotationArgument(\"{arg.name}\", {arg.bValue})")
+                            } elif (arg.basicType == Type.tString) {
+                                write(sb, "AnnotationArgument(\"{arg.name}\", string(\"{arg.sValue}\"))")
+                            } elif (arg.basicType == Type.tInt) {
+                                write(sb, "AnnotationArgument(\"{arg.name}\", {arg.iValue})")
+                            } elif (arg.basicType == Type.tFloat) {
+                                write(sb, "AnnotationArgument(\"{arg.name}\", {arg.fValue}f)")
+                            }
+                        }
+                    }
+                    write(*writer, "static AnnotationArguments {structInfoName(info)}_field_{fi}_ann = \{ {annArgs} \};\n")
+                }
+            }
         }
         let fields = (info.count |> range()
                                  |> each()

--- a/include/daScript/simulate/aot_builtin_string.h
+++ b/include/daScript/simulate/aot_builtin_string.h
@@ -148,7 +148,7 @@ namespace das {
     uint64_t builtin_build_hash_T ( TT && block, Context * /*context*/, LineInfoArg * /*at*/ ) {
         StringBuilderWriter writer;
         block(writer);
-        return hash_block64((const uint8_t *)writer.c_str(),size_t(writer.tellp()));
+        return hash_blockz64((const uint8_t *)writer.c_str());
     }
 
     inline uint64_t builtin_build_hash_T ( const Block &block, Context * context, LineInfoArg * at ) {

--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -635,8 +635,20 @@ namespace das {
             ss << "};\n";
             ss << "    for (auto& ann : annotations) {\n"
                   "        ann.resolveAnnotation();\n"
-                  "    }\n"
-                  "}\n\n";
+                  "    }\n";
+            // link annotation_arguments for VarInfo fields
+            for ( const auto & [_, sinfo] : ordered(smn2s) ) {
+                if ( !sinfo->fields ) continue;
+                for ( uint32_t fi=0, fis=sinfo->count; fi!=fis; ++fi ) {
+                    auto fld = sinfo->fields[fi];
+                    if ( !fld->annotation_arguments ) continue;
+                    auto aa = (AnnotationArguments *) fld->annotation_arguments;
+                    if ( aa->empty() ) continue;
+                    ss << "    " << structInfoName(sinfo) << "_field_" << fi
+                       << ".annotation_arguments = &" << structInfoName(sinfo) << "_field_" << fi << "_ann;\n";
+                }
+            }
+            ss << "}\n\n";
             info2Name.clear();
             info2TypeName.clear();
             return ss.str();
@@ -690,6 +702,34 @@ namespace das {
                 auto prefix = info->module_name != nullptr ? string(info->module_name) + "::" : "";
                 describeCppVarInfo(ss, (prefix + info->name), info->fields[fi],suffix);
                 ss << " };\n";
+                auto fld = info->fields[fi];
+                if ( fld->annotation_arguments ) {
+                    auto aa = (AnnotationArguments *) fld->annotation_arguments;
+                    if ( !aa->empty() ) {
+                        ss << "static AnnotationArguments " << structInfoName(info) << "_field_" << fi << "_ann = { ";
+                        bool first = true;
+                        for ( const auto & arg : *aa ) {
+                            if ( !first ) ss << ", ";
+                            first = false;
+                            if ( arg.type==Type::tBool ) {
+                                ss << "AnnotationArgument(\"" << arg.name << "\", " << (arg.bValue ? "true" : "false") << ")";
+                            } else if ( arg.type==Type::tString ) {
+                                ss << "AnnotationArgument(\"" << arg.name << "\", string(\"";
+                                for ( auto ch : arg.sValue ) {
+                                    if ( ch=='"' ) ss << "\\\"";
+                                    else if ( ch=='\\' ) ss << "\\\\";
+                                    else ss << ch;
+                                }
+                                ss << "\"))";
+                            } else if ( arg.type==Type::tInt ) {
+                                ss << "AnnotationArgument(\"" << arg.name << "\", " << arg.iValue << ")";
+                            } else if ( arg.type==Type::tFloat ) {
+                                ss << "AnnotationArgument(\"" << arg.name << "\", " << arg.fValue << "f)";
+                            }
+                        }
+                        ss << " };\n";
+                    }
+                }
             }
             ss << "VarInfo * " << structInfoName(info) << "_fields[" << info->count << "] =  { ";
             for ( uint32_t fi=0, fis=info->count; fi!=fis; ++fi ) {

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1877,7 +1877,7 @@ namespace das
         addExtern<DAS_BIND_FUN(_builtin_hash_ptr)>(*this, lib, "hash", SideEffects::none, "_builtin_hash_ptr")->arg("value");
         addExtern<DAS_BIND_FUN(_builtin_hash_float)>(*this, lib, "hash", SideEffects::none, "_builtin_hash_float")->arg("value");
         addExtern<DAS_BIND_FUN(_builtin_hash_double)>(*this, lib, "hash", SideEffects::none, "_builtin_hash_double")->arg("value");
-        addExtern<DAS_BIND_FUN(_builtin_hash_das_string)>(*this, lib, "hash", SideEffects::none, "_builtin_hash_string")->arg("value");
+        addExtern<DAS_BIND_FUN(_builtin_hash_das_string)>(*this, lib, "hash", SideEffects::none, "_builtin_hash_das_string")->arg("value");
         // table functions
         addExtern<DAS_BIND_FUN(builtin_table_clear)>(*this, lib, "_builtin_table_clear",
             SideEffects::modifyArgument, "builtin_table_clear")

--- a/src/builtin/module_builtin_uriparser.cpp
+++ b/src/builtin/module_builtin_uriparser.cpp
@@ -332,7 +332,7 @@ public:
                 ->args({"base","relative"});
         using remove_base_uri_method = DAS_CALL_MEMBER(das::Uri::removeBaseUri);
         addExtern<DAS_CALL_METHOD(remove_base_uri_method),SimNode_ExtFuncCallAndCopyOrMove>(*this, lib, "remove_base_uri",
-            SideEffects::none, DAS_CALL_MEMBER_CPP(das::Uri::BaseUri))
+            SideEffects::none, DAS_CALL_MEMBER_CPP(das::Uri::removeBaseUri))
                 ->args({"base","relative"});
         using normalize_method = DAS_CALL_MEMBER(das::Uri::normalize);
         addExtern<DAS_CALL_METHOD(normalize_method)>(*this, lib, "normalize",

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -31,6 +31,18 @@ SET(AOT_DASLIB_MODULE_FILES
     daslib/math_bits.das
     daslib/random.das
     daslib/regex.das
+    daslib/regex_boost.das
+    daslib/safe_addr.das
+    daslib/soa.das
+    daslib/spoof.das
+    daslib/linked_list.das
+    daslib/strings_boost.das
+    daslib/temp_strings.das
+    daslib/templates.das
+    daslib/type_traits.das
+    daslib/bitfield_trait.das
+    daslib/defer.das
+    daslib/uriparser_boost.das
 )
 
 add_custom_target(test_aot_daslib_modules)
@@ -138,6 +150,32 @@ SET(AOT_MATH_MODULE_FILES
 
 # AOT for module_tests test files
 FILE(GLOB AOT_MODULE_TESTS_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/module_tests/*.das")
+
+# AOT for regex test files
+FILE(GLOB AOT_REGEX_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/regex/*.das")
+
+# AOT for safe_addr test files
+FILE(GLOB AOT_SAFE_ADDR_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/safe_addr/*.das")
+
+# AOT for soa test files
+FILE(GLOB AOT_SOA_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/soa/*.das")
+
+# AOT for spoof test files
+FILE(GLOB AOT_SPOOF_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/spoof/*.das")
+
+# AOT for strings test files
+FILE(GLOB AOT_STRINGS_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/strings/*.das")
+# Exclude expect-error tests
+list(FILTER AOT_STRINGS_FILES EXCLUDE REGEX "_failed")
+
+# AOT for template test files
+FILE(GLOB AOT_TEMPLATE_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/template/*.das")
+
+# AOT for type_traits test files
+FILE(GLOB AOT_TYPE_TRAITS_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/type_traits/*.das")
+
+# AOT for uri test files
+FILE(GLOB AOT_URI_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/uri/*.das")
 
 # AOT for lpipe test files
 FILE(GLOB AOT_LPIPE_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/lpipe/*.das")
@@ -269,6 +307,38 @@ add_custom_target(test_aot_module_tests)
 SET(MODULE_TESTS_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_MODULE_TESTS_FILES}" MODULE_TESTS_AOT_GENERATED_SRC test_aot_module_tests daslang)
 
+add_custom_target(test_aot_regex)
+SET(REGEX_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_REGEX_FILES}" REGEX_AOT_GENERATED_SRC test_aot_regex daslang)
+
+add_custom_target(test_aot_safe_addr)
+SET(SAFE_ADDR_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_SAFE_ADDR_FILES}" SAFE_ADDR_AOT_GENERATED_SRC test_aot_safe_addr daslang)
+
+add_custom_target(test_aot_soa)
+SET(SOA_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_SOA_FILES}" SOA_AOT_GENERATED_SRC test_aot_soa daslang)
+
+add_custom_target(test_aot_spoof)
+SET(SPOOF_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_SPOOF_FILES}" SPOOF_AOT_GENERATED_SRC test_aot_spoof daslang)
+
+add_custom_target(test_aot_strings)
+SET(STRINGS_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_STRINGS_FILES}" STRINGS_AOT_GENERATED_SRC test_aot_strings daslang)
+
+add_custom_target(test_aot_template)
+SET(TEMPLATE_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_TEMPLATE_FILES}" TEMPLATE_AOT_GENERATED_SRC test_aot_template daslang)
+
+add_custom_target(test_aot_type_traits)
+SET(TYPE_TRAITS_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_TYPE_TRAITS_FILES}" TYPE_TRAITS_AOT_GENERATED_SRC test_aot_type_traits daslang)
+
+add_custom_target(test_aot_uri)
+SET(URI_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_URI_FILES}" URI_AOT_GENERATED_SRC test_aot_uri daslang)
+
 add_custom_target(test_aot_lpipe)
 SET(LPIPE_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_LPIPE_FILES}" LPIPE_AOT_GENERATED_SRC test_aot_lpipe daslang)
@@ -314,6 +384,14 @@ SOURCE_GROUP_FILES("aot generated" MATCH_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" MATH_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" MATH_MODULES_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" MODULE_TESTS_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" REGEX_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" SAFE_ADDR_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" SOA_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" SPOOF_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" STRINGS_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" TEMPLATE_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" TYPE_TRAITS_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" URI_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LPIPE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LANGUAGE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LANGUAGE_MODULES_AOT_GENERATED_SRC)
@@ -351,6 +429,14 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
     ${MATH_AOT_GENERATED_SRC}
     ${MATH_MODULES_AOT_GENERATED_SRC}
     ${MODULE_TESTS_AOT_GENERATED_SRC}
+    ${REGEX_AOT_GENERATED_SRC}
+    ${SAFE_ADDR_AOT_GENERATED_SRC}
+    ${SOA_AOT_GENERATED_SRC}
+    ${SPOOF_AOT_GENERATED_SRC}
+    ${STRINGS_AOT_GENERATED_SRC}
+    ${TEMPLATE_AOT_GENERATED_SRC}
+    ${TYPE_TRAITS_AOT_GENERATED_SRC}
+    ${URI_AOT_GENERATED_SRC}
     ${LPIPE_AOT_GENERATED_SRC}
     ${LANGUAGE_AOT_GENERATED_SRC}
     ${LANGUAGE_MODULES_AOT_GENERATED_SRC}
@@ -372,6 +458,9 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_linq test_aot_linq_modules
     test_aot_match
     test_aot_math test_aot_math_modules test_aot_module_tests
+    test_aot_regex
+    test_aot_safe_addr test_aot_soa test_aot_spoof test_aot_strings
+    test_aot_template test_aot_type_traits test_aot_uri
     test_aot_lpipe
     test_aot_language test_aot_language_modules
     test_aot_daslib_modules test_aot_decs_modules

--- a/tests/regex/test_regex_api.das
+++ b/tests/regex/test_regex_api.das
@@ -1,7 +1,6 @@
 options gen2
 options no_unused_function_arguments = false
 options no_unused_block_arguments = false
-options no_aot
 options persistent_heap
 require dastest/testing_boost public
 require daslib/regex_boost

--- a/tests/regex/test_regex_basic.das
+++ b/tests/regex/test_regex_basic.das
@@ -1,7 +1,6 @@
 options gen2
 options no_unused_function_arguments = false
 options no_unused_block_arguments = false
-options no_aot
 require dastest/testing_boost public
 require daslib/regex
 

--- a/tests/regex/test_regex_charclass.das
+++ b/tests/regex/test_regex_charclass.das
@@ -1,7 +1,6 @@
 options gen2
 options no_unused_function_arguments = false
 options no_unused_block_arguments = false
-options no_aot
 require dastest/testing_boost public
 require daslib/regex
 

--- a/tests/regex/test_regex_edge.das
+++ b/tests/regex/test_regex_edge.das
@@ -1,7 +1,6 @@
 options gen2
 options no_unused_function_arguments = false
 options no_unused_block_arguments = false
-options no_aot
 require dastest/testing_boost public
 require daslib/regex
 

--- a/tests/regex/test_regex_newfeatures.das
+++ b/tests/regex/test_regex_newfeatures.das
@@ -1,7 +1,6 @@
 options gen2
 options no_unused_function_arguments = false
 options no_unused_block_arguments = false
-options no_aot
 require dastest/testing_boost public
 require daslib/regex
 

--- a/tests/regex/test_regex_phase2.das
+++ b/tests/regex/test_regex_phase2.das
@@ -1,7 +1,6 @@
 options gen2
 options no_unused_function_arguments = false
 options no_unused_block_arguments = false
-
 require dastest/testing_boost public
 require daslib/regex_boost
 

--- a/tests/regex/test_regex_phase3.das
+++ b/tests/regex/test_regex_phase3.das
@@ -1,7 +1,6 @@
 options gen2
 options no_unused_function_arguments = false
 options no_unused_block_arguments = false
-options no_aot
 options persistent_heap
 require dastest/testing_boost public
 require daslib/regex_boost

--- a/tests/regex/test_strings_reexport.das
+++ b/tests/regex/test_strings_reexport.das
@@ -1,7 +1,6 @@
 options gen2
 options no_unused_function_arguments = false
 options no_unused_block_arguments = false
-
 require dastest/testing_boost public
 require daslib/regex
 // NOTE: no explicit "require strings" — should be visible via regex's "require strings public"


### PR DESCRIPTION
## Summary

- **Fix AOT `annotation_arguments` serialization**: `sprint_json` struct field annotations (`@optional`, `@enum_as_int`, `@embed`, `@unescape`, `@rename`) were silently ignored in AOT mode because VarInfo `annotation_arguments` was never populated in generated C++ code. Now generates static `AnnotationArguments` alongside VarInfo fields and links them during AOT init — both in `aot_cpp.das` (ground truth) and `ast_aot_cpp.cpp` (C++ fallback).
- **Fix `hash(das_string)` AOT cppName**: was `_builtin_hash_string` (doesn't exist), now `_builtin_hash_das_string`
- **Fix `builtin_build_hash_T` AOT template**: used `hash_block64` (length-based) instead of `hash_blockz64` (null-terminated), producing wrong hash values
- **Fix `Uri::removeBaseUri` AOT cppName**: was `BaseUri` (doesn't exist), now `removeBaseUri`
- **Add 8 test directories to AOT**: regex, json, safe_addr, soa, spoof, strings, template, type_traits, uri — all added to both `CMakeLists.txt` and CI `build.yml`
- **Remove redundant `options no_aot`** from regex test files

## Test plan

- [x] `test_aot --test tests/json/test_sprint_json.das` — 57/57 pass (was 49/57)
- [x] `test_aot --test tests/strings` — 384/384 pass
- [x] `test_aot --test tests/uri` — 13/13 pass
- [x] `test_aot --test tests/regex` — 278/278 pass
- [x] `test_aot --test tests` — 3517 pass, 0 fail, 45 errors (all JIT-only)
