### PR TITLE
ci: disable test_aot on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -347,8 +347,7 @@ jobs:
             echo "Skipping AOT tests on 32-bit Windows"
             ;;
            windows*)
-            cd bin/"${{ matrix.cmake_preset }}"
-            ./test_aot -use-aot _dasroot_/dastest/dastest.das -- --use-aot --color --test ../../tests
+            echo "Skipping AOT tests on Windows"
             ;;
            *)
             cd bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -959,7 +959,7 @@ SET(DAS_DASCRIPT_MAIN_SRC
 # Tests
 if (NOT ${DAS_TESTS_DISABLED})
     include(examples/pathTracer/CMakeLists.txt)
-    if(NOT ${DAS_AOT_EXAMPLES_DISABLED})
+    if(NOT ${DAS_AOT_EXAMPLES_DISABLED} AND NOT WIN32)
         include(tests/aot/CMakeLists.txt)
     endif()
 endif()


### PR DESCRIPTION
## Summary
- Skip building the `test_aot` target on WIN32 (`CMakeLists.txt`)
- Skip running AOT tests on all Windows targets in CI (`build.yml`)
