### PR TITLE
mcp: fix shared module caching across compile_check calls

### DIFF
--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -6,6 +6,7 @@ require dastest/testing_boost public
 require daslib/json
 require daslib/json_boost
 require strings
+require fio
 
 require tools/compile_check public
 require tools/list_functions public
@@ -932,5 +933,28 @@ def test_grep_usage_detect(t : T?) {
     t |> run("detects ast-grep") <| @(t : T?) {
         let sg = detect_ast_grep()
         t |> success(!empty(sg), "ast-grep should be detected in test environment")
+    }
+}
+
+// ── shared module caching ───────────────────────────────────────────
+
+[test]
+def test_shared_module_not_cached(t : T?) {
+    let shared_mod = "utils/mcp/tests/fixture_shared_mod.das"
+    let original = "options gen2\nmodule fixture_shared_mod shared\n\nstruct Foo \{\n    x : int = 0;\n\}\n"
+    let modified = "options gen2\nmodule fixture_shared_mod shared\n\nstruct Foo \{\n    x : int = 0;\n\}\n\nstruct Bar \{\n    y : int = 0;\n\}\n"
+    t |> run("sees new struct after shared module changes") <| @(t : T?) {
+        // 1. compile user1 — caches shared module with only Foo
+        var text : string
+        var is_error = false
+        parse_result(do_compile_check(fixture_path("_fixture_shared_user.das")), text, is_error)
+        t |> success(!is_error, "user1 should compile (Foo exists)")
+        // 2. add Bar to the shared module
+        t |> success(fwrite(shared_mod, modified), "should write modified shared module")
+        // 3. compile user2 — uses Bar, must see the updated module
+        parse_result(do_compile_check(fixture_path("_fixture_shared_user2.das")), text, is_error)
+        t |> success(!is_error, "user2 should compile (Bar should be visible after module change)")
+        // 4. restore original
+        fwrite(shared_mod, original)
     }
 }

--- a/utils/mcp/tests/_fixture_shared_user.das
+++ b/utils/mcp/tests/_fixture_shared_user.das
@@ -1,0 +1,8 @@
+options gen2
+require fixture_shared_mod
+
+[export]
+def main() {
+    var f = Foo(x = 42)
+    print("{f.x}\n")
+}

--- a/utils/mcp/tests/_fixture_shared_user2.das
+++ b/utils/mcp/tests/_fixture_shared_user2.das
@@ -1,0 +1,8 @@
+options gen2
+require fixture_shared_mod
+
+[export]
+def main() {
+    var b = Bar(y = 99)
+    print("{b.y}\n")
+}

--- a/utils/mcp/tests/fixture_shared_mod.das
+++ b/utils/mcp/tests/fixture_shared_mod.das
@@ -1,0 +1,6 @@
+options gen2
+module fixture_shared_mod shared
+
+struct Foo {
+    x : int = 0;
+}

--- a/utils/mcp/tools/common.das
+++ b/utils/mcp/tools/common.das
@@ -51,6 +51,7 @@ def compile_program(file : string; _export_all : bool; _no_opt : bool; project :
     using() <| $(var mg : ModuleGroup) {
         using() <| $(var cop : CodeOfPolicies) {
             cop.threadlock_context = true
+            cop.ignore_shared_modules = true
             if (_export_all) {
                 cop.export_all = true
             }


### PR DESCRIPTION
## Summary
- Fix MCP server caching `shared` modules across `compile_check` calls, causing stale structs/functions to be invisible after module changes
- Set `cop.ignore_shared_modules = true` in `compile_program()` so each compilation gets fresh shared modules
- Add regression test that modifies a shared module mid-session and verifies the new struct is visible

## Test plan
- [x] New test `test_shared_module_not_cached` fails without the fix, passes with it
- [x] All 129 MCP tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
