### PR TITLE
MCP: add aot tool for per-function AOT C++ extraction

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -1131,6 +1131,7 @@ class public CppAot : AstVisitor {
     prologue : bool = false;
     solidContext : bool = false;
     cross_platform : bool = false;
+    aot_filter_function : string;  // when set, emit markers around matching function
 
     cachedTi = new DebugVarCache()
 
@@ -1302,6 +1303,9 @@ class public CppAot : AstVisitor {
         return true;
     }
     def override preVisitFunction(fn : FunctionPtr) {
+        if (!empty(aot_filter_function) && (fn.name == aot_filter_function || aotFuncName(fn.get_ptr()) == aot_filter_function)) {
+            write(*ss, "\n/*<<AOT_FUNC_BEGIN>>*/");
+        }
         write(*ss, "\ninline ");
         describeLocalCppType(ss, fn.result, cross_platform, CpptSubstitureRef.no, CpptSkipConst.yes);
         write(*ss, " {aotFuncName(fn.get_ptr())} ( Context * __context__");
@@ -1348,6 +1352,9 @@ class public CppAot : AstVisitor {
             write(*ss, "}\n");
         } else {
             write(*ss, "\n");
+        }
+        if (!empty(aot_filter_function) && (fn.name == aot_filter_function || aotFuncName(fn.get_ptr()) == aot_filter_function)) {
+            write(*ss, "/*<<AOT_FUNC_END>>*/\n");
         }
         return fn;
     }
@@ -4067,6 +4074,72 @@ def public run_aot(prog : Program?; var pctx : Context?; cop : CodeOfPolicies) :
     }
 }
 
+
+let AOT_FUNC_BEGIN = "/*<<AOT_FUNC_BEGIN>>*/"
+let AOT_FUNC_END = "/*<<AOT_FUNC_END>>*/"
+
+[export]
+def public run_aot_function(prog : Program?; var pctx : Context?; cop : CodeOfPolicies; func_name : string) : string {
+    //! Generates AOT C++ for a single function, identified by name.
+    //! Returns the extracted function body, or empty string if not found.
+    let program <- unsafe(reinterpret<ProgramPtr>(prog));
+    return build_string() $(writer) {
+        let (modules_str, noAotModule) = getRequiredModulesFor(program)
+        if ((program._options |> find_arg("no_aot") ?as tBool ?? false) || noAotModule) {
+            return
+        }
+        build_string() $(tmp_writer) {
+            let marker_vis = new NoAotMarker();
+            var inscope adapter_marker <- make_visitor(*marker_vis)
+            visit(program, adapter_marker);
+
+            var coll = new BlockVariableCollector();
+            var inscope adapter_coll <- make_visitor(*coll)
+            visit(program, adapter_coll)
+
+            var pmarker = new PrologueMarker();
+            var inscope adapter_p <- make_visitor(*pmarker)
+            visit(program, adapter_p)
+
+            var flags = new SetPrinterFlags();
+            var inscope flags_adapter <- make_visitor(*flags)
+            visit(program, flags_adapter)
+
+            setAotHashes(program, *pctx)
+
+            var cpp_aot = new CppAot(ss = unsafe(addr(tmp_writer)),
+                                        program := program,
+                                        collector = coll,
+                                        prologue = program._options |> find_arg("aot_prologue") ?as tBool ?? false ||
+                                                program.getDebugger,
+                                        solidContext = program.policies.solid_context ||
+                                                (program._options |> find_arg("solid_context") ?as tBool ?? false),
+                                        cross_platform = cop.cross_platform,
+                                        aot_filter_function = func_name)
+            cpp_aot.helper.helper.rtti = program._options  |> find_arg("rtti") ?as tBool ?? false;
+            cpp_aot.helper.cross_platform = cop.cross_platform;
+            var inscope adapter <- make_visitor(*cpp_aot)
+            cpp_aot.adapter := adapter
+            dumpDependencies(program, cpp_aot);
+            visit(program, cpp_aot.adapter, true)
+            let full_output = cpp_aot.str()
+            delete cpp_aot.helper.helper
+            unsafe {
+                delete cpp_aot.collector
+                delete cpp_aot
+            }
+            // extract between markers
+            let begin_pos = find(full_output, AOT_FUNC_BEGIN)
+            if (begin_pos >= 0) {
+                let content_start = begin_pos + length(AOT_FUNC_BEGIN)
+                let end_pos = find(full_output, AOT_FUNC_END, content_start)
+                if (end_pos >= 0) {
+                    write(writer, slice(full_output, content_start, end_pos))
+                }
+            }
+        }
+    }
+}
 
 [export]
 def public aot(input : string; paranoid_validation : bool, cross_platform : bool; cop : CodeOfPolicies) : string {

--- a/utils/mcp/README.md
+++ b/utils/mcp/README.md
@@ -26,6 +26,7 @@ A minimal [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) serve
 | `describe_type` | Describe a type's fields, methods, values, and base type. Supports structs, classes, handled types, enums, bitfields, variants, tuples, typedefs |
 | `grep_usage` | Parse-aware symbol search across `.das` files using ast-grep + tree-sitter. Finds identifier occurrences excluding comments and strings. Conditional on `sg` CLI |
 | `outline` | List all declarations (functions, structs, classes, enums, bitfields, variants, globals, typedefs) in a file or set of files using tree-sitter. Works on broken/incomplete code — no compilation needed. Conditional on `sg` CLI |
+| `aot` | Generate AOT (ahead-of-time) C++ code for a `.das` file or a single function. Without `function`, returns full AOT output. With `function`, extracts that function's C++ only. Overloaded names return a disambiguation list with mangled names for exact selection |
 
 ## Setup
 
@@ -91,7 +92,8 @@ Optionally, allow the MCP tools without prompting by adding to `.claude/settings
       "mcp__daslang__eval_expression",
       "mcp__daslang__describe_type",
       "mcp__daslang__grep_usage",
-      "mcp__daslang__outline"
+      "mcp__daslang__outline",
+      "mcp__daslang__aot"
     ]
   }
 }

--- a/utils/mcp/protocol.das
+++ b/utils/mcp/protocol.das
@@ -32,6 +32,7 @@ require tools/eval_expression public
 require tools/describe_type public
 require tools/grep_usage public
 require tools/outline public
+require tools/aot public
 
 let HEAP_COLLECT_THRESHOLD = 1024ul * 1024ul  // 1 MB
 let LOG_FILE = "utils/mcp/mcp_server.log"
@@ -375,6 +376,16 @@ def handle_tools_list(id_json : string) : string {
             ["file"]
         ))
     }
+    result.tools |> emplace(make_tool(
+        "aot",
+        "Generate AOT (ahead-of-time) C++ code for a daScript file or a single function. Without 'function', returns the full AOT output. With 'function', returns C++ for that function only. If multiple functions match, returns the list of matches.",
+        {
+            "file" => PropertySchema(_type = "string", description = "Path to the .das file"),
+            "function" => PropertySchema(_type = "string", description = "Function name to extract AOT for. Supports exact name, method name (matches ClassName`method), and generic origin."),
+            "project" => PROJECT_PROP
+        },
+        ["file"]
+    ))
     return json_rpc_response(id_json, sprint_json(result, false))
 }
 
@@ -442,6 +453,8 @@ def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, project : string) : s
         return do_grep_usage(arg1, arg2, arg3, arg4)
     } elif (tool_name == "outline") {
         return do_outline(arg1, arg2)
+    } elif (tool_name == "aot") {
+        return do_aot(arg1, arg2, project)
     } else {
         return make_tool_result("unknown tool: {tool_name}", true)
     }
@@ -561,6 +574,12 @@ def handle_tools_call(id_json : string; params : JsonValue?) : string {
         }
     } elif (name == "list_modules") {
         // no args needed
+    } elif (name == "aot") {
+        arg1 = get_string_arg(args, "file")
+        if (empty(arg1)) {
+            return json_rpc_error(id_json, -32602, "missing 'file' argument")
+        }
+        arg2 = get_string_arg(args, "function")
     } else {
         return json_rpc_error(id_json, -32602, "unknown tool: {name}")
     }

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -27,6 +27,7 @@ require tools/eval_expression public
 require tools/describe_type public
 require tools/grep_usage public
 require tools/outline public
+require tools/aot public
 
 // helper: parse tool result JSON, return (text, isError)
 def parse_result(result : string; var text : string&; var is_error : bool&) : bool {
@@ -980,5 +981,100 @@ def test_shared_module_not_cached(t : T?) {
         t |> success(!is_error, "user2 should compile (Bar should be visible after module change)")
         // 4. restore original
         fwrite(shared_mod, original)
+    }
+}
+
+// ── aot ─────────────────────────────────────────────────────────────
+
+[test]
+def test_aot_full_file(t : T?) {
+    t |> run("full file AOT") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_aot(fixture_path("_fixture_valid.das"), ""), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(!is_error, "should not be error")
+        t |> success(find(text, "inline") >= 0, "should contain inline functions")
+        t |> success(find(text, "namespace das") >= 0, "should contain namespace")
+    }
+}
+
+[test]
+def test_aot_single_function(t : T?) {
+    t |> run("extracts single function by name") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_aot(fixture_path("_fixture_aot.das"), "helper"), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(!is_error, "should not be error")
+        t |> success(find(text, "inline") >= 0, "should contain inline keyword")
+        t |> success(find(text, "helper") >= 0, "should contain helper function name")
+        // should NOT contain describe
+        t |> success(find(text, "describe") < 0, "should not contain other functions")
+    }
+}
+
+[test]
+def test_aot_not_found(t : T?) {
+    t |> run("nonexistent function") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_aot(fixture_path("_fixture_aot.das"), "nonexistent"), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(!is_error, "should not be error (informational)")
+        t |> success(find(text, "No function matching") >= 0, "should say no match")
+        t |> success(find(text, "Available functions") >= 0, "should list available functions")
+    }
+}
+
+[test]
+def test_aot_multiple_matches(t : T?) {
+    t |> run("overloaded function returns disambiguation list") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_aot(fixture_path("_fixture_aot.das"), "describe"), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(!is_error, "should not be error")
+        t |> success(find(text, "Multiple functions match") >= 0, "should say multiple matches")
+        t |> success(find(text, "int") >= 0, "should show int overload signature")
+        t |> success(find(text, "float") >= 0, "should show float overload signature")
+    }
+}
+
+[test]
+def test_aot_select_by_aot_name(t : T?) {
+    t |> run("select overload by mangled aot_name") <| @(t : T?) {
+        // first get the disambiguation list to find the aot_name
+        var text : string
+        var is_error = false
+        parse_result(do_aot(fixture_path("_fixture_aot.das"), "describe"), text, is_error)
+        // extract an aot_name from the list (format: "describe(...) [describe_HEXHASH]")
+        let bracket_pos = find(text, "[describe_")
+        t |> success(bracket_pos >= 0, "should contain bracketed aot_name")
+        if (bracket_pos < 0) {
+            return
+        }
+        let name_start = bracket_pos + 1
+        let name_end = find(text, "]", name_start)
+        t |> success(name_end > name_start, "should have closing bracket")
+        if (name_end <= name_start) {
+            return
+        }
+        let aot_name = slice(text, name_start, name_end)
+        // now select by aot_name
+        parse_result(do_aot(fixture_path("_fixture_aot.das"), aot_name), text, is_error)
+        t |> success(!is_error, "should not be error")
+        t |> success(find(text, "inline") >= 0, "should contain inline function")
+        t |> success(find(text, aot_name) >= 0, "should contain the selected aot_name")
+    }
+}
+
+[test]
+def test_aot_missing_file(t : T?) {
+    t |> run("missing file reports error") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        parse_result(do_aot("nonexistent_file_12345.das", ""), text, is_error)
+        t |> success(is_error, "should be error")
     }
 }

--- a/utils/mcp/tests/_fixture_aot.das
+++ b/utils/mcp/tests/_fixture_aot.das
@@ -1,0 +1,20 @@
+options gen2
+
+def describe(x : int) {
+    print("int: {x}\n")
+}
+
+def describe(x : float) {
+    print("float: {x}\n")
+}
+
+def helper() {
+    print("helper\n")
+}
+
+[export]
+def main() {
+    describe(42)
+    describe(3.14)
+    helper()
+}

--- a/utils/mcp/tools/aot.das
+++ b/utils/mcp/tools/aot.das
@@ -1,0 +1,160 @@
+options gen2
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require common public
+require daslib/aot_cpp
+require daslib/ast_boost
+require strings
+
+struct AotFuncInfo {
+    name : string       // fn.name (daslang name)
+    aot_name : string   // mangled C++ name with hash
+    signature : string  // human-readable signature
+}
+
+def collect_aot_functions(program : smart_ptr<Program>) : array<AotFuncInfo> {
+    var result : array<AotFuncInfo>
+    let this_mod = program.getThisModule
+    this_mod |> for_each_module_function($(fn) {
+        if (fn.flags.noAot || fn.moreFlags.isTemplate || !fn.flags.used) {
+            return
+        }
+        if (fn.flags.builtIn || fn.flags.generated) {
+            return
+        }
+        var sig = build_string() <| $(var w) {
+            write(w, string(fn.name))
+            write(w, "(")
+            var first = true
+            for (i in range(length(fn.arguments))) {
+                if (fn.arguments[i]._type.baseType == Type.fakeContext || fn.arguments[i]._type.baseType == Type.fakeLineInfo) {
+                    continue
+                }
+                if (!first) {
+                    write(w, "; ")
+                }
+                first = false
+                write(w, "{string(fn.arguments[i].name)} : {describe(fn.arguments[i]._type)}")
+            }
+            write(w, ")")
+            if (fn.result != null && !fn.result.isVoid) {
+                write(w, " : {describe(fn.result)}")
+            }
+        }
+        result |> emplace(AotFuncInfo(
+            name = string(fn.name),
+            aot_name = aotFuncName(fn.get_ptr()),
+            signature = sig
+        ))
+    })
+    return <- result
+}
+
+def match_function_name(fn_name, query : string) : bool {
+    if (fn_name == query) {
+        return true
+    }
+    // method match: query "foo" matches "ClassName`foo"
+    let bt = find(fn_name, "`")
+    if (bt >= 0 && slice(fn_name, bt + 1) == query) {
+        return true
+    }
+    return false
+}
+
+def match_function_generic(fn_name, query : string; program : smart_ptr<Program>) : bool {
+    var found = false
+    let this_mod = program.getThisModule
+    this_mod |> for_each_module_function($(fn) {
+        if (found) {
+            return
+        }
+        if (string(fn.name) != fn_name) {
+            return
+        }
+        if (fn.fromGeneric != null && match_function_name(string(fn.fromGeneric.name), query)) {
+            found = true
+        }
+    })
+    return found
+}
+
+def do_aot(file, func_name : string; project : string = "") : string {
+    if (empty(file)) {
+        return make_tool_result("missing 'file' argument", true)
+    }
+
+    // full file AOT when no function specified
+    if (empty(func_name)) {
+        return compile_and_simulate_ctx(file, project) <| $(program : smart_ptr<Program>; var ctx : smart_ptr<Context>; issues : string) {
+            var warnings = ""
+            if (!empty(issues)) {
+                warnings = "Warnings:\n{issues}\n"
+            }
+            var result : string
+            using() <| $(var cop : CodeOfPolicies) {
+                cop.aot = false
+                cop.aot_module = true
+                result = "{warnings}{run_aot(program.get_ptr(), ctx.get_ptr(), cop)}"
+            }
+            return result
+        }
+    }
+
+    // single function AOT
+    return compile_and_simulate_ctx(file, project) <| $(program : smart_ptr<Program>; var ctx : smart_ptr<Context>; issues : string) {
+        let all_funcs <- collect_aot_functions(program)
+
+        // try exact match on fn.name first, then on aot_name
+        var matches : array<int>
+        for (i in range(length(all_funcs))) {
+            if (all_funcs[i].name == func_name) {
+                matches |> push(i)
+            }
+        }
+        // exact match on aot_name (mangled C++ name)
+        if (empty(matches)) {
+            for (i in range(length(all_funcs))) {
+                if (all_funcs[i].aot_name == func_name) {
+                    matches |> push(i)
+                }
+            }
+        }
+        // fuzzy: method match and generic origin
+        if (empty(matches)) {
+            for (i in range(length(all_funcs))) {
+                if (match_function_name(all_funcs[i].name, func_name) || match_function_generic(all_funcs[i].name, func_name, program)) {
+                    matches |> push(i)
+                }
+            }
+        }
+
+        if (empty(matches)) {
+            var sigs : array<string>
+            for (fi in all_funcs) {
+                sigs |> push(fi.signature)
+            }
+            return "No function matching '{func_name}' found.\nAvailable functions:\n" + join(sigs, "\n")
+        }
+        if (length(matches) == 1) {
+            let matched_name = all_funcs[matches[0]].aot_name
+            var result : string
+            using() <| $(var cop : CodeOfPolicies) {
+                cop.aot = false
+                cop.aot_module = true
+                result = run_aot_function(program.get_ptr(), ctx.get_ptr(), cop, matched_name)
+            }
+            if (empty(result)) {
+                return "Function '{matched_name}' produced no AOT output (marked noAot or no_aot)."
+            }
+            return result
+        }
+        // multiple matches — show signatures with aot_name for disambiguation
+        var lines : array<string>
+        for (idx in matches) {
+            lines |> push("{all_funcs[idx].signature}  [{all_funcs[idx].aot_name}]")
+        }
+        return "Multiple functions match '{func_name}':\n" + join(lines, "\n") + "\nUse the bracketed name for exact selection."
+    }
+}

--- a/utils/mcp/tools/common.das
+++ b/utils/mcp/tools/common.das
@@ -40,6 +40,34 @@ def compile_and_simulate(file : string; project : string = ""; blk : block<(prog
     return compile_program(file, false, false, project) <| blk
 }
 
+def compile_and_simulate_ctx(file : string; project : string = ""; blk : block<(program : smart_ptr<Program>; var ctx : smart_ptr<Context>; issues : string) : string>) : string {
+    var inscope access <- make_file_access(project)
+    var result : string
+    var had_error = false
+    using() <| $(var mg : ModuleGroup) {
+        using() <| $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            cop.ignore_shared_modules = true
+            compile_file(file, access, unsafe(addr(mg)), cop) <| $(ok; program; issues) {
+                if (!ok) {
+                    result = "Compilation failed:\n{issues}"
+                    had_error = true
+                } else {
+                    simulate(program) <| $(sok; var ctx; serrors) {
+                        if (!sok) {
+                            result = "Simulation failed:\n{serrors}"
+                            had_error = true
+                            return
+                        }
+                        result = invoke(blk, program, ctx, string(issues))
+                    }
+                }
+            }
+        }
+    }
+    return make_tool_result(result, had_error)
+}
+
 def compile_program(file : string; _export_all : bool; blk : block<(program : smart_ptr<Program>; issues : string) : string>) : string {
     return compile_program(file, _export_all, false, "") <| blk
 }


### PR DESCRIPTION
## Summary

- Add `aot` MCP tool that generates AOT C++ code for a whole `.das` file or a single function
- Uses marker-based extraction (`/*<<AOT_FUNC_BEGIN>>*/` / `/*<<AOT_FUNC_END>>*/`) in the `CppAot` visitor — all prep visitors still run on the full program so state is correct
- Function matching: exact `fn.name` → exact mangled `aotFuncName` → method name after backtick → generic origin
- Overloaded names return a disambiguation list with signatures and mangled names for exact selection
- Adds `run_aot_function()` public API to `daslib/aot_cpp.das`
- 6 new tests covering full file, single function, not found, multiple matches, disambiguation by aot_name, missing file

## Test plan

- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test utils/mcp/test_tools.das` — all AOT tests pass
- [x] MCP tool tested live via Claude Code (`mcp__daslang__aot`)
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
