### PR TITLE
Add daspkg-claude example bot with compile_check tool

### DIFF
--- a/examples/daspkg/daspkg-claude/daslang_helper_bot.das
+++ b/examples/daspkg/daspkg-claude/daslang_helper_bot.das
@@ -5,6 +5,7 @@ options no_unused_block_arguments = false
 
 require telegram/tbot
 require anthropic/anthropic
+require daslib/json_boost
 require fio
 require strings
 
@@ -23,15 +24,214 @@ def load_system_prompt() {
     print("Loaded system prompt ({length(system_prompt)} bytes)\n")
 }
 
+// ============================================================================
+// compile_check tool — compiles daslang code in-process
+// ============================================================================
+
+def compile_check_tool() : Tool {
+    return <- Tool(
+        name = "compile_check",
+        description = "Compile daslang code and return diagnostics. Use this to verify code before showing it to the user.",
+        input_schema = "\{\"type\":\"object\",\"properties\":\{\"code\":\{\"type\":\"string\",\"description\":\"daslang source code to compile\"\}\},\"required\":[\"code\"]\}"
+    )
+}
+
+def compile_check(code : string) : string {
+    let file_name = "__check__.das"
+    var inscope access <- make_file_access("sandbox.das_project")
+    set_file_source(access, file_name, code)
+    var result : string
+    using() <| $(var mg : ModuleGroup) {
+        using() <| $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            cop.ignore_shared_modules = true
+            compile_file(file_name, access, unsafe(addr(mg)), cop) <| $(ok; program; issues) {
+                if (!ok) {
+                    result = "Compilation FAILED:\n{issues}"
+                } else {
+                    var warnings = ""
+                    if (!empty(issues)) {
+                        warnings = "Warnings:\n{issues}\n"
+                    }
+                    result = "{warnings}Compilation OK."
+                }
+            }
+        }
+    }
+    return result
+}
+
+// ============================================================================
+// tool dispatch + narration
+// ============================================================================
+
+def html_escape(text : string) : string {
+    return build_string() $(var w) {
+        for (ch in text) {
+            if (ch == '&') {
+                w |> write("&amp;")
+            } elif (ch == '<') {
+                w |> write("&lt;")
+            } elif (ch == '>') {
+                w |> write("&gt;")
+            } else {
+                w |> write_char(int(ch))
+            }
+        }
+    }
+}
+
+// convert standard markdown to Telegram HTML
+// handles: ```code blocks```, **bold**, `inline code`
+def markdown_to_html(md : string) : string {
+    return build_string() $(var w) {
+        var i = 0
+        let n = length(md)
+        var in_code_block = false
+        while (i < n) {
+            // fenced code block: ```
+            if (i + 2 < n && character_at(md, i) == '`' && character_at(md, i + 1) == '`' && character_at(md, i + 2) == '`') {
+                if (!in_code_block) {
+                    in_code_block = true
+                    i += 3
+                    // skip optional language tag (e.g. "das\n")
+                    while (i < n && character_at(md, i) != '\n') {
+                        i++
+                    }
+                    if (i < n) {
+                        i++ // skip \n
+                    }
+                    w |> write("<pre>")
+                } else {
+                    in_code_block = false
+                    i += 3
+                    // skip trailing newline after closing ```
+                    if (i < n && character_at(md, i) == '\n') {
+                        i++
+                    }
+                    w |> write("</pre>")
+                }
+                continue
+            }
+            if (in_code_block) {
+                let ch = character_at(md, i)
+                if (ch == '&') {
+                    w |> write("&amp;")
+                } elif (ch == '<') {
+                    w |> write("&lt;")
+                } elif (ch == '>') {
+                    w |> write("&gt;")
+                } else {
+                    w |> write_char(ch)
+                }
+                i++
+                continue
+            }
+            // **bold**
+            if (i + 1 < n && character_at(md, i) == '*' && character_at(md, i + 1) == '*') {
+                let close = find(md, "**", i + 2)
+                if (close >= 0) {
+                    w |> write("<b>")
+                    w |> write(html_escape(slice(md, i + 2, close)))
+                    w |> write("</b>")
+                    i = close + 2
+                    continue
+                }
+            }
+            // `inline code`
+            if (character_at(md, i) == '`') {
+                let close = find(md, "`", i + 1)
+                if (close >= 0) {
+                    w |> write("<code>")
+                    w |> write(html_escape(slice(md, i + 1, close)))
+                    w |> write("</code>")
+                    i = close + 1
+                    continue
+                }
+            }
+            // regular character — escape
+            let ch = character_at(md, i)
+            if (ch == '&') {
+                w |> write("&amp;")
+            } elif (ch == '<') {
+                w |> write("&lt;")
+            } elif (ch == '>') {
+                w |> write("&gt;")
+            } else {
+                w |> write_char(ch)
+            }
+            i++
+        }
+    }
+}
+
+def send_html(chat_id, text : string) {
+    telegram_sendLongMessage(send_message(chat_id = chat_id, text = text, parse_mode = "HTML"))
+}
+
+def get_code_from_tool(tc : ToolUseBlock) : string {
+    let code_val = tc.input != null ? (tc.input.value as _object)?["code"] ?? default<JsonValue?> : null
+    if (code_val != null && code_val.value is _string) {
+        return code_val.value as _string
+    }
+    return ""
+}
+
+def preview(code : string; max_lines : int = 6) : string {
+    var lines : int
+    var pos = 0
+    while (pos < length(code) && lines < max_lines) {
+        let nl = find(code, "\n", pos)
+        if (nl < 0) {
+            break
+        }
+        pos = nl + 1
+        lines++
+    }
+    if (pos < length(code)) {
+        return slice(code, 0, pos) + "..."
+    }
+    return code
+}
+
+// ============================================================================
+// message handling
+// ============================================================================
+
 def handle_message(chat_id, user_name, text : string) {
     print("{user_name}: {text}\n")
-    // send "typing" indicator would be nice, but not in tbot API yet
     var config <- claude_config_from_env()
     var params : MessageCreateParams
     params.system = system_prompt
     params.messages |> emplace(user_message(text))
+    params.tools |> emplace(compile_check_tool())
+    var attempt = 0
     var error : string
-    var msg = create_message(config, params, error)
+    var msg = run_tool_loop(config, params, $(tc) {
+        if (tc.name != "compile_check") {
+            return "Error: unknown tool '{tc.name}'"
+        }
+        let code = get_code_from_tool(tc)
+        if (empty(code)) {
+            return "Error: missing 'code' parameter"
+        }
+        attempt++
+        print("  [tool] compile_check attempt {attempt} ({length(code)} bytes)\n")
+        let code_html = "<pre>{html_escape(preview(code))}</pre>"
+        if (attempt == 1) {
+            send_html(chat_id, "Verifying code...\n{code_html}")
+        } else {
+            send_html(chat_id, "Attempt {attempt} — fixing...\n{code_html}")
+        }
+        let result = compile_check(code)
+        let ok = find(result, "Compilation OK") >= 0
+        if (ok) {
+            send_html(chat_id, "<b>Compiles OK!</b>")
+        } else {
+            send_html(chat_id, "Compilation error:\n<pre>{html_escape(result)}</pre>")
+        }
+        return result
+    }, error)
     var reply : string
     if (!empty(error)) {
         reply = "Error: {error}"
@@ -40,7 +240,7 @@ def handle_message(chat_id, user_name, text : string) {
         reply = get_text(msg)
         print("  Reply: {length(reply)} chars, {msg.usage.input_tokens}+{msg.usage.output_tokens} tokens\n")
     }
-    telegram_sendLongMessage(send_message(chat_id = chat_id, text = reply))
+    send_html(chat_id, markdown_to_html(reply))
     let send_err = telegram_get_last_error()
     if (!empty(send_err)) {
         print("  Send error: {send_err}\n")
@@ -49,9 +249,7 @@ def handle_message(chat_id, user_name, text : string) {
 
 [export]
 def main() {
-    // load system prompt
     load_system_prompt()
-    // configure telegram
     var token = ""
     unsafe {
         token = get_env_variable("TELEGRAM_BOT_TOKEN")
@@ -67,7 +265,6 @@ def main() {
     if (empty(token)) {
         panic("No bot token. Set TELEGRAM_BOT_TOKEN or create .bot_token file")
     }
-    // verify anthropic key
     if (!has_env_variable("ANTHROPIC_API_KEY")) {
         panic("ANTHROPIC_API_KEY environment variable is not set")
     }

--- a/examples/daspkg/daspkg-claude/examples/daslang_helper/system_prompt.md
+++ b/examples/daspkg/daspkg-claude/examples/daslang_helper/system_prompt.md
@@ -83,13 +83,17 @@ length(arr)      // returns int
 - Annotations: `[export]`, `[private]`, `[test]`
 - `require` uses forward slash: `require daslib/json` -- NOT backslash
 
-## Common Modules
+## Modules Available in compile_check Sandbox
 
-- `strings` -- string manipulation (`to_int`, `to_float`, `split`, `join`, etc.)
+The `compile_check` tool runs in a sandbox. Only these modules are allowed:
 - `math` -- math functions
-- `daslib/json_boost` -- JSON serialization
-- `daslib/regex` -- regular expressions
+- `strings` -- string manipulation (`to_int`, `to_float`, `split`, `join`, etc.)
+- `daslib/strings_boost` -- extra string helpers
 - `daslib/algorithm` -- sorting, searching
+- `daslib/functional` -- functional programming helpers
+
+No file I/O, networking, JSON, regex, unsafe blocks, or `options rtti` allowed.
+If the user asks about modules outside the sandbox, explain the code but note it can't be verified.
 
 ## Response Format
 
@@ -98,6 +102,6 @@ When answering questions:
 2. Include necessary `require` statements
 3. Add `[export] def main() { ... }` so the code can be run directly
 4. Be concise -- show the code, explain briefly only if the pattern is non-obvious
-5. If you have access to the `run_code` tool, verify your code compiles before answering
+5. Always use the `compile_check` tool to verify your code compiles before answering
 
-When you use the `run_code` tool, the code runs in a sandbox with only safe modules (strings, math, daslib/*). No file I/O, no networking, no unsafe blocks.
+You have a `compile_check` tool that compiles daslang code and returns diagnostics. **Always use it** to verify code before showing it to the user. If compilation fails, fix the errors and re-check until the code compiles cleanly. The tool only checks compilation — it does not run the code.

--- a/examples/daspkg/daspkg-claude/sandbox.das_project
+++ b/examples/daspkg/daspkg-claude/sandbox.das_project
@@ -1,0 +1,88 @@
+options gen2
+
+// Sandbox policy for the compile_check tool.
+// Only safe modules are allowed — no file I/O, no networking, no unsafe blocks.
+
+require strings
+require daslib/strings_boost
+
+typedef module_info = tuple<string; string; string> const
+
+var DAS_PAK_ROOT = "./"
+
+// ---------------------------------------------------------------------------
+// module_get — resolve `require` paths to files
+// ---------------------------------------------------------------------------
+[export]
+def module_get(req, from : string) : module_info {
+    let rs <- split_by_chars(req, "./")
+    let mod_name = rs[length(rs) - 1]
+    if (length(rs) == 2 && rs[0] == "daslib") {
+        return (mod_name, "{get_das_root()}/daslib/{mod_name}.das", "")
+    }
+    // relative module
+    var fr <- split_by_chars(from, "/")
+    if (length(fr) > 0) {
+        pop(fr)
+    }
+    for (se in rs) {
+        push(fr, se)
+    }
+    return (mod_name, join(fr, "/") + ".das", "")
+}
+
+// ---------------------------------------------------------------------------
+// module_allowed — whitelist safe modules only
+// ---------------------------------------------------------------------------
+[export]
+def module_allowed(mod, filename : string) : bool {
+    // core
+    if (mod == "$") {
+        return true
+    }
+    // safe native modules
+    if (mod == "math" || mod == "strings") {
+        return true
+    }
+    // safe daslib modules
+    if (mod == "strings_boost" || mod == "utf8_utils") {
+        return true
+    }
+    if (mod == "algorithm" || mod == "functional") {
+        return true
+    }
+    return false
+}
+
+// ---------------------------------------------------------------------------
+// module_allowed_unsafe — no unsafe blocks
+// ---------------------------------------------------------------------------
+[export]
+def module_allowed_unsafe(mod, filename : string) : bool {
+    return false
+}
+
+// ---------------------------------------------------------------------------
+// option_allowed — cosmetic and gen2 options only
+// ---------------------------------------------------------------------------
+[export]
+def option_allowed(opt, from : string) : bool {
+    if (opt == "gen2" || opt == "indenting") {
+        return true
+    }
+    if (opt == "no_unused_function_arguments" || opt == "no_unused_block_arguments") {
+        return true
+    }
+    return false
+}
+
+// ---------------------------------------------------------------------------
+// annotation_allowed — common safe annotations
+// ---------------------------------------------------------------------------
+[export]
+def annotation_allowed(ann, from : string) : bool {
+    if (ann == "export" || ann == "private") {
+        return true
+    }
+    return false
+}


### PR DESCRIPTION
## Summary

- Add daspkg-claude example: a Telegram bot that answers daslang questions using Claude API
- Bot uses tool-use to compile-check code in a sandbox before responding to the user
- Narrates the verification process in the chat (shows code preview, compilation status)
- Renders Claude markdown response as Telegram HTML (pre, b, code tags)
- Sandbox .das_project restricts compile_check to safe modules only (no fio, networking, unsafe)

Depends on dasAnthropic and dasTelegram packages (installed via daspkg install).

Note: PR #2246 (popen-timeout) is in flight separately.

## Test plan

- [x] Bot compiles with daspkg modules installed
- [x] compile_check function tested in isolation (valid + invalid code)
- [x] Sandbox blocks fio, unsafe, options rtti, and transitive deps like json_boost
- [x] markdown_to_html tested: code blocks, bold, inline code, HTML escaping
