### PR TITLE
Add daspkg_build MCP tool and increase build timeouts

### DIFF
--- a/utils/mcp/protocol.das
+++ b/utils/mcp/protocol.das
@@ -481,6 +481,14 @@ def handle_tools_list(id_json : string) : string {
         },
         []
     ))
+    result.tools |> emplace(make_tool(
+        "daspkg_build",
+        "Build C/C++ packages that have CMakeLists.txt. Runs cmake configure and build for each package in the modules directory.",
+        {
+            "root" => PropertySchema(_type = "string", description = "Project root directory (default: daScript repo root)")
+        },
+        []
+    ))
     return json_rpc_response(id_json, sprint_json(result, false))
 }
 
@@ -566,6 +574,8 @@ def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, project : string) : s
         return do_daspkg_update(arg1, arg2)
     } elif (tool_name == "daspkg_upgrade") {
         return do_daspkg_upgrade(arg1, arg2)
+    } elif (tool_name == "daspkg_build") {
+        return do_daspkg_build(arg1)
     } else {
         return make_tool_result("unknown tool: {tool_name}", true)
     }
@@ -729,6 +739,8 @@ def handle_tools_call(id_json : string; params : JsonValue?) : string {
     } elif (name == "daspkg_update" || name == "daspkg_upgrade") {
         arg1 = get_string_arg(args, "name")
         arg2 = get_string_arg(args, "root")
+    } elif (name == "daspkg_build") {
+        arg1 = get_string_arg(args, "root")
     } elif (name == "aot") {
         arg1 = get_string_arg(args, "file")
         if (empty(arg1)) {

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -1173,6 +1173,16 @@ def test_daspkg_upgrade_no_lockfile(t : T?) {
     }
 }
 
+[test]
+def test_daspkg_build_no_packages(t : T?) {
+    t |> run("build with no buildable packages") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        parse_result(do_daspkg_build(""), text, is_error)
+        t |> success(find(text, "No packages") >= 0 || find(text, "no lock file") >= 0 || find(text, "No modules") >= 0 || find(text, "succeeded") >= 0, "should report build status")
+    }
+}
+
 // ── JSON output mode tests ──────────────────────────────────────────
 
 [test]

--- a/utils/mcp/tools/daspkg.das
+++ b/utils/mcp/tools/daspkg.das
@@ -6,7 +6,7 @@ require common public
 
 // Run a daspkg command, return (output, exit_code).
 // root defaults to get_das_root() (the daScript repo root).
-def private run_daspkg_raw(command : string; var output : string&; root : string = "") : int {
+def private run_daspkg_raw(command : string; var output : string&; root : string = ""; timeout_sec : float = 120.0) : int {
     let exe = get_daslang_exe()
     if (empty(exe)) {
         output = "Cannot determine daslang executable path"
@@ -14,14 +14,14 @@ def private run_daspkg_raw(command : string; var output : string&; root : string
     }
     let daspkg_script = "{get_das_root()}/utils/daspkg/main.das"
     let pkg_root = empty(root) ? get_das_root() : resolve_path(root)
-    return run_and_capture("{exe} {daspkg_script} -- {command} --root {pkg_root} --no-color", output, 120.0)
+    return run_and_capture("{exe} {daspkg_script} -- {command} --root {pkg_root} --no-color", output, timeout_sec)
 }
 
-def private run_daspkg(command : string; root : string = "") : string {
+def private run_daspkg(command : string; root : string = ""; timeout_sec : float = 120.0) : string {
     var output : string
-    let exit_code = run_daspkg_raw(command, output, root)
+    let exit_code = run_daspkg_raw(command, output, root, timeout_sec)
     if (exit_code == popen_timed_out) {
-        return make_tool_result("daspkg timed out after 120s:\n{output}", true)
+        return make_tool_result("daspkg timed out after {int(timeout_sec)}s:\n{output}", true)
     }
     if (exit_code != 0) {
         return make_tool_result("daspkg failed (exit code {exit_code}):\n{output}", true)
@@ -54,10 +54,10 @@ def do_daspkg_check(root : string) : string {
 
 def do_daspkg_install(spec, root : string; force : bool) : string {
     if (empty(spec)) {
-        return run_daspkg("install", root)
+        return run_daspkg("install", root, 600.0)
     }
     let force_flag = force ? " --force" : ""
-    return run_daspkg("install {spec}{force_flag}", root)
+    return run_daspkg("install {spec}{force_flag}", root, 600.0)
 }
 
 def do_daspkg_remove(name, root : string) : string {
@@ -66,14 +66,18 @@ def do_daspkg_remove(name, root : string) : string {
 
 def do_daspkg_update(name, root : string) : string {
     if (empty(name)) {
-        return run_daspkg("update", root)
+        return run_daspkg("update", root, 600.0)
     }
-    return run_daspkg("update {name}", root)
+    return run_daspkg("update {name}", root, 600.0)
 }
 
 def do_daspkg_upgrade(name, root : string) : string {
     if (empty(name)) {
-        return run_daspkg("upgrade", root)
+        return run_daspkg("upgrade", root, 600.0)
     }
-    return run_daspkg("upgrade {name}", root)
+    return run_daspkg("upgrade {name}", root, 600.0)
+}
+
+def do_daspkg_build(root : string) : string {
+    return run_daspkg("build", root, 600.0)
 }


### PR DESCRIPTION
## Summary
- Add `daspkg_build` as MCP tool #30 — builds C/C++ packages with CMakeLists.txt via cmake
- Increase timeout from 120s to 600s for `daspkg_install`, `daspkg_update`, and `daspkg_upgrade` since they can trigger CMake builds
- Add `daspkg_build` test case

## Test plan
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test utils/mcp/test_tools.das` passes
- [x] Invoke `daspkg_build` via MCP client and verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)