### PR TITLE
Fix type inference bugs in ast_infer_type and ast_typedecl

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -4927,7 +4927,8 @@ namespace das {
 
         vector<TypeDeclPtr> nonNamedTypes;
         if (!inferArguments(nonNamedTypes, expr->nonNamedArguments)) {
-            // TODO: report error
+            error("can't infer type of non-named argument in call to " + expr->name, "", "",
+                  expr->at, CompilationError::invalid_argument_type);
             return Visitor::visit(expr);
         }
         MatchingFunctions functions, generics;

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -277,7 +277,7 @@ namespace das
         } else {
             if ( decl->firstType ) updateAliasMap(decl->firstType, pass->firstType, aliases, options);
             if ( decl->secondType ) updateAliasMap(decl->secondType, pass->secondType, aliases, options);
-            for ( size_t iA=0, iAs = decl->argTypes.size(); iA!=iAs; ++iA ) {
+            for ( size_t iA=0, iAs = min(decl->argTypes.size(), pass->argTypes.size()); iA!=iAs; ++iA ) {
                 updateAliasMap(decl->argTypes[iA], pass->argTypes[iA], aliases, options);
             }
         }


### PR DESCRIPTION
## Summary

- **ast_infer_type.cpp**: Report a proper compilation error (`invalid_argument_type`) when type inference fails for non-named call arguments, instead of silently returning (was a `TODO: report error`)
- **ast_typedecl.cpp**: Prevent out-of-bounds access in `updateAliasMap` by using `min(decl->argTypes.size(), pass->argTypes.size())` when iterating arg types

fixes some of https://github.com/GaijinEntertainment/daScript/issues/2214