### PR TITLE
Update utils documentation: dascov, dastest, MCP

### DIFF
--- a/doc/source/reference/utils.rst
+++ b/doc/source/reference/utils.rst
@@ -5,12 +5,13 @@
 ==========
 
 This section documents the command-line tools that ship with daslang:
-the test framework, the package manager, and the MCP server for AI
-coding assistants.
+the test framework, the code coverage tool, the package manager, and
+the MCP server for AI coding assistants.
 
 .. toctree::
    :maxdepth: 2
 
    utils/dastest.rst
+   utils/dascov.rst
    utils/daspkg.rst
    utils/mcp.rst

--- a/doc/source/reference/utils/dascov.rst
+++ b/doc/source/reference/utils/dascov.rst
@@ -1,0 +1,158 @@
+.. _utils_dascov:
+
+.. index::
+   single: Utils; dascov
+   single: Utils; Code Coverage
+   single: Utils; LCOV
+
+=====================================
+ dascov --- Code Coverage
+=====================================
+
+dascov is a command-line tool for measuring code coverage of daslang
+programs.  It instruments code at compile time via ``daslib/coverage``,
+runs it, and reports per-file, per-function, and branch coverage.
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Quick start
+===========
+
+Measure coverage and print a brief summary::
+
+   daslang utils/dascov/main.das -- - path/to/script.das
+
+Measure coverage and write an LCOV report::
+
+   daslang utils/dascov/main.das -- coverage.lcov path/to/script.das
+
+View a summary of an existing LCOV file::
+
+   daslang utils/dascov/main.das -- coverage.lcov
+
+
+Usage modes
+===========
+
+dascov has two modes of operation: **instrument and measure** (runs a
+daslang program with coverage enabled) and **LCOV summary** (parses an
+existing LCOV file and prints a summary).
+
+Instrument and measure
+----------------------
+
+::
+
+   daslang utils/dascov/main.das -- <output> <input_file> [<args>...]
+
+- ``<output>`` -- coverage destination:
+
+  - ``-`` -- print a brief summary to stdout.
+  - ``<filename>`` -- write a full LCOV-format report to the file.
+
+- ``<input_file>`` -- the ``.das`` file to instrument and run.
+- ``<args>`` -- any remaining arguments are forwarded to the target
+  script as its command-line arguments.
+
+dascov compiles the target file with coverage instrumentation enabled,
+runs its ``main`` function, then collects and outputs the results.
+
+LCOV summary
+------------
+
+::
+
+   daslang utils/dascov/main.das -- <lcov_file> [--exclude <prefix>]...
+
+Parses an existing LCOV coverage file (e.g. produced by
+``dastest --cov-path``) and prints a human-readable summary to stdout.
+
+- ``<lcov_file>`` -- path to the LCOV file.
+- ``--exclude <prefix>`` -- skip files whose path starts with
+  *prefix*.  Can be repeated to exclude multiple prefixes.
+
+Example::
+
+   daslang utils/dascov/main.das -- coverage.lcov --exclude tests/ --exclude daslib/
+
+
+Output formats
+==============
+
+Brief summary (stdout)
+----------------------
+
+When the output is ``-``, dascov prints a columnar summary with
+per-file and per-function hit/miss counts::
+
+   Coverage Summary
+   ==============================================
+   File            Hits      Missed    Coverage
+   ----------------------------------------------
+   main.das        3         1         75%
+     main          3         1         75%
+   ----------------------------------------------
+   TOTAL           3         1         75%
+
+LCOV format (file)
+------------------
+
+When the output is a filename, dascov writes standard
+`LCOV <https://github.com/linux-test-project/lcov>`_ trace data.
+The format includes:
+
+- ``SF:<source_file>`` -- source file path
+- ``FN:<line>,<function>`` -- function definition
+- ``FNDA:<hits>,<function>`` -- function hit count
+- ``FNF:<count>`` / ``FNH:<count>`` -- functions found / hit
+- ``BRDA:<line>,<block>,<branch>,<hits>`` -- branch data
+- ``BRF:<count>`` / ``BRH:<count>`` -- branches found / hit
+- ``DA:<line>,<hits>`` -- line hit count
+- ``LF:<count>`` / ``LH:<count>`` -- lines found / hit
+
+This output is compatible with standard LCOV tools, IDE coverage
+plugins, and CI/CD integrations.
+
+
+Integration with dastest
+========================
+
+dastest can generate LCOV coverage data directly via the
+``--cov-path`` flag::
+
+   daslang dastest/dastest.das -- --test tests/ --cov-path coverage.lcov
+
+Each test file's coverage is appended to the output file.  After the
+run, use dascov to view a summary::
+
+   daslang utils/dascov/main.das -- coverage.lcov --exclude tests/
+
+This workflow gives you coverage of your library code exercised by
+your test suite, excluding the test files themselves.
+
+
+Programmatic use
+================
+
+The underlying ``daslib/coverage`` module can be used directly in
+daslang code.  Adding ``require daslib/coverage`` to a program enables
+compile-time coverage instrumentation via an ``[infer_macro]``.
+
+Key functions:
+
+- ``fill_coverage_report(dest, name)`` -- fill a string with LCOV
+  data (for cross-context use via ``invoke_in_context``).
+- ``fill_coverage_summary(dest, per_function)`` -- fill a string with
+  a brief summary.
+- ``summary_from_lcov_file(filename, excludes)`` -- parse an LCOV file
+  and return a summary string.
+
+
+.. seealso::
+
+   :ref:`utils_dastest` -- the test framework (generates LCOV via ``--cov-path``)
+
+   ``daslib/coverage`` -- the coverage instrumentation module

--- a/doc/source/reference/utils/dastest.rst
+++ b/doc/source/reference/utils/dastest.rst
@@ -121,6 +121,12 @@ Command-line arguments
    * - ``--failures-only``
      - Suppress PASS and RUN output; show only failures and the final
        summary.  Useful for large test runs where only errors matter.
+   * - ``--cov-path <path>``
+     - Enable code coverage and write an LCOV report to *path*.  Each
+       test file's coverage is appended (the file is truncated at the
+       start of the run).  Requires ``daslib/coverage``.  The resulting
+       file can be viewed with :ref:`utils_dascov` or standard LCOV
+       tools.
 
 Internal arguments (used by isolated mode):
 
@@ -337,3 +343,5 @@ Test file conventions
    :ref:`tutorial_testing` -- introductory tutorial on writing tests
 
    ``dastest/testing_boost`` -- the testing boost module (assertions, sub-tests, benchmarks)
+
+   :ref:`utils_dascov` -- standalone code coverage tool (parses LCOV output from ``--cov-path``)

--- a/doc/source/reference/utils/mcp.rst
+++ b/doc/source/reference/utils/mcp.rst
@@ -9,11 +9,11 @@
  MCP Server --- AI Tool Integration
 ===========================================
 
-The daslang MCP server exposes 29 compiler-backed tools to AI coding
+The daslang MCP server exposes 20 compiler-backed tools to AI coding
 assistants via the `Model Context Protocol <https://modelcontextprotocol.io/>`_.
 It provides compilation diagnostics, type inspection, go-to-definition,
 find-references, AST dump, AOT generation, expression evaluation,
-parse-aware grep, package management, and more.
+parse-aware grep, and more.
 
 Uses stdio transport -- no extra build dependencies.
 
@@ -57,7 +57,7 @@ session.
 Tools
 =====
 
-The server exposes 29 tools.  Each tool is invoked via MCP's
+The server exposes 20 tools.  Each tool is invoked via MCP's
 ``tools/call`` method.
 
 Compilation and diagnostics
@@ -89,7 +89,8 @@ Compilation and diagnostics
    * - ``list_module_api``
      - List all functions, types, enums, and globals exported by a
        builtin or daslib module.  Optional ``compact`` mode for large
-       modules.
+       modules, ``filter`` for substring matching, ``section`` to
+       limit output (e.g. ``functions``, ``structs``).
 
 Code navigation
 ---------------
@@ -198,38 +199,6 @@ Parse-aware search (tree-sitter)
        tree-sitter.  Works on broken/incomplete code -- no compilation
        needed.  Conditional on ``sg`` CLI.
 
-Package management (daspkg)
-----------------------------
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Tool
-     - Description
-   * - ``daspkg_search``
-     - Search the daspkg package index.  Returns matching packages as
-       JSON array.  Empty query returns all packages.
-   * - ``daspkg_info``
-     - Get full metadata for a single package by exact name.
-   * - ``daspkg_list``
-     - List all installed packages with sources, versions, and flags.
-   * - ``daspkg_check``
-     - Verify installed packages -- checks directories and
-       ``.das_module`` files.
-   * - ``daspkg_install``
-     - Install a package from GitHub, index, or local path.  Without
-       ``spec``, installs all dependencies from ``.das_package``.
-   * - ``daspkg_remove``
-     - Remove an installed package.
-   * - ``daspkg_update``
-     - Re-install package(s) at their pinned version.  Without
-       ``name``, updates all.
-   * - ``daspkg_upgrade``
-     - Upgrade package(s) to latest version.  Without ``name``,
-       upgrades all.
-
-
 ast-grep / tree-sitter setup
 =============================
 
@@ -310,15 +279,7 @@ Optionally, allow all MCP tools without prompting by adding to
          "mcp__daslang__describe_type",
          "mcp__daslang__grep_usage",
          "mcp__daslang__outline",
-         "mcp__daslang__aot",
-         "mcp__daslang__daspkg_search",
-         "mcp__daslang__daspkg_info",
-         "mcp__daslang__daspkg_list",
-         "mcp__daslang__daspkg_check",
-         "mcp__daslang__daspkg_install",
-         "mcp__daslang__daspkg_remove",
-         "mcp__daslang__daspkg_update",
-         "mcp__daslang__daspkg_upgrade"
+         "mcp__daslang__aot"
        ]
      }
    }


### PR DESCRIPTION
## Summary
- Add new documentation for the `dascov` code coverage tool (`utils/dascov/`)
- Add missing `--cov-path` parameter to dastest command-line docs
- Remove obsolete daspkg MCP tools section (8 tools removed, moved to CLI skill)
- Fix MCP tool count from 29 to 20
- Add `filter`/`section` params to `list_module_api` description

## Test plan
- [x] Sphinx build succeeds with zero warnings/errors
- [x] Verify dascov page renders correctly in built HTML
- [ ] Verify dastest `--cov-path` entry appears in command-line table
- [x] Verify MCP page no longer references daspkg tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)