### PR TITLE
Add error if not modules registered

### DIFF
--- a/src/ast/ast_module.cpp
+++ b/src/ast/ast_module.cpp
@@ -139,6 +139,10 @@ namespace das {
         daScriptEnvironment::ensure();
         g_envTotal ++;
 
+        if (daScriptEnvironment::getBound()->modules == nullptr) {
+            DAS_FATAL_ERROR("No modules founds. You should add modules before call that function.");
+        }
+
         // InitDependencies do not add new modules.
         vector<bool> mod_state;
         bool any = true;


### PR DESCRIPTION
Why: because now code write error like Unable to initialize some modules:, without any errors because modules is null