### PR TITLE
compiler: fix missed define

### DIFF
--- a/include/daScript/simulate/heap.h
+++ b/include/daScript/simulate/heap.h
@@ -375,7 +375,7 @@ namespace das {
 
     struct NodePrefix {
         uint32_t    size = 0;
-#ifdef NDEBUG
+#ifdef DAS_NO_ASSERTIONS
         uint32_t    magic;
 #else
         uint32_t    magic = 0xdeadc0de;


### PR DESCRIPTION
NDEBUG was replaced to DAS_NO_ASSERTIONS.

In NodePrefix NDEBUG was still used. So this fails:
```
    SimNode * SimNode::copyNode ( Context &, NodeAllocator * code ) {
        auto prefix = ((NodePrefix *)this) - 1;
#ifndef DAS_NO_ASSERTIONS
        DAS_ASSERTF(prefix->magic==0xdeadc0de,"node was allocated on the heap without prefix");
#endif
```