### PR TITLE
jit: match interpreter in prologue

### DIFF
--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -6555,7 +6555,7 @@ class public DisableJitVisitor : AstVisitor {
             if (ssrc_t.isRange || ssrc_t.dim |> length != 0 ||
                 ssrc_t.isGoodArrayType || ssrc_t.isIterator ||
                 ssrc_t.isString) {
-            } else {
+            } elif (!disable) {
                 assert(false,
                     "We shouldn't be here, all loop sources expected to be supported"
                 )

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -5242,7 +5242,7 @@ class public LlvmJitVisitor : AstVisitor {
         build_wrapper_function(fnmna, thisBlock.arguments, thisBlock.returnType, isCmres, captureType, thisBlock.at)
         build_function_entry(expr.at, hash(fnmna),
             thisBlock.blockFlags.hasMakeBlock || emit_prologue,
-            thisFunc.totalStackSize, thisBlock.arguments)
+            SIZE_OF_PROLOGUE, thisBlock.arguments)
         process_function_hints(thisBlock.annotations, thisBlock.arguments)
         process_labels(expr)
         process_finally(expr)

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -1,6 +1,7 @@
 options gen2
 options indenting = 4
 options strict_smart_pointers = false
+options stack = 4_194_304
 
 require llvm/daslib/llvm_boost
 require llvm/daslib/llvm_dll_utils


### PR DESCRIPTION
Earlier we pushed incorrect stack size when block was called. We should match interpreter behaviour and interpreter uses SIZE_OF_PROLOGUE.