### PR TITLE
gc: minor cleanup

### DIFF
--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -6382,10 +6382,6 @@ def public generate_globals_initialization_fn(ctx : Context?; prog : Program?;
     var inscope adapter = make_visitor(*visitor)
     visitor.adapter := adapter
 
-    // dummy Function with 0 arguments so get_context_param returns LLVMGetParam(ffunc, 0u)
-    var dummyFunc <- new Function(name := fn_name)
-    visitor.thisFunc = dummyFunc
-
     let globals_fn_type = LLVMFunctionType(types.t_void,
         array<LLVMTypeRef>(types.LLVMVoidPtrType())
     )
@@ -6401,7 +6397,13 @@ def public generate_globals_initialization_fn(ctx : Context?; prog : Program?;
     visitor.function_entry = entry
     LLVMPositionBuilderAtEnd(visitor.g_builder, body)
     let ctx_param = LLVMGetParam(globals_fn, 0u)
+
     ast_gc_guard() {
+
+        // dummy Function with 0 arguments so get_context_param returns LLVMGetParam(ffunc, 0u)
+        var dummyFunc <- new Function(name := fn_name)
+        visitor.thisFunc = dummyFunc
+
         prog |> for_each_module() $(mod) {
             mod |> for_each_global() $(glob) {
                 if (glob.init != null && glob.flags.used) {

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -572,6 +572,18 @@ namespace das {
         return false;
     }
 
+    struct GcCollectOnExit {
+        gc_guard & scope;
+        Program * prog = nullptr;
+        GcCollectOnExit(gc_guard & s) : scope(s) {}
+        GcCollectOnExit(gc_guard & s, Program * p) : scope(s), prog(p) {}
+        ~GcCollectOnExit() {
+            if ( !prog ) return;
+            prog->thisModule->gc_collect(&scope.guard_root);
+        }
+    };
+
+
     ProgramPtr parseDaScript ( const string & fileName,
                                const string & moduleName,
                               const FileAccessPtr & access,
@@ -582,15 +594,7 @@ namespace das {
                               CodeOfPolicies policies ) {
         ProgramPtr program = make_smart<Program>();
         gc_guard parse_gc_scope;
-        struct GcCollectOnExit {
-            gc_guard & scope;
-            Program * prog;
-            GcCollectOnExit(gc_guard & s, Program * p) : scope(s), prog(p) {}
-            ~GcCollectOnExit() {
-                if ( !prog ) return;
-                prog->thisModule->gc_collect(&scope.guard_root);
-            }
-        } parse_gc_collect(parse_gc_scope, program.get());
+        GcCollectOnExit parse_gc_collect(parse_gc_scope, program.get());
         program->library.renameModule(program->thisModule.get(), moduleName);
         ReuseCacheGuard rcg;
         auto time0 = ref_time_ticks();
@@ -1090,15 +1094,7 @@ namespace das {
                                 ModuleGroup & libGroup,
                                 CodeOfPolicies policies ) {
         gc_guard compile_gc_scope;
-        struct GcCollectOnExit {
-            gc_guard & scope;
-            Program * prog = nullptr;
-            GcCollectOnExit(gc_guard & s) : scope(s) {}
-            ~GcCollectOnExit() {
-                if ( !prog ) return;
-                prog->thisModule->gc_collect(&scope.guard_root);
-            }
-        } compile_gc_collect(compile_gc_scope);
+        GcCollectOnExit compile_gc_collect(compile_gc_scope);
         ReuseCacheGuard rcg;
         bool exportAll = policies.export_all;
         auto time0 = ref_time_ticks();

--- a/src/builtin/module_builtin_math.cpp
+++ b/src/builtin/module_builtin_math.cpp
@@ -267,7 +267,8 @@ namespace das {
         }
         virtual SimNode * simulateGetAt ( Context & context, const LineInfo & at, const TypeDeclPtr &,
                                          ExpressionPtr rv, ExpressionPtr idx, uint32_t ofs ) const override {
-            if ( auto tnode = trySimulate(context, rv, idx, new TypeDecl(Type::none), ofs) ) {
+            gc_local<TypeDecl> none = new TypeDecl(Type::none);
+            if ( auto tnode = trySimulate(context, rv, idx, none.ptr, ofs) ) {
                 return tnode;
             } else {
                 return context.code->makeNode<SimNode_At>(at,
@@ -279,7 +280,8 @@ namespace das {
         virtual SimNode * simulateGetAtR2V ( Context & context, const LineInfo & at, const TypeDeclPtr & readType,
                                             ExpressionPtr rv, ExpressionPtr idx, uint32_t ofs ) const override {
             auto r2vType = readType->baseType;
-            if ( auto tnode = trySimulate(context, rv, idx, new TypeDecl(r2vType), ofs) ) {
+            gc_local<TypeDecl> r2vTypeDecl = new TypeDecl(r2vType);
+            if ( auto tnode = trySimulate(context, rv, idx, r2vTypeDecl.ptr, ofs) ) {
                 return tnode;
             } else {
                 return context.code->makeValueNode<SimNode_AtR2V>(  r2vType, at,


### PR DESCRIPTION
## Summary

- Move `dummyFunc` creation inside `ast_gc_guard()` scope in LLVM JIT globals initialization to ensure proper GC lifetime
- Deduplicate `GcCollectOnExit` struct in `ast_parse.cpp` (was defined twice locally, now a single file-scope struct)
- Fix GC leaks in `module_builtin_math.cpp` — use `gc_local<TypeDecl>` instead of bare `new TypeDecl`

## Test plan

- [x] 6037 tests pass (0 failed, 0 errors)
- [x] Lint: all issues pre-existing, none introduced