### PR TITLE
make_visitor: replace smart_ptr return with block-based API

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -1118,7 +1118,7 @@ class public CppAot : AstVisitor {
     }
 */
 
-    adapter : smart_ptr<VisitorAdapter>
+    adapter : VisitorAdapter ?
 
     def str() {
         let maybe_nl = type_info |> empty() ? "" : "\n";
@@ -3761,8 +3761,9 @@ class public CppAot : AstVisitor {
 def public dumpDependencies(program : ProgramPtr; var aotVisitor : CppAot?) {
     //! Writes forward declarations and dependent type/function definitions for AOT output.
     let utm = new UseTypeMarker();
-    var inscope adapter <- make_visitor(*utm)
-    visit(program, adapter);
+    make_visitor(*utm) $(adapter) {
+        visit(program, adapter);
+    }
     let remUS = program._options  |> find_arg("remove_unused_symbols") ?as tBool ?? true;
     program.get_ptr() |> for_each_module_no_order($(pm) {
         if (pm.moduleFlags.fromExtraDependency) {
@@ -3894,8 +3895,9 @@ def public collectProgramUsedFunctions(program : ProgramPtr; all_modules : bool;
 def registerAotCpp(var logs : StringBuilderWriter?; program : ProgramPtr; var context : Context; cross_platform; headers, all_modules : bool = false) {
     let fnn = collectProgramUsedFunctions(program, all_modules, false);
     let visitor = new ArgsConverter(logs, cross_platform);
-    var inscope adapter_marker <- make_visitor(*visitor)
-    visit(program, adapter_marker);
+    make_visitor(*visitor) $(adapter_marker) {
+        visit(program, adapter_marker);
+    }
 
     var funInit = false;
     for (fn in fnn) {
@@ -4051,21 +4053,25 @@ def public run_aot(prog : Program?; var pctx : Context?; cop : CodeOfPolicies) :
             write(writer, "namespace {program.thisNamespace} \{\n");
             build_string() $(tmp_writer) {
                 let marker_vis = new NoAotMarker();
-                var inscope adapter_marker <- make_visitor(*marker_vis)
-                visit(program, adapter_marker);
+                make_visitor(*marker_vis) $(adapter_marker) {
+                    visit(program, adapter_marker);
+                }
 
                 var coll = new BlockVariableCollector();
-                var inscope adapter_coll <- make_visitor(*coll)
-                visit(program, adapter_coll)
+                make_visitor(*coll) $(adapter_coll) {
+                    visit(program, adapter_coll)
+                }
 
                 // mark prologue
                 var pmarker = new PrologueMarker();
-                var inscope adapter_p <- make_visitor(*pmarker)
-                visit(program, adapter_p)
+                make_visitor(*pmarker) $(adapter_p) {
+                    visit(program, adapter_p)
+                }
 
                 var flags = new SetPrinterFlags();
-                var inscope flags_adapter <- make_visitor(*flags)
-                visit(program, flags_adapter)
+                make_visitor(*flags) $(flags_adapter) {
+                    visit(program, flags_adapter)
+                }
 
 
                 setAotHashes(program, *pctx)
@@ -4080,10 +4086,11 @@ def public run_aot(prog : Program?; var pctx : Context?; cop : CodeOfPolicies) :
                                             cross_platform = cop.cross_platform)
                 cpp_aot.helper.helper.rtti = program._options  |> find_arg("rtti") ?as tBool ?? false;
                 cpp_aot.helper.cross_platform = cop.cross_platform;
-                var inscope adapter <- make_visitor(*cpp_aot)
-                cpp_aot.adapter := adapter
-                dumpDependencies(program, cpp_aot);
-                visit(program, cpp_aot.adapter, true)
+                make_visitor(*cpp_aot) $(adapter) {
+                    cpp_aot.adapter := adapter
+                    dumpDependencies(program, cpp_aot);
+                    visit(program, cpp_aot.adapter, true)
+                }
                 write(writer, "{cpp_aot.str()}");
                 delete cpp_aot.helper.helper
                 unsafe {
@@ -4125,20 +4132,24 @@ def public run_aot_function(prog : Program?; var pctx : Context?; cop : CodeOfPo
         }
         build_string() $(tmp_writer) {
             let marker_vis = new NoAotMarker();
-            var inscope adapter_marker <- make_visitor(*marker_vis)
-            visit(program, adapter_marker);
+            make_visitor(*marker_vis) $(adapter_marker) {
+                visit(program, adapter_marker);
+            }
 
             var coll = new BlockVariableCollector();
-            var inscope adapter_coll <- make_visitor(*coll)
-            visit(program, adapter_coll)
+            make_visitor(*coll) $(adapter_coll) {
+                visit(program, adapter_coll)
+            }
 
             var pmarker = new PrologueMarker();
-            var inscope adapter_p <- make_visitor(*pmarker)
-            visit(program, adapter_p)
+            make_visitor(*pmarker) $(adapter_p) {
+                visit(program, adapter_p)
+            }
 
             var flags = new SetPrinterFlags();
-            var inscope flags_adapter <- make_visitor(*flags)
-            visit(program, flags_adapter)
+            make_visitor(*flags) $(flags_adapter) {
+                visit(program, flags_adapter)
+            }
 
             setAotHashes(program, *pctx)
 
@@ -4153,10 +4164,11 @@ def public run_aot_function(prog : Program?; var pctx : Context?; cop : CodeOfPo
                                         aot_filter_function = func_name)
             cpp_aot.helper.helper.rtti = program._options  |> find_arg("rtti") ?as tBool ?? false;
             cpp_aot.helper.cross_platform = cop.cross_platform;
-            var inscope adapter <- make_visitor(*cpp_aot)
-            cpp_aot.adapter := adapter
-            dumpDependencies(program, cpp_aot);
-            visit(program, cpp_aot.adapter, true)
+            make_visitor(*cpp_aot) $(adapter) {
+                cpp_aot.adapter := adapter
+                dumpDependencies(program, cpp_aot);
+                visit(program, cpp_aot.adapter, true)
+            }
             let full_output = cpp_aot.str()
             delete cpp_aot.helper.helper
             unsafe {

--- a/daslib/aot_standalone.das
+++ b/daslib/aot_standalone.das
@@ -333,9 +333,10 @@ def genStandaloneSrc(var program : ProgramPtr;
     let ctx_generated = build_string() $(tw) {
         let deps = build_string() $(tmp_writer) {
             var cpp_aot = new CppAot(program := program, collector = coll, ss = unsafe(addr(tmp_writer)), cross_platform = cfg.cross_platform);
-            var inscope aot_adapter <- make_visitor(*cpp_aot)
-            cpp_aot.adapter := aot_adapter
-            dumpDependencies(program, cpp_aot);
+            make_visitor(*cpp_aot) $(aot_adapter) {
+                cpp_aot.adapter := aot_adapter
+                dumpDependencies(program, cpp_aot);
+            }
             unsafe {
                 delete cpp_aot
             }
@@ -343,9 +344,10 @@ def genStandaloneSrc(var program : ProgramPtr;
         write(tw, deps);
         build_string() $(tmp_writer) {
             var gen = new StandaloneContextGen(program, unsafe(addr(tmp_writer)), coll, cfg.cross_platform);
-            var inscope adapter <- make_visitor(*gen)
-            gen.adapter := adapter
-            program |> visit_module(adapter, program.getThisModule);
+            make_visitor(*gen) $(adapter) {
+                gen.adapter := adapter
+                program |> visit_module(adapter, program.getThisModule);
+            }
 
             initFunctions = addFunctionInfo(program._options |> find_arg("no_init") ?as tBool ?? program.policies.no_init,
                                             program._options |> find_arg("rtti") ?as tBool ?? program.policies.rtti,
@@ -371,19 +373,22 @@ def public runStandaloneVisitor(var program : ProgramPtr, modules : array<string
 
     // mark prologue
     var pmarker = new PrologueMarker();
-    var inscope adapter_p <- make_visitor(*pmarker)
-    visit(program, adapter_p)
+    make_visitor(*pmarker) $(adapter_p) {
+        visit(program, adapter_p)
+    }
 
     setAotHashes(program, context);
 
     // now, for that AOT
     var flags = new SetPrinterFlags();
-    var inscope flags_adapter <- make_visitor(*flags)
-    visit(program, flags_adapter)
+    make_visitor(*flags) $(flags_adapter) {
+        visit(program, flags_adapter)
+    }
 
     var coll = new BlockVariableCollector();
-    var inscope adapter_coll <- make_visitor(*coll)
-    visit(program, adapter_coll)
+    make_visitor(*coll) $(adapter_coll) {
+        visit(program, adapter_coll)
+    }
 
     let mod = program.getThisModule;
     // if ( mod.isProperBuiltin() ) return true;

--- a/daslib/ast.das
+++ b/daslib/ast.das
@@ -702,16 +702,15 @@ def make_enumeration_annotation(name : string; var someClassPtr) : EnumerationAn
     }
 }
 
-def make_visitor(someClass) : smart_ptr<VisitorAdapter> {
+def make_visitor(someClass; blk : block<(var adapter : VisitorAdapter?) : void>) {
     static_if (typeinfo is_class(someClass)) {
         unsafe {
             let classPtr = addr(someClass)
             let classInfo = class_info(someClass)
-            return <- make_visitor(classPtr, classInfo)
+            make_visitor(classPtr, classInfo, blk)
         }
     } else {
         concept_assert(false, "can't make visitor of non-class")
-        return <- default<smart_ptr<VisitorAdpater>>
     }
 }
 

--- a/daslib/ast_block_to_loop.das
+++ b/daslib/ast_block_to_loop.das
@@ -112,8 +112,9 @@ def public convert_block_to_loop(var blk : Expression?; failOnReturn, replaceRet
     //! If `replaceReturnWithContinue` is true, then `return cond;` are replaced with `if cond; continue;`.
     //! If `requireContinueCond` is false, then `return;` is replaced with `continue;`, otherwise it is an error.
     var astVisitor = new B2LVisitor(failOnReturn, replaceReturnWithContinue, requireContinueCond)
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    visit(blk, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit(blk, astVisitorAdapter)
+    }
     unsafe {
         delete astVisitor
     }

--- a/daslib/ast_cursor.das
+++ b/daslib/ast_cursor.das
@@ -148,8 +148,9 @@ def private reverse_hits(var src : array<CursorHit>) : array<CursorHit> {
 //! `file` is a substring matched against ``FileInfo.name`` (use "" to match any file).
 def public find_at_cursor(program : smart_ptr<Program>; file : string; line, col : int) : array<CursorHit> {
     var visitor = new CursorVisitor(file, line, col)
-    var inscope adapter <- make_visitor(*visitor)
-    visit(program, adapter)
+    make_visitor(*visitor) $(adapter) {
+        visit(program, adapter)
+    }
     // visitor collects parent-first (depth-first pre-order), reverse for innermost-first
     var result <- reverse_hits(visitor.hits)
     unsafe {
@@ -163,8 +164,9 @@ def public find_at_cursor(program : smart_ptr<Program>; file : string; line, col
 def public find_at_cursor_in_function(func : FunctionPtr; file : string; line, col : int) : array<CursorHit> {
     var visitor = new CursorVisitor(file, line, col)
     visitor.currentFunc = func
-    var inscope adapter <- make_visitor(*visitor)
-    visit(func, adapter)
+    make_visitor(*visitor) $(adapter) {
+        visit(func, adapter)
+    }
     var result <- reverse_hits(visitor.hits)
     unsafe {
         delete visitor

--- a/daslib/ast_print.das
+++ b/daslib/ast_print.das
@@ -1265,8 +1265,9 @@ def allExpr(arg : int) {
 def test {
     //! Self-test: visits this program's AST and prints it.
     var astVisitor = new PrintVisitor();
-    var astVisitorAdapter <- make_visitor(*astVisitor);
-    visit(this_program(), astVisitorAdapter);
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit(this_program(), astVisitorAdapter);
+    }
 
 /*
     // ast_typedecl
@@ -1292,30 +1293,34 @@ def test {
 def printAst(var prog : ProgramPtr; var writer : StringBuilderWriter?) {
     //! Pretty-prints the entire program AST to the given writer.
     var flags = new PrintVisitor(writer = writer);
-    var inscope adapter <- make_visitor(*flags)
-    visit(prog, adapter)
+    make_visitor(*flags) $(adapter) {
+        visit(prog, adapter)
+    }
 }
 
 [export]
 def printExpr(var expr : ExpressionPtr; var writer : StringBuilderWriter?) {
     //! Pretty-prints a single expression AST node to the given writer.
     var flags = new PrintVisitor(writer = writer);
-    var inscope adapter <- make_visitor(*flags)
-    visit(expr, adapter)
+    make_visitor(*flags) $(adapter) {
+        visit(expr, adapter)
+    }
 }
 
 [export]
 def printFunc(var func : FunctionPtr; var writer : StringBuilderWriter?) {
     //! Pretty-prints a single function AST node to the given writer.
     var flags = new PrintVisitor(writer = writer);
-    var inscope adapter <- make_visitor(*flags)
-    visit(func, adapter)
+    make_visitor(*flags) $(adapter) {
+        visit(func, adapter)
+    }
 }
 
 [export]
 def setFlags(var prog : ProgramPtr) {
     //! Visits the program AST to set printer flags before pretty-printing.
     var flags = new SetPrinterFlags();
-    var inscope adapter <- make_visitor(*flags)
-    visit(prog, adapter)
+    make_visitor(*flags) $(adapter) {
+        visit(prog, adapter)
+    }
 }

--- a/daslib/ast_used.das
+++ b/daslib/ast_used.das
@@ -60,10 +60,11 @@ def public collect_used_types(vfun : array<Function?>; vvar : array<Variable?>; 
     //! Goes through list of functions `vfun` and variables `vvar` and collects list of which enumeration and structure types are used in them.
     //! Calls `blk` with said list.
     var astVisitor = new TypeVisitor()
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    for (f in vfun) {
-        unsafe {
-            visit(reinterpret<FunctionPtr> f, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        for (f in vfun) {
+            unsafe {
+                visit(reinterpret<FunctionPtr> f, astVisitorAdapter)
+            }
         }
     }
     for (v in vvar) {

--- a/daslib/async_boost.das
+++ b/daslib/async_boost.das
@@ -97,8 +97,9 @@ class AsyncMacro : AstFunctionAnnotation {
         var astVisitor = new CollectAndReplaceIteratorFields()
         astVisitor.voidRoutine = voidRoutine
         astVisitor.retType := retT
-        var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-        visit(func.body, astVisitorAdapter)
+        make_visitor(*astVisitor) $(astVisitorAdapter) {
+            visit(func.body, astVisitorAdapter)
+        }
         // gc handles TypeDecl lifetime
         unsafe {
             delete astVisitor

--- a/daslib/coverage.das
+++ b/daslib/coverage.das
@@ -478,8 +478,9 @@ class CoveragePass : AstPassMacro {
         }
         add_module_require(mod, covModule, false)
         var astVisitor = new CoverageMacro()
-        var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-        visit_module(prog, astVisitorAdapter, mod)
+        make_visitor(*astVisitor) $(astVisitorAdapter) {
+            visit_module(prog, astVisitorAdapter, mod)
+        }
         let result = astVisitor.astChanged
         if (result) {
             // generate [init] function that registers all instrumented lines with 0 hits

--- a/daslib/heartbeat.das
+++ b/daslib/heartbeat.das
@@ -88,8 +88,9 @@ class HeartbeatPass : AstPassMacro {
     //! Pass macro that instruments functions with heartbeat calls.
     def override apply(prog : ProgramPtr; mod : Module?) : bool {
         var astVisitor = new AddHeartbeat()
-        var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-        visit(prog, astVisitorAdapter)
+        make_visitor(*astVisitor) $(astVisitorAdapter) {
+            visit(prog, astVisitorAdapter)
+        }
         let result = astVisitor.astChanged
         unsafe {
             delete astVisitor

--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -33,7 +33,7 @@ class LintVisitor : AstVisitor {
     //!   - LINT002: unused variable
     //!   - LINT003: variable can be made const (var→let)
     //!   - LINT004: underscore-prefixed variable is actually used
-    astVisitorAdapter : smart_ptr<ast::VisitorAdapter>
+    astVisitorAdapter : VisitorAdapter?
     exprForTerminator : array<uint64>
     compile_time_errors : bool
     noLint : bool = false
@@ -207,11 +207,10 @@ class LintVisitor : AstVisitor {
 def public paranoid(prog : ProgramPtr; compile_time_errors : bool) {
     //! Runs the paranoid lint visitor on the program to check for common coding issues.
     var astVisitor = new LintVisitor(compile_time_errors = compile_time_errors)
-    unsafe {
-        astVisitor.astVisitorAdapter <- make_visitor(*astVisitor)
+    make_visitor(*astVisitor) $(adapter) {
+        astVisitor.astVisitorAdapter = adapter
+        visit(prog, astVisitor.astVisitorAdapter)
     }
-    visit(prog, astVisitor.astVisitorAdapter)
-    astVisitor.astVisitorAdapter := null
     unsafe {
         delete astVisitor
     }
@@ -221,16 +220,15 @@ def public paranoid_collect(prog : ProgramPtr; var errors : array<string>) : int
     //! Runs the paranoid lint visitor and collects errors as strings.
     //! Returns the number of lint issues found.
     var astVisitor = new LintVisitor(compile_time_errors = false, collect_errors = true)
-    unsafe {
-        astVisitor.astVisitorAdapter <- make_visitor(*astVisitor)
+    make_visitor(*astVisitor) $(adapter) {
+        astVisitor.astVisitorAdapter = adapter
+        visit(prog, astVisitor.astVisitorAdapter)
     }
-    visit(prog, astVisitor.astVisitorAdapter)
     let count = length(astVisitor.errors)
     errors |> reserve(count)
     for (e in astVisitor.errors) {
         errors |> push(e)
     }
-    astVisitor.astVisitorAdapter := null
     unsafe {
         delete astVisitor
     }

--- a/daslib/macro_boost.das
+++ b/daslib/macro_boost.das
@@ -79,8 +79,9 @@ struct public CapturedVariable {
 def public capture_block(expr : ExpressionPtr) : array<CapturedVariable> {
     //! Collect all captured variables in the expression.
     var astVisitor = new CaptureBlock()
-    var inscope adapter <- make_visitor(*astVisitor)
-    visit(expr, adapter)
+    make_visitor(*astVisitor) $(adapter) {
+        visit(expr, adapter)
+    }
     var res := [for (k, v in keys(astVisitor.captured), values(astVisitor.captured)); CapturedVariable(variable=k, expression=v) ]
     unsafe {
         delete astVisitor
@@ -113,8 +114,9 @@ def public collect_finally(expr : ExpressionPtr; alwaysFor : bool = false) {
     //! Returns array of ExprBlock? with all the blocks which have `finally` section
     //! Does not go into 'make_block' expression, such as `lambda`, or 'block' expressions
     var astVisitor = new ColletFinally(alwaysFor = alwaysFor)
-    var inscope adapter <- make_visitor(*astVisitor)
-    visit(expr, adapter)
+    make_visitor(*astVisitor) $(adapter) {
+        visit(expr, adapter)
+    }
     var res := [for (k in keys(astVisitor.blocks)); k ]
     unsafe {
         delete astVisitor
@@ -139,8 +141,9 @@ def public collect_labels(expr : ExpressionPtr) {
     //! Collect all labels in the expression. Returns array of integer with label indices
     //! Does not go into 'make_block' expression, such as `lambda`, or 'block' expressions
     var astVisitor = new ColletLabels()
-    var inscope adapter <- make_visitor(*astVisitor)
-    visit(expr, adapter)
+    make_visitor(*astVisitor) $(adapter) {
+        visit(expr, adapter)
+    }
     var res := [for (k in keys(astVisitor.labels)); k ]
     unsafe {
         delete astVisitor

--- a/daslib/perf_lint.das
+++ b/daslib/perf_lint.das
@@ -746,8 +746,9 @@ def public perf_lint(prog : ProgramPtr; compile_time_errors : bool) : int {
     //! Runs the performance lint visitor on the compiled program.
     //! Returns the number of warnings found.
     var astVisitor = new PerfLintVisitor(compile_time_errors = compile_time_errors)
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    visit(prog, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit(prog, astVisitorAdapter)
+    }
     let count = astVisitor.warning_count
     unsafe { delete astVisitor; }
     return count
@@ -757,8 +758,9 @@ def public perf_lint_collect(prog : ProgramPtr; var warnings : array<string>) : 
     //! Runs the performance lint visitor and collects warnings as strings.
     //! Returns the number of warnings found.
     var astVisitor = new PerfLintVisitor(compile_time_errors = false, collect_warnings = true)
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    visit(prog, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit(prog, astVisitorAdapter)
+    }
     let count = astVisitor.warning_count
     warnings |> reserve(length(astVisitor.warnings))
     for (w in astVisitor.warnings) {

--- a/daslib/quote.das
+++ b/daslib/quote.das
@@ -438,8 +438,9 @@ class QuotePass : AstPassMacro {
             return false // nothing to do
         }
         var astVisitor = new QuoteConverter()
-        var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-        visit(prog, astVisitorAdapter)
+        make_visitor(*astVisitor) $(astVisitorAdapter) {
+            visit(prog, astVisitorAdapter)
+        }
         let result = astVisitor.astChanged
         unsafe {
             delete astVisitor

--- a/daslib/soa.das
+++ b/daslib/soa.das
@@ -321,8 +321,9 @@ class CollectAndReplaceIteratorFields : AstVisitor {
 def collect_and_replace_iterator_fields(prefix : string; blk : ExpressionPtr) : array<string> {
     var names : array<string>
     var astVisitor = new CollectAndReplaceIteratorFields(prefix)
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    visit(blk, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit(blk, astVisitorAdapter)
+    }
     for (n in keys(astVisitor.names)) {
         names |> push(n)
     }

--- a/daslib/style_lint.das
+++ b/daslib/style_lint.das
@@ -379,8 +379,9 @@ def public style_lint(prog : ProgramPtr; compile_time_errors : bool; postfix_con
     //! Runs the style lint visitor on the compiled program.
     //! Returns the number of warnings found.
     var astVisitor = new StyleLintVisitor(compile_time_errors = compile_time_errors, postfix_conditionals = postfix_conditionals)
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    visit_with_generics(prog, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit_with_generics(prog, astVisitorAdapter)
+    }
     let count = astVisitor.warning_count
     unsafe { delete astVisitor; }
     return count
@@ -390,8 +391,9 @@ def public style_lint_collect(prog : ProgramPtr; var warnings : array<string>; p
     //! Runs the style lint visitor and collects warnings as strings.
     //! Returns the number of warnings found.
     var astVisitor = new StyleLintVisitor(compile_time_errors = false, collect_warnings = true, postfix_conditionals = postfix_conditionals)
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    visit_with_generics(prog, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit_with_generics(prog, astVisitorAdapter)
+    }
     let count = astVisitor.warning_count
     warnings |> reserve(length(astVisitor.warnings))
     for (w in astVisitor.warnings) {

--- a/daslib/templates_boost.das
+++ b/daslib/templates_boost.das
@@ -379,7 +379,7 @@ class private TemplateVisitor : AstVisitor {
     }
 }
 
-def visit_expression(var expr : Expression?&; var adapter : smart_ptr<VisitorAdapter>) {
+def visit_expression(var expr : Expression?&; var adapter : VisitorAdapter?) {
     //! Visits the expression with the given visitor adapter.
     unsafe {
         var newExpr = expr |> visit(adapter)
@@ -390,8 +390,9 @@ def visit_expression(var expr : Expression?&; var adapter : smart_ptr<VisitorAda
 def apply_template(var rules : Template; at : LineInfo; var expr : Expression?; forceAt : bool = true) : Expression? {
     //! Applies the template to the given expression. If `forceAt` is set, the resulting expression will have the same line info as 'at'.
     var astVisitor = new TemplateVisitor(unsafe(addr(rules)))
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    visit_expression(expr, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit_expression(expr, astVisitorAdapter)
+    }
     if (forceAt) {
         expr |> force_at(at)
     }
@@ -401,7 +402,7 @@ def apply_template(var rules : Template; at : LineInfo; var expr : Expression?; 
     return expr
 }
 
-def private visit_type(var typ : TypeDeclPtr&; var adapter : smart_ptr<VisitorAdapter>) {
+def private visit_type(var typ : TypeDeclPtr&; var adapter : VisitorAdapter?) {
     //! Visits the type declaration with the given visitor adapter.
     unsafe {
         // note: visit returns smart_ptr_raw, so we need to be careful with lifetime here
@@ -416,8 +417,9 @@ def private visit_type(var typ : TypeDeclPtr&; var adapter : smart_ptr<VisitorAd
 def apply_template(var rules : Template; at : LineInfo; var typ : TypeDecl?; forceAt : bool = true) : TypeDeclPtr {
     //! Applies the template to the given expression. If `forceAt` is set, the resulting expression will have the same line info as 'at'.
     var astVisitor = new TemplateVisitor(unsafe(addr(rules)))
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    visit_type(typ, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit_type(typ, astVisitorAdapter)
+    }
     /*
     if forceAt
         expr |> force_at(at)
@@ -600,8 +602,9 @@ def public remove_deref(varname : string; var expr : Expression?) {
     //! Removes dereferences of the variable `varname` from the expression.
     //! This is typically used when replacing 'workhorse' variable with constant.
     var astVisitor = new RemoveDerefVisitor(varname)
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    expr |> visit(astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit_expression(expr, astVisitorAdapter)
+    }
     unsafe {
         delete astVisitor
     }
@@ -975,8 +978,9 @@ def private apply_qrules(var expr : Expression?&) : ExprBlock? {
         blockFlags = ExprBlockFlags.isClosure
     )
     var astVisitor = new QRulesVisitor(eblk)
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    visit_expression(expr, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit_expression(expr, astVisitorAdapter)
+    }
     if (astVisitor.failed) {
         eblk = null
     }
@@ -999,8 +1003,9 @@ def private apply_function_qrules(var func : FunctionPtr) : ExprBlock? {
         blockFlags = ExprBlockFlags.isClosure
     )
     var astVisitor = new QRulesVisitor(eblk)
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-    visit(func, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit(func, astVisitorAdapter)
+    }
     if (astVisitor.failed) {
         eblk = null
     }
@@ -1023,24 +1028,23 @@ def private apply_template_qrules(prog : ProgramPtr; var template_structure : St
         blockFlags = ExprBlockFlags.isClosure
     )
     var astVisitor = new QRulesVisitor(eblk)
-    var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-
-    var mod = template_structure._module
-    unsafe {
-        var ts = template_structure
-        var vis_structure <- reinterpret<Structure?>(ts)
-        prog.visit_structure(vis_structure, astVisitorAdapter)
-    }
-
-    if (!astVisitor.failed) {
-        for_each_function(mod, "", $(func){
-            return if (astVisitor.failed)
-            if (func.flags.isClassMethod) {
-                if (func.classParent == template_structure) {
-                    visit(func, astVisitorAdapter)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        var mod = template_structure._module
+        unsafe {
+            var ts = template_structure
+            var vis_structure <- reinterpret<Structure?>(ts)
+            prog.visit_structure(vis_structure, astVisitorAdapter)
+        }
+        if (!astVisitor.failed) {
+            for_each_function(mod, "", $(func){
+                return if (astVisitor.failed)
+                if (func.flags.isClassMethod) {
+                    if (func.classParent == template_structure) {
+                        visit(func, astVisitorAdapter)
+                    }
                 }
-            }
-        })
+            })
+        }
     }
 
     if (astVisitor.failed) {

--- a/daslib/validate_code.das
+++ b/daslib/validate_code.das
@@ -118,10 +118,11 @@ class VerifyCompletion : AstFunctionAnnotation {
     def override lint(var func : FunctionPtr; var group : ModuleGroup; args, progArgs : AnnotationArgumentList; var errors : das_string) : bool {
         var visited : table<Function?>
         var astVisitor = new ValidateCompletionVisitor()
-        var inscope adapter <- make_visitor(*astVisitor)
-        collect_call_tree(func, visited)
-        for (fun in visited |> keys()) {
-            visit(unsafe(reinterpret<FunctionPtr> fun), adapter)
+        make_visitor(*astVisitor) $(adapter) {
+            collect_call_tree(func, visited)
+            for (fun in visited |> keys()) {
+                visit(unsafe(reinterpret<FunctionPtr> fun), adapter)
+            }
         }
         unsafe {
             delete astVisitor
@@ -151,19 +152,20 @@ class JIT_LLVM : AstSimulateMacro {
     //! Simulate macro for LLVM JIT compilation.
     def lint_module(prog : Program?; var ctx : Context?) {
         var astVisitor = new ValidateShaderVisitor()
-        var inscope adapter <- make_visitor(*astVisitor)
-        prog |> for_each_module() $(mod) {
-            mod |> for_each_function("") $(f) {
-                if (f.flags.used) {
-                    visit(f, adapter)
+        make_visitor(*astVisitor) $(adapter) {
+            prog |> for_each_module() $(mod) {
+                mod |> for_each_function("") $(f) {
+                    if (f.flags.used) {
+                        visit(f, adapter)
+                    }
                 }
-            }
-            mod |> for_each_global() $(g) {
-                if (g.flags.used) {
-                    if (!g._type.isNoHeapType) {
-                        macro_error(compiling_program(), g.at, "global variable {g.name} requires heap")
-                    } elif (g.init != null) {
-                        visit(g.init, adapter)
+                mod |> for_each_global() $(g) {
+                    if (g.flags.used) {
+                        if (!g._type.isNoHeapType) {
+                            macro_error(compiling_program(), g.at, "global variable {g.name} requires heap")
+                        } elif (g.init != null) {
+                            visit(g.init, adapter)
+                        }
                     }
                 }
             }

--- a/doc/source/reference/language/datatypes.rst
+++ b/doc/source/reference/language/datatypes.rst
@@ -379,8 +379,10 @@ Smart pointers in AST code:
     var expr = new ExprConstInt(value=42)       // Expression is gc_node
     var fn = new ExprCall(at=expr.at, name:="foo")
 
-    // Smart pointer types (non-GC) — use inscope + <-
-    var inscope adapter <- make_visitor(*visitor)   // VisitorAdapter is smart_ptr
+    // Visitor adapter — use block-based make_visitor
+    make_visitor(*visitor) $ (adapter) {     // adapter alive inside the block
+        visit(program, adapter)
+    }
 
 The key properties of smart pointers:
 
@@ -394,7 +396,7 @@ declared with ``inscope`` to ensure automatic cleanup:
 
 .. code-block:: das
 
-    var inscope a <- make_visitor(*visitor)   // create — safe, no unsafe needed
+    var inscope a <- some_function()          // create — safe, no unsafe needed
     var inscope b <- a                        // move — safe, a becomes null
     unsafe {
         var inscope c <- some_function()      // move from function result — unsafe

--- a/doc/source/reference/language/macros.rst
+++ b/doc/source/reference/language/macros.rst
@@ -689,14 +689,17 @@ The adapter then can be applied to a program via the ``visit`` function:
 .. code-block:: das
 
     var astVisitor = new PrintVisitor()
-    var astVisitorAdapter <- make_visitor(*astVisitor)
-    visit(this_program(), astVisitorAdapter)
+    make_visitor(*astVisitor) $ (astVisitorAdapter) {
+        visit(this_program(), astVisitorAdapter)
+    }
 
 If an expression needs to be visited, and can potentially be fully substituted, the ``visit_expression`` function should be used:
 
 .. code-block:: das
 
-    expr <- visit_expression(expr,astVisitorAdapter)
+    make_visitor(*astVisitor) $ (astVisitorAdapter) {
+        expr <- visit_expression(expr,astVisitorAdapter)
+    }
 
 .. seealso::
 

--- a/doc/source/reference/tutorials/macros/03_function_macro.rst
+++ b/doc/source/reference/tutorials/macros/03_function_macro.rst
@@ -525,8 +525,9 @@ The ``lint()`` method creates the visitor, adapts it with
 
    def override lint(...) : bool {
        var astVisitor = new NoPrintVisitor()
-       var inscope adapter <- make_visitor(*astVisitor)
-       visit(func, adapter)
+       make_visitor(*astVisitor) $ (adapter) {
+           visit(func, adapter)
+       }
        if (astVisitor.found_print) {
            errors := "function {string(func.name)} must not call builtin print"
            unsafe { delete astVisitor; }
@@ -536,9 +537,9 @@ The ``lint()`` method creates the visitor, adapts it with
        return true
    }
 
-* **``make_visitor(*astVisitor)``** — wraps the daslang visitor object
-  into an adapter that the C++ ``visit()`` function can call.  The
-  ``*`` dereferences the smart pointer.
+* **``make_visitor(*astVisitor) $ (adapter) { ... }``** — wraps the daslang visitor object
+  into an adapter that the C++ ``visit()`` function can call, available inside the block.
+  The ``*`` dereferences the smart pointer.
 * **``visit(func, adapter)``** — walks the function’s AST, calling
   the visitor’s ``preVisit*`` / ``visit*`` hooks at each node.
 * **Error reporting** uses the same pattern as ``verifyCall()`` —

--- a/doc/source/reference/tutorials/macros/14_pass_macro.rst
+++ b/doc/source/reference/tutorials/macros/14_pass_macro.rst
@@ -198,8 +198,9 @@ The pass macro creates the visitor and walks the full program:
     class TraceCallsPass : AstPassMacro {
         def override apply(prog : ProgramPtr; mod : Module?) : bool {
             var astVisitor = new TraceCallsVisitor()
-            var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-            visit(prog, astVisitorAdapter)
+            make_visitor(*astVisitor) $ (astVisitorAdapter) {
+                visit(prog, astVisitorAdapter)
+            }
             let result = astVisitor.astChanged
             unsafe {
                 delete astVisitor
@@ -212,8 +213,8 @@ Key points:
 
 - **``new TraceCallsVisitor()``** allocates the visitor on the heap
   (macro code cannot use stack-allocated visitors).
-- **``make_visitor(*astVisitor)``** wraps it in a ``smart_ptr``
-  adapter for the ``visit`` function.
+- **``make_visitor(*astVisitor) $ (adapter) { ... }``** wraps it in an
+  adapter for the ``visit`` function, available inside the block.
 - **``visit(prog, astVisitorAdapter)``** walks the entire program — all
   modules, all functions.  Use ``visit(func, adapter)`` to walk a
   single function instead.

--- a/doc/source/stdlib/generated/ast.rst
+++ b/doc/source/stdlib/generated/ast.rst
@@ -5508,122 +5508,124 @@ Creates the appropriate call expression for a given function name in the program
 Visitor pattern
 +++++++++++++++
 
-  *  :ref:`visit (program: smart_ptr\<Program\>; adapter: smart_ptr\<VisitorAdapter\>; sortStructures: bool) <function-ast_visit_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr__bool>`
-  *  :ref:`visit (program: smart_ptr\<Program\>; adapter: smart_ptr\<VisitorAdapter\>) <function-ast_visit_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr_>`
-  *  :ref:`visit (expression: Expression?; adapter: smart_ptr\<VisitorAdapter\>) : Expression? <function-ast_visit_Expression_q__smart_ptr_ls_VisitorAdapter_gr_>`
-  *  :ref:`visit (function: Function?; adapter: smart_ptr\<VisitorAdapter\>) <function-ast_visit_Function_q__smart_ptr_ls_VisitorAdapter_gr_>`
-  *  :ref:`visit (expression: TypeDecl?; adapter: smart_ptr\<VisitorAdapter\>) : TypeDecl? <function-ast_visit_TypeDecl_q__smart_ptr_ls_VisitorAdapter_gr_>`
-  *  :ref:`visit_enumeration (program: smart_ptr\<Program\>; enumeration: Enumeration?; adapter: smart_ptr\<VisitorAdapter\>) <function-ast_visit_enumeration_smart_ptr_ls_Program_gr__Enumeration_q__smart_ptr_ls_VisitorAdapter_gr_>`
-  *  :ref:`visit_finally (expression: ExprBlock?; adapter: smart_ptr\<VisitorAdapter\>) <function-ast_visit_finally_ExprBlock_q__smart_ptr_ls_VisitorAdapter_gr_>`
-  *  :ref:`visit_module (program: smart_ptr\<Program\>; adapter: smart_ptr\<VisitorAdapter\>; module: Module?) <function-ast_visit_module_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr__Module_q_>`
-  *  :ref:`visit_modules (program: smart_ptr\<Program\>; adapter: smart_ptr\<VisitorAdapter\>) <function-ast_visit_modules_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr_>`
-  *  :ref:`visit_structure (program: smart_ptr\<Program\>; structure: Structure?; adapter: smart_ptr\<VisitorAdapter\>) <function-ast_visit_structure_smart_ptr_ls_Program_gr__Structure_q__smart_ptr_ls_VisitorAdapter_gr_>`
-  *  :ref:`visit_with_generics (program: smart_ptr\<Program\>; adapter: smart_ptr\<VisitorAdapter\>) <function-ast_visit_with_generics_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr_>`
+  *  :ref:`visit (program: smart_ptr\<Program\>; adapter: VisitorAdapter?; sortStructures: bool) <function-ast_visit_smart_ptr_ls_Program_gr__VisitorAdapter_q__bool>`
+  *  :ref:`visit (program: smart_ptr\<Program\>; adapter: VisitorAdapter?) <function-ast_visit_smart_ptr_ls_Program_gr__VisitorAdapter_q_>`
+  *  :ref:`visit (expression: Expression?; adapter: VisitorAdapter?) : Expression? <function-ast_visit_Expression_q__VisitorAdapter_q_>`
+  *  :ref:`visit (function: Function?; adapter: VisitorAdapter?) <function-ast_visit_Function_q__VisitorAdapter_q_>`
+  *  :ref:`visit (expression: TypeDecl?; adapter: VisitorAdapter?) : TypeDecl? <function-ast_visit_TypeDecl_q__VisitorAdapter_q_>`
+  *  :ref:`visit_enumeration (program: smart_ptr\<Program\>; enumeration: Enumeration?; adapter: VisitorAdapter?) <function-ast_visit_enumeration_smart_ptr_ls_Program_gr__Enumeration_q__VisitorAdapter_q_>`
+  *  :ref:`visit_finally (expression: ExprBlock?; adapter: VisitorAdapter?) <function-ast_visit_finally_ExprBlock_q__VisitorAdapter_q_>`
+  *  :ref:`visit_module (program: smart_ptr\<Program\>; adapter: VisitorAdapter?; module: Module?) <function-ast_visit_module_smart_ptr_ls_Program_gr__VisitorAdapter_q__Module_q_>`
+  *  :ref:`visit_modules (program: smart_ptr\<Program\>; adapter: VisitorAdapter?) <function-ast_visit_modules_smart_ptr_ls_Program_gr__VisitorAdapter_q_>`
+  *  :ref:`visit_structure (program: smart_ptr\<Program\>; structure: Structure?; adapter: VisitorAdapter?) <function-ast_visit_structure_smart_ptr_ls_Program_gr__Structure_q__VisitorAdapter_q_>`
+  *  :ref:`visit_with_generics (program: smart_ptr\<Program\>; adapter: VisitorAdapter?) <function-ast_visit_with_generics_smart_ptr_ls_Program_gr__VisitorAdapter_q_>`
 
 
 visit
 ^^^^^
 
-.. _function-ast_visit_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr__bool:
+.. _function-ast_visit_smart_ptr_ls_Program_gr__VisitorAdapter_q__bool:
 
-.. das:function:: visit(program: smart_ptr<Program>; adapter: smart_ptr<VisitorAdapter>; sortStructures: bool)
+.. das:function:: visit(program: smart_ptr<Program>; adapter: VisitorAdapter?; sortStructures: bool)
 
 Visit the program with the given visitor adapter. When sortStructures is true, struct declarations are visited in topological (dependency) order, ensuring that structs used by value in fields are visited before the structs that contain them.
 
 
 :Arguments: * **program** : smart_ptr< :ref:`Program <handle-rtti-Program>`> implicit
 
-            * **adapter** : smart_ptr< :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`> implicit
+            * **adapter** :  :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`? implicit
 
             * **sortStructures** : bool
 
-.. _function-ast_visit_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr_:
+.. _function-ast_visit_smart_ptr_ls_Program_gr__VisitorAdapter_q_:
 
-.. das:function:: visit(program: smart_ptr<Program>; adapter: smart_ptr<VisitorAdapter>)
+.. das:function:: visit(program: smart_ptr<Program>; adapter: VisitorAdapter?)
 
-.. _function-ast_visit_Expression_q__smart_ptr_ls_VisitorAdapter_gr_:
+.. _function-ast_visit_Expression_q__VisitorAdapter_q_:
 
-.. das:function:: visit(expression: Expression?; adapter: smart_ptr<VisitorAdapter>) : Expression?
+.. das:function:: visit(expression: Expression?; adapter: VisitorAdapter?) : Expression?
 
-.. _function-ast_visit_Function_q__smart_ptr_ls_VisitorAdapter_gr_:
+.. _function-ast_visit_Function_q__VisitorAdapter_q_:
 
-.. das:function:: visit(function: Function?; adapter: smart_ptr<VisitorAdapter>)
+.. das:function:: visit(function: Function?; adapter: VisitorAdapter?)
 
-.. _function-ast_visit_TypeDecl_q__smart_ptr_ls_VisitorAdapter_gr_:
+.. _function-ast_visit_TypeDecl_q__VisitorAdapter_q_:
 
-.. das:function:: visit(expression: TypeDecl?; adapter: smart_ptr<VisitorAdapter>) : TypeDecl?
+.. das:function:: visit(expression: TypeDecl?; adapter: VisitorAdapter?) : TypeDecl?
 
 ----
 
-.. _function-ast_visit_enumeration_smart_ptr_ls_Program_gr__Enumeration_q__smart_ptr_ls_VisitorAdapter_gr_:
+.. _function-ast_visit_enumeration_smart_ptr_ls_Program_gr__Enumeration_q__VisitorAdapter_q_:
 
-.. das:function:: visit_enumeration(program: smart_ptr<Program>; enumeration: Enumeration?; adapter: smart_ptr<VisitorAdapter>)
+.. das:function:: visit_enumeration(program: smart_ptr<Program>; enumeration: Enumeration?; adapter: VisitorAdapter?)
 
 Applies the given visitor adapter to the specified enumeration within the context of the program, triggering the appropriate visitor callbacks.
+
 
 :Arguments: * **program** : smart_ptr< :ref:`Program <handle-rtti-Program>`> implicit
 
             * **enumeration** :  :ref:`Enumeration <handle-ast-Enumeration>`? implicit
 
-            * **adapter** : smart_ptr< :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`> implicit
+            * **adapter** :  :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`? implicit
 
-.. _function-ast_visit_finally_ExprBlock_q__smart_ptr_ls_VisitorAdapter_gr_:
+.. _function-ast_visit_finally_ExprBlock_q__VisitorAdapter_q_:
 
-.. das:function:: visit_finally(expression: ExprBlock?; adapter: smart_ptr<VisitorAdapter>)
+.. das:function:: visit_finally(expression: ExprBlock?; adapter: VisitorAdapter?)
 
 Invokes the visitor on the finally section of a block.
 
 
 :Arguments: * **expression** :  :ref:`ExprBlock <handle-ast-ExprBlock>`? implicit
 
-            * **adapter** : smart_ptr< :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`> implicit
+            * **adapter** :  :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`? implicit
 
-.. _function-ast_visit_module_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr__Module_q_:
+.. _function-ast_visit_module_smart_ptr_ls_Program_gr__VisitorAdapter_q__Module_q_:
 
-.. das:function:: visit_module(program: smart_ptr<Program>; adapter: smart_ptr<VisitorAdapter>; module: Module?)
+.. das:function:: visit_module(program: smart_ptr<Program>; adapter: VisitorAdapter?; module: Module?)
 
 Invokes an AST visitor on the given module.
 
 
 :Arguments: * **program** : smart_ptr< :ref:`Program <handle-rtti-Program>`> implicit
 
-            * **adapter** : smart_ptr< :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`> implicit
+            * **adapter** :  :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`? implicit
 
             * **module** :  :ref:`Module <handle-rtti-Module>`? implicit
 
-.. _function-ast_visit_modules_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr_:
+.. _function-ast_visit_modules_smart_ptr_ls_Program_gr__VisitorAdapter_q_:
 
-.. das:function:: visit_modules(program: smart_ptr<Program>; adapter: smart_ptr<VisitorAdapter>)
+.. das:function:: visit_modules(program: smart_ptr<Program>; adapter: VisitorAdapter?)
 
 Invokes an AST visitor on all modules in the specified program.
 
 
 :Arguments: * **program** : smart_ptr< :ref:`Program <handle-rtti-Program>`> implicit
 
-            * **adapter** : smart_ptr< :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`> implicit
+            * **adapter** :  :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`? implicit
 
-.. _function-ast_visit_structure_smart_ptr_ls_Program_gr__Structure_q__smart_ptr_ls_VisitorAdapter_gr_:
+.. _function-ast_visit_structure_smart_ptr_ls_Program_gr__Structure_q__VisitorAdapter_q_:
 
-.. das:function:: visit_structure(program: smart_ptr<Program>; structure: Structure?; adapter: smart_ptr<VisitorAdapter>)
+.. das:function:: visit_structure(program: smart_ptr<Program>; structure: Structure?; adapter: VisitorAdapter?)
 
 Applies the given visitor adapter to the specified structure within the context of the program, triggering the appropriate visitor callbacks.
+
 
 :Arguments: * **program** : smart_ptr< :ref:`Program <handle-rtti-Program>`> implicit
 
             * **structure** :  :ref:`Structure <handle-ast-Structure>`? implicit
 
-            * **adapter** : smart_ptr< :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`> implicit
+            * **adapter** :  :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`? implicit
 
-.. _function-ast_visit_with_generics_smart_ptr_ls_Program_gr__smart_ptr_ls_VisitorAdapter_gr_:
+.. _function-ast_visit_with_generics_smart_ptr_ls_Program_gr__VisitorAdapter_q_:
 
-.. das:function:: visit_with_generics(program: smart_ptr<Program>; adapter: smart_ptr<VisitorAdapter>)
+.. das:function:: visit_with_generics(program: smart_ptr<Program>; adapter: VisitorAdapter?)
 
-Visits the program AST including generic function instantiations. Unlike `visit`, which only walks non-generic functions, this also visits each instantiated generic, making it suitable for lint passes that need to check generated code.
+Visits the program AST including generic function instantiations. Unlike visit, which only walks non-generic functions, this also visits each instantiated generic, making it suitable for lint passes that need to check generated code.
 
 
 :Arguments: * **program** : smart_ptr< :ref:`Program <handle-rtti-Program>`> implicit
 
-            * **adapter** : smart_ptr< :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`> implicit
+            * **adapter** :  :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`? implicit
 
 
 +++++++++++++++++++++
@@ -5684,41 +5686,41 @@ Adapter generation
   *  :ref:`make_block_annotation (name: string; class: void?; info: StructInfo const?) : smart_ptr\<FunctionAnnotation\> <function-ast_make_block_annotation_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_block_type (blk: ExprBlock?) : TypeDecl? <function-ast_make_block_type_ExprBlock_q_>`
   *  :ref:`make_call_macro (name: string; class: void?; info: StructInfo const?) : smart_ptr\<CallMacro\> <function-ast_make_call_macro_string_void_q__StructInfo_const_q_>`
-  *  :ref:`make_call_macro (name: string; var someClassPtr: auto) : CallMacroPtr <function-ast_make_call_macro_string_auto_0x2ed>`
+  *  :ref:`make_call_macro (name: string; var someClassPtr: auto) : CallMacroPtr <function-ast_make_call_macro_string_auto_0x2ec>`
   *  :ref:`make_capture_macro (name: string; class: void?; info: StructInfo const?) : smart_ptr\<CaptureMacro\> <function-ast_make_capture_macro_string_void_q__StructInfo_const_q_>`
-  *  :ref:`make_capture_macro (name: string; var someClassPtr: auto) : CaptureMacroPtr <function-ast_make_capture_macro_string_auto_0x333>`
+  *  :ref:`make_capture_macro (name: string; var someClassPtr: auto) : CaptureMacroPtr <function-ast_make_capture_macro_string_auto_0x332>`
   *  :ref:`make_clone_structure (structure: Structure?) : Function? <function-ast_make_clone_structure_Structure_q_>`
   *  :ref:`make_comment_reader (class: void?; info: StructInfo const?) : smart_ptr\<CommentReader\> <function-ast_make_comment_reader_void_q__StructInfo_const_q_>`
-  *  :ref:`make_comment_reader (name: string; var someClassPtr: auto) : CommentReaderPtr <function-ast_make_comment_reader_string_auto_0x2df>`
+  *  :ref:`make_comment_reader (name: string; var someClassPtr: auto) : CommentReaderPtr <function-ast_make_comment_reader_string_auto_0x2de>`
   *  :ref:`make_enum_debug_info (helper: smart_ptr\<DebugInfoHelper\>; en: Enumeration const?) : EnumInfo? <function-ast_make_enum_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Enumeration_const_q_>`
   *  :ref:`make_enumeration_annotation (name: string; var someClassPtr: auto) : EnumerationAnnotationPtr <function-ast_make_enumeration_annotation_string_auto_0x2b6>`
   *  :ref:`make_enumeration_annotation (name: string; class: void?; info: StructInfo const?) : smart_ptr\<EnumerationAnnotation\> <function-ast_make_enumeration_annotation_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_for_loop_macro (name: string; class: void?; info: StructInfo const?) : smart_ptr\<ForLoopMacro\> <function-ast_make_for_loop_macro_string_void_q__StructInfo_const_q_>`
-  *  :ref:`make_for_loop_macro (name: string; var someClassPtr: auto) : ForLoopMacroPtr <function-ast_make_for_loop_macro_string_auto_0x325>`
+  *  :ref:`make_for_loop_macro (name: string; var someClassPtr: auto) : ForLoopMacroPtr <function-ast_make_for_loop_macro_string_auto_0x324>`
   *  :ref:`make_function_annotation (name: string; var someClassPtr: auto) : FunctionAnnotationPtr <function-ast_make_function_annotation_string_auto_0x28c>`
   *  :ref:`make_function_annotation (name: string; class: void?; info: StructInfo const?) : smart_ptr\<FunctionAnnotation\> <function-ast_make_function_annotation_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_function_debug_info (helper: smart_ptr\<DebugInfoHelper\>; fn: Function const?) : FuncInfo? <function-ast_make_function_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Function_const_q_>`
   *  :ref:`make_invokable_type_debug_info (helper: smart_ptr\<DebugInfoHelper\>; blk: TypeDecl?; at: LineInfo) : FuncInfo? <function-ast_make_invokable_type_debug_info_smart_ptr_ls_DebugInfoHelper_gr__TypeDecl_q__LineInfo>`
   *  :ref:`make_pass_macro (name: string; class: void?; info: StructInfo const?) : smart_ptr\<PassMacro\> <function-ast_make_pass_macro_string_void_q__StructInfo_const_q_>`
-  *  :ref:`make_pass_macro (name: string; var someClassPtr: auto) : PassMacroPtr <function-ast_make_pass_macro_string_auto_0x309>`
-  *  :ref:`make_reader_macro (name: string; var someClassPtr: auto) : ReaderMacroPtr <function-ast_make_reader_macro_string_auto_0x2d1>`
+  *  :ref:`make_pass_macro (name: string; var someClassPtr: auto) : PassMacroPtr <function-ast_make_pass_macro_string_auto_0x308>`
+  *  :ref:`make_reader_macro (name: string; var someClassPtr: auto) : ReaderMacroPtr <function-ast_make_reader_macro_string_auto_0x2d0>`
   *  :ref:`make_reader_macro (name: string; class: void?; info: StructInfo const?) : smart_ptr\<ReaderMacro\> <function-ast_make_reader_macro_string_void_q__StructInfo_const_q_>`
-  *  :ref:`make_simulate_macro (name: string; var someClassPtr: auto) : SimulateMacroPtr <function-ast_make_simulate_macro_string_auto_0x34c>`
+  *  :ref:`make_simulate_macro (name: string; var someClassPtr: auto) : SimulateMacroPtr <function-ast_make_simulate_macro_string_auto_0x34b>`
   *  :ref:`make_simulate_macro (name: string; class: void?; info: StructInfo const?) : smart_ptr\<SimulateMacro\> <function-ast_make_simulate_macro_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_struct_debug_info (helper: smart_ptr\<DebugInfoHelper\>; st: Structure const?) : StructInfo? <function-ast_make_struct_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Structure_const_q_>`
   *  :ref:`make_struct_variable_debug_info (helper: smart_ptr\<DebugInfoHelper\>; st: Structure const?; var: FieldDeclaration const?) : VarInfo? <function-ast_make_struct_variable_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Structure_const_q__FieldDeclaration_const_q_>`
   *  :ref:`make_structure_annotation (name: string; var someClassPtr: auto) : StructureAnnotationPtr <function-ast_make_structure_annotation_string_auto_0x2a8>`
   *  :ref:`make_structure_annotation (name: string; class: void?; info: StructInfo const?) : smart_ptr\<StructureAnnotation\> <function-ast_make_structure_annotation_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_type_info (helper: smart_ptr\<DebugInfoHelper\>; info: TypeInfo?; type: TypeDecl? const&) : TypeInfo? <function-ast_make_type_info_smart_ptr_ls_DebugInfoHelper_gr__TypeInfo_q__TypeDecl_q__const_ref_>`
-  *  :ref:`make_type_macro (name: string; var someClassPtr: auto) : TypeMacroPtr <function-ast_make_type_macro_string_auto_0x33f>`
+  *  :ref:`make_type_macro (name: string; var someClassPtr: auto) : TypeMacroPtr <function-ast_make_type_macro_string_auto_0x33e>`
   *  :ref:`make_type_macro (name: string; class: void?; info: StructInfo const?) : smart_ptr\<TypeMacro\> <function-ast_make_type_macro_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_typeinfo_macro (name: string; class: void?; info: StructInfo const?) : smart_ptr\<TypeInfoMacro\> <function-ast_make_typeinfo_macro_string_void_q__StructInfo_const_q_>`
-  *  :ref:`make_typeinfo_macro (name: string; var someClassPtr: auto) : TypeInfoMacroPtr <function-ast_make_typeinfo_macro_string_auto_0x2fb>`
+  *  :ref:`make_typeinfo_macro (name: string; var someClassPtr: auto) : TypeInfoMacroPtr <function-ast_make_typeinfo_macro_string_auto_0x2fa>`
   *  :ref:`make_variable_debug_info (helper: smart_ptr\<DebugInfoHelper\>; var: Variable?) : VarInfo? <function-ast_make_variable_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Variable_q_>`
-  *  :ref:`make_variant_macro (name: string; var someClassPtr: auto) : VariantMacroPtr <function-ast_make_variant_macro_string_auto_0x317>`
+  *  :ref:`make_variant_macro (name: string; var someClassPtr: auto) : VariantMacroPtr <function-ast_make_variant_macro_string_auto_0x316>`
   *  :ref:`make_variant_macro (name: string; class: void?; info: StructInfo const?) : smart_ptr\<VariantMacro\> <function-ast_make_variant_macro_string_void_q__StructInfo_const_q_>`
-  *  :ref:`make_visitor (someClass: auto) : smart_ptr\<VisitorAdapter\> <function-ast_make_visitor_auto_0x2c1>`
-  *  :ref:`make_visitor (class: void?; info: StructInfo const?) : smart_ptr\<VisitorAdapter\> <function-ast_make_visitor_void_q__StructInfo_const_q_>`
+  *  :ref:`make_visitor (someClass: auto; blk: block\<(var adapter:VisitorAdapter?):void\>) : auto <function-ast_make_visitor_auto_block_ls_var_adapter_c_VisitorAdapter_q__c_void_gr__0x2c1>`
+  *  :ref:`make_visitor (class: void?; info: StructInfo const?; blk: block\<(VisitorAdapter?):void\>) <function-ast_make_visitor_void_q__StructInfo_const_q__block_ls_VisitorAdapter_q__c_void_gr_>`
 
 
 make_block_annotation
@@ -5766,7 +5768,7 @@ Creates an adapter for the AstCallMacro interface.
 
             * **info** :  :ref:`StructInfo <handle-rtti-StructInfo>`? implicit
 
-.. _function-ast_make_call_macro_string_auto_0x2ed:
+.. _function-ast_make_call_macro_string_auto_0x2ec:
 
 .. das:function:: make_call_macro(name: string; someClassPtr: auto) : CallMacroPtr
 
@@ -5789,7 +5791,7 @@ Creates an adapter for the AstCaptureMacro interface.
 
             * **info** :  :ref:`StructInfo <handle-rtti-StructInfo>`? implicit
 
-.. _function-ast_make_capture_macro_string_auto_0x333:
+.. _function-ast_make_capture_macro_string_auto_0x332:
 
 .. das:function:: make_capture_macro(name: string; someClassPtr: auto) : CaptureMacroPtr
 
@@ -5819,7 +5821,7 @@ Creates an adapter for the AstCommentReader interface.
 
             * **info** :  :ref:`StructInfo <handle-rtti-StructInfo>`? implicit
 
-.. _function-ast_make_comment_reader_string_auto_0x2df:
+.. _function-ast_make_comment_reader_string_auto_0x2de:
 
 .. das:function:: make_comment_reader(name: string; someClassPtr: auto) : CommentReaderPtr
 
@@ -5873,7 +5875,7 @@ Creates an adapter for the AstForLoopMacro interface.
 
             * **info** :  :ref:`StructInfo <handle-rtti-StructInfo>`? implicit
 
-.. _function-ast_make_for_loop_macro_string_auto_0x325:
+.. _function-ast_make_for_loop_macro_string_auto_0x324:
 
 .. das:function:: make_for_loop_macro(name: string; someClassPtr: auto) : ForLoopMacroPtr
 
@@ -5940,7 +5942,7 @@ Creates an adapter for the AstPassMacro interface.
 
             * **info** :  :ref:`StructInfo <handle-rtti-StructInfo>`? implicit
 
-.. _function-ast_make_pass_macro_string_auto_0x309:
+.. _function-ast_make_pass_macro_string_auto_0x308:
 
 .. das:function:: make_pass_macro(name: string; someClassPtr: auto) : PassMacroPtr
 
@@ -5950,7 +5952,7 @@ Creates an adapter for the AstPassMacro interface.
 make_reader_macro
 ^^^^^^^^^^^^^^^^^
 
-.. _function-ast_make_reader_macro_string_auto_0x2d1:
+.. _function-ast_make_reader_macro_string_auto_0x2d0:
 
 .. das:function:: make_reader_macro(name: string; someClassPtr: auto) : ReaderMacroPtr
 
@@ -5970,7 +5972,7 @@ def make_reader_macro (name: string; var someClassPtr: auto) : ReaderMacroPtr
 make_simulate_macro
 ^^^^^^^^^^^^^^^^^^^
 
-.. _function-ast_make_simulate_macro_string_auto_0x34c:
+.. _function-ast_make_simulate_macro_string_auto_0x34b:
 
 .. das:function:: make_simulate_macro(name: string; someClassPtr: auto) : SimulateMacroPtr
 
@@ -6047,7 +6049,7 @@ Generates a TypeInfo for the specified type using the given DebugInfoHelper.
 make_type_macro
 ^^^^^^^^^^^^^^^
 
-.. _function-ast_make_type_macro_string_auto_0x33f:
+.. _function-ast_make_type_macro_string_auto_0x33e:
 
 .. das:function:: make_type_macro(name: string; someClassPtr: auto) : TypeMacroPtr
 
@@ -6080,7 +6082,7 @@ Creates an adapter for the AstTypeInfoMacro interface.
 
             * **info** :  :ref:`StructInfo <handle-rtti-StructInfo>`? implicit
 
-.. _function-ast_make_typeinfo_macro_string_auto_0x2fb:
+.. _function-ast_make_typeinfo_macro_string_auto_0x2fa:
 
 .. das:function:: make_typeinfo_macro(name: string; someClassPtr: auto) : TypeInfoMacroPtr
 
@@ -6101,7 +6103,7 @@ Generates a VariableInfo for the specified variable using the given DebugInfoHel
 make_variant_macro
 ^^^^^^^^^^^^^^^^^^
 
-.. _function-ast_make_variant_macro_string_auto_0x317:
+.. _function-ast_make_variant_macro_string_auto_0x316:
 
 .. das:function:: make_variant_macro(name: string; someClassPtr: auto) : VariantMacroPtr
 
@@ -6121,17 +6123,19 @@ def make_variant_macro (name: string; var someClassPtr: auto) : VariantMacroPtr
 make_visitor
 ^^^^^^^^^^^^
 
-.. _function-ast_make_visitor_auto_0x2c1:
+.. _function-ast_make_visitor_auto_block_ls_var_adapter_c_VisitorAdapter_q__c_void_gr__0x2c1:
 
-.. das:function:: make_visitor(someClass: auto) : smart_ptr<VisitorAdapter>
+.. das:function:: make_visitor(someClass: auto; blk: block<(var adapter:VisitorAdapter?):void>) : auto
 
-def make_visitor (someClass: auto) : smart_ptr<VisitorAdapter>
+def make_visitor (someClass: auto; blk: block<(var adapter:VisitorAdapter?):void>) : auto
 
 :Arguments: * **someClass** : auto
 
-.. _function-ast_make_visitor_void_q__StructInfo_const_q_:
+            * **blk** : block<(adapter: :ref:`VisitorAdapter <handle-ast-VisitorAdapter>`?):void>
 
-.. das:function:: make_visitor(class: void?; info: StructInfo const?) : smart_ptr<VisitorAdapter>
+.. _function-ast_make_visitor_void_q__StructInfo_const_q__block_ls_VisitorAdapter_q__c_void_gr_:
+
+.. das:function:: make_visitor(class: void?; info: StructInfo const?; blk: block<(VisitorAdapter?):void>)
 
 
 +++++++++++++++++++
@@ -6153,25 +6157,25 @@ Adapter application
   *  :ref:`add_infer_macro (module: Module?; annotation: smart_ptr\<PassMacro\>&) <function-ast_add_infer_macro_Module_q__smart_ptr_ls_PassMacro_gr__ref_>`
   *  :ref:`add_lint_macro (module: Module?; annotation: smart_ptr\<PassMacro\>&) <function-ast_add_lint_macro_Module_q__smart_ptr_ls_PassMacro_gr__ref_>`
   *  :ref:`add_module_option (module: Module?; option: string; type: Type) <function-ast_add_module_option_Module_q__string_Type>`
-  *  :ref:`add_new_block_annotation (name: string; var someClassPtr: auto) : auto <function-ast_add_new_block_annotation_string_auto_0x358>`
-  *  :ref:`add_new_call_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_call_macro_string_auto_0x39f>`
-  *  :ref:`add_new_capture_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_capture_macro_string_auto_0x382>`
-  *  :ref:`add_new_comment_reader (name: string; var someClassPtr: auto) : auto <function-ast_add_new_comment_reader_string_auto_0x399>`
-  *  :ref:`add_new_contract_annotation (name: string; var someClassPtr: auto) : auto <function-ast_add_new_contract_annotation_string_auto_0x364>`
-  *  :ref:`add_new_dirty_infer_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_dirty_infer_macro_string_auto_0x3b1>`
-  *  :ref:`add_new_enumeration_annotation (name: string; var someClassPtr: auto) : auto <function-ast_add_new_enumeration_annotation_string_auto_0x370>`
-  *  :ref:`add_new_for_loop_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_for_loop_macro_string_auto_0x37c>`
-  *  :ref:`add_new_function_annotation (name: string; var someClassPtr: auto) : auto <function-ast_add_new_function_annotation_string_auto_0x35e>`
-  *  :ref:`add_new_global_lint_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_global_lint_macro_string_auto_0x3bd>`
-  *  :ref:`add_new_infer_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_infer_macro_string_auto_0x3ab>`
-  *  :ref:`add_new_lint_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_lint_macro_string_auto_0x3b7>`
-  *  :ref:`add_new_optimization_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_optimization_macro_string_auto_0x3c3>`
-  *  :ref:`add_new_reader_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_reader_macro_string_auto_0x394>`
-  *  :ref:`add_new_simulate_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_simulate_macro_string_auto_0x38e>`
-  *  :ref:`add_new_structure_annotation (name: string; var someClassPtr: auto) : auto <function-ast_add_new_structure_annotation_string_auto_0x36a>`
-  *  :ref:`add_new_type_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_type_macro_string_auto_0x388>`
-  *  :ref:`add_new_typeinfo_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_typeinfo_macro_string_auto_0x3a5>`
-  *  :ref:`add_new_variant_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_variant_macro_string_auto_0x376>`
+  *  :ref:`add_new_block_annotation (name: string; var someClassPtr: auto) : auto <function-ast_add_new_block_annotation_string_auto_0x357>`
+  *  :ref:`add_new_call_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_call_macro_string_auto_0x39e>`
+  *  :ref:`add_new_capture_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_capture_macro_string_auto_0x381>`
+  *  :ref:`add_new_comment_reader (name: string; var someClassPtr: auto) : auto <function-ast_add_new_comment_reader_string_auto_0x398>`
+  *  :ref:`add_new_contract_annotation (name: string; var someClassPtr: auto) : auto <function-ast_add_new_contract_annotation_string_auto_0x363>`
+  *  :ref:`add_new_dirty_infer_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_dirty_infer_macro_string_auto_0x3b0>`
+  *  :ref:`add_new_enumeration_annotation (name: string; var someClassPtr: auto) : auto <function-ast_add_new_enumeration_annotation_string_auto_0x36f>`
+  *  :ref:`add_new_for_loop_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_for_loop_macro_string_auto_0x37b>`
+  *  :ref:`add_new_function_annotation (name: string; var someClassPtr: auto) : auto <function-ast_add_new_function_annotation_string_auto_0x35d>`
+  *  :ref:`add_new_global_lint_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_global_lint_macro_string_auto_0x3bc>`
+  *  :ref:`add_new_infer_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_infer_macro_string_auto_0x3aa>`
+  *  :ref:`add_new_lint_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_lint_macro_string_auto_0x3b6>`
+  *  :ref:`add_new_optimization_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_optimization_macro_string_auto_0x3c2>`
+  *  :ref:`add_new_reader_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_reader_macro_string_auto_0x393>`
+  *  :ref:`add_new_simulate_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_simulate_macro_string_auto_0x38d>`
+  *  :ref:`add_new_structure_annotation (name: string; var someClassPtr: auto) : auto <function-ast_add_new_structure_annotation_string_auto_0x369>`
+  *  :ref:`add_new_type_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_type_macro_string_auto_0x387>`
+  *  :ref:`add_new_typeinfo_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_typeinfo_macro_string_auto_0x3a4>`
+  *  :ref:`add_new_variant_macro (name: string; var someClassPtr: auto) : auto <function-ast_add_new_variant_macro_string_auto_0x375>`
   *  :ref:`add_optimization_macro (module: Module?; annotation: smart_ptr\<PassMacro\>&) <function-ast_add_optimization_macro_Module_q__smart_ptr_ls_PassMacro_gr__ref_>`
   *  :ref:`add_reader_macro (module: Module?; annotation: smart_ptr\<ReaderMacro\>&) <function-ast_add_reader_macro_Module_q__smart_ptr_ls_ReaderMacro_gr__ref_>`
   *  :ref:`add_simulate_macro (module: Module?; annotation: smart_ptr\<SimulateMacro\>&) <function-ast_add_simulate_macro_Module_q__smart_ptr_ls_SimulateMacro_gr__ref_>`
@@ -6339,7 +6343,7 @@ Adds a module-specific option accessible via the `options` keyword.
 
             * **type** :  :ref:`Type <enum-rtti-Type>`
 
-.. _function-ast_add_new_block_annotation_string_auto_0x358:
+.. _function-ast_add_new_block_annotation_string_auto_0x357:
 
 .. das:function:: add_new_block_annotation(name: string; someClassPtr: auto) : auto
 
@@ -6349,7 +6353,7 @@ def add_new_block_annotation (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_call_macro_string_auto_0x39f:
+.. _function-ast_add_new_call_macro_string_auto_0x39e:
 
 .. das:function:: add_new_call_macro(name: string; someClassPtr: auto) : auto
 
@@ -6359,7 +6363,7 @@ def add_new_call_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_capture_macro_string_auto_0x382:
+.. _function-ast_add_new_capture_macro_string_auto_0x381:
 
 .. das:function:: add_new_capture_macro(name: string; someClassPtr: auto) : auto
 
@@ -6369,7 +6373,7 @@ def add_new_capture_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_comment_reader_string_auto_0x399:
+.. _function-ast_add_new_comment_reader_string_auto_0x398:
 
 .. das:function:: add_new_comment_reader(name: string; someClassPtr: auto) : auto
 
@@ -6379,7 +6383,7 @@ def add_new_comment_reader (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_contract_annotation_string_auto_0x364:
+.. _function-ast_add_new_contract_annotation_string_auto_0x363:
 
 .. das:function:: add_new_contract_annotation(name: string; someClassPtr: auto) : auto
 
@@ -6389,7 +6393,7 @@ def add_new_contract_annotation (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_dirty_infer_macro_string_auto_0x3b1:
+.. _function-ast_add_new_dirty_infer_macro_string_auto_0x3b0:
 
 .. das:function:: add_new_dirty_infer_macro(name: string; someClassPtr: auto) : auto
 
@@ -6399,7 +6403,7 @@ def add_new_dirty_infer_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_enumeration_annotation_string_auto_0x370:
+.. _function-ast_add_new_enumeration_annotation_string_auto_0x36f:
 
 .. das:function:: add_new_enumeration_annotation(name: string; someClassPtr: auto) : auto
 
@@ -6409,7 +6413,7 @@ def add_new_enumeration_annotation (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_for_loop_macro_string_auto_0x37c:
+.. _function-ast_add_new_for_loop_macro_string_auto_0x37b:
 
 .. das:function:: add_new_for_loop_macro(name: string; someClassPtr: auto) : auto
 
@@ -6419,7 +6423,7 @@ def add_new_for_loop_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_function_annotation_string_auto_0x35e:
+.. _function-ast_add_new_function_annotation_string_auto_0x35d:
 
 .. das:function:: add_new_function_annotation(name: string; someClassPtr: auto) : auto
 
@@ -6429,7 +6433,7 @@ def add_new_function_annotation (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_global_lint_macro_string_auto_0x3bd:
+.. _function-ast_add_new_global_lint_macro_string_auto_0x3bc:
 
 .. das:function:: add_new_global_lint_macro(name: string; someClassPtr: auto) : auto
 
@@ -6439,7 +6443,7 @@ def add_new_global_lint_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_infer_macro_string_auto_0x3ab:
+.. _function-ast_add_new_infer_macro_string_auto_0x3aa:
 
 .. das:function:: add_new_infer_macro(name: string; someClassPtr: auto) : auto
 
@@ -6449,7 +6453,7 @@ def add_new_infer_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_lint_macro_string_auto_0x3b7:
+.. _function-ast_add_new_lint_macro_string_auto_0x3b6:
 
 .. das:function:: add_new_lint_macro(name: string; someClassPtr: auto) : auto
 
@@ -6459,7 +6463,7 @@ def add_new_lint_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_optimization_macro_string_auto_0x3c3:
+.. _function-ast_add_new_optimization_macro_string_auto_0x3c2:
 
 .. das:function:: add_new_optimization_macro(name: string; someClassPtr: auto) : auto
 
@@ -6469,7 +6473,7 @@ def add_new_optimization_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_reader_macro_string_auto_0x394:
+.. _function-ast_add_new_reader_macro_string_auto_0x393:
 
 .. das:function:: add_new_reader_macro(name: string; someClassPtr: auto) : auto
 
@@ -6479,7 +6483,7 @@ def add_new_reader_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_simulate_macro_string_auto_0x38e:
+.. _function-ast_add_new_simulate_macro_string_auto_0x38d:
 
 .. das:function:: add_new_simulate_macro(name: string; someClassPtr: auto) : auto
 
@@ -6489,7 +6493,7 @@ def add_new_simulate_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_structure_annotation_string_auto_0x36a:
+.. _function-ast_add_new_structure_annotation_string_auto_0x369:
 
 .. das:function:: add_new_structure_annotation(name: string; someClassPtr: auto) : auto
 
@@ -6499,7 +6503,7 @@ def add_new_structure_annotation (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_type_macro_string_auto_0x388:
+.. _function-ast_add_new_type_macro_string_auto_0x387:
 
 .. das:function:: add_new_type_macro(name: string; someClassPtr: auto) : auto
 
@@ -6509,7 +6513,7 @@ def add_new_type_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_typeinfo_macro_string_auto_0x3a5:
+.. _function-ast_add_new_typeinfo_macro_string_auto_0x3a4:
 
 .. das:function:: add_new_typeinfo_macro(name: string; someClassPtr: auto) : auto
 
@@ -6519,7 +6523,7 @@ def add_new_typeinfo_macro (name: string; var someClassPtr: auto) : auto
 
             * **someClassPtr** : auto
 
-.. _function-ast_add_new_variant_macro_string_auto_0x376:
+.. _function-ast_add_new_variant_macro_string_auto_0x375:
 
 .. das:function:: add_new_variant_macro(name: string; someClassPtr: auto) : auto
 

--- a/doc/source/stdlib/handmade/function-ast-visit-0x1ed2b2cb08872295.rst
+++ b/doc/source/stdlib/handmade/function-ast-visit-0x1ed2b2cb08872295.rst
@@ -1,0 +1,1 @@
+Visit the program with the given visitor adapter. When sortStructures is true, struct declarations are visited in topological (dependency) order, ensuring that structs used by value in fields are visited before the structs that contain them.

--- a/doc/source/stdlib/handmade/function-ast-visit_enumeration-0x7ea9f65fdb4fe546.rst
+++ b/doc/source/stdlib/handmade/function-ast-visit_enumeration-0x7ea9f65fdb4fe546.rst
@@ -1,0 +1,1 @@
+Applies the given visitor adapter to the specified enumeration within the context of the program, triggering the appropriate visitor callbacks.

--- a/doc/source/stdlib/handmade/function-ast-visit_finally-0x25b2f5c5e8b47369.rst
+++ b/doc/source/stdlib/handmade/function-ast-visit_finally-0x25b2f5c5e8b47369.rst
@@ -1,0 +1,1 @@
+Invokes the visitor on the finally section of a block.

--- a/doc/source/stdlib/handmade/function-ast-visit_module-0xf537b41b44807174.rst
+++ b/doc/source/stdlib/handmade/function-ast-visit_module-0xf537b41b44807174.rst
@@ -1,0 +1,1 @@
+Invokes an AST visitor on the given module.

--- a/doc/source/stdlib/handmade/function-ast-visit_modules-0xc935b5019c42f63a.rst
+++ b/doc/source/stdlib/handmade/function-ast-visit_modules-0xc935b5019c42f63a.rst
@@ -1,0 +1,1 @@
+Invokes an AST visitor on all modules in the specified program.

--- a/doc/source/stdlib/handmade/function-ast-visit_structure-0x620d3036f2d2f82c.rst
+++ b/doc/source/stdlib/handmade/function-ast-visit_structure-0x620d3036f2d2f82c.rst
@@ -1,0 +1,1 @@
+Applies the given visitor adapter to the specified structure within the context of the program, triggering the appropriate visitor callbacks.

--- a/doc/source/stdlib/handmade/function-ast-visit_with_generics-0xf099a7f375f390b4.rst
+++ b/doc/source/stdlib/handmade/function-ast-visit_with_generics-0xf099a7f375f390b4.rst
@@ -1,0 +1,1 @@
+Visits the program AST including generic function instantiations. Unlike visit, which only walks non-generic functions, this also visits each instantiated generic, making it suitable for lint passes that need to check generated code.

--- a/include/daScript/ast/ast_visitor.h
+++ b/include/daScript/ast/ast_visitor.h
@@ -20,7 +20,7 @@ namespace das {
 #pragma clang diagnostic ignored "-Wunused-parameter"
 #endif
 
-    class Visitor : public ptr_ref_count {
+    class Visitor {
     protected:
         virtual ~Visitor() {}
     public:

--- a/include/daScript/simulate/aot_builtin_ast.h
+++ b/include/daScript/simulate/aot_builtin_ast.h
@@ -443,17 +443,18 @@ namespace das {
     DAS_API DebugAgentPtr makeDebugAgent ( const void * pClass, const StructInfo * info, Context * context );
     DAS_API Module * thisModule ( Context * context, LineInfoArg * lineinfo );
     DAS_API smart_ptr_raw<Program> thisProgram ( Context * context );
-    DAS_API void astVisit ( smart_ptr_raw<Program> program, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info );
-    DAS_API void astVisitGenerics ( smart_ptr_raw<Program> program, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info );
-    DAS_API void astVisitModule ( smart_ptr_raw<Program> program, smart_ptr_raw<VisitorAdapter> adapter,
+    DAS_API void astVisit ( smart_ptr_raw<Program> program, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info );
+    DAS_API void astVisitGenerics ( smart_ptr_raw<Program> program, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info );
+    DAS_API void astVisitModule ( smart_ptr_raw<Program> program, VisitorAdapter * adapter,
                       Module* module, Context * context, LineInfoArg * line_info );
-    DAS_API void astVisitModulesInOrder ( smart_ptr_raw<Program> program, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info );
-    DAS_API void astVisitFunction ( Function * func, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info);
-    DAS_API Expression * astVisitExpression ( Expression * expr, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info);
-    DAS_API TypeDecl * astVisitTypeDecl ( TypeDecl * type, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info);
-    DAS_API void astVisitBlockFinally ( ExprBlock * expr, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info );
+    DAS_API void astVisitModulesInOrder ( smart_ptr_raw<Program> program, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info );
+    DAS_API void astVisitFunction ( Function * func, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info);
+    DAS_API Expression * astVisitExpression ( Expression * expr, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info);
+    DAS_API TypeDecl * astVisitTypeDecl ( TypeDecl * type, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info);
+    DAS_API void astVisitBlockFinally ( ExprBlock * expr, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info );
     DAS_API PassMacroPtr makePassMacro ( const char * name, const void * pClass, const StructInfo * info, Context * context );
-    DAS_API smart_ptr<VisitorAdapter> makeVisitor ( const void * pClass, const StructInfo * info, Context * context );
+    DAS_API void makeVisitor ( const void * pClass, const StructInfo * info,
+            const TBlock<void,VisitorAdapter*> & blk, Context * context, LineInfoArg * at );
     DAS_API void addModuleInferMacro ( Module * module, PassMacroPtr & _newM, Context * );
     DAS_API void addModuleInferDirtyMacro ( Module * module, PassMacroPtr & newM, Context * context );
     DAS_API void addModuleLintMacro ( Module * module, PassMacroPtr & _newM, Context * );
@@ -504,8 +505,8 @@ namespace das {
     DAS_API void addBlockBlockAnnotation ( ExprBlock * block, FunctionAnnotationPtr & _ann, Context * context, LineInfoArg * at );
     DAS_API void addAndApplyBlockAnnotation ( ExprBlock * blk, smart_ptr_raw<AnnotationDeclaration> & ann, Context * context, LineInfoArg * at );
     DAS_API void addAndApplyStructAnnotation ( Structure * st, smart_ptr_raw<AnnotationDeclaration> & ann, Context * context, LineInfoArg * at );
-    DAS_API void visitEnumeration ( ProgramPtr program, Enumeration * enumeration, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info );
-    DAS_API void visitStructure ( ProgramPtr program, Structure * structure, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info );
+    DAS_API void visitEnumeration ( ProgramPtr program, Enumeration * enumeration, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info );
+    DAS_API void visitStructure ( ProgramPtr program, Structure * structure, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info );
     __forceinline ExpressionPtr clone_expression ( ExpressionPtr value ) { return value ?value->clone() : nullptr; }
     __forceinline FunctionPtr clone_function ( FunctionPtr value ) { return value ? value->clone() : nullptr; }
     __forceinline TypeDeclPtr clone_type ( TypeDeclPtr value ) { return value ? new TypeDecl(*value) : nullptr; }

--- a/modules/dasGlsl/glsl/glsl_internal.das
+++ b/modules/dasGlsl/glsl/glsl_internal.das
@@ -296,7 +296,7 @@ class GlslExport : AstVisitor {
     shaderType : ShaderType
     version : int = 0
     renames : array<tuple<name : string; repl : string>>
-    astVisitorAdapter : smart_ptr<ast::VisitorAdapter>
+    astVisitorAdapter : VisitorAdapter?
     compute_local_size : int3
     caps : ShaderExportCaps
     inout_stub : string
@@ -1877,31 +1877,30 @@ def generate_glsl(fnMain : FunctionPtr; var errors : array<string>; shaderType :
     var inout_decl = ""
     let st = build_string() $(var writer) {
         var astVisitor = new GlslExport(writer, shaderType, version, comp_loc_size, caps)
-        unsafe {
-            astVisitor.astVisitorAdapter <- make_visitor(*astVisitor)
-        }
-        collect_dependencies(fnMain) $(vfun, vvar) {
-            for (f in vfun) {
-                astVisitor.depFun[intptr(f)] = true
-            }
-            for (v in vvar) {
-                astVisitor.depVar[intptr(v)] = true
-            }
-            collect_used_types(vfun, vvar) $(onlyUsed) : void {
-                for (st in keys(onlyUsed.st)) {
-                    astVisitor.depStruct[intptr(st)] = true
-                    astVisitor.stnames["{st.name}"] = true
+        make_visitor(*astVisitor) $(adapter) {
+            astVisitor.astVisitorAdapter = adapter
+            collect_dependencies(fnMain) $(vfun, vvar) {
+                for (f in vfun) {
+                    astVisitor.depFun[intptr(f)] = true
                 }
-                for (en in keys(onlyUsed.en)) {
-                    astVisitor.depStruct[intptr(en)] = true
+                for (v in vvar) {
+                    astVisitor.depVar[intptr(v)] = true
                 }
-                visit_modules(compiling_program(), astVisitor.astVisitorAdapter)
+                collect_used_types(vfun, vvar) $(onlyUsed) : void {
+                    for (st in keys(onlyUsed.st)) {
+                        astVisitor.depStruct[intptr(st)] = true
+                        astVisitor.stnames["{st.name}"] = true
+                    }
+                    for (en in keys(onlyUsed.en)) {
+                        astVisitor.depStruct[intptr(en)] = true
+                    }
+                    visit_modules(compiling_program(), astVisitor.astVisitorAdapter)
+                }
             }
         }
         errors <- astVisitor.errors
         inout_stub = astVisitor.inout_stub
         inout_decl = astVisitor.inout_decl
-        astVisitor.astVisitorAdapter := null
         unsafe {
             delete astVisitor
         }

--- a/modules/dasLLVM/daslib/llvm_dll_utils.das
+++ b/modules/dasLLVM/daslib/llvm_dll_utils.das
@@ -189,9 +189,10 @@ class public UidNodes {
 def public create_uid_nodes(prog : Program?; funcs : array<FunctionPtr>) {
     var res = new table<void?, uint64>()
     var uids = new UidGen(id_map = res)
-    var inscope adapter <- make_visitor(*uids)
-    for (fun in funcs) {
-        visit(fun, adapter)
+    make_visitor(*uids) $(adapter) {
+        for (fun in funcs) {
+            visit(fun, adapter)
+        }
     }
     unsafe {
         delete uids

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -432,19 +432,20 @@ def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVM
                                mod : LLVMOpaqueModule?; var types : PrimitiveTypes?;
                                var funcs : array<FunctionPtr>; var uids : UidNodes?) {
     var extern_resolver = new CollectExternVisitor(standalone_context, ctx, builder, mod, types, uids)
-    var inscope adapter_resolve = make_visitor(*extern_resolver)
-    ast_gc_guard() {
-        for (fn in funcs) {
-            visit(fn, adapter_resolve)
+    make_visitor(*extern_resolver) $(adapter_resolve) {
+        ast_gc_guard() {
+            for (fn in funcs) {
+                visit(fn, adapter_resolve)
+            }
         }
-    }
-    // Register [pinvoke] and [export] functions in tabMnLookup so they can be
-    // found by name at runtime (e.g. via invoke_in_context).
-    for (fn in funcs) {
-        if (!fn.flags.builtIn && (fn.moreFlags.pinvoke || fn.flags.exports)) {
-            extern_resolver.uid.reset(fn)
-            extern_resolver.register_function(fn)
-            extern_resolver.uid.reset(null)
+        // Register [pinvoke] and [export] functions in tabMnLookup so they can be
+        // found by name at runtime (e.g. via invoke_in_context).
+        for (fn in funcs) {
+            if (!fn.flags.builtIn && (fn.moreFlags.pinvoke || fn.flags.exports)) {
+                extern_resolver.uid.reset(fn)
+                extern_resolver.register_function(fn)
+                extern_resolver.uid.reset(null)
+            }
         }
     }
     var result = extern_resolver.any_unimplemented

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -269,7 +269,7 @@ bitfield public LlvmJitFlags {
 
 [macro]
 class public LlvmJitVisitor : AstVisitor {
-    adapter : smart_ptr<VisitorAdapter>
+    adapter : VisitorAdapter?
     e2v : table<Expression?; LLVMOpaqueValue?>
     v2v : table<Variable?; LLVMOpaqueValue?>
     v2t : table<LLVMOpaqueValue?; LLVMOpaqueType?>
@@ -5259,30 +5259,31 @@ class public LlvmJitVisitor : AstVisitor {
 
     def make_block_function(expr : ExprMakeBlock?; captured : array<CapturedVariable>; first_field_index : int; captureType : LLVMOpaqueType?) : tuple<func : LLVMOpaqueValue?; impl : LLVMOpaqueValue?> {
         var astVisitor = new LlvmJitVisitor(jit_context, types, uid, flags, g_di_builder, attributes)
-        unsafe {
-            astVisitor.adapter <- make_visitor(*astVisitor)
-        }
-        let fmna = (*astVisitor)->pre_make_block(unsafe(reinterpret<ExprBlock?> expr._block), thisFunc, captureType)
-        var cblk = (*astVisitor)->before_function_entry()
-        var carg = (*astVisitor)->get_capture_param()
-        carg = LLVMBuildLoad2(astVisitor.g_builder, captureType, carg, "capture")
-        for (c, ai in captured, count()) {
-            var arg_i = LLVMBuildExtractValue(astVisitor.g_builder, carg, uint(ai + first_field_index), "var_{c.variable.name}_index_{ai}_stindex_{ai+first_field_index}")
-            if (c.eref) {
-                var arg_t = LLVMPointerType(type_to_llvm_type(c.variable._type), 0u)
-                var arg_p = LLVMBuildAlloca(astVisitor.g_builder, arg_t, "var_{c.variable.name}_index_{ai}_stindex_{ai+first_field_index}_var")
-                LLVMBuildStore(astVisitor.g_builder, arg_i, arg_p)
-                (*astVisitor)->setV(c.variable, arg_p)
-            } else {
-                (*astVisitor)->setV(c.variable, arg_i)
+        var result : LLVMOpaqueValue?
+        var impl : LLVMOpaqueValue?
+        make_visitor(*astVisitor) $(mv_adapter) {
+            astVisitor.adapter = mv_adapter
+            let fmna = (*astVisitor)->pre_make_block(unsafe(reinterpret<ExprBlock?> expr._block), thisFunc, captureType)
+            var cblk = (*astVisitor)->before_function_entry()
+            var carg = (*astVisitor)->get_capture_param()
+            carg = LLVMBuildLoad2(astVisitor.g_builder, captureType, carg, "capture")
+            for (c, ai in captured, count()) {
+                var arg_i = LLVMBuildExtractValue(astVisitor.g_builder, carg, uint(ai + first_field_index), "var_{c.variable.name}_index_{ai}_stindex_{ai+first_field_index}")
+                if (c.eref) {
+                    var arg_t = LLVMPointerType(type_to_llvm_type(c.variable._type), 0u)
+                    var arg_p = LLVMBuildAlloca(astVisitor.g_builder, arg_t, "var_{c.variable.name}_index_{ai}_stindex_{ai+first_field_index}_var")
+                    LLVMBuildStore(astVisitor.g_builder, arg_i, arg_p)
+                    (*astVisitor)->setV(c.variable, arg_p)
+                } else {
+                    (*astVisitor)->setV(c.variable, arg_i)
+                }
             }
+            (*astVisitor)->after_function_entry(cblk)
+            visit(expr._block, astVisitor.adapter)
+            (*astVisitor)->post_make_block(unsafe(reinterpret<ExprBlock?> expr._block))
+            result = LLVMGetNamedFunction(g_mod, fmna.publ())
+            impl = LLVMGetNamedFunction(g_mod, fmna.impl())
         }
-        (*astVisitor)->after_function_entry(cblk)
-        visit(expr._block, astVisitor.adapter)
-        (*astVisitor)->post_make_block(unsafe(reinterpret<ExprBlock?> expr._block))
-        let result = LLVMGetNamedFunction(g_mod, fmna.publ())
-        let impl = LLVMGetNamedFunction(g_mod, fmna.impl())
-        astVisitor.adapter := null
         unsafe {
             delete astVisitor
         }
@@ -6352,11 +6353,11 @@ def public generate_llvm(ctx : Context?; types : PrimitiveTypes?; uids : UidNode
         globalVar |> LLVMSetInitializer(types.ConstI64(aot_hash))
     }
     var astVisitor = new LlvmJitVisitor(ctx, types, uids, flags, null, attrs)
-    unsafe {
-        astVisitor.adapter <- make_visitor(*astVisitor)
-    }
-    ast_gc_guard() {
-        visit(fn, astVisitor.adapter)
+    make_visitor(*astVisitor) $(mv_adapter) {
+        astVisitor.adapter = mv_adapter
+        ast_gc_guard() {
+            visit(fn, astVisitor.adapter)
+        }
     }
     if (length(g_errors) > 0) {
         let errors = g_errors |> join("\n")
@@ -6364,7 +6365,6 @@ def public generate_llvm(ctx : Context?; types : PrimitiveTypes?; uids : UidNode
         to_log(LOG_ERROR, "LLVM JIT FAILED:\n{errors}\n")
         g_failed = true
     }
-    astVisitor.adapter := null
     unsafe {
         delete astVisitor
     }
@@ -6379,70 +6379,72 @@ def public generate_globals_initialization_fn(ctx : Context?; prog : Program?;
                                               fn_name : string = "init_globals") {
     let attrs = new Attributes(g_ctx)
     var visitor = new LlvmJitVisitor(ctx, types, uids, flags, null, attrs)
-    var inscope adapter = make_visitor(*visitor)
-    visitor.adapter := adapter
+    var globals_fn : LLVMOpaqueValue?
+    var globals_fn_type : LLVMOpaqueType?
+    make_visitor(*visitor) $(adapter) {
+        visitor.adapter = adapter
 
-    let globals_fn_type = LLVMFunctionType(types.t_void,
-        array<LLVMTypeRef>(types.LLVMVoidPtrType())
-    )
-    let globals_fn = LLVMAddFunctionWithType(g_mod, fn_name, globals_fn_type)
-    if (flags.need_di) {
-        set_debug_linkage(globals_fn)
-    } else {
-        set_private_linkage(globals_fn)
-    }
-    visitor.ffunc = globals_fn
-    let entry = LLVMAppendBasicBlockInContext(g_ctx, globals_fn, "entry")
-    let body = LLVMAppendBasicBlockInContext(g_ctx, globals_fn, "body")
-    visitor.function_entry = entry
-    LLVMPositionBuilderAtEnd(visitor.g_builder, body)
-    let ctx_param = LLVMGetParam(globals_fn, 0u)
+        globals_fn_type = LLVMFunctionType(types.t_void,
+            array<LLVMTypeRef>(types.LLVMVoidPtrType())
+        )
+        globals_fn = LLVMAddFunctionWithType(g_mod, fn_name, globals_fn_type)
+        if (flags.need_di) {
+            set_debug_linkage(globals_fn)
+        } else {
+            set_private_linkage(globals_fn)
+        }
+        visitor.ffunc = globals_fn
+        let entry = LLVMAppendBasicBlockInContext(g_ctx, globals_fn, "entry")
+        let body = LLVMAppendBasicBlockInContext(g_ctx, globals_fn, "body")
+        visitor.function_entry = entry
+        LLVMPositionBuilderAtEnd(visitor.g_builder, body)
+        let ctx_param = LLVMGetParam(globals_fn, 0u)
 
-    ast_gc_guard() {
+        ast_gc_guard() {
 
-        // dummy Function with 0 arguments so get_context_param returns LLVMGetParam(ffunc, 0u)
-        var dummyFunc <- new Function(name := fn_name)
-        visitor.thisFunc = dummyFunc
+            // dummy Function with 0 arguments so get_context_param returns LLVMGetParam(ffunc, 0u)
+            var dummyFunc <- new Function(name := fn_name)
+            visitor.thisFunc = dummyFunc
 
-        prog |> for_each_module() $(mod) {
-            mod |> for_each_global() $(glob) {
-                if (glob.init != null && glob.flags.used) {
-                    // compute global variable destination pointer before visiting init expression
-                    let isSolidContext = glob._module.moduleFlags.isSolidContext
-                    var vptr : LLVMOpaqueValue?
-                    if (!isSolidContext) {
-                        let mnh = hash(get_mangled_name(glob))
-                        var params = fixed_array(
-                            LLVMConstInt(types.t_int64, mnh, 0),
-                            ctx_param
-                        )
-                        var func = LLVMGetNamedFunction(g_mod, glob.flags.global_shared ? FN_JIT_GET_SHARED_MNH : FN_JIT_GET_GLOBAL_MNH)
-                        var typ = g_fn_types[glob.flags.global_shared ? FN_JIT_GET_SHARED_MNH : FN_JIT_GET_GLOBAL_MNH]
-                        vptr = LLVMBuildCall2(visitor.g_builder, typ, func, params, "global_var_{glob.name}_mnh_ptr")
-                        vptr = LLVMBuildPointerCast(visitor.g_builder, vptr, get_type_pointer(glob._type), "global_var_{glob.name}")
-                    } else {
-                        var ctx_ptr = LLVMBuildPointerCast(visitor.g_builder, ctx_param, LLVMPointerType(types.t_int8, 0u), "")
-                        let coffset = glob.flags.global_shared ? CONTEXT_OFFSET_OF_SHARED : CONTEXT_OFFSET_OF_GLOBALS
-                        var global_ptr = LLVMBuildGEP2(visitor.g_builder, types.t_int8, ctx_ptr, types.ConstI32(uint64(coffset)), "")
-                        global_ptr = LLVMBuildLoad2(visitor.g_builder, LLVMPointerType(types.t_int8, 0u), global_ptr, "")
-                        vptr = LLVMBuildGEP2(visitor.g_builder, types.t_int8, global_ptr, types.ConstI32(uint64(glob.stackTop)), "")
-                    }
-                    // register CMRES destination so init expressions that return by copy/move
-                    // write directly into the global variable's memory
-                    let usedCmres = visitor.make_call_to_cmres(glob.init, vptr)
-                    visit_expression(glob.init, adapter)
-                    if (!usedCmres) {
-                        visitor.build_copy(vptr, glob.init)
+            prog |> for_each_module() $(mod) {
+                mod |> for_each_global() $(glob) {
+                    if (glob.init != null && glob.flags.used) {
+                        // compute global variable destination pointer before visiting init expression
+                        let isSolidContext = glob._module.moduleFlags.isSolidContext
+                        var vptr : LLVMOpaqueValue?
+                        if (!isSolidContext) {
+                            let mnh = hash(get_mangled_name(glob))
+                            var params = fixed_array(
+                                LLVMConstInt(types.t_int64, mnh, 0),
+                                ctx_param
+                            )
+                            var func = LLVMGetNamedFunction(g_mod, glob.flags.global_shared ? FN_JIT_GET_SHARED_MNH : FN_JIT_GET_GLOBAL_MNH)
+                            var typ = g_fn_types[glob.flags.global_shared ? FN_JIT_GET_SHARED_MNH : FN_JIT_GET_GLOBAL_MNH]
+                            vptr = LLVMBuildCall2(visitor.g_builder, typ, func, params, "global_var_{glob.name}_mnh_ptr")
+                            vptr = LLVMBuildPointerCast(visitor.g_builder, vptr, get_type_pointer(glob._type), "global_var_{glob.name}")
+                        } else {
+                            var ctx_ptr = LLVMBuildPointerCast(visitor.g_builder, ctx_param, LLVMPointerType(types.t_int8, 0u), "")
+                            let coffset = glob.flags.global_shared ? CONTEXT_OFFSET_OF_SHARED : CONTEXT_OFFSET_OF_GLOBALS
+                            var global_ptr = LLVMBuildGEP2(visitor.g_builder, types.t_int8, ctx_ptr, types.ConstI32(uint64(coffset)), "")
+                            global_ptr = LLVMBuildLoad2(visitor.g_builder, LLVMPointerType(types.t_int8, 0u), global_ptr, "")
+                            vptr = LLVMBuildGEP2(visitor.g_builder, types.t_int8, global_ptr, types.ConstI32(uint64(glob.stackTop)), "")
+                        }
+                        // register CMRES destination so init expressions that return by copy/move
+                        // write directly into the global variable's memory
+                        let usedCmres = visitor.make_call_to_cmres(glob.init, vptr)
+                        visit_expression(glob.init, adapter)
+                        if (!usedCmres) {
+                            visitor.build_copy(vptr, glob.init)
+                        }
                     }
                 }
             }
         }
+        LLVMBuildRetVoid(visitor.g_builder)
+        // terminate entry block with branch to body (entry only has allocas from at_function_entry)
+        LLVMPositionBuilderAtEnd(visitor.g_builder, entry)
+        LLVMBuildBr(visitor.g_builder, body)
     }
-    LLVMBuildRetVoid(visitor.g_builder)
-    // terminate entry block with branch to body (entry only has allocas from at_function_entry)
-    LLVMPositionBuilderAtEnd(visitor.g_builder, entry)
-    LLVMBuildBr(visitor.g_builder, body)
-    visitor.adapter := null
     unsafe {
         delete visitor
     }

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -87,7 +87,6 @@ class JIT_LLVM : AstSimulateMacro {
         var funcs : array<FunctionPtr>
         var disabled : array<FunctionPtr>
         var disableJitVisitor = new DisableJitVisitor()
-        var inscope disableJitVisitorAdapter <- make_visitor(*disableJitVisitor)
 
         assume jit_all_functions = prog.policies.jit_jit_all_functions
         assume debug_info = prog.policies.jit_debug_info
@@ -113,22 +112,24 @@ class JIT_LLVM : AstSimulateMacro {
         // Set global options
         LLVM_JIT_ALLOW_UNALIGNED_VECTOR_READ_OUT_OF_BOUNDS = prog._options |> find_arg("jit_vec3_ldu") ?as tBool ?? LLVM_JIT_ALLOW_UNALIGNED_VECTOR_READ_OUT_OF_BOUNDS_DEFAULT
 
-        prog |> for_each_module() $(mod) {
-            mod |> for_each_function("") $(fun) {
-                let rqj = fun.moreFlags.requestJit
-                fun.moreFlags &= ~MoreFunctionFlags.requestJit
-                if (fun.flags.used && (jit_all_functions || rqj)) {
-                    if (!fun.moreFlags.requestNoJit) {
-                        disableJitVisitor.disable = false
-                        fun |> visit(disableJitVisitorAdapter)
-                        if (!disableJitVisitor.disable) {
-                            fun.moreFlags |= MoreFunctionFlags.requestJit
-                            funcs |> emplace(fun)
+        make_visitor(*disableJitVisitor) $(disableJitVisitorAdapter) {
+            prog |> for_each_module() $(mod) {
+                mod |> for_each_function("") $(fun) {
+                    let rqj = fun.moreFlags.requestJit
+                    fun.moreFlags &= ~MoreFunctionFlags.requestJit
+                    if (fun.flags.used && (jit_all_functions || rqj)) {
+                        if (!fun.moreFlags.requestNoJit) {
+                            disableJitVisitor.disable = false
+                            fun |> visit(disableJitVisitorAdapter)
+                            if (!disableJitVisitor.disable) {
+                                fun.moreFlags |= MoreFunctionFlags.requestJit
+                                funcs |> emplace(fun)
+                            } else {
+                                to_log(LOG_INFO, "LLVM JIT: disabled {fun.name}\n")
+                            }
                         } else {
-                            to_log(LOG_INFO, "LLVM JIT: disabled {fun.name}\n")
+                            disabled |> emplace(fun)
                         }
-                    } else {
-                        disabled |> emplace(fun)
                     }
                 }
             }
@@ -236,9 +237,10 @@ class JIT_LLVM : AstSimulateMacro {
             if (use_dll) {
                 assert(g_dynamic_lib_handle.handle != null)
                 var extern_resolver = new ResolveExternVisitor(g_dynamic_lib_handle, g_prim_t, ctx, clone(uids))
-                var inscope adapter_resolve = make_visitor(*extern_resolver)
-                for (fn in funcs) {
-                    visit(fn, adapter_resolve)
+                make_visitor(*extern_resolver) $(adapter_resolve) {
+                    for (fn in funcs) {
+                        visit(fn, adapter_resolve)
+                    }
                 }
             }
             if (!gen_exe) {

--- a/src/builtin/module_builtin_ast_adapters.cpp
+++ b/src/builtin/module_builtin_ast_adapters.cpp
@@ -1162,7 +1162,7 @@ namespace das {
     }
 
 
-    struct AstVisitorAdapterAnnotation : ManagedStructureAnnotation<VisitorAdapter,false,true> {
+    struct AstVisitorAdapterAnnotation : ManagedStructureAnnotation<VisitorAdapter,false,false> {
         AstVisitorAdapterAnnotation(ModuleLibrary & ml)
             : ManagedStructureAnnotation ("VisitorAdapter", ml) {
         }
@@ -2259,8 +2259,13 @@ namespace das {
         }
     }
 
-    smart_ptr<VisitorAdapter> makeVisitor ( const void * pClass, const StructInfo * info, Context * context ) {
-        return make_smart<VisitorAdapter>((char *)pClass,info,context);
+    void makeVisitor ( const void * pClass, const StructInfo * info,
+            const TBlock<void,VisitorAdapter*> & blk, Context * context, LineInfoArg * at ) {
+        auto adapter = new VisitorAdapter((char *)pClass,info,context);
+        vec4f args[1];
+        args[0] = cast<VisitorAdapter*>::from(adapter);
+        context->invoke(blk, args, nullptr, at);
+        delete adapter;
     }
 
     PassMacroPtr makePassMacro ( const char * name, const void * pClass, const StructInfo * info, Context * context ) {
@@ -2478,7 +2483,7 @@ namespace das {
         st->annotations.push_back(ann);
     }
 
-    void astVisit ( smart_ptr_raw<Program> program, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info ) {
+    void astVisit ( smart_ptr_raw<Program> program, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info ) {
         if (!adapter)
             context->throw_error_at(line_info, "adapter is required");
         if (!program)
@@ -2486,7 +2491,7 @@ namespace das {
         program->visit(*adapter);
     }
 
-    void astVisitGenerics ( smart_ptr_raw<Program> program, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info ) {
+    void astVisitGenerics ( smart_ptr_raw<Program> program, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info ) {
         if (!adapter)
             context->throw_error_at(line_info, "adapter is required");
         if (!program)
@@ -2494,7 +2499,7 @@ namespace das {
         program->visit(*adapter, true);
     }
 
-    void astVisitWithSort ( smart_ptr_raw<Program> program, smart_ptr_raw<VisitorAdapter> adapter, bool sortStructures, Context * context, LineInfoArg * line_info ) {
+    void astVisitWithSort ( smart_ptr_raw<Program> program, VisitorAdapter * adapter, bool sortStructures, Context * context, LineInfoArg * line_info ) {
         if (!adapter)
             context->throw_error_at(line_info, "adapter is required");
         if (!program)
@@ -2502,7 +2507,7 @@ namespace das {
         program->visit(*adapter, false, sortStructures);
     }
 
-    void astVisitModule ( smart_ptr_raw<Program> program, smart_ptr_raw<VisitorAdapter> adapter,
+    void astVisitModule ( smart_ptr_raw<Program> program, VisitorAdapter * adapter,
                           Module* module, Context * context, LineInfoArg * line_info ) {
         if (!adapter)
             context->throw_error_at(line_info, "adapter is required");
@@ -2511,7 +2516,7 @@ namespace das {
         program->visitModule(*adapter, module);
     }
 
-    void astVisitModulesInOrder ( smart_ptr_raw<Program> program, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info ) {
+    void astVisitModulesInOrder ( smart_ptr_raw<Program> program, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info ) {
         if (!adapter)
             context->throw_error_at(line_info, "adapter is required");
         if (!program)
@@ -2519,7 +2524,7 @@ namespace das {
         program->visitModulesInOrder(*adapter);
     }
 
-    void astVisitFunction ( Function * func, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info ) {
+    void astVisitFunction ( Function * func, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info ) {
         if (!adapter)
             context->throw_error_at(line_info, "adapter is required");
         if (!func)
@@ -2527,7 +2532,7 @@ namespace das {
         func->visit(*adapter);
     }
 
-    TypeDecl * astVisitTypeDecl ( TypeDecl * expr, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info ) {
+    TypeDecl * astVisitTypeDecl ( TypeDecl * expr, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info ) {
         if (!adapter)
             context->throw_error_at(line_info, "adapter is required");
         if (!expr)
@@ -2538,15 +2543,15 @@ namespace das {
         return res;
     }
 
-    void visitEnumeration ( ProgramPtr program, Enumeration * enumeration, smart_ptr_raw<VisitorAdapter> adapter, Context * , LineInfoArg * ) {
+    void visitEnumeration ( ProgramPtr program, Enumeration * enumeration, VisitorAdapter * adapter, Context * , LineInfoArg * ) {
         program->visitEnumeration(*adapter, enumeration);
     }
 
-    void visitStructure ( ProgramPtr program, Structure * structure, smart_ptr_raw<VisitorAdapter> adapter, Context * , LineInfoArg *  ) {
+    void visitStructure ( ProgramPtr program, Structure * structure, VisitorAdapter * adapter, Context * , LineInfoArg *  ) {
         program->visitStructure(*adapter, structure);
     }
 
-    Expression * astVisitExpression ( Expression * expr, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info ) {
+    Expression * astVisitExpression ( Expression * expr, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info ) {
         if (!adapter)
             context->throw_error_at(line_info, "adapter is required");
         if (!expr)
@@ -2555,7 +2560,7 @@ namespace das {
         return res;
     }
 
-    void astVisitBlockFinally ( ExprBlock * expr, smart_ptr_raw<VisitorAdapter> adapter, Context * context, LineInfoArg * line_info ) {
+    void astVisitBlockFinally ( ExprBlock * expr, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info ) {
         if (!adapter)
             context->throw_error_at(line_info, "adapter is required");
         if (!expr)
@@ -2568,7 +2573,7 @@ namespace das {
         addAnnotation(make_smart<AstVisitorAdapterAnnotation>(lib));
         addExtern<DAS_BIND_FUN(makeVisitor)>(*this, lib,  "make_visitor",
             SideEffects::modifyExternal, "makeVisitor")
-                ->args({"class","info","context"});
+                ->args({"class","info","blk","context","at"})->unsafeOperation = true;
         addExtern<DAS_BIND_FUN(astVisit)>(*this, lib,  "visit",
             SideEffects::accessExternal, "astVisit")
                 ->args({"program","adapter","context","line"});

--- a/tutorials/macros/function_macro_mod.das
+++ b/tutorials/macros/function_macro_mod.das
@@ -214,10 +214,10 @@ class NoPrintMacro : AstFunctionAnnotation {
 
         // Step 1: Create a visitor and adapt it for the visit() call
         var astVisitor = new NoPrintVisitor()
-        var inscope adapter <- make_visitor(*astVisitor)
-
-        // Step 2: Walk the function body
-        visit(func, adapter)
+        make_visitor(*astVisitor) $(adapter) {
+            // Step 2: Walk the function body
+            visit(func, adapter)
+        }
 
         // Step 3: Check the result
         if (astVisitor.found_print) {

--- a/tutorials/macros/pass_macro_mod.das
+++ b/tutorials/macros/pass_macro_mod.das
@@ -103,8 +103,9 @@ class TraceCallsPass : AstPassMacro {
     //! Pass macro that inserts trace calls at every function entry.
     def override apply(prog : ProgramPtr; mod : Module?) : bool {
         var astVisitor = new TraceCallsVisitor()
-        var inscope astVisitorAdapter <- make_visitor(*astVisitor)
-        visit(prog, astVisitorAdapter)
+        make_visitor(*astVisitor) $(astVisitorAdapter) {
+            visit(prog, astVisitorAdapter)
+        }
         let result = astVisitor.astChanged
         unsafe {
             delete astVisitor

--- a/utils/mcp/tools/find_references.das
+++ b/utils/mcp/tools/find_references.das
@@ -444,11 +444,12 @@ def public do_find_references(file : string; line_str, col_str, scope_str, no_op
         // Step 2: walk AST to find all references
         let file_filter = all_modules ? "" : file
         var visitor = new RefVisitor(target, file_filter)
-        var inscope adapter <- make_visitor(*visitor)
-        if (all_modules) {
-            visit_modules(program, adapter)
-        } else {
-            visit(program, adapter)
+        make_visitor(*visitor) $(adapter) {
+            if (all_modules) {
+                visit_modules(program, adapter)
+            } else {
+                visit(program, adapter)
+            }
         }
         let result = format_references(visitor.refs, target)
         unsafe {


### PR DESCRIPTION
## Summary

- Replace `make_visitor` returning `smart_ptr<VisitorAdapter>` with block-based API — adapter lifetime is scoped to the block
- Convert all `.das` callers from `var inscope adapter <- make_visitor(...)` to `make_visitor(...) $ (adapter) { ... }`
- Change visitor adapter field types from `smart_ptr<VisitorAdapter>` to `VisitorAdapter?` in `lint.das`, `glsl_internal.das` (LLVM's `llvm_jit.das` was already changed)
- Update C++ bindings, RST documentation, and tutorial examples

## Files changed (33)

**C++ (API):** `ast_visitor.h`, `aot_builtin_ast.h`, `module_builtin_ast_adapters.cpp`
**daslib (18):** `ast.das`, `aot_cpp.das`, `aot_standalone.das`, `ast_block_to_loop.das`, `ast_cursor.das`, `ast_print.das`, `ast_used.das`, `async_boost.das`, `coverage.das`, `heartbeat.das`, `lint.das`, `macro_boost.das`, `perf_lint.das`, `quote.das`, `soa.das`, `style_lint.das`, `templates_boost.das`, `validate_code.das`
**modules (5):** `dasGlsl/glsl_internal.das`, `dasLLVM/llvm_dll_utils.das`, `dasLLVM/llvm_exe.das`, `dasLLVM/llvm_jit.das`, `dasLLVM/llvm_macro.das`
**tutorials (2):** `function_macro_mod.das`, `pass_macro_mod.das`
**utils (1):** `mcp/tools/find_references.das`
**docs (4):** `datatypes.rst`, `macros.rst`, `03_function_macro.rst`, `14_pass_macro.rst`

## Test plan

- [x] Lint: 0 errors on daslib/, modules/, tutorials/
- [x] Tests: 6037 passed, 0 failed
- [x] AOT: 5452 passed, 0 failed
- [x] All changed `.das` files formatted