### PR TITLE
C API: add missing das_argument_int64 and das_argument_uint64

### DIFF
--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -510,6 +510,8 @@ char * das_allocate_string ( das_context * context, char * str ) {
 
 int    das_argument_int ( vec4f arg ) { return cast<int>::to(arg); }
 unsigned int   das_argument_uint ( vec4f arg ) { return cast<unsigned int>::to(arg); }
+long long das_argument_int64 ( vec4f arg ) { return cast<long long>::to(arg); }
+unsigned long long das_argument_uint64 ( vec4f arg ) { return cast<unsigned long long>::to(arg); }
 int    das_argument_bool ( vec4f arg ) { return cast<bool>::to(arg) ? 1 : 0; }
 float  das_argument_float ( vec4f arg ) { return cast<float>::to(arg); }
 double  das_argument_double ( vec4f arg ) { return cast<double>::to(arg); }


### PR DESCRIPTION
## Summary
- Add missing implementations of `das_argument_int64` and `das_argument_uint64` in `daScriptC.cpp` — declared in `daScriptC.h` but never defined, causing linker errors for C API users
-  Audited all other `das_argument_*` and `das_result_*` functions (aligned + unaligned variants) — all present and correct\n
- Fixes #2408