### PR TITLE
ast: add is_cpp_keyword and is_das_keyword to daScript API

### DIFF
--- a/doc/source/stdlib/handmade/function-ast-is_cpp_keyword-0xbfe6c3e2c645a59f.rst
+++ b/doc/source/stdlib/handmade/function-ast-is_cpp_keyword-0xbfe6c3e2c645a59f.rst
@@ -1,0 +1,1 @@
+Returns true if the string is a reserved C++ keyword (including contextual keywords like override and final).

--- a/doc/source/stdlib/handmade/function-ast-is_das_keyword-0xaabaaa640cbb8872.rst
+++ b/doc/source/stdlib/handmade/function-ast-is_das_keyword-0xaabaaa640cbb8872.rst
@@ -1,0 +1,1 @@
+Returns true if the string is a built-in daScript language keyword.

--- a/include/daScript/simulate/aot_builtin_ast.h
+++ b/include/daScript/simulate/aot_builtin_ast.h
@@ -585,6 +585,8 @@ namespace das {
     DAS_API void for_each_structure_alias ( Structure * structure, const TBlock<void,TypeDecl *> & block, Context * context, LineInfoArg * at );
     DAS_API TypeDeclPtr get_structure_alias ( Structure * structure, const char * aliasName, Context * context, LineInfoArg * at );
     DAS_API Function * findCompilingFunctionByMangledNameHash(char * module_name, uint64_t mnh, Context * context, LineInfoArg * at);
+    DAS_API bool isCppKeyword ( const char * str );
+    DAS_API bool isDasKeyword ( const char * str );
 
     template <>
     struct das_iterator <AnnotationArgumentList> : das_iterator<vector<AnnotationArgument>> {

--- a/src/ast/ast_lint.cpp
+++ b/src/ast/ast_lint.cpp
@@ -4,6 +4,7 @@
 #include "daScript/ast/ast_generate.h"
 #include "daScript/ast/ast_expressions.h"
 #include "daScript/ast/ast_visitor.h"
+#include "daScript/simulate/aot_builtin_ast.h"
 
 namespace das {
 
@@ -34,25 +35,6 @@ namespace das {
     };
 
 
-    das::unordered_set<string> g_cpp_keywords = {
-        /* reserved C++ names*/
-        "alignas","alignof","and","and_eq","asm","atomic_cancel","atomic_commit","atomic_noexcept","auto"
-        ,"bitand","bitor","bool","break","case","catch","char","char8_t","char16_t","char32_t","class"
-        ,"compl","concept","const","consteval","constexpr","constinit","const_cast","continue","co_await"
-        ,"co_return","co_yield","decltype","default","delete","do","double","dynamic_cast","else","enum"
-        ,"explicit","export","extern","false","float","for","friend","goto","if","inline","int","long"
-        ,"mutable","namespace","new","noexcept","not","not_eq","nullptr","operator","or","or_eq","private"
-        ,"protected","public","reflexpr","register","reinterpret_cast","requires","return","short","signed"
-        ,"sizeof","static","static_assert","static_cast","struct","switch","synchronized","template","this"
-        ,"thread_local","throw","true","try","typedef","typeid","typename","union","unsigned","using"
-        ,"virtual","void","volatile","wchar_t","while","xor","xor_eq"
-        /* extra */
-        ,"override","final","import","module","transaction_safe","transaction_safe_dynamic","super"
-    };
-
-    bool isCppKeyword(const string & str) {
-        return g_cpp_keywords.find(str) != g_cpp_keywords.end();
-    }
 
     bool hasLabels ( const ExprBlock * block ) {
         for ( auto & be : block->list ) {
@@ -268,7 +250,7 @@ namespace das {
             }
         }
         bool isValidModuleName(const string & str) const {
-            return !isCppKeyword(str);
+            return !isCppKeyword(str.c_str());
         }
         virtual void preVisitModule ( Module * mod ) override {
             Visitor::preVisitModule(mod);
@@ -278,10 +260,10 @@ namespace das {
             }
         }
         bool isValidEnumName(const string & str) const {
-            return !isCppKeyword(str);
+            return !isCppKeyword(str.c_str());
         }
         bool isValidEnumValueName(const string & str) const {
-            return !isCppKeyword(str);
+            return !isCppKeyword(str.c_str());
         }
         void lintType ( TypeDecl * td ) {
             for ( auto & name : td->argNames ) {
@@ -322,7 +304,7 @@ namespace das {
             }
         }
         bool isValidStructureName(const string & str) const {
-            return !isCppKeyword(str);
+            return !isCppKeyword(str.c_str());
         }
         virtual bool canVisitStructure ( Structure * st ) override {
             return !st->isTemplate;     // not a thing with templates
@@ -364,7 +346,7 @@ namespace das {
             }
         }
         bool isValidVarName(const string & str) const {
-            return !isCppKeyword(str);
+            return !isCppKeyword(str.c_str());
         }
         virtual void preVisitStructureField ( Structure * var, Structure::FieldDeclaration & decl, bool last ) override {
             Visitor::preVisitStructureField(var, decl, last);
@@ -857,7 +839,7 @@ namespace das {
             }
         }
         bool isValidFunctionName(const string & str) const {
-            return !isCppKeyword(str);
+            return !isCppKeyword(str.c_str());
         }
         virtual bool canVisitFunction ( Function * fun ) override {
             return !fun->stub && !fun->isTemplate;    // we don't do a thing with templates

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -65,6 +65,42 @@ namespace das {
         return module->addTypeFunction(kwd, true);
     }
 
+    bool isCppKeyword ( const char * str ) {
+        static das_hash_set<string> cpp_kw = {
+            "alignas","alignof","and","and_eq","asm","atomic_cancel","atomic_commit","atomic_noexcept","auto"
+            ,"bitand","bitor","bool","break","case","catch","char","char8_t","char16_t","char32_t","class"
+            ,"compl","concept","const","consteval","constexpr","constinit","const_cast","continue","co_await"
+            ,"co_return","co_yield","decltype","default","delete","do","double","dynamic_cast","else","enum"
+            ,"explicit","export","extern","false","float","for","friend","goto","if","inline","int","long"
+            ,"mutable","namespace","new","noexcept","not","not_eq","nullptr","operator","or","or_eq","private"
+            ,"protected","public","reflexpr","register","reinterpret_cast","requires","return","short","signed"
+            ,"sizeof","static","static_assert","static_cast","struct","switch","synchronized","template","this"
+            ,"thread_local","throw","true","try","typedef","typeid","typename","union","unsigned","using"
+            ,"virtual","void","volatile","wchar_t","while","xor","xor_eq"
+            ,"override","final","import","module","transaction_safe","transaction_safe_dynamic","super"
+        };
+        if ( !str ) return false;
+        return cpp_kw.find(str) != cpp_kw.end();
+    }
+
+    bool isDasKeyword ( const char * str ) {
+        static das_hash_set<string> das_kw = {
+            "include","capture","for","while","if","static_if","elif","static_elif","else","finally"
+            ,"def","with","aka","assume","let","var","uninitialized","struct","class","enum","try"
+            ,"recover","typedef","typedecl","label","goto","module","public","options","operator"
+            ,"require","block","function","lambda","generator","tuple","variant","const","continue"
+            ,"where","cast","upcast","pass","reinterpret","override","sealed","template","abstract"
+            ,"expect","table","array","fixed_array","default","iterator","in","implicit","explicit"
+            ,"shared","private","smart_ptr","unsafe","inscope","static","as","is","deref","addr"
+            ,"null","return","yield","break","typeinfo","type","new","delete","true","false","auto"
+            ,"bool","void","string","range64","urange64","range","urange","int","int8","int16","int64"
+            ,"int2","int3","int4","uint","bitfield","uint8","uint16","uint64","uint2","uint3","uint4"
+            ,"double","float","float2","float3","float4"
+        };
+        if ( !str ) return false;
+        return das_kw.find(str) != das_kw.end();
+    }
+
     void forEachFunction ( Module * module, const char * name, const TBlock<void,FunctionPtr> & block, Context * context, LineInfoArg * lineInfo ) {
         if ( !module ) context->throw_error_at(lineInfo, "expecting module, not null");
         vec4f args[1];
@@ -1532,6 +1568,12 @@ namespace das {
         addExtern<DAS_BIND_FUN(findCompilingFunctionByMangledNameHash)>(*this, lib,  "find_compiling_function_by_mangled_name_hash",
             SideEffects::accessExternal, "findCompilingFunctionByMangledNameHash")
                 ->args({"moduleName","mangledNameHash","context","at"});
+        addExtern<DAS_BIND_FUN(isCppKeyword)>(*this, lib, "is_cpp_keyword",
+            SideEffects::none, "isCppKeyword")
+                ->args({"str"});
+        addExtern<DAS_BIND_FUN(isDasKeyword)>(*this, lib, "is_das_keyword",
+            SideEffects::none, "isDasKeyword")
+                ->args({"str"});
     }
 
     ModuleAotType Module_Ast::aotRequire ( TextWriter & tw ) const {

--- a/tests/daslib/keyword_test.das
+++ b/tests/daslib/keyword_test.das
@@ -1,0 +1,63 @@
+options gen2
+options no_aot
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require ast_core
+require dastest/testing_boost public
+
+[test]
+def test_is_cpp_keyword(t : T?) {
+    // positive
+    t |> success(is_cpp_keyword("int"), "int is a C++ keyword")
+    t |> success(is_cpp_keyword("class"), "class is a C++ keyword")
+    t |> success(is_cpp_keyword("virtual"), "virtual is a C++ keyword")
+    t |> success(is_cpp_keyword("constexpr"), "constexpr is a C++ keyword")
+    t |> success(is_cpp_keyword("co_await"), "co_await is a C++ keyword")
+    t |> success(is_cpp_keyword("override"), "override is a C++ keyword")
+    t |> success(is_cpp_keyword("nullptr"), "nullptr is a C++ keyword")
+    t |> success(is_cpp_keyword("template"), "template is a C++ keyword")
+    // negative
+    t |> success(!is_cpp_keyword("foo"), "foo is not a C++ keyword")
+    t |> success(!is_cpp_keyword(""), "empty string is not a C++ keyword")
+    t |> success(!is_cpp_keyword("def"), "def is not a C++ keyword")
+    t |> success(!is_cpp_keyword("yield"), "yield is not a C++ keyword")
+    t |> success(!is_cpp_keyword("recover"), "recover is not a C++ keyword")
+}
+
+[test]
+def test_is_das_keyword(t : T?) {
+    // positive
+    t |> success(is_das_keyword("def"), "def is a daScript keyword")
+    t |> success(is_das_keyword("let"), "let is a daScript keyword")
+    t |> success(is_das_keyword("struct"), "struct is a daScript keyword")
+    t |> success(is_das_keyword("yield"), "yield is a daScript keyword")
+    t |> success(is_das_keyword("smart_ptr"), "smart_ptr is a daScript keyword")
+    t |> success(is_das_keyword("static_if"), "static_if is a daScript keyword")
+    t |> success(is_das_keyword("float4"), "float4 is a daScript keyword")
+    t |> success(is_das_keyword("recover"), "recover is a daScript keyword")
+    t |> success(is_das_keyword("fixed_array"), "fixed_array is a daScript keyword")
+    // negative
+    t |> success(!is_das_keyword("foo"), "foo is not a daScript keyword")
+    t |> success(!is_das_keyword(""), "empty string is not a daScript keyword")
+    t |> success(!is_das_keyword("virtual"), "virtual is not a daScript keyword")
+    t |> success(!is_das_keyword("constexpr"), "constexpr is not a daScript keyword")
+    t |> success(!is_das_keyword("namespace"), "namespace is not a daScript keyword")
+}
+
+[test]
+def test_overlap_keywords(t : T?) {
+    // keywords in both languages
+    t |> success(is_cpp_keyword("class") && is_das_keyword("class"), "class is in both")
+    t |> success(is_cpp_keyword("struct") && is_das_keyword("struct"), "struct is in both")
+    t |> success(is_cpp_keyword("return") && is_das_keyword("return"), "return is in both")
+    t |> success(is_cpp_keyword("enum") && is_das_keyword("enum"), "enum is in both")
+    t |> success(is_cpp_keyword("template") && is_das_keyword("template"), "template is in both")
+    // C++ only
+    t |> success(is_cpp_keyword("virtual") && !is_das_keyword("virtual"), "virtual is C++ only")
+    t |> success(is_cpp_keyword("namespace") && !is_das_keyword("namespace"), "namespace is C++ only")
+    // daScript only
+    t |> success(!is_cpp_keyword("def") && is_das_keyword("def"), "def is daScript only")
+    t |> success(!is_cpp_keyword("recover") && is_das_keyword("recover"), "recover is daScript only")
+    t |> success(!is_cpp_keyword("smart_ptr") && is_das_keyword("smart_ptr"), "smart_ptr is daScript only")
+}


### PR DESCRIPTION
## Summary

- Add `is_cpp_keyword(str)` and `is_das_keyword(str)` functions to `ast_core` module, exposed to daScript
- Remove redundant `g_cpp_keywords` set and `isCppKeyword(const string&)` from `ast_lint.cpp` — linter now calls the shared implementation
- Add tests in `tests/daslib/keyword_test.das`

## Test plan

- [x] Lint: `utils/lint/main.das` — 0 issues
- [x] Tests: `dastest -- --test tests/` — 5410 passed, 0 failed, 0 errors
- [x] New test: `tests/daslib/keyword_test.das` — 3 tests (positive/negative/overlap cases)
- [x] AOT: test file uses `options no_aot`; `tests/daslib/` is not registered for AOT (matches existing `ast_cursor_test.das` pattern)
- [x] Docs: functions match existing "Properties" group regex `(is|has|get|can)_.*` in `das2rst.das` — no grouping changes needed