### PR TITLE
compiler: convert DataWalker, StackWalker, NetworkServer, DebugInfoHelper from smart_ptr to regular pointers

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -594,8 +594,11 @@ class public AotDebugInfoHelper {
     //! Helper for generating debug type and variable information in AOT C++ output.
     private info2Name  = new DebugVarCache()
     private info2TypeName = new DebugVarCache()
-    helper : smart_ptr<DebugInfoHelper> <- new DebugInfoHelper(uninitialized);
+    helper : DebugInfoHelper? = new DebugInfoHelper(uninitialized)
     cross_platform : bool = false
+    def operator delete {
+        unsafe { delete helper; }
+    }
 
     def writeDim(var writer : StringBuilderWriter?; info : TypeInfo?; suffix : string = "") {
         if (info.dimSize > 0u) {
@@ -4092,8 +4095,8 @@ def public run_aot(prog : Program?; var pctx : Context?; cop : CodeOfPolicies) :
                     visit(program, cpp_aot.adapter, true)
                 }
                 write(writer, "{cpp_aot.str()}");
-                delete cpp_aot.helper.helper
                 unsafe {
+                    delete cpp_aot.helper.helper
                     delete cpp_aot.collector
                     delete cpp_aot
                 }
@@ -4170,8 +4173,8 @@ def public run_aot_function(prog : Program?; var pctx : Context?; cop : CodeOfPo
                 visit(program, cpp_aot.adapter, true)
             }
             let full_output = cpp_aot.str()
-            delete cpp_aot.helper.helper
             unsafe {
+                delete cpp_aot.helper.helper
                 delete cpp_aot.collector
                 delete cpp_aot
             }

--- a/daslib/ast_debug.das
+++ b/daslib/ast_debug.das
@@ -133,21 +133,20 @@ class SampleStackWalker : DapiStackWalker {
 
 class ContextStateAgent : DapiDebugAgent {
     //! Debug agent that installs context-level stack walkers.
-    walker_adapter : smart_ptr<StackWalker>
     walker : SampleStackWalker?
     def ContextStateAgent {
         walker = new SampleStackWalker()
-        move_new(walker_adapter, make_stack_walker(walker))
     }
     def operator delete {
         unsafe {
-            delete walker_adapter
             delete walker
         }
     }
     def override onCollect(var ctx : Context; at : LineInfo) {
         walker.ctxid = unsafe(addr(ctx))
-        walk_stack(walker_adapter, ctx, at)
+        make_stack_walker(walker) $(adapter) {
+            walk_stack(adapter, ctx, at)
+        }
     }
 }
 

--- a/daslib/debug.das
+++ b/daslib/debug.das
@@ -674,7 +674,6 @@ def iter_top_child_var(stack : DAStackFrame; cb : block<(res : DAVariable) : voi
 
 class private DAStackWalker : DapiStackWalker {
     //! Stack walker that collects frames for the DAP debugger.
-    dataWalkerAdapter : smart_ptr<DataWalker>
     dataWalker : DAWalker?
 
     collectAllGlobals : bool = false
@@ -687,17 +686,13 @@ class private DAStackWalker : DapiStackWalker {
     @do_not_delete pathsCache : table<string; string>?
 
     def DAStackWalker() {
-        //! Constructs a DAStackWalker and initializes its data walker adapter.
+        //! Constructs a DAStackWalker and initializes its data walker.
         dataWalker = new DAWalker()
-        unsafe {
-            dataWalkerAdapter <- make_data_walker(dataWalker)
-        }
     }
 
     def operator delete {
-        //! Cleans up the data walker and its adapter.
+        //! Cleans up the data walker.
         unsafe {
-            delete dataWalkerAdapter
             delete dataWalker
         }
     }
@@ -715,7 +710,9 @@ class private DAStackWalker : DapiStackWalker {
 
         if (ti != null) {
             dataWalker->startWalk(frame, global) $ {
-                dataWalkerAdapter |> walk_data(value, *ti)
+                make_data_walker(dataWalker) $(adapter) {
+                    adapter |> walk_data(value, *ti)
+                }
             }
         }
 
@@ -833,7 +830,9 @@ class private DAStackWalker : DapiStackWalker {
             var variable = DAVariable(uid = frame.varId++, name = vinfo.name, _type = describe(ti), address = intptr(arg), size = ti.size, typeInfo = ti)
             if (ti != null) {
                 dataWalker->startWalk(frame, variable) $ {
-                    dataWalkerAdapter |> walk_data(arg, *ti)
+                    make_data_walker(dataWalker) $(adapter) {
+                        adapter |> walk_data(arg, *ti)
+                    }
                 }
             }
 
@@ -857,7 +856,9 @@ class private DAStackWalker : DapiStackWalker {
             var variable = DAVariable(uid = frame.varId++, name = vinfo.name, _type = describe(ti), address = ti.isRef ? intptr(unsafe(reinterpret<void?> arg)) : 0ul, size = ti.size, typeInfo = ti, rawValue = arg)
             if (ti != null) {
                 dataWalker->startWalk(frame, variable) $ {
-                    dataWalkerAdapter |> walk_data(arg, *ti)
+                    make_data_walker(dataWalker) $(adapter) {
+                        adapter |> walk_data(arg, *ti)
+                    }
                 }
             }
 
@@ -954,7 +955,6 @@ def private compare_path(p1, p2 : string) {
 class private DAgent : DapiDebugAgent {
     //! Main debug agent implementing the DAP protocol.
 
-    walkerAdapter : smart_ptr<StackWalker>
     walker : DAStackWalker?
     server : DAServer?
 
@@ -990,7 +990,6 @@ class private DAgent : DapiDebugAgent {
 
         walker = new DAStackWalker()
         unsafe {
-            walkerAdapter <- make_stack_walker(walker)
             walker.workingPaths = addr(workingPaths)
             walker.pathAliases = addr(pathAliases)
             walker.pathsCache = addr(pathsCache)
@@ -1053,9 +1052,8 @@ class private DAgent : DapiDebugAgent {
     }
 
     def operator delete {
-        //! Cleans up the stack walker, walker adapter, and server resources.
+        //! Cleans up the stack walker and server resources.
         unsafe {
-            delete walkerAdapter
             delete walker
             delete server
         }
@@ -1349,7 +1347,9 @@ class private DAgent : DapiDebugAgent {
         unsafe {
             walker.ctx = addr(ctxData)
         }
-        walkerAdapter |> walk_stack(ctx, at)
+        make_stack_walker(walker) $(adapter) {
+            adapter |> walk_stack(ctx, at)
+        }
         if (length(ctxData.stack) > 0) {
             for (i in range(1, length(ctxData.stack))) {
                 let j = length(ctxData.stack) - i
@@ -1376,7 +1376,9 @@ class private DAgent : DapiDebugAgent {
                 var frame & = unsafe(ctxData.stack[0])
                 var variable = DAVariable(uid = frame.varId++, name = name, _type = describe(info), address = intptr(data), size = info.size)
                 walker.dataWalker->startWalk(frame, variable) $ {
-                    walker.dataWalkerAdapter |> walk_data(data, info)
+                    make_data_walker(walker.dataWalker) $(adapter) {
+                        adapter |> walk_data(data, info)
+                    }
                 }
                 if (variable.children == null) {
                     unsafe {
@@ -1667,9 +1669,9 @@ class private DAServer : Server {
         //! Saves the current network session for a potential server restart.
         if (_server != null) {
             unsafe {
-                var session : smart_ptr<NetworkServer>
+                var session : NetworkServer?
                 self->save(session)
-                gc0_save_smart_ptr("telnet-session", session)
+                gc0_save_ptr("telnet-session", session)
             }
         }
     }

--- a/daslib/debugger.das
+++ b/daslib/debugger.das
@@ -191,13 +191,14 @@ class DapiDataWalker {
     def abstract InvalidData : void
 }
 
-def make_data_walker(classPtr) : smart_ptr<DataWalker> {
+def make_data_walker(classPtr; blk : block<(var adapter : DataWalker?) : void>) {
     static_if (typeinfo is_class(*classPtr)) {
-        let classInfo = class_info(*classPtr)
-        return <- make_data_walker(classPtr, classInfo)
+        unsafe {
+            let classInfo = class_info(*classPtr)
+            make_data_walker(classPtr, classInfo, blk)
+        }
     } else {
         concept_assert(false, "can't make data walker of non-class")
-        return <- default<smart_ptr<DataWalker>>
     }
 }
 
@@ -218,12 +219,13 @@ class DapiStackWalker {
     def abstract onCorruptStack(pp : Prologue) : void
 }
 
-def make_stack_walker(classPtr) : smart_ptr<StackWalker> {
+def make_stack_walker(classPtr; blk : block<(var adapter : StackWalker?) : void>) {
     static_if (typeinfo is_class(*classPtr)) {
-        let classInfo = class_info(*classPtr)
-        return <- make_stack_walker(classPtr, classInfo)
+        unsafe {
+            let classInfo = class_info(*classPtr)
+            make_stack_walker(classPtr, classInfo, blk)
+        }
     } else {
         concept_assert(false, "can't make stack walker of non-class")
-        return <- default<smart_ptr<StackWalker>>
     }
 }

--- a/daslib/network.das
+++ b/daslib/network.das
@@ -8,7 +8,7 @@ require network_core public
 require daslib/rtti
 
 class Server {
-    _server : smart_ptr<NetworkServer>
+    _server : NetworkServer?
     def Server {
         pass
     }
@@ -23,15 +23,17 @@ class Server {
     def init(port : int) : bool {
         return server_init(_server, port)
     }
-    def restore(var shared_orphan : smart_ptr<NetworkServer>&) {
-        _server |> move() <| shared_orphan
+    def restore(var shared_orphan : NetworkServer?&) {
+        _server = shared_orphan
+        shared_orphan = null
         let classInfo = class_info(self)
         unsafe {
             server_restore(_server, addr(self), classInfo)
         }
     }
-    def save(var shared_orphan : smart_ptr<NetworkServer>&) {
-        shared_orphan |> move() <|  _server
+    def save(var shared_orphan : NetworkServer?&) {
+        shared_orphan = _server
+        _server = null
     }
     def has_session : bool {
         return _server != null

--- a/doc/source/reference/tutorials/47_data_walker.rst
+++ b/doc/source/reference/tutorials/47_data_walker.rst
@@ -58,11 +58,11 @@ then call ``walk_data`` with a pointer and ``TypeInfo``:
 .. code-block:: das
 
     var walker = new ScalarPrinter()
-    var inscope adapter <- make_data_walker(walker)
-
     var x = 42
-    unsafe {
-        adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+    make_data_walker(walker) $(adapter) {
+        unsafe {
+            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        }
     }
 
 ``typeinfo rtti_typeinfo(variable)`` is a compile-time intrinsic that
@@ -294,11 +294,13 @@ The ``to_json`` helper wraps the walk in ``build_string``:
 
     def to_json(var value; tinfo : TypeInfo) : string {
         var walker = new JsonWalker()
-        var inscope adapter <- make_data_walker(walker)
-        let res = build_string() $(var writer) {
-            unsafe {
-                walker.writer = addr(writer)
-                adapter |> walk_data(addr(value), tinfo)
+        var res : string
+        make_data_walker(walker) $(adapter) {
+            res = build_string() $(var writer) {
+                unsafe {
+                    walker.writer = addr(writer)
+                    adapter |> walk_data(addr(value), tinfo)
+                }
             }
         }
         unsafe { delete walker }

--- a/doc/source/stdlib/generated/ast.rst
+++ b/doc/source/stdlib/generated/ast.rst
@@ -5692,31 +5692,31 @@ Adapter generation
   *  :ref:`make_clone_structure (structure: Structure?) : Function? <function-ast_make_clone_structure_Structure_q_>`
   *  :ref:`make_comment_reader (class: void?; info: StructInfo const?) : CommentReader? <function-ast_make_comment_reader_void_q__StructInfo_const_q_>`
   *  :ref:`make_comment_reader (name: string; var someClassPtr: auto) : CommentReaderPtr <function-ast_make_comment_reader_string_auto_0x2de>`
-  *  :ref:`make_enum_debug_info (helper: smart_ptr\<DebugInfoHelper\>; en: Enumeration const?) : EnumInfo? <function-ast_make_enum_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Enumeration_const_q_>`
+  *  :ref:`make_enum_debug_info (helper: DebugInfoHelper?; en: Enumeration const?) : EnumInfo? <function-ast_make_enum_debug_info_DebugInfoHelper_q__Enumeration_const_q_>`
   *  :ref:`make_enumeration_annotation (name: string; var someClassPtr: auto) : EnumerationAnnotationPtr <function-ast_make_enumeration_annotation_string_auto_0x2b6>`
   *  :ref:`make_enumeration_annotation (name: string; class: void?; info: StructInfo const?) : EnumerationAnnotation? <function-ast_make_enumeration_annotation_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_for_loop_macro (name: string; class: void?; info: StructInfo const?) : ForLoopMacro? <function-ast_make_for_loop_macro_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_for_loop_macro (name: string; var someClassPtr: auto) : ForLoopMacroPtr <function-ast_make_for_loop_macro_string_auto_0x324>`
   *  :ref:`make_function_annotation (name: string; var someClassPtr: auto) : FunctionAnnotationPtr <function-ast_make_function_annotation_string_auto_0x28c>`
   *  :ref:`make_function_annotation (name: string; class: void?; info: StructInfo const?) : FunctionAnnotation? <function-ast_make_function_annotation_string_void_q__StructInfo_const_q_>`
-  *  :ref:`make_function_debug_info (helper: smart_ptr\<DebugInfoHelper\>; fn: Function const?) : FuncInfo? <function-ast_make_function_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Function_const_q_>`
-  *  :ref:`make_invokable_type_debug_info (helper: smart_ptr\<DebugInfoHelper\>; blk: TypeDecl?; at: LineInfo) : FuncInfo? <function-ast_make_invokable_type_debug_info_smart_ptr_ls_DebugInfoHelper_gr__TypeDecl_q__LineInfo>`
+  *  :ref:`make_function_debug_info (helper: DebugInfoHelper?; fn: Function const?) : FuncInfo? <function-ast_make_function_debug_info_DebugInfoHelper_q__Function_const_q_>`
+  *  :ref:`make_invokable_type_debug_info (helper: DebugInfoHelper?; blk: TypeDecl?; at: LineInfo) : FuncInfo? <function-ast_make_invokable_type_debug_info_DebugInfoHelper_q__TypeDecl_q__LineInfo>`
   *  :ref:`make_pass_macro (name: string; class: void?; info: StructInfo const?) : PassMacro? <function-ast_make_pass_macro_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_pass_macro (name: string; var someClassPtr: auto) : PassMacroPtr <function-ast_make_pass_macro_string_auto_0x308>`
   *  :ref:`make_reader_macro (name: string; var someClassPtr: auto) : ReaderMacroPtr <function-ast_make_reader_macro_string_auto_0x2d0>`
   *  :ref:`make_reader_macro (name: string; class: void?; info: StructInfo const?) : ReaderMacro? <function-ast_make_reader_macro_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_simulate_macro (name: string; var someClassPtr: auto) : SimulateMacroPtr <function-ast_make_simulate_macro_string_auto_0x34b>`
   *  :ref:`make_simulate_macro (name: string; class: void?; info: StructInfo const?) : SimulateMacro? <function-ast_make_simulate_macro_string_void_q__StructInfo_const_q_>`
-  *  :ref:`make_struct_debug_info (helper: smart_ptr\<DebugInfoHelper\>; st: Structure const?) : StructInfo? <function-ast_make_struct_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Structure_const_q_>`
-  *  :ref:`make_struct_variable_debug_info (helper: smart_ptr\<DebugInfoHelper\>; st: Structure const?; var: FieldDeclaration const?) : VarInfo? <function-ast_make_struct_variable_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Structure_const_q__FieldDeclaration_const_q_>`
+  *  :ref:`make_struct_debug_info (helper: DebugInfoHelper?; st: Structure const?) : StructInfo? <function-ast_make_struct_debug_info_DebugInfoHelper_q__Structure_const_q_>`
+  *  :ref:`make_struct_variable_debug_info (helper: DebugInfoHelper?; st: Structure const?; var: FieldDeclaration const?) : VarInfo? <function-ast_make_struct_variable_debug_info_DebugInfoHelper_q__Structure_const_q__FieldDeclaration_const_q_>`
   *  :ref:`make_structure_annotation (name: string; var someClassPtr: auto) : StructureAnnotationPtr <function-ast_make_structure_annotation_string_auto_0x2a8>`
   *  :ref:`make_structure_annotation (name: string; class: void?; info: StructInfo const?) : StructureAnnotation? <function-ast_make_structure_annotation_string_void_q__StructInfo_const_q_>`
-  *  :ref:`make_type_info (helper: smart_ptr\<DebugInfoHelper\>; info: TypeInfo?; type: TypeDecl? const&) : TypeInfo? <function-ast_make_type_info_smart_ptr_ls_DebugInfoHelper_gr__TypeInfo_q__TypeDecl_q__const_ref_>`
+  *  :ref:`make_type_info (helper: DebugInfoHelper?; info: TypeInfo?; type: TypeDecl? const&) : TypeInfo? <function-ast_make_type_info_DebugInfoHelper_q__TypeInfo_q__TypeDecl_q__const_ref_>`
   *  :ref:`make_type_macro (name: string; var someClassPtr: auto) : TypeMacroPtr <function-ast_make_type_macro_string_auto_0x33e>`
   *  :ref:`make_type_macro (name: string; class: void?; info: StructInfo const?) : TypeMacro? <function-ast_make_type_macro_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_typeinfo_macro (name: string; class: void?; info: StructInfo const?) : TypeInfoMacro? <function-ast_make_typeinfo_macro_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_typeinfo_macro (name: string; var someClassPtr: auto) : TypeInfoMacroPtr <function-ast_make_typeinfo_macro_string_auto_0x2fa>`
-  *  :ref:`make_variable_debug_info (helper: smart_ptr\<DebugInfoHelper\>; var: Variable?) : VarInfo? <function-ast_make_variable_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Variable_q_>`
+  *  :ref:`make_variable_debug_info (helper: DebugInfoHelper?; var: Variable?) : VarInfo? <function-ast_make_variable_debug_info_DebugInfoHelper_q__Variable_q_>`
   *  :ref:`make_variant_macro (name: string; var someClassPtr: auto) : VariantMacroPtr <function-ast_make_variant_macro_string_auto_0x316>`
   *  :ref:`make_variant_macro (name: string; class: void?; info: StructInfo const?) : VariantMacro? <function-ast_make_variant_macro_string_void_q__StructInfo_const_q_>`
   *  :ref:`make_visitor (someClass: auto; blk: block\<(var adapter:VisitorAdapter?):void\>) : auto <function-ast_make_visitor_auto_block_ls_var_adapter_c_VisitorAdapter_q__c_void_gr__0x2c1>`
@@ -5827,14 +5827,14 @@ Creates an adapter for the AstCommentReader interface.
 
 ----
 
-.. _function-ast_make_enum_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Enumeration_const_q_:
+.. _function-ast_make_enum_debug_info_DebugInfoHelper_q__Enumeration_const_q_:
 
-.. das:function:: make_enum_debug_info(helper: smart_ptr<DebugInfoHelper>; en: Enumeration const?) : EnumInfo?
+.. das:function:: make_enum_debug_info(helper: DebugInfoHelper?; en: Enumeration const?) : EnumInfo?
 
 Generates an EnumInfo for the specified enumeration using the given DebugInfoHelper.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **en** :  :ref:`Enumeration <handle-ast-Enumeration>`? implicit
 
@@ -5901,25 +5901,25 @@ def make_function_annotation (name: string; var someClassPtr: auto) : FunctionAn
 
 ----
 
-.. _function-ast_make_function_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Function_const_q_:
+.. _function-ast_make_function_debug_info_DebugInfoHelper_q__Function_const_q_:
 
-.. das:function:: make_function_debug_info(helper: smart_ptr<DebugInfoHelper>; fn: Function const?) : FuncInfo?
+.. das:function:: make_function_debug_info(helper: DebugInfoHelper?; fn: Function const?) : FuncInfo?
 
 Generates a FuncInfo for the specified function using the given DebugInfoHelper.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **fn** :  :ref:`Function <handle-ast-Function>`? implicit
 
-.. _function-ast_make_invokable_type_debug_info_smart_ptr_ls_DebugInfoHelper_gr__TypeDecl_q__LineInfo:
+.. _function-ast_make_invokable_type_debug_info_DebugInfoHelper_q__TypeDecl_q__LineInfo:
 
-.. das:function:: make_invokable_type_debug_info(helper: smart_ptr<DebugInfoHelper>; blk: TypeDecl?; at: LineInfo) : FuncInfo?
+.. das:function:: make_invokable_type_debug_info(helper: DebugInfoHelper?; blk: TypeDecl?; at: LineInfo) : FuncInfo?
 
 Generates a FuncInfo for an invokable type such as a lambda or block using the given DebugInfoHelper.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **blk** :  :ref:`TypeDecl <handle-ast-TypeDecl>`? implicit
 
@@ -5988,25 +5988,25 @@ def make_simulate_macro (name: string; var someClassPtr: auto) : SimulateMacroPt
 
 ----
 
-.. _function-ast_make_struct_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Structure_const_q_:
+.. _function-ast_make_struct_debug_info_DebugInfoHelper_q__Structure_const_q_:
 
-.. das:function:: make_struct_debug_info(helper: smart_ptr<DebugInfoHelper>; st: Structure const?) : StructInfo?
+.. das:function:: make_struct_debug_info(helper: DebugInfoHelper?; st: Structure const?) : StructInfo?
 
 Generates a StructInfo for the specified structure using the given DebugInfoHelper.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **st** :  :ref:`Structure <handle-ast-Structure>`? implicit
 
-.. _function-ast_make_struct_variable_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Structure_const_q__FieldDeclaration_const_q_:
+.. _function-ast_make_struct_variable_debug_info_DebugInfoHelper_q__Structure_const_q__FieldDeclaration_const_q_:
 
-.. das:function:: make_struct_variable_debug_info(helper: smart_ptr<DebugInfoHelper>; st: Structure const?; var: FieldDeclaration const?) : VarInfo?
+.. das:function:: make_struct_variable_debug_info(helper: DebugInfoHelper?; st: Structure const?; var: FieldDeclaration const?) : VarInfo?
 
 Generates a VariableInfo for a structure field using the given DebugInfoHelper.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **st** :  :ref:`Structure <handle-ast-Structure>`? implicit
 
@@ -6032,14 +6032,14 @@ def make_structure_annotation (name: string; var someClassPtr: auto) : Structure
 
 ----
 
-.. _function-ast_make_type_info_smart_ptr_ls_DebugInfoHelper_gr__TypeInfo_q__TypeDecl_q__const_ref_:
+.. _function-ast_make_type_info_DebugInfoHelper_q__TypeInfo_q__TypeDecl_q__const_ref_:
 
-.. das:function:: make_type_info(helper: smart_ptr<DebugInfoHelper>; info: TypeInfo?; type: TypeDecl? const&) : TypeInfo?
+.. das:function:: make_type_info(helper: DebugInfoHelper?; info: TypeInfo?; type: TypeDecl? const&) : TypeInfo?
 
 Generates a TypeInfo for the specified type using the given DebugInfoHelper.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **info** :  :ref:`TypeInfo <handle-rtti-TypeInfo>`? implicit
 
@@ -6088,14 +6088,14 @@ Creates an adapter for the AstTypeInfoMacro interface.
 
 ----
 
-.. _function-ast_make_variable_debug_info_smart_ptr_ls_DebugInfoHelper_gr__Variable_q_:
+.. _function-ast_make_variable_debug_info_DebugInfoHelper_q__Variable_q_:
 
-.. das:function:: make_variable_debug_info(helper: smart_ptr<DebugInfoHelper>; var: Variable?) : VarInfo?
+.. das:function:: make_variable_debug_info(helper: DebugInfoHelper?; var: Variable?) : VarInfo?
 
 Generates a VariableInfo for the specified variable using the given DebugInfoHelper.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **var** :  :ref:`Variable <handle-ast-Variable>`? implicit
 
@@ -7822,6 +7822,8 @@ Properties
   *  :ref:`get_vector_length (vec: void?; type: TypeDecl?) : int <function-ast_get_vector_length_void_q__TypeDecl_q_>`
   *  :ref:`get_vector_ptr_at_index (vec: void?; type: TypeDecl?; idx: int) : void? <function-ast_get_vector_ptr_at_index_void_q__TypeDecl_q__int>`
   *  :ref:`has_field (type: TypeDecl?; fieldName: string; constant: bool) : bool <function-ast_has_field_TypeDecl_q__string_bool>`
+  *  :ref:`is_cpp_keyword (str: string) : bool <function-ast_is_cpp_keyword_string>`
+  *  :ref:`is_das_keyword (str: string) : bool <function-ast_is_das_keyword_string>`
   *  :ref:`is_expr_const (expression: Expression?) : bool <function-ast_is_expr_const_Expression_q_>`
   *  :ref:`is_expr_like_call (expression: Expression?) : bool <function-ast_is_expr_like_call_Expression_q_>`
   *  :ref:`is_same_type (argType: TypeDecl?; passType: TypeDecl?; refMatters: bool; constMatters: bool; temporaryMatters: bool; allowSubstitute: bool) : bool <function-ast_is_same_type_TypeDecl_q__TypeDecl_q__bool_bool_bool_bool>`
@@ -8070,6 +8072,24 @@ Returns true if a structure, variant, tuple, handled type, or pointer to any of 
 
             * **constant** : bool
 
+.. _function-ast_is_cpp_keyword_string:
+
+.. das:function:: is_cpp_keyword(str: string) : bool
+
+Returns true if the string is a reserved C++ keyword (including contextual keywords like override and final).
+
+
+:Arguments: * **str** : string implicit
+
+.. _function-ast_is_das_keyword_string:
+
+.. das:function:: is_das_keyword(str: string) : bool
+
+Returns true if the string is a built-in daScript language keyword.
+
+
+:Arguments: * **str** : string implicit
+
 .. _function-ast_is_expr_const_Expression_q_:
 
 .. das:function:: is_expr_const(expression: Expression?) : bool
@@ -8232,88 +8252,88 @@ Marks a function as modified by a macro so that it will be inferred again.
 Debug info helpers
 ++++++++++++++++++
 
-  *  :ref:`debug_helper_find_struct_cppname (helper: smart_ptr\<DebugInfoHelper\> const&; struct_info: StructInfo?) : string <function-ast_debug_helper_find_struct_cppname_smart_ptr_ls_DebugInfoHelper_gr__const_ref__StructInfo_q_>`
-  *  :ref:`debug_helper_find_type_cppname (helper: smart_ptr\<DebugInfoHelper\> const&; type_info: TypeInfo?) : string <function-ast_debug_helper_find_type_cppname_smart_ptr_ls_DebugInfoHelper_gr__const_ref__TypeInfo_q_>`
-  *  :ref:`debug_helper_iter_enums (helper: smart_ptr\<DebugInfoHelper\>; blk: block\<(string;EnumInfo?):void\>) <function-ast_debug_helper_iter_enums_smart_ptr_ls_DebugInfoHelper_gr__block_ls_string;EnumInfo_q__c_void_gr_>`
-  *  :ref:`debug_helper_iter_funcs (helper: smart_ptr\<DebugInfoHelper\>; blk: block\<(string;FuncInfo?):void\>) <function-ast_debug_helper_iter_funcs_smart_ptr_ls_DebugInfoHelper_gr__block_ls_string;FuncInfo_q__c_void_gr_>`
-  *  :ref:`debug_helper_iter_structs (helper: smart_ptr\<DebugInfoHelper\>; blk: block\<(string;StructInfo?):void\>) <function-ast_debug_helper_iter_structs_smart_ptr_ls_DebugInfoHelper_gr__block_ls_string;StructInfo_q__c_void_gr_>`
-  *  :ref:`debug_helper_iter_types (helper: smart_ptr\<DebugInfoHelper\>; blk: block\<(string;TypeInfo?):void\>) <function-ast_debug_helper_iter_types_smart_ptr_ls_DebugInfoHelper_gr__block_ls_string;TypeInfo_q__c_void_gr_>`
-  *  :ref:`debug_helper_iter_vars (helper: smart_ptr\<DebugInfoHelper\>; blk: block\<(string;VarInfo?):void\>) <function-ast_debug_helper_iter_vars_smart_ptr_ls_DebugInfoHelper_gr__block_ls_string;VarInfo_q__c_void_gr_>`
+  *  :ref:`debug_helper_find_struct_cppname (helper: DebugInfoHelper?; struct_info: StructInfo?) : string <function-ast_debug_helper_find_struct_cppname_DebugInfoHelper_q__StructInfo_q_>`
+  *  :ref:`debug_helper_find_type_cppname (helper: DebugInfoHelper?; type_info: TypeInfo?) : string <function-ast_debug_helper_find_type_cppname_DebugInfoHelper_q__TypeInfo_q_>`
+  *  :ref:`debug_helper_iter_enums (helper: DebugInfoHelper?; blk: block\<(string;EnumInfo?):void\>) <function-ast_debug_helper_iter_enums_DebugInfoHelper_q__block_ls_string;EnumInfo_q__c_void_gr_>`
+  *  :ref:`debug_helper_iter_funcs (helper: DebugInfoHelper?; blk: block\<(string;FuncInfo?):void\>) <function-ast_debug_helper_iter_funcs_DebugInfoHelper_q__block_ls_string;FuncInfo_q__c_void_gr_>`
+  *  :ref:`debug_helper_iter_structs (helper: DebugInfoHelper?; blk: block\<(string;StructInfo?):void\>) <function-ast_debug_helper_iter_structs_DebugInfoHelper_q__block_ls_string;StructInfo_q__c_void_gr_>`
+  *  :ref:`debug_helper_iter_types (helper: DebugInfoHelper?; blk: block\<(string;TypeInfo?):void\>) <function-ast_debug_helper_iter_types_DebugInfoHelper_q__block_ls_string;TypeInfo_q__c_void_gr_>`
+  *  :ref:`debug_helper_iter_vars (helper: DebugInfoHelper?; blk: block\<(string;VarInfo?):void\>) <function-ast_debug_helper_iter_vars_DebugInfoHelper_q__block_ls_string;VarInfo_q__c_void_gr_>`
 
-.. _function-ast_debug_helper_find_struct_cppname_smart_ptr_ls_DebugInfoHelper_gr__const_ref__StructInfo_q_:
+.. _function-ast_debug_helper_find_struct_cppname_DebugInfoHelper_q__StructInfo_q_:
 
-.. das:function:: debug_helper_find_struct_cppname(helper: smart_ptr<DebugInfoHelper> const&; struct_info: StructInfo?) : string
+.. das:function:: debug_helper_find_struct_cppname(helper: DebugInfoHelper?; struct_info: StructInfo?) : string
 
 Finds a structure in the DebugInfoHelper and returns its C++ name.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`>\ & implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **struct_info** :  :ref:`StructInfo <handle-rtti-StructInfo>`? implicit
 
-.. _function-ast_debug_helper_find_type_cppname_smart_ptr_ls_DebugInfoHelper_gr__const_ref__TypeInfo_q_:
+.. _function-ast_debug_helper_find_type_cppname_DebugInfoHelper_q__TypeInfo_q_:
 
-.. das:function:: debug_helper_find_type_cppname(helper: smart_ptr<DebugInfoHelper> const&; type_info: TypeInfo?) : string
+.. das:function:: debug_helper_find_type_cppname(helper: DebugInfoHelper?; type_info: TypeInfo?) : string
 
 Finds a type in the DebugInfoHelper and returns its C++ name.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`>\ & implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **type_info** :  :ref:`TypeInfo <handle-rtti-TypeInfo>`? implicit
 
-.. _function-ast_debug_helper_iter_enums_smart_ptr_ls_DebugInfoHelper_gr__block_ls_string;EnumInfo_q__c_void_gr_:
+.. _function-ast_debug_helper_iter_enums_DebugInfoHelper_q__block_ls_string;EnumInfo_q__c_void_gr_:
 
-.. das:function:: debug_helper_iter_enums(helper: smart_ptr<DebugInfoHelper>; blk: block<(string;EnumInfo?):void>)
+.. das:function:: debug_helper_iter_enums(helper: DebugInfoHelper?; blk: block<(string;EnumInfo?):void>)
 
 Iterates through all enumerations in the DebugInfoHelper, invoking the provided block for each one.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **blk** : block<(string; :ref:`EnumInfo <handle-rtti-EnumInfo>`?):void> implicit
 
-.. _function-ast_debug_helper_iter_funcs_smart_ptr_ls_DebugInfoHelper_gr__block_ls_string;FuncInfo_q__c_void_gr_:
+.. _function-ast_debug_helper_iter_funcs_DebugInfoHelper_q__block_ls_string;FuncInfo_q__c_void_gr_:
 
-.. das:function:: debug_helper_iter_funcs(helper: smart_ptr<DebugInfoHelper>; blk: block<(string;FuncInfo?):void>)
+.. das:function:: debug_helper_iter_funcs(helper: DebugInfoHelper?; blk: block<(string;FuncInfo?):void>)
 
 Iterates through all functions in the DebugInfoHelper, invoking the provided block for each one.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **blk** : block<(string; :ref:`FuncInfo <handle-rtti-FuncInfo>`?):void> implicit
 
-.. _function-ast_debug_helper_iter_structs_smart_ptr_ls_DebugInfoHelper_gr__block_ls_string;StructInfo_q__c_void_gr_:
+.. _function-ast_debug_helper_iter_structs_DebugInfoHelper_q__block_ls_string;StructInfo_q__c_void_gr_:
 
-.. das:function:: debug_helper_iter_structs(helper: smart_ptr<DebugInfoHelper>; blk: block<(string;StructInfo?):void>)
+.. das:function:: debug_helper_iter_structs(helper: DebugInfoHelper?; blk: block<(string;StructInfo?):void>)
 
 Iterates through all structures in the DebugInfoHelper, invoking the provided block for each one.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **blk** : block<(string; :ref:`StructInfo <handle-rtti-StructInfo>`?):void> implicit
 
-.. _function-ast_debug_helper_iter_types_smart_ptr_ls_DebugInfoHelper_gr__block_ls_string;TypeInfo_q__c_void_gr_:
+.. _function-ast_debug_helper_iter_types_DebugInfoHelper_q__block_ls_string;TypeInfo_q__c_void_gr_:
 
-.. das:function:: debug_helper_iter_types(helper: smart_ptr<DebugInfoHelper>; blk: block<(string;TypeInfo?):void>)
+.. das:function:: debug_helper_iter_types(helper: DebugInfoHelper?; blk: block<(string;TypeInfo?):void>)
 
 Iterates through all types in the DebugInfoHelper, invoking the provided block for each one.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **blk** : block<(string; :ref:`TypeInfo <handle-rtti-TypeInfo>`?):void> implicit
 
-.. _function-ast_debug_helper_iter_vars_smart_ptr_ls_DebugInfoHelper_gr__block_ls_string;VarInfo_q__c_void_gr_:
+.. _function-ast_debug_helper_iter_vars_DebugInfoHelper_q__block_ls_string;VarInfo_q__c_void_gr_:
 
-.. das:function:: debug_helper_iter_vars(helper: smart_ptr<DebugInfoHelper>; blk: block<(string;VarInfo?):void>)
+.. das:function:: debug_helper_iter_vars(helper: DebugInfoHelper?; blk: block<(string;VarInfo?):void>)
 
 Iterates through all variables in the DebugInfoHelper, invoking the provided block for each one.
 
 
-:Arguments: * **helper** : smart_ptr< :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`> implicit
+:Arguments: * **helper** :  :ref:`DebugInfoHelper <handle-rtti-DebugInfoHelper>`? implicit
 
             * **blk** : block<(string; :ref:`VarInfo <handle-rtti-VarInfo>`?):void> implicit
 

--- a/doc/source/stdlib/handmade/function-ast-debug_helper_find_struct_cppname-0xad36b19b9028576e.rst
+++ b/doc/source/stdlib/handmade/function-ast-debug_helper_find_struct_cppname-0xad36b19b9028576e.rst
@@ -1,0 +1,1 @@
+Finds a structure in the DebugInfoHelper and returns its C++ name.

--- a/doc/source/stdlib/handmade/function-ast-debug_helper_find_type_cppname-0x135f122b25a68638.rst
+++ b/doc/source/stdlib/handmade/function-ast-debug_helper_find_type_cppname-0x135f122b25a68638.rst
@@ -1,0 +1,1 @@
+Finds a type in the DebugInfoHelper and returns its C++ name.

--- a/doc/source/stdlib/handmade/function-ast-debug_helper_iter_enums-0x61ddf3406d41abcb.rst
+++ b/doc/source/stdlib/handmade/function-ast-debug_helper_iter_enums-0x61ddf3406d41abcb.rst
@@ -1,0 +1,1 @@
+Iterates through all enumerations in the DebugInfoHelper, invoking the provided block for each one.

--- a/doc/source/stdlib/handmade/function-ast-debug_helper_iter_funcs-0x277f6483d22b1afa.rst
+++ b/doc/source/stdlib/handmade/function-ast-debug_helper_iter_funcs-0x277f6483d22b1afa.rst
@@ -1,0 +1,1 @@
+Iterates through all functions in the DebugInfoHelper, invoking the provided block for each one.

--- a/doc/source/stdlib/handmade/function-ast-debug_helper_iter_structs-0x334f3fbe1a8d0cd9.rst
+++ b/doc/source/stdlib/handmade/function-ast-debug_helper_iter_structs-0x334f3fbe1a8d0cd9.rst
@@ -1,0 +1,1 @@
+Iterates through all structures in the DebugInfoHelper, invoking the provided block for each one.

--- a/doc/source/stdlib/handmade/function-ast-debug_helper_iter_types-0xa6c01f3b73b93fa0.rst
+++ b/doc/source/stdlib/handmade/function-ast-debug_helper_iter_types-0xa6c01f3b73b93fa0.rst
@@ -1,0 +1,1 @@
+Iterates through all types in the DebugInfoHelper, invoking the provided block for each one.

--- a/doc/source/stdlib/handmade/function-ast-debug_helper_iter_vars-0x5ce28f0253d017ec.rst
+++ b/doc/source/stdlib/handmade/function-ast-debug_helper_iter_vars-0x5ce28f0253d017ec.rst
@@ -1,0 +1,1 @@
+Iterates through all variables in the DebugInfoHelper, invoking the provided block for each one.

--- a/doc/source/stdlib/handmade/function-ast-make_enum_debug_info-0x6ab135219f204d2e.rst
+++ b/doc/source/stdlib/handmade/function-ast-make_enum_debug_info-0x6ab135219f204d2e.rst
@@ -1,0 +1,1 @@
+Generates an EnumInfo for the specified enumeration using the given DebugInfoHelper.

--- a/doc/source/stdlib/handmade/function-ast-make_function_debug_info-0xc81ba8c6cee6d830.rst
+++ b/doc/source/stdlib/handmade/function-ast-make_function_debug_info-0xc81ba8c6cee6d830.rst
@@ -1,0 +1,1 @@
+Generates a FuncInfo for the specified function using the given DebugInfoHelper.

--- a/doc/source/stdlib/handmade/function-ast-make_invokable_type_debug_info-0x2b85b16ef8a53117.rst
+++ b/doc/source/stdlib/handmade/function-ast-make_invokable_type_debug_info-0x2b85b16ef8a53117.rst
@@ -1,0 +1,1 @@
+Generates a FuncInfo for an invokable type such as a lambda or block using the given DebugInfoHelper.

--- a/doc/source/stdlib/handmade/function-ast-make_struct_debug_info-0xe55175b7187c6a57.rst
+++ b/doc/source/stdlib/handmade/function-ast-make_struct_debug_info-0xe55175b7187c6a57.rst
@@ -1,0 +1,1 @@
+Generates a StructInfo for the specified structure using the given DebugInfoHelper.

--- a/doc/source/stdlib/handmade/function-ast-make_struct_variable_debug_info-0x1a97f0ae382d96.rst
+++ b/doc/source/stdlib/handmade/function-ast-make_struct_variable_debug_info-0x1a97f0ae382d96.rst
@@ -1,0 +1,1 @@
+Generates a VariableInfo for a structure field using the given DebugInfoHelper.

--- a/doc/source/stdlib/handmade/function-ast-make_type_info-0x7cf487a479c9f149.rst
+++ b/doc/source/stdlib/handmade/function-ast-make_type_info-0x7cf487a479c9f149.rst
@@ -1,0 +1,1 @@
+Generates a TypeInfo for the specified type using the given DebugInfoHelper.

--- a/doc/source/stdlib/handmade/function-ast-make_variable_debug_info-0xcdc50658e9336aa0.rst
+++ b/doc/source/stdlib/handmade/function-ast-make_variable_debug_info-0xcdc50658e9336aa0.rst
@@ -1,0 +1,1 @@
+Generates a VariableInfo for the specified variable using the given DebugInfoHelper.

--- a/doc/source/stdlib/handmade/function-debugapi-make_data_walker-0x41799332b5e2293f.rst
+++ b/doc/source/stdlib/handmade/function-debugapi-make_data_walker-0x41799332b5e2293f.rst
@@ -1,0 +1,1 @@
+Wraps a `DapiDataWalker` class pointer into a `smart_ptr<DataWalker>` for use with `walk_data`.

--- a/doc/source/stdlib/handmade/function-debugapi-make_stack_walker-0x5fcd9ebadbec4601.rst
+++ b/doc/source/stdlib/handmade/function-debugapi-make_stack_walker-0x5fcd9ebadbec4601.rst
@@ -1,0 +1,1 @@
+Wraps a `DapiStackWalker` class pointer into a `smart_ptr<StackWalker>` for use with `walk_stack`.

--- a/doc/source/stdlib/handmade/function-debugapi-walk_data-0xfb914dd7d4aebe87.rst
+++ b/doc/source/stdlib/handmade/function-debugapi-walk_data-0xfb914dd7d4aebe87.rst
@@ -1,0 +1,1 @@
+Walks a daslang data structure using the provided `DataWalker`.  The walker receives typed callbacks for each value encountered.  Overloaded for raw data+`StructInfo`, `float4`+`TypeInfo`, and `void?`+`TypeInfo`.

--- a/doc/source/stdlib/handmade/function-debugapi-walk_stack-0x7d2b92e926cc7486.rst
+++ b/doc/source/stdlib/handmade/function-debugapi-walk_stack-0x7d2b92e926cc7486.rst
@@ -1,0 +1,1 @@
+Walks the call stack of the given context using the provided `StackWalker`.  The walker receives callbacks for each stack frame, argument, and local variable.

--- a/doc/source/stdlib/handmade/function-network-server_init-0xd2b5dbb905a77cfe.rst
+++ b/doc/source/stdlib/handmade/function-network-server_init-0xd2b5dbb905a77cfe.rst
@@ -1,0 +1,1 @@
+Initializes the server to listen on the specified port.

--- a/doc/source/stdlib/handmade/function-network-server_is_connected-0x539e6883075facb8.rst
+++ b/doc/source/stdlib/handmade/function-network-server_is_connected-0x539e6883075facb8.rst
@@ -1,0 +1,1 @@
+Returns ``true`` if the server has an active client connection.

--- a/doc/source/stdlib/handmade/function-network-server_is_open-0x67f3a340b2a4090b.rst
+++ b/doc/source/stdlib/handmade/function-network-server_is_open-0x67f3a340b2a4090b.rst
@@ -1,0 +1,1 @@
+Returns ``true`` if the server is listening on its bound port.

--- a/doc/source/stdlib/handmade/function-network-server_restore-0xfca1fd0008204ce0.rst
+++ b/doc/source/stdlib/handmade/function-network-server_restore-0xfca1fd0008204ce0.rst
@@ -1,0 +1,1 @@
+Restores a server from an orphaned or interrupted state.

--- a/doc/source/stdlib/handmade/function-network-server_send-0xfc2c591cb0f7a06b.rst
+++ b/doc/source/stdlib/handmade/function-network-server_send-0xfc2c591cb0f7a06b.rst
@@ -1,0 +1,1 @@
+Sends data from the server to the connected client.

--- a/doc/source/stdlib/handmade/function-network-server_tick-0x8ca981ba5fd582bf.rst
+++ b/doc/source/stdlib/handmade/function-network-server_tick-0x8ca981ba5fd582bf.rst
@@ -1,0 +1,1 @@
+Processes pending network I/O; must be called periodically for the server to function.

--- a/examples/debugapi/stack_walker.das
+++ b/examples/debugapi/stack_walker.das
@@ -89,19 +89,14 @@ class BasicStackWalker : DapiStackWalker {
 // ============================================================
 
 class StackWalkAgent : DapiDebugAgent {
-    walker_adapter : smart_ptr<StackWalker>
     walker : BasicStackWalker?
 
     def StackWalkAgent() {
         walker = new BasicStackWalker()
-        unsafe {
-            walker_adapter <- make_stack_walker(walker)
-        }
     }
 
     def operator delete() {
         unsafe {
-            delete walker_adapter
             delete walker
         }
     }
@@ -110,7 +105,9 @@ class StackWalkAgent : DapiDebugAgent {
                               reason, text : string) : void {
         print("  --- stack walk at line {int(at.line)} ---\n")
         walker.frame_depth = 0
-        walk_stack(walker_adapter, ctx, at)
+        make_stack_walker(walker) $(adapter) {
+            walk_stack(adapter, ctx, at)
+        }
         print("  --- end stack walk ---\n")
     }
 }
@@ -164,20 +161,15 @@ def demo_basic_stack_walk() {
 //   - Build diagnostic objects from runtime state
 
 class DiagnosticAgent : DapiDebugAgent {
-    walker_adapter : smart_ptr<StackWalker>
     walker : BasicStackWalker?
     collection_count : int = 0
 
     def DiagnosticAgent() {
         walker = new BasicStackWalker()
-        unsafe {
-            walker_adapter <- make_stack_walker(walker)
-        }
     }
 
     def operator delete() {
         unsafe {
-            delete walker_adapter
             delete walker
         }
     }
@@ -199,7 +191,9 @@ class DiagnosticAgent : DapiDebugAgent {
 
         // Walk the stack for a full picture
         walker.frame_depth = 0
-        walk_stack(walker_adapter, ctx, at)
+        make_stack_walker(walker) $(adapter) {
+            walk_stack(adapter, ctx, at)
+        }
         print("  --- end collection ---\n")
     }
 

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1472,7 +1472,7 @@ namespace das
         string name;
     };
 
-    class DAS_API DebugInfoHelper : public ptr_ref_count {
+    class DAS_API DebugInfoHelper {
     public:
         DebugInfoHelper () { debugInfo = make_shared<DebugInfoAllocator>(); }
         DebugInfoHelper ( const shared_ptr<DebugInfoAllocator> & di ) : debugInfo(di) {}

--- a/include/daScript/misc/network.h
+++ b/include/daScript/misc/network.h
@@ -11,7 +11,7 @@ namespace das {
         typedef int socket_t;
     #endif
 
-    class Server : public ptr_ref_count {
+    class Server {
     public:
         Server ();
         virtual ~Server();

--- a/include/daScript/simulate/aot_builtin_ast.h
+++ b/include/daScript/simulate/aot_builtin_ast.h
@@ -67,24 +67,24 @@ namespace das {
     DAS_API TypeDeclPtr makeBlockType(ExprBlock *blk);
     // Note: it will be removed once DebugInfoHelper rewritten in das
 
-    DAS_API TypeInfo * makeTypeInfo ( smart_ptr<DebugInfoHelper> helper, TypeInfo * info, const TypeDeclPtr & type );
-    DAS_API VarInfo * makeVariableDebugInfo ( smart_ptr<DebugInfoHelper> helper, Variable *var );
-    DAS_API VarInfo * makeStructVariableDebugInfo ( smart_ptr<DebugInfoHelper> helper, const Structure * st, const Structure::FieldDeclaration * var );
-    DAS_API StructInfo * makeStructureDebugInfo ( smart_ptr<DebugInfoHelper> helper, const Structure * st );
-    DAS_API FuncInfo * makeFunctionDebugInfo ( smart_ptr<DebugInfoHelper> helper, const Function * fn );
-    DAS_API EnumInfo * makeEnumDebugInfo ( smart_ptr<DebugInfoHelper> helper, const Enumeration * en );
-    DAS_API FuncInfo * makeInvokeableTypeDebugInfo ( smart_ptr<DebugInfoHelper> helper, TypeDeclPtr blk, const LineInfo & at );
+    DAS_API TypeInfo * makeTypeInfo ( DebugInfoHelper * helper, TypeInfo * info, const TypeDeclPtr & type );
+    DAS_API VarInfo * makeVariableDebugInfo ( DebugInfoHelper * helper, Variable *var );
+    DAS_API VarInfo * makeStructVariableDebugInfo ( DebugInfoHelper * helper, const Structure * st, const Structure::FieldDeclaration * var );
+    DAS_API StructInfo * makeStructureDebugInfo ( DebugInfoHelper * helper, const Structure * st );
+    DAS_API FuncInfo * makeFunctionDebugInfo ( DebugInfoHelper * helper, const Function * fn );
+    DAS_API EnumInfo * makeEnumDebugInfo ( DebugInfoHelper * helper, const Enumeration * en );
+    DAS_API FuncInfo * makeInvokeableTypeDebugInfo ( DebugInfoHelper * helper, TypeDeclPtr blk, const LineInfo & at );
 
     template <typename T>
     using DebugBlockT = TBlock<void,const char *, T>;
 
-    DAS_API void debug_helper_iter_structs(smart_ptr<DebugInfoHelper> helper, const DebugBlockT<StructInfo*> & block, Context * context, LineInfoArg * at);
-    DAS_API void debug_helper_iter_types(smart_ptr<DebugInfoHelper> helper, const DebugBlockT<TypeInfo*> & block, Context * context, LineInfoArg * at);
-    DAS_API void debug_helper_iter_vars(smart_ptr<DebugInfoHelper> helper, const DebugBlockT<VarInfo*> & block, Context * context, LineInfoArg * at);
-    DAS_API void debug_helper_iter_funcs(smart_ptr<DebugInfoHelper> helper, const DebugBlockT<FuncInfo*> & block, Context * context, LineInfoArg * at);
-    DAS_API void debug_helper_iter_enums(smart_ptr<DebugInfoHelper> helper, const DebugBlockT<EnumInfo*> & block, Context * context, LineInfoArg * at);
-    DAS_API const char *debug_helper_find_type_cppname(const smart_ptr<DebugInfoHelper> &helper, TypeInfo *info, Context * context, LineInfoArg * at);
-    DAS_API const char *debug_helper_find_struct_cppname(const smart_ptr<DebugInfoHelper> &helper, StructInfo *info, Context * context, LineInfoArg * at);
+    DAS_API void debug_helper_iter_structs(DebugInfoHelper * helper, const DebugBlockT<StructInfo*> & block, Context * context, LineInfoArg * at);
+    DAS_API void debug_helper_iter_types(DebugInfoHelper * helper, const DebugBlockT<TypeInfo*> & block, Context * context, LineInfoArg * at);
+    DAS_API void debug_helper_iter_vars(DebugInfoHelper * helper, const DebugBlockT<VarInfo*> & block, Context * context, LineInfoArg * at);
+    DAS_API void debug_helper_iter_funcs(DebugInfoHelper * helper, const DebugBlockT<FuncInfo*> & block, Context * context, LineInfoArg * at);
+    DAS_API void debug_helper_iter_enums(DebugInfoHelper * helper, const DebugBlockT<EnumInfo*> & block, Context * context, LineInfoArg * at);
+    DAS_API const char *debug_helper_find_type_cppname(DebugInfoHelper * helper, TypeInfo *info, Context * context, LineInfoArg * at);
+    DAS_API const char *debug_helper_find_struct_cppname(DebugInfoHelper * helper, StructInfo *info, Context * context, LineInfoArg * at);
     DAS_API bool macro_aot_infix(TypeInfoMacro *macro, StringBuilderWriter *ss, ExpressionPtr expr);
     DAS_API FileInfo *clone_file_info(const char *name, int tabSize, Context * context, LineInfoArg * at);
     DAS_API void for_each_module_function(Module *module, const TBlock<void,FunctionPtr> &blk, Context * context, LineInfoArg * at);

--- a/include/daScript/simulate/aot_builtin_debugger.h
+++ b/include/daScript/simulate/aot_builtin_debugger.h
@@ -6,12 +6,14 @@ namespace das {
     DAS_API void debuggerStackWalk ( Context & context, const LineInfo & lineInfo );
     DAS_API void debuggerSetContextSingleStep ( Context & context, bool step );
 
-    DAS_API DataWalkerPtr makeDataWalker ( const void * pClass, const StructInfo * info, Context * context );
+    DAS_API void makeDataWalker ( const void * pClass, const StructInfo * info,
+        const TBlock<void, DataWalker *> & blk, Context * context, LineInfoArg * at );
     DAS_API void dapiWalkData ( DataWalkerPtr walker, void * data, const TypeInfo & info );
     DAS_API void dapiWalkDataV ( DataWalkerPtr walker, float4 data, const TypeInfo & info );
     DAS_API void dapiWalkDataS ( DataWalkerPtr walker, void * data, const StructInfo & info );
 
-    DAS_API StackWalkerPtr makeStackWalker ( const void * pClass, const StructInfo * info, Context * context );
+    DAS_API void makeStackWalker ( const void * pClass, const StructInfo * info,
+        const TBlock<void, StackWalker *> & blk, Context * context, LineInfoArg * at );
 
     DAS_API vec4f pinvoke_impl ( Context & context, SimNode_CallBase * call, vec4f * args );
     DAS_API vec4f pinvoke_impl2 ( Context & context, SimNode_CallBase * call, vec4f * args );

--- a/include/daScript/simulate/aot_builtin_network.h
+++ b/include/daScript/simulate/aot_builtin_network.h
@@ -5,10 +5,10 @@
 
 namespace das {
     bool makeServer ( const void * pClass, const StructInfo * info, Context * context );
-    bool server_init ( smart_ptr_raw<Server> server, int port, Context * ctx, LineInfoArg * at );
-    bool server_is_open ( smart_ptr_raw<Server> server, Context * context, LineInfoArg * at );
-    bool server_is_connected ( smart_ptr_raw<Server> server, Context * context, LineInfoArg * at );
-    bool server_send ( smart_ptr_raw<Server> server, uint8_t * data, int32_t size, Context * context, LineInfoArg * at );
-    void server_tick ( smart_ptr_raw<Server> server, Context * context, LineInfoArg * at );
-    void server_restore ( smart_ptr_raw<Server> server, const void * pClass, const StructInfo * info, Context * context, LineInfoArg * at );
+    bool server_init ( Server * server, int port, Context * ctx, LineInfoArg * at );
+    bool server_is_open ( Server * server, Context * context, LineInfoArg * at );
+    bool server_is_connected ( Server * server, Context * context, LineInfoArg * at );
+    bool server_send ( Server * server, uint8_t * data, int32_t size, Context * context, LineInfoArg * at );
+    void server_tick ( Server * server, Context * context, LineInfoArg * at );
+    void server_restore ( Server * server, const void * pClass, const StructInfo * info, Context * context, LineInfoArg * at );
 }

--- a/include/daScript/simulate/data_walker.h
+++ b/include/daScript/simulate/data_walker.h
@@ -184,7 +184,7 @@ namespace das {
         vector<loop_point> visited_handles;
     };
 
-    typedef smart_ptr<DataWalker> DataWalkerPtr;
+    typedef DataWalker * DataWalkerPtr;
 
 #if defined(_MSC_VER)
 #pragma warning(pop)

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -295,7 +295,7 @@ namespace das
         virtual bool onAfterCall ( Prologue * ) { return true; }
         virtual void onCorruptStack ( Prologue * ) { }
     };
-    typedef smart_ptr<StackWalker> StackWalkerPtr;
+    typedef StackWalker * StackWalkerPtr;
 
     void dapiStackWalk ( StackWalkerPtr walker, Context & context, const LineInfo & at );
     int32_t dapiStackDepth ( Context & context );

--- a/modules/dasHV/example/telnet.das
+++ b/modules/dasHV/example/telnet.das
@@ -28,9 +28,9 @@ class TelnetServer : Server {
     }
     def restart {
         if (_server != null) {
-            var inscope session : smart_ptr<NetworkServer>
+            var session : NetworkServer?
             self->save(session)
-            gc0_save_smart_ptr("telnet-session", session)
+            gc0_save_ptr("telnet-session", session)
         }
     }
     def override onData(msg : uint8?; size : int) {
@@ -82,7 +82,7 @@ def main {
     let port = 9000
     var telnet = new TelnetServer()
     telnet->make_server_adapter()
-    var inscope session : smart_ptr<NetworkServer> <- unsafe(reinterpret<smart_ptr<NetworkServer>>(gc0_restore_smart_ptr("telnet-session")))
+    var session : NetworkServer? = unsafe(reinterpret<NetworkServer?>(gc0_restore_ptr("telnet-session")))
     if (session != null) {
         print("restoring server after restart\n")
         telnet->restore(session)

--- a/modules/dasLLVM/daslib/llvm_debug.das
+++ b/modules/dasLLVM/daslib/llvm_debug.das
@@ -89,23 +89,20 @@ class SampleStackWalker : DapiStackWalker {
 }
 
 class ContextStateAgent : DapiDebugAgent {
-    walker_adapter : smart_ptr<StackWalker>
     walker : SampleStackWalker?
     def ContextStateAgent {
         walker = new SampleStackWalker()
-        unsafe {
-            walker_adapter <- make_stack_walker(walker)
-        }
     }
     def operator delete {
         unsafe {
-            delete walker_adapter
             delete walker
         }
     }
     def override onCollect(var ctx : Context; at : LineInfo) {
         walker.ctxid = unsafe(addr(ctx))
-        walk_stack(walker_adapter, ctx, at)
+        make_stack_walker(walker) $(adapter) {
+            walk_stack(adapter, ctx, at)
+        }
     }
 }
 

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -905,31 +905,31 @@ namespace das {
 
 // debugInfoHelper
 
-    TypeInfo * makeTypeInfo ( smart_ptr<DebugInfoHelper> helper, TypeInfo * info, const TypeDeclPtr & type ) {
+    TypeInfo * makeTypeInfo ( DebugInfoHelper * helper, TypeInfo * info, const TypeDeclPtr & type ) {
         return helper->makeTypeInfo(info, type);
     }
 
-    VarInfo * makeVariableDebugInfo ( smart_ptr<DebugInfoHelper> helper, Variable *var ) {
+    VarInfo * makeVariableDebugInfo ( DebugInfoHelper * helper, Variable *var ) {
         return helper->makeVariableDebugInfo(*var);
     }
 
-    VarInfo * makeStructVariableDebugInfo ( smart_ptr<DebugInfoHelper> helper, const Structure * st, const Structure::FieldDeclaration * var ) {
+    VarInfo * makeStructVariableDebugInfo ( DebugInfoHelper * helper, const Structure * st, const Structure::FieldDeclaration * var ) {
         return helper->makeVariableDebugInfo(*st, *var);
     }
 
-    StructInfo * makeStructureDebugInfo ( smart_ptr<DebugInfoHelper> helper, const Structure * st ) {
+    StructInfo * makeStructureDebugInfo ( DebugInfoHelper * helper, const Structure * st ) {
         return helper->makeStructureDebugInfo(*st);
     }
 
-    FuncInfo * makeFunctionDebugInfo ( smart_ptr<DebugInfoHelper> helper, const Function * fn ) {
+    FuncInfo * makeFunctionDebugInfo ( DebugInfoHelper * helper, const Function * fn ) {
         return helper->makeFunctionDebugInfo(*fn);
     }
 
-    EnumInfo * makeEnumDebugInfo ( smart_ptr<DebugInfoHelper> helper, const Enumeration * en ) {
+    EnumInfo * makeEnumDebugInfo ( DebugInfoHelper * helper, const Enumeration * en ) {
         return helper->makeEnumDebugInfo(*en);
     }
 
-    FuncInfo * makeInvokeableTypeDebugInfo ( smart_ptr<DebugInfoHelper> helper, TypeDeclPtr blk, const LineInfo & at ) {
+    FuncInfo * makeInvokeableTypeDebugInfo ( DebugInfoHelper * helper, TypeDeclPtr blk, const LineInfo & at ) {
         return helper->makeInvokeableTypeDebugInfo(blk, at);
     }
 
@@ -946,32 +946,32 @@ namespace das {
         }
     }
 
-    void debug_helper_iter_structs(smart_ptr<DebugInfoHelper> helper, const DebugBlockT<StructInfo*> & block, Context * context, LineInfoArg * at) {
+    void debug_helper_iter_structs(DebugInfoHelper * helper, const DebugBlockT<StructInfo*> & block, Context * context, LineInfoArg * at) {
         call_each(ordered(helper->smn2s), block, context, at);
     }
 
-    void debug_helper_iter_types(smart_ptr<DebugInfoHelper> helper, const DebugBlockT<TypeInfo*> & block, Context * context, LineInfoArg * at) {
+    void debug_helper_iter_types(DebugInfoHelper * helper, const DebugBlockT<TypeInfo*> & block, Context * context, LineInfoArg * at) {
         call_each(ordered(helper->tmn2t), block, context, at);
     }
 
-    void debug_helper_iter_vars(smart_ptr<DebugInfoHelper> helper, const DebugBlockT<VarInfo*> & block, Context * context, LineInfoArg * at) {
+    void debug_helper_iter_vars(DebugInfoHelper * helper, const DebugBlockT<VarInfo*> & block, Context * context, LineInfoArg * at) {
         call_each(ordered(helper->vmn2v), block, context, at);
     }
 
-    void debug_helper_iter_funcs(smart_ptr<DebugInfoHelper> helper, const DebugBlockT<FuncInfo*> & block, Context * context, LineInfoArg * at) {
+    void debug_helper_iter_funcs(DebugInfoHelper * helper, const DebugBlockT<FuncInfo*> & block, Context * context, LineInfoArg * at) {
         call_each(ordered(helper->fmn2f), block, context, at);
     }
 
-    void debug_helper_iter_enums(smart_ptr<DebugInfoHelper> helper, const DebugBlockT<EnumInfo*> & block, Context * context, LineInfoArg * at) {
+    void debug_helper_iter_enums(DebugInfoHelper * helper, const DebugBlockT<EnumInfo*> & block, Context * context, LineInfoArg * at) {
         call_each(ordered(helper->emn2e), block, context, at);
     }
 
-    const char *debug_helper_find_type_cppname(const smart_ptr<DebugInfoHelper> &helper, TypeInfo *info, Context * context, LineInfoArg * at) {
+    const char *debug_helper_find_type_cppname(DebugInfoHelper * helper, TypeInfo *info, Context * context, LineInfoArg * at) {
         DAS_ASSERT(helper->t2cppTypeName.find(info) != helper->t2cppTypeName.end());
         return context->allocateString(helper->t2cppTypeName.find(info)->second, at);
     }
 
-    const char *debug_helper_find_struct_cppname(const smart_ptr<DebugInfoHelper> &helper, StructInfo *info, Context * context, LineInfoArg * at) {
+    const char *debug_helper_find_struct_cppname(DebugInfoHelper * helper, StructInfo *info, Context * context, LineInfoArg * at) {
         DAS_ASSERT(helper->s2cppTypeName.find(info) != helper->s2cppTypeName.end());
         return context->allocateString(helper->s2cppTypeName.find(info)->second, at);
     }

--- a/src/builtin/module_builtin_debugger.cpp
+++ b/src/builtin/module_builtin_debugger.cpp
@@ -780,8 +780,13 @@ namespace debugger {
         }
     };
 
-    StackWalkerPtr makeStackWalker ( const void * pClass, const StructInfo * info, Context * context ) {
-        return make_smart<StackWalkerAdapter>((char *)pClass,info,context);
+    void makeStackWalker ( const void * pClass, const StructInfo * info,
+            const TBlock<void, StackWalker *> & blk, Context * context, LineInfoArg * at ) {
+        auto adapter = new StackWalkerAdapter((char *)pClass,info,context);
+        vec4f args[1];
+        args[0] = cast<StackWalker *>::from(adapter);
+        context->invoke(blk, args, nullptr, at);
+        delete adapter;
     }
 
     DebugAgentPtr makeDebugAgent ( const void * pClass, const StructInfo * info, Context * context ) {
@@ -814,8 +819,13 @@ namespace debugger {
         context.stackWalk(&lineInfo, true, true);
     }
 
-    DataWalkerPtr makeDataWalker ( const void * pClass, const StructInfo * info, Context * context ) {
-        return make_smart<DataWalkerAdapter>((char *)pClass,info,context);
+    void makeDataWalker ( const void * pClass, const StructInfo * info,
+            const TBlock<void, DataWalker *> & blk, Context * context, LineInfoArg * at ) {
+        auto adapter = new DataWalkerAdapter((char *)pClass,info,context);
+        vec4f args[1];
+        args[0] = cast<DataWalker *>::from(adapter);
+        context->invoke(blk, args, nullptr, at);
+        delete adapter;
     }
 
     void dapiWalkData ( DataWalkerPtr walker, void * data, const TypeInfo & info ) {
@@ -1387,8 +1397,8 @@ namespace debugger {
                     ->args({"command"});
             // data walker
             addExtern<DAS_BIND_FUN(makeDataWalker)>(*this, lib,  "make_data_walker",
-                SideEffects::modifyExternal, "makeDataWalker")
-                    ->args({"class","info","context"});
+                SideEffects::modifyExternal|SideEffects::invoke, "makeDataWalker")
+                    ->args({"class","info","block","context","at"});
             addExtern<DAS_BIND_FUN(dapiWalkData)>(*this, lib,  "walk_data",
                 SideEffects::modifyExternal, "dapiWalkData")
                     ->args({"walker","data","info"});
@@ -1400,8 +1410,8 @@ namespace debugger {
                     ->args({"walker","data","struct_info"});
             // stack walker
             addExtern<DAS_BIND_FUN(makeStackWalker)>(*this, lib,  "make_stack_walker",
-                SideEffects::modifyExternal, "makeStackWalker")
-                    ->args({"class","info","context"});
+                SideEffects::modifyExternal|SideEffects::invoke, "makeStackWalker")
+                    ->args({"class","info","block","context","at"});
             addExtern<DAS_BIND_FUN(dapiStackWalk)>(*this, lib,  "walk_stack",
                 SideEffects::modifyExternal, "dapiStackWalk")
                     ->args({"walker","context","line"});

--- a/src/builtin/module_builtin_network.cpp
+++ b/src/builtin/module_builtin_network.cpp
@@ -85,40 +85,39 @@ namespace das {
     };
 
     bool makeServer ( const void * pClass, const StructInfo * info, Context * context ) {
-        auto server = make_smart<ServerAdapter>((char *)pClass,info,context);
-        if ( !server->isValid() ) return false;
-        server.orphan();
+        auto server = new ServerAdapter((char *)pClass,info,context);
+        if ( !server->isValid() ) { delete server; return false; }
         return true;
     }
 
-    bool server_init ( smart_ptr_raw<Server> server, int port, Context * context, LineInfoArg * at ) {
+    bool server_init ( Server * server, int port, Context * context, LineInfoArg * at ) {
         if ( !server ) context->throw_error_at(at, "null server");
         return server->init(port);
     }
 
-    bool server_is_open ( smart_ptr_raw<Server> server, Context * context, LineInfoArg * at ) {
+    bool server_is_open ( Server * server, Context * context, LineInfoArg * at ) {
         if ( !server ) context->throw_error_at(at, "null server");
         return server->is_open();
     }
 
-    bool server_is_connected ( smart_ptr_raw<Server> server, Context * context, LineInfoArg * at ) {
+    bool server_is_connected ( Server * server, Context * context, LineInfoArg * at ) {
         if ( !server ) context->throw_error_at(at, "null server");
         return server->is_connected();
     }
 
-    bool server_send ( smart_ptr_raw<Server> server, uint8_t * data, int32_t size, Context * context, LineInfoArg * at ) {
+    bool server_send ( Server * server, uint8_t * data, int32_t size, Context * context, LineInfoArg * at ) {
         if ( !server ) context->throw_error_at(at, "null server");
         return server->send_msg((char *)data, size);
     }
 
-    void server_tick ( smart_ptr_raw<Server> server, Context * context, LineInfoArg * at ) {
+    void server_tick ( Server * server, Context * context, LineInfoArg * at ) {
         if ( !server ) context->throw_error_at(at, "null server");
         server->tick();
     }
 
-    void server_restore ( smart_ptr_raw<Server> server, const void * pClass, const StructInfo * info, Context * context, LineInfoArg * at ) {
+    void server_restore ( Server * server, const void * pClass, const StructInfo * info, Context * context, LineInfoArg * at ) {
         if ( !server ) context->throw_error_at(at, "null server");
-        auto adapter = (ServerAdapter *) server.get();
+        auto adapter = (ServerAdapter *) server;
         adapter->update((char *)pClass,info,context);
     }
 

--- a/src/simulate/simulate.cpp
+++ b/src/simulate/simulate.cpp
@@ -1628,12 +1628,12 @@ namespace das
         char * sp = stack.ap();
         ssw << "CALL STACK (sp=" << (stack.top() - stack.ap())
             << ",sptr=0x" << HEX  << intptr_t(sp) << DEC << "):\n";
-        auto walker = make_smart<StackWalkerTextWriter> ( ssw, this );
-        walker->showArguments = showArguments;
-        walker->showLocalVariables =  showLocalVariables;
-        walker->showOutOfScope = showOutOfScope;
-        walker->stackTopOnly = stackTopOnly;
-        dapiStackWalk ( walker, *this, at ? *at : LineInfo() );
+        StackWalkerTextWriter walker ( ssw, this );
+        walker.showArguments = showArguments;
+        walker.showLocalVariables =  showLocalVariables;
+        walker.showOutOfScope = showOutOfScope;
+        walker.stackTopOnly = stackTopOnly;
+        dapiStackWalk ( &walker, *this, at ? *at : LineInfo() );
         ssw << "\n";
     #else
         ssw << "\nCALL STACK TRACKING DISABLED:\n\n";

--- a/tests/data_walker/test_walk_containers.das
+++ b/tests/data_walker/test_walk_containers.das
@@ -20,9 +20,10 @@ def test_walk_array(t : T?) {
     t |> run("array of ints") @(t : T?) {
         var walker = new LogWalker()
         var arr = [10, 20, 30]
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         var expected = "beforeArray\n"
         expected += "beforeArrayData:3\n"
@@ -43,9 +44,10 @@ def test_walk_array(t : T?) {
     t |> run("empty array") @(t : T?) {
         var walker = new LogWalker()
         var arr : array<int>
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         var expected = "beforeArray\n"
         expected += "beforeArrayData:0\n"
@@ -57,9 +59,10 @@ def test_walk_array(t : T?) {
     t |> run("single element array") @(t : T?) {
         var walker = new LogWalker()
         var arr = [42]
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         // Single element: index=0, last=true
         t |> equal(find(walker.log, "beforeElem:0:true") != -1, true)
@@ -71,9 +74,10 @@ def test_walk_array(t : T?) {
         var arr : array<SimpleStruct>
         arr |> push(SimpleStruct(x = 1, y = 1.0))
         arr |> push(SimpleStruct(x = 2, y = 2.0))
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         t |> equal(find(walker.log, "beforeArray") != -1, true)
         t |> equal(find(walker.log, "beforeStruct:SimpleStruct") != -1, true)
@@ -84,9 +88,10 @@ def test_walk_array(t : T?) {
     t |> run("array of strings") @(t : T?) {
         var walker = new LogWalker()
         var arr = ["foo", "bar", "baz"]
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         t |> equal(find(walker.log, "String:foo") != -1, true)
         t |> equal(find(walker.log, "String:bar") != -1, true)
@@ -98,9 +103,10 @@ def test_walk_array(t : T?) {
         var arr : array<tuple<int; string>>
         arr |> push((1, "one"))
         arr |> push((2, "two"))
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         t |> equal(find(walker.log, "beforeArray") != -1, true)
         t |> equal(find(walker.log, "beforeTuple") != -1, true)
@@ -125,9 +131,10 @@ def test_walk_dim(t : T?) {
         arr[0] = 100
         arr[1] = 200
         arr[2] = 300
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         t |> equal(find(walker.log, "beforeDim") != -1, true)
         t |> equal(find(walker.log, "Int:100") != -1, true)
@@ -149,9 +156,10 @@ def test_walk_table(t : T?) {
         var walker = new LogWalker()
         var tab : table<string; int>
         tab |> insert("alpha", 1)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+            }
         }
         t |> equal(find(walker.log, "beforeTable") != -1, true)
         t |> equal(find(walker.log, "String:alpha") != -1, true)
@@ -162,9 +170,10 @@ def test_walk_table(t : T?) {
     t |> run("empty table") @(t : T?) {
         var walker = new LogWalker()
         var tab : table<string; int>
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+            }
         }
         var expected = "beforeTable\n"
         expected += "afterTable\n"
@@ -176,9 +185,10 @@ def test_walk_table(t : T?) {
         var walker = new LogWalker()
         var tab : table<string; int>
         tab |> insert("x", 42)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+            }
         }
         var key_pos = find(walker.log, "beforeKey")
         var key_after_pos = find(walker.log, "afterKey")
@@ -194,9 +204,10 @@ def test_walk_table(t : T?) {
         var walker = new LogWalker()
         var tab : table<int; string>
         tab |> insert(42, "answer")
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+            }
         }
         t |> equal(find(walker.log, "Int:42") != -1, true)
         t |> equal(find(walker.log, "String:answer") != -1, true)
@@ -208,9 +219,10 @@ def test_walk_table(t : T?) {
         tab |> insert("a", 1)
         tab |> insert("b", 2)
         tab |> insert("c", 3)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+            }
         }
         // All 3 keys and values should appear (order may vary due to hash table)
         t |> equal(find(walker.log, "String:a") != -1, true)

--- a/tests/data_walker/test_walk_edge_cases.das
+++ b/tests/data_walker/test_walk_edge_cases.das
@@ -41,9 +41,10 @@ def test_walk_null_pointer(t : T?) {
     t |> run("null pointer") @(t : T?) {
         var walker = new LogWalker()
         var p : SimpleStruct?
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(p), typeinfo rtti_typeinfo(p))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(p), typeinfo rtti_typeinfo(p))
+            }
         }
         // Null pointer: beforePtr → Null → afterPtr (walker still brackets with ptr callbacks)
         var expected = "beforePtr\n"
@@ -56,9 +57,10 @@ def test_walk_null_pointer(t : T?) {
         var walker = new LogWalker()
         var s = SimpleStruct(x = 7, y = 1.5)
         var p : SimpleStruct? = unsafe(addr(s))
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(p), typeinfo rtti_typeinfo(p))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(p), typeinfo rtti_typeinfo(p))
+            }
         }
         t |> equal(find(walker.log, "beforePtr") != -1, true)
         t |> equal(find(walker.log, "beforeStruct:SimpleStruct") != -1, true)
@@ -81,9 +83,10 @@ def test_walk_lambda(t : T?) {
         var lam <- @ {
             return captured_value
         }
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(lam), typeinfo rtti_typeinfo(lam))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(lam), typeinfo rtti_typeinfo(lam))
+            }
         }
         t |> equal(find(walker.log, "beforeLambda") != -1, true)
         t |> equal(find(walker.log, "afterLambda") != -1, true)
@@ -101,9 +104,10 @@ def test_walk_edge_values(t : T?) {
     t |> run("zero int") @(t : T?) {
         var walker = new LogWalker()
         var x = 0
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Int:0\n")
         unsafe { delete walker; }
@@ -111,9 +115,10 @@ def test_walk_edge_values(t : T?) {
     t |> run("negative int") @(t : T?) {
         var walker = new LogWalker()
         var x = -42
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Int:-42\n")
         unsafe { delete walker; }
@@ -121,9 +126,10 @@ def test_walk_edge_values(t : T?) {
     t |> run("negative float") @(t : T?) {
         var walker = new LogWalker()
         var x = -1.5
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Float:-1.5\n")
         unsafe { delete walker; }
@@ -131,9 +137,10 @@ def test_walk_edge_values(t : T?) {
     t |> run("max int") @(t : T?) {
         var walker = new LogWalker()
         var x = 2147483647
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Int:2147483647\n")
         unsafe { delete walker; }
@@ -141,9 +148,10 @@ def test_walk_edge_values(t : T?) {
     t |> run("min int") @(t : T?) {
         var walker = new LogWalker()
         var x = -2147483647 - 1
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Int:-2147483648\n")
         unsafe { delete walker; }
@@ -163,9 +171,10 @@ def test_deeply_nested(t : T?) {
         root.children |> emplace(TreeNode(value = 2))
         root.children |> emplace(TreeNode(value = 3))
         root.children[0].children |> emplace(TreeNode(value = 4))
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(root), typeinfo rtti_typeinfo(root))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(root), typeinfo rtti_typeinfo(root))
+            }
         }
         // All 4 values should be visited
         t |> equal(find(walker.log, "Int:1") != -1, true)
@@ -185,19 +194,20 @@ def test_deeply_nested(t : T?) {
 def test_reuse_adapter(t : T?) {
     t |> run("walk twice with same adapter") @(t : T?) {
         var walker = new LogWalker()
-        var inscope adapter <- make_data_walker(walker)
-        var x = 10
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            var x = 10
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
+            t |> equal(walker.log, "Int:10\n")
+            // Reset log and walk again
+            walker.log = ""
+            var y = 20
+            unsafe {
+                adapter |> walk_data(addr(y), typeinfo rtti_typeinfo(y))
+            }
+            t |> equal(walker.log, "Int:20\n")
         }
-        t |> equal(walker.log, "Int:10\n")
-        // Reset log and walk again
-        walker.log = ""
-        var y = 20
-        unsafe {
-            adapter |> walk_data(addr(y), typeinfo rtti_typeinfo(y))
-        }
-        t |> equal(walker.log, "Int:20\n")
         unsafe { delete walker; }
     }
 }
@@ -212,9 +222,10 @@ def test_count_scalars(t : T?) {
     t |> run("count in struct") @(t : T?) {
         var walker = new CountWalker()
         var s = SimpleStruct(x = 1, y = 2.0)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
         }
         t |> equal(walker.count, 2)   // x(int) + y(float)
         unsafe { delete walker; }
@@ -222,9 +233,10 @@ def test_count_scalars(t : T?) {
     t |> run("count in nested struct") @(t : T?) {
         var walker = new CountWalker()
         var s = NestedStruct(inner = SimpleStruct(x = 1, y = 2.0), tag = "test")
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
         }
         t |> equal(walker.count, 3)   // inner.x(int) + inner.y(float) + tag(string)
         unsafe { delete walker; }
@@ -232,9 +244,10 @@ def test_count_scalars(t : T?) {
     t |> run("count in array") @(t : T?) {
         var walker = new CountWalker()
         var arr = [1, 2, 3, 4, 5]
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         t |> equal(walker.count, 5)
         unsafe { delete walker; }

--- a/tests/data_walker/test_walk_filtering.das
+++ b/tests/data_walker/test_walk_filtering.das
@@ -138,9 +138,10 @@ def test_can_visit_filtering(t : T?) {
     t |> run("skip structures") @(t : T?) {
         var walker = new SkipStructWalker()
         var s = SimpleStruct(x = 10, y = 2.5)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
         }
         // Should see canVisitStructure but NOT beforeStruct/afterStruct or field values
         t |> equal(find(walker.log, "canVisitStructure:false") != -1, true)
@@ -152,9 +153,10 @@ def test_can_visit_filtering(t : T?) {
     t |> run("skip arrays") @(t : T?) {
         var walker = new SkipArrayWalker()
         var arr = [1, 2, 3]
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         // Should NOT see any Int callbacks or beforeArray
         t |> equal(walker.log, "")
@@ -168,9 +170,10 @@ def test_can_visit_array_data(t : T?) {
     t |> run("skip array data but still get before/after array") @(t : T?) {
         var walker = new SkipArrayDataWalker()
         var arr = [1, 2, 3]
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         // Should see beforeArray/afterArray but no element callbacks
         t |> equal(find(walker.log, "beforeArray") != -1, true)
@@ -189,9 +192,10 @@ def test_can_visit_table_data(t : T?) {
         var tab : table<string; int>
         tab |> insert("a", 1)
         tab |> insert("b", 2)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
+            }
         }
         t |> equal(find(walker.log, "beforeTable") != -1, true)
         t |> equal(find(walker.log, "afterTable") != -1, true)
@@ -209,9 +213,10 @@ def test_can_visit_pointer(t : T?) {
         var walker = new SkipPointerWalker()
         var s = SimpleStruct(x = 99, y = 1.0)
         var p : SimpleStruct? = unsafe(addr(s))
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(p), typeinfo rtti_typeinfo(p))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(p), typeinfo rtti_typeinfo(p))
+            }
         }
         // Should NOT walk through the pointer
         t |> equal(walker.log, "")
@@ -226,9 +231,10 @@ def test_selective_struct_visit(t : T?) {
         var walker = new SelectiveStructWalker()
         walker.skip_name = "SimpleStruct"
         var s = NestedStruct(inner = SimpleStruct(x = 1, y = 2.0), tag = "outer")
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
         }
         // Should visit NestedStruct but skip SimpleStruct
         t |> equal(find(walker.log, "visit:NestedStruct") != -1, true)

--- a/tests/data_walker/test_walk_mutation.das
+++ b/tests/data_walker/test_walk_mutation.das
@@ -41,9 +41,10 @@ def test_mutation(t : T?) {
     t |> run("mutate scalar int") @(t : T?) {
         var walker = new Doubler()
         var x = 21
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(x, 42)
         unsafe { delete walker; }
@@ -51,9 +52,10 @@ def test_mutation(t : T?) {
     t |> run("mutate struct fields") @(t : T?) {
         var walker = new Doubler()
         var s = SimpleStruct(x = 5, y = 1.5)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
         }
         t |> equal(s.x, 10)
         t |> equal(s.y, 3.0)
@@ -62,9 +64,10 @@ def test_mutation(t : T?) {
     t |> run("mutate array elements") @(t : T?) {
         var walker = new Doubler()
         var arr = [1, 2, 3]
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         t |> equal(arr[0], 2)
         t |> equal(arr[1], 4)
@@ -79,9 +82,10 @@ def test_mutate_nested(t : T?) {
     t |> run("mutate strings in struct") @(t : T?) {
         var walker = new StringUpperWalker()
         var s = NestedStruct(inner = SimpleStruct(x = 1, y = 2.0), tag = "hello")
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
         }
         t |> equal(s.tag, "HELLO")
         unsafe { delete walker; }
@@ -89,9 +93,10 @@ def test_mutate_nested(t : T?) {
     t |> run("mutate strings in array") @(t : T?) {
         var walker = new StringUpperWalker()
         var arr = ["abc", "def"]
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
         }
         t |> equal(arr[0], "ABC")
         t |> equal(arr[1], "DEF")

--- a/tests/data_walker/test_walk_scalars.das
+++ b/tests/data_walker/test_walk_scalars.das
@@ -15,9 +15,10 @@ def test_walk_int(t : T?) {
     t |> run("int") @(t : T?) {
         var walker = new LogWalker()
         var x = 42
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Int:42\n")
         unsafe { delete walker; }
@@ -25,9 +26,10 @@ def test_walk_int(t : T?) {
     t |> run("uint") @(t : T?) {
         var walker = new LogWalker()
         var x = 0xFF_u
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "UInt:0xff\n")
         unsafe { delete walker; }
@@ -35,9 +37,10 @@ def test_walk_int(t : T?) {
     t |> run("int64") @(t : T?) {
         var walker = new LogWalker()
         var x = 100_000_000_000l
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Int64:100000000000\n")
         unsafe { delete walker; }
@@ -45,9 +48,10 @@ def test_walk_int(t : T?) {
     t |> run("uint64") @(t : T?) {
         var walker = new LogWalker()
         var x = 99ul
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "UInt64:0x63\n")
         unsafe { delete walker; }
@@ -55,9 +59,10 @@ def test_walk_int(t : T?) {
     t |> run("int8") @(t : T?) {
         var walker = new LogWalker()
         var x = int8(127)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Int8:127\n")
         unsafe { delete walker; }
@@ -65,9 +70,10 @@ def test_walk_int(t : T?) {
     t |> run("uint8") @(t : T?) {
         var walker = new LogWalker()
         var x = uint8(200)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "UInt8:200\n")
         unsafe { delete walker; }
@@ -75,9 +81,10 @@ def test_walk_int(t : T?) {
     t |> run("int16") @(t : T?) {
         var walker = new LogWalker()
         var x = int16(-1000)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Int16:-1000\n")
         unsafe { delete walker; }
@@ -85,9 +92,10 @@ def test_walk_int(t : T?) {
     t |> run("uint16") @(t : T?) {
         var walker = new LogWalker()
         var x = uint16(60000)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "UInt16:60000\n")
         unsafe { delete walker; }
@@ -100,9 +108,10 @@ def test_walk_float_double(t : T?) {
     t |> run("float") @(t : T?) {
         var walker = new LogWalker()
         var x = 3.14
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Float:3.14\n")
         unsafe { delete walker; }
@@ -110,9 +119,10 @@ def test_walk_float_double(t : T?) {
     t |> run("double") @(t : T?) {
         var walker = new LogWalker()
         var x = 2.718281828lf
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Double:2.718281828\n")
         unsafe { delete walker; }
@@ -125,9 +135,10 @@ def test_walk_bool_string(t : T?) {
     t |> run("bool true") @(t : T?) {
         var walker = new LogWalker()
         var x = true
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Bool:true\n")
         unsafe { delete walker; }
@@ -135,9 +146,10 @@ def test_walk_bool_string(t : T?) {
     t |> run("bool false") @(t : T?) {
         var walker = new LogWalker()
         var x = false
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "Bool:false\n")
         unsafe { delete walker; }
@@ -145,9 +157,10 @@ def test_walk_bool_string(t : T?) {
     t |> run("string") @(t : T?) {
         var walker = new LogWalker()
         var x = "hello world"
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "String:hello world\n")
         unsafe { delete walker; }
@@ -155,9 +168,10 @@ def test_walk_bool_string(t : T?) {
     t |> run("empty string") @(t : T?) {
         var walker = new LogWalker()
         var x = ""
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+            }
         }
         t |> equal(walker.log, "String:\n")
         unsafe { delete walker; }
@@ -170,9 +184,10 @@ def test_walk_enum(t : T?) {
     t |> run("enum value") @(t : T?) {
         var walker = new LogWalker()
         var c : Color = Color.Green
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(c), typeinfo rtti_typeinfo(c))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(c), typeinfo rtti_typeinfo(c))
+            }
         }
         t |> equal(walker.log, "Enum:Color:1\n")
         unsafe { delete walker; }
@@ -180,9 +195,10 @@ def test_walk_enum(t : T?) {
     t |> run("first enum value") @(t : T?) {
         var walker = new LogWalker()
         var c : Color = Color.Red
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(c), typeinfo rtti_typeinfo(c))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(c), typeinfo rtti_typeinfo(c))
+            }
         }
         t |> equal(walker.log, "Enum:Color:0\n")
         unsafe { delete walker; }
@@ -195,9 +211,10 @@ def test_walk_bitfield(t : T?) {
     t |> run("bitfield with flags set") @(t : T?) {
         var walker = new LogWalker()
         var p : Permissions = Permissions.read | Permissions.execute
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(p), typeinfo rtti_typeinfo(p))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(p), typeinfo rtti_typeinfo(p))
+            }
         }
         // read=bit0 (1), execute=bit2 (4) → 5 = 0x5
         t |> equal(walker.log, "Bitfield:0x5\n")
@@ -206,9 +223,10 @@ def test_walk_bitfield(t : T?) {
     t |> run("empty bitfield") @(t : T?) {
         var walker = new LogWalker()
         var p : Permissions
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(p), typeinfo rtti_typeinfo(p))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(p), typeinfo rtti_typeinfo(p))
+            }
         }
         t |> equal(walker.log, "Bitfield:0x0\n")
         unsafe { delete walker; }

--- a/tests/data_walker/test_walk_structs.das
+++ b/tests/data_walker/test_walk_structs.das
@@ -15,9 +15,10 @@ def test_walk_struct(t : T?) {
     t |> run("simple struct") @(t : T?) {
         var walker = new LogWalker()
         var s = SimpleStruct(x = 10, y = 2.5)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
         }
         var expected = "beforeStruct:SimpleStruct\n"
         expected += "beforeField:x:false\n"
@@ -33,9 +34,10 @@ def test_walk_struct(t : T?) {
     t |> run("nested struct") @(t : T?) {
         var walker = new LogWalker()
         var s = NestedStruct(inner = SimpleStruct(x = 1, y = 2.0), tag = "test")
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
         }
         // Should see: NestedStruct → inner(SimpleStruct → x, y) → tag
         t |> equal(find(walker.log, "beforeStruct:NestedStruct") != -1, true)
@@ -49,9 +51,10 @@ def test_walk_struct(t : T?) {
         // ManyFields has 4 fields — only the last should have last=true
         var walker = new LogWalker()
         var s = ManyFields(a = 1, b = 2, c = 3, d = 4)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
         }
         t |> equal(find(walker.log, "beforeField:a:false") != -1, true)
         t |> equal(find(walker.log, "beforeField:b:false") != -1, true)
@@ -67,9 +70,10 @@ def test_walk_class(t : T?) {
     t |> run("base class") @(t : T?) {
         var walker = new LogWalker()
         var a = new Animal(name = "cat")
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(a), typeinfo rtti_typeinfo(a))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(a), typeinfo rtti_typeinfo(a))
+            }
         }
         // Walking a class pointer: beforePtr → beforeStruct:Animal → field:name → afterStruct → afterPtr
         t |> equal(find(walker.log, "beforeStruct:Animal") != -1, true)
@@ -79,9 +83,10 @@ def test_walk_class(t : T?) {
     t |> run("derived class") @(t : T?) {
         var walker = new LogWalker()
         var d = new Dog(name = "Rex", breed = "Shepherd")
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(d), typeinfo rtti_typeinfo(d))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(d), typeinfo rtti_typeinfo(d))
+            }
         }
         // Derived class should walk Dog fields including breed
         t |> equal(find(walker.log, "beforeStruct:Dog") != -1, true)
@@ -110,9 +115,10 @@ def test_walk_all_scalars_in_struct(t : T?) {
             i64 = 100l,
             u64 = 200ul
         )
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
         }
         // Verify all scalar callbacks fired
         t |> equal(find(walker.log, "Bool:true") != -1, true)
@@ -142,9 +148,10 @@ def test_walk_vectors_in_struct(t : T?) {
             v4 = float4(6.0, 7.0, 8.0, 9.0),
             r = range(10, 20)
         )
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
         }
         t |> equal(find(walker.log, "Float2:") != -1, true)
         t |> equal(find(walker.log, "Float3:") != -1, true)

--- a/tests/data_walker/test_walk_tuples_variants.das
+++ b/tests/data_walker/test_walk_tuples_variants.das
@@ -14,9 +14,10 @@ def test_walk_tuple(t : T?) {
     t |> run("int-string tuple") @(t : T?) {
         var walker = new LogWalker()
         var tup : tuple<int; string> = (42, "hello")
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(tup), typeinfo rtti_typeinfo(tup))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(tup), typeinfo rtti_typeinfo(tup))
+            }
         }
         var expected = "beforeTuple\n"
         expected += "beforeTupleEntry:0:false\n"
@@ -32,9 +33,10 @@ def test_walk_tuple(t : T?) {
     t |> run("3-element tuple") @(t : T?) {
         var walker = new LogWalker()
         var tup : tuple<int; float; bool> = (1, 2.0, true)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(tup), typeinfo rtti_typeinfo(tup))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(tup), typeinfo rtti_typeinfo(tup))
+            }
         }
         // Middle element should not be last
         t |> equal(find(walker.log, "beforeTupleEntry:1:false") != -1, true)
@@ -50,9 +52,10 @@ def test_walk_variant(t : T?) {
     t |> run("variant int alternative") @(t : T?) {
         var walker = new LogWalker()
         var v : MyVariant = MyVariant(i = 42)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(find(walker.log, "beforeVariant") != -1, true)
         t |> equal(find(walker.log, "Int:42") != -1, true)
@@ -65,9 +68,10 @@ def test_walk_variant(t : T?) {
     t |> run("variant string alternative") @(t : T?) {
         var walker = new LogWalker()
         var v : MyVariant = MyVariant(s = "hello")
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(find(walker.log, "beforeVariant") != -1, true)
         t |> equal(find(walker.log, "String:hello") != -1, true)
@@ -78,9 +82,10 @@ def test_walk_variant(t : T?) {
     t |> run("variant float alternative") @(t : T?) {
         var walker = new LogWalker()
         var v : MyVariant = MyVariant(f = 9.5)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(find(walker.log, "Float:9.5") != -1, true)
         unsafe { delete walker; }

--- a/tests/data_walker/test_walk_vectors_ranges.das
+++ b/tests/data_walker/test_walk_vectors_ranges.das
@@ -14,9 +14,10 @@ def test_walk_vectors(t : T?) {
     t |> run("int2") @(t : T?) {
         var walker = new LogWalker()
         var v = int2(10, 20)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(walker.log, "Int2:{v}\n")
         unsafe { delete walker; }
@@ -24,9 +25,10 @@ def test_walk_vectors(t : T?) {
     t |> run("int3") @(t : T?) {
         var walker = new LogWalker()
         var v = int3(1, 2, 3)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(walker.log, "Int3:{v}\n")
         unsafe { delete walker; }
@@ -34,9 +36,10 @@ def test_walk_vectors(t : T?) {
     t |> run("int4") @(t : T?) {
         var walker = new LogWalker()
         var v = int4(1, 2, 3, 4)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(walker.log, "Int4:{v}\n")
         unsafe { delete walker; }
@@ -44,9 +47,10 @@ def test_walk_vectors(t : T?) {
     t |> run("float2") @(t : T?) {
         var walker = new LogWalker()
         var v = float2(1.5, 2.5)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(walker.log, "Float2:{v}\n")
         unsafe { delete walker; }
@@ -54,9 +58,10 @@ def test_walk_vectors(t : T?) {
     t |> run("float3") @(t : T?) {
         var walker = new LogWalker()
         var v = float3(1.0, 2.0, 3.0)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(walker.log, "Float3:{v}\n")
         unsafe { delete walker; }
@@ -64,9 +69,10 @@ def test_walk_vectors(t : T?) {
     t |> run("float4") @(t : T?) {
         var walker = new LogWalker()
         var v = float4(1.0, 2.0, 3.0, 4.0)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(walker.log, "Float4:{v}\n")
         unsafe { delete walker; }
@@ -74,9 +80,10 @@ def test_walk_vectors(t : T?) {
     t |> run("uint2") @(t : T?) {
         var walker = new LogWalker()
         var v = uint2(1u, 2u)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(walker.log, "UInt2:{v}\n")
         unsafe { delete walker; }
@@ -84,9 +91,10 @@ def test_walk_vectors(t : T?) {
     t |> run("uint3") @(t : T?) {
         var walker = new LogWalker()
         var v = uint3(1u, 2u, 3u)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(walker.log, "UInt3:{v}\n")
         unsafe { delete walker; }
@@ -94,9 +102,10 @@ def test_walk_vectors(t : T?) {
     t |> run("uint4") @(t : T?) {
         var walker = new LogWalker()
         var v = uint4(1u, 2u, 3u, 4u)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(v), typeinfo rtti_typeinfo(v))
+            }
         }
         t |> equal(walker.log, "UInt4:{v}\n")
         unsafe { delete walker; }
@@ -109,9 +118,10 @@ def test_walk_ranges(t : T?) {
     t |> run("range") @(t : T?) {
         var walker = new LogWalker()
         var r = range(0, 10)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(r), typeinfo rtti_typeinfo(r))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(r), typeinfo rtti_typeinfo(r))
+            }
         }
         t |> equal(walker.log, "Range:{r}\n")
         unsafe { delete walker; }
@@ -119,9 +129,10 @@ def test_walk_ranges(t : T?) {
     t |> run("urange") @(t : T?) {
         var walker = new LogWalker()
         var r = urange(5u, 15u)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(r), typeinfo rtti_typeinfo(r))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(r), typeinfo rtti_typeinfo(r))
+            }
         }
         t |> equal(walker.log, "URange:{r}\n")
         unsafe { delete walker; }
@@ -129,9 +140,10 @@ def test_walk_ranges(t : T?) {
     t |> run("range64") @(t : T?) {
         var walker = new LogWalker()
         var r = range64(0l, 100l)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(r), typeinfo rtti_typeinfo(r))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(r), typeinfo rtti_typeinfo(r))
+            }
         }
         t |> equal(walker.log, "Range64:{r}\n")
         unsafe { delete walker; }
@@ -139,9 +151,10 @@ def test_walk_ranges(t : T?) {
     t |> run("urange64") @(t : T?) {
         var walker = new LogWalker()
         var r = urange64(10ul, 20ul)
-        var inscope adapter <- make_data_walker(walker)
-        unsafe {
-            adapter |> walk_data(addr(r), typeinfo rtti_typeinfo(r))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(r), typeinfo rtti_typeinfo(r))
+            }
         }
         t |> equal(walker.log, "URange64:{r}\n")
         unsafe { delete walker; }

--- a/tutorials/language/47_data_walker.das
+++ b/tutorials/language/47_data_walker.das
@@ -18,7 +18,7 @@
 //   - Override before/after callbacks for containers (structures, arrays, etc.)
 //   - All canVisit methods default to true — override to prune traversal
 //   - Scalar callbacks receive mutable references — values can be modified
-//   - walk_data takes a smart_ptr<DataWalker> adapter, a data pointer, and TypeInfo
+//   - walk_data takes a DataWalker? adapter, a data pointer, and TypeInfo
 //
 // Run: daslang.exe tutorials/language/47_data_walker.das
 
@@ -58,32 +58,32 @@ def demo_scalar_types() {
 
     // Step 1: create the walker and its adapter
     var walker = new ScalarPrinter()
-    var inscope adapter <- make_data_walker(walker)
+    make_data_walker(walker) $(adapter) {
+        // Step 2: walk various scalar values
+        // typeinfo rtti_typeinfo(var) returns the TypeInfo for any variable
+        var x = 42
+        print("Walking int 42:\n")
+        unsafe {
+            adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
+        }
 
-    // Step 2: walk various scalar values
-    // typeinfo rtti_typeinfo(var) returns the TypeInfo for any variable
-    var x = 42
-    print("Walking int 42:\n")
-    unsafe {
-        adapter |> walk_data(addr(x), typeinfo rtti_typeinfo(x))
-    }
+        var f = 3.14
+        print("Walking float 3.14:\n")
+        unsafe {
+            adapter |> walk_data(addr(f), typeinfo rtti_typeinfo(f))
+        }
 
-    var f = 3.14
-    print("Walking float 3.14:\n")
-    unsafe {
-        adapter |> walk_data(addr(f), typeinfo rtti_typeinfo(f))
-    }
+        var s = "hello"
+        print("Walking string \"hello\":\n")
+        unsafe {
+            adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+        }
 
-    var s = "hello"
-    print("Walking string \"hello\":\n")
-    unsafe {
-        adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
-    }
-
-    var b = true
-    print("Walking bool true:\n")
-    unsafe {
-        adapter |> walk_data(addr(b), typeinfo rtti_typeinfo(b))
+        var b = true
+        print("Walking bool true:\n")
+        unsafe {
+            adapter |> walk_data(addr(b), typeinfo rtti_typeinfo(b))
+        }
     }
 
     unsafe {
@@ -159,12 +159,12 @@ def demo_structures() {
     print("\n=== Section 2: Structures ===\n")
 
     var walker = new StructPrinter()
-    var inscope adapter <- make_data_walker(walker)
-
-    var player = Player(name = "Alice", health = 100, pos = Vec3(x = 1.0, y = 2.5, z = -3.0))
-    print("Walking Player:\n")
-    unsafe {
-        adapter |> walk_data(addr(player), typeinfo rtti_typeinfo(player))
+    make_data_walker(walker) $(adapter) {
+        var player = Player(name = "Alice", health = 100, pos = Vec3(x = 1.0, y = 2.5, z = -3.0))
+        print("Walking Player:\n")
+        unsafe {
+            adapter |> walk_data(addr(player), typeinfo rtti_typeinfo(player))
+        }
     }
 
     unsafe {
@@ -255,21 +255,21 @@ def demo_arrays_and_tables() {
     print("\n=== Section 3: Arrays and tables ===\n")
 
     var walker = new ContainerPrinter()
-    var inscope adapter <- make_data_walker(walker)
+    make_data_walker(walker) $(adapter) {
+        var nums = [10, 20, 30, 40, 50]
+        print("Walking array<int>:\n")
+        unsafe {
+            adapter |> walk_data(addr(nums), typeinfo rtti_typeinfo(nums))
+        }
 
-    var nums = [10, 20, 30, 40, 50]
-    print("Walking array<int>:\n")
-    unsafe {
-        adapter |> walk_data(addr(nums), typeinfo rtti_typeinfo(nums))
-    }
-
-    var scores : table<string; int>
-    scores |> insert("Alice", 95)
-    scores |> insert("Bob", 87)
-    scores |> insert("Charlie", 72)
-    print("\nWalking table<string;int>:\n")
-    unsafe {
-        adapter |> walk_data(addr(scores), typeinfo rtti_typeinfo(scores))
+        var scores : table<string; int>
+        scores |> insert("Alice", 95)
+        scores |> insert("Bob", 87)
+        scores |> insert("Charlie", 72)
+        print("\nWalking table<string;int>:\n")
+        unsafe {
+            adapter |> walk_data(addr(scores), typeinfo rtti_typeinfo(scores))
+        }
     }
 
     unsafe {
@@ -344,24 +344,24 @@ def demo_tuples_and_variants() {
     print("\n=== Section 4: Tuples and variants ===\n")
 
     var walker = new TupleVariantPrinter()
-    var inscope adapter <- make_data_walker(walker)
+    make_data_walker(walker) $(adapter) {
+        var t = ("hello", 42, 3.14)
+        print("Walking tuple<string;int;float>:\n")
+        unsafe {
+            adapter |> walk_data(addr(t), typeinfo rtti_typeinfo(t))
+        }
 
-    var t = ("hello", 42, 3.14)
-    print("Walking tuple<string;int;float>:\n")
-    unsafe {
-        adapter |> walk_data(addr(t), typeinfo rtti_typeinfo(t))
-    }
+        var ok_result = Result(ok = 42)
+        print("\nWalking variant (ok=42):\n")
+        unsafe {
+            adapter |> walk_data(addr(ok_result), typeinfo rtti_typeinfo(ok_result))
+        }
 
-    var ok_result = Result(ok = 42)
-    print("\nWalking variant (ok=42):\n")
-    unsafe {
-        adapter |> walk_data(addr(ok_result), typeinfo rtti_typeinfo(ok_result))
-    }
-
-    var err_result = Result(err = "not found")
-    print("\nWalking variant (err=\"not found\"):\n")
-    unsafe {
-        adapter |> walk_data(addr(err_result), typeinfo rtti_typeinfo(err_result))
+        var err_result = Result(err = "not found")
+        print("\nWalking variant (err=\"not found\"):\n")
+        unsafe {
+            adapter |> walk_data(addr(err_result), typeinfo rtti_typeinfo(err_result))
+        }
     }
 
     unsafe {
@@ -427,18 +427,18 @@ def demo_enums_and_bitfields() {
     print("\n=== Section 5: Enumerations and bitfields ===\n")
 
     var walker = new EnumBitfieldPrinter()
-    var inscope adapter <- make_data_walker(walker)
+    make_data_walker(walker) $(adapter) {
+        var color = Color.Green
+        print("Walking enum Color.Green:\n")
+        unsafe {
+            adapter |> walk_data(addr(color), typeinfo rtti_typeinfo(color))
+        }
 
-    var color = Color.Green
-    print("Walking enum Color.Green:\n")
-    unsafe {
-        adapter |> walk_data(addr(color), typeinfo rtti_typeinfo(color))
-    }
-
-    var perms : Permissions = Permissions.readable | Permissions.executable
-    print("Walking bitfield (readable | executable):\n")
-    unsafe {
-        adapter |> walk_data(addr(perms), typeinfo rtti_typeinfo(perms))
+        var perms : Permissions = Permissions.readable | Permissions.executable
+        print("Walking bitfield (readable | executable):\n")
+        unsafe {
+            adapter |> walk_data(addr(perms), typeinfo rtti_typeinfo(perms))
+        }
     }
 
     unsafe {
@@ -631,12 +631,14 @@ class JsonWalker : DapiDataWalker {
 
 def to_json(var value; tinfo : TypeInfo) : string {
     var walker = new JsonWalker()
-    var inscope adapter <- make_data_walker(walker)
-    let res = build_string() $(var writer) {
-        unsafe {
-            walker.writer = addr(writer)
-            adapter |> walk_data(addr(value), tinfo)
-            walker.writer = null
+    var res : string
+    make_data_walker(walker) $(adapter) {
+        res = build_string() $(var writer) {
+            unsafe {
+                walker.writer = addr(writer)
+                adapter |> walk_data(addr(value), tinfo)
+                walker.writer = null
+            }
         }
     }
     unsafe {
@@ -731,17 +733,17 @@ def demo_filtering() {
 
     var walker = new FilteringWalker()
     walker.skipStructName = "Secret"
-    var inscope adapter <- make_data_walker(walker)
+    make_data_walker(walker) $(adapter) {
+        var record = PublicRecord(
+            title = "Performance Review",
+            secret = Secret(classified = "top-secret", code = 42),
+            score = 95
+        )
 
-    var record = PublicRecord(
-        title = "Performance Review",
-        secret = Secret(classified = "top-secret", code = 42),
-        score = 95
-    )
-
-    print("Walking PublicRecord (Secret fields skipped):\n")
-    unsafe {
-        adapter |> walk_data(addr(record), typeinfo rtti_typeinfo(record))
+        print("Walking PublicRecord (Secret fields skipped):\n")
+        unsafe {
+            adapter |> walk_data(addr(record), typeinfo rtti_typeinfo(record))
+        }
     }
 
     unsafe {
@@ -786,10 +788,10 @@ def demo_mutation() {
     print("Before clamping: x={particle.x} y={particle.y} z={particle.z} alpha={particle.alpha}\n")
 
     var walker = new FloatClamper()
-    var inscope adapter <- make_data_walker(walker)
-
-    unsafe {
-        adapter |> walk_data(addr(particle), typeinfo rtti_typeinfo(particle))
+    make_data_walker(walker) $(adapter) {
+        unsafe {
+            adapter |> walk_data(addr(particle), typeinfo rtti_typeinfo(particle))
+        }
     }
 
     print("After clamping:  x={particle.x} y={particle.y} z={particle.z} alpha={particle.alpha}\n")


### PR DESCRIPTION
## Summary

- **DataWalker** and **StackWalker**: converted from `smart_ptr<T>` factory pattern to block-argument pattern (like `make_visitor`) — adapter is created, passed to a block, and deleted automatically
- **NetworkServer**: converted from `smart_ptr<Server>` / `smart_ptr_raw<Server>` to raw `Server*` throughout C++ bindings and daScript wrapper
- **DebugInfoHelper**: converted from `smart_ptr<DebugInfoHelper>` to raw `DebugInfoHelper*` in all C++ bindings; added missing `operator delete` to `AotDebugInfoHelper`
- Removed `ptr_ref_count` base class from `Server` and `DebugInfoHelper` (no longer needed)
- Updated all usage sites: daslib modules, tutorials, tests, examples, documentation

## Test plan

- [x] Lint: 0 issues on all changed `.das` files
- [x] Tests: 6040/6040 passed, 0 GC leaks
- [x] AOT: test_aot built and 5455/5455 passed
- [x] Tutorial `47_data_walker.das` runs correctly
- [x] Documentation: das2rst, stubs filled, Sphinx build succeeded with 0 warnings