### PR TITLE
smart_ptr: always-on tracking with linked list, remove debug macros

### DIFF
--- a/CMakeCommon.txt
+++ b/CMakeCommon.txt
@@ -114,7 +114,6 @@ MACRO(SETUP_LIB_DEFINITIONS _target)
         $<$<CONFIG:Release>:DAS_FUSION=2 DAS_DEBUGGER=0>
         $<$<CONFIG:MinSizeRel>:DAS_FUSION=1 DAS_DEBUGGER=0>
         $<$<CONFIG:RelWithDebInfo>:DAS_FUSION=1>
-        $<$<CONFIG:RelWithDebInfo>:DAS_SMART_PTR_DEBUG=1>
     )
 ENDMACRO()
 

--- a/doc/source/reference/tutorials/47_data_walker.rst
+++ b/doc/source/reference/tutorials/47_data_walker.rst
@@ -405,7 +405,7 @@ Quick reference
 
 =================================================  ====================================================
 ``DapiDataWalker``                                 Base class — subclass and override callbacks
-``make_data_walker(walker)``                       Wrap class instance into ``smart_ptr<DataWalker>``
+``make_data_walker(walker)``                       Wrap class instance into ``DataWalker?``
 ``walk_data(adapter, ptr, typeinfo)``              Walk data at ``ptr`` using RTTI ``TypeInfo``
 ``typeinfo rtti_typeinfo(var)``                    Get ``TypeInfo`` for any variable (compile-time)
 ``unsafe { addr(var) }``                           Get ``void?`` pointer to a variable

--- a/doc/source/stdlib/handmade/function-debugapi-make_data_walker-0x41799332b5e2293f.rst
+++ b/doc/source/stdlib/handmade/function-debugapi-make_data_walker-0x41799332b5e2293f.rst
@@ -1,1 +1,1 @@
-Wraps a `DapiDataWalker` class pointer into a `smart_ptr<DataWalker>` for use with `walk_data`.
+Wraps a `DapiDataWalker` class pointer into a `DataWalker?` for use with `walk_data`.

--- a/doc/source/stdlib/handmade/function-debugapi-make_data_walker-0xab9be4d0d66ab7a6.rst
+++ b/doc/source/stdlib/handmade/function-debugapi-make_data_walker-0xab9be4d0d66ab7a6.rst
@@ -1,1 +1,1 @@
-Wraps a `DapiDataWalker` class pointer into a `smart_ptr<DataWalker>` for use with `walk_data`.
+Wraps a `DapiDataWalker` class pointer into a `DataWalker?` for use with `walk_data`.

--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -465,27 +465,6 @@ private:
     #endif
 #endif
 
-#if DAS_SMART_PTR_DEBUG==1
-    #define DAS_SMART_PTR_TRACKER   1
-    #define DAS_SMART_PTR_MAGIC     1
-    #define DAS_SMART_PTR_ID        1
-#endif
-
-#ifndef DAS_SMART_PTR_TRACKER
-    #ifdef DAS_NO_ASSERTIONS
-        #define DAS_SMART_PTR_TRACKER   0
-    #else
-        #define DAS_SMART_PTR_TRACKER   1
-    #endif
-#endif
-
-#ifndef DAS_SMART_PTR_MAGIC
-    #ifdef DAS_NO_ASSERTIONS
-        #define DAS_SMART_PTR_MAGIC     0
-    #else
-        #define DAS_SMART_PTR_MAGIC     1
-    #endif
-#endif
 
 // if -funsafe-math-optimizations or -freciprocal-math is used, this flat needs to be 0
 // unfortunately, it's not possible to detect this flag in the preprocessor

--- a/include/daScript/misc/smart_ptr.h
+++ b/include/daScript/misc/smart_ptr.h
@@ -1,19 +1,6 @@
 #pragma once
 
-#ifndef DAS_SMART_PTR_ID
-#define DAS_SMART_PTR_ID    0
-#endif
-
-#if DAS_SMART_PTR_TRACKER
 #include <atomic>
-#endif
-
-// when enabled, smart_ptr will keep allocated memory after delete
-// that way ID of the broken object does not get overwritten
-// this is useful for debugging, but it is not a good idea to use it in production
-#ifndef DAS_SMART_PTR_BROKEN
-#define DAS_SMART_PTR_BROKEN 0
-#endif
 
 DAS_API void os_debug_break();
 
@@ -332,46 +319,44 @@ namespace das {
         return reinterpret_cast<T *>(r.get());
     }
 
-#if DAS_SMART_PTR_ID
     #define DAS_NEW_SMART_PTR_ID \
     { \
         lock_guard<mutex> guard(ref_count_mutex); \
         ref_count_id = ++ref_count_total; \
-        ref_count_ids.insert(ref_count_id); \
+        ref_count_next = ref_count_head; \
+        ref_count_prev = nullptr; \
+        if (ref_count_head) ref_count_head->ref_count_prev = this; \
+        ref_count_head = this; \
     }
     #define DAS_DELETE_SMART_PTR_ID \
     { \
         lock_guard<mutex> guard(ref_count_mutex); \
-        ref_count_ids.erase(ref_count_id); \
+        if (ref_count_prev) ref_count_prev->ref_count_next = ref_count_next; \
+        else ref_count_head = ref_count_next; \
+        if (ref_count_next) ref_count_next->ref_count_prev = ref_count_prev; \
     }
     #define DAS_TRACK_SMART_PTR_ID         if ( ref_count_id==ref_count_track ) os_debug_break();
     #define DAS_TRACK_SMART_PTR_ID_DTOR    if ( ref_count_id==ref_count_track_destructor ) os_debug_break();
-#else
-    #define DAS_NEW_SMART_PTR_ID
-    #define DAS_TRACK_SMART_PTR_ID
-    #define DAS_TRACK_SMART_PTR_ID_DTOR
-    #define DAS_DELETE_SMART_PTR_ID
-#endif
 
-#if DAS_SMART_PTR_TRACKER
     DAS_API extern atomic<uint64_t> g_smart_ptr_total;
     #define DAS_SMART_PTR_NEW     g_smart_ptr_total++;
     #define DAS_SMART_PTR_DELETE  g_smart_ptr_total--;
-#else
-    #define DAS_SMART_PTR_NEW
-    #define DAS_SMART_PTR_DELETE
-#endif
 
     class DAS_API ptr_ref_count {
     public:
-#if DAS_SMART_PTR_ID
         uint64_t                    ref_count_id;
+        ptr_ref_count *             ref_count_next = nullptr;
+        ptr_ref_count *             ref_count_prev = nullptr;
+        uint32_t                    ref_count_magic = 0;
         static uint64_t             ref_count_total;
         static uint64_t             ref_count_track;
         static uint64_t             ref_count_track_destructor;
-        static das_set<uint64_t>    ref_count_ids;
+        static ptr_ref_count *      ref_count_head;
         static mutex                ref_count_mutex;
-#endif
+        static constexpr uint32_t   TRACK_PTR_CONTEXT     = 0xDA5C7801;
+        static constexpr uint32_t   TRACK_PTR_PROGRAM     = 0xDA5C7802;
+        static constexpr uint32_t   TRACK_PTR_FILE_ACCESS = 0xDA5C7803;
+        static void DumpTrackPtr();
     public:
         __forceinline ptr_ref_count () {
             DAS_NEW_SMART_PTR_ID
@@ -391,43 +376,27 @@ namespace das {
         __forceinline ptr_ref_count & operator = ( const ptr_ref_count & ) { return *this;}
         __forceinline ptr_ref_count & operator = ( ptr_ref_count && ) { return *this; }
         virtual ~ptr_ref_count() {
-#if DAS_SMART_PTR_MAGIC
             if ( ref_count!=0 ) DAS_FATAL_ERROR("%p ref_count=%i, can't delete", (void *)this, ref_count);
             if ( magic!=0x1ee7c0de ) DAS_FATAL_ERROR("%p magic=%08x, object was deleted or corrupted", (void *)this, magic);
             magic = 0xdeadbeef;
-#else
-            DAS_ASSERTF(ref_count == 0, "can only delete when ref_count==0");
-#endif
             DAS_DELETE_SMART_PTR_ID
             DAS_SMART_PTR_DELETE
         }
         __forceinline void addRef() {
             DAS_TRACK_SMART_PTR_ID
             ref_count ++;
-#if DAS_SMART_PTR_MAGIC
             if ( ref_count==0 || magic!=0x1ee7c0de ) {
                 DAS_FATAL_ERROR("%p ref_count=%i, magic=%08x, object was deleted or corrupted", (void *)this, ref_count, magic);
             }
-#else
-            DAS_ASSERTF(ref_count, "ref_count overflow");
-#endif
         }
         __forceinline bool delRef() {
             DAS_TRACK_SMART_PTR_ID
-#if DAS_SMART_PTR_MAGIC
             if ( ref_count==0 || magic!=0x1ee7c0de ) {
                 DAS_FATAL_ERROR("%p ref_count=%i, magic=%08x, object was deleted or corrupted", (void *)this, ref_count, magic);
             }
-#else
-            DAS_ASSERTF(ref_count, "deleting reference on the object with ref_count==0");
-#endif
             if ( --ref_count==0 ) {
                 DAS_TRACK_SMART_PTR_ID_DTOR
-#if DAS_SMART_PTR_BROKEN
-                this->~ptr_ref_count(); // call destructor, but don't release memory
-#else
                 delete this;
-#endif
                 return true;
             } else {
                 return false;
@@ -437,17 +406,11 @@ namespace das {
             return ref_count;
         }
         __forceinline bool is_valid() const {
-#if DAS_SMART_PTR_MAGIC
             return magic==0x1ee7c0de && ref_count!=0;
-#else
-            return ref_count!=0;
-#endif
         }
         void serialize ( AstSerializer & ser );
     private:
-#if DAS_SMART_PTR_MAGIC
         unsigned int magic = 0x1ee7c0de;
-#endif
         unsigned int ref_count = 0;
     };
 

--- a/include/daScript/simulate/debug_info.h
+++ b/include/daScript/simulate/debug_info.h
@@ -193,7 +193,7 @@ namespace das
     typedef smart_ptr<class FileAccess> FileAccessPtr;
     class DAS_API FileAccess : public ptr_ref_count {
     public:
-        FileAccess() {}
+        FileAccess() { ref_count_magic = TRACK_PTR_FILE_ACCESS; }
         virtual ~FileAccess() {}
 
         FileAccess& operator=(const FileAccess&) = delete;

--- a/include/daScript/simulate/debug_print.h
+++ b/include/daScript/simulate/debug_print.h
@@ -228,12 +228,8 @@ namespace das {
                 ss << "(" << debug_type(ti) << " 0x" << HEX << intptr_t(*(char**)pa) << DEC;
                 if ( ti->flags & TypeInfo::flag_isSmartPtr ) {
                     if ( ptr_ref_count * ps = *(ptr_ref_count**)pa) {
-#if DAS_SMART_PTR_ID
                         ss << " smart_ptr(" << int32_t(ps->use_count())
                             << ",id=" << HEX << ps->ref_count_id << DEC << ") = ";
-#else
-                        ss << " smart_ptr(" << int32_t(ps->use_count()) << ") = ";
-#endif
                     } else {
                         ss << " smart_ptr = ";
                     }

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -20,10 +20,6 @@ namespace das
 
     #define DAS_CALL_METHOD(mname)              DAS_BIND_FUN(mname::invoke)
 
-    #ifndef DAS_ENABLE_SMART_PTR_TRACKING
-    #define DAS_ENABLE_SMART_PTR_TRACKING   0
-    #endif
-
     #ifndef DAS_ENABLE_STACK_WALK
     #define DAS_ENABLE_STACK_WALK   1
     #endif
@@ -299,7 +295,6 @@ namespace das
 
     void dapiStackWalk ( StackWalkerPtr walker, Context & context, const LineInfo & at );
     int32_t dapiStackDepth ( Context & context );
-    void dumpTrackingLeaks();
     void dapiReportContextState ( Context & ctx, const char * category, const char * name, const TypeInfo * info, void * data );
     void dapiSimulateContext ( Context & ctx );
     void dapiUserCommand ( const char * command );
@@ -883,9 +878,6 @@ namespace das
     public:
         int32_t         fnDepth = 0;
     public:
-#if DAS_ENABLE_SMART_PTR_TRACKING
-        static vector<smart_ptr<ptr_ref_count>> sptrAllocations;
-#endif
         // It's better to use shared memory + finalize for things like this.
         struct JitContext {
             void *shared_lib;

--- a/include/daScript/simulate/simulate_nodes.h
+++ b/include/daScript/simulate/simulate_nodes.h
@@ -554,9 +554,6 @@ namespace das {
             DAS_PROFILE_NODE
             auto res = new TT();
             res->addRef();
-#if DAS_ENABLE_SMART_PTR_TRACKING
-            Context::sptrAllocations.push_back(res);
-#endif
             return (char *) res;
         }
         virtual SimNode * visit ( SimVisitor & vis ) override;

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -3038,6 +3038,7 @@ namespace das {
     }
 
     Program::Program() {
+        ref_count_magic = TRACK_PTR_PROGRAM;
         thisModule = make_unique<ModuleDas>();
         library.addBuiltInModule();
         library.addModule(thisModule.get());

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -739,13 +739,7 @@ namespace das {
 
     template <typename F>
     static auto apply_to_vec(void* vec, string_view tstr, F apply) {
-        if (tstr == "smart_ptr<ast::Expression>") {
-            return apply(static_cast<vector<Expression *>*>(vec));
-        } else if (tstr == "smart_ptr<ast::Variable>") {
-            return apply(static_cast<vector<Variable *>*>(vec));
-        } else if (tstr == "smart_ptr<ast::TypeDecl>") {
-            return apply(static_cast<vector<TypeDecl *>*>(vec));
-        } else if (tstr == "string") {
+        if (tstr == "string") {
             return apply(static_cast<vector<const char *>*>(vec));
         } else if (tstr == "$::das_string") {
             return apply(static_cast<vector<string>*>(vec));
@@ -757,8 +751,6 @@ namespace das {
             return apply(static_cast<vector<uint8_t>*>(vec));
         } else if (tstr == "tuple<uint;uint>") {
             return apply(static_cast<vector<pair<unsigned int, unsigned int>>*>(vec));
-        } else if (tstr == "smart_ptr<rtti::AnnotationDeclaration>") {
-            return apply(static_cast<vector<smart_ptr<AnnotationDeclaration>>*>(vec));
         } else if (tstr == "rtti_core::AnnotationArgument") {
             return apply(static_cast<vector<AnnotationArgument>*>(vec));
         } else if (tstr == "rtti_core::LineInfo") {

--- a/src/hal/debug_break.cpp
+++ b/src/hal/debug_break.cpp
@@ -4,17 +4,13 @@
 
 #include <signal.h>
 
-#if DAS_SMART_PTR_ID
-    uint64_t das::ptr_ref_count::ref_count_total = 0;
-    uint64_t das::ptr_ref_count::ref_count_track = 0;
-    uint64_t das::ptr_ref_count::ref_count_track_destructor = 0;
-    das::das_set<uint64_t> das::ptr_ref_count::ref_count_ids;
-    das::mutex             das::ptr_ref_count::ref_count_mutex;
-#endif
+uint64_t               das::ptr_ref_count::ref_count_total = 0;
+uint64_t               das::ptr_ref_count::ref_count_track = 0;
+uint64_t               das::ptr_ref_count::ref_count_track_destructor = 0;
+das::ptr_ref_count *   das::ptr_ref_count::ref_count_head = nullptr;
+das::mutex             das::ptr_ref_count::ref_count_mutex;
 
-#if DAS_SMART_PTR_TRACKER
-    DAS_API das::atomic<uint64_t> das::g_smart_ptr_total {0};
-#endif
+DAS_API das::atomic<uint64_t> das::g_smart_ptr_total {0};
 
 DAS_API void os_debug_break()
 {

--- a/src/simulate/simulate.cpp
+++ b/src/simulate/simulate.cpp
@@ -967,6 +967,7 @@ namespace das
     }
 
     Context::Context(uint32_t stackSize, bool ph) : stack(stackSize) {
+        ref_count_magic = TRACK_PTR_CONTEXT;
         code = make_shared<NodeAllocator>();
         constStringHeap = make_shared<ConstStringAllocator>();
         debugInfo = make_shared<DebugInfoAllocator>();
@@ -1177,6 +1178,7 @@ namespace das
 
     Context::Context(const Context & ctx, const CopyOptions & opts)
         : stack(opts.stackSize ? opts.stackSize : ctx.stack.size()) {
+        ref_count_magic = TRACK_PTR_CONTEXT;
         verySafeContext = ctx.verySafeContext;
         persistent = ctx.persistent;
         gcEnabled = ctx.gcEnabled;

--- a/src/simulate/simulate_tracking.cpp
+++ b/src/simulate/simulate_tracking.cpp
@@ -2,101 +2,34 @@
 
 #include "daScript/ast/ast.h"
 #include "daScript/ast/ast_expressions.h"
+#include "daScript/simulate/simulate.h"
 
 namespace das
 {
-#if DAS_ENABLE_SMART_PTR_TRACKING
-    vector<smart_ptr<ptr_ref_count>> Context::sptrAllocations;
-#endif
-
     string around ( const LineInfo & info ) {
         TextWriter tw;
         tw << ":" << info.line << ":" << info.column;
         return tw.str();
     }
 
-#if DAS_ENABLE_SMART_PTR_TRACKING
-    void safeDumpType ( TextWriter & tp, const TypeDeclPtr & td ) {
-        if ( td->baseType==Type::tStructure ) {
-            tp << "structure";
-        } else if ( td->baseType==Type::tHandle ) {
-            tp << "handle";
-        } else if ( td->baseType==Type::tPointer ) {
-            if ( td->firstType ) {
-                safeDumpType(tp,td->firstType);
-                tp << "?";
-            } else {
-                tp << "void?";
-            }
-        } else if ( td->baseType==Type::tTuple || td->baseType==Type::tVariant ) {
-            tp << das_to_string(td->baseType) << "<";
-            for ( auto & st : td->argTypes ) {
-                safeDumpType(tp, st);
-                if ( st != td->argTypes.back() ) tp << ";";
-            }
-            tp << ">";
-        } else {
-            tp << das_to_string(td->baseType);
-        }
-        for ( auto i : td->dim ) {
-            tp << "[" << i << "]";
-        }
-        if ( td->constant ) tp << " const";
-        if ( td->ref ) tp << " &";
-        if ( td->temporary ) tp << " #";
-    }
-#endif
-
-    void dumpTrackingLeaks ( ) {
-        LOG tp(LogLevel::debug);
-#if DAS_ENABLE_SMART_PTR_TRACKING
-        bool any = true;
-        tp << "cleaning up tracking...\n";
-        while ( any ) {
-            any = false;
-            for ( auto it = Context::sptrAllocations.begin(); it!=Context::sptrAllocations.end(); ) {
-                auto & ptr = *it;
-                if ( ptr->use_count()==1 ) {
-                    it = Context::sptrAllocations.erase(it);
-                    any = true;
-                } else {
-                    ++it;
-                }
-            }
-        }
+    void ptr_ref_count::DumpTrackPtr() {
+        lock_guard<mutex> guard(ref_count_mutex);
+        TextPrinter tp;
         int total = 0;
-        for ( auto & ptr : Context::sptrAllocations ) {
-            tp << "0x" << HEX << intptr_t(ptr.get()) << DEC << " (" << ptr->use_count() << ")";
-#if DAS_SMART_PTR_ID
-            tp << " id=" << HEX << ptr->ref_count_id << DEC;
-#endif
-            if ( auto td = dynamic_cast<TypeDecl *>(ptr.get()) ) {
-                tp << " TypeDecl at " << around(td->at) << " ";
-                safeDumpType(tp,td);
-            } else if ( auto ex = dynamic_cast<Expression *>(ptr.get()) ) {
-                tp << " " <<  ex->__rtti << " at " << around(ex->at);
-                if ( strcmp(ex->__rtti,"ExprConstString")==0 ) {
-                    auto excs = static_cast<ExprConstString *>(ex);
-                    tp << " \"" << excs->text << "\"";
-                } else if ( strcmp(ex->__rtti,"ExprField")==0 ) {
-                    auto exf = static_cast<ExprField *>(ex);
-                    tp << " ." << exf->field;
-                } else if ( strcmp(ex->__rtti,"ExprCall")==0 ) {
-                    auto exc = static_cast<ExprCall *>(ex);
-                    tp << " " << exc->name << "(with " << exc->arguments.size() << " arguments)";
-                }
-            } else if ( auto vp = dynamic_cast<Variable *>(ptr.get()) ) {
-                tp << " Variable " << vp->name << " at " << around(vp->at);
-            } else if ( auto fp = dynamic_cast<Function *>(ptr.get()) ) {
-                tp << " Function " << fp->name << " at " << around(fp->at);
+        for ( auto p = ref_count_head; p; p = p->ref_count_next ) {
+            tp << "0x" << HEX << intptr_t(p) << DEC
+               << " (rc=" << p->use_count() << ", id=" << HEX << p->ref_count_id << DEC << ")";
+            if ( p->ref_count_magic == TRACK_PTR_CONTEXT ) {
+                auto ctx = static_cast<Context*>(p);
+                tp << " Context " << ctx->name;
+            } else if ( p->ref_count_magic == TRACK_PTR_PROGRAM ) {
+                tp << " Program";
+            } else if ( p->ref_count_magic == TRACK_PTR_FILE_ACCESS ) {
+                tp << " FileAccess";
             }
             tp << "\n";
-            total ++;
+            total++;
         }
-        tp << "total " << total << " leaks\n";
-#else
-        tp << "smart_ptr tracking is disabled\n";
-#endif
+        if ( total ) tp << "total " << total << " tracked pointers\n";
     }
 }
-

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -515,9 +515,7 @@ void print_help() {
         << "    -dry-run    compile and simulate script without execution\n"
         << "    -compile-only compile script without simulation and execution\n"
         << "    -dasroot <path> set path to daslang root folder (with daslib)\n"
-#if DAS_SMART_PTR_ID
         << "    -track-smart-ptr <id> track smart pointer with id\n"
-#endif
         << "    -linear-stack-allocator  disable scoped stack allocator\n"
         << "    -das-wait-debugger wait for debugger to attach\n"
         << "    -das-profiler enable profiler\n"
@@ -539,9 +537,7 @@ void print_help() {
   #define MAIN_FUNC_NAME main
 #endif
 
-#if DAS_SMART_PTR_TRACKER
 #include <inttypes.h>
-#endif
 
 namespace das {
     extern AotListBase impl_aot_ast_boost;
@@ -709,7 +705,6 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
                     print_help();
                     return -1;
                 }
-#if DAS_SMART_PTR_ID
                 uint64_t id = 0;
                 if ( sscanf(argv[i+1], "%" PRIx64, &id)!=1 ) {
                     printf("expecting smart pointer id, got %s\n", argv[i+1]);
@@ -718,10 +713,6 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
                 ptr_ref_count::ref_count_track = id;
                 i += 1;
                 printf("tracking %" PRIx64 " aka %" PRIu64 "\n", id, id);
-#else
-                printf("smart ptr id tracking is disabled\n");
-                return -1;
-#endif
             } else if ( cmd=="-das-wait-debugger") {
                 debuggerRequired = true;
             } else if ( cmd=="-linear-stack-allocator") {
@@ -796,25 +787,12 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     // and done
     if ( pauseAfterDone ) getchar();
     Module::Shutdown();
-#if DAS_SMART_PTR_TRACKER
     if ( g_smart_ptr_total!=0 ) {
         TextPrinter tp;
         tp << "smart pointers leaked: " << uint64_t(g_smart_ptr_total) << "\n";
-#if DAS_SMART_PTR_ID
-        tp << "leaked ids:";
-        vector<uint64_t> ids;
-        for ( auto it : ptr_ref_count::ref_count_ids ) {
-            ids.push_back(it);
-        }
-        std::sort(ids.begin(), ids.end());
-        for ( auto it : ids ) {
-            tp << " " << HEX << it << DEC;
-        }
-        tp << "\n";
-#endif
+        ptr_ref_count::DumpTrackPtr();
         exit(1);
     }
-#endif
     return failedFiles;
 }
 


### PR DESCRIPTION
## Summary

- Remove `DAS_SMART_PTR_DEBUG`, `DAS_SMART_PTR_TRACKER`, `DAS_SMART_PTR_MAGIC`, `DAS_SMART_PTR_ID`, and `DAS_ENABLE_SMART_PTR_TRACKING` conditional compilation — all debug infrastructure is now always-on
- Replace `ref_count_ids` (`das_set<uint64_t>`) with intrusive doubly-linked list of all live `ptr_ref_count` objects
- Add `ref_count_magic` field for type identification (Context/Program/FileAccess) without `dynamic_cast`
- Add `DumpTrackPtr()` that walks the linked list at shutdown to report leaked pointers with type info
- Remove `safeDumpType`, `dumpTrackingLeaks`, `sptrAllocations` (dead tracking system)
- Doc fixes: `smart_ptr<DataWalker>` → `DataWalker?`
- Remove dead `smart_ptr<ast::*>` branches from `apply_to_vec`

## Test plan

- [x] 6040 tests passed (`dastest -- --test tests`)
- [x] 5455 AOT tests passed (`test_aot -use-aot`)
- [x] No `.das` files changed — lint/format N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)