### PR TITLE
JobStatus/Feature tracking, AtomicTT separation, strudel leak fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/style_lint.md` | Adding new style lint rules to `daslib/style_lint.das` |
 | `skills/gc_migration.md` | Migrating `.das` or C++ code from `smart_ptr<T>` to gc_node for AST types (TypeDecl, Expression, Function, Structure, Enumeration, Variable, MakeFieldDecl) |
 | `skills/version_update.md` | Bumping the daslang version number (all files that need updating) |
+| `skills/jobque_debugging.md` | Debugging Channel/LockBox/JobStatus/Feature leaks using the tracking system (`--track-job-status`, `DumpJobQueLeaks`, refcount tracing) |
 | `skills/make_pr.md` | Creating a pull request (lint, test, AOT build+test, format checklist) |
 
 Multiple skill files may apply to a single task. For example, creating a new daslib module requires reading `skills/das_formatting.md`, `skills/daslib_modules.md`, and possibly `skills/documentation_rst.md`.

--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -1641,7 +1641,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
         let inner_ann_name = bt == Type.tPointer && xtype.firstType != null && xtype.firstType.annotation != null ? string(xtype.firstType.annotation.name) : ""
         if (inner_ann_name == "TypeDecl" || inner_ann_name == "Expression") {
             if (inner_ann_name == "TypeDecl") {
-                // smart_ptr<TypeDecl> field — use generate_type_match
+                // TypeDecl? field — use generate_type_match
                 let pv = unsafe(reinterpret<TypeDeclPtr?> p8)
                 if (*pv != null) {
                     let child_td = *pv

--- a/examples/daStrudel/strudel_live/main.das
+++ b/examples/daStrudel/strudel_live/main.das
@@ -124,12 +124,14 @@ def cmd_strudel(input : JsonValue?) : JsonValue? {
     return JV("sent: {args.cmd}")
 }
 
+var asch : AudioSystemChannels
+
 // daslang-live mode
 [export]
 def init() {
     print("daStrudel live\n")
     if (get_audio_command_channel() == null) {
-        audio_system_create()
+        asch = audio_system_create()
     }
     load_samples()
     strudel_init(@@strudel_main)
@@ -143,7 +145,9 @@ def update() {
 
 [export]
 def shutdown() {
-    pass
+    print("Shutting down...\n")
+    strudel_shutdown()
+    audio_system_finalize(asch.command, asch.collect, asch.next_sid)
 }
 
 // standalone mode (daslang.exe)

--- a/examples/daStrudel/strudel_sf2_live/main.das
+++ b/examples/daStrudel/strudel_sf2_live/main.das
@@ -97,10 +97,12 @@ def cmd_unpause(input : JsonValue?) : JsonValue? {
 
 // --- daslang-live mode ---
 
+var asch : AudioSystemChannels
+
 [export]
 def init() {
     if (get_audio_command_channel() == null) {
-        audio_system_create()
+        asch = audio_system_create()
     }
     if (!strudel_has_sf2()) {
         let sf2_path = find_sf2()
@@ -123,7 +125,9 @@ def update() {
 
 [export]
 def shutdown() {
-    pass
+    print("Shutting down...\n")
+    strudel_shutdown()
+    audio_system_finalize(asch.command, asch.collect, asch.next_sid)
 }
 
 // --- standalone mode (daslang.exe) ---

--- a/examples/daStrudel/strudel_visualizer/main.das
+++ b/examples/daStrudel/strudel_visualizer/main.das
@@ -182,6 +182,8 @@ def cmd_debug(input : JsonValue?) : JsonValue? {
 
 // --- Lifecycle ---
 
+var asch : AudioSystemChannels
+
 [export]
 def init() {
     live_create_window("daStrudel Visualizer", 1280, 720)
@@ -197,7 +199,7 @@ def init() {
     upload_font_texture(font)
     // audio
     if (get_audio_command_channel() == null) {
-        audio_system_create()
+        asch = audio_system_create()
     }
     // load SF2 soundfont
     if (USE_SF2) {
@@ -407,6 +409,9 @@ def update() {
 
 [export]
 def shutdown() {
+    print("Shutting down...\n")
+    strudel_shutdown()
+    audio_system_finalize(asch.command, asch.collect, asch.next_sid)
     delete render_states
     delete audio_analyses
     delete drum_panel_states
@@ -417,11 +422,28 @@ def shutdown() {
 
 // --- Standalone mode ---
 
+var max_frame_limit = 0
+
+def parse_args() {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = to_int(args[i + 1])
+        }
+    }
+}
+
 [export]
 def main() {
+    parse_args()
     init()
+    var frame_count = 0
     while (!exit_requested()) {
         update()
+        frame_count ++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/examples/daslive/arcanoid/main.das
+++ b/examples/daslive/arcanoid/main.das
@@ -1312,12 +1312,14 @@ def draw_hud() {
 
 // --- Lifecycle ---
 
+var asch : AudioSystemChannels
+
 [export]
 def init() {
     live_create_window("Arcanoid", 1024, 768)
     create_gl_objects()
     if (!audio_initialized) {
-        audio_system_create()
+        asch = audio_system_create()
         audio_initialized = true
         init_audio_samples()
     }
@@ -1488,16 +1490,35 @@ def update() {
 
 [export]
 def shutdown() {
+    print("Shutting down...\n")
     strudel_shutdown()
+    audio_system_finalize(asch.command, asch.collect, asch.next_sid)
     delete_gl_objects()
     live_destroy_window()
 }
 
+var max_frame_limit = 0
+
+def parse_args() {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = to_int(args[i + 1])
+        }
+    }
+}
+
 [export]
 def main() {
+    parse_args()
     init()
+    var frame_count = 0
     while (!exit_requested()) {
         update()
+        frame_count ++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/include/daScript/ast/ast_visitor.h
+++ b/include/daScript/ast/ast_visitor.h
@@ -341,8 +341,8 @@ namespace das {
             : PassVisitor(round), ctx(prog->getContextStackSize()), helper(ctx.debugInfo) {
             ctx.thisProgram = prog.get();
             ctx.thisHelper = &helper;
-            ctx.heap = make_smart<LinearHeapAllocator>();
-            ctx.stringHeap = make_smart<LinearStringAllocator>();
+            ctx.heap = make_unique<LinearHeapAllocator>();
+            ctx.stringHeap = make_unique<LinearStringAllocator>();
             ctx.category = uint32_t(ContextCategory::folding_context);
             helper.rtti = true;
         }

--- a/include/daScript/misc/job_que.h
+++ b/include/daScript/misc/job_que.h
@@ -6,6 +6,11 @@
 #include <atomic>
 
 namespace das {
+    struct LineInfo;
+
+    // shared tracking counter for JobStatus and Feature
+    DAS_API extern atomic<uint64_t> g_jobque_track_total;
+    DAS_API extern atomic<uint64_t> g_jobque_track_id;       // ID to detail-trace (0 = none)
     // single job
     typedef function<void()> Job;
     typedef function<void(int,int)> JobChunk;
@@ -26,23 +31,40 @@ namespace das {
     class DAS_API JobStatus {
     public:
         enum { STATUS_MAGIC = 0xdeadbeef };
-        JobStatus() {};
-        JobStatus(uint32_t count) { Clear( count); };
+        JobStatus();
+        JobStatus(uint32_t count);
         JobStatus ( JobStatus && ) = delete;
         JobStatus ( const JobStatus & ) = delete;
         virtual ~JobStatus();
         JobStatus & operator = ( JobStatus && ) = delete;
         JobStatus & operator = ( const JobStatus & ) = delete;
         bool Notify();
-        bool NotifyAndRelease();
+        bool NotifyAndRelease( LineInfo * at = nullptr );
         bool isReady();
         void Wait();
         void Clear(uint32_t count = 1);
-        int addRef() { return mRef++; }
-        int releaseRef() { return --mRef; }
+        int addRef( LineInfo * at = nullptr );
+        int releaseRef( LineInfo * at = nullptr );
         int size() const;
         int append(int size);
         bool isValid() const { return mMagic==uint32_t(STATUS_MAGIC); }
+    // tracking
+    public:
+        uint64_t        mTrackId = 0;
+        JobStatus *     mTrackNext = nullptr;
+        JobStatus *     mTrackPrev = nullptr;
+        uint32_t        mTrackMagic = 0;
+        string          mCreatedAt;
+        static JobStatus *  sTrackHead;
+        static mutex        sTrackMutex;
+        static constexpr uint32_t TRACK_JOB_STATUS = 0xDA5CA001;
+        static constexpr uint32_t TRACK_CHANNEL    = 0xDA5CA002;
+        static constexpr uint32_t TRACK_LOCKBOX    = 0xDA5CA003;
+        static void DumpJobQueLeaks();
+        void trackEvent ( LineInfo * at, bool isAddRef );
+    protected:
+        void trackInsert();
+        void trackRemove();
     protected:
         mutable mutex       mCompleteMutex;
         uint32_t            mRemaining = 0;

--- a/include/daScript/misc/memory_model.h
+++ b/include/daScript/misc/memory_model.h
@@ -368,7 +368,7 @@ namespace das {
         HeapChunk * next;
     };
 
-    class DAS_API LinearChunkAllocator : public ptr_ref_count {
+    class DAS_API LinearChunkAllocator {
         enum { default_initial_size = 65536 };
     public:
         LinearChunkAllocator() { }

--- a/include/daScript/simulate/aot_builtin_jobque.h
+++ b/include/daScript/simulate/aot_builtin_jobque.h
@@ -8,34 +8,38 @@
 
 namespace das {
 
-    struct Feature {
+    struct DAS_API Feature {
+        // tracking
+        uint64_t            fTrackId = 0;
+        Feature *           fTrackNext = nullptr;
+        Feature *           fTrackPrev = nullptr;
+        string              fCreatedAt;
+        JobStatus *         fOwner = nullptr;
+        uint64_t            fOwnerTrackId = 0;
+        static Feature *    sTrackHead;
+        static mutex        sTrackMutex;
+        static void DumpFeatures();
+        void trackInsert();
+        void trackRemove();
+        // data
         void *              data = nullptr;
         TypeInfo *          type = nullptr;
         Context *           from = nullptr;
         shared_ptr<Context> fromShared;
-        Feature() {}
-        __forceinline Feature ( void * d, TypeInfo * ti, Context * c) : data(d), type(ti) {
-            setFrom(c);
-        }
-        __forceinline void setFrom ( Context * c ) {
-            from = c;
-            if ( c && c->sharedPtrContext ) {
-                fromShared = c->shared_from_this();
-            } else {
-                fromShared.reset();
-            }
-        }
-        __forceinline void clear() {
-            data = nullptr;
-            type = nullptr;
-            from = nullptr;
-            fromShared.reset();
-        }
+        Feature();
+        Feature ( void * d, TypeInfo * ti, Context * c );
+        ~Feature();
+        Feature ( const Feature & f );
+        Feature ( Feature && f );
+        Feature & operator = ( const Feature & f );
+        Feature & operator = ( Feature && f );
+        void setFrom ( Context * c );
+        void clear();
     };
 
     class LockBox : public JobStatus {
     public:
-        LockBox() {}
+        LockBox() { mTrackMagic = TRACK_LOCKBOX; }
         virtual ~LockBox();
         void set ( void * data, TypeInfo * ti, Context * context );
         void get ( const TBlock<void,void *> & blk, Context * context, LineInfoArg * at );
@@ -55,7 +59,7 @@ namespace das {
     };
 
     template <typename TT>
-    class AtomicTT : public JobStatus {
+    class AtomicTT {
     public:
         TT inc () { return ++ value; }
         TT dec () { return -- value; }
@@ -72,8 +76,8 @@ namespace das {
 
     class DAS_API Channel : public JobStatus {
     public:
-        Channel( Context * ctx ) : owner(ctx) {}
-        Channel( Context * ctx, int count) : owner(ctx) { mRemaining = count; }
+        Channel( Context * ctx ) : owner(ctx) { mTrackMagic = TRACK_CHANNEL; }
+        Channel( Context * ctx, int count) : owner(ctx) { mTrackMagic = TRACK_CHANNEL; mRemaining = count; }
         virtual ~Channel();
         void push ( void * data, TypeInfo * ti, Context * context );
         void pushBatch ( void ** data, int count, TypeInfo * ti, Context * context );
@@ -174,56 +178,44 @@ namespace das {
     AtomicTT<TT> * atomicCreate( Context *, LineInfoArg * ) {
         auto ch = new AtomicTT<TT>();
         ch->set(0);
-        ch->addRef();
         return ch;
     }
 
     template <typename TT>
     void atomicRemove( AtomicTT<TT> * & ch, Context * context, LineInfoArg * at ) {
         if ( !ch ) context->throw_error_at(at, "atomicRemove: atomic is null");
-        if (!ch->isValid()) context->throw_error_at(at, "atomic is invalid (already deleted?)");
-        if (ch->releaseRef()) context->throw_error_at(at, "atomic being deleted while being used");
         delete ch;
         ch = nullptr;
     }
 
     template <typename TT>
     void withAtomic ( const TBlock<void,AtomicTT<TT> *> & blk, Context * context, LineInfoArg * at ) {
-        using TAtomic = AtomicTT<TT>;
-        TAtomic ch;
+        AtomicTT<TT> ch;
         ch.set(0);
-        ch.addRef();
-        das::das_invoke<void>::invoke<TAtomic *>(context, at, blk, &ch);
-        if ( ch.releaseRef() ) {
-            context->throw_error_at(at, "atomic box being deleted while being used");
-        }
+        das::das_invoke<void>::invoke<AtomicTT<TT> *>(context, at, blk, &ch);
     }
 
     template <typename TT>
     TT atomicGet ( AtomicTT<TT> * ch, Context * context, LineInfoArg * at ) {
         if ( !ch ) context->throw_error_at(at, "atomic is null");
-        if (!ch->isValid()) context->throw_error_at(at, "atomic is invalid (already deleted?)");
         return ch->get();
     }
 
     template <typename TT>
     void atomicSet ( AtomicTT<TT> * ch, TT val, Context * context, LineInfoArg * at ) {
         if ( !ch ) context->throw_error_at(at, "atomic is null");
-        if (!ch->isValid()) context->throw_error_at(at, "atomic is invalid (already deleted?)");
         ch->set(val);
     }
 
     template <typename TT>
     TT atomicInc ( AtomicTT<TT> * ch, Context * context, LineInfoArg * at ) {
         if ( !ch ) context->throw_error_at(at, "atomic is null");
-        if (!ch->isValid()) context->throw_error_at(at, "atomic is invalid (already deleted?)");
         return ch->inc();
     }
 
     template <typename TT>
     TT atomicDec ( AtomicTT<TT> * ch, Context * context, LineInfoArg * at ) {
         if ( !ch ) context->throw_error_at(at, "atomic is null");
-        if (!ch->isValid()) context->throw_error_at(at, "atomic is invalid (already deleted?)");
         return ch->dec();
     }
 }

--- a/include/daScript/simulate/heap.h
+++ b/include/daScript/simulate/heap.h
@@ -122,8 +122,9 @@ namespace das {
         uint32_t    stackSize = 0;
     };
 
-    class DAS_API AnyHeapAllocator : public ptr_ref_count {
+    class DAS_API AnyHeapAllocator {
     public:
+        virtual ~AnyHeapAllocator() = default;
         virtual bool breakOnFree ( void *, uint32_t ) { return false; }
         virtual char * impl_allocate ( uint32_t ) = 0;
         virtual void impl_free ( char *, uint32_t ) = 0;

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -799,8 +799,8 @@ namespace das
             }
         }
     public:
-        smart_ptr<StringHeapAllocator>  stringHeap;
-        smart_ptr<AnyHeapAllocator>     heap;
+        unique_ptr<StringHeapAllocator>  stringHeap;
+        unique_ptr<AnyHeapAllocator>     heap;
         shared_ptr<ConstStringAllocator> constStringHeap;
         shared_ptr<NodeAllocator>       code;
         shared_ptr<DebugInfoAllocator>  debugInfo;

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -825,7 +825,6 @@ def command_processor {
                     ch.source->append_temporary(samples)
                 }
             }
-            box |> release()
         } elif (cmd is pause) {
             let pcmd = cmd as pause
             g_sid_2_channel |> get(pcmd.sid) $(var ch : AudioChannel?&) {
@@ -1005,14 +1004,19 @@ def finalize_mixer {
     }
 }
 
-def public audio_system_create(collect : bool = false) : tuple<command : Channel?; collect : Channel?; next_sid : Atomic64?> {
+tuple public AudioSystemChannels {
+    command : Channel ?
+    collect : Channel ?
+    next_sid : Atomic64 ?
+}
+
+def public audio_system_create(collect : bool = false) : AudioSystemChannels {
     //! Low-level: creates the audio system. Prefer with_audio_system.
     sound_initalize(@@mixer, MA_SAMPLE_RATE, MA_CHANNELS, this_context())
     var channel = unsafe(channel_create())
     channel |> add_ref()
     g_command_channel = channel
     g_sound_sid = atomic64_create()
-    g_sound_sid |> add_ref()
     var collectChannel : Channel?
     if (collect) {
         collectChannel = unsafe(channel_create())
@@ -1031,8 +1035,6 @@ def public audio_system_finalize(var channel, collectChannel : Channel?&; var ne
     g_command_channel |> release
     channel |> join
     unsafe(channel_remove(channel))
-    next_sid |> release
-    g_sound_sid |> join
     unsafe(atomic64_remove(g_sound_sid))
     if (g_collect_channel != null) {
         g_collect_channel |> release
@@ -1203,7 +1205,6 @@ def public append_box_to_pcm(sid : SID; box : LockBox?; var samples : array<floa
     //! append samples from lock box to PCM stream. Box is grabbed and released on audio thread.
     //! samples buffer must outlive the grab — caller keeps it alive until box.isReady.
     _builtin_lockbox_fill(box, unsafe(addr(samples)))
-    box |> add_ref
     push_cmd <| new AudioCommand(append_box_pcm = (sid, unsafe(reinterpret<void?>(box))))
     return sid
 }
@@ -1400,11 +1401,5 @@ def public set_sound_sid(next_sid : void?) {
     if (sid == g_sound_sid) {
         return
     }
-    if (g_sound_sid != null) {
-        g_sound_sid |> release
-    }
     g_sound_sid = sid
-    if (g_sound_sid != null) {
-        g_sound_sid |> add_ref
-    }
 }

--- a/modules/dasAudio/strudel/strudel_midi_player.das
+++ b/modules/dasAudio/strudel/strudel_midi_player.das
@@ -911,10 +911,11 @@ def private midi_thread_main(sid : uint64; var cmd_channel : Channel?; var done_
         to_log(0, "midi {UTILIZATION/10}.{UTILIZATION%10}% avg, {MAX_UTIL/10}.{MAX_UTIL%10}% peak utilization\n")
     }
     pcm_box |> join()
-    pcm_box |> release()
+    unsafe(lock_box_remove(pcm_box))
     unset_status_update(sid)
     clear_status(status_box)
-    status_box |> release()
+    status_box |> join()
+    unsafe(lock_box_remove(status_box))
     unsafe {
         set_audio_thread_command_channel(null)
     }
@@ -949,9 +950,7 @@ def public midi_init() {
         g_midi_sid = play_sound_from_pcm_stream(MA_SAMPLE_RATE, MA_CHANNELS)
     }
     g_midi_cmd_channel = unsafe(channel_create())
-    g_midi_cmd_channel |> add_ref()
     g_midi_done_channel = unsafe(channel_create())
-    g_midi_done_channel |> add_ref()
     let sid = g_midi_sid
     var cmd_ch = g_midi_cmd_channel
     var done_ch = g_midi_done_channel
@@ -1079,9 +1078,9 @@ def public midi_shutdown() {
             }
         }
     }
-    g_midi_cmd_channel |> release()
+    unsafe(channel_remove(g_midi_cmd_channel))
     g_midi_cmd_channel = null
-    g_midi_done_channel |> release()
+    unsafe(channel_remove(g_midi_done_channel))
     g_midi_done_channel = null
     g_midi_running = false
 }

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -470,11 +470,12 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
         to_log(0, "strudel {UTILIZATION/10}.{UTILIZATION%10}% utilization\n")
     }
     pcm_box |> join()
-    pcm_box |> release()
+    unsafe(lock_box_remove(pcm_box))
     ma_volume_mixer_uninit(unsafe(addr(mixer)))
     unset_status_update(g_sid)
     clear_status(status_box)
-    status_box |> release()
+    status_box |> join()
+    unsafe(lock_box_remove(status_box))
 }
 
 // Spawn strudel thread. Captures bank/sf2 pointers from main thread.
@@ -487,13 +488,10 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
     // create playback time lockbox
     if (g_playback_box == null) {
         g_playback_box = unsafe(lock_box_create())
-        g_playback_box |> add_ref()
     }
     // create channels
     g_cmd_channel = unsafe(channel_create())
-    g_cmd_channel |> add_ref()
     g_done_channel = unsafe(channel_create())
-    g_done_channel |> add_ref()
     // create PCM stream on main thread (audio globals are initialized here)
     let thread_sid = play_sound_from_pcm_stream(MA_SAMPLE_RATE, MA_CHANNELS)
     // capture shared resources from main thread
@@ -503,9 +501,6 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
     var cmd_ch = g_cmd_channel
     var done_ch = g_done_channel
     var pb_box = g_playback_box
-    pb_box |> add_ref()
-    cmd_ch |> add_ref()
-    done_ch |> add_ref()
     let wt = g_wall_time
     let cps = g_cps
     let la = g_look_ahead
@@ -537,22 +532,36 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
 }
 
 def public strudel_shutdown() {
-    if (g_cmd_channel == null) {
-        return
-    }
-    g_cmd_channel |> push(new StrudelCommand(shutdown = true))
-    var got_done = false
-    while (!got_done) {
-        _builtin_channel_pop(g_done_channel) $(data) {
-            if (data != null) {
-                got_done = true
+    if (g_cmd_channel != null) {
+        g_cmd_channel |> push(new StrudelCommand(shutdown = true))
+        var got_done = false
+        while (!got_done) {
+            _builtin_channel_pop(g_done_channel) $(data) {
+                if (data != null) {
+                    got_done = true
+                }
             }
         }
+        // command channel
+        unsafe(channel_remove(g_cmd_channel))
+        g_cmd_channel = null
+        // done channel
+        unsafe(channel_remove(g_done_channel))
+        g_done_channel = null
+        // player box
+        unsafe(lock_box_remove(g_playback_box))
+        g_playback_box = null
     }
-    g_cmd_channel |> release()
-    g_cmd_channel = null
-    g_done_channel |> release()
-    g_done_channel = null
+    // status box (main-thread mode: created in strudel_create_channel)
+    if (g_tick_status_box != null) {
+        unset_status_update(g_sid)
+        clear_status(g_tick_status_box)
+        var tick_ptr = g_tick_status_box
+        g_tick_status_box |> release()
+        tick_ptr |> join()
+        unsafe(lock_box_remove(tick_ptr))
+        g_tick_status_box = null
+    }
 }
 
 // --- Persistence ---

--- a/skills/jobque_debugging.md
+++ b/skills/jobque_debugging.md
@@ -1,0 +1,199 @@
+# Debugging JobStatus / Channel / LockBox / Feature Leaks
+
+## Overview
+
+`JobStatus`, `Channel`, `LockBox`, and `Feature` are threading primitives in `job_que.h` / `aot_builtin_jobque.h`. They use manual refcounting (`addRef`/`releaseRef`) and are a common source of leaks. A permanent tracking system (intrusive linked lists + per-ID tracing) is always on — no debug macros or rebuild needed.
+
+## Architecture
+
+### Object hierarchy
+
+- **JobStatus** — base refcounted sync primitive (`mRef`, `mRemaining`, condition variable)
+- **Channel : JobStatus** — FIFO queue of `Feature` values (`mTrackMagic = TRACK_CHANNEL`)
+- **LockBox : JobStatus** — single-slot fill/grab/join container (`mTrackMagic = TRACK_LOCKBOX`)
+- **Feature** — value type carrying `void* data + TypeInfo + Context`. Lives in Channels and LockBoxes
+- **AtomicTT** — bare `std::atomic<TT>`, does NOT inherit from JobStatus, no refcounting
+
+### Tracking fields
+
+Every `JobStatus` has:
+- `mTrackId` — unique ID from shared counter `g_jobque_track_total` (shared with Feature)
+- `mTrackNext/mTrackPrev` — intrusive doubly-linked list
+- `mTrackMagic` — subtype tag: `TRACK_JOB_STATUS`, `TRACK_CHANNEL`, or `TRACK_LOCKBOX`
+- `mCreatedAt` — string description of the daScript source location where created
+
+Every `Feature` has:
+- `fTrackId` — unique ID from same shared counter
+- `fTrackNext/fTrackPrev` — separate intrusive doubly-linked list
+- `fCreatedAt` — creation source location
+- `fOwner` / `fOwnerTrackId` — which Channel/LockBox holds this Feature
+
+### Key files
+
+| File | What |
+|---|---|
+| `include/daScript/misc/job_que.h` | JobStatus tracking fields, addRef/releaseRef signatures |
+| `include/daScript/simulate/aot_builtin_jobque.h` | Feature tracking fields, AtomicTT (standalone) |
+| `src/misc/job_que.cpp` | Tracking implementation: linked list ops, DumpJobQueLeaks, trackEvent |
+| `src/builtin/module_builtin_jobque.cpp` | daScript wrappers that pass LineInfo to addRef/releaseRef |
+| `src/hal/debug_break.cpp` | Static variable definitions for tracking globals |
+
+## Step 1: Get the Leak Dump
+
+`DumpJobQueLeaks()` runs at exit in both `daslang.exe` and `daslang-live.exe`. It walks both linked lists and prints all surviving objects.
+
+**With daslang.exe:**
+```bash
+bin/Debug/daslang.exe path/to/script.das
+```
+
+**With daslang-live.exe** — capture output to file:
+```bash
+cd path/to/script/dir
+bin/Debug/daslang-live.exe main.das > /tmp/output.txt 2>&1 &
+# ... interact, then shutdown via REST API or live_shutdown MCP tool
+cat /tmp/output.txt
+```
+
+### Reading the dump
+
+```
+  JobStatus #4 (rc=2) LockBox created at strudel_player.das:280:35
+total 1 leaked JobStatus objects
+  Feature #5 owner=#4
+total 1 leaked Feature objects
+```
+
+- **#4** — track ID (shared between JobStatus and Feature)
+- **(rc=2)** — current refcount at dump time (should be 0 for cleanup)
+- **LockBox** — subtype (Channel, LockBox, or JobStatus)
+- **created at** — daScript source location
+- **owner=#4** — Feature is inside JobStatus #4
+
+## Step 2: Trace a Specific Object
+
+Once you know the leaking ID, use `--track-job-status` to get every addRef/releaseRef with source locations:
+
+```bash
+bin/Debug/daslang.exe --track-job-status 4 path/to/script.das
+```
+
+This sets `g_jobque_track_id = 4`. Every `addRef`/`releaseRef` on that object prints immediately:
+
+```
+tracking JobStatus #4
+JobStatus #4 (LockBox) addRef (rc=0) at strudel_player.das:280:35
+JobStatus #4 (LockBox) addRef (rc=1) at strudel_player.das:281:29
+JobStatus #4 (LockBox) addRef (rc=2) at audio_boost.das:1265:14
+Shutting down...
+JobStatus #4 (LockBox) releaseRef (rc=3) at audio_boost.das:215:22
+```
+
+**Read the trace:** Each line shows the rc *before* the operation. Here rc goes 0→1→2→3, then only one releaseRef 3→2. Two refs were never released — that's the leak.
+
+## Step 3: Identify the Leak Pattern
+
+### Common patterns
+
+**Missing cleanup on early return:**
+```
+strudel_shutdown() {
+    if (g_cmd_channel == null) { return }  // ← early return skips status box cleanup
+    ...
+    // status box cleanup never reached in main-thread mode
+}
+```
+Fix: move cleanup outside the guard, or restructure the function.
+
+**`release()` nulls the pointer:**
+The daScript `release()` wrapper calls `releaseRef` then sets the pointer to `nullptr`. If you need the pointer after release, save it first:
+```das
+var saved = my_box
+my_box |> release()       // my_box is now null
+unsafe(lock_box_remove(saved))  // use saved copy
+```
+
+**Async `unset_status_update` on dead audio thread:**
+`unset_status_update` pushes an async command. If the audio system is already shut down, the command never gets processed and the ref is never released. Fix: call `unset_status_update` while audio is still alive, then `join()` to wait for the audio thread to process it.
+
+**`set_status_update` adds a hidden `add_ref`:**
+`set_status_update(sid, box)` calls `box |> add_ref` internally (audio_boost.das:1265). This ref is released when `unset_status_update` is processed by the audio thread. The cleanup must account for this ref.
+
+**Capture macro implicit `add_ref`:**
+When a Channel/LockBox/JobStatus is captured in a lambda, `capture_macro` in `jobque_boost.das` auto-inserts `addRef` at capture and `releaseRef` at lambda destruction. These refs appear in the trace but not in the daScript source.
+
+### Refcount accounting
+
+For a typical LockBox with `set_status_update`:
+```
+lock_box_create()           rc: 0 → 1  (create)
+add_ref()                   rc: 1 → 2  (explicit, in user code)
+set_status_update() add_ref rc: 2 → 3  (hidden, inside audio_boost)
+--- audio thread processes unset ---
+releaseRef                  rc: 3 → 2  (audio thread releases set_status_update ref)
+release()                   rc: 2 → 1  (matches explicit add_ref)
+lock_box_remove()           rc: 1 → 0  (delete)
+```
+
+### LockBox lifecycle (fill/grab/join)
+
+LockBox synchronization: `fill()` sets `mRemaining=1`, `grab()` sets `mRemaining=0` and notifies, `join()` waits for `mRemaining==0`. No extra `add_ref`/`release` needed for the fill/grab/join cycle itself — the refs are for ownership tracking (who holds a pointer to the box).
+
+## Step 4: Add `--max-frames` for Automated Testing
+
+For GUI apps, add a `--max-frames N` argument to exit after N frames:
+```das
+var max_frame_limit = 0
+
+def parse_args() {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = to_int(args[i + 1])
+        }
+    }
+}
+
+[export]
+def main() {
+    parse_args()
+    init()
+    var frame_count = 0
+    while (!exit_requested()) {
+        update()
+        frame_count ++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
+    }
+    shutdown()
+}
+```
+
+Then test:
+```bash
+bin/Debug/daslang.exe --track-job-status 4 path/to/script.das -- --max-frames 30
+```
+
+Note: `--track-job-status` goes before the script path (daslang arg), `--max-frames` goes after `--` (script arg).
+
+## Shutdown Order
+
+Audio apps must shut down in the correct order:
+
+1. `unset_status_update(sid)` — tell audio thread to release the status box ref
+2. Wait for audio thread to process it (the box's `join()` will return once the audio thread's grab/release cycle completes)
+3. `strudel_shutdown()` or equivalent — stop the strudel/midi thread
+4. `audio_system_finalize(...)` — stop the audio thread
+5. `lock_box_remove()` / `channel_remove()` — delete the objects (rc must be 1)
+
+If `audio_system_finalize` runs before `unset_status_update` is processed, the async command is lost and the ref leaks.
+
+## Quick Checklist
+
+1. Build debug: `cmake --build build --config Debug --target daslang -- /nodeReuse:false`
+2. Run script, check exit output for leak dump
+3. If leaks found, rerun with `--track-job-status <id>` to get addRef/releaseRef trace
+4. Count refs: every addRef must have a matching releaseRef
+5. Check: early returns skipping cleanup? `release()` nulling pointer before further use? async unset on dead thread? missing `unset_status_update`?
+6. Fix and verify: no leak lines in output, exit code 0

--- a/src/ast/ast_aot_cpp.cpp
+++ b/src/ast/ast_aot_cpp.cpp
@@ -3435,7 +3435,6 @@ namespace das {
         }
         virtual ExpressionPtr visitLooksLikeCallArg ( ExprLooksLikeCall * call, Expression * arg, bool last ) override {
             if ( call->name=="invoke" ) {
-                auto argType = arg->type;
                 if ( arg->type->isRefType() ) {
                     if ( needsArgPass(arg) ) {
                         ss << ")";
@@ -4240,7 +4239,7 @@ namespace das {
                     var->init = var->init->visit(*this);
                     var->init = visitGlobalLetInit(var, var->init);
                 }
-                auto varn = visitGlobalLet(var);
+                visitGlobalLet(var);
             }
             tab --;
             ss << "}\n";

--- a/src/ast/ast_block_folding.cpp
+++ b/src/ast/ast_block_folding.cpp
@@ -30,10 +30,10 @@ namespace das {
     public:
         using PassVisitor::PassVisitor;
 
-        virtual bool canVisitStructure ( Structure * st ) override { return false; }
-        virtual bool canVisitEnumeration ( Enumeration * en ) override { return false; }
-        virtual bool canVisitStructureFieldInit ( Structure * var ) override { return false; }
-        virtual bool canVisitArgumentInit ( Function * fun, const VariablePtr & var, Expression * init ) override { return false; }
+        virtual bool canVisitStructure ( Structure * /*st*/ ) override { return false; }
+        virtual bool canVisitEnumeration ( Enumeration * /*en*/ ) override { return false; }
+        virtual bool canVisitStructureFieldInit ( Structure * /*var*/ ) override { return false; }
+        virtual bool canVisitArgumentInit ( Function * /*fun*/, const VariablePtr & /*var*/, Expression * /*init*/ ) override { return false; }
 
     protected:
         // note: loop_source is set during type inference (ast_infer_type.cpp)
@@ -153,15 +153,15 @@ namespace das {
     public:
         using PassVisitor::PassVisitor;
 
-        virtual bool canVisitStructure ( Structure * st ) override { return false; }
-        virtual bool canVisitGlobalVariable ( Variable * fun ) override { return false; }
-        virtual bool canVisitEnumeration ( Enumeration * en ) override { return false; }
-        virtual bool canVisitStructureFieldInit ( Structure * var ) override { return false; }
-        virtual bool canVisitExpr ( ExprTypeInfo * expr, Expression * subexpr ) override { return false; }
-        virtual bool canVisitMakeStructureBlock ( ExprMakeStruct * expr, Expression * blk ) override { return false; }
-        virtual bool canVisitMakeStructureBody ( ExprMakeStruct * expr ) override { return false; }
-        virtual bool canVisitArgumentInit ( Function * fun, const VariablePtr & var, Expression * init ) override { return false; }
-        virtual bool canVisitNamedCall ( ExprNamedCall * expr ) override { return false; }
+        virtual bool canVisitStructure ( Structure * /*st*/ ) override { return false; }
+        virtual bool canVisitGlobalVariable ( Variable * /*fun*/ ) override { return false; }
+        virtual bool canVisitEnumeration ( Enumeration * /*en*/ ) override { return false; }
+        virtual bool canVisitStructureFieldInit ( Structure * /*var*/ ) override { return false; }
+        virtual bool canVisitExpr ( ExprTypeInfo * /*expr*/, Expression * /*subexpr*/ ) override { return false; }
+        virtual bool canVisitMakeStructureBlock ( ExprMakeStruct * /*expr*/, Expression * /*blk*/ ) override { return false; }
+        virtual bool canVisitMakeStructureBody ( ExprMakeStruct * /*expr*/ ) override { return false; }
+        virtual bool canVisitArgumentInit ( Function * /*fun*/, const VariablePtr & /*var*/, Expression * /*init*/ ) override { return false; }
+        virtual bool canVisitNamedCall ( ExprNamedCall * /*expr*/ ) override { return false; }
 
     protected:
         das_set<int32_t> labels;
@@ -294,11 +294,11 @@ namespace das {
     public:
         using PassVisitor::PassVisitor;
 
-        virtual bool canVisitStructure ( Structure * st ) override { return false; }
-        virtual bool canVisitGlobalVariable ( Variable * fun ) override { return false; }
-        virtual bool canVisitEnumeration ( Enumeration * en ) override { return false; }
-        virtual bool canVisitStructureFieldInit ( Structure * var ) override { return false; }
-        virtual bool canVisitArgumentInit ( Function * fun, const VariablePtr & var, Expression * init ) override { return false; }
+        virtual bool canVisitStructure ( Structure * /*st*/ ) override { return false; }
+        virtual bool canVisitGlobalVariable ( Variable * /*fun*/ ) override { return false; }
+        virtual bool canVisitEnumeration ( Enumeration * /*en*/ ) override { return false; }
+        virtual bool canVisitStructureFieldInit ( Structure * /*var*/ ) override { return false; }
+        virtual bool canVisitArgumentInit ( Function * /*fun*/, const VariablePtr & /*var*/, Expression * /*init*/ ) override { return false; }
 
     protected:
         virtual ExpressionPtr visit ( ExprIfThenElse * expr ) override {

--- a/src/ast/ast_infer_type_function.cpp
+++ b/src/ast/ast_infer_type_function.cpp
@@ -886,7 +886,7 @@ namespace das {
             bool less = false;
             bool more = false;
             for (size_t d = 0; d != d1; ++d) {
-                TypeDeclPtr t1Arg, t2Arg;
+                TypeDeclPtr t1Arg = nullptr, t2Arg = nullptr;
                 if (t1->dimExpr[d]->rtti_isTypeDecl()) {
                     t1Arg = static_cast<ExprTypeDecl*>(t1->dimExpr[d])->typeexpr;
                 }

--- a/src/ast/ast_infer_type_op.cpp
+++ b/src/ast/ast_infer_type_op.cpp
@@ -640,7 +640,7 @@ namespace das {
                         auto fidx = efield->value->type->bitFieldIndex(efield->name);
                         if (fidx != -1) {
                             reportAstChanged();
-                            auto mask = new ExprConstBitfield(efield->at, 1ul << fidx);
+                            auto mask = new ExprConstBitfield(efield->at, uint64_t(1) << uint64_t(fidx));
                             mask->bitfieldType = new TypeDecl(*efield->value->type);
                             auto call = new ExprCall(efield->at, "__bit_set");
                             call->arguments.push_back(value->clone());

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -486,7 +486,6 @@ namespace das
         for ( const auto & decl : variants ) {
             auto fieldVariant = makeType->findArgumentIndex(decl->name);
             DAS_ASSERT(fieldVariant!=-1 && "should have failed in type infer otherwise");
-            auto fieldType = makeType->argTypes[fieldVariant];
             if ( decl->value->rtti_isMakeLocal() ) {
                 auto fieldOffset = makeType->getVariantFieldOffset(fieldVariant);
                 uint32_t offset =  extraOffset + index*stride + fieldOffset;
@@ -3228,11 +3227,11 @@ namespace das
         context.gcEnabled = options.getBoolOption("gc", false);
         context.debugger = getDebugger();
         if ( context.persistent ) {
-            context.heap = make_smart<PersistentHeapAllocator>();
-            context.stringHeap = make_smart<PersistentStringAllocator>();
+            context.heap = make_unique<PersistentHeapAllocator>();
+            context.stringHeap = make_unique<PersistentStringAllocator>();
         } else {
-            context.heap = make_smart<LinearHeapAllocator>();
-            context.stringHeap = make_smart<LinearStringAllocator>();
+            context.heap = make_unique<LinearHeapAllocator>();
+            context.stringHeap = make_unique<LinearStringAllocator>();
         }
         context.heap->setInitialSize ( options.getIntOption("heap_size_hint", policies.heap_size_hint) );
         context.heap->setLimit ( options.getUInt64OptionEx("heap_size_limit", "max_heap_allocated", policies.max_heap_allocated) );

--- a/src/ast/ast_unused.cpp
+++ b/src/ast/ast_unused.cpp
@@ -691,12 +691,12 @@ namespace das {
         virtual bool canVisitFunction ( Function * fun ) override {
             return funcIsDirty(fun) && !fun->stub && !fun->isTemplate;    // we don't do a thing with templates
         }
-        virtual bool canVisitStructure ( Structure * st ) override { return false; }
-        virtual bool canVisitStructureFieldInit ( Structure * ) override { return false; }
-        virtual bool canVisitArgumentInit ( Function * , const VariablePtr &, Expression * ) override { return false; }
-        virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
-        virtual bool canVisitGlobalVariable ( Variable * fun ) override { return false; }
-        virtual bool canVisitEnumeration ( Enumeration * en ) override { return false; }
+        virtual bool canVisitStructure ( Structure * /*st*/ ) override { return false; }
+        virtual bool canVisitStructureFieldInit ( Structure * /*var*/ ) override { return false; }
+        virtual bool canVisitArgumentInit ( Function * /*fun*/, const VariablePtr & /*var*/, Expression * /*init*/ ) override { return false; }
+        virtual bool canVisitQuoteSubexpression ( ExprQuote * /*expr*/ ) override { return false; }
+        virtual bool canVisitGlobalVariable ( Variable * /*fun*/ ) override { return false; }
+        virtual bool canVisitEnumeration ( Enumeration * /*en*/ ) override { return false; }
 
     // ExprLet
         virtual VariablePtr visitLet ( ExprLet * let, const VariablePtr & var, bool last ) override {

--- a/src/builtin/module_builtin_dasbind.cpp
+++ b/src/builtin/module_builtin_dasbind.cpp
@@ -396,7 +396,7 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
         }
 #else
 
-        bool verifyCallCorrect( const FunctionPtr & fun, const AnnotationArgumentList & args, string & err ) {
+        bool verifyCallCorrect( const FunctionPtr & fun, const AnnotationArgumentList & /*args*/, string & err ) {
             if ( fun->arguments.size() >= MAX_WRAPPER_ARGUMENTS ) {
                 err = "function has too many arguments for the current wrapper config";
                 return false;
@@ -533,7 +533,7 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
             }
             return newCallExpr;
         }
-        virtual SimNode * simulate ( Context * context, Function * fun, const AnnotationArgumentList & args, string & err ) override {
+        virtual SimNode * simulate ( Context * /*context*/, Function * fun, const AnnotationArgumentList & /*args*/, string & /*err*/ ) override {
             if (is_in_completion()) return nullptr;
             DAS_FATAL_ERROR("Should be unreachable. We handled it in transformCall. Failed on: %s.", fun->name.c_str());
             // // All validation is in apply(). This path is only reached for late/opengl functions.

--- a/src/builtin/module_builtin_debugger.cpp
+++ b/src/builtin/module_builtin_debugger.cpp
@@ -1301,6 +1301,7 @@ namespace debugger {
 #endif
 
     void track_insane_pointer ( void * ptr, Context * ctx ) {
+        ptr;
 #if DAS_TRACK_INSANE_POINTER
         das_track_insane_pointer(ptr);
 #else

--- a/src/builtin/module_builtin_jobque.cpp
+++ b/src/builtin/module_builtin_jobque.cpp
@@ -20,10 +20,10 @@ namespace das {
     template <typename TT>
     struct AddReleaseGuard {
         AddReleaseGuard ( TT * tt, Context * c, LineInfoArg * a ) : t(tt), at(a), context(c) {
-            t->addRef();
+            t->addRef(a);
         }
         ~AddReleaseGuard () {
-            if ( int ref = t->releaseRef() ) {
+            if ( int ref = t->releaseRef(at) ) {
                 context->throw_error_at(at, "synch primitive deleted while being used (ref=%i)", ref);
             }
         }
@@ -40,6 +40,8 @@ namespace das {
     void LockBox::set ( void * data, TypeInfo * ti, Context * context ) {
         lock_guard<mutex> guard(mCompleteMutex);
         box = Feature(data,ti,context);
+        box.fOwner = this;
+        box.fOwnerTrackId = mTrackId;
         mCond.notify_all();
     }
 
@@ -51,6 +53,8 @@ namespace das {
     void LockBox::fill ( void * data, TypeInfo * ti, Context * context ) {
         lock_guard<mutex> guard(mCompleteMutex);
         box = Feature(data,ti,context);
+        box.fOwner = this;
+        box.fOwnerTrackId = mTrackId;
         mRemaining = 1;
         mCond.notify_all();
     }
@@ -83,6 +87,8 @@ namespace das {
     void Channel::push ( void * data, TypeInfo * ti, Context * context ) {
         lock_guard<mutex> guard(mCompleteMutex);
         pipe.emplace_back(data, ti, context!=owner ? context : nullptr);
+        pipe.back().fOwner = this;
+        pipe.back().fOwnerTrackId = mTrackId;
         mCond.notify_all();  // notify_one??
     }
 
@@ -91,6 +97,8 @@ namespace das {
         auto pushCtx = context!=owner ? context : nullptr;
         for ( int i=0; i!=count; ++i ) {
             pipe.emplace_back(data[i], ti, pushCtx);
+            pipe.back().fOwner = this;
+            pipe.back().fOwnerTrackId = mTrackId;
         }
         mCond.notify_all();  // notify_one??
     }
@@ -262,16 +270,17 @@ namespace das {
         das_invoke<void>::invoke<Channel *>(context, at, blk, &ch);
     }
 
-    Channel * channelCreate( Context * context, LineInfoArg * ) {
+    Channel * channelCreate( Context * context, LineInfoArg * at ) {
         Channel * ch = new Channel(context);
-        ch->addRef();
+        if ( at ) ch->mCreatedAt = at->describe();
+        ch->addRef(at);
         return ch;
     }
 
     void channelRemove( Channel * & ch, Context * context, LineInfoArg * at ) {
         if ( !ch ) context->throw_error_at(at, "channelRemove: channel is null");
         if (!ch->isValid()) context->throw_error_at(at, "channel is invalid (already deleted?)");
-        if (ch->releaseRef()) context->throw_error_at(at, "channel being deleted while being used");
+        if (ch->releaseRef(at)) context->throw_error_at(at, "channel being deleted while being used");
         delete ch;
         ch = nullptr;
     }
@@ -312,16 +321,17 @@ namespace das {
     mutex              g_jobQueMutex;
     shared_ptr<JobQue> g_jobQue;
 
-    LockBox * lockBoxCreate( Context *, LineInfoArg * ) {
+    LockBox * lockBoxCreate( Context *, LineInfoArg * at ) {
         LockBox * ch = new LockBox();
-        ch->addRef();
+        if ( at ) ch->mCreatedAt = at->describe();
+        ch->addRef(at);
         return ch;
     }
 
     void lockBoxRemove( LockBox * & ch, Context * context, LineInfoArg * at ) {
         if ( !ch ) context->throw_error_at(at, "lockBoxRemove: lock box is null");
         if (!ch->isValid()) context->throw_error_at(at, "lock box is invalid (already deleted?)");
-        if (ch->releaseRef()) context->throw_error_at(at, "lock box being deleted while being used");
+        if (ch->releaseRef(at)) context->throw_error_at(at, "lock box being deleted while being used");
         delete ch;
         ch = nullptr;
     }
@@ -396,10 +406,6 @@ namespace das {
         virtual void walk(DataWalker & walker, void * data) override {
             BasicStructureAnnotation::walk(walker, data);
             auto ch = (AtomicTT<TT> *) data;
-            if ( !ch->isValid() ) {
-                walker.invalidData();
-                return;
-            }
             TypeInfo info;
             memset(&info, 0, sizeof(TypeInfo));
             info.type = sizeof(TT)==4 ? Type::tInt : Type::tInt64;
@@ -510,12 +516,12 @@ namespace das {
 
     void jobStatusAddRef ( JobStatus * status, Context * context, LineInfoArg * at ) {
         if ( !status ) context->throw_error_at(at, "jobStatusAddRef: status is null");
-        status->addRef();
+        status->addRef(at);
     }
 
     void jobStatusReleaseRef ( JobStatus * & status, Context * context, LineInfoArg * at ) {
         if ( !status ) context->throw_error_at(at, "jobStatusReleaseRef: status is null");
-        status->releaseRef();
+        status->releaseRef(at);
         status = nullptr;
     }
 
@@ -527,16 +533,17 @@ namespace das {
         context->invoke(block,args,nullptr,lineInfo);
     }
 
-    JobStatus * jobStatusCreate( Context *, LineInfoArg * ) {
+    JobStatus * jobStatusCreate( Context *, LineInfoArg * at ) {
         JobStatus * ch = new JobStatus();
-        ch->addRef();
+        if ( at ) ch->mCreatedAt = at->describe();
+        ch->addRef(at);
         return ch;
     }
 
     void jobStatusRemove( JobStatus * & ch, Context * context, LineInfoArg * at ) {
         if ( !ch ) context->throw_error_at(at, "jobStatusRemove: job status is null");
         if (!ch->isValid()) context->throw_error_at(at, "job status is invalid (already deleted?)");
-        if (ch->releaseRef()) context->throw_error_at(at, "job status being deleted while being used");
+        if (ch->releaseRef(at)) context->throw_error_at(at, "job status being deleted while being used");
         delete ch;
         ch = nullptr;
     }
@@ -553,7 +560,7 @@ namespace das {
 
     void notifyAndReleaseJob ( JobStatus * & status, Context * context, LineInfoArg * at ) {
         if ( !status ) context->throw_error_at(at, "notifyAndReleaseJob: status is null");
-        if ( !status->NotifyAndRelease() ) context->throw_error_at(at, "notifyAndReleaseJob: nothing to notify");
+        if ( !status->NotifyAndRelease(at) ) context->throw_error_at(at, "notifyAndReleaseJob: nothing to notify");
         status = nullptr;
     }
 
@@ -583,10 +590,8 @@ namespace das {
             lbx->from("JobStatus");
             addAnnotation(lbx);
             auto a32 = new AtomicAnnotation<int32_t>("Atomic32",lib);
-            a32->from("JobStatus");
             addAnnotation(a32);
             auto a64 = new AtomicAnnotation<int64_t>("Atomic64",lib);
-            a64->from("JobStatus");
             addAnnotation(a64);
             // atomic 32
             addExtern<DAS_BIND_FUN(atomicCreate<int32_t>)>(*this, lib, "atomic32_create",

--- a/src/hal/debug_break.cpp
+++ b/src/hal/debug_break.cpp
@@ -1,6 +1,7 @@
 #include "daScript/misc/platform.h"
 
 #include "daScript/misc/smart_ptr.h"
+#include "daScript/misc/job_que.h"
 
 #include <signal.h>
 
@@ -11,6 +12,12 @@ das::ptr_ref_count *   das::ptr_ref_count::ref_count_head = nullptr;
 das::mutex             das::ptr_ref_count::ref_count_mutex;
 
 DAS_API das::atomic<uint64_t> das::g_smart_ptr_total {0};
+
+// JobStatus / Feature tracking
+DAS_API das::atomic<uint64_t> das::g_jobque_track_total {0};
+DAS_API das::atomic<uint64_t> das::g_jobque_track_id {0};
+das::JobStatus *    das::JobStatus::sTrackHead = nullptr;
+das::mutex          das::JobStatus::sTrackMutex;
 
 DAS_API void os_debug_break()
 {

--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -1,6 +1,13 @@
 #include "daScript/misc/platform.h"
 
 #include "daScript/misc/job_que.h"
+#include "daScript/simulate/debug_info.h"
+#include "daScript/simulate/aot_builtin_jobque.h"
+#include "daScript/misc/string_writer.h"
+
+// Feature tracking statics
+das::Feature *  das::Feature::sTrackHead = nullptr;
+das::mutex      das::Feature::sTrackMutex;
 
 namespace das {
 
@@ -235,10 +242,65 @@ namespace das {
         }
     }
 
+    // JobStatus tracking
+
+    void JobStatus::trackInsert() {
+        lock_guard<mutex> guard(sTrackMutex);
+        mTrackId = ++g_jobque_track_total;
+        mTrackNext = sTrackHead;
+        mTrackPrev = nullptr;
+        if (sTrackHead) sTrackHead->mTrackPrev = this;
+        sTrackHead = this;
+    }
+
+    void JobStatus::trackRemove() {
+        lock_guard<mutex> guard(sTrackMutex);
+        if (mTrackPrev) mTrackPrev->mTrackNext = mTrackNext;
+        else sTrackHead = mTrackNext;
+        if (mTrackNext) mTrackNext->mTrackPrev = mTrackPrev;
+    }
+
+    void JobStatus::trackEvent ( LineInfo * at, bool isAddRef ) {
+        if ( !at ) return;
+        if ( mTrackId != g_jobque_track_id.load() ) return;
+        TextPrinter tp;
+        tp << "JobStatus #" << HEX << mTrackId << DEC;
+        if ( mTrackMagic == TRACK_CHANNEL ) tp << " (Channel)";
+        else if ( mTrackMagic == TRACK_LOCKBOX ) tp << " (LockBox)";
+        else tp << " (JobStatus)";
+        tp << (isAddRef ? " addRef" : " releaseRef")
+           << " (rc=" << int(mRef.load()) << ")";
+        tp << " at " << at->describe() << "\n";
+    }
+
+    int JobStatus::addRef( LineInfo * at ) {
+        trackEvent(at, true);
+        return mRef++;
+    }
+
+    int JobStatus::releaseRef( LineInfo * at ) {
+        trackEvent(at, false);
+        return --mRef;
+    }
+
+    // JobStatus constructors/destructor
+
+    JobStatus::JobStatus() {
+        mTrackMagic = TRACK_JOB_STATUS;
+        trackInsert();
+    }
+
+    JobStatus::JobStatus(uint32_t count) {
+        mTrackMagic = TRACK_JOB_STATUS;
+        trackInsert();
+        Clear(count);
+    }
+
     JobStatus::~JobStatus() {
         DAS_VERIFY(mMagic==STATUS_MAGIC);
         DAS_VERIFY(mRef==0);
         mMagic = 0;
+        trackRemove();
     }
 
     bool JobStatus::Notify() {
@@ -251,8 +313,9 @@ namespace das {
         return true;
     }
 
-    bool JobStatus::NotifyAndRelease() {
+    bool JobStatus::NotifyAndRelease( LineInfo * at ) {
         lock_guard<mutex> guard(mCompleteMutex);
+        trackEvent(at, false);
         mRef--;
         if ( mRemaining == 0 ) return false;
         --mRemaining;
@@ -277,6 +340,151 @@ namespace das {
     void JobStatus::Clear(uint32_t count) {
         lock_guard<mutex> guard(mCompleteMutex);
         mRemaining = count;
+    }
+
+    void JobStatus::DumpJobQueLeaks() {
+        {
+            lock_guard<mutex> guard(sTrackMutex);
+            TextPrinter tp;
+            int total = 0;
+            for ( auto p = sTrackHead; p; p = p->mTrackNext ) {
+                tp << "  JobStatus #" << HEX << p->mTrackId << DEC
+                   << " (rc=" << int(p->mRef.load()) << ")";
+                if ( p->mTrackMagic == TRACK_CHANNEL ) tp << " Channel";
+                else if ( p->mTrackMagic == TRACK_LOCKBOX ) tp << " LockBox";
+                else tp << " JobStatus";
+                if ( !p->mCreatedAt.empty() ) tp << " created at " << p->mCreatedAt;
+                tp << "\n";
+                total++;
+            }
+            if ( total ) tp << "total " << total << " leaked JobStatus objects\n";
+        }
+        {
+            lock_guard<mutex> guard(Feature::sTrackMutex);
+            TextPrinter tp;
+            int total = 0;
+            for ( auto f = Feature::sTrackHead; f; f = f->fTrackNext ) {
+                tp << "  Feature #" << HEX << f->fTrackId << DEC;
+                if ( f->fOwner ) {
+                    tp << " owner=#" << HEX << f->fOwnerTrackId << DEC;
+                }
+                if ( !f->fCreatedAt.empty() ) tp << " created at " << f->fCreatedAt;
+                tp << "\n";
+                total++;
+            }
+            if ( total ) tp << "total " << total << " leaked Feature objects\n";
+        }
+    }
+
+    // Feature tracking
+
+    void Feature::trackInsert() {
+        lock_guard<mutex> guard(sTrackMutex);
+        fTrackId = ++g_jobque_track_total;
+        fTrackNext = sTrackHead;
+        fTrackPrev = nullptr;
+        if (sTrackHead) sTrackHead->fTrackPrev = this;
+        sTrackHead = this;
+    }
+
+    void Feature::trackRemove() {
+        lock_guard<mutex> guard(sTrackMutex);
+        if (fTrackPrev) fTrackPrev->fTrackNext = fTrackNext;
+        else sTrackHead = fTrackNext;
+        if (fTrackNext) fTrackNext->fTrackPrev = fTrackPrev;
+    }
+
+    Feature::Feature() {
+        trackInsert();
+    }
+
+    Feature::Feature ( void * d, TypeInfo * ti, Context * c ) : data(d), type(ti) {
+        trackInsert();
+        setFrom(c);
+    }
+
+    Feature::~Feature() {
+        trackRemove();
+    }
+
+    Feature::Feature ( const Feature & f )
+        : data(f.data), type(f.type), from(f.from), fromShared(f.fromShared) {
+        fCreatedAt = f.fCreatedAt;
+        fOwner = f.fOwner;
+        fOwnerTrackId = f.fOwnerTrackId;
+        trackInsert();
+    }
+
+    Feature::Feature ( Feature && f )
+        : data(f.data), type(f.type), from(f.from), fromShared(das::move(f.fromShared)) {
+        fCreatedAt = f.fCreatedAt;
+        fOwner = f.fOwner;
+        fOwnerTrackId = f.fOwnerTrackId;
+        f.data = nullptr;
+        f.type = nullptr;
+        f.from = nullptr;
+        trackInsert();
+    }
+
+    Feature & Feature::operator = ( const Feature & f ) {
+        if ( this != &f ) {
+            data = f.data;
+            type = f.type;
+            from = f.from;
+            fromShared = f.fromShared;
+            fCreatedAt = f.fCreatedAt;
+            fOwner = f.fOwner;
+            fOwnerTrackId = f.fOwnerTrackId;
+        }
+        return *this;
+    }
+
+    Feature & Feature::operator = ( Feature && f ) {
+        if ( this != &f ) {
+            data = f.data;
+            type = f.type;
+            from = f.from;
+            fromShared = das::move(f.fromShared);
+            fCreatedAt = f.fCreatedAt;
+            fOwner = f.fOwner;
+            fOwnerTrackId = f.fOwnerTrackId;
+            f.data = nullptr;
+            f.type = nullptr;
+            f.from = nullptr;
+        }
+        return *this;
+    }
+
+    void Feature::setFrom ( Context * c ) {
+        from = c;
+        if ( c && c->sharedPtrContext ) {
+            fromShared = c->shared_from_this();
+        } else {
+            fromShared.reset();
+        }
+    }
+
+    void Feature::clear() {
+        data = nullptr;
+        type = nullptr;
+        from = nullptr;
+        fromShared.reset();
+    }
+
+    void Feature::DumpFeatures() {
+        lock_guard<mutex> guard(sTrackMutex);
+        TextPrinter tp;
+        int total = 0;
+        for ( auto f = sTrackHead; f; f = f->fTrackNext ) {
+            tp << "  Feature #" << HEX << f->fTrackId << DEC;
+            if ( f->fOwner ) {
+                tp << " owner=#" << HEX << f->fOwnerTrackId << DEC;
+            }
+            if ( !f->fCreatedAt.empty() ) tp << " created at " << f->fCreatedAt;
+            tp << "\n";
+            total++;
+        }
+        if ( total ) tp << "total " << total << " tracked Feature objects\n";
     }
 }
 

--- a/src/simulate/simulate.cpp
+++ b/src/simulate/simulate.cpp
@@ -981,11 +981,11 @@ namespace das
         gcEnabled = options.getBoolOption("gc", false);
         persistent = options.getBoolOption("persistent_heap", policies.persistent_heap);
         if ( persistent ) {
-            heap = make_smart<PersistentHeapAllocator>();
-            stringHeap = make_smart<PersistentStringAllocator>();
+            heap = make_unique<PersistentHeapAllocator>();
+            stringHeap = make_unique<PersistentStringAllocator>();
         } else {
-            heap = make_smart<LinearHeapAllocator>();
-            stringHeap = make_smart<LinearStringAllocator>();
+            heap = make_unique<LinearHeapAllocator>();
+            stringHeap = make_unique<LinearStringAllocator>();
         }
         heap->setInitialSize ( options.getIntOption("heap_size_hint", policies.heap_size_hint) );
         heap->setLimit ( options.getUInt64OptionEx("heap_size_limit", "max_heap_allocated", policies.max_heap_allocated) );
@@ -1191,11 +1191,11 @@ namespace das
         category.value = opts.category;
         ownStack = (ctx.stack.size() != 0);
         if ( persistent ) {
-            heap = make_smart<PersistentHeapAllocator>();
-            stringHeap = make_smart<PersistentStringAllocator>();
+            heap = make_unique<PersistentHeapAllocator>();
+            stringHeap = make_unique<PersistentStringAllocator>();
         } else {
-            heap = make_smart<LinearHeapAllocator>();
-            stringHeap = make_smart<LinearStringAllocator>();
+            heap = make_unique<LinearHeapAllocator>();
+            stringHeap = make_unique<LinearStringAllocator>();
         }
         // heap
         heap->setInitialSize(ctx.heap->getInitialSize());

--- a/tests/jobque/test_jobque_tracking.das
+++ b/tests/jobque/test_jobque_tracking.das
@@ -1,0 +1,83 @@
+options gen2
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+require dastest/testing_boost public
+require daslib/jobque_boost
+
+[test]
+def test_tracking_clean_run(t : T?) {
+    t |> run("channel create+remove leaves no leak") @(t : T?) {
+        unsafe {
+            var ch = channel_create()
+            t |> success(ch != null)
+            ch |> channel_remove
+            t |> success(ch == null)
+        }
+    }
+    t |> run("lockbox create+remove leaves no leak") @(t : T?) {
+        unsafe {
+            var box = lock_box_create()
+            t |> success(box != null)
+            box |> lock_box_remove
+            t |> success(box == null)
+        }
+    }
+    t |> run("job_status create+remove leaves no leak") @(t : T?) {
+        unsafe {
+            var js = job_status_create()
+            t |> success(js != null)
+            js |> job_status_remove
+            t |> success(js == null)
+        }
+    }
+    t |> run("with_channel scoped cleanup") @(t : T?) {
+        with_channel() $(ch) {
+            t |> success(ch != null)
+        }
+    }
+    t |> run("with_lock_box scoped cleanup") @(t : T?) {
+        with_lock_box() $(box) {
+            t |> success(box != null)
+        }
+    }
+    t |> run("with_job_status scoped cleanup") @(t : T?) {
+        with_job_status(1) $(js) {
+            t |> success(js != null)
+            js |> notify
+        }
+    }
+}
+
+[test]
+def test_tracking_atomics_standalone(t : T?) {
+    t |> run("atomic32 create+remove works without JobStatus") @(t : T?) {
+        unsafe {
+            var a = atomic32_create()
+            a |> set(42)
+            t |> equal(42, a |> get)
+            a |> atomic32_remove
+            t |> success(a == null)
+        }
+    }
+    t |> run("atomic64 create+remove works without JobStatus") @(t : T?) {
+        unsafe {
+            var a = atomic64_create()
+            a |> set(123l)
+            t |> equal(123l, a |> get)
+            a |> atomic64_remove
+            t |> success(a == null)
+        }
+    }
+    t |> run("with_atomic32 scoped") @(t : T?) {
+        with_atomic32() $(a) {
+            a |> set(7)
+            t |> equal(7, a |> get)
+        }
+    }
+    t |> run("with_atomic64 scoped") @(t : T?) {
+        with_atomic64() $(a) {
+            a |> set(99l)
+            t |> equal(99l, a |> get)
+        }
+    }
+}

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -8,6 +8,7 @@
 #include "../dasFormatter/fmt.h"
 #include "daScript/ast/ast_aot_cpp.h"
 #include "daScript/misc/crash_handler.h"
+#include "daScript/misc/job_que.h"
 #if defined(_WIN32) && defined(_DEBUG)
 #include <crtdbg.h>
 #endif
@@ -516,6 +517,7 @@ void print_help() {
         << "    -compile-only compile script without simulation and execution\n"
         << "    -dasroot <path> set path to daslang root folder (with daslib)\n"
         << "    -track-smart-ptr <id> track smart pointer with id\n"
+        << "    -track-job-status <id> track JobStatus/Channel/LockBox with id\n"
         << "    -linear-stack-allocator  disable scoped stack allocator\n"
         << "    -das-wait-debugger wait for debugger to attach\n"
         << "    -das-profiler enable profiler\n"
@@ -713,6 +715,20 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
                 ptr_ref_count::ref_count_track = id;
                 i += 1;
                 printf("tracking %" PRIx64 " aka %" PRIu64 "\n", id, id);
+            } else if ( cmd=="-track-job-status" ) {
+                if ( i+1 > argc ) {
+                    printf("expecting job status id\n");
+                    print_help();
+                    return -1;
+                }
+                uint64_t id = 0;
+                if ( sscanf(argv[i+1], "%" PRIu64, &id)!=1 ) {
+                    printf("expecting job status id, got %s\n", argv[i+1]);
+                    return -1;
+                }
+                g_jobque_track_id.store(id);
+                i += 1;
+                printf("tracking JobStatus #%" PRIu64 "\n", id);
             } else if ( cmd=="-das-wait-debugger") {
                 debuggerRequired = true;
             } else if ( cmd=="-linear-stack-allocator") {
@@ -787,6 +803,7 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     // and done
     if ( pauseAfterDone ) getchar();
     Module::Shutdown();
+    JobStatus::DumpJobQueLeaks();
     if ( g_smart_ptr_total!=0 ) {
         TextPrinter tp;
         tp << "smart pointers leaked: " << uint64_t(g_smart_ptr_total) << "\n";

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -13,6 +13,7 @@
 #include "daScript/simulate/fs_file_info.h"
 #include "daScript/ast/dyn_modules.h"
 #include "daScript/misc/crash_handler.h"
+#include "daScript/misc/job_que.h"
 #include <sys/stat.h>
 
 #if defined(_WIN32) && defined(_DEBUG)
@@ -158,7 +159,6 @@ struct CompileResult {
     ProgramPtr program;
     ContextPtr ctx;
     FileAccessPtr access;
-    ModuleGroup moduleGroup;
     string errors;  // non-empty if compile/simulate failed
 };
 
@@ -176,7 +176,8 @@ static CompileResult compile_script(const string & fn) {
     policies.ignore_shared_modules = true;
     policies.rtti = true;
 
-    result.program = compileDaScript(fn, result.access, tout, result.moduleGroup, policies);
+    ModuleGroup moduleGroup;
+    result.program = compileDaScript(fn, result.access, tout, moduleGroup, policies);
     if (!result.program) {
         result.errors = "failed to compile " + fn;
         tout << "ERROR: " << result.errors << "\n";
@@ -710,6 +711,7 @@ int main(int argc, char * argv[]) {
     int result = run_lifecycle(scriptFile);
 
     Module::Shutdown();
+    JobStatus::DumpJobQueLeaks();
     release_single_instance();
     return result;
 }


### PR DESCRIPTION
## Summary

- **Always-on intrusive linked list tracking** for `JobStatus` (Channel/LockBox) and `Feature` objects. Shared ID counter, creation location, Feature-to-owner relationship. `DumpJobQueLeaks()` at exit reports all surviving objects with ownership graph.
- **`--track-job-status <id>`** CLI arg for per-object addRef/releaseRef tracing with source locations.
- **`AtomicTT` no longer inherits from `JobStatus`** -- bare `std::atomic` wrapper, no refcounting.
- **Fix LockBox leaks** in `strudel_player`, `strudel_midi_player`: fill/grab/join is sufficient sync, removed redundant add_ref/release. Fix main-thread mode leak where `strudel_shutdown` early-returned when `g_cmd_channel` was null.
- **Add proper shutdown** to `strudel_live`, `strudel_sf2_live`, `strudel_visualizer` (were missing `strudel_shutdown` + `audio_system_finalize`).
- **Fix `daslang-live` ModuleGroup crash** on shutdown (was stored in CompileResult, destroyed after modules were gone).
- **Add `--max-frames`** to arcanoid and strudel_visualizer for automated testing.
- **Add `jobque_debugging` skill file** documenting the tracking system usage.

## Test plan

- [x] Lint: 0 issues on all changed `.das` files
- [x] 6052 tests passed, 0 failures, 0 errors
- [x] 5467 AOT tests passed, 0 failures, 0 errors
- [x] das2rst + Sphinx: build succeeded, 0 warnings
- [x] Formatted all changed `.das` files
- [x] Debug build: arcanoid exits clean (no leaks) with `daslang.exe` and `daslang-live.exe`
- [x] Debug build: strudel_visualizer exits clean with `daslang.exe` and `daslang-live.exe`
- [x] `--track-job-status 4` correctly traces all addRef/releaseRef on LockBox #4