### PR TITLE
strudel: streaming oscillator voices

### DIFF
--- a/examples/daStrudel/player_demo/main.das
+++ b/examples/daStrudel/player_demo/main.das
@@ -6,7 +6,7 @@ require audio/audio_boost
 require audio/audio_wav
 require strudel/strudel
 require strudel/strudel_player
-require daslib/fioy
+require daslib/fio
 
 [export]
 def main() {

--- a/modules/dasAudio/strudel/strudel_scheduler.das
+++ b/modules/dasAudio/strudel/strudel_scheduler.das
@@ -43,6 +43,7 @@ struct Scheduler {
     startTime    : double = 0.0lf   // wall-clock time when playback started
     lastQueryEnd : double = 0.0lf   // cycle position of last query end
     voices       : array<Voice?>    // pre-rendered sample/oscillator voices
+    osc_voices   : array<OscVoice> // streaming oscillator voices
     mixer        : ma_volume_mixer  // reused across ticks
     mixer_ready  : bool = false
     // SF2 real-time voice pool
@@ -254,6 +255,18 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
     }
 }
 
+// Render all active streaming oscillator voices into the output buffer.
+def private osc_render_voices(var sched : Scheduler; var output : array<float>; chunkFrames : int) {
+    var i = length(sched.osc_voices) - 1
+    while (i >= 0) {
+        osc_render_chunk(sched.osc_voices[i], output, chunkFrames)
+        if (sched.osc_voices[i].finished) {
+            sched.osc_voices |> erase(i)
+        }
+        i --
+    }
+}
+
 // Tick the scheduler: query pattern for new events, render them,
 // mix all active voices into a fixed-size stereo buffer.
 //
@@ -275,41 +288,51 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
             if (h.has_whole && abs(h.whole.start - h.part.start) < 0.0001lf && h.whole.start < spawnEnd) {
                 let durCycles = h.whole.stop - h.whole.start
                 let durSec = float(durCycles / sched.cps)
+                let cutGroup = h.value.cut
+                let onsetCycle = h.whole.start
+                let onsetWall = sched.startTime + onsetCycle / sched.cps
+                let offsetSec = float(onsetWall - wall_time)
+                // cut groups: kill voices in all pools
+                if (cutGroup != 0) {
+                    var k = length(sched.voices) - 1
+                    while (k >= 0) {
+                        if (sched.voices[k].cut == cutGroup) {
+                            unsafe { delete sched.voices[k]; }
+                            sched.voices |> erase(k)
+                        }
+                        k --
+                    }
+                    var ko = length(sched.osc_voices) - 1
+                    while (ko >= 0) {
+                        if (sched.osc_voices[ko].cut == cutGroup) {
+                            sched.osc_voices |> erase(ko)
+                        }
+                        ko --
+                    }
+                }
                 // SF2 path: spawn real-time voices
                 if (h.value.sf2_program >= 0 && sched.sf2 != null) {
-                    // cut groups: also kill pre-rendered voices in same group
-                    let cutGroup = h.value.cut
-                    if (cutGroup != 0) {
-                        var k = length(sched.voices) - 1
-                        while (k >= 0) {
-                            if (sched.voices[k].cut == cutGroup) {
-                                unsafe { delete sched.voices[k]; }
-                                sched.voices |> erase(k)
-                            }
-                            k --
-                        }
-                    }
                     sf2_spawn_voices(sched, h.value, durSec)
+                } elif (to_osc_type(h.value.s) != OscType.osc_unknown) {
+                    // streaming oscillator path
+                    let offsetFrames = max(int(offsetSec * float(SAMPLE_RATE)), 0)
+                    sched.osc_voices |> push(OscVoice(
+                        osc_type = to_osc_type(h.value.s),
+                        freq = note_to_freq(h.value.note),
+                        duration = durSec,
+                        attack = h.value.attack,
+                        decay = h.value.decay,
+                        sustain = h.value.sustain,
+                        release_sec = h.value.release,
+                        gain = h.value.gain * h.value.velocity,
+                        pan = h.value.pan * 2.0 - 1.0,
+                        cut = cutGroup,
+                        offset_frames = offsetFrames
+                    ))
                 } else {
-                    // sample/oscillator path: pre-render to buffer
+                    // sample/drum path: pre-render to buffer
                     var stereo <- render_event_stereo(h.value, durSec, bank)
-                    // calculate how many samples into the chunk this onset falls
-                    let onsetCycle = h.whole.start
-                    let onsetWall = sched.startTime + onsetCycle / sched.cps
-                    let offsetSec = float(onsetWall - wall_time)
                     let offsetSamples = max(int(offsetSec * float(SAMPLE_RATE)) * 2, 0) // stereo offset
-                    // cut groups: kill existing voices in same group
-                    let cutGroup = h.value.cut
-                    if (cutGroup != 0) {
-                        var k = length(sched.voices) - 1
-                        while (k >= 0) {
-                            if (sched.voices[k].cut == cutGroup) {
-                                unsafe { delete sched.voices[k]; }
-                                sched.voices |> erase(k)
-                            }
-                            k --
-                        }
-                    }
                     sched.voices |> push(new Voice(
                         samples <- stereo,
                         position = -offsetSamples,
@@ -369,6 +392,9 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
 
     // render SF2 real-time voices into the same output buffer
     sf2_render_voices(sched, output, chunkFrames)
+
+    // render streaming oscillator voices into the same output buffer
+    osc_render_voices(sched, output, chunkFrames)
 
     return <- output
 }

--- a/modules/dasAudio/strudel/strudel_synth.das
+++ b/modules/dasAudio/strudel/strudel_synth.das
@@ -144,6 +144,24 @@ def to_osc_type(sound : string) : OscType {
     return OscType.osc_unknown
 }
 
+// Streaming oscillator voice — renders per-chunk instead of pre-rendering the full duration.
+struct OscVoice {
+    osc_type        : OscType = OscType.osc_sine
+    freq            : float = 440.0
+    phase           : float = 0.0       // oscillator phase [0,1)
+    duration        : float = 1.0       // total note duration in seconds
+    attack          : float = 0.001
+    decay           : float = 0.05
+    sustain         : float = 1.0
+    release_sec     : float = 0.1
+    samples_elapsed : int = 0           // samples rendered so far
+    finished        : bool = false
+    gain            : float = 1.0       // event.gain * event.velocity
+    pan             : float = 0.0       // -1=left, 0=center, 1=right
+    cut             : int = 0           // cut group
+    offset_frames   : int = 0           // sub-chunk onset delay (frames)
+}
+
 def render_oscillator(sound : string; duration : float; freq : float; gain : float; event : Event) : array<float> {
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples : array<float>
@@ -187,6 +205,80 @@ def render_oscillator(sound : string; duration : float; freq : float; gain : flo
         }
     }
     return <- samples
+}
+
+// Render one chunk of an oscillator voice directly into the output buffer (additive).
+// Applies gain and pan inline — no intermediate buffer needed.
+def osc_render_chunk(var voice : OscVoice; var output : array<float>; chunkFrames : int) {
+    let iSr = 1.0 / float(SAMPLE_RATE)
+    let phaseInc = voice.freq * iSr
+    let tp = float(TWO_PI)
+    // pan law matching volume_mixer.h ma_volume_mixer_pan_lr
+    let pan = clamp(voice.pan, -1.0, 1.0)
+    let angle = (pan + 1.0) * 0.25 * float(TWO_PI / 2.0)
+    let lGain = voice.gain * cos(angle)
+    let rGain = voice.gain * sin(angle)
+    // consume sub-chunk onset offset
+    if (voice.offset_frames >= chunkFrames) {
+        voice.offset_frames -= chunkFrames
+        return
+    }
+    let startFrame = voice.offset_frames
+    voice.offset_frames = 0
+    let att = voice.attack
+    let dec = voice.decay
+    let sus = voice.sustain
+    let rel = voice.release_sec
+    let dur = voice.duration
+    if (voice.osc_type == OscType.osc_sine) {
+        for (f in range(startFrame, chunkFrames)) {
+            let t = float(voice.samples_elapsed) * iSr
+            let env = adsr(t, att, dec, sus, rel, dur)
+            if (env <= 0.001 && t >= dur) { voice.finished = true; break; }
+            let sample = sin(voice.phase * tp) * env
+            output[f * 2]     += sample * lGain
+            output[f * 2 + 1] += sample * rGain
+            voice.phase += phaseInc
+            voice.phase -= floor(voice.phase)
+            voice.samples_elapsed ++
+        }
+    } elif (voice.osc_type == OscType.osc_sawtooth) {
+        for (f in range(startFrame, chunkFrames)) {
+            let t = float(voice.samples_elapsed) * iSr
+            let env = adsr(t, att, dec, sus, rel, dur)
+            if (env <= 0.001 && t >= dur) { voice.finished = true; break; }
+            let sample = (voice.phase * 2.0 - 1.0) * env
+            output[f * 2]     += sample * lGain
+            output[f * 2 + 1] += sample * rGain
+            voice.phase += phaseInc
+            voice.phase -= floor(voice.phase)
+            voice.samples_elapsed ++
+        }
+    } elif (voice.osc_type == OscType.osc_square) {
+        for (f in range(startFrame, chunkFrames)) {
+            let t = float(voice.samples_elapsed) * iSr
+            let env = adsr(t, att, dec, sus, rel, dur)
+            if (env <= 0.001 && t >= dur) { voice.finished = true; break; }
+            let sample = (voice.phase < 0.5 ? 1.0 : -1.0) * env
+            output[f * 2]     += sample * lGain
+            output[f * 2 + 1] += sample * rGain
+            voice.phase += phaseInc
+            voice.phase -= floor(voice.phase)
+            voice.samples_elapsed ++
+        }
+    } elif (voice.osc_type == OscType.osc_triangle) {
+        for (f in range(startFrame, chunkFrames)) {
+            let t = float(voice.samples_elapsed) * iSr
+            let env = adsr(t, att, dec, sus, rel, dur)
+            if (env <= 0.001 && t >= dur) { voice.finished = true; break; }
+            let sample = (abs(voice.phase * 4.0 - 2.0) - 1.0) * env
+            output[f * 2]     += sample * lGain
+            output[f * 2 + 1] += sample * rGain
+            voice.phase += phaseInc
+            voice.phase -= floor(voice.phase)
+            voice.samples_elapsed ++
+        }
+    }
 }
 
 // ─── Main render entry point ───


### PR DESCRIPTION
## Summary
- Oscillators (sine, sawtooth, square, triangle) now render per-chunk (~60 bytes of `OscVoice` state) instead of pre-rendering the entire note duration into a buffer
- A 64-second sine at 48kHz previously allocated 24 MB (6.1M floats); now costs 60 bytes
- Drums and sample playback remain pre-rendered (small buffers, no benefit from streaming)

## Changes
- **strudel_synth.das**: Added `OscVoice` struct and `osc_render_chunk` function that renders directly into the output buffer with gain/pan applied inline (matching `volume_mixer.h` pan law)
- **strudel_scheduler.das**: Added `osc_voices` array to `Scheduler`, `osc_render_voices` lifecycle wrapper, modified spawn path to route oscillators to streaming and drums/samples to pre-render. Consolidated cut group logic across all voice pools.

## Test plan
- [x] Lint + format pass on all changed files
- [x] Bit-perfect comparison test: streaming vs pre-rendered paths produce identical output
- [x] Scheduler simulation: voices spawn, render, and finish on correct timing
- [x] Manual listening test with multi-track arpeggio pattern (4 tracks, mixed oscillators)