### PR TITLE
strudel: first-class chorus, SF2 features, CC combinators, peak util, leak fix

### DIFF
--- a/examples/daStrudel/features/chorus_basic.das
+++ b/examples/daStrudel/features/chorus_basic.das
@@ -1,0 +1,15 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Sawtooth chord with chorus effect — warm detuned pad with gentle stereo widening.
+// Hear: rich sawtooth chords shimmer and spread as chorus adds subtle detuning.
+// Note: strudel.cc .chorus() is audio chopping, not an effect — our chorus send is daslang-only.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note_pattern("<[c3,e3,g3] [f3,a3,c4] [g3,b3,d4] [a3,c4,e4]>", "sawtooth") |> set_chorus(0.5) |> set_attack(0.05) |> set_decay(0.1) |> set_sustain(0.6) |> set_release(0.3) |> set_gain(0.4)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/feature_common.das
+++ b/examples/daStrudel/features/feature_common.das
@@ -11,10 +11,12 @@ require audio/audio_boost
 require daslib/fio
 require strings
 
+var public default_feature_duration = 10.0
+
 // Parse --duration N and --track-memory from command line args.
 // Returns (duration_seconds, track_memory).
 def parse_feature_args() : tuple<float; bool> {
-    var duration = 10.0
+    var duration = default_feature_duration
     var track_memory = false
     let args <- get_command_line_arguments()
     var i = 0
@@ -36,7 +38,7 @@ def parse_feature_args() : tuple<float; bool> {
 // Uses main-thread mode (strudel_create_channel + strudel_tick) so we stay in
 // one context — memory tracking sees everything.
 // Optional setup block runs after channel creation (for loading samples, etc.).
-def play_feature_cps(var pat : Pattern; cps : double = 0.5lf; setup : block = $() {}) {
+def play_feature_cps(var pat : Pattern; cps : double = 0.5lf; setup : block = $ {}) {
     let args = parse_feature_args()
     let duration = args._0
     let track_memory = args._1
@@ -47,17 +49,25 @@ def play_feature_cps(var pat : Pattern; cps : double = 0.5lf; setup : block = $(
         invoke(setup)
         strudel_add_track(pat)
         strudel_reset_memory_baseline()  // baseline after all setup; shutdown frees before measuring
+        if (track_memory) {
+            to_log(0, "=== HEAP BEFORE PLAYBACK ===\n")
+            heap_report()
+        }
         let t0 = ref_time_ticks()
         while (float(get_time_usec(t0)) / 1000000.0 < duration) {
             strudel_tick()
             sleep(5u)
         }
         strudel_shutdown()
+        if (track_memory) {
+            to_log(0, "=== HEAP AFTER SHUTDOWN ===\n")
+            heap_report()
+        }
     }
 }
 
 // Same as play_feature_cps but takes BPM (converts to cps = bpm / 60 / 2).
-def play_feature(var pat : Pattern; bpm : double = 120.0lf; setup : block = $() {}) {
+def play_feature(var pat : Pattern; bpm : double = 120.0lf; setup : block = $ {}) {
     play_feature_cps(pat, bpm / 120.0lf, setup)
 }
 

--- a/examples/daStrudel/features/sf2_drums_and_bass.das
+++ b/examples/daStrudel/features/sf2_drums_and_bass.das
@@ -1,0 +1,22 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Drums and bass layered — GM percussion with acoustic bass.
+// Hear: punchy kick-snare-hihat groove anchored by a walking bass line.
+// SF2 is daslang-only — no strudel.cc equivalent.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- stack([
+        // Drums — bank 128 GM percussion
+        note_pattern("c2 ~ d2 ~, [fs2 fs2] [fs2 fs2] [fs2 fs2] [fs2 fs2]") |> set_sf2(0) |> set_sf2_bank(128) |> set_gain(0.7),
+        // Bass — root notes following chord changes
+        note_pattern("c2 ~ c2 ~, ~ ~ e2 ~, g2 ~ ~ g2, ~ ~ f2 ~") |> set_sf2("acoustic_bass") |> set_gain(0.6)
+    ])
+    play_feature_cps(pat, 0.5lf) <| $ {
+        strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
+    }
+}

--- a/examples/daStrudel/features/sf2_drums_basic.das
+++ b/examples/daStrudel/features/sf2_drums_basic.das
@@ -1,0 +1,19 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Basic drum pattern using GM percussion bank 128.
+// GM drum note mapping: c2=kick(36), d2=snare(38), eb2=clap(39),
+//   fs2=closed_hh(42), as2=open_hh(46), cs2=side_stick(37).
+// Hear: four-on-the-floor kick, snare on 2 and 4, steady closed hi-hats.
+// SF2 is daslang-only — no strudel.cc equivalent.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note_pattern("c2 ~ d2 ~, [fs2 fs2] [fs2 fs2] [fs2 fs2] [fs2 fs2]") |> set_sf2(0) |> set_sf2_bank(128) |> set_gain(0.7)
+    play_feature_cps(pat, 0.5lf) <| $ {
+        strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
+    }
+}

--- a/examples/daStrudel/features/sf2_expression.das
+++ b/examples/daStrudel/features/sf2_expression.das
@@ -1,0 +1,22 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// SF2 expression control on string ensemble — two layers at different dynamic levels.
+// Hear: soft strings (expression 0.3) underneath full strings (expression 1.0), showing dynamics without gain change.
+// SF2 expression is daslang-only — no strudel.cc equivalent.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- stack([
+        // Soft strings — low expression for gentle dynamics
+        note_pattern("<[c3,e3,g3] [f3,a3,c4]>") |> set_sf2("string_ensemble") |> set_sf2_expression(0.3) |> set_gain(0.5),
+        // Full strings — high expression for rich dynamics
+        note_pattern("<[g3,b3,d4] [a3,c4,e4]>") |> set_sf2("string_ensemble") |> set_sf2_expression(1.0) |> set_gain(0.5)
+    ])
+    play_feature_cps(pat, 0.5lf) <| $ {
+        strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
+    }
+}

--- a/examples/daStrudel/features/sf2_full_band.das
+++ b/examples/daStrudel/features/sf2_full_band.das
@@ -1,0 +1,27 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Full band arrangement: drums, bass, piano chords, flute melody.
+// Am-F-C-G progression with four SF2 layers via stack.
+// Hear: complete lo-fi chill track — kick-snare groove, walking bass, jazzy piano, soaring flute.
+// SF2 is daslang-only — no strudel.cc equivalent.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- stack([
+        // Drums — GM bank 128: kick, clap, closed hi-hats
+        note_pattern("c2 ~ d2 ~, ~ eb2 ~ eb2, [fs2 fs2] [fs2 fs2] [fs2 fs2] [fs2 fs2]") |> set_sf2(0) |> set_sf2_bank(128) |> set_gain(0.7),
+        // Bass — acoustic bass following Am-F-C-G roots
+        note_pattern("<[a1 ~ ~ a1 ~ a1 ~ ~] [f1 ~ ~ f1 ~ f1 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g1 ~ ~ g1 ~ g1 ~ ~]>") |> set_sf2("acoustic_bass") |> set_gain(0.6),
+        // Piano — block chords, Am-F-C-G
+        note_pattern("<[a3,c4,e4] [f3,a3,c4] [c3,e3,g3] [g3,b3,d4]>") |> set_sf2("piano") |> set_gain(0.4),
+        // Flute — arpeggiated melody over the progression
+        note_pattern("<[a4 c5 e5 a5] [f4 a4 c5 f5] [c4 e4 g4 c5] [g4 b4 d5 g5]>") |> set_sf2("flute") |> set_gain(0.45)
+    ])
+    play_feature_cps(pat, 0.5lf) <| $ {
+        strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
+    }
+}

--- a/examples/daStrudel/features/sf2_instruments.das
+++ b/examples/daStrudel/features/sf2_instruments.das
@@ -1,0 +1,24 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Three GM instruments layered: string ensemble pad, flute melody, piano chords.
+// Hear: lush strings sustain Am-F-C-G, flute arpeggiates over them, piano punctuates chords.
+// SF2 is daslang-only — no strudel.cc equivalent.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- stack([
+        // String ensemble pad — sustained chords, Am-F-C-G
+        note_pattern("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>") |> set_sf2("string_ensemble") |> set_gain(0.3),
+        // Flute melody — arpeggiated notes over the chords
+        note_pattern("<[a4 c5 e5] [f4 a4 c5] [c4 e4 g4] [g4 b4 d5]>") |> set_sf2("flute") |> set_gain(0.5),
+        // Piano chords — block chords for harmonic support
+        note_pattern("<[a3,c4,e4] [f3,a3,c4] [c3,e3,g3] [g3,b3,d4]>") |> set_sf2("piano") |> set_gain(0.4)
+    ])
+    play_feature_cps(pat, 0.5lf) <| $ {
+        strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
+    }
+}

--- a/examples/daStrudel/features/sf2_integration_full_ambient.das
+++ b/examples/daStrudel/features/sf2_integration_full_ambient.das
@@ -1,0 +1,77 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// SF2 ambient piece — 8 layers using SoundFont instruments for natural, organic textures.
+// Inspired by integration_full_ambient.das but using SF2 for richer timbres.
+// Arrhythmic, slow harmonic drift, large reverb spaces, modal harmony in C minor.
+// SF2 is daslang-only — no strudel.cc equivalent.
+
+require feature_common
+require daslib/fio
+
+def find_sf2() : string {
+    let dir = "{get_das_root()}/examples/daStrudel/midi_sf2_demo"
+    var st : FStat
+    // prefer larger soundfonts — more samples, better quality
+    let stolen = "{dir}/Stolen Soundfont v2.08.2 (rev.3).sf2"
+    if (stat(stolen, st)) {
+        return stolen
+    }
+    let musyng = "{dir}/Musyng Kite.sf2"
+    if (stat(musyng, st)) {
+        return musyng
+    }
+    let fluid = "{dir}/FluidR3_GM.sf2"
+    if (stat(fluid, st)) {
+        return fluid
+    }
+    let generaluser = "{dir}/GeneralUser GS v1.471.sf2"
+    if (stat(generaluser, st)) {
+        return generaluser
+    }
+    return ""
+}
+
+[export]
+def main() {
+    // Layer 1: Deep cello drone — slow root movement, huge reverb tail
+    var layer1 <- note_pattern("<c2 g2 f2 eb2 bb1 f2>") |> set_sf2("cello") |> slow(32.0lf) |> set_gain(0.15) |> set_sf2_expression(0.6) |> set_room(0.8) |> set_roomsize(10.0) |> set_orbit(1)
+
+    // Layer 2: String ensemble pad — warm sustained chords, gentle sway
+    let pan2 <- signal_sine() |> signal_range(0.3, 0.7) |> slow(20.0lf)
+    var layer2 <- note_pattern("<[c3,eb3,g3] [eb3,g3,bb3] [f3,ab3,c4] [bb2,eb3,g3] [ab2,c3,eb3] [g2,bb2,eb3]>") |> set_sf2("string_ensemble") |> slow(24.0lf) |> set_gain(0.25) |> set_sf2_expression(0.5) |> set_sf2_mod_wheel(0.3) |> set_room(0.7) |> set_roomsize(8.0) |> set_pan(pan2) |> set_orbit(2)
+
+    // Layer 3: Choir — ethereal texture, very slow, drenched in reverb+delay
+    var layer3 <- note_pattern("<[g3,c4,eb4] [f3,bb3,eb4] [ab3,c4,f4] [g3,bb3,eb4]>") |> set_sf2("choir") |> slow(28.0lf) |> set_gain(0.15) |> set_sf2_expression(0.4) |> set_sf2_mod_wheel(0.5) |> set_room(0.9) |> set_roomsize(10.0) |> set_delay(0.25) |> set_delaytime(0.8) |> set_delayfeedback(0.4) |> set_orbit(3)
+
+    // Layer 4: Vibraphone arpeggios — delicate bell-like bubbles
+    let gain4 <- signal_perlin() |> signal_range(0.08, 0.25) |> slow(10.0lf)
+    let pan4 <- signal_sine() |> signal_range(0.15, 0.85) |> slow(7.0lf)
+    var layer4 <- note_pattern("c5 ~ ~ eb5 ~ g4 ~ ~ bb4 ~ f5 ~") |> set_sf2("vibraphone") |> slow(6.0lf) |> set_gain(gain4) |> set_pan(pan4) |> set_room(0.7) |> set_roomsize(6.0) |> set_delay(0.4) |> set_delaytime(0.5) |> set_delayfeedback(0.55) |> set_orbit(4)
+
+    // Layer 5: Flute — high, sparse, breathy melody floating above everything
+    let gain5 <- signal_perlin() |> signal_range(0.05, 0.18) |> slow(14.0lf)
+    let pan5 <- signal_sine() |> signal_range(0.1, 0.9) |> slow(11.0lf)
+    var layer5 <- note_pattern("~ g5 ~ ~ c5 ~ ~ ~ eb5 ~ ~ bb5") |> set_sf2("flute") |> slow(8.0lf) |> set_gain(gain5) |> set_sf2_mod_wheel(0.6) |> set_pan(pan5) |> set_room(0.8) |> set_roomsize(9.0) |> set_delay(0.3) |> set_delaytime(0.75) |> set_delayfeedback(0.45) |> set_orbit(4)
+
+    // Layer 6: Harp — occasional gentle plucks, wide stereo, adding sparkle
+    let gain6 <- signal_perlin() |> signal_range(0.06, 0.2) |> slow(12.0lf)
+    let pan6 <- signal_sine() |> signal_range(0.1, 0.9) |> slow(9.0lf)
+    var layer6 <- note_pattern("~ ~ c4 ~ ~ ~ g4 ~ ~ eb4 ~ ~") |> set_sf2("harp") |> slow(10.0lf) |> set_gain(gain6) |> set_pan(pan6) |> set_room(0.6) |> set_roomsize(5.0) |> set_delay(0.35) |> set_delaytime(0.6) |> set_delayfeedback(0.5) |> set_orbit(5)
+
+    // Layer 7: Contrabass — sub-harmonic anchor, very slow, barely there
+    let gain7 <- signal_sine() |> signal_range(0.05, 0.2) |> slow(16.0lf)
+    var layer7 <- note_pattern("<c1 c1 f1 f1>") |> set_sf2("contrabass") |> slow(48.0lf) |> set_gain(gain7) |> set_sf2_expression(0.4) |> set_room(0.5) |> set_roomsize(6.0) |> set_orbit(1)
+
+    // Layer 8: Heartbeat — slow kick + soft rimshot, distant and hypnotic
+    let gain8 <- signal_sine() |> signal_range(0.06, 0.15) |> slow(20.0lf)
+    var layer8 <- note_pattern("c2 ~ ~ ~ ~ ~ cs2 ~ ~ ~ ~ ~") |> set_sf2(0) |> set_sf2_bank(128) |> slow(4.0lf) |> set_gain(gain8) |> set_room(0.5) |> set_roomsize(4.0) |> set_orbit(5)
+
+    let pat <- stack([layer1, layer2, layer3, layer4, layer5, layer6, layer7, layer8])
+
+    default_feature_duration = 60.0  // override default duration for this feature
+    play_feature_cps(pat, 15.0lf / 60.0lf) <| $ {
+        strudel_load_sf2(find_sf2())
+    }
+}

--- a/examples/daStrudel/features/sf2_mod_wheel.das
+++ b/examples/daStrudel/features/sf2_mod_wheel.das
@@ -1,0 +1,22 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Flute melody with and without mod wheel vibrato — compare clean vs expressive.
+// Hear: dry flute plays a simple melody, then vibrato-rich flute repeats it with warmth and motion.
+// SF2 mod wheel is daslang-only — no strudel.cc equivalent.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- stack([
+        // Clean flute — no mod wheel, dry and pure
+        note_pattern("c4 e4 g4 c5") |> set_sf2("flute") |> set_gain(0.5),
+        // Vibrato flute — mod wheel adds expressive vibrato
+        note_pattern("c4 e4 g4 c5") |> set_sf2("flute") |> set_sf2_mod_wheel(0.8) |> set_gain(0.5)
+    ])
+    play_feature_cps(pat, 0.5lf) <| $ {
+        strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
+    }
+}

--- a/examples/daStrudel/features/sf2_piano.das
+++ b/examples/daStrudel/features/sf2_piano.das
@@ -1,0 +1,17 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Simple ascending C major scale on acoustic piano via SF2.
+// Hear: clean piano notes stepping up from C3 to C4.
+// SF2 is daslang-only — no strudel.cc equivalent.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note_pattern("c3 d3 e3 f3 g3 a3 b3 c4") |> set_sf2("piano") |> set_gain(0.6)
+    play_feature_cps(pat, 0.5lf) <| $ {
+        strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
+    }
+}

--- a/examples/daStrudel/features/sf2_pitch_bend.das
+++ b/examples/daStrudel/features/sf2_pitch_bend.das
@@ -1,0 +1,24 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Guitar notes with pitch bend — bent down, center, and bent up.
+// Hear: first note bends below pitch, second is natural, third bends above — like a guitarist bending strings.
+// SF2 pitch bend is daslang-only — no strudel.cc equivalent.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- stack([
+        // Bent down — pitch wheel below center
+        note_pattern("e3") |> set_sf2("guitar") |> set_sf2_pitch_bend(0.3) |> set_gain(0.5),
+        // Center — natural pitch, no bend
+        note_pattern("e3") |> set_sf2("guitar") |> set_sf2_pitch_bend(0.5) |> set_gain(0.5),
+        // Bent up — pitch wheel above center
+        note_pattern("e3") |> set_sf2("guitar") |> set_sf2_pitch_bend(0.7) |> set_gain(0.5)
+    ])
+    play_feature_cps(pat, 0.5lf) <| $ {
+        strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
+    }
+}

--- a/examples/daStrudel/features/sf2_program_numbers.das
+++ b/examples/daStrudel/features/sf2_program_numbers.das
@@ -1,0 +1,25 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Using numeric GM program IDs instead of instrument names.
+// Program numbers: 0=acoustic_grand_piano, 73=flute, 48=string_ensemble.
+// Hear: piano chords, flute melody, and string pad — same as sf2_instruments but with numbers.
+// SF2 is daslang-only — no strudel.cc equivalent.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- stack([
+        // String ensemble pad — program 48
+        note_pattern("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>") |> set_sf2(48) |> set_gain(0.3),
+        // Flute melody — program 73
+        note_pattern("<[a4 c5 e5] [f4 a4 c5] [c4 e4 g4] [g4 b4 d5]>") |> set_sf2(73) |> set_gain(0.5),
+        // Piano chords — program 0
+        note_pattern("<[a3,c4,e4] [f3,a3,c4] [c3,e3,g3] [g3,b3,d4]>") |> set_sf2(0) |> set_gain(0.4)
+    ])
+    play_feature_cps(pat, 0.5lf) <| $ {
+        strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
+    }
+}

--- a/modules/dasAudio/strudel/strudel_event.das
+++ b/modules/dasAudio/strudel/strudel_event.das
@@ -32,6 +32,10 @@ struct Event {
     fm      : float = 0.0       // FM synthesis modulation depth
     fmh     : float = 1.0       // FM harmonicity ratio (modulator freq / carrier freq)
     vowel   : string = ""      // vowel formant filter ("a", "e", "i", "o", "u", etc.)
-    sf2_program : int = -1      // SF2 GM program number (-1 = not SF2, use sample/oscillator)
-    sf2_bank    : int = 0       // SF2 bank (0 = melodic, 128 = percussion)
+    chorus  : float = 0.0       // chorus send amount 0.0–1.0
+    sf2_program    : int = -1   // SF2 GM program number (-1 = not SF2, use sample/oscillator)
+    sf2_bank       : int = 0    // SF2 bank (0 = melodic, 128 = percussion)
+    sf2_expression : float = -1.0 // SF2 expression CC11 (0.0–1.0, -1 = use default)
+    sf2_mod_wheel  : float = -1.0 // SF2 mod wheel CC1 (0.0–1.0, -1 = use default)
+    sf2_pitch_bend : float = -1.0 // SF2 pitch bend (0.0–1.0 where 0.5 = center, -1 = use default)
 }

--- a/modules/dasAudio/strudel/strudel_midi_player.das
+++ b/modules/dasAudio/strudel/strudel_midi_player.das
@@ -295,8 +295,9 @@ def private sf2_note_on(var state : MidiPlaybackState; ch, note, velocity : int)
     if (preset_idx < 0) {
         return
     }
-    let zones = sf2_find_zones(*state.sf2, preset_idx, note, velocity)
+    var zones <- sf2_find_zones(*state.sf2, preset_idx, note, velocity)
     if (length(zones) == 0) {
+        delete zones
         return
     }
     // kill existing voice on same channel+note (re-trigger)
@@ -333,6 +334,7 @@ def private sf2_note_on(var state : MidiPlaybackState; ch, note, velocity : int)
             g_sf2_meta |> emplace(SF2VoiceMeta(channel = ch, note = note, exclusive_class = excl, reverb_send = rsend, chorus_send = csend, atten_state <- atten_state))
         }
     }
+    delete zones
 }
 
 // Recalculate attenuation for all active SF2 voices on a channel.

--- a/modules/dasAudio/strudel/strudel_pattern.das
+++ b/modules/dasAudio/strudel/strudel_pattern.das
@@ -539,6 +539,38 @@ def set_sf2_bank(var pat : Pattern; bank : int) : Pattern {
     return <- fmap(pat, fn)
 }
 
+// pat |> set_sf2_expression(0.5) — set SF2 expression CC11 (0.0–1.0)
+def set_sf2_expression(var pat : Pattern; v : float) : Pattern {
+    let fn <- @capture(= v) (e : Event) : Event {
+        var r = e; r.sf2_expression = v; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+// pat |> set_sf2_mod_wheel(0.5) — set SF2 mod wheel CC1 (0.0–1.0, vibrato depth)
+def set_sf2_mod_wheel(var pat : Pattern; v : float) : Pattern {
+    let fn <- @capture(= v) (e : Event) : Event {
+        var r = e; r.sf2_mod_wheel = v; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+// pat |> set_sf2_pitch_bend(0.6) — set SF2 pitch bend (0.0–1.0, 0.5 = center)
+def set_sf2_pitch_bend(var pat : Pattern; v : float) : Pattern {
+    let fn <- @capture(= v) (e : Event) : Event {
+        var r = e; r.sf2_pitch_bend = v; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+// pat |> set_chorus(0.5) — set chorus send amount (0.0–1.0)
+def set_chorus(var pat : Pattern; c : float) : Pattern {
+    let fn <- @capture(= c) (e : Event) : Event {
+        var r = e; r.chorus = c; return r
+    }
+    return <- fmap(pat, fn)
+}
+
 // pat |> set_lpq(5.0) — set low-pass filter resonance
 def set_lpq(var pat : Pattern; q : float) : Pattern {
     let fn <- @capture(= q) (e : Event) : Event {
@@ -1100,6 +1132,34 @@ def set_fm(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 def set_fmh(var pat : Pattern; var mod_pat : Pattern) : Pattern {
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.fmh = val; return r
+    })
+}
+
+// pat |> set_chorus(signal_pattern) — modulate chorus send with a signal
+def set_chorus(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.chorus = val; return r
+    })
+}
+
+// pat |> set_sf2_expression(signal_pattern) — modulate SF2 expression with a signal
+def set_sf2_expression(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.sf2_expression = val; return r
+    })
+}
+
+// pat |> set_sf2_mod_wheel(signal_pattern) — modulate SF2 mod wheel with a signal
+def set_sf2_mod_wheel(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.sf2_mod_wheel = val; return r
+    })
+}
+
+// pat |> set_sf2_pitch_bend(signal_pattern) — modulate SF2 pitch bend with a signal
+def set_sf2_pitch_bend(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.sf2_pitch_bend = val; return r
     })
 }
 

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -76,8 +76,9 @@ var private g_mem_str_max : uint64 = 0ul
 var private g_mem_tick_count : int = 0  // for periodic logging in main-thread mode
 
 // --- Tick timing ---
-var private g_tick_total_time : double = 0.lf   // total tick time in ms
-var private g_tick_total_samples : uint64 = 0ul // total samples rendered
+var private g_tick_total_time : double = 0.lf       // total tick time in ms
+var private g_tick_total_samples : uint64 = 0ul     // total samples rendered
+var private g_tick_max_chunk_usec : double = 0.lf   // peak chunk time in usec
 
 struct AudioChunk {
     samples : array<float>
@@ -269,9 +270,9 @@ def public strudel_add_track(var pat : Pattern; gain : float = 1.0) : int {
     track.sched.cps = g_cps
     track.sched.lastQueryEnd = g_wall_time * g_cps
     track.sched.sf2 = g_sf2 != null ? unsafe(reinterpret<SF2File const?>(g_sf2)) : null
+    init_chorus(track.sched)
     if (g_sf2 != null) {
         init_reverb(track.sched)
-        init_chorus(track.sched)
     }
     // ensure per-track PCM arrays are big enough
     while (length(g_track_pcm) <= idx) {
@@ -454,8 +455,10 @@ def public strudel_tick() {
     g_wall_time = double(g_wall_samples) / double(SAMPLE_RATE)
     ma_volume_mixer_uninit(unsafe(addr(mixer)))
     // tick timing
-    g_tick_total_time += double(get_time_usec(t0)) / 1000.lf
+    let chunk_usec = double(get_time_usec(t0))
+    g_tick_total_time += chunk_usec / 1000.lf
     g_tick_total_samples += uint64(chunkSamples / 2)
+    if (chunk_usec > g_tick_max_chunk_usec) { g_tick_max_chunk_usec = chunk_usec; }
     // memory tracking
     let mem_heap_cur = heap_bytes_allocated()
     let mem_str_cur = string_heap_bytes_allocated()
@@ -477,6 +480,7 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
     let LOW_WATERMARK = 2
     var total_time = 0.lf
     var total_samples = 0ul
+    var max_chunk_usec = 0.0lf
     var status_box <- unsafe(lock_box_create())
     set_status_update(g_sid, status_box)
     var pcm_box <- unsafe(lock_box_create())
@@ -549,8 +553,10 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
         if (length(output) > 0) {
             append_box_to_pcm(g_sid, pcm_box, output)
         }
-        total_time += double(get_time_usec(t0)) / 1000.lf
+        let chunk_usec = double(get_time_usec(t0))
+        total_time += chunk_usec / 1000.lf
         total_samples += uint64(chunkSamples / 2)
+        if (chunk_usec > max_chunk_usec) { max_chunk_usec = chunk_usec; }
         let chunkFrames = chunkSamples / 2
         g_wall_samples += int64(chunkFrames)
         g_wall_time = double(g_wall_samples) / double(SAMPLE_RATE)
@@ -582,9 +588,11 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
         let SPEED = total_time / double(total_samples)
         let SPEED_OF_LIGHT = 1000.lf / 48000.lf
         let UTILIZATION = int(SPEED / SPEED_OF_LIGHT * 1000.lf)
+        let chunk_budget_usec = double(CHUNK_SEC) * 1000000.lf
+        let MAX_UTIL = int(max_chunk_usec / chunk_budget_usec * 1000.lf)
         let delta_heap = int64(mem_heap_max) - int64(mem_heap_base)
         let delta_str = int64(mem_str_max) - int64(mem_str_base)
-        to_log(0, "strudel {UTILIZATION/10}.{UTILIZATION%10}% util, heap {mem_heap_max/1024ul}kb (delta {delta_heap}), str {mem_str_max/1024ul}kb (delta {delta_str})\n")
+        to_log(0, "strudel {UTILIZATION/10}.{UTILIZATION%10}% avg, {MAX_UTIL/10}.{MAX_UTIL%10}% peak util, heap {mem_heap_max/1024ul}kb (delta {delta_heap}), str {mem_str_max/1024ul}kb (delta {delta_str})\n")
         if (delta_heap > 0l || delta_str > 0l) {
             to_log(0, "strudel WARNING: potential memory leak detected (delta heap={delta_heap}, str={delta_str})\n")
         }
@@ -705,10 +713,13 @@ def public strudel_shutdown() {
         let SPEED = g_tick_total_time / double(g_tick_total_samples)
         let SPEED_OF_LIGHT = 1000.lf / 48000.lf
         let UTILIZATION = int(SPEED / SPEED_OF_LIGHT * 1000.lf)
-        to_log(0, "strudel {UTILIZATION/10}.{UTILIZATION%10}% utilization\n")
+        let chunk_budget_usec = double(g_chunk_seconds) * 1000000.lf
+        let MAX_UTIL = int(g_tick_max_chunk_usec / chunk_budget_usec * 1000.lf)
+        to_log(0, "strudel {UTILIZATION/10}.{UTILIZATION%10}% avg, {MAX_UTIL/10}.{MAX_UTIL%10}% peak utilization\n")
     }
     g_tick_total_time = 0.lf
     g_tick_total_samples = 0ul
+    g_tick_max_chunk_usec = 0.lf
     // memory stats (main-thread mode)
     if (g_mem_heap_baseline > 0ul) {
         let mem_heap_now = heap_bytes_allocated()

--- a/modules/dasAudio/strudel/strudel_scheduler.das
+++ b/modules/dasAudio/strudel/strudel_scheduler.das
@@ -21,9 +21,10 @@ struct Voice {
     cut : int = 0            // cut group (0 = no cut)
     gain : float = 0.8       // volume for this voice
     pan : float = 0.0        // pan for this voice (-1=left, 0=center, 1=right)
-    reverb_send : float = 0.0 // reverb send amount from Event.room (0.0–1.0)
-    delay_send : float = 0.0  // delay send amount from Event.delay_amount (0.0–1.0)
-    orbit : int = 0           // effect bus routing
+    reverb_send : float = 0.0  // reverb send amount from Event.room (0.0–1.0)
+    chorus_send : float = 0.0  // chorus send amount from Event.chorus (0.0–1.0)
+    delay_send : float = 0.0   // delay send amount from Event.delay_amount (0.0–1.0)
+    orbit : int = 0            // effect bus routing
 }
 
 // Per-voice metadata for SF2 voices (not stored in the C ma_sf2_voice struct).
@@ -149,7 +150,7 @@ def init_reverb(var sched : Scheduler) {
     init_orbit_reverb(*sched.orbit_buses[0])
 }
 
-// Initialize chorus on the scheduler (SF2-only, not orbit-routed).
+// Initialize chorus on the scheduler (not orbit-routed).
 def init_chorus(var sched : Scheduler) {
     if (sched.chorus == null) {
         sched.chorus = new ma_chorus
@@ -183,6 +184,9 @@ def private setup_orbit_for_event(var sched : Scheduler; event : Event) {
             update_orbit_delay_params(*bus, event.delaytime, event.delayfeedback)
         }
     }
+    if (event.chorus > 0.0) {
+        init_chorus(sched)
+    }
 }
 
 // Spawn SF2 voices for an event onset.
@@ -193,8 +197,9 @@ def private sf2_spawn_voices(var sched : Scheduler; event : Event; durSec : floa
     if (preset_idx < 0) {
         return
     }
-    let zones = sf2_find_zones(*sched.sf2, preset_idx, note, velocity)
+    var zones <- sf2_find_zones(*sched.sf2, preset_idx, note, velocity)
     if (length(zones) == 0) {
+        delete zones
         return
     }
     let preset = sched.sf2.presets[preset_idx]
@@ -204,6 +209,10 @@ def private sf2_spawn_voices(var sched : Scheduler; event : Event; durSec : floa
     var atten_state = SF2VoiceAttenState()
     var cc_defaults : int[128]
     sf2_default_cc_values(cc_defaults)
+    // per-event CC overrides from pattern combinators
+    if (event.sf2_expression >= 0.0) { cc_defaults[11] = clamp(int(event.sf2_expression * 127.0), 0, 127); }
+    if (event.sf2_mod_wheel >= 0.0)  { cc_defaults[1]  = clamp(int(event.sf2_mod_wheel * 127.0), 0, 127); }
+    if (event.sf2_pitch_bend >= 0.0) { cc_defaults[127] = clamp(int(event.sf2_pitch_bend * 16383.0), 0, 16383); }
     for (z in zones) {
         var pzone : SF2Zone const?
         for (pz in preset.zones) {
@@ -215,6 +224,7 @@ def private sf2_spawn_voices(var sched : Scheduler; event : Event; durSec : floa
         }
         let excl = sf2_get_exclusive_class(*sched.sf2, z.x, z.y, pzone, preset.global_zone)
         var voice : ma_sf2_voice
+        delete atten_state.atten_mods  // free previous iteration's mods (<- is memcpy+memzero, not finalize)
         if (sf2_create_c_voice(*sched.sf2, z.x, z.y, pzone, preset.global_zone, note, velocity, 0, cc_defaults, voice, atten_state)) {
             // exclusive class: quick-kill existing SF2 voices with same class
             if (excl > 0) {
@@ -233,7 +243,7 @@ def private sf2_spawn_voices(var sched : Scheduler; event : Event; durSec : floa
                 }
             }
             let rsend = sf2_get_reverb_send(*sched.sf2, z.x, z.y, pzone, preset.global_zone)
-            let csend = sf2_get_chorus_send(*sched.sf2, z.x, z.y, pzone, preset.global_zone)
+            let csend = max(sf2_get_chorus_send(*sched.sf2, z.x, z.y, pzone, preset.global_zone), event.chorus)
             sched.sf2_voices |> push(voice)
             sched.sf2_meta |> push(StrudelSF2Meta(
                 note = note,
@@ -248,6 +258,8 @@ def private sf2_spawn_voices(var sched : Scheduler; event : Event; durSec : floa
             ))
         }
     }
+    delete atten_state.atten_mods
+    delete zones
 }
 
 // Get the reverb send buffer for a given orbit. Returns empty array ref if no reverb on that orbit.
@@ -273,18 +285,6 @@ def private get_orbit_delay_send(var sched : Scheduler; orbit : int) : array<flo
 def private sf2_render_voices(var sched : Scheduler; var output : array<float>; chunkFrames : int) {
     if (length(sched.sf2_voices) == 0 || sched.sf2 == null) {
         return
-    }
-    let buf_samples = chunkFrames * 2
-    // prepare chorus send bus (SF2-only, self-contained)
-    var has_chorus_send = false
-    if (sched.chorus != null) {
-        if (length(sched.chorus_send_buf) < buf_samples) {
-            sched.chorus_send_buf |> resize(buf_samples)
-            sched.chorus_out_buf |> resize(buf_samples)
-        }
-        for (s in range(buf_samples)) {
-            sched.chorus_send_buf[s] = 0.0
-        }
     }
     var si = length(sched.sf2_voices) - 1
     while (si >= 0) {
@@ -372,7 +372,6 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
                             )
                         }
                     }
-                    if (chorus_send > 0.001) { has_chorus_send = true; }
                 } else {
                     unsafe {
                         ma_sf2_voice_render(
@@ -404,22 +403,11 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
         }
         si --
     }
-    // process chorus send bus and mix into output (SF2-only)
-    if (has_chorus_send && sched.chorus != null) {
-        for (s in range(buf_samples)) {
-            sched.chorus_out_buf[s] = 0.0
-        }
-        unsafe {
-            chorus_process(sched.chorus, addr(sched.chorus_send_buf[0]), addr(sched.chorus_out_buf[0]), chunkFrames)
-        }
-        for (s in range(buf_samples)) {
-            output[s] += sched.chorus_out_buf[s]
-        }
-    }
 }
 
 // Render all active streaming oscillator voices into the output buffer.
 // Sends accumulate into per-orbit bus buffers based on each voice's orbit.
+// Chorus send accumulates into the scheduler-level chorus_send_buf.
 def private osc_render_voices(var sched : Scheduler; var output : array<float>; chunkFrames : int) {
     var i = length(sched.osc_voices) - 1
     while (i >= 0) {
@@ -432,19 +420,19 @@ def private osc_render_voices(var sched : Scheduler; var output : array<float>; 
         if (sched.osc_voices[i].delay_send > 0.0) {
             delay_buf = get_orbit_delay_send(sched, orb)
         }
-        // osc_render_chunk needs non-null array refs — use empty statics if no bus
+        // osc_render_chunk needs non-null array refs — use empty locals if no bus
         if (reverb_buf != null && delay_buf != null) {
-            osc_render_chunk(sched.osc_voices[i], output, *reverb_buf, *delay_buf, chunkFrames)
+            osc_render_chunk(sched.osc_voices[i], output, *reverb_buf, *delay_buf, sched.chorus_send_buf, chunkFrames)
         } elif (reverb_buf != null) {
             var empty : array<float>
-            osc_render_chunk(sched.osc_voices[i], output, *reverb_buf, empty, chunkFrames)
+            osc_render_chunk(sched.osc_voices[i], output, *reverb_buf, empty, sched.chorus_send_buf, chunkFrames)
         } elif (delay_buf != null) {
             var empty : array<float>
-            osc_render_chunk(sched.osc_voices[i], output, empty, *delay_buf, chunkFrames)
+            osc_render_chunk(sched.osc_voices[i], output, empty, *delay_buf, sched.chorus_send_buf, chunkFrames)
         } else {
             var empty1 : array<float>
             var empty2 : array<float>
-            osc_render_chunk(sched.osc_voices[i], output, empty1, empty2, chunkFrames)
+            osc_render_chunk(sched.osc_voices[i], output, empty1, empty2, sched.chorus_send_buf, chunkFrames)
         }
         if (sched.osc_voices[i].finished) {
             sched.osc_voices |> erase(i)
@@ -476,6 +464,16 @@ def private prepare_orbit_buses(var sched : Scheduler; chunkSamples : int) {
             for (s in range(chunkSamples)) {
                 bus.delay_send_buf[s] = 0.0
             }
+        }
+    }
+    // chorus is scheduler-level (not per-orbit)
+    if (sched.chorus != null) {
+        if (length(sched.chorus_send_buf) < chunkSamples) {
+            sched.chorus_send_buf |> resize(chunkSamples)
+            sched.chorus_out_buf |> resize(chunkSamples)
+        }
+        for (s in range(chunkSamples)) {
+            sched.chorus_send_buf[s] = 0.0
         }
     }
 }
@@ -511,6 +509,34 @@ def private process_orbit_buses(var sched : Scheduler; var output : array<float>
                 output[s] += bus.delay_out_buf[s]
             }
         }
+    }
+}
+
+// Process chorus send bus and mix into output (all voice types).
+def private process_chorus(var sched : Scheduler; var output : array<float>; chunkFrames : int) {
+    if (sched.chorus == null) {
+        return
+    }
+    let buf_samples = chunkFrames * 2
+    // check if anything was sent to chorus
+    var has_send = false
+    for (s in range(buf_samples)) {
+        if (abs(sched.chorus_send_buf[s]) > 0.00001) {
+            has_send = true
+            break
+        }
+    }
+    if (!has_send) {
+        return
+    }
+    for (s in range(buf_samples)) {
+        sched.chorus_out_buf[s] = 0.0
+    }
+    unsafe {
+        chorus_process(sched.chorus, addr(sched.chorus_send_buf[0]), addr(sched.chorus_out_buf[0]), chunkFrames)
+    }
+    for (s in range(buf_samples)) {
+        output[s] += sched.chorus_out_buf[s]
     }
 }
 
@@ -578,6 +604,7 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                         fm_depth = h.value.fm,
                         fm_harmonicity = h.value.fmh,
                         reverb_send = h.value.room,
+                        chorus_send = h.value.chorus,
                         delay_send = h.value.delay_amount,
                         orbit = h.value.orbit
                     )
@@ -600,6 +627,7 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                         gain = h.value.gain * h.value.velocity,
                         pan = h.value.pan * 2.0 - 1.0,
                         reverb_send = h.value.room,
+                        chorus_send = h.value.chorus,
                         delay_send = h.value.delay_amount,
                         orbit = h.value.orbit
                     ))
@@ -677,6 +705,20 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                     (*delay_buf)[di + 1] += voice.samples[si + 1] * dR
                 }
             }
+            // chorus send for pre-rendered voices
+            if (voice.chorus_send > 0.0 && sched.chorus != null && length(sched.chorus_send_buf) >= chunkSamples) {
+                let pan = clamp(voice.pan, -1.0, 1.0)
+                let angle = (pan + 1.0) * 0.25 * float(TWO_PI / 2.0)
+                let cL = voice.gain * voice.chorus_send * cos(angle)
+                let cR = voice.gain * voice.chorus_send * sin(angle)
+                let nf = count / 2
+                for (f in range(nf)) {
+                    let si = srcStart + f * 2
+                    let di = dstStart + f * 2
+                    sched.chorus_send_buf[di]     += voice.samples[si]     * cL
+                    sched.chorus_send_buf[di + 1] += voice.samples[si + 1] * cR
+                }
+            }
         }
         voice.position += chunkSamples
         if (voice.position >= voiceLen) {
@@ -696,6 +738,9 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
 
     // process all orbit bus effects and mix into output
     process_orbit_buses(sched, sched.output, chunkFrames)
+
+    // process chorus send bus and mix into output (all voice types)
+    process_chorus(sched, sched.output, chunkFrames)
 
     // output stays in sched.output — caller reads it directly
 }

--- a/modules/dasAudio/strudel/strudel_synth.das
+++ b/modules/dasAudio/strudel/strudel_synth.das
@@ -733,6 +733,8 @@ struct OscVoice {
     white_seed : uint = 12345u
     // reverb send
     reverb_send : float = 0.0   // reverb send amount from Event.room (0.0–1.0)
+    // chorus send
+    chorus_send : float = 0.0   // chorus send amount from Event.chorus (0.0–1.0)
     // delay send
     delay_send : float = 0.0    // delay send amount from Event.delay_amount (0.0–1.0)
     // orbit
@@ -769,7 +771,7 @@ def osc_voice_init_filters(var voice : OscVoice; lpf, hpf, lpq, hpq : float) {
 // Common invariants are hoisted; FM, filter, and send checks remain
 // (they're simple booleans — acceptable for the interpreter).
 
-def private osc_chunk_sine(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; startFrame, chunkFrames : int; iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR : float; hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel, hasFm : bool; fmScale, fmModPhaseInc : float) {
+def private osc_chunk_sine(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; var chorus_send_buf : array<float>; startFrame, chunkFrames : int; iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR : float; hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel, hasFm : bool; fmScale, fmModPhaseInc : float) {
     let att = voice.attack; let dec = voice.decay; let sus = voice.sustain
     let rel = voice.release_sec; let dur = voice.duration
     for (f in range(startFrame, chunkFrames)) {
@@ -790,12 +792,13 @@ def private osc_chunk_sine(var voice : OscVoice; var output : array<float>; var 
         output[f * 2 + 1] += sample * rGain
         if (hasSend) { reverb_send_buf[f * 2] += sample * sendL; reverb_send_buf[f * 2 + 1] += sample * sendR; }
         if (hasDelaySend) { delay_send_buf[f * 2] += sample * delaySendL; delay_send_buf[f * 2 + 1] += sample * delaySendR; }
+        if (hasChorusSend) { chorus_send_buf[f * 2] += sample * chorusSendL; chorus_send_buf[f * 2 + 1] += sample * chorusSendR; }
         voice.phase += phaseInc; voice.phase -= floor(voice.phase)
         voice.samples_elapsed ++
     }
 }
 
-def private osc_chunk_sawtooth(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; startFrame, chunkFrames : int; iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR : float; hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel, hasFm : bool; fmScale, fmModPhaseInc : float) {
+def private osc_chunk_sawtooth(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; var chorus_send_buf : array<float>; startFrame, chunkFrames : int; iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR : float; hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel, hasFm : bool; fmScale, fmModPhaseInc : float) {
     let att = voice.attack; let dec = voice.decay; let sus = voice.sustain
     let rel = voice.release_sec; let dur = voice.duration
     for (f in range(startFrame, chunkFrames)) {
@@ -818,12 +821,13 @@ def private osc_chunk_sawtooth(var voice : OscVoice; var output : array<float>; 
         output[f * 2 + 1] += sample * rGain
         if (hasSend) { reverb_send_buf[f * 2] += sample * sendL; reverb_send_buf[f * 2 + 1] += sample * sendR; }
         if (hasDelaySend) { delay_send_buf[f * 2] += sample * delaySendL; delay_send_buf[f * 2 + 1] += sample * delaySendR; }
+        if (hasChorusSend) { chorus_send_buf[f * 2] += sample * chorusSendL; chorus_send_buf[f * 2 + 1] += sample * chorusSendR; }
         voice.phase += phaseInc; voice.phase -= floor(voice.phase)
         voice.samples_elapsed ++
     }
 }
 
-def private osc_chunk_square(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; startFrame, chunkFrames : int; iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR : float; hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel, hasFm : bool; fmScale, fmModPhaseInc : float) {
+def private osc_chunk_square(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; var chorus_send_buf : array<float>; startFrame, chunkFrames : int; iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR : float; hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel, hasFm : bool; fmScale, fmModPhaseInc : float) {
     let att = voice.attack; let dec = voice.decay; let sus = voice.sustain
     let rel = voice.release_sec; let dur = voice.duration
     for (f in range(startFrame, chunkFrames)) {
@@ -846,12 +850,13 @@ def private osc_chunk_square(var voice : OscVoice; var output : array<float>; va
         output[f * 2 + 1] += sample * rGain
         if (hasSend) { reverb_send_buf[f * 2] += sample * sendL; reverb_send_buf[f * 2 + 1] += sample * sendR; }
         if (hasDelaySend) { delay_send_buf[f * 2] += sample * delaySendL; delay_send_buf[f * 2 + 1] += sample * delaySendR; }
+        if (hasChorusSend) { chorus_send_buf[f * 2] += sample * chorusSendL; chorus_send_buf[f * 2 + 1] += sample * chorusSendR; }
         voice.phase += phaseInc; voice.phase -= floor(voice.phase)
         voice.samples_elapsed ++
     }
 }
 
-def private osc_chunk_triangle(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; startFrame, chunkFrames : int; iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR : float; hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel, hasFm : bool; fmScale, fmModPhaseInc : float) {
+def private osc_chunk_triangle(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; var chorus_send_buf : array<float>; startFrame, chunkFrames : int; iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR : float; hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel, hasFm : bool; fmScale, fmModPhaseInc : float) {
     let att = voice.attack; let dec = voice.decay; let sus = voice.sustain
     let rel = voice.release_sec; let dur = voice.duration
     for (f in range(startFrame, chunkFrames)) {
@@ -874,12 +879,13 @@ def private osc_chunk_triangle(var voice : OscVoice; var output : array<float>; 
         output[f * 2 + 1] += sample * rGain
         if (hasSend) { reverb_send_buf[f * 2] += sample * sendL; reverb_send_buf[f * 2 + 1] += sample * sendR; }
         if (hasDelaySend) { delay_send_buf[f * 2] += sample * delaySendL; delay_send_buf[f * 2 + 1] += sample * delaySendR; }
+        if (hasChorusSend) { chorus_send_buf[f * 2] += sample * chorusSendL; chorus_send_buf[f * 2 + 1] += sample * chorusSendR; }
         voice.phase += phaseInc; voice.phase -= floor(voice.phase)
         voice.samples_elapsed ++
     }
 }
 
-def private osc_chunk_supersaw(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; startFrame, chunkFrames : int; iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR : float; hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel, hasFm : bool; fmScale, fmModPhaseInc : float) {
+def private osc_chunk_supersaw(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; var chorus_send_buf : array<float>; startFrame, chunkFrames : int; iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR : float; hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel, hasFm : bool; fmScale, fmModPhaseInc : float) {
     let att = voice.attack; let dec = voice.decay; let sus = voice.sustain
     let rel = voice.release_sec; let dur = voice.duration
     let gainAdj = 1.0 / sqrt(float(SUPERSAW_VOICES))
@@ -930,12 +936,13 @@ def private osc_chunk_supersaw(var voice : OscVoice; var output : array<float>; 
         output[f * 2 + 1] += sampleR * rGain
         if (hasSend) { reverb_send_buf[f * 2] += sampleL * sendL; reverb_send_buf[f * 2 + 1] += sampleR * sendR; }
         if (hasDelaySend) { delay_send_buf[f * 2] += sampleL * delaySendL; delay_send_buf[f * 2 + 1] += sampleR * delaySendR; }
+        if (hasChorusSend) { chorus_send_buf[f * 2] += sampleL * chorusSendL; chorus_send_buf[f * 2 + 1] += sampleR * chorusSendR; }
         voice.phase += phaseInc; voice.phase -= floor(voice.phase)
         voice.samples_elapsed ++
     }
 }
 
-def private osc_chunk_pink_noise(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; startFrame, chunkFrames : int; iSr, lGain, rGain, sendL, sendR, delaySendL, delaySendR : float; hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel : bool) {
+def private osc_chunk_pink_noise(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; var chorus_send_buf : array<float>; startFrame, chunkFrames : int; iSr, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR : float; hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel : bool) {
     let att = voice.attack; let dec = voice.decay; let sus = voice.sustain
     let rel = voice.release_sec; let dur = voice.duration
     for (f in range(startFrame, chunkFrames)) {
@@ -950,11 +957,12 @@ def private osc_chunk_pink_noise(var voice : OscVoice; var output : array<float>
         output[f * 2 + 1] += sample * rGain
         if (hasSend) { reverb_send_buf[f * 2] += sample * sendL; reverb_send_buf[f * 2 + 1] += sample * sendR; }
         if (hasDelaySend) { delay_send_buf[f * 2] += sample * delaySendL; delay_send_buf[f * 2 + 1] += sample * delaySendR; }
+        if (hasChorusSend) { chorus_send_buf[f * 2] += sample * chorusSendL; chorus_send_buf[f * 2 + 1] += sample * chorusSendR; }
         voice.samples_elapsed ++
     }
 }
 
-def private osc_chunk_white_noise(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; startFrame, chunkFrames : int; iSr, lGain, rGain, sendL, sendR, delaySendL, delaySendR : float; hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel : bool) {
+def private osc_chunk_white_noise(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; var chorus_send_buf : array<float>; startFrame, chunkFrames : int; iSr, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR : float; hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel : bool) {
     let att = voice.attack; let dec = voice.decay; let sus = voice.sustain
     let rel = voice.release_sec; let dur = voice.duration
     for (f in range(startFrame, chunkFrames)) {
@@ -969,13 +977,14 @@ def private osc_chunk_white_noise(var voice : OscVoice; var output : array<float
         output[f * 2 + 1] += sample * rGain
         if (hasSend) { reverb_send_buf[f * 2] += sample * sendL; reverb_send_buf[f * 2 + 1] += sample * sendR; }
         if (hasDelaySend) { delay_send_buf[f * 2] += sample * delaySendL; delay_send_buf[f * 2 + 1] += sample * delaySendR; }
+        if (hasChorusSend) { chorus_send_buf[f * 2] += sample * chorusSendL; chorus_send_buf[f * 2 + 1] += sample * chorusSendR; }
         voice.samples_elapsed ++
     }
 }
 
 // Render one chunk of an oscillator voice directly into the output buffer (additive).
 // Dispatches to per-type loop with invariants hoisted out.
-def osc_render_chunk(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; chunkFrames : int) {
+def osc_render_chunk(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; var chorus_send_buf : array<float>; chunkFrames : int) {
     // consume sub-chunk onset offset
     if (voice.offset_frames >= chunkFrames) {
         voice.offset_frames -= chunkFrames
@@ -997,6 +1006,9 @@ def osc_render_chunk(var voice : OscVoice; var output : array<float>; var reverb
     let hasDelaySend = voice.delay_send > 0.0 && length(delay_send_buf) >= chunkFrames * 2
     let delaySendL = lGain * voice.delay_send
     let delaySendR = rGain * voice.delay_send
+    let hasChorusSend = voice.chorus_send > 0.0 && length(chorus_send_buf) >= chunkFrames * 2
+    let chorusSendL = lGain * voice.chorus_send
+    let chorusSendR = rGain * voice.chorus_send
     let hasLpf = voice.lpf_biquad.active != 0
     let hasHpf = voice.hpf_biquad.active != 0
     let hasVowel = voice.vowel_filter.active
@@ -1004,19 +1016,19 @@ def osc_render_chunk(var voice : OscVoice; var output : array<float>; var reverb
     let fmScale = voice.fm_depth / tp
     let fmModPhaseInc = voice.freq * voice.fm_harmonicity * iSr
     if (voice.osc_type == OscType.osc_sine) {
-        osc_chunk_sine(voice, output, reverb_send_buf, delay_send_buf, startFrame, chunkFrames, iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel, hasFm, fmScale, fmModPhaseInc)
+        osc_chunk_sine(voice, output, reverb_send_buf, delay_send_buf, chorus_send_buf, startFrame, chunkFrames, iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR, hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel, hasFm, fmScale, fmModPhaseInc)
     } elif (voice.osc_type == OscType.osc_sawtooth) {
-        osc_chunk_sawtooth(voice, output, reverb_send_buf, delay_send_buf, startFrame, chunkFrames, iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel, hasFm, fmScale, fmModPhaseInc)
+        osc_chunk_sawtooth(voice, output, reverb_send_buf, delay_send_buf, chorus_send_buf, startFrame, chunkFrames, iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR, hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel, hasFm, fmScale, fmModPhaseInc)
     } elif (voice.osc_type == OscType.osc_square) {
-        osc_chunk_square(voice, output, reverb_send_buf, delay_send_buf, startFrame, chunkFrames, iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel, hasFm, fmScale, fmModPhaseInc)
+        osc_chunk_square(voice, output, reverb_send_buf, delay_send_buf, chorus_send_buf, startFrame, chunkFrames, iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR, hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel, hasFm, fmScale, fmModPhaseInc)
     } elif (voice.osc_type == OscType.osc_triangle) {
-        osc_chunk_triangle(voice, output, reverb_send_buf, delay_send_buf, startFrame, chunkFrames, iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel, hasFm, fmScale, fmModPhaseInc)
+        osc_chunk_triangle(voice, output, reverb_send_buf, delay_send_buf, chorus_send_buf, startFrame, chunkFrames, iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR, hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel, hasFm, fmScale, fmModPhaseInc)
     } elif (voice.osc_type == OscType.osc_supersaw) {
-        osc_chunk_supersaw(voice, output, reverb_send_buf, delay_send_buf, startFrame, chunkFrames, iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel, hasFm, fmScale, fmModPhaseInc)
+        osc_chunk_supersaw(voice, output, reverb_send_buf, delay_send_buf, chorus_send_buf, startFrame, chunkFrames, iSr, phaseInc, tp, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR, hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel, hasFm, fmScale, fmModPhaseInc)
     } elif (voice.osc_type == OscType.osc_pink_noise) {
-        osc_chunk_pink_noise(voice, output, reverb_send_buf, delay_send_buf, startFrame, chunkFrames, iSr, lGain, rGain, sendL, sendR, delaySendL, delaySendR, hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel)
+        osc_chunk_pink_noise(voice, output, reverb_send_buf, delay_send_buf, chorus_send_buf, startFrame, chunkFrames, iSr, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR, hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel)
     } elif (voice.osc_type == OscType.osc_white_noise) {
-        osc_chunk_white_noise(voice, output, reverb_send_buf, delay_send_buf, startFrame, chunkFrames, iSr, lGain, rGain, sendL, sendR, delaySendL, delaySendR, hasSend, hasDelaySend, hasLpf, hasHpf, hasVowel)
+        osc_chunk_white_noise(voice, output, reverb_send_buf, delay_send_buf, chorus_send_buf, startFrame, chunkFrames, iSr, lGain, rGain, sendL, sendR, delaySendL, delaySendR, chorusSendL, chorusSendR, hasSend, hasDelaySend, hasChorusSend, hasLpf, hasHpf, hasVowel)
     }
 }
 

--- a/modules/dasAudio/strudel/utils/sf2_compare.das
+++ b/modules/dasAudio/strudel/utils/sf2_compare.das
@@ -157,8 +157,9 @@ def render_note(sf2 : SF2File; bank, preset_num, key, velocity : int; duration :
         return
     }
 
-    let zones = sf2_find_zones(sf2, preset_idx, key, velocity)
+    var zones <- sf2_find_zones(sf2, preset_idx, key, velocity)
     if (length(zones) == 0) {
+        delete zones
         return
     }
 
@@ -215,6 +216,7 @@ def render_note(sf2 : SF2File; bank, preset_num, key, velocity : int; duration :
         }
         frame += frames
     }
+    delete zones
 }
 
 // ─── Output ───

--- a/modules/dasAudio/strudel/utils/sf2_render_note.das
+++ b/modules/dasAudio/strudel/utils/sf2_render_note.das
@@ -68,8 +68,9 @@ def render_note(sf2 : SF2File; bank, program, key, velocity : int; duration : fl
         return
     }
 
-    let zones = sf2_find_zones(sf2, preset_idx, key, velocity)
+    var zones <- sf2_find_zones(sf2, preset_idx, key, velocity)
     if (length(zones) == 0) {
+        delete zones
         print("  no zones for preset={program} key={key} vel={velocity}\n")
         return
     }
@@ -132,4 +133,5 @@ def render_note(sf2 : SF2File; bank, program, key, velocity : int; duration : fl
 
     write_wav(output_path, output, [sample_rate = uint(sample_rate)])
     print("  rendered bank={bank} prog={program} key={key} vel={velocity} dur={duration}s -> {output_path} ({length(voices)} voices)\n")
+    delete zones
 }

--- a/tests/strudel/test_synthesis.das
+++ b/tests/strudel/test_synthesis.das
@@ -24,7 +24,8 @@ def private render_voice_stereo(var voice : OscVoice; frames : int) : array<floa
     }
     var empty_send : array<float>
     var empty_delay_send : array<float>
-    osc_render_chunk(voice, output, empty_send, empty_delay_send, frames)
+    var empty_chorus_send : array<float>
+    osc_render_chunk(voice, output, empty_send, empty_delay_send, empty_chorus_send, frames)
     return <- output
 }
 

--- a/tests/strudel/test_vowel.das
+++ b/tests/strudel/test_vowel.das
@@ -292,7 +292,8 @@ def test_osc_voice_vowel_renders(t : T?) {
     output |> resize(chunkFrames * 2)
     var reverb_buf : array<float>
     var delay_buf : array<float>
-    osc_render_chunk(voice, output, reverb_buf, delay_buf, chunkFrames)
+    var chorus_buf : array<float>
+    osc_render_chunk(voice, output, reverb_buf, delay_buf, chorus_buf, chunkFrames)
     var maxAbs = 0.0
     for (sv in output) {
         maxAbs = max(maxAbs, abs(sv))
@@ -309,6 +310,7 @@ def test_osc_voice_vowel_vs_no_vowel(t : T?) {
     output_vowel |> resize(chunkFrames * 2)
     var reverb_buf : array<float>
     var delay_buf : array<float>
+    var chorus_buf : array<float>
     var voice_plain = OscVoice(
         osc_type = OscType.osc_sawtooth,
         freq = 220.0,
@@ -316,7 +318,7 @@ def test_osc_voice_vowel_vs_no_vowel(t : T?) {
         gain = 0.8,
         pan = 0.0
     )
-    osc_render_chunk(voice_plain, output_plain, reverb_buf, delay_buf, chunkFrames)
+    osc_render_chunk(voice_plain, output_plain, reverb_buf, delay_buf, chorus_buf, chunkFrames)
     var voice_vowel = OscVoice(
         osc_type = OscType.osc_sawtooth,
         freq = 220.0,
@@ -325,7 +327,7 @@ def test_osc_voice_vowel_vs_no_vowel(t : T?) {
         pan = 0.0
     )
     vowel_filter_init(voice_vowel.vowel_filter, "a")
-    osc_render_chunk(voice_vowel, output_vowel, reverb_buf, delay_buf, chunkFrames)
+    osc_render_chunk(voice_vowel, output_vowel, reverb_buf, delay_buf, chorus_buf, chunkFrames)
     var diff_energy = 0.0
     for (i in range(chunkFrames * 2)) {
         let d = output_vowel[i] - output_plain[i]


### PR DESCRIPTION
## Summary

- **First-class chorus combinator** (`set_chorus`) works on all voice types — oscillators, samples, and SF2 — not just SF2-zone-only anymore. Chorus send wired through all render paths (pre-rendered, 7 oscillator types, SF2 voices).
- **SF2 CC combinators**: `set_sf2_expression` (CC11), `set_sf2_mod_wheel` (CC1), `set_sf2_pitch_bend` — override hardcoded CC defaults per-event
- **Peak utilization tracking** for both non-threaded and threaded strudel paths (avg + peak format, matching MIDI player)
- **Fixed SF2 per-voice memory leaks**: `sf2_find_zones` return array and `SF2VoiceAttenState.atten_mods` not freed (`<-` is memcpy+memzero, not finalize+move). SF2 leak went from 100kb (scaling with voice count) to 0kb.
- **12 new feature examples**: SF2 basics (piano, drums, instruments, full band), chorus, SF2 CC demos (expression, mod wheel, pitch bend), integration ambient piece
- Configurable `default_feature_duration` in feature_common
- SF2 soundfont preference chain (Stolen > Musyng > FluidR3 > GeneralUser)

## Test plan

- [x] All changed `.das` files pass `compile_check`
- [x] All changed `.das` files pass lint (0 errors)
- [x] All changed `.das` files formatted
- [x] All 12 feature examples run successfully with 8kb baseline leak (no SF2-specific leak)
- [x] `dastest -- --test tests/` passes
- [x] AOT build + test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)