### PR TITLE
strudel: offline WAV rendering for feature examples

### DIFF
--- a/examples/daStrudel/features/feature_common.das
+++ b/examples/daStrudel/features/feature_common.das
@@ -8,60 +8,99 @@ module feature_common shared public
 require strudel/strudel public
 require strudel/strudel_player public
 require audio/audio_boost
+require audio/audio_wav
 require daslib/fio
 require strings
 
 var public default_feature_duration = 10.0
 
-// Parse --duration N and --track-memory from command line args.
-// Returns (duration_seconds, track_memory).
-def parse_feature_args() : tuple<float; bool> {
-    var duration = default_feature_duration
-    var track_memory = false
+// Parse --duration N, --track-memory, and --wav PATH from command line args.
+// Returns (duration_seconds, track_memory, wav_path).
+struct FeatureArgs {
+    duration : float = 10.0
+    track_memory : bool = false
+    wav_path : string
+}
+
+def parse_feature_args() : FeatureArgs {
+    var res = FeatureArgs(duration = default_feature_duration)
     let args <- get_command_line_arguments()
     var i = 0
     while (i < length(args)) {
         if (args[i] == "--duration" && i + 1 < length(args)) {
-            duration = float(to_float(args[i + 1]))
+            res.duration = float(to_float(args[i + 1]))
             i += 2
         } elif (args[i] == "--track-memory") {
-            track_memory = true
+            res.track_memory = true
             i ++
+        } elif (args[i] == "--wav" && i + 1 < length(args)) {
+            res.wav_path = args[i + 1]
+            i += 2
         } else {
             i ++
         }
     }
-    return duration => track_memory
+    return res
 }
 
 // Main-thread mode playback: init audio, create channel, tick in loop, shutdown.
 // Uses main-thread mode (strudel_create_channel + strudel_tick) so we stay in
 // one context — memory tracking sees everything.
 // Optional setup block runs after channel creation (for loading samples, etc.).
+// If --wav PATH is given, renders offline to WAV file instead of playing audio.
 def play_feature_cps(var pat : Pattern; cps : double = 0.5lf; setup : block = $ {}) {
     let args = parse_feature_args()
-    let duration = args._0
-    let track_memory = args._1
-    with_audio_system() {
-        strudel_create_channel()
+    let duration = args.duration
+    let track_memory = args.track_memory
+    let wav_path = args.wav_path
+    if (!empty(wav_path)) {
+        // --- Offline WAV render (no audio driver) ---
         strudel_set_cps(cps)
         strudel_debug_memory(track_memory)
         invoke(setup)
         strudel_add_track(pat)
-        strudel_reset_memory_baseline()  // baseline after all setup; shutdown frees before measuring
-        if (track_memory) {
-            to_log(0, "=== HEAP BEFORE PLAYBACK ===\n")
-            heap_report()
+        strudel_reset_memory_baseline()
+        var all_samples : array<float>
+        let total_frames = int(duration * 48000.0)
+        all_samples |> reserve(total_frames * 2)
+        to_log(0, "rendering {duration} seconds to {wav_path}...\n")
+        while (g_wall_time < double(duration)) {
+            strudel_tick_offline()
+            for (s in g_master_pcm) {
+                all_samples |> push(s)
+            }
         }
-        let t0 = ref_time_ticks()
-        while (float(get_time_usec(t0)) / 1000000.0 < duration) {
-            strudel_tick()
-            sleep(5u)
-        }
+        write_wav(wav_path, all_samples, 48000u, 2)
+        to_log(0, "wrote {wav_path} ({length(all_samples) / 2} frames)\n")
+        delete all_samples
         strudel_shutdown()
         if (track_memory) {
             to_log(0, "=== HEAP AFTER SHUTDOWN ===\n")
             heap_report()
+        }
+    } else {
+        // --- Audio playback ---
+        with_audio_system() {
+            strudel_create_channel()
+            strudel_set_cps(cps)
+            strudel_debug_memory(track_memory)
+            invoke(setup)
+            strudel_add_track(pat)
+            strudel_reset_memory_baseline()  // baseline after all setup; shutdown frees before measuring
+            if (track_memory) {
+                to_log(0, "=== HEAP BEFORE PLAYBACK ===\n")
+                heap_report()
+            }
+            let t0 = ref_time_ticks()
+            while (float(get_time_usec(t0)) / 1000000.0 < duration) {
+                strudel_tick()
+                sleep(5u)
+            }
+            strudel_shutdown()
+            if (track_memory) {
+                to_log(0, "=== HEAP AFTER SHUTDOWN ===\n")
+                heap_report()
+            }
         }
     }
 }

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -471,6 +471,90 @@ def public strudel_tick() {
     }
 }
 
+// Offline tick: same as strudel_tick but without audio driver.
+// Does not require audio system or PCM channel — renders into g_master_pcm,
+// advances g_wall_time. Call in a tight loop for offline WAV rendering.
+def public strudel_tick_offline() {
+    let t0 = ref_time_ticks()
+    let CHUNK_SEC = g_chunk_seconds
+    let chunkSamples = int(float(CHUNK_SEC) * float(SAMPLE_RATE)) * 2
+    // prepare master output
+    g_master_pcm |> resize(chunkSamples)
+    for (s in g_master_pcm) {
+        s = 0.0
+    }
+    // master mixer — linear pan (no cos/sin attenuation at center)
+    var mixer : ma_volume_mixer
+    ma_volume_mixer_init(unsafe(addr(mixer)), 2u)
+    // tick all active tracks
+    for (i in range(length(g_tracks))) {
+        var track = g_tracks[i]
+        if (track == null) {
+            continue
+        }
+        // sync tempo
+        if (track.sched.cps != g_cps) {
+            track.sched.lastQueryEnd = g_wall_time * g_cps
+            track.sched.cps = g_cps
+        }
+        tick(track.sched, track.pat, g_bank, g_wall_time, float(CHUNK_SEC), g_look_ahead)
+        // mix scheduler output into master with track gain
+        if (length(track.sched.output) > 0 && track.gain > 0.001) {
+            // copy to per-track PCM for visualizer access
+            if (i < length(g_track_pcm)) {
+                g_track_pcm[i] := track.sched.output
+            }
+            ma_volume_mixer_set_volume(unsafe(addr(mixer)), track.gain)
+            let nFrames = uint64(min(length(track.sched.output), chunkSamples) / 2)
+            unsafe {
+                ma_volume_mixer_process_pcm_frames(
+                    addr(mixer),
+                    addr(track.sched.output[0]),
+                    addr(g_master_pcm[0]),
+                    nFrames
+                )
+            }
+        }
+        // update fade envelope
+        if (track.fade_speed > 0.0) {
+            if (track.gain < track.target_gain) {
+                track.gain = min(track.gain + track.fade_speed * float(CHUNK_SEC), track.target_gain)
+            } elif (track.gain > track.target_gain) {
+                track.gain = max(track.gain - track.fade_speed * float(CHUNK_SEC), track.target_gain)
+            }
+            if (abs(track.gain - track.target_gain) < 0.001) {
+                track.gain = track.target_gain
+                track.fade_speed = 0.0
+            }
+        }
+        // remove faded-out tracks
+        if (track.gain <= 0.001 && track.target_gain <= 0.001 && track.fade_speed == 0.0) {
+            shutdown_scheduler(track.sched)
+            unsafe { delete g_tracks[i]; }
+            g_tracks[i] = null
+        }
+    }
+    let chunkFrames = int(float(CHUNK_SEC) * float(SAMPLE_RATE))
+    g_wall_samples += int64(chunkFrames)
+    g_wall_time = double(g_wall_samples) / double(SAMPLE_RATE)
+    ma_volume_mixer_uninit(unsafe(addr(mixer)))
+    // tick timing
+    let chunk_usec = double(get_time_usec(t0))
+    g_tick_total_time += chunk_usec / 1000.lf
+    g_tick_total_samples += uint64(chunkSamples / 2)
+    if (chunk_usec > g_tick_max_chunk_usec) { g_tick_max_chunk_usec = chunk_usec; }
+    // memory tracking
+    let mem_heap_cur = heap_bytes_allocated()
+    let mem_str_cur = string_heap_bytes_allocated()
+    g_mem_heap_max = max(g_mem_heap_max, mem_heap_cur)
+    g_mem_str_max = max(g_mem_str_max, mem_str_cur)
+    g_mem_tick_count ++
+    let mem_log_interval = max(int(1.0 / CHUNK_SEC), 1)
+    if (g_debug_memory && g_mem_tick_count % mem_log_interval == 0) {
+        to_log(0, "strudel mem: heap {mem_heap_cur/1024ul}kb / str {mem_str_cur/1024ul}kb (max heap {g_mem_heap_max/1024ul}kb / str {g_mem_str_max/1024ul}kb)\n")
+    }
+}
+
 // --- Threaded mode ---
 
 // Blocking multi-track tick loop. Call from your strudel_main on the thread.


### PR DESCRIPTION
## Summary

- Add `--wav PATH` argument to `feature_common.das` — any feature example can render offline to a `.wav` file instead of playing through speakers
- Add `strudel_tick_offline()` to `strudel_player.das` — same multi-track rendering as `strudel_tick()` but without audio driver (no PCM channel, no buffer level checks, no audio submission)
- All existing `play_feature` / `play_feature_cps` / `play_feature_cpm` callers get WAV support automatically

Usage: `daslang.exe examples/daStrudel/features/sf2_integration_full_ambient.das -- --wav output.wav --duration 120`

## Test plan

- [x] Lint: 0 issues on both changed files
- [x] Format: both files already formatted
- [x] Tests: 6250 passed, 0 failed, 0 errors
- [x] Verified: `sf2_integration_full_ambient.das --wav E:/test_ambient.wav --duration 120` produces correct 5.76M frame WAV