### PR TITLE
strudel: API harmonization — aliases, combinators, per-voice FX

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -1277,6 +1277,8 @@ def document_module_audio(root : string) {
         group_by_regex("Convolution Reverb", mod, %regex~conv_reverb%%),
         group_by_regex("Chorus", mod, %regex~chorus%%),
         group_by_regex("Delay", mod, %regex~delay_%%),
+        group_by_regex("Per-voice effects", mod, %regex~.*(bandpass|bitcrush|compressor|djfilter|phaser|tremolo|waveshaper)_(init|process|setup)$%%),
+        group_by_regex("Per-voice effect types", mod, %regex~ma_(bandpass|bitcrush|compressor|djfilter|phaser|tremolo|waveshaper)$%%),
         group_by_regex("SF2 voice", mod, %regex~ma_sf2%%),
         group_by_regex("Enumerations and constants", mod, %regex~MA_SAMPLE_RATE$%%)
     )

--- a/doc/source/stdlib/handmade/function-audio-bandpass_init-0xacbbcff10a06a25c.rst
+++ b/doc/source/stdlib/handmade/function-audio-bandpass_init-0xacbbcff10a06a25c.rst
@@ -1,0 +1,1 @@
+Initialize a stereo biquad bandpass filter at the given sample rate with default 1 kHz center frequency and Q of 1.

--- a/doc/source/stdlib/handmade/function-audio-bandpass_process-0x6c5a06be112fa2fc.rst
+++ b/doc/source/stdlib/handmade/function-audio-bandpass_process-0x6c5a06be112fa2fc.rst
@@ -1,0 +1,1 @@
+Process an interleaved stereo buffer in place through the bandpass filter for the given number of frames.

--- a/doc/source/stdlib/handmade/function-audio-bandpass_setup-0xc6f5ac349eb8d2d7.rst
+++ b/doc/source/stdlib/handmade/function-audio-bandpass_setup-0xc6f5ac349eb8d2d7.rst
@@ -1,0 +1,1 @@
+Recompute the bandpass biquad coefficients for the given center frequency in Hz and quality factor Q.

--- a/doc/source/stdlib/handmade/function-audio-bitcrush_init-0xb16e031e5723c12.rst
+++ b/doc/source/stdlib/handmade/function-audio-bitcrush_init-0xb16e031e5723c12.rst
@@ -1,0 +1,1 @@
+Initialize a stereo bitcrusher with bit-depth reduction and sample-and-hold decimation, both disabled by default.

--- a/doc/source/stdlib/handmade/function-audio-bitcrush_process-0x1a552993710db734.rst
+++ b/doc/source/stdlib/handmade/function-audio-bitcrush_process-0x1a552993710db734.rst
@@ -1,0 +1,1 @@
+Process an interleaved stereo buffer in place through the bitcrusher, applying bit-depth quantization and coarse sample-rate reduction.

--- a/doc/source/stdlib/handmade/function-audio-compressor_init-0xdb83f4be4627fc20.rst
+++ b/doc/source/stdlib/handmade/function-audio-compressor_init-0xdb83f4be4627fc20.rst
@@ -1,0 +1,1 @@
+Initialize a feed-forward compressor with envelope follower and soft knee at the given sample rate; starts in bypass (threshold 0 dB).

--- a/doc/source/stdlib/handmade/function-audio-compressor_process-0xa0d20ff452e75de5.rst
+++ b/doc/source/stdlib/handmade/function-audio-compressor_process-0xa0d20ff452e75de5.rst
@@ -1,0 +1,1 @@
+Process an interleaved stereo buffer in place through the compressor, applying peak-detected gain reduction with the configured threshold, ratio, knee, attack, and release.

--- a/doc/source/stdlib/handmade/function-audio-djfilter_init-0xdb288cc693239e68.rst
+++ b/doc/source/stdlib/handmade/function-audio-djfilter_init-0xdb288cc693239e68.rst
@@ -1,0 +1,1 @@
+Initialize a DJ-style one-knob filter at the given sample rate, centered at the bypass position (0.5).

--- a/doc/source/stdlib/handmade/function-audio-djfilter_process-0x6fc0fb78f7b9cee6.rst
+++ b/doc/source/stdlib/handmade/function-audio-djfilter_process-0x6fc0fb78f7b9cee6.rst
@@ -1,0 +1,1 @@
+Process an interleaved stereo buffer in place through the DJ filter, sweeping from low-pass (position 0) through bypass (0.5) to high-pass (position 1).

--- a/doc/source/stdlib/handmade/function-audio-phaser_init-0xbbcc7526fec929f0.rst
+++ b/doc/source/stdlib/handmade/function-audio-phaser_init-0xbbcc7526fec929f0.rst
@@ -1,0 +1,1 @@
+Initialize a 4-stage all-pass phaser with feedback at the given sample rate, defaulting to 1 Hz LFO rate, 0.75 depth, 1 kHz center, and 2000-cent sweep.

--- a/doc/source/stdlib/handmade/function-audio-phaser_process-0x4946802e2815061d.rst
+++ b/doc/source/stdlib/handmade/function-audio-phaser_process-0x4946802e2815061d.rst
@@ -1,0 +1,1 @@
+Process an interleaved stereo buffer in place through the phaser, applying the LFO-swept all-pass chain with resonant feedback.

--- a/doc/source/stdlib/handmade/function-audio-tremolo_init-0x427be331802b93ae.rst
+++ b/doc/source/stdlib/handmade/function-audio-tremolo_init-0x427be331802b93ae.rst
@@ -1,0 +1,1 @@
+Initialize a sine-LFO stereo tremolo at the given sample rate, disabled by default (rate 0 Hz, full depth).

--- a/doc/source/stdlib/handmade/function-audio-tremolo_process-0xcd9cda48a6fd304f.rst
+++ b/doc/source/stdlib/handmade/function-audio-tremolo_process-0xcd9cda48a6fd304f.rst
@@ -1,0 +1,1 @@
+Process an interleaved stereo buffer in place through the tremolo, modulating amplitude with a sine LFO at the configured rate and depth.

--- a/doc/source/stdlib/handmade/function-audio-waveshaper_init-0x8561e7053ae2e8c2.rst
+++ b/doc/source/stdlib/handmade/function-audio-waveshaper_init-0x8561e7053ae2e8c2.rst
@@ -1,0 +1,1 @@
+Initialize a tanh-based stereo waveshaper with drive set to zero (bypass).

--- a/doc/source/stdlib/handmade/function-audio-waveshaper_process-0x6d9c8e10b1d34bc6.rst
+++ b/doc/source/stdlib/handmade/function-audio-waveshaper_process-0x6d9c8e10b1d34bc6.rst
@@ -1,0 +1,1 @@
+Process an interleaved stereo buffer in place through the waveshaper, applying gain-compensated tanh saturation proportional to drive.

--- a/doc/source/stdlib/handmade/structure_annotation-audio-ma_bandpass.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-audio-ma_bandpass.rst
@@ -1,0 +1,4 @@
+Stereo biquad bandpass filter state.
+Center frequency in Hz.
+Quality factor (filter bandwidth).
+Sample rate in Hz.

--- a/doc/source/stdlib/handmade/structure_annotation-audio-ma_bitcrush.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-audio-ma_bitcrush.rst
@@ -1,0 +1,3 @@
+Stereo bitcrusher with bit-depth reduction and sample-and-hold decimation.
+Target bit depth (4-16, 0 disables quantization).
+Sample-rate reduction factor (0 disables, 2 halves, 4 quarters).

--- a/doc/source/stdlib/handmade/structure_annotation-audio-ma_compressor.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-audio-ma_compressor.rst
@@ -1,0 +1,7 @@
+Feed-forward compressor with envelope follower and soft knee.
+Threshold in dB (>= 0 bypasses the compressor).
+Compression ratio (1:1 or greater).
+Soft-knee width in dB.
+Attack time in seconds.
+Release time in seconds.
+Sample rate in Hz.

--- a/doc/source/stdlib/handmade/structure_annotation-audio-ma_djfilter.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-audio-ma_djfilter.rst
@@ -1,0 +1,3 @@
+DJ-style one-knob filter sweeping from low-pass through bypass to high-pass.
+Filter position (0 full LPF, 0.5 bypass, 1 full HPF).
+Sample rate in Hz.

--- a/doc/source/stdlib/handmade/structure_annotation-audio-ma_phaser.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-audio-ma_phaser.rst
@@ -1,0 +1,6 @@
+Four-stage all-pass phaser with resonant feedback and triangle LFO.
+LFO rate in Hz.
+Wet/dry mix depth (0..1); also scales feedback.
+Center frequency in Hz for the LFO sweep.
+One-sided LFO sweep range in cents.
+Sample rate in Hz.

--- a/doc/source/stdlib/handmade/structure_annotation-audio-ma_tremolo.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-audio-ma_tremolo.rst
@@ -1,0 +1,4 @@
+Sine-LFO stereo tremolo (amplitude modulation).
+LFO rate in Hz (0 disables the effect).
+Modulation depth (0..1).
+Sample rate in Hz.

--- a/doc/source/stdlib/handmade/structure_annotation-audio-ma_waveshaper.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-audio-ma_waveshaper.rst
@@ -1,0 +1,2 @@
+tanh-based stereo waveshaper for soft saturation.
+Drive amount (0 bypass, 1 mild, 5+ harsh).

--- a/examples/daStrudel/features/chorus_basic.das
+++ b/examples/daStrudel/features/chorus_basic.das
@@ -4,12 +4,12 @@ options persistent_heap
 
 // Sawtooth chord with chorus effect — warm detuned pad with gentle stereo widening.
 // Hear: rich sawtooth chords shimmer and spread as chorus adds subtle detuning.
-// Note: strudel.cc .chorus() is audio chopping, not an effect — our chorus send is daslang-only.
+// Note: chorus here is a per-voice effect send (not pattern audio chopping).
 
 require feature_common
 
 [export]
 def main() {
-    let pat <- note_pattern("<[c3,e3,g3] [f3,a3,c4] [g3,b3,d4] [a3,c4,e4]>", "sawtooth") |> set_chorus(0.5) |> set_attack(0.05) |> set_decay(0.1) |> set_sustain(0.6) |> set_release(0.3) |> set_gain(0.4)
+    let pat <- note("<[c3,e3,g3] [f3,a3,c4] [g3,b3,d4] [a3,c4,e4]>", "sawtooth") |> chorus(0.5) |> attack(0.05) |> decay(0.1) |> sustain(0.6) |> release(0.3) |> gain(0.4)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/combinator_choose.das
+++ b/examples/daStrudel/features/combinator_choose.das
@@ -1,0 +1,26 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// choose randomly picks one pattern per cycle.
+// Hear: each cycle plays a different melodic phrase chosen at random.
+// Note: choose performs a discrete per-cycle pick (alias: chooseCycles).
+/*
+chooseCycles(
+  note("c4 e4 g4").s("sine"),
+  note("d4 f4 a4").s("sine"),
+  note("e4 g4 b4").s("sine")
+).cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- chooseCycles([
+        note("c4 e4 g4", "sine"),
+        note("d4 f4 a4", "sine"),
+        note("e4 g4 b4", "sine")
+    ])
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_chunk.das
+++ b/examples/daStrudel/features/combinator_chunk.das
@@ -1,0 +1,19 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// chunk divides the cycle into n chunks and applies a transform to a rotating chunk.
+// Hear: 8-note pattern where one chunk (out of 4) is played faster each cycle.
+/*
+note("c4 d4 e4 f4 g4 a4 b4 c5").s("sine")
+  .chunk(4, x => x.fast(2))
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 d4 e4 f4 g4 a4 b4 c5", "sine") |> chunk(4, @(var x : Pattern) => fast(x, 2.0lf))
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_compress.das
+++ b/examples/daStrudel/features/combinator_compress.das
@@ -1,0 +1,20 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// compress squeezes the pattern into a time window within each cycle.
+// Hear: melody plays only during the middle half of each cycle, silent at start and end.
+/*
+note("c4 e4 g4 c5").s("sine")
+  .sustain(0.3)
+  .compress(0.25, 0.75)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 e4 g4 c5", "sine") |> sustain(0.3) |> compress(0.25lf, 0.75lf)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_echo.das
+++ b/examples/daStrudel/features/combinator_echo.das
@@ -1,0 +1,20 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// echo — event repetition with gain decay. Each repeat is quieter.
+// Hear: pluck plays, then 3 delayed echoes fading out.
+/*
+note("c4 ~ ~ ~ g3 ~ ~ ~").s("sine")
+  .attack(0.001).decay(0.1).sustain(0).release(0.05)
+  .echo(4, 1/8, 0.5)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 ~ ~ ~ g3 ~ ~ ~", "sine") |> attack(0.001) |> decay(0.1) |> sustain(0.0) |> release(0.05) |> echo(4, 0.125lf, 0.5)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_elongation.das
+++ b/examples/daStrudel/features/combinator_elongation.das
@@ -21,9 +21,9 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- stack([
-      note_pattern("c4 _ _ e4 g4") |> set_sustain(1.0), // elongation with _
-      note_pattern("c4@3 e4 g4") |> set_sustain(1.0)    // same rhythm via @weight
+    let pat <- stack([
+      note("c4 _ _ e4 g4") |> sustain(1.0), // elongation with _
+      note("c4@3 e4 g4") |> sustain(1.0)    // same rhythm via @weight
     ])
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/combinator_hurry.das
+++ b/examples/daStrudel/features/combinator_hurry.das
@@ -1,0 +1,24 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// hurry combines fast + speed — pattern plays faster AND samples pitch up (like tape sped up).
+// Hear: drums play at 2x speed with each hit pitched up an octave. Note: speed only
+// affects sample playback, not oscillators — use a sample source to hear the pitch shift.
+/*
+s("bd sd hh cp").hurry(2).gain(0.4).cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let media = "{get_das_root()}/examples/media"
+    let pat <- s("bd sd hh cp") |> hurry(2.0lf) |> gain(0.4)
+    play_feature_cps(pat, 0.5lf) {
+        strudel_load_sound("{media}/drums/bd", "bd")
+        strudel_load_sound("{media}/drums/sd", "sd")
+        strudel_load_sound("{media}/drums/hh", "hh")
+        strudel_load_sound("{media}/drums/cp", "cp")
+    }
+}

--- a/examples/daStrudel/features/combinator_iter.das
+++ b/examples/daStrudel/features/combinator_iter.das
@@ -1,0 +1,19 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// iter shifts the pattern by 1/n each cycle.
+// Hear: 4-note phrase that rotates its starting point each cycle (c-e-g-a, then e-g-a-c, then g-a-c-e...).
+/*
+note("c4 e4 g4 a4").s("sine")
+  .iter(4)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 e4 g4 a4", "sine") |> iter(4)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_iter_back.das
+++ b/examples/daStrudel/features/combinator_iter_back.das
@@ -1,0 +1,19 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// iterBack shifts right instead of left — phrase rotation in reverse direction.
+// Hear: 4-note phrase rotating its start point BACKWARD each cycle.
+/*
+note("c4 e4 g4 a4").s("sine")
+  .iterBack(4)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 e4 g4 a4", "sine") |> iterBack(4)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_jux_rev.das
+++ b/examples/daStrudel/features/combinator_jux_rev.das
@@ -16,8 +16,8 @@ require feature_common
 [export]
 def main() {
     let media = "{get_das_root()}/examples/media"
-    var pat <- jux(s("bd sd hh cp"), @(x) => rev(x))
-    play_feature_cps(pat, 0.5lf) <| $ {
+    let pat <- jux(s("bd sd hh cp"), @(x) => rev(x))
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sound("{media}/drums/bd", "bd")
         strudel_load_sound("{media}/drums/sd", "sd")
         strudel_load_sound("{media}/drums/hh", "hh")

--- a/examples/daStrudel/features/combinator_jux_transpose.das
+++ b/examples/daStrudel/features/combinator_jux_transpose.das
@@ -16,6 +16,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- jux(note_pattern("c4 e4 g4 c5") |> set_sustain(1.0), @(x) => transpose(x, 7.0))
+    let pat <- jux(note("c4 e4 g4 c5") |> sustain(1.0), @(x) => transpose(x, 7.0))
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/combinator_layer_chord.das
+++ b/examples/daStrudel/features/combinator_layer_chord.das
@@ -16,9 +16,9 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- layer([
-        note_pattern("c3 e3 g3 c4") |> set_sustain(1.0) |> transpose(4.0),
-        note_pattern("c3 e3 g3 c4") |> set_sustain(1.0) |> transpose(7.0)],
-      note_pattern("c3 e3 g3 c4") |> set_sustain(1.0))
+    let pat <- layer([
+        note("c3 e3 g3 c4") |> sustain(1.0) |> transpose(4.0),
+        note("c3 e3 g3 c4") |> sustain(1.0) |> transpose(7.0)],
+      note("c3 e3 g3 c4") |> sustain(1.0))
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/combinator_linger.das
+++ b/examples/daStrudel/features/combinator_linger.das
@@ -1,0 +1,19 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// linger loops the first fraction of a pattern.
+// Hear: only the first half of the melody plays, but it loops twice as fast to fill each cycle.
+/*
+note("c4 e4 g4 c5 a4 g4 e4 c4").s("sine")
+  .linger(0.5)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 e4 g4 c5 a4 g4 e4 c4", "sine") |> linger(0.5lf)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_mask.das
+++ b/examples/daStrudel/features/combinator_mask.das
@@ -1,0 +1,19 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// mask keeps events only where the mask pattern has active events.
+// Hear: melody plays, but muted on beats 2 and 4 (controlled by the mask).
+/*
+note("c4 d4 e4 f4").s("sine")
+  .mask("1 0 1 0")
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 d4 e4 f4", "sine") |> mask(s("1 ~ 1 ~"))
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_off_canon.das
+++ b/examples/daStrudel/features/combinator_off_canon.das
@@ -16,6 +16,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- off(note_pattern("c4 e4 g4 b4") |> set_sustain(1.0), 0.25lf, @(x) => transpose(x, 12.0))
+    let pat <- off(note("c4 e4 g4 b4") |> sustain(1.0), 0.25lf, @(x) => transpose(x, 12.0))
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/combinator_palindrome.das
+++ b/examples/daStrudel/features/combinator_palindrome.das
@@ -1,0 +1,19 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// palindrome alternates forward and reversed cycles.
+// Hear: ascending scale on cycle 0/2/4, descending scale on cycle 1/3/5.
+/*
+note("c4 e4 g4 c5").s("sine")
+  .palindrome()
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 e4 g4 c5", "sine") |> palindrome
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_ply.das
+++ b/examples/daStrudel/features/combinator_ply.das
@@ -1,0 +1,20 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// ply repeats each event n times within its timespan.
+// Hear: 4-note melody where each note is played 3 times in rapid succession.
+/*
+note("c4 e4 g4 c5").s("sine")
+  .sustain(0.3)
+  .ply(3)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 e4 g4 c5", "sine") |> sustain(0.3) |> ply(3)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_rev_melody.das
+++ b/examples/daStrudel/features/combinator_rev_melody.das
@@ -16,6 +16,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- every(2, note_pattern("c4 e4 g4 c5") |> set_sustain(1.0) |> rev(), note_pattern("c4 e4 g4 c5") |> set_sustain(1.0))
+    let pat <- every(2, note("c4 e4 g4 c5") |> sustain(1.0) |> rev(), note("c4 e4 g4 c5") |> sustain(1.0))
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/combinator_scramble.das
+++ b/examples/daStrudel/features/combinator_scramble.das
@@ -1,0 +1,19 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// scramble randomizes pattern with replacement — slots pick randomly, duplicates possible.
+// Hear: 8-note sequence where each slot plays a random note from the original.
+/*
+note("c4 d4 e4 f4 g4 a4 b4 c5").s("sine")
+  .scramble(8)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 d4 e4 f4 g4 a4 b4 c5", "sine") |> scramble(8)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_shuffle.das
+++ b/examples/daStrudel/features/combinator_shuffle.das
@@ -1,0 +1,19 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// shuffle randomly permutes n subdivisions of the pattern per cycle.
+// Hear: 8-note sequence with its order scrambled differently each cycle.
+/*
+note("c4 d4 e4 f4 g4 a4 b4 c5").s("sine")
+  .shuffle(8)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 d4 e4 f4 g4 a4 b4 c5", "sine") |> shuffle(8)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_sometimes_fast.das
+++ b/examples/daStrudel/features/combinator_sometimes_fast.das
@@ -15,8 +15,8 @@ require feature_common
 [export]
 def main() {
     let media = "{get_das_root()}/examples/media"
-    var pat <- sometimes(s("bd sd hh cp"), @(x) => fast(x, 2.0lf))
-    play_feature_cps(pat, 0.5lf) <| $ {
+    let pat <- sometimes(s("bd sd hh cp"), @(x) => fast(x, 2.0lf))
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sound("{media}/drums/bd", "bd")
         strudel_load_sound("{media}/drums/sd", "sd")
         strudel_load_sound("{media}/drums/hh", "hh")

--- a/examples/daStrudel/features/combinator_striate.das
+++ b/examples/daStrudel/features/combinator_striate.das
@@ -1,0 +1,27 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// striate cuts each sample into n slices via begin/end.
+// Hear: drum pattern sped up by 4 — each event plays a progressive quarter of the sample,
+// so successive hits reveal later portions of the sample's natural decay envelope.
+/*
+s("bd sd hh cp")
+  .striate(4)
+  .gain(0.4)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let media = "{get_das_root()}/examples/media"
+    let pat <- s("bd sd hh cp") |> striate(4) |> gain(0.4)
+    play_feature_cps(pat, 0.5lf) {
+        strudel_load_sound("{media}/drums/bd", "bd")
+        strudel_load_sound("{media}/drums/sd", "sd")
+        strudel_load_sound("{media}/drums/hh", "hh")
+        strudel_load_sound("{media}/drums/cp", "cp")
+    }
+}

--- a/examples/daStrudel/features/combinator_struct.das
+++ b/examples/daStrudel/features/combinator_struct.das
@@ -1,0 +1,20 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// struct_ restructures a pattern using a boolean mask pattern.
+// Hear: single note c4, played only on the rhythm specified by the boolean pattern.
+// struct_ replaces the pattern's timing with the mask's timing.
+/*
+note("c4").s("sine")
+  .struct("1 0 1 1 0 1 0 1")
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4", "sine") |> struct_(s("1 ~ 1 1 ~ 1 ~ 1"))
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/combinator_superimpose.das
+++ b/examples/daStrudel/features/combinator_superimpose.das
@@ -1,0 +1,19 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// superimpose stacks the original pattern with a transformed copy.
+// Hear: melody in root position AND a fifth up simultaneously — parallel harmony.
+/*
+note("c4 e4 g4 c5").s("sine")
+  .superimpose(x => x.add(7))
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 e4 g4 c5", "sine") |> superimpose(@(var x : Pattern) => transpose(x, 7.0))
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/delay_basic.das
+++ b/examples/daStrudel/features/delay_basic.das
@@ -20,6 +20,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c4 ~ e4 ~ g4 ~ c5 ~", "sine") |> set_attack(0.001) |> set_decay(0.15) |> set_sustain(0.0) |> set_release(0.01) |> set_delay(0.5) |> set_delaytime(0.5) |> set_delayfeedback(0.4)
+    let pat <- note("c4 ~ e4 ~ g4 ~ c5 ~", "sine") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> delay(0.5) |> delaytime(0.5) |> delayfeedback(0.4)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/delay_long_feedback.das
+++ b/examples/daStrudel/features/delay_long_feedback.das
@@ -20,6 +20,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c4 ~ ~ ~", "sine") |> set_attack(0.001) |> set_decay(0.2) |> set_sustain(0.0) |> set_release(0.01) |> set_delay(0.6) |> set_delaytime(0.375) |> set_delayfeedback(0.8)
+    let pat <- note("c4 ~ ~ ~", "sine") |> attack(0.001) |> decay(0.2) |> sustain(0.0) |> release(0.01) |> delay(0.6) |> delaytime(0.375) |> delayfeedback(0.8)
     play_feature_cps(pat, 0.25lf)
 }

--- a/examples/daStrudel/features/delay_on_melody.das
+++ b/examples/daStrudel/features/delay_on_melody.das
@@ -20,6 +20,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c4 e4 g4 b4 c5 b4 g4 e4", "triangle") |> set_attack(0.001) |> set_decay(0.15) |> set_sustain(0.0) |> set_release(0.01) |> set_delay(0.3) |> set_delaytime(0.75) |> set_delayfeedback(0.4)
+    let pat <- note("c4 e4 g4 b4 c5 b4 g4 e4", "triangle") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> delay(0.3) |> delaytime(0.75) |> delayfeedback(0.4)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/delay_plus_reverb.das
+++ b/examples/daStrudel/features/delay_plus_reverb.das
@@ -22,6 +22,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c4 ~ ~ e4 ~ ~ g4 ~ ~ c5 ~ ~", "sine") |> set_attack(0.001) |> set_decay(0.15) |> set_sustain(0.0) |> set_release(0.01) |> set_delay(0.4) |> set_delaytime(0.375) |> set_delayfeedback(0.5) |> set_room(0.6) |> set_roomsize(3.0)
+    let pat <- note("c4 ~ ~ e4 ~ ~ g4 ~ ~ c5 ~ ~", "sine") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> delay(0.4) |> delaytime(0.375) |> delayfeedback(0.5) |> room(0.6) |> roomsize(3.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/delay_short.das
+++ b/examples/daStrudel/features/delay_short.das
@@ -20,6 +20,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c4 e4 g4 c5", "sine") |> set_attack(0.001) |> set_decay(0.1) |> set_sustain(0.0) |> set_release(0.01) |> set_delay(0.5) |> set_delaytime(0.08) |> set_delayfeedback(0.3)
+    let pat <- note("c4 e4 g4 c5", "sine") |> attack(0.001) |> decay(0.1) |> sustain(0.0) |> release(0.01) |> delay(0.5) |> delaytime(0.08) |> delayfeedback(0.3)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/effect_bandpass_true.das
+++ b/examples/daStrudel/features/effect_bandpass_true.das
@@ -1,0 +1,22 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// True biquad bandpass (bpf/bpq) — narrow resonant peak, unlike the LPF+HPF
+// combination used elsewhere. Hear: a vocal-ish "wah" sweeping across the
+// spectrum, emphasising only a narrow band around the centre frequency.
+/*
+note("c3 e3 g3 c4").s("sawtooth")
+  .sustain(0.8)
+  .bpf(sine.range(300, 3000).slow(4))
+  .bpq(6)
+  .cps(0.8)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c3 e3 g3 c4", "sawtooth") |> sustain(0.8) |> bpf(signal_sine() |> signal_range(300.0, 3000.0) |> slow(4.0lf)) |> bpq(6.0)
+    play_feature_cps(pat, 0.8lf)
+}

--- a/examples/daStrudel/features/effect_bitcrush.das
+++ b/examples/daStrudel/features/effect_bitcrush.das
@@ -1,0 +1,22 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Bitcrusher — amplitude quantisation and sample-rate reduction.
+// Hear: a smooth sawtooth turns into a crunchy, lo-fi, chiptune-style tone.
+// Bits=4 collapses amplitude to 16 levels; coarse=4 holds every 4th sample.
+/*
+note("c3 e3 g3 c4").s("sawtooth")
+  .sustain(0.8)
+  .crush(4)
+  .coarse(4)
+  .cps(0.8)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c3 e3 g3 c4", "sawtooth") |> sustain(0.8) |> crush(4.0) |> coarse(4)
+    play_feature_cps(pat, 0.8lf)
+}

--- a/examples/daStrudel/features/effect_compressor.das
+++ b/examples/daStrudel/features/effect_compressor.das
@@ -1,0 +1,22 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Compressor — feed-forward dynamics with peak detection.
+// Hear: a hard-hitting drum pattern evens out; peaks past the threshold get
+// squashed, making softer hits relatively louder and the groove more punchy.
+/*
+s("bd sd [~ bd] sd,hh*8")
+  .compressor(-20).compressorRatio(10)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    // Punchy drum line: the compressor tames the kick+snare peaks so the hats sit up.
+    let beat <- s("bd sd [~ bd] sd, hh*8")
+    let pat <- beat |> compressor(-20.0) |> compressorRatio(10.0) |> compressorAttack(0.002) |> compressorRelease(0.02)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/effect_djfilter.das
+++ b/examples/daStrudel/features/effect_djfilter.das
@@ -1,0 +1,21 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// DJ filter — LPF/HPF on one knob, bypassed at 0.5.
+// Hear: a slow sweep from bass-only (djf=0) through wide-open (0.5)
+// to high-pass telephone (1.0), like a club filter knob.
+/*
+note("c3 e3 g3 c4").s("sawtooth")
+  .sustain(0.8)
+  .djf(saw.slow(4))
+  .cps(0.8)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c3 e3 g3 c4", "sawtooth") |> sustain(0.8) |> djf(signal_saw() |> slow(4.0lf))
+    play_feature_cps(pat, 0.8lf)
+}

--- a/examples/daStrudel/features/effect_phaser.das
+++ b/examples/daStrudel/features/effect_phaser.das
@@ -1,0 +1,21 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Phaser — single notch biquad with an LFO sweeping the notch frequency.
+// Hear: a sustained sawtooth takes on a swooshing, swept-resonance character
+// as the notch moves through the mid-frequency band.
+/*
+n(run(8)).scale("D:pentatonic").s("sawtooth").release(0.5)
+  .sustain(1)
+  .phaser(2)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- run(8) |> scale("D:pentatonic") |> sound("sawtooth") |> sustain(1.0) |> release(0.5) |> phaser(2.0)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/effect_tremolo.das
+++ b/examples/daStrudel/features/effect_tremolo.das
@@ -1,0 +1,21 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Tremolo — amplitude modulation by a sine LFO.
+// Hear: a sustained pad pulses between full volume and near silence as the
+// LFO sweeps the gain; rate in Hz controls how fast it wobbles.
+/*
+note("d3 d3 d#3 d3").s("supersaw")
+  .sustain(1).release(0.5)
+  .tremolo(8).tremolodepth(0.8)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("d3 d3 d#3 d3", "supersaw") |> sustain(1.0) |> release(0.5) |> tremolo(8.0) |> tremolodepth(0.8)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/effect_waveshaper.das
+++ b/examples/daStrudel/features/effect_waveshaper.das
@@ -1,0 +1,22 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Waveshaper — tanh soft-clipping distortion with adjustable drive.
+// Hear: a pure sine becomes a gritty overdriven tone as shape sweeps up.
+// shape=0 is clean; higher drive adds harmonics and compresses peaks.
+/*
+note("c3 e3 g3 c4").s("sine")
+  .sustain(0.8)
+  .shape(sine.range(0.5, 6))
+  .slow(2)
+  .cps(0.8)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c3 e3 g3 c4", "sine") |> sustain(0.8) |> shape(signal_sine() |> signal_range(0.5, 6.0)) |> slow(2.0lf)
+    play_feature_cps(pat, 0.8lf)
+}

--- a/examples/daStrudel/features/filter_bandpass.das
+++ b/examples/daStrudel/features/filter_bandpass.das
@@ -16,6 +16,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("sawtooth") |> set_note(48.0) |> set_sustain(1.0) |> set_lpf(1500.0) |> set_hpf(500.0)
+    let pat <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> lpf(1500.0) |> hpf(500.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/filter_hpf_thin.das
+++ b/examples/daStrudel/features/filter_hpf_thin.das
@@ -15,6 +15,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("sawtooth") |> set_note(48.0) |> set_sustain(1.0) |> set_hpf(2000.0)
+    let pat <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> hpf(2000.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/filter_lpf_muffled.das
+++ b/examples/daStrudel/features/filter_lpf_muffled.das
@@ -15,6 +15,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("sawtooth") |> set_note(48.0) |> set_sustain(1.0) |> set_lpf(200.0)
+    let pat <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> lpf(200.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/filter_lpf_resonance.das
+++ b/examples/daStrudel/features/filter_lpf_resonance.das
@@ -16,6 +16,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("sawtooth") |> set_note(48.0) |> set_sustain(1.0) |> set_lpf(800.0) |> set_lpq(10.0)
+    let pat <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> lpf(800.0) |> lpq(10.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/filter_resonant_sweep.das
+++ b/examples/daStrudel/features/filter_resonant_sweep.das
@@ -16,7 +16,7 @@ require feature_common
 
 [export]
 def main() {
-    var lpf_sig <- signal_sine() |> signal_range(200.0, 4000.0)
-    var pat <- atom("sawtooth") |> set_note(36.0) |> set_sustain(1.0) |> set_lpf(lpf_sig) |> set_lpq(8.0)
+    let lpf_sig <- sine() |> range(200.0, 4000.0)
+    let pat <- atom("sawtooth") |> note(36.0) |> sustain(1.0) |> lpf(lpf_sig) |> lpq(8.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/integration_fm_vowel_reverb.das
+++ b/examples/daStrudel/features/integration_fm_vowel_reverb.das
@@ -24,6 +24,6 @@ require feature_common
 [export]
 def main() {
     let vowelPat <- s("<a e i o u e>") |> slow(12.0lf)
-    let pat <- note_pattern("<g3 c4 eb4 f4 bb3 g3 ab3 c4>", "sine") |> set_fm(2.0) |> set_fmh(3.0) |> slow(28.0lf) |> set_gain(0.08) |> set_attack(6.0) |> set_decay(3.0) |> set_sustain(0.5) |> set_release(10.0) |> set_vowel(vowelPat) |> set_lpf(1200.0) |> set_room(1.0) |> set_roomsize(10.0) |> set_delay(0.3) |> set_delaytime(0.8) |> set_delayfeedback(0.45)
+    let pat <- note("<g3 c4 eb4 f4 bb3 g3 ab3 c4>", "sine") |> fm(2.0) |> fmh(3.0) |> slow(28.0lf) |> gain(0.08) |> attack(6.0) |> decay(3.0) |> sustain(0.5) |> release(10.0) |> vowel(vowelPat) |> lpf(1200.0) |> room(1.0) |> roomsize(10.0) |> delay(0.3) |> delaytime(0.8) |> delayfeedback(0.45)
     play_feature_cpm(pat, 15.0lf)
 }

--- a/examples/daStrudel/features/integration_full_ambient.das
+++ b/examples/daStrudel/features/integration_full_ambient.das
@@ -78,34 +78,34 @@ require feature_common
 [export]
 def main() {
     // Layer 1: Deep ocean drone — low sine, very slow root movement
-    var layer1 <- note_pattern("<c1 g1 f1 eb1 bb0 f1>", "sine") |> slow(32.0lf) |> set_gain(0.3) |> set_attack(6.0) |> set_sustain(1.0) |> set_release(8.0) |> set_lpf(180.0) |> set_room(1.0) |> set_roomsize(10.0) |> set_orbit(1)
+    var layer1 <- note("<c1 g1 f1 eb1 bb0 f1>", "sine") |> slow(32.0lf) |> gain(0.3) |> attack(6.0) |> sustain(1.0) |> release(8.0) |> lpf(180.0) |> room(1.0) |> roomsize(10.0) |> orbit(1)
 
     // Layer 2: Warm mid pad — detuned supersaw, slow filter sweep
-    let lpf2 <- signal_sine() |> signal_range(250.0, 800.0) |> slow(32.0lf)
-    let pan2 <- signal_sine() |> signal_range(0.3, 0.7) |> slow(20.0lf)
-    var layer2 <- note_pattern("<c2 eb2 g2 bb2 f2 ab2 g2 eb2>", "supersaw") |> slow(24.0lf) |> set_gain(0.1) |> set_attack(4.0) |> set_decay(2.0) |> set_sustain(0.7) |> set_release(6.0) |> set_lpf(lpf2) |> set_hpf(80.0) |> set_room(0.9) |> set_roomsize(8.0) |> set_pan(pan2) |> set_orbit(2)
+    let lpf2 <- sine() |> range(250.0, 800.0) |> slow(32.0lf)
+    let pan2 <- sine() |> range(0.3, 0.7) |> slow(20.0lf)
+    var layer2 <- note("<c2 eb2 g2 bb2 f2 ab2 g2 eb2>", "supersaw") |> slow(24.0lf) |> gain(0.1) |> attack(4.0) |> decay(2.0) |> sustain(0.7) |> release(6.0) |> lpf(lpf2) |> hpf(80.0) |> room(0.9) |> roomsize(8.0) |> pan(pan2) |> orbit(2)
 
     // Layer 3: Choral texture — FM sine + vowel filter
     let vowel3 <- s("<a e i o u e>") |> slow(12.0lf)
-    var layer3 <- note_pattern("<g3 c4 eb4 f4 bb3 g3 ab3 c4>", "sine") |> set_fm(2.0) |> set_fmh(3.0) |> slow(28.0lf) |> set_gain(0.08) |> set_attack(6.0) |> set_decay(3.0) |> set_sustain(0.5) |> set_release(10.0) |> set_vowel(vowel3) |> set_lpf(1200.0) |> set_room(1.0) |> set_roomsize(10.0) |> set_delay(0.3) |> set_delaytime(0.8) |> set_delayfeedback(0.45) |> set_orbit(3)
+    var layer3 <- note("<g3 c4 eb4 f4 bb3 g3 ab3 c4>", "sine") |> fm(2.0) |> fmh(3.0) |> slow(28.0lf) |> gain(0.08) |> attack(6.0) |> decay(3.0) |> sustain(0.5) |> release(10.0) |> vowel(vowel3) |> lpf(1200.0) |> room(1.0) |> roomsize(10.0) |> delay(0.3) |> delaytime(0.8) |> delayfeedback(0.45) |> orbit(3)
 
     // Layer 4: Bubble arpeggios — pentatonic triangle, sparse
-    let gain4 <- signal_perlin() |> signal_range(0.03, 0.12) |> slow(10.0lf)
-    let pan4 <- signal_sine() |> signal_range(0.15, 0.85) |> slow(7.0lf)
-    var layer4 <- scale_pattern("0 ~ ~ 4 ~ 2 ~ ~ 6 ~ 3 ~", "C4:pentatonic", "triangle") |> slow(6.0lf) |> set_gain(gain4) |> set_attack(0.01) |> set_decay(0.4) |> set_sustain(0.05) |> set_release(2.0) |> set_lpf(3000.0) |> set_pan(pan4) |> set_room(0.8) |> set_roomsize(6.0) |> set_delay(0.55) |> set_delaytime(0.5) |> set_delayfeedback(0.65) |> set_orbit(4)
+    let gain4 <- perlin() |> range(0.03, 0.12) |> slow(10.0lf)
+    let pan4 <- sine() |> range(0.15, 0.85) |> slow(7.0lf)
+    var layer4 <- scale_pattern("0 ~ ~ 4 ~ 2 ~ ~ 6 ~ 3 ~", "C4:pentatonic", "triangle") |> slow(6.0lf) |> gain(gain4) |> attack(0.01) |> decay(0.4) |> sustain(0.05) |> release(2.0) |> lpf(3000.0) |> pan(pan4) |> room(0.8) |> roomsize(6.0) |> delay(0.55) |> delaytime(0.5) |> delayfeedback(0.65) |> orbit(4)
 
     // Layer 5: Second arpeggio layer — higher, sparser
-    let gain5 <- signal_perlin() |> signal_range(0.02, 0.08) |> slow(14.0lf)
-    let pan5 <- signal_sine() |> signal_range(0.1, 0.9) |> slow(11.0lf)
-    var layer5 <- scale_pattern("~ 5 ~ ~ 1 ~ ~ ~ 3 ~ ~ 7", "C5:pentatonic", "sine") |> slow(8.0lf) |> set_gain(gain5) |> set_attack(0.02) |> set_decay(0.3) |> set_sustain(0.0) |> set_release(3.0) |> set_lpf(4000.0) |> set_pan(pan5) |> set_room(0.9) |> set_roomsize(9.0) |> set_delay(0.4) |> set_delaytime(0.75) |> set_delayfeedback(0.55) |> set_orbit(4)
+    let gain5 <- perlin() |> range(0.02, 0.08) |> slow(14.0lf)
+    let pan5 <- sine() |> range(0.1, 0.9) |> slow(11.0lf)
+    var layer5 <- scale_pattern("~ 5 ~ ~ 1 ~ ~ ~ 3 ~ ~ 7", "C5:pentatonic", "sine") |> slow(8.0lf) |> gain(gain5) |> attack(0.02) |> decay(0.3) |> sustain(0.0) |> release(3.0) |> lpf(4000.0) |> pan(pan5) |> room(0.9) |> roomsize(9.0) |> delay(0.4) |> delaytime(0.75) |> delayfeedback(0.55) |> orbit(4)
 
     // Layer 6: Filtered noise bed — gentle ocean ambience
-    let lpf6 <- signal_sine() |> signal_range(120.0, 350.0) |> slow(40.0lf)
-    var layer6 <- atom("pink") |> set_gain(0.03) |> set_sustain(1.0) |> set_lpf(lpf6) |> set_hpf(40.0) |> set_room(0.5) |> set_roomsize(4.0) |> set_orbit(5)
+    let lpf6 <- sine() |> range(120.0, 350.0) |> slow(40.0lf)
+    var layer6 <- atom("pink") |> gain(0.03) |> sustain(1.0) |> lpf(lpf6) |> hpf(40.0) |> room(0.5) |> roomsize(4.0) |> orbit(5)
 
     // Layer 7: Sub-harmonic pulse — very slow, barely audible low throb
-    let gain7 <- signal_sine() |> signal_range(0.0, 0.15) |> slow(16.0lf)
-    var layer7 <- note_pattern("<c1 c1 f0 f0>", "sine") |> slow(48.0lf) |> set_gain(gain7) |> set_attack(8.0) |> set_sustain(1.0) |> set_release(10.0) |> set_lpf(100.0) |> set_orbit(1)
+    let gain7 <- sine() |> range(0.0, 0.15) |> slow(16.0lf)
+    var layer7 <- note("<c1 c1 f0 f0>", "sine") |> slow(48.0lf) |> gain(gain7) |> attack(8.0) |> sustain(1.0) |> release(10.0) |> lpf(100.0) |> orbit(1)
 
     let pat <- stack([layer1, layer2, layer3, layer4, layer5, layer6, layer7])
     play_feature_cpm(pat, 15.0lf)

--- a/examples/daStrudel/features/integration_noise_bed.das
+++ b/examples/daStrudel/features/integration_noise_bed.das
@@ -19,7 +19,7 @@ require feature_common
 
 [export]
 def main() {
-    let lpfSig <- signal_sine() |> signal_range(120.0, 350.0) |> slow(40.0lf)
-    let pat <- atom("pink") |> set_gain(0.3) |> set_sustain(1.0) |> set_lpf(lpfSig) |> set_hpf(40.0) |> set_room(0.5) |> set_roomsize(4.0) |> set_orbit(5)
+    let lpfSig <- sine() |> range(120.0, 350.0) |> slow(40.0lf)
+    let pat <- atom("pink") |> gain(0.3) |> sustain(1.0) |> lpf(lpfSig) |> hpf(40.0) |> room(0.5) |> roomsize(4.0) |> orbit(5)
     play_feature_cpm(pat, 15.0lf)
 }

--- a/examples/daStrudel/features/integration_scale_delay_pan.das
+++ b/examples/daStrudel/features/integration_scale_delay_pan.das
@@ -23,8 +23,8 @@ require feature_common
 
 [export]
 def main() {
-    let gainSig <- signal_perlin() |> signal_range(0.03, 0.12) |> slow(10.0lf)
-    let panSig <- signal_sine() |> signal_range(0.15, 0.85) |> slow(7.0lf)
-    let pat <- scale_pattern("0 ~ ~ 4 ~ 2 ~ ~ 6 ~ 3 ~", "C4:pentatonic", "triangle") |> slow(6.0lf) |> set_gain(gainSig) |> set_attack(0.01) |> set_decay(0.4) |> set_sustain(0.05) |> set_release(2.0) |> set_lpf(3000.0) |> set_pan(panSig) |> set_room(0.8) |> set_roomsize(6.0) |> set_delay(0.55) |> set_delaytime(0.5) |> set_delayfeedback(0.65)
+    let gainSig <- perlin() |> range(0.03, 0.12) |> slow(10.0lf)
+    let panSig <- sine() |> range(0.15, 0.85) |> slow(7.0lf)
+    let pat <- scale_pattern("0 ~ ~ 4 ~ 2 ~ ~ 6 ~ 3 ~", "C4:pentatonic", "triangle") |> slow(6.0lf) |> gain(gainSig) |> attack(0.01) |> decay(0.4) |> sustain(0.05) |> release(2.0) |> lpf(3000.0) |> pan(panSig) |> room(0.8) |> roomsize(6.0) |> delay(0.55) |> delaytime(0.5) |> delayfeedback(0.65)
     play_feature_cpm(pat, 15.0lf)
 }

--- a/examples/daStrudel/features/integration_signal_filter_reverb.das
+++ b/examples/daStrudel/features/integration_signal_filter_reverb.das
@@ -23,7 +23,7 @@ require feature_common
 
 [export]
 def main() {
-    let lpfSig <- signal_sine() |> signal_range(200.0, 2000.0) |> slow(4.0lf)
-    let pat <- note_pattern("c3 e3 g3", "sawtooth") |> set_lpf(lpfSig) |> set_gain(0.2) |> set_attack(0.05) |> set_decay(0.2) |> set_sustain(0.8) |> set_release(0.3) |> set_room(0.7) |> set_roomsize(5.0)
+    let lpfSig <- sine() |> range(200.0, 2000.0) |> slow(4.0lf)
+    let pat <- note("c3 e3 g3", "sawtooth") |> lpf(lpfSig) |> gain(0.2) |> attack(0.05) |> decay(0.2) |> sustain(0.8) |> release(0.3) |> room(0.7) |> roomsize(5.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/integration_supersaw_pad.das
+++ b/examples/daStrudel/features/integration_supersaw_pad.das
@@ -23,8 +23,8 @@ require feature_common
 
 [export]
 def main() {
-    let lpfSig <- signal_sine() |> signal_range(250.0, 800.0) |> slow(32.0lf)
-    let panSig <- signal_sine() |> signal_range(0.3, 0.7) |> slow(20.0lf)
-    let pat <- note_pattern("<c2 eb2 g2 bb2 f2 ab2 g2 eb2>", "supersaw") |> slow(24.0lf) |> set_gain(0.1) |> set_attack(4.0) |> set_decay(2.0) |> set_sustain(0.7) |> set_release(6.0) |> set_lpf(lpfSig) |> set_hpf(80.0) |> set_room(0.9) |> set_roomsize(8.0) |> set_pan(panSig) |> set_orbit(2)
+    let lpfSig <- sine() |> range(250.0, 800.0) |> slow(32.0lf)
+    let panSig <- sine() |> range(0.3, 0.7) |> slow(20.0lf)
+    let pat <- note("<c2 eb2 g2 bb2 f2 ab2 g2 eb2>", "supersaw") |> slow(24.0lf) |> gain(0.1) |> attack(4.0) |> decay(2.0) |> sustain(0.7) |> release(6.0) |> lpf(lpfSig) |> hpf(80.0) |> room(0.9) |> roomsize(8.0) |> pan(panSig) |> orbit(2)
     play_feature_cpm(pat, 15.0lf)
 }

--- a/examples/daStrudel/features/orbit_different_reverb.das
+++ b/examples/daStrudel/features/orbit_different_reverb.das
@@ -20,9 +20,9 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- stack([
-        note_pattern("c4 ~ e4 ~", "sine") |> set_attack(0.001) |> set_decay(0.15) |> set_sustain(0.0) |> set_release(0.01) |> set_room(0.8) |> set_roomsize(0.5) |> set_orbit(0),
-        note_pattern("c3", "triangle") |> set_attack(0.5) |> set_decay(0.2) |> set_sustain(0.6) |> set_release(0.5) |> set_room(0.8) |> set_roomsize(8.0) |> set_orbit(1)
+    let pat <- stack([
+        note("c4 ~ e4 ~", "sine") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> room(0.8) |> roomsize(0.5) |> orbit(0),
+        note("c3", "triangle") |> attack(0.5) |> decay(0.2) |> sustain(0.6) |> release(0.5) |> room(0.8) |> roomsize(8.0) |> orbit(1)
     ])
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/orbit_reverb_and_delay.das
+++ b/examples/daStrudel/features/orbit_reverb_and_delay.das
@@ -19,9 +19,9 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- stack([
-        note_pattern("c4 e4 g4 c5", "sine") |> set_attack(0.001) |> set_decay(0.1) |> set_sustain(0.0) |> set_release(0.01) |> set_room(0.8) |> set_roomsize(3.0) |> set_orbit(0),
-        note_pattern("e5 ~ g5 ~ c6 ~ e6 ~", "sine") |> set_attack(0.001) |> set_decay(0.08) |> set_sustain(0.0) |> set_release(0.01) |> set_delay(0.6) |> set_delaytime(0.375) |> set_delayfeedback(0.5) |> set_orbit(1)
+    let pat <- stack([
+        note("c4 e4 g4 c5", "sine") |> attack(0.001) |> decay(0.1) |> sustain(0.0) |> release(0.01) |> room(0.8) |> roomsize(3.0) |> orbit(0),
+        note("e5 ~ g5 ~ c6 ~ e6 ~", "sine") |> attack(0.001) |> decay(0.08) |> sustain(0.0) |> release(0.01) |> delay(0.6) |> delaytime(0.375) |> delayfeedback(0.5) |> orbit(1)
     ])
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/orbit_three_layers.das
+++ b/examples/daStrudel/features/orbit_three_layers.das
@@ -21,13 +21,13 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- stack([
-        note_pattern("c2 ~ c2 ~ g1 ~ g1 ~", "sawtooth") |> set_attack(0.01) |> set_decay(0.1) |> set_sustain(0.3) |> set_release(0.1) |> set_lpf(200.0) |> set_room(0.6) |> set_roomsize(5.0) |> set_orbit(0),
-        note_pattern("e4 g4 c5 e5", "sine") |> set_attack(0.001) |> set_decay(0.1) |> set_sustain(0.0) |> set_release(0.01) |> set_delay(0.4) |> set_delaytime(0.75) |> set_delayfeedback(0.4) |> set_orbit(1),
-        s("bd ~ sd ~ bd ~ sd hh") |> set_orbit(2)
+    let pat <- stack([
+        note("c2 ~ c2 ~ g1 ~ g1 ~", "sawtooth") |> attack(0.01) |> decay(0.1) |> sustain(0.3) |> release(0.1) |> lpf(200.0) |> room(0.6) |> roomsize(5.0) |> orbit(0),
+        note("e4 g4 c5 e5", "sine") |> attack(0.001) |> decay(0.1) |> sustain(0.0) |> release(0.01) |> delay(0.4) |> delaytime(0.75) |> delayfeedback(0.4) |> orbit(1),
+        s("bd ~ sd ~ bd ~ sd hh") |> orbit(2)
     ])
     let media = "{get_das_root()}/examples/media"
-    play_feature_cps(pat, 0.5lf) <| $ {
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sound("{media}/drums/bd", "bd")
         strudel_load_sound("{media}/drums/sd", "sd")
         strudel_load_sound("{media}/drums/hh", "hh")

--- a/examples/daStrudel/features/reverb_dry_vs_wet.das
+++ b/examples/daStrudel/features/reverb_dry_vs_wet.das
@@ -19,6 +19,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c4 ~ c4 ~", "sine") |> set_attack(0.001) |> set_decay(0.15) |> set_sustain(0.0) |> set_release(0.01) |> set_room(0.8) |> set_roomsize(2.0)
+    let pat <- note("c4 ~ c4 ~", "sine") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> room(0.8) |> roomsize(2.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/reverb_large_room.das
+++ b/examples/daStrudel/features/reverb_large_room.das
@@ -19,6 +19,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c4 ~ ~ e4 ~ ~ g4 ~ ~ c5 ~ ~", "sine") |> set_attack(0.001) |> set_decay(0.15) |> set_sustain(0.0) |> set_release(0.01) |> set_room(0.8) |> set_roomsize(8.0)
+    let pat <- note("c4 ~ ~ e4 ~ ~ g4 ~ ~ c5 ~ ~", "sine") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> room(0.8) |> roomsize(8.0)
     play_feature_cps(pat, 0.25lf)
 }

--- a/examples/daStrudel/features/reverb_on_drums.das
+++ b/examples/daStrudel/features/reverb_on_drums.das
@@ -15,6 +15,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- s("bd sd bd [sd cp]") |> set_room(0.5) |> set_roomsize(3.0)
+    let pat <- s("bd sd bd [sd cp]") |> room(0.5) |> roomsize(3.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/reverb_on_pad.das
+++ b/examples/daStrudel/features/reverb_on_pad.das
@@ -20,6 +20,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c3,e3,g3", "supersaw") |> set_attack(0.5) |> set_decay(0.1) |> set_sustain(0.7) |> set_release(1.0) |> set_lpf(3000.0) |> set_room(0.8) |> set_roomsize(4.0)
+    let pat <- note("c3,e3,g3", "supersaw") |> attack(0.5) |> decay(0.1) |> sustain(0.7) |> release(1.0) |> lpf(3000.0) |> room(0.8) |> roomsize(4.0)
     play_feature_cps(pat, 0.25lf)
 }

--- a/examples/daStrudel/features/reverb_small_room.das
+++ b/examples/daStrudel/features/reverb_small_room.das
@@ -19,6 +19,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c4 e4 g4 c5", "sine") |> set_attack(0.001) |> set_decay(0.1) |> set_sustain(0.0) |> set_release(0.01) |> set_room(0.8) |> set_roomsize(0.3)
+    let pat <- note("c4 e4 g4 c5", "sine") |> attack(0.001) |> decay(0.1) |> sustain(0.0) |> release(0.01) |> room(0.8) |> roomsize(0.3)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/scale_major_vs_minor.das
+++ b/examples/daStrudel/features/scale_major_vs_minor.das
@@ -18,8 +18,8 @@ require feature_common
 [export]
 def main() {
     let pat <- stack([
-        scale_pattern("0 2 4 6", "C4:major") |> set_attack(0.001) |> set_decay(0.1) |> set_sustain(0.0) |> set_release(0.2) |> set_gain(0.5),
-        scale_pattern("0 2 4 6", "C4:minor", "sawtooth") |> set_attack(0.01) |> set_decay(0.1) |> set_sustain(0.3) |> set_release(0.2) |> set_gain(0.3) |> set_lpf(2000.0)
+        scale_pattern("0 2 4 6", "C4:major") |> attack(0.001) |> decay(0.1) |> sustain(0.0) |> release(0.2) |> gain(0.5),
+        scale_pattern("0 2 4 6", "C4:minor", "sawtooth") |> attack(0.01) |> decay(0.1) |> sustain(0.3) |> release(0.2) |> gain(0.3) |> lpf(2000.0)
     ])
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/scale_minor.das
+++ b/examples/daStrudel/features/scale_minor.das
@@ -15,6 +15,6 @@ require feature_common
 
 [export]
 def main() {
-    let pat <- scale_pattern("0 1 2 3 4", "C4:minor:pentatonic") |> set_attack(0.001) |> set_decay(0.1) |> set_sustain(0.0) |> set_release(0.2)
+    let pat <- scale_pattern("0 1 2 3 4", "C4:minor:pentatonic") |> attack(0.001) |> decay(0.1) |> sustain(0.0) |> release(0.2)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/scale_pentatonic.das
+++ b/examples/daStrudel/features/scale_pentatonic.das
@@ -14,6 +14,6 @@ require feature_common
 
 [export]
 def main() {
-    let pat <- scale_pattern("0 1 2 3 4", "C4:major:pentatonic") |> set_attack(0.001) |> set_decay(0.1) |> set_sustain(0.0) |> set_release(0.2)
+    let pat <- scale_pattern("0 1 2 3 4", "C4:major:pentatonic") |> attack(0.001) |> decay(0.1) |> sustain(0.0) |> release(0.2)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/scale_two_octaves.das
+++ b/examples/daStrudel/features/scale_two_octaves.das
@@ -20,8 +20,8 @@ require feature_common
 [export]
 def main() {
     let pat <- stack([
-        scale_pattern("0 2 4 3", "C4:major:pentatonic", "sawtooth") |> set_attack(0.01) |> set_decay(0.1) |> set_sustain(0.3) |> set_release(0.1) |> set_lpf(500.0) |> set_gain(0.4),
-        scale_pattern("4 2 3 0", "C5:major:pentatonic") |> set_attack(0.001) |> set_decay(0.05) |> set_sustain(0.0) |> set_release(0.2) |> set_delay(0.3) |> set_delaytime(0.375) |> set_delayfeedback(0.3) |> set_gain(0.5)
+        scale_pattern("0 2 4 3", "C4:major:pentatonic", "sawtooth") |> attack(0.01) |> decay(0.1) |> sustain(0.3) |> release(0.1) |> lpf(500.0) |> gain(0.4),
+        scale_pattern("4 2 3 0", "C5:major:pentatonic") |> attack(0.001) |> decay(0.05) |> sustain(0.0) |> release(0.2) |> delay(0.3) |> delaytime(0.375) |> delayfeedback(0.3) |> gain(0.5)
     ])
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/scale_with_rests.das
+++ b/examples/daStrudel/features/scale_with_rests.das
@@ -15,6 +15,6 @@ require feature_common
 
 [export]
 def main() {
-    let pat <- scale_pattern("0 ~ ~ 4 ~ 2 ~ ~ 6 ~ 3 ~", "C4:major:pentatonic") |> set_attack(0.001) |> set_decay(0.05) |> set_sustain(0.0) |> set_release(0.3) |> set_room(0.4) |> set_roomsize(3.0)
+    let pat <- scale_pattern("0 ~ ~ 4 ~ 2 ~ ~ 6 ~ 3 ~", "C4:major:pentatonic") |> attack(0.001) |> decay(0.05) |> sustain(0.0) |> release(0.3) |> room(0.4) |> roomsize(3.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/sf2_drums_and_bass.das
+++ b/examples/daStrudel/features/sf2_drums_and_bass.das
@@ -4,7 +4,7 @@ options persistent_heap
 
 // Drums and bass layered — GM percussion with acoustic bass.
 // Hear: punchy kick-snare-hihat groove anchored by a walking bass line.
-// SF2 is daslang-only — no strudel.cc equivalent.
+// SF2 playback is a daslang-only extension.
 
 require feature_common
 
@@ -12,11 +12,11 @@ require feature_common
 def main() {
     let pat <- stack([
         // Drums — bank 128 GM percussion
-        note_pattern("c2 ~ d2 ~, [fs2 fs2] [fs2 fs2] [fs2 fs2] [fs2 fs2]") |> set_sf2(0) |> set_sf2_bank(128) |> set_gain(0.7),
+        note("c2 ~ d2 ~, [fs2 fs2] [fs2 fs2] [fs2 fs2] [fs2 fs2]") |> sf2(0) |> sf2_bank(128) |> gain(0.7),
         // Bass — root notes following chord changes
-        note_pattern("c2 ~ c2 ~, ~ ~ e2 ~, g2 ~ ~ g2, ~ ~ f2 ~") |> set_sf2("acoustic_bass") |> set_gain(0.6)
+        note("c2 ~ c2 ~, ~ ~ e2 ~, g2 ~ ~ g2, ~ ~ f2 ~") |> sf2("acoustic_bass") |> gain(0.6)
     ])
-    play_feature_cps(pat, 0.5lf) <| $ {
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
     }
 }

--- a/examples/daStrudel/features/sf2_drums_basic.das
+++ b/examples/daStrudel/features/sf2_drums_basic.das
@@ -6,14 +6,14 @@ options persistent_heap
 // GM drum note mapping: c2=kick(36), d2=snare(38), eb2=clap(39),
 //   fs2=closed_hh(42), as2=open_hh(46), cs2=side_stick(37).
 // Hear: four-on-the-floor kick, snare on 2 and 4, steady closed hi-hats.
-// SF2 is daslang-only — no strudel.cc equivalent.
+// SF2 playback is a daslang-only extension.
 
 require feature_common
 
 [export]
 def main() {
-    let pat <- note_pattern("c2 ~ d2 ~, [fs2 fs2] [fs2 fs2] [fs2 fs2] [fs2 fs2]") |> set_sf2(0) |> set_sf2_bank(128) |> set_gain(0.7)
-    play_feature_cps(pat, 0.5lf) <| $ {
+    let pat <- note("c2 ~ d2 ~, [fs2 fs2] [fs2 fs2] [fs2 fs2] [fs2 fs2]") |> sf2(0) |> sf2_bank(128) |> gain(0.7)
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
     }
 }

--- a/examples/daStrudel/features/sf2_expression.das
+++ b/examples/daStrudel/features/sf2_expression.das
@@ -4,7 +4,7 @@ options persistent_heap
 
 // SF2 expression control on string ensemble — two layers at different dynamic levels.
 // Hear: soft strings (expression 0.3) underneath full strings (expression 1.0), showing dynamics without gain change.
-// SF2 expression is daslang-only — no strudel.cc equivalent.
+// SF2 expression is a daslang-only extension.
 
 require feature_common
 
@@ -12,11 +12,11 @@ require feature_common
 def main() {
     let pat <- stack([
         // Soft strings — low expression for gentle dynamics
-        note_pattern("<[c3,e3,g3] [f3,a3,c4]>") |> set_sf2("string_ensemble") |> set_sf2_expression(0.3) |> set_gain(0.5),
+        note("<[c3,e3,g3] [f3,a3,c4]>") |> sf2("string_ensemble") |> sf2_expression(0.3) |> gain(0.5),
         // Full strings — high expression for rich dynamics
-        note_pattern("<[g3,b3,d4] [a3,c4,e4]>") |> set_sf2("string_ensemble") |> set_sf2_expression(1.0) |> set_gain(0.5)
+        note("<[g3,b3,d4] [a3,c4,e4]>") |> sf2("string_ensemble") |> sf2_expression(1.0) |> gain(0.5)
     ])
-    play_feature_cps(pat, 0.5lf) <| $ {
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
     }
 }

--- a/examples/daStrudel/features/sf2_full_band.das
+++ b/examples/daStrudel/features/sf2_full_band.das
@@ -5,7 +5,7 @@ options persistent_heap
 // Full band arrangement: drums, bass, piano chords, flute melody.
 // Am-F-C-G progression with four SF2 layers via stack.
 // Hear: complete lo-fi chill track — kick-snare groove, walking bass, jazzy piano, soaring flute.
-// SF2 is daslang-only — no strudel.cc equivalent.
+// SF2 playback is a daslang-only extension.
 
 require feature_common
 
@@ -13,15 +13,15 @@ require feature_common
 def main() {
     let pat <- stack([
         // Drums — GM bank 128: kick, clap, closed hi-hats
-        note_pattern("c2 ~ d2 ~, ~ eb2 ~ eb2, [fs2 fs2] [fs2 fs2] [fs2 fs2] [fs2 fs2]") |> set_sf2(0) |> set_sf2_bank(128) |> set_gain(0.7),
+        note("c2 ~ d2 ~, ~ eb2 ~ eb2, [fs2 fs2] [fs2 fs2] [fs2 fs2] [fs2 fs2]") |> sf2(0) |> sf2_bank(128) |> gain(0.7),
         // Bass — acoustic bass following Am-F-C-G roots
-        note_pattern("<[a1 ~ ~ a1 ~ a1 ~ ~] [f1 ~ ~ f1 ~ f1 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g1 ~ ~ g1 ~ g1 ~ ~]>") |> set_sf2("acoustic_bass") |> set_gain(0.6),
+        note("<[a1 ~ ~ a1 ~ a1 ~ ~] [f1 ~ ~ f1 ~ f1 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g1 ~ ~ g1 ~ g1 ~ ~]>") |> sf2("acoustic_bass") |> gain(0.6),
         // Piano — block chords, Am-F-C-G
-        note_pattern("<[a3,c4,e4] [f3,a3,c4] [c3,e3,g3] [g3,b3,d4]>") |> set_sf2("piano") |> set_gain(0.4),
+        note("<[a3,c4,e4] [f3,a3,c4] [c3,e3,g3] [g3,b3,d4]>") |> sf2("piano") |> gain(0.4),
         // Flute — arpeggiated melody over the progression
-        note_pattern("<[a4 c5 e5 a5] [f4 a4 c5 f5] [c4 e4 g4 c5] [g4 b4 d5 g5]>") |> set_sf2("flute") |> set_gain(0.45)
+        note("<[a4 c5 e5 a5] [f4 a4 c5 f5] [c4 e4 g4 c5] [g4 b4 d5 g5]>") |> sf2("flute") |> gain(0.45)
     ])
-    play_feature_cps(pat, 0.5lf) <| $ {
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
     }
 }

--- a/examples/daStrudel/features/sf2_instruments.das
+++ b/examples/daStrudel/features/sf2_instruments.das
@@ -4,7 +4,7 @@ options persistent_heap
 
 // Three GM instruments layered: string ensemble pad, flute melody, piano chords.
 // Hear: lush strings sustain Am-F-C-G, flute arpeggiates over them, piano punctuates chords.
-// SF2 is daslang-only — no strudel.cc equivalent.
+// SF2 playback is a daslang-only extension.
 
 require feature_common
 
@@ -12,13 +12,13 @@ require feature_common
 def main() {
     let pat <- stack([
         // String ensemble pad — sustained chords, Am-F-C-G
-        note_pattern("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>") |> set_sf2("string_ensemble") |> set_gain(0.3),
+        note("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>") |> sf2("string_ensemble") |> gain(0.3),
         // Flute melody — arpeggiated notes over the chords
-        note_pattern("<[a4 c5 e5] [f4 a4 c5] [c4 e4 g4] [g4 b4 d5]>") |> set_sf2("flute") |> set_gain(0.5),
+        note("<[a4 c5 e5] [f4 a4 c5] [c4 e4 g4] [g4 b4 d5]>") |> sf2("flute") |> gain(0.5),
         // Piano chords — block chords for harmonic support
-        note_pattern("<[a3,c4,e4] [f3,a3,c4] [c3,e3,g3] [g3,b3,d4]>") |> set_sf2("piano") |> set_gain(0.4)
+        note("<[a3,c4,e4] [f3,a3,c4] [c3,e3,g3] [g3,b3,d4]>") |> sf2("piano") |> gain(0.4)
     ])
-    play_feature_cps(pat, 0.5lf) <| $ {
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
     }
 }

--- a/examples/daStrudel/features/sf2_integration_full_ambient.das
+++ b/examples/daStrudel/features/sf2_integration_full_ambient.das
@@ -5,7 +5,7 @@ options persistent_heap
 // SF2 ambient piece — 8 layers using SoundFont instruments for natural, organic textures.
 // Inspired by integration_full_ambient.das but using SF2 for richer timbres.
 // Arrhythmic, slow harmonic drift, large reverb spaces, modal harmony in C minor.
-// SF2 is daslang-only — no strudel.cc equivalent.
+// SF2 playback is a daslang-only extension.
 
 require feature_common
 require daslib/fio
@@ -36,42 +36,42 @@ def find_sf2() : string {
 [export]
 def main() {
     // Layer 1: Deep cello drone — slow root movement, huge reverb tail
-    var layer1 <- note_pattern("<c2 g2 f2 eb2 bb1 f2>") |> set_sf2("cello") |> slow(32.0lf) |> set_gain(0.15) |> set_sf2_expression(0.6) |> set_room(0.8) |> set_roomsize(10.0) |> set_orbit(1)
+    var layer1 <- note("<c2 g2 f2 eb2 bb1 f2>") |> sf2("cello") |> slow(32.0lf) |> gain(0.15) |> sf2_expression(0.6) |> room(0.8) |> roomsize(10.0) |> orbit(1)
 
     // Layer 2: String ensemble pad — warm sustained chords, gentle sway
-    let pan2 <- signal_sine() |> signal_range(0.3, 0.7) |> slow(20.0lf)
-    var layer2 <- note_pattern("<[c3,eb3,g3] [eb3,g3,bb3] [f3,ab3,c4] [bb2,eb3,g3] [ab2,c3,eb3] [g2,bb2,eb3]>") |> set_sf2("string_ensemble") |> slow(24.0lf) |> set_gain(0.25) |> set_sf2_expression(0.5) |> set_sf2_mod_wheel(0.3) |> set_room(0.7) |> set_roomsize(8.0) |> set_pan(pan2) |> set_orbit(2)
+    let pan2 <- sine() |> range(0.3, 0.7) |> slow(20.0lf)
+    var layer2 <- note("<[c3,eb3,g3] [eb3,g3,bb3] [f3,ab3,c4] [bb2,eb3,g3] [ab2,c3,eb3] [g2,bb2,eb3]>") |> sf2("string_ensemble") |> slow(24.0lf) |> gain(0.25) |> sf2_expression(0.5) |> sf2_mod_wheel(0.3) |> room(0.7) |> roomsize(8.0) |> pan(pan2) |> orbit(2)
 
     // Layer 3: Choir — ethereal texture, very slow, drenched in reverb+delay
-    var layer3 <- note_pattern("<[g3,c4,eb4] [f3,bb3,eb4] [ab3,c4,f4] [g3,bb3,eb4]>") |> set_sf2("choir") |> slow(28.0lf) |> set_gain(0.15) |> set_sf2_expression(0.4) |> set_sf2_mod_wheel(0.5) |> set_room(0.9) |> set_roomsize(10.0) |> set_delay(0.25) |> set_delaytime(0.8) |> set_delayfeedback(0.4) |> set_orbit(3)
+    var layer3 <- note("<[g3,c4,eb4] [f3,bb3,eb4] [ab3,c4,f4] [g3,bb3,eb4]>") |> sf2("choir") |> slow(28.0lf) |> gain(0.15) |> sf2_expression(0.4) |> sf2_mod_wheel(0.5) |> room(0.9) |> roomsize(10.0) |> delay(0.25) |> delaytime(0.8) |> delayfeedback(0.4) |> orbit(3)
 
     // Layer 4: Vibraphone arpeggios — delicate bell-like bubbles
-    let gain4 <- signal_perlin() |> signal_range(0.08, 0.25) |> slow(10.0lf)
-    let pan4 <- signal_sine() |> signal_range(0.15, 0.85) |> slow(7.0lf)
-    var layer4 <- note_pattern("c5 ~ ~ eb5 ~ g4 ~ ~ bb4 ~ f5 ~") |> set_sf2("vibraphone") |> slow(6.0lf) |> set_gain(gain4) |> set_pan(pan4) |> set_room(0.7) |> set_roomsize(6.0) |> set_delay(0.4) |> set_delaytime(0.5) |> set_delayfeedback(0.55) |> set_orbit(4)
+    let gain4 <- perlin() |> range(0.08, 0.25) |> slow(10.0lf)
+    let pan4 <- sine() |> range(0.15, 0.85) |> slow(7.0lf)
+    var layer4 <- note("c5 ~ ~ eb5 ~ g4 ~ ~ bb4 ~ f5 ~") |> sf2("vibraphone") |> slow(6.0lf) |> gain(gain4) |> pan(pan4) |> room(0.7) |> roomsize(6.0) |> delay(0.4) |> delaytime(0.5) |> delayfeedback(0.55) |> orbit(4)
 
     // Layer 5: Flute — high, sparse, breathy melody floating above everything
-    let gain5 <- signal_perlin() |> signal_range(0.05, 0.18) |> slow(14.0lf)
-    let pan5 <- signal_sine() |> signal_range(0.1, 0.9) |> slow(11.0lf)
-    var layer5 <- note_pattern("~ g5 ~ ~ c5 ~ ~ ~ eb5 ~ ~ bb5") |> set_sf2("flute") |> slow(8.0lf) |> set_gain(gain5) |> set_sf2_mod_wheel(0.6) |> set_pan(pan5) |> set_room(0.8) |> set_roomsize(9.0) |> set_delay(0.3) |> set_delaytime(0.75) |> set_delayfeedback(0.45) |> set_orbit(4)
+    let gain5 <- perlin() |> range(0.05, 0.18) |> slow(14.0lf)
+    let pan5 <- sine() |> range(0.1, 0.9) |> slow(11.0lf)
+    var layer5 <- note("~ g5 ~ ~ c5 ~ ~ ~ eb5 ~ ~ bb5") |> sf2("flute") |> slow(8.0lf) |> gain(gain5) |> sf2_mod_wheel(0.6) |> pan(pan5) |> room(0.8) |> roomsize(9.0) |> delay(0.3) |> delaytime(0.75) |> delayfeedback(0.45) |> orbit(4)
 
     // Layer 6: Harp — occasional gentle plucks, wide stereo, adding sparkle
-    let gain6 <- signal_perlin() |> signal_range(0.06, 0.2) |> slow(12.0lf)
-    let pan6 <- signal_sine() |> signal_range(0.1, 0.9) |> slow(9.0lf)
-    var layer6 <- note_pattern("~ ~ c4 ~ ~ ~ g4 ~ ~ eb4 ~ ~") |> set_sf2("harp") |> slow(10.0lf) |> set_gain(gain6) |> set_pan(pan6) |> set_room(0.6) |> set_roomsize(5.0) |> set_delay(0.35) |> set_delaytime(0.6) |> set_delayfeedback(0.5) |> set_orbit(5)
+    let gain6 <- perlin() |> range(0.06, 0.2) |> slow(12.0lf)
+    let pan6 <- sine() |> range(0.1, 0.9) |> slow(9.0lf)
+    var layer6 <- note("~ ~ c4 ~ ~ ~ g4 ~ ~ eb4 ~ ~") |> sf2("harp") |> slow(10.0lf) |> gain(gain6) |> pan(pan6) |> room(0.6) |> roomsize(5.0) |> delay(0.35) |> delaytime(0.6) |> delayfeedback(0.5) |> orbit(5)
 
     // Layer 7: Contrabass — sub-harmonic anchor, very slow, barely there
-    let gain7 <- signal_sine() |> signal_range(0.05, 0.2) |> slow(16.0lf)
-    var layer7 <- note_pattern("<c1 c1 f1 f1>") |> set_sf2("contrabass") |> slow(48.0lf) |> set_gain(gain7) |> set_sf2_expression(0.4) |> set_room(0.5) |> set_roomsize(6.0) |> set_orbit(1)
+    let gain7 <- sine() |> range(0.05, 0.2) |> slow(16.0lf)
+    var layer7 <- note("<c1 c1 f1 f1>") |> sf2("contrabass") |> slow(48.0lf) |> gain(gain7) |> sf2_expression(0.4) |> room(0.5) |> roomsize(6.0) |> orbit(1)
 
     // Layer 8: Heartbeat — slow kick + soft rimshot, distant and hypnotic
-    let gain8 <- signal_sine() |> signal_range(0.06, 0.15) |> slow(20.0lf)
-    var layer8 <- note_pattern("c2 ~ ~ ~ ~ ~ cs2 ~ ~ ~ ~ ~") |> set_sf2(0) |> set_sf2_bank(128) |> slow(4.0lf) |> set_gain(gain8) |> set_room(0.5) |> set_roomsize(4.0) |> set_orbit(5)
+    let gain8 <- sine() |> range(0.06, 0.15) |> slow(20.0lf)
+    var layer8 <- note("c2 ~ ~ ~ ~ ~ cs2 ~ ~ ~ ~ ~") |> sf2(0) |> sf2_bank(128) |> slow(4.0lf) |> gain(gain8) |> room(0.5) |> roomsize(4.0) |> orbit(5)
 
     let pat <- stack([layer1, layer2, layer3, layer4, layer5, layer6, layer7, layer8])
 
     default_feature_duration = 60.0  // override default duration for this feature
-    play_feature_cps(pat, 15.0lf / 60.0lf) <| $ {
+    play_feature_cps(pat, 15.0lf / 60.0lf) {
         strudel_load_sf2(find_sf2())
     }
 }

--- a/examples/daStrudel/features/sf2_mod_wheel.das
+++ b/examples/daStrudel/features/sf2_mod_wheel.das
@@ -4,7 +4,7 @@ options persistent_heap
 
 // Flute melody with and without mod wheel vibrato — compare clean vs expressive.
 // Hear: dry flute plays a simple melody, then vibrato-rich flute repeats it with warmth and motion.
-// SF2 mod wheel is daslang-only — no strudel.cc equivalent.
+// SF2 mod wheel is a daslang-only extension.
 
 require feature_common
 
@@ -12,11 +12,11 @@ require feature_common
 def main() {
     let pat <- stack([
         // Clean flute — no mod wheel, dry and pure
-        note_pattern("c4 e4 g4 c5") |> set_sf2("flute") |> set_gain(0.5),
+        note("c4 e4 g4 c5") |> sf2("flute") |> gain(0.5),
         // Vibrato flute — mod wheel adds expressive vibrato
-        note_pattern("c4 e4 g4 c5") |> set_sf2("flute") |> set_sf2_mod_wheel(0.8) |> set_gain(0.5)
+        note("c4 e4 g4 c5") |> sf2("flute") |> sf2_mod_wheel(0.8) |> gain(0.5)
     ])
-    play_feature_cps(pat, 0.5lf) <| $ {
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
     }
 }

--- a/examples/daStrudel/features/sf2_piano.das
+++ b/examples/daStrudel/features/sf2_piano.das
@@ -4,14 +4,14 @@ options persistent_heap
 
 // Simple ascending C major scale on acoustic piano via SF2.
 // Hear: clean piano notes stepping up from C3 to C4.
-// SF2 is daslang-only — no strudel.cc equivalent.
+// SF2 playback is a daslang-only extension.
 
 require feature_common
 
 [export]
 def main() {
-    let pat <- note_pattern("c3 d3 e3 f3 g3 a3 b3 c4") |> set_sf2("piano") |> set_gain(0.6)
-    play_feature_cps(pat, 0.5lf) <| $ {
+    let pat <- note("c3 d3 e3 f3 g3 a3 b3 c4") |> sf2("piano") |> gain(0.6)
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
     }
 }

--- a/examples/daStrudel/features/sf2_pitch_bend.das
+++ b/examples/daStrudel/features/sf2_pitch_bend.das
@@ -4,7 +4,7 @@ options persistent_heap
 
 // Guitar notes with pitch bend — bent down, center, and bent up.
 // Hear: first note bends below pitch, second is natural, third bends above — like a guitarist bending strings.
-// SF2 pitch bend is daslang-only — no strudel.cc equivalent.
+// SF2 pitch bend is a daslang-only extension.
 
 require feature_common
 
@@ -12,13 +12,13 @@ require feature_common
 def main() {
     let pat <- stack([
         // Bent down — pitch wheel below center
-        note_pattern("e3") |> set_sf2("guitar") |> set_sf2_pitch_bend(0.3) |> set_gain(0.5),
+        note("e3") |> sf2("guitar") |> sf2_pitch_bend(0.3) |> gain(0.5),
         // Center — natural pitch, no bend
-        note_pattern("e3") |> set_sf2("guitar") |> set_sf2_pitch_bend(0.5) |> set_gain(0.5),
+        note("e3") |> sf2("guitar") |> sf2_pitch_bend(0.5) |> gain(0.5),
         // Bent up — pitch wheel above center
-        note_pattern("e3") |> set_sf2("guitar") |> set_sf2_pitch_bend(0.7) |> set_gain(0.5)
+        note("e3") |> sf2("guitar") |> sf2_pitch_bend(0.7) |> gain(0.5)
     ])
-    play_feature_cps(pat, 0.5lf) <| $ {
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
     }
 }

--- a/examples/daStrudel/features/sf2_program_numbers.das
+++ b/examples/daStrudel/features/sf2_program_numbers.das
@@ -5,7 +5,7 @@ options persistent_heap
 // Using numeric GM program IDs instead of instrument names.
 // Program numbers: 0=acoustic_grand_piano, 73=flute, 48=string_ensemble.
 // Hear: piano chords, flute melody, and string pad — same as sf2_instruments but with numbers.
-// SF2 is daslang-only — no strudel.cc equivalent.
+// SF2 playback is a daslang-only extension.
 
 require feature_common
 
@@ -13,13 +13,13 @@ require feature_common
 def main() {
     let pat <- stack([
         // String ensemble pad — program 48
-        note_pattern("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>") |> set_sf2(48) |> set_gain(0.3),
+        note("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>") |> sf2(48) |> gain(0.3),
         // Flute melody — program 73
-        note_pattern("<[a4 c5 e5] [f4 a4 c5] [c4 e4 g4] [g4 b4 d5]>") |> set_sf2(73) |> set_gain(0.5),
+        note("<[a4 c5 e5] [f4 a4 c5] [c4 e4 g4] [g4 b4 d5]>") |> sf2(73) |> gain(0.5),
         // Piano chords — program 0
-        note_pattern("<[a3,c4,e4] [f3,a3,c4] [c3,e3,g3] [g3,b3,d4]>") |> set_sf2(0) |> set_gain(0.4)
+        note("<[a3,c4,e4] [f3,a3,c4] [c3,e3,g3] [g3,b3,d4]>") |> sf2(0) |> gain(0.4)
     ])
-    play_feature_cps(pat, 0.5lf) <| $ {
+    play_feature_cps(pat, 0.5lf) {
         strudel_load_sf2("{get_das_root()}/examples/daStrudel/midi_sf2_demo/FluidR3_GM.sf2")
     }
 }

--- a/examples/daStrudel/features/signal_fast_vs_slow.das
+++ b/examples/daStrudel/features/signal_fast_vs_slow.das
@@ -15,7 +15,7 @@ require feature_common
 
 [export]
 def main() {
-    var lpf_sig <- signal_sine() |> signal_range(200.0, 4000.0) |> slow(n("<2 16>"))
-    var pat <- atom("sawtooth") |> set_note(48.0) |> set_sustain(1.0) |> set_lpf(lpf_sig)
+    let lpf_sig <- sine() |> range(200.0, 4000.0) |> slow(n("<2 16>"))
+    let pat <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> lpf(lpf_sig)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/signal_gain_pulse.das
+++ b/examples/daStrudel/features/signal_gain_pulse.das
@@ -14,6 +14,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("sine") |> set_note(48.0) |> set_sustain(1.0) |> set_gain(signal_sine() |> slow(2.0lf))
+    let pat <- atom("sine") |> note(48.0) |> sustain(1.0) |> gain(sine() |> slow(2.0lf))
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/signal_lpf_sweep.das
+++ b/examples/daStrudel/features/signal_lpf_sweep.das
@@ -15,6 +15,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("sawtooth") |> set_note(48.0) |> set_sustain(1.0) |> set_lpf(signal_sine() |> signal_range(200.0, 4000.0) |> slow(4.0lf))
+    let pat <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> lpf(sine() |> range(200.0, 4000.0) |> slow(4.0lf))
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/signal_on_chord.das
+++ b/examples/daStrudel/features/signal_on_chord.das
@@ -20,6 +20,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c3,e3,g3", "sawtooth") |> set_sustain(1.0) |> set_lpf(signal_sine() |> signal_range(200.0, 3000.0) |> slow(4.0lf)) |> set_gain(0.3)
+    let pat <- note("c3,e3,g3", "sawtooth") |> sustain(1.0) |> lpf(sine() |> range(200.0, 3000.0) |> slow(4.0lf)) |> gain(0.3)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/signal_pan_drift.das
+++ b/examples/daStrudel/features/signal_pan_drift.das
@@ -14,6 +14,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("sine") |> set_note(48.0) |> set_sustain(1.0) |> set_pan(signal_sine() |> slow(4.0lf))
+    let pat <- atom("sine") |> note(48.0) |> sustain(1.0) |> pan(sine() |> slow(4.0lf))
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/signal_perlin_gain.das
+++ b/examples/daStrudel/features/signal_perlin_gain.das
@@ -15,6 +15,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("sawtooth") |> set_note(48.0) |> set_sustain(1.0) |> set_lpf(800.0) |> set_gain(signal_perlin() |> signal_range(0.1, 0.8) |> slow(4.0lf))
+    let pat <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> lpf(800.0) |> gain(perlin() |> range(0.1, 0.8) |> slow(4.0lf))
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/signal_rand_pan.das
+++ b/examples/daStrudel/features/signal_rand_pan.das
@@ -1,0 +1,20 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Random signal modulates pan — notes bounce around unpredictably in stereo field.
+// Hear: melody with each note landing at a random stereo position.
+/*
+note("c4 e4 g4 a4 g4 e4").s("sine")
+  .sustain(0.5)
+  .pan(rand)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 e4 g4 a4 g4 e4", "sine") |> sustain(0.5) |> pan(rand())
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/signal_run.das
+++ b/examples/daStrudel/features/signal_run.das
@@ -1,0 +1,18 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// run generates a discrete ramp 0..n-1 across each cycle.
+// Hear: 8-step rising chromatic sequence C3..G3 — each step 1/8 of a cycle.
+/*
+note(run(8).add(48)).s("sine").sustain(0.3).cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    // run(8) produces notes 0..7 across a cycle → add 48 for chromatic C3..G3 (MIDI 48..55)
+    let pat <- run(8) |> add(48.0) |> sound("sine") |> sustain(0.3)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/signal_square.das
+++ b/examples/daStrudel/features/signal_square.das
@@ -1,0 +1,21 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Square wave signal modulates gain — hard on/off pulsing (50% duty cycle).
+// Hear: sustained pad that cuts out completely every half-cycle.
+/*
+note("c3").s("sawtooth")
+  .sustain(1)
+  .gain(square.range(0.0, 0.6).slow(2))
+  .lpf(800)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> lpf(800.0) |> gain(square() |> range(0.0, 0.6) |> slow(2.0lf))
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/synth_fm_bells.das
+++ b/examples/daStrudel/features/synth_fm_bells.das
@@ -17,6 +17,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c5", "sine") |> set_fm(1.0) |> set_fmh(7.0) |> set_decay(0.3) |> set_release(0.5)
+    let pat <- note("c5", "sine") |> fm(1.0) |> fmh(7.0) |> decay(0.3) |> release(0.5)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/synth_fm_gentle.das
+++ b/examples/daStrudel/features/synth_fm_gentle.das
@@ -20,6 +20,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("g3", "sine") |> set_fm(2.0) |> set_fmh(3.0) |> set_attack(0.05) |> set_decay(0.2) |> set_sustain(0.7) |> set_release(0.5)
+    let pat <- note("g3", "sine") |> fm(2.0) |> fmh(3.0) |> attack(0.05) |> decay(0.2) |> sustain(0.7) |> release(0.5)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/synth_fm_harsh.das
+++ b/examples/daStrudel/features/synth_fm_harsh.das
@@ -18,6 +18,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c3", "sine") |> set_fm(5.0) |> set_fmh(1.4) |> set_attack(0.01) |> set_decay(0.2) |> set_release(0.3)
+    let pat <- note("c3", "sine") |> fm(5.0) |> fmh(1.4) |> attack(0.01) |> decay(0.2) |> release(0.3)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/synth_fm_sweep.das
+++ b/examples/daStrudel/features/synth_fm_sweep.das
@@ -19,7 +19,7 @@ require feature_common
 
 [export]
 def main() {
-    var fmSig <- signal_sine() |> signal_range(0.0, 5.0) |> slow(4.0lf)
-    var pat <- atom("sine") |> set_note(60.0) |> set_fm(fmSig) |> set_fmh(3.0) |> set_attack(0.01) |> set_decay(0.1) |> set_sustain(0.8) |> set_release(0.3)
+    let fmSig <- sine() |> range(0.0, 5.0) |> slow(4.0lf)
+    let pat <- atom("sine") |> note(60.0) |> fm(fmSig) |> fmh(3.0) |> attack(0.01) |> decay(0.1) |> sustain(0.8) |> release(0.3)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/synth_pink_noise.das
+++ b/examples/daStrudel/features/synth_pink_noise.das
@@ -15,6 +15,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("pink") |> set_sustain(1.0) |> set_lpf(300.0)
+    let pat <- atom("pink") |> sustain(1.0) |> lpf(300.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/synth_pink_vs_white.das
+++ b/examples/daStrudel/features/synth_pink_vs_white.das
@@ -15,6 +15,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- s("pink white") |> set_sustain(1.0) |> set_gain(0.6)
+    let pat <- s("pink white") |> sustain(1.0) |> gain(0.6)
     play_feature_cps(pat, 0.25lf)
 }

--- a/examples/daStrudel/features/synth_sawtooth.das
+++ b/examples/daStrudel/features/synth_sawtooth.das
@@ -18,6 +18,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- s("sawtooth") |> set_note(48.0) |> set_attack(0.01) |> set_decay(0.1) |> set_sustain(0.7) |> set_release(0.3) |> set_lpf(2000.0)
+    let pat <- s("sawtooth") |> note(48.0) |> attack(0.01) |> decay(0.1) |> sustain(0.7) |> release(0.3) |> lpf(2000.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/synth_sine.das
+++ b/examples/daStrudel/features/synth_sine.das
@@ -17,6 +17,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- s("sine") |> set_note(48.0) |> set_attack(0.05) |> set_decay(0.1) |> set_sustain(0.8) |> set_release(0.5)
+    let pat <- s("sine") |> note(48.0) |> attack(0.05) |> decay(0.1) |> sustain(0.8) |> release(0.5)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/synth_square.das
+++ b/examples/daStrudel/features/synth_square.das
@@ -18,6 +18,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- s("square") |> set_note(48.0) |> set_attack(0.01) |> set_decay(0.15) |> set_sustain(0.6) |> set_release(0.2) |> set_lpf(1500.0)
+    let pat <- s("square") |> note(48.0) |> attack(0.01) |> decay(0.15) |> sustain(0.6) |> release(0.2) |> lpf(1500.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/synth_supersaw_chord.das
+++ b/examples/daStrudel/features/synth_supersaw_chord.das
@@ -18,6 +18,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c3,e3,g3", "supersaw") |> set_attack(0.05) |> set_decay(0.1) |> set_sustain(0.7) |> set_release(0.5) |> set_lpf(4000.0)
+    let pat <- note("c3,e3,g3", "supersaw") |> attack(0.05) |> decay(0.1) |> sustain(0.7) |> release(0.5) |> lpf(4000.0)
     play_feature_cps(pat, 0.25lf)
 }

--- a/examples/daStrudel/features/synth_supersaw_filtered.das
+++ b/examples/daStrudel/features/synth_supersaw_filtered.das
@@ -18,7 +18,7 @@ require feature_common
 
 [export]
 def main() {
-    var lpfSig <- signal_sine() |> signal_range(400.0, 6000.0) |> slow(4.0lf)
-    var pat <- note_pattern("c3", "supersaw") |> set_lpf(lpfSig) |> set_attack(0.05) |> set_decay(0.1) |> set_sustain(0.8) |> set_release(0.5)
+    let lpfSig <- sine() |> range(400.0, 6000.0) |> slow(4.0lf)
+    let pat <- note("c3", "supersaw") |> lpf(lpfSig) |> attack(0.05) |> decay(0.1) |> sustain(0.8) |> release(0.5)
     play_feature_cps(pat, 0.25lf)
 }

--- a/examples/daStrudel/features/synth_supersaw_vs_saw.das
+++ b/examples/daStrudel/features/synth_supersaw_vs_saw.das
@@ -17,6 +17,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- s("<supersaw sawtooth>") |> set_note(48.0) |> set_attack(0.01) |> set_decay(0.1) |> set_sustain(0.8) |> set_release(0.3)
+    let pat <- s("<supersaw sawtooth>") |> note(48.0) |> attack(0.01) |> decay(0.1) |> sustain(0.8) |> release(0.3)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/synth_triangle.das
+++ b/examples/daStrudel/features/synth_triangle.das
@@ -17,6 +17,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- s("triangle") |> set_note(48.0) |> set_attack(0.03) |> set_decay(0.1) |> set_sustain(0.8) |> set_release(0.4)
+    let pat <- s("triangle") |> note(48.0) |> attack(0.03) |> decay(0.1) |> sustain(0.8) |> release(0.4)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/vowel_a.das
+++ b/examples/daStrudel/features/vowel_a.das
@@ -21,6 +21,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("sawtooth") |> set_note(48.0) |> set_vowel("a") |> set_gain(0.3) |> set_attack(0.01) |> set_decay(0.1) |> set_sustain(0.8) |> set_release(0.3)
+    let pat <- atom("sawtooth") |> note(48.0) |> vowel("a") |> gain(0.3) |> attack(0.01) |> decay(0.1) |> sustain(0.8) |> release(0.3)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/vowel_compare.das
+++ b/examples/daStrudel/features/vowel_compare.das
@@ -21,6 +21,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("sawtooth") |> set_note(48.0) |> set_vowel("<a e i o u>") |> set_gain(0.3) |> set_attack(0.01) |> set_decay(0.1) |> set_sustain(0.8) |> set_release(0.3)
+    let pat <- atom("sawtooth") |> note(48.0) |> vowel("<a e i o u>") |> gain(0.3) |> attack(0.01) |> decay(0.1) |> sustain(0.8) |> release(0.3)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/vowel_on_fm.das
+++ b/examples/daStrudel/features/vowel_on_fm.das
@@ -24,6 +24,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c3 eb3 g3 bb3", "sine") |> set_fm(2.0) |> set_fmh(3.0) |> set_vowel("<a e i o u>") |> set_gain(0.3) |> set_attack(0.05) |> set_decay(0.2) |> set_sustain(0.6) |> set_release(0.5) |> set_room(0.5) |> set_roomsize(4.0)
+    let pat <- note("c3 eb3 g3 bb3", "sine") |> fm(2.0) |> fmh(3.0) |> vowel("<a e i o u>") |> gain(0.3) |> attack(0.05) |> decay(0.2) |> sustain(0.6) |> release(0.5) |> room(0.5) |> roomsize(4.0)
     play_feature_cps(pat, 0.25lf)
 }

--- a/examples/daStrudel/features/vowel_on_noise.das
+++ b/examples/daStrudel/features/vowel_on_noise.das
@@ -21,6 +21,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- atom("white") |> set_vowel("<a e i o u>") |> set_gain(0.4) |> set_attack(0.01) |> set_decay(0.1) |> set_sustain(0.6) |> set_release(0.3)
+    let pat <- atom("white") |> vowel("<a e i o u>") |> gain(0.4) |> attack(0.01) |> decay(0.1) |> sustain(0.6) |> release(0.3)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/features/vowel_sequence.das
+++ b/examples/daStrudel/features/vowel_sequence.das
@@ -22,6 +22,6 @@ require feature_common
 
 [export]
 def main() {
-    var pat <- note_pattern("c3 e3 g3", "sawtooth") |> set_vowel("<a e i o u>") |> set_gain(0.2) |> set_attack(0.05) |> set_decay(0.2) |> set_sustain(0.7) |> set_release(0.5) |> set_room(0.3) |> set_roomsize(3.0)
+    let pat <- note("c3 e3 g3", "sawtooth") |> vowel("<a e i o u>") |> gain(0.2) |> attack(0.05) |> decay(0.2) |> sustain(0.7) |> release(0.5) |> room(0.3) |> roomsize(3.0)
     play_feature_cps(pat, 0.5lf)
 }

--- a/examples/daStrudel/piano_demo/main.das
+++ b/examples/daStrudel/piano_demo/main.das
@@ -40,8 +40,8 @@ def strudel_main() {
          e4 e4 f4 g4 | g4 f4 e4 d4 | c4 c4 d4 e4 | d4 c4 c4 ~"
     )
     // map note events to piano samples with pitch-shifting
-    var piano <- melody |> set_gain(0.6) |> fmap(@(e) => piano_map(e))
-    var drums <- s("bd ~ sd ~") |> set_gain(0.5)
+    var piano <- melody |> gain(0.6) |> fmap(@(e) => piano_map(e))
+    var drums <- s("bd ~ sd ~") |> gain(0.5)
     strudel_add_track(stack([piano, drums]))
     strudel_set_bpm(100.0lf)
     strudel_play()

--- a/examples/daStrudel/sf2_demo/main.das
+++ b/examples/daStrudel/sf2_demo/main.das
@@ -34,17 +34,17 @@ def strudel_main() {
     strudel_set_bpm(120.0lf)
     strudel_add_track(stack([
         // drums — SF2 GM percussion (bank 128): c2=kick, d2=snare, eb2=clap, fs2=closed hh
-        note_pattern("c2 ~ [~ c2] ~, ~ eb2 ~ eb2, [~ fs2] [~ fs2] [~ fs2] [~ fs2]")
-            |> set_sf2(0) |> set_sf2_bank(128) |> set_gain(0.7),
+        note("c2 ~ [~ c2] ~, ~ eb2 ~ eb2, [~ fs2] [~ fs2] [~ fs2] [~ fs2]")
+            |> sf2(0) |> sf2_bank(128) |> gain(0.7),
         // piano arpeggios — broken chords, Am-F-C-G
-        note_pattern("<[a3 c4 e4 a4 e4 c4 a3 c4] [f3 a3 c4 f4 c4 a3 f3 a3] [c3 e3 g3 c4 g3 e3 c3 e3] [g3 b3 d4 g4 d4 b3 g3 b3]>")
-            |> set_sf2("piano") |> set_gain(0.45),
+        note("<[a3 c4 e4 a4 e4 c4 a3 c4] [f3 a3 c4 f4 c4 a3 f3 a3] [c3 e3 g3 c4 g3 e3 c3 e3] [g3 b3 d4 g4 d4 b3 g3 b3]>")
+            |> sf2("piano") |> gain(0.45),
         // bass — root notes with a bit of movement
-        note_pattern("<[a2 ~ ~ a2 ~ a2 ~ ~] [f2 ~ ~ f2 ~ f2 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g2 ~ ~ g2 ~ g2 ~ ~]>")
-            |> set_sf2("acoustic_bass") |> set_gain(0.6),
+        note("<[a2 ~ ~ a2 ~ a2 ~ ~] [f2 ~ ~ f2 ~ f2 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g2 ~ ~ g2 ~ g2 ~ ~]>")
+            |> sf2("acoustic_bass") |> gain(0.6),
         // string pad — sustained chords
-        note_pattern("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>")
-            |> set_sf2("string_ensemble") |> set_gain(0.2)
+        note("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>")
+            |> sf2("string_ensemble") |> gain(0.2)
     ]))
     strudel_play()
 }

--- a/examples/daStrudel/sf2_demo/render_wav.das
+++ b/examples/daStrudel/sf2_demo/render_wav.das
@@ -47,17 +47,17 @@ def main() {
     // build the pattern
     let pat <- stack([
         // drums — SF2 GM percussion (bank 128)
-        note_pattern("c2 ~ [~ c2] ~, ~ eb2 ~ eb2, [~ fs2] [~ fs2] [~ fs2] [~ fs2]")
-            |> set_sf2(0) |> set_sf2_bank(128) |> set_gain(0.7),
+        note("c2 ~ [~ c2] ~, ~ eb2 ~ eb2, [~ fs2] [~ fs2] [~ fs2] [~ fs2]")
+            |> sf2(0) |> sf2_bank(128) |> gain(0.7),
         // piano arpeggios
-        note_pattern("<[a3 c4 e4 a4 e4 c4 a3 c4] [f3 a3 c4 f4 c4 a3 f3 a3] [c3 e3 g3 c4 g3 e3 c3 e3] [g3 b3 d4 g4 d4 b3 g3 b3]>")
-            |> set_sf2("piano") |> set_gain(0.45),
+        note("<[a3 c4 e4 a4 e4 c4 a3 c4] [f3 a3 c4 f4 c4 a3 f3 a3] [c3 e3 g3 c4 g3 e3 c3 e3] [g3 b3 d4 g4 d4 b3 g3 b3]>")
+            |> sf2("piano") |> gain(0.45),
         // bass
-        note_pattern("<[a2 ~ ~ a2 ~ a2 ~ ~] [f2 ~ ~ f2 ~ f2 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g2 ~ ~ g2 ~ g2 ~ ~]>")
-            |> set_sf2("acoustic_bass") |> set_gain(0.6),
+        note("<[a2 ~ ~ a2 ~ a2 ~ ~] [f2 ~ ~ f2 ~ f2 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g2 ~ ~ g2 ~ g2 ~ ~]>")
+            |> sf2("acoustic_bass") |> gain(0.6),
         // string pad
-        note_pattern("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>")
-            |> set_sf2("string_ensemble") |> set_gain(0.2)
+        note("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>")
+            |> sf2("string_ensemble") |> gain(0.2)
     ])
 
     // set up scheduler
@@ -77,11 +77,10 @@ def main() {
 
     print("Rendering {duration} seconds...\n")
     while (wall_time < duration) {
-        var chunk <- tick(sched, pat, bank, wall_time, chunk_sec)
-        for (s in chunk) {
+        tick(sched, pat, bank, wall_time, chunk_sec)
+        for (s in g_master_pcm) {
             output |> push(s)
         }
-        delete chunk
         wall_time += double(chunk_sec)
     }
 

--- a/examples/daStrudel/strudel_sf2_live/main.das
+++ b/examples/daStrudel/strudel_sf2_live/main.das
@@ -43,17 +43,17 @@ def strudel_main() {
     strudel_set_bpm(120.0lf)
     strudel_add_track(stack([
         // drums — SF2 GM percussion (bank 128): c2=kick, d2=snare, eb2=clap, fs2=closed hh
-        note_pattern("c2 ~ [~ c2] ~, ~ eb2 ~ eb2, [~ fs2] [~ fs2] [~ fs2] [~ fs2]")
-            |> set_sf2(0) |> set_sf2_bank(128) |> set_gain(0.7),
+        note("c2 ~ [~ c2] ~, ~ eb2 ~ eb2, [~ fs2] [~ fs2] [~ fs2] [~ fs2]")
+            |> sf2(0) |> sf2_bank(128) |> gain(0.7),
         // piano arpeggios — Am-F-C-G
-        note_pattern("<[a3 c4 e4 a4 e4 c4 a3 c4] [f3 a3 c4 f4 c4 a3 f3 a3] [c3 e3 g3 c4 g3 e3 c3 e3] [g3 b3 d4 g4 d4 b3 g3 b3]>")
-            |> set_sf2("piano") |> set_gain(0.45),
+        note("<[a3 c4 e4 a4 e4 c4 a3 c4] [f3 a3 c4 f4 c4 a3 f3 a3] [c3 e3 g3 c4 g3 e3 c3 e3] [g3 b3 d4 g4 d4 b3 g3 b3]>")
+            |> sf2("piano") |> gain(0.45),
         // bass
-        note_pattern("<[a2 ~ ~ a2 ~ a2 ~ ~] [f2 ~ ~ f2 ~ f2 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g2 ~ ~ g2 ~ g2 ~ ~]>")
-            |> set_sf2("acoustic_bass") |> set_gain(0.6),
+        note("<[a2 ~ ~ a2 ~ a2 ~ ~] [f2 ~ ~ f2 ~ f2 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g2 ~ ~ g2 ~ g2 ~ ~]>")
+            |> sf2("acoustic_bass") |> gain(0.6),
         // string pad
-        note_pattern("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>")
-            |> set_sf2("string_ensemble") |> set_gain(0.2)
+        note("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>")
+            |> sf2("string_ensemble") |> gain(0.2)
     ]))
     strudel_play()
 }

--- a/examples/daStrudel/strudel_visualizer/main.das
+++ b/examples/daStrudel/strudel_visualizer/main.das
@@ -223,28 +223,28 @@ def init() {
         )
         */
         strudel_add_track(
-            note_pattern("c2 ~ [~ c2] ~, ~ eb2 ~ eb2, [~ fs2] [~ fs2] [~ fs2] [~ fs2]")
-                |> set_sf2(0) |> set_sf2_bank(128) |> set_gain(0.7)
+            note("c2 ~ [~ c2] ~, ~ eb2 ~ eb2, [~ fs2] [~ fs2] [~ fs2] [~ fs2]")
+                |> sf2(0) |> sf2_bank(128) |> gain(0.7)
                 |> pianoroll("drums") |> vis_color(0xFF5722u) |> drums()
         )
         strudel_add_track(
-            note_pattern("<[a3 c4 e4 a4 e4 c4 a3 c4] [f3 a3 c4 f4 c4 a3 f3 a3] [c3 e3 g3 c4 g3 e3 c3 e3] [g3 b3 d4 g4 d4 b3 g3 b3]>")
-                |> set_sf2("piano") |> set_gain(0.45)
+            note("<[a3 c4 e4 a4 e4 c4 a3 c4] [f3 a3 c4 f4 c4 a3 f3 a3] [c3 e3 g3 c4 g3 e3 c3 e3] [g3 b3 d4 g4 d4 b3 g3 b3]>")
+                |> sf2("piano") |> gain(0.45)
                 |> pianoroll("piano") |> vis_color(0x42A5F5u)
         )
         strudel_add_track(
-            note_pattern("<[a2 ~ ~ a2 ~ a2 ~ ~] [f2 ~ ~ f2 ~ f2 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g2 ~ ~ g2 ~ g2 ~ ~]>")
-                |> set_sf2("acoustic_bass") |> set_gain(0.6)
+            note("<[a2 ~ ~ a2 ~ a2 ~ ~] [f2 ~ ~ f2 ~ f2 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g2 ~ ~ g2 ~ g2 ~ ~]>")
+                |> sf2("acoustic_bass") |> gain(0.6)
                 |> pianoroll("bass") |> vis_color(0x8BC34Au) |> scope()
         )
         strudel_add_track(
-            note_pattern("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>")
-                |> set_sf2("string_ensemble") |> set_gain(0.2)
+            note("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>")
+                |> sf2("string_ensemble") |> gain(0.2)
                 |> pianoroll("strings") |> vis_color(0xE040FFu) |> vectorscope()
         )
         strudel_add_track(
-            note_pattern("<e4 ~ ~ a4> <~ d5 ~ ~> <g4 ~ f4 ~> <~ ~ b4 ~>")
-                |> set_sf2("violin") |> set_gain(0.9)
+            note("<e4 ~ ~ a4> <~ d5 ~ ~> <g4 ~ f4 ~> <~ ~ b4 ~>")
+                |> sf2("violin") |> gain(0.9)
                 |> pianoroll("violin") |> vis_color(0xF06292u) |> spectrum()
         )
     } else {
@@ -253,20 +253,20 @@ def init() {
                 |> pianoroll("drums") |> vis_color(0xFF5722u) |> drums()
         )
         strudel_add_track(
-            note_pattern("<[a3 c4 e4 a4 e4 c4 a3 c4] [f3 a3 c4 f4 c4 a3 f3 a3] [c3 e3 g3 c4 g3 e3 c3 e3] [g3 b3 d4 g4 d4 b3 g3 b3]>", "sawtooth")
-                |> set_gain(0.3) |> pianoroll("piano") |> vis_color(0x42A5F5u)
+            note("<[a3 c4 e4 a4 e4 c4 a3 c4] [f3 a3 c4 f4 c4 a3 f3 a3] [c3 e3 g3 c4 g3 e3 c3 e3] [g3 b3 d4 g4 d4 b3 g3 b3]>", "sawtooth")
+                |> gain(0.3) |> pianoroll("piano") |> vis_color(0x42A5F5u)
         )
         strudel_add_track(
-            note_pattern("<[a2 ~ ~ a2 ~ a2 ~ ~] [f2 ~ ~ f2 ~ f2 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g2 ~ ~ g2 ~ g2 ~ ~]>", "sine")
-                |> set_gain(0.4) |> pianoroll("bass") |> vis_color(0x8BC34Au) |> scope()
+            note("<[a2 ~ ~ a2 ~ a2 ~ ~] [f2 ~ ~ f2 ~ f2 ~ ~] [c2 ~ ~ c2 ~ c2 ~ ~] [g2 ~ ~ g2 ~ g2 ~ ~]>", "sine")
+                |> gain(0.4) |> pianoroll("bass") |> vis_color(0x8BC34Au) |> scope()
         )
         strudel_add_track(
-            note_pattern("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>", "sawtooth")
-                |> set_gain(0.15) |> pianoroll("strings") |> vis_color(0xE040FFu) |> vectorscope()
+            note("<[a2,c3,e3] [f2,a2,c3] [c2,e2,g2] [g2,b2,d3]>", "sawtooth")
+                |> gain(0.15) |> pianoroll("strings") |> vis_color(0xE040FFu) |> vectorscope()
         )
         strudel_add_track(
-            note_pattern("<e4 ~ ~ a4> <~ d5 ~ ~> <g4 ~ f4 ~> <~ ~ b4 ~>", "sawtooth")
-                |> set_gain(0.1) |> pianoroll("violin") |> vis_color(0xF06292u) |> spectrum()
+            note("<e4 ~ ~ a4> <~ d5 ~ ~> <g4 ~ f4 ~> <~ ~ b4 ~>", "sawtooth")
+                |> gain(0.1) |> pianoroll("violin") |> vis_color(0xF06292u) |> spectrum()
         )
     }
     // Build panels from visualization registrations

--- a/examples/daStrudel/synth_demo/main.das
+++ b/examples/daStrudel/synth_demo/main.das
@@ -14,8 +14,8 @@ def strudel_main() {
     strudel_set_bpm(120.0lf)
     strudel_add_track(stack([
         s("bd sd [hh hh] cp"),
-        note_pattern("c2 c2 f2 g2", "sine") |> set_gain(0.4),
-        note_pattern("<e4 d4> <c4 d4> <e4 f4> <g4 e4>", "sawtooth") |> set_gain(0.3)
+        note("c2 c2 f2 g2", "sine") |> gain(0.4),
+        note("<e4 d4> <c4 d4> <e4 f4> <g4 e4>", "sawtooth") |> gain(0.3)
     ]))
     strudel_play()
 }

--- a/modules/dasAudio/src/compressor.h
+++ b/modules/dasAudio/src/compressor.h
@@ -1,0 +1,96 @@
+#pragma once
+
+// Per-voice feed-forward compressor with envelope follower and soft knee.
+// Parameters: threshold/ratio/knee in dB, attack/release in seconds.
+// Threshold >= 0 means bypass.
+// Header-only; define MA_COMPRESSOR_IMPLEMENTATION in exactly one .cpp.
+
+#include <math.h>
+#include <string.h>
+
+struct ma_compressor {
+    float threshold_db;   // threshold in dB (>= 0 = bypass)
+    float ratio;          // compression ratio (1+ : 1)
+    float knee_db;        // soft knee width in dB
+    float attack;         // attack time seconds
+    float release;        // release time seconds
+    float sample_rate;
+    float envelope;       // envelope follower state (linear)
+    float attack_coef;    // cached 1-exp(-1/(attack*sr))
+    float release_coef;   // cached 1-exp(-1/(release*sr))
+    float cached_attack;
+    float cached_release;
+};
+
+void ma_compressor_init(ma_compressor * c, float sample_rate);
+void ma_compressor_process(ma_compressor * c, float * buf, int frame_count);
+
+#ifdef MA_COMPRESSOR_IMPLEMENTATION
+
+static void ma_compressor_update_coefs(ma_compressor * c) {
+    if (c->attack != c->cached_attack) {
+        c->attack_coef = c->attack > 0.0f ? 1.0f - expf(-1.0f / (c->attack * c->sample_rate)) : 1.0f;
+        c->cached_attack = c->attack;
+    }
+    if (c->release != c->cached_release) {
+        c->release_coef = c->release > 0.0f ? 1.0f - expf(-1.0f / (c->release * c->sample_rate)) : 1.0f;
+        c->cached_release = c->release;
+    }
+}
+
+void ma_compressor_init(ma_compressor * c, float sample_rate) {
+    memset(c, 0, sizeof(*c));
+    c->sample_rate = sample_rate;
+    c->threshold_db = 1.0f;   // bypass
+    c->ratio = 10.0f;
+    c->knee_db = 10.0f;
+    c->attack = 0.005f;
+    c->release = 0.05f;
+    c->envelope = 0.0f;
+    c->cached_attack = -1.0f;
+    c->cached_release = -1.0f;
+    ma_compressor_update_coefs(c);
+}
+
+void ma_compressor_process(ma_compressor * c, float * buf, int frame_count) {
+    if (c->threshold_db >= 0.0f) return;   // bypass
+    ma_compressor_update_coefs(c);
+    float ratio = c->ratio < 1.0f ? 1.0f : c->ratio;
+    float thr_db = c->threshold_db;
+    float knee = c->knee_db < 0.0f ? 0.0f : c->knee_db;
+    float half_knee = knee * 0.5f;
+    float inv_ratio = 1.0f / ratio;
+    float env = c->envelope;
+    float ac = c->attack_coef;
+    float rc = c->release_coef;
+    const float EPS = 1.0e-9f;
+    for (int f = 0; f < frame_count; f++) {
+        float l = buf[f * 2];
+        float r = buf[f * 2 + 1];
+        // peak detector over max(|L|, |R|)
+        float peak = fabsf(l) > fabsf(r) ? fabsf(l) : fabsf(r);
+        // envelope follower
+        float coef = peak > env ? ac : rc;
+        env += coef * (peak - env);
+        if (env < EPS) env = EPS;
+        // gain computer (soft-knee)
+        float level_db = 20.0f * log10f(env);
+        float over = level_db - thr_db;
+        float gain_reduction_db;
+        if (knee > 0.0f && over > -half_knee && over < half_knee) {
+            // soft knee: quadratic interpolation
+            float x = over + half_knee;
+            gain_reduction_db = (1.0f - inv_ratio) * x * x / (2.0f * knee);
+        } else if (over >= half_knee) {
+            gain_reduction_db = (1.0f - inv_ratio) * over;
+        } else {
+            gain_reduction_db = 0.0f;
+        }
+        float gain = powf(10.0f, -gain_reduction_db / 20.0f);
+        buf[f * 2]     = l * gain;
+        buf[f * 2 + 1] = r * gain;
+    }
+    c->envelope = env;
+}
+
+#endif // MA_COMPRESSOR_IMPLEMENTATION

--- a/modules/dasAudio/src/convolution_reverb.h
+++ b/modules/dasAudio/src/convolution_reverb.h
@@ -2,7 +2,7 @@
 #define convolution_reverb_h
 
 // Partitioned convolution reverb using synthetic impulse response.
-// Based on the strudel-cc approach: random noise with exponential decay and lowpass sweep.
+// IR synthesis: random noise with exponential decay and lowpass sweep.
 // Uses uniform partitioned overlap-save with minfft for FFT.
 //
 // The IR is split into fixed-size blocks (CONV_BLOCK_SIZE). Each block is pre-transformed

--- a/modules/dasAudio/src/dasAudio.cpp
+++ b/modules/dasAudio/src/dasAudio.cpp
@@ -43,6 +43,18 @@
 #define CONVOLUTION_REVERB_IMPLEMENTATION
 #include "convolution_reverb.h"
 
+#define MA_EFFECTS_IMPLEMENTATION
+#include "effects.h"
+
+#define MA_PHASER_IMPLEMENTATION
+#include "phaser.h"
+
+#define MA_TREMOLO_IMPLEMENTATION
+#include "tremolo.h"
+
+#define MA_COMPRESSOR_IMPLEMENTATION
+#include "compressor.h"
+
 #include "dasAudio.h"
 
 #ifndef HRTF_SAMPLE_RATE
@@ -79,6 +91,15 @@ MAKE_TYPE_FACTORY(ma_chorus_config,ma_chorus_config);
 MAKE_TYPE_FACTORY(ma_chorus,ma_chorus);
 
 MAKE_TYPE_FACTORY(ma_delay,ma_delay);
+
+MAKE_TYPE_FACTORY(ma_bitcrush,ma_bitcrush);
+MAKE_TYPE_FACTORY(ma_waveshaper,ma_waveshaper);
+MAKE_TYPE_FACTORY(ma_djfilter,ma_djfilter);
+MAKE_TYPE_FACTORY(ma_bandpass,ma_bandpass);
+
+MAKE_TYPE_FACTORY(ma_phaser,ma_phaser);
+MAKE_TYPE_FACTORY(ma_tremolo,ma_tremolo);
+MAKE_TYPE_FACTORY(ma_compressor,ma_compressor);
 
 DAS_BASE_BIND_ENUM ( ma_format, ma_format, \
     ma_format_unknown, \
@@ -570,6 +591,141 @@ ma_chorus_config dasAudio_chorusConfigDefault ( ) {
     return ma_chorus_config_default();
 }
 
+// ─── Effects (bitcrush, waveshaper, djfilter, bandpass) ───
+
+struct MaBitcrushAnnotation : ManagedStructureAnnotation<ma_bitcrush,true,true> {
+    MaBitcrushAnnotation ( ModuleLibrary & mlib )
+        : ManagedStructureAnnotation("ma_bitcrush", mlib, "ma_bitcrush") {
+        addField<DAS_BIND_MANAGED_FIELD(bits)>("bits","bits");
+        addField<DAS_BIND_MANAGED_FIELD(coarse)>("coarse","coarse");
+    }
+};
+
+struct MaWaveshaperAnnotation : ManagedStructureAnnotation<ma_waveshaper,true,true> {
+    MaWaveshaperAnnotation ( ModuleLibrary & mlib )
+        : ManagedStructureAnnotation("ma_waveshaper", mlib, "ma_waveshaper") {
+        addField<DAS_BIND_MANAGED_FIELD(drive)>("drive","drive");
+    }
+};
+
+struct MaDjfilterAnnotation : ManagedStructureAnnotation<ma_djfilter,true,true> {
+    MaDjfilterAnnotation ( ModuleLibrary & mlib )
+        : ManagedStructureAnnotation("ma_djfilter", mlib, "ma_djfilter") {
+        addField<DAS_BIND_MANAGED_FIELD(position)>("position","position");
+        addField<DAS_BIND_MANAGED_FIELD(sample_rate)>("sample_rate","sample_rate");
+    }
+};
+
+struct MaBandpassAnnotation : ManagedStructureAnnotation<ma_bandpass,true,true> {
+    MaBandpassAnnotation ( ModuleLibrary & mlib )
+        : ManagedStructureAnnotation("ma_bandpass", mlib, "ma_bandpass") {
+        addField<DAS_BIND_MANAGED_FIELD(freq)>("freq","freq");
+        addField<DAS_BIND_MANAGED_FIELD(q)>("q","q");
+        addField<DAS_BIND_MANAGED_FIELD(sample_rate)>("sample_rate","sample_rate");
+    }
+};
+
+void dasAudio_bitcrushInit ( ma_bitcrush * bc, Context * context, LineInfoArg * at ) {
+    if ( !bc ) context->throw_error_at(at,"bitcrush is null");
+    ma_bitcrush_init(bc);
+}
+void dasAudio_bitcrushProcess ( ma_bitcrush * bc, float * buf, int nFrames, Context * context, LineInfoArg * at ) {
+    if ( !bc ) context->throw_error_at(at,"bitcrush is null");
+    ma_bitcrush_process(bc, buf, nFrames);
+}
+
+void dasAudio_waveshaperInit ( ma_waveshaper * ws, Context * context, LineInfoArg * at ) {
+    if ( !ws ) context->throw_error_at(at,"waveshaper is null");
+    ma_waveshaper_init(ws);
+}
+void dasAudio_waveshaperProcess ( ma_waveshaper * ws, float * buf, int nFrames, Context * context, LineInfoArg * at ) {
+    if ( !ws ) context->throw_error_at(at,"waveshaper is null");
+    ma_waveshaper_process(ws, buf, nFrames);
+}
+
+void dasAudio_djfilterInit ( ma_djfilter * dj, float sample_rate, Context * context, LineInfoArg * at ) {
+    if ( !dj ) context->throw_error_at(at,"djfilter is null");
+    ma_djfilter_init(dj, sample_rate);
+}
+void dasAudio_djfilterProcess ( ma_djfilter * dj, float * buf, int nFrames, Context * context, LineInfoArg * at ) {
+    if ( !dj ) context->throw_error_at(at,"djfilter is null");
+    ma_djfilter_process(dj, buf, nFrames);
+}
+
+void dasAudio_bandpassInit ( ma_bandpass * bp, float sample_rate, Context * context, LineInfoArg * at ) {
+    if ( !bp ) context->throw_error_at(at,"bandpass is null");
+    ma_bandpass_init(bp, sample_rate);
+}
+void dasAudio_bandpassSetup ( ma_bandpass * bp, float freq, float q, Context * context, LineInfoArg * at ) {
+    if ( !bp ) context->throw_error_at(at,"bandpass is null");
+    ma_bandpass_setup(bp, freq, q);
+}
+void dasAudio_bandpassProcess ( ma_bandpass * bp, float * buf, int nFrames, Context * context, LineInfoArg * at ) {
+    if ( !bp ) context->throw_error_at(at,"bandpass is null");
+    ma_bandpass_process(bp, buf, nFrames);
+}
+
+// ─── Phaser / Tremolo / Compressor ───
+
+struct MaPhaserAnnotation : ManagedStructureAnnotation<ma_phaser,true,true> {
+    MaPhaserAnnotation ( ModuleLibrary & mlib )
+        : ManagedStructureAnnotation("ma_phaser", mlib, "ma_phaser") {
+        addField<DAS_BIND_MANAGED_FIELD(rate)>("rate","rate");
+        addField<DAS_BIND_MANAGED_FIELD(depth)>("depth","depth");
+        addField<DAS_BIND_MANAGED_FIELD(center)>("center","center");
+        addField<DAS_BIND_MANAGED_FIELD(sweep)>("sweep","sweep");
+        addField<DAS_BIND_MANAGED_FIELD(sample_rate)>("sample_rate","sample_rate");
+    }
+};
+
+struct MaTremoloAnnotation : ManagedStructureAnnotation<ma_tremolo,true,true> {
+    MaTremoloAnnotation ( ModuleLibrary & mlib )
+        : ManagedStructureAnnotation("ma_tremolo", mlib, "ma_tremolo") {
+        addField<DAS_BIND_MANAGED_FIELD(rate)>("rate","rate");
+        addField<DAS_BIND_MANAGED_FIELD(depth)>("depth","depth");
+        addField<DAS_BIND_MANAGED_FIELD(sample_rate)>("sample_rate","sample_rate");
+    }
+};
+
+struct MaCompressorAnnotation : ManagedStructureAnnotation<ma_compressor,true,true> {
+    MaCompressorAnnotation ( ModuleLibrary & mlib )
+        : ManagedStructureAnnotation("ma_compressor", mlib, "ma_compressor") {
+        addField<DAS_BIND_MANAGED_FIELD(threshold_db)>("threshold_db","threshold_db");
+        addField<DAS_BIND_MANAGED_FIELD(ratio)>("ratio","ratio");
+        addField<DAS_BIND_MANAGED_FIELD(knee_db)>("knee_db","knee_db");
+        addField<DAS_BIND_MANAGED_FIELD(attack)>("attack","attack");
+        addField<DAS_BIND_MANAGED_FIELD(release)>("release","release");
+        addField<DAS_BIND_MANAGED_FIELD(sample_rate)>("sample_rate","sample_rate");
+    }
+};
+
+void dasAudio_phaserInit ( ma_phaser * ph, float sample_rate, Context * context, LineInfoArg * at ) {
+    if ( !ph ) context->throw_error_at(at,"phaser is null");
+    ma_phaser_init(ph, sample_rate);
+}
+void dasAudio_phaserProcess ( ma_phaser * ph, float * buf, int nFrames, Context * context, LineInfoArg * at ) {
+    if ( !ph ) context->throw_error_at(at,"phaser is null");
+    ma_phaser_process(ph, buf, nFrames);
+}
+
+void dasAudio_tremoloInit ( ma_tremolo * tr, float sample_rate, Context * context, LineInfoArg * at ) {
+    if ( !tr ) context->throw_error_at(at,"tremolo is null");
+    ma_tremolo_init(tr, sample_rate);
+}
+void dasAudio_tremoloProcess ( ma_tremolo * tr, float * buf, int nFrames, Context * context, LineInfoArg * at ) {
+    if ( !tr ) context->throw_error_at(at,"tremolo is null");
+    ma_tremolo_process(tr, buf, nFrames);
+}
+
+void dasAudio_compressorInit ( ma_compressor * c, float sample_rate, Context * context, LineInfoArg * at ) {
+    if ( !c ) context->throw_error_at(at,"compressor is null");
+    ma_compressor_init(c, sample_rate);
+}
+void dasAudio_compressorProcess ( ma_compressor * c, float * buf, int nFrames, Context * context, LineInfoArg * at ) {
+    if ( !c ) context->throw_error_at(at,"compressor is null");
+    ma_compressor_process(c, buf, nFrames);
+}
+
 struct MAHrtfAnnotation : ManagedStructureAnnotation<ma_hrtf> {
     MAHrtfAnnotation ( ModuleLibrary & mlib )
         : ManagedStructureAnnotation("ma_hrtf", mlib, "ma_hrtf") {
@@ -766,6 +922,45 @@ public:
             SideEffects::modifyArgumentAndExternal, "dasAudio_chorusSetConfig")->args({"chorus", "config", "context", "at"});
         addExtern<DAS_BIND_FUN(dasAudio_chorusConfigDefault),SimNode_ExtFuncCallAndCopyOrMove>(*this, lib, "chorus_config_default",
             SideEffects::none, "dasAudio_chorusConfigDefault");
+        // effects (bitcrush, waveshaper, djfilter, bandpass)
+        addAnnotation(new MaBitcrushAnnotation(lib));
+        addExtern<DAS_BIND_FUN(dasAudio_bitcrushInit)>(*this, lib, "bitcrush_init",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_bitcrushInit")->args({"bc", "context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_bitcrushProcess)>(*this, lib, "bitcrush_process",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_bitcrushProcess")->args({"bc", "buf", "nFrames", "context", "at"});
+        addAnnotation(new MaWaveshaperAnnotation(lib));
+        addExtern<DAS_BIND_FUN(dasAudio_waveshaperInit)>(*this, lib, "waveshaper_init",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_waveshaperInit")->args({"ws", "context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_waveshaperProcess)>(*this, lib, "waveshaper_process",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_waveshaperProcess")->args({"ws", "buf", "nFrames", "context", "at"});
+        addAnnotation(new MaDjfilterAnnotation(lib));
+        addExtern<DAS_BIND_FUN(dasAudio_djfilterInit)>(*this, lib, "djfilter_init",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_djfilterInit")->args({"dj", "sample_rate", "context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_djfilterProcess)>(*this, lib, "djfilter_process",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_djfilterProcess")->args({"dj", "buf", "nFrames", "context", "at"});
+        addAnnotation(new MaBandpassAnnotation(lib));
+        addExtern<DAS_BIND_FUN(dasAudio_bandpassInit)>(*this, lib, "bandpass_init",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_bandpassInit")->args({"bp", "sample_rate", "context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_bandpassSetup)>(*this, lib, "bandpass_setup",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_bandpassSetup")->args({"bp", "freq", "q", "context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_bandpassProcess)>(*this, lib, "bandpass_process",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_bandpassProcess")->args({"bp", "buf", "nFrames", "context", "at"});
+        // phaser / tremolo / compressor
+        addAnnotation(new MaPhaserAnnotation(lib));
+        addExtern<DAS_BIND_FUN(dasAudio_phaserInit)>(*this, lib, "phaser_init",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_phaserInit")->args({"ph", "sample_rate", "context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_phaserProcess)>(*this, lib, "phaser_process",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_phaserProcess")->args({"ph", "buf", "nFrames", "context", "at"});
+        addAnnotation(new MaTremoloAnnotation(lib));
+        addExtern<DAS_BIND_FUN(dasAudio_tremoloInit)>(*this, lib, "tremolo_init",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_tremoloInit")->args({"tr", "sample_rate", "context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_tremoloProcess)>(*this, lib, "tremolo_process",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_tremoloProcess")->args({"tr", "buf", "nFrames", "context", "at"});
+        addAnnotation(new MaCompressorAnnotation(lib));
+        addExtern<DAS_BIND_FUN(dasAudio_compressorInit)>(*this, lib, "compressor_init",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_compressorInit")->args({"c", "sample_rate", "context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_compressorProcess)>(*this, lib, "compressor_process",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_compressorProcess")->args({"c", "buf", "nFrames", "context", "at"});
         // delay
         addAnnotation(new MaDelayAnnotation(lib));
         addExtern<DAS_BIND_FUN(dasAudio_delayInit)>(*this, lib, "delay_init",

--- a/modules/dasAudio/src/dasAudio.h
+++ b/modules/dasAudio/src/dasAudio.h
@@ -6,6 +6,10 @@
 #include "reverb.h"
 #include "chorus.h"
 #include "convolution_reverb.h"
+#include "effects.h"
+#include "phaser.h"
+#include "tremolo.h"
+#include "compressor.h"
 
 // AOT-visible declarations for global-scope functions called from namespace das
 float das_ma_sf2_biquad_tick ( ma_sf2_biquad * bq, float input );
@@ -71,4 +75,21 @@ namespace das {
     void dasAudio_delayUninit ( ma_delay * d, Context * context, LineInfoArg * at );
     void dasAudio_delaySetParams ( ma_delay * d, int sample_rate, float delay_time_sec, float feedback, Context * context, LineInfoArg * at );
     void dasAudio_delayProcess ( ma_delay * d, float * input, float * output, int nFrames, Context * context, LineInfoArg * at );
+
+    void dasAudio_bitcrushInit ( ma_bitcrush * bc, Context * context, LineInfoArg * at );
+    void dasAudio_bitcrushProcess ( ma_bitcrush * bc, float * buf, int nFrames, Context * context, LineInfoArg * at );
+    void dasAudio_waveshaperInit ( ma_waveshaper * ws, Context * context, LineInfoArg * at );
+    void dasAudio_waveshaperProcess ( ma_waveshaper * ws, float * buf, int nFrames, Context * context, LineInfoArg * at );
+    void dasAudio_djfilterInit ( ma_djfilter * dj, float sample_rate, Context * context, LineInfoArg * at );
+    void dasAudio_djfilterProcess ( ma_djfilter * dj, float * buf, int nFrames, Context * context, LineInfoArg * at );
+    void dasAudio_bandpassInit ( ma_bandpass * bp, float sample_rate, Context * context, LineInfoArg * at );
+    void dasAudio_bandpassSetup ( ma_bandpass * bp, float freq, float q, Context * context, LineInfoArg * at );
+    void dasAudio_bandpassProcess ( ma_bandpass * bp, float * buf, int nFrames, Context * context, LineInfoArg * at );
+
+    void dasAudio_phaserInit ( ma_phaser * ph, float sample_rate, Context * context, LineInfoArg * at );
+    void dasAudio_phaserProcess ( ma_phaser * ph, float * buf, int nFrames, Context * context, LineInfoArg * at );
+    void dasAudio_tremoloInit ( ma_tremolo * tr, float sample_rate, Context * context, LineInfoArg * at );
+    void dasAudio_tremoloProcess ( ma_tremolo * tr, float * buf, int nFrames, Context * context, LineInfoArg * at );
+    void dasAudio_compressorInit ( ma_compressor * c, float sample_rate, Context * context, LineInfoArg * at );
+    void dasAudio_compressorProcess ( ma_compressor * c, float * buf, int nFrames, Context * context, LineInfoArg * at );
 }

--- a/modules/dasAudio/src/effects.h
+++ b/modules/dasAudio/src/effects.h
@@ -1,0 +1,210 @@
+#pragma once
+
+// Bitcrusher, waveshaper, DJ filter, and bandpass effects.
+// Header-only; define MA_EFFECTS_IMPLEMENTATION in exactly one .cpp before including.
+
+#include <math.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+struct ma_bitcrush {
+    float bits;           // target bit depth (4-16, 0=off)
+    int coarse;           // sample rate reduction factor (0=off, 2=half, 4=quarter)
+    float held_l, held_r; // sample-and-hold state for coarse
+    int hold_counter;     // countdown for coarse
+};
+
+struct ma_waveshaper {
+    float drive;          // drive amount (0=off, 1=mild, 5+=harsh)
+};
+
+struct ma_djfilter {
+    float position;       // 0=full LPF, 0.5=bypass, 1=full HPF
+    float z1_l, z1_r;    // one-pole filter state (left, right)
+    float sample_rate;
+};
+
+struct ma_bandpass {
+    float freq;           // center frequency Hz
+    float q;              // quality factor
+    float sample_rate;
+    // biquad coefficients
+    float a0, a1, a2, b1, b2;
+    // state per channel
+    float z1_l, z2_l, z1_r, z2_r;
+};
+
+void ma_bitcrush_init(ma_bitcrush * bc);
+void ma_bitcrush_process(ma_bitcrush * bc, float * buf, int frame_count);
+
+void ma_waveshaper_init(ma_waveshaper * ws);
+void ma_waveshaper_process(ma_waveshaper * ws, float * buf, int frame_count);
+
+void ma_djfilter_init(ma_djfilter * dj, float sample_rate);
+void ma_djfilter_process(ma_djfilter * dj, float * buf, int frame_count);
+
+void ma_bandpass_init(ma_bandpass * bp, float sample_rate);
+void ma_bandpass_setup(ma_bandpass * bp, float freq, float q);
+void ma_bandpass_process(ma_bandpass * bp, float * buf, int frame_count);
+
+// ─── Implementation ───
+
+#ifdef MA_EFFECTS_IMPLEMENTATION
+
+void ma_bitcrush_init(ma_bitcrush * bc) {
+    memset(bc, 0, sizeof(*bc));
+}
+
+void ma_bitcrush_process(ma_bitcrush * bc, float * buf, int frame_count) {
+    for (int f = 0; f < frame_count; f++) {
+        float l = buf[f * 2];
+        float r = buf[f * 2 + 1];
+
+        // bit depth reduction
+        if (bc->bits > 0.0f) {
+            float levels = powf(2.0f, bc->bits);
+            l = floorf(l * levels + 0.5f) / levels;
+            r = floorf(r * levels + 0.5f) / levels;
+        }
+
+        // sample rate reduction (sample-and-hold)
+        if (bc->coarse > 0) {
+            if (bc->hold_counter <= 0) {
+                bc->held_l = l;
+                bc->held_r = r;
+                bc->hold_counter = bc->coarse;
+            }
+            bc->hold_counter--;
+            l = bc->held_l;
+            r = bc->held_r;
+        }
+
+        buf[f * 2]     = l;
+        buf[f * 2 + 1] = r;
+    }
+}
+
+void ma_waveshaper_init(ma_waveshaper * ws) {
+    memset(ws, 0, sizeof(*ws));
+}
+
+void ma_waveshaper_process(ma_waveshaper * ws, float * buf, int frame_count) {
+    if (ws->drive <= 0.0f) return;
+    float gain = 1.0f + ws->drive * 10.0f;
+    float norm = 1.0f / tanhf(gain);
+    for (int f = 0; f < frame_count; f++) {
+        buf[f * 2]     = tanhf(buf[f * 2]     * gain) * norm;
+        buf[f * 2 + 1] = tanhf(buf[f * 2 + 1] * gain) * norm;
+    }
+}
+
+void ma_djfilter_init(ma_djfilter * dj, float sample_rate) {
+    memset(dj, 0, sizeof(*dj));
+    dj->position = 0.5f;
+    dj->sample_rate = sample_rate;
+}
+
+void ma_djfilter_process(ma_djfilter * dj, float * buf, int frame_count) {
+    float pos = dj->position;
+    if (pos < 0.0f) pos = 0.0f;
+    if (pos > 1.0f) pos = 1.0f;
+
+    // bypass
+    if (pos > 0.499f && pos < 0.501f) return;
+
+    float cutoff;
+    int is_hpf;
+    if (pos < 0.5f) {
+        // LPF: cutoff sweeps from 200Hz (pos=0) to 20000Hz (pos=0.5)
+        float t = pos / 0.5f;
+        cutoff = 200.0f * powf(20000.0f / 200.0f, t);
+        is_hpf = 0;
+    } else {
+        // HPF: cutoff sweeps from 20Hz (pos=0.5) to 4000Hz (pos=1)
+        float t = (pos - 0.5f) / 0.5f;
+        cutoff = 20.0f * powf(4000.0f / 20.0f, t);
+        is_hpf = 1;
+    }
+
+    float alpha = 1.0f - expf(-2.0f * (float)M_PI * cutoff / dj->sample_rate);
+    float z1_l = dj->z1_l;
+    float z1_r = dj->z1_r;
+
+    for (int f = 0; f < frame_count; f++) {
+        float in_l = buf[f * 2];
+        float in_r = buf[f * 2 + 1];
+
+        // one-pole LPF
+        z1_l += alpha * (in_l - z1_l);
+        z1_r += alpha * (in_r - z1_r);
+
+        if (is_hpf) {
+            buf[f * 2]     = in_l - z1_l;
+            buf[f * 2 + 1] = in_r - z1_r;
+        } else {
+            buf[f * 2]     = z1_l;
+            buf[f * 2 + 1] = z1_r;
+        }
+    }
+
+    dj->z1_l = z1_l;
+    dj->z1_r = z1_r;
+}
+
+void ma_bandpass_init(ma_bandpass * bp, float sample_rate) {
+    memset(bp, 0, sizeof(*bp));
+    bp->sample_rate = sample_rate;
+    bp->freq = 1000.0f;
+    bp->q = 1.0f;
+    ma_bandpass_setup(bp, bp->freq, bp->q);
+}
+
+void ma_bandpass_setup(ma_bandpass * bp, float freq, float q) {
+    bp->freq = freq;
+    bp->q = q;
+    if (bp->q < 0.01f) bp->q = 0.01f;
+
+    float w0 = 2.0f * (float)M_PI * freq / bp->sample_rate;
+    float sin_w0 = sinf(w0);
+    float cos_w0 = cosf(w0);
+    float alpha = sin_w0 / (2.0f * bp->q);
+
+    float norm = 1.0f / (1.0f + alpha);
+    bp->a0 =  alpha * norm;
+    bp->a1 =  0.0f;
+    bp->a2 = -alpha * norm;
+    bp->b1 = -2.0f * cos_w0 * norm;
+    bp->b2 =  (1.0f - alpha) * norm;
+}
+
+void ma_bandpass_process(ma_bandpass * bp, float * buf, int frame_count) {
+    float a0 = bp->a0, a1 = bp->a1, a2 = bp->a2;
+    float b1 = bp->b1, b2 = bp->b2;
+    float z1_l = bp->z1_l, z2_l = bp->z2_l;
+    float z1_r = bp->z1_r, z2_r = bp->z2_r;
+
+    for (int f = 0; f < frame_count; f++) {
+        float x_l = buf[f * 2];
+        float x_r = buf[f * 2 + 1];
+
+        // transposed direct form II
+        float y_l = a0 * x_l + z1_l;
+        z1_l = a1 * x_l - b1 * y_l + z2_l;
+        z2_l = a2 * x_l - b2 * y_l;
+
+        float y_r = a0 * x_r + z1_r;
+        z1_r = a1 * x_r - b1 * y_r + z2_r;
+        z2_r = a2 * x_r - b2 * y_r;
+
+        buf[f * 2]     = y_l;
+        buf[f * 2 + 1] = y_r;
+    }
+
+    bp->z1_l = z1_l; bp->z2_l = z2_l;
+    bp->z1_r = z1_r; bp->z2_r = z2_r;
+}
+
+#endif // MA_EFFECTS_IMPLEMENTATION

--- a/modules/dasAudio/src/phaser.h
+++ b/modules/dasAudio/src/phaser.h
@@ -1,0 +1,118 @@
+#pragma once
+
+// Per-voice phaser: classic multi-stage 1-pole all-pass topology (MXR Phase 90 style).
+// 4 cascaded all-pass sections produce 2 swept notches when summed with dry.
+// depth controls wet/dry mix; sweep controls LFO range in cents; center is the
+// geometric mean of the sweep; rate is the LFO Hz. Triangle LFO.
+// Header-only; define MA_PHASER_IMPLEMENTATION in exactly one .cpp.
+
+#include <math.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#define MA_PHASER_STAGES 4
+
+struct ma_phaser {
+    float rate;            // LFO rate Hz
+    float depth;           // wet/dry mix 0..1 (deeper notch at higher values)
+    float center;          // center frequency Hz
+    float sweep;           // sweep range cents (one-sided)
+    float sample_rate;
+    float lfo_phase;       // 0..1
+    // 1-pole all-pass coef (shared across stages; modulated by LFO)
+    float a;
+    // state per stage, per channel
+    float x_l[MA_PHASER_STAGES], y_l[MA_PHASER_STAGES];
+    float x_r[MA_PHASER_STAGES], y_r[MA_PHASER_STAGES];
+    // feedback tap (last-stage output from previous sample, per channel)
+    float fb_l, fb_r;
+    int update_counter;    // refresh coef every N samples
+};
+
+void ma_phaser_init(ma_phaser * ph, float sample_rate);
+void ma_phaser_process(ma_phaser * ph, float * buf, int frame_count);
+
+#ifdef MA_PHASER_IMPLEMENTATION
+
+static void ma_phaser_setup_coef(ma_phaser * ph, float freq) {
+    if (freq < 20.0f) freq = 20.0f;
+    float nyq = ph->sample_rate * 0.49f;
+    if (freq > nyq) freq = nyq;
+    // 1-pole all-pass: y[n] = -a*x[n] + x[n-1] + a*y[n-1]
+    // where a = (1 - tan(w/2)) / (1 + tan(w/2)), w = 2*pi*freq/sr.
+    float w = (float)M_PI * freq / ph->sample_rate;  // = w/2 when w=2πf/sr
+    float t = tanf(w);
+    ph->a = (1.0f - t) / (1.0f + t);
+}
+
+void ma_phaser_init(ma_phaser * ph, float sample_rate) {
+    memset(ph, 0, sizeof(*ph));
+    ph->sample_rate = sample_rate;
+    ph->rate = 1.0f;
+    ph->depth = 0.75f;
+    ph->center = 1000.0f;
+    ph->sweep = 2000.0f;
+    ma_phaser_setup_coef(ph, ph->center);
+}
+
+void ma_phaser_process(ma_phaser * ph, float * buf, int frame_count) {
+    if (ph->rate <= 0.0f || ph->depth <= 0.0f) return;
+    float phase_inc = ph->rate / ph->sample_rate;
+    float a = ph->a;
+    int counter = ph->update_counter;
+    const int UPDATE_EVERY = 16;
+    // triangle LFO modulates all-pass cutoff in cents around center.
+    const float CENTS_INV = 1.0f / 1200.0f;
+    float depth = ph->depth; if (depth > 1.0f) depth = 1.0f; if (depth < 0.0f) depth = 0.0f;
+    // Classic phaser: notch depth comes from cancellation at frequencies where the
+    // all-pass chain phase-inverts the signal. With feedback, the notches resonate.
+    // depth modulates both wet/dry mix AND feedback for a bigger audible swing.
+    float feedback = 0.9f * depth;   // up to 90% feedback → deep resonant notches
+    float wet = depth;
+    float norm = 1.0f / (1.0f + depth);
+    float fb_l = ph->fb_l, fb_r = ph->fb_r;
+    for (int f = 0; f < frame_count; f++) {
+        if (counter <= 0) {
+            float lfo = 4.0f * fabsf(ph->lfo_phase - 0.5f) - 1.0f;
+            float freq = ph->center * powf(2.0f, lfo * ph->sweep * CENTS_INV);
+            ma_phaser_setup_coef(ph, freq);
+            a = ph->a;
+            counter = UPDATE_EVERY;
+        }
+        counter--;
+        ph->lfo_phase += phase_inc;
+        if (ph->lfo_phase >= 1.0f) ph->lfo_phase -= 1.0f;
+
+        float xl = buf[f * 2];
+        float xr = buf[f * 2 + 1];
+        // Mix input with last-stage output fed back (creates resonance at notches)
+        float in_l = xl + fb_l * feedback;
+        float in_r = xr + fb_r * feedback;
+        // Cascade N all-pass stages
+        for (int s = 0; s < MA_PHASER_STAGES; s++) {
+            float yl = -a * in_l + ph->x_l[s] + a * ph->y_l[s];
+            ph->x_l[s] = in_l;
+            ph->y_l[s] = yl;
+            in_l = yl;
+            float yr = -a * in_r + ph->x_r[s] + a * ph->y_r[s];
+            ph->x_r[s] = in_r;
+            ph->y_r[s] = yr;
+            in_r = yr;
+        }
+        fb_l = in_l;
+        fb_r = in_r;
+        // Soft-clip feedback to prevent runaway at very high depth
+        if (fb_l > 2.0f) fb_l = 2.0f; if (fb_l < -2.0f) fb_l = -2.0f;
+        if (fb_r > 2.0f) fb_r = 2.0f; if (fb_r < -2.0f) fb_r = -2.0f;
+        buf[f * 2]     = (xl + in_l * wet) * norm;
+        buf[f * 2 + 1] = (xr + in_r * wet) * norm;
+    }
+    ph->update_counter = counter;
+    ph->fb_l = fb_l;
+    ph->fb_r = fb_r;
+}
+
+#endif // MA_PHASER_IMPLEMENTATION

--- a/modules/dasAudio/src/tremolo.h
+++ b/modules/dasAudio/src/tremolo.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// Per-voice tremolo — sine LFO modulating amplitude.
+// Output = input * (1 - depth * 0.5 * (1 - sin(phase))), so gain sweeps
+// between (1 - depth) and 1.0. At depth=0 no effect; at depth=1 full AM.
+// Header-only; define MA_TREMOLO_IMPLEMENTATION in exactly one .cpp.
+
+#include <math.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+struct ma_tremolo {
+    float rate;           // LFO rate Hz (0 = off)
+    float depth;          // modulation depth 0..1
+    float sample_rate;
+    float lfo_phase;      // 0..1
+};
+
+void ma_tremolo_init(ma_tremolo * tr, float sample_rate);
+void ma_tremolo_process(ma_tremolo * tr, float * buf, int frame_count);
+
+#ifdef MA_TREMOLO_IMPLEMENTATION
+
+void ma_tremolo_init(ma_tremolo * tr, float sample_rate) {
+    memset(tr, 0, sizeof(*tr));
+    tr->sample_rate = sample_rate;
+    tr->rate = 0.0f;
+    tr->depth = 1.0f;
+    tr->lfo_phase = 0.0f;
+}
+
+void ma_tremolo_process(ma_tremolo * tr, float * buf, int frame_count) {
+    if (tr->rate <= 0.0f || tr->depth <= 0.0f) return;
+    float d = tr->depth; if (d > 1.0f) d = 1.0f;
+    float half_d = d * 0.5f;
+    float min_gain = 1.0f - d;
+    if (min_gain < 0.0f) min_gain = 0.0f;
+    float phase_inc = tr->rate / tr->sample_rate;
+    float phase = tr->lfo_phase;
+    for (int f = 0; f < frame_count; f++) {
+        // gain sweeps min_gain (sin=-1) .. 1.0 (sin=1)
+        float lfo = sinf(phase * 2.0f * (float)M_PI);
+        float gain = min_gain + (1.0f - min_gain) * (0.5f + 0.5f * lfo);
+        buf[f * 2]     *= gain;
+        buf[f * 2 + 1] *= gain;
+        phase += phase_inc;
+        if (phase >= 1.0f) phase -= 1.0f;
+    }
+    tr->lfo_phase = phase;
+    (void)half_d;
+}
+
+#endif // MA_TREMOLO_IMPLEMENTATION

--- a/modules/dasAudio/strudel/strudel_event.das
+++ b/modules/dasAudio/strudel/strudel_event.das
@@ -5,7 +5,7 @@ module strudel_event shared
 
 // The payload of every pattern event — "what to play and how".
 // All defaults are "do nothing" values: gain 0.8 is a sensible level,
-// lpf 20000 means filter wide open, pan 0.5 is center, etc.
+// lpf 0 means "no filter" (undefined = no filter).
 struct Event {
     s       : string = ""       // sound name: "bd", "sd", "sawtooth", "sine"
     note    : float = 60.0      // MIDI note number (60 = middle C)
@@ -14,7 +14,7 @@ struct Event {
     velocity : float = 1.0     // expression 0.0–1.0 (scales gain, may affect timbre later)
     pan     : float = 0.5       // stereo pan: 0.0 = left, 0.5 = center, 1.0 = right
     speed   : float = 1.0       // sample playback speed (1.0 = normal)
-    lpf     : float = 20000.0   // low-pass filter cutoff Hz (20kHz = wide open)
+    lpf     : float = 0.0       // low-pass filter cutoff Hz (0 = no filter; set to activate)
     lpq     : float = 1.0       // low-pass filter resonance Q (1.0 = gentle, >5 = peaky)
     hpf     : float = 0.0       // high-pass filter cutoff Hz (0 = off)
     hpq     : float = 1.0       // high-pass filter resonance Q (1.0 = gentle, >5 = peaky)
@@ -33,6 +33,31 @@ struct Event {
     fmh     : float = 1.0       // FM harmonicity ratio (modulator freq / carrier freq)
     vowel   : string = ""      // vowel formant filter ("a", "e", "i", "o", "u", etc.)
     chorus  : float = 0.0       // chorus send amount 0.0–1.0
+    // Sample region (0.0–1.0 of sample length)
+    begin   : float = 0.0       // sample start position (0.0 = start)
+    end_pos : float = 1.0       // sample end position (1.0 = end). Named end_pos to avoid keyword conflict.
+    // Audio effects
+    crush   : float = 0.0       // bit depth reduction (0 = off, 4–16 = bit depth)
+    coarse  : int = 0           // sample rate reduction factor (0 = off, 2 = half rate, etc.)
+    shape   : float = 0.0       // waveshaper drive (0 = off, >0 = saturated)
+    djf     : float = 0.5       // DJ filter (0 = full LPF, 0.5 = off, 1 = full HPF)
+    bpf     : float = 0.0       // bandpass filter cutoff Hz (0 = off)
+    bpq     : float = 1.0       // bandpass filter Q
+    // Phaser (single notch biquad with LFO-modulated center)
+    phaser        : float = 0.0     // phaser LFO rate in Hz (0 = off)
+    phaserdepth   : float = 0.75    // phaser depth 0..1 (notch Q + sweep scale)
+    phasercenter  : float = 1000.0  // phaser center frequency Hz
+    phasersweep   : float = 2000.0  // phaser sweep range Hz
+    // Tremolo (amplitude modulation)
+    tremolo       : float = 0.0     // tremolo LFO rate in Hz (0 = off)
+    tremolodepth  : float = 1.0     // tremolo depth 0..1
+    // Compressor (threshold in dB; >=0 = bypass)
+    compressor    : float = 1.0     // threshold dB (>=0 = bypass; typical -20..-3)
+    compressor_ratio   : float = 10.0   // compression ratio (>=1)
+    compressor_knee    : float = 10.0   // soft-knee width in dB
+    compressor_attack  : float = 0.005  // attack time seconds
+    compressor_release : float = 0.05   // release time seconds
+    // SF2 SoundFont
     sf2_program    : int = -1   // SF2 GM program number (-1 = not SF2, use sample/oscillator)
     sf2_bank       : int = 0    // SF2 bank (0 = melodic, 128 = percussion)
     sf2_expression : float = -1.0 // SF2 expression CC11 (0.0–1.0, -1 = use default)

--- a/modules/dasAudio/strudel/strudel_mini.das
+++ b/modules/dasAudio/strudel/strudel_mini.das
@@ -109,7 +109,9 @@ def tokenize(input : string) : array<Token> {
                 let start = i
                 while (i < n) {
                     let c = int(data[i])
-                    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+                    // Include '#' so note names like "d#3" parse as a single WORD token
+                    // (mini-notation treats # as a step char).
+                    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '#') {
                         i ++
                     } else {
                         break
@@ -316,6 +318,9 @@ def parse_atom(var p : Parser) : Pattern {
 
 // Try to parse a note name like "c3", "eb4", "fs2" → MIDI number.
 // Returns -1.0 if not a note name.
+// Parse a note name with explicit octave. "d3", "eb4", "fs3". Returns -1 on miss.
+// Used by the mini-notation tokenizer — bare letters like "d" are treated as sounds,
+// not notes, so `s("a e i")` can be vowels or sound names without collision.
 def parse_note_name(name : string) : float {
     let n = length(name)
     if (n < 2 || n > 3) {
@@ -352,6 +357,52 @@ def parse_note_name(name : string) : float {
             return
         }
         let octave = octCh - int('0')
+        result = float((octave + 1) * 12 + semitone)
+    }
+    return result
+}
+
+// Parse a note name allowing octave to be omitted (defaults to default_oct,
+// e.g. noteToMidi(note, defaultOctave=3)). "d", "d#", "d#3", "eb".
+// Returns -1 if the string isn't a valid note.
+def parse_note_name_default(name : string; default_oct : int) : float {
+    let n = length(name)
+    if (n < 1 || n > 3) {
+        return -1.0
+    }
+    var result = -1.0
+    peek_data(name) $(bytes) {
+        let ch = int(bytes[0])
+        var semitone = -1
+        if (ch == 'c') { semitone = 0; }
+        elif (ch == 'd') { semitone = 2; }
+        elif (ch == 'e') { semitone = 4; }
+        elif (ch == 'f') { semitone = 5; }
+        elif (ch == 'g') { semitone = 7; }
+        elif (ch == 'a') { semitone = 9; }
+        elif (ch == 'b') { semitone = 11; }
+        if (semitone < 0) {
+            return
+        }
+        var octave = default_oct
+        var nextIdx = 1
+        if (n >= 2) {
+            let mod = int(bytes[1])
+            if (mod == 's' || mod == '#') {
+                semitone ++
+                nextIdx = 2
+            } elif (mod == 'b') {
+                semitone --
+                nextIdx = 2
+            }
+        }
+        if (nextIdx < n) {
+            let octCh = int(bytes[nextIdx])
+            if (octCh < '0' || octCh > '9') {
+                return
+            }
+            octave = octCh - int('0')
+        }
         result = float((octave + 1) * 12 + semitone)
     }
     return result
@@ -475,7 +526,22 @@ def set_s(var pat : Pattern; notation : string) : Pattern {
 // note("c3 ~ e3 g3") → pattern with note events (sound defaults to "sine")
 def note_pattern(notation : string; sound : string = "sine") : Pattern {
     let pat <- s(notation)
-    return <- pat |> set_sound(sound)
+    // Post-process: any event whose .s is a note name (including bare "d", "d#"
+    // without octave) gets converted to .note via default-octave parsing.
+    // parse_atom already converts tokens with explicit octave ("d3"); this pass
+    // handles the shorthand where the octave is implicit (default 3).
+    let converted <- pat |> fmap(@(e : Event) : Event {
+        var r = e
+        if (!empty(r.s)) {
+            let midi = parse_note_name_default(r.s, 3)
+            if (midi >= 0.0) {
+                r.note = midi
+                r.s = ""
+            }
+        }
+        return r
+    })
+    return <- converted |> set_sound(sound)
 }
 
 // Parse mini-notation with | bar separators for sequential melodies.
@@ -512,3 +578,14 @@ def every_degrade(n : int; prob : float; notation : string) : Pattern {
     let off <- s(notation)
     return <- every(n, on, off)
 }
+
+// ─── Bare-Name Aliases ───
+
+// note("c3 e3 g3") — alias for note_pattern
+def note(notation : string; sound : string = "sine") : Pattern { return <- note_pattern(notation, sound); }
+
+// vowel("a") or vowel("<a e i>") — alias for set_vowel (string overload)
+def vowel(var pat : Pattern; notation : string) : Pattern { return <- set_vowel(pat, notation); }
+
+// vowel(s("<a e i>") |> slow(4.0lf)) — alias for set_vowel (Pattern overload)
+def vowel(var pat : Pattern; var vowel_pat : Pattern) : Pattern { return <- set_vowel(pat, vowel_pat); }

--- a/modules/dasAudio/strudel/strudel_pattern.das
+++ b/modules/dasAudio/strudel/strudel_pattern.das
@@ -218,9 +218,7 @@ def degrade(var pat : Pattern; prob : float) : Pattern {
         var result : array<Hap>
         var haps <- pat(span)
         for (h in haps) {
-            let seed = uint(h.whole.start * 10000.0lf)
-            let hash = (seed * 2654435761u) >> 16u
-            let r = float(hash % 1000u) / 1000.0
+            let r = strudel_hash01(h.whole.start, 0)
             if (r >= prob) {
                 result |> push(h)
             }
@@ -413,6 +411,144 @@ def set_fm(var pat : Pattern; f : float) : Pattern {
 def set_fmh(var pat : Pattern; f : float) : Pattern {
     let fn <- @capture(= f) (e : Event) : Event {
         var ev = e; ev.fmh = f; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
+// ─── Sample Region & Audio Effects ───
+
+def set_begin(var pat : Pattern; b : float) : Pattern {
+    let fn <- @capture(= b) (e : Event) : Event {
+        var r = e; r.begin = b; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_end(var pat : Pattern; e_val : float) : Pattern {
+    let fn <- @capture(= e_val) (e : Event) : Event {
+        var r = e; r.end_pos = e_val; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_crush(var pat : Pattern; c : float) : Pattern {
+    let fn <- @capture(= c) (e : Event) : Event {
+        var r = e; r.crush = c; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_coarse(var pat : Pattern; c : int) : Pattern {
+    let fn <- @capture(= c) (e : Event) : Event {
+        var r = e; r.coarse = c; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_shape(var pat : Pattern; s : float) : Pattern {
+    let fn <- @capture(= s) (e : Event) : Event {
+        var r = e; r.shape = s; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_djf(var pat : Pattern; d : float) : Pattern {
+    let fn <- @capture(= d) (e : Event) : Event {
+        var r = e; r.djf = d; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_bpf(var pat : Pattern; freq : float) : Pattern {
+    let fn <- @capture(= freq) (e : Event) : Event {
+        var r = e; r.bpf = freq; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_bpq(var pat : Pattern; q : float) : Pattern {
+    let fn <- @capture(= q) (e : Event) : Event {
+        var r = e; r.bpq = q; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+// Phaser: rate in Hz (0 disables). Modulates a single notch biquad.
+def set_phaser(var pat : Pattern; r : float) : Pattern {
+    let fn <- @capture(= r) (e : Event) : Event {
+        var ev = e; ev.phaser = r; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_phaserdepth(var pat : Pattern; d : float) : Pattern {
+    let fn <- @capture(= d) (e : Event) : Event {
+        var ev = e; ev.phaserdepth = d; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_phasercenter(var pat : Pattern; c : float) : Pattern {
+    let fn <- @capture(= c) (e : Event) : Event {
+        var ev = e; ev.phasercenter = c; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_phasersweep(var pat : Pattern; s : float) : Pattern {
+    let fn <- @capture(= s) (e : Event) : Event {
+        var ev = e; ev.phasersweep = s; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
+// Tremolo: rate in Hz (0 disables), amplitude modulation.
+def set_tremolo(var pat : Pattern; r : float) : Pattern {
+    let fn <- @capture(= r) (e : Event) : Event {
+        var ev = e; ev.tremolo = r; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_tremolodepth(var pat : Pattern; d : float) : Pattern {
+    let fn <- @capture(= d) (e : Event) : Event {
+        var ev = e; ev.tremolodepth = d; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
+// Compressor: threshold in dB (>=0 = bypass). Negative values activate.
+def set_compressor(var pat : Pattern; thr_db : float) : Pattern {
+    let fn <- @capture(= thr_db) (e : Event) : Event {
+        var ev = e; ev.compressor = thr_db; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_compressor_ratio(var pat : Pattern; ratio : float) : Pattern {
+    let fn <- @capture(= ratio) (e : Event) : Event {
+        var ev = e; ev.compressor_ratio = ratio; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_compressor_knee(var pat : Pattern; knee : float) : Pattern {
+    let fn <- @capture(= knee) (e : Event) : Event {
+        var ev = e; ev.compressor_knee = knee; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_compressor_attack(var pat : Pattern; a : float) : Pattern {
+    let fn <- @capture(= a) (e : Event) : Event {
+        var ev = e; ev.compressor_attack = a; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
+def set_compressor_release(var pat : Pattern; r : float) : Pattern {
+    let fn <- @capture(= r) (e : Event) : Event {
+        var ev = e; ev.compressor_release = r; return ev
     }
     return <- fmap(pat, fn)
 }
@@ -703,9 +839,7 @@ def degrade_keep(var pat : Pattern; prob : float) : Pattern {
         var inscope haps = pat(span)
         for (h in haps) {
             if (h.has_whole) {
-                let seed = uint(h.whole.start * 10000.0lf)
-                let hash = (seed * 2654435761u) >> 16u
-                let r = float(hash % 1000u) / 1000.0
+                let r = strudel_hash01(h.whole.start, 0)
                 if (r >= cn) {
                     result |> push(h) // nolint:PERF006
                 }
@@ -723,9 +857,7 @@ def degrade_drop(var pat : Pattern; prob : float) : Pattern {
         var inscope haps = pat(span)
         for (h in haps) {
             if (h.has_whole) {
-                let seed = uint(h.whole.start * 10000.0lf)
-                let hash = (seed * 2654435761u) >> 16u
-                let r = float(hash % 1000u) / 1000.0
+                let r = strudel_hash01(h.whole.start, 0)
                 if (r < cn) {
                     result |> push(h) // nolint:PERF006
                 }
@@ -943,8 +1075,8 @@ def signal_perlin() : Pattern {
         let i = int(floor(t))
         let frac = float(t - floor(t))
         // hash integer cycle to pseudo-random value 0..1
-        let h0 = float((uint(i) * 2654435761u) & 0xFFFFu) / 65535.0
-        let h1 = float((uint(i + 1) * 2654435761u) & 0xFFFFu) / 65535.0
+        let h0 = strudel_hash01(double(i), 0)
+        let h1 = strudel_hash01(double(i + 1), 0)
         // smootherstep: 6t^5 - 15t^4 + 10t^3
         let u = frac * frac * frac * (frac * (frac * 6.0 - 15.0) + 10.0)
         return h0 + (h1 - h0) * u
@@ -1163,6 +1295,116 @@ def set_sf2_pitch_bend(var pat : Pattern; var mod_pat : Pattern) : Pattern {
     })
 }
 
+// ─── Pattern-modulated sample region & effects setters ───
+
+def set_begin(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.begin = val; return r
+    })
+}
+
+def set_end(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.end_pos = val; return r
+    })
+}
+
+def set_crush(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.crush = val; return r
+    })
+}
+
+def set_shape(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.shape = val; return r
+    })
+}
+
+def set_djf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.djf = val; return r
+    })
+}
+
+def set_bpf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.bpf = val; return r
+    })
+}
+
+def set_bpq(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.bpq = val; return r
+    })
+}
+
+def set_phaser(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.phaser = val; return r
+    })
+}
+
+def set_phaserdepth(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.phaserdepth = val; return r
+    })
+}
+
+def set_phasercenter(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.phasercenter = val; return r
+    })
+}
+
+def set_phasersweep(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.phasersweep = val; return r
+    })
+}
+
+def set_tremolo(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.tremolo = val; return r
+    })
+}
+
+def set_tremolodepth(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.tremolodepth = val; return r
+    })
+}
+
+def set_compressor(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.compressor = val; return r
+    })
+}
+
+def set_compressor_ratio(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.compressor_ratio = val; return r
+    })
+}
+
+def set_compressor_knee(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.compressor_knee = val; return r
+    })
+}
+
+def set_compressor_attack(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.compressor_attack = val; return r
+    })
+}
+
+def set_compressor_release(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.compressor_release = val; return r
+    })
+}
+
 // ─── String-valued combineWith (for vowel, etc.) ───
 
 // Like combineWith but samples a string value from the value pattern's event.s field.
@@ -1225,3 +1467,918 @@ def euclid(var pat : Pattern; k, n : int) : Pattern {
         return <- result
     }
 }
+
+// ─── Additional Combinators ───
+
+// Play forward on even cycles, reversed on odd cycles.
+def palindrome(var pat : Pattern) : Pattern {
+    return @capture(<- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var inscope split = splitSpans(span)
+        for (sub in split) {
+            let cycle = int(sameCycle(sub.start))
+            if (cycle % 2 == 0) {
+                var haps <- pat(sub)
+                for (h in haps) {
+                    result |> push(h) // nolint:PERF006
+                }
+                delete haps
+            } else {
+                // mirror within cycle
+                let cyc = floor(sub.start)
+                let relStart = sub.start - cyc
+                let relStop = sub.stop - cyc
+                let mirStart = 1.0lf - relStop
+                let mirStop = 1.0lf - relStart
+                let mirSpan = TimeSpan(start = mirStart + cyc, stop = mirStop + cyc)
+                var haps <- pat(mirSpan)
+                for (h in haps) {
+                    let hCycle = floor(h.whole.start)
+                    let wStart = h.whole.start - hCycle
+                    let wStop = h.whole.stop - hCycle
+                    let pStart = h.part.start - hCycle
+                    let pStop = h.part.stop - hCycle
+                    result |> push(Hap( // nolint:PERF006
+                        whole = TimeSpan(start = 1.0lf - wStop + hCycle, stop = 1.0lf - wStart + hCycle),
+                        part = TimeSpan(start = 1.0lf - pStop + hCycle, stop = 1.0lf - pStart + hCycle),
+                        has_whole = h.has_whole,
+                        value = h.value
+                    ))
+                }
+                delete haps
+            }
+        }
+        return <- result
+    }
+}
+
+// Stack original + transformed copy.
+// superimpose(pat, @(x) => fast(x, 2.0lf)) — layer faster copy on top
+def superimpose(var pat : Pattern; transform : PatternTransform) : Pattern {
+    var transformed <- invoke(transform, pat)
+    var layers : array<Pattern>
+    layers |> emplace <| pat
+    layers |> emplace <| transformed
+    return <- stack(layers)
+}
+
+// Repeat events with time offset and gain decay.
+// echo(pat, 3, 0.25, 0.5) — 3 echoes, 0.25 cycles apart, each 50% quieter
+def echo(var pat : Pattern; times : int; time : double; feedback : float) : Pattern {
+    // Build gain table and offsets, then query pat once per span and duplicate haps
+    var gains : array<float>
+    var offsets : array<double>
+    gains |> reserve(times)
+    offsets |> reserve(times)
+    gains |> push(1.0)       // original at full gain
+    offsets |> push(0.0lf)   // original at zero offset
+    var current_gain = feedback
+    for (i in range(1, times)) {
+        gains |> push(current_gain)
+        offsets |> push(time * double(i))
+        current_gain *= feedback
+    }
+    let n = length(gains)
+    return @capture(= n, <- gains, <- offsets, <- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        for (layer in range(n)) {
+            let off = offsets[layer]
+            let g = gains[layer]
+            // Echoes play LATER than original: query pat at (span - off), emit at (hap + off)
+            let innerSpan = TimeSpan(start = span.start - off, stop = span.stop - off)
+            var haps <- pat(innerSpan)
+            for (h in haps) {
+                var ev = h.value
+                ev.gain = ev.gain * g
+                result |> push(Hap( // nolint:PERF006
+                    whole = TimeSpan(start = h.whole.start + off, stop = h.whole.stop + off),
+                    part = TimeSpan(start = h.part.start + off, stop = h.part.stop + off),
+                    has_whole = h.has_whole,
+                    value = ev
+                ))
+            }
+            delete haps
+        }
+        return <- result
+    }
+}
+
+// stut — alias for echo with reordered parameters (times, feedback, time).
+def stut(var pat : Pattern; times : int; feedback : float; time : double) : Pattern {
+    return <- echo(pat, times, time, feedback)
+}
+
+// Repeat each event n times within its timespan.
+def ply(var pat : Pattern; n : int) : Pattern {
+    let nf = double(n)
+    return @capture(= n, = nf, <- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var haps <- pat(span)
+        for (h in haps) {
+            if (!h.has_whole) {
+                result |> push(h) // nolint:PERF006
+                continue
+            }
+            let dur = (h.whole.stop - h.whole.start) / nf
+            for (i in range(n)) {
+                let subStart = h.whole.start + dur * double(i)
+                let subStop = subStart + dur
+                let pStart = max(subStart, h.part.start)
+                let pStop = min(subStop, h.part.stop)
+                if (pStart < pStop) {
+                    result |> push(Hap(
+                        whole = TimeSpan(start = subStart, stop = subStop),
+                        part = TimeSpan(start = pStart, stop = pStop),
+                        has_whole = true,
+                        value = h.value
+                    ))
+                }
+            }
+        }
+        delete haps
+        return <- result
+    }
+}
+
+// Shift pattern left by 1/n each cycle.
+// iter(pat, 4) — cycle 0: original, cycle 1: shifted 1/4, cycle 2: shifted 2/4, etc.
+def iter(var pat : Pattern; n : int) : Pattern {
+    let nf = double(n)
+    return @capture(= n, = nf, <- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var inscope split = splitSpans(span)
+        for (sub in split) {
+            let cycle = int(sameCycle(sub.start))
+            var shift = double(cycle % n) / nf
+            if (shift < 0.0lf) {
+                shift += 1.0lf
+            }
+            let innerSpan = TimeSpan(start = sub.start + shift, stop = sub.stop + shift)
+            var haps <- pat(innerSpan)
+            for (h in haps) {
+                result |> push(Hap( // nolint:PERF006
+                    whole = TimeSpan(start = h.whole.start - shift, stop = h.whole.stop - shift),
+                    part = TimeSpan(start = h.part.start - shift, stop = h.part.stop - shift),
+                    has_whole = h.has_whole,
+                    value = h.value
+                ))
+            }
+            delete haps
+        }
+        return <- result
+    }
+}
+
+// Like iter but shifts right instead of left.
+def iterBack(var pat : Pattern; n : int) : Pattern {
+    let nf = double(n)
+    return @capture(= n, = nf, <- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var inscope split = splitSpans(span)
+        for (sub in split) {
+            let cycle = int(sameCycle(sub.start))
+            var shift = 0.0lf - double(cycle % n) / nf
+            if (shift > 0.0lf) {
+                shift -= 1.0lf
+            }
+            let innerSpan = TimeSpan(start = sub.start + shift, stop = sub.stop + shift)
+            var haps <- pat(innerSpan)
+            for (h in haps) {
+                result |> push(Hap( // nolint:PERF006
+                    whole = TimeSpan(start = h.whole.start - shift, stop = h.whole.stop - shift),
+                    part = TimeSpan(start = h.part.start - shift, stop = h.part.stop - shift),
+                    has_whole = h.has_whole,
+                    value = h.value
+                ))
+            }
+            delete haps
+        }
+        return <- result
+    }
+}
+
+// Conditional transform based on cycle number.
+// when_cycle(pat, @(c) => c % 4 == 0, @(x) => fast(x, 2.0lf))
+def when_cycle(var pat : Pattern; var cond : lambda<(cycle : int) : bool>; transform : PatternTransform) : Pattern {
+    var transformed <- invoke(transform, pat)
+    return @capture(<- pat, <- transformed, <- cond) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var inscope split = splitSpans(span)
+        for (sub in split) {
+            let cycle = int(sameCycle(sub.start))
+            if (cond(cycle)) {
+                var haps <- transformed(sub)
+                for (h in haps) {
+                    result |> push(h) // nolint:PERF006
+                }
+                delete haps
+            } else {
+                var haps <- pat(sub)
+                for (h in haps) {
+                    result |> push(h) // nolint:PERF006
+                }
+                delete haps
+            }
+        }
+        return <- result
+    }
+}
+
+// Loop first fraction of pattern. linger(pat, 0.25) — first quarter looped to fill each cycle.
+// Semantics: output(T) = pat(T mod t). Equivalent to pat.zoom(0, t).slow(t).
+def linger(var pat : Pattern; t : double) : Pattern {
+    return @capture(= t, <- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        return <- result if (t <= 0.0lf)
+        var inscope split = splitSpans(span)
+        for (sub in split) {
+            let cycle = floor(sub.start)
+            let relStart = sub.start - cycle
+            let relStop = sub.stop - cycle
+            // iterate each period-t chunk overlapping [relStart, relStop]
+            var i = 0
+            while (true) {
+                let chunkStart = double(i) * t
+                break if (chunkStart >= 1.0lf || chunkStart >= relStop)
+                let chunkStop = chunkStart + t
+                if (chunkStop > relStart) {
+                    let overlapStart = max(chunkStart, relStart)
+                    let overlapStop = min(min(chunkStop, 1.0lf), relStop)
+                    // query pat at the same offset inside [0, t], in this cycle
+                    let innerSpan = TimeSpan(
+                        start = cycle + (overlapStart - chunkStart),
+                        stop = cycle + (overlapStop - chunkStart)
+                    )
+                    var haps <- pat(innerSpan)
+                    for (h in haps) {
+                        // shift events by chunkStart so they land in the output iteration
+                        result |> push(Hap( // nolint:PERF006
+                            whole = TimeSpan(start = h.whole.start + chunkStart, stop = h.whole.stop + chunkStart),
+                            part = TimeSpan(start = h.part.start + chunkStart, stop = h.part.stop + chunkStart),
+                            has_whole = h.has_whole,
+                            value = h.value
+                        ))
+                    }
+                    delete haps
+                }
+                i ++
+            }
+        }
+        return <- result
+    }
+}
+
+// Combined fast + speed. hurry(pat, 2.0) speeds up pattern AND sample playback.
+def hurry(var pat : Pattern; factor : double) : Pattern {
+    return <- fast(pat, factor) |> set_speed(float(factor))
+}
+
+// Squeeze pattern into time window [b,e] within each cycle.
+// compress(pat, 0.25, 0.75) — pattern plays in middle half of each cycle
+def compress(var pat : Pattern; b, e : double) : Pattern {
+    let dur = e - b
+    return @capture(= b, = dur, <- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var inscope split = splitSpans(span)
+        for (sub in split) {
+            let cycle = floor(sub.start)
+            let winStart = cycle + b
+            let winStop = cycle + b + dur
+            let overStart = max(sub.start, winStart)
+            let overStop = min(sub.stop, winStop)
+            if (overStart >= overStop) {
+                continue
+            }
+            // map [winStart,winStop] → [cycle,cycle+1]
+            let innerStart = cycle + (overStart - winStart) / dur
+            let innerStop = cycle + (overStop - winStart) / dur
+            var haps <- pat(TimeSpan(start = innerStart, stop = innerStop))
+            for (h in haps) {
+                // map back: [cycle,cycle+1] → [winStart,winStop]
+                result |> push(Hap( // nolint:PERF006
+                    whole = TimeSpan(
+                        start = (h.whole.start - cycle) * dur + winStart,
+                        stop = (h.whole.stop - cycle) * dur + winStart
+                    ),
+                    part = TimeSpan(
+                        start = (h.part.start - cycle) * dur + winStart,
+                        stop = (h.part.stop - cycle) * dur + winStart
+                    ),
+                    has_whole = h.has_whole,
+                    value = h.value
+                ))
+            }
+            delete haps
+        }
+        return <- result
+    }
+}
+
+// Apply function to the nth chunk each cycle (rotating).
+// chunk(pat, 4, @(x) => fast(x, 2.0lf)) — doubles speed of chunk 0, then 1, then 2, then 3
+def chunk(var pat : Pattern; n : int; transform : PatternTransform) : Pattern {
+    var transformed <- invoke(transform, pat)
+    let nf = double(n)
+    return @capture(= n, = nf, <- pat, <- transformed) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var inscope split = splitSpans(span)
+        for (sub in split) {
+            let cycle = int(sameCycle(sub.start))
+            var activeChunk = cycle % n
+            if (activeChunk < 0) {
+                activeChunk += n
+            }
+            let cyc = floor(sub.start)
+            for (i in range(n)) {
+                let chunkStart = cyc + double(i) / nf
+                let chunkStop = cyc + double(i + 1) / nf
+                let overStart = max(sub.start, chunkStart)
+                let overStop = min(sub.stop, chunkStop)
+                if (overStart >= overStop) {
+                    continue
+                }
+                let querySpan = TimeSpan(start = overStart, stop = overStop)
+                if (i == activeChunk) {
+                    var haps <- transformed(querySpan)
+                    for (h in haps) {
+                        result |> push(h) // nolint:PERF006
+                    }
+                    delete haps
+                } else {
+                    var haps <- pat(querySpan)
+                    for (h in haps) {
+                        result |> push(h) // nolint:PERF006
+                    }
+                    delete haps
+                }
+            }
+        }
+        return <- result
+    }
+}
+
+// Interleave n slices of the pattern across events.
+// striate(pat, 4) — cuts each sample into n parts; slice i gets begin=i/n, end=(i+1)/n.
+// Behavior: progressive slices reveal later parts of the sample envelope.
+def striate(var pat : Pattern; n : int) : Pattern {
+    let nf = double(n)
+    let nfinv = 1.0 / float(n)
+    return @capture(= n, = nf, = nfinv, <- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        // speed up pattern by n, then assign each event the begin/end for its slice
+        let innerSpan = TimeSpan(start = span.start * nf, stop = span.stop * nf)
+        var haps <- pat(innerSpan)
+        result |> reserve(length(haps))
+        for (h in haps) {
+            let step = int(sameCycle(h.whole.start)) % n
+            var ev = h.value
+            ev.begin = float(step) * nfinv
+            ev.end_pos = float(step + 1) * nfinv
+            result |> push(Hap(
+                whole = TimeSpan(start = h.whole.start / nf, stop = h.whole.stop / nf),
+                part = TimeSpan(start = h.part.start / nf, stop = h.part.stop / nf),
+                has_whole = h.has_whole,
+                value = ev
+            ))
+        }
+        delete haps
+        return <- result
+    }
+}
+
+// Restructure pattern using a boolean mask from mini-notation.
+// struct_(pat, s("t f t t")) — play events only where mask is true
+def struct_(var pat : Pattern; var bool_pat : Pattern) : Pattern {
+    return @capture(<- pat, <- bool_pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var mask_haps <- bool_pat(span)
+        for (mh in mask_haps) {
+            if (!mh.has_whole) {
+                continue
+            }
+            // query inner pattern at mask hap's whole
+            var inner_haps <- pat(mh.whole)
+            for (ih in inner_haps) {
+                let pStart = max(ih.part.start, mh.part.start)
+                let pStop = min(ih.part.stop, mh.part.stop)
+                if (pStart < pStop) {
+                    result |> push(Hap( // nolint:PERF006
+                        whole = mh.whole,
+                        part = TimeSpan(start = pStart, stop = pStop),
+                        has_whole = true,
+                        value = ih.value
+                    ))
+                }
+            }
+            delete inner_haps
+        }
+        delete mask_haps
+        return <- result
+    }
+}
+
+// Keep events where mask pattern is active (has events).
+def mask(var pat : Pattern; var mask_pat : Pattern) : Pattern {
+    return @capture(<- pat, <- mask_pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var haps <- pat(span)
+        for (h in haps) {
+            if (!h.has_whole) {
+                continue
+            }
+            // check if mask has any event overlapping this hap
+            var mask_haps <- mask_pat(h.whole)
+            if (length(mask_haps) > 0) {
+                result |> push(h) // nolint:PERF006
+            }
+            delete mask_haps
+        }
+        delete haps
+        return <- result
+    }
+}
+
+// Randomly pick one pattern per cycle.
+def choose(var pats : array<Pattern>) : Pattern {
+    let cn = length(pats)
+    return @capture(= cn, <- pats) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var inscope split = splitSpans(span)
+        for (sub in split) {
+            let cycle = int(sameCycle(sub.start))
+            let idx = int(strudel_hash32(double(cycle), 0) % uint(cn))
+            var haps <- invoke(pats[idx], sub)
+            for (h in haps) {
+                result |> push(h) // nolint:PERF006
+            }
+            delete haps
+        }
+        return <- result
+    }
+}
+
+// Weighted random pattern selection per cycle.
+def wchoose(var pats : array<Pattern>; var weights : array<float>) : Pattern {
+    var total_weight = 0.0
+    for (w in weights) {
+        total_weight += w
+    }
+    let tw = total_weight
+    let cn = length(pats)
+    return @capture(= cn, = tw, <- pats, <- weights) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var inscope split = splitSpans(span)
+        for (sub in split) {
+            let cycle = int(sameCycle(sub.start))
+            let r = strudel_hash01(double(cycle), 0) * tw
+            var cumulative = 0.0
+            var idx = 0
+            for (i in range(cn)) {
+                cumulative += weights[i]
+                if (r < cumulative) {
+                    idx = i
+                    break
+                }
+            }
+            var haps <- invoke(pats[idx], sub)
+            for (h in haps) {
+                result |> push(h) // nolint:PERF006
+            }
+            delete haps
+        }
+        return <- result
+    }
+}
+
+// Alias for choose.
+def randcat(var pats : array<Pattern>) : Pattern {
+    return <- choose(pats)
+}
+
+// Alias for choose — chooseCycles (one pick per cycle).
+// daStrudel's `choose` already behaves per-cycle; this name exists for the
+// `chooseCycles` convention used by some pattern libraries where `choose`
+// is a continuous rand signal (glitchy for discrete note patterns).
+def chooseCycles(var pats : array<Pattern>) : Pattern {
+    return <- choose(pats)
+}
+
+// Deterministic 32-bit RNG for strudel. Given a query time and an index,
+// returns a well-mixed uint. Approach:
+//   T = floor(t * 2^29)  — ~1.86ns time resolution, overflow-safe for decades
+//   decorrelate (T_low, T_high, slot) with Murmur mix constants
+//   apply Murmur3 finalizer for full avalanche
+// This replaces earlier LCG/single-multiply hashes whose middle bits correlated
+// across consecutive slots (the "same-note-in-a-row" bug in scramble/shuffle).
+def strudel_hash32(t : double; slot : int) : uint {
+    let Ti = int64(t * 536870912.0lf)
+    let lo = uint(Ti)
+    let hi = uint(Ti >> 32l)
+    var key = lo ^ ((hi ^ 0x85EBCA6Bu) * 0xC2B2AE35u)
+    key ^= (uint(slot) ^ 0x7F4A7C15u) * 0x9E3779B9u
+    key ^= key >> 16u
+    key *= 0x85EBCA6Bu
+    key ^= key >> 13u
+    key *= 0xC2B2AE35u
+    key ^= key >> 16u
+    return key
+}
+
+// Same hash, mapped to float in [0, 1).
+def strudel_hash01(t : double; slot : int) : float {
+    return float(strudel_hash32(t, slot)) / 4294967296.0
+}
+
+// Random permutation of n subdivisions per cycle.
+def shuffle(var pat : Pattern; n : int) : Pattern {
+    let nf = double(n)
+    return @capture(= n, = nf, <- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var inscope split = splitSpans(span)
+        for (sub in split) {
+            let cycle = int(sameCycle(sub.start))
+            // Fisher-Yates shuffle using cycle as seed
+            var perm : array<int>
+            perm |> resize(n)
+            for (i in range(n)) {
+                perm[i] = i
+            }
+            var fi = n - 1
+            while (fi > 0) {
+                let j = int(strudel_hash32(double(cycle), fi) % uint(fi + 1))
+                let tmp = perm[fi]
+                perm[fi] = perm[j]
+                perm[j] = tmp
+                fi --
+            }
+            let cyc = floor(sub.start)
+            for (i in range(n)) {
+                let slotStart = cyc + double(i) / nf
+                let slotStop = cyc + double(i + 1) / nf
+                let overStart = max(sub.start, slotStart)
+                let overStop = min(sub.stop, slotStop)
+                if (overStart >= overStop) {
+                    continue
+                }
+                // query the perm[i]-th subdivision
+                let srcStart = cyc + double(perm[i]) / nf
+                let srcStop = cyc + double(perm[i] + 1) / nf
+                var haps <- pat(TimeSpan(start = srcStart, stop = srcStop))
+                for (h in haps) {
+                    // remap to destination slot
+                    let shift = slotStart - srcStart
+                    result |> push(Hap( // nolint:PERF006
+                        whole = TimeSpan(start = h.whole.start + shift, stop = h.whole.stop + shift),
+                        part = TimeSpan(start = max(h.part.start + shift, overStart), stop = min(h.part.stop + shift, overStop)),
+                        has_whole = h.has_whole,
+                        value = h.value
+                    ))
+                }
+                delete haps
+            }
+        }
+        return <- result
+    }
+}
+
+// Shuffle with replacement — each slot picks a random subdivision.
+def scramble(var pat : Pattern; n : int) : Pattern {
+    let nf = double(n)
+    return @capture(= n, = nf, <- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var inscope split = splitSpans(span)
+        for (sub in split) {
+            let cycle = int(sameCycle(sub.start))
+            let cyc = floor(sub.start)
+            for (i in range(n)) {
+                let slotStart = cyc + double(i) / nf
+                let slotStop = cyc + double(i + 1) / nf
+                let overStart = max(sub.start, slotStart)
+                let overStop = min(sub.stop, slotStop)
+                if (overStart >= overStop) {
+                    continue
+                }
+                let srcIdx = int(strudel_hash32(double(cycle), i) % uint(n))
+                let srcStart = cyc + double(srcIdx) / nf
+                let srcStop = cyc + double(srcIdx + 1) / nf
+                var haps <- pat(TimeSpan(start = srcStart, stop = srcStop))
+                for (h in haps) {
+                    let shift = slotStart - srcStart
+                    result |> push(Hap( // nolint:PERF006
+                        whole = TimeSpan(start = h.whole.start + shift, stop = h.whole.stop + shift),
+                        part = TimeSpan(start = max(h.part.start + shift, overStart), stop = min(h.part.stop + shift, overStop)),
+                        has_whole = h.has_whole,
+                        value = h.value
+                    ))
+                }
+                delete haps
+            }
+        }
+        return <- result
+    }
+}
+
+// ─── Additional Signals ───
+
+// Square wave 0..1. First half = 1.0, second half = 0.0.
+def signal_square() : Pattern {
+    return signal(@(t : double) : float {
+        let pos = t - floor(t)
+        return pos < 0.5lf ? 1.0 : 0.0
+    })
+}
+
+// Inverted sawtooth 0..1. Falls from 1.0 to 0.0 each cycle.
+def signal_isaw() : Pattern {
+    return signal(@(t : double) : float {
+        return 1.0 - float(t - floor(t))
+    })
+}
+
+// Inverted triangle 0..1. Starts at 1.0, falls to 0.0 at midpoint, returns to 1.0.
+def signal_itri() : Pattern {
+    return signal(@(t : double) : float {
+        let pos = float(t - floor(t))
+        return pos < 0.5 ? 1.0 - pos * 2.0 : (pos - 0.5) * 2.0
+    })
+}
+
+// Bipolar sine -1..1
+def signal_sine2() : Pattern {
+    return signal(@(t : double) : float {
+        return float(sin(3.14159265358979323846lf * 2.0lf * t))
+    })
+}
+
+// Bipolar cosine -1..1
+def signal_cosine2() : Pattern {
+    return signal(@(t : double) : float {
+        return float(cos(3.14159265358979323846lf * 2.0lf * t))
+    })
+}
+
+// Bipolar sawtooth -1..1
+def signal_saw2() : Pattern {
+    return signal(@(t : double) : float {
+        return float(t - floor(t)) * 2.0 - 1.0
+    })
+}
+
+// Bipolar triangle -1..1
+def signal_tri2() : Pattern {
+    return signal(@(t : double) : float {
+        let pos = float(t - floor(t))
+        return pos < 0.5 ? pos * 4.0 - 1.0 : 3.0 - pos * 4.0
+    })
+}
+
+// Bipolar square -1..1
+def signal_square2() : Pattern {
+    return signal(@(t : double) : float {
+        let pos = t - floor(t)
+        return pos < 0.5lf ? 1.0 : -1.0
+    })
+}
+
+// Bipolar inverted sawtooth -1..1
+def signal_isaw2() : Pattern {
+    return signal(@(t : double) : float {
+        return 1.0 - float(t - floor(t)) * 2.0
+    })
+}
+
+// Bipolar inverted triangle -1..1
+def signal_itri2() : Pattern {
+    return signal(@(t : double) : float {
+        let pos = float(t - floor(t))
+        return pos < 0.5 ? 1.0 - pos * 4.0 : pos * 4.0 - 3.0
+    })
+}
+
+// Random 0..1 — deterministic per query time (hash-based).
+def signal_rand() : Pattern {
+    return signal(@(t : double) : float {
+        return strudel_hash01(t, 0)
+    })
+}
+
+// Random -1..1
+def signal_rand2() : Pattern {
+    return signal(@(t : double) : float {
+        return strudel_hash01(t, 0) * 2.0 - 1.0
+    })
+}
+
+// Random integer 0..n-1
+def signal_irand(n : int) : Pattern {
+    return signal(@capture(= n) (t : double) : float {
+        return float(strudel_hash32(t, 0) % uint(n))
+    })
+}
+
+// Discrete ramp 0..n-1 within each cycle.
+def signal_run(n : int) : Pattern {
+    let nf = double(n)
+    return @capture(= n, = nf) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        let cycle = floor(span.start)
+        for (i in range(n)) {
+            let start = cycle + double(i) / nf
+            let stop = cycle + double(i + 1) / nf
+            if (stop > span.start && start < span.stop) {
+                let pStart = max(start, span.start)
+                let pStop = min(stop, span.stop)
+                result |> push(Hap(
+                    whole = TimeSpan(start = start, stop = stop),
+                    part = TimeSpan(start = pStart, stop = pStop),
+                    has_whole = true,
+                    value = Event(note = float(i))
+                ))
+            }
+        }
+        return <- result
+    }
+}
+
+// ─── Bare-Name Aliases ───
+// Shorter names for chainable pattern combinators.
+// Old set_* names remain valid.
+
+// ── Scalar parameter aliases ──
+
+def gain(var pat : Pattern; g : float) : Pattern { return <- set_gain(pat, g); }
+def velocity(var pat : Pattern; v : float) : Pattern { return <- set_velocity(pat, v); }
+def vel(var pat : Pattern; v : float) : Pattern { return <- set_velocity(pat, v); }
+def pan(var pat : Pattern; p : float) : Pattern { return <- set_pan(pat, p); }
+def speed(var pat : Pattern; spd : float) : Pattern { return <- set_speed(pat, spd); }
+def note(var pat : Pattern; n : float) : Pattern { return <- set_note(pat, n); }
+def sound(var pat : Pattern; snd : string) : Pattern { return <- set_sound(pat, snd); }
+def cut(var pat : Pattern; c : int) : Pattern { return <- set_cut(pat, c); }
+def room(var pat : Pattern; r : float) : Pattern { return <- set_room(pat, r); }
+def roomsize(var pat : Pattern; r : float) : Pattern { return <- set_roomsize(pat, r); }
+def size(var pat : Pattern; r : float) : Pattern { return <- set_roomsize(pat, r); }
+def delay(var pat : Pattern; d : float) : Pattern { return <- set_delay(pat, d); }
+def delaytime(var pat : Pattern; d : float) : Pattern { return <- set_delaytime(pat, d); }
+def dt(var pat : Pattern; d : float) : Pattern { return <- set_delaytime(pat, d); }
+def delayfeedback(var pat : Pattern; d : float) : Pattern { return <- set_delayfeedback(pat, d); }
+def dfb(var pat : Pattern; d : float) : Pattern { return <- set_delayfeedback(pat, d); }
+def orbit(var pat : Pattern; o : int) : Pattern { return <- set_orbit(pat, o); }
+def fm(var pat : Pattern; f : float) : Pattern { return <- set_fm(pat, f); }
+def fmh(var pat : Pattern; f : float) : Pattern { return <- set_fmh(pat, f); }
+def lpf(var pat : Pattern; freq : float) : Pattern { return <- set_lpf(pat, freq); }
+def lp(var pat : Pattern; freq : float) : Pattern { return <- set_lpf(pat, freq); }
+def hpf(var pat : Pattern; freq : float) : Pattern { return <- set_hpf(pat, freq); }
+def hp(var pat : Pattern; freq : float) : Pattern { return <- set_hpf(pat, freq); }
+def lpq(var pat : Pattern; q : float) : Pattern { return <- set_lpq(pat, q); }
+def resonance(var pat : Pattern; q : float) : Pattern { return <- set_lpq(pat, q); }
+def hpq(var pat : Pattern; q : float) : Pattern { return <- set_hpq(pat, q); }
+def attack(var pat : Pattern; a : float) : Pattern { return <- set_attack(pat, a); }
+def att(var pat : Pattern; a : float) : Pattern { return <- set_attack(pat, a); }
+def decay(var pat : Pattern; d : float) : Pattern { return <- set_decay(pat, d); }
+def dec(var pat : Pattern; d : float) : Pattern { return <- set_decay(pat, d); }
+def sustain(var pat : Pattern; s : float) : Pattern { return <- set_sustain(pat, s); }
+def sus(var pat : Pattern; s : float) : Pattern { return <- set_sustain(pat, s); }
+def release(var pat : Pattern; r : float) : Pattern { return <- set_release(pat, r); }
+def rel(var pat : Pattern; r : float) : Pattern { return <- set_release(pat, r); }
+def chorus(var pat : Pattern; c : float) : Pattern { return <- set_chorus(pat, c); }
+
+// ── Sample region & effects aliases ──
+
+def begin(var pat : Pattern; b : float) : Pattern { return <- set_begin(pat, b); }
+def end_pos(var pat : Pattern; e_val : float) : Pattern { return <- set_end(pat, e_val); }
+def crush(var pat : Pattern; c : float) : Pattern { return <- set_crush(pat, c); }
+def coarse(var pat : Pattern; c : int) : Pattern { return <- set_coarse(pat, c); }
+def shape(var pat : Pattern; s : float) : Pattern { return <- set_shape(pat, s); }
+def djf(var pat : Pattern; d : float) : Pattern { return <- set_djf(pat, d); }
+def bpf(var pat : Pattern; freq : float) : Pattern { return <- set_bpf(pat, freq); }
+def bpq(var pat : Pattern; q : float) : Pattern { return <- set_bpq(pat, q); }
+
+// ── Phaser / Tremolo / Compressor aliases ──
+
+def phaser(var pat : Pattern; r : float) : Pattern { return <- set_phaser(pat, r); }
+def ph(var pat : Pattern; r : float) : Pattern { return <- set_phaser(pat, r); }
+def phaserdepth(var pat : Pattern; d : float) : Pattern { return <- set_phaserdepth(pat, d); }
+def phd(var pat : Pattern; d : float) : Pattern { return <- set_phaserdepth(pat, d); }
+def phasercenter(var pat : Pattern; c : float) : Pattern { return <- set_phasercenter(pat, c); }
+def phc(var pat : Pattern; c : float) : Pattern { return <- set_phasercenter(pat, c); }
+def phasersweep(var pat : Pattern; s : float) : Pattern { return <- set_phasersweep(pat, s); }
+def phs(var pat : Pattern; s : float) : Pattern { return <- set_phasersweep(pat, s); }
+
+def tremolo(var pat : Pattern; r : float) : Pattern { return <- set_tremolo(pat, r); }
+def trem(var pat : Pattern; r : float) : Pattern { return <- set_tremolo(pat, r); }
+def tremolodepth(var pat : Pattern; d : float) : Pattern { return <- set_tremolodepth(pat, d); }
+def tremdepth(var pat : Pattern; d : float) : Pattern { return <- set_tremolodepth(pat, d); }
+
+def compressor(var pat : Pattern; thr_db : float) : Pattern { return <- set_compressor(pat, thr_db); }
+// camelCase aliases; also expose snake_case for daScript-idiomatic callers.
+def compressorRatio(var pat : Pattern; r : float) : Pattern { return <- set_compressor_ratio(pat, r); }
+def compressor_ratio(var pat : Pattern; r : float) : Pattern { return <- set_compressor_ratio(pat, r); }
+def compressorKnee(var pat : Pattern; k : float) : Pattern { return <- set_compressor_knee(pat, k); }
+def compressor_knee(var pat : Pattern; k : float) : Pattern { return <- set_compressor_knee(pat, k); }
+def compressorAttack(var pat : Pattern; a : float) : Pattern { return <- set_compressor_attack(pat, a); }
+def compressor_attack(var pat : Pattern; a : float) : Pattern { return <- set_compressor_attack(pat, a); }
+def compressorRelease(var pat : Pattern; r : float) : Pattern { return <- set_compressor_release(pat, r); }
+def compressor_release(var pat : Pattern; r : float) : Pattern { return <- set_compressor_release(pat, r); }
+
+// ── SF2 aliases ──
+
+def sf2(var pat : Pattern; program : int) : Pattern { return <- set_sf2(pat, program); }
+def sf2(var pat : Pattern; name : string) : Pattern { return <- set_sf2(pat, name); }
+def sf2_bank(var pat : Pattern; bank : int) : Pattern { return <- set_sf2_bank(pat, bank); }
+def sf2_expression(var pat : Pattern; v : float) : Pattern { return <- set_sf2_expression(pat, v); }
+def sf2_mod_wheel(var pat : Pattern; v : float) : Pattern { return <- set_sf2_mod_wheel(pat, v); }
+def sf2_pitch_bend(var pat : Pattern; v : float) : Pattern { return <- set_sf2_pitch_bend(pat, v); }
+
+// ── Pattern-modulated parameter aliases ──
+
+def gain(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_gain(pat, mod_pat); }
+def velocity(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_velocity(pat, mod_pat); }
+def vel(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_velocity(pat, mod_pat); }
+def pan(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_pan(pat, mod_pat); }
+def speed(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_speed(pat, mod_pat); }
+def note(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_note(pat, mod_pat); }
+def sound(var pat : Pattern; var sound_pat : Pattern) : Pattern { return <- set_sound(pat, sound_pat); }
+def room(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_room(pat, mod_pat); }
+def roomsize(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_roomsize(pat, mod_pat); }
+def size(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_roomsize(pat, mod_pat); }
+def delay(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_delay(pat, mod_pat); }
+def delaytime(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_delaytime(pat, mod_pat); }
+def dt(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_delaytime(pat, mod_pat); }
+def delayfeedback(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_delayfeedback(pat, mod_pat); }
+def dfb(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_delayfeedback(pat, mod_pat); }
+def fm(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_fm(pat, mod_pat); }
+def fmh(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_fmh(pat, mod_pat); }
+def lpf(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_lpf(pat, mod_pat); }
+def lp(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_lpf(pat, mod_pat); }
+def hpf(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_hpf(pat, mod_pat); }
+def hp(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_hpf(pat, mod_pat); }
+def lpq(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_lpq(pat, mod_pat); }
+def resonance(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_lpq(pat, mod_pat); }
+def hpq(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_hpq(pat, mod_pat); }
+def attack(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_attack(pat, mod_pat); }
+def att(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_attack(pat, mod_pat); }
+def decay(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_decay(pat, mod_pat); }
+def dec(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_decay(pat, mod_pat); }
+def sustain(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_sustain(pat, mod_pat); }
+def sus(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_sustain(pat, mod_pat); }
+def release(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_release(pat, mod_pat); }
+def rel(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_release(pat, mod_pat); }
+def chorus(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_chorus(pat, mod_pat); }
+def sf2_expression(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_sf2_expression(pat, mod_pat); }
+def sf2_mod_wheel(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_sf2_mod_wheel(pat, mod_pat); }
+def sf2_pitch_bend(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_sf2_pitch_bend(pat, mod_pat); }
+def begin(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_begin(pat, mod_pat); }
+def end_pos(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_end(pat, mod_pat); }
+def crush(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_crush(pat, mod_pat); }
+def shape(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_shape(pat, mod_pat); }
+def djf(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_djf(pat, mod_pat); }
+def bpf(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_bpf(pat, mod_pat); }
+def bpq(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_bpq(pat, mod_pat); }
+def phaser(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phaser(pat, mod_pat); }
+def ph(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phaser(pat, mod_pat); }
+def phaserdepth(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phaserdepth(pat, mod_pat); }
+def phd(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phaserdepth(pat, mod_pat); }
+def phasercenter(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phasercenter(pat, mod_pat); }
+def phc(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phasercenter(pat, mod_pat); }
+def phasersweep(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phasersweep(pat, mod_pat); }
+def phs(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phasersweep(pat, mod_pat); }
+def tremolo(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_tremolo(pat, mod_pat); }
+def trem(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_tremolo(pat, mod_pat); }
+def tremolodepth(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_tremolodepth(pat, mod_pat); }
+def tremdepth(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_tremolodepth(pat, mod_pat); }
+def compressor(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor(pat, mod_pat); }
+def compressorRatio(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_ratio(pat, mod_pat); }
+def compressor_ratio(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_ratio(pat, mod_pat); }
+def compressorKnee(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_knee(pat, mod_pat); }
+def compressor_knee(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_knee(pat, mod_pat); }
+def compressorAttack(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_attack(pat, mod_pat); }
+def compressor_attack(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_attack(pat, mod_pat); }
+def compressorRelease(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_release(pat, mod_pat); }
+def compressor_release(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_release(pat, mod_pat); }
+
+// ── Signal aliases ──
+
+def sine() : Pattern { return <- signal_sine(); }
+def cosine() : Pattern { return <- signal_cosine(); }
+def saw() : Pattern { return <- signal_saw(); }
+def tri() : Pattern { return <- signal_tri(); }
+def perlin() : Pattern { return <- signal_perlin(); }
+def range(var pat : Pattern; lo, hi : float) : Pattern { return <- signal_range(pat, lo, hi); }
+def square() : Pattern { return <- signal_square(); }
+def isaw() : Pattern { return <- signal_isaw(); }
+def itri() : Pattern { return <- signal_itri(); }
+def sine2() : Pattern { return <- signal_sine2(); }
+def cosine2() : Pattern { return <- signal_cosine2(); }
+def saw2() : Pattern { return <- signal_saw2(); }
+def tri2() : Pattern { return <- signal_tri2(); }
+def square2() : Pattern { return <- signal_square2(); }
+def isaw2() : Pattern { return <- signal_isaw2(); }
+def itri2() : Pattern { return <- signal_itri2(); }
+def rand() : Pattern { return <- signal_rand(); }
+def rand2() : Pattern { return <- signal_rand2(); }
+def irand(n : int) : Pattern { return <- signal_irand(n); }
+def run(n : int) : Pattern { return <- signal_run(n); }
+
+// ── Additional aliases ──
+
+def degradeBy(var pat : Pattern; prob : float) : Pattern { return <- degrade(pat, prob); }

--- a/modules/dasAudio/strudel/strudel_samples.das
+++ b/modules/dasAudio/strudel/strudel_samples.das
@@ -149,8 +149,10 @@ def load_sound_memory(data : array<uint8>; name : string; var bank : SampleBank)
 }
 
 // Render a sample with speed control via miniaudio resampler + channel converter.
+// begin/end_pos are normalized slice bounds (0.0–1.0) — striate, chop, loop_at use these.
 // Returns interleaved stereo, no gain/pan applied.
-def render_sample(bank : SampleBank; name : string; variation : int; speed : float) : array<float> {
+def render_sample(bank : SampleBank; name : string; variation : int; speed : float;
+                  begin : float = 0.0; end_pos : float = 1.0) : array<float> {
     var stereo : array<float>
     bank.sounds |> get(name) $(variations) {
         if (length(variations) == 0) {
@@ -161,6 +163,15 @@ def render_sample(bank : SampleBank; name : string; variation : int; speed : flo
         let srcLen = length(variations[idx].data)
         let srcFrames = srcLen / int(srcChannels)
         if (srcFrames == 0) {
+            return
+        }
+        // clamp begin/end to [0,1], compute slice frame range
+        let b = clamp(begin, 0.0, 1.0)
+        let e = clamp(end_pos, 0.0, 1.0)
+        let sliceStart = int(b * float(srcFrames))
+        let sliceStop = min(srcFrames, max(sliceStart + 1, int(e * float(srcFrames))))
+        let sliceFrames = sliceStop - sliceStart
+        if (sliceFrames <= 0) {
             return
         }
         // resample: source rate * speed → target rate (MA_SAMPLE_RATE)
@@ -175,14 +186,14 @@ def render_sample(bank : SampleBank; name : string; variation : int; speed : flo
             ma_resample_algorithm.ma_resample_algorithm_linear
         )
         ma_resampler_init(unsafe(addr(resampler_config)), unsafe(addr(resampler)))
-        var outFrames = uint64(ma_resampler_get_expected_output_frame_count(unsafe(addr(resampler)), uint64(srcFrames)))
+        var outFrames = uint64(ma_resampler_get_expected_output_frame_count(unsafe(addr(resampler)), uint64(sliceFrames)))
         var resampled : array<float>
         resampled |> resize(int(outFrames) * int(srcChannels))
-        var inFrames = uint64(srcFrames)
+        var inFrames = uint64(sliceFrames)
         unsafe {
             ma_resampler_process_pcm_frames(
                 addr(resampler),
-                addr(variations[idx].data[0]),
+                addr(variations[idx].data[sliceStart * int(srcChannels)]),
                 addr(inFrames),
                 addr(resampled[0]),
                 addr(outFrames)

--- a/modules/dasAudio/strudel/strudel_scales.das
+++ b/modules/dasAudio/strudel/strudel_scales.das
@@ -49,12 +49,12 @@ def private get_scale_intervals(scale_type : string) : array<int> {
 }
 
 // Parse root note from scale string prefix.
-// Supports: "C", "C4", "Eb", "Eb4", "Fs", "Fs3", etc.
-// Returns MIDI note number. Default octave is 4 if not specified.
+// Supports: "C", "C3", "Eb", "Eb4", "Fs", "Fs3", etc.
+// Returns MIDI note number. Default octave is 3.
 def private parse_scale_root(root_str : string) : int {
     let n = length(root_str)
     if (n == 0) {
-        return 60  // default C4
+        return 48  // default C3
     }
     var semitone = -1
     peek_data(root_str) $(bytes) {
@@ -68,9 +68,9 @@ def private parse_scale_root(root_str : string) : int {
         elif (ch == 'B' || ch == 'b') { semitone = 11; }
     }
     if (semitone < 0) {
-        return 60  // fallback C4
+        return 48  // fallback C3
     }
-    var octave = 4  // default octave
+    var octave = 3  // default octave
     var idx = 1
     if (n > 1) {
         peek_data(root_str) $(bytes) {
@@ -108,12 +108,12 @@ def private normalize_scale_type(raw : string) : string {
 }
 
 // Parse a scale definition string "Root:Type" or "Root:Mod:Type" → (root_midi, scale_type).
-// Examples: "C4:major" → (60, "major"), "C4:minor:pentatonic" → (60, "minor_pentatonic")
-// If no colon, treats entire string as type with C4 root.
+// Examples: "C4:major" → (60, "major"), "D:pentatonic" → (50, "pentatonic") using default oct=3.
+// If no colon, treats entire string as type with C3 root.
 def private parse_scale_def(scale_def : string) : tuple<int; string> {
     let colon_pos = find(scale_def, ":")
     if (colon_pos < 0) {
-        return tuple(60, scale_def)
+        return tuple(48, scale_def)
     }
     let root_str = slice(scale_def, 0, colon_pos)
     let type_str = normalize_scale_type(slice(scale_def, colon_pos + 1))
@@ -175,3 +175,8 @@ def get_scale_intervals_by_name(scale_type : string) : array<int> {
 def parse_root(root_str : string) : int {
     return parse_scale_root(root_str)
 }
+
+// ─── Alias ───
+
+// scale("C4:major") — alias for set_scale
+def scale(var pat : Pattern; scale_def : string) : Pattern { return <- set_scale(pat, scale_def); }

--- a/modules/dasAudio/strudel/strudel_scheduler.das
+++ b/modules/dasAudio/strudel/strudel_scheduler.das
@@ -28,6 +28,7 @@ struct Voice {
 }
 
 // Per-voice metadata for SF2 voices (not stored in the C ma_sf2_voice struct).
+[safe_when_uninitialized]
 struct StrudelSF2Meta {
     note             : int = 0       // MIDI note (for re-trigger matching)
     note_off_sample  : int = -1      // sample position to fire note-off (-1 = don't auto note-off)
@@ -39,6 +40,8 @@ struct StrudelSF2Meta {
     cut              : int = 0       // strudel cut group
     gain             : float = 1.0   // event gain * velocity (applied as attenuation scale)
     orbit            : int = 0       // effect bus routing
+    @safe_when_uninitialized fx : VoiceFX  // per-voice audio effects
+    pan              : float = 0.0   // stereo pan (-1..1) used when fx routes through temp buffer
 }
 
 // Per-orbit effect bus. Each orbit has independent reverb + delay instances.
@@ -79,6 +82,8 @@ struct Scheduler {
     chorus          : ma_chorus?
     chorus_send_buf : array<float>
     chorus_out_buf  : array<float>
+    // Shared scratch buffer for per-voice FX processing (sized per-tick)
+    voice_fx_buf    : array<float>
 }
 
 // Convert wall-clock time to cycle position.
@@ -101,7 +106,7 @@ def private init_orbit_reverb(var bus : OrbitBus; roomsize : float = 2.0) {
     if (bus.reverb == null) {
         let rs = clamp(roomsize, 0.1, 10.0)
         bus.reverb = new ConvolutionReverb
-        conv_reverb_init(bus.reverb, SAMPLE_RATE, rs, 15000.0, 1000.0, 0.01)
+        conv_reverb_init(bus.reverb, SAMPLE_RATE, rs, 15000.0, 1000.0, 0.1)
         bus.current_roomsize = rs
     }
 }
@@ -115,7 +120,7 @@ def private update_orbit_reverb_roomsize(var bus : OrbitBus; roomsize : float) {
     bus.current_roomsize = rs
     // Reinitialize with new decay time
     conv_reverb_uninit(bus.reverb)
-    conv_reverb_init(bus.reverb, SAMPLE_RATE, rs, 15000.0, 1000.0, 0.01)
+    conv_reverb_init(bus.reverb, SAMPLE_RATE, rs, 15000.0, 1000.0, 0.1)
 }
 
 // Initialize delay on an orbit bus.
@@ -245,7 +250,7 @@ def private sf2_spawn_voices(var sched : Scheduler; event : Event; durSec : floa
             let rsend = sf2_get_reverb_send(*sched.sf2, z.x, z.y, pzone, preset.global_zone)
             let csend = max(sf2_get_chorus_send(*sched.sf2, z.x, z.y, pzone, preset.global_zone), event.chorus)
             sched.sf2_voices |> push(voice)
-            sched.sf2_meta |> push(StrudelSF2Meta(
+            var meta = StrudelSF2Meta(
                 note = note,
                 note_off_sample = note_off_sample,
                 reverb_send = rsend,
@@ -254,8 +259,11 @@ def private sf2_spawn_voices(var sched : Scheduler; event : Event; durSec : floa
                 exclusive_class = excl,
                 cut = cutGroup,
                 gain = eventGain,
-                orbit = event.orbit
-            ))
+                orbit = event.orbit,
+                pan = event.pan * 2.0 - 1.0
+            )
+            fx_init_from_event(meta.fx, event, float(SAMPLE_RATE))
+            sched.sf2_meta |> push(meta)
         }
     }
     delete atten_state.atten_mods
@@ -299,7 +307,40 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
             let chorus_send = meta.chorus_send
             let delay_send_amt = meta.delay_send
             let has_sends = reverb_send > 0.001 || chorus_send > 0.001 || delay_send_amt > 0.001
-            if (has_sends) {
+            if (meta.fx.active) {
+                // FX path: render dry into scratch, apply effects, then mix post-FX
+                // into output + sends. Uses the same temp buffer as osc voices.
+                let chunkSamples = chunkFrames * 2
+                if (length(sched.voice_fx_buf) < chunkSamples) {
+                    sched.voice_fx_buf |> resize(chunkSamples)
+                }
+                for (s in range(chunkSamples)) {
+                    sched.voice_fx_buf[s] = 0.0
+                }
+                unsafe {
+                    ma_sf2_voice_render(
+                        addr(sched.sf2_voices[si]),
+                        addr(sched.sf2.sample_data[0]),
+                        length(sched.sf2.sample_data),
+                        addr(sched.voice_fx_buf[0]),
+                        0, chunkFrames
+                    )
+                }
+                fx_apply(sched.sf2_meta[si].fx, sched.voice_fx_buf, chunkFrames)
+                var reverb_buf = get_orbit_reverb_send(sched, meta.orbit)
+                var delay_buf = get_orbit_delay_send(sched, meta.orbit)
+                let mix_reverb = reverb_buf != null && reverb_send > 0.001
+                let mix_delay  = delay_buf != null && delay_send_amt > 0.001
+                let mix_chorus = sched.chorus != null && chorus_send > 0.001 && length(sched.chorus_send_buf) >= chunkSamples
+                let dry_gain = has_sends ? max(0.0, 1.0 - reverb_send - chorus_send) : 1.0
+                for (s in range(chunkSamples)) {
+                    let v = sched.voice_fx_buf[s]
+                    output[s] += v * dry_gain
+                    if (mix_reverb) { (*reverb_buf)[s] += v * reverb_send; }
+                    if (mix_delay)  { (*delay_buf)[s]  += v * delay_send_amt; }
+                    if (mix_chorus) { sched.chorus_send_buf[s] += v * chorus_send; }
+                }
+            } elif (has_sends) {
                 var reverb_buf = get_orbit_reverb_send(sched, meta.orbit)
                 var delay_buf = get_orbit_delay_send(sched, meta.orbit)
                 let has_reverb = reverb_buf != null && reverb_send > 0.001
@@ -408,10 +449,14 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
 // Render all active streaming oscillator voices into the output buffer.
 // Sends accumulate into per-orbit bus buffers based on each voice's orbit.
 // Chorus send accumulates into the scheduler-level chorus_send_buf.
+// When a voice has active FX, render dry (no sends) into voice_fx_buf,
+// apply effects, then mix post-FX into output + sends.
 def private osc_render_voices(var sched : Scheduler; var output : array<float>; chunkFrames : int) {
+    let chunkSamples = chunkFrames * 2
     var i = length(sched.osc_voices) - 1
     while (i >= 0) {
         let orb = sched.osc_voices[i].orbit
+        let has_fx = sched.osc_voices[i].fx.active
         var reverb_buf : array<float>?
         var delay_buf : array<float>?
         if (sched.osc_voices[i].reverb_send > 0.0) {
@@ -420,19 +465,47 @@ def private osc_render_voices(var sched : Scheduler; var output : array<float>; 
         if (sched.osc_voices[i].delay_send > 0.0) {
             delay_buf = get_orbit_delay_send(sched, orb)
         }
-        // osc_render_chunk needs non-null array refs — use empty locals if no bus
-        if (reverb_buf != null && delay_buf != null) {
-            osc_render_chunk(sched.osc_voices[i], output, *reverb_buf, *delay_buf, sched.chorus_send_buf, chunkFrames)
-        } elif (reverb_buf != null) {
-            var empty : array<float>
-            osc_render_chunk(sched.osc_voices[i], output, *reverb_buf, empty, sched.chorus_send_buf, chunkFrames)
-        } elif (delay_buf != null) {
-            var empty : array<float>
-            osc_render_chunk(sched.osc_voices[i], output, empty, *delay_buf, sched.chorus_send_buf, chunkFrames)
-        } else {
+        if (has_fx) {
+            // route through scratch buffer: render dry (no sends), apply FX, mix into output + sends
+            if (length(sched.voice_fx_buf) < chunkSamples) {
+                sched.voice_fx_buf |> resize(chunkSamples)
+            }
+            for (s in range(chunkSamples)) {
+                sched.voice_fx_buf[s] = 0.0
+            }
             var empty1 : array<float>
             var empty2 : array<float>
-            osc_render_chunk(sched.osc_voices[i], output, empty1, empty2, sched.chorus_send_buf, chunkFrames)
+            var empty3 : array<float>
+            osc_render_chunk(sched.osc_voices[i], sched.voice_fx_buf, empty1, empty2, empty3, chunkFrames)
+            fx_apply(sched.osc_voices[i].fx, sched.voice_fx_buf, chunkFrames)
+            let rev_send = sched.osc_voices[i].reverb_send
+            let del_send = sched.osc_voices[i].delay_send
+            let cho_send = sched.osc_voices[i].chorus_send
+            let mix_reverb = reverb_buf != null && rev_send > 0.0
+            let mix_delay  = delay_buf != null && del_send > 0.0
+            let mix_chorus = sched.chorus != null && cho_send > 0.0 && length(sched.chorus_send_buf) >= chunkSamples
+            for (s in range(chunkSamples)) {
+                let v = sched.voice_fx_buf[s]
+                output[s] += v
+                if (mix_reverb) { (*reverb_buf)[s] += v * rev_send; }
+                if (mix_delay)  { (*delay_buf)[s]  += v * del_send; }
+                if (mix_chorus) { sched.chorus_send_buf[s] += v * cho_send; }
+            }
+        } else {
+            // osc_render_chunk needs non-null array refs — use empty locals if no bus
+            if (reverb_buf != null && delay_buf != null) {
+                osc_render_chunk(sched.osc_voices[i], output, *reverb_buf, *delay_buf, sched.chorus_send_buf, chunkFrames)
+            } elif (reverb_buf != null) {
+                var empty : array<float>
+                osc_render_chunk(sched.osc_voices[i], output, *reverb_buf, empty, sched.chorus_send_buf, chunkFrames)
+            } elif (delay_buf != null) {
+                var empty : array<float>
+                osc_render_chunk(sched.osc_voices[i], output, empty, *delay_buf, sched.chorus_send_buf, chunkFrames)
+            } else {
+                var empty1 : array<float>
+                var empty2 : array<float>
+                osc_render_chunk(sched.osc_voices[i], output, empty1, empty2, sched.chorus_send_buf, chunkFrames)
+            }
         }
         if (sched.osc_voices[i].finished) {
             sched.osc_voices |> erase(i)
@@ -615,10 +688,14 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                     if (oscType == OscType.osc_supersaw) {
                         osc_voice_init_supersaw(oscv)
                     }
+                    fx_init_from_event(oscv.fx, h.value, float(SAMPLE_RATE))
                     sched.osc_voices |> push(oscv)
                 } else {
                     // sample/drum path: pre-render to buffer
                     var stereo <- render_event_stereo(h.value, durSec, bank)
+                    // per-voice effects (crush/coarse/shape/djf/bpf) are applied
+                    // once post-render; state is local to this call
+                    fx_apply_to_samples(h.value, stereo, float(SAMPLE_RATE))
                     let offsetSamples = max(int(offsetSec * float(SAMPLE_RATE)) * 2, 0)
                     sched.voices |> push(new Voice(
                         samples <- stereo,

--- a/modules/dasAudio/strudel/strudel_synth.das
+++ b/modules/dasAudio/strudel/strudel_synth.das
@@ -24,6 +24,24 @@ def noise(var seed : uint&) : float {
     return float(seed >> 9u & 0x7FFFFFu) / float(0x3FFFFFu) - 1.0
 }
 
+// Polynomial band-limited step. Smooths the discontinuity at phase 0 / 1
+// of a naive sawtooth or square to eliminate aliases above Nyquist.
+// Ref: https://www.kvraudio.com/forum/viewtopic.php?t=375517
+// t = phase [0,1), dt = freq / sample_rate.
+def poly_blep(t, dt : float) : float {
+    var dt2 = dt
+    if (dt2 > 0.5) { dt2 = 0.5; }
+    if (dt2 < 0.0001) { return 0.0; }
+    if (t < dt2) {
+        let x = t / dt2
+        return x + x - x * x - 1.0
+    } elif (t > 1.0 - dt2) {
+        let x = (t - 1.0) / dt2
+        return x * x + x + x + 1.0
+    }
+    return 0.0
+}
+
 // ADSR envelope. Returns amplitude 0.0–1.0 for a given time position.
 def adsr(t, attack, decay, sustain, release, duration : float) : float {
     if (t < 0.0) {
@@ -522,8 +540,8 @@ def to_osc_type(sound : string) : OscType {
     return OscType.osc_unknown
 }
 
-let SUPERSAW_VOICES = 7
-let SUPERSAW_DETUNE = 0.2  // detune spread in semitones (+/- from center)
+let SUPERSAW_VOICES = 5       // default unison voice count
+let SUPERSAW_DETUNE = 0.18    // default frequency spread in semitones
 
 // Pink noise state — Paul Kellet's 7-stage cascaded IIR filter
 struct PinkNoiseState {
@@ -704,6 +722,107 @@ def vowel_filter_tick(var vf : VowelFilter; input : float) : float {
     return sum * VOWEL_MAKEUP_GAIN
 }
 
+// ─── Per-voice effect chain (bitcrush, waveshaper, DJ filter, bandpass, phaser, tremolo, compressor) ───
+// Wraps the C++ ma_* effect structs; initialised from Event fields.
+// Fields whose corresponding Event field is at its "off" value stay unused,
+// so a default VoiceFX is a cheap no-op.
+[safe_when_uninitialized]
+struct VoiceFX {
+    @safe_when_uninitialized bc   : ma_bitcrush
+    @safe_when_uninitialized ws   : ma_waveshaper
+    @safe_when_uninitialized dj   : ma_djfilter
+    @safe_when_uninitialized bp   : ma_bandpass
+    @safe_when_uninitialized ph   : ma_phaser
+    @safe_when_uninitialized trem : ma_tremolo
+    @safe_when_uninitialized comp : ma_compressor
+    has_crush : bool = false
+    has_shape : bool = false
+    has_djf   : bool = false
+    has_bpf   : bool = false
+    has_phaser : bool = false
+    has_tremolo : bool = false
+    has_compressor : bool = false
+    active    : bool = false
+}
+
+// Configure a VoiceFX from an Event. Returns silently if nothing is active.
+def fx_init_from_event(var fx : VoiceFX; event : Event; sample_rate : float) {
+    if (event.crush > 0.0 || event.coarse > 0) {
+        unsafe { bitcrush_init(addr(fx.bc)); }
+        fx.bc.bits = event.crush
+        fx.bc.coarse = event.coarse
+        fx.has_crush = true
+    }
+    if (event.shape > 0.0) {
+        unsafe { waveshaper_init(addr(fx.ws)); }
+        fx.ws.drive = event.shape
+        fx.has_shape = true
+    }
+    if (abs(event.djf - 0.5) > 0.001) {
+        unsafe { djfilter_init(addr(fx.dj), sample_rate); }
+        fx.dj.position = event.djf
+        fx.has_djf = true
+    }
+    if (event.bpf > 0.0) {
+        unsafe { bandpass_init(addr(fx.bp), sample_rate); }
+        unsafe { bandpass_setup(addr(fx.bp), event.bpf, max(event.bpq, 0.01)); }
+        fx.has_bpf = true
+    }
+    if (event.phaser > 0.0) {
+        unsafe { phaser_init(addr(fx.ph), sample_rate); }
+        fx.ph.rate = event.phaser
+        fx.ph.depth = clamp(event.phaserdepth, 0.0, 1.0)
+        fx.ph.center = event.phasercenter
+        fx.ph.sweep = event.phasersweep
+        fx.has_phaser = true
+    }
+    if (event.tremolo > 0.0 && event.tremolodepth > 0.0) {
+        unsafe { tremolo_init(addr(fx.trem), sample_rate); }
+        fx.trem.rate = event.tremolo
+        fx.trem.depth = clamp(event.tremolodepth, 0.0, 1.0)
+        fx.has_tremolo = true
+    }
+    if (event.compressor < 0.0) {
+        unsafe { compressor_init(addr(fx.comp), sample_rate); }
+        fx.comp.threshold_db = event.compressor
+        fx.comp.ratio = max(event.compressor_ratio, 1.0)
+        fx.comp.knee_db = max(event.compressor_knee, 0.0)
+        fx.comp.attack = max(event.compressor_attack, 0.0)
+        fx.comp.release = max(event.compressor_release, 0.0)
+        fx.has_compressor = true
+    }
+    fx.active = fx.has_crush || fx.has_shape || fx.has_djf || fx.has_bpf || fx.has_phaser || fx.has_tremolo || fx.has_compressor
+}
+
+// Apply configured effects to an interleaved stereo buffer (n_frames = sample-frame count).
+// Ordered: crush → shape → djfilter → bandpass → phaser → tremolo → compressor.
+// Phaser and tremolo come after the timbral effects to modulate the finished tone;
+// compressor is last so it sees the post-FX signal.
+def fx_apply(var fx : VoiceFX; var buf : array<float>; n_frames : int) {
+    if (!fx.active || n_frames <= 0 || length(buf) < n_frames * 2) {
+        return
+    }
+    if (fx.has_crush)      { unsafe { bitcrush_process(addr(fx.bc), addr(buf[0]), n_frames); } }
+    if (fx.has_shape)      { unsafe { waveshaper_process(addr(fx.ws), addr(buf[0]), n_frames); } }
+    if (fx.has_djf)        { unsafe { djfilter_process(addr(fx.dj), addr(buf[0]), n_frames); } }
+    if (fx.has_bpf)        { unsafe { bandpass_process(addr(fx.bp), addr(buf[0]), n_frames); } }
+    if (fx.has_phaser)     { unsafe { phaser_process(addr(fx.ph), addr(buf[0]), n_frames); } }
+    if (fx.has_tremolo)    { unsafe { tremolo_process(addr(fx.trem), addr(buf[0]), n_frames); } }
+    if (fx.has_compressor) { unsafe { compressor_process(addr(fx.comp), addr(buf[0]), n_frames); } }
+}
+
+// Apply effects to an already-rendered stereo PCM buffer (one-shot for pre-rendered voices).
+// State is local to this call, so effects reset every render.
+def fx_apply_to_samples(event : Event; var samples : array<float>; sample_rate : float) {
+    let n_frames = length(samples) / 2
+    if (n_frames <= 0) {
+        return
+    }
+    var fx : VoiceFX
+    fx_init_from_event(fx, event, sample_rate)
+    fx_apply(fx, samples, n_frames)
+}
+
 // Streaming oscillator voice — renders per-chunk instead of pre-rendering the full duration.
 struct OscVoice {
     osc_type        : OscType = OscType.osc_sine
@@ -741,6 +860,8 @@ struct OscVoice {
     orbit : int = 0             // effect bus routing
     // vowel formant filter
     @safe_when_uninitialized vowel_filter : VowelFilter
+    // per-voice audio effects (crush/coarse/shape/djf/bpf/bpq)
+    @safe_when_uninitialized fx : VoiceFX
 }
 
 // Initialize supersaw phases with random offsets for natural unison spread.
@@ -813,7 +934,8 @@ def private osc_chunk_sawtooth(var voice : OscVoice; var output : array<float>; 
         }
         var p = voice.phase + fmOffset
         p -= floor(p)
-        var sample = (p * 2.0 - 1.0) * env
+        // Band-limited sawtooth via polyBLEP to suppress aliasing above Nyquist.
+        var sample = (p * 2.0 - 1.0 - poly_blep(p, phaseInc)) * env
         if (hasLpf) { unsafe { sample = ma_sf2_biquad_tick(addr(voice.lpf_biquad), sample); } }
         if (hasHpf) { unsafe { sample = ma_sf2_biquad_tick(addr(voice.hpf_biquad), sample); } }
         if (hasVowel) { sample = vowel_filter_tick(voice.vowel_filter, sample); }
@@ -842,7 +964,10 @@ def private osc_chunk_square(var voice : OscVoice; var output : array<float>; va
         }
         var p = voice.phase + fmOffset
         p -= floor(p)
-        var sample = (p < 0.5 ? 1.0 : -1.0) * env
+        // Band-limited square: subtract BLEP at rising edge (p=0), add BLEP at falling edge (p=0.5).
+        var p_half = p + 0.5
+        p_half -= floor(p_half)
+        var sample = ((p < 0.5 ? 1.0 : -1.0) - poly_blep(p, phaseInc) + poly_blep(p_half, phaseInc)) * env
         if (hasLpf) { unsafe { sample = ma_sf2_biquad_tick(addr(voice.lpf_biquad), sample); } }
         if (hasHpf) { unsafe { sample = ma_sf2_biquad_tick(addr(voice.hpf_biquad), sample); } }
         if (hasVowel) { sample = vowel_filter_tick(voice.vowel_filter, sample); }
@@ -911,7 +1036,8 @@ def private osc_chunk_supersaw(var voice : OscVoice; var output : array<float>; 
         for (v in range(SUPERSAW_VOICES)) {
             var p = voice.supersaw_phases[v] + fmOffset
             p -= floor(p)
-            let saw = (p * 2.0 - 1.0) * gainAdj
+            // polyBLEP-corrected sawtooth per detuned voice
+            let saw = (p * 2.0 - 1.0 - poly_blep(p, voicePhaseInc[v])) * gainAdj
             if (v % 2 == 0) { mixL += saw; } else { mixR += saw; }
             voice.supersaw_phases[v] += voicePhaseInc[v]
             voice.supersaw_phases[v] -= floor(voice.supersaw_phases[v])
@@ -1075,7 +1201,7 @@ def render_event_stereo(event : Event; duration_sec : float) : array<float> {
 // Returns raw stereo — no gain or pan.
 def render_event_stereo(event : Event; duration_sec : float; bank : SampleBank) : array<float> {
     if (key_exists(bank.sounds, event.s)) {
-        var samples <- render_sample(bank, event.s, event.n, event.speed)
+        var samples <- render_sample(bank, event.s, event.n, event.speed, event.begin, event.end_pos)
         if (length(samples) > 0) {
             return <- samples
         }

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -154,8 +154,11 @@ IF(NOT DAS_AUDIO_DISABLED)
         tests/strudel/test_sf2.das
         tests/strudel/test_sf2_voice.das
         tests/strudel/test_sf2_modulators.das
+        tests/strudel/test_aliases.das
         tests/strudel/test_combinators.das
         tests/strudel/test_delay.das
+        tests/strudel/test_effects.das
+        tests/strudel/test_new_combinators.das
         tests/strudel/test_integration.das
         tests/strudel/test_memory.das
         tests/strudel/test_orbits.das

--- a/tests/strudel/test_aliases.das
+++ b/tests/strudel/test_aliases.das
@@ -1,0 +1,425 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost
+require strudel/strudel
+require math
+
+// ─── Bare-name setter aliases (scalar) ───
+
+[test]
+def test_gain_alias(t : T?) {
+    let pat <- atom("bd") |> gain(0.5)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 1)
+    t |> success(abs(haps[0].value.gain - 0.5) < 0.001)
+}
+
+[test]
+def test_velocity_alias(t : T?) {
+    let pat <- atom("bd") |> velocity(0.7)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.velocity - 0.7) < 0.001)
+}
+
+[test]
+def test_vel_short_alias(t : T?) {
+    let pat <- atom("bd") |> vel(0.3)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.velocity - 0.3) < 0.001)
+}
+
+[test]
+def test_pan_alias(t : T?) {
+    let pat <- atom("bd") |> pan(0.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.pan - 0.0) < 0.001)
+}
+
+[test]
+def test_speed_alias(t : T?) {
+    let pat <- atom("bd") |> speed(2.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.speed - 2.0) < 0.001)
+}
+
+[test]
+def test_note_float_alias(t : T?) {
+    let pat <- atom("sine") |> note(72.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.note - 72.0) < 0.001)
+}
+
+[test]
+def test_sound_alias(t : T?) {
+    let pat <- atom("bd") |> sound("sawtooth")
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(haps[0].value.s, "sawtooth")
+}
+
+[test]
+def test_cut_alias(t : T?) {
+    let pat <- atom("bd") |> cut(3)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(haps[0].value.cut, 3)
+}
+
+[test]
+def test_room_alias(t : T?) {
+    let pat <- atom("bd") |> room(0.5)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.room - 0.5) < 0.001)
+}
+
+[test]
+def test_roomsize_alias(t : T?) {
+    let pat <- atom("bd") |> roomsize(3.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.roomsize - 3.0) < 0.001)
+}
+
+[test]
+def test_size_short_alias(t : T?) {
+    let pat <- atom("bd") |> size(4.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.roomsize - 4.0) < 0.001)
+}
+
+[test]
+def test_delay_alias(t : T?) {
+    let pat <- atom("bd") |> delay(0.8)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.delay_amount - 0.8) < 0.001)
+}
+
+[test]
+def test_delaytime_alias(t : T?) {
+    let pat <- atom("bd") |> delaytime(0.25)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.delaytime - 0.25) < 0.001)
+}
+
+[test]
+def test_dt_short_alias(t : T?) {
+    let pat <- atom("bd") |> dt(0.125)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.delaytime - 0.125) < 0.001)
+}
+
+[test]
+def test_delayfeedback_alias(t : T?) {
+    let pat <- atom("bd") |> delayfeedback(0.6)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.delayfeedback - 0.6) < 0.001)
+}
+
+[test]
+def test_dfb_short_alias(t : T?) {
+    let pat <- atom("bd") |> dfb(0.9)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.delayfeedback - 0.9) < 0.001)
+}
+
+[test]
+def test_orbit_alias(t : T?) {
+    let pat <- atom("bd") |> orbit(2)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(haps[0].value.orbit, 2)
+}
+
+[test]
+def test_fm_alias(t : T?) {
+    let pat <- atom("sine") |> fm(3.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.fm - 3.0) < 0.001)
+}
+
+[test]
+def test_fmh_alias(t : T?) {
+    let pat <- atom("sine") |> fmh(2.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.fmh - 2.0) < 0.001)
+}
+
+[test]
+def test_lpf_alias(t : T?) {
+    let pat <- atom("bd") |> lpf(2000.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.lpf - 2000.0) < 0.001)
+}
+
+[test]
+def test_lp_short_alias(t : T?) {
+    let pat <- atom("bd") |> lp(1500.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.lpf - 1500.0) < 0.001)
+}
+
+[test]
+def test_hpf_alias(t : T?) {
+    let pat <- atom("bd") |> hpf(300.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.hpf - 300.0) < 0.001)
+}
+
+[test]
+def test_hp_short_alias(t : T?) {
+    let pat <- atom("bd") |> hp(500.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.hpf - 500.0) < 0.001)
+}
+
+[test]
+def test_lpq_alias(t : T?) {
+    let pat <- atom("bd") |> lpq(5.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.lpq - 5.0) < 0.001)
+}
+
+[test]
+def test_resonance_alias(t : T?) {
+    let pat <- atom("bd") |> resonance(8.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.lpq - 8.0) < 0.001)
+}
+
+[test]
+def test_hpq_alias(t : T?) {
+    let pat <- atom("bd") |> hpq(3.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.hpq - 3.0) < 0.001)
+}
+
+[test]
+def test_attack_alias(t : T?) {
+    let pat <- atom("sine") |> attack(0.1)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.attack - 0.1) < 0.001)
+}
+
+[test]
+def test_att_short_alias(t : T?) {
+    let pat <- atom("sine") |> att(0.2)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.attack - 0.2) < 0.001)
+}
+
+[test]
+def test_decay_alias(t : T?) {
+    let pat <- atom("sine") |> decay(0.3)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.decay - 0.3) < 0.001)
+}
+
+[test]
+def test_dec_short_alias(t : T?) {
+    let pat <- atom("sine") |> dec(0.4)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.decay - 0.4) < 0.001)
+}
+
+[test]
+def test_sustain_alias(t : T?) {
+    let pat <- atom("sine") |> sustain(0.7)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.sustain - 0.7) < 0.001)
+}
+
+[test]
+def test_sus_short_alias(t : T?) {
+    let pat <- atom("sine") |> sus(0.8)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.sustain - 0.8) < 0.001)
+}
+
+[test]
+def test_release_alias(t : T?) {
+    let pat <- atom("sine") |> release(0.5)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.release - 0.5) < 0.001)
+}
+
+[test]
+def test_rel_short_alias(t : T?) {
+    let pat <- atom("sine") |> rel(0.6)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.release - 0.6) < 0.001)
+}
+
+[test]
+def test_chorus_alias(t : T?) {
+    let pat <- atom("sine") |> chorus(0.4)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.chorus - 0.4) < 0.001)
+}
+
+// ─── SF2 aliases ───
+
+[test]
+def test_sf2_program_alias(t : T?) {
+    let pat <- atom("bd") |> sf2(42)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(haps[0].value.sf2_program, 42)
+}
+
+[test]
+def test_sf2_name_alias(t : T?) {
+    let pat <- atom("bd") |> sf2("piano")
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(haps[0].value.sf2_program, 0)
+}
+
+[test]
+def test_sf2_bank_alias(t : T?) {
+    let pat <- atom("bd") |> sf2_bank(128)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(haps[0].value.sf2_bank, 128)
+}
+
+[test]
+def test_sf2_expression_alias(t : T?) {
+    let pat <- atom("bd") |> sf2_expression(0.9)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.sf2_expression - 0.9) < 0.001)
+}
+
+// ─── Pattern-modulated aliases ───
+
+[test]
+def test_gain_pattern_alias(t : T?) {
+    let pat <- atom("bd") |> gain(sine())
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 1)
+    // gain should be ~0.5 at t=0 (sine starts at midpoint)
+    t |> success(abs(haps[0].value.gain - 0.5) < 0.1)
+}
+
+[test]
+def test_lpf_pattern_alias(t : T?) {
+    let pat <- atom("sawtooth") |> lpf(sine() |> range(200.0, 4000.0))
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 1)
+    // At t=0, sine=0.5, mapped to 200+0.5*3800=2100
+    t |> success(abs(haps[0].value.lpf - 2100.0) < 100.0)
+}
+
+// ─── Signal aliases ───
+
+[test]
+def test_sine_alias(t : T?) {
+    let pat <- sine()
+    let haps <- pat(TimeSpan(start = 0.25lf, stop = 0.251lf))
+    t |> success(abs(haps[0].value.note - 1.0) < 0.01)
+}
+
+[test]
+def test_saw_alias(t : T?) {
+    let pat <- saw()
+    let haps <- pat(TimeSpan(start = 0.5lf, stop = 0.501lf))
+    t |> success(abs(haps[0].value.note - 0.5) < 0.01)
+}
+
+[test]
+def test_tri_alias(t : T?) {
+    let pat <- tri()
+    let haps <- pat(TimeSpan(start = 0.5lf, stop = 0.501lf))
+    t |> success(abs(haps[0].value.note - 1.0) < 0.01)
+}
+
+[test]
+def test_cosine_alias(t : T?) {
+    let pat <- cosine()
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> success(abs(haps[0].value.note - 1.0) < 0.01)
+}
+
+[test]
+def test_perlin_alias(t : T?) {
+    let pat <- perlin()
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> equal(length(haps), 1)
+    t |> success(haps[0].value.note >= 0.0 && haps[0].value.note <= 1.0)
+}
+
+[test]
+def test_range_alias(t : T?) {
+    let pat <- saw() |> range(100.0, 200.0)
+    let haps <- pat(TimeSpan(start = 0.5lf, stop = 0.501lf))
+    // saw at 0.5 = 0.5, mapped to 100 + 0.5*100 = 150
+    t |> success(abs(haps[0].value.note - 150.0) < 1.0)
+}
+
+// ─── note() mini-notation alias ───
+
+[test]
+def test_note_string_alias(t : T?) {
+    let pat <- note("c4 e4 g4")
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 3)
+    t |> success(abs(haps[0].value.note - 60.0) < 0.01)  // C4 = 60
+    t |> success(abs(haps[1].value.note - 64.0) < 0.01)  // E4 = 64
+    t |> success(abs(haps[2].value.note - 67.0) < 0.01)  // G4 = 67
+    // default sound is "sine"
+    t |> equal(haps[0].value.s, "sine")
+}
+
+// ─── scale() alias ───
+
+[test]
+def test_scale_alias(t : T?) {
+    let pat <- n("0 2 4") |> scale("C4:major")
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 3)
+    t |> success(abs(haps[0].value.note - 60.0) < 0.01)  // C4
+    t |> success(abs(haps[1].value.note - 64.0) < 0.01)  // E4
+    t |> success(abs(haps[2].value.note - 67.0) < 0.01)  // G4
+}
+
+// ─── degradeBy alias ───
+
+[test]
+def test_degradeBy_alias(t : T?) {
+    let pat <- s("bd sd hh cp") |> degradeBy(0.5)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // With 50% degradation, should have fewer than 4 events (probabilistic but deterministic)
+    t |> success(length(haps) <= 4)
+    t |> success(length(haps) >= 0)
+}
+
+// ─── Chain multiple bare-name aliases (integration test) ───
+
+[test]
+def test_chain_bare_names(t : T?) {
+    // Chained bare-name aliases: note("c4").s("sawtooth").gain(0.5).lpf(2000).attack(0.01).room(0.3)
+    let pat <- note("c4", "sawtooth") |> gain(0.5) |> lpf(2000.0) |> att(0.01) |> room(0.3)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 1)
+    t |> equal(haps[0].value.s, "sawtooth")
+    t |> success(abs(haps[0].value.note - 60.0) < 0.01)
+    t |> success(abs(haps[0].value.gain - 0.5) < 0.001)
+    t |> success(abs(haps[0].value.lpf - 2000.0) < 0.001)
+    t |> success(abs(haps[0].value.attack - 0.01) < 0.001)
+    t |> success(abs(haps[0].value.room - 0.3) < 0.001)
+}
+
+[test]
+def test_begin_alias(t : T?) {
+    let pat <- atom("bd") |> begin(0.25)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.begin - 0.25) < 0.001)
+}
+
+[test]
+def test_end_pos_alias(t : T?) {
+    let pat <- atom("bd") |> end_pos(0.75)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.end_pos - 0.75) < 0.001)
+}
+
+[test]
+def test_begin_end_chain(t : T?) {
+    let pat <- atom("bd") |> begin(0.1) |> end_pos(0.6)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.begin - 0.1) < 0.001)
+    t |> success(abs(haps[0].value.end_pos - 0.6) < 0.001)
+}

--- a/tests/strudel/test_effects.das
+++ b/tests/strudel/test_effects.das
@@ -1,0 +1,632 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost
+require strudel/strudel
+require strudel/strudel_synth
+require strudel/strudel_scheduler
+require strudel/strudel_samples
+require math
+
+// ─── Setter propagation (bare aliases + scalar + Pattern) ───
+
+[test]
+def test_crush_alias(t : T?) {
+    let pat <- atom("bd") |> crush(8.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 1)
+    t |> success(abs(haps[0].value.crush - 8.0) < 0.001)
+}
+
+[test]
+def test_coarse_alias(t : T?) {
+    let pat <- atom("bd") |> coarse(4)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(haps[0].value.coarse, 4)
+}
+
+[test]
+def test_shape_alias(t : T?) {
+    let pat <- atom("bd") |> shape(0.5)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.shape - 0.5) < 0.001)
+}
+
+[test]
+def test_djf_alias(t : T?) {
+    let pat <- atom("bd") |> djf(0.2)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.djf - 0.2) < 0.001)
+}
+
+[test]
+def test_bpf_alias(t : T?) {
+    let pat <- atom("bd") |> bpf(1200.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.bpf - 1200.0) < 0.001)
+}
+
+[test]
+def test_bpq_alias(t : T?) {
+    let pat <- atom("bd") |> bpq(5.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.bpq - 5.0) < 0.001)
+}
+
+[test]
+def test_effects_chain(t : T?) {
+    // all six setters stack onto one pattern
+    let pat <- atom("bd") |> crush(10.0) |> coarse(2) |> shape(0.3) |> djf(0.7) |> bpf(800.0) |> bpq(3.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    let e = haps[0].value
+    t |> success(abs(e.crush - 10.0) < 0.001)
+    t |> equal(e.coarse, 2)
+    t |> success(abs(e.shape - 0.3) < 0.001)
+    t |> success(abs(e.djf - 0.7) < 0.001)
+    t |> success(abs(e.bpf - 800.0) < 0.001)
+    t |> success(abs(e.bpq - 3.0) < 0.001)
+}
+
+[test]
+def test_crush_pattern_modulator(t : T?) {
+    // Pattern-valued modulator: a signal sampled at the event's onset
+    let pat <- atom("bd") |> crush(signal_saw() |> signal_range(4.0, 12.0))
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(length(haps) >= 1)
+    // signal_saw at t=0 → 0 → mapped to 4.0
+    t |> success(abs(haps[0].value.crush - 4.0) < 0.1, "crush sampled from modulator = {haps[0].value.crush}")
+}
+
+// ─── VoiceFX behavior ───
+
+[test]
+def test_voicefx_default_is_inactive(t : T?) {
+    var fx : VoiceFX
+    let e = Event()
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(!fx.active, "default event has no active FX")
+    t |> success(!fx.has_crush)
+    t |> success(!fx.has_shape)
+    t |> success(!fx.has_djf)
+    t |> success(!fx.has_bpf)
+}
+
+[test]
+def test_voicefx_crush_activates(t : T?) {
+    var fx : VoiceFX
+    var e = Event()
+    e.crush = 8.0
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(fx.active)
+    t |> success(fx.has_crush)
+    t |> success(!fx.has_shape)
+}
+
+[test]
+def test_voicefx_coarse_alone_activates(t : T?) {
+    var fx : VoiceFX
+    var e = Event()
+    e.coarse = 4
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(fx.has_crush, "coarse alone routes through the bitcrusher")
+    t |> success(fx.active)
+}
+
+[test]
+def test_voicefx_djf_bypass_when_half(t : T?) {
+    var fx : VoiceFX
+    let e = Event()
+    // djf default is 0.5 (bypass) — should not activate
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(!fx.has_djf, "djf at 0.5 is bypass — FX should not activate")
+}
+
+[test]
+def test_voicefx_djf_offcenter_activates(t : T?) {
+    var fx : VoiceFX
+    var e = Event()
+    e.djf = 0.2
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(fx.has_djf)
+    t |> success(fx.active)
+}
+
+[test]
+def test_voicefx_bpf_activates(t : T?) {
+    var fx : VoiceFX
+    var e = Event()
+    e.bpf = 1000.0
+    e.bpq = 2.0
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(fx.has_bpf)
+    t |> success(fx.active)
+}
+
+[test]
+def test_fx_apply_bypass_is_noop(t : T?) {
+    var fx : VoiceFX
+    let e = Event()
+    fx_init_from_event(fx, e, 48000.0)
+    var buf : array<float>
+    buf |> resize(64)
+    for (i in range(64)) {
+        buf[i] = float(i) * 0.01
+    }
+    var orig : array<float>
+    orig |> resize(64)
+    for (i in range(64)) {
+        orig[i] = buf[i]
+    }
+    fx_apply(fx, buf, 32)
+    for (i in range(64)) {
+        t |> success(abs(buf[i] - orig[i]) < 1.0e-6, "buf[{i}] unchanged when FX inactive")
+    }
+    delete orig
+    delete buf
+}
+
+[test]
+def test_fx_apply_crush_quantizes(t : T?) {
+    var fx : VoiceFX
+    var e = Event()
+    e.crush = 2.0   // very aggressive — 4 levels total (2^2=4)
+    fx_init_from_event(fx, e, 48000.0)
+    var buf : array<float>
+    buf |> resize(64)
+    for (i in range(32)) {
+        buf[i * 2]     = 0.37
+        buf[i * 2 + 1] = -0.63
+    }
+    fx_apply(fx, buf, 32)
+    // 2-bit quantization with round-to-nearest should collapse many samples to the same level
+    var unique_vals : array<float>
+    for (i in range(64)) {
+        var found = false
+        for (u in unique_vals) {
+            if (abs(u - buf[i]) < 1.0e-4) {
+                found = true
+                break
+            }
+        }
+        if (!found) {
+            unique_vals |> push(buf[i])
+        }
+    }
+    t |> success(length(unique_vals) <= 8, "2-bit crush collapses to a small number of levels, got {length(unique_vals)}")
+    delete unique_vals
+    delete buf
+}
+
+[test]
+def test_fx_apply_shape_clamps(t : T?) {
+    var fx : VoiceFX
+    var e = Event()
+    e.shape = 5.0   // strong drive
+    fx_init_from_event(fx, e, 48000.0)
+    var buf : array<float>
+    buf |> resize(64)
+    for (i in range(32)) {
+        buf[i * 2]     = 10.0    // extreme input
+        buf[i * 2 + 1] = -10.0
+    }
+    fx_apply(fx, buf, 32)
+    for (i in range(64)) {
+        t |> success(abs(buf[i]) <= 1.01, "waveshaper output bounded |{buf[i]}|")
+    }
+    delete buf
+}
+
+// ─── Scheduler integration: effects-on-osc-voice renders differently from dry ───
+
+def private tick_chunks(var sched : Scheduler; var pat : Pattern; bank : SampleBank; numChunks : int; chunkSec : float = 0.05) : array<float> {
+    let chunkFrames = int(chunkSec * float(SAMPLE_RATE))
+    var result : array<float>
+    result |> reserve(numChunks * chunkFrames * 2)
+    for (c in range(numChunks)) {
+        let wall = double(c) * double(chunkSec)
+        tick(sched, pat, bank, wall, chunkSec)
+        for (s in sched.output) {
+            result |> push(s)
+        }
+    }
+    return <- result
+}
+
+def private rms(samples : array<float>) : float {
+    var sum = 0.0
+    for (s in samples) {
+        sum += s * s
+    }
+    if (length(samples) == 0) {
+        return 0.0
+    }
+    return sqrt(sum / float(length(samples)))
+}
+
+def private diff_rms(a, b : array<float>) : float {
+    let n = min(length(a), length(b))
+    var sum = 0.0
+    for (i in range(n)) {
+        let d = a[i] - b[i]
+        sum += d * d
+    }
+    if (n == 0) {
+        return 0.0
+    }
+    return sqrt(sum / float(n))
+}
+
+[test]
+def test_scheduler_osc_crush_differs_from_dry(t : T?) {
+    t |> run("crush applied to osc voice changes output") @(t : T?) {
+        var dry_sched : Scheduler
+        dry_sched.cps = 1.0lf
+        var wet_sched : Scheduler
+        wet_sched.cps = 1.0lf
+        let bank : SampleBank
+        let dry_pat <- atom("sawtooth") |> note(60.0)
+        let wet_pat <- atom("sawtooth") |> note(60.0) |> crush(3.0)
+        var dry <- tick_chunks(dry_sched, dry_pat, bank, 4)
+        var wet <- tick_chunks(wet_sched, wet_pat, bank, 4)
+        let dry_rms = rms(dry)
+        let wet_rms = rms(wet)
+        let delta = diff_rms(dry, wet)
+        t |> success(dry_rms > 1.0e-4, "dry output has signal (rms={dry_rms})")
+        t |> success(wet_rms > 1.0e-4, "wet output has signal (rms={wet_rms})")
+        t |> success(delta > 1.0e-4, "crush produces audibly different output (delta rms={delta})")
+        delete dry
+        delete wet
+    }
+}
+
+[test]
+def test_scheduler_osc_bpf_reduces_rms(t : T?) {
+    t |> run("narrow bandpass reduces overall energy") @(t : T?) {
+        var dry_sched : Scheduler
+        dry_sched.cps = 1.0lf
+        var wet_sched : Scheduler
+        wet_sched.cps = 1.0lf
+        let bank : SampleBank
+        let dry_pat <- atom("sawtooth") |> note(60.0)
+        // Narrow BPF around a frequency unrelated to the note's partials
+        let wet_pat <- atom("sawtooth") |> note(60.0) |> bpf(4000.0) |> bpq(8.0)
+        var dry <- tick_chunks(dry_sched, dry_pat, bank, 4)
+        var wet <- tick_chunks(wet_sched, wet_pat, bank, 4)
+        let dry_rms = rms(dry)
+        let wet_rms = rms(wet)
+        t |> success(dry_rms > 1.0e-4, "dry has energy")
+        t |> success(wet_rms < dry_rms, "bpf reduces total energy (dry={dry_rms} wet={wet_rms})")
+        delete dry
+        delete wet
+    }
+}
+
+[test]
+def test_scheduler_osc_voicefx_marked_active(t : T?) {
+    t |> run("osc voice gets fx.active when event has effect params") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        let bank : SampleBank
+        let pat <- atom("sawtooth") |> note(60.0) |> crush(6.0) |> bpf(1000.0)
+        tick(sched, pat, bank, 0.0lf, 0.01)
+        t |> success(length(sched.osc_voices) >= 1)
+        if (length(sched.osc_voices) >= 1) {
+            t |> success(sched.osc_voices[0].fx.active, "osc voice should have active FX")
+            t |> success(sched.osc_voices[0].fx.has_crush)
+            t |> success(sched.osc_voices[0].fx.has_bpf)
+        }
+    }
+}
+
+[test]
+def test_scheduler_drum_crush_differs_from_dry(t : T?) {
+    t |> run("crush applied to pre-rendered drum changes output") @(t : T?) {
+        var dry_sched : Scheduler
+        dry_sched.cps = 1.0lf
+        var wet_sched : Scheduler
+        wet_sched.cps = 1.0lf
+        let bank : SampleBank
+        let dry_pat <- atom("bd")
+        let wet_pat <- atom("bd") |> crush(3.0)
+        var dry <- tick_chunks(dry_sched, dry_pat, bank, 6)
+        var wet <- tick_chunks(wet_sched, wet_pat, bank, 6)
+        let delta = diff_rms(dry, wet)
+        t |> success(delta > 1.0e-4, "crush produces audibly different drum output (delta rms={delta})")
+        delete dry
+        delete wet
+    }
+}
+
+[test]
+def test_scheduler_djf_lpf_vs_bypass(t : T?) {
+    t |> run("djf=0.1 (full LPF) differs from djf=0.5 (bypass)") @(t : T?) {
+        var dry_sched : Scheduler
+        dry_sched.cps = 1.0lf
+        var wet_sched : Scheduler
+        wet_sched.cps = 1.0lf
+        let bank : SampleBank
+        let dry_pat <- atom("sawtooth") |> note(60.0)  // djf default 0.5 = bypass
+        let wet_pat <- atom("sawtooth") |> note(60.0) |> djf(0.1)
+        var dry <- tick_chunks(dry_sched, dry_pat, bank, 4)
+        var wet <- tick_chunks(wet_sched, wet_pat, bank, 4)
+        let delta = diff_rms(dry, wet)
+        t |> success(delta > 1.0e-4, "djf lowpass differs from bypass (delta rms={delta})")
+        delete dry
+        delete wet
+    }
+}
+
+[test]
+def test_scheduler_shape_distorts(t : T?) {
+    t |> run("shape adds harmonic distortion to osc voice") @(t : T?) {
+        var dry_sched : Scheduler
+        dry_sched.cps = 1.0lf
+        var wet_sched : Scheduler
+        wet_sched.cps = 1.0lf
+        let bank : SampleBank
+        let dry_pat <- atom("sine") |> note(60.0)
+        let wet_pat <- atom("sine") |> note(60.0) |> shape(5.0)
+        var dry <- tick_chunks(dry_sched, dry_pat, bank, 4)
+        var wet <- tick_chunks(wet_sched, wet_pat, bank, 4)
+        let delta = diff_rms(dry, wet)
+        t |> success(delta > 1.0e-4, "shape distorts sine wave (delta rms={delta})")
+        delete dry
+        delete wet
+    }
+}
+
+// ─── Phase 5 effects: phaser, tremolo, compressor ───
+
+[test]
+def test_phaser_alias(t : T?) {
+    let pat <- atom("sawtooth") |> phaser(2.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.phaser - 2.0) < 0.001)
+}
+
+[test]
+def test_phaser_params(t : T?) {
+    let pat <- atom("sawtooth") |> phaser(1.5) |> phaserdepth(0.5) |> phasercenter(800.0) |> phasersweep(1500.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    let e = haps[0].value
+    t |> success(abs(e.phaser - 1.5) < 0.001)
+    t |> success(abs(e.phaserdepth - 0.5) < 0.001)
+    t |> success(abs(e.phasercenter - 800.0) < 0.001)
+    t |> success(abs(e.phasersweep - 1500.0) < 0.001)
+}
+
+[test]
+def test_phaser_short_aliases(t : T?) {
+    let pat <- atom("sawtooth") |> ph(3.0) |> phd(0.25) |> phc(1200.0) |> phs(1800.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    let e = haps[0].value
+    t |> success(abs(e.phaser - 3.0) < 0.001)
+    t |> success(abs(e.phaserdepth - 0.25) < 0.001)
+    t |> success(abs(e.phasercenter - 1200.0) < 0.001)
+    t |> success(abs(e.phasersweep - 1800.0) < 0.001)
+}
+
+[test]
+def test_tremolo_alias(t : T?) {
+    let pat <- atom("sawtooth") |> tremolo(5.0) |> tremolodepth(0.7)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    let e = haps[0].value
+    t |> success(abs(e.tremolo - 5.0) < 0.001)
+    t |> success(abs(e.tremolodepth - 0.7) < 0.001)
+}
+
+[test]
+def test_tremolo_short_aliases(t : T?) {
+    let pat <- atom("sawtooth") |> trem(4.0) |> tremdepth(0.5)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    let e = haps[0].value
+    t |> success(abs(e.tremolo - 4.0) < 0.001)
+    t |> success(abs(e.tremolodepth - 0.5) < 0.001)
+}
+
+[test]
+def test_compressor_alias(t : T?) {
+    let pat <- atom("sawtooth") |> compressor(-20.0)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(haps[0].value.compressor - (-20.0)) < 0.001)
+}
+
+[test]
+def test_compressor_camel_case_aliases(t : T?) {
+    // camelCase aliases
+    let pat <- atom("sawtooth") |> compressor(-15.0) |> compressorRatio(8.0) |> compressorKnee(5.0) |> compressorAttack(0.003) |> compressorRelease(0.04)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    let e = haps[0].value
+    t |> success(abs(e.compressor - (-15.0)) < 0.001)
+    t |> success(abs(e.compressor_ratio - 8.0) < 0.001)
+    t |> success(abs(e.compressor_knee - 5.0) < 0.001)
+    t |> success(abs(e.compressor_attack - 0.003) < 0.0001)
+    t |> success(abs(e.compressor_release - 0.04) < 0.0001)
+}
+
+[test]
+def test_compressor_snake_case_aliases(t : T?) {
+    // idiomatic daScript snake_case variants
+    let pat <- atom("sawtooth") |> compressor(-10.0) |> compressor_ratio(6.0) |> compressor_knee(2.0) |> compressor_attack(0.001) |> compressor_release(0.03)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    let e = haps[0].value
+    t |> success(abs(e.compressor_ratio - 6.0) < 0.001)
+    t |> success(abs(e.compressor_knee - 2.0) < 0.001)
+    t |> success(abs(e.compressor_attack - 0.001) < 0.0001)
+    t |> success(abs(e.compressor_release - 0.03) < 0.0001)
+}
+
+[test]
+def test_voicefx_phaser_activates(t : T?) {
+    var fx : VoiceFX
+    var e = Event()
+    e.phaser = 2.0
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(fx.has_phaser, "phaser>0 activates")
+    t |> success(fx.active)
+}
+
+[test]
+def test_voicefx_phaser_off(t : T?) {
+    var fx : VoiceFX
+    var e = Event()
+    // phaser=0 (default) should NOT activate even with depth set
+    e.phaserdepth = 0.5
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(!fx.has_phaser, "phaser rate=0 stays inactive")
+}
+
+[test]
+def test_voicefx_tremolo_activates(t : T?) {
+    var fx : VoiceFX
+    var e = Event()
+    e.tremolo = 5.0
+    e.tremolodepth = 1.0
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(fx.has_tremolo)
+    t |> success(fx.active)
+}
+
+[test]
+def test_voicefx_tremolo_zero_depth_inactive(t : T?) {
+    var fx : VoiceFX
+    var e = Event()
+    e.tremolo = 5.0
+    e.tremolodepth = 0.0
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(!fx.has_tremolo, "tremolo depth=0 stays inactive")
+}
+
+[test]
+def test_voicefx_compressor_bypass_by_default(t : T?) {
+    var fx : VoiceFX
+    let e = Event()
+    // compressor default is 1.0 (above 0 dB) = bypass
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(!fx.has_compressor, "compressor default (+1 dB) stays bypass")
+}
+
+[test]
+def test_voicefx_compressor_activates(t : T?) {
+    var fx : VoiceFX
+    var e = Event()
+    e.compressor = -20.0
+    fx_init_from_event(fx, e, 48000.0)
+    t |> success(fx.has_compressor)
+    t |> success(fx.active)
+}
+
+[test]
+def test_fx_apply_phaser_modulates(t : T?) {
+    // Phaser should modify a static sine test signal (notch filter output differs from input).
+    var fx : VoiceFX
+    var e = Event()
+    e.phaser = 2.0
+    e.phaserdepth = 0.75
+    fx_init_from_event(fx, e, 48000.0)
+    var buf : array<float>
+    buf |> resize(512)
+    // fill with a 440Hz sine (roughly in phaser sweep range)
+    for (i in range(256)) {
+        let s = sin(float(i) * 440.0 * 2.0 * float(PI) / 48000.0) * 0.5
+        buf[i * 2]     = s
+        buf[i * 2 + 1] = s
+    }
+    var orig : array<float>
+    orig |> resize(512)
+    for (i in range(512)) { orig[i] = buf[i]; }
+    fx_apply(fx, buf, 256)
+    var diff = 0.0
+    for (i in range(512)) { diff += abs(buf[i] - orig[i]); }
+    t |> success(diff > 1.0e-3, "phaser alters signal (total diff={diff})")
+    delete orig
+    delete buf
+}
+
+[test]
+def test_fx_apply_tremolo_envelopes(t : T?) {
+    // Tremolo should produce an amplitude envelope — peaks and troughs vs dry constant.
+    var fx : VoiceFX
+    var e = Event()
+    e.tremolo = 20.0   // 20 Hz — noticeable within a short buffer
+    e.tremolodepth = 1.0
+    fx_init_from_event(fx, e, 48000.0)
+    var buf : array<float>
+    buf |> resize(4800 * 2)  // 100ms at 48kHz
+    for (i in range(4800)) {
+        buf[i * 2]     = 0.5  // constant DC signal
+        buf[i * 2 + 1] = 0.5
+    }
+    fx_apply(fx, buf, 4800)
+    // find min and max amplitude — tremolo should sweep between them
+    var mn = 1.0e9
+    var mx = -1.0e9
+    for (i in range(4800)) {
+        if (buf[i * 2] < mn) { mn = buf[i * 2]; }
+        if (buf[i * 2] > mx) { mx = buf[i * 2]; }
+    }
+    t |> success(mx - mn > 0.1, "tremolo creates envelope (range={mx - mn})")
+    delete buf
+}
+
+[test]
+def test_fx_apply_compressor_reduces_peaks(t : T?) {
+    // Compressor with aggressive threshold should reduce peak amplitude of a loud signal.
+    var fx : VoiceFX
+    var e = Event()
+    e.compressor = -20.0
+    e.compressor_ratio = 20.0
+    e.compressor_attack = 0.0001  // fast attack so the first samples get compressed
+    e.compressor_release = 0.01
+    e.compressor_knee = 0.0
+    fx_init_from_event(fx, e, 48000.0)
+    var buf : array<float>
+    buf |> resize(4800 * 2)
+    for (i in range(4800)) {
+        buf[i * 2]     = 0.9
+        buf[i * 2 + 1] = 0.9
+    }
+    fx_apply(fx, buf, 4800)
+    // Peak near the end (after attack settles) should be well below the input 0.9
+    var tail_peak = 0.0
+    for (i in range(4000, 4800)) {
+        if (abs(buf[i * 2]) > tail_peak) { tail_peak = abs(buf[i * 2]); }
+    }
+    t |> success(tail_peak < 0.9, "compressor reduces steady peak ({tail_peak} < 0.9)")
+    delete buf
+}
+
+[test]
+def test_scheduler_osc_phaser_differs_from_dry(t : T?) {
+    t |> run("phaser changes osc voice output") @(t : T?) {
+        var dry_sched : Scheduler
+        dry_sched.cps = 1.0lf
+        var wet_sched : Scheduler
+        wet_sched.cps = 1.0lf
+        let bank : SampleBank
+        let dry_pat <- atom("sawtooth") |> note(60.0)
+        let wet_pat <- atom("sawtooth") |> note(60.0) |> phaser(4.0) |> phaserdepth(0.9)
+        var dry <- tick_chunks(dry_sched, dry_pat, bank, 4)
+        var wet <- tick_chunks(wet_sched, wet_pat, bank, 4)
+        let delta = diff_rms(dry, wet)
+        t |> success(delta > 1.0e-4, "phaser produces audibly different output (delta rms={delta})")
+        delete dry
+        delete wet
+    }
+}
+
+[test]
+def test_scheduler_osc_tremolo_marks_fx(t : T?) {
+    t |> run("tremolo on osc voice sets has_tremolo") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        let bank : SampleBank
+        let pat <- atom("sawtooth") |> note(60.0) |> tremolo(8.0)
+        tick(sched, pat, bank, 0.0lf, 0.01)
+        t |> success(length(sched.osc_voices) >= 1)
+        if (length(sched.osc_voices) >= 1) {
+            t |> success(sched.osc_voices[0].fx.has_tremolo, "osc voice should have tremolo")
+            t |> success(sched.osc_voices[0].fx.active)
+        }
+    }
+}

--- a/tests/strudel/test_mini.das
+++ b/tests/strudel/test_mini.das
@@ -198,3 +198,106 @@ def test_note_pattern(t : T?) {
     t |> equal(haps[1].value.s, "sine")
     t |> equal(haps[2].value.s, "sine")
 }
+
+// ─── Tokenizer: accidentals must stay inside the word ───
+
+[test]
+def test_tokenize_sharp_in_word(t : T?) {
+    // Previously '#' was silently skipped, splitting "d#3" into "d" + "3".
+    // It must now be part of the WORD so note-name parsing sees "d#3".
+    let tokens <- tokenize("d#3 eb4 f#")
+    t |> equal(tokens[0].kind, TokenKind.WORD)
+    t |> equal(tokens[0].text, "d#3")
+    t |> equal(tokens[1].kind, TokenKind.WORD)
+    t |> equal(tokens[1].text, "eb4")
+    t |> equal(tokens[2].kind, TokenKind.WORD)
+    t |> equal(tokens[2].text, "f#")
+    t |> equal(tokens[3].kind, TokenKind.EOF_TOKEN)
+}
+
+// ─── parse_note_name: explicit octave required ───
+
+[test]
+def test_parse_note_name_requires_octave(t : T?) {
+    t |> success(abs(parse_note_name("d3") - 50.0) < 0.01)
+    t |> success(abs(parse_note_name("d#3") - 51.0) < 0.01)
+    t |> success(abs(parse_note_name("eb4") - 63.0) < 0.01)
+    t |> success(abs(parse_note_name("c4") - 60.0) < 0.01)
+    // Bare letter without octave returns -1 so s("a e i") stays as sound tokens.
+    t |> success(parse_note_name("d") < 0.0)
+    t |> success(parse_note_name("d#") < 0.0)
+    t |> success(parse_note_name("a") < 0.0)
+}
+
+// ─── parse_note_name_default: defaults octave to 3 ───
+
+[test]
+def test_parse_note_name_default(t : T?) {
+    // Bare "d" → D3 (MIDI 50) via default octave 3
+    t |> success(abs(parse_note_name_default("d", 3) - 50.0) < 0.01)
+    t |> success(abs(parse_note_name_default("d#", 3) - 51.0) < 0.01)
+    t |> success(abs(parse_note_name_default("eb", 3) - 51.0) < 0.01)  // Eb3 = 48 + (4 - 1)
+    // Explicit octave overrides the default
+    t |> success(abs(parse_note_name_default("d3", 3) - 50.0) < 0.01)
+    t |> success(abs(parse_note_name_default("d#3", 3) - 51.0) < 0.01)
+    t |> success(abs(parse_note_name_default("c4", 3) - 60.0) < 0.01)
+    t |> success(abs(parse_note_name_default("d5", 3) - 74.0) < 0.01)
+    // Non-note strings return -1 (for sound-name disambiguation)
+    t |> success(parse_note_name_default("bd", 3) < 0.0)
+    t |> success(parse_note_name_default("hh", 3) < 0.0)
+}
+
+// ─── note(): bare-letter note names resolve to default octave 3 ───
+
+[test]
+def test_note_bare_letters(t : T?) {
+    // note("d d d# d") → D3, D3, D#3, D3 (default octave 3)
+    let pat <- note("d d d# d", "supersaw")
+    let haps <- query_one_cycle(pat)
+    t |> equal(length(haps), 4)
+    t |> success(abs(haps[0].value.note - 50.0) < 0.01, "note 0 should be D3=50, got {haps[0].value.note}")
+    t |> success(abs(haps[1].value.note - 50.0) < 0.01)
+    t |> success(abs(haps[2].value.note - 51.0) < 0.01, "note 2 should be D#3=51, got {haps[2].value.note}")
+    t |> success(abs(haps[3].value.note - 50.0) < 0.01)
+    // .s gets set by set_sound("supersaw"), not left as the note name
+    t |> equal(haps[0].value.s, "supersaw")
+    t |> equal(haps[2].value.s, "supersaw")
+}
+
+[test]
+def test_note_mixed_octaves(t : T?) {
+    // Mixing bare and explicit forms should round-trip.
+    let pat <- note("d d#3 e4 f", "sine")
+    let haps <- query_one_cycle(pat)
+    t |> equal(length(haps), 4)
+    t |> success(abs(haps[0].value.note - 50.0) < 0.01)  // D3 (default oct)
+    t |> success(abs(haps[1].value.note - 51.0) < 0.01)  // D#3 explicit
+    t |> success(abs(haps[2].value.note - 64.0) < 0.01)  // E4
+    t |> success(abs(haps[3].value.note - 53.0) < 0.01)  // F3 (default oct)
+}
+
+[test]
+def test_note_flat_bare(t : T?) {
+    // "eb" should resolve to E♭3 = MIDI 51 - 1 semitone below D4 ... = 51
+    // Actually Eb3 = 4+3 chroma+octave offsets...
+    // chroma(e)=4 + accidental(-1) + (3+1)*12 = 48 + 4 - 1 = 51 → Eb3
+    let pat <- note("eb eb4", "sine")
+    let haps <- query_one_cycle(pat)
+    t |> equal(length(haps), 2)
+    t |> success(abs(haps[0].value.note - 51.0) < 0.01, "Eb3={haps[0].value.note}")
+    t |> success(abs(haps[1].value.note - 63.0) < 0.01, "Eb4={haps[1].value.note}")
+}
+
+[test]
+def test_s_single_letter_stays_sound(t : T?) {
+    // Crucial invariant: s("a e i o u") is sound tokens (vowel names), NOT notes.
+    // parse_note_name rejects bare letters so this still produces atoms with .s set.
+    let pat <- s("a e i o u")
+    let haps <- query_one_cycle(pat)
+    t |> equal(length(haps), 5)
+    t |> equal(haps[0].value.s, "a")
+    t |> equal(haps[1].value.s, "e")
+    t |> equal(haps[2].value.s, "i")
+    t |> equal(haps[3].value.s, "o")
+    t |> equal(haps[4].value.s, "u")
+}

--- a/tests/strudel/test_new_combinators.das
+++ b/tests/strudel/test_new_combinators.das
@@ -1,0 +1,790 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost
+require strudel/strudel
+require math
+
+// ─── palindrome ───
+
+[test]
+def test_palindrome_even_cycle(t : T?) {
+    // On even cycle (0), palindrome plays forward
+    let pat <- palindrome(s("bd sd hh cp"))
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 4)
+    t |> equal(haps[0].value.s, "bd")
+    t |> equal(haps[1].value.s, "sd")
+    t |> equal(haps[2].value.s, "hh")
+    t |> equal(haps[3].value.s, "cp")
+    // Forward: bd at 0.0-0.25
+    t |> success(abs(haps[0].whole.start - 0.0lf) < 0.001lf)
+    t |> success(abs(haps[0].whole.stop - 0.25lf) < 0.001lf)
+}
+
+[test]
+def test_palindrome_odd_cycle(t : T?) {
+    // On odd cycle (1), palindrome plays reversed
+    let pat <- palindrome(s("bd sd hh cp"))
+    let haps <- pat(TimeSpan(start = 1.0lf, stop = 2.0lf))
+    t |> equal(length(haps), 4)
+    // Reversed: bd(was 0.0-0.25) now at 0.75-1.0 (relative to cycle)
+    t |> equal(haps[0].value.s, "bd")
+    t |> success(abs(haps[0].whole.start - 1.75lf) < 0.001lf)
+    t |> success(abs(haps[0].whole.stop - 2.0lf) < 0.001lf)
+    // cp(was 0.75-1.0) now at 0.0-0.25 (relative to cycle)
+    t |> equal(haps[3].value.s, "cp")
+    t |> success(abs(haps[3].whole.start - 1.0lf) < 0.001lf)
+    t |> success(abs(haps[3].whole.stop - 1.25lf) < 0.001lf)
+}
+
+// ─── superimpose ───
+
+[test]
+def test_superimpose(t : T?) {
+    // Stack original + reversed copy
+    let pat <- superimpose(atom("bd"), @(p) => rev(p))
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // atom produces 1 event, rev(atom) produces 1 event, stacked = 2
+    t |> equal(length(haps), 2)
+    t |> equal(haps[0].value.s, "bd")
+    t |> equal(haps[1].value.s, "bd")
+}
+
+[test]
+def test_superimpose_transpose(t : T?) {
+    // superimpose with transpose: original + transposed copy
+    let pat <- superimpose(atom("sine") |> set_note(60.0), @(p) => transpose(p, 7.0))
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 2)
+    var has_60 = false
+    var has_67 = false
+    for (h in haps) {
+        if (abs(h.value.note - 60.0) < 0.01) {
+            has_60 = true
+        } elif (abs(h.value.note - 67.0) < 0.01) {
+            has_67 = true
+        }
+    }
+    t |> success(has_60)
+    t |> success(has_67)
+}
+
+// ─── echo ───
+
+[test]
+def test_echo_single(t : T?) {
+    // echo with times=1 produces just the original (no delayed copies)
+    let pat <- echo(atom("bd"), 1, 0.25lf, 0.5)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 1)
+    t |> success(abs(haps[0].value.gain - 0.8) < 0.001)
+    t |> success(abs(haps[0].whole.start - 0.0lf) < 0.001lf)
+}
+
+[test]
+def test_echo_forward_decay(t : T?) {
+    // echoes must play LATER than the original, with decreasing gain
+    let pat <- echo(atom("bd"), 4, 0.125lf, 0.5)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // Keep onsets within this cycle (earlier cycles' echoes may trail in but
+    // their whole.start is negative — scheduler ignores those)
+    var starts : array<double>
+    var gains : array<float>
+    for (h in haps) {
+        if (h.whole.start >= 0.0lf && h.whole.start < 1.0lf) {
+            starts |> push(h.whole.start)
+            gains |> push(h.value.gain)
+        }
+    }
+    t |> equal(length(starts), 4)
+    // Pair-sort by start using simple bubble (4 elements)
+    for (i in range(length(starts))) {
+        for (j in range(i + 1, length(starts))) {
+            if (starts[j] < starts[i]) {
+                let ts = starts[i]; starts[i] = starts[j]; starts[j] = ts
+                let tg = gains[i];  gains[i]  = gains[j];  gains[j]  = tg
+            }
+        }
+    }
+    // Expected: start times 0, 0.125, 0.25, 0.375 with gains 0.8, 0.4, 0.2, 0.1
+    t |> success(abs(starts[0] - 0.0lf)   < 0.001lf)
+    t |> success(abs(starts[1] - 0.125lf) < 0.001lf)
+    t |> success(abs(starts[2] - 0.25lf)  < 0.001lf)
+    t |> success(abs(starts[3] - 0.375lf) < 0.001lf)
+    t |> success(abs(gains[0] - 0.8f) < 0.001f)
+    t |> success(abs(gains[1] - 0.4f) < 0.001f)
+    t |> success(abs(gains[2] - 0.2f) < 0.001f)
+    t |> success(abs(gains[3] - 0.1f) < 0.001f)
+}
+
+// ─── stut (alias for echo with different param order) ───
+
+[test]
+def test_stut_single(t : T?) {
+    // stut(pat, times, feedback, time) == echo(pat, times, time, feedback)
+    let pat <- stut(atom("bd"), 1, 0.5, 0.25lf)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 1)
+    t |> success(abs(haps[0].value.gain - 0.8) < 0.001)
+}
+
+// ─── ply ───
+
+[test]
+def test_ply(t : T?) {
+    // ply repeats each event n times within its span
+    let pat <- ply(atom("bd"), 3)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 3)
+    // Each sub-event is 1/3 of the original span
+    t |> success(abs(haps[0].whole.start - 0.0lf) < 0.001lf)
+    t |> success(abs(haps[0].whole.stop - (1.0lf / 3.0lf)) < 0.001lf)
+    t |> success(abs(haps[1].whole.start - (1.0lf / 3.0lf)) < 0.001lf)
+    t |> success(abs(haps[1].whole.stop - (2.0lf / 3.0lf)) < 0.001lf)
+    t |> success(abs(haps[2].whole.start - (2.0lf / 3.0lf)) < 0.001lf)
+    t |> success(abs(haps[2].whole.stop - 1.0lf) < 0.001lf)
+}
+
+[test]
+def test_ply_multi_event(t : T?) {
+    // ply on 2-event pattern with ply=2
+    let pat <- ply(s("bd sd"), 2)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // 2 events, each plied into 2 = 4 total
+    t |> equal(length(haps), 4)
+    t |> equal(haps[0].value.s, "bd")
+    t |> equal(haps[1].value.s, "bd")
+    t |> equal(haps[2].value.s, "sd")
+    t |> equal(haps[3].value.s, "sd")
+}
+
+// ─── iter ───
+
+[test]
+def test_iter_cycle_0(t : T?) {
+    // Cycle 0: no shift (0/4 = 0)
+    let pat <- iter(s("bd sd hh cp"), 4)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 4)
+    t |> equal(haps[0].value.s, "bd")
+    t |> equal(haps[1].value.s, "sd")
+    t |> equal(haps[2].value.s, "hh")
+    t |> equal(haps[3].value.s, "cp")
+}
+
+[test]
+def test_iter_cycle_1(t : T?) {
+    // Cycle 1: shift left by 1/4
+    let pat <- iter(s("bd sd hh cp"), 4)
+    let haps <- pat(TimeSpan(start = 1.0lf, stop = 2.0lf))
+    t |> equal(length(haps), 4)
+    // After shifting left by 1/4: sd hh cp bd
+    t |> equal(haps[0].value.s, "sd")
+    t |> equal(haps[1].value.s, "hh")
+    t |> equal(haps[2].value.s, "cp")
+    t |> equal(haps[3].value.s, "bd")
+}
+
+// ─── iterBack ───
+
+[test]
+def test_iterBack_cycle_0(t : T?) {
+    // Cycle 0: no shift
+    let pat <- iterBack(s("bd sd hh cp"), 4)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 4)
+    t |> equal(haps[0].value.s, "bd")
+    t |> equal(haps[1].value.s, "sd")
+    t |> equal(haps[2].value.s, "hh")
+    t |> equal(haps[3].value.s, "cp")
+}
+
+[test]
+def test_iterBack_cycle_1(t : T?) {
+    // Cycle 1: shift right by 1/4
+    let pat <- iterBack(s("bd sd hh cp"), 4)
+    let haps <- pat(TimeSpan(start = 1.0lf, stop = 2.0lf))
+    t |> equal(length(haps), 4)
+    // After shifting right by 1/4: cp bd sd hh
+    t |> equal(haps[0].value.s, "cp")
+    t |> equal(haps[1].value.s, "bd")
+    t |> equal(haps[2].value.s, "sd")
+    t |> equal(haps[3].value.s, "hh")
+}
+
+// ─── when_cycle ───
+
+[test]
+def test_when_cycle_applies_on_match(t : T?) {
+    // Transform on even cycles, original on odd
+    let pat <- when_cycle(atom("sine") |> set_note(60.0),
+        @(c : int) => c % 2 == 0,
+        @(p) => transpose(p, 12.0)
+    )
+    // Cycle 0 (even): transformed (note=72)
+    let haps0 <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps0), 1)
+    t |> success(abs(haps0[0].value.note - 72.0) < 0.001)
+    // Cycle 1 (odd): original (note=60)
+    let haps1 <- pat(TimeSpan(start = 1.0lf, stop = 2.0lf))
+    t |> equal(length(haps1), 1)
+    t |> success(abs(haps1[0].value.note - 60.0) < 0.001)
+}
+
+// ─── linger ───
+
+[test]
+def test_linger(t : T?) {
+    // linger(pat, 0.25) loops the first quarter — expect bd repeated 4x per cycle
+    let pat <- linger(s("bd sd hh cp"), 0.25lf)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 4)
+    // sort onsets
+    var starts : array<double>
+    starts |> reserve(length(haps))
+    for (h in haps) {
+        starts |> push(h.whole.start)
+        t |> equal(h.value.s, "bd")
+    }
+    for (i in range(length(starts))) {
+        for (j in range(i + 1, length(starts))) {
+            if (starts[j] < starts[i]) {
+                let tmp = starts[i]; starts[i] = starts[j]; starts[j] = tmp
+            }
+        }
+    }
+    // Expected onsets: 0.0, 0.25, 0.5, 0.75
+    t |> success(abs(starts[0] - 0.0lf)  < 0.001lf)
+    t |> success(abs(starts[1] - 0.25lf) < 0.001lf)
+    t |> success(abs(starts[2] - 0.5lf)  < 0.001lf)
+    t |> success(abs(starts[3] - 0.75lf) < 0.001lf)
+}
+
+// ─── hurry ───
+
+[test]
+def test_hurry(t : T?) {
+    // hurry = fast + speed. Factor 2: twice as fast, speed=2.0
+    let pat <- hurry(atom("bd"), 2.0lf)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // fast(2) on atom gives 2 events per cycle
+    t |> equal(length(haps), 2)
+    // speed should be set to 2.0
+    t |> success(abs(haps[0].value.speed - 2.0) < 0.001)
+    t |> success(abs(haps[1].value.speed - 2.0) < 0.001)
+}
+
+// ─── compress ───
+
+[test]
+def test_compress(t : T?) {
+    // Squeeze full pattern into [0.25, 0.75]
+    let pat <- compress(s("bd sd"), 0.25lf, 0.75lf)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 2)
+    // bd should be in [0.25, 0.5], sd in [0.5, 0.75]
+    t |> success(abs(haps[0].whole.start - 0.25lf) < 0.001lf)
+    t |> success(abs(haps[0].whole.stop - 0.5lf) < 0.001lf)
+    t |> success(abs(haps[1].whole.start - 0.5lf) < 0.001lf)
+    t |> success(abs(haps[1].whole.stop - 0.75lf) < 0.001lf)
+}
+
+[test]
+def test_compress_outside_window(t : T?) {
+    // Query outside the window should return nothing
+    let pat <- compress(atom("bd"), 0.5lf, 0.75lf)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 0.4lf))
+    t |> equal(length(haps), 0)
+}
+
+// ─── chunk ───
+
+[test]
+def test_chunk(t : T?) {
+    // chunk(pat, 4, transform) applies transform to rotating chunk.
+    // Cycle 0: chunk 0 is transformed
+    let pat <- chunk(s("bd sd hh cp"), 4, @(p) => fast(p, 2.0lf))
+    let haps0 <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // Chunk 0 (0.0-0.25) is transformed (fast doubles events),
+    // other chunks are original = 3 normal + transformed chunk
+    t |> success(length(haps0) >= 4)
+    // Cycle 1: chunk 1 is transformed
+    let haps1 <- pat(TimeSpan(start = 1.0lf, stop = 2.0lf))
+    t |> success(length(haps1) >= 4)
+}
+
+// ─── striate ───
+
+[test]
+def test_striate(t : T?) {
+    // striate(pat, 4) cuts the sample into 4 slices via begin/end
+    let pat <- striate(atom("bd"), 4)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // 4 events — each slice i maps to begin=i/4, end=(i+1)/4
+    t |> equal(length(haps), 4)
+    for (i in range(4)) {
+        t |> equal(haps[i].value.s, "bd")
+        let expectedBegin = float(i) * 0.25
+        let expectedEnd = float(i + 1) * 0.25
+        t |> success(abs(haps[i].value.begin - expectedBegin) < 0.0001)
+        t |> success(abs(haps[i].value.end_pos - expectedEnd) < 0.0001)
+    }
+}
+
+// ─── struct_ ───
+
+[test]
+def test_struct_(t : T?) {
+    // struct_ restructures pattern using a mask pattern's timing
+    // mask s("x x") has 2 windows: [0,0.5) and [0.5,1.0)
+    // inner s("bd sd hh cp") queried at each mask window
+    let pat <- struct_(s("bd sd hh cp"), s("x x"))
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // Each mask window queries the inner pattern at its whole span.
+    // Window [0,0.5): inner has bd[0,0.25) and sd[0.25,0.5) -> 2 events
+    // Window [0.5,1.0): inner has hh[0.5,0.75) and cp[0.75,1.0) -> 2 events
+    t |> equal(length(haps), 4)
+    t |> equal(haps[0].value.s, "bd")
+    t |> equal(haps[1].value.s, "sd")
+    t |> equal(haps[2].value.s, "hh")
+    t |> equal(haps[3].value.s, "cp")
+}
+
+// ─── mask ───
+
+[test]
+def test_mask(t : T?) {
+    // mask keeps events where mask pattern has events
+    // atom("bd") produces 1 event [0,1). mask with s("x ~") has event at [0,0.5) only
+    // But "~" is rest/silence — let's use a simpler approach
+    let pat <- mask(s("bd sd hh cp"), s("x x"))
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // s("x x") has 2 events at [0,0.5) and [0.5,1.0), covering all of [0,1)
+    // All 4 events of the inner pattern overlap with mask events
+    t |> equal(length(haps), 4)
+}
+
+[test]
+def test_mask_partial(t : T?) {
+    // mask with atom("x") covers full [0,1), so all events pass through
+    let pat <- mask(s("bd sd hh cp"), atom("x"))
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 4)
+}
+
+// ─── choose ───
+
+[test]
+def test_choose(t : T?) {
+    // choose picks one pattern per cycle deterministically (hash-based)
+    var pats : array<Pattern>
+    var p0 <- atom("bd")
+    var p1 <- atom("sd")
+    var p2 <- atom("hh")
+    pats |> emplace <| p0
+    pats |> emplace <| p1
+    pats |> emplace <| p2
+    let pat <- choose(pats)
+    // Each cycle should produce exactly 1 event
+    for (cyc in range(10)) {
+        let span = TimeSpan(start = double(cyc), stop = double(cyc) + 1.0lf)
+        let haps <- pat(span)
+        t |> equal(length(haps), 1)
+    }
+}
+
+[test]
+def test_choose_deterministic(t : T?) {
+    // Same cycle should always pick same pattern
+    var pats : array<Pattern>
+    var p0 <- atom("bd")
+    var p1 <- atom("sd")
+    pats |> emplace <| p0
+    pats |> emplace <| p1
+    let pat <- choose(pats)
+    let haps1 <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    let haps2 <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps1), 1)
+    t |> equal(length(haps2), 1)
+    t |> equal(haps1[0].value.s, haps2[0].value.s)
+}
+
+// ─── wchoose ───
+
+[test]
+def test_wchoose(t : T?) {
+    // Weighted random: heavier weight should appear more often
+    var pats : array<Pattern>
+    var p0 <- atom("bd")
+    var p1 <- atom("sd")
+    pats |> emplace <| p0
+    pats |> emplace <| p1
+    var weights : array<float>
+    weights |> push(100.0)
+    weights |> push(0.0)
+    let pat <- wchoose(pats, weights)
+    // With weight 100 vs 0, should always pick "bd"
+    for (cyc in range(10)) {
+        let span = TimeSpan(start = double(cyc), stop = double(cyc) + 1.0lf)
+        let haps <- pat(span)
+        t |> equal(length(haps), 1)
+        t |> equal(haps[0].value.s, "bd")
+    }
+}
+
+// ─── randcat ───
+
+[test]
+def test_randcat(t : T?) {
+    // randcat is alias for choose
+    var pats : array<Pattern>
+    var p0 <- atom("bd")
+    var p1 <- atom("sd")
+    pats |> emplace <| p0
+    pats |> emplace <| p1
+    let pat <- randcat(pats)
+    for (cyc in range(10)) {
+        let span = TimeSpan(start = double(cyc), stop = double(cyc) + 1.0lf)
+        let haps <- pat(span)
+        t |> equal(length(haps), 1)
+    }
+}
+
+// ─── chooseCycles ───
+
+[test]
+def test_choose_cycles(t : T?) {
+    // chooseCycles is an alias for choose (per-cycle pick)
+    var pats : array<Pattern>
+    var p0 <- atom("bd")
+    var p1 <- atom("sd")
+    pats |> emplace <| p0
+    pats |> emplace <| p1
+    let pat <- chooseCycles(pats)
+    for (cyc in range(10)) {
+        let span = TimeSpan(start = double(cyc), stop = double(cyc) + 1.0lf)
+        let haps <- pat(span)
+        t |> equal(length(haps), 1)
+    }
+}
+
+// ─── shuffle ───
+
+[test]
+def test_shuffle(t : T?) {
+    // shuffle(pat, 4) produces a permutation of 4 subdivisions
+    let pat <- shuffle(s("bd sd hh cp"), 4)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // Should still have 4 events (permutation preserves count)
+    t |> equal(length(haps), 4)
+    // Each event should be one of the original sounds
+    for (h in haps) {
+        t |> success(h.value.s == "bd" || h.value.s == "sd" || h.value.s == "hh" || h.value.s == "cp")
+    }
+}
+
+[test]
+def test_shuffle_deterministic(t : T?) {
+    // Same cycle gives same permutation
+    let pat <- shuffle(s("bd sd hh cp"), 4)
+    let haps1 <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    let haps2 <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps1), length(haps2))
+    for (i in range(length(haps1))) {
+        t |> equal(haps1[i].value.s, haps2[i].value.s)
+    }
+}
+
+// ─── scramble ───
+
+[test]
+def test_scramble(t : T?) {
+    // scramble(pat, 4) picks random subdivision for each slot (with replacement)
+    let pat <- scramble(s("bd sd hh cp"), 4)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // Should have 4 events (one per slot)
+    t |> equal(length(haps), 4)
+    for (h in haps) {
+        t |> success(h.value.s == "bd" || h.value.s == "sd" || h.value.s == "hh" || h.value.s == "cp")
+    }
+}
+
+[test]
+def test_scramble_deterministic(t : T?) {
+    let pat <- scramble(s("bd sd hh cp"), 4)
+    let haps1 <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    let haps2 <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps1), length(haps2))
+    for (i in range(length(haps1))) {
+        t |> equal(haps1[i].value.s, haps2[i].value.s)
+    }
+}
+
+[test]
+def test_scramble_slot_positions(t : T?) {
+    // scramble(8) produces 8 slots; each slot start at i/8
+    let pat <- scramble(s("bd sd hh cp ho oh lt ht"), 8)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 8)
+    var starts : array<double>
+    starts |> reserve(length(haps))
+    for (h in haps) {
+        starts |> push(h.whole.start)
+    }
+    for (i in range(length(starts))) {
+        for (j in range(i + 1, length(starts))) {
+            if (starts[j] < starts[i]) {
+                let tmp = starts[i]; starts[i] = starts[j]; starts[j] = tmp
+            }
+        }
+    }
+    for (i in range(8)) {
+        t |> success(abs(starts[i] - double(i) / 8.0lf) < 0.001lf)
+    }
+}
+
+[test]
+def test_scramble_no_slot_correlation(t : T?) {
+    // Regression: the LCG-based RNG made slots 2 and 3 produce the same index
+    // in every cycle. Check that across many cycles, slot i and slot i+1 are
+    // NOT always equal for any pair (i, i+1).
+    let pat <- scramble(s("a b c d e f g h"), 8)
+    let M = 100
+    var always_equal = fixed_array(true, true, true, true, true, true, true)
+    for (cyc in range(M)) {
+        var sorted <- pat(TimeSpan(start = double(cyc), stop = double(cyc) + 1.0lf))
+        for (i in range(1, length(sorted))) {
+            var j = i
+            while (j > 0 && sorted[j].whole.start < sorted[j - 1].whole.start) {
+                let tmp = sorted[j]; sorted[j] = sorted[j - 1]; sorted[j - 1] = tmp
+                j --
+            }
+        }
+        for (i in range(length(sorted) - 1)) {
+            if (sorted[i].value.s != sorted[i + 1].value.s) {
+                always_equal[i] = false
+            }
+        }
+    }
+    for (i in range(7)) {
+        t |> equal(always_equal[i], false)
+    }
+}
+
+[test]
+def test_scramble_allows_repeats_across_cycles(t : T?) {
+    // scramble picks with replacement — over many cycles, expect some sample to
+    // appear with non-uniform frequency (unlike shuffle which is always a permutation).
+    // Loose check: across 16 cycles × 4 slots = 64 events, at least one sample appears >16 times.
+    let pat <- scramble(s("bd sd hh cp"), 4)
+    var counts : array<int>
+    counts |> resize(4)
+    for (cyc in range(16)) {
+        let haps <- pat(TimeSpan(start = double(cyc), stop = double(cyc) + 1.0lf))
+        for (h in haps) {
+            if (h.value.s == "bd") {
+                counts[0] ++
+            } elif (h.value.s == "sd") {
+                counts[1] ++
+            } elif (h.value.s == "hh") {
+                counts[2] ++
+            } elif (h.value.s == "cp") {
+                counts[3] ++
+            }
+        }
+    }
+    // Total should be 64 (16 cycles × 4 slots)
+    var total = 0
+    for (c in counts) {
+        total += c
+    }
+    t |> equal(total, 64)
+    // At least one bucket non-uniform (with replacement → some variation)
+    var min_c = counts[0]
+    var max_c = counts[0]
+    for (c in counts) {
+        if (c < min_c) {
+            min_c = c
+        }
+        if (c > max_c) {
+            max_c = c
+        }
+    }
+    t |> success(max_c > min_c)
+}
+
+// ─── New Signals ───
+
+[test]
+def test_square_signal(t : T?) {
+    let pat <- square()
+    // First half = 1.0
+    let haps_first <- pat(TimeSpan(start = 0.1lf, stop = 0.101lf))
+    t |> equal(length(haps_first), 1)
+    t |> success(abs(haps_first[0].value.note - 1.0) < 0.01)
+    // Second half = 0.0
+    let haps_second <- pat(TimeSpan(start = 0.7lf, stop = 0.701lf))
+    t |> equal(length(haps_second), 1)
+    t |> success(abs(haps_second[0].value.note - 0.0) < 0.01)
+}
+
+[test]
+def test_isaw_signal(t : T?) {
+    // Inverted saw: falls from 1.0 to 0.0
+    let pat <- isaw()
+    // At t=0.0, isaw=1.0
+    let haps_start <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> success(abs(haps_start[0].value.note - 1.0) < 0.02)
+    // At t=0.5, isaw=0.5
+    let haps_mid <- pat(TimeSpan(start = 0.5lf, stop = 0.501lf))
+    t |> success(abs(haps_mid[0].value.note - 0.5) < 0.02)
+}
+
+[test]
+def test_itri_signal(t : T?) {
+    // Inverted triangle: 1.0 at start, 0.0 at mid, 1.0 at end
+    let pat <- itri()
+    // At t=0.0, itri=1.0
+    let haps_start <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> success(abs(haps_start[0].value.note - 1.0) < 0.02)
+    // At t=0.5, itri=0.0
+    let haps_mid <- pat(TimeSpan(start = 0.5lf, stop = 0.501lf))
+    t |> success(abs(haps_mid[0].value.note - 0.0) < 0.02)
+}
+
+[test]
+def test_sine2_signal(t : T?) {
+    // Bipolar sine -1..1
+    let pat <- sine2()
+    // At t=0.25, sin(2*pi*0.25)=1.0
+    let haps_peak <- pat(TimeSpan(start = 0.25lf, stop = 0.251lf))
+    t |> success(abs(haps_peak[0].value.note - 1.0) < 0.02)
+    // At t=0.75, sin(2*pi*0.75)=-1.0
+    let haps_trough <- pat(TimeSpan(start = 0.75lf, stop = 0.751lf))
+    t |> success(abs(haps_trough[0].value.note - (-1.0)) < 0.02)
+}
+
+[test]
+def test_cosine2_signal(t : T?) {
+    // Bipolar cosine -1..1
+    let pat <- cosine2()
+    // At t=0, cos(0)=1.0
+    let haps_start <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> success(abs(haps_start[0].value.note - 1.0) < 0.02)
+    // At t=0.5, cos(pi)=-1.0
+    let haps_mid <- pat(TimeSpan(start = 0.5lf, stop = 0.501lf))
+    t |> success(abs(haps_mid[0].value.note - (-1.0)) < 0.02)
+}
+
+[test]
+def test_saw2_signal(t : T?) {
+    // Bipolar sawtooth -1..1
+    let pat <- saw2()
+    // At t=0, saw2 = -1.0
+    let haps_start <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> success(abs(haps_start[0].value.note - (-1.0)) < 0.02)
+    // At t=0.5, saw2 = 0.0
+    let haps_mid <- pat(TimeSpan(start = 0.5lf, stop = 0.501lf))
+    t |> success(abs(haps_mid[0].value.note - 0.0) < 0.02)
+}
+
+[test]
+def test_tri2_signal(t : T?) {
+    // Bipolar triangle -1..1
+    let pat <- tri2()
+    // At t=0, tri2 = -1.0
+    let haps_start <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> success(abs(haps_start[0].value.note - (-1.0)) < 0.02)
+    // At t=0.25, tri2 = 0.0
+    let haps_quarter <- pat(TimeSpan(start = 0.25lf, stop = 0.251lf))
+    t |> success(abs(haps_quarter[0].value.note - 0.0) < 0.02)
+    // At t=0.5, tri2 = 1.0
+    let haps_mid <- pat(TimeSpan(start = 0.5lf, stop = 0.501lf))
+    t |> success(abs(haps_mid[0].value.note - 1.0) < 0.02)
+}
+
+[test]
+def test_square2_signal(t : T?) {
+    // Bipolar square -1..1
+    let pat <- square2()
+    // First half = 1.0
+    let haps_first <- pat(TimeSpan(start = 0.1lf, stop = 0.101lf))
+    t |> success(abs(haps_first[0].value.note - 1.0) < 0.01)
+    // Second half = -1.0
+    let haps_second <- pat(TimeSpan(start = 0.7lf, stop = 0.701lf))
+    t |> success(abs(haps_second[0].value.note - (-1.0)) < 0.01)
+}
+
+[test]
+def test_rand_signal(t : T?) {
+    // rand() returns values in 0..1
+    let pat <- rand()
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> equal(length(haps), 1)
+    t |> success(haps[0].value.note >= 0.0 && haps[0].value.note <= 1.0)
+}
+
+[test]
+def test_irand_signal(t : T?) {
+    // irand(4) returns integers 0..3
+    let pat <- irand(4)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> equal(length(haps), 1)
+    let v = haps[0].value.note
+    t |> success(v >= 0.0 && v < 4.0)
+    // Should be an integer value
+    t |> success(abs(v - float(int(v))) < 0.001)
+}
+
+[test]
+def test_run_signal(t : T?) {
+    // run(4) produces discrete events 0, 1, 2, 3
+    let pat <- run(4)
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(haps), 4)
+    t |> success(abs(haps[0].value.note - 0.0) < 0.001)
+    t |> success(abs(haps[1].value.note - 1.0) < 0.001)
+    t |> success(abs(haps[2].value.note - 2.0) < 0.001)
+    t |> success(abs(haps[3].value.note - 3.0) < 0.001)
+    // Each event spans 1/4 of the cycle
+    t |> success(abs(haps[0].whole.start - 0.0lf) < 0.001lf)
+    t |> success(abs(haps[0].whole.stop - 0.25lf) < 0.001lf)
+    t |> success(abs(haps[3].whole.start - 0.75lf) < 0.001lf)
+    t |> success(abs(haps[3].whole.stop - 1.0lf) < 0.001lf)
+}
+
+// ─── isaw2, itri2, rand2 (additional bipolar signals) ───
+
+[test]
+def test_isaw2_signal(t : T?) {
+    // Bipolar inverted sawtooth -1..1
+    let pat <- isaw2()
+    // At t=0, isaw2 = 1.0
+    let haps_start <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> success(abs(haps_start[0].value.note - 1.0) < 0.02)
+    // At t=0.5, isaw2 = 0.0
+    let haps_mid <- pat(TimeSpan(start = 0.5lf, stop = 0.501lf))
+    t |> success(abs(haps_mid[0].value.note - 0.0) < 0.02)
+}
+
+[test]
+def test_itri2_signal(t : T?) {
+    // Bipolar inverted triangle -1..1
+    let pat <- itri2()
+    // At t=0, itri2 = 1.0
+    let haps_start <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> success(abs(haps_start[0].value.note - 1.0) < 0.02)
+    // At t=0.5, itri2 = -1.0
+    let haps_mid <- pat(TimeSpan(start = 0.5lf, stop = 0.501lf))
+    t |> success(abs(haps_mid[0].value.note - (-1.0)) < 0.02)
+}
+
+[test]
+def test_rand2_signal(t : T?) {
+    // rand2() returns values in -1..1
+    let pat <- rand2()
+    let haps <- pat(TimeSpan(start = 0.0lf, stop = 0.001lf))
+    t |> equal(length(haps), 1)
+    t |> success(haps[0].value.note >= -1.0 && haps[0].value.note <= 1.0)
+}

--- a/tests/strudel/test_samples.das
+++ b/tests/strudel/test_samples.das
@@ -85,3 +85,76 @@ def test_invalid_data(t : T?) {
         t |> equal(length(sample.data), 0)
     }
 }
+
+[test]
+def test_render_sample_full(t : T?) {
+    t |> run("render_sample full range matches default") <| @(t : T?) {
+        var bank : SampleBank
+        let bytes <- read_file_bytes("{MEDIA}/drums/bd/kick_0.ogg")
+        load_sound_memory(bytes, "bd", bank)
+        let full <- render_sample(bank, "bd", 0, 1.0)
+        let full_explicit <- render_sample(bank, "bd", 0, 1.0, 0.0, 1.0)
+        t |> success(length(full) > 0, "full render produced samples")
+        t |> equal(length(full), length(full_explicit), "default == explicit [0,1]")
+    }
+}
+
+[test]
+def test_render_sample_half_slice(t : T?) {
+    t |> run("render_sample begin=0.5 produces ~half") <| @(t : T?) {
+        var bank : SampleBank
+        let bytes <- read_file_bytes("{MEDIA}/drums/bd/kick_0.ogg")
+        load_sound_memory(bytes, "bd", bank)
+        let full <- render_sample(bank, "bd", 0, 1.0, 0.0, 1.0)
+        let tail_half <- render_sample(bank, "bd", 0, 1.0, 0.5, 1.0)
+        let head_half <- render_sample(bank, "bd", 0, 1.0, 0.0, 0.5)
+        // each half should be ~50% of full length (±2 frames for rounding)
+        let fullFrames = length(full) / 2
+        let tailFrames = length(tail_half) / 2
+        let headFrames = length(head_half) / 2
+        t |> success(abs(tailFrames - fullFrames / 2) <= 2, "tail half length matches")
+        t |> success(abs(headFrames - fullFrames / 2) <= 2, "head half length matches")
+    }
+}
+
+[test]
+def test_render_sample_quarter_slices(t : T?) {
+    t |> run("render_sample 4 quarters cover the full length") <| @(t : T?) {
+        var bank : SampleBank
+        let bytes <- read_file_bytes("{MEDIA}/drums/bd/kick_0.ogg")
+        load_sound_memory(bytes, "bd", bank)
+        let full <- render_sample(bank, "bd", 0, 1.0, 0.0, 1.0)
+        let fullFrames = length(full) / 2
+        var totalQuarterFrames = 0
+        for (i in range(4)) {
+            let b = float(i) * 0.25
+            let e = float(i + 1) * 0.25
+            let q <- render_sample(bank, "bd", 0, 1.0, b, e)
+            totalQuarterFrames += length(q) / 2
+        }
+        // 4 quarters should sum to ~ full length (±8 frames for rounding per slice)
+        t |> success(abs(totalQuarterFrames - fullFrames) <= 8, "quarters sum to full")
+    }
+}
+
+[test]
+def test_render_sample_head_not_equal_tail(t : T?) {
+    t |> run("head and tail slices produce different audio") <| @(t : T?) {
+        var bank : SampleBank
+        let bytes <- read_file_bytes("{MEDIA}/drums/bd/kick_0.ogg")
+        load_sound_memory(bytes, "bd", bank)
+        let head <- render_sample(bank, "bd", 0, 1.0, 0.0, 0.5)
+        let tail <- render_sample(bank, "bd", 0, 1.0, 0.5, 1.0)
+        t |> success(length(head) > 0 && length(tail) > 0, "both slices have samples")
+        // kick samples decay — peak amplitude of head should exceed tail
+        var headPeak = 0.0
+        var tailPeak = 0.0
+        for (i in range(length(head))) {
+            headPeak = max(headPeak, abs(head[i]))
+        }
+        for (i in range(length(tail))) {
+            tailPeak = max(tailPeak, abs(tail[i]))
+        }
+        t |> success(headPeak > tailPeak, "head louder than tail (natural decay)")
+    }
+}

--- a/tests/strudel/test_scales.das
+++ b/tests/strudel/test_scales.das
@@ -80,8 +80,8 @@ def test_parse_root_c3(t : T?) {
 
 [test]
 def test_parse_root_g(t : T?) {
-    // G without octave → G4 = 67
-    t |> equal(parse_root("G"), 67)
+    // G without octave → G3 = 55 (default octave is 3)
+    t |> equal(parse_root("G"), 55)
 }
 
 [test]
@@ -183,12 +183,12 @@ def test_set_scale_g_major(t : T?) {
 
 [test]
 def test_set_scale_no_root(t : T?) {
-    // just "major" without root → defaults to C4
+    // just "major" without root → defaults to C3 (default octave 3)
     let pat <- n("0 4") |> set_scale("major")
     var inscope events <- query_all(pat)
     t |> equal(length(events), 2)
-    t |> success(abs(events[0].note - 60.0) < 0.01)  // C4
-    t |> success(abs(events[1].note - 67.0) < 0.01)  // G4
+    t |> success(abs(events[0].note - 48.0) < 0.01)  // C3
+    t |> success(abs(events[1].note - 55.0) < 0.01)  // G3
 }
 
 // ─── scale_pattern convenience ───


### PR DESCRIPTION
## Summary

Harmonizes the daStrudel API surface with idiomatic pattern-language conventions so existing patterns port with minimal rewrites.

- **Aliases + new combinators**: `hurry`, `linger`, `chunk`, `iter`/`iterBack`, `ply`, `palindrome`, `echo`, `shuffle`, `scramble`, `choose`/`chooseCycles`, `struct`, `mask`, `striate`, `compress`, `superimpose`, plus camelCase + snake_case wrappers for every effect setter.
- **Per-voice effects**: classic 4-stage all-pass phaser (MXR Phase 90 topology with feedback), sine-LFO tremolo, feed-forward peak compressor, bitcrusher, waveshaper, DJ filter, bandpass — wired through `VoiceFX` in the scheduler.
- **Tuning**: scale default octave `4 → 3`; convolution reverb `fadeIn 0.01 → 0.1`; default `lpf` off (was 20000).
- **Mini-notation fix**: tokenizer now keeps `#` inside word tokens, and `note_pattern()` fmaps bare-letter `.s` values (e.g. `"d"`, `"eb"`) through `parse_note_name_default()` to MIDI. Fixes `"d d d# d"` sounding identical to `"d3 d3 d3 d3"`.
- **Docs**: two new groups in `das2rst` (Per-voice effects, Per-voice effect types); 22 handmade descriptions (15 functions, 7 struct annotations).

## Test plan

- [x] Lint clean on all branch-touched `.das` files (LINT003/PERF006/STYLE002)
- [x] Full `dastest/dastest.das --test tests/` — 6418/6418 pass, no GC leaks
- [x] `test_aot` build + `--use-aot --test tests` — 5833/5833 pass, no leaks
- [x] `das2rst` succeeds; `grep Uncategorized doc/source/stdlib/generated/audio.rst` → 0; no remaining `// stub` in handmade/
- [x] Clean Sphinx build: `build succeeded.` with 0 warnings, 0 errors
- [x] Formatter idempotent on all changed `.das` files

Regression coverage added:
- `tests/strudel/test_aliases.das` — bare-name alias chain parity
- `tests/strudel/test_effects.das` — per-voice FX pass-through and camelCase parity
- `tests/strudel/test_new_combinators.das` — palindrome, echo/stut, ply, shuffle, scramble, choose, striate, compress, chunk, mask, struct, linger, hurry
- `tests/strudel/test_mini.das` — `#`-in-word tokenization, default-octave note parsing

One playable feature example per new combinator and per new per-voice effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)