### PR TITLE
strudel: tempo-aware ADSR and delay defaults

### DIFF
--- a/modules/dasAudio/strudel/strudel_event.das
+++ b/modules/dasAudio/strudel/strudel_event.das
@@ -3,6 +3,8 @@ options indenting = 4
 
 module strudel_event shared
 
+require math
+
 // The payload of every pattern event — "what to play and how".
 // All defaults are "do nothing" values: gain 0.8 is a sensible level,
 // lpf 0 means "no filter" (undefined = no filter).
@@ -18,16 +20,17 @@ struct Event {
     lpq     : float = 1.0       // low-pass filter resonance Q (1.0 = gentle, >5 = peaky)
     hpf     : float = 0.0       // high-pass filter cutoff Hz (0 = off)
     hpq     : float = 1.0       // high-pass filter resonance Q (1.0 = gentle, >5 = peaky)
-    attack  : float = 0.001     // envelope attack time in seconds
-    decay   : float = 0.05      // envelope decay time
-    sustain : float = 0.0       // envelope sustain level (default: no sustain hold)
-    release : float = 0.01      // envelope release time
+    attack  : float = -1.0      // envelope attack time in seconds (-1 = unset → resolver picks default)
+    decay   : float = -1.0      // envelope decay time (-1 = unset)
+    sustain : float = -1.0      // envelope sustain level (-1 = unset; full sustain if no ADSR set, percussion if decay set alone)
+    release : float = -1.0      // envelope release time (-1 = unset)
     cut     : int = 0           // cut group (0 = no cut, >0 = kill same group)
     room    : float = 0.0       // reverb send amount 0.0–1.0
     roomsize : float = 2.0      // reverb decay time in seconds (0.1–10.0)
     delay_amount : float = 0.0  // delay send amount 0.0–1.0
-    delaytime    : float = 0.5  // delay time in seconds
+    delaytime    : float = -1.0 // delay time in seconds (-1 = unset → derived from delaysync and cps)
     delayfeedback : float = 0.5 // delay feedback 0.0–1.0
+    delaysync    : float = 0.1875 // delay time in cycles (3/16 cycle); used when delaytime is unset
     orbit   : int = 0           // effect bus routing (0 = default)
     fm      : float = 0.0       // FM synthesis modulation depth
     fmh     : float = 1.0       // FM harmonicity ratio (modulator freq / carrier freq)
@@ -63,4 +66,44 @@ struct Event {
     sf2_expression : float = -1.0 // SF2 expression CC11 (0.0–1.0, -1 = use default)
     sf2_mod_wheel  : float = -1.0 // SF2 mod wheel CC1 (0.0–1.0, -1 = use default)
     sf2_pitch_bend : float = -1.0 // SF2 pitch bend (0.0–1.0 where 0.5 = center, -1 = use default)
+}
+
+// Resolve ADSR fields from their "user set / unset" form (−1 = unset) into concrete
+// envelope parameters. The rules are designed so that intuitive shorthand sounds right:
+//
+//   • Nothing set           → a=0.001, d=0.001, s=1.0, r=0.01 (a held tone with tiny envelope edges)
+//   • Only decay set        → sustain drops to 0.001 (percussion: attack-then-decay to silence)
+//   • Only attack or only release set (no decay) → sustain stays at 1.0 (held tone)
+//   • Sustain set explicitly → use the given value, whatever else is set
+//
+// All values are clamped to envmin/releaseMin floors so a stray 0 never produces a click.
+def resolve_adsr(attack, decay, sustain, release : float) : tuple<float; float; float; float> {
+    let envmin = 0.001
+    let envmax = 1.0
+    let release_min = 0.01
+    let a_set = attack >= 0.0
+    let d_set = decay >= 0.0
+    let s_set = sustain >= 0.0
+    let r_set = release >= 0.0
+    if (!a_set && !d_set && !s_set && !r_set) {
+        return (envmin, envmin, envmax, release_min)
+    }
+    let sustain_resolved = s_set ? sustain : (d_set ? envmin : envmax)
+    let a_final = max(a_set ? attack : 0.0, envmin)
+    let d_final = max(d_set ? decay : 0.0, envmin)
+    let r_final = max(r_set ? release : 0.0, release_min)
+    let s_final = min(sustain_resolved, envmax)
+    return (a_final, d_final, s_final, r_final)
+}
+
+// Resolve delay time: if delaytime was set explicitly (>= 0), use it; otherwise
+// derive it from delaysync (in cycles) and the current cps so the echo locks to
+// the tempo. The 3/16-cycle default yields a dotted-eighth feel that changes
+// automatically when the user changes cps.
+def resolve_delaytime(delaytime, delaysync, cps : float) : float {
+    if (delaytime >= 0.0) {
+        return delaytime
+    }
+    let safe_cps = cps > 0.0001 ? cps : 0.5
+    return delaysync / safe_cps
 }

--- a/modules/dasAudio/strudel/strudel_pattern.das
+++ b/modules/dasAudio/strudel/strudel_pattern.das
@@ -391,6 +391,14 @@ def set_delayfeedback(var pat : Pattern; d : float) : Pattern {
     return <- fmap(pat, fn)
 }
 
+// pat |> set_delaysync(0.1875) — set delay time in cycles (tempo-synced delay)
+def set_delaysync(var pat : Pattern; d : float) : Pattern {
+    let fn <- @capture(= d) (e : Event) : Event {
+        var ev = e; ev.delaysync = d; return ev
+    }
+    return <- fmap(pat, fn)
+}
+
 // pat |> set_orbit(1) — set effect bus routing
 def set_orbit(var pat : Pattern; o : int) : Pattern {
     let fn <- @capture(= o) (e : Event) : Event {
@@ -2222,6 +2230,7 @@ def delaytime(var pat : Pattern; d : float) : Pattern { return <- set_delaytime(
 def dt(var pat : Pattern; d : float) : Pattern { return <- set_delaytime(pat, d); }
 def delayfeedback(var pat : Pattern; d : float) : Pattern { return <- set_delayfeedback(pat, d); }
 def dfb(var pat : Pattern; d : float) : Pattern { return <- set_delayfeedback(pat, d); }
+def delaysync(var pat : Pattern; d : float) : Pattern { return <- set_delaysync(pat, d); }
 def orbit(var pat : Pattern; o : int) : Pattern { return <- set_orbit(pat, o); }
 def fm(var pat : Pattern; f : float) : Pattern { return <- set_fm(pat, f); }
 def fmh(var pat : Pattern; f : float) : Pattern { return <- set_fmh(pat, f); }

--- a/modules/dasAudio/strudel/strudel_scheduler.das
+++ b/modules/dasAudio/strudel/strudel_scheduler.das
@@ -183,10 +183,11 @@ def private setup_orbit_for_event(var sched : Scheduler; event : Event) {
         update_orbit_reverb_roomsize(*bus, event.roomsize)
     }
     if (event.delay_amount > 0.0) {
+        let dt = resolve_delaytime(event.delaytime, event.delaysync, float(sched.cps))
         if (bus.delay_proc == null) {
-            init_orbit_delay(*bus, event.delaytime, event.delayfeedback)
+            init_orbit_delay(*bus, dt, event.delayfeedback)
         } else {
-            update_orbit_delay_params(*bus, event.delaytime, event.delayfeedback)
+            update_orbit_delay_params(*bus, dt, event.delayfeedback)
         }
     }
     if (event.chorus > 0.0) {
@@ -662,14 +663,15 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                     // streaming oscillator path
                     let offsetFrames = max(int(offsetSec * float(SAMPLE_RATE)), 0)
                     let oscType = to_osc_type(h.value.s)
+                    let adsr = resolve_adsr(h.value.attack, h.value.decay, h.value.sustain, h.value.release)
                     var oscv = OscVoice(
                         osc_type = oscType,
                         freq = note_to_freq(h.value.note),
                         duration = durSec,
-                        attack = h.value.attack,
-                        decay = h.value.decay,
-                        sustain = h.value.sustain,
-                        release_sec = h.value.release,
+                        attack = adsr._0,
+                        decay = adsr._1,
+                        sustain = adsr._2,
+                        release_sec = adsr._3,
                         gain = h.value.gain * h.value.velocity,
                         pan = h.value.pan * 2.0 - 1.0,
                         cut = cutGroup,

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -154,6 +154,7 @@ IF(NOT DAS_AUDIO_DISABLED)
         tests/strudel/test_sf2.das
         tests/strudel/test_sf2_voice.das
         tests/strudel/test_sf2_modulators.das
+        tests/strudel/test_adsr_resolver.das
         tests/strudel/test_aliases.das
         tests/strudel/test_combinators.das
         tests/strudel/test_delay.das

--- a/tests/strudel/test_adsr_resolver.das
+++ b/tests/strudel/test_adsr_resolver.das
@@ -1,0 +1,121 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost
+require strudel/strudel
+require strudel/strudel_event
+require math
+
+[test]
+def test_resolve_adsr_none_set(t : T?) {
+    // Nothing set: full-sustain held tone with tiny edges.
+    let r = resolve_adsr(-1.0, -1.0, -1.0, -1.0)
+    t |> equal(r._0, 0.001)
+    t |> equal(r._1, 0.001)
+    t |> equal(r._2, 1.0)
+    t |> equal(r._3, 0.01)
+}
+
+[test]
+def test_resolve_adsr_only_decay_percussion(t : T?) {
+    // Decay alone → percussion: sustain drops to envmin (0.001).
+    let r = resolve_adsr(-1.0, 0.2, -1.0, -1.0)
+    t |> equal(r._0, 0.001)
+    t |> equal(r._1, 0.2)
+    t |> equal(r._2, 0.001)
+    t |> equal(r._3, 0.01)
+}
+
+[test]
+def test_resolve_adsr_only_attack(t : T?) {
+    // Attack alone, no decay → held tone with slow attack.
+    let r = resolve_adsr(0.3, -1.0, -1.0, -1.0)
+    t |> equal(r._0, 0.3)
+    t |> equal(r._1, 0.001)
+    t |> equal(r._2, 1.0)
+    t |> equal(r._3, 0.01)
+}
+
+[test]
+def test_resolve_adsr_only_release(t : T?) {
+    // Release alone → held tone with long release tail.
+    let r = resolve_adsr(-1.0, -1.0, -1.0, 0.5)
+    t |> equal(r._0, 0.001)
+    t |> equal(r._1, 0.001)
+    t |> equal(r._2, 1.0)
+    t |> equal(r._3, 0.5)
+}
+
+[test]
+def test_resolve_adsr_sustain_explicit_wins(t : T?) {
+    // Sustain set explicitly overrides percussion default even when decay is set.
+    let r = resolve_adsr(-1.0, 0.1, 0.5, -1.0)
+    t |> equal(r._0, 0.001)
+    t |> equal(r._1, 0.1)
+    t |> equal(r._2, 0.5)
+    t |> equal(r._3, 0.01)
+}
+
+[test]
+def test_resolve_adsr_sustain_zero_explicit(t : T?) {
+    // sustain=0 explicitly (percussion) is distinct from sustain unset.
+    let r = resolve_adsr(-1.0, -1.0, 0.0, -1.0)
+    t |> equal(r._0, 0.001)
+    t |> equal(r._1, 0.001)
+    t |> equal(r._2, 0.0)
+    t |> equal(r._3, 0.01)
+}
+
+[test]
+def test_resolve_adsr_all_set(t : T?) {
+    let r = resolve_adsr(0.05, 0.1, 0.8, 0.5)
+    t |> equal(r._0, 0.05)
+    t |> equal(r._1, 0.1)
+    t |> equal(r._2, 0.8)
+    t |> equal(r._3, 0.5)
+}
+
+[test]
+def test_resolve_adsr_clamp_floors(t : T?) {
+    // Zero or tiny values clamp up to envmin/release_min floors.
+    let r = resolve_adsr(0.0, 0.0, 0.5, 0.0)
+    t |> equal(r._0, 0.001)
+    t |> equal(r._1, 0.001)
+    t |> equal(r._2, 0.5)
+    t |> equal(r._3, 0.01)
+}
+
+[test]
+def test_resolve_adsr_sustain_clamp_max(t : T?) {
+    // Sustain >1 clamps down to 1.
+    let r = resolve_adsr(-1.0, -1.0, 2.5, -1.0)
+    t |> equal(r._2, 1.0)
+}
+
+// ─── Delay time resolver ───
+
+[test]
+def test_resolve_delaytime_explicit_wins(t : T?) {
+    // Explicit delaytime is returned verbatim regardless of delaysync/cps.
+    t |> equal(resolve_delaytime(0.4, 0.1875, 0.5), 0.4)
+    t |> equal(resolve_delaytime(0.0, 0.1875, 0.5), 0.0)
+    t |> equal(resolve_delaytime(1.25, 0.1875, 2.0), 1.25)
+}
+
+[test]
+def test_resolve_delaytime_tempo_synced(t : T?) {
+    // Unset delaytime derives from delaysync / cps.
+    // 3/16 cycle at cps=0.5 → 0.375s (dotted-eighth at 120 BPM when beats=4/cycle).
+    t |> success(abs(resolve_delaytime(-1.0, 0.1875, 0.5) - 0.375) < 1e-6)
+    // 3/16 cycle at cps=1.0 → 0.1875s.
+    t |> success(abs(resolve_delaytime(-1.0, 0.1875, 1.0) - 0.1875) < 1e-6)
+    // 1/4 cycle at cps=2.0 → 0.125s.
+    t |> success(abs(resolve_delaytime(-1.0, 0.25, 2.0) - 0.125) < 1e-6)
+}
+
+[test]
+def test_resolve_delaytime_degenerate_cps(t : T?) {
+    // Zero/near-zero cps falls back to cps=0.5 so we never divide by zero.
+    t |> success(abs(resolve_delaytime(-1.0, 0.1875, 0.0) - 0.375) < 1e-6)
+    t |> success(abs(resolve_delaytime(-1.0, 0.1875, 0.00001) - 0.375) < 1e-6)
+}

--- a/tests/strudel/test_setters.das
+++ b/tests/strudel/test_setters.das
@@ -111,7 +111,8 @@ def test_event_defaults(t : T?) {
     t |> success(abs(ev.room) < 0.001)
     t |> success(abs(ev.roomsize - 2.0) < 0.001)
     t |> success(abs(ev.delay_amount) < 0.001)
-    t |> success(abs(ev.delaytime - 0.5) < 0.001)
+    t |> success(ev.delaytime < 0.0)  // sentinel: unset → resolver derives from delaysync + cps
+    t |> success(abs(ev.delaysync - 0.1875) < 0.001)  // 3/16 cycle default
     t |> success(abs(ev.delayfeedback - 0.5) < 0.001)
     t |> equal(ev.orbit, 0)
     t |> success(abs(ev.fm) < 0.001)


### PR DESCRIPTION
## Summary

Two related fixes to make daStrudel example playback match upstream live-coding conventions out of the box.

### ADSR defaults

Previously `Event.sustain` defaulted to `0.0`, so a plain `note("c4").s("sine")` decayed to silence in ~50 ms regardless of the note's duration — every melodic example sounded percussive.

Now ADSR fields use a `-1` "unset" sentinel, and a new `resolve_adsr` function picks defaults based on which knobs the user actually touched:

| User sets | Resolved |
|---|---|
| Nothing | held tone (sustain = 1.0, tiny edges) |
| Decay alone | percussion (sustain = 0.001) |
| Sustain explicitly | always wins |

### Delay time

Previously `Event.delaytime` was hardcoded to `0.5s`. Any example using `.delay(x)` without also calling `.delaytime(...)` produced an echo that ignored the tempo.

Now `delaytime` defaults to `-1` (unset) and a new `delaysync` field (default `3/16` cycle) drives `resolve_delaytime(delaytime, delaysync, cps)` at orbit delay setup. Explicit `delaytime` still wins; otherwise the echo locks to the tempo (0.375 s at cps = 0.5, 0.1875 s at cps = 1.0).

## Test plan

- [x] `tests/strudel/` — 575 tests pass (563 baseline + 12 new resolver tests)
- [x] Full AOT suite — 5845 tests pass
- [x] Lint clean on all 5 changed `.das` files
- [x] RMS sanity check on `combinator_iter_back`: old rendering was silent half the time (notes died in ~50 ms); new rendering sustains continuously
- [x] Offline render of `sf2_integration_full_ambient` for 2 minutes — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)