### PR TITLE
compiler: split libDaScrpt into 2 libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,7 +676,6 @@ SET(BUILTIN_SRC
 include/daScript/builtin/ast_gen.inc
 include/daScript/builtin/debugapi_gen.inc
 
-src/builtin/modules.cpp
 src/builtin/module_builtin.h
 src/builtin/module_builtin.cpp
 src/builtin/module_builtin_misc_types.cpp
@@ -742,7 +741,6 @@ src/misc/string_writer.cpp
 src/misc/memory_model.cpp
 src/misc/job_que.cpp
 src/misc/free_list.cpp
-src/misc/daScriptC.cpp
 src/misc/uric.cpp
 src/misc/format.cpp
 )
@@ -917,20 +915,13 @@ list(SORT DAS_LIB_SRC)
 include_directories(include)
 include_directories(3rdparty/fmt/include)
 
-MACRO(SETUP_LIBDASCRIPT library shared_lib)
+MACRO(SETUP_LIBDASCRIPT library shared_lib full_setup sources exports_def)
     IF(${shared_lib})
-        SETUP_DAS_SHARED_LIBRARY(${library} ${PARSER_GENERATED_SRC}
-                ${PARSER_SRC} ${VECMATH_SRC} ${AST_SRC} ${SIMULATE_SRC} ${BUILTIN_SRC}
-                ${MISC_SRC} ${SIMULATE_FUSION_SRC} ${MAIN_SRC}
-                ${DAGOR_NOISE_SRC} ${FLAT_HASH_MAP_SRC} ${FAST_FLOAT_SRC} ${DASCRIPT_FMT_SRC})
-        TARGET_COMPILE_DEFINITIONS(${library} PRIVATE DAS_EXPORTS=1 DAS_MOD_EXPORTS=1)
+        SETUP_DAS_SHARED_LIBRARY(${library} ${${sources}})
+        TARGET_COMPILE_DEFINITIONS(${library} PRIVATE ${exports_def}=1 DAS_MOD_EXPORTS=1)
         TARGET_COMPILE_DEFINITIONS(${library} PUBLIC DAS_ENABLE_DLL=1)
-        # Set DAS_EXPORTS to export all MOD symbols from libDaScript
     ELSE()
-        ADD_DAS_STATIC_LIBRARY(${library} ${PARSER_GENERATED_SRC}
-                ${PARSER_SRC} ${VECMATH_SRC} ${AST_SRC} ${SIMULATE_SRC} ${BUILTIN_SRC}
-                ${MISC_SRC} ${SIMULATE_FUSION_SRC} ${MAIN_SRC}
-                ${DAGOR_NOISE_SRC} ${FLAT_HASH_MAP_SRC} ${FAST_FLOAT_SRC} ${DASCRIPT_FMT_SRC})
+        ADD_DAS_STATIC_LIBRARY(${library} ${${sources}})
     ENDIF()
     TARGET_COMPILE_DEFINITIONS(${library} PUBLIC DAS_ENABLE_DYN_INCLUDES=1)
     ADD_DEPENDENCIES(${library} need_and_resolve)
@@ -940,23 +931,25 @@ MACRO(SETUP_LIBDASCRIPT library shared_lib)
             ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/uriparser/include
             ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
-    IF(${shared_lib})
-        target_link_libraries(${library} libUriParserDyn)
-    ELSE()
-        target_link_libraries(${library} libUriParser)
-    ENDIF()
-    #target_link_libraries(${library} fmt::fmt)
-    IF(LINUX_UUID)
-        target_link_libraries(${library} uuid)
-    ENDIF()
-    IF(UNIX AND NOT APPLE)
-        TARGET_LINK_LIBRARIES(${library} ${CMAKE_DL_LIBS})
-    ENDIF()
-    IF(HAIKU)
-        TARGET_LINK_LIBRARIES(${library} network uuid)
-    ENDIF()
-    IF(WIN32)
-        target_link_libraries(${library} dbghelp)
+    IF(${full_setup})
+        IF(${shared_lib})
+            target_link_libraries(${library} libUriParserDyn)
+        ELSE()
+            target_link_libraries(${library} libUriParser)
+        ENDIF()
+        #target_link_libraries(${library} fmt::fmt)
+        IF(LINUX_UUID)
+            target_link_libraries(${library} uuid)
+        ENDIF()
+        IF(UNIX AND NOT APPLE)
+            TARGET_LINK_LIBRARIES(${library} ${CMAKE_DL_LIBS})
+        ENDIF()
+        IF(HAIKU)
+            TARGET_LINK_LIBRARIES(${library} network uuid)
+        ENDIF()
+        IF(WIN32)
+            target_link_libraries(${library} dbghelp)
+        ENDIF()
     ENDIF()
     SETUP_CPP11(${library})
     target_compile_features(${library} PUBLIC cxx_std_17)
@@ -969,8 +962,31 @@ MACRO(SETUP_LIBDASCRIPT library shared_lib)
     )
 ENDMACRO()
 
-SETUP_LIBDASCRIPT(libDaScript OFF)
-SETUP_LIBDASCRIPT(libDaScriptDyn ON)
+SET(LIBDASCRIPT_RUNTIME_SRC
+    ${PARSER_GENERATED_SRC}
+    ${PARSER_SRC} ${VECMATH_SRC} ${AST_SRC} ${SIMULATE_SRC} ${BUILTIN_SRC}
+    ${MISC_SRC} ${MAIN_SRC}
+    ${DAGOR_NOISE_SRC} ${FLAT_HASH_MAP_SRC} ${FAST_FLOAT_SRC} ${DASCRIPT_FMT_SRC}
+)
+
+SET(LIBDASCRIPT_COMPILER_SRC
+    ${SIMULATE_FUSION_SRC}
+    src/misc/daScriptC.cpp
+    src/builtin/modules.cpp
+)
+
+# Eventually libDaScript_runtime will contain only minimal subset of sources
+# required to run standalone executable.
+#
+# Note: Now it contains everything except fusion.
+SETUP_LIBDASCRIPT(libDaScript_runtime OFF ON LIBDASCRIPT_RUNTIME_SRC DAS_EXPORTS)
+SETUP_LIBDASCRIPT(libDaScriptDyn_runtime ON ON LIBDASCRIPT_RUNTIME_SRC DAS_EXPORTS)
+
+SETUP_LIBDASCRIPT(libDaScript OFF OFF LIBDASCRIPT_COMPILER_SRC DAS_CC_EXPORTS)
+SETUP_LIBDASCRIPT(libDaScriptDyn ON OFF LIBDASCRIPT_COMPILER_SRC DAS_CC_EXPORTS)
+
+target_link_libraries(libDaScript libDaScript_runtime)
+target_link_libraries(libDaScriptDyn libDaScriptDyn_runtime)
 
 if(NOT ${DAS_AOT_EXAMPLES_DISABLED})
 
@@ -1336,7 +1352,7 @@ install(FILES ${DAS_BUILTIN_HEADERS}
 
 # Install all modules and main library.
 install(TARGETS
-    libDaScript libDaScriptDyn libUriParser libUriParserDyn
+    libDaScript libDaScript_runtime libDaScriptDyn libDaScriptDyn_runtime libUriParser libUriParserDyn
     EXPORT DASTargets
     RUNTIME DESTINATION ${DAS_INSTALL_BINDIR}
     LIBRARY DESTINATION ${DAS_INSTALL_LIBDIR}

--- a/doc/source/stdlib/handmade/function-fio-for_each_registered_dynamic_module-0xd2869eeda9404b7d.rst
+++ b/doc/source/stdlib/handmade/function-fio-for_each_registered_dynamic_module-0xd2869eeda9404b7d.rst
@@ -1,0 +1,1 @@
+Iterates over all registered dynamic modules, invoking the block with the library path, C++ module name, and daslang module name for each entry.

--- a/doc/source/stdlib/handmade/function-fio-for_each_registered_native_path-0x739bf6ab4c1fa7e4.rst
+++ b/doc/source/stdlib/handmade/function-fio-for_each_registered_native_path-0x739bf6ab4c1fa7e4.rst
@@ -1,0 +1,1 @@
+Iterates over all registered native path mappings, invoking the block with the module name, source prefix, and destination prefix for each entry.

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1703,7 +1703,6 @@ namespace das
         bool optimizationBlockFolding(int32_t round);
         bool optimizationCondFolding(int32_t round);
         bool optimizationUnused(TextWriter & logs, int32_t round);
-        void fusion ( Context & context, TextWriter & logs );
         void buildAccessFlags(TextWriter & logs);
         bool verifyAndFoldContracts();
         void validateAst();

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1260,6 +1260,7 @@ namespace das
         gc_root                                     module_gc_root;     // gc_node root for this module's gc-managed AST nodes
         uint64_t                                    cumulativeHash = 0; // hash of all mangled names in this module (for builtin modules)
         string                                      name;
+        string                                      cppClassName;       // C++ class name (e.g. "Module_Math"), set by REGISTER_MODULE
         uint64_t                                    nameHash = 0;
         string                                      fileName;           // where the module was found, if not built-in
         union {
@@ -1287,7 +1288,11 @@ namespace das
         DAS_EXPORT_DLL das::Module * register_##ClassName () { \
             das::daScriptEnvironment::ensure(); \
             ClassName * module_##ClassName = new ClassName(); \
+            module_##ClassName->cppClassName = #ClassName; \
             return module_##ClassName; \
+        } \
+        extern "C" DAS_EXPORT_DLL das::Module * jit_register_##ClassName () { \
+            return register_##ClassName(); \
         }
 
     #if DAS_ENABLE_DLL
@@ -1297,6 +1302,7 @@ namespace das
                 if ( buildId != DAS_BUILD_ID ) return nullptr; \
                 das::daScriptEnvironment::ensure(); \
                 ClassName * module_##ClassName = new ClassName(); \
+                module_##ClassName->cppClassName = #ClassName; \
                 return module_##ClassName; \
             } \
         }
@@ -1312,7 +1318,11 @@ namespace das
         DAS_EXPORT_DLL das::Module * register_##ClassName () { \
             das::daScriptEnvironment::ensure(); \
             Namespace::ClassName * module_##ClassName = new Namespace::ClassName(); \
+            module_##ClassName->cppClassName = #ClassName; \
             return module_##ClassName; \
+        } \
+        extern "C" DAS_EXPORT_DLL das::Module * jit_register_##ClassName () { \
+            return register_##ClassName(); \
         }
 
     using module_pull_t = das::Module*(*)();

--- a/include/daScript/ast/ast_typedecl.h
+++ b/include/daScript/ast/ast_typedecl.h
@@ -691,7 +691,7 @@ namespace das {
                            CpptRedundantConst redundantConst = CpptRedundantConst::yes,
                            ChooseSmartPtr chooseSmartPtr = ChooseSmartPtr::no);
 
-    class MangledNameParser {
+    class DAS_API MangledNameParser {
     protected:
         virtual void error ( const string &, const char * );
         string parseAnyName ( const char * & ch, bool allowModule );

--- a/include/daScript/daScriptC.h
+++ b/include/daScript/daScriptC.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 #if DAS_ENABLE_DLL
-#ifndef DAS_API
+#ifndef DAS_CC_API
 #ifdef _MSC_VER
     #define DAS_EXPORT_DLL __declspec(dllexport)
     #define DAS_IMPORT_DLL __declspec(dllimport)
@@ -11,14 +11,14 @@
     #define DAS_EXPORT_DLL __attribute__((visibility("default")))
     #define DAS_IMPORT_DLL
 #endif
-#ifdef DAS_EXPORTS
-    #define DAS_API DAS_EXPORT_DLL
+#ifdef DAS_CC_EXPORTS
+    #define DAS_CC_API DAS_EXPORT_DLL
 #else
-    #define DAS_API DAS_IMPORT_DLL
+    #define DAS_CC_API DAS_IMPORT_DLL
 #endif
 #endif
 #else
-#define DAS_API
+#define DAS_CC_API
 #endif
 //if target is not defined, try to auto-detect target
 #ifndef _TARGET_SIMD_SSE
@@ -53,17 +53,17 @@
 extern "C" {
 #endif
 
-extern DAS_API uint32_t SIDEEFFECTS_none;
-extern DAS_API uint32_t SIDEEFFECTS_unsafe;
-extern DAS_API uint32_t SIDEEFFECTS_userScenario;
-extern DAS_API uint32_t SIDEEFFECTS_modifyExternal;
-extern DAS_API uint32_t SIDEEFFECTS_accessExternal;
-extern DAS_API uint32_t SIDEEFFECTS_modifyArgument;
-extern DAS_API uint32_t SIDEEFFECTS_modifyArgumentAndExternal;
-extern DAS_API uint32_t SIDEEFFECTS_worstDefault;
-extern DAS_API uint32_t SIDEEFFECTS_accessGlobal;
-extern DAS_API uint32_t SIDEEFFECTS_invoke;
-extern DAS_API uint32_t SIDEEFFECTS_inferredSideEffects;
+extern DAS_CC_API uint32_t SIDEEFFECTS_none;
+extern DAS_CC_API uint32_t SIDEEFFECTS_unsafe;
+extern DAS_CC_API uint32_t SIDEEFFECTS_userScenario;
+extern DAS_CC_API uint32_t SIDEEFFECTS_modifyExternal;
+extern DAS_CC_API uint32_t SIDEEFFECTS_accessExternal;
+extern DAS_CC_API uint32_t SIDEEFFECTS_modifyArgument;
+extern DAS_CC_API uint32_t SIDEEFFECTS_modifyArgumentAndExternal;
+extern DAS_CC_API uint32_t SIDEEFFECTS_worstDefault;
+extern DAS_CC_API uint32_t SIDEEFFECTS_accessGlobal;
+extern DAS_CC_API uint32_t SIDEEFFECTS_invoke;
+extern DAS_CC_API uint32_t SIDEEFFECTS_inferredSideEffects;
 
 typedef struct dasTextOutputHandle das_text_writer;
 typedef struct dasModuleGroupHandle das_module_group;
@@ -118,33 +118,33 @@ typedef void (das_interop_function_unaligned) ( das_context * ctx, das_node * no
 
 // Initialize all built-in modules and internal structures.
 // Must be called once before any other daslang C API call.
-DAS_API void das_initialize();
+DAS_CC_API void das_initialize();
 // Shut down the daslang runtime and free all internal structures and memory.
 // Must be called once when the host application is done with daslang.
-DAS_API void das_shutdown();
+DAS_CC_API void das_shutdown();
 
 // --- Text output ---
 
 // Create a text writer that prints to stdout.
 // Use das_text_make_writer() instead if you need to capture output as a string.
-DAS_API das_text_writer * das_text_make_printer();
+DAS_CC_API das_text_writer * das_text_make_printer();
 // Create a text writer that accumulates output in an internal string buffer.
 // Use das_text_make_printer() instead if you just want stdout output.
-DAS_API das_text_writer * das_text_make_writer();
+DAS_CC_API das_text_writer * das_text_make_writer();
 // Release a text writer created by das_text_make_printer() or das_text_make_writer().
-DAS_API void das_text_release ( das_text_writer * output );
+DAS_CC_API void das_text_release ( das_text_writer * output );
 // Write a null-terminated string to a text writer.
-DAS_API void das_text_output ( das_text_writer * output, char * text );
+DAS_CC_API void das_text_output ( das_text_writer * output, char * text );
 
 // --- Module groups ---
 
 // Create a module group. A module group holds references to modules
 // that the compiler should use when resolving `require` statements.
-DAS_API das_module_group * das_modulegroup_make ();
+DAS_CC_API das_module_group * das_modulegroup_make ();
 // Add a module to a module group so that compiled scripts can `require` it.
-DAS_API void das_modulegroup_add_module ( das_module_group* lib, das_module* mod );
+DAS_CC_API void das_modulegroup_add_module ( das_module_group* lib, das_module* mod );
 // Release a module group created by das_modulegroup_make().
-DAS_API void das_modulegroup_release ( das_module_group * group );
+DAS_CC_API void das_modulegroup_release ( das_module_group * group );
 
 // --- Dynamic modules ---
 
@@ -154,94 +154,94 @@ DAS_API void das_modulegroup_release ( das_module_group * group );
 // If tout is NULL, diagnostic output goes to stdout.
 //
 // Returns 0 on success.
-DAS_API int das_register_dynamic_modules(das_file_access *file_access,
+DAS_CC_API int das_register_dynamic_modules(das_file_access *file_access,
                                          const char *project_root,
                                          das_text_writer *tout);
 
 // --- File access ---
 
 // Create a default file access that reads directly from the filesystem.
-DAS_API das_file_access * das_fileaccess_make_default (  );
+DAS_CC_API das_file_access * das_fileaccess_make_default (  );
 // Create a file access backed by a .das_project file.
 // The project file is a daslang program that exports callback functions
 // controlling module resolution, permissions, and compilation policies.
 // See tutorial 06 (sandbox) for a complete example.
-DAS_API das_file_access * das_fileaccess_make_project ( const char * project_file  );
+DAS_CC_API das_file_access * das_fileaccess_make_project ( const char * project_file  );
 // Release a file access created by das_fileaccess_make_default() or das_fileaccess_make_project().
-DAS_API void das_fileaccess_release ( das_file_access * access );
+DAS_CC_API void das_fileaccess_release ( das_file_access * access );
 // Register a virtual file from a C string.
 // The file appears at 'file_name' during compilation even though it does not exist on disk.
 // If 'owns' is non-zero, the content is copied internally and the caller may free file_content.
 // If 'owns' is zero, the content is borrowed and the caller must keep file_content alive
 // for the lifetime of the file access.
-DAS_API void das_fileaccess_introduce_file ( das_file_access * access, const char * file_name, const char * file_content, int owns );
+DAS_CC_API void das_fileaccess_introduce_file ( das_file_access * access, const char * file_name, const char * file_content, int owns );
 
 // Read a file from disk at 'disk_path' and cache it under the virtual path 'name'.
 // 'name' is what module resolution returns (e.g. "daslib/strings.das");
 // 'disk_path' is the actual location on the filesystem.
-DAS_API void das_fileaccess_introduce_file_from_disk ( das_file_access * access, const char * name, const char * disk_path );
+DAS_CC_API void das_fileaccess_introduce_file_from_disk ( das_file_access * access, const char * name, const char * disk_path );
 // Pre-load all standard library modules from getDasRoot()/daslib/ into the file access cache.
 // Typically called before das_fileaccess_lock() when setting up a sandbox.
-DAS_API void das_fileaccess_introduce_daslib ( das_file_access * access );
+DAS_CC_API void das_fileaccess_introduce_daslib ( das_file_access * access );
 // Pre-load all native plugin modules listed in external_resolve.inc into the file access cache.
 // Modules not present on disk are silently skipped.
-DAS_API void das_fileaccess_introduce_native_modules ( das_file_access * access );
+DAS_CC_API void das_fileaccess_introduce_native_modules ( das_file_access * access );
 // Pre-load a single native module by its require-style path (e.g. "opengl/opengl_boost").
 // Returns 1 if the module file was found and cached, 0 otherwise.
-DAS_API int das_fileaccess_introduce_native_module ( das_file_access * access, const char * req );
+DAS_CC_API int das_fileaccess_introduce_native_module ( das_file_access * access, const char * req );
 
 // Lock the file access. While locked, getNewFileInfo() returns NULL for all
 // files not already in the cache, so only pre-introduced files can be accessed.
-DAS_API void das_fileaccess_lock ( das_file_access * access );
+DAS_CC_API void das_fileaccess_lock ( das_file_access * access );
 // Unlock the file access, re-enabling filesystem reads and further introduce calls.
-DAS_API void das_fileaccess_unlock ( das_file_access * access );
+DAS_CC_API void das_fileaccess_unlock ( das_file_access * access );
 // Return 1 if the file access is locked, 0 otherwise.
-DAS_API int das_fileaccess_is_locked ( das_file_access * access );
+DAS_CC_API int das_fileaccess_is_locked ( das_file_access * access );
 
 // Copy the daslang root path into 'root'. At most 'maxbuf' bytes are written
 // (including the null terminator). The root path is used to locate daslib/ and other resources.
-DAS_API void das_get_root ( char * root, int maxbuf );
+DAS_CC_API void das_get_root ( char * root, int maxbuf );
 
 // --- Compilation ---
 
 // Compile a daslang program from the file at 'program_file'.
 // Compiler diagnostics are written to 'tout'. The returned program is always
 // non-NULL; check das_program_err_count() to determine if compilation succeeded.
-DAS_API das_program * das_program_compile ( char * program_file, das_file_access * access, das_text_writer * tout, das_module_group * libgroup );
+DAS_CC_API das_program * das_program_compile ( char * program_file, das_file_access * access, das_text_writer * tout, das_module_group * libgroup );
 // Release a compiled program.
-DAS_API void das_program_release ( das_program * program );
+DAS_CC_API void das_program_release ( das_program * program );
 // Return the number of compilation errors. Zero means the program compiled successfully.
-DAS_API int das_program_err_count ( das_program * program );
+DAS_CC_API int das_program_err_count ( das_program * program );
 // Return the minimum context stack size (in bytes) needed to simulate this program.
 // Pass this value to das_context_make().
-DAS_API int das_program_context_stack_size ( das_program * program );
+DAS_CC_API int das_program_context_stack_size ( das_program * program );
 // Simulate (link) a compiled program into a context.
 // Returns 1 on success, 0 on failure. On failure, error details can be retrieved
 // with das_program_get_error(). The text writer 'tout' receives diagnostic output.
-DAS_API int das_program_simulate ( das_program * program, das_context * ctx, das_text_writer * tout );
+DAS_CC_API int das_program_simulate ( das_program * program, das_context * ctx, das_text_writer * tout );
 // Return the i-th compilation or simulation error, or NULL if index is out of range.
 // Valid indices are [0, das_program_err_count(program)).
-DAS_API das_error * das_program_get_error ( das_program * program, int index );
+DAS_CC_API das_error * das_program_get_error ( das_program * program, int index );
 
 // --- Errors ---
 
 // Write a human-readable error description to a text writer.
-DAS_API void das_error_output ( das_error * error, das_text_writer * tout );
+DAS_CC_API void das_error_output ( das_error * error, das_text_writer * tout );
 // Write a human-readable error description into 'text' (at most 'maxLength' bytes,
 // including the null terminator). Truncated if the message exceeds maxLength.
-DAS_API void das_error_report ( das_error * error, char * text, int maxLength );
+DAS_CC_API void das_error_report ( das_error * error, char * text, int maxLength );
 
 // --- Context ---
 
 // Create an execution context with the given stack size (in bytes).
 // stackSize must be >= das_program_context_stack_size(program) for the program
 // you intend to simulate.
-DAS_API das_context * das_context_make ( int stackSize );
+DAS_CC_API das_context * das_context_make ( int stackSize );
 // Release an execution context.
-DAS_API void das_context_release ( das_context * context );
+DAS_CC_API void das_context_release ( das_context * context );
 // Find an exported function by name in a simulated context.
 // Returns NULL if no function with that name exists.
-DAS_API das_function * das_context_find_function ( das_context * context, char * name );
+DAS_CC_API das_function * das_context_find_function ( das_context * context, char * name );
 
 // --- Threading: environment ---
 // daScriptEnvironment is thread-local (TLS).  Every thread that touches
@@ -251,19 +251,19 @@ DAS_API das_function * das_context_find_function ( das_context * context, char *
 // for a fully independent environment (Part B pattern).
 
 // Return the environment bound to the current thread, or NULL.
-DAS_API das_environment * das_environment_get_bound ();
+DAS_CC_API das_environment * das_environment_get_bound ();
 // Bind an environment on the current thread.  The worker thread must call
 // this before any other daslang API call when sharing the main thread's env.
-DAS_API void das_environment_set_bound ( das_environment * env );
+DAS_CC_API void das_environment_set_bound ( das_environment * env );
 
 // --- Threading: reuse cache guard ---
 // A thread-local free-list cache used by the daslang allocator.
 // Must be created first on any worker thread that uses daslang.
 
 // Create a reuse-cache guard (call at thread start).
-DAS_API das_reuse_cache_guard * das_reuse_cache_guard_create ();
+DAS_CC_API das_reuse_cache_guard * das_reuse_cache_guard_create ();
 // Release a reuse-cache guard (call before thread exit).
-DAS_API void das_reuse_cache_guard_release ( das_reuse_cache_guard * guard );
+DAS_CC_API void das_reuse_cache_guard_release ( das_reuse_cache_guard * guard );
 
 // --- Threading: context cloning ---
 // Clone a context for use on a worker thread.  The clone has its own
@@ -271,12 +271,12 @@ DAS_API void das_reuse_cache_guard_release ( das_reuse_cache_guard * guard );
 // das_context_release().
 
 // Context-category constants (bitmask flags).
-extern DAS_API uint32_t DAS_CONTEXT_CATEGORY_THREAD_CLONE;
-extern DAS_API uint32_t DAS_CONTEXT_CATEGORY_JOB_CLONE;
+extern DAS_CC_API uint32_t DAS_CONTEXT_CATEGORY_THREAD_CLONE;
+extern DAS_CC_API uint32_t DAS_CONTEXT_CATEGORY_JOB_CLONE;
 
 // Clone 'source' with the given category flags.  Typically pass
 // DAS_CONTEXT_CATEGORY_THREAD_CLONE for threading.
-DAS_API das_context * das_context_clone ( das_context * source, uint32_t category );
+DAS_CC_API das_context * das_context_clone ( das_context * source, uint32_t category );
 
 // --- Function evaluation (aligned, vec4f) ---
 // All arguments and return values are passed as vec4f (16-byte aligned SIMD registers).
@@ -284,7 +284,7 @@ DAS_API das_context * das_context_clone ( das_context * source, uint32_t categor
 // If the function throws an exception, retrieve it with das_context_get_exception().
 
 // Call a function. Returns the result as vec4f.
-DAS_API vec4f das_context_eval_with_catch ( das_context * context, das_function * fun, vec4f * arguments );
+DAS_CC_API vec4f das_context_eval_with_catch ( das_context * context, das_function * fun, vec4f * arguments );
 
 // --- Function evaluation (unaligned, vec4f_unaligned) ---
 // Same semantics as above, but arguments and result use vec4f_unaligned (no alignment requirement).
@@ -292,7 +292,7 @@ DAS_API vec4f das_context_eval_with_catch ( das_context * context, das_function 
 // 'narguments' is the number of elements in the arguments array.
 
 // Call a function with unaligned arguments. Result is written into *result.
-DAS_API void das_context_eval_with_catch_unaligned ( das_context * context, das_function * fun, vec4f_unaligned * arguments, int narguments, vec4f_unaligned * result );
+DAS_CC_API void das_context_eval_with_catch_unaligned ( das_context * context, das_function * fun, vec4f_unaligned * arguments, int narguments, vec4f_unaligned * result );
 
 // --- Function evaluation returning complex results (cmres) ---
 // Functions that return structures, tuples, or other types that do not fit in a single
@@ -300,37 +300,37 @@ DAS_API void das_context_eval_with_catch_unaligned ( das_context * context, das_
 // for the return type and pass it via the 'cmres' pointer.
 
 // Call a function that returns a complex result (aligned arguments).
-DAS_API void das_context_eval_with_catch_cmres ( das_context * context, das_function * fun, vec4f * arguments, void * cmres );
+DAS_CC_API void das_context_eval_with_catch_cmres ( das_context * context, das_function * fun, vec4f * arguments, void * cmres );
 // Call a function that returns a complex result (unaligned arguments).
-DAS_API void das_context_eval_with_catch_cmres_unaligned ( das_context * context, das_function * fun, vec4f_unaligned * arguments, int narguments, void * cmres );
+DAS_CC_API void das_context_eval_with_catch_cmres_unaligned ( das_context * context, das_function * fun, vec4f_unaligned * arguments, int narguments, void * cmres );
 // Return the current exception message, or NULL if no exception occurred.
-DAS_API char * das_context_get_exception ( das_context * context );
+DAS_CC_API char * das_context_get_exception ( das_context * context );
 
 // --- Lambda evaluation ---
 // Lambdas are heap-allocated closures. The same aligned / unaligned / cmres
 // variants apply as for function evaluation above.
 
 // Call a lambda (aligned). Returns result as vec4f.
-DAS_API vec4f das_context_eval_lambda ( das_context * context, das_lambda * lambda, vec4f * arguments );
+DAS_CC_API vec4f das_context_eval_lambda ( das_context * context, das_lambda * lambda, vec4f * arguments );
 // Call a lambda (unaligned). Result written into *result.
-DAS_API void das_context_eval_lambda_unaligned ( das_context * context, das_lambda * lambda, vec4f_unaligned * arguments, int narguments, vec4f_unaligned * result );
+DAS_CC_API void das_context_eval_lambda_unaligned ( das_context * context, das_lambda * lambda, vec4f_unaligned * arguments, int narguments, vec4f_unaligned * result );
 // Call a lambda returning a complex result (aligned).
-DAS_API void das_context_eval_lambda_cmres ( das_context * context, das_lambda * lambda, vec4f * arguments, void * cmres );
+DAS_CC_API void das_context_eval_lambda_cmres ( das_context * context, das_lambda * lambda, vec4f * arguments, void * cmres );
 // Call a lambda returning a complex result (unaligned).
-DAS_API void das_context_eval_lambda_cmres_unaligned ( das_context * context, das_lambda * lambda, vec4f_unaligned * arguments, int narguments, void * cmres );
+DAS_CC_API void das_context_eval_lambda_cmres_unaligned ( das_context * context, das_lambda * lambda, vec4f_unaligned * arguments, int narguments, void * cmres );
 
 // --- Block evaluation ---
 // Blocks are stack-allocated closures. The same aligned / unaligned / cmres
 // variants apply as for function evaluation above.
 
 // Call a block (aligned). Returns result as vec4f.
-DAS_API vec4f das_context_eval_block ( das_context * context, das_block * block, vec4f * arguments );
+DAS_CC_API vec4f das_context_eval_block ( das_context * context, das_block * block, vec4f * arguments );
 // Call a block (unaligned). Result written into *result.
-DAS_API void das_context_eval_block_unaligned ( das_context * context, das_block * block, vec4f_unaligned * arguments, int narguments, vec4f_unaligned * result );
+DAS_CC_API void das_context_eval_block_unaligned ( das_context * context, das_block * block, vec4f_unaligned * arguments, int narguments, vec4f_unaligned * result );
 // Call a block returning a complex result (aligned).
-DAS_API void das_context_eval_block_cmres ( das_context * context, das_block * block, vec4f * arguments, void * cmres );
+DAS_CC_API void das_context_eval_block_cmres ( das_context * context, das_block * block, vec4f * arguments, void * cmres );
 // Call a block returning a complex result (unaligned).
-DAS_API void das_context_eval_block_cmres_unaligned ( das_context * context, das_block * block, vec4f_unaligned * arguments, int narguments, void * cmres );
+DAS_CC_API void das_context_eval_block_cmres_unaligned ( das_context * context, das_block * block, vec4f_unaligned * arguments, int narguments, void * cmres );
 
 // --- Type binding: structures ---
 
@@ -339,11 +339,11 @@ DAS_API void das_context_eval_block_cmres_unaligned ( das_context * context, das
 // 'sz' and 'al' are sizeof() and alignof() of the C struct.
 // The returned handle must be populated with das_structure_add_field() and then
 // registered into a module with das_module_bind_structure().
-DAS_API das_structure * das_structure_make ( das_module_group * lib, const char * name, const char * cppname, int sz, int al );
+DAS_CC_API das_structure * das_structure_make ( das_module_group * lib, const char * name, const char * cppname, int sz, int al );
 // Add a field to a structure created by das_structure_make().
 // 'offset' is offsetof() of the field in the C struct.
 // 'tname' is the field type in mangled-name format (see type_mangling.rst).
-DAS_API void das_structure_add_field ( das_structure * st, das_module * mod, das_module_group * lib,  const char * name, const char * cppname, int offset, const char * tname );
+DAS_CC_API void das_structure_add_field ( das_structure * st, das_module * mod, das_module_group * lib,  const char * name, const char * cppname, int offset, const char * tname );
 
 // --- Type binding: enumerations ---
 
@@ -351,110 +351,110 @@ DAS_API void das_structure_add_field ( das_structure * st, das_module * mod, das
 // 'name' is the daslang name, 'cppname' is the C/C++ type name.
 // 'ext' is non-zero if the enum's underlying storage is int64 (otherwise int).
 // Populate with das_enumeration_add_value(), then register with das_module_bind_enumeration().
-DAS_API das_enumeration * das_enumeration_make ( const char * name, const char * cppname, int ext );
+DAS_CC_API das_enumeration * das_enumeration_make ( const char * name, const char * cppname, int ext );
 // Add a named value to an enumeration created by das_enumeration_make().
-DAS_API void das_enumeration_add_value ( das_enumeration * enu, const char * name, const char * cppName, int value );
+DAS_CC_API void das_enumeration_add_value ( das_enumeration * enu, const char * name, const char * cppName, int value );
 
 // --- Modules ---
 
 // Create a new module with the given name.
 // After populating it with bindings, add it to a module group with das_modulegroup_add_module().
-DAS_API das_module * das_module_create ( char * name );
+DAS_CC_API das_module * das_module_create ( char * name );
 // Find an already-registered module by name (e.g. "rtti_core", "$").
 // Returns NULL if no module with that name exists.
-DAS_API das_module * das_module_find ( const char * name );
+DAS_CC_API das_module * das_module_find ( const char * name );
 // Bind a C interop function (aligned, vec4f calling convention) to a module.
 // 'name' is the daslang function name, 'cppName' is the C symbol name.
 // 'sideffects' is a combination of SIDEEFFECTS_* flags.
 // 'args' is a mangled signature string describing argument and return types
 // (see type_mangling.rst).
-DAS_API void das_module_bind_interop_function ( das_module * mod, das_module_group * lib, das_interop_function * fun, char * name, char * cppName, uint32_t sideffects, char* args );
+DAS_CC_API void das_module_bind_interop_function ( das_module * mod, das_module_group * lib, das_interop_function * fun, char * name, char * cppName, uint32_t sideffects, char* args );
 // Bind a C interop function (unaligned, vec4f_unaligned calling convention) to a module.
 // Same parameters as das_module_bind_interop_function(); use this variant when the
 // interop function uses vec4f_unaligned arguments and result.
-DAS_API void das_module_bind_interop_function_unaligned ( das_module * mod, das_module_group * lib, das_interop_function_unaligned * fun, char * name, char * cppName, uint32_t sideffects, char* args );
+DAS_CC_API void das_module_bind_interop_function_unaligned ( das_module * mod, das_module_group * lib, das_interop_function_unaligned * fun, char * name, char * cppName, uint32_t sideffects, char* args );
 // Bind a type alias to a module. 'aname' is the alias name visible in daslang,
 // 'tname' is the target type in mangled-name format.
-DAS_API void das_module_bind_alias ( das_module * mod, das_module_group * lib, char * aname, char * tname );
+DAS_CC_API void das_module_bind_alias ( das_module * mod, das_module_group * lib, char * aname, char * tname );
 // Register a structure (from das_structure_make()) into a module.
-DAS_API void das_module_bind_structure ( das_module * mod, das_structure * st );
+DAS_CC_API void das_module_bind_structure ( das_module * mod, das_structure * st );
 // Register an enumeration (from das_enumeration_make()) into a module.
-DAS_API void das_module_bind_enumeration ( das_module * mod, das_enumeration * en );
+DAS_CC_API void das_module_bind_enumeration ( das_module * mod, das_enumeration * en );
 
 // --- String allocation ---
 
 // Allocate a copy of 'str' on the daslang string heap.
 // Use this to return strings from interop functions; the returned pointer
 // is managed by the context and must not be freed by the caller.
-DAS_API char * das_allocate_string ( das_context * context, char * str );
+DAS_CC_API char * das_allocate_string ( das_context * context, char * str );
 
 // --- Argument getters (aligned) ---
 // Extract a C value from a vec4f argument inside an interop function.
 
-DAS_API int    das_argument_int ( vec4f arg );
-DAS_API unsigned int   das_argument_uint ( vec4f arg );
-DAS_API long long das_argument_int64 ( vec4f arg );
-DAS_API unsigned long long das_argument_uint64 ( vec4f arg );
-DAS_API int    das_argument_bool ( vec4f arg );
-DAS_API float  das_argument_float ( vec4f arg );
-DAS_API double das_argument_double ( vec4f arg );
-DAS_API char * das_argument_string ( vec4f arg );
-DAS_API void * das_argument_ptr ( vec4f arg );
-DAS_API das_function * das_argument_function ( vec4f arg );
-DAS_API das_lambda * das_argument_lambda ( vec4f arg );
-DAS_API das_block * das_argument_block ( vec4f arg );
+DAS_CC_API int    das_argument_int ( vec4f arg );
+DAS_CC_API unsigned int   das_argument_uint ( vec4f arg );
+DAS_CC_API long long das_argument_int64 ( vec4f arg );
+DAS_CC_API unsigned long long das_argument_uint64 ( vec4f arg );
+DAS_CC_API int    das_argument_bool ( vec4f arg );
+DAS_CC_API float  das_argument_float ( vec4f arg );
+DAS_CC_API double das_argument_double ( vec4f arg );
+DAS_CC_API char * das_argument_string ( vec4f arg );
+DAS_CC_API void * das_argument_ptr ( vec4f arg );
+DAS_CC_API das_function * das_argument_function ( vec4f arg );
+DAS_CC_API das_lambda * das_argument_lambda ( vec4f arg );
+DAS_CC_API das_block * das_argument_block ( vec4f arg );
 
 // --- Argument getters (unaligned) ---
 // Extract a C value from a vec4f_unaligned argument pointer.
 // Use these in unaligned interop functions.
 
-DAS_API int das_argument_bool_unaligned ( vec4f_unaligned * arg );
-DAS_API int das_argument_int_unaligned ( vec4f_unaligned * arg );
-DAS_API unsigned int das_argument_uint_unaligned ( vec4f_unaligned * arg );
-DAS_API long long das_argument_int64_unaligned ( vec4f_unaligned * arg );
-DAS_API unsigned long long das_argument_uint64_unaligned ( vec4f_unaligned * arg );
-DAS_API float das_argument_float_unaligned ( vec4f_unaligned * arg );
-DAS_API double das_argument_double_unaligned ( vec4f_unaligned * arg );
-DAS_API char * das_argument_string_unaligned ( vec4f_unaligned * arg );
-DAS_API void * das_argument_ptr_unaligned ( vec4f_unaligned * arg );
-DAS_API das_function * das_argument_function_unaligned ( vec4f_unaligned * arg );
-DAS_API das_lambda * das_argument_lambda_unaligned ( vec4f_unaligned * arg );
-DAS_API das_block * das_argument_block_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API int das_argument_bool_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API int das_argument_int_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API unsigned int das_argument_uint_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API long long das_argument_int64_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API unsigned long long das_argument_uint64_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API float das_argument_float_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API double das_argument_double_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API char * das_argument_string_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API void * das_argument_ptr_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API das_function * das_argument_function_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API das_lambda * das_argument_lambda_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API das_block * das_argument_block_unaligned ( vec4f_unaligned * arg );
 
 // --- Result setters (aligned) ---
 // Pack a C value into vec4f for returning from an aligned interop function.
 
-DAS_API vec4f das_result_void ();
-DAS_API vec4f das_result_int ( int r );
-DAS_API vec4f das_result_uint ( unsigned int r );
-DAS_API vec4f das_result_int64 ( long long r );
-DAS_API vec4f das_result_uint64 ( unsigned long long r );
-DAS_API vec4f das_result_bool ( int r );
-DAS_API vec4f das_result_float ( float r );
-DAS_API vec4f das_result_double ( double r );
-DAS_API vec4f das_result_string ( char * r );
-DAS_API vec4f das_result_ptr ( void * r );
-DAS_API vec4f das_result_function ( das_function * r );
-DAS_API vec4f das_result_lambda ( das_lambda * r );
-DAS_API vec4f das_result_block ( das_block * r );
+DAS_CC_API vec4f das_result_void ();
+DAS_CC_API vec4f das_result_int ( int r );
+DAS_CC_API vec4f das_result_uint ( unsigned int r );
+DAS_CC_API vec4f das_result_int64 ( long long r );
+DAS_CC_API vec4f das_result_uint64 ( unsigned long long r );
+DAS_CC_API vec4f das_result_bool ( int r );
+DAS_CC_API vec4f das_result_float ( float r );
+DAS_CC_API vec4f das_result_double ( double r );
+DAS_CC_API vec4f das_result_string ( char * r );
+DAS_CC_API vec4f das_result_ptr ( void * r );
+DAS_CC_API vec4f das_result_function ( das_function * r );
+DAS_CC_API vec4f das_result_lambda ( das_lambda * r );
+DAS_CC_API vec4f das_result_block ( das_block * r );
 
 // --- Result setters (unaligned) ---
 // Write a C value into a vec4f_unaligned result pointer.
 // Use these in unaligned interop functions.
 
-DAS_API void das_result_void_unaligned ( vec4f_unaligned * result );
-DAS_API void das_result_int_unaligned ( vec4f_unaligned * result, int r );
-DAS_API void das_result_uint_unaligned ( vec4f_unaligned * result, unsigned int r );
-DAS_API void das_result_int64_unaligned ( vec4f_unaligned * result, long long r );
-DAS_API void das_result_uint64_unaligned ( vec4f_unaligned * result, unsigned long long r );
-DAS_API void das_result_bool_unaligned ( vec4f_unaligned * result, int r );
-DAS_API void das_result_float_unaligned ( vec4f_unaligned * result, float r );
-DAS_API void das_result_double_unaligned ( vec4f_unaligned * result, double r );
-DAS_API void das_result_string_unaligned ( vec4f_unaligned * result, char * r );
-DAS_API void das_result_ptr_unaligned ( vec4f_unaligned * result, void * r );
-DAS_API void das_result_function_unaligned ( vec4f_unaligned * result, das_function * r );
-DAS_API void das_result_lambda_unaligned ( vec4f_unaligned * result, das_lambda * r );
-DAS_API void das_result_block_unaligned ( vec4f_unaligned * result, das_block * r );
+DAS_CC_API void das_result_void_unaligned ( vec4f_unaligned * result );
+DAS_CC_API void das_result_int_unaligned ( vec4f_unaligned * result, int r );
+DAS_CC_API void das_result_uint_unaligned ( vec4f_unaligned * result, unsigned int r );
+DAS_CC_API void das_result_int64_unaligned ( vec4f_unaligned * result, long long r );
+DAS_CC_API void das_result_uint64_unaligned ( vec4f_unaligned * result, unsigned long long r );
+DAS_CC_API void das_result_bool_unaligned ( vec4f_unaligned * result, int r );
+DAS_CC_API void das_result_float_unaligned ( vec4f_unaligned * result, float r );
+DAS_CC_API void das_result_double_unaligned ( vec4f_unaligned * result, double r );
+DAS_CC_API void das_result_string_unaligned ( vec4f_unaligned * result, char * r );
+DAS_CC_API void das_result_ptr_unaligned ( vec4f_unaligned * result, void * r );
+DAS_CC_API void das_result_function_unaligned ( vec4f_unaligned * result, das_function * r );
+DAS_CC_API void das_result_lambda_unaligned ( vec4f_unaligned * result, das_lambda * r );
+DAS_CC_API void das_result_block_unaligned ( vec4f_unaligned * result, das_block * r );
 
 // --- Compilation policies ---
 // CodeOfPolicies controls compiler and runtime behavior: AOT, safety,
@@ -489,33 +489,33 @@ typedef enum das_int_policy {
 } das_int_policy;
 
 // Create a new policies object with default values.
-DAS_API das_policies * das_policies_make();
+DAS_CC_API das_policies * das_policies_make();
 // Release a policies object.
-DAS_API void das_policies_release ( das_policies * policies );
+DAS_CC_API void das_policies_release ( das_policies * policies );
 // Set a boolean policy flag. Returns 1 on success, 0 if the flag is unknown.
-DAS_API int das_policies_set_bool ( das_policies * policies, das_bool_policy flag, int value );
+DAS_CC_API int das_policies_set_bool ( das_policies * policies, das_bool_policy flag, int value );
 // Set an integer policy field. Returns 1 on success, 0 if the field is unknown.
-DAS_API int das_policies_set_int ( das_policies * policies, das_int_policy field, int64_t value );
+DAS_CC_API int das_policies_set_int ( das_policies * policies, das_int_policy field, int64_t value );
 
 // Compile a daslang program with custom compilation policies.
 // Same as das_program_compile() but applies the given CodeOfPolicies.
-DAS_API das_program * das_program_compile_policies ( char * program_file, das_file_access * access, das_text_writer * tout, das_module_group * libgroup, das_policies * policies );
+DAS_CC_API das_program * das_program_compile_policies ( char * program_file, das_file_access * access, das_text_writer * tout, das_module_group * libgroup, das_policies * policies );
 
 // --- Context variables ---
 // After simulation, global variables declared in daslang are accessible
 // by name or by index. findVariable returns -1 if not found.
 
 // Look up a global variable by name. Returns its index, or -1 if not found.
-DAS_API int das_context_find_variable ( das_context * context, const char * name );
+DAS_CC_API int das_context_find_variable ( das_context * context, const char * name );
 // Get a raw pointer to the storage of a global variable at index 'idx'.
 // Cast to the appropriate C type (e.g. int32_t*, float*, char**).
-DAS_API void * das_context_get_variable ( das_context * context, int idx );
+DAS_CC_API void * das_context_get_variable ( das_context * context, int idx );
 // Return the total number of global variables in the context.
-DAS_API int das_context_get_total_variables ( das_context * context );
+DAS_CC_API int das_context_get_total_variables ( das_context * context );
 // Return the name of the global variable at index 'idx', or NULL if out of range.
-DAS_API const char * das_context_get_variable_name ( das_context * context, int idx );
+DAS_CC_API const char * das_context_get_variable_name ( das_context * context, int idx );
 // Return the size (in bytes) of the global variable at index 'idx', or 0 if out of range.
-DAS_API int das_context_get_variable_size ( das_context * context, int idx );
+DAS_CC_API int das_context_get_variable_size ( das_context * context, int idx );
 
 // --- Serialization ---
 // Serialize a compiled+simulated program to a binary blob and deserialize
@@ -525,18 +525,18 @@ DAS_API int das_context_get_variable_size ( das_context * context, int idx );
 // The program must have been simulated at least once before serialization.
 // Returns a handle to the serialized data; use das_serialized_data_release() to free it.
 // 'out_data' receives a pointer to the raw bytes, 'out_size' receives the byte count.
-DAS_API das_serialized_data * das_program_serialize ( das_program * program, const void ** out_data, int64_t * out_size );
+DAS_CC_API das_serialized_data * das_program_serialize ( das_program * program, const void ** out_data, int64_t * out_size );
 // Deserialize a program from a raw byte buffer.
 // Returns a new program handle that must be released with das_program_release().
-DAS_API das_program * das_program_deserialize ( const void * data, int64_t size );
+DAS_CC_API das_program * das_program_deserialize ( const void * data, int64_t size );
 // Release serialized data returned by das_program_serialize().
-DAS_API void das_serialized_data_release ( das_serialized_data * blob );
+DAS_CC_API void das_serialized_data_release ( das_serialized_data * blob );
 
 // --- Function info ---
 
 // Return 1 if the function has been AOT-linked, 0 otherwise.
 // Use this after simulation to check whether functions execute as native code.
-DAS_API int das_function_is_aot ( das_function * func );
+DAS_CC_API int das_function_is_aot ( das_function * func );
 
 // --- Type introspection: base type enum ---
 
@@ -593,184 +593,184 @@ typedef enum das_base_type {
 // --- Type introspection: flag constants ---
 
 // TypeInfo flags (bitmask).
-extern DAS_API uint32_t DAS_TYPEINFO_FLAG_REF;
-extern DAS_API uint32_t DAS_TYPEINFO_FLAG_REF_TYPE;
-extern DAS_API uint32_t DAS_TYPEINFO_FLAG_CAN_COPY;
-extern DAS_API uint32_t DAS_TYPEINFO_FLAG_IS_POD;
-extern DAS_API uint32_t DAS_TYPEINFO_FLAG_IS_RAW_POD;
-extern DAS_API uint32_t DAS_TYPEINFO_FLAG_IS_CONST;
-extern DAS_API uint32_t DAS_TYPEINFO_FLAG_IS_TEMP;
-extern DAS_API uint32_t DAS_TYPEINFO_FLAG_IS_SMART_PTR;
-extern DAS_API uint32_t DAS_TYPEINFO_FLAG_IS_HANDLED;
+extern DAS_CC_API uint32_t DAS_TYPEINFO_FLAG_REF;
+extern DAS_CC_API uint32_t DAS_TYPEINFO_FLAG_REF_TYPE;
+extern DAS_CC_API uint32_t DAS_TYPEINFO_FLAG_CAN_COPY;
+extern DAS_CC_API uint32_t DAS_TYPEINFO_FLAG_IS_POD;
+extern DAS_CC_API uint32_t DAS_TYPEINFO_FLAG_IS_RAW_POD;
+extern DAS_CC_API uint32_t DAS_TYPEINFO_FLAG_IS_CONST;
+extern DAS_CC_API uint32_t DAS_TYPEINFO_FLAG_IS_TEMP;
+extern DAS_CC_API uint32_t DAS_TYPEINFO_FLAG_IS_SMART_PTR;
+extern DAS_CC_API uint32_t DAS_TYPEINFO_FLAG_IS_HANDLED;
 
 // StructInfo flags (bitmask).
-extern DAS_API uint32_t DAS_STRUCTINFO_FLAG_CLASS;
-extern DAS_API uint32_t DAS_STRUCTINFO_FLAG_LAMBDA;
-extern DAS_API uint32_t DAS_STRUCTINFO_FLAG_HEAP_GC;
-extern DAS_API uint32_t DAS_STRUCTINFO_FLAG_STRING_HEAP_GC;
+extern DAS_CC_API uint32_t DAS_STRUCTINFO_FLAG_CLASS;
+extern DAS_CC_API uint32_t DAS_STRUCTINFO_FLAG_LAMBDA;
+extern DAS_CC_API uint32_t DAS_STRUCTINFO_FLAG_HEAP_GC;
+extern DAS_CC_API uint32_t DAS_STRUCTINFO_FLAG_STRING_HEAP_GC;
 
 // FuncInfo flags (bitmask).
-extern DAS_API uint32_t DAS_FUNCINFO_FLAG_INIT;
-extern DAS_API uint32_t DAS_FUNCINFO_FLAG_BUILTIN;
-extern DAS_API uint32_t DAS_FUNCINFO_FLAG_PRIVATE;
-extern DAS_API uint32_t DAS_FUNCINFO_FLAG_SHUTDOWN;
+extern DAS_CC_API uint32_t DAS_FUNCINFO_FLAG_INIT;
+extern DAS_CC_API uint32_t DAS_FUNCINFO_FLAG_BUILTIN;
+extern DAS_CC_API uint32_t DAS_FUNCINFO_FLAG_PRIVATE;
+extern DAS_CC_API uint32_t DAS_FUNCINFO_FLAG_SHUTDOWN;
 
 // --- Type introspection: entry points ---
 
 // Return the type info for a global variable at index 'idx'.
 // Returns NULL if out of range. The returned pointer is valid for the
 // lifetime of the context and must not be freed.
-DAS_API das_type_info * das_context_get_variable_type ( das_context * context, int idx );
+DAS_CC_API das_type_info * das_context_get_variable_type ( das_context * context, int idx );
 
 // Return the total number of simulated functions in the context.
-DAS_API int das_context_get_total_functions ( das_context * context );
+DAS_CC_API int das_context_get_total_functions ( das_context * context );
 
 // Return the function handle at index 'idx', or NULL if out of range.
-DAS_API das_function * das_context_get_function ( das_context * context, int idx );
+DAS_CC_API das_function * das_context_get_function ( das_context * context, int idx );
 
 // Return the debug info (FuncInfo) for a function handle.
 // Returns NULL if the function has no debug info.
-DAS_API das_func_info * das_function_get_info ( das_function * func );
+DAS_CC_API das_func_info * das_function_get_info ( das_function * func );
 
 // --- Type introspection: TypeInfo accessors ---
 
 // Return the base type classification (DAS_TYPE_*).
-DAS_API das_base_type das_type_info_get_type ( das_type_info * info );
+DAS_CC_API das_base_type das_type_info_get_type ( das_type_info * info );
 
 // Return the size in bytes of this type.
-DAS_API int das_type_info_get_size ( das_type_info * info );
+DAS_CC_API int das_type_info_get_size ( das_type_info * info );
 
 // Return the alignment in bytes.
-DAS_API int das_type_info_get_align ( das_type_info * info );
+DAS_CC_API int das_type_info_get_align ( das_type_info * info );
 
 // Return the flags bitmask (DAS_TYPEINFO_FLAG_*).
-DAS_API uint32_t das_type_info_get_flags ( das_type_info * info );
+DAS_CC_API uint32_t das_type_info_get_flags ( das_type_info * info );
 
 // Return the 64-bit type hash.
-DAS_API uint64_t das_type_info_get_hash ( das_type_info * info );
+DAS_CC_API uint64_t das_type_info_get_hash ( das_type_info * info );
 
 // Return a human-readable type description (e.g. "array<int>", "MyStruct").
 // The returned string is in a thread-local buffer and is valid until the
 // next call to this function on the same thread.
-DAS_API const char * das_type_info_get_description ( das_type_info * info );
+DAS_CC_API const char * das_type_info_get_description ( das_type_info * info );
 
 // Return the mangled name string for this type.
 // Same thread-local lifetime as das_type_info_get_description().
-DAS_API const char * das_type_info_get_mangled_name ( das_type_info * info );
+DAS_CC_API const char * das_type_info_get_mangled_name ( das_type_info * info );
 
 // --- Type introspection: composite type navigation ---
 
 // For arrays, pointers, iterators: return the element/pointee type.
 // For tables: return the key type.
 // Returns NULL if not applicable.
-DAS_API das_type_info * das_type_info_get_first_type ( das_type_info * info );
+DAS_CC_API das_type_info * das_type_info_get_first_type ( das_type_info * info );
 
 // For tables: return the value type. Returns NULL if not applicable.
-DAS_API das_type_info * das_type_info_get_second_type ( das_type_info * info );
+DAS_CC_API das_type_info * das_type_info_get_second_type ( das_type_info * info );
 
 // For tuples, variants, function types: return the number of sub-types.
-DAS_API int das_type_info_get_arg_count ( das_type_info * info );
+DAS_CC_API int das_type_info_get_arg_count ( das_type_info * info );
 
 // Return the i-th sub-type, or NULL if out of range.
-DAS_API das_type_info * das_type_info_get_arg_type ( das_type_info * info, int idx );
+DAS_CC_API das_type_info * das_type_info_get_arg_type ( das_type_info * info, int idx );
 
 // Return the name of the i-th sub-type, or NULL.
-DAS_API const char * das_type_info_get_arg_name ( das_type_info * info, int idx );
+DAS_CC_API const char * das_type_info_get_arg_name ( das_type_info * info, int idx );
 
 // For tuples: return the byte offset of the i-th field.
-DAS_API int das_type_info_get_tuple_field_offset ( das_type_info * info, int idx );
+DAS_CC_API int das_type_info_get_tuple_field_offset ( das_type_info * info, int idx );
 
 // For variants: return the byte offset of the i-th field.
-DAS_API int das_type_info_get_variant_field_offset ( das_type_info * info, int idx );
+DAS_CC_API int das_type_info_get_variant_field_offset ( das_type_info * info, int idx );
 
 // Return the number of fixed-array dimensions (0 = not a fixed-array).
-DAS_API int das_type_info_get_dim_count ( das_type_info * info );
+DAS_CC_API int das_type_info_get_dim_count ( das_type_info * info );
 
 // Return the size of the i-th fixed-array dimension.
-DAS_API int das_type_info_get_dim ( das_type_info * info, int idx );
+DAS_CC_API int das_type_info_get_dim ( das_type_info * info, int idx );
 
 // --- Type introspection: structures ---
 
 // For tStructure types: return the StructInfo.
 // Returns NULL if the type is not a structure.
-DAS_API das_struct_info * das_type_info_get_struct ( das_type_info * info );
+DAS_CC_API das_struct_info * das_type_info_get_struct ( das_type_info * info );
 
 // Return the structure name.
-DAS_API const char * das_struct_info_get_name ( das_struct_info * info );
+DAS_CC_API const char * das_struct_info_get_name ( das_struct_info * info );
 
 // Return the module name that defines this structure.
-DAS_API const char * das_struct_info_get_module ( das_struct_info * info );
+DAS_CC_API const char * das_struct_info_get_module ( das_struct_info * info );
 
 // Return the number of fields.
-DAS_API int das_struct_info_get_field_count ( das_struct_info * info );
+DAS_CC_API int das_struct_info_get_field_count ( das_struct_info * info );
 
 // Return the total size of the structure in bytes.
-DAS_API int das_struct_info_get_size ( das_struct_info * info );
+DAS_CC_API int das_struct_info_get_size ( das_struct_info * info );
 
 // Return the structure flags bitmask (DAS_STRUCTINFO_FLAG_*).
-DAS_API uint32_t das_struct_info_get_flags ( das_struct_info * info );
+DAS_CC_API uint32_t das_struct_info_get_flags ( das_struct_info * info );
 
 // Return the 64-bit hash of the structure.
-DAS_API uint64_t das_struct_info_get_hash ( das_struct_info * info );
+DAS_CC_API uint64_t das_struct_info_get_hash ( das_struct_info * info );
 
 // Return the name of the i-th field, or NULL if out of range.
-DAS_API const char * das_struct_info_get_field_name ( das_struct_info * info, int idx );
+DAS_CC_API const char * das_struct_info_get_field_name ( das_struct_info * info, int idx );
 
 // Return the byte offset of the i-th field, or -1 if out of range.
-DAS_API int das_struct_info_get_field_offset ( das_struct_info * info, int idx );
+DAS_CC_API int das_struct_info_get_field_offset ( das_struct_info * info, int idx );
 
 // Return the type info for the i-th field, or NULL if out of range.
-DAS_API das_type_info * das_struct_info_get_field_type ( das_struct_info * info, int idx );
+DAS_CC_API das_type_info * das_struct_info_get_field_type ( das_struct_info * info, int idx );
 
 // --- Type introspection: enumerations ---
 
 // For tEnumeration/tEnumeration8/16/64 types: return the EnumInfo.
 // Returns NULL if the type is not an enumeration.
-DAS_API das_enum_info * das_type_info_get_enum ( das_type_info * info );
+DAS_CC_API das_enum_info * das_type_info_get_enum ( das_type_info * info );
 
 // Return the enumeration name.
-DAS_API const char * das_enum_info_get_name ( das_enum_info * info );
+DAS_CC_API const char * das_enum_info_get_name ( das_enum_info * info );
 
 // Return the module name that defines this enumeration.
-DAS_API const char * das_enum_info_get_module ( das_enum_info * info );
+DAS_CC_API const char * das_enum_info_get_module ( das_enum_info * info );
 
 // Return the number of values in the enumeration.
-DAS_API int das_enum_info_get_count ( das_enum_info * info );
+DAS_CC_API int das_enum_info_get_count ( das_enum_info * info );
 
 // Return the name of the i-th value, or NULL if out of range.
-DAS_API const char * das_enum_info_get_value_name ( das_enum_info * info, int idx );
+DAS_CC_API const char * das_enum_info_get_value_name ( das_enum_info * info, int idx );
 
 // Return the integer value of the i-th entry, or 0 if out of range.
-DAS_API int64_t das_enum_info_get_value ( das_enum_info * info, int idx );
+DAS_CC_API int64_t das_enum_info_get_value ( das_enum_info * info, int idx );
 
 // --- Type introspection: function info ---
 
 // Return the function name.
-DAS_API const char * das_func_info_get_name ( das_func_info * info );
+DAS_CC_API const char * das_func_info_get_name ( das_func_info * info );
 
 // Return the C++ mangled name.
-DAS_API const char * das_func_info_get_cpp_name ( das_func_info * info );
+DAS_CC_API const char * das_func_info_get_cpp_name ( das_func_info * info );
 
 // Return the number of arguments.
-DAS_API int das_func_info_get_arg_count ( das_func_info * info );
+DAS_CC_API int das_func_info_get_arg_count ( das_func_info * info );
 
 // Return the type info for the i-th argument, or NULL if out of range.
-DAS_API das_type_info * das_func_info_get_arg_type ( das_func_info * info, int idx );
+DAS_CC_API das_type_info * das_func_info_get_arg_type ( das_func_info * info, int idx );
 
 // Return the name of the i-th argument, or NULL if out of range.
-DAS_API const char * das_func_info_get_arg_name ( das_func_info * info, int idx );
+DAS_CC_API const char * das_func_info_get_arg_name ( das_func_info * info, int idx );
 
 // Return the return type info.
-DAS_API das_type_info * das_func_info_get_result ( das_func_info * info );
+DAS_CC_API das_type_info * das_func_info_get_result ( das_func_info * info );
 
 // Return the 64-bit function hash.
-DAS_API uint64_t das_func_info_get_hash ( das_func_info * info );
+DAS_CC_API uint64_t das_func_info_get_hash ( das_func_info * info );
 
 // Return the function flags bitmask (DAS_FUNCINFO_FLAG_*).
-DAS_API uint32_t das_func_info_get_flags ( das_func_info * info );
+DAS_CC_API uint32_t das_func_info_get_flags ( das_func_info * info );
 
 // Return the stack size needed by this function.
-DAS_API int das_func_info_get_stack_size ( das_func_info * info );
+DAS_CC_API int das_func_info_get_stack_size ( das_func_info * info );
 
 #ifdef __cplusplus
 }

--- a/include/daScript/daScriptModule.h
+++ b/include/daScript/daScriptModule.h
@@ -19,6 +19,9 @@ namespace das
     extern DAS_API das::Module * register_##ClassName (); \
     *das::ModuleKarma += unsigned(intptr_t(register_##ClassName()));
 
+#define NEED_FUSION \
+    { extern DAS_CC_API void register_fusion(); register_fusion(); }
+
 #define NEED_ALL_DEFAULT_MODULES \
     NEED_MODULE(Module_BuiltIn); \
     NEED_MODULE(Module_Math); \
@@ -29,7 +32,8 @@ namespace das
     NEED_MODULE(Module_Jit); \
     NEED_MODULE(Module_FIO); \
     NEED_MODULE(Module_DASBIND); \
-    NEED_MODULE(Module_Network);
+    NEED_MODULE(Module_Network); \
+    NEED_FUSION;
 
 // DECLARE_MODULE / PULL_MODULE — namespace-safe alternatives to NEED_MODULE.
 //
@@ -55,6 +59,12 @@ namespace das
 #define PULL_MODULE(ClassName) \
     *das::ModuleKarma += unsigned(intptr_t(::register_##ClassName()))
 
+#define DECLARE_FUSION \
+    extern DAS_CC_API void register_fusion()
+
+#define PULL_FUSION \
+    ::register_fusion()
+
 #define DECLARE_ALL_DEFAULT_MODULES \
     DECLARE_MODULE(Module_BuiltIn); \
     DECLARE_MODULE(Module_Math); \
@@ -65,7 +75,8 @@ namespace das
     DECLARE_MODULE(Module_Jit); \
     DECLARE_MODULE(Module_FIO); \
     DECLARE_MODULE(Module_DASBIND); \
-    DECLARE_MODULE(Module_Network)
+    DECLARE_MODULE(Module_Network); \
+    DECLARE_FUSION
 
 #define PULL_ALL_DEFAULT_MODULES \
     PULL_MODULE(Module_BuiltIn); \
@@ -77,5 +88,6 @@ namespace das
     PULL_MODULE(Module_Jit); \
     PULL_MODULE(Module_FIO); \
     PULL_MODULE(Module_DASBIND); \
-    PULL_MODULE(Module_Network)
+    PULL_MODULE(Module_Network); \
+    PULL_FUSION
 

--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -267,6 +267,11 @@ __forceinline uint64_t rotr64_c(uint64_t a, uint64_t b) {
 #else
     #define DAS_MOD_API DAS_IMPORT_DLL
 #endif
+#ifdef DAS_CC_EXPORTS
+    #define DAS_CC_API DAS_EXPORT_DLL
+#else
+    #define DAS_CC_API DAS_IMPORT_DLL
+#endif
 #endif
 #else
 
@@ -274,6 +279,7 @@ __forceinline uint64_t rotr64_c(uint64_t a, uint64_t b) {
 #define DAS_IMPORT_DLL
 #define DAS_API
 #define DAS_MOD_API
+#define DAS_CC_API
 
 #endif
 

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -838,6 +838,8 @@ namespace das
         const char *    last_exception = nullptr;
         jmp_buf *       throwBuf = nullptr;
     protected:
+        friend void fusionContext( Context & context, TextWriter & logs, bool enableFusion );
+
         GlobalVariable * globalVariables = nullptr;
         SimFunction * functions = nullptr;
         SimFunction ** initFunctions = nullptr;

--- a/include/daScript/simulate/simulate_fusion.h
+++ b/include/daScript/simulate/simulate_fusion.h
@@ -75,6 +75,11 @@ namespace das {
     };
 
 
+    // function pointers for fusion library decoupling
+    // runtime defines these; fusion lib sets them via register_fusion()
+    DAS_API extern void (*g_fusionContextFn) ( Context & context, TextWriter & logs, bool enableFusion );
+    DAS_API extern void (*g_resetFusionEngineFn) ();
+
     string fuseName ( const string & name, const string & typeName );
     unique_ptr<FusionEngine> &getFusionEngine();
     void resetFusionEngine();
@@ -110,3 +115,5 @@ namespace das {
     void createFusionEngine_call2();
 #endif
 }
+
+extern DAS_CC_API void register_fusion ();

--- a/include/daScript/simulate/simulate_nodes.h
+++ b/include/daScript/simulate/simulate_nodes.h
@@ -24,7 +24,7 @@ namespace das {
         ,   sShared
     };
 
-    struct SimSource {
+    struct DAS_API SimSource {
         union {
             SimNode *       subexpr;
             union {
@@ -2969,7 +2969,7 @@ SIM_NODE_AT_VECTOR(Float, float)
     };
 
     // COPY REFERENCE VALUE
-    struct SimNode_CopyRefValue : SimNode {
+    struct DAS_API SimNode_CopyRefValue : SimNode {
         SimNode_CopyRefValue(const LineInfo & at, SimNode * ll, SimNode * rr, size_t sz)
             : SimNode(at), l(ll), r(rr), size(uint32_t(sz)) {}
         virtual SimNode * visit ( SimVisitor & vis ) override;

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -56,6 +56,13 @@ class CollectExternVisitor : AstVisitor {
     types : PrimitiveTypes -const? -const
     seen : table<string; bool>
     any_unimplemented : bool
+    needs_whole_lib : bool
+    extern_modules : table<string; bool>
+    registered_modules : table<string; bool>
+    dynamic_modules : table<string; bool>
+    register_mod_type : LLVMOpaqueType?
+    init_fn : LLVMOpaqueValue?
+    init_builder : LLVMBuilderRef
 
     reg_extern_fn_type : LLVMOpaqueType?
     reg_extern_fn : LLVMOpaqueValue?
@@ -78,12 +85,35 @@ class CollectExternVisitor : AstVisitor {
                              _mod : LLVMOpaqueModule?; var _types : PrimitiveTypes?,
                              uids : UidNodes?) {
         any_unimplemented = false
+        needs_whole_lib = false
         uid := uids
         ctx = _ctx
         standalone_ctx = standalone_context
         mod = _mod
         types = _types
         builder = _builder
+        register_mod_type = LLVMFunctionType(types.LLVMVoidPtrType(), array<LLVMTypeRef>())
+
+        // Create initialize_modules() function — filled incrementally as we discover needed modules
+        let init_fn_type = LLVMFunctionType(types.t_void, array<LLVMTypeRef>())
+        init_fn = LLVMGetNamedFunction(g_mod, "initialize_modules")
+        let init_entry = LLVMAppendBasicBlockInContext(ctx, init_fn, "entry")
+        init_builder = LLVMCreateBuilder()
+        LLVMPositionBuilderAtEnd(init_builder, init_entry)
+        // Always call das_ensure_environment first
+        let env_type = LLVMFunctionType(types.t_void, array<LLVMTypeRef>())
+        var env_fn = LLVMGetNamedFunction(g_mod, "das_ensure_environment")
+        if (env_fn == null) {
+            env_fn = LLVMAddFunctionWithType(g_mod, "das_ensure_environment", env_type)
+        }
+        LLVMBuildCall2(init_builder, env_type, env_fn, array<LLVMValueRef>(), "")
+        // Always register Module_BuiltIn ($) and Module_Strings (strings)
+        var reg_builtin = LLVMAddFunctionWithType(g_mod, "jit_register_Module_BuiltIn", register_mod_type)
+        LLVMBuildCall2(init_builder, register_mod_type, reg_builtin, array<LLVMValueRef>(), "")
+        registered_modules["$"] = true
+        var reg_strings = LLVMAddFunctionWithType(g_mod, "jit_register_Module_Strings", register_mod_type)
+        LLVMBuildCall2(init_builder, register_mod_type, reg_strings, array<LLVMValueRef>(), "")
+        registered_modules["strings"] = true
 
         reg_extern_tab_type = LLVMFunctionType(types.LLVMVoidPtrType(),
             fixed_array<LLVMTypeRef>(
@@ -191,6 +221,24 @@ class CollectExternVisitor : AstVisitor {
         }
     }
 
+    def ensure_module(m : Module?) {
+        if (m == null) { return ; }
+        let mod_name = string(m.name)
+        if (key_exists(registered_modules, mod_name)) { return ; }
+        if (key_exists(dynamic_modules, mod_name)) { return ; }
+        registered_modules[mod_name] = true
+        // First ensure all dependencies of this module are registered
+        module_for_each_dependency(m) <| $(var dep : Module?; var pub : bool) {
+            ensure_module(dep)
+        }
+        let cpp_name = string(m.cppClassName)
+        if (empty(cpp_name)) { return ; }
+        let reg_fn_name = "jit_register_{cpp_name}"
+        to_log(LOG_INFO, "LLVM EXE: NEED_MODULE({cpp_name}) for `{mod_name}`\n")
+        var reg_fn = LLVMAddFunctionWithType(g_mod, reg_fn_name, register_mod_type)
+        LLVMBuildCall2(init_builder, register_mod_type, reg_fn, array<LLVMValueRef>(), "")
+    }
+
     def make_call(expr : ExprCallFunc?) {
         if (expr.func == null) { return ; }
         if (has_intrinsic(expr)) { return ; }
@@ -211,8 +259,16 @@ class CollectExternVisitor : AstVisitor {
                 if (global_var == null) {
                     return
                 }
+                let mod_name = string(expr.func._module.name)
+                extern_modules[mod_name] = true
+                ensure_module(expr.func._module)
+                // Sort functions with cblock use Context/Block infrastructure from the compiler lib
+                let fn_name = string(expr.func.name)
+                if (find(fn_name, "sort") != -1 && find(fn_name, "cblock") != -1) {
+                    needs_whole_lib = true
+                }
                 var call_args = array<LLVMValueRef>(
-                    get_string_constant_ptr(builder, string(expr.func._module.name)),
+                    get_string_constant_ptr(builder, mod_name),
                     get_string_constant_ptr(builder, get_mangled_name(expr.func)),
                     LLVMBuildPointerCast(builder, global_var, types.LLVMVoidPtrType(), ""),
                 )
@@ -222,8 +278,11 @@ class CollectExternVisitor : AstVisitor {
     }
 
     def get_annotation(ann : TypeAnnotation?) {
+        let mod_name = string(ann._module.name)
+        extern_modules[mod_name] = true
+        ensure_module(ann._module)
         var call_args = array<LLVMValueRef>(
-            get_string_constant_ptr(builder, string(ann._module.name)),
+            get_string_constant_ptr(builder, mod_name),
             get_string_constant_ptr(builder, string(ann.name)),
         )
         return LLVMBuildCall2(builder, get_extern_ann_type, get_extern_ann, call_args, "")
@@ -430,8 +489,11 @@ class CollectExternVisitor : AstVisitor {
 
 def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVMContextRef; builder : LLVMBuilderRef,
                                mod : LLVMOpaqueModule?; var types : PrimitiveTypes?;
-                               var funcs : array<FunctionPtr>; var uids : UidNodes?) {
+                               var funcs : array<FunctionPtr>; var uids : UidNodes?;
+                               var used_modules : table<string; bool>&;
+                               dynamic_modules : table<string; bool>) : tuple<any_unimplemented : bool; needs_whole_lib : bool> {
     var extern_resolver = new CollectExternVisitor(standalone_context, ctx, builder, mod, types, uids)
+    extern_resolver.dynamic_modules := dynamic_modules
     make_visitor(*extern_resolver) $(adapter_resolve) {
         ast_gc_guard() {
             for (fn in funcs) {
@@ -448,18 +510,60 @@ def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVM
             }
         }
     }
-    var result = extern_resolver.any_unimplemented
+    var any_unimp = extern_resolver.any_unimplemented
+    var whole_lib = extern_resolver.needs_whole_lib
+    for (mod_name in keys(extern_resolver.extern_modules)) {
+        used_modules[mod_name] = true
+    }
+    // Finalize initialize_modules(): emit dynamic modules, native paths, Module::Initialize, ret
+    let ib = extern_resolver.init_builder
+    let t = extern_resolver.types
+    let reg_dyn_mod_type = LLVMFunctionType(t.LLVMVoidPtrType(),
+        fixed_array<LLVMTypeRef>(t.LLVMVoidPtrType(), t.LLVMVoidPtrType())
+    )
+    var jit_reg_dyn_mod = LLVMGetNamedFunction(g_mod, "jit_register_dynamic_module")
+    if (jit_reg_dyn_mod == null) {
+        jit_reg_dyn_mod = LLVMAddFunctionWithType(g_mod, "jit_register_dynamic_module", reg_dyn_mod_type)
+    }
+    for_each_registered_dynamic_module() <| $(path, mod_name, das_name) {
+        if (key_exists(used_modules, das_name)) {
+            to_log(LOG_INFO, "LLVM EXE: include dynamic module: `{das_name}`\n")
+            let path_str = get_string_constant_ptr(ib, path)
+            let name_str = get_string_constant_ptr(ib, mod_name)
+            LLVMBuildCall2(ib, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(path_str, name_str), "")
+        }
+    }
+    let reg_native_path_type = LLVMFunctionType(t.t_void,
+        fixed_array<LLVMTypeRef>(t.LLVMVoidPtrType(), t.LLVMVoidPtrType(), t.LLVMVoidPtrType())
+    )
+    var jit_reg_native_path = LLVMGetNamedFunction(g_mod, "jit_register_native_path")
+    if (jit_reg_native_path == null) {
+        jit_reg_native_path = LLVMAddFunctionWithType(g_mod, "jit_register_native_path", reg_native_path_type)
+    }
+    for_each_registered_native_path() <| $(mod_name, src_path, dst_path) {
+        let mod_str = get_string_constant_ptr(ib, mod_name)
+        let src_str = get_string_constant_ptr(ib, src_path)
+        let dst_str = get_string_constant_ptr(ib, dst_path)
+        LLVMBuildCall2(ib, reg_native_path_type, jit_reg_native_path, fixed_array(mod_str, src_str, dst_str), "")
+    }
+    if (!empty(extern_resolver.registered_modules) || !empty(used_modules)) {
+        let init_done_type = LLVMFunctionType(t.t_void, array<LLVMTypeRef>())
+        var jit_init_done = LLVMAddFunctionWithType(g_mod, "jit_initialize_modules_done", init_done_type)
+        LLVMBuildCall2(ib, init_done_type, jit_init_done, array<LLVMValueRef>(), "")
+    }
+    LLVMBuildRetVoid(ib)
+    LLVMDisposeBuilder(ib)
     extern_resolver.uid = null
     extern_resolver.types = null
     unsafe { delete extern_resolver; }
-    return <- result
+    return (any_unimp, whole_lib)
 }
 
 // Creates main function that initializes a standalone JIT context, registers
 // all compiled functions, runs init scripts, then calls the program entry point.
 def public inject_main(program_context : Context?; ctx : LLVMContextRef;
                        prog : Program?; entry_point : string; mod : LLVMOpaqueModule?;
-                       var types : PrimitiveTypes?, var uids : UidNodes?; strict : bool) : LLVMOpaqueValue? {
+                       var types : PrimitiveTypes?, var uids : UidNodes?; strict : bool) : tuple<fn : LLVMOpaqueValue?; link_whole_lib : bool> {
 
     let builder = LLVMCreateBuilder()
     defer() {
@@ -471,7 +575,8 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     var funcs : array<FunctionPtr>
     var has_no_jit = false
     var any_pinvoke = false
-    prog |> for_each_module() $(m) {
+    var used_modules : table<string; bool>
+    prog |> for_each_module <| $(m) {
         if (m.name == "llvm_func" || m.name == "llvm_macro") {
             return
         }
@@ -484,13 +589,14 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
                 if (fun.moreFlags.pinvoke) {
                     any_pinvoke = true
                 }
+                used_modules[string(fun._module.name)] = true
                 funcs |> emplace(fun)
             }
         }
     }
     if (strict && has_no_jit) {
         to_log(LOG_ERROR, "Cannot build standalone exe: some functions are no_jit in strict mode\n")
-        return null
+        return (null, false)
     }
 
     var start_fn_name = ""
@@ -509,7 +615,7 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     }
     if (start_fn_name |> empty()) {
         to_log(LOG_ERROR, "entrypoint `{entry_point}()` not found in input file.\n")
-        return null
+        return (null, false)
     }
 
     let main_fn_type = LLVMFunctionType(types.t_int32,
@@ -522,13 +628,84 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     let entry = LLVMAppendBasicBlockInContext(ctx, main_fn, "entry")
     LLVMPositionBuilderAtEnd(builder, entry)
 
-    // Init modules. Right now we init only builtin modules.
-    // Custom modules is not implemented yet.
-    let das_initialize_type = LLVMFunctionType(types.t_void,
-        array<LLVMTypeRef>()
+    // Collect dynamic module names — used by CollectExternVisitor to skip dlopen'd modules
+    var dynamic_modules : table<string; bool>
+    for_each_registered_dynamic_module() <| $(path, mod_name, das_name) {
+        dynamic_modules[das_name] = true
+    }
+
+    // Init static modules — emit register_ClassName() for each used non-dynamic module
+    let register_mod_type = LLVMFunctionType(types.LLVMVoidPtrType(), array<LLVMTypeRef>())
+    let das_ensure_env_type = LLVMFunctionType(types.t_void, array<LLVMTypeRef>())
+    var das_ensure_env = LLVMAddFunctionWithType(g_mod, "das_ensure_environment", das_ensure_env_type)
+    LLVMBuildCall2(builder, das_ensure_env_type, das_ensure_env, array<LLVMValueRef>(), "")
+    var has_cpp_modules = false
+    for (mod_name in keys(used_modules)) {
+        if (key_exists(dynamic_modules, mod_name)) {
+            continue
+        }
+        prog |> for_each_module <| $(m) {
+            if (string(m.name) != mod_name) {
+                return
+            }
+            if (!empty(m.cppClassName)) {
+                has_cpp_modules = true
+                let reg_fn_name = "jit_register_{m.cppClassName}"
+                to_log(LOG_INFO, "LLVM EXE: NEED_MODULE({m.cppClassName}) for `{m.name}`\n")
+                var reg_fn = LLVMAddFunctionWithType(g_mod, reg_fn_name, register_mod_type)
+                LLVMBuildCall2(builder, register_mod_type, reg_fn, array<LLVMValueRef>(), "")
+            }
+        }
+    }
+
+    // Register dynamic modules that were loaded during compilation
+    let reg_dyn_mod_type = LLVMFunctionType(types.LLVMVoidPtrType(),
+        fixed_array<LLVMTypeRef>(
+            types.LLVMVoidPtrType(), // const char * path
+            types.LLVMVoidPtrType()  // const char * mod_name
+        )
     )
-    var das_initialize = LLVMAddFunctionWithType(g_mod, "jit_initialize_modules", das_initialize_type)
-    LLVMBuildCall2(builder, das_initialize_type, das_initialize, array<LLVMValueRef>(), "")
+    var jit_reg_dyn_mod = LLVMAddFunctionWithType(g_mod, "jit_register_dynamic_module", reg_dyn_mod_type)
+    for_each_registered_dynamic_module() <| $(path, mod_name, das_name) {
+        if (key_exists(used_modules, das_name)) {
+            has_cpp_modules = true
+            to_log(LOG_INFO, "LLVM EXE: include dynamic module: `{das_name}`\n")
+            let path_str = get_string_constant_ptr(builder, path)
+            let name_str = get_string_constant_ptr(builder, mod_name)
+            LLVMBuildCall2(builder, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(path_str, name_str), "")
+        }
+    }
+
+    // Register native paths (das include paths) that were loaded during compilation
+    let reg_native_path_type = LLVMFunctionType(types.t_void,
+        fixed_array<LLVMTypeRef>(
+            types.LLVMVoidPtrType(), // const char * mod_name
+            types.LLVMVoidPtrType(), // const char * src_path
+            types.LLVMVoidPtrType()  // const char * dst_path
+        )
+    )
+    var jit_reg_native_path = LLVMAddFunctionWithType(g_mod, "jit_register_native_path", reg_native_path_type)
+    for_each_registered_native_path() <| $(mod_name, src_path, dst_path) {
+        let mod_str = get_string_constant_ptr(builder, mod_name)
+        let src_str = get_string_constant_ptr(builder, src_path)
+        let dst_str = get_string_constant_ptr(builder, dst_path)
+        LLVMBuildCall2(builder, reg_native_path_type, jit_reg_native_path, fixed_array(mod_str, src_str, dst_str), "")
+    }
+
+    // Finalize module initialization after all static/dynamic modules are registered
+    if (has_cpp_modules) {
+        let init_done_type = LLVMFunctionType(types.t_void, array<LLVMTypeRef>())
+        var jit_init_done = LLVMAddFunctionWithType(g_mod, "jit_initialize_modules_done", init_done_type)
+        LLVMBuildCall2(builder, init_done_type, jit_init_done, array<LLVMValueRef>(), "")
+    }
+
+    // Call initialize_modules() — built by CollectExternVisitor during collect_external_functions
+    let init_modules_type = LLVMFunctionType(types.t_void, array<LLVMTypeRef>())
+    var init_modules_fn = LLVMGetNamedFunction(g_mod, "initialize_modules")
+    if (init_modules_fn == null) {
+        init_modules_fn = LLVMAddFunctionWithType(g_mod, "initialize_modules", init_modules_type)
+    }
+    LLVMBuildCall2(builder, init_modules_type, init_modules_fn, array<LLVMValueRef>(), "")
 
     // Init argc, argv
     let set_cmd_args_type = LLVMFunctionType(types.t_void,
@@ -581,12 +758,26 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     )
     let global_context = LLVMBuildCall2(builder, create_ctx_type, jit_create_context, params, "")
 
-    let any_unimplemented = collect_external_functions(global_context, ctx, builder, mod, types, funcs, uids)
+    let (any_unimplemented, sort_needs_whole_lib) = collect_external_functions(global_context, ctx, builder, mod, types, funcs, uids, used_modules, dynamic_modules)
     if (strict && any_unimplemented) {
         to_log(LOG_ERROR, "Some of the nodes above are unimplemented!\n")
-        return null
+        return (null, false)
+    }
+    // Determine if exe needs the whole compiler lib (rtti, ast, debugger, jit, sort-with-cblock)
+    var needs_whole_lib = sort_needs_whole_lib
+    for (mod_name in keys(used_modules)) {
+        if (mod_name == "rtti_core") {
+            needs_whole_lib = true
+            break
+        }
     }
 
+    // When linking whole compiler lib, register fusion engine (needed by simulate)
+    if (needs_whole_lib) {
+        let reg_fusion_type = LLVMFunctionType(types.t_void, array<LLVMTypeRef>())
+        let reg_fusion_fn = LLVMAddFunctionWithType(g_mod, "jit_register_fusion", reg_fusion_type)
+        LLVMBuildCall2(builder, reg_fusion_type, reg_fusion_fn, array<LLVMValueRef>(), "")
+    }
 
     let init_global_var_type = LLVMFunctionType(types.LLVMVoidPtrType(),
         fixed_array<LLVMTypeRef>(
@@ -651,5 +842,5 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
         LLVMBuildRet(builder, main_ret)
     }
     to_log(LOG_INFO, "LLVM JIT: standalone exe entry point generated '{start_fn_name}', {length(funcs)} functions\n")
-    return main_fn
+    return (main_fn, needs_whole_lib)
 }

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -668,23 +668,23 @@ def public with_default_target_machine(blk : block<(LLVMTargetMachineRef) : void
 // @path_to_dascript_lib - path to library, required on Windows. Has no effect on Linux.
 // @path_to_linker - path to clang-cl on Windows. By default we'll use clang-cl from LLVM package
 // on Windows, default otherwise.
-def public write_dll(mod : LLVMOpaqueModule?; out_path : string; path_to_dascript_lib, path_to_linker : string) {
+def public write_dll(mod : LLVMOpaqueModule?; out_path : string; path_to_dascript_lib, path_to_linker : string; link_whole_lib : bool) {
     with_default_target_machine() $(targetMachine : LLVMTargetMachineRef) {
         let error : string?
         let file = add_obj_extension(out_path)
         let filetype = LLVMCodeGenFileType.LLVMObjectFile
         LLVMTargetMachineEmitToFile(targetMachine, mod, file, filetype, error)
-        create_shared_library(file, add_dll_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", true)
+        create_shared_library(file, add_dll_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", true, link_whole_lib)
     }
 }
 
-def public write_exe(mod : LLVMOpaqueModule?; out_path : string; path_to_dascript_lib, path_to_linker : string) {
+def public write_exe(mod : LLVMOpaqueModule?; out_path : string; path_to_dascript_lib, path_to_linker : string; link_whole_lib : bool) {
     with_default_target_machine() $(targetMachine : LLVMTargetMachineRef) {
         let error : string?
         let file = add_obj_extension(out_path)
         let filetype = LLVMCodeGenFileType.LLVMObjectFile
         LLVMTargetMachineEmitToFile(targetMachine, mod, file, filetype, error)
-        create_shared_library(file, add_exe_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", false)
+        create_shared_library(file, add_exe_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", false, link_whole_lib)
     }
 }
 

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -17,6 +17,7 @@ require jit
 
 module llvm_macro shared private
 
+var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole library; when false, only against runtime
 
 struct JitState {
     dll : void?
@@ -185,8 +186,9 @@ class JIT_LLVM : AstSimulateMacro {
                     }
                 }
                 if (gen_exe) {
-                    let fn = inject_main(ctx, g_ctx, prog, exe_main, g_mod, g_prim_t, uids, exe_strict)
-                    if (fn == null) {
+                    let res = inject_main(ctx, g_ctx, prog, exe_main, g_mod, g_prim_t, uids, exe_strict)
+                    LINK_WHOLE_LIB = res.link_whole_lib
+                    if (res.fn == null) {
                         finalize_jit(use_dll, gen_exe, g_dynamic_lib_handle)
                         // JIT failed. Couldn't create executable.
                         // Still return true, macro worked correctly.
@@ -222,10 +224,10 @@ class JIT_LLVM : AstSimulateMacro {
                 }
                 if (gen_exe) {
                     mkdir_rec(dir_name(output_path))
-                    write_exe(g_mod, output_path, path_to_shared_lib, path_to_linker)
+                    write_exe(g_mod, output_path, path_to_shared_lib, path_to_linker, LINK_WHOLE_LIB)
                 } elif (use_dll) {
                     mkdir_rec(dir_name(output_path))
-                    write_dll(g_mod, output_path, path_to_shared_lib, path_to_linker)
+                    write_dll(g_mod, output_path, path_to_shared_lib, path_to_linker, LINK_WHOLE_LIB)
 
                     // Open just stored DLL, so we can keep working.
                     g_dynamic_lib_handle.reset()

--- a/src/ast/ast_module.cpp
+++ b/src/ast/ast_module.cpp
@@ -4,6 +4,7 @@
 #include "daScript/ast/ast_visitor.h"
 #include "daScript/das_common.h"
 #include "daScript/daScriptModule.h"
+#include "daScript/simulate/simulate_fusion.h"
 
 #include <atomic>
 
@@ -132,8 +133,6 @@ namespace das {
         }
     }
 
-    void resetFusionEngine();
-
     atomic<int> g_envTotal(0);
 
     void Module::Initialize() {
@@ -213,7 +212,8 @@ namespace das {
         delete daScriptEnvironment::getBound()->g_dyn_modules_resolve;
 
         clearGlobalAotLibrary();
-        resetFusionEngine();
+        DAS_ASSERTF(g_resetFusionEngineFn, "fusion library not loaded");
+        g_resetFusionEngineFn();
         daScriptEnvironment::setBound(nullptr);
         if ( daScriptEnvironment::getOwned() ) {
             delete daScriptEnvironment::getOwned();

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -5,6 +5,7 @@
 #include "daScript/ast/ast_expressions.h"
 #include "daScript/ast/ast_visitor.h"
 #include "daScript/ast/ast_simulate.h"
+#include "daScript/simulate/simulate_fusion.h"
 
 #include "daScript/simulate/runtime_array.h"
 #include "daScript/simulate/runtime_table_nodes.h"
@@ -22,6 +23,9 @@ das::Context * get_context ( int stackSize=0 );//link time resolved dependencies
 
 namespace das
 {
+    // fusion function pointers (defined here in main lib, set by fusion lib)
+    void (*g_fusionContextFn) ( Context & context, TextWriter & logs, bool enableFusion ) = nullptr;
+    void (*g_resetFusionEngineFn) () = nullptr;
     // topological sort for the [init] nodes
 
     struct InitSort {
@@ -3760,7 +3764,8 @@ namespace das
         bool aot_hint = policies.aot && !folding && !thisModule->isModule;
 #if DAS_FUSION
         if ( !folding ) {               // note: only run fusion when not folding
-            fusion(context, logs);
+            DAS_ASSERTF(g_fusionContextFn, "fusion library not loaded, add call to NEED_FUSION macro.");
+            g_fusionContextFn(context, logs, options.getBoolOption("fusion",true));
             context.relocateCode(true); // this to get better estimate on relocated size. its fust enough
         }
 #else

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -871,6 +871,9 @@ namespace das {
         Fail,           // error message is displayed and exception is thrown
     };
 
+    static vector<tuple<string,string,string>> g_registered_dynamic_modules; // path, cpp_class_name, daslang_name
+    static vector<tuple<string,string,string>> g_registered_native_paths;
+
     // Returns DLL handle.
     void *register_dynamic_module(const char *path, const char *mod_name, int on_error, Context * context, LineInfoArg * at ) {
         string actualPath(path);
@@ -916,6 +919,7 @@ namespace das {
             return nullptr;
         }
         *ModuleKarma += unsigned(intptr_t(mod));
+        g_registered_dynamic_modules.emplace_back(path, mod_name, mod->name);
         return lib;
     }
     void *register_dynamic_module_silent(const char *path, const char *mod_name, Context * context, LineInfoArg * at ) {
@@ -938,6 +942,19 @@ namespace das {
             cur_mod = prev(mod_resolve->end());
         }
         cur_mod->paths.emplace_back(src_path, dst_path);
+        g_registered_native_paths.emplace_back(mod_name, src_path, dst_path);
+    }
+
+    void for_each_registered_native_path ( const TBlock<void,const char *,const char *,const char *> & block, Context * context, LineInfoArg * at ) {
+        for ( const auto & [mod_name, src_path, dst_path] : g_registered_native_paths ) {
+            das_invoke<void>::invoke<const char *,const char *,const char *>(context, at, block, mod_name.c_str(), src_path.c_str(), dst_path.c_str());
+        }
+    }
+
+    void for_each_registered_dynamic_module ( const TBlock<void,const char *,const char *,const char *> & block, Context * context, LineInfoArg * at ) {
+        for ( const auto & [path, mod_name, das_name] : g_registered_dynamic_modules ) {
+            das_invoke<void>::invoke<const char *,const char *,const char *>(context, at, block, path.c_str(), mod_name.c_str(), das_name.c_str());
+        }
     }
 
     char * sanitize_command_line ( const char * cmd, Context * context, LineInfoArg * at ) {
@@ -1351,6 +1368,12 @@ namespace das {
             addExtern<DAS_BIND_FUN(register_native_path)>(*this, lib, "register_native_path",
                 SideEffects::worstDefault, "register_native_path")
                     ->args({"mod_name", "src", "dst", "context","at"});
+            addExtern<DAS_BIND_FUN(for_each_registered_dynamic_module)>(*this, lib, "for_each_registered_dynamic_module",
+                SideEffects::accessExternal, "for_each_registered_dynamic_module")
+                    ->args({"block", "context","at"});
+            addExtern<DAS_BIND_FUN(for_each_registered_native_path)>(*this, lib, "for_each_registered_native_path",
+                SideEffects::accessExternal, "for_each_registered_native_path")
+                    ->args({"block", "context","at"});
             addExtern<DAS_BIND_FUN(sanitize_command_line)>(*this, lib, "sanitize_command_line",
                 SideEffects::none, "sanitize_command_line")
                     ->args({"var","context","at"});

--- a/src/builtin/module_builtin_jobque.cpp
+++ b/src/builtin/module_builtin_jobque.cpp
@@ -581,6 +581,7 @@ namespace das {
             // libs
             ModuleLibrary lib(this);
             lib.addBuiltInModule();
+            addBuiltinDependency(lib, Module::require("rtti_core"));
             // types
             addAnnotation(new JobStatusAnnotation(lib));
             auto cha = new ChannelAnnotation(lib);

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -237,6 +237,7 @@ namespace das {
     struct ModuleAnnotation : ManagedStructureAnnotation<Module,false> {
         ModuleAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation ("Module", ml) {
             addField<DAS_BIND_MANAGED_FIELD(name)>("name");
+            addField<DAS_BIND_MANAGED_FIELD(cppClassName)>("cppClassName");
             addField<DAS_BIND_MANAGED_FIELD(fileName)>("fileName");
             addFieldEx ( "moduleFlags", "moduleFlags", offsetof(Module, moduleFlags), makeModuleFlags() );
         }

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -35,6 +35,10 @@
 #include <inttypes.h>
 
 namespace das {
+    // forward declarations from module_builtin_fio.cpp
+    void * register_dynamic_module(const char *, const char *, int, Context *, LineInfoArg *);
+    void register_native_path(const char *, const char *, const char *, Context *, LineInfoArg *);
+
     typedef vec4f ( * JitFunction ) ( Context * , vec4f *, void * );
 
     struct SimNode_Jit : SimNode {
@@ -718,44 +722,64 @@ extern "C" {
         }
     }
 
-    static pair<string, string> get_real_lib_linker_paths(const char * dasLib, const char * customLinker) {
-        string linker = customLinker != nullptr ? customLinker : "";
-        string dasLibrary = dasLib != nullptr ? dasLib : "";
-        if (linker.empty() || dasLibrary.empty()) {
+    struct LinkerPaths {
+        string linker;
+        string runtimeLibrary;  // always needed
+        string compilerLibrary; // non-empty when linkWholeLib — exe also needs compiler lib
+    };
+
+    static LinkerPaths get_real_lib_linker_paths(const char * dasLib, const char * customLinker, bool isShared, bool linkWholeLib) {
+        LinkerPaths result;
+        result.linker = customLinker != nullptr ? customLinker : "";
+        result.runtimeLibrary = dasLib != nullptr ? dasLib : "";
+
+        if (result.linker.empty() || result.runtimeLibrary.empty()) {
             #if defined(_WIN32) || defined(_WIN64)
-                if (linker.empty()) {
-                    linker = getDasRoot() + "/bin/clang-cl.exe";
+                if (result.linker.empty()) {
+                    result.linker = getDasRoot() + "/bin/clang-cl.exe";
                 }
-                if (dasLibrary.empty()) {
+                if (result.runtimeLibrary.empty()) {
                     const auto path = get_prefix(getExecutableFileName());
                     const auto winCfg = path.substr(path.find_last_of("\\/") + 1);
                     const auto windowsConfig = (winCfg == "bin" ? "" : (winCfg + "/"));
-                    dasLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn.lib";
+                    result.runtimeLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn.lib";
+                    if (linkWholeLib) {
+                        result.compilerLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn.lib";
+                    }
                 }
             #else
-                if (linker.empty()) {
-                    linker = "c++";
+                if (result.linker.empty()) {
+                    result.linker = "c++";
                 }
-                if (dasLibrary.empty()) {
+                if (result.runtimeLibrary.empty()) {
                 #if defined(__APPLE__)
-                    dasLibrary = getDasRoot() + "/lib/liblibDaScriptDyn.dylib";
+                    result.runtimeLibrary = getDasRoot() + "/lib/liblibDaScriptDyn.dylib";
+                    if (linkWholeLib) {
+                        result.compilerLibrary = getDasRoot() + "/lib/liblibDaScriptDyn.dylib";
+                    }
                 #else
-                    dasLibrary = getDasRoot() + "/lib/liblibDaScriptDyn.so";
+                    result.runtimeLibrary = getDasRoot() + "/lib/liblibDaScriptDyn.so";
+                    if (linkWholeLib) {
+                        result.compilerLibrary = getDasRoot() + "/lib/liblibDaScriptDyn.so";
+                    }
                 #endif
                 }
             #endif
         }
-        return {linker, dasLibrary};
+        return result;
     }
 
 #if (defined(_MSC_VER) || defined(__linux__) || defined(__APPLE__)) && !defined(_GAMING_XBOX) && !defined(_DURANGO)
-    void create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, bool isShared, Context *context ) {
+    void create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, bool isShared, bool linkWholeLib, Context *context ) {
         char cmd[1024];
-        const auto [linker, dasLibrary] = get_real_lib_linker_paths(dasLib, customLinker);
+        const auto paths = get_real_lib_linker_paths(dasLib, customLinker, isShared, linkWholeLib);
+        const auto & linker = paths.linker;
+        const auto & runtimeLibrary = paths.runtimeLibrary;
+        const auto & compilerLibrary = paths.compilerLibrary;
 
         #if defined(_WIN32) || defined(_WIN64) || defined(__APPLE__)
-        if (!check_file_present(dasLibrary.c_str())) {
-            LOG(LogLevel::error) << "File '" << dasLibrary << "' , containing daslang library, does not exist\n";
+        if (!check_file_present(runtimeLibrary.c_str())) {
+            LOG(LogLevel::error) << "File '" << runtimeLibrary << "' , containing daslang runtime library, does not exist\n";
             return;
         }
         #endif
@@ -767,16 +791,23 @@ extern "C" {
 
         #if defined(_WIN32) || defined(_WIN64)
             const auto linkerParam = isShared ? "-DLL" : "";
-            auto result = fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" msvcrt.lib -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, dasLibrary, linkerParam, libraryName);
+            auto result = compilerLibrary.empty()
+                ? fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" msvcrt.lib -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, linkerParam, libraryName)
+                : fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" \"{}\" msvcrt.lib -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, compilerLibrary, linkerParam, libraryName);
         #elif defined(__APPLE__)
             const auto linkerParam = isShared ? "-shared " : "";
-            const auto rpath = "-Wl,-rpath," + get_prefix(dasLibrary);
-            auto result = fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" 2>&1"), linker, linkerParam, rpath, libraryName, dasLibrary, objFilePath);
+            const auto rpath = "-Wl,-rpath," + get_prefix(runtimeLibrary);
+            auto result = compilerLibrary.empty()
+                ? fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" 2>&1"), linker, linkerParam, rpath, libraryName, runtimeLibrary, objFilePath)
+                : fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" \"{}\" 2>&1"), linker, linkerParam, rpath, libraryName, runtimeLibrary, compilerLibrary, objFilePath);
         #else
             const auto linkerParam = isShared ? "-shared" : "";
-            const auto rpath = "-Wl,-rpath," + get_prefix(dasLibrary);
-            auto result = fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" 2>&1"),
-                                        linker, linkerParam, rpath, libraryName, objFilePath, dasLibrary);
+            const auto rpath = "-Wl,-rpath," + get_prefix(runtimeLibrary);
+            auto result = compilerLibrary.empty()
+                ? fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" 2>&1"),
+                                        linker, linkerParam, rpath, libraryName, objFilePath, runtimeLibrary)
+                : fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -Wl,--no-as-needed -o \"{}\" \"{}\" \"{}\" \"{}\" 2>&1"),
+                                        linker, linkerParam, rpath, libraryName, objFilePath, runtimeLibrary, compilerLibrary);
         #endif
             *result = '\0';
 
@@ -822,7 +853,7 @@ extern "C" {
         }
     }
 #else
-    void create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, bool isShared, Context *context ) { }
+    void create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, bool isShared, bool linkWholeLib, Context *context ) { }
 #endif
 
     void jit_set_jit_state(Context & context, void *shared_lib, void *llvm_ee, void *llvm_context) {
@@ -969,7 +1000,7 @@ extern "C" {
                     ->args({"library"});
             addExtern<DAS_BIND_FUN(create_shared_library)>(*this, lib,  "create_shared_library",
                 SideEffects::worstDefault, "create_shared_library")
-                    ->args({"objFilePath","libraryName","dasLib","customLinker", "isShared", "context"});
+                    ->args({"objFilePath","libraryName","dasLib","customLinker", "isShared", "linkWholeLib", "context"});
             addExtern<DAS_BIND_FUN(jit_set_jit_state)>(*this, lib,  "set_jit_state",
                 SideEffects::worstDefault, "jit_set_jit_state")
                     ->args({"context","shared_lib","llvm_ee","llvm_ctx"});
@@ -994,21 +1025,25 @@ extern "C" {
 
 REGISTER_MODULE_IN_NAMESPACE(Module_Jit,das);
 
-static void init() {
-    NEED_ALL_DEFAULT_MODULES;
-    NEED_MODULE(Module_UriParser);
-    NEED_MODULE(Module_JobQue);
+extern "C" {
+DAS_API void das_ensure_environment () {
+    das::daScriptEnvironment::ensure();
 }
 
-extern "C" {
 DAS_API void jit_initialize_modules () {
-    init();
-#ifdef DAS_ENABLE_DYN_INCLUDES
+    // No need to initialize modules. JIT will generate required calls.
     das::daScriptEnvironment::ensure();
-    auto access = das::make_smart<das::FsFileAccess>();
-    das::TextPrinter tout;
-    das::require_dynamic_modules(access, das::getDasRoot(), "", tout);
-#endif
+}
+
+DAS_API void jit_initialize_modules_done () {
     das::Module::Initialize();
+}
+
+DAS_API void * jit_register_dynamic_module ( const char * path, const char * mod_name ) {
+    return das::register_dynamic_module(path, mod_name, 0/*Quiet*/, nullptr, nullptr);
+}
+
+DAS_API void jit_register_native_path ( const char * mod_name, const char * src_path, const char * dst_path ) {
+    das::register_native_path(mod_name, src_path, dst_path, nullptr, nullptr);
 }
 }

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -742,7 +742,7 @@ extern "C" {
                     const auto path = get_prefix(getExecutableFileName());
                     const auto winCfg = path.substr(path.find_last_of("\\/") + 1);
                     const auto windowsConfig = (winCfg == "bin" ? "" : (winCfg + "/"));
-                    result.runtimeLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn.lib";
+                    result.runtimeLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn_runtime.lib";
                     if (linkWholeLib) {
                         result.compilerLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn.lib";
                     }
@@ -753,12 +753,12 @@ extern "C" {
                 }
                 if (result.runtimeLibrary.empty()) {
                 #if defined(__APPLE__)
-                    result.runtimeLibrary = getDasRoot() + "/lib/liblibDaScriptDyn.dylib";
+                    result.runtimeLibrary = getDasRoot() + "/lib/liblibDaScriptDyn_runtime.dylib";
                     if (linkWholeLib) {
                         result.compilerLibrary = getDasRoot() + "/lib/liblibDaScriptDyn.dylib";
                     }
                 #else
-                    result.runtimeLibrary = getDasRoot() + "/lib/liblibDaScriptDyn.so";
+                    result.runtimeLibrary = getDasRoot() + "/lib/liblibDaScriptDyn_runtime.so";
                     if (linkWholeLib) {
                         result.compilerLibrary = getDasRoot() + "/lib/liblibDaScriptDyn.so";
                     }

--- a/src/builtin/modules.cpp
+++ b/src/builtin/modules.cpp
@@ -3,6 +3,7 @@
 
 static void register_builtin_modules_impl() {
     using das::Module;
+    NEED_FUSION;
     if (!Module::require("$")) {
         NEED_MODULE(Module_BuiltIn);
     }

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -98,20 +98,20 @@ void das_initialize_modules() {
 
 extern "C" {
 
-DAS_API uint32_t SIDEEFFECTS_none = uint32_t(SideEffects::none);
-DAS_API uint32_t SIDEEFFECTS_unsafe = uint32_t(SideEffects::unsafe);
-DAS_API uint32_t SIDEEFFECTS_userScenario = uint32_t(SideEffects::userScenario);
-DAS_API uint32_t SIDEEFFECTS_modifyExternal = uint32_t(SideEffects::modifyExternal);
-DAS_API uint32_t SIDEEFFECTS_accessExternal = uint32_t(SideEffects::accessExternal);
-DAS_API uint32_t SIDEEFFECTS_modifyArgument = uint32_t(SideEffects::modifyArgument);
-DAS_API uint32_t SIDEEFFECTS_modifyArgumentAndExternal = uint32_t(SideEffects::modifyArgumentAndExternal);
-DAS_API uint32_t SIDEEFFECTS_worstDefault = uint32_t(SideEffects::worstDefault);
-DAS_API uint32_t SIDEEFFECTS_accessGlobal = uint32_t(SideEffects::accessGlobal);
-DAS_API uint32_t SIDEEFFECTS_invoke =  uint32_t(SideEffects::invoke);
-DAS_API uint32_t SIDEEFFECTS_inferredSideEffects =  uint32_t(SideEffects::inferredSideEffects);
+DAS_CC_API uint32_t SIDEEFFECTS_none = uint32_t(SideEffects::none);
+DAS_CC_API uint32_t SIDEEFFECTS_unsafe = uint32_t(SideEffects::unsafe);
+DAS_CC_API uint32_t SIDEEFFECTS_userScenario = uint32_t(SideEffects::userScenario);
+DAS_CC_API uint32_t SIDEEFFECTS_modifyExternal = uint32_t(SideEffects::modifyExternal);
+DAS_CC_API uint32_t SIDEEFFECTS_accessExternal = uint32_t(SideEffects::accessExternal);
+DAS_CC_API uint32_t SIDEEFFECTS_modifyArgument = uint32_t(SideEffects::modifyArgument);
+DAS_CC_API uint32_t SIDEEFFECTS_modifyArgumentAndExternal = uint32_t(SideEffects::modifyArgumentAndExternal);
+DAS_CC_API uint32_t SIDEEFFECTS_worstDefault = uint32_t(SideEffects::worstDefault);
+DAS_CC_API uint32_t SIDEEFFECTS_accessGlobal = uint32_t(SideEffects::accessGlobal);
+DAS_CC_API uint32_t SIDEEFFECTS_invoke =  uint32_t(SideEffects::invoke);
+DAS_CC_API uint32_t SIDEEFFECTS_inferredSideEffects =  uint32_t(SideEffects::inferredSideEffects);
 
-DAS_API uint32_t DAS_CONTEXT_CATEGORY_THREAD_CLONE = uint32_t(ContextCategory::thread_clone);
-DAS_API uint32_t DAS_CONTEXT_CATEGORY_JOB_CLONE = uint32_t(ContextCategory::job_clone);
+DAS_CC_API uint32_t DAS_CONTEXT_CATEGORY_THREAD_CLONE = uint32_t(ContextCategory::thread_clone);
+DAS_CC_API uint32_t DAS_CONTEXT_CATEGORY_JOB_CLONE = uint32_t(ContextCategory::job_clone);
 
 void das_initialize() {
     das_initialize_modules();

--- a/src/simulate/simulate_fusion.cpp
+++ b/src/simulate/simulate_fusion.cpp
@@ -216,9 +216,9 @@ namespace das {
         das_hash_map<SimNode *,SimNodeInfo> & info;
     };
 
-    void Program::fusion ( Context & context, TextWriter & logs ) {
+    void fusionContext ( Context & context, TextWriter & logs, bool enableFusion ) {
         // log all functions
-        if ( options.getBoolOption("fusion",true) ) {
+        if ( enableFusion ) {
             bool anyFusion = true;
             while ( anyFusion) {
                 anyFusion = false;
@@ -247,6 +247,12 @@ namespace das {
     void registerFusion ( const char * OpName, const char * CTypeName, FusionPoint * node ) {
         (**g_fusionEngine)[fuseName(OpName,CTypeName)].emplace_back(node);
     }
+
+}
+
+DAS_CC_API void register_fusion () {
+    das::g_fusionContextFn = &das::fusionContext;
+    das::g_resetFusionEngineFn = &das::resetFusionEngine;
 }
 
 extern "C" DAS_CC_API void jit_register_fusion () {

--- a/src/simulate/simulate_fusion.cpp
+++ b/src/simulate/simulate_fusion.cpp
@@ -249,3 +249,7 @@ namespace das {
     }
 }
 
+extern "C" DAS_CC_API void jit_register_fusion () {
+    register_fusion();
+}
+


### PR DESCRIPTION
For now runtime has almost everything except fusion. In future it should contain minimal closure of sources required to run das programs as a standalone executable.