### PR TITLE
fio: throw on invalid fopen mode instead of returning null

### DIFF
--- a/include/daScript/simulate/aot_builtin_fio.h
+++ b/include/daScript/simulate/aot_builtin_fio.h
@@ -45,7 +45,7 @@ namespace das {
     };
 #endif
 
-    DAS_API const FILE * builtin_fopen  ( const char * name, const char * mode );
+    DAS_API const FILE * builtin_fopen  ( const char * name, const char * mode, Context * context, LineInfoArg * at );
     DAS_API void builtin_fclose ( const FILE * f, Context * context, LineInfoArg * at );
     DAS_API void builtin_fflush ( const FILE * f, Context * context, LineInfoArg * at );
     DAS_API void builtin_fprint ( const FILE * f, const char * text, Context * context, LineInfoArg * at );

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -252,8 +252,18 @@ namespace das {
         if ( text ) fputs(text,(FILE *)f);
     }
 
+    static bool is_valid_fopen_mode(const char *mode) {
+        if (!mode || (mode[0] != 'r' && mode[0] != 'w' && mode[0] != 'a'))
+            return false;
+        for (const char *p = mode + 1; *p; ++p) {
+            if (*p != '+' && *p != 'b' && *p != 't' && *p != 'x')
+                return false;
+        }
+        return true;
+    }
+
     const FILE * builtin_fopen  ( const char * name, const char * mode ) {
-        if ( name && mode ) {
+        if ( name && is_valid_fopen_mode(mode)) {
             FILE * f = fopen(name, mode);
             if ( f ) setvbuf(f, NULL, _IOFBF, 65536);
             return f;

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -160,7 +160,7 @@ namespace das {
     const FILE * builtin_stdout() GENERATE_IO_STUB_RET
     const FILE * builtin_stderr() GENERATE_IO_STUB_RET
     bool builtin_feof(const FILE* _f) GENERATE_IO_STUB_RET
-    const FILE * builtin_fopen  ( const char * name, const char * mode ) GENERATE_IO_STUB_RET
+    const FILE * builtin_fopen  ( const char * name, const char * mode, Context *, LineInfoArg * ) GENERATE_IO_STUB_RET
     vec4f builtin_read ( Context & context, SimNode_CallBase * call, vec4f * args ) GENERATE_IO_STUB_RET
     vec4f builtin_write ( Context & context, SimNode_CallBase * call, vec4f * args ) GENERATE_IO_STUB_RET
     vec4f builtin_load ( Context & context, SimNode_CallBase * node, vec4f * args ) GENERATE_IO_STUB_RET
@@ -253,23 +253,15 @@ namespace das {
     }
 
     static bool is_valid_fopen_mode(const char *mode) {
-        if (!mode || (mode[0] != 'r' && mode[0] != 'w' && mode[0] != 'a'))
-            return false;
-        for (const char *p = mode + 1; *p; ++p) {
-            if (*p != '+' && *p != 'b' && *p != 't' && *p != 'x')
-                return false;
-        }
-        return true;
+        return mode && strchr("rwa", mode[0]) && mode[1 + strspn(mode + 1, "+btx")] == '\0';
     }
 
-    const FILE * builtin_fopen  ( const char * name, const char * mode ) {
-        if ( name && is_valid_fopen_mode(mode)) {
-            FILE * f = fopen(name, mode);
-            if ( f ) setvbuf(f, NULL, _IOFBF, 65536);
-            return f;
-        } else {
-            return nullptr;
-        }
+    const FILE * builtin_fopen  ( const char * name, const char * mode, Context * context, LineInfoArg * at ) {
+        if ( !name ) context->throw_error_at(at, "can't fopen NULL name");
+        if ( !is_valid_fopen_mode(mode) ) context->throw_error_at(at, "invalid fopen mode '%s'", mode ? mode : "<null>");
+        FILE * f = fopen(name, mode);
+        if ( f ) setvbuf(f, NULL, _IOFBF, 65536);
+        return f;
     }
 
     void builtin_fclose ( const FILE * f, Context * context, LineInfoArg * at ) {
@@ -1242,7 +1234,7 @@ namespace das {
                     ->args({"path","error","context","at"});
             addExtern<DAS_BIND_FUN(builtin_fopen)>(*this, lib, "fopen",
                 SideEffects::modifyExternal, "builtin_fopen")
-                    ->args({"name","mode"})->setNoDiscard();
+                    ->args({"name","mode","context","line"})->setNoDiscard();
             addExtern<DAS_BIND_FUN(builtin_fclose)>(*this, lib, "fclose",
                 SideEffects::modifyExternal, "builtin_fclose")
                     ->args({"file","context","line"});

--- a/tests/fio/fio_errors.das
+++ b/tests/fio/fio_errors.das
@@ -251,3 +251,47 @@ def test_mkdir_result(t : T?) {
         t |> success(!empty(unsafe(r.error)), "error should be non-empty")
     }
 }
+
+// ---- fopen mode validation ----
+
+def expect_fopen_throws(t : T?; mode : string) {
+    var threw = false
+    try {
+        let f = fopen("_fopen_bad_mode_test_99999.tmp", mode)
+        if (f != null) {
+            fclose(f)
+        }
+    } recover {
+        threw = true
+    }
+    t |> success(threw, "fopen with mode '{mode}' should throw, not fail silently")
+}
+
+[test]
+def test_fopen_invalid_mode(t : T?) {
+    t |> run("empty mode throws") @(t : T?) {
+        expect_fopen_throws(t, "")
+    }
+    t |> run("unknown first char throws") @(t : T?) {
+        expect_fopen_throws(t, "q")
+    }
+    t |> run("unknown modifier throws") @(t : T?) {
+        expect_fopen_throws(t, "rX")
+    }
+    t |> run("garbage mode throws") @(t : T?) {
+        expect_fopen_throws(t, "zzz")
+    }
+    t |> run("valid mode does not throw") @(t : T?) {
+        var threw = false
+        try {
+            let f = fopen("_no_such_file_for_fopen_test_99999.xyz", "rb")
+            // missing file returns null, but must not throw
+            if (f != null) {
+                fclose(f)
+            }
+        } recover {
+            threw = true
+        }
+        t |> success(!threw, "valid mode should not throw even when file is missing")
+    }
+}


### PR DESCRIPTION
## Summary
- `builtin_fopen` now calls `context->throw_error_at(at, ...)` on invalid mode instead of silently returning `nullptr`. Silent failure was indistinguishable from "file not found" at the call site — any caller that forwards a bad mode will now get a daslang runtime error pointing at the offending call.
- Also throws on `NULL` name, matching the style of `builtin_fclose` / `builtin_fflush` / `builtin_fprint`.
- `is_valid_fopen_mode` collapsed to a one-liner using `strchr` + `strspn` (per review feedback).

## Test plan
- [x] New `tests/fio/fio_errors.das::test_fopen_invalid_mode` covers:
  - empty mode `""` throws
  - unknown first char `"q"` throws
  - unknown modifier `"rX"` throws
  - garbage mode `"zzz"` throws
  - valid mode `"rb"` on a missing file still returns null without throwing
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/fio/` — 80/80 pass
