### PR TITLE
strudel: documentation pass — reference, tutorials, comparison, porting skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/version_update.md` | Bumping the daslang version number (all files that need updating) |
 | `skills/jobque_debugging.md` | Debugging Channel/LockBox/JobStatus/Feature leaks using the tracking system (`--track-job-status`, `DumpJobQueLeaks`, refcount tracing) |
 | `skills/make_pr.md` | Creating a pull request (lint, test, AOT build+test, format checklist) |
+| `skills/strudel_port.md` | Copy-pasting a strudel.cc pattern (user-level live-coding expression) into daslang |
 
 Multiple skill files may apply to a single task. For example, creating a new daslib module requires reading `skills/das_formatting.md`, `skills/daslib_modules.md`, and possibly `skills/documentation_rst.md`.
 

--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -576,7 +576,7 @@ def describe_type(td : TypeDecl?) {
         // if td.flags.constant
         //     write(writer," const")
         for (d in td.dim) {
-            write(writer, "[")
+            write(writer, "\\ [")
             write(writer, d)
             write(writer, "]")
         }

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -101,8 +101,20 @@ require stbimage/stbimage_boost
 require stbimage/stbimage_ttf
 require audio/audio_boost
 require audio/audio_wav
+require strudel/strudel_event
+require strudel/strudel_time
+require strudel/strudel_live
+require strudel/strudel_scales
+require strudel/strudel_mini
+require strudel/strudel_samples
+require strudel/strudel_synth
+require strudel/strudel_scheduler
+require strudel/strudel_player
 require strudel/strudel_midi
+require strudel/strudel_midi_player
 require strudel/strudel_sf2
+require strudel/strudel_sf2_voice
+require strudel/strudel_pattern
 
 def document_module_math(root : string) {
     var mod = get_module("math")
@@ -1313,6 +1325,96 @@ def document_module_audio_wav(root : string) {
     document("WAV file reading and writing", mod, "audio_wav.rst", groups)
 }
 
+def document_module_strudel_event(root : string) {
+    var mod = find_module("strudel_event")
+    var groups <- array<DocGroup>(
+        group_by_regex("ADSR and delay resolution", mod, %regex~(resolve_adsr|resolve_delaytime)$%%)
+    )
+    document("Event payload and ADSR/delay-time resolvers", mod, "strudel_event.rst", groups)
+}
+
+def document_module_strudel_time(root : string) {
+    var mod = find_module("strudel_time")
+    var groups <- array<DocGroup>(
+        group_by_regex("Cycle math", mod, %regex~(cyclePos|sameCycle|splitSpans)$%%)
+    )
+    document("Cycle-space time primitives: TimeSpan, Hap, and cycle helpers", mod, "strudel_time.rst", groups)
+}
+
+def document_module_strudel_live(root : string) {
+    var mod = find_module("strudel_live")
+    var groups <- array<DocGroup>(
+        group_by_regex("Live-reload state", mod, %regex~(save_strudel_state|restore_strudel_state)$%%)
+    )
+    document("Live-reload state preservation", mod, "strudel_live.rst", groups)
+}
+
+def document_module_strudel_scales(root : string) {
+    var mod = find_module("strudel_scales")
+    var groups <- array<DocGroup>(
+        group_by_regex("Scale and note selection", mod, %regex~(scale|set_scale|scale_pattern|get_scale_intervals_by_name|degree_to_note|parse_root)$%%)
+    )
+    document("Musical scales and note-name helpers", mod, "strudel_scales.rst", groups)
+}
+
+def document_module_strudel_mini(root : string) {
+    var mod = find_module("strudel_mini")
+    var groups <- array<DocGroup>(
+        group_by_regex("Tokenizer and parser", mod, %regex~(tokenize|parse_note_name|parse_note_name_default)$%%),
+        group_by_regex("Fluent DSL constructors", mod, %regex~(s|n|note_pattern|seq|note|vowel|set_s|set_vowel)$%%),
+        group_by_regex("Cycle-rate variants", mod, %regex~(every_fast|every_slow|every_degrade)$%%)
+    )
+    document("Mini-notation tokenizer, parser, and fluent-DSL entry points", mod, "strudel_mini.rst", groups)
+}
+
+def document_module_strudel_samples(root : string) {
+    var mod = find_module("strudel_samples")
+    var groups <- array<DocGroup>(
+        group_by_regex("Loading", mod, %regex~(load_audio_file|load_sound|load_audio_memory|load_sound_memory)$%%),
+        group_by_regex("Rendering", mod, %regex~(render_sample)$%%)
+    )
+    document("Sample bank and audio file loading", mod, "strudel_samples.rst", groups)
+}
+
+def document_module_strudel_synth(root : string) {
+    var mod = find_module("strudel_synth")
+    var groups <- array<DocGroup>(
+        group_by_regex("Pitch conversion", mod, %regex~(note_to_freq)$%%),
+        group_by_regex("Noise generators", mod, %regex~(noise)$%%),
+        group_by_regex("Drum renderers", mod, %regex~render_(bd|sd|hh|cp|oh|tom|ride|crash|rimshot|cowbell|tambourine)$%%),
+        group_by_regex("Oscillator type", mod, %regex~(to_osc_type)$%%),
+        group_by_regex("Voice FX chain", mod, %regex~(fx_init_from_event|fx_apply|fx_apply_to_samples)$%%),
+        group_by_regex("Oscillator voice", mod, %regex~(osc_voice_init_supersaw|osc_voice_init_filters|osc_render_chunk)$%%),
+        group_by_regex("Vowel filter", mod, %regex~(vowel_get_formant_data|vowel_filter_init|vowel_filter_tick|formant_biquad_setup_bpf|formant_biquad_tick)$%%),
+        group_by_regex("Voice rendering", mod, %regex~(render_event_stereo|mono_to_stereo)$%%)
+    )
+    document("Audio synthesis: oscillators, drums, filters, and effects", mod, "strudel_synth.rst", groups)
+}
+
+def document_module_strudel_scheduler(root : string) {
+    var mod = find_module("strudel_scheduler")
+    var groups <- array<DocGroup>(
+        group_by_regex("Orbit effects", mod, %regex~(init_reverb|init_chorus|init_delay|get_orbit_reverb|get_orbit_delay)$%%),
+        group_by_regex("Scheduler lifecycle", mod, %regex~(tick|shutdown_scheduler)$%%)
+    )
+    document("Voice allocation, effect bus routing, and per-tick mixing", mod, "strudel_scheduler.rst", groups)
+}
+
+def document_module_strudel_player(root : string) {
+    var mod = find_module("strudel_player")
+    var groups <- array<DocGroup>(
+        group_by_regex("Lifecycle", mod, %regex~strudel_(init|shutdown|create_channel)$%%),
+        group_by_regex("Playback control", mod, %regex~strudel_(play|stop|set_pause|is_playing|noop_cmd|tick|tick_offline|command)$%%),
+        group_by_regex("Tempo and timing", mod, %regex~strudel_(set_bpm|set_cps|get_bpm|get_cps|get_playback_time|set_look_ahead)$%%),
+        group_by_regex("Volume", mod, %regex~strudel_(set_volume|get_volume)$%%),
+        group_by_regex("Asset loading", mod, %regex~strudel_(load_sound|load_sample_dir|load_sf2|get_sf2_path|has_sf2)$%%),
+        group_by_regex("Track management", mod, %regex~strudel_(add_track|remove_track|fade_track)$%%),
+        group_by_regex("State serialization", mod, %regex~strudel_(save_state|restore_state|save_sf2_state|restore_sf2_state)$%%),
+        group_by_regex("Debug and diagnostics", mod, %regex~strudel_(debug_memory|reset_memory_baseline|debug_sample_peaks|debug_master_peak|debug_output_peak|debug_voices)$%%)
+    )
+    document("Top-level playback harness: tracks, BPM/CPS, and threaded audio", mod, "strudel_player.rst", groups)
+}
+
 def document_module_strudel_midi(root : string) {
     var mod = find_module("strudel_midi")
     var groups <- array<DocGroup>(
@@ -1321,6 +1423,19 @@ def document_module_strudel_midi(root : string) {
         group_by_regex("Binary readers", mod, %regex~(read_byte|read_u16|read_u32|read_vlq)$%%)
     )
     document("MIDI file parser", mod, "strudel_midi.rst", groups)
+}
+
+def document_module_strudel_midi_player(root : string) {
+    var mod = find_module("strudel_midi_player")
+    var groups <- array<DocGroup>(
+        group_by_regex("Lifecycle", mod, %regex~midi_(init|shutdown|init_reverb)$%%),
+        group_by_regex("Playback control", mod, %regex~midi_(play|play_data|stop|set_pause|is_playing|tick)$%%),
+        group_by_regex("Audio setup", mod, %regex~midi_(set_volume|set_audio_vis_channel)$%%),
+        group_by_regex("Asset loading", mod, %regex~midi_(load_samples|load_sf2)$%%),
+        group_by_regex("Event processing", mod, %regex~(init_playback|process_events)$%%),
+        group_by_regex("Drum and GM preset rendering", mod, %regex~(render_drum_hit|gm_preset|midi_adsr)$%%)
+    )
+    document("MIDI file playback with GM preset mapping", mod, "strudel_midi_player.rst", groups)
 }
 
 def document_module_strudel_sf2(root : string) {
@@ -1333,6 +1448,36 @@ def document_module_strudel_sf2(root : string) {
         group_by_regex("Modulator source helpers", mod, %regex~(sf2_mod_src)%%)
     )
     document("SoundFont 2 file parser", mod, "strudel_sf2.rst", groups)
+}
+
+def document_module_strudel_sf2_voice(root : string) {
+    var mod = find_module("strudel_sf2_voice")
+    var groups <- array<DocGroup>(
+        group_by_regex("Envelope", mod, %regex~sf2_env_(start|tick)$%%),
+        group_by_regex("LFO", mod, %regex~sf2_lfo_tick$%%),
+        group_by_regex("Modulators", mod, %regex~sf2_(velocity_attenuation|mod_get_value|apply_modulators|mod_identity_match|apply_default_modulators|default_cc_values|collect_atten_modulators|recalc_atten)$%%),
+        group_by_regex("Voice creation", mod, %regex~sf2_(create_c_voice|get_exclusive_class|get_reverb_send|get_chorus_send)$%%)
+    )
+    document("SoundFont 2 per-voice runtime: envelope, LFO, modulators, biquad", mod, "strudel_sf2_voice.rst", groups)
+}
+
+def document_module_strudel_pattern(root : string) {
+    var mod = find_module("strudel_pattern")
+    var groups <- array<DocGroup>(
+        group_by_regex("Pattern construction", mod, %regex~(pure|silence|atom|querySpan|queryArc|patternType)$%%),
+        group_by_regex("Time manipulation", mod, %regex~(fast|slow|stack|cat|fastcat|weighted_fastcat|fmap)$%%),
+        group_by_regex("Combinators", mod, %regex~(rev|jux|off|layer|superimpose|euclid|palindrome|ply|iter|iterBack|when_cycle|linger|hurry|compress|chunk|striate|struct_|mask|choose|wchoose|randcat|chooseCycles|shuffle|scramble|echo|stut|transpose|add|innerJoin|combineWith|combineWithStr|degrade|degradeBy|every|bjorklund|sometimes|often|sometimesby)$%%),
+        group_by_regex("Setter primitives", mod, %regex~set_.*$%%),
+        group_by_regex("Fluent control: dynamics and routing", mod, %regex~(gain|velocity|vel|pan|speed|note|sound|cut|orbit|begin|end_pos)$%%),
+        group_by_regex("Fluent control: effects sends", mod, %regex~(room|roomsize|size|delay|delaytime|dt|delayfeedback|dfb|delaysync|chorus)$%%),
+        group_by_regex("Fluent control: filters", mod, %regex~(lpf|lp|hpf|hp|lpq|resonance|hpq|bpf|bpq|djf)$%%),
+        group_by_regex("Fluent control: envelope", mod, %regex~(attack|att|decay|dec|sustain|sus|release|rel)$%%),
+        group_by_regex("Fluent control: synthesis and shaping", mod, %regex~(fm|fmh|crush|coarse|shape)$%%),
+        group_by_regex("Fluent control: modulation FX", mod, %regex~(phaser|ph|phaserdepth|phd|phasercenter|phc|phasersweep|phs|tremolo|trem|tremolodepth|tremdepth|compressor.*)$%%),
+        group_by_regex("Fluent control: SF2", mod, %regex~sf2.*$%%),
+        group_by_regex("Signals", mod, %regex~(signal|signal_.*|sine|cosine|saw|tri|perlin|range|square|isaw|itri|sine2|cosine2|saw2|tri2|square2|isaw2|itri2|rand|rand2|irand|run)$%%)
+    )
+    document("Pattern algebra, combinators, and fluent control API", mod, "strudel_pattern.rst", groups)
 }
 
 def document_module_peg(root : string) {
@@ -1369,8 +1514,21 @@ def main {
     // document dasAudio daScript modules
     document_module_audio_boost(root)
     document_module_audio_wav(root)
+    // document strudel modules
+    document_module_strudel_event(root)
+    document_module_strudel_time(root)
+    document_module_strudel_live(root)
+    document_module_strudel_scales(root)
+    document_module_strudel_mini(root)
+    document_module_strudel_samples(root)
+    document_module_strudel_synth(root)
+    document_module_strudel_scheduler(root)
+    document_module_strudel_player(root)
     document_module_strudel_midi(root)
+    document_module_strudel_midi_player(root)
     document_module_strudel_sf2(root)
+    document_module_strudel_sf2_voice(root)
+    document_module_strudel_pattern(root)
     // document dasPEG module
     document_module_peg(root)
     document_module_debugapi(root)

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -27,3 +27,4 @@ THE SOFTWARE.
    embedding.rst
    utils.rst
    tutorials.rst
+   strudel_vs_strudel_cc.rst

--- a/doc/source/reference/strudel_vs_strudel_cc.rst
+++ b/doc/source/reference/strudel_vs_strudel_cc.rst
@@ -1,0 +1,329 @@
+.. _strudel_vs_strudel_cc:
+
+====================================================
+daslang strudel vs strudel.cc — Feature Comparison
+====================================================
+
+This page compares the daslang ``strudel`` library
+(``modules/dasAudio/strudel/``) to its inspiration, the strudel.cc
+live-coding system.  It is the **only** documentation page that names
+strudel.cc explicitly — all other pages should reference this one for
+anything comparative.
+
+Read this before porting a strudel.cc pattern to daslang. The
+Claude-assistant porting workflow lives in the repository at
+``skills/strudel_port.md``. For the
+generated reference of every strudel symbol, see
+:ref:`stdlib_strudel_section`. For the tutorial series, see
+:ref:`tutorials_dastrudel`.
+
+.. contents:: Contents
+   :local:
+   :depth: 2
+
+
+.. _strudel_cc_overview:
+
+Scope and philosophy
+====================
+
+The daslang port is **feature-focused, not code-ported**.  We implement
+the musical primitives of strudel.cc on top of daslang's compiler,
+pattern matcher, and audio engine — but with no JavaScript runtime, no
+web UI, no REPL, and no external DSP graph.  Everything runs in one
+daslang context, with a per-voice synthesis pipeline and per-orbit
+effect busses.
+
+Two consequences of that design:
+
+* **The core pattern algebra, mini-notation, scales, SF2/MIDI, and
+  live-reload are first-class.**  For the vast majority of strudel.cc
+  patterns you can rewrite the code almost verbatim — same names,
+  same mini-notation, same combinators.
+* **The synth engine and effect routing are daslang-native and
+  sometimes diverge.**  Per-voice FX, orbit busses, and ADSR defaults
+  all have specific semantics that do not match strudel.cc exactly.
+  Those cases are enumerated below.
+
+
+.. _strudel_cc_have:
+
+What we have
+============
+
+Parity or near-parity with strudel.cc:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Feature area
+     - daslang module
+     - Notes
+   * - Mini-notation
+     - ``strudel_mini``
+     - ``"bd sd ~ cp"`` literals via ``s``, ``n``, ``note``, ``seq``;
+       subdivisions ``[a b]``, repeats ``a*4``, rests ``~``, angle
+       brackets ``<a b c>``, elongation ``@``, degrade ``?``,
+       replicate ``!``
+   * - Pattern algebra
+     - ``strudel_pattern``
+     - ``Pattern`` as a time-span → haps function; ``pure``,
+       ``silence``, ``stack``, ``cat``, ``fastcat``, ``fmap``
+   * - Time combinators
+     - ``strudel_pattern``
+     - ``fast``, ``slow``, ``rev``, ``hurry``, ``compress``,
+       ``linger``, ``palindrome``, ``ply``, ``iter``, ``iterBack``,
+       ``chunk``, ``striate``, ``when_cycle``, ``every``
+   * - Per-voice combinators
+     - ``strudel_pattern``
+     - ``jux``, ``off``, ``layer``, ``superimpose``, ``echo``,
+       ``stut``, ``transpose``, ``add``
+   * - Choice combinators
+     - ``strudel_pattern``
+     - ``choose``, ``wchoose``, ``randcat``, ``chooseCycles``,
+       ``shuffle``, ``scramble``, ``sometimes``, ``often``,
+       ``sometimesby``, ``degrade``, ``degradeBy``
+   * - Euclidean rhythms
+     - ``strudel_pattern``
+     - ``euclid(k, n)``, ``bjorklund``.  (``euclidRot`` and
+       mini-notation ``bd(3,8)`` forms are gaps — see below.)
+   * - Scales
+     - ``strudel_scales``
+     - ``scale("c:minor")``, ``note`` with scale context, modes
+       (dorian, mixolydian, …), pentatonic, blues, major/minor
+   * - Signals
+     - ``strudel_pattern``
+     - ``sine``/``cosine``/``saw``/``tri``/``square``/``isaw``/``itri``
+       and their bipolar ``*2`` variants, ``perlin``, ``rand``/``irand``,
+       ``run``, ``range``
+   * - Synthesis
+     - ``strudel_synth``
+     - oscillators (``sine``, ``sawtooth``, ``square``, ``triangle``,
+       ``supersaw``), noise (``white``, ``pink``), FM via ``fm`` +
+       ``fmh``, vowel/formant filter, per-voice biquads. Note
+       ``sawtooth`` is spelled out — there is no ``saw`` alias (unlike
+       strudel.cc)
+   * - Samples
+     - ``strudel_samples``
+     - WAV / MP3 / FLAC / OGG loading via ``load_audio_file`` /
+       ``strudel_load_sound`` / ``strudel_load_sample_dir``; sample
+       banks, per-pattern speed/pitch via ``speed``
+   * - SF2 soundfonts
+     - ``strudel_sf2`` + ``strudel_sf2_voice``
+     - Full SF2 parser (format 0/1 meta-events, generators,
+       modulators), per-voice envelope / LFO / biquad, GM drum map
+       compatibility, expression and mod-wheel CCs
+   * - MIDI playback
+     - ``strudel_midi`` + ``strudel_midi_player``
+     - Format 0/1 parser, merged-track playback, GM preset mapping,
+       integration with synth or SF2 backend
+   * - Live-reload
+     - ``strudel_live``
+     - Persistent state across source reload via
+       ``save_strudel_state`` / ``restore_strudel_state`` and the
+       ``daslang-live`` host; ``[live_command]``,
+       ``[before_reload]``, ``[after_reload]``
+   * - Effects (send busses)
+     - ``strudel_scheduler``
+     - Per-orbit ``room`` / ``delay`` / ``chorus``; each orbit
+       number routes to one ``OrbitBus``
+   * - Effects (per-voice)
+     - ``strudel_synth`` (``VoiceFX``)
+     - Phaser, tremolo, compressor, waveshaper, DJ filter, bitcrush,
+       sample-rate reduction — all applied per voice before the
+       orbit mix
+
+
+.. _strudel_cc_missing:
+
+What we don't have (yet)
+========================
+
+Features that are present in strudel.cc and absent in the daslang port:
+
+* **``euclidRot``** — Euclidean rotation helper.  Not implemented;
+  compose ``euclid`` with ``rev`` or ``off`` for a workaround.
+* **Mini-notation ``bd(3,8)`` form** — tokens ``(`` / ``)`` are
+  lexed but not parsed into Euclidean rhythms.  Use the
+  ``euclid(pat, 3, 8)`` function form instead.
+* **``jux_rev`` / ``chop`` / other convenience aliases** — the
+  parametric forms (``jux(pat, fn)``, ``stutter``, etc.) are
+  public; a few one-letter convenience wrappers were not ported.
+* **Web sample packs** — strudel.cc streams sample packs from
+  the web at runtime; daslang loads local samples from disk (via
+  ``strudel_load_sample_dir``).  Bring your own sample library.
+* **REPL UI** — strudel.cc has a browser REPL with visualisation;
+  daslang uses ``daslang-live`` for hot-reload and a separate
+  visualiser example (``examples/daStrudel/strudel_visualizer/``).
+* **OSC / tidalcycles output** — the daslang port renders audio
+  directly.  There is no equivalent of strudel.cc's SuperDirt /
+  OSC backend.
+* **Hydra-style visual patterns** — out of scope; daslang is
+  audio-only.
+* **Some mini-notation modifiers** — a handful of exotic forms
+  (e.g. some of the richer polymeter notations) may be missing;
+  check ``strudel_mini.das`` for the authoritative list of
+  supported tokens.
+
+
+.. _strudel_cc_differences:
+
+Behavioural differences
+=======================
+
+Cases where a primitive with the **same name** behaves differently
+in the daslang port.  Before porting a pattern that uses one of
+these, read the table — the output may differ even if the code
+looks identical.
+
+ADSR defaults are tempo-aware
+-----------------------------
+
+**Divergence:** daslang scales the default attack / decay / sustain /
+release values with the current CPS so that a default envelope feels
+right at any tempo.  strudel.cc uses fixed-millisecond defaults.
+
+**Why:** When you change tempo with ``strudel_set_cps`` mid-pattern,
+you don't want the envelope to suddenly overpower the note or shorten
+to a click.  The defaults are defined so that a whole-note envelope
+fills one cycle at the current tempo.
+
+**How to apply:**
+
+* For patterns that relied on strudel.cc's fixed ADSR, pass explicit
+  values: ``pat |> attack(0.01) |> release(0.5)``.
+* If you want the daslang behaviour in strudel.cc, multiply the
+  attack / release by the period (1 / CPS).
+
+See the ``adsr-defaults`` branch history for the full introduction.
+
+Per-voice FX chain
+------------------
+
+**Divergence:** ``phaser``, ``tremolo``, ``compressor``, ``shape``,
+``crush``, ``coarse``, and ``djf`` are applied **per voice**, inside
+the voice renderer, before the orbit mix.  strudel.cc applies most
+of these after the send-bus mix.
+
+**Why:** Per-voice FX gives a cleaner sound for polyphonic patterns
+(one voice's compressor can't duck another voice's transient) and
+integrates tightly with the ``VoiceFX`` struct, which the per-voice
+synth engine already carries.
+
+**How to apply:** for patterns that rely on strudel.cc's post-bus
+phaser, use ``room`` / ``delay`` bus routing (per-orbit) instead.
+Per-voice combinators like ``jux`` interact with per-voice FX
+differently — each transformed voice carries its own FX chain.
+
+Orbit bus model
+---------------
+
+**Divergence:** daslang has an explicit ``OrbitBus`` per orbit
+number.  ``room`` sends to that orbit's reverb; ``delay`` to that
+orbit's delay; ``chorus`` is per-voice, **not** per-orbit.
+strudel.cc routes reverb/delay through SuperDirt differently.
+
+**How to apply:** if your strudel.cc pattern mixes two orbits to
+share a reverb, in daslang they need the same ``orbit`` number.
+If you want independent reverbs per voice, split orbits.
+
+Mini-notation parsing
+---------------------
+
+**Divergence:** mini-notation strings are **only parsed** by
+``parse_pattern`` / ``s`` / ``n`` / ``note`` / ``seq`` — not by
+any implicit string coercion.  ``pat = "bd sd"`` is a string
+literal, not a ``Pattern``.
+
+**Why:** daslang is statically typed; implicit coercion from
+``string`` to ``Pattern`` would require custom conversion at every
+call site.  Explicit constructors are clearer and play better with
+type-dispatched combinators.
+
+**How to apply:** always wrap mini-notation in ``s("bd sd")``,
+``n("0 2 4")``, ``note("c4 e4 g4")``, or ``parse_pattern("...")``.
+
+``fast`` at non-integer ratios
+------------------------------
+
+**Divergence:** both engines allow fractional factors (``fast(1.5)``),
+but the underlying hap-slicing uses floor-division in daslang's
+``splitSpans`` helper.  Edge cases where the speedup causes a hap to
+straddle a cycle boundary are resolved by keeping the earlier half;
+strudel.cc may keep the later half.
+
+**How to apply:** for rhythms near integer factors, behaviour is
+identical.  For oddly fractional ``fast`` values, compare audibly
+and adjust.
+
+Scheduler and voice pool
+------------------------
+
+**Divergence:** daslang has a fixed voice-pool size (set at
+``Scheduler`` init); when exceeded, the oldest voice is stolen.
+strudel.cc allocates voices dynamically per hap.
+
+**How to apply:** very dense polyphony may drop notes in daslang.
+Raise the pool size at ``Scheduler`` construction or thin the
+pattern.
+
+
+.. _strudel_cc_naming:
+
+Naming map (quick reference)
+============================
+
+For porting at speed: the daslang name is the **same** as strudel.cc
+for ~95% of primitives.  When it differs:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 35 30
+
+   * - strudel.cc
+     - daslang
+     - Notes
+   * - ``s("bd sd")``
+     - ``s("bd sd")``
+     - identical
+   * - ``n("0 2 4")``
+     - ``n("0 2 4")``
+     - identical
+   * - ``note("c4")``
+     - ``note("c4")``
+     - identical; for scale-degree use ``note(0.0)`` after ``scale(...)``
+   * - ``.fast(2)``
+     - ``|> fast(2.0)``
+     - same name; pipe syntax preferred but method-chain also works
+   * - ``.jux(rev)``
+     - ``|> jux(@(x) => rev(x))``
+     - daslang expects a typed fn; lambda literal is normal
+   * - ``.velocity(0.5)`` / ``.vel(...)``
+     - ``|> velocity(0.5)`` / ``|> vel(...)``
+     - both aliases exist
+   * - ``.stack(a, b)``
+     - ``stack(a, b)``
+     - top-level function, not a method
+   * - ``.euclidRot(3, 8, 1)``
+     - *not available*
+     - use ``euclid(pat, 3, 8) |> off(1.0/8.0, @(x) => x)``
+   * - ``"bd(3,8)"``
+     - ``euclid(s("bd"), 3, 8)``
+     - mini-notation Euclid form not parsed
+
+For everything else, assume the name is identical.  Use the MCP
+``list_module_api`` tool on ``strudel_pattern`` /
+``strudel_synth`` / ``strudel_scales`` to confirm.
+
+
+.. seealso::
+
+   :ref:`stdlib_strudel_section` — generated reference for every
+   strudel symbol.
+
+   :ref:`tutorials_dastrudel` — 15-tutorial numbered series covering
+   patterns, mini-notation, effects, synthesis, samples, MIDI, and
+   live-reload.
+
+   :ref:`tutorial_dastrudel_hello_pattern` — start here for a tour.

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -293,6 +293,42 @@ Run any tutorial from the project root::
    tutorials/dasAudio_07_wav_io.rst
    tutorials/dasAudio_08_midi.rst
 
+.. _tutorials_dastrudel:
+
+daStrudel (Live-Coding) Tutorials
+==================================
+
+These tutorials cover the ``strudel`` module — pattern-based live-coding
+music with mini-notation, time algebra, per-voice effects, samples, SF2
+soundfonts, MIDI playback, and live-reload.  Companion ``.das`` files
+are in ``tutorials/daStrudel/``.
+
+Run any tutorial from the project root::
+
+   daslang.exe tutorials/daStrudel/daStrudel_01_hello_pattern.das
+
+For the strudel-to-strudel.cc feature comparison, see
+:ref:`strudel_vs_strudel_cc`.
+
+.. toctree::
+   :maxdepth: 1
+
+   tutorials/daStrudel_01_hello_pattern.rst
+   tutorials/daStrudel_02_mini_notation_fundamentals.rst
+   tutorials/daStrudel_03_mini_notation_advanced.rst
+   tutorials/daStrudel_04_time_manipulation.rst
+   tutorials/daStrudel_05_euclidean_rhythms.rst
+   tutorials/daStrudel_06_stacking_combining.rst
+   tutorials/daStrudel_07_per_voice_fx.rst
+   tutorials/daStrudel_08_effects_filters.rst
+   tutorials/daStrudel_09_adsr_envelopes.rst
+   tutorials/daStrudel_10_scales_music_theory.rst
+   tutorials/daStrudel_11_synthesis.rst
+   tutorials/daStrudel_12_samples.rst
+   tutorials/daStrudel_13_sf2_soundfont.rst
+   tutorials/daStrudel_14_midi_files.rst
+   tutorials/daStrudel_15_live_reloading.rst
+
 .. _tutorials_daspeg:
 
 dasPEG (Parser Generator) Tutorials

--- a/doc/source/reference/tutorials/daStrudel_01_hello_pattern.rst
+++ b/doc/source/reference/tutorials/daStrudel_01_hello_pattern.rst
@@ -1,0 +1,167 @@
+.. _tutorial_dastrudel_hello_pattern:
+
+==========================
+STRUDEL-01 — Hello Pattern
+==========================
+
+.. index::
+    single: Tutorial; Strudel; Hello Pattern
+    single: Tutorial; Strudel; Pattern
+    single: Tutorial; Strudel; Hap
+
+This tutorial is the entry point for the daStrudel series. It introduces the
+two central concepts of the library — the ``Pattern`` type and the ``Hap``
+event — and shows three different ways to create your first pattern.
+By the end you will have queried a pattern by hand, played a single drum
+hit through the audio system, and played a single sine note. No
+mini-notation, no combinators — just the bare data model and the playback
+loop.
+
+What is a Pattern?
+==================
+
+A ``Pattern`` is **a pure function from a query window to a list of events**.
+Concretely:
+
+.. code-block:: das
+
+    typedef Pattern = lambda<(span : TimeSpan) : array<Hap>>
+
+You give it a ``TimeSpan`` (a half-open interval ``[start, stop)`` measured
+in *cycles* — not seconds), and it returns every ``Hap`` whose lifetime
+intersects that span. The function has no side effects, allocates only
+the result array, and can be queried any number of times. This is the
+single design idea that makes the rest of the library work — every
+combinator (``fast``, ``slow``, ``rev``, ``euclid``, ``jux``, ...) just
+wraps an inner pattern with a function that rewrites query spans on the
+way in and result haps on the way out.
+
+What is a Hap?
+==============
+
+A ``Hap`` is one event with two timestamps and a value:
+
+.. code-block:: das
+
+    struct Hap {
+        whole : TimeSpan      // the event's full lifetime
+        part  : TimeSpan      // the slice that fell inside the query
+        has_whole : bool
+        value : Event         // sound name, note number, gain, pan, ...
+    }
+
+``whole`` is when the event would naturally start and stop. ``part`` is
+the portion that actually lies inside the query span. They differ when
+your query cuts an event in half — the audio engine uses ``part`` to
+decide what to schedule and ``whole`` to compute envelope phase.
+
+Part A: Query a Pattern by hand
+===============================
+
+The simplest constructor is ``pure(Event)`` — it lifts an event into a
+pattern that emits it once per cycle. We can call the pattern lambda
+directly with ``invoke`` to see what it produces:
+
+.. code-block:: das
+
+    let pat <- pure(Event(s = "bd"))
+    var haps <- invoke(pat, TimeSpan(start = 0.0lf, stop = 1.0lf))
+    for (h in haps) {
+        print("whole=[{h.whole.start}, {h.whole.stop})  s='{h.value.s}'\n")
+    }
+    // output: whole=[0, 1)  s='bd'
+
+That single hap is what the audio engine will receive once per cycle and
+turn into a kick-drum sample trigger. No audio yet — just data.
+
+Part B: Play a single drum sound
+================================
+
+To turn haps into audio you need three things: an audio system, a strudel
+channel, and a tick loop. The minimal harness used throughout this
+tutorial series:
+
+.. code-block:: das
+
+    require strudel/strudel public
+    require strudel/strudel_player
+    require audio/audio_boost
+    require daslib/fio
+
+    def play(var pat : Pattern; seconds : float = 4.0; cps : double = 0.5lf) {
+        with_audio_system() {
+            strudel_create_channel()
+            strudel_set_cps(cps)
+            strudel_add_track(pat)
+            let t0 = ref_time_ticks()
+            while (float(get_time_usec(t0)) / 1000000.0 < seconds) {
+                strudel_tick()
+                sleep(5u)
+            }
+            strudel_shutdown()
+        }
+    }
+
+The fully featured version of this harness — with WAV rendering,
+``--duration`` and ``--track-memory`` flags — lives in
+``examples/daStrudel/features/feature_common.das``. The minimal form
+above is enough to get sound out and is what every tutorial in the
+``01..05`` set uses.
+
+``s("bd")`` is the shortest mini-notation: a single token. It parses to
+the same Pattern as ``pure(Event(s = "bd"))`` but goes through the
+mini-notation parser:
+
+.. code-block:: das
+
+    let pat <- s("bd")
+    play(pat, 4.0)
+
+``cps = 0.5`` means **half a cycle per second** — one cycle every two
+seconds. So you hear "bd" played twice over a four-second run.
+
+Part C: Play a single synth note
+================================
+
+For pitched sound, ``note()`` is the synth counterpart of ``s()``. It
+parses note names ("c4", "eb3", "g#5") into MIDI numbers, and the
+optional second argument picks an oscillator:
+
+.. code-block:: das
+
+    let pat <- note("c4", "sine") |> sustain(0.5)
+    play(pat, 4.0)
+
+``sustain(0.5)`` says each note holds for half its slot. Without it the
+default ADSR envelope would cut the note very short.
+
+The pipe operator ``|>`` is just function call with the left side as the
+first argument — ``pat |> sustain(0.5)`` is identical to
+``sustain(pat, 0.5)``. Every per-event setter (``gain``, ``pan``,
+``lpf``, ``room``, ...) follows this Pattern-in / Pattern-out shape, so
+you build effect chains by piping.
+
+Where next
+==========
+
+You now know:
+
+- A Pattern is a pure function ``TimeSpan -> array<Hap>``
+- A Hap is an event with two timestamps and a value
+- ``pure``, ``s``, and ``note`` are three constructors
+- The minimal playback harness is ``with_audio_system + create_channel +
+  set_cps + add_track + tick loop + shutdown``
+
+Tutorial 02 introduces real mini-notation — sequences, rests, and
+subdivisions — so a single ``s(...)`` call can describe a full drum
+pattern.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_01_hello_pattern.das <../../../../tutorials/daStrudel/daStrudel_01_hello_pattern.das>`
+
+   Next tutorial: :ref:`tutorial_dastrudel_mini_fundamentals`
+
+   Related: :ref:`tutorial_lambdas` — the Pattern type is a typed lambda
+
+   Related: :ref:`tutorial_modules` — ``require strudel/strudel`` and other module forms

--- a/doc/source/reference/tutorials/daStrudel_02_mini_notation_fundamentals.rst
+++ b/doc/source/reference/tutorials/daStrudel_02_mini_notation_fundamentals.rst
@@ -1,0 +1,106 @@
+.. _tutorial_dastrudel_mini_fundamentals:
+
+==========================================
+STRUDEL-02 — Mini-Notation Fundamentals
+==========================================
+
+.. index::
+    single: Tutorial; Strudel; Mini-Notation
+    single: Tutorial; Strudel; Sequence
+    single: Tutorial; Strudel; Subdivision
+    single: Tutorial; Strudel; Rest
+
+The mini-notation is a tiny string DSL for describing rhythmic patterns.
+A line like ``"bd sd ~ cp"`` reads almost like a drum-kit transcription
+and parses to a real ``Pattern``. This tutorial covers the four
+primitives you will use in nearly every pattern you write: **sequences**,
+**rests**, **subdivisions**, and **repeats**.
+
+Part A: Sequences and rests
+===========================
+
+The simplest mini-notation is a space-separated list of tokens. Each
+token gets an equal slice of the cycle:
+
+.. code-block:: das
+
+    let pat <- s("bd sd ~ cp")
+    play(pat, 4.0)
+
+Four tokens, each occupies 1/4 of a cycle. The kick lands at 0/4, the
+snare at 1/4, **silence** at 2/4 (``~`` is the rest token), and the clap
+at 3/4. Replace ``~`` with another sound and the rhythm fills in.
+
+This is the canonical four-on-the-floor skeleton you will see throughout
+the strudel ecosystem. ``s()`` does all the work — it tokenises the
+string, builds a parse-tree-free Pattern via recursive descent, and
+returns it.
+
+Part B: Subdivisions with [ ]
+=============================
+
+Square brackets group tokens into a sub-sequence that fits inside **one
+step** of the parent sequence:
+
+.. code-block:: das
+
+    let pat <- s("bd [sd sd] ~ cp")
+    play(pat, 4.0)
+
+Now slot two contains two snares packed together — the same total time
+that a single snare took before. This is recursive: ``[a [b c] d]`` works
+exactly as you expect, with ``b`` and ``c`` sharing the slot that ``b``
+alone would have occupied.
+
+Subdivision is the operation that gives mini-notation its expressive
+power. With nothing else, you can already write any rational rhythm.
+
+Part C: Repeats with \*N
+========================
+
+The ``*N`` postfix is a shorthand for "repeat this token N times within
+its step":
+
+.. code-block:: das
+
+    let pat <- s("bd hh*4 sd hh")
+    play(pat, 4.0)
+
+``hh*4`` is exactly equivalent to ``[hh hh hh hh]`` — four hi-hats packed
+into the second slot. ``*N`` is read first, so ``hh*4*2`` packs eight
+hats. There is also ``/N`` for the inverse (slow down by N), but for
+in-cycle repetition ``*N`` is the workhorse.
+
+Part D: Combining the basics
+============================
+
+All three primitives nest and combine freely:
+
+.. code-block:: das
+
+    let pat <- s("bd [sd sd*2] ~ hh*4")
+    play(pat, 4.0)
+
+Reading left to right: kick, then a sub-sequence containing one snare
+and a doubled snare, then a rest, then four hats. This single string
+describes a busy backbeat — and it is still just data, just a Pattern,
+ready to be transformed by ``fast``, ``rev``, ``euclid``, or any other
+combinator.
+
+Where next
+==========
+
+Tutorial 03 covers the four **advanced** mini-notation operators that
+the simple sequencer does not give you: angle brackets ``<a b c>`` for
+per-cycle alternation, ``@N`` for elongation, ``?`` for random degrade,
+and ``!N`` for parent-level replication.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_02_mini_notation_fundamentals.das <../../../../tutorials/daStrudel/daStrudel_02_mini_notation_fundamentals.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_hello_pattern`
+
+   Next tutorial: :ref:`tutorial_dastrudel_mini_advanced`
+
+   Related: :ref:`tutorial_strings` — string interpolation behaves like mini-notation parsing

--- a/doc/source/reference/tutorials/daStrudel_03_mini_notation_advanced.rst
+++ b/doc/source/reference/tutorials/daStrudel_03_mini_notation_advanced.rst
@@ -1,0 +1,123 @@
+.. _tutorial_dastrudel_mini_advanced:
+
+==========================================
+STRUDEL-03 — Mini-Notation Advanced
+==========================================
+
+.. index::
+    single: Tutorial; Strudel; Mini-Notation
+    single: Tutorial; Strudel; Alternation
+    single: Tutorial; Strudel; Elongation
+    single: Tutorial; Strudel; Degrade
+    single: Tutorial; Strudel; Replicate
+
+The four operators in this tutorial — ``<...>``, ``@N``, ``?``, and
+``!N`` — are what take you from drum-machine patterns to genuinely
+musical phrases. They also exist purely inside the mini-notation parser:
+each one rewrites the parsed pattern into the same combinators (``cat``,
+``weighted_fastcat``, ``degrade``, ``fast``) you can call directly from
+daslang. Knowing both forms is useful: mini-notation for terseness,
+combinators when the input is dynamic.
+
+Part A: Alternation with ``< >``
+================================
+
+Angle brackets pick **one element per cycle**, advancing on each cycle
+and looping when it runs out:
+
+.. code-block:: das
+
+    let pat <- s("<bd sd cp>")
+    play(pat, 6.0)
+
+You hear ``bd`` on cycle 0, ``sd`` on cycle 1, ``cp`` on cycle 2, then
+back to ``bd``. This is the ``cat`` combinator under the hood: the angle
+group spans one full cycle each iteration.
+
+Inside a sequence the angle group still occupies one **slot**:
+
+.. code-block:: das
+
+    let pat <- s("bd <sd cp> hh hh")
+    play(pat, 4.0)
+
+The ``<sd cp>`` slot alternates each cycle — snare on cycle 0, clap on
+cycle 1. This pattern is how you write "second beat changes" in a single
+line.
+
+Part B: Elongation with ``@N``
+==============================
+
+Postfix ``@N`` makes an element occupy **N units** of the parent
+sequence (default is 1). It is implemented via ``weighted_fastcat`` —
+the parser tracks weights for each token and divides the cycle
+proportionally:
+
+.. code-block:: das
+
+    let pat <- s("bd@3 sd") |> sustain(0.5)
+    play(pat, 4.0)
+
+Without ``@3`` each token would get half a cycle. With it the kick gets
+3/4 and the snare gets 1/4. This is how you write swung or front-loaded
+phrases without nested brackets.
+
+Underscore ``_`` is the equivalent for **the previous element**:
+``"bd _ _ sd"`` is the same as ``"bd@3 sd"``. Use whichever reads better
+for your phrase.
+
+Part C: Degrade with ``?``
+==========================
+
+Postfix ``?`` randomly drops events at the marked element with 50%
+probability. Hi-hats are the canonical use:
+
+.. code-block:: das
+
+    let pat <- s("bd hh? sd hh?")
+    play(pat, 6.0)
+
+The kick and snare are reliable; the hats appear roughly half the time,
+randomly per cycle. Run it twice and you get different results — the
+RNG seed is tied to the cycle position so the rhythm is deterministic
+within one play, but the pattern feels human.
+
+You can also write ``hh?0.25`` to use a different drop probability —
+the default ``?`` is shorthand for ``?0.5``.
+
+Part D: Replicate with ``!N``
+=============================
+
+Postfix ``!N`` is like ``*N`` from tutorial 02 but expands the element
+into N **parent slots** instead of squeezing them into one:
+
+.. code-block:: das
+
+    let pat <- s("bd!3 sd")
+    play(pat, 4.0)
+
+This expands to four equal slots ``bd bd bd sd`` — three kicks then a
+snare. Compare to ``bd*3 sd`` which packs three kicks into one slot
+followed by a snare in the second.
+
+The mental model: ``*N`` divides time, ``!N`` adds slots. Use ``*`` to
+make things faster within one slot, ``!`` to repeat the same element
+across the parent sequence.
+
+Where next
+==========
+
+You now know the full mini-notation surface. Tutorial 04 leaves the
+parser behind and shows the **time algebra** — ``fast``, ``slow``,
+``rev``, ``hurry`` — which transforms any Pattern (mini-notation or
+not) by rewriting query spans.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_03_mini_notation_advanced.das <../../../../tutorials/daStrudel/daStrudel_03_mini_notation_advanced.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_mini_fundamentals`
+
+   Next tutorial: :ref:`tutorial_dastrudel_time`
+
+   Related: :ref:`tutorial_random` — how degrade's randomness is seeded

--- a/doc/source/reference/tutorials/daStrudel_04_time_manipulation.rst
+++ b/doc/source/reference/tutorials/daStrudel_04_time_manipulation.rst
@@ -1,0 +1,139 @@
+.. _tutorial_dastrudel_time:
+
+==========================================
+STRUDEL-04 — Time Manipulation
+==========================================
+
+.. index::
+    single: Tutorial; Strudel; Time Manipulation
+    single: Tutorial; Strudel; fast
+    single: Tutorial; Strudel; slow
+    single: Tutorial; Strudel; rev
+    single: Tutorial; Strudel; hurry
+
+So far every Pattern played at one cycle per cycle, in forward order.
+This tutorial introduces the **time algebra**: four functions that take
+a Pattern and return a new Pattern by rewriting the query timeline.
+``fast`` and ``slow`` change density, ``rev`` mirrors per-cycle, and
+``hurry`` couples speed with pitch. They all compose freely, and they
+work on any Pattern — mini-notation, ``pure``, or signals.
+
+The mental model: a combinator wraps a Pattern with a function that
+**rewrites the query span on the way in** and **rewrites the result
+haps on the way out**. ``fast(2)`` queries the inner pattern with
+``span * 2``, then divides every returned hap's timestamps by 2.
+``slow(N)`` is exactly ``fast(1/N)``. ``rev`` mirrors the span within
+each cycle and mirrors the haps back. That is the entire framework.
+
+Part A: ``fast(N)``
+===================
+
+``fast(N)`` repeats the pattern N times per cycle:
+
+.. code-block:: das
+
+    let pat <- s("c4 e4 g4 c5") |> fast(2.0lf)
+    play(pat, 4.0)
+
+The four-note arpeggio plays twice per cycle. ``N`` is a ``double``,
+so non-integer values work — ``fast(1.5lf)`` gives 3 repetitions every
+2 cycles, useful for polyrhythms (covered in tutorial 05).
+
+Part B: ``slow(N)``
+===================
+
+``slow(N)`` stretches one pass of the pattern over N cycles. It is
+defined as ``fast(1.0lf / n)``:
+
+.. code-block:: das
+
+    let pat <- s("bd sd hh cp") |> slow(2.0lf)
+    play(pat, 6.0)
+
+The four hits now span two cycles instead of one. Use this to stretch
+melodies, make pad-style sustains, or build a slow LFO out of a signal
+pattern.
+
+Part C: ``rev``
+===============
+
+``rev`` reverses event positions **within each cycle**:
+
+.. code-block:: das
+
+    let pat <- note("c4 e4 g4 c5", "sine") |> sustain(0.4) |> rev
+    play(pat, 4.0)
+
+The arpeggio plays backward as ``c5 g4 e4 c4``. This is per-cycle
+mirroring — not a global reverse. Each cycle stands alone, so
+``rev |> rev`` is the identity. Combine it with ``jux`` to get instant
+stereo widening (tutorial 06 covers combinators).
+
+``rev`` is callable bare or with parentheses: ``pat |> rev`` and
+``pat |> rev()`` are equivalent.
+
+Part D: ``hurry(N)``
+====================
+
+``hurry(N)`` speeds time up by N **and** multiplies the per-event
+playback ``speed`` by N. For sample-based sounds (drum hits,
+field-recordings), speed scales playback rate, which means pitch goes
+up by ``log2(N)`` octaves:
+
+.. code-block:: das
+
+    let pat <- s("c3 e3 g3 c4") |> hurry(2.0lf)
+    play(pat, 4.0)
+
+The pattern plays twice as fast and an octave higher. This is a single
+function call away from the classic chipmunk effect. For synth voices
+(``sine``, ``sawtooth``, ``supersaw``), ``hurry`` and ``fast`` differ
+only in the ``speed`` field — pitch comes from ``note``, not ``speed``.
+
+Part E: Composition
+===================
+
+The four functions all return Patterns, so they compose with the pipe
+operator like any other transform:
+
+.. code-block:: das
+
+    let pat <- note("c4 e4 g4 b4", "sine")
+        |> sustain(0.4)
+        |> rev
+        |> slow(2.0lf)
+    play(pat, 6.0)
+
+Order matters — ``rev |> slow(2)`` reverses then stretches; ``slow(2) |>
+rev`` stretches then reverses (and the two produce different rhythms in
+general because ``rev`` operates per-cycle).
+
+A note on ``early`` and ``late``
+================================
+
+You may have seen ``early(N)`` / ``late(N)`` in other Tidal/Strudel
+documentation — they shift the pattern earlier or later by N cycles.
+In this build they exist but are **private** to the strudel module
+(used internally by ``off``, the canon-style overlay combinator). To
+shift a pattern, the public route is to chain ``slow`` and ``cat``, or
+to wait for them to be exported in a future release.
+
+Where next
+==========
+
+Tutorial 05 covers **Euclidean rhythms** — the ``euclid(pat, k, n)``
+combinator that distributes ``k`` events evenly across ``n`` steps and
+produces traditional drum patterns from many cultures with a single
+line.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_04_time_manipulation.das <../../../../tutorials/daStrudel/daStrudel_04_time_manipulation.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_mini_advanced`
+
+   Next tutorial: :ref:`tutorial_dastrudel_euclid`
+
+   Related: :ref:`tutorial_lambdas` — Patterns are lambdas, and so are the wrappers ``fast``/``slow``/``rev`` build
+
+   Related: :ref:`tutorial_functions` — pipe operator ``|>`` is just function call syntax

--- a/doc/source/reference/tutorials/daStrudel_05_euclidean_rhythms.rst
+++ b/doc/source/reference/tutorials/daStrudel_05_euclidean_rhythms.rst
@@ -1,0 +1,151 @@
+.. _tutorial_dastrudel_euclid:
+
+==========================================
+STRUDEL-05 — Euclidean Rhythms
+==========================================
+
+.. index::
+    single: Tutorial; Strudel; Euclidean
+    single: Tutorial; Strudel; Bjorklund
+    single: Tutorial; Strudel; Polyrhythm
+
+Euclidean rhythms are produced by **distributing k onsets as evenly as
+possible across n discrete steps**. The algorithm — Bjorklund's, named
+after the physicist who first wrote it down for a particle-collider
+problem — turns out to generate many traditional drum patterns from
+around the world. Toussaint's 2005 paper *The Euclidean Algorithm
+Generates Traditional Musical Rhythms* catalogs the matches: the Cuban
+*tresillo* is ``(3, 8)``; the Cumbia bell is ``(5, 8)``; the West-
+African ``(4, 9)`` shows up in the Aka Pygmy ``mbira`` patterns; and
+so on.
+
+In daStrudel this is one function: ``euclid(pat, k, n)``.
+
+Part A: ``bjorklund(k, n)`` — the underlying rhythm
+====================================================
+
+Before the combinator, here is the raw algorithm. ``bjorklund(3, 8)``
+returns a length-8 ``array<bool>`` with three ``true`` entries
+distributed evenly:
+
+.. code-block:: das
+
+    let r <- bjorklund(3, 8)
+    for (b in r) {
+        let glyph = b ? "x" : "."
+        print("{glyph} ")
+    }
+    // output: x . . x . . x .
+
+The implementation is a tight integer loop — no floating point, no
+fractional accumulation, just ``(i * k) / n`` integer division. This
+matters when you need to call it for big ``n`` values (per-event in a
+signal, for example) — it allocates one boolean array and is otherwise
+allocation-free.
+
+Part B: ``euclid(pat, k, n)``
+==============================
+
+``euclid`` first speeds the pattern up by ``n`` (so each input cycle now
+contains ``n`` repetitions), then keeps only the haps falling on the
+``k`` Bjorklund onsets. The classic Cuban tresillo:
+
+.. code-block:: das
+
+    let pat <- atom("bd") |> euclid(3, 8)
+    play(pat, 6.0)
+
+Three kicks over eight evenly-spaced steps — ``x . . x . . x .``.
+Replace ``atom("bd")`` with any Pattern and the same selection rule
+applies. ``s("bd sd")`` would alternate kick / snare across the kept
+onsets.
+
+Part C: A small library of classic rhythms
+==========================================
+
+Most of the patterns Toussaint catalogs are one ``euclid`` call:
+
+===========  ==================================
+``(k, n)``   Pattern
+===========  ==================================
+``(3, 4)``   Three-against-four feel
+``(3, 8)``   Cuban tresillo / Bossa kick
+``(5, 8)``   Cumbia bell, West-African
+``(7, 8)``   Dense, almost-straight
+``(2, 5)``   Persian *Khafif-e-ramal*
+``(3, 7)``   Bulgarian, *ruchenitza*
+``(5, 16)``  Bossa Nova clave (rotated form)
+===========  ==================================
+
+Try them by changing the integers:
+
+.. code-block:: das
+
+    let pat <- atom("hh") |> euclid(7, 8)
+    play(pat, 4.0)
+
+Part D: Polyrhythm via ``stack``
+================================
+
+``stack`` layers patterns simultaneously. Stack two Euclidean patterns
+with different ``k`` and you have a polyrhythm:
+
+.. code-block:: das
+
+    var kick <- atom("bd") |> euclid(3, 8)
+    var hat  <- atom("hh") |> euclid(5, 8)
+    var layers : array<Pattern>
+    layers |> emplace <| kick
+    layers |> emplace <| hat
+    let pat <- stack(layers)
+    play(pat, 6.0)
+
+Both layers complete every cycle (``n = 8`` in both), but the **3
+onsets** of the kick and the **5 onsets** of the hat sit at different
+grid positions, so the perceived feel is polyrhythmic. Use mismatched
+``n`` values (e.g. ``(3, 8)`` against ``(2, 5)``) and the cycle length
+becomes ``lcm(8, 5) = 40`` — the patterns realign every 40 steps.
+
+The ``var`` (not ``let``) on ``kick`` and ``hat`` matters: ``stack``
+takes ``array<Pattern>`` and ``emplace`` needs to **move** the lambda
+(Patterns are non-copyable lambdas) — that requires a mutable
+binding.
+
+Note on the ``bd(3,8)`` mini-notation form
+==========================================
+
+In the original Tidal/Strudel mini-notation, ``"bd(3,8)"`` is an inline
+shorthand for euclid. **This daStrudel build does not parse parentheses
+inside mini-notation strings** — the parser tokenises ``(`` and ``)``
+but does not assemble them into the euclid form. Use the function
+directly:
+
+.. code-block:: das
+
+    s("bd sd") |> euclid(5, 8)
+    atom("hh") |> euclid(3, 8)
+
+Rotation (Tidal's ``bd(3,8,1)``, the JS Strudel ``euclidRot``) is
+likewise not exposed as a standalone function in this build. To get a
+rotated rhythm you can reorder the elements inside the pattern fed to
+``euclid``, or chain ``rev`` / ``slow`` against a control pattern.
+
+Where next
+==========
+
+You now have the four building-block topics every strudel-style
+language needs: the data model (01), the mini-notation surface (02–03),
+the time algebra (04), and Euclidean rhythms (05). Tutorials 06+
+introduce **combinators** — ``jux``, ``every``, ``off``,
+``superimpose``, ``palindrome``, ``ply``, ``echo``, ``chunk`` — which
+turn one-line patterns into full musical phrases.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_05_euclidean_rhythms.das <../../../../tutorials/daStrudel/daStrudel_05_euclidean_rhythms.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_time`
+
+   Related: :ref:`tutorial_lambdas` — Patterns are non-copyable lambdas (hence ``var`` + ``emplace``)
+
+   Related: :ref:`tutorial_arrays` — ``array<Pattern>`` and ``emplace`` semantics

--- a/doc/source/reference/tutorials/daStrudel_06_stacking_combining.rst
+++ b/doc/source/reference/tutorials/daStrudel_06_stacking_combining.rst
@@ -1,0 +1,103 @@
+.. _tutorial_dastrudel_stacking_combining:
+
+=================================
+STRUDEL-06 — Stacking & Combining
+=================================
+
+.. index::
+    single: Tutorial; Strudel; Stacking
+    single: Tutorial; Strudel; stack
+    single: Tutorial; Strudel; cat
+    single: Tutorial; Strudel; layer
+    single: Tutorial; Strudel; superimpose
+
+Strudel patterns are values, not statements — and once you have a few of
+them, the next question is how to combine them.  This tutorial walks
+through four *structural combinators* that take patterns as input and
+return a new pattern:
+
+================  ==============  ===================================================
+``stack``         vertical        all patterns play simultaneously
+``cat``           horizontal      pattern *i* plays during cycle (i mod N)
+``layer``         vertical        a base pattern plus stacked transforms of itself
+``superimpose``   vertical        overlay one transformed copy of a pattern on top
+================  ==============  ===================================================
+
+All four return a fresh ``Pattern``, so you can pipe them through
+setters (``gain``, ``room``, ``orbit``, …) just like any other pattern.
+
+Part A: ``stack`` — play patterns at the same time
+==================================================
+
+``stack`` takes an array of patterns and merges their events into the
+same cycle.  Use it to combine independent voices (bass + lead + drums):
+
+.. code-block:: das
+
+    let pat <- stack([
+        note("c3 e3 g3 c4", "sine") |> sustain(0.5),
+        note("c5 ~ ~ g4 ~ ~ e4 ~", "triangle") |> sustain(0.3) |> gain(0.4)
+    ])
+
+Each element of the array is treated as one voice that runs in parallel.
+Note that ``stack`` consumes its argument array (``var pats`` parameter),
+so you cannot reuse the inner patterns afterwards.
+
+Part B: ``cat`` — sequence patterns across cycles
+=================================================
+
+``cat`` is the horizontal counterpart.  With *N* patterns in the array,
+pattern *i* plays during cycle (i mod N), each stretched to fill exactly
+one cycle.  This is the standard way to glue short building blocks into
+longer arrangements:
+
+.. code-block:: das
+
+    let pat <- cat([
+        note("c4 e4 g4 c5", "sine") |> sustain(0.4),
+        note("c5 g4 e4 c4", "sine") |> sustain(0.4),
+        note("c4 e4 g4 b4", "sine") |> sustain(0.4)
+    ])
+
+Three cycles of melody, then it loops.
+
+Part C: ``layer`` — chord-from-melody
+=====================================
+
+``layer(pats, base)`` stacks ``base`` plus every pattern in ``pats``.
+The idiom is to derive every layer from the same source so that one
+melody plays as a chord:
+
+.. code-block:: das
+
+    let pat <- layer([
+        note("c4 e4 g4 c5", "sine") |> sustain(0.4) |> transpose(4.0),  // major third
+        note("c4 e4 g4 c5", "sine") |> sustain(0.4) |> transpose(7.0)   // perfect fifth
+    ], note("c4 e4 g4 c5", "sine") |> sustain(0.4))                      // root
+
+Each note plays as a triad: root + third + fifth.
+
+Part D: ``superimpose`` — overlay a transformed copy
+====================================================
+
+``superimpose(pat, fn)`` is equivalent to ``stack([pat, fn(pat)])`` but
+reads more naturally because it takes the transform as a lambda.  Below
+we add a faster octave-up echo on top:
+
+.. code-block:: das
+
+    let pat <- superimpose(note("c4 e4 g4 c5", "sine") |> sustain(0.4),
+                           @(p) => gain(fast(transpose(p, 12.0), 2.0lf), 0.4))
+
+The lambda has type ``@(Pattern) => Pattern`` — the same shape every
+transforming combinator (``jux``, ``off``, ``superimpose``, …) expects.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_06_stacking_combining.das <../../../../tutorials/daStrudel/daStrudel_06_stacking_combining.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_euclid`
+
+   Next tutorial: :ref:`tutorial_dastrudel_per_voice_fx`
+
+   Related: :ref:`tutorial_lambdas`, :ref:`tutorial_functions`

--- a/doc/source/reference/tutorials/daStrudel_07_per_voice_fx.rst
+++ b/doc/source/reference/tutorials/daStrudel_07_per_voice_fx.rst
@@ -1,0 +1,103 @@
+.. _tutorial_dastrudel_per_voice_fx:
+
+=======================================
+STRUDEL-07 — Per-Voice FX & Combinators
+=======================================
+
+.. index::
+    single: Tutorial; Strudel; jux
+    single: Tutorial; Strudel; off
+    single: Tutorial; Strudel; chunk
+    single: Tutorial; Strudel; per-voice FX
+
+This tutorial covers the *transforming* combinators — those that take a
+``@(Pattern) => Pattern`` lambda and use it to derive a second copy of
+the input — and the daslang-specific *per-voice FX* group (phaser,
+tremolo, compressor, shape, crush).
+
+Part A: ``jux`` — stereo splitting via a transform
+==================================================
+
+``jux(pat, fn)`` plays the original pattern in the left channel and
+``fn(pat)`` in the right.  The classic move is to reverse the right
+side, producing the trademark live-coding stereo wobble:
+
+.. code-block:: das
+
+    let pat <- jux(note("c4 e4 g4 c5", "sine") |> sustain(0.4), @(p) => rev(p))
+
+Or transpose the right side up a fifth for instant harmony:
+
+.. code-block:: das
+
+    let pat <- jux(note("c4 e4 g4 c5", "sine") |> sustain(0.4),
+                   @(p) => transpose(p, 7.0))
+
+Any function ``Pattern → Pattern`` works as the transform — including
+combinators built out of ``stack``, ``cat`` or ``fast``.
+
+Part B: ``off`` — canon, delayed transformed copy
+=================================================
+
+``off(pat, time, fn)`` plays the original AND a copy of ``fn(pat)``
+delayed by ``time`` cycles.  With ``time = 0.25`` and an octave-up
+transpose you get a textbook canon at the octave:
+
+.. code-block:: das
+
+    let pat <- off(note("c4 e4 g4 b4", "sine") |> sustain(0.4), 0.25lf,
+                   @(p) => transpose(p, 12.0))
+
+The delayed voice obeys whatever the transform does to it — try
+``@(p) => fast(p, 2.0lf)`` to layer a faster echo, or ``rev`` for a
+retrograde answer.
+
+Part C: ``chunk`` — apply a transform to one slice at a time
+============================================================
+
+``chunk(pat, n, fn)`` divides each cycle into ``n`` equal slices and
+applies ``fn`` to slice 0 on cycle 0, slice 1 on cycle 1, and so on.
+Use it to add evolving variation without rewriting the pattern:
+
+.. code-block:: das
+
+    let pat <- chunk(note("c4 e4 g4 c5", "sine") |> sustain(0.4), 4,
+                     @(p) => fast(p, 2.0lf))
+
+Each beat in turn doubles in speed for one cycle, then settles back.
+
+Part D: per-voice FX (a daslang divergence)
+===========================================
+
+Most live-coding systems treat ``phaser``, ``tremolo``, ``compressor``,
+``shape``, ``crush`` as effects on a shared bus.  In daslang these are
+*per-voice* — each playing voice carries its own FX chain, applied
+**before** the voice mix is summed into the orbit.  Two simultaneous
+notes in a single ``stack`` can therefore use entirely different FX
+parameters without any cross-talk:
+
+.. code-block:: das
+
+    let pat <- stack([
+        note("c4", "sawtooth") |> sustain(1.0) |> phaser(0.5) |> gain(0.4),
+        note("g4", "sawtooth") |> sustain(1.0) |> phaser(2.0) |> gain(0.4)
+    ])
+
+Above, the C voice carries a slow phaser sweep while the G voice
+carries a fast one.  On a shared-bus system both voices would have to
+share the same rate.
+
+The per-voice setters available today: ``lpf``, ``hpf``, ``phaser`` /
+``ph``, ``tremolo`` / ``trem``, ``compressor``, ``shape``, ``crush``,
+``coarse``.  The shared-bus setters (``room``, ``delay``, ``chorus``)
+are covered in the next tutorial.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_07_per_voice_fx.das <../../../../tutorials/daStrudel/daStrudel_07_per_voice_fx.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_stacking_combining`
+
+   Next tutorial: :ref:`tutorial_dastrudel_effects_filters`
+
+   Related: :ref:`tutorial_lambdas`, :ref:`tutorial_function_pointers`

--- a/doc/source/reference/tutorials/daStrudel_08_effects_filters.rst
+++ b/doc/source/reference/tutorials/daStrudel_08_effects_filters.rst
@@ -1,0 +1,109 @@
+.. _tutorial_dastrudel_effects_filters:
+
+==============================
+STRUDEL-08 — Effects & Filters
+==============================
+
+.. index::
+    single: Tutorial; Strudel; lpf
+    single: Tutorial; Strudel; hpf
+    single: Tutorial; Strudel; reverb
+    single: Tutorial; Strudel; delay
+    single: Tutorial; Strudel; orbit
+    single: Tutorial; Strudel; phaser
+
+Strudel splits effects into two groups, distinguished by where they live
+in the signal graph:
+
+================== =========================== ================================================
+Group              Setters                     Lifetime
+================== =========================== ================================================
+Per-orbit bus FX   ``room``, ``delay``,        one shared instance per orbit; voices send wet
+                   ``chorus``                  / dry into it
+Per-voice FX       ``lpf``, ``hpf``,           baked into each individual voice; runs before
+                   ``phaser``, ``tremolo``,    mixdown into the orbit
+                   ``compressor``, ``shape``,
+                   ``crush``, ``coarse``
+================== =========================== ================================================
+
+This split lets you give each layer of a stack its own reverb and delay
+character (per-orbit), while still personalising every note's filter and
+modulation (per-voice).
+
+Part A: per-voice filters — ``lpf`` and ``hpf``
+===============================================
+
+``lpf(freq)`` cuts harmonics above ``freq`` Hz; ``hpf(freq)`` cuts below.
+Compare a muffled sawtooth (``lpf 200``) against a thin one
+(``hpf 2000``):
+
+.. code-block:: das
+
+    // Dark, all-bass:
+    let pat_lpf <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> lpf(200.0)
+
+    // Thin, all-treble:
+    let pat_hpf <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> hpf(2000.0)
+
+Each voice carries its own filter coefficients, so two stacked voices
+can be filtered differently.
+
+Part B: per-orbit reverb — ``room`` and ``roomsize``
+====================================================
+
+``room(amount)`` sets the wet send to the orbit's reverb bus;
+``roomsize(N)`` controls the room dimensions.  Both live on the bus, so
+all voices on the same orbit share one reverb instance:
+
+.. code-block:: das
+
+    let pat <- note("c4 ~ c4 ~", "sine") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> room(0.8) |> roomsize(2.0)
+
+Part C: per-orbit delay — tempo-aware by default
+================================================
+
+``delay(amount)``, ``delaytime(seconds)`` and ``delayfeedback(0..1)``
+drive the orbit's delay line.  ``delaytime`` defaults to a tempo-aware
+3/16 cycle (resolved from ``delaysync`` and the current cps), so plain
+``delay(0.5)`` already locks to the tempo even without a ``delaytime``
+setter.  Tutorial 09 covers the resolver in detail.
+
+.. code-block:: das
+
+    let pat <- note("c4 ~ e4 ~ g4 ~ c5 ~", "sine") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> delay(0.5) |> delaytime(0.5) |> delayfeedback(0.4)
+
+Part D: per-voice phaser
+========================
+
+``phaser(rateHz)`` sweeps a notch through the spectrum at the given
+rate.  Because it is per-voice, every note carries its own phase — two
+stacked voices stay independent, which is **not** how shared-bus
+live-coding systems behave.
+
+.. code-block:: das
+
+    let pat <- run(8) |> scale("D:pentatonic") |> sound("sawtooth") |> sustain(1.0) |> release(0.5) |> phaser(2.0)
+
+Part E: orbits — give each layer its own bus FX
+===============================================
+
+Different orbits get independent bus FX instances.  Below, orbit 0 sits
+in a tight small room while orbit 1 sits inside a cathedral:
+
+.. code-block:: das
+
+    let pat <- stack([
+        note("c4 ~ e4 ~", "sine") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> room(0.8) |> roomsize(0.5) |> orbit(0),
+        note("c3", "triangle") |> attack(0.5) |> decay(0.2) |> sustain(0.6) |> release(0.5) |> room(0.8) |> roomsize(8.0) |> orbit(1)
+    ])
+
+The pluck on orbit 0 sounds tight; the pad on orbit 1 swims in
+reverb — neither bleeds into the other.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_08_effects_filters.das <../../../../tutorials/daStrudel/daStrudel_08_effects_filters.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_per_voice_fx`
+
+   Next tutorial: :ref:`tutorial_dastrudel_adsr_envelopes`

--- a/doc/source/reference/tutorials/daStrudel_09_adsr_envelopes.rst
+++ b/doc/source/reference/tutorials/daStrudel_09_adsr_envelopes.rst
@@ -1,0 +1,125 @@
+.. _tutorial_dastrudel_adsr_envelopes:
+
+====================================
+STRUDEL-09 — ADSR & Envelope Shaping
+====================================
+
+.. index::
+    single: Tutorial; Strudel; ADSR
+    single: Tutorial; Strudel; attack
+    single: Tutorial; Strudel; decay
+    single: Tutorial; Strudel; sustain
+    single: Tutorial; Strudel; release
+    single: Tutorial; Strudel; tempo-aware defaults
+
+An ADSR envelope shapes a note's amplitude over time:
+
+==========  ============================================================
+Attack      time from key-down to peak amplitude
+Decay       time to fall from the peak to the sustain level
+Sustain     held level (0..1) while the note is on
+Release     time to fade to silence after key-up
+==========  ============================================================
+
+daslang's strudel uses **tempo-aware defaults** for ADSR.  Instead of
+fixed numeric defaults, each field defaults to ``-1`` — a sentinel
+meaning *unset*.  At playback time a resolver fills in sensible values
+based on which fields the user actually touched:
+
+============================== ===========================================
+Nothing set                    held tone — sustain = 1, tiny attack/release
+Only ``decay`` set             percussion — sustain auto-zeroes
+``sustain`` set explicitly     always wins
+============================== ===========================================
+
+The same idea applies to ``delaytime``: it defaults to ``-1`` and is
+derived from ``delaysync`` (in cycles) and the current cps so the echo
+locks to tempo automatically.
+
+Part A: default envelope — held tone
+====================================
+
+With no ADSR setters at all, the resolver picks a held-tone envelope:
+the note rings for its full scheduled duration, instead of decaying to
+silence in 50ms as in older defaults.
+
+.. code-block:: das
+
+    let pat <- note("c4 e4 g4 c5", "sine")
+
+This is the *unset → held* branch of the resolver.
+
+Part B: pluck — decay only
+==========================
+
+Set ``decay`` alone and the resolver assumes a percussive envelope:
+sustain drops to 0 so each note plucks then decays away.  This is the
+idiom for short, rhythmic synth blips:
+
+.. code-block:: das
+
+    let pat <- note("c4 e4 g4 c5", "sine") |> decay(0.15)
+
+No need to spell out ``sustain(0.0)`` — the resolver does it because
+*"only decay was set"*.
+
+Part C: pad — explicit ADSR
+===========================
+
+Setting all four fields gives full manual control.  A pad-style
+envelope uses a long attack so the note swells in, plus a long release
+so it fades out gradually after key-up:
+
+.. code-block:: das
+
+    let pat <- note("c3", "triangle") |> attack(0.5) |> decay(0.2) |> sustain(0.6) |> release(0.5)
+
+Because ``sustain`` was set explicitly, the resolver leaves all four
+values untouched.
+
+Part D: tempo-aware delay defaults
+==================================
+
+The "unset sentinel + resolver" idea also applies to ``delaytime``.
+Plain ``delay(0.6)`` without ``delaytime(...)`` derives ``delaytime``
+from ``delaysync`` (3/16 cycle by default) and the current cps.  This
+gives a dotted-eighth feel that **automatically tracks tempo
+changes**:
+
+.. code-block:: das
+
+    let pat_slow <- note("c4 ~ e4 ~ g4 ~", "sine") |> decay(0.15) |> delay(0.6)
+    play(pat_slow, 0.5lf, 4.0lf)
+
+    let pat_fast <- note("c4 ~ e4 ~ g4 ~", "sine") |> decay(0.15) |> delay(0.6)
+    play(pat_fast, 1.0lf, 4.0lf)
+
+Same pattern, two different cps — the echo timing follows the tempo.
+Setting ``delaytime`` (or ``delaysync``) explicitly bypasses the
+resolver.
+
+Part E: velocity via gain
+=========================
+
+``gain`` multiplies the envelope output.  Use it for a velocity curve
+over a pattern: alternating loud and soft hits while the envelope shape
+stays constant.
+
+.. code-block:: das
+
+    let pat <- stack([
+        note("c4", "sine") |> decay(0.15) |> gain(0.9),
+        note("e4", "sine") |> decay(0.15) |> gain(0.4),
+        note("g4", "sine") |> decay(0.15) |> gain(0.7),
+        note("c5", "sine") |> decay(0.15) |> gain(0.3)
+    ])
+
+Each voice keeps the same plucky envelope but a different peak level.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_09_adsr_envelopes.das <../../../../tutorials/daStrudel/daStrudel_09_adsr_envelopes.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_effects_filters`
+
+   Next tutorial: :ref:`tutorial_dastrudel_scales_music_theory`

--- a/doc/source/reference/tutorials/daStrudel_10_scales_music_theory.rst
+++ b/doc/source/reference/tutorials/daStrudel_10_scales_music_theory.rst
@@ -1,0 +1,104 @@
+.. _tutorial_dastrudel_scales_music_theory:
+
+==================================
+STRUDEL-10 — Scales & Music Theory
+==================================
+
+.. index::
+    single: Tutorial; Strudel; scale
+    single: Tutorial; Strudel; modes
+    single: Tutorial; Strudel; transposition
+
+Writing melodies in absolute pitches (``c4``, ``e4``, ``g4``) gets old
+fast — every key change means rewriting every note.  Strudel scales let
+you write in *degrees* (0, 1, 2, …) against a named scale.  Change the
+scale and the same degree pattern produces a new key, mode, or mood.
+
+Part A: ``scale_pattern`` — degrees against a scale
+===================================================
+
+``scale_pattern(notation, scale_def, sound)`` is a shorthand for
+``n(notation) |> scale(scale_def) |> sound(sound)``.  The same
+``"0 2 4 6"`` against C major and C minor is a one-line A/B test:
+
+.. code-block:: das
+
+    let pat <- stack([
+        scale_pattern("0 2 4 6", "C4:major") |> decay(0.2) |> gain(0.5),
+        scale_pattern("0 2 4 6", "C4:minor", "sawtooth") |> sustain(0.3) |> release(0.2) |> gain(0.3) |> lpf(2000.0)
+    ])
+
+Major sounds bright; minor sounds dark — same degrees, different
+intervals.
+
+Part B: pentatonic — only "safe" notes
+======================================
+
+``"C4:major:pentatonic"`` maps degrees 0..4 onto C, D, E, G, A — a
+five-note scale with no semitone clashes, so any degree pattern always
+sounds consonant.  Useful when you want guaranteed-pretty arpeggios
+without thinking about voice leading:
+
+.. code-block:: das
+
+    let pat <- scale_pattern("0 1 2 3 4", "C4:major:pentatonic") |> decay(0.1) |> release(0.2)
+
+Part C: modes — same root, different intervals
+==============================================
+
+Modes are seven-note scales that share the white-keys interval pattern
+but start on a different scale degree.  Two of the most distinctive:
+
+- ``dorian`` — minor with a *raised* sixth.  Jazzy, folksy.
+- ``mixolydian`` — major with a *flattened* seventh.  Bluesy.
+
+.. code-block:: das
+
+    let dorian_pat <- scale_pattern("0 1 2 3 4 5 6 7", "D4:dorian") |> decay(0.15) |> release(0.2)
+    let mixo_pat   <- scale_pattern("0 1 2 3 4 5 6 7", "G4:mixolydian") |> decay(0.15) |> release(0.2)
+
+The other supported modes are ``phrygian``, ``lydian`` and ``locrian``;
+all share the seven-note interval shape but rotate the starting degree.
+
+Part D: transposition
+=====================
+
+Two ways to transpose:
+
+1. **Change the scale root.**  ``"C4:major" → "E4:major"`` — degrees
+   stay the same; pitches shift.
+2. **Add ``transpose(semitones)``.**  Applied after pitch resolution,
+   shifts every note by the given number of semitones.
+
+.. code-block:: das
+
+    let pat <- stack([
+        scale_pattern("0 2 4 2", "C4:major") |> decay(0.15) |> gain(0.5),
+        scale_pattern("0 2 4 2", "C4:major") |> transpose(7.0) |> decay(0.15) |> gain(0.5)
+    ])
+
+Above, the second voice plays the same melody a perfect fifth higher.
+
+Part E: two octaves, same scale
+===============================
+
+Stack two ``scale_pattern`` voices at different octaves to build a
+bass + lead pair from one scale — switch the scale root (``C4`` vs
+``C5``) to move between octaves while keeping the degree pattern:
+
+.. code-block:: das
+
+    let pat <- stack([
+        scale_pattern("0 2 4 3", "C4:major:pentatonic", "sawtooth") |> sustain(0.3) |> release(0.1) |> lpf(500.0) |> gain(0.4),
+        scale_pattern("4 2 3 0", "C5:major:pentatonic") |> decay(0.05) |> release(0.2) |> delay(0.3) |> delayfeedback(0.3) |> gain(0.5)
+    ])
+
+Same scale, two octaves, two different envelopes — instant counterpoint.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_10_scales_music_theory.das <../../../../tutorials/daStrudel/daStrudel_10_scales_music_theory.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_adsr_envelopes`
+
+   Next tutorial: :ref:`tutorial_dastrudel_synthesis`

--- a/doc/source/reference/tutorials/daStrudel_11_synthesis.rst
+++ b/doc/source/reference/tutorials/daStrudel_11_synthesis.rst
@@ -1,0 +1,99 @@
+.. _tutorial_dastrudel_synthesis:
+
+==========================
+STRUDEL-11 — Synthesis
+==========================
+
+.. index::
+    single: Tutorial; Strudel; Synthesis
+    single: Tutorial; Oscillator
+    single: Tutorial; FM
+
+daStrudel ships five built-in oscillators, two noise generators, and a
+two-operator FM engine — enough to produce most classic subtractive and
+FM timbres without loading a single sample.  Every source is selected the
+same way: ``s("name")`` picks the voice, and the usual ADSR / filter
+chain shapes the result.
+
+Part A: Oscillators
+===================
+
+``s("sine" | "triangle" | "square" | "sawtooth" | "supersaw")`` picks the
+oscillator.  They share one API — the same ``attack`` / ``decay`` /
+``sustain`` / ``release`` and filter words apply to all of them:
+
+.. code-block:: das
+
+    require strudel/strudel
+
+    let pat <- s("<sine triangle square sawtooth>") |> note(48.0) |> attack(0.02) |> decay(0.1) |> sustain(0.7) |> release(0.3) |> lpf(2000.0)
+
+Tonal character:
+
+- ``sine`` — pure, no harmonics
+- ``triangle`` — soft, odd harmonics, gentle roll-off
+- ``square`` — hollow and woody, odd harmonics only
+- ``sawtooth`` — bright and buzzy, all harmonics
+
+Part B: Supersaw
+================
+
+``supersaw`` is seven detuned saws stacked into one voice — the classic
+"trance" pad sound.  It is much wider and fatter than a single saw; a
+low-pass filter tames the top end:
+
+.. code-block:: das
+
+    let pat <- note("c3,eb3,g3,c4", "supersaw") |> attack(0.1) |> decay(0.1) |> sustain(0.8) |> release(0.6) |> lpf(3500.0)
+
+Commas inside ``note()`` build chords — all four notes sound simultaneously
+per step.
+
+Part C: Noise
+=============
+
+``"white"`` and ``"pink"`` are pitch-less noise generators.  Pink noise
+has more energy in the low end — perceptually "warmer" than white.  Run
+them through filters to shape specific colours (ocean, wind, static,
+hi-hat):
+
+.. code-block:: das
+
+    let pat <- atom("pink") |> sustain(1.0) |> lpf(400.0) |> gain(0.4)
+
+``atom()`` wraps a plain string as a one-step pattern — useful when you
+want a continuous source with no rhythm.
+
+Part D: FM Synthesis
+====================
+
+FM modulates a sine carrier's frequency with a second sine.  Two knobs
+control the timbre:
+
+- ``fm(index)`` — modulation depth: higher = more harmonics, brighter sound
+- ``fmh(harmonicity)`` — ratio of modulator to carrier frequency
+
+Integer harmonicity values (1, 2, 3) sound musical; non-integer values
+produce inharmonic, bell- or clang-like timbres:
+
+.. code-block:: das
+
+    // Metallic bell — high inharmonic ratio
+    let bells <- note("c5", "sine") |> fm(1.0) |> fmh(7.0) |> decay(0.3) |> release(0.8)
+
+    // Gentle brass-like tone — integer ratio
+    let brass <- note("<c3 e3 g3 c4>", "sine") |> fm(2.0) |> fmh(2.0) |> attack(0.02) |> decay(0.2) |> sustain(0.6) |> release(0.3)
+
+The ``note("c5", "sine")`` form is shorthand for
+``s("sine") |> note("c5")`` — the second argument picks the oscillator.
+
+See :ref:`tutorial_lambdas` for how ``|>`` threads a pattern through a
+chain of modifiers — each ``|>`` returns a new ``Pattern``.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_11_synthesis.das <../../../../tutorials/daStrudel/daStrudel_11_synthesis.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_scales_music_theory`
+
+   Next tutorial: :ref:`tutorial_dastrudel_samples`

--- a/doc/source/reference/tutorials/daStrudel_12_samples.rst
+++ b/doc/source/reference/tutorials/daStrudel_12_samples.rst
@@ -1,0 +1,108 @@
+.. _tutorial_dastrudel_samples:
+
+==========================
+STRUDEL-12 — Samples
+==========================
+
+.. index::
+    single: Tutorial; Strudel; Samples
+    single: Tutorial; Sample bank
+    single: Tutorial; Pitch shift
+
+Oscillators cover a lot of ground but most modern music is built from
+samples.  daStrudel loads sample banks from disk and indexes them by
+name, so mini-notation patterns like ``s("bd sd hh cp")`` just work.
+
+Part A: Sample Banks
+====================
+
+A sample bank is a directory of folders — one folder per named sound.
+Every audio file inside the folder becomes an indexed variation:
+
+::
+
+   drums/
+     bd/            ← "bd" sound
+       BT0A0A7.wav  ← variation 0 (bd:0)
+       BT0AADA.wav  ← variation 1 (bd:1)
+       ...
+     sd/
+     hh/
+     cp/
+
+``strudel_load_sound`` loads one folder under a given name.  Files are
+sorted alphabetically, so the ``:0``, ``:1``, ... indices are stable:
+
+.. code-block:: das
+
+    require strudel/strudel_player
+
+    strudel_load_sound("{MEDIA}/drums/bd", "bd")
+    strudel_load_sound("{MEDIA}/drums/sd", "sd")
+    strudel_load_sound("{MEDIA}/drums/hh", "hh")
+    strudel_load_sound("{MEDIA}/drums/cp", "cp")
+
+Once loaded, the sounds are visible to every pattern through the
+mini-notation:
+
+.. code-block:: das
+
+    let pat <- s("bd sd hh cp") |> gain(0.7)
+
+Part B: Variations
+==================
+
+Multiple files in one sound folder are addressable as ``name:index``:
+
+.. code-block:: das
+
+    // Alternate two kick variations per cycle
+    let pat <- s("bd:0 bd:1 bd:0 bd:1") |> gain(0.7)
+
+Omitting the index (just ``"bd"``) always picks ``:0``.  Use variations
+to keep machine-gun patterns from sounding mechanical — even a pair of
+slightly different kicks feels more human than a single repeated file.
+
+Part C: Pitch Shifting with ``speed``
+=====================================
+
+``speed(factor)`` scales the sample playback rate.  ``speed(2.0)`` is one
+octave up and twice as fast; ``speed(0.5)`` is one octave down and half
+as fast.  It is tape-style pitch shifting — shorter or longer than the
+original:
+
+.. code-block:: das
+
+    let normal <- s("bd bd bd bd") |> speed(1.0) |> gain(0.6)
+    let pitched <- s("bd bd bd bd") |> speed(2.0) |> gain(0.6)
+
+``speed`` only affects sample playback; oscillator voices (``sine``,
+``sawtooth``, ...) ignore it and use ``note()`` for pitch instead.
+
+Part D: Single-file Decoding with ``load_audio_file``
+=====================================================
+
+Sometimes you just want to decode one audio file — to inspect it, to
+feed it into your own DSP chain, or to build a custom sample bank.
+``load_audio_file`` decodes WAV / MP3 / FLAC / OGG into a ``Sample``
+struct:
+
+.. code-block:: das
+
+    require strudel/strudel_samples
+
+    let sample <- load_audio_file("{MEDIA}/drums/bd/BT0A0A7.wav")
+    print("channels: {sample.channels}\n")
+    print("sample_rate: {sample.sample_rate} Hz\n")
+    print("frames: {length(sample.data) / sample.channels}\n")
+
+An empty ``Sample`` (``length(data) == 0``) signals a decode failure —
+always check before using the data.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_12_samples.das <../../../../tutorials/daStrudel/daStrudel_12_samples.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_synthesis`
+
+   Next tutorial: :ref:`tutorial_dastrudel_sf2_soundfont`

--- a/doc/source/reference/tutorials/daStrudel_13_sf2_soundfont.rst
+++ b/doc/source/reference/tutorials/daStrudel_13_sf2_soundfont.rst
@@ -1,0 +1,120 @@
+.. _tutorial_dastrudel_sf2_soundfont:
+
+===================================
+STRUDEL-13 — SF2 SoundFont Playback
+===================================
+
+.. index::
+    single: Tutorial; Strudel; SoundFont
+    single: Tutorial; SF2
+    single: Tutorial; General MIDI
+
+Sample banks are great for drums but painful for pitched instruments —
+a single kick sample works fine at any note, but a piano needs dozens of
+samples across the keyboard.  The General MIDI SoundFont format (.sf2)
+packs a whole orchestra of multi-sampled instruments into one file, with
+a standard preset numbering that makes playback portable.
+
+daStrudel loads GM SoundFonts directly and dispatches notes to SF2
+presets through the usual pattern chain.
+
+Part A: Loading a SoundFont
+===========================
+
+``strudel_load_sf2`` reads a ``.sf2`` file and activates it for the next
+patterns.  It returns ``true`` on success:
+
+.. code-block:: das
+
+    require strudel/strudel_player
+
+    if (!strudel_load_sf2("FluidR3_GM.sf2")) {
+        print("failed to load SoundFont\n")
+    }
+
+One SoundFont is active at a time; reloading replaces the previous one.
+Any General MIDI SoundFont works — FluidR3_GM, GeneralUser GS, Musyng
+Kite, Stolen Soundfont.  Larger fonts have more samples and sound better.
+
+Part B: Instruments by Name or Number
+=====================================
+
+Two ways to pick an instrument:
+
+.. code-block:: das
+
+    // By GM program name — looked up in the SoundFont's preset table
+    let piano <- note("c3 d3 e3 f3 g3 a3 b3 c4") |> sf2("piano") |> gain(0.6)
+
+    // By program number (0..127) — the raw GM program code
+    let flute <- note("c4 e4 g4") |> sf2(73) |> gain(0.5)
+
+Common GM program numbers:
+
+=================  =======================
+Program            Instrument
+=================  =======================
+0                  acoustic grand piano
+24                 nylon guitar
+40                 violin
+56                 trumpet
+73                 flute
+81                 lead square
+=================  =======================
+
+Use the program number when the name lookup does not match the preset
+names in your SoundFont, or when you want a specific patch.
+
+Part C: GM Drums on Bank 128
+============================
+
+The GM percussion kit lives on **bank 128** — every MIDI note number is
+a different drum.  Switch to it with ``sf2(0) |> sf2_bank(128)`` and
+play the drum map directly:
+
+.. code-block:: das
+
+    let drums <- note("c2 ~ d2 ~, [fs2 fs2] [fs2 fs2] [fs2 fs2] [fs2 fs2]") |> sf2(0) |> sf2_bank(128) |> gain(0.7)
+
+Key drum mappings (octave 2):
+
+=================  =======================
+Note               Drum
+=================  =======================
+c2 (36)            bass drum
+d2 (38)            snare
+eb2 (39)           hand clap
+cs2 (37)           side stick
+fs2 (42)           closed hi-hat
+as2 (46)           open hi-hat
+=================  =======================
+
+Part D: Expression and Velocity
+===============================
+
+Pitched SF2 presets respond to two kinds of per-note dynamics:
+
+- ``velocity(v)`` — attack intensity (0..1) — changes timbre as well as level
+- ``sf2_expression(e)`` — continuous volume (0..1) — pure level control
+
+Together they drive realistic phrasing.  This example stacks two string
+layers at different expression levels to thicken the pad:
+
+.. code-block:: das
+
+    let pat <- stack([
+        note("<[c3,e3,g3] [f3,a3,c4]>") |> sf2("string_ensemble") |> sf2_expression(0.3) |> gain(0.5),
+        note("<[g3,b3,d4] [a3,c4,e4]>") |> sf2("string_ensemble") |> sf2_expression(1.0) |> gain(0.5)
+    ])
+
+SF2 playback in daStrudel is a daslang-only extension — there is no
+equivalent in strudel.cc.  See :ref:`strudel_vs_strudel_cc` for the full
+list of daslang-only features.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_13_sf2_soundfont.das <../../../../tutorials/daStrudel/daStrudel_13_sf2_soundfont.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_samples`
+
+   Next tutorial: :ref:`tutorial_dastrudel_midi_files`

--- a/doc/source/reference/tutorials/daStrudel_14_midi_files.rst
+++ b/doc/source/reference/tutorials/daStrudel_14_midi_files.rst
@@ -1,0 +1,107 @@
+.. _tutorial_dastrudel_midi_files:
+
+==========================
+STRUDEL-14 — MIDI Files
+==========================
+
+.. index::
+    single: Tutorial; Strudel; MIDI
+    single: Tutorial; Standard MIDI File
+    single: Tutorial; Tempo map
+
+daStrudel parses and plays Standard MIDI Files (.mid) — the universal
+sheet-music format.  You get a structured view of tracks, events, and
+tempo, plus a high-level ``midi_play`` entry point that runs the file
+through either built-in samples or an SF2 SoundFont.
+
+Part A: Parsing
+===============
+
+``load_midi`` reads a ``.mid`` file and returns a ``MidiFile`` struct:
+
+.. code-block:: das
+
+    require strudel/strudel_midi
+
+    let midi = load_midi("fur_elise.mid")
+    print("Format: {midi.format}\n")         // 0 = single track, 1 = multi-track
+    print("Ticks/QN: {midi.ticks_per_qn}\n") // timing resolution
+    print("Tracks: {length(midi.tracks)}\n")
+
+Each track is a ``MidiTrack`` containing an array of ``MidiEvent``.
+Events carry a ``tick`` timestamp, a ``MidiEventKind`` (note-on, note-off,
+control change, tempo, etc.), a ``channel`` number, and two data bytes.
+
+Format 0 packs everything into one track; format 1 uses parallel tracks
+— daStrudel handles both.  ``ticks_per_qn`` is the time resolution:
+higher values mean finer timing subdivisions.
+
+Part B: Merging and Tempo
+=========================
+
+``merge_tracks`` collapses all tracks into one stable-sorted event
+stream, which is easier to walk for analysis:
+
+.. code-block:: das
+
+    var merged <- merge_tracks(midi)
+    for (evt in merged) {
+        if (evt.kind == MidiEventKind.midi_tempo && evt.tempo > 0) {
+            let bpm = 60000000.0 / float(evt.tempo)
+            print("Tempo change at tick {evt.tick}: {bpm:.1f} BPM\n")
+        }
+    }
+
+Tempo events store microseconds-per-quarter-note in the ``tempo`` field;
+convert to BPM with ``60_000_000 / tempo``.  Files with no tempo events
+default to 120 BPM.
+
+Part C: Playback with Sample Banks
+==================================
+
+The ``midi_play`` path uses the audio system's streaming infrastructure
+and a built-in piano + drum sample bank.  The lifecycle:
+
+.. code-block:: das
+
+    require strudel/strudel_midi_player
+
+    midi_load_samples(media_path)   // load built-in banks from media folder
+    midi_init()                     // start the playback thread
+    midi_play("music", "fur_elise.mid", [gain = 0.6, looping = false])
+    sleep(6000u)
+    midi_stop("music")
+    midi_shutdown()
+
+The first argument to ``midi_play`` is an arbitrary **track name** — you
+can play multiple MIDI files at once and control them independently
+(cross-fade, stop, set volume) via that name.
+
+Part D: Playback with SF2
+=========================
+
+For higher-quality rendering, swap the sample backend for a General MIDI
+SoundFont.  ``midi_load_sf2`` activates it; subsequent ``midi_play``
+calls dispatch notes through the SoundFont presets (channel 10 uses the
+GM drum kit automatically):
+
+.. code-block:: das
+
+    midi_load_sf2("FluidR3_GM.sf2")
+    midi_init()
+    midi_play("music", "Bach_Air_on_G_string.mid", [gain = 1.0])
+    sleep(8000u)
+    midi_shutdown()
+
+The SF2 backend respects program change events — if the MIDI file
+switches instruments mid-song, the SoundFont follows.  Pair with
+:ref:`tutorial_dastrudel_sf2_soundfont` for per-instrument control from
+live patterns.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_14_midi_files.das <../../../../tutorials/daStrudel/daStrudel_14_midi_files.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_sf2_soundfont`
+
+   Next tutorial: :ref:`tutorial_dastrudel_live_reloading`

--- a/doc/source/reference/tutorials/daStrudel_15_live_reloading.rst
+++ b/doc/source/reference/tutorials/daStrudel_15_live_reloading.rst
@@ -1,0 +1,161 @@
+.. _tutorial_dastrudel_live_reloading:
+
+====================================
+STRUDEL-15 — Live-Reloading Patterns
+====================================
+
+.. index::
+    single: Tutorial; Strudel; Live-reloading
+    single: Tutorial; Hot reload
+    single: Tutorial; Live commands
+
+This is the killer feature.  ``daslang-live.exe`` compiles your script,
+runs it, then watches the file on disk — every save triggers a recompile
+and a hot-reload of the new code **without stopping the audio stream**.
+Edit a pattern, save, hear the change.  No process restart, no decoder
+cost, no audio glitch.
+
+Run this tutorial under the live host:
+
+::
+
+   bin/Release/daslang-live.exe tutorials/daStrudel/daStrudel_15_live_reloading.das
+
+It also runs under plain ``daslang.exe`` — the file works in both hosts.
+In standalone mode there is no hot-reload and the lifecycle collapses to
+``main()``.
+
+Part A: Lifecycle Functions
+===========================
+
+Scripts that export ``init`` / ``update`` / ``shutdown`` run in
+**lifecycle mode** under daslang-live:
+
+.. code-block:: das
+
+    [export] def init() { ... }      // called on start and after every reload
+    [export] def update() { ... }    // called every frame
+    [export] def shutdown() { ... }  // called on exit and before every reload
+
+The audio thread and any OS resources (windows, sample banks) live
+outside the reload scope — only the daScript side recompiles.
+
+Part B: Preserving Player State
+===============================
+
+``require strudel/strudel_live`` is all it takes to keep the strudel
+player state alive across reloads.  The module registers
+``[before_reload]`` and ``[after_reload]`` hooks that serialise the
+player (tracks, SID, BPM, timing) and the loaded SF2 data into the
+persistent byte store:
+
+.. code-block:: das
+
+    require strudel/strudel public
+    require strudel/strudel_player
+    require strudel/strudel_live   // auto-persists player state
+    require live_host
+
+    def strudel_main() {
+        strudel_add_track(s("bd [hh hh] sd [hh cp]"))
+        strudel_set_bpm(120.0lf)
+        strudel_play()
+    }
+
+    [export] def init() {
+        load_samples()
+        strudel_init(@@strudel_main)
+    }
+
+Edit the pattern inside ``strudel_main`` and save — the audio system
+keeps rolling, ``strudel_init`` runs again, and the new pattern takes
+over on the next cycle boundary.  The SID (sound identifier) stays the
+same, so external audio routing is unaffected.
+
+Part C: Live Commands (REST API)
+================================
+
+``[live_command]`` annotations expose daScript functions over HTTP.
+daslang-live starts a REST server on port 9090; any external tool can
+drive the running script via ``POST /command``:
+
+.. code-block:: das
+
+    require live/live_commands
+    require daslib/json_boost
+
+    struct CmdBpmArgs {
+        bpm : double = 120.0lf
+    }
+
+    [live_command(description="Set tempo in BPM")]
+    def cmd_set_bpm(input : JsonValue?) : JsonValue? {
+        let args = from_JV(input, type<CmdBpmArgs>)
+        strudel_set_bpm(args.bpm)
+        return JV("bpm set to {args.bpm}")
+    }
+
+Call it from the shell:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:9090/command \
+      -d '{"name":"cmd_set_bpm","args":{"bpm":140}}'
+
+The MCP server exposes these commands through the ``live_command`` tool
+so AI assistants can steer a running strudel patch directly.  See
+:ref:`tutorial_annotations` for annotation syntax.
+
+Part D: Custom Persistent State
+===============================
+
+strudel_live handles the player.  Your own state needs its own hooks —
+use ``[before_reload]`` / ``[after_reload]`` and the persistent byte
+store to keep globals alive:
+
+.. code-block:: das
+
+    var g_reload_count : int = 0
+
+    [before_reload]
+    def save_my_state() {
+        var data : array<uint8>
+        data |> resize(4)
+        unsafe { *reinterpret<int?>(addr(data[0])) = g_reload_count; }
+        live_store_bytes("tutorial15_reload_count", data)
+    }
+
+    [after_reload]
+    def restore_my_state() {
+        var data : array<uint8>
+        if (live_load_bytes("tutorial15_reload_count", data) && length(data) >= 4) {
+            unsafe { g_reload_count = *reinterpret<int?>(addr(data[0])); }
+            g_reload_count ++
+        }
+    }
+
+The store takes arbitrary byte arrays keyed by string.  For structured
+data, serialise with ``daslib/archive`` (which is how strudel_live
+preserves the player itself).
+
+Workflow Tips
+=============
+
+- Save the file to reload — the file-watcher does the rest.
+- Hit ``POST /reload`` for a manual reload.
+- ``POST /reload/full`` does a deeper recompilation if module-level
+  structure changed.
+- ``is_live_mode()`` returns ``true`` under daslang-live, ``false`` under
+  daslang.exe — branch on it for dual-mode scripts.
+- A compile error freezes the running version — fix, save again, and the
+  new code takes over.  The audio never stops.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_15_live_reloading.das <../../../../tutorials/daStrudel/daStrudel_15_live_reloading.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_midi_files`
+
+   Comparison with strudel.cc: :ref:`strudel_vs_strudel_cc`
+
+   Full daStrudel reference: :ref:`stdlib_strudel_section`

--- a/doc/source/stdlib/handmade/module-strudel_event.rst
+++ b/doc/source/stdlib/handmade/module-strudel_event.rst
@@ -1,0 +1,1 @@
+Module strudel_event

--- a/doc/source/stdlib/handmade/module-strudel_live.rst
+++ b/doc/source/stdlib/handmade/module-strudel_live.rst
@@ -1,0 +1,1 @@
+Module strudel_live

--- a/doc/source/stdlib/handmade/module-strudel_midi_player.rst
+++ b/doc/source/stdlib/handmade/module-strudel_midi_player.rst
@@ -1,0 +1,1 @@
+Module strudel_midi_player

--- a/doc/source/stdlib/handmade/module-strudel_mini.rst
+++ b/doc/source/stdlib/handmade/module-strudel_mini.rst
@@ -1,0 +1,1 @@
+Module strudel_mini

--- a/doc/source/stdlib/handmade/module-strudel_pattern.rst
+++ b/doc/source/stdlib/handmade/module-strudel_pattern.rst
@@ -1,0 +1,1 @@
+Module strudel_pattern

--- a/doc/source/stdlib/handmade/module-strudel_player.rst
+++ b/doc/source/stdlib/handmade/module-strudel_player.rst
@@ -1,0 +1,1 @@
+Module strudel_player

--- a/doc/source/stdlib/handmade/module-strudel_samples.rst
+++ b/doc/source/stdlib/handmade/module-strudel_samples.rst
@@ -1,0 +1,1 @@
+Module strudel_samples

--- a/doc/source/stdlib/handmade/module-strudel_scales.rst
+++ b/doc/source/stdlib/handmade/module-strudel_scales.rst
@@ -1,0 +1,1 @@
+Module strudel_scales

--- a/doc/source/stdlib/handmade/module-strudel_scheduler.rst
+++ b/doc/source/stdlib/handmade/module-strudel_scheduler.rst
@@ -1,0 +1,1 @@
+Module strudel_scheduler

--- a/doc/source/stdlib/handmade/module-strudel_sf2_voice.rst
+++ b/doc/source/stdlib/handmade/module-strudel_sf2_voice.rst
@@ -1,0 +1,1 @@
+Module strudel_sf2_voice

--- a/doc/source/stdlib/handmade/module-strudel_synth.rst
+++ b/doc/source/stdlib/handmade/module-strudel_synth.rst
@@ -1,0 +1,1 @@
+Module strudel_synth

--- a/doc/source/stdlib/handmade/module-strudel_time.rst
+++ b/doc/source/stdlib/handmade/module-strudel_time.rst
@@ -1,0 +1,1 @@
+Module strudel_time

--- a/doc/source/stdlib/index.rst
+++ b/doc/source/stdlib/index.rst
@@ -39,5 +39,6 @@ THE SOFTWARE.
    sec_code_quality.rst
    sec_media.rst
    sec_audio.rst
+   sec_strudel.rst
 
 

--- a/doc/source/stdlib/sec_audio.rst
+++ b/doc/source/stdlib/sec_audio.rst
@@ -11,5 +11,3 @@ Audio playback, 3D spatial audio, effects, WAV file I/O, MIDI parsing, and SF2 s
    generated/audio.rst
    generated/audio_boost.rst
    generated/audio_wav.rst
-   generated/strudel_midi.rst
-   generated/strudel_sf2.rst

--- a/doc/source/stdlib/sec_strudel.rst
+++ b/doc/source/stdlib/sec_strudel.rst
@@ -1,0 +1,28 @@
+.. _stdlib_strudel_section:
+
+**************************
+Strudel (Live Coding)
+**************************
+
+Pattern-based live-coding music library: cycle-space time, mini-notation DSL,
+pattern algebra and combinators, synthesis, samples, SF2 soundfonts, MIDI
+playback, per-voice effect chains, and a threaded playback harness.
+
+See also :ref:`tutorials_dastrudel` and :ref:`strudel_vs_strudel_cc`.
+
+.. toctree::
+
+   generated/strudel_event.rst
+   generated/strudel_time.rst
+   generated/strudel_pattern.rst
+   generated/strudel_mini.rst
+   generated/strudel_scales.rst
+   generated/strudel_synth.rst
+   generated/strudel_samples.rst
+   generated/strudel_scheduler.rst
+   generated/strudel_player.rst
+   generated/strudel_midi.rst
+   generated/strudel_midi_player.rst
+   generated/strudel_sf2.rst
+   generated/strudel_sf2_voice.rst
+   generated/strudel_live.rst

--- a/modules/dasAudio/strudel/strudel_event.das
+++ b/modules/dasAudio/strudel/strudel_event.das
@@ -1,71 +1,124 @@
 options gen2
 options indenting = 4
 
-module strudel_event shared
+module strudel_event shared public
+//! The `Event` payload — "what to play and how" — plus ADSR and delay-time resolvers.
+//! Every pattern event carries one `Event` with sound, note, gain, filter, envelope,
+//! and effect settings. `-1.0` in an ADSR field means "unset — resolver picks default".
 
 require math
 
-// The payload of every pattern event — "what to play and how".
-// All defaults are "do nothing" values: gain 0.8 is a sensible level,
-// lpf 0 means "no filter" (undefined = no filter).
+//! Payload of every pattern event. Defaults are "do nothing" values: `gain = 0.8` is
+//! a sensible level, `lpf = 0` means "no filter", and ADSR fields of `-1.0` mean "unset".
 struct Event {
     s       : string = ""       // sound name: "bd", "sd", "sawtooth", "sine"
+        //! Sound/sample name (`"bd"`, `"sd"`, `"sawtooth"`, `"sine"`, ...).
     note    : float = 60.0      // MIDI note number (60 = middle C)
+        //! MIDI note number (60 = middle C).
     n       : int = 0           // sample variation index (bd:0, bd:1, bd:2)
+        //! Sample variation index within a bank (`bd:0`, `bd:1`, `bd:2`).
     gain    : float = 0.8       // amplitude 0.0–1.0 (applied after rendering)
+        //! Amplitude 0.0–1.0, applied after rendering.
     velocity : float = 1.0     // expression 0.0–1.0 (scales gain, may affect timbre later)
+        //! Expression 0.0–1.0; scales `gain` and may affect timbre.
     pan     : float = 0.5       // stereo pan: 0.0 = left, 0.5 = center, 1.0 = right
+        //! Stereo pan: 0.0 = left, 0.5 = center, 1.0 = right.
     speed   : float = 1.0       // sample playback speed (1.0 = normal)
+        //! Sample playback speed (1.0 = normal, 2.0 = double, 0.5 = half).
     lpf     : float = 0.0       // low-pass filter cutoff Hz (0 = no filter; set to activate)
+        //! Low-pass filter cutoff in Hz (0 = disabled).
     lpq     : float = 1.0       // low-pass filter resonance Q (1.0 = gentle, >5 = peaky)
+        //! Low-pass filter resonance Q (1.0 = gentle, >5 = peaky).
     hpf     : float = 0.0       // high-pass filter cutoff Hz (0 = off)
+        //! High-pass filter cutoff in Hz (0 = disabled).
     hpq     : float = 1.0       // high-pass filter resonance Q (1.0 = gentle, >5 = peaky)
+        //! High-pass filter resonance Q (1.0 = gentle, >5 = peaky).
     attack  : float = -1.0      // envelope attack time in seconds (-1 = unset → resolver picks default)
+        //! Envelope attack time in seconds (-1 = unset, resolver picks default).
     decay   : float = -1.0      // envelope decay time (-1 = unset)
+        //! Envelope decay time in seconds (-1 = unset).
     sustain : float = -1.0      // envelope sustain level (-1 = unset; full sustain if no ADSR set, percussion if decay set alone)
+        //! Envelope sustain level 0.0–1.0 (-1 = unset).
     release : float = -1.0      // envelope release time (-1 = unset)
+        //! Envelope release time in seconds (-1 = unset).
     cut     : int = 0           // cut group (0 = no cut, >0 = kill same group)
+        //! Cut group (0 = no cut, >0 = kill any voice with the same cut id).
     room    : float = 0.0       // reverb send amount 0.0–1.0
+        //! Reverb send amount 0.0–1.0.
     roomsize : float = 2.0      // reverb decay time in seconds (0.1–10.0)
+        //! Reverb decay time in seconds (0.1–10.0).
     delay_amount : float = 0.0  // delay send amount 0.0–1.0
+        //! Delay send amount 0.0–1.0.
     delaytime    : float = -1.0 // delay time in seconds (-1 = unset → derived from delaysync and cps)
+        //! Delay time in seconds (-1 = unset, derived from `delaysync` and cps).
     delayfeedback : float = 0.5 // delay feedback 0.0–1.0
+        //! Delay feedback 0.0–1.0.
     delaysync    : float = 0.1875 // delay time in cycles (3/16 cycle); used when delaytime is unset
+        //! Delay time in cycles; used when `delaytime` is unset (default = 3/16 cycle, dotted-eighth feel).
     orbit   : int = 0           // effect bus routing (0 = default)
+        //! Effect-bus routing id (0 = default bus).
     fm      : float = 0.0       // FM synthesis modulation depth
+        //! FM synthesis modulation depth.
     fmh     : float = 1.0       // FM harmonicity ratio (modulator freq / carrier freq)
+        //! FM harmonicity ratio (modulator frequency / carrier frequency).
     vowel   : string = ""      // vowel formant filter ("a", "e", "i", "o", "u", etc.)
+        //! Vowel formant filter (`"a"`, `"e"`, `"i"`, `"o"`, `"u"`, ...).
     chorus  : float = 0.0       // chorus send amount 0.0–1.0
+        //! Chorus send amount 0.0–1.0.
     // Sample region (0.0–1.0 of sample length)
     begin   : float = 0.0       // sample start position (0.0 = start)
+        //! Sample region start (fraction of sample length, 0.0 = beginning).
     end_pos : float = 1.0       // sample end position (1.0 = end). Named end_pos to avoid keyword conflict.
+        //! Sample region end (fraction of sample length, 1.0 = end). Named to avoid the `end` keyword.
     // Audio effects
     crush   : float = 0.0       // bit depth reduction (0 = off, 4–16 = bit depth)
+        //! Bit-depth reduction (0 = off, 4–16 = target bit depth).
     coarse  : int = 0           // sample rate reduction factor (0 = off, 2 = half rate, etc.)
+        //! Sample-rate reduction factor (0 = off, 2 = half rate).
     shape   : float = 0.0       // waveshaper drive (0 = off, >0 = saturated)
+        //! Waveshaper drive (0 = off, >0 = saturated).
     djf     : float = 0.5       // DJ filter (0 = full LPF, 0.5 = off, 1 = full HPF)
+        //! DJ filter (0 = full LPF, 0.5 = bypass, 1 = full HPF).
     bpf     : float = 0.0       // bandpass filter cutoff Hz (0 = off)
+        //! Bandpass filter cutoff in Hz (0 = disabled).
     bpq     : float = 1.0       // bandpass filter Q
+        //! Bandpass filter resonance Q.
     // Phaser (single notch biquad with LFO-modulated center)
     phaser        : float = 0.0     // phaser LFO rate in Hz (0 = off)
+        //! Phaser LFO rate in Hz (0 = off).
     phaserdepth   : float = 0.75    // phaser depth 0..1 (notch Q + sweep scale)
+        //! Phaser depth 0.0–1.0 (controls notch Q and sweep range).
     phasercenter  : float = 1000.0  // phaser center frequency Hz
+        //! Phaser center frequency in Hz.
     phasersweep   : float = 2000.0  // phaser sweep range Hz
+        //! Phaser sweep range in Hz.
     // Tremolo (amplitude modulation)
     tremolo       : float = 0.0     // tremolo LFO rate in Hz (0 = off)
+        //! Tremolo LFO rate in Hz (0 = off).
     tremolodepth  : float = 1.0     // tremolo depth 0..1
+        //! Tremolo depth 0.0–1.0.
     // Compressor (threshold in dB; >=0 = bypass)
     compressor    : float = 1.0     // threshold dB (>=0 = bypass; typical -20..-3)
+        //! Compressor threshold in dB (>=0 = bypass; typical -20..-3).
     compressor_ratio   : float = 10.0   // compression ratio (>=1)
+        //! Compression ratio (>=1).
     compressor_knee    : float = 10.0   // soft-knee width in dB
+        //! Compressor soft-knee width in dB.
     compressor_attack  : float = 0.005  // attack time seconds
+        //! Compressor attack time in seconds.
     compressor_release : float = 0.05   // release time seconds
+        //! Compressor release time in seconds.
     // SF2 SoundFont
     sf2_program    : int = -1   // SF2 GM program number (-1 = not SF2, use sample/oscillator)
+        //! SF2 GM program number (-1 = not SF2; use sample/oscillator instead).
     sf2_bank       : int = 0    // SF2 bank (0 = melodic, 128 = percussion)
+        //! SF2 bank (0 = melodic, 128 = percussion).
     sf2_expression : float = -1.0 // SF2 expression CC11 (0.0–1.0, -1 = use default)
+        //! SF2 expression (CC11) 0.0–1.0 (-1 = use default).
     sf2_mod_wheel  : float = -1.0 // SF2 mod wheel CC1 (0.0–1.0, -1 = use default)
+        //! SF2 mod wheel (CC1) 0.0–1.0 (-1 = use default).
     sf2_pitch_bend : float = -1.0 // SF2 pitch bend (0.0–1.0 where 0.5 = center, -1 = use default)
+        //! SF2 pitch bend 0.0–1.0 (0.5 = center, -1 = use default).
 }
 
 // Resolve ADSR fields from their "user set / unset" form (−1 = unset) into concrete
@@ -78,6 +131,11 @@ struct Event {
 //
 // All values are clamped to envmin/releaseMin floors so a stray 0 never produces a click.
 def resolve_adsr(attack, decay, sustain, release : float) : tuple<float; float; float; float> {
+    //! Resolve ADSR fields from their "user set / unset" form (-1 = unset) into concrete
+    //! envelope parameters. Rules: nothing set -> tiny edges + full sustain; only decay
+    //! set -> percussion (sustain drops to zero); only attack/release set -> held tone;
+    //! sustain set explicitly -> uses the given value. All values are clamped to floors
+    //! so a stray 0 never produces a click.
     let envmin = 0.001
     let envmax = 1.0
     let release_min = 0.01
@@ -101,6 +159,9 @@ def resolve_adsr(attack, decay, sustain, release : float) : tuple<float; float; 
 // the tempo. The 3/16-cycle default yields a dotted-eighth feel that changes
 // automatically when the user changes cps.
 def resolve_delaytime(delaytime, delaysync, cps : float) : float {
+    //! Resolve delay time: use `delaytime` if set (>= 0), otherwise derive from
+    //! `delaysync` (in cycles) and the current `cps` so the echo locks to tempo.
+    //! The 3/16-cycle default yields a dotted-eighth feel that tracks tempo changes.
     if (delaytime >= 0.0) {
         return delaytime
     }

--- a/modules/dasAudio/strudel/strudel_midi.das
+++ b/modules/dasAudio/strudel/strudel_midi.das
@@ -53,6 +53,7 @@ struct MidiEvent {
 //! A sequence of MIDI events forming one track.
 struct MidiTrack {
     events : array<MidiEvent>
+        //! Events in this track, in order of absolute tick position.
 }
 
 //! Parsed MIDI file containing header info and tracks.
@@ -119,7 +120,7 @@ def read_vlq(data : array<uint8>; var cursor : int&) : int {
 
 // ─── Track Parser ───
 
-def parse_midi_track(data : array<uint8>; var cursor : int&) : MidiTrack {
+def private parse_midi_track(data : array<uint8>; var cursor : int&) : MidiTrack {
     //! Parse a single MTrk chunk starting at cursor, returning the track with all events.
     var track : MidiTrack
     // expect "MTrk"

--- a/modules/dasAudio/strudel/strudel_midi_player.das
+++ b/modules/dasAudio/strudel/strudel_midi_player.das
@@ -4,6 +4,9 @@ options no_unused_block_arguments = false
 options no_unused_function_arguments = false
 
 module strudel_midi_player shared public
+//! MIDI Standard File playback on a dedicated audio thread.
+//! Routes events to either a GM-preset oscillator/sample path or an SF2 soundfont,
+//! mixes multiple tracks through reverb/chorus buses, and exposes a command-channel API.
 
 require strudel/strudel_midi
 require strudel/strudel_synth
@@ -19,15 +22,23 @@ require math
 
 // ─── GM Instrument Presets ───
 
+//! General MIDI instrument preset: oscillator waveform and ADSR envelope.
 struct GmPreset {
     osc   : OscType = OscType.osc_sine
+        //! Oscillator waveform used to synthesise the instrument.
     att   : float = 0.005
+        //! Envelope attack time in seconds.
     dec   : float = 0.1
+        //! Envelope decay time in seconds.
     sus   : float = 0.5
+        //! Envelope sustain level in [0, 1].
     rel   : float = 0.15
+        //! Envelope release time in seconds.
 }
 
 def gm_preset(program : int) : GmPreset {
+    //! Map a General MIDI program number (0-127) to a `GmPreset` used by the oscillator path.
+    //! Groups programs by GM family (piano, strings, brass, synth lead/pad, ...) and returns a reasonable default envelope per family.
     if (program < 8) {         // Piano — percussive, no sustain
         return GmPreset(osc = OscType.osc_triangle, att = 0.002, dec = 1.5, sus = 0.0, rel = 0.1)
     } elif (program < 16) {    // Chromatic Percussion
@@ -67,6 +78,8 @@ def gm_preset(program : int) : GmPreset {
 // ─── Channel 10 Drum Map ───
 
 def render_drum_hit(note : int; velocity : float) : array<float> {
+    //! Render a GM channel-10 drum hit for `note` at the given velocity as a mono PCM buffer.
+    //! Dispatches to the appropriate `render_*` drum voice from `strudel_synth`; falls back to a short hi-hat burst for unmapped notes.
     let gain = velocity
     if (note == 35 || note == 36) {
         return <- render_bd(0.5, gain)
@@ -117,7 +130,7 @@ def render_drum_hit(note : int; velocity : float) : array<float> {
 
 // ─── GM Drum Note → Sample Bank Name ───
 
-def gm_drum_name(note : int) : string {
+def private gm_drum_name(note : int) : string {
     if (note == 35 || note == 36) { return "bd"; }
     if (note == 37) { return "sidestick"; }
     if (note == 38 || note == 40) { return "sd"; }
@@ -137,9 +150,9 @@ def gm_drum_name(note : int) : string {
 
 // ─── Piano Note → Sample Mapping ───
 
-let PIANO_PITCH_CENTERS = fixed_array(29, 35, 40, 45, 50, 55, 59, 62, 65, 71, 76, 81, 86, 91, 96)
+let private PIANO_PITCH_CENTERS = fixed_array(29, 35, 40, 45, 50, 55, 59, 62, 65, 71, 76, 81, 86, 91, 96)
 
-def piano_sample_name(midi_note : int) : tuple<name : string; speed : float> {
+def private piano_sample_name(midi_note : int) : tuple<name : string; speed : float> {
     var best = 62
     var bestDist = 200
     for (n in PIANO_PITCH_CENTERS) {
@@ -156,6 +169,8 @@ def piano_sample_name(midi_note : int) : tuple<name : string; speed : float> {
 // ─── MIDI ADSR (sustain holds until note-off) ───
 
 def midi_adsr(elapsed, note_off_elapsed, attack, decay, sustain, release : float) : float {
+    //! Evaluate the MIDI-style ADSR at `elapsed` seconds since note-on and `note_off_elapsed` seconds since note-off.
+    //! `note_off_elapsed < 0` means the note is still held. The sustain phase also decays exponentially so long-held notes fade.
     if (elapsed < 0.0) {
         return 0.0
     }
@@ -183,6 +198,7 @@ def midi_adsr(elapsed, note_off_elapsed, attack, decay, sustain, release : float
 
 // ─── MIDI Voice ───
 
+//! One active oscillator/sample voice on the legacy (non-SF2) MIDI playback path.
 struct MidiVoice {
     channel     : int
     note        : int
@@ -206,6 +222,7 @@ struct MidiVoice {
 
 // ─── Channel State ───
 
+//! Per-MIDI-channel playback state (program, CCs, pitch bend, sustain pedal).
 struct MidiChannelState {
     program    : int = 0
     volume     : float = 1.0    // CC7 (linear 0-1, used for non-SF2 voices)
@@ -220,37 +237,60 @@ struct MidiChannelState {
     cc_raw     : int[128]
 }
 
-def channel_init_cc(var ch : MidiChannelState) {
+def private channel_init_cc(var ch : MidiChannelState) {
     sf2_default_cc_values(ch.cc_raw)
 }
 
 // ─── Playback State (per track) ───
 
+//! Top-level playback state for a single MIDI track (multiple tracks are mixed by the audio thread).
 struct MidiPlaybackState {
     name           : string
+        //! Track name supplied by the caller (also used by ``midi_stop`` / ``midi_set_volume``).
     events         : array<MidiEvent>   // merged, sorted by tick
+        //! All MIDI events across tracks, merged and sorted by absolute tick.
     @safe_when_uninitialized channels : MidiChannelState[16]
+        //! Per-channel state (program, CCs, pitch bend, sustain pedal).
     voices         : array<MidiVoice?>
+        //! Active oscillator/sample voices (legacy path; unused when SF2 is active).
     csf2_voices    : array<ma_sf2_voice>   // SF2-based voices (C, for real-time rendering)
+        //! Active SF2 voices rendered by the C runtime.
     bank           : SampleBank const?  // optional sample bank (pointer to main context)
+        //! Optional sample bank pointer (owned by the main context).
     sf2            : SF2File const?     // optional SF2 soundfont (pointer to main context)
+        //! Optional SF2 soundfont pointer (owned by the main context).
     ticks_per_qn   : int = 480          // from MIDI file
+        //! Ticks per quarter note, taken from the MIDI file header.
     event_index    : int = 0
+        //! Index of the next event in `events` to process.
     current_tick   : double = 0.0lf
+        //! Current playback position in ticks.
     ticks_per_sec  : double = 0.0lf
+        //! Conversion factor from seconds to ticks (depends on current tempo).
     tempo_usec     : int = 500000       // default 120 BPM
+        //! Current tempo in microseconds per quarter note (500000 = 120 BPM).
     playback_time  : double = 0.0lf
+        //! Elapsed playback time in seconds.
     looping        : bool = false
+        //! If true, playback restarts from the beginning when the track ends.
     gain           : float = 1.0
+        //! Current linear gain applied to the track mix.
     target_gain    : float = 1.0
+        //! Fade target for `gain`; used by `midi_set_volume` to implement fades.
     fade_speed     : float = 0.0
+        //! Fade rate per second; 0 means instantaneous.
     remove_when_silent : bool = false
+        //! If true, the track is removed once it fades to zero (used by ``midi_stop``).
     done           : bool = false
+        //! Set to true when playback has finished and no voices remain.
     mixer          : ma_volume_mixer
+        //! Volume/pan mixer used for drum and sample voices.
     mixer_ready    : bool = false
+        //! True after `ma_volume_mixer_init` has been called on `mixer`.
 }
 
 def init_playback(var state : MidiPlaybackState; midi : MidiFile const?; name : string; gain : float; looping : bool; bank : SampleBank const? = null; sf2 : SF2File const? = null) {
+    //! Initialise a `MidiPlaybackState` from a parsed `MidiFile`, merging its tracks and resetting per-channel state to GM defaults.
     state.name = name
     state.events <- merge_tracks(*midi)
     state.gain = gain
@@ -270,7 +310,7 @@ def init_playback(var state : MidiPlaybackState; midi : MidiFile const?; name : 
 // ─── SF2 Voice Management ───
 
 // Per-voice metadata not stored in ma_sf2_voice (C struct doesn't have these)
-struct SF2VoiceMeta {
+struct private SF2VoiceMeta {
     channel : int = 0
     note : int = 0
     exclusive_class : int = 0
@@ -363,6 +403,8 @@ def private sf2_note_off(var state : MidiPlaybackState; ch, note : int) {
 // ─── Event Processing ───
 
 def process_events(var state : MidiPlaybackState) {
+    //! Dispatch all MIDI events up to the current playback tick: note-on/off, program changes, CCs, pitch bend, tempo.
+    //! Routes note events either to the SF2 voice allocator or to the legacy oscillator/sample path depending on `state.sf2`.
     while (state.event_index < length(state.events)) {
         let ev & = unsafe(state.events[state.event_index])
         if (double(ev.tick) > state.current_tick) {
@@ -508,6 +550,8 @@ def process_events(var state : MidiPlaybackState) {
 // ─── Render One Tick ───
 
 def midi_tick(var state : MidiPlaybackState; chunk_seconds : float) : array<float> {
+    //! Advance playback by `chunk_seconds`, process pending events, render all active voices and return an interleaved stereo PCM chunk.
+    //! Handles oscillator voices, drum/sample playback, SF2 voices, and the shared reverb/chorus send buses.
     process_events(state)
     let chunkFrames = int(chunk_seconds * float(SAMPLE_RATE))
     let chunkSamples = chunkFrames * 2  // stereo
@@ -750,7 +794,7 @@ def midi_tick(var state : MidiPlaybackState; chunk_seconds : float) : array<floa
 
 // ─── Command Channel ───
 
-variant MidiCommand {
+variant private MidiCommand {
     shutdown     : bool;
     add_track    : MidiTrackCmd;
     remove_track : string;
@@ -758,7 +802,7 @@ variant MidiCommand {
     set_pause    : bool;
 }
 
-struct MidiTrackCmd {
+struct private MidiTrackCmd {
     name    : string
     file    : MidiFile const?   // pointer to main context's g_midi_files entry
     bank    : SampleBank const? // pointer to main context's sample bank (optional)
@@ -973,12 +1017,14 @@ def private midi_thread_main(sid : uint64; var cmd_channel : Channel?; var done_
 
 // ─── Public API ───
 
-// Set a visualization channel for MIDI audio output. Call before midi_init().
 def public midi_set_audio_vis_channel(var ch : Channel?) {
+    //! Register a channel that will receive rendered audio chunks for visualisation; call before `midi_init`.
     g_midi_audio_vis_ptr = unsafe(reinterpret<void?>(ch))
 }
 
 def public midi_init() {
+    //! Start the MIDI playback thread and attach it to the running audio stream.
+    //! No-op if already running; panics if the audio system has not been initialised first.
     if (g_midi_running) {
         return
     }
@@ -1003,8 +1049,8 @@ def public midi_init() {
     g_midi_running = true
 }
 
-// Load standard piano + drum samples into the module-global bank.
 def public midi_load_samples(media_path : string) {
+    //! Populate the module-global sample bank with piano samples (`note_{n}`) and GM drum samples under `media_path`.
     // piano samples
     for (n in PIANO_PITCH_CENTERS) {
         load_sound("{media_path}/piano/note_{n}", "note_{n}", g_midi_bank)
@@ -1016,13 +1062,15 @@ def public midi_load_samples(media_path : string) {
     }
 }
 
-// Load an SF2 soundfont into the module-global slot.
 def public midi_load_sf2(path : string) : bool {
+    //! Load an SF2 soundfont from disk into the module-global slot; returns true on success.
     g_midi_sf2 = sf2_load(path)
     return g_midi_sf2 != null
 }
 
 def public midi_play(name : string; path : string; gain : float = 1.0; looping : bool = false; bank : SampleBank const? = null; use_sf2 : bool = true) : bool {
+    //! Parse a .mid file from disk and submit it for playback under `name`.
+    //! Auto-starts the playback thread if needed; falls back to the oscillator/sample path when no SF2 is loaded or `use_sf2` is false.
     g_midi_files[name] <- load_midi(path)
     if (length(g_midi_files[name].tracks) == 0) {
         g_midi_files |> erase(name)
@@ -1046,6 +1094,8 @@ def public midi_play(name : string; path : string; gain : float = 1.0; looping :
 }
 
 def public midi_play_data(name : string; data : array<uint8>; gain : float = 1.0; looping : bool = false; bank : SampleBank const? = null; use_sf2 : bool = true) : bool {
+    //! Parse a .mid file from an in-memory byte array and submit it for playback under `name`.
+    //! Same semantics as `midi_play` but sourced from memory instead of disk.
     g_midi_files[name] <- parse_midi(data)
     if (length(g_midi_files[name].tracks) == 0) {
         g_midi_files |> erase(name)
@@ -1069,6 +1119,7 @@ def public midi_play_data(name : string; data : array<uint8>; gain : float = 1.0
 }
 
 def public midi_stop(name : string = "") {
+    //! Stop a single track by name, or shut down the whole playback thread when `name` is empty.
     if (!g_midi_running) {
         return
     }
@@ -1086,6 +1137,7 @@ def public midi_stop(name : string = "") {
 }
 
 def public midi_set_volume(name : string; volume : float; fade : float = 0.0) {
+    //! Set the linear gain of a named track, optionally fading over `fade` seconds (0 = instantaneous).
     if (!g_midi_running || g_midi_cmd_channel == null) {
         return
     }
@@ -1098,6 +1150,7 @@ def public midi_set_volume(name : string; volume : float; fade : float = 0.0) {
 }
 
 def public midi_set_pause(paused : bool) {
+    //! Pause or resume all MIDI playback (the underlying audio stream continues with silence while paused).
     if (!g_midi_running || g_midi_cmd_channel == null) {
         return
     }
@@ -1105,6 +1158,7 @@ def public midi_set_pause(paused : bool) {
 }
 
 def public midi_shutdown() {
+    //! Stop the playback thread and release its channels; blocks until the audio thread confirms shutdown.
     if (!g_midi_running || g_midi_cmd_channel == null) {
         return
     }
@@ -1125,11 +1179,12 @@ def public midi_shutdown() {
 }
 
 def public midi_is_playing() : bool {
+    //! Return true while the MIDI playback thread is running.
     return g_midi_running
 }
 
-// Initialize reverb + chorus for offline rendering (midi_tick without midi_init/thread).
 def public midi_init_reverb() {
+    //! Initialise the module-global reverb and chorus effects for offline rendering (calling `midi_tick` without running the thread).
     if (g_reverb == null) {
         g_reverb = new ConvolutionReverb
         conv_reverb_init(g_reverb, SAMPLE_RATE, 2.0, 15000.0, 1000.0, 0.01)

--- a/modules/dasAudio/strudel/strudel_mini.das
+++ b/modules/dasAudio/strudel/strudel_mini.das
@@ -1,7 +1,10 @@
 options gen2
 options indenting = 4
 
-module strudel_mini shared
+module strudel_mini shared public
+//! Mini-notation tokenizer and parser — the strudel DSL for describing patterns as strings.
+//! Turns `"bd sd [hh hh] cp"` into a `Pattern` via `s()` / `n()` / `seq()`. Also provides
+//! fluent setters (`set_s`, `set_vowel`, `note_pattern`) and aliases (`s`, `note`, `vowel`).
 
 require strudel/strudel_event
 require strudel/strudel_time
@@ -11,36 +14,59 @@ require strings  // to_int, to_float, to_double, slice
 
 // ─── Tokenizer ───
 
+//! Mini-notation token kind.
 enum TokenKind {
     WORD        // bd, sd, c3, sawtooth
+        //! Identifier: sound name, note name, or keyword.
     NUMBER      // 3, 0.5
+        //! Numeric literal.
     TILDE       // ~ (silence)
+        //! Silence `~`.
     LBRACKET    // [
+        //! Opening bracket `[` — start of a subsequence.
     RBRACKET    // ]
+        //! Closing bracket `]` — end of a subsequence.
     LANGLE      // <
+        //! Opening angle `<` — start of an alternation (slowcat).
     RANGLE      // >
+        //! Closing angle `>` — end of an alternation.
     LPAREN      // (
+        //! Opening parenthesis `(` — reserved.
     RPAREN      // )
+        //! Closing parenthesis `)` — reserved.
     COMMA       // ,
+        //! Comma `,` — stack separator.
     STAR        // *
+        //! Star `*` — fast modifier (`x*n` = `x` played `n` times).
     SLASH       // /
+        //! Slash `/` — slow modifier (`x/n` = `x` stretched over `n` cycles).
     BANG        // !
+        //! Bang `!` — replicate modifier.
     AT          // @
+        //! At `@` — weight modifier (`x@n` occupies `n` units of the parent sequence).
     QUESTION    // ?
+        //! Question `?` — degrade modifier (random drop).
     COLON       // :
+        //! Colon `:` — sample-index modifier (`bd:1` picks variation 1).
     PIPE        // |
+        //! Pipe `|` — bar separator in `seq(...)`.
     EOF_TOKEN
+        //! End-of-input marker.
 }
 
+//! A single mini-notation token.
 struct Token {
     kind : TokenKind
+        //! Token kind.
     text : string
+        //! Source text of the token.
     pos  : int
+        //! Byte offset of the token in the original input string.
 }
 
-// Tokenize a mini-notation string.
-// Uses peek_data for O(1) per-character access instead of character_at (which is O(n)).
 def tokenize(input : string) : array<Token> {
+    //! Tokenize a mini-notation string into an array of `Token`. Uses `peek_data` for
+    //! O(1) per-character access. An `EOF_TOKEN` is always appended at the end.
     var tokens : array<Token>
     peek_data(input) $(data) {
         var i = 0
@@ -138,22 +164,22 @@ def tokenize(input : string) : array<Token> {
 //   atom_expr = WORD | NUMBER | "~" | "[" pattern "]" | "<" seq_expr+ ">"
 //   modifier  = "*" NUMBER | "/" NUMBER | "!" NUMBER | "?" NUMBER?
 
-struct Parser {
+struct private Parser {
     tokens : array<Token>
     pos    : int = 0
 }
 
-def peek(p : Parser) : Token {
+def private peek(p : Parser) : Token {
     return p.tokens[p.pos]
 }
 
-def advance(var p : Parser) : Token {
+def private advance(var p : Parser) : Token {
     let tok = p.tokens[p.pos]
     p.pos ++
     return tok
 }
 
-def expect_token(var p : Parser; kind : TokenKind) : Token {
+def private expect_token(var p : Parser; kind : TokenKind) : Token {
     let tok = peek(p)
     if (tok.kind != kind) {
         panic("mini-notation parse error at {tok.pos}: expected {kind}, got {tok.kind} '{tok.text}'")
@@ -161,12 +187,12 @@ def expect_token(var p : Parser; kind : TokenKind) : Token {
     return advance(p)
 }
 
-def at_end(p : Parser) : bool {
+def private at_end(p : Parser) : bool {
     return p.tokens[p.pos].kind == TokenKind.EOF_TOKEN
 }
 
 // Is the current token the start of an element?
-def is_element_start(p : Parser) : bool {
+def private is_element_start(p : Parser) : bool {
     let k = peek(p).kind
     return k == TokenKind.WORD || k == TokenKind.NUMBER || k == TokenKind.TILDE || k == TokenKind.LBRACKET || k == TokenKind.LANGLE
 }
@@ -174,7 +200,7 @@ def is_element_start(p : Parser) : bool {
 // Forward declarations via mutual recursion — daScript handles this.
 
 // parse_pattern → stack_expr
-def parse_pattern(var p : Parser) : Pattern {
+def private parse_pattern(var p : Parser) : Pattern {
     var first <- parse_seq(p)
     if (peek(p).kind != TokenKind.COMMA) {
         return <- first
@@ -191,7 +217,7 @@ def parse_pattern(var p : Parser) : Pattern {
 }
 
 // parse_seq → element+ → fastcat (or weighted_fastcat if _ or @ used)
-def parse_seq(var p : Parser) : Pattern {
+def private parse_seq(var p : Parser) : Pattern {
     var elements : array<Pattern>
     var weights : array<float>
     var has_weights = false
@@ -231,7 +257,7 @@ def parse_seq(var p : Parser) : Pattern {
 }
 
 // parse_element → atom_expr modifier*
-def parse_element(var p : Parser) : Pattern {
+def private parse_element(var p : Parser) : Pattern {
     var pat <- parse_atom(p)
     // apply modifiers
     while (!at_end(p)) {
@@ -275,7 +301,7 @@ def parse_element(var p : Parser) : Pattern {
 }
 
 // parse_atom → WORD | NUMBER | ~ | [ pattern ] | < seq+ >
-def parse_atom(var p : Parser) : Pattern {
+def private parse_atom(var p : Parser) : Pattern {
     let tok = peek(p)
     if (tok.kind == TokenKind.WORD) {
         advance(p)
@@ -316,12 +342,10 @@ def parse_atom(var p : Parser) : Pattern {
 
 // ─── Note Name Parsing ───
 
-// Try to parse a note name like "c3", "eb4", "fs2" → MIDI number.
-// Returns -1.0 if not a note name.
-// Parse a note name with explicit octave. "d3", "eb4", "fs3". Returns -1 on miss.
-// Used by the mini-notation tokenizer — bare letters like "d" are treated as sounds,
-// not notes, so `s("a e i")` can be vowels or sound names without collision.
 def parse_note_name(name : string) : float {
+    //! Parse a note name with explicit octave (`"c3"`, `"eb4"`, `"fs2"`) into a MIDI
+    //! number. Returns `-1.0` on miss. Bare letters without an octave return -1 —
+    //! this is intentional so `s("a e i")` parses as sound names, not notes.
     let n = length(name)
     if (n < 2 || n > 3) {
         return -1.0
@@ -362,10 +386,9 @@ def parse_note_name(name : string) : float {
     return result
 }
 
-// Parse a note name allowing octave to be omitted (defaults to default_oct,
-// e.g. noteToMidi(note, defaultOctave=3)). "d", "d#", "d#3", "eb".
-// Returns -1 if the string isn't a valid note.
 def parse_note_name_default(name : string; default_oct : int) : float {
+    //! Parse a note name allowing the octave to be omitted (falls back to `default_oct`).
+    //! Accepts `"d"`, `"d#"`, `"d#3"`, `"eb"`. Returns `-1.0` on miss.
     let n = length(name)
     if (n < 1 || n > 3) {
         return -1.0
@@ -413,7 +436,7 @@ def parse_note_name_default(name : string; default_oct : int) : float {
 // Parse notation with | bar separators.
 // "A B | C D E" = cat([fastcat([A, B]), fastcat([C, D, E])])
 // Each bar plays for one cycle; notes within a bar subdivide evenly.
-def parse_bars(var p : Parser) : Pattern {
+def private parse_bars(var p : Parser) : Pattern {
     // check if there are any PIPE tokens — if not, fall back to regular parsing
     var has_pipes = false
     for (tok in p.tokens) {
@@ -453,27 +476,25 @@ def parse_bars(var p : Parser) : Pattern {
 
 // ─── Public API ───
 
-// Parse mini-notation and return a Pattern of sound events.
-// s("bd sd [hh hh] cp") → fastcat([atom("bd"), atom("sd"), fastcat([atom("hh"), atom("hh")]), atom("cp")])
 def s(notation : string) : Pattern {
+    //! Parse mini-notation and return a `Pattern` of sound events. Example:
+    //! `s("bd sd [hh hh] cp")` plays kick, snare, two hats in one step, clap.
     var tokens <- tokenize(notation)
     var p = Parser()
     p.tokens <- tokens
     return <- parse_pattern(p)
 }
 
-// Parse mini-notation as numeric values (note field holds the number).
-// n("<2 16>") → pattern alternating 2.0 and 16.0 per cycle.
-// Useful as patternified parameter: slow(pat, n("<2 16>"))
 def n(notation : string) : Pattern {
+    //! Parse mini-notation as numeric values (each atom's `note` field holds the number).
+    //! Useful as a patternified parameter, e.g. `slow(pat, n("<2 16>"))`.
     return <- s(notation)
 }
 
-// pat |> set_vowel("a") — static vowel, or
-// pat |> set_vowel("<a e i o u>") — cycling vowel from mini-notation.
-// Single token (no spaces, brackets, or angle brackets) → static fmap.
-// Otherwise → parse as mini-notation pattern, sample at each event's onset.
 def set_vowel(var pat : Pattern; notation : string) : Pattern {
+    //! Apply a vowel-formant filter. Static: `pat |> set_vowel("a")`. Cycling:
+    //! `pat |> set_vowel("<a e i o u>")` parses mini-notation and samples at each
+    //! event's onset. Single-token input takes a fast-path `fmap`.
     // detect mini-notation: contains space, <, >, [, ], *, or comma
     var is_pattern = false
     for (ch in notation) {
@@ -496,17 +517,18 @@ def set_vowel(var pat : Pattern; notation : string) : Pattern {
     })
 }
 
-// pat |> set_vowel(s("<a e i o u>") |> slow(5.0lf)) — set vowel from a pre-built pattern.
-// Use when the vowel pattern needs transforms (slow, fast, rev) before applying.
 def set_vowel(var pat : Pattern; var vowel_pat : Pattern) : Pattern {
+    //! Set vowel from a pre-built pattern. Use when the vowel pattern needs transforms
+    //! (`slow`, `fast`, `rev`) before applying — e.g. `pat |> set_vowel(s("<a e i o u>") |> slow(5.0lf))`.
     return combineWithStr(pat, vowel_pat, @(e : Event; val : string) : Event {
         var r = e; r.vowel = val; return r
     })
 }
 
-// pat |> set_s("<supersaw sawtooth>") — strudel-style .s() with mini-notation.
-// Single token → static set_sound. Mini-notation → parse and sample at onset.
 def set_s(var pat : Pattern; notation : string) : Pattern {
+    //! Strudel-style `.s()` with mini-notation. Example: `pat |> set_s("<supersaw sawtooth>")`.
+    //! Single-token input goes through `set_sound` directly; mini-notation is parsed
+    //! and sampled at each event's onset.
     // detect mini-notation: contains space, <, >, [, ], *, or comma
     var is_pattern = false
     for (ch in notation) {
@@ -522,9 +544,10 @@ def set_s(var pat : Pattern; notation : string) : Pattern {
     return set_sound(pat, sound_pat)
 }
 
-// Parse mini-notation for note patterns.
-// note("c3 ~ e3 g3") → pattern with note events (sound defaults to "sine")
 def note_pattern(notation : string; sound : string = "sine") : Pattern {
+    //! Parse mini-notation for note patterns. Example: `note_pattern("c3 ~ e3 g3")`
+    //! plays C3, silence, E3, G3 with the default `"sine"` sound. Any atom whose
+    //! token looks like a note name is converted via default-octave parsing.
     let pat <- s(notation)
     // Post-process: any event whose .s is a note name (including bare "d", "d#"
     // without octave) gets converted to .note via default-octave parsing.
@@ -544,9 +567,10 @@ def note_pattern(notation : string; sound : string = "sine") : Pattern {
     return <- converted |> set_sound(sound)
 }
 
-// Parse mini-notation with | bar separators for sequential melodies.
-// "e4 e4 f4 g4 | g4 f4 e4 d4" → each bar is one cycle, notes subdivide evenly.
 def seq(notation : string; sound : string = "sine") : Pattern {
+    //! Parse mini-notation with `|` bar separators for sequential melodies. Each bar
+    //! plays for one cycle with its notes evenly subdivided. Example:
+    //! `seq("e4 e4 f4 g4 | g4 f4 e4 d4")` plays two bars of four quarter-notes each.
     var tokens <- tokenize(notation)
     var p = Parser()
     p.tokens <- tokens
@@ -558,22 +582,25 @@ def seq(notation : string; sound : string = "sine") : Pattern {
 // These re-parse the notation to create two independent patterns,
 // since lambdas aren't copyable.
 
-// every_fast(4, 2.0, "bd sd hh cp") — double speed every 4th cycle
 def every_fast(n : int; factor : double; notation : string) : Pattern {
+    //! Apply `fast(factor)` to the pattern every `n`th cycle. Example:
+    //! `every_fast(4, 2.0, "bd sd hh cp")` plays at double speed on cycles 4, 8, 12, ...
     let on <- s(notation) |> fast(factor)
     let off <- s(notation)
     return <- every(n, on, off)
 }
 
-// every_slow(4, 2.0, "bd sd hh cp") — half speed every 4th cycle
 def every_slow(n : int; factor : double; notation : string) : Pattern {
+    //! Apply `slow(factor)` to the pattern every `n`th cycle. Example:
+    //! `every_slow(4, 2.0, "bd sd hh cp")` plays at half speed on cycles 4, 8, 12, ...
     let on <- s(notation) |> slow(factor)
     let off <- s(notation)
     return <- every(n, on, off)
 }
 
-// every_degrade(4, 0.5, "bd sd hh cp") — randomly drop events every 4th cycle
 def every_degrade(n : int; prob : float; notation : string) : Pattern {
+    //! Randomly drop events from the pattern every `n`th cycle. Example:
+    //! `every_degrade(4, 0.5, "bd sd hh cp")` drops ~half the events on cycles 4, 8, ...
     let on <- s(notation) |> degrade(prob)
     let off <- s(notation)
     return <- every(n, on, off)
@@ -581,11 +608,18 @@ def every_degrade(n : int; prob : float; notation : string) : Pattern {
 
 // ─── Bare-Name Aliases ───
 
-// note("c3 e3 g3") — alias for note_pattern
-def note(notation : string; sound : string = "sine") : Pattern { return <- note_pattern(notation, sound); }
+def note(notation : string; sound : string = "sine") : Pattern {
+    //! Alias for `note_pattern`. Example: `note("c3 e3 g3")`.
+    return <- note_pattern(notation, sound);
+}
 
-// vowel("a") or vowel("<a e i>") — alias for set_vowel (string overload)
-def vowel(var pat : Pattern; notation : string) : Pattern { return <- set_vowel(pat, notation); }
+def vowel(var pat : Pattern; notation : string) : Pattern {
+    //! Alias for `set_vowel` (string overload). Example: `pat |> vowel("<a e i>")`.
+    return <- set_vowel(pat, notation);
+}
 
-// vowel(s("<a e i>") |> slow(4.0lf)) — alias for set_vowel (Pattern overload)
-def vowel(var pat : Pattern; var vowel_pat : Pattern) : Pattern { return <- set_vowel(pat, vowel_pat); }
+def vowel(var pat : Pattern; var vowel_pat : Pattern) : Pattern {
+    //! Alias for `set_vowel` (Pattern overload). Use when the vowel pattern needs
+    //! transforms. Example: `pat |> vowel(s("<a e i>") |> slow(4.0lf))`.
+    return <- set_vowel(pat, vowel_pat);
+}

--- a/modules/dasAudio/strudel/strudel_pattern.das
+++ b/modules/dasAudio/strudel/strudel_pattern.das
@@ -1,21 +1,32 @@
 options gen2
 options indenting = 4
 
-module strudel_pattern shared
+module strudel_pattern shared public
+//! Core pattern algebra and fluent DSL for daStrudel.
+//! A Pattern is a pure function from time span to events (haps). This module
+//! provides constructors (`pure`, `silence`, `atom`), time operators (`fast`,
+//! `slow`, `stack`, `cat`), combinators (`rev`, `jux`, `every`, `euclid`, ...),
+//! signals (`sine`, `saw`, `perlin`), and the full per-hap parameter setter
+//! surface (`gain`, `pan`, `note`, `lpf`, `room`, ADSR, phaser, ...).
 
 require strudel/strudel_event
 require strudel/strudel_time
 require math
 
-// A Pattern is a function from time span to events.
-// Patterns are pure — no side effects, no audio, just data.
+//! A Pattern is a pure function from a query `TimeSpan` to the `Hap`s
+//! (events with timing info) that fall within it. No side effects, no audio —
+//! just data. All combinators in this module take and return `Pattern`.
 typedef Pattern = lambda<(span : TimeSpan) : array<Hap>>
+//! A function pattern → pattern. Passed to combinators like ``jux`` and ``off``
+//! to describe how the transformed copy of a pattern should differ from the
+//! original. Use ``@(x) => rev(x)`` for a lambda literal at call sites.
 typedef PatternTransform = lambda<(var pat : Pattern) : Pattern>
 
 // ─── Constructors ───
 
 // A single event spanning every cycle.
 def pure(value : Event) : Pattern {
+    //! Lifts an `Event` into a `Pattern` that emits that value once per cycle, spanning the entire cycle.
     return @capture(= value) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var inscope split = splitSpans(span)
@@ -30,6 +41,7 @@ def pure(value : Event) : Pattern {
 
 // No events, ever.
 def silence() : Pattern {
+    //! The empty pattern — produces no haps for any query span.
     return @(span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         return <- result
@@ -38,6 +50,7 @@ def silence() : Pattern {
 
 // Shorthand: make a pattern from a sound name.
 def atom(name : string) : Pattern {
+    //! Shorthand for `pure(Event(s=name))` — a pattern with one event per cycle using the named sound. Example: `atom("bd")`.
     return pure(Event(s = name))
 }
 
@@ -45,6 +58,7 @@ def atom(name : string) : Pattern {
 
 // Speed up by factor n. The pattern repeats n times per cycle.
 def fast(var pat : Pattern; n : double) : Pattern {
+    //! Speeds up `pat` by factor `n` — the pattern repeats `n` times per cycle. Example: `s("bd") |> fast(2.0lf)`.
     return @capture(= n, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         let innerSpan = TimeSpan(start = span.start * n, stop = span.stop * n)
@@ -65,11 +79,12 @@ def fast(var pat : Pattern; n : double) : Pattern {
 
 // Slow down by factor n.
 def slow(var pat : Pattern; n : double) : Pattern {
+    //! Slows down `pat` by factor `n` — `pat` takes `n` cycles to complete once. Example: `s("bd sd") |> slow(2.0lf)`.
     return fast(pat, 1.0lf / n)
 }
 
 // Shift pattern earlier in time by `offset` cycles.
-def early(var pat : Pattern; offset : double) : Pattern {
+def private early(var pat : Pattern; offset : double) : Pattern {
     return @capture(= offset, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         let innerSpan = TimeSpan(start = span.start + offset, stop = span.stop + offset)
@@ -89,7 +104,7 @@ def early(var pat : Pattern; offset : double) : Pattern {
 }
 
 // Shift pattern later in time.
-def late(var pat : Pattern; offset : double) : Pattern {
+def private late(var pat : Pattern; offset : double) : Pattern {
     return early(pat, 0.0lf - offset)
 }
 
@@ -97,6 +112,7 @@ def late(var pat : Pattern; offset : double) : Pattern {
 
 // Layer patterns on top of each other (simultaneous).
 def stack(var pats : array<Pattern>) : Pattern {
+    //! Layers all patterns simultaneously — every pattern plays at once. Example: `stack([s("bd"), s("hh"), s("sd")])`.
     return @capture(<- pats) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         for (pat in pats) {
@@ -113,6 +129,7 @@ def stack(var pats : array<Pattern>) : Pattern {
 // Sequence patterns across cycles. With N patterns, pattern i plays
 // during cycle i (mod N). Each pattern is time-stretched to fill one cycle.
 def cat(var pats : array<Pattern>) : Pattern {
+    //! Sequences patterns across cycles — with N patterns, pattern `i` plays during cycle `i mod N`, each stretched to one cycle. Example: `cat([s("bd"), s("sd")])`.
     let cn = length(pats)
     return @capture(= cn, <- pats) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -143,6 +160,7 @@ def cat(var pats : array<Pattern>) : Pattern {
 
 // Like cat but all patterns squeezed into one cycle.
 def fastcat(var pats : array<Pattern>) : Pattern {
+    //! Like `cat` but squeezes all patterns into a single cycle, side by side. Example: `fastcat([s("bd"), s("sd"), s("hh")])`.
     let cn = double(length(pats))
     return fast(cat(pats), cn)
 }
@@ -150,6 +168,7 @@ def fastcat(var pats : array<Pattern>) : Pattern {
 // Like fastcat but each element gets time proportional to its weight.
 // weighted_fastcat([a, b], [3.0, 1.0]) → a gets 3/4 of cycle, b gets 1/4.
 def weighted_fastcat(var pats : array<Pattern>; var weights : array<float>) : Pattern {
+    //! Like `fastcat` but each element's cycle slice is proportional to its weight. Example: `weighted_fastcat([a, b], [3.0, 1.0])` — `a` fills 3/4, `b` fills 1/4.
     var total_weight = 0.0
     for (w in weights) {
         total_weight += w
@@ -192,6 +211,7 @@ def weighted_fastcat(var pats : array<Pattern>; var weights : array<float>) : Pa
 
 // Transform the value of every event.
 def fmap(var pat : Pattern; var fn : lambda<(e : Event) : Event>) : Pattern {
+    //! Applies `fn` to the `Event` value of every hap produced by `pat`, preserving timing. The functor-map over patterns.
     return @capture(<- fn, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var haps <- pat(span)
@@ -214,6 +234,7 @@ def fmap(var pat : Pattern; var fn : lambda<(e : Event) : Event>) : Pattern {
 // Randomly remove events with given probability.
 // Uses deterministic hash of cycle position — same cycle = same result.
 def degrade(var pat : Pattern; prob : float) : Pattern {
+    //! Randomly drops events from `pat` with probability `prob` (0..1). Deterministic — same time yields same result. Example: `s("bd*8") |> degrade(0.3)`.
     return @capture(= prob, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var haps <- pat(span)
@@ -231,6 +252,7 @@ def degrade(var pat : Pattern; prob : float) : Pattern {
 // Apply a different pattern every nth cycle.
 // every(4, fast_version, normal_version) — use fast_version on cycles 0,4,8,...
 def every(n : int; var pat_on : Pattern; var pat_off : Pattern) : Pattern {
+    //! Plays `pat_on` on every `n`-th cycle, `pat_off` otherwise. Example: `every(4, s("cp"), s("bd"))` — clap every 4th cycle.
     var cn = n
     return @capture(<- cn, <- pat_on, <- pat_off) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -262,6 +284,7 @@ def every(n : int; var pat_on : Pattern; var pat_off : Pattern) : Pattern {
 // Bjorklund's algorithm: distribute k onsets across n slots.
 // bjorklund(3, 8) → [x . . x . . x .]
 def bjorklund(k, n : int) : array<bool> {
+    //! Bjorklund's algorithm — distributes `k` onsets as evenly as possible across `n` slots. Example: `bjorklund(3, 8)` gives `[x . . x . . x .]`.
     var pattern : array<bool>
     pattern |> resize(n)
     if (k <= 0) {
@@ -289,6 +312,7 @@ def bjorklund(k, n : int) : array<bool> {
 
 // pat |> set_gain(0.5) — set amplitude
 def set_gain(var pat : Pattern; g : float) : Pattern {
+    //! Sets the `gain` (amplitude, 0..1) field on every event in `pat`. Example: `pat |> set_gain(0.5)`.
     let fn <- @capture(= g) (e : Event) : Event {
         var r = e; r.gain = g; return r
     }
@@ -296,7 +320,7 @@ def set_gain(var pat : Pattern; g : float) : Pattern {
 }
 
 // pat |> set_velocity(0.5) — set expression/velocity
-def set_velocity(var pat : Pattern; v : float) : Pattern {
+def private set_velocity(var pat : Pattern; v : float) : Pattern {
     let fn <- @capture(= v) (e : Event) : Event {
         var r = e; r.velocity = v; return r
     }
@@ -305,6 +329,7 @@ def set_velocity(var pat : Pattern; v : float) : Pattern {
 
 // pat |> set_pan(0.0) — set stereo position (0=left, 0.5=center, 1=right)
 def set_pan(var pat : Pattern; p : float) : Pattern {
+    //! Sets the `pan` (stereo position: 0=left, 0.5=center, 1=right) field on every event in `pat`.
     let fn <- @capture(= p) (e : Event) : Event {
         var r = e; r.pan = p; return r
     }
@@ -312,7 +337,7 @@ def set_pan(var pat : Pattern; p : float) : Pattern {
 }
 
 // pat |> set_speed(2.0) — set sample playback speed
-def set_speed(var pat : Pattern; spd : float) : Pattern {
+def private set_speed(var pat : Pattern; spd : float) : Pattern {
     let fn <- @capture(= spd) (e : Event) : Event {
         var r = e; r.speed = spd; return r
     }
@@ -321,6 +346,7 @@ def set_speed(var pat : Pattern; spd : float) : Pattern {
 
 // pat |> set_note(48.0) — set MIDI note number
 def set_note(var pat : Pattern; n : float) : Pattern {
+    //! Sets the MIDI `note` number on every event in `pat`. Example: `pat |> set_note(48.0)` (C3).
     let fn <- @capture(= n) (e : Event) : Event {
         var r = e; r.note = n; return r
     }
@@ -329,6 +355,7 @@ def set_note(var pat : Pattern; n : float) : Pattern {
 
 // pat |> set_sound("sawtooth") — change the sound name
 def set_sound(var pat : Pattern; snd : string) : Pattern {
+    //! Sets the sound name `s` on every event in `pat`. Example: `pat |> set_sound("sawtooth")`.
     let fn <- @capture(= snd) (e : Event) : Event {
         var r = e; r.s = snd; return r
     }
@@ -338,13 +365,14 @@ def set_sound(var pat : Pattern; snd : string) : Pattern {
 // pat |> set_sound(sound_pat) — sample sound name from a pattern at each event onset.
 // Enables strudel-style: note("c3").s("<supersaw sawtooth>")
 def set_sound(var pat : Pattern; var sound_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_sound`: samples the sound name from `sound_pat` at each event onset. Example: `note("c3") |> set_sound(s("<saw tri>"))`.
     return combineWithStr(pat, sound_pat, @(e : Event; val : string) : Event {
         var r = e; r.s = val; return r
     })
 }
 
 // pat |> set_cut(1) — set cut group (new voice kills previous in same group)
-def set_cut(var pat : Pattern; c : int) : Pattern {
+def private set_cut(var pat : Pattern; c : int) : Pattern {
     let fn <- @capture(= c) (e : Event) : Event {
         var r = e; r.cut = c; return r
     }
@@ -353,6 +381,7 @@ def set_cut(var pat : Pattern; c : int) : Pattern {
 
 // pat |> set_room(0.5) — set reverb send amount
 def set_room(var pat : Pattern; r : float) : Pattern {
+    //! Sets the reverb send amount `room` (0..1) on every event in `pat`.
     let fn <- @capture(= r) (e : Event) : Event {
         var ev = e; ev.room = r; return ev
     }
@@ -361,6 +390,7 @@ def set_room(var pat : Pattern; r : float) : Pattern {
 
 // pat |> set_roomsize(0.8) — set reverb room size
 def set_roomsize(var pat : Pattern; r : float) : Pattern {
+    //! Sets the reverb room size `roomsize` (larger = more sustained reverb) on every event in `pat`.
     let fn <- @capture(= r) (e : Event) : Event {
         var ev = e; ev.roomsize = r; return ev
     }
@@ -369,6 +399,7 @@ def set_roomsize(var pat : Pattern; r : float) : Pattern {
 
 // pat |> set_delay(0.5) — set delay send amount
 def set_delay(var pat : Pattern; d : float) : Pattern {
+    //! Sets the delay send amount (`delay_amount`, 0..1) on every event in `pat`.
     let fn <- @capture(= d) (e : Event) : Event {
         var ev = e; ev.delay_amount = d; return ev
     }
@@ -377,6 +408,7 @@ def set_delay(var pat : Pattern; d : float) : Pattern {
 
 // pat |> set_delaytime(0.25) — set delay time in seconds
 def set_delaytime(var pat : Pattern; d : float) : Pattern {
+    //! Sets the delay time `delaytime` (seconds) on every event in `pat`.
     let fn <- @capture(= d) (e : Event) : Event {
         var ev = e; ev.delaytime = d; return ev
     }
@@ -385,6 +417,7 @@ def set_delaytime(var pat : Pattern; d : float) : Pattern {
 
 // pat |> set_delayfeedback(0.7) — set delay feedback
 def set_delayfeedback(var pat : Pattern; d : float) : Pattern {
+    //! Sets the delay feedback `delayfeedback` (0..<1) on every event in `pat`.
     let fn <- @capture(= d) (e : Event) : Event {
         var ev = e; ev.delayfeedback = d; return ev
     }
@@ -392,7 +425,7 @@ def set_delayfeedback(var pat : Pattern; d : float) : Pattern {
 }
 
 // pat |> set_delaysync(0.1875) — set delay time in cycles (tempo-synced delay)
-def set_delaysync(var pat : Pattern; d : float) : Pattern {
+def private set_delaysync(var pat : Pattern; d : float) : Pattern {
     let fn <- @capture(= d) (e : Event) : Event {
         var ev = e; ev.delaysync = d; return ev
     }
@@ -401,6 +434,7 @@ def set_delaysync(var pat : Pattern; d : float) : Pattern {
 
 // pat |> set_orbit(1) — set effect bus routing
 def set_orbit(var pat : Pattern; o : int) : Pattern {
+    //! Sets the effect-bus routing index `orbit` on every event in `pat`. Different orbits have independent FX chains.
     let fn <- @capture(= o) (e : Event) : Event {
         var ev = e; ev.orbit = o; return ev
     }
@@ -409,6 +443,7 @@ def set_orbit(var pat : Pattern; o : int) : Pattern {
 
 // pat |> set_fm(2.0) — set FM modulation depth
 def set_fm(var pat : Pattern; f : float) : Pattern {
+    //! Sets the FM modulation depth `fm` (modulator amplitude) on every event in `pat`.
     let fn <- @capture(= f) (e : Event) : Event {
         var ev = e; ev.fm = f; return ev
     }
@@ -417,6 +452,7 @@ def set_fm(var pat : Pattern; f : float) : Pattern {
 
 // pat |> set_fmh(1.5) — set FM harmonicity ratio
 def set_fmh(var pat : Pattern; f : float) : Pattern {
+    //! Sets the FM harmonicity ratio `fmh` (modulator frequency / carrier frequency) on every event in `pat`.
     let fn <- @capture(= f) (e : Event) : Event {
         var ev = e; ev.fmh = f; return ev
     }
@@ -425,56 +461,56 @@ def set_fmh(var pat : Pattern; f : float) : Pattern {
 
 // ─── Sample Region & Audio Effects ───
 
-def set_begin(var pat : Pattern; b : float) : Pattern {
+def private set_begin(var pat : Pattern; b : float) : Pattern {
     let fn <- @capture(= b) (e : Event) : Event {
         var r = e; r.begin = b; return r
     }
     return <- fmap(pat, fn)
 }
 
-def set_end(var pat : Pattern; e_val : float) : Pattern {
+def private set_end(var pat : Pattern; e_val : float) : Pattern {
     let fn <- @capture(= e_val) (e : Event) : Event {
         var r = e; r.end_pos = e_val; return r
     }
     return <- fmap(pat, fn)
 }
 
-def set_crush(var pat : Pattern; c : float) : Pattern {
+def private set_crush(var pat : Pattern; c : float) : Pattern {
     let fn <- @capture(= c) (e : Event) : Event {
         var r = e; r.crush = c; return r
     }
     return <- fmap(pat, fn)
 }
 
-def set_coarse(var pat : Pattern; c : int) : Pattern {
+def private set_coarse(var pat : Pattern; c : int) : Pattern {
     let fn <- @capture(= c) (e : Event) : Event {
         var r = e; r.coarse = c; return r
     }
     return <- fmap(pat, fn)
 }
 
-def set_shape(var pat : Pattern; s : float) : Pattern {
+def private set_shape(var pat : Pattern; s : float) : Pattern {
     let fn <- @capture(= s) (e : Event) : Event {
         var r = e; r.shape = s; return r
     }
     return <- fmap(pat, fn)
 }
 
-def set_djf(var pat : Pattern; d : float) : Pattern {
+def private set_djf(var pat : Pattern; d : float) : Pattern {
     let fn <- @capture(= d) (e : Event) : Event {
         var r = e; r.djf = d; return r
     }
     return <- fmap(pat, fn)
 }
 
-def set_bpf(var pat : Pattern; freq : float) : Pattern {
+def private set_bpf(var pat : Pattern; freq : float) : Pattern {
     let fn <- @capture(= freq) (e : Event) : Event {
         var r = e; r.bpf = freq; return r
     }
     return <- fmap(pat, fn)
 }
 
-def set_bpq(var pat : Pattern; q : float) : Pattern {
+def private set_bpq(var pat : Pattern; q : float) : Pattern {
     let fn <- @capture(= q) (e : Event) : Event {
         var r = e; r.bpq = q; return r
     }
@@ -482,28 +518,28 @@ def set_bpq(var pat : Pattern; q : float) : Pattern {
 }
 
 // Phaser: rate in Hz (0 disables). Modulates a single notch biquad.
-def set_phaser(var pat : Pattern; r : float) : Pattern {
+def private set_phaser(var pat : Pattern; r : float) : Pattern {
     let fn <- @capture(= r) (e : Event) : Event {
         var ev = e; ev.phaser = r; return ev
     }
     return <- fmap(pat, fn)
 }
 
-def set_phaserdepth(var pat : Pattern; d : float) : Pattern {
+def private set_phaserdepth(var pat : Pattern; d : float) : Pattern {
     let fn <- @capture(= d) (e : Event) : Event {
         var ev = e; ev.phaserdepth = d; return ev
     }
     return <- fmap(pat, fn)
 }
 
-def set_phasercenter(var pat : Pattern; c : float) : Pattern {
+def private set_phasercenter(var pat : Pattern; c : float) : Pattern {
     let fn <- @capture(= c) (e : Event) : Event {
         var ev = e; ev.phasercenter = c; return ev
     }
     return <- fmap(pat, fn)
 }
 
-def set_phasersweep(var pat : Pattern; s : float) : Pattern {
+def private set_phasersweep(var pat : Pattern; s : float) : Pattern {
     let fn <- @capture(= s) (e : Event) : Event {
         var ev = e; ev.phasersweep = s; return ev
     }
@@ -511,14 +547,14 @@ def set_phasersweep(var pat : Pattern; s : float) : Pattern {
 }
 
 // Tremolo: rate in Hz (0 disables), amplitude modulation.
-def set_tremolo(var pat : Pattern; r : float) : Pattern {
+def private set_tremolo(var pat : Pattern; r : float) : Pattern {
     let fn <- @capture(= r) (e : Event) : Event {
         var ev = e; ev.tremolo = r; return ev
     }
     return <- fmap(pat, fn)
 }
 
-def set_tremolodepth(var pat : Pattern; d : float) : Pattern {
+def private set_tremolodepth(var pat : Pattern; d : float) : Pattern {
     let fn <- @capture(= d) (e : Event) : Event {
         var ev = e; ev.tremolodepth = d; return ev
     }
@@ -526,35 +562,35 @@ def set_tremolodepth(var pat : Pattern; d : float) : Pattern {
 }
 
 // Compressor: threshold in dB (>=0 = bypass). Negative values activate.
-def set_compressor(var pat : Pattern; thr_db : float) : Pattern {
+def private set_compressor(var pat : Pattern; thr_db : float) : Pattern {
     let fn <- @capture(= thr_db) (e : Event) : Event {
         var ev = e; ev.compressor = thr_db; return ev
     }
     return <- fmap(pat, fn)
 }
 
-def set_compressor_ratio(var pat : Pattern; ratio : float) : Pattern {
+def private set_compressor_ratio(var pat : Pattern; ratio : float) : Pattern {
     let fn <- @capture(= ratio) (e : Event) : Event {
         var ev = e; ev.compressor_ratio = ratio; return ev
     }
     return <- fmap(pat, fn)
 }
 
-def set_compressor_knee(var pat : Pattern; knee : float) : Pattern {
+def private set_compressor_knee(var pat : Pattern; knee : float) : Pattern {
     let fn <- @capture(= knee) (e : Event) : Event {
         var ev = e; ev.compressor_knee = knee; return ev
     }
     return <- fmap(pat, fn)
 }
 
-def set_compressor_attack(var pat : Pattern; a : float) : Pattern {
+def private set_compressor_attack(var pat : Pattern; a : float) : Pattern {
     let fn <- @capture(= a) (e : Event) : Event {
         var ev = e; ev.compressor_attack = a; return ev
     }
     return <- fmap(pat, fn)
 }
 
-def set_compressor_release(var pat : Pattern; r : float) : Pattern {
+def private set_compressor_release(var pat : Pattern; r : float) : Pattern {
     let fn <- @capture(= r) (e : Event) : Event {
         var ev = e; ev.compressor_release = r; return ev
     }
@@ -564,7 +600,7 @@ def set_compressor_release(var pat : Pattern; r : float) : Pattern {
 // ─── SF2 SoundFont Helpers ───
 
 // GM instrument name → program number mapping.
-def gm_program_by_name(name : string) : int {
+def private gm_program_by_name(name : string) : int {
     // Piano family
     if (name == "piano" || name == "acoustic_grand_piano") { return 0; }
     if (name == "bright_piano") { return 1; }
@@ -659,7 +695,7 @@ def gm_program_by_name(name : string) : int {
 }
 
 // pat |> set_sf2(0) — set SF2 program number (GM instrument)
-def set_sf2(var pat : Pattern; program : int) : Pattern {
+def private set_sf2(var pat : Pattern; program : int) : Pattern {
     let fn <- @capture(= program) (e : Event) : Event {
         var r = e; r.sf2_program = program; return r
     }
@@ -667,7 +703,7 @@ def set_sf2(var pat : Pattern; program : int) : Pattern {
 }
 
 // pat |> set_sf2("piano") — set SF2 instrument by GM name
-def set_sf2(var pat : Pattern; name : string) : Pattern {
+def private set_sf2(var pat : Pattern; name : string) : Pattern {
     let program = gm_program_by_name(name)
     let fn <- @capture(= program) (e : Event) : Event {
         var r = e; r.sf2_program = program; return r
@@ -676,7 +712,7 @@ def set_sf2(var pat : Pattern; name : string) : Pattern {
 }
 
 // pat |> set_sf2_bank(128) — set SF2 bank (0 = melodic, 128 = percussion)
-def set_sf2_bank(var pat : Pattern; bank : int) : Pattern {
+def private set_sf2_bank(var pat : Pattern; bank : int) : Pattern {
     let fn <- @capture(= bank) (e : Event) : Event {
         var r = e; r.sf2_bank = bank; return r
     }
@@ -684,7 +720,7 @@ def set_sf2_bank(var pat : Pattern; bank : int) : Pattern {
 }
 
 // pat |> set_sf2_expression(0.5) — set SF2 expression CC11 (0.0–1.0)
-def set_sf2_expression(var pat : Pattern; v : float) : Pattern {
+def private set_sf2_expression(var pat : Pattern; v : float) : Pattern {
     let fn <- @capture(= v) (e : Event) : Event {
         var r = e; r.sf2_expression = v; return r
     }
@@ -692,7 +728,7 @@ def set_sf2_expression(var pat : Pattern; v : float) : Pattern {
 }
 
 // pat |> set_sf2_mod_wheel(0.5) — set SF2 mod wheel CC1 (0.0–1.0, vibrato depth)
-def set_sf2_mod_wheel(var pat : Pattern; v : float) : Pattern {
+def private set_sf2_mod_wheel(var pat : Pattern; v : float) : Pattern {
     let fn <- @capture(= v) (e : Event) : Event {
         var r = e; r.sf2_mod_wheel = v; return r
     }
@@ -700,7 +736,7 @@ def set_sf2_mod_wheel(var pat : Pattern; v : float) : Pattern {
 }
 
 // pat |> set_sf2_pitch_bend(0.6) — set SF2 pitch bend (0.0–1.0, 0.5 = center)
-def set_sf2_pitch_bend(var pat : Pattern; v : float) : Pattern {
+def private set_sf2_pitch_bend(var pat : Pattern; v : float) : Pattern {
     let fn <- @capture(= v) (e : Event) : Event {
         var r = e; r.sf2_pitch_bend = v; return r
     }
@@ -708,7 +744,7 @@ def set_sf2_pitch_bend(var pat : Pattern; v : float) : Pattern {
 }
 
 // pat |> set_chorus(0.5) — set chorus send amount (0.0–1.0)
-def set_chorus(var pat : Pattern; c : float) : Pattern {
+def private set_chorus(var pat : Pattern; c : float) : Pattern {
     let fn <- @capture(= c) (e : Event) : Event {
         var r = e; r.chorus = c; return r
     }
@@ -717,6 +753,7 @@ def set_chorus(var pat : Pattern; c : float) : Pattern {
 
 // pat |> set_lpq(5.0) — set low-pass filter resonance
 def set_lpq(var pat : Pattern; q : float) : Pattern {
+    //! Sets the low-pass filter resonance `lpq` (Q factor) on every event in `pat`.
     let fn <- @capture(= q) (e : Event) : Event {
         var r = e; r.lpq = q; return r
     }
@@ -725,6 +762,7 @@ def set_lpq(var pat : Pattern; q : float) : Pattern {
 
 // pat |> set_hpq(5.0) — set high-pass filter resonance
 def set_hpq(var pat : Pattern; q : float) : Pattern {
+    //! Sets the high-pass filter resonance `hpq` (Q factor) on every event in `pat`.
     let fn <- @capture(= q) (e : Event) : Event {
         var r = e; r.hpq = q; return r
     }
@@ -733,6 +771,7 @@ def set_hpq(var pat : Pattern; q : float) : Pattern {
 
 // pat |> set_lpf(1000.0) — set low-pass filter cutoff
 def set_lpf(var pat : Pattern; freq : float) : Pattern {
+    //! Sets the low-pass filter cutoff `lpf` (Hz) on every event in `pat`.
     let fn <- @capture(= freq) (e : Event) : Event {
         var r = e; r.lpf = freq; return r
     }
@@ -741,6 +780,7 @@ def set_lpf(var pat : Pattern; freq : float) : Pattern {
 
 // pat |> set_hpf(200.0) — set high-pass filter cutoff
 def set_hpf(var pat : Pattern; freq : float) : Pattern {
+    //! Sets the high-pass filter cutoff `hpf` (Hz) on every event in `pat`.
     let fn <- @capture(= freq) (e : Event) : Event {
         var r = e; r.hpf = freq; return r
     }
@@ -749,6 +789,7 @@ def set_hpf(var pat : Pattern; freq : float) : Pattern {
 
 // pat |> set_attack(0.1) — set envelope attack time
 def set_attack(var pat : Pattern; a : float) : Pattern {
+    //! Sets the amp-envelope `attack` time (seconds) on every event in `pat`.
     let fn <- @capture(= a) (e : Event) : Event {
         var r = e; r.attack = a; return r
     }
@@ -757,6 +798,7 @@ def set_attack(var pat : Pattern; a : float) : Pattern {
 
 // pat |> set_decay(0.3) — set envelope decay time
 def set_decay(var pat : Pattern; d : float) : Pattern {
+    //! Sets the amp-envelope `decay` time (seconds) on every event in `pat`.
     let fn <- @capture(= d) (e : Event) : Event {
         var r = e; r.decay = d; return r
     }
@@ -765,6 +807,7 @@ def set_decay(var pat : Pattern; d : float) : Pattern {
 
 // pat |> set_sustain(0.7) — set envelope sustain level
 def set_sustain(var pat : Pattern; s : float) : Pattern {
+    //! Sets the amp-envelope `sustain` level (0..1) on every event in `pat`.
     let fn <- @capture(= s) (e : Event) : Event {
         var r = e; r.sustain = s; return r
     }
@@ -773,6 +816,7 @@ def set_sustain(var pat : Pattern; s : float) : Pattern {
 
 // pat |> set_release(0.5) — set envelope release time
 def set_release(var pat : Pattern; r : float) : Pattern {
+    //! Sets the amp-envelope `release` time (seconds) on every event in `pat`.
     let fn <- @capture(= r) (e : Event) : Event {
         var ev = e; ev.release = r; return ev
     }
@@ -785,6 +829,7 @@ def set_release(var pat : Pattern; r : float) : Pattern {
 // Mirrors the query span within each cycle, queries the inner pattern at the
 // mirrored position, then mirrors the results back.
 def rev(var pat : Pattern) : Pattern {
+    //! Reverses event positions within each cycle. Example: `s("bd sd cp") |> rev()` plays `cp sd bd`.
     return @capture(<- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         // mirror the query span per-cycle, then flip results back
@@ -820,6 +865,7 @@ def rev(var pat : Pattern) : Pattern {
 // Stereo split: original panned left, transformed panned right.
 // jux(s("bd sd"), @(x) => rev(x)) — classic stereo widening
 def jux(var pat : Pattern; transform : PatternTransform) : Pattern {
+    //! Stereo split: original is panned left, `transform(pat)` is panned right. Example: `s("bd sd") |> jux(@@(x) => rev(x))`.
     var transformed <- invoke(transform, pat) // nolint:LINT003
     var left <- pat |> set_pan(0.0)
     var right <- transformed |> set_pan(1.0)
@@ -832,6 +878,7 @@ def jux(var pat : Pattern; transform : PatternTransform) : Pattern {
 // Overlay pattern with a time-shifted copy.
 // off(s("bd sd"), 0.125, @(x) => transpose(x, 7.0)) — canon at the fifth
 def off(var pat : Pattern; time : double; transform : PatternTransform) : Pattern {
+    //! Overlays `pat` with a time-shifted copy transformed by `transform`. Example: `s("bd sd") |> off(0.125, @@(x) => transpose(x, 7.0))` — canon at the fifth.
     var shifted <- invoke(transform, pat) |> late(time)
     var layers : array<Pattern>
     layers |> emplace <| pat
@@ -840,7 +887,7 @@ def off(var pat : Pattern; time : double; transform : PatternTransform) : Patter
 }
 
 // Keep events where hash >= prob (original survivors).
-def degrade_keep(var pat : Pattern; prob : float) : Pattern {
+def private degrade_keep(var pat : Pattern; prob : float) : Pattern {
     let cn = prob
     return @capture(= cn, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -858,7 +905,7 @@ def degrade_keep(var pat : Pattern; prob : float) : Pattern {
 }
 
 // Keep events where hash < prob (complement — selected for transform).
-def degrade_drop(var pat : Pattern; prob : float) : Pattern {
+def private degrade_drop(var pat : Pattern; prob : float) : Pattern {
     let cn = prob
     return @capture(= cn, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -879,6 +926,7 @@ def degrade_drop(var pat : Pattern; prob : float) : Pattern {
 // Matches strudel: stack(degrade(pat, prob), transform(undegrade(pat, prob)))
 // Randomness is decided at original event positions, BEFORE transform reshuffles timing.
 def sometimesby(var pat : Pattern; prob : float; transform : PatternTransform) : Pattern {
+    //! Applies `transform` to each event with probability `prob` (0..1). Example: `s("bd*8") |> sometimesby(0.3, @@(x) => fast(x, 2.0lf))`.
     var degraded <- degrade_keep(pat, prob)
     var undegraded <- degrade_drop(pat, prob) // nolint:LINT003
     var transformed <- invoke(transform, undegraded) // nolint:LINT003
@@ -890,28 +938,32 @@ def sometimesby(var pat : Pattern; prob : float; transform : PatternTransform) :
 
 // sometimes = 50% probability
 def sometimes(var pat : Pattern; transform : PatternTransform) : Pattern {
+    //! Applies `transform` to each event with 50% probability. Shorthand for `sometimesby(pat, 0.5, transform)`.
     return <- sometimesby(pat, 0.5, transform)
 }
 
 // often = 75% probability
 def often(var pat : Pattern; transform : PatternTransform) : Pattern {
+    //! Applies `transform` to each event with 75% probability. Shorthand for `sometimesby(pat, 0.75, transform)`.
     return <- sometimesby(pat, 0.75, transform)
 }
 
 // rarely = 25% probability
-def rarely(var pat : Pattern; transform : PatternTransform) : Pattern {
+def private rarely(var pat : Pattern; transform : PatternTransform) : Pattern {
     return <- sometimesby(pat, 0.25, transform)
 }
 
 // Stack multiple patterns on top of the base pattern.
 // layer(s("bd"), [s("bd") |> transpose(7.0), s("bd") |> transpose(12.0)])
 def layer(var pats : array<Pattern>; var base : Pattern) : Pattern {
+    //! Stacks `pats` on top of `base`, all playing simultaneously. Example: `s("bd") |> layer([s("bd") |> transpose(7.0), s("bd") |> transpose(12.0)])`.
     pats |> emplace <| base
     return <- stack(pats)
 }
 
 // Shift note by semitones. transpose(pat, 7) = up a fifth.
 def transpose(var pat : Pattern; semitones : float) : Pattern {
+    //! Shifts every event's MIDI note by `semitones`. Example: `pat |> transpose(7.0)` transposes up a fifth.
     let fn <- @capture(= semitones) (e : Event) : Event {
         var r = e; r.note += semitones; return r
     }
@@ -920,6 +972,7 @@ def transpose(var pat : Pattern; semitones : float) : Pattern {
 
 // Alias: add is the same as transpose (matches strudel naming).
 def add(var pat : Pattern; semitones : float) : Pattern {
+    //! Alias for `transpose` — adds `semitones` to each event's note. Matches strudel naming.
     return <- transpose(pat, semitones)
 }
 
@@ -929,6 +982,7 @@ def add(var pat : Pattern; semitones : float) : Pattern {
 // create a pattern from its note value via fn, query that inner pattern,
 // and collect results whose parts overlap. This is how slow("<2 16>") works.
 def innerJoin(var param_pat : Pattern; var fn : lambda<(val : float) : Pattern>) : Pattern {
+    //! Pattern monadic join — for each hap in `param_pat`, builds an inner pattern via `fn(hap.note)` and intersects its haps with the outer hap's part. Core mechanism for patternified parameters.
     return @capture(<- param_pat, <- fn) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var outer_haps <- param_pat(span)
@@ -960,6 +1014,7 @@ def innerJoin(var param_pat : Pattern; var fn : lambda<(val : float) : Pattern>)
 // Patternified slow: factor varies per cycle based on factor_pat's note values.
 // slow(pat, n("<2 16>")) — slow by 2 on even cycles, 16 on odd cycles
 def slow(var pat : Pattern; var factor_pat : Pattern) : Pattern {
+    //! Patternified `slow` — slow factor varies per cycle from `factor_pat`'s note values. Example: `slow(pat, n("<2 16>"))` alternates between 2x and 16x slowdown.
     return @capture(<- pat, <- factor_pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var outer_haps <- factor_pat(span)
@@ -996,6 +1051,7 @@ def slow(var pat : Pattern; var factor_pat : Pattern) : Pattern {
 
 // Patternified fast: factor varies per cycle based on factor_pat's note values.
 def fast(var pat : Pattern; var factor_pat : Pattern) : Pattern {
+    //! Patternified `fast` — speed factor varies per cycle from `factor_pat`'s note values. Example: `fast(pat, n("<1 2 4>"))`.
     return @capture(<- pat, <- factor_pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var outer_haps <- factor_pat(span)
@@ -1035,6 +1091,7 @@ def fast(var pat : Pattern; var factor_pat : Pattern) : Pattern {
 
 // Base signal constructor: wraps a function from cycle-time to value.
 def signal(var fn : lambda<(t : double) : float>) : Pattern {
+    //! Builds a continuous-signal pattern from `fn(t) : float`. Produces one hap per query with `has_whole=false` and value stored in `note`. Foundation for `sine`, `saw`, `perlin`, etc.
     return @capture(<- fn) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         result |> push(Hap(
@@ -1049,6 +1106,7 @@ def signal(var fn : lambda<(t : double) : float>) : Pattern {
 
 // Sine wave mapped to 0..1. At t=0 → 0.5, t=0.25 → 1.0, t=0.5 → 0.5, t=0.75 → 0.0.
 def signal_sine() : Pattern {
+    //! Unipolar sine signal, mapped to `0..1` over one cycle. At t=0 → 0.5, t=0.25 → 1.0, t=0.5 → 0.5, t=0.75 → 0.0.
     return signal(@(t : double) : float {
         return float(sin(3.14159265358979323846lf * 2.0lf * t) + 1.0lf) * 0.5
     })
@@ -1056,6 +1114,7 @@ def signal_sine() : Pattern {
 
 // Cosine wave mapped to 0..1. Same as sine shifted left by 0.25 cycles.
 def signal_cosine() : Pattern {
+    //! Unipolar cosine signal, mapped to `0..1` over one cycle. Same as `signal_sine` shifted left by 0.25 cycles.
     return signal(@(t : double) : float {
         return float(cos(3.14159265358979323846lf * 2.0lf * t) + 1.0lf) * 0.5
     })
@@ -1063,6 +1122,7 @@ def signal_cosine() : Pattern {
 
 // Sawtooth ramp 0..1 within each cycle.
 def signal_saw() : Pattern {
+    //! Sawtooth signal — ramps `0..1` linearly within each cycle.
     return signal(@(t : double) : float {
         return float(t - floor(t))
     })
@@ -1070,6 +1130,7 @@ def signal_saw() : Pattern {
 
 // Triangle wave 0..1. Rises 0→1 in first half, falls 1→0 in second half.
 def signal_tri() : Pattern {
+    //! Triangle signal — rises `0→1` in the first half of each cycle, falls `1→0` in the second half.
     return signal(@(t : double) : float {
         let pos = float(t - floor(t))
         return pos < 0.5 ? pos * 2.0 : (1.0 - pos) * 2.0
@@ -1079,6 +1140,7 @@ def signal_tri() : Pattern {
 // Deterministic Perlin-style noise mapped to 0..1.
 // Uses smootherstep interpolation between pseudo-random values at integer cycles.
 def signal_perlin() : Pattern {
+    //! Deterministic Perlin-style noise mapped to `0..1`. Uses smootherstep interpolation between hashed random values at integer cycle boundaries.
     return signal(@(t : double) : float {
         let i = int(floor(t))
         let frac = float(t - floor(t))
@@ -1093,6 +1155,7 @@ def signal_perlin() : Pattern {
 
 // Scale a signal from 0..1 to lo..hi.
 def signal_range(var pat : Pattern; lo, hi : float) : Pattern {
+    //! Scales a signal pattern from `0..1` to `lo..hi`. Example: `sine() |> signal_range(200.0, 4000.0)` for a 200..4000 Hz filter sweep.
     let span = hi - lo
     return fmap(pat, @capture(= lo, = span) (e : Event) : Event {
         var r = e
@@ -1106,6 +1169,7 @@ def signal_range(var pat : Pattern; lo, hi : float) : Pattern {
 // applies fn(baseEvent, sampledValue) to produce the output event.
 // The sampled value is extracted from the value pattern's hap value.note field.
 def combineWith(var pat : Pattern; var val_pat : Pattern; var fn : lambda<(e : Event; val : float) : Event>) : Pattern {
+    //! For each hap in `pat`, samples `val_pat` at the hap's onset and applies `fn(event, sampledValue)` to produce the output event. Core primitive for pattern-modulated setters.
     return @capture(<- pat, <- val_pat, <- fn) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var haps <- pat(span)
@@ -1137,6 +1201,7 @@ def combineWith(var pat : Pattern; var val_pat : Pattern; var fn : lambda<(e : E
 
 // pat |> set_gain(signal_sine()) — modulate gain with a signal
 def set_gain(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_gain` — samples `mod_pat` at each event onset to set `gain`. Example: `pat |> set_gain(sine())`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.gain = val; return r
     })
@@ -1144,6 +1209,7 @@ def set_gain(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_note(signal_saw() |> signal_range(48.0, 72.0)) — modulate note
 def set_note(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_note` — samples `mod_pat` at each event onset to set `note`. Example: `pat |> set_note(saw() |> range(48.0, 72.0))`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.note = val; return r
     })
@@ -1151,6 +1217,7 @@ def set_note(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_pan(signal_sine()) — modulate pan with a signal
 def set_pan(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_pan` — samples `mod_pat` at each event onset to set `pan`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.pan = val; return r
     })
@@ -1158,6 +1225,7 @@ def set_pan(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_lpf(signal_sine() |> signal_range(200.0, 4000.0)) — modulate lpf
 def set_lpf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_lpf` — samples `mod_pat` at each event onset to set `lpf` cutoff. Example: `pat |> set_lpf(sine() |> range(200.0, 4000.0))`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.lpf = val; return r
     })
@@ -1165,6 +1233,7 @@ def set_lpf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_hpf(signal_pattern) — modulate hpf with a signal
 def set_hpf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_hpf` — samples `mod_pat` at each event onset to set `hpf` cutoff.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.hpf = val; return r
     })
@@ -1172,6 +1241,7 @@ def set_hpf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_speed(signal_pattern) — modulate speed with a signal
 def set_speed(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_speed` — samples `mod_pat` at each event onset to set sample playback `speed`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.speed = val; return r
     })
@@ -1179,6 +1249,7 @@ def set_speed(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_attack(signal_pattern) — modulate attack with a signal
 def set_attack(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_attack` — samples `mod_pat` at each event onset to set envelope `attack`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.attack = val; return r
     })
@@ -1186,6 +1257,7 @@ def set_attack(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_decay(signal_pattern) — modulate decay with a signal
 def set_decay(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_decay` — samples `mod_pat` at each event onset to set envelope `decay`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.decay = val; return r
     })
@@ -1193,6 +1265,7 @@ def set_decay(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_sustain(signal_pattern) — modulate sustain with a signal
 def set_sustain(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_sustain` — samples `mod_pat` at each event onset to set envelope `sustain`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.sustain = val; return r
     })
@@ -1200,6 +1273,7 @@ def set_sustain(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_release(signal_pattern) — modulate release with a signal
 def set_release(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_release` — samples `mod_pat` at each event onset to set envelope `release`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.release = val; return r
     })
@@ -1207,6 +1281,7 @@ def set_release(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_velocity(signal_pattern) — modulate velocity with a signal
 def set_velocity(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_velocity` — samples `mod_pat` at each event onset to set `velocity`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.velocity = val; return r
     })
@@ -1214,6 +1289,7 @@ def set_velocity(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_lpq(signal_pattern) — modulate lpq with a signal
 def set_lpq(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_lpq` — samples `mod_pat` at each event onset to set low-pass resonance.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.lpq = val; return r
     })
@@ -1221,6 +1297,7 @@ def set_lpq(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_hpq(signal_pattern) — modulate hpq with a signal
 def set_hpq(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_hpq` — samples `mod_pat` at each event onset to set high-pass resonance.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.hpq = val; return r
     })
@@ -1228,6 +1305,7 @@ def set_hpq(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_room(signal_pattern) — modulate reverb send with a signal
 def set_room(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_room` — samples `mod_pat` at each event onset to set reverb send amount.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.room = val; return r
     })
@@ -1235,6 +1313,7 @@ def set_room(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_roomsize(signal_pattern) — modulate room size with a signal
 def set_roomsize(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_roomsize` — samples `mod_pat` at each event onset to set reverb `roomsize`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.roomsize = val; return r
     })
@@ -1242,6 +1321,7 @@ def set_roomsize(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_delay(signal_pattern) — modulate delay send with a signal
 def set_delay(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_delay` — samples `mod_pat` at each event onset to set delay send.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.delay_amount = val; return r
     })
@@ -1249,6 +1329,7 @@ def set_delay(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_delaytime(signal_pattern) — modulate delay time with a signal
 def set_delaytime(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_delaytime` — samples `mod_pat` at each event onset to set delay time.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.delaytime = val; return r
     })
@@ -1256,6 +1337,7 @@ def set_delaytime(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_delayfeedback(signal_pattern) — modulate delay feedback with a signal
 def set_delayfeedback(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_delayfeedback` — samples `mod_pat` at each event onset to set delay feedback.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.delayfeedback = val; return r
     })
@@ -1263,6 +1345,7 @@ def set_delayfeedback(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_fm(signal_pattern) — modulate FM depth with a signal
 def set_fm(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_fm` — samples `mod_pat` at each event onset to set FM modulation depth.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.fm = val; return r
     })
@@ -1270,6 +1353,7 @@ def set_fm(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_fmh(signal_pattern) — modulate FM harmonicity with a signal
 def set_fmh(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_fmh` — samples `mod_pat` at each event onset to set FM harmonicity ratio.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.fmh = val; return r
     })
@@ -1277,6 +1361,7 @@ def set_fmh(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_chorus(signal_pattern) — modulate chorus send with a signal
 def set_chorus(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_chorus` — samples `mod_pat` at each event onset to set chorus send.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.chorus = val; return r
     })
@@ -1284,6 +1369,7 @@ def set_chorus(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_sf2_expression(signal_pattern) — modulate SF2 expression with a signal
 def set_sf2_expression(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_sf2_expression` — samples `mod_pat` at each event onset to set SF2 expression CC11.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.sf2_expression = val; return r
     })
@@ -1291,6 +1377,7 @@ def set_sf2_expression(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_sf2_mod_wheel(signal_pattern) — modulate SF2 mod wheel with a signal
 def set_sf2_mod_wheel(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_sf2_mod_wheel` — samples `mod_pat` at each event onset to set SF2 mod wheel CC1.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.sf2_mod_wheel = val; return r
     })
@@ -1298,6 +1385,7 @@ def set_sf2_mod_wheel(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 
 // pat |> set_sf2_pitch_bend(signal_pattern) — modulate SF2 pitch bend with a signal
 def set_sf2_pitch_bend(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_sf2_pitch_bend` — samples `mod_pat` at each event onset to set SF2 pitch bend.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.sf2_pitch_bend = val; return r
     })
@@ -1306,108 +1394,126 @@ def set_sf2_pitch_bend(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 // ─── Pattern-modulated sample region & effects setters ───
 
 def set_begin(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_begin` — samples `mod_pat` at each event onset to set sample start position (0..1).
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.begin = val; return r
     })
 }
 
 def set_end(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_end` — samples `mod_pat` at each event onset to set sample end position (0..1).
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.end_pos = val; return r
     })
 }
 
 def set_crush(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_crush` — samples `mod_pat` at each event onset to set bit-crush amount.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.crush = val; return r
     })
 }
 
 def set_shape(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_shape` — samples `mod_pat` at each event onset to set waveshape/distortion amount.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.shape = val; return r
     })
 }
 
 def set_djf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_djf` — samples `mod_pat` at each event onset to set DJ-filter position (<0.5 = LP, >0.5 = HP).
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.djf = val; return r
     })
 }
 
 def set_bpf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_bpf` — samples `mod_pat` at each event onset to set band-pass filter cutoff (Hz).
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.bpf = val; return r
     })
 }
 
 def set_bpq(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_bpq` — samples `mod_pat` at each event onset to set band-pass filter Q.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.bpq = val; return r
     })
 }
 
 def set_phaser(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_phaser` — samples `mod_pat` at each event onset to set phaser rate (Hz).
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.phaser = val; return r
     })
 }
 
 def set_phaserdepth(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_phaserdepth` — samples `mod_pat` at each event onset to set phaser depth.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.phaserdepth = val; return r
     })
 }
 
 def set_phasercenter(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_phasercenter` — samples `mod_pat` at each event onset to set phaser center frequency.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.phasercenter = val; return r
     })
 }
 
 def set_phasersweep(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_phasersweep` — samples `mod_pat` at each event onset to set phaser sweep range.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.phasersweep = val; return r
     })
 }
 
 def set_tremolo(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_tremolo` — samples `mod_pat` at each event onset to set tremolo rate (Hz).
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.tremolo = val; return r
     })
 }
 
 def set_tremolodepth(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_tremolodepth` — samples `mod_pat` at each event onset to set tremolo depth.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.tremolodepth = val; return r
     })
 }
 
 def set_compressor(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_compressor` — samples `mod_pat` at each event onset to set compressor threshold (dB).
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.compressor = val; return r
     })
 }
 
 def set_compressor_ratio(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_compressor_ratio` — samples `mod_pat` at each event onset to set compressor ratio.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.compressor_ratio = val; return r
     })
 }
 
 def set_compressor_knee(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_compressor_knee` — samples `mod_pat` at each event onset to set compressor knee (dB).
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.compressor_knee = val; return r
     })
 }
 
 def set_compressor_attack(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_compressor_attack` — samples `mod_pat` at each event onset to set compressor attack (seconds).
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.compressor_attack = val; return r
     })
 }
 
 def set_compressor_release(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_compressor_release` — samples `mod_pat` at each event onset to set compressor release (seconds).
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.compressor_release = val; return r
     })
@@ -1418,6 +1524,7 @@ def set_compressor_release(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 // Like combineWith but samples a string value from the value pattern's event.s field.
 // Used for string-typed parameters like vowel.
 def combineWithStr(var pat : Pattern; var val_pat : Pattern; var fn : lambda<(e : Event; val : string) : Event>) : Pattern {
+    //! Like `combineWith` but samples a string from `val_pat`'s `event.s` field. Used for string-typed parameters (e.g. `vowel`, `s`).
     return @capture(<- pat, <- val_pat, <- fn) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var haps <- pat(span)
@@ -1453,6 +1560,7 @@ def combineWithStr(var pat : Pattern; var val_pat : Pattern; var fn : lambda<(e 
 // Euclidean rhythm: play pattern at k evenly-spaced onsets across n subdivisions.
 // euclid(3, 8, atom("bd")) → kick on steps 0, 3, 6 of an 8-step cycle
 def euclid(var pat : Pattern; k, n : int) : Pattern {
+    //! Euclidean rhythm — `pat` plays at `k` evenly-spaced onsets over `n` subdivisions of each cycle. Example: `atom("bd") |> euclid(3, 8)` → hits on steps 0, 3, 6.
     var rhythm <- bjorklund(k, n)
     let nf = double(n)
     return @capture(<- rhythm, = nf, <- pat) (span : TimeSpan) : array<Hap> {
@@ -1480,6 +1588,7 @@ def euclid(var pat : Pattern; k, n : int) : Pattern {
 
 // Play forward on even cycles, reversed on odd cycles.
 def palindrome(var pat : Pattern) : Pattern {
+    //! Plays `pat` forward on even cycles, reversed on odd cycles. Example: `s("bd sd cp") |> palindrome()`.
     return @capture(<- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var inscope split = splitSpans(span)
@@ -1523,6 +1632,7 @@ def palindrome(var pat : Pattern) : Pattern {
 // Stack original + transformed copy.
 // superimpose(pat, @(x) => fast(x, 2.0lf)) — layer faster copy on top
 def superimpose(var pat : Pattern; transform : PatternTransform) : Pattern {
+    //! Stacks `pat` with `transform(pat)`, both playing simultaneously. Example: `pat |> superimpose(@@(x) => fast(x, 2.0lf))`.
     var transformed <- invoke(transform, pat)
     var layers : array<Pattern>
     layers |> emplace <| pat
@@ -1533,6 +1643,7 @@ def superimpose(var pat : Pattern; transform : PatternTransform) : Pattern {
 // Repeat events with time offset and gain decay.
 // echo(pat, 3, 0.25, 0.5) — 3 echoes, 0.25 cycles apart, each 50% quieter
 def echo(var pat : Pattern; times : int; time : double; feedback : float) : Pattern {
+    //! Repeats every event `times` times, offset by `time` cycles each, with each repeat scaled by `feedback`. Example: `pat |> echo(3, 0.25lf, 0.5)`.
     // Build gain table and offsets, then query pat once per span and duplicate haps
     var gains : array<float>
     var offsets : array<double>
@@ -1573,11 +1684,13 @@ def echo(var pat : Pattern; times : int; time : double; feedback : float) : Patt
 
 // stut — alias for echo with reordered parameters (times, feedback, time).
 def stut(var pat : Pattern; times : int; feedback : float; time : double) : Pattern {
+    //! Alias for `echo` with argument order `(times, feedback, time)`. Example: `pat |> stut(3, 0.5, 0.125lf)`.
     return <- echo(pat, times, time, feedback)
 }
 
 // Repeat each event n times within its timespan.
 def ply(var pat : Pattern; n : int) : Pattern {
+    //! Repeats each event `n` times within its own timespan. Example: `s("bd sd") |> ply(3)` plays each hit as a triplet.
     let nf = double(n)
     return @capture(= n, = nf, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -1611,6 +1724,7 @@ def ply(var pat : Pattern; n : int) : Pattern {
 // Shift pattern left by 1/n each cycle.
 // iter(pat, 4) — cycle 0: original, cycle 1: shifted 1/4, cycle 2: shifted 2/4, etc.
 def iter(var pat : Pattern; n : int) : Pattern {
+    //! Rotates `pat` left by `1/n` cycle each cycle. Example: `pat |> iter(4)` — cycle 0 original, cycle 1 shifted 1/4, etc.
     let nf = double(n)
     return @capture(= n, = nf, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -1639,6 +1753,7 @@ def iter(var pat : Pattern; n : int) : Pattern {
 
 // Like iter but shifts right instead of left.
 def iterBack(var pat : Pattern; n : int) : Pattern {
+    //! Like `iter` but rotates `pat` right by `1/n` cycle each cycle. Example: `pat |> iterBack(4)`.
     let nf = double(n)
     return @capture(= n, = nf, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -1668,6 +1783,7 @@ def iterBack(var pat : Pattern; n : int) : Pattern {
 // Conditional transform based on cycle number.
 // when_cycle(pat, @(c) => c % 4 == 0, @(x) => fast(x, 2.0lf))
 def when_cycle(var pat : Pattern; var cond : lambda<(cycle : int) : bool>; transform : PatternTransform) : Pattern {
+    //! Applies `transform` to `pat` on cycles where `cond(cycle)` is true, leaving others untouched. Example: `pat |> when_cycle(@(c) => c % 4 == 0, @@(x) => fast(x, 2.0lf))`.
     var transformed <- invoke(transform, pat)
     return @capture(<- pat, <- transformed, <- cond) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -1695,6 +1811,7 @@ def when_cycle(var pat : Pattern; var cond : lambda<(cycle : int) : bool>; trans
 // Loop first fraction of pattern. linger(pat, 0.25) — first quarter looped to fill each cycle.
 // Semantics: output(T) = pat(T mod t). Equivalent to pat.zoom(0, t).slow(t).
 def linger(var pat : Pattern; t : double) : Pattern {
+    //! Loops the first `t`-cycle fraction of `pat` to fill each cycle. Example: `pat |> linger(0.25lf)` loops the first quarter.
     return @capture(= t, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         return <- result if (t <= 0.0lf)
@@ -1738,12 +1855,14 @@ def linger(var pat : Pattern; t : double) : Pattern {
 
 // Combined fast + speed. hurry(pat, 2.0) speeds up pattern AND sample playback.
 def hurry(var pat : Pattern; factor : double) : Pattern {
+    //! Combined `fast` + `set_speed` — speeds up both pattern timing AND sample playback by `factor`. Example: `pat |> hurry(2.0lf)`.
     return <- fast(pat, factor) |> set_speed(float(factor))
 }
 
 // Squeeze pattern into time window [b,e] within each cycle.
 // compress(pat, 0.25, 0.75) — pattern plays in middle half of each cycle
 def compress(var pat : Pattern; b, e : double) : Pattern {
+    //! Squeezes `pat` into the cycle-time window `[b, e]`. Example: `pat |> compress(0.25lf, 0.75lf)` plays the pattern in the middle half.
     let dur = e - b
     return @capture(= b, = dur, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -1785,6 +1904,7 @@ def compress(var pat : Pattern; b, e : double) : Pattern {
 // Apply function to the nth chunk each cycle (rotating).
 // chunk(pat, 4, @(x) => fast(x, 2.0lf)) — doubles speed of chunk 0, then 1, then 2, then 3
 def chunk(var pat : Pattern; n : int; transform : PatternTransform) : Pattern {
+    //! Divides each cycle into `n` chunks, applying `transform` to a different chunk each cycle (rotating). Example: `pat |> chunk(4, @@(x) => fast(x, 2.0lf))`.
     var transformed <- invoke(transform, pat)
     let nf = double(n)
     return @capture(= n, = nf, <- pat, <- transformed) (span : TimeSpan) : array<Hap> {
@@ -1829,6 +1949,7 @@ def chunk(var pat : Pattern; n : int; transform : PatternTransform) : Pattern {
 // striate(pat, 4) — cuts each sample into n parts; slice i gets begin=i/n, end=(i+1)/n.
 // Behavior: progressive slices reveal later parts of the sample envelope.
 def striate(var pat : Pattern; n : int) : Pattern {
+    //! Cuts each sample into `n` slices and plays them in sequence. Slice `i` gets `begin=i/n`, `end=(i+1)/n`. Example: `pat |> striate(4)`.
     let nf = double(n)
     let nfinv = 1.0 / float(n)
     return @capture(= n, = nf, = nfinv, <- pat) (span : TimeSpan) : array<Hap> {
@@ -1857,6 +1978,7 @@ def striate(var pat : Pattern; n : int) : Pattern {
 // Restructure pattern using a boolean mask from mini-notation.
 // struct_(pat, s("t f t t")) — play events only where mask is true
 def struct_(var pat : Pattern; var bool_pat : Pattern) : Pattern {
+    //! Restructures `pat` to the rhythmic positions of `bool_pat`'s truthy haps — values come from `pat`, timing from the mask. Example: `pat |> struct_(s("t f t t"))`.
     return @capture(<- pat, <- bool_pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var mask_haps <- bool_pat(span)
@@ -1887,6 +2009,7 @@ def struct_(var pat : Pattern; var bool_pat : Pattern) : Pattern {
 
 // Keep events where mask pattern is active (has events).
 def mask(var pat : Pattern; var mask_pat : Pattern) : Pattern {
+    //! Keeps only events from `pat` whose timespan overlaps an event in `mask_pat`. Example: `pat |> mask(s("t t f t"))`.
     return @capture(<- pat, <- mask_pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var haps <- pat(span)
@@ -1908,6 +2031,7 @@ def mask(var pat : Pattern; var mask_pat : Pattern) : Pattern {
 
 // Randomly pick one pattern per cycle.
 def choose(var pats : array<Pattern>) : Pattern {
+    //! Randomly (deterministically) picks one pattern from `pats` per cycle. Example: `choose([s("bd"), s("cp"), s("sd")])`.
     let cn = length(pats)
     return @capture(= cn, <- pats) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -1927,6 +2051,7 @@ def choose(var pats : array<Pattern>) : Pattern {
 
 // Weighted random pattern selection per cycle.
 def wchoose(var pats : array<Pattern>; var weights : array<float>) : Pattern {
+    //! Weighted random pick from `pats` per cycle using parallel `weights` array. Example: `wchoose([s("bd"), s("cp")], [3.0, 1.0])` — `bd` 75% of the time.
     var total_weight = 0.0
     for (w in weights) {
         total_weight += w
@@ -1960,6 +2085,7 @@ def wchoose(var pats : array<Pattern>; var weights : array<float>) : Pattern {
 
 // Alias for choose.
 def randcat(var pats : array<Pattern>) : Pattern {
+    //! Alias for `choose` — randomly picks one pattern per cycle.
     return <- choose(pats)
 }
 
@@ -1968,6 +2094,7 @@ def randcat(var pats : array<Pattern>) : Pattern {
 // `chooseCycles` convention used by some pattern libraries where `choose`
 // is a continuous rand signal (glitchy for discrete note patterns).
 def chooseCycles(var pats : array<Pattern>) : Pattern {
+    //! Alias for `choose` — one random pick per cycle. Present for pattern libraries where `choose` is a continuous rand signal.
     return <- choose(pats)
 }
 
@@ -1978,7 +2105,7 @@ def chooseCycles(var pats : array<Pattern>) : Pattern {
 //   apply Murmur3 finalizer for full avalanche
 // This replaces earlier LCG/single-multiply hashes whose middle bits correlated
 // across consecutive slots (the "same-note-in-a-row" bug in scramble/shuffle).
-def strudel_hash32(t : double; slot : int) : uint {
+def private strudel_hash32(t : double; slot : int) : uint {
     let Ti = int64(t * 536870912.0lf)
     let lo = uint(Ti)
     let hi = uint(Ti >> 32l)
@@ -1993,12 +2120,13 @@ def strudel_hash32(t : double; slot : int) : uint {
 }
 
 // Same hash, mapped to float in [0, 1).
-def strudel_hash01(t : double; slot : int) : float {
+def private strudel_hash01(t : double; slot : int) : float {
     return float(strudel_hash32(t, slot)) / 4294967296.0
 }
 
 // Random permutation of n subdivisions per cycle.
 def shuffle(var pat : Pattern; n : int) : Pattern {
+    //! Randomly permutes `n` equal subdivisions of each cycle (Fisher-Yates, deterministic per cycle). Example: `pat |> shuffle(4)`.
     let nf = double(n)
     return @capture(= n, = nf, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -2051,6 +2179,7 @@ def shuffle(var pat : Pattern; n : int) : Pattern {
 
 // Shuffle with replacement — each slot picks a random subdivision.
 def scramble(var pat : Pattern; n : int) : Pattern {
+    //! Like `shuffle` but with replacement — each of the `n` slots independently picks a random subdivision. Example: `pat |> scramble(8)`.
     let nf = double(n)
     return @capture(= n, = nf, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -2089,7 +2218,7 @@ def scramble(var pat : Pattern; n : int) : Pattern {
 // ─── Additional Signals ───
 
 // Square wave 0..1. First half = 1.0, second half = 0.0.
-def signal_square() : Pattern {
+def private signal_square() : Pattern {
     return signal(@(t : double) : float {
         let pos = t - floor(t)
         return pos < 0.5lf ? 1.0 : 0.0
@@ -2097,14 +2226,14 @@ def signal_square() : Pattern {
 }
 
 // Inverted sawtooth 0..1. Falls from 1.0 to 0.0 each cycle.
-def signal_isaw() : Pattern {
+def private signal_isaw() : Pattern {
     return signal(@(t : double) : float {
         return 1.0 - float(t - floor(t))
     })
 }
 
 // Inverted triangle 0..1. Starts at 1.0, falls to 0.0 at midpoint, returns to 1.0.
-def signal_itri() : Pattern {
+def private signal_itri() : Pattern {
     return signal(@(t : double) : float {
         let pos = float(t - floor(t))
         return pos < 0.5 ? 1.0 - pos * 2.0 : (pos - 0.5) * 2.0
@@ -2112,28 +2241,28 @@ def signal_itri() : Pattern {
 }
 
 // Bipolar sine -1..1
-def signal_sine2() : Pattern {
+def private signal_sine2() : Pattern {
     return signal(@(t : double) : float {
         return float(sin(3.14159265358979323846lf * 2.0lf * t))
     })
 }
 
 // Bipolar cosine -1..1
-def signal_cosine2() : Pattern {
+def private signal_cosine2() : Pattern {
     return signal(@(t : double) : float {
         return float(cos(3.14159265358979323846lf * 2.0lf * t))
     })
 }
 
 // Bipolar sawtooth -1..1
-def signal_saw2() : Pattern {
+def private signal_saw2() : Pattern {
     return signal(@(t : double) : float {
         return float(t - floor(t)) * 2.0 - 1.0
     })
 }
 
 // Bipolar triangle -1..1
-def signal_tri2() : Pattern {
+def private signal_tri2() : Pattern {
     return signal(@(t : double) : float {
         let pos = float(t - floor(t))
         return pos < 0.5 ? pos * 4.0 - 1.0 : 3.0 - pos * 4.0
@@ -2141,7 +2270,7 @@ def signal_tri2() : Pattern {
 }
 
 // Bipolar square -1..1
-def signal_square2() : Pattern {
+def private signal_square2() : Pattern {
     return signal(@(t : double) : float {
         let pos = t - floor(t)
         return pos < 0.5lf ? 1.0 : -1.0
@@ -2149,14 +2278,14 @@ def signal_square2() : Pattern {
 }
 
 // Bipolar inverted sawtooth -1..1
-def signal_isaw2() : Pattern {
+def private signal_isaw2() : Pattern {
     return signal(@(t : double) : float {
         return 1.0 - float(t - floor(t)) * 2.0
     })
 }
 
 // Bipolar inverted triangle -1..1
-def signal_itri2() : Pattern {
+def private signal_itri2() : Pattern {
     return signal(@(t : double) : float {
         let pos = float(t - floor(t))
         return pos < 0.5 ? 1.0 - pos * 4.0 : pos * 4.0 - 3.0
@@ -2164,28 +2293,28 @@ def signal_itri2() : Pattern {
 }
 
 // Random 0..1 — deterministic per query time (hash-based).
-def signal_rand() : Pattern {
+def private signal_rand() : Pattern {
     return signal(@(t : double) : float {
         return strudel_hash01(t, 0)
     })
 }
 
 // Random -1..1
-def signal_rand2() : Pattern {
+def private signal_rand2() : Pattern {
     return signal(@(t : double) : float {
         return strudel_hash01(t, 0) * 2.0 - 1.0
     })
 }
 
 // Random integer 0..n-1
-def signal_irand(n : int) : Pattern {
+def private signal_irand(n : int) : Pattern {
     return signal(@capture(= n) (t : double) : float {
         return float(strudel_hash32(t, 0) % uint(n))
     })
 }
 
 // Discrete ramp 0..n-1 within each cycle.
-def signal_run(n : int) : Pattern {
+def private signal_run(n : int) : Pattern {
     let nf = double(n)
     return @capture(= n, = nf) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -2214,180 +2343,648 @@ def signal_run(n : int) : Pattern {
 
 // ── Scalar parameter aliases ──
 
-def gain(var pat : Pattern; g : float) : Pattern { return <- set_gain(pat, g); }
-def velocity(var pat : Pattern; v : float) : Pattern { return <- set_velocity(pat, v); }
-def vel(var pat : Pattern; v : float) : Pattern { return <- set_velocity(pat, v); }
-def pan(var pat : Pattern; p : float) : Pattern { return <- set_pan(pat, p); }
-def speed(var pat : Pattern; spd : float) : Pattern { return <- set_speed(pat, spd); }
-def note(var pat : Pattern; n : float) : Pattern { return <- set_note(pat, n); }
-def sound(var pat : Pattern; snd : string) : Pattern { return <- set_sound(pat, snd); }
-def cut(var pat : Pattern; c : int) : Pattern { return <- set_cut(pat, c); }
-def room(var pat : Pattern; r : float) : Pattern { return <- set_room(pat, r); }
-def roomsize(var pat : Pattern; r : float) : Pattern { return <- set_roomsize(pat, r); }
-def size(var pat : Pattern; r : float) : Pattern { return <- set_roomsize(pat, r); }
-def delay(var pat : Pattern; d : float) : Pattern { return <- set_delay(pat, d); }
-def delaytime(var pat : Pattern; d : float) : Pattern { return <- set_delaytime(pat, d); }
-def dt(var pat : Pattern; d : float) : Pattern { return <- set_delaytime(pat, d); }
-def delayfeedback(var pat : Pattern; d : float) : Pattern { return <- set_delayfeedback(pat, d); }
-def dfb(var pat : Pattern; d : float) : Pattern { return <- set_delayfeedback(pat, d); }
-def delaysync(var pat : Pattern; d : float) : Pattern { return <- set_delaysync(pat, d); }
-def orbit(var pat : Pattern; o : int) : Pattern { return <- set_orbit(pat, o); }
-def fm(var pat : Pattern; f : float) : Pattern { return <- set_fm(pat, f); }
-def fmh(var pat : Pattern; f : float) : Pattern { return <- set_fmh(pat, f); }
-def lpf(var pat : Pattern; freq : float) : Pattern { return <- set_lpf(pat, freq); }
-def lp(var pat : Pattern; freq : float) : Pattern { return <- set_lpf(pat, freq); }
-def hpf(var pat : Pattern; freq : float) : Pattern { return <- set_hpf(pat, freq); }
-def hp(var pat : Pattern; freq : float) : Pattern { return <- set_hpf(pat, freq); }
-def lpq(var pat : Pattern; q : float) : Pattern { return <- set_lpq(pat, q); }
-def resonance(var pat : Pattern; q : float) : Pattern { return <- set_lpq(pat, q); }
-def hpq(var pat : Pattern; q : float) : Pattern { return <- set_hpq(pat, q); }
-def attack(var pat : Pattern; a : float) : Pattern { return <- set_attack(pat, a); }
-def att(var pat : Pattern; a : float) : Pattern { return <- set_attack(pat, a); }
-def decay(var pat : Pattern; d : float) : Pattern { return <- set_decay(pat, d); }
-def dec(var pat : Pattern; d : float) : Pattern { return <- set_decay(pat, d); }
-def sustain(var pat : Pattern; s : float) : Pattern { return <- set_sustain(pat, s); }
-def sus(var pat : Pattern; s : float) : Pattern { return <- set_sustain(pat, s); }
-def release(var pat : Pattern; r : float) : Pattern { return <- set_release(pat, r); }
-def rel(var pat : Pattern; r : float) : Pattern { return <- set_release(pat, r); }
-def chorus(var pat : Pattern; c : float) : Pattern { return <- set_chorus(pat, c); }
+def gain(var pat : Pattern; g : float) : Pattern {
+    //! Fluent shorthand for `set_gain`. Sets amplitude (0..1) on every event.
+    return <- set_gain(pat, g)
+}
+def velocity(var pat : Pattern; v : float) : Pattern {
+    //! Fluent shorthand for `set_velocity`. Sets MIDI-like velocity (0..1) on every event.
+    return <- set_velocity(pat, v)
+}
+def vel(var pat : Pattern; v : float) : Pattern {
+    //! Alias for `velocity`.
+    return <- set_velocity(pat, v)
+}
+def pan(var pat : Pattern; p : float) : Pattern {
+    //! Fluent shorthand for `set_pan`. Sets stereo position (0=L, 0.5=C, 1=R).
+    return <- set_pan(pat, p)
+}
+def speed(var pat : Pattern; spd : float) : Pattern {
+    //! Fluent shorthand for `set_speed`. Sets sample playback speed.
+    return <- set_speed(pat, spd)
+}
+def note(var pat : Pattern; n : float) : Pattern {
+    //! Fluent shorthand for `set_note`. Sets MIDI note number on every event.
+    return <- set_note(pat, n)
+}
+def sound(var pat : Pattern; snd : string) : Pattern {
+    //! Fluent shorthand for `set_sound`. Sets the sound name.
+    return <- set_sound(pat, snd)
+}
+def cut(var pat : Pattern; c : int) : Pattern {
+    //! Fluent shorthand for `set_cut`. Sets the cut group (new voice kills previous in same group).
+    return <- set_cut(pat, c)
+}
+def room(var pat : Pattern; r : float) : Pattern {
+    //! Fluent shorthand for `set_room`. Sets reverb send amount (0..1).
+    return <- set_room(pat, r)
+}
+def roomsize(var pat : Pattern; r : float) : Pattern {
+    //! Fluent shorthand for `set_roomsize`. Sets reverb room size.
+    return <- set_roomsize(pat, r)
+}
+def size(var pat : Pattern; r : float) : Pattern {
+    //! Alias for `roomsize`.
+    return <- set_roomsize(pat, r)
+}
+def delay(var pat : Pattern; d : float) : Pattern {
+    //! Fluent shorthand for `set_delay`. Sets delay send amount (0..1).
+    return <- set_delay(pat, d)
+}
+def delaytime(var pat : Pattern; d : float) : Pattern {
+    //! Fluent shorthand for `set_delaytime`. Sets delay time in seconds.
+    return <- set_delaytime(pat, d)
+}
+def dt(var pat : Pattern; d : float) : Pattern {
+    //! Alias for `delaytime`.
+    return <- set_delaytime(pat, d)
+}
+def delayfeedback(var pat : Pattern; d : float) : Pattern {
+    //! Fluent shorthand for `set_delayfeedback`. Sets delay feedback (0..<1).
+    return <- set_delayfeedback(pat, d)
+}
+def dfb(var pat : Pattern; d : float) : Pattern {
+    //! Alias for `delayfeedback`.
+    return <- set_delayfeedback(pat, d)
+}
+def delaysync(var pat : Pattern; d : float) : Pattern {
+    //! Fluent shorthand for `set_delaysync`. Sets delay time in cycles (tempo-synced delay).
+    return <- set_delaysync(pat, d)
+}
+def orbit(var pat : Pattern; o : int) : Pattern {
+    //! Fluent shorthand for `set_orbit`. Sets the effect-bus routing index.
+    return <- set_orbit(pat, o)
+}
+def fm(var pat : Pattern; f : float) : Pattern {
+    //! Fluent shorthand for `set_fm`. Sets FM modulation depth.
+    return <- set_fm(pat, f)
+}
+def fmh(var pat : Pattern; f : float) : Pattern {
+    //! Fluent shorthand for `set_fmh`. Sets FM harmonicity ratio.
+    return <- set_fmh(pat, f)
+}
+def lpf(var pat : Pattern; freq : float) : Pattern {
+    //! Fluent shorthand for `set_lpf`. Sets low-pass cutoff (Hz).
+    return <- set_lpf(pat, freq)
+}
+def lp(var pat : Pattern; freq : float) : Pattern {
+    //! Alias for `lpf`.
+    return <- set_lpf(pat, freq)
+}
+def hpf(var pat : Pattern; freq : float) : Pattern {
+    //! Fluent shorthand for `set_hpf`. Sets high-pass cutoff (Hz).
+    return <- set_hpf(pat, freq)
+}
+def hp(var pat : Pattern; freq : float) : Pattern {
+    //! Alias for `hpf`.
+    return <- set_hpf(pat, freq)
+}
+def lpq(var pat : Pattern; q : float) : Pattern {
+    //! Fluent shorthand for `set_lpq`. Sets low-pass filter resonance.
+    return <- set_lpq(pat, q)
+}
+def resonance(var pat : Pattern; q : float) : Pattern {
+    //! Alias for `lpq`.
+    return <- set_lpq(pat, q)
+}
+def hpq(var pat : Pattern; q : float) : Pattern {
+    //! Fluent shorthand for `set_hpq`. Sets high-pass filter resonance.
+    return <- set_hpq(pat, q)
+}
+def attack(var pat : Pattern; a : float) : Pattern {
+    //! Fluent shorthand for `set_attack`. Sets envelope attack (seconds).
+    return <- set_attack(pat, a)
+}
+def att(var pat : Pattern; a : float) : Pattern {
+    //! Alias for `attack`.
+    return <- set_attack(pat, a)
+}
+def decay(var pat : Pattern; d : float) : Pattern {
+    //! Fluent shorthand for `set_decay`. Sets envelope decay (seconds).
+    return <- set_decay(pat, d)
+}
+def dec(var pat : Pattern; d : float) : Pattern {
+    //! Alias for `decay`.
+    return <- set_decay(pat, d)
+}
+def sustain(var pat : Pattern; s : float) : Pattern {
+    //! Fluent shorthand for `set_sustain`. Sets envelope sustain level (0..1).
+    return <- set_sustain(pat, s)
+}
+def sus(var pat : Pattern; s : float) : Pattern {
+    //! Alias for `sustain`.
+    return <- set_sustain(pat, s)
+}
+def release(var pat : Pattern; r : float) : Pattern {
+    //! Fluent shorthand for `set_release`. Sets envelope release (seconds).
+    return <- set_release(pat, r)
+}
+def rel(var pat : Pattern; r : float) : Pattern {
+    //! Alias for `release`.
+    return <- set_release(pat, r)
+}
+def chorus(var pat : Pattern; c : float) : Pattern {
+    //! Fluent shorthand for `set_chorus`. Sets chorus send amount (0..1).
+    return <- set_chorus(pat, c)
+}
 
 // ── Sample region & effects aliases ──
 
-def begin(var pat : Pattern; b : float) : Pattern { return <- set_begin(pat, b); }
-def end_pos(var pat : Pattern; e_val : float) : Pattern { return <- set_end(pat, e_val); }
-def crush(var pat : Pattern; c : float) : Pattern { return <- set_crush(pat, c); }
-def coarse(var pat : Pattern; c : int) : Pattern { return <- set_coarse(pat, c); }
-def shape(var pat : Pattern; s : float) : Pattern { return <- set_shape(pat, s); }
-def djf(var pat : Pattern; d : float) : Pattern { return <- set_djf(pat, d); }
-def bpf(var pat : Pattern; freq : float) : Pattern { return <- set_bpf(pat, freq); }
-def bpq(var pat : Pattern; q : float) : Pattern { return <- set_bpq(pat, q); }
+def begin(var pat : Pattern; b : float) : Pattern {
+    //! Fluent shorthand for `set_begin`. Sets sample start position (0..1).
+    return <- set_begin(pat, b)
+}
+def end_pos(var pat : Pattern; e_val : float) : Pattern {
+    //! Fluent shorthand for `set_end`. Sets sample end position (0..1).
+    return <- set_end(pat, e_val)
+}
+def crush(var pat : Pattern; c : float) : Pattern {
+    //! Fluent shorthand for `set_crush`. Sets bit-crush amount.
+    return <- set_crush(pat, c)
+}
+def coarse(var pat : Pattern; c : int) : Pattern {
+    //! Fluent shorthand for `set_coarse`. Sets sample-rate reduction factor.
+    return <- set_coarse(pat, c)
+}
+def shape(var pat : Pattern; s : float) : Pattern {
+    //! Fluent shorthand for `set_shape`. Sets waveshape/distortion amount.
+    return <- set_shape(pat, s)
+}
+def djf(var pat : Pattern; d : float) : Pattern {
+    //! Fluent shorthand for `set_djf`. Sets DJ-filter position (<0.5 = LP, >0.5 = HP).
+    return <- set_djf(pat, d)
+}
+def bpf(var pat : Pattern; freq : float) : Pattern {
+    //! Fluent shorthand for `set_bpf`. Sets band-pass filter cutoff (Hz).
+    return <- set_bpf(pat, freq)
+}
+def bpq(var pat : Pattern; q : float) : Pattern {
+    //! Fluent shorthand for `set_bpq`. Sets band-pass filter Q.
+    return <- set_bpq(pat, q)
+}
 
 // ── Phaser / Tremolo / Compressor aliases ──
 
-def phaser(var pat : Pattern; r : float) : Pattern { return <- set_phaser(pat, r); }
-def ph(var pat : Pattern; r : float) : Pattern { return <- set_phaser(pat, r); }
-def phaserdepth(var pat : Pattern; d : float) : Pattern { return <- set_phaserdepth(pat, d); }
-def phd(var pat : Pattern; d : float) : Pattern { return <- set_phaserdepth(pat, d); }
-def phasercenter(var pat : Pattern; c : float) : Pattern { return <- set_phasercenter(pat, c); }
-def phc(var pat : Pattern; c : float) : Pattern { return <- set_phasercenter(pat, c); }
-def phasersweep(var pat : Pattern; s : float) : Pattern { return <- set_phasersweep(pat, s); }
-def phs(var pat : Pattern; s : float) : Pattern { return <- set_phasersweep(pat, s); }
+def phaser(var pat : Pattern; r : float) : Pattern {
+    //! Fluent shorthand for `set_phaser`. Sets phaser rate in Hz (0 disables).
+    return <- set_phaser(pat, r)
+}
+def ph(var pat : Pattern; r : float) : Pattern {
+    //! Alias for `phaser`.
+    return <- set_phaser(pat, r)
+}
+def phaserdepth(var pat : Pattern; d : float) : Pattern {
+    //! Fluent shorthand for `set_phaserdepth`. Sets phaser depth.
+    return <- set_phaserdepth(pat, d)
+}
+def phd(var pat : Pattern; d : float) : Pattern {
+    //! Alias for `phaserdepth`.
+    return <- set_phaserdepth(pat, d)
+}
+def phasercenter(var pat : Pattern; c : float) : Pattern {
+    //! Fluent shorthand for `set_phasercenter`. Sets phaser center frequency.
+    return <- set_phasercenter(pat, c)
+}
+def phc(var pat : Pattern; c : float) : Pattern {
+    //! Alias for `phasercenter`.
+    return <- set_phasercenter(pat, c)
+}
+def phasersweep(var pat : Pattern; s : float) : Pattern {
+    //! Fluent shorthand for `set_phasersweep`. Sets phaser sweep range.
+    return <- set_phasersweep(pat, s)
+}
+def phs(var pat : Pattern; s : float) : Pattern {
+    //! Alias for `phasersweep`.
+    return <- set_phasersweep(pat, s)
+}
 
-def tremolo(var pat : Pattern; r : float) : Pattern { return <- set_tremolo(pat, r); }
-def trem(var pat : Pattern; r : float) : Pattern { return <- set_tremolo(pat, r); }
-def tremolodepth(var pat : Pattern; d : float) : Pattern { return <- set_tremolodepth(pat, d); }
-def tremdepth(var pat : Pattern; d : float) : Pattern { return <- set_tremolodepth(pat, d); }
+def tremolo(var pat : Pattern; r : float) : Pattern {
+    //! Fluent shorthand for `set_tremolo`. Sets tremolo rate in Hz (0 disables).
+    return <- set_tremolo(pat, r)
+}
+def trem(var pat : Pattern; r : float) : Pattern {
+    //! Alias for `tremolo`.
+    return <- set_tremolo(pat, r)
+}
+def tremolodepth(var pat : Pattern; d : float) : Pattern {
+    //! Fluent shorthand for `set_tremolodepth`. Sets tremolo depth.
+    return <- set_tremolodepth(pat, d)
+}
+def tremdepth(var pat : Pattern; d : float) : Pattern {
+    //! Alias for `tremolodepth`.
+    return <- set_tremolodepth(pat, d)
+}
 
-def compressor(var pat : Pattern; thr_db : float) : Pattern { return <- set_compressor(pat, thr_db); }
+def compressor(var pat : Pattern; thr_db : float) : Pattern {
+    //! Fluent shorthand for `set_compressor`. Sets compressor threshold in dB (>=0 bypasses).
+    return <- set_compressor(pat, thr_db)
+}
 // camelCase aliases; also expose snake_case for daScript-idiomatic callers.
-def compressorRatio(var pat : Pattern; r : float) : Pattern { return <- set_compressor_ratio(pat, r); }
-def compressor_ratio(var pat : Pattern; r : float) : Pattern { return <- set_compressor_ratio(pat, r); }
-def compressorKnee(var pat : Pattern; k : float) : Pattern { return <- set_compressor_knee(pat, k); }
-def compressor_knee(var pat : Pattern; k : float) : Pattern { return <- set_compressor_knee(pat, k); }
-def compressorAttack(var pat : Pattern; a : float) : Pattern { return <- set_compressor_attack(pat, a); }
-def compressor_attack(var pat : Pattern; a : float) : Pattern { return <- set_compressor_attack(pat, a); }
-def compressorRelease(var pat : Pattern; r : float) : Pattern { return <- set_compressor_release(pat, r); }
-def compressor_release(var pat : Pattern; r : float) : Pattern { return <- set_compressor_release(pat, r); }
+def compressorRatio(var pat : Pattern; r : float) : Pattern {
+    //! camelCase fluent shorthand for `set_compressor_ratio`. Sets compressor ratio.
+    return <- set_compressor_ratio(pat, r)
+}
+def compressor_ratio(var pat : Pattern; r : float) : Pattern {
+    //! snake_case fluent shorthand for `set_compressor_ratio`. Sets compressor ratio.
+    return <- set_compressor_ratio(pat, r)
+}
+def compressorKnee(var pat : Pattern; k : float) : Pattern {
+    //! camelCase fluent shorthand for `set_compressor_knee`. Sets compressor knee (dB).
+    return <- set_compressor_knee(pat, k)
+}
+def compressor_knee(var pat : Pattern; k : float) : Pattern {
+    //! snake_case fluent shorthand for `set_compressor_knee`. Sets compressor knee (dB).
+    return <- set_compressor_knee(pat, k)
+}
+def compressorAttack(var pat : Pattern; a : float) : Pattern {
+    //! camelCase fluent shorthand for `set_compressor_attack`. Sets compressor attack (seconds).
+    return <- set_compressor_attack(pat, a)
+}
+def compressor_attack(var pat : Pattern; a : float) : Pattern {
+    //! snake_case fluent shorthand for `set_compressor_attack`. Sets compressor attack (seconds).
+    return <- set_compressor_attack(pat, a)
+}
+def compressorRelease(var pat : Pattern; r : float) : Pattern {
+    //! camelCase fluent shorthand for `set_compressor_release`. Sets compressor release (seconds).
+    return <- set_compressor_release(pat, r)
+}
+def compressor_release(var pat : Pattern; r : float) : Pattern {
+    //! snake_case fluent shorthand for `set_compressor_release`. Sets compressor release (seconds).
+    return <- set_compressor_release(pat, r)
+}
 
 // ── SF2 aliases ──
 
-def sf2(var pat : Pattern; program : int) : Pattern { return <- set_sf2(pat, program); }
-def sf2(var pat : Pattern; name : string) : Pattern { return <- set_sf2(pat, name); }
-def sf2_bank(var pat : Pattern; bank : int) : Pattern { return <- set_sf2_bank(pat, bank); }
-def sf2_expression(var pat : Pattern; v : float) : Pattern { return <- set_sf2_expression(pat, v); }
-def sf2_mod_wheel(var pat : Pattern; v : float) : Pattern { return <- set_sf2_mod_wheel(pat, v); }
-def sf2_pitch_bend(var pat : Pattern; v : float) : Pattern { return <- set_sf2_pitch_bend(pat, v); }
+def sf2(var pat : Pattern; program : int) : Pattern {
+    //! Fluent shorthand for `set_sf2`. Sets SF2 GM program number (0..127).
+    return <- set_sf2(pat, program)
+}
+def sf2(var pat : Pattern; name : string) : Pattern {
+    //! Fluent shorthand for `set_sf2` by GM instrument name. Example: `pat |> sf2("piano")`.
+    return <- set_sf2(pat, name)
+}
+def sf2_bank(var pat : Pattern; bank : int) : Pattern {
+    //! Fluent shorthand for `set_sf2_bank`. Sets SF2 bank (0 = melodic, 128 = percussion).
+    return <- set_sf2_bank(pat, bank)
+}
+def sf2_expression(var pat : Pattern; v : float) : Pattern {
+    //! Fluent shorthand for `set_sf2_expression`. Sets SF2 expression CC11 (0..1).
+    return <- set_sf2_expression(pat, v)
+}
+def sf2_mod_wheel(var pat : Pattern; v : float) : Pattern {
+    //! Fluent shorthand for `set_sf2_mod_wheel`. Sets SF2 mod wheel CC1 (0..1, vibrato depth).
+    return <- set_sf2_mod_wheel(pat, v)
+}
+def sf2_pitch_bend(var pat : Pattern; v : float) : Pattern {
+    //! Fluent shorthand for `set_sf2_pitch_bend`. Sets SF2 pitch bend (0..1, 0.5 = center).
+    return <- set_sf2_pitch_bend(pat, v)
+}
 
 // ── Pattern-modulated parameter aliases ──
 
-def gain(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_gain(pat, mod_pat); }
-def velocity(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_velocity(pat, mod_pat); }
-def vel(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_velocity(pat, mod_pat); }
-def pan(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_pan(pat, mod_pat); }
-def speed(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_speed(pat, mod_pat); }
-def note(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_note(pat, mod_pat); }
-def sound(var pat : Pattern; var sound_pat : Pattern) : Pattern { return <- set_sound(pat, sound_pat); }
-def room(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_room(pat, mod_pat); }
-def roomsize(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_roomsize(pat, mod_pat); }
-def size(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_roomsize(pat, mod_pat); }
-def delay(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_delay(pat, mod_pat); }
-def delaytime(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_delaytime(pat, mod_pat); }
-def dt(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_delaytime(pat, mod_pat); }
-def delayfeedback(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_delayfeedback(pat, mod_pat); }
-def dfb(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_delayfeedback(pat, mod_pat); }
-def fm(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_fm(pat, mod_pat); }
-def fmh(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_fmh(pat, mod_pat); }
-def lpf(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_lpf(pat, mod_pat); }
-def lp(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_lpf(pat, mod_pat); }
-def hpf(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_hpf(pat, mod_pat); }
-def hp(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_hpf(pat, mod_pat); }
-def lpq(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_lpq(pat, mod_pat); }
-def resonance(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_lpq(pat, mod_pat); }
-def hpq(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_hpq(pat, mod_pat); }
-def attack(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_attack(pat, mod_pat); }
-def att(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_attack(pat, mod_pat); }
-def decay(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_decay(pat, mod_pat); }
-def dec(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_decay(pat, mod_pat); }
-def sustain(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_sustain(pat, mod_pat); }
-def sus(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_sustain(pat, mod_pat); }
-def release(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_release(pat, mod_pat); }
-def rel(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_release(pat, mod_pat); }
-def chorus(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_chorus(pat, mod_pat); }
-def sf2_expression(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_sf2_expression(pat, mod_pat); }
-def sf2_mod_wheel(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_sf2_mod_wheel(pat, mod_pat); }
-def sf2_pitch_bend(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_sf2_pitch_bend(pat, mod_pat); }
-def begin(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_begin(pat, mod_pat); }
-def end_pos(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_end(pat, mod_pat); }
-def crush(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_crush(pat, mod_pat); }
-def shape(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_shape(pat, mod_pat); }
-def djf(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_djf(pat, mod_pat); }
-def bpf(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_bpf(pat, mod_pat); }
-def bpq(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_bpq(pat, mod_pat); }
-def phaser(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phaser(pat, mod_pat); }
-def ph(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phaser(pat, mod_pat); }
-def phaserdepth(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phaserdepth(pat, mod_pat); }
-def phd(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phaserdepth(pat, mod_pat); }
-def phasercenter(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phasercenter(pat, mod_pat); }
-def phc(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phasercenter(pat, mod_pat); }
-def phasersweep(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phasersweep(pat, mod_pat); }
-def phs(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_phasersweep(pat, mod_pat); }
-def tremolo(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_tremolo(pat, mod_pat); }
-def trem(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_tremolo(pat, mod_pat); }
-def tremolodepth(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_tremolodepth(pat, mod_pat); }
-def tremdepth(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_tremolodepth(pat, mod_pat); }
-def compressor(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor(pat, mod_pat); }
-def compressorRatio(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_ratio(pat, mod_pat); }
-def compressor_ratio(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_ratio(pat, mod_pat); }
-def compressorKnee(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_knee(pat, mod_pat); }
-def compressor_knee(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_knee(pat, mod_pat); }
-def compressorAttack(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_attack(pat, mod_pat); }
-def compressor_attack(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_attack(pat, mod_pat); }
-def compressorRelease(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_release(pat, mod_pat); }
-def compressor_release(var pat : Pattern; var mod_pat : Pattern) : Pattern { return <- set_compressor_release(pat, mod_pat); }
+def gain(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `gain` — sampled from `mod_pat` per event.
+    return <- set_gain(pat, mod_pat)
+}
+def velocity(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `velocity` — sampled from `mod_pat` per event.
+    return <- set_velocity(pat, mod_pat)
+}
+def vel(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `velocity`.
+    return <- set_velocity(pat, mod_pat)
+}
+def pan(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `pan` — sampled from `mod_pat` per event.
+    return <- set_pan(pat, mod_pat)
+}
+def speed(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `speed` — sampled from `mod_pat` per event.
+    return <- set_speed(pat, mod_pat)
+}
+def note(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `note` — sampled from `mod_pat` per event.
+    return <- set_note(pat, mod_pat)
+}
+def sound(var pat : Pattern; var sound_pat : Pattern) : Pattern {
+    //! Pattern-valued `sound` — sound name sampled from `sound_pat.s` per event. Example: `note("c3") |> sound(s("<saw tri>"))`.
+    return <- set_sound(pat, sound_pat)
+}
+def room(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `room` — sampled from `mod_pat` per event.
+    return <- set_room(pat, mod_pat)
+}
+def roomsize(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `roomsize` — sampled from `mod_pat` per event.
+    return <- set_roomsize(pat, mod_pat)
+}
+def size(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `roomsize`.
+    return <- set_roomsize(pat, mod_pat)
+}
+def delay(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `delay` send — sampled from `mod_pat` per event.
+    return <- set_delay(pat, mod_pat)
+}
+def delaytime(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `delaytime` — sampled from `mod_pat` per event.
+    return <- set_delaytime(pat, mod_pat)
+}
+def dt(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `delaytime`.
+    return <- set_delaytime(pat, mod_pat)
+}
+def delayfeedback(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `delayfeedback` — sampled from `mod_pat` per event.
+    return <- set_delayfeedback(pat, mod_pat)
+}
+def dfb(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `delayfeedback`.
+    return <- set_delayfeedback(pat, mod_pat)
+}
+def fm(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated FM depth — sampled from `mod_pat` per event.
+    return <- set_fm(pat, mod_pat)
+}
+def fmh(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated FM harmonicity — sampled from `mod_pat` per event.
+    return <- set_fmh(pat, mod_pat)
+}
+def lpf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `lpf` cutoff — sampled from `mod_pat` per event.
+    return <- set_lpf(pat, mod_pat)
+}
+def lp(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `lpf`.
+    return <- set_lpf(pat, mod_pat)
+}
+def hpf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `hpf` cutoff — sampled from `mod_pat` per event.
+    return <- set_hpf(pat, mod_pat)
+}
+def hp(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `hpf`.
+    return <- set_hpf(pat, mod_pat)
+}
+def lpq(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `lpq` resonance — sampled from `mod_pat` per event.
+    return <- set_lpq(pat, mod_pat)
+}
+def resonance(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `lpq`.
+    return <- set_lpq(pat, mod_pat)
+}
+def hpq(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `hpq` resonance — sampled from `mod_pat` per event.
+    return <- set_hpq(pat, mod_pat)
+}
+def attack(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated envelope `attack` — sampled from `mod_pat` per event.
+    return <- set_attack(pat, mod_pat)
+}
+def att(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `attack`.
+    return <- set_attack(pat, mod_pat)
+}
+def decay(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated envelope `decay` — sampled from `mod_pat` per event.
+    return <- set_decay(pat, mod_pat)
+}
+def dec(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `decay`.
+    return <- set_decay(pat, mod_pat)
+}
+def sustain(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated envelope `sustain` — sampled from `mod_pat` per event.
+    return <- set_sustain(pat, mod_pat)
+}
+def sus(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `sustain`.
+    return <- set_sustain(pat, mod_pat)
+}
+def release(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated envelope `release` — sampled from `mod_pat` per event.
+    return <- set_release(pat, mod_pat)
+}
+def rel(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `release`.
+    return <- set_release(pat, mod_pat)
+}
+def chorus(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated chorus send — sampled from `mod_pat` per event.
+    return <- set_chorus(pat, mod_pat)
+}
+def sf2_expression(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated SF2 expression (CC11) — sampled from `mod_pat` per event.
+    return <- set_sf2_expression(pat, mod_pat)
+}
+def sf2_mod_wheel(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated SF2 mod wheel (CC1) — sampled from `mod_pat` per event.
+    return <- set_sf2_mod_wheel(pat, mod_pat)
+}
+def sf2_pitch_bend(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated SF2 pitch bend — sampled from `mod_pat` per event.
+    return <- set_sf2_pitch_bend(pat, mod_pat)
+}
+def begin(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated sample `begin` — sampled from `mod_pat` per event.
+    return <- set_begin(pat, mod_pat)
+}
+def end_pos(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated sample `end_pos` — sampled from `mod_pat` per event.
+    return <- set_end(pat, mod_pat)
+}
+def crush(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated bit-`crush` — sampled from `mod_pat` per event.
+    return <- set_crush(pat, mod_pat)
+}
+def shape(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated wave-`shape` — sampled from `mod_pat` per event.
+    return <- set_shape(pat, mod_pat)
+}
+def djf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated DJ-filter `djf` — sampled from `mod_pat` per event.
+    return <- set_djf(pat, mod_pat)
+}
+def bpf(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated band-pass cutoff `bpf` — sampled from `mod_pat` per event.
+    return <- set_bpf(pat, mod_pat)
+}
+def bpq(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated band-pass Q `bpq` — sampled from `mod_pat` per event.
+    return <- set_bpq(pat, mod_pat)
+}
+def phaser(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated phaser rate — sampled from `mod_pat` per event.
+    return <- set_phaser(pat, mod_pat)
+}
+def ph(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `phaser`.
+    return <- set_phaser(pat, mod_pat)
+}
+def phaserdepth(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated phaser depth — sampled from `mod_pat` per event.
+    return <- set_phaserdepth(pat, mod_pat)
+}
+def phd(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `phaserdepth`.
+    return <- set_phaserdepth(pat, mod_pat)
+}
+def phasercenter(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated phaser center frequency — sampled from `mod_pat` per event.
+    return <- set_phasercenter(pat, mod_pat)
+}
+def phc(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `phasercenter`.
+    return <- set_phasercenter(pat, mod_pat)
+}
+def phasersweep(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated phaser sweep — sampled from `mod_pat` per event.
+    return <- set_phasersweep(pat, mod_pat)
+}
+def phs(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `phasersweep`.
+    return <- set_phasersweep(pat, mod_pat)
+}
+def tremolo(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated tremolo rate — sampled from `mod_pat` per event.
+    return <- set_tremolo(pat, mod_pat)
+}
+def trem(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `tremolo`.
+    return <- set_tremolo(pat, mod_pat)
+}
+def tremolodepth(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated tremolo depth — sampled from `mod_pat` per event.
+    return <- set_tremolodepth(pat, mod_pat)
+}
+def tremdepth(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Alias for pattern-modulated `tremolodepth`.
+    return <- set_tremolodepth(pat, mod_pat)
+}
+def compressor(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated compressor threshold — sampled from `mod_pat` per event.
+    return <- set_compressor(pat, mod_pat)
+}
+def compressorRatio(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated compressor ratio (camelCase) — sampled from `mod_pat` per event.
+    return <- set_compressor_ratio(pat, mod_pat)
+}
+def compressor_ratio(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated compressor ratio (snake_case) — sampled from `mod_pat` per event.
+    return <- set_compressor_ratio(pat, mod_pat)
+}
+def compressorKnee(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated compressor knee (camelCase) — sampled from `mod_pat` per event.
+    return <- set_compressor_knee(pat, mod_pat)
+}
+def compressor_knee(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated compressor knee (snake_case) — sampled from `mod_pat` per event.
+    return <- set_compressor_knee(pat, mod_pat)
+}
+def compressorAttack(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated compressor attack (camelCase) — sampled from `mod_pat` per event.
+    return <- set_compressor_attack(pat, mod_pat)
+}
+def compressor_attack(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated compressor attack (snake_case) — sampled from `mod_pat` per event.
+    return <- set_compressor_attack(pat, mod_pat)
+}
+def compressorRelease(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated compressor release (camelCase) — sampled from `mod_pat` per event.
+    return <- set_compressor_release(pat, mod_pat)
+}
+def compressor_release(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated compressor release (snake_case) — sampled from `mod_pat` per event.
+    return <- set_compressor_release(pat, mod_pat)
+}
 
 // ── Signal aliases ──
 
-def sine() : Pattern { return <- signal_sine(); }
-def cosine() : Pattern { return <- signal_cosine(); }
-def saw() : Pattern { return <- signal_saw(); }
-def tri() : Pattern { return <- signal_tri(); }
-def perlin() : Pattern { return <- signal_perlin(); }
-def range(var pat : Pattern; lo, hi : float) : Pattern { return <- signal_range(pat, lo, hi); }
-def square() : Pattern { return <- signal_square(); }
-def isaw() : Pattern { return <- signal_isaw(); }
-def itri() : Pattern { return <- signal_itri(); }
-def sine2() : Pattern { return <- signal_sine2(); }
-def cosine2() : Pattern { return <- signal_cosine2(); }
-def saw2() : Pattern { return <- signal_saw2(); }
-def tri2() : Pattern { return <- signal_tri2(); }
-def square2() : Pattern { return <- signal_square2(); }
-def isaw2() : Pattern { return <- signal_isaw2(); }
-def itri2() : Pattern { return <- signal_itri2(); }
-def rand() : Pattern { return <- signal_rand(); }
-def rand2() : Pattern { return <- signal_rand2(); }
-def irand(n : int) : Pattern { return <- signal_irand(n); }
-def run(n : int) : Pattern { return <- signal_run(n); }
+def sine() : Pattern {
+    //! Unipolar sine signal `0..1`. Alias for `signal_sine`.
+    return <- signal_sine()
+}
+def cosine() : Pattern {
+    //! Unipolar cosine signal `0..1`. Alias for `signal_cosine`.
+    return <- signal_cosine()
+}
+def saw() : Pattern {
+    //! Unipolar sawtooth signal `0..1`. Alias for `signal_saw`.
+    return <- signal_saw()
+}
+def tri() : Pattern {
+    //! Unipolar triangle signal `0..1`. Alias for `signal_tri`.
+    return <- signal_tri()
+}
+def perlin() : Pattern {
+    //! Unipolar Perlin-noise signal `0..1`. Alias for `signal_perlin`.
+    return <- signal_perlin()
+}
+def range(var pat : Pattern; lo, hi : float) : Pattern {
+    //! Scales a signal pattern from `0..1` to `lo..hi`. Alias for `signal_range`. Example: `sine() |> range(200.0, 4000.0)`.
+    return <- signal_range(pat, lo, hi)
+}
+def square() : Pattern {
+    //! Unipolar square signal (1.0 first half, 0.0 second half).
+    return <- signal_square()
+}
+def isaw() : Pattern {
+    //! Inverted unipolar sawtooth signal — falls from 1.0 to 0.0 each cycle.
+    return <- signal_isaw()
+}
+def itri() : Pattern {
+    //! Inverted unipolar triangle signal — starts at 1.0, dips to 0.0 at midpoint.
+    return <- signal_itri()
+}
+def sine2() : Pattern {
+    //! Bipolar sine signal `-1..1`.
+    return <- signal_sine2()
+}
+def cosine2() : Pattern {
+    //! Bipolar cosine signal `-1..1`.
+    return <- signal_cosine2()
+}
+def saw2() : Pattern {
+    //! Bipolar sawtooth signal `-1..1`.
+    return <- signal_saw2()
+}
+def tri2() : Pattern {
+    //! Bipolar triangle signal `-1..1`.
+    return <- signal_tri2()
+}
+def square2() : Pattern {
+    //! Bipolar square signal `-1..1`.
+    return <- signal_square2()
+}
+def isaw2() : Pattern {
+    //! Bipolar inverted sawtooth signal `-1..1`.
+    return <- signal_isaw2()
+}
+def itri2() : Pattern {
+    //! Bipolar inverted triangle signal `-1..1`.
+    return <- signal_itri2()
+}
+def rand() : Pattern {
+    //! Unipolar deterministic random signal `0..1` — hash-based, same time yields same value.
+    return <- signal_rand()
+}
+def rand2() : Pattern {
+    //! Bipolar deterministic random signal `-1..1` — hash-based.
+    return <- signal_rand2()
+}
+def irand(n : int) : Pattern {
+    //! Random integer signal in `0..n-1`, deterministic.
+    return <- signal_irand(n)
+}
+def run(n : int) : Pattern {
+    //! Discrete ramp `0..n-1` within each cycle — `n` haps per cycle with values `0, 1, ..., n-1`.
+    return <- signal_run(n)
+}
 
 // ── Additional aliases ──
 
-def degradeBy(var pat : Pattern; prob : float) : Pattern { return <- degrade(pat, prob); }
+def degradeBy(var pat : Pattern; prob : float) : Pattern {
+    //! Alias for `degrade` with explicit probability. Randomly drops events with probability `prob`. Example: `pat |> degradeBy(0.3)`.
+    return <- degrade(pat, prob)
+}

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -4,6 +4,9 @@ options no_unused_block_arguments = false
 options no_unused_function_arguments = false
 
 module strudel_player shared public
+//! Top-level playback harness for strudel patterns.
+//! Manages tracks, BPM/CPS, sample/SF2 banks, and a command channel for both
+//! main-thread (strudel_tick) and dedicated-thread (strudel_play) playback modes.
 
 require strudel/strudel_event
 require strudel/strudel_time
@@ -22,7 +25,7 @@ require math
 
 // --- Command channel ---
 
-variant StrudelCommand {
+variant private StrudelCommand {
     shutdown : bool;
     set_bpm  : double;
     set_cps  : double;
@@ -32,7 +35,7 @@ variant StrudelCommand {
 // --- Track ---
 
 [safe_when_uninitialized]
-struct StrudelTrack {
+struct private StrudelTrack {
     pat         : Pattern
     @safe_when_uninitialized sched : Scheduler
     gain        : float = 1.0
@@ -45,8 +48,11 @@ struct StrudelTrack {
 var private g_bank : SampleBank
 var private g_bank_ptr : SampleBank?   // for threaded mode: points to main thread's bank
 var private g_sid : uint64 = 0ul
+//! Current playback wall-clock time in seconds. Derived from exact sample count.
+//! Written by the playback thread (threaded mode) or strudel_tick (main-thread mode).
 var public g_wall_time : double = 0.0lf
 var private g_wall_samples : int64 = 0l  // exact sample count — g_wall_time derived from this
+//! Current tempo in cycles per second (0.5 = 120 BPM at 4 beats/cycle).
 var public g_cps : double = 0.5lf
 var private g_cmd_channel : Channel?
 var private g_done_channel : Channel?
@@ -60,11 +66,13 @@ var private g_chunk_seconds : float = 0.05
 var private g_tick_status_box : LockBox?  // buffer level feedback for strudel_tick
 var private g_tick_pcm_box : LockBox?    // lock box for append_box_to_pcm in main-thread mode
 
-// Per-track PCM output (populated by strudel_tick, main-thread mode only)
+//! Per-track PCM output written by strudel_tick (main-thread mode only), indexed by track index.
+//! Visualizer combinators read this to render per-track waveforms.
 var public g_track_pcm : array<array<float>>
+//! Master mixed stereo PCM output for the most recent tick (main-thread mode only).
 var public g_master_pcm : array<float>
 
-// Rolling vis index — bumped by strudel_add_track, read by visualizer combinators
+//! Rolling visualizer index — incremented by strudel_add_track, read by visualizer combinators.
 var public g_vis_index : int = 0
 
 // --- Memory tracking ---
@@ -80,23 +88,23 @@ var private g_tick_total_time : double = 0.lf       // total tick time in ms
 var private g_tick_total_samples : uint64 = 0ul     // total samples rendered
 var private g_tick_max_chunk_usec : double = 0.lf   // peak chunk time in usec
 
+//! A PCM audio block passed between the playback thread and the visualizer or saver.
 struct AudioChunk {
     samples : array<float>
+        //! Interleaved stereo PCM samples for one chunk.
 }
 
-struct PlaybackTime {
+struct private PlaybackTime {
     wall_time : double
     cps       : double
 }
 
 // --- Playback time ---
 
-// Get current playback position and tempo.
-// In threaded mode reads from lockbox.
-// In main-thread mode uses hardware playback position (smooth, matches what you hear).
-// The playback position lags behind g_wall_time by the audio buffer depth — that's correct:
-// the pianoroll shows upcoming notes, and the playhead shows where playback actually is.
 def public strudel_get_playback_time() : tuple<double; double> {
+    //! Get current playback wall-clock time and tempo as (wall_time, cps).
+    //! In threaded mode reads from a lockbox; in main-thread mode uses the hardware
+    //! consumed position (smooth, matches what you hear) and lags g_wall_time by the audio buffer depth.
     var wt = 0.0lf
     var cp = 0.5lf
     if (g_playback_box != null) {
@@ -124,6 +132,7 @@ def public strudel_get_playback_time() : tuple<double; double> {
 // --- Resource loading ---
 
 def public strudel_load_sound(path, name : string) {
+    //! Load a single audio sample from disk and register it under the given name. Duplicates are ignored.
     let sname = to_lower(name)
     if (key_exists(g_bank.sounds, sname)) {
         return
@@ -132,6 +141,7 @@ def public strudel_load_sound(path, name : string) {
 }
 
 def public strudel_load_sample_dir(root : string) {
+    //! Load every audio file under root as a named sample (filename becomes the sound name).
     dir(root) $(entry) {
         if (entry == "." || entry == "..") {
             return
@@ -145,6 +155,7 @@ def public strudel_load_sample_dir(root : string) {
 }
 
 def public strudel_load_sf2(path : string) : bool {
+    //! Load a SoundFont (.sf2) file for SF2-based synthesis. Returns true on success.
     g_sf2 = sf2_load(path)
     if (g_sf2 != null) {
         g_sf2_path = path
@@ -153,22 +164,26 @@ def public strudel_load_sf2(path : string) : bool {
 }
 
 def public strudel_get_sf2_path() : string {
+    //! Return the path of the currently loaded SoundFont (empty string if none).
     return g_sf2_path
 }
 
 def public strudel_has_sf2() : bool {
+    //! Return true if a SoundFont has been loaded.
     return g_sf2 != null
 }
 
 // --- Volume / Pause ---
 
 def public strudel_set_volume(volume : float; time : float = 0.0) {
+    //! Set the master playback volume, optionally ramping to it over the given time in seconds.
     if (g_sid != 0ul) {
         set_volume(g_sid, volume, time)
     }
 }
 
 def public strudel_set_pause(paused : bool) {
+    //! Pause or resume audio output.
     if (g_sid != 0ul) {
         set_pause(g_sid, paused)
     }
@@ -177,6 +192,7 @@ def public strudel_set_pause(paused : bool) {
 // --- Tempo (affects both threads) ---
 
 def public strudel_set_bpm(bpm : double) {
+    //! Set tempo in beats per minute (assumes 4 beats per cycle). Safe to call from the main thread.
     g_cps = bpm / 240.0lf
     if (g_cmd_channel != null) {
         g_cmd_channel |> push(new StrudelCommand(set_bpm = bpm))
@@ -184,6 +200,7 @@ def public strudel_set_bpm(bpm : double) {
 }
 
 def public strudel_set_cps(cps : double) {
+    //! Set tempo directly in cycles per second. Safe to call from the main thread.
     g_cps = cps
     if (g_cmd_channel != null) {
         g_cmd_channel |> push(new StrudelCommand(set_cps = cps))
@@ -191,16 +208,18 @@ def public strudel_set_cps(cps : double) {
 }
 
 def public strudel_set_look_ahead(look_ahead : float) {
+    //! Set how far ahead (in seconds) to query the pattern for upcoming events.
     g_look_ahead = look_ahead
 }
 
 def public strudel_debug_memory(enabled : bool) {
+    //! Enable or disable periodic heap/string-memory logging during playback.
     g_debug_memory = enabled
 }
 
-// Reset memory baseline to current heap state. Call after all one-time setup
-// (audio stream, pattern, tracks) so only growth during playback is measured.
 def public strudel_reset_memory_baseline() {
+    //! Reset memory-tracking baseline to the current heap state.
+    //! Call after all one-time setup (audio stream, pattern, tracks) so only playback growth is measured.
     g_mem_heap_baseline = heap_bytes_allocated()
     g_mem_str_baseline = string_heap_bytes_allocated()
     g_mem_heap_max = g_mem_heap_baseline
@@ -209,6 +228,7 @@ def public strudel_reset_memory_baseline() {
 }
 
 def public strudel_debug_sample_peaks() {
+    //! Log the peak amplitude of every loaded sample in the bank (debug helper).
     for (name in keys(g_bank.sounds)) {
         var samples <- render_sample(g_bank, name, 0, 1.0)
         var peak = 0.0
@@ -221,6 +241,7 @@ def public strudel_debug_sample_peaks() {
 }
 
 def public strudel_debug_master_peak() {
+    //! Log the peak amplitude of the current master PCM buffer (debug helper, main-thread mode).
     if (length(g_master_pcm) > 0) {
         var peak = 0.0
         for (i in range(length(g_master_pcm))) {
@@ -233,6 +254,7 @@ def public strudel_debug_master_peak() {
 }
 
 def public strudel_debug_output_peak() {
+    //! Log the peak amplitude of each track's scheduler output (debug helper).
     for (i in range(length(g_tracks))) {
         var track = g_tracks[i]
         if (track != null && length(track.sched.output) > 0) {
@@ -248,6 +270,7 @@ def public strudel_debug_output_peak() {
 }
 
 def public strudel_debug_voices() {
+    //! Log the number of active sample/oscillator voices on each track (debug helper).
     for (i in range(length(g_tracks))) {
         var track = g_tracks[i]
         if (track != null) {
@@ -258,8 +281,8 @@ def public strudel_debug_voices() {
 
 // --- Track management ---
 
-// Add a track. Returns its index (matches g_vis_index for visualizer combinators).
 def public strudel_add_track(var pat : Pattern; gain : float = 1.0) : int {
+    //! Add a track playing the given pattern at the given gain. Returns its index (matches g_vis_index for visualizer combinators).
     let idx = g_vis_index
     g_tracks |> push(new StrudelTrack(
         pat <- pat,
@@ -283,8 +306,8 @@ def public strudel_add_track(var pat : Pattern; gain : float = 1.0) : int {
     return idx
 }
 
-// Remove a track by index (sets slot to null).
 def public strudel_remove_track(idx : int) {
+    //! Remove a track by index (shuts down its scheduler and sets the slot to null).
     if (idx >= 0 && idx < length(g_tracks) && g_tracks[idx] != null) {
         shutdown_scheduler(g_tracks[idx].sched)
         unsafe { delete g_tracks[idx]; }
@@ -292,8 +315,8 @@ def public strudel_remove_track(idx : int) {
     }
 }
 
-// Fade a track by index.
 def public strudel_fade_track(idx : int; target_gain : float; time : float) {
+    //! Fade a track's gain to target_gain over the given time in seconds (time=0 snaps instantly).
     if (idx >= 0 && idx < length(g_tracks) && g_tracks[idx] != null) {
         var track = g_tracks[idx]
         track.target_gain = target_gain
@@ -312,6 +335,8 @@ def public strudel_fade_track(idx : int; target_gain : float; time : float) {
 // --- Commands (main -> thread) ---
 
 def public strudel_command(cmd : string) {
+    //! Send a user command string from the main thread to the strudel playback thread.
+    //! The command is dispatched to the cmd_fn passed to strudel_init.
     if (g_cmd_channel != null) {
         var sc = new StrudelCommand(shutdown = false)
         unsafe {
@@ -323,6 +348,7 @@ def public strudel_command(cmd : string) {
 }
 
 def public strudel_noop_cmd(cmd : string) {
+    //! No-op command handler — default argument when no user command dispatcher is needed.
     pass
 }
 
@@ -350,8 +376,8 @@ def private strudel_process_commands(cmd_fn : function<(cmd : string) : void>) :
 
 // --- Main-thread mode ---
 
-// Create a PCM stream for main-thread playback. Call after audio_system_create().
 def public strudel_create_channel() {
+    //! Create the PCM stream for main-thread playback. Call once after audio_system_create() and before strudel_tick.
     if (g_sid == 0ul) {
         g_sid = play_sound_from_pcm_stream(MA_SAMPLE_RATE, MA_CHANNELS)
         g_tick_status_box = unsafe(lock_box_create())
@@ -367,9 +393,9 @@ def public strudel_create_channel() {
     }
 }
 
-// Single tick: queries all tracks, renders audio, mixes, appends to PCM stream.
-// Call from your render loop. Self-regulating: skips when audio buffer has enough data.
 def public strudel_tick() {
+    //! Single main-thread tick: query all tracks, render audio, mix, append to the PCM stream.
+    //! Call from your render loop; self-regulating — skips when the audio buffer has enough data queued.
     if (g_sid == 0ul) {
         return
     }
@@ -471,10 +497,9 @@ def public strudel_tick() {
     }
 }
 
-// Offline tick: same as strudel_tick but without audio driver.
-// Does not require audio system or PCM channel — renders into g_master_pcm,
-// advances g_wall_time. Call in a tight loop for offline WAV rendering.
 def public strudel_tick_offline() {
+    //! Offline tick: same as strudel_tick but without an audio driver.
+    //! Renders into g_master_pcm and advances g_wall_time; call in a tight loop for offline WAV rendering.
     let t0 = ref_time_ticks()
     let CHUNK_SEC = g_chunk_seconds
     let chunkSamples = int(float(CHUNK_SEC) * float(SAMPLE_RATE)) * 2
@@ -557,8 +582,9 @@ def public strudel_tick_offline() {
 
 // --- Threaded mode ---
 
-// Blocking multi-track tick loop. Call from your strudel_main on the thread.
 def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noop_cmd) {
+    //! Blocking multi-track tick loop for threaded playback.
+    //! Runs on the strudel thread (spawned by strudel_init); dispatches incoming user commands via cmd_fn until shutdown.
     let CHUNK_SEC = g_chunk_seconds
     let TARGET_CHUNKS = 4
     let LOW_WATERMARK = 2
@@ -690,9 +716,9 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
     unsafe(lock_box_remove(status_box))
 }
 
-// Spawn strudel thread. Captures bank/sf2 pointers from main thread.
-// fn runs on the thread — add tracks and call strudel_play() there.
 def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : string) : void> = @@strudel_noop_cmd) {
+    //! Spawn the strudel playback thread and inject shared resources (sample bank, SF2, audio channel).
+    //! fn runs on the new thread — it should add tracks and call strudel_play(). Call from main thread only.
     if (get_audio_command_channel() == null) {
         panic("strudel_init: audio system not initialized. Call audio_system_create() first.")
     }
@@ -744,6 +770,8 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
 }
 
 def public strudel_shutdown() {
+    //! Shut down playback: signal the strudel thread to stop, release channels/lockboxes, free all tracks.
+    //! Safe to call from the main thread; also finalizes memory/utilization stats.
     if (g_cmd_channel != null) {
         g_cmd_channel |> push(new StrudelCommand(shutdown = true))
         var got_done = false
@@ -969,6 +997,7 @@ def private serialize_sf2(var arch : Archive; var sf2 : SF2File?&) {
 }
 
 def public strudel_save_sf2_state() : array<uint8> {
+    //! Serialize the currently loaded SoundFont to a byte array (empty if none loaded).
     if (g_sf2 == null) {
         var empty : array<uint8>
         return <- empty
@@ -982,6 +1011,7 @@ def public strudel_save_sf2_state() : array<uint8> {
 }
 
 def public strudel_restore_sf2_state(data : array<uint8>) {
+    //! Restore a previously serialized SoundFont from a byte array (no-op on empty data).
     if (length(data) == 0) {
         return
     }
@@ -992,6 +1022,7 @@ def public strudel_restore_sf2_state(data : array<uint8>) {
 }
 
 def public strudel_save_state() : array<uint8> {
+    //! Serialize playback state (wall time, CPS, sample bank) into a byte array; shuts down playback first.
     if (g_sid == 0ul) {
         var empty : array<uint8>
         return <- empty
@@ -1009,6 +1040,7 @@ def public strudel_save_state() : array<uint8> {
 }
 
 def public strudel_restore_state(data : array<uint8>) {
+    //! Restore previously saved playback state (wall time, CPS, sample bank) from a byte array.
     if (length(data) == 0) {
         return
     }

--- a/modules/dasAudio/strudel/strudel_samples.das
+++ b/modules/dasAudio/strudel/strudel_samples.das
@@ -1,7 +1,10 @@
 options gen2
 options indenting = 4
 
-module strudel_samples shared
+module strudel_samples shared public
+//! Sample bank and audio file loading for the strudel pattern engine.
+//! Decodes WAV/MP3/FLAC/OGG via miniaudio (from disk or memory), organises
+//! them into named banks with indexed variations, and resamples playback.
 
 require audio/audio_boost
 require audio
@@ -9,22 +12,26 @@ require daslib/fio
 require daslib/strings_boost
 require math
 
-// A sample: interleaved float data + channel count.
+//! A decoded PCM audio sample.
 [safe_when_uninitialized]
 struct Sample {
     data        : array<float>   // interleaved PCM
+        //! Interleaved PCM float samples (left, right, left, right, ...).
     channels    : int = 1
+        //! Channel count (1 = mono, 2 = stereo).
     sample_rate : int = 48000
+        //! Native sample rate of the decoded audio in Hz.
 }
 
-// A sample bank: sound name → array of variations.
+//! A named bank of samples, each mapped to an array of variations.
 struct SampleBank {
     sounds : table<string; array<Sample>>
+        //! Map from lowercase sound name to its indexed variations (bd:0, bd:1, ...).
 }
 
-// Load a single audio file via miniaudio decoder.
-// Keeps native channel count (mono or stereo).
 def load_audio_file(path : string) : Sample {
+    //! Decode a single audio file (WAV/MP3/FLAC/OGG) from disk into a Sample.
+    //! Keeps the native channel count (mono or stereo); returns an empty Sample on failure.
     var result : Sample
     var decoder = new ma_decoder
     var config <- ma_decoder_config_init(ma_format.ma_format_f32, 0u, 0u)
@@ -50,14 +57,14 @@ def load_audio_file(path : string) : Sample {
 }
 
 // Check if a filename looks like an audio file.
-def is_audio_file(name : string) : bool {
+def private is_audio_file(name : string) : bool {
     let lower = to_lower(name)
     return ends_with(lower, ".wav") || ends_with(lower, ".mp3") || ends_with(lower, ".flac") || ends_with(lower, ".ogg")
 }
 
-// Load a single sound from a directory of audio files.
-// Files are sorted alphabetically to match strudel sample indexing.
 def load_sound(path : string; name : string; var bank : SampleBank) {
+    //! Load a single named sound from a directory of audio files into the bank.
+    //! Files are sorted alphabetically so index :0, :1, ... matches strudel's sample indexing.
     var files : array<string>
     dir(path) $(file) {
         if (file == "." || file == "..") {
@@ -84,7 +91,7 @@ def load_sound(path : string; name : string; var bank : SampleBank) {
 }
 
 // Load a Dirt-Samples style directory structure.
-def load_sample_dir(root : string; var bank : SampleBank) {
+def private load_sample_dir(root : string; var bank : SampleBank) {
     dir(root) $(entry) {
         if (entry == "." || entry == "..") {
             return
@@ -109,9 +116,9 @@ def load_sample_dir(root : string; var bank : SampleBank) {
     }
 }
 
-// Load audio from in-memory bytes (WAV, MP3, FLAC, OGG).
-// Uses miniaudio's memory decoder. Returns empty Sample on failure.
 def load_audio_memory(data : array<uint8>) : Sample {
+    //! Decode audio bytes (WAV/MP3/FLAC/OGG) from memory into a Sample.
+    //! Uses miniaudio's memory decoder with explicit error checking; returns an empty Sample on failure.
     var result : Sample
     if (length(data) == 0) {
         return <- result
@@ -137,8 +144,8 @@ def load_audio_memory(data : array<uint8>) : Sample {
     return <- result
 }
 
-// Load a sound from in-memory bytes into a sample bank.
 def load_sound_memory(data : array<uint8>; name : string; var bank : SampleBank) {
+    //! Decode audio bytes and add the result as a single-variation sound in the bank.
     var sample <- load_audio_memory(data)
     if (length(sample.data) > 0) {
         let soundName = to_lower(name)
@@ -148,11 +155,11 @@ def load_sound_memory(data : array<uint8>; name : string; var bank : SampleBank)
     }
 }
 
-// Render a sample with speed control via miniaudio resampler + channel converter.
-// begin/end_pos are normalized slice bounds (0.0–1.0) — striate, chop, loop_at use these.
-// Returns interleaved stereo, no gain/pan applied.
 def render_sample(bank : SampleBank; name : string; variation : int; speed : float;
                   begin : float = 0.0; end_pos : float = 1.0) : array<float> {
+    //! Render a sample slice at the given playback speed as interleaved stereo.
+    //! begin/end_pos are normalized [0.0..1.0] slice bounds used by striate/chop/loop_at;
+    //! speed resamples via miniaudio and mono input is upmixed to stereo. No gain/pan applied.
     var stereo : array<float>
     bank.sounds |> get(name) $(variations) {
         if (length(variations) == 0) {

--- a/modules/dasAudio/strudel/strudel_scales.das
+++ b/modules/dasAudio/strudel/strudel_scales.das
@@ -1,7 +1,10 @@
 options gen2
 options indenting = 4
 
-module strudel_scales shared
+module strudel_scales shared public
+//! Music-theory helpers: scale interval tables (major, minor, modes, pentatonic, blues, ...)
+//! and the `set_scale` combinator that reinterprets `event.note` as a scale degree.
+//! Scale definitions use the `Root:Type` string syntax, e.g. `"C4:major"` or `"D:pentatonic"`.
 
 require strudel/strudel_event
 require strudel/strudel_time
@@ -125,6 +128,9 @@ def private parse_scale_def(scale_def : string) : tuple<int; string> {
 // Wraps at octave boundaries: degree 7 in major = root + 12.
 // Handles negative degrees (wraps backwards).
 def degree_to_note(degree : int; root_midi : int; intervals : array<int> const) : float {
+    //! Convert a scale degree to a MIDI note number. Degree 0 = root, 1 = second, etc.;
+    //! wraps at octave boundaries so degree 7 in a major scale = root + 12. Negative
+    //! degrees wrap backwards: degree -1 in a 7-note scale is the 7th one octave down.
     let n = length(intervals)
     if (n == 0) {
         return float(root_midi)
@@ -147,6 +153,9 @@ def degree_to_note(degree : int; root_midi : int; intervals : array<int> const) 
 // pat |> set_scale("C4:major") — degree 0→60, 1→62, 2→64, 3→65, 4→67...
 
 def set_scale(var pat : Pattern; scale_def : string) : Pattern {
+    //! Treat each event's `note` field as a scale degree and map it to a MIDI note
+    //! using `scale_def` (format `"Root:Type"`, e.g. `"C4:major"`, `"D:pentatonic"`).
+    //! Example: `n("0 2 4 7") |> set_scale("C4:major")` plays C, E, G, C (one octave up).
     let parsed = parse_scale_def(scale_def)
     let root_midi = parsed._0
     let scale_type = parsed._1
@@ -161,22 +170,29 @@ def set_scale(var pat : Pattern; scale_def : string) : Pattern {
 
 // ─── Convenience Constructors ───
 
-// scale_pattern("0 2 4 7", "C4:pentatonic") — shorthand for n() |> set_scale() |> set_sound()
 def scale_pattern(notation : string; scale_def : string; sound : string = "sine") : Pattern {
+    //! Shorthand for `n(notation) |> set_scale(scale_def) |> set_sound(sound)`.
+    //! Example: `scale_pattern("0 2 4 7", "C4:pentatonic")` plays a pentatonic arpeggio.
     return <- n(notation) |> set_scale(scale_def) |> set_sound(sound)
 }
 
 // ─── Query Helpers (for tests) ───
 
 def get_scale_intervals_by_name(scale_type : string) : array<int> {
+    //! Return the semitone-interval table for a named scale (`"major"`, `"minor"`,
+    //! `"dorian"`, `"pentatonic"`, `"blues"`, `"chromatic"`, ...). Used by tests.
     return <- get_scale_intervals(scale_type)
 }
 
 def parse_root(root_str : string) : int {
+    //! Parse a root-note string (`"C"`, `"Eb4"`, `"Fs3"`, ...) into a MIDI note number.
+    //! Default octave is 3. Exposed for tests.
     return parse_scale_root(root_str)
 }
 
 // ─── Alias ───
 
-// scale("C4:major") — alias for set_scale
-def scale(var pat : Pattern; scale_def : string) : Pattern { return <- set_scale(pat, scale_def); }
+def scale(var pat : Pattern; scale_def : string) : Pattern {
+    //! Alias for `set_scale`. Example: `n("0 2 4") |> scale("C4:major")`.
+    return <- set_scale(pat, scale_def);
+}

--- a/modules/dasAudio/strudel/strudel_scheduler.das
+++ b/modules/dasAudio/strudel/strudel_scheduler.das
@@ -1,7 +1,10 @@
 options gen2
 options indenting = 4
 
-module strudel_scheduler shared
+module strudel_scheduler shared public
+//! Voice allocation, effect bus routing, and per-tick mixing for strudel playback.
+//! Maintains pre-rendered sample voices, streaming oscillator voices, and real-time SF2 voices,
+//! routing each through per-orbit reverb/delay buses plus a shared chorus bus.
 
 require strudel/strudel_event
 require strudel/strudel_time
@@ -14,80 +17,126 @@ require audio/audio_boost
 require audio
 require math
 
-// An active voice: a pre-rendered stereo buffer being played back.
+//! An active voice: a pre-rendered stereo buffer being played back.
 struct Voice {
     samples : array<float>   // interleaved stereo PCM (raw, no gain/pan)
+        //! Interleaved stereo PCM buffer (raw, without gain/pan applied).
     position : int = 0       // current read position (in floats, not frames)
+        //! Current read position in floats (not frames); negative values delay playback start.
     cut : int = 0            // cut group (0 = no cut)
+        //! Cut group — new voices in the same group kill older ones (0 = no cut).
     gain : float = 0.8       // volume for this voice
+        //! Linear gain applied during mixing.
     pan : float = 0.0        // pan for this voice (-1=left, 0=center, 1=right)
+        //! Stereo pan (-1 = left, 0 = center, 1 = right).
     reverb_send : float = 0.0  // reverb send amount from Event.room (0.0–1.0)
+        //! Reverb send amount (0.0–1.0) from Event.room.
     chorus_send : float = 0.0  // chorus send amount from Event.chorus (0.0–1.0)
+        //! Chorus send amount (0.0–1.0) from Event.chorus.
     delay_send : float = 0.0   // delay send amount from Event.delay_amount (0.0–1.0)
+        //! Delay send amount (0.0–1.0) from Event.delay_amount.
     orbit : int = 0            // effect bus routing
+        //! Orbit index — selects which per-orbit effect bus receives this voice's sends.
 }
 
-// Per-voice metadata for SF2 voices (not stored in the C ma_sf2_voice struct).
+//! Per-voice metadata for SF2 voices (companion to the C ma_sf2_voice struct).
 [safe_when_uninitialized]
 struct StrudelSF2Meta {
     note             : int = 0       // MIDI note (for re-trigger matching)
+        //! MIDI note number (used for re-trigger matching).
     note_off_sample  : int = -1      // sample position to fire note-off (-1 = don't auto note-off)
+        //! Sample index at which to fire note-off (-1 = never auto note-off).
     samples_elapsed  : int = 0       // how many samples rendered so far
+        //! Total samples rendered for this voice so far.
     reverb_send      : float = 0.0   // per-voice reverb amount from SF2 generators
+        //! Per-voice reverb send (from SF2 generators).
     chorus_send      : float = 0.0   // per-voice chorus amount from SF2 generators
+        //! Per-voice chorus send (from SF2 generators).
     delay_send       : float = 0.0   // per-voice delay amount from Event.delay_amount
+        //! Per-voice delay send (from Event.delay_amount).
     exclusive_class  : int = 0       // SF2 exclusive class (hi-hat choke etc.)
+        //! SF2 exclusive class — voices in the same non-zero class choke each other (e.g. hi-hats).
     cut              : int = 0       // strudel cut group
+        //! Strudel cut group (0 = no cut).
     gain             : float = 1.0   // event gain * velocity (applied as attenuation scale)
+        //! Event gain × velocity, applied as an attenuation scale factor.
     orbit            : int = 0       // effect bus routing
+        //! Orbit index — selects which per-orbit effect bus receives this voice's sends.
     @safe_when_uninitialized fx : VoiceFX  // per-voice audio effects
+        //! Per-voice audio effects (crush/shape/filter/etc.), applied post-render.
     pan              : float = 0.0   // stereo pan (-1..1) used when fx routes through temp buffer
+        //! Stereo pan (-1..1), used when FX routing goes through a temp buffer.
 }
 
-// Per-orbit effect bus. Each orbit has independent reverb + delay instances.
-// Orbits are created on demand when a voice with that orbit index is spawned.
+//! Per-orbit effect bus. Each orbit has independent reverb + delay instances.
+//! Orbits are created on demand when a voice with that orbit index is spawned.
 [safe_when_uninitialized]
 struct OrbitBus {
     reverb            : ConvolutionReverb?
+        //! Convolution reverb instance (null until a voice requests reverb).
     delay_proc        : ma_delay?
+        //! Stereo delay instance (null until a voice requests delay).
     reverb_send_buf   : array<float>
+        //! Scratch buffer accumulating reverb sends from all voices routed to this orbit.
     reverb_out_buf    : array<float>
+        //! Scratch buffer receiving the reverb's wet output for mixing into the master.
     delay_send_buf    : array<float>
+        //! Scratch buffer accumulating delay sends from all voices routed to this orbit.
     delay_out_buf     : array<float>
+        //! Scratch buffer receiving the delay's wet output for mixing into the master.
     current_roomsize      : float = -1.0
+        //! Most recently applied reverb roomsize (-1 = uninitialized).
     current_delaytime     : float = -1.0
+        //! Most recently applied delay time in seconds (-1 = uninitialized).
     current_delayfeedback : float = -1.0
+        //! Most recently applied delay feedback amount (-1 = uninitialized).
 }
 
-// The scheduler bridges the pattern engine and audio output.
-// Maintains two pools: pre-rendered sample voices and real-time SF2 voices.
-// Effects are routed through per-orbit buses (each orbit has its own reverb + delay).
+//! Bridges the pattern engine and audio output.
+//! Maintains three voice pools (pre-rendered samples, streaming oscillators, real-time SF2)
+//! and routes each voice's sends through per-orbit effect buses plus a shared chorus.
 [safe_when_uninitialized]
 struct Scheduler {
     cps          : double = 0.5lf   // cycles per second (0.5 = 120 BPM at 4 beats/cycle)
+        //! Cycles per second (0.5 = 120 BPM at 4 beats per cycle).
     startTime    : double = 0.0lf   // wall-clock time when playback started
+        //! Wall-clock time when playback started (seconds).
     lastQueryEnd : double = 0.0lf   // cycle position of last query end
+        //! Cycle position of the last pattern-query end, used to avoid duplicate spawning.
     voices       : array<Voice?>    // pre-rendered sample/oscillator voices
+        //! Pool of pre-rendered sample voices.
     osc_voices   : array<OscVoice> // streaming oscillator voices
+        //! Pool of streaming oscillator voices.
     mixer        : ma_volume_mixer  // reused across ticks
+        //! Miniaudio volume mixer, reused across ticks for gain/pan application.
     mixer_ready  : bool = false
+        //! True once the mixer has been initialized.
     output       : array<float>    // reusable output buffer (avoids per-tick allocation)
+        //! Reusable stereo output buffer for the current tick.
     // SF2 real-time voice pool
     sf2           : SF2File const?        // loaded soundfont (null = SF2 disabled)
+        //! Loaded SoundFont (null = SF2 disabled for this scheduler).
     sf2_voices    : array<ma_sf2_voice>   // real-time SF2 voices (C structs)
+        //! Pool of real-time SF2 voices (C structs).
     sf2_meta      : array<StrudelSF2Meta> // parallel metadata
+        //! Parallel metadata array for each SF2 voice.
     // Per-orbit effect buses (created on demand)
     orbit_buses   : array<OrbitBus?>
+        //! Per-orbit effect buses, indexed by orbit number and allocated on demand.
     // Chorus (SF2-only, not orbit-routed)
     chorus          : ma_chorus?
+        //! Shared chorus unit (null until any voice requests chorus).
     chorus_send_buf : array<float>
+        //! Chorus send accumulation buffer shared across orbits.
     chorus_out_buf  : array<float>
+        //! Chorus wet-output buffer mixed into the master.
     // Shared scratch buffer for per-voice FX processing (sized per-tick)
     voice_fx_buf    : array<float>
+        //! Scratch buffer for per-voice FX processing, sized on demand each tick.
 }
 
 // Convert wall-clock time to cycle position.
-def current_cycle(sched : Scheduler; wall_time : double) : double {
+def private current_cycle(sched : Scheduler; wall_time : double) : double {
     return (wall_time - sched.startTime) * sched.cps
 }
 
@@ -149,14 +198,14 @@ def private update_orbit_delay_params(var bus : OrbitBus; delaytime, delayfeedba
     delay_set_params(bus.delay_proc, SAMPLE_RATE, dt, fb)
 }
 
-// Initialize reverb on the scheduler's default orbit (backwards compat).
 def init_reverb(var sched : Scheduler) {
+    //! Initialize reverb on the scheduler's default orbit (bus 0). Convenience wrapper used by older API.
     ensure_orbit(sched, 0)
     init_orbit_reverb(*sched.orbit_buses[0])
 }
 
-// Initialize chorus on the scheduler (not orbit-routed).
 def init_chorus(var sched : Scheduler) {
+    //! Initialize the scheduler's shared chorus unit with default parameters (no-op if already initialized).
     if (sched.chorus == null) {
         sched.chorus = new ma_chorus
         chorus_init(sched.chorus, float(SAMPLE_RATE))
@@ -165,8 +214,8 @@ def init_chorus(var sched : Scheduler) {
     }
 }
 
-// Initialize delay on the scheduler's default orbit (backwards compat).
 def init_delay(var sched : Scheduler; delaytime : float = 0.5; delayfeedback : float = 0.5) {
+    //! Initialize delay on the scheduler's default orbit (bus 0) with the given time/feedback.
     ensure_orbit(sched, 0)
     init_orbit_delay(*sched.orbit_buses[0], delaytime, delayfeedback)
 }
@@ -614,12 +663,9 @@ def private process_chorus(var sched : Scheduler; var output : array<float>; chu
     }
 }
 
-// Tick the scheduler: query pattern for new events, render them,
-// mix all active voices into a fixed-size stereo buffer.
-//
-// chunk_seconds: how much audio to produce this tick (e.g. 0.05 for 50ms)
-// lookAhead: how far ahead in time to query for new events (in seconds)
 def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time : double; chunk_seconds : float = 0.05; lookAhead : float = 0.1) : void {
+    //! Advance one audio block: query the pattern for new events, spawn voices, mix all voices through the orbit/chorus buses into sched.output.
+    //! chunk_seconds controls how much audio is produced this tick; lookAhead is how far ahead in time to query for new events.
     let cycleNow = current_cycle(sched, wall_time)
     let cycleEnd = current_cycle(sched, wall_time + double(lookAhead))
     let spawnEnd = current_cycle(sched, wall_time + double(chunk_seconds) + 0.01lf)
@@ -824,8 +870,8 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
     // output stays in sched.output — caller reads it directly
 }
 
-// Accessors for orbit bus effects (for tests and backwards compat).
 def get_orbit_reverb(var sched : Scheduler; orbit : int = 0) : ConvolutionReverb? {
+    //! Fetch the reverb instance for the given orbit (for inspection or tests). Returns null if no bus or no reverb configured.
     if (orbit < length(sched.orbit_buses) && sched.orbit_buses[orbit] != null) {
         return sched.orbit_buses[orbit].reverb
     }
@@ -833,14 +879,15 @@ def get_orbit_reverb(var sched : Scheduler; orbit : int = 0) : ConvolutionReverb
 }
 
 def get_orbit_delay(var sched : Scheduler; orbit : int = 0) : ma_delay? {
+    //! Fetch the delay instance for the given orbit (for inspection or tests). Returns null if no bus or no delay configured.
     if (orbit < length(sched.orbit_buses) && sched.orbit_buses[orbit] != null) {
         return sched.orbit_buses[orbit].delay_proc
     }
     return null
 }
 
-// Release native resources owned by the scheduler.
 def shutdown_scheduler(var sched : Scheduler) {
+    //! Release native resources owned by the scheduler (reverb/delay/chorus instances on every orbit bus).
     for (bus in sched.orbit_buses) {
         if (bus != null) {
             if (bus.delay_proc != null) {
@@ -859,11 +906,11 @@ def shutdown_scheduler(var sched : Scheduler) {
 }
 
 // Set tempo in BPM (assumes 4 beats per cycle).
-def set_bpm(var sched : Scheduler; bpm : double) {
+def private set_bpm(var sched : Scheduler; bpm : double) {
     sched.cps = bpm / 240.0lf
 }
 
 // Set cycles per second directly.
-def setcps(var sched : Scheduler; cps : double) {
+def private setcps(var sched : Scheduler; cps : double) {
     sched.cps = cps
 }

--- a/modules/dasAudio/strudel/strudel_sf2.das
+++ b/modules/dasAudio/strudel/strudel_sf2.das
@@ -71,9 +71,13 @@ enum SF2GenOper {
 
 // ─── SF2 Sample Types ───
 
+//! Mono sample — produces a single channel.
 let public SF2_SAMPLE_MONO   = 1u
+//! Right channel of a stereo pair (linked to a left sample).
 let public SF2_SAMPLE_RIGHT  = 2u
+//! Left channel of a stereo pair (linked to a right sample).
 let public SF2_SAMPLE_LEFT   = 4u
+//! Linked sample flag — indicates a multi-sample link set.
 let public SF2_SAMPLE_LINKED = 8u
 
 // ─── SF2 Data Structures ───
@@ -294,19 +298,19 @@ def private parse_sample_headers(data : array<uint8>; offset, size : int) : arra
     return <- result
 }
 
-struct RawPresetHeader {
+struct private RawPresetHeader {
     name : string
     preset : int
     bank : int
     pbag_index : int
 }
 
-struct RawInstrumentHeader {
+struct private RawInstrumentHeader {
     name : string
     ibag_index : int
 }
 
-struct RawBag {
+struct private RawBag {
     gen_index : int
     mod_index : int
 }

--- a/modules/dasAudio/strudel/strudel_sf2_voice.das
+++ b/modules/dasAudio/strudel/strudel_sf2_voice.das
@@ -4,16 +4,19 @@ options no_unused_block_arguments = false
 options no_unused_function_arguments = false
 
 module strudel_sf2_voice shared public
+//! Per-voice SF2 synthesis: envelopes, LFOs, biquad filter, and modulator matrix.
+//! Resolves SF2 generators across preset/instrument/global zone layers, evaluates
+//! SF2.01 default and zone modulators, and populates the C `ma_sf2_voice` runtime state.
 
 require strudel/strudel_sf2
 require audio
 require math
 
-let SF2_SAMPLE_RATE = 48000.0
+let private SF2_SAMPLE_RATE = 48000.0
 
-// SF2 default velocity→attenuation curve (concave, 960 cB range)
-// See SF2 spec section 8.4.2 — default modulator #1
 def public sf2_velocity_attenuation(velocity : int) : float {
+    //! SF2 default velocity-to-attenuation curve (concave, 960 cB range).
+    //! Implements default modulator #1 from SF2 spec section 8.4.2; returns a linear gain.
     if (velocity <= 0) {
         return 0.0
     }
@@ -123,8 +126,9 @@ def private sf2_mod_transform_source(src : int; val, src_range : float) : float 
     return v
 }
 
-// Evaluate a single SF2 modulator: amount * transform(src1) * transform(src2)
 def public sf2_mod_get_value(m : SF2Modulator; velocity, key : int; cc_values : int[128]) : float {
+    //! Evaluate a single SF2 modulator: amount * transform(src1) * transform(src2).
+    //! Applies the optional absolute-value transform when `m.transform == 2`.
     let s1 = sf2_mod_source_value(m.src_oper, velocity, key, cc_values)
     let v1 = sf2_mod_transform_source(m.src_oper, s1._0, s1._1)
     let s2 = sf2_mod_source_value(m.amt_src_oper, velocity, key, cc_values)
@@ -136,9 +140,8 @@ def public sf2_mod_get_value(m : SF2Modulator; velocity, key : int; cc_values : 
     return result
 }
 
-// Apply all modulators from a zone to a generator accumulator.
-// gen_offsets[oper] += sum of modulator outputs targeting that generator.
 def public sf2_apply_modulators(zone : SF2Zone; velocity, key : int; cc_values : int[128]; var gen_offsets : float[64]) {
+    //! Accumulate all modulator outputs from a zone into `gen_offsets` indexed by destination generator.
     for (m in zone.modulators) {
         let val = sf2_mod_get_value(m, velocity, key, cc_values)
         if (m.dest_oper >= 0 && m.dest_oper < 64) {
@@ -149,8 +152,9 @@ def public sf2_apply_modulators(zone : SF2Zone; velocity, key : int; cc_values :
 
 // ─── SF2 Default Modulators (spec 8.4.1-8.4.10) ───
 
-// Two modulators match identity if they have the same src1, src2, and destination.
 def public sf2_mod_identity_match(a, b : SF2Modulator) : bool {
+    //! Two SF2 modulators share identity when src1, src2, and destination all match.
+    //! Used to detect when a zone modulator overrides a default modulator.
     return a.src_oper == b.src_oper && a.amt_src_oper == b.amt_src_oper && a.dest_oper == b.dest_oper
 }
 
@@ -191,11 +195,11 @@ let private SF2_DEFAULT_MODS = fixed_array(
     SF2Modulator(src_oper = int(0x020E), amt_src_oper = int(0x0010), dest_oper = int(SF2GenOper.fineTune), amount = 12700, transform = 0)
 )
 
-// Apply default modulators that are not overridden by any zone modulator.
-// Call this AFTER applying zone modulators to gen_offsets.
 def public sf2_apply_default_modulators(izone : SF2Zone; global_izone : SF2Zone const?;
                                         pzone : SF2Zone const?; global_pzone : SF2Zone const?;
                                         velocity, key : int; cc_values : int[128]; var gen_offsets : float[64]) {
+    //! Apply the 10 SF2 spec default modulators (8.4.1-8.4.10) that are not overridden by any zone modulator.
+    //! Must be called AFTER zone modulators have already been accumulated into `gen_offsets`.
     for (dm in SF2_DEFAULT_MODS) {
         if (dm.amount == 0) {
             continue  // disabled default (#2 vel→filter)
@@ -222,32 +226,55 @@ def public sf2_apply_default_modulators(izone : SF2Zone; global_izone : SF2Zone 
 
 // ─── Envelope ───
 
+//! SF2 six-stage DAHDSR envelope stage enumeration.
 enum SF2EnvStage {
     env_delay
+        //! Silent delay before the envelope starts.
     env_attack
+        //! Rising ramp from 0.0 to 1.0.
     env_hold
+        //! Hold at peak level before decay begins.
     env_decay
+        //! Falling ramp from peak toward sustain level.
     env_sustain
+        //! Held at sustain level until note-off.
     env_release
+        //! Falling ramp from current level toward zero after note-off.
     env_finished
+        //! Envelope has fully decayed and voice can be freed.
 }
 
+//! SF2 volume or modulation envelope state (DAHDSR).
 struct SF2Envelope {
     stage : SF2EnvStage = SF2EnvStage.env_delay
+        //! Current envelope stage.
     time_in_stage : float = 0.0
+        //! Countdown samples remaining in the current stage (delay/hold).
     level : float = 0.0
+        //! Current envelope output level [0..1].
     release_level : float = 1.0     // captured at note-off
+        //! Level captured at note-off; release ramps down from here.
     slope : float = 0.0             // per-sample slope (linear or exponential base)
+        //! Per-sample slope (linear delta or exponential multiplier depending on stage).
     is_exponential : bool = false   // current segment uses exponential curve
+        //! True when the current segment uses an exponential curve instead of linear.
     is_amp_env : bool = false       // amplitude envelope uses exponential decay/release
+        //! True for the amplitude envelope (uses exponential decay/release and velocity-scaled attack).
     midi_velocity : int = 127       // for velocity-scaled attack
+        //! MIDI velocity used to scale the attack segment length on amplitude envelopes.
     // parameters (seconds)
     delay_sec : float = 0.0
+        //! Delay stage duration in seconds.
     attack_sec : float = 0.001
+        //! Attack stage duration in seconds.
     hold_sec : float = 0.0
+        //! Hold stage duration in seconds.
     decay_sec : float = 0.001
+        //! Decay stage duration in seconds.
     sustain_level : float = 1.0     // 0.0 to 1.0
+        //! Sustain level in [0..1] as a linear fraction (1.0 = peak, 0.0 = silence).
     release_sec : float = 0.001
+        //! Release stage duration in seconds.
 }
 
 // Initialize envelope for a specific stage transition
@@ -314,6 +341,7 @@ def private sf2_env_next_segment(var env : SF2Envelope&; sample_rate : float) {
 }
 
 def sf2_env_start(var env : SF2Envelope&; sample_rate : float) {
+    //! Begin playback of an SF2 envelope: enter the delay stage (or jump straight to attack if delay is zero).
     // start delay (or skip to attack if delay is 0)
     env.stage = SF2EnvStage.env_delay
     env.level = 0.0
@@ -328,6 +356,8 @@ def sf2_env_start(var env : SF2Envelope&; sample_rate : float) {
 }
 
 def sf2_env_tick(var env : SF2Envelope&; released : bool; sample_rate : float) : float {
+    //! Advance the envelope one sample and return the current level.
+    //! When `released` becomes true the envelope jumps into the release stage from its current level.
     if (released && env.stage != SF2EnvStage.env_release && env.stage != SF2EnvStage.env_finished) {
         // jump to release from current level
         env.release_level = env.level
@@ -392,14 +422,20 @@ def sf2_env_tick(var env : SF2Envelope&; released : bool; sample_rate : float) :
 
 // ─── LFO ───
 
+//! SF2 low-frequency oscillator state (triangle wave with an initial delay).
 struct SF2LFO {
     delay_sec : float = 0.0
+        //! Silent delay before the LFO begins oscillating, in seconds.
     freq : float = 8.176       // Hz
+        //! LFO frequency in Hz (SF2 default ~8.176 Hz = 0 cents from middle C).
     phase : float = 0.0
+        //! Current phase in [0..1].
     elapsed : float = 0.0
+        //! Elapsed time since note-on, used to test against `delay_sec`.
 }
 
 def sf2_lfo_tick(var lfo : SF2LFO&; dt : float) : float {
+    //! Advance the LFO by `dt` seconds and return the triangle-wave output in [-1..1] (zero during the delay).
     lfo.elapsed += dt
     if (lfo.elapsed < lfo.delay_sec) {
         return 0.0
@@ -415,7 +451,7 @@ def sf2_lfo_tick(var lfo : SF2LFO&; dt : float) : float {
 // ─── Biquad Low-Pass Filter ───
 
 // Transposed direct form II biquad low-pass filter
-struct SF2Biquad {
+struct private SF2Biquad {
     q_inv : double = 0.0lf
     a0 : double = 0.0lf
     a1 : double = 0.0lf
@@ -426,7 +462,7 @@ struct SF2Biquad {
     active : bool = false
 }
 
-def sf2_biquad_setup(var bq : SF2Biquad&; fc_normalized : float) {
+def private sf2_biquad_setup(var bq : SF2Biquad&; fc_normalized : float) {
     // fc_normalized = cutoff_hz / sample_rate (0 to 0.5)
     // QInv must be set before calling this
     if (fc_normalized >= 0.499) {
@@ -443,7 +479,7 @@ def sf2_biquad_setup(var bq : SF2Biquad&; fc_normalized : float) {
     bq.b2 = (1.0lf - K * bq.q_inv + KK) * norm
 }
 
-def sf2_biquad_tick(var bq : SF2Biquad&; input : float) : float {
+def private sf2_biquad_tick(var bq : SF2Biquad&; input : float) : float {
     if (!bq.active) {
         return input
     }
@@ -478,10 +514,9 @@ def private get_gen(izone : SF2Zone; global_izone : SF2Zone const?; pzone : SF2Z
     return val
 }
 
-// Initialize CC values to GM defaults. Used by MidiChannelState and standalone voice creation.
-// CC7=100 (GM volume), CC10=64 (pan center), CC11=127 (expression max),
-// CC[127]=8192 (pitch wheel center — stored in last CC slot as placeholder for SF2 modulators).
 def public sf2_default_cc_values(var cc : int[128]) {
+    //! Initialise a CC array to General MIDI defaults (CC7=100, CC10=64, CC11=127, pitchwheel slot=8192).
+    //! Used by MidiChannelState and standalone voice creation; slot 127 holds the pitch wheel value for SF2 modulator input.
     cc[7] = 100
     cc[10] = 64
     cc[11] = 127
@@ -490,20 +525,23 @@ def public sf2_default_cc_values(var cc : int[128]) {
 
 // ─── Per-voice attenuation state for CC re-evaluation ───
 
-// Stores everything needed to recalculate attenuation when CC values change.
-// All modulators targeting initialAttenuation are
-// stored per voice and re-evaluated when CC7/CC11/etc. change.
+//! Per-voice state for recomputing volume attenuation when MIDI CCs change.
+//! Caches every modulator that targets initialAttenuation so CC7/CC11/etc changes can be applied without re-resolving zones.
 struct SF2VoiceAttenState {
     base_atten_cb : int = 0           // generator initialAttenuation (centibels)
+        //! Generator initialAttenuation value in centibels, before modulators.
     velocity : int = 127
+        //! Note-on velocity captured at voice creation.
     key : int = 60
+        //! MIDI key number captured at voice creation.
     atten_mods : array<SF2Modulator>  // all modulators targeting initialAttenuation
+        //! All modulators (zone + unoverridden defaults) targeting initialAttenuation, collected once.
 }
 
-// Collect all modulators that target initialAttenuation from all zone layers,
-// plus defaults that aren't overridden. This is called once at voice creation.
 def public sf2_collect_atten_modulators(izone : SF2Zone; global_izone : SF2Zone const?;
                                         pzone : SF2Zone const?; global_pzone : SF2Zone const?) : array<SF2Modulator> {
+    //! Collect every modulator targeting initialAttenuation across all zone layers plus unoverridden defaults.
+    //! Called once at voice creation; results are cached in SF2VoiceAttenState for fast CC-driven re-evaluation.
     var result : array<SF2Modulator>
     let target = int(SF2GenOper.initialAttenuation)
     // zone modulators
@@ -555,9 +593,9 @@ def public sf2_collect_atten_modulators(izone : SF2Zone; global_izone : SF2Zone 
     return <- result
 }
 
-// Recalculate voice attenuation from stored modulators + current CC values.
-// Called at voice creation and whenever CC7/CC11 change.
 def public sf2_recalc_atten(atten_state : SF2VoiceAttenState; cc_values : int[128]) : float {
+    //! Recalculate voice attenuation (linear gain) from cached modulators and current CC values.
+    //! Called at voice creation and whenever CC7/CC11/etc change on the channel.
     var mod_sum = 0.0
     for (m in atten_state.atten_mods) {
         mod_sum += sf2_mod_get_value(m, atten_state.velocity, atten_state.key, cc_values)
@@ -577,6 +615,8 @@ def public sf2_create_c_voice(sf2 : SF2File; inst_idx, izone_idx : int;
                               cc_values : int[128];
                               var out_voice : ma_sf2_voice;
                               var out_atten_state : SF2VoiceAttenState) : bool {
+    //! Resolve all SF2 generators/modulators for a note and populate the C `ma_sf2_voice` runtime state.
+    //! Sets up sample addressing, pitch, envelopes, LFOs, filter, pan and attenuation; returns false if the sample is invalid.
     let inst = sf2.instruments[inst_idx]
     let izone = inst.zones[izone_idx]
     let global_izone = inst.global_zone
@@ -794,6 +834,8 @@ def public sf2_create_c_voice(sf2 : SF2File; inst_idx, izone_idx : int;
 
 def public sf2_get_exclusive_class(sf2 : SF2File; inst_idx, izone_idx : int;
                                    pzone : SF2Zone const?; global_pzone : SF2Zone const?) : int {
+    //! Resolve the exclusiveClass generator across all zone layers.
+    //! Non-zero classes cut off earlier notes in the same class (GM drum open/closed hi-hat behaviour).
     let inst = sf2.instruments[inst_idx]
     let izone = inst.zones[izone_idx]
     return get_gen(*izone, inst.global_zone, pzone, global_pzone, int(SF2GenOper.exclusiveClass), 0)
@@ -801,6 +843,7 @@ def public sf2_get_exclusive_class(sf2 : SF2File; inst_idx, izone_idx : int;
 
 def public sf2_get_reverb_send(sf2 : SF2File; inst_idx, izone_idx : int;
                                pzone : SF2Zone const?; global_pzone : SF2Zone const?) : float {
+    //! Resolve the reverb effects-send amount across zone layers, normalised to [0..1].
     let inst = sf2.instruments[inst_idx]
     let izone = inst.zones[izone_idx]
     let send = get_gen(*izone, inst.global_zone, pzone, global_pzone, int(SF2GenOper.reverbEffectsSend), 0)
@@ -809,6 +852,7 @@ def public sf2_get_reverb_send(sf2 : SF2File; inst_idx, izone_idx : int;
 
 def public sf2_get_chorus_send(sf2 : SF2File; inst_idx, izone_idx : int;
                                pzone : SF2Zone const?; global_pzone : SF2Zone const?) : float {
+    //! Resolve the chorus effects-send amount across zone layers, normalised to [0..1].
     let inst = sf2.instruments[inst_idx]
     let izone = inst.zones[izone_idx]
     let send = get_gen(*izone, inst.global_zone, pzone, global_pzone, int(SF2GenOper.chorusEffectsSend), 0)

--- a/modules/dasAudio/strudel/strudel_synth.das
+++ b/modules/dasAudio/strudel/strudel_synth.das
@@ -1,7 +1,10 @@
 options gen2
 options indenting = 4
 
-module strudel_synth shared
+module strudel_synth shared public
+//! Audio synthesis and effects for the strudel pattern engine.
+//! Houses oscillators (sine/saw/square/triangle/supersaw), drum voices (bd/sd/hh/tom/ride/...),
+//! biquad/formant filters, the per-voice FX chain and the top-level `render_event_stereo` entry point.
 
 require strudel/strudel_event
 require strudel/strudel_samples
@@ -12,14 +15,13 @@ let SAMPLE_RATE = 48000
 let TWO_PI = 3.14159265358979323846 * 2.0
 let OSC_TURN_DOWN = 0.3  // oscillator turn-down — only oscillators, not samples/drums
 
-// Convert MIDI note number to frequency in Hz.
-// 60 = middle C = 261.63 Hz
 def note_to_freq(note : float) : float {
+    //! Convert a MIDI note number to frequency in Hz (A4 = 69 = 440 Hz, middle C = 60).
     return 440.0 * pow(2.0, (note - 69.0) / 12.0)
 }
 
-// Simple pseudo-random noise from a seed. Returns -1.0 to 1.0.
 def noise(var seed : uint&) : float {
+    //! Linear congruential pseudo-random noise in [-1.0, 1.0]. Advances the seed in place.
     seed = seed * 1664525u + 1013904223u
     return float(seed >> 9u & 0x7FFFFFu) / float(0x3FFFFFu) - 1.0
 }
@@ -28,7 +30,7 @@ def noise(var seed : uint&) : float {
 // of a naive sawtooth or square to eliminate aliases above Nyquist.
 // Ref: https://www.kvraudio.com/forum/viewtopic.php?t=375517
 // t = phase [0,1), dt = freq / sample_rate.
-def poly_blep(t, dt : float) : float {
+def private poly_blep(t, dt : float) : float {
     var dt2 = dt
     if (dt2 > 0.5) { dt2 = 0.5; }
     if (dt2 < 0.0001) { return 0.0; }
@@ -43,7 +45,7 @@ def poly_blep(t, dt : float) : float {
 }
 
 // ADSR envelope. Returns amplitude 0.0–1.0 for a given time position.
-def adsr(t, attack, decay, sustain, release, duration : float) : float {
+def private adsr(t, attack, decay, sustain, release, duration : float) : float {
     if (t < 0.0) {
         return 0.0
     }
@@ -70,7 +72,7 @@ def adsr(t, attack, decay, sustain, release, duration : float) : float {
 
 // Apply convolution reverb to a mono buffer. amount=0.0 is dry, 1.0 is full wet.
 // Uses a synthetic impulse response (noise with exponential decay + lowpass sweep).
-def apply_room(var samples : array<float>; amount : float = 0.3, decay_sec : float = 0.4) {
+def private apply_room(var samples : array<float>; amount : float = 0.3, decay_sec : float = 0.4) {
     if (amount <= 0.0) {
         return
     }
@@ -95,7 +97,7 @@ def apply_room(var samples : array<float>; amount : float = 0.3, decay_sec : flo
 }
 
 // Add a single slapback echo at a given delay (in seconds) with given gain.
-def apply_slapback(var samples : array<float>; delay_sec : float = 0.035; echo_gain : float = 0.4) {
+def private apply_slapback(var samples : array<float>; delay_sec : float = 0.035; echo_gain : float = 0.4) {
     let delay_samples = int(delay_sec * float(SAMPLE_RATE))
     let n = length(samples)
     for (i in range(delay_samples, n)) {
@@ -105,8 +107,9 @@ def apply_slapback(var samples : array<float>; delay_sec : float = 0.035; echo_g
 
 // ─── Drum Synthesis ───
 
-// Kick drum: 808-style — fast pitch sweep (~6ms), noise click transient, soft waveshaping
 def render_bd(duration : float; gain : float) : array<float> {
+    //! Render an 808-style kick drum as a mono buffer at SAMPLE_RATE.
+    //! Combines a pitched sine body with a fast pitch sweep, a bandpass beater click and a rimshot-like snap, then applies a short room.
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples : array<float>
     samples |> resize(nsamples)
@@ -140,8 +143,8 @@ def render_bd(duration : float; gain : float) : array<float> {
     return <- samples
 }
 
-// Snare: tonal body (~220Hz) + high-passed noise (snare wires) + room
 def render_sd(duration : float; gain : float) : array<float> {
+    //! Render a snare drum as a mono buffer: tonal body (~220/330 Hz) plus high-passed noise for the wires, with a short room tail.
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples : array<float>
     samples |> resize(nsamples)
@@ -172,8 +175,8 @@ def render_sd(duration : float; gain : float) : array<float> {
     return <- samples
 }
 
-// Hi-hat: metallic oscillator bank + tonal body + room
 def render_hh(duration : float; gain : float) : array<float> {
+    //! Render a closed hi-hat: metallic oscillator bank layered with a short tonal bell (~180 Hz), plus room.
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples <- render_metallic(duration, gain * 0.7, 18.0)
     // add tonal component (~200Hz) like SF2 — the "bell" of the hi-hat
@@ -190,8 +193,8 @@ def render_hh(duration : float; gain : float) : array<float> {
     return <- samples
 }
 
-// Clap: sharp noise burst through bandpass (~1.1kHz) + long room tail
 def render_cp(duration : float; gain : float) : array<float> {
+    //! Render a hand-clap: a sharp bandpassed noise burst (~1.1 kHz) with a metallic bright edge and a long room tail.
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples : array<float>
     samples |> resize(nsamples)
@@ -214,7 +217,7 @@ def render_cp(duration : float; gain : float) : array<float> {
 
 // ─── Biquad Filter ───
 
-struct BiquadState {
+struct private BiquadState {
     x1 : float = 0.0
     x2 : float = 0.0
     y1 : float = 0.0
@@ -226,7 +229,7 @@ struct BiquadState {
     b2 : float = 0.0
 }
 
-def biquad_highpass(var bq : BiquadState; freq, sample_rate : float) {
+def private biquad_highpass(var bq : BiquadState; freq, sample_rate : float) {
     let w0 = float(TWO_PI) * freq / sample_rate
     let cs = cos(w0)
     let sn = sin(w0)
@@ -239,7 +242,7 @@ def biquad_highpass(var bq : BiquadState; freq, sample_rate : float) {
     bq.b2 = (1.0 - alpha) * norm
 }
 
-def biquad_bandpass(var bq : BiquadState; freq, q, sample_rate : float) {
+def private biquad_bandpass(var bq : BiquadState; freq, q, sample_rate : float) {
     let w0 = float(TWO_PI) * freq / sample_rate
     let cs = cos(w0)
     let sn = sin(w0)
@@ -252,7 +255,7 @@ def biquad_bandpass(var bq : BiquadState; freq, q, sample_rate : float) {
     bq.b2 = (1.0 - alpha) * norm
 }
 
-def biquad_process(var bq : BiquadState; x : float) : float {
+def private biquad_process(var bq : BiquadState; x : float) : float {
     let y = bq.a0 * x + bq.a1 * bq.x1 + bq.a2 * bq.x2 - bq.b1 * bq.y1 - bq.b2 * bq.y2
     bq.x2 = bq.x1
     bq.x1 = x
@@ -265,9 +268,9 @@ def biquad_process(var bq : BiquadState; x : float) : float {
 
 // 6 square-wave oscillators at inharmonic ratios produce metallic timbre.
 // Used by hi-hat, ride, crash, and tambourine.
-let HH_FREQS = fixed_array(205.3, 304.4, 369.6, 522.7, 540.0, 800.0)
+let private HH_FREQS = fixed_array(205.3, 304.4, 369.6, 522.7, 540.0, 800.0)
 
-def render_metallic(duration : float; gain : float; decay_rate : float; hpf_freq : float = 5000.0; noise_mix : float = 0.3) : array<float> {
+def private render_metallic(duration : float; gain : float; decay_rate : float; hpf_freq : float = 5000.0; noise_mix : float = 0.3) : array<float> {
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples : array<float>
     samples |> resize(nsamples)
@@ -304,15 +307,16 @@ def render_metallic(duration : float; gain : float; decay_rate : float; hpf_freq
 
 // ─── Additional Drum Synthesis ───
 
-// Open hi-hat: same metallic oscillator bank, much longer decay
 def render_oh(duration : float; gain : float) : array<float> {
+    //! Render an open hi-hat: the same metallic oscillator bank as hh but with a much slower decay.
     var samples <- render_metallic(duration, gain, 8.0)
     apply_room(samples, 0.1)
     return <- samples
 }
 
-// Tom: same layered approach as BD — body + beater click + impulse + room
 def render_tom(duration : float; gain : float; base_freq : float) : array<float> {
+    //! Render a tom drum at `base_freq` with a BD-style body + beater click + impulse + resonant-head overtones and a short room.
+    //! Used for tom_low (~80 Hz) and tom_high (~175 Hz).
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples : array<float>
     samples |> resize(nsamples)
@@ -352,8 +356,8 @@ def render_tom(duration : float; gain : float; base_freq : float) : array<float>
     return <- samples
 }
 
-// Ride cymbal: bell tone (~350Hz) + metallic shimmer, long sustain
 def render_ride(duration : float; gain : float) : array<float> {
+    //! Render a ride cymbal: two bell partials (~340/387 Hz) plus a metallic shimmer, with a long sustain.
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples : array<float>
     samples |> resize(nsamples)
@@ -386,8 +390,8 @@ def render_ride(duration : float; gain : float) : array<float> {
     return <- samples
 }
 
-// Crash cymbal: bell tone (~490Hz) + metallic wash, medium-fast decay
 def render_crash(duration : float; gain : float) : array<float> {
+    //! Render a crash cymbal: lower-pitched bell partials plus a broadband metallic wash with a medium-fast decay.
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples : array<float>
     samples |> resize(nsamples)
@@ -420,8 +424,8 @@ def render_crash(duration : float; gain : float) : array<float> {
     return <- samples
 }
 
-// Rimshot: woody thud (~200Hz) + high click (~1200Hz) + noise snap
 def render_rimshot(duration : float; gain : float) : array<float> {
+    //! Render a rimshot/side-stick: a short woody body (~200 Hz) plus a bandpassed noise snap and a high transient click.
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples : array<float>
     samples |> resize(nsamples)
@@ -448,8 +452,8 @@ def render_rimshot(duration : float; gain : float) : array<float> {
     return <- samples
 }
 
-// Cowbell: two square waves at 540 Hz and 800 Hz through bandpass
 def render_cowbell(duration : float; gain : float) : array<float> {
+    //! Render a cowbell: two detuned square-wave tones through a narrow bandpass, with a second quieter strike 8 ms later.
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples : array<float>
     samples |> resize(nsamples)
@@ -478,8 +482,8 @@ def render_cowbell(duration : float; gain : float) : array<float> {
     return <- samples
 }
 
-// Tambourine: high-pass noise with narrow band peaks for jingle
 def render_tambourine(duration : float; gain : float) : array<float> {
+    //! Render a tambourine: high-passed noise with two narrow bandpass jingle peaks (~3.8 kHz and ~8.8 kHz) and a delayed second hit.
     let nsamples = int(duration * float(SAMPLE_RATE))
     var samples : array<float>
     samples |> resize(nsamples)
@@ -510,18 +514,28 @@ def render_tambourine(duration : float; gain : float) : array<float> {
 
 // ─── Oscillators ───
 
+//! Oscillator waveform selector for an `OscVoice`.
 enum OscType {
     osc_sine
+        //! Pure sine wave.
     osc_sawtooth
+        //! Band-limited sawtooth (poly-BLEP anti-aliased).
     osc_square
+        //! Band-limited square wave (poly-BLEP anti-aliased).
     osc_triangle
+        //! Triangle wave derived from the phase.
     osc_supersaw
+        //! Unison stack of detuned band-limited sawtooths, stereo-spread.
     osc_pink_noise
+        //! Pink noise via Paul Kellet's 7-stage cascaded IIR.
     osc_white_noise
+        //! Uniform white noise.
     osc_unknown
+        //! Unrecognised sound name — used as a sentinel by `to_osc_type`.
 }
 
 def to_osc_type(sound : string) : OscType {
+    //! Map a strudel sound name ("sine", "sawtooth", ...) to an `OscType`; unknown names return `osc_unknown`.
     if (sound == "sine") {
         return OscType.osc_sine
     } elif (sound == "sawtooth") {
@@ -540,10 +554,10 @@ def to_osc_type(sound : string) : OscType {
     return OscType.osc_unknown
 }
 
-let SUPERSAW_VOICES = 5       // default unison voice count
-let SUPERSAW_DETUNE = 0.18    // default frequency spread in semitones
+let private SUPERSAW_VOICES = 5       // default unison voice count
+let private SUPERSAW_DETUNE = 0.18    // default frequency spread in semitones
 
-// Pink noise state — Paul Kellet's 7-stage cascaded IIR filter
+//! Pink noise state — Paul Kellet's 7-stage cascaded IIR filter.
 struct PinkNoiseState {
     b0 : float = 0.0
     b1 : float = 0.0
@@ -555,7 +569,7 @@ struct PinkNoiseState {
     seed : uint = 54321u
 }
 
-def pink_noise_tick(var st : PinkNoiseState) : float {
+def private pink_noise_tick(var st : PinkNoiseState) : float {
     let white = noise(st.seed)
     st.b0 = 0.99886 * st.b0 + white * 0.0555179
     st.b1 = 0.99332 * st.b1 + white * 0.0750759
@@ -572,21 +586,32 @@ def pink_noise_tick(var st : PinkNoiseState) : float {
 // 5 parallel bandpass filters using standard formant tables.
 // Each formant has frequency, gain, and Q. The outputs are summed with a makeup gain of 8.0.
 
-// Bandpass biquad filter (transposed direct form II, 3 numerator coefficients).
-// Unlike ma_sf2_biquad which hardcodes a2=a0 (LPF/HPF only), this has explicit a2.
+//! General-purpose bandpass biquad (transposed direct form II) with all three numerator coefficients.
+//! Unlike `ma_sf2_biquad` (LPF/HPF only, `a2 == a0`), this stores an explicit `a2`, allowing true BPF/BRF shapes.
 struct FormantBiquad {
     a0 : double = 0.0lf
+        //! Feed-forward coefficient 0.
     a1 : double = 0.0lf
+        //! Feed-forward coefficient 1 (0 for BPF).
     a2 : double = 0.0lf
+        //! Feed-forward coefficient 2 (`-a0` for BPF).
     b1 : double = 0.0lf
+        //! Feedback coefficient 1.
     b2 : double = 0.0lf
+        //! Feedback coefficient 2.
     z1 : double = 0.0lf
+        //! Internal delay-line state 1.
     z2 : double = 0.0lf
+        //! Internal delay-line state 2.
     gain : float = 1.0          // per-formant amplitude scaling
+        //! Per-formant amplitude scaling applied to the filter output by the vowel filter.
     active : int = 0
+        //! Non-zero when the filter has valid coefficients and should process samples.
 }
 
 def formant_biquad_setup_bpf(var bq : FormantBiquad; freq, q, sample_rate : float) {
+    //! Compute bandpass coefficients for the given centre frequency and Q.
+    //! Deactivates the filter if the cutoff is outside the usable range (near 0 or Nyquist).
     let fc_norm = freq / sample_rate
     if (fc_norm <= 0.001 || fc_norm >= 0.499) {
         bq.active = 0
@@ -607,6 +632,7 @@ def formant_biquad_setup_bpf(var bq : FormantBiquad; freq, q, sample_rate : floa
 }
 
 def formant_biquad_tick(var bq : FormantBiquad; input : float) : float {
+    //! Process one sample through the biquad and return the output.
     let inp = double(input)
     let out = inp * bq.a0 + bq.z1
     bq.z1 = inp * bq.a1 + bq.z2 - bq.b1 * out
@@ -617,20 +643,27 @@ def formant_biquad_tick(var bq : FormantBiquad; input : float) : float {
 let VOWEL_NUM_FORMANTS = 5
 let VOWEL_MAKEUP_GAIN = 8.0    // makeup gain for vowel formant filter
 
+//! Five parallel bandpass filters that impose a vowel-like formant shape on an input signal.
 struct VowelFilter {
     @safe_when_uninitialized formants : FormantBiquad[5]
+        //! Five formant bandpass biquads processed in parallel and summed.
     active : bool = false
+        //! True once the filter has been set up for a known vowel; otherwise ``tick`` is bypassed by callers.
 }
 
-// Formant data: [freq, gain, Q] per formant, 5 formants per vowel.
-// Standard formant tables.
+//! Table row of formant parameters for a single vowel (5 formants × freq/gain/Q).
 struct FormantData {
     freqs : float[5]
+        //! Centre frequency of each formant in Hz.
     gains : float[5]
+        //! Linear gain of each formant (formant 0 is usually the loudest).
     qs    : float[5]
+        //! Q (resonance) of each formant bandpass.
 }
 
 def vowel_get_formant_data(vowel : string; var data : FormantData) : bool {
+    //! Look up formant parameters for a vowel name ("a", "e", "i", "o", "u", "ae", "aa", "oe", "ue", "y", "uh", "un", "en", "an", "on").
+    //! Returns false if the vowel is unknown.
     if (vowel == "a") {
         data.freqs = fixed_array(660.0, 1120.0, 2750.0, 3000.0, 3350.0)
         data.gains = fixed_array(1.0, 0.5012, 0.0708, 0.0631, 0.0126)
@@ -698,6 +731,7 @@ def vowel_get_formant_data(vowel : string; var data : FormantData) : bool {
 }
 
 def vowel_filter_init(var vf : VowelFilter; vowel : string) {
+    //! Configure a VowelFilter for the named vowel, deactivating it if the vowel is unknown.
     var data : FormantData
     if (!vowel_get_formant_data(vowel, data)) {
         vf.active = false
@@ -711,8 +745,8 @@ def vowel_filter_init(var vf : VowelFilter; vowel : string) {
     vf.active = true
 }
 
-// Apply vowel filter: 5 parallel bandpass filters, sum outputs, scale by makeup gain.
 def vowel_filter_tick(var vf : VowelFilter; input : float) : float {
+    //! Process one sample through the vowel filter: sum the 5 parallel formant bandpass outputs and apply the makeup gain.
     var sum = 0.0
     for (i in range(VOWEL_NUM_FORMANTS)) {
         if (vf.formants[i].active != 0) {
@@ -722,31 +756,46 @@ def vowel_filter_tick(var vf : VowelFilter; input : float) : float {
     return sum * VOWEL_MAKEUP_GAIN
 }
 
-// ─── Per-voice effect chain (bitcrush, waveshaper, DJ filter, bandpass, phaser, tremolo, compressor) ───
-// Wraps the C++ ma_* effect structs; initialised from Event fields.
-// Fields whose corresponding Event field is at its "off" value stay unused,
-// so a default VoiceFX is a cheap no-op.
+//! Per-voice effect chain: bitcrush, waveshaper, DJ filter, bandpass, phaser, tremolo and compressor.
+//! Wraps the C++ `ma_*` effect structs and is initialised from Event fields; a default-constructed
+//! VoiceFX with no Event-driven parameters active is a cheap no-op.
 [safe_when_uninitialized]
 struct VoiceFX {
     @safe_when_uninitialized bc   : ma_bitcrush
+        //! Bitcrusher state (bit-depth + sample-rate reduction).
     @safe_when_uninitialized ws   : ma_waveshaper
+        //! Waveshaper state (drive-based soft distortion).
     @safe_when_uninitialized dj   : ma_djfilter
+        //! DJ filter state (single-knob low-pass/high-pass blend).
     @safe_when_uninitialized bp   : ma_bandpass
+        //! Bandpass filter state (centre + Q).
     @safe_when_uninitialized ph   : ma_phaser
+        //! Phaser state (rate/depth/centre/sweep).
     @safe_when_uninitialized trem : ma_tremolo
+        //! Tremolo state (amplitude modulation rate/depth).
     @safe_when_uninitialized comp : ma_compressor
+        //! Compressor state (threshold/ratio/knee/attack/release).
     has_crush : bool = false
+        //! Bitcrush is enabled and will be applied to the voice.
     has_shape : bool = false
+        //! Waveshaper is enabled.
     has_djf   : bool = false
+        //! DJ filter is enabled (position != 0.5).
     has_bpf   : bool = false
+        //! Bandpass filter is enabled.
     has_phaser : bool = false
+        //! Phaser is enabled.
     has_tremolo : bool = false
+        //! Tremolo is enabled.
     has_compressor : bool = false
+        //! Compressor is enabled.
     active    : bool = false
+        //! True if any of the above effects is enabled; skip `fx_apply` entirely when false.
 }
 
-// Configure a VoiceFX from an Event. Returns silently if nothing is active.
 def fx_init_from_event(var fx : VoiceFX; event : Event; sample_rate : float) {
+    //! Configure a VoiceFX chain from the relevant Event fields (crush/coarse/shape/djf/bpf/phaser/tremolo/compressor).
+    //! Leaves everything disabled when no Event field is active, so the chain can stay at `fx.active == false`.
     if (event.crush > 0.0 || event.coarse > 0) {
         unsafe { bitcrush_init(addr(fx.bc)); }
         fx.bc.bits = event.crush
@@ -794,11 +843,10 @@ def fx_init_from_event(var fx : VoiceFX; event : Event; sample_rate : float) {
     fx.active = fx.has_crush || fx.has_shape || fx.has_djf || fx.has_bpf || fx.has_phaser || fx.has_tremolo || fx.has_compressor
 }
 
-// Apply configured effects to an interleaved stereo buffer (n_frames = sample-frame count).
-// Ordered: crush → shape → djfilter → bandpass → phaser → tremolo → compressor.
-// Phaser and tremolo come after the timbral effects to modulate the finished tone;
-// compressor is last so it sees the post-FX signal.
 def fx_apply(var fx : VoiceFX; var buf : array<float>; n_frames : int) {
+    //! Apply the enabled effects to an interleaved stereo buffer in place.
+    //! Order: crush -> shape -> djfilter -> bandpass -> phaser -> tremolo -> compressor
+    //! (phaser/tremolo modulate the finished tone, compressor is last so it sees the post-FX signal).
     if (!fx.active || n_frames <= 0 || length(buf) < n_frames * 2) {
         return
     }
@@ -811,9 +859,9 @@ def fx_apply(var fx : VoiceFX; var buf : array<float>; n_frames : int) {
     if (fx.has_compressor) { unsafe { compressor_process(addr(fx.comp), addr(buf[0]), n_frames); } }
 }
 
-// Apply effects to an already-rendered stereo PCM buffer (one-shot for pre-rendered voices).
-// State is local to this call, so effects reset every render.
 def fx_apply_to_samples(event : Event; var samples : array<float>; sample_rate : float) {
+    //! Apply Event-driven effects to a pre-rendered stereo buffer as a one-shot.
+    //! Effect state is local to this call, so effects reset every render; used for drum/sample voices that don't stream.
     let n_frames = length(samples) / 2
     if (n_frames <= 0) {
         return
@@ -823,57 +871,87 @@ def fx_apply_to_samples(event : Event; var samples : array<float>; sample_rate :
     fx_apply(fx, samples, n_frames)
 }
 
-// Streaming oscillator voice — renders per-chunk instead of pre-rendering the full duration.
+//! Streaming oscillator voice rendered per audio chunk rather than pre-rendered for the full duration.
+//! Holds oscillator state, ADSR, filters, FM, supersaw unison, noise, effect sends, vowel filter and per-voice FX.
 struct OscVoice {
     osc_type        : OscType = OscType.osc_sine
+        //! Which waveform this voice produces.
     freq            : float = 440.0
+        //! Base frequency in Hz (before FM and supersaw detune).
     phase           : float = 0.0       // oscillator phase [0,1)
+        //! Main oscillator phase in [0, 1).
     duration        : float = 1.0       // total note duration in seconds
+        //! Total note duration in seconds (release stage extends beyond this).
     attack          : float = 0.001
+        //! ADSR attack time in seconds.
     decay           : float = 0.05
+        //! ADSR decay time in seconds.
     sustain         : float = 0.0
+        //! ADSR sustain level in [0, 1].
     release_sec     : float = 0.01
+        //! ADSR release time in seconds.
     samples_elapsed : int = 0           // samples rendered so far
+        //! Number of samples rendered so far; used to compute the envelope time.
     finished        : bool = false
+        //! Set to true when the ADSR has fully decayed; scheduler then retires the voice.
     gain            : float = 1.0       // event.gain * event.velocity
+        //! Effective voice gain (event.gain * event.velocity).
     pan             : float = 0.0       // -1=left, 0=center, 1=right
+        //! Stereo pan: -1 = full left, 0 = centre, +1 = full right.
     cut             : int = 0           // cut group
+        //! Cut group — non-zero values cut off any previous voice with the same cut value.
     offset_frames   : int = 0           // sub-chunk onset delay (frames)
+        //! Sub-chunk onset delay in frames, consumed at the start of the first render chunk.
     lpf_biquad      : ma_sf2_biquad     // low-pass filter state
+        //! Low-pass biquad filter state (initialised by `osc_voice_init_filters`).
     hpf_biquad      : ma_sf2_biquad     // high-pass filter state
+        //! High-pass biquad filter state.
     // FM synthesis state
     fm_depth        : float = 0.0       // FM modulation index (0 = off)
+        //! FM modulation index (0 disables FM).
     fm_harmonicity  : float = 1.0       // modulator freq = carrier freq * harmonicity
+        //! Ratio of modulator frequency to carrier frequency.
     fm_mod_phase    : float = 0.0       // modulator oscillator phase [0,1)
+        //! FM modulator oscillator phase in [0, 1).
     // supersaw state — 7 detuned sawtooth phases
     supersaw_phases : float[7]
+        //! Independent phases for each detuned sawtooth voice in the supersaw stack.
     // noise state
     @safe_when_uninitialized pink : PinkNoiseState
+        //! Pink-noise generator state (Paul Kellet's 7-stage IIR).
     white_seed : uint = 12345u
+        //! LCG seed used by the white-noise generator.
     // reverb send
     reverb_send : float = 0.0   // reverb send amount from Event.room (0.0–1.0)
+        //! Send amount into the reverb bus (driven by Event.room).
     // chorus send
     chorus_send : float = 0.0   // chorus send amount from Event.chorus (0.0–1.0)
+        //! Send amount into the chorus bus (driven by Event.chorus).
     // delay send
     delay_send : float = 0.0    // delay send amount from Event.delay_amount (0.0–1.0)
+        //! Send amount into the delay bus (driven by Event.delay_amount).
     // orbit
     orbit : int = 0             // effect bus routing
+        //! Orbit index used by the scheduler to route this voice into a shared effect bus.
     // vowel formant filter
     @safe_when_uninitialized vowel_filter : VowelFilter
+        //! Optional vowel formant filter applied after the biquad filters.
     // per-voice audio effects (crush/coarse/shape/djf/bpf/bpq)
     @safe_when_uninitialized fx : VoiceFX
+        //! Per-voice FX chain (bitcrush/waveshaper/DJ filter/bandpass/phaser/tremolo/compressor).
 }
 
-// Initialize supersaw phases with random offsets for natural unison spread.
 def osc_voice_init_supersaw(var voice : OscVoice) {
+    //! Seed the supersaw unison phases with randomised offsets so the detuned voices don't start in phase.
     var seed = 99999u
     for (i in range(SUPERSAW_VOICES)) {
         voice.supersaw_phases[i] = float(noise(seed) * 0.5 + 0.5)  // [0,1)
     }
 }
 
-// Initialize OscVoice filter state from Event lpf/hpf/lpq/hpq values.
 def osc_voice_init_filters(var voice : OscVoice; lpf, hpf, lpq, hpq : float) {
+    //! Configure the voice's low-pass and high-pass biquads from Event lpf/hpf cutoffs and lpq/hpq resonances.
+    //! Cutoffs <= 0 or >= Nyquist leave the corresponding filter inactive.
     let sr = float(SAMPLE_RATE)
     // LPF: active if cutoff > 0 and below Nyquist
     if (lpf > 0.0 && lpf < sr * 0.5) {
@@ -1108,9 +1186,9 @@ def private osc_chunk_white_noise(var voice : OscVoice; var output : array<float
     }
 }
 
-// Render one chunk of an oscillator voice directly into the output buffer (additive).
-// Dispatches to per-type loop with invariants hoisted out.
 def osc_render_chunk(var voice : OscVoice; var output : array<float>; var reverb_send_buf : array<float>; var delay_send_buf : array<float>; var chorus_send_buf : array<float>; chunkFrames : int) {
+    //! Render one chunk of the oscillator voice additively into the output buffer and the reverb/delay/chorus send buffers.
+    //! Hoists invariants out of the inner loop and dispatches to the per-oscillator-type render function.
     // consume sub-chunk onset offset
     if (voice.offset_frames >= chunkFrames) {
         voice.offset_frames -= chunkFrames
@@ -1160,10 +1238,9 @@ def osc_render_chunk(var voice : OscVoice; var output : array<float>; var reverb
 
 // ─── Main render entry point ───
 
-// Render an Event into interleaved stereo PCM.
-// Returns raw audio — no gain or pan applied. The scheduler's
-// ma_volume_mixer handles gain and pan during the mix pass.
 def render_event_stereo(event : Event; duration_sec : float) : array<float> {
+    //! Render an Event into an interleaved stereo PCM buffer using the built-in drum synths.
+    //! Returns raw audio with no gain/pan applied — the scheduler's `ma_volume_mixer` applies those during the mix pass.
     let s = event.s
     var mono : array<float>
     // drum sounds have fixed durations, rendered at unit gain
@@ -1197,9 +1274,9 @@ def render_event_stereo(event : Event; duration_sec : float) : array<float> {
     return <- mono_to_stereo(mono)
 }
 
-// Render with sample bank — tries bank first, falls back to synthesis.
-// Returns raw stereo — no gain or pan.
 def render_event_stereo(event : Event; duration_sec : float; bank : SampleBank) : array<float> {
+    //! Render an Event into stereo PCM, preferring a sample from the bank when present and falling back to synthesis.
+    //! Returns raw stereo — gain and pan are applied later by the scheduler.
     if (key_exists(bank.sounds, event.s)) {
         var samples <- render_sample(bank, event.s, event.n, event.speed, event.begin, event.end_pos)
         if (length(samples) > 0) {
@@ -1209,8 +1286,9 @@ def render_event_stereo(event : Event; duration_sec : float; bank : SampleBank) 
     return <- render_event_stereo(event, duration_sec)
 }
 
-// Convert mono buffer to interleaved stereo (duplicate to both channels).
 def mono_to_stereo(var mono : array<float>) : array<float> {
+    //! Upmix a mono buffer to interleaved stereo by duplicating each sample to both channels.
+    //! Consumes `mono` (moves and frees it).
     var stereo : array<float>
     let n = length(mono)
     stereo |> resize(n * 2)

--- a/modules/dasAudio/strudel/strudel_time.das
+++ b/modules/dasAudio/strudel/strudel_time.das
@@ -1,32 +1,39 @@
 options gen2
 options indenting = 4
 
-module strudel_time shared
+module strudel_time shared public
+//! Cycle-space time primitives for pattern queries.
+//! Defines `TimeSpan` (a [start, stop) interval in cycles) and `Hap` (a single
+//! event with its ideal whole span and the visible part within a query window).
 
 require strudel/strudel_event
 require math
 
-// A time span in cycle-space. Cycles are continuous floats:
-// 0.0–1.0 is the first cycle, 1.0–2.0 the second, etc.
+//! A time span in cycle-space. Cycles are continuous floats: 0.0–1.0 is the first cycle,
+//! 1.0–2.0 the second, etc.
 struct TimeSpan {
     start : double
+        //! Inclusive start position in cycles.
     stop  : double
+        //! Exclusive end position in cycles.
 }
 
-// A single event produced by querying a pattern.
-//
-// `whole` is the "ideal" time span — the full note duration.
-// `part` is the portion visible in the query window.
+//! A single event produced by querying a pattern. `whole` is the ideal note duration;
+//! `part` is the portion visible in the query window (may be a subset of `whole`).
 struct Hap {
     whole : TimeSpan
+        //! Ideal full span of the event (full note duration).
     part  : TimeSpan
+        //! Portion of `whole` visible in the current query window.
     has_whole : bool = true
+        //! False for continuous events that have no discrete onset (e.g. signals).
     @safe_when_uninitialized value : Event
+        //! The event payload (what to play and how).
 }
 
-// Split a time span at integer cycle boundaries.
-// splitSpans(TimeSpan(0.75, 2.25)) → [(0.75,1.0), (1.0,2.0), (2.0,2.25)]
 def splitSpans(span : TimeSpan) : array<TimeSpan> {
+    //! Split a time span at integer cycle boundaries. Example: `splitSpans(TimeSpan(0.75, 2.25))`
+    //! returns `[(0.75,1.0), (1.0,2.0), (2.0,2.25)]`.
     var result : array<TimeSpan>
     var current = span.start
     while (current < span.stop) {
@@ -39,12 +46,12 @@ def splitSpans(span : TimeSpan) : array<TimeSpan> {
     return <- result
 }
 
-// Which cycle number does this time position fall in?
 def sameCycle(t : double) : double {
+    //! Cycle number containing time position `t` (integer part as double).
     return floor(t)
 }
 
-// Fraction within the current cycle (0.0–1.0)
 def cyclePos(t : double) : double {
+    //! Fractional position within the current cycle (0.0–1.0).
     return t - floor(t)
 }

--- a/site/index.html
+++ b/site/index.html
@@ -98,6 +98,9 @@
             <h2>News</h2>
             <ul  style="list-style-type:none;">
             <li>
+                <b>April 17th, 2026</b>: daStrudel gets <a href="doc/stdlib/sec_strudel.html">module reference</a> and <a href="doc/reference/tutorials.html#tutorials-dastrudel">a 15-part tutorial series</a>.
+            </li>
+            <li>
                 <b>April 4th, 2026</b>: 0.6.1 is <a href="https://github.com/GaijinEntertainment/daScript/releases/tag/0.6.1-RC2">out!</a>
             </li>
             <li>

--- a/skills/strudel_port.md
+++ b/skills/strudel_port.md
@@ -1,0 +1,304 @@
+# Copy-Pasting strudel.cc Patterns into daslang
+
+Read this skill when the user has a pattern from strudel.cc — a line or
+block of JavaScript like ``s("bd sd").fast(2).jux(rev)`` — and wants
+to run it under daslang's strudel library. This is about **translating
+user patterns**, not porting library features. For the library-side
+"implement this primitive in daslang" workflow, the public API already
+covers almost everything strudel.cc users rely on; use
+:ref:`strudel_vs_strudel_cc` to check what's available.
+
+## Where strudel.cc patterns come from
+
+- The REPL at https://strudel.cc — everything on the front page is a
+  pattern
+- Example gallery: https://strudel.cc/workshop/
+- Upstream source, for behavioural ground-truth:
+  https://github.com/tidalcycles/strudel — use `WebFetch` on specific
+  files rather than cloning
+
+## The five mechanical rewrites
+
+Doing these five in order turns almost every strudel.cc pattern into a
+valid daslang expression. Apply them top-down on the pasted snippet.
+
+### 1. Method chain → pipe chain
+
+```
+// strudel.cc
+s("bd sd").fast(2).jux(rev).gain(0.8)
+
+// daslang
+s("bd sd") |> fast(2.0) |> jux(@(x) => rev(x)) |> gain(0.8)
+```
+
+Every ``.name(args)`` becomes ``|> name(args)``. Chains of four or
+five stages are normal.
+
+Note that daslang **does** support ``.method()`` as sugar for
+``method(receiver, ...)`` — but only on **struct** types. ``Pattern``
+is a ``lambda<...>`` typedef, not a struct, so ``s("bd").fast(2.0)``
+fails to compile. Pipe (``|>``) is the correct form for strudel
+chains, and it is faster to compile than method syntax anyway.
+
+To break a long chain across lines, wrap it in ``(...)`` — daslang
+permits newlines **anywhere inside** parens, square brackets, and
+table-literal braces:
+
+```das
+let pat <- (
+    s("bd sd hh cp")
+    |> fast(2.0)
+    |> jux(@(x) => rev(x))
+    |> gain(0.8)
+    |> room(0.3)
+)
+```
+
+Without the surrounding parens the chain must be on one line
+(statement-level parsing is line-oriented).
+
+### 2. Numeric literals need a type
+
+strudel.cc accepts bare integers everywhere; daslang is typed:
+
+```
+.fast(2)        →  |> fast(2.0)
+.gain(0.5)      →  |> gain(0.5)     // already OK
+.note(60)       →  |> note(60.0)
+.delay(0.25)    →  |> delay(0.25)
+.orbit(1)       →  |> orbit(1)      // orbit is int — OK
+```
+
+Rule: when in doubt, write the float with an explicit ``.0``. The
+compiler error for ``int`` where ``float`` is expected is loud and
+immediate.
+
+### 3. Bare identifiers as transforms → lambda literals
+
+strudel.cc passes **function names** to combinators; daslang wants a
+typed lambda:
+
+```
+.jux(rev)              →  |> jux(@(x) => rev(x))
+.off(1/8, fast(2))     →  |> off(0.125, @(x) => fast(x, 2.0))
+.every(4, rev)         →  |> every(4, @(x) => rev(x))
+```
+
+The ``@(x) => ...`` form is an inline lambda. See
+:ref:`tutorial_lambdas` for the syntax. If the transform itself is a
+chain, build it inside the lambda body:
+
+```
+// strudel.cc
+.jux(x => x.fast(2).rev())
+
+// daslang
+|> jux(@(x) => x |> fast(2.0) |> rev())
+```
+
+### 4. Top-level combinators aren't methods
+
+``stack``, ``cat``, ``fastcat`` take patterns as **arguments**, not
+``this``:
+
+```
+// strudel.cc
+stack(s("bd"), s("hh*4"))
+
+// daslang
+stack([s("bd"), s("hh*4")])     // array of patterns — note the brackets
+```
+
+Same for ``cat``, ``fastcat``, ``randcat``, ``choose``, ``wchoose``.
+
+### 5. Playback is explicit
+
+strudel.cc auto-plays whatever the last line evaluates to. daslang
+needs a harness:
+
+```das
+require strudel/strudel public
+require audio/audio_boost
+require daslib/fio
+
+def play(var pat : Pattern; seconds : float; cps : double = 0.5lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (float(get_time_usec(t0)) / 1000000.0 < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+[export]
+def main() {
+    let pat <- s("bd sd") |> fast(2.0) |> jux(@(x) => rev(x))
+    play(pat, 8.0)
+}
+```
+
+Every tutorial under ``tutorials/daStrudel/`` uses this shape — copy
+the harness from the closest one. For offline WAV rendering instead of
+live audio, see ``examples/daStrudel/features/feature_common.das``
+(``play_feature_cps`` with ``--wav PATH``).
+
+## Samples, synths, and soundfonts
+
+daslang ships with **built-in drum synthesis**. The following sample
+names are synthesised out of the box — no sample pack needed:
+
+``bd``, ``sd``, ``hh`` / ``hh_pedal``, ``oh`` / ``hh_open``, ``cp``,
+``tom_low``, ``tom_high``, ``ride`` / ``ride_bell``, ``crash``,
+``sidestick``, ``cowbell`` / ``cb``, ``tambourine`` / ``tamb``.
+
+So ``s("bd sd hh cp")`` pasted from strudel.cc produces audio
+immediately — an 808-style kick, a snare with wires, a noise-burst
+hi-hat, a clap. The synth is "decent", not sample-accurate; if the
+user wants the exact strudel.cc timbre, load the upstream sample
+pack (option 1 below).
+
+Dispatch rule in ``strudel_synth.render_event_stereo``: if a
+``SampleBank`` has a sample with the event's name, use the sample;
+otherwise if the name matches a built-in drum, synthesise it;
+otherwise silence.
+
+Three ways to add anything beyond the built-in drums, in order of
+effort:
+
+1. **Load a local sample bank.** Download
+   https://github.com/tidalcycles/dirt-samples
+   (or any pack you own), then before ``strudel_add_track``::
+
+       strudel_load_sample_dir("/path/to/dirt-samples")
+
+   Every top-level folder becomes a sound name; ``s("bd")`` will
+   then play the sample (the loaded sample overrides the built-in
+   synth).
+
+2. **Use the oscillator voices.** For melodic material, the synth
+   engine exposes named oscillators::
+
+       s("sine sawtooth")                 // pure tones
+       s("sine") |> note("c4 e4 g4")
+
+   See :ref:`tutorial_dastrudel_synthesis` for the full list:
+   ``sine``, ``sawtooth``, ``square``, ``triangle``, ``supersaw``,
+   ``pink``, ``white``. **Note the exact names** — strudel.cc aliases
+   ``sawtooth`` as ``saw``; daslang does not. ``s("saw")`` falls
+   through to silence.
+
+3. **Load a SoundFont.** If the strudel.cc pattern used a melodic
+   instrument::
+
+       strudel_load_sf2("/path/to/gm.sf2")
+       ...
+       s("sf2") |> note("c4 e4 g4") |> sf2_bank(0) |> sf2(40)   // violin
+
+   See :ref:`tutorial_dastrudel_sf2_soundfont`.
+
+## Common friction points when pasting
+
+### Mini-notation ``bd(3,8)`` Euclidean form
+
+strudel.cc parses the integer-pair inside the string as Euclidean
+rhythm; daslang's mini-notation lexes the parens but does not parse
+them. **Rewrite** as an explicit combinator call::
+
+    // strudel.cc
+    s("bd(3,8)")
+
+    // daslang
+    euclid(s("bd"), 3, 8)
+
+### ``euclidRot``
+
+Not implemented. Compose ``euclid`` with rotation via ``off`` or
+``rev``. See :ref:`strudel_vs_strudel_cc` for the full gap list.
+
+### Method aliases that don't exist
+
+``jux_rev``, ``chop``, and a few one-letter convenience wrappers are
+absent. Expand to the parametric form:
+
+```
+.jux_rev()   →  |> jux(@(x) => rev(x))
+.chop(4)     →  |> striate(4)       // nearest equivalent
+```
+
+### Backtick-heavy mini-notation
+
+strudel.cc mini-notation works identically for subdivisions ``[a b]``,
+repeats ``a*4``, rests ``~``, angle-brackets ``<a b c>``, elongation
+``@``, degrade ``?``, replicate ``!``. Paste them verbatim inside
+``s("...")`` / ``n("...")`` / ``note("...")``.
+
+### ADSR sounds different
+
+daslang's ADSR defaults are tempo-aware; strudel.cc uses fixed-ms
+values. If the pasted pattern sounds too soft/harsh at the attack or
+release, set values explicitly::
+
+    |> attack(0.01) |> decay(0.1) |> sustain(0.7) |> release(0.3)
+
+Details in :ref:`strudel_vs_strudel_cc`.
+
+### Pattern-valued setters
+
+strudel.cc accepts a pattern as the argument to a setter::
+
+    s("bd*4").gain("1 0.5")
+
+daslang has pattern-valued overloads for every setter — the same
+syntax works::
+
+    s("bd*4") |> gain(s("1 0.5"))
+
+If ``gain("1 0.5")`` doesn't compile, wrap the pattern literal in
+``s(...)`` or the appropriate parser call.
+
+## Verification loop
+
+1. **Compile-check** — `bin/Release/daslang.exe -compile-only <file>.das`
+   exits 0. Syntax and type errors surface here.
+2. **Listen** — run the ported pattern for 8-16 seconds. Compare to a
+   mental image of the strudel.cc playback (or load the strudel.cc
+   REPL side-by-side).
+3. **If it sounds wrong:** check the three most common culprits in
+   order — (a) missing samples falling back to silence, (b)
+   tempo-aware ADSR making the envelope feel different, (c) a
+   combinator rewrite (``jux_rev``, ``chop``, ``euclidRot``) that
+   silently did nothing because the rewrite was wrong.
+
+## Quick reference card
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - strudel.cc
+     - daslang
+   * - ``s("bd").fast(2)``
+     - ``s("bd") \|> fast(2.0)``
+   * - ``.jux(rev)``
+     - ``\|> jux(@(x) => rev(x))``
+   * - ``.every(4, fast(2))``
+     - ``\|> every(4, @(x) => fast(x, 2.0))``
+   * - ``stack(a, b, c)``
+     - ``stack([a, b, c])``
+   * - ``"bd(3,8)"``
+     - ``euclid(s("bd"), 3, 8)``
+   * - ``.gain("1 0.5")``
+     - ``\|> gain(s("1 0.5"))``
+   * - ``.note(60)``
+     - ``\|> note(60.0)``
+   * - ``s("saw")``
+     - ``s("sawtooth")`` — no ``saw`` alias
+   * - auto-play
+     - ``play(pat, seconds)`` harness + ``[export] def main``
+

--- a/tutorials/daStrudel/daStrudel_01_hello_pattern.das
+++ b/tutorials/daStrudel/daStrudel_01_hello_pattern.das
@@ -1,0 +1,94 @@
+// Tutorial DASTRUDEL-01: Hello Pattern
+//
+// This tutorial covers:
+//   - Your first Pattern: s("bd"), note("c4"), and pure()
+//   - The Pattern type — a pure function from time span to events (Haps)
+//   - Querying a Pattern by hand to see what a Hap looks like
+//   - Playing a Pattern through the audio system
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_01_hello_pattern.das
+
+options gen2
+options indenting = 4
+options persistent_heap
+
+require strudel/strudel public
+require strudel/strudel_player
+require audio/audio_boost
+require daslib/fio
+
+// Tiny harness — feed a pattern to the main-thread player for `seconds` seconds.
+// The full version (with WAV rendering, memory tracking, etc.) lives in
+// examples/daStrudel/features/feature_common.das.
+def play(var pat : Pattern; seconds : float = 4.0; cps : double = 0.5lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (float(get_time_usec(t0)) / 1000000.0 < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — What is a Pattern? Querying one by hand
+// ──────────────────────────────────────────────────────────────────────────
+//
+// A Pattern is a pure function from a TimeSpan (a query window) to an
+// array of Haps (events that fall within that window). No side effects,
+// no audio — just data. Time is measured in *cycles*, not seconds.
+//
+// pure(Event) lifts a single Event into a Pattern that emits it once
+// per cycle.
+
+def example_query_by_hand() {
+    print("=== Section 1: Query a Pattern by hand ===\n")
+    let pat <- pure(Event(s = "bd"))
+    var haps <- invoke(pat, TimeSpan(start = 0.0lf, stop = 1.0lf))
+    print("  Querying [0, 1) returned {length(haps)} hap(s):\n")
+    for (h in haps) {
+        print("    whole=[{h.whole.start}, {h.whole.stop})  s='{h.value.s}'\n")
+    }
+    delete haps
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — s("bd"): one drum hit per cycle
+// ──────────────────────────────────────────────────────────────────────────
+//
+// s() parses mini-notation and builds a Pattern of sound events. Even the
+// simplest input — a single sound name — is valid mini-notation: it produces
+// one hap per cycle, just like pure() did, but typed by the parser.
+
+def example_s_one_sound() {
+    print("\n=== Section 2: s(\"bd\") — one bass-drum hit per cycle ===\n")
+    let pat <- s("bd")
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — note("c4"): one synth note per cycle
+// ──────────────────────────────────────────────────────────────────────────
+//
+// note() is the synth counterpart of s(). It parses note names ("c4",
+// "eb3", "g#5") into MIDI numbers. The second arg picks an oscillator;
+// "sine" is the default.
+
+def example_note_one_note() {
+    print("\n=== Section 3: note(\"c4\") — one sine note per cycle ===\n")
+    let pat <- note("c4", "sine") |> sustain(0.5)
+    play(pat, 4.0)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-01: Hello Pattern\n\n")
+    example_query_by_hand()
+    example_s_one_sound()
+    example_note_one_note()
+    print("\nDone!\n")
+}

--- a/tutorials/daStrudel/daStrudel_02_mini_notation_fundamentals.das
+++ b/tutorials/daStrudel/daStrudel_02_mini_notation_fundamentals.das
@@ -1,0 +1,98 @@
+// Tutorial DASTRUDEL-02: Mini-Notation Fundamentals
+//
+// This tutorial covers:
+//   - Sequences: "bd sd ~ cp" — events spaced evenly across one cycle
+//   - The rest token: ~ (silence)
+//   - Subdivisions: [a b] — squeeze a sub-sequence into one parent step
+//   - Repeats: x*N — play x N times within its step
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_02_mini_notation_fundamentals.das
+
+options gen2
+options indenting = 4
+options persistent_heap
+
+require strudel/strudel public
+require strudel/strudel_player
+require audio/audio_boost
+require daslib/fio
+
+// Tiny harness — feed a pattern to the main-thread player for `seconds` seconds.
+def play(var pat : Pattern; seconds : float = 4.0; cps : double = 0.5lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (float(get_time_usec(t0)) / 1000000.0 < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — A sequence with rests
+// ──────────────────────────────────────────────────────────────────────────
+//
+// "bd sd ~ cp" is the canonical four-step pattern: kick, snare, REST, clap.
+// Tokens are split on whitespace. ~ is the rest (silence) token. Each step
+// occupies an equal slice of the cycle (1/4 here).
+
+def example_sequence_with_rest() {
+    print("=== Section 1: \"bd sd ~ cp\" — kick, snare, rest, clap ===\n")
+    let pat <- s("bd sd ~ cp")
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Subdivisions with [ ]
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Square brackets group tokens into a sub-sequence that fits inside ONE step
+// of the parent. "bd [sd sd] ~ cp" plays kick, then two snares packed into
+// the second slot, then rest, then clap. Brackets nest arbitrarily.
+
+def example_subdivision() {
+    print("\n=== Section 2: \"bd [sd sd] ~ cp\" — two snares in one step ===\n")
+    let pat <- s("bd [sd sd] ~ cp")
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Repeats with *N
+// ──────────────────────────────────────────────────────────────────────────
+//
+// The `*N` postfix is shorthand for repeating a token N times within its
+// step. "bd hh*4 sd hh" plays a kick, four hi-hats packed into one step,
+// snare, then one hi-hat — equivalent to "bd [hh hh hh hh] sd hh".
+
+def example_repeat() {
+    print("\n=== Section 3: \"bd hh*4 sd hh\" — four hats in one step ===\n")
+    let pat <- s("bd hh*4 sd hh")
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — Combining the basics
+// ──────────────────────────────────────────────────────────────────────────
+//
+// All three primitives nest and combine freely. Here a kick, a snare with
+// two ghosted snares packed in, a rest, and four hats — a busy backbeat.
+
+def example_combined() {
+    print("\n=== Section 4: \"bd [sd sd*2] ~ hh*4\" ===\n")
+    let pat <- s("bd [sd sd*2] ~ hh*4")
+    play(pat, 4.0)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-02: Mini-Notation Fundamentals\n\n")
+    example_sequence_with_rest()
+    example_subdivision()
+    example_repeat()
+    example_combined()
+    print("\nDone!\n")
+}

--- a/tutorials/daStrudel/daStrudel_03_mini_notation_advanced.das
+++ b/tutorials/daStrudel/daStrudel_03_mini_notation_advanced.das
@@ -1,0 +1,106 @@
+// Tutorial DASTRUDEL-03: Mini-Notation Advanced
+//
+// This tutorial covers:
+//   - Angle brackets <a b c> — pick one element per cycle (alternation)
+//   - Elongation @N — make an element occupy N units of its parent
+//   - Degrade ? — randomly drop events with 50% probability
+//   - Replicate !N — repeat an element N times in its parent sequence
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_03_mini_notation_advanced.das
+
+options gen2
+options indenting = 4
+options persistent_heap
+
+require strudel/strudel public
+require strudel/strudel_player
+require audio/audio_boost
+require daslib/fio
+
+def play(var pat : Pattern; seconds : float = 4.0; cps : double = 0.5lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (float(get_time_usec(t0)) / 1000000.0 < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Alternation with < >
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Angle brackets pick ONE element per cycle, advancing on each cycle.
+// "<bd sd cp>" plays bd on cycle 0, sd on cycle 1, cp on cycle 2, then
+// loops. Inside a sequence, the angle group itself takes one step.
+
+def example_alternation() {
+    print("=== Section 1: \"<bd sd cp>\" — one per cycle ===\n")
+    let pat <- s("<bd sd cp>")
+    play(pat, 6.0)
+}
+
+def example_alternation_in_sequence() {
+    print("\n=== Section 1b: \"bd <sd cp> hh hh\" — alternation inside a sequence ===\n")
+    // The <sd cp> slot alternates each cycle: snare on cycle 0, clap on cycle 1.
+    let pat <- s("bd <sd cp> hh hh")
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Elongation with @N
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Postfix @N makes an element occupy N units of the parent sequence
+// (default 1). "bd@3 sd" gives the kick three quarters of the cycle and
+// the snare the last quarter — without elongation each would get half.
+
+def example_elongation() {
+    print("\n=== Section 2: \"bd@3 sd\" — kick takes 3/4 of the cycle ===\n")
+    let pat <- s("bd@3 sd") |> sustain(0.5)
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Degrade with ?
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Postfix ? randomly drops events at the marked element with 50% probability.
+// "bd hh? sd hh?" plays the snare and kick reliably; the hi-hats appear
+// roughly half the time, randomly per cycle. Great for adding human feel.
+
+def example_degrade() {
+    print("\n=== Section 3: \"bd hh? sd hh?\" — humanised hi-hats ===\n")
+    let pat <- s("bd hh? sd hh?")
+    play(pat, 6.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — Replicate with !N
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Postfix !N is like *N but repeats the element across N parent slots
+// instead of squeezing them into one. "bd!3 sd" expands to "bd bd bd sd"
+// — four equal slots, three kicks then a snare.
+
+def example_replicate() {
+    print("\n=== Section 4: \"bd!3 sd\" — three kicks then a snare ===\n")
+    let pat <- s("bd!3 sd")
+    play(pat, 4.0)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-03: Mini-Notation Advanced\n\n")
+    example_alternation()
+    example_alternation_in_sequence()
+    example_elongation()
+    example_degrade()
+    example_replicate()
+    print("\nDone!\n")
+}

--- a/tutorials/daStrudel/daStrudel_04_time_manipulation.das
+++ b/tutorials/daStrudel/daStrudel_04_time_manipulation.das
@@ -1,0 +1,115 @@
+// Tutorial DASTRUDEL-04: Time Manipulation
+//
+// This tutorial covers:
+//   - fast(N): squeeze N copies of the pattern into one cycle
+//   - slow(N): stretch one copy of the pattern over N cycles
+//   - rev: reverse event positions within each cycle
+//   - hurry(N): like fast(N), but also pitch-shifts samples up
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_04_time_manipulation.das
+
+options gen2
+options indenting = 4
+options persistent_heap
+
+require strudel/strudel public
+require strudel/strudel_player
+require audio/audio_boost
+require daslib/fio
+
+def play(var pat : Pattern; seconds : float = 4.0; cps : double = 0.5lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (float(get_time_usec(t0)) / 1000000.0 < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — fast(N): denser, faster
+// ──────────────────────────────────────────────────────────────────────────
+//
+// fast(2) repeats the pattern twice per cycle. Internally it scales the
+// query span by N before passing it to the inner pattern, then divides
+// every returned hap's timing back by N.
+
+def example_fast() {
+    print("=== Section 1: fast(2) — pattern plays twice per cycle ===\n")
+    let pat <- s("c4 e4 g4 c5") |> fast(2.0lf)
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — slow(N): sparser, slower
+// ──────────────────────────────────────────────────────────────────────────
+//
+// slow(N) is exactly fast(1/N). One full pass of the pattern now takes N
+// cycles. Useful for stretching melodies or making slow LFO-style patterns.
+
+def example_slow() {
+    print("\n=== Section 2: slow(2) — pattern takes 2 cycles to complete ===\n")
+    let pat <- s("bd sd hh cp") |> slow(2.0lf)
+    play(pat, 6.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — rev: reverse the cycle
+// ──────────────────────────────────────────────────────────────────────────
+//
+// rev mirrors the query span within each cycle, queries the inner pattern
+// at the mirrored position, then mirrors the results back. The result:
+// "c4 e4 g4 c5" plays backward as "c5 g4 e4 c4". Per-cycle reversal — not
+// a global reverse. Combine with jux for instant stereo widening (see
+// tutorial 06: combinators).
+
+def example_rev() {
+    print("\n=== Section 3: rev — \"c4 e4 g4 c5\" played backward ===\n")
+    let pat <- note("c4 e4 g4 c5", "sine") |> sustain(0.4) |> rev
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — hurry(N): fast plus pitch shift
+// ──────────────────────────────────────────────────────────────────────────
+//
+// hurry(N) speeds time up by N (like fast) AND multiplies the per-event
+// playback `speed` by N. For sample-based sounds this lifts pitch by
+// log2(N) octaves. Hear: hurry(2) doubles tempo and pitches an octave up.
+
+def example_hurry() {
+    print("\n=== Section 4: hurry(2) — twice as fast and an octave higher ===\n")
+    let pat <- s("c3 e3 g3 c4") |> hurry(2.0lf)
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 5 — The time algebra: composing transforms
+// ──────────────────────────────────────────────────────────────────────────
+//
+// All four operate on the SAME thing — the query timeline. They compose
+// freely: rev(slow(2, p)) reverses a slowed pattern; fast(2, rev(p)) plays
+// the reversed pattern twice per cycle. Order matters, but the result is
+// always another Pattern.
+
+def example_composition() {
+    print("\n=== Section 5: rev |> slow(2) — reversed and stretched ===\n")
+    let pat <- note("c4 e4 g4 b4", "sine") |> sustain(0.4) |> rev |> slow(2.0lf)
+    play(pat, 6.0)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-04: Time Manipulation\n\n")
+    example_fast()
+    example_slow()
+    example_rev()
+    example_hurry()
+    example_composition()
+    print("\nDone!\n")
+}

--- a/tutorials/daStrudel/daStrudel_05_euclidean_rhythms.das
+++ b/tutorials/daStrudel/daStrudel_05_euclidean_rhythms.das
@@ -1,0 +1,128 @@
+// Tutorial DASTRUDEL-05: Euclidean Rhythms
+//
+// This tutorial covers:
+//   - euclid(pat, k, n): play pat at k evenly-spaced onsets across n steps
+//   - The Bjorklund algorithm and why it sounds "musical"
+//   - Polyrhythm: stacking euclid patterns with different (k, n) ratios
+//   - Why this codebase uses euclid(pat, k, n) instead of bd(k,n) mini-notation
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_05_euclidean_rhythms.das
+
+options gen2
+options indenting = 4
+options persistent_heap
+
+require strudel/strudel public
+require strudel/strudel_player
+require audio/audio_boost
+require daslib/fio
+
+def play(var pat : Pattern; seconds : float = 4.0; cps : double = 0.5lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (float(get_time_usec(t0)) / 1000000.0 < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — bjorklund(k, n): the underlying rhythm
+// ──────────────────────────────────────────────────────────────────────────
+//
+// bjorklund(3, 8) returns [x . . x . . x .] — three onsets distributed as
+// evenly as possible across eight steps. This is the algorithm Toussaint
+// showed maps onto traditional rhythms from many cultures (the Cuban
+// tresillo (3,8), the Cumbia (3,4), the Bossa-Nova (3,8) rotated, etc.).
+
+def example_bjorklund_print() {
+    print("=== Section 1: bjorklund(3, 8) — print the raw pattern ===\n")
+    let r <- bjorklund(3, 8)
+    print("  ")
+    for (b in r) {
+        let glyph = b ? "x" : "."
+        print("{glyph} ")
+    }
+    print("\n")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — euclid(pat, k, n): kick on the Euclidean grid
+// ──────────────────────────────────────────────────────────────────────────
+//
+// euclid(pat, k, n) speeds the pattern up by n, then keeps only the haps
+// that fall on the k Bjorklund onsets. The classic (3, 8) "tresillo" kick
+// pattern is one line of code.
+
+def example_tresillo() {
+    print("\n=== Section 2: euclid(bd, 3, 8) — Cuban tresillo ===\n")
+    let pat <- atom("bd") |> euclid(3, 8)
+    play(pat, 6.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Other classic Euclidean rhythms
+// ──────────────────────────────────────────────────────────────────────────
+//
+// (5, 8)  — Cumbia / West-African bell
+// (5, 16) — Bossa-Nova clave (with rotation)
+// (7, 8)  — dense, almost-straight rhythm
+// (3, 4)  — three-against-four feel
+
+def example_clave_family() {
+    print("\n=== Section 3: euclid(5, 8) — Cumbia bell pattern ===\n")
+    let pat <- atom("bd") |> euclid(5, 8)
+    play(pat, 6.0)
+
+    print("\n=== Section 3b: euclid(7, 8) — dense, near-straight ===\n")
+    let pat2 <- atom("hh") |> euclid(7, 8)
+    play(pat2, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — Polyrhythm: stack patterns with different (k, n) ratios
+// ──────────────────────────────────────────────────────────────────────────
+//
+// stack() layers patterns simultaneously. Stack two Euclidean patterns
+// whose n values share no common factor and you get a true polyrhythm:
+// here a 3-against-8 kick under a 5-against-8 hat — the cycle aligns
+// every cycle (both are length 8) but the onsets weave.
+
+def example_polyrhythm() {
+    print("\n=== Section 4: euclid(3,8) kick + euclid(5,8) hi-hat ===\n")
+    let pat <- stack([
+        atom("bd") |> euclid(3, 8),
+        atom("hh") |> euclid(5, 8)
+    ])
+    play(pat, 6.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// A note on syntax
+// ──────────────────────────────────────────────────────────────────────────
+//
+// In the original Tidal/Strudel mini-notation, "bd(3,8)" is the inline form
+// for euclid. THIS daStrudel build does not parse parentheses inside
+// mini-notation — you call euclid(pat, k, n) as a normal function. The
+// fluent pipe style stays compact:
+//   atom("bd") |> euclid(3, 8)
+//   s("bd sd") |> euclid(5, 8)
+//
+// Rotation (Tidal's `bd(3,8,1)`, `euclidRot`) is not yet exposed as a
+// standalone function in this build. Achieve it for now by reordering
+// elements inside the pattern fed to euclid, or with rev/slow chains.
+
+[export]
+def main() {
+    print("DASTRUDEL-05: Euclidean Rhythms\n\n")
+    example_bjorklund_print()
+    example_tresillo()
+    example_clave_family()
+    example_polyrhythm()
+    print("\nDone!\n")
+}

--- a/tutorials/daStrudel/daStrudel_06_stacking_combining.das
+++ b/tutorials/daStrudel/daStrudel_06_stacking_combining.das
@@ -1,0 +1,113 @@
+// Tutorial DASTRUDEL-06: Stacking & Combining
+//
+// This tutorial covers structural combinators that build a single Pattern
+// out of several smaller ones:
+//   - stack(...)       : play patterns simultaneously (vertical layering)
+//   - cat(...)         : play patterns one cycle after another (horizontal sequencing)
+//   - layer(...)       : transform the SAME pattern several ways and stack the results
+//   - superimpose(fn)  : overlay a transformed copy of a pattern on top of itself
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_06_stacking_combining.das
+
+options gen2
+options indenting = 4
+
+require strudel/strudel public
+require strudel/strudel_player public
+require audio/audio_boost
+require daslib/fio
+
+// ──────────────────────────────────────────────────────────────────────────
+// Minimal playback harness — same as examples/daStrudel/features/feature_common.das
+// (inlined here so the tutorial stands on its own).
+// ──────────────────────────────────────────────────────────────────────────
+
+def play(var pat : Pattern; cps : double = 0.5lf; seconds : double = 4.0lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (double(get_time_usec(t0)) / 1000000.0lf < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — stack: play multiple patterns at the same time
+// ──────────────────────────────────────────────────────────────────────────
+//
+// stack accepts an array of patterns. Each one runs in parallel; their
+// events are merged into the same cycle. Use stack to combine independent
+// voices (bass + lead + drums).
+
+def example_stack() {
+    print("\n=== Section 1: stack ===\n")
+    let pat <- stack([
+        note("c3 e3 g3 c4", "sine") |> sustain(0.5),
+        note("c5 ~ ~ g4 ~ ~ e4 ~", "triangle") |> sustain(0.3) |> gain(0.4)
+    ])
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — cat: sequence patterns across cycles
+// ──────────────────────────────────────────────────────────────────────────
+//
+// With N patterns, pattern i plays during cycle (i mod N), each stretched
+// to fill exactly one cycle. Use cat to build longer arrangements out of
+// short building blocks.
+
+def example_cat() {
+    print("\n=== Section 2: cat ===\n")
+    let pat <- cat([
+        note("c4 e4 g4 c5", "sine") |> sustain(0.4),
+        note("c5 g4 e4 c4", "sine") |> sustain(0.4),
+        note("c4 e4 g4 b4", "sine") |> sustain(0.4)
+    ])
+    play(pat, 0.5lf, 6.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — layer: stack transforms of one base pattern
+// ──────────────────────────────────────────────────────────────────────────
+//
+// layer takes an array of already-built patterns AND a base pattern, and
+// stacks them all. The idiom is to derive each layer from the same base
+// (root + transposed copies) to build chords from a melody.
+
+def example_layer_chord() {
+    print("\n=== Section 3: layer (build a triad from a melody) ===\n")
+    let pat <- layer([
+        note("c4 e4 g4 c5", "sine") |> sustain(0.4) |> transpose(4.0),  // major third on top
+        note("c4 e4 g4 c5", "sine") |> sustain(0.4) |> transpose(7.0)   // perfect fifth on top
+    ], note("c4 e4 g4 c5", "sine") |> sustain(0.4))                      // root
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — superimpose: overlay a transformed copy of a pattern
+// ──────────────────────────────────────────────────────────────────────────
+//
+// superimpose(pat, fn) is equivalent to stack([pat, fn(pat)]) but reads
+// more naturally in a pipe. Here we add a faster octave-up echo on top.
+
+def example_superimpose() {
+    print("\n=== Section 4: superimpose ===\n")
+    let pat <- superimpose(note("c4 e4 g4 c5", "sine") |> sustain(0.4),
+                           @(p) => gain(fast(transpose(p, 12.0), 2.0lf), 0.4))
+    play(pat, 0.5lf)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-06: Stacking & Combining\n")
+    example_stack()
+    example_cat()
+    example_layer_chord()
+    example_superimpose()
+    print("\nDone.\n")
+}

--- a/tutorials/daStrudel/daStrudel_07_per_voice_fx.das
+++ b/tutorials/daStrudel/daStrudel_07_per_voice_fx.das
@@ -1,0 +1,118 @@
+// Tutorial DASTRUDEL-07: Per-Voice FX & Transforming Combinators
+//
+// This tutorial covers combinators that take a *transform function* and
+// apply it to a copy of the pattern, producing a richer texture:
+//   - jux(pat, fn)       : original goes left, fn(pat) goes right (stereo widening)
+//   - off(pat, t, fn)    : delayed copy of fn(pat), offset by t cycles (canon)
+//   - chunk(pat, n, fn)  : apply fn to every n-th chunk in turn
+//
+// It also introduces daslang's *per-voice FX* (phaser, tremolo, compressor,
+// shape) which differ from typical live-coding systems where these effects
+// are placed on a shared bus. In daslang each playing voice carries its own
+// FX chain — the FX run BEFORE the voices are mixed into the orbit, so
+// per-note timbral variation is possible.
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_07_per_voice_fx.das
+
+options gen2
+options indenting = 4
+
+require strudel/strudel public
+require strudel/strudel_player public
+require audio/audio_boost
+require daslib/fio
+
+def play(var pat : Pattern; cps : double = 0.5lf; seconds : double = 4.0lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (double(get_time_usec(t0)) / 1000000.0lf < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — jux: stereo splitting via a transform
+// ──────────────────────────────────────────────────────────────────────────
+//
+// jux duplicates the pattern, sends the original to the left channel and
+// the transformed copy to the right. Common transforms: rev (reverse) and
+// transpose (shift pitch). The lambda has type @(Pattern) => Pattern.
+
+def example_jux_rev() {
+    print("\n=== Section 1a: jux + rev (left = forward, right = reversed) ===\n")
+    let pat <- jux(note("c4 e4 g4 c5", "sine") |> sustain(0.4), @(p) => rev(p))
+    play(pat, 0.5lf)
+}
+
+def example_jux_transpose() {
+    print("\n=== Section 1b: jux + transpose(7) (left = root, right = fifth above) ===\n")
+    let pat <- jux(note("c4 e4 g4 c5", "sine") |> sustain(0.4),
+                   @(p) => transpose(p, 7.0))
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — off: canon, delayed transformed copy
+// ──────────────────────────────────────────────────────────────────────────
+//
+// off(pat, time, fn) plays the original AND a copy of fn(pat) delayed by
+// `time` cycles. With time = 0.25 and a transpose-up-an-octave transform,
+// you get a classic canon at the octave.
+
+def example_off_canon() {
+    print("\n=== Section 2: off — canon at the octave, 1/4 cycle later ===\n")
+    let pat <- off(note("c4 e4 g4 b4", "sine") |> sustain(0.4), 0.25lf,
+                   @(p) => transpose(p, 12.0))
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — chunk: apply a transform to one n-th of the pattern at a time
+// ──────────────────────────────────────────────────────────────────────────
+//
+// chunk(pat, n, fn) splits each cycle into n equal slices and applies fn
+// to slice 0 on cycle 0, slice 1 on cycle 1, etc. Below, slices take turns
+// playing twice as fast.
+
+def example_chunk_fast() {
+    print("\n=== Section 3: chunk — each quarter in turn plays twice as fast ===\n")
+    let pat <- chunk(note("c4 e4 g4 c5", "sine") |> sustain(0.4), 4,
+                     @(p) => fast(p, 2.0lf))
+    play(pat, 0.5lf, 6.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — per-voice FX: phaser
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Per-voice FX — phaser, tremolo, compressor, shape — are baked into each
+// playing voice. This is a daslang divergence from systems where these are
+// global bus effects. Because the FX live with the voice, two simultaneous
+// notes in a single stack can carry DIFFERENT phaser rates without leaking
+// into each other.
+
+def example_per_voice_phaser() {
+    print("\n=== Section 4: per-voice phaser at two different rates ===\n")
+    let pat <- stack([
+        note("c4", "sawtooth") |> sustain(1.0) |> phaser(0.5) |> gain(0.4),  // slow sweep
+        note("g4", "sawtooth") |> sustain(1.0) |> phaser(2.0) |> gain(0.4)   // fast sweep
+    ])
+    play(pat, 0.5lf, 6.0lf)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-07: Per-Voice FX & Combinators\n")
+    example_jux_rev()
+    example_jux_transpose()
+    example_off_canon()
+    example_chunk_fast()
+    example_per_voice_phaser()
+    print("\nDone.\n")
+}

--- a/tutorials/daStrudel/daStrudel_08_effects_filters.das
+++ b/tutorials/daStrudel/daStrudel_08_effects_filters.das
@@ -1,0 +1,121 @@
+// Tutorial DASTRUDEL-08: Effects & Filters
+//
+// daslang's strudel splits effects into two groups:
+//
+//   Per-orbit bus FX     — room (reverb), delay, chorus
+//                          one shared instance per orbit, voices send wet/dry
+//   Per-voice FX         — lpf, hpf, phaser, tremolo, compressor, shape, crush
+//                          baked into each individual voice
+//
+// Use orbit(N) to route a pattern to a specific bus so each layer can carry
+// its own reverb size and delay time. Use the per-voice setters to colour
+// individual notes.
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_08_effects_filters.das
+
+options gen2
+options indenting = 4
+
+require strudel/strudel public
+require strudel/strudel_player public
+require audio/audio_boost
+require daslib/fio
+
+def play(var pat : Pattern; cps : double = 0.5lf; seconds : double = 4.0lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (double(get_time_usec(t0)) / 1000000.0lf < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — lpf and hpf (per-voice filters)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// lpf(freq) cuts harmonics above `freq` Hz; hpf(freq) cuts below. Compare a
+// muffled sawtooth (lpf 200) against a thin one (hpf 2000).
+
+def example_lpf_hpf() {
+    print("\n=== Section 1: lpf vs hpf on a sawtooth ===\n")
+    let pat_lpf <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> lpf(200.0)
+    play(pat_lpf, 0.5lf, 3.0lf)
+
+    let pat_hpf <- atom("sawtooth") |> note(48.0) |> sustain(1.0) |> hpf(2000.0)
+    play(pat_hpf, 0.5lf, 3.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — room (reverb, per-orbit bus)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// room(amount) sets the wet send to the orbit's reverb bus; roomsize(N)
+// controls the room dimensions. Both live on the bus, so all voices on the
+// same orbit share one reverb instance.
+
+def example_room() {
+    print("\n=== Section 2: dry vs wet reverb ===\n")
+    let pat <- note("c4 ~ c4 ~", "sine") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> room(0.8) |> roomsize(2.0)
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — delay (per-orbit bus)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// delay(amount), delaytime(seconds), delayfeedback(0..1) drive the orbit's
+// delay line. delaytime defaults to a tempo-aware 3/16 cycle (see tutorial
+// 09 for the resolver), so plain `delay(0.5)` already locks to the cps.
+
+def example_delay() {
+    print("\n=== Section 3: delay echo on a pluck ===\n")
+    let pat <- note("c4 ~ e4 ~ g4 ~ c5 ~", "sine") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> delay(0.5) |> delaytime(0.5) |> delayfeedback(0.4)
+    play(pat, 0.5lf, 6.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — phaser (per-voice)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// phaser(rateHz) sweeps a notch through the spectrum at the given rate.
+// Because it is per-voice, every note carries its own phase — two stacked
+// voices stay independent.
+
+def example_phaser() {
+    print("\n=== Section 4: per-voice phaser on a sustained sawtooth ===\n")
+    let pat <- run(8) |> scale("D:pentatonic") |> sound("sawtooth") |> sustain(1.0) |> release(0.5) |> phaser(2.0)
+    play(pat, 0.5lf, 6.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 5 — per-orbit FX busses: two layers, two reverbs
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Different orbits have independent FX instances. Here, orbit 0 gets a
+// tight small room while orbit 1 sits inside a big cathedral.
+
+def example_orbit_busses() {
+    print("\n=== Section 5: two orbits, two reverb sizes ===\n")
+    let pat <- stack([
+        note("c4 ~ e4 ~", "sine") |> attack(0.001) |> decay(0.15) |> sustain(0.0) |> release(0.01) |> room(0.8) |> roomsize(0.5) |> orbit(0),
+        note("c3", "triangle") |> attack(0.5) |> decay(0.2) |> sustain(0.6) |> release(0.5) |> room(0.8) |> roomsize(8.0) |> orbit(1)
+    ])
+    play(pat, 0.5lf, 6.0lf)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-08: Effects & Filters\n")
+    example_lpf_hpf()
+    example_room()
+    example_delay()
+    example_phaser()
+    example_orbit_busses()
+    print("\nDone.\n")
+}

--- a/tutorials/daStrudel/daStrudel_09_adsr_envelopes.das
+++ b/tutorials/daStrudel/daStrudel_09_adsr_envelopes.das
@@ -1,0 +1,134 @@
+// Tutorial DASTRUDEL-09: ADSR & Envelope Shaping
+//
+// An ADSR envelope shapes a note's amplitude over time:
+//   Attack  — time from key-down to peak
+//   Decay   — time to drop from peak to the sustain level
+//   Sustain — held level (0..1) while the note is on
+//   Release — time to fade to silence after key-up
+//
+// daslang's strudel uses TEMPO-AWARE defaults: each ADSR field defaults to
+// a -1 sentinel meaning "unset". A resolver applies sensible defaults at
+// playback time:
+//   * nothing set            → held tone (sustain = 1, tiny edges)
+//   * decay set, no sustain  → percussion (sustain = 0)
+//   * sustain set explicitly → always wins
+// This lets `note(...).s("sine")` ring out for the full note, instead of
+// decaying to silence in 50ms like older defaults.
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_09_adsr_envelopes.das
+
+options gen2
+options indenting = 4
+
+require strudel/strudel public
+require strudel/strudel_player public
+require audio/audio_boost
+require daslib/fio
+
+def play(var pat : Pattern; cps : double = 0.5lf; seconds : double = 4.0lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (double(get_time_usec(t0)) / 1000000.0lf < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Default envelope: held tone
+// ──────────────────────────────────────────────────────────────────────────
+//
+// With no ADSR setters at all, the resolver picks a held-tone envelope:
+// quick attack, full sustain, short release. The note rings for its full
+// scheduled duration.
+
+def example_default_held() {
+    print("\n=== Section 1: default envelope (held tone) ===\n")
+    let pat <- note("c4 e4 g4 c5", "sine")
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Plucky percussion: decay only
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Set decay alone and the resolver assumes a percussive envelope: sustain
+// drops to 0, so each note "plucks" then decays away. This is the idiom
+// for short, rhythmic synth blips.
+
+def example_pluck() {
+    print("\n=== Section 2: pluck — decay only, sustain auto-zero ===\n")
+    let pat <- note("c4 e4 g4 c5", "sine") |> decay(0.15)
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Explicit ADSR: pad with slow attack and release
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Setting all four fields gives full manual control. A pad-style envelope
+// uses a long attack so the note swells in, plus a long release so it
+// fades out gradually after key-up.
+
+def example_pad() {
+    print("\n=== Section 3: pad — explicit slow attack and release ===\n")
+    let pat <- note("c3", "triangle") |> attack(0.5) |> decay(0.2) |> sustain(0.6) |> release(0.5)
+    play(pat, 0.25lf, 6.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — Tempo-aware delay defaults
+// ──────────────────────────────────────────────────────────────────────────
+//
+// The same "unset sentinel + resolver" idea applies to delaytime. Plain
+// delay(x) without delaytime(...) derives delaytime from delaysync (cycles)
+// and the current cps. The 3/16 cycle default gives a dotted-eighth feel
+// that automatically tracks tempo changes.
+//
+// Below: same pattern at two different cps values — the echo timing
+// follows the tempo.
+
+def example_tempo_delay() {
+    print("\n=== Section 4a: tempo-aware delay at cps = 0.5 ===\n")
+    let pat_slow <- note("c4 ~ e4 ~ g4 ~", "sine") |> decay(0.15) |> delay(0.6)
+    play(pat_slow, 0.5lf, 4.0lf)
+
+    print("\n=== Section 4b: same pattern at cps = 1.0 — echoes track tempo ===\n")
+    let pat_fast <- note("c4 ~ e4 ~ g4 ~", "sine") |> decay(0.15) |> delay(0.6)
+    play(pat_fast, 1.0lf, 4.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 5 — Velocity via gain on top of ADSR
+// ──────────────────────────────────────────────────────────────────────────
+//
+// gain multiplies the envelope output. Use it for a velocity curve over a
+// pattern: alternating loud and soft hits while the envelope shape stays
+// constant.
+
+def example_velocity_curve() {
+    print("\n=== Section 5: velocity (gain) on top of a fixed envelope ===\n")
+    let pat <- stack([
+        note("c4", "sine") |> decay(0.15) |> gain(0.9),
+        note("e4", "sine") |> decay(0.15) |> gain(0.4),
+        note("g4", "sine") |> decay(0.15) |> gain(0.7),
+        note("c5", "sine") |> decay(0.15) |> gain(0.3)
+    ])
+    play(pat, 0.5lf)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-09: ADSR & Envelope Shaping\n")
+    example_default_held()
+    example_pluck()
+    example_pad()
+    example_tempo_delay()
+    example_velocity_curve()
+    print("\nDone.\n")
+}

--- a/tutorials/daStrudel/daStrudel_10_scales_music_theory.das
+++ b/tutorials/daStrudel/daStrudel_10_scales_music_theory.das
@@ -1,0 +1,132 @@
+// Tutorial DASTRUDEL-10: Scales & Music Theory
+//
+// Scales let you write melodies in terms of degrees (0, 1, 2, ...) instead
+// of absolute pitches. Combined with a scale name like "C4:major" or
+// "D:dorian", the same degree pattern produces wildly different moods.
+//
+// Topics:
+//   - n("0 2 4") |> scale("C4:major")        — degrees against a scale
+//   - scale_pattern("0 1 2", "C4:minor")     — shorthand: numeric pattern + scale + sound
+//   - modes: dorian, mixolydian, lydian, phrygian, locrian
+//   - transposition by switching the scale root or by transpose(semitones)
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_10_scales_music_theory.das
+
+options gen2
+options indenting = 4
+
+require strudel/strudel public
+require strudel/strudel_player public
+require audio/audio_boost
+require daslib/fio
+
+def play(var pat : Pattern; cps : double = 0.5lf; seconds : double = 4.0lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (double(get_time_usec(t0)) / 1000000.0lf < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Major vs minor: same degrees, different mood
+// ──────────────────────────────────────────────────────────────────────────
+//
+// scale_pattern(notation, scale_def, sound) is the shorthand for
+//   n(notation) |> scale(scale_def) |> sound(sound)
+// Run the same degree sequence "0 2 4 6" against C major and C minor and
+// hear how the third and sixth shift the mood.
+
+def example_major_vs_minor() {
+    print("\n=== Section 1: major vs minor on the same degrees ===\n")
+    let pat <- stack([
+        scale_pattern("0 2 4 6", "C4:major") |> decay(0.2) |> gain(0.5),
+        scale_pattern("0 2 4 6", "C4:minor", "sawtooth") |> sustain(0.3) |> release(0.2) |> gain(0.3) |> lpf(2000.0)
+    ])
+    play(pat, 0.5lf, 4.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Pentatonic: only "safe" notes
+// ──────────────────────────────────────────────────────────────────────────
+//
+// "C4:major:pentatonic" maps degrees 0..4 onto C, D, E, G, A — a five-note
+// scale with no semitone clashes, so any degree pattern always sounds
+// consonant. Useful when you want guaranteed-pretty arpeggios.
+
+def example_pentatonic() {
+    print("\n=== Section 2: C major pentatonic — degrees 0..4 ===\n")
+    let pat <- scale_pattern("0 1 2 3 4", "C4:major:pentatonic") |> decay(0.1) |> release(0.2)
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Modes: same root, different intervals
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Modes are seven-note scales that share the white-keys interval pattern
+// but start on a different degree. dorian (minor with raised 6th) sounds
+// jazzy/folksy; mixolydian (major with lowered 7th) sounds bluesy.
+
+def example_modes() {
+    print("\n=== Section 3a: D dorian — minor with a bright 6th ===\n")
+    let dorian_pat <- scale_pattern("0 1 2 3 4 5 6 7", "D4:dorian") |> decay(0.15) |> release(0.2)
+    play(dorian_pat, 0.5lf, 5.0lf)
+
+    print("\n=== Section 3b: G mixolydian — major with a flat 7th ===\n")
+    let mixo_pat <- scale_pattern("0 1 2 3 4 5 6 7", "G4:mixolydian") |> decay(0.15) |> release(0.2)
+    play(mixo_pat, 0.5lf, 5.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — Transposition
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Two ways to transpose:
+//   1. Change the scale root: "C4:major" → "E4:major" — the degrees stay
+//      the same but the actual pitches shift.
+//   2. transpose(semitones) — applied after pitch resolution, shifts every
+//      note by the given number of semitones.
+
+def example_transpose() {
+    print("\n=== Section 4: melody played in C, then transposed up a fifth ===\n")
+    let pat <- stack([
+        scale_pattern("0 2 4 2", "C4:major") |> decay(0.15) |> gain(0.5),
+        scale_pattern("0 2 4 2", "C4:major") |> transpose(7.0) |> decay(0.15) |> gain(0.5)
+    ])
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 5 — Two octaves, same pentatonic
+// ──────────────────────────────────────────────────────────────────────────
+//
+// You can stack two scale_pattern voices at different octaves to build a
+// bass + melody pair from one scale. Switch the root (C4 vs C5) to move
+// between octaves while keeping the degree pattern.
+
+def example_two_octaves() {
+    print("\n=== Section 5: bass + lead in C major pentatonic, two octaves ===\n")
+    let pat <- stack([
+        scale_pattern("0 2 4 3", "C4:major:pentatonic", "sawtooth") |> sustain(0.3) |> release(0.1) |> lpf(500.0) |> gain(0.4),
+        scale_pattern("4 2 3 0", "C5:major:pentatonic") |> decay(0.05) |> release(0.2) |> delay(0.3) |> delayfeedback(0.3) |> gain(0.5)
+    ])
+    play(pat, 0.5lf, 5.0lf)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-10: Scales & Music Theory\n")
+    example_major_vs_minor()
+    example_pentatonic()
+    example_modes()
+    example_transpose()
+    example_two_octaves()
+    print("\nDone.\n")
+}

--- a/tutorials/daStrudel/daStrudel_11_synthesis.das
+++ b/tutorials/daStrudel/daStrudel_11_synthesis.das
@@ -1,0 +1,115 @@
+// Tutorial DASTRUDEL-11: Synthesis
+//
+// This tutorial covers:
+//   - Oscillator sources via s("sine"|"sawtooth"|"square"|"triangle"|"supersaw")
+//   - Supersaw (seven detuned saws) for thick pad sounds
+//   - Noise sources ("white", "pink", "brown")
+//   - FM synthesis with fm() and fmh() (modulation index and harmonicity)
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_11_synthesis.das
+
+options gen2
+options indenting = 4
+options persistent_heap
+
+require strudel/strudel public
+require strudel/strudel_player
+require audio/audio_boost
+require daslib/fio
+
+// Tiny harness — feed a pattern to the main-thread player for `seconds` seconds.
+def play(var pat : Pattern; seconds : float = 4.0; cps : double = 0.5lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (float(get_time_usec(t0)) / 1000000.0 < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Basic oscillators
+// ──────────────────────────────────────────────────────────────────────────
+//
+// s("name") picks the oscillator. Seven are built in:
+//   - sine:      pure tone, no harmonics
+//   - triangle:  soft flute-like, odd harmonics, gentle roll-off
+//   - square:    hollow woody, odd harmonics only
+//   - sawtooth:  bright and buzzy, all harmonics
+//   - supersaw:  five detuned sawtooths stacked, fat and wide
+//   - pink:      pink noise (-3 dB/octave)
+//   - white:     white noise (flat spectrum)
+
+def example_oscillators() {
+    print("=== Section 1: Oscillators (sine, triangle, square, sawtooth) ===\n")
+    // Alternate one oscillator per cycle with <> — angle brackets step per cycle.
+    let pat <- s("<sine triangle square sawtooth>") |> note(48.0) |> attack(0.02) |> decay(0.1) |> sustain(0.7) |> release(0.3) |> lpf(2000.0)
+    play(pat, 8.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Supersaw (thick pad sound)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// The supersaw voice is seven detuned sawtooth oscillators stacked — the
+// classic "trance" pad. It is much wider and fatter than a single saw. A
+// low-pass filter tames the top end for a warm tone.
+
+def example_supersaw() {
+    print("\n=== Section 2: Supersaw chord ===\n")
+    // C minor triad voiced across two octaves for extra depth.
+    let pat <- note("c3,eb3,g3,c4", "supersaw") |> attack(0.1) |> decay(0.1) |> sustain(0.8) |> release(0.6) |> lpf(3500.0)
+    play(pat, 4.0, 0.25lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Noise sources
+// ──────────────────────────────────────────────────────────────────────────
+//
+// "white" and "pink" are pitch-less noise generators. Pink noise has more
+// energy in the low end — perceptually "warmer" than white. Filter them
+// to sculpt specific colours (ocean, wind, static, hi-hat).
+
+def example_noise() {
+    print("\n=== Section 3: Pink noise filtered into a pad ===\n")
+    let pat <- atom("pink") |> sustain(1.0) |> lpf(400.0) |> gain(0.4)
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — FM synthesis (fm = index, fmh = harmonicity)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// FM modulates the sine carrier's frequency with a second sine. Two knobs:
+//   - fm(index):       modulation depth — higher = more harmonics
+//   - fmh(harmonicity): ratio of modulator to carrier frequency
+// Integer fmh values (1, 2, 3...) are "musical"; non-integer values give
+// inharmonic, bell- or clang-like timbres.
+
+def example_fm_bells() {
+    print("\n=== Section 4a: FM bells (fm=1, fmh=7) ===\n")
+    let pat <- note("c5", "sine") |> fm(1.0) |> fmh(7.0) |> decay(0.3) |> release(0.8)
+    play(pat, 4.0)
+}
+
+def example_fm_gentle() {
+    print("\n=== Section 4b: Gentle FM (fm=2, fmh=2) ===\n")
+    let pat <- note("<c3 e3 g3 c4>", "sine") |> fm(2.0) |> fmh(2.0) |> attack(0.02) |> decay(0.2) |> sustain(0.6) |> release(0.3)
+    play(pat, 4.0)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-11: Synthesis\n\n")
+    example_oscillators()
+    example_supersaw()
+    example_noise()
+    example_fm_bells()
+    example_fm_gentle()
+    print("\nDone!\n")
+}

--- a/tutorials/daStrudel/daStrudel_12_samples.das
+++ b/tutorials/daStrudel/daStrudel_12_samples.das
@@ -1,0 +1,132 @@
+// Tutorial DASTRUDEL-12: Samples
+//
+// This tutorial covers:
+//   - Loading audio files into named sample banks with strudel_load_sound
+//   - Playing samples with s("bd sd hh cp") — mini-notation drum patterns
+//   - Sample variations: s("bd:0 bd:1") picks indexed variants
+//   - Pitch-shifting samples with speed() (2.0 = one octave up)
+//   - Decoding a single file with load_audio_file
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_12_samples.das
+
+options gen2
+options indenting = 4
+options persistent_heap
+
+require strudel/strudel public
+require strudel/strudel_player
+require strudel/strudel_samples
+require audio/audio_boost
+require daslib/fio
+
+let MEDIA = "{get_das_root()}/examples/media"
+
+def play(var pat : Pattern; seconds : float = 6.0; cps : double = 0.5lf; setup : block = $ {}) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        invoke(setup)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (float(get_time_usec(t0)) / 1000000.0 < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+def load_drum_bank() {
+    // Each "bd" / "sd" / "hh" / "cp" is a folder of audio files. Files are
+    // sorted alphabetically and become variations indexed :0, :1, :2, ...
+    strudel_load_sound("{MEDIA}/drums/bd", "bd")
+    strudel_load_sound("{MEDIA}/drums/sd", "sd")
+    strudel_load_sound("{MEDIA}/drums/hh", "hh")
+    strudel_load_sound("{MEDIA}/drums/cp", "cp")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Drum patterns from a sample bank
+// ──────────────────────────────────────────────────────────────────────────
+//
+// A sample bank is just a directory of folders named after the sounds.
+// strudel_load_sound("path/to/bd", "bd") loads every audio file in the
+// folder; they become variations accessible as bd:0, bd:1, ... in the
+// mini-notation. s("bd sd hh cp") is a classic 4-step drum pattern.
+
+def example_drum_pattern() {
+    print("=== Section 1: Drum pattern (bd sd hh cp) ===\n")
+    let pat <- s("bd sd hh cp") |> gain(0.7)
+    play(pat, 6.0, 0.5lf) {
+        load_drum_bank()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Sample variations with :N
+// ──────────────────────────────────────────────────────────────────────────
+//
+// When a sound folder has multiple files, the :N suffix picks a specific
+// variation. s("bd:0") uses the first file, s("bd:1") the second, and so on.
+// Omitting the suffix (just "bd") defaults to :0.
+
+def example_variations() {
+    print("\n=== Section 2: Variations (bd:0, bd:1) ===\n")
+    // Alternate two kick variations per cycle.
+    let pat <- s("bd:0 bd:1 bd:0 bd:1") |> gain(0.7)
+    play(pat, 4.0, 0.5lf) {
+        load_drum_bank()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Pitch-shifting with speed()
+// ──────────────────────────────────────────────────────────────────────────
+//
+// speed() scales the playback rate of a sample. speed(2.0) is one octave up
+// and twice as fast (tape-style pitch shift). This only affects sample
+// playback — oscillators (sine, saw, ...) ignore speed().
+
+def example_speed_shift() {
+    print("\n=== Section 3: Pitch shift via speed() ===\n")
+    // Alternate normal / pitched-up kicks each step.
+    let pat <- s("bd bd bd bd") |> speed(1.0) |> gain(0.6)
+    play(pat, 3.0, 0.5lf) {
+        load_drum_bank()
+    }
+    let pitched <- s("bd bd bd bd") |> speed(2.0) |> gain(0.6)
+    play(pitched, 3.0, 0.5lf) {
+        load_drum_bank()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — load_audio_file: decode a single file
+// ──────────────────────────────────────────────────────────────────────────
+//
+// load_audio_file decodes one WAV/MP3/FLAC/OGG into a Sample struct so you
+// can inspect channels, sample rate, and frame count without scheduling
+// playback. Empty Sample (length=0) indicates a decode failure.
+
+def example_decode() {
+    print("\n=== Section 4: load_audio_file inspection ===\n")
+    let sample <- load_audio_file("{MEDIA}/drums/bd/BT0A0A7.wav")
+    if (length(sample.data) == 0) {
+        print("  (file not found — skipping)\n")
+        return
+    }
+    print("  channels:    {sample.channels}\n")
+    print("  sample_rate: {sample.sample_rate} Hz\n")
+    print("  frames:      {length(sample.data) / sample.channels}\n")
+    print("  duration:    {float(length(sample.data)) / float(sample.channels * sample.sample_rate):.3f} s\n")
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-12: Samples\n\n")
+    example_drum_pattern()
+    example_variations()
+    example_speed_shift()
+    example_decode()
+    print("\nDone!\n")
+}

--- a/tutorials/daStrudel/daStrudel_13_sf2_soundfont.das
+++ b/tutorials/daStrudel/daStrudel_13_sf2_soundfont.das
@@ -1,0 +1,147 @@
+// Tutorial DASTRUDEL-13: SF2 SoundFont Playback
+//
+// This tutorial covers:
+//   - Loading a General MIDI SoundFont with strudel_load_sf2
+//   - Selecting instruments by GM program name: sf2("piano") / sf2("flute")
+//   - Selecting by MIDI program number: sf2(0) / sf2(40)
+//   - The GM drum map on bank 128: sf2(0) |> sf2_bank(128)
+//   - Per-note expression and velocity: sf2_expression / velocity
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_13_sf2_soundfont.das
+//
+// Requires: a General MIDI .sf2 file (e.g. FluidR3_GM.sf2) under
+// examples/daStrudel/midi_sf2_demo/ — see that folder's README.md for
+// download links. If the SoundFont is missing, SF2 events are silent.
+
+options gen2
+options indenting = 4
+options persistent_heap
+
+require strudel/strudel public
+require strudel/strudel_player
+require audio/audio_boost
+require daslib/fio
+
+def find_sf2() : string {
+    let dir = "{get_das_root()}/examples/daStrudel/midi_sf2_demo"
+    var st : FStat
+    if (stat("{dir}/FluidR3_GM.sf2", st)) {
+        return "{dir}/FluidR3_GM.sf2"
+    }
+    if (stat("{dir}/GeneralUser GS v1.471.sf2", st)) {
+        return "{dir}/GeneralUser GS v1.471.sf2"
+    }
+    if (stat("{dir}/Musyng Kite.sf2", st)) {
+        return "{dir}/Musyng Kite.sf2"
+    }
+    return ""
+}
+
+def play(var pat : Pattern; seconds : float = 6.0; cps : double = 0.5lf; sf2_path : string = "") {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        if (!empty(sf2_path)) {
+            strudel_load_sf2(sf2_path)
+        }
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (float(get_time_usec(t0)) / 1000000.0 < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Instruments by name
+// ──────────────────────────────────────────────────────────────────────────
+//
+// sf2("piano") looks up the GM preset whose name matches. Common names:
+// "piano", "flute", "string_ensemble", "acoustic_bass", "electric_guitar".
+// The built-in name table maps to standard GM program numbers.
+
+def example_instruments(sf2_path : string) {
+    print("=== Section 1: Piano scale ===\n")
+    let pat <- note("c3 d3 e3 f3 g3 a3 b3 c4") |> sf2("piano") |> gain(0.6)
+    play(pat, 8.0, 0.5lf, sf2_path)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Instruments by program number
+// ──────────────────────────────────────────────────────────────────────────
+//
+// sf2(program) takes a GM program number (0..127). Reference:
+//   0   = acoustic grand piano
+//   24  = nylon guitar
+//   40  = violin
+//   56  = trumpet
+//   73  = flute
+//   81  = lead square
+// Useful when you want a specific patch or the name lookup doesn't match.
+
+def example_program_numbers(sf2_path : string) {
+    print("\n=== Section 2: Program numbers (piano=0, flute=73) ===\n")
+    // Stack a piano melody and a flute countermelody.
+    let pat <- stack([
+        note("c4 e4 g4 c5") |> sf2(0) |> gain(0.5),
+        note("g4 a4 e4 g4") |> sf2(73) |> gain(0.5)
+    ])
+    play(pat, 8.0, 0.5lf, sf2_path)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — GM drums (bank 128)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// The GM percussion map lives on bank 128 — every MIDI note number is a
+// different drum sound. Key mappings (octave 2):
+//   c2  = kick (36)          fs2 = closed hi-hat (42)
+//   d2  = snare (38)         as2 = open hi-hat (46)
+//   eb2 = hand clap (39)     cs2 = side stick (37)
+// Use sf2(0) |> sf2_bank(128) to select the drum kit.
+
+def example_drums(sf2_path : string) {
+    print("\n=== Section 3: GM drum kit on bank 128 ===\n")
+    let pat <- note("c2 ~ d2 ~, [fs2 fs2] [fs2 fs2] [fs2 fs2] [fs2 fs2]") |> sf2(0) |> sf2_bank(128) |> gain(0.7)
+    play(pat, 8.0, 0.5lf, sf2_path)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — Expression vs velocity
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Two ways to shape per-note dynamics on SF2 patches:
+//   - velocity(v):       note attack intensity (0..1) — changes timbre
+//   - sf2_expression(e): continuous volume (0..1) — changes level only
+// Gain is the post-mix volume. Velocity + expression together drive
+// realistic phrasing on instruments that respond to both.
+
+def example_expression(sf2_path : string) {
+    print("\n=== Section 4: String pad with expression layer ===\n")
+    let pat <- stack([
+        // Soft strings — low expression
+        note("<[c3,e3,g3] [f3,a3,c4]>") |> sf2("string_ensemble") |> sf2_expression(0.3) |> gain(0.5),
+        // Full strings — high expression
+        note("<[g3,b3,d4] [a3,c4,e4]>") |> sf2("string_ensemble") |> sf2_expression(1.0) |> gain(0.5)
+    ])
+    play(pat, 8.0, 0.5lf, sf2_path)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-13: SF2 SoundFont\n\n")
+    let sf2_path = find_sf2()
+    if (empty(sf2_path)) {
+        print("No SF2 found — place a GM SoundFont under examples/daStrudel/midi_sf2_demo/\n")
+        print("(SF2 events will be silent; tutorial will still run)\n\n")
+    } else {
+        print("Using SoundFont: {sf2_path}\n\n")
+    }
+    example_instruments(sf2_path)
+    example_program_numbers(sf2_path)
+    example_drums(sf2_path)
+    example_expression(sf2_path)
+    print("\nDone!\n")
+}

--- a/tutorials/daStrudel/daStrudel_14_midi_files.das
+++ b/tutorials/daStrudel/daStrudel_14_midi_files.das
@@ -1,0 +1,159 @@
+// Tutorial DASTRUDEL-14: MIDI Files
+//
+// This tutorial covers:
+//   - Parsing MIDI files with load_midi (format 0 and format 1)
+//   - Inspecting tracks, events, and tempo data
+//   - merge_tracks: combining tracks into one sorted event list
+//   - Playback with built-in sample banks via midi_play
+//   - Switching to SF2 synthesis with midi_load_sf2
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_14_midi_files.das
+
+options gen2
+options indenting = 4
+options persistent_heap
+
+require strudel/strudel_midi
+require strudel/strudel_midi_player
+require audio/audio_boost
+require daslib/fio
+
+let MEDIA = "{get_das_root()}/examples/media"
+
+def find_sf2() : string {
+    let dir = "{get_das_root()}/examples/daStrudel/midi_sf2_demo"
+    var st : FStat
+    if (stat("{dir}/FluidR3_GM.sf2", st)) {
+        return "{dir}/FluidR3_GM.sf2"
+    }
+    if (stat("{dir}/GeneralUser GS v1.471.sf2", st)) {
+        return "{dir}/GeneralUser GS v1.471.sf2"
+    }
+    return ""
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Parse a MIDI file and inspect it
+// ──────────────────────────────────────────────────────────────────────────
+//
+// load_midi returns a MidiFile with:
+//   - format:        0 (single track) or 1 (multi-track synchronous)
+//   - ticks_per_qn:  timing resolution — ticks per quarter note
+//   - tracks:        array of MidiTrack, each with an array of MidiEvent
+//
+// Each MidiEvent has tick, kind (MidiEventKind), channel, data1, data2.
+// Tempo events stash microseconds-per-quarter-note in the tempo field.
+
+def example_parse() {
+    print("=== Section 1: Parse Fur Elise ===\n")
+    let path = "{MEDIA}/midi/fur_elise.mid"
+    let midi = load_midi(path)
+    if (length(midi.tracks) == 0) {
+        print("  (file not found — skipping)\n")
+        return
+    }
+    print("  Format:       {midi.format}\n")
+    print("  Ticks per QN: {midi.ticks_per_qn}\n")
+    print("  Tracks:       {length(midi.tracks)}\n")
+    for (i in range(length(midi.tracks))) {
+        print("    Track {i}: {length(midi.tracks[i].events)} events\n")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — merge_tracks and tempo inspection
+// ──────────────────────────────────────────────────────────────────────────
+//
+// merge_tracks collapses all tracks into one stable-sorted stream — easier
+// to iterate for analysis. Here we walk it looking for tempo change events
+// (MIDI meta events) and convert microseconds-per-QN to BPM.
+
+def example_tempo() {
+    print("\n=== Section 2: Tempo events ===\n")
+    let midi = load_midi("{MEDIA}/midi/fur_elise.mid")
+    if (length(midi.tracks) == 0) {
+        print("  (file not found — skipping)\n")
+        return
+    }
+    var merged <- merge_tracks(midi)
+    print("  Merged events: {length(merged)}\n")
+    var found_tempo = false
+    for (evt in merged) {
+        if (evt.kind == MidiEventKind.midi_tempo && evt.tempo > 0) {
+            let bpm = 60000000.0 / float(evt.tempo)
+            print("    Tempo change at tick {evt.tick}: {bpm:.1f} BPM\n")
+            found_tempo = true
+        }
+    }
+    if (!found_tempo) {
+        print("  (no tempo events — defaults to 120 BPM)\n")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Playback with built-in sample banks
+// ──────────────────────────────────────────────────────────────────────────
+//
+// midi_play runs a MIDI file on the audio system's streaming thread. The
+// lifecycle is:
+//   1. midi_load_samples(media_path)  — load piano + drum banks
+//   2. midi_init()                    — spin up the playback thread
+//   3. midi_play(name, path, ...)     — schedule a track (named so we can
+//                                       control it later)
+//   4. midi_stop(name) / midi_shutdown() — stop and tear down
+// Multiple tracks can play at once — each gets its own name.
+
+def example_play_samples() {
+    print("\n=== Section 3: Play with built-in piano samples ===\n")
+    with_audio_system() {
+        midi_load_samples(MEDIA)
+        midi_init()
+        if (midi_play("music", "{MEDIA}/midi/fur_elise.mid", [gain = 0.6, looping = false])) {
+            print("  Playing 6 seconds of Fur Elise (piano samples)...\n")
+            sleep(6000u)
+        } else {
+            print("  (file not found — skipping)\n")
+        }
+        midi_stop("music")
+        midi_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — Play with an SF2 SoundFont backend
+// ──────────────────────────────────────────────────────────────────────────
+//
+// midi_load_sf2 swaps the sample-based backend for a GM SoundFont — every
+// channel's program change now picks a real instrument, and channel 10 uses
+// the SF2 drum kit. This is the highest-quality playback path.
+
+def example_play_sf2() {
+    print("\n=== Section 4: Play with SF2 backend ===\n")
+    let sf2 = find_sf2()
+    if (empty(sf2)) {
+        print("  (no SF2 found — skipping)\n")
+        return
+    }
+    with_audio_system() {
+        midi_load_sf2(sf2)
+        midi_init()
+        if (midi_play("music", "{MEDIA}/midi/Bach_Air_on_G_string_BWV1068.mid", [gain = 1.0, looping = false])) {
+            print("  Playing 8 seconds of Bach Air (SF2)...\n")
+            sleep(8000u)
+        } else {
+            print("  (file not found — skipping)\n")
+        }
+        midi_stop("music")
+        midi_shutdown()
+    }
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-14: MIDI Files\n\n")
+    example_parse()
+    example_tempo()
+    example_play_samples()
+    example_play_sf2()
+    print("\nDone!\n")
+}

--- a/tutorials/daStrudel/daStrudel_15_live_reloading.das
+++ b/tutorials/daStrudel/daStrudel_15_live_reloading.das
@@ -1,0 +1,185 @@
+// Tutorial DASTRUDEL-15: Live-Reloading Patterns
+//
+// This tutorial covers:
+//   - Running daStrudel under daslang-live.exe for instant code reload
+//   - Lifecycle functions: init / update / shutdown
+//   - [live_command] — REST-callable functions for external control
+//   - Preserving player state across reloads via strudel_live
+//   - The persistent byte store: live_store_bytes / live_load_bytes
+//
+// Run (live mode, recommended):
+//   bin/Release/daslang-live.exe tutorials/daStrudel/daStrudel_15_live_reloading.das
+//
+// Also works in standalone mode:
+//   bin/Release/daslang.exe tutorials/daStrudel/daStrudel_15_live_reloading.das
+//
+// In live mode, edit this file and save — the pattern updates without
+// stopping the audio stream. The SID stays the same, the sample bank stays
+// loaded (no decode cost), and any tracked BPM/volume settings survive.
+
+options gen2
+options indenting = 4
+options persistent_heap
+
+require strudel/strudel public
+require strudel/strudel_player
+// strudel_live registers [before_reload]/[after_reload] hooks automatically —
+// just require it and player state (tracks, SID, SF2 data) is preserved.
+require strudel/strudel_live
+require audio/audio_boost
+require live/audio_live
+require live/live_commands
+require live/live_api
+require live_host
+require daslib/fio
+require daslib/json
+require daslib/json_boost
+
+let MEDIA = "{get_das_root()}/examples/media"
+
+// ──────────────────────────────────────────────────────────────────────────
+// Part A — The pattern (edit and save to hot-reload)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Every time this file is saved, daslang-live recompiles and calls init()
+// again. strudel_live saves the player state before reload and restores it
+// after — so the audio thread keeps ticking, but strudel_add_track picks up
+// the newly compiled pattern.
+
+def strudel_main() {
+    // Classic drum pattern — try editing this! Save the file and hear it
+    // change live. Suggested edits:
+    //   s("bd [bd sd] hh [sd cp]")
+    //   s("bd*2 sd*4, hh*8") |> gain(0.8)
+    //   s("bd sd hh cp") |> speed(1.5)
+    strudel_add_track(s("bd [hh hh] sd [hh cp]"))
+    strudel_set_bpm(120.0lf)
+    strudel_play()
+}
+
+def load_samples() {
+    strudel_load_sound("{MEDIA}/drums/bd", "bd")
+    strudel_load_sound("{MEDIA}/drums/sd", "sd")
+    strudel_load_sound("{MEDIA}/drums/hh", "hh")
+    strudel_load_sound("{MEDIA}/drums/cp", "cp")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Part B — Live commands (REST API)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// [live_command] annotations expose functions over HTTP so external tools
+// (or the MCP server's live_command tool) can drive the running script.
+// Call with:
+//   curl -X POST http://localhost:9090/command -d '{"name":"cmd_set_bpm","args":{"bpm":140}}'
+//
+// The input JsonValue is decoded into a struct via from_JV; the return
+// value is serialized back to the caller.
+
+struct CmdBpmArgs {
+    bpm : double = 120.0lf
+}
+
+[live_command(description="Set tempo in BPM")]
+def cmd_set_bpm(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<CmdBpmArgs>)
+    strudel_set_bpm(args.bpm)
+    return JV("bpm set to {args.bpm}")
+}
+
+struct CmdVolumeArgs {
+    volume : float = 1.0
+    time : float = 0.0
+}
+
+[live_command(description="Set master volume (0..1) with optional fade time")]
+def cmd_set_volume(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<CmdVolumeArgs>)
+    strudel_set_volume(args.volume, args.time)
+    return JV("volume set to {args.volume} (fade {args.time}s)")
+}
+
+[live_command(description="Pause playback")]
+def cmd_pause(input : JsonValue?) : JsonValue? {
+    strudel_set_pause(true)
+    return JV("paused")
+}
+
+[live_command(description="Unpause playback")]
+def cmd_unpause(input : JsonValue?) : JsonValue? {
+    strudel_set_pause(false)
+    return JV("unpaused")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Part C — Custom persistent state with live_store_bytes
+// ──────────────────────────────────────────────────────────────────────────
+//
+// strudel_live handles the player, but your own script state also needs to
+// survive a reload. [before_reload] and [after_reload] run at reload time;
+// inside them, use live_store_bytes / live_load_bytes to stash raw bytes.
+// Here we persist a simple reload-counter so we can see reloads happening.
+
+var g_reload_count : int = 0
+
+[before_reload]
+def save_my_state() {
+    var data : array<uint8>
+    data |> resize(4)
+    unsafe { *reinterpret<int?>(addr(data[0])) = g_reload_count; }
+    live_store_bytes("tutorial15_reload_count", data)
+}
+
+[after_reload]
+def restore_my_state() {
+    var data : array<uint8>
+    if (live_load_bytes("tutorial15_reload_count", data) && length(data) >= 4) {
+        unsafe { g_reload_count = *reinterpret<int?>(addr(data[0])); }
+        g_reload_count ++
+        to_log(LOG_INFO, "tutorial15: reload #{g_reload_count}\n")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Lifecycle — daslang-live calls init() once, then update() every frame,
+// then shutdown() on exit. init() also fires after every reload (but the
+// audio system / player already exist, thanks to strudel_live).
+// ──────────────────────────────────────────────────────────────────────────
+
+var asch : AudioSystemChannels
+
+[export]
+def init() {
+    print("daStrudel tutorial 15 — live reload\n")
+    if (get_audio_command_channel() == null) {
+        asch = audio_system_create()
+    }
+    load_samples()
+    strudel_init(@@strudel_main)
+    print("playing — edit this file and save to hot-reload the pattern!\n")
+}
+
+[export]
+def update() {
+    pass
+}
+
+[export]
+def shutdown() {
+    print("shutdown\n")
+    strudel_shutdown()
+    audio_system_finalize(asch.command, asch.collect, asch.next_sid)
+}
+
+// Standalone fallback — if run under daslang.exe, act as a regular demo.
+[export]
+def main() {
+    print("daStrudel tutorial 15 (standalone — no hot-reload)\n")
+    with_audio_system() {
+        load_samples()
+        strudel_init(@@strudel_main)
+        print("playing 10 seconds...\n")
+        sleep(10000u)
+        strudel_shutdown()
+    }
+}


### PR DESCRIPTION
## Summary

Five co-dependent deliverables for the strudel library, landed in one PR.

### API visibility audit
~90 symbols marked `private` across 14 modules so the public surface contains only user-facing API. All 14 sub-modules now declared `shared public` so das2rst can document them.

### `//!` doc-comments
Every public `def` / `struct` / `enum` / `variant` in every strudel module now has a `//!` comment. Style matches the existing `strudel_midi` module (canonical reference).

### Auto-generated reference
New dedicated `doc/source/stdlib/sec_strudel.rst` section with one RST page per module, generated from `//!` source comments via `doc/reflections/das2rst.das`. strudel entries removed from `sec_audio.rst`.

### Tutorial series
15 numbered tutorials under `tutorials/daStrudel/`:
- `01_hello_pattern` → Pattern / Hap basics
- `02_mini_notation_fundamentals` → `"bd sd ~ cp"`, `[a b]`, `a*4`, `~`
- `03_mini_notation_advanced` → `<a b c>`, `@`, `?`, `!`
- `04_time_manipulation` → `fast`, `slow`, `early`, `late`, `rev`
- `05_euclidean_rhythms` → `euclid`, `bjorklund`, polyrhythm
- `06_stacking_combining` → `stack`, `cat`, `layer`, `superimpose`
- `07_per_voice_fx` → `jux`, `off`, `chunk`, per-voice `phaser`
- `08_effects_filters` → `lpf`, `hpf`, `delay`, `reverb`, per-orbit busses
- `09_adsr_envelopes` → `attack`/`decay`/`sustain`/`release`, tempo-aware defaults
- `10_scales_music_theory` → `scale`, modes, transposition
- `11_synthesis` → oscillators, `supersaw`, noise, FM
- `12_samples` → `s("name")`, sample banks, pitch/speed
- `13_sf2_soundfont` → `load_sf2`, preset lookup, GM drum map
- `14_midi_files` → `load_midi`, `merge_tracks`, SF2/synth backends
- `15_live_reloading` → `strudel_live`, `[live_command]`, state preservation

Each `.das` compiles cleanly; matching RST pages in `doc/source/reference/tutorials/` linked from `tutorials.rst` under a new `tutorials_dastrudel` section.

### Porting skill
`skills/strudel_port.md` for Claude: a five-step mechanical rewrite recipe (method-chain → pipe, typed numerics, lambda literals, top-level combinators, explicit playback harness) plus notes on built-in drum synthesis, oscillator naming (`sawtooth` not `saw`), and mini-notation gotchas (`bd(3,8)` → `euclid(s("bd"), 3, 8)`).

### Site link
`site/index.html` news entry now points to the generated module reference and the tutorial series.

## Test plan

- [x] Lint: 32 changed `.das` files, 0 issues (via MCP `lint`)
- [x] JIT tests: 6430/6430 pass (`dastest -- --test tests/`)
- [x] AOT tests: 5845/5845 pass (`test_aot.exe -use-aot … --use-aot --test tests`)
- [x] Sphinx build: `build succeeded.` with zero warnings
- [x] das2rst: 0 Uncategorized sections, 0 strudel stubs in handmade/
- [x] All 15 tutorials compile clean (`-compile-only`)
- [x] All 98 `examples/daStrudel/features/*.das` still compile
- [x] All 10 `examples/daStrudel/*/main.das` demo apps still compile
- [x] All 25 `tests/strudel/*.das` still compile

