### PR TITLE
jobque/strudel: migrate MIDI + strudel to Stream; extend capture macro to Stream

### DIFF
--- a/daslib/jobque_boost.das
+++ b/daslib/jobque_boost.das
@@ -662,6 +662,12 @@ def public capture_jobque_lock_box(var js : LockBox?) : LockBox? {
     return js
 }
 
+def public capture_jobque_stream(var s : Stream?) : Stream? {
+    //! this function is used to capture a stream that is used by the jobque.
+    s |> add_ref
+    return s
+}
+
 def public release_capture_jobque_channel(ch : Channel?) {
     //! this function is used to release a channel that is used by the jobque.
     if (ch != null) {
@@ -680,6 +686,13 @@ def public release_capture_jobque_lock_box(js : LockBox?) {
     //! this function is used to release a lock box that is used by the jobque.
     if (js != null) {
         panic("LockBox has not been released. missing box|>release or box|>notify_and_release")
+    }
+}
+
+def public release_capture_jobque_stream(s : Stream?) {
+    //! this function is used to release a stream that is used by the jobque.
+    if (s != null) {
+        panic("Stream has not been released. missing stream|>release or stream|>notify_and_release")
     }
 }
 
@@ -723,7 +736,7 @@ class private ChannelAndStatusCapture : AstCaptureMacro {
         )
         return <- pCall
     }
-    //! This macro implements capturing of the `jobque::Channel` and `jobque::JobStatus` types.
+    //! This macro implements capturing of the `jobque::Channel`, `jobque::JobStatus`, `jobque::LockBox`, and `jobque::Stream` types.
     //! When captured reference counts are increased. When lambda is destroyed, reference counts are decreased.
     def override captureExpression(prog : Program?; mod : Module?; expr : ExpressionPtr; typ : TypeDeclPtr) : ExpressionPtr {
         //! Implementation details for the capture macro.
@@ -733,14 +746,16 @@ class private ChannelAndStatusCapture : AstCaptureMacro {
             return <- make_capture_call(expr, "jobque_boost::capture_jobque_job_status")
         } elif (typ |> isPtrToJQ("LockBox")) {
             return <- make_capture_call(expr, "jobque_boost::capture_jobque_lock_box")
+        } elif (typ |> isPtrToJQ("Stream")) {
+            return <- make_capture_call(expr, "jobque_boost::capture_jobque_stream")
         }
         return null
     }
     def override captureFunction(prog : Program?; mod : Module?; var lcs : Structure?; var fun : FunctionPtr) : void {
         //! Implementation details for the capture macro.
         //! Note: generators are skipped because their ``finally`` section is called on every
-        //! iteration, not just once at destruction. This means ``Channel``, ``JobStatus``, and
-        //! ``LockBox`` captures inside generators do NOT get automatic release checks.
+        //! iteration, not just once at destruction. This means ``Channel``, ``JobStatus``,
+        //! ``LockBox``, and ``Stream`` captures inside generators do NOT get automatic release checks.
         //! Users must manually call ``release`` on captured jobque objects inside generators.
         if (fun.flags._generator) {// generator gets finally section called every single time. nothing we can do
             return
@@ -754,6 +769,9 @@ class private ChannelAndStatusCapture : AstCaptureMacro {
                 (fun.body as ExprBlock).finalList |> emplace(pCall)
             } elif (fld._type |> isPtrToJQ("LockBox")) {
                 var pCall = make_release_call(fld, "jobque_boost::release_capture_jobque_lock_box")
+                (fun.body as ExprBlock).finalList |> emplace(pCall)
+            } elif (fld._type |> isPtrToJQ("Stream")) {
+                var pCall = make_release_call(fld, "jobque_boost::release_capture_jobque_stream")
                 (fun.body as ExprBlock).finalList |> emplace(pCall)
             }
         }

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -475,7 +475,7 @@ def document_module_jobque_boost(root : string) {
         group_by_regex("Synchronization", mod, %regex~(with_wait_group|done)$%%),
         group_by_regex("Parallel execution", mod, %regex~(_parallel_for|parallel_for|_parallel_for_each|parallel_for_each|_parallel_map|parallel_map)$%%),
         group_by_regex("LockBox operations", mod, %regex~(set|get|update|clear|fill|grab)$%%),
-        group_by_regex("Internal capture details", mod, %regex~(capture_jobque_channel|capture_jobque_job_status|release_capture_jobque_channel|release_capture_jobque_job_status|capture_jobque_lock_box|release_capture_jobque_lock_box)$%%)
+        group_by_regex("Internal capture details", mod, %regex~(capture_jobque_channel|capture_jobque_job_status|release_capture_jobque_channel|release_capture_jobque_job_status|capture_jobque_lock_box|release_capture_jobque_lock_box|capture_jobque_stream|release_capture_jobque_stream)$%%)
     )
     document("Boost package for jobs and threads", mod, "jobque_boost.rst", groups)
 }

--- a/modules/dasAudio/strudel/strudel_midi_player.das
+++ b/modules/dasAudio/strudel/strudel_midi_player.das
@@ -6,7 +6,7 @@ options no_unused_function_arguments = false
 module strudel_midi_player shared public
 //! MIDI Standard File playback on a dedicated audio thread.
 //! Routes events to either a GM-preset oscillator/sample path or an SF2 soundfont,
-//! mixes multiple tracks through reverb/chorus buses, and exposes a command-channel API.
+//! mixes multiple tracks through reverb/chorus buses, and exposes a command-stream API.
 
 require strudel/strudel_midi
 require strudel/strudel_synth
@@ -16,6 +16,7 @@ require strudel/strudel_sf2_voice
 require audio/audio_boost
 require audio
 require daslib/jobque_boost
+require daslib/archive
 require strudel/strudel_player
 require daslib/fio
 require math
@@ -792,7 +793,7 @@ def midi_tick(var state : MidiPlaybackState; chunk_seconds : float) : array<floa
     return <- output
 }
 
-// ─── Command Channel ───
+// ─── Command Stream ───
 
 variant private MidiCommand {
     shutdown     : bool;
@@ -802,11 +803,14 @@ variant private MidiCommand {
     set_pause    : bool;
 }
 
+// Pointer fields are encoded as uint64 (via intptr) so the command payload is POD-serializable.
+// The pointed-to MidiFile/SampleBank/SF2File lives in main-thread globals that outlive the command.
+[safe_when_uninitialized]
 struct private MidiTrackCmd {
     name    : string
-    file    : MidiFile const?   // pointer to main context's g_midi_files entry
-    bank    : SampleBank const? // pointer to main context's sample bank (optional)
-    sf2     : SF2File const?    // pointer to main context's SF2 file (optional)
+    file    : uint64    // MidiFile const?   — main-thread g_midi_files entry
+    bank    : uint64    // SampleBank const? — main-thread sample bank (0 = none)
+    sf2     : uint64    // SF2File const?    — main-thread SF2 file (0 = none)
     gain    : float = 1.0
     looping : bool = false
 }
@@ -814,8 +818,8 @@ struct private MidiTrackCmd {
 // ─── Module Globals ───
 
 var private g_midi_sid : uint64 = 0ul
-var private g_midi_cmd_channel : Channel?
-var private g_midi_done_channel : Channel?
+var private g_midi_cmd_stream  : Stream?
+var private g_midi_done_status : JobStatus?
 var private g_midi_files : table<string; MidiFile>  // owns parsed data
 var private g_midi_bank : SampleBank                // module-global sample bank
 var private g_midi_sf2 : SF2File?                   // module-global SF2 soundfont
@@ -824,7 +828,7 @@ var private g_midi_audio_vis_ptr : void?  // audio vis channel as void* (avoids 
 
 // ─── Audio Thread Main Loop ───
 
-def private midi_thread_main(sid : uint64; var cmd_channel : Channel?; var done_channel : Channel?; audio_channel : void?; vis_ptr : void?) {
+def private midi_thread_main(sid : uint64; var cmd_stream : Stream?; var done_status : JobStatus?; audio_channel : void?; vis_ptr : void?) {
     unsafe {
         set_audio_thread_command_stream(audio_channel)
     }
@@ -854,20 +858,17 @@ def private midi_thread_main(sid : uint64; var cmd_channel : Channel?; var done_
     var running = true
     while (running) {
         // process commands
-        cmd_channel |> gather() $(cmd : MidiCommand#) {
+        cmd_stream |> gather_archive() $(var cmd : MidiCommand) {
             if (cmd is shutdown) {
                 running = false
             } elif (cmd is add_track) {
-                let tc & = cmd as add_track
-                // extract pointer via reinterpret to strip # temp lifetime
-                let file_ptr = unsafe(reinterpret<MidiFile const?>(tc.file))
-                let bank_ptr = unsafe(reinterpret<SampleBank const?>(tc.bank))
-                let sf2_ptr = unsafe(reinterpret<SF2File const?>(tc.sf2))
+                assume tc = cmd as add_track
+                // payload pointers are uint64 (intptr-encoded); keep them opaque until use
                 pending_adds |> emplace(MidiTrackCmd(
                     name := tc.name,
-                    file = file_ptr,
-                    bank = bank_ptr,
-                    sf2 = sf2_ptr,
+                    file = tc.file,
+                    bank = tc.bank,
+                    sf2 = tc.sf2,
                     gain = tc.gain,
                     looping = tc.looping
                 ))
@@ -912,7 +913,11 @@ def private midi_thread_main(sid : uint64; var cmd_channel : Channel?; var done_
                 k --
             }
             var ps = new MidiPlaybackState()
-            init_playback(*ps, tc.file, tc.name, tc.gain, tc.looping, tc.bank, tc.sf2)
+            // reinterpret uint64 payload pointers back to typed smart pointers
+            let file_ptr = unsafe(reinterpret<MidiFile const?>(tc.file))
+            let bank_ptr = unsafe(reinterpret<SampleBank const?>(tc.bank))
+            let sf2_ptr  = unsafe(reinterpret<SF2File const?>(tc.sf2))
+            init_playback(*ps, file_ptr, tc.name, tc.gain, tc.looping, bank_ptr, sf2_ptr)
             tracks |> push(ps)
         }
         pending_adds |> clear()
@@ -1001,7 +1006,7 @@ def private midi_thread_main(sid : uint64; var cmd_channel : Channel?; var done_
     unsafe {
         set_audio_thread_command_stream(null)
     }
-    cmd_channel |> release()
+    cmd_stream |> release
     unsafe {
         if (g_reverb != null) {
             conv_reverb_uninit(g_reverb)
@@ -1011,8 +1016,7 @@ def private midi_thread_main(sid : uint64; var cmd_channel : Channel?; var done_
             delete g_chorus
         }
     }
-    done_channel |> push(new MidiCommand(shutdown = true))
-    done_channel |> release()
+    done_status |> notify_and_release
 }
 
 // ─── Public API ───
@@ -1034,17 +1038,19 @@ def public midi_init() {
     if (g_midi_sid == 0ul) {
         g_midi_sid = play_sound_from_pcm_stream(MA_SAMPLE_RATE, MA_CHANNELS)
     }
-    g_midi_cmd_channel = unsafe(channel_create())
-    g_midi_done_channel = unsafe(channel_create())
+    g_midi_cmd_stream = unsafe(stream_create())
+    g_midi_done_status = unsafe(job_status_create())
+    g_midi_done_status |> append(1)                   // expect one notification on worker exit
+    // @capture auto-bumps refcount for Stream and JobStatus — no manual add_ref needed
     let sid = g_midi_sid
-    var cmd_ch = g_midi_cmd_channel
-    var done_ch = g_midi_done_channel
+    var cmd_st = g_midi_cmd_stream
+    var done_st = g_midi_done_status
     let audio_ch = get_audio_command_stream()
     let vis_ptr = g_midi_audio_vis_ptr
-    new_thread() <| @capture(= sid, = cmd_ch, = done_ch, = audio_ch, = vis_ptr) {
-        midi_thread_main(sid, cmd_ch, done_ch, audio_ch, vis_ptr)
-        cmd_ch = null
-        done_ch = null
+    new_thread() <| @capture(= sid, = cmd_st, = done_st, = audio_ch, = vis_ptr) {
+        midi_thread_main(sid, cmd_st, done_st, audio_ch, vis_ptr)
+        cmd_st = null
+        done_st = null
     }
     g_midi_running = true
 }
@@ -1081,15 +1087,15 @@ def public midi_play(name : string; path : string; gain : float = 1.0; looping :
     }
     let file_ptr = unsafe(addr(g_midi_files[name]))
     let sf2_ptr = use_sf2 && g_midi_sf2 != null ? unsafe(reinterpret<SF2File const?>(g_midi_sf2)) : null
-    var cmd = new MidiCommand(add_track = MidiTrackCmd(
+    let bank_ptr = bank != null ? bank : unsafe(reinterpret<SampleBank const?>(unsafe(addr(g_midi_bank))))
+    g_midi_cmd_stream |> push_archive(MidiCommand(add_track = MidiTrackCmd(
         name = name,
-        file = file_ptr,
-        bank = bank != null ? bank : unsafe(reinterpret<SampleBank const?>(unsafe(addr(g_midi_bank)))),
-        sf2 = sf2_ptr,
+        file = intptr(file_ptr),
+        bank = intptr(bank_ptr),
+        sf2  = intptr(sf2_ptr),
         gain = gain,
         looping = looping
-    ))
-    g_midi_cmd_channel |> push(cmd)
+    )))
     return true
 }
 
@@ -1106,15 +1112,15 @@ def public midi_play_data(name : string; data : array<uint8>; gain : float = 1.0
     }
     let file_ptr = unsafe(addr(g_midi_files[name]))
     let sf2_ptr = use_sf2 && g_midi_sf2 != null ? unsafe(reinterpret<SF2File const?>(g_midi_sf2)) : null
-    var cmd = new MidiCommand(add_track = MidiTrackCmd(
+    let bank_ptr = bank != null ? bank : unsafe(reinterpret<SampleBank const?>(unsafe(addr(g_midi_bank))))
+    g_midi_cmd_stream |> push_archive(MidiCommand(add_track = MidiTrackCmd(
         name = name,
-        file = file_ptr,
-        bank = bank != null ? bank : unsafe(reinterpret<SampleBank const?>(unsafe(addr(g_midi_bank)))),
-        sf2 = sf2_ptr,
+        file = intptr(file_ptr),
+        bank = intptr(bank_ptr),
+        sf2  = intptr(sf2_ptr),
         gain = gain,
         looping = looping
-    ))
-    g_midi_cmd_channel |> push(cmd)
+    )))
     return true
 }
 
@@ -1127,54 +1133,36 @@ def public midi_stop(name : string = "") {
         // stop all — shutdown the thread
         midi_shutdown()
     } else {
-        var cmd = new MidiCommand(shutdown = false)
-        unsafe {
-            set_variant_index(*cmd, 2)  // remove_track
-            cmd.remove_track = name
-        }
-        g_midi_cmd_channel |> push(cmd)
+        g_midi_cmd_stream |> push_archive(MidiCommand(remove_track = name))
     }
 }
 
 def public midi_set_volume(name : string; volume : float; fade : float = 0.0) {
     //! Set the linear gain of a named track, optionally fading over `fade` seconds (0 = instantaneous).
-    if (!g_midi_running || g_midi_cmd_channel == null) {
+    if (!g_midi_running || g_midi_cmd_stream == null) {
         return
     }
-    var cmd = new MidiCommand(shutdown = false)
-    unsafe {
-        set_variant_index(*cmd, 3)  // set_volume
-        cmd.set_volume = (name, volume, fade)
-    }
-    g_midi_cmd_channel |> push(cmd)
+    g_midi_cmd_stream |> push_archive(MidiCommand(set_volume = (name, volume, fade)))
 }
 
 def public midi_set_pause(paused : bool) {
     //! Pause or resume all MIDI playback (the underlying audio stream continues with silence while paused).
-    if (!g_midi_running || g_midi_cmd_channel == null) {
+    if (!g_midi_running || g_midi_cmd_stream == null) {
         return
     }
-    g_midi_cmd_channel |> push(new MidiCommand(set_pause = paused))
+    g_midi_cmd_stream |> push_archive(MidiCommand(set_pause = paused))
 }
 
 def public midi_shutdown() {
-    //! Stop the playback thread and release its channels; blocks until the audio thread confirms shutdown.
-    if (!g_midi_running || g_midi_cmd_channel == null) {
+    //! Stop the playback thread and release its stream/status; blocks until the audio thread confirms shutdown.
+    if (!g_midi_running || g_midi_cmd_stream == null) {
         return
     }
-    g_midi_cmd_channel |> push(new MidiCommand(shutdown = true))
-    var got_done = false
-    while (!got_done) {
-        _builtin_channel_pop(g_midi_done_channel) $(data) {
-            if (data != null) {
-                got_done = true
-            }
-        }
-    }
-    unsafe(channel_remove(g_midi_cmd_channel))
-    g_midi_cmd_channel = null
-    unsafe(channel_remove(g_midi_done_channel))
-    g_midi_done_channel = null
+    g_midi_cmd_stream |> push_archive(MidiCommand(shutdown = true))
+    g_midi_done_status |> join                        // blocks until worker notify_and_release
+    // refcount was 2 after init; worker's release made it 1; stream_remove decrements to 0 and deletes
+    unsafe(stream_remove(g_midi_cmd_stream))
+    unsafe(job_status_remove(g_midi_done_status))
     g_midi_running = false
     // release SF2 soundfont (finalizer recursively frees instruments/presets/zones)
     if (g_midi_sf2 != null) {

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -5,7 +5,7 @@ options no_unused_function_arguments = false
 
 module strudel_player shared public
 //! Top-level playback harness for strudel patterns.
-//! Manages tracks, BPM/CPS, sample/SF2 banks, and a command channel for both
+//! Manages tracks, BPM/CPS, sample/SF2 banks, and a command stream for both
 //! main-thread (strudel_tick) and dedicated-thread (strudel_play) playback modes.
 
 require strudel/strudel_event
@@ -23,7 +23,7 @@ require daslib/fio
 require daslib/strings_boost
 require math
 
-// --- Command channel ---
+// --- Command stream ---
 
 variant private StrudelCommand {
     shutdown : bool;
@@ -54,8 +54,8 @@ var public g_wall_time : double = 0.0lf
 var private g_wall_samples : int64 = 0l  // exact sample count — g_wall_time derived from this
 //! Current tempo in cycles per second (0.5 = 120 BPM at 4 beats/cycle).
 var public g_cps : double = 0.5lf
-var private g_cmd_channel : Channel?
-var private g_done_channel : Channel?
+var private g_cmd_stream : Stream?
+var private g_done_status : JobStatus?
 var private g_sf2 : SF2File?
 var private g_sf2_path : string
 var private g_cmd_fn : function<(cmd : string) : void>
@@ -195,16 +195,16 @@ def public strudel_set_pause(paused : bool) {
 def public strudel_set_bpm(bpm : double) {
     //! Set tempo in beats per minute (assumes 4 beats per cycle). Safe to call from the main thread.
     g_cps = bpm / 240.0lf
-    if (g_cmd_channel != null) {
-        g_cmd_channel |> push(new StrudelCommand(set_bpm = bpm))
+    if (g_cmd_stream != null) {
+        g_cmd_stream |> push_archive(StrudelCommand(set_bpm = bpm))
     }
 }
 
 def public strudel_set_cps(cps : double) {
     //! Set tempo directly in cycles per second. Safe to call from the main thread.
     g_cps = cps
-    if (g_cmd_channel != null) {
-        g_cmd_channel |> push(new StrudelCommand(set_cps = cps))
+    if (g_cmd_stream != null) {
+        g_cmd_stream |> push_archive(StrudelCommand(set_cps = cps))
     }
 }
 
@@ -338,13 +338,8 @@ def public strudel_fade_track(idx : int; target_gain : float; time : float) {
 def public strudel_command(cmd : string) {
     //! Send a user command string from the main thread to the strudel playback thread.
     //! The command is dispatched to the cmd_fn passed to strudel_init.
-    if (g_cmd_channel != null) {
-        var sc = new StrudelCommand(shutdown = false)
-        unsafe {
-            set_variant_index(*sc, 3)  // user_cmd
-            sc.user_cmd = cmd
-        }
-        g_cmd_channel |> push(sc)
+    if (g_cmd_stream != null) {
+        g_cmd_stream |> push_archive(StrudelCommand(user_cmd = cmd))
     }
 }
 
@@ -356,11 +351,11 @@ def public strudel_noop_cmd(cmd : string) {
 // --- Command processing (called on strudel thread) ---
 
 def private strudel_process_commands(cmd_fn : function<(cmd : string) : void>) : bool {
-    if (g_cmd_channel == null) {
+    if (g_cmd_stream == null) {
         return true
     }
     var running = true
-    g_cmd_channel |> gather() $(cmd : StrudelCommand#) {
+    g_cmd_stream |> gather_archive() $(var cmd : StrudelCommand) {
         if (cmd is shutdown) {
             running = false
         } elif (cmd is set_bpm) {
@@ -728,22 +723,24 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
     if (g_playback_box == null) {
         g_playback_box = unsafe(lock_box_create())
     }
-    // create channels
-    g_cmd_channel = unsafe(channel_create())
-    g_done_channel = unsafe(channel_create())
+    // create command stream and done status (thread-exit signal, wait group of 1).
+    // @capture auto-bumps refcount for Stream and JobStatus — no manual add_ref needed.
+    g_cmd_stream = unsafe(stream_create())
+    g_done_status = unsafe(job_status_create())
+    g_done_status |> append(1)
     // create PCM stream on main thread (audio globals are initialized here)
     let thread_sid = play_sound_from_pcm_stream(MA_SAMPLE_RATE, MA_CHANNELS)
     // capture shared resources from main thread
     var bank_ptr = unsafe(addr(g_bank))
     var sf2_ptr = g_sf2 != null ? unsafe(reinterpret<SF2File const?>(g_sf2)) : null
     var audio_ch = get_audio_command_stream()
-    var cmd_ch = g_cmd_channel
-    var done_ch = g_done_channel
+    var cmd_st = g_cmd_stream
+    var done_st = g_done_status
     var pb_box = g_playback_box
     let wt = g_wall_time
     let cps = g_cps
     let la = g_look_ahead
-    new_thread() <| @capture(= fn, = bank_ptr, = sf2_ptr, = audio_ch, = cmd_ch, = done_ch, = pb_box, = wt, = cps, = la, = thread_sid) {
+    new_thread() <| @capture(= fn, = bank_ptr, = sf2_ptr, = audio_ch, = cmd_st, = done_st, = pb_box, = wt, = cps, = la, = thread_sid) {
         // inject shared resources into thread context
         g_bank_ptr = bank_ptr
         unsafe {
@@ -751,8 +748,8 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
         }
         g_sf2 = unsafe(reinterpret<SF2File?>(sf2_ptr))
         g_sid = thread_sid
-        g_cmd_channel = cmd_ch
-        g_done_channel = done_ch
+        g_cmd_stream = cmd_st
+        g_done_status = done_st
         g_playback_box = pb_box
         g_wall_time = wt
         g_cps = cps
@@ -763,32 +760,22 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
         unsafe {
             set_audio_thread_command_stream(null)
         }
-        cmd_ch |> release()
+        cmd_st |> release()
         pb_box |> release()
-        done_ch |> push(new StrudelCommand(shutdown = true))
-        done_ch |> release()
+        done_st |> notify_and_release
     }
 }
 
 def public strudel_shutdown() {
-    //! Shut down playback: signal the strudel thread to stop, release channels/lockboxes, free all tracks.
+    //! Shut down playback: signal the strudel thread to stop, release stream/status/lockboxes, free all tracks.
     //! Safe to call from the main thread; also finalizes memory/utilization stats.
-    if (g_cmd_channel != null) {
-        g_cmd_channel |> push(new StrudelCommand(shutdown = true))
-        var got_done = false
-        while (!got_done) {
-            _builtin_channel_pop(g_done_channel) $(data) {
-                if (data != null) {
-                    got_done = true
-                }
-            }
-        }
-        // command channel
-        unsafe(channel_remove(g_cmd_channel))
-        g_cmd_channel = null
-        // done channel
-        unsafe(channel_remove(g_done_channel))
-        g_done_channel = null
+    if (g_cmd_stream != null) {
+        g_cmd_stream |> push_archive(StrudelCommand(shutdown = true))
+        // wait for worker thread to exit (notify_and_release on done_status)
+        g_done_status |> join
+        // refcount was 2 after init; worker's release made it 1; *_remove decrements to 0 and deletes
+        unsafe(stream_remove(g_cmd_stream))
+        unsafe(job_status_remove(g_done_status))
         // player box
         unsafe(lock_box_remove(g_playback_box))
         g_playback_box = null


### PR DESCRIPTION
## Summary

Follow-up to #2437 (channel-to-stream). The audio_boost migration left two audio transports still using the old `Channel?` + typed-pointer pattern — the MIDI player and the strudel pattern scheduler. This PR:

- Migrates both players to byte `Stream` + archive (pointer payloads encoded as `uint64` via `intptr()` / decoded via `reinterpret<T?>()`).
- Replaces the one-shot `done_channel` + `_builtin_channel_pop` spin-loop with a `JobStatus` wait group (`append(1)` / `notify_and_release` / `join`).
- Extends the jobque capture macro (`daslib/jobque_boost.das`) to handle `Stream` consistently with `Channel`, `JobStatus`, `LockBox` — auto `add_ref` on capture, auto release-check on lambda exit. Fixes an asymmetry where capturing a `Stream` into a thread lambda required manual `add_ref` bookkeeping but the other three jobque primitives did not.

Without these changes the daStrudel / dasAudio MIDI demos crashed on exit (`streamRemove: stream is null` or `job status being deleted while being used`) and leaked refcounted Stream/JobStatus objects.

## Files

- `daslib/jobque_boost.das` — add `capture_jobque_stream` / `release_capture_jobque_stream`; extend `ChannelAndStatusCapture` macro.
- `modules/dasAudio/strudel/strudel_player.das` — Channel → Stream, done-channel → JobStatus.
- `modules/dasAudio/strudel/strudel_midi_player.das` — same, plus `MidiTrackCmd` pointer fields → `uint64`.
- `doc/reflections/das2rst.das` — add new helpers to the jobque doc group.

## Test plan

- [x] `mcp__daslang__lint` on changed files: 0 issues
- [x] Full native test suite: **6456/6456 pass**
- [x] Full AOT test suite (`test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests`): **5871/5871 pass**
- [x] `tutorials/dasAudio/08_midi.das` runs end-to-end (parse + play + crossfade) with exit 0, no exception, no refcount leaks
- [x] `tutorials/daStrudel/daStrudel_08_effects_filters.das` runs 5 init/shutdown cycles, `strudel mem: leak 0kb` per section

🤖 Generated with [Claude Code](https://claude.com/claude-code)