### PR TITLE
strudel: fix per-frame visualizer leak (~250-400 KB/tick) and ~2 GB SF2 shutdown leak

### DIFF
--- a/examples/daStrudel/strudel_visualizer/audio_analysis.das
+++ b/examples/daStrudel/strudel_visualizer/audio_analysis.das
@@ -61,6 +61,8 @@ def audio_analysis_update_spectrum(var aa : AudioAnalysis) {
     for (i in range(FFT_BINS)) {
         aa.spectrum_smooth[i] = aa.spectrum_smooth[i] * (1.0 - smooth) + aa.spectrum_bins[i] * smooth
     }
+    delete re
+    delete im
 }
 
 // --- FFT (radix-2 Cooley-Tukey, in-place) ---

--- a/examples/daStrudel/strudel_visualizer/main.das
+++ b/examples/daStrudel/strudel_visualizer/main.das
@@ -403,6 +403,7 @@ def update() {
             let py0 = fh - panel_h * float(pi + 1)
             render_panel_name(font, p.name, display_w, display_h, py0 + m, py1 - m)
         }
+        delete verts
     }
     live_end_frame()
 }

--- a/modules/dasAudio/strudel/strudel_sf2.das
+++ b/modules/dasAudio/strudel/strudel_sf2.das
@@ -228,6 +228,10 @@ def finalize(var f : SF2File explicit) {
         }
     }
     delete f.presets
+    // explicit finalizer replaces the default cascade — must delete remaining heap-owning fields
+    delete f.sample_data
+    delete f.samples
+    delete f.preset_lookup
 }
 
 // ─── Binary Readers (Little-Endian) ───
@@ -563,7 +567,9 @@ def public sf2_load(path : string) : SF2File? {
         to_log(0, "SF2: file too small or not found: {path}\n")
         return null
     }
-    return <- sf2_parse(data)
+    var result = sf2_parse(data)
+    delete data
+    return <- result
 }
 
 def public sf2_parse(data : array<uint8>) : SF2File? {


### PR DESCRIPTION
## Summary

Two unrelated heap leaks in the strudel stack, both rooted in daslang's lack of scope-based RAII for `var` declarations.

### 1. strudel_visualizer: per-frame leak (~250-400 KB/tick)

The visualizer was leaking ~250-400 KB of heap per frame, ballooning to >2 GB after a few thousand frames and OOM-crashing the app on long runs. Two locations allocated fresh arrays every frame and never freed them:

- `update()` declared `var verts : array<VisVertex>` per frame and pushed all panel geometry into it (~384 KB at full workload with scope/spectrum/vectorscope panels active)
- `audio_analysis_update_spectrum()` allocated `re`/`im` FFT scratch buffers (~4 KB each) on every call, once per audio panel per frame

Fixed by adding explicit `delete` at end of scope.

### 2. strudel/sf2: cleanup-time leaks (~2 GB never freed at shutdown)

After `strudel_shutdown`, two 1 GiB blocks survived:

- `SF2File`'s `explicit` finalizer freed only `instruments` and `presets`. Since `explicit` fully **replaces** the default per-field cascade, the heap-owning `sample_data` (~1 GB for Musyng Kite), `samples`, and `preset_lookup` were never reclaimed. Added the missing `delete`s to the finalizer.
- `sf2_load`'s local `var data : array<uint8>` (the full SF2 file, ~1 GB) was assumed to free at scope exit but never did. Captured the parse result in a local and `delete data` before returning.

## Measurement

Strudel visualizer at full workload (SF2 + 5 tracks + pianoroll/scope/spectrum/vectorscope/drums):

| Frames | Heap leak before | Heap leak after |
|---|---|---|
| 200  | 77 MB (per-frame) + 2 GB (shutdown) | ~0 |
| 600  | (would be ~250 MB + 2 GB) | ~0 (heap actually shrinks vs baseline) |

Heap-after-shutdown drops from ~2.05 GB to ~1.5 MB.

## Test plan

- [x] Lint passes on all changed files (`mcp__daslang__lint`)
- [x] All files match formatter output (`mcp__daslang__format_file`)
- [x] All 575 strudel tests pass (`tests/strudel/`)
- [x] Smoke run at 60 frames completes cleanly with negative heap delta vs baseline
- [x] Long run at 600 frames no longer grows the heap monotonically

## Notes

- The `explicit` finalizer footgun (silently dropping the default per-field cascade) is a real footrgun in daslang — the SF2File case is the second author who got bitten. A `super`/`augment` finalize mechanism would help; tracked separately.
- Same per-frame anti-pattern (large `var arr : array<T>` in a hot loop, no `delete`) likely exists in other strudel/audio examples; worth a sweep separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)