### PR TITLE
style_lint: add STYLE012 — array init by push/emplace run

### DIFF
--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -944,9 +944,7 @@ def document_bitfield(mod : Module?; doc_file : file; name : string; value : Typ
     var tab : array<array<string>>
     emplace(tab, array<string>("field", "bit"))
     for (an, bit in value.argNames, urange(32)) {
-        var line : array<string>
-        push(line, string(an))
-        push(line, "{uint64(1ul << uint64(bit))}")
+        var line <- [string(an), "{uint64(1ul << uint64(bit))}"]
         emplace(tab, line)
     }
 
@@ -968,9 +966,7 @@ def document_variant(mod : Module?; doc_file : file; name : string; value : Type
     var tab : array<array<string>>
     emplace(tab, array<string>("field", "type"))
     for (an, at in value.argNames, value.argTypes) {
-        var line : array<string>
-        push(line, string(an))
-        push(line, describe_type(at))
+        var line <- [string(an), describe_type(at)]
         emplace(tab, line)
     }
     document_topic("Variants", doc_file, topic("typedef", mod, name), describe(value), tab)
@@ -1183,9 +1179,7 @@ def document_function_arguments(doc_file : file; argNames : array<string>; argTy
     for (an, at in argNames, argTypes) {
         continue if (skip-- > 0)
         if (argument_needs_documenting(at)) {
-            var line : array<string>
-            push(line, an)
-            push(line, describe_type(at))
+            var line <- [an, describe_type(at)]
             emplace(tab, line)
         }
     }
@@ -1353,9 +1347,7 @@ def document_classes(doc_file : file; mods : array<Module?>) {
             for_each_global(mod) $(gVar) {
                 peek(gVar.name) $(gvar_name) {
                 if (!gVar.flags.private_variable && gvar_name |> starts_with(staticFieldPrefix)) {
-                    var line : array<string>
-                    push(line, "{value.name}.{gvar_name |> slice(length(staticFieldPrefix))}")
-                    push(line, describe_type(gVar._type))
+                    var line <- ["{value.name}.{gvar_name |> slice(length(staticFieldPrefix))}", describe_type(gVar._type)]
                     if (hasValues) {
                         push(line, gVar.init != null ? describe(gVar.init) : "")
                     }
@@ -1366,9 +1358,7 @@ def document_classes(doc_file : file; mods : array<Module?>) {
 
             for (fld in value.fields) {
                 if (!is_class_method(value, fld) && !(fld.flags.generated) && fld.flags.implemented && !fld.flags.privateField && !(fld.flags.parentType) && (fld.name != "__rtti")) {
-                    var line : array<string>
-                    push(line, string(fld.name))
-                    push(line, describe_type(fld._type))
+                    var line <- [string(fld.name), describe_type(fld._type)]
                     if (hasValues) {
                         push(line, fld.init != null ? describe(fld.init) : "")
                     }
@@ -1499,9 +1489,7 @@ def document_structure(doc_file : file; mod : Module?; var value : StructurePtr)
     }
     for (fld in value.fields) {
         if (!is_class_method(value, fld) && !(fld.flags.generated) && fld.flags.implemented && !fld.flags.privateField && !(fld.flags.parentType) && (fld.name != "__rtti")) {
-            var line : array<string>
-            push(line, string(fld.name))
-            push(line, describe_type(fld._type))
+            var line <- [string(fld.name), describe_type(fld._type)]
             if (hasValues) {
                 push(line, fld.init != null ? describe(fld.init) : "")
             }

--- a/daslib/style_lint.das
+++ b/daslib/style_lint.das
@@ -20,6 +20,7 @@ module style_lint shared private
 //!   STYLE006 — string(__rtti) comparison should use `is` operator
 //!   STYLE010 — if (true) should be a bare block
 //!   STYLE011 — variable declaration followed by immediate assignment
+//!   STYLE012 — array<T> var initialized via push/emplace; use an array literal
 
 require daslib/ast_boost
 require strings
@@ -385,6 +386,77 @@ class StyleLintVisitor : AstVisitor {
             }
             pending_uninit_vars |> resize(0)
         }
+        if (expr is ExprLet) {
+            self->check_style012_array_init(blk, expr as ExprLet)
+        }
+    }
+
+    // --- STYLE012: array<T> var then contiguous push/emplace instead of literal ---
+
+    def check_style012_array_init(blk : ExprBlock?; elet : ExprLet?) : void {
+        if (current_function != null && current_function.fromGeneric != null) {
+            return
+        }
+        // Find this ExprLet's index in the enclosing block's statement list.
+        var idx = -1
+        let n = length(blk.list)
+        for (k in range(n)) {
+            if (blk.list[k] == elet) {
+                idx = k
+                break
+            }
+        }
+        if (idx < 0 || idx + 1 >= n) {
+            return
+        }
+        for (v in elet.variables) {
+            if (v.init != null) {
+                continue
+            }
+            if (v.flags.generated || v.flags.inScope) {
+                continue
+            }
+            if (v._type == null || v._type.baseType != Type.tArray) {
+                continue
+            }
+            if (length(v._type.dim) != 0) {
+                continue
+            }
+            var count = 0
+            for (j in range(idx + 1, n)) {
+                let stmt = blk.list[j]
+                if (!(stmt is ExprCall)) {
+                    break
+                }
+                if (!self->is_push_or_emplace_of(stmt as ExprCall, v)) {
+                    break
+                }
+                count++
+            }
+            if (count >= 2) {
+                self->style_warning("STYLE012: array<T> initialized by a run of push/emplace calls; use an array literal `var a <- [x, <-y, z]` (or `var a <- array<T>(x, y, z)` when you need an explicit element type, e.g. for polymorphic upcasts)", v.at)
+            }
+        }
+    }
+
+    def is_push_or_emplace_of(call : ExprCall?; target : Variable?) : bool {
+        if (call.func == null || call.func.fromGeneric == null) {
+            return false
+        }
+        if (call.func.fromGeneric.name != "push" && call.func.fromGeneric.name != "emplace") {
+            return false
+        }
+        if (length(call.arguments) < 2) {
+            return false
+        }
+        var arg = call.arguments[0]
+        if (arg is ExprRef2Value) {
+            arg = (arg as ExprRef2Value.subexpr)
+        }
+        if (!(arg is ExprVar)) {
+            return false
+        }
+        return (arg as ExprVar).variable == target
     }
 
     // --- helpers ---

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -550,6 +550,47 @@ semantics), compiler-generated variables, and generic instantiations.
     // Good — combined
     var s := src
 
+STYLE012 — ``array<T>`` initialized by a run of ``push``/``emplace``
+====================================================================
+
+Declaring an empty ``array<T>`` variable immediately followed by two or
+more contiguous ``push`` or ``emplace`` calls that all target the same
+variable is a common "I forgot how to initialize an array" pattern. Use
+an array literal instead — it is shorter, faster (one allocation with
+the right capacity instead of repeated grows), and makes the initial
+contents obvious at a glance.
+
+A single ``push`` right after the declaration is **not** flagged,
+because the verbose form is often the most readable option for a single
+element. ``push_clone`` is deliberately excluded — there is no clean
+array-literal equivalent.
+
+The rule excludes ``var inscope``, compiler-generated variables, and
+generic instantiations (same exclusions as STYLE011).
+
+.. code-block:: das
+
+    // Bad — two pushes after empty array declaration
+    var a : array<int>
+    a |> push(1)                                // STYLE012
+    a |> push(2)
+
+    // Good — inferred element type
+    var a <- [1, 2]
+
+    // Good — typed constructor, useful for polymorphic upcasts or
+    // interface pointers where array literal type inference picks the
+    // first element's type
+    var shapes <- array<Shape?>(new Circle(3.0),
+                                new Rectangle(2.0, 5.0),
+                                new Circle(1.0))
+
+    // Good — conditional / loop pushes are not flagged
+    var b : array<int>
+    for (i in range(10)) {
+        b |> push(i)
+    }
+
 -----
 Tests
 -----

--- a/skills/style_lint.md
+++ b/skills/style_lint.md
@@ -22,7 +22,9 @@ The `style_lint` module detects non-idiomatic patterns in daslang code at compil
 | STYLE003 | `foo() $() { ... }` | Remove redundant `$()`; use `foo() { ... }` |
 | STYLE005 | `if (cond) { return val }` | Use `return val if (cond)` (configurable, off by default) |
 | STYLE006 | `string(x.__rtti) == "ExprFoo"` | Use `x is ExprFoo` |
+| STYLE010 | `if (true) { ... }` | Use a bare block `{ ... }` |
 | STYLE011 | `var x : int; x = 5` | Combine into `var x = 5` (or `:=` / `<-`) |
+| STYLE012 | `var a : array<T>; a \|> push(x); a \|> emplace(<-y)` (≥ 2 contiguous `push`/`emplace`) | Use array literal `var a <- [x, <-y]`, or typed constructor `var a <- array<T>(x, y)` when an explicit element type is needed (polymorphic upcasts, interface pointers). `push_clone` excluded; single `push` stays silent — often more readable |
 
 Note: `get_ptr()` related patterns (null comparison, field access) are in `perf_lint` as PERF010/PERF011 since they have performance implications.
 
@@ -34,11 +36,15 @@ The `<|` pipe and `$()` are desugared during parsing — in the compiled AST, `f
 
 **Generators:** `generator<T>() <| $ { ... }` is fully lowered before the lint pass — `ExprMakeGenerator` becomes `ExprMakeStruct` + builtin `each` call. Detection uses `preVisitExprMakeStruct` with column-precise source line check: verifies the `ExprMakeStruct` at position starts with `generator<` in the source, then checks for `<|` pipe after it.
 
-### Pure AST (STYLE005-006)
+**`defer` special case:** The `defer` macro erases its call node before the lint pass runs, so `preVisitExprCall` never sees `defer <| $() { ... }`. Instead, `preVisitFunction` invokes `check_defer_pipe`, which scans each source line of the function body for `defer` followed by `<|` and a block opener (`$(`, `$ `, `${`, `@`, `{`). This is why STYLE001/002 on `defer` fire from a different code path than on ordinary calls.
+
+### Pure AST (STYLE005-006, STYLE010-011)
 
 - **STYLE005:** `ExprIfThenElse` with no `if_false`, single-statement body that is `ExprReturn`/`ExprBreak`/`ExprContinue`. Skips already-postfix forms by checking `ifte.at.line != stmt.at.line`.
 - **STYLE006:** `ExprOp2("==")` where one side is `string(x.__rtti)` pattern.
+- **STYLE010:** `ExprIfThenElse` with `cond is ExprConstBool && cond.value && if_false == null`. Runs in the same `preVisitExprIfThenElse` override as STYLE005; `if_flags.isStatic` branches are skipped so `static_if (true)` doesn't trigger. Works because the lint visitor runs before constant-folding would collapse the `if`.
 - **STYLE011:** Tracks uninitialized variables from `preVisitExprLetVariable` (excluding `generated` and `inScope`). In `preVisitExprBlockExpression`, checks if the next statement is `ExprCopy`/`ExprClone`/`ExprMove` whose left side references a tracked variable.
+- **STYLE012:** In `preVisitExprBlockExpression`, when `expr is ExprLet`, locates the let's index inside `blk.list` (pointer equality via `smart_ptr ==`). For each variable `v` in the let that is `var a : array<T>` with no init (also excluding `generated`, `inScope`, and generic-host instantiations), walks forward through `blk.list` counting contiguous `ExprCall` statements where `call.func.fromGeneric.name` is `"push"` or `"emplace"` and `arguments[0]` (unwrapping `ExprRef2Value`) resolves to `v`. Stops at the first non-matching statement. Emits when count ≥ 2 — a single `push` is often the more readable form, so the rule targets "I forgot how to init an array" bugs rather than every possible rewrite. `push_clone` is deliberately excluded because there is no clean array-literal equivalent.
 
 ## How to Add a New Rule
 
@@ -98,6 +104,5 @@ bin/Release/daslang.exe utils/lint/main.das -- file1.das [file2.das ...] [--quie
 
 ## Known Limitations
 
-- **STYLE010 (if true)**: Cannot be detected via AST — `if (true)` is constant-folded before the visitor runs. `no_infer_time_folding` would prevent this but breaks `daslib/ast.das` compilation. Needs tree-sitter.
 - **STYLE001-003 source detection**: Uses `get_file_source_line()` which reads one line at a time. Multi-line call expressions are handled by scanning from the call's line to the block's line.
 - **`[lint_macro]` errors vs `expect`**: Style warnings emitted via `[lint_macro]` don't work with `expect` directives. Tests use the standalone runner instead.

--- a/tutorials/language/11_tuples_and_variants.das
+++ b/tutorials/language/11_tuples_and_variants.das
@@ -152,9 +152,7 @@ def main {
 
     // typedef creates a name for any type.
     // StringArray was declared above as array<string>.
-    var names : StringArray
-    names |> push("Alice")
-    names |> push("Bob")
+    let names : StringArray <- ["Alice", "Bob"]
     print("names: {names[0]}, {names[1]}\n")
 
     // You can also use typedef for function types, tables, etc.

--- a/tutorials/language/18_classes.das
+++ b/tutorials/language/18_classes.das
@@ -122,10 +122,7 @@ def main {
     // === Polymorphism ===
 
     // Base pointer can hold any derived instance
-    var shapes : array<Shape?>
-    shapes |> push(new Circle(3.0))
-    shapes |> push(new Rectangle(2.0, 5.0))
-    shapes |> push(new Circle(1.0))
+    var shapes <- array<Shape?>(new Circle(3.0), new Rectangle(2.0, 5.0), new Circle(1.0))
 
     print("all shapes:\n")
     for (s in shapes) {

--- a/tutorials/language/24_pattern_matching.das
+++ b/tutorials/language/24_pattern_matching.das
@@ -385,11 +385,9 @@ def main {
     print("  [1,5,9] -> {classify_static_arr(sa)}\n")
     sa = fixed_array<int>(7, 7, 7)
     print("  [7,7,7] -> {classify_static_arr(sa)}\n")
-    var da : array<int>
-    da |> push(0); da |> push(0); da |> push(3); da |> push(4)
+    let da <- [0, 0, 3, 4]
     print("  [0,0,3,4] -> {classify_dynamic_arr(da)}\n")
-    var da2 : array<int>
-    da2 |> push(5); da2 |> push(6)
+    let da2 <- [5, 6]
     print("  [5,6] -> {classify_dynamic_arr(da2)}\n")
 
     // match_expr

--- a/tutorials/language/26_contracts.das
+++ b/tutorials/language/26_contracts.das
@@ -128,8 +128,7 @@ def main {
     // [expect_dim] — see summary for built-in contracts
     // [expect_any_array] — any array type
     print("expect_any_array:\n")
-    var nums : array<int>
-    nums |> push(1); nums |> push(2); nums |> push(3)
+    let nums <- [1, 2, 3]
     print_first(nums)
 
     // [expect_any_numeric] — numeric types only
@@ -165,11 +164,9 @@ def main {
 
     // concept_assert
     print("concept_assert:\n")
-    var ints : array<int>
-    ints |> push(10); ints |> push(20); ints |> push(30)
+    let ints <- [10, 20, 30]
     print("  sum_all([10,20,30]) = {sum_all(ints)}\n")
-    var floats : array<float>
-    floats |> push(1.0); floats |> push(2.0); floats |> push(3.0)
+    let floats <- [1.0, 2.0, 3.0]
     print("  sum_all([1,2,3]) = {sum_all(floats)}\n")
     // var strs : array<string>
     // strs |> push("a")

--- a/tutorials/language/39_dynamic_type_checking.das
+++ b/tutorials/language/39_dynamic_type_checking.das
@@ -203,10 +203,9 @@ def is_as_syntax_demo() {
 def process_shapes() {
     print("\n=== polymorphic processing ===\n")
 
-    var shapes : array<Shape?>
-    shapes |> push(new Circle(name = "sun", radius = 10.0))
-    shapes |> push(new Rectangle(name = "wall", width = 8.0, height = 3.0))
-    shapes |> push(new Circle(name = "ball", radius = 2.5))
+    var shapes <- array<Shape?>(new Circle(name = "sun", radius = 10.0),
+                                new Rectangle(name = "wall", width = 8.0, height = 3.0),
+                                new Circle(name = "ball", radius = 2.5))
     var sq = new Square(name = "tile")
     sq.width = 4.0
     sq.height = 4.0

--- a/tutorials/language/40_coroutines.das
+++ b/tutorials/language/40_coroutines.das
@@ -112,10 +112,7 @@ def worker(name : string; steps : int) {
 
 def demo_run_all() {
     print("\n=== cr_run_all (cooperative scheduling) ===\n")
-    var tasks : Coroutines
-    tasks |> emplace <| worker("alpha", 3)
-    tasks |> emplace <| worker("beta", 2)
-    tasks |> emplace <| worker("gamma", 4)
+    var tasks : Coroutines <- [worker("alpha", 3), worker("beta", 2), worker("gamma", 4)]
     cr_run_all(tasks)
     print("  all tasks done\n")
 }
@@ -223,9 +220,7 @@ def batch_processor(name : string; total_items : int) {
 
 def demo_practical() {
     print("\n=== practical: cooperative batch processing ===\n")
-    var tasks : Coroutines
-    tasks |> emplace <| batch_processor("worker-A", 5)
-    tasks |> emplace <| batch_processor("worker-B", 3)
+    var tasks : Coroutines <- [batch_processor("worker-A", 5), batch_processor("worker-B", 3)]
     cr_run_all(tasks)
     print("  all batches done\n")
 }

--- a/tutorials/language/43_interfaces.das
+++ b/tutorials/language/43_interfaces.das
@@ -160,9 +160,7 @@ def demo_polymorphic_dispatch() {
     var c = new Circle(3.0)
     var s = new Sprite("tree")
 
-    var drawables : array<IDrawable?>
-    drawables |> push(c as IDrawable)
-    drawables |> push(s as IDrawable)
+    var drawables <- array<IDrawable?>(c as IDrawable, s as IDrawable)
 
     draw_all(drawables)
 }

--- a/tutorials/language/48_apply.das
+++ b/tutorials/language/48_apply.das
@@ -175,10 +175,7 @@ variant Shape {
 def demo_variants() {
     print("\n=== Section 5: Variants ===\n")
 
-    var shapes : array<Shape>
-    shapes |> emplace(Shape(circle = 5.0))
-    shapes |> emplace(Shape(rect = float2(3.0, 4.0)))
-    shapes |> emplace(Shape(triangle = float3(3.0, 4.0, 5.0)))
+    var shapes <- [Shape(circle = 5.0), Shape(rect = float2(3.0, 4.0)), Shape(triangle = float3(3.0, 4.0, 5.0))]
 
     for (s in shapes) {
         apply(s) $(name, field) {

--- a/tutorials/language/49_async.das
+++ b/tutorials/language/49_async.das
@@ -188,9 +188,7 @@ def demo_runners() {
     async_run(single)
 
     print("\n=== async_run_all (cooperative) ===\n")
-    var tasks : array<iterator<bool>>
-    tasks |> emplace <| worker("alpha", 2)
-    tasks |> emplace <| worker("beta", 3)
+    var tasks : array<iterator<bool>> <- [worker("alpha", 2), worker("beta", 3)]
     async_run_all(tasks)
     print("  all done\n")
 

--- a/tutorials/macros/advanced_function_macro_mod.das
+++ b/tutorials/macros/advanced_function_macro_mod.das
@@ -199,12 +199,13 @@ class MemoizeMacro : AstFunctionAnnotation {
         }
 
         // Step 6: Assemble the wrapper body
-        var bodyExprs : array<ExpressionPtr>
-        bodyExprs |> push <| qmacro_expr(${ let key = $e(keyExpr); })
-        bodyExprs |> push <| qmacro_expr(${ if (key_exists($i(cacheName), key)) { unsafe { return $i(cacheName)[key]; } } })
-        bodyExprs |> push <| qmacro_expr(${ let result = $c(originalCopyName)($a(callArgs)); })
-        bodyExprs |> push <| qmacro_expr(${ $i(cacheName) |> insert_clone(key, result); })
-        bodyExprs |> push <| qmacro_expr(${ return result; })
+        var bodyExprs <- [
+            qmacro_expr(${ let key = $e(keyExpr); }),
+            qmacro_expr(${ if (key_exists($i(cacheName), key)) { unsafe { return $i(cacheName)[key]; } } }),
+            qmacro_expr(${ let result = $c(originalCopyName)($a(callArgs)); }),
+            qmacro_expr(${ $i(cacheName) |> insert_clone(key, result); }),
+            qmacro_expr(${ return result; })
+        ]
 
         // Step 7: Create the wrapper function
         var wrapperFn <- qmacro_function(wrapperName) $($a(wrapperArgs)) : $t(wrapperRetType) {

--- a/tutorials/macros/qmacro_mod.das
+++ b/tutorials/macros/qmacro_mod.das
@@ -113,10 +113,11 @@ class BuildDemoMacro : AstCallMacro {
         // 6. qmacro_block() { stmts } — multiple statements as ExprBlock.
         //    $b(stmts) — splice array<ExpressionPtr> as a block body.
         // ===============================================================
-        var steps : array<ExpressionPtr>
-        steps |> push <| qmacro(print("  step 1\n"))
-        steps |> push <| qmacro(print("  step 2\n"))
-        steps |> push <| qmacro(print("  step 3\n"))
+        var steps <- [
+            qmacro(print("  step 1\n")),
+            qmacro(print("  step 2\n")),
+            qmacro(print("  step 3\n"))
+        ]
 
         var block_stmts = qmacro_block() {
             print("qmacro_block body:\n")

--- a/tutorials/macros/structure_macro_mod.das
+++ b/tutorials/macros/structure_macro_mod.das
@@ -95,12 +95,12 @@ class SerializableMacro : AstStructureAnnotation {
         // splice compile-time strings, and only `obj` (the generated
         // function's parameter) for runtime references.
         let funcName = "describe_{st.name}"
-        var bodyExprs : array<ExpressionPtr>
-
         // Header: "StructName (version N):\n"
-        bodyExprs |> push <| qmacro(print($v("{st.name} (version ")))
-        bodyExprs |> push <| qmacro(print("{obj._version}"))
-        bodyExprs |> push <| qmacro(print($v("):\n")))
+        var bodyExprs <- [
+            qmacro(print($v("{st.name} (version "))),
+            qmacro(print("{obj._version}")),
+            qmacro(print($v("):\n")))
+        ]
 
         // Build and register the stub.
         // $t(st) splices the struct type, $b() injects the statements.

--- a/utils/lint/tests/style001_false_positives.das
+++ b/utils/lint/tests/style001_false_positives.das
@@ -20,6 +20,6 @@ def good_lambda_shorthand_complex() {
 
 // Value pipe: <| expr is valid style, only block pipes should be flagged
 def good_value_pipe() {
-    var arr : array<int>
+    var arr <- [1, 2, 3]
     arr |> push <| 42
 }

--- a/utils/lint/tests/style012_array_push_instead_of_literal.das
+++ b/utils/lint/tests/style012_array_push_instead_of_literal.das
@@ -1,0 +1,97 @@
+options gen2
+// STYLE012: array<T> variable initialized via push/emplace instead of literal
+//
+// Problem: Declaring an empty `array<T>` and then populating it with a
+// contiguous run of TWO OR MORE `push`/`emplace` calls is a common
+// "I-forgot-how-to-init-arrays" bug — and it's both harder to read and slower
+// than using an array literal `var a <- [x, <-y]`. A single push stays silent
+// because it is often more readable that way.
+//
+// Bad pattern:
+//   var a : array<int>
+//   a |> push(1)
+//   a |> push(2)
+//
+// Good patterns:
+//   var a <- [1, 2]                          // inferred element type
+//   var a <- array<Shape?>(new Circle(),     // explicit element type,
+//                          new Square())     //   useful for polymorphic upcasts
+//
+// `push_clone` is intentionally NOT flagged — no clean array-literal equivalent.
+
+struct Foo {
+    x : int
+}
+
+// bad: two pushes after empty array decl (1 warning)
+def bad_push_sequence() {
+    var a : array<int>
+    a |> push(1)
+    a |> push(2)
+}
+
+// good: single push — readability is fine, stays silent
+def good_single_push() {
+    var a : array<int>
+    a |> push(42)
+}
+
+// bad: emplace sequence (1 warning)
+def bad_emplace_sequence() {
+    var f1 = Foo(x = 1)
+    var f2 = Foo(x = 2)
+    var a : array<Foo>
+    a |> emplace(f1)
+    a |> emplace(f2)
+}
+
+// bad: mixed push + emplace (1 warning)
+def bad_mixed() {
+    var f = Foo(x = 1)
+    var a : array<Foo>
+    a |> push(Foo(x = 0))
+    a |> emplace(f)
+}
+
+// good: array literal
+def good_literal() {
+    var a <- [1, 2, 3]
+    a |> push(4)  // the literal used initialization; this push is acceptable
+}
+
+// good: push_clone is intentionally ignored
+def good_push_clone() {
+    var s = "hi"
+    var a : array<string>
+    a |> push_clone(s)
+}
+
+// good: push inside a loop is fine (not a literal candidate)
+def good_loop_push() {
+    var a : array<int>
+    for (i in range(5)) {
+        a |> push(i)
+    }
+}
+
+// good: push inside conditional is fine
+def good_conditional_push(cond : bool) {
+    var a : array<int>
+    if (cond) {
+        a |> push(1)
+    }
+}
+
+// good: inscope variable (matches STYLE011 exclusion)
+def good_inscope() {
+    var inscope a : array<int>
+    a |> push(1)
+}
+
+// good: var decl followed by other statement, then push (push not contiguous)
+def good_interleaved() : int {
+    var a : array<int>
+    let x = 42
+    a |> push(x)
+    return x
+}


### PR DESCRIPTION
## Summary

New style lint rule **STYLE012** that detects the common "I forgot how to initialize an array" pattern:

```das
var a : array<int>
a |> push(1)
a |> push(2)
```

and suggests the array-literal form:

```das
var a <- [1, 2]
// or, for polymorphic upcasts / interface pointers:
var shapes <- array<Shape?>(new Circle(), new Square())
```

### Why a new rule
- Repeated `push`/`emplace` on a fresh array allocates and grows multiple times — a literal allocates once with the right capacity.
- The literal form makes the initial contents obvious at the declaration site.
- This pattern appears organically when writing daslang for the first time; catching it early saves reviewer churn.

### Detection scope
- Fires only on a contiguous run of **two or more** `push`/`emplace` calls immediately after a qualifying `var a : array<T>` (no init, not `generated`, not `inScope`, not in a generic-host instantiation — same exclusions as STYLE011).
- A single `push` right after the declaration is **not** flagged — often the more readable choice.
- `push_clone` is **deliberately excluded** — there is no clean array-literal equivalent for clone-semantic insertion.
- Loops and conditionals naturally break the contiguous run, so `for (i in range(N)) { a |> push(i) }` is left alone.

### Implementation
- `preVisitExprBlockExpression` locates the `ExprLet`'s index in `blk.list`, then walks forward counting matching `ExprCall` statements to `push`/`emplace` whose `arguments[0]` resolves (through `ExprRef2Value`) to the declared variable. Emits when the run length is ≥ 2.
- Lives in `daslib/style_lint.das`. No new state, no block-scope bookkeeping — lookahead from each declaration is enough.

### Incidental daslib / tutorial fixes
Running the rule across the tree surfaced 6 real hits in `daslib/rst.das` (table-row builders in `document_*` helpers) and ~14 incidental sites across 12 tutorial files (setup data for polymorphism, contracts, coroutine, async, apply, and macro demos). Those are rewritten to literals. Didactic sites where `push`/`emplace` **is** the lesson itself (`tutorials/language/06_arrays.das`, `17_move_copy_clone.das`, `27_testing.das`, `30_json.das`, `50_soa.das`, and one `qmacro_mod.das` site with inline comments between pushes that teach each reification operator) are intentionally left alone.

### Docs
- New `STYLE012 — array<T> initialized by a run of push/emplace` section in `doc/source/reference/language/lint.rst`.
- Rules-table row + Pure-AST detection bullet in `skills/style_lint.md`.
- Updated `//!` header in `daslib/style_lint.das`.

## Test plan

- [x] `bin/Release/daslang.exe utils/lint/main.das -- utils/lint/tests/style012_array_push_instead_of_literal.das --style-only` — 3 warnings on the 3 bad functions, 0 on the 7 good functions.
- [x] `bin/Release/daslang.exe utils/lint/main.das -- daslib tutorials --style-only --quiet` — confirms only the intentionally-left-alone didactic sites remain flagged (no regressions).
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests` — **6456 passed, 0 failed, 0 errors**.
- [x] Clean Sphinx build with zero warnings/errors (`doc/source/reference/language/lint.rst` edit validated).
- [x] All edited `.das` files run through MCP `format_file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)