### PR TITLE
ast: permissive tuple constness on argument pass

### DIFF
--- a/doc/source/reference/language/pointers.rst
+++ b/doc/source/reference/language/pointers.rst
@@ -234,6 +234,48 @@ Increment and addition
    Pointer arithmetic can easily cause out-of-bounds access or invalid
    pointer states.  Use array bounds-checked access whenever possible.
 
+.. _pointer_const_argument:
+
+--------------------------------
+Const widening when passing args
+--------------------------------
+
+When passing a pointer as a function argument, a non-const pointer ``T?`` is
+accepted where the parameter is declared as ``T const?``.  The callee promises
+not to modify the pointee, so narrowing the caller's permission is safe:
+
+.. code-block:: das
+
+    def inspect(p : Point const?) {   // read-only view
+        print("{p.x}, {p.y}\n")
+    }
+
+    var pt = new Point(x = 1.0, y = 2.0)
+    inspect(pt)                       // Point?  ->  Point const?  — OK
+
+The same widening applies when the pointer is wrapped in a :ref:`tuple <tuples>`
+at the top of the parameter type:
+
+.. code-block:: das
+
+    var ats : array<tuple<string; Point const?>>
+
+    def push_named(dst : array<tuple<string; Point const?>>;
+                   e   : tuple<string; Point const?>) {
+        dst |> push(e)
+    }
+
+    var p = new Point()
+    push_named(ats, ("origin", p))    // tuple<string; Point?>  accepted for
+                                      // tuple<string; Point const?>
+
+The rule is one-directional: a ``T const?`` argument is **not** accepted where
+a non-const ``T?`` is expected.  The widening also only applies at the top
+level of the argument type — pointers nested inside arrays, tables, or deeper
+structures must match constness exactly.  See ``TypeDecl::isSameType`` (the
+``isPassType`` parameter) in ``src/ast/ast_typedecl.cpp`` for the
+implementation.
+
 .. _pointer_void:
 
 --------------

--- a/doc/source/reference/language/tuples.rst
+++ b/doc/source/reference/language/tuples.rst
@@ -109,11 +109,51 @@ Iterators and containers can be expanded in the for-loop in a similar way:
         assert(c == "3")
     }
 
+Passing tuples as arguments — const widening
+============================================
+
+When a tuple value is passed as a function argument, each pointer field
+inside the tuple participates in the same const-widening rule used for
+top-level pointer parameters (see :ref:`Pointers <pointer_const_argument>`).
+A non-const pointer ``T?`` inside the argument tuple is accepted where the
+parameter tuple has ``T const?``:
+
+.. code-block:: das
+
+    struct Node { at : Loc }
+    var ats : array<tuple<string; Loc const?>>
+
+    // Exact-match overload.
+    def takeng(a : array<tuple<string; Loc const?>>;
+               b : tuple<string; Loc const?>) { ... }
+
+    // Generic overload — TT is inferred from the array element type,
+    // so b must match tuple<string; Loc const?> as well.
+    def take(a : array<auto(TT)>; b : TT) { ... }
+
+    def feed(var a : Node?&) {
+        take(ats,   ("test", unsafe(addr(a.at))))   // tuple<string; Loc?>
+        takeng(ats, ("test", unsafe(addr(a.at))))   // accepted for
+                                                    // tuple<string; Loc const?>
+    }
+
+The widening is one-directional (``T?`` widens to ``T const?``, not the
+reverse) and applies to tuples that appear **directly** as an argument type.
+Tuples nested inside containers or inside other structures are not relaxed —
+their element types must match exactly.  Variants and options do **not**
+participate in this relaxation.
+
+The implementation lives in ``TypeDecl::isSameType`` in
+``src/ast/ast_typedecl.cpp``: the ``isPassType`` flag is propagated into the
+tuple's ``argTypes`` comparison so the pointer field inherits the same
+relaxation that the top-level parameter pointer gets.
+
 .. seealso::
 
     :ref:`Datatypes <datatypes_and_values>` for a list of built-in types,
     :ref:`Pattern matching <pattern-matching>` for matching and destructuring tuples,
     :ref:`Finalizers <finalizers>` for tuple finalization,
     :ref:`Move, copy, and clone <clone_to_move>` for tuple copy and move rules,
-    :ref:`Aliases <aliases>` for the ``typedef`` shorthand tuple syntax.
+    :ref:`Aliases <aliases>` for the ``typedef`` shorthand tuple syntax,
+    :ref:`Pointers <pointer_const_argument>` for the matching rule on top-level pointer arguments.
 

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -1744,11 +1744,12 @@ namespace das
                         }
                     }
                 }
+                auto isPass = baseType==Type::tTuple ? isPassType : false;
                 for ( size_t i=0, is=argTypes.size(); i!=is; ++i ) {
                     const auto & arg = argTypes[i];
                     const auto & declArg = decl.argTypes[i];
                     if ( !arg->isSameType(*declArg, RefMatters::yes, ConstMatters::yes,
-                            TemporaryMatters::yes,AllowSubstitute::no,true ) ) {
+                            TemporaryMatters::yes,AllowSubstitute::no,true,isPass ) ) {
                         return false;
                     }
                 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -531,6 +531,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | override_field.das | Struct field `override` for function pointers in derived struct | |
 | partial_specialization.das | Generic function specialization dispatch | |
 | peek_and_modify_string.das | `peek_data` finds chars, `modify_data` replaces bytes | |
+| permissive_tuple_const.das | Tuple param with `const?` field accepts argument tuple with non-const `?` field (generic + exact overloads) | |
 | pointers.das | Pointer operations — new, deref, safe navigation, null checks | |
 | ptr_arithmetic.das | Pointer arithmetic — signed/unsigned int/int64/uint/uint64 | |
 | ptr_index.das | Pointer deref and index, default null pointer argument | |

--- a/tests/language/permissive_tuple_const.das
+++ b/tests/language/permissive_tuple_const.das
@@ -1,0 +1,49 @@
+options gen2
+require dastest/testing_boost public
+
+// Regression test for permissive tuple constness when passing a tuple
+// whose inner pointer is non-const to a parameter whose inner pointer
+// is const. See src/ast/ast_typedecl.cpp — isSameType propagates
+// isPassType into tuple argTypes.
+
+struct Loc {
+    a : int
+}
+
+struct Node {
+    at : Loc
+}
+
+typedef NodePtr = Node?
+
+var ats : array<tuple<string, Loc const?>>
+
+var generic_hits : int = 0
+var exact_hits : int = 0
+
+def take(a : array<auto(TT)>; b : TT) {
+    generic_hits ++
+}
+
+def takeng(a : array<tuple<string, Loc const?>>; b : tuple<string, Loc const?>) {
+    exact_hits ++
+}
+
+def feed(var a : NodePtr&) {
+    take(ats, ("test", unsafe(addr(a.at))))
+    takeng(ats, ("test", unsafe(addr(a.at))))
+}
+
+[test]
+def test_permissive_tuple_const(t : T?) {
+    t |> run("tuple with const-pointer field accepts non-const-pointer argument") @(t : T?) {
+        generic_hits = 0
+        exact_hits = 0
+        var e : Node
+        e.at.a = 42
+        var ep : NodePtr = unsafe(addr(e))
+        feed(ep)
+        t |> equal(generic_hits, 1)
+        t |> equal(exact_hits, 1)
+    }
+}


### PR DESCRIPTION
## Summary

- `TypeDecl::isSameType` now threads the `isPassType` flag into each tuple `argType` comparison, so a tuple whose pointer field is non-const binds to a parameter tuple whose field is declared `const?`. This mirrors the existing top-level pointer widening rule.
- The relaxation is one-directional (`T?` → `T const?`, not the reverse) and applies only at the top level of the argument type; pointers inside arrays, tables, or other nested containers still require exact constness match. Variants and options are not affected.
- New language test `tests/language/permissive_tuple_const.das` exercises both a generic `take(a : array<auto(TT)>; b : TT)` overload and an exact-match `takeng(...)` overload, passing `("test", unsafe(addr(node.at)))` against `tuple<string; Loc const?>`.
- Docs: new `_pointer_const_argument` section in `pointers.rst` and matching "Passing tuples as arguments — const widening" section in `tuples.rst`, cross-linked.

## Test plan

- [x] `daslang.exe` interpreter run of the new test passes
- [x] `test_aot.exe -use-aot` runs the new test — passes under AOT
- [x] Full `tests/` suite under interpreter: 6458 / 6458
- [x] Full `tests/` suite under `test_aot -use-aot`: 5873 / 5873
- [x] Lint of the new test file (`utils/lint/main.das`): no issues
- [x] Clean Sphinx build: `build succeeded.` with zero warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)