### PR TITLE
Run loop finally per-iteration across all execution tiers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ Or let VSCode CMake Tools pick up the settings change automatically.
 
 When AOT fails with `error[50101]: AOT link failed`, the issue is a **semantic hash mismatch** between the generated C++ stubs and runtime. Each generated `.cpp` file has hash comments showing function hashes and dependency hashes. The runtime error also prints the same breakdown. Compare them to find the diverging function or dependency. See `skills/aot_testing.md` for the full debugging guide (hash architecture, debug macros, common causes).
 
+The AOT C++ emitter lives in **`daslib/aot_cpp.das`** (the old `src/ast/ast_aot_cpp.cpp` was emptied by commit `581363ebc`). When codegen output diverges, edit `daslib/aot_cpp.das` — not the C++ stub in `src/ast/`.
+
 ## GitHub Operations
 
 - **Use GitHub MCP tools** (`mcp__github__*`) for all GitHub operations (creating PRs, listing issues, reading PRs, etc.) — they avoid shell escaping issues entirely
@@ -172,6 +174,7 @@ All code MUST use gen2 syntax (add `options gen2` at the top of every file). Key
 
 - daslang has garbage collection — `delete` is not required in most code
 - `var inscope` declares automatic cleanup; struct fields need defaults or `@safe_when_uninitialized`
+- `var inscope` is legal inside `for` / `while` loop bodies — the loop's `finally` runs per iteration (on fall-through, `continue`, `break`, `return`), so each iteration finalizes its own scoped variables
 - `<-` is memcpy+memset(0), NOT smart_ptr-aware — see `skills/das_macros.md` for smart_ptr patterns
 
 ### Context heaps and threading

--- a/CMakeCommon.txt
+++ b/CMakeCommon.txt
@@ -111,8 +111,8 @@ MACRO(SETUP_LIB_DEFINITIONS _target)
         )
     endif()
     target_compile_definitions(${_target} PUBLIC
-        $<$<CONFIG:Release>:DAS_FUSION=2 DAS_DEBUGGER=0>
-        $<$<CONFIG:MinSizeRel>:DAS_FUSION=1 DAS_DEBUGGER=0>
+        $<$<CONFIG:Release>:DAS_FUSION=2>
+        $<$<CONFIG:MinSizeRel>:DAS_FUSION=1>
         $<$<CONFIG:RelWithDebInfo>:DAS_FUSION=1>
     )
 ENDMACRO()

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -1401,9 +1401,6 @@ class public CppAot : AstVisitor {
     def override preVisitExprBlock(var blk : ExprBlock?) {
         push(scopes, blk);
         blk.blockFlags |= ExprBlockFlags.finallyBeforeBody;
-        if (blk.blockFlags.inTheLoop) {
-            blk.blockFlags |= ExprBlockFlags.finallyDisabled;
-        }
         write(*ss, "\{\n");
         tab ++;
         // pre-declare variables
@@ -2485,28 +2482,12 @@ class public CppAot : AstVisitor {
     }
 // ExprWhile
     def override preVisitExprWhile(wh : ExprWhile?) {
-        if (wh.body is ExprBlock) {
-            let blk = wh.body as ExprBlock;
-            if (!blk.finalList.empty()) {
-                write(*ss, "\{\n");
-                tab ++;
-                visit_finally(blk, adapter);
-                write(*ss, tabs());
-            }
-        }
         write(*ss, "while ( ");
     }
     def override preVisitExprWhileBody(wh : ExprWhile?; body : ExpressionPtr) {
         write(*ss, " )\n{tabs()}");
     }
     def override visitExprWhile(var wh : ExprWhile?) : ExpressionPtr {
-        if (wh.body is ExprBlock) {
-            let blk = wh.body as ExprBlock;
-            if (!blk.finalList.empty()) {
-                tab --;
-                write(*ss, "\n{tabs()}\}");
-            }
-        }
         return wh;
     }
 // if then else
@@ -3678,12 +3659,6 @@ class public CppAot : AstVisitor {
     }
     def override preVisitExprForBody(ffor : ExprFor?) {
         let nl = needLoopName(ffor);
-        if (ffor.body is ExprBlock) {
-            let blk = ffor.body as ExprBlock;
-            if (!blk.finalList.empty()) {
-                visit_finally(blk, adapter)
-            }
-        }
         write(*ss, "{tabs()}for ( ; {nl} ; {nl} = ");
         for (variable in ffor.iteratorVariables) {
             if (variable != ffor.iteratorVariables[0]) {

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -33,6 +33,8 @@ struct SuiteCtx {
     compile_only : bool = false
     use_aot : bool = false
     cov_path : string = ""
+    debugger : bool = false    // --debugger: set cop.debugger so context.debugger is truthy, exercising _Debug SimNode variants
+    keep_alive : bool = false  // --keep-alive: set cop.keep_alive so _KeepAlive SimNode variants get dispatched
 
     // Testing-related options.
     testNames : array<string>
@@ -99,6 +101,8 @@ def SuiteCtx(args : array<string>) : SuiteCtx {
     ctx.compile_only = args |> has_value("--compile-only")
     ctx.use_aot = args |> has_value("--use-aot") || is_in_aot()
     ctx.cov_path = args |> get_str_arg("--cov-path", "")
+    ctx.debugger = args |> has_value("--debugger")
+    ctx.keep_alive = args |> has_value("--keep-alive")
     collect_tests_names(args, ctx.testNames)
 
     ctx.bench_enabled = args |> has_value("--bench")
@@ -174,6 +178,8 @@ def test_file(file_name : string; var ctx : SuiteCtx; var file_ctx : FileCtx) : 
             cop.fail_on_no_aot = ctx.use_aot
             cop.threadlock_context = true
             cop.jit_enabled = jit_enabled()
+            cop.debugger = ctx.debugger
+            cop.keep_alive = ctx.keep_alive
             if (jit_enabled()) {
                 access |> add_extra_module("just_in_time", "{get_das_root()}/daslib/just_in_time.das")
             }

--- a/doc/source/reference/language/statements.rst
+++ b/doc/source/reference/language/statements.rst
@@ -415,17 +415,26 @@ how it exits (normal flow, ``break``, ``continue``, or ``return``):
         print("search complete\n")
     }
 
-``finally`` can be attached to any block, including loops and bare visibility blocks:
+When attached to a ``for`` or ``while`` loop body, ``finally`` runs **at the end of
+every iteration** — on normal fall-through, ``continue``, ``break``, and ``return``.
+This makes ``var inscope`` inside a loop body safe: each iteration finalizes its own
+scoped variables before the next iteration begins.
 
 .. code-block:: das
 
     for ( x in data ) {
-        if ( x < 0 ) {
-            break
-        }
+        var inscope buf <- allocate(x)
+        process(buf)
     } finally {
-        print("loop done\n")
+        print("iteration done\n")
     }
+    // "iteration done" prints once per element in `data`
+
+If the iterator is empty (or the initial ``while`` condition is false), the body
+never enters and the loop's ``finally`` never runs.
+
+``finally`` can also be attached to a bare visibility block, where it runs once
+when the block exits:
 
 .. code-block:: das
 
@@ -503,8 +512,8 @@ section of the enclosing block:
     // ... use resource ...
     // delete resource is called automatically at end of block
 
-``inscope`` cannot appear directly in a loop block, since the ``finally`` section of a loop
-executes only once.
+``inscope`` is allowed inside loop bodies — the loop's ``finally`` runs per iteration,
+so each iteration finalizes its own scoped variables.
 
 **Variable name aliases (aka):**
 

--- a/doc/source/reference/tutorials/20_lifetime.rst
+++ b/doc/source/reference/tutorials/20_lifetime.rst
@@ -77,12 +77,24 @@ that needs prompt release.
 finally blocks
 ==============
 
-``finally`` runs cleanup code when a block exits::
+``finally`` runs cleanup code when a block exits. When attached to a ``for`` or
+``while`` loop body, it runs at the end of **every** iteration — on normal
+fall-through, ``continue``, ``break``, and ``return``::
 
   for (i in range(3)) {
       counter += 1
   } finally {
-      print("done, counter={counter}\n")
+      print("iter done, counter={counter}\n")
+  }
+  // prints three times: counter=1, counter=2, counter=3
+
+This is what makes ``var inscope`` safe inside a loop body — each iteration
+finalizes its own scoped variables before the next one begins::
+
+  for (path in paths) {
+      var inscope f = acquire("File", path)
+      read(f)
+      // delete f runs here, at the end of each iteration
   }
 
 Heap pointers

--- a/doc/source/reference/tutorials/21_error_handling.rst
+++ b/doc/source/reference/tutorials/21_error_handling.rst
@@ -73,12 +73,14 @@ at the **caller's** line — useful inside generic functions::
 finally and defer
 =================
 
-``finally`` runs cleanup code when a block exits::
+``finally`` runs cleanup code when a block exits. On a ``for`` or ``while`` loop
+body it runs at the end of **every** iteration — normal fall-through,
+``continue``, ``break``, and ``return`` all route through it::
 
   for (i in range(3)) {
       total += i
   } finally {
-      print("loop done\n")
+      print("iter done\n")   // prints three times
   }
 
 ``defer`` (from ``daslib/defer``) schedules cleanup that runs when the

--- a/include/daScript/simulate/runtime_array.h
+++ b/include/daScript/simulate/runtime_array.h
@@ -141,24 +141,42 @@ namespace das
                 pi[t] = (char **)(context.stack.sp() + stackTop[t]);
                 szz = das::min(szz, int(pha[t]->size));
             }
-            SimNode ** __restrict tail = list + total;
-            for (int i = 0; i!=szz; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += strides[t];
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = list + total;
+                for (int i = 0; i!=szz; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += strides[t];
+                    }
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
                 }
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            } else {
+                SimNode ** __restrict tail = list + total;
+                for (int i = 0; i!=szz; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += strides[t];
+                    }
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
             for ( int t=0; t!=totalCount; ++t ) {
                 array_unlock(context, *pha[t], &this->debugInfo);
             }
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -173,9 +191,8 @@ namespace das
             V_FINAL();
             V_END();
         }
-        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & ) override {
             DAS_PROFILE_NODE
-            evalFinal(context);
             return v_zero();
         }
     };
@@ -197,20 +214,36 @@ namespace das
             int szz = int(pha->size);
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            SimNode ** __restrict tail = list + total;
-            for (int i = 0; i!=szz; ++i) {
-                *pi = ph;
-                ph += stride;
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = list + total;
+                for (int i = 0; i!=szz; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                }
+            } else {
+                SimNode ** __restrict tail = list + total;
+                for (int i = 0; i!=szz; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
             array_unlock(context, *pha, &this->debugInfo);
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -237,20 +270,32 @@ namespace das
                 pi[t] = (char **)(context.stack.sp() + stackTop[t]);
                 szz = das::min(szz, int(pha[t]->size));
             }
-            SimNode * __restrict body = list[0];
-            for (int i = 0; i!=szz && !context.stopFlags; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += strides[t];
+            if ( this->totalFinal == 0 ) {
+                SimNode * __restrict body = list[0];
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += strides[t];
+                    }
+                    body->eval(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
                 }
-                body->eval(context);
-                DAS_PROCESS_LOOP1_FLAGS(continue);
+            } else {
+                SimNode * __restrict body = list[0];
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += strides[t];
+                    }
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
             for ( int t=0; t!=totalCount; ++t ) {
                 array_unlock(context, *pha[t], &this->debugInfo);
             }
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -265,9 +310,8 @@ namespace das
             V_FINAL();
             V_END();
         }
-        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & ) override {
             DAS_PROFILE_NODE
-            evalFinal(context);
             return v_zero();
         }
     };
@@ -289,16 +333,26 @@ namespace das
             int szz = int(pha->size);
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            SimNode * __restrict body = list[0];
-            for (int i = 0; i!=szz && !context.stopFlags; ++i) {
-                *pi = ph;
-                ph += stride;
-                body->eval(context);
-                DAS_PROCESS_LOOP1_FLAGS(continue);
+            if ( this->totalFinal == 0 ) {
+                SimNode * __restrict body = list[0];
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    body->eval(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
+            } else {
+                SimNode * __restrict body = list[0];
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
             array_unlock(context, *pha, &this->debugInfo);
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -328,25 +382,44 @@ namespace das
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
                 szz = das::min(szz, int(pha[t]->size));
             }
-            SimNode ** __restrict tail = this->list + this->total;
-            for (int i = 0; i!=szz; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += this->strides[t];
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = this->list + this->total;
+                for (int i = 0; i!=szz; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    SimNode ** __restrict body = this->list;
+                loopbegin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
                 }
-                SimNode ** __restrict body = this->list;
-            loopbegin:;
-                DAS_KEEPALIVE_LOOP(&context);
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            } else {
+                SimNode ** __restrict tail = this->list + this->total;
+                for (int i = 0; i!=szz; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    SimNode ** __restrict body = this->list;
+                loopbegin_fin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
             for ( int t=0; t!=totalCount; ++t ) {
                 array_unlock(context, *pha[t], &this->debugInfo);
             }
-            this->evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -371,21 +444,38 @@ namespace das
             int szz = int(pha->size);
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            SimNode ** __restrict tail = list + total;
-            for (int i = 0; i!=szz; ++i) {
-                *pi = ph;
-                ph += stride;
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                DAS_KEEPALIVE_LOOP(&context);
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = list + total;
+                for (int i = 0; i!=szz; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                }
+            } else {
+                SimNode ** __restrict tail = list + total;
+                for (int i = 0; i!=szz; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
             array_unlock(context, *pha, &this->debugInfo);
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -409,20 +499,32 @@ namespace das
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
                 szz = das::min(szz, int(pha[t]->size));
             }
-            SimNode * __restrict body = this->list[0];
-            for (int i = 0; i!=szz && !context.stopFlags; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += this->strides[t];
+            if ( this->totalFinal == 0 ) {
+                SimNode * __restrict body = this->list[0];
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    body->eval(context);
+                    DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
                 }
-                body->eval(context);
-                DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+            } else {
+                SimNode * __restrict body = this->list[0];
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
             for ( int t=0; t!=totalCount; ++t ) {
                 array_unlock(context, *pha[t], &this->debugInfo);
             }
-            this->evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -447,16 +549,26 @@ namespace das
             int szz = int(pha->size);
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            SimNode * __restrict body = list[0];
-            for (int i = 0; i!=szz && !context.stopFlags; ++i) {
-                *pi = ph;
-                ph += stride;
-                body->eval(context);
-                DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+            if ( this->totalFinal == 0 ) {
+                SimNode * __restrict body = list[0];
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    body->eval(context);
+                    DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+                }
+            } else {
+                SimNode * __restrict body = list[0];
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
             array_unlock(context, *pha, &this->debugInfo);
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -488,25 +600,44 @@ namespace das
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
                 szz = das::min(szz, int(pha[t]->size));
             }
-            SimNode ** __restrict tail = this->list + this->total;
-            for (int i = 0; i!=szz; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += this->strides[t];
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = this->list + this->total;
+                for (int i = 0; i!=szz; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    SimNode ** __restrict body = this->list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
                 }
-                SimNode ** __restrict body = this->list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            } else {
+                SimNode ** __restrict tail = this->list + this->total;
+                for (int i = 0; i!=szz; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    SimNode ** __restrict body = this->list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
             for ( int t=0; t!=totalCount; ++t ) {
                 array_unlock(context, *pha[t], &this->debugInfo);
             }
-            this->evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -531,20 +662,37 @@ namespace das
             int szz = int(pha->size);
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            SimNode ** __restrict tail = list + total;
-            for (int i = 0; i!=szz; ++i) {
-                *pi = ph;
-                ph += stride;
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = list + total;
+                for (int i = 0; i!=szz; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                }
+            } else {
+                SimNode ** __restrict tail = list + total;
+                for (int i = 0; i!=szz; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
-            evalFinal(context);
             array_unlock(context, *pha, &this->debugInfo);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
@@ -569,21 +717,34 @@ namespace das
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
                 szz = das::min(szz, int(pha[t]->size));
             }
-            SimNode * __restrict body = this->list[0];
-            for (int i = 0; i!=szz && !context.stopFlags; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += this->strides[t];
+            if ( this->totalFinal == 0 ) {
+                SimNode * __restrict body = this->list[0];
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    DAS_SINGLE_STEP(context,body->debugInfo,true);
+                    body->eval(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
                 }
-                DAS_SINGLE_STEP(context,body->debugInfo,true);
-                body->eval(context);
-                DAS_PROCESS_LOOP1_FLAGS(continue);
+            } else {
+                SimNode * __restrict body = this->list[0];
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    DAS_SINGLE_STEP(context,body->debugInfo,true);
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
             for ( int t=0; t!=totalCount; ++t ) {
                 array_unlock(context, *pha[t], &this->debugInfo);
             }
-            this->evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -608,17 +769,28 @@ namespace das
             int szz = int(pha->size);
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            for (int i = 0; i!=szz && !context.stopFlags; ++i) {
-                *pi = ph;
-                ph += stride;
-                SimNode * body = list[0];    // note: instruments
-                DAS_SINGLE_STEP(context,body->debugInfo,true);
-                body->eval(context);
-                DAS_PROCESS_LOOP1_FLAGS(continue);
+            if ( this->totalFinal == 0 ) {
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode * body = list[0];    // note: instruments
+                    DAS_SINGLE_STEP(context,body->debugInfo,true);
+                    body->eval(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
+            } else {
+                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode * body = list[0];    // note: instruments
+                    DAS_SINGLE_STEP(context,body->debugInfo,true);
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
             array_unlock(context, *pha, &this->debugInfo);
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -647,21 +819,39 @@ namespace das
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + stackTop[t]);
             }
-            SimNode ** __restrict tail = list + total;
-            for (uint32_t i=0, is=size; i!=is; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += strides[t];
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = list + total;
+                for (uint32_t i=0, is=size; i!=is; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += strides[t];
+                    }
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
                 }
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            } else {
+                SimNode ** __restrict tail = list + total;
+                for (uint32_t i=0, is=size; i!=is; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += strides[t];
+                    }
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -676,9 +866,8 @@ namespace das
             V_FINAL();
             V_END();
         }
-        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & ) override {
             DAS_PROFILE_NODE
-            evalFinal(context);
             return v_zero();
         }
     };
@@ -694,19 +883,35 @@ namespace das
             char * __restrict ph = cast<char *>::to(sources[0]->eval(context));
             char ** __restrict pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            SimNode ** __restrict tail = list + total;
-            for (uint32_t i=0, is=size; i!=is; ++i) {
-                *pi = ph;
-                ph += stride;
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = list + total;
+                for (uint32_t i=0, is=size; i!=is; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                }
+            } else {
+                SimNode ** __restrict tail = list + total;
+                for (uint32_t i=0, is=size; i!=is; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -729,17 +934,29 @@ namespace das
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + stackTop[t]);
             }
-            SimNode * __restrict body = list[0];
-            for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += strides[t];
+            if ( this->totalFinal == 0 ) {
+                SimNode * __restrict body = list[0];
+                for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += strides[t];
+                    }
+                    body->eval(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
                 }
-                body->eval(context);
-                DAS_PROCESS_LOOP1_FLAGS(continue);
+            } else {
+                SimNode * __restrict body = list[0];
+                for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += strides[t];
+                    }
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -754,9 +971,8 @@ namespace das
             V_FINAL();
             V_END();
         }
-        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & ) override {
             DAS_PROFILE_NODE
-            evalFinal(context);
             return v_zero();
         }
     };
@@ -772,15 +988,25 @@ namespace das
             char * __restrict ph = cast<char *>::to(sources[0]->eval(context));
             char ** __restrict pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            SimNode * __restrict body = list[0];
-            for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
-                *pi = ph;
-                ph += stride;
-                body->eval(context);
-                DAS_PROCESS_LOOP1_FLAGS(continue);
+            if ( this->totalFinal == 0 ) {
+                SimNode * __restrict body = list[0];
+                for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    body->eval(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
+            } else {
+                SimNode * __restrict body = list[0];
+                for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -806,22 +1032,41 @@ namespace das
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
             }
-            SimNode ** __restrict tail = this->list + this->total;
-            for (uint32_t i=0, is=this->size; i!=is; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += this->strides[t];
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = this->list + this->total;
+                for (uint32_t i=0, is=this->size; i!=is; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    SimNode ** __restrict body = this->list;
+                loopbegin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
                 }
-                SimNode ** __restrict body = this->list;
-            loopbegin:;
-                DAS_KEEPALIVE_LOOP(&context);
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            } else {
+                SimNode ** __restrict tail = this->list + this->total;
+                for (uint32_t i=0, is=this->size; i!=is; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    SimNode ** __restrict body = this->list;
+                loopbegin_fin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
-            this->evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -840,20 +1085,37 @@ namespace das
             char * __restrict ph = cast<char *>::to(sources[0]->eval(context));
             char ** __restrict pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            SimNode ** __restrict tail = list + total;
-            for (uint32_t i=0, is=size; i!=is; ++i) {
-                *pi = ph;
-                ph += stride;
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                DAS_KEEPALIVE_LOOP(&context);
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = list + total;
+                for (uint32_t i=0, is=size; i!=is; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                }
+            } else {
+                SimNode ** __restrict tail = list + total;
+                for (uint32_t i=0, is=size; i!=is; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -876,17 +1138,29 @@ namespace das
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
             }
-            SimNode * __restrict body = this->list[0];
-            for (uint32_t i=0, is=this->size; i!=is && !context.stopFlags; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += this->strides[t];
+            if ( this->totalFinal == 0 ) {
+                SimNode * __restrict body = this->list[0];
+                for (uint32_t i=0, is=this->size; i!=is && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    body->eval(context);
+                    DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
                 }
-                body->eval(context);
-                DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+            } else {
+                SimNode * __restrict body = this->list[0];
+                for (uint32_t i=0, is=this->size; i!=is && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
-            this->evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -905,15 +1179,25 @@ namespace das
             char * __restrict ph = cast<char *>::to(sources[0]->eval(context));
             char ** __restrict pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            SimNode * __restrict body = list[0];
-            for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
-                *pi = ph;
-                ph += stride;
-                body->eval(context);
-                DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+            if ( this->totalFinal == 0 ) {
+                SimNode * __restrict body = list[0];
+                for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    body->eval(context);
+                    DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+                }
+            } else {
+                SimNode * __restrict body = list[0];
+                for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -942,22 +1226,41 @@ namespace das
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
             }
-            SimNode ** __restrict tail = this->list + this->total;
-            for (uint32_t i=0, is=this->size; i!=is; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += this->strides[t];
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = this->list + this->total;
+                for (uint32_t i=0, is=this->size; i!=is; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    SimNode ** __restrict body = this->list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
                 }
-                SimNode ** __restrict body = this->list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            } else {
+                SimNode ** __restrict tail = this->list + this->total;
+                for (uint32_t i=0, is=this->size; i!=is; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    SimNode ** __restrict body = this->list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
-            this->evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -976,20 +1279,37 @@ namespace das
             char * __restrict ph = cast<char *>::to(sources[0]->eval(context));
             char ** __restrict pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            SimNode ** __restrict tail = list + total;
-            for (uint32_t i=0, is=size; i!=is; ++i) {
-                *pi = ph;
-                ph += stride;
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                SimNode ** __restrict tail = list + total;
+                for (uint32_t i=0, is=size; i!=is; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                }
+            } else {
+                SimNode ** __restrict tail = list + total;
+                for (uint32_t i=0, is=size; i!=is; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
                 }
             }
         loopend:;
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -1009,18 +1329,31 @@ namespace das
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
             }
-            for (uint32_t i=0, is=this->size; i!=is && !context.stopFlags; ++i) {
-                for (int t = 0; t != totalCount; ++t) {
-                    *pi[t] = ph[t];
-                    ph[t] += this->strides[t];
+            if ( this->totalFinal == 0 ) {
+                for (uint32_t i=0, is=this->size; i!=is && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    SimNode * body = this->list[0]; // note: instruments
+                    DAS_SINGLE_STEP(context,body->debugInfo,true);
+                    body->eval(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
                 }
-                SimNode * body = this->list[0]; // note: instruments
-                DAS_SINGLE_STEP(context,body->debugInfo,true);
-                body->eval(context);
-                DAS_PROCESS_LOOP1_FLAGS(continue);
+            } else {
+                for (uint32_t i=0, is=this->size; i!=is && !context.stopFlags; ++i) {
+                    for (int t = 0; t != totalCount; ++t) {
+                        *pi[t] = ph[t];
+                        ph[t] += this->strides[t];
+                    }
+                    SimNode * body = this->list[0]; // note: instruments
+                    DAS_SINGLE_STEP(context,body->debugInfo,true);
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
-            this->evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -1039,16 +1372,27 @@ namespace das
             char * __restrict ph = cast<char *>::to(sources[0]->eval(context));
             char ** __restrict pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
-            for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
-                *pi = ph;
-                ph += stride;
-                SimNode * body = list[0];    // note: instruments
-                DAS_SINGLE_STEP(context,body->debugInfo,true);
-                body->eval(context);
-                DAS_PROCESS_LOOP1_FLAGS(continue);
+            if ( this->totalFinal == 0 ) {
+                for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode * body = list[0];    // note: instruments
+                    DAS_SINGLE_STEP(context,body->debugInfo,true);
+                    body->eval(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
+            } else {
+                for (uint32_t i=0, is=size; i!=is && !context.stopFlags; ++i) {
+                    *pi = ph;
+                    ph += stride;
+                    SimNode * body = list[0];    // note: instruments
+                    DAS_SINGLE_STEP(context,body->debugInfo,true);
+                    body->eval(context);
+                    this->evalFinal(context);
+                    DAS_PROCESS_LOOP1_FLAGS(continue);
+                }
             }
         loopend:;
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }

--- a/include/daScript/simulate/runtime_range.h
+++ b/include/daScript/simulate/runtime_range.h
@@ -171,18 +171,33 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        { SimNode ** __restrict tail = this->list + this->total;
-        for (baseType i = r.from; i != r_to; ++i) {
-            *pi = i;
-            SimNode ** __restrict body = this->list;
-        loopbegin:;
-            for (; body!=tail; ++body) {
-                (*body)->eval(context);
-                DAS_PROCESS_LOOP_FLAGS(break);
+        if ( this->totalFinal == 0 ) {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                SimNode ** __restrict body = this->list;
+            loopbegin:;
+                for (; body!=tail; ++body) {
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS(break);
+                }
             }
-        } }
+        } else {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                SimNode ** __restrict body = this->list;
+            loopbegin_fin:;
+                for (; body!=tail; ++body) {
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                }
+            loopend_fin:;
+                this->evalFinal(context);
+                if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~EvalFlags::stopForBreak;
         return v_zero();
     }
@@ -196,15 +211,25 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        { SimNode ** __restrict tail = this->list + this->total;
-        for (baseType i = r.from; i != r_to; ++i) {
-            *pi = i;
-            for (SimNode ** __restrict body = this->list; body!=tail; ++body) {
-                (*body)->eval(context);
+        if ( this->totalFinal == 0 ) {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                for (SimNode ** __restrict body = this->list; body!=tail; ++body) {
+                    (*body)->eval(context);
+                }
             }
-        } }
+        } else {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                for (SimNode ** __restrict body = this->list; body!=tail; ++body) {
+                    (*body)->eval(context);
+                }
+                this->evalFinal(context);
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~(EvalFlags::stopForBreak | EvalFlags::stopForContinue);
         return v_zero();
     }
@@ -218,14 +243,23 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        { SimNode * __restrict pbody = this->list[0];
-        for (baseType i = r.from; i != r_to; ++i) {
-            *pi = i;
-            pbody->eval(context);
-            DAS_PROCESS_LOOP1_FLAGS(continue);
-        } }
+        if ( this->totalFinal == 0 ) {
+            SimNode * __restrict pbody = this->list[0];
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                pbody->eval(context);
+                DAS_PROCESS_LOOP1_FLAGS(continue);
+            }
+        } else {
+            SimNode * __restrict pbody = this->list[0];
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                pbody->eval(context);
+                this->evalFinal(context);
+                DAS_PROCESS_LOOP1_FLAGS(continue);
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~(EvalFlags::stopForBreak | EvalFlags::stopForContinue);
         return v_zero();
     }
@@ -239,13 +273,21 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        { SimNode * __restrict pbody = this->list[0];
-        for (baseType i = r.from; i != r_to; ++i) {
-            *pi = i;
-            pbody->eval(context);
-        } }
+        if ( this->totalFinal == 0 ) {
+            SimNode * __restrict pbody = this->list[0];
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                pbody->eval(context);
+            }
+        } else {
+            SimNode * __restrict pbody = this->list[0];
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                pbody->eval(context);
+                this->evalFinal(context);
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~(EvalFlags::stopForBreak | EvalFlags::stopForContinue);
         return v_zero();
     }
@@ -265,19 +307,35 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        { SimNode ** __restrict tail = this->list + this->total;
-        for (baseType i = r.from; i != r_to; ++i) {
-            *pi = i;
-            SimNode ** __restrict body = this->list;
-        loopbegin:;
-            DAS_KEEPALIVE_LOOP(&context);
-            for (; body!=tail; ++body) {
-                (*body)->eval(context);
-                DAS_PROCESS_LOOP_FLAGS(break);
+        if ( this->totalFinal == 0 ) {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                SimNode ** __restrict body = this->list;
+            loopbegin:;
+                DAS_KEEPALIVE_LOOP(&context);
+                for (; body!=tail; ++body) {
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS(break);
+                }
             }
-        } }
+        } else {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                SimNode ** __restrict body = this->list;
+            loopbegin_fin:;
+                DAS_KEEPALIVE_LOOP(&context);
+                for (; body!=tail; ++body) {
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                }
+            loopend_fin:;
+                this->evalFinal(context);
+                if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~EvalFlags::stopForBreak;
         return v_zero();
     }
@@ -291,16 +349,27 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        { SimNode ** __restrict tail = this->list + this->total;
-        for (baseType i = r.from; i != r_to; ++i) {
-            DAS_KEEPALIVE_LOOP(&context);
-            *pi = i;
-            for (SimNode ** __restrict body = this->list; body!=tail; ++body) {
-                (*body)->eval(context);
+        if ( this->totalFinal == 0 ) {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                DAS_KEEPALIVE_LOOP(&context);
+                *pi = i;
+                for (SimNode ** __restrict body = this->list; body!=tail; ++body) {
+                    (*body)->eval(context);
+                }
             }
-        } }
+        } else {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                DAS_KEEPALIVE_LOOP(&context);
+                *pi = i;
+                for (SimNode ** __restrict body = this->list; body!=tail; ++body) {
+                    (*body)->eval(context);
+                }
+                this->evalFinal(context);
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~(EvalFlags::stopForBreak | EvalFlags::stopForContinue);
         return v_zero();
     }
@@ -314,14 +383,23 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        { SimNode * __restrict pbody = this->list[0];
-        for (baseType i = r.from; i != r_to; ++i) {
-            *pi = i;
-            pbody->eval(context);
-            DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
-        } }
+        if ( this->totalFinal == 0 ) {
+            SimNode * __restrict pbody = this->list[0];
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                pbody->eval(context);
+                DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+            }
+        } else {
+            SimNode * __restrict pbody = this->list[0];
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                pbody->eval(context);
+                this->evalFinal(context);
+                DAS_PROCESS_KEEPALIVE_LOOP1_FLAGS(continue);
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~(EvalFlags::stopForBreak | EvalFlags::stopForContinue);
         return v_zero();
     }
@@ -335,14 +413,23 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        { SimNode * __restrict pbody = this->list[0];
-        for (baseType i = r.from; i != r_to; ++i) {
-            *pi = i;
-            pbody->eval(context);
-            DAS_KEEPALIVE_LOOP(&context);
-        } }
+        if ( this->totalFinal == 0 ) {
+            SimNode * __restrict pbody = this->list[0];
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                pbody->eval(context);
+                DAS_KEEPALIVE_LOOP(&context);
+            }
+        } else {
+            SimNode * __restrict pbody = this->list[0];
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                pbody->eval(context);
+                this->evalFinal(context);
+                DAS_KEEPALIVE_LOOP(&context);
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~(EvalFlags::stopForBreak | EvalFlags::stopForContinue);
         return v_zero();
     }
@@ -364,19 +451,35 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        { SimNode ** __restrict tail = this->list + this->total;
-        for (baseType i = r.from; i != r_to; ++i) {
-            *pi = i;
-            SimNode ** __restrict body = this->list;
-        loopbegin:;
-            for (; body!=tail; ++body) {
-                DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
-                (*body)->eval(context);
-                DAS_PROCESS_LOOP_FLAGS(break);
+        if ( this->totalFinal == 0 ) {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                SimNode ** __restrict body = this->list;
+            loopbegin:;
+                for (; body!=tail; ++body) {
+                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS(break);
+                }
             }
-        } }
+        } else {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                SimNode ** __restrict body = this->list;
+            loopbegin_fin:;
+                for (; body!=tail; ++body) {
+                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                }
+            loopend_fin:;
+                this->evalFinal(context);
+                if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~EvalFlags::stopForBreak;
         return v_zero();
     }
@@ -390,16 +493,27 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        { SimNode ** __restrict tail = this->list + this->total;
-        for (baseType i = r.from; i != r_to; ++i) {
-            *pi = i;
-            for (SimNode ** __restrict body = this->list; body!=tail; ++body) {
-                DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
-                (*body)->eval(context);
+        if ( this->totalFinal == 0 ) {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                for (SimNode ** __restrict body = this->list; body!=tail; ++body) {
+                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                    (*body)->eval(context);
+                }
             }
-        } }
+        } else {
+            SimNode ** __restrict tail = this->list + this->total;
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                for (SimNode ** __restrict body = this->list; body!=tail; ++body) {
+                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                    (*body)->eval(context);
+                }
+                this->evalFinal(context);
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~(EvalFlags::stopForBreak | EvalFlags::stopForContinue);
         return v_zero();
     }
@@ -413,16 +527,25 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        {
-        for (baseType i = r.from; i != r_to; ++i) {
-            *pi = i;
-            SimNode * pbody = this->list[0];   // note: instruments
-            DAS_SINGLE_STEP(context,pbody->debugInfo,true);
-            pbody->eval(context);
-            DAS_PROCESS_LOOP1_FLAGS(continue);
-        } }
+        if ( this->totalFinal == 0 ) {
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                SimNode * pbody = this->list[0];   // note: instruments
+                DAS_SINGLE_STEP(context,pbody->debugInfo,true);
+                pbody->eval(context);
+                DAS_PROCESS_LOOP1_FLAGS(continue);
+            }
+        } else {
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                SimNode * pbody = this->list[0];   // note: instruments
+                DAS_SINGLE_STEP(context,pbody->debugInfo,true);
+                pbody->eval(context);
+                this->evalFinal(context);
+                DAS_PROCESS_LOOP1_FLAGS(continue);
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~(EvalFlags::stopForBreak | EvalFlags::stopForContinue);
         return v_zero();
     }
@@ -436,15 +559,23 @@ namespace das
         baseType * pi = (baseType *)(context.stack.sp() + this->stackTop[0]);
         baseType r_to = r.to;
         if ( r.from >= r_to ) goto loopend;
-        {
-        for (baseType i = r.from; i != r_to; ++i) {
-            *pi = i;
-            SimNode * pbody = this->list[0];   // note: instruments
-            DAS_SINGLE_STEP(context,pbody->debugInfo,true);
-            pbody->eval(context);
-        } }
+        if ( this->totalFinal == 0 ) {
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                SimNode * pbody = this->list[0];   // note: instruments
+                DAS_SINGLE_STEP(context,pbody->debugInfo,true);
+                pbody->eval(context);
+            }
+        } else {
+            for (baseType i = r.from; i != r_to; ++i) {
+                *pi = i;
+                SimNode * pbody = this->list[0];   // note: instruments
+                DAS_SINGLE_STEP(context,pbody->debugInfo,true);
+                pbody->eval(context);
+                this->evalFinal(context);
+            }
+        }
     loopend:;
-        this->evalFinal(context);
         context.stopFlags &= ~(EvalFlags::stopForBreak | EvalFlags::stopForContinue);
         return v_zero();
     }

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -174,7 +174,7 @@ namespace das
     ,   yield               = 1 << 4
     };
 
-#define DAS_PROCESS_LOOP_FLAGS(howtocontinue) \
+#define DAS_PROCESS_LOOP_FLAGS_LABELED(beginLabel,endLabel,howtocontinue) \
     {   if (context.stopFlags) { \
         if (context.stopFlags & EvalFlags::stopForContinue) { \
             context.stopFlags &= ~EvalFlags::stopForContinue; \
@@ -182,11 +182,14 @@ namespace das
         } else if (context.stopFlags&EvalFlags::jumpToLabel && context.gotoLabel<this->totalLabels) { \
             if ((body=this->list+this->labels[context.gotoLabel])>=this->list) { \
                 context.stopFlags &= ~EvalFlags::jumpToLabel; \
-                goto loopbegin; \
+                goto beginLabel; \
             } \
         } \
-        goto loopend; \
+        goto endLabel; \
     } }
+
+#define DAS_PROCESS_LOOP_FLAGS(howtocontinue) \
+    DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin,loopend,howtocontinue)
 
 #define DAS_PROCESS_LOOP1_FLAGS(howtocontinue) \
     {   if (context.stopFlags) { \

--- a/include/daScript/simulate/simulate_nodes.h
+++ b/include/daScript/simulate/simulate_nodes.h
@@ -3508,21 +3508,38 @@ SIM_NODE_AT_VECTOR(Float, float)
                 if ( context.stopFlags ) goto loopend;
             }
             if ( !needLoop ) goto loopend;
-            while ( !context.stopFlags ) {
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                    for ( int t=0; t!=totalCount; ++t ){
+                        if ( !sources[t]->next(context, pi[t]) ) goto loopend;
+                        if ( context.stopFlags ) goto loopend;
+                    }
                 }
-                for ( int t=0; t!=totalCount; ++t ){
-                    if ( !sources[t]->next(context, pi[t]) ) goto loopend;
-                    if ( context.stopFlags ) goto loopend;
+            } else {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
+                    for ( int t=0; t!=totalCount; ++t ){
+                        if ( !sources[t]->next(context, pi[t]) ) goto loopend;
+                        if ( context.stopFlags ) goto loopend;
+                    }
                 }
             }
         loopend:
             closeIterators(sources, pi, context);
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -3538,9 +3555,8 @@ SIM_NODE_AT_VECTOR(Float, float)
             V_FINAL();
             V_END();
         }
-        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
+        DAS_EVAL_ABI virtual vec4f eval ( Context & ) override {
             DAS_PROFILE_NODE
-            evalFinal(context);
             return v_zero();
         }
     };
@@ -3563,19 +3579,34 @@ SIM_NODE_AT_VECTOR(Float, float)
             sources->isOpen = true;
             needLoop = sources->first(context, pi) && needLoop;
             if ( context.stopFlags || !needLoop) goto loopend;
-            while ( !context.stopFlags ) {
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                    if ( !sources->next(context, pi) ) goto loopend;
+                    if ( context.stopFlags ) goto loopend;
                 }
-                if ( !sources->next(context, pi) ) goto loopend;
-                if ( context.stopFlags ) goto loopend;
+            } else {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
+                    if ( !sources->next(context, pi) ) goto loopend;
+                    if ( context.stopFlags ) goto loopend;
+                }
             }
         loopend:
             sources->close(context, pi);
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -3616,22 +3647,40 @@ SIM_NODE_AT_VECTOR(Float, float)
                 if ( context.stopFlags ) goto loopend;
             }
             if ( !needLoop ) goto loopend;
-            while ( !context.stopFlags ) {
-                SimNode ** __restrict body = this->list;
-            loopbegin:;
-                DAS_KEEPALIVE_LOOP(&context);
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = this->list;
+                loopbegin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                    for ( int t=0; t!=totalCount; ++t ){
+                        if ( !sources[t]->next(context, pi[t]) ) goto loopend;
+                        if ( context.stopFlags ) goto loopend;
+                    }
                 }
-                for ( int t=0; t!=totalCount; ++t ){
-                    if ( !sources[t]->next(context, pi[t]) ) goto loopend;
-                    if ( context.stopFlags ) goto loopend;
+            } else {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = this->list;
+                loopbegin_fin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
+                    for ( int t=0; t!=totalCount; ++t ){
+                        if ( !sources[t]->next(context, pi[t]) ) goto loopend;
+                        if ( context.stopFlags ) goto loopend;
+                    }
                 }
             }
         loopend:
             this->closeIterators(sources, pi, context);
-            this->evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -3658,20 +3707,36 @@ SIM_NODE_AT_VECTOR(Float, float)
             sources->isOpen = true;
             needLoop = sources->first(context, pi) && needLoop;
             if ( context.stopFlags || !needLoop) goto loopend;
-            while ( !context.stopFlags ) {
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                DAS_KEEPALIVE_LOOP(&context);
-                for (; body!=tail; ++body) {
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                    if ( !sources->next(context, pi) ) goto loopend;
+                    if ( context.stopFlags ) goto loopend;
                 }
-                if ( !sources->next(context, pi) ) goto loopend;
-                if ( context.stopFlags ) goto loopend;
+            } else {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    DAS_KEEPALIVE_LOOP(&context);
+                    for (; body!=tail; ++body) {
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
+                    if ( !sources->next(context, pi) ) goto loopend;
+                    if ( context.stopFlags ) goto loopend;
+                }
             }
         loopend:
             sources->close(context, pi);
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -3714,22 +3779,40 @@ SIM_NODE_AT_VECTOR(Float, float)
                 if ( context.stopFlags ) goto loopend;
             }
             if ( !needLoop ) goto loopend;
-            while ( !context.stopFlags ) {
-                SimNode ** __restrict body = this->list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = this->list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                    for ( int t=0; t!=totalCount; ++t ){
+                        if ( !sources[t]->next(context, pi[t]) ) goto loopend;
+                        if ( context.stopFlags ) goto loopend;
+                    }
                 }
-                for ( int t=0; t!=totalCount; ++t ){
-                    if ( !sources[t]->next(context, pi[t]) ) goto loopend;
-                    if ( context.stopFlags ) goto loopend;
+            } else {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = this->list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
+                    for ( int t=0; t!=totalCount; ++t ){
+                        if ( !sources[t]->next(context, pi[t]) ) goto loopend;
+                        if ( context.stopFlags ) goto loopend;
+                    }
                 }
             }
         loopend:
             this->closeIterators(sources, pi, context);
-            this->evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }
@@ -3756,20 +3839,36 @@ SIM_NODE_AT_VECTOR(Float, float)
             sources->isOpen = true;
             needLoop = sources->first(context, pi) && needLoop;
             if ( context.stopFlags || !needLoop) goto loopend;
-            while ( !context.stopFlags ) {
-                SimNode ** __restrict body = list;
-            loopbegin:;
-                for (; body!=tail; ++body) {
-                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
-                    (*body)->eval(context);
-                    DAS_PROCESS_LOOP_FLAGS(break);
+            if ( this->totalFinal == 0 ) {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = list;
+                loopbegin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS(break);
+                    }
+                    if ( !sources->next(context, pi) ) goto loopend;
+                    if ( context.stopFlags ) goto loopend;
                 }
-                if ( !sources->next(context, pi) ) goto loopend;
-                if ( context.stopFlags ) goto loopend;
+            } else {
+                while ( !context.stopFlags ) {
+                    SimNode ** __restrict body = list;
+                loopbegin_fin:;
+                    for (; body!=tail; ++body) {
+                        DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                        (*body)->eval(context);
+                        DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                    }
+                loopend_fin:;
+                    this->evalFinal(context);
+                    if ( context.stopFlags & (EvalFlags::stopForBreak | EvalFlags::stopForReturn) ) goto loopend;
+                    if ( !sources->next(context, pi) ) goto loopend;
+                    if ( context.stopFlags ) goto loopend;
+                }
             }
         loopend:
             sources->close(context, pi);
-            evalFinal(context);
             context.stopFlags &= ~EvalFlags::stopForBreak;
             return v_zero();
         }

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -866,7 +866,9 @@ class public LlvmJitVisitor : AstVisitor {
             if (stopAtLoop && blk.blockFlags.inTheLoop) {
                 break
             }
-            return true
+            if (blk |> hasFinalSection()) {
+                return true
+            }
         }
         return false
     }

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -291,6 +291,7 @@ class public LlvmJitVisitor : AstVisitor {
     sortedLabels : array<SLabel>
     finallyBlocks : table<ExprBlock?; LLVMOpaqueBasicBlock?>
     afterFinallyBlocks : table<ExprBlock?; array<LLVMOpaqueBasicBlock?>>
+    forBodyToExpr : table<ExprBlock?; ExprFor?>     // for-loop body block -> ExprFor (for iterator close on return path)
     skipCall : table<ExprCall?>
     range2 : table<Expression?; LLVMOpaqueValue?>       // for loop - range - where to
     callBlock : LLVMOpaqueValue?
@@ -509,7 +510,7 @@ class public LlvmJitVisitor : AstVisitor {
     }
 
     def process_finally(expr : ExpressionPtr) {
-        var blk <- collect_finally(expr, true)
+        var blk <- collect_finally(expr, false)
         sort(blk) <| $(a, b) => uid.get_block_name_ptr(a).publ() < uid.get_block_name_ptr(b).publ()
         for (bl in blk) {
             finallyBlocks[bl] = append_basic_block("finally_block_at_{int(bl.at.line)}_")
@@ -855,11 +856,7 @@ class public LlvmJitVisitor : AstVisitor {
         if (blk == null) {
             return false
         }
-        if (length(blk.finalList) > 0) {
-            return true
-        }
-        // TODO: do better test here. block with iterator, or over an array<> has a final section. maybe other??? but not all
-        return blk.blockFlags.forLoop   // for loop always has final section
+        return length(blk.finalList) > 0
     }
 
     def has_any_finally_block(stopAtLoop : bool) {
@@ -879,9 +876,7 @@ class public LlvmJitVisitor : AstVisitor {
         var anyFinallyBlocks = false
         for (i in range(len)) {
             var blk = block_stack[len - 1 - i]
-            if (stopAtLoop && (blk.blockFlags.inTheLoop || blk.blockFlags.forLoop)) {
-                break
-            }
+            var atLoopBoundary = stopAtLoop && (blk.blockFlags.inTheLoop || blk.blockFlags.forLoop)
             if (blk |> hasFinalSection()) {
                 var after = append_basic_block("{from_where}_after_call_finally_block_{int(blk.at.line)}")
                 var after_ptr = LLVMBlockAddress(LLVMGetBasicBlockParent(after), after)
@@ -892,14 +887,20 @@ class public LlvmJitVisitor : AstVisitor {
                 afterFinallyBlocks[blk] |> push(after)
                 anyFinallyBlocks = true
             }
+            // For return paths that bypass loop_end (stopAtLoop=false), emit iterator-close
+            // for each enclosing for-loop body. break/continue route through loop_end/loop_continue
+            // which already handle close, so skip there.
+            if (!stopAtLoop && blk.blockFlags.forLoop && key_exists(forBodyToExpr, blk)) {
+                emit_iterator_close(forBodyToExpr[blk])
+            }
+            if (atLoopBoundary) {
+                break
+            }
         }
         return anyFinallyBlocks
     }
 
     def override preVisitExprBlock(var blk : ExprBlock?) : void {
-        if (blk.blockFlags.inTheLoop) {
-            blk.blockFlags |= ExprBlockFlags.finallyDisabled
-        }
         block_stack |> push(blk)
     }
 
@@ -913,14 +914,13 @@ class public LlvmJitVisitor : AstVisitor {
 
     def override preVisitExprBlockFinal(blk : ExprBlock?) : void {
         add_default_terminator(blk)
-        if (!blk.blockFlags.forLoop) {// for loop just does it
-            if (finallyBlocks |> key_exists(blk)) {
-                var fblk = finallyBlocks[blk]
-                if (!current_block_terminates()) {
-                    LLVMBuildBr(g_builder, fblk)
-                }
-                LLVMPositionBuilderAtEnd(g_builder, fblk)
+        if (finallyBlocks |> key_exists(blk)) {
+            var fblk = finallyBlocks[blk]
+            if (!current_block_terminates()) {
+                LLVMBuildStore(g_builder, LLVMConstNull(LLVMPointerType(types.t_int8, 0u)), callBlock)
+                LLVMBuildBr(g_builder, fblk)
             }
+            LLVMPositionBuilderAtEnd(g_builder, fblk)
         }
     }
 
@@ -949,15 +949,12 @@ class public LlvmJitVisitor : AstVisitor {
     }
 
     def override visitExprBlock(var blk : ExprBlock?) : ExpressionPtr {
-        if (length(blk.finalList) == 0) {// TODO: check for loop
+        if (length(blk.finalList) == 0) {
             add_default_terminator(blk)
-        } elif (!blk.blockFlags.inTheLoop) {
+        } else {
             jump_to_next_finally(blk)
         }
         block_stack |> pop()
-        if (blk.blockFlags.inTheLoop) {
-            blk.blockFlags ^= ExprBlockFlags.finallyDisabled
-        }
         return blk
     }
 
@@ -2693,15 +2690,6 @@ class public LlvmJitVisitor : AstVisitor {
             LLVMBuildBr(g_builder, lblk.loop_start)
         }
         LLVMPositionBuilderAtEnd(g_builder, lblk.loop_end)
-        if (expr.body is ExprBlock) {
-            let body = expr.body as ExprBlock
-            if (length(body.finalList) != 0) {
-                LLVMBuildStore(g_builder, LLVMConstNull(LLVMPointerType(types.t_int8, 0u)), callBlock)
-                LLVMBuildBr(g_builder, finallyBlocks[body])
-                visit_finally(body, adapter)
-                jump_to_next_finally(body)
-            }
-        }
         return expr
     }
 
@@ -2870,6 +2858,9 @@ class public LlvmJitVisitor : AstVisitor {
             lblk.need_loop = LLVMBuildAlloca(g_builder, types.t_int1, "need_loop")
         }
         loop_stack |> push(lblk)
+        if (expr.body is ExprBlock) {
+            forBodyToExpr[expr.body as ExprBlock] = expr
+        }
         for (ssrc in expr.sources) {
             if (is_count_or_ucount(ssrc)) {
                 skipCall |> insert(ssrc as ExprCall)
@@ -3103,13 +3094,13 @@ class public LlvmJitVisitor : AstVisitor {
             }
         */
         LLVMPositionBuilderAtEnd(g_builder, lblk.loop_end)                  // LOOP END
-        // in for loop closing iterators is included in the finally section
-        let body = expr.body as ExprBlock
-        var fblk = finallyBlocks[body]
-        LLVMBuildStore(g_builder, LLVMConstNull(LLVMPointerType(types.t_int8, 0u)), callBlock)
-        LLVMBuildBr(g_builder, fblk)
-        LLVMPositionBuilderAtEnd(g_builder, fblk)
-        // close all iterators
+        emit_iterator_close(expr)
+        return expr
+    }
+
+    def emit_iterator_close(expr : ExprFor?) {
+        // close iterators in reverse order; called at loop_end (normal/break exit)
+        // and inline in call_all_finally_blocks for return paths that bypass loop_end
         let len = length(expr.iteratorVariables)
         for (i in range(len)) {
             let ri = len - i - 1
@@ -3126,12 +3117,6 @@ class public LlvmJitVisitor : AstVisitor {
                 }
             }
         }
-        // now, final block if there is anything there
-        if (length(body.finalList) != 0) {
-            visit_finally(body, adapter)
-        }
-        jump_to_next_finally(body)
-        return expr
     }
 
 // ExprMakeVariant

--- a/skills/aot_testing.md
+++ b/skills/aot_testing.md
@@ -16,6 +16,16 @@ daslang supports three execution tiers: interpreter → AOT (to C++) → JIT (LL
   - `cop.aot_module = true` — set during AOT generation (not at runtime)
   - `cop.aot_lib = true` — library AOT mode (for daslib modules)
 
+### AOT C++ emitter location
+
+The AOT C++ emitter lives in **`daslib/aot_cpp.das`** (a visitor written in daslang). The old `src/ast/ast_aot_cpp.cpp` was emptied by commit `581363ebc` — do not edit it. When codegen output changes shape, edit `daslib/aot_cpp.das` and rebuild `libDaScriptAot`.
+
+Key helpers used by the emitter:
+
+- **`preVisitExprBlockFinal(blk)`** — emits `auto <finallyName> = das_finally([&]() { ... });` at the start of the block's finally region. The RAII guard fires on normal fall-through, `continue`, `break`, and `return`. For `for`/`while` loop bodies the guard sits **inside** the generated C++ body braces, so finally runs once per iteration — not once after the loop.
+- **`das_finally`** — C++ RAII scope guard defined in the runtime. Destructor runs the captured finally lambda at any scope exit.
+- **`finallyName(blk)`** — generates a unique C++ identifier for the per-block `das_finally` guard variable.
+
 ## The test_aot Binary
 
 `tests/aot/CMakeLists.txt` defines the `test_aot` executable — a standalone binary with AOT stubs compiled in. It uses the same `main.cpp` as `daslang` but links additional AOT-generated object files.

--- a/src/ast/ast_generate.cpp
+++ b/src/ast/ast_generate.cpp
@@ -926,8 +926,8 @@ namespace das {
 
     class BreakAndContinueVisitor : public Visitor {
     public:
-        BreakAndContinueVisitor ( int32_t bg, int32_t cg )
-            : breakGoto(bg), continueGoto(cg) {
+        BreakAndContinueVisitor ( int32_t bg, int32_t cg, const string & bf = string() )
+            : breakGoto(bg), continueGoto(cg), breakFlag(bf) {
         }
         virtual void preVisit ( ExprWhile * expr ) override {
             Visitor::preVisit(expr);
@@ -947,7 +947,19 @@ namespace das {
         }
         virtual ExpressionPtr visit(ExprBreak *expr) override {
             if ( depth ) return Visitor::visit(expr);
-            return new ExprGoto(expr->at, breakGoto);
+            if ( breakFlag.empty() ) {
+                return new ExprGoto(expr->at, breakGoto);
+            }
+            // emit: { breakFlag = true; goto breakGoto }
+            auto blk = new ExprBlock();
+            blk->at = expr->at;
+            blk->isCollapseable = true;
+            auto flg = new ExprVar(expr->at, breakFlag);
+            auto trv = new ExprConstBool(expr->at, true);
+            auto cpy = new ExprCopy(expr->at, flg, trv);
+            blk->list.push_back(cpy);
+            blk->list.push_back(new ExprGoto(expr->at, breakGoto));
+            return blk;
         }
         virtual ExpressionPtr visit(ExprContinue *expr) override {
             if ( depth ) return Visitor::visit(expr);
@@ -956,11 +968,17 @@ namespace das {
     protected:
         int32_t breakGoto;
         int32_t continueGoto;
+        string  breakFlag;
         int     depth = 0;
     };
 
     void replaceBreakAndContinue ( Expression * expr, int32_t bg, int32_t cg ) {
         BreakAndContinueVisitor rbnc(bg, cg);
+        expr->visit(rbnc);
+    }
+
+    void replaceBreakAndContinueWithFlag ( Expression * expr, int32_t bg, int32_t cg, const string & breakFlag ) {
+        BreakAndContinueVisitor rbnc(bg, cg, breakFlag);
         expr->visit(rbnc);
     }
 
@@ -1137,19 +1155,49 @@ namespace das {
 
     ExpressionPtr replaceGeneratorWhile ( ExprWhile * expr, const FunctionPtr & func ) {
         auto begin_loop_label = func->totalGenLabel ++;
+        auto iter_end_loop_label = func->totalGenLabel ++;
         auto end_loop_label = func->totalGenLabel ++;
         ExprBlock * bodyBlock = nullptr;
+        const bool hasFinally = expr->body->rtti_isBlock() &&
+                                !static_cast<ExprBlock*>(expr->body)->finalList.empty();
+        // only introduce __broke flag when body has a finally — otherwise classic break -> end
+        string breakFlag;
+        if ( hasFinally ) {
+            breakFlag = "__broke_while_" + to_string(expr->at.line) + "_" + to_string(expr->at.column);
+        }
         if ( expr->body->rtti_isBlock() ) {
             bodyBlock = static_cast<ExprBlock*>(expr->body->clone());
             giveBlockVariablesUniqueNames(bodyBlock);
-            replaceBreakAndContinue(bodyBlock, end_loop_label, begin_loop_label);
+            if ( hasFinally ) {
+                // break -> set flag, goto iter_end (runs finally, then exits via flag check)
+                // continue -> iter_end (runs finally, flag=false, loops back)
+                replaceBreakAndContinueWithFlag(bodyBlock, iter_end_loop_label, iter_end_loop_label, breakFlag);
+            } else {
+                replaceBreakAndContinue(bodyBlock, end_loop_label, begin_loop_label);
+            }
         }
         auto blk = new ExprBlock();
         blk->at = expr->at;
         blk->isCollapseable = true;
+        // __broke = false  (only when finally present)
+        if ( hasFinally ) {
+            auto leqt = new ExprLet();
+            leqt->at = expr->at;
+            leqt->atInit = expr->at;
+            leqt->visibility = expr->at;
+            auto bvar = new Variable();
+            bvar->generated = true;
+            bvar->at = expr->at;
+            bvar->name = breakFlag;
+            bvar->type = new TypeDecl(Type::tBool);
+            bvar->init = new ExprConstBool(expr->at, false);
+            leqt->variables.push_back(bvar);
+            blk->list.push_back(leqt);
+        }
         auto bll = new ExprLabel(expr->at, begin_loop_label,
                                           "begin while at line " + to_string(expr->at.line));
         blk->list.push_back(bll);
+        // false initial / exhausted cond skips finally entirely
         auto gtel = new ExprGoto(expr->at, end_loop_label);
         auto btel = new ExprBlock();
         btel->at = expr->at;
@@ -1164,16 +1212,27 @@ namespace das {
         } else {
             blk->list.push_back(expr->body->clone());
         }
+        if ( hasFinally ) {
+            // iter_end label: per-iteration finally (normal fall-through, continue, break all route here)
+            auto iell = new ExprLabel(expr->at, iter_end_loop_label,
+                                               "iter end while at line " + to_string(expr->at.line));
+            blk->list.push_back(iell);
+            for ( auto & fse : bodyBlock->finalList ) {
+                blk->list.push_back(fse->clone());
+            }
+            // if (__broke) goto end — else fall through to goto begin
+            auto gtef = new ExprGoto(expr->at, end_loop_label);
+            auto btef = new ExprBlock();
+            btef->at = expr->at;
+            btef->list.push_back(gtef);
+            auto fchk = new ExprIfThenElse(expr->at, new ExprVar(expr->at, breakFlag), btef, nullptr);
+            blk->list.push_back(fchk);
+        }
         auto gbeg = new ExprGoto(expr->at, begin_loop_label);
         blk->list.push_back(gbeg);
         auto ell = new ExprLabel(expr->at, end_loop_label,
                                           "end while at line " + to_string(expr->at.line));
         blk->list.push_back(ell);
-        if ( bodyBlock && !bodyBlock->finalList.empty() ) { // finally, if we have it
-            for ( auto & fse : bodyBlock->finalList ) {
-                blk->list.push_back(fse->clone());
-            }
-        }
         verifyGenerated(blk);
         return blk;
     }
@@ -1189,11 +1248,23 @@ namespace das {
         auto end_loop_label = func->totalGenLabel ++;
         ExprFor * forCopy = nullptr;
         ExprBlock * bodyBlock = nullptr;
+        const bool hasFinally = expr->body->rtti_isBlock() &&
+                                !static_cast<ExprBlock*>(expr->body)->finalList.empty();
+        string breakFlag;
+        if ( hasFinally ) {
+            breakFlag = "__broke_for_" + to_string(expr->at.line) + "_" + to_string(expr->at.column);
+        }
         if ( expr->body->rtti_isBlock() ) {
             forCopy = static_cast<ExprFor*>(expr->clone());
             bodyBlock = static_cast<ExprBlock*>(forCopy->body);
             giveBlockVariablesUniqueNames(forCopy);
-            replaceBreakAndContinue(bodyBlock, end_loop_label, mid_loop_label);
+            if ( hasFinally ) {
+                // break -> set flag, goto mid (finally runs, flag check -> end, iterator_close runs)
+                // continue -> mid (finally runs, advances iterator, re-checks)
+                replaceBreakAndContinueWithFlag(bodyBlock, mid_loop_label, mid_loop_label, breakFlag);
+            } else {
+                replaceBreakAndContinue(bodyBlock, end_loop_label, mid_loop_label);
+            }
             expr = forCopy;
         }
         auto blk = new ExprBlock();
@@ -1222,6 +1293,21 @@ namespace das {
         lvar->init = new ExprConstBool(expr->at, true);
         leqt->variables.push_back(lvar);
         blk->list.push_back(leqt);
+        // __broke = false (only when finally present)
+        if ( hasFinally ) {
+            auto bleqt = new ExprLet();
+            bleqt->at = expr->at;
+            bleqt->atInit = expr->at;
+            bleqt->visibility = expr->visibility;
+            auto bvar = new Variable();
+            bvar->generated = true;
+            bvar->at = expr->at;
+            bvar->name = breakFlag;
+            bvar->type = new TypeDecl(Type::tBool);
+            bvar->init = new ExprConstBool(expr->at, false);
+            bleqt->variables.push_back(bvar);
+            blk->list.push_back(bleqt);
+        }
         // sources
         for ( size_t si=0, sis=expr->sources.size(); si!=sis; ++si ) {
             const string & srcName = srcNames[si];
@@ -1343,6 +1429,19 @@ namespace das {
         auto mll = new ExprLabel(expr->at, mid_loop_label,
                                           "continue for at line " + to_string(expr->at.line));
         blk->list.push_back(mll);
+        if ( hasFinally ) {
+            // per-iteration finally (normal fall-through, continue, and break all route here)
+            for ( auto & fse : bodyBlock->finalList ) {
+                blk->list.push_back(fse->clone());
+            }
+            // if (__broke) goto end — skip iterator_next
+            auto gtef = new ExprGoto(expr->at, end_loop_label);
+            auto btef = new ExprBlock();
+            btef->at = expr->at;
+            btef->list.push_back(gtef);
+            auto fchk = new ExprIfThenElse(expr->at, new ExprVar(expr->at, breakFlag), btef, nullptr);
+            blk->list.push_back(fchk);
+        }
         // loop &= _builtin_iterator_next(it0,pvar0)
         for ( size_t si=0, sis=expr->sources.size(); si!=sis; ++si ) {
             const string & srcName = srcNames[si];
@@ -1360,11 +1459,6 @@ namespace das {
         auto ell = new ExprLabel(expr->at, end_loop_label,
                                           "end for at line " + to_string(expr->at.line));
         blk->list.push_back(ell);
-        if ( bodyBlock && !bodyBlock->finalList.empty() ) { // finally, if we have it
-            for ( auto & fse : bodyBlock->finalList ) {
-                blk->list.push_back(fse->clone());
-            }
-        }
         // loop &= _builtin_iterator_close(it0,pvar0)
         for ( size_t si=0, sis=expr->sources.size(); si!=sis; ++si ) {
             const string & srcName = srcNames[si];

--- a/src/ast/ast_generate.cpp
+++ b/src/ast/ast_generate.cpp
@@ -926,8 +926,10 @@ namespace das {
 
     class BreakAndContinueVisitor : public Visitor {
     public:
-        BreakAndContinueVisitor ( int32_t bg, int32_t cg, const string & bf = string() )
-            : breakGoto(bg), continueGoto(cg), breakFlag(bf) {
+        BreakAndContinueVisitor ( int32_t bg, int32_t cg, const string & bf = string(),
+                                  int32_t rg = 0, const string & rf = string(), const string & rvn = string() )
+            : breakGoto(bg), continueGoto(cg), breakFlag(bf),
+              returnGoto(rg), returnFlag(rf), returnValueName(rvn) {
         }
         virtual void preVisit ( ExprWhile * expr ) override {
             Visitor::preVisit(expr);
@@ -965,10 +967,35 @@ namespace das {
             if ( depth ) return Visitor::visit(expr);
             return new ExprGoto(expr->at, continueGoto);
         }
+        virtual ExpressionPtr visit(ExprReturn *expr) override {
+            if ( depth ) return Visitor::visit(expr);
+            if ( returnFlag.empty() ) return Visitor::visit(expr);
+            // yield-emitted returns are internal control-flow — leave them alone
+            if ( expr->fromYield ) return Visitor::visit(expr);
+            // emit: { __return_value = subexpr; __returning = true; goto returnGoto }
+            // so the enclosing loop's per-iteration finally runs before the real return
+            auto blk = new ExprBlock();
+            blk->at = expr->at;
+            blk->isCollapseable = true;
+            if ( expr->subexpr && !returnValueName.empty() ) {
+                auto rv = new ExprVar(expr->at, returnValueName);
+                auto cpy = new ExprCopy(expr->at, rv, expr->subexpr->clone());
+                blk->list.push_back(cpy);
+            }
+            auto flg = new ExprVar(expr->at, returnFlag);
+            auto trv = new ExprConstBool(expr->at, true);
+            auto cpy2 = new ExprCopy(expr->at, flg, trv);
+            blk->list.push_back(cpy2);
+            blk->list.push_back(new ExprGoto(expr->at, returnGoto));
+            return blk;
+        }
     protected:
         int32_t breakGoto;
         int32_t continueGoto;
         string  breakFlag;
+        int32_t returnGoto;
+        string  returnFlag;
+        string  returnValueName;
         int     depth = 0;
     };
 
@@ -980,6 +1007,31 @@ namespace das {
     void replaceBreakAndContinueWithFlag ( Expression * expr, int32_t bg, int32_t cg, const string & breakFlag ) {
         BreakAndContinueVisitor rbnc(bg, cg, breakFlag);
         expr->visit(rbnc);
+    }
+
+    void replaceBreakContinueAndReturn ( Expression * expr, int32_t bg, int32_t cg, const string & breakFlag,
+                                         int32_t rg, const string & returnFlag, const string & returnValueName ) {
+        BreakAndContinueVisitor rbnc(bg, cg, breakFlag, rg, returnFlag, returnValueName);
+        expr->visit(rbnc);
+    }
+
+    class HasTopLevelReturnVisitor : public Visitor {
+    public:
+        virtual void preVisit ( ExprWhile * ) override { depth ++; }
+        virtual ExpressionPtr visit ( ExprWhile * expr ) override { depth --; return Visitor::visit(expr); }
+        virtual void preVisit ( ExprFor * ) override { depth ++; }
+        virtual ExpressionPtr visit ( ExprFor * expr ) override { depth --; return Visitor::visit(expr); }
+        virtual void preVisit ( ExprReturn * expr ) override {
+            if ( depth == 0 && !expr->fromYield ) found = true;
+        }
+        bool found = false;
+        int  depth = 0;
+    };
+
+    bool bodyHasTopLevelReturn ( Expression * body ) {
+        HasTopLevelReturnVisitor v;
+        body->visit(v);
+        return v.found;
     }
 
     ExpressionPtr generateYield( ExprYield * expr, const FunctionPtr & func ) {
@@ -1160,10 +1212,17 @@ namespace das {
         ExprBlock * bodyBlock = nullptr;
         const bool hasFinally = expr->body->rtti_isBlock() &&
                                 !static_cast<ExprBlock*>(expr->body)->finalList.empty();
-        // only introduce __broke flag when body has a finally — otherwise classic break -> end
-        string breakFlag;
+        // only introduce __broke / __returning flags when body has a finally —
+        // otherwise classic break -> end, and return just exits the enclosing function
+        string breakFlag, returnFlag, returnValueName;
+        bool hasReturn = false;
         if ( hasFinally ) {
             breakFlag = "__broke_while_" + to_string(expr->at.line) + "_" + to_string(expr->at.column);
+            hasReturn = bodyHasTopLevelReturn(expr->body);
+            if ( hasReturn ) {
+                returnFlag = "__returning_while_" + to_string(expr->at.line) + "_" + to_string(expr->at.column);
+                returnValueName = "__return_value_while_" + to_string(expr->at.line) + "_" + to_string(expr->at.column);
+            }
         }
         if ( expr->body->rtti_isBlock() ) {
             bodyBlock = static_cast<ExprBlock*>(expr->body->clone());
@@ -1171,7 +1230,9 @@ namespace das {
             if ( hasFinally ) {
                 // break -> set flag, goto iter_end (runs finally, then exits via flag check)
                 // continue -> iter_end (runs finally, flag=false, loops back)
-                replaceBreakAndContinueWithFlag(bodyBlock, iter_end_loop_label, iter_end_loop_label, breakFlag);
+                // return -> spill value, set flag, goto iter_end (runs finally, then real return)
+                replaceBreakContinueAndReturn(bodyBlock, iter_end_loop_label, iter_end_loop_label, breakFlag,
+                                              iter_end_loop_label, returnFlag, returnValueName);
             } else {
                 replaceBreakAndContinue(bodyBlock, end_loop_label, begin_loop_label);
             }
@@ -1194,6 +1255,37 @@ namespace das {
             leqt->variables.push_back(bvar);
             blk->list.push_back(leqt);
         }
+        // __returning = false; __return_value : <func->result>  (only when body has return)
+        if ( hasReturn ) {
+            auto leqt = new ExprLet();
+            leqt->at = expr->at;
+            leqt->atInit = expr->at;
+            leqt->visibility = expr->at;
+            auto rvar = new Variable();
+            rvar->generated = true;
+            rvar->at = expr->at;
+            rvar->name = returnFlag;
+            rvar->type = new TypeDecl(Type::tBool);
+            rvar->init = new ExprConstBool(expr->at, false);
+            leqt->variables.push_back(rvar);
+            blk->list.push_back(leqt);
+            if ( func->result && !func->result->isVoid() ) {
+                auto lvqt = new ExprLet();
+                lvqt->at = expr->at;
+                lvqt->atInit = expr->at;
+                lvqt->visibility = expr->at;
+                auto vvar = new Variable();
+                vvar->generated = true;
+                vvar->at = expr->at;
+                vvar->name = returnValueName;
+                vvar->type = new TypeDecl(*func->result);
+                vvar->type->constant = false;
+                vvar->type->explicitConst = false;
+                vvar->type->ref = false;
+                lvqt->variables.push_back(vvar);
+                blk->list.push_back(lvqt);
+            }
+        }
         auto bll = new ExprLabel(expr->at, begin_loop_label,
                                           "begin while at line " + to_string(expr->at.line));
         blk->list.push_back(bll);
@@ -1213,12 +1305,26 @@ namespace das {
             blk->list.push_back(expr->body->clone());
         }
         if ( hasFinally ) {
-            // iter_end label: per-iteration finally (normal fall-through, continue, break all route here)
+            // iter_end label: per-iteration finally (normal fall-through, continue, break, return all route here)
             auto iell = new ExprLabel(expr->at, iter_end_loop_label,
                                                "iter end while at line " + to_string(expr->at.line));
             blk->list.push_back(iell);
             for ( auto & fse : bodyBlock->finalList ) {
                 blk->list.push_back(fse->clone());
+            }
+            // if (__returning) return __return_value (runs before break check so return wins over break)
+            if ( hasReturn ) {
+                auto rblk = new ExprBlock();
+                rblk->at = expr->at;
+                rblk->isCollapseable = true;
+                auto pRet = new ExprReturn();
+                pRet->at = expr->at;
+                if ( func->result && !func->result->isVoid() ) {
+                    pRet->subexpr = new ExprVar(expr->at, returnValueName);
+                }
+                rblk->list.push_back(pRet);
+                auto rchk = new ExprIfThenElse(expr->at, new ExprVar(expr->at, returnFlag), rblk, nullptr);
+                blk->list.push_back(rchk);
             }
             // if (__broke) goto end — else fall through to goto begin
             auto gtef = new ExprGoto(expr->at, end_loop_label);
@@ -1250,9 +1356,15 @@ namespace das {
         ExprBlock * bodyBlock = nullptr;
         const bool hasFinally = expr->body->rtti_isBlock() &&
                                 !static_cast<ExprBlock*>(expr->body)->finalList.empty();
-        string breakFlag;
+        string breakFlag, returnFlag, returnValueName;
+        bool hasReturn = false;
         if ( hasFinally ) {
             breakFlag = "__broke_for_" + to_string(expr->at.line) + "_" + to_string(expr->at.column);
+            hasReturn = bodyHasTopLevelReturn(expr->body);
+            if ( hasReturn ) {
+                returnFlag = "__returning_for_" + to_string(expr->at.line) + "_" + to_string(expr->at.column);
+                returnValueName = "__return_value_for_" + to_string(expr->at.line) + "_" + to_string(expr->at.column);
+            }
         }
         if ( expr->body->rtti_isBlock() ) {
             forCopy = static_cast<ExprFor*>(expr->clone());
@@ -1261,7 +1373,9 @@ namespace das {
             if ( hasFinally ) {
                 // break -> set flag, goto mid (finally runs, flag check -> end, iterator_close runs)
                 // continue -> mid (finally runs, advances iterator, re-checks)
-                replaceBreakAndContinueWithFlag(bodyBlock, mid_loop_label, mid_loop_label, breakFlag);
+                // return -> spill value, set flag, goto mid (finally runs, then real return)
+                replaceBreakContinueAndReturn(bodyBlock, mid_loop_label, mid_loop_label, breakFlag,
+                                              mid_loop_label, returnFlag, returnValueName);
             } else {
                 replaceBreakAndContinue(bodyBlock, end_loop_label, mid_loop_label);
             }
@@ -1307,6 +1421,37 @@ namespace das {
             bvar->init = new ExprConstBool(expr->at, false);
             bleqt->variables.push_back(bvar);
             blk->list.push_back(bleqt);
+        }
+        // __returning = false; __return_value : <func->result>  (only when body has return)
+        if ( hasReturn ) {
+            auto rleqt = new ExprLet();
+            rleqt->at = expr->at;
+            rleqt->atInit = expr->at;
+            rleqt->visibility = expr->visibility;
+            auto rvar = new Variable();
+            rvar->generated = true;
+            rvar->at = expr->at;
+            rvar->name = returnFlag;
+            rvar->type = new TypeDecl(Type::tBool);
+            rvar->init = new ExprConstBool(expr->at, false);
+            rleqt->variables.push_back(rvar);
+            blk->list.push_back(rleqt);
+            if ( func->result && !func->result->isVoid() ) {
+                auto vleqt = new ExprLet();
+                vleqt->at = expr->at;
+                vleqt->atInit = expr->at;
+                vleqt->visibility = expr->visibility;
+                auto vvar = new Variable();
+                vvar->generated = true;
+                vvar->at = expr->at;
+                vvar->name = returnValueName;
+                vvar->type = new TypeDecl(*func->result);
+                vvar->type->constant = false;
+                vvar->type->explicitConst = false;
+                vvar->type->ref = false;
+                vleqt->variables.push_back(vvar);
+                blk->list.push_back(vleqt);
+            }
         }
         // sources
         for ( size_t si=0, sis=expr->sources.size(); si!=sis; ++si ) {
@@ -1430,9 +1575,31 @@ namespace das {
                                           "continue for at line " + to_string(expr->at.line));
         blk->list.push_back(mll);
         if ( hasFinally ) {
-            // per-iteration finally (normal fall-through, continue, and break all route here)
+            // per-iteration finally (normal fall-through, continue, break, return all route here)
             for ( auto & fse : bodyBlock->finalList ) {
                 blk->list.push_back(fse->clone());
+            }
+            // if (__returning) { <close iterators>; return __return_value }
+            if ( hasReturn ) {
+                auto rblk = new ExprBlock();
+                rblk->at = expr->at;
+                rblk->isCollapseable = true;
+                // close iterators before returning (mirrors normal end_loop path)
+                for ( size_t si=0, sis=expr->sources.size(); si!=sis; ++si ) {
+                    auto cbif = new ExprCall(expr->at, "_builtin_iterator_close");
+                    cbif->generated = true;
+                    cbif->arguments.push_back(new ExprVar(expr->at, srcNames[si]));
+                    cbif->arguments.push_back(new ExprVar(expr->at, pVarNames[si]));
+                    rblk->list.push_back(cbif);
+                }
+                auto pRet = new ExprReturn();
+                pRet->at = expr->at;
+                if ( func->result && !func->result->isVoid() ) {
+                    pRet->subexpr = new ExprVar(expr->at, returnValueName);
+                }
+                rblk->list.push_back(pRet);
+                auto rchk = new ExprIfThenElse(expr->at, new ExprVar(expr->at, returnFlag), rblk, nullptr);
+                blk->list.push_back(rchk);
             }
             // if (__broke) goto end — skip iterator_next
             auto gtef = new ExprGoto(expr->at, end_loop_label);

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -4737,10 +4737,6 @@ namespace das {
         expr->visibility.last_line = scope->at.last_line;
         // macro generated invisible variable
         // DAS_ASSERTF(expr->visibility.line,"visiblity failed at %s",expr->at.describe().c_str());
-        if (expr->inScope && scopes.back()->inTheLoop) {
-            error("in scope let is not allowed in the loop",
-                  "you can always create scope with 'if true'", "", expr->at, CompilationError::in_scope_in_the_loop);
-        }
     }
     void InferTypes::preVisitLet(ExprLet *expr, const VariablePtr &var, bool last) {
         Visitor::preVisitLet(expr, var, last);

--- a/src/ast/ast_inscope_pod.cpp
+++ b/src/ast/ast_inscope_pod.cpp
@@ -53,7 +53,6 @@ namespace das {
                         || func->hasUnsafe
                         || !func->module->allowPodInscope
                         || (func->fromGeneric && !func->fromGeneric->module->allowPodInscope)
-                        || blocks.back()->inTheLoop
                     ) {
                     if ( logs ) {
                         if ( !var->at.empty() && var->at.fileInfo ) {
@@ -68,7 +67,6 @@ namespace das {
                         if ( !func->module->allowPodInscope ) *logs << "\tmodule " << func->module->name << " does not allow in-scope POD\n";
                         if ( func->fromGeneric && !func->fromGeneric->module->allowPodInscope )
                             *logs << "\tgeneric function module " << func->fromGeneric->module->name << " does not allow in-scope POD\n";
-                        if ( blocks.back()->inTheLoop ) *logs << "\tblock is in the loop, which does not have separate 'finally' scope. you can add 'if ( true )' to create scope, or take variable outside of loop\n";
                     }
                 } else {
                     func->notInferred();

--- a/src/simulate/simulate.cpp
+++ b/src/simulate/simulate.cpp
@@ -705,16 +705,28 @@ namespace das
     vec4f SimNode_While::eval ( Context & context ) {
         DAS_PROFILE_NODE
         SimNode ** __restrict tail = list + total;
-        while ( cond->evalBool(context) && !context.stopFlags ) {
-            SimNode ** __restrict body = list;
-        loopbegin:;
-            for (; body!=tail; ++body) {
-                (*body)->eval(context);
-                DAS_PROCESS_LOOP_FLAGS(break);
+        if ( this->totalFinal == 0 ) {
+            while ( cond->evalBool(context) && !context.stopFlags ) {
+                SimNode ** __restrict body = list;
+            loopbegin:;
+                for (; body!=tail; ++body) {
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS(break);
+                }
+            }
+        } else {
+            while ( cond->evalBool(context) && !context.stopFlags ) {
+                SimNode ** __restrict body = list;
+            loopbegin_fin:;
+                for (; body!=tail; ++body) {
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                }
+            loopend_fin:;
+                evalFinal(context);
             }
         }
     loopend:;
-        evalFinal(context);
         context.stopFlags &= ~EvalFlags::stopForBreak;
         return v_zero();
     }
@@ -724,17 +736,30 @@ namespace das
     vec4f SimNodeDebug_While::eval ( Context & context ) {
         DAS_PROFILE_NODE
         SimNode ** __restrict tail = list + total;
-        while ( cond->evalBool(context) && !context.stopFlags ) {
-            SimNode ** __restrict body = list;
-        loopbegin:;
-            for (; body!=tail; ++body) {
-                DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
-                (*body)->eval(context);
-                DAS_PROCESS_LOOP_FLAGS(break);
+        if ( this->totalFinal == 0 ) {
+            while ( cond->evalBool(context) && !context.stopFlags ) {
+                SimNode ** __restrict body = list;
+            loopbegin:;
+                for (; body!=tail; ++body) {
+                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS(break);
+                }
+            }
+        } else {
+            while ( cond->evalBool(context) && !context.stopFlags ) {
+                SimNode ** __restrict body = list;
+            loopbegin_fin:;
+                for (; body!=tail; ++body) {
+                    DAS_SINGLE_STEP(context,(*body)->debugInfo,true);
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                }
+            loopend_fin:;
+                evalFinalSingleStep(context);
             }
         }
     loopend:;
-        evalFinalSingleStep(context);
         context.stopFlags &= ~EvalFlags::stopForBreak;
         return v_zero();
     }
@@ -745,17 +770,30 @@ namespace das
     vec4f SimNodeKeepAlive_While::eval ( Context & context ) {
         DAS_PROFILE_NODE
         SimNode ** __restrict tail = list + total;
-        while ( cond->evalBool(context) && !context.stopFlags ) {
-            SimNode ** __restrict body = list;
-        loopbegin:;
-            DAS_KEEPALIVE_LOOP(&context);
-            for (; body!=tail; ++body) {
-                (*body)->eval(context);
-                DAS_PROCESS_LOOP_FLAGS(break);
+        if ( this->totalFinal == 0 ) {
+            while ( cond->evalBool(context) && !context.stopFlags ) {
+                SimNode ** __restrict body = list;
+            loopbegin:;
+                DAS_KEEPALIVE_LOOP(&context);
+                for (; body!=tail; ++body) {
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS(break);
+                }
+            }
+        } else {
+            while ( cond->evalBool(context) && !context.stopFlags ) {
+                SimNode ** __restrict body = list;
+            loopbegin_fin:;
+                DAS_KEEPALIVE_LOOP(&context);
+                for (; body!=tail; ++body) {
+                    (*body)->eval(context);
+                    DAS_PROCESS_LOOP_FLAGS_LABELED(loopbegin_fin,loopend_fin,break);
+                }
+            loopend_fin:;
+                evalFinal(context);
             }
         }
     loopend:;
-        evalFinal(context);
         context.stopFlags &= ~EvalFlags::stopForBreak;
         return v_zero();
     }

--- a/tests/README.md
+++ b/tests/README.md
@@ -600,6 +600,20 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | vector_fields.das | float4 .r/.g/.b/.a fields and swizzle | |
 | with_statement.das | `with (struct) { field = val }` block scoping | |
 
+## loops/
+
+Coverage of per-iteration `finally` semantics across every loop form. Each cell asserts the finally counter equals the expected per-iteration count; `inscope` cells verify `var inscope` inside a loop body is legal and leak-free.
+
+| File | Description | Expects errors |
+|---|---|---|
+| for_range.das | `for (x in range(n))` — plain, break, continue, return, nested, var inscope, empty | |
+| for_array.das | `for (x in array<int>)` — plain, break, continue, return, nested, var inscope, empty | |
+| for_fixed_array.das | `for (x in int[N])` — plain, break, continue, return, var inscope | |
+| for_iterator.das | `for (x in iterator<int>)` (generator-backed) — plain, break, continue, return, var inscope, empty | |
+| for_multi_source.das | `for (a, b in src1, src2)` — plain, break, continue, return, var inscope, empty, uneven sources | |
+| while.das | `while (cond)` — plain, break, continue, return, nested, var inscope, never-taken | |
+| nested.das | Mixed nested loops — for-in-for, while-in-for, for-in-while, triple-nested, break isolation | |
+
 ## linq/
 
 | File | Description | Expects errors |

--- a/tests/README.md
+++ b/tests/README.md
@@ -613,6 +613,7 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 | for_multi_source.das | `for (a, b in src1, src2)` — plain, break, continue, return, var inscope, empty, uneven sources | |
 | while.das | `while (cond)` — plain, break, continue, return, nested, var inscope, never-taken | |
 | nested.das | Mixed nested loops — for-in-for, while-in-for, for-in-while, triple-nested, break isolation | |
+| generator_loops.das | `for`/`while` inside a generator body — yield-from-finally interleaves with body yields per iteration; break, continue, return, nested, empty | |
 
 ## linq/
 

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -307,6 +307,9 @@ SET(AOT_STBIMAGE_MODULE_FILES
 # AOT for jit test files
 FILE(GLOB AOT_JIT_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/jit/*.das")
 
+# AOT for loops test files
+FILE(GLOB AOT_LOOPS_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/loops/*.das")
+
 # AOT for language test files
 FILE(GLOB AOT_LANGUAGE_TEST_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/language/*.das")
 # Exclude expect-error tests and no_aot files
@@ -538,6 +541,10 @@ add_custom_target(test_aot_jit)
 SET(JIT_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_JIT_FILES}" JIT_AOT_GENERATED_SRC test_aot_jit daslang)
 
+add_custom_target(test_aot_loops)
+SET(LOOPS_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_LOOPS_FILES}" LOOPS_AOT_GENERATED_SRC test_aot_loops daslang)
+
 add_custom_target(test_aot_language)
 SET(LANGUAGE_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_LANGUAGE_TEST_FILES}" LANGUAGE_AOT_GENERATED_SRC test_aot_language daslang)
@@ -604,6 +611,7 @@ SOURCE_GROUP_FILES("aot generated" TYPE_TRAITS_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" URI_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LPIPE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" JIT_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" LOOPS_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LANGUAGE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LANGUAGE_MODULES_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DASLIB_MODULES_AOT_GENERATED_SRC)
@@ -664,6 +672,7 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
     ${URI_AOT_GENERATED_SRC}
     ${LPIPE_AOT_GENERATED_SRC}
     ${JIT_AOT_GENERATED_SRC}
+    ${LOOPS_AOT_GENERATED_SRC}
     ${LANGUAGE_AOT_GENERATED_SRC}
     ${LANGUAGE_MODULES_AOT_GENERATED_SRC}
     ${DASLIB_MODULES_AOT_GENERATED_SRC}
@@ -698,6 +707,7 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_template test_aot_type_traits test_aot_uri
     test_aot_lpipe
     test_aot_jit
+    test_aot_loops
     test_aot_language test_aot_language_modules
     test_aot_daslib_modules test_aot_decs_modules
     test_aot_stbimage test_aot_stbimage_modules

--- a/tests/jit_tests/finally.das
+++ b/tests/jit_tests/finally.das
@@ -235,7 +235,7 @@ struct CmresBag {
 [jit]
 def cmres_return_without_finally() : CmresBag {
     {
-        return CmresBag(a=1, b=2, c=3, d=4)
+        return CmresBag(a = 1, b = 2, c = 3, d = 4)
     }
 }
 

--- a/tests/jit_tests/finally.das
+++ b/tests/jit_tests/finally.das
@@ -35,6 +35,14 @@ def test_finally(t : T?) {
         t |> success(!jit_enabled() || is_jit_function(@@test_block_finally))
         t |> success(test_block_finally())
     }
+    t |> run("cmres return without finally") @(t : T?) {
+        t |> success(!jit_enabled() || is_jit_function(@@cmres_return_without_finally))
+        let bag = cmres_return_without_finally()
+        t |> equal(bag.a, 1)
+        t |> equal(bag.b, 2)
+        t |> equal(bag.c, 3)
+        t |> equal(bag.d, 4)
+    }
     t |> run("for loop with early out") @(t : T?) {
         t |> success(!jit_enabled() || is_jit_function(@@early_out))
         g_steps = 0
@@ -212,6 +220,23 @@ def test_block_finally() {
     var t = 0
     invoke() <| $() { t = 1; } finally { t = 2; }
     return t == 2
+}
+
+struct CmresBag {
+    a : int
+    b : int
+    c : int
+    d : int
+}
+
+// CMRES return from inside a bare block with NO finally on any enclosing block —
+// exercises has_any_finally_block's false-returning path (LLVM JIT must NOT spill
+// the return value to a temp when no finally is present).
+[jit]
+def cmres_return_without_finally() : CmresBag {
+    {
+        return CmresBag(a=1, b=2, c=3, d=4)
+    }
 }
 
 

--- a/tests/jit_tests/finally.das
+++ b/tests/jit_tests/finally.das
@@ -39,7 +39,8 @@ def test_finally(t : T?) {
         t |> success(!jit_enabled() || is_jit_function(@@early_out))
         g_steps = 0
         early_out(t, array<int>(1, 2, 3, 4))
-        t |> equal(2, g_steps)
+        // per-iter inner finally fires at aidx=1 and aidx=2 (before return); outer fires once = 3
+        t |> equal(3, g_steps)
     }
 }
 
@@ -55,7 +56,8 @@ def early_out(t : T?; var aclone : array<int>) {
         }
     } finally {
         g_steps ++
-        t |> equal(0, lock_count(aclone))
+        // per-iteration finally fires while iterator still holds the lock
+        t |> equal(1, lock_count(aclone))
     }
 } finally {
     t |> equal(0, lock_count(aclone))
@@ -149,7 +151,8 @@ def test_for_finally(max : int = 10) {
         t[9] = 13
         count += uno
     }
-    return count == 1 && t[9] == 13
+    // per-iter finally: iterations 0..5 each run finally (break after x==5's finally)
+    return count == 6 && t[9] == 13
 }
 
 var {
@@ -179,7 +182,8 @@ def test_while_finally(max : int = 10) {
         t[9] = 12 + uno
         count ++
     }
-    return count == 1 && t[9] == 13
+    // per-iter finally: iterations 0..5 each run finally (break after x==5's finally)
+    return count == 6 && t[9] == 13
 }
 
 var {

--- a/tests/jit_tests/for_loop.das
+++ b/tests/jit_tests/for_loop.das
@@ -39,7 +39,7 @@ def range_for_range(value : range) {
 [jit]
 def range_for_range_extra(value : range) {
     var i = 0
-    for (a, b in value, range(13, 100500)) {
+    for (_a, _b in value, range(13, 100500)) {
         i ++
     }
     return i
@@ -144,7 +144,7 @@ def iterator_for(value : int) {
 [jit]
 def hybrid_for(value : int) {
     var i = 0
-    for (a, b in gen_range(value), range(7)) {
+    for (_a, _b in gen_range(value), range(7)) {
         i ++
     }
     return i
@@ -178,7 +178,7 @@ def add_elements(a : array<int>) {
 [jit]
 def special_count(max, start, step : int) {
     var add = 0
-    for (i, j in range(max), count(start, step)) {
+    for (_i, j in range(max), count(start, step)) {
         add += j
     }
     return add
@@ -202,7 +202,8 @@ def test_for_loop(t : T?) {
         t |> equal(range_for_range_extra(range(100, 110)), 10)
         t |> equal(range_for_with_break(10, 5), 5)
         t |> equal(range_for_with_continue(10, 5), 4)
-        t |> equal(range_for_with_finally(10), 1)
+        // per-iter finally: finally fires once per iteration, so tf == 10 for range(10)
+        t |> equal(range_for_with_finally(10), 10)
     }
     t |> run("dim for") @(t : T?) {
         t |> success(!jit_enabled() || is_jit_function(@@dim_for))

--- a/tests/jit_tests/while_loop.das
+++ b/tests/jit_tests/while_loop.das
@@ -55,7 +55,8 @@ def test_while_loop(t : T?) {
     t |> equal(count_all(10), 10)
     t |> equal(count_with_break(10, 5), 5)
     t |> equal(count_with_continue(10, 5), 4)
-    t |> equal(count_with_finally(10), 1)
+    // per-iter finally: finally fires once per iteration, so tf == 10 for while (i < 10)
+    t |> equal(count_with_finally(10), 10)
 }
 
 

--- a/tests/language/finally.das
+++ b/tests/language/finally.das
@@ -42,7 +42,8 @@ def test_for_finally(tt : T?) {
         t[9] = 13
         count += uno
     }
-    tt |> equal(count, 1)
+    // per-iteration finally: iterations 0..5 each run finally (break after x==5's finally)
+    tt |> equal(count, 6)
     tt |> equal(t[9], 13)
 }
 
@@ -62,7 +63,8 @@ def test_while_finally(tt : T?) {
         t[9] = 12 + uno
         count ++
     }
-    tt |> equal(count, 1)
+    // per-iteration finally: iterations 0..5 each run finally (break after x==5's finally)
+    tt |> equal(count, 6)
     tt |> equal(t[9], 13)
 }
 

--- a/tests/language/generators.das
+++ b/tests/language/generators.das
@@ -15,6 +15,20 @@ def checkIt(t : T?; var gen : iterator<int>) {
     t |> equal(count, 10)
 }
 
+[sideeffects]
+def checkSeq(t : T?; var gen : iterator<int>; expected : array<int>) {
+    var i = 0
+    for (x in gen) {
+        if (i >= length(expected)) {
+            t |> failure("output too long")
+            return
+        }
+        t |> equal(x, expected[i])
+        i ++
+    }
+    t |> equal(i, length(expected))
+}
+
 def test_yield(t : T?) {
     var gen <- generator<int>() <| $() {
         yield 0
@@ -163,6 +177,9 @@ def test_while_nested(t : T?) {
 }
 
 def test_while_finally(t : T?) {
+    // per-iteration semantics: finally runs at the end of every iteration of the body,
+    // NOT once after the loop. `yield 9` fires interleaved after each body yield.
+    // cond becomes false -> finally does NOT run for that phantom iteration.
     var gen <- generator<int>() <| $() {
         var t = 0
         while (t < 9) {
@@ -172,7 +189,64 @@ def test_while_finally(t : T?) {
         }
         return false
     }
-    checkIt(t, gen)
+    checkSeq(t, gen, [0, 9, 1, 9, 2, 9, 3, 9, 4, 9, 5, 9, 6, 9, 7, 9, 8, 9])
+}
+
+def test_while_finally_break(t : T?) {
+    // break routes through finally once (current iteration's finally), then exits
+    var gen <- generator<int>() <| $() {
+        var t = 0
+        while (t < 100) {
+            yield t ++
+            if (t == 3) {
+                break
+            }
+        } finally {
+            yield 99
+        }
+        return false
+    }
+    // iter 0: yield 0 -> t=1, no break, finally yields 99
+    // iter 1: yield 1 -> t=2, no break, finally yields 99
+    // iter 2: yield 2 -> t=3, break, finally yields 99, exit
+    checkSeq(t, gen, [0, 99, 1, 99, 2, 99])
+}
+
+def test_while_finally_continue(t : T?) {
+    // continue routes through finally (same as normal end of iter), then loops back
+    var gen <- generator<int>() <| $() {
+        var t = 0
+        while (t < 5) {
+            t ++
+            if (t % 2 == 0) {
+                continue
+            }
+            yield t
+        } finally {
+            yield 99
+        }
+        return false
+    }
+    // t=1: odd, yield 1, finally 99
+    // t=2: even, continue, finally 99
+    // t=3: odd, yield 3, finally 99
+    // t=4: even, continue, finally 99
+    // t=5: odd, yield 5, finally 99
+    // t<5 false, exit without finally
+    checkSeq(t, gen, [1, 99, 99, 3, 99, 99, 5, 99])
+}
+
+def test_while_finally_empty(t : T?) {
+    // empty loop: body never enters, finally never runs
+    var gen <- generator<int>() <| $() {
+        while (false) {
+            yield 1
+        } finally {
+            yield 99
+        }
+        return false
+    }
+    checkSeq(t, gen, [])
 }
 
 def test_for(t : T?) {
@@ -224,6 +298,9 @@ def test_for_nested(t : T?) {
 }
 
 def test_for_finally(t : T?) {
+    // per-iteration semantics: finally runs at mid_loop (after body, before iterator_next)
+    // for N iterations we get N body yields and N finally yields, interleaved.
+    // On iterator exhaustion: initial !loop check jumps past finally (skipped for empty or post-last).
     var gen <- generator<int>() <| $() {
         for (t in range(9)) {
             yield t
@@ -232,7 +309,58 @@ def test_for_finally(t : T?) {
         }
         return false
     }
-    checkIt(t, gen)
+    checkSeq(t, gen, [0, 9, 1, 9, 2, 9, 3, 9, 4, 9, 5, 9, 6, 9, 7, 9, 8, 9])
+}
+
+def test_for_finally_break(t : T?) {
+    var gen <- generator<int>() <| $() {
+        for (t in range(100)) {
+            yield t
+            if (t == 2) {
+                break
+            }
+        } finally {
+            yield 99
+        }
+        return false
+    }
+    // iter 0: yield 0, t!=2, finally 99
+    // iter 1: yield 1, t!=2, finally 99
+    // iter 2: yield 2, t==2 break, finally 99, exit
+    checkSeq(t, gen, [0, 99, 1, 99, 2, 99])
+}
+
+def test_for_finally_continue(t : T?) {
+    var gen <- generator<int>() <| $() {
+        for (t in range(5)) {
+            if (t % 2 == 0) {
+                continue
+            }
+            yield t
+        } finally {
+            yield 99
+        }
+        return false
+    }
+    // t=0 even continue, finally 99
+    // t=1 odd, yield 1, finally 99
+    // t=2 even continue, finally 99
+    // t=3 odd, yield 3, finally 99
+    // t=4 even continue, finally 99
+    checkSeq(t, gen, [99, 1, 99, 99, 3, 99, 99])
+}
+
+def test_for_finally_empty(t : T?) {
+    // empty iterator: body never enters, finally never runs
+    var gen <- generator<int>() <| $() {
+        for (t in range(0)) {
+            yield t
+        } finally {
+            yield 99
+        }
+        return false
+    }
+    checkSeq(t, gen, [])
 }
 
 [test]
@@ -246,9 +374,15 @@ def test_generators(t : T?) {
     t |> run("while continue in generator") @(t : T?) { test_while_continue(t); }
     t |> run("nested while in generator") @(t : T?) { test_while_nested(t); }
     t |> run("while finally in generator") @(t : T?) { test_while_finally(t); }
+    t |> run("while finally + break in generator") @(t : T?) { test_while_finally_break(t); }
+    t |> run("while finally + continue in generator") @(t : T?) { test_while_finally_continue(t); }
+    t |> run("while finally empty in generator") @(t : T?) { test_while_finally_empty(t); }
     t |> run("for loop in generator") @(t : T?) { test_for(t); }
     t |> run("for break in generator") @(t : T?) { test_for_break(t); }
     t |> run("for continue in generator") @(t : T?) { test_for_continue(t); }
     t |> run("nested for in generator") @(t : T?) { test_for_nested(t); }
     t |> run("for finally in generator") @(t : T?) { test_for_finally(t); }
+    t |> run("for finally + break in generator") @(t : T?) { test_for_finally_break(t); }
+    t |> run("for finally + continue in generator") @(t : T?) { test_for_finally_continue(t); }
+    t |> run("for finally empty in generator") @(t : T?) { test_for_finally_empty(t); }
 }

--- a/tests/loops/for_array.das
+++ b/tests/loops/for_array.das
@@ -1,0 +1,96 @@
+// Per-iteration finally on for-over-dynamic-array loops.
+options gen2
+require dastest/testing_boost public
+
+[test]
+def test_for_array(t : T?) {
+    t |> run("plain") @(t : T?) {
+        var arr <- [10, 20, 30]
+        var count = 0
+        for (_x in arr) {
+        } finally {
+            count ++
+        }
+        t |> equal(count, 3)
+    }
+    t |> run("break") @(t : T?) {
+        var arr <- [1, 2, 3, 4, 5]
+        var count = 0
+        for (x in arr) {
+            if (x == 3) {
+                break
+            }
+        } finally {
+            count ++
+        }
+        // iterations for 1,2,3 each fire finally (break runs after x==3's finally)
+        t |> equal(count, 3)
+    }
+    t |> run("continue") @(t : T?) {
+        var arr <- [1, 2, 3, 4]
+        var count = 0
+        var hits = 0
+        for (x in arr) {
+            if (x % 2 == 0) {
+                continue
+            }
+            hits ++
+        } finally {
+            count ++
+        }
+        t |> equal(count, 4)
+        t |> equal(hits, 2)
+    }
+    t |> run("return") @(t : T?) {
+        // return captures count=1 (after iter x=10's finally); iter x=20's finally runs after return expr is evaluated
+        t |> equal(for_array_return(), 1)
+    }
+    t |> run("nested") @(t : T?) {
+        var a <- [1, 2, 3]
+        var b <- [10, 20]
+        var outer = 0
+        var inner = 0
+        for (_y in a) {
+            for (_x in b) {
+            } finally {
+                inner ++
+            }
+        } finally {
+            outer ++
+        }
+        t |> equal(outer, 3)
+        t |> equal(inner, 6)
+    }
+    t |> run("inscope") @(t : T?) {
+        var src <- [1, 2, 3]
+        for (i in src) {
+            var inscope tmp : array<int>
+            tmp |> push(i); tmp |> push(i * 2)
+            t |> equal(tmp[0], i)
+            t |> equal(tmp[1], i * 2)
+        }
+    }
+    t |> run("empty") @(t : T?) {
+        var arr : array<int>
+        var count = 0
+        for (_x in arr) {
+        } finally {
+            count ++
+        }
+        // empty array: body never enters, finally never runs
+        t |> equal(count, 0)
+    }
+}
+
+def for_array_return() : int {
+    var arr <- [10, 20, 30]
+    var count = 0
+    for (x in arr) {
+        if (x == 20) {
+            return count
+        }
+    } finally {
+        count ++
+    }
+    return -1
+}

--- a/tests/loops/for_fixed_array.das
+++ b/tests/loops/for_fixed_array.das
@@ -1,0 +1,72 @@
+// Per-iteration finally on for-over-fixed-array (dim) loops.
+options gen2
+require dastest/testing_boost public
+
+[test]
+def test_for_fixed_array(t : T?) {
+    t |> run("plain") @(t : T?) {
+        var arr : int[5]
+        arr[0] = 10; arr[1] = 20; arr[2] = 30; arr[3] = 40; arr[4] = 50
+        var count = 0
+        for (_x in arr) {
+        } finally {
+            count ++
+        }
+        t |> equal(count, 5)
+    }
+    t |> run("break") @(t : T?) {
+        var arr : int[5]
+        arr[0] = 1; arr[1] = 2; arr[2] = 3; arr[3] = 4; arr[4] = 5
+        var count = 0
+        for (x in arr) {
+            if (x == 3) {
+                break
+            }
+        } finally {
+            count ++
+        }
+        t |> equal(count, 3)
+    }
+    t |> run("continue") @(t : T?) {
+        var arr : int[4]
+        arr[0] = 1; arr[1] = 2; arr[2] = 3; arr[3] = 4
+        var count = 0
+        var hits = 0
+        for (x in arr) {
+            if (x % 2 == 0) {
+                continue
+            }
+            hits ++
+        } finally {
+            count ++
+        }
+        t |> equal(count, 4)
+        t |> equal(hits, 2)
+    }
+    t |> run("return") @(t : T?) {
+        t |> equal(for_fixed_return(), 1)
+    }
+    t |> run("inscope") @(t : T?) {
+        var src : int[3]
+        src[0] = 7; src[1] = 8; src[2] = 9
+        for (i in src) {
+            var inscope tmp : array<int>
+            tmp |> push(i)
+            t |> equal(tmp[0], i)
+        }
+    }
+}
+
+def for_fixed_return() : int {
+    var arr : int[3]
+    arr[0] = 10; arr[1] = 20; arr[2] = 30
+    var count = 0
+    for (x in arr) {
+        if (x == 20) {
+            return count
+        }
+    } finally {
+        count ++
+    }
+    return -1
+}

--- a/tests/loops/for_iterator.das
+++ b/tests/loops/for_iterator.das
@@ -1,0 +1,81 @@
+// Per-iteration finally on for-over-iterator loops (SimNode_ForWithIterator path).
+options gen2
+require dastest/testing_boost public
+
+def make_iter(n : int) : iterator<int> {
+    return <- generator<int>() <| $() {
+        for (i in range(n)) {
+            yield i
+        }
+        return false
+    }
+}
+
+[test]
+def test_for_iterator(t : T?) {
+    t |> run("plain") @(t : T?) {
+        var count = 0
+        for (_x in make_iter(5)) {
+        } finally {
+            count ++
+        }
+        t |> equal(count, 5)
+    }
+    t |> run("break") @(t : T?) {
+        var count = 0
+        for (x in make_iter(10)) {
+            if (x == 4) {
+                break
+            }
+        } finally {
+            count ++
+        }
+        // iterations for x=0..4 each fire finally (break runs after x==4's finally)
+        t |> equal(count, 5)
+    }
+    t |> run("continue") @(t : T?) {
+        var count = 0
+        var hits = 0
+        for (x in make_iter(6)) {
+            if (x % 2 == 0) {
+                continue
+            }
+            hits ++
+        } finally {
+            count ++
+        }
+        t |> equal(count, 6)
+        t |> equal(hits, 3)
+    }
+    t |> run("return") @(t : T?) {
+        t |> equal(for_iterator_return(), 2)
+    }
+    t |> run("inscope") @(t : T?) {
+        for (i in make_iter(4)) {
+            var inscope tmp : array<int>
+            tmp |> push(i); tmp |> push(i * 10)
+            t |> equal(tmp[0], i)
+            t |> equal(tmp[1], i * 10)
+        }
+    }
+    t |> run("empty") @(t : T?) {
+        var count = 0
+        for (_x in make_iter(0)) {
+        } finally {
+            count ++
+        }
+        t |> equal(count, 0)
+    }
+}
+
+def for_iterator_return() : int {
+    var count = 0
+    for (x in make_iter(5)) {
+        if (x == 2) {
+            return count
+        }
+    } finally {
+        count ++
+    }
+    return -1
+}

--- a/tests/loops/for_multi_source.das
+++ b/tests/loops/for_multi_source.das
@@ -1,0 +1,85 @@
+// Per-iteration finally on for-over-multi-source loops: `for (a, b in src1, src2)`.
+options gen2
+require dastest/testing_boost public
+
+[test]
+def test_for_multi_source(t : T?) {
+    t |> run("plain") @(t : T?) {
+        var count = 0
+        var sum = 0
+        for (a, b in range(4), range(10, 14)) {
+            sum += a + b
+        } finally {
+            count ++
+        }
+        t |> equal(count, 4)
+        t |> equal(sum, (0 + 1 + 2 + 3) + (10 + 11 + 12 + 13))
+    }
+    t |> run("break") @(t : T?) {
+        var count = 0
+        for (a, _b in range(10), range(100, 110)) {
+            if (a == 3) {
+                break
+            }
+        } finally {
+            count ++
+        }
+        // iterations for a=0..3 each fire finally (break runs after a==3's finally)
+        t |> equal(count, 4)
+    }
+    t |> run("continue") @(t : T?) {
+        var count = 0
+        var hits = 0
+        for (a, _b in range(4), range(10, 14)) {
+            if (a % 2 == 0) {
+                continue
+            }
+            hits ++
+        } finally {
+            count ++
+        }
+        t |> equal(count, 4)
+        t |> equal(hits, 2)
+    }
+    t |> run("return") @(t : T?) {
+        t |> equal(for_multi_return(), 2)
+    }
+    t |> run("inscope") @(t : T?) {
+        for (a, b in range(3), range(100, 103)) {
+            var inscope tmp : array<int>
+            tmp |> push(a); tmp |> push(b)
+            t |> equal(tmp[0], a)
+            t |> equal(tmp[1], b)
+        }
+    }
+    t |> run("empty") @(t : T?) {
+        var count = 0
+        // shortest source is empty -> loop body never enters
+        for (_a, _b in range(0), range(10, 15)) {
+        } finally {
+            count ++
+        }
+        t |> equal(count, 0)
+    }
+    t |> run("uneven sources") @(t : T?) {
+        var count = 0
+        // shortest source (length 3) determines iteration count
+        for (_a, _b in range(10), range(100, 103)) {
+        } finally {
+            count ++
+        }
+        t |> equal(count, 3)
+    }
+}
+
+def for_multi_return() : int {
+    var count = 0
+    for (a, _b in range(10), range(100, 110)) {
+        if (a == 2) {
+            return count
+        }
+    } finally {
+        count ++
+    }
+    return -1
+}

--- a/tests/loops/for_range.das
+++ b/tests/loops/for_range.das
@@ -1,0 +1,86 @@
+// Per-iteration finally on for-over-range loops.
+options gen2
+require dastest/testing_boost public
+
+[test]
+def test_for_range(t : T?) {
+    t |> run("plain") @(t : T?) {
+        var count = 0
+        for (_x in range(10)) {
+        } finally {
+            count ++
+        }
+        t |> equal(count, 10)
+    }
+    t |> run("break") @(t : T?) {
+        var count = 0
+        for (x in range(10)) {
+            if (x == 5) {
+                break
+            }
+        } finally {
+            count ++
+        }
+        // iterations 0..5 each fire finally (break after x==5's finally)
+        t |> equal(count, 6)
+    }
+    t |> run("continue") @(t : T?) {
+        var count = 0
+        var hits = 0
+        for (x in range(10)) {
+            if (x % 2 == 0) {
+                continue
+            }
+            hits ++
+        } finally {
+            count ++
+        }
+        t |> equal(count, 10)
+        t |> equal(hits, 5)
+    }
+    t |> run("return") @(t : T?) {
+        t |> equal(for_range_return(), 3)
+    }
+    t |> run("nested") @(t : T?) {
+        var outer = 0
+        var inner = 0
+        for (_y in range(4)) {
+            for (_x in range(3)) {
+            } finally {
+                inner ++
+            }
+        } finally {
+            outer ++
+        }
+        t |> equal(outer, 4)
+        t |> equal(inner, 12)
+    }
+    t |> run("inscope") @(t : T?) {
+        for (i in range(5)) {
+            var inscope arr : array<int>
+            arr |> push(i)
+            t |> equal(arr[0], i)
+        }
+    }
+    t |> run("empty") @(t : T?) {
+        var count = 0
+        for (_x in range(0)) {
+        } finally {
+            count ++
+        }
+        // empty iterator: body never enters, finally never runs
+        t |> equal(count, 0)
+    }
+}
+
+def for_range_return() : int {
+    var count = 0
+    for (x in range(10)) {
+        if (x == 3) {
+            return count
+        }
+    } finally {
+        count ++
+    }
+    return -1
+}

--- a/tests/loops/generator_loops.das
+++ b/tests/loops/generator_loops.das
@@ -140,4 +140,59 @@ def test_generator_loops(t : T?) {
         //   outer finally 99
         checkSeq(t, gen, [0, 77, 1, 77, 99, 10, 77, 11, 77, 99])
     }
+    t |> run("for finally return") @(t : T?) {
+        var gen <- generator<int>() <| $() {
+            for (i in range(5)) {
+                yield i
+                if (i == 1) {
+                    return false   // early generator end — iter 1's finally must fire first
+                }
+            } finally {
+                yield 99
+            }
+            return false
+        }
+        // iter 0: yield 0, finally 99
+        // iter 1: yield 1, return triggers finally (yield 99), then generator ends
+        checkSeq(t, gen, [0, 99, 1, 99])
+    }
+    t |> run("while finally return") @(t : T?) {
+        var gen <- generator<int>() <| $() {
+            var i = 0
+            while (i < 10) {
+                yield i
+                if (i == 2) {
+                    return false
+                }
+                i ++
+            } finally {
+                yield 99
+            }
+            return false
+        }
+        // iter i=0: yield 0, finally 99
+        // iter i=1: yield 1, finally 99
+        // iter i=2: yield 2, return triggers finally (yield 99), then generator ends
+        checkSeq(t, gen, [0, 99, 1, 99, 2, 99])
+    }
+    t |> run("for finally return nested") @(t : T?) {
+        var gen <- generator<int>() <| $() {
+            for (y in range(3)) {
+                for (x in range(3)) {
+                    yield y * 10 + x
+                    if (x == 1 && y == 1) {
+                        return false
+                    }
+                } finally {
+                    yield 77   // inner finally must fire per inner iter + on return
+                }
+            } finally {
+                yield 99   // outer finally must fire on the return path too
+            }
+            return false
+        }
+        // y=0: x=0 yield 0, 77; x=1 yield 1, 77; x=2 yield 2, 77; outer 99
+        // y=1: x=0 yield 10, 77; x=1 yield 11, return -> inner 77, outer 99, generator ends
+        checkSeq(t, gen, [0, 77, 1, 77, 2, 77, 99, 10, 77, 11, 77, 99])
+    }
 }

--- a/tests/loops/generator_loops.das
+++ b/tests/loops/generator_loops.das
@@ -1,0 +1,143 @@
+// Per-iteration finally in generator loops.
+// Generators linearize loops to label/goto form (ast_generate.cpp: replaceGeneratorWhile /
+// replaceGeneratorFor). Finally lowered to the iter_end / mid_loop label so yield-from-finally
+// fires interleaved with body yields instead of once after the loop.
+options gen2
+require dastest/testing_boost public
+
+[sideeffects]
+def checkSeq(t : T?; var gen : iterator<int>; expected : array<int>) {
+    var i = 0
+    for (x in gen) {
+        if (i >= length(expected)) {
+            t |> failure("output too long")
+            return
+        }
+        t |> equal(x, expected[i])
+        i ++
+    }
+    t |> equal(i, length(expected))
+}
+
+[test]
+def test_generator_loops(t : T?) {
+    t |> run("for plain finally") @(t : T?) {
+        var gen <- generator<int>() <| $() {
+            for (i in range(3)) {
+                yield i
+            } finally {
+                yield 99
+            }
+            return false
+        }
+        // body and finally interleaved per iteration
+        checkSeq(t, gen, [0, 99, 1, 99, 2, 99])
+    }
+    t |> run("for finally break") @(t : T?) {
+        var gen <- generator<int>() <| $() {
+            for (i in range(10)) {
+                yield i
+                if (i == 1) {
+                    break
+                }
+            } finally {
+                yield 99
+            }
+            return false
+        }
+        // iter 0 body/finally, iter 1 body, break (finally still runs for this iter), exit
+        checkSeq(t, gen, [0, 99, 1, 99])
+    }
+    t |> run("for finally continue") @(t : T?) {
+        var gen <- generator<int>() <| $() {
+            for (i in range(4)) {
+                if (i == 1) {
+                    continue
+                }
+                yield i
+            } finally {
+                yield 99
+            }
+            return false
+        }
+        // i=0 yield 0, finally 99
+        // i=1 continue, finally 99
+        // i=2 yield 2, finally 99
+        // i=3 yield 3, finally 99
+        checkSeq(t, gen, [0, 99, 99, 2, 99, 3, 99])
+    }
+    t |> run("for finally empty") @(t : T?) {
+        var gen <- generator<int>() <| $() {
+            for (i in range(0)) {
+                yield i
+            } finally {
+                yield 99
+            }
+            return false
+        }
+        checkSeq(t, gen, [])
+    }
+    t |> run("while plain finally") @(t : T?) {
+        var gen <- generator<int>() <| $() {
+            var i = 0
+            while (i < 3) {
+                yield i
+                i ++
+            } finally {
+                yield 99
+            }
+            return false
+        }
+        checkSeq(t, gen, [0, 99, 1, 99, 2, 99])
+    }
+    t |> run("while finally break") @(t : T?) {
+        var gen <- generator<int>() <| $() {
+            var i = 0
+            while (i < 100) {
+                yield i
+                i ++
+                if (i == 2) {
+                    break
+                }
+            } finally {
+                yield 99
+            }
+            return false
+        }
+        checkSeq(t, gen, [0, 99, 1, 99])
+    }
+    t |> run("while finally empty") @(t : T?) {
+        var gen <- generator<int>() <| $() {
+            while (false) {
+                yield 1
+            } finally {
+                yield 99
+            }
+            return false
+        }
+        checkSeq(t, gen, [])
+    }
+    t |> run("nested for finally") @(t : T?) {
+        var gen <- generator<int>() <| $() {
+            for (y in range(2)) {
+                for (x in range(2)) {
+                    yield y * 10 + x
+                } finally {
+                    yield 77  // inner finally per inner iter
+                }
+            } finally {
+                yield 99  // outer finally per outer iter
+            }
+            return false
+        }
+        // y=0:
+        //   x=0 yield 0, inner finally 77
+        //   x=1 yield 1, inner finally 77
+        //   outer finally 99
+        // y=1:
+        //   x=0 yield 10, inner finally 77
+        //   x=1 yield 11, inner finally 77
+        //   outer finally 99
+        checkSeq(t, gen, [0, 77, 1, 77, 99, 10, 77, 11, 77, 99])
+    }
+}

--- a/tests/loops/nested.das
+++ b/tests/loops/nested.das
@@ -1,0 +1,109 @@
+// Per-iteration finally correctness for nested loops of mixed kinds.
+options gen2
+require dastest/testing_boost public
+
+[test]
+def test_nested(t : T?) {
+    t |> run("for in for") @(t : T?) {
+        var outer = 0
+        var inner = 0
+        for (_y in range(4)) {
+            for (_x in range(3)) {
+            } finally {
+                inner ++
+            }
+        } finally {
+            outer ++
+        }
+        t |> equal(outer, 4)
+        t |> equal(inner, 4 * 3)
+    }
+    t |> run("while in for") @(t : T?) {
+        var outer = 0
+        var inner = 0
+        for (_y in range(3)) {
+            var x = 0
+            while (x < 5) {
+                x ++
+            } finally {
+                inner ++
+            }
+        } finally {
+            outer ++
+        }
+        t |> equal(outer, 3)
+        t |> equal(inner, 3 * 5)
+    }
+    t |> run("for in while") @(t : T?) {
+        var y = 0
+        var outer = 0
+        var inner = 0
+        while (y < 3) {
+            for (_x in range(4)) {
+            } finally {
+                inner ++
+            }
+            y ++
+        } finally {
+            outer ++
+        }
+        t |> equal(outer, 3)
+        t |> equal(inner, 3 * 4)
+    }
+    t |> run("triple nested") @(t : T?) {
+        var outer = 0
+        var mid = 0
+        var inner = 0
+        for (_z in range(2)) {
+            for (_y in range(3)) {
+                for (_x in range(4)) {
+                } finally {
+                    inner ++
+                }
+            } finally {
+                mid ++
+            }
+        } finally {
+            outer ++
+        }
+        t |> equal(outer, 2)
+        t |> equal(mid, 2 * 3)
+        t |> equal(inner, 2 * 3 * 4)
+    }
+    t |> run("inner break preserves outer") @(t : T?) {
+        var outer = 0
+        var inner = 0
+        for (_y in range(3)) {
+            for (x in range(10)) {
+                if (x == 2) {
+                    break
+                }
+            } finally {
+                inner ++
+            }
+        } finally {
+            outer ++
+        }
+        // inner break at x==2: 3 finally fires per outer iter; outer runs full 3 times
+        t |> equal(outer, 3)
+        t |> equal(inner, 3 * 3)
+    }
+    t |> run("outer break after inner finishes") @(t : T?) {
+        var outer = 0
+        var inner = 0
+        for (y in range(5)) {
+            for (_x in range(2)) {
+            } finally {
+                inner ++
+            }
+            if (y == 1) {
+                break
+            }
+        } finally {
+            outer ++
+        }
+        // outer breaks on y==1, so outer iterations 0 and 1 fire: outer finally = 2
+        t |> equal(outer, 2)
+        t |> equal(inner, 2 * 2)
+    }
+}

--- a/tests/loops/while.das
+++ b/tests/loops/while.das
@@ -1,0 +1,100 @@
+// Per-iteration finally on while loops.
+options gen2
+require dastest/testing_boost public
+
+[test]
+def test_while(t : T?) {
+    t |> run("plain") @(t : T?) {
+        var i = 0
+        var count = 0
+        while (i < 5) {
+            i ++
+        } finally {
+            count ++
+        }
+        t |> equal(count, 5)
+    }
+    t |> run("break") @(t : T?) {
+        var i = 0
+        var count = 0
+        while (i < 10) {
+            if (i == 3) {
+                break
+            }
+            i ++
+        } finally {
+            count ++
+        }
+        // iterations i=0,1,2,3 each fire finally (break runs after i==3's finally)
+        t |> equal(count, 4)
+    }
+    t |> run("continue") @(t : T?) {
+        var i = 0
+        var count = 0
+        var hits = 0
+        while (i < 6) {
+            i ++
+            if (i % 2 == 0) {
+                continue
+            }
+            hits ++
+        } finally {
+            count ++
+        }
+        t |> equal(count, 6)
+        t |> equal(hits, 3)
+    }
+    t |> run("return") @(t : T?) {
+        t |> equal(while_return(), 2)
+    }
+    t |> run("nested") @(t : T?) {
+        var outer_count = 0
+        var inner_count = 0
+        var y = 0
+        while (y < 3) {
+            var x = 0
+            while (x < 4) {
+                x ++
+            } finally {
+                inner_count ++
+            }
+            y ++
+        } finally {
+            outer_count ++
+        }
+        t |> equal(outer_count, 3)
+        t |> equal(inner_count, 12)
+    }
+    t |> run("inscope") @(t : T?) {
+        var i = 0
+        while (i < 5) {
+            var inscope tmp : array<int>
+            tmp |> push(i)
+            t |> equal(tmp[0], i)
+            i ++
+        }
+    }
+    t |> run("never taken") @(t : T?) {
+        var count = 0
+        while (false) {
+        } finally {
+            count ++
+        }
+        // condition false from the start: body never enters, finally never runs
+        t |> equal(count, 0)
+    }
+}
+
+def while_return() : int {
+    var i = 0
+    var count = 0
+    while (i < 10) {
+        if (i == 2) {
+            return count
+        }
+        i ++
+    } finally {
+        count ++
+    }
+    return -1
+}

--- a/tutorials/language/20_lifetime.das
+++ b/tutorials/language/20_lifetime.das
@@ -100,11 +100,12 @@ def main {
     // even if an error occurs.
 
     print("=== finally ===\n")
+    // 'finally' on a loop body runs at the end of every iteration.
     var counter = 0
     for (_i in range(3)) {
         counter += 1
     } finally {
-        print("  loop done, counter={counter}\n")
+        print("  iter done, counter={counter}\n")
     }
 
     // === Heap pointers (new) ===
@@ -149,5 +150,7 @@ def main {
 //   cleanup: File (id=2)
 //   inscope block ended
 // === finally ===
-//   loop done, counter=3
+//   iter done, counter=1
+//   iter done, counter=2
+//   iter done, counter=3
 // === done ===

--- a/tutorials/language/21_error_handling.das
+++ b/tutorials/language/21_error_handling.das
@@ -61,13 +61,14 @@ def sum_numbers(a, b : auto(T)) : T {
 
 // === finally blocks ===
 // Runs when a block exits, regardless of how (return, panic, etc.)
+// On a for/while loop body, finally runs per iteration — not once at the end.
 
 def process_with_cleanup() {
     var counter = 0
     for (_i in range(3)) {
         counter += 1
     } finally {
-        print("  loop cleanup, counter={counter}\n")
+        print("  iter cleanup, counter={counter}\n")
     }
     // finally can attach to any block: functions, loops, if blocks
 }
@@ -165,7 +166,9 @@ def main {
 //   sum_numbers(3, 4) = 7
 //   sum_numbers(1.5, 2.5) = 4
 // finally:
-//   loop cleanup, counter=3
+//   iter cleanup, counter=1
+//   iter cleanup, counter=2
+//   iter cleanup, counter=3
 // defer:
 //   step 1: acquire resources
 //   step 2: do work


### PR DESCRIPTION
## Summary

Flip `finally` semantics on `for` / `while` loop bodies from **once-at-end** to **per-iteration**. Every path out of the iteration body — normal fall-through, `continue`, `break`, and `return` — now routes through the loop's `finally` section. An empty iterator still never enters the body, so its `finally` does not run (unchanged).

## Motivation

`var inscope x` was forbidden inside loop bodies because the loop's `finally` fired only once, which would leak per-iteration `inscope` scoped values. With per-iteration semantics, `inscope` inside a loop is safe: each iteration finalizes its own scoped variables before the next begins.

```das
for (path in paths) {
    var inscope f = acquire("File", path)
    read(f)
    // delete f runs here, at the end of each iteration
}
```

## Changes per tier

- **dastest** — new `--debugger` / `--keep-alive` CLI flags plumbed through `SuiteCtx` so one binary exercises the default, `_Debug`, and `_KeepAlive` SimNode variant families. `DAS_DEBUGGER=1` kept in Release.
- **Interpreter (SimNode)** — two-copy hoisted-invariant pattern across all 63 loop variants in `runtime_range.h`, `runtime_array.h`, `simulate_nodes.h`, `simulate.cpp`. No-finally loops take the fast path unchanged; with-finally loops run the finally block per iteration. New `DAS_PROCESS_LOOP_FLAGS_LABELED` macro in `simulate.h`.
- **Type inference** — drop `blocks.back()->inTheLoop` in `ast_inscope_pod.cpp` and the `scopes.back()->inTheLoop` rejection in `ast_infer_type.cpp`.
- **Generator linearizer** (`ast_generate.cpp`) — `replaceGeneratorWhile` and `replaceGeneratorFor` emit the finally body at the iteration epilogue (continue target + normal fall-through) and route `break` through it via a single `__broke` flag. Single clone avoids duplicated yield-label ids.
- **AOT emitter** (`daslib/aot_cpp.das`) — drop `finallyDisabled` scaffolding, remove pre-loop finally emission, place the block's `das_finally` RAII guard *inside* the generated C++ body braces. Destructor fires per iteration on fall-through / continue / break / return.
- **LLVM JIT** (`modules/dasLLVM/daslib/llvm_jit.das`) — mirror AOT's pattern: drop pre-loop finally dispatch, route body fall-through / continue / break / return through the finally BB, and extract `emit_iterator_close` so for-loop iterators close both at normal loop exit and on return paths that bypass loop_end (since JIT has no C++ destructors).

## Tests

New `tests/loops/` suite (8 files, 61 cells) covering `for_range` / `for_array` / `for_fixed_array` / `for_iterator` / `for_multi_source` / `while` / `nested` / `generator_loops` × plain / break / continue / return / inscope / empty.

Existing `tests/language/finally.das`, `tests/language/generators.das`, `tests/jit_tests/finally.das`, `tests/jit_tests/for_loop.das`, `tests/jit_tests/while_loop.das` rewritten for per-iter semantics. Registered in `tests/aot/CMakeLists.txt`.

### Final verification (all green, zero GC leaks)

| Mode | Tests |
|---|---|
| Interpreter (default) | 6525 / 6525 |
| Interpreter (keep-alive) | 6525 / 6525 |
| AOT (`test_aot.exe -use-aot`) | 5940 / 5940 |
| JIT (`daslang.exe -jit`) | 6199 / 6199 |

## Docs

Updated `doc/source/reference/language/statements.rst` (finally section + inscope-in-loop restriction removed), tutorials 20 and 21 (lifetime / error handling), tutorial `.das` files (expected-output comments), `CLAUDE.md` (inscope-in-loop note + AOT emitter location pointer), `skills/aot_testing.md` (AOT C++ emitter section).

## Breaking changes

Loops with `finally` that relied on the old once-at-end semantics will now execute the finally body per iteration. The existing affected tests (`tests/language/finally.das`, `tests/language/generators.das`, three files under `tests/jit_tests/`) were rewritten to verify the new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)