### PR TITLE
jit: content-address JIT DLLs and cache aotHash

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1033,7 +1033,7 @@ namespace das
 
     uint64_t getFunctionHash ( Function * fun, SimNode * node, Context * context );
 
-    uint64_t getFunctionAotHash ( const Function * fun );
+    uint64_t getFunctionAotHash ( Function * fun );
     string getAotHashComment ( const Function * fun );
     uint64_t getVariableListAotHash ( const vector<const Variable *> & globs, uint64_t initHash );
 

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -19,6 +19,49 @@ module llvm_macro shared private
 
 var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole library; when false, only against runtime
 
+// Bump this constant whenever LLVM codegen / linking logic changes in a way that
+// invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
+// runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
+// makes every previously written DLL miss the cache on the next run and get GC'd.
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x01ul
+
+let JIT_FNV_PRIME : uint64 = 1099511628211ul
+
+def jit_dll_basename(funcs : array<FunctionPtr>; opt_level : int; size_level : int;
+                     emit_prologue : bool; debug_info : bool) : string {
+    var h = LLVM_JIT_CODEGEN_VERSION
+    for (fn in funcs) {
+        h = (h ^ get_function_aot_hash(fn)) * JIT_FNV_PRIME
+    }
+    h = (h ^ uint64(opt_level)) * JIT_FNV_PRIME
+    h = (h ^ uint64(size_level)) * JIT_FNV_PRIME
+    h = (h ^ (emit_prologue ? 1ul : 0ul)) * JIT_FNV_PRIME
+    h = (h ^ (debug_info ? 1ul : 0ul)) * JIT_FNV_PRIME
+    return "{h}"
+}
+
+def jit_gc_stale_dlls(subdir : string; keep_basename : string) {
+    // Delete any file in subdir whose basename does not match the current hash.
+    // Covers stale `.dll` plus linker artifacts (`.o`, `.lib`, `.exp`, `.pdb`).
+    let keep_prefix = "{keep_basename}."
+    dir(subdir) $(fname) {
+        if (fname == "." || fname == "..") {
+            return
+        }
+        if (fname |> starts_with(keep_prefix)) {
+            return
+        }
+        let full_path = "{subdir}/{fname}"
+        var err : string
+        let ok = remove(full_path, err)
+        if (ok && empty(err)) {
+            to_log(LOG_INFO, "LLVM JIT: GC stale artifact {full_path}\n")
+        } else {
+            to_log(LOG_WARNING, "LLVM JIT: failed to GC stale artifact {full_path}: {err}\n")
+        }
+    }
+}
+
 struct JitState {
     dll : void?
     ee : void?
@@ -106,7 +149,7 @@ class JIT_LLVM : AstSimulateMacro {
         // out to be reachable.
         let exe_strict = true
         assume config_out_path = string(prog.policies.jit_output_path)
-        let output_path = config_out_path |> empty() ? ".jitted_scripts/{prog.thisNamespace}" : config_out_path
+        var output_path = config_out_path |> empty() ? ".jitted_scripts/{prog.thisNamespace}" : config_out_path
         assume path_to_shared_lib = string(prog.policies.jit_path_to_shared_lib)
         assume path_to_linker = string(prog.policies.jit_path_to_linker)
 
@@ -140,6 +183,15 @@ class JIT_LLVM : AstSimulateMacro {
         }
         if (!empty(funcs)) {
             let totalTime = ref_time_ticks()
+            // Content-address the DLL so that distinct (AST + codegen version + opt flags)
+            // combinations land in distinct files. Same inputs -> same filename -> cache hit.
+            // Only applied in dll-mode with the default output path; if the user pinned
+            // jit_output_path explicitly or we're producing an exe, keep their path.
+            var dll_hash_basename : string
+            if (use_dll && config_out_path |> empty()) {
+                dll_hash_basename = jit_dll_basename(funcs, opt_level, size_level, emit_prologue, debug_info)
+                output_path = ".jitted_scripts/{prog.thisNamespace}/{dll_hash_basename}"
+            }
             init_jit(opt_level |> uint)
 
             var jit_flags : LlvmJitFlags
@@ -167,6 +219,9 @@ class JIT_LLVM : AstSimulateMacro {
                 recompile_prog = dll_changed
                 if (recompile_prog) {
                     g_dynamic_lib_handle.reset();
+                    to_log(LOG_INFO, "LLVM JIT: DLL cache miss, codegen for {output_path}.dll\n")
+                } else {
+                    to_log(LOG_INFO, "LLVM JIT: DLL cache hit {output_path}.dll\n")
                 }
             }
             if (recompile_prog) {
@@ -234,6 +289,11 @@ class JIT_LLVM : AstSimulateMacro {
                     g_dynamic_lib_handle = get_dll_by_path(output_path)
                     let (missing, disabling) = get_dll_missing(funcs, disabled, g_dynamic_lib_handle, uids)
                     assert(missing |> empty() && disabling |> empty())
+
+                    // Clean up stale DLLs in the per-script subdirectory.
+                    if (!(dll_hash_basename |> empty())) {
+                        jit_gc_stale_dlls(dir_name(output_path), dll_hash_basename)
+                    }
                 }
             }
             if (use_dll) {

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -4038,7 +4038,7 @@ namespace das
         for ( int fni=0, fnis=context.totalFunctions; fni!=fnis; ++fni ) {
             if ( !fnn[fni]->noAot ) {
                 SimFunction & fn = context.functions[fni];
-                uint64_t semHash = fnn[fni]->aotHash = getFunctionAotHash(fnn[fni]);
+                uint64_t semHash = getFunctionAotHash(fnn[fni]);
                 auto it = aotLib.find(semHash);
                 if ( it != aotLib.end() ) {
                     fn.code = (it->second)(context);

--- a/src/simulate/simulate_fn_hash.cpp
+++ b/src/simulate/simulate_fn_hash.cpp
@@ -225,7 +225,8 @@ namespace das {
         context->invoke(block, args, nullptr, line);
     }
 
-    uint64_t getFunctionAotHash ( const Function * fun ) {
+    uint64_t getFunctionAotHash ( Function * fun ) {
+        if ( fun->aotHash != 0 ) return fun->aotHash; // cached
         DependencyCollector collector;
         collector.collect(fun);
         auto vec = collector.getStableDependencies();
@@ -243,6 +244,7 @@ namespace das {
         }
         uint64_t res = hash_block64((const uint8_t *)uvec.data(), uint32_t(uvec.size()*sizeof(uint64_t)));
         debug_aot_hash("AOT HASH %" PRIx64 "\n", res);
+        fun->aotHash = res;
         return res;
     }
 

--- a/tests/jit_tests/dll_cache.das
+++ b/tests/jit_tests/dll_cache.das
@@ -1,0 +1,109 @@
+// Tests JIT DLL content-addressed caching:
+//   - recompile with identical source        -> cache hit  (same DLL filename)
+//   - recompile with different source        -> cache miss (new filename, old artifacts GC'd)
+// Runs only under -jit on a dll-build binary; in-process via compile_file + simulate.
+options gen2
+options no_aot
+
+require daslib/fio
+require daslib/rtti
+require strings
+require dastest/testing_boost
+
+let OUTPUT_DIR = "{get_das_root()}/build/tests"
+let PROBE_PATH = "{OUTPUT_DIR}/dll_cache_probe.das"
+
+def write_probe(body_expr : string) : bool {
+    mkdir_rec(OUTPUT_DIR)
+    var ok = false
+    fopen(PROBE_PATH, "w") $(f) {
+        if (f != null) {
+            fprint(f, "options gen2\n")
+            fprint(f, "require daslib/just_in_time\n\n")
+            fprint(f, "[jit, sideeffects, export]\n")
+            fprint(f, "def probe(x : int) : int \{\n")
+            fprint(f, "    return {body_expr}\n")
+            fprint(f, "\}\n")
+            fprint(f, "\n[export]\ndef main() \{\n    let _ = probe(0)\n\}\n")
+            ok = true
+        }
+    }
+    return ok
+}
+
+def compile_probe() : string {
+    var ns : string
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.jit_enabled = true
+            cop.jit_dll_mode = true
+            access |> add_extra_module("just_in_time", "{get_das_root()}/daslib/just_in_time.das")
+            compile_file(PROBE_PATH, access, unsafe(addr(mg)), cop) $(ok, program, errors) {
+                if (ok && program != null) {
+                    ns = string(program.thisNamespace)
+                    simulate(program) $(sok, context, serrors) {}
+                }
+            }
+        }
+    }
+    return ns
+}
+
+def list_dlls(subdir : string) : array<string> {
+    var res : array<string>
+    dir(subdir) $(fname) {
+        if (fname |> ends_with(".dll")) {
+            res |> push(fname)
+        }
+    }
+    return <- res
+}
+
+def clear_subdir(subdir : string) {
+    dir(subdir) $(fname) {
+        if (fname == "." || fname == "..") {
+            return
+        }
+        var err : string
+        remove("{subdir}/{fname}", err)
+    }
+}
+
+def test_dll_cache(t : T?) {
+    if (!jit_enabled() || !das_is_dll_build()) {
+        return
+    }
+    // first compile seeds the namespace so we can locate the per-script subdir
+    t |> equal(write_probe("x + 1"), true)
+    let ns = compile_probe()
+    t |> equal(empty(ns), false)
+    let subdir = ".jitted_scripts/{ns}"
+    clear_subdir(subdir)
+
+    // compile 1: cache miss, one DLL appears
+    compile_probe()
+    let dlls1 <- list_dlls(subdir)
+    t |> equal(length(dlls1), 1)
+    let first_dll = dlls1[0]
+
+    // compile 2 with same source: cache hit, same filename, count still 1
+    compile_probe()
+    let dlls2 <- list_dlls(subdir)
+    t |> equal(length(dlls2), 1)
+    t |> strictEqual(dlls2[0], first_dll, "cache hit keeps same DLL filename")
+
+    // compile 3 with different body: miss, new DLL, old artifacts GC'd
+    t |> equal(write_probe("x + 2"), true)
+    compile_probe()
+    let dlls3 <- list_dlls(subdir)
+    t |> equal(length(dlls3), 1)
+    t |> equal(dlls3[0] != first_dll, true)
+}
+
+[test]
+def test_main(t : T?) {
+    t |> run("dll_cache") @(t : T?) {
+        test_dll_cache(t)
+    }
+}


### PR DESCRIPTION
## Summary

- **Content-addressed JIT DLL names.** Moves from `.jitted_scripts/<ns>.dll` to `.jitted_scripts/<ns>/<jit_hash>.dll`, where `<jit_hash>` folds each jitted function's `aotHash` with `opt_level`, `size_level`, `emit_prologue`, `debug_info`, and a manually bumped `LLVM_JIT_CODEGEN_VERSION` constant. Same inputs ⇒ same filename ⇒ cache hit; any codegen-affecting change ⇒ new filename.
- **GC of stale DLL artifacts** (`.dll`, `.o`, `.lib`, `.exp`, `.pdb`) after every successful write — catches both renamed scripts and content churn.
- **`getFunctionAotHash` now self-caches** into `Function::aotHash`. Callers (`linkCppAot`, the JIT simulate macro, `get_dll_missing`, `generate_llvm`) keep calling the same function; repeats are O(1). Empirically verified the field was `0` at JIT-macro time before this change — `linkCppAot` was the only writer and only runs when `policies.aot` is true.

## Motivation

Before this PR, editing a script under `-jit` silently overwrote the DLL at the same path, renamed scripts leaked DLLs in `.jitted_scripts/`, and every cache-miss-check call recomputed the dependency-folded aot hash via `DependencyCollector`. The pure-path-hash filename also meant that changes to `llvm_jit.das` / `llvm_macro.das` / `llvm_jit_common.das` or the runtime helper ABI did **not** invalidate existing DLLs — bump `LLVM_JIT_CODEGEN_VERSION` in the same commit when touching those.

## Numbers

Measured on `tests/jit_tests/` (49 files, `-jit` enabled):
- First run (all misses, codegen + link per file): **~20 s**
- Second run (all hits, disk read only): **~1.08 s** — ~18× faster

## Test plan

- [x] `utils/lint/main.das` on changed `.das` files — PASS
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests` — 6531/6531
- [x] `bin/Release/daslang.exe -jit dastest/dastest.das -- --test tests/jit_tests` — 280/280 (incl. new `dll_cache.das`)
- [x] `cmake --build build --config Release --target test_aot` then `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — 5943/5943
- [x] Manual smoke: cache-miss → cache-hit → source edit → old artifacts GC'd (verified via `LOG_INFO` output and filesystem inspection)

New in-process test `tests/jit_tests/dll_cache.das` covers the three invariants:
1. identical recompile keeps same DLL filename (cache hit)
2. edited source produces a new filename (cache miss)
3. sibling artifacts from the old hash get GC'd (count stays at 1 DLL per subdir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)