### PR TITLE
ast: diagnose un-inferred ExprCall instead of crashing

### DIFF
--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -59,7 +59,37 @@ namespace das {
     };
 
     class NoSideEffectVisitor : public Visitor {
+    public:
+        explicit NoSideEffectVisitor ( Program * prog ) : program(prog) {}
     protected:
+        Program * program = nullptr;
+        // report an internal compiler error. a resolved ExprCall / ExprOpN
+        // must have a non-null func by this stage; reaching here means the
+        // call was produced after type inference and infer was never re-run
+        // on it. common causes:
+        //  - a structure or function annotation patch() mutated the AST but did
+        //    not set astChanged=true, so the parse loop did not re-infer;
+        //  - a pass / optimization macro modified the AST and returned false from
+        //    apply(), suppressing the re-infer cycle;
+        //  - a substitution macro (call / reader / typeinfo / variant / type / etc.)
+        //    produced a node, but the call site forgot to forward it as a substitute
+        //    so type inference never sees it.
+        // we report the diagnostic (which sets failToCompile) and then let the
+        // caller fall through to Visitor::visit so child traversal continues.
+        // skipping the func-deref code path keeps us safe within this pass; the
+        // noSideEffects/noNativeSideEffects flags retain their conservative
+        // default of false set by SetSideEffectVisitor::preVisitExpression, and
+        // ast_parse.cpp now gates downstream pipeline stages (foldUnsafe /
+        // optimize / buildAccessFlags / verifyAndFoldContracts) on !failed()
+        // so the broken AST is not walked again.
+        void reportNullFunc ( Expression * expr, const char * exprKind ) {
+            program->error("internal compilation error, " + string(exprKind) +
+                " reached side-effect analysis with unresolved func",
+                "this typically means the AST was modified after type inference "
+                "without signalling that infer needs to run again - check the "
+                "annotation patch() / pass apply() / substitution macro that produced this node",
+                "", expr->at, CompilationError::missing_node);
+        }
         virtual bool canVisitFunction ( Function * fun ) override {
             return !fun->stub && !fun->isTemplate;    // we don't do a thing with templates
         }
@@ -171,6 +201,7 @@ namespace das {
         }
     // op1
         virtual ExpressionPtr visit ( ExprOp1 * expr ) override {
+            if ( !expr->func ) { reportNullFunc(expr, "op1"); return Visitor::visit(expr); }
             expr->noSideEffects = expr->subexpr->noSideEffects && (expr->func->sideEffectFlags==0);
             expr->noNativeSideEffects = expr->subexpr->noNativeSideEffects
                 && ((expr->func->sideEffectFlags & uint32_t(SideEffects::inferredSideEffects))==0);
@@ -178,6 +209,7 @@ namespace das {
         }
     // op2
         virtual ExpressionPtr visit ( ExprOp2 * expr ) override {
+            if ( !expr->func ) { reportNullFunc(expr, "op2"); return Visitor::visit(expr); }
             expr->noSideEffects = expr->left->noSideEffects && expr->right->noSideEffects && (expr->func->sideEffectFlags==0);
             expr->noNativeSideEffects = expr->left->noNativeSideEffects && expr->right->noNativeSideEffects
                 && ((expr->func->sideEffectFlags & uint32_t(SideEffects::inferredSideEffects))==0);
@@ -192,6 +224,7 @@ namespace das {
         }
     // call
         virtual ExpressionPtr visit ( ExprCall * expr ) override {
+            if ( !expr->func ) { reportNullFunc(expr, "call"); return Visitor::visit(expr); }
             expr->noSideEffects = (expr->func->sideEffectFlags==0);
             expr->noNativeSideEffects = (expr->func->sideEffectFlags & uint32_t(SideEffects::inferredSideEffects))==0;
             if ( expr->noSideEffects ) {
@@ -938,7 +971,7 @@ namespace das {
     void Program::checkSideEffects() {
         SetSideEffectVisitor sse;
         visit(sse);
-        NoSideEffectVisitor nse;
+        NoSideEffectVisitor nse(this);
         visit(nse);
     }
 

--- a/src/ast/ast_lint.cpp
+++ b/src/ast/ast_lint.cpp
@@ -579,6 +579,25 @@ namespace das {
         }
         virtual void preVisit ( ExprCall * expr ) override {
             Visitor::preVisit(expr);
+            if ( !expr->func ) {
+                // a resolved ExprCall must have a non-null func by this stage;
+                // reaching here means the call was produced after type inference
+                // and infer was never re-run on it. common causes:
+                //  - a structure or function annotation patch() mutated the AST
+                //    but did not set astChanged=true, so the parse loop did not
+                //    re-infer;
+                //  - a pass / optimization macro modified the AST and returned
+                //    false from apply(), suppressing the re-infer cycle;
+                //  - a substitution macro (call / reader / typeinfo / variant /
+                //    type / etc.) produced a node, but the call site forgot to
+                //    forward it as a substitute so type inference never sees it.
+                program->error("internal compilation error, call reached lint with unresolved func",
+                    "this typically means the AST was modified after type inference "
+                    "without signalling that infer needs to run again - check the "
+                    "annotation patch() / pass apply() / substitution macro that produced this node",
+                    "", expr->at, CompilationError::missing_node);
+                return;
+            }
             verifyOnlyFastAot(expr->func, expr->at);
             verifyNoWrite(expr);
             if ( checkDeprecated && expr->func->deprecated ) {

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -780,12 +780,15 @@ namespace das {
                 if (!program->failed())
                     program->lint(logs, libGroup);
                 if ( policies.macro_context_collect ) libGroup.collectMacroContexts();
-                program->foldUnsafe();
+                if (!program->failed())
+                    program->foldUnsafe();
                 auto timeO = ref_time_ticks();
-                if (program->getOptimize()) {
-                    program->optimize(logs,libGroup);
-                } else {
-                    program->buildAccessFlags(logs);
+                if (!program->failed()) {
+                    if (program->getOptimize()) {
+                        program->optimize(logs,libGroup);
+                    } else {
+                        program->buildAccessFlags(logs);
+                    }
                 }
                 if ( policies.macro_context_collect ) libGroup.collectMacroContexts();
                 *totOpt += get_time_usec(timeO);

--- a/tests/README.md
+++ b/tests/README.md
@@ -373,6 +373,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 |---|---|---|
 | _glob.das | *(helper)* Shared module defining `AAA = 10` | |
 | _helper_foo.das | *(helper)* Module providing `TestObjectFoo` struct and `testFoo` function | |
+| _helper_macro_uninferred.das | *(helper)* `[bad_emitter]` structure_macro that adds an un-inferred function during patch | |
 | _module_a.das | *(helper)* Module for module_vis_fail — globals, types, functions | |
 | _module_b.das | *(helper)* Module for module_vis_fail — requires _module_a | |
 | _operators_derived.das | *(helper)* Derived class BarOp | |
@@ -505,6 +506,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | make_handle.das | Handle construction — `TestObjectFoo(fooData=...)`, global/local/cmres/ascend | |
 | make_local.das | Struct local construction — defaults, `uninitialized`, fixed_array | |
 | make_struct_with_clone.das | Struct construction with clone `:=` for array fields | |
+| failed_macro_added_function_must_infer.das | structure_macro adds a function during patch without setting astChanged — compiler reports internal-error diagnostics with a hint, instead of crashing | **expect** `50100:2` |
 | map_to_a.das | `map_to_array` — reinterpret raw memory as typed array via unsafe block | |
 | memset.das | memset8, memset16, memset32, memset64, memset128 | |
 | memzero.das | memzero for float and fixed_array | |

--- a/tests/language/_helper_macro_uninferred.das
+++ b/tests/language/_helper_macro_uninferred.das
@@ -1,0 +1,27 @@
+// helper module for failed_macro_added_function_must_infer test
+// the [bad_emitter] structure_macro adds a function to the module
+// during patch() but emits a call with an unresolvable identifier and
+// does NOT set astChanged - exercising the path where a function
+// is created post-infer and never visited by type inference
+options gen2
+
+module _helper_macro_uninferred public
+
+require daslib/ast
+require daslib/ast_boost
+require daslib/templates_boost
+
+def some_callee(x : int) : void {
+}
+
+[structure_macro(name = "bad_emitter")]
+class BadEmitterMacro : AstStructureAnnotation {
+    def override patch(var st : StructurePtr; var group : ModuleGroup;
+                       args : AnnotationArgumentList; var errors : das_string;
+                       var astChanged : bool&) : bool {
+        let badname = "id|{st.name}"
+        var regblk <- setup_call_list("emitted_calls|{st.name}", st.at, true, true)
+        regblk.list |> emplace_new <| qmacro(some_callee($i(badname)))
+        return true
+    }
+}

--- a/tests/language/failed_macro_added_function_must_infer.das
+++ b/tests/language/failed_macro_added_function_must_infer.das
@@ -1,0 +1,22 @@
+// regression test: a structure_macro that adds a function during
+// patch() without setting astChanged used to leave the new function
+// uninferred, which then crashed lint/checkSideEffects with a null
+// expr->func deref.
+//
+// the compiler must turn this into a clean diagnostic instead of a
+// crash. NoSideEffectVisitor and LintVisitor each catch the null
+// func and emit error 50100 with a hint pointing at the missing
+// astChanged=true in the macro.
+options gen2
+expect 50100:2    // call reached side-effect analysis / lint with null func
+
+require _helper_macro_uninferred
+
+[bad_emitter]
+struct Foo {
+    x : int
+}
+
+[export]
+def main() {
+}


### PR DESCRIPTION
## Summary

A `structure_macro` / `function_macro` `patch()` that mutates the AST without setting `astChanged = true` leaves the new function un-inferred. Subsequent visitors (`NoSideEffectVisitor`, `LintVisitor`, `optimizationUnused`) then deref `expr->func == nullptr` and segfault — the original report is at https://codeberg.org/Pukeko/BugRepro.

The compiler now produces a clear diagnostic instead of crashing.

## Changes

- **Guards in `NoSideEffectVisitor`** (`ExprOp1`, `ExprOp2`, `ExprCall`) and **`LintVisitor`** (`ExprCall`): on null `func`, report `error[50100]` with a hint pointing at the three signalling paths where AST changes after type inference must be communicated:
  - annotation `patch()` setting `astChanged = true`
  - pass / optimization macro `apply()` returning `true`
  - substitution macro (call / reader / typeinfo / variant / type / etc.) producing a node that the call site forwards as a substitute
- **Parse-loop hardening** (`ast_parse.cpp`): gate `foldUnsafe()`, `optimize()` and `buildAccessFlags()` on `!program->failed()` so the post-lint pipeline does not run on a known-broken AST. Without this, `optimizationUnused` (under lint mode) would still walk the bad `ExprCall` and crash.
- **Regression test** `tests/language/failed_macro_added_function_must_infer.das` plus helper `_helper_macro_uninferred.das`. The helper defines a `[bad_emitter]` structure_macro that uses `setup_call_list` + `qmacro` to emit a call referencing an unresolvable identifier, and crucially does **not** set `astChanged`. The test expects `50100:2` (one diagnostic from each visitor).

## Sample diagnostic

```
error[50100]: internal compilation error, call reached lint with unresolved func
        regblk.list |> emplace_new <| qmacro(some_callee($i(badname)))
                                             ^^^^^^^^^^^
this typically means the AST was modified after type inference without signalling
that infer needs to run again - check the annotation patch() / pass apply() /
substitution macro that produced this node
```

## Test plan

- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/` — 6532/6532 pass
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — 5944/5944 pass
- [x] Lint on changed `.das` files (helper PASS, test reports the expected `50100`)
- [x] New test PASSES via dastest
- [x] Verified guards fire by temporarily reverting the parse-loop gate — both NoSideEffectVisitor and LintVisitor now emit `50100` instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)