### PR TITLE
Add C++ heap leak tracker for daslang tools (RelWithDebInfo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ benchdata.db
 
 # build artifacts
 build/
+build-track/
 # All build binaries stored here
 bin/
 # JIT stores dll's here

--- a/CMakeCommon.txt
+++ b/CMakeCommon.txt
@@ -110,10 +110,12 @@ MACRO(SETUP_LIB_DEFINITIONS _target)
             $<$<CONFIG:RelWithDebInfo>:DAS_NO_ASSERTIONS>
         )
     endif()
+    # RelWithDebInfo is our heap-leak audit configuration and MUST match Release
+    # codegen (fusion, inlining) so diagnostics are representative of what ships.
     target_compile_definitions(${_target} PUBLIC
         $<$<CONFIG:Release>:DAS_FUSION=2>
         $<$<CONFIG:MinSizeRel>:DAS_FUSION=1>
-        $<$<CONFIG:RelWithDebInfo>:DAS_FUSION=1>
+        $<$<CONFIG:RelWithDebInfo>:DAS_FUSION=2>
     )
 ENDMACRO()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,17 @@ option(DAS_AOT_EXAMPLES_DISABLED "Disable dasAOT examples" OFF)
 option(DAS_TUTORIAL_DISABLED "Disable dasTutorial" OFF)
 option(DAS_TESTS_DISABLED "Disable dasTests" OFF)
 option(DAS_BUILD_DOCUMENTATION "Build HTML documentation via Sphinx during install" OFF)
+# RelWithDebInfo is permanently our heap-leak tracking / audit build.
+# DAS_TRACK_ALLOC=1 (and the global new/delete override) are auto-enabled below
+# via generator expressions; tracker source files are #if DAS_TRACK_ALLOC-gated
+# so they compile to empty TUs in Release/Debug.
+#
+# Note on RelWithDebInfo inlining: CMakeCommon's SETUP_COMPILER hard-resets
+# CMAKE_CXX_FLAGS_RELWITHDEBINFO without any explicit /Ob level. Because the
+# flag string retains /O2 (added by MSBuild's RelWithDebInfo defaults), /O2
+# implies /Ob2 per the MSVC docs, so codegen still matches Release inlining.
+# Do not reintroduce an /Ob1 -> /Ob2 string(REPLACE) here -- CMakeCommon would
+# overwrite it, making the replace dead code.
 set(DAS_INSTALL_BINDIR bin CACHE STRING "Directory where to install binaries")
 set(DAS_INSTALL_LIBDIR lib CACHE STRING "Directory where to install binaries")
 set(DAS_INSTALL_DOCDIR . CACHE STRING "Directory where to install documentation")
@@ -740,6 +751,8 @@ src/misc/string_writer.cpp
 src/misc/memory_model.cpp
 src/misc/job_que.cpp
 src/misc/free_list.cpp
+src/misc/alloc_tracker.cpp
+src/misc/alloc_tracker_fast_stack.cpp
 src/misc/uric.cpp
 src/misc/format.cpp
 )
@@ -984,6 +997,25 @@ SETUP_LIBDASCRIPT(libDaScriptDyn_runtime ON ON LIBDASCRIPT_RUNTIME_SRC DAS_EXPOR
 SETUP_LIBDASCRIPT(libDaScript OFF OFF LIBDASCRIPT_COMPILER_SRC DAS_CC_EXPORTS)
 SETUP_LIBDASCRIPT(libDaScriptDyn ON OFF LIBDASCRIPT_COMPILER_SRC DAS_CC_EXPORTS)
 
+# Heap leak tracking: permanently enabled in RelWithDebInfo only.
+# DAS_FREE_LIST=0 forces the reuse cache off so every aligned allocation reaches
+# the tracker and free_list.cpp's global operator new/delete overrides stay inert
+# (no double-override).
+target_compile_definitions(libDaScript_runtime    PUBLIC
+    $<$<CONFIG:RelWithDebInfo>:DAS_TRACK_ALLOC=1>
+    $<$<CONFIG:RelWithDebInfo>:DAS_FREE_LIST=0>)
+target_compile_definitions(libDaScriptDyn_runtime PUBLIC
+    $<$<CONFIG:RelWithDebInfo>:DAS_TRACK_ALLOC=1>
+    $<$<CONFIG:RelWithDebInfo>:DAS_FREE_LIST=0>)
+# Global new/delete override: covers STL/raw new/smart_ptr refcount blocks.
+# On Windows each module resolves operator new per-CRT, so the override TU must
+# be compiled into every binary that wants its own code covered. Uses std::malloc
+# internally for cross-CRT compatibility; orphan frees (cross-module) are counted
+# at track_free_hook for diagnostics. The TU is #if DAS_TRACK_ALLOC-gated, so it
+# compiles empty in Release/Debug.
+target_sources(libDaScript_runtime    PRIVATE src/misc/alloc_tracker_overrides.cpp)
+target_sources(libDaScriptDyn_runtime PRIVATE src/misc/alloc_tracker_overrides.cpp)
+
 target_link_libraries(libDaScript libDaScript_runtime)
 target_link_libraries(libDaScriptDyn libDaScriptDyn_runtime)
 
@@ -1070,6 +1102,10 @@ if (NOT ${DAS_TOOLS_DISABLED})
 
     # Dynamic/DLL compiler binary — the default shipped binary.
     SETUP_COMPILER_BINARY(daslang libDaScriptDyn "" DAS_DYN_MODULES_LIBS)
+    # Each binary needs its own copy of the override TU to cover its own code
+    # (Windows resolves operator new per-CRT). TU is #if DAS_TRACK_ALLOC-gated.
+    target_sources(daslang        PRIVATE src/misc/alloc_tracker_overrides.cpp)
+    target_sources(daslang_static PRIVATE src/misc/alloc_tracker_overrides.cpp)
     # relative RPATH from install location
     if(APPLE)
         SET_TARGET_PROPERTIES(daslang PROPERTIES
@@ -1095,6 +1131,7 @@ if (NOT ${DAS_TOOLS_DISABLED})
         ${DAS_MODULES_NEED_INC}
     )
     add_executable(daslang-live ${DAS_LIVE_MAIN_SRC})
+    target_sources(daslang-live PRIVATE src/misc/alloc_tracker_overrides.cpp)
     TARGET_LINK_LIBRARIES(daslang-live libDaScriptDyn ${SRC_LIBRARIES})
     ADD_DEPENDENCIES(daslang-live libDaScriptDyn ${DAS_DYN_MODULES_LIBS})
     target_include_directories(daslang-live PRIVATE

--- a/dastest/dastest.das
+++ b/dastest/dastest.das
@@ -194,9 +194,6 @@ def serialize_path(ctx : SuiteCtx, files : array<string>, out_file : string) {
     if (res.errors > 0) {
         log::error("{res.errors} error(s)")
     }
-    unsafe {
-        fio::exit(res.errors > 0 ? 1 : 0)
-    }
     return res
 }
 
@@ -255,7 +252,7 @@ def deserialize_path(var ctx : SuiteCtx, files : array<string>, in_file : string
 }
 
 [export]
-def main() {
+def main() : int {
     var args <- get_command_line_arguments()
     log::init_log(args)
     let runIdx = args |> find_index("--run")
@@ -274,7 +271,7 @@ def main() {
             tests <- suite::test_results
         )
         log::info_raw("\n{jsonResultPrefix}{sprint_json(report, false)}\n{jsonResultPrefix}")
-        return
+        return res.failed + res.errors
     }
 
     log::failuresOnly = args |> has_value("--failures-only")
@@ -287,9 +284,21 @@ def main() {
         unsafe {
             var mainCtx & = this_context()
             new_thread <| @capture(& res, & mainCtx) {
-                fio::sleep(uint(timeout * 1000.))
-                unsafe {
-                    mainCtx |> invoke_in_context("timeout_tests", res, startTime, timeout)
+                // Polled sleep: chunk into 100ms slices and watch for jobque
+                // shutdown so a clean main-return does not have to wait for
+                // the full timeout. ~Module_JobQue busy-waits on the thread
+                // count, so without this the shutdown path hangs.
+                let total_ms = uint(timeout * 1000.)
+                var slept = 0u
+                while (slept < total_ms && !is_job_que_shutting_down()) {
+                    let chunk = min(100u, total_ms - slept)
+                    fio::sleep(chunk)
+                    slept += chunk
+                }
+                if (slept >= total_ms) {
+                    unsafe {
+                        mainCtx |> invoke_in_context("timeout_tests", res, startTime, timeout)
+                    }
                 }
             }
         }
@@ -299,10 +308,7 @@ def main() {
     collect_input_paths(args, inputPaths)
     var files : array<string>
     if (!collect_files(inputPaths, files)) {
-        unsafe {
-            fio::exit(1)
-        }
-        return
+        return 1
     }
 
     timingOutliers = args |> get_int_arg("--timing-outliers", 0)
@@ -487,7 +493,7 @@ def main() {
             }
         }
     }
-    finish_tests(res, startTime)
+    return finish_tests(res, startTime)
 }
 
 
@@ -496,7 +502,11 @@ def timeout_tests(var res : SuiteResult; start_time : int64; timeout_sec : float
     res.errors += 1
     res.total += 1
     log::error("Test timed out after {timeout_sec}s")
-    finish_tests(res, start_time)
+    // timeout fires from a worker thread; fio::exit is the cross-thread
+    // cancellation mechanism (bypasses shutdown dump — acceptable for this path).
+    unsafe {
+        fio::exit(finish_tests(res, start_time))
+    }
 }
 
 
@@ -541,7 +551,7 @@ def private print_timing_outliers() {
 }
 
 
-def finish_tests(res : SuiteResult; start_time : int64) {
+def finish_tests(res : SuiteResult; start_time : int64) : int {
     let resCode = res.failed + res.errors
     let totalDt = get_time_usec(start_time)
     log::info("\n{to_string(res)}")
@@ -578,9 +588,7 @@ def finish_tests(res : SuiteResult; start_time : int64) {
             }
         }
     }
-    unsafe {
-        fio::exit(resCode)
-    }
+    return resCode
 }
 
 

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -197,12 +197,6 @@ namespace das
         Type                baseType = Type::tInt;
         AnnotationList      annotations;
         bool                isPrivate = false;
-#if DAS_MACRO_SANITIZER
-    public:
-        void* operator new ( size_t count ) { return das_aligned_alloc16(count); }
-        void operator delete  ( void* ptr ) { auto size = das_aligned_memsize(ptr);
-            memset(ptr, 0xcd, size); das_aligned_free16(ptr); }
-#endif
     };
 
     class DAS_API Structure : public gc_node {
@@ -330,12 +324,6 @@ namespace das
             uint32_t    flags = 0;
         };
         mutable bool circularGuard = false;   // we prevent circular lookups with this guard. Do not serialize, do not expose to daslang
-#if DAS_MACRO_SANITIZER
-    public:
-        void* operator new ( size_t count ) { return das_aligned_alloc16(count); }
-        void operator delete  ( void* ptr ) { auto size = das_aligned_memsize(ptr);
-            memset(ptr, 0xcd, size); das_aligned_free16(ptr); }
-#endif
     };
 
     struct DAS_API Variable : gc_node {
@@ -415,12 +403,6 @@ namespace das
         };
 
         AnnotationArgumentList  annotation;
-#if DAS_MACRO_SANITIZER
-    public:
-        void* operator new ( size_t count ) { return das_aligned_alloc16(count); }
-        void operator delete  ( void* ptr ) { auto size = das_aligned_memsize(ptr);
-            memset(ptr, 0xcd, size); das_aligned_free16(ptr); }
-#endif
     };
 
     struct VarLessPred {
@@ -739,12 +721,6 @@ namespace das
             };
             uint32_t    printFlags = 0;
         };
-#if DAS_MACRO_SANITIZER
-    public:
-        void* operator new ( size_t count ) { return das_aligned_alloc16(count); }
-        void operator delete  ( void* ptr ) { auto size = das_aligned_memsize(ptr);
-            memset(ptr, 0xcd, size); das_aligned_free16(ptr); }
-#endif
     };
 
     struct ExprLooksLikeCall;
@@ -1023,12 +999,6 @@ namespace das
         bool isFullyInferred = false;
         string inferredSource;
 
-#if DAS_MACRO_SANITIZER
-    public:
-        void* operator new ( size_t count ) { return das_aligned_alloc16(count); }
-        void operator delete  ( void* ptr ) { auto size = das_aligned_memsize(ptr);
-            memset(ptr, 0xcd, size); das_aligned_free16(ptr); }
-#endif
     };
 
     uint64_t getFunctionHash ( Function * fun, SimNode * node, Context * context );

--- a/include/daScript/ast/ast_typedecl.h
+++ b/include/daScript/ast/ast_typedecl.h
@@ -281,12 +281,6 @@ namespace das {
         string              alias;
         LineInfo            at;
         Module *            module = nullptr;
-#if DAS_MACRO_SANITIZER
-    public:
-        void* operator new ( size_t count ) { return das_aligned_alloc16(count); }
-        void operator delete  ( void* ptr ) { auto size = das_aligned_memsize(ptr);
-            memset(ptr, 0xcd, size); das_aligned_free16(ptr); }
-#endif
     };
 
     struct MatchingOptionError {

--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -366,22 +366,64 @@ void DAS_API os_debug_break();
     #endif
 #endif
 
+// Heap-leak tracking hooks. Zero-cost when DAS_TRACK_ALLOC is off (empty inline bodies
+// fold away). When on, external implementations in src/misc/alloc_tracker.cpp record
+// every aligned allocation and symbolize survivors after Module::Shutdown().
+namespace das {
+#if DAS_TRACK_ALLOC
+    DAS_API void    track_alloc_hook(void *p, size_t sz) noexcept;
+    DAS_API void    track_free_hook(void *p) noexcept;
+    DAS_API void    arm_alloc_tracking() noexcept;
+    DAS_API size_t  dump_alloc_leaks(FILE *out);
+    // Landmark RAII: ctor walks the stack once and stores the chain; alloc-site
+    // captures that match the landmark's RSP short-circuit with a memcpy. Place
+    // one on the stack high in the call tree (e.g. top of compile_and_run) to
+    // cut per-allocation unwind cost from ~N frames to ~depth-above-landmark.
+    // Win64 only — other platforms treat it as a no-op.
+    #if defined(_MSC_VER) && defined(_M_X64)
+        DAS_API void das_fast_stack_landmark_enter() noexcept;
+        DAS_API void das_fast_stack_landmark_exit() noexcept;
+        struct AllocTrackingLandmark {
+            AllocTrackingLandmark() noexcept  { das_fast_stack_landmark_enter(); }
+            ~AllocTrackingLandmark() noexcept { das_fast_stack_landmark_exit(); }
+        };
+    #else
+        struct AllocTrackingLandmark {
+            AllocTrackingLandmark() noexcept {}
+            ~AllocTrackingLandmark() noexcept {}
+        };
+    #endif
+#else
+    inline void   track_alloc_hook(void *, size_t) noexcept {}
+    inline void   track_free_hook(void *) noexcept {}
+    inline void   arm_alloc_tracking() noexcept {}
+    inline size_t dump_alloc_leaks(FILE *) { return 0; }
+    struct AllocTrackingLandmark {
+        AllocTrackingLandmark() noexcept {}
+        ~AllocTrackingLandmark() noexcept {}
+    };
+#endif
+}
+
 #ifndef DAS_ALIGNED_ALLOC
 #define DAS_ALIGNED_ALLOC 1
 inline void *das_aligned_alloc16(size_t size) {
     DAS_ASSERTF(size != 0, "das_aligned_alloc16 called with size 0");
+    void *p;
 #if defined(_MSC_VER)
-    return _aligned_malloc(size, 16);
+    p = _aligned_malloc(size, 16);
 #else
-    void * mem = nullptr;
-    if (posix_memalign(&mem, 16, size)) {
+    p = nullptr;
+    if (posix_memalign(&p, 16, size)) {
         DAS_ASSERTF(0, "posix_memalign returned nullptr");
         return nullptr;
     }
-    return mem;
 #endif
+    das::track_alloc_hook(p, size);
+    return p;
 }
 inline void das_aligned_free16(void *ptr) {
+    das::track_free_hook(ptr);
 #if defined(_MSC_VER)
     _aligned_free(ptr);
 #else
@@ -420,12 +462,6 @@ inline size_t das_aligned_memsize(void * ptr){
 
 #ifndef DAS_TRACK_INSANE_POINTERS
 #define DAS_TRACK_INSANE_POINTERS 0
-#endif
-
-// when enabled, TypeDecl, Expression, Variable, Structure, Enumeration and Function
-// will be filled with 0xcd when deleted
-#ifndef DAS_MACRO_SANITIZER
-#define DAS_MACRO_SANITIZER 0
 #endif
 
 #if defined(_M_IX86) && defined(_MSC_VER) && !defined(__clang__) && _MSC_VER <= 1900

--- a/src/misc/alloc_tracker.cpp
+++ b/src/misc/alloc_tracker.cpp
@@ -1,0 +1,551 @@
+#include "daScript/misc/platform.h"
+
+#if DAS_TRACK_ALLOC
+
+#include <atomic>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <cstdint>
+#include <mutex>
+#include <new>
+#include <chrono>
+
+#if defined(_MSC_VER)
+    #include <windows.h>
+    #include <dbghelp.h>
+    #pragma comment(lib, "dbghelp.lib")
+#elif defined(__linux__) || defined(__APPLE__)
+    #include <execinfo.h>
+    #include <cxxabi.h>
+    #include <dlfcn.h>
+#endif
+
+// init_seg(lib) puts this TU's file-scope dynamic initializers in the "library"
+// group, which runs before any init_seg(user) — i.e., before all user-level C++
+// static constructors. Our registration struct (below) calls std::atexit() from
+// its constructor, so its handler lands at the bottom of the atexit LIFO stack.
+// Subsequent user static destructors register via __cxa_atexit and stack on top.
+// Result: our dump fires AFTER every user-level static destructor has run, so
+// process-lifetime statics (Meyers singletons, static vectors, etc.) no longer
+// appear as leaks.
+#if defined(_MSC_VER)
+    #pragma warning(push)
+    #pragma warning(disable: 4073)  // initializers put in library initialization area
+    #pragma init_seg(lib)
+    #pragma warning(pop)
+#endif
+
+namespace das {
+
+static constexpr int kFrames = 16;
+
+struct AllocInfo {
+    size_t size;
+    int    frameCount;
+    void * frames[kFrames];
+};
+
+struct Entry {
+    void *      key;        // nullptr = empty, kTombstone = deleted
+    AllocInfo   info;
+};
+
+static void * const kTombstone = reinterpret_cast<void*>(uintptr_t(-1));
+
+// Hand-rolled open-addressing hash map keyed by void*. Uses std::malloc/std::free
+// directly so its own storage never re-enters our hooks.
+struct LeakMap {
+    Entry *  entries   = nullptr;
+    size_t   capacity  = 0;
+    size_t   live      = 0;     // real entries
+    size_t   filled    = 0;     // real + tombstones (for rehash threshold)
+
+    void init() {
+        capacity = 4096;
+        entries = static_cast<Entry*>(std::calloc(capacity, sizeof(Entry)));
+    }
+
+    static size_t mix(void *p) {
+        uintptr_t x = reinterpret_cast<uintptr_t>(p);
+        x ^= x >> 33;
+        x *= 0xff51afd7ed558ccdULL;
+        x ^= x >> 33;
+        x *= 0xc4ceb9fe1a85ec53ULL;
+        x ^= x >> 33;
+        return size_t(x);
+    }
+
+    size_t find(void *key) const {
+        size_t mask = capacity - 1;
+        size_t i = mix(key) & mask;
+        size_t first_tomb = SIZE_MAX;
+        while (true) {
+            void *k = entries[i].key;
+            if (k == nullptr) return (first_tomb != SIZE_MAX) ? first_tomb : i;
+            if (k == key)     return i;
+            if (k == kTombstone && first_tomb == SIZE_MAX) first_tomb = i;
+            i = (i + 1) & mask;
+        }
+    }
+
+    void rehash(size_t new_cap) {
+        Entry *old_entries = entries;
+        size_t old_cap = capacity;
+        entries = static_cast<Entry*>(std::calloc(new_cap, sizeof(Entry)));
+        capacity = new_cap;
+        size_t mask = new_cap - 1;
+        for (size_t j = 0; j < old_cap; ++j) {
+            void *k = old_entries[j].key;
+            if (k == nullptr || k == kTombstone) continue;
+            size_t i = mix(k) & mask;
+            while (entries[i].key != nullptr) i = (i + 1) & mask;
+            entries[i] = old_entries[j];
+        }
+        std::free(old_entries);
+        filled = live;
+    }
+
+    void insert(void *key, const AllocInfo &info) {
+        if (!entries) init();
+        if ((filled + 1) * 4 >= capacity * 3) rehash(capacity * 2);
+        size_t i = find(key);
+        void *k = entries[i].key;
+        entries[i].key  = key;
+        entries[i].info = info;
+        if (k == nullptr) { ++filled; ++live; }
+        else if (k == kTombstone) { ++live; }
+        // else: replacement of existing key, counts unchanged
+    }
+
+    void erase(void *key) {
+        if (!entries || !live) return;
+        size_t i = find(key);
+        if (entries[i].key == key) {
+            entries[i].key = kTombstone;
+            --live;
+        }
+    }
+};
+
+// Leaked Meyers singleton: the map is never destroyed, so track_free after static
+// destructors is safe.
+static LeakMap & getMap() {
+    alignas(LeakMap) static unsigned char storage[sizeof(LeakMap)];
+    static LeakMap *m = ::new (storage) LeakMap();
+    return *m;
+}
+
+static std::mutex & getMutex() {
+    alignas(std::mutex) static unsigned char storage[sizeof(std::mutex)];
+    static std::mutex *m = ::new (storage) std::mutex();
+    return *m;
+}
+
+static std::atomic<bool>     g_armed{false};
+static std::atomic<uint64_t> g_orphan_free{0}; // free() of ptr not in map — cross-module guard
+static thread_local bool     tl_inside = false;
+
+struct ReentryGuard {
+    bool prev;
+    ReentryGuard() : prev(tl_inside) { tl_inside = true; }
+    ~ReentryGuard() { tl_inside = prev; }
+};
+
+#if defined(_MSC_VER) && defined(_M_X64)
+// Implemented in alloc_tracker_fast_stack.cpp — cached .pdata + lightweight
+// unwinder + landmark tail-memoize. Drop-in replacement for CaptureStackBackTrace.
+// skipFrames drops the N deepest frames; default 2 hides das_fast_stack_capture
+// itself and the tracker hook that called it.
+unsigned das_fast_stack_capture(void **stack, unsigned maxFrames, int skipFrames = 2) noexcept;
+#endif
+
+static int capture_stack(void **frames, int max_frames) noexcept {
+#if defined(_MSC_VER) && defined(_M_X64)
+    // skipFrames=2: drop das_fast_stack_capture + track_alloc_hook so the
+    // visible top frame is the caller of the tracker (operator new wrapper,
+    // das_aligned_alloc16, etc.).
+    return (int)das_fast_stack_capture(frames, (unsigned)max_frames, 2);
+#elif defined(_MSC_VER)
+    // FramesToSkip=1: drop the noinline track_alloc_hook itself.
+    return (int)CaptureStackBackTrace(1, (DWORD)max_frames, frames, nullptr);
+#elif defined(__linux__) || defined(__APPLE__)
+    // Drop backtrace()'s own frame and track_alloc_hook.
+    void * raw[64];
+    int n = max_frames + 2 > 64 ? 64 : max_frames + 2;
+    int got = backtrace(raw, n);
+    int skip = got > 2 ? 2 : got;
+    int out = got - skip;
+    if (out > max_frames) out = max_frames;
+    for (int i = 0; i < out; ++i) frames[i] = raw[skip + i];
+    return out;
+#else
+    (void)frames; (void)max_frames;
+    return 0;
+#endif
+}
+
+// noinline so skipFrames=2 in capture_stack (via das_fast_stack_capture) reliably
+// drops this frame regardless of /Ob level.
+#if defined(_MSC_VER)
+__declspec(noinline)
+#else
+__attribute__((noinline))
+#endif
+void track_alloc_hook(void *p, size_t sz) noexcept {
+    if (!g_armed.load(std::memory_order_relaxed)) return;
+    if (!p || tl_inside) return;
+    ReentryGuard g;
+    AllocInfo info;
+    info.size = sz;
+    info.frameCount = capture_stack(info.frames, kFrames);
+    std::lock_guard<std::mutex> lock(getMutex());
+    getMap().insert(p, info);
+}
+
+void track_free_hook(void *p) noexcept {
+    if (!g_armed.load(std::memory_order_relaxed)) return;
+    if (!p || tl_inside) return;
+    ReentryGuard g;
+    std::lock_guard<std::mutex> lock(getMutex());
+    LeakMap &m = getMap();
+    if (m.entries && m.live) {
+        size_t i = m.find(p);
+        if (m.entries[i].key == p) {
+            m.entries[i].key = kTombstone;
+            --m.live;
+            return;
+        }
+    }
+    // Pointer not in our map. Either allocated pre-arm, or freed by a module that
+    // doesn't share our override (cross-DLL). Counted for diagnostics.
+    g_orphan_free.fetch_add(1, std::memory_order_relaxed);
+}
+
+void arm_alloc_tracking() noexcept {
+    g_armed.store(true, std::memory_order_release);
+}
+
+// ------------------------- Symbolization -------------------------
+
+#if defined(_MSC_VER)
+static bool g_symInitialized = false;
+
+static void init_symbols() {
+    if (g_symInitialized) return;
+    // FAIL_CRITICAL_ERRORS + NO_PROMPTS: never pop message boxes from DBGHELP.
+    // OMAP_FIND_NEAREST: handle BBT-optimized binaries correctly.
+    // fInvadeProcess=TRUE enumerates all loaded modules at init; combined with
+    // DEFERRED_LOADS, PDBs are mapped on first SymFromAddr for each module.
+    SymSetOptions(SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS |
+                  SYMOPT_OMAP_FIND_NEAREST | SYMOPT_FAIL_CRITICAL_ERRORS |
+                  SYMOPT_NO_PROMPTS | SYMOPT_INCLUDE_32BIT_MODULES);
+    if (SymInitialize(GetCurrentProcess(), nullptr, TRUE)) {
+        g_symInitialized = true;
+        // Refresh catches any modules loaded after init (late-bound DLLs).
+        SymRefreshModuleList(GetCurrentProcess());
+    }
+}
+
+// disp larger than this means SymFromAddr fell back to a distant symbol;
+// suppress the name and show module+offset instead. 64KB is generous for a
+// single C++ function; typical codegen functions are under 4KB.
+static constexpr DWORD64 kMaxTrustedSymbolOffset = 0x10000;
+
+static void print_module_fallback(FILE *out, HANDLE proc, void *addr, DWORD64 addr64) {
+    IMAGEHLP_MODULE64 modInfo;
+    memset(&modInfo, 0, sizeof(modInfo));
+    modInfo.SizeOfStruct = sizeof(modInfo);
+    if (SymGetModuleInfo64(proc, addr64, &modInfo)) {
+        DWORD64 moduleOffset = addr64 - modInfo.BaseOfImage;
+        fprintf(out, "    %p  %s+0x%llx\n",
+                addr, modInfo.ModuleName, (unsigned long long)moduleOffset);
+    } else {
+        fprintf(out, "    %p  ?\n", addr);
+    }
+}
+
+static void print_frame(FILE *out, void *addr) {
+    HANDLE proc = GetCurrentProcess();
+    DWORD64 addr64 = (DWORD64)addr;
+
+    char symbuf[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(char)];
+    SYMBOL_INFO *sym = (SYMBOL_INFO*)symbuf;
+    sym->SizeOfStruct = sizeof(SYMBOL_INFO);
+    sym->MaxNameLen   = MAX_SYM_NAME;
+
+    DWORD64 disp = 0;
+    bool haveSym = SymFromAddr(proc, addr64, &disp, sym) != FALSE;
+    if (!haveSym || disp >= kMaxTrustedSymbolOffset) {
+        // SymFromAddr failed, or matched a symbol so far away it's almost
+        // certainly a misattribution. Show module+offset instead — more
+        // useful than `transform_syntax+0x747d`.
+        print_module_fallback(out, proc, addr, addr64);
+        return;
+    }
+
+    const char *name = sym->Name;
+    IMAGEHLP_LINE64 line;
+    memset(&line, 0, sizeof(line));
+    line.SizeOfStruct = sizeof(line);
+    DWORD lineDisp = 0;
+    if (SymGetLineFromAddr64(proc, addr64, &lineDisp, &line)) {
+        fprintf(out, "    %p  %s+0x%llx   %s:%lu\n",
+                addr, name, (unsigned long long)disp, line.FileName, (unsigned long)line.LineNumber);
+    } else {
+        fprintf(out, "    %p  %s+0x%llx\n",
+                addr, name, (unsigned long long)disp);
+    }
+}
+#else
+static void init_symbols() {}
+
+static void print_frame(FILE *out, void *addr) {
+#if defined(__linux__) || defined(__APPLE__)
+    Dl_info info;
+    if (dladdr(addr, &info) && info.dli_sname) {
+        int status = 0;
+        char *demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
+        const char *name = (status == 0 && demangled) ? demangled : info.dli_sname;
+        uintptr_t offset = (uintptr_t)addr - (uintptr_t)info.dli_saddr;
+        fprintf(out, "    %p  %s+0x%lx   (%s)\n",
+                addr, name, (unsigned long)offset, info.dli_fname ? info.dli_fname : "?");
+        std::free(demangled);
+    } else {
+        fprintf(out, "    %p  ?\n", addr);
+    }
+#else
+    fprintf(out, "    %p\n", addr);
+#endif
+}
+#endif
+
+// ------------------------- Dump -------------------------
+
+struct Group {
+    uint64_t  hash;
+    size_t    count;
+    size_t    totalBytes;
+    size_t    minSize;
+    size_t    maxSize;
+    void *    samplePtr;
+    int       frameCount;
+    void *    frames[kFrames];
+};
+
+static uint64_t hash_frames(void * const *frames, int n) {
+    uint64_t h = 0xcbf29ce484222325ULL;
+    for (int i = 0; i < n; ++i) {
+        h ^= (uint64_t)(uintptr_t)frames[i];
+        h *= 0x100000001b3ULL;
+    }
+    return h;
+}
+
+static void format_with_commas(char *buf, size_t buflen, uint64_t v) {
+    char tmp[32];
+    int n = snprintf(tmp, sizeof(tmp), "%llu", (unsigned long long)v);
+    // insert commas
+    int out = 0;
+    for (int i = 0; i < n && out < (int)buflen - 1; ++i) {
+        int remaining = n - i;
+        if (i > 0 && (remaining % 3) == 0) {
+            if (out < (int)buflen - 1) buf[out++] = ',';
+        }
+        buf[out++] = tmp[i];
+    }
+    buf[out] = 0;
+}
+
+size_t dump_alloc_leaks(FILE *out) {
+    // Disarm tracking during dump so fprintf/Sym*/etc don't churn the map.
+    bool was_armed = g_armed.exchange(false);
+    (void)was_armed;
+    tl_inside = true;
+
+    auto t0 = std::chrono::steady_clock::now();
+
+    // Snapshot groups under lock so other threads (if any) don't race us.
+    // Use std::malloc for snapshot storage — no tracker re-entry.
+    Group *groups = nullptr;
+    size_t groupCount = 0;
+    size_t groupCap   = 0;
+    size_t totalLeaks = 0;
+    size_t totalBytes = 0;
+    size_t largestSingle = 0;
+    bool   groupsExhausted = false;
+
+    {
+        std::lock_guard<std::mutex> lock(getMutex());
+        LeakMap &m = getMap();
+        for (size_t i = 0; i < m.capacity; ++i) {
+            void *k = m.entries[i].key;
+            if (k == nullptr || k == kTombstone) continue;
+            const AllocInfo &info = m.entries[i].info;
+            ++totalLeaks;
+            totalBytes += info.size;
+            if (info.size > largestSingle) largestSingle = info.size;
+
+            if (groupsExhausted) continue; // keep counting totals, drop per-site detail
+
+            uint64_t h = hash_frames(info.frames, info.frameCount);
+
+            // linear scan for existing group (small N typical; replace w/ hash later if needed)
+            Group *g = nullptr;
+            for (size_t j = 0; j < groupCount; ++j) {
+                if (groups[j].hash == h) { g = &groups[j]; break; }
+            }
+            if (!g) {
+                if (groupCount == groupCap) {
+                    size_t newCap = groupCap ? groupCap * 2 : 64;
+                    Group *resized = (Group*)std::realloc(groups, newCap * sizeof(Group));
+                    if (!resized) {
+                        // OOM during shutdown report: keep the buffer we already have,
+                        // tally totals on the remaining entries but stop adding sites.
+                        groupsExhausted = true;
+                        continue;
+                    }
+                    groups   = resized;
+                    groupCap = newCap;
+                }
+                g = &groups[groupCount++];
+                g->hash       = h;
+                g->count      = 0;
+                g->totalBytes = 0;
+                g->minSize    = SIZE_MAX;
+                g->maxSize    = 0;
+                g->samplePtr  = k;
+                g->frameCount = info.frameCount;
+                memcpy(g->frames, info.frames, info.frameCount * sizeof(void*));
+            }
+            g->count      += 1;
+            g->totalBytes += info.size;
+            if (info.size < g->minSize) g->minSize = info.size;
+            if (info.size > g->maxSize) g->maxSize = info.size;
+        }
+    }
+
+    // Sort groups: by totalBytes desc, then count desc, then hash for stability.
+    // Simple insertion sort — groupCount is typically small.
+    for (size_t i = 1; i < groupCount; ++i) {
+        Group key = groups[i];
+        size_t j = i;
+        while (j > 0) {
+            const Group &a = groups[j - 1];
+            bool before = (a.totalBytes < key.totalBytes) ||
+                          (a.totalBytes == key.totalBytes && a.count < key.count) ||
+                          (a.totalBytes == key.totalBytes && a.count == key.count && a.hash < key.hash);
+            if (!before) break;
+            groups[j] = groups[j - 1];
+            --j;
+        }
+        groups[j] = key;
+    }
+
+    // No leaks → silent. Skip the entire report (header, body, footer).
+    if (totalLeaks == 0) {
+        std::free(groups);
+        tl_inside = false;
+        return 0;
+    }
+
+    // Header.
+    char b1[32], b2[32], b3[32];
+    format_with_commas(b1, sizeof(b1), totalLeaks);
+    format_with_commas(b2, sizeof(b2), totalBytes);
+    format_with_commas(b3, sizeof(b3), largestSingle);
+
+    fprintf(out, "\n=== daslang C++ heap leak report ===\n");
+    fprintf(out, "Total live allocations: %s\n", b1);
+    fprintf(out, "Total bytes:            %s\n", b2);
+    fprintf(out, "Distinct leak sites:    %zu\n", groupCount);
+    fprintf(out, "Largest single alloc:   %s bytes\n", b3);
+    uint64_t orphan = g_orphan_free.load(std::memory_order_relaxed);
+    if (orphan) {
+        fprintf(out, "Orphan frees (pre-arm or cross-module): %llu\n",
+                (unsigned long long)orphan);
+    }
+    if (groupsExhausted) {
+        fprintf(out, "WARNING: realloc() failed during grouping; per-site detail truncated.\n"
+                     "         Totals above are accurate; only the leak-site breakdown is partial.\n");
+    }
+
+    if (groupCount > 0) {
+        init_symbols();
+        for (size_t i = 0; i < groupCount; ++i) {
+            const Group &g = groups[i];
+            uint64_t mean = g.count ? g.totalBytes / g.count : 0;
+            char bc[32], bt[32], bmn[32], bmx[32], bavg[32];
+            format_with_commas(bc,  sizeof(bc),  g.count);
+            format_with_commas(bt,  sizeof(bt),  g.totalBytes);
+            format_with_commas(bmn, sizeof(bmn), g.minSize);
+            format_with_commas(bmx, sizeof(bmx), g.maxSize);
+            format_with_commas(bavg,sizeof(bavg),mean);
+            fprintf(out, "\n--- Leak site #%zu: %s allocs, %s bytes (min %s, max %s, mean %s) ---\n",
+                    i + 1, bc, bt, bmn, bmx, bavg);
+            fprintf(out, "  sample ptr: %p\n", g.samplePtr);
+            for (int j = 0; j < g.frameCount; ++j) {
+                print_frame(out, g.frames[j]);
+            }
+        }
+    }
+
+    auto t1 = std::chrono::steady_clock::now();
+    double secs = std::chrono::duration<double>(t1 - t0).count();
+    fprintf(out, "\n=== End report (%s leaks, %zu sites, symbolized in %.2fs) ===\n",
+            b1, groupCount, secs);
+    fflush(out);
+
+    std::free(groups);
+    tl_inside = false;
+    // intentionally leave disarmed after dump
+    return totalLeaks;
+}
+
+// ------------------------- Atexit registration -------------------------
+//
+// With #pragma init_seg(lib) at the top of this TU, the constructor of
+// g_register_leak_dump_atexit runs before any init_seg(user) static ctor.
+// std::atexit() pushes onto a LIFO stack shared with __cxa_atexit (which
+// C++ static destructors use). Because we register first, our handler sits
+// at the bottom of the stack and fires LAST — after every user-level
+// static destructor. This means static-lifetime allocations (Meyers
+// singletons, static vectors, etc.) are freed before we report, and only
+// genuine leaks remain in the dump.
+//
+// Idempotence guard: protects against the explicit dump_alloc_leaks(stderr)
+// call from main.cpp or a double-registered atexit.
+
+static std::atomic<bool> g_dumped{false};
+
+// Defined in src/ast/ast_module.cpp. Incremented in Module::Initialize, decremented
+// in Module::Shutdown. If nonzero at exit time, the process bypassed cleanup
+// (e.g., dastest exits via fio::exit -> C exit() without calling Module::Shutdown),
+// so live allocations are not real leaks — they're memory the cleanup never got
+// a chance to free. Suppress the dump in that case to avoid noise.
+extern std::atomic<int> g_envTotal;
+
+static void dump_alloc_leaks_atexit() {
+    if (g_dumped.exchange(true, std::memory_order_acq_rel)) return;
+    int pending = g_envTotal.load(std::memory_order_relaxed);
+    if (pending > 0) {
+        fprintf(stderr,
+            "\n=== daslang C++ heap leak report SKIPPED ===\n"
+            "Module::Shutdown() was not called (%d environment(s) still active).\n"
+            "Likely cause: the process exited via exit()/abort() bypassing cleanup.\n"
+            "Live allocations are not reported because they may still be owned.\n",
+            pending);
+        fflush(stderr);
+        return;
+    }
+    dump_alloc_leaks(stderr);
+}
+
+struct RegisterLeakDumpAtExit {
+    RegisterLeakDumpAtExit() noexcept { std::atexit(&dump_alloc_leaks_atexit); }
+};
+static RegisterLeakDumpAtExit g_register_leak_dump_atexit;
+
+} // namespace das
+
+#endif // DAS_TRACK_ALLOC

--- a/src/misc/alloc_tracker_fast_stack.cpp
+++ b/src/misc/alloc_tracker_fast_stack.cpp
@@ -1,0 +1,490 @@
+#include "daScript/misc/platform.h"
+
+// Fast Win64 stack unwinder for the heap-leak tracker. Replaces the
+// per-allocation call to CaptureStackBackTrace (which takes a spinlock inside
+// RtlLookupFunctionEntry) with:
+//   1) A cached PE .pdata table -- binary-searched, no OS locks.
+//   2) A lightweight UNWIND_INFO interpreter that avoids RtlVirtualUnwind for
+//      the common opcodes.
+//   3) A single-level "landmark" RAII that fully walks once, stores the
+//      remaining chain, and lets later captures tail-memoize from a known
+//      frame (matched by RSP).
+//
+// Non-Win64 platforms fall through to the generic path in alloc_tracker.cpp.
+// Ported from Gaijin's dag_fastStackCapture.cpp.
+
+#if DAS_TRACK_ALLOC && defined(_MSC_VER) && defined(_M_X64)
+
+#include <windows.h>
+#include <winnt.h>
+#include <tlhelp32.h>
+#include <intrin.h>
+
+#include <atomic>
+#include <mutex>
+#include <new>         // placement new for the immortal mutex storage
+#include <algorithm>
+#include <cstring>
+#include <cstdint>
+
+namespace das {
+
+// ---------------------------------------------------------------------------
+// Module cache
+// ---------------------------------------------------------------------------
+
+struct CachedModule {
+    ULONG64             base;
+    ULONG64             end;
+    PRUNTIME_FUNCTION   pdata;
+    ULONG               pdataLast;
+};
+
+static constexpr int MAX_CACHED_MODULES = 512;
+static CachedModule         g_modules[MAX_CACHED_MODULES];
+static std::atomic<int>     g_moduleCount{0};
+static std::atomic<bool>    g_cacheReady{false};
+static std::mutex &         getCacheMutex() {
+    alignas(std::mutex) static unsigned char storage[sizeof(std::mutex)];
+    static std::mutex *m = ::new (storage) std::mutex();
+    return *m;
+}
+
+// Negative cache for PCs that don't belong to any module (JIT code, etc).
+// Direct-mapped, lossy on collisions; page granularity is 64KB.
+static constexpr int NEG_CACHE_BITS = 6;
+static constexpr int NEG_CACHE_SIZE = 1 << NEG_CACHE_BITS;
+static std::atomic<uint64_t> g_negCache[NEG_CACHE_SIZE];
+
+static __forceinline bool isNegCached(ULONG64 pc) {
+    uint64_t page = pc >> 16;
+    return g_negCache[page & (NEG_CACHE_SIZE - 1)].load(std::memory_order_relaxed) == page;
+}
+static __forceinline void addNegCache(ULONG64 pc) {
+    uint64_t page = pc >> 16;
+    g_negCache[page & (NEG_CACHE_SIZE - 1)].store(page, std::memory_order_relaxed);
+}
+
+static void buildModuleCache() noexcept {
+    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, 0);
+    if (snap == INVALID_HANDLE_VALUE) return;
+    MODULEENTRY32W me;
+    me.dwSize = sizeof(me);
+    int count = 0;
+    BOOL ok = Module32FirstW(snap, &me);
+    while (ok && count < MAX_CACHED_MODULES) {
+        const BYTE *dllBase = me.modBaseAddr;
+        if (dllBase && me.modBaseSize) {
+            __try {
+                const IMAGE_DOS_HEADER *dos = (const IMAGE_DOS_HEADER*)dllBase;
+                if (dos->e_magic == IMAGE_DOS_SIGNATURE) {
+                    const IMAGE_NT_HEADERS64 *nt = (const IMAGE_NT_HEADERS64*)(dllBase + dos->e_lfanew);
+                    if (nt->Signature == IMAGE_NT_SIGNATURE &&
+                        nt->OptionalHeader.NumberOfRvaAndSizes > IMAGE_DIRECTORY_ENTRY_EXCEPTION) {
+                        const IMAGE_DATA_DIRECTORY &excDir =
+                            nt->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXCEPTION];
+                        if (excDir.VirtualAddress && excDir.Size >= sizeof(RUNTIME_FUNCTION)) {
+                            CachedModule &m = g_modules[count];
+                            m.base       = (ULONG64)dllBase;
+                            m.end        = (ULONG64)dllBase + me.modBaseSize;
+                            m.pdata      = (PRUNTIME_FUNCTION)(dllBase + excDir.VirtualAddress);
+                            m.pdataLast  = (excDir.Size / sizeof(RUNTIME_FUNCTION)) - 1;
+                            ++count;
+                        }
+                    }
+                }
+            } __except (EXCEPTION_EXECUTE_HANDLER) {}
+        }
+        ok = Module32NextW(snap, &me);
+    }
+    CloseHandle(snap);
+    std::sort(g_modules, g_modules + count,
+              [](const CachedModule &a, const CachedModule &b) { return a.base < b.base; });
+    g_moduleCount.store(count, std::memory_order_release);
+}
+
+static __declspec(noinline) void ensureCacheReady() noexcept {
+    if (g_cacheReady.load(std::memory_order_acquire)) return;
+    std::lock_guard<std::mutex> lock(getCacheMutex());
+    if (g_cacheReady.load(std::memory_order_relaxed)) return;
+    buildModuleCache();
+    g_cacheReady.store(true, std::memory_order_release);
+}
+
+static __forceinline bool findModule(ULONG64 pc, const CachedModule *&lastModule, ULONG64 &imageBase) {
+    if (lastModule && pc >= imageBase && pc < lastModule->end)
+        return true;
+    lastModule = nullptr;
+    int count = g_moduleCount.load(std::memory_order_acquire);
+    int lo = 0, hi = count - 1;
+    while (lo <= hi) {
+        int mid = (lo + hi) >> 1;
+        const CachedModule &mod = g_modules[mid];
+        if (pc < mod.base)       hi = mid - 1;
+        else if (pc >= mod.end)  lo = mid + 1;
+        else { lastModule = &mod; imageBase = mod.base; return true; }
+    }
+    return false;
+}
+
+static __forceinline PRUNTIME_FUNCTION findFunctionEntry(const CachedModule *mod, DWORD rva, int &hint) {
+    PRUNTIME_FUNCTION table = mod->pdata;
+    int lo = 0, hi = (int)mod->pdataLast;
+    int mid = hint;
+    goto first_check;
+    do {
+        mid = (lo + hi) >> 1;
+    first_check:
+        if (rva < table[mid].BeginAddress)      hi = mid - 1;
+        else if (rva >= table[mid].EndAddress)  lo = mid + 1;
+        else { hint = mid; return &table[mid]; }
+    } while (lo <= hi);
+    return nullptr;
+}
+
+static __forceinline PRUNTIME_FUNCTION cachedLookupOnly(ULONG64 pc, const CachedModule *&lastModule,
+                                                       ULONG64 &imageBase, int &pdataHint) {
+    const CachedModule *prev = lastModule;
+    if (findModule(pc, lastModule, imageBase)) {
+        if (lastModule != prev) pdataHint = (int)(lastModule->pdataLast) >> 1;
+        return findFunctionEntry(lastModule, (DWORD)(pc - imageBase), pdataHint);
+    }
+    return nullptr;
+}
+
+// SEH-wrapped PE parse: reads from dllBase may fault on unmapped pages during
+// module teardown. Returns true if newMod was populated. Kept free of C++
+// objects with destructors so MSVC allows the __try/__except (C2712).
+static bool parseModuleHeader(ULONG64 pc, const BYTE *dllBase, CachedModule &newMod) noexcept {
+    __try {
+        const IMAGE_DOS_HEADER *dos = (const IMAGE_DOS_HEADER*)dllBase;
+        if (dos->e_magic != IMAGE_DOS_SIGNATURE) { addNegCache(pc); return false; }
+        const IMAGE_NT_HEADERS64 *nt = (const IMAGE_NT_HEADERS64*)(dllBase + dos->e_lfanew);
+        if (nt->Signature != IMAGE_NT_SIGNATURE ||
+            nt->OptionalHeader.NumberOfRvaAndSizes <= IMAGE_DIRECTORY_ENTRY_EXCEPTION) {
+            addNegCache(pc); return false;
+        }
+        const IMAGE_DATA_DIRECTORY &excDir =
+            nt->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXCEPTION];
+        if (!excDir.VirtualAddress || excDir.Size < sizeof(RUNTIME_FUNCTION)) {
+            addNegCache(pc); return false;
+        }
+        newMod.base       = (ULONG64)dllBase;
+        newMod.end        = (ULONG64)dllBase + nt->OptionalHeader.SizeOfImage;
+        newMod.pdata      = (PRUNTIME_FUNCTION)(dllBase + excDir.VirtualAddress);
+        newMod.pdataLast  = (excDir.Size / sizeof(RUNTIME_FUNCTION)) - 1;
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        addNegCache(pc);
+        return false;
+    }
+}
+
+// Incremental add for late-loaded DLLs via GetModuleHandleExW — avoids full snapshot reinit.
+//
+// Concurrency: writers serialize through getCacheMutex(); readers in findModule()
+// load g_modules[] without locking. The memmove below shifts existing entries
+// in place, so a concurrent reader's binary search may briefly observe torn
+// base/end/pdataLast values from an in-flight shift. Possible outcomes:
+//   1. Mis-comparison → findModule returns nullptr → caller falls into
+//      tryAddAndLookup again, which re-acquires the writer lock and finds the
+//      module already present. Wasted work, no functional damage.
+//   2. Garbage pdataLast or pdata → findFunctionEntry walks an invalid table →
+//      access violation → outer __try/__except in walk_from_context catches it
+//      and we return a partial stack.
+// The race window is the duration of one memmove (≤256 entries × 24 bytes,
+// micro-second scale) and only opens when a DLL is loaded after the initial
+// snapshot — i.e. fio::register_dynamic_module, JIT codegen, or transitive
+// LoadLibrary. Net effect at the diagnostic level is rare truncated frames,
+// no crashes, which matches the trade-off in the upstream Gaijin source.
+static bool tryAddModuleForPC(ULONG64 pc) noexcept {
+    if (isNegCached(pc)) return false;
+    HMODULE hMod = nullptr;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            (LPCWSTR)(uintptr_t)pc, &hMod) || !hMod) {
+        addNegCache(pc);
+        return false;
+    }
+    CachedModule newMod{};
+    if (!parseModuleHeader(pc, (const BYTE*)hMod, newMod)) return false;
+
+    std::lock_guard<std::mutex> lock(getCacheMutex());
+    int count = g_moduleCount.load(std::memory_order_relaxed);
+    if (count >= MAX_CACHED_MODULES) return false;
+    // sorted insert
+    int lo = 0, hi = count - 1, insertPos = count;
+    while (lo <= hi) {
+        int mid = (lo + hi) >> 1;
+        if (newMod.base < g_modules[mid].base)      { insertPos = mid; hi = mid - 1; }
+        else if (newMod.base > g_modules[mid].base) { lo = mid + 1; }
+        else                                         { return true; } // already added by other thread
+    }
+    memmove(&g_modules[insertPos + 1], &g_modules[insertPos],
+            (count - insertPos) * sizeof(CachedModule));
+    g_modules[insertPos] = newMod;
+    g_moduleCount.store(count + 1, std::memory_order_release);
+    return true;
+}
+
+static __declspec(noinline) PRUNTIME_FUNCTION tryAddAndLookup(ULONG64 pc, const CachedModule *&lastMod,
+                                                              ULONG64 &imageBase, int &pdataHint) noexcept {
+    return tryAddModuleForPC(pc) ? cachedLookupOnly(pc, lastMod, imageBase, pdataHint) : nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Lightweight UNWIND_INFO interpreter
+// ---------------------------------------------------------------------------
+
+#define UNW_UWOP_PUSH_NONVOL     0
+#define UNW_UWOP_ALLOC_LARGE     1
+#define UNW_UWOP_ALLOC_SMALL     2
+#define UNW_UWOP_SET_FPREG       3
+#define UNW_UWOP_SAVE_NONVOL     4
+#define UNW_UWOP_SAVE_NONVOL_FAR 5
+#define UNW_UWOP_SAVE_XMM128     8
+#define UNW_UWOP_SAVE_XMM128_FAR 9
+#define UNW_UWOP_PUSH_MACHFRAME  10
+
+struct UNWIND_CODE_ENTRY_X {
+    BYTE CodeOffset;
+    BYTE UnwindOp : 4;
+    BYTE OpInfo   : 4;
+};
+struct UNWIND_INFO_HEADER_X {
+    BYTE VersionAndFlags;
+    BYTE SizeOfProlog;
+    BYTE CountOfCodes;
+    BYTE FrameRegAndOffset;
+    UNWIND_CODE_ENTRY_X UnwindCode[1]; // variable length
+};
+
+static __forceinline DWORD64 &contextGpReg(CONTEXT &ctx, unsigned regNum) {
+    return (&ctx.Rax)[regNum];
+}
+
+static __forceinline bool lightweightVirtualUnwind(PRUNTIME_FUNCTION func, ULONG64 imageBase, CONTEXT &ctx) {
+    struct ChainEntry {
+        const UNWIND_INFO_HEADER_X *info;
+        PRUNTIME_FUNCTION           func;
+    };
+    constexpr int MAX_CHAIN = 8;
+    ChainEntry chain[MAX_CHAIN];
+    int chainLen = 0;
+
+    {
+        const UNWIND_INFO_HEADER_X *cur = (const UNWIND_INFO_HEADER_X*)(imageBase + func->UnwindData);
+        PRUNTIME_FUNCTION curFunc = func;
+        while (chainLen < MAX_CHAIN) {
+            chain[chainLen++] = { cur, curFunc };
+            if (!(cur->VersionAndFlags & 0x20)) break; // UNW_FLAG_CHAININFO
+            unsigned codeSlots = (cur->CountOfCodes + 1) & ~1u;
+            curFunc = (PRUNTIME_FUNCTION)&cur->UnwindCode[codeSlots];
+            cur = (const UNWIND_INFO_HEADER_X*)(imageBase + curFunc->UnwindData);
+        }
+    }
+
+    const UNWIND_INFO_HEADER_X *primaryInfo = chain[0].info;
+    unsigned frameReg = primaryInfo->FrameRegAndOffset & 0x0F;
+    if (frameReg != 0) {
+        unsigned frameOffset = (primaryInfo->FrameRegAndOffset >> 4) & 0x0F;
+        ctx.Rsp = contextGpReg(ctx, frameReg) - (DWORD64)frameOffset * 16;
+    }
+    DWORD64 initialRsp = ctx.Rsp;
+    DWORD ripRva = (DWORD)(ctx.Rip - imageBase);
+
+    for (int c = 0; c < chainLen; ++c) {
+        const UNWIND_INFO_HEADER_X *info = chain[c].info;
+        DWORD funcBegin = chain[c].func->BeginAddress;
+        int count = info->CountOfCodes;
+        for (int i = 0; i < count;) {
+            const UNWIND_CODE_ENTRY_X &code = info->UnwindCode[i];
+            bool executed = (c > 0) || (ripRva >= (DWORD)(funcBegin + code.CodeOffset));
+            switch (code.UnwindOp) {
+                case UNW_UWOP_PUSH_NONVOL:
+                    if (executed) {
+                        contextGpReg(ctx, code.OpInfo) = *(DWORD64*)ctx.Rsp;
+                        ctx.Rsp += 8;
+                    }
+                    i += 1; break;
+                case UNW_UWOP_ALLOC_LARGE:
+                    if (code.OpInfo == 0) {
+                        if (executed && (i + 1) < count)
+                            ctx.Rsp += *(const USHORT*)&info->UnwindCode[i + 1] * 8;
+                        i += 2;
+                    } else {
+                        if (executed && (i + 2) < count)
+                            ctx.Rsp += *(const ULONG*)&info->UnwindCode[i + 1];
+                        i += 3;
+                    }
+                    break;
+                case UNW_UWOP_ALLOC_SMALL:
+                    if (executed) ctx.Rsp += code.OpInfo * 8 + 8;
+                    i += 1; break;
+                case UNW_UWOP_SET_FPREG: i += 1; break;
+                case UNW_UWOP_SAVE_NONVOL:
+                    if (executed && (i + 1) < count) {
+                        ULONG offset = *(const USHORT*)&info->UnwindCode[i + 1] * 8;
+                        contextGpReg(ctx, code.OpInfo) = *(DWORD64*)(initialRsp + offset);
+                    }
+                    i += 2; break;
+                case UNW_UWOP_SAVE_NONVOL_FAR:
+                    if (executed && (i + 2) < count) {
+                        ULONG offset = *(const ULONG*)&info->UnwindCode[i + 1];
+                        contextGpReg(ctx, code.OpInfo) = *(DWORD64*)(initialRsp + offset);
+                    }
+                    i += 3; break;
+                case UNW_UWOP_SAVE_XMM128:     i += 2; break;
+                case UNW_UWOP_SAVE_XMM128_FAR: i += 3; break;
+                case UNW_UWOP_PUSH_MACHFRAME:  return false;
+                default:                       return false;
+            }
+        }
+    }
+    ctx.Rip = *(DWORD64*)ctx.Rsp;
+    ctx.Rsp += 8;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Landmark (tail-memoize cache)
+//
+// Tail-memoize matches by RSP, which is inherently per-thread, so the landmark
+// is thread_local: each thread arms its own landmark on entry and consumes its
+// own on subsequent captures. No cross-thread races, no atomics required.
+// Before this was thread_local, enterCount was a plain int on a process-global
+// landmark and concurrent enter/exit on different threads was a data race.
+// ---------------------------------------------------------------------------
+
+static constexpr int kLandmarkFrames = 32;
+
+struct Landmark {
+    bool     active = false;
+    DWORD64  rsp = 0;
+    int      frameCount = 0;
+    void *   frames[kLandmarkFrames] = {};
+    int      enterCount = 0; // nested enters no-op; only outermost arms
+};
+static thread_local Landmark g_landmark;
+
+// ---------------------------------------------------------------------------
+// Walk inner: given a captured CONTEXT, fill `stack[]` by unwinding.
+// Uses the landmark cache if armed and the match flag is set.
+// ---------------------------------------------------------------------------
+
+static __declspec(noinline) unsigned walk_from_context(void **stack, unsigned maxFrames,
+                                                      CONTEXT &ctx, int skipFrames,
+                                                      bool useLandmark) noexcept {
+    const CachedModule *lastMod = nullptr;
+    ULONG64             imageBase = 0;
+    int                 pdataHint = -1;
+    int                 frame = -skipFrames;
+
+    DWORD64 landmarkRsp = 0;
+    bool    canMatch    = false;
+    if (useLandmark && g_landmark.active) {
+        landmarkRsp = g_landmark.rsp;
+        canMatch    = (landmarkRsp != 0);
+    }
+
+    __try {
+        while (ctx.Rip && frame < (int)maxFrames) {
+            // Try to tail-memoize from landmark before recording this frame.
+            if (canMatch && frame >= 0 && ctx.Rsp == landmarkRsp) {
+                int copy = g_landmark.frameCount;
+                int room = (int)maxFrames - frame;
+                if (copy > room) copy = room;
+                memcpy(&stack[frame], g_landmark.frames, copy * sizeof(void*));
+                return (unsigned)(frame + copy);
+            }
+            if (frame >= 0) stack[frame] = (void*)(uintptr_t)ctx.Rip;
+
+            PRUNTIME_FUNCTION pFunc = cachedLookupOnly(ctx.Rip, lastMod, imageBase, pdataHint);
+            if (!pFunc)
+                pFunc = tryAddAndLookup(ctx.Rip, lastMod, imageBase, pdataHint);
+            if (!pFunc) break;
+
+            if (!lightweightVirtualUnwind(pFunc, imageBase, ctx)) {
+                // PUSH_MACHFRAME or unknown opcode → fall back to OS.
+                PVOID handlerData = nullptr;
+                ULONG64 establisherFrame = 0;
+                RtlVirtualUnwind(UNW_FLAG_NHANDLER, imageBase, ctx.Rip, pFunc,
+                                 &ctx, &handlerData, &establisherFrame, nullptr);
+            }
+            ++frame;
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        // Partial result is fine for diagnostics.
+    }
+    return frame > 0 ? (unsigned)frame : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public API (internal to this translation unit / alloc_tracker.cpp)
+// ---------------------------------------------------------------------------
+
+// Default skipFrames=2 drops this function's own frame AND the caller (the
+// tracker hook, which is always track_alloc_hook and carries no signal). Both
+// this function and track_alloc_hook are declared noinline so the skip count
+// is stable across /Ob levels.
+__declspec(noinline) unsigned das_fast_stack_capture(void **stack, unsigned maxFrames, int skipFrames) noexcept {
+    if (!stack || !maxFrames) return 0;
+    CONTEXT ctx;
+    RtlCaptureContext(&ctx);
+    ensureCacheReady();
+    return walk_from_context(stack, maxFrames, ctx, skipFrames, /*useLandmark*/ true);
+}
+
+// Arm/disarm the landmark. First enter fully walks the stack from the caller's
+// frame and stores it; later captures matching the caller's RSP short-circuit
+// with a memcpy. Nested enters are no-ops. disarm clears when refcount hits 0.
+//
+// SEH-wrapped: cachedLookupOnly / tryAddAndLookup / lightweightVirtualUnwind
+// may AV on torn reads during the late-DLL-load race window or on freshly
+// unmapped DLLs. Failure degrades to "landmark disabled" (active stays false
+// and subsequent captures just walk fully), never a process crash.
+__declspec(noinline) void das_fast_stack_landmark_enter() noexcept {
+    // Guard against nested enters (e.g. recursive compile_and_run).
+    if (g_landmark.enterCount++ != 0) return;
+
+    __try {
+        CONTEXT ctx;
+        RtlCaptureContext(&ctx);
+        ensureCacheReady();
+
+        // Unwind once to leave this function — ctx then describes the caller frame.
+        const CachedModule *lastMod = nullptr;
+        ULONG64 imageBase = 0;
+        int     pdataHint = -1;
+        PRUNTIME_FUNCTION pFunc = cachedLookupOnly(ctx.Rip, lastMod, imageBase, pdataHint);
+        if (!pFunc) pFunc = tryAddAndLookup(ctx.Rip, lastMod, imageBase, pdataHint);
+        if (!pFunc) return; // give up; leave landmark disarmed
+        if (!lightweightVirtualUnwind(pFunc, imageBase, ctx)) {
+            PVOID handlerData = nullptr;
+            ULONG64 establisherFrame = 0;
+            RtlVirtualUnwind(UNW_FLAG_NHANDLER, imageBase, ctx.Rip, pFunc,
+                             &ctx, &handlerData, &establisherFrame, nullptr);
+        }
+
+        DWORD64 landmarkRsp = ctx.Rsp;
+        // Walk the rest WITHOUT landmark match (we're building it). walk_from_context
+        // has its own __try/__except, so any fault inside it returns a partial frame
+        // count rather than escaping.
+        g_landmark.frameCount = (int)walk_from_context(g_landmark.frames, kLandmarkFrames, ctx,
+                                                       /*skipFrames*/ 0, /*useLandmark*/ false);
+        g_landmark.rsp    = landmarkRsp;
+        g_landmark.active = true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        // Leave landmark disarmed; subsequent captures will walk without memoization.
+    }
+}
+
+__declspec(noinline) void das_fast_stack_landmark_exit() noexcept {
+    if (--g_landmark.enterCount != 0) return;
+    g_landmark.active     = false;
+    g_landmark.rsp        = 0;
+    g_landmark.frameCount = 0;
+}
+
+} // namespace das
+
+#endif // DAS_TRACK_ALLOC && _MSC_VER && _M_X64

--- a/src/misc/alloc_tracker_overrides.cpp
+++ b/src/misc/alloc_tracker_overrides.cpp
@@ -1,0 +1,134 @@
+// Global operator new/delete overrides for the daslang leak tracker.
+//
+// Compiled into every target participating in the leak audit (daslang,
+// daslang_static, daslang-live, libDaScript_runtime, libDaScriptDyn_runtime);
+// see CMakeLists.txt target_sources lines. The TU body is #if DAS_TRACK_ALLOC-
+// gated, so it compiles to an empty object in Release/Debug. DAS_TRACK_ALLOC
+// itself is set by generator expression to $<CONFIG:RelWithDebInfo>, i.e. the
+// tracker is permanently on in RelWithDebInfo and off everywhere else -- no
+// user-facing CMake option.
+//
+// The Windows DLL model resolves operator new per-module against each module's
+// CRT, so a single override living in libDaScriptDyn_runtime only covers its
+// own code; the exe and every shared module need their own copy.
+//
+// Uses std::malloc/std::free (not _aligned_malloc) for the backing store so
+// cross-module mismatches (e.g. allocated here, freed through a module that
+// doesn't share our override) stay ABI-compatible with the default CRT
+// allocator and don't corrupt the heap. The tracker's own map records and
+// track_free_hook reports orphan frees for diagnostic visibility.
+//
+// Full overload set: C++14 sized delete and C++17 aligned new/delete are
+// replaced alongside the classic unsized forms so every compiler-emitted
+// deallocation funnels through track_free_hook. A missing overload would let
+// the default runtime free the pointer directly, bypassing the hook and
+// leaving a stale entry that would be reported as a (false) leak.
+
+#include "daScript/misc/platform.h"
+
+#if DAS_TRACK_ALLOC
+
+#include <cstdlib>
+#include <cstdint>
+#include <new>
+
+// -----------------------------------------------------------------------------
+// Aligned allocation helper. std::aligned_alloc is POSIX-only and requires size
+// to be a multiple of alignment. On MSVC we use _aligned_malloc / _aligned_free.
+// Aligned pointers must be freed through the matching aligned API (the CRT
+// stores bookkeeping before the returned pointer). We track the allocation in
+// the usual map so track_free_hook fires as for any other alloc.
+// -----------------------------------------------------------------------------
+
+static void * track_new_impl(size_t size) {
+    void *p = std::malloc(size ? size : 1);
+    das::track_alloc_hook(p, size);
+    return p;
+}
+
+static void track_delete_impl(void *p) noexcept {
+    if (!p) return;
+    das::track_free_hook(p);
+    std::free(p);
+}
+
+#if defined(_MSC_VER)
+#  include <malloc.h>
+static void * track_new_aligned_impl(size_t size, size_t alignment) {
+    if (size == 0) size = 1;
+    if (alignment < sizeof(void*)) alignment = sizeof(void*);
+    void *p = _aligned_malloc(size, alignment);
+    das::track_alloc_hook(p, size);
+    return p;
+}
+static void track_delete_aligned_impl(void *p) noexcept {
+    if (!p) return;
+    das::track_free_hook(p);
+    _aligned_free(p);
+}
+#else
+static void * track_new_aligned_impl(size_t size, size_t alignment) {
+    if (size == 0) size = alignment;
+    // posix_memalign / aligned_alloc both require alignment to be a power of
+    // two and a multiple of sizeof(void*).
+    if (alignment < sizeof(void*)) alignment = sizeof(void*);
+    // aligned_alloc requires size to be a multiple of alignment.
+    size_t rounded = (size + alignment - 1) & ~(alignment - 1);
+    void *p = std::aligned_alloc(alignment, rounded);
+    das::track_alloc_hook(p, size);
+    return p;
+}
+static void track_delete_aligned_impl(void *p) noexcept {
+    if (!p) return;
+    das::track_free_hook(p);
+    std::free(p);
+}
+#endif
+
+// -----------------------------------------------------------------------------
+// Plain new / delete (unsized)
+// -----------------------------------------------------------------------------
+
+void * operator new  (size_t size)                           { return track_new_impl(size); }
+void * operator new[](size_t size)                           { return track_new_impl(size); }
+
+void * operator new  (size_t size, std::nothrow_t const &) noexcept { return track_new_impl(size); }
+void * operator new[](size_t size, std::nothrow_t const &) noexcept { return track_new_impl(size); }
+
+#ifdef __APPLE__
+void operator delete  (void *p) _NOEXCEPT                       { track_delete_impl(p); }
+void operator delete[](void *p) _NOEXCEPT                       { track_delete_impl(p); }
+void operator delete  (void *p, std::nothrow_t const &) _NOEXCEPT { track_delete_impl(p); }
+void operator delete[](void *p, std::nothrow_t const &) _NOEXCEPT { track_delete_impl(p); }
+#else
+void operator delete  (void *p) noexcept                        { track_delete_impl(p); }
+void operator delete[](void *p) noexcept                        { track_delete_impl(p); }
+void operator delete  (void *p, std::nothrow_t const &) noexcept { track_delete_impl(p); }
+void operator delete[](void *p, std::nothrow_t const &) noexcept { track_delete_impl(p); }
+#endif
+
+// Sized delete (C++14). MSVC emits calls to these whenever it knows the static
+// size of the type being deleted; without our replacement the default CRT
+// deallocator runs and bypasses track_free_hook.
+void operator delete  (void *p, size_t /*size*/) noexcept       { track_delete_impl(p); }
+void operator delete[](void *p, size_t /*size*/) noexcept       { track_delete_impl(p); }
+
+// -----------------------------------------------------------------------------
+// Aligned new / delete (C++17). Emitted for types whose alignof exceeds
+// __STDCPP_DEFAULT_NEW_ALIGNMENT__ (16 on x64). Separate allocator because
+// MSVC's _aligned_malloc stores bookkeeping before the returned pointer.
+// -----------------------------------------------------------------------------
+
+void * operator new  (size_t size, std::align_val_t al)                             { return track_new_aligned_impl(size, (size_t)al); }
+void * operator new[](size_t size, std::align_val_t al)                             { return track_new_aligned_impl(size, (size_t)al); }
+void * operator new  (size_t size, std::align_val_t al, std::nothrow_t const &) noexcept { return track_new_aligned_impl(size, (size_t)al); }
+void * operator new[](size_t size, std::align_val_t al, std::nothrow_t const &) noexcept { return track_new_aligned_impl(size, (size_t)al); }
+
+void operator delete  (void *p, std::align_val_t) noexcept                                  { track_delete_aligned_impl(p); }
+void operator delete[](void *p, std::align_val_t) noexcept                                  { track_delete_aligned_impl(p); }
+void operator delete  (void *p, std::align_val_t, std::nothrow_t const &) noexcept          { track_delete_aligned_impl(p); }
+void operator delete[](void *p, std::align_val_t, std::nothrow_t const &) noexcept          { track_delete_aligned_impl(p); }
+void operator delete  (void *p, size_t /*size*/, std::align_val_t) noexcept                 { track_delete_aligned_impl(p); }
+void operator delete[](void *p, size_t /*size*/, std::align_val_t) noexcept                 { track_delete_aligned_impl(p); }
+
+#endif // DAS_TRACK_ALLOC

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -229,6 +229,10 @@ int das_aot_main ( int argc, char * argv[] ) {
 //   0 on success
 //   non-zero from int main, or 1 on compile/simulate/verify/exception failure
 int compile_and_run ( const string & fn, const string & mainFnName, bool outputProgramCode, bool dryRun, bool compileOnly, const char * introFile = nullptr ) {
+    // Heap-leak tracker: arm the tail-memoize landmark so per-allocation stack
+    // captures below this frame skip re-walking ancestors. No-op when
+    // DAS_TRACK_ALLOC is off or on non-Win64.
+    das::AllocTrackingLandmark _alloc_tracker_landmark;
     auto access = get_file_access((char*)(projectFile.empty() ? nullptr : projectFile.c_str()));
     if ( introFile ) {
         auto fileInfo = make_unique<TextFileInfo>(introFile, uint32_t(strlen(introFile)), false);
@@ -461,6 +465,7 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     _set_error_mode(_OUT_TO_STDERR);
 #endif
     install_das_crash_handler();
+    das::arm_alloc_tracking();
     bool isArgAot = false;
     if (argc > 1) {
         isArgAot = strcmp(argv[1],"-aot")==0;
@@ -692,6 +697,8 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     if ( pauseAfterDone ) getchar();
     Module::Shutdown();
     JobStatus::DumpJobQueLeaks();
+    // das::dump_alloc_leaks is registered as an atexit handler via init_seg(lib),
+    // so it fires after all static destructors — cleaner than dumping here.
     if ( g_smart_ptr_total!=0 ) {
         TextPrinter tp;
         tp << "smart pointers leaked: " << uint64_t(g_smart_ptr_total) << "\n";

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -635,6 +635,7 @@ int main(int argc, char * argv[]) {
 #endif
 
     install_das_crash_handler();
+    das::arm_alloc_tracking();
 
     string scriptFile;
     bool noDynamicModules = false;
@@ -728,6 +729,8 @@ int main(int argc, char * argv[]) {
 
     Module::Shutdown();
     JobStatus::DumpJobQueLeaks();
+    // das::dump_alloc_leaks is registered as an atexit handler via init_seg(lib),
+    // so it fires after all static destructors — cleaner than dumping here.
     release_single_instance();
     return result;
 }


### PR DESCRIPTION
## Summary

- Always-on heap leak tracker for `daslang.exe` and `daslang-live.exe` in RelWithDebInfo. Every `new` / `delete` is recorded with a 16-frame stack; live allocations are dumped to stderr at process exit, after every static destructor has run. Release and Debug pay zero cost — the tracking TUs compile to empty objects outside RelWithDebInfo.
- Full `dastest -- --test tests` run (6,532 tests, 79.5s) now emits only 2 real leak sites across the entire suite:
  - one 128-byte ska-hashmap entry from `TypeDecl::getOwnSemanticHash` during `fio::register_dynamic_module` (reproducible via `tests/dastest/test_json_output.das`),
  - 9 gc_nodes retained by the dastest aggregator process across its `pinvoke` test-running loop.
  Both are pre-existing daslang-side leaks to triage separately.
- Drive-by cleanups required to make the dump accurate: remove the unused `DAS_MACRO_SANITIZER` operator-new override on AST nodes; convert dastest from `fio::exit` → `main() : int` return on normal paths; make dastest's `--timeout` sleeper cooperatively cancel via `is_job_que_shutting_down()` so shutdown doesn't hang.

## How it works

- CMake gates the tracker with `$<CONFIG:RelWithDebInfo>:DAS_TRACK_ALLOC=1>` on the runtime libs. `alloc_tracker_overrides.cpp` (global `new`/`delete`) is unconditionally linked into every daslang/daslang-live binary but is internally `#if DAS_TRACK_ALLOC`-gated, so non-RelWithDebInfo builds link an empty TU. RelWithDebInfo also unconditionally bumps `/Ob1` → `/Ob2` and sets `DAS_FUSION=2` so audit builds match Release codegen.
- Per-allocation overhead on Win64 is ~1.5 µs thanks to a cached-.pdata fast unwinder (`alloc_tracker_fast_stack.cpp`, ported from Gaijin's `dag_fastStackCapture.cpp`) with landmark RAII tail-memoize. Fallback on other platforms is `CaptureStackBackTrace` / `backtrace`.
- The dump is registered via `std::atexit` from a `#pragma init_seg(lib)` file-scope initializer, so it ends up at the *bottom* of the atexit LIFO and fires **last** — after every user static destructor registered via `__cxa_atexit` has released its allocations. Before this change, naive "dump at end of main" reported ~40 spurious "leaks" that were just live module statics.
- The atexit handler reads `g_envTotal` (maintained by `Module::Initialize` / `Module::Shutdown`). If nonzero, some environment never got torn down (e.g. the process exited via `exit()`/`abort()` bypassing cleanup); in that case the dump is suppressed and a "report SKIPPED" line is printed instead. When no leaks are found, the tracker is completely silent — no noise on clean exit.

## Test plan

- [x] `daslang.exe dastest/dastest.das -- --test tests` — 6,532 / 6,532 pass
- [x] `daslang.exe dastest/dastest.das -- --test tests/algorithm` — 162 / 162 pass, zero leak reports across 162 subprocess exits
- [x] Lint on changed `.das` (`dastest/dastest.das`) — 8 warnings, all pre-existing on master
- [x] `cmake --build build --config Release --target test_aot -j 64` — succeeded
- [x] `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --failures-only --test tests` — 5,944 / 5,944 pass
- [x] `format_file` on `dastest/dastest.das` — already formatted
- [x] Positive control: `(void)(new int[1024])` in main reports exactly 1 leak / 4,096 bytes with correct file:line
- [x] Clean-exit silence: `hello_world.das` prints no tracker output
