### PR TITLE
misc: heap leak tracker — per-shared-module new/delete override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,12 @@ MACRO(ADD_DAS_SHARED_MODULE_LIB module_name)
     TARGET_COMPILE_DEFINITIONS(${module_name} PRIVATE DAS_MOD_EXPORTS DAS_ENABLE_DLL=1)
     TARGET_LINK_LIBRARIES(${module_name} PUBLIC libDaScriptDyn)
     ADD_DEPENDENCIES(${module_name} libDaScriptDyn)
+    # Each shared module needs its own copy of the global new/delete overrides:
+    # Windows resolves operator new per-module at link time, and a module that
+    # allocates via the tracker but frees through the default CRT (or vice versa)
+    # looks like a leak. The TU is #if DAS_TRACK_ALLOC-gated so it compiles empty
+    # outside RelWithDebInfo. DAS_TRACK_ALLOC propagates from libDaScriptDyn_runtime.
+    target_sources(${module_name} PRIVATE ${PROJECT_SOURCE_DIR}/src/misc/alloc_tracker_overrides.cpp)
     LIST(APPEND DAS_DYN_MODULES_LIBS ${module_name})
 ENDMACRO()
 


### PR DESCRIPTION
## Summary

The leak tracker's global `operator new/delete` override TU was only linked into the main runtime libs (`libDaScript[_Dyn]_runtime`) and the final binaries (`daslang`, `daslang_static`, `daslang-live`). Shared modules like `dasModuleUnitTest.dll` did not compile the override. On Windows each module has its own `operator new/delete` resolution, so:

- Allocations that bottomed out inside the runtime DLL (e.g. `TypeDecl::getOwnSemanticHash` populating the local `das_set<Annotation *> adep` in `TypeAnnotation::seal`) used the tracked override → recorded in the map.
- Matching frees whose destructor template was instantiated inside a module DLL went through the module's default CRT `operator delete` → `track_free_hook` never ran.

Net effect: the 128B ska-hashmap bucket for the local `adep` set in `TypeAnnotation::seal` appeared as a leak every time a dynamic `UnitTest`-style module was loaded, even though the memory was freed correctly by the default delete. This is the "128B ska-hashmap entry via `register_dyn_Module_UnitTest`" reported as a known leak after #2448.

## Fix

Add `src/misc/alloc_tracker_overrides.cpp` to every shared module via `ADD_DAS_SHARED_MODULE_LIB` in `CMakeLists.txt`. The TU is `#if DAS_TRACK_ALLOC`-gated, and `DAS_TRACK_ALLOC` already propagates `PUBLIC` from `libDaScriptDyn_runtime`, so:

- In `Release`/`Debug`, the TU compiles to an empty object — zero cost.
- In `RelWithDebInfo`, each module DLL now has its own `operator new/delete` that forwards to the shared `track_alloc_hook` / `track_free_hook` (these are `DAS_API`, so a single implementation is shared across all modules).

## Effect on the leak audit

- The 128B false positive from `fio::register_dynamic_module` → `register_dyn_Module_UnitTest` disappears on `test_json_output.das` and on the full suite.
- Real allocations/frees that happen entirely inside module DLLs are now visible to the tracker. A full `dastest -- --test tests` run now surfaces ~2,000 previously-invisible allocations in `dasHV` (`WebServer_Adapter`, `HttpService::AddRoute` internals, etc.) — those are pre-existing real leaks in the HV module's bindings (e.g. `makeWebSocketServer` allocates `new WebServer_Adapter(...)` and `das_wss_stop` calls `stop()` but never `delete adapter`). They will be addressed in a follow-up PR.

## Test plan

- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests` — 6,532 / 6,532 pass
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --color --failures-only --timeout 900 --test tests` — 5,944 / 5,944 pass
- [x] `bin/RelWithDebInfo/daslang.exe dastest/dastest.das -- --test tests/dastest/test_json_output.das` — 0 leaks (was 1 × 128B before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)