### PR TITLE
leaks: glfw callbacks deallocate fully; ast_gc_guard 3 tests

### DIFF
--- a/modules/dasGlfw/src/dasGLFW.main.cpp
+++ b/modules/dasGlfw/src/dasGLFW.main.cpp
@@ -156,7 +156,7 @@ namespace das {
     thread_local das_map<void *, GlswCallbacks> Module_dasGLFW::g_Callbacks;
 
     Module_dasGLFW::~Module_dasGLFW() {
-        swap(das_map<void *, GlswCallbacks>(), Module_dasGLFW::g_Callbacks);
+        Module_dasGLFW::g_Callbacks = das_map<void *, GlswCallbacks>{};
     }
 
 	void Module_dasGLFW::initMain () {

--- a/modules/dasGlfw/src/dasGLFW.main.cpp
+++ b/modules/dasGlfw/src/dasGLFW.main.cpp
@@ -156,7 +156,7 @@ namespace das {
     thread_local das_map<void *, GlswCallbacks> Module_dasGLFW::g_Callbacks;
 
     Module_dasGLFW::~Module_dasGLFW() {
-        g_Callbacks.clear();
+        swap(das_map<void *, GlswCallbacks>(), Module_dasGLFW::g_Callbacks);
     }
 
 	void Module_dasGLFW::initMain () {

--- a/tests/jit_tests/typeinfo.das
+++ b/tests/jit_tests/typeinfo.das
@@ -82,12 +82,13 @@ def test_type_info(t : T?) {
         feint("rtti = {test_rtti()}\n")
     }
     t |> run("typeinfo ast_typedecl") @(t : T?) {
-        t |> success(!jit_enabled() || is_jit_function(@@test_ast_typedecl))
-        var ccc <- test_ast_typedecl()
-        t |> equal(ccc.baseType, Type.tInt)
-        t |> equal(ccc.flags.constant, true)
-        t |> equal("int const", ccc |> describe)
-        // gc handles TypeDecl lifetime
+        ast_gc_guard() {
+            t |> success(!jit_enabled() || is_jit_function(@@test_ast_typedecl))
+            var ccc <- test_ast_typedecl()
+            t |> equal(ccc.baseType, Type.tInt)
+            t |> equal(ccc.flags.constant, true)
+            t |> equal("int const", ccc |> describe)
+        }
     }
 }
 

--- a/tests/language/strict_smart_ptr.das
+++ b/tests/language/strict_smart_ptr.das
@@ -12,7 +12,7 @@ struct Foo {
 [test]
 def test_resize_array(t : T?) {
     t |> run("emplace") @(t : T?) {
-        {
+        ast_gc_guard() {
             var a : array<ExpressionPtr>
             var b <- new ExprOp2(op := "==")
             a |> emplace(b)
@@ -21,13 +21,13 @@ def test_resize_array(t : T?) {
         }
     }
     t |> run("array init") @(t : T?) {
-        {
+        ast_gc_guard() {
             var b : ExpressionPtr <- new ExprOp2(op := "==")
             var a <- array<ExpressionPtr>(b)
             t |> equal(1, length(a))
             // Note: GC-managed ExpressionPtr is not zeroed by array construction (pass by value)
         }
-        {
+        ast_gc_guard() {
             var b : ExpressionPtr <- new ExprOp2(op := "==")
             var a <- array<ExpressionPtr>(move_to_local(b))
             t |> equal(1, length(a))
@@ -42,7 +42,7 @@ def test_resize_array(t : T?) {
             t |> equal(null, b)
         */
     t |> run("struct init") @(t : T?) {
-        {
+        ast_gc_guard() {
             var b : ExpressionPtr <- new ExprOp2(op := "==")
             var a <- Foo(a <- b)
             // Note: GC-managed ExpressionPtr is not zeroed by struct construction move

--- a/tests/match/all_matches.das
+++ b/tests/match/all_matches.das
@@ -521,18 +521,22 @@ def test_all_match(t : T?) {
         t |> equal(23, struct_ptr_match(new Foo(a = 23)))
     }
     t |> run("match handle ptr") @@(t : T?) {
-        t |> equal("null", match_handle_ptr(default<TypeDeclPtr>))
-        var tp = new TypeDecl(baseType = Type.tPointer)
-        t |> equal("pointer", match_handle_ptr(tp))
-        var tnp = new TypeDecl(baseType = Type.tInt)
-        t |> equal("anything", match_handle_ptr(tnp))
+        ast_gc_guard() {
+            t |> equal("null", match_handle_ptr(default<TypeDeclPtr>))
+            var tp = new TypeDecl(baseType = Type.tPointer)
+            t |> equal("pointer", match_handle_ptr(tp))
+            var tnp = new TypeDecl(baseType = Type.tInt)
+            t |> equal("anything", match_handle_ptr(tnp))
+        }
     }
     t |> run("match ast expression ptr") @@(t : T?) {
-        t |> equal("null", match_ast_expr_ptr(default<ExpressionPtr>))
-        var ep <- new ExprConstInt(value = 13)
-        t |> equal("int 13", match_ast_expr_ptr(ep))
-        var fp <- new ExprConstFloat(value = 13.0)
-        t |> equal("anything", match_ast_expr_ptr(fp))
+        ast_gc_guard() {
+            t |> equal("null", match_ast_expr_ptr(default<ExpressionPtr>))
+            var ep <- new ExprConstInt(value = 13)
+            t |> equal("int 13", match_ast_expr_ptr(ep))
+            var fp <- new ExprConstFloat(value = 13.0)
+            t |> equal("anything", match_ast_expr_ptr(fp))
+        }
     }
     t |> run("match as is") @@(t : T?) {
         t |> equal(0., matching_as_and_is(Cmd()))


### PR DESCRIPTION
## Summary

Post-`das-hash-map` merge audit under RelWithDebInfo (`DAS_TRACK_ALLOC=1`, `DAS_FREE_LIST=0`). Full 6532-test suite on master showed **0 C++ heap leaks** but **9 GC APP LEAK gc_nodes**. All fixed here.

## Changes

### `dasGLFW.main.cpp` — destructor deallocates when non-empty
```diff
 Module_dasGLFW::~Module_dasGLFW() {
-    g_Callbacks.clear();
+    swap(das_map<void *, GlswCallbacks>(), Module_dasGLFW::g_Callbacks);
 }
```
`clear()` empties the map but keeps its allocated capacity — the atexit heap tracker sees that capacity as live memory. Swap-with-empty-temp transfers storage into the temp, whose destructor frees it at end of statement; `g_Callbacks` then holds `daslang_hash_map`'s zero-heap default state. No-op when the map was empty, correct cleanup when it held entries.

### `tests/*` — wrap ast-producing blocks in `ast_gc_guard()`
- `tests/jit_tests/typeinfo.das` — 1 TypeDecl leak from `typeinfo ast_typedecl(type<int const>)`
- `tests/match/all_matches.das` — 2 TypeDecl + 2 ExprConst in the "match handle ptr" / "match ast expression ptr" blocks
- `tests/language/strict_smart_ptr.das` — 4 ExprOp2 across emplace / array-init / struct-init blocks

Each `[test]` block that `new`s AST nodes or keeps a `typeinfo ast_*` result now runs inside `ast_gc_guard() { ... }` so gc_nodes unwind at scope exit instead of accumulating on the thread root.

## Test plan

- [x] `cmake --build build --config RelWithDebInfo --target daslang --target dasModuleGlfw`
- [x] `bin/RelWithDebInfo/daslang.exe dastest/dastest.das -- --test tests` → **6532/6532 pass, 0 GC APP LEAK, 0 C++ heap leak report** (silent atexit = success)
- [x] Individual spot-check of each fixed file reproduces clean output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
