### PR TITLE
delete super.self: sugar for calling base-class finalizer

### DIFF
--- a/doc/source/reference/language/classes.rst
+++ b/doc/source/reference/language/classes.rst
@@ -146,6 +146,26 @@ Inside a derived class, ``super()`` calls the parent class constructor:
 Both forms are rewritten by the compiler into explicit calls to the parent class function:
 ``super()`` becomes ``Base`Base(self)`` and ``super.process(x)`` becomes ``Base`process(self, x)``.
 
+Inside a derived class's finalizer (``operator delete``), ``delete super.self`` runs the
+parent's finalizer on the current object:
+
+.. code-block:: das
+
+    class Derived : Base {
+        def operator delete {
+            delete super.self       // calls Base's finalizer on self
+            // additional cleanup
+        }
+    }
+
+The compiler rewrites ``delete super.self`` into ``delete cast<Base>(self)``. It is only
+valid inside an ``operator delete`` (or equivalently ``def finalize``) of a class that has
+a base class; other uses are rejected at compile time. The same form also works for struct
+finalizers declared as free functions — see :ref:`Structs <structs>`.
+
+Base-class finalization is explicit, not automatic: a derived finalizer that omits
+``delete super.self`` will not run the base finalizer.
+
 The option ``always_call_super`` can be enabled to require ``super()`` in every constructor
 (see :ref:`Options <options>`).
 

--- a/doc/source/reference/language/structs.rst
+++ b/doc/source/reference/language/structs.rst
@@ -225,6 +225,23 @@ Virtual functions can be overridden in the derived structure:
         }
     }
 
+Struct finalizers are declared as free functions named ``operator delete`` (or ``finalize``)
+whose first argument is ``self``. Inside such a finalizer for a derived struct,
+``delete super.self`` runs the parent's finalizer:
+
+.. code-block:: das
+
+    struct Bar: Foo {}
+
+    def operator delete(var self: Bar) {
+        delete super.self       // calls Foo's finalizer on self
+        // additional cleanup
+    }
+
+The compiler rewrites ``delete super.self`` into ``delete cast<Foo>(self)``. See
+:ref:`Classes <classes>` for the full description of the ``super`` sugar — it applies
+identically to structs with inheritance.
+
 .. _structs_alignment:
 
 ---------

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -2473,6 +2473,47 @@ namespace das {
         return Visitor::visit(expr);
     }
     ExpressionPtr InferTypes::visit(ExprDelete *expr) {
+        // sugar inside a finalizer:
+        //   delete super.self   ==>   delete cast<BaseClass>(self)   (alwaysSafe)
+        // lets the derived finalizer call the base class/struct finalizer without
+        // having to name the base type explicitly.
+        if (expr->subexpr->rtti_isField()) {
+            auto eField = static_cast<ExprField *>(expr->subexpr);
+            if (eField->name == "self" && eField->value->rtti_isVar()) {
+                auto eVar = static_cast<ExprVar *>(eField->value);
+                if (eVar->name == "super") {
+                    // finalizer shape: name=="finalize", exactly 1 arg named "self" of struct type
+                    if (!func || func->name != "finalize" || func->arguments.size() != 1) {
+                        error("delete super.self is only allowed inside operator delete (a finalizer)",
+                              "", "", expr->at, CompilationError::bad_delete);
+                        return Visitor::visit(expr);
+                    }
+                    auto &selfArg = func->arguments[0];
+                    if (selfArg->name != "self" || !selfArg->type || !selfArg->type->isStructure()) {
+                        error("delete super.self: finalizer's first argument must be 'self' of a structure type",
+                              "", "", expr->at, CompilationError::bad_delete);
+                        return Visitor::visit(expr);
+                    }
+                    auto selfStruct = selfArg->type->structType;
+                    auto baseStruct = selfStruct->parent;
+                    if (!baseStruct) {
+                        error("delete super.self: " + selfStruct->name + " has no base class or structure",
+                              "", "", expr->at, CompilationError::bad_delete);
+                        return Visitor::visit(expr);
+                    }
+                    reportAstChanged();
+                    auto selfVar = new ExprVar(expr->at, "self");
+                    auto castT = new TypeDecl(baseStruct);
+                    auto castExpr = new ExprCast(expr->at, selfVar, castT);
+                    auto newDel = new ExprDelete(expr->at, castExpr);
+                    newDel->alwaysSafe = true;
+                    newDel->native = expr->native;
+                    if (expr->sizeexpr)
+                        newDel->sizeexpr = expr->sizeexpr->clone();
+                    return newDel;
+                }
+            }
+        }
         if (!expr->subexpr->type)
             return Visitor::visit(expr);
         if (expr->sizeexpr && !expr->sizeexpr->type)

--- a/tests/README.md
+++ b/tests/README.md
@@ -571,6 +571,8 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | failed_structure_field_already_declared.das | Duplicate struct field name | **expect** `30115` |
 | failed_structure_not_found_ambiguous.das | Ambiguous struct name — same name in two modules | **expect** `30302` |
 | super.das | `super` keyword — parent constructor calls, parent method calls, 3-level hierarchy | |
+| super_finalize.das | `delete super.self` — base-class finalizer chain (class, 3-level, free struct finalizer) | |
+| cant_delete_super_self.das | `delete super.self` misuse — outside finalizer, no base, wrong arg shape | **expect** `31002:6` `30305:6` `30503:6` |
 | table.das | Table tombstone handling and iteration | |
 | table_operations.das | Table find, insert, delete, key_exists, erase collision, lock panic, defaults, modify | |
 | test_value_table_key.das | `table<EntityId; string>` — value-type table key ops, set operations | |

--- a/tests/language/cant_delete_super_self.das
+++ b/tests/language/cant_delete_super_self.das
@@ -1,0 +1,56 @@
+// delete super.self error cases — covers every validation branch.
+options gen2
+expect 31002:6, 30305:6, 30503:6
+
+class Base {
+}
+
+// 1. no base class
+class NoParent {
+    def operator delete {
+        delete super.self                           // 31002: no base class
+    }
+}
+
+// 2. not inside a finalizer: regular class method
+class DerivedA : Base {
+    def bad_method() {
+        delete super.self                           // 31002: not in operator delete
+    }
+}
+
+// 3. not inside a finalizer: free function
+def free_not_finalizer {
+    delete super.self                               // 31002: not in operator delete
+}
+
+// 4. finalize with more than 1 argument
+struct StructX {
+    v : int
+}
+
+struct StructY : StructX {
+    w : int
+}
+
+def finalize(var self : StructY, extra : int) {     // 2 args
+    delete super.self                               // 31002: not a finalizer
+}
+
+// 5. first arg not named 'self'
+struct StructZ : StructX {
+    z : int
+}
+
+def operator delete(var x : StructZ) {              // arg name 'x'
+    delete super.self                               // 31002: first arg must be 'self'
+}
+
+// 6. first arg isn't a structure type
+def finalize(var self : int) {                      // int, not struct
+    delete super.self                               // 31002: must be a structure type
+}
+
+[export]
+def main {
+}

--- a/tests/language/oop.das
+++ b/tests/language/oop.das
@@ -50,7 +50,7 @@ class Foo3D : Foo {
         z = -2
     }
     def operator delete {
-        delete cast<Foo> self
+        delete super.self
         delFoo3D ++
     }
 }

--- a/tests/language/super_finalize.das
+++ b/tests/language/super_finalize.das
@@ -1,0 +1,99 @@
+// Tests `delete super.self` — calling the base class/struct finalizer from a derived finalizer.
+options gen2
+require dastest/testing_boost public
+
+var class2_del_base = 0
+var class2_del_derived = 0
+
+class ClassBase {
+    def operator delete {
+        class2_del_base ++
+    }
+}
+
+class ClassDerived : ClassBase {
+    def operator delete {
+        delete super.self
+        class2_del_derived ++
+    }
+}
+
+var class3_del_a = 0
+var class3_del_b = 0
+var class3_del_c = 0
+
+class ClassA {
+    def operator delete {
+        class3_del_a ++
+    }
+}
+
+class ClassB : ClassA {
+    def operator delete {
+        delete super.self
+        class3_del_b ++
+    }
+}
+
+class ClassC : ClassB {
+    def operator delete {
+        delete super.self
+        class3_del_c ++
+    }
+}
+
+var struct_del_base = 0
+var struct_del_derived = 0
+
+struct StructBase {
+    a : int
+}
+
+def operator delete(var self : StructBase) {
+    struct_del_base ++
+}
+
+struct StructDerived : StructBase {
+    b : int
+}
+
+def operator delete(var self : StructDerived) {
+    delete super.self
+    struct_del_derived ++
+}
+
+[test]
+def test_delete_super_self(t : T?) {
+    t |> run("class derived operator delete chains to base via super.self") @(t : T?) {
+        class2_del_base = 0
+        class2_del_derived = 0
+        var d = new ClassDerived()
+        unsafe {
+            delete d
+        }
+        t |> equal(class2_del_base, 1)
+        t |> equal(class2_del_derived, 1)
+    }
+    t |> run("3-level class hierarchy chains all finalizers") @(t : T?) {
+        class3_del_a = 0
+        class3_del_b = 0
+        class3_del_c = 0
+        var c = new ClassC()
+        unsafe {
+            delete c
+        }
+        t |> equal(class3_del_a, 1)
+        t |> equal(class3_del_b, 1)
+        t |> equal(class3_del_c, 1)
+    }
+    t |> run("struct free-function finalizer chains via super.self") @(t : T?) {
+        struct_del_base = 0
+        struct_del_derived = 0
+        var d = new StructDerived()
+        unsafe {
+            delete d
+        }
+        t |> equal(struct_del_base, 1)
+        t |> equal(struct_del_derived, 1)
+    }
+}


### PR DESCRIPTION
## Summary

Inside a derived class or struct's finalizer, `delete super.self` now rewrites to `delete cast<Base>(self)` so the derived finalizer can call the base's finalizer without naming the base type.

```das
class Bar : Foo {
    def operator delete {
        delete super.self       // calls Foo's finalizer on self
        // additional cleanup
    }
}
```

Mirrors the existing `super()` / `super.method(args)` sugars. **Base finalization is explicit** — omitting `delete super.self` does not run the base finalizer (consistent with how `super()` in constructors works).

Works identically for free struct finalizers:

```das
struct Bar : Foo {}
def operator delete(var self : Bar) {
    delete super.self
}
```

## Details

The rewrite happens at the top of `InferTypes::visit(ExprDelete *)` in `src/ast/ast_infer_type.cpp` before the existing `subexpr->type` early-return. The AST-rewrite-then-retry mechanism that `super.method(args)` already relies on (errors cleared between passes) handles the fact that `super` isn't a real variable.

Validation enforces the finalizer shape at compile time:
- Enclosing function name is `finalize` (class `operator delete` → `finalize` via the parser)
- Exactly one argument named `self`
- `self`'s type is a structure (`baseType == tStructure` and `dim.size() == 0` via `TypeDecl::isStructure()`)
- That structure has a `parent`

Any failure emits `error[31002]` with a descriptive message.

## Tests

- `tests/language/oop.das:53` — switched existing `delete cast<Foo> self` to `delete super.self` (validates rewrite end-to-end via existing finalizer-counter assertions)
- `tests/language/super_finalize.das` — new: 2-level class, 3-level class, free struct finalizer
- `tests/language/cant_delete_super_self.das` — new: all six error paths (no base, regular class method, free function, 2-arg finalize, arg not named `self`, non-struct arg type); `cant_` prefix excludes it from AOT

## Documentation

- `doc/source/reference/language/classes.rst` — full description under "Calling Parent Methods"
- `doc/source/reference/language/structs.rst` — short note under "Inheritance" pointing back to classes.rst

Sphinx build: `build succeeded.` with zero warnings.

## Test plan

- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/` — 6537/6537 pass, no GC leaks
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests/` — 5949/5949 pass
- [x] Lint on changed `.das` files (no new issues)
- [x] MCP `format_file` on all changed `.das` files
- [x] Clean Sphinx build with zero warnings
