### PR TITLE
das_hash_map: silence GCC -fpermissive on iterator::reference alias

### DIFF
--- a/include/das_hash_map/das_hash_map.h
+++ b/include/das_hash_map/das_hash_map.h
@@ -230,12 +230,12 @@ public:
     // This is what makes `for (auto & kv : map)` and `for (auto & [k,v] : map)` bind
     // under clang; MSVC was lenient about prvalue-to-lvalue-ref.
     class iterator {
-        daslang_hash_map * owner_ = nullptr;
-        size_t             index_ = 0;
-        mutable typename std::aligned_storage<sizeof(reference), alignof(reference)>::type ref_storage_;
-        friend class daslang_hash_map;
-        friend class const_iterator;
     public:
+        // Aliases come first so `reference` below refers to the alias, not the
+        // enclosing daslang_hash_map::reference via injected-class-name lookup.
+        // GCC's [basic.scope.class] diagnostic (-fpermissive) fires otherwise,
+        // because the name's meaning would differ between enclosing-scope lookup
+        // (outer struct) and complete-class-scope lookup (the alias).
         using iterator_category = forward_iterator_tag;
         // pair<K, V> (not pair<const K, V>): matches ska's value_type contract and
         // matches what operator* actually yields (non-const K& inside reference).
@@ -243,7 +243,13 @@ public:
         using difference_type   = ptrdiff_t;
         using pointer           = daslang_hash_map::reference *;
         using reference         = daslang_hash_map::reference;
-
+    private:
+        daslang_hash_map * owner_ = nullptr;
+        size_t             index_ = 0;
+        mutable typename std::aligned_storage<sizeof(reference), alignof(reference)>::type ref_storage_;
+        friend class daslang_hash_map;
+        friend class const_iterator;
+    public:
         iterator () noexcept = default;
         iterator ( daslang_hash_map * o, size_t i ) noexcept : owner_(o), index_(i) {}
 
@@ -267,17 +273,18 @@ public:
     };
 
     class const_iterator {
-        const daslang_hash_map * owner_ = nullptr;
-        size_t                   index_ = 0;
-        mutable typename std::aligned_storage<sizeof(const_reference), alignof(const_reference)>::type ref_storage_;
-        friend class daslang_hash_map;
     public:
         using iterator_category = forward_iterator_tag;
         using value_type        = pair<K, V>;
         using difference_type   = ptrdiff_t;
         using pointer           = const daslang_hash_map::const_reference *;
         using reference         = daslang_hash_map::const_reference;
-
+    private:
+        const daslang_hash_map * owner_ = nullptr;
+        size_t                   index_ = 0;
+        mutable typename std::aligned_storage<sizeof(const_reference), alignof(const_reference)>::type ref_storage_;
+        friend class daslang_hash_map;
+    public:
         const_iterator () noexcept = default;
         const_iterator ( const daslang_hash_map * o, size_t i ) noexcept : owner_(o), index_(i) {}
         const_iterator ( const iterator & it ) noexcept : owner_(it.owner_), index_(it.index_) {}


### PR DESCRIPTION
## Summary

GCC rejects `das_hash_map.h` with:

```
error: declaration of 'using reference = struct das::daslang_hash_map<...>::reference'
       changes meaning of 'reference' [-fpermissive]
```

Inside `class iterator`, the line

```cpp
mutable typename std::aligned_storage<sizeof(reference), alignof(reference)>::type ref_storage_;
```

uses `reference`, which resolves via injected-class-name lookup to the enclosing `daslang_hash_map::reference` struct. A few lines later, `using reference = daslang_hash_map::reference;` is declared. Per [basic.scope.class]/2, a name used in a class must refer to the same declaration whether looked up in the enclosing scope or in the complete class scope — the `using` changes the meaning between those two points. MSVC and Clang are lenient; GCC 12+ diagnoses it as an error.

The same structural issue exists in `const_iterator`, where the aliased `reference` resolves to a *different* type (`const_reference`) than the enclosing-scope `reference` struct.

## Fix

Hoist the public `using` aliases above the private data in both `iterator` and `const_iterator`, so `reference` refers to the alias at every point within each class. Enclosing-scope and complete-class-scope lookups now agree, and GCC accepts it.

- Behavior, ABI, and class layout unchanged — data member order and visibility are identical
- `sizeof(iterator)` / `sizeof(const_iterator)` unchanged

## Test plan

- [x] Incremental Release build of `daslang` target on MSVC — clean
- [x] Full test suite: **6537/6537 pass**, 0 failures, 0 leaks (~26s)
- [x] `test_aot` Release build — clean
- [x] AOT test suite: **5949/5949 pass**, 0 failures, 0 leaks
- [ ] CI to confirm GCC, Linux/macOS builds