### PR TITLE
strudel: release sample voices + orbit buses on shutdown

### DIFF
--- a/modules/dasAudio/strudel/strudel_midi_player.das
+++ b/modules/dasAudio/strudel/strudel_midi_player.das
@@ -19,6 +19,7 @@ require daslib/jobque_boost
 require daslib/archive
 require strudel/strudel_player
 require daslib/fio
+require daslib/rtti
 require math
 
 // ─── GM Instrument Presets ───
@@ -1048,6 +1049,7 @@ def public midi_init() {
     let audio_ch = get_audio_command_stream()
     let vis_ptr = g_midi_audio_vis_ptr
     new_thread() <| @capture(= sid, = cmd_st, = done_st, = audio_ch, = vis_ptr) {
+        this_context().name := "midi_thread"
         midi_thread_main(sid, cmd_st, done_st, audio_ch, vis_ptr)
         cmd_st = null
         done_st = null

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -694,19 +694,6 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
             to_log(0, "strudel mem: heap {mem_heap_cur/1024ul}kb / str {mem_str_cur/1024ul}kb (max heap {mem_heap_max/1024ul}kb / str {mem_str_max/1024ul}kb)\n")
         }
     }
-    if (total_samples > 0ul) {
-        let SPEED = total_time / double(total_samples)
-        let SPEED_OF_LIGHT = 1000.lf / 48000.lf
-        let UTILIZATION = int(SPEED / SPEED_OF_LIGHT * 1000.lf)
-        let chunk_budget_usec = double(CHUNK_SEC) * 1000000.lf
-        let MAX_UTIL = int(max_chunk_usec / chunk_budget_usec * 1000.lf)
-        let delta_heap = int64(mem_heap_max) - int64(mem_heap_base)
-        let delta_str = int64(mem_str_max) - int64(mem_str_base)
-        to_log(0, "strudel {UTILIZATION/10}.{UTILIZATION%10}% avg, {MAX_UTIL/10}.{MAX_UTIL%10}% peak util, heap {mem_heap_max/1024ul}kb (delta {delta_heap}), str {mem_str_max/1024ul}kb (delta {delta_str})\n")
-        if (delta_heap > LEAK_WARN_THRESHOLD || delta_str > LEAK_WARN_THRESHOLD) {
-            to_log(0, "strudel WARNING: potential memory leak detected (delta heap={delta_heap}, str={delta_str})\n")
-        }
-    }
     pcm_box |> join()
     unsafe(lock_box_remove(pcm_box))
     ma_volume_mixer_uninit(unsafe(addr(mixer)))
@@ -714,6 +701,33 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
     clear_status(status_box)
     status_box |> join()
     unsafe(lock_box_remove(status_box))
+    delete output
+    // release thread-local tracks so sample voices and orbit buses are freed
+    // before the leak-check below (and before the context dies).
+    for (i in range(length(g_tracks))) {
+        if (g_tracks[i] != null) {
+            shutdown_scheduler(g_tracks[i].sched)
+            unsafe { delete g_tracks[i]; }
+            g_tracks[i] = null
+        }
+    }
+    delete g_tracks
+    if (total_samples > 0ul) {
+        let SPEED = total_time / double(total_samples)
+        let SPEED_OF_LIGHT = 1000.lf / 48000.lf
+        let UTILIZATION = int(SPEED / SPEED_OF_LIGHT * 1000.lf)
+        let chunk_budget_usec = double(CHUNK_SEC) * 1000000.lf
+        let MAX_UTIL = int(max_chunk_usec / chunk_budget_usec * 1000.lf)
+        // leak = heap after cleanup minus baseline; peak is just informational.
+        let mem_heap_final = heap_bytes_allocated()
+        let mem_str_final = string_heap_bytes_allocated()
+        let leak_heap = int64(mem_heap_final) - int64(mem_heap_base)
+        let leak_str = int64(mem_str_final) - int64(mem_str_base)
+        to_log(0, "strudel {UTILIZATION/10}.{UTILIZATION%10}% avg, {MAX_UTIL/10}.{MAX_UTIL%10}% peak util, heap peak {mem_heap_max/1024ul}kb final {mem_heap_final/1024ul}kb (leak {leak_heap}), str peak {mem_str_max/1024ul}kb final {mem_str_final/1024ul}kb (leak {leak_str})\n")
+        if (leak_heap > LEAK_WARN_THRESHOLD || leak_str > LEAK_WARN_THRESHOLD) {
+            to_log(0, "strudel WARNING: potential memory leak detected (leak heap={leak_heap}, str={leak_str})\n")
+        }
+    }
 }
 
 def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : string) : void> = @@strudel_noop_cmd) {
@@ -745,6 +759,8 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
     let cps = g_cps
     let la = g_look_ahead
     new_thread() <| @capture(= fn, = bank_ptr, = sf2_ptr, = audio_ch, = cmd_st, = done_st, = pb_box, = wt, = cps, = la, = thread_sid) {
+        // name it
+        this_context().name := "strudel_thread"
         // inject shared resources into thread context
         g_bank_ptr = bank_ptr
         unsafe {
@@ -758,9 +774,8 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
         g_wall_time = wt
         g_cps = cps
         g_look_ahead = la
-        // run user setup + play loop
+        // run user setup + play loop (strudel_play releases thread-local tracks on exit)
         invoke(fn)
-        // cleanup
         unsafe {
             set_audio_thread_command_stream(null)
         }

--- a/modules/dasAudio/strudel/strudel_samples.das
+++ b/modules/dasAudio/strudel/strudel_samples.das
@@ -88,6 +88,7 @@ def load_sound(path : string; name : string; var bank : SampleBank) {
     } else {
         to_log(LOG_WARNING, "load_sound: no audio files found in '{path}' for '{name}'\n")
     }
+    delete files
 }
 
 // Load a Dirt-Samples style directory structure.

--- a/modules/dasAudio/strudel/strudel_scheduler.das
+++ b/modules/dasAudio/strudel/strudel_scheduler.das
@@ -887,7 +887,22 @@ def get_orbit_delay(var sched : Scheduler; orbit : int = 0) : ma_delay? {
 }
 
 def shutdown_scheduler(var sched : Scheduler) {
-    //! Release native resources owned by the scheduler (reverb/delay/chorus instances on every orbit bus).
+    //! Release every resource owned by the scheduler: native reverb/delay/chorus instances,
+    //! pre-rendered sample voices (each carrying a large PCM buffer), SF2/oscillator voice pools,
+    //! per-orbit effect buses and their scratch buffers, and the per-tick output buffer.
+    // pre-rendered sample voices — their `samples` arrays are the biggest leaked allocations
+    for (i in range(length(sched.voices))) {
+        if (sched.voices[i] != null) {
+            unsafe { delete sched.voices[i]; }
+            sched.voices[i] = null
+        }
+    }
+    delete sched.voices
+    // streaming oscillator / SF2 voices
+    delete sched.osc_voices
+    delete sched.sf2_voices
+    delete sched.sf2_meta
+    // per-orbit buses — free native effect instances then send/output scratch buffers
     for (bus in sched.orbit_buses) {
         if (bus != null) {
             if (bus.delay_proc != null) {
@@ -898,10 +913,33 @@ def shutdown_scheduler(var sched : Scheduler) {
                 conv_reverb_uninit(bus.reverb)
                 unsafe { delete bus.reverb; }
             }
+            delete bus.reverb_send_buf
+            delete bus.reverb_out_buf
+            delete bus.delay_send_buf
+            delete bus.delay_out_buf
         }
     }
+    for (i in range(length(sched.orbit_buses))) {
+        if (sched.orbit_buses[i] != null) {
+            unsafe { delete sched.orbit_buses[i]; }
+            sched.orbit_buses[i] = null
+        }
+    }
+    delete sched.orbit_buses
+    // shared chorus and its buffers
     if (sched.chorus != null) {
         unsafe { delete sched.chorus; }
+        sched.chorus = null
+    }
+    delete sched.chorus_send_buf
+    delete sched.chorus_out_buf
+    // per-tick scratch buffers
+    delete sched.voice_fx_buf
+    delete sched.output
+    // mixer — symmetric teardown to ma_volume_mixer_init in tick()
+    if (sched.mixer_ready) {
+        ma_volume_mixer_uninit(unsafe(addr(sched.mixer)))
+        sched.mixer_ready = false
     }
 }
 


### PR DESCRIPTION
## Summary

Running `examples/daStrudel/player_demo/main.das` (or any threaded-mode strudel app) under `--das-profiler --das-profiler-leaks` reported ~3 MB of heap leaks on exit. The bulk was per-voice PCM buffers from `render_sample` and per-orbit reverb/delay send/output buffers — `shutdown_scheduler` only released native reverb/delay/chorus instances, and `strudel_shutdown` ran on the main thread where per-thread globals (`g_tracks`) were empty.

## Changes

- `shutdown_scheduler` now frees every resource the scheduler owns: sample/osc/SF2 voice pools, per-orbit bus scratch buffers, the `OrbitBus` smart_ptrs themselves, the `orbit_buses` array, chorus send/out buffers, `voice_fx_buf`, and the per-tick `output` buffer.
- `strudel_play` releases its local `output` buffer on exit, then iterates its own thread-local `g_tracks` (calling `shutdown_scheduler` + `delete` per track) before measuring the leak. Per-thread globals live in the strudel-thread context, so this cleanup has to happen on that thread — main-thread `strudel_shutdown` never saw them.
- Leak check now compares the final heap against the baseline instead of the peak — transient per-tick growth no longer fires the warning.
- `load_sound` deletes its `files` scratch array before returning.
- Name the `strudel_thread` / `midi_thread` contexts via `this_context().name` so `--das-profiler-leaks` attributes allocations to a readable context instead of `<unnamed>`.

## Before / After (player_demo)

Before:
```
strudel 1.0% avg, 11.9% peak util, heap 0xc84kb (delta 3244656), str 0x0kb (delta 0)
strudel WARNING: potential memory leak detected (delta heap=3244656, str=0)
[I] === Memory leaks in context 'strudel_thread' (29 allocations, 0x320f00 bytes) ===
```

After:
```
strudel 1.0% avg, 15.3% peak util, heap peak 0x1c84kb final 0x2kb (leak -33360), str peak 0x0kb final 0x0kb (leak 0)
[I] === Memory leaks in context 'strudel_thread' (15 allocations, 0xaa8 bytes) ===
```

The 15 remaining allocations are all pattern/mini-notation closures (`tokenize`, `parse_seq`, `pure`, `atom`, `fastcat`, `cat`, `fast`) — out of scope for this PR.

## Test plan

- [x] `utils/lint/main.das` on changed files — clean
- [x] `dastest -- --test tests/strudel` — 575/575 pass
- [x] AOT build (`cmake --build build --config Release --target test_aot`) — succeeded
- [x] AOT tests `test_aot.exe -use-aot -- --use-aot --test tests/strudel` — 575/575 pass
- [x] `player_demo` under `--das-profiler-leaks` — warning gone, heap final matches baseline (~0 leak)
- [x] Files already formatter-clean (MCP `format_file`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)