### PR TITLE
HandleRegistry leak dump at exit + unified --no-dump-leaks + dasHV test fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -756,12 +756,14 @@ include/daScript/misc/debug_break.h
 include/daScript/misc/instance_debugger.h
 include/daScript/misc/gc_node.h
 include/daScript/misc/job_que.h
+include/daScript/misc/handle_registry.h
 include/daScript/misc/uric.h
 src/misc/gc_node.cpp
 src/misc/sysos.cpp
 src/misc/string_writer.cpp
 src/misc/memory_model.cpp
 src/misc/job_que.cpp
+src/misc/handle_registry.cpp
 src/misc/free_list.cpp
 src/misc/alloc_tracker.cpp
 src/misc/alloc_tracker_fast_stack.cpp
@@ -1275,6 +1277,7 @@ SET(DAS_RELEASE_MISC_INCLUDE
     include/daScript/misc/hash.h
     include/daScript/misc/instance_debugger.h
     include/daScript/misc/job_que.h
+    include/daScript/misc/handle_registry.h
     include/daScript/misc/macro.h
     include/daScript/misc/memory_model.h
     include/daScript/misc/network.h

--- a/doc/source/reference/utils/memory_leak_detection.rst
+++ b/doc/source/reference/utils/memory_leak_detection.rst
@@ -53,7 +53,7 @@ At a glance
    * - 6
      - :ref:`HandleRegistry <utils_mlk_handle_registry>` (dasHV)
      - value-sized handles (WebSocket client/server/channel)
-     - *infrastructure exists, not auto-reporting today*
+     - automatic ``Handle<TypeName>`` dump at process exit
 
 
 Picking the right tool
@@ -280,36 +280,59 @@ value-sized ``Handle<T>`` integers backed by
 a ``std::shared_ptr<T>`` per handle. The registry is defined in
 ``include/daScript/misc/handle_registry.h``.
 
-**Current status.** The registry publishes ``live_count()``,
-``for_each_live(cb)``, and a module-wide
-``handleRegistry_dumpAll()`` / ``handleRegistry_registerDump(fn)`` pair,
-but **no call site invokes them at shutdown today**. The infrastructure is
-in place; the auto-report is not.
+**Automatic dump at process exit.** ``handleRegistry_dumpAll()`` runs
+inside ``Module::Shutdown(dumpLeaks)`` in both ``daslang.exe`` and
+``daslang-live.exe``, in the window between the module destructor loop
+(which drains job threads via ``Module_JobQue::~Module_JobQue``) and
+the ``DynamicModuleInfo`` teardown that unloads shared modules. That
+ordering is deliberate: before the window, live job threads legitimately
+hold handles; after it, the ``dumpHandleLeaks<T>`` function pointers
+registered from shared-module DLLs are dangling. Every handle type
+registered via ``addHandleAnnotation<T>`` auto-registers a per-type dump
+callback that walks ``HandleRegistry<T>::instance()`` and reports any
+live handles at that moment.
 
-**Manual query from C++.**
+**Sample output.**
+
+.. code-block:: none
+
+     Handle<WebSocketClient> idx=3 gen=1 (rc=1)
+     Handle<WebSocketServer> idx=0 gen=9 (rc=1)
+   total 1 leaked handles of type WebSocketClient
+   total 1 leaked handles of type WebSocketServer
+
+Columns are the slot index, generation counter (rolls on release and
+reacquire), and ``shared_ptr::use_count()`` at dump time. ``rc=1`` means
+the registry is the sole owner --- a classic forgotten-release bug.
+``rc>1`` means another strong reference is keeping the object alive;
+look for a forgotten capture.
+
+**How type names are resolved.** The dumper calls ``typeName<T>::name()``,
+which is specialized by ``MAKE_EXTERNAL_TYPE_FACTORY(Name, hv::Name)`` in
+``modules/dasHV/src/dasHV.h``. Adding a new handle type without
+``typeName<T>`` is a compile-time error on the first
+``addHandleAnnotation<T>`` call --- by design.
+
+**Disabled modules cost nothing.** When ``DAS_HV_DISABLED=ON`` the module
+TUs are not compiled; no callbacks get registered; the dump iterates an
+empty hooks vector.
+
+**Advisory, not fatal.** The dump prints but does not change exit code
+(matches ``DumpJobQueLeaks`` precedent). Only ``ptr_ref_count`` leaks
+trigger ``exit(1)``.
+
+**Manual query.** Still useful for in-process programmatic inspection ---
+for example, a long-running server that wants to log its own handle
+census periodically:
 
 .. code-block:: cpp
 
    auto & reg = HandleRegistry<hv::WebSocketClient>::instance();
    if ( auto n = reg.live_count() ) {
        reg.for_each_live([](Handle<hv::WebSocketClient> h, auto & p){
-           // log h.value, p.get()
+           // log h.value, p.use_count(), p.get()
        });
    }
-
-**Wiring an automatic report.** Register per-type dump hooks in dasHV's
-module init:
-
-.. code-block:: cpp
-
-   handleRegistry_registerDump([]{
-       auto & reg = HandleRegistry<hv::WebSocketClient>::instance();
-       if ( auto n = reg.live_count() ) { /* log */ }
-   });
-
-Then call ``handleRegistry_dumpAll()`` from ``shutdownDebugAgent()`` or the
-program-teardown path. This is a small, tractable C++ change if the need
-arises for a production service.
 
 
 See also

--- a/doc/source/reference/utils/memory_leak_detection.rst
+++ b/doc/source/reference/utils/memory_leak_detection.rst
@@ -321,6 +321,12 @@ empty hooks vector.
 (matches ``DumpJobQueLeaks`` precedent). Only ``ptr_ref_count`` leaks
 trigger ``exit(1)``.
 
+**Silencing all three exit-time dumps.** Pass ``--no-dump-leaks`` to
+``daslang.exe`` or ``daslang-live.exe`` and the JobStatus, HandleRegistry,
+and smart_ptr ``TextPrinter`` dumps all become quiet. The ``exit(1)`` on a
+smart_ptr leak is preserved --- it is a failure signal, not diagnostic
+noise. Default is on.
+
 **Manual query.** Still useful for in-process programmatic inspection ---
 for example, a long-running server that wants to log its own handle
 census periodically:

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1156,7 +1156,7 @@ namespace das
         static Module * requireEx ( const string & name, bool allowPromoted );
         static void Initialize();
         static void CollectFileInfo(das::vector<FileInfoPtr> &accesses);
-        static void Shutdown();
+        static void Shutdown( bool dumpHandleLeaks = true );
         static void Reset(bool debAg);
         static void ClearSharedModules();
         static void CollectSharedModules();

--- a/include/daScript/ast/ast_handle.h
+++ b/include/daScript/ast/ast_handle.h
@@ -921,10 +921,28 @@ namespace das
     template <typename T> bool das_handle_nequ ( Handle<T> a, Handle<T> b ) { return a != b; }
 
     template <typename T>
+    void dumpHandleLeaks () {
+        auto & reg = HandleRegistry<T>::instance();
+        if ( reg.live_count() == 0 ) return;
+        TextPrinter tp;
+        string tn = typeName<T>::name();
+        int total = 0;
+        reg.for_each_live([&](Handle<T> h, const shared_ptr<T> & p){
+            uint32_t idx = uint32_t(h.value & 0xFFFFFFFFu) - 1;
+            uint32_t gen = uint32_t(h.value >> 32);
+            tp << "  Handle<" << tn << "> idx=" << idx << " gen=" << gen
+               << " (rc=" << int(p.use_count()) << ")\n";
+            total++;
+        });
+        if ( total ) tp << "total " << total << " leaked handles of type " << tn << "\n";
+    }
+
+    template <typename T>
     void addHandleAnnotation ( Module * mod, ModuleLibrary & lib,
                                const string & name,
                                const string & destroyFnName = string(),
                                const string & cppTypeName = string() ) {
+        handleRegistry_registerDump(&dumpHandleLeaks<T>);
         mod->addAnnotation(new ManagedHandleAnnotation<T>(lib, name, cppTypeName));
         addExtern<decltype(&das_handle_equ<T>),  das_handle_equ<T>>
             (*mod, lib, "==", SideEffects::none, "das_handle_equ");

--- a/include/daScript/misc/handle_registry.h
+++ b/include/daScript/misc/handle_registry.h
@@ -23,15 +23,25 @@ namespace das {
 
     using HandleLeakDumpFn = void (*)();
 
+    // Definitions in src/misc/handle_registry.cpp — single instance across
+    // daslang.exe + all dasModule*.shared_module DLLs so registrations from any
+    // module are visible at dump time.
+    DAS_API vector<HandleLeakDumpFn> & handleRegistry_dumpHooks_impl ();
+    DAS_API mutex & handleRegistry_dumpMutex_impl ();
+    DAS_API void handleRegistry_registerDump_impl ( HandleLeakDumpFn fn );
+    DAS_API void handleRegistry_dumpAll_impl ();
+
     inline vector<HandleLeakDumpFn> & handleRegistry_dumpHooks () {
-        static vector<HandleLeakDumpFn> hooks;
-        return hooks;
+        return handleRegistry_dumpHooks_impl();
+    }
+    inline mutex & handleRegistry_dumpMutex () {
+        return handleRegistry_dumpMutex_impl();
     }
     inline void handleRegistry_registerDump ( HandleLeakDumpFn fn ) {
-        handleRegistry_dumpHooks().push_back(fn);
+        handleRegistry_registerDump_impl(fn);
     }
     inline void handleRegistry_dumpAll () {
-        for ( auto fn : handleRegistry_dumpHooks() ) fn();
+        handleRegistry_dumpAll_impl();
     }
 
     template <typename T>

--- a/skills/memory_leak_detection.md
+++ b/skills/memory_leak_detection.md
@@ -17,7 +17,7 @@ material in docs style.
 | Long-running run keeps growing, or want per-context heap dump at exit | **#2 `-track-allocations -heap-report`** (single dash) |
 | Know a specific smart_ptr id is misbehaving, want debug-break on every addRef/delRef | **#4 `--track-smart-ptr <hexId>`** |
 | Script uses channels/jobs/lockboxes, `DumpJobQueLeaks` printed survivors | **#5 `--track-job-status`** (`skills/jobque_debugging.md`) |
-| Long-running dasHV server suspected to leak WebSocket-client handles | **#6 `HandleRegistry` manual query** (infrastructure is dormant — see below) |
+| Long-running dasHV server suspected to leak WebSocket-client handles | **#6 `HandleRegistry` auto-dump** — `Handle<TypeName>` lines at process exit list unreleased handles |
 
 **CLI dash convention:** `-track-allocations` and `-heap-report` use **one**
 leading dash; `--track-smart-ptr`, `--track-job-status`, and
@@ -208,39 +208,67 @@ refs, lockbox fill/grab/join lifecycle).
 
 ---
 
-## #6 — `HandleRegistry<T>` (dasHV WebSocket handles) — dormant
+## #6 — `HandleRegistry<T>` (dasHV WebSocket handles) — automatic
 
 **Scope:** value-sized handles backed by `std::shared_ptr<T>` on the C++
 side. Used by dasHV for `hv::WebSocketClient`, `hv::WebSocketServer`,
 `hv::WebSocketChannel`. Infrastructure in
 `include/daScript/misc/handle_registry.h`.
 
-**Status:** the dump infrastructure exists
-(`handleRegistry_dumpHooks`, `handleRegistry_registerDump`,
-`handleRegistry_dumpAll`, per-instance `live_count()`, `for_each_live()`)
-but **no site currently calls `handleRegistry_dumpAll()` at shutdown**.
-Grepping the tree confirms zero call sites.
+**Invoke:** nothing. `handleRegistry_dumpAll()` runs inside
+`Module::Shutdown(dumpLeaks)` in both `daslang.exe` and `daslang-live.exe`,
+in the window between the module destructor loop (which drains job
+threads via `Module_JobQue::~Module_JobQue`) and the
+`DynamicModuleInfo` teardown that unloads shared modules. That ordering
+is deliberate: before the window, live job threads legitimately hold
+handles; after it, the `dumpHandleLeaks<T>` function pointers registered
+from shared-module DLLs are dangling. Every handle type registered via
+`addHandleAnnotation<T>` auto-registers a per-type dump callback — no
+per-module boilerplate.
 
-**Manual query today:** from C++ code:
+**Output:**
+```
+  Handle<WebSocketClient> idx=3 gen=1 (rc=1)
+  Handle<WebSocketServer> idx=0 gen=9 (rc=1)
+total 1 leaked handles of type WebSocketClient
+total 1 leaked handles of type WebSocketServer
+```
+
+Columns: slot index, generation counter (rolls on release/reacquire), and
+`shared_ptr::use_count()` at dump time. `rc=1` = registry is the sole
+owner (textbook leak). `rc>1` = another strong ref is keeping the object
+alive — look for forgotten captures.
+
+**Type names** come from `typeName<T>::name()` — for handle types this is
+wired via `MAKE_EXTERNAL_TYPE_FACTORY(Name, hv::Name)` in
+`modules/dasHV/src/dasHV.h`. Any new handle type introduced via
+`addHandleAnnotation<T>` that does NOT have a `typeName<T>` specialization
+fails to compile (by design — compile-time enforcement of a readable name).
+
+**Manual query** (still useful for in-process programmatic inspection):
 ```cpp
 auto & reg = HandleRegistry<hv::WebSocketClient>::instance();
 auto n = reg.live_count();
 if ( n ) {
     reg.for_each_live([](Handle<hv::WebSocketClient> h, auto & p){
-        // log h.value, p.get()
+        // log h.value, p.use_count(), p.get()
     });
 }
 ```
 
-From a daslang helper you would need a `[pinvoke]` C++ bridge exposing
-`live_count` / `for_each_live` — none exists in `modules/dasHV/` today.
+**Read it:** match leaked `Handle<TypeName>` against the acquire site (e.g.
+`makeWebSocketClient`, `makeWebSocketServer`). The leak means user code
+reached script exit without calling the matching destroy function (e.g.
+`destroy_web_socket_client`) or without triggering the wrapping class's
+`operator delete` (e.g. via `inscope` / explicit `delete`).
 
-**When you hit this:** either (a) wire `handleRegistry_dumpAll()` into
-`shutdownDebugAgent()` / program teardown, and register per-type dump hooks
-in dasHV's module init; or (b) add a diagnostic C++ helper to dasHV that
-iterates the relevant `HandleRegistry` instances. Prefer (a) — one line per
-type in `modules/dasHV/src/dasHV.cpp` using
-`handleRegistry_registerDump([]{ /* log survivors */ })`.
+**Disabled modules:** `handleRegistry_dumpAll()` is cheap even when dasHV
+is disabled via `DAS_HV_DISABLED=ON` — the module's TUs aren't compiled, so
+no callbacks are registered, and the dump iterates an empty hooks vector.
+
+**Advisory, not fatal:** the dump prints but does not change exit code
+(matches `DumpJobQueLeaks` precedent). Only `ptr_ref_count` leaks force
+`exit(1)`.
 
 ---
 
@@ -279,7 +307,7 @@ Common non-leaks that look like leaks:
 | AST node leak from daslang macro | #3 gc_node (always on) |
 | `smart_ptr<Context>` / `smart_ptr<Program>` stuck | #4 via the `DumpTrackPtr` exit dump |
 | Channel / LockBox / JobStatus survivor | #5 (`skills/jobque_debugging.md`) |
-| Native `hv::WebSocketClient` / `Channel` / `Server` | #6 (manual query today) |
+| Native `hv::WebSocketClient` / `Channel` / `Server` | #6 |
 
 ---
 

--- a/skills/memory_leak_detection.md
+++ b/skills/memory_leak_detection.md
@@ -270,6 +270,14 @@ no callbacks are registered, and the dump iterates an empty hooks vector.
 (matches `DumpJobQueLeaks` precedent). Only `ptr_ref_count` leaks force
 `exit(1)`.
 
+**Silencing all three exit-time dumps:** pass `--no-dump-leaks` to
+`daslang.exe` / `daslang-live.exe` and the JobStatus, HandleRegistry, and
+smart_ptr TextPrinter dumps all become quiet (the exit(1) on smart_ptr
+leak is preserved — it's a failure signal, not diagnostic noise).
+Default is on. Use this in environments where pre-existing noisy leaks
+would drown out the signal you're looking for, or when another tool is
+consuming daslang output.
+
 ---
 
 ## Before reporting a leak

--- a/src/ast/ast_module.cpp
+++ b/src/ast/ast_module.cpp
@@ -4,6 +4,7 @@
 #include "daScript/ast/ast_visitor.h"
 #include "daScript/das_common.h"
 #include "daScript/daScriptModule.h"
+#include "daScript/misc/handle_registry.h"
 #include "daScript/simulate/simulate_fusion.h"
 
 #include <atomic>
@@ -195,7 +196,7 @@ namespace das {
         }
     }
 
-    void Module::Shutdown() {
+    void Module::Shutdown( bool dumpHandleLeaks ) {
         DAS_ASSERT(daScriptEnvironment::getOwned()!=nullptr);
         DAS_ASSERT(daScriptEnvironment::getBound()!=nullptr);
         g_envTotal --;
@@ -208,7 +209,12 @@ namespace das {
             m = m->next;
             delete pM;
         }
-        // Free allocated structures for dynamic modules.
+        // Window between module destruction (which drains job threads via
+        // Module_JobQue::~Module_JobQue) and DLL unload below: function
+        // pointers in dasModule*.shared_module DLLs are still valid, and any
+        // live job threads that were holding handles have exited. Dump here.
+        if ( dumpHandleLeaks ) handleRegistry_dumpAll();
+        // Free allocated structures for dynamic modules (unloads DLLs).
         delete daScriptEnvironment::getBound()->g_dyn_modules_resolve;
 
         clearGlobalAotLibrary();

--- a/src/misc/handle_registry.cpp
+++ b/src/misc/handle_registry.cpp
@@ -1,0 +1,40 @@
+#include "daScript/misc/platform.h"
+#include "daScript/misc/handle_registry.h"
+
+namespace das {
+
+    // Singletons live in the main DAS library so all DLLs (daslang.exe + each
+    // dasModule*.shared_module) share one hooks vector and one mutex.
+    // Without this, inline function-local statics would be per-DLL and dump
+    // callbacks registered from a module DLL would never be seen by the host.
+
+    DAS_API vector<HandleLeakDumpFn> & handleRegistry_dumpHooks_impl () {
+        static vector<HandleLeakDumpFn> hooks;
+        return hooks;
+    }
+
+    DAS_API mutex & handleRegistry_dumpMutex_impl () {
+        static mutex m;
+        return m;
+    }
+
+    DAS_API void handleRegistry_registerDump_impl ( HandleLeakDumpFn fn ) {
+        lock_guard<mutex> g(handleRegistry_dumpMutex_impl());
+        auto & hooks = handleRegistry_dumpHooks_impl();
+        for ( auto e : hooks ) if ( e == fn ) return;
+        hooks.push_back(fn);
+    }
+
+    DAS_API void handleRegistry_dumpAll_impl () {
+        // Snapshot hooks under the registry mutex, then invoke outside so
+        // that a callback freeing handles (or re-registering) cannot deadlock
+        // against a concurrent addHandleAnnotation<T> on another thread.
+        vector<HandleLeakDumpFn> hooks;
+        {
+            lock_guard<mutex> g(handleRegistry_dumpMutex_impl());
+            hooks = handleRegistry_dumpHooks_impl();
+        }
+        for ( auto fn : hooks ) fn();
+    }
+
+}

--- a/tests/dasHV/test_forms.das
+++ b/tests/dasHV/test_forms.das
@@ -119,6 +119,10 @@ def with_form_test_server(port : int; blk : block<(base_url : string; upload_dir
                         sleep(1u)
                     }
                     server->stop()
+                    server->cleanup()
+                    unsafe {
+                        delete server
+                    }
                     finished |> notify_and_release
                 }
                 started |> join

--- a/tests/dasHV/test_server_advanced.das
+++ b/tests/dasHV/test_server_advanced.das
@@ -99,6 +99,10 @@ def with_advanced_test_server(port : int; blk : block<(base_url : string) : void
                         sleep(1u)
                     }
                     server->stop()
+                    server->cleanup()
+                    unsafe {
+                        delete server
+                    }
                     finished |> notify_and_release
                 }
                 started |> join

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -713,6 +713,9 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     }
     // and done
     if ( pauseAfterDone ) getchar();
+    // Handle-leak dump runs inside Module::Shutdown, between module
+    // destruction (drains job threads) and DLL unload (invalidates the
+    // dumpHandleLeaks<T> function pointers registered from shared modules).
     Module::Shutdown();
     JobStatus::DumpJobQueLeaks();
     // das::dump_alloc_leaks is registered as an atexit handler via init_seg(lib),

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -420,6 +420,7 @@ void print_help() {
         << "    -dasroot <path> set path to daslang root folder (with daslib)\n"
         << "    --track-smart-ptr <id> track smart pointer with id\n"
         << "    --track-job-status <id> track JobStatus/Channel/LockBox with id\n"
+        << "    --no-dump-leaks  silence the JobStatus + HandleRegistry + smart_ptr leak dumps at exit (default: dump)\n"
         << "    --linear-stack-allocator  disable scoped stack allocator\n"
         << "    --das-wait-debugger wait for debugger to attach\n"
         << "    --das-profiler enable profiler\n"
@@ -492,6 +493,7 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     bool pauseAfterDone = false;
     bool dryRun = false;
     bool compileOnly = false;
+    bool dumpLeaks = true;
     string project_root;
     optional<format::FormatOptions> formatter;
     for ( int i=1; i < argc; ++i ) {
@@ -659,6 +661,10 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
                 i += 1;
             } else if ( cmd=="no-dynamic-modules" ) {
                 noDynamicModules = true;
+            } else if ( cmd=="-dump-leaks" ) {
+                dumpLeaks = true;
+            } else if ( cmd=="-no-dump-leaks" ) {
+                dumpLeaks = false;
             } else if ( cmd=="h" || cmd=="-help" ) {
                 print_help();
                 return 0;
@@ -716,14 +722,18 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     // Handle-leak dump runs inside Module::Shutdown, between module
     // destruction (drains job threads) and DLL unload (invalidates the
     // dumpHandleLeaks<T> function pointers registered from shared modules).
-    Module::Shutdown();
-    JobStatus::DumpJobQueLeaks();
+    Module::Shutdown(dumpLeaks);
+    if ( dumpLeaks ) {
+        JobStatus::DumpJobQueLeaks();
+    }
     // das::dump_alloc_leaks is registered as an atexit handler via init_seg(lib),
     // so it fires after all static destructors — cleaner than dumping here.
     if ( g_smart_ptr_total!=0 ) {
-        TextPrinter tp;
-        tp << "smart pointers leaked: " << uint64_t(g_smart_ptr_total) << "\n";
-        ptr_ref_count::DumpTrackPtr();
+        if ( dumpLeaks ) {
+            TextPrinter tp;
+            tp << "smart pointers leaked: " << uint64_t(g_smart_ptr_total) << "\n";
+            ptr_ref_count::DumpTrackPtr();
+        }
         exit(1);
     }
     return exitCode;

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -573,6 +573,7 @@ static void print_help() {
     tout << "  -track-allocations — track where heap allocations came from\n";
     tout << "  -heap-report      — dump heap contents on shutdown\n";
     tout << "  --no-dyn-modules  — skip loading dynamic modules\n";
+    tout << "  --no-dump-leaks   — silence JobStatus + HandleRegistry leak dumps at exit (default: dump)\n";
     tout << "  --                — separator for script arguments\n";
     tout << "  -h, --help        — this help\n";
 }
@@ -640,6 +641,7 @@ int main(int argc, char * argv[]) {
     string scriptFile;
     bool noDynamicModules = false;
     bool changeCwd = false;
+    bool dumpLeaks = true;
 
     // Parse args
     for (int i = 1; i < argc; i++) {
@@ -658,6 +660,10 @@ int main(int argc, char * argv[]) {
             heapReportAtExit = true;
         } else if (arg == "--no-dyn-modules") {
             noDynamicModules = true;
+        } else if (arg == "--dump-leaks") {
+            dumpLeaks = true;
+        } else if (arg == "--no-dump-leaks") {
+            dumpLeaks = false;
         } else if (arg == "-h" || arg == "--help") {
             print_help();
             return 0;
@@ -730,8 +736,10 @@ int main(int argc, char * argv[]) {
     // Handle-leak dump runs inside Module::Shutdown, between module
     // destruction (drains job threads) and DLL unload (invalidates the
     // dumpHandleLeaks<T> function pointers registered from shared modules).
-    Module::Shutdown();
-    JobStatus::DumpJobQueLeaks();
+    Module::Shutdown(dumpLeaks);
+    if ( dumpLeaks ) {
+        JobStatus::DumpJobQueLeaks();
+    }
     // das::dump_alloc_leaks is registered as an atexit handler via init_seg(lib),
     // so it fires after all static destructors — cleaner than dumping here.
     release_single_instance();

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -727,6 +727,9 @@ int main(int argc, char * argv[]) {
 
     int result = run_lifecycle(scriptFile);
 
+    // Handle-leak dump runs inside Module::Shutdown, between module
+    // destruction (drains job threads) and DLL unload (invalidates the
+    // dumpHandleLeaks<T> function pointers registered from shared modules).
     Module::Shutdown();
     JobStatus::DumpJobQueLeaks();
     // das::dump_alloc_leaks is registered as an atexit handler via init_seg(lib),

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -441,6 +441,7 @@ SET(MISC_SRC
 ../src/misc/free_list.cpp
 ../src/misc/gc_node.cpp
 ../src/misc/daScriptC.cpp
+../src/misc/handle_registry.cpp
 ../src/misc/uric.cpp
 ../src/misc/format.cpp
 )


### PR DESCRIPTION
## Summary

Activates the previously-dormant `HandleRegistry<T>` leak-dump scaffolding so every handle-backed C++ type exposed to daslang (currently dasHV's `WebSocketClient` / `WebSocketServer` / `WebSocketChannel` and any future user-added types) reports unreleased handles at process exit — same style as `JobStatus::DumpJobQueLeaks`. Fixes 18 pre-existing leaks uncovered by the new dump, and adds a single `--no-dump-leaks` CLI flag that silences all three exit-time reports in one place.

### `handle-registry: wire automatic leak dump at process exit`

- `HandleLeakDumpFn` registry moved from header-only statics into `src/misc/handle_registry.cpp` as `DAS_API` forwarders, so the hooks vector is ONE instance across `daslang.exe` + every `dasModule*.shared_module` DLL (per-DLL statics would fragment registrations).
- Register path takes a mutex and dedupes by fn-pointer so repeated `addHandleAnnotation<T>` calls across modules are safe.
- Templated `dumpHandleLeaks<T>()` added next to `das_handle_release<T>` in `ast_handle.h`; `addHandleAnnotation<T>` auto-registers it. Display names come from the existing `typeName<T>::name()` specialization that every handle-backed type already declares via `MAKE_EXTERNAL_TYPE_FACTORY` — no new per-module boilerplate.
- Output format:
  ```
    Handle<WebSocketServer> idx=0 gen=9 (rc=1)
  total 18 leaked handles of type WebSocketServer
  ```
  `rc=1` = only the registry holds a ref (classic forgot-to-release); `rc>1` = someone else also kept a strong ref.
- `daslang.exe` and `daslang-live.exe` call `handleRegistry_dumpAll()` right after `JobStatus::DumpJobQueLeaks()`.
- Docs rewrite: `skills/memory_leak_detection.md` + `doc/source/reference/utils/memory_leak_detection.rst` — tool #6 moves from "dormant" to "automatic".

### `leaks: unify exit-time dumps under --no-dump-leaks`

Single bool (`dumpLeaks`, default true) gates all three exit-time dumps — JobStatus, HandleRegistry, and smart_ptr — so CI can silence pre-existing noise with one flag instead of three. `exit(1)` on smart_ptr leak is preserved regardless of the flag (that's a failure signal, not diagnostic noise).

### `tests/dasHV: release WebSocketServer in form + advanced helpers`

The new dump immediately flagged 18 `Handle<WebSocketServer>` leaks on full-suite runs. Root cause: `test_forms.das` and `test_server_advanced.das` each define a local `with_*_test_server()` helper that is a near-copy of the shared `with_test_server()` in `_dashv_test_common.das` — but both dropped the `server->cleanup()` + `delete server` calls at the worker thread tail. 9 invocations × 2 files = 18 leaks. Fix is four lines per file.

## Test plan

- [x] Full Release suite: 6543/6543 pass (`bin/Release/daslang.exe dastest/dastest.das -- --test tests`), zero `Handle<...>` dump at exit
- [x] Full AOT suite: 5955/5955 pass (`bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests`)
- [x] dasHV isolated + multi-file: 132/132 pass, zero leak output
- [x] `--no-dump-leaks` silences all three dump sections verified manually
