### PR TITLE
sort: fix non-strict-weak-ordering comparator

### DIFF
--- a/daslib/remove_call_args.das
+++ b/daslib/remove_call_args.das
@@ -38,7 +38,7 @@ def get_remove_indices(args : AnnotationArgumentList) {
         }
     }
     if (length(indices) > 0) {
-        indices |> sort() <| $(a, b) => a >= b
+        indices |> sort() <| $(a, b) => a > b
     }
     return <- indices
 }

--- a/tests/language/sort.das
+++ b/tests/language/sort.das
@@ -7,7 +7,29 @@ def test_sort(t : T?; var arr : auto(TT)) {
     for (i in range(1, len)) {
         t |> success(arr[i - 1] < arr[i])
     }
-    sort(arr, $(a, b) => !(a < b))
+    sort(arr, $(a, b) => b < a)
+    for (i in range(1, len)) {
+        t |> success(!(arr[i - 1] < arr[i]))
+    }
+}
+
+def test_sort_dupes(t : T?; var arr : auto(TT); expected_sum : auto(SS)) {
+    let len = length(arr)
+    sort(arr)
+    var asc_sum = default<SS>
+    for (v in arr) {
+        asc_sum += SS(v)
+    }
+    t |> equal(asc_sum, expected_sum)
+    for (i in range(1, len)) {
+        t |> success(!(arr[i] < arr[i - 1]))
+    }
+    sort(arr, $(a, b) => a > b)
+    var desc_sum = default<SS>
+    for (v in arr) {
+        desc_sum += SS(v)
+    }
+    t |> equal(desc_sum, expected_sum)
     for (i in range(1, len)) {
         t |> success(!(arr[i - 1] < arr[i]))
     }
@@ -62,4 +84,8 @@ def test_sort_all(t : T?) {
     test_sort(t, [Foo(x=1, y=2), Foo(x=1, y=1), Foo(x=2, y=2), Foo(x=0, y=1)])
     // vector
     test_vector_sort(t)
+    // duplicates -- exercises strict-weak-ordering comparator on equal elements
+    test_sort_dupes(t, array<int>(5, 2, 5, 3, 2, 1, 4, 2, 5), 29l)
+    test_sort_dupes(t, fixed_array<int>(5, 2, 5, 3, 2, 1, 4, 2, 5), 29l)
+    test_sort_dupes(t, array<float>(1.5, 2.5, 1.5, 2.5, 3.5), 11.5lf)
 }


### PR DESCRIPTION
## Summary

Two call sites passed a comparator that violates strict-weak-ordering irreflexivity (`comp(a, a) == true` on equal elements):

- `daslib/remove_call_args.das:41` — `indices |> sort() <| $(a, b) => a >= b`
- `tests/language/sort.das:10` — `sort(arr, $(a, b) => !(a < b))`

daslang's `sort` is smoothsort (musl `qsort_r`, `src/builtin/das_qsort_r.h`), not `std::sort`. All loops are bounded by `pshift` / Leonardo bits (strictly decreasing regardless of the comparator), and pointer arithmetic stays within `width * nel`. A non-SWO comparator therefore does **not** hang or corrupt memory — but it does produce wrong ordering when duplicates are present, which for `remove_call_args` breaks the invariant that back-to-front index erasure is sound (e.g. `[remove_call_args(arg=(1, 1))]`).

Changes:

- `remove_call_args.das`: `a >= b` → `a > b`
- `tests/language/sort.das`: `!(a < b)` → `b < a` (the existing test uses `Foo` which only defines `operator <`)
- Add `test_sort_dupes` helper exercising ascending + strict-descending sort on arrays with duplicates; asserts monotonicity and sum preservation (permutation check)

## Test plan

- [x] `bin/Release/daslang.exe utils/lint/main.das -- daslib/remove_call_args.das tests/language/sort.das` — two pre-existing STYLE warnings in untouched code
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/` — 6543/6543 pass
- [x] `cmake --build build --config Release --target test_aot`
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — 5955/5955 pass
- [x] Both changed files pass MCP `format_file` (already formatted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)