### PR TITLE
heap-tracker: fix tag_array/tag_table dangling-pointer on GC

### DIFF
--- a/src/builtin/module_builtin_array.cpp
+++ b/src/builtin/module_builtin_array.cpp
@@ -84,10 +84,12 @@ namespace das {
         // up in heap reports under that name. Requires `options track_allocations`
         // (the heap's mark_comment is a no-op otherwise). The tag is preserved
         // across realloc by array_reserve, which reads the previous tag before
-        // overwriting with the generic "array" default. Intern the tag into the
-        // context's string heap so the pointer stored in bigStuffComment stays
-        // valid even if the caller's `name` string is later freed or GC'd.
-        if ( arr.data && name ) context->heap->mark_comment(arr.data, context->intern(name));
+        // overwriting with the generic "array" default. `name` is stored as-is
+        // in bigStuffComment; the caller owns its lifetime. The common case is
+        // a daslang literal (constStringHeap, never swept); dynamic daslang
+        // strings live in stringHeap, whose GC is skipped while track_allocations
+        // is on (see Context::collectHeap).
+        if ( arr.data && name ) context->heap->mark_comment(arr.data, name);
     }
 
     void Module_BuiltIn::addArrayTypes(ModuleLibrary & lib) {

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -983,10 +983,12 @@ namespace das
         // up in heap reports under that name. Requires `options track_allocations`
         // (the heap's mark_comment is a no-op otherwise). The tag is preserved
         // across realloc by TableHash::reserveInternal, which reads the previous
-        // tag before overwriting with the generic "table" default. Intern the tag
-        // into the context's string heap so the pointer stored in bigStuffComment
-        // stays valid even if the caller's `name` string is later freed or GC'd.
-        if ( tab.data && name ) context->heap->mark_comment(tab.data, context->intern(name));
+        // tag before overwriting with the generic "table" default. `name` is
+        // stored as-is in bigStuffComment; the caller owns its lifetime. The
+        // common case is a daslang literal (constStringHeap, never swept);
+        // dynamic daslang strings live in stringHeap, whose GC is skipped while
+        // track_allocations is on (see Context::collectHeap).
+        if ( tab.data && name ) context->heap->mark_comment(tab.data, name);
     }
 
     bool builtin_iterator_first ( Sequence & it, void * data, Context * context, LineInfoArg * at ) {

--- a/src/simulate/simulate_gc.cpp
+++ b/src/simulate/simulate_gc.cpp
@@ -965,6 +965,12 @@ namespace das
         GcGuard guard(this);
         // clean up, so that all small allocations are marked as 'free'
         stringDisposeQue = nullptr;
+        // When allocation tracking is on, entries in MemoryModel::bigStuffComment
+        // may point into stringHeap (e.g. tag_array/tag_table with a dynamic name)
+        // and are not reachable as GC roots. Skipping stringHeap GC keeps those
+        // pointers valid for the heap report. track_allocations is a diagnostic
+        // mode, so unbounded stringHeap growth during the run is acceptable.
+        if ( stringHeap->isTrackingAllocations() ) sheap = false;
         if ( sheap && !stringHeap->mark() ) return;
         if ( !heap->mark() ) return;
         // now


### PR DESCRIPTION
## Summary

`builtin_array_tag` and `builtin_table_tag` stored `context->intern(name)` in `MemoryModel::bigStuffComment`. `intern` returns a pointer into `constStringHeap` (stable forever) for daslang literals, but into `stringHeap` for dynamic strings — and `bigStuffComment` is **not** walked as a GC root, so the very next `stringHeap` sweep reclaimed the tag and left a dangling pointer for the next heap report.

The `intern` call is also wasteful: for literals it's two hash lookups that hand back the same pointer; for non-literals it's theater that doesn't actually make the stored pointer GC-safe.

## Fix

Two parts:

1. Drop `intern` in both helpers; store `name` as-is.
2. In `Context::collectHeap`, skip `stringHeap` mark+sweep while `track_allocations` is on, so any tag pointers into `stringHeap` stay valid for heap reports. `track_allocations` is a diagnostic mode — bounded runs — so unbounded `stringHeap` growth is acceptable.

All other `mark_comment` callers already pass C++ string literals (`"new"`, `"array"`, `"table"`, `"new [[ ]]"` …), so only these two helpers were affected.

## Test plan

- [x] `cmake --build build --config Release --target daslang` — clean build
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests` — **6543 / 6543 pass**, 0 leak lines
- [x] `cmake --build build --config Release --target test_aot` — clean build
- [x] `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — **5955 / 5955 pass**, 0 leak lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)