### PR TITLE
tutorials/cpp: add tutorial 23 — binding std::shared_ptr via Handle

### DIFF
--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -162,6 +162,7 @@ build all C++ tutorials directly against the SDK — see
    tutorials/integration_cpp_20_standalone_contexts.rst
    tutorials/integration_cpp_21_threading.rst
    tutorials/integration_cpp_22_namespace_integration.rst
+   tutorials/integration_cpp_23_handle_registry.rst
 
 .. _tutorials_macros:
 

--- a/doc/source/reference/tutorials/integration_cpp_23_handle_registry.rst
+++ b/doc/source/reference/tutorials/integration_cpp_23_handle_registry.rst
@@ -1,0 +1,285 @@
+.. _tutorial_integration_cpp_handle_registry:
+
+.. index::
+   single: Tutorial; C++ Integration; Handle Registry
+
+==========================================================
+ C++ Integration: Binding ``shared_ptr`` via ``Handle<T>``
+==========================================================
+
+This tutorial shows how to expose ``std::shared_ptr<T>``-owned C++ objects
+to daslang as value-typed handles, **without** modifying the C++ class
+to inherit ``das::ptr_ref_count``.  Topics covered:
+
+* ``das::Handle<T>`` — a 64-bit, generation-checked value handle
+* ``das::HandleRegistry<T>`` — per-T singleton that owns the live ``shared_ptr``
+* ``addHandleAnnotation<T>`` — one call registers the type plus
+  ``==``, ``!=``, ``is_alive``, and an optional destructor
+* Automatic leak-at-shutdown reporting
+* When to pick ``Handle<T>`` vs ``smart_ptr<T>``
+
+This is the pattern used by ``modules/dasHV`` for ``WebSocketClient``,
+``WebSocketServer``, ``HttpServer`` and similar types whose ownership
+lives inside libhv.
+
+
+Prerequisites
+=============
+
+* Tutorial 11 — :ref:`tutorial_integration_cpp_context_variables`.
+* Tutorial 12 — :ref:`tutorial_integration_cpp_smart_pointers` — read it
+  first to see the intrusive-refcount alternative, then decide which
+  pattern fits your C++ type.
+
+
+When to use ``Handle<T>`` vs ``smart_ptr<T>``
+=============================================
+
++------------------------------------+---------------------------------+--------------------------------+
+| Question                           | ``smart_ptr<T>`` (Tutorial 12)  | ``Handle<T>`` (this tutorial)  |
++====================================+=================================+================================+
+| Can I modify the C++ class?        | yes — inherit ``ptr_ref_count`` | no — use ``shared_ptr`` as-is  |
++------------------------------------+---------------------------------+--------------------------------+
+| Ownership primarily lives in…      | daslang                         | C++ engine                     |
++------------------------------------+---------------------------------+--------------------------------+
+| Script-side cost per copy          | refcount bump                   | 64-bit value copy              |
++------------------------------------+---------------------------------+--------------------------------+
+| Use-after-free safety              | refcount (lifetime)             | generation check               |
++------------------------------------+---------------------------------+--------------------------------+
+| Registry thread safety             | n/a                             | yes — mutex inside registry    |
++------------------------------------+---------------------------------+--------------------------------+
+| Requires ``var inscope`` in script | yes                             | no — plain ``var h = …``       |
++------------------------------------+---------------------------------+--------------------------------+
+
+
+Defining the C++ type
+=====================
+
+``Actor`` is a plain ``struct`` — no base class, no refcount:
+
+.. code-block:: cpp
+
+   struct Actor {
+       std::string name;
+       float       x = 0.f, y = 0.f;
+       int32_t     health = 100;
+       explicit Actor(const char * n) : name(n ? n : "unnamed") { }
+       ~Actor() { }
+       void move(float dx, float dy)   { x += dx; y += dy; }
+       void take_damage(int32_t dmg)   { health -= dmg; if (health < 0) health = 0; }
+       bool is_dead() const            { return health <= 0; }
+   };
+
+This is the whole point of the tutorial: you do **not** need to touch
+``Actor`` to expose it to daslang.
+
+
+Declaring ``typeName<T>``
+=========================
+
+``Handle<T>`` carries a ``cast<>`` / ``typeFactory<>`` specialization
+for itself, but the leak-dump path reads the **inner** type name via
+``typeName<T>::name()``.  Provide it at file scope:
+
+.. code-block:: cpp
+
+   MAKE_TYPE_FACTORY(Actor, Actor)
+
+(In dasHV the equivalent line is
+``MAKE_EXTERNAL_TYPE_FACTORY(WebSocketClient, hv::WebSocketClient)`` in
+``dasHV.h`` + ``IMPLEMENT_EXTERNAL_TYPE_FACTORY(...)`` in ``dasHV.cpp``
+— use the external variant only if the declaration has to cross a
+header/translation-unit boundary.)
+
+
+``addHandleAnnotation<T>``
+==========================
+
+.. code-block:: cpp
+
+   #include "daScript/misc/handle_registry.h"   // Handle, HandleRegistry
+   #include "daScript/ast/ast_handle.h"         // addHandleAnnotation
+
+   addHandleAnnotation<Actor>(this, lib, "Actor",
+       "destroy_actor",              // optional — daslang destructor name
+       "das::Handle<Actor>");        // name AOT emits into generated C++
+
+One call registers:
+
++--------------------------+--------------------------------------------------+
+| ``Actor`` annotation     | ``ManagedHandleAnnotation<Actor>`` —             |
+|                          | a value annotation wrapping ``Handle<Actor>``    |
++--------------------------+--------------------------------------------------+
+| ``==`` / ``!=``          | structural comparison of the 64-bit value        |
++--------------------------+--------------------------------------------------+
+| ``is_alive``             | generation-checked validity probe                |
++--------------------------+--------------------------------------------------+
+| ``destroy_actor``        | only if ``destroyFnName`` (the argument after    |
+|                          | the type name) is non-empty — calls              |
+|                          | ``HandleRegistry<Actor>::release(h)``            |
++--------------------------+--------------------------------------------------+
+| leak-dump hook           | wired automatically via                          |
+|                          | ``handleRegistry_registerDump<Actor>``           |
++--------------------------+--------------------------------------------------+
+
+
+Factory — ``acquire``
+=====================
+
+The factory creates a fresh ``shared_ptr`` and hands it to the registry:
+
+.. code-block:: cpp
+
+   static Handle<Actor> make_actor(const char * name, float x, float y) {
+       auto sp = std::make_shared<Actor>(name);
+       sp->x = x;
+       sp->y = y;
+       return HandleRegistry<Actor>::instance().acquire(sp);
+   }
+
+``HandleRegistry<T>::instance()`` is a per-``T`` singleton; every module
+and DLL that references ``HandleRegistry<Actor>`` sees the same storage.
+
+
+Method — ``lookup`` + null-check
+================================
+
+Bound "methods" are free functions that take ``Handle<Actor>`` by value
+and resolve it through ``lookup``:
+
+.. code-block:: cpp
+
+   static void actor_move(Handle<Actor> h, float dx, float dy) {
+       if ( auto p = HandleRegistry<Actor>::instance().lookup(h) )
+           p->move(dx, dy);
+   }
+
+``lookup`` returns an empty ``shared_ptr`` for null, stale, or
+slot-reused handles — the null-check is a guaranteed
+use-after-free guard.
+
+.. warning::
+
+   ``Handle<T>`` is passed **by value**, so a bound function that
+   mutates the underlying object cannot use
+   ``SideEffects::modifyArgument`` (which requires a non-const
+   reference argument — you will get ``can't add function ... modify
+   argument requires non-const ref argument`` at module registration).
+   Use ``SideEffects::modifyExternal`` instead: the handle itself is
+   not modified, the external state behind it is.
+
+
+Explicit destroy and ``is_alive``
+=================================
+
+The daslang name passed as ``destroyFnName`` becomes a script-callable
+destructor that unregisters the handle:
+
+.. code-block:: das
+
+   var goblin = make_actor("Goblin", 10.0, 5.0)
+   destroy_actor(goblin)
+   assert(!is_alive(goblin))
+
+``destroy_actor`` does **not** necessarily destroy the ``Actor`` — it
+releases only the registry's ``shared_ptr``.  If your engine holds
+another ``shared_ptr``, the object survives until the engine drops it.
+
+.. warning::
+
+   ``Handle<T>`` has **no scope-based auto-release** — unlike
+   ``smart_ptr<T>`` (Tutorial 12), going out of scope does nothing.
+   Every handle the script acquired via a factory must be explicitly
+   destroyed (or handed off to the engine for release), or it will
+   leak and the runtime will print a ``Handle<T> idx=... (rc=...)``
+   line at shutdown.
+
+
+Leak dump at shutdown
+=====================
+
+``addHandleAnnotation`` calls ``handleRegistry_registerDump<T>`` once,
+registering a per-``T`` dump callback.  ``Module::Shutdown(bool
+dumpHandleLeaks = true)`` calls ``handleRegistry_dumpAll()`` directly
+and the runtime prints any live handles:
+
+.. code-block:: text
+
+   Handle<Actor> idx=3 gen=1 (rc=1)
+   total 1 leaked handles of type Actor
+
+The tutorial script is designed to end with zero leaked handles — if
+you see output above, the script is holding a live handle past shutdown.
+
+
+AOT compatibility
+=================
+
+``Handle<T>`` is value-typed via a ``cast<Handle<T>>`` specialization
+in ``ast_handle.h`` that maps directly to ``uint64_t``.  AOT-generated
+C++ passes the handle in a raw register — no boxing, no allocations.
+
+The ``cppTypeName`` argument to ``addHandleAnnotation``
+(``"das::Handle<Actor>"`` above) is the string AOT writes into the
+generated stub, so the emitted C++ compiles against the same header
+your module uses.
+
+
+Building and running
+====================
+
+::
+
+   cmake --build build --config Release --target integration_cpp_23
+   bin\Release\integration_cpp_23.exe
+
+Expected output::
+
+   === Create actors ===
+     [C++] Actor('Hero') constructed
+     [C++] Actor('Goblin') constructed
+   hero:   Hero hp=100 alive=true
+   goblin: Goblin hp=100 alive=true
+
+   === Value semantics ===
+   hero == hero_copy : true
+   hero == goblin    : false
+
+   === Combat ===
+   hero hp = 100
+   goblin hp after 30 damage = 70
+   goblin hp after lethal    = 0  is_dead=true
+
+   === Explicit destroy ===
+   is_alive(goblin) before destroy = true
+     [C++] Actor('Goblin') destroyed
+   is_alive(goblin) after  destroy = false
+   dead goblin.health = 0
+   dead goblin.name   = ''
+
+   === Engine-owned lifetime ===
+     [C++] Actor('Shopkeeper') constructed
+   after destroy: is_alive(npc) = false
+     [C++] Actor('Hero') destroyed
+
+   === End of test — expect zero leak-dump output below ===
+     [C++] Actor('Shopkeeper') destroyed
+
+Observe: Goblin and Hero die when ``destroy_actor`` drops the
+registry's last ``shared_ptr``.  Shopkeeper's destructor runs *after*
+the "End of test" line — that is the engine dropping its vector in
+``main`` after ``Module::Shutdown``, proving that registry release
+and engine ownership are independent.  The key property is **zero**
+``Handle<Actor> idx=…`` leak lines.
+
+
+.. seealso::
+
+   Full source:
+   :download:`23_handle_registry.cpp <../../../../tutorials/integration/cpp/23_handle_registry.cpp>`,
+   :download:`23_handle_registry.das <../../../../tutorials/integration/cpp/23_handle_registry.das>`
+
+   Previous tutorial: :ref:`tutorial_integration_cpp_namespace_integration`
+
+   Compare with the intrusive-refcount pattern:
+   :ref:`tutorial_integration_cpp_smart_pointers`

--- a/skills/cpp_integration.md
+++ b/skills/cpp_integration.md
@@ -143,6 +143,67 @@ addExtern<DAS_CALL_METHOD(method_get)>(*this, lib, "get",
 - **Const methods**: `SideEffects::none`
 - `DAS_CALL_MEMBER_CPP(Class::method)` provides the AOT-compatible name string
 
+## Binding `std::shared_ptr<T>` — `Handle<T>` + `HandleRegistry`
+
+Use this pattern when the C++ type is already owned by `std::shared_ptr` and you cannot or do not want to retrofit `ptr_ref_count`. This is how `modules/dasHV` exposes `WebSocketClient`, `WebSocketServer`, `HttpServer`, etc. See `tutorials/integration/cpp/23_handle_registry.cpp` for a self-contained example.
+
+**Headers:**
+```cpp
+#include "daScript/misc/handle_registry.h"   // Handle<T>, HandleRegistry<T>
+#include "daScript/ast/ast_handle.h"         // ManagedHandleAnnotation, addHandleAnnotation, cast<Handle<T>>
+```
+
+**File-scope `typeName<T>` — REQUIRED.** The leak-dump path reads `typeName<T>::name()` on the inner type. Without this you get `error C2027: use of undefined type 'das::typeName<T>'` at the `addHandleAnnotation` call site. Use `MAKE_TYPE_FACTORY(MyType, MyType)` for single-TU types, or `MAKE_EXTERNAL_TYPE_FACTORY` / `IMPLEMENT_EXTERNAL_TYPE_FACTORY` when split across header/cpp (dasHV uses the external pair).
+
+**One-call registration:**
+```cpp
+MAKE_TYPE_FACTORY(MyType, MyType)     // at file scope
+
+addHandleAnnotation<MyType>(this, lib, "MyType",
+    "destroy_my_type",                // optional daslang destructor
+    "das::Handle<MyType>");           // C++ name AOT emits into stubs
+```
+Registers the annotation **plus** `==`, `!=`, `is_alive`, and (if `destroyFnName` is non-empty) the release helper. Also installs a per-T leak-dump hook via `handleRegistry_registerDump` — `Module::Shutdown(bool dumpHandleLeaks = true)` calls `handleRegistry_dumpAll()` directly; pass `false` to suppress leak output (CI use).
+
+**Factory (acquire) and method (lookup) patterns:**
+```cpp
+Handle<MyType> make_my_type(const char * n) {
+    auto sp = std::make_shared<MyType>(n);
+    return HandleRegistry<MyType>::instance().acquire(sp);
+}
+int my_type_do_thing(Handle<MyType> h, int arg) {
+    auto p = HandleRegistry<MyType>::instance().lookup(h);
+    if ( !p ) return -1;                       // stale / reused / null handle
+    return p->do_thing(arg);
+}
+```
+`lookup` returns an empty `shared_ptr` for null, stale, or slot-reused handles — the null-check is a **guaranteed** use-after-free guard (generation-checked).
+
+**`HandleRegistry<T>::instance()`** is a per-`T` singleton shared across `daslang.exe` and every `dasModule*.shared_module` DLL — all modules see the same storage. The registry is thread-safe (internal `mutex`).
+
+**`SideEffects` for bound methods — use `modifyExternal`, NOT `modifyArgument`.** `Handle<T>` is passed by value, so `modifyArgument` is rejected at module-registration time (`can't add function ... modify argument requires non-const ref argument`). The handle itself isn't mutated — the Actor/connection/whatever behind it is, which is external state.
+
+**Script side — Handle<T> is a value, not a smart_ptr:**
+- No `var inscope` required — plain `var h = make_my_type(...)`.
+- `==`, `!=`, `is_alive(h)` all work directly.
+- `destroy_my_type(h)` releases **only** the registry's `shared_ptr` — if another owner (your engine) holds a ref, the object survives; the handle becomes dead (`is_alive` → `false`).
+- **No scope-based auto-release** — unlike `smart_ptr<T>`, a handle going out of scope does nothing. Every script-acquired handle must be explicitly destroyed, or it leaks and gets printed at shutdown.
+
+**AOT:** no extra work. `cast<Handle<T>>` in `ast_handle.h` maps directly to `uint64_t`; AOT emits raw register passes. The `cppTypeName` argument is what AOT writes into the generated `.cpp`.
+
+**Leak dump at shutdown:** registered automatically. Use `--no-dump-leaks` on the daslang CLI for CI runs that intentionally exit with live handles.
+
+**When to pick which pattern:**
+
+| | `smart_ptr<T>` (Tutorial 12) | `Handle<T>` (Tutorial 23) |
+|---|---|---|
+| C++ class | must inherit `ptr_ref_count` | unchanged |
+| Primary owner | daslang | C++ engine |
+| Per-copy cost | refcount bump | 64-bit value copy |
+| UAF safety | refcount | generation check |
+| Thread-safe registry | n/a | yes |
+| Script-side syntax | `var inscope p <- ...` | `var h = ...` |
+
 ## Binding operators and properties
 
 **Operators**: register functions with the operator symbol as the daslang name:

--- a/tutorials/integration/cpp/23_handle_registry.cpp
+++ b/tutorials/integration/cpp/23_handle_registry.cpp
@@ -1,0 +1,237 @@
+// Tutorial 23 — Binding C++ std::shared_ptr via Handle<T>
+//
+// Companion to Tutorial 12 (smart pointers). Where tutorial 12 requires
+// the C++ type to inherit das::ptr_ref_count (intrusive refcount),
+// this tutorial shows the alternative pattern used when the C++ type
+// already uses std::shared_ptr and cannot — or should not — be retrofitted.
+//
+//   - std::shared_ptr<T> ownership stays on the C++ side.
+//   - HandleRegistry<T>::instance() holds the live shared_ptr.
+//   - Scripts see Handle<T> — a 64-bit value encoding
+//       (generation << 32) | (index + 1).
+//   - addHandleAnnotation<T>() registers the type plus ==, !=, is_alive,
+//     and an optional destroy function.
+//   - handleRegistry_registerDump (called from inside addHandleAnnotation)
+//     wires up leak-at-shutdown reporting automatically.
+//
+// The same pattern powers dasHV (WebSocketClient / WebSocketServer /
+// HttpServer) in modules/dasHV. This tutorial reproduces the mechanics
+// with a self-contained toy type (Actor) — no external dependencies.
+
+#include "daScript/daScript.h"
+#include "daScript/ast/ast_interop.h"
+#include "daScript/ast/ast_handle.h"           // ManagedHandleAnnotation, addHandleAnnotation, cast<Handle<T>>
+#include "daScript/misc/handle_registry.h"     // Handle<T>, HandleRegistry<T>
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace das;
+
+// -----------------------------------------------------------------------
+// The C++ type — plain std::shared_ptr ownership, NO ptr_ref_count.
+// This is the whole point of the tutorial: you do NOT need to touch
+// the class to expose it.
+// -----------------------------------------------------------------------
+
+struct Actor {
+    std::string name;
+    float       x      = 0.f;
+    float       y      = 0.f;
+    int32_t     health = 100;
+
+    explicit Actor(const char * n) : name(n ? n : "unnamed") {
+        printf("  [C++] Actor('%s') constructed\n", name.c_str());
+    }
+    ~Actor() {
+        printf("  [C++] Actor('%s') destroyed\n", name.c_str());
+    }
+
+    void    move(float dx, float dy)   { x += dx; y += dy; }
+    void    take_damage(int32_t dmg)   { health -= dmg; if (health < 0) health = 0; }
+    bool    is_dead() const            { return health <= 0; }
+};
+
+// Provide typeName<Actor>::name() — dumpHandleLeaks<T> uses it to label
+// leak output, and typeFactory<Handle<Actor>>::make() uses it to build
+// the daslang type. MAKE_TYPE_FACTORY also defines typeFactory<Actor>,
+// but that specialization is unused here because Handle<T> has its own
+// typeFactory in ast_handle.h.
+MAKE_TYPE_FACTORY(Actor, Actor)
+
+// -----------------------------------------------------------------------
+// Factory — make_shared on the engine side, then hand out a handle.
+// -----------------------------------------------------------------------
+
+static Handle<Actor> make_actor(const char * name, float x, float y) {
+    auto sp = std::make_shared<Actor>(name);
+    sp->x = x;
+    sp->y = y;
+    return HandleRegistry<Actor>::instance().acquire(sp);
+}
+
+// -----------------------------------------------------------------------
+// Bound "methods" — take Handle<Actor> by value, lookup() to resolve.
+// lookup() returns an empty shared_ptr for null, stale, or reused handles;
+// always null-check the result.
+// -----------------------------------------------------------------------
+
+static void actor_move(Handle<Actor> h, float dx, float dy) {
+    if ( auto p = HandleRegistry<Actor>::instance().lookup(h) ) {
+        p->move(dx, dy);
+    }
+}
+
+static void actor_take_damage(Handle<Actor> h, int32_t dmg) {
+    if ( auto p = HandleRegistry<Actor>::instance().lookup(h) ) {
+        p->take_damage(dmg);
+    }
+}
+
+static int32_t actor_health(Handle<Actor> h) {
+    if ( auto p = HandleRegistry<Actor>::instance().lookup(h) ) return p->health;
+    return 0;
+}
+
+static bool actor_is_dead(Handle<Actor> h) {
+    auto p = HandleRegistry<Actor>::instance().lookup(h);
+    return !p || p->is_dead();
+}
+
+static const char * actor_name(Handle<Actor> h) {
+    auto p = HandleRegistry<Actor>::instance().lookup(h);
+    return p ? p->name.c_str() : "";
+}
+
+// Engine-owned actor — the engine keeps its own shared_ptr so the object
+// outlives the script-side handle. Demonstrates that release(h) only drops
+// the registry's copy; the Actor is destroyed when the LAST shared_ptr
+// (engine's or registry's) goes away.
+static std::vector<std::shared_ptr<Actor>> g_engine_actors;
+
+static Handle<Actor> engine_register(const char * name) {
+    auto sp = std::make_shared<Actor>(name);
+    g_engine_actors.push_back(sp);
+    return HandleRegistry<Actor>::instance().acquire(sp);
+}
+
+// -----------------------------------------------------------------------
+// Module
+// -----------------------------------------------------------------------
+
+class Module_Tutorial23 : public Module {
+public:
+    Module_Tutorial23() : Module("tutorial_23_cpp") {
+        ModuleLibrary lib(this);
+        lib.addBuiltInModule();
+
+        // Register the handle type. addHandleAnnotation also registers
+        //   ==, !=, is_alive, and (because destroyFnName is non-empty)
+        //   destroy_actor. A per-T leak-dump hook is installed so the
+        //   runtime prints any live handles at Module::Shutdown().
+        //
+        //   name          = "Actor"              — daslang type name
+        //   destroyFnName = "destroy_actor"      — daslang release()
+        //   cppTypeName   = "das::Handle<Actor>" — what AOT writes into
+        //                                          generated C++ stubs
+        addHandleAnnotation<Actor>(this, lib, "Actor",
+            "destroy_actor", "das::Handle<Actor>");
+
+        addExtern<DAS_BIND_FUN(make_actor)>(*this, lib, "make_actor",
+            SideEffects::modifyExternal, "make_actor")
+                ->args({"name","x","y"});
+
+        // Handle<Actor> is a value type — the handle itself isn't mutated,
+        // the Actor behind it (in the registry) is. That's modifyExternal,
+        // NOT modifyArgument (which requires a non-const reference arg).
+        addExtern<DAS_BIND_FUN(actor_move)>(*this, lib, "move_actor",
+            SideEffects::modifyExternal, "actor_move")
+                ->args({"actor","dx","dy"});
+
+        addExtern<DAS_BIND_FUN(actor_take_damage)>(*this, lib, "take_damage",
+            SideEffects::modifyExternal, "actor_take_damage")
+                ->args({"actor","amount"});
+
+        addExtern<DAS_BIND_FUN(actor_health)>(*this, lib, "health",
+            SideEffects::accessExternal, "actor_health")
+                ->args({"actor"});
+
+        addExtern<DAS_BIND_FUN(actor_is_dead)>(*this, lib, "is_dead",
+            SideEffects::accessExternal, "actor_is_dead")
+                ->args({"actor"});
+
+        addExtern<DAS_BIND_FUN(actor_name)>(*this, lib, "name_of",
+            SideEffects::accessExternal, "actor_name")
+                ->args({"actor"});
+
+        addExtern<DAS_BIND_FUN(engine_register)>(*this, lib, "engine_register",
+            SideEffects::modifyExternal, "engine_register")
+                ->args({"name"});
+    }
+};
+
+REGISTER_MODULE(Module_Tutorial23);
+
+// -----------------------------------------------------------------------
+// Host program
+// -----------------------------------------------------------------------
+
+#define SCRIPT_NAME "/tutorials/integration/cpp/23_handle_registry.das"
+
+void tutorial() {
+    TextPrinter tout;
+    ModuleGroup dummyLibGroup;
+    auto fAccess = make_smart<FsFileAccess>();
+
+    auto program = compileDaScript(getDasRoot() + SCRIPT_NAME,
+                                   fAccess, tout, dummyLibGroup);
+    if ( program->failed() ) {
+        tout << "Compilation failed:\n";
+        for ( auto & err : program->errors ) {
+            tout << reportError(err.at, err.what, err.extra,
+                                err.fixme, err.cerr);
+        }
+        return;
+    }
+
+    Context ctx(program->getContextStackSize());
+    if ( !program->simulate(ctx, tout) ) {
+        tout << "Simulation failed:\n";
+        for ( auto & err : program->errors ) {
+            tout << reportError(err.at, err.what, err.extra,
+                                err.fixme, err.cerr);
+        }
+        return;
+    }
+
+    auto fnTest = ctx.findFunction("test");
+    if ( !fnTest ) {
+        tout << "Function 'test' not found\n";
+        return;
+    }
+
+    ctx.evalWithCatch(fnTest, nullptr);
+    if ( auto ex = ctx.getException() ) {
+        tout << "Exception: " << ex << "\n";
+    }
+}
+
+int main(int, char * []) {
+    NEED_ALL_DEFAULT_MODULES;
+    NEED_MODULE(Module_Tutorial23);
+    Module::Initialize();
+    tutorial();
+    // Module::Shutdown(bool dumpHandleLeaks = true) calls
+    // handleRegistry_dumpAll() directly; pass false to suppress the dump
+    // (useful in CI runs that exit with known-live handles). Any live
+    // Handle<Actor> would be printed there — this tutorial is designed
+    // to end with zero leak output.
+    Module::Shutdown();
+    // Engine drops its own shared_ptrs last, so the Shopkeeper destructor
+    // runs after the registry dump — proving the two lifetimes are
+    // independent.
+    g_engine_actors.clear();
+    return 0;
+}

--- a/tutorials/integration/cpp/23_handle_registry.das
+++ b/tutorials/integration/cpp/23_handle_registry.das
@@ -1,0 +1,61 @@
+options gen2
+
+// Companion script for Tutorial 23 — Binding C++ std::shared_ptr via Handle<T>.
+//
+// Handle<Actor> is a value type (64-bit). No `var inscope` needed —
+// copies are cheap, equality is structural, and `is_alive` reports
+// whether the underlying shared_ptr is still registered.
+
+require tutorial_23_cpp
+
+[export]
+def test() {
+    // --- Factory ---
+    print("=== Create actors ===\n")
+    var hero   = make_actor("Hero",   0.0, 0.0)
+    var goblin = make_actor("Goblin", 10.0, 5.0)
+    print("hero:   {name_of(hero)} hp={health(hero)} alive={!is_dead(hero)}\n")
+    print("goblin: {name_of(goblin)} hp={health(goblin)} alive={!is_dead(goblin)}\n")
+
+    // --- Handles are values — cheap copies, structural equality ---
+    print("\n=== Value semantics ===\n")
+    var hero_copy = hero
+    print("hero == hero_copy : {hero == hero_copy}\n")
+    print("hero == goblin    : {hero == goblin}\n")
+
+    // --- Methods: the C++ side calls lookup() + null-check ---
+    print("\n=== Combat ===\n")
+    move_actor(hero, 3.0, 4.0)
+    take_damage(goblin, 30)
+    print("hero hp = {health(hero)}\n")
+    print("goblin hp after 30 damage = {health(goblin)}\n")
+
+    take_damage(goblin, 200)
+    print("goblin hp after lethal    = {health(goblin)}  is_dead={is_dead(goblin)}\n")
+
+    // --- Explicit destroy — release() on the registry ---
+    print("\n=== Explicit destroy ===\n")
+    print("is_alive(goblin) before destroy = {is_alive(goblin)}\n")
+    destroy_actor(goblin)
+    print("is_alive(goblin) after  destroy = {is_alive(goblin)}\n")
+
+    // Calls through a dead handle are no-ops / return defaults.
+    print("dead goblin.health = {health(goblin)}\n")
+    print("dead goblin.name   = '{name_of(goblin)}'\n")
+
+    // --- Engine-owned actor: registry releases, engine keeps the object ---
+    print("\n=== Engine-owned lifetime ===\n")
+    var npc = engine_register("Shopkeeper")
+    destroy_actor(npc)
+    print("after destroy: is_alive(npc) = {is_alive(npc)}\n")
+    // Shopkeeper's destructor runs later, when the engine drops its vector.
+
+    // --- Explicit lifetime: Handle<T> does NOT auto-release ---
+    // Unlike smart_ptr<T> (Tutorial 12), Handle<T> is a value type with
+    // no scope-based release. Any handle the script acquired via a
+    // factory must be explicitly destroyed, or it leaks — the runtime
+    // will print `Handle<Actor> idx=... (rc=1)` at shutdown.
+    destroy_actor(hero)              // also covers hero_copy (same value)
+
+    print("\n=== End of test — expect zero leak-dump output below ===\n")
+}

--- a/tutorials/integration/cpp/CMakeLists.txt
+++ b/tutorials/integration/cpp/CMakeLists.txt
@@ -198,6 +198,13 @@ DAS_CPP_INTEGRATION_TUTORIAL(integration_cpp_22
     ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/integration/cpp/22_namespace_integration.cpp
 )
 
+#################################
+# Tutorial 23 — Handle Registry (binding std::shared_ptr)
+#################################
+DAS_CPP_INTEGRATION_TUTORIAL(integration_cpp_23
+    ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/integration/cpp/23_handle_registry.cpp
+)
+
 # Install C++ integration tutorial source files
 file(GLOB CPP_INTEGRATION_TUTORIAL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/integration/cpp/*.cpp


### PR DESCRIPTION
## Summary

Adds **Tutorial 23 — Binding `std::shared_ptr` via `Handle<T>`** to the
C++ integration series. Tutorial 12 covers the intrusive `ptr_ref_count`
+ `smart_ptr<T>` pattern; this tutorial covers the alternative value-typed
`Handle<T>` + per-T `HandleRegistry<T>` pattern (PR #2450) used by dasHV
when the C++ type is already owned by `std::shared_ptr` and cannot /
should not be retrofitted.

Example is a self-contained `Actor` — no `ptr_ref_count` base, no external
deps. The `.das` companion exercises:
- factory (`acquire`) and method (`lookup` + null-check) patterns
- value semantics — `var h = …` (no `inscope`), structural `==`
- explicit `destroy_actor` via the `destroyFnName` argument
- `is_alive` generation check (use-after-free probe)
- engine-retained `shared_ptr` surviving handle release
- zero-leak shutdown (verified — tutorial ends with no `Handle<Actor> idx=…` lines)

Docs:
- new RST page `doc/source/reference/tutorials/integration_cpp_23_handle_registry.rst`
- toctree entry in `doc/source/reference/tutorials.rst`
- extends `skills/cpp_integration.md` with a **Binding `std::shared_ptr<T>` — `Handle<T>` + `HandleRegistry`** section covering two traps hit while writing the tutorial:
  1. `MAKE_TYPE_FACTORY(T, T)` at file scope is required — `dumpHandleLeaks<T>` reads `typeName<T>::name()` and you get `C2027: use of undefined type 'das::typeName<T>'` without it
  2. bound mutating methods on `Handle<T>` must use `SideEffects::modifyExternal`, not `modifyArgument` (which requires a non-const reference — registration fails otherwise)

## Test plan

- [x] Tutorial binary builds (`cmake --build build --config Release --target integration_cpp_23`)
- [x] Tutorial runs with exit 0, output matches RST expected block, zero leak-dump lines
- [x] Full test suite: 6543/6543 passed, 0 failed, 0 errors
- [x] AOT test suite: 5955/5955 passed, 0 failed, 0 errors
- [x] Clean Sphinx build: `build succeeded`, zero warnings
- [x] `daslib/das_source_formatter` clean on the new `.das` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)