### PR TITLE
daslang: lint: LINT006-009 follow-up — tests, docs, daslib cleanup

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -2584,8 +2584,6 @@ class public CppAot : AstVisitor {
             if (length(expr.fields) == 1) {
                 if (expr._type.baseType != Type.tFloat) write(*ss, ")");
                 write(*ss, ")");
-            } elif (isSequencialMask(expr.fields)) {
-                write(*ss, ")");
             } else {
                 write(*ss, ")");
             }
@@ -3295,8 +3293,6 @@ class public CppAot : AstVisitor {
         if (!last) {
             if (call.name == "debug") {
                 write(*ss, "),(");
-            } elif (call.name == "assert" || call.name == "verify") {
-                write(*ss, ",");
             } else {
                 write(*ss, ",");
             }

--- a/daslib/ast_boost.das
+++ b/daslib/ast_boost.das
@@ -1278,8 +1278,6 @@ def private debug_expression_impl(var writer : StringBuilderWriter; expr : Expre
             } elif (tstr == "bool") {
                 let pv = unsafe(reinterpret<bool?> p8)
                 writer |> write(" {name}={*pv}")
-            } elif (tstr == "$::dasvector`ptr`Expression") {
-                pass
             } else {
                 pass
             }

--- a/daslib/ast_print.das
+++ b/daslib/ast_print.das
@@ -545,11 +545,7 @@ class PrintVisitor : AstVisitor {
     }
     def override preVisitExprIfThenElseElseBlock(expr : ExprIfThenElse?; elseBlock : ExpressionPtr) {
         //! Prints the 'else' keyword before the else block.
-        if (elseBlock.__rtti == "ExprIfThenElse") {
-            write(*writer, " else ");
-        } else {
-            write(*writer, " else ");
-        }
+        write(*writer, " else ");
     }
 // for
     def override preVisitExprFor(expr : ExprFor?) {

--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -269,6 +269,9 @@ class LintVisitor : AstVisitor {
         if (require_pure && (!a.flags.noSideEffects || !b.flags.noSideEffects)) {
             return false
         }
+        // daslang AST nodes are not shared — each Expression has exactly one parent, so
+        // pointer-equality between sibling operands (left vs right) is effectively never
+        // true. Structural compare via describe() is the only correct option here.
         return describe(a) == describe(b)
     }
 

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -177,6 +177,101 @@ skips generic instantiations and compiler-generated functions.
     // Good — strips const (not flagged)
     var y = unsafe(reinterpret<int?>(const_ptr))
 
+LINT006 — division by zero (constant zero divisor)
+====================================================
+
+``x / 0`` and ``x % 0`` produce a runtime panic (integer) or ``inf`` / ``nan``
+(float). When the right-hand side is a literal zero, this is almost always a
+typo. Also covers the compound forms ``/=`` and ``%=``. Recognizes literal zero
+across ``int``, ``uint``, ``int64``, ``uint64``, ``float``, and ``double``.
+
+.. code-block:: das
+
+    // Bad
+    let y = x / 0                           // LINT006
+    x %= 0                                  // LINT006
+
+    // Good
+    let y = x / divisor
+
+LINT007 — identical left and right operands
+=============================================
+
+Both sides of a binary operator are the same expression. The result is trivial
+(``x == x`` is always true, ``x - x`` is always 0, ``x && x`` is just ``x``)
+and the code is almost always a copy-paste typo. Triggers on: ``==``, ``!=``,
+``<``, ``>``, ``<=``, ``>=``, ``-``, ``/``, ``%``, ``&&``, ``||``, ``&``,
+``|``, ``^``, ``-=``, ``/=``, ``%=``.
+
+.. code-block:: das
+
+    // Bad — author meant `size == capacity` or similar
+    if (size == size) { ... }               // LINT007
+
+    // Good
+    if (size == capacity) { ... }
+
+Operators like ``+`` and ``*`` are deliberately excluded: ``x + x`` is the
+common way to double a value and ``x * x`` is squaring, both of which are
+intentional.
+
+**NaN idiom.** ``x != x`` on ``float`` or ``double`` is the canonical IEEE 754
+NaN check — daslang has no dedicated ``is_nan`` helper for scalar floats.
+Suppress LINT007 on the one line that needs it:
+
+.. code-block:: das
+
+    def is_nan(x : float) : bool {
+        return x != x // nolint:LINT007 — canonical IEEE 754 NaN check
+    }
+
+**Note on constant folding.** The paranoid lint runs after optimization.
+``let x = 1; x == x`` is folded to ``true`` before lint sees it and will not
+fire. LINT007 catches cases where operands are runtime values (function
+parameters, field reads, function calls).
+
+Structural equality uses the expression pretty-printer: ``describe(left) ==
+describe(right)``. This catches both ``x`` vs ``x`` and ``a.b.c`` vs ``a.b.c``,
+at the cost of serializing both subtrees. Pointer-identity is not used as a
+fast path because daslang AST nodes are not shared — each ``Expression`` has
+exactly one parent, so sibling operands are always distinct nodes.
+
+LINT008 — both ternary branches equivalent
+============================================
+
+``cond ? x : x`` ignores ``cond`` and always produces ``x``. Copy-paste bug.
+
+.. code-block:: das
+
+    // Bad
+    let y = cond ? value : value            // LINT008
+
+    // Good
+    let y = cond ? then_value : else_value
+
+LINT009 — ``then`` branch equivalent to ``else`` branch
+=========================================================
+
+``if (c) { A } else { A }`` runs ``A`` regardless of ``c``. Usually the author
+copy-pasted one branch and forgot to edit the other. Caught even when ``A``
+has side effects — the structural pattern is suspicious regardless of purity.
+
+.. code-block:: das
+
+    // Bad
+    if (flag) {
+        x = 1                               // LINT009
+    } else {
+        x = 1
+    }
+
+    // Good
+    if (flag) {
+        x = 1
+    } else {
+        x = 2
+    }
+
 .. _perf_lint:
 
 -----------------

--- a/utils/lint/tests/lint006_division_by_zero.das
+++ b/utils/lint/tests/lint006_division_by_zero.das
@@ -1,0 +1,80 @@
+options gen2
+// LINT006: Division by zero (constant zero divisor)
+//
+// Problem:
+//   `x / 0` and `x % 0` produce a runtime panic or undefined division.
+//   When the right-hand side is a literal zero, this is almost always a typo.
+//
+// Bad pattern:
+//   let y = x / 0
+//
+// Good pattern:
+//   let y = x / divisor
+
+expect 40104:10
+
+require daslib/lint
+
+// --- Bad: division or modulo by literal zero across supported const types ---
+
+def bad_div_int(x : int) : int {
+    return x / 0                                    // LINT006
+}
+
+def bad_div_uint(x : uint) : uint {
+    return x / 0u                                   // LINT006
+}
+
+def bad_div_int64(x : int64) : int64 {
+    return x / 0l                                   // LINT006
+}
+
+def bad_div_uint64(x : uint64) : uint64 {
+    return x / 0ul                                  // LINT006
+}
+
+def bad_div_float(x : float) : float {
+    return x / 0.0f                                 // LINT006
+}
+
+def bad_div_double(x : double) : double {
+    return x / 0.0lf                                // LINT006
+}
+
+def bad_mod_int(x : int) : int {
+    return x % 0                                    // LINT006
+}
+
+def bad_mod_uint(x : uint) : uint {
+    return x % 0u                                   // LINT006
+}
+
+def bad_div_assign(x : int) : int {
+    var y = x
+    y /= 0                                          // LINT006
+    return y
+}
+
+def bad_mod_assign(x : int) : int {
+    var y = x
+    y %= 0                                          // LINT006
+    return y
+}
+
+// --- Good: non-zero constant or variable divisor ---
+
+def good_const_divisor(x : int) : int {
+    return x / 7
+}
+
+def good_var_divisor(x : int; y : int) : int {
+    return x / y
+}
+
+def good_modulo(x : int) : int {
+    return x % 10
+}
+
+def good_float_nonzero(x : float) : float {
+    return x / 2.0f
+}

--- a/utils/lint/tests/lint007_same_operands.das
+++ b/utils/lint/tests/lint007_same_operands.das
@@ -1,0 +1,123 @@
+options gen2
+// LINT007: Left and right operands of binary operator are identical
+//
+// Problem:
+//   `x op x` where both sides are the same expression produces a trivial
+//   result: `x == x` is always true, `x - x` is always 0, `x && x` is just x.
+//   Almost always a typo — the author meant `x op y`.
+//
+// Bad pattern:
+//   if (size == size) { ... }          // meant `size == capacity` or similar
+//
+// Good pattern:
+//   if (size == capacity) { ... }
+//
+// NaN idiom (rare, legitimate):
+//   `x != x` on float/double is the canonical IEEE 754 NaN check; daslang has
+//   no dedicated `is_nan` helper on scalar floats. Suppress on the one line
+//   that needs it with `// nolint:LINT007 — NaN check`.
+//
+// Note on constant folding:
+//   `let x = 1; x == x` is folded to `true` before lint runs and will NOT
+//   fire. LINT007 catches cases where operands are runtime values (function
+//   parameters, field reads, etc.). The fixture uses parameters on purpose.
+
+expect 40104:17
+
+require daslib/lint
+
+// --- Bad: each LINT007 operator once ---
+
+def bad_eq(x : int) : bool {
+    return x == x                                    // LINT007
+}
+
+def bad_ne(x : int) : bool {
+    return x != x                                    // LINT007
+}
+
+def bad_lt(x : int) : bool {
+    return x < x                                     // LINT007
+}
+
+def bad_gt(x : int) : bool {
+    return x > x                                     // LINT007
+}
+
+def bad_le(x : int) : bool {
+    return x <= x                                    // LINT007
+}
+
+def bad_ge(x : int) : bool {
+    return x >= x                                    // LINT007
+}
+
+def bad_sub(x : int) : int {
+    return x - x                                     // LINT007
+}
+
+def bad_div(x : int) : int {
+    return x / x                                     // LINT007
+}
+
+def bad_mod(x : int) : int {
+    return x % x                                     // LINT007
+}
+
+def bad_and_and(b : bool) : bool {
+    return b && b                                    // LINT007
+}
+
+def bad_or_or(b : bool) : bool {
+    return b || b                                    // LINT007
+}
+
+def bad_bit_and(x : uint) : uint {
+    return x & x                                     // LINT007
+}
+
+def bad_bit_or(x : uint) : uint {
+    return x | x                                     // LINT007
+}
+
+def bad_xor(x : uint) : uint {
+    return x ^ x                                     // LINT007
+}
+
+def bad_sub_assign(x : int) : int {
+    var y = x
+    y -= y                                           // LINT007
+    return y
+}
+
+def bad_div_assign(x : int) : int {
+    var y = x
+    y /= y                                           // LINT007
+    return y
+}
+
+def bad_mod_assign(x : int) : int {
+    var y = x
+    y %= y                                           // LINT007
+    return y
+}
+
+// --- Good: different operands ---
+
+def good_diff_eq(a : int; b : int) : bool {
+    return a == b
+}
+
+def good_diff_sub(a : int; b : int) : int {
+    return a - b
+}
+
+// --- Good: NaN idiom, suppressed on the one line that needs it ---
+
+def good_nan_check(x : float) : bool {
+    return x != x // nolint:LINT007 — canonical IEEE 754 NaN check
+}
+
+def good_is_not_nan(x : double) : bool {
+    return x == x // nolint:LINT007 — canonical IEEE 754 non-NaN check (true for ±inf too)
+}

--- a/utils/lint/tests/lint008_ternary_same_branches.das
+++ b/utils/lint/tests/lint008_ternary_same_branches.das
@@ -1,0 +1,44 @@
+options gen2
+// LINT008: Both branches of ternary `?:` are equivalent
+//
+// Problem:
+//   `cond ? x : x` ignores `cond` entirely and always evaluates `x` — almost
+//   always a copy-paste bug where one branch should have been something else.
+//
+// Bad pattern:
+//   return cond ? value : value
+//
+// Good pattern:
+//   return cond ? then_value : else_value
+
+expect 40104:3
+
+require daslib/lint
+
+// --- Bad: both branches identical ---
+
+def bad_same_var(cond : bool; x : int) : int {
+    return cond ? x : x                              // LINT008
+}
+
+def bad_same_expr(cond : bool; x : int; y : int) : int {
+    return cond ? (x + y) : (x + y)                  // LINT008
+}
+
+def bad_same_mul(cond : bool; x : int) : int {
+    return cond ? (x * 2) : (x * 2)                  // LINT008
+}
+
+// --- Good: branches differ ---
+
+def good_diff_values(cond : bool; x : int; y : int) : int {
+    return cond ? x : y
+}
+
+def good_neg(cond : bool; x : int) : int {
+    return cond ? x : -x
+}
+
+def good_constants(cond : bool) : int {
+    return cond ? 1 : 0
+}

--- a/utils/lint/tests/lint009_if_same_branches.das
+++ b/utils/lint/tests/lint009_if_same_branches.das
@@ -1,0 +1,78 @@
+options gen2
+// LINT009: `then` branch is equivalent to `else` branch
+//
+// Problem:
+//   `if (c) { A } else { A }` runs A regardless of c. Usually the author
+//   copy-pasted one branch and forgot to edit the other. Caught even when
+//   the body has side effects, since this structural pattern is suspicious
+//   regardless of purity.
+//
+// Bad pattern:
+//   if (flag) {
+//       x = 1
+//   } else {
+//       x = 1
+//   }
+//
+// Good pattern:
+//   if (flag) {
+//       x = 1
+//   } else {
+//       x = 2
+//   }
+
+expect 40104:3
+
+require daslib/lint
+
+// --- Bad: then and else identical ---
+
+def bad_same_assign(cond : bool; var x : int&) {
+    if (cond) {                                      // LINT009
+        x = 1
+    } else {
+        x = 1
+    }
+}
+
+def bad_same_return(cond : bool; x : int) : int {
+    if (cond) {                                      // LINT009
+        return x + 1
+    } else {
+        return x + 1
+    }
+}
+
+def bad_same_block(cond : bool; x : int) : int {
+    if (cond) {                                      // LINT009
+        let y = x * 2
+        return y
+    } else {
+        let y = x * 2
+        return y
+    }
+}
+
+// --- Good: branches differ ---
+
+def good_diff_assign(cond : bool; var x : int&) {
+    if (cond) {
+        x = 1
+    } else {
+        x = 2
+    }
+}
+
+def good_no_else(cond : bool; var x : int&) {
+    if (cond) {
+        x = 1
+    }
+}
+
+def good_diff_return(cond : bool; x : int) : int {
+    if (cond) {
+        return x + 1
+    } else {
+        return x - 1
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2476 (LINT006-009 paranoid checks):

- **Tests** — 4 fixtures under [`utils/lint/tests/`](https://github.com/GaijinEntertainment/daScript/tree/lint-006-009-followup/utils/lint/tests) covering every bad/good case:
  - `lint006_division_by_zero.das` — 10 firings across `int`/`uint`/`int64`/`uint64`/`float`/`double` literal-zero divisors, `%`, `/=`, `%=`
  - `lint007_same_operands.das` — 17 firings covering every operator in the rule, plus a `// nolint:LINT007 — NaN check` demo so the IEEE 754 `x != x` idiom is preserved as a regression test
  - `lint008_ternary_same_branches.das` — ternary identical branches
  - `lint009_if_same_branches.das` — `if`/`else` identical branches
- **Docs** — new LINT006-009 sections in [`doc/source/reference/language/lint.rst`](https://github.com/GaijinEntertainment/daScript/blob/lint-006-009-followup/doc/source/reference/language/lint.rst) with example code; NaN-suppression idiom called out explicitly under LINT007 since daslang has no scalar `is_nan` helper.
- **daslib cleanup** — the new rule surfaced 4 real LINT009 issues on master; all trivially fixable:
  - `daslib/ast_print.das:548` — `if (x.__rtti == "ExprIfThenElse") { write(" else ") } else { write(" else ") }` — both branches identical
  - `daslib/ast_boost.das:1281` — redundant `elif (tstr == "...") { pass } else { pass }`
  - `daslib/aot_cpp.das:2587` and `:3298` — `elif` branches with bodies identical to the `else`

## Notes

- `LintVisitor.expr_equal` now documents why pointer-equality is not used as a fast path — daslang AST nodes have exactly one parent, so sibling operands are always distinct pointers. Comment only, no behavior change.
- **Perf**: linting `daslib/` (105 files) with LINT001-009 takes ~29s warm-cache, indistinguishable from LINT001-005 alone. The 3 new visitors (`preVisitExprOp2`/`Op3`/`IfThenElse`) add no measurable overhead on top of compilation.

## Test plan

- [x] `bin/Release/daslang.exe utils/lint/main.das -- daslib/ --paranoid-only --quiet` — **0 issues** (down from 4 on master before the cleanup commit)
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test utils/lint/tests` — **9/9 pass**
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/` — **6543/6543 pass**
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — **5955/5955 pass**
- [x] `sphinx-build -W --keep-going -b html` — **build succeeded, 0 warnings** (after `doc/reflections/das2rst.das`)
- [x] `format_file` clean on all changed `.das` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)