### PR TITLE
dasSQLITE chunk 2: _sql macro foundation + composability test + AOT

### DIFF
--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -17,6 +17,26 @@ module ast_match shared public
 //! sub-expressions, constant values, and identifier names using the same tag
 //! system as ``qmacro`` but in reverse: ``$e`` clones a matched expression,
 //! ``$v`` extracts a constant value, ``$i`` extracts an identifier name.
+//!
+//! TODO — ExprRef2Value transparency. Post-inference, a read of a ``var``
+//! local can appear wrapped in ``ExprRef2Value(inner)`` (the ref-to-value
+//! adapter that fires when daslang dereferences a reference to consume its
+//! value). The current matcher is RTTI-strict, so a pattern like
+//! ``$e(lhs) == $e(rhs)`` matches the literal LHS/RHS shape but ``$e(rhs)``
+//! captures the wrapper, not the underlying ``ExprVar``/``ExprConst`` —
+//! callers that then check ``rhs is ExprVar`` will miss it. Two fixes:
+//!   1. **Auto-peel in $e capture** — ``generate_match`` could strip
+//!      ``ExprRef2Value`` wrappers when binding to ``$e(name)`` so the
+//!      captured expression is the underlying value.
+//!   2. **Auto-peel in fixed sub-patterns** — when matching a literal-shaped
+//!      sub-pattern (``a + b``), peel ``ExprRef2Value`` from the actual
+//!      before the RTTI guard fires.
+//! Either fix would let downstream callers (e.g. ``modules/dasSQLITE/daslib/
+//! sqlite_linq.das`` ``is_const_or_captured_var``) drop their own peel logic.
+//! Not urgent — current chunk-2 tests all pass because the captured-var
+//! inputs reach the macro before the wrapper is inserted — but the next
+//! complex case (struct-field reads, array indexing, anything that goes
+//! through more inference passes) will hit it.
 
 require daslib/ast public
 require daslib/rtti

--- a/modules/dasSQLITE/.das_module
+++ b/modules/dasSQLITE/.das_module
@@ -6,4 +6,8 @@ def initialize(project_path : string) {
     if (das_is_dll_build()) {
         register_dynamic_module("{project_path}/dasModuleSQLITE.shared_module", "Module_dasSQLITE")
     }
+    let sqlite_paths = ["sqlite_boost", "sqlite_linq"]
+    for (path in sqlite_paths) {
+        register_native_path("sqlite", "{path}", "{project_path}/daslib/{path}.das")
+    }
 }

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -37,6 +37,110 @@ beyond SQL:
 Both prereqs are now done. The rework is unblocked on design **and**
 language impl; only the dasSQLITE-specific phases remain.
 
+## Shipped — chunk 2: `_sql` macro foundation (branch `dassqlite-chunk2-sql-macro`)
+
+- New module file `modules/dasSQLITE/daslib/sqlite_linq.das` housing `_sql(...)`
+  and the companion `_sql_text(...)` (SQL-text-debug macro — name decision
+  locked to `_sql_text`, returns `string`). Module registered in CMake via
+  `ADD_MODULE_DAS(sqlite daslib sqlite_linq)` and in `.das_module` via a new
+  `register_native_path` block that also backfills `sqlite_boost`.
+- Runtime shim: `sqlite_boost` adds the read-direction dispatch rail
+  `sqlite_read(stmt, col, type<T>) : T` (mirrors `sqlite_bind`), the
+  `select_from(db, type<T>) : array<T>` runtime entry, and the
+  `try_run_select` / `run_select` helpers the macro emits calls to. The
+  `[sql_table]` structure macro now also emits `_sql_select_all_sql` (full-row
+  SELECT string) and `_sql_read_row` (per-struct row materializer) for each
+  user table.
+- **Operator surface in chunk 2:** `select_from(type<T>)` (root) +
+  `_to_array()` (no-op terminal) + `_select(_.Field)` (single-column
+  projection) + `_where(predicate)` with bind capture (literals and free
+  variables → `?` placeholders; supports `==`, `!=`, `<`, `<=`, `>`, `>=`,
+  `&&`, `||`, `!`). Multiple `_where` calls in a chain compose AND-wise.
+
+### Architecture: Mode 2 inner-first expansion
+
+`_sql` (and `_sql_text`) run as plain `[call_macro]` decls with the
+**default `canVisitArgument=true`**. That contract — confirmed during
+chunk-2 development — means daslang's macro pass expands inner
+call_macros bottom-up *before* the outer `visit()` fires. By the time
+`_sql.visit` walks the chain, `_where(it, expr)` has already become
+`where_(it, $(_:T) => expr)`, `_select(it, expr)` has become
+`select(it, $(_:T) => expr)`, and any user-defined wrapper macro has
+cascaded into the same canonical `where_` / `select` shape.
+
+This makes the chain analyzer trivially small: it pattern-matches
+`select_from(...)` at the root, `where_` / `select` calls in the body
+(via `match_linq_call(node, "where_" | "select")` + `peel_lambda_body`),
+and `_to_array(...)` as the only outermost terminal. No per-operator
+macro plumbing — every chain stage is just a `linq` call by the time
+the analyzer sees it.
+
+The Mode 2 contract was nearly missed during development. An initial
+Mode-1 attempt added `canVisitArgument → false` overrides on `_sql` /
+`_sql_text` to guarantee raw-AST inputs, after a synthetic test seemed
+to show inner expansion not firing. The diagnosis was wrong: the real
+problem was that `sqlite_linq.das` didn't `require daslib/linq_boost
+public`, so `_where` / `_select` were unavailable as call_macros at
+user-file scope and produced unbound-`_` cascades. Adding the public
+require made Mode 2 work; the override is gone.
+
+**Composable user wrappers (proven by `test_07_sql_composability.das`):**
+a user can write `[call_macro(name="when_price_lt")]` that expands to
+`_where(it, _.Price < val)` and call `_sql(db |> select_from(type<Car>)
+|> when_price_lt(200))` — the wrapper expansion cascades through `_where`
+into `where_`, and the analyzer sees the same `where_` shape it would
+for a user-written `_where(_.Price < 200)`. The 10-test composability
+suite covers the baked-field form, the generic form
+(`when_lt(it, _.Field, val)` passing the field-ref through as an
+argument), wrapper-then-`_where` AND-composition, wrapper-then-`_select`
+projection composition, and two-wrapper AND chains.
+
+### Hardening / diagnostics
+
+- **Entry guards on `_sql` and `_sql_text`** use `macro_verify` (loud
+  failure with `{describe(arg)}`) rather than soft `return null`, so a
+  null `_type` on the chain argument — which means an inner call_macro
+  didn't expand because of a missing-require — surfaces immediately at
+  the call site instead of cascading into unrelated infer errors.
+- **`ExprRef2Value` peel** at the top of `analyze_projection`,
+  `pred_to_sql`, and `is_const_or_captured_var`: the typer wraps field
+  reads in `ExprRef2Value` after Mode-2 inner expansion, so the analyzer
+  unwraps it before pattern-matching shapes like `_.Field` or comparing
+  to `ExprVar`. (TODO in `daslib/ast_match.das`: add auto-peel inside
+  `qmatch` so callers don't need to do this manually.)
+
+### AOT status
+
+`sqlite_linq.das` is registered in `tests/aot/CMakeLists.txt`'s
+`AOT_DASSQLITE_MODULE_FILES` and AOT-codegens cleanly into
+`test_aot_dassqlite_modules_sqlite_linq.das.cpp`. Runtime AOT for
+dasSQLITE inherits whatever sqlite_boost AOT delivers — chunk-2 doesn't
+gate or worsen anything in that path. `failed_sql_macro.das` is excluded
+from the AOT glob via the same `list(FILTER ... EXCLUDE REGEX
+"failed_")` pattern used by `tests/decs/`, since expect-error tests
+intentionally fail to compile and would break AOT codegen.
+
+### Deferred to chunk 3+
+
+Struct-constructor and named-tuple `_select` projections; `_order_by`,
+`_take`, `_skip`, `_distinct`; aggregates (`_count`, `_sum`, `_avg`,
+`_min`, `_max`); `_first` / `_first_or_default`; `_group_by`, `_having`;
+`_join`, `_left_join`; `_in`, `_not_in`, `_any`, `_none`; the
+panic-free `_try_sql` variant. All planned, none in this PR.
+
+### Surface in this PR
+
+- **Tutorial 04** is now real (`tutorial/04-select_all.das`) — first end-to-end
+  exposure to `_sql`.
+- **Tests:** `tests/dasSQLITE/test_05_sql_macro.das` (17 execution cases),
+  `tests/dasSQLITE/test_06_sql_text.das` (19 SQL-string-emission cases),
+  `tests/dasSQLITE/test_07_sql_composability.das` (10 user-wrapper cases),
+  `tests/dasSQLITE/test_07_macros.das` (companion module defining
+  `when_price_lt` and `when_lt` wrapper call_macros),
+  `tests/dasSQLITE/failed_sql_macro.das` (`expect`-based macro-error cases).
+  `tests/dasSQLITE/test_04_user_types.das` extended with a `select_from`
+  round-trip exercising the user-side `sqlite_read` overload.
+
 ## SQL read-side prerequisites (daslib/linq + daslib/linq_boost rework)
 
 The `_sql(...)` chain is a thin SQL-emitting translator over daslib/linq.

--- a/modules/dasSQLITE/CMakeLists.txt
+++ b/modules/dasSQLITE/CMakeLists.txt
@@ -79,6 +79,7 @@ IF ((NOT DAS_SQLITE_INCLUDED) AND ((NOT ${DAS_SQLITE_DISABLED}) OR (NOT DEFINED 
 	SETUP_LTO(sqlite_shell)
 
     ADD_MODULE_DAS(sqlite daslib sqlite_boost)
+    ADD_MODULE_DAS(sqlite daslib sqlite_linq)
 
     INSTALL(TARGETS sqlite_shell
         RUNTIME DESTINATION ${DAS_INSTALL_BINDIR}

--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -49,9 +49,15 @@ one-line helpers. Everything after this assumes this vocabulary.
    AUTOINCREMENT. Mockup: [03-last_row_id.das](tutorial-mockup/03-last_row_id.das.mockup).
 4. **Read every row** — iterate a table with
    `_sql(db |> select_from(type<Car>))`. Introduces: `select_from`, the
-   iterator result, `_to_array()` terminal. First exposure to `_sql(...)`
-   — deliberate: the macro is *the* read-side story and appears in every
-   subsequent read tutorial. Mockup: [04-select_all.das](tutorial-mockup/04-select_all.das.mockup).
+   `array<T>` result, `_to_array()` no-op terminal, single-column
+   projection via `_select(_.Field)`, filtering with `_where(predicate)`
+   (with bind capture for free variables and literals), and the
+   companion `_sql_text(chain)` for inspecting the emitted SQL. First
+   exposure to `_sql(...)` — deliberate: the macro is *the* read-side
+   story and appears in every subsequent read tutorial. **Shipped:**
+   [04-select_all.das](tutorial/04-select_all.das) (chunk 2, branch
+   `dassqlite-chunk2-sql-macro`). Original mockup:
+   [04-select_all.das.mockup](tutorial-mockup/04-select_all.das.mockup).
 
 ## Part 2 — Parameters + error handling rail
 

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -223,6 +223,57 @@ def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : auto(TT)) : void {
     concept_assert(false, "sqlite_bind: unsupported field type. Define `def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : YourType) : void` to extend.")
 }
 
+// ============================================================================
+// Read-side dispatch: sqlite_read
+//
+// Mirrors `sqlite_bind` for the read direction. `[sql_table]`-generated
+// `_sql_read_row` and the `_sql` macro's row materializer emit calls to
+// `sqlite_read(stmt, col, type<T>) : T` for every column. Built-in primitive
+// types are handled by the overloads below; user-defined types extend the
+// surface with their own overload — no registration step:
+//
+//     def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<MyType>) : MyType { ... }
+//
+// The generic catch-all fires `concept_assert(false, ...)` for any type that
+// doesn't have a specific overload. Reports at the caller's line.
+// ============================================================================
+
+[unused_argument(t)]
+def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<int>) : int {
+    return sqlite3_column_int(stmt, col)
+}
+
+[unused_argument(t)]
+def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<int64>) : int64 {
+    return sqlite3_column_int64(stmt, col)
+}
+
+[unused_argument(t)]
+def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<float>) : float {
+    return float(sqlite3_column_double(stmt, col))
+}
+
+[unused_argument(t)]
+def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<double>) : double {
+    return sqlite3_column_double(stmt, col)
+}
+
+[unused_argument(t)]
+def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<string>) : string {
+    return sqlite3_column_text_(stmt, col)
+}
+
+[unused_argument(t)]
+def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<bool>) : bool {
+    return sqlite3_column_int(stmt, col) != 0
+}
+
+[unused_argument(stmt, col, t)]
+def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<auto(TT)>) : TT {
+    concept_assert(false, "sqlite_read: unsupported field type. Define `def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<YourType>) : YourType` to extend.")
+    return default<TT>
+}
+
 [unused_argument(t)]
 def try_query_scalar(db : SqlRunner; sql : string; t : type<string>) : Result<string, string> {
     //! Prepares ``sql``, steps once, returns column 0 as ``string``.
@@ -395,6 +446,94 @@ def private ignore_sql_error(e : SqlError) : void {
     //! Discards a SqlError. Used by try_insert(array) to swallow ROLLBACK failures while preserving the original error.
 }
 
+[unused_argument(t)]
+def try_select_from(db : SqlRunner; t : type<auto(TT)>) : Result<array<TT -const -#>, string> {
+    //! Reads every row of the table backing ``T`` and materializes them as ``array<TT>``.
+    //! Compat-mode counterpart to the ``_sql(db |> select_from(type<T>))`` macro path:
+    //! when no chain operators or ``_sql`` wrapper is involved, this is what runs.
+    //! Returns ``Err(errmsg)`` on prepare or step failure.
+    //!
+    //! NOTE: uses a regular generic (`type<auto(TT)>`) rather than `[template]` so
+    //! the `type<T>` argument survives in the AST for `_sql` chain-pattern matching.
+    let sql = _::_sql_select_all_sql(type<TT -const -#>)
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        let msg = "select_from prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<array<TT -const -#>>)
+    }
+    var inscope result : array<TT -const -#>
+    var rc = sqlite3_step(stmt)
+    while (rc == SQLITE_ROW) {
+        result |> emplace(_::_sql_read_row(stmt, type<TT -const -#>))
+        rc = sqlite3_step(stmt)
+    }
+    if (rc != SQLITE_DONE) {
+        let msg = "select_from step failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<array<TT -const -#>>)
+    }
+    sqlite3_finalize(stmt)
+    return move_ok(result, type<string>)
+}
+
+[unused_argument(t)]
+def select_from(db : SqlRunner; t : type<auto(TT)>) : array<TT -const -#> {
+    //! Strict variant of ``try_select_from``. Panics with the libsqlite3 errmsg on failure.
+    var r <- db |> try_select_from(type<TT -const -#>)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return <- r._value
+}
+
+// ============================================================================
+// _sql macro runtime: try_run_select / run_select
+//
+// The `_sql` macro emits a call to one of these. `bind_blk` runs once after
+// prepare to push bound values; `row_blk` is invoked per row to materialize
+// the typed result. Generic on the row type (`auto(TT)`) so the call site
+// determines whether the array is `array<Car>`, `array<string>`, or any
+// other projected shape.
+// ============================================================================
+
+def try_run_select(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite3_stmt?) : void>; row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : Result<array<TT -const -#>, string> {
+    //! Prepares ``sql``, runs ``bind_blk`` once, then steps the cursor and
+    //! materializes each row via ``row_blk``. Returns ``Err(errmsg)`` on
+    //! prepare or step failure.
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        let msg = "_sql prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<array<TT -const -#>>)
+    }
+    invoke(bind_blk, stmt)
+    var inscope result : array<TT -const -#>
+    var rc = sqlite3_step(stmt)
+    while (rc == SQLITE_ROW) {
+        result |> push(invoke(row_blk, stmt))
+        rc = sqlite3_step(stmt)
+    }
+    if (rc != SQLITE_DONE) {
+        let msg = "_sql step failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<array<TT -const -#>>)
+    }
+    sqlite3_finalize(stmt)
+    return move_ok(result, type<string>)
+}
+
+def run_select(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite3_stmt?) : void>; row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : array<TT -const -#> {
+    //! Strict variant of ``try_run_select``. Panics on prepare/step failure.
+    var r <- try_run_select(db, sql, bind_blk, row_blk)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return <- r._value
+}
+
 // ============================================================================
 // [sql_table] structure macro
 //
@@ -474,6 +613,10 @@ class SqlTableMacro : AstStructureAnnotation {
         compiling_module() |> add_function(fn_pk_unset)
         var fn_bind = make_bind_row_fn(st, fields)
         compiling_module() |> add_function(fn_bind)
+        var fn_select_all = make_select_all_sql_fn(st, table_name, fields)
+        compiling_module() |> add_function(fn_select_all)
+        var fn_read = make_read_row_fn(st, fields)
+        compiling_module() |> add_function(fn_read)
 
         return true
     }
@@ -644,6 +787,49 @@ class SqlTableMacro : AstStructureAnnotation {
             } else {
                 $b(no_pk_exprs)
             }
+        }
+        fn.flags |= FunctionFlags.generated
+        fn.body |> force_at(st.at)
+        return <- fn
+    }
+
+    def make_select_all_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>) : FunctionPtr {
+        let col_list = build_string() <| $(var w) {
+            for (i in range(length(fields))) {
+                if (i > 0) {
+                    w |> write(", ")
+                }
+                w |> write("\"")
+                w |> write(fields[i].col_name)
+                w |> write("\"")
+            }
+        }
+        let sql = "SELECT {col_list} FROM \"{table_name}\""
+        var fn = qmacro_function("_sql_select_all_sql") $(typ : $t(st)) : string {
+            return $v(sql)
+        }
+        fn.flags |= FunctionFlags.generated
+        fn.body |> force_at(st.at)
+        return <- fn
+    }
+
+    def make_read_row_fn(var st : StructurePtr; fields : array<FieldInfo>) : FunctionPtr {
+        var assign_exprs : array<ExpressionPtr>
+        assign_exprs |> reserve(length(fields))
+
+        for (i in range(length(fields))) {
+            let info = fields[i]
+            let col_idx = i
+            let field_name = info.name
+            assign_exprs |> push(qmacro_expr(${
+                row.$f(field_name) = sqlite_read(stmt, $v(col_idx), type<$t(st.fields[i]._type)>);
+            }))
+        }
+
+        var fn = qmacro_function("_sql_read_row") $(stmt : sqlite3_stmt?; typ : $t(st)) : $t(st) {
+            var row : $t(st)
+            $b(assign_exprs)
+            return <- row
         }
         fn.flags |= FunctionFlags.generated
         fn.body |> force_at(st.at)

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -1,0 +1,584 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+options strict_smart_pointers
+
+module sqlite_linq shared public
+
+require sqlite/sqlite_boost public
+require daslib/sql public
+require daslib/linq_boost public
+
+require daslib/ast public
+require daslib/ast_boost
+require daslib/ast_match
+require daslib/templates
+require daslib/templates_boost
+require daslib/macro_boost
+require daslib/rtti
+require strings public
+
+// ============================================================================
+// _to_array passthrough
+//
+// Recognized by the `_sql` macro as a no-op terminal. In compatibility mode
+// (no `_sql` wrapper) it forwards to the bare materialization done by
+// `select_from` (which already returns `array<T>`).
+// ============================================================================
+
+[unused_argument(arr)]
+def _to_array(var arr : array<auto(TT)>) : array<TT -const -#> {
+    //! Passthrough terminal. In compat mode `select_from` has already materialized
+    //! the array; this just yields it. Inside `_sql(...)` the macro recognizes
+    //! the call and treats it as a no-op terminal.
+    return <- arr
+}
+
+// ============================================================================
+// SqlQuery — accumulator for chain analysis (compile-time only).
+// ============================================================================
+
+struct private SqlQuery {
+    rootType    : TypeDeclPtr
+    tableName   : string
+    selectCols  : array<string>
+    whereSql    : string
+    bindExprs   : array<ExpressionPtr>
+    projType    : TypeDeclPtr
+    seenSelect  : bool
+    seenToArray : bool
+    dbExpr      : ExpressionPtr
+}
+
+// ============================================================================
+// Chain analysis — walk a pipe-composed chain backwards.
+//
+// `_sql` runs as a normal call_macro (no `canVisitArgument` override), so by
+// the time `analyze_chain` runs daslang has already expanded all inner
+// call_macros bottom-up. The chain we see is the post-expansion shape:
+//
+//   _where(it, expr)  →  where_(it, $(_ : T) => expr)         [from linq_boost]
+//   _select(it, expr) →  select(it,  $(_ : T) => expr)        [from linq_boost]
+//   _to_array(arr)    →  _to_array(arr)                        [plain fn, stays]
+//   select_from(db, type<T>) → unchanged                       [plain fn]
+//
+// Because expansion is complete, `_` inside the lambda body is a real bound
+// parameter with type T, captured vars carry their `_type`, and any
+// user-defined wrapper macro (e.g. `when_its_cold(it)` → `_where(it, ...)`)
+// has already cascaded into a `where_` / `select` we recognize.
+// ============================================================================
+
+[macro_function]
+def private peel_lambda_body(var lam : ExpressionPtr) : ExpressionPtr {
+    //! Peel `$(_ : T) => body` (post-expansion linq lambda) → body expression.
+    //! Returns null if shape is unexpected. Mirrors `linq_boost.fold_linq_cond`.
+    if (lam == null || !(lam is ExprMakeBlock)) {
+        return null
+    }
+    var mblk = lam as ExprMakeBlock
+    var blk = mblk._block as ExprBlock
+    if (blk == null || blk.arguments |> length != 1 || blk.list |> length != 1) {
+        return null
+    }
+    if (!(blk.list[0] is ExprReturn)) {
+        return null
+    }
+    var ret = blk.list[0] as ExprReturn
+    return ret.subexpr
+}
+
+[macro_function]
+def private match_linq_call(var expr : ExpressionPtr; name : string) : ExprCall? {
+    //! Match a fully-resolved call to `name` from module `linq`. Walks
+    //! through `fromGeneric` so generic instances are recognized. Mirrors
+    //! `linq_boost.is_call_or_generic`.
+    if (expr == null || !(expr is ExprCall)) {
+        return null
+    }
+    var call = expr as ExprCall
+    if (call.func == null || call.func._module == null) {
+        return null
+    }
+    if (call.func.name == name && call.func._module.name == "linq") {
+        return call
+    }
+    if (call.func.fromGeneric != null
+            && call.func.fromGeneric.name == name
+            && call.func.fromGeneric._module != null
+            && call.func.fromGeneric._module.name == "linq") {
+        return call
+    }
+    return null
+}
+
+[macro_function]
+def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
+    if (node == null) {
+        macro_error(prog, at, "_sql: empty chain")
+        return false
+    }
+
+    // Peel _to_array(prev) — plain function in this module, no expansion.
+    // Must be outermost.
+    {
+        var inner : ExpressionPtr
+        if (qmatch(node, _to_array($e(inner))).matched) {
+            if (q.seenToArray) {
+                macro_error(prog, at, "_sql: _to_array() can only appear once and must be the outermost operator")
+                return false
+            }
+            q.seenToArray = true
+            return analyze_chain(inner, q, prog, at)
+        }
+    }
+
+    // Peel select(prev, lambda) — post-expansion of `_select(prev, expr)`.
+    {
+        var sCall = match_linq_call(node, "select")
+        if (sCall != null) {
+            if (q.seenSelect) {
+                macro_error(prog, at, "_sql: _select can only appear once in the chain")
+                return false
+            }
+            var body = peel_lambda_body(sCall.arguments[1])
+            if (body == null) {
+                macro_error(prog, at, "_sql: _select projection lambda has unexpected shape")
+                return false
+            }
+            if (!analyze_projection(body, q, prog, at)) {
+                return false
+            }
+            q.seenSelect = true
+            return analyze_chain(sCall.arguments[0], q, prog, at)
+        }
+    }
+
+    // Peel where_(prev, lambda) — post-expansion of `_where(prev, predicate)`.
+    {
+        var wCall = match_linq_call(node, "where_")
+        if (wCall != null) {
+            var body = peel_lambda_body(wCall.arguments[1])
+            if (body == null) {
+                macro_error(prog, at, "_sql: _where predicate lambda has unexpected shape")
+                return false
+            }
+            if (!analyze_predicate(body, q, prog, at)) {
+                return false
+            }
+            return analyze_chain(wCall.arguments[0], q, prog, at)
+        }
+    }
+
+    // Bottom: select_from(db, type<T>) — plain function in sqlite_boost.
+    {
+        var dbE : ExpressionPtr
+        var rootT : TypeDeclPtr
+        if (qmatch(node, select_from($e(dbE), type<$t(rootT)>)).matched) {
+            q.dbExpr = dbE
+            q.rootType = rootT
+            // Default projection if no _select was seen above
+            if (!q.seenSelect) {
+                fill_default_columns(q, rootT, prog, at)
+                q.projType = clone_type(rootT)
+            }
+            q.tableName = sql_table_name_from_type(rootT)
+            return true
+        }
+    }
+
+    macro_error(prog, at, "_sql: unsupported chain root or operator. chunk 2 supports `select_from(type<T>)` at the root, with optional `_select` / `_where` / `_to_array`. Got: {describe(node)}")
+    return false
+}
+
+// ============================================================================
+// Projection analysis (_select).
+//
+// Chunk 2 supports a single projection shape:
+//   _select(_.FieldName)   -> single-column projection
+//
+// Struct-constructor / named-tuple projection is deferred to chunk 3.
+//
+// `body` is the projection expression (e.g. `_.Name`) after Mode-2
+// expansion has already lambda-wrapped it via `select(it, $(_:T) => body)`,
+// so what we receive is the inner body extracted by `peel_lambda_body`.
+// The typer wraps field reads in `ExprRef2Value` post-expansion, so we
+// peel that adapter before pattern-matching the column shape.
+// ============================================================================
+
+[macro_function]
+def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
+    if (body == null) {
+        macro_error(prog, at, "_sql: _select: missing projection")
+        return false
+    }
+    // After Mode-2 expansion the typer may wrap field reads in ExprRef2Value
+    // (the value-from-ref adapter). Peel it before pattern-matching.
+    if (body is ExprRef2Value) {
+        body = (body as ExprRef2Value).subexpr
+        if (body == null) {
+            macro_error(prog, at, "_sql: _select: ExprRef2Value with null subexpr")
+            return false
+        }
+    }
+
+    // Single-column form: _.FieldName
+    {
+        var fieldName : string
+        if (qmatch(body, _.$f(fieldName)).matched) {
+            q.selectCols |> clear
+            q.selectCols |> push(fieldName)
+            // projType becomes the field's type — defer to inference; leave
+            // q.projType null. The macro emission path for chunk 2 currently
+            // reuses select_from for bare cases; once it emits invoke blocks
+            // we'll set projType from the struct's field metadata.
+            return true
+        }
+    }
+
+    macro_error(prog, at, "_sql: _select: chunk 2 supports `_.Field` (single column) only; got: {describe(body)}")
+    return false
+}
+
+// ============================================================================
+// Predicate analysis (_where) — recursive AST walk emitting SQL.
+//
+// Bind capture: literals and free-variable references become `?` placeholders;
+// each captured ExpressionPtr is appended to q.bindExprs in left-to-right order
+// matching the placeholder index sequence.
+//
+// Capture-leak protocol: every qmatch attempt uses fresh capture variables in
+// its own bare block so partial writes from a failed earlier attempt cannot
+// leak into a later attempt.
+// ============================================================================
+
+[macro_function]
+def private analyze_predicate(var body : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
+    //! `body` is the predicate expression (e.g. `_.Id == 5`) extracted by
+    //! `peel_lambda_body` from the post-expansion `where_(prev, $(_:T) => body)`.
+    if (body == null) {
+        macro_error(prog, at, "_sql: _where: missing predicate")
+        return false
+    }
+    let s = pred_to_sql(body, q, prog, at)
+    if (empty(s)) {
+        return false   // pred_to_sql already issued a macro_error
+    }
+    if (empty(q.whereSql)) {
+        q.whereSql = s
+    } else {
+        q.whereSql = "({q.whereSql}) AND ({s})"
+    }
+    return true
+}
+
+[macro_function]
+def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : string {
+    if (node == null) {
+        macro_error(prog, at, "_sql: _where: null sub-expression")
+        return ""
+    }
+    // Peel ExprRef2Value (value-from-ref adapter that the typer inserts
+    // around field reads after Mode-2 inner expansion).
+    if (node is ExprRef2Value) {
+        node = (node as ExprRef2Value).subexpr
+        if (node == null) {
+            macro_error(prog, at, "_sql: _where: ExprRef2Value with null subexpr")
+            return ""
+        }
+    }
+
+    // Logical NOT  →  NOT (...)
+    {
+        var inner : ExpressionPtr
+        if (qmatch(node, !$e(inner)).matched) {
+            return "NOT ({pred_to_sql(inner, q, prog, at)})"
+        }
+    }
+    // Logical AND
+    {
+        var lhs : ExpressionPtr
+        var rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) && $e(rhs)).matched) {
+            return "({pred_to_sql(lhs, q, prog, at)}) AND ({pred_to_sql(rhs, q, prog, at)})"
+        }
+    }
+    // Logical OR
+    {
+        var lhs : ExpressionPtr
+        var rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) || $e(rhs)).matched) {
+            return "({pred_to_sql(lhs, q, prog, at)}) OR ({pred_to_sql(rhs, q, prog, at)})"
+        }
+    }
+    // Comparison ops — six shapes, each in its own scope.
+    {
+        var lhs, rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) == $e(rhs)).matched) {
+            return "{pred_to_sql(lhs, q, prog, at)} = {pred_to_sql(rhs, q, prog, at)}"
+        }
+    }
+    {
+        var lhs, rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) != $e(rhs)).matched) {
+            return "{pred_to_sql(lhs, q, prog, at)} <> {pred_to_sql(rhs, q, prog, at)}"
+        }
+    }
+    {
+        var lhs, rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) < $e(rhs)).matched) {
+            return "{pred_to_sql(lhs, q, prog, at)} < {pred_to_sql(rhs, q, prog, at)}"
+        }
+    }
+    {
+        var lhs, rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) <= $e(rhs)).matched) {
+            return "{pred_to_sql(lhs, q, prog, at)} <= {pred_to_sql(rhs, q, prog, at)}"
+        }
+    }
+    {
+        var lhs, rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) > $e(rhs)).matched) {
+            return "{pred_to_sql(lhs, q, prog, at)} > {pred_to_sql(rhs, q, prog, at)}"
+        }
+    }
+    {
+        var lhs, rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) >= $e(rhs)).matched) {
+            return "{pred_to_sql(lhs, q, prog, at)} >= {pred_to_sql(rhs, q, prog, at)}"
+        }
+    }
+
+    // Column reference: _.ColName  (ExprField rooted at lambda param `_`)
+    {
+        var fieldName : string
+        if (qmatch(node, _.$f(fieldName)).matched) {
+            return fieldName
+        }
+    }
+
+    // Literal / captured var → bind param. Clone the *peeled* expression so
+    // when we re-emit it as a `sqlite_bind` argument the runtime reads the
+    // captured value cleanly (without re-wrapping into ExprRef2Value).
+    if (is_const_or_captured_var(node)) {
+        q.bindExprs |> push <| clone_expression(node)
+        return "?"
+    }
+
+    macro_error(prog, at, "_sql: _where: unsupported expression. Chunk 2 supports field refs (_.Col), constants, captured vars, comparisons (=, <>, <, <=, >, >=), &&/||, !. Got: {describe(node)}")
+    return ""
+}
+
+[macro_function]
+def private is_const_or_captured_var(var node : ExpressionPtr) : bool {
+    //! Recognize a literal or a captured-var read so the predicate walker can
+    //! emit a `?` placeholder + bind. After Mode-2 inner expansion captured
+    //! local-var reads can arrive wrapped in `ExprRef2Value` (the read-from-ref
+    //! adapter); peel through it before classifying.
+    if (node == null) {
+        return false
+    }
+    if (node is ExprRef2Value) {
+        node = (node as ExprRef2Value).subexpr
+        if (node == null) {
+            return false
+        }
+    }
+    if (node is ExprConstInt || node is ExprConstInt64 || node is ExprConstUInt || node is ExprConstUInt64
+        || node is ExprConstFloat || node is ExprConstDouble || node is ExprConstBool || node is ExprConstString) {
+        return true
+    }
+    if (node is ExprVar) {
+        let v = node as ExprVar
+        // The lambda parameter `_` is not a captured var; it's the row.
+        return v.name != "_"
+    }
+    return false
+}
+
+[macro_function]
+def private fill_default_columns(var q : SqlQuery&; rootT : TypeDeclPtr; prog : ProgramPtr; at : LineInfo) : void {
+    if (rootT == null || rootT.structType == null) {
+        macro_error(prog, at, "_sql: select_from(type<T>): T must be a struct (got {describe(rootT)})")
+        return
+    }
+    var st = rootT.structType
+    for (field in st.fields) {
+        q.selectCols |> push(string(field.name))
+    }
+}
+
+[macro_function]
+def private sql_table_name_from_type(rootT : TypeDeclPtr) : string {
+    // For chunk 2 we read the table name via the chunk-1 emitted helper at
+    // runtime. At macro-expansion time we cannot directly call the user's
+    // _::_sql_table_name (the helper lives in the user's module, not in
+    // sqlite_linq's macro context). Instead, emit a string concat or use the
+    // struct name as a default. For the SQL-text generation use the struct
+    // name; if [sql_table(name="...")] overrode it, the runtime helper still
+    // emits the right SQL (because the macro uses it via _::_sql_table_name).
+    //
+    // For chunk 2 minimum: use the [sql_table]-stored arg `name` if present,
+    // else the struct name.
+    if (rootT == null || rootT.structType == null) {
+        return ""
+    }
+    var st = rootT.structType
+    // Try to read the [sql_table(name="...")] override from the structure
+    // annotation list. `[sql_table]` cannot appear twice on the same struct
+    // (daslang rejects duplicate annotations), so once we find it and finish
+    // scanning its arguments, break out — no other `sql_table` annotation
+    // can exist in the list.
+    for (annDecl in st.annotations) {
+        if (annDecl.annotation.name == "sql_table") {
+            for (arg in annDecl.arguments) {
+                if (arg.name == "name" && arg.basicType == Type.tString) {
+                    return string(arg.sValue)
+                }
+            }
+            break
+        }
+    }
+    return string(st.name)
+}
+
+// ============================================================================
+// SQL string assembly
+// ============================================================================
+
+[macro_function]
+def private build_sql_string(q : SqlQuery) : string {
+    return build_string() $(var w) {
+        w |> write("SELECT ")
+        for (i in range(length(q.selectCols))) {
+            if (i > 0) {
+                w |> write(", ")
+            }
+            w |> write("\"")
+            w |> write(q.selectCols[i])
+            w |> write("\"")
+        }
+        w |> write(" FROM \"")
+        w |> write(q.tableName)
+        w |> write("\"")
+        if (!empty(q.whereSql)) {
+            w |> write(" WHERE ")
+            w |> write(q.whereSql)
+        }
+    }
+}
+
+// ============================================================================
+// _sql_text — emit the compiled SQL string at the call site.
+// ============================================================================
+
+[call_macro(name="_sql_text")]
+class private SqlTextMacro : AstCallMacro {
+    //! _sql_text(chain) -> string. Returns the SQL that _sql(chain) would emit,
+    //! with `?` placeholders for binds. Used for testing the macro's output.
+    //!
+    //! Default `canVisitArgument=true` → daslang expands inner call_macros
+    //! (`_where`, `_select`, user wrappers like `when_its_cold`) bottom-up
+    //! before this fires. We then pattern-match the post-expansion shape.
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        macro_verify(call.arguments |> length == 1, prog, call.at, "_sql_text expects one argument: a chain expression")
+        var argT = call.arguments[0]._type
+        macro_verify(argT != null, prog, call.at, "_sql_text: chain argument has null _type — inner call_macros did not expand before this fired (daslang macro-pass bug). Arg: {describe(call.arguments[0])}")
+        macro_verify(!argT.isAutoOrAlias, prog, call.at, "_sql_text: chain type is auto/alias after _type is set — compiler bug")
+        var q : SqlQuery
+        if (!analyze_chain(call.arguments[0], q, prog, call.at)) {
+            return null
+        }
+        let sql = build_sql_string(q)
+        var res = qmacro($v(sql))
+        res.force_at(call.at)
+        return res
+    }
+}
+
+// ============================================================================
+// _sql — emit the runtime materialization at the call site.
+//
+// Chunk 2 minimum: bare `select_from(type<T>)` -> array<T>. Builds an invoke
+// block that prepares the SQL, steps, materializes via _::_sql_read_row.
+// ============================================================================
+
+[macro_function]
+def private lookup_struct_field_type(rootT : TypeDeclPtr; fieldName : string) : TypeDeclPtr {
+    if (rootT == null || rootT.structType == null) {
+        return null
+    }
+    var st = rootT.structType
+    for (field in st.fields) {
+        if (field.name == fieldName) {
+            return clone_type(field._type)
+        }
+    }
+    return null
+}
+
+[call_macro(name="_sql")]
+class private SqlMacro : AstCallMacro {
+    //! _sql(chain) -> array<T>. Compile-time LINQ-to-SQL translator. Pattern-matches
+    //! the chain, emits SQL + a runtime materialization via run_select.
+    //!
+    //! **Default `canVisitArgument=true`.** Daslang's macro pass expands
+    //! inner call_macros bottom-up *before* this `visit()` fires. By the
+    //! time we run, `_where(it, expr)` has become `where_(it, $(_:T) => expr)`,
+    //! `_select(it, expr)` has become `select(it, $(_:T) => expr)`, and any
+    //! user-defined wrapper macro (e.g. `when_its_cold(it)` →
+    //! `_where(it, _.temp < 0)`) has cascaded into the same shape.
+    //!
+    //! **Entry guard:** if `arguments[0]._type == null`, the inner chain
+    //! still has un-expanded macros somewhere — return null and let the
+    //! macro pass try again on the next iteration. If `_type` is set but
+    //! `isAutoOrAlias`, that's a compiler bug — fail loudly.
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        macro_verify(call.arguments |> length == 1, prog, call.at, "_sql expects one argument: a chain expression")
+        var argT = call.arguments[0]._type
+        macro_verify(argT != null, prog, call.at, "_sql: chain argument has null _type — inner call_macros did not expand before this fired (daslang macro-pass bug). Arg: {describe(call.arguments[0])}")
+        macro_verify(!argT.isAutoOrAlias, prog, call.at, "_sql: chain type is auto/alias after _type is set — compiler bug")
+        var q : SqlQuery
+        if (!analyze_chain(call.arguments[0], q, prog, call.at)) {
+            return null
+        }
+        let sql = build_sql_string(q)
+
+        // Build bind statements: sqlite_bind(stmt, i+1, $e(boundExpr))
+        var bind_stmts : array<ExpressionPtr>
+        bind_stmts |> reserve(length(q.bindExprs))
+        for (i in range(length(q.bindExprs))) {
+            let bindIdx = i + 1
+            var be = q.bindExprs[i]
+            bind_stmts |> push <| qmacro_expr(${
+                sqlite_bind(_sql_stmt, $v(bindIdx), $e(be));
+            })
+        }
+
+        // Build row materializer based on projection shape.
+        var rootType = clone_type(q.rootType)
+        var rowBuilder : ExpressionPtr
+        if (q.seenSelect && length(q.selectCols) == 1) {
+            // single-column projection: emit sqlite_read(stmt, 0, type<FieldType>)
+            let colIdx = 0
+            var fieldType = lookup_struct_field_type(q.rootType, q.selectCols[0])
+            if (fieldType == null) {
+                macro_error(prog, call.at, "_sql: cannot resolve type of projected column '{q.selectCols[0]}'")
+                return null
+            }
+            rowBuilder = qmacro(sqlite_read(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
+        } else {
+            // full row: emit _::_sql_read_row(stmt, type<T>)
+            rowBuilder = qmacro(_::_sql_read_row(_sql_stmt, type<$t(rootType)>))
+        }
+
+        var dbExpr = q.dbExpr
+        var res = qmacro(_::run_select($e(dbExpr), $v(sql),
+            $(var _sql_stmt : sqlite3_stmt?) {
+                $b(bind_stmts)
+            },
+            $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
+        res.force_at(call.at)
+        return res
+    }
+}

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -353,7 +353,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
     {
         var fieldName : string
         if (qmatch(node, _.$f(fieldName)).matched) {
-            return fieldName
+            return "\"{fieldName}\""
         }
     }
 
@@ -410,16 +410,11 @@ def private fill_default_columns(var q : SqlQuery&; rootT : TypeDeclPtr; prog : 
 
 [macro_function]
 def private sql_table_name_from_type(rootT : TypeDeclPtr) : string {
-    // For chunk 2 we read the table name via the chunk-1 emitted helper at
-    // runtime. At macro-expansion time we cannot directly call the user's
-    // _::_sql_table_name (the helper lives in the user's module, not in
-    // sqlite_linq's macro context). Instead, emit a string concat or use the
-    // struct name as a default. For the SQL-text generation use the struct
-    // name; if [sql_table(name="...")] overrode it, the runtime helper still
-    // emits the right SQL (because the macro uses it via _::_sql_table_name).
-    //
-    // For chunk 2 minimum: use the [sql_table]-stored arg `name` if present,
-    // else the struct name.
+    // At macro-expansion time we cannot directly call the user's
+    // _::_sql_table_name helper because it lives in the user's module, not in
+    // sqlite_linq's macro context. Instead, derive the table name here from
+    // the struct metadata: use [sql_table(name="...")] when present, else
+    // fall back to the struct name.
     if (rootT == null || rootT.structType == null) {
         return ""
     }
@@ -483,8 +478,8 @@ class private SqlTextMacro : AstCallMacro {
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         macro_verify(call.arguments |> length == 1, prog, call.at, "_sql_text expects one argument: a chain expression")
         var argT = call.arguments[0]._type
-        macro_verify(argT != null, prog, call.at, "_sql_text: chain argument has null _type — inner call_macros did not expand before this fired (daslang macro-pass bug). Arg: {describe(call.arguments[0])}")
-        macro_verify(!argT.isAutoOrAlias, prog, call.at, "_sql_text: chain type is auto/alias after _type is set — compiler bug")
+        macro_verify(argT != null, prog, call.at, "_sql_text: chain argument is not inferred yet")
+        macro_verify(!argT.isAutoOrAlias, prog, call.at, "_sql_text: chain type is auto/alias after inference")
         var q : SqlQuery
         if (!analyze_chain(call.arguments[0], q, prog, call.at)) {
             return null
@@ -529,15 +524,15 @@ class private SqlMacro : AstCallMacro {
     //! user-defined wrapper macro (e.g. `when_its_cold(it)` →
     //! `_where(it, _.temp < 0)`) has cascaded into the same shape.
     //!
-    //! **Entry guard:** if `arguments[0]._type == null`, the inner chain
-    //! still has un-expanded macros somewhere — return null and let the
-    //! macro pass try again on the next iteration. If `_type` is set but
-    //! `isAutoOrAlias`, that's a compiler bug — fail loudly.
+    //! **Entry guard:** the chain argument's `_type` must be resolved before
+    //! `_sql` runs — if it's null, inner call_macros didn't expand (typically a
+    //! missing `require` for an operator/wrapper); if it's still auto/alias,
+    //! type inference didn't finish. Both fail loudly via `macro_verify`.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         macro_verify(call.arguments |> length == 1, prog, call.at, "_sql expects one argument: a chain expression")
         var argT = call.arguments[0]._type
-        macro_verify(argT != null, prog, call.at, "_sql: chain argument has null _type — inner call_macros did not expand before this fired (daslang macro-pass bug). Arg: {describe(call.arguments[0])}")
-        macro_verify(!argT.isAutoOrAlias, prog, call.at, "_sql: chain type is auto/alias after _type is set — compiler bug")
+        macro_verify(argT != null, prog, call.at, "_sql: chain argument is not inferred yet")
+        macro_verify(!argT.isAutoOrAlias, prog, call.at, "_sql: chain type is auto/alias after inference")
         var q : SqlQuery
         if (!analyze_chain(call.arguments[0], q, prog, call.at)) {
             return null

--- a/modules/dasSQLITE/tutorial/04-select_all.das
+++ b/modules/dasSQLITE/tutorial/04-select_all.das
@@ -40,7 +40,7 @@ def main() {
 
         // ── Filter with _where (bind capture) ─────────────────────────
         // Free variables in the predicate become `?` bind parameters.
-        // Macro emits:  ... WHERE Price > ?     binds: [threshold]
+        // Macro emits:  ... WHERE "Price" > ?     binds: [threshold]
         let threshold = 200
         let pricey <- _sql(db |> select_from(type<Car>) |> _where(_.Price > threshold))
         to_log(LOG_INFO, "Cars priced over {threshold}:\n")

--- a/modules/dasSQLITE/tutorial/04-select_all.das
+++ b/modules/dasSQLITE/tutorial/04-select_all.das
@@ -1,30 +1,63 @@
 options gen2
-// based on https://zetcode.com/db/sqlitec/
+
+// Tutorial 04 — Reading rows with `_sql`.
+//
+// Defines a [sql_table] struct, inserts a few rows, and reads them back through
+// the `_sql(...)` call macro. `_sql` takes a daslib/linq-shaped chain
+// (`db |> select_from(type<T>) |> _select(_.X) |> _where(predicate)` etc.)
+// and translates it at compile time into SQL + bound parameters. The runtime
+// just runs the prepared statement and materializes the result.
 
 require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
 
 [export]
-def main {
-    var db : sqlite3?
-    var rc = sqlite3_open("test.db", unsafe(addr(db)))
-    if (rc != SQLITE_OK) {
-        to_log(LOG_ERROR, "Cannot open database: sqlite3_errmsg(db)\n")
-        sqlite3_close(db)
-        return
-    }
-    var err_msg : string
-    rc = sqlite3_exec(db, "SELECT * FROM Cars", unsafe(addr(err_msg))) $(values, columns) {
-        for (v, c in values, columns) {
-            print("{c} = {v}; ")
+def main() {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+        db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+        db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+        db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+        db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+
+        // ── Read every row ────────────────────────────────────────────
+        // _sql(db |> select_from(type<Car>)) compiles to:
+        //   SELECT "Id", "Name", "Price" FROM "Cars"
+        // and materializes each row as a Car.
+        let cars <- _sql(db |> select_from(type<Car>))
+        to_log(LOG_INFO, "Read {length(cars)} cars:\n")
+        for (car in cars) {
+            to_log(LOG_INFO, "  Id={car.Id} Name={car.Name} Price={car.Price}\n")
         }
-        print("\n")
-        return SQLITE_OK
+
+        // ── Filter with _where (bind capture) ─────────────────────────
+        // Free variables in the predicate become `?` bind parameters.
+        // Macro emits:  ... WHERE Price > ?     binds: [threshold]
+        let threshold = 200
+        let pricey <- _sql(db |> select_from(type<Car>) |> _where(_.Price > threshold))
+        to_log(LOG_INFO, "Cars priced over {threshold}:\n")
+        for (car in pricey) {
+            to_log(LOG_INFO, "  {car.Name}: {car.Price}\n")
+        }
+
+        // ── Project a single column with _select ──────────────────────
+        // Macro emits:  SELECT "Name" FROM "Cars"
+        // Result type is array<string>.
+        let names <- _sql(db |> select_from(type<Car>) |> _select(_.Name))
+        to_log(LOG_INFO, "All car names: {names}\n")
+
+        // ── Inspect the generated SQL ─────────────────────────────────
+        // _sql_text emits the SQL string the macro would have run, with `?`
+        // placeholders for binds. Useful for tests and debugging.
+        let sql_text = _sql_text(db |> select_from(type<Car>) |> _where(_.Id == 5))
+        to_log(LOG_INFO, "_sql_text: {sql_text}\n")
     }
-    if (rc != SQLITE_OK) {
-        to_log(LOG_ERROR, "SQL error: {err_msg}\n")
-        sqlite3_free(err_msg)
-        sqlite3_close(db)
-        return
-    }
-    sqlite3_close(db)
 }

--- a/skills/das_macros.md
+++ b/skills/das_macros.md
@@ -143,3 +143,100 @@ positive/negative pair together — do not say "negate with `!`".
 Discoverability is part of the UX.
 
 This avoids parser issues with `qmacro_function` body that contains complex nested blocks or variable declarations.
+
+## `[call_macro]` entry-guard contract
+
+Every `[call_macro]` `class : AstCallMacro` declares an implicit contract
+about how its `visit()` sees its arguments. Get this wrong and you'll
+either expand against unresolved AST (and produce gibberish) or miss
+inner macro expansions entirely.
+
+### `canVisitArgument=true` is the default — inner-first expansion
+
+Daslang's macro pass walks each call_macro argument before firing the
+outer macro's `visit`. The walk runs the typer **and** any inner
+call_macros recursively. By the time `visit(call)` runs:
+
+- inner `_where(...)`, `_select(...)`, etc. — and any user-defined
+  wrapper that expands to one of them — have **already cascaded** into
+  their canonical `where_(...,$(_:T)=>...)` / `select(...)` shapes;
+- type-checked sub-expressions carry resolved `_type`;
+- field reads on those resolved types may be wrapped in
+  `ExprRef2Value` (the value-from-ref adapter the typer inserts);
+- raw arguments that genuinely can't type yet (e.g. `_.Field` outside
+  a lambda, where `_` is unbound) stay as raw AST with `null _type` —
+  the macro pass tolerates these because the outer macro is going to
+  rewrite them anyway.
+
+You almost never want to override this default. The Mode-1/Mode-2 story
+documented in `modules/dasSQLITE/API_REWORK.md` chunk-2 section is the
+cautionary tale: `_sql` shipped briefly with `canVisitArgument → false`
+overrides because a synthetic test seemed to show inner expansion not
+firing. The real cause was a missing `require daslib/linq_boost public`
+in `sqlite_linq.das` — without that, `_where` / `_select` weren't
+registered as call_macros at user-file scope, so they had nothing to
+expand into. Removing the override + adding the require made everything
+work. **If inner macros aren't expanding, look for a missing require
+before changing visit semantics.**
+
+### Entry guards: `macro_verify`, not `return null`
+
+When `visit()` must assume a property of its arguments (typed input,
+non-auto chain, expected arity), check it loudly with `macro_verify`,
+including a `{describe(arg)}` in the message:
+
+```
+[call_macro(name="_sql")]
+class private SqlMacro : AstCallMacro {
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        macro_verify(call.arguments |> length == 1, prog, call.at,
+            "_sql expects one argument: a chain expression")
+        var argT = call.arguments[0]._type
+        macro_verify(argT != null, prog, call.at,
+            "_sql: chain argument has null _type — inner call_macros did not expand " +
+            "before this fired. Arg: {describe(call.arguments[0])}")
+        macro_verify(!argT.isAutoOrAlias, prog, call.at,
+            "_sql: chain type is auto/alias after _type is set — compiler bug")
+        // ... real work
+    }
+}
+```
+
+A null `_type` on the chain argument doesn't mean "Mode 2 is broken" —
+it means an inner call_macro that should have expanded didn't, almost
+always because the user didn't `require` the module that defines it.
+Loud failure tells the user that immediately; silent `return null`
+re-queues the macro and lets the daslang pipeline emit a confusing
+infer-time cascade instead.
+
+### Peel `ExprRef2Value` before `qmatch`
+
+Post-Mode-2-expansion AST walking will see field reads wrapped in
+`ExprRef2Value`. `qmatch` is RTTI-strict — it matches `ExprField` but
+not `ExprRef2Value(ExprField(...))`. Peel before matching:
+
+```
+if (node is ExprRef2Value) {
+    node = (node as ExprRef2Value).subexpr
+    if (node == null) {
+        macro_error(prog, at, "_where: ExprRef2Value with null subexpr")
+        return ""
+    }
+}
+// now `qmatch(node, _.$f(name))` etc. work as expected
+```
+
+Auto-peel inside `qmatch` itself is a TODO documented in
+`daslib/ast_match.das`. Until then, every analyzer entry point that
+takes an expression coming out of post-expansion (predicate body,
+projection body, classifier helpers like `is_const_or_captured_var`)
+needs the peel at the top.
+
+### When you really do need raw arguments
+
+If a macro genuinely needs un-expanded raw AST (rare — mostly for
+qmacro-only sugar that builds new code without inspecting it), override
+`canVisitArgument` to return `false` for those argument indices. Pair
+with a unit test that exercises the inner-macro composition case
+specifically — that's the path that breaks first when the override is
+wrong.

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -104,6 +104,7 @@ SET(AOT_DASSQLITE_MODULE_FILES)
 IF(NOT DAS_SQLITE_DISABLED)
     SET(AOT_DASSQLITE_MODULE_FILES
         modules/dasSQLITE/daslib/sqlite_boost.das
+        modules/dasSQLITE/daslib/sqlite_linq.das
     )
 ENDIF()
 
@@ -111,6 +112,8 @@ ENDIF()
 SET(AOT_DASSQLITE_FILES)
 IF(NOT DAS_SQLITE_DISABLED)
     FILE(GLOB AOT_DASSQLITE_FILES RELATIVE ${PROJECT_SOURCE_DIR} "tests/dasSQLITE/*.das")
+    # Exclude expect-error tests (they intentionally fail to compile)
+    list(FILTER AOT_DASSQLITE_FILES EXCLUDE REGEX "failed_")
 ENDIF()
 
 # AOT for strudel/audio module library files (required by strudel tests)

--- a/tests/dasSQLITE/failed_sql_macro.das
+++ b/tests/dasSQLITE/failed_sql_macro.das
@@ -1,0 +1,47 @@
+options gen2
+
+// Each `_sql` / `_sql_text` call below is intentionally malformed and must
+// produce a macro_error (40104) from the analyzer. Under Mode 2
+// (canVisitArgument=true, inner call_macros expand before outer fires),
+// some malformed chains additionally cascade real type errors before the
+// analyzer ever runs — e.g. `_select(_.Name) |> _select(_.Price)` is a
+// genuine type bug (string has no `Price` field) and `some_unknown_func(_)`
+// hits the unresolved function. Those cascades are expected.
+expect 40104:7, 30304:2, 30503:1
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+[export]
+def main() {
+    var db = SqlRunner()
+
+    // 1. _sql(non-chain) — bare integer is not a chain
+    let bad1 <- _sql(42)
+
+    // 2. _sql(chain rooted at wrong fn) — chain root must be select_from
+    let bad2 <- _sql(db |> insert(Car(Id = 1, Name = "x", Price = 0)))
+
+    // 3. _sql with unsupported chain operator (linq's _order_by, not in chunk 2)
+    let bad3 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Id))
+
+    // 4. _sql with double _select
+    let bad4 <- _sql(db |> select_from(type<Car>) |> _select(_.Name) |> _select(_.Price))
+
+    // 5. _sql with _select projection that's not a column ref (chunk 2 only supports _.Field)
+    let bad5 <- _sql(db |> select_from(type<Car>) |> _select(_.Price * 2))
+
+    // 6. _sql with _where containing an unsupported expression (function call inside)
+    let bad6 <- _sql(db |> select_from(type<Car>) |> _where(some_unknown_func(_.Id)))
+
+    // 7. _sql_text with non-chain
+    let bad7 = _sql_text(42)
+}

--- a/tests/dasSQLITE/test_04_user_types.das
+++ b/tests/dasSQLITE/test_04_user_types.das
@@ -3,6 +3,7 @@ options gen2
 require dastest/testing_boost public
 
 require daslib/sql
+require daslib/strings_boost
 require sqlite/sqlite_boost
 
 // User-defined column type. Stored as TEXT, formatted "r,g,b" on bind, parsed
@@ -21,6 +22,13 @@ def sqlite_sql_type(witness : Color) : string {
 def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : Color) : void {
     let s = "{value.r},{value.g},{value.b}"
     sqlite3_bind_text(stmt, idx, s)
+}
+
+[unused_argument(t)]
+def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<Color>) : Color {
+    let s = sqlite3_column_text_(stmt, col)
+    let parts <- split(s, ",")
+    return Color(r = to_int(parts[0]), g = to_int(parts[1]), b = to_int(parts[2]))
 }
 
 [sql_table(name="Pixels")]
@@ -42,5 +50,23 @@ def test_user_type_round_trip(t : T?) {
         db |> insert(Pixel(Id = 1, Tint = Color(r = 255, g = 64, b = 0)))
         let s = db |> query_scalar("SELECT Tint FROM Pixels WHERE Id = 1", type<string>)
         t |> equal(s, "255,64,0", "user sqlite_bind formatted the value on insert")
+    }
+}
+
+[test]
+def test_user_type_select_from(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Pixel>)
+        db |> insert(Pixel(Id = 1, Tint = Color(r = 255, g = 64, b = 0)))
+        db |> insert(Pixel(Id = 2, Tint = Color(r = 0, g = 128, b = 255)))
+        let rows <- db |> select_from(type<Pixel>)
+        t |> equal(length(rows), 2, "select_from returns all rows")
+        t |> equal(rows[0].Id, 1, "row 0 Id")
+        t |> equal(rows[0].Tint.r, 255, "row 0 Tint.r — round-tripped through user sqlite_read")
+        t |> equal(rows[0].Tint.g, 64, "row 0 Tint.g")
+        t |> equal(rows[0].Tint.b, 0, "row 0 Tint.b")
+        t |> equal(rows[1].Tint.r, 0, "row 1 Tint.r")
+        t |> equal(rows[1].Tint.g, 128, "row 1 Tint.g")
+        t |> equal(rows[1].Tint.b, 255, "row 1 Tint.b")
     }
 }

--- a/tests/dasSQLITE/test_05_sql_macro.das
+++ b/tests/dasSQLITE/test_05_sql_macro.das
@@ -1,0 +1,223 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",     Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",    Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla",   Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",    Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo",   Price = 999))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _sql — bare select_from
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_sql_bare_select_from_empty_table(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        let cars <- _sql(db |> select_from(type<Car>))
+        t |> equal(length(cars), 0, "empty table -> empty array")
+    }
+}
+
+[test]
+def test_sql_bare_select_from_returns_all_rows(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>))
+        t |> equal(length(cars), 5, "5 rows expected")
+        t |> equal(cars[0].Id,    1,        "row 0 Id")
+        t |> equal(cars[0].Name,  "BMW",    "row 0 Name")
+        t |> equal(cars[0].Price, 100,      "row 0 Price")
+        t |> equal(cars[4].Id,    5,        "row 4 Id")
+        t |> equal(cars[4].Name,  "Lambo",  "row 4 Name")
+        t |> equal(cars[4].Price, 999,      "row 4 Price")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _to_array — explicit terminal (no-op semantically)
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_sql_to_array_explicit_terminal(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> _to_array())
+        t |> equal(length(cars), 5, "_to_array() yields the same array")
+        t |> equal(cars[0].Name, "BMW", "row 0 Name preserved")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _select — single-column projection
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_sql_select_string_column(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let names <- _sql(db |> select_from(type<Car>) |> _select(_.Name))
+        t |> equal(length(names), 5, "5 names expected")
+        t |> equal(names[0], "BMW",   "name 0")
+        t |> equal(names[2], "Tesla", "name 2")
+        t |> equal(names[4], "Lambo", "name 4")
+    }
+}
+
+[test]
+def test_sql_select_int_column(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let prices <- _sql(db |> select_from(type<Car>) |> _select(_.Price))
+        t |> equal(length(prices), 5, "5 prices expected")
+        t |> equal(prices[0], 100, "price 0")
+        t |> equal(prices[3], 50,  "price 3")
+        t |> equal(prices[4], 999, "price 4")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _where — predicate filter with bind capture
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_sql_where_eq_literal_int(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> _where(_.Id == 3))
+        t |> equal(length(cars), 1, "one row matches Id=3")
+        t |> equal(cars[0].Name, "Tesla", "matched Tesla")
+    }
+}
+
+[test]
+def test_sql_where_eq_literal_string(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> _where(_.Name == "Audi"))
+        t |> equal(length(cars), 1, "one row matches Name=Audi")
+        t |> equal(cars[0].Id, 2, "matched Id 2")
+    }
+}
+
+[test]
+def test_sql_where_captured_var(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let target = 4
+        let cars <- _sql(db |> select_from(type<Car>) |> _where(_.Id == target))
+        t |> equal(length(cars), 1, "one row matches captured target")
+        t |> equal(cars[0].Name, "Lada", "matched Lada")
+    }
+}
+
+[test]
+def test_sql_where_gt_literal(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> _where(_.Price > 200))
+        t |> equal(length(cars), 2, "two rows priced > 200 (Tesla, Lambo)")
+        t |> equal(cars[0].Name, "Tesla", "row 0 Tesla")
+        t |> equal(cars[1].Name, "Lambo", "row 1 Lambo")
+    }
+}
+
+[test]
+def test_sql_where_lt_literal(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> _where(_.Price < 100))
+        t |> equal(length(cars), 1, "one row priced < 100 (Lada)")
+        t |> equal(cars[0].Name, "Lada", "matched Lada")
+    }
+}
+
+[test]
+def test_sql_where_neq(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> _where(_.Id != 3))
+        t |> equal(length(cars), 4, "four rows have Id != 3")
+    }
+}
+
+[test]
+def test_sql_where_and_with_two_captures(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let lo = 100
+        let hi = 300
+        let cars <- _sql(db |> select_from(type<Car>) |> _where(_.Price >= lo && _.Price <= hi))
+        t |> equal(length(cars), 3, "BMW, Audi, Tesla in [100, 300]")
+        t |> equal(cars[0].Name, "BMW",   "row 0")
+        t |> equal(cars[1].Name, "Audi",  "row 1")
+        t |> equal(cars[2].Name, "Tesla", "row 2")
+    }
+}
+
+[test]
+def test_sql_where_or(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> _where(_.Id == 1 || _.Id == 5))
+        t |> equal(length(cars), 2, "two rows: Id=1 OR Id=5")
+        t |> equal(cars[0].Name, "BMW",   "row 0")
+        t |> equal(cars[1].Name, "Lambo", "row 1")
+    }
+}
+
+[test]
+def test_sql_where_not(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> _where(!(_.Id == 3)))
+        t |> equal(length(cars), 4, "four rows have NOT Id=3")
+    }
+}
+
+[test]
+def test_sql_where_then_select_compound(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let names <- _sql(db |> select_from(type<Car>) |> _where(_.Price >= 200) |> _select(_.Name))
+        t |> equal(length(names), 3, "three names priced >= 200")
+        t |> equal(names[0], "Audi",  "row 0")
+        t |> equal(names[1], "Tesla", "row 1")
+        t |> equal(names[2], "Lambo", "row 2")
+    }
+}
+
+[test]
+def test_sql_two_where_calls_compose_as_and(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> _where(_.Price >= 100) |> _where(_.Price <= 300))
+        t |> equal(length(cars), 3, "two _where calls compose AND-wise: BMW, Audi, Tesla")
+    }
+}
+
+[test]
+def test_sql_with_to_array_terminal(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> _where(_.Id == 2) |> _to_array())
+        t |> equal(length(cars), 1, "_to_array as terminal yields a row")
+        t |> equal(cars[0].Name, "Audi", "matched Audi")
+    }
+}

--- a/tests/dasSQLITE/test_05a_select_from_compat.das
+++ b/tests/dasSQLITE/test_05a_select_from_compat.das
@@ -1,0 +1,134 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Compatibility mode: select_from used WITHOUT the _sql macro wrapper.
+//
+// `select_from(db, type<T>) : array<T>` is a regular runtime function. It
+// prepares `SELECT col1, col2, ... FROM Table`, steps the cursor, and
+// materializes every row via the chunk-1 `[sql_table]`-emitted
+// `_sql_read_row` helper + `sqlite_read` dispatch rail. Anything chained on
+// top in compat mode is plain daslib/linq running client-side over the
+// already-materialized array — no SQL push-down. `_sql` is the optimization
+// path; `select_from` standalone is the always-works baseline.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_compat_select_from_bare_returns_array(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- db |> select_from(type<Car>)
+        t |> equal(length(cars), 5,        "5 rows materialized")
+        t |> equal(cars[0].Name, "BMW",    "row 0 Name")
+        t |> equal(cars[2].Name, "Tesla",  "row 2 Name")
+        t |> equal(cars[4].Price, 999,     "row 4 Price")
+    }
+}
+
+[test]
+def test_compat_select_from_empty_table(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        let cars <- db |> select_from(type<Car>)
+        t |> equal(length(cars), 0, "empty table -> empty array")
+    }
+}
+
+[test]
+def test_compat_select_from_for_loop(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        var seen_ids : array<int>
+        seen_ids |> reserve(5)
+        for (car in db |> select_from(type<Car>)) {
+            seen_ids |> push(car.Id)
+        }
+        t |> equal(length(seen_ids), 5, "for loop iterates all rows")
+        t |> equal(seen_ids[0], 1, "first Id")
+        t |> equal(seen_ids[4], 5, "last Id")
+    }
+}
+
+[test]
+def test_compat_select_from_then_linq_where(t : T?) {
+    // No _sql wrapper: select_from materializes the whole table, then
+    // daslib/linq_boost's _where filters client-side over the array via
+    // each() iterator wrap.
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- db |> select_from(type<Car>)
+        let pricey <- unsafe(each(cars)) |> _where_to_array(_.Price > 200)
+        t |> equal(length(pricey), 2, "linq _where over materialized array")
+        t |> equal(pricey[0].Name, "Tesla", "row 0")
+        t |> equal(pricey[1].Name, "Lambo", "row 1")
+    }
+}
+
+[test]
+def test_compat_select_from_then_linq_select(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- db |> select_from(type<Car>)
+        let names <- unsafe(each(cars)) |> _select_to_array(_.Name)
+        t |> equal(length(names), 5, "linq _select over materialized array")
+        t |> equal(names[0], "BMW",   "name 0")
+        t |> equal(names[4], "Lambo", "name 4")
+    }
+}
+
+[test]
+def test_compat_select_from_chain_with_to_array_terminal(t : T?) {
+    // sqlite_linq's _to_array is a regular passthrough function in compat
+    // mode — it just returns the array.
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- db |> select_from(type<Car>) |> _to_array()
+        t |> equal(length(cars), 5, "_to_array() in compat mode is a passthrough")
+        t |> equal(cars[2].Name, "Tesla", "row 2 preserved")
+    }
+}
+
+[test]
+def test_compat_try_select_from_ok(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        var r <- db |> try_select_from(type<Car>)
+        t |> success(r |> is_ok, "try_select_from returns Ok on a valid table")
+        let cars <- r |> unwrap
+        t |> equal(length(cars), 5, "5 rows via try_ form")
+    }
+}
+
+[test]
+def test_compat_try_select_from_propagates_error(t : T?) {
+    // Calling select_from on a Car table that doesn't exist surfaces the
+    // libsqlite3 errmsg through Result rather than panicking.
+    with_sqlite(":memory:") $(db) {
+        // Note: we did NOT create the Cars table, so the SELECT must fail.
+        var r <- db |> try_select_from(type<Car>)
+        t |> success(r |> is_err, "try_select_from returns Err on missing table")
+    }
+}

--- a/tests/dasSQLITE/test_06_sql_text.das
+++ b/tests/dasSQLITE/test_06_sql_text.das
@@ -73,49 +73,49 @@ def test_sql_text_select_int_column(t : T?) {
 def test_sql_text_where_eq_literal(t : T?) {
     var _db = SqlRunner()
     let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Id == 5))
-    t |> equal(sql, "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE Id = ?", "WHERE eq literal: ?")
+    t |> equal(sql, "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE \"Id\" = ?", "WHERE eq literal: ?")
 }
 
 [test]
 def test_sql_text_where_neq(t : T?) {
     var _db = SqlRunner()
     let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Id != 5))
-    t |> success(sql |> find("WHERE Id <> ?") >= 0, "WHERE != becomes <>")
+    t |> success(sql |> find("WHERE \"Id\" <> ?") >= 0, "WHERE != becomes <>")
 }
 
 [test]
 def test_sql_text_where_lt(t : T?) {
     var _db = SqlRunner()
     let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price < 200))
-    t |> success(sql |> find("WHERE Price < ?") >= 0, "WHERE < emits <")
+    t |> success(sql |> find("WHERE \"Price\" < ?") >= 0, "WHERE < emits <")
 }
 
 [test]
 def test_sql_text_where_le(t : T?) {
     var _db = SqlRunner()
     let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price <= 200))
-    t |> success(sql |> find("WHERE Price <= ?") >= 0, "WHERE <= emits <=")
+    t |> success(sql |> find("WHERE \"Price\" <= ?") >= 0, "WHERE <= emits <=")
 }
 
 [test]
 def test_sql_text_where_gt(t : T?) {
     var _db = SqlRunner()
     let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price > 200))
-    t |> success(sql |> find("WHERE Price > ?") >= 0, "WHERE > emits >")
+    t |> success(sql |> find("WHERE \"Price\" > ?") >= 0, "WHERE > emits >")
 }
 
 [test]
 def test_sql_text_where_ge(t : T?) {
     var _db = SqlRunner()
     let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price >= 200))
-    t |> success(sql |> find("WHERE Price >= ?") >= 0, "WHERE >= emits >=")
+    t |> success(sql |> find("WHERE \"Price\" >= ?") >= 0, "WHERE >= emits >=")
 }
 
 [test]
 def test_sql_text_where_string_literal(t : T?) {
     var _db = SqlRunner()
     let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Name == "BMW"))
-    t |> success(sql |> find("WHERE Name = ?") >= 0, "WHERE eq string literal also gets ? placeholder")
+    t |> success(sql |> find("WHERE \"Name\" = ?") >= 0, "WHERE eq string literal also gets ? placeholder")
 }
 
 [test]
@@ -123,7 +123,7 @@ def test_sql_text_where_captured_var(t : T?) {
     var _db = SqlRunner()
     let _target = 3
     let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Id == _target))
-    t |> success(sql |> find("WHERE Id = ?") >= 0, "captured var also yields ? placeholder")
+    t |> success(sql |> find("WHERE \"Id\" = ?") >= 0, "captured var also yields ? placeholder")
 }
 
 [test]
@@ -144,8 +144,8 @@ def test_sql_text_where_and(t : T?) {
     let _hi = 500
     let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price >= _lo && _.Price <= _hi))
     t |> success(sql |> find("AND") >= 0, "AND appears in compound WHERE")
-    t |> success(sql |> find("Price >= ?") >= 0, "first conjunct present")
-    t |> success(sql |> find("Price <= ?") >= 0, "second conjunct present")
+    t |> success(sql |> find("\"Price\" >= ?") >= 0, "first conjunct present")
+    t |> success(sql |> find("\"Price\" <= ?") >= 0, "second conjunct present")
 }
 
 [test]
@@ -168,7 +168,7 @@ def test_sql_text_where_not(t : T?) {
 def test_sql_text_where_then_select(t : T?) {
     var _db = SqlRunner()
     let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price > 100) |> _select(_.Name))
-    t |> equal(sql, "SELECT \"Name\" FROM \"Cars\" WHERE Price > ?", "_where + _select compose")
+    t |> equal(sql, "SELECT \"Name\" FROM \"Cars\" WHERE \"Price\" > ?", "_where + _select compose")
 }
 
 [test]

--- a/tests/dasSQLITE/test_06_sql_text.das
+++ b/tests/dasSQLITE/test_06_sql_text.das
@@ -1,0 +1,180 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _sql_text — compile-time SQL emission. The chain expression is never run;
+// the macro inspects the AST and returns the SQL string that _sql() would
+// have emitted. Whitespace is canonicalized (single spaces, no trailing).
+//
+// The dummy `var _db = SqlRunner()` is unused at runtime — _sql_text never
+// executes the chain — so each test's binding-targets (`_db`, `_target`,
+// `_lo`, `_hi`) carry an `_` prefix to suppress the LINT002 unused-var
+// warning. The captured-var tests still exercise the bind-emission path
+// because the macro analyzer reads the AST regardless of runtime use.
+// ──────────────────────────────────────────────────────────────────────────
+
+// ── bare select_from ──────────────────────────────────────────────────────
+
+[test]
+def test_sql_text_bare_select_from(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>))
+    t |> equal(sql, "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\"", "bare select_from emits SELECT * with all columns and table name")
+}
+
+[test]
+def test_sql_text_uses_sql_table_name_override(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>))
+    t |> success(sql |> find("FROM \"Cars\"") >= 0, "FROM uses [sql_table(name=)] override, not struct name")
+}
+
+// ── _to_array — no-op terminal ────────────────────────────────────────────
+
+[test]
+def test_sql_text_to_array_is_noop(t : T?) {
+    var _db = SqlRunner()
+    let with_to    = _sql_text(_db |> select_from(type<Car>) |> _to_array())
+    let without_to = _sql_text(_db |> select_from(type<Car>))
+    t |> equal(with_to, without_to, "_to_array() does not change emitted SQL")
+}
+
+// ── _select — single-column projection ───────────────────────────────────
+
+[test]
+def test_sql_text_select_single_column(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _select(_.Name))
+    t |> equal(sql, "SELECT \"Name\" FROM \"Cars\"", "_select(_.Field) projects single column")
+}
+
+[test]
+def test_sql_text_select_int_column(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _select(_.Price))
+    t |> equal(sql, "SELECT \"Price\" FROM \"Cars\"", "_select(_.IntField) projects int column")
+}
+
+// ── _where — filter clause ───────────────────────────────────────────────
+
+[test]
+def test_sql_text_where_eq_literal(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Id == 5))
+    t |> equal(sql, "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE Id = ?", "WHERE eq literal: ?")
+}
+
+[test]
+def test_sql_text_where_neq(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Id != 5))
+    t |> success(sql |> find("WHERE Id <> ?") >= 0, "WHERE != becomes <>")
+}
+
+[test]
+def test_sql_text_where_lt(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price < 200))
+    t |> success(sql |> find("WHERE Price < ?") >= 0, "WHERE < emits <")
+}
+
+[test]
+def test_sql_text_where_le(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price <= 200))
+    t |> success(sql |> find("WHERE Price <= ?") >= 0, "WHERE <= emits <=")
+}
+
+[test]
+def test_sql_text_where_gt(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price > 200))
+    t |> success(sql |> find("WHERE Price > ?") >= 0, "WHERE > emits >")
+}
+
+[test]
+def test_sql_text_where_ge(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price >= 200))
+    t |> success(sql |> find("WHERE Price >= ?") >= 0, "WHERE >= emits >=")
+}
+
+[test]
+def test_sql_text_where_string_literal(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Name == "BMW"))
+    t |> success(sql |> find("WHERE Name = ?") >= 0, "WHERE eq string literal also gets ? placeholder")
+}
+
+[test]
+def test_sql_text_where_captured_var(t : T?) {
+    var _db = SqlRunner()
+    let _target = 3
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Id == _target))
+    t |> success(sql |> find("WHERE Id = ?") >= 0, "captured var also yields ? placeholder")
+}
+
+[test]
+def test_sql_text_where_captured_and_literal_match(t : T?) {
+    // Captured-var literal vs. inline literal produce identical SQL — proves the
+    // macro emits placeholders, not the literal value.
+    var _db = SqlRunner()
+    let _target = 5
+    let with_var     = _sql_text(_db |> select_from(type<Car>) |> _where(_.Id == _target))
+    let with_literal = _sql_text(_db |> select_from(type<Car>) |> _where(_.Id == 5))
+    t |> equal(with_var, with_literal, "captured var and inline literal produce identical SQL (both ?)")
+}
+
+[test]
+def test_sql_text_where_and(t : T?) {
+    var _db = SqlRunner()
+    let _lo = 100
+    let _hi = 500
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price >= _lo && _.Price <= _hi))
+    t |> success(sql |> find("AND") >= 0, "AND appears in compound WHERE")
+    t |> success(sql |> find("Price >= ?") >= 0, "first conjunct present")
+    t |> success(sql |> find("Price <= ?") >= 0, "second conjunct present")
+}
+
+[test]
+def test_sql_text_where_or(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Id == 1 || _.Id == 2))
+    t |> success(sql |> find("OR") >= 0, "OR appears in compound WHERE")
+}
+
+[test]
+def test_sql_text_where_not(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(!(_.Id == 5)))
+    t |> success(sql |> find("NOT") >= 0, "NOT appears for ! op")
+}
+
+// ── compound: _where + _select ────────────────────────────────────────────
+
+[test]
+def test_sql_text_where_then_select(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price > 100) |> _select(_.Name))
+    t |> equal(sql, "SELECT \"Name\" FROM \"Cars\" WHERE Price > ?", "_where + _select compose")
+}
+
+[test]
+def test_sql_text_where_with_to_array(t : T?) {
+    var _db = SqlRunner()
+    let with_to    = _sql_text(_db |> select_from(type<Car>) |> _where(_.Id == 1) |> _to_array())
+    let without_to = _sql_text(_db |> select_from(type<Car>) |> _where(_.Id == 1))
+    t |> equal(with_to, without_to, "_to_array still no-op when chained after _where")
+}

--- a/tests/dasSQLITE/test_07_macros.das
+++ b/tests/dasSQLITE/test_07_macros.das
@@ -1,0 +1,70 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+options no_aot = true
+
+// Companion macro module for test_07_sql_composability.das.
+//
+// Defines two user-level wrapper call_macros that expand to `_where(it, ...)`.
+// Their purpose is to prove the chunk-2 composability story: under Mode 2
+// (`canVisitArgument=true`, the daslang default), inner call_macros expand
+// before the outer's `visit` fires. So when `_sql(... |> when_price_lt(...))`
+// runs, the macro pass first turns `when_price_lt` into `_where`, then turns
+// `_where` into `where_(...,$(_:T) => ...)`, then `_sql` sees the same
+// `where_` shape its analyzer recognizes — no special-casing required.
+
+module test_07_macros shared private
+
+require daslib/ast
+require daslib/ast_boost
+require daslib/macro_boost
+require daslib/templates_boost
+
+require daslib/linq_boost public
+require sqlite/sqlite_linq public
+
+// ──────────────────────────────────────────────────────────────────────────
+// Baked-field form: when_price_lt(it, value) → _where(it, _.Price < value)
+//
+// Field name is hardcoded in the macro. This is the simpler composability
+// case — only one free `_.Field` reference embedded inside the qmacro.
+// ──────────────────────────────────────────────────────────────────────────
+
+[call_macro(name="when_price_lt")]
+class WhenPriceLtMacro : AstCallMacro {
+    //! `when_price_lt(it, value)` expands to `_where(it, _.Price < value)`.
+    //! `_where` is itself a call_macro, so the macro pass cascades.
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        macro_verify(call.arguments |> length == 2, prog, call.at, "expecting when_price_lt(iterator, value)")
+        var it = call.arguments[0]
+        var val = call.arguments[1]
+        var res = qmacro(_where($e(it), _.Price < $e(val)))
+        res.force_at(call.at)
+        return res
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Generic form: when_lt(it, _.Field, value) → _where(it, _.Field < value)
+//
+// Field reference is passed in by the caller as the second argument. Tests
+// that a free-`_` field-ref expression survives transit through an outer
+// call_macro's argument list before the inner `_where` lambda binds it.
+// ──────────────────────────────────────────────────────────────────────────
+
+[call_macro(name="when_lt")]
+class WhenLtMacro : AstCallMacro {
+    //! `when_lt(it, fieldExpr, value)` expands to `_where(it, fieldExpr < value)`.
+    //! `fieldExpr` typically has shape `_.Field`; the unbound `_` resolves once
+    //! `_where` wraps the predicate in a `$(_:T) => ...` lambda.
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        macro_verify(call.arguments |> length == 3, prog, call.at, "expecting when_lt(iterator, field, value)")
+        var it = call.arguments[0]
+        var fld = call.arguments[1]
+        var val = call.arguments[2]
+        var res = qmacro(_where($e(it), $e(fld) < $e(val)))
+        res.force_at(call.at)
+        return res
+    }
+}

--- a/tests/dasSQLITE/test_07_sql_composability.das
+++ b/tests/dasSQLITE/test_07_sql_composability.das
@@ -48,7 +48,7 @@ def test_when_price_lt_sql_text(t : T?) {
     let with_wrapper = _sql_text(_db |> select_from(type<Car>) |> when_price_lt(200))
     let direct       = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price < 200))
     t |> equal(with_wrapper, direct, "when_price_lt and direct _where emit identical SQL")
-    t |> equal(with_wrapper, "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE Price < ?",
+    t |> equal(with_wrapper, "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE \"Price\" < ?",
         "wrapper round-trips through _where → where_ → analyzer with the expected SQL")
 }
 
@@ -89,7 +89,7 @@ def test_when_lt_sql_text(t : T?) {
 def test_when_lt_different_field(t : T?) {
     var _db = SqlRunner()
     let sql = _sql_text(_db |> select_from(type<Car>) |> when_lt(_.Id, 3))
-    t |> equal(sql, "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE Id < ?",
+    t |> equal(sql, "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE \"Id\" < ?",
         "field-ref argument routes through to the right column")
 }
 
@@ -132,7 +132,7 @@ def test_wrapper_then_select(t : T?) {
 def test_wrapper_then_select_sql_text(t : T?) {
     var _db = SqlRunner()
     let sql = _sql_text(_db |> select_from(type<Car>) |> when_price_lt(300) |> _select(_.Name))
-    t |> equal(sql, "SELECT \"Name\" FROM \"Cars\" WHERE Price < ?",
+    t |> equal(sql, "SELECT \"Name\" FROM \"Cars\" WHERE \"Price\" < ?",
         "wrapper-emitted WHERE composes with explicit _select projection")
 }
 

--- a/tests/dasSQLITE/test_07_sql_composability.das
+++ b/tests/dasSQLITE/test_07_sql_composability.das
@@ -1,0 +1,148 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+require test_07_macros
+
+// ──────────────────────────────────────────────────────────────────────────
+// Composability tests for `_sql`.
+//
+// Mode 2's promise: user-defined call_macros that expand to `_where` /
+// `_select` compose transparently inside `_sql(...)`. The macro pass
+// expands inner call_macros bottom-up before `_sql.visit` fires, so by the
+// time the analyzer walks the chain, every wrapper has already cascaded
+// into the canonical `where_(...,$(_:T) => ...)` / `select(...)` shape.
+//
+// `test_07_macros.das` defines two wrappers:
+//   * when_price_lt(it, val)         → _where(it, _.Price < val)
+//   * when_lt(it, fieldExpr, val)    → _where(it, fieldExpr < val)
+// ──────────────────────────────────────────────────────────────────────────
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Baked-field wrapper — when_price_lt
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_when_price_lt_sql_text(t : T?) {
+    var _db = SqlRunner()
+    let with_wrapper = _sql_text(_db |> select_from(type<Car>) |> when_price_lt(200))
+    let direct       = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price < 200))
+    t |> equal(with_wrapper, direct, "when_price_lt and direct _where emit identical SQL")
+    t |> equal(with_wrapper, "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE Price < ?",
+        "wrapper round-trips through _where → where_ → analyzer with the expected SQL")
+}
+
+[test]
+def test_when_price_lt_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> when_price_lt(200))
+        t |> equal(length(cars), 2, "two rows priced < 200")
+        t |> equal(cars[0].Name, "BMW",  "row 0")
+        t |> equal(cars[1].Name, "Lada", "row 1")
+    }
+}
+
+[test]
+def test_when_price_lt_with_captured_value(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let threshold = 300
+        let cars <- _sql(db |> select_from(type<Car>) |> when_price_lt(threshold))
+        t |> equal(length(cars), 3, "three rows priced < 300 (BMW, Lada, Audi)")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Generic wrapper — when_lt(it, _.Field, val)
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_when_lt_sql_text(t : T?) {
+    var _db = SqlRunner()
+    let with_wrapper = _sql_text(_db |> select_from(type<Car>) |> when_lt(_.Price, 200))
+    let direct       = _sql_text(_db |> select_from(type<Car>) |> _where(_.Price < 200))
+    t |> equal(with_wrapper, direct, "when_lt and direct _where emit identical SQL")
+}
+
+[test]
+def test_when_lt_different_field(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> when_lt(_.Id, 3))
+    t |> equal(sql, "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE Id < ?",
+        "field-ref argument routes through to the right column")
+}
+
+[test]
+def test_when_lt_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> when_lt(_.Id, 3))
+        t |> equal(length(cars), 2, "two rows with Id < 3 (BMW=1, Audi=2)")
+        t |> equal(cars[0].Name, "BMW",  "row 0")
+        t |> equal(cars[1].Name, "Audi", "row 1")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Composition: wrapper + canonical _where / _select in the same chain.
+// Verifies the analyzer treats wrapper-emitted `where_` calls identically
+// to user-written ones.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_wrapper_then_where_compose_as_and(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cars <- _sql(db |> select_from(type<Car>) |> when_price_lt(500) |> _where(_.Id != 2))
+        t |> equal(length(cars), 3, "Price<500 AND Id!=2 → BMW, Tesla, Lada")
+    }
+}
+
+[test]
+def test_wrapper_then_select(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let names <- _sql(db |> select_from(type<Car>) |> when_price_lt(300) |> _select(_.Name))
+        t |> equal(length(names), 3, "three names priced < 300 (BMW, Lada, Audi)")
+    }
+}
+
+[test]
+def test_wrapper_then_select_sql_text(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> when_price_lt(300) |> _select(_.Name))
+    t |> equal(sql, "SELECT \"Name\" FROM \"Cars\" WHERE Price < ?",
+        "wrapper-emitted WHERE composes with explicit _select projection")
+}
+
+[test]
+def test_two_wrappers_compose_as_and(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Two wrapper calls — proves the analyzer's where AND-composition
+        // treats wrapper output identically to source-level _where output.
+        let cars <- _sql(db |> select_from(type<Car>) |> when_price_lt(500) |> when_lt(_.Id, 4))
+        t |> equal(length(cars), 3, "Price<500 AND Id<4 → BMW(1), Audi(2), Tesla(3)")
+    }
+}


### PR DESCRIPTION
## Summary

- New `modules/dasSQLITE/daslib/sqlite_linq.das` housing the `_sql(chain) -> array<T>` LINQ-to-SQL translator and its SQL-text-debug companion `_sql_text(chain) -> string`. Operator surface: `select_from(type<T>)` (root) + `_to_array()` (no-op terminal) + `_select(_.Field)` (single-column projection) + `_where(predicate)` with bind capture (literals + free vars → `?`; supports `==`, `!=`, `<`, `<=`, `>`, `>=`, `&&`, `||`, `!`). Multiple `_where` calls compose AND-wise.
- Runtime additions in sqlite_boost: `sqlite_read(stmt, col, type<T>)` read-direction dispatch rail (mirrors `sqlite_bind`), `select_from(db, type<T>)`, and the `try_run_select` / `run_select` helpers the macro emits calls to. `[sql_table]` structure macro now also emits `_sql_select_all_sql` and `_sql_read_row` per user table.
- AOT enabled for sqlite_linq.das. The new expect-failure test `failed_sql_macro.das` is excluded from the AOT glob (`list(FILTER ... EXCLUDE REGEX "failed_")`, same pattern as `tests/decs/`) since AOT codegen exits with -1 on intentionally malformed code.
- Tutorial 04 (`tutorial/04-select_all.das`) is now a real script — first end-to-end exposure to `_sql`.

## Architecture: Mode 2 inner-first expansion

`_sql` runs as a plain `[call_macro]` with the **default `canVisitArgument=true`**. The macro pass expands inner call_macros bottom-up *before* the outer's `visit()` fires, so by the time the chain analyzer walks, `_where(it, expr)` has cascaded into `where_(it, $(_:T) => expr)`, `_select(it, expr)` into `select(...)`, and any user-defined wrapper that expands to one of them has cascaded into the same canonical shape. This makes the chain analyzer trivially small (pattern-matches `select_from` at root, `where_` / `select` calls in the body, `_to_array` outermost) and enables transparent composability.

The Mode-1/Mode-2 framing was nearly missed during development. An initial `canVisitArgument -> false` override was tried after a synthetic test seemed to show inner expansion not firing. Real cause: `sqlite_linq.das` didn't `require daslib/linq_boost public`, so `_where` / `_select` weren't registered as call_macros at user-file scope. Fix was the public require + removing the override; documented as a project-wide pattern in `skills/das_macros.md` (new "[call_macro] entry-guard contract" section: canVisitArgument default, `macro_verify` entry guards, `ExprRef2Value` peel pattern).

## Composability proof

`tests/dasSQLITE/test_07_sql_composability.das` (10 tests) verifies that user-defined wrapper macros compose transparently inside `_sql(...)`. Two wrapper styles exercised:

```
[call_macro(name="when_price_lt")]   // baked-field, 2-arg
class WhenPriceLtMacro : AstCallMacro {
    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
        var res = qmacro(_where($e(call.arguments[0]), _.Price < $e(call.arguments[1])))
        ...
    }
}

[call_macro(name="when_lt")]         // generic 3-arg, _.Field passed in
class WhenLtMacro : AstCallMacro {
    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
        var res = qmacro(_where($e(call.arguments[0]), $e(call.arguments[1]) < $e(call.arguments[2])))
        ...
    }
}
```

Tests cover `_sql_text` SQL parity vs direct `_where`, runtime row-result correctness, captured-value bind-through, and composition with explicit `_where` / `_select` downstream and with another wrapper.

## Test plan

- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/dasSQLITE` — **81/81 green**
  - test_05_sql_macro: 17 execution cases
  - test_05a_select_from_compat: 8 bare-select_from compat cases
  - test_06_sql_text: 19 SQL-string emission cases
  - test_07_sql_composability: 10 user-wrapper composition cases
  - test_07_macros: companion module (when_price_lt + when_lt)
  - failed_sql_macro: 1 expect-based macro-error case
  - test_04_user_types: extended with select_from round-trip
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/` — **6889 / 6889 green** (full interpreted suite)
- [x] `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests/dasSQLITE` — **81/81 green** (AOT)
- [x] `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests/` — **6301 / 6301 green** (full AOT suite)
- [x] Lint clean for chunk-2 files; format clean
- [x] Docs updated: `modules/dasSQLITE/API_REWORK.md` chunk-2 section, `modules/dasSQLITE/TUTORIALS.md` tut 04 status, `skills/das_macros.md` entry-guard contract section

## Deferred to chunk 3+

Struct-constructor and named-tuple `_select` projections; `_order_by`, `_take`, `_skip`, `_distinct`; aggregates (`_count`, `_sum`, `_avg`, `_min`, `_max`); `_first` / `_first_or_default`; `_group_by`, `_having`; `_join`, `_left_join`; `_in`, `_not_in`, `_any`, `_none`; the panic-free `_try_sql` variant. All planned (see `modules/dasSQLITE/API_REWORK.md`), none in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)