### PR TITLE
find_dupes: cross-file similar-function detector

### DIFF
--- a/utils/find_dupes/README.md
+++ b/utils/find_dupes/README.md
@@ -1,0 +1,99 @@
+# find_dupes — cross-file similar-function detector
+
+Walks a directory tree of `.das` files, normalises each user function into
+an alpha-renamed token stream (identifiers, types, and literals all
+collapsed), and reports:
+
+- **Exact-clone clusters** — functions that hash to the same canonical
+  text. Pure structural duplicates, modulo names/types/values.
+- **Fuzzy near-duplicates** — pairs whose 64-slot MinHash signatures
+  match above a threshold AND whose token counts are within the same
+  threshold (the length gate suppresses MinHash false-positives on
+  highly periodic boilerplate).
+
+Useful for surfacing test-suite boilerplate that could be factored,
+near-clones that drifted apart, or copy-pasted helpers that escaped
+review.
+
+## Usage
+
+```sh
+./bin/daslang utils/find_dupes/main.das -- -p tests --json /tmp/dupes.json
+./bin/daslang utils/find_dupes/main.das -- -p tests/strings -t 0.85 -n 20
+./bin/daslang utils/find_dupes/main.das -- -p daslib --no-fuzzy --min-tokens 32
+./bin/daslang utils/find_dupes/main.das -- -p tests -L --min-tokens 16    # cluster dastest run() bodies
+./bin/daslang utils/find_dupes/main.das -- -?
+```
+
+`./bin/daslang -jit utils/find_dupes/main.das -- …` works too — find_dupes itself JITs cleanly. Net runtime improvement is modest because per-file cost is dominated by interpreter compilation of the scanned files.
+
+Flags:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `-p / --path` | required | File or directory to scan; repeatable |
+| `-t / --threshold` | 0.7 | Fuzzy similarity floor (0..1). Combined Jaccard × length-ratio |
+| `-n / --top` | 20 | Top-N entries shown in stdout summary |
+| `--json` | (off) | Path for full JSON report |
+| `-x / --no-fuzzy` | off | Skip MinHash pass — exact clusters only |
+| `--min-tokens` | 8 | Drop functions with fewer than N tokens (filters trivial wrappers) |
+| `-L / --lambdas-only` | off | Skip top-level functions, keep only lambdas — useful for clustering dastest `t \|> run("…") @(t) { … }` bodies |
+| `-v / --verbose` | off | Per-file progress |
+| `-?` | | Help |
+
+`builtin.das`, `daslib/debugger.das`, and `daslib/profiler.das` are skipped automatically — the latter two install thread-local debug agents at compile time, which would abort the scanner on second use.
+
+## Canonical form
+
+Each function emits a flat tag stream. Examples:
+
+| Source | Canonical (excerpt) |
+|---|---|
+| `def add(a,b:int):int { return a+b }` | `FN ARG <var_0> TYP ARG <var_1> TYP TYP BODY BLK STMT RET OP2:+ <var_0> <var_1> ENDBLK ENDFN` |
+| `def add(a,b:float):float { return a+b }` | (same — types collapse) |
+| `def double(a:int) { return a*2 }` | `FN ARG <var_0> TYP BODY BLK STMT RET OP2:* <var_0> LIT ENDBLK ENDFN` |
+
+User identifiers → `<var_0>`, `<var_1>`, …
+All types → `TYP`. All literals → `LIT`. Field/swizzle names → `.FLD` /
+`.SWZ`. Called function names are kept (`CALL:push` vs `CALL:emplace`
+is real signal).
+
+## Implementation
+
+| File | Role |
+|---|---|
+| `canonical.das` | `CanonicalVisitor` (extends `daslib/ast` `AstVisitor`) and `tokenize_canonical` |
+| `minhash.das` | 64-slot MinHash signatures over 5-grams, Jaccard estimate |
+| `cluster.das` | Exact-bucket clustering + fuzzy all-pairs with length gate |
+| `report.das` | JSON + stdout summary writer |
+| `main.das` | CLI (`daslib/clargs`), file scan, compile-and-collect orchestration |
+| `fixture/synth.das` | Hand-crafted fixture for smoke-testing the visitor end-to-end |
+
+Notes:
+
+- Compile policy mirrors `utils/lint`: `ignore_shared_modules`,
+  `export_all`. Optimisations and infer-time folding stay ON so dastest
+  macros (e.g. `unroll`) compile.
+- **Default mode** drops everything `generated` (which includes
+  lambdas). The dispatcher already references each lambda via an `ADDR`
+  token, so the lambda's structural fingerprint is partially preserved
+  in the parent function. Use `-L` to flip this and cluster the lambda
+  bodies themselves.
+- **Lambda-only mode (`-L`)** is dominated at the top by linq's `each`
+  macro emissions (a 100+-token `GOTO/LABEL/_builtin_iterator_first /
+  next/close` shell that recurs hundreds of times). Real test-body
+  signal starts a few clusters down; sort/grep accordingly.
+- Functions whose `at.fileInfo` points outside the compiled file are
+  filtered out — without this, reified generics from required modules
+  (e.g. `dastest/testing.das`) flood the report.
+- Per-source-line dedup: a generic reified for N types becomes N
+  FunctionPtrs all pointing at the same `(file, line)`. We keep the
+  first to avoid the same source location being counted N times.
+
+## Out of scope
+
+- LSH / banding (4.4K² is fine; revisit at >50K functions).
+- Embedding-based similarity (would need an external service).
+- Auto-fix or refactor suggestions — discovery only.
+- CI integration — first read what it finds; promote findings to lint
+  rules later.

--- a/utils/find_dupes/README.md
+++ b/utils/find_dupes/README.md
@@ -36,7 +36,7 @@ Flags:
 | Flag | Default | Meaning |
 |---|---|---|
 | `-p / --path` | required | File or directory to scan; repeatable |
-| `-t / --threshold` | 0.7 | Fuzzy similarity floor (0..1). Combined Jaccard × length-ratio |
+| `-t / --threshold` | 0.7 | Fuzzy similarity floor (0..1). Score is `sqrt(jaccard × len_ratio)` plus a hard `len_ratio ≥ threshold` gate |
 | `-n / --top` | 20 | Top-N entries shown in stdout summary |
 | `--json` | (off) | Path for full JSON report |
 | `-x / --no-fuzzy` | off | Skip MinHash pass — exact clusters only |

--- a/utils/find_dupes/README.md
+++ b/utils/find_dupes/README.md
@@ -6,10 +6,14 @@ collapsed), and reports:
 
 - **Exact-clone clusters** — functions that hash to the same canonical
   text. Pure structural duplicates, modulo names/types/values.
-- **Fuzzy near-duplicates** — pairs whose 64-slot MinHash signatures
-  match above a threshold AND whose token counts are within the same
-  threshold (the length gate suppresses MinHash false-positives on
-  highly periodic boilerplate).
+- **Fuzzy near-duplicates** — pairs scored as `sqrt(jaccard × len_ratio)`
+  on top of a 64-slot MinHash signature and a hard `len_ratio ≥ threshold`
+  gate. The length gate suppresses MinHash false-positives on highly
+  periodic boilerplate (otherwise a 4-statement and a 7-statement copy
+  of the same `t |> run(...)` block both look 100% identical to MinHash).
+  Note that the geometric mean admits Jaccard somewhat below `threshold`
+  when lengths match closely — this is intentional and biases toward
+  recall.
 
 Useful for surfacing test-suite boilerplate that could be factored,
 near-clones that drifted apart, or copy-pasted helpers that escaped

--- a/utils/find_dupes/canonical.das
+++ b/utils/find_dupes/canonical.das
@@ -1,0 +1,490 @@
+options gen2
+
+options rtti = true
+options strict_smart_pointers = false
+
+require daslib/rtti
+require daslib/ast
+require daslib/ast_boost
+require daslib/strings_boost
+
+
+// CanonicalVisitor walks one function and emits a flat tag stream
+// where every user identifier is replaced by <var_N>, every type by
+// <type>, and every literal by <lit>. The token stream is what we
+// hash for exact clustering and shingle for MinHash.
+class CanonicalVisitor : AstVisitor {
+    writer : StringBuilderWriter?
+    rename : table<string; string>
+    next_var : int = 0
+    typ_depth : int = 0
+
+    def emit(tag : string) {
+        write(*writer, tag)
+        write(*writer, " ")
+    }
+
+    def assign_var(name : das_string) : string {
+        let key = string(name)
+        if (key_exists(rename, key)) {
+            return rename[key]
+        }
+        let placeholder = "<var_{next_var}>"
+        rename |> insert(key, placeholder)
+        next_var++
+        return placeholder
+    }
+
+    def lookup_var(name : das_string) : string {
+        let key = string(name)
+        if (key_exists(rename, key)) {
+            return rename[key]
+        }
+        return "<sym>"
+    }
+
+// function
+    def override preVisitFunction(fun : FunctionPtr) {
+        rename |> clear
+        next_var = 0
+        typ_depth = 0
+        emit(fun.flags._lambda ? "LAMBDA" : "FN")
+    }
+    def override visitFunction(var fun : FunctionPtr) : FunctionPtr {
+        emit("ENDFN")
+        return fun
+    }
+    def override preVisitFunctionArgument(fun : FunctionPtr; arg : VariablePtr; lastArg : bool) {
+        let p = assign_var(arg.name)
+        emit("ARG")
+        emit(p)
+    }
+    def override preVisitFunctionBody(fun : FunctionPtr; expr : ExpressionPtr) {
+        emit("BODY")
+    }
+
+// type
+    def override preVisitTypeDecl(typ : TypeDeclPtr) {
+        if (typ_depth == 0) {
+            emit("TYP")
+        }
+        typ_depth++
+    }
+    def override visitTypeDecl(var typ : TypeDeclPtr) : TypeDeclPtr {
+        typ_depth--
+        return typ
+    }
+
+// alias
+    def override preVisitAlias(typ : TypeDeclPtr; name : das_string) {
+        emit("ALIAS")
+    }
+
+// block
+    def override preVisitExprBlock(blk : ExprBlock?) {
+        emit("BLK")
+    }
+    def override visitExprBlock(blk : ExprBlock?) : ExpressionPtr {
+        emit("ENDBLK")
+        return unsafe(reinterpret<ExpressionPtr>(blk))
+    }
+    def override preVisitExprBlockArgument(blk : ExprBlock?; arg : VariablePtr; lastArg : bool) {
+        let p = assign_var(arg.name)
+        emit("BLK_ARG")
+        emit(p)
+    }
+    def override preVisitExprBlockExpression(blk : ExprBlock?; expr : ExpressionPtr) {
+        emit("STMT")
+    }
+    def override preVisitExprBlockFinalExpression(blk : ExprBlock?; expr : ExpressionPtr) {
+        emit("FIN_STMT")
+    }
+
+// let
+    def override preVisitExprLet(expr : ExprLet?) {
+        emit("LET")
+    }
+    def override preVisitExprLetVariable(expr : ExprLet?; arg : VariablePtr; lastArg : bool) {
+        let p = assign_var(arg.name)
+        emit("LET_VAR")
+        emit(p)
+    }
+
+// for
+    def override preVisitExprFor(expr : ExprFor?) {
+        emit("FOR")
+    }
+    def override preVisitExprForVariable(expr : ExprFor?; svar : VariablePtr; last : bool) {
+        let p = assign_var(svar.name)
+        emit("FOR_VAR")
+        emit(p)
+    }
+    def override preVisitExprForBody(expr : ExprFor?) {
+        emit("FOR_BODY")
+    }
+
+// while
+    def override preVisitExprWhile(expr : ExprWhile?) {
+        emit("WHILE")
+    }
+    def override preVisitExprWhileBody(expr : ExprWhile?; right : ExpressionPtr) {
+        emit("WHILE_BODY")
+    }
+
+// if
+    def override preVisitExprIfThenElse(expr : ExprIfThenElse?) {
+        emit("IF")
+    }
+    def override preVisitExprIfThenElseIfBlock(expr : ExprIfThenElse?; ifBlock : ExpressionPtr) {
+        emit("THEN")
+    }
+    def override preVisitExprIfThenElseElseBlock(expr : ExprIfThenElse?; elseBlock : ExpressionPtr) {
+        emit("ELSE")
+    }
+
+// try-catch
+    def override preVisitExprTryCatch(expr : ExprTryCatch?) {
+        emit("TRY")
+    }
+    def override preVisitExprTryCatchCatch(expr : ExprTryCatch?; right : ExpressionPtr) {
+        emit("CATCH")
+    }
+
+// with / assume
+    def override preVisitExprWith(expr : ExprWith?) {
+        emit("WITH")
+    }
+    def override preVisitExprAssume(expr : ExprAssume?) {
+        emit("ASSUME")
+    }
+
+// control flow
+    def override preVisitExprReturn(expr : ExprReturn?) {
+        emit("RET")
+    }
+    def override preVisitExprYield(expr : ExprYield?) {
+        emit("YIELD")
+    }
+    def override preVisitExprBreak(expr : ExprBreak?) {
+        emit("BREAK")
+    }
+    def override preVisitExprContinue(expr : ExprContinue?) {
+        emit("CONT")
+    }
+    def override preVisitExprLabel(expr : ExprLabel?) {
+        emit("LABEL")
+    }
+    def override preVisitExprGoto(expr : ExprGoto?) {
+        emit("GOTO")
+    }
+
+// operators
+    def override preVisitExprOp1(expr : ExprOp1?) {
+        emit("OP1:{expr.op}")
+    }
+    def override preVisitExprOp2(expr : ExprOp2?) {
+        emit("OP2:{expr.op}")
+    }
+    def override preVisitExprOp3(expr : ExprOp3?) {
+        emit("OP3")
+    }
+
+// copy/move/clone
+    def override preVisitExprCopy(expr : ExprCopy?) {
+        emit("COPY")
+    }
+    def override preVisitExprMove(expr : ExprMove?) {
+        emit("MOVE")
+    }
+    def override preVisitExprClone(expr : ExprClone?) {
+        emit("CLONE")
+    }
+
+// new / delete / cast / ascend
+    def override preVisitExprNew(expr : ExprNew?) {
+        emit("NEW")
+    }
+    def override preVisitExprDelete(expr : ExprDelete?) {
+        emit("DEL")
+    }
+    def override preVisitExprCast(expr : ExprCast?) {
+        emit("CAST")
+    }
+    def override preVisitExprAscend(expr : ExprAscend?) {
+        emit("ASC")
+    }
+    def override preVisitExprAddr(expr : ExprAddr?) {
+        emit("ADDR")
+    }
+    def override preVisitExprPtr2Ref(expr : ExprPtr2Ref?) {
+        emit("P2R")
+    }
+    def override preVisitExprRef2Value(expr : ExprRef2Value?) {
+        emit("R2V")
+    }
+    def override preVisitExprRef2Ptr(expr : ExprRef2Ptr?) {
+        emit("R2P")
+    }
+    def override preVisitExprUnsafe(expr : ExprUnsafe?) {
+        emit("UNSAFE")
+    }
+
+// at / safe at
+    def override preVisitExprAt(expr : ExprAt?) {
+        emit("AT")
+    }
+    def override preVisitExprSafeAt(expr : ExprSafeAt?) {
+        emit("SAFE_AT")
+    }
+
+// is / variant
+    def override preVisitExprIs(expr : ExprIs?) {
+        emit("IS")
+    }
+    def override preVisitExprIsVariant(expr : ExprIsVariant?) {
+        emit("IS_VAR")
+    }
+    def override preVisitExprAsVariant(expr : ExprAsVariant?) {
+        emit("AS_VAR")
+    }
+    def override preVisitExprSafeAsVariant(expr : ExprSafeAsVariant?) {
+        emit("SAFE_AS_VAR")
+    }
+
+// null coalescing
+    def override preVisitExprNullCoalescing(expr : ExprNullCoalescing?) {
+        emit("NCOA")
+    }
+
+// make-* aggregates
+    def override preVisitExprMakeStruct(expr : ExprMakeStruct?) {
+        emit("MK_STR")
+    }
+    def override preVisitExprMakeArray(expr : ExprMakeArray?) {
+        emit("MK_ARR")
+    }
+    def override preVisitExprMakeTuple(expr : ExprMakeTuple?) {
+        emit("MK_TUP")
+    }
+    def override preVisitExprMakeVariant(expr : ExprMakeVariant?) {
+        emit("MK_VAR")
+    }
+    def override preVisitExprMakeBlock(expr : ExprMakeBlock?) {
+        emit("MK_BLK")
+    }
+    def override preVisitExprMakeGenerator(expr : ExprMakeGenerator?) {
+        emit("MK_GEN")
+    }
+    def override preVisitExprArrayComprehension(expr : ExprArrayComprehension?) {
+        emit("ARR_COMP")
+    }
+    def override preVisitExprStringBuilder(expr : ExprStringBuilder?) {
+        emit("SBLD")
+    }
+
+// type info
+    def override preVisitExprTypeInfo(expr : ExprTypeInfo?) {
+        emit("TYPEINFO")
+    }
+    def override preVisitExprTypeDecl(expr : ExprTypeDecl?) {
+        emit("EXPR_TYPE")
+    }
+
+// looks-like-call family. Keep the called function name — it carries
+// real signal (`push`, `delete`, `assert`, ...) and is not a user
+// identifier we want to alpha-rename.
+    def override preVisitExprLooksLikeCall(expr : ExprLooksLikeCall?) {
+        emit("CALL:{expr.name}")
+    }
+    def override preVisitExprCall(expr : ExprCall?) {
+        emit("CALL:{expr.name}")
+    }
+    def override preVisitExprNamedCall(expr : ExprNamedCall?) {
+        emit("NCALL:{expr.name}")
+    }
+    def override preVisitExprCallMacro(expr : ExprCallMacro?) {
+        emit("CALL_MACRO:{expr.name}")
+    }
+    def override preVisitExprAssert(expr : ExprAssert?) {
+        emit("ASSERT")
+    }
+    def override preVisitExprStaticAssert(expr : ExprStaticAssert?) {
+        emit("STATIC_ASSERT")
+    }
+    def override preVisitExprQuote(expr : ExprQuote?) {
+        emit("QUOTE")
+    }
+    def override preVisitExprDebug(expr : ExprDebug?) {
+        emit("DEBUG")
+    }
+    def override preVisitExprInvoke(expr : ExprInvoke?) {
+        emit("INVOKE")
+    }
+    def override preVisitExprErase(expr : ExprErase?) {
+        emit("ERASE")
+    }
+    def override preVisitExprFind(expr : ExprFind?) {
+        emit("FIND")
+    }
+    def override preVisitExprKeyExists(expr : ExprKeyExists?) {
+        emit("KEY_EXISTS")
+    }
+    def override preVisitExprSetInsert(expr : ExprSetInsert?) {
+        emit("SET_INSERT")
+    }
+    def override preVisitExprMemZero(expr : ExprMemZero?) {
+        emit("MEMZERO")
+    }
+
+// var
+    def override preVisitExprVar(expr : ExprVar?) {
+        let p = lookup_var(expr.name)
+        emit(p)
+    }
+
+// field access (post-visit so the receiver is emitted first)
+    def override visitExprField(var expr : ExprField?) : ExpressionPtr {
+        emit(".FLD")
+        return unsafe(reinterpret<ExpressionPtr>(expr))
+    }
+    def override visitExprSafeField(var expr : ExprSafeField?) : ExpressionPtr {
+        emit("?.FLD")
+        return unsafe(reinterpret<ExpressionPtr>(expr))
+    }
+    def override visitExprSwizzle(var expr : ExprSwizzle?) : ExpressionPtr {
+        emit(".SWZ")
+        return unsafe(reinterpret<ExpressionPtr>(expr))
+    }
+
+// constants — every numeric / string / bool collapses to <lit>.
+// Keep enum literals separate so cross-enum confusion is detectable.
+    def override preVisitExprConst(expr : ExprConst?) {
+        pass
+    }
+    def override preVisitExprConstPtr(expr : ExprConstPtr?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstInt8(expr : ExprConstInt8?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstInt16(expr : ExprConstInt16?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstInt(expr : ExprConstInt?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstInt64(expr : ExprConstInt64?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstInt2(expr : ExprConstInt2?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstInt3(expr : ExprConstInt3?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstInt4(expr : ExprConstInt4?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstUInt8(expr : ExprConstUInt8?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstUInt16(expr : ExprConstUInt16?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstUInt(expr : ExprConstUInt?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstUInt64(expr : ExprConstUInt64?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstUInt2(expr : ExprConstUInt2?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstUInt3(expr : ExprConstUInt3?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstUInt4(expr : ExprConstUInt4?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstFloat(expr : ExprConstFloat?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstFloat2(expr : ExprConstFloat2?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstFloat3(expr : ExprConstFloat3?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstFloat4(expr : ExprConstFloat4?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstDouble(expr : ExprConstDouble?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstBool(expr : ExprConstBool?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstString(expr : ExprConstString?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstRange(expr : ExprConstRange?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstURange(expr : ExprConstURange?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstRange64(expr : ExprConstRange64?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstURange64(expr : ExprConstURange64?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstBitfield(expr : ExprConstBitfield?) {
+        emit("LIT")
+    }
+    def override preVisitExprConstEnumeration(expr : ExprConstEnumeration?) {
+        emit("ENUM_LIT")
+    }
+
+// reader / fake
+    def override preVisitExprReader(expr : ExprReader?) {
+        emit("READER")
+    }
+    def override preVisitExprFakeContext(expr : ExprFakeContext?) {
+        emit("FAKE_CTX")
+    }
+    def override preVisitExprFakeLineInfo(expr : ExprFakeLineInfo?) {
+        emit("FAKE_LI")
+    }
+    def override preVisitExprTag(expr : ExprTag?) {
+        emit("TAG")
+    }
+}
+
+
+// canonicalize_function walks `fn` and returns its canonical text.
+def public canonicalize_function(fn : FunctionPtr) : string {
+    return build_string() $(var sb) {
+        var v = new CanonicalVisitor(writer = unsafe(addr(sb)))
+        make_visitor(*v) $(adapter) {
+            visit(fn, adapter)
+        }
+        unsafe { delete v; }
+    }
+}
+
+
+// tokenize_canonical splits a canonical text into a flat token list.
+// `emit()` writes each tag followed by exactly one space, so plain
+// split(" ") + drop-empty is correct and O(n).
+def public tokenize_canonical(text : string) : array<string> {
+    var raw <- text |> split(" ")
+    var out : array<string>
+    out |> reserve(length(raw))
+    for (t in raw) {
+        if (!empty(t)) {
+            out |> push(t)
+        }
+    }
+    return <- out
+}

--- a/utils/find_dupes/cluster.das
+++ b/utils/find_dupes/cluster.das
@@ -16,7 +16,6 @@ struct public MemberRef {
 struct public FuncRecord {
     ref : MemberRef
     canonical : string
-    canonical_hash : uint64
     sig : array<uint64>
     token_count : int
     cluster_id : int = -1
@@ -42,19 +41,22 @@ struct public FuzzyPair {
 // Build exact-clone clusters by grouping records with identical
 // canonical text. Mutates `records[i].cluster_id` so the fuzzy pass
 // can skip same-cluster pairs. Skips clusters of size 1.
+//
+// Bucket on the canonical string itself (not its 64-bit hash) so a
+// rare hash collision can't conflate two unrelated functions.
 def public exact_buckets(var records : array<FuncRecord>; min_tokens : int) : array<Cluster> {
-    var buckets : table<uint64; array<int>>
+    var buckets : table<string; array<int>>
     for (i in range(length(records))) {
-        let h = records[i].canonical_hash
         if (records[i].token_count < min_tokens) {
             continue
         }
-        if (key_exists(buckets, h)) {
-            buckets[h] |> push(i)
+        let key = records[i].canonical
+        if (key_exists(buckets, key)) {
+            buckets[key] |> push(i)
         } else {
             var lst : array<int>
             lst |> push(i)
-            buckets[h] <- lst
+            buckets[key] <- lst
         }
     }
     var out : array<Cluster>
@@ -101,7 +103,11 @@ def public fuzzy_pairs(records : array<FuncRecord>; threshold : float; min_token
             if (records[i].cluster_id != -1 && records[i].cluster_id == records[j].cluster_id) {
                 continue
             }
-            if (records[i].canonical_hash == records[j].canonical_hash) {
+            // Same canonical text would already be in the exact-cluster
+            // set (caught above when both have a cluster_id). Compare on
+            // the string itself rather than the 64-bit hash to dodge any
+            // theoretical collision.
+            if (records[i].canonical == records[j].canonical) {
                 continue
             }
             let ti = float(records[i].token_count)

--- a/utils/find_dupes/cluster.das
+++ b/utils/find_dupes/cluster.das
@@ -135,13 +135,48 @@ def public fuzzy_pairs(records : array<FuncRecord>; threshold : float; min_token
 }
 
 
-// Sort clusters by member count descending (the biggest dupes first).
-def public sort_clusters(var clusters : array<Cluster>) {
-    sort(clusters) <| $(a, b) => length(a.members) > length(b.members)
+def member_key(m : MemberRef) : string {
+    return "{m.file}:{m.line}:{m.name}"
 }
 
 
-// Sort fuzzy pairs by similarity descending.
+// Sort clusters by member count descending; tie-break on token_count
+// desc, then canonical_sample, then first-member location. Without
+// tie-breakers `values(buckets)` iteration order leaks into the report
+// and diff-ing two runs becomes noisy.
+def public sort_clusters(var clusters : array<Cluster>) {
+    sort(clusters) $(a, b) {
+        let na = length(a.members)
+        let nb = length(b.members)
+        if (na != nb) {
+            return na > nb
+        }
+        if (a.token_count != b.token_count) {
+            return a.token_count > b.token_count
+        }
+        if (a.canonical_sample != b.canonical_sample) {
+            return a.canonical_sample < b.canonical_sample
+        }
+        if (na == 0) {
+            return false
+        }
+        return member_key(a.members[0]) < member_key(b.members[0])
+    }
+}
+
+
+// Sort fuzzy pairs by similarity descending; tie-break on (a, b)
+// member locations so pair ordering is reproducible across runs.
 def public sort_pairs(var pairs : array<FuzzyPair>) {
-    sort(pairs) <| $(a, b) => a.similarity > b.similarity
+    sort(pairs) $(a, b) {
+        if (a.similarity != b.similarity) {
+            return a.similarity > b.similarity
+        }
+        let ka = member_key(a.a)
+        let kb = member_key(b.a)
+        if (ka != kb) {
+            return ka < kb
+        }
+        return member_key(a.b) < member_key(b.b)
+    }
 }

--- a/utils/find_dupes/cluster.das
+++ b/utils/find_dupes/cluster.das
@@ -1,0 +1,141 @@
+options gen2
+
+require strings
+require math
+require minhash
+
+
+struct public MemberRef {
+    file : string
+    name : string
+    line : int
+    is_lambda : bool
+}
+
+
+struct public FuncRecord {
+    ref : MemberRef
+    canonical : string
+    canonical_hash : uint64
+    sig : array<uint64>
+    token_count : int
+    cluster_id : int = -1
+}
+
+
+struct public Cluster {
+    canonical_sample : string
+    token_count : int
+    members : array<MemberRef>
+}
+
+
+struct public FuzzyPair {
+    similarity : float
+    a : MemberRef
+    b : MemberRef
+    canonical_a : string
+    canonical_b : string
+}
+
+
+// Build exact-clone clusters by grouping records with identical
+// canonical text. Mutates `records[i].cluster_id` so the fuzzy pass
+// can skip same-cluster pairs. Skips clusters of size 1.
+def public exact_buckets(var records : array<FuncRecord>; min_tokens : int) : array<Cluster> {
+    var buckets : table<uint64; array<int>>
+    for (i in range(length(records))) {
+        let h = records[i].canonical_hash
+        if (records[i].token_count < min_tokens) {
+            continue
+        }
+        if (key_exists(buckets, h)) {
+            buckets[h] |> push(i)
+        } else {
+            var lst : array<int>
+            lst |> push(i)
+            buckets[h] <- lst
+        }
+    }
+    var out : array<Cluster>
+    var cluster_idx = 0
+    for (idxs in values(buckets)) {
+        if (length(idxs) < 2) {
+            continue
+        }
+        var c = Cluster()
+        c.canonical_sample := records[idxs[0]].canonical
+        c.token_count = records[idxs[0]].token_count
+        c.members |> reserve(length(idxs))
+        for (i in idxs) {
+            records[i].cluster_id = cluster_idx
+            c.members |> push(records[i].ref)
+        }
+        out |> emplace(c)
+        cluster_idx++
+    }
+    return <- out
+}
+
+
+// All-pairs MinHash comparison. Skips pairs already in the same exact
+// cluster (those are reported as exact, not fuzzy). Skips pairs where
+// either function has fewer than min_tokens tokens (noise floor).
+//
+// MinHash works on the SET of shingles. Highly periodic code (e.g. a
+// boilerplate block repeated N times) has a tiny shingle set, so 4x
+// and 7x repetitions both estimate Jaccard = 1.0 even though they're
+// not the same function. Gate the report on a length ratio too.
+def public fuzzy_pairs(records : array<FuncRecord>; threshold : float; min_tokens : int) : array<FuzzyPair> {
+    var out : array<FuzzyPair>
+    out |> reserve(64)
+    let n = length(records)
+    for (i in range(n)) {
+        if (records[i].token_count < min_tokens) {
+            continue
+        }
+        for (j in range(i + 1, n)) {
+            if (records[j].token_count < min_tokens) {
+                continue
+            }
+            if (records[i].cluster_id != -1 && records[i].cluster_id == records[j].cluster_id) {
+                continue
+            }
+            if (records[i].canonical_hash == records[j].canonical_hash) {
+                continue
+            }
+            let ti = float(records[i].token_count)
+            let tj = float(records[j].token_count)
+            let len_ratio = ti < tj ? ti / tj : tj / ti
+            if (len_ratio < threshold) {
+                continue
+            }
+            let s = jaccard_estimate(records[i].sig, records[j].sig)
+            // Geometric mean of MinHash similarity and length similarity:
+            // periodic code with very different lengths drops out.
+            let combined = sqrt(s * len_ratio)
+            if (combined >= threshold) {
+                var p = FuzzyPair()
+                p.similarity = combined
+                p.a = records[i].ref
+                p.b = records[j].ref
+                p.canonical_a := records[i].canonical
+                p.canonical_b := records[j].canonical
+                out |> emplace(p)
+            }
+        }
+    }
+    return <- out
+}
+
+
+// Sort clusters by member count descending (the biggest dupes first).
+def public sort_clusters(var clusters : array<Cluster>) {
+    sort(clusters) <| $(a, b) => length(a.members) > length(b.members)
+}
+
+
+// Sort fuzzy pairs by similarity descending.
+def public sort_pairs(var pairs : array<FuzzyPair>) {
+    sort(pairs) <| $(a, b) => a.similarity > b.similarity
+}

--- a/utils/find_dupes/fixture/synth.das
+++ b/utils/find_dupes/fixture/synth.das
@@ -1,0 +1,55 @@
+options gen2
+
+
+def add_int(a, b : int) : int {
+    return a + b
+}
+
+
+def add_int_renamed_args(x, y : int) : int {
+    return x + y
+}
+
+
+def add_float(a, b : float) : float {
+    return a + b
+}
+
+
+def double_int(a : int) : int {
+    return a * 2
+}
+
+
+def loop_sum(arr : array<int>) : int {
+    var s = 0
+    for (v in arr) {
+        s += v
+    }
+    return s
+}
+
+
+def loop_product(arr : array<int>) : int {
+    var p = 1
+    for (v in arr) {
+        p *= v
+    }
+    return p
+}
+
+
+def with_lambda(var arr : array<int>) {
+    arr |> sort() <| $(a, b : int) => a < b
+}
+
+
+def with_lambda_renamed(var arr : array<int>) {
+    arr |> sort() <| $(x, y : int) => x < y
+}
+
+
+[export]
+def main() {
+    print("dummy main\n")
+}

--- a/utils/find_dupes/main.das
+++ b/utils/find_dupes/main.das
@@ -22,11 +22,11 @@ struct Config {
 
     @clarg_short = "t"
     @clarg_doc = "Fuzzy similarity threshold 0..1 (default 0.7)"
-    threshold : float
+    threshold : float = 0.7f
 
     @clarg_short = "n"
     @clarg_doc = "Top N entries shown in stdout summary (default 20)"
-    top : int
+    top : int = 20
 
     @clarg_doc = "Path to JSON report (optional)"
     json : string
@@ -36,7 +36,7 @@ struct Config {
     no_fuzzy : bool
 
     @clarg_doc = "Min token count per function for inclusion (default 8)"
-    min_tokens : int
+    min_tokens : int = 8
 
     @clarg_short = "v"
     @clarg_doc = "Per-file progress to stdout"
@@ -245,9 +245,12 @@ def main() {
         print_help(get_command_info(type<Config>), "find_dupes")
         return
     }
-    let threshold = cfg.threshold > 0.0f ? cfg.threshold : 0.7f
-    let top = cfg.top > 0 ? cfg.top : 20
-    let min_tokens = cfg.min_tokens > 0 ? cfg.min_tokens : 8
+    // Defaults live in the Config struct field initializers — clargs
+    // respects them when the flag is omitted, so 0 is now a legitimate
+    // user-supplied value (e.g. --min-tokens 0 to include all functions).
+    let threshold = cfg.threshold
+    let top = cfg.top
+    let min_tokens = cfg.min_tokens
     let want_sigs = !cfg.no_fuzzy
 
     var files : array<string>

--- a/utils/find_dupes/main.das
+++ b/utils/find_dupes/main.das
@@ -1,0 +1,291 @@
+options gen2
+
+require daslib/clargs
+require daslib/ast
+require daslib/ast_boost
+require daslib/fio
+require daslib/strings_boost
+require math
+require strings
+require canonical
+require minhash
+require cluster
+require report
+
+
+[CommandLineArgs]
+struct Config {
+    @clarg_short = "p"
+    @clarg_doc = "Path(s) to scan (file or directory). Repeatable."
+    path : array<string>
+
+    @clarg_short = "t"
+    @clarg_doc = "Fuzzy similarity threshold 0..1 (default 0.7)"
+    threshold : float
+
+    @clarg_short = "n"
+    @clarg_doc = "Top N entries shown in stdout summary (default 20)"
+    top : int
+
+    @clarg_doc = "Path to JSON report (optional)"
+    json : string
+
+    @clarg_short = "x"
+    @clarg_doc = "Skip fuzzy MinHash pass"
+    no_fuzzy : bool
+
+    @clarg_doc = "Min token count per function for inclusion (default 8)"
+    min_tokens : int
+
+    @clarg_short = "v"
+    @clarg_doc = "Per-file progress to stdout"
+    verbose : bool
+
+    @clarg_short = "L"
+    @clarg_doc = "Lambda-only mode: skip top-level functions, keep only lambdas (e.g. dastest run() bodies)"
+    lambdas_only : bool
+
+    @clarg_short = "?"
+    @clarg_name = "show-help"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+
+def is_skip_file(name : string) : bool {
+    // debugger/profiler install thread-local agents at compile time; the
+    // second install in the same process throws and aborts the scan.
+    return name == "builtin.das" || name == "debugger.das" || name == "profiler.das"
+}
+
+
+def is_skip_dir(name : string) : bool {
+    return name |> starts_with(".")
+}
+
+
+def has_expect_directive(file : string) : bool {
+    let text = fread(file)
+    if (empty(text)) {
+        return false
+    }
+    let lines <- text |> split("\n")
+    for (line in lines) {
+        let trimmed = line |> strip
+        if (trimmed |> starts_with("expect ")) {
+            return true
+        }
+    }
+    return false
+}
+
+
+def scan_das_files(path : string; var files : array<string>; var cache : table<string; void?>) {
+    let st = stat(path)
+    if (!st.is_valid) {
+        return
+    }
+    if (st.is_reg) {
+        if (path |> ends_with(".das") && !cache |> key_exists(path)) {
+            let last_slash = max(rfind(path, "/"), rfind(path, "\\"))
+            let fname = last_slash >= 0 ? slice(path, last_slash + 1) : path
+            if (!is_skip_file(fname)) {
+                cache |> insert(path, null)
+                files |> push(path)
+            }
+        }
+        return
+    }
+    if (!st.is_dir) {
+        return
+    }
+    fio::dir(path) $(name) {
+        if (name == "." || name == "..") {
+            return
+        }
+        if (name |> starts_with("_") || is_skip_dir(name)) {
+            return
+        }
+        let full = "{path}/{name}"
+        let fst = stat(full)
+        if (!fst.is_valid) {
+            return
+        }
+        if (fst.is_dir) {
+            scan_das_files(full, files, cache)
+        } elif (fst.is_reg && name |> ends_with(".das") && !is_skip_file(name) && !cache |> key_exists(full)) {
+            cache |> insert(full, null)
+            files |> push(full)
+        }
+    }
+}
+
+
+// Walk one compiled program and append a FuncRecord per user
+// function (lambdas included; only builtIn / generated skipped).
+//
+// Generic-template functions (e.g. dastest's `equal<T>`) get reified
+// into every caller's module, so without filtering we see hundreds of
+// copies of the same library helpers. The file-source filter drops
+// any function whose `at.fileInfo` points outside the file we just
+// compiled, leaving only what was actually written in that file.
+def collect_from_program(program : ProgramPtr; source_file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; lambdas_only : bool) {
+    let thisMod = get_this_module(program)
+    for_each_function(thisMod, "") $(func) {
+        if (func.flags.builtIn) {
+            return
+        }
+        // Lambdas are emitted as `generated` synthesized functions
+        // (`__lambda_function_at_line_xxx`). Default mode skips them via
+        // the generated filter (the dispatcher already references them
+        // via ADDR). Lambda-only mode lets them through and drops the
+        // top-level functions instead.
+        if (lambdas_only) {
+            if (!func.flags._lambda) {
+                return
+            }
+        } else {
+            if (func.flags.generated) {
+                return
+            }
+        }
+        let fn_file = (func.at.fileInfo != null) ? string(func.at.fileInfo.name) : ""
+        if (fn_file != source_file) {
+            return
+        }
+        // Generic templates get reified per type (e.g. `test_conversions`
+        // reified for int8, uint16, uint, uint64). Each reification is a
+        // distinct FunctionPtr but they all point at the same source
+        // (file, line). Keep the first; the rest are reported as
+        // duplicates against themselves which is just noise.
+        let loc = "{fn_file}:{int(func.at.line)}"
+        if (key_exists(seen_loc, loc)) {
+            return
+        }
+        seen_loc |> insert(loc, null)
+        let canon = canonicalize_function(func)
+        if (empty(canon)) {
+            return
+        }
+        let tokens <- tokenize_canonical(canon)
+        var rec = FuncRecord()
+        rec.ref.file = fn_file
+        rec.ref.name = string(func.name)
+        rec.ref.line = int(func.at.line)
+        rec.ref.is_lambda = func.flags._lambda
+        rec.canonical := canon
+        rec.canonical_hash = hash(canon)
+        rec.token_count = length(tokens)
+        rec.sig <- minhash_signature(tokens)
+        records |> emplace(rec)
+    }
+}
+
+
+def compile_and_collect(file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; verbose : bool; lambdas_only : bool) : bool {
+    var inscope access <- make_file_access("")
+    var ok_compile = true
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.ignore_shared_modules = true
+            cop.export_all = true
+            // Leave optimisations and infer-time folding ON: dastest macros
+            // (e.g. unroll) need constant folding to compile, and folded-equal
+            // expressions are exactly the kind of duplicate we want to catch.
+            compile_file(file, access, unsafe(addr(mg)), cop) $(ok; program; issues) {
+                if (!ok) {
+                    ok_compile = false
+                    if (verbose) {
+                        print("FAIL {file}\n  {issues}\n")
+                    } else {
+                        print("FAIL {file}\n")
+                    }
+                    return
+                }
+                collect_from_program(program, file, records, seen_loc, lambdas_only)
+            }
+        }
+    }
+    return ok_compile
+}
+
+
+[export]
+def main() {
+    var cfg = Config()
+    let err = parse_args(cfg)
+    if (cfg.help) {
+        print_help(get_command_info(type<Config>), "find_dupes")
+        return
+    }
+    if (err != "") {
+        print("error: {err}\n\n")
+        print_help(get_command_info(type<Config>), "find_dupes")
+        return
+    }
+    if (length(cfg.path) == 0) {
+        print("error: at least one --path is required\n\n")
+        print_help(get_command_info(type<Config>), "find_dupes")
+        return
+    }
+    let threshold = cfg.threshold > 0.0f ? cfg.threshold : 0.7f
+    let top = cfg.top > 0 ? cfg.top : 20
+    let min_tokens = cfg.min_tokens > 0 ? cfg.min_tokens : 8
+
+    var files : array<string>
+    var cache : table<string; void?>
+    for (p in cfg.path) {
+        scan_das_files(p, files, cache)
+    }
+    if (length(files) == 0) {
+        print("error: no .das files found under given paths\n")
+        return
+    }
+    print("scanning {length(files)} file(s)...\n")
+
+    var records : array<FuncRecord>
+    var seen_loc : table<string; void?>
+    var n_failed = 0
+    var n_skipped = 0
+    for (i in range(length(files))) {
+        let file = files[i]
+        if (cfg.verbose) {
+            print("[{i + 1}/{length(files)}] {file}\n")
+        }
+        if (has_expect_directive(file)) {
+            n_skipped++
+            continue
+        }
+        if (!compile_and_collect(file, records, seen_loc, cfg.verbose, cfg.lambdas_only)) {
+            n_failed++
+        }
+    }
+    print("collected {length(records)} function record(s); {n_failed} compile failure(s), {n_skipped} skipped (expect-directive)\n")
+
+    print("clustering exact matches...\n")
+    var clusters <- exact_buckets(records, min_tokens)
+    sort_clusters(clusters)
+    var pairs : array<FuzzyPair>
+    if (!cfg.no_fuzzy) {
+        print("scanning {length(records)} records for fuzzy near-duplicates (threshold {threshold})...\n")
+        pairs <- fuzzy_pairs(records, threshold, min_tokens)
+        sort_pairs(pairs)
+    }
+
+    var rep : Report
+    rep.files_scanned = length(files)
+    rep.functions_analyzed = length(records)
+    rep.threshold = threshold
+    rep.min_tokens = min_tokens
+    rep.exact_clusters <- clusters
+    rep.fuzzy_pairs <- pairs
+
+    print_summary(rep, top)
+    if (!empty(cfg.json)) {
+        if (write_json_report(rep, cfg.json)) {
+            print("\nJSON report written to {cfg.json}\n")
+        } else {
+            print("\nERROR: could not write JSON report to {cfg.json}\n")
+        }
+    }
+}

--- a/utils/find_dupes/main.das
+++ b/utils/find_dupes/main.das
@@ -53,12 +53,17 @@ struct Config {
 }
 
 
+def normalize_path(p : string) : string {
+    return p |> replace("\\", "/")
+}
+
+
 def is_daslib_skip(path : string; basename : string) : bool {
     // `daslib/debugger.das` and `daslib/profiler.das` install thread-local
     // agents at compile time; the second install in the same process throws
     // and aborts the scan. Match by daslib/ path suffix, not bare basename
     // — a project's own `myapp/debugger.das` should not be silently skipped.
-    let normalized = path |> replace("\\", "/")
+    let normalized = normalize_path(path)
     let prefix = "daslib/{basename}"
     return normalized == prefix || normalized |> ends_with("/{prefix}")
 }
@@ -145,6 +150,7 @@ def scan_das_files(path : string; var files : array<string>; var cache : table<s
 // compiled, leaving only what was actually written in that file.
 def collect_from_program(program : ProgramPtr; source_file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; lambdas_only : bool; want_sigs : bool; min_tokens : int) {
     let thisMod = get_this_module(program)
+    let source_norm = normalize_path(source_file)
     for_each_function(thisMod, "") $(func) {
         if (func.flags.builtIn) {
             return
@@ -164,7 +170,10 @@ def collect_from_program(program : ProgramPtr; source_file : string; var records
             }
         }
         let fn_file = (func.at.fileInfo != null) ? string(func.at.fileInfo.name) : ""
-        if (fn_file != source_file) {
+        // Normalize both sides — Windows runners and recursive scans can
+        // mix separators / `./` prefixes, and a literal mismatch silently
+        // drops every function from a file that compiled fine.
+        if (normalize_path(fn_file) != source_norm) {
             return
         }
         // Generic templates get reified per type (e.g. `test_conversions`
@@ -243,6 +252,18 @@ def main() {
     if (length(cfg.path) == 0) {
         print("error: at least one --path is required\n\n")
         print_help(get_command_info(type<Config>), "find_dupes")
+        return
+    }
+    if (cfg.threshold < 0.0f || cfg.threshold > 1.0f) {
+        print("error: --threshold must be in 0..1, got {cfg.threshold}\n")
+        return
+    }
+    if (cfg.top < 0) {
+        print("error: --top must be >= 0, got {cfg.top}\n")
+        return
+    }
+    if (cfg.min_tokens < 0) {
+        print("error: --min-tokens must be >= 0, got {cfg.min_tokens}\n")
         return
     }
     // Defaults live in the Config struct field initializers — clargs

--- a/utils/find_dupes/main.das
+++ b/utils/find_dupes/main.das
@@ -1,4 +1,5 @@
 options gen2
+options persistent_heap
 
 require daslib/clargs
 require daslib/ast
@@ -52,10 +53,23 @@ struct Config {
 }
 
 
-def is_skip_file(name : string) : bool {
-    // debugger/profiler install thread-local agents at compile time; the
-    // second install in the same process throws and aborts the scan.
-    return name == "builtin.das" || name == "debugger.das" || name == "profiler.das"
+def is_daslib_skip(path : string; basename : string) : bool {
+    // `daslib/debugger.das` and `daslib/profiler.das` install thread-local
+    // agents at compile time; the second install in the same process throws
+    // and aborts the scan. Match by daslib/ path suffix, not bare basename
+    // — a project's own `myapp/debugger.das` should not be silently skipped.
+    let normalized = path |> replace("\\", "/")
+    let prefix = "daslib/{basename}"
+    return normalized == prefix || normalized |> ends_with("/{prefix}")
+}
+
+
+def is_skip_file(path : string; basename : string) : bool {
+    if (basename == "builtin.das") {
+        return true
+    }
+    return (is_daslib_skip(path, "debugger.das")
+        || is_daslib_skip(path, "profiler.das"))
 }
 
 
@@ -89,7 +103,7 @@ def scan_das_files(path : string; var files : array<string>; var cache : table<s
         if (path |> ends_with(".das") && !cache |> key_exists(path)) {
             let last_slash = max(rfind(path, "/"), rfind(path, "\\"))
             let fname = last_slash >= 0 ? slice(path, last_slash + 1) : path
-            if (!is_skip_file(fname)) {
+            if (!is_skip_file(path, fname)) {
                 cache |> insert(path, null)
                 files |> push(path)
             }
@@ -113,7 +127,7 @@ def scan_das_files(path : string; var files : array<string>; var cache : table<s
         }
         if (fst.is_dir) {
             scan_das_files(full, files, cache)
-        } elif (fst.is_reg && name |> ends_with(".das") && !is_skip_file(name) && !cache |> key_exists(full)) {
+        } elif (fst.is_reg && name |> ends_with(".das") && !is_skip_file(full, name) && !cache |> key_exists(full)) {
             cache |> insert(full, null)
             files |> push(full)
         }
@@ -129,7 +143,7 @@ def scan_das_files(path : string; var files : array<string>; var cache : table<s
 // copies of the same library helpers. The file-source filter drops
 // any function whose `at.fileInfo` points outside the file we just
 // compiled, leaving only what was actually written in that file.
-def collect_from_program(program : ProgramPtr; source_file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; lambdas_only : bool) {
+def collect_from_program(program : ProgramPtr; source_file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; lambdas_only : bool; want_sigs : bool; min_tokens : int) {
     let thisMod = get_this_module(program)
     for_each_function(thisMod, "") $(func) {
         if (func.flags.builtIn) {
@@ -174,15 +188,18 @@ def collect_from_program(program : ProgramPtr; source_file : string; var records
         rec.ref.line = int(func.at.line)
         rec.ref.is_lambda = func.flags._lambda
         rec.canonical := canon
-        rec.canonical_hash = hash(canon)
         rec.token_count = length(tokens)
-        rec.sig <- minhash_signature(tokens)
+        // Skip signature work when fuzzy is disabled or when the function
+        // is below the noise floor — fuzzy_pairs filters those out anyway.
+        if (want_sigs && rec.token_count >= min_tokens) {
+            rec.sig <- minhash_signature(tokens)
+        }
         records |> emplace(rec)
     }
 }
 
 
-def compile_and_collect(file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; verbose : bool; lambdas_only : bool) : bool {
+def compile_and_collect(file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; verbose : bool; lambdas_only : bool; want_sigs : bool; min_tokens : int) : bool {
     var inscope access <- make_file_access("")
     var ok_compile = true
     using() $(var mg : ModuleGroup) {
@@ -202,7 +219,7 @@ def compile_and_collect(file : string; var records : array<FuncRecord>; var seen
                     }
                     return
                 }
-                collect_from_program(program, file, records, seen_loc, lambdas_only)
+                collect_from_program(program, file, records, seen_loc, lambdas_only, want_sigs, min_tokens)
             }
         }
     }
@@ -231,6 +248,7 @@ def main() {
     let threshold = cfg.threshold > 0.0f ? cfg.threshold : 0.7f
     let top = cfg.top > 0 ? cfg.top : 20
     let min_tokens = cfg.min_tokens > 0 ? cfg.min_tokens : 8
+    let want_sigs = !cfg.no_fuzzy
 
     var files : array<string>
     var cache : table<string; void?>
@@ -256,7 +274,7 @@ def main() {
             n_skipped++
             continue
         }
-        if (!compile_and_collect(file, records, seen_loc, cfg.verbose, cfg.lambdas_only)) {
+        if (!compile_and_collect(file, records, seen_loc, cfg.verbose, cfg.lambdas_only, want_sigs, min_tokens)) {
             n_failed++
         }
     }
@@ -273,12 +291,14 @@ def main() {
     }
 
     var rep : Report
-    rep.files_scanned = length(files)
-    rep.functions_analyzed = length(records)
-    rep.threshold = threshold
-    rep.min_tokens = min_tokens
+    rep.summary.files_scanned = length(files)
+    rep.summary.functions_analyzed = length(records)
+    rep.summary.threshold = threshold
+    rep.summary.min_tokens = min_tokens
     rep.exact_clusters <- clusters
     rep.fuzzy_pairs <- pairs
+    rep.summary.exact_clusters = length(rep.exact_clusters)
+    rep.summary.fuzzy_pairs = length(rep.fuzzy_pairs)
 
     print_summary(rep, top)
     if (!empty(cfg.json)) {

--- a/utils/find_dupes/minhash.das
+++ b/utils/find_dupes/minhash.das
@@ -1,0 +1,83 @@
+options gen2
+
+require strings
+
+
+// MinHash signature length and shingle width. K=64 keeps the all-pairs
+// dot product cheap; N=5 is the usual choice for code-token shingles.
+let public K_HASHES = 64
+let public N_GRAM = 5
+
+let FNV_PRIME : uint64 = 0x100000001b3ul
+let FNV_OFFSET : uint64 = 0xcbf29ce484222325ul
+let MIX_MULT : uint64 = 0xbf58476d1ce4e5b9ul
+let SEED_BASE : uint64 = 0x9E3779B97F4A7C15ul
+let MAX_U64 : uint64 = 0xFFFFFFFFFFFFFFFFul
+
+
+// Combine n consecutive token hashes into a single shingle hash via
+// FNV-style polynomial folding (sequence-order-sensitive).
+def shingle_hash(token_hashes : array<uint64>; start, n : int) : uint64 {
+    var sh = FNV_OFFSET
+    for (j in range(n)) {
+        sh = (sh * FNV_PRIME) ^ token_hashes[start + j]
+    }
+    return sh
+}
+
+
+// Apply the k-th hash function to a base shingle hash.
+def hash_with_seed(sh : uint64; k : int) : uint64 {
+    let seed = (uint64(k) + 1ul) * SEED_BASE
+    return (sh ^ seed) * MIX_MULT
+}
+
+
+// Build a K-slot MinHash signature for a token list. Pads short token
+// lists so functions with fewer tokens than N_GRAM still get a stable
+// signature (one shingle covering all tokens).
+def public minhash_signature(tokens : array<string>) : array<uint64> {
+    var sig : array<uint64>
+    sig |> resize(K_HASHES)
+    for (k in range(K_HASHES)) {
+        sig[k] = MAX_U64
+    }
+
+    var token_hashes : array<uint64>
+    token_hashes |> reserve(length(tokens))
+    for (t in tokens) {
+        token_hashes |> push(hash(t))
+    }
+    let pad_hash = hash("<PAD>")
+    while (length(token_hashes) < N_GRAM) {
+        token_hashes |> push(pad_hash)
+    }
+
+    let limit = length(token_hashes) - N_GRAM + 1
+    for (i in range(limit)) {
+        let sh = shingle_hash(token_hashes, i, N_GRAM)
+        for (k in range(K_HASHES)) {
+            let cand = hash_with_seed(sh, k)
+            if (cand < sig[k]) {
+                sig[k] = cand
+            }
+        }
+    }
+    return <- sig
+}
+
+
+// Estimate Jaccard similarity from two MinHash signatures: fraction of
+// matching slots. With K=64, resolution is ~1.5%.
+def public jaccard_estimate(sig_a, sig_b : array<uint64>) : float {
+    if (length(sig_a) != length(sig_b) || length(sig_a) == 0) {
+        return 0.0f
+    }
+    var matches = 0
+    for (i in range(length(sig_a))) {
+        if (sig_a[i] == sig_b[i]) {
+            matches++
+        }
+    }
+    return float(matches) / float(length(sig_a))
+}

--- a/utils/find_dupes/report.das
+++ b/utils/find_dupes/report.das
@@ -1,115 +1,43 @@
 options gen2
+options rtti
 
 require strings
 require daslib/strings_boost
+require daslib/json_boost
 require daslib/fio
 require cluster
 
 
-struct public Report {
+struct public Summary {
     files_scanned : int
     functions_analyzed : int
+    exact_clusters : int
+    fuzzy_pairs : int
     threshold : float
     min_tokens : int
+}
+
+
+struct public Report {
+    summary : Summary
     exact_clusters : array<Cluster>
     fuzzy_pairs : array<FuzzyPair>
 }
 
 
-// All canonical text is printable ASCII by construction. File paths
-// and function names may contain backslashes (on Windows) or quotes
-// in pathological cases. This handles the JSON-mandatory escapes and
-// passes the rest through unchanged.
-def json_escape(s : string) : string {
-    return build_string() $(var w) {
-        peek_data(s) $(arr) {
-            for (b in arr) {
-                let c = int(b)
-                if (c == int(0x22)) {
-                    write(w, "\\\"")
-                } elif (c == int(0x5C)) {
-                    write(w, "\\\\")
-                } elif (c == int(0x0A)) {
-                    write(w, "\\n")
-                } elif (c == int(0x0D)) {
-                    write(w, "\\r")
-                } elif (c == int(0x09)) {
-                    write(w, "\\t")
-                } else {
-                    write(w, "{to_char(c)}")
-                }
-            }
-        }
-    }
-}
-
-
-def write_member(var w : StringBuilderWriter; m : MemberRef) {
-    write(w, "\{\"file\":\"{json_escape(m.file)}\",\"name\":\"{json_escape(m.name)}\",\"line\":{m.line},\"is_lambda\":{m.is_lambda}\}")
-}
-
-
+// JSON serialization is delegated to `sprint_json` from `daslib/json_boost`,
+// which walks struct fields via RTTI and escapes correctly (Unicode-safe,
+// emits `\u00XX` for control bytes < 0x20). Annotations on Cluster /
+// FuzzyPair / Summary fields would let us rename or omit fields if needed.
 def public write_json_report(report : Report; path : string) : bool {
+    let body = sprint_json(report, true)
     var ok = false
     fopen(path, "wb") $(fw) {
         if (fw == null) {
             return
         }
         ok = true
-        let body = build_string() $(var w) {
-            write(w, "\{\n")
-            write(w, "  \"summary\": \{\n")
-            write(w, "    \"files_scanned\": {report.files_scanned},\n")
-            write(w, "    \"functions_analyzed\": {report.functions_analyzed},\n")
-            write(w, "    \"exact_clusters\": {length(report.exact_clusters)},\n")
-            write(w, "    \"fuzzy_pairs\": {length(report.fuzzy_pairs)},\n")
-            write(w, "    \"threshold\": {report.threshold},\n")
-            write(w, "    \"min_tokens\": {report.min_tokens}\n")
-            write(w, "  \},\n")
-            write(w, "  \"exact_clusters\": [\n")
-            for (i in range(length(report.exact_clusters))) {
-                write(w, "    \{\n")
-                write(w, "      \"size\": {length(report.exact_clusters[i].members)},\n")
-                write(w, "      \"token_count\": {report.exact_clusters[i].token_count},\n")
-                write(w, "      \"canonical_sample\": \"{json_escape(report.exact_clusters[i].canonical_sample)}\",\n")
-                write(w, "      \"members\": [\n")
-                let mn = length(report.exact_clusters[i].members)
-                for (j in range(mn)) {
-                    write(w, "        ")
-                    write_member(w, report.exact_clusters[i].members[j])
-                    if (j + 1 < mn) {
-                        write(w, ",")
-                    }
-                    write(w, "\n")
-                }
-                write(w, "      ]\n")
-                write(w, "    \}")
-                if (i + 1 < length(report.exact_clusters)) {
-                    write(w, ",")
-                }
-                write(w, "\n")
-            }
-            write(w, "  ],\n")
-            write(w, "  \"fuzzy_pairs\": [\n")
-            for (i in range(length(report.fuzzy_pairs))) {
-                write(w, "    \{\n")
-                write(w, "      \"similarity\": {report.fuzzy_pairs[i].similarity},\n")
-                write(w, "      \"a\": ")
-                write_member(w, report.fuzzy_pairs[i].a)
-                write(w, ",\n      \"b\": ")
-                write_member(w, report.fuzzy_pairs[i].b)
-                write(w, ",\n      \"canonical_a\": \"{json_escape(report.fuzzy_pairs[i].canonical_a)}\",\n")
-                write(w, "      \"canonical_b\": \"{json_escape(report.fuzzy_pairs[i].canonical_b)}\"\n")
-                write(w, "    \}")
-                if (i + 1 < length(report.fuzzy_pairs)) {
-                    write(w, ",")
-                }
-                write(w, "\n")
-            }
-            write(w, "  ]\n")
-            write(w, "\}\n")
-        }
-        fw |> fwrite(body)
+        fw |> fprint(body)
     }
     return ok
 }
@@ -123,11 +51,11 @@ def member_label(m : MemberRef) : string {
 
 def public print_summary(report : Report; top : int) {
     print("\n=== find_dupes summary ===\n")
-    print("files scanned     : {report.files_scanned}\n")
-    print("functions analyzed: {report.functions_analyzed}\n")
+    print("files scanned     : {report.summary.files_scanned}\n")
+    print("functions analyzed: {report.summary.functions_analyzed}\n")
     print("exact clusters    : {length(report.exact_clusters)}\n")
-    print("fuzzy pairs       : {length(report.fuzzy_pairs)}  (threshold {report.threshold})\n")
-    print("min tokens        : {report.min_tokens}\n")
+    print("fuzzy pairs       : {length(report.fuzzy_pairs)}  (threshold {report.summary.threshold})\n")
+    print("min tokens        : {report.summary.min_tokens}\n")
     let n_ex = top < length(report.exact_clusters) ? top : length(report.exact_clusters)
     if (n_ex > 0) {
         print("\n--- top {n_ex} exact-clone clusters ---\n")

--- a/utils/find_dupes/report.das
+++ b/utils/find_dupes/report.das
@@ -1,0 +1,155 @@
+options gen2
+
+require strings
+require daslib/strings_boost
+require daslib/fio
+require cluster
+
+
+struct public Report {
+    files_scanned : int
+    functions_analyzed : int
+    threshold : float
+    min_tokens : int
+    exact_clusters : array<Cluster>
+    fuzzy_pairs : array<FuzzyPair>
+}
+
+
+// All canonical text is printable ASCII by construction. File paths
+// and function names may contain backslashes (on Windows) or quotes
+// in pathological cases. This handles the JSON-mandatory escapes and
+// passes the rest through unchanged.
+def json_escape(s : string) : string {
+    return build_string() $(var w) {
+        peek_data(s) $(arr) {
+            for (b in arr) {
+                let c = int(b)
+                if (c == int(0x22)) {
+                    write(w, "\\\"")
+                } elif (c == int(0x5C)) {
+                    write(w, "\\\\")
+                } elif (c == int(0x0A)) {
+                    write(w, "\\n")
+                } elif (c == int(0x0D)) {
+                    write(w, "\\r")
+                } elif (c == int(0x09)) {
+                    write(w, "\\t")
+                } else {
+                    write(w, "{to_char(c)}")
+                }
+            }
+        }
+    }
+}
+
+
+def write_member(var w : StringBuilderWriter; m : MemberRef) {
+    write(w, "\{\"file\":\"{json_escape(m.file)}\",\"name\":\"{json_escape(m.name)}\",\"line\":{m.line},\"is_lambda\":{m.is_lambda}\}")
+}
+
+
+def public write_json_report(report : Report; path : string) : bool {
+    var ok = false
+    fopen(path, "wb") $(fw) {
+        if (fw == null) {
+            return
+        }
+        ok = true
+        let body = build_string() $(var w) {
+            write(w, "\{\n")
+            write(w, "  \"summary\": \{\n")
+            write(w, "    \"files_scanned\": {report.files_scanned},\n")
+            write(w, "    \"functions_analyzed\": {report.functions_analyzed},\n")
+            write(w, "    \"exact_clusters\": {length(report.exact_clusters)},\n")
+            write(w, "    \"fuzzy_pairs\": {length(report.fuzzy_pairs)},\n")
+            write(w, "    \"threshold\": {report.threshold},\n")
+            write(w, "    \"min_tokens\": {report.min_tokens}\n")
+            write(w, "  \},\n")
+            write(w, "  \"exact_clusters\": [\n")
+            for (i in range(length(report.exact_clusters))) {
+                write(w, "    \{\n")
+                write(w, "      \"size\": {length(report.exact_clusters[i].members)},\n")
+                write(w, "      \"token_count\": {report.exact_clusters[i].token_count},\n")
+                write(w, "      \"canonical_sample\": \"{json_escape(report.exact_clusters[i].canonical_sample)}\",\n")
+                write(w, "      \"members\": [\n")
+                let mn = length(report.exact_clusters[i].members)
+                for (j in range(mn)) {
+                    write(w, "        ")
+                    write_member(w, report.exact_clusters[i].members[j])
+                    if (j + 1 < mn) {
+                        write(w, ",")
+                    }
+                    write(w, "\n")
+                }
+                write(w, "      ]\n")
+                write(w, "    \}")
+                if (i + 1 < length(report.exact_clusters)) {
+                    write(w, ",")
+                }
+                write(w, "\n")
+            }
+            write(w, "  ],\n")
+            write(w, "  \"fuzzy_pairs\": [\n")
+            for (i in range(length(report.fuzzy_pairs))) {
+                write(w, "    \{\n")
+                write(w, "      \"similarity\": {report.fuzzy_pairs[i].similarity},\n")
+                write(w, "      \"a\": ")
+                write_member(w, report.fuzzy_pairs[i].a)
+                write(w, ",\n      \"b\": ")
+                write_member(w, report.fuzzy_pairs[i].b)
+                write(w, ",\n      \"canonical_a\": \"{json_escape(report.fuzzy_pairs[i].canonical_a)}\",\n")
+                write(w, "      \"canonical_b\": \"{json_escape(report.fuzzy_pairs[i].canonical_b)}\"\n")
+                write(w, "    \}")
+                if (i + 1 < length(report.fuzzy_pairs)) {
+                    write(w, ",")
+                }
+                write(w, "\n")
+            }
+            write(w, "  ]\n")
+            write(w, "\}\n")
+        }
+        fw |> fwrite(body)
+    }
+    return ok
+}
+
+
+def member_label(m : MemberRef) : string {
+    let base = m.is_lambda ? "<lambda>" : m.name
+    return "{m.file}:{m.line}  {base}"
+}
+
+
+def public print_summary(report : Report; top : int) {
+    print("\n=== find_dupes summary ===\n")
+    print("files scanned     : {report.files_scanned}\n")
+    print("functions analyzed: {report.functions_analyzed}\n")
+    print("exact clusters    : {length(report.exact_clusters)}\n")
+    print("fuzzy pairs       : {length(report.fuzzy_pairs)}  (threshold {report.threshold})\n")
+    print("min tokens        : {report.min_tokens}\n")
+    let n_ex = top < length(report.exact_clusters) ? top : length(report.exact_clusters)
+    if (n_ex > 0) {
+        print("\n--- top {n_ex} exact-clone clusters ---\n")
+        for (i in range(n_ex)) {
+            let size = length(report.exact_clusters[i].members)
+            let tcount = report.exact_clusters[i].token_count
+            print("\n[{i + 1}] size={size} tokens={tcount}\n")
+            print("    {report.exact_clusters[i].canonical_sample}\n")
+            for (m in report.exact_clusters[i].members) {
+                print("    - {member_label(m)}\n")
+            }
+        }
+    }
+    let n_fz = top < length(report.fuzzy_pairs) ? top : length(report.fuzzy_pairs)
+    if (n_fz > 0) {
+        print("\n--- top {n_fz} fuzzy pairs ---\n")
+        for (i in range(n_fz)) {
+            print("\n[{i + 1}] similarity={report.fuzzy_pairs[i].similarity}\n")
+            print("    a: {member_label(report.fuzzy_pairs[i].a)}\n")
+            print("    b: {member_label(report.fuzzy_pairs[i].b)}\n")
+            print("    a canonical: {report.fuzzy_pairs[i].canonical_a}\n")
+            print("    b canonical: {report.fuzzy_pairs[i].canonical_b}\n")
+        }
+    }
+}

--- a/utils/find_dupes/report.das
+++ b/utils/find_dupes/report.das
@@ -44,7 +44,9 @@ def public write_json_report(report : Report; path : string) : bool {
 
 
 def member_label(m : MemberRef) : string {
-    let base = m.is_lambda ? "<lambda>" : m.name
+    // Synthetic lambda names already encode line:col, which makes
+    // multiple `@(...)` blocks on the same line distinguishable.
+    let base = m.is_lambda ? "<lambda> ({m.name})" : m.name
     return "{m.file}:{m.line}  {base}"
 }
 


### PR DESCRIPTION
## Summary

New `utils/find_dupes/` CLI that walks a directory of `.das` files, normalises each function into an alpha-renamed token stream (identifiers + types + literals all collapsed), and reports:

- **Exact-clone clusters** — functions that hash to the same canonical text.
- **Fuzzy near-duplicate pairs** — 64-slot MinHash signatures combined with a length-ratio gate (the gate suppresses MinHash false-positives on highly periodic boilerplate).

Discovery-only — no auto-fix, no CI integration. Useful for surfacing test-suite boilerplate, copy-pasted helpers, and near-clones that drifted apart.

## Usage

```sh
./bin/daslang utils/find_dupes/main.das -- -p tests --json /tmp/dupes.json
./bin/daslang utils/find_dupes/main.das -- -p daslib --no-fuzzy --min-tokens 32
./bin/daslang utils/find_dupes/main.das -- -p tests -L --min-tokens 16   # lambda-only mode
./bin/daslang -jit utils/find_dupes/main.das -- -p tutorials -p examples --min-tokens 32
```

See `utils/find_dupes/README.md` for full flag list and canonical-form examples.

## Notable behaviour

- **Lambda-only mode (`-L`)** — flips the filter to keep only `_lambda` functions and drop top-level. Useful for clustering dastest `t |> run("…") @(t) { … }` bodies. Default mode is unchanged (drops everything `generated` including lambdas; the dispatcher's `ADDR` token preserves a partial fingerprint).
- **Auto-skipped files** — `builtin.das`, `daslib/debugger.das`, and `daslib/profiler.das`. The latter two install thread-local debug agents at compile time; the second install in the same scanner process throws and aborts the run.
- **JIT-compatible** — `-jit` works on the tool itself (LLVM JIT cache hits on subsequent runs). Net runtime improvement is modest because per-file cost is dominated by interpreter compilation of the scanned files.

## Sample findings (real refactor candidates surfaced on this codebase)

- `tutorials/dasPEG/{01,02,03,05,06}.das` — 8+ near-identical `parse_*` wrappers (push → peek_data → clone → parse → branch on success → sort_unique → invoke).
- `tutorials/dasHV/{03,06,07,tutorial_server}.das` — 4 near-identical `with_*_server` 84-token bodies (with_job_status×2 + with_atomic32 + new_thread_invoke + join×2).
- `examples/daStrudel/strudel_visualizer/vis_renderer.das` — 4-copy in-file dup of `spectrum`/`scope`/`vectorscope`/`drums`.
- `tutorials/daStrudel/daStrudel_*.das` — 11 nearly-identical `play()` shells, split into 2 clusters (6 + 5) by an arg-order drift between older and newer signatures.
- Lambda-only mode on full `tests/`: 74 single-`equal()` test bodies, 42 `equal(t, regex_test_match(…), …)` regex bodies, etc.

## Test plan

- [x] Lint clean on the 6 new `.das` files (the 8 LINT003 warnings reported are in `daslib/clargs.das`, triggered by the `[CommandLineArgs]` macro expansion — unchanged code).
- [x] All 6 `.das` files already MCP-formatted.
- [x] End-to-end smoke runs:
  - `./bin/daslang utils/find_dupes/main.das -- -p tests/strings -t 0.85 -n 12` → 52 records, 5 clusters.
  - `./bin/daslang -jit utils/find_dupes/main.das -- -p tutorials -p examples --min-tokens 32` → 62 s, JSON report written.
  - `./bin/daslang -jit utils/find_dupes/main.das -- -p tests -L --min-tokens 16` → ~75 s, lambda-mode clusters as advertised.
- [ ] Full `tests/` and AOT suites — **not run**. The change is purely additive: new self-contained utility under `utils/`, no CMake, no library, no AOT-stub changes. Happy to run them on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
