### PR TITLE
dasSQLITE: chunk 3 — aggregate framework + tutorials 5/6/8/9 + _try_sql

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/das_formatting.md` | Creating or modifying any `.das` file (tutorials, tests, daslib modules, utilities) |
 | `skills/writing_tests.md` | Writing or editing test files under `tests/` |
 | `skills/documentation_rst.md` | Editing RST files in `doc/source/`, editing `//!` doc-comments in `daslib/*.das`, writing tutorial RST pages |
+| `skills/tutorials.md` | Creating, moving, or restructuring tutorial `.das` files. **Always check before editing anything that looks like a tutorial** — tutorials live under `/tutorials/<area>/`, NEVER inside `modules/<X>/tutorial/` (which holds inherited examples) |
 | `skills/cpp_integration.md` | Writing or editing C++ files in `src/`, `modules/`, or `tutorials/integration/cpp/` |
 | `skills/daslib_modules.md` | Working with `daslib/` modules (linq, json, regex, functional, match, etc.), channels, or extending the standard library |
 | `skills/das_macros.md` | Writing compile-time macros, AST manipulation, qmacro/quote code generation, gc_node AST-pointer patterns |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1666,6 +1666,14 @@ install(FILES ${AUDIO_TUTORIAL_SOURCES}
     DESTINATION ${DAS_INSTALL_TUTORIALSDIR}/dasAudio
 )
 
+# Install dasSQLITE tutorial .das files
+file(GLOB SQL_TUTORIAL_SOURCES
+    ${PROJECT_SOURCE_DIR}/tutorials/sql/*.das
+)
+install(FILES ${SQL_TUTORIAL_SOURCES}
+    DESTINATION ${DAS_INSTALL_TUTORIALSDIR}/sql
+)
+
 # ── Documentation build (optional) ──────────────────────────────────────────
 if(DAS_BUILD_DOCUMENTATION)
     find_package(Python3 COMPONENTS Interpreter)

--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -632,7 +632,7 @@ def private generate_type_match(pat_type : TypeDecl?; td_var : string; expr_var 
             let tag_expr = pat_type.firstType.dimExpr[0]
             if (tag_expr != null && tag_expr is ExprVar) {
                 let tmp = next_var(index)
-                body |> push <| qmacro_expr(${ var $i(tmp) = clone_type($i(td_var)); })
+                body |> push <| qmacro_expr(${ var $i(tmp) = clone_type($i(td_var)); }) // nolint:LINT004
                 body |> push <| qmacro_expr(${ $i((tag_expr as ExprVar).name) = $i(tmp); })
             }
         }
@@ -1077,7 +1077,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
             let var_expr = tag.subexpr as ExprVar
             if (var_expr != null) {
                 let tmp = next_var(index)
-                body |> push <| qmacro_expr(${ var $i(tmp) = clone_expression($i(actual_var)); })
+                body |> push <| qmacro_expr(${ var $i(tmp) = clone_expression($i(actual_var)); }) // nolint:LINT004
                 body |> push <| qmacro_expr(${ $i(var_expr.name) <- $i(tmp); })
             }
             return
@@ -1187,10 +1187,10 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
         let cast_var = next_var(index)
         var as_val = make_var_ref(at, actual_var)
         var as_cast = new ExprAsVariant(at = at, value = as_val, name := "ExprTypeDecl")
-        body |> push <| qmacro_expr(${ var $i(cast_var) = $e(as_cast); })
+        body |> push <| qmacro_expr(${ var $i(cast_var) = $e(as_cast); }) // nolint:LINT004
         // Clone the typeexpr for matching
         let td_var = next_var(index)
-        body |> push <| qmacro_expr(${ var $i(td_var) = clone_type($i(cast_var).typeexpr); })
+        body |> push <| qmacro_expr(${ var $i(td_var) = clone_type($i(cast_var).typeexpr); }) // nolint:LINT004
         generate_type_match((pattern as ExprTypeDecl).typeexpr, td_var, actual_var, body, index, at)
         return
     }
@@ -1406,7 +1406,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
                         if (*pv != null) {
                             let child_pattern = *pv
                             let child_var = next_var(index)
-                            body |> push <| qmacro_expr(${ var $i(child_var) = clone_expression($i(cast_var).$f(name)); })
+                            body |> push <| qmacro_expr(${ var $i(child_var) = clone_expression($i(cast_var).$f(name)); }) // nolint:LINT004
                             if (!is_wildcard_call(child_pattern) && !(child_pattern is ExprTag)) {
                                 var ncond = qmacro($i(child_var) == null)
                                 var nfail = qmacro(qm_fail_null())
@@ -1583,7 +1583,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
         let cast_var = next_var(index)
         var as_val_c = make_var_ref(at, actual_var)
         var as_cast_c = new ExprAsVariant(at = at, value = as_val_c, name := rtti)
-        body |> push <| qmacro_expr(${ var $i(cast_var) = $e(as_cast_c); })
+        body |> push <| qmacro_expr(${ var $i(cast_var) = $e(as_cast_c); }) // nolint:LINT004
         // Match name (ExprCall only) then match arguments (skipping fakeContext/fakeLineInfo)
         if (rtti == "ExprCall") {
             let call = pattern as ExprCall
@@ -1601,9 +1601,9 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
                     let child_pattern = arg
                     if (child_pattern != null) {
                         let phys_var = next_var(index)
-                        body |> push <| qmacro_expr(${ var $i(phys_var) = qm_real_call_arg_index($i(cast_var).arguments, $v(i)); })
+                        body |> push <| qmacro_expr(${ var $i(phys_var) = qm_real_call_arg_index($i(cast_var).arguments, $v(i)); }) // nolint:LINT004
                         let child_var = next_var(index)
-                        body |> push <| qmacro_expr(${ var $i(child_var) = clone_expression($i(cast_var).arguments[$i(phys_var)]); })
+                        body |> push <| qmacro_expr(${ var $i(child_var) = clone_expression($i(cast_var).arguments[$i(phys_var)]); }) // nolint:LINT004
                         generate_match(child_pattern, child_var, body, index, at)
                     }
                 }
@@ -1619,9 +1619,9 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
                     let child_pattern = arg
                     if (child_pattern != null) {
                         let phys_var = next_var(index)
-                        body |> push <| qmacro_expr(${ var $i(phys_var) = qm_real_call_arg_index($i(cast_var).arguments, $v(i)); })
+                        body |> push <| qmacro_expr(${ var $i(phys_var) = qm_real_call_arg_index($i(cast_var).arguments, $v(i)); }) // nolint:LINT004
                         let child_var = next_var(index)
-                        body |> push <| qmacro_expr(${ var $i(child_var) = clone_expression($i(cast_var).arguments[$i(phys_var)]); })
+                        body |> push <| qmacro_expr(${ var $i(child_var) = clone_expression($i(cast_var).arguments[$i(phys_var)]); }) // nolint:LINT004
                         generate_match(child_pattern, child_var, body, index, at)
                     }
                 }
@@ -1637,7 +1637,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
     let cast_var = next_var(index)
     var as_val2 = make_var_ref(at, actual_var)
     var as_cast2 = new ExprAsVariant(at = at, value = as_val2, name := rtti)
-    body |> push <| qmacro_expr(${ var $i(cast_var) = $e(as_cast2); })
+    body |> push <| qmacro_expr(${ var $i(cast_var) = $e(as_cast2); }) // nolint:LINT004
 
     // Iterate fields via annotation reflection
     var ann = unsafe(reinterpret<BasicStructureAnnotation?> get_expression_annotation(pattern))
@@ -1680,7 +1680,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
                 if (*pv != null) {
                     let child_pattern = *pv
                     let child_var = next_var(index)
-                    body |> push <| qmacro_expr(${ var $i(child_var) = clone_expression($i(cast_var).$f(name)); })
+                    body |> push <| qmacro_expr(${ var $i(child_var) = clone_expression($i(cast_var).$f(name)); }) // nolint:LINT004
                     if (!is_wildcard_call(child_pattern) && !(child_pattern is ExprTag)) {
                         var ncond = qmacro($i(child_var) == null)
                         var nfail = qmacro(qm_fail_null())

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -291,6 +291,11 @@ Run any tutorial from the project root::
    tutorials/sql_01_hello.rst
    tutorials/sql_02_insert_data.rst
    tutorials/sql_03_last_row_id.rst
+   tutorials/sql_04_select_all.rst
+   tutorials/sql_05_parametrized.rst
+   tutorials/sql_06_error_handling.rst
+   tutorials/sql_08_where.rst
+   tutorials/sql_09_select.rst
 
 .. _tutorials_dasaudio:
 

--- a/doc/source/reference/tutorials/sql_03_last_row_id.rst
+++ b/doc/source/reference/tutorials/sql_03_last_row_id.rst
@@ -103,3 +103,5 @@ Helper                                      Description
     Full source: :download:`tutorials/sql/03-last_row_id.das <../../../../tutorials/sql/03-last_row_id.das>`
 
     Previous tutorial: :ref:`tutorial_sql_insert_data`
+
+    Next tutorial: :ref:`tutorial_sql_select_all`

--- a/doc/source/reference/tutorials/sql_04_select_all.rst
+++ b/doc/source/reference/tutorials/sql_04_select_all.rst
@@ -1,0 +1,145 @@
+.. _tutorial_sql_select_all:
+
+==========================================
+SQL-04 --- Reading Rows with ``_sql``
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; _sql
+    single: Tutorial; select_from
+    single: Tutorial; _select
+    single: Tutorial; _where
+
+Tutorials 1-3 covered opening a database, declaring a table, and writing
+rows. This tutorial introduces ``_sql(...)`` --- the call macro that
+translates a daslib/linq-shaped chain into SQL at compile time --- and
+the ``select_from`` / ``_where`` / ``_select`` chain stages.
+
+Setup
+=====
+
+Three requires::
+
+    require daslib/sql
+    require sqlite/sqlite_boost
+    require sqlite/sqlite_linq
+
+The first two are the standard pair from tutorial 1. The third,
+``sqlite/sqlite_linq``, brings in the ``_sql`` and ``_sql_text`` call
+macros plus the ``select_from`` runtime entry. The abstract layer
+``daslib/sql`` deliberately does *not* re-export sqlite-specific
+symbols --- each provider keeps its linq adapter in its own boost
+module so a future ``postgres/postgres_linq`` lands cleanly alongside.
+
+Reading every row
+=================
+
+The minimal chain ``select_from(type<T>)`` reads every row of the table
+into ``array<T>``:
+
+.. code-block:: das
+
+    let cars <- _sql(db |> select_from(type<Car>))
+    for (car in cars) {
+        to_log(LOG_INFO, "  {car.Name}: {car.Price}\n")
+    }
+
+The macro emits the SQL ``SELECT "Id", "Name", "Price" FROM "Cars"``
+and the runtime materializes each row into a ``Car`` via the
+per-field ``sqlite_read`` overloads ``[sql_table]`` generates. The
+move-assign ``<-`` is required because ``array<Car>`` is non-copyable.
+
+Filtering with ``_where`` (bind capture)
+========================================
+
+``_where(predicate)`` pipes after the chain root and adds a ``WHERE``
+clause. Free variables in the predicate are *captured* and lowered to
+``?`` bind parameters --- so the SQL is parameterized, not
+string-interpolated:
+
+.. code-block:: das
+
+    let threshold = 200
+    let pricey <- _sql(
+        db |> select_from(type<Car>) |> _where(_.Price > threshold))
+    // emits:  SELECT "Id", "Name", "Price" FROM "Cars" WHERE "Price" > ?
+    // binds:  [threshold]
+
+The ``_.Field`` shorthand inside the predicate refers to a column of
+the row source. The macro classifies each name in the predicate as
+either a column reference (``_.X``) or a captured value (everything
+else), and routes them to the SQL identifier vs. bind list
+accordingly. Multiple ``_where`` calls compose AND-wise.
+
+Supported operators inside ``_where``: ``==``, ``!=``, ``<``, ``<=``,
+``>``, ``>=``, ``&&``, ``||``, ``!``. The captured side may be a
+literal or a free variable from any enclosing scope.
+
+Projecting a single column with ``_select``
+===========================================
+
+``_select(_.Field)`` projects a single column, producing
+``array<FieldType>`` instead of ``array<T>``:
+
+.. code-block:: das
+
+    let names <- _sql(db |> select_from(type<Car>) |> _select(_.Name))
+    // emits:  SELECT "Name" FROM "Cars"
+    // result: array<string>
+
+This chunk supports the single-column ``_.Field`` form. Multi-column
+projections (struct constructors, named-tuple literals) ship in a
+later chunk.
+
+Inspecting the emitted SQL with ``_sql_text``
+=============================================
+
+``_sql_text`` is the debug companion: same chain, but instead of
+running it the macro returns the SQL string that ``_sql`` would have
+prepared. ``?`` placeholders stay literal --- the bind values are not
+substituted into the text:
+
+.. code-block:: das
+
+    let sql = _sql_text(
+        db |> select_from(type<Car>) |> _where(_.Id == 5))
+    to_log(LOG_INFO, "{sql}\n")
+    // SELECT "Id", "Name", "Price" FROM "Cars" WHERE "Id" = ?
+
+Use this in tests to lock the emission shape, and during development
+to confirm the macro is translating what you expect.
+
+Composability
+=============
+
+``_sql`` runs as a default ``[call_macro]`` (``canVisitArgument =
+true``), so any user-defined call macro that expands to one of the
+recognised chain stages composes transparently. A wrapper macro that
+expands to ``_where(it, _.Price < threshold)`` slots into a ``_sql``
+chain at the same place a literal ``_where`` would, and the analyzer
+walks the post-expansion shape uniformly. Tests in
+``tests/dasSQLITE/test_07_sql_composability.das`` pin the contract.
+
+Quick reference
+===============
+
+==========================================================  =========================================================
+Helper                                                      Description
+==========================================================  =========================================================
+``_sql(chain) -> array<T>``                                 Translate a linq-shaped chain to SQL and materialize
+``_sql_text(chain) -> string``                              Same translation, return the SQL string instead
+``db |> select_from(type<T>)``                              Chain root --- iterate every row of table T
+``... |> _where(predicate)``                                Filter; captured variables become ``?`` binds
+``... |> _select(_.Field)``                                 Single-column projection
+``... |> _to_array()``                                      No-op terminal --- materializes into ``array<T>``
+==========================================================  =========================================================
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/04-select_all.das <../../../../tutorials/sql/04-select_all.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_last_row_id`
+
+    Next tutorial: :ref:`tutorial_sql_parametrized`

--- a/doc/source/reference/tutorials/sql_05_parametrized.rst
+++ b/doc/source/reference/tutorials/sql_05_parametrized.rst
@@ -1,0 +1,114 @@
+.. _tutorial_sql_parametrized:
+
+==================================
+SQL-05 --- Parameter Binding
+==================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; bind parameters
+    single: Tutorial; query_one
+    single: Tutorial; _first
+    single: Tutorial; _first_opt
+
+Parameter binding has two stories in dasSQLITE, and the chunk-3 design
+is to keep the everyday one **invisible**.
+
+LINQ form: capture is binding
+=============================
+
+Inside ``_sql(...)``, the macro's expression walker classifies each
+name in the chain as either a **column reference** (``_.Field``) or a
+**captured value** (anything else). Captured values are lowered to
+``?`` placeholders and bound automatically --- you never type ``?`` or
+``:name``:
+
+.. code-block:: das
+
+    let target = 3
+    let car = _sql(db |> select_from(type<Car>)
+                     |> _where(_.Id == target)
+                     |> _first())
+    // emits:  SELECT "Id", "Name", "Price" FROM "Cars" WHERE "Id" = ? LIMIT 1
+    // binds:  [target]
+
+``_first()`` is the single-row terminal: it adds ``LIMIT 1`` and
+panics if no row matches. ``_first_opt()`` is the non-panic sibling
+--- same SQL, but the result is ``Option<T>`` (``none`` on empty):
+
+.. code-block:: das
+
+    let maybe = _sql(db |> select_from(type<Car>)
+                       |> _where(_.Id == 999)
+                       |> _first_opt())
+    // maybe : Option<Car>;  is_some -> false here
+
+Tutorial 5's whole conceptual surface (parameter binding) becomes
+invisible at the call site. That's the design win.
+
+Raw-SQL escape hatch: ``query_one`` with positional ``?``
+=========================================================
+
+For migrations, ad-hoc queries, or anything ``_sql`` can't translate,
+the ``query_one`` family takes positional ``?`` arguments via
+variadic trailing args:
+
+.. code-block:: das
+
+    let raw = db |> query_one(
+        "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id = ?",
+        type<Car>, target)
+
+The trailing args bind to ``?`` placeholders in declaration order.
+Mixed types are fine --- daslang's overload resolution dispatches to
+the right ``sqlite_bind`` for each arg:
+
+.. code-block:: das
+
+    let multi = db |> query_one(
+        "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id = ? AND Name = ?",
+        type<Car>, 2, "Audi")
+
+Chunk 3 ships 0..3 positional args. Named-tuple bind for ``:name``
+placeholders ships in a follow-up.
+
+Strict / Result / Option triples
+================================
+
+Every read helper has the same three flavours --- pick by what
+"no row" or "error" should mean at the call site:
+
+==============================================================  ==========================================================
+Form                                                            Behaviour
+==============================================================  ==========================================================
+``query_one(...)``                                              Strict; panics on prepare/step error or 0 rows
+``try_query_one(...) : Result<T, string>``                      Returns ``Err`` on prepare/step error or 0 rows
+``query_one_opt(...) : Option<T>``                              Panics on error; ``none`` on 0 rows
+``_sql(... |> _first())``                                       Strict; panics on 0 rows or step failure
+``_try_sql(... |> _first()) : Result<T, string>``               Returns ``Err`` on 0 rows or step failure
+``_sql(... |> _first_opt()) : Option<T>``                       Panics on error; ``none`` on 0 rows
+==============================================================  ==========================================================
+
+Tutorial 6 walks the full matrix with worked examples.
+
+Quick reference
+===============
+
+==============================================================  ==========================================================
+Form                                                            Description
+==============================================================  ==========================================================
+``... |> _first()``                                             Single-row terminal; ``LIMIT 1`` + panic on empty
+``... |> _first_opt()``                                         Single-row terminal; ``Option<T>``, ``none`` on empty
+``db |> query_one(sql, type<T>, args...)``                      Raw-SQL one-row read; up to 3 positional ``?`` binds
+``db |> try_query_one(sql, type<T>, args...)``                  Same; returns ``Result<T, string>``
+``db |> query_one_opt(sql, type<T>, args...)``                  Same; returns ``Option<T>`` (``none`` on 0 rows)
+==============================================================  ==========================================================
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/05-parametrized.das <../../../../tutorials/sql/05-parametrized.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_select_all`
+
+    Next tutorial: :ref:`tutorial_sql_error_handling`

--- a/doc/source/reference/tutorials/sql_06_error_handling.rst
+++ b/doc/source/reference/tutorials/sql_06_error_handling.rst
@@ -1,0 +1,126 @@
+.. _tutorial_sql_error_handling:
+
+==================================
+SQL-06 --- Error Handling
+==================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; error handling
+    single: Tutorial; Result
+    single: Tutorial; Option
+    single: Tutorial; try_open_sqlite
+    single: Tutorial; try_insert
+    single: Tutorial; query_scalar_opt
+    single: Tutorial; _try_sql
+
+dasSQLITE follows a uniform naming convention. Pick the variant by how
+you want errors and "no row" to surface at the call site:
+
+==============================  ==================================================================
+Suffix                          Meaning
+==============================  ==================================================================
+``foo(...)``                    Strict; panics on error (programmer-error default)
+``try_foo(...)``                ``Result<T, string>`` for write-side errors you want to handle
+``foo_opt(...)``                ``Option<T>`` for read-side empty results (0 rows is a normal outcome)
+==============================  ==================================================================
+
+The same convention extends to the ``_sql`` macro: ``_sql(chain)`` is
+strict, ``_try_sql(chain)`` is the non-panicking ``Result`` sibling.
+
+Opening: ``try_open_sqlite``
+============================
+
+Use ``try_open_sqlite`` when the path is user-supplied or otherwise
+unreliable. The strict ``open_sqlite`` / ``with_sqlite`` forms panic
+on the same failure:
+
+.. code-block:: das
+
+    var open_result <- try_open_sqlite(":memory:")
+    if (open_result |> is_err) {
+        to_log(LOG_ERROR, "could not open db: {open_result |> unwrap_err}\n")
+        return
+    }
+    var inscope db <- open_result._value
+
+``SqlRunner`` finalizes on scope exit (closes the SQLite handle), so
+it must be ``var inscope`` and bound by move (``<-``). Plain
+``unwrap`` would fail because the type isn't copyable.
+
+Writes: ``try_insert``
+======================
+
+``insert`` panics on a constraint violation. ``try_insert`` returns
+``Result<int64, string>`` carrying the libsqlite3 error message:
+
+.. code-block:: das
+
+    let first = db |> try_insert(User(Id = 1, Name = "alice"))
+    // first : Result<int64, string>;  rowid on success
+
+    // Explicit collision --- strict insert() would abort here.
+    let dup = db |> try_insert(User(Id = 1, Name = "alice-dup"))
+    if (dup |> is_err) {
+        // dup |> unwrap_err == "insert step failed: UNIQUE constraint failed: ..."
+    }
+
+Reads where 0 rows is fine: ``query_scalar_opt``
+================================================
+
+When 0 rows is a normal outcome (key not in table, lookup miss), the
+``*_opt`` variant returns ``Option<T>``. Combine with ``??`` for a
+default:
+
+.. code-block:: das
+
+    let lookup = db |> query_scalar_opt(
+        "SELECT \"Name\" FROM \"Users\" WHERE \"Id\" = 42", type<string>)
+    to_log(LOG_INFO, "user 42 is {lookup ?? "unknown"}\n")
+
+``_try_sql``: ``_sql`` that doesn't panic
+=========================================
+
+``_try_sql`` is the non-panic sibling of ``_sql``. Same chain
+analyzer, same emitted SQL --- the only difference is the runtime
+helper used and the return type:
+
+.. code-block:: das
+
+    // _try_sql(... |> _first())     : Result<T, string>
+    // _try_sql(... |> _first_opt()) : Result<Option<T>, string>
+    // _try_sql(... |> count())      : Result<int64, string>
+
+    let res = _try_sql(db |> select_from(type<User>) |> _first())
+    if (res |> is_ok) {
+        let u = res |> unwrap
+    }
+
+The ``_first`` vs ``_first_opt`` distinction still applies under
+``_try_sql``: ``_first`` reports 0 rows as ``Err``; ``_first_opt``
+reports them as ``ok(none)``. Pick the one that matches your domain.
+
+Quick reference
+===============
+
+==============================================================  ==========================================================
+Form                                                            When to use
+==============================================================  ==========================================================
+``open_sqlite(path)``                                           Strict open; panic on failure
+``try_open_sqlite(path) : Result<SqlRunner, string>``           Open with handleable error
+``insert(row)``                                                 Strict; panic on constraint violation
+``try_insert(row) : Result<int64, string>``                     Returns rowid on success or libsqlite3 errmsg
+``query_scalar(sql, type<T>)``                                  Strict; panic on 0 rows
+``query_scalar_opt(sql, type<T>) : Option<T>``                  ``none`` on 0 rows; panic only on prepare/step error
+``_sql(chain)``                                                 Strict ``_sql``; panic on prepare/step error
+``_try_sql(chain) : Result<..., string>``                       Non-panic sibling; same SQL, wrapped result
+==============================================================  ==========================================================
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/06-error_handling.das <../../../../tutorials/sql/06-error_handling.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_parametrized`
+
+    Next tutorial: :ref:`tutorial_sql_where`

--- a/doc/source/reference/tutorials/sql_08_where.rst
+++ b/doc/source/reference/tutorials/sql_08_where.rst
@@ -1,0 +1,144 @@
+.. _tutorial_sql_where:
+
+==================================================
+SQL-08 --- ``_where`` Predicates: the Full Surface
+==================================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; _where
+    single: Tutorial; LIKE
+    single: Tutorial; starts_with
+    single: Tutorial; ends_with
+    single: Tutorial; contains
+
+Inside ``_sql(...)``, ``_where(predicate)`` accumulates a ``WHERE``
+clause via a recursive AST walk. Multiple ``_where`` calls compose
+with ``AND``. This tutorial walks every predicate shape the chunk-3
+analyzer recognizes; anything outside this surface raises a
+compile-time ``macro_error`` pointing at the offending node.
+
+Recognized predicate shapes
+===========================
+
+============================================  ============================================================
+Source shape                                  Lowered SQL
+============================================  ============================================================
+``_.FieldName``                               column reference (quoted identifier)
+``someVar``, ``42``, ``"alice"``              bind parameter (``?``)
+``==``, ``!=``                                ``=``, ``<>``
+``<``, ``<=``, ``>``, ``>=``                  same operators
+``&&``, ``||``, ``!``                         ``AND``, ``OR``, ``NOT``
+``s |> starts_with(p)``                       ``s LIKE ? || '%'``        (``p`` bound)
+``s |> ends_with(p)``                         ``s LIKE '%' || ?``        (``p`` bound)
+``s |> contains(p)``                          ``s LIKE '%' || ? || '%'`` (``p`` bound)
+``s |> to_lower()``, ``s |> to_upper()``      ``LOWER(s)``, ``UPPER(s)``
+``length(s)``                                 ``LENGTH(s)``
+``x |> abs()``                                ``ABS(x)``
+============================================  ============================================================
+
+Captured-variable equality
+==========================
+
+The simplest pattern --- a free variable on one side, a column ref on
+the other:
+
+.. code-block:: das
+
+    let target = 3
+    let one <- _sql(db |> select_from(type<Car>)
+                      |> _where(_.Id == target))
+    // emits:  ... WHERE "Id" = ?     binds: [3]
+
+Composition with multiple ``_where``
+====================================
+
+Each ``_where`` adds an AND-clause; chain freely:
+
+.. code-block:: das
+
+    let cheap_F <- _sql(db |> select_from(type<Car>)
+                          |> _where(_.Price < 1000)
+                          |> _where(_.Name |> starts_with("F")))
+    // emits:  ... WHERE "Price" < ? AND "Name" LIKE ? || '%'
+    // binds:  [1000, "F"]
+
+Boolean operators
+=================
+
+``&&``, ``||``, ``!`` lower to SQL ``AND`` / ``OR`` / ``NOT``. Use
+parentheses to disambiguate precedence:
+
+.. code-block:: das
+
+    let cheap_or_F <- _sql(db |> select_from(type<Car>)
+                             |> _where(_.Price < 100
+                                       || (_.Name |> starts_with("F"))))
+
+String-tests via ``LIKE``
+=========================
+
+``starts_with`` / ``ends_with`` / ``contains`` lower to a ``LIKE``
+pattern:
+
+.. code-block:: das
+
+    let ends_da   <- _sql(db |> select_from(type<Car>)
+                            |> _where(_.Name |> ends_with("da")))
+    let contains_o <- _sql(db |> select_from(type<Car>)
+                             |> _where(_.Name |> contains("o")))
+
+Case folding
+============
+
+``to_lower`` / ``to_upper`` lower to ``LOWER`` / ``UPPER``:
+
+.. code-block:: das
+
+    let case_match <- _sql(db |> select_from(type<Car>)
+                             |> _where(_.Name |> to_lower() == "ford"))
+
+String length and numeric scalar
+================================
+
+``length(s)`` and ``x |> abs()`` lower to ``LENGTH(...)`` and
+``ABS(...)``:
+
+.. code-block:: das
+
+    let long_names <- _sql(db |> select_from(type<Car>)
+                             |> _where(length(_.Name) > 5))
+
+    let dear <- _sql(db |> select_from(type<Car>)
+                       |> _where((_.Price |> abs()) > 5000))
+
+Inspecting the emitted SQL
+==========================
+
+``_sql_text`` returns the SQL the macro would emit instead of running
+it --- useful when the chain grows complex:
+
+.. code-block:: das
+
+    let sql = _sql_text(db |> select_from(type<Car>)
+                          |> _where((_.Price |> abs()) > 5000))
+    // sql == 'SELECT "Id", "Name", "Price" FROM "Cars" WHERE ABS("Price") > ?'
+
+Untranslatable predicates
+=========================
+
+If you write a shape the analyzer doesn't recognize (a user-defined
+function, a math op without a builtin lowering, a regex), the macro
+raises ``macro_error`` at compile time pointing at the offending
+node. For those cases, drop down to the raw-SQL escape hatch
+(``query_one``, ``query_scalar``, ``exec``) covered in
+:ref:`tutorial_sql_parametrized`.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/08-where.das <../../../../tutorials/sql/08-where.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_error_handling`
+
+    Next tutorial: :ref:`tutorial_sql_select`

--- a/doc/source/reference/tutorials/sql_09_select.rst
+++ b/doc/source/reference/tutorials/sql_09_select.rst
@@ -1,0 +1,137 @@
+.. _tutorial_sql_select:
+
+==================================
+SQL-09 --- ``_select`` Projections
+==================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; _select
+    single: Tutorial; projection
+    single: Tutorial; named tuple
+    single: Tutorial; tuple recordNames
+
+``_select(...)`` controls *what* columns the SQL emits and *what shape*
+the result has. Three forms ship in chunk 3:
+
+==============================================================  ==========================================================
+Form                                                            Result shape
+==============================================================  ==========================================================
+default (no ``_select``)                                        ``array<Car>`` --- all columns, source struct
+``_select(_.FieldName)``                                        ``array<FieldType>`` --- one column, that column's type
+``_select((Name=_.Name, Price=_.Price))``                       ``array<tuple<Name:string;Price:int>>`` --- named tuple
+==============================================================  ==========================================================
+
+Default projection: full row
+============================
+
+No ``_select`` --- the macro emits ``SELECT`` of every column declared
+in the ``[sql_table]`` struct, in declaration order, and materializes
+each row as the source struct:
+
+.. code-block:: das
+
+    let cars <- _sql(db |> select_from(type<Car>))
+    // emits:  SELECT "Id", "Name", "Price" FROM "Cars"
+    // result: array<Car>
+
+Single-column projection
+========================
+
+``_select(_.Field)`` projects exactly one column. The result element
+type matches the column's daslang type (``int``, ``string``, ...):
+
+.. code-block:: das
+
+    let names <- _sql(db |> select_from(type<Car>) |> _select(_.Name))
+    // emits:  SELECT "Name" FROM "Cars"
+    // result: array<string>
+
+Named-tuple projection
+======================
+
+``_select((Name=_.Name, Price=_.Price))`` projects multiple columns
+into a daslang ``tuple`` whose ``recordNames`` preserve the chosen
+names. You read tuple fields by the chosen name --- the source field
+name no longer matters at the use site:
+
+.. code-block:: das
+
+    let pairs <- _sql(db |> select_from(type<Car>)
+                        |> _select((Name=_.Name, Price=_.Price)))
+    // emits:  SELECT "Name", "Price" FROM "Cars"
+    // result: array<tuple<Name:string;Price:int>>
+
+    for (p in pairs) {
+        to_log(LOG_INFO, "  {p.Name} (price={p.Price})\n")
+    }
+
+The recordNames live on the result tuple's ``TypeDecl.argNames``;
+``build_row_builder`` constructs that ``recordType`` explicitly because
+the ``ExprMakeTuple``'s own recordNames vector isn't bound to daslang
+yet.
+
+Renaming via named tuple
+========================
+
+Because the tuple's recordNames are independent of the source columns,
+you can rename freely. The result fields can shadow keywords or just
+match the domain language better than the SQL column names do:
+
+.. code-block:: das
+
+    let renamed <- _sql(db |> select_from(type<Car>)
+                          |> _select((Identifier=_.Id, Label=_.Name)))
+    // emits:  SELECT "Id", "Name" FROM "Cars"
+    // result: array<tuple<Identifier:int;Label:string>>
+
+    for (r in renamed) {
+        to_log(LOG_INFO, "  Identifier={r.Identifier} Label={r.Label}\n")
+    }
+
+Combining with terminals
+========================
+
+``_select`` composes with ``_first`` / ``_first_opt`` / ``count`` /
+``_where`` exactly as you'd expect --- it's just another chain stage:
+
+.. code-block:: das
+
+    let head = _sql(db |> select_from(type<Car>)
+                      |> _select((Name=_.Name, Price=_.Price))
+                      |> _first())
+    // result: tuple<Name:string;Price:int>
+
+Inspecting the emitted SQL
+==========================
+
+``_sql_text`` returns the SQL the macro would emit:
+
+.. code-block:: das
+
+    let sql = _sql_text(db |> select_from(type<Car>)
+                          |> _select((Name=_.Name, Price=_.Price)))
+    // sql == 'SELECT "Name", "Price" FROM "Cars"'
+
+Quick reference
+===============
+
+==============================================================  ==========================================================
+Form                                                            Description
+==============================================================  ==========================================================
+default (no ``_select``)                                        Full row; ``array<T>``
+``_select(_.Field)``                                            Single column; ``array<FieldType>``
+``_select((Name=_.X, Other=_.Y))``                              Named tuple; ``array<tuple<Name:..;Other:..>>``
+``_select((Renamed=_.Id, ...))``                                Result fields can rename source columns
+==============================================================  ==========================================================
+
+Deferred to chunk 4: struct-type projection ``_select(type<T2>)`` for
+projecting into a different ``[sql_table]`` struct. Today users get
+the same result via named-tuple projection.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/09-select.das <../../../../tutorials/sql/09-select.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_where`

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -128,10 +128,145 @@ Struct-constructor and named-tuple `_select` projections; `_order_by`,
 `_join`, `_left_join`; `_in`, `_not_in`, `_any`, `_none`; the
 panic-free `_try_sql` variant. All planned, none in this PR.
 
+## Shipped — chunk 3: aggregate framework + _try_sql + tuts 5/6/8/9 (branch `dassqlite-chunk3-sql-framework`)
+
+Builds the discriminator infrastructure that aggregates (chunk 4's tut 13)
+will plug into, and ships the `_sql`-side surface for tutorials 5/6/8/9.
+The framework is proven end-to-end by a `_count` canary; chunk 4 broadens
+to `_sum`/`_avg`/`_min`/`_max` plus tutorials 10–13.
+
+### Framework rework — three discriminators in `analyze_chain`
+
+- **`Materializer`** enum threaded through `SqlQuery`:
+  - `Array` — default, returns `array<T>` via `run_select`
+  - `One` — single row, panics on empty (covers `_first`, `count()`)
+  - `OneOpt` — `Option<T>`, none on empty (covers `_first_opt`)
+- **`ProjectionShape`** enum:
+  - `FullRow` — default, `SELECT cols-of(rootT)`
+  - `SingleColumn` — `_select(_.Field)` (chunk 2)
+  - `NamedTuple` — `_select((Name=_.Name, Price=_.Price))` (new)
+  - `Aggregate` — `SELECT COUNT(*)` (canary) — chunk 4 broadens
+- **Function-call dispatch** in `pred_to_sql`: `(name, arity) -> SQL_template`.
+  Chunk 3 entries: `starts_with`/`ends_with`/`contains` (LIKE patterns),
+  `to_lower`/`to_upper` (case folding), `length`, `abs`. Chunk 4 adds
+  date/time + the aggregate row (`sum`, `avg`, etc.).
+
+### New chain operators
+
+- **`_first()`** — terminal. Plain function in `sqlite_linq.das`; recognized
+  in `analyze_chain`; emits ` LIMIT 1` and uses Materializer.One.
+- **`_first_opt()`** — terminal. Plain function in `sqlite_linq.das`; emits
+  ` LIMIT 1` and uses Materializer.OneOpt.
+- **`count()`** (no underscore — `_count` is reserved by linq_boost as a
+  predicate-form macro). Recognized in `analyze_chain`; sets
+  ProjectionShape.Aggregate and Materializer.One. **Canary** for the
+  framework — chunk 4 will land `_sum` / `_avg` / `_min` / `_max` in the
+  same shape.
+
+### `_try_sql(chain)` macro — non-panicking sibling of `_sql`
+
+Shares the analyzer with `_sql` (the visit body is factored into
+`emit_sql_macro_body(prog, call, isTry : bool)`). Difference: emits
+`try_run_*` runtime helpers wrapping the result in `Result<T, string>`
+(or `Result<Option<T>, string>` for OneOpt). Tut 6 demonstrates the full
+matrix.
+
+### Runtime additions in `sqlite_boost.das`
+
+- **`run_select_one` + `try_run_select_one`** — single-row materializer
+  (errors on 0 rows; one row -> T or Result<T,string>).
+- **`run_select_one_opt` + `try_run_select_one_opt`** — single-row Option
+  variant (0 rows = none).
+- **`query_one` + `try_query_one` + `query_one_opt`** — full-row read
+  with positional bind. 0/1/2/3-arg overloads; 4+ positional args is a
+  follow-up. Pattern mirrors chunk-1's `try_query_scalar` — `try_*` does
+  the work and returns `Result<T, string>`; strict panics on err; `_opt`
+  returns `Option<T>`.
+- **`query_scalar` overloads** for `int`, `int64`, `float`, `double`,
+  `bool`. (Chunk 1 shipped `string` only.) Each with `try_*` and `_opt`
+  siblings.
+
+### Deferred to chunk 4
+
+- **Named-tuple bind for `query_one(sql, type<T>, (id=…, name=…))`.**
+  Needs a `[call_macro]` to walk the trailing tuple's `argNames` at
+  compile time and emit unrolled `sqlite3_bind_parameter_index +
+  sqlite_bind` calls. Pattern is the `qmacro_function`-per-instantiation
+  used by chunk-1's `_sql_bind_row` for `[sql_table]` rows. Tut 5 ships
+  positional-bind only this chunk; the named-tuple form is a follow-up.
+- **Struct-type `_select(type<T2>)` projection.** Project a subset of
+  source fields into a different `[sql_table]` struct. Today users can
+  use named-tuple projection (`_select((A=_.A, B=_.B))`) to get the same
+  result with a tuple instead of a struct.
+- **4+ positional args for `query_one`.** Add overloads or a call_macro
+  in chunk 4 if a real use case shows up (rare in practice).
+- **Tutorial 7 ("Anatomy of `_sql`")** is folded into tuts 8/9 inline
+  comments + Appendix C below — no standalone tutorial.
+
 ### Surface in this PR
 
-- **Tutorial 04** is now real (`tutorial/04-select_all.das`) — first end-to-end
-  exposure to `_sql`.
+- **Tutorials 5, 6, 8, 9** under `tutorials/sql/`.
+- **22 new test files** under `tests/dasSQLITE/`:
+  - test_08 / test_09 — `_first`, `_first_opt`
+  - test_10 / test_11 — `query_one` positional (1/2/3-arg)
+  - test_13 — `query_one_opt`
+  - test_15..test_20 — `query_scalar` int/int64/double/bool + `_opt` + `try_*`
+  - test_21 — `_try_sql` (Result/Option/Result<Option> matrix)
+  - test_22 — `_select` named-tuple projection
+  - test_24..test_29 — `_where` operators (starts_with, ends_with,
+    contains, to_lower/to_upper, length, abs)
+  - test_30 / test_31 — `_count` canary (basic + with `_where`)
+- **151 dasSQLITE tests pass** interpreted (81 chunk-2 + 70 chunk-3).
+- AOT path stays green (CMake glob auto-picks new tests; reconfigure
+  required after adding the first new test of a chunk).
+
+## Appendix C — `_sql` translation boundary (the content tut 7 would have covered)
+
+What `_sql(chain)` translates and what it refuses, in one place. The
+macro walks the chain bottom-up after Mode-2 expansion has unfolded
+inner call_macros (`_where` → `where_(it, $(_:T) => body)`, etc.).
+
+**Translates:**
+
+- **Chain root:** `select_from(db, type<T>)` where `T` is a `[sql_table]`
+  struct.
+- **Chain operators:** `_to_array()`, `_first()`, `_first_opt()`,
+  `count()` (chunk 3); `_sum`/`_avg`/`_min`/`_max`/`_order_by`/`_take`/
+  `_skip`/`_distinct`/`_group_by`/`_having`/`_join`/`_left_join`/
+  subqueries (chunk 4+).
+- **Projections (`_select`):** `_.Field` (single column),
+  `(Name=_.Name, Price=_.Price)` (named tuple). Struct-type projection
+  is chunk 4.
+- **Predicates (`_where`):** column refs (`_.Field`), captured vars and
+  literals (auto-bound as `?`), comparisons (`==`, `!=`, `<`, `<=`, `>`,
+  `>=`), logic (`&&`, `||`, `!`), and the appendix-A function calls
+  (`starts_with`, `ends_with`, `contains`, `to_lower`, `to_upper`,
+  `length`, `abs`).
+
+**Refuses with a compile-time `macro_error` pointing at the offending
+node:**
+
+- Unknown function calls in `_where` (anything not in the dispatch table).
+- `_select` projections that aren't `_.Field` or named-tuple.
+- Multiple `_select` calls in one chain.
+- Multiple terminals in one chain (`_to_array() |> _first()` etc.).
+
+**Workarounds:**
+
+- Use `db |> exec(sql)` / `try_exec(sql)` for DDL and arbitrary
+  statements that don't fit the chain.
+- Use `db |> query_one(sql, type<T>, args…)` /
+  `db |> query_scalar(sql, type<T>)` for hand-written SELECT statements
+  that return rows.
+- The `_sql_text(chain)` companion macro returns the exact SQL string
+  that `_sql(chain)` would emit (with `?` placeholders) — useful for
+  inspecting generated SQL while debugging.
+
+### Surface in this PR
+
+- **Tutorial 04** is now real (`tutorials/sql/04-select_all.das` — relocated
+  from `modules/dasSQLITE/tutorial/` to the project-wide tutorials home in
+  chunk 2.5) — first end-to-end exposure to `_sql`.
 - **Tests:** `tests/dasSQLITE/test_05_sql_macro.das` (17 execution cases),
   `tests/dasSQLITE/test_06_sql_text.das` (19 SQL-string-emission cases),
   `tests/dasSQLITE/test_07_sql_composability.das` (10 user-wrapper cases),

--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -55,8 +55,10 @@ one-line helpers. Everything after this assumes this vocabulary.
    companion `_sql_text(chain)` for inspecting the emitted SQL. First
    exposure to `_sql(...)` — deliberate: the macro is *the* read-side
    story and appears in every subsequent read tutorial. **Shipped:**
-   [04-select_all.das](tutorial/04-select_all.das) (chunk 2, branch
-   `dassqlite-chunk2-sql-macro`). Original mockup:
+   [tutorials/sql/04-select_all.das](../../tutorials/sql/04-select_all.das)
+   (chunk 2 introduced; relocated from `modules/dasSQLITE/tutorial/`
+   to the project-wide `tutorials/sql/` home in chunk 2.5). Original
+   mockup:
    [04-select_all.das.mockup](tutorial-mockup/04-select_all.das.mockup).
 
 ## Part 2 — Parameters + error handling rail
@@ -320,15 +322,15 @@ E. **Forward-looking: `dasSQL` abstraction layer** — the roadmap beyond
 
 | # | Title | Mockup | Status |
 |---|---|---|---|
-| 1 | Hello dasSQLITE | `01-version.das` | Has mockup |
-| 2 | Declare a table, insert rows | `02-insert_data.das` | Has mockup |
-| 3 | Auto-increment primary keys | `03-last_row_id.das` | Has mockup |
-| 4 | Read every row | `04-select_all.das` | Has mockup |
-| 5 | Parameters — positional + named | `05-parametrized.das` | Has mockup |
-| 6 | Error handling — `try_` / `_opt` | `_error_handling.das` | Has mockup |
-| 7 | Anatomy of `_sql` | — | **Needs mockup** |
-| 8 | `_where` — predicates | — | **Needs mockup** |
-| 9 | `_select` — projections | — | **Needs mockup** |
+| 1 | Hello dasSQLITE | `01-version.das` | **Shipped** (chunk 1) |
+| 2 | Declare a table, insert rows | `02-insert_data.das` | **Shipped** (chunk 1) |
+| 3 | Auto-increment primary keys | `03-last_row_id.das` | **Shipped** (chunk 1) |
+| 4 | Read every row | `04-select_all.das` | **Shipped** (chunk 2) |
+| 5 | Parameters — positional | `05-parametrized.das` | **Shipped** (chunk 3); named-tuple bind for `:name` placeholders deferred to chunk 4 |
+| 6 | Error handling — `try_` / `_opt` / `_try_sql` | `_error_handling.das` | **Shipped** (chunk 3) |
+| 7 | Anatomy of `_sql` | — | **Folded** into tut 8/9 inline comments + Appendix C (no standalone tutorial — see chunk-3 plan) |
+| 8 | `_where` — predicates + appendix-A operators | direct | **Shipped** (chunk 3) |
+| 9 | `_select` — single-column + named-tuple | direct | **Shipped** (chunk 3); struct-type projection (`_select(type<T2>)`) deferred to chunk 4 |
 | 10 | `_order_by` / `_then_by` | — | **Needs mockup** |
 | 11 | `_take` / `_skip` + keyset | — | **Needs mockup** |
 | 12 | `_distinct` + set ops | — | **Needs mockup** |

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -274,39 +274,249 @@ def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<auto(TT)>) : TT {
     return default<TT>
 }
 
+// ============================================================================
+// query_scalar — read column 0 of the first row as ``TT``
+//
+// Generic over any type with a ``sqlite_read(stmt, col, type<TT>) : TT``
+// overload. Built-ins: string, int, int64, float, double, bool. User types
+// extend by adding their own ``sqlite_read`` overload — no registration step.
+//
+// `try_*` returns ``Result<TT, string>`` (prepare/step error or zero rows).
+// `query_scalar` is the strict variant — panics on err.
+// ============================================================================
+
 [unused_argument(t)]
-def try_query_scalar(db : SqlRunner; sql : string; t : type<string>) : Result<string, string> {
-    //! Prepares ``sql``, steps once, returns column 0 as ``string``.
+def try_query_scalar(db : SqlRunner; sql : string; t : type<auto(TT)>) : Result<TT -const -#, string> {
+    //! Prepares ``sql``, steps once, returns column 0 as ``TT``.
     //! Returns ``Err(errmsg)`` on prepare/step error or zero rows.
     var stmt : sqlite3_stmt?
     let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
     if (prc != SQLITE_OK) {
         let msg = "query_scalar prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
         sqlite3_finalize(stmt)
-        return err(msg, type<string>)
+        return err(msg, type<TT -const -#>)
     }
     let src = sqlite3_step(stmt)
-    if (src != SQLITE_ROW) {
-        let msg = "query_scalar: expected one row, got rc={src}: {sqlite3_errmsg(db.sqlite_handle)}"
+    if (src == SQLITE_DONE) {
         sqlite3_finalize(stmt)
-        return err(msg, type<string>)
+        return err("query_scalar: expected one row, got 0 rows", type<TT -const -#>)
     }
-    var result : string
-    unsafe {
-        result := clone_string(sqlite3_column_text(stmt, 0))
+    if (src != SQLITE_ROW) {
+        let msg = "query_scalar: step failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<TT -const -#>)
     }
+    var result = sqlite_read(stmt, 0, type<TT -const -#>) // nolint:LINT003
     sqlite3_finalize(stmt)
-    return ok(result, type<string>)
+    return move_ok(result, type<string>)
 }
 
 [unused_argument(t)]
-def query_scalar(db : SqlRunner; sql : string; t : type<string>) : string {
+def query_scalar(db : SqlRunner; sql : string; t : type<auto(TT)>) : TT -const -# {
     //! Strict variant of ``try_query_scalar``. Panics on prepare/step error or zero rows.
-    let r = db |> try_query_scalar(sql, type<string>)
+    let r = db |> try_query_scalar(sql, type<TT -const -#>)
     if (r |> is_err) {
         panic(r |> unwrap_err)
     }
     return r |> unwrap
+}
+
+// ============================================================================
+// query_scalar_opt — Option<TT> variant for "0 rows is expected"
+//
+// Returns ``some(val)`` if a row is found, ``none`` if zero rows. Panics
+// only on prepare/step failure (genuine errors). Use when 0 rows is a
+// normal outcome (lookups by primary key, etc.); use ``query_scalar`` when
+// 0 rows is a programmer error.
+// ============================================================================
+
+[unused_argument(t)]
+def query_scalar_opt(db : SqlRunner; sql : string; t : type<auto(TT)>) : Option<TT -const -#> {
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        sqlite3_finalize(stmt)
+        panic("query_scalar_opt prepare failed: {sqlite3_errmsg(db.sqlite_handle)}")
+    }
+    let src = sqlite3_step(stmt)
+    if (src == SQLITE_DONE) {
+        sqlite3_finalize(stmt)
+        return none(type<TT -const -#>)
+    }
+    if (src != SQLITE_ROW) {
+        sqlite3_finalize(stmt)
+        panic("query_scalar_opt step failed: {sqlite3_errmsg(db.sqlite_handle)}")
+    }
+    var result = sqlite_read(stmt, 0, type<TT -const -#>) // nolint:LINT003
+    sqlite3_finalize(stmt)
+    return move_some(result)
+}
+
+// ============================================================================
+// query_one — full-row read with positional bind args
+//
+// Each [sql_table] struct gets a generated ``_sql_read_row`` helper at macro
+// time; ``query_one`` family uses that to materialize the row. Bind args go
+// to positional placeholders in declaration order. Currently only 0..3
+// positional args are supported (one explicit overload per arity). 4+ args
+// and named-tuple bind (``query_one(sql, type<T>, (a=1, b=2, ...))`` for
+// ``:name`` placeholders) are deferred to chunk 4 — the named-tuple form
+// needs a ``[call_macro]`` to walk the trailing tuple's argNames.
+//
+// `try_*` returns ``Result<T, string>`` (bind/prepare/step errors AND zero
+// rows); strict panics on err; ``*_opt`` returns ``Option<T>`` (``none`` on
+// zero rows; panic only on bind/prepare/step error).
+// ============================================================================
+
+// All 12 public variants below delegate to one of three private impls
+// that take a `bind_blk : block<(var stmt : sqlite3_stmt?) : void>`,
+// invoked once after prepare. Each public wrapper supplies the right
+// bind block for its arity.
+
+def private try_query_one_impl(db : SqlRunner; sql : string; t : type<auto(TT)>;
+                               bind_blk : block<(var stmt : sqlite3_stmt?) : void>) : Result<TT -const -#, string> {
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        let msg = "query_one prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<TT -const -#>)
+    }
+    invoke(bind_blk, stmt)
+    let src = sqlite3_step(stmt)
+    if (src == SQLITE_DONE) {
+        sqlite3_finalize(stmt)
+        return err("query_one: expected one row, got 0 rows", type<TT -const -#>)
+    }
+    if (src != SQLITE_ROW) {
+        let msg = "query_one: step failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<TT -const -#>)
+    }
+    var row : TT -const -# = _::_sql_read_row(stmt, type<TT -const -#>) // nolint:LINT003
+    sqlite3_finalize(stmt)
+    return move_ok(row, type<string>)
+}
+
+def private query_one_impl(db : SqlRunner; sql : string; t : type<auto(TT)>;
+                           bind_blk : block<(var stmt : sqlite3_stmt?) : void>) : TT -const -# {
+    var r <- try_query_one_impl(db, sql, type<TT -const -#>, bind_blk)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return <- r._value
+}
+
+def private query_one_opt_impl(db : SqlRunner; sql : string; t : type<auto(TT)>;
+                               bind_blk : block<(var stmt : sqlite3_stmt?) : void>) : Option<TT -const -#> {
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        sqlite3_finalize(stmt)
+        panic("query_one_opt prepare failed: {sqlite3_errmsg(db.sqlite_handle)}")
+    }
+    invoke(bind_blk, stmt)
+    let src = sqlite3_step(stmt)
+    if (src == SQLITE_DONE) {
+        sqlite3_finalize(stmt)
+        return none(type<TT -const -#>)
+    }
+    if (src != SQLITE_ROW) {
+        sqlite3_finalize(stmt)
+        panic("query_one_opt step failed: {sqlite3_errmsg(db.sqlite_handle)}")
+    }
+    var row : TT -const -# = _::_sql_read_row(stmt, type<TT -const -#>) // nolint:LINT003
+    sqlite3_finalize(stmt)
+    return move_some(row)
+}
+
+// ---- try_query_one — Result<TT, string>; 0..3 positional args ----
+
+def try_query_one(db : SqlRunner; sql : string; t : type<auto(TT)>) : Result<TT -const -#, string> {
+    //! Zero-arg form. Errors on prepare/step failure or zero rows.
+    return <- try_query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {})
+}
+
+def try_query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0)) : Result<TT -const -#, string> {
+    //! 1-arg positional bind.
+    return <- try_query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
+        sqlite_bind(stmt, 1, arg0)
+    })
+}
+
+def try_query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1)) : Result<TT -const -#, string> {
+    //! 2-arg positional bind.
+    return <- try_query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
+        sqlite_bind(stmt, 1, arg0)
+        sqlite_bind(stmt, 2, arg1)
+    })
+}
+
+def try_query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1); arg2 : auto(A2)) : Result<TT -const -#, string> {
+    //! 3-arg positional bind.
+    return <- try_query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
+        sqlite_bind(stmt, 1, arg0)
+        sqlite_bind(stmt, 2, arg1)
+        sqlite_bind(stmt, 3, arg2)
+    })
+}
+
+// ---- query_one (strict) — TT; 0..3 positional args; panics on err ----
+
+[unused_argument(t)]
+def query_one(db : SqlRunner; sql : string; t : type<auto(TT)>) : TT -const -# {
+    return <- query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {})
+}
+
+[unused_argument(t)]
+def query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0)) : TT -const -# {
+    return <- query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
+        sqlite_bind(stmt, 1, arg0)
+    })
+}
+
+[unused_argument(t)]
+def query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1)) : TT -const -# {
+    return <- query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
+        sqlite_bind(stmt, 1, arg0)
+        sqlite_bind(stmt, 2, arg1)
+    })
+}
+
+[unused_argument(t)]
+def query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1); arg2 : auto(A2)) : TT -const -# {
+    return <- query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
+        sqlite_bind(stmt, 1, arg0)
+        sqlite_bind(stmt, 2, arg1)
+        sqlite_bind(stmt, 3, arg2)
+    })
+}
+
+// ---- query_one_opt — Option<TT>; 0..3 positional args; panics only on prepare/step error ----
+
+def query_one_opt(db : SqlRunner; sql : string; t : type<auto(TT)>) : Option<TT -const -#> {
+    return <- query_one_opt_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {})
+}
+
+def query_one_opt(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0)) : Option<TT -const -#> {
+    return <- query_one_opt_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
+        sqlite_bind(stmt, 1, arg0)
+    })
+}
+
+def query_one_opt(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1)) : Option<TT -const -#> {
+    return <- query_one_opt_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
+        sqlite_bind(stmt, 1, arg0)
+        sqlite_bind(stmt, 2, arg1)
+    })
+}
+
+def query_one_opt(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1); arg2 : auto(A2)) : Option<TT -const -#> {
+    return <- query_one_opt_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
+        sqlite_bind(stmt, 1, arg0)
+        sqlite_bind(stmt, 2, arg1)
+        sqlite_bind(stmt, 3, arg2)
+    })
 }
 
 // ============================================================================
@@ -528,6 +738,87 @@ def try_run_select(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sq
 def run_select(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite3_stmt?) : void>; row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : array<TT -const -#> {
     //! Strict variant of ``try_run_select``. Panics on prepare/step failure.
     var r <- try_run_select(db, sql, bind_blk, row_blk)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return <- r._value
+}
+
+// ============================================================================
+// _sql macro runtime: single-row materializers (One / OneOpt)
+//
+// Used by `_sql(...)` chains that end in `_first()`, `_first_opt()`, or
+// `_count()` (and chunk-4 aggregates). One panics-on-empty (for `_first`,
+// `_count`, future `_sum`-on-empty); OneOpt returns Option<T>.
+// ============================================================================
+
+def try_run_select_one(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite3_stmt?) : void>; row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : Result<TT -const -#, string> {
+    //! Prepares ``sql``, runs ``bind_blk`` once, steps once, materializes
+    //! the first row via ``row_blk``. Returns ``Err(errmsg)`` on prepare or
+    //! step failure or zero rows.
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        let msg = "_sql prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<TT -const -#>)
+    }
+    invoke(bind_blk, stmt)
+    let rc = sqlite3_step(stmt)
+    if (rc == SQLITE_DONE) {
+        sqlite3_finalize(stmt)
+        return err("_sql: expected one row, got 0 rows", type<TT -const -#>)
+    }
+    if (rc != SQLITE_ROW) {
+        let msg = "_sql step failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<TT -const -#>)
+    }
+    var row : TT -const -# = invoke(row_blk, stmt) // nolint:LINT003
+    sqlite3_finalize(stmt)
+    return move_ok(row, type<string>)
+}
+
+def run_select_one(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite3_stmt?) : void>; row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : TT -const -# {
+    //! Strict variant of ``try_run_select_one``. Panics on prepare/step failure or zero rows.
+    var r <- try_run_select_one(db, sql, bind_blk, row_blk)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return <- r._value
+}
+
+def try_run_select_one_opt(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite3_stmt?) : void>; row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : Result<Option<TT -const -#>, string> {
+    //! Prepares ``sql``, runs ``bind_blk`` once, steps once. Returns
+    //! ``Ok(some(row))`` if a row is found, ``Ok(none)`` if zero rows, or
+    //! ``Err(errmsg)`` on prepare/step failure.
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        let msg = "_sql prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<Option<TT -const -#>>)
+    }
+    invoke(bind_blk, stmt)
+    let rc = sqlite3_step(stmt)
+    if (rc == SQLITE_DONE) {
+        sqlite3_finalize(stmt)
+        return ok(none(type<TT -const -#>), type<string>)
+    }
+    if (rc != SQLITE_ROW) {
+        let msg = "_sql step failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<Option<TT -const -#>>)
+    }
+    var row : TT -const -# = invoke(row_blk, stmt) // nolint:LINT003
+    sqlite3_finalize(stmt)
+    return move_ok(move_some(row), type<string>)
+}
+
+def run_select_one_opt(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite3_stmt?) : void>; row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : Option<TT -const -#> {
+    //! Strict variant of ``try_run_select_one_opt``. Panics on prepare/step failure;
+    //! returns ``none`` on zero rows (which is the expected empty case here).
+    var r <- try_run_select_one_opt(db, sql, bind_blk, row_blk)
     if (r |> is_err) {
         panic(r |> unwrap_err)
     }
@@ -794,7 +1085,7 @@ class SqlTableMacro : AstStructureAnnotation {
     }
 
     def make_select_all_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>) : FunctionPtr {
-        let col_list = build_string() <| $(var w) {
+        let col_list = build_string() $(var w) {
             for (i in range(length(fields))) {
                 if (i > 0) {
                     w |> write(", ")

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -36,18 +36,69 @@ def _to_array(var arr : array<auto(TT)>) : array<TT -const -#> {
 }
 
 // ============================================================================
-// SqlQuery — accumulator for chain analysis (compile-time only).
+// _first_opt — Option<T>-returning sibling of linq.das's `first`.
+//
+// Inside `_sql(...)` the macro recognizes the call, emits `LIMIT 1`, and
+// uses the OneOpt materializer. In compat mode (no `_sql` wrapper) the
+// fallback inspects the materialized array.
 // ============================================================================
+
+def _first_opt(arr : array<auto(TT)>) : Option<TT -const -#> {
+    //! Compat-mode fallback: returns ``some(arr[0])`` if non-empty, ``none`` otherwise.
+    //! Inside `_sql(...)` the macro intercepts this call before evaluation
+    //! and emits ` LIMIT 1` with the OneOpt materializer.
+    if (length(arr) > 0) {
+        return some(arr[0])
+    }
+    return none(type<TT -const -#>)
+}
+
+def _first(arr : array<auto(TT)>) : TT -const -& {
+    //! Compat-mode fallback: delegates to ``daslib/linq.das`` ``first``,
+    //! which panics with "sequence contains no elements" on empty and
+    //! handles non-copyable ``TT`` via ``clone_to_move``. Inside `_sql(...)`
+    //! the macro intercepts this call before evaluation and emits ` LIMIT 1`
+    //! with the One materializer.
+    return first(arr)
+}
+
+// ============================================================================
+// SqlQuery — accumulator for chain analysis (compile-time only).
+//
+// Materializer and ProjectionShape are the framework discriminators. Each
+// chain operator recognized in `analyze_chain` sets one or both, then the
+// emit pass in `_sql.visit()` switches on them to choose runtime helper +
+// row builder.
+// ============================================================================
+
+enum private Materializer {
+    Array        //!< default: `array<T>` via run_select
+    One          //!< exactly-one row (panic on 0); covers `_first`, `_count`
+    OneOpt       //!< 0-or-1 row, returns `Option<T>`; covers `_first_opt`
+}
+
+enum private ProjectionShape {
+    FullRow      //!< no `_select`: SELECT cols-of(rootT); reads via _::_sql_read_row
+    SingleColumn //!< `_select(_.Field)`: SELECT one col; reads via sqlite_read
+    NamedTuple   //!< `_select((Name=_.Name, Price=_.Price))`: SELECT cols; reads via tuple builder
+    Aggregate    //!< `_count()` etc.: raw SQL expression in SELECT; scalar reader
+}
 
 struct private SqlQuery {
     rootType    : TypeDeclPtr
     tableName   : string
-    selectCols  : array<string>
+    selectCols  : array<string>           //!< SingleColumn / FullRow / NamedTuple: column names (quoted in SQL)
+    projRecordNames : array<string>       //!< NamedTuple: per-column tuple field names (parallel to selectCols)
+    aggregateExpr : string                //!< Aggregate: raw SELECT-list text (e.g. "COUNT(*)")
+    aggregateType : TypeDeclPtr           //!< Aggregate: result scalar type (e.g. int64 for COUNT)
     whereSql    : string
     bindExprs   : array<ExpressionPtr>
-    projType    : TypeDeclPtr
+    sqlSuffix   : string                  //!< " LIMIT 1" for One/OneOpt
+    matr        : Materializer = Materializer.Array
+    proj        : ProjectionShape = ProjectionShape.FullRow
     seenSelect  : bool
     seenToArray : bool
+    seenTerminal : bool                   //!< true once a single-row/scalar terminal has been peeled
     dbExpr      : ExpressionPtr
 }
 
@@ -60,7 +111,10 @@ struct private SqlQuery {
 //
 //   _where(it, expr)  →  where_(it, $(_ : T) => expr)         [from linq_boost]
 //   _select(it, expr) →  select(it,  $(_ : T) => expr)        [from linq_boost]
+//   _first(it)        →  first(it)                             [linq.das fn]
+//   _count(it)        →  count(it)                             [linq.das fn]
 //   _to_array(arr)    →  _to_array(arr)                        [plain fn, stays]
+//   _first_opt(arr)   →  _first_opt(arr)                       [plain fn, stays]
 //   select_from(db, type<T>) → unchanged                       [plain fn]
 //
 // Because expansion is complete, `_` inside the lambda body is a real bound
@@ -113,25 +167,126 @@ def private match_linq_call(var expr : ExpressionPtr; name : string) : ExprCall?
 }
 
 [macro_function]
+def private match_module_call(var expr : ExpressionPtr; name : string; modName : string) : ExprCall? {
+    //! Like match_linq_call but matches against any named module — used to
+    //! recognize sqlite_linq's own plain functions like `_first_opt` after
+    //! expansion (linq_boost recognizes `_first_opt` only as a fall-through
+    //! to its underlying call; for `_sql` we want to peel the call here).
+    if (expr == null || !(expr is ExprCall)) {
+        return null
+    }
+    var call = expr as ExprCall
+    if (call.func == null || call.func._module == null) {
+        return null
+    }
+    if (call.func.name == name && call.func._module.name == modName) {
+        return call
+    }
+    if (call.func.fromGeneric != null
+            && call.func.fromGeneric.name == name
+            && call.func.fromGeneric._module != null
+            && call.func.fromGeneric._module.name == modName) {
+        return call
+    }
+    return null
+}
+
+[macro_function]
 def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
     if (node == null) {
         macro_error(prog, at, "_sql: empty chain")
         return false
     }
 
+    // ---- Terminal recognition (must come before _select / _where peel) ----
+    // These set the materializer and (sometimes) the projection, then recurse
+    // into the inner chain. Only one terminal allowed per chain.
+
     // Peel _to_array(prev) — plain function in this module, no expansion.
-    // Must be outermost.
     {
         var inner : ExpressionPtr
         if (qmatch(node, _to_array($e(inner))).matched) {
-            if (q.seenToArray) {
-                macro_error(prog, at, "_sql: _to_array() can only appear once and must be the outermost operator")
+            if (q.seenToArray || q.seenTerminal) {
+                macro_error(prog, at, "_sql: only one terminal allowed per chain")
+                return false
+            }
+            // _to_array() must be the outermost chain element. analyze_chain
+            // walks outermost-first, so any operator already peeled (any of
+            // these flags / fields populated) means _to_array is buried under
+            // a wrapper like _where(...) that would mean "filter after
+            // materialize" — not translatable to SQL.
+            if (q.seenSelect || q.whereSql != "") {
+                macro_error(prog, at, "_sql: _to_array() must be the outermost chain element")
                 return false
             }
             q.seenToArray = true
+            q.matr = Materializer.Array
             return analyze_chain(inner, q, prog, at)
         }
     }
+
+    // Peel first(prev) — written as either `|> first()` (linq.das `first`)
+    // or `|> _first()` (sqlite_linq's underscore-form passthrough).
+    {
+        var fCall = match_linq_call(node, "first")
+        if (fCall == null) {
+            fCall = match_module_call(node, "_first", "sqlite_linq")
+        }
+        if (fCall != null) {
+            if (q.seenTerminal || q.seenToArray) {
+                macro_error(prog, at, "_sql: only one terminal allowed per chain")
+                return false
+            }
+            if (fCall.arguments |> length != 1) {
+                macro_error(prog, at, "_sql: _first(predicate) is chunk 4; chunk 3 supports `|> _first()` only")
+                return false
+            }
+            q.matr = Materializer.One
+            q.seenTerminal = true
+            q.sqlSuffix = " LIMIT 1"
+            return analyze_chain(fCall.arguments[0], q, prog, at)
+        }
+    }
+
+    // Peel _first_opt(prev) — plain function in this module.
+    {
+        var foCall = match_module_call(node, "_first_opt", "sqlite_linq")
+        if (foCall != null) {
+            if (q.seenTerminal || q.seenToArray) {
+                macro_error(prog, at, "_sql: only one terminal allowed per chain")
+                return false
+            }
+            q.matr = Materializer.OneOpt
+            q.seenTerminal = true
+            q.sqlSuffix = " LIMIT 1"
+            return analyze_chain(foCall.arguments[0], q, prog, at)
+        }
+    }
+
+    // Peel count(prev) — post-expansion of `_count()` (linq.das `count`).
+    // Sets MaterializeOne + ProjAggregate("COUNT(*)", int64). Canary for the
+    // chunk-3 aggregate framework; chunk 4 broadens to _sum / _avg / etc.
+    {
+        var cCall = match_linq_call(node, "count")
+        if (cCall != null) {
+            if (q.seenTerminal || q.seenToArray) {
+                macro_error(prog, at, "_sql: only one terminal allowed per chain")
+                return false
+            }
+            if (cCall.arguments |> length != 1) {
+                macro_error(prog, at, "_sql: _count(predicate) is chunk 4; chunk 3 supports `|> _count()` only")
+                return false
+            }
+            q.matr = Materializer.One
+            q.seenTerminal = true
+            q.proj = ProjectionShape.Aggregate
+            q.aggregateExpr = "COUNT(*)"
+            q.aggregateType = new TypeDecl(at = at, baseType = Type.tInt64)
+            return analyze_chain(cCall.arguments[0], q, prog, at)
+        }
+    }
+
+    // ---- Stage operators ----
 
     // Peel select(prev, lambda) — post-expansion of `_select(prev, expr)`.
     {
@@ -140,6 +295,16 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             if (q.seenSelect) {
                 macro_error(prog, at, "_sql: _select can only appear once in the chain")
                 return false
+            }
+            if (q.proj == ProjectionShape.Aggregate) {
+                // Soft pass-through: aggregate terminals (count/sum/...) emit their
+                // own projection (e.g. COUNT(*)) and ignore any prior _select.
+                // Mark seenSelect so select_from doesn't fill default columns —
+                // the aggregate's projection wins. The inner _select's body is
+                // still walked for side-effect-free typing but its column choice
+                // does not affect the emitted SQL.
+                q.seenSelect = true
+                return analyze_chain(sCall.arguments[0], q, prog, at)
             }
             var body = peel_lambda_body(sCall.arguments[1])
             if (body == null) {
@@ -178,26 +343,27 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             q.dbExpr = dbE
             q.rootType = rootT
             // Default projection if no _select was seen above
-            if (!q.seenSelect) {
+            if (!q.seenSelect && q.proj != ProjectionShape.Aggregate) {
                 fill_default_columns(q, rootT, prog, at)
-                q.projType = clone_type(rootT)
+                q.proj = ProjectionShape.FullRow
             }
             q.tableName = sql_table_name_from_type(rootT)
             return true
         }
     }
 
-    macro_error(prog, at, "_sql: unsupported chain root or operator. chunk 2 supports `select_from(type<T>)` at the root, with optional `_select` / `_where` / `_to_array`. Got: {describe(node)}")
+    macro_error(prog, at, "_sql: unsupported chain root or operator. Got: {describe(node)}")
     return false
 }
 
 // ============================================================================
 // Projection analysis (_select).
 //
-// Chunk 2 supports a single projection shape:
-//   _select(_.FieldName)   -> single-column projection
+// Supported projection shapes:
+//   _select(_.FieldName)                 -> single-column projection
+//   _select((Name=_.X, Other=_.Y))       -> named-tuple projection (recordNames preserved)
 //
-// Struct-constructor / named-tuple projection is deferred to chunk 3.
+// Struct-type projection (_select(type<T2>)) is deferred to chunk 4.
 //
 // `body` is the projection expression (e.g. `_.Name`) after Mode-2
 // expansion has already lambda-wrapped it via `select(it, $(_:T) => body)`,
@@ -228,15 +394,42 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
         if (qmatch(body, _.$f(fieldName)).matched) {
             q.selectCols |> clear
             q.selectCols |> push(fieldName)
-            // projType becomes the field's type — defer to inference; leave
-            // q.projType null. The macro emission path for chunk 2 currently
-            // reuses select_from for bare cases; once it emits invoke blocks
-            // we'll set projType from the struct's field metadata.
+            q.proj = ProjectionShape.SingleColumn
             return true
         }
     }
 
-    macro_error(prog, at, "_sql: _select: chunk 2 supports `_.Field` (single column) only; got: {describe(body)}")
+    // Named-tuple form: (Name=_.Name, Price=_.Price). recordNames live on
+    // the inferred tuple type (TypeDecl.argNames) — the ExprMakeTuple's
+    // own recordNames vector isn't exposed to daslang.
+    if (body is ExprMakeTuple) {
+        var mkTup = body as ExprMakeTuple
+        var tupT = mkTup._type
+        if (tupT != null && tupT.baseType == Type.tTuple
+                && length(tupT.argNames) > 0
+                && length(mkTup.values) == length(tupT.argNames)) {
+            q.selectCols |> clear
+            q.projRecordNames |> clear
+            for (i in range(length(mkTup.values))) {
+                var val = mkTup.values[i]
+                if (val is ExprRef2Value) {
+                    val = (val as ExprRef2Value).subexpr
+                }
+                var fieldName : string
+                if (qmatch(val, _.$f(fieldName)).matched) {
+                    q.selectCols |> push(fieldName)
+                    q.projRecordNames |> push(string(tupT.argNames[i]))
+                } else {
+                    macro_error(prog, at, "_sql: _select named-tuple values must be `_.Field` shape; got: {describe(val)}")
+                    return false
+                }
+            }
+            q.proj = ProjectionShape.NamedTuple
+            return true
+        }
+    }
+
+    macro_error(prog, at, "_sql: _select: supported shapes are `_.Field` (single column) and `(Name=_.Name, Price=_.Price)` (named tuple); got: {describe(body)}")
     return false
 }
 
@@ -357,6 +550,16 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         }
     }
 
+    // Function call → SQL function dispatch (table-driven entries below).
+    // Handles `_.Name |> starts_with("F")` (post-pipe-expansion: starts_with(_.Name, "F")),
+    // `length(_.Name)`, `_.Price |> abs()`, `to_lower(_.Name)`, etc.
+    if (node is ExprCall) {
+        let sql = fn_call_to_sql(node as ExprCall, q, prog, at)
+        if (!empty(sql)) {
+            return sql
+        }
+    }
+
     // Literal / captured var → bind param. Clone the *peeled* expression so
     // when we re-emit it as a `sqlite_bind` argument the runtime reads the
     // captured value cleanly (without re-wrapping into ExprRef2Value).
@@ -365,7 +568,100 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         return "?"
     }
 
-    macro_error(prog, at, "_sql: _where: unsupported expression. Chunk 2 supports field refs (_.Col), constants, captured vars, comparisons (=, <>, <, <=, >, >=), &&/||, !. Got: {describe(node)}")
+    macro_error(prog, at, "_sql: _where: unsupported expression. Got: {describe(node)}")
+    return ""
+}
+
+// ============================================================================
+// SQL function dispatch — daslang call → SQL expression
+//
+// Table-driven shape: each entry maps `(daslang_name, arity)` to a SQL
+// template where ``$0`` / ``$1`` are placeholders for the recursively-
+// translated arguments. Adding a new operator is a one-row change here
+// plus a test.
+//
+// Per Appendix A of TUTORIALS.md: chunk 3 ships LIKE-pattern strings,
+// case folding, length, and abs. Chunk 4 broadens with date/time and
+// aggregates that can appear in projections.
+// ============================================================================
+
+[macro_function]
+def private user_arg_count(call : ExprCall?) : int {
+    //! Daslang builtins (string ops, etc.) inject hidden trailing args:
+    //! ``__context__`` (ExprFakeContext), ``__line__`` (ExprFakeLineInfo).
+    //! Count only user-supplied args by stripping the trailing builtin ones.
+    if (call == null) {
+        return 0
+    }
+    var n = length(call.arguments)
+    while (n > 0) {
+        let a = call.arguments[n - 1]
+        let kind = string(a.__rtti)
+        if (kind == "ExprFakeContext" || kind == "ExprFakeLineInfo") {
+            n--
+        } else {
+            break
+        }
+    }
+    return n
+}
+
+[macro_function]
+def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : string {
+    //! Returns the SQL expression text for a recognized function call,
+    //! or "" if the call name isn't in the dispatch table (caller falls
+    //! through to literal/captured-var bind).
+    if (call == null || call.func == null) {
+        return ""
+    }
+    var fname = string(call.func.name)
+    if (call.func.fromGeneric != null) {
+        fname = string(call.func.fromGeneric.name)
+    }
+    let argc = user_arg_count(call)
+
+    // ---- String predicates: LIKE patterns ----
+    if (fname == "starts_with" && argc == 2) {
+        let lhs = pred_to_sql(call.arguments[0], q, prog, at)
+        let rhs = pred_to_sql(call.arguments[1], q, prog, at)
+        return "{lhs} LIKE {rhs} || '%'"
+    }
+    if (fname == "ends_with" && argc == 2) {
+        let lhs = pred_to_sql(call.arguments[0], q, prog, at)
+        let rhs = pred_to_sql(call.arguments[1], q, prog, at)
+        return "{lhs} LIKE '%' || {rhs}"
+    }
+    if (fname == "contains" && argc == 2) {
+        // linq.das also has `contains(array, T)` — we only translate the
+        // string form here; the array form (post-Mode-2-expansion of
+        // `array._contains(x)`) doesn't reach this codepath.
+        let lhs = pred_to_sql(call.arguments[0], q, prog, at)
+        let rhs = pred_to_sql(call.arguments[1], q, prog, at)
+        return "{lhs} LIKE '%' || {rhs} || '%'"
+    }
+
+    // ---- Case folding ----
+    if (fname == "to_lower" && argc == 1) {
+        let inner = pred_to_sql(call.arguments[0], q, prog, at)
+        return "LOWER({inner})"
+    }
+    if (fname == "to_upper" && argc == 1) {
+        let inner = pred_to_sql(call.arguments[0], q, prog, at)
+        return "UPPER({inner})"
+    }
+
+    // ---- String length ----
+    if (fname == "length" && argc == 1) {
+        let inner = pred_to_sql(call.arguments[0], q, prog, at)
+        return "LENGTH({inner})"
+    }
+
+    // ---- Numeric scalar ----
+    if (fname == "abs" && argc == 1) {
+        let inner = pred_to_sql(call.arguments[0], q, prog, at)
+        return "ABS({inner})"
+    }
+
     return ""
 }
 
@@ -445,13 +741,17 @@ def private sql_table_name_from_type(rootT : TypeDeclPtr) : string {
 def private build_sql_string(q : SqlQuery) : string {
     return build_string() $(var w) {
         w |> write("SELECT ")
-        for (i in range(length(q.selectCols))) {
-            if (i > 0) {
-                w |> write(", ")
+        if (q.proj == ProjectionShape.Aggregate) {
+            w |> write(q.aggregateExpr)
+        } else {
+            for (i in range(length(q.selectCols))) {
+                if (i > 0) {
+                    w |> write(", ")
+                }
+                w |> write("\"")
+                w |> write(q.selectCols[i])
+                w |> write("\"")
             }
-            w |> write("\"")
-            w |> write(q.selectCols[i])
-            w |> write("\"")
         }
         w |> write(" FROM \"")
         w |> write(q.tableName)
@@ -459,6 +759,9 @@ def private build_sql_string(q : SqlQuery) : string {
         if (!empty(q.whereSql)) {
             w |> write(" WHERE ")
             w |> write(q.whereSql)
+        }
+        if (!empty(q.sqlSuffix)) {
+            w |> write(q.sqlSuffix)
         }
     }
 }
@@ -480,7 +783,7 @@ class private SqlTextMacro : AstCallMacro {
         var argT = call.arguments[0]._type
         macro_verify(argT != null, prog, call.at, "_sql_text: chain argument is not inferred yet")
         macro_verify(!argT.isAutoOrAlias, prog, call.at, "_sql_text: chain type is auto/alias after inference")
-        var q : SqlQuery
+        var q = SqlQuery()
         if (!analyze_chain(call.arguments[0], q, prog, call.at)) {
             return null
         }
@@ -494,8 +797,16 @@ class private SqlTextMacro : AstCallMacro {
 // ============================================================================
 // _sql — emit the runtime materialization at the call site.
 //
-// Chunk 2 minimum: bare `select_from(type<T>)` -> array<T>. Builds an invoke
-// block that prepares the SQL, steps, materializes via _::_sql_read_row.
+// The framework switches on (q.matr, q.proj):
+//   - Materializer.Array  → _::run_select(...)            returns array<T>
+//   - Materializer.One    → _::run_select_one(...)        returns T
+//   - Materializer.OneOpt → _::run_select_one_opt(...)    returns Option<T>
+//
+// The row-builder block is determined by q.proj:
+//   - FullRow      → _::_sql_read_row(stmt, type<T>)
+//   - SingleColumn → sqlite_read(stmt, 0, type<FieldType>)
+//   - NamedTuple   → tuple row builder for the projected fields
+//   - Aggregate    → sqlite_read(stmt, 0, type<aggregateType>)
 // ============================================================================
 
 [macro_function]
@@ -512,10 +823,134 @@ def private lookup_struct_field_type(rootT : TypeDeclPtr; fieldName : string) : 
     return null
 }
 
+[macro_function]
+def private build_row_builder(q : SqlQuery; prog : ProgramPtr; at : LineInfo) : ExpressionPtr {
+    //! Build the per-row materialization expression based on q.proj.
+    //! Returns null on error (macro_error already emitted).
+    if (q.proj == ProjectionShape.Aggregate) {
+        let colIdx = 0
+        var aggT = clone_type(q.aggregateType)
+        return qmacro(sqlite_read(_sql_stmt, $v(colIdx), type<$t(aggT)>))
+    }
+    if (q.proj == ProjectionShape.SingleColumn) {
+        let colIdx = 0
+        var fieldType = lookup_struct_field_type(q.rootType, q.selectCols[0])
+        if (fieldType == null) {
+            macro_error(prog, at, "_sql: cannot resolve type of projected column '{q.selectCols[0]}'")
+            return null
+        }
+        return qmacro(sqlite_read(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
+    }
+    if (q.proj == ProjectionShape.NamedTuple) {
+        // Build  (Name = sqlite_read(stmt, 0, type<...>), Price = sqlite_read(stmt, 1, type<...>))
+        // recordNames live on the tuple TypeDecl's argNames — set those via
+        // recordType so the typer reads them back into the ExprMakeTuple.
+        let n = length(q.selectCols)
+        var tupT = new TypeDecl(at = at, baseType = Type.tTuple)
+        tupT.argNames.resize(n)
+        var mkTup = new ExprMakeTuple(at = at)
+        for (i in range(n)) {
+            let colIdx = i
+            var fieldType = lookup_struct_field_type(q.rootType, q.selectCols[i])
+            if (fieldType == null) {
+                macro_error(prog, at, "_sql: cannot resolve type of projected column '{q.selectCols[i]}'")
+                return null
+            }
+            var readExpr = qmacro(sqlite_read(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
+            emplace(mkTup.values, readExpr)
+            tupT.argTypes |> emplace_new(clone_type(fieldType))
+            tupT.argNames[i] := q.projRecordNames[i]
+        }
+        mkTup.recordType = tupT
+        return mkTup
+    }
+    // FullRow (default)
+    var rootType = clone_type(q.rootType)
+    return qmacro(_::_sql_read_row(_sql_stmt, type<$t(rootType)>))
+}
+
+[macro_function]
+def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; isTry : bool) : ExpressionPtr {
+    //! Shared body for `_sql` and `_try_sql`. Difference: `isTry=true` emits
+    //! the `try_run_*` variants returning `Result<..., string>`; `isTry=false`
+    //! emits the strict `run_*` variants that panic on prepare/step failure.
+    var argT = call.arguments[0]._type
+    macro_verify(argT != null, prog, call.at, "_sql/_try_sql: chain argument is not inferred yet")
+    macro_verify(!argT.isAutoOrAlias, prog, call.at, "_sql/_try_sql: chain type is auto/alias after inference")
+    var q = SqlQuery()
+    if (!analyze_chain(call.arguments[0], q, prog, call.at)) {
+        return null
+    }
+    let sql = build_sql_string(q)
+
+    // Build bind statements: sqlite_bind(stmt, i+1, $e(boundExpr))
+    var bind_stmts : array<ExpressionPtr>
+    bind_stmts |> reserve(length(q.bindExprs))
+    for (i in range(length(q.bindExprs))) {
+        let bindIdx = i + 1
+        var be = q.bindExprs[i]
+        bind_stmts |> push <| qmacro_expr(${
+            sqlite_bind(_sql_stmt, $v(bindIdx), $e(be));
+        })
+    }
+
+    var rowBuilder = build_row_builder(q, prog, call.at)
+    if (rowBuilder == null) {
+        return null
+    }
+
+    var dbExpr = q.dbExpr
+    var res : ExpressionPtr
+    if (isTry) {
+        if (q.matr == Materializer.One) {
+            res = qmacro(_::try_run_select_one($e(dbExpr), $v(sql),
+                $(var _sql_stmt : sqlite3_stmt?) {
+                    $b(bind_stmts)
+                },
+                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
+        } elif (q.matr == Materializer.OneOpt) {
+            res = qmacro(_::try_run_select_one_opt($e(dbExpr), $v(sql),
+                $(var _sql_stmt : sqlite3_stmt?) {
+                    $b(bind_stmts)
+                },
+                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
+        } else {
+            res = qmacro(_::try_run_select($e(dbExpr), $v(sql),
+                $(var _sql_stmt : sqlite3_stmt?) {
+                    $b(bind_stmts)
+                },
+                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
+        }
+    } else {
+        if (q.matr == Materializer.One) {
+            res = qmacro(_::run_select_one($e(dbExpr), $v(sql),
+                $(var _sql_stmt : sqlite3_stmt?) {
+                    $b(bind_stmts)
+                },
+                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
+        } elif (q.matr == Materializer.OneOpt) {
+            res = qmacro(_::run_select_one_opt($e(dbExpr), $v(sql),
+                $(var _sql_stmt : sqlite3_stmt?) {
+                    $b(bind_stmts)
+                },
+                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
+        } else {
+            res = qmacro(_::run_select($e(dbExpr), $v(sql),
+                $(var _sql_stmt : sqlite3_stmt?) {
+                    $b(bind_stmts)
+                },
+                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
+        }
+    }
+    res.force_at(call.at)
+    return res
+}
+
 [call_macro(name="_sql")]
 class private SqlMacro : AstCallMacro {
-    //! _sql(chain) -> array<T>. Compile-time LINQ-to-SQL translator. Pattern-matches
-    //! the chain, emits SQL + a runtime materialization via run_select.
+    //! _sql(chain) -> array<T> | T | Option<T>. Compile-time LINQ-to-SQL
+    //! translator. Pattern-matches the chain, emits SQL + a runtime
+    //! materialization via run_select / run_select_one / run_select_one_opt.
     //!
     //! **Default `canVisitArgument=true`.** Daslang's macro pass expands
     //! inner call_macros bottom-up *before* this `visit()` fires. By the
@@ -530,50 +965,18 @@ class private SqlMacro : AstCallMacro {
     //! type inference didn't finish. Both fail loudly via `macro_verify`.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         macro_verify(call.arguments |> length == 1, prog, call.at, "_sql expects one argument: a chain expression")
-        var argT = call.arguments[0]._type
-        macro_verify(argT != null, prog, call.at, "_sql: chain argument is not inferred yet")
-        macro_verify(!argT.isAutoOrAlias, prog, call.at, "_sql: chain type is auto/alias after inference")
-        var q : SqlQuery
-        if (!analyze_chain(call.arguments[0], q, prog, call.at)) {
-            return null
-        }
-        let sql = build_sql_string(q)
+        return emit_sql_macro_body(prog, call, false)
+    }
+}
 
-        // Build bind statements: sqlite_bind(stmt, i+1, $e(boundExpr))
-        var bind_stmts : array<ExpressionPtr>
-        bind_stmts |> reserve(length(q.bindExprs))
-        for (i in range(length(q.bindExprs))) {
-            let bindIdx = i + 1
-            var be = q.bindExprs[i]
-            bind_stmts |> push <| qmacro_expr(${
-                sqlite_bind(_sql_stmt, $v(bindIdx), $e(be));
-            })
-        }
-
-        // Build row materializer based on projection shape.
-        var rootType = clone_type(q.rootType)
-        var rowBuilder : ExpressionPtr
-        if (q.seenSelect && length(q.selectCols) == 1) {
-            // single-column projection: emit sqlite_read(stmt, 0, type<FieldType>)
-            let colIdx = 0
-            var fieldType = lookup_struct_field_type(q.rootType, q.selectCols[0])
-            if (fieldType == null) {
-                macro_error(prog, call.at, "_sql: cannot resolve type of projected column '{q.selectCols[0]}'")
-                return null
-            }
-            rowBuilder = qmacro(sqlite_read(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
-        } else {
-            // full row: emit _::_sql_read_row(stmt, type<T>)
-            rowBuilder = qmacro(_::_sql_read_row(_sql_stmt, type<$t(rootType)>))
-        }
-
-        var dbExpr = q.dbExpr
-        var res = qmacro(_::run_select($e(dbExpr), $v(sql),
-            $(var _sql_stmt : sqlite3_stmt?) {
-                $b(bind_stmts)
-            },
-            $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
-        res.force_at(call.at)
-        return res
+[call_macro(name="_try_sql")]
+class private TrySqlMacro : AstCallMacro {
+    //! _try_sql(chain) -> Result<T, string> | Result<Option<T>, string> |
+    //! Result<array<T>, string>. Non-panicking sibling of _sql. Same
+    //! analyzer; emits `try_run_*` runtime helpers that wrap the result in
+    //! `Result<..., string>` instead of panicking on prepare/step failure.
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        macro_verify(call.arguments |> length == 1, prog, call.at, "_try_sql expects one argument: a chain expression")
+        return emit_sql_macro_body(prog, call, true)
     }
 }

--- a/modules/dasSQLITE/tutorial/04-select_all.das
+++ b/modules/dasSQLITE/tutorial/04-select_all.das
@@ -1,63 +1,30 @@
 options gen2
-
-// Tutorial 04 — Reading rows with `_sql`.
-//
-// Defines a [sql_table] struct, inserts a few rows, and reads them back through
-// the `_sql(...)` call macro. `_sql` takes a daslib/linq-shaped chain
-// (`db |> select_from(type<T>) |> _select(_.X) |> _where(predicate)` etc.)
-// and translates it at compile time into SQL + bound parameters. The runtime
-// just runs the prepared statement and materializes the result.
+// based on https://zetcode.com/db/sqlitec/
 
 require sqlite/sqlite_boost
-require sqlite/sqlite_linq
-
-[sql_table(name="Cars")]
-struct Car {
-    @sql_primary_key Id : int
-    Name  : string
-    Price : int
-}
 
 [export]
-def main() {
-    with_sqlite(":memory:") $(db) {
-        db |> create_table(type<Car>)
-        db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
-        db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
-        db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
-        db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
-        db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
-
-        // ── Read every row ────────────────────────────────────────────
-        // _sql(db |> select_from(type<Car>)) compiles to:
-        //   SELECT "Id", "Name", "Price" FROM "Cars"
-        // and materializes each row as a Car.
-        let cars <- _sql(db |> select_from(type<Car>))
-        to_log(LOG_INFO, "Read {length(cars)} cars:\n")
-        for (car in cars) {
-            to_log(LOG_INFO, "  Id={car.Id} Name={car.Name} Price={car.Price}\n")
-        }
-
-        // ── Filter with _where (bind capture) ─────────────────────────
-        // Free variables in the predicate become `?` bind parameters.
-        // Macro emits:  ... WHERE "Price" > ?     binds: [threshold]
-        let threshold = 200
-        let pricey <- _sql(db |> select_from(type<Car>) |> _where(_.Price > threshold))
-        to_log(LOG_INFO, "Cars priced over {threshold}:\n")
-        for (car in pricey) {
-            to_log(LOG_INFO, "  {car.Name}: {car.Price}\n")
-        }
-
-        // ── Project a single column with _select ──────────────────────
-        // Macro emits:  SELECT "Name" FROM "Cars"
-        // Result type is array<string>.
-        let names <- _sql(db |> select_from(type<Car>) |> _select(_.Name))
-        to_log(LOG_INFO, "All car names: {names}\n")
-
-        // ── Inspect the generated SQL ─────────────────────────────────
-        // _sql_text emits the SQL string the macro would have run, with `?`
-        // placeholders for binds. Useful for tests and debugging.
-        let sql_text = _sql_text(db |> select_from(type<Car>) |> _where(_.Id == 5))
-        to_log(LOG_INFO, "_sql_text: {sql_text}\n")
+def main {
+    var db : sqlite3?
+    var rc = sqlite3_open("test.db", unsafe(addr(db)))
+    if (rc != SQLITE_OK) {
+        to_log(LOG_ERROR, "Cannot open database (rc={rc}): {sqlite3_errmsg(db)}\n")
+        sqlite3_close(db)
+        return
     }
+    var err_msg : string
+    rc = sqlite3_exec(db, "SELECT * FROM Cars", unsafe(addr(err_msg))) $(values, columns) {
+        for (v, c in values, columns) {
+            print("{c} = {v}; ")
+        }
+        print("\n")
+        return SQLITE_OK
+    }
+    if (rc != SQLITE_OK) {
+        to_log(LOG_ERROR, "SQL error: {err_msg}\n")
+        sqlite3_free(err_msg)
+        sqlite3_close(db)
+        return
+    }
+    sqlite3_close(db)
 }

--- a/skills/documentation_rst.md
+++ b/skills/documentation_rst.md
@@ -174,7 +174,9 @@ After creating or modifying any RST files, stdlib documentation, or `daslib/*.da
 
 ## Tutorial RST conventions
 
-Tutorial RST files live in `doc/source/reference/tutorials/` with companion `.das` files in `tutorials/language/` (language tutorials), `tutorials/dasStbImage/` (image tutorials), `tutorials/dasHV/` (HTTP tutorials), `tutorials/dasPUGIXML/` (XML tutorials), `tutorials/macros/` (macro tutorials), or `tutorials/integration/cpp/` (C++ integration tutorials).
+Tutorial source-file conventions (location, naming, header shape, install hooks) live in `skills/tutorials.md`. **Read that first** when adding or moving tutorials — overwriting the inherited examples under `modules/<X>/tutorial/` is a recurring mistake the source-side skill exists to prevent.
+
+Tutorial RST files live in `doc/source/reference/tutorials/` with companion `.das` files in `tutorials/<area>/`. Active areas: `language`, `macros`, `integration/c`, `integration/cpp`, `sql`, `dasAudio`, `dasHV`, `dasPEG`, `dasPUGIXML`, `dasStbImage`, `daStrudel`.
 
 - Each RST starts with a label: `.. _tutorial_name:` (e.g., `.. _tutorial_linq:`)
 - Include `.. index::` directive with relevant `single: Tutorial; Topic` entries

--- a/skills/tutorials.md
+++ b/skills/tutorials.md
@@ -1,0 +1,129 @@
+# Tutorial Source Files (REQUIRED)
+
+The companion skill is `skills/documentation_rst.md` for the RST side. **This file owns the `.das` source side**: where it lives, how it's named, what its header looks like, and the install hook.
+
+## Where tutorials live
+
+**Root `/tutorials/<area>/` only.** Never inside `modules/<X>/tutorial/`.
+
+| Path | Purpose |
+|---|---|
+| `tutorials/<area>/*.das` | The canonical, project-wide tutorial home. New tutorials go here. |
+| `modules/<X>/tutorial/*.das` | **Inherited / upstream examples** (e.g. `modules/dasSQLITE/tutorial/` is the zetcode C-API port). Reference material — leave them alone. |
+| `modules/<X>/tutorial-mockup/*.mockup` | Pre-implementation design artifacts (un-compilable). Reference material — leave them alone. |
+
+If you find yourself editing or replacing a file under `modules/<X>/tutorial/`, **stop**. Create the new tutorial under `tutorials/<area>/` instead and leave the inherited file as-is — those files are the cross-reference for the API rewrite, and overwriting them loses provenance.
+
+Existing areas (one per "topic", roughly one per non-language module):
+
+```
+tutorials/language/        — language tutorials (NN_name.das)
+tutorials/macros/          — macro tutorials (NN_name.das + name_mod.das)
+tutorials/integration/c/   — C integration tutorials
+tutorials/integration/cpp/ — C++ integration tutorials
+tutorials/sql/             — dasSQLITE (NN-name.das, hyphenated)
+tutorials/dasAudio/        — dasAudio
+tutorials/dasHV/           — dasHV (HTTP/WebSocket)
+tutorials/dasPEG/          — dasPEG (parser)
+tutorials/dasPUGIXML/      — dasPUGIXML (XML)
+tutorials/dasStbImage/     — dasStbImage
+tutorials/daStrudel/       — daStrudel (live-coding)
+```
+
+When adding tutorials for a **new** module, create a new `tutorials/<module>/` directory rather than dumping into an existing one.
+
+## Naming convention
+
+Match the area you're adding to. The conventions in use:
+
+| Area | Pattern | Example |
+|---|---|---|
+| `language/`, `macros/`, `dasAudio/`, `dasHV/`, `dasPEG/`, `dasPUGIXML/`, `dasStbImage/` | `NN_topic.das` (underscore) | `01_hello_sound.das` |
+| `sql/` | `NN-topic.das` (hyphen) | `01-version.das` |
+| `daStrudel/` | `daStrudel_NN_topic.das` (full prefix) | `daStrudel_01_hello_pattern.das` |
+
+Use **two-digit zero-padded** numbers (`01`, not `1`). Numbering is contiguous within an area and follows teaching order (each tutorial assumes the prior tutorials).
+
+## File header (recommended shape for new tutorials)
+
+Open with `options gen2` and a header comment block. Existing tutorials may vary, especially in older areas (`tutorials/sql/01-version.das` and other inherited examples don't follow this format yet). Apply this shape to **new** tutorials and to existing ones as you touch them:
+
+```das
+options gen2
+options persistent_heap   // only if needed (audio, async, GC-pressure paths)
+
+require <module>/<boost>
+require daslib/<helper>   // as needed
+
+// Tutorial AREA-NN: One-line title
+//
+// This tutorial covers:
+//   - Bullet 1
+//   - Bullet 2
+//
+// Prerequisites: ... (optional, when needed)
+//
+// Run: daslang.exe tutorials/<area>/NN_name.das
+```
+
+**`require` rules:**
+
+- For dasSQLITE the canonical user-facing pair is `require daslib/sql` + `require sqlite/sqlite_boost`. Add `require sqlite/sqlite_linq` only when the tutorial uses the `_sql(...)` macro. `daslib/sql` is the abstract layer; never re-export sqlite-specific symbols through it.
+- For other modules, follow the require shape used by the area's existing tutorials.
+
+**`options`:** keep to the minimum the tutorial actually needs. `gen2` is mandatory. `persistent_heap` for audio / strudel / async / heavy-allocation paths. `indenting = 4` is fine but not required (the formatter normalizes).
+
+## File structure
+
+Each tutorial is **one self-contained `[export] def main()` script** that runs end-to-end with `daslang.exe path/to/tutorial.das`. Inside `main()`:
+
+- Use section-banner comments to chunk the body:
+  ```das
+  // ──────────────────────────────────────────────────────────────────────────
+  // Section 1 — One-line section title
+  // ──────────────────────────────────────────────────────────────────────────
+  //
+  // 2-3 lines of prose explaining what this section demonstrates.
+  ```
+- Print to `print(...)` or `to_log(LOG_INFO, ...)` so the reader can follow what's happening when they run it. Tutorials in `tests/`-adjacent areas (`daslib`) prefer `to_log`; tutorials proper can use `print` freely.
+- Keep examples runnable in isolation. Avoid global state; use local `let`/`var` bindings.
+- Inline comments explain the *why* (which API surface this exercises, why the choice matters), not the *what* (which the code already shows).
+
+## Macro tutorials are split
+
+Anything under `tutorials/macros/` follows a special two-file pattern: numbered usage file (`NN_topic.das`) requires a non-numbered module file (`topic_mod.das`). Module files have no number prefix so `require` resolution works. See `skills/documentation_rst.md` § "Macro tutorial RST conventions" for the doc side.
+
+## RST companion (REQUIRED)
+
+Every shipped tutorial has a paired RST page under `doc/source/reference/tutorials/`. The full conventions (label pattern, `.. seealso::` block, toctree placement) live in `skills/documentation_rst.md` § "Tutorial RST conventions". The short version:
+
+1. Create `doc/source/reference/tutorials/<area>_NN_<topic>.rst` (use a sibling tutorial's RST as the template — same pattern as `sql_03_last_row_id.rst` or `01_hello_world.rst`).
+2. Add the new entry to the matching toctree section in `doc/source/reference/tutorials.rst`.
+3. Run the Sphinx workflow from `skills/documentation_rst.md` to verify zero new warnings.
+
+## CMake install hook
+
+Tutorials are installed to `${DAS_INSTALL_TUTORIALSDIR}/<area>/` via per-area `file(GLOB ...) + install(FILES ...)` blocks in the root `CMakeLists.txt` (search for `_TUTORIAL_SOURCES`). When adding a tutorial to an **existing** registered area (`language`, `macros`, `dasHV`, `dasPUGIXML`, `dasStbImage`, `dasAudio`), the glob picks it up automatically — no CMake edit needed.
+
+When adding a tutorial to an **unregistered** area, add the install rule. Currently missing as of writing: `tutorials/dasPEG/`, `tutorials/daStrudel/`. Pattern:
+
+```cmake
+file(GLOB SQL_TUTORIAL_SOURCES
+    ${PROJECT_SOURCE_DIR}/tutorials/sql/*.das
+)
+install(FILES ${SQL_TUTORIAL_SOURCES}
+    DESTINATION ${DAS_INSTALL_TUTORIALSDIR}/sql
+)
+```
+
+If a tutorial pulls in non-`.das` data files (like `tutorials/dasPUGIXML/books.xml`), add the matching glob pattern (`*.xml`, `*.json`, etc.).
+
+## Development workflow
+
+From `skills/documentation_rst.md` § "Tutorial development workflow" — repeated here because it's load-bearing:
+
+1. **Throwaway test file** during development to validate behavior — `dastest --test test_<topic>.das`. Always check `$LASTEXITCODE`.
+2. **Do NOT stage or commit the test file.** Tutorials are self-demonstrating — running the tutorial file itself is the test.
+3. **Format** every `.das` tutorial with the MCP `format_file` tool before staging (`skills/das_formatting.md`).
+4. **Run the tutorial end-to-end** as the final check: `bin/Release/daslang.exe tutorials/<area>/NN_name.das` and inspect output. Crashes can produce no output — always check exit code.
+5. Stage only: tutorial `.das`, RST page, toctree update, CMake install rule (if first tutorial in a new area).

--- a/tests/dasSQLITE/failed_sql_macro.das
+++ b/tests/dasSQLITE/failed_sql_macro.das
@@ -7,7 +7,7 @@ options gen2
 // analyzer ever runs — e.g. `_select(_.Name) |> _select(_.Price)` is a
 // genuine type bug (string has no `Price` field) and `some_unknown_func(_)`
 // hits the unresolved function. Those cascades are expected.
-expect 40104:7, 30304:2, 30503:1
+expect 40104:9, 30304:2, 30503:2
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -44,4 +44,10 @@ def main() {
 
     // 7. _sql_text with non-chain
     let bad7 = _sql_text(42)
+
+    // 8. _to_array() buried under _where — must be outermost terminal
+    let bad8 <- _sql(db |> select_from(type<Car>) |> _to_array() |> _where(_.Id == 1))
+
+    // 9. _to_array() after _select — must be outermost terminal
+    let bad9 <- _sql(db |> select_from(type<Car>) |> _select(_.Name) |> _to_array() |> _where(_.Id == 1))
 }

--- a/tests/dasSQLITE/test_08_first.das
+++ b/tests/dasSQLITE/test_08_first.das
@@ -1,0 +1,83 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",     Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",    Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla",   Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",    Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo",   Price = 999))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _first — single row terminal, panics on empty (LIMIT 1)
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_first_returns_first_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let car = _sql(db |> select_from(type<Car>) |> _first())
+        t |> equal(car.Id,    1,     "row 0 Id")
+        t |> equal(car.Name,  "BMW", "row 0 Name")
+        t |> equal(car.Price, 100,   "row 0 Price")
+    }
+}
+
+[test]
+def test_first_with_where_filters(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let target = 3
+        let car = _sql(db |> select_from(type<Car>)
+                         |> _where(_.Id == target)
+                         |> _first())
+        t |> equal(car.Id,    3,        "filtered row Id")
+        t |> equal(car.Name,  "Tesla",  "filtered row Name")
+    }
+}
+
+[test]
+def test_first_emits_limit_1(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _first())
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" LIMIT 1",
+        "_first() emits ` LIMIT 1` suffix")
+}
+
+[test]
+def test_first_with_where_emits_limit_1(t : T?) {
+    var _db = SqlRunner()
+    let target = 3
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(_.Id == target)
+                          |> _first())
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE \"Id\" = ? LIMIT 1",
+        "_where + _first emit WHERE then ` LIMIT 1`")
+}
+
+[test]
+def test_first_with_select_and_first(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let name = _sql(db |> select_from(type<Car>)
+                          |> _select(_.Name)
+                          |> _first())
+        t |> equal(name, "BMW", "first projected name")
+    }
+}

--- a/tests/dasSQLITE/test_09_first_opt.das
+++ b/tests/dasSQLITE/test_09_first_opt.das
@@ -1,0 +1,66 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+require daslib/option
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",     Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",    Price = 200))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _first_opt — Option<T>, none on empty (LIMIT 1)
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_first_opt_returns_some_when_present(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let res = _sql(db |> select_from(type<Car>) |> _first_opt())
+        t |> success(res |> is_some, "non-empty table -> some(...)")
+        let car = res |> unwrap
+        t |> equal(car.Id, 1, "first row Id")
+    }
+}
+
+[test]
+def test_first_opt_returns_none_when_empty(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        let res = _sql(db |> select_from(type<Car>) |> _first_opt())
+        t |> success(res |> is_none, "empty table -> none")
+    }
+}
+
+[test]
+def test_first_opt_returns_none_with_no_match(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let target = 999
+        let res = _sql(db |> select_from(type<Car>)
+                         |> _where(_.Id == target)
+                         |> _first_opt())
+        t |> success(res |> is_none, "no matching row -> none")
+    }
+}
+
+[test]
+def test_first_opt_emits_limit_1(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _first_opt())
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" LIMIT 1",
+        "_first_opt() emits ` LIMIT 1` suffix")
+}

--- a/tests/dasSQLITE/test_10_query_one_positional.das
+++ b/tests/dasSQLITE/test_10_query_one_positional.das
@@ -1,0 +1,73 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require daslib/result
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",     Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",    Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla",   Price = 300))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// query_one — single-arg positional bind
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_query_one_single_arg_returns_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let car = db |> query_one(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id = ?",
+            type<Car>, 2)
+        t |> equal(car.Id,    2,      "filtered Id")
+        t |> equal(car.Name,  "Audi", "filtered Name")
+        t |> equal(car.Price, 200,    "filtered Price")
+    }
+}
+
+[test]
+def test_query_one_zero_arg_returns_first_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let car = db |> query_one(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars LIMIT 1",
+            type<Car>)
+        t |> equal(car.Id, 1, "first row Id")
+    }
+}
+
+[test]
+def test_try_query_one_ok_on_match(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let res = db |> try_query_one(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id = ?",
+            type<Car>, 3)
+        t |> success(res |> is_ok, "match returns ok")
+        let car = res |> unwrap
+        t |> equal(car.Name, "Tesla", "ok value")
+    }
+}
+
+[test]
+def test_try_query_one_err_on_no_match(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let res = db |> try_query_one(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id = ?",
+            type<Car>, 999)
+        t |> success(res |> is_err, "no rows -> err")
+    }
+}

--- a/tests/dasSQLITE/test_11_query_one_variadic.das
+++ b/tests/dasSQLITE/test_11_query_one_variadic.das
@@ -1,0 +1,62 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",     Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",    Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla",   Price = 300))
+    db |> insert(Car(Id = 4, Name = "Tesla",   Price = 999))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// query_one — 2/3-arg positional bind (mixed types)
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_query_one_two_args(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let car = db |> query_one(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Name = ? AND Price = ?",
+            type<Car>, "Tesla", 999)
+        t |> equal(car.Id,    4,       "matched Id")
+        t |> equal(car.Name,  "Tesla", "matched Name")
+        t |> equal(car.Price, 999,     "matched Price")
+    }
+}
+
+[test]
+def test_query_one_three_args(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // 3-arg form: id-range + name-prefix-like
+        let car = db |> query_one(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id >= ? AND Id <= ? AND Name = ?",
+            type<Car>, 1, 5, "Audi")
+        t |> equal(car.Id,    2,      "matched Id")
+        t |> equal(car.Name,  "Audi", "matched Name")
+    }
+}
+
+[test]
+def test_try_query_one_two_args_err(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let res = db |> try_query_one(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Name = ? AND Price = ?",
+            type<Car>, "Tesla", 1)
+        t |> success(res |> is_err, "no row matches Tesla+1")
+    }
+}

--- a/tests/dasSQLITE/test_13_query_one_opt.das
+++ b/tests/dasSQLITE/test_13_query_one_opt.das
@@ -1,0 +1,70 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require daslib/option
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",  Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi", Price = 200))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// query_one_opt — 0-row case returns none, no panic
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_query_one_opt_some_on_match(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let res = db |> query_one_opt(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id = ?",
+            type<Car>, 1)
+        t |> success(res |> is_some, "match -> some(...)")
+        let car = res |> unwrap
+        t |> equal(car.Name, "BMW", "some value")
+    }
+}
+
+[test]
+def test_query_one_opt_none_on_no_match(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let res = db |> query_one_opt(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id = ?",
+            type<Car>, 999)
+        t |> success(res |> is_none, "no match -> none")
+    }
+}
+
+[test]
+def test_query_one_opt_zero_arg(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let res = db |> query_one_opt(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars LIMIT 1",
+            type<Car>)
+        t |> success(res |> is_some, "non-empty -> some(first)")
+    }
+}
+
+[test]
+def test_query_one_opt_zero_arg_empty(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        let res = db |> query_one_opt(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars LIMIT 1",
+            type<Car>)
+        t |> success(res |> is_none, "empty -> none")
+    }
+}

--- a/tests/dasSQLITE/test_15_query_scalar_int.das
+++ b/tests/dasSQLITE/test_15_query_scalar_int.das
@@ -1,0 +1,31 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[test]
+def test_query_scalar_int(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let v = db |> query_scalar("SELECT 42", type<int>)
+        t |> equal(v, 42, "int scalar")
+    }
+}
+
+[test]
+def test_query_scalar_int_negative(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let v = db |> query_scalar("SELECT -7", type<int>)
+        t |> equal(v, -7, "int scalar negative")
+    }
+}
+
+[test]
+def test_try_query_scalar_int_ok(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let res = db |> try_query_scalar("SELECT 100", type<int>)
+        t |> success(res |> is_ok, "ok")
+        t |> equal(res |> unwrap, 100, "value")
+    }
+}

--- a/tests/dasSQLITE/test_16_query_scalar_int64.das
+++ b/tests/dasSQLITE/test_16_query_scalar_int64.das
@@ -1,0 +1,24 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[test]
+def test_query_scalar_int64(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let v = db |> query_scalar("SELECT 9223372036854775807", type<int64>)
+        t |> equal(v, 9223372036854775807l, "int64 max")
+    }
+}
+
+[test]
+def test_query_scalar_int64_count(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> exec("CREATE TABLE t (x INT)")
+        db |> exec("INSERT INTO t VALUES (1), (2), (3)")
+        let v = db |> query_scalar("SELECT COUNT(*) FROM t", type<int64>)
+        t |> equal(int(v), 3, "count(*) -> int64")
+    }
+}

--- a/tests/dasSQLITE/test_17_query_scalar_double.das
+++ b/tests/dasSQLITE/test_17_query_scalar_double.das
@@ -1,0 +1,22 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[test]
+def test_query_scalar_double(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let v = db |> query_scalar("SELECT 3.14", type<double>)
+        t |> equal(v, 3.14lf, "double scalar")
+    }
+}
+
+[test]
+def test_query_scalar_double_pi(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let v = db |> query_scalar("SELECT 3.141592653589793", type<double>)
+        t |> success(v > 3.14lf && v < 3.15lf, "double precision")
+    }
+}

--- a/tests/dasSQLITE/test_18_query_scalar_bool.das
+++ b/tests/dasSQLITE/test_18_query_scalar_bool.das
@@ -1,0 +1,30 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[test]
+def test_query_scalar_bool_true(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let v = db |> query_scalar("SELECT 1", type<bool>)
+        t |> equal(v, true, "1 -> true")
+    }
+}
+
+[test]
+def test_query_scalar_bool_false(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let v = db |> query_scalar("SELECT 0", type<bool>)
+        t |> equal(v, false, "0 -> false")
+    }
+}
+
+[test]
+def test_query_scalar_bool_from_predicate(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let v = db |> query_scalar("SELECT 5 > 3", type<bool>)
+        t |> equal(v, true, "5 > 3 -> true")
+    }
+}

--- a/tests/dasSQLITE/test_19_query_scalar_opt.das
+++ b/tests/dasSQLITE/test_19_query_scalar_opt.das
@@ -1,0 +1,61 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require daslib/option
+
+[test]
+def test_query_scalar_opt_string_some(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let res = db |> query_scalar_opt("SELECT 'hello'", type<string>)
+        t |> success(res |> is_some, "some")
+        t |> equal(res |> unwrap, "hello", "value")
+    }
+}
+
+[test]
+def test_query_scalar_opt_int_some(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let res = db |> query_scalar_opt("SELECT 42", type<int>)
+        t |> success(res |> is_some, "some")
+        t |> equal(res |> unwrap, 42, "value")
+    }
+}
+
+[test]
+def test_query_scalar_opt_none_on_empty(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> exec("CREATE TABLE u (x INT)")
+        let res = db |> query_scalar_opt("SELECT x FROM u WHERE x = 999", type<int>)
+        t |> success(res |> is_none, "no rows -> none")
+    }
+}
+
+[test]
+def test_query_scalar_opt_int64(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let res = db |> query_scalar_opt("SELECT 9223372036854775807", type<int64>)
+        t |> success(res |> is_some, "some")
+        t |> equal(res |> unwrap, 9223372036854775807l, "int64 max")
+    }
+}
+
+[test]
+def test_query_scalar_opt_double(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let res = db |> query_scalar_opt("SELECT 3.14", type<double>)
+        t |> success(res |> is_some, "some")
+        t |> equal(res |> unwrap, 3.14lf, "value")
+    }
+}
+
+[test]
+def test_query_scalar_opt_bool(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let res = db |> query_scalar_opt("SELECT 1", type<bool>)
+        t |> success(res |> is_some, "some")
+        t |> equal(res |> unwrap, true, "value")
+    }
+}

--- a/tests/dasSQLITE/test_20_try_query_scalar_overloads.das
+++ b/tests/dasSQLITE/test_20_try_query_scalar_overloads.das
@@ -1,0 +1,52 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require daslib/result
+
+[test]
+def test_try_query_scalar_int(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let res = db |> try_query_scalar("SELECT 7", type<int>)
+        t |> success(res |> is_ok, "ok")
+        t |> equal(res |> unwrap, 7, "value")
+    }
+}
+
+[test]
+def test_try_query_scalar_int64(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let res = db |> try_query_scalar("SELECT 12345", type<int64>)
+        t |> success(res |> is_ok, "ok")
+        t |> equal(res |> unwrap, 12345l, "value")
+    }
+}
+
+[test]
+def test_try_query_scalar_double(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let res = db |> try_query_scalar("SELECT 1.5", type<double>)
+        t |> success(res |> is_ok, "ok")
+        t |> equal(res |> unwrap, 1.5lf, "value")
+    }
+}
+
+[test]
+def test_try_query_scalar_bool(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let res = db |> try_query_scalar("SELECT 1", type<bool>)
+        t |> success(res |> is_ok, "ok")
+        t |> equal(res |> unwrap, true, "value")
+    }
+}
+
+[test]
+def test_try_query_scalar_int_err_on_no_rows(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> exec("CREATE TABLE u (x INT)")
+        let res = db |> try_query_scalar("SELECT x FROM u WHERE x = 999", type<int>)
+        t |> success(res |> is_err, "no rows -> err")
+    }
+}

--- a/tests/dasSQLITE/test_21_try_sql_macro.das
+++ b/tests/dasSQLITE/test_21_try_sql_macro.das
@@ -1,0 +1,90 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+require daslib/result
+require daslib/option
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",  Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi", Price = 200))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _try_sql — non-panicking sibling of _sql. Same analyzer, wraps result
+// in Result<T, string>.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_try_sql_array_ok(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        var res <- _try_sql(db |> select_from(type<Car>))
+        t |> success(res |> is_ok, "well-formed query -> ok")
+        let cars <- res._value
+        t |> equal(length(cars), 2, "2 rows")
+    }
+}
+
+[test]
+def test_try_sql_first_ok(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let res = _try_sql(db |> select_from(type<Car>) |> _first())
+        t |> success(res |> is_ok, "non-empty -> ok")
+        let car = res |> unwrap
+        t |> equal(car.Id, 1, "first row")
+    }
+}
+
+[test]
+def test_try_sql_first_err_on_empty(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        let res = _try_sql(db |> select_from(type<Car>) |> _first())
+        t |> success(res |> is_err, "empty + _first -> err")
+    }
+}
+
+[test]
+def test_try_sql_first_opt_some(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let res = _try_sql(db |> select_from(type<Car>) |> _first_opt())
+        t |> success(res |> is_ok, "ok wraps the option")
+        let opt = res |> unwrap
+        t |> success(opt |> is_some, "non-empty -> some(...)")
+    }
+}
+
+[test]
+def test_try_sql_first_opt_none(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        let res = _try_sql(db |> select_from(type<Car>) |> _first_opt())
+        t |> success(res |> is_ok, "empty -> ok(none) (not err)")
+        let opt = res |> unwrap
+        t |> success(opt |> is_none, "empty -> none")
+    }
+}
+
+[test]
+def test_try_sql_count(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let res = _try_sql(db |> select_from(type<Car>) |> count())
+        t |> success(res |> is_ok, "count is always 1 row -> ok")
+        t |> equal(int(res |> unwrap), 2, "ok value")
+    }
+}

--- a/tests/dasSQLITE/test_22_select_named_tuple.das
+++ b/tests/dasSQLITE/test_22_select_named_tuple.das
@@ -1,0 +1,75 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",     Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",    Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla",   Price = 300))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _select with named-tuple projection: (Name=_.Name, Price=_.Price)
+// Returns array<tuple<Name:string;Price:int>> with recordNames preserved.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_select_named_tuple_two_fields(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<Car>)
+                           |> _select((Name = _.Name, Price = _.Price)))
+        t |> equal(length(rows), 3, "3 rows")
+        t |> equal(rows[0].Name,  "BMW",  "row 0 Name (by tuple field)")
+        t |> equal(rows[0].Price, 100,    "row 0 Price (by tuple field)")
+        t |> equal(rows[2].Name,  "Tesla", "row 2 Name")
+        t |> equal(rows[2].Price, 300,    "row 2 Price")
+    }
+}
+
+[test]
+def test_select_named_tuple_with_first(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let row = _sql(db |> select_from(type<Car>)
+                         |> _select((Name = _.Name, Price = _.Price))
+                         |> _first())
+        t |> equal(row.Name,  "BMW", "first Name (named-tuple + _first)")
+        t |> equal(row.Price, 100,   "first Price")
+    }
+}
+
+[test]
+def test_select_named_tuple_emits_select_two_cols(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _select((Name = _.Name, Price = _.Price)))
+    t |> equal(sql,
+        "SELECT \"Name\", \"Price\" FROM \"Cars\"",
+        "named-tuple projection emits SELECT col1, col2")
+}
+
+[test]
+def test_select_named_tuple_three_fields(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<Car>)
+                           |> _select((Identifier = _.Id, Label = _.Name, Cost = _.Price)))
+        t |> equal(length(rows), 3, "3 rows")
+        t |> equal(rows[1].Identifier, 2,      "renamed Id field")
+        t |> equal(rows[1].Label,      "Audi", "renamed Name field")
+        t |> equal(rows[1].Cost,       200,    "renamed Price field")
+    }
+}

--- a/tests/dasSQLITE/test_24_where_starts_with.das
+++ b/tests/dasSQLITE/test_24_where_starts_with.das
@@ -1,0 +1,46 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "Ford",     Price = 100))
+    db |> insert(Car(Id = 2, Name = "Ferrari",  Price = 9999))
+    db |> insert(Car(Id = 3, Name = "Audi",     Price = 200))
+    db |> insert(Car(Id = 4, Name = "Lada",     Price = 50))
+}
+
+[test]
+def test_where_starts_with_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let prefix = "F"
+        let cars <- _sql(db |> select_from(type<Car>)
+                           |> _where(_.Name |> starts_with(prefix)))
+        t |> equal(length(cars), 2, "2 cars start with 'F'")
+        t |> equal(cars[0].Name, "Ford",    "first match")
+        t |> equal(cars[1].Name, "Ferrari", "second match")
+    }
+}
+
+[test]
+def test_where_starts_with_emits_like_pattern(t : T?) {
+    var _db = SqlRunner()
+    let _prefix = "F"
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(_.Name |> starts_with(_prefix)))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE \"Name\" LIKE ? || '%'",
+        "starts_with -> LIKE ? || '%'")
+}

--- a/tests/dasSQLITE/test_25_where_ends_with.das
+++ b/tests/dasSQLITE/test_25_where_ends_with.das
@@ -1,0 +1,45 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "Ford"))
+    db |> insert(Car(Id = 2, Name = "Honda"))
+    db |> insert(Car(Id = 3, Name = "Audi"))
+    db |> insert(Car(Id = 4, Name = "Lada"))
+}
+
+[test]
+def test_where_ends_with_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let suffix = "da"
+        let cars <- _sql(db |> select_from(type<Car>)
+                           |> _where(_.Name |> ends_with(suffix)))
+        t |> equal(length(cars), 2, "2 cars end in 'da' (Honda, Lada)")
+        t |> equal(cars[0].Name, "Honda", "first match")
+        t |> equal(cars[1].Name, "Lada",  "second match")
+    }
+}
+
+[test]
+def test_where_ends_with_emits_like_suffix(t : T?) {
+    var _db = SqlRunner()
+    let _suffix = "X"
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(_.Name |> ends_with(_suffix)))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\" FROM \"Cars\" WHERE \"Name\" LIKE '%' || ?",
+        "ends_with -> LIKE '%' || ?")
+}

--- a/tests/dasSQLITE/test_26_where_contains.das
+++ b/tests/dasSQLITE/test_26_where_contains.das
@@ -1,0 +1,44 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+require daslib/strings_boost
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "Ford"))
+    db |> insert(Car(Id = 2, Name = "Honda"))
+    db |> insert(Car(Id = 3, Name = "Toyota"))
+    db |> insert(Car(Id = 4, Name = "Lada"))
+}
+
+[test]
+def test_where_contains_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let needle = "o"
+        let cars <- _sql(db |> select_from(type<Car>)
+                           |> _where(_.Name |> contains(needle)))
+        t |> equal(length(cars), 3, "3 cars contain 'o' (Ford, Honda, Toyota)")
+    }
+}
+
+[test]
+def test_where_contains_emits_like_wildcards(t : T?) {
+    var _db = SqlRunner()
+    let _needle = "x"
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(_.Name |> contains(_needle)))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\" FROM \"Cars\" WHERE \"Name\" LIKE '%' || ? || '%'",
+        "contains -> LIKE '%' || ? || '%'")
+}

--- a/tests/dasSQLITE/test_27_where_to_lower.das
+++ b/tests/dasSQLITE/test_27_where_to_lower.das
@@ -1,0 +1,54 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "Ford"))
+    db |> insert(Car(Id = 2, Name = "Honda"))
+    db |> insert(Car(Id = 3, Name = "Audi"))
+}
+
+[test]
+def test_where_to_lower_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let target = "ford"
+        let cars <- _sql(db |> select_from(type<Car>)
+                           |> _where(_.Name |> to_lower() == target))
+        t |> equal(length(cars), 1, "case-insensitive match")
+        t |> equal(cars[0].Name, "Ford", "matched")
+    }
+}
+
+[test]
+def test_where_to_lower_emits_lower_call(t : T?) {
+    var _db = SqlRunner()
+    let target = "x"
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(_.Name |> to_lower() == target))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\" FROM \"Cars\" WHERE LOWER(\"Name\") = ?",
+        "to_lower -> LOWER(...)")
+}
+
+[test]
+def test_where_to_upper_emits_upper_call(t : T?) {
+    var _db = SqlRunner()
+    let target = "X"
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(_.Name |> to_upper() == target))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\" FROM \"Cars\" WHERE UPPER(\"Name\") = ?",
+        "to_upper -> UPPER(...)")
+}

--- a/tests/dasSQLITE/test_28_where_length.das
+++ b/tests/dasSQLITE/test_28_where_length.das
@@ -1,0 +1,42 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "Audi"))
+    db |> insert(Car(Id = 2, Name = "Ferrari"))
+    db |> insert(Car(Id = 3, Name = "Lamborghini"))
+}
+
+[test]
+def test_where_length_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cutoff = 5
+        let cars <- _sql(db |> select_from(type<Car>)
+                           |> _where(length(_.Name) > cutoff))
+        t |> equal(length(cars), 2, "Ferrari + Lamborghini have length > 5")
+    }
+}
+
+[test]
+def test_where_length_emits_length_call(t : T?) {
+    var _db = SqlRunner()
+    let cutoff = 5
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(length(_.Name) > cutoff))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\" FROM \"Cars\" WHERE LENGTH(\"Name\") > ?",
+        "length -> LENGTH(...)")
+}

--- a/tests/dasSQLITE/test_29_where_abs.das
+++ b/tests/dasSQLITE/test_29_where_abs.das
@@ -1,0 +1,44 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+require math
+
+[sql_table(name="Score")]
+struct Score {
+    @sql_primary_key Id : int
+    Delta : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Score>)
+    db |> insert(Score(Id = 1, Delta = -150))
+    db |> insert(Score(Id = 2, Delta = 80))
+    db |> insert(Score(Id = 3, Delta = 200))
+    db |> insert(Score(Id = 4, Delta = -50))
+}
+
+[test]
+def test_where_abs_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let threshold = 100
+        let rows <- _sql(db |> select_from(type<Score>)
+                           |> _where((_.Delta |> abs()) > threshold))
+        t |> equal(length(rows), 2, "|delta|>100: Id 1 (-150) + Id 3 (200)")
+    }
+}
+
+[test]
+def test_where_abs_emits_abs_call(t : T?) {
+    var _db = SqlRunner()
+    let threshold = 100
+    let sql = _sql_text(_db |> select_from(type<Score>)
+                          |> _where((_.Delta |> abs()) > threshold))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Delta\" FROM \"Score\" WHERE ABS(\"Delta\") > ?",
+        "abs -> ABS(...)")
+}

--- a/tests/dasSQLITE/test_30_count_canary.das
+++ b/tests/dasSQLITE/test_30_count_canary.das
@@ -1,0 +1,81 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",     Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",    Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla",   Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",    Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo",   Price = 999))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _count canary — proves the aggregate framework path:
+//   - ProjectionShape.Aggregate sets the SELECT-list to "COUNT(*)"
+//   - Materializer.One reads back a single int64
+//
+// `_count` is reserved as a 2-arg call_macro in linq_boost (predicate form,
+// chunk 4 territory). For the bare aggregate we use linq.das's `count(src)`
+// directly (no underscore).
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_count_returns_int64_total(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = _sql(db |> select_from(type<Car>) |> count())
+        t |> equal(int(n), 5, "5 rows total")
+    }
+}
+
+[test]
+def test_count_on_empty_table_is_zero(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        let n = _sql(db |> select_from(type<Car>) |> count())
+        t |> equal(int(n), 0, "empty table counts 0")
+    }
+}
+
+[test]
+def test_count_emits_count_star(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> count())
+    t |> equal(sql, "SELECT COUNT(*) FROM \"Cars\"", "_count() emits COUNT(*) projection")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _select |> count(): _select before an aggregate terminal is a soft
+// pass-through — the aggregate's COUNT(*) wins. Verifies the analyzer
+// accepts the chain and emits the same SQL as plain count().
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_count_after_select_returns_same_total(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = _sql(db |> select_from(type<Car>) |> _select(_.Name) |> count())
+        t |> equal(int(n), 5, "_select(_.Name) |> count() returns row total, not column count")
+    }
+}
+
+[test]
+def test_count_after_select_emits_count_star(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _select(_.Name) |> count())
+    t |> equal(sql, "SELECT COUNT(*) FROM \"Cars\"",
+        "_select before count() is ignored; aggregate emits COUNT(*) regardless")
+}

--- a/tests/dasSQLITE/test_31_count_with_where.das
+++ b/tests/dasSQLITE/test_31_count_with_where.das
@@ -1,0 +1,59 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",     Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",    Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla",   Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",    Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo",   Price = 999))
+}
+
+[test]
+def test_count_with_where_filter(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cutoff = 150
+        let n = _sql(db |> select_from(type<Car>)
+                       |> _where(_.Price > cutoff)
+                       |> count())
+        t |> equal(int(n), 3, "3 rows with Price > 150")
+    }
+}
+
+[test]
+def test_count_with_no_matches_is_zero(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let target = 999999
+        let n = _sql(db |> select_from(type<Car>)
+                       |> _where(_.Id == target)
+                       |> count())
+        t |> equal(int(n), 0, "no matches -> 0")
+    }
+}
+
+[test]
+def test_count_with_where_emits_count_with_where_sql(t : T?) {
+    var _db = SqlRunner()
+    let cutoff = 150
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(_.Price > cutoff)
+                          |> count())
+    t |> equal(sql,
+        "SELECT COUNT(*) FROM \"Cars\" WHERE \"Price\" > ?",
+        "count + where emits COUNT(*) FROM ... WHERE ...")
+}

--- a/tutorials/sql/04-select_all.das
+++ b/tutorials/sql/04-select_all.das
@@ -1,0 +1,64 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 04 — Reading rows with `_sql`.
+//
+// Defines a [sql_table] struct, inserts a few rows, and reads them back through
+// the `_sql(...)` call macro. `_sql` takes a daslib/linq-shaped chain
+// (`db |> select_from(type<T>) |> _select(_.X) |> _where(predicate)` etc.)
+// and translates it at compile time into SQL + bound parameters. The runtime
+// just runs the prepared statement and materializes the result.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        db |> insert(Car(Id = 1, Name = "BMW", Price = 100))
+        db |> insert(Car(Id = 2, Name = "Audi", Price = 200))
+        db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+        db |> insert(Car(Id = 4, Name = "Lada", Price = 50))
+        db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+
+        // ── Read every row ────────────────────────────────────────────
+        // _sql(db |> select_from(type<Car>)) compiles to:
+        //   SELECT "Id", "Name", "Price" FROM "Cars"
+        // and materializes each row as a Car.
+        let cars <- _sql(db |> select_from(type<Car>))
+        to_log(LOG_INFO, "Read {length(cars)} cars:\n")
+        for (car in cars) {
+            to_log(LOG_INFO, "  Id={car.Id} Name={car.Name} Price={car.Price}\n")
+        }
+
+        // ── Filter with _where (bind capture) ─────────────────────────
+        // Free variables in the predicate become `?` bind parameters.
+        // Macro emits:  ... WHERE "Price" > ?     binds: [threshold]
+        let threshold = 200
+        let pricey <- _sql(db |> select_from(type<Car>) |> _where(_.Price > threshold))
+        to_log(LOG_INFO, "Cars priced over {threshold}:\n")
+        for (car in pricey) {
+            to_log(LOG_INFO, "  {car.Name}: {car.Price}\n")
+        }
+
+        // ── Project a single column with _select ──────────────────────
+        // Macro emits:  SELECT "Name" FROM "Cars"
+        // Result type is array<string>.
+        let names <- _sql(db |> select_from(type<Car>) |> _select(_.Name))
+        to_log(LOG_INFO, "All car names: {names}\n")
+
+        // ── Inspect the generated SQL ─────────────────────────────────
+        // _sql_text emits the SQL string the macro would have run, with `?`
+        // placeholders for binds. Useful for tests and debugging.
+        let sql_text = _sql_text(db |> select_from(type<Car>) |> _where(_.Id == 5))
+        to_log(LOG_INFO, "_sql_text: {sql_text}\n")
+    }
+}

--- a/tutorials/sql/05-parametrized.das
+++ b/tutorials/sql/05-parametrized.das
@@ -1,0 +1,72 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 05 — Parameter binding.
+//
+// Two stories share this tutorial:
+//
+//  1. Under `_sql(...)`, captured variables in the chain become SQL bind
+//     parameters AUTOMATICALLY. The reader never types `?` or `:name` —
+//     the macro's expression walker classifies `_.Field` as a column
+//     identifier and any free variable as a bind value, then emits
+//     `SELECT ... WHERE Id = ?` with the value bound. Tutorial 5's whole
+//     conceptual surface (parameter binding) becomes invisible — that's
+//     the design win.
+//
+//  2. For raw SQL (migrations, ad-hoc queries, statements `_sql` can't
+//     translate), the `query_one(sql, type<T>, args...)` family takes
+//     positional `?` arguments via variadic trailing args (chunk 3 ships
+//     0..3 args; named-tuple bind for `:name` placeholders ships in a
+//     follow-up).
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+        db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+        db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+
+        // ── LINQ form (primary) ──────────────────────────────────────────
+        // `target` is a captured local; `_.Id` is a column reference.
+        // `_sql` emits  SELECT "Id", "Name", "Price" FROM "Cars" WHERE "Id" = ? LIMIT 1
+        // and binds [target] before stepping. `_first()` panics on empty.
+        let target = 3
+        let car = _sql(db |> select_from(type<Car>)
+                         |> _where(_.Id == target)
+                         |> _first())
+        to_log(LOG_INFO, "Found ID = {car.Id}, name = {car.Name}\n")
+
+        // ── Non-panic LINQ variant: _first_opt() returns Option<T> ───────
+        let maybe = _sql(db |> select_from(type<Car>)
+                           |> _where(_.Id == 999)
+                           |> _first_opt())
+        to_log(LOG_INFO, "ID 999 found? {maybe |> is_some}\n")
+
+        // ── Raw-SQL escape hatch (positional `?`) ────────────────────────
+        // Variadic trailing args bind to placeholders in declaration order.
+        // Mixed types (here: int) are fine — no homogeneity constraint.
+        let raw = db |> query_one(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id = ?",
+            type<Car>, target)
+        to_log(LOG_INFO, "Raw lookup ID = {raw.Id}, name = {raw.Name}\n")
+
+        // ── Multi-arg positional bind ────────────────────────────────────
+        // Up to 3 positional args this chunk; named-tuple `(id=…, name=…)`
+        // form for `:name` placeholders is a chunk-4 follow-up.
+        let multi = db |> query_one(
+            "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id = ? AND Name = ?",
+            type<Car>, 2, "Audi")
+        to_log(LOG_INFO, "Multi-arg lookup: {multi.Name}\n")
+    }
+}

--- a/tutorials/sql/06-error_handling.das
+++ b/tutorials/sql/06-error_handling.das
@@ -1,0 +1,90 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+require daslib/option
+require daslib/result
+
+// Tutorial 06 — Error handling.
+//
+// Naming convention throughout dasSQLITE:
+//   foo(...)      — strict; panics on error (programmer-error default)
+//   try_foo(...)  — Result<T, string>; for write-side errors you want to
+//                   handle (constraint violations, prepare failures, etc.)
+//   foo_opt(...)  — Option<T>; for read-side empty results (0 rows is a
+//                   normal outcome, not an error)
+//
+// On the LINQ side:
+//   _sql(chain)      — strict; panics on prepare/step failure
+//   _try_sql(chain)  — Result<T, string>; non-panic sibling, same chain
+//                      analyzer
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+[export]
+def main() {
+    // try_open_sqlite: Result<SqlRunner, string> — use when the path is
+    // user-supplied or otherwise unreliable. The strict open_sqlite /
+    // with_sqlite forms panic on the same failure.
+    var open_result <- try_open_sqlite(":memory:")
+    if (open_result |> is_err) {
+        to_log(LOG_ERROR, "could not open db: {open_result |> unwrap_err}\n")
+        return
+    }
+    // Move the SqlRunner out of the Result. SqlRunner has finalize-on-scope-
+    // exit (closes the SQLite handle), so it must be `var inscope` and bound
+    // by move (`<-`); plain `unwrap` would fail because the type isn't copyable.
+    var inscope db <- open_result._value
+    db |> create_table(type<User>)
+
+    // ── try_insert: Result<int64, string> ────────────────────────────────
+    let first = db |> try_insert(User(Id = 1, Name = "alice"))
+    if (first |> is_ok) {
+        to_log(LOG_INFO, "inserted rowid={first |> unwrap}\n")
+    }
+    // Explicit collision — strict insert() would abort here. try_insert
+    // returns Err and execution continues.
+    let dup = db |> try_insert(User(Id = 1, Name = "alice-dup"))
+    if (dup |> is_err) {
+        to_log(LOG_INFO, "duplicate rejected as expected: {dup |> unwrap_err}\n")
+    }
+
+    // ── query_scalar_opt: Option<T> for "0 rows is fine" ────────────────
+    let lookup = db |> query_scalar_opt(
+        "SELECT \"Name\" FROM \"Users\" WHERE \"Id\" = 42", type<string>)
+    to_log(LOG_INFO, "user 42 is {lookup ?? "unknown"}\n")
+
+    // ── _try_sql(chain) — non-panicking _sql sibling ─────────────────────
+    // Returns the SAME shape as _sql but wrapped in Result<..., string>.
+    // _try_sql(... |> _first())     returns  Result<T, string>
+    // _try_sql(... |> _first_opt()) returns  Result<Option<T>, string>
+    // _try_sql(... |> count())      returns  Result<int64, string>
+    let res = _try_sql(db |> select_from(type<User>) |> _first())
+    if (res |> is_ok) {
+        let u = res |> unwrap
+        to_log(LOG_INFO, "first user: {u.Name}\n")
+    }
+
+    // _try_sql with _first on empty table -> Err (0 rows is an error
+    // for _first; for non-error empty handling, use _first_opt).
+    let drop_err = db |> try_exec("DELETE FROM \"Users\"")
+    if (drop_err |> is_some) {
+        to_log(LOG_ERROR, "delete failed: {drop_err |> unwrap}\n")
+    }
+    let res2 = _try_sql(db |> select_from(type<User>) |> _first())
+    if (res2 |> is_err) {
+        to_log(LOG_INFO, "after delete, _first errs as expected: {res2 |> unwrap_err}\n")
+    }
+
+    // _first_opt under _try_sql: 0 rows is not an error, returns ok(none).
+    let res3 = _try_sql(db |> select_from(type<User>) |> _first_opt())
+    if (res3 |> is_ok) {
+        let opt = res3 |> unwrap
+        to_log(LOG_INFO, "after delete, _first_opt is none: {opt |> is_none}\n")
+    }
+}

--- a/tutorials/sql/08-where.das
+++ b/tutorials/sql/08-where.das
@@ -1,0 +1,95 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+require math
+require daslib/strings_boost
+
+// Tutorial 08 — `_where` predicates: the full surface.
+//
+// Inside `_sql(...)`, `_where(predicate)` accumulates a WHERE clause via
+// a recursive AST walk. Multiple `_where` calls compose with AND.
+//
+// Recognized predicate shapes:
+//   - Column refs:        `_.FieldName`
+//   - Captured vars/lits: `someVar`, `42`, `"alice"`  → bind params (`?`)
+//   - Comparison ops:     `==`, `!=`, `<`, `<=`, `>`, `>=`  → SQL `=`, `<>`, `<`, etc.
+//   - Logic ops:          `&&`, `||`, `!`               → SQL AND, OR, NOT
+//   - String tests:       `|> starts_with(s)`, `|> ends_with(s)`,
+//                         `|> contains(s)`              → SQL LIKE patterns
+//   - Case folding:       `|> to_lower()`, `|> to_upper()` → LOWER / UPPER
+//   - String length:      `length(s)`                   → LENGTH(...)
+//   - Numeric scalar:     `|> abs()`                    → ABS(...)
+//
+// Untranslatable shapes raise a compile-time macro_error pointing at the
+// offending node. Reach for the raw-SQL escape hatch (`db |> exec(...)`,
+// `query_one`, etc.) for cases the macro doesn't translate.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "Ford",     Price = 100))
+    db |> insert(Car(Id = 2, Name = "Ferrari",  Price = 9999))
+    db |> insert(Car(Id = 3, Name = "Honda",    Price = 200))
+    db |> insert(Car(Id = 4, Name = "Lada",     Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lamborghini", Price = 88888))
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // ── Captured-var binding: simple equality ────────────────────────
+        let target = 3
+        let one <- _sql(db |> select_from(type<Car>) |> _where(_.Id == target))
+        to_log(LOG_INFO, "Id == 3 -> {length(one)} row(s)\n")
+
+        // ── Multiple _where calls compose with AND ───────────────────────
+        let cheap_F <- _sql(db |> select_from(type<Car>)
+                              |> _where(_.Price < 1000)
+                              |> _where(_.Name |> starts_with("F")))
+        to_log(LOG_INFO, "Price<1000 AND starts_with('F') -> {length(cheap_F)} row(s)\n")
+
+        // ── Logic ops: && / || / ! ───────────────────────────────────────
+        let cheap_or_F <- _sql(db |> select_from(type<Car>)
+                                 |> _where(_.Price < 100 || (_.Name |> starts_with("F"))))
+        to_log(LOG_INFO, "Price<100 OR starts_with('F') -> {length(cheap_or_F)} row(s)\n")
+
+        // ── String predicates ────────────────────────────────────────────
+        let ends_da <- _sql(db |> select_from(type<Car>)
+                              |> _where(_.Name |> ends_with("da")))
+        to_log(LOG_INFO, "ends_with('da') -> {length(ends_da)} row(s)\n")
+
+        let contains_o <- _sql(db |> select_from(type<Car>)
+                                 |> _where(_.Name |> contains("o")))
+        to_log(LOG_INFO, "contains('o') -> {length(contains_o)} row(s)\n")
+
+        // ── Case folding ─────────────────────────────────────────────────
+        let case_match <- _sql(db |> select_from(type<Car>)
+                                 |> _where(_.Name |> to_lower() == "ford"))
+        to_log(LOG_INFO, "lower(name) == 'ford' -> {length(case_match)} row(s)\n")
+
+        // ── String length ────────────────────────────────────────────────
+        let long_names <- _sql(db |> select_from(type<Car>)
+                                 |> _where(length(_.Name) > 5))
+        to_log(LOG_INFO, "length(name) > 5 -> {length(long_names)} row(s)\n")
+
+        // ── Numeric scalar (abs) ─────────────────────────────────────────
+        let dear <- _sql(db |> select_from(type<Car>)
+                           |> _where((_.Price |> abs()) > 5000))
+        to_log(LOG_INFO, "|price| > 5000 -> {length(dear)} row(s)\n")
+
+        // ── Inspect the emitted SQL via _sql_text (debugging aid) ────────
+        let sql = _sql_text(db |> select_from(type<Car>)
+                              |> _where((_.Price |> abs()) > 5000))
+        to_log(LOG_INFO, "  emitted SQL: {sql}\n")
+    }
+}

--- a/tutorials/sql/09-select.das
+++ b/tutorials/sql/09-select.das
@@ -1,0 +1,85 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 09 — `_select` projections.
+//
+// `_select(...)` controls what columns the SQL emits and what shape the
+// result has. Three forms ship in chunk 3:
+//
+//   - default (no _select): SELECT all columns, materialize as the source
+//                           struct  →  array<Car>
+//   - single column:        _select(_.FieldName)
+//                           SELECT one column, materialize as that column's type
+//                                  →  array<string> (etc.)
+//   - named tuple:          _select((Name = _.Name, Price = _.Price))
+//                           SELECT chosen columns, materialize as a tuple
+//                           with `recordNames` so you read result.Name etc.
+//                                  →  array<tuple<Name:string;Price:int>>
+//
+// The named-tuple form lets you rename columns at the result-type level
+// (`(Identifier=_.Id, Label=_.Name)` returns rows whose `Identifier` field
+// holds the underlying `Id`). Struct-type projection (`_select(type<T2>)`)
+// for projecting into a different `[sql_table]` struct is a chunk-4 follow-up.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+        db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+        db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+
+        // ── default projection: full Car ─────────────────────────────────
+        let cars <- _sql(db |> select_from(type<Car>))
+        to_log(LOG_INFO, "Default projection — {length(cars)} cars:\n")
+        for (c in cars) {
+            to_log(LOG_INFO, "  Id={c.Id} Name={c.Name} Price={c.Price}\n")
+        }
+
+        // ── single-column projection: _select(_.Field) ───────────────────
+        let names <- _sql(db |> select_from(type<Car>) |> _select(_.Name))
+        to_log(LOG_INFO, "Single-column — {length(names)} names:\n")
+        for (n in names) {
+            to_log(LOG_INFO, "  {n}\n")
+        }
+
+        // ── named-tuple projection ───────────────────────────────────────
+        // Result type is tuple<Name:string;Price:int>. The tuple's
+        // recordNames preserve `Name` / `Price` so you read row.Name.
+        let pairs <- _sql(db |> select_from(type<Car>)
+                            |> _select((Name = _.Name, Price = _.Price)))
+        to_log(LOG_INFO, "Named-tuple — {length(pairs)} pairs:\n")
+        for (p in pairs) {
+            to_log(LOG_INFO, "  {p.Name} (price={p.Price})\n")
+        }
+
+        // ── Renaming via named tuple: result fields differ from source ───
+        let renamed <- _sql(db |> select_from(type<Car>)
+                              |> _select((Identifier = _.Id, Label = _.Name)))
+        to_log(LOG_INFO, "Renamed projection — {length(renamed)} rows:\n")
+        for (r in renamed) {
+            to_log(LOG_INFO, "  Identifier={r.Identifier} Label={r.Label}\n")
+        }
+
+        // ── Combining with terminals: _first, _first_opt ─────────────────
+        let head = _sql(db |> select_from(type<Car>)
+                          |> _select((Name = _.Name, Price = _.Price))
+                          |> _first())
+        to_log(LOG_INFO, "First named-tuple: {head.Name} ({head.Price})\n")
+
+        // ── Inspect the emitted SQL ──────────────────────────────────────
+        let sql = _sql_text(db |> select_from(type<Car>)
+                              |> _select((Name = _.Name, Price = _.Price)))
+        to_log(LOG_INFO, "  emitted SQL: {sql}\n")
+    }
+}


### PR DESCRIPTION
## Summary

- **Aggregate framework** in `sqlite_linq.das`: `Materializer` enum (Array / One / OneOpt) + `ProjectionShape` enum (FullRow / SingleColumn / NamedTuple / Aggregate) threaded through `SqlQuery`. Function-call dispatch in `pred_to_sql` (table-driven): `starts_with`/`ends_with`/`contains` → `LIKE` patterns, `to_lower`/`to_upper` → `LOWER`/`UPPER`, `length` → `LENGTH`, `abs` → `ABS`. `emit_sql_macro_body` factored so `_sql` and `_try_sql` share the analyzer.
- **New chain operators**: `_first()` / `_first_opt()` (single-row terminals: `LIMIT 1` + `One` / `OneOpt`), `count()` (canary aggregate, sets `ProjectionShape.Aggregate`).
- **New top-level macro**: `_try_sql(chain)` — non-panic sibling of `_sql`, returns `Result<T, string>`. Shares analyzer; `isTry` flag toggles emit.
- **Runtime additions** in `sqlite_boost.das`: `run_select_one` / `try_run_select_one` / `*_opt` siblings; `query_one` family with positional bind (0..3 args); `query_scalar` family generic over `type<auto(TT)>` dispatching through `sqlite_read` (built-ins: string/int/int64/float/double/bool, user types extend via own `sqlite_read` overload).
- **Named-tuple projection**: `_select((Name=_.Name, Price=_.Price))` emits `SELECT Name, Price` and materializes into `tuple<Name:string;Price:int>` with `recordNames` preserved.
- **Tutorials shipped** under `tutorials/sql/` (with companion RST under `doc/source/reference/tutorials/`): 04 (re-introduced), 05 (parametrized), 06 (error handling), 08 (`_where` predicates), 09 (`_select` projections). Tutorial 7 ("Anatomy of `_sql`") folded into 08/09 inline comments + API_REWORK Appendix C. New `skills/tutorials.md` codifies the `tutorials/<area>/` location convention.
- **22 new tests** under `tests/dasSQLITE/` (test_08 through test_31). 151/151 dasSQLITE pass interpreted and AOT.

## Test plan

- [x] `bin/Release/daslang.exe utils/lint/main.das -- <changed-files>` — 0 issues, 0 errors (29 .das files)
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/` — 7005 / 7005 passed, 0 failed, 0 errors
- [x] `cmake --build build --config Release --target test_aot` — clean
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — 6417 / 6417 passed, 0 failed, 0 errors
- [x] Sphinx clean build (`sphinx-build -b html`) — `build succeeded.` with 0 warnings

## Deferred to chunk 4

- Named-tuple bind for `query_one(sql, type<T>, (id=…, name=…))`. Needs `[call_macro]` walking the trailing tuple's argNames; pattern is `qmacro_function`-per-instantiation like `[sql_table]`'s `_sql_bind_row`. Tut 5 ships positional-bind only.
- Struct-type `_select(type<T2>)` projection (today: same effect via named-tuple projection).
- 4+ positional args for `query_one` — add overloads or `[call_macro]` if a real use case shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)