### PR TITLE
install: port json/xml/test/leak skills to SDK + CLAUDE.md updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/strudel_port.md` | Copy-pasting a strudel.cc pattern (user-level live-coding expression) into daslang |
 | `skills/gc_use_after_sweep.md` | Debugging crashes in `TypeDecl`/`Expression` copy-ctors (`bad_alloc`, `length_error`, `basic_string::_M_create`) — gc_node use-after-sweep, `DAS_GC_DEBUG`, `DAS_GC_BREAK_ON_ID`, copy-on-mutate fix pattern |
 | `skills/clargs_migration.md` | Editing any in-tree tool that still calls `get_command_line_arguments()` directly — migrate its argv parsing to `daslib/clargs` in the same PR (`utils/lint`, `utils/aot`, `utils/dasFormatter`, `utils/benchctl`, `utils/mcp`, `utils/daslang-live`, `daslib/debug`, `daslib/ansi_colors`, etc.) |
+| `skills/json.md` | Reading or writing JSON in `.das` code — choosing between `sprint_json`/`sscan_json`, `JV`/`from_JV` from `daslib/json_boost`, custom converters, or manual `JsonValue?` |
+| `skills/xml.md` | Reading, building, querying, or serializing XML via `dasPUGIXML` (`PUGIXML_boost`) — RAII parsing, iteration, `tag`/`attr` builder, XPath, struct↔XML round-trip |
 
 Multiple skill files may apply to a single task. For example, creating a new daslib module requires reading `skills/das_formatting.md`, `skills/daslib_modules.md`, and possibly `skills/documentation_rst.md`.
 

--- a/install/CLAUDE.md
+++ b/install/CLAUDE.md
@@ -24,8 +24,36 @@ daslang was created at Gaijin Entertainment to solve a concrete problem: **inter
 
 - **Run a script:** `bin/daslang path/to/script.das`
 - **Compile-only check:** `bin/daslang -compile-only path/to/script.das` — compiles without simulation or execution. Use `-dry-run` to also simulate (but not execute).
-- **AOT generation:** `bin/daslang -aot input.das output.cpp`
+- **AOT generation:** `bin/daslang -aot input.das output.cpp` — emit C++ stubs ahead-of-time. Add `-aot-macros` to include macros in the output.
+- **JIT execution:** `bin/daslang -jit path/to/script.das` — compile to native via LLVM JIT before running. Available only in builds compiled with the JIT module. `bin/daslang -exe path/to/script.das -output out.exe` JITs to a standalone executable (implies `-dry-run`).
+- **AOT-linked execution:** `bin/daslang -use-aot path/to/script.das` — run with AOT stubs that have been linked into the binary (host-side flag).
+- **Pass arguments to the script:** everything after `--` is forwarded to the script. `bin/daslang script.das -- arg1 arg2`. Use `daslib/clargs` to parse them — see `skills/clargs_usage.md`.
 - **Example:** `bin/daslang examples/hello_world.das`
+
+### Project files (`.das_project`)
+
+A `.das_project` file is a daslang script the compiler runs at startup to control module resolution, includes, and sandboxing. Pass it with `-project`:
+
+```bash
+bin/daslang -project path/to/project.das_project script.das
+```
+
+The project script can export callbacks the compiler invokes during resolution:
+
+| Callback | Purpose |
+|---|---|
+| `module_get(req, from)` | Required. Returns `(module_name, file_path, import_alias)` for a `require` |
+| `include_get(inc, from)` | Resolve `#include` directives |
+| `module_allowed(mod, filename)` | Whitelist which modules a file may `require` |
+| `module_allowed_unsafe(mod, filename)` | Allow `unsafe` inside specific modules |
+| `option_allowed(opt, from)` | Whitelist `options` directives |
+| `annotation_allowed(ann, from)` | Whitelist annotations |
+
+The compiler sets `DAS_PAK_ROOT` to the project directory before evaluating callbacks. Project files can themselves `include other.das_project` to compose. If you hit "module not found" errors when your modules live outside `daslib/` or the script directory, you almost always need a `.das_project`.
+
+### Tutorials
+
+`tutorials/language/01_hello_world.das` through `tutorials/language/53_clargs.das` are an ordered tour of the language — start there when learning a new feature. Each tutorial is a runnable `.das` file with comments explaining the construct. Module-specific tutorials live alongside (`tutorials/dasPUGIXML/`, `tutorials/dasHV/`, `tutorials/dasAudio/`, `tutorials/sql/`, `tutorials/macros/`, `tutorials/integration/`).
 
 ### Debugging
 
@@ -51,6 +79,11 @@ Task-specific instructions are in skill files under `skills/`. Read the relevant
 | `skills/clargs_usage.md` | Writing your own daslang command-line tools — declarative argv parsing via `daslib/clargs` |
 | `skills/dynamic_modules.md` | Understanding `.das_module` descriptors, module resolution, `register_native_path`, `register_dynamic_module` |
 | `skills/daslang_live.md` | Working with `daslang-live`, live-reload lifecycle, REST API, `[live_command]`, persistent state |
+| `skills/json.md` | Reading or writing JSON in `.das` code — choosing between `sprint_json`/`sscan_json`, `JV`/`from_JV` from `daslib/json_boost`, custom converters, or manual `JsonValue?` |
+| `skills/xml.md` | Reading, building, querying, or serializing XML via `dasPUGIXML` (`PUGIXML_boost`) — RAII parsing, iteration, `tag`/`attr` builder, XPath, struct↔XML round-trip |
+| `skills/writing_tests.md` | Writing tests for your daslang code with the bundled `dastest` framework (`bin/daslang dastest/dastest.das -- --test ...`) |
+| `skills/memory_leak_detection.md` | Diagnosing leaks — `--das-profiler-leaks`, `-track-allocations -heap-report`, `GC APP LEAK` reports, `--track-smart-ptr`, `HandleRegistry` dump |
+| `skills/jobque_debugging.md` | Debugging Channel/LockBox/JobStatus/Stream/Feature leaks using `DumpJobQueLeaks` and `--track-job-status <id>` refcount tracing |
 
 Multiple skill files may apply to a single task. For example, embedding daslang and calling its standard library requires reading both `skills/cpp_integration.md` and `skills/daslib_modules.md`.
 
@@ -246,7 +279,7 @@ If you find yourself reading older guidance about `var inscope`, `<-`, or `clone
 - `examples/` — Example scripts
 - `tutorials/` — Language, integration, and module tutorials
 - `dastest/` — Test framework (usable for testing your own code)
-- `utils/mcp/` — MCP server for AI coding assistants (29 tools, stdio transport, no extra deps)
+- `utils/mcp/` — MCP server for AI coding assistants (30 tools, stdio transport, no extra deps)
 - `utils/daspkg/` — Package manager
 - `utils/dascov/` — Code coverage tool
 - `tree-sitter-daslang/` — Tree-sitter grammar, shared library, and highlighting queries
@@ -294,6 +327,7 @@ See `skills/daspkg.md` for `.das_package` manifest format and package structure.
 | `grep_usage` | Grepping for symbol names across files (parse-aware via ast-grep + tree-sitter) |
 | `outline` | Manually scanning files for function/struct/enum declarations |
 | `aot` | Manually running AOT generation and extracting function C++ |
+| `lint` | Running lint/perf_lint/style_lint manually or requiring the modules for code quality, performance, and style checks |
 | `live_launch` | Manually starting `daslang-live` from shell |
 | `live_status` | `curl http://localhost:9090/status` |
 | `live_error` | `curl http://localhost:9090/error` |

--- a/install/README.md
+++ b/install/README.md
@@ -76,7 +76,7 @@ A full tree-sitter grammar for daslang is included in `tree-sitter-daslang/`. Us
 
 ## MCP Server (AI Tool Integration)
 
-`utils/mcp/` contains an [MCP](https://modelcontextprotocol.io/) server exposing 29 compiler-backed tools to AI coding assistants: compilation diagnostics, type inspection, go-to-definition, find-references, AST dump, AOT generation, expression evaluation, parse-aware grep, package management, and more. Uses stdio transport — no extra build dependencies.
+`utils/mcp/` contains an [MCP](https://modelcontextprotocol.io/) server exposing 30 compiler-backed tools to AI coding assistants: compilation diagnostics, type inspection, go-to-definition, find-references, AST dump, AOT generation, expression evaluation, parse-aware grep, package management, and more. Uses stdio transport — no extra build dependencies.
 
 Configure in `.mcp.json`:
 ```json

--- a/install/skills/jobque_debugging.md
+++ b/install/skills/jobque_debugging.md
@@ -1,0 +1,197 @@
+# Debugging JobStatus / Channel / LockBox / Feature Leaks
+
+`JobStatus`, `Channel`, `LockBox`, and `Feature` are threading primitives in the daslang runtime. They use manual refcounting (`addRef`/`releaseRef`) and are a common source of leaks. A permanent tracking system (intrusive linked lists + per-ID tracing) is always on — no debug build or special flag needed to get the basic dump.
+
+## Object hierarchy
+
+- **JobStatus** — base refcounted sync primitive (`mRef`, `mRemaining`, condition variable)
+- **Channel : JobStatus** — FIFO queue of `Feature` values
+- **LockBox : JobStatus** — single-slot fill/grab/join container
+- **Feature** — value type carrying `void* data + TypeInfo + Context`. Lives in Channels and LockBoxes.
+- **AtomicTT** — bare `std::atomic<TT>`, NOT refcounted — does not appear in the leak dump.
+
+Each `JobStatus` carries a `mTrackId`, intrusive `mTrackNext/Prev`, a subtype tag (`TRACK_JOB_STATUS`, `TRACK_CHANNEL`, `TRACK_LOCKBOX`), and `mCreatedAt` (the daslang source location where it was created). Every `Feature` carries the same plus an `fOwner` / `fOwnerTrackId` linking it back to the Channel/LockBox holding it.
+
+## Step 1: get the leak dump
+
+`DumpJobQueLeaks()` runs at exit in `bin/daslang` and `bin/daslang-live`.
+
+```bash
+bin/daslang path/to/script.das
+```
+
+For `daslang-live`, capture stdout/stderr to a file and shut down via the REST API (`POST /shutdown`) or the `live_shutdown` MCP tool:
+
+```bash
+bin/daslang-live main.das > /tmp/output.txt 2>&1 &
+# ... interact, then shut down ...
+cat /tmp/output.txt
+```
+
+### Reading the dump
+
+```
+  JobStatus #4 (rc=2) LockBox created at strudel_player.das:280:35
+total 1 leaked JobStatus objects
+  Feature #5 owner=#4
+total 1 leaked Feature objects
+```
+
+- **#4** — track ID (shared between JobStatus and Feature)
+- **(rc=2)** — current refcount at dump time (should be 0 for cleanup)
+- **LockBox** — subtype (Channel, LockBox, or JobStatus)
+- **created at** — daslang source location
+- **owner=#4** — Feature is inside JobStatus #4
+
+## Step 2: trace a specific object
+
+Once you know the leaking ID, use `--track-job-status` to get every addRef/releaseRef with source locations:
+
+```bash
+bin/daslang --track-job-status 4 path/to/script.das
+```
+
+This prints every `addRef`/`releaseRef` on that object as it happens:
+
+```
+tracking JobStatus #4
+JobStatus #4 (LockBox) addRef (rc=0) at strudel_player.das:280:35
+JobStatus #4 (LockBox) addRef (rc=1) at strudel_player.das:281:29
+JobStatus #4 (LockBox) addRef (rc=2) at audio_boost.das:1265:14
+Shutting down...
+JobStatus #4 (LockBox) releaseRef (rc=3) at audio_boost.das:215:22
+```
+
+**Read the trace:** each line shows the rc *before* the operation. Here rc goes 0→1→2→3, then only one releaseRef 3→2. Two refs were never released — that's the leak.
+
+## Step 3: identify the leak pattern
+
+### Common patterns
+
+**Missing cleanup on early return**
+
+```das
+def my_shutdown() {
+    if (g_cmd_channel == null) { return }   // ← early return skips status box cleanup
+    ...
+    // status box cleanup never reached
+}
+```
+
+Fix: move cleanup outside the guard, or restructure the function so all paths run cleanup.
+
+**`release()` nulls the pointer**
+
+The daslang `release()` wrapper calls `releaseRef` then sets the pointer to `nullptr`. If you need the pointer after release, save it first:
+
+```das
+var saved = my_box
+my_box |> release()       // my_box is now null
+unsafe(lock_box_remove(saved))  // use the saved copy
+```
+
+**Async command on a dead worker thread**
+
+If a function pushes an async command to a worker thread (e.g. `unset_status_update`) but the worker has already shut down, the command never gets processed and the ref it would have released leaks. Fix: drain async commands while the worker is still alive, then `join()` to wait for them to be processed.
+
+**Hidden `add_ref` inside library calls**
+
+Some library calls (e.g. `set_status_update(sid, box)`) call `box |> add_ref` internally. The release happens later when the matching `unset_status_update` is processed. The cleanup must account for this hidden ref.
+
+**Capture macro implicit `add_ref`**
+
+When a Channel/LockBox/JobStatus/Stream is captured in a lambda, `capture_macro` in `jobque_boost.das` auto-inserts `addRef` at capture and `releaseRef` at lambda destruction. These refs appear in the trace but not in the daslang source — if the lambda outlives expectations, the ref outlives it too.
+
+### Refcount accounting example
+
+For a typical LockBox with `set_status_update`:
+
+```
+lock_box_create()           rc: 0 → 1   (create)
+add_ref()                   rc: 1 → 2   (explicit, in user code)
+set_status_update() add_ref rc: 2 → 3   (hidden, inside library)
+--- worker thread processes unset ---
+releaseRef                  rc: 3 → 2   (worker releases set_status_update ref)
+release()                   rc: 2 → 1   (matches explicit add_ref)
+lock_box_remove()           rc: 1 → 0   (delete)
+```
+
+### LockBox lifecycle (fill/grab/join)
+
+LockBox synchronization: `fill()` sets `mRemaining=1`, `grab()` sets `mRemaining=0` and notifies, `join()` waits for `mRemaining==0`. No extra `add_ref`/`release` needed for the fill/grab/join cycle itself — the refs track *ownership* (who holds a pointer), not the synchronization state.
+
+## Step 4: add `--max-frames` for automated testing
+
+For GUI / event-loop apps that don't naturally exit, add a `--max-frames N` argument so tests can exit deterministically after N frames:
+
+```das
+require daslib/clargs
+
+[CommandLineArgs]
+struct Config {
+    @clarg_doc = "Exit after N frames (0 = unlimited)"
+    max_frames : int
+}
+
+[export]
+def main() {
+    var cfg = Config()
+    parse_args(cfg)
+    init()
+    var frame_count = 0
+    while (!exit_requested()) {
+        update()
+        frame_count ++
+        break if (cfg.max_frames > 0 && frame_count >= cfg.max_frames)
+    }
+    shutdown()
+}
+```
+
+Then run:
+
+```bash
+bin/daslang --track-job-status 4 path/to/script.das -- --max-frames 30
+```
+
+Note: `--track-job-status` is a **daslang** flag, so it goes BEFORE the script path. `--max-frames` is a **script** arg, so it goes AFTER the `--`.
+
+## Stream-capturing jobs MUST release the captured ref
+
+When a `new_job() @() { ... }` lambda captures a `Stream?`, the jobque capture macro bumps the Stream's refcount on capture. The job body **must** drop that ref before it returns or the runtime panics:
+
+```
+Stream has not been released. missing stream|>release or stream|>notify_and_release
+```
+
+…and the Stream is then deleted while the outer scope still holds a handle, producing the secondary crash:
+
+```
+synch primitive deleted while being used (ref=1)
+```
+
+Two idioms balance the capture:
+
+- **`s |> release`** — when completion is signalled separately (e.g. alongside a `with_wait_group` / JobStatus that the job also signals). Use this when the consumer doesn't care about the Stream's own count.
+- **`s |> notify_and_release`** — when the Stream itself is the completion signal (`with_stream(count)` form, consumer checks `s.isReady`). Use this when the consumer is gated on the stream's ready state.
+
+The symmetry with Channel / JobStatus / LockBox / Feature (all four primitives auto-refcount on lambda capture) means the rule is uniform — but the panic only fires at runtime from an inner lambda frame, so the crash message is not obviously tied to the forgotten release at the **top** of the job body. There is no RAII / `defer` wrapper that does it implicitly.
+
+## Shutdown order
+
+Apps with worker threads should shut down in the correct order:
+
+1. Tell each worker to release any `add_ref`'d state it holds (e.g. `unset_status_update(sid)`).
+2. Wait for the worker to process step 1 (`join()` on the relevant box, or the worker's own quit signal).
+3. Stop the worker thread itself.
+4. Delete the sync primitives (`lock_box_remove`, `channel_remove`) — refcount must be 1 at this point.
+
+If step 3 runs before step 2 finishes, the async command is lost and the ref leaks.
+
+## Quick checklist
+
+1. Run the script normally; check exit output for the leak dump.
+2. If leaks are reported, rerun with `--track-job-status <id>` to get the addRef/releaseRef trace.
+3. Count refs: every addRef must have a matching releaseRef.
+4. Check: early returns skipping cleanup? `release()` nulling the pointer before further use? async unset on a dead worker? missing `unset_status_update`? stream-capturing job missing `s |> release` or `s |> notify_and_release`?
+5. Fix and verify: no leak lines in output, exit code 0.

--- a/install/skills/json.md
+++ b/install/skills/json.md
@@ -1,0 +1,202 @@
+# JSON in daslang
+
+Read this skill before writing or editing `.das` code that produces, consumes, or navigates JSON. The companion tutorial is [tutorials/language/30_json.das](tutorials/language/30_json.das); read it for runnable examples of every pattern below.
+
+## Pick the right tool first
+
+Reach for the simplest tool that fits the data. The order of preference is fixed:
+
+| Situation | Use | Why |
+|---|---|---|
+| You have a daslang struct/array/value and want a JSON string, or you have a JSON string and a struct to fill | **`sprint_json(v, pretty)` / `sscan_json(json, var v)`** | Zero ceremony, no `JsonValue?` allocation, respects all field annotations (`@rename`, `@optional`, `@embed`, `@unescape`, `@enum_as_int`). Handles structs, classes, arrays, tables, tuples, variants, enums, bitfields, vector types, pointers, all basic types |
+| You're navigating arbitrary JSON whose shape isn't known at compile time, or you need a `JsonValue?` tree to mutate | **`JV(x)` / `from_JV(js, type<T>)` from `daslib/json_boost`** | Generic reflection on structs/tables/arrays/tuples/variants/vectors/enums; safe-access ops `?.`, `?[]`, `??`; `is`/`as` on the underlying variant |
+| The generic `JV` / `from_JV` doesn't know your custom type | **Add a `def JV(x : MyType)` / `def from_JV(...)` overload** | Function-overload dispatch picks it up automatically — no macro, no annotation |
+| Building a JSON object by hand from a `table<string; JsonValue?>` | **Last resort** — only when neither sprint nor JV applies | Verbose; loses field-annotation support; the structure is invisible to types |
+
+If you find yourself reaching for the last row, ask first whether the JSON shape can be modeled as a struct or variant — almost always it can, and `sprint_json` will be cleaner.
+
+## `require`
+
+```das
+require daslib/json_boost
+```
+
+`json_boost` re-exports `daslib/json` publicly — never `require` both. The `sprint_json` / `sscan_json` builtins are exposed by the runtime; no extra require is needed for them.
+
+## `sprint_json` / `sscan_json`
+
+The default for any "value ↔ JSON string" task.
+
+```das
+let s = sprint_json(value, /*pretty=*/false)   // compact
+let s = sprint_json(value, /*pretty=*/true)    // human-readable, multi-line
+
+var dst : MyStruct
+let ok = sscan_json(json_str, dst)             // returns bool
+```
+
+Notes:
+- Supports the full set: structs, classes (deref via `*ptr`), arrays, tables, tuples, variants (key = active variant name), enums (string by default; int with `@enum_as_int`), bitfields, `floatN`/`intN` vectors, pointers, all primitives.
+- `sscan_json` returns `bool` — false on parse error. Missing fields keep their existing/default values; **unknown keys are silently ignored**, so validate required fields yourself if needed.
+- Round-trip: `sscan_json(sprint_json(x, false), var y)` reproduces `x` for any supported shape.
+
+## Field annotations
+
+These are read by both `sprint_json`/`sscan_json` and the generic `JV`/`from_JV`:
+
+| Annotation | Effect |
+|---|---|
+| `@optional` | Skip the field on output if it equals the default/empty value |
+| `@embed` | Emit a `string` field as raw JSON (no surrounding quotes — caller's responsibility to provide valid JSON) |
+| `@unescape` | Don't escape characters in the string output |
+| `@enum_as_int` | Serialize an enum as its integer value instead of its string name |
+| `@rename = "json_key"` | Map this field to a different JSON key — the standard fix when the JSON key collides with a daslang keyword (`type`, `class`) |
+
+Idiomatic: prefix the daslang field with `_` and use `@rename` (e.g. `@rename = "type" _type : string`).
+
+## `JV` / `from_JV` (json_boost)
+
+Use when working with `JsonValue?` trees — reading arbitrary JSON, building one tree to merge into another, or implementing a thin adapter that doesn't have the destination struct on hand.
+
+```das
+let p = Player(name = "Hero", hp = 100)
+var js = JV(p)                              // struct → JsonValue?
+
+var error : string
+var parsed = read_json(json_str, error)
+let p2 = from_JV(parsed, type<Player>)      // JsonValue? → struct
+```
+
+`JV` accepts: any primitive, vectors, tables, arrays, tuples, variants, enums, structs/classes (via reflection). `JV(a, b, c, ...)` with multiple args (up to 10) builds an array — useful for one-line literals like `JV(1920, 1080)`.
+
+`from_JV` second argument is a type witness (`type<T>`); an optional third argument is the default if the value is null/missing/wrong-typed.
+
+## Custom-type extension
+
+When the generic reflection can't (or shouldn't) handle your type, add an overload. No macro, no annotation — function-overload resolution does the rest.
+
+Pattern (see [daslib/dap.das](daslib/dap.das) `JV(data : Variable)` and [daslib/refactor.das](daslib/refactor.das) `JV(li : LineInfo)`):
+
+```das
+def JV(data : MyType) : JsonValue? {
+    var inscope tab <- {
+        "field1" => JV(data.field1),
+        "field2" => JV(data.field2)
+    }
+    return JV(tab)
+}
+
+def from_JV(v : JsonValue const explicit?; ent : MyType; defV : MyType = MyType()) : MyType {
+    return MyType(
+        field1 = v?.field1 ?? defV.field1,
+        field2 = v?.field2 ?? defV.field2
+    )
+}
+```
+
+For `JV` the return type **must** be `JsonValue?`. For `from_JV` the second argument is a value of the type (not `type<T>`) and the third is the default — match the signatures of the primitive overloads in [daslib/json_boost.das](daslib/json_boost.das).
+
+## Safe access on `JsonValue?`
+
+`json_boost` overloads the safe-access operators so they never crash:
+
+```das
+let name        = js?.user?.name ?? "unknown"          // ?. for object keys
+let first_score = js?["user"]?["scores"]?[0] ?? 0      // ?[] for keys / array indices
+let safe_val    = (nothing : JsonValue?)?.foo ?? "ok"  // null pointer is fine
+```
+
+**Gotcha:** `js?.value` reads the *struct field* `JsonValue.value` (the underlying `JsValue` variant), **not** a JSON key called `"value"`. For a JSON key, use `js?["value"]`.
+
+## `is` / `as` on `JsonValue?`
+
+Checks the underlying `JsValue` variant — works through the pointer.
+
+```das
+if (js is _string)  { let s = js as _string }
+if (js is _longint) { let n = js as _longint }
+```
+
+The seven variant cases:
+
+| Case | Type |
+|---|---|
+| `_object`  | `table<string; JsonValue?>` |
+| `_array`   | `array<JsonValue?>` |
+| `_string`  | `string` |
+| `_number`  | `double` (floating point) |
+| `_longint` | `int64` (integer) |
+| `_bool`    | `bool` |
+| `_null`    | `void?` |
+
+`is`/`as` on the wrong case crashes — always guard with `is` first when the shape is uncertain.
+
+## `%json~ ... %%` reader macro
+
+Embed a compile-time JSON literal:
+
+```das
+var settings = %json~
+{
+    "resolution": [1920, 1080],
+    "fullscreen": true,
+    "title": "My Game"
+}
+%%
+```
+
+Runs through `read_json` at compile time; the result is a runtime `JsonValue?`. Useful for fixtures, defaults, and tests.
+
+## Parsing & errors
+
+```das
+var error : string
+var js = read_json(text, error)
+if (js == null) { /* error string is set */ }
+```
+
+- `read_json(text, var error)` — returns `JsonValue?` or `null` on failure; takes either `string` or `array<uint8>`.
+- `write_json(js)` — serialize a `JsonValue?`. Null pointer writes as `"null"`.
+- `try_fixing_broken_json(text)` — repair LLM output: fixes string concatenation (`"a" + "b"` → `"ab"`), trailing commas, double-quoted nesting. Run before `read_json` when consuming model-generated JSON.
+
+## Writer settings
+
+Each setter returns the previous value — save/restore for scoped changes.
+
+```das
+let prev = set_no_trailing_zeros(true)
+defer() { set_no_trailing_zeros(prev) }
+// ... write_json calls in here drop trailing zeros ...
+```
+
+- `set_no_trailing_zeros(bool)` — drop `.000000` from round floats (e.g. `1` instead of `1.000000`).
+- `set_no_empty_arrays(bool)` — skip empty array fields in objects.
+- `set_allow_duplicate_keys(bool)` — accept duplicate keys in `read_json` (last wins).
+
+## Manual construction (last resort)
+
+When the JSON shape really is dynamic — mixed-type maps, schema decided at runtime — build the tree directly:
+
+```das
+var inscope tab : table<string; JsonValue?>
+tab |> insert("name", JV("Alice"))
+tab |> insert("age",  JV(30))
+var obj = JV(tab)
+```
+
+Don't reach for this until you've ruled out modeling the data as a struct/variant. Field annotations (`@rename`, `@optional`, etc.) don't apply here — every key is hand-written.
+
+## Common gotchas
+
+- **Class instances**: `sprint_json` takes a value; deref the smart pointer with `sprint_json(*classPtr, false)`. `JV(*classPtr)` likewise.
+- **Unknown keys are ignored** by `sscan_json` and `from_JV` — they aren't an error. Validate required fields explicitly if missing data is meaningful.
+- **`@rename` for keyword keys**: JSON keys like `"type"` and `"class"` collide with daslang keywords. Name the field `_type` / `_class` and add `@rename = "type"` / `@rename = "class"`.
+- **Cross-context JSON**: a `JsonValue?` allocated in one context's heap is invalid in another. If you parse on the main thread and consume on a worker, clone the strings (`clone_string`) on receive and reparse, or send the raw text instead.
+- **`var inscope` for the residual smart_ptrs only** — `JsonValue?` is a raw pointer (gc_node), pass-by-value is just a pointer copy. Don't use `var inscope` on `JsonValue?`.
+
+## Reference
+
+- Tutorial — read this first for runnable examples of every pattern: [tutorials/language/30_json.das](tutorials/language/30_json.das)
+- daslib sources: [daslib/json.das](daslib/json.das), [daslib/json_boost.das](daslib/json_boost.das)
+- Real custom `JV` overloads: [daslib/dap.das](daslib/dap.das), [daslib/refactor.das](daslib/refactor.das)
+- Real `sprint_json` users: [utils/daspkg/lockfile.das](utils/daspkg/lockfile.das), [daslib/debug.das](daslib/debug.das), [utils/mcp/protocol.das](utils/mcp/protocol.das)

--- a/install/skills/memory_leak_detection.md
+++ b/install/skills/memory_leak_detection.md
@@ -1,0 +1,169 @@
+# Memory Leak Detection
+
+`bin/daslang` ships several leak-detection mechanisms. Read this skill first to pick the right tool, then jump to the relevant section.
+
+## Quick decision tree
+
+| Symptom | Tool |
+|---|---|
+| Script leaks a `new Foo()` / `array<T>` / table — want per-allocation call stack | **`--das-profiler-leaks`** (#1) |
+| Long-running run keeps growing — want per-context heap dump at exit | **`-track-allocations -heap-report`** (#2) |
+| Exit prints `GC COMPILE LEAK` / `GC APP LEAK` (gc_node leaks) | **`DAS_GC_BREAK_ON_ID` env var** (#3) |
+| Suspect a specific smart_ptr id (Context, Program, FileAccess) — want a debug-break on every addRef/delRef | **`--track-smart-ptr <hexId>`** (#4) |
+| Script uses channels/jobs/lockboxes — `DumpJobQueLeaks` printed survivors | **`--track-job-status`** (`skills/jobque_debugging.md`) |
+| Long-running dasHV server suspected to leak handles | **`HandleRegistry` auto-dump** (#6) |
+
+**CLI dash convention:** `-track-allocations` and `-heap-report` use **one** leading dash; `--track-smart-ptr`, `--track-job-status`, and `--das-profiler-leaks` use **two**. Preserve the dashes exactly as shown.
+
+If multiple leak reports fire at exit: fix gc_node (#3) first, then job-que primitives (#5), then heap (#1/#2), then smart_ptr / handles (#4/#6).
+
+---
+
+## #1 — `--das-profiler-leaks` (heap with captured call stacks)
+
+**Scope:** every live allocation on a daslang `Context` heap, grouped per context, with the full daslang call stack that produced it.
+
+```bash
+bin/daslang --das-profiler --das-profiler-leaks path/to/script.das
+```
+
+Optional `--das-profiler-log-file <path>` writes the report to a file instead of `to_log(LOG_INFO, ...)`.
+
+**Output (per context, on context destroy):**
+```
+=== Memory leaks in context '<unnamed>' (3 allocations, 0x2b0 bytes) ===
+[leak] size=0x200 bytes
+  at builtin`push`4379756157886752001 daslib/builtin.das:117
+  at make_big_leak examples/leak_smoke.das:14
+  at main examples/leak_smoke.das:37
+```
+
+Sizes are in hex, stacks are leaf-first, `file:line` is terminal-clickable. Multi-context programs (audio thread, jobque workers) get one block per context.
+
+**Read it:** the leaf frame is where the allocation call sits; walk up the stack to find the scope that owns the memory and failed to free it.
+
+**Don't:** enable this for a shipping build. Every allocation clones the shadow call stack — it's a debug tool.
+
+---
+
+## #2 — `-track-allocations -heap-report` (per-Context heap dump)
+
+**Scope:** one report per main context at exit, listing all live blocks in the Context's heap + string heap.
+
+```bash
+bin/daslang -track-allocations -heap-report path/to/script.das
+```
+
+**Output (default linear heap — one line per chunk):**
+```
+--- heap report ---
+2b0202057	944 of 65536
+--- string heap report ---
+2b0191a05	52 of 65536
+```
+
+Columns: chunk address, bytes in use, chunk size. The linear allocator is bulk-reset, so you don't see individual blocks.
+
+**Output (with `options persistent_heap = true`):**
+```
+--- heap report ---
+big stuff:
+	size	pointer		id
+	512	0x2069eeae630	1	array
+	48	0x2069ece4c20	2	new [[ ]]	D:/script.das:22:12
+bytes per location:
+48	D:/script.das:22:12
+```
+
+The persistent allocator shows each live block separately: size, pointer, sequential id, optional comment (`array`, `new [[ ]]`, `table`, …), optional `file:line` from the LineInfo at the allocation site. "bytes per location" aggregates totals by source site.
+
+**vs #1:** #2 is per-Context with raw blocks and a single LineInfo; #1 is cross-context with full call stacks. Use #1 when you want to know *how* a block was allocated; use #2 for a quick survey of "what's alive right now."
+
+---
+
+## #3 — gc_node leak detection (automatic, AST nodes)
+
+**Scope:** every `gc_node`-derived AST type (`TypeDecl`, `Expression`, `Function`, `Structure`, `Enumeration`, `Variable`, `MakeFieldDecl`, `MakeStruct`, …) that outlives compilation or execution.
+
+**Invoke:** nothing. The host checks `gc_root::gc_get_thread_root().gc_count` after compile+simulate (`GC COMPILE LEAK`) and after main returns (`GC APP LEAK`). Any non-zero count triggers `gc_report()`.
+
+**Output:**
+```
+GC APP LEAK: 3 gc_node(s) after execution
+gc_root 0x7ff...: count=3
+  node 0x7ff...: id=1234 type=TypeDecl magic=0xDA5C0001
+  ...
+```
+
+**Narrow it down:** set `DAS_GC_BREAK_ON_ID=<id>` as an environment variable (pick an id from the report), then run under a debugger. The check fires in the gc_node constructor and triggers `os_debug_break()` — you get the full C++ + daslang stack trace for the creation site.
+
+```bash
+DAS_GC_BREAK_ON_ID=1234 bin/daslang path/to/script.das
+```
+
+**Common cause:** daslang code that builds AST at runtime (`clone_type`, `new TypeDecl`, `qmacro`) without wrapping in `ast_gc_guard() { ... }` from `daslib/ast`. Wrap the build scope in `ast_gc_guard` and the leak goes away.
+
+**Don't:** ignore GC leak reports. A non-zero count at exit usually means ownership is wrong somewhere, and the symptom can cascade into broken AOT hashes or crashes on subsequent runs.
+
+---
+
+## #4 — `--track-smart-ptr <hexId>` (single smart_ptr trace)
+
+**Scope:** one specific `ptr_ref_count` instance — Context, Program, FileAccess, or any other residual smart_ptr.
+
+```bash
+bin/daslang --track-smart-ptr 0x5a path/to/script.das
+```
+
+The id is the `ref_count_id` of the target object — usually read from a prior exit-time `DumpTrackPtr` line like `0x7ffee1301000 (rc=2, id=5a) Context main_ctx`.
+
+**Behavior:** every `addRef`, `delRef`, and destructor on that specific id hits `os_debug_break()`. Attach a debugger (or `-das-wait-debugger`) to collect stack traces.
+
+**Automatic companion:** at exit `bin/daslang` prints all surviving smart pointers. Read a suspect id from there, rerun with `--track-smart-ptr <id>`, debug.
+
+---
+
+## #5 — JobStatus / Channel / LockBox / Feature
+
+`DumpJobQueLeaks()` runs automatically at exit when `JobStatus`/`Channel`/`LockBox`/`Feature` survivors exist. See the dedicated [`skills/jobque_debugging.md`](jobque_debugging.md) for the full workflow (refcount accounting, shutdown order, `--max-frames`, capture-macro hidden refs, lockbox fill/grab/join lifecycle).
+
+---
+
+## #6 — `HandleRegistry<T>` (dasHV WebSocket and similar handles)
+
+**Scope:** value-sized handles backed by `std::shared_ptr<T>` on the C++ side — used by dasHV for `hv::WebSocketClient`, `hv::WebSocketServer`, `hv::WebSocketChannel`, and any custom handle type registered via `addHandleAnnotation<T>`.
+
+**Invoke:** nothing. `handleRegistry_dumpAll()` runs inside `Module::Shutdown(dumpLeaks)`.
+
+**Output:**
+```
+  Handle<WebSocketClient> idx=3 gen=1 (rc=1)
+  Handle<WebSocketServer> idx=0 gen=9 (rc=1)
+total 1 leaked handles of type WebSocketClient
+total 1 leaked handles of type WebSocketServer
+```
+
+Columns: slot index, generation counter (rolls on release/reacquire), `shared_ptr::use_count()` at dump time. `rc=1` = registry is the sole owner (textbook leak). `rc>1` = another strong ref is keeping the object alive — look for forgotten captures.
+
+**Read it:** match leaked `Handle<TypeName>` against the acquire site (e.g. `makeWebSocketClient`, `makeWebSocketServer`). The leak means user code reached script exit without calling the matching destroy function (e.g. `destroy_web_socket_client`) or without triggering the wrapping class's `operator delete` (e.g. via `inscope` / explicit `delete`).
+
+**Advisory, not fatal:** the dump prints but does not change exit code. Only `ptr_ref_count` leaks force `exit(1)`.
+
+---
+
+## Silencing exit-time dumps
+
+Pass `--no-dump-leaks` to make all three exit-time dumps (JobStatus, HandleRegistry, smart_ptr TextPrinter) quiet. The `exit(1)` on smart_ptr leak is preserved — it's a failure signal, not diagnostic noise. Useful when pre-existing noisy leaks would drown out the signal you're chasing.
+
+---
+
+## Before reporting a leak
+
+Common non-leaks that look like leaks:
+
+- **Missing `inscope` on a smart_ptr** (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`) — the value lives for the context's lifetime by design. Fix: add `inscope`, or explicit `delete`.
+- **`var arr : array<int>` with no `delete arr` and no `inscope`** — arrays have NO scope-based RAII; the heap-side data survives until context destroy. Use explicit `delete arr` or move ownership out.
+- **Channel / Stream not released** — holding past the last `s |> release()` / `s |> notify_and_release()` leaks the primitive. See `skills/jobque_debugging.md`.
+- **Capture-macro hidden addRef** — lambdas over JobStatus/Channel/Stream bump the refcount via `capture_macro` in `jobque_boost.das`; the matching release fires at lambda destruction. If the lambda outlives expectations, the ref outlives it too.
+- **String interning** — `intern`'d strings live in `constStringHeap` for the program lifetime. Not a leak.
+- **Persistent heap option** — `options persistent_heap = true` keeps allocated memory across context runs intentionally.

--- a/install/skills/writing_tests.md
+++ b/install/skills/writing_tests.md
@@ -1,0 +1,111 @@
+# Testing Conventions (dastest)
+
+The SDK ships the `dastest` test framework at `dastest/dastest.das`. Use it to write tests for your own daslang code — no extra dependencies.
+
+## Running tests
+
+```bash
+# Single file
+bin/daslang dastest/dastest.das -- --test path/to/test_foo.das
+
+# A directory
+bin/daslang dastest/dastest.das -- --test path/to/tests/
+
+# All tests in your project
+bin/daslang dastest/dastest.das -- --test tests/
+```
+
+The `--` separator splits daslang flags (left) from script args (right). Everything after `--` is forwarded to `dastest`.
+
+## Test file structure
+
+```das
+options gen2
+require dastest/testing_boost public
+require my/module_under_test
+
+[test]
+def test_something(t : T?) {
+    t |> run("description") @(t : T?) {
+        t |> equal(actual, expected)
+        t |> success(condition)
+    }
+}
+```
+
+## Key assertion functions
+
+- `t |> equal(actual, expected)` — value equality (reports "values differ" with both sides)
+- `t |> success(condition)` — boolean assertion (reports "expected success, got failure")
+- `t |> success(condition, "message")` — boolean assertion with a custom message
+- `t |> failure("message")` — unconditional failure
+- `t |> run("name") @(t : T?) { ... }` — named subtest
+- `t |> strictEqual(actual, expected)` — strict equality, fatal on fail
+- `t |> numericEqual(actual, expected)` — numeric equality with NaN handling
+
+## Use `feint` instead of `print` in tests
+
+`feint` has the same signature and side-effect annotations as `print` (`SideEffects::modifyExternal`), so the compiler will not optimize it out — but it produces no output, keeping test runs clean.
+
+```das
+// WRONG — produces noise in test output
+print("x = {x}\n")
+
+// RIGHT — same effect for testing, no output
+feint("x = {x}\n")
+```
+
+Use real `print` only when the test specifically validates logging or output redirection.
+
+## NEVER use `assert` / `verify` in test files
+
+Do NOT use `assert(...)` or `verify(...)` in `[test]` functions. They crash the process on failure with no detailed report. Use the dastest API instead:
+
+| Don't write | Write instead |
+|---|---|
+| `assert(a == b)` | `t |> equal(a, b)` |
+| `verify(a == b)` | `t |> equal(a, b)` |
+| `assert(condition)` | `t |> success(condition)` |
+| `assert(condition, "msg")` | `t |> success(condition, "msg")` |
+| `assert(false)` (guard) | `t |> failure("reason")` |
+
+The dastest API records failures with file/line info and continues running other tests.
+
+**Exception:** files that use `expect <code>:<count>` directives are compilation-failure tests — they don't use `[test]` or `t : T?` at all.
+
+## Threading `t : T?` through helpers
+
+When a `[test]` function calls helper functions that need to assert:
+
+1. Add `t : T?` as the **first** parameter to the helper.
+2. Use `t |> equal(...)` / `t |> success(...)` inside the helper.
+3. Pass `t` from the test function: `my_helper(t, other_args)`.
+
+Avoid naming local variables `t` in helpers — it shadows the test object parameter. Use `ii`, `idx`, `val`, `sptr` etc.
+
+## Common test options
+
+- `options no_unused_function_arguments = false` — suppress warnings for test params
+- `options no_unused_block_arguments = false` — suppress warnings for block params
+- Shared helpers go in a `_common.das` file inside the same test directory
+
+## Testing non-copyable types
+
+When testing operations on types containing non-copyable fields (`array<T>`, `table<K;V>`):
+
+- **Use `emplace`** to add structs with non-copyable fields to arrays: `arr |> emplace <| make_value()`. Plain `push` copies and fails on non-copyable fields.
+- **Verify source preservation** after `push(container, named_var)` — the source variable should still be intact. If the implementation accidentally calls `emplace` instead of `push_clone`, the source is destroyed.
+- **Test non-copyable fields explicitly** — include at least one struct with an `array<T>` or `table<K;V>` field so accidental copies surface.
+- **Factory helpers** — write `make_xxx()` functions that construct test values, keeping test code concise.
+
+## Test-first bug verification
+
+When fixing bugs, write the failing test BEFORE applying the fix:
+
+1. Write a test that demonstrates the expected behavior.
+2. Run it — confirm it FAILS (this proves the bug exists and the test is valid).
+3. Apply the fix.
+4. Run the test again — confirm it PASSES.
+5. Run the full test suite to ensure no regressions.
+
+This catches tests that pass for the wrong reason (a tautology that never exercised the bug).

--- a/install/skills/xml.md
+++ b/install/skills/xml.md
@@ -1,0 +1,170 @@
+# XML in daslang (dasPUGIXML)
+
+Read this skill before writing or editing `.das` code that parses, builds, queries, or serializes XML. There is one path: `dasPUGIXML` (a binding around the C++ pugixml library) plus its `PUGIXML_boost` daslib layer with iterators, RAII helpers, and the builder EDSL. Read [tutorials/dasPUGIXML/](tutorials/dasPUGIXML/) for runnable examples (4 tutorials, in order).
+
+## `require`
+
+```das
+require pugixml/PUGIXML_boost
+```
+
+`PUGIXML_boost` re-exports the C++ `pugixml` module — never `require` both.
+
+If `require pugixml/PUGIXML_boost` fails at compile time, this SDK was built without the dasPUGIXML module — use a build that includes it.
+
+## Loading & parsing — RAII blocks
+
+All three entry points take a block that runs with a live document; the document is freed automatically at block exit.
+
+```das
+parse_xml(xml_str) $(doc, ok) {
+    if (!ok) { return ; }
+    let root = doc.document_element
+    // ... work with doc/root ...
+}
+
+open_xml("path/to/file.xml") $(doc, ok) {
+    if (!ok) { return ; }
+    // ...
+}
+
+with_doc() $(doc) {
+    // empty document, build it via tag()/attr() ...
+    print(to_string(doc))
+}
+```
+
+**Always check `ok` first** — pugixml returns errors as a bool flag, not exceptions. Reading from a doc whose parse failed is undefined.
+
+**Don't escape document/node pointers past the block.** They become dangling once the RAII block exits. Materialize what you need (strings, structs, your own data) inside the block, and return that.
+
+## Iteration
+
+Two styles for the same iteration — pick whichever reads cleaner at the call site:
+
+```das
+// Iterator (preferred for plain reads)
+for (ch in each_child(node))            { ... }    // all children
+for (ch in each_child(node, "name"))    { ... }    // children with this tag
+for (a  in each_attribute(node))        { ... }
+
+// Block (required when you need a `var` child for mutation)
+node |> for_each_child()       $(ch)      { ... }
+node |> for_each_child("name") $(ch)      { ... }
+node |> for_each_attribute()   $(a)       { ... }
+```
+
+Manual `node.first_child` / `node.next_sibling` walking still works but is rarely the right choice.
+
+## Quick accessors (with defaults)
+
+```das
+let title  = node_text(root, "title")                       // child element text
+let desc   = node_text(root, "desc", "no description")
+let id     = node_attr(root, "id")                          // attribute as string
+let count  = node_attr_int(root, "count", 0)
+let ratio  = node_attr_float(root, "ratio", 1.0)
+let active = node_attr_bool(root, "active", false)
+```
+
+These read; they do not mutate. Missing data returns the supplied default.
+
+## Typed `is` / `as` on attributes and text
+
+`PUGIXML_boost` overloads `operator []` on `xml_node` to return an `xml_attribute`, and overloads `is`/`as` for `int / uint / float / double / bool / string` on both `xml_attribute` and `xml_text`.
+
+```das
+let x_attr = root["x"]                          // xml_attribute
+let x_val  = root["x"] as int                   // 0 if missing — does NOT crash
+let label  = root["label"] as string
+
+// Existence check on attribute / non-empty check on text
+if (root["x"] is int)        { ... }
+if (count_node.text is int)  { let n = count_node.text as int }
+
+// Whole-node serialization
+let xml_string = (some_node as string)
+```
+
+A missing attribute reads as a "falsy" `xml_attribute` (its `.ok` field is false) — typed `as` returns the type's default rather than erroring.
+
+## Building XML — the `tag` / `attr` EDSL
+
+`tag()` appends a child and runs a block inside it. `attr()` appends an attribute and returns its parent for chaining. Both pipe naturally.
+
+```das
+with_doc() $(doc) {
+    doc |> tag("library") $(var library) {
+        library |> tag("book") $(var book) {
+            book |> tag("title", "The C Programming Language")     // child + text
+            book |> tag("author", "Brian W. Kernighan")
+            book |> attr("isbn",  "978-0131103627")                // attribute
+            book |> attr("year",  1988)                            // typed: int
+            book |> attr("price", 67.99)                           // typed: float
+        }
+    }
+    print(to_string(doc))
+}
+```
+
+- `tag(name, blk)` — append child, run block on it, return the child.
+- `tag(name, text)` — append child with text content (no nested block).
+- `tag(name)` — append a bare child.
+- `attr(name, value)` — string / int / float / bool overloads; returns the parent for chaining.
+- Low-level: `add_child`, `add_child_ex`, `add_attr` — use only when the EDSL doesn't fit.
+
+## Serializing
+
+```das
+let s = to_string(doc)        // serialize whole document
+let s = to_string(some_node)  // serialize a subtree
+```
+
+2-space indent, UTF-8 (auto-detected for input; emitted by default for output).
+
+## XPath
+
+```das
+let first_name = select_text(root, "product[1]/name")
+let isbn       = select_value(root, "book[1]/@isbn")     // attribute or text
+
+root |> for_each_select("book[@year>'2000']") $(xn) {
+    let n = xn.node
+    print("{n.name}\n")
+}
+
+// Reuse a compiled query
+with_xpath("book[@in_stock='true']") $(q) {
+    // pass q to evaluate_node_set / iterate
+}
+```
+
+`for_each_select` auto-frees the result set; the block parameter is an `xpath_node` (`.node` is the underlying `xml_node`). Compile a query once with `with_xpath` if you'll evaluate it many times.
+
+## Struct ↔ XML
+
+Round-trip arbitrary struct values:
+
+```das
+let player = Player(name = "Hero", hp = 100)
+let xml_str = to_XML(player, "player")               // string
+let restored = from_XML(xml_str, type<Player>)       // string → struct
+let same_via_node = from_XML(some_node, type<Player>) // node → struct
+```
+
+Supports nested structs, enums, arrays, tables, tuples, variants, vector types (`floatN`, `intN`). The same field annotations as JSON apply (`@rename`, `@enum_as_int`, `@unescape`).
+
+## Common gotchas
+
+- **Errors are `ok` bool flags, not exceptions** — always branch on the second block parameter before using `doc`.
+- **No escape past the RAII block** — `xml_document?` and any `xml_node` derived from it are valid only inside the block. Returning them past the block exit is use-after-free.
+- **Missing attributes don't error**: `root["does_not_exist"] as int` returns `0`. Use the `is` test if you need to distinguish "missing" from "zero".
+
+## Reference
+
+- Tutorials (read in order, runnable):
+  - [tutorials/dasPUGIXML/01_parsing_and_navigation.das](tutorials/dasPUGIXML/01_parsing_and_navigation.das) — parsing, iteration, quick accessors, `is`/`as`
+  - [tutorials/dasPUGIXML/02_building_xml.das](tutorials/dasPUGIXML/02_building_xml.das) — `with_doc`, `tag`/`attr` EDSL, serialization
+  - [tutorials/dasPUGIXML/03_xpath.das](tutorials/dasPUGIXML/03_xpath.das) — XPath queries, compiled XPath
+  - [tutorials/dasPUGIXML/04_serialization.das](tutorials/dasPUGIXML/04_serialization.das) — `to_XML`/`from_XML` round-trip
+- daslib helpers (the source of truth for the EDSL): [modules/dasPUGIXML/daslib/PUGIXML_boost.das](modules/dasPUGIXML/daslib/PUGIXML_boost.das)

--- a/skills/install_instructions.md
+++ b/skills/install_instructions.md
@@ -16,6 +16,12 @@ Source files live under `install/` in the repo; CMake installs them to the SDK r
 | `install/skills/daspkg.md` | `skills/daspkg.md` | Package manager usage |
 | `install/skills/dynamic_modules.md` | `skills/dynamic_modules.md` | `.das_module` descriptors |
 | `install/skills/daslang_live.md` | `skills/daslang_live.md` | Live-reload host |
+| `install/skills/clargs_usage.md` | `skills/clargs_usage.md` | Command-line argument parsing for user tools |
+| `install/skills/json.md` | `skills/json.md` | JSON read/write via `sprint_json`/`sscan_json` and `JV`/`from_JV` |
+| `install/skills/xml.md` | `skills/xml.md` | XML via `dasPUGIXML`/`PUGIXML_boost` |
+| `install/skills/writing_tests.md` | `skills/writing_tests.md` | dastest framework usage for SDK consumers |
+| `install/skills/memory_leak_detection.md` | `skills/memory_leak_detection.md` | Heap / gc_node / smart_ptr / handle leak detection — runtime CLI flags |
+| `install/skills/jobque_debugging.md` | `skills/jobque_debugging.md` | Channel/LockBox/JobStatus/Stream/Feature leak debugging with `--track-job-status` |
 | `utils/mcp/` (whole dir) | `utils/mcp/` | MCP server for AI assistants (gated on dasHV) |
 
 ## What belongs in install instructions
@@ -63,6 +69,7 @@ The install CLAUDE.md derives from the repo CLAUDE.md but is NOT a copy. When up
 4. **New C++ integration patterns** — update BOTH `skills/cpp_integration.md` AND `install/skills/cpp_integration.md`; omit repo-internal codebase notes from the install version
 5. **Formatter changes** — update BOTH `skills/das_formatting.md` AND `install/skills/das_formatting.md`; use `bin/daslang` paths in the install version
 6. **MCP tool changes** (new tools, API changes) — update BOTH repo `CLAUDE.md` MCP section AND `install/CLAUDE.md` MCP section; use `bin/daslang` paths in install version. The MCP source files (`utils/mcp/`) are installed directly by CMake (gated on `NOT DAS_HV_DISABLED`)
+7. **Library / module skills** (`json.md`, `xml.md`, `daslib_modules.md`, etc.) — update BOTH repo and install versions. In the install version: drop `tests/` references (tests aren't shipped), drop repo-only doc paths (`doc/source/...`), drop CMake-flag / `.vscode/settings.json` build-config sections (install users get a pre-built binary — they cannot flip `DAS_*_DISABLED`), drop the "no `print` in tests/daslib" gotcha (a repo-development convention, not user-facing), drop `skills/tutorials.md` cross-references (not in install). Keep all `daslib/*.das`, `tutorials/`, `examples/`, `utils/mcp/`, `utils/daspkg/`, `modules/<X>/daslib/*.das` references — those all ship
 
 ## CMake install rules
 
@@ -91,6 +98,12 @@ After modifying install instructions:
    - `D:/daslang/skills/daspkg.md`
    - `D:/daslang/skills/dynamic_modules.md`
    - `D:/daslang/skills/daslang_live.md`
+   - `D:/daslang/skills/clargs_usage.md`
+   - `D:/daslang/skills/json.md`
+   - `D:/daslang/skills/xml.md`
+   - `D:/daslang/skills/writing_tests.md`
+   - `D:/daslang/skills/memory_leak_detection.md`
+   - `D:/daslang/skills/jobque_debugging.md`
    - `D:/daslang/utils/mcp/main.das` (only if built with `DAS_HV_DISABLED=OFF`)
    - `D:/daslang/utils/mcp/tools/common.das` (only if built with `DAS_HV_DISABLED=OFF`)
 4. Spot-check that no repo-internal paths leaked into install files

--- a/skills/json.md
+++ b/skills/json.md
@@ -1,0 +1,205 @@
+# JSON in daslang
+
+Read this skill before writing or editing `.das` code that produces, consumes, or navigates JSON. The companion tutorial is [tutorials/language/30_json.das](tutorials/language/30_json.das); read it for runnable examples of every pattern below.
+
+## Pick the right tool first
+
+Reach for the simplest tool that fits the data. The order of preference is fixed:
+
+| Situation | Use | Why |
+|---|---|---|
+| You have a daslang struct/array/value and want a JSON string, or you have a JSON string and a struct to fill | **`sprint_json(v, pretty)` / `sscan_json(json, var v)`** | Zero ceremony, no `JsonValue?` allocation, respects all field annotations (`@rename`, `@optional`, `@embed`, `@unescape`, `@enum_as_int`). Handles structs, classes, arrays, tables, tuples, variants, enums, bitfields, vector types, pointers, all basic types |
+| You're navigating arbitrary JSON whose shape isn't known at compile time, or you need a `JsonValue?` tree to mutate | **`JV(x)` / `from_JV(js, type<T>)` from `daslib/json_boost`** | Generic reflection on structs/tables/arrays/tuples/variants/vectors/enums; safe-access ops `?.`, `?[]`, `??`; `is`/`as` on the underlying variant |
+| The generic `JV` / `from_JV` doesn't know your custom type | **Add a `def JV(x : MyType)` / `def from_JV(...)` overload** | Function-overload dispatch picks it up automatically — no macro, no annotation |
+| Building a JSON object by hand from a `table<string; JsonValue?>` | **Last resort** — only when neither sprint nor JV applies | Verbose; loses field-annotation support; the structure is invisible to types |
+
+If you find yourself reaching for the last row, ask first whether the JSON shape can be modeled as a struct or variant — almost always it can, and `sprint_json` will be cleaner.
+
+## `require`
+
+```das
+require daslib/json_boost
+```
+
+`json_boost` re-exports `daslib/json` publicly — never `require` both. The `sprint_json` / `sscan_json` builtins are exposed by the runtime; no extra require is needed for them.
+
+## `sprint_json` / `sscan_json`
+
+The default for any "value ↔ JSON string" task.
+
+```das
+let s = sprint_json(value, /*pretty=*/false)   // compact
+let s = sprint_json(value, /*pretty=*/true)    // human-readable, multi-line
+
+var dst : MyStruct
+let ok = sscan_json(json_str, dst)             // returns bool
+```
+
+Notes:
+- Supports the full set: structs, classes (deref via `*ptr`), arrays, tables, tuples, variants (key = active variant name), enums (string by default; int with `@enum_as_int`), bitfields, `floatN`/`intN` vectors, pointers, all primitives.
+- `sscan_json` returns `bool` — false on parse error. Missing fields keep their existing/default values; **unknown keys are silently ignored**, so validate required fields yourself if needed.
+- Round-trip: `sscan_json(sprint_json(x, false), var y)` reproduces `x` for any supported shape.
+
+## Field annotations
+
+These are read by both `sprint_json`/`sscan_json` and the generic `JV`/`from_JV`:
+
+| Annotation | Effect |
+|---|---|
+| `@optional` | Skip the field on output if it equals the default/empty value |
+| `@embed` | Emit a `string` field as raw JSON (no surrounding quotes — caller's responsibility to provide valid JSON) |
+| `@unescape` | Don't escape characters in the string output |
+| `@enum_as_int` | Serialize an enum as its integer value instead of its string name |
+| `@rename = "json_key"` | Map this field to a different JSON key — the standard fix when the JSON key collides with a daslang keyword (`type`, `class`) |
+
+Idiomatic: prefix the daslang field with `_` and use `@rename` (e.g. `@rename = "type" _type : string`).
+
+## `JV` / `from_JV` (json_boost)
+
+Use when working with `JsonValue?` trees — reading arbitrary JSON, building one tree to merge into another, or implementing a thin adapter that doesn't have the destination struct on hand.
+
+```das
+let p = Player(name = "Hero", hp = 100)
+var js = JV(p)                              // struct → JsonValue?
+
+var error : string
+var parsed = read_json(json_str, error)
+let p2 = from_JV(parsed, type<Player>)      // JsonValue? → struct
+```
+
+`JV` accepts: any primitive, vectors, tables, arrays, tuples, variants, enums, structs/classes (via reflection). `JV(a, b, c, ...)` with multiple args (up to 10) builds an array — useful for one-line literals like `JV(1920, 1080)`.
+
+`from_JV` second argument is a type witness (`type<T>`); an optional third argument is the default if the value is null/missing/wrong-typed.
+
+## Custom-type extension
+
+When the generic reflection can't (or shouldn't) handle your type, add an overload. No macro, no annotation — function-overload resolution does the rest.
+
+Pattern (see [daslib/dap.das](daslib/dap.das) `JV(data : Variable)` and [daslib/refactor.das](daslib/refactor.das) `JV(li : LineInfo)`):
+
+```das
+def JV(data : MyType) : JsonValue? {
+    var inscope tab <- {
+        "field1" => JV(data.field1),
+        "field2" => JV(data.field2)
+    }
+    return JV(tab)
+}
+
+def from_JV(v : JsonValue const explicit?; ent : MyType; defV : MyType = MyType()) : MyType {
+    return MyType(
+        field1 = v?.field1 ?? defV.field1,
+        field2 = v?.field2 ?? defV.field2
+    )
+}
+```
+
+For `JV` the return type **must** be `JsonValue?`. For `from_JV` the second argument is a value of the type (not `type<T>`) and the third is the default — match the signatures of the primitive overloads in [daslib/json_boost.das](daslib/json_boost.das).
+
+## Safe access on `JsonValue?`
+
+`json_boost` overloads the safe-access operators so they never crash:
+
+```das
+let name        = js?.user?.name ?? "unknown"          // ?. for object keys
+let first_score = js?["user"]?["scores"]?[0] ?? 0      // ?[] for keys / array indices
+let safe_val    = (nothing : JsonValue?)?.foo ?? "ok"  // null pointer is fine
+```
+
+**Gotcha:** `js?.value` reads the *struct field* `JsonValue.value` (the underlying `JsValue` variant), **not** a JSON key called `"value"`. For a JSON key, use `js?["value"]`.
+
+## `is` / `as` on `JsonValue?`
+
+Checks the underlying `JsValue` variant — works through the pointer.
+
+```das
+if (js is _string)  { let s = js as _string }
+if (js is _longint) { let n = js as _longint }
+```
+
+The seven variant cases:
+
+| Case | Type |
+|---|---|
+| `_object`  | `table<string; JsonValue?>` |
+| `_array`   | `array<JsonValue?>` |
+| `_string`  | `string` |
+| `_number`  | `double` (floating point) |
+| `_longint` | `int64` (integer) |
+| `_bool`    | `bool` |
+| `_null`    | `void?` |
+
+`is`/`as` on the wrong case crashes — always guard with `is` first when the shape is uncertain.
+
+## `%json~ ... %%` reader macro
+
+Embed a compile-time JSON literal:
+
+```das
+var settings = %json~
+{
+    "resolution": [1920, 1080],
+    "fullscreen": true,
+    "title": "My Game"
+}
+%%
+```
+
+Runs through `read_json` at compile time; the result is a runtime `JsonValue?`. Useful for fixtures, defaults, and tests.
+
+## Parsing & errors
+
+```das
+var error : string
+var js = read_json(text, error)
+if (js == null) { /* error string is set */ }
+```
+
+- `read_json(text, var error)` — returns `JsonValue?` or `null` on failure; takes either `string` or `array<uint8>`.
+- `write_json(js)` — serialize a `JsonValue?`. Null pointer writes as `"null"`.
+- `try_fixing_broken_json(text)` — repair LLM output: fixes string concatenation (`"a" + "b"` → `"ab"`), trailing commas, double-quoted nesting. Run before `read_json` when consuming model-generated JSON.
+
+## Writer settings
+
+Each setter returns the previous value — save/restore for scoped changes.
+
+```das
+let prev = set_no_trailing_zeros(true)
+defer() { set_no_trailing_zeros(prev) }
+// ... write_json calls in here drop trailing zeros ...
+```
+
+- `set_no_trailing_zeros(bool)` — drop `.000000` from round floats (e.g. `1` instead of `1.000000`).
+- `set_no_empty_arrays(bool)` — skip empty array fields in objects.
+- `set_allow_duplicate_keys(bool)` — accept duplicate keys in `read_json` (last wins).
+
+## Manual construction (last resort)
+
+When the JSON shape really is dynamic — mixed-type maps, schema decided at runtime — build the tree directly:
+
+```das
+var inscope tab : table<string; JsonValue?>
+tab |> insert("name", JV("Alice"))
+tab |> insert("age",  JV(30))
+var obj = JV(tab)
+```
+
+Don't reach for this until you've ruled out modeling the data as a struct/variant. Field annotations (`@rename`, `@optional`, etc.) don't apply here — every key is hand-written.
+
+## Common gotchas
+
+- **`print` is not allowed in tests or daslib code** — use `to_log(LOG_INFO, "...")` instead. (See `CLAUDE.md`.)
+- **Class instances**: `sprint_json` takes a value; deref the smart pointer with `sprint_json(*classPtr, false)`. `JV(*classPtr)` likewise.
+- **Unknown keys are ignored** by `sscan_json` and `from_JV` — they aren't an error. Validate required fields explicitly if missing data is meaningful.
+- **`@rename` for keyword keys**: JSON keys like `"type"` and `"class"` collide with daslang keywords. Name the field `_type` / `_class` and add `@rename = "type"` / `@rename = "class"`.
+- **Cross-context JSON**: a `JsonValue?` allocated in one context's heap is invalid in another. If you parse on the main thread and consume on a worker, clone the strings (`clone_string`) on receive and reparse, or send the raw text instead.
+- **`var inscope` for the residual smart_ptrs only** — `JsonValue?` is a raw pointer (gc_node), pass-by-value is just a pointer copy. Don't use `var inscope` on `JsonValue?`.
+
+## Reference
+
+- Tutorial — read this first for runnable examples of every pattern: [tutorials/language/30_json.das](tutorials/language/30_json.das)
+- RST companion: [doc/source/reference/tutorials/30_json.rst](doc/source/reference/tutorials/30_json.rst); auto-generated module docs at `doc/source/stdlib/handmade/module-json.rst` and `module-json_boost.rst`
+- daslib sources: [daslib/json.das](daslib/json.das), [daslib/json_boost.das](daslib/json_boost.das)
+- Tests with usage patterns: [tests/json/test_sprint_json.das](tests/json/test_sprint_json.das), [tests/json/test_sscan_json.das](tests/json/test_sscan_json.das)
+- Real custom `JV` overloads: [daslib/dap.das](daslib/dap.das), [daslib/refactor.das](daslib/refactor.das)
+- Real `sprint_json` users: [utils/daspkg/lockfile.das](utils/daspkg/lockfile.das), [daslib/debug.das](daslib/debug.das), [utils/mcp/protocol.das](utils/mcp/protocol.das)

--- a/skills/xml.md
+++ b/skills/xml.md
@@ -1,0 +1,175 @@
+# XML in daslang (dasPUGIXML)
+
+Read this skill before writing or editing `.das` code that parses, builds, queries, or serializes XML. There is one path: `dasPUGIXML` (a binding around the C++ pugixml library) plus its `PUGIXML_boost` daslib layer with iterators, RAII helpers, and the builder EDSL. Read [tutorials/dasPUGIXML/](tutorials/dasPUGIXML/) for runnable examples (4 tutorials, in order).
+
+## Module & build flag
+
+```das
+require pugixml/PUGIXML_boost
+```
+
+`PUGIXML_boost` re-exports the C++ `pugixml` module — never `require` both.
+
+The module is **gated by CMake**: `DAS_PUGIXML_DISABLED` (default `ON` = disabled). To use it locally, set `DAS_PUGIXML_DISABLED=OFF` in `cmake.configureSettings` of `.vscode/settings.json` and reconfigure. See `CLAUDE.md` § "Build Configurations" for the workflow.
+
+## Loading & parsing — RAII blocks
+
+All three entry points take a block that runs with a live document; the document is freed automatically at block exit.
+
+```das
+parse_xml(xml_str) $(doc, ok) {
+    if (!ok) { return ; }
+    let root = doc.document_element
+    // ... work with doc/root ...
+}
+
+open_xml("path/to/file.xml") $(doc, ok) {
+    if (!ok) { return ; }
+    // ...
+}
+
+with_doc() $(doc) {
+    // empty document, build it via tag()/attr() ...
+    print(to_string(doc))
+}
+```
+
+**Always check `ok` first** — pugixml returns errors as a bool flag, not exceptions. Reading from a doc whose parse failed is undefined.
+
+**Don't escape document/node pointers past the block.** They become dangling once the RAII block exits. Materialize what you need (strings, structs, your own data) inside the block, and return that.
+
+## Iteration
+
+Two styles for the same iteration — pick whichever reads cleaner at the call site:
+
+```das
+// Iterator (preferred for plain reads)
+for (ch in each_child(node))            { ... }    // all children
+for (ch in each_child(node, "name"))    { ... }    // children with this tag
+for (a  in each_attribute(node))        { ... }
+
+// Block (required when you need a `var` child for mutation)
+node |> for_each_child()       $(ch)      { ... }
+node |> for_each_child("name") $(ch)      { ... }
+node |> for_each_attribute()   $(a)       { ... }
+```
+
+Manual `node.first_child` / `node.next_sibling` walking still works but is rarely the right choice.
+
+## Quick accessors (with defaults)
+
+```das
+let title  = node_text(root, "title")                       // child element text
+let desc   = node_text(root, "desc", "no description")
+let id     = node_attr(root, "id")                          // attribute as string
+let count  = node_attr_int(root, "count", 0)
+let ratio  = node_attr_float(root, "ratio", 1.0)
+let active = node_attr_bool(root, "active", false)
+```
+
+These read; they do not mutate. Missing data returns the supplied default.
+
+## Typed `is` / `as` on attributes and text
+
+`PUGIXML_boost` overloads `operator []` on `xml_node` to return an `xml_attribute`, and overloads `is`/`as` for `int / uint / float / double / bool / string` on both `xml_attribute` and `xml_text`.
+
+```das
+let x_attr = root["x"]                          // xml_attribute
+let x_val  = root["x"] as int                   // 0 if missing — does NOT crash
+let label  = root["label"] as string
+
+// Existence check on attribute / non-empty check on text
+if (root["x"] is int)        { ... }
+if (count_node.text is int)  { let n = count_node.text as int }
+
+// Whole-node serialization
+let xml_string = (some_node as string)
+```
+
+A missing attribute reads as a "falsy" `xml_attribute` (its `.ok` field is false) — typed `as` returns the type's default rather than erroring.
+
+## Building XML — the `tag` / `attr` EDSL
+
+`tag()` appends a child and runs a block inside it. `attr()` appends an attribute and returns its parent for chaining. Both pipe naturally.
+
+```das
+with_doc() $(doc) {
+    doc |> tag("library") $(var library) {
+        library |> tag("book") $(var book) {
+            book |> tag("title", "The C Programming Language")     // child + text
+            book |> tag("author", "Brian W. Kernighan")
+            book |> attr("isbn",  "978-0131103627")                // attribute
+            book |> attr("year",  1988)                            // typed: int
+            book |> attr("price", 67.99)                           // typed: float
+        }
+    }
+    print(to_string(doc))
+}
+```
+
+- `tag(name, blk)` — append child, run block on it, return the child.
+- `tag(name, text)` — append child with text content (no nested block).
+- `tag(name)` — append a bare child.
+- `attr(name, value)` — string / int / float / bool overloads; returns the parent for chaining.
+- Low-level: `add_child`, `add_child_ex`, `add_attr` — use only when the EDSL doesn't fit.
+
+## Serializing
+
+```das
+let s = to_string(doc)        // serialize whole document
+let s = to_string(some_node)  // serialize a subtree
+```
+
+2-space indent, UTF-8 (auto-detected for input; emitted by default for output).
+
+## XPath
+
+```das
+let first_name = select_text(root, "product[1]/name")
+let isbn       = select_value(root, "book[1]/@isbn")     // attribute or text
+
+root |> for_each_select("book[@year>'2000']") $(xn) {
+    let n = xn.node
+    print("{n.name}\n")
+}
+
+// Reuse a compiled query
+with_xpath("book[@in_stock='true']") $(q) {
+    // pass q to evaluate_node_set / iterate
+}
+```
+
+`for_each_select` auto-frees the result set; the block parameter is an `xpath_node` (`.node` is the underlying `xml_node`). Compile a query once with `with_xpath` if you'll evaluate it many times.
+
+## Struct ↔ XML
+
+Round-trip arbitrary struct values:
+
+```das
+let player = Player(name = "Hero", hp = 100)
+let xml_str = to_XML(player, "player")               // string
+let restored = from_XML(xml_str, type<Player>)       // string → struct
+let same_via_node = from_XML(some_node, type<Player>) // node → struct
+```
+
+Supports nested structs, enums, arrays, tables, tuples, variants, vector types (`floatN`, `intN`). The same field annotations as JSON apply (`@rename`, `@enum_as_int`, `@unescape`).
+
+## Common gotchas
+
+- **Errors are `ok` bool flags, not exceptions** — always branch on the second block parameter before using `doc`.
+- **No escape past the RAII block** — `xml_document?` and any `xml_node` derived from it are valid only inside the block. Returning them past the block exit is use-after-free.
+- **Missing attributes don't error**: `root["does_not_exist"] as int` returns `0`. Use the `is` test if you need to distinguish "missing" from "zero".
+- **Build flag**: if `require pugixml/PUGIXML_boost` fails at compile time, the module is disabled — flip `DAS_PUGIXML_DISABLED=OFF` (`CLAUDE.md` § "Build Configurations").
+- **CMake install for tutorial data**: a tutorial that ships sample XML (e.g. [tutorials/dasPUGIXML/books.xml](tutorials/dasPUGIXML/books.xml)) needs a `*.xml` glob in the install rule — see `skills/tutorials.md`.
+
+## Reference
+
+- Tutorials (read in order, runnable):
+  - [tutorials/dasPUGIXML/01_parsing_and_navigation.das](tutorials/dasPUGIXML/01_parsing_and_navigation.das) — parsing, iteration, quick accessors, `is`/`as`
+  - [tutorials/dasPUGIXML/02_building_xml.das](tutorials/dasPUGIXML/02_building_xml.das) — `with_doc`, `tag`/`attr` EDSL, serialization
+  - [tutorials/dasPUGIXML/03_xpath.das](tutorials/dasPUGIXML/03_xpath.das) — XPath queries, compiled XPath
+  - [tutorials/dasPUGIXML/04_serialization.das](tutorials/dasPUGIXML/04_serialization.das) — `to_XML`/`from_XML` round-trip
+- daslib helpers (the source of truth for the EDSL): [modules/dasPUGIXML/daslib/PUGIXML_boost.das](modules/dasPUGIXML/daslib/PUGIXML_boost.das)
+- C++ binding (for adding new functions): [modules/dasPUGIXML/src/dasPUGIXML.h](modules/dasPUGIXML/src/dasPUGIXML.h), `dasPUGIXML.cpp`
+- Tests with patterns: [tests/dasPUGIXML/](tests/dasPUGIXML/) — `test_pugixml_core.das`, `test_pugixml_mutation.das`, `test_pugixml_boost.das`, `test_serial_*.das`
+- Auto-generated RST: `doc/source/stdlib/handmade/function-pugixml-*.rst`, `structure_annotation-pugixml-*.rst`, `Variable-pugixml-*.rst`


### PR DESCRIPTION
## Summary

- Adds the `json.md` and `xml.md` skills to the **repo** (`skills/`) and the **install** (`install/skills/`), so SDK consumers get the same library guidance daslang developers do.
- Adds three more SDK-user-facing runtime skills the install was missing: `writing_tests.md`, `memory_leak_detection.md`, `jobque_debugging.md`.
- Brings `install/CLAUDE.md` up to date — `.das_project` callback table, JIT/AOT flags, argv conventions, tutorials hint, the missing `lint` MCP tool, tool count fix.
- Updates the maintainer guide (`skills/install_instructions.md`) with the new mappings and a "what to strip when porting repo→install" rule.

Markdown only — no `.das` / C++ / RST changes, so the make_pr lint/test/AOT/format checks don't apply.

## Commits

1. **`skills: add json.md and xml.md`** (205f86c8d) — repo-side skills.
   - `json.md` sets a clear priority order: `sprint_json` / `sscan_json` first, then `JV` / `from_JV` from `json_boost` on `JsonValue?` trees (with custom `def JV(MyType)` overloads), and only fall back to manual `table<string;JsonValue?>` as a last resort. Documents field annotations, safe-access ops, the `%json~` reader macro, parsing, writer settings, and gotchas.
   - `xml.md` covers `dasPUGIXML` / `PUGIXML_boost`: RAII parsing (`parse_xml` / `open_xml` / `with_doc`), iteration helpers, quick accessors, typed `is`/`as` on attributes/text, the `tag`/`attr` builder EDSL, XPath, and `to_XML`/`from_XML` round-trip.
   - Both link to the in-tree tutorials and tests as primary reference. Repo `CLAUDE.md` skill table updated with two new rows.

2. **`install: port json/xml/test/leak skills to SDK + CLAUDE.md updates`** (3df18291d) — install/SDK-side additions.

   New `install/skills/`:
   - `json.md`, `xml.md` — install variants of the repo skills.
   - `writing_tests.md` — dastest framework usage for SDK consumers.
   - `memory_leak_detection.md` — `--das-profiler-leaks`, `-track-allocations`, `GC APP LEAK` / `DAS_GC_BREAK_ON_ID`, `--track-smart-ptr`, `HandleRegistry` dump.
   - `jobque_debugging.md` — Channel/LockBox/JobStatus/Stream/Feature leaks via `DumpJobQueLeaks` and `--track-job-status` refcount tracing.

   The install variants strip repo-development bits (`tests/aot` CMake registration, "no `print` in tests" convention, build-flag wrangling via `.vscode/settings.json`, `doc/source/` cross-refs, repo-internal C++ source paths) while keeping all runtime CLI flags, `daslib/` paths, tutorial references, and module helper paths — all of those ship in the SDK.

   `install/CLAUDE.md` additions:
   - `.das_project` subsection — file format, `-project` flag, callback table (`module_get` / `include_get` / `module_allowed` / `option_allowed` / `annotation_allowed`), `DAS_PAK_ROOT`.
   - JIT/AOT execution flags — `-jit`, `-exe -output`, `-use-aot`, `-aot-macros`.
   - Script argv conventions — `-- arg1 arg2` after the script path, pointer to `clargs_usage` skill.
   - Tutorials subsection — pointer to `tutorials/language/01..53` plus per-module tutorial directories.
   - Five new skill rows in the table.
   - Missing `lint` MCP tool row added; tool count corrected 29 → 30.

   `install/README.md`: tool count corrected 29 → 30.

   `skills/install_instructions.md` (maintainer guide): six new file mappings (`clargs_usage` was previously missing from the index even though the file shipped); rule 7 documents what to strip when porting library/runtime skills repo→install; verification list updated with all new files.

## Test plan

- [ ] Spot-check rendered Markdown on GitHub for the new install skill files.
- [ ] Confirm `cmake --install` lays the new files at `<install>/skills/{json,xml,writing_tests,memory_leak_detection,jobque_debugging}.md` (covered by the existing `install(DIRECTORY install/skills DESTINATION ...)` rule — no CMake change needed).
- [ ] Verify no repo-internal paths (`bin/Release/`, `tests/`, `.vscode/settings.json`, `doc/source/`) leaked into install files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)