### PR TITLE
find_dupes: export/import functions JSON + comprehensive test suite

### DIFF
--- a/utils/find_dupes/README.md
+++ b/utils/find_dupes/README.md
@@ -42,6 +42,8 @@ Flags:
 | `-x / --no-fuzzy` | off | Skip MinHash pass — exact clusters only |
 | `--min-tokens` | 8 | Drop functions with fewer than N tokens (filters trivial wrappers) |
 | `-L / --lambdas-only` | off | Skip top-level functions, keep only lambdas — useful for clustering dastest `t \|> run("…") @(t) { … }` bodies |
+| `--export-functions` | (off) | Write all extracted functions to a JSON file and exit before clustering |
+| `--import-functions` | (off) | Load functions from a JSON file (produced by `--export-functions`) instead of compiling. Mutually exclusive with `--path` and `--export-functions` |
 | `-v / --verbose` | off | Per-file progress |
 | `-?` | | Help |
 
@@ -71,7 +73,11 @@ is real signal).
 | `cluster.das` | Exact-bucket clustering + fuzzy all-pairs with length gate |
 | `report.das` | JSON + stdout summary writer |
 | `main.das` | CLI (`daslib/clargs`), file scan, compile-and-collect orchestration |
+| `pipeline.das` | `compile_and_collect` / `collect_from_program` — compile-and-extract orchestration, shared by `main.das` and the test suite |
+| `exchange.das` | On-disk JSON schema + writer/reader for `--export-functions` / `--import-functions` |
 | `fixture/synth.das` | Hand-crafted fixture for smoke-testing the visitor end-to-end |
+| `fixture/canonical_cases.das` | Narrowly-targeted fixture (one function per canonicalization concern) for unit-testing `CanonicalVisitor` |
+| `test_find_dupes.das` | dastest suite — run with `bin/daslang dastest/dastest.das -- --test utils/find_dupes/test_find_dupes.das` |
 
 Notes:
 
@@ -93,6 +99,34 @@ Notes:
 - Per-source-line dedup: a generic reified for N types becomes N
   FunctionPtrs all pointing at the same `(file, line)`. We keep the
   first to avoid the same source location being counted N times.
+
+## Export / import
+
+Compilation is the expensive step; the canonical-form computation is deterministic. To hand the function list off to an external tool (visualizer, custom clusterer), or to shard compilation across machines and merge later, dump the post-canonicalization records and reload them:
+
+```sh
+# compile + extract, write JSON, exit before clustering
+./bin/daslang utils/find_dupes/main.das -- -p tests --export-functions /tmp/funcs.json
+
+# skip compilation; cluster + report from JSON (--json still works as before)
+./bin/daslang utils/find_dupes/main.das -- --import-functions /tmp/funcs.json --json /tmp/dupes.json
+```
+
+`--import-functions` is mutually exclusive with both `--path` and `--export-functions`. `--export-functions` always exits before the clustering pass.
+
+The on-disk schema is a small envelope:
+
+```json
+{
+  "schema_version": 1,
+  "functions": [
+    { "name": "add_int", "file": "tests/foo.das", "line": 4,
+      "is_lambda": false, "canonical": "FN ARG <var_0> TYP …" }
+  ]
+}
+```
+
+MinHash signatures are not included — they're recomputed on import (deterministic and cheap). On import, `--no-fuzzy` and `--min-tokens` apply just like in the compile path.
 
 ## Out of scope
 

--- a/utils/find_dupes/exchange.das
+++ b/utils/find_dupes/exchange.das
@@ -1,0 +1,131 @@
+options gen2
+options rtti
+
+require strings
+require daslib/json_boost
+require daslib/fio
+require cluster
+require minhash
+require canonical
+
+
+// Slim per-function record for the on-disk export. Drops the MinHash
+// signature (recomputed on import — deterministic and cheap) and
+// `cluster_id` (assigned by `exact_buckets`, not part of the input
+// shape).
+struct public ExportedFunction {
+    name : string
+    file : string
+    line : int
+    is_lambda : bool
+    canonical : string
+}
+
+
+// `schema_version` lets a future schema bump reject older readers
+// loudly instead of silently mis-parsing. Bump on any breaking change
+// to ExportedFunction's field set. Default to 0 (an invalid version)
+// so JSON missing the key is rejected by the explicit version check
+// in `read_import` rather than silently treated as v1.
+struct public ExportEnvelope {
+    schema_version : int = 0
+    functions : array<ExportedFunction>
+}
+
+
+let public EXCHANGE_SCHEMA_VERSION = 1
+
+
+// Single source of truth for "given a canonical string, finish
+// populating the FuncRecord" — used both by the compile path
+// (`collect_from_program`) and by the import path. Keeps the two
+// in sync if tokenization or signing ever changes.
+//
+// Always (re)sets `sig`: when `want_sigs` is false (or token_count
+// is below the floor), `sig` is cleared so a reused record can't
+// carry a stale signature into fuzzy_pairs.
+def public derive_sig_and_count(var rec : FuncRecord; want_sigs : bool; min_tokens : int) {
+    let tokens <- tokenize_canonical(rec.canonical)
+    rec.token_count = length(tokens)
+    if (want_sigs && rec.token_count >= min_tokens) {
+        rec.sig <- minhash_signature(tokens)
+    } else {
+        rec.sig |> clear()
+    }
+}
+
+
+def public write_export(records : array<FuncRecord>; path : string) : bool {
+    var env = ExportEnvelope()
+    env.schema_version = EXCHANGE_SCHEMA_VERSION
+    env.functions |> reserve(length(records))
+    for (rec in records) {
+        var ef : ExportedFunction
+        ef.name := rec.ref.name
+        ef.file := rec.ref.file
+        ef.line = rec.ref.line
+        ef.is_lambda = rec.ref.is_lambda
+        ef.canonical := rec.canonical
+        env.functions |> emplace(ef)
+    }
+    let body = sprint_json(env, true)
+    var ok = false
+    fopen(path, "wb") $(fw) {
+        if (fw == null) {
+            return
+        }
+        ok = true
+        fw |> fprint(body)
+    }
+    return ok
+}
+
+
+// An imported function record is "well-formed" when it has a non-empty
+// canonical (the only field that affects clustering), a non-empty name
+// and file (so reports are interpretable), and a non-negative line.
+// Empty canonicals are the dangerous case: with `--min-tokens 0` they
+// would all collide in a single fake exact-cluster.
+def is_well_formed(ef : ExportedFunction) : bool {
+    return !empty(ef.canonical) && !empty(ef.name) && !empty(ef.file) && ef.line >= 0
+}
+
+
+def public read_import(path : string; var records : array<FuncRecord>;
+                       want_sigs : bool; min_tokens : int;
+                       var error : string&) : bool {
+    let text = fread(path)
+    if (empty(text)) {
+        error := "could not read file (empty or missing): {path}"
+        return false
+    }
+    var env = ExportEnvelope()
+    if (!sscan_json(text, env)) {
+        error := "could not parse JSON: {path}"
+        return false
+    }
+    if (env.schema_version != EXCHANGE_SCHEMA_VERSION) {
+        error := "unsupported schema_version {env.schema_version} (expected {EXCHANGE_SCHEMA_VERSION}): {path}"
+        return false
+    }
+    records |> reserve(length(records) + length(env.functions))
+    var skipped = 0
+    for (ef in env.functions) {
+        if (!is_well_formed(ef)) {
+            skipped++
+            continue
+        }
+        var rec = FuncRecord()
+        rec.ref.name := ef.name
+        rec.ref.file := ef.file
+        rec.ref.line = ef.line
+        rec.ref.is_lambda = ef.is_lambda
+        rec.canonical := ef.canonical
+        derive_sig_and_count(rec, want_sigs, min_tokens)
+        records |> emplace(rec)
+    }
+    if (skipped > 0) {
+        print("warning: skipped {skipped} malformed function record(s) during import\n")
+    }
+    return true
+}

--- a/utils/find_dupes/fixture/canonical_cases.das
+++ b/utils/find_dupes/fixture/canonical_cases.das
@@ -1,0 +1,92 @@
+options gen2
+
+
+// ── Alpha-rename equivalence ──────────────────────────────────────────
+// These three functions differ only in identifier names and parameter
+// types; CanonicalVisitor must collapse them all to the same tag stream
+// (var slots numbered by declaration order; TYP for any concrete type).
+def case_add_baseline(a, b : int) : int {
+    return a + b
+}
+
+def case_add_renamed(x, y : int) : int {
+    return x + y
+}
+
+def case_add_typed_float(a, b : float) : float {
+    return a + b
+}
+
+
+// ── Literal collapse ──────────────────────────────────────────────────
+// All numeric/string literals collapse to LIT regardless of value.
+def case_lit_one(a : int) : int {
+    return a + 1
+}
+
+def case_lit_big(a : int) : int {
+    return a + 999
+}
+
+
+// ── Call-name preservation ────────────────────────────────────────────
+// User identifier names collapse, but called function names are kept —
+// CALL:push vs CALL:reserve is real signal we want to surface.
+def case_call_push(var arr : array<int>) {
+    arr |> push(1)
+}
+
+def case_call_reserve(var arr : array<int>) {
+    arr |> reserve(1)
+}
+
+
+// ── Field access (.FLD) ───────────────────────────────────────────────
+struct CanonField {
+    value : int
+}
+
+def case_field_read(s : CanonField) : int {
+    return s.value
+}
+
+
+// ── Swizzle (.SWZ) ────────────────────────────────────────────────────
+def case_swizzle(v : float4) : float2 {
+    return v.xy
+}
+
+
+// ── While vs for ──────────────────────────────────────────────────────
+// for and while emit distinct loop markers (FOR vs WHILE).
+def case_while_loop(start : int) : int {
+    var x = start
+    while (x > 0) {
+        x -= 1
+    }
+    return x
+}
+
+def case_for_loop(arr : array<int>) : int {
+    var n = 0
+    for (v in arr) {
+        n = v
+    }
+    return n
+}
+
+
+// ── Lambda body (MK_BLK) ──────────────────────────────────────────────
+def case_lambda_use(var arr : array<int>) {
+    arr |> sort() <| $(a, b : int) => a < b
+}
+
+
+// ── let / var (LET_VAR) ───────────────────────────────────────────────
+// Initialize from a parameter so the optimizer can't fold the local
+// away — we want LET_VAR to appear in the canonical stream. The
+// canonical visitor emits LET_VAR for both `let` and `var` locals.
+def case_let_var(seed : int) : int {
+    let x = seed
+    return x + 1
+}

--- a/utils/find_dupes/main.das
+++ b/utils/find_dupes/main.das
@@ -12,6 +12,8 @@ require canonical
 require minhash
 require cluster
 require report
+require exchange
+require pipeline
 
 
 [CommandLineArgs]
@@ -46,15 +48,16 @@ struct Config {
     @clarg_doc = "Lambda-only mode: skip top-level functions, keep only lambdas (e.g. dastest run() bodies)"
     lambdas_only : bool
 
+    @clarg_doc = "Write all extracted functions to JSON and exit before clustering"
+    export_functions : string
+
+    @clarg_doc = "Load functions from a JSON file (produced by --export-functions) instead of compiling"
+    import_functions : string
+
     @clarg_short = "?"
     @clarg_name = "show-help"
     @clarg_doc = "Show this help and exit"
     help : bool
-}
-
-
-def normalize_path(p : string) : string {
-    return p |> replace("\\", "/")
 }
 
 
@@ -140,102 +143,6 @@ def scan_das_files(path : string; var files : array<string>; var cache : table<s
 }
 
 
-// Walk one compiled program and append a FuncRecord per user
-// function (lambdas included; only builtIn / generated skipped).
-//
-// Generic-template functions (e.g. dastest's `equal<T>`) get reified
-// into every caller's module, so without filtering we see hundreds of
-// copies of the same library helpers. The file-source filter drops
-// any function whose `at.fileInfo` points outside the file we just
-// compiled, leaving only what was actually written in that file.
-def collect_from_program(program : ProgramPtr; source_file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; lambdas_only : bool; want_sigs : bool; min_tokens : int) {
-    let thisMod = get_this_module(program)
-    let source_norm = normalize_path(source_file)
-    for_each_function(thisMod, "") $(func) {
-        if (func.flags.builtIn) {
-            return
-        }
-        // Lambdas are emitted as `generated` synthesized functions
-        // (`__lambda_function_at_line_xxx`). Default mode skips them via
-        // the generated filter (the dispatcher already references them
-        // via ADDR). Lambda-only mode lets them through and drops the
-        // top-level functions instead.
-        if (lambdas_only) {
-            if (!func.flags._lambda) {
-                return
-            }
-        } else {
-            if (func.flags.generated) {
-                return
-            }
-        }
-        let fn_file = (func.at.fileInfo != null) ? string(func.at.fileInfo.name) : ""
-        // Normalize both sides — Windows runners and recursive scans can
-        // mix separators / `./` prefixes, and a literal mismatch silently
-        // drops every function from a file that compiled fine.
-        if (normalize_path(fn_file) != source_norm) {
-            return
-        }
-        // Generic templates get reified per type (e.g. `test_conversions`
-        // reified for int8, uint16, uint, uint64). Each reification is a
-        // distinct FunctionPtr but they all point at the same source
-        // (file, line). Keep the first; the rest are reported as
-        // duplicates against themselves which is just noise.
-        let loc = "{fn_file}:{int(func.at.line)}"
-        if (key_exists(seen_loc, loc)) {
-            return
-        }
-        seen_loc |> insert(loc, null)
-        let canon = canonicalize_function(func)
-        if (empty(canon)) {
-            return
-        }
-        let tokens <- tokenize_canonical(canon)
-        var rec = FuncRecord()
-        rec.ref.file = fn_file
-        rec.ref.name = string(func.name)
-        rec.ref.line = int(func.at.line)
-        rec.ref.is_lambda = func.flags._lambda
-        rec.canonical := canon
-        rec.token_count = length(tokens)
-        // Skip signature work when fuzzy is disabled or when the function
-        // is below the noise floor — fuzzy_pairs filters those out anyway.
-        if (want_sigs && rec.token_count >= min_tokens) {
-            rec.sig <- minhash_signature(tokens)
-        }
-        records |> emplace(rec)
-    }
-}
-
-
-def compile_and_collect(file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; verbose : bool; lambdas_only : bool; want_sigs : bool; min_tokens : int) : bool {
-    var inscope access <- make_file_access("")
-    var ok_compile = true
-    using() $(var mg : ModuleGroup) {
-        using() $(var cop : CodeOfPolicies) {
-            cop.ignore_shared_modules = true
-            cop.export_all = true
-            // Leave optimisations and infer-time folding ON: dastest macros
-            // (e.g. unroll) need constant folding to compile, and folded-equal
-            // expressions are exactly the kind of duplicate we want to catch.
-            compile_file(file, access, unsafe(addr(mg)), cop) $(ok; program; issues) {
-                if (!ok) {
-                    ok_compile = false
-                    if (verbose) {
-                        print("FAIL {file}\n  {issues}\n")
-                    } else {
-                        print("FAIL {file}\n")
-                    }
-                    return
-                }
-                collect_from_program(program, file, records, seen_loc, lambdas_only, want_sigs, min_tokens)
-            }
-        }
-    }
-    return ok_compile
-}
-
-
 [export]
 def main() {
     var cfg = Config()
@@ -249,8 +156,18 @@ def main() {
         print_help(get_command_info(type<Config>), "find_dupes")
         return
     }
-    if (length(cfg.path) == 0) {
-        print("error: at least one --path is required\n\n")
+    let importing = !empty(cfg.import_functions)
+    let exporting = !empty(cfg.export_functions)
+    if (importing && length(cfg.path) > 0) {
+        print("error: --import-functions and --path are mutually exclusive\n")
+        return
+    }
+    if (importing && exporting) {
+        print("error: --import-functions and --export-functions are mutually exclusive (transcode is a no-op)\n")
+        return
+    }
+    if (!importing && length(cfg.path) == 0) {
+        print("error: at least one --path is required (or pass --import-functions)\n\n")
         print_help(get_command_info(type<Config>), "find_dupes")
         return
     }
@@ -272,37 +189,75 @@ def main() {
     let threshold = cfg.threshold
     let top = cfg.top
     let min_tokens = cfg.min_tokens
-    let want_sigs = !cfg.no_fuzzy
-
-    var files : array<string>
-    var cache : table<string; void?>
-    for (p in cfg.path) {
-        scan_das_files(p, files, cache)
-    }
-    if (length(files) == 0) {
-        print("error: no .das files found under given paths\n")
-        return
-    }
-    print("scanning {length(files)} file(s)...\n")
+    // Skip MinHash signing in export-only mode: signatures aren't
+    // written to the export and clustering is skipped, so the work
+    // would be discarded. Saves O(tokens × 64) per function on big
+    // shard runs.
+    let want_sigs = !cfg.no_fuzzy && !exporting
 
     var records : array<FuncRecord>
-    var seen_loc : table<string; void?>
-    var n_failed = 0
-    var n_skipped = 0
-    for (i in range(length(files))) {
-        let file = files[i]
-        if (cfg.verbose) {
-            print("[{i + 1}/{length(files)}] {file}\n")
+    var files_scanned = 0
+
+    if (importing) {
+        var ierr : string
+        if (!read_import(cfg.import_functions, records, want_sigs, min_tokens, ierr)) {
+            print("error: {ierr}\n")
+            return
         }
-        if (has_expect_directive(file)) {
-            n_skipped++
-            continue
+        print("loaded {length(records)} function record(s) from {cfg.import_functions}\n")
+    } else {
+        var files : array<string>
+        var cache : table<string; void?>
+        for (p in cfg.path) {
+            scan_das_files(p, files, cache)
         }
-        if (!compile_and_collect(file, records, seen_loc, cfg.verbose, cfg.lambdas_only, want_sigs, min_tokens)) {
-            n_failed++
+        if (length(files) == 0) {
+            print("error: no .das files found under given paths\n")
+            return
+        }
+        print("scanning {length(files)} file(s)...\n")
+
+        var seen_loc : table<string; void?>
+        var n_failed = 0
+        var n_skipped = 0
+        for (i in range(length(files))) {
+            let file = files[i]
+            if (cfg.verbose) {
+                print("[{i + 1}/{length(files)}] {file}\n")
+            }
+            if (has_expect_directive(file)) {
+                n_skipped++
+                continue
+            }
+            if (!compile_and_collect(file, records, seen_loc, cfg.verbose, cfg.lambdas_only, want_sigs, min_tokens)) {
+                n_failed++
+            }
+        }
+        files_scanned = length(files)
+        print("collected {length(records)} function record(s); {n_failed} compile failure(s), {n_skipped} skipped (expect-directive)\n")
+
+        if (exporting) {
+            // In export mode, treat compile failures as fatal —
+            // sharding scripts that merge multiple exports must be able
+            // to detect partial-failure runs, same reason write
+            // failures panic below. Best-effort export would silently
+            // ship an incomplete corpus.
+            if (n_failed > 0) {
+                print("error: {n_failed} compile failure(s); refusing to write partial export\n")
+                panic("find_dupes export failed: {n_failed} compile failure(s)")
+            }
+            if (write_export(records, cfg.export_functions)) {
+                print("wrote {length(records)} function(s) to {cfg.export_functions}\n")
+                return
+            }
+            // Use `panic` to surface a non-zero exit code so scripts
+            // sharding compile-then-merge across machines can detect
+            // partial-failure runs. The `error:` prefix matches the
+            // format used elsewhere for usage errors in this CLI.
+            print("error: could not write export to {cfg.export_functions}\n")
+            panic("find_dupes export failed")
         }
     }
-    print("collected {length(records)} function record(s); {n_failed} compile failure(s), {n_skipped} skipped (expect-directive)\n")
 
     print("clustering exact matches...\n")
     var clusters <- exact_buckets(records, min_tokens)
@@ -315,7 +270,7 @@ def main() {
     }
 
     var rep : Report
-    rep.summary.files_scanned = length(files)
+    rep.summary.files_scanned = files_scanned
     rep.summary.functions_analyzed = length(records)
     rep.summary.threshold = threshold
     rep.summary.min_tokens = min_tokens

--- a/utils/find_dupes/pipeline.das
+++ b/utils/find_dupes/pipeline.das
@@ -1,0 +1,103 @@
+options gen2
+
+require daslib/ast
+require daslib/ast_boost
+require strings
+require canonical
+require cluster
+require exchange
+
+
+def public normalize_path(p : string) : string {
+    return p |> replace("\\", "/")
+}
+
+
+// Walk one compiled program and append a FuncRecord per user
+// function (lambdas included; only builtIn / generated skipped).
+//
+// Generic-template functions (e.g. dastest's `equal<T>`) get reified
+// into every caller's module, so without filtering we see hundreds of
+// copies of the same library helpers. The file-source filter drops
+// any function whose `at.fileInfo` points outside the file we just
+// compiled, leaving only what was actually written in that file.
+def public collect_from_program(program : ProgramPtr; source_file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; lambdas_only : bool; want_sigs : bool; min_tokens : int) {
+    let thisMod = get_this_module(program)
+    let source_norm = normalize_path(source_file)
+    for_each_function(thisMod, "") $(func) {
+        if (func.flags.builtIn) {
+            return
+        }
+        // Lambdas are emitted as `generated` synthesized functions
+        // (`__lambda_function_at_line_xxx`). Default mode skips them via
+        // the generated filter (the dispatcher already references them
+        // via ADDR). Lambda-only mode lets them through and drops the
+        // top-level functions instead.
+        if (lambdas_only) {
+            if (!func.flags._lambda) {
+                return
+            }
+        } else {
+            if (func.flags.generated) {
+                return
+            }
+        }
+        let fn_file = (func.at.fileInfo != null) ? string(func.at.fileInfo.name) : ""
+        // Normalize slash direction — Windows runners can mix `\` and
+        // `/`, and a literal mismatch silently drops every function
+        // from a file that compiled fine.
+        if (normalize_path(fn_file) != source_norm) {
+            return
+        }
+        // Generic templates get reified per type (e.g. `test_conversions`
+        // reified for int8, uint16, uint, uint64). Each reification is a
+        // distinct FunctionPtr but they all point at the same source
+        // (file, line). Keep the first; the rest are reported as
+        // duplicates against themselves which is just noise.
+        let loc = "{fn_file}:{int(func.at.line)}"
+        if (key_exists(seen_loc, loc)) {
+            return
+        }
+        seen_loc |> insert(loc, null)
+        let canon = canonicalize_function(func)
+        if (empty(canon)) {
+            return
+        }
+        var rec = FuncRecord()
+        rec.ref.file = fn_file
+        rec.ref.name = string(func.name)
+        rec.ref.line = int(func.at.line)
+        rec.ref.is_lambda = func.flags._lambda
+        rec.canonical := canon
+        derive_sig_and_count(rec, want_sigs, min_tokens)
+        records |> emplace(rec)
+    }
+}
+
+
+def public compile_and_collect(file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; verbose : bool; lambdas_only : bool; want_sigs : bool; min_tokens : int) : bool {
+    var inscope access <- make_file_access("")
+    var ok_compile = true
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.ignore_shared_modules = true
+            cop.export_all = true
+            // Leave optimisations and infer-time folding ON: dastest macros
+            // (e.g. unroll) need constant folding to compile, and folded-equal
+            // expressions are exactly the kind of duplicate we want to catch.
+            compile_file(file, access, unsafe(addr(mg)), cop) $(ok; program; issues) {
+                if (!ok) {
+                    ok_compile = false
+                    if (verbose) {
+                        print("FAIL {file}\n  {issues}\n")
+                    } else {
+                        print("FAIL {file}\n")
+                    }
+                    return
+                }
+                collect_from_program(program, file, records, seen_loc, lambdas_only, want_sigs, min_tokens)
+            }
+        }
+    }
+    return ok_compile
+}

--- a/utils/find_dupes/test_find_dupes.das
+++ b/utils/find_dupes/test_find_dupes.das
@@ -1,0 +1,792 @@
+options gen2
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require strings
+require math
+require daslib/fio
+require daslib/json_boost
+
+require canonical
+require minhash
+require cluster
+require exchange
+require pipeline
+
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+def make_record(name : string; canonical : string; line : int; want_sigs : bool) : FuncRecord {
+    var rec = FuncRecord()
+    rec.ref.name := name
+    rec.ref.file := "test.das"
+    rec.ref.line = line
+    rec.ref.is_lambda = false
+    rec.canonical := canonical
+    derive_sig_and_count(rec, want_sigs, 0)
+    return <- rec
+}
+
+
+def find_canonical_by_name(records : array<FuncRecord>; name : string) : string {
+    for (rec in records) {
+        if (rec.ref.name == name) {
+            return rec.canonical
+        }
+    }
+    return ""
+}
+
+
+def find_record_by_name(records : array<FuncRecord>; name : string) : int {
+    for (i in range(length(records))) {
+        if (records[i].ref.name == name) {
+            return i
+        }
+    }
+    return -1
+}
+
+
+def cluster_has_member(c : Cluster; name : string) : bool {
+    for (m in c.members) {
+        if (m.name == name) {
+            return true
+        }
+    }
+    return false
+}
+
+
+def find_cluster_with_member(clusters : array<Cluster>; name : string) : int {
+    for (i in range(length(clusters))) {
+        if (cluster_has_member(clusters[i], name)) {
+            return i
+        }
+    }
+    return -1
+}
+
+
+def compile_fixture(file : string; var records : array<FuncRecord>; lambdas_only : bool; want_sigs : bool) : bool {
+    var seen_loc : table<string; void?>
+    return compile_and_collect(file, records, seen_loc, false, lambdas_only, want_sigs, 0)
+}
+
+
+def fabs_f(x : float) : float {
+    return x < 0.0f ? -x : x
+}
+
+
+// Compile fixture/canonical_cases.das for the canonical-visitor tests.
+// Wraps the failure assertion so individual tests can early-return on
+// compile failure instead of cascading into "" == "" false positives.
+def compile_canonical_fixture(t : T?; var records : array<FuncRecord>) : bool {
+    let ok = compile_fixture(CANONICAL_FIXTURE, records, false, false)
+    t |> success(ok, "canonical_cases.das compiled")
+    return ok
+}
+
+
+// Look up a function's canonical AND assert it's non-empty in one call.
+// Defends against silent passes where the fixture changed (function
+// renamed, removed) and `find_canonical_by_name` returns "" — naked
+// `t |> equal(a, b)` would still pass for "" == "".
+def find_canonical_required(t : T?; records : array<FuncRecord>; name : string) : string {
+    let canon = find_canonical_by_name(records, name)
+    t |> success(!empty(canon), "canonical present for {name}")
+    return canon
+}
+
+
+// ── tokenize_canonical ───────────────────────────────────────────────
+
+[test]
+def test_tokenize_basic(t : T?) {
+    let toks <- tokenize_canonical("A B C")
+    t |> equal(length(toks), 3)
+    t |> equal(toks[0], "A")
+    t |> equal(toks[1], "B")
+    t |> equal(toks[2], "C")
+}
+
+
+[test]
+def test_tokenize_empty(t : T?) {
+    let toks <- tokenize_canonical("")
+    t |> equal(length(toks), 0)
+}
+
+
+[test]
+def test_tokenize_collapses_whitespace(t : T?) {
+    let toks <- tokenize_canonical("  A   B  ")
+    t |> equal(length(toks), 2)
+    t |> equal(toks[0], "A")
+    t |> equal(toks[1], "B")
+}
+
+
+[test]
+def test_tokenize_trailing_space(t : T?) {
+    // CanonicalVisitor.emit() always trails a space; tokenize must drop
+    // that empty tail, not produce a phantom "" token.
+    let toks <- tokenize_canonical("FN ENDFN ")
+    t |> equal(length(toks), 2)
+}
+
+
+// ── minhash + jaccard ────────────────────────────────────────────────
+
+[test]
+def test_minhash_signature_length(t : T?) {
+    var toks : array<string>
+    toks |> push("alpha")
+    toks |> push("beta")
+    toks |> push("gamma")
+    let sig <- minhash_signature(toks)
+    t |> equal(length(sig), 64)
+}
+
+
+[test]
+def test_minhash_padding_for_short_input(t : T?) {
+    // 1 token is below N_GRAM (=5) — padding kicks in so we still get
+    // a stable 64-slot signature.
+    var toks : array<string>
+    toks |> push("only_one")
+    let sig <- minhash_signature(toks)
+    t |> equal(length(sig), 64)
+}
+
+
+[test]
+def test_minhash_deterministic(t : T?) {
+    var toks_a : array<string>
+    var toks_b : array<string>
+    for (i in range(20)) {
+        toks_a |> push("token_{i}")
+        toks_b |> push("token_{i}")
+    }
+    let sig_a <- minhash_signature(toks_a)
+    let sig_b <- minhash_signature(toks_b)
+    var all_match = true
+    for (i in range(length(sig_a))) {
+        if (sig_a[i] != sig_b[i]) {
+            all_match = false
+        }
+    }
+    t |> success(all_match, "signatures of identical token lists must match slot-for-slot")
+}
+
+
+[test]
+def test_jaccard_identical(t : T?) {
+    var toks : array<string>
+    for (i in range(15)) {
+        toks |> push("t{i}")
+    }
+    let sig_a <- minhash_signature(toks)
+    let sig_b <- minhash_signature(toks)
+    t |> equal(jaccard_estimate(sig_a, sig_b), 1.0f)
+}
+
+
+[test]
+def test_jaccard_empty(t : T?) {
+    let empty_a : array<uint64>
+    let empty_b : array<uint64>
+    t |> equal(jaccard_estimate(empty_a, empty_b), 0.0f)
+}
+
+
+[test]
+def test_jaccard_length_mismatch(t : T?) {
+    var toks : array<string>
+    toks |> push("x")
+    toks |> push("y")
+    let sig <- minhash_signature(toks)
+    var short_sig : array<uint64>
+    short_sig |> push(0ul)
+    t |> equal(jaccard_estimate(sig, short_sig), 0.0f)
+}
+
+
+[test]
+def test_jaccard_unrelated_low(t : T?) {
+    // Not asserting exactly 0 — MinHash with K=64 has ~1.5% slot
+    // resolution and rare collisions are normal. Just check the
+    // estimate is far below "duplicate" territory.
+    var toks_a : array<string>
+    var toks_b : array<string>
+    for (i in range(30)) {
+        toks_a |> push("aaa_{i}")
+        toks_b |> push("zzz_{i + 1000}")
+    }
+    let sig_a <- minhash_signature(toks_a)
+    let sig_b <- minhash_signature(toks_b)
+    let j = jaccard_estimate(sig_a, sig_b)
+    t |> success(j < 0.3f, "unrelated inputs should have jaccard < 0.3, got {j}")
+}
+
+
+// ── exact_buckets ────────────────────────────────────────────────────
+
+[test]
+def test_exact_groups_duplicates(t : T?) {
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("a", "FN ARG <var_0> RET <var_0> ENDFN", 1, false)
+    records |> emplace <| make_record("b", "FN ARG <var_0> RET <var_0> ENDFN", 2, false)
+    records |> emplace <| make_record("c", "FN ARG <var_0> RET LIT ENDFN", 3, false)
+    records |> emplace <| make_record("d", "FN ARG <var_0> RET <var_0> ENDFN", 4, false)
+    var clusters <- exact_buckets(records, 0)
+    // 3 records share canonical → 1 cluster of size 3; record "c" is
+    // alone → not reported.
+    t |> equal(length(clusters), 1)
+    t |> equal(length(clusters[0].members), 3)
+    t |> success(cluster_has_member(clusters[0], "a"), "cluster contains a")
+    t |> success(cluster_has_member(clusters[0], "b"), "cluster contains b")
+    t |> success(cluster_has_member(clusters[0], "d"), "cluster contains d")
+    t |> success(!cluster_has_member(clusters[0], "c"), "cluster does NOT contain c")
+}
+
+
+[test]
+def test_exact_min_tokens_filter(t : T?) {
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("a", "FN ENDFN", 1, false)            // 2 tokens
+    records |> emplace <| make_record("b", "FN ENDFN", 2, false)            // 2 tokens
+    records |> emplace <| make_record("c", "FN BODY BLK STMT ENDBLK ENDFN", 3, false)
+    records |> emplace <| make_record("d", "FN BODY BLK STMT ENDBLK ENDFN", 4, false)
+    var clusters <- exact_buckets(records, 5)
+    // a/b at 2 tokens are below min_tokens=5; only c/d remain.
+    t |> equal(length(clusters), 1)
+    t |> equal(length(clusters[0].members), 2)
+    t |> success(cluster_has_member(clusters[0], "c"), "c clustered")
+    t |> success(cluster_has_member(clusters[0], "d"), "d clustered")
+}
+
+
+[test]
+def test_exact_assigns_cluster_id(t : T?) {
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("a", "FN X Y Z ENDFN", 1, false)
+    records |> emplace <| make_record("b", "FN X Y Z ENDFN", 2, false)
+    records |> emplace <| make_record("c", "FN P Q R ENDFN", 3, false)
+    var clusters <- exact_buckets(records, 0)
+    let i_a = find_record_by_name(records, "a")
+    let i_b = find_record_by_name(records, "b")
+    let i_c = find_record_by_name(records, "c")
+    t |> success(records[i_a].cluster_id >= 0, "a got a cluster_id")
+    t |> success(records[i_b].cluster_id >= 0, "b got a cluster_id")
+    t |> equal(records[i_a].cluster_id, records[i_b].cluster_id)
+    t |> equal(records[i_c].cluster_id, -1)
+}
+
+
+[test]
+def test_exact_singleton_not_reported(t : T?) {
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("solo", "FN UNIQUE STREAM ENDFN", 1, false)
+    var clusters <- exact_buckets(records, 0)
+    t |> equal(length(clusters), 0)
+}
+
+
+// ── sort_clusters / sort_pairs ───────────────────────────────────────
+
+[test]
+def test_sort_clusters_by_size(t : T?) {
+    var records : array<FuncRecord>
+    // Two clusters: AAA size 2, BBB size 3. After sort, BBB comes first.
+    records |> emplace <| make_record("a1", "FN AAA ENDFN", 1, false)
+    records |> emplace <| make_record("a2", "FN AAA ENDFN", 2, false)
+    records |> emplace <| make_record("b1", "FN BBB ENDFN", 3, false)
+    records |> emplace <| make_record("b2", "FN BBB ENDFN", 4, false)
+    records |> emplace <| make_record("b3", "FN BBB ENDFN", 5, false)
+    var clusters <- exact_buckets(records, 0)
+    sort_clusters(clusters)
+    t |> equal(length(clusters), 2)
+    t |> equal(length(clusters[0].members), 3)
+    t |> equal(length(clusters[1].members), 2)
+    t |> success(cluster_has_member(clusters[0], "b1"), "size-3 cluster ranked first")
+}
+
+
+[test]
+def test_sort_pairs_by_similarity(t : T?) {
+    var pairs : array<FuzzyPair>
+    var p1 : FuzzyPair
+    p1.similarity = 0.75f
+    p1.a.name := "low_a"
+    p1.a.file := "f"
+    p1.a.line = 1
+    p1.b.name := "low_b"
+    p1.b.file := "f"
+    p1.b.line = 2
+    var p2 : FuzzyPair
+    p2.similarity = 0.95f
+    p2.a.name := "hi_a"
+    p2.a.file := "f"
+    p2.a.line = 3
+    p2.b.name := "hi_b"
+    p2.b.file := "f"
+    p2.b.line = 4
+    pairs |> emplace(p1)
+    pairs |> emplace(p2)
+    sort_pairs(pairs)
+    t |> equal(pairs[0].similarity, 0.95f)
+    t |> equal(pairs[1].similarity, 0.75f)
+}
+
+
+// ── fuzzy_pairs ──────────────────────────────────────────────────────
+
+[test]
+def test_fuzzy_near_duplicates_pair(t : T?) {
+    var records : array<FuncRecord>
+    // Two long, very similar canonicals — differ in one operator token.
+    let canon_a = "FN ARG <var_0> TYP BODY BLK STMT LET LET_VAR <var_1> LIT STMT FOR FOR_VAR <var_2> <var_0> FOR_BODY BLK STMT OP2:+= <var_1> <var_2> ENDBLK STMT RET <var_1> ENDBLK ENDFN"
+    let canon_b = "FN ARG <var_0> TYP BODY BLK STMT LET LET_VAR <var_1> LIT STMT FOR FOR_VAR <var_2> <var_0> FOR_BODY BLK STMT OP2:*= <var_1> <var_2> ENDBLK STMT RET <var_1> ENDBLK ENDFN"
+    records |> emplace <| make_record("a", canon_a, 1, true)
+    records |> emplace <| make_record("b", canon_b, 2, true)
+    var pairs <- fuzzy_pairs(records, 0.7f, 0)
+    t |> equal(length(pairs), 1)
+    t |> success(pairs[0].similarity >= 0.7f, "similarity above threshold, got {pairs[0].similarity}")
+}
+
+
+[test]
+def test_fuzzy_skips_identical(t : T?) {
+    // Same canonical text → exact-cluster territory; fuzzy pass must
+    // skip them so they're not double-counted.
+    var records : array<FuncRecord>
+    let canon = "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN"
+    records |> emplace <| make_record("a", canon, 1, true)
+    records |> emplace <| make_record("b", canon, 2, true)
+    var pairs <- fuzzy_pairs(records, 0.7f, 0)
+    t |> equal(length(pairs), 0)
+}
+
+
+[test]
+def test_fuzzy_skips_same_cluster(t : T?) {
+    // After exact_buckets stamps cluster_id on duplicates, fuzzy must
+    // skip intra-cluster pairs (avoids double-reporting).
+    var records : array<FuncRecord>
+    let canon = "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN"
+    records |> emplace <| make_record("a", canon, 1, true)
+    records |> emplace <| make_record("b", canon, 2, true)
+    var clusters <- exact_buckets(records, 0)
+    t |> equal(length(clusters), 1)
+    var pairs <- fuzzy_pairs(records, 0.7f, 0)
+    t |> equal(length(pairs), 0)
+}
+
+
+[test]
+def test_fuzzy_length_ratio_gate(t : T?) {
+    // Very different lengths → length_ratio gate drops the pair regardless
+    // of MinHash similarity.
+    var records : array<FuncRecord>
+    records |> emplace <| make_record(
+        "short",
+        "FN ARG <var_0> TYP BODY BLK STMT RET <var_0> ENDBLK ENDFN",
+        1, true)
+    records |> emplace <| make_record(
+        "long",
+        "FN ARG <var_0> TYP ARG <var_1> TYP ARG <var_2> TYP TYP BODY BLK STMT LET LET_VAR <var_3> LIT STMT FOR FOR_VAR <var_4> <var_0> FOR_BODY BLK STMT OP2:+= <var_3> <var_4> ENDBLK STMT FOR FOR_VAR <var_5> <var_1> FOR_BODY BLK STMT OP2:*= <var_3> <var_5> ENDBLK STMT RET <var_3> ENDBLK ENDFN",
+        2, true)
+    var pairs <- fuzzy_pairs(records, 0.7f, 0)
+    t |> equal(length(pairs), 0)
+}
+
+
+[test]
+def test_fuzzy_min_tokens_filter(t : T?) {
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("a", "FN A B C ENDFN", 1, true)
+    records |> emplace <| make_record("b", "FN A B C ENDFN", 2, true)
+    var pairs <- fuzzy_pairs(records, 0.7f, 100)
+    t |> equal(length(pairs), 0)
+}
+
+
+// ── exchange (export/import round-trip) ──────────────────────────────
+//
+// Each test creates its own temp file via `create_temp_file_result`
+// so the suite is portable across platforms (Windows CI has no /tmp)
+// and immune to leftover files from previous runs. The `remove(path)`
+// at the end cleans up.
+
+def make_temp_export_path(t : T?) : string {
+    let r = create_temp_file_result("find_dupes_test", ".json")
+    if (!(r is value)) {
+        t |> failure("create_temp_file_result failed: {unsafe(r.error)}")
+        return ""
+    }
+    return unsafe(r.value)
+}
+
+
+[test]
+def test_export_import_basic(t : T?) {
+    let path = make_temp_export_path(t)
+    if (empty(path)) return
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("alpha", "FN A B C ENDFN", 10, false)
+    records |> emplace <| make_record("beta", "FN X Y Z ENDFN", 20, false)
+    records[1].ref.is_lambda = true
+
+    let wrote = write_export(records, path)
+    t |> success(wrote, "write_export returned true")
+
+    var loaded : array<FuncRecord>
+    var err : string
+    let read_ok = read_import(path, loaded, false, 0, err)
+    t |> success(read_ok, "read_import returned true; err={err}")
+    t |> equal(length(loaded), 2)
+    t |> equal(loaded[0].ref.name, "alpha")
+    t |> equal(loaded[0].ref.line, 10)
+    t |> equal(loaded[0].ref.is_lambda, false)
+    t |> equal(loaded[0].canonical, "FN A B C ENDFN")
+    t |> equal(loaded[1].ref.name, "beta")
+    t |> equal(loaded[1].ref.is_lambda, true)
+    remove(path)
+}
+
+
+[test]
+def test_export_import_recomputes_sig(t : T?) {
+    let path = make_temp_export_path(t)
+    if (empty(path)) return
+    var records : array<FuncRecord>
+    records |> emplace <| make_record(
+        "x",
+        "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN",
+        1, false)
+    write_export(records, path)
+    var loaded : array<FuncRecord>
+    var err : string
+    read_import(path, loaded, true, 0, err)
+    t |> equal(length(loaded), 1)
+    t |> equal(length(loaded[0].sig), 64)
+    t |> success(loaded[0].token_count > 0, "token_count was recomputed")
+    remove(path)
+}
+
+
+[test]
+def test_export_import_skips_sig_when_no_fuzzy(t : T?) {
+    let path = make_temp_export_path(t)
+    if (empty(path)) return
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("x", "FN A B C D E F G H I J ENDFN", 1, false)
+    write_export(records, path)
+    var loaded : array<FuncRecord>
+    var err : string
+    read_import(path, loaded, false, 0, err)
+    t |> equal(length(loaded), 1)
+    t |> equal(length(loaded[0].sig), 0)
+    t |> success(loaded[0].token_count > 0, "token_count still computed")
+    remove(path)
+}
+
+
+[test]
+def test_import_missing_file(t : T?) {
+    // Create a temp file, immediately remove it — the path is now
+    // guaranteed-nonexistent and unique to this run.
+    let path = make_temp_export_path(t)
+    if (empty(path)) return
+    remove(path)
+    var loaded : array<FuncRecord>
+    var err : string
+    let ok = read_import(path, loaded, false, 0, err)
+    t |> success(!ok, "read_import returns false for missing file")
+    t |> success(!empty(err), "error message set")
+}
+
+
+[test]
+def test_import_malformed_json(t : T?) {
+    let path = make_temp_export_path(t)
+    if (empty(path)) return
+    fopen(path, "wb") $(fw) {
+        if (fw != null) {
+            fw |> fprint("this is not valid json !!!")
+        }
+    }
+    var loaded : array<FuncRecord>
+    var err : string
+    let ok = read_import(path, loaded, false, 0, err)
+    t |> success(!ok, "read_import returns false for garbage")
+    t |> success(!empty(err), "error message set")
+    remove(path)
+}
+
+
+[test]
+def test_import_bad_schema_version(t : T?) {
+    let path = make_temp_export_path(t)
+    if (empty(path)) return
+    var bad = ExportEnvelope()
+    bad.schema_version = 99
+    let body = sprint_json(bad, false)
+    fopen(path, "wb") $(fw) {
+        if (fw != null) {
+            fw |> fprint(body)
+        }
+    }
+    var loaded : array<FuncRecord>
+    var err : string
+    let ok = read_import(path, loaded, false, 0, err)
+    t |> success(!ok, "read_import rejects unknown schema_version")
+    t |> success(find(err, "schema_version") >= 0, "error mentions schema_version: {err}")
+    remove(path)
+}
+
+
+// ── derive_sig_and_count ─────────────────────────────────────────────
+
+[test]
+def test_derive_sig_and_count_no_sigs(t : T?) {
+    var rec = FuncRecord()
+    rec.canonical := "FN A B C D E ENDFN"
+    derive_sig_and_count(rec, false, 0)
+    t |> equal(rec.token_count, 7)
+    t |> equal(length(rec.sig), 0)
+}
+
+
+[test]
+def test_derive_sig_and_count_with_sigs(t : T?) {
+    var rec = FuncRecord()
+    rec.canonical := "FN A B C D E F G H I J K ENDFN"
+    derive_sig_and_count(rec, true, 0)
+    t |> equal(length(rec.sig), 64)
+}
+
+
+[test]
+def test_derive_sig_and_count_below_floor(t : T?) {
+    var rec = FuncRecord()
+    rec.canonical := "FN A B ENDFN"  // 4 tokens, below floor=100
+    derive_sig_and_count(rec, true, 100)
+    t |> equal(length(rec.sig), 0)
+    t |> equal(rec.token_count, 4)
+}
+
+
+// ── canonical visitor (compile fixture/canonical_cases.das) ──────────
+//
+// Each [test] re-compiles canonical_cases.das because non-copyable
+// `array<FuncRecord>` cannot be shared across `t |> run` lambda blocks
+// without unsafe-by-move capture. The fixture is small (~13 functions),
+// so per-test overhead is acceptable.
+
+let CANONICAL_FIXTURE = "utils/find_dupes/fixture/canonical_cases.das"
+
+
+[test]
+def test_canonical_alpha_rename(t : T?) {
+    var records : array<FuncRecord>
+    if (!compile_canonical_fixture(t, records)) return
+    let a = find_canonical_required(t, records, "case_add_baseline")
+    let b = find_canonical_required(t, records, "case_add_renamed")
+    t |> equal(a, b)
+}
+
+
+[test]
+def test_canonical_type_collapse(t : T?) {
+    var records : array<FuncRecord>
+    if (!compile_canonical_fixture(t, records)) return
+    let a = find_canonical_required(t, records, "case_add_baseline")
+    let c = find_canonical_required(t, records, "case_add_typed_float")
+    t |> equal(a, c)
+}
+
+
+[test]
+def test_canonical_literal_collapse(t : T?) {
+    var records : array<FuncRecord>
+    if (!compile_canonical_fixture(t, records)) return
+    let a = find_canonical_required(t, records, "case_lit_one")
+    let b = find_canonical_required(t, records, "case_lit_big")
+    t |> equal(a, b)
+    t |> success(find(a, "LIT") >= 0, "LIT token present")
+}
+
+
+[test]
+def test_canonical_call_name_preserved(t : T?) {
+    var records : array<FuncRecord>
+    if (!compile_canonical_fixture(t, records)) return
+    let a = find_canonical_required(t, records, "case_call_push")
+    let b = find_canonical_required(t, records, "case_call_reserve")
+    t |> success(a != b, "different called fns must produce different canonical")
+    t |> success(find(a, "push") >= 0, "case_call_push canonical mentions push")
+    t |> success(find(b, "reserve") >= 0, "case_call_reserve canonical mentions reserve")
+}
+
+
+[test]
+def test_canonical_field_marker(t : T?) {
+    var records : array<FuncRecord>
+    if (!compile_canonical_fixture(t, records)) return
+    let a = find_canonical_required(t, records, "case_field_read")
+    t |> success(find(a, ".FLD") >= 0, ".FLD token present in: {a}")
+}
+
+
+[test]
+def test_canonical_swizzle_marker(t : T?) {
+    var records : array<FuncRecord>
+    if (!compile_canonical_fixture(t, records)) return
+    let a = find_canonical_required(t, records, "case_swizzle")
+    t |> success(find(a, ".SWZ") >= 0, ".SWZ token present in: {a}")
+}
+
+
+[test]
+def test_canonical_for_vs_while(t : T?) {
+    var records : array<FuncRecord>
+    if (!compile_canonical_fixture(t, records)) return
+    let f = find_canonical_required(t, records, "case_for_loop")
+    let w = find_canonical_required(t, records, "case_while_loop")
+    t |> success(find(f, "FOR") >= 0, "FOR token in for-loop")
+    t |> success(find(w, "WHILE") >= 0, "WHILE token in while-loop")
+    t |> success(find(f, "WHILE") < 0, "no WHILE in for-loop")
+    t |> success(find(w, "FOR") < 0, "no FOR in while-loop")
+}
+
+
+[test]
+def test_canonical_lambda_emits_mk_blk(t : T?) {
+    var records : array<FuncRecord>
+    if (!compile_canonical_fixture(t, records)) return
+    let l = find_canonical_required(t, records, "case_lambda_use")
+    t |> success(find(l, "MK_BLK") >= 0, "MK_BLK present in lambda use: {l}")
+}
+
+
+[test]
+def test_canonical_let_var_token(t : T?) {
+    var records : array<FuncRecord>
+    if (!compile_canonical_fixture(t, records)) return
+    let a = find_canonical_required(t, records, "case_let_var")
+    t |> success(find(a, "LET_VAR") >= 0, "LET_VAR present in: {a}")
+}
+
+
+// ── end-to-end pipeline against fixture/synth.das ────────────────────
+
+let SYNTH_FIXTURE = "utils/find_dupes/fixture/synth.das"
+
+
+[test]
+def test_pipeline_synth_collects_functions(t : T?) {
+    var records : array<FuncRecord>
+    let ok = compile_fixture(SYNTH_FIXTURE, records, false, false)
+    t |> success(ok, "synth.das compiled")
+    // 8 user functions + main = 9 records when min_tokens=0.
+    t |> equal(length(records), 9)
+    t |> success(find_record_by_name(records, "add_int") >= 0, "add_int present")
+    t |> success(find_record_by_name(records, "loop_sum") >= 0, "loop_sum present")
+    t |> success(find_record_by_name(records, "with_lambda") >= 0, "with_lambda present")
+}
+
+
+[test]
+def test_pipeline_synth_exact_clusters(t : T?) {
+    var records : array<FuncRecord>
+    compile_fixture(SYNTH_FIXTURE, records, false, false)
+    var clusters <- exact_buckets(records, 0)
+    sort_clusters(clusters)
+    t |> equal(length(clusters), 2)
+    // First cluster: the three add_* functions (largest)
+    t |> equal(length(clusters[0].members), 3)
+    t |> success(cluster_has_member(clusters[0], "add_int"), "add_int in first cluster")
+    t |> success(cluster_has_member(clusters[0], "add_int_renamed_args"), "add_int_renamed_args")
+    t |> success(cluster_has_member(clusters[0], "add_float"), "add_float")
+    // Second cluster: the two with_lambda variants
+    t |> equal(length(clusters[1].members), 2)
+    t |> success(cluster_has_member(clusters[1], "with_lambda"), "with_lambda")
+    t |> success(cluster_has_member(clusters[1], "with_lambda_renamed"), "with_lambda_renamed")
+}
+
+
+[test]
+def test_pipeline_synth_fuzzy_pair(t : T?) {
+    var records : array<FuncRecord>
+    compile_fixture(SYNTH_FIXTURE, records, false, true)
+    var clusters <- exact_buckets(records, 0)
+    var pairs <- fuzzy_pairs(records, 0.7f, 0)
+    t |> equal(length(pairs), 1)
+    let names_match = (
+        (pairs[0].a.name == "loop_sum" && pairs[0].b.name == "loop_product") ||
+        (pairs[0].a.name == "loop_product" && pairs[0].b.name == "loop_sum"))
+    t |> success(names_match, "loop_sum/loop_product pair (got {pairs[0].a.name} / {pairs[0].b.name})")
+    t |> success(pairs[0].similarity >= 0.7f, "similarity above threshold: {pairs[0].similarity}")
+}
+
+
+[test]
+def test_pipeline_lambdas_only_mode(t : T?) {
+    var records : array<FuncRecord>
+    let ok = compile_fixture(SYNTH_FIXTURE, records, true, false)
+    t |> success(ok, "compile in lambdas-only mode")
+    // synth.das uses `$(...)` block syntax (not `@(...)` lambdas), so
+    // lambdas-only mode produces zero records. The point of this test
+    // is to verify the filter excludes top-level `def`s — no add_int,
+    // no main, regardless of how many actual lambdas the fixture has.
+    t |> equal(find_record_by_name(records, "add_int"), -1)
+    t |> equal(find_record_by_name(records, "main"), -1)
+    t |> equal(find_record_by_name(records, "loop_sum"), -1)
+    t |> equal(find_record_by_name(records, "with_lambda"), -1)
+    // Every surviving record (if any) must have is_lambda set.
+    for (rec in records) {
+        t |> success(rec.ref.is_lambda, "lambdas-only record has is_lambda=true: {rec.ref.name}")
+    }
+}
+
+
+[test]
+def test_pipeline_export_import_clusters_match(t : T?) {
+    let path = make_temp_export_path(t)
+    if (empty(path)) return
+    var records_compiled : array<FuncRecord>
+    compile_fixture(SYNTH_FIXTURE, records_compiled, false, true)
+    write_export(records_compiled, path)
+
+    var records_imported : array<FuncRecord>
+    var err : string
+    let read_ok = read_import(path, records_imported, true, 0, err)
+    t |> success(read_ok, "read_import OK; err={err}")
+
+    var c_compiled <- exact_buckets(records_compiled, 0)
+    var c_imported <- exact_buckets(records_imported, 0)
+    sort_clusters(c_compiled)
+    sort_clusters(c_imported)
+    t |> equal(length(c_compiled), length(c_imported))
+    for (i in range(length(c_compiled))) {
+        t |> equal(c_compiled[i].canonical_sample, c_imported[i].canonical_sample)
+        t |> equal(length(c_compiled[i].members), length(c_imported[i].members))
+    }
+
+    var p_compiled <- fuzzy_pairs(records_compiled, 0.7f, 0)
+    var p_imported <- fuzzy_pairs(records_imported, 0.7f, 0)
+    sort_pairs(p_compiled)
+    sort_pairs(p_imported)
+    t |> equal(length(p_compiled), length(p_imported))
+    for (i in range(length(p_compiled))) {
+        let diff = fabs_f(p_compiled[i].similarity - p_imported[i].similarity)
+        t |> success(diff < 1.0e-5f, "similarity matches: {p_compiled[i].similarity} vs {p_imported[i].similarity}")
+        t |> equal(p_compiled[i].canonical_a, p_imported[i].canonical_a)
+        t |> equal(p_compiled[i].canonical_b, p_imported[i].canonical_b)
+    }
+    remove(path)
+}


### PR DESCRIPTION
## Summary

- Adds `--export-functions <path>` / `--import-functions <path>` to `utils/find_dupes/main.das` so the post-canonicalization function list can be shipped to external tools (visualizers, custom clusterers, sharded compile-then-merge workflows) without re-running the daslang front-end. The existing `--json` flag (full Report including clusters + fuzzy pairs) is unchanged.
- Refactors the compile-and-collect orchestration out of `main.das` into a new `pipeline.das` module so the test suite can drive the pipeline directly. `main.das` becomes a thin CLI wrapper.
- Adds `test_find_dupes.das` — a 45-case dastest suite (~0.05s wall) covering tokenization, MinHash signatures and Jaccard estimates, exact clustering and sort determinism, fuzzy-pair detection (incl. length-ratio gate, same-cluster skip, min_tokens filter), exchange round-trip with negative paths, `derive_sig_and_count`, `CanonicalVisitor` against a new `fixture/canonical_cases.das` (one function per canonicalization concern: alpha-rename, type collapse, literal collapse, call-name preservation, `.FLD`, `.SWZ`, for-vs-while, MK_BLK, LET_VAR), and end-to-end against `fixture/synth.das` (collect, exact clusters, fuzzy pair, lambdas-only filter, export/import equivalence).

## On-disk schema (versioned)

```json
{
  "schema_version": 1,
  "functions": [
    { "name": "...", "file": "...", "line": N,
      "is_lambda": false, "canonical": "FN ARG <var_0> ..." }
  ]
}
```

MinHash signatures are not stored — they recompute deterministically on import.

## CLI semantics

- `--export-functions` exits before clustering (the export is the only thing you want when sharding).
- `--import-functions` is mutually exclusive with both `--path` and `--export-functions`.
- Schema-version mismatch and malformed/missing JSON yield clear errors.

## Test plan

- [x] `bin/daslang utils/find_dupes/main.das -- --path utils/find_dupes/fixture/synth.das --json /tmp/baseline.json --min-tokens 0` — baseline output matches before/after refactor (byte-identical).
- [x] Round-trip: `--export-functions` then `--import-functions` produces identical clusters and fuzzy pairs (only `files_scanned` differs: 1 vs 0).
- [x] Negative paths: `--path X --import-functions Y`, `--export-functions X --import-functions Y`, missing import file, `schema_version: 99` — all rejected with clear errors.
- [x] `bin/daslang dastest/dastest.das -- --test utils/find_dupes/test_find_dupes.das` — 45/45 pass.
- [x] `bin/daslang dastest/dastest.das -- --test tests/` — 6987 tests, 6981 pass, 0 fail, 0 errors, 6 skipped (matches master).
- [x] Lint clean on changed files (remaining warnings are advisory style/perf in test code).
- [x] All changed `.das` files MCP-formatted; named-arg spacing compatible with CI `das-fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)