### PR TITLE
dasSQLITE: chunk 4 — read-side depth (distinct, take/skip, order_by, aggregates, group_by, NULL)

### DIFF
--- a/daslib/linq_boost.das
+++ b/daslib/linq_boost.das
@@ -593,12 +593,19 @@ class private LinqGroupBy : AstCallMacro_LinqPred2 {
     //!   arr._group_by(_.City)._select((
     //!       City   = _._0,
     //!       N      = _._1 |> length,
-    //!       AvgAge = _._1 |> _select(_.Age) |> average()))
+    //!       AvgAge = _._1 |> select($(u : Person) => u.Age) |> average()))
     //!
-    //! SQL-style sugar (``_count()`` / ``_sum(_.X)`` / ``_avg(_.X)`` etc.
-    //! recognised as group-scope) lives in the ``_sql`` macro only —
-    //! ``_sql`` walks the whole chain expression at once and rewrites
-    //! these conveniences during SQL emission.
+    //! The inner ``select`` lambda parameter is intentionally **named**
+    //! (``$(u : Person)``), not ``_`` — the outer ``_select`` lambda
+    //! already binds ``_`` to the group tuple, and daslang flags a
+    //! same-name-different-type lambda nested inside as a shadowing
+    //! error. Naming the inner parameter sidesteps it.
+    //!
+    //! The ``_sql`` macro recognises this same shape (``_._0`` as the
+    //! group key column, ``_._1 |> length`` as ``COUNT(*)``,
+    //! ``_._1 |> select($(u:T) => u.X) |> sum()`` as ``SUM("X")``, and
+    //! the same pattern for ``average``/``min``/``max``) and emits
+    //! ``GROUP BY`` plus the corresponding SQL aggregates.
     override predName = "group_by_lazy"
 }
 

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -294,8 +294,15 @@ Run any tutorial from the project root::
    tutorials/sql_04_select_all.rst
    tutorials/sql_05_parametrized.rst
    tutorials/sql_06_error_handling.rst
+   tutorials/sql_07_anatomy.rst
    tutorials/sql_08_where.rst
    tutorials/sql_09_select.rst
+   tutorials/sql_10_order_by.rst
+   tutorials/sql_11_take_skip.rst
+   tutorials/sql_12_distinct.rst
+   tutorials/sql_13_aggregates.rst
+   tutorials/sql_14_group_by.rst
+   tutorials/sql_18_null_handling.rst
 
 .. _tutorials_dasaudio:
 

--- a/doc/source/reference/tutorials/sql_06_error_handling.rst
+++ b/doc/source/reference/tutorials/sql_06_error_handling.rst
@@ -123,4 +123,4 @@ Form                                                            When to use
 
     Previous tutorial: :ref:`tutorial_sql_parametrized`
 
-    Next tutorial: :ref:`tutorial_sql_where`
+    Next tutorial: :ref:`tutorial_sql_anatomy`

--- a/doc/source/reference/tutorials/sql_07_anatomy.rst
+++ b/doc/source/reference/tutorials/sql_07_anatomy.rst
@@ -1,0 +1,145 @@
+.. _tutorial_sql_anatomy:
+
+================================
+SQL-07 --- Anatomy of ``_sql``
+================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; _sql
+    single: Tutorial; _sql_text
+    single: Tutorial; macro
+    single: Tutorial; bind parameter
+
+``_sql(chain)`` is a compile-time macro. It walks a daslib/linq-shaped
+chain, classifies each operator, and emits a SQL string plus a list
+of bind expressions. By the time the program runs, the chain is gone
+--- only the SQL and the binds remain. There is no runtime
+LINQ-to-SQL inspection.
+
+Three moving parts
+==================
+
+==============================================  ================================================================
+Source shape                                    Compile-time translation
+==============================================  ================================================================
+``_.Field``                                     quoted column identifier (``"Field"``)
+free variable, literal                          ``?`` bind parameter
+recognized operator / function call             SQL operator (``=``, ``<``, ``AND``, ``LIKE``, ``COALESCE``, ...)
+==============================================  ================================================================
+
+Anything outside that surface raises a compile-time ``macro_error``
+pointing at the offending node.
+
+Inspecting the SQL with ``_sql_text``
+=====================================
+
+``_sql_text`` shares the analyzer with ``_sql`` and returns the SQL
+string instead of running it. The ``?`` placeholders show where each
+bind goes:
+
+.. code-block:: das
+
+    let sql1 = _sql_text(db |> select_from(type<Car>)
+                           |> _where(_.Price > 100))
+    // SELECT "Id", "Name", "Price" FROM "Cars" WHERE "Price" > ?
+
+This is the primary debugging tool for ``_sql`` chains --- when the
+chain grows, ``_sql_text`` makes the macro's view of it visible
+without a database round-trip.
+
+Captured-vs-literal binding
+===========================
+
+A captured local becomes a bind. A literal *also* becomes a bind ---
+the analyzer doesn't bother distinguishing, because keeping the SQL
+parameterized either way is the safe-by-default behavior:
+
+.. code-block:: das
+
+    let cutoff = 150
+    let sql2 = _sql_text(db |> select_from(type<Car>)
+                           |> _where(_.Price > cutoff))
+    // SELECT "Id", "Name", "Price" FROM "Cars" WHERE "Price" > ?
+
+Column-side detection is symmetric --- the analyzer recognizes
+``_.Field`` as a column on whichever side of an operator it appears:
+
+.. code-block:: das
+
+    _where(_.Price > cutoff)    // WHERE "Price" > ?
+    _where(cutoff < _.Price)    // WHERE ? < "Price"
+
+Composing ``_where``
+====================
+
+Each ``_where`` adds another ``AND`` conjunct:
+
+.. code-block:: das
+
+    _sql(db |> select_from(type<Car>)
+           |> _where(_.Price > 100)
+           |> _where(_.Name |> starts_with("T")))
+    // ... WHERE ("Name" LIKE ? || '%') AND ("Price" > ?)
+
+The full ``_where`` translation surface lives in
+:ref:`tutorial_sql_where`.
+
+The raw-SQL escape hatch
+========================
+
+For SQL the macro can't or shouldn't translate (DDL, vendor-specific
+statements, dynamic SQL), drop down to the raw-SQL helpers covered in
+:ref:`tutorial_sql_parametrized`:
+
+==========================================================  =====================================================
+Helper                                                      Purpose
+==========================================================  =====================================================
+``db |> exec(sql)``                                         run a statement, no result
+``db |> query_scalar(sql, type<T>)``                        SELECT one column from one row
+``db |> query_one(sql, type<T>, args...)``                  SELECT one row, build a struct
+``db |> query_one_opt(sql, type<T>, args...)``              same, but ``Option<T>`` if no row
+==========================================================  =====================================================
+
+Bind parameters are positional ``?`` --- pass values as trailing
+arguments.
+
+The translation surface in one glance
+=====================================
+
+Tutorials 7-18 cover the full read-side translation. Each one shows
+its operator's recognized shapes and the SQL the macro emits:
+
+================================================  =========================================================
+Tutorial                                          Surface
+================================================  =========================================================
+:ref:`tutorial_sql_where`                         predicates: ``==``, ``<``, ``&&``, ``starts_with``, ...
+:ref:`tutorial_sql_select`                        projections: ``_.Field``, named tuples
+:ref:`tutorial_sql_order_by`                      ``_order_by``, ``_order_by_descending``
+:ref:`tutorial_sql_take_skip`                     ``take`` / ``skip`` (LIMIT / OFFSET)
+:ref:`tutorial_sql_distinct`                      ``distinct``
+:ref:`tutorial_sql_aggregates`                    ``count`` / ``sum`` / ``average`` / ``min`` / ``max``
+:ref:`tutorial_sql_group_by`                      ``_group_by`` + ``_having``
+:ref:`tutorial_sql_null_handling`                 ``Option<T>`` columns + ``is_some`` / ``is_none`` / ``unwrap_or``
+================================================  =========================================================
+
+What ``_sql`` refuses
+=====================
+
+If you write a shape outside the translation table --- an arbitrary
+user-defined function in ``_where``, an unsupported math op, a regex
+--- compile fails with ``macro_error`` pointing at the offending
+node. Two responses:
+
+- Add the rule to the analyzer (fork-and-extend) if the pattern is
+  reusable across queries.
+- Use the raw-SQL escape hatch above for one-offs.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/07-anatomy.das <../../../../tutorials/sql/07-anatomy.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_error_handling`
+
+    Next tutorial: :ref:`tutorial_sql_where`

--- a/doc/source/reference/tutorials/sql_08_where.rst
+++ b/doc/source/reference/tutorials/sql_08_where.rst
@@ -139,6 +139,6 @@ node. For those cases, drop down to the raw-SQL escape hatch
 
     Full source: :download:`tutorials/sql/08-where.das <../../../../tutorials/sql/08-where.das>`
 
-    Previous tutorial: :ref:`tutorial_sql_error_handling`
+    Previous tutorial: :ref:`tutorial_sql_anatomy`
 
     Next tutorial: :ref:`tutorial_sql_select`

--- a/doc/source/reference/tutorials/sql_09_select.rst
+++ b/doc/source/reference/tutorials/sql_09_select.rst
@@ -135,3 +135,5 @@ the same result via named-tuple projection.
     Full source: :download:`tutorials/sql/09-select.das <../../../../tutorials/sql/09-select.das>`
 
     Previous tutorial: :ref:`tutorial_sql_where`
+
+    Next tutorial: :ref:`tutorial_sql_order_by`

--- a/doc/source/reference/tutorials/sql_10_order_by.rst
+++ b/doc/source/reference/tutorials/sql_10_order_by.rst
@@ -1,0 +1,97 @@
+.. _tutorial_sql_order_by:
+
+=======================================================
+SQL-10 --- ``_order_by`` and ``_order_by_descending``
+=======================================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; _order_by
+    single: Tutorial; ORDER BY
+    single: Tutorial; tuple key
+
+``_order_by(key)`` adds an ``ORDER BY`` clause. The key shape decides
+what the macro emits:
+
+==============================================  ===========================================
+Key shape                                       Emitted SQL
+==============================================  ===========================================
+``_.Field``                                     ``ORDER BY "Field" ASC``
+``(_.k1, _.k2, ...)``                           ``ORDER BY "k1" ASC, "k2" ASC, ...``
+``_order_by_descending(_.Field)``               ``ORDER BY "Field" DESC``
+==============================================  ===========================================
+
+Single-column order
+===================
+
+.. code-block:: das
+
+    let by_price <- _sql(db |> select_from(type<Car>)
+                           |> _order_by(_.Price))
+    // SELECT "Id", "Name", "Price" FROM "Cars" ORDER BY "Price" ASC
+
+``_order_by_descending`` flips the direction:
+
+.. code-block:: das
+
+    let by_price_desc <- _sql(db |> select_from(type<Car>)
+                                |> _order_by_descending(_.Price))
+    // ... ORDER BY "Price" DESC
+
+Multi-column tuple key
+======================
+
+A tuple-shaped key emits each tuple field as its own ``ORDER BY``
+column. Useful for primary-and-tie-breaker ordering:
+
+.. code-block:: das
+
+    let by_price_then_name <- _sql(db |> select_from(type<Car>)
+                                     |> _order_by((_.Price, _.Name)))
+    // ... ORDER BY "Price" ASC, "Name" ASC
+
+If two rows tie on ``Price``, the second column breaks the tie.
+
+Mixed ASC/DESC
+==============
+
+A single ``_order_by`` step emits all columns in the same direction.
+Mixed ASC/DESC across columns (e.g. ``ORDER BY a ASC, b DESC``) is
+**out of chunk-4 scope**. Until a marker syntax lands, drop down to
+the raw-SQL escape hatch (``query_one`` / ``query_scalar`` /
+``exec``) when you need it.
+
+Composes with ``_where`` and ``take``
+=====================================
+
+``_order_by`` is just another chain stage --- it composes with
+filter, project, paginate, and aggregate operators in the natural
+SQL order:
+
+.. code-block:: das
+
+    let cheap_top3 <- _sql(db |> select_from(type<Car>)
+                             |> _where(_.Price > 50)
+                             |> _order_by(_.Price)
+                             |> take(3))
+    // ... WHERE "Price" > ? ORDER BY "Price" ASC LIMIT ?
+
+Note the SQL clause order: ``WHERE`` first, ``ORDER BY`` next,
+``LIMIT`` last --- same as the chain order.
+
+Stable pagination
+=================
+
+``LIMIT``/``OFFSET`` without ``ORDER BY`` is non-deterministic ---
+SQLite is free to return rows in any order. Pair ``take``/``skip``
+with ``_order_by`` whenever you actually care about page boundaries.
+See :ref:`tutorial_sql_take_skip`.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/10-order_by.das <../../../../tutorials/sql/10-order_by.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_select`
+
+    Next tutorial: :ref:`tutorial_sql_take_skip`

--- a/doc/source/reference/tutorials/sql_11_take_skip.rst
+++ b/doc/source/reference/tutorials/sql_11_take_skip.rst
@@ -1,0 +1,108 @@
+.. _tutorial_sql_take_skip:
+
+==========================================
+SQL-11 --- ``take`` and ``skip``: Paging
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; take
+    single: Tutorial; skip
+    single: Tutorial; LIMIT
+    single: Tutorial; OFFSET
+    single: Tutorial; pagination
+
+==============================================  =================================================
+Source shape                                    Emitted SQL
+==============================================  =================================================
+``take(n)``                                     ``LIMIT ?``
+``skip(n)`` (alone)                             ``LIMIT -1 OFFSET ?``
+``take(n) |> skip(m)``                          ``LIMIT ? OFFSET ?``
+``take`` followed by ``_first()``               ``LIMIT 1`` (single-row terminal wins)
+==============================================  =================================================
+
+``take(n)`` --- LIMIT
+=====================
+
+.. code-block:: das
+
+    let first_two <- _sql(db |> select_from(type<Car>) |> take(2))
+    // SELECT "Id", "Name", "Price" FROM "Cars" LIMIT ?
+
+``skip(n)`` --- OFFSET
+======================
+
+SQLite requires a ``LIMIT`` whenever ``OFFSET`` is present, so a
+bare ``skip(n)`` emits ``LIMIT -1 OFFSET ?`` (``LIMIT -1`` is
+SQLite's "no limit"):
+
+.. code-block:: das
+
+    let after_three <- _sql(db |> select_from(type<Car>) |> skip(3))
+    // SELECT "Id", "Name", "Price" FROM "Cars" LIMIT -1 OFFSET ?
+
+Combined --- a paging window
+============================
+
+Combine ``take`` and ``skip`` for a window. Order in the chain
+doesn't change the SQL --- the macro accumulates both into a single
+``LIMIT ... OFFSET ...`` clause. Note that ``take(n) skip(m)`` is
+``LIMIT n OFFSET m`` --- rows ``m..m+n-1``, NOT "page (m+1) of
+size n" --- standard paging is ``page k of size n`` =
+``take(n) skip((k-1) * n)``:
+
+.. code-block:: das
+
+    let window <- _sql(db |> select_from(type<Car>) |> take(2) |> skip(1))
+    // ... LIMIT ? OFFSET ?     (rows 2..3)
+
+Bind ordering
+=============
+
+LIMIT and OFFSET binds always go *after* WHERE binds in the
+placeholder index sequence. A ``_where(...) |> take(n)`` chain
+produces ``WHERE col > ? LIMIT ?`` with binds in
+``[wherevalue, n]`` order:
+
+.. code-block:: das
+
+    let threshold = 100
+    let cheap_two <- _sql(db |> select_from(type<Car>)
+                            |> _where(_.Price > threshold)
+                            |> take(2))
+    // SELECT ... WHERE "Price" > ? LIMIT ?     binds: [100, 2]
+
+Single-row terminals override ``take``
+======================================
+
+``_first`` and ``_first_opt`` always emit ``LIMIT 1``, ignoring any
+earlier ``take``. The terminal's intent (one row) overrides the
+chain's pagination hint:
+
+.. code-block:: das
+
+    let head = _sql(db |> select_from(type<Car>) |> take(5) |> _first())
+    // ... LIMIT 1
+
+Stable pagination needs ``_order_by``
+=====================================
+
+``LIMIT``/``OFFSET`` without ``ORDER BY`` isn't deterministic ---
+SQLite can return rows in any order. Pair ``take``/``skip`` with
+:ref:`tutorial_sql_order_by` whenever the page boundaries matter:
+
+.. code-block:: das
+
+    let stable_page <- _sql(db |> select_from(type<Car>)
+                              |> _order_by(_.Price)
+                              |> take(2) |> skip(1))
+    // ... ORDER BY "Price" ASC LIMIT ? OFFSET ?
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/11-take_skip.das <../../../../tutorials/sql/11-take_skip.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_order_by`
+
+    Next tutorial: :ref:`tutorial_sql_distinct`

--- a/doc/source/reference/tutorials/sql_12_distinct.rst
+++ b/doc/source/reference/tutorials/sql_12_distinct.rst
@@ -1,0 +1,73 @@
+.. _tutorial_sql_distinct:
+
+==================================
+SQL-12 --- ``distinct``
+==================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; distinct
+    single: Tutorial; DISTINCT
+    single: Tutorial; UNION
+
+``distinct()`` flips a single bool flag on the analyzer's
+``SqlQuery`` and emits ``SELECT DISTINCT`` instead of plain
+``SELECT``. The rest of the chain (column list, ``WHERE``,
+``ORDER BY``, ``LIMIT``) composes normally.
+
+Full-row DISTINCT
+=================
+
+Without a ``_select``, every column is in the row --- DISTINCT
+deduplicates whole rows:
+
+.. code-block:: das
+
+    let all_rows <- _sql(db |> select_from(type<Car>) |> distinct())
+    // SELECT DISTINCT "Id", "Name", "Price" FROM "Cars"
+
+Single-column DISTINCT
+======================
+
+Project one column with ``_select(_.Field)`` and dedupe it:
+
+.. code-block:: das
+
+    let names <- _sql(db |> select_from(type<Car>)
+                        |> _select(_.Name)
+                        |> distinct())
+    // SELECT DISTINCT "Name" FROM "Cars"
+
+Composes with ``_where``
+========================
+
+.. code-block:: das
+
+    let names_over_100 <- _sql(db |> select_from(type<Car>)
+                                 |> _where(_.Price > 100)
+                                 |> _select(_.Name)
+                                 |> distinct())
+    // SELECT DISTINCT "Name" FROM "Cars" WHERE "Price" > ?
+
+Set operations --- deferred
+===========================
+
+``UNION`` / ``INTERSECT`` / ``EXCEPT`` are **out of chunk-4 scope**.
+The chain analyzer is single-source today: every ``SELECT`` comes
+from one ``select_from(type<T>)``. Set operations bring in a second
+``SqlQuery`` and need a multi-stage emitter --- the same engine work
+joins and subqueries need.
+
+Until that lands, work around set ops via the raw-SQL escape hatch
+(``db |> exec(...)`` for DDL plus ``CREATE TEMP VIEW``, then
+``select_from`` the view; or drive the SQLite C API directly for
+multi-row reads of arbitrary SQL).
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/12-distinct.das <../../../../tutorials/sql/12-distinct.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_take_skip`
+
+    Next tutorial: :ref:`tutorial_sql_aggregates`

--- a/doc/source/reference/tutorials/sql_13_aggregates.rst
+++ b/doc/source/reference/tutorials/sql_13_aggregates.rst
@@ -1,0 +1,93 @@
+.. _tutorial_sql_aggregates:
+
+==========================================
+SQL-13 --- Aggregates: ``sum``/``avg``/...
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; aggregate
+    single: Tutorial; SUM
+    single: Tutorial; AVG
+    single: Tutorial; MIN
+    single: Tutorial; MAX
+    single: Tutorial; COUNT
+
+==============================================  ============================  ========================
+Source shape                                    Emitted SQL                   Result type
+==============================================  ============================  ========================
+``... |> count()``                              ``SELECT COUNT(*) ...``       ``int``
+``... |> _select(_.Col) |> sum()``              ``SELECT SUM("Col") ...``     column type
+``... |> _select(_.Col) |> average()``          ``SELECT AVG("Col") ...``     ``double``
+``... |> _select(_.Col) |> min()``              ``SELECT MIN("Col") ...``     column type
+``... |> _select(_.Col) |> max()``              ``SELECT MAX("Col") ...``     column type
+==============================================  ============================  ========================
+
+All five are *terminals* --- they end the chain and produce a
+scalar, not an array. The four column-driven aggregates need a
+``_select(_.Col)`` to pick the column; ``count`` operates on rows,
+not values, and stands alone.
+
+``count`` --- whole-source row count
+====================================
+
+.. code-block:: das
+
+    let n = _sql(db |> select_from(type<Car>) |> count())
+    // SELECT COUNT(*) FROM "Cars"
+
+``count`` returns ``int`` --- matching daslang's ``length(arr)``
+return type --- not ``int64``. SQLite's underlying ``COUNT`` returns
+``int64``; the column-reader narrows to ``int``.
+
+``sum`` / ``min`` / ``max`` --- inherit column type
+===================================================
+
+.. code-block:: das
+
+    let total    = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> sum())
+    let cheapest = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> min())
+    let priciest = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> max())
+
+The result element type matches the projected column. ``Price`` is
+``int``, so ``total`` is ``int``; ``Price`` of type ``int64`` would
+produce ``int64``.
+
+``average`` --- always promotes to ``double``
+=============================================
+
+.. code-block:: das
+
+    let mean = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> average())
+    // SELECT AVG("Price") FROM "Cars"     -- result type: double
+
+Composing with ``_where``
+=========================
+
+A ``_where`` predicate filters the input rows the aggregate sees:
+
+.. code-block:: das
+
+    let cutoff = 100
+    let total_over_100 = _sql(db |> select_from(type<Car>)
+                                |> _where(_.Price > cutoff)
+                                |> _select(_.Price)
+                                |> sum())
+    // SELECT SUM("Price") FROM "Cars" WHERE "Price" > ?
+
+Per-bucket aggregates --- ``_group_by``
+=======================================
+
+Aggregates inside ``_group_by`` are covered in
+:ref:`tutorial_sql_group_by`. There the same primitives
+(``length`` / ``sum`` / ``average`` / ``min`` / ``max``) appear
+inside an inner ``select`` lambda over the group elements.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/13-aggregates.das <../../../../tutorials/sql/13-aggregates.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_distinct`
+
+    Next tutorial: :ref:`tutorial_sql_group_by`

--- a/doc/source/reference/tutorials/sql_14_group_by.rst
+++ b/doc/source/reference/tutorials/sql_14_group_by.rst
@@ -1,0 +1,150 @@
+.. _tutorial_sql_group_by:
+
+==========================================
+SQL-14 --- ``_group_by`` and ``_having``
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; _group_by
+    single: Tutorial; _having
+    single: Tutorial; GROUP BY
+    single: Tutorial; HAVING
+    single: Tutorial; IGrouping
+    single: Tutorial; aggregate
+
+``_group_by(key)`` partitions rows into buckets. After grouping, the
+chain element is a (key, group-rows) tuple shaped like C# LINQ's
+``IGrouping<K, T>``:
+
+==========================================  =============================================
+Group-tuple shape                           Meaning
+==========================================  =============================================
+``_._0``                                    group key (single-key form)
+``_._0._N``                                 N-th key column (multi-key form)
+``_._1``                                    array of rows in this bucket
+==========================================  =============================================
+
+Aggregating over the group
+==========================
+
+The macro recognizes a fixed set of pipe shapes on ``_._1``:
+
+==================================================================  ==============================
+Source shape                                                        Emitted SQL
+==================================================================  ==============================
+``_._1 |> length``                                                  ``COUNT(*)``
+``_._1 |> count``                                                   ``COUNT(*)`` (alias)
+``_._1 |> select($(u : T) => u.Field) |> sum``                      ``SUM("Field")``
+``_._1 |> select($(u : T) => u.Field) |> average``                  ``AVG("Field")``
+``_._1 |> select($(u : T) => u.Field) |> min``                      ``MIN("Field")``
+``_._1 |> select($(u : T) => u.Field) |> max``                      ``MAX("Field")``
+==================================================================  ==============================
+
+The inner ``select`` lambda parameter is intentionally **named**
+(``$(u : User)``), not ``_``. The outer ``_select`` lambda already
+binds ``_`` to the group tuple, and daslang flags a same-name-
+different-type lambda nested inside as a shadowing error. Naming the
+inner parameter sidesteps the conflict; the macro recognizes the
+body as ``<param>.<field>`` for any parameter name.
+
+Single-key grouping
+===================
+
+.. code-block:: das
+
+    let by_city <- _sql(db |> select_from(type<User>)
+                          |> _group_by(_.City)
+                          |> _order_by(_._0)
+                          |> _select((City = _._0, N = _._1 |> length)))
+    // SELECT "City", COUNT(*) FROM "Users" GROUP BY "City"
+
+Multiple aggregates in one projection
+=====================================
+
+.. code-block:: das
+
+    let stats <- _sql(db |> select_from(type<User>)
+                        |> _group_by(_.City)
+                        |> _select((
+                            City   = _._0,
+                            N      = _._1 |> length,
+                            MinAge = _._1 |> select($(u : User) => u.Age)    |> min,
+                            MaxAge = _._1 |> select($(u : User) => u.Age)    |> max,
+                            Total  = _._1 |> select($(u : User) => u.Salary) |> sum)))
+
+Pre-aggregate filter --- ``_where``
+===================================
+
+``_where`` before ``_group_by`` filters input rows --- it lowers to
+``WHERE`` (pre-aggregate). The macro routes binds correctly: WHERE
+binds first, then HAVING, then LIMIT.
+
+.. code-block:: das
+
+    _sql(db |> select_from(type<User>)
+           |> _where(_.Age >= 30)
+           |> _group_by(_.City)
+           |> _select((City = _._0, N = _._1 |> length)))
+    // ... WHERE "Age" >= ? GROUP BY "City"
+
+Post-aggregate filter --- ``_having``
+=====================================
+
+``_having(predicate)`` filters on the aggregated buckets. It sits
+between ``_group_by`` and the projection. Aggregate expressions
+inside ``_having`` translate the same way as inside ``_select``:
+
+.. code-block:: das
+
+    _sql(db |> select_from(type<User>)
+           |> _group_by(_.City)
+           |> _having(_._1 |> length > 1)
+           |> _select((City = _._0, N = _._1 |> length)))
+    // SELECT "City", COUNT(*) FROM "Users"
+    // GROUP BY "City" HAVING COUNT(*) > ?
+
+Multi-key grouping
+==================
+
+Pass a tuple to ``_group_by``. Each tuple field becomes its own
+``GROUP BY`` column. Project the keys with ``_._0._N``:
+
+.. code-block:: das
+
+    _sql(db |> select_from(type<User>)
+           |> _group_by((_.City, _.Age))
+           |> _select((City = _._0._0, Age = _._0._1, N = _._1 |> length)))
+    // SELECT "City", "Age", COUNT(*) FROM "Users"
+    // GROUP BY "City", "Age"
+
+The full reporting query
+========================
+
+The chain mirrors SQL clause order one-for-one:
+
+.. code-block:: das
+
+    let report <- _sql(db |> select_from(type<User>)
+                         |> _where(_.Age >= min_age)
+                         |> _group_by(_.City)
+                         |> _having(_._1 |> length >= min_count)
+                         |> _order_by(_._0)
+                         |> _select((
+                             City      = _._0,
+                             N         = _._1 |> length,
+                             AvgSalary = _._1 |> select($(u : User) => u.Salary) |> average))
+                         |> take(10))
+
+    // SELECT "City", COUNT(*), AVG("Salary") FROM "Users"
+    // WHERE "Age" >= ? GROUP BY "City" HAVING COUNT(*) >= ?
+    // ORDER BY "City" ASC LIMIT ?
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/14-group_by.das <../../../../tutorials/sql/14-group_by.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_aggregates`
+
+    Next tutorial: :ref:`tutorial_sql_null_handling`

--- a/doc/source/reference/tutorials/sql_18_null_handling.rst
+++ b/doc/source/reference/tutorials/sql_18_null_handling.rst
@@ -1,0 +1,172 @@
+.. _tutorial_sql_null_handling:
+
+==================================================
+SQL-18 --- NULL Handling: ``Option<T>`` Everywhere
+==================================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; NULL
+    single: Tutorial; Option
+    single: Tutorial; is_some
+    single: Tutorial; is_none
+    single: Tutorial; unwrap_or
+    single: Tutorial; COALESCE
+    single: Tutorial; IS NULL
+
+Nullability is **type-driven**. The struct field's daslang type is
+the single source of truth --- there is no ``@sql_nullable``
+annotation. The same ``[sql_table]`` struct doubles as the row shape
+and the schema.
+
+==============================================  ==================================================
+Field type                                      DDL emitted
+==============================================  ==================================================
+``T``                                           ``COLUMN TYPE NOT NULL``
+``Option<T>``                                   ``COLUMN TYPE`` (no ``NOT NULL``)
+==============================================  ==================================================
+
+The ``[sql_table]`` macro inspects each field at compile time and
+emits the matching DDL, INSERT/UPDATE binds, and SELECT readers.
+
+DDL example
+===========
+
+.. code-block:: das
+
+    [sql_table(name="Users")]
+    struct User {
+        @sql_primary_key Id : int
+        Name      : string
+        @safe_when_uninitialized Age       : Option<int>
+        @safe_when_uninitialized Nick      : Option<string>
+        @safe_when_uninitialized DeletedAt : Option<int64>
+    }
+
+Generated DDL:
+
+.. code-block:: sql
+
+    CREATE TABLE "Users"(
+        "Id" INTEGER PRIMARY KEY,
+        "Name" TEXT NOT NULL,
+        "Age" INTEGER,
+        "Nick" TEXT,
+        "DeletedAt" INTEGER
+    )
+
+The ``@safe_when_uninitialized`` annotation on each ``Option<T>``
+field is required under ``strict_smart_pointers`` so the macro can
+default-initialize a row in the row-builder. The Option's internal
+``_value`` is already so-marked inside the template; the wrapping
+struct field still needs its own annotation.
+
+Round-trip --- ``some(v)`` and ``none()``
+=========================================
+
+INSERT/UPDATE bind code branches per field type at compile time.
+``is_some(field)`` binds the underlying value; ``is_none()`` binds
+``sqlite3_bind_null``. SELECT readers check
+``sqlite3_column_type == SQLITE_NULL`` and wrap accordingly.
+
+.. code-block:: das
+
+    db |> insert(User(
+        Id = 1, Name = "alice",
+        Age = some(30), Nick = none(type<string>), DeletedAt = none(type<int64>)))
+
+    let everyone <- db |> select_from(type<User>)
+    for (u in everyone) {
+        if (u.Age |> is_some) {
+            to_log(LOG_INFO, "{u.Name}: age {u.Age |> unwrap}\n")
+        } else {
+            to_log(LOG_INFO, "{u.Name}: age unknown\n")
+        }
+    }
+
+NULL predicates in ``_where``
+=============================
+
+Three Option methods translate to SQL null operators:
+
+==============================================  ==================================================
+Source shape                                    Emitted SQL
+==============================================  ==================================================
+``_.Col |> is_some``                            ``"Col" IS NOT NULL``
+``_.Col |> is_none``                            ``"Col" IS NULL``
+``_.Col |> unwrap_or(default)``                 ``COALESCE("Col", ?)``  (``default`` binds)
+==============================================  ==================================================
+
+``is_some`` / ``is_none``:
+
+.. code-block:: das
+
+    let known_age <- _sql(db |> select_from(type<User>)
+                            |> _where(_.Age |> is_some))
+    // ... WHERE "Age" IS NOT NULL
+
+    let alive <- _sql(db |> select_from(type<User>)
+                        |> _where(_.DeletedAt |> is_none))
+    // ... WHERE "DeletedAt" IS NULL
+
+``unwrap_or`` --- COALESCE with a fallback:
+
+.. code-block:: das
+
+    let cutoff = 18
+    let adults_or_unknown <- _sql(db |> select_from(type<User>)
+                                    |> _where(_.Age |> unwrap_or(0) >= cutoff))
+    // ... WHERE COALESCE("Age", ?) >= ?     binds: [0, 18]
+
+The ``unwrap_or`` default (``0`` here) routes through the predicate
+rewriter --- both captured locals and literals are emitted as ``?``
+bind parameters (the analyzer doesn't bother distinguishing; keeping
+the SQL parameterized either way is the safe-by-default behavior;
+see :ref:`tutorial_sql_anatomy`).
+
+Option<T> in projections
+========================
+
+Full-row projection (no ``_select``) preserves each field's exact
+type --- ``Option<T>`` stays ``Option<T>`` in the result struct.
+There is no implicit unwrap. Users see the same nullability
+discipline at projection sites as at row sites.
+
+Three-valued-logic gotcha
+=========================
+
+In SQL, ``NULL = NULL`` is ``NULL``, never ``TRUE``. ``NULL <> x``
+is also ``NULL``. ``WHERE`` treats ``NULL``-valued predicates as
+false, so ``WHERE Col = NULL`` matches **nothing**. The Option API
+steers users away from that footgun: use ``_.Col |> is_none()``
+(emits ``IS NULL``) or ``_.Col |> unwrap_or(d) == x`` (emits
+``COALESCE`` then compare).
+
+Direct ``_.Col == none()`` in a predicate is intentionally not
+translated this chunk. A future revision may either lower it to
+``IS NULL`` automatically or raise a ``macro_error`` with a fix-it
+pointing to ``|> is_none()`` --- the leaning is toward the explicit
+diagnostic so the user has to confront three-valued logic head-on.
+
+``_try_sql`` composes
+=====================
+
+The non-panicking ``_try_sql`` form composes with all of the above
+--- the Option methods are predicate-translation rules, orthogonal
+to the outer success/failure wrapper:
+
+.. code-block:: das
+
+    let attempt <- _try_sql(db |> select_from(type<User>)
+                              |> _where(_.Age |> is_some))
+    if (attempt |> is_ok) {
+        let rows <- attempt |> unwrap
+        // ...
+    }
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/18-null_handling.das <../../../../tutorials/sql/18-null_handling.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_group_by`

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -220,7 +220,149 @@ matrix.
 - AOT path stays green (CMake glob auto-picks new tests; reconfigure
   required after adding the first new test of a chunk).
 
-## Appendix C — `_sql` translation boundary (the content tut 7 would have covered)
+## Shipped — chunk 4: read-side depth — distinct/take/skip/order_by/aggregates/group_by/NULL (branch `dassqlite-chunk4-read-depth`)
+
+Chunk 4 broadens the chunk-3 framework with the rest of the read-side
+operators and ships tutorials 7, 10, 11, 12, 13, 14, 18. Set
+operations (UNION/INTERSECT/EXCEPT — tut 12 second half) and joins +
+subqueries (tuts 15–17) are deferred to chunk 5: they all need the
+same multi-source / multi-stage SqlQuery extension.
+
+### New chain operators (all in `analyze_chain` / `pred_to_sql`)
+
+- **`distinct()`** — sets `q.distinctFlag`; emits `SELECT DISTINCT`.
+- **`take(n)` / `skip(n)`** — bind expressions stashed in
+  `q.limitBindExpr` / `q.offsetBindExpr`; pushed *after* WHERE binds
+  in `emit_sql_macro_body`. Solo `skip(n)` emits `LIMIT -1 OFFSET ?`
+  to satisfy SQLite's OFFSET-requires-LIMIT rule. Single-row
+  terminals (`_first` / `_first_opt`) override `take`'s `LIMIT`.
+- **`_order_by(_.Col)` / `_order_by_descending(_.Col)`** — single-key
+  ASC/DESC. Tuple-key form `_order_by((_.k1, _.k2))` emits each
+  tuple field as its own `ORDER BY` column. Recurse-first on the
+  peel so downstream `seenGroupBy` is known when analyzing the key.
+  Mixed ASC/DESC across columns is **deferred** (D2).
+- **`sum` / `average` / `min` / `max`** — terminal column aggregates
+  via `peel_column_aggregate`. Recurse-first: peel the aggregate,
+  let the inner chain populate `selectCols`, then wrap
+  `selectCols[0]` in the SQL aggregate. AVG promotes to `double`;
+  SUM/MIN/MAX inherit the column type. LIMIT 1 suppressed for
+  aggregate Materializer.
+- **`_group_by(_.Col)` / `_group_by((_.k1, _.k2))`** — single- and
+  multi-key grouping via the existing linq.das `group_by_lazy`
+  lowering. Adds `ProjectionShape.GroupedNamedTuple` with parallel
+  `q.groupedSelectExprs` / `q.groupedSelectTypes`. Macro-side
+  recognition of the IGrouping shape: `_._0` for the group key
+  (single-key), `_._0._N` for multi-key, `_._1` for group rows;
+  `_._1 |> length` / `_._1 |> count` → `COUNT(*)` (result type
+  `int` not `int64` — matches daslang's `length`/`count` returns);
+  `_._1 |> select($(u : T) => u.Field) |> sum/average/min/max` →
+  `SUM("Field")` / etc.
+- **`_having(predicate)`** — recurse-first; rejected if
+  `!seenGroupBy` or wrong order. Bind exprs route to
+  `q.havingBindExprs` and slot in between WHERE and LIMIT in the
+  placeholder index sequence.
+- **NULL handling — Option<T> in `_where` predicates:**
+  `_.Col |> is_some` → `Col IS NOT NULL`;
+  `_.Col |> is_none` → `Col IS NULL`;
+  `_.Col |> unwrap_or(default)` → `COALESCE(Col, ?)` (default routed
+  through `pred_to_sql` so both captured locals and literals are
+  emitted as `?` binds — same default-parameterize behavior as the
+  rest of `_where`).
+
+### `[sql_table]` runtime extensions for `Option<T>`
+
+- `is_option_field_type(td)` recognizes both pre-resolution
+  (`Type.typeMacro` with `dimExpr[0]` ExprConstString = "Option")
+  and post-resolution (`Type.tStructure` with module=="option")
+  forms — structure macro runs before the `[template_structure]`
+  expansion, so the typemacro form is what actually shows up.
+- `sqlite_sql_type` / `sqlite_bind` / `sqlite_read` overloads for
+  `$Option<auto(TT)>`. Bind branches on `_has_value` and binds
+  `sqlite3_bind_null` for `none`. Read branches on
+  `sqlite3_column_type == SQLITE_NULL` and wraps in `some(v)` /
+  `none()`.
+- DDL emitter omits `NOT NULL` for `Option<T>` columns; rejects
+  `@sql_primary_key` on `Option<T>` via `errors:=`.
+- `_sql_read_row` body uses `var row = default<$t(st)>` so
+  Option-bearing user structs default-init cleanly under
+  `strict_smart_pointers`.
+
+### IGrouping shape vs the original mockup (locked 2026-04-26)
+
+The original `19-group_by.das.mockup` used aspirational syntax
+(`_count_all()`, `_sum(_.X)`, `_avg(_.X)`) inside the post-group
+`_select`. After `_group_by` lowers to `group_by_lazy`, the chain
+element is `tuple<KeyType; array<RowType>>`, so the next `_select`
+sees `_:tuple<...>` — `_.X` doesn't typecheck (the tuple has
+`_0`/`_1`, not `X`).
+
+Chunk 4 ships the **IGrouping shape** (matches existing
+`tests/linq/test_linq_group_by.das`):
+
+- `_._0` for the group key (single-key), `_._0._N` for multi-key
+- `_._1` for the group element array
+- `_._1 |> length` / `_._1 |> count` → `COUNT(*)`
+- `_._1 |> select($(u : RowType) => u.X) |> sum/average/min/max` →
+  the matching SQL aggregate
+
+The inner `select` lambda parameter is intentionally **named**
+(`$(u : User)` etc.), not `_` — the outer `_select` lambda already
+binds `_` to the group tuple, and daslang flags a same-name-
+different-type lambda nested inside as a shadowing error. Naming
+the inner parameter sidesteps it; the macro recognizes the body as
+`<param>.<field>` for any parameter name. This aligns with EF Core
+/ C# LINQ shape (`g.Key` ↔ `_._0`, `g.Count()` ↔ `_._1 |> length`,
+`g.Average(u => u.Age)` ↔ `_._1 |> select($(u) => u.Age) |> average`).
+
+### Deferred to chunk 5+
+
+- **Set operations (UNION / INTERSECT / EXCEPT)** — tut 12 second
+  half. Single-source `SqlQuery` today; needs `setOpKind` +
+  `setOpRhsQuery` plus the multi-stage emitter. Bundled with joins
+  and subqueries.
+- **`_join` / `_left_join`** (tuts 15-16) — multi-source FROM,
+  equi-join predicate extraction.
+- **Subqueries — `_in` / `_not_in` / `_any` / `_none`** (tut 17) —
+  nested SqlQuery walker, outer-lambda-param classifier for
+  correlated columns, scalar-subquery embedding in predicates.
+- **`_then_by` and multi-key ordering protocol (D1)** — needs an
+  `IOrderedEnumerable<T>`-equivalent in daslib/linq. Chunk-4
+  workaround: tuple-key `_order_by((_.k1, _.k2))` emits each tuple
+  field as its own `ORDER BY` column.
+- **Mixed ASC/DESC across columns (D2)** — `ORDER BY a ASC, b DESC`
+  in one chain step. Possible future syntax: marker-in-tuple
+  `_order_by(@(x) => (x.a, desc(x.b)))`. Out of chunk 4 scope; raw
+  SQL escape hatch handles it today.
+- **`Option<T> == none()` in `_sql` predicates (D4)** — currently
+  not translated. Lock decision (macro_error with fixit vs silent
+  rewrite to `IS NULL`) when a real test forces it; leaning
+  fixit-with-macro_error for explicit-over-magic.
+- **Projection-side `_.Col |> unwrap_or(d)` in `_select`** — the
+  predicate-side rule lands this chunk; the projection-side
+  COALESCE case requires extending `analyze_projection` beyond
+  plain `_.Field` shape and is deferred.
+
+### Surface in this PR
+
+- **Tutorials 7, 10, 11, 12, 13, 14, 18** under `tutorials/sql/`.
+- **6 new test files** under `tests/dasSQLITE/`:
+  - test_32 — `distinct`
+  - test_33 — `take` / `skip`
+  - test_34 — `_order_by` (single-key, descending, tuple-key)
+  - test_35 — column aggregates (sum/average/min/max)
+  - test_36 — `_group_by` + `_having` (single/multi-key, full reporting query)
+  - test_37 — NULL handling (DDL, round-trip, is_some / is_none /
+    unwrap_or in `_where`, full-row Option pass-through)
+- `failed_sql_macro.das` extended with bad10 (`_having` without
+  `_group_by`) and bad11 (bare scalar projection after `_group_by`).
+- **205/205 dasSQLITE tests pass** interpreted; chunk-2 (81),
+  chunk-3 (70), chunk-4 (54). AOT path stays green; lint clean.
+- New RST: `sql_07_anatomy.rst`, `sql_10_order_by.rst`,
+  `sql_11_take_skip.rst`, `sql_12_distinct.rst`,
+  `sql_13_aggregates.rst`, `sql_14_group_by.rst`,
+  `sql_18_null_handling.rst`. Sphinx `-W` clean.
+
+## Appendix C — `_sql` translation boundary (cross-reference for tutorial 7)
 
 What `_sql(chain)` translates and what it refuses, in one place. The
 macro walks the chain bottom-up after Mode-2 expansion has unfolded

--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -99,7 +99,9 @@ part re-uses the same [sql_table] from Part 1.
    the `options log` story for debugging, the raw-SQL escape hatch
    via `db |> exec(sql, …)` / `try_exec` for DDL and for statements
    the macro can't (or shouldn't) translate. Appendix C documents the
-   full translation-failure policy. Mockup: **none yet — write new**.
+   full translation-failure policy. **Shipped:**
+   [tutorials/sql/07-anatomy.das](../../tutorials/sql/07-anatomy.das)
+   (chunk 4).
 8. **`_where` — predicates** — filtering with captured-variable bind
    params. Introduces: the `_where` block macro, the captured-var-to-
    bind rewriter, `_.Col` column sugar, translatable string predicates
@@ -110,20 +112,36 @@ part re-uses the same [sql_table] from Part 1.
    `(Name=_.Name, Price=_.Price)` or to an existing struct type.
    Introduces: named-tuple projections, how `_sql` passes tuple field
    names through to column aliases. Mockup: **none yet — write new**.
-10. **`_order_by` / `_then_by`** — single- and multi-column ordering,
-    ASC via `_order_by(expr)` / DESC via `_order_by_descending(expr)`.
-    Covers API_MISSING §20. Mockup: **none yet — write new**.
-11. **`_take` / `_skip` + keyset pagination** — offset/limit pagination
-    and the faster keyset variant. Covers API_MISSING §21. Mockup:
-    **none yet — write new**.
-12. **`_distinct` + set operations** — DISTINCT, UNION / INTERSECT /
-    EXCEPT. Covers API_MISSING §22. Mockup: **none yet — write new**.
-13. **Aggregates — `_count` / `_sum` / `_avg` / `_min` / `_max`** — terminal
-    aggregates on the whole source. Establishes the primitives group-by
-    builds on. Covers API_MISSING §18. Mockup: **none yet — write new**.
+10. **`_order_by` / `_order_by_descending`** — single-column ordering
+    via `_.Field`, multi-column via tuple-key `(_.k1, _.k2)`. Mixed
+    ASC/DESC across columns and a multi-key `_then_by` protocol are
+    deferred (D1/D2 in the chunk-4 plan). Covers API_MISSING §20.
+    **Shipped:** [tutorials/sql/10-order_by.das](../../tutorials/sql/10-order_by.das) (chunk 4).
+11. **`take` / `skip` (LIMIT / OFFSET)** — offset/limit pagination via
+    the linq.das primitives, no `_`-prefixed wrappers needed. Bind
+    ordering: WHERE binds first, then HAVING, then LIMIT/OFFSET.
+    Single-row terminals (`_first`/`_first_opt`) override `take`.
+    Keyset pagination is a future concept tut. Covers API_MISSING §21.
+    **Shipped:** [tutorials/sql/11-take_skip.das](../../tutorials/sql/11-take_skip.das) (chunk 4).
+12. **`distinct`** — DISTINCT row dedupe. Set operations (UNION /
+    INTERSECT / EXCEPT) **deferred to chunk 5** alongside joins and
+    subqueries — they need a multi-source emitter. Covers API_MISSING §22.
+    **Shipped:** [tutorials/sql/12-distinct.das](../../tutorials/sql/12-distinct.das) (chunk 4).
+13. **Aggregates — `count` / `sum` / `average` / `min` / `max`** —
+    terminal aggregates on the whole source. `count` stands alone;
+    the four column-driven aggregates compose with `_select(_.Col)`
+    upstream. AVG promotes to `double`; SUM/MIN/MAX inherit the
+    column type. Covers API_MISSING §18.
+    **Shipped:** [tutorials/sql/13-aggregates.das](../../tutorials/sql/13-aggregates.das) (chunk 4).
 14. **`_group_by` + `_having`** — aggregate per bucket, post-aggregate
-    filter. Introduces: `_group_by` / `_group_by_lazy`, fusion with the
-    next `_select`, HAVING emission. Mockup: [19-group_by.das](tutorial-mockup/19-group_by.das.mockup).
+    filter. Group rows surface as IGrouping-shaped tuples (`_._0` =
+    key, `_._1` = group rows); aggregates over the group use
+    `_._1 |> length` / `_._1 |> select($(u : T) => u.X) |> sum`
+    (etc.). The chunk-4 mockup `19-group_by.das.mockup` was based on
+    aspirational `_count_all()` / `_sum(_.X)` / `_avg(_.X)` syntax
+    that does not typecheck after `_group_by` lowers — see
+    API_REWORK §19 for the IGrouping-shape lock-in. **Shipped:**
+    [tutorials/sql/14-group_by.das](../../tutorials/sql/14-group_by.das) (chunk 4).
 15. **`_join` — inner equi-join** — join two tables on `(l, r) => l.X == r.Y`.
     Introduces: the equi-join-only constraint, `into` projection. Mockup:
     [23-joins.das](tutorial-mockup/23-joins.das.mockup) (first half).
@@ -140,7 +158,11 @@ part re-uses the same [sql_table] from Part 1.
     predicates emit IS NOT NULL / IS NULL, `|> unwrap_or(x)` emits
     COALESCE, `Option<T>` carries through projections to result tuples.
     Introduces: three-valued logic, why daslang uses `Option<T>`
-    instead of nullable pointers for SQL columns. Mockup: [25-null_handling.das](tutorial-mockup/25-null_handling.das.mockup).
+    instead of nullable pointers for SQL columns. The original mockup
+    `25-null_handling.das.mockup` shipped largely as designed; the
+    `_.Col == none()` diagnostic and projection-side `unwrap_or` are
+    deferred (D4 in the chunk-4 plan). **Shipped:**
+    [tutorials/sql/18-null_handling.das](../../tutorials/sql/18-null_handling.das) (chunk 4).
 
 ## Part 4 — Writes
 
@@ -328,18 +350,18 @@ E. **Forward-looking: `dasSQL` abstraction layer** — the roadmap beyond
 | 4 | Read every row | `04-select_all.das` | **Shipped** (chunk 2) |
 | 5 | Parameters — positional | `05-parametrized.das` | **Shipped** (chunk 3); named-tuple bind for `:name` placeholders deferred to chunk 4 |
 | 6 | Error handling — `try_` / `_opt` / `_try_sql` | `_error_handling.das` | **Shipped** (chunk 3) |
-| 7 | Anatomy of `_sql` | — | **Folded** into tut 8/9 inline comments + Appendix C (no standalone tutorial — see chunk-3 plan) |
+| 7 | Anatomy of `_sql` | `07-anatomy.das` | **Shipped** (chunk 4) |
 | 8 | `_where` — predicates + appendix-A operators | direct | **Shipped** (chunk 3) |
-| 9 | `_select` — single-column + named-tuple | direct | **Shipped** (chunk 3); struct-type projection (`_select(type<T2>)`) deferred to chunk 4 |
-| 10 | `_order_by` / `_then_by` | — | **Needs mockup** |
-| 11 | `_take` / `_skip` + keyset | — | **Needs mockup** |
-| 12 | `_distinct` + set ops | — | **Needs mockup** |
-| 13 | Aggregates | — | **Needs mockup** |
-| 14 | `_group_by` + `_having` | `19-group_by.das` | Has mockup |
+| 9 | `_select` — single-column + named-tuple | direct | **Shipped** (chunk 3); struct-type projection (`_select(type<T2>)`) deferred to chunk 5 |
+| 10 | `_order_by` / `_order_by_descending` (+ tuple key) | `10-order_by.das` | **Shipped** (chunk 4); `_then_by` and per-column ASC/DESC mix deferred |
+| 11 | `take` / `skip` (LIMIT / OFFSET) | `11-take_skip.das` | **Shipped** (chunk 4); keyset pagination is a future concept tut |
+| 12 | `distinct` (set ops deferred) | `12-distinct.das` | **Shipped** (chunk 4); UNION/INTERSECT/EXCEPT punted to chunk 5 alongside joins/subqueries |
+| 13 | Aggregates — `count` / `sum` / `average` / `min` / `max` | `13-aggregates.das` | **Shipped** (chunk 4) |
+| 14 | `_group_by` + `_having` | `14-group_by.das` (`19-group_by.das.mockup` superseded — IGrouping shape, see API_REWORK §19) | **Shipped** (chunk 4) |
 | 15 | `_join` — inner equi-join | `23-joins.das` | Has mockup |
 | 16 | `_left_join` — outer | `23-joins.das` | Has mockup (shared) |
 | 17 | Subqueries | `24-subqueries.das` | Has mockup |
-| 18 | NULL handling — `Option<T>` | `25-null_handling.das` | Has mockup |
+| 18 | NULL handling — `Option<T>` | `18-null_handling.das` (`25-null_handling.das.mockup` shipped largely as designed; `_.Col == none()` diagnostic + projection-side `unwrap_or` deferred) | **Shipped** (chunk 4) |
 | 19 | UPDATE | `15-update.das` | Has mockup |
 | 20 | DELETE | `16-delete.das` | Has mockup |
 | 21 | UPSERT | `17-upsert.das` | Has mockup |

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -10,6 +10,7 @@ require sqlite public
 
 require strings public
 require daslib/contracts
+require daslib/option public
 require daslib/sql public
 require daslib/ast_boost
 require daslib/templates
@@ -189,6 +190,14 @@ def sqlite_sql_type(witness : bool) : string {
 }
 
 [unused_argument(witness)]
+def sqlite_sql_type(witness : $Option < auto(TT) >) : string {
+    //! Option<T> nullability is type-driven — the column's SQL type comes from the inner ``T``.
+    //! Whether a NOT NULL constraint is emitted is decided at macro-expansion time by the
+    //! [sql_table] DDL emitter, not here.
+    return sqlite_sql_type(default<TT>)
+}
+
+[unused_argument(witness)]
 def sqlite_sql_type(witness : auto(TT)) : string {
     concept_assert(false, "sqlite_sql_type: unsupported field type. Define `def sqlite_sql_type(witness : YourType) : string` to extend.")
     return ""
@@ -216,6 +225,15 @@ def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : string) : void {
 
 def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : bool) : void {
     sqlite3_bind_int64(stmt, idx, value ? 1l : 0l)
+}
+
+def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : $Option < auto(TT) >) : void {
+    //! Option<T>: bind the underlying value when ``some``, SQL NULL when ``none``.
+    if (value._has_value) {
+        sqlite_bind(stmt, idx, value._value)
+    } else {
+        sqlite3_bind_null(stmt, idx)
+    }
 }
 
 [unused_argument(stmt, idx, value)]
@@ -266,6 +284,15 @@ def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<string>) : string {
 [unused_argument(t)]
 def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<bool>) : bool {
     return sqlite3_column_int(stmt, col) != 0
+}
+
+[unused_argument(t)]
+def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<$Option<auto(TT)>>) : Option<TT -const -#> {
+    //! Option<T>: SQLITE_NULL → ``none``; otherwise read the inner ``T`` and wrap in ``some``.
+    if (sqlite3_column_type(stmt, col) == SQLITE_NULL) {
+        return none(type<TT -const -#>)
+    }
+    return some(sqlite_read(stmt, col, type<TT -const -#>))
 }
 
 [unused_argument(stmt, col, t)]
@@ -872,6 +899,28 @@ struct private FieldInfo {
     col_name : string
     is_pk : bool
     is_int_pk : bool
+    is_optional : bool
+}
+
+def private is_option_field_type(td : TypeDeclPtr) : bool {
+    //! Recognize ``Option<T>`` for the [sql_table] DDL emitter (drop NOT NULL,
+    //! reject @sql_primary_key on the field). Structure macros run before the
+    //! ``[template_structure]`` typemacro has been resolved, so a field
+    //! declared as ``Option<int>`` arrives as ``Type.typeMacro`` with the
+    //! macro name in ``dimExpr[0]``. We also accept the post-resolution form
+    //! (``Type.tStructure`` with structType.name == "Option", module ==
+    //! "option") so the helper works even if a later pass reaches it.
+    if (td == null) {
+        return false
+    }
+    if (td.baseType == Type.typeMacro && length(td.dimExpr) > 0 && (td.dimExpr[0] is ExprConstString)) {
+        return (td.dimExpr[0] as ExprConstString).value == "Option"
+    }
+    return (td.baseType == Type.tStructure
+        && td.structType != null
+        && td.structType.name == "Option"
+        && td.structType._module != null
+        && td.structType._module.name == "option")
 }
 
 [structure_macro(name=sql_table)]
@@ -882,11 +931,17 @@ class SqlTableMacro : AstStructureAnnotation {
         var fields : array<FieldInfo>
         for (field in st.fields) {
             let is_pk = find_bool_annotation(field.annotation, "sql_primary_key", false)
+            let is_optional = is_option_field_type(field._type)
+            if (is_pk && is_optional) {
+                errors := "[sql_table]: @sql_primary_key on field '{field.name}' must not be Option<T> — primary keys cannot be NULL in SQL. Use a non-optional type."
+                return false
+            }
             fields |> push(FieldInfo(
                 name = string(field.name),
                 col_name = string(field.name),
                 is_pk = is_pk,
-                is_int_pk = is_pk && (field._type.baseType == Type.tInt || field._type.baseType == Type.tInt64)
+                is_int_pk = is_pk && (field._type.baseType == Type.tInt || field._type.baseType == Type.tInt64),
+                is_optional = is_optional
             ))
         }
 
@@ -941,7 +996,10 @@ class SqlTableMacro : AstStructureAnnotation {
         for (i in range(length(fields))) {
             let info = fields[i]
             let prefix = i == 0 ? "\"{info.col_name}\" " : ", \"{info.col_name}\" "
-            let suffix = info.is_pk ? " PRIMARY KEY" : " NOT NULL"
+            // Nullability is type-driven: Option<T> fields drop NOT NULL.
+            // PK columns are implicitly NOT NULL in SQLite for INTEGER PRIMARY KEY,
+            // and rejected as Option<T> earlier in apply().
+            let suffix = info.is_pk ? " PRIMARY KEY" : (info.is_optional ? "" : " NOT NULL")
             write_exprs |> push(qmacro_expr(${ writer |> write($v(prefix)); }))
             write_exprs |> push(qmacro_expr(${ writer |> write(sqlite_sql_type(type<$t(st.fields[i]._type)>)); }))
             write_exprs |> push(qmacro_expr(${ writer |> write($v(suffix)); }))
@@ -1117,8 +1175,13 @@ class SqlTableMacro : AstStructureAnnotation {
             }))
         }
 
+        // `var row = default<$t(st)>` — explicit default so structs with
+        // Option<T> fields (which lack a builtin per-field default and rely
+        // on `@safe_when_uninitialized` only in the value position) still
+        // satisfy strict_smart_pointers' uninitialized-var check inside the
+        // generated `_sql_read_row` body.
         var fn = qmacro_function("_sql_read_row") $(stmt : sqlite3_stmt?; typ : $t(st)) : $t(st) {
-            var row : $t(st)
+            var row = default<$t(st)>
             $b(assign_exprs)
             return <- row
         }

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -62,6 +62,7 @@ def _first(arr : array<auto(TT)>) : TT -const -& {
     return first(arr)
 }
 
+
 // ============================================================================
 // SqlQuery — accumulator for chain analysis (compile-time only).
 //
@@ -78,10 +79,11 @@ enum private Materializer {
 }
 
 enum private ProjectionShape {
-    FullRow      //!< no `_select`: SELECT cols-of(rootT); reads via _::_sql_read_row
-    SingleColumn //!< `_select(_.Field)`: SELECT one col; reads via sqlite_read
-    NamedTuple   //!< `_select((Name=_.Name, Price=_.Price))`: SELECT cols; reads via tuple builder
-    Aggregate    //!< `_count()` etc.: raw SQL expression in SELECT; scalar reader
+    FullRow             //!< no `_select`: SELECT cols-of(rootT); reads via _::_sql_read_row
+    SingleColumn        //!< `_select(_.Field)`: SELECT one col; reads via sqlite_read
+    NamedTuple          //!< `_select((Name=_.Name, Price=_.Price))`: SELECT cols; reads via tuple builder
+    Aggregate           //!< `_count()` etc.: raw SQL expression in SELECT; scalar reader
+    GroupedNamedTuple   //!< `_select` after `_group_by`: tuple of group keys + group-scope aggregates
 }
 
 struct private SqlQuery {
@@ -90,15 +92,30 @@ struct private SqlQuery {
     selectCols  : array<string>           //!< SingleColumn / FullRow / NamedTuple: column names (quoted in SQL)
     projRecordNames : array<string>       //!< NamedTuple: per-column tuple field names (parallel to selectCols)
     aggregateExpr : string                //!< Aggregate: raw SELECT-list text (e.g. "COUNT(*)")
-    aggregateType : TypeDeclPtr           //!< Aggregate: result scalar type (e.g. int64 for COUNT)
+    aggregateType : TypeDeclPtr           //!< Aggregate: resolved scalar result type; varies by aggregate expression (int for COUNT, double for AVG, column type for SUM/MIN/MAX)
     whereSql    : string
-    bindExprs   : array<ExpressionPtr>
-    sqlSuffix   : string                  //!< " LIMIT 1" for One/OneOpt
+    bindExprs   : array<ExpressionPtr>    //!< WHERE binds, populated during analyze_chain
+    limitBindExpr : ExpressionPtr         //!< take(n) bind expr (null = no LIMIT, except terminal-induced)
+    offsetBindExpr : ExpressionPtr        //!< skip(n) bind expr (null = no OFFSET)
+    distinctFlag : bool                   //!< distinct() seen → emits "SELECT DISTINCT"
+    orderByCols : array<string>           //!< each entry like `"Col" ASC` / `"Col" DESC`
+    groupByCols : array<string>           //!< each entry like `"Col"` (already SQL-quoted)
+    havingSql : string                    //!< pre-formatted HAVING clause (without leading "HAVING ")
+    havingBindExprs : array<ExpressionPtr>  //!< HAVING binds, kept separate so they sort after WHERE binds
+    groupedSelectExprs : array<string>    //!< GroupedNamedTuple: raw SQL fragment per column
+    groupedSelectTypes : array<TypeDeclPtr>  //!< GroupedNamedTuple: resolved scalar type per column
     matr        : Materializer = Materializer.Array
     proj        : ProjectionShape = ProjectionShape.FullRow
     seenSelect  : bool
     seenToArray : bool
     seenTerminal : bool                   //!< true once a single-row/scalar terminal has been peeled
+    seenDistinct : bool                   //!< duplicate-stage guard for distinct()
+    seenTake    : bool                    //!< duplicate-stage guard for take(n)
+    seenSkip    : bool                    //!< duplicate-stage guard for skip(n)
+    seenOrderBy : bool                    //!< duplicate-stage guard for _order_by
+    seenGroupBy : bool                    //!< _group_by seen — group-scope context for downstream _select / _having
+    seenHaving  : bool                    //!< duplicate-stage guard for _having
+    inHaving    : bool                    //!< pred_to_sql writes binds to havingBindExprs while this is true
     dbExpr      : ExpressionPtr
 }
 
@@ -192,6 +209,50 @@ def private match_module_call(var expr : ExpressionPtr; name : string; modName :
 }
 
 [macro_function]
+def private peel_column_aggregate(var node : ExpressionPtr; var q : SqlQuery&;
+                                  linqName : string; sqlOp : string; promote_to_double : bool;
+                                  prog : ProgramPtr; at : LineInfo) : bool {
+    //! Peel a column aggregate (sum/average/min/max) wrapping a SingleColumn
+    //! projection. Returns true if this node matched (regardless of success);
+    //! the caller treats `q.aggregateExpr != ""` as success and returns true,
+    //! else propagates the macro_error already emitted.
+    //!
+    //! Strategy: recurse into the inner chain FIRST so the inner `_select` /
+    //! `select_from` populates q.selectCols, then wrap selectCols[0] in
+    //! `sqlOp(...)`. This lets the same slot serve any column aggregate.
+    var aCall = match_linq_call(node, linqName)
+    if (aCall == null) {
+        return false
+    }
+    if (q.seenTerminal || q.seenToArray) {
+        macro_error(prog, at, "_sql: only one terminal allowed per chain")
+        return true
+    }
+    if (aCall.arguments |> length != 1) {
+        macro_error(prog, at, "_sql: {linqName}(predicate) is not yet supported in `_sql` chains; use `_select(_.Col) |> {linqName}()` for column aggregates")
+        return true
+    }
+    if (!analyze_chain(aCall.arguments[0], q, prog, at)) {
+        return true
+    }
+    if (q.proj != ProjectionShape.SingleColumn || length(q.selectCols) != 1) {
+        macro_error(prog, at, "_sql: {linqName}() needs an upstream `_select(_.Col)` projecting exactly one column (got proj={int(q.proj)}, cols={length(q.selectCols)})")
+        return true
+    }
+    let col = q.selectCols[0]
+    q.aggregateExpr = "{sqlOp}(\"{col}\")"
+    if (promote_to_double) {
+        q.aggregateType = new TypeDecl(at = at, baseType = Type.tDouble)
+    } else {
+        q.aggregateType = lookup_struct_field_type(q.rootType, col)
+    }
+    q.proj = ProjectionShape.Aggregate
+    q.matr = Materializer.One
+    q.seenTerminal = true
+    return true
+}
+
+[macro_function]
 def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
     if (node == null) {
         macro_error(prog, at, "_sql: empty chain")
@@ -243,7 +304,6 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             }
             q.matr = Materializer.One
             q.seenTerminal = true
-            q.sqlSuffix = " LIMIT 1"
             return analyze_chain(fCall.arguments[0], q, prog, at)
         }
     }
@@ -258,7 +318,6 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             }
             q.matr = Materializer.OneOpt
             q.seenTerminal = true
-            q.sqlSuffix = " LIMIT 1"
             return analyze_chain(foCall.arguments[0], q, prog, at)
         }
     }
@@ -281,14 +340,173 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             q.seenTerminal = true
             q.proj = ProjectionShape.Aggregate
             q.aggregateExpr = "COUNT(*)"
-            q.aggregateType = new TypeDecl(at = at, baseType = Type.tInt64)
+            // SQLite's COUNT(*) is int64 internally, but daslang's
+            // `length(arr)` / `count(arr)` return `int`, so narrow via
+            // `sqlite_read(stmt, 0, type<int>)`. Matches the grouped
+            // form (`_._1 |> length`) which also lands as `int`. Any
+            // plausible row count fits.
+            q.aggregateType = new TypeDecl(at = at, baseType = Type.tInt)
             return analyze_chain(cCall.arguments[0], q, prog, at)
+        }
+    }
+
+    // ---- Column aggregates: sum / average / min / max ----
+    // Pattern: `... |> _select(_.Col) |> sum()` (or average/min/max).
+    // Implementation note: recurse into the inner chain FIRST so selectCols
+    // is populated, then wrap selectCols[0] in the SQL aggregate. This lets
+    // the same emitter slot serve any column-aggregate primitive — adding a
+    // new one is a one-line entry plus a column-type rule.
+    {
+        if (peel_column_aggregate(node, q, "sum",     "SUM", false, prog, at)) {
+            return q.aggregateExpr != ""
+        }
+    }
+    {
+        if (peel_column_aggregate(node, q, "average", "AVG", true,  prog, at)) {
+            return q.aggregateExpr != ""
+        }
+    }
+    {
+        if (peel_column_aggregate(node, q, "min",     "MIN", false, prog, at)) {
+            return q.aggregateExpr != ""
+        }
+    }
+    {
+        if (peel_column_aggregate(node, q, "max",     "MAX", false, prog, at)) {
+            return q.aggregateExpr != ""
         }
     }
 
     // ---- Stage operators ----
 
+    // Peel distinct(prev) — linq.das's `distinct` plain function. Sets
+    // SELECT DISTINCT on the emitted SQL. The SELECT-list itself comes from
+    // the rest of the chain (FullRow / SingleColumn / NamedTuple); aggregates
+    // pair with DISTINCT only via the function-internal form (e.g.
+    // COUNT(DISTINCT col)) which is not yet wired — flag a guard for that.
+    {
+        var dCall = match_linq_call(node, "distinct")
+        if (dCall != null) {
+            if (q.seenDistinct) {
+                macro_error(prog, at, "_sql: distinct() can appear at most once in the chain")
+                return false
+            }
+            if (dCall.arguments |> length != 1) {
+                macro_error(prog, at, "_sql: distinct() takes no explicit arguments (chain form: `|> distinct()`)")
+                return false
+            }
+            q.distinctFlag = true
+            q.seenDistinct = true
+            return analyze_chain(dCall.arguments[0], q, prog, at)
+        }
+    }
+
+    // Peel take(prev, n) — linq.das's `take(arr, int)`. Sets LIMIT n.
+    // `n` is stashed on q.limitBindExpr; the bind statement is emitted in
+    // emit_sql_macro_body AFTER the WHERE binds so the placeholder index
+    // (LIMIT comes after WHERE in SQL) lines up correctly.
+    {
+        var tCall = match_linq_call(node, "take")
+        if (tCall != null) {
+            if (q.seenTake) {
+                macro_error(prog, at, "_sql: take(n) can appear at most once in the chain")
+                return false
+            }
+            if (tCall.arguments |> length != 2) {
+                macro_error(prog, at, "_sql: only the `take(arr, n : int)` overload (chain form: `|> take(n)`) is supported in `_sql` chains; `take(arr, range)` is not translatable")
+                return false
+            }
+            q.limitBindExpr = clone_expression(tCall.arguments[1])
+            q.seenTake = true
+            return analyze_chain(tCall.arguments[0], q, prog, at)
+        }
+    }
+
+    // Peel order_by(prev, lambda) — post-expansion of `_order_by(prev, expr)`.
+    // Single-column: body is `_.Col` → push `"Col" ASC`.
+    // Multi-column: body is a tuple literal `(_.k1, _.k2)` → push each
+    // `"k_i" ASC`. After `_group_by`, body is `_._0` (single key) or
+    // `_._0._N` (multi-key). Mixed ASC/DESC across columns is out of
+    // chunk-4 scope (use the raw-SQL escape hatch); see plan D2.
+    //
+    // Recurse FIRST so `q.seenGroupBy` / `q.groupByCols` are populated by
+    // the time `collect_order_keys` runs, letting it route `_._0` to the
+    // correct group-by column.
+    {
+        var obCall = match_linq_call(node, "order_by")
+        if (obCall != null) {
+            if (q.seenOrderBy) {
+                macro_error(prog, at, "_sql: _order_by() can appear at most once in the chain (use a tuple key for multi-column ordering: `_order_by((_.k1, _.k2))`)")
+                return false
+            }
+            var body = peel_lambda_body(obCall.arguments[1])
+            if (body == null) {
+                macro_error(prog, at, "_sql: _order_by key lambda has unexpected shape")
+                return false
+            }
+            if (!analyze_chain(obCall.arguments[0], q, prog, at)) {
+                return false
+            }
+            if (!collect_order_keys(body, q, "ASC", prog, at)) {
+                return false
+            }
+            q.seenOrderBy = true
+            return true
+        }
+    }
+
+    // Peel order_by_descending(prev, lambda) — post-expansion of
+    // `_order_by_descending(prev, expr)`. Same shape as order_by; emits DESC.
+    {
+        var odCall = match_linq_call(node, "order_by_descending")
+        if (odCall != null) {
+            if (q.seenOrderBy) {
+                macro_error(prog, at, "_sql: _order_by() can appear at most once in the chain (use a tuple key for multi-column ordering)")
+                return false
+            }
+            var body = peel_lambda_body(odCall.arguments[1])
+            if (body == null) {
+                macro_error(prog, at, "_sql: _order_by_descending key lambda has unexpected shape")
+                return false
+            }
+            if (!analyze_chain(odCall.arguments[0], q, prog, at)) {
+                return false
+            }
+            if (!collect_order_keys(body, q, "DESC", prog, at)) {
+                return false
+            }
+            q.seenOrderBy = true
+            return true
+        }
+    }
+
+    // Peel skip(prev, n) — linq.das's `skip(arr, int)`. Sets OFFSET n.
+    // OFFSET in SQL requires LIMIT; SQLite accepts `LIMIT -1 OFFSET n` to
+    // skip-without-limit, which build_sql_string emits when seenSkip without
+    // seenTake.
+    {
+        var sCall = match_linq_call(node, "skip")
+        if (sCall != null) {
+            if (q.seenSkip) {
+                macro_error(prog, at, "_sql: skip(n) can appear at most once in the chain")
+                return false
+            }
+            if (sCall.arguments |> length != 2) {
+                macro_error(prog, at, "_sql: only the `skip(arr, n : int)` overload (chain form: `|> skip(n)`) is supported in `_sql` chains")
+                return false
+            }
+            q.offsetBindExpr = clone_expression(sCall.arguments[1])
+            q.seenSkip = true
+            return analyze_chain(sCall.arguments[0], q, prog, at)
+        }
+    }
+
     // Peel select(prev, lambda) — post-expansion of `_select(prev, expr)`.
+    // Recurses into the inner chain FIRST so any downstream `_group_by` has
+    // populated `q.seenGroupBy` by the time we analyze the projection body.
+    // The grouped path uses `analyze_grouped_projection` (mixed group keys +
+    // group-scope aggregate primitives); the row-scope path uses
+    // `analyze_projection`.
     {
         var sCall = match_linq_call(node, "select")
         if (sCall != null) {
@@ -306,16 +524,105 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
                 q.seenSelect = true
                 return analyze_chain(sCall.arguments[0], q, prog, at)
             }
+            // Recurse first so q.seenGroupBy reflects whether a downstream
+            // `_group_by` will fuse with this `_select`.
+            if (!analyze_chain(sCall.arguments[0], q, prog, at)) {
+                return false
+            }
             var body = peel_lambda_body(sCall.arguments[1])
             if (body == null) {
                 macro_error(prog, at, "_sql: _select projection lambda has unexpected shape")
                 return false
             }
-            if (!analyze_projection(body, q, prog, at)) {
-                return false
+            if (q.seenGroupBy) {
+                if (!analyze_grouped_projection(body, q, prog, at)) {
+                    return false
+                }
+            } else {
+                if (!analyze_projection(body, q, prog, at)) {
+                    return false
+                }
             }
             q.seenSelect = true
-            return analyze_chain(sCall.arguments[0], q, prog, at)
+            return true
+        }
+    }
+
+    // Peel having_(prev, lambda) — post-expansion of `_having(prev, predicate)`.
+    // Recurses into the inner chain FIRST so we can validate that `_group_by`
+    // is downstream (HAVING without GROUP BY is meaningless in SQL). Binds
+    // captured by the predicate go to `q.havingBindExprs` so they can be
+    // appended after WHERE binds in the placeholder index sequence.
+    {
+        var hCall = match_linq_call(node, "having_")
+        if (hCall != null) {
+            if (hCall.arguments |> length != 2) {
+                macro_error(prog, at, "_sql: _having has unexpected shape; expected having_(prev, predicate)")
+                return false
+            }
+            let beforeGroupBy = q.seenGroupBy
+            if (!analyze_chain(hCall.arguments[0], q, prog, at)) {
+                return false
+            }
+            if (q.seenHaving) {
+                macro_error(prog, at, "_sql: _having can appear at most once in the chain")
+                return false
+            }
+            if (!q.seenGroupBy) {
+                macro_error(prog, at, "_sql: _having requires a preceding _group_by; for row-level filters use _where")
+                return false
+            }
+            if (beforeGroupBy) {
+                // _group_by was set BEFORE we recursed → it sits OUTSIDE this
+                // _having in source order = HAVING came before GROUP BY.
+                macro_error(prog, at, "_sql: _having must appear AFTER _group_by in the chain")
+                return false
+            }
+            var body = peel_lambda_body(hCall.arguments[1])
+            if (body == null) {
+                macro_error(prog, at, "_sql: _having predicate lambda has unexpected shape")
+                return false
+            }
+            q.inHaving = true
+            let s = pred_to_sql(body, q, prog, at)
+            q.inHaving = false
+            if (empty(s)) {
+                return false   // pred_to_sql already issued a macro_error
+            }
+            q.havingSql = s
+            q.seenHaving = true
+            return true
+        }
+    }
+
+    // Peel group_by_lazy(prev, lambda) — post-expansion of both `_group_by`
+    // and `_group_by_lazy` (linq_boost lowers both to the same backing call).
+    // Inside `_sql` both forms emit GROUP BY; the IGrouping per-group
+    // iterators never materialize at runtime because `_sql` rewrites the
+    // entire chain into a `run_select` call before evaluation. Users who
+    // want the actual IGrouping per-group iterator should not wrap in
+    // `_sql(...)`.
+    {
+        var gbCall = match_linq_call(node, "group_by_lazy")
+        if (gbCall != null) {
+            if (q.seenGroupBy) {
+                macro_error(prog, at, "_sql: _group_by can appear at most once in the chain")
+                return false
+            }
+            if (gbCall.arguments |> length != 2) {
+                macro_error(prog, at, "_sql: _group_by expects (chain, key)")
+                return false
+            }
+            var body = peel_lambda_body(gbCall.arguments[1])
+            if (body == null) {
+                macro_error(prog, at, "_sql: _group_by key lambda has unexpected shape")
+                return false
+            }
+            if (!collect_group_keys(body, q, prog, at)) {
+                return false
+            }
+            q.seenGroupBy = true
+            return analyze_chain(gbCall.arguments[0], q, prog, at)
         }
     }
 
@@ -434,6 +741,275 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
 }
 
 // ============================================================================
+// Grouped projection analysis (_select after _group_by) — IGrouping shape.
+//
+// `_group_by` lowers to ``group_by_lazy`` which yields per-bucket tuples
+// of shape ``tuple<KeyType; array<RowType>>`` — index ``_0`` is the group
+// key, index ``_1`` is the array of group elements. The user expresses
+// SQL aggregates against that shape, and `_sql` translates the patterns
+// to GROUP BY + the corresponding SQL aggregate function:
+//
+//   _._0                                    → group key column (single-key)
+//   _._0._N                                 → multi-key Nth column
+//   _._1 |> length                                 → COUNT(*)
+//   _._1 |> count                                  → COUNT(*)
+//   _._1 |> select($(u:T) => u.X) |> sum           → SUM("X")
+//   _._1 |> select($(u:T) => u.X) |> average       → AVG("X")  (result type double)
+//   _._1 |> select($(u:T) => u.X) |> min           → MIN("X")
+//   _._1 |> select($(u:T) => u.X) |> max           → MAX("X")
+//
+// Required projection shape is a NAMED tuple literal so the result row
+// schema (column names) is explicit. The same aggregate recognition is
+// reused inside `_having` predicates by `try_translate_group_aggregate`.
+// ============================================================================
+
+[macro_function]
+def private peel_ref2val(var node : ExpressionPtr) : ExpressionPtr {
+    //! Strip a single ``ExprRef2Value`` wrapper that the typer inserts
+    //! around field reads after Mode-2 inner expansion. Returns ``node``
+    //! unchanged if not wrapped.
+    if (node != null && node is ExprRef2Value) {
+        var sub = (node as ExprRef2Value).subexpr
+        if (sub != null) {
+            return sub
+        }
+    }
+    return node
+}
+
+[macro_function]
+def private is_underscore_field(var node : ExpressionPtr; expectedField : string) : bool {
+    //! True if ``node`` is the ExprField ``_.<expectedField>`` (the lambda
+    //! parameter ``_`` followed by a specific tuple-index or struct field).
+    //! Inlined manually rather than via qmatch — qmatch inside helper
+    //! functions called from a macro_function body did not match reliably
+    //! in this context.
+    var n = peel_ref2val(node)
+    if (n == null || !(n is ExprField)) {
+        return false
+    }
+    var ef = n as ExprField
+    if (ef.name != expectedField) {
+        return false
+    }
+    var recv = peel_ref2val(ef.value)
+    if (recv == null || !(recv is ExprVar)) {
+        return false
+    }
+    return (recv as ExprVar).name == "_"
+}
+
+[macro_function]
+def private group_key_column_name(q : SqlQuery; idx : int) : string {
+    //! Return the unquoted column name of the idx-th group-by key.
+    //! ``q.groupByCols[idx]`` is already SQL-quoted (e.g. ``"\"City\""``);
+    //! strip the surrounding quotes.
+    let raw = q.groupByCols[idx]
+    let n = length(raw)
+    if (n >= 2 && raw |> starts_with("\"") && raw |> ends_with("\"")) {
+        return slice(raw, 1, n - 1)
+    }
+    return raw
+}
+
+[macro_function]
+def private try_translate_group_aggregate(var node : ExpressionPtr; q : SqlQuery; prog : ProgramPtr; at : LineInfo;
+                                          var sqlOut : string&; var typeOut : TypeDeclPtr&) : bool {
+    //! Recognize one of the IGrouping-shape SQL aggregate patterns and
+    //! fill ``sqlOut`` / ``typeOut``. Returns true on a recognized
+    //! aggregate (even on column-resolution failure — caller checks
+    //! ``empty(sqlOut)``); false if the node isn't one of the recognized
+    //! aggregate forms.
+    var n = peel_ref2val(node)
+    if (n == null || !(n is ExprCall)) {
+        return false
+    }
+    var call = n as ExprCall
+    if (call.func == null) {
+        return false
+    }
+    var fname = string(call.func.name)
+    if (call.func.fromGeneric != null) {
+        fname = string(call.func.fromGeneric.name)
+    }
+    let argc = user_arg_count(call)
+
+    // length(_._1) / count(_._1) → COUNT(*)
+    // Result type is `int` to match daslang's `length`/`count` return on
+    // arrays. SQLite COUNT(*) returns int64 internally but sqlite_read
+    // narrows to int via sqlite3_column_int — fine for any plausible row
+    // count and matches the user's projection-tuple inferred type.
+    if ((fname == "length" || fname == "count") && argc == 1
+            && is_underscore_field(call.arguments[0], "_1")) {
+        sqlOut = "COUNT(*)"
+        typeOut = new TypeDecl(at = at, baseType = Type.tInt)
+        return true
+    }
+
+    // sum / average / min / max applied to select(_._1, $(p:T) => p.X) → SUM("X") / etc.
+    // The inner lambda's parameter name is intentionally NOT required to be
+    // `_` — daslang flags `_` shadowing across nested lambdas as a compile
+    // error (the outer lambda's `_` is the group tuple, the inner is a row),
+    // so users name the inner parameter explicitly (`$(u : User) => u.Age`).
+    if ((fname == "sum" || fname == "average" || fname == "min" || fname == "max") && argc == 1) {
+        var inner : ExpressionPtr = call.arguments[0]
+        var innerCall = match_linq_call(inner, "select")
+        if (innerCall != null && innerCall.arguments |> length == 2
+                && is_underscore_field(innerCall.arguments[0], "_1")) {
+            var lamBody = peel_lambda_body(innerCall.arguments[1])
+            if (lamBody == null) {
+                macro_error(prog, at, "_sql: aggregate's inner select lambda has unexpected shape")
+                return true
+            }
+            lamBody = peel_ref2val(lamBody)
+            // Body must be `<param>.<field>` — an ExprField rooted at a
+            // single ExprVar (the lambda's parameter, whatever its name).
+            if (lamBody != null && lamBody is ExprField) {
+                var ef = lamBody as ExprField
+                var recv = peel_ref2val(ef.value)
+                if (recv != null && recv is ExprVar) {
+                    let col = string(ef.name)
+                    var sqlOp = ""
+                    if (fname == "sum") {
+                        sqlOp = "SUM"
+                    } elif (fname == "average") {
+                        sqlOp = "AVG"
+                    } elif (fname == "min") {
+                        sqlOp = "MIN"
+                    } else {
+                        sqlOp = "MAX"
+                    }
+                    sqlOut = "{sqlOp}(\"{col}\")"
+                    if (fname == "average") {
+                        typeOut = new TypeDecl(at = at, baseType = Type.tDouble)
+                    } else {
+                        var colType = lookup_struct_field_type(q.rootType, col)
+                        if (colType == null) {
+                            macro_error(prog, at, "_sql: cannot resolve column '{col}' in {fname}(...)")
+                            return true
+                        }
+                        typeOut = colType
+                    }
+                    return true
+                }
+            }
+            macro_error(prog, at, "_sql: aggregate's inner select body must be `<param>.<field>`; got: {describe(lamBody)}")
+            return true
+        }
+    }
+    return false
+}
+
+[macro_function]
+def private analyze_grouped_projection(var body : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
+    if (body == null) {
+        macro_error(prog, at, "_sql: _select after _group_by: missing projection")
+        return false
+    }
+    body = peel_ref2val(body)
+    if (!(body is ExprMakeTuple)) {
+        macro_error(prog, at, "_sql: _select after _group_by must be a named-tuple projection — `(Key=_._0, N=_._1 |> length, AvgX=_._1 |> select($(u:T) => u.X) |> average)`. Got: {describe(body)}")
+        return false
+    }
+    var mkTup = body as ExprMakeTuple
+    var tupT = mkTup._type
+    if (tupT == null || tupT.baseType != Type.tTuple
+            || length(tupT.argNames) == 0
+            || length(tupT.argNames) != length(mkTup.values)) {
+        macro_error(prog, at, "_sql: _select after _group_by must be a NAMED tuple — every entry needs `Name=expr`")
+        return false
+    }
+    q.groupedSelectExprs |> clear
+    q.groupedSelectTypes |> clear
+    q.projRecordNames |> clear
+    let nKeys = length(q.groupByCols)
+    for (i in range(length(mkTup.values))) {
+        var val = peel_ref2val(mkTup.values[i])
+
+        // Inspect ExprField shapes — `_.<f>` (single-key key ref) and
+        // `_._0._<n>` (multi-key key component). Both have an outer
+        // ExprField; differentiate by recursing on the receiver.
+        if (val != null && val is ExprField) {
+            var ef = val as ExprField
+            var recv = peel_ref2val(ef.value)
+            let outerName = string(ef.name)
+            // Case A: receiver is ExprVar("_") — direct `_.<f>` (so `_._0` for single-key).
+            if (recv != null && recv is ExprVar
+                    && (recv as ExprVar).name == "_"
+                    && nKeys == 1
+                    && outerName == "_0") {
+                let col = group_key_column_name(q, 0)
+                var fieldType = lookup_struct_field_type(q.rootType, col)
+                if (fieldType == null) {
+                    macro_error(prog, at, "_sql: cannot resolve type of group key column '{col}'")
+                    return false
+                }
+                q.groupedSelectExprs |> push("\"{col}\"")
+                q.groupedSelectTypes |> push(fieldType)
+                q.projRecordNames |> push(string(tupT.argNames[i]))
+                continue
+            }
+            // Case B: receiver is itself `_._0` — multi-key form `_._0._<n>`.
+            if (nKeys > 1 && recv != null && recv is ExprField) {
+                var inner = recv as ExprField
+                var innerRecv = peel_ref2val(inner.value)
+                if (innerRecv != null && innerRecv is ExprVar
+                        && (innerRecv as ExprVar).name == "_"
+                        && inner.name == "_0") {
+                    if (length(outerName) > 1 && outerName |> starts_with("_")) {
+                        let suffix = slice(outerName, 1, length(outerName))
+                        var keyIdx = -1
+                        try {
+                            keyIdx = to_int(suffix)
+                        } recover {
+                            keyIdx = -1
+                        }
+                        if (keyIdx >= 0 && keyIdx < nKeys) {
+                            let col = group_key_column_name(q, keyIdx)
+                            var fieldType = lookup_struct_field_type(q.rootType, col)
+                            if (fieldType == null) {
+                                macro_error(prog, at, "_sql: cannot resolve type of group key column '{col}'")
+                                return false
+                            }
+                            q.groupedSelectExprs |> push("\"{col}\"")
+                            q.groupedSelectTypes |> push(fieldType)
+                            q.projRecordNames |> push(string(tupT.argNames[i]))
+                            continue
+                        }
+                        macro_error(prog, at, "_sql: multi-key group has {nKeys} keys; `_._0.{outerName}` is out of range")
+                        return false
+                    }
+                }
+            }
+            // Multi-key reject: `_._0` (whole key tuple) is ambiguous in projection.
+            if (nKeys > 1 && recv != null && recv is ExprVar
+                    && (recv as ExprVar).name == "_"
+                    && outerName == "_0") {
+                macro_error(prog, at, "_sql: multi-key group: `_._0` refers to the whole key tuple; use `_._0._N` to access the N-th key column")
+                return false
+            }
+        }
+
+        // Aggregate over the group's elements (`_._1`).
+        var sqlFrag : string
+        var resType : TypeDeclPtr
+        if (try_translate_group_aggregate(val, q, prog, at, sqlFrag, resType)) {
+            if (empty(sqlFrag)) {
+                return false   // helper emitted macro_error
+            }
+            q.groupedSelectExprs |> push(sqlFrag)
+            q.groupedSelectTypes |> push(resType)
+            q.projRecordNames |> push(string(tupT.argNames[i]))
+            continue
+        }
+        macro_error(prog, at, "_sql: _select after _group_by: each value must be a group key reference (`_._0` or `_._0._N` for multi-key) or an aggregate (`_._1 |> length`, `_._1 |> select($(u:T) => u.X) |> sum/average/min/max`); got: {describe(val)}")
+        return false
+    }
+    q.proj = ProjectionShape.GroupedNamedTuple
+    return true
+}
+
+// ============================================================================
 // Predicate analysis (_where) — recursive AST walk emitting SQL.
 //
 // Bind capture: literals and free-variable references become `?` placeholders;
@@ -444,6 +1020,156 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
 // its own bare block so partial writes from a failed earlier attempt cannot
 // leak into a later attempt.
 // ============================================================================
+
+[macro_function]
+def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; direction : string; prog : ProgramPtr; at : LineInfo) : bool {
+    //! Walk the body of an order_by lambda and push column entries onto
+    //! q.orderByCols. Accepts a single `_.Field` reference (one column) or a
+    //! tuple literal `(_.k1, _.k2)` (multi-column). All columns get the same
+    //! direction (ASC or DESC) per chunk-4 scope; mixed-direction is plan D2.
+    if (body == null) {
+        macro_error(prog, at, "_sql: _order_by: missing key expression")
+        return false
+    }
+    if (body is ExprRef2Value) {
+        body = (body as ExprRef2Value).subexpr
+        if (body == null) {
+            macro_error(prog, at, "_sql: _order_by: ExprRef2Value with null subexpr")
+            return false
+        }
+    }
+    // Group-key form (after `_group_by`): `_._0` (single key) or `_._0._N`
+    // (multi-key Nth column). The chain element type post-group is
+    // `tuple<K; array<T>>` so plain `_.Field` no longer typechecks; users
+    // sort by the group key explicitly.
+    if (q.seenGroupBy && body is ExprField) {
+        var ef = body as ExprField
+        var recv = ef.value
+        if (recv is ExprRef2Value) {
+            recv = (recv as ExprRef2Value).subexpr
+        }
+        let outerName = string(ef.name)
+        let nKeys = length(q.groupByCols)
+        // Single-key: `_._0` → first group-by column.
+        if (nKeys == 1 && recv != null && recv is ExprVar
+                && (recv as ExprVar).name == "_"
+                && outerName == "_0") {
+            q.orderByCols |> push("{q.groupByCols[0]} {direction}")
+            return true
+        }
+        // Multi-key: `_._0._N`.
+        if (nKeys > 1 && recv != null && recv is ExprField) {
+            var inner = recv as ExprField
+            var innerRecv = inner.value
+            if (innerRecv is ExprRef2Value) {
+                innerRecv = (innerRecv as ExprRef2Value).subexpr
+            }
+            if (innerRecv != null && innerRecv is ExprVar
+                    && (innerRecv as ExprVar).name == "_"
+                    && inner.name == "_0"
+                    && length(outerName) > 1 && outerName |> starts_with("_")) {
+                let suffix = slice(outerName, 1, length(outerName))
+                var keyIdx = -1
+                try {
+                    keyIdx = to_int(suffix)
+                } recover {
+                    keyIdx = -1
+                }
+                if (keyIdx >= 0 && keyIdx < nKeys) {
+                    q.orderByCols |> push("{q.groupByCols[keyIdx]} {direction}")
+                    return true
+                }
+            }
+        }
+    }
+    // Single-column form: _.FieldName
+    {
+        var fieldName : string
+        if (qmatch(body, _.$f(fieldName)).matched) {
+            q.orderByCols |> push("\"{fieldName}\" {direction}")
+            return true
+        }
+    }
+    // Multi-column form: tuple literal `(_.k1, _.k2)`. Each entry must be
+    // a `_.Field` ref (after ExprRef2Value peel). Anonymous tuple (no
+    // recordNames) is the natural shape; named tuples also work.
+    if (body is ExprMakeTuple) {
+        var mkTup = body as ExprMakeTuple
+        if (length(mkTup.values) == 0) {
+            macro_error(prog, at, "_sql: _order_by: empty tuple key")
+            return false
+        }
+        for (i in range(length(mkTup.values))) {
+            var val = mkTup.values[i]
+            if (val is ExprRef2Value) {
+                val = (val as ExprRef2Value).subexpr
+            }
+            var fieldName : string
+            if (qmatch(val, _.$f(fieldName)).matched) {
+                q.orderByCols |> push("\"{fieldName}\" {direction}")
+            } else {
+                macro_error(prog, at, "_sql: _order_by: tuple-key entries must be `_.Field`; got: {describe(val)}")
+                return false
+            }
+        }
+        return true
+    }
+    macro_error(prog, at, "_sql: _order_by: key must be `_.Field` or a tuple of `_.Field`s; got: {describe(body)}")
+    return false
+}
+
+[macro_function]
+def private collect_group_keys(var body : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
+    //! Walk the body of a `_group_by` lambda and push column entries onto
+    //! ``q.groupByCols``. Accepts a single ``_.Field`` reference or a tuple
+    //! literal of ``_.Field`` references for multi-column grouping. SQL
+    //! functions in the key (e.g. ``year(_.SignupDate)``) are not yet
+    //! supported in chunk 4 — see API_REWORK § 19 / mockup section (c).
+    if (body == null) {
+        macro_error(prog, at, "_sql: _group_by: missing key expression")
+        return false
+    }
+    if (body is ExprRef2Value) {
+        body = (body as ExprRef2Value).subexpr
+        if (body == null) {
+            macro_error(prog, at, "_sql: _group_by: ExprRef2Value with null subexpr")
+            return false
+        }
+    }
+    // Single-column form: _.FieldName
+    {
+        var fieldName : string
+        if (qmatch(body, _.$f(fieldName)).matched) {
+            q.groupByCols |> push("\"{fieldName}\"")
+            return true
+        }
+    }
+    // Multi-column form: tuple literal `(_.k1, _.k2)`. Both anonymous and
+    // named tuples accepted (the names don't affect SQL emission).
+    if (body is ExprMakeTuple) {
+        var mkTup = body as ExprMakeTuple
+        if (length(mkTup.values) == 0) {
+            macro_error(prog, at, "_sql: _group_by: empty tuple key")
+            return false
+        }
+        for (i in range(length(mkTup.values))) {
+            var val = mkTup.values[i]
+            if (val is ExprRef2Value) {
+                val = (val as ExprRef2Value).subexpr
+            }
+            var fieldName : string
+            if (qmatch(val, _.$f(fieldName)).matched) {
+                q.groupByCols |> push("\"{fieldName}\"")
+            } else {
+                macro_error(prog, at, "_sql: _group_by: tuple-key entries must be `_.Field`; got: {describe(val)}")
+                return false
+            }
+        }
+        return true
+    }
+    macro_error(prog, at, "_sql: _group_by: key must be `_.Field` or a tuple of `_.Field`s; got: {describe(body)}")
+    return false
+}
 
 [macro_function]
 def private analyze_predicate(var body : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
@@ -550,6 +1276,24 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         }
     }
 
+    // Group-scope aggregate (IGrouping shape) in expression position —
+    // typically inside HAVING (`_._1 |> length > 5l`). The same patterns
+    // recognized by `analyze_grouped_projection`. The aggregate's SQL
+    // fragment doesn't depend on WHERE/HAVING context, so we accept it in
+    // either (SQLite will reject aggregates inside WHERE at runtime with a
+    // clear "misuse of aggregate" error). The result type is discarded
+    // here — the surrounding comparison handles type matching.
+    {
+        var aggSql : string
+        var aggType : TypeDeclPtr
+        if (try_translate_group_aggregate(node, q, prog, at, aggSql, aggType)) {
+            if (empty(aggSql)) {
+                return ""   // helper emitted macro_error
+            }
+            return aggSql
+        }
+    }
+
     // Function call → SQL function dispatch (table-driven entries below).
     // Handles `_.Name |> starts_with("F")` (post-pipe-expansion: starts_with(_.Name, "F")),
     // `length(_.Name)`, `_.Price |> abs()`, `to_lower(_.Name)`, etc.
@@ -563,8 +1307,14 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
     // Literal / captured var → bind param. Clone the *peeled* expression so
     // when we re-emit it as a `sqlite_bind` argument the runtime reads the
     // captured value cleanly (without re-wrapping into ExprRef2Value).
+    // Inside `_having`, route to havingBindExprs so the placeholder index
+    // matches the SQL emission order (WHERE → HAVING → LIMIT).
     if (is_const_or_captured_var(node)) {
-        q.bindExprs |> push <| clone_expression(node)
+        if (q.inHaving) {
+            q.havingBindExprs |> push <| clone_expression(node)
+        } else {
+            q.bindExprs |> push <| clone_expression(node)
+        }
         return "?"
     }
 
@@ -662,6 +1412,28 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
         return "ABS({inner})"
     }
 
+    // ---- Option<T> nullability ----
+    // `_.Col |> is_some()` / `_.Col |> is_none()` translate to SQL's
+    // explicit null-check operators. Always use IS NULL / IS NOT NULL —
+    // `Col = NULL` is never true under SQL's three-valued logic, so the
+    // typesafe path here is also the semantically correct one.
+    if (fname == "is_some" && argc == 1) {
+        let inner = pred_to_sql(call.arguments[0], q, prog, at)
+        return "{inner} IS NOT NULL"
+    }
+    if (fname == "is_none" && argc == 1) {
+        let inner = pred_to_sql(call.arguments[0], q, prog, at)
+        return "{inner} IS NULL"
+    }
+    // `_.Col |> unwrap_or(default)` collapses NULL to a fallback —
+    // `COALESCE("Col", ?)`. The default goes through pred_to_sql so it
+    // can be a literal, captured local, or another column reference.
+    if (fname == "unwrap_or" && argc == 2) {
+        let inner = pred_to_sql(call.arguments[0], q, prog, at)
+        let dflt  = pred_to_sql(call.arguments[1], q, prog, at)
+        return "COALESCE({inner}, {dflt})"
+    }
+
     return ""
 }
 
@@ -741,8 +1513,20 @@ def private sql_table_name_from_type(rootT : TypeDeclPtr) : string {
 def private build_sql_string(q : SqlQuery) : string {
     return build_string() $(var w) {
         w |> write("SELECT ")
+        if (q.distinctFlag) {
+            w |> write("DISTINCT ")
+        }
         if (q.proj == ProjectionShape.Aggregate) {
             w |> write(q.aggregateExpr)
+        } elif (q.proj == ProjectionShape.GroupedNamedTuple) {
+            // Already-formatted SQL fragments (e.g. `"City"`, `COUNT(*)`,
+            // `AVG("Age")`); emit verbatim, no extra quoting.
+            for (i in range(length(q.groupedSelectExprs))) {
+                if (i > 0) {
+                    w |> write(", ")
+                }
+                w |> write(q.groupedSelectExprs[i])
+            }
         } else {
             for (i in range(length(q.selectCols))) {
                 if (i > 0) {
@@ -760,8 +1544,48 @@ def private build_sql_string(q : SqlQuery) : string {
             w |> write(" WHERE ")
             w |> write(q.whereSql)
         }
-        if (!empty(q.sqlSuffix)) {
-            w |> write(q.sqlSuffix)
+        // GROUP BY / HAVING come between WHERE and ORDER BY in SQL clause
+        // order. groupByCols entries are pre-quoted; havingSql is the
+        // pre-formatted clause body (no leading "HAVING ").
+        if (length(q.groupByCols) > 0) {
+            w |> write(" GROUP BY ")
+            for (i in range(length(q.groupByCols))) {
+                if (i > 0) {
+                    w |> write(", ")
+                }
+                w |> write(q.groupByCols[i])
+            }
+        }
+        if (!empty(q.havingSql)) {
+            w |> write(" HAVING ")
+            w |> write(q.havingSql)
+        }
+        if (length(q.orderByCols) > 0) {
+            w |> write(" ORDER BY ")
+            for (i in range(length(q.orderByCols))) {
+                if (i > 0) {
+                    w |> write(", ")
+                }
+                w |> write(q.orderByCols[i])
+            }
+        }
+        // LIMIT / OFFSET. Single-row terminals (One/OneOpt) force LIMIT 1
+        // regardless of any user-supplied _take() — except aggregates, which
+        // intrinsically return one row (LIMIT 1 would be redundant noise on
+        // SELECT COUNT/SUM/AVG/MIN/MAX). User _take wins only when the
+        // materializer is Array. SQLite requires LIMIT to precede OFFSET,
+        // and OFFSET without LIMIT needs LIMIT -1 (= no upper bound).
+        let forced_one_row = ((q.matr == Materializer.One || q.matr == Materializer.OneOpt)
+                              && q.proj != ProjectionShape.Aggregate)
+        if (forced_one_row) {
+            w |> write(" LIMIT 1")
+        } elif (q.limitBindExpr != null) {
+            w |> write(" LIMIT ?")
+        } elif (q.offsetBindExpr != null) {
+            w |> write(" LIMIT -1")
+        }
+        if (!forced_one_row && q.offsetBindExpr != null) {
+            w |> write(" OFFSET ?")
         }
     }
 }
@@ -864,6 +1688,25 @@ def private build_row_builder(q : SqlQuery; prog : ProgramPtr; at : LineInfo) : 
         mkTup.recordType = tupT
         return mkTup
     }
+    if (q.proj == ProjectionShape.GroupedNamedTuple) {
+        // Same shape as NamedTuple, but column types come from
+        // `groupedSelectTypes` (filled at projection-analysis time —
+        // mixes group-key column types with aggregate result types).
+        let n = length(q.groupedSelectExprs)
+        var tupT = new TypeDecl(at = at, baseType = Type.tTuple)
+        tupT.argNames.resize(n)
+        var mkTup = new ExprMakeTuple(at = at)
+        for (i in range(n)) {
+            let colIdx = i
+            var fieldType = clone_type(q.groupedSelectTypes[i])
+            var readExpr = qmacro(sqlite_read(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
+            emplace(mkTup.values, readExpr)
+            tupT.argTypes |> emplace_new(clone_type(fieldType))
+            tupT.argNames[i] := q.projRecordNames[i]
+        }
+        mkTup.recordType = tupT
+        return mkTup
+    }
     // FullRow (default)
     var rootType = clone_type(q.rootType)
     return qmacro(_::_sql_read_row(_sql_stmt, type<$t(rootType)>))
@@ -880,6 +1723,54 @@ def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; is
     var q = SqlQuery()
     if (!analyze_chain(call.arguments[0], q, prog, call.at)) {
         return null
+    }
+    // `take(n)` / `skip(n)` upstream of an aggregate (sum / average /
+    // min / max / count) is degenerate in SQL: the aggregate already
+    // collapses to one row, so `LIMIT n` / `OFFSET n` become no-ops
+    // (e.g. `SELECT SUM(p) FROM Cars LIMIT 2` returns the sum of
+    // ALL rows). The user almost certainly wants "<agg> over the
+    // first n rows", which requires a subquery
+    // (`SELECT SUM(c) FROM (SELECT p AS c FROM Cars LIMIT 2)`) —
+    // landing with joins / subqueries in chunk 5+. Reject loud now
+    // so users see a clear pointer instead of silently-wrong sums.
+    if (q.proj == ProjectionShape.Aggregate
+            && (q.limitBindExpr != null || q.offsetBindExpr != null)) {
+        macro_error(prog, call.at, "_sql: take(n)/skip(n) before an aggregate is not translatable — `LIMIT`/`OFFSET` after an aggregate has no effect (aggregate collapses to one row); use `_where(...)` for pre-aggregate filtering, or wait for subquery support in chunk 5+")
+        return null
+    }
+    // `distinct()` upstream of an aggregate (sum / average / min /
+    // max / count) is degenerate in SQL: `SELECT DISTINCT SUM(...)`
+    // / `SELECT DISTINCT COUNT(*)` etc. dedupe a single-row result,
+    // which is always a no-op. The meaningful form is
+    // `COUNT(DISTINCT col)` (DISTINCT *inside* the aggregate), which
+    // would need a separate analyzer path — not yet wired. Reject
+    // loud rather than emit silently-meaningless SQL.
+    if (q.proj == ProjectionShape.Aggregate && q.distinctFlag) {
+        macro_error(prog, call.at, "_sql: distinct() before an aggregate is not translatable — `SELECT DISTINCT` over a single-row aggregate result is always a no-op; the meaningful form is `COUNT(DISTINCT col)` etc. (aggregate-distinct), which is not yet implemented")
+        return null
+    }
+    // Append HAVING / LIMIT / OFFSET binds AFTER WHERE binds so the
+    // placeholder index matches the SQL order
+    // (WHERE … HAVING … LIMIT ? OFFSET ?). Single-row terminals
+    // (`_first` / `_first_opt`) emit a literal `LIMIT 1` (no bind),
+    // so skip the limit push in that case. Aggregate terminals
+    // (`sum` / `average` / `min` / `max` / `count`) with upstream
+    // `take(n)` / `skip(n)` are rejected at compile time above
+    // (degenerate SQL — `LIMIT` after an aggregate is a no-op), so
+    // there's no aggregate-specific bind push reachable here. The
+    // `q.proj != Aggregate` exclusion below mirrors
+    // `build_sql_string`'s `forced_one_row` check for hygiene.
+    q.bindExprs |> reserve(length(q.bindExprs) + length(q.havingBindExprs) + 2)
+    for (be in q.havingBindExprs) {
+        q.bindExprs |> push(be)
+    }
+    let forced_one_row = ((q.matr == Materializer.One || q.matr == Materializer.OneOpt)
+        && q.proj != ProjectionShape.Aggregate)
+    if (!forced_one_row && q.limitBindExpr != null) {
+        q.bindExprs |> push(q.limitBindExpr)
+    }
+    if (!forced_one_row && q.offsetBindExpr != null) {
+        q.bindExprs |> push(q.offsetBindExpr)
     }
     let sql = build_sql_string(q)
 

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -178,9 +178,106 @@ CI's `extended_checks` job runs `./bin/Release/daslang ./das-fmt/dasfmt.das -- -
 
 Stage, commit, push, and create the PR using GitHub MCP tools or `gh` CLI. Follow the commit message conventions from the repository (see recent `git log` for style).
 
-**Squashed branches:** If the user asked to squash the branch (single commit), keep it squashed. Any subsequent fixes (lint, test failures, formatting, CI issues) must be amended into the existing commit (`git commit --amend --no-edit`) and force-pushed — do NOT create new commits on a squashed branch.
+**Squashed branches:** If the user asked to squash the branch (single commit), keep it squashed. Any subsequent fixes (lint, test failures, formatting, CI issues, review-comment fixes) must be amended into the existing commit (`git commit --amend --no-edit`) and force-pushed — do NOT create new commits on a squashed branch.
 
 **Squash-from-multi-commit pattern (`git reset --soft master`)**: only safe AFTER step 0 has rebased onto `origin/master`. Otherwise the soft reset collapses the gap between local `master` and origin's into your one commit. If you forgot step 0 and already pushed a leaky PR, the fix is `git fetch origin master && git rebase origin/master && git push --force-with-lease` — git's 3-way merge drops files where your "modification" matches the already-merged content on origin/master.
+
+## 7. Iterate on review feedback (CI failures + Copilot/human comments)
+
+Once the PR is open, the work isn't done — CI runs and a reviewer (Copilot, human, or both) leaves comments. Drive each round to closure with the same discipline as the gates above: triage, fix, re-run gates, amend, force-push, reply, resolve, re-request.
+
+### 7a. Watching the PR
+
+Pick a cadence — either ping the user when something interesting happens, or use `/loop` (without an interval, dynamic mode) to self-pace polls. On each tick:
+
+- `gh pr checks <PR>` — CI status (pending / pass / fail)
+- `gh api repos/<owner>/<repo>/pulls/<PR>/comments` — inline review comments
+- `gh api repos/<owner>/<repo>/pulls/<PR>/reviews` — review-level state (`COMMENTED` / `CHANGES_REQUESTED` / `APPROVED`)
+
+When CI is green AND Copilot has left a `COMMENTED`-state review (or a human approved), surface and stop polling — there's something to react to.
+
+### 7b. CI failure handling
+
+If a check goes red:
+1. Identify the failing job: `gh pr checks <PR>` shows the URL; `gh run view <runID> --log-failed` fetches the log.
+2. Apply the same fix policy as Step 2: own change → fix it; obvious pre-existing → fix it; non-obvious pre-existing → ask the user.
+3. After the fix, **re-run the gates from Step 1-5** (lint + interpreted + AOT + Sphinx if `//!` or RST touched + format) — don't trust spot-checks. CI failures often come bundled (a missing format triggers a lint, a removed function triggers an AOT hash mismatch).
+4. Amend the squashed commit + force-push. CI re-runs automatically on push. No need to re-request review for a CI-only fix unless the diff is large.
+
+### 7c. Triaging review comments — discuss BEFORE acting
+
+When a review lands (especially Copilot — fast, often verbose), **don't auto-execute**. Pull the comments, classify each one, and surface to the user with a verdict per comment. Only act after the user signs off.
+
+Fetch the comments:
+```bash
+gh api repos/<owner>/<repo>/pulls/<PR>/comments | jq '.[] | {id, path, line: (.line // .original_line), body}'
+```
+
+For each comment, give the user a concise verdict:
+
+| Verdict | Means | Example |
+|---|---|---|
+| 🔴 **Real bug** | Reviewer found a correctness issue | "take(n) before aggregate emits unbound `LIMIT ?` placeholder" |
+| 🟡 **Cosmetic accept** | Wording / consistency / doc-drift fix | "diagnostic says `_distinct()` but public API is `distinct()`" |
+| 🔴 **Reject with evidence** | Reviewer is wrong; reply with proof | "RST already matches actual emitter output (paste runtime line)" |
+
+Real-bug verdicts deserve a probe before declaring fix direction — the obvious fix isn't always the right fix. (e.g., aligning the bind-push wasn't enough for the `take(n) |> sum()` bug because the underlying SQL is degenerate; the right answer was compile-time rejection.)
+
+Wait for the user to greenlight before applying. They may push back on individual verdicts ("reject this one too" or "let's not bundle this fix into chunk 4").
+
+### 7d. Apply fixes + re-run gates
+
+After greenlight:
+1. Edit the code per the agreed verdicts.
+2. **Watch for contradictory comments.** When fixing a bug, scan inline comments that describe the affected surface — they often need updating in the same pass. (If you forget, the next review round will flag it.)
+3. **Re-run the full gates** from Step 1-5. Yes, full. CI is unforgiving; every amend goes back through the whole matrix.
+4. **`//!` doc-comment changes:** re-run `bin/Release/daslang.exe doc/reflections/das2rst.das`, then a clean Sphinx build (`rm -rf doc/sphinx-build site/doc` first — cached builds hide errors). Generated `doc/source/stdlib/generated/*.rst` are gitignored; Sphinx picks them up at build time.
+5. **`git commit --amend --no-edit`** + **`git push --force-with-lease`** (NOT `--force` — protects against racing pushes).
+
+### 7e. Reply to each comment + resolve all threads
+
+Replying and resolving are **separate API surfaces**. Both are required.
+
+**Reply** uses the REST API via the MCP tool (takes the comment's `id`):
+```
+mcp__github__add_reply_to_pull_request_comment(commentId=<id>, body="…")
+```
+Reply content should:
+- For accepts: state what changed and why (e.g. "kept your suggestion but tightened the wording because the original exposed macro-author internals").
+- For accepts with sibling fixes: mention them ("also caught a sibling diagnostic on line ~996 with the same wrong example").
+- For rejects: include evidence — runtime output, file content, a probe script result. Don't just say "I disagree."
+
+**Resolve** uses GraphQL — REST doesn't expose `resolveReviewThread`. Two-step:
+
+```bash
+# Get thread node IDs (each thread wraps one or more comments)
+gh api graphql -f query='query { repository(owner:"O", name:"R") { pullRequest(number:N) { reviewThreads(first:30) { nodes { id isResolved comments(first:1) { nodes { databaseId path line } } } } } } }'
+
+# Resolve each
+gh api graphql -f query="mutation { resolveReviewThread(input:{threadId:\"$thread\"}) { thread { id isResolved } } }"
+```
+
+**Resolve every thread you replied on** — including rejections (the discussion is closed; the reply explains why). Verify at the end:
+
+```bash
+gh api graphql -f query='query { repository(owner:"O", name:"R") { pullRequest(number:N) { reviewThreads(first:30) { nodes { id isResolved } } } } }' | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+```
+Expect `0`.
+
+### 7f. Re-request Copilot review
+
+After all replies + resolves + force-push, re-request:
+```
+mcp__github__request_copilot_review(owner=…, repo=…, pullNumber=…)
+```
+Copilot reviews the new commit's diff and may flag:
+- Same-class issues you missed elsewhere in the file (it's worth scanning the affected file for each accepted pattern before pushing — saves a round).
+- New issues introduced by the fix itself (e.g. a comment block that contradicts the new behavior — happened in chunk-4 round 2).
+- **Zero new comments** = Copilot is done from its perspective. Move to human review.
+
+### 7g. Loop until both Copilot and humans are done
+
+Each iteration: triage → discuss → fix → gate → amend → force-push → reply → resolve → re-request. Convergence is normal — most PRs need 1-3 rounds. Don't get fatigued; the discipline is what keeps the review-comment vs. force-push history clean.
 
 ## Quick reference
 
@@ -194,3 +291,4 @@ Stage, commit, push, and create the PR using GitHub MCP tools or `gh` CLI. Follo
 | Docs | `das2rst.das` + stubs + Sphinx | Only if daslib/C++ bindings/RST changed |
 | Format | MCP `format_file` on each changed `.das` | Only changed files |
 | PR | GitHub MCP `create_pull_request` or `gh pr create` | — |
+| Review iter | Triage → discuss → fix → gates → amend → force-push → reply → resolve all threads → re-request | One round per Copilot pass; convergence in 1-3 rounds is normal |

--- a/tests/dasSQLITE/failed_sql_macro.das
+++ b/tests/dasSQLITE/failed_sql_macro.das
@@ -7,7 +7,7 @@ options gen2
 // analyzer ever runs — e.g. `_select(_.Name) |> _select(_.Price)` is a
 // genuine type bug (string has no `Price` field) and `some_unknown_func(_)`
 // hits the unresolved function. Those cascades are expected.
-expect 40104:9, 30304:2, 30503:2
+expect 40104:13, 30304:2, 30503:3
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -30,8 +30,8 @@ def main() {
     // 2. _sql(chain rooted at wrong fn) — chain root must be select_from
     let bad2 <- _sql(db |> insert(Car(Id = 1, Name = "x", Price = 0)))
 
-    // 3. _sql with unsupported chain operator (linq's _order_by, not in chunk 2)
-    let bad3 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Id))
+    // 3. _sql with duplicate distinct() — analyzer enforces single-stage guard
+    let bad3 <- _sql(db |> select_from(type<Car>) |> distinct() |> distinct())
 
     // 4. _sql with double _select
     let bad4 <- _sql(db |> select_from(type<Car>) |> _select(_.Name) |> _select(_.Price))
@@ -50,4 +50,23 @@ def main() {
 
     // 9. _to_array() after _select — must be outermost terminal
     let bad9 <- _sql(db |> select_from(type<Car>) |> _select(_.Name) |> _to_array() |> _where(_.Id == 1))
+
+    // 10. _having without _group_by — HAVING is meaningless without aggregation
+    let bad10 <- _sql(db |> select_from(type<Car>) |> _having(_._1 |> length > 1))
+
+    // 11. _select after _group_by must be a NAMED tuple — bare scalar rejected
+    let bad11 <- _sql(db |> select_from(type<Car>) |> _group_by(_.Name) |> _select(_._0))
+
+    // 12. take(n) before an aggregate is degenerate in SQL — `LIMIT` after
+    //     an aggregate is a no-op (aggregate already returns one row).
+    //     User almost certainly wants the subquery form
+    //     `SELECT SUM(c) FROM (SELECT p AS c FROM Cars LIMIT n)`, which lands
+    //     with joins/subqueries in chunk 5+. Reject loud now.
+    let bad12 <- _sql(db |> select_from(type<Car>) |> take(2) |> _select(_.Price) |> sum())
+
+    // 13. distinct() before an aggregate is degenerate — `SELECT DISTINCT
+    //     SUM(...)` / `SELECT DISTINCT COUNT(*)` dedupes a single-row result.
+    //     The meaningful form is `COUNT(DISTINCT col)` (DISTINCT inside the
+    //     aggregate), which is not yet wired.
+    let bad13 <- _sql(db |> select_from(type<Car>) |> distinct() |> count())
 }

--- a/tests/dasSQLITE/test_30_count_canary.das
+++ b/tests/dasSQLITE/test_30_count_canary.das
@@ -25,7 +25,9 @@ def private fixture(db : SqlRunner) {
 // ──────────────────────────────────────────────────────────────────────────
 // _count canary — proves the aggregate framework path:
 //   - ProjectionShape.Aggregate sets the SELECT-list to "COUNT(*)"
-//   - Materializer.One reads back a single int64
+//   - Materializer.One reads back a single int (matches daslang's
+//     `length(arr)`/`count(arr)` return type; SQLite COUNT(*) is int64
+//     internally but `sqlite_read(stmt, 0, type<int>)` narrows it)
 //
 // `_count` is reserved as a 2-arg call_macro in linq_boost (predicate form,
 // chunk 4 territory). For the bare aggregate we use linq.das's `count(src)`
@@ -33,11 +35,11 @@ def private fixture(db : SqlRunner) {
 // ──────────────────────────────────────────────────────────────────────────
 
 [test]
-def test_count_returns_int64_total(t : T?) {
+def test_count_returns_total(t : T?) {
     with_sqlite(":memory:") $(db) {
         fixture(db)
         let n = _sql(db |> select_from(type<Car>) |> count())
-        t |> equal(int(n), 5, "5 rows total")
+        t |> equal(n, 5, "5 rows total")
     }
 }
 
@@ -46,7 +48,7 @@ def test_count_on_empty_table_is_zero(t : T?) {
     with_sqlite(":memory:") $(db) {
         db |> create_table(type<Car>)
         let n = _sql(db |> select_from(type<Car>) |> count())
-        t |> equal(int(n), 0, "empty table counts 0")
+        t |> equal(n, 0, "empty table counts 0")
     }
 }
 
@@ -68,7 +70,7 @@ def test_count_after_select_returns_same_total(t : T?) {
     with_sqlite(":memory:") $(db) {
         fixture(db)
         let n = _sql(db |> select_from(type<Car>) |> _select(_.Name) |> count())
-        t |> equal(int(n), 5, "_select(_.Name) |> count() returns row total, not column count")
+        t |> equal(n, 5, "_select(_.Name) |> count() returns row total, not column count")
     }
 }
 

--- a/tests/dasSQLITE/test_31_count_with_where.das
+++ b/tests/dasSQLITE/test_31_count_with_where.das
@@ -30,7 +30,7 @@ def test_count_with_where_filter(t : T?) {
         let n = _sql(db |> select_from(type<Car>)
                        |> _where(_.Price > cutoff)
                        |> count())
-        t |> equal(int(n), 3, "3 rows with Price > 150")
+        t |> equal(n, 3, "3 rows with Price > 150")
     }
 }
 
@@ -42,7 +42,7 @@ def test_count_with_no_matches_is_zero(t : T?) {
         let n = _sql(db |> select_from(type<Car>)
                        |> _where(_.Id == target)
                        |> count())
-        t |> equal(int(n), 0, "no matches -> 0")
+        t |> equal(n, 0, "no matches -> 0")
     }
 }
 

--- a/tests/dasSQLITE/test_32_distinct.das
+++ b/tests/dasSQLITE/test_32_distinct.das
@@ -1,0 +1,64 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture_with_dupes(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "BMW",   Price = 150))
+    db |> insert(Car(Id = 4, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 5, Name = "Audi",  Price = 200))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// distinct() — emits SELECT DISTINCT. The framework slot is a single bool
+// on SqlQuery; the SELECT-list still comes from the rest of the chain
+// (FullRow / SingleColumn / NamedTuple). Tests here cover:
+//   - bare full-row DISTINCT (deduplicates whole rows)
+//   - emitted SQL via _sql_text
+//   - duplicate distinct() in chain → macro_error (covered in failed_*)
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_distinct_full_row_emits_select_distinct(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> distinct())
+    t |> equal(sql,
+        "SELECT DISTINCT \"Id\", \"Name\", \"Price\" FROM \"Cars\"",
+        "distinct() emits SELECT DISTINCT before the full column list")
+}
+
+[test]
+def test_distinct_with_where_emits_distinct_and_where(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(_.Price > 100)
+                          |> distinct())
+    t |> equal(sql,
+        "SELECT DISTINCT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE \"Price\" > ?",
+        "distinct() composes with _where")
+}
+
+[test]
+def test_distinct_full_row_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_with_dupes(db)
+        // All 5 inserted rows have unique PKs (Id), so full-row DISTINCT
+        // returns all 5. That confirms the SELECT DISTINCT emission roundtrips
+        // through the runtime without losing rows.
+        let rows <- _sql(db |> select_from(type<Car>) |> distinct())
+        t |> equal(length(rows), 5, "all 5 PK-distinct rows survive full-row DISTINCT")
+    }
+}

--- a/tests/dasSQLITE/test_33_take_skip.das
+++ b/tests/dasSQLITE/test_33_take_skip.das
@@ -1,0 +1,124 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// take(n) / skip(n) — emit LIMIT / OFFSET. Bind ordering: LIMIT/OFFSET
+// binds come AFTER WHERE binds in the placeholder index sequence.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_take_emits_limit(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> take(2))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" LIMIT ?",
+        "take(n) emits LIMIT ?")
+}
+
+[test]
+def test_skip_emits_limit_neg1_offset(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> skip(2))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" LIMIT -1 OFFSET ?",
+        "skip(n) without take needs LIMIT -1 to satisfy SQLite's OFFSET-requires-LIMIT rule")
+}
+
+[test]
+def test_take_then_skip_emits_limit_and_offset(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> take(3) |> skip(1))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" LIMIT ? OFFSET ?",
+        "take + skip combine into LIMIT … OFFSET …")
+}
+
+[test]
+def test_where_then_take_orders_binds_correctly(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(_.Price > 100)
+                          |> take(2))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE \"Price\" > ? LIMIT ?",
+        "WHERE bind goes first, LIMIT bind goes last — placeholder order matches bind-array order")
+}
+
+[test]
+def test_take_runtime_returns_n_rows(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<Car>) |> take(2))
+        t |> equal(length(rows), 2, "take(2) returns 2 rows")
+        t |> equal(rows[0].Name, "BMW",  "first row")
+        t |> equal(rows[1].Name, "Audi", "second row")
+    }
+}
+
+[test]
+def test_skip_runtime_skips_n_rows(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<Car>) |> skip(3))
+        t |> equal(length(rows), 2, "skip(3) over 5 rows leaves 2")
+        t |> equal(rows[0].Name, "Lada",  "row[3] = first after skip")
+        t |> equal(rows[1].Name, "Lambo", "row[4]")
+    }
+}
+
+[test]
+def test_take_and_skip_combined_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<Car>) |> take(2) |> skip(1))
+        t |> equal(length(rows), 2, "take(2) skip(1) returns 2 rows starting from row 1")
+        t |> equal(rows[0].Name, "Audi",  "row[1]")
+        t |> equal(rows[1].Name, "Tesla", "row[2]")
+    }
+}
+
+[test]
+def test_where_take_runtime_binds(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let threshold = 100
+        let rows <- _sql(db |> select_from(type<Car>)
+                           |> _where(_.Price > threshold)
+                           |> take(2))
+        t |> equal(length(rows), 2, "WHERE filters then LIMIT applies")
+        // Cars >100 in insertion order: Audi(200), Tesla(300), Lambo(999) — take 2.
+        t |> equal(rows[0].Name, "Audi",  "first match")
+        t |> equal(rows[1].Name, "Tesla", "second match")
+    }
+}
+
+[test]
+def test_first_after_take_uses_limit_1(t : T?) {
+    var _db = SqlRunner()
+    // take(5) |> _first() — terminal forces LIMIT 1 (overrides take's 5).
+    let sql = _sql_text(_db |> select_from(type<Car>) |> take(5) |> _first())
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" LIMIT 1",
+        "single-row terminal overrides take's LIMIT")
+}

--- a/tests/dasSQLITE/test_34_order_by.das
+++ b/tests/dasSQLITE/test_34_order_by.das
@@ -1,0 +1,102 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 100))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _order_by — single column ASC. Multi-column via tuple-key (_.k1, _.k2).
+// _order_by_descending — single column DESC.
+// Mixed ASC/DESC across columns is plan D2 (out of chunk-4 scope).
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_order_by_emits_asc(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _order_by(_.Price))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" ORDER BY \"Price\" ASC",
+        "_order_by emits ORDER BY col ASC")
+}
+
+[test]
+def test_order_by_descending_emits_desc(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _order_by_descending(_.Price))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" ORDER BY \"Price\" DESC",
+        "_order_by_descending emits ORDER BY col DESC")
+}
+
+[test]
+def test_order_by_tuple_key_emits_multi_col(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _order_by((_.Price, _.Name)))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" ORDER BY \"Price\" ASC, \"Name\" ASC",
+        "tuple-key _order_by emits each field as its own ORDER BY column")
+}
+
+[test]
+def test_order_by_with_where_and_take(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(_.Price > 50)
+                          |> _order_by(_.Price)
+                          |> take(3))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" WHERE \"Price\" > ? ORDER BY \"Price\" ASC LIMIT ?",
+        "WHERE then ORDER BY then LIMIT — SQL clause order")
+}
+
+[test]
+def test_order_by_runtime_sorts_ascending(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price))
+        t |> equal(length(rows), 5, "5 rows")
+        t |> equal(rows[0].Price, 50,  "first by Price ASC = Lada (50)")
+        t |> equal(rows[4].Price, 999, "last by Price ASC = Lambo (999)")
+    }
+}
+
+[test]
+def test_order_by_descending_runtime_sorts(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<Car>) |> _order_by_descending(_.Price))
+        t |> equal(rows[0].Price, 999, "first DESC = Lambo")
+        t |> equal(rows[4].Price, 50,  "last DESC = Lada")
+    }
+}
+
+[test]
+def test_order_by_tuple_key_runtime_breaks_ties(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // BMW(100) and Tesla(100) tie on Price; tuple key (Price, Name)
+        // breaks the tie alphabetically by Name ASC.
+        let rows <- _sql(db |> select_from(type<Car>) |> _order_by((_.Price, _.Name)))
+        t |> equal(rows[0].Name, "Lada",  "Price=50")
+        t |> equal(rows[1].Name, "BMW",   "Price=100, Name=BMW first alphabetically")
+        t |> equal(rows[2].Name, "Tesla", "Price=100, Name=Tesla second")
+    }
+}

--- a/tests/dasSQLITE/test_35_aggregates.das
+++ b/tests/dasSQLITE/test_35_aggregates.das
@@ -1,0 +1,143 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Column aggregates: sum / average / min / max. Each peels via the shared
+// peel_column_aggregate helper — recurses into the inner chain first so
+// `_select(_.Col)` populates selectCols, then wraps selectCols[0] in the
+// SQL aggregate. AVG always promotes to double; SUM/MIN/MAX inherit the
+// column's type.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_sum_emits_sum_col(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _select(_.Price) |> sum())
+    t |> equal(sql,
+        "SELECT SUM(\"Price\") FROM \"Cars\"",
+        "sum() emits SELECT SUM(col)")
+}
+
+[test]
+def test_average_emits_avg_col(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _select(_.Price) |> average())
+    t |> equal(sql,
+        "SELECT AVG(\"Price\") FROM \"Cars\"",
+        "average() emits SELECT AVG(col)")
+}
+
+[test]
+def test_min_emits_min_col(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _select(_.Price) |> min())
+    t |> equal(sql,
+        "SELECT MIN(\"Price\") FROM \"Cars\"",
+        "min() emits SELECT MIN(col)")
+}
+
+[test]
+def test_max_emits_max_col(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _select(_.Price) |> max())
+    t |> equal(sql,
+        "SELECT MAX(\"Price\") FROM \"Cars\"",
+        "max() emits SELECT MAX(col)")
+}
+
+[test]
+def test_sum_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let total = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> sum())
+        t |> equal(total, 100 + 200 + 300 + 50 + 999, "SUM of all prices")
+    }
+}
+
+[test]
+def test_min_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cheapest = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> min())
+        t |> equal(cheapest, 50, "min Price = Lada")
+    }
+}
+
+[test]
+def test_max_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let priciest = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> max())
+        t |> equal(priciest, 999, "max Price = Lambo")
+    }
+}
+
+[test]
+def test_average_runtime_promotes_to_double(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let avg = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> average())
+        // AVG returns double; allow tiny FP slop.
+        let expected = double(100 + 200 + 300 + 50 + 999) / 5.0lf
+        t |> equal(avg, expected, "AVG returns double")
+    }
+}
+
+[test]
+def test_sum_with_where(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _where(_.Price > 100)
+                          |> _select(_.Price)
+                          |> sum())
+    t |> equal(sql,
+        "SELECT SUM(\"Price\") FROM \"Cars\" WHERE \"Price\" > ?",
+        "sum() with WHERE composes")
+}
+
+[test]
+def test_sum_with_where_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let total = _sql(db |> select_from(type<Car>)
+                           |> _where(_.Price > 100)
+                           |> _select(_.Price)
+                           |> sum())
+        t |> equal(total, 200 + 300 + 999, "SUM where Price > 100")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// `take(n)` / `skip(n)` upstream of an aggregate is rejected at compile time:
+// `SELECT SUM(p) FROM Cars LIMIT n` is degenerate (aggregate already returns
+// one row, so LIMIT is a no-op). The user almost certainly wants the subquery
+// form `SELECT SUM(c) FROM (SELECT p AS c FROM Cars LIMIT n)`, which lands
+// with joins/subqueries in chunk 5+. Compile-time rejection lives in the
+// failed_sql_macro suite (bad12) — see also tests/dasSQLITE/failed_sql_macro.das.
+//
+// Without that rejection the analyzer used to produce `SELECT SUM(p) FROM
+// Cars LIMIT ?` with NO bind for the placeholder, which SQLite read as NULL
+// (= no upper bound) — `take(n)` was silently ignored. Caught by Copilot's
+// review of PR #2492.
+// ──────────────────────────────────────────────────────────────────────────

--- a/tests/dasSQLITE/test_36_group_by.das
+++ b/tests/dasSQLITE/test_36_group_by.das
@@ -1,0 +1,258 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    City : string
+    Age : int
+    Salary : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "Alice",   City = "NYC",     Age = 30, Salary = 100))
+    db |> insert(User(Id = 2, Name = "Bob",     City = "NYC",     Age = 25, Salary = 80))
+    db |> insert(User(Id = 3, Name = "Carol",   City = "Chicago", Age = 40, Salary = 120))
+    db |> insert(User(Id = 4, Name = "Dave",    City = "Chicago", Age = 35, Salary = 90))
+    db |> insert(User(Id = 5, Name = "Eve",     City = "Chicago", Age = 50, Salary = 200))
+    db |> insert(User(Id = 6, Name = "Frank",   City = "Boston",  Age = 28, Salary = 70))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _group_by + _select using IGrouping shape:
+//   _._0                                   → group key column (single-key)
+//   _._0._N                                → multi-key Nth column
+//   _._1 |> length / |> count              → COUNT(*)
+//   _._1 |> select($(u:T) => u.X) |> sum   → SUM("X")
+//   _._1 |> select($(u:T) => u.X) |> average → AVG("X")  (result type double)
+//   _._1 |> select($(u:T) => u.X) |> min   → MIN("X")
+//   _._1 |> select($(u:T) => u.X) |> max   → MAX("X")
+//
+// Aligns with EF-Core / linq.das `g.Key` / `g.Count()` /
+// `g.Average(u => u.Age)` shape — `_._0` corresponds to ``g.Key``,
+// ``_._1 |> length`` to ``g.Count()``, ``_._1 |> select(u => u.Age) |> average``
+// to ``g.Average(u => u.Age)``.
+//
+// The inner ``select`` uses a NAMED lambda parameter (``$(u : User)``)
+// rather than ``_select(_.Age)`` because the outer ``_select`` lambda
+// already binds ``_`` to the group tuple — daslang reports a shadowing
+// error when an inner ``_`` lambda has a different type. Naming the inner
+// parameter (``u``) sidesteps the conflict.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_group_by_count_emits_group_by(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _group_by(_.City)
+                          |> _select((City = _._0, N = _._1 |> length)))
+    t |> equal(sql,
+        "SELECT \"City\", COUNT(*) FROM \"Users\" GROUP BY \"City\"",
+        "_group_by + (_._0, _._1 |> length) emits GROUP BY + COUNT(*)")
+}
+
+[test]
+def test_group_by_avg_emits_avg_col(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _group_by(_.City)
+                          |> _select((City = _._0, AvgAge = _._1 |> select($(u : User) => u.Age) |> average)))
+    t |> equal(sql,
+        "SELECT \"City\", AVG(\"Age\") FROM \"Users\" GROUP BY \"City\"",
+        "_._1 |> select(u => u.X) |> average emits AVG(col)")
+}
+
+[test]
+def test_group_by_multi_aggregates(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _group_by(_.City)
+                          |> _select((City   = _._0,
+                                      N      = _._1 |> length,
+                                      MinAge = _._1 |> select($(u : User) => u.Age)    |> min,
+                                      MaxAge = _._1 |> select($(u : User) => u.Age)    |> max,
+                                      Total  = _._1 |> select($(u : User) => u.Salary) |> sum)))
+    t |> equal(sql,
+        "SELECT \"City\", COUNT(*), MIN(\"Age\"), MAX(\"Age\"), SUM(\"Salary\") FROM \"Users\" GROUP BY \"City\"",
+        "multi-aggregate projection emits all SQL aggregates")
+}
+
+[test]
+def test_group_by_count_via_count_fn(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _group_by(_.City)
+                          |> _select((City = _._0, N = _._1 |> count)))
+    t |> equal(sql,
+        "SELECT \"City\", COUNT(*) FROM \"Users\" GROUP BY \"City\"",
+        "_._1 |> count emits COUNT(*) (alias of |> length)")
+}
+
+[test]
+def test_group_by_multi_key(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _group_by((_.City, _.Age))
+                          |> _select((City = _._0._0, Age = _._0._1, N = _._1 |> length)))
+    t |> equal(sql,
+        "SELECT \"City\", \"Age\", COUNT(*) FROM \"Users\" GROUP BY \"City\", \"Age\"",
+        "multi-column _group_by emits GROUP BY col1, col2; projection uses _._0._N")
+}
+
+[test]
+def test_group_by_with_where(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where(_.Age > 25)
+                          |> _group_by(_.City)
+                          |> _select((City = _._0, N = _._1 |> length)))
+    t |> equal(sql,
+        "SELECT \"City\", COUNT(*) FROM \"Users\" WHERE \"Age\" > ? GROUP BY \"City\"",
+        "_where before _group_by emits WHERE before GROUP BY")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _having — post-aggregate filter. Emits HAVING clause; bind exprs go to
+// havingBindExprs and slot in between WHERE and LIMIT in the placeholder
+// index sequence.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_having_with_count_threshold(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _group_by(_.City)
+                          |> _having(_._1 |> length > 1)
+                          |> _select((City = _._0, N = _._1 |> length)))
+    t |> equal(sql,
+        "SELECT \"City\", COUNT(*) FROM \"Users\" GROUP BY \"City\" HAVING COUNT(*) > ?",
+        "_having with COUNT(*) > N emits HAVING")
+}
+
+[test]
+def test_having_combined_full_query(t : T?) {
+    var _db = SqlRunner()
+    let min_age = 25
+    let min_count = 1
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where(_.Age >= min_age)
+                          |> _group_by(_.City)
+                          |> _having(_._1 |> length >= min_count)
+                          |> _order_by(_._0)
+                          |> _select((City = _._0,
+                                      N = _._1 |> length,
+                                      AvgSalary = _._1 |> select($(u : User) => u.Salary) |> average))
+                          |> take(10))
+    t |> equal(sql,
+        "SELECT \"City\", COUNT(*), AVG(\"Salary\") FROM \"Users\" WHERE \"Age\" >= ? GROUP BY \"City\" HAVING COUNT(*) >= ? ORDER BY \"City\" ASC LIMIT ?",
+        "full reporting query: WHERE → GROUP BY → HAVING → ORDER BY → LIMIT")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Runtime — actual rows from grouped queries.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_group_by_count_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _group_by(_.City)
+                           |> _order_by(_._0)
+                           |> _select((City = _._0, N = _._1 |> length)))
+        t |> equal(length(rows), 3, "three cities")
+        t |> equal(rows[0].City, "Boston",  "row 0 city")
+        t |> equal(rows[0].N,    1,         "Boston: 1 user")
+        t |> equal(rows[1].City, "Chicago", "row 1 city")
+        t |> equal(rows[1].N,    3,         "Chicago: 3 users")
+        t |> equal(rows[2].City, "NYC",     "row 2 city")
+        t |> equal(rows[2].N,    2,         "NYC: 2 users")
+    }
+}
+
+[test]
+def test_group_by_avg_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _group_by(_.City)
+                           |> _order_by(_._0)
+                           |> _select((City = _._0, AvgSalary = _._1 |> select($(u : User) => u.Salary) |> average)))
+        t |> equal(length(rows), 3, "three cities")
+        t |> equal(rows[0].City,      "Boston",                          "Boston row")
+        t |> equal(rows[0].AvgSalary, 70.0lf,                            "Boston avg salary")
+        t |> equal(rows[1].City,      "Chicago",                         "Chicago row")
+        t |> equal(rows[1].AvgSalary, double(120 + 90 + 200) / 3.0lf,    "Chicago avg salary")
+        t |> equal(rows[2].City,      "NYC",                             "NYC row")
+        t |> equal(rows[2].AvgSalary, double(100 + 80) / 2.0lf,          "NYC avg salary")
+    }
+}
+
+[test]
+def test_group_by_having_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Cities with 2+ users — should drop Boston.
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _group_by(_.City)
+                           |> _having(_._1 |> length > 1)
+                           |> _order_by(_._0)
+                           |> _select((City = _._0, N = _._1 |> length)))
+        t |> equal(length(rows), 2, "Chicago and NYC remain (Boston filtered out)")
+        t |> equal(rows[0].City, "Chicago", "Chicago kept")
+        t |> equal(rows[0].N,    3,         "Chicago count")
+        t |> equal(rows[1].City, "NYC",     "NYC kept")
+        t |> equal(rows[1].N,    2,         "NYC count")
+    }
+}
+
+[test]
+def test_group_by_combined_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let min_age = 25
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _where(_.Age >= min_age)
+                           |> _group_by(_.City)
+                           |> _having(_._1 |> length > 1)
+                           |> _order_by(_._0)
+                           |> _select((City = _._0,
+                                       N = _._1 |> length,
+                                       MinAge = _._1 |> select($(u : User) => u.Age) |> min,
+                                       MaxAge = _._1 |> select($(u : User) => u.Age) |> max)))
+        t |> equal(length(rows), 2, "two qualifying cities (Chicago and NYC)")
+        t |> equal(rows[0].City,    "Chicago", "Chicago kept")
+        t |> equal(rows[0].N,       3,         "Chicago: 3 users >= 25")
+        t |> equal(rows[0].MinAge,  35,        "Chicago min age")
+        t |> equal(rows[0].MaxAge,  50,        "Chicago max age")
+        t |> equal(rows[1].City,    "NYC",     "NYC kept")
+        t |> equal(rows[1].N,       2,         "NYC: 2 users >= 25")
+        t |> equal(rows[1].MinAge,  25,        "NYC min age")
+        t |> equal(rows[1].MaxAge,  30,        "NYC max age")
+    }
+}
+
+[test]
+def test_group_by_multi_key_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        // Add Adam in NYC age 30 (matches Alice's group key) so we can
+        // observe a multi-key bucket having two members.
+        fixture(db)
+        db |> insert(User(Id = 7, Name = "Adam", City = "NYC", Age = 30, Salary = 110))
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _group_by((_.City, _.Age))
+                           |> _having(_._1 |> length > 1)
+                           |> _select((City = _._0._0, Age = _._0._1, N = _._1 |> length)))
+        t |> equal(length(rows), 1, "exactly one (City, Age) bucket has 2+ members")
+        t |> equal(rows[0].City, "NYC", "NYC bucket")
+        t |> equal(rows[0].Age,  30,    "Age 30 bucket")
+        t |> equal(rows[0].N,    2,     "Alice + Adam")
+    }
+}

--- a/tests/dasSQLITE/test_37_null_handling.das
+++ b/tests/dasSQLITE/test_37_null_handling.das
@@ -1,0 +1,186 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/option
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Type-driven nullability — `T` columns are NOT NULL, `Option<T>` columns
+// allow SQL NULL. The same `User` struct doubles as the row shape and the
+// schema; no `@sql_nullable` annotation, no second source of truth.
+[sql_table(name="Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name      : string
+    @safe_when_uninitialized Age       : Option<int>
+    @safe_when_uninitialized Nick      : Option<string>
+    @safe_when_uninitialized DeletedAt : Option<int64>
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "alice", Age = some(30),     Nick = none(type<string>), DeletedAt = none(type<int64>)))
+    db |> insert(User(Id = 2, Name = "bob",   Age = none(type<int>), Nick = some("bobby"),    DeletedAt = none(type<int64>)))
+    db |> insert(User(Id = 3, Name = "carol", Age = some(40),     Nick = some("c"),         DeletedAt = some(1000l)))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// DDL — Option<T> drops NOT NULL; T keeps it.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_create_table_drops_not_null_for_option(t : T?) {
+    t |> equal(_::_sql_create_table_sql(type<User>),
+        "CREATE TABLE \"Users\"(\"Id\" INTEGER PRIMARY KEY, \"Name\" TEXT NOT NULL, \"Age\" INTEGER, \"Nick\" TEXT, \"DeletedAt\" INTEGER)",
+        "Option<T> columns omit NOT NULL; required T columns keep it")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// INSERT — some(v) binds the underlying value; none() binds SQL NULL.
+// SELECT (full row) — readers wrap NULL → none, value → some.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_round_trip_option_columns(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- db |> select_from(type<User>)
+        t |> equal(length(rows), 3, "three users")
+
+        // alice — Age=some(30), Nick=none, DeletedAt=none
+        t |> equal(rows[0].Name, "alice", "alice row")
+        t |> success(rows[0].Age |> is_some, "alice age present")
+        t |> equal(rows[0].Age |> unwrap, 30, "alice age value")
+        t |> success(rows[0].Nick |> is_none, "alice nick absent")
+        t |> success(rows[0].DeletedAt |> is_none, "alice not soft-deleted")
+
+        // bob — Age=none, Nick=some("bobby")
+        t |> equal(rows[1].Name, "bob", "bob row")
+        t |> success(rows[1].Age |> is_none, "bob age absent")
+        t |> success(rows[1].Nick |> is_some, "bob nick present")
+        t |> equal(rows[1].Nick |> unwrap, "bobby", "bob nick value")
+
+        // carol — all some
+        t |> equal(rows[2].Name, "carol", "carol row")
+        t |> equal(rows[2].Age |> unwrap, 40, "carol age")
+        t |> equal(rows[2].Nick |> unwrap, "c", "carol nick")
+        t |> equal(rows[2].DeletedAt |> unwrap, 1000l, "carol deleted_at")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _where — is_some / is_none translate to IS NOT NULL / IS NULL.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_where_is_some_emits_is_not_null(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where(_.Age |> is_some))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Age\", \"Nick\", \"DeletedAt\" FROM \"Users\" WHERE \"Age\" IS NOT NULL",
+        "_.Col |> is_some emits Col IS NOT NULL")
+}
+
+[test]
+def test_where_is_none_emits_is_null(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where(_.DeletedAt |> is_none))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Age\", \"Nick\", \"DeletedAt\" FROM \"Users\" WHERE \"DeletedAt\" IS NULL",
+        "_.Col |> is_none emits Col IS NULL")
+}
+
+[test]
+def test_where_is_some_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _where(_.Age |> is_some)
+                           |> _order_by(_.Id))
+        t |> equal(length(rows), 2, "alice and carol have ages")
+        t |> equal(rows[0].Name, "alice", "alice first")
+        t |> equal(rows[1].Name, "carol", "carol second")
+    }
+}
+
+[test]
+def test_where_is_none_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _where(_.Age |> is_none))
+        t |> equal(length(rows), 1, "only bob has no age")
+        t |> equal(rows[0].Name, "bob", "bob has no age")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _where — unwrap_or translates to COALESCE(col, ?).
+// The default value goes through pred_to_sql, so a captured local becomes
+// a bind parameter (`?`), and the surrounding comparison adds another.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_where_unwrap_or_emits_coalesce(t : T?) {
+    var _db = SqlRunner()
+    let cutoff = 18
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where(_.Age |> unwrap_or(0) >= cutoff))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Age\", \"Nick\", \"DeletedAt\" FROM \"Users\" WHERE COALESCE(\"Age\", ?) >= ?",
+        "_.Col |> unwrap_or(d) >= x emits COALESCE + comparison")
+}
+
+[test]
+def test_where_unwrap_or_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // bob has Age=none → COALESCE returns 0 → 0 >= 18 false, bob filtered out.
+        let cutoff = 18
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _where(_.Age |> unwrap_or(0) >= cutoff)
+                           |> _order_by(_.Id))
+        t |> equal(length(rows), 2, "alice + carol pass; bob's none → 0 < 18 fails")
+        t |> equal(rows[0].Name, "alice", "alice in")
+        t |> equal(rows[1].Name, "carol", "carol in")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Projection — Option<T> field passes through into the result tuple.
+// The result element type is the table struct (FullRow), which preserves
+// the field's `Option<int>` shape. No implicit unwrapping at projection.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_full_row_preserves_option_in_result(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let alive <- _sql(db |> select_from(type<User>)
+                            |> _where(_.DeletedAt |> is_none)
+                            |> _order_by(_.Id))
+        t |> equal(length(alive), 2, "alice + bob alive; carol soft-deleted")
+        t |> success(alive[0].DeletedAt |> is_none, "alice DeletedAt none")
+        t |> success(alive[1].DeletedAt |> is_none, "bob DeletedAt none")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _try_sql variant — Option methods compose with the non-panicking form.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_try_sql_with_is_some(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let attempt <- _try_sql(db |> select_from(type<User>)
+                                  |> _where(_.Age |> is_some))
+        t |> success(attempt |> is_ok, "_try_sql succeeded")
+        let rows <- attempt |> unwrap
+        t |> equal(length(rows), 2, "two users have known ages")
+    }
+}

--- a/tutorials/sql/07-anatomy.das
+++ b/tutorials/sql/07-anatomy.das
@@ -1,0 +1,107 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 07 — Anatomy of `_sql(...)`.
+//
+// Everything in `_sql(chain)` is decided at compile time. The macro
+// walks the daslib/linq-shaped chain, classifies each operator, and
+// emits a SQL string + a list of bind expressions. There is no
+// runtime LINQ→SQL inspection — by the time the program runs, only
+// the SQL and the binds remain.
+//
+// The translation has three moving parts:
+//   1. Column references — `_.Field` becomes a quoted identifier.
+//   2. Captured values  — any free variable or literal becomes a `?`
+//                          bind parameter.
+//   3. Recognized ops   — comparisons / boolean logic / a fixed set
+//                          of function calls (`starts_with`, `length`,
+//                          `is_some`, `unwrap_or`, …) lower to SQL
+//                          equivalents.
+//
+// Anything outside that surface is rejected at compile time with a
+// `macro_error` pointing at the offending node. The escape hatch is
+// the raw-SQL form: `db |> exec(...)`, `db |> query_one(...)`,
+// `db |> query_scalar(...)`. They take a SQL string and bind
+// parameters directly — no chain to translate.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+        db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+        db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+
+        // ── (1) `_sql_text` — the inspector ──────────────────────────────
+        // Same analyzer as `_sql`, but returns the SQL string instead
+        // of running it. The `?` placeholders show where each bind goes.
+        let sql1 = _sql_text(db |> select_from(type<Car>) |> _where(_.Price > 100))
+        to_log(LOG_INFO, "(1) SELECT all rows where Price > 100:\n  {sql1}\n")
+        // → SELECT "Id", "Name", "Price" FROM "Cars" WHERE "Price" > ?
+
+        // ── (2) Captured-vs-literal binding ──────────────────────────────
+        // A captured local variable becomes a bind. A literal *also*
+        // becomes a bind (the analyzer doesn't bother distinguishing —
+        // the SQL stays parameterized either way, which is the safe
+        // default for SQL injection).
+        let cutoff = 150
+        let sql2 = _sql_text(db |> select_from(type<Car>) |> _where(_.Price > cutoff))
+        to_log(LOG_INFO, "(2) Captured-var WHERE:\n  {sql2}\n")
+
+        // ── (3) Column ref vs bind: which side is which ──────────────────
+        // `_.Price` is a column reference (becomes "Price"). `cutoff`
+        // is a captured value (becomes ?). Swap the sides — the macro
+        // figures out which is the column on each side independently.
+        let sql3a = _sql_text(db |> select_from(type<Car>) |> _where(_.Price > cutoff))
+        let sql3b = _sql_text(db |> select_from(type<Car>) |> _where(cutoff < _.Price))
+        to_log(LOG_INFO, "(3) symmetric:\n  a: {sql3a}\n  b: {sql3b}\n")
+
+        // ── (4) Multiple `_where` calls compose with AND ─────────────────
+        // Every `_where` adds another conjunct. Chain freely.
+        let sql4 = _sql_text(db |> select_from(type<Car>)
+                               |> _where(_.Price > 100)
+                               |> _where(_.Name |> starts_with("T")))
+        to_log(LOG_INFO, "(4) two _where calls → AND:\n  {sql4}\n")
+
+        // ── (5) Running the same chain — the analyzer is pure ────────────
+        // `_sql_text` and `_sql` share the analyzer; the only difference
+        // is what the runtime helper does with the SQL string + binds.
+        let cars <- _sql(db |> select_from(type<Car>)
+                           |> _where(_.Price > 100)
+                           |> _where(_.Name |> starts_with("T")))
+        to_log(LOG_INFO, "(5) {length(cars)} cars match the chain in (4) above\n")
+
+        // ── (6) Raw-SQL escape hatch ─────────────────────────────────────
+        // For SQL the macro doesn't translate (DDL, vendor-specific
+        // statements, dynamic SQL), drop down to `db |> exec(...)` /
+        // `db |> query_one(...)`. Bind parameters are positional `?`.
+        // Tutorial 5 covers the parametrized-query API in detail.
+        let total = db |> query_scalar("SELECT SUM(Price) FROM Cars", type<int>)
+        to_log(LOG_INFO, "(6) raw-SQL total Price = {total}\n")
+
+        // ── (7) What `_sql` refuses ──────────────────────────────────────
+        // The translation table is intentionally finite. If you write a
+        // shape the analyzer doesn't recognize — an arbitrary user-
+        // defined function call inside `_where`, an unsupported math
+        // op, a regex — compile fails with `macro_error` pointing at
+        // the offending node. Two possible responses:
+        //   - Add the rule to the analyzer (fork-and-extend) if the
+        //     pattern is reusable.
+        //   - Use the raw-SQL escape hatch (6) if it's a one-off.
+        //
+        // The translation surface for `_where` predicates lives in
+        // tutorial 8; for `_select` projections in tutorial 9. The
+        // remaining read-side operators (order_by, take/skip, distinct,
+        // aggregates, group_by, NULL handling) live in 10-14 and 18.
+    }
+}

--- a/tutorials/sql/10-order_by.das
+++ b/tutorials/sql/10-order_by.das
@@ -1,0 +1,81 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 10 — `_order_by` and `_order_by_descending`.
+//
+// `_order_by(key)` adds an `ORDER BY` clause. The key shape decides
+// what the macro emits:
+//
+//   - `_.Field`              → ORDER BY "Field" ASC
+//   - `(_.k1, _.k2, …)`      → ORDER BY "k1" ASC, "k2" ASC, …
+//   - `_order_by_descending` flips ASC to DESC for the whole chain step
+//
+// Mixed ASC/DESC across columns in a single chain step is **out of
+// scope** for chunk 4 — use the raw-SQL escape hatch
+// (`db |> query_one("...ORDER BY a, b DESC", ...)`) when you need it.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 100))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // ── ASC by a single column ───────────────────────────────────────
+        let by_price <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price))
+        to_log(LOG_INFO, "ASC by Price — cheapest first:\n")
+        for (c in by_price) {
+            to_log(LOG_INFO, "  {c.Name}: {c.Price}\n")
+        }
+
+        // ── DESC by a single column ──────────────────────────────────────
+        let by_price_desc <- _sql(db |> select_from(type<Car>) |> _order_by_descending(_.Price))
+        to_log(LOG_INFO, "DESC by Price — priciest first:\n")
+        for (c in by_price_desc) {
+            to_log(LOG_INFO, "  {c.Name}: {c.Price}\n")
+        }
+
+        // ── Multi-column tuple key — primary then tie-breaker ────────────
+        // BMW(100) and Tesla(100) tie on Price. The tuple-key form
+        // `(_.Price, _.Name)` adds a second `ORDER BY` column so the
+        // tie breaks by Name ASC.
+        let by_price_then_name <- _sql(db |> select_from(type<Car>)
+                                         |> _order_by((_.Price, _.Name)))
+        to_log(LOG_INFO, "Tuple-key (Price, Name) — alphabetical tie-break:\n")
+        for (c in by_price_then_name) {
+            to_log(LOG_INFO, "  {c.Name}: {c.Price}\n")
+        }
+
+        // ── Composes with `_where` and `take` ────────────────────────────
+        let cheap_top3 <- _sql(db |> select_from(type<Car>)
+                                 |> _where(_.Price > 50)
+                                 |> _order_by(_.Price)
+                                 |> take(3))
+        to_log(LOG_INFO, "WHERE Price>50 ORDER BY Price ASC LIMIT 3:\n")
+        for (c in cheap_top3) {
+            to_log(LOG_INFO, "  {c.Name}: {c.Price}\n")
+        }
+
+        // ── Inspect emitted SQL ──────────────────────────────────────────
+        let sql = _sql_text(db |> select_from(type<Car>)
+                              |> _order_by((_.Price, _.Name)))
+        to_log(LOG_INFO, "  emitted SQL: {sql}\n")
+    }
+}

--- a/tutorials/sql/11-take_skip.das
+++ b/tutorials/sql/11-take_skip.das
@@ -1,0 +1,102 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 11 — `take(n)` / `skip(n)`: LIMIT and OFFSET pagination.
+//
+// `take(n)` emits `LIMIT ?`. `skip(n)` emits `OFFSET ?`; on its own
+// (without `take`), SQLite requires `LIMIT -1 OFFSET ?` (LIMIT-of-
+// negative-one means no limit), and the macro emits exactly that.
+//
+// Bind ordering: LIMIT and OFFSET binds always go *after* WHERE
+// binds in the placeholder index sequence, so a `_where(...) |>
+// take(n)` chain produces `WHERE col > ? LIMIT ?` with binds in
+// `[wherevalue, n]` order — no surprises.
+//
+// Single-row terminals (`_first` / `_first_opt`) override `take`'s
+// LIMIT and emit `LIMIT 1` instead.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // ── take(n) ──────────────────────────────────────────────────────
+        let first_two <- _sql(db |> select_from(type<Car>) |> take(2))
+        to_log(LOG_INFO, "take(2) — first two rows:\n")
+        for (c in first_two) {
+            to_log(LOG_INFO, "  {c.Name}\n")
+        }
+
+        // ── skip(n) — needs LIMIT -1 in SQLite without a take ────────────
+        let skip_three <- _sql(db |> select_from(type<Car>) |> skip(3))
+        to_log(LOG_INFO, "skip(3) — drop the first three:\n")
+        for (c in skip_three) {
+            to_log(LOG_INFO, "  {c.Name}\n")
+        }
+
+        // ── take + skip — pagination window ──────────────────────────────
+        // take(n) skip(m) = LIMIT n OFFSET m → rows m..m+n-1. So take(2)
+        // skip(1) returns rows 2..3. (For pages of size 2, page 1 = rows
+        // 1..2 with no skip; page 2 = rows 3..4 with skip(2).) Combine
+        // in either order — the SQL is identical.
+        let window <- _sql(db |> select_from(type<Car>) |> take(2) |> skip(1))
+        to_log(LOG_INFO, "take(2) skip(1) — rows 2-3:\n")
+        for (c in window) {
+            to_log(LOG_INFO, "  {c.Name}\n")
+        }
+
+        // ── take with WHERE — placeholder ordering ───────────────────────
+        // SQL emitted: WHERE Price > ? LIMIT ?
+        // Binds:       [threshold, 2]
+        let threshold = 100
+        let cheap_two <- _sql(db |> select_from(type<Car>)
+                                |> _where(_.Price > threshold)
+                                |> take(2))
+        to_log(LOG_INFO, "WHERE Price>100 LIMIT 2:\n")
+        for (c in cheap_two) {
+            to_log(LOG_INFO, "  {c.Name}: {c.Price}\n")
+        }
+
+        // ── Pair with order_by for stable pagination ─────────────────────
+        // LIMIT/OFFSET without ORDER BY isn't deterministic — SQLite
+        // can return rows in any order. Always combine the two when
+        // you actually care about page boundaries.
+        let stable_page <- _sql(db |> select_from(type<Car>)
+                                  |> _order_by(_.Price)
+                                  |> take(2) |> skip(1))
+        to_log(LOG_INFO, "ORDER BY Price ASC LIMIT 2 OFFSET 1:\n")
+        for (c in stable_page) {
+            to_log(LOG_INFO, "  {c.Name}: {c.Price}\n")
+        }
+
+        // ── Single-row terminals override take's LIMIT ───────────────────
+        // `_first` always emits `LIMIT 1`, ignoring any earlier `take`.
+        let head = _sql(db |> select_from(type<Car>) |> take(5) |> _first())
+        to_log(LOG_INFO, "_first overrides take's LIMIT: {head.Name}\n")
+
+        // ── Inspect emitted SQL ──────────────────────────────────────────
+        let sql = _sql_text(db |> select_from(type<Car>)
+                              |> _order_by(_.Price)
+                              |> take(2) |> skip(1))
+        to_log(LOG_INFO, "  emitted SQL: {sql}\n")
+    }
+}

--- a/tutorials/sql/12-distinct.das
+++ b/tutorials/sql/12-distinct.das
@@ -1,0 +1,82 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 12 — `distinct()`: DISTINCT row dedupe.
+//
+// `distinct()` flips a single bool flag on the analyzer's `SqlQuery`
+// and emits `SELECT DISTINCT` instead of plain `SELECT`. The rest
+// of the chain (column list, WHERE, ORDER BY, LIMIT) composes
+// normally.
+//
+// Set operations (UNION / INTERSECT / EXCEPT) are **deferred to a
+// later chunk**: they need a multi-source / multi-stage analyzer
+// extension that lives alongside joins and subqueries. Until then,
+// the raw-SQL escape hatch (`db |> exec(...)` /
+// `db |> query_one(...)`) handles those cases.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "BMW",   Price = 150))
+    db |> insert(Car(Id = 4, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 5, Name = "Audi",  Price = 200))
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // ── Full-row DISTINCT ────────────────────────────────────────────
+        // Whole-row dedupe — every column must match. PKs differ here
+        // so all 5 rows survive; the point is to show the SQL emission.
+        let all_rows <- _sql(db |> select_from(type<Car>) |> distinct())
+        to_log(LOG_INFO, "Full-row DISTINCT: {length(all_rows)} rows\n")
+
+        // ── Single-column DISTINCT — distinct names ──────────────────────
+        // `_select(_.Name) |> distinct()` projects one column and
+        // dedupes it. The result element type matches the column type.
+        let names <- _sql(db |> select_from(type<Car>)
+                            |> _select(_.Name)
+                            |> distinct())
+        to_log(LOG_INFO, "DISTINCT names: {length(names)} unique\n")
+        for (n in names) {
+            to_log(LOG_INFO, "  {n}\n")
+        }
+
+        // ── DISTINCT composes with WHERE ─────────────────────────────────
+        let names_over_100 <- _sql(db |> select_from(type<Car>)
+                                     |> _where(_.Price > 100)
+                                     |> _select(_.Name)
+                                     |> distinct())
+        to_log(LOG_INFO, "DISTINCT names where Price>100: {length(names_over_100)}\n")
+        for (n in names_over_100) {
+            to_log(LOG_INFO, "  {n}\n")
+        }
+
+        // ── Inspect emitted SQL ──────────────────────────────────────────
+        let sql = _sql_text(db |> select_from(type<Car>)
+                              |> _select(_.Name)
+                              |> distinct())
+        to_log(LOG_INFO, "  emitted SQL: {sql}\n")
+
+        // ── Set operations (UNION / INTERSECT / EXCEPT) — deferred ───────
+        // The chain analyzer is single-source today: every SELECT comes
+        // from one `select_from(type<T>)`. Set ops bring in a second
+        // SqlQuery and need a multi-stage emitter — same engine work
+        // joins and subqueries need. Until that lands, drive `sqlite3_*`
+        // directly or `exec` a `CREATE TEMP VIEW` that wraps the union
+        // and `select_from` the view.
+    }
+}

--- a/tutorials/sql/13-aggregates.das
+++ b/tutorials/sql/13-aggregates.das
@@ -1,0 +1,88 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 13 — Column aggregates: `sum`, `average`, `min`, `max`,
+// plus `count` (already shown in tutorial 6 and used as a canary in
+// chunk 3).
+//
+// All five are *terminals* — they end the chain and produce a
+// scalar, not an array. The translation pattern is the same for the
+// four column-driven ones:
+//
+//   db |> select_from(type<Car>) |> _select(_.Price) |> sum()
+//                                                       ^^^^^
+//   - `_select(_.Price)` picks the column.
+//   - The terminal (`sum` / `average` / `min` / `max`) wraps it.
+//
+// `count()` doesn't need a `_select` — it counts rows.
+//
+// Result types:
+//   - `sum`, `min`, `max` inherit the column's daslang type
+//     (`int` for `Price`, `int64` for big-number columns, etc.).
+//   - `average` always promotes to `double`.
+//   - `count` returns `int` (matching daslang's `length(arr)`).
+//
+// Composing with `_where` works as expected — the predicate filters
+// the rows the aggregate sees.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // ── count — over the whole source, no `_select` needed ──────────
+        let n = _sql(db |> select_from(type<Car>) |> count())
+        to_log(LOG_INFO, "count = {n} rows\n")
+
+        // ── sum — column total ──────────────────────────────────────────
+        let total = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> sum())
+        to_log(LOG_INFO, "SUM(Price) = {total}\n")
+
+        // ── average — promotes to double ─────────────────────────────────
+        let mean = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> average())
+        to_log(LOG_INFO, "AVG(Price) = {mean}\n")
+
+        // ── min / max — inherit the column's type ────────────────────────
+        let cheapest = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> min())
+        let priciest = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> max())
+        to_log(LOG_INFO, "MIN(Price) = {cheapest}\n")
+        to_log(LOG_INFO, "MAX(Price) = {priciest}\n")
+
+        // ── Aggregates compose with `_where` ─────────────────────────────
+        let cutoff = 100
+        let total_over_100 = _sql(db |> select_from(type<Car>)
+                                    |> _where(_.Price > cutoff)
+                                    |> _select(_.Price)
+                                    |> sum())
+        to_log(LOG_INFO, "SUM(Price) WHERE Price>100 = {total_over_100}\n")
+
+        // ── Inspect emitted SQL ──────────────────────────────────────────
+        let sql_sum = _sql_text(db |> select_from(type<Car>)
+                                  |> _select(_.Price)
+                                  |> sum())
+        let sql_avg = _sql_text(db |> select_from(type<Car>)
+                                  |> _select(_.Price)
+                                  |> average())
+        to_log(LOG_INFO, "  SUM SQL: {sql_sum}\n")
+        to_log(LOG_INFO, "  AVG SQL: {sql_avg}\n")
+    }
+}

--- a/tutorials/sql/14-group_by.das
+++ b/tutorials/sql/14-group_by.das
@@ -1,0 +1,163 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 14 — `_group_by` and `_having`.
+//
+// `_group_by(key)` partitions rows into buckets. After grouping, the
+// chain element is a (key, group-rows) tuple shaped like C# LINQ's
+// `IGrouping<K, T>`:
+//
+//   - `_._0`        — the group key (single-key `_group_by(_.City)`)
+//   - `_._0._N`     — the Nth key column (multi-key `(_.City, _.Age)`)
+//   - `_._1`        — the array of rows in this bucket
+//
+// Aggregates on the group:
+//
+//   - `_._1 |> length`                                   → COUNT(*)
+//   - `_._1 |> count`                                    → COUNT(*) (alias)
+//   - `_._1 |> select($(u : T) => u.Field) |> sum`       → SUM("Field")
+//   - `_._1 |> select($(u : T) => u.Field) |> average`   → AVG("Field")
+//   - `_._1 |> select($(u : T) => u.Field) |> min`       → MIN("Field")
+//   - `_._1 |> select($(u : T) => u.Field) |> max`       → MAX("Field")
+//
+// The inner `select` lambda parameter is **named** (`$(u : User)`),
+// not `_`. The outer `_select` already binds `_` to the group tuple,
+// and daslang flags a same-name-different-type lambda nested inside
+// as a shadowing error. Naming the inner parameter sidesteps it.
+// The macro recognizes the body as `<param>.<field>` for any param
+// name.
+//
+// `_having(predicate)` filters on the aggregated buckets — it sits
+// between `_group_by` and the projection. `_where` (pre-aggregate)
+// stays before `_group_by`. The macro routes binds correctly:
+// WHERE binds first, HAVING next, LIMIT last, in placeholder order.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name   : string
+    City   : string
+    Age    : int
+    Salary : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "Alice", City = "NYC",     Age = 30, Salary = 100))
+    db |> insert(User(Id = 2, Name = "Bob",   City = "NYC",     Age = 25, Salary = 80))
+    db |> insert(User(Id = 3, Name = "Carol", City = "Chicago", Age = 40, Salary = 120))
+    db |> insert(User(Id = 4, Name = "Dave",  City = "Chicago", Age = 35, Salary = 90))
+    db |> insert(User(Id = 5, Name = "Eve",   City = "Chicago", Age = 50, Salary = 200))
+    db |> insert(User(Id = 6, Name = "Frank", City = "Boston",  Age = 28, Salary = 70))
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // ── Single-key group_by: head-count per city ─────────────────────
+        // SELECT "City", COUNT(*) FROM "Users" GROUP BY "City"
+        let by_city <- _sql(db |> select_from(type<User>)
+                              |> _group_by(_.City)
+                              |> _order_by(_._0)
+                              |> _select((City = _._0, N = _._1 |> length)))
+        to_log(LOG_INFO, "Users per city:\n")
+        for (r in by_city) {
+            to_log(LOG_INFO, "  {r.City}: {r.N}\n")
+        }
+
+        // ── Multiple aggregates in one projection ────────────────────────
+        // SELECT "City", COUNT(*), MIN("Age"), MAX("Age"), SUM("Salary")
+        // FROM "Users" GROUP BY "City"
+        let stats <- _sql(db |> select_from(type<User>)
+                            |> _group_by(_.City)
+                            |> _order_by(_._0)
+                            |> _select((
+                                City   = _._0,
+                                N      = _._1 |> length,
+                                MinAge = _._1 |> select($(u : User) => u.Age)    |> min,
+                                MaxAge = _._1 |> select($(u : User) => u.Age)    |> max,
+                                Total  = _._1 |> select($(u : User) => u.Salary) |> sum)))
+        to_log(LOG_INFO, "Per-city stats:\n")
+        for (r in stats) {
+            to_log(LOG_INFO, "  {r.City}: N={r.N} ages={r.MinAge}..{r.MaxAge} salary={r.Total}\n")
+        }
+
+        // ── _where (pre-aggregate filter) before _group_by ───────────────
+        // SQL clause order: WHERE → GROUP BY. The macro routes
+        // `_where` to the WHERE clause (filters input rows) and the
+        // result is grouped over what's left.
+        let by_city_seniors <- _sql(db |> select_from(type<User>)
+                                      |> _where(_.Age >= 30)
+                                      |> _group_by(_.City)
+                                      |> _order_by(_._0)
+                                      |> _select((City = _._0, N = _._1 |> length)))
+        to_log(LOG_INFO, "Seniors per city (Age>=30):\n")
+        for (r in by_city_seniors) {
+            to_log(LOG_INFO, "  {r.City}: {r.N}\n")
+        }
+
+        // ── _having (post-aggregate filter) ─────────────────────────────
+        // SELECT "City", COUNT(*) FROM "Users"
+        // GROUP BY "City" HAVING COUNT(*) > ?
+        // Binds: [1]
+        let popular <- _sql(db |> select_from(type<User>)
+                              |> _group_by(_.City)
+                              |> _having(_._1 |> length > 1)
+                              |> _order_by(_._0)
+                              |> _select((City = _._0, N = _._1 |> length)))
+        to_log(LOG_INFO, "Cities with more than 1 user:\n")
+        for (r in popular) {
+            to_log(LOG_INFO, "  {r.City}: {r.N}\n")
+        }
+
+        // ── Multi-key grouping ───────────────────────────────────────────
+        // Group key is a tuple. Each tuple field becomes its own
+        // GROUP BY column; project them with `_._0._N`.
+        // SQL: SELECT "City", "Age", COUNT(*) FROM "Users"
+        //      GROUP BY "City", "Age"
+        db |> insert(User(Id = 7, Name = "Adam", City = "NYC", Age = 30, Salary = 110))
+        let by_city_age <- _sql(db |> select_from(type<User>)
+                                  |> _group_by((_.City, _.Age))
+                                  |> _having(_._1 |> length > 1)
+                                  |> _select((City = _._0._0, Age = _._0._1, N = _._1 |> length)))
+        to_log(LOG_INFO, "Multi-key buckets with 2+ members:\n")
+        for (r in by_city_age) {
+            to_log(LOG_INFO, "  ({r.City}, age {r.Age}): {r.N}\n")
+        }
+
+        // ── Full reporting query: WHERE → GROUP BY → HAVING → ORDER BY → LIMIT
+        // The chain mirrors SQL clause order one-for-one. Bind ordering
+        // tracks: WHERE binds first, HAVING next, LIMIT last.
+        let min_age = 25
+        let min_count = 1
+        let report <- _sql(db |> select_from(type<User>)
+                             |> _where(_.Age >= min_age)
+                             |> _group_by(_.City)
+                             |> _having(_._1 |> length >= min_count)
+                             |> _order_by(_._0)
+                             |> _select((
+                                 City      = _._0,
+                                 N         = _._1 |> length,
+                                 AvgSalary = _._1 |> select($(u : User) => u.Salary) |> average))
+                             |> take(10))
+        to_log(LOG_INFO, "Reporting query:\n")
+        for (r in report) {
+            to_log(LOG_INFO, "  {r.City}: N={r.N} avg salary={r.AvgSalary}\n")
+        }
+
+        // ── Inspect emitted SQL ──────────────────────────────────────────
+        let sql = _sql_text(db |> select_from(type<User>)
+                              |> _where(_.Age >= min_age)
+                              |> _group_by(_.City)
+                              |> _having(_._1 |> length >= min_count)
+                              |> _order_by(_._0)
+                              |> _select((City = _._0, N = _._1 |> length))
+                              |> take(10))
+        to_log(LOG_INFO, "  emitted SQL: {sql}\n")
+    }
+}

--- a/tutorials/sql/18-null_handling.das
+++ b/tutorials/sql/18-null_handling.das
@@ -1,0 +1,154 @@
+options gen2
+
+require daslib/sql
+require daslib/option
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 18 — NULL handling: `Option<T>` everywhere.
+//
+// Nullability is type-driven. The struct field's daslang type is the
+// single source of truth — there is no `@sql_nullable` annotation.
+//
+//   - `T` field          → column declared `NOT NULL`
+//   - `Option<T>` field  → column allows `NULL`
+//
+// The `[sql_table]` macro inspects each field at compile time:
+//
+//   - DDL: emits `NOT NULL` for `T`, omits it for `Option<T>`
+//   - INSERT/UPDATE bind:
+//       `is_some(field)` → bind the underlying value
+//       `is_none()`      → bind SQL NULL
+//   - SELECT reader: checks `sqlite3_column_type == SQLITE_NULL` and
+//     wraps in `some(v)` / `none()` for `Option<T>` fields
+//
+// Inside `_sql(...)` predicates, three Option methods translate to
+// SQL null-comparison operators:
+//
+//   `_.Col |> is_some`        →  "Col" IS NOT NULL
+//   `_.Col |> is_none`        →  "Col" IS NULL
+//   `_.Col |> unwrap_or(d)`   →  COALESCE("Col", ?)   (d binds)
+//
+// Three-valued-logic gotcha: in SQL, `NULL = NULL` is NULL, never
+// TRUE. The Option API steers users away from that footgun — write
+// `_.Age |> is_none()` or `_.Age |> unwrap_or(0) >= 18`, never
+// `_.Age == 0` for "missing or zero".
+
+// `Option<T>` fields need `@safe_when_uninitialized` so the
+// `[sql_table]` reader can build a default-initialized row without
+// tripping `strict_smart_pointers`. The Option's internal `_value`
+// is already so-marked inside the template; the wrapping struct
+// field still needs its own annotation under strict mode.
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name      : string
+    @safe_when_uninitialized Age       : Option<int>
+    @safe_when_uninitialized Nick      : Option<string>
+    @safe_when_uninitialized DeletedAt : Option<int64>
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    // alice: known age, no nick, alive
+    db |> insert(User(
+        Id = 1, Name = "alice",
+        Age = some(30), Nick = none(type<string>), DeletedAt = none(type<int64>)))
+    // bob: unknown age, has nick, alive
+    db |> insert(User(
+        Id = 2, Name = "bob",
+        Age = none(type<int>), Nick = some("bobby"), DeletedAt = none(type<int64>)))
+    // carol: known age, has nick, soft-deleted
+    db |> insert(User(
+        Id = 3, Name = "carol",
+        Age = some(40), Nick = some("c"), DeletedAt = some(1000l)))
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // ── (1) Type-driven DDL ──────────────────────────────────────────
+        // The CREATE TABLE statement skips `NOT NULL` on Option<T>
+        // columns and keeps it on plain T columns. Inspect the DDL
+        // string the macro generates:
+        let ddl = _::_sql_create_table_sql(type<User>)
+        to_log(LOG_INFO, "DDL:\n  {ddl}\n")
+
+        // ── (2) Round-trip — some(v) and none() both store + read back ──
+        let everyone <- db |> select_from(type<User>)
+        to_log(LOG_INFO, "All users:\n")
+        for (u in everyone) {
+            // Each Option<T> field is read back as the same Option<T>.
+            // Pattern-match with is_some / is_none / unwrap.
+            if (u.Age |> is_some) {
+                to_log(LOG_INFO, "  {u.Name}: age {u.Age |> unwrap}\n")
+            } else {
+                to_log(LOG_INFO, "  {u.Name}: age unknown\n")
+            }
+        }
+
+        // ── (3) `is_some` / `is_none` in `_where` ────────────────────────
+        // SQL: WHERE "Age" IS NOT NULL
+        let known_age <- _sql(db |> select_from(type<User>)
+                                |> _where(_.Age |> is_some)
+                                |> _order_by(_.Id))
+        to_log(LOG_INFO, "Users with known age:\n")
+        for (u in known_age) {
+            to_log(LOG_INFO, "  {u.Name}\n")
+        }
+
+        // SQL: WHERE "DeletedAt" IS NULL
+        let alive <- _sql(db |> select_from(type<User>)
+                            |> _where(_.DeletedAt |> is_none)
+                            |> _order_by(_.Id))
+        to_log(LOG_INFO, "Alive users:\n")
+        for (u in alive) {
+            to_log(LOG_INFO, "  {u.Name}\n")
+        }
+
+        // ── (4) `unwrap_or(default)` lowers to COALESCE ──────────────────
+        // SQL: WHERE COALESCE("Age", ?) >= ?
+        // Binds: [0, 18]
+        // bob has Age=none, so COALESCE returns 0; 0 >= 18 is false →
+        // bob is filtered out. alice and carol pass.
+        let cutoff = 18
+        let adults_or_unknown <- _sql(db |> select_from(type<User>)
+                                        |> _where(_.Age |> unwrap_or(0) >= cutoff)
+                                        |> _order_by(_.Id))
+        to_log(LOG_INFO, "Adults (treating unknown age as 0):\n")
+        for (u in adults_or_unknown) {
+            to_log(LOG_INFO, "  {u.Name}\n")
+        }
+
+        // ── (5) Option<T> carries through full-row projection ────────────
+        // No implicit unwrap. The result element is the source struct,
+        // so `Option<int>` stays `Option<int>`.
+        let with_age <- _sql(db |> select_from(type<User>)
+                               |> _where(_.Age |> is_some)
+                               |> _order_by(_.Id))
+        to_log(LOG_INFO, "Projected rows preserve Option:\n")
+        for (u in with_age) {
+            to_log(LOG_INFO, "  {u.Name}: Age is_some={u.Age |> is_some}\n")
+        }
+
+        // ── (6) `_try_sql` composes with Option predicates ───────────────
+        let attempt <- _try_sql(db |> select_from(type<User>)
+                                  |> _where(_.Age |> is_some))
+        if (attempt |> is_ok) {
+            let rows <- attempt |> unwrap
+            to_log(LOG_INFO, "_try_sql returned {length(rows)} known-age users\n")
+        } else {
+            to_log(LOG_ERROR, "query failed: {attempt |> unwrap_err}\n")
+        }
+
+        // ── Inspect emitted SQL ──────────────────────────────────────────
+        let sql_is_some = _sql_text(db |> select_from(type<User>)
+                                      |> _where(_.Age |> is_some))
+        let sql_coalesce = _sql_text(db |> select_from(type<User>)
+                                       |> _where(_.Age |> unwrap_or(0) >= cutoff))
+        to_log(LOG_INFO, "  is_some SQL:  {sql_is_some}\n")
+        to_log(LOG_INFO, "  COALESCE SQL: {sql_coalesce}\n")
+    }
+}


### PR DESCRIPTION
## Summary

Broadens the chunk-3 framework with the rest of the read-side operators and ships **tutorials 7, 10, 11, 12, 13, 14, 18**. Set operations (UNION/INTERSECT/EXCEPT — tut 12 second half) and joins + subqueries (tuts 15–17) are deferred to chunk 5: they all need the same multi-source / multi-stage `SqlQuery` extension.

### New `_sql` chain operators

| Operator | Recognition | SQL emitted |
|---|---|---|
| `distinct()` | `SqlQuery.distinctFlag` | `SELECT DISTINCT` |
| `take(n)` | `q.limitBindExpr` (binds after WHERE) | `LIMIT ?` |
| `skip(n)` | `q.offsetBindExpr` | `OFFSET ?` (or `LIMIT -1 OFFSET ?` solo — SQLite quirk) |
| `_order_by(_.Col)` / `_order_by_descending(_.Col)` | recurse-first | `ORDER BY "Col" ASC/DESC` |
| `_order_by((_.k1, _.k2))` | tuple-key | `ORDER BY "k1" ASC, "k2" ASC` |
| `sum` / `average` / `min` / `max` | `peel_column_aggregate` (recurse-first) | `SELECT SUM/AVG/MIN/MAX("Col")` — AVG promotes to `double` |
| `_group_by(_.Col)` / `_group_by((_.k1, _.k2))` | new `ProjectionShape.GroupedNamedTuple` | `GROUP BY "Col" [, ...]` |
| `_having(predicate)` | recurse-first; `q.havingBindExprs` | `HAVING …` (binds slot between WHERE and LIMIT) |
| `_.Col \|> is_some` / `is_none` | `fn_call_to_sql` | `Col IS [NOT] NULL` |
| `_.Col \|> unwrap_or(d)` | `fn_call_to_sql` | `COALESCE("Col", ?)` |

### IGrouping shape (locked)

After `_group_by` lowers to `group_by_lazy`, the chain element is `tuple<KeyType; array<RowType>>`. The post-group `_select` recognizes:

- `_._0` — group key (single-key form), `_._0._N` — multi-key
- `_._1` — group rows array
- `_._1 |> length` / `_._1 |> count` → `COUNT(*)` (result type `int`, matches daslang's `length`/`count`)
- `_._1 |> select($(u : T) => u.Field) |> sum/average/min/max` → `SUM/AVG/MIN/MAX("Field")`

Inner `select` lambda parameter is **named** (not `_`) to sidestep daslang's same-name-different-type lambda shadowing rule. The original `19-group_by.das.mockup` syntax (`_count_all()`, `_sum(_.X)`) does not typecheck after `_group_by` lowering — IGrouping is the workable shape and matches EF Core's `g.Key` / `g.Count()` / `g.Average(u => u.X)`.

### `[sql_table]` runtime extensions for `Option<T>`

- `is_option_field_type` recognizes both pre- and post-resolution forms (`typeMacro` vs `tStructure`)
- `sqlite_sql_type` / `sqlite_bind` / `sqlite_read` overloads for `$Option<auto(TT)>`; bind branches on `_has_value`, read branches on `sqlite3_column_type == SQLITE_NULL`
- DDL omits `NOT NULL` for `Option<T>`; rejects `@sql_primary_key` on `Option<T>`
- `_sql_read_row` body uses `var row = default<$t(st)>` so Option-bearing user structs default-init cleanly under `strict_smart_pointers`

### Tutorials + RST

7 new tutorials under `tutorials/sql/`: 07-anatomy, 10-order_by, 11-take_skip, 12-distinct, 13-aggregates, 14-group_by, 18-null_handling. Matching `sql_NN_*.rst` pages wired into `tutorials.rst`; prev/next links in `sql_06`/`sql_08`/`sql_09` updated. `TUTORIALS.md` status table updated; `API_REWORK.md` gains a "Shipped — chunk 4" section with all deferred items listed.

### Tests

`failed_sql_macro.das` extended with bad10 (`_having` without `_group_by`) + bad11 (bare scalar projection after `_group_by`); test_32 distinct, test_33 take/skip, test_34 order_by, test_35 aggregates, test_36 group_by + having, test_37 null handling. **205 dasSQLITE tests** (chunk-2 81 + chunk-3 70 + chunk-4 54).

## Test plan

- [x] `git rebase origin/master` — clean rebase, 30 files in PR diff
- [x] `bin/Release/daslang.exe utils/lint/main.das -- modules/dasSQLITE tutorials/sql tests/dasSQLITE` — 0 issues on chunk-4 surface
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/` — **7059 / 7059 passed**, 0 GC leaks
- [x] `cmake --build build --config Release --target test_aot -j 64` — clean
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — **6471 / 6471 passed**, 0 GC leaks
- [x] `bin/Release/daslang.exe doc/reflections/das2rst.das` — RST regenerated for `linq_boost.das` `//!` doc-comment update
- [x] Sphinx clean build (cache cleared) — `build succeeded.` with 0 warnings/errors
- [x] MCP `format_file` on every changed `.das` — already formatted

## Deferred to chunk 5+

- **Set operations** (UNION/INTERSECT/EXCEPT) — tut 12 second half. Bundled with joins and subqueries.
- **`_join` / `_left_join`** (tuts 15–16) — multi-source FROM, equi-join predicate extraction.
- **Subqueries — `_in` / `_not_in` / `_any` / `_none`** (tut 17) — nested SqlQuery walker, correlated columns.
- **`_then_by` and multi-key ordering protocol (D1)** — needs `IOrderedEnumerable<T>`-equivalent in daslib/linq. Chunk-4 workaround: tuple-key `_order_by((_.k1, _.k2))`.
- **Mixed ASC/DESC across columns (D2)** — `ORDER BY a ASC, b DESC` in one chain step.
- **`Option<T> == none()` in `_sql` predicates (D4)** — diagnostic with fix-it pointing at `|> is_none()`.
- **Projection-side `_.Col |> unwrap_or(d)` in `_select`** — predicate-side ships this chunk; projection-side requires extending `analyze_projection` beyond plain `_.Field`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)