### PR TITLE
find_dupes: candidate-filter modes (B1 baseline, B2 against) + MCP tool

### DIFF
--- a/utils/find_dupes/README.md
+++ b/utils/find_dupes/README.md
@@ -153,7 +153,9 @@ Snapshot the corpus once, commit the JSON, and on every PR re-scan + diff.
 ./bin/daslang utils/find_dupes/main.das -- -p tests --baseline tests_baseline.json --check
 ```
 
-A cluster appears in the report if (a) its canonical is brand-new (no record in the baseline had it), or (b) it gained a new member. Use `--baseline-strict` to drop case (b) — only new clusters survive. Pairs aren't strict-filtered (the baseline doesn't carry MinHash signatures), so strict is cluster-only.
+Records are tagged candidate when their **member identity** (`file:line:name`) is absent from the baseline. A cluster appears in the report if any of its members is a candidate, which catches both (a) brand-new canonicals and (b) growth — a new copy of an already-tracked canonical added in a new location. Use `--baseline-strict` to drop case (b) — strict additionally filters out clusters whose canonical was already in the baseline, so only fully-new canonicals survive. Pairs aren't strict-filtered (the baseline doesn't carry MinHash signatures), so strict is cluster-only.
+
+Note: `file:line:name` keying means an unrelated edit that shifts line numbers will look like a "new member" and surface its cluster — acceptable for CI, since touched code is the right default to re-check.
 
 `--check` turns the filtered report into a CI gate — non-zero exit when any cluster or pair survives the filter.
 

--- a/utils/find_dupes/README.md
+++ b/utils/find_dupes/README.md
@@ -45,7 +45,7 @@ Flags:
 | `--export-functions` | (off) | Write all extracted functions to a JSON file and exit before clustering |
 | `--import-functions` | (off) | Load functions from a JSON file (produced by `--export-functions`) instead of compiling. Mutually exclusive with `--path` and `--export-functions` |
 | `-v / --verbose` | off | Per-file progress |
-| `--baseline` | (off) | B1: load corpus JSON; tag records whose canonical isn't in the baseline as candidates and filter to those |
+| `--baseline` | (off) | B1: load corpus JSON; tag records whose member identity (`file:line:name`) isn't in the baseline as candidates and filter to those |
 | `--baseline-strict` | off | B1 modifier: also drop clusters whose canonical exists in the baseline (only fully-new clusters survive) |
 | `--against` | (off) | B2 candidate path (file or directory). Repeatable. Compiled in-process; their functions are tagged candidates and the report is filtered |
 | `--against-from-stdin` | off | B2: read newline-delimited candidate paths from stdin (use with `git diff --name-only … \| find_dupes --against-from-stdin …`) |

--- a/utils/find_dupes/README.md
+++ b/utils/find_dupes/README.md
@@ -45,6 +45,12 @@ Flags:
 | `--export-functions` | (off) | Write all extracted functions to a JSON file and exit before clustering |
 | `--import-functions` | (off) | Load functions from a JSON file (produced by `--export-functions`) instead of compiling. Mutually exclusive with `--path` and `--export-functions` |
 | `-v / --verbose` | off | Per-file progress |
+| `--baseline` | (off) | B1: load corpus JSON; tag records whose canonical isn't in the baseline as candidates and filter to those |
+| `--baseline-strict` | off | B1 modifier: also drop clusters whose canonical exists in the baseline (only fully-new clusters survive) |
+| `--against` | (off) | B2 candidate path (file or directory). Repeatable. Compiled in-process; their functions are tagged candidates and the report is filtered |
+| `--against-from-stdin` | off | B2: read newline-delimited candidate paths from stdin (use with `git diff --name-only … \| find_dupes --against-from-stdin …`) |
+| `--check` | off | Exit non-zero when the post-filter report contains any clusters/pairs (CI gate) |
+| `--flat` | off | In `--against` mode, force the flat clusters+pairs writer (default is the per-candidate rollup) |
 | `-?` | | Help |
 
 `builtin.das`, `daslib/debugger.das`, and `daslib/profiler.das` are skipped automatically — the latter two install thread-local debug agents at compile time, which would abort the scanner on second use.
@@ -128,10 +134,53 @@ The on-disk schema is a small envelope:
 
 MinHash signatures are not included — they're recomputed on import (deterministic and cheap). On import, `--no-fuzzy` and `--min-tokens` apply just like in the compile path.
 
+## Modes
+
+The flat report from `-p` is the firehose — useful once on a new corpus to
+calibrate, less useful day-to-day. Two filtered modes are layered on top
+via a single `is_candidate` flag inside `FuncRecord`. A cluster or fuzzy
+pair is **kept** iff at least one of its members is a candidate.
+
+### B1 — baseline diff (CI gate)
+
+Snapshot the corpus once, commit the JSON, and on every PR re-scan + diff.
+
+```sh
+# one-off: build the baseline (commit this)
+./bin/daslang utils/find_dupes/main.das -- -p tests --export-functions tests_baseline.json
+
+# CI: scan again, surface only what isn't in the baseline
+./bin/daslang utils/find_dupes/main.das -- -p tests --baseline tests_baseline.json --check
+```
+
+A cluster appears in the report if (a) its canonical is brand-new (no record in the baseline had it), or (b) it gained a new member. Use `--baseline-strict` to drop case (b) — only new clusters survive. Pairs aren't strict-filtered (the baseline doesn't carry MinHash signatures), so strict is cluster-only.
+
+`--check` turns the filtered report into a CI gate — non-zero exit when any cluster or pair survives the filter.
+
+### B2 — PR-files / interactive
+
+"Did I just write something that already exists?" Compare a file list against a pre-built corpus:
+
+```sh
+./bin/daslang utils/find_dupes/main.das -- \
+    --import-functions tests_baseline.json --against tests/strings/new_helper.das
+
+# git pipeline:
+git diff --name-only master | grep '\.das$' | \
+    ./bin/daslang utils/find_dupes/main.das -- \
+        --import-functions tests_baseline.json --against-from-stdin
+```
+
+When `--against` and `--import-functions` are both set, corpus records whose `file` matches any candidate path are dropped first, then the candidate is freshly compiled — so the file is compared against the rest of the world, never against its own stale copy in the baseline. Look for the `dropped N corpus records overridden` line.
+
+The default writer in `--against` mode is a per-candidate rollup ("for each function in the focus set, here are its top siblings"). Use `--flat` to revert to the legacy clusters+pairs view.
+
+### MCP integration
+
+The `find_duplicates` tool in the [daslang MCP server](../mcp/) wraps B2 mode for AI assistants. Pass `paths` (newline- or comma-delimited, or a glob) and `corpus` (the JSON from `--export-functions`); receive a per-candidate JSON envelope. Used by Claude Code et al. during PR review.
+
 ## Out of scope
 
 - LSH / banding (4.4K² is fine; revisit at >50K functions).
 - Embedding-based similarity (would need an external service).
 - Auto-fix or refactor suggestions — discovery only.
-- CI integration — first read what it finds; promote findings to lint
-  rules later.

--- a/utils/find_dupes/cluster.das
+++ b/utils/find_dupes/cluster.das
@@ -194,7 +194,7 @@ def public fuzzy_pairs(records : array<FuncRecord>; threshold : float; min_token
 }
 
 
-def member_key(m : MemberRef) : string {
+def public member_key(m : MemberRef) : string {
     return "{m.file}:{m.line}:{m.name}"
 }
 

--- a/utils/find_dupes/cluster.das
+++ b/utils/find_dupes/cluster.das
@@ -19,6 +19,12 @@ struct public FuncRecord {
     sig : array<uint64>
     token_count : int
     cluster_id : int = -1
+    // Set true on records that came from the user's "focus set"
+    // (e.g. PR files, or new functions vs. a baseline). When any
+    // record is flagged, exact_buckets and fuzzy_pairs filter their
+    // output to only entries that include at least one candidate.
+    // Runtime/derived flag — never serialized in ExportedFunction.
+    is_candidate : bool = false
 }
 
 
@@ -44,7 +50,8 @@ struct public FuzzyPair {
 //
 // Bucket on the canonical string itself (not its 64-bit hash) so a
 // rare hash collision can't conflate two unrelated functions.
-def public exact_buckets(var records : array<FuncRecord>; min_tokens : int) : array<Cluster> {
+def public exact_buckets(var records : array<FuncRecord>; min_tokens : int;
+                         filter_candidates : bool = false) : array<Cluster> {
     var buckets : table<string; array<int>>
     for (i in range(length(records))) {
         if (records[i].token_count < min_tokens) {
@@ -69,12 +76,27 @@ def public exact_buckets(var records : array<FuncRecord>; min_tokens : int) : ar
         c.canonical_sample := records[idxs[0]].canonical
         c.token_count = records[idxs[0]].token_count
         c.members |> reserve(length(idxs))
+        var cluster_has_candidate = false
         for (i in idxs) {
+            // Always assign cluster_id, even for clusters we'll drop —
+            // fuzzy_pairs uses cluster_id to skip same-canonical pairs,
+            // and that semantics shouldn't depend on the filter.
             records[i].cluster_id = cluster_idx
             c.members |> push(records[i].ref)
+            if (records[i].is_candidate) {
+                cluster_has_candidate = true
+            }
+        }
+        cluster_idx++
+        // Drop clusters with no candidate members ONLY when the caller
+        // requested filtering. Auto-detecting "any candidate exists"
+        // would silently fall back to legacy mode in baseline runs
+        // where genuinely zero records are new (e.g. CI on an unchanged
+        // branch), which is the wrong default for a CI gate.
+        if (filter_candidates && !cluster_has_candidate) {
+            continue
         }
         out |> emplace(c)
-        cluster_idx++
     }
     return <- out
 }
@@ -88,47 +110,84 @@ def public exact_buckets(var records : array<FuncRecord>; min_tokens : int) : ar
 // boilerplate block repeated N times) has a tiny shingle set, so 4x
 // and 7x repetitions both estimate Jaccard = 1.0 even though they're
 // not the same function. Gate the report on a length ratio too.
-def public fuzzy_pairs(records : array<FuncRecord>; threshold : float; min_tokens : int) : array<FuzzyPair> {
+// Inner-body helper: the per-pair filtering and emit logic, shared by
+// the legacy O(N²) loop and the candidate-restricted loop. `lo` and
+// `hi` must satisfy lo < hi so the emitted pair's (a, b) ordering
+// matches the legacy report.
+def fuzzy_emit_if_match(records : array<FuncRecord>; lo : int; hi : int;
+                        threshold : float; min_tokens : int;
+                        var out : array<FuzzyPair>) {
+    if (records[lo].token_count < min_tokens || records[hi].token_count < min_tokens) {
+        return
+    }
+    if (records[lo].cluster_id != -1 && records[lo].cluster_id == records[hi].cluster_id) {
+        return
+    }
+    // Same canonical text would already be in the exact-cluster set
+    // (caught above when both have a cluster_id). Compare on the string
+    // itself rather than the 64-bit hash to dodge any theoretical
+    // collision.
+    if (records[lo].canonical == records[hi].canonical) {
+        return
+    }
+    let tl = float(records[lo].token_count)
+    let th = float(records[hi].token_count)
+    let len_ratio = tl < th ? tl / th : th / tl
+    if (len_ratio < threshold) {
+        return
+    }
+    let s = jaccard_estimate(records[lo].sig, records[hi].sig)
+    // Geometric mean of MinHash similarity and length similarity:
+    // periodic code with very different lengths drops out.
+    let combined = sqrt(s * len_ratio)
+    if (combined >= threshold) {
+        var p = FuzzyPair()
+        p.similarity = combined
+        p.a = records[lo].ref
+        p.b = records[hi].ref
+        p.canonical_a := records[lo].canonical
+        p.canonical_b := records[hi].canonical
+        out |> emplace(p)
+    }
+}
+
+
+def public fuzzy_pairs(records : array<FuncRecord>; threshold : float; min_tokens : int;
+                       filter_candidates : bool = false) : array<FuzzyPair> {
     var out : array<FuzzyPair>
     out |> reserve(64)
     let n = length(records)
-    for (i in range(n)) {
-        if (records[i].token_count < min_tokens) {
-            continue
+    if (!filter_candidates) {
+        for (i in range(n)) {
+            for (j in range(i + 1, n)) {
+                fuzzy_emit_if_match(records, i, j, threshold, min_tokens, out)
+            }
         }
-        for (j in range(i + 1, n)) {
-            if (records[j].token_count < min_tokens) {
+        return <- out
+    }
+    // Candidate-restricted path: outer iterates flagged records only,
+    // inner iterates all. Saves O(N²) → O(K·N) when K = |candidates|
+    // << N. Dedup rule: when both endpoints are candidates, only emit
+    // during the iteration whose outer index is smaller — `candidate_indices`
+    // is built in ascending order, so when records[j].is_candidate &&
+    // j < i, the pair was already emitted at iteration j.
+    var candidate_indices : array<int>
+    for (i in range(n)) {
+        if (records[i].is_candidate) {
+            candidate_indices |> push(i)
+        }
+    }
+    for (i in candidate_indices) {
+        for (j in range(n)) {
+            if (j == i) {
                 continue
             }
-            if (records[i].cluster_id != -1 && records[i].cluster_id == records[j].cluster_id) {
+            if (records[j].is_candidate && j < i) {
                 continue
             }
-            // Same canonical text would already be in the exact-cluster
-            // set (caught above when both have a cluster_id). Compare on
-            // the string itself rather than the 64-bit hash to dodge any
-            // theoretical collision.
-            if (records[i].canonical == records[j].canonical) {
-                continue
-            }
-            let ti = float(records[i].token_count)
-            let tj = float(records[j].token_count)
-            let len_ratio = ti < tj ? ti / tj : tj / ti
-            if (len_ratio < threshold) {
-                continue
-            }
-            let s = jaccard_estimate(records[i].sig, records[j].sig)
-            // Geometric mean of MinHash similarity and length similarity:
-            // periodic code with very different lengths drops out.
-            let combined = sqrt(s * len_ratio)
-            if (combined >= threshold) {
-                var p = FuzzyPair()
-                p.similarity = combined
-                p.a = records[i].ref
-                p.b = records[j].ref
-                p.canonical_a := records[i].canonical
-                p.canonical_b := records[j].canonical
-                out |> emplace(p)
-            }
+            let lo = i < j ? i : j
+            let hi = i < j ? j : i
+            fuzzy_emit_if_match(records, lo, hi, threshold, min_tokens, out)
         }
     }
     return <- out

--- a/utils/find_dupes/exchange.das
+++ b/utils/find_dupes/exchange.das
@@ -91,12 +91,23 @@ def is_well_formed(ef : ExportedFunction) : bool {
 }
 
 
+// Slash-direction normalization for file paths. Lives here (rather than
+// in pipeline.das) because exchange is below pipeline in the dep graph
+// and `member_id` needs it. pipeline.das re-uses this via `require
+// exchange`, so callers see one canonical helper.
+def public normalize_path(p : string) : string {
+    return p |> replace("\\", "/")
+}
+
+
 // Stable member identity used to compare a freshly-extracted record
 // against a baseline. Same shape as cluster.das `member_key`, copied
 // here to avoid a require cycle (exchange already needs to know about
-// records but not about clustering helpers).
+// records but not about clustering helpers). Path is normalized so
+// Windows runs (mixed `\` and `/` from `fileInfo.name`) match Unix
+// baselines.
 def member_id(file : string; line : int; name : string) : string {
-    return "{file}:{line}:{name}"
+    return "{normalize_path(file)}:{line}:{name}"
 }
 
 

--- a/utils/find_dupes/exchange.das
+++ b/utils/find_dupes/exchange.das
@@ -125,9 +125,13 @@ def public load_baseline_canonicals(path : string; var canonicals : table<string
 }
 
 
+// `quiet=true` suppresses the "skipped N malformed records" warning print —
+// required when called from the MCP server, whose stdio transport reserves
+// stdout for JSON-RPC. Default false preserves CLI behavior.
 def public read_import(path : string; var records : array<FuncRecord>;
                        want_sigs : bool; min_tokens : int;
-                       var error : string&) : bool {
+                       var error : string&;
+                       quiet : bool = false) : bool {
     let text = fread(path)
     if (empty(text)) {
         error := "could not read file (empty or missing): {path}"
@@ -158,7 +162,7 @@ def public read_import(path : string; var records : array<FuncRecord>;
         derive_sig_and_count(rec, want_sigs, min_tokens)
         records |> emplace(rec)
     }
-    if (skipped > 0) {
+    if (skipped > 0 && !quiet) {
         print("warning: skipped {skipped} malformed function record(s) during import\n")
     }
     return true

--- a/utils/find_dupes/exchange.das
+++ b/utils/find_dupes/exchange.das
@@ -91,13 +91,33 @@ def is_well_formed(ef : ExportedFunction) : bool {
 }
 
 
-// Read an exported envelope and project it down to the set of canonical
-// strings. Used by --baseline mode to identify "what already exists" so
-// new records can be tagged as candidates. The set is keyed on the
-// canonical text — same key exact_buckets buckets on — so two functions
-// with identical canonicals collapse to one entry, matching the
-// exact-cluster equivalence relation.
-def public load_baseline_canonicals(path : string; var canonicals : table<string; void?>;
+// Stable member identity used to compare a freshly-extracted record
+// against a baseline. Same shape as cluster.das `member_key`, copied
+// here to avoid a require cycle (exchange already needs to know about
+// records but not about clustering helpers).
+def member_id(file : string; line : int; name : string) : string {
+    return "{file}:{line}:{name}"
+}
+
+
+// Read an exported envelope and project it down to two sets:
+//   * `canonicals`  — set of canonical texts (used by --baseline-strict
+//     to drop clusters whose canonical already existed in baseline).
+//   * `members`     — set of `file:line:name` identities (used by default
+//     baseline mode to tag records that DIDN'T exist in baseline as
+//     candidates). Member-level keying catches "growth" — a new copy of
+//     an already-tracked canonical added in a new location — which a
+//     pure canonical-set diff would miss (the canonical is in baseline,
+//     so the new member would never be flagged).
+//
+// Trade-off of `file:line:name`: an unrelated edit that shifts line
+// numbers will look like "new members" and surface those clusters in
+// the report. Acceptable for CI gating — re-checking touched code is
+// the right default; the user can ignore false positives the same way
+// they would for any line-based diff tool.
+def public load_baseline_canonicals(path : string;
+                                    var canonicals : table<string; void?>;
+                                    var members : table<string; void?>;
                                     var error : string&) : bool {
     let text = fread(path)
     if (empty(text)) {
@@ -119,6 +139,10 @@ def public load_baseline_canonicals(path : string; var canonicals : table<string
         }
         if (!key_exists(canonicals, ef.canonical)) {
             canonicals |> insert(ef.canonical, null)
+        }
+        let mid = member_id(ef.file, ef.line, ef.name)
+        if (!key_exists(members, mid)) {
+            members |> insert(mid, null)
         }
     }
     return true

--- a/utils/find_dupes/exchange.das
+++ b/utils/find_dupes/exchange.das
@@ -91,6 +91,40 @@ def is_well_formed(ef : ExportedFunction) : bool {
 }
 
 
+// Read an exported envelope and project it down to the set of canonical
+// strings. Used by --baseline mode to identify "what already exists" so
+// new records can be tagged as candidates. The set is keyed on the
+// canonical text — same key exact_buckets buckets on — so two functions
+// with identical canonicals collapse to one entry, matching the
+// exact-cluster equivalence relation.
+def public load_baseline_canonicals(path : string; var canonicals : table<string; void?>;
+                                    var error : string&) : bool {
+    let text = fread(path)
+    if (empty(text)) {
+        error := "could not read baseline file (empty or missing): {path}"
+        return false
+    }
+    var env = ExportEnvelope()
+    if (!sscan_json(text, env)) {
+        error := "could not parse baseline JSON: {path}"
+        return false
+    }
+    if (env.schema_version != EXCHANGE_SCHEMA_VERSION) {
+        error := "unsupported baseline schema_version {env.schema_version} (expected {EXCHANGE_SCHEMA_VERSION}): {path}"
+        return false
+    }
+    for (ef in env.functions) {
+        if (empty(ef.canonical)) {
+            continue
+        }
+        if (!key_exists(canonicals, ef.canonical)) {
+            canonicals |> insert(ef.canonical, null)
+        }
+    }
+    return true
+}
+
+
 def public read_import(path : string; var records : array<FuncRecord>;
                        want_sigs : bool; min_tokens : int;
                        var error : string&) : bool {

--- a/utils/find_dupes/main.das
+++ b/utils/find_dupes/main.das
@@ -54,6 +54,24 @@ struct Config {
     @clarg_doc = "Load functions from a JSON file (produced by --export-functions) instead of compiling"
     import_functions : string
 
+    @clarg_doc = "Path to baseline JSON (an --export-functions output) — B1 mode: tag records whose canonical is not in the baseline as candidates"
+    baseline : string
+
+    @clarg_doc = "Strict baseline: also drop clusters whose canonical exists in the baseline (only fully-new clusters survive)"
+    baseline_strict : bool
+
+    @clarg_doc = "B2 mode candidate path(s) — file or directory; functions extracted from these are tagged as candidates and the report is filtered to those involving them. Repeatable."
+    against : array<string>
+
+    @clarg_doc = "Read newline-delimited candidate paths from stdin (B2 mode, complements --against)"
+    against_from_stdin : bool
+
+    @clarg_doc = "Exit with non-zero code when the post-filter report contains any clusters or pairs (CI gate)"
+    check : bool
+
+    @clarg_doc = "Force the flat clusters/pairs writer even when --against is active (default in --against mode is the per-candidate writer)"
+    flat : bool
+
     @clarg_short = "?"
     @clarg_name = "show-help"
     @clarg_doc = "Show this help and exit"
@@ -143,6 +161,95 @@ def scan_das_files(path : string; var files : array<string>; var cache : table<s
 }
 
 
+// Read newline-delimited paths from stdin. Used by --against-from-stdin
+// to plug into shell pipelines: `git diff --name-only master |
+// daslang utils/find_dupes/main.das -- --against-from-stdin
+// --import-functions corpus.json`. Skips blank lines.
+def read_stdin_paths(var paths : array<string>) {
+    let f = fstdin()
+    if (f == null) {
+        return
+    }
+    while (!feof(f)) {
+        let line = fgets(f) |> strip
+        if (!empty(line)) {
+            paths |> push(line)
+        }
+    }
+}
+
+
+// Expand each `--against` argument (file or directory) into a normalized
+// set of `.das` file paths. Reuses scan_das_files so the same skip
+// rules (`builtin.das`, debugger/profiler) apply.
+def resolve_against_files(against : array<string>; from_stdin : bool;
+                          var out_set : table<string; void?>) {
+    var raw : array<string>
+    for (p in against) {
+        raw |> push(p)
+    }
+    if (from_stdin) {
+        read_stdin_paths(raw)
+    }
+    var cache : table<string; void?>
+    var files : array<string>
+    for (p in raw) {
+        scan_das_files(p, files, cache)
+    }
+    for (f in files) {
+        let n = normalize_path(f)
+        if (!key_exists(out_set, n)) {
+            out_set |> insert(n, null)
+        }
+    }
+}
+
+
+// Mark in-place: any record whose file is in `against_files` becomes a
+// candidate. Idempotent; safe to call after compile or after import.
+def mark_records_as_candidates(var records : array<FuncRecord>;
+                               against_files : table<string; void?>) {
+    for (r in records) {
+        if (key_exists(against_files, normalize_path(r.ref.file))) {
+            r.is_candidate = true
+        }
+    }
+}
+
+
+// Walk records and tag any whose canonical is NOT in the baseline as a
+// candidate. Additive — does not clear existing candidate flags from
+// --against.
+def tag_baseline_new_canonicals(var records : array<FuncRecord>;
+                                baseline_canonicals : table<string; void?>) {
+    for (r in records) {
+        if (r.is_candidate) {
+            continue
+        }
+        if (!key_exists(baseline_canonicals, r.canonical)) {
+            r.is_candidate = true
+        }
+    }
+}
+
+
+// In strict baseline mode, drop clusters whose canonical existed in the
+// baseline (we only want fully-new clusters, not growth on existing
+// ones). Pairs are unaffected: they have no per-pair baseline equivalent.
+def strict_drop_baseline_clusters(var clusters : array<Cluster>;
+                                  baseline_canonicals : table<string; void?>) {
+    var kept : array<Cluster>
+    kept |> reserve(length(clusters))
+    for (c in clusters) {
+        if (key_exists(baseline_canonicals, c.canonical_sample)) {
+            continue
+        }
+        kept |> push_clone(c)
+    }
+    clusters <- kept
+}
+
+
 [export]
 def main() {
     var cfg = Config()
@@ -158,6 +265,8 @@ def main() {
     }
     let importing = !empty(cfg.import_functions)
     let exporting = !empty(cfg.export_functions)
+    let has_against = length(cfg.against) > 0 || cfg.against_from_stdin
+    let has_baseline = !empty(cfg.baseline)
     if (importing && length(cfg.path) > 0) {
         print("error: --import-functions and --path are mutually exclusive\n")
         return
@@ -166,8 +275,16 @@ def main() {
         print("error: --import-functions and --export-functions are mutually exclusive (transcode is a no-op)\n")
         return
     }
-    if (!importing && length(cfg.path) == 0) {
-        print("error: at least one --path is required (or pass --import-functions)\n\n")
+    if (exporting && (has_against || has_baseline)) {
+        print("error: --export-functions is incompatible with --against / --baseline (export captures the raw corpus, not a filtered view)\n")
+        return
+    }
+    if (cfg.baseline_strict && !has_baseline) {
+        print("error: --baseline-strict requires --baseline\n")
+        return
+    }
+    if (!importing && !has_against && length(cfg.path) == 0) {
+        print("error: at least one --path is required (or pass --import-functions, or --against)\n\n")
         print_help(get_command_info(type<Config>), "find_dupes")
         return
     }
@@ -195,8 +312,20 @@ def main() {
     // shard runs.
     let want_sigs = !cfg.no_fuzzy && !exporting
 
+    // Resolve --against paths first (B2 mode) so we can drop overridden
+    // corpus records and tag candidates as we go.
+    var against_files : table<string; void?>
+    if (has_against) {
+        resolve_against_files(cfg.against, cfg.against_from_stdin, against_files)
+        if (length(against_files) == 0) {
+            print("error: --against (or stdin) yielded no .das files\n")
+            return
+        }
+    }
+
     var records : array<FuncRecord>
     var files_scanned = 0
+    var seen_loc : table<string; void?>
 
     if (importing) {
         var ierr : string
@@ -205,19 +334,26 @@ def main() {
             return
         }
         print("loaded {length(records)} function record(s) from {cfg.import_functions}\n")
+        if (has_against) {
+            let dropped = drop_records_under_files(records, against_files)
+            if (dropped > 0) {
+                print("dropped {dropped} corpus record(s) overridden by --against paths\n")
+            }
+        }
     } else {
         var files : array<string>
         var cache : table<string; void?>
         for (p in cfg.path) {
             scan_das_files(p, files, cache)
         }
-        if (length(files) == 0) {
+        if (length(files) == 0 && !has_against) {
             print("error: no .das files found under given paths\n")
             return
         }
-        print("scanning {length(files)} file(s)...\n")
+        if (length(files) > 0) {
+            print("scanning {length(files)} file(s)...\n")
+        }
 
-        var seen_loc : table<string; void?>
         var n_failed = 0
         var n_skipped = 0
         for (i in range(length(files))) {
@@ -259,13 +395,76 @@ def main() {
         }
     }
 
+    // B2 wiring: tag any already-extracted records whose file is in the
+    // candidate set (covers `-p` overlap), then compile any candidate
+    // files not yet seen and tag those too.
+    if (has_against) {
+        mark_records_as_candidates(records, against_files)
+        var n_against_failed = 0
+        var n_against_skipped = 0
+        var n_against_compiled = 0
+        for (af in keys(against_files)) {
+            // Skip files already extracted (either via `-p` or, post-drop,
+            // we already removed any that came from the corpus). Re-scan
+            // current records to detect coverage.
+            var already_have = false
+            for (r in records) {
+                if (normalize_path(r.ref.file) == af) {
+                    already_have = true
+                    break
+                }
+            }
+            if (already_have) {
+                continue
+            }
+            if (has_expect_directive(af)) {
+                n_against_skipped++
+                continue
+            }
+            let before = length(records)
+            if (!compile_and_collect(af, records, seen_loc, cfg.verbose, cfg.lambdas_only, want_sigs, min_tokens)) {
+                n_against_failed++
+                continue
+            }
+            // Tag the freshly-pushed records as candidates.
+            for (i in range(before, length(records))) {
+                records[i].is_candidate = true
+            }
+            n_against_compiled++
+        }
+        if (n_against_compiled > 0 || n_against_failed > 0 || n_against_skipped > 0) {
+            print("--against: compiled {n_against_compiled}, failed {n_against_failed}, skipped {n_against_skipped}\n")
+        }
+    }
+
+    // B1 wiring: tag records whose canonical isn't in the baseline.
+    var baseline_canonicals : table<string; void?>
+    if (has_baseline) {
+        var berr : string
+        if (!load_baseline_canonicals(cfg.baseline, baseline_canonicals, berr)) {
+            print("error: {berr}\n")
+            return
+        }
+        print("loaded {length(baseline_canonicals)} baseline canonical(s) from {cfg.baseline}\n")
+        tag_baseline_new_canonicals(records, baseline_canonicals)
+    }
+
+    let filter_candidates = has_against || has_baseline
     print("clustering exact matches...\n")
-    var clusters <- exact_buckets(records, min_tokens)
+    var clusters <- exact_buckets(records, min_tokens, filter_candidates)
+    if (cfg.baseline_strict) {
+        let before_strict = length(clusters)
+        strict_drop_baseline_clusters(clusters, baseline_canonicals)
+        let dropped_strict = before_strict - length(clusters)
+        if (dropped_strict > 0) {
+            print("--baseline-strict: dropped {dropped_strict} cluster(s) whose canonical was already in baseline\n")
+        }
+    }
     sort_clusters(clusters)
     var pairs : array<FuzzyPair>
     if (!cfg.no_fuzzy) {
         print("scanning {length(records)} records for fuzzy near-duplicates (threshold {threshold})...\n")
-        pairs <- fuzzy_pairs(records, threshold, min_tokens)
+        pairs <- fuzzy_pairs(records, threshold, min_tokens, filter_candidates)
         sort_pairs(pairs)
     }
 
@@ -279,12 +478,43 @@ def main() {
     rep.summary.exact_clusters = length(rep.exact_clusters)
     rep.summary.fuzzy_pairs = length(rep.fuzzy_pairs)
 
-    print_summary(rep, top)
+    let use_per_candidate = has_against && !cfg.flat
+    if (use_per_candidate) {
+        let cand_refs <- collect_candidate_refs(records)
+        // Default to a tighter top in per-candidate mode (matches what the
+        // MCP tool exposes); user can still override with --top.
+        let per_top = cfg.top == 20 ? 5 : cfg.top
+        print_per_candidate_summary(rep, cand_refs, per_top)
+    } else {
+        print_summary(rep, top)
+    }
     if (!empty(cfg.json)) {
-        if (write_json_report(rep, cfg.json)) {
+        var json_ok = false
+        if (use_per_candidate) {
+            let cand_refs <- collect_candidate_refs(records)
+            let per_top = cfg.top == 20 ? 5 : cfg.top
+            let body = write_per_candidate_report(rep, cand_refs, per_top)
+            fopen(cfg.json, "wb") $(fw) {
+                if (fw == null) {
+                    return
+                }
+                json_ok = true
+                fw |> fprint(body)
+            }
+        } else {
+            json_ok = write_json_report(rep, cfg.json)
+        }
+        if (json_ok) {
             print("\nJSON report written to {cfg.json}\n")
         } else {
             print("\nERROR: could not write JSON report to {cfg.json}\n")
         }
+    }
+
+    if (cfg.check && (length(rep.exact_clusters) > 0 || length(rep.fuzzy_pairs) > 0)) {
+        // --check turns the post-filter report into a CI gate. Use
+        // `panic` to surface a non-zero exit code (same pattern as the
+        // export-failure path above).
+        panic("find_dupes --check failed: {length(rep.exact_clusters)} cluster(s), {length(rep.fuzzy_pairs)} pair(s)")
     }
 }

--- a/utils/find_dupes/main.das
+++ b/utils/find_dupes/main.das
@@ -185,6 +185,7 @@ def read_stdin_paths(var paths : array<string>) {
 def resolve_against_files(against : array<string>; from_stdin : bool;
                           var out_set : table<string; void?>) {
     var raw : array<string>
+    raw |> reserve(length(against))
     for (p in against) {
         raw |> push(p)
     }
@@ -403,7 +404,16 @@ def main() {
         var n_against_failed = 0
         var n_against_skipped = 0
         var n_against_compiled = 0
-        for (af in keys(against_files)) {
+        // Sort the candidate file list so compile-and-report order is
+        // deterministic across runs — `keys(table)` iteration order is
+        // unspecified, which would make the per-candidate output (and the
+        // exit-code-driven CI behavior of `--check`) non-reproducible.
+        var against_files_sorted : array<string>
+        for (k in keys(against_files)) {
+            against_files_sorted |> push(k)
+        }
+        sort(against_files_sorted)
+        for (af in against_files_sorted) {
             // Skip files already extracted (either via `-p` or, post-drop,
             // we already removed any that came from the corpus). Re-scan
             // current records to detect coverage.

--- a/utils/find_dupes/main.das
+++ b/utils/find_dupes/main.das
@@ -54,7 +54,7 @@ struct Config {
     @clarg_doc = "Load functions from a JSON file (produced by --export-functions) instead of compiling"
     import_functions : string
 
-    @clarg_doc = "Path to baseline JSON (an --export-functions output) — B1 mode: tag records whose canonical is not in the baseline as candidates"
+    @clarg_doc = "Path to baseline JSON (an --export-functions output) — B1 mode: tag records whose member identity (file:line:name) is not in the baseline as candidates"
     baseline : string
 
     @clarg_doc = "Strict baseline: also drop clusters whose canonical exists in the baseline (only fully-new clusters survive)"
@@ -231,7 +231,10 @@ def tag_baseline_new_members(var records : array<FuncRecord>;
         if (r.is_candidate) {
             continue
         }
-        let mid = "{r.ref.file}:{r.ref.line}:{r.ref.name}"
+        // Path-normalize so a Windows-recorded baseline (`a\b.das`) and a
+        // Unix-runner record (`a/b.das`) collide instead of mass-tagging
+        // every file as new.
+        let mid = "{normalize_path(r.ref.file)}:{r.ref.line}:{r.ref.name}"
         if (!key_exists(baseline_members, mid)) {
             r.is_candidate = true
         }

--- a/utils/find_dupes/main.das
+++ b/utils/find_dupes/main.das
@@ -218,16 +218,21 @@ def mark_records_as_candidates(var records : array<FuncRecord>;
 }
 
 
-// Walk records and tag any whose canonical is NOT in the baseline as a
-// candidate. Additive — does not clear existing candidate flags from
-// --against.
-def tag_baseline_new_canonicals(var records : array<FuncRecord>;
-                                baseline_canonicals : table<string; void?>) {
+// Walk records and tag any whose member identity (file:line:name) is
+// NOT in the baseline as a candidate. Member-level rather than
+// canonical-level so "growth" is caught: a new copy of an
+// already-tracked canonical at a new location surfaces as a candidate
+// (and the cluster containing it survives the filter), while unchanged
+// records stay invisible. Additive — does not clear existing candidate
+// flags from --against.
+def tag_baseline_new_members(var records : array<FuncRecord>;
+                             baseline_members : table<string; void?>) {
     for (r in records) {
         if (r.is_candidate) {
             continue
         }
-        if (!key_exists(baseline_canonicals, r.canonical)) {
+        let mid = "{r.ref.file}:{r.ref.line}:{r.ref.name}"
+        if (!key_exists(baseline_members, mid)) {
             r.is_candidate = true
         }
     }
@@ -447,16 +452,21 @@ def main() {
         }
     }
 
-    // B1 wiring: tag records whose canonical isn't in the baseline.
+    // B1 wiring: tag records whose member identity (file:line:name)
+    // isn't in the baseline. The canonical set is also loaded for
+    // --baseline-strict, which post-filters clusters whose canonical
+    // already existed in baseline (so only "brand-new canonical"
+    // clusters survive, not "existing canonical, new member" growth).
     var baseline_canonicals : table<string; void?>
+    var baseline_members : table<string; void?>
     if (has_baseline) {
         var berr : string
-        if (!load_baseline_canonicals(cfg.baseline, baseline_canonicals, berr)) {
+        if (!load_baseline_canonicals(cfg.baseline, baseline_canonicals, baseline_members, berr)) {
             print("error: {berr}\n")
             return
         }
-        print("loaded {length(baseline_canonicals)} baseline canonical(s) from {cfg.baseline}\n")
-        tag_baseline_new_canonicals(records, baseline_canonicals)
+        print("loaded {length(baseline_canonicals)} baseline canonical(s), {length(baseline_members)} member(s) from {cfg.baseline}\n")
+        tag_baseline_new_members(records, baseline_members)
     }
 
     let filter_candidates = has_against || has_baseline
@@ -491,10 +501,11 @@ def main() {
     let use_per_candidate = has_against && !cfg.flat
     if (use_per_candidate) {
         let cand_refs <- collect_candidate_refs(records)
-        // Default to a tighter top in per-candidate mode (matches what the
-        // MCP tool exposes); user can still override with --top.
-        let per_top = cfg.top == 20 ? 5 : cfg.top
-        print_per_candidate_summary(rep, cand_refs, per_top)
+        // `top` applies to both writers — same flag, no implicit
+        // mode-dependent default. Per-candidate mode used to halve the
+        // value behind the user's back, but that misfired when the user
+        // explicitly passed `--top 20` and silently downgraded it to 5.
+        print_per_candidate_summary(rep, cand_refs, top)
     } else {
         print_summary(rep, top)
     }
@@ -502,8 +513,7 @@ def main() {
         var json_ok = false
         if (use_per_candidate) {
             let cand_refs <- collect_candidate_refs(records)
-            let per_top = cfg.top == 20 ? 5 : cfg.top
-            let body = write_per_candidate_report(rep, cand_refs, per_top)
+            let body = write_per_candidate_report(rep, cand_refs, top)
             fopen(cfg.json, "wb") $(fw) {
                 if (fw == null) {
                     return

--- a/utils/find_dupes/pipeline.das
+++ b/utils/find_dupes/pipeline.das
@@ -75,6 +75,41 @@ def public collect_from_program(program : ProgramPtr; source_file : string; var 
 }
 
 
+// Drop records whose `file` matches any path in `against_files` (paths
+// must already be normalized via `normalize_path`). Used after loading
+// a corpus when --against / candidate-mode is active, to override "the
+// old version of this file" with the freshly-compiled one. Returns the
+// count of dropped records.
+def public drop_records_under_files(var records : array<FuncRecord>;
+                                    against_files : table<string; void?>) : int {
+    var kept : array<FuncRecord>
+    kept |> reserve(length(records))
+    var dropped = 0
+    for (r in records) {
+        if (key_exists(against_files, normalize_path(r.ref.file))) {
+            dropped++
+            continue
+        }
+        kept |> push_clone(r)
+    }
+    records <- kept
+    return dropped
+}
+
+
+// Collect MemberRefs of all candidate records — used to feed the
+// per-candidate report writer.
+def public collect_candidate_refs(records : array<FuncRecord>) : array<MemberRef> {
+    var out : array<MemberRef>
+    for (r in records) {
+        if (r.is_candidate) {
+            out |> push(r.ref)
+        }
+    }
+    return <- out
+}
+
+
 def public compile_and_collect(file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; verbose : bool; lambdas_only : bool; want_sigs : bool; min_tokens : int) : bool {
     var inscope access <- make_file_access("")
     var ok_compile = true

--- a/utils/find_dupes/pipeline.das
+++ b/utils/find_dupes/pipeline.das
@@ -8,9 +8,9 @@ require cluster
 require exchange
 
 
-def public normalize_path(p : string) : string {
-    return p |> replace("\\", "/")
-}
+// `normalize_path` lives in exchange.das — pulled in via `require exchange`
+// above so callers in this file (and downstream of `require pipeline`) keep
+// working unchanged.
 
 
 // Walk one compiled program and append a FuncRecord per user

--- a/utils/find_dupes/pipeline.das
+++ b/utils/find_dupes/pipeline.das
@@ -110,8 +110,21 @@ def public collect_candidate_refs(records : array<FuncRecord>) : array<MemberRef
 }
 
 
-def public compile_and_collect(file : string; var records : array<FuncRecord>; var seen_loc : table<string; void?>; verbose : bool; lambdas_only : bool; want_sigs : bool; min_tokens : int) : bool {
-    var inscope access <- make_file_access("")
+// `quiet=true` suppresses the "FAIL {file}" stdout print — required when
+// called from the MCP server (stdio transport reserves stdout for
+// JSON-RPC). The boolean return value is the caller's signal anyway. CLI
+// keeps the print for human visibility.
+//
+// `project` lets callers point at a `.das_project` for custom module
+// resolution, mirroring other compilation-based MCP tools. Empty string
+// preserves the original "no project" behavior.
+def public compile_and_collect(file : string; var records : array<FuncRecord>;
+                               var seen_loc : table<string; void?>;
+                               verbose : bool; lambdas_only : bool;
+                               want_sigs : bool; min_tokens : int;
+                               quiet : bool = false;
+                               project : string = "") : bool {
+    var inscope access <- make_file_access(project)
     var ok_compile = true
     using() $(var mg : ModuleGroup) {
         using() $(var cop : CodeOfPolicies) {
@@ -123,10 +136,12 @@ def public compile_and_collect(file : string; var records : array<FuncRecord>; v
             compile_file(file, access, unsafe(addr(mg)), cop) $(ok; program; issues) {
                 if (!ok) {
                     ok_compile = false
-                    if (verbose) {
-                        print("FAIL {file}\n  {issues}\n")
-                    } else {
-                        print("FAIL {file}\n")
+                    if (!quiet) {
+                        if (verbose) {
+                            print("FAIL {file}\n  {issues}\n")
+                        } else {
+                            print("FAIL {file}\n")
+                        }
                     }
                     return
                 }

--- a/utils/find_dupes/report.das
+++ b/utils/find_dupes/report.das
@@ -84,11 +84,6 @@ struct public PerCandidateReport {
 }
 
 
-def member_id(m : MemberRef) : string {
-    return "{m.file}:{m.line}:{m.name}"
-}
-
-
 def make_match(m : MemberRef; similarity : float) : CandidateMatch {
     var cm = CandidateMatch()
     cm.name := m.name
@@ -110,7 +105,7 @@ def public build_per_candidate_report(report : Report;
                                       top_per_candidate : int) : PerCandidateReport {
     var cand_keys : table<string; int>
     for (i in range(length(candidate_refs))) {
-        let k = member_id(candidate_refs[i])
+        let k = member_key(candidate_refs[i])
         if (!key_exists(cand_keys, k)) {
             cand_keys |> insert(k, i)
         }
@@ -130,13 +125,13 @@ def public build_per_candidate_report(report : Report;
     // to multiple clusters across a multi-file rebuild — be permissive.
     for (c in report.exact_clusters) {
         for (m in c.members) {
-            let k = member_id(m)
+            let k = member_key(m)
             if (!key_exists(cand_keys, k)) {
                 continue
             }
             let idx = cand_keys[k]
             for (other in c.members) {
-                if (member_id(other) == k) {
+                if (member_key(other) == k) {
                     continue
                 }
                 rollups[idx].exact_matches |> emplace(make_match(other, 1.0f))
@@ -147,8 +142,8 @@ def public build_per_candidate_report(report : Report;
     // When BOTH endpoints are candidates, each side gets the other in
     // its rollup — the pair is symmetric, the rollup is per-candidate.
     for (p in report.fuzzy_pairs) {
-        let ka = member_id(p.a)
-        let kb = member_id(p.b)
+        let ka = member_key(p.a)
+        let kb = member_key(p.b)
         let a_is_cand = key_exists(cand_keys, ka)
         let b_is_cand = key_exists(cand_keys, kb)
         if (a_is_cand) {

--- a/utils/find_dupes/report.das
+++ b/utils/find_dupes/report.das
@@ -51,6 +51,177 @@ def member_label(m : MemberRef) : string {
 }
 
 
+// Per-candidate JSON shape: "for each function in the focus set, here
+// are the existing functions it resembles." Used by --against mode and
+// the find_duplicates MCP tool — both want the result keyed on the
+// user's mental model ("what should I look at for *this* function I
+// just wrote") rather than the flat clusters/pairs view.
+
+struct public CandidateMatch {
+    name : string
+    file : string
+    line : int
+    is_lambda : bool
+    // 1.0 for exact-cluster siblings, < 1.0 (the geometric-mean score)
+    // for fuzzy matches. Using one struct for both keeps the JSON shape
+    // uniform.
+    similarity : float = 0.0f
+}
+
+
+struct public CandidateRollup {
+    name : string
+    file : string
+    line : int
+    is_lambda : bool
+    exact_matches : array<CandidateMatch>
+    fuzzy_matches : array<CandidateMatch>
+}
+
+
+struct public PerCandidateReport {
+    candidates : array<CandidateRollup>
+}
+
+
+def member_id(m : MemberRef) : string {
+    return "{m.file}:{m.line}:{m.name}"
+}
+
+
+def make_match(m : MemberRef; similarity : float) : CandidateMatch {
+    var cm = CandidateMatch()
+    cm.name := m.name
+    cm.file := m.file
+    cm.line = m.line
+    cm.is_lambda = m.is_lambda
+    cm.similarity = similarity
+    return <- cm
+}
+
+
+// Build the per-candidate pivot. `candidate_refs` is the caller's list
+// of focus-set members (typically `[r.ref for r in records if
+// r.is_candidate]`). The rollup includes one entry per candidate even
+// when it has no matches — useful for the MCP consumer that wants to
+// confirm "I checked these N functions and found nothing."
+def public build_per_candidate_report(report : Report;
+                                      candidate_refs : array<MemberRef>;
+                                      top_per_candidate : int) : PerCandidateReport {
+    var cand_keys : table<string; int>
+    for (i in range(length(candidate_refs))) {
+        let k = member_id(candidate_refs[i])
+        if (!key_exists(cand_keys, k)) {
+            cand_keys |> insert(k, i)
+        }
+    }
+    var rollups : array<CandidateRollup>
+    rollups |> reserve(length(candidate_refs))
+    for (cref in candidate_refs) {
+        var r = CandidateRollup()
+        r.name := cref.name
+        r.file := cref.file
+        r.line = cref.line
+        r.is_lambda = cref.is_lambda
+        rollups |> emplace(r)
+    }
+    // Exact siblings: walk every cluster the candidate belongs to,
+    // collecting the OTHER members. A candidate could in theory belong
+    // to multiple clusters across a multi-file rebuild — be permissive.
+    for (c in report.exact_clusters) {
+        for (m in c.members) {
+            let k = member_id(m)
+            if (!key_exists(cand_keys, k)) {
+                continue
+            }
+            let idx = cand_keys[k]
+            for (other in c.members) {
+                if (member_id(other) == k) {
+                    continue
+                }
+                rollups[idx].exact_matches |> emplace(make_match(other, 1.0f))
+            }
+        }
+    }
+    // Fuzzy partners: pairs where either endpoint matches a candidate.
+    // When BOTH endpoints are candidates, each side gets the other in
+    // its rollup — the pair is symmetric, the rollup is per-candidate.
+    for (p in report.fuzzy_pairs) {
+        let ka = member_id(p.a)
+        let kb = member_id(p.b)
+        let a_is_cand = key_exists(cand_keys, ka)
+        let b_is_cand = key_exists(cand_keys, kb)
+        if (a_is_cand) {
+            rollups[cand_keys[ka]].fuzzy_matches |> emplace(make_match(p.b, p.similarity))
+        }
+        if (b_is_cand) {
+            rollups[cand_keys[kb]].fuzzy_matches |> emplace(make_match(p.a, p.similarity))
+        }
+    }
+    // Trim to top_per_candidate (fuzzy_matches were inserted in
+    // sort_pairs order so they're already similarity-DESC; exact_matches
+    // are append-order, fine for stable diffs since clusters are sorted).
+    if (top_per_candidate >= 0) {
+        for (r in rollups) {
+            if (length(r.exact_matches) > top_per_candidate) {
+                unsafe(resize(r.exact_matches, top_per_candidate))
+            }
+            if (length(r.fuzzy_matches) > top_per_candidate) {
+                unsafe(resize(r.fuzzy_matches, top_per_candidate))
+            }
+        }
+    }
+    var out = PerCandidateReport()
+    out.candidates <- rollups
+    return <- out
+}
+
+
+def public write_per_candidate_report(report : Report;
+                                      candidate_refs : array<MemberRef>;
+                                      top_per_candidate : int) : string {
+    let pcr = build_per_candidate_report(report, candidate_refs, top_per_candidate)
+    return sprint_json(pcr, true)
+}
+
+
+def public print_per_candidate_summary(report : Report;
+                                       candidate_refs : array<MemberRef>;
+                                       top_per_candidate : int) {
+    let pcr = build_per_candidate_report(report, candidate_refs, top_per_candidate)
+    print("\n=== find_dupes per-candidate report ===\n")
+    print("candidates scanned: {length(pcr.candidates)}\n")
+    var n_with_hits = 0
+    for (r in pcr.candidates) {
+        if (length(r.exact_matches) > 0 || length(r.fuzzy_matches) > 0) {
+            n_with_hits++
+        }
+    }
+    print("candidates with matches: {n_with_hits}\n")
+    for (r in pcr.candidates) {
+        if (length(r.exact_matches) == 0 && length(r.fuzzy_matches) == 0) {
+            continue
+        }
+        let header = r.is_lambda ? "<lambda> ({r.name})" : r.name
+        print("\n* {r.file}:{r.line}  {header}\n")
+        if (length(r.exact_matches) > 0) {
+            print("  exact:\n")
+            for (m in r.exact_matches) {
+                let mhdr = m.is_lambda ? "<lambda> ({m.name})" : m.name
+                print("    - {m.file}:{m.line}  {mhdr}\n")
+            }
+        }
+        if (length(r.fuzzy_matches) > 0) {
+            print("  fuzzy:\n")
+            for (m in r.fuzzy_matches) {
+                let mhdr = m.is_lambda ? "<lambda> ({m.name})" : m.name
+                print("    - {m.similarity}  {m.file}:{m.line}  {mhdr}\n")
+            }
+        }
+    }
+}
+
+
 def public print_summary(report : Report; top : int) {
     print("\n=== find_dupes summary ===\n")
     print("files scanned     : {report.summary.files_scanned}\n")

--- a/utils/find_dupes/test_find_dupes.das
+++ b/utils/find_dupes/test_find_dupes.das
@@ -884,13 +884,20 @@ def test_baseline_load_canonical_set(t : T?) {
     write_export(records, path)
 
     var canonicals : table<string; void?>
+    var members : table<string; void?>
     var err : string
-    let ok = load_baseline_canonicals(path, canonicals, err)
+    let ok = load_baseline_canonicals(path, canonicals, members, err)
     t |> success(ok, "load_baseline_canonicals returned true; err={err}")
     // Two distinct canonicals — duplicates collapse, matching exact-cluster equivalence.
     t |> equal(length(canonicals), 2)
     t |> success(key_exists(canonicals, "FN AAA ENDFN"), "AAA in set")
     t |> success(key_exists(canonicals, "FN BBB ENDFN"), "BBB in set")
+    // Three members — `c` is a separate identity from `a` even though
+    // they share a canonical (member-level diff catches growth).
+    t |> equal(length(members), 3)
+    t |> success(key_exists(members, "test.das:1:a"), "a member-id present")
+    t |> success(key_exists(members, "test.das:2:b"), "b member-id present")
+    t |> success(key_exists(members, "test.das:3:c"), "c member-id present (the growth case)")
     remove(path)
 }
 
@@ -908,8 +915,9 @@ def test_baseline_load_rejects_bad_schema(t : T?) {
         }
     }
     var canonicals : table<string; void?>
+    var members : table<string; void?>
     var err : string
-    let ok = load_baseline_canonicals(path, canonicals, err)
+    let ok = load_baseline_canonicals(path, canonicals, members, err)
     t |> success(!ok, "load_baseline_canonicals rejects bad schema_version")
     t |> success(find(err, "schema_version") >= 0, "error mentions schema_version: {err}")
     remove(path)

--- a/utils/find_dupes/test_find_dupes.das
+++ b/utils/find_dupes/test_find_dupes.das
@@ -801,15 +801,15 @@ def test_candidate_filter_drops_pure_corpus_clusters(t : T?) {
     // Three identical records, none flagged as candidate. With the
     // filter active, the cluster should be dropped (no candidate
     // member). Without the filter, the cluster would be kept.
-    var records : array<FuncRecord>
-    records |> emplace <| make_record("a", "FN A B C D E F G H ENDFN", 1, false)
-    records |> emplace <| make_record("b", "FN A B C D E F G H ENDFN", 2, false)
-    records |> emplace <| make_record("c", "FN A B C D E F G H ENDFN", 3, false)
+    var records : array<FuncRecord> <- [
+        <- make_record("a", "FN A B C D E F G H ENDFN", 1, false),
+        <- make_record("b", "FN A B C D E F G H ENDFN", 2, false),
+        <- make_record("c", "FN A B C D E F G H ENDFN", 3, false)]
 
-    var legacy_clusters <- exact_buckets(records, 0)
+    let legacy_clusters <- exact_buckets(records, 0)
     t |> equal(length(legacy_clusters), 1)
 
-    var filtered <- exact_buckets(records, 0, true)
+    let filtered <- exact_buckets(records, 0, true)
     t |> equal(length(filtered), 0)
 }
 
@@ -819,13 +819,13 @@ def test_candidate_filter_keeps_mixed_clusters(t : T?) {
     // Same canonical, but one record is flagged. Cluster kept; all
     // three members reported (the filter is at the cluster level, not
     // member level).
-    var records : array<FuncRecord>
-    records |> emplace <| make_record("a", "FN A B C D E F G H ENDFN", 1, false)
-    records |> emplace <| make_record("b", "FN A B C D E F G H ENDFN", 2, false)
-    records |> emplace <| make_record("c", "FN A B C D E F G H ENDFN", 3, false)
+    var records : array<FuncRecord> <- [
+        <- make_record("a", "FN A B C D E F G H ENDFN", 1, false),
+        <- make_record("b", "FN A B C D E F G H ENDFN", 2, false),
+        <- make_record("c", "FN A B C D E F G H ENDFN", 3, false)]
     records[1].is_candidate = true
 
-    var clusters <- exact_buckets(records, 0, true)
+    let clusters <- exact_buckets(records, 0, true)
     t |> equal(length(clusters), 1)
     t |> equal(length(clusters[0].members), 3)
 }
@@ -836,15 +836,13 @@ def test_candidate_filter_intra_candidate_pair(t : T?) {
     // Two near-duplicate candidates, no corpus around them. With the
     // candidate filter active the pair must still appear (intra-PR
     // duplicates are real signal).
-    var records : array<FuncRecord>
-    records |> emplace <| make_record(
-        "a", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, true)
-    records |> emplace <| make_record(
-        "b", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT ENDBLK ENDFN", 2, true)
+    var records : array<FuncRecord> <- [
+        <- make_record("a", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, true),
+        <- make_record("b", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT ENDBLK ENDFN", 2, true)]
     records[0].is_candidate = true
     records[1].is_candidate = true
 
-    var pairs <- fuzzy_pairs(records, 0.7f, 0, true)
+    let pairs <- fuzzy_pairs(records, 0.7f, 0, true)
     t |> equal(length(pairs), 1)
     // Pair ordering: lower-index record is `a`.
     t |> equal(pairs[0].a.name, "a")
@@ -858,23 +856,19 @@ def test_candidate_filter_fuzzy_skips_pure_corpus(t : T?) {
     // resembles none of them. The pure-corpus pairs must NOT appear;
     // only pairs involving the candidate are eligible (and the
     // candidate is dissimilar to all → empty result).
-    var records : array<FuncRecord>
-    records |> emplace <| make_record(
-        "x", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, true)
-    records |> emplace <| make_record(
-        "y", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT ENDBLK ENDFN", 2, true)
-    records |> emplace <| make_record(
-        "z", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT LIT ENDBLK ENDFN", 3, true)
-    // Candidate has a totally different shape — no fuzzy match expected.
-    records |> emplace <| make_record(
-        "cand", "FN ARG <var_0> TYP BODY BLK STMT FOR FOR_VAR <var_1> CALL:range LIT FOR_BODY BLK ENDBLK ENDBLK ENDFN", 4, true)
+    var records : array<FuncRecord> <- [
+        <- make_record("x", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, true),
+        <- make_record("y", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT ENDBLK ENDFN", 2, true),
+        <- make_record("z", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT LIT ENDBLK ENDFN", 3, true),
+        // Candidate has a totally different shape — no fuzzy match expected.
+        <- make_record("cand", "FN ARG <var_0> TYP BODY BLK STMT FOR FOR_VAR <var_1> CALL:range LIT FOR_BODY BLK ENDBLK ENDBLK ENDFN", 4, true)]
     records[3].is_candidate = true
 
     // Sanity: without the filter, x/y/z would produce pairs.
-    var legacy <- fuzzy_pairs(records, 0.7f, 0)
+    let legacy <- fuzzy_pairs(records, 0.7f, 0)
     t |> success(length(legacy) >= 1, "legacy mode: at least one corpus pair: got {length(legacy)}")
 
-    var filtered <- fuzzy_pairs(records, 0.7f, 0, true)
+    let filtered <- fuzzy_pairs(records, 0.7f, 0, true)
     t |> equal(length(filtered), 0)
 }
 
@@ -883,10 +877,10 @@ def test_candidate_filter_fuzzy_skips_pure_corpus(t : T?) {
 def test_baseline_load_canonical_set(t : T?) {
     let path = make_temp_export_path(t)
     if (empty(path)) return
-    var records : array<FuncRecord>
-    records |> emplace <| make_record("a", "FN AAA ENDFN", 1, false)
-    records |> emplace <| make_record("b", "FN BBB ENDFN", 2, false)
-    records |> emplace <| make_record("c", "FN AAA ENDFN", 3, false) // dup canonical
+    let records : array<FuncRecord> <- [
+        <- make_record("a", "FN AAA ENDFN", 1, false),
+        <- make_record("b", "FN BBB ENDFN", 2, false),
+        <- make_record("c", "FN AAA ENDFN", 3, false)]// dup canonical
     write_export(records, path)
 
     var canonicals : table<string; void?>
@@ -926,12 +920,12 @@ def test_baseline_load_rejects_bad_schema(t : T?) {
 def test_drop_records_under_files(t : T?) {
     // Build a record set spanning two files; drop one file's records
     // and verify the other survives.
-    var records : array<FuncRecord>
-    records |> emplace <| make_record("a", "FN A ENDFN", 1, false)
+    var records : array<FuncRecord> <- [
+        <- make_record("a", "FN A ENDFN", 1, false),
+        <- make_record("b", "FN B ENDFN", 2, false),
+        <- make_record("c", "FN C ENDFN", 3, false)]
     records[0].ref.file := "src/keep.das"
-    records |> emplace <| make_record("b", "FN B ENDFN", 2, false)
     records[1].ref.file := "src/drop.das"
-    records |> emplace <| make_record("c", "FN C ENDFN", 3, false)
     records[2].ref.file := "src/drop.das"
 
     var against : table<string; void?>
@@ -949,10 +943,10 @@ def test_drop_records_under_files(t : T?) {
 def test_collect_candidate_refs(t : T?) {
     // Helper used by the per-candidate report writer and by the MCP
     // tool — verify it picks out exactly the flagged records.
-    var records : array<FuncRecord>
-    records |> emplace <| make_record("a", "FN A ENDFN", 1, false)
-    records |> emplace <| make_record("b", "FN B ENDFN", 2, false)
-    records |> emplace <| make_record("c", "FN C ENDFN", 3, false)
+    var records : array<FuncRecord> <- [
+        <- make_record("a", "FN A ENDFN", 1, false),
+        <- make_record("b", "FN B ENDFN", 2, false),
+        <- make_record("c", "FN C ENDFN", 3, false)]
     records[0].is_candidate = true
     records[2].is_candidate = true
 
@@ -967,13 +961,10 @@ def test_collect_candidate_refs(t : T?) {
 def test_per_candidate_rollup_shape(t : T?) {
     // Build a small report with one exact cluster and one fuzzy pair
     // both involving a candidate, then pivot via build_per_candidate_report.
-    var records : array<FuncRecord>
-    records |> emplace <| make_record(
-        "cand", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, true)
-    records |> emplace <| make_record(
-        "exact_sib", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 2, true)
-    records |> emplace <| make_record(
-        "fuzzy_partner", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT ENDBLK ENDFN", 3, true)
+    var records : array<FuncRecord> <- [
+        <- make_record("cand", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, true),
+        <- make_record("exact_sib", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 2, true),
+        <- make_record("fuzzy_partner", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT ENDBLK ENDFN", 3, true)]
     records[0].is_candidate = true
 
     var clusters <- exact_buckets(records, 0, true)

--- a/utils/find_dupes/test_find_dupes.das
+++ b/utils/find_dupes/test_find_dupes.das
@@ -13,6 +13,7 @@ require minhash
 require cluster
 require exchange
 require pipeline
+require report
 
 
 // ── helpers ──────────────────────────────────────────────────────────
@@ -789,4 +790,212 @@ def test_pipeline_export_import_clusters_match(t : T?) {
         t |> equal(p_compiled[i].canonical_b, p_imported[i].canonical_b)
     }
     remove(path)
+}
+
+
+// ── candidate filter (B1 baseline + B2 against modes) ────────────────
+
+
+[test]
+def test_candidate_filter_drops_pure_corpus_clusters(t : T?) {
+    // Three identical records, none flagged as candidate. With the
+    // filter active, the cluster should be dropped (no candidate
+    // member). Without the filter, the cluster would be kept.
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("a", "FN A B C D E F G H ENDFN", 1, false)
+    records |> emplace <| make_record("b", "FN A B C D E F G H ENDFN", 2, false)
+    records |> emplace <| make_record("c", "FN A B C D E F G H ENDFN", 3, false)
+
+    var legacy_clusters <- exact_buckets(records, 0)
+    t |> equal(length(legacy_clusters), 1)
+
+    var filtered <- exact_buckets(records, 0, true)
+    t |> equal(length(filtered), 0)
+}
+
+
+[test]
+def test_candidate_filter_keeps_mixed_clusters(t : T?) {
+    // Same canonical, but one record is flagged. Cluster kept; all
+    // three members reported (the filter is at the cluster level, not
+    // member level).
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("a", "FN A B C D E F G H ENDFN", 1, false)
+    records |> emplace <| make_record("b", "FN A B C D E F G H ENDFN", 2, false)
+    records |> emplace <| make_record("c", "FN A B C D E F G H ENDFN", 3, false)
+    records[1].is_candidate = true
+
+    var clusters <- exact_buckets(records, 0, true)
+    t |> equal(length(clusters), 1)
+    t |> equal(length(clusters[0].members), 3)
+}
+
+
+[test]
+def test_candidate_filter_intra_candidate_pair(t : T?) {
+    // Two near-duplicate candidates, no corpus around them. With the
+    // candidate filter active the pair must still appear (intra-PR
+    // duplicates are real signal).
+    var records : array<FuncRecord>
+    records |> emplace <| make_record(
+        "a", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, true)
+    records |> emplace <| make_record(
+        "b", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT ENDBLK ENDFN", 2, true)
+    records[0].is_candidate = true
+    records[1].is_candidate = true
+
+    var pairs <- fuzzy_pairs(records, 0.7f, 0, true)
+    t |> equal(length(pairs), 1)
+    // Pair ordering: lower-index record is `a`.
+    t |> equal(pairs[0].a.name, "a")
+    t |> equal(pairs[0].b.name, "b")
+}
+
+
+[test]
+def test_candidate_filter_fuzzy_skips_pure_corpus(t : T?) {
+    // Three near-duplicate corpus records and one candidate that
+    // resembles none of them. The pure-corpus pairs must NOT appear;
+    // only pairs involving the candidate are eligible (and the
+    // candidate is dissimilar to all → empty result).
+    var records : array<FuncRecord>
+    records |> emplace <| make_record(
+        "x", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, true)
+    records |> emplace <| make_record(
+        "y", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT ENDBLK ENDFN", 2, true)
+    records |> emplace <| make_record(
+        "z", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT LIT ENDBLK ENDFN", 3, true)
+    // Candidate has a totally different shape — no fuzzy match expected.
+    records |> emplace <| make_record(
+        "cand", "FN ARG <var_0> TYP BODY BLK STMT FOR FOR_VAR <var_1> CALL:range LIT FOR_BODY BLK ENDBLK ENDBLK ENDFN", 4, true)
+    records[3].is_candidate = true
+
+    // Sanity: without the filter, x/y/z would produce pairs.
+    var legacy <- fuzzy_pairs(records, 0.7f, 0)
+    t |> success(length(legacy) >= 1, "legacy mode: at least one corpus pair: got {length(legacy)}")
+
+    var filtered <- fuzzy_pairs(records, 0.7f, 0, true)
+    t |> equal(length(filtered), 0)
+}
+
+
+[test]
+def test_baseline_load_canonical_set(t : T?) {
+    let path = make_temp_export_path(t)
+    if (empty(path)) return
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("a", "FN AAA ENDFN", 1, false)
+    records |> emplace <| make_record("b", "FN BBB ENDFN", 2, false)
+    records |> emplace <| make_record("c", "FN AAA ENDFN", 3, false) // dup canonical
+    write_export(records, path)
+
+    var canonicals : table<string; void?>
+    var err : string
+    let ok = load_baseline_canonicals(path, canonicals, err)
+    t |> success(ok, "load_baseline_canonicals returned true; err={err}")
+    // Two distinct canonicals — duplicates collapse, matching exact-cluster equivalence.
+    t |> equal(length(canonicals), 2)
+    t |> success(key_exists(canonicals, "FN AAA ENDFN"), "AAA in set")
+    t |> success(key_exists(canonicals, "FN BBB ENDFN"), "BBB in set")
+    remove(path)
+}
+
+
+[test]
+def test_baseline_load_rejects_bad_schema(t : T?) {
+    let path = make_temp_export_path(t)
+    if (empty(path)) return
+    var bad = ExportEnvelope()
+    bad.schema_version = 99
+    let body = sprint_json(bad, false)
+    fopen(path, "wb") $(fw) {
+        if (fw != null) {
+            fw |> fprint(body)
+        }
+    }
+    var canonicals : table<string; void?>
+    var err : string
+    let ok = load_baseline_canonicals(path, canonicals, err)
+    t |> success(!ok, "load_baseline_canonicals rejects bad schema_version")
+    t |> success(find(err, "schema_version") >= 0, "error mentions schema_version: {err}")
+    remove(path)
+}
+
+
+[test]
+def test_drop_records_under_files(t : T?) {
+    // Build a record set spanning two files; drop one file's records
+    // and verify the other survives.
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("a", "FN A ENDFN", 1, false)
+    records[0].ref.file := "src/keep.das"
+    records |> emplace <| make_record("b", "FN B ENDFN", 2, false)
+    records[1].ref.file := "src/drop.das"
+    records |> emplace <| make_record("c", "FN C ENDFN", 3, false)
+    records[2].ref.file := "src/drop.das"
+
+    var against : table<string; void?>
+    against |> insert("src/drop.das", null)
+
+    let dropped = drop_records_under_files(records, against)
+    t |> equal(dropped, 2)
+    t |> equal(length(records), 1)
+    t |> equal(records[0].ref.name, "a")
+    t |> equal(records[0].ref.file, "src/keep.das")
+}
+
+
+[test]
+def test_collect_candidate_refs(t : T?) {
+    // Helper used by the per-candidate report writer and by the MCP
+    // tool — verify it picks out exactly the flagged records.
+    var records : array<FuncRecord>
+    records |> emplace <| make_record("a", "FN A ENDFN", 1, false)
+    records |> emplace <| make_record("b", "FN B ENDFN", 2, false)
+    records |> emplace <| make_record("c", "FN C ENDFN", 3, false)
+    records[0].is_candidate = true
+    records[2].is_candidate = true
+
+    let refs <- collect_candidate_refs(records)
+    t |> equal(length(refs), 2)
+    t |> equal(refs[0].name, "a")
+    t |> equal(refs[1].name, "c")
+}
+
+
+[test]
+def test_per_candidate_rollup_shape(t : T?) {
+    // Build a small report with one exact cluster and one fuzzy pair
+    // both involving a candidate, then pivot via build_per_candidate_report.
+    var records : array<FuncRecord>
+    records |> emplace <| make_record(
+        "cand", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, true)
+    records |> emplace <| make_record(
+        "exact_sib", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 2, true)
+    records |> emplace <| make_record(
+        "fuzzy_partner", "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT LIT ENDBLK ENDFN", 3, true)
+    records[0].is_candidate = true
+
+    var clusters <- exact_buckets(records, 0, true)
+    sort_clusters(clusters)
+    var pairs <- fuzzy_pairs(records, 0.6f, 0, true)
+    sort_pairs(pairs)
+
+    var rep : Report
+    rep.exact_clusters <- clusters
+    rep.fuzzy_pairs <- pairs
+
+    let cand_refs <- collect_candidate_refs(records)
+    let pcr = build_per_candidate_report(rep, cand_refs, 5)
+
+    t |> equal(length(pcr.candidates), 1)
+    t |> equal(pcr.candidates[0].name, "cand")
+    t |> equal(length(pcr.candidates[0].exact_matches), 1)
+    t |> equal(pcr.candidates[0].exact_matches[0].name, "exact_sib")
+    t |> equal(pcr.candidates[0].exact_matches[0].similarity, 1.0f)
+    t |> equal(length(pcr.candidates[0].fuzzy_matches), 1)
+    t |> equal(pcr.candidates[0].fuzzy_matches[0].name, "fuzzy_partner")
+    t |> success(pcr.candidates[0].fuzzy_matches[0].similarity > 0.6f
+        && pcr.candidates[0].fuzzy_matches[0].similarity < 1.0f,
+        "fuzzy similarity in (0.6, 1.0): {pcr.candidates[0].fuzzy_matches[0].similarity}")
 }

--- a/utils/mcp/protocol.das
+++ b/utils/mcp/protocol.das
@@ -34,6 +34,7 @@ require tools/grep_usage public
 require tools/outline public
 require tools/aot public
 require tools/lint_tool public
+require tools/find_duplicates public
 require tools/live public
 
 let HEAP_COLLECT_THRESHOLD = 1024ul * 1024ul  // 1 MB
@@ -423,6 +424,18 @@ def handle_tools_list(id_json : string) : string {
         ["file"]
     ))
     result.tools |> emplace(make_tool(
+        "find_duplicates",
+        "Find functions in `paths` that duplicate or closely resemble functions in a pre-built corpus (an `--export-functions` JSON from `find_dupes`). Returns a per-candidate JSON report: each input function, its top exact-cluster siblings, and its top fuzzy partners with similarity scores. Use to answer 'did I just write something that already exists?' during PR authoring or review.",
+        {
+            "paths" => PropertySchema(_type = "string", description = "One or more .das files to compare against the corpus. Comma-separated list or glob (e.g. 'daslib/perf_lint.das' or 'src/foo/*.das'). Directories are not expanded — use a glob."),
+            "corpus" => PropertySchema(_type = "string", description = "Path to a corpus.json produced by `find_dupes --export-functions`. Records whose `file` matches a `paths` entry are dropped from the corpus and replaced by the freshly-compiled version (so the candidate file is compared against the rest of the world, not against itself)."),
+            "threshold" => PropertySchema(_type = "string", description = "Fuzzy similarity floor 0..1 (default 0.7). Score is sqrt(jaccard × len_ratio)."),
+            "min_tokens" => PropertySchema(_type = "string", description = "Minimum canonical-token count per function (default 8). Filters trivial wrappers."),
+            "top" => PropertySchema(_type = "string", description = "Top-N similar matches per candidate (default 5).")
+        },
+        ["paths", "corpus"]
+    ))
+    result.tools |> emplace(make_tool(
         "live_status",
         "Get status of a running daslang-live instance (fps, uptime, paused, dt, has_error). Returns 503 JSON with compilation error if the script failed to compile.",
         { "port" => PropertySchema(_type = "string", description = "Live API port (default: 9090)") },
@@ -555,6 +568,8 @@ def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, project : string) : s
         return do_aot(arg1, arg2, project)
     } elif (tool_name == "lint") {
         return do_lint(arg1, project)
+    } elif (tool_name == "find_duplicates") {
+        return do_find_duplicates(arg1, arg2, arg3, arg4, arg5)
     } elif (tool_name == "live_status") {
         return do_live_status(arg1)
     } elif (tool_name == "live_error") {
@@ -730,6 +745,18 @@ def handle_tools_call(id_json : string; params : JsonValue?) : string {
         if (empty(arg1)) {
             return json_rpc_error(id_json, -32602, "missing 'file' argument")
         }
+    } elif (name == "find_duplicates") {
+        arg1 = get_string_arg(args, "paths")
+        if (empty(arg1)) {
+            return json_rpc_error(id_json, -32602, "missing 'paths' argument")
+        }
+        arg2 = get_string_arg(args, "corpus")
+        if (empty(arg2)) {
+            return json_rpc_error(id_json, -32602, "missing 'corpus' argument")
+        }
+        arg3 = get_string_arg(args, "threshold")
+        arg4 = get_string_arg(args, "min_tokens")
+        arg5 = get_string_arg(args, "top")
     } elif (name == "live_status") {
         arg1 = get_string_arg(args, "port")
     } elif (name == "live_error") {

--- a/utils/mcp/protocol.das
+++ b/utils/mcp/protocol.das
@@ -427,11 +427,12 @@ def handle_tools_list(id_json : string) : string {
         "find_duplicates",
         "Find functions in `paths` that duplicate or closely resemble functions in a pre-built corpus (an `--export-functions` JSON from `find_dupes`). Returns a per-candidate JSON report: each input function, its top exact-cluster siblings, and its top fuzzy partners with similarity scores. Use to answer 'did I just write something that already exists?' during PR authoring or review.",
         {
-            "paths" => PropertySchema(_type = "string", description = "One or more .das files to compare against the corpus. Comma-separated list or glob (e.g. 'daslib/perf_lint.das' or 'src/foo/*.das'). Directories are not expanded — use a glob."),
+            "paths" => PropertySchema(_type = "string", description = "One or more .das files to compare against the corpus. Comma- or newline-delimited list, or a glob (e.g. 'daslib/perf_lint.das' or 'src/foo/*.das'). Directories are not expanded — use a glob. Newline support lets `git diff --name-only` output be piped in directly."),
             "corpus" => PropertySchema(_type = "string", description = "Path to a corpus.json produced by `find_dupes --export-functions`. Records whose `file` matches a `paths` entry are dropped from the corpus and replaced by the freshly-compiled version (so the candidate file is compared against the rest of the world, not against itself)."),
             "threshold" => PropertySchema(_type = "string", description = "Fuzzy similarity floor 0..1 (default 0.7). Score is sqrt(jaccard × len_ratio)."),
             "min_tokens" => PropertySchema(_type = "string", description = "Minimum canonical-token count per function (default 8). Filters trivial wrappers."),
-            "top" => PropertySchema(_type = "string", description = "Top-N similar matches per candidate (default 5).")
+            "top" => PropertySchema(_type = "string", description = "Top-N similar matches per candidate (default 5)."),
+            "project" => PROJECT_PROP
         },
         ["paths", "corpus"]
     ))
@@ -569,7 +570,7 @@ def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, project : string) : s
     } elif (tool_name == "lint") {
         return do_lint(arg1, project)
     } elif (tool_name == "find_duplicates") {
-        return do_find_duplicates(arg1, arg2, arg3, arg4, arg5)
+        return do_find_duplicates(arg1, arg2, arg3, arg4, arg5, project)
     } elif (tool_name == "live_status") {
         return do_live_status(arg1)
     } elif (tool_name == "live_error") {

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -1284,7 +1284,7 @@ def test_find_duplicates_missing_corpus(t : T?) {
     t |> run("missing 'corpus' arg returns error envelope") <| @(t : T?) {
         var text : string
         var is_error = false
-        let ok = parse_result(do_find_duplicates("foo.das", "", "", "", ""), text, is_error)
+        let ok = parse_result(do_find_duplicates("foo.das", "", "", "", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error")
         t |> success(find(text, "corpus") >= 0, "should mention corpus: {text}")
@@ -1301,7 +1301,7 @@ def test_find_duplicates_missing_paths(t : T?) {
         }
         var text : string
         var is_error = false
-        let ok = parse_result(do_find_duplicates("", path, "", "", ""), text, is_error)
+        let ok = parse_result(do_find_duplicates("", path, "", "", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error")
         t |> success(find(text, "paths") >= 0, "should mention paths: {text}")
@@ -1313,10 +1313,18 @@ def test_find_duplicates_missing_paths(t : T?) {
 [test]
 def test_find_duplicates_corpus_not_found(t : T?) {
     t |> run("nonexistent corpus path is reported") <| @(t : T?) {
+        // Generate a portable temp path then immediately delete the file
+        // — the path is now guaranteed nonexistent and unique to this run,
+        // and works on Windows runners where /tmp doesn't exist.
+        let bogus = make_temp_corpus_file(t, "")
+        if (empty(bogus)) {
+            return
+        }
+        remove(bogus)
         var text : string
         var is_error = false
         let ok = parse_result(do_find_duplicates(fixture_path("_fixture_valid.das"),
-            "/tmp/nonexistent_find_dupes_corpus_xyz123.json", "", "", ""), text, is_error)
+            bogus, "", "", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error")
     }
@@ -1333,7 +1341,7 @@ def test_find_duplicates_empty_corpus(t : T?) {
         var text : string
         var is_error = false
         let ok = parse_result(do_find_duplicates(fixture_path("_fixture_valid.das"),
-            path, "", "", ""), text, is_error)
+            path, "", "", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(!is_error, "should NOT be error: {text}")
         t |> success(find(text, "candidate_functions") >= 0, "envelope has candidate_functions: {text}")
@@ -1358,7 +1366,7 @@ def test_find_duplicates_bad_schema(t : T?) {
         var text : string
         var is_error = false
         let ok = parse_result(do_find_duplicates(fixture_path("_fixture_valid.das"),
-            path, "", "", ""), text, is_error)
+            path, "", "", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error")
         t |> success(find(text, "schema_version") >= 0, "mentions schema_version: {text}")

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -29,6 +29,7 @@ require tools/grep_usage public
 require tools/outline public
 require tools/aot public
 require tools/lint_tool public
+require tools/find_duplicates public
 
 // helper: parse tool result JSON, return (text, isError)
 def parse_result(result : string; var text : string&; var is_error : bool&) : bool {
@@ -1256,6 +1257,112 @@ def test_lint_no_match(t : T?) {
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error")
         t |> success(find(text, "no files matched") >= 0, "should mention no files matched")
+    }
+}
+
+// ── find_duplicates ──────────────────────────────────────────────────
+
+
+def make_temp_corpus_file(t : T?; body : string) : string {
+    let r = create_temp_file_result("find_dupes_mcp_test", ".json")
+    if (!(r is value)) {
+        t |> failure("create_temp_file_result failed")
+        return ""
+    }
+    let path = unsafe(r.value)
+    fopen(path, "wb") $(fw) {
+        if (fw != null) {
+            fw |> fprint(body)
+        }
+    }
+    return path
+}
+
+
+[test]
+def test_find_duplicates_missing_corpus(t : T?) {
+    t |> run("missing 'corpus' arg returns error envelope") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_find_duplicates("foo.das", "", "", "", ""), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(is_error, "should be error")
+        t |> success(find(text, "corpus") >= 0, "should mention corpus: {text}")
+    }
+}
+
+
+[test]
+def test_find_duplicates_missing_paths(t : T?) {
+    t |> run("missing 'paths' arg returns error envelope") <| @(t : T?) {
+        let path = make_temp_corpus_file(t, "\{\"schema_version\":1,\"functions\":[]\}")
+        if (empty(path)) {
+            return
+        }
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_find_duplicates("", path, "", "", ""), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(is_error, "should be error")
+        t |> success(find(text, "paths") >= 0, "should mention paths: {text}")
+        remove(path)
+    }
+}
+
+
+[test]
+def test_find_duplicates_corpus_not_found(t : T?) {
+    t |> run("nonexistent corpus path is reported") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_find_duplicates(fixture_path("_fixture_valid.das"),
+            "/tmp/nonexistent_find_dupes_corpus_xyz123.json", "", "", ""), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(is_error, "should be error")
+    }
+}
+
+
+[test]
+def test_find_duplicates_empty_corpus(t : T?) {
+    t |> run("empty corpus + valid candidate yields envelope with zero matches") <| @(t : T?) {
+        let path = make_temp_corpus_file(t, "\{\"schema_version\":1,\"functions\":[]\}")
+        if (empty(path)) {
+            return
+        }
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_find_duplicates(fixture_path("_fixture_valid.das"),
+            path, "", "", ""), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(!is_error, "should NOT be error: {text}")
+        t |> success(find(text, "candidate_functions") >= 0, "envelope has candidate_functions: {text}")
+        t |> success(find(text, "exact_clusters_kept") >= 0, "envelope has exact_clusters_kept")
+        t |> success(find(text, "fuzzy_pairs_kept") >= 0, "envelope has fuzzy_pairs_kept")
+        t |> success(find(text, "\"report\"") >= 0, "envelope has nested report")
+        // Empty corpus → no matches possible.
+        t |> success(find(text, "\"exact_clusters_kept\": 0") >= 0, "zero exact clusters: {text}")
+        t |> success(find(text, "\"fuzzy_pairs_kept\": 0") >= 0, "zero fuzzy pairs: {text}")
+        remove(path)
+    }
+}
+
+
+[test]
+def test_find_duplicates_bad_schema(t : T?) {
+    t |> run("corpus with bad schema_version is rejected") <| @(t : T?) {
+        let path = make_temp_corpus_file(t, "\{\"schema_version\":99,\"functions\":[]\}")
+        if (empty(path)) {
+            return
+        }
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_find_duplicates(fixture_path("_fixture_valid.das"),
+            path, "", "", ""), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(is_error, "should be error")
+        t |> success(find(text, "schema_version") >= 0, "mentions schema_version: {text}")
+        remove(path)
     }
 }
 

--- a/utils/mcp/tools/find_duplicates.das
+++ b/utils/mcp/tools/find_duplicates.das
@@ -33,15 +33,21 @@ def parse_int_default(s : string; default_val : int) : int {
 // resemble (or duplicate) functions already in the corpus. Output is
 // the per-candidate JSON shape: one entry per candidate function with
 // its top-N exact-cluster siblings and fuzzy partners.
+//
+// stdio transport reserves stdout for JSON-RPC, so every helper called
+// here must run in quiet mode — `read_import(..., quiet=true)` and
+// `compile_and_collect(..., quiet=true)`. Failure counts surface only
+// via the returned envelope.
 def public do_find_duplicates(paths : string; corpus : string;
                               threshold_str : string;
                               min_tokens_str : string;
-                              top_str : string) : string {
+                              top_str : string;
+                              project : string) : string {
     if (empty(corpus)) {
         return make_tool_result("find_duplicates: missing required 'corpus' parameter (path to a corpus.json produced by `find_dupes --export-functions`)", true)
     }
     if (empty(paths)) {
-        return make_tool_result("find_duplicates: missing required 'paths' parameter (one or more .das files, comma-separated or glob)", true)
+        return make_tool_result("find_duplicates: missing required 'paths' parameter (one or more .das files; comma- or newline-delimited, or a glob)", true)
     }
     let threshold = parse_float_default(threshold_str, 0.7f)
     let min_tokens = parse_int_default(min_tokens_str, 8)
@@ -56,39 +62,49 @@ def public do_find_duplicates(paths : string; corpus : string;
         return make_tool_result("find_duplicates: top must be >= 0, got {top}", true)
     }
 
+    // `parse_file_list` only splits on commas and globs, so normalize
+    // newlines first — supports `git diff --name-only ... | …` style input
+    // that the README documents.
+    let paths_normalized = paths |> replace("\n", ",")
     var files : array<string>
-    parse_file_list(paths, files)
+    parse_file_list(paths_normalized, files)
     if (empty(files)) {
         return make_tool_result("find_duplicates: no files matched: {paths}", true)
     }
-    // Build the candidate file set (normalized for comparison).
+    // Build the candidate file set (normalized for comparison) AND keep a
+    // sorted list for deterministic compile order — table key iteration is
+    // unordered, which would make compile order (and per-candidate report
+    // order) non-reproducible across runs.
     var against_files : table<string; void?>
+    var against_files_sorted : array<string>
     for (f in files) {
         let n = normalize_path(f)
         if (!key_exists(against_files, n)) {
             against_files |> insert(n, null)
+            against_files_sorted |> push(n)
         }
     }
+    sort(against_files_sorted)
 
     // Load the corpus. want_sigs=true because we need MinHash signatures
     // for fuzzy matching — both sides of every comparison must have one.
     var records : array<FuncRecord>
     var ierr : string
-    if (!read_import(corpus, records, true, min_tokens, ierr)) {
+    if (!read_import(corpus, records, true, min_tokens, ierr, true)) {
         return make_tool_result("find_duplicates: {ierr}", true)
     }
     let corpus_total = length(records)
     let dropped = drop_records_under_files(records, against_files)
 
     // Compile the candidate files in-process and tag the freshly-pushed
-    // records as candidates.
+    // records as candidates. Iterate the sorted list, not the table.
     var seen_loc : table<string; void?>
     var n_failed = 0
     var n_compiled = 0
     var failed_files : array<string>
-    for (af in keys(against_files)) {
+    for (af in against_files_sorted) {
         let before = length(records)
-        if (!compile_and_collect(af, records, seen_loc, false, false, true, min_tokens)) {
+        if (!compile_and_collect(af, records, seen_loc, false, false, true, min_tokens, true, project)) {
             n_failed++
             failed_files |> push(af)
             continue

--- a/utils/mcp/tools/find_duplicates.das
+++ b/utils/mcp/tools/find_duplicates.das
@@ -1,0 +1,141 @@
+options gen2
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require common public
+require ../../find_dupes/pipeline.das
+require ../../find_dupes/cluster.das
+require ../../find_dupes/exchange.das
+require ../../find_dupes/report.das
+require ../../find_dupes/canonical.das
+require strings
+require math
+require daslib/strings_boost
+
+
+def parse_float_default(s : string; default_val : float) : float {
+    if (empty(s)) {
+        return default_val
+    }
+    return to_float(s)
+}
+
+
+def parse_int_default(s : string; default_val : int) : int {
+    if (empty(s)) {
+        return default_val
+    }
+    return to_int(s)
+}
+
+
+// MCP entry point: load a corpus and report functions in `paths` that
+// resemble (or duplicate) functions already in the corpus. Output is
+// the per-candidate JSON shape: one entry per candidate function with
+// its top-N exact-cluster siblings and fuzzy partners.
+def public do_find_duplicates(paths : string; corpus : string;
+                              threshold_str : string;
+                              min_tokens_str : string;
+                              top_str : string) : string {
+    if (empty(corpus)) {
+        return make_tool_result("find_duplicates: missing required 'corpus' parameter (path to a corpus.json produced by `find_dupes --export-functions`)", true)
+    }
+    if (empty(paths)) {
+        return make_tool_result("find_duplicates: missing required 'paths' parameter (one or more .das files, comma-separated or glob)", true)
+    }
+    let threshold = parse_float_default(threshold_str, 0.7f)
+    let min_tokens = parse_int_default(min_tokens_str, 8)
+    let top = parse_int_default(top_str, 5)
+    if (threshold < 0.0f || threshold > 1.0f) {
+        return make_tool_result("find_duplicates: threshold must be in 0..1, got {threshold}", true)
+    }
+    if (min_tokens < 0) {
+        return make_tool_result("find_duplicates: min_tokens must be >= 0, got {min_tokens}", true)
+    }
+    if (top < 0) {
+        return make_tool_result("find_duplicates: top must be >= 0, got {top}", true)
+    }
+
+    var files : array<string>
+    parse_file_list(paths, files)
+    if (empty(files)) {
+        return make_tool_result("find_duplicates: no files matched: {paths}", true)
+    }
+    // Build the candidate file set (normalized for comparison).
+    var against_files : table<string; void?>
+    for (f in files) {
+        let n = normalize_path(f)
+        if (!key_exists(against_files, n)) {
+            against_files |> insert(n, null)
+        }
+    }
+
+    // Load the corpus. want_sigs=true because we need MinHash signatures
+    // for fuzzy matching — both sides of every comparison must have one.
+    var records : array<FuncRecord>
+    var ierr : string
+    if (!read_import(corpus, records, true, min_tokens, ierr)) {
+        return make_tool_result("find_duplicates: {ierr}", true)
+    }
+    let corpus_total = length(records)
+    let dropped = drop_records_under_files(records, against_files)
+
+    // Compile the candidate files in-process and tag the freshly-pushed
+    // records as candidates.
+    var seen_loc : table<string; void?>
+    var n_failed = 0
+    var n_compiled = 0
+    var failed_files : array<string>
+    for (af in keys(against_files)) {
+        let before = length(records)
+        if (!compile_and_collect(af, records, seen_loc, false, false, true, min_tokens)) {
+            n_failed++
+            failed_files |> push(af)
+            continue
+        }
+        for (i in range(before, length(records))) {
+            records[i].is_candidate = true
+        }
+        n_compiled++
+    }
+
+    let cand_refs <- collect_candidate_refs(records)
+    if (empty(cand_refs)) {
+        let msg = (n_failed > 0
+            ? "find_duplicates: no candidate functions extracted (compile failed for {n_failed} file(s); first: {failed_files[0]})"
+            : "find_duplicates: no candidate functions extracted from {paths}")
+        return make_tool_result(msg, true)
+    }
+
+    var clusters <- exact_buckets(records, min_tokens, true)
+    sort_clusters(clusters)
+    var pairs <- fuzzy_pairs(records, threshold, min_tokens, true)
+    sort_pairs(pairs)
+
+    var rep : Report
+    rep.summary.functions_analyzed = length(records)
+    rep.summary.threshold = threshold
+    rep.summary.min_tokens = min_tokens
+    rep.exact_clusters <- clusters
+    rep.fuzzy_pairs <- pairs
+    rep.summary.exact_clusters = length(rep.exact_clusters)
+    rep.summary.fuzzy_pairs = length(rep.fuzzy_pairs)
+
+    // Wrap the per-candidate report in a small envelope so consumers can
+    // see corpus stats and compile-failure counts without parsing stdout.
+    let pcr_body = write_per_candidate_report(rep, cand_refs, top)
+    let envelope = build_string() $(var w) {
+        w |> write("\{")
+        w |> write("\"corpus_records\": {corpus_total}, ")
+        w |> write("\"corpus_dropped_for_override\": {dropped}, ")
+        w |> write("\"candidate_files_compiled\": {n_compiled}, ")
+        w |> write("\"candidate_files_failed\": {n_failed}, ")
+        w |> write("\"candidate_functions\": {length(cand_refs)}, ")
+        w |> write("\"exact_clusters_kept\": {rep.summary.exact_clusters}, ")
+        w |> write("\"fuzzy_pairs_kept\": {rep.summary.fuzzy_pairs}, ")
+        w |> write("\"report\": ")
+        w |> write(pcr_body)
+        w |> write("\}")
+    }
+    return make_tool_result(envelope, n_failed > 0)
+}


### PR DESCRIPTION
## Summary

The flat 180-cluster / 979-pair report on `daslib` was unusable in real workflows. Adds two filtered modes built on a single `is_candidate` flag, plus an MCP tool that exposes B2 to AI assistants.

- **B1 — baseline diff (CI gate):** `--baseline corpus.json` tags records whose canonical isn't in the baseline as candidates and filters output to those. `--baseline-strict` additionally drops clusters whose canonical existed in the baseline (only fully-new wins). `--check` exits non-zero when the filtered report has anything.
- **B2 — PR-files / interactive:** `--against <path>` (repeatable, also `--against-from-stdin` for `git diff --name-only | …`) compiles candidate files in-process and tags them. When combined with `--import-functions`, drops corpus records whose `file` matches a candidate path so the file is compared against the rest of the world rather than its own stale corpus copy. Default writer in `--against` mode is the per-candidate rollup; `--flat` reverts.
- **MCP `find_duplicates(paths, corpus, threshold?, min_tokens?, top?)`:** wraps B2 mode in-process via file-path requires, returns a JSON envelope with corpus stats + per-candidate rollup.

Cluster filter is opt-in (`filter_candidates : bool = false`) so legacy callers see no change. Fuzzy pass becomes O(K·N) when filter is active.

## Dogfooding

Ran B2 against this branch (PR files vs. master corpus) — caught one self-introduced exact dupe: `report.das:member_id` was an exact duplicate of `cluster.das:member_key`. Consolidated in commit 2 (`9b770d094`). Working as intended.

Also surfaced a pre-existing `has_expect_directive` triplet in `utils/find_dupes/main.das`, `utils/lint/main.das`, `utils/mcp/tools/lint_tool.das` — out of scope here, follow-up worthy.

## Test plan

- [x] `bin/daslang dastest/dastest.das -- --test utils/find_dupes/test_find_dupes.das` — 54/54 pass (45 → 54, +9 candidate-filter tests)
- [x] `bin/daslang dastest/dastest.das -- --test utils/mcp/test_tools.das` — 181/181 pass (176 → 181, +5 MCP tool tests)
- [x] `bin/daslang dastest/dastest.das -- --test tests/` — 6987 tests, 0 failed, 0 errored, 6 intentional skips
- [x] AOT build + `bin/test_aot -use-aot ... --test tests` — clean except one pre-existing flake in `tests/language/random_numbers.das` (reproduces on master, unrelated to this PR)
- [x] `bin/daslang utils/lint/main.das -- <changed files>` — new code is lint-clean; 42 remaining warnings are pre-existing patterns in `test_find_dupes.das`
- [x] Format check via MCP `format_file` on every changed `.das`
- [x] B1 smoke (unchanged corpus → 0 clusters/pairs, exit 0)
- [x] B1 with injected dupe + `--check` → exit 1
- [x] B2 smoke (`--import-functions` + `--against perf_lint.das` surfaces the known `preVisitExprFor`/`preVisitExprWhile` 0.95 pair)
- [x] `--against-from-stdin` smoke via `echo path | …`
- [x] MCP `find_duplicates` tool invoked over JSON-RPC stdin returns the expected envelope shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)