### PR TITLE
daslib/strings_convert: soft-failing string→numeric conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1052,6 +1052,7 @@ if(NOT ${DAS_AOT_EXAMPLES_DISABLED})
         daslib/regex_boost.das
         daslib/regex.das
         daslib/strings_boost.das
+        daslib/strings_convert.das
         daslib/templates_boost.das
         daslib/utf8_utils.das
     )

--- a/daslib/strings_convert.das
+++ b/daslib/strings_convert.das
@@ -1,0 +1,158 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+options strict_smart_pointers = true
+
+module strings_convert shared public
+
+//! Soft-failing string-to-numeric conversions returning ``Result<T; ConversionError>``.
+//!
+//! Companion to the panicking ``string_to_int*`` builtins and the silent-fail
+//! ``to_int*`` family. Use ``try_to_*`` when you need to distinguish
+//! ``invalid_argument`` (not a number), ``out_of_range`` (overflow), and
+//! ``trailing_garbage`` (``"123abc"``).
+//!
+//! Leading whitespace is consumed; trailing characters - including whitespace -
+//! yield ``trailing_garbage``. Hex variants accept an optional ``0x``/``0X``
+//! prefix when ``hex`` is ``true``.
+
+require strings public
+require daslib/result public
+
+//! Reason a ``try_to_*`` conversion failed.
+enum public ConversionError {
+    invalid_argument
+    out_of_range
+    trailing_garbage
+}
+
+def private classify(result : ConversionResult; offset : int; full_length : int) : ConversionError {
+    if (result == ConversionResult.out_of_range) {
+        return ConversionError.out_of_range
+    }
+    if (result == ConversionResult.ok && offset != full_length) {
+        return ConversionError.trailing_garbage
+    }
+    return ConversionError.invalid_argument
+}
+
+def public try_to_int8(str : string implicit; hex : bool = false) : Result<int8; ConversionError> {
+    //! Parse ``str`` as a signed 8-bit integer.
+    var result : ConversionResult
+    var offset = 0
+    let parsed = int8(str, result, offset, hex)
+    let len = length(str)
+    if (result == ConversionResult.ok && offset == len) {
+        return ok(parsed, type<ConversionError>)
+    }
+    return err(classify(result, offset, len), type<int8>)
+}
+
+def public try_to_uint8(str : string implicit; hex : bool = false) : Result<uint8; ConversionError> {
+    //! Parse ``str`` as an unsigned 8-bit integer.
+    var result : ConversionResult
+    var offset = 0
+    let parsed = uint8(str, result, offset, hex)
+    let len = length(str)
+    if (result == ConversionResult.ok && offset == len) {
+        return ok(parsed, type<ConversionError>)
+    }
+    return err(classify(result, offset, len), type<uint8>)
+}
+
+def public try_to_int16(str : string implicit; hex : bool = false) : Result<int16; ConversionError> {
+    //! Parse ``str`` as a signed 16-bit integer.
+    var result : ConversionResult
+    var offset = 0
+    let parsed = int16(str, result, offset, hex)
+    let len = length(str)
+    if (result == ConversionResult.ok && offset == len) {
+        return ok(parsed, type<ConversionError>)
+    }
+    return err(classify(result, offset, len), type<int16>)
+}
+
+def public try_to_uint16(str : string implicit; hex : bool = false) : Result<uint16; ConversionError> {
+    //! Parse ``str`` as an unsigned 16-bit integer.
+    var result : ConversionResult
+    var offset = 0
+    let parsed = uint16(str, result, offset, hex)
+    let len = length(str)
+    if (result == ConversionResult.ok && offset == len) {
+        return ok(parsed, type<ConversionError>)
+    }
+    return err(classify(result, offset, len), type<uint16>)
+}
+
+def public try_to_int(str : string implicit; hex : bool = false) : Result<int; ConversionError> {
+    //! Parse ``str`` as a signed 32-bit integer.
+    var result : ConversionResult
+    var offset = 0
+    let parsed = int(str, result, offset, hex)
+    let len = length(str)
+    if (result == ConversionResult.ok && offset == len) {
+        return ok(parsed, type<ConversionError>)
+    }
+    return err(classify(result, offset, len), type<int>)
+}
+
+def public try_to_uint(str : string implicit; hex : bool = false) : Result<uint; ConversionError> {
+    //! Parse ``str`` as an unsigned 32-bit integer.
+    var result : ConversionResult
+    var offset = 0
+    let parsed = uint(str, result, offset, hex)
+    let len = length(str)
+    if (result == ConversionResult.ok && offset == len) {
+        return ok(parsed, type<ConversionError>)
+    }
+    return err(classify(result, offset, len), type<uint>)
+}
+
+def public try_to_int64(str : string implicit; hex : bool = false) : Result<int64; ConversionError> {
+    //! Parse ``str`` as a signed 64-bit integer.
+    var result : ConversionResult
+    var offset = 0
+    let parsed = int64(str, result, offset, hex)
+    let len = length(str)
+    if (result == ConversionResult.ok && offset == len) {
+        return ok(parsed, type<ConversionError>)
+    }
+    return err(classify(result, offset, len), type<int64>)
+}
+
+def public try_to_uint64(str : string implicit; hex : bool = false) : Result<uint64; ConversionError> {
+    //! Parse ``str`` as an unsigned 64-bit integer.
+    var result : ConversionResult
+    var offset = 0
+    let parsed = uint64(str, result, offset, hex)
+    let len = length(str)
+    if (result == ConversionResult.ok && offset == len) {
+        return ok(parsed, type<ConversionError>)
+    }
+    return err(classify(result, offset, len), type<uint64>)
+}
+
+def public try_to_float(str : string implicit) : Result<float; ConversionError> {
+    //! Parse ``str`` as a 32-bit float.
+    var result : ConversionResult
+    var offset = 0
+    let parsed = float(str, result, offset)
+    let len = length(str)
+    if (result == ConversionResult.ok && offset == len) {
+        return ok(parsed, type<ConversionError>)
+    }
+    return err(classify(result, offset, len), type<float>)
+}
+
+def public try_to_double(str : string implicit) : Result<double; ConversionError> {
+    //! Parse ``str`` as a 64-bit float.
+    var result : ConversionResult
+    var offset = 0
+    let parsed = double(str, result, offset)
+    let len = length(str)
+    if (result == ConversionResult.ok && offset == len) {
+        return ok(parsed, type<ConversionError>)
+    }
+    return err(classify(result, offset, len), type<double>)
+}

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -11,6 +11,7 @@ require jobque
 require daslib/ast_boost
 require daslib/rst_comment
 require daslib/strings_boost
+require daslib/strings_convert
 require daslib/rst
 require daslib/functional
 require daslib/json
@@ -378,6 +379,13 @@ def document_module_strings_boost(root : string) {
         group_by_regex("Levenshtein distance", mod, %regex~(levenshtein_distance|levenshtein_distance_fast)$%%),
         group_by_regex("Character traits", mod, %regex~(is_hex|is_tab_or_space)$%%))
     document("Boost package for string manipulation library", mod, "strings_boost.rst", groups)
+}
+
+def document_module_strings_convert(root : string) {
+    var mod = find_module("strings_convert")
+    var groups <- array<DocGroup>(
+        group_by_regex("Soft-failing conversions", mod, %regex~try_to_(int|uint|int8|uint8|int16|uint16|int64|uint64|float|double)$%%))
+    document("Soft-failing string-to-numeric conversions returning Result<T; ConversionError>", mod, "strings_convert.rst", groups)
 }
 
 
@@ -1653,6 +1661,7 @@ def main {
     document_module_stbimage_ttf(root)
     document_module_stringify(root)
     document_module_strings_boost(root)
+    document_module_strings_convert(root)
     document_module_temp_strings(root)
     document_module_templates_boost(root)
     document_module_templates(root)

--- a/doc/source/stdlib/handmade/module-strings_convert.rst
+++ b/doc/source/stdlib/handmade/module-strings_convert.rst
@@ -1,0 +1,31 @@
+The STRINGS_CONVERT module provides soft-failing string-to-numeric conversions
+that return ``Result<T; ConversionError>`` instead of panicking or silently
+returning zero. Use these when parsing untrusted input where you need to
+distinguish between not-a-number, overflow, and trailing-garbage.
+
+All functions and symbols are in the "strings_convert" module, use require to get access to it.
+
+.. code-block:: das
+
+    require daslib/strings_convert
+
+Example:
+
+.. code-block:: das
+
+    require daslib/strings_convert
+
+    [export]
+    def main() {
+        let r = try_to_int("42")
+        if (is_ok(r)) {
+            print("parsed: {unwrap(r)}\n")
+        }
+        let bad = try_to_int("nope")
+        if (is_err(bad)) {
+            print("error: {unwrap_err(bad)}\n")
+        }
+    }
+    // output:
+    // parsed: 42
+    // error: invalid_argument

--- a/doc/source/stdlib/sec_strings.rst
+++ b/doc/source/stdlib/sec_strings.rst
@@ -10,6 +10,7 @@ String manipulation, formatting, encoding, and temporary string utilities.
 
    generated/strings.rst
    generated/strings_boost.rst
+   generated/strings_convert.rst
    generated/temp_strings.rst
    generated/utf8_utils.rst
    generated/base64.rst

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -18,6 +18,7 @@ require daslib/templates_boost
 require daslib/macro_boost
 require daslib/rtti
 require strings public
+require daslib/strings_convert
 
 // ============================================================================
 // _to_array passthrough
@@ -958,12 +959,7 @@ def private analyze_grouped_projection(var body : ExpressionPtr; var q : SqlQuer
                         && inner.name == "_0") {
                     if (length(outerName) > 1 && outerName |> starts_with("_")) {
                         let suffix = slice(outerName, 1, length(outerName))
-                        var keyIdx = -1
-                        try {
-                            keyIdx = to_int(suffix)
-                        } recover {
-                            keyIdx = -1
-                        }
+                        let keyIdx = try_to_int(suffix) ?? -1
                         if (keyIdx >= 0 && keyIdx < nKeys) {
                             let col = group_key_column_name(q, keyIdx)
                             var fieldType = lookup_struct_field_type(q.rootType, col)
@@ -1069,12 +1065,7 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
                     && inner.name == "_0"
                     && length(outerName) > 1 && outerName |> starts_with("_")) {
                 let suffix = slice(outerName, 1, length(outerName))
-                var keyIdx = -1
-                try {
-                    keyIdx = to_int(suffix)
-                } recover {
-                    keyIdx = -1
-                }
+                let keyIdx = try_to_int(suffix) ?? -1
                 if (keyIdx >= 0 && keyIdx < nKeys) {
                     q.orderByCols |> push("{q.groupByCols[keyIdx]} {direction}")
                     return true

--- a/tests/README.md
+++ b/tests/README.md
@@ -775,6 +775,7 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 | test_cpp_functions.das | C++ string functions — fmt, safe_unescape, to_lower_in_place, character_at | |
 | test_new_string_functions.das | New string utilities — contains, count_chars, pad_left/right, trim_chars | |
 | test_strings_boost_extra.das | Extra strings_boost — wide, is_character_at, eq, join overloads | |
+| test_strings_convert.das | `daslib/strings_convert` — `try_to_*` returning `Result<T; ConversionError>` | |
 
 ## template/
 

--- a/tests/strings/test_strings_convert.das
+++ b/tests/strings/test_strings_convert.das
@@ -1,0 +1,148 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require daslib/strings_convert
+
+def expect_ok_value(t : T?; r : auto(R) const; expected : auto(V)) {
+    t |> equal(true, is_ok(r))
+    if (is_ok(r)) {
+        t |> equal(expected, unwrap(r))
+    }
+}
+
+def expect_err_kind(t : T?; r : auto(R) const; expected : ConversionError) {
+    t |> equal(false, is_ok(r))
+    if (is_err(r)) {
+        t |> equal(expected, unwrap_err(r))
+    }
+}
+
+[test]
+def test_try_to_int_basic(t : T?) {
+    expect_ok_value(t, try_to_int("13"), 13)
+    expect_ok_value(t, try_to_int("-13"), -13)
+    expect_ok_value(t, try_to_int("0"), 0)
+    expect_ok_value(t, try_to_int("  13"), 13)
+    expect_err_kind(t, try_to_int("13  "), ConversionError.trailing_garbage)
+    expect_err_kind(t, try_to_int("13abc"), ConversionError.trailing_garbage)
+    expect_err_kind(t, try_to_int(""), ConversionError.invalid_argument)
+    expect_err_kind(t, try_to_int("   "), ConversionError.invalid_argument)
+    expect_err_kind(t, try_to_int("abc"), ConversionError.invalid_argument)
+    expect_err_kind(t, try_to_int("1.5"), ConversionError.trailing_garbage)
+    expect_err_kind(t, try_to_int("9999999999999999999"), ConversionError.out_of_range)
+}
+
+[test]
+def test_try_to_int_hex(t : T?) {
+    expect_ok_value(t, try_to_int("13", true), int(0x13))
+    expect_ok_value(t, try_to_int("0x1F", true), int(0x1F))
+    expect_ok_value(t, try_to_int("FF", true), int(0xFF))
+    expect_err_kind(t, try_to_int("0x1F", false), ConversionError.trailing_garbage)
+    expect_err_kind(t, try_to_int("xyz", true), ConversionError.invalid_argument)
+}
+
+[test]
+def test_try_to_int8(t : T?) {
+    expect_ok_value(t, try_to_int8("13"), int8(13))
+    expect_ok_value(t, try_to_int8("-128"), int8(-128))
+    expect_ok_value(t, try_to_int8("127"), int8(127))
+    expect_err_kind(t, try_to_int8("128"), ConversionError.out_of_range)
+    expect_err_kind(t, try_to_int8(""), ConversionError.invalid_argument)
+    expect_err_kind(t, try_to_int8("13x"), ConversionError.trailing_garbage)
+}
+
+[test]
+def test_try_to_uint8(t : T?) {
+    expect_ok_value(t, try_to_uint8("13"), uint8(13))
+    expect_ok_value(t, try_to_uint8("255"), uint8(255))
+    expect_err_kind(t, try_to_uint8("256"), ConversionError.out_of_range)
+    expect_err_kind(t, try_to_uint8("-1"), ConversionError.invalid_argument)
+}
+
+[test]
+def test_try_to_int16(t : T?) {
+    expect_ok_value(t, try_to_int16("13"), int16(13))
+    expect_ok_value(t, try_to_int16("-32768"), int16(-32768))
+    expect_ok_value(t, try_to_int16("32767"), int16(32767))
+    expect_err_kind(t, try_to_int16("32768"), ConversionError.out_of_range)
+}
+
+[test]
+def test_try_to_uint16(t : T?) {
+    expect_ok_value(t, try_to_uint16("13"), uint16(13))
+    expect_ok_value(t, try_to_uint16("65535"), uint16(65535))
+    expect_err_kind(t, try_to_uint16("65536"), ConversionError.out_of_range)
+}
+
+[test]
+def test_try_to_uint(t : T?) {
+    expect_ok_value(t, try_to_uint("13"), 13u)
+    expect_ok_value(t, try_to_uint("4294967295"), 4294967295u)
+    expect_err_kind(t, try_to_uint("4294967296"), ConversionError.out_of_range)
+    expect_err_kind(t, try_to_uint("-1"), ConversionError.invalid_argument)
+}
+
+[test]
+def test_try_to_int64(t : T?) {
+    expect_ok_value(t, try_to_int64("12345678999"), 12345678999l)
+    expect_ok_value(t, try_to_int64("-12345678999"), -12345678999l)
+    expect_err_kind(t, try_to_int64("99999999999999999999"), ConversionError.out_of_range)
+}
+
+[test]
+def test_try_to_uint64(t : T?) {
+    expect_ok_value(t, try_to_uint64("12345678999"), 12345678999ul)
+    expect_ok_value(t, try_to_uint64("18446744073709551615"), 18446744073709551615ul)
+    expect_err_kind(t, try_to_uint64("18446744073709551616"), ConversionError.out_of_range)
+    expect_err_kind(t, try_to_uint64("-1"), ConversionError.invalid_argument)
+}
+
+[test]
+def test_try_to_float_basic(t : T?) {
+    expect_ok_value(t, try_to_float("13"), 13.f)
+    expect_ok_value(t, try_to_float("13.5"), 13.5f)
+    expect_ok_value(t, try_to_float("-13."), -13.f)
+    expect_ok_value(t, try_to_float("  -13.54"), -13.54f)
+    expect_err_kind(t, try_to_float(""), ConversionError.invalid_argument)
+    expect_err_kind(t, try_to_float("abc"), ConversionError.invalid_argument)
+    expect_err_kind(t, try_to_float("13x"), ConversionError.trailing_garbage)
+    expect_err_kind(t, try_to_float("13.5  "), ConversionError.trailing_garbage)
+    expect_err_kind(t, try_to_float("1e39"), ConversionError.out_of_range)
+}
+
+[test]
+def test_try_to_double_basic(t : T?) {
+    expect_ok_value(t, try_to_double("13"), 13.lf)
+    expect_ok_value(t, try_to_double("13.54"), 13.54lf)
+    expect_ok_value(t, try_to_double("-13.54"), -13.54lf)
+    expect_err_kind(t, try_to_double(""), ConversionError.invalid_argument)
+    expect_err_kind(t, try_to_double("13x"), ConversionError.trailing_garbage)
+    expect_err_kind(t, try_to_double("1e309"), ConversionError.out_of_range)
+}
+
+[test]
+def test_try_to_round_trip(t : T?) {
+    let i8 = int8(-42)
+    expect_ok_value(t, try_to_int8(string(i8)), i8)
+    let u8 = uint8(200)
+    expect_ok_value(t, try_to_uint8(string(u8)), u8)
+    let i16 = int16(-12345)
+    expect_ok_value(t, try_to_int16(string(i16)), i16)
+    let u16 = uint16(54321)
+    expect_ok_value(t, try_to_uint16(string(u16)), u16)
+    let i32 = -1234567
+    expect_ok_value(t, try_to_int(string(i32)), i32)
+    let u32 = 1234567u
+    expect_ok_value(t, try_to_uint(string(u32)), u32)
+    let i64 = -123456789012345l
+    expect_ok_value(t, try_to_int64(string(i64)), i64)
+    let u64 = 123456789012345ul
+    expect_ok_value(t, try_to_uint64(string(u64)), u64)
+    let f = 3.5f
+    expect_ok_value(t, try_to_float(string(f)), f)
+    let d = 3.5lf
+    expect_ok_value(t, try_to_double(string(d)), d)
+}


### PR DESCRIPTION
## Summary

- New `daslib/strings_convert` module: `try_to_int*` / `try_to_uint*` / `try_to_float` / `try_to_double` returning `Result<T; ConversionError>`. Fills the gap between panicking `string_to_int*` and silent-fail `to_int*` so callers can parse untrusted input without `try/recover` anti-patterns.
- Errors: `invalid_argument` (not a number), `out_of_range` (overflow), `trailing_garbage` (`"123abc"`). Leading whitespace tolerated; trailing characters rejected.
- Migrates two `try/recover`-around-`to_int` blocks in `sqlite_linq.das` to `try_to_int(suffix) ?? -1`, fixing a latent bug — the old `recover` was dead code (`to_int` is silent-fail), so non-numeric `_._0._N` suffixes silently mapped to `groupByCols[0]` instead of being skipped.

## Module surface

```
enum ConversionError { invalid_argument; out_of_range; trailing_garbage }

try_to_int8/16/32/64  : (str; hex=false) -> Result<T; ConversionError>
try_to_uint8/16/32/64 : (str; hex=false) -> Result<T; ConversionError>
try_to_float          : (str)            -> Result<float; ConversionError>
try_to_double         : (str)            -> Result<double; ConversionError>
```

No C++ changes — wraps the existing `convert_from_string_*` bindings in [`module_builtin_string.cpp:1063-1082`](https://github.com/GaijinEntertainment/daScript/blob/master/src/builtin/module_builtin_string.cpp#L1063).

## Test plan

- [x] Lint clean on all 4 changed `.das` files (`mcp__daslang__lint`)
- [x] Format clean on all 4 changed `.das` files (`mcp__daslang__format_file`)
- [x] 12 new tests in `tests/strings/test_strings_convert.das` cover happy path, leading whitespace, trailing garbage, invalid input, out-of-range per type, hex on/off, signed negatives, unsigned negatives, round-trip per type
- [x] Full interpreted test suite green: 7071/7071 pass
- [x] Full AOT test suite green: 6483/6483 pass (after CMakeLists.txt registration of new module)
- [x] dasSQLITE order_by/group_by suites pass after sqlite_linq.das migration (205/205 interpreted, same AOT)
- [x] `daslang.exe doc/reflections/das2rst.das` exits 0; no `// stub` left for strings_convert; no `Uncategorized` in generated RST
- [x] Clean Sphinx build: `build succeeded.`, zero warnings, zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)