### PR TITLE
dasSQLITE: chunk 5 — multi-source read-side (joins, subqueries, set-ops)

### DIFF
--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -300,8 +300,12 @@ Run any tutorial from the project root::
    tutorials/sql_10_order_by.rst
    tutorials/sql_11_take_skip.rst
    tutorials/sql_12_distinct.rst
+   tutorials/sql_12b_set_ops.rst
    tutorials/sql_13_aggregates.rst
    tutorials/sql_14_group_by.rst
+   tutorials/sql_15_join.rst
+   tutorials/sql_16_left_join.rst
+   tutorials/sql_17_subqueries.rst
    tutorials/sql_18_null_handling.rst
 
 .. _tutorials_dasaudio:

--- a/doc/source/reference/tutorials/sql_12_distinct.rst
+++ b/doc/source/reference/tutorials/sql_12_distinct.rst
@@ -70,4 +70,4 @@ multi-row reads of arbitrary SQL).
 
     Previous tutorial: :ref:`tutorial_sql_take_skip`
 
-    Next tutorial: :ref:`tutorial_sql_aggregates`
+    Next tutorial: :ref:`tutorial_sql_set_ops`

--- a/doc/source/reference/tutorials/sql_12b_set_ops.rst
+++ b/doc/source/reference/tutorials/sql_12b_set_ops.rst
@@ -1,0 +1,64 @@
+.. _tutorial_sql_set_ops:
+
+==========================================
+SQL-12b --- Set operations
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; UNION
+    single: Tutorial; INTERSECT
+    single: Tutorial; EXCEPT
+    single: Tutorial; set operations
+
+Set operations stack two SELECT queries with compatible projections
+and dedupe / intersect / subtract their result rows. Under
+``_sql(...)`` the existing ``daslib/linq.das`` array/iterator
+functions ``union``, ``intersect``, and ``except`` are recognized
+by the emitter and lowered to the matching SQL set-op:
+
+==========================================  =============================================
+Source shape                                Emitted SQL
+==========================================  =============================================
+``lhs |> union(rhs)``                       ``<lhs-sql> UNION <rhs-sql>``
+``lhs |> intersect(rhs)``                   ``<lhs-sql> INTERSECT <rhs-sql>``
+``lhs |> except(rhs)``                      ``<lhs-sql> EXCEPT <rhs-sql>``
+==========================================  =============================================
+
+Both sides must project the same column shape (same column count
+and types). Use ``_select(_.Col)`` to pin the shape explicitly when
+the sources have different schemas.
+
+Distinct tags from either table
+===============================
+
+.. code-block:: das
+
+    let all_tiers <- _sql((db |> select_from(type<Customer>) |> _select(_.Tier))
+                          |> union(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+    // SELECT "Tier" FROM "Customers" UNION SELECT "Tier" FROM "Prospects"
+
+Tags present in both tables
+===========================
+
+.. code-block:: das
+
+    let shared <- _sql((db |> select_from(type<Customer>) |> _select(_.Tier))
+                       |> intersect(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+
+Tags present only on the LHS
+============================
+
+.. code-block:: das
+
+    let exclusive <- _sql((db |> select_from(type<Customer>) |> _select(_.Tier))
+                          |> except(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/12b-set_ops.das <../../../../tutorials/sql/12b-set_ops.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_distinct`
+
+    Next tutorial: :ref:`tutorial_sql_aggregates`

--- a/doc/source/reference/tutorials/sql_13_aggregates.rst
+++ b/doc/source/reference/tutorials/sql_13_aggregates.rst
@@ -88,6 +88,6 @@ inside an inner ``select`` lambda over the group elements.
 
     Full source: :download:`tutorials/sql/13-aggregates.das <../../../../tutorials/sql/13-aggregates.das>`
 
-    Previous tutorial: :ref:`tutorial_sql_distinct`
+    Previous tutorial: :ref:`tutorial_sql_set_ops`
 
     Next tutorial: :ref:`tutorial_sql_group_by`

--- a/doc/source/reference/tutorials/sql_14_group_by.rst
+++ b/doc/source/reference/tutorials/sql_14_group_by.rst
@@ -147,4 +147,4 @@ The chain mirrors SQL clause order one-for-one:
 
     Previous tutorial: :ref:`tutorial_sql_aggregates`
 
-    Next tutorial: :ref:`tutorial_sql_null_handling`
+    Next tutorial: :ref:`tutorial_sql_join`

--- a/doc/source/reference/tutorials/sql_15_join.rst
+++ b/doc/source/reference/tutorials/sql_15_join.rst
@@ -1,0 +1,112 @@
+.. _tutorial_sql_join:
+
+==========================================
+SQL-15 --- ``_join`` (inner equi-join)
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; _join
+    single: Tutorial; INNER JOIN
+    single: Tutorial; equi-join
+
+``_join(other, on, into)`` is sugar over the existing
+``daslib/linq.das::join`` function --- under ``_sql(...)`` it emits
+SQL's ``INNER JOIN ... ON ...``.
+
+Equi-join shape
+===============
+
+The ``on`` predicate is locked to the equi-join shape
+
+.. code-block:: das
+
+    $(l : TA, r : TB) => l.X == r.Y
+
+--- a 2-arg lambda whose body is one ``==`` comparison between a
+left-side field and a right-side field. Theta joins (``<``, ``>``,
+``&&``-chained multi-key equality, function calls inside) emit a
+compile-time ``macro_error`` pointing at raw SQL as the escape
+hatch. The single-key restriction matches the backing ``join`` fn's
+hash-based O(n+m) implementation; multi-key tuple joins land later.
+
+Multi-source mode and table aliases
+====================================
+
+In multi-source mode the FROM clause aliases the root table as
+``t0``, the joined table as ``t1``, and every column ref in the
+WHERE, projection, and ON clauses qualifies with the matching alias.
+Single-source chains keep the unqualified shape --- only multi-source
+queries pay the alias-noise tax.
+
+.. code-block:: das
+
+    let rows <- _sql(db |> select_from(type<User>)
+                       |> _join(db |> select_from(type<Order>),
+                                $(u : User, o : Order) => u.Id == o.UserId,
+                                $(u : User, o : Order) => (UserName = u.Name, Total = o.Total)))
+    // SELECT "t0"."Name", "t1"."Total"
+    //   FROM "Users" AS "t0"
+    //   INNER JOIN "Orders" AS "t1"
+    //     ON "t0"."Id" = "t1"."UserId"
+
+Filtering before / inside / after the join
+==========================================
+
+Pre-join ``_where`` filters the LEFT source. Column refs qualify
+with the left alias automatically:
+
+.. code-block:: das
+
+    db |> select_from(type<User>)
+       |> _where(_.Active)
+       |> _join(...)
+    // ... WHERE "t0"."Active"
+
+``_where`` can also live inside the right-side chain --- filters
+there qualify with the right alias ``t1`` and emit into the JOIN's
+``ON`` clause (not the outer ``WHERE``):
+
+.. code-block:: das
+
+    _join(db |> select_from(type<Order>) |> _where(_.Total > 75), ...)
+    // ... INNER JOIN "Orders" AS "t1" ON ... AND ("t1"."Total" > ?)
+
+This placement is required for ``_left_join`` --- a row-level filter
+in the outer ``WHERE`` would drop ``NULL``-extended unmatched rows
+and silently turn ``LEFT JOIN`` into ``INNER JOIN``. ``_join`` (INNER)
+uses the same ``ON`` placement for consistency and planner stability.
+
+The ``into`` projection
+=======================
+
+The ``into`` lambda has two args bound to the two sources. Naming
+is up to you (``u``, ``o`` here). Refer to columns from each source
+through the arg name (``u.Name``, ``o.Total``); the ``_sql``
+translator rewrites them to alias-qualified column refs.
+
+Single-column and named-tuple projections both work. Per-source
+projections (``_select(...)`` on the right side) are rejected ---
+the join's ``into`` lambda is the only projection.
+
+What's not shipped
+==================
+
+* ``_right_join`` --- trivially ``_left_join`` with swapped sources
+* ``_full_outer_join`` --- rare; raw SQL escape hatch
+* ``_cross_join`` --- footgun; raw SQL escape hatch
+* Three-table joins --- compose syntactically but produce verbose
+  tuple chains; documented as "use 2-table joins idiomatically;
+  3+ either chain with verbose tuple access, or drop to raw SQL"
+* Multi-key equi-joins (``u.Id == o.UserId && u.Tenant == o.Tenant``)
+  --- legitimate, but the backing ``join`` fn's keys are
+  single-column; deferred to a later ``multi_key_join`` extension
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/15-join.das <../../../../tutorials/sql/15-join.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_group_by`
+
+    Next tutorial: :ref:`tutorial_sql_left_join`

--- a/doc/source/reference/tutorials/sql_16_left_join.rst
+++ b/doc/source/reference/tutorials/sql_16_left_join.rst
@@ -1,0 +1,70 @@
+.. _tutorial_sql_left_join:
+
+==============================================
+SQL-16 --- ``_left_join`` with ``Option<TB>``
+==============================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; _left_join
+    single: Tutorial; LEFT JOIN
+    single: Tutorial; outer join
+    single: Tutorial; Option<TB>
+
+``_left_join(other, on, into)`` has the same 4-arg shape as ``_join``
+but the ``into`` lambda's right-side parameter is ``Option<TB>`` ---
+``none`` when the left row had no matching right row, ``some(tb)``
+otherwise.
+
+Under ``_sql(...)`` the right-side columns become NULL on no-match
+rows; ``Option<TB>`` is the daslang lift of that NULL semantics.
+
+Probing the right-side option
+=============================
+
+The projection can probe the option:
+
+==================================  ==========================================
+Source shape                        Emitted SQL fragment
+==================================  ==========================================
+``o |> is_some``                    ``"t1"."<rightKey>" IS NOT NULL``
+``o |> is_none``                    ``"t1"."<rightKey>" IS NULL``
+==================================  ==========================================
+
+The probe column is the right-side ON-key --- if THAT came back
+NULL the row had no match.
+
+.. code-block:: das
+
+    let rows <- _sql(db |> select_from(type<User>)
+                       |> _left_join(db |> select_from(type<Order>),
+                                     $(u : User, o : Order) => u.Id == o.UserId,
+                                     $(u : User, o : Option<Order>) => (Name = u.Name, HasOrder = o |> is_some)))
+    // SELECT "t0"."Name", "t1"."UserId" IS NOT NULL
+    //   FROM "Users" AS "t0"
+    //   LEFT JOIN "Orders" AS "t1"
+    //     ON "t0"."Id" = "t1"."UserId"
+
+What's not yet wired
+====================
+
+* Per-column nullability inside ``Option<TB>`` --- ``o.Total``
+  doesn't compile on Option, and ``o |> unwrap_or(default).Total``
+  isn't translated yet. For per-column NULL handling drop to raw
+  SQL or restructure with two queries.
+
+What's not shipped (locked)
+===========================
+
+* ``_right_join`` --- trivially ``_left_join`` with swapped sources
+* ``_full_outer_join`` --- rare
+* ``_cross_join`` --- accidental footgun in macro form
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/16-left_join.das <../../../../tutorials/sql/16-left_join.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_join`
+
+    Next tutorial: :ref:`tutorial_sql_subqueries`

--- a/doc/source/reference/tutorials/sql_17_subqueries.rst
+++ b/doc/source/reference/tutorials/sql_17_subqueries.rst
@@ -1,0 +1,87 @@
+.. _tutorial_sql_subqueries:
+
+==========================================
+SQL-17 --- Subqueries
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; _in
+    single: Tutorial; _not_in
+    single: Tutorial; _any
+    single: Tutorial; _none
+    single: Tutorial; subquery
+    single: Tutorial; IN
+    single: Tutorial; EXISTS
+
+Four ``daslib/linq_boost`` macros lower to SQL's IN / NOT IN /
+EXISTS / NOT EXISTS forms when used inside a ``_where`` predicate
+under ``_sql(...)``:
+
+==========================================  =============================================
+Source shape                                Emitted SQL
+==========================================  =============================================
+``x._in(subquery)``                         ``<x> IN (<subquery-sql>)``
+``x._not_in(subquery)``                     ``<x> NOT IN (<subquery-sql>)``
+``subquery._any()``                         ``EXISTS (<subquery-sql>)``
+``subquery._any(predicate)``                ``EXISTS (... WHERE <predicate>)``
+``subquery._none()``                        ``NOT EXISTS (<subquery-sql>)``
+``subquery._none(predicate)``               ``NOT EXISTS (... WHERE <predicate>)``
+==========================================  =============================================
+
+Why explicit positive/negative names
+====================================
+
+Negated forms have **explicit names** (``_not_in``, ``_none``)
+rather than ``!_in(...)`` / ``!_any(...)``. The ``_sql`` AST walker
+pattern-matches on the macro's textual name; a leading ``!`` would
+require deep AST walking that fights with daslang's expansion order.
+Expect this convention to repeat for any future predicate primitive
+with a negated form.
+
+IN / NOT IN with a single-column subquery
+==========================================
+
+For IN-style subqueries, project a single column with
+``_select(_.Col)`` so the IN list shape matches.
+
+.. code-block:: das
+
+    let with_orders <- _sql(db |> select_from(type<User>)
+                              |> _where(_.Id._in(db |> select_from(type<Order>) |> _select(_.UserId))))
+    // SELECT "Id", "Name", "Active" FROM "Users"
+    //   WHERE "Id" IN (SELECT "UserId" FROM "Orders")
+
+    let no_orders <- _sql(db |> select_from(type<User>)
+                            |> _where(_.Id._not_in(db |> select_from(type<Order>) |> _select(_.UserId))))
+    // ... WHERE "Id" NOT IN (...)
+
+EXISTS / NOT EXISTS
+===================
+
+.. code-block:: das
+
+    let some_big <- _sql(db |> select_from(type<User>)
+                           |> _where((db |> select_from(type<Order>))._any(_.Total > 200)))
+    // ... WHERE EXISTS (SELECT ... FROM "Orders" WHERE "Total" > ?)
+
+    let no_huge <- _sql(db |> select_from(type<User>)
+                          |> _where((db |> select_from(type<Order>))._none(_.Total > 1000)))
+    // ... WHERE NOT EXISTS (SELECT ... FROM "Orders" WHERE "Total" > ?)
+
+Uncorrelated only (chunk 5)
+===========================
+
+Chunk 5 ships **uncorrelated** subqueries --- the inner WHERE
+references only the subquery's own row (``_``), not outer columns.
+Correlated subqueries (referring to outer columns from inside the
+subquery's WHERE) land in a follow-up.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/17-subqueries.das <../../../../tutorials/sql/17-subqueries.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_left_join`
+
+    Next tutorial: :ref:`tutorial_sql_null_handling`

--- a/doc/source/reference/tutorials/sql_18_null_handling.rst
+++ b/doc/source/reference/tutorials/sql_18_null_handling.rst
@@ -169,4 +169,4 @@ to the outer success/failure wrapper:
 
     Full source: :download:`tutorials/sql/18-null_handling.das <../../../../tutorials/sql/18-null_handling.das>`
 
-    Previous tutorial: :ref:`tutorial_sql_group_by`
+    Previous tutorial: :ref:`tutorial_sql_subqueries`

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -87,10 +87,61 @@ enum private ProjectionShape {
     GroupedNamedTuple   //!< `_select` after `_group_by`: tuple of group keys + group-scope aggregates
 }
 
+enum private JoinKind {
+    Inner   //!< INNER JOIN — `_join` macro
+    Left    //!< LEFT JOIN — `_left_join` macro; right-side row is `Option<TB>`
+}
+
+enum private SetOpKind {
+    None       //!< no set operation in the chain
+    // Compound queries are emitted WITHOUT surrounding parens — SQLite parses
+    // a per-side `ORDER BY` / `LIMIT` / `OFFSET` as a syntax error in that
+    // shape, which is why chunk 5 rejects those stages on either side. Per-
+    // side parens (and the corresponding compound-trailing-clause support)
+    // are deferred to a future chunk.
+    Union      //!< `union(a, b)`     → `<a> UNION <b>`
+    Intersect  //!< `intersect(a, b)` → `<a> INTERSECT <b>`
+    Except     //!< `except(a, b)`    → `<a> EXCEPT <b>`
+}
+
+struct private JoinSpec {
+    //! Single `_join` / `_left_join` recognized by chunk 5: the root source
+    //! is alias `t0`, the joined source is alias `t1`. `process_join_call`
+    //! rejects a second join in the same chain (3+ table joins are deferred
+    //! to a future chunk). The `joins : array<JoinSpec>` field on `SqlQuery`
+    //! holds the future shape — chunk 5 fills at most one entry.
+    kind        : JoinKind
+    rootType    : TypeDeclPtr     //!< right-side row type
+    tableName   : string          //!< right-side table name (unquoted)
+    alias       : string          //!< right-side alias (currently always `t1`)
+    leftCol     : string          //!< left side of equi-join `on` (field name on the LEFT source)
+    leftAlias   : string          //!< alias of the LEFT source (currently always `t0`)
+    rightCol    : string          //!< right side of equi-join `on` (field name on the JOINED source)
+    // Right-side `_where` filter — emitted into the JOIN's `ON` clause
+    // (NOT the outer WHERE) as `... ON t0.k = t1.k AND (rightWhereSql)`.
+    // Required for `LEFT JOIN`: a per-row predicate in the outer WHERE
+    // would filter out NULL-extended unmatched rows and silently turn
+    // LEFT JOIN into INNER JOIN. INNER JOIN uses the same ON-clause path
+    // for consistency (semantically equivalent to a WHERE merge for INNER,
+    // but more idiomatic SQL and stable across query planners).
+    rightWhereSql     : string
+    // Right-side bind exprs are stored per-JoinSpec rather than appended
+    // to outer q.bindExprs, because ON binds must precede outer-WHERE
+    // binds in the runtime placeholder order (`SELECT ... ON ?_on ...
+    // WHERE ?_outer`). The runtime bind builder concatenates them in this
+    // order: per-join ON binds (in join order) → outer WHERE → HAVING →
+    // LIMIT/OFFSET.
+    rightOnBindExprs  : array<ExpressionPtr>
+}
+
 struct private SqlQuery {
     rootType    : TypeDeclPtr
     tableName   : string
-    selectCols  : array<string>           //!< SingleColumn / FullRow / NamedTuple: column names (quoted in SQL)
+    rootAlias   : string                  //!< `""` in single-source mode; `"t0"` once a join is peeled (see seenJoin)
+    selectCols  : array<string>           //!< SingleColumn / FullRow / NamedTuple: column names (quoted in SQL); empty entry when the column is a computed expression (selectColSqlFragments[i] holds the SQL).
+    selectColAliases : array<string>      //!< multi-source: alias for each column's owning source (parallel to selectCols); empty for single-source columns and for computed expressions.
+    selectColTypes : array<TypeDeclPtr>   //!< multi-source: the RESOLVED column type (already field-looked-up). Used by build_row_builder directly — no further lookup needed. Empty in single-source mode (build_row_builder falls back to q.rootType + lookup_struct_field_type).
+    selectColSqlFragments : array<string> //!< multi-source: precomputed SQL fragment for non-trivial projection values (e.g. `"t1"."Id" IS NOT NULL` for `o |> is_some`). Empty entry → emit `"alias"."col"` from selectColAliases/selectCols.
     projRecordNames : array<string>       //!< NamedTuple: per-column tuple field names (parallel to selectCols)
     aggregateExpr : string                //!< Aggregate: raw SELECT-list text (e.g. "COUNT(*)")
     aggregateType : TypeDeclPtr           //!< Aggregate: resolved scalar result type; varies by aggregate expression (int for COUNT, double for AVG, column type for SUM/MIN/MAX)
@@ -117,7 +168,86 @@ struct private SqlQuery {
     seenGroupBy : bool                    //!< _group_by seen — group-scope context for downstream _select / _having
     seenHaving  : bool                    //!< duplicate-stage guard for _having
     inHaving    : bool                    //!< pred_to_sql writes binds to havingBindExprs while this is true
+    seenJoin    : bool                    //!< multi-source mode flag (any join peeled) — qualifies column refs as `"talias"."Col"`
+    joins       : array<JoinSpec>         //!< joined sources in chain order
+    setOpKind     : SetOpKind = SetOpKind.None  //!< set-op (UNION/INTERSECT/EXCEPT) wrapping the LHS query
+    setOpRhsSql   : string                 //!< RHS query's SQL string (already built via build_sql_string on the sub-q)
+    seenSetOp     : bool                  //!< guard: only one set-op per chain in chunk 5 (chained set-ops are deferred)
+    // Lambda-arg → source-idx binding stack. Populated transiently around
+    // `analyze_predicate` / `analyze_projection` calls to teach `pred_to_sql`
+    // / projection analyzers which source a 2-arg `into` lambda's named
+    // parameters refer to. Single-source mode keeps this empty (`_` in
+    // `_where` predicates always means source 0; we don't need a mapping).
+    argNames    : array<string>
+    argSourceIdx : array<int>             //!< parallel to argNames
     dbExpr      : ExpressionPtr
+}
+
+// ============================================================================
+// Multi-source column qualification helpers.
+//
+// Single-source mode emits unqualified `"Col"`. Multi-source mode (any join
+// peeled) emits `"talias"."Col"` so column refs are unambiguous when
+// SQLite's planner sees JOIN clauses.
+//
+// `column_sql_for_alias(alias, field)` is the single emission point that
+// every column-ref site routes through. Callers compute the alias via
+// `source_alias_for_idx(q, idx)` (idx 0 = root, 1+ = join idx 0+) and pass
+// the alias here.
+// ============================================================================
+
+[macro_function]
+def private source_alias_for_idx(q : SqlQuery; idx : int) : string {
+    //! Alias of source `idx`: 0 = root (`q.rootAlias`), 1.. = `q.joins[idx-1].alias`.
+    //! Returns `""` when no rootAlias is set (single-source mode); a non-empty
+    //! rootAlias is the alias-emission signal, not `q.seenJoin` — the right-
+    //! side subQ analyzed by `process_join_call` has `rootAlias = "t1"` but
+    //! `seenJoin = false` (see process_join_call step 3).
+    if (empty(q.rootAlias)) {
+        return ""
+    }
+    if (idx == 0) {
+        return q.rootAlias
+    }
+    return q.joins[idx - 1].alias
+}
+
+[macro_function]
+def private source_rootType_for_idx(var q : SqlQuery&; idx : int) : TypeDeclPtr {
+    //! Look up the rootType (struct TypeDecl) of source `idx`. Source 0 is
+    //! `q.rootType`; sources 1.. live on `q.joins[idx-1].rootType`. Used by
+    //! `build_row_builder` for column-type lookup in multi-source projections.
+    //! `var q&` is required because daslang's const-q field access yields
+    //! `TypeDecl const?` (pointer-to-const), incompatible with the
+    //! `lookup_struct_field_type` signature.
+    if (idx == 0) {
+        return q.rootType
+    }
+    return q.joins[idx - 1].rootType
+}
+
+[macro_function]
+def private column_sql_for_alias(alias : string; field : string) : string {
+    //! Format a column SQL fragment. Empty alias → unqualified `"Col"` (single-
+    //! source mode). Non-empty alias → `"talias"."Col"`.
+    if (empty(alias)) {
+        return "\"{field}\""
+    }
+    return "\"{alias}\".\"{field}\""
+}
+
+[macro_function]
+def private lookup_arg_source(q : SqlQuery; argName : string) : int {
+    //! Resolve a lambda-arg name to its source index. Returns -1 if not
+    //! bound (caller falls back to source 0 in single-source mode, or
+    //! emits a macro_error in multi-source mode).
+    let n = length(q.argNames)
+    for (i in range(n)) {
+        if (q.argNames[i] == argName) {
+            return q.argSourceIdx[i]
+        }
+    }
+    return -1
 }
 
 // ============================================================================
@@ -250,6 +380,200 @@ def private peel_column_aggregate(var node : ExpressionPtr; var q : SqlQuery&;
     q.proj = ProjectionShape.Aggregate
     q.matr = Materializer.One
     q.seenTerminal = true
+    return true
+}
+
+[macro_function]
+def private extract_key_selector_field(var keyLambda : ExpressionPtr; expectedArgName : string;
+                                       prog : ProgramPtr; at : LineInfo) : string {
+    //! Pull the `<arg>.<field>` out of a 1-arg key-selector lambda body.
+    //! `linq_boost`'s `_join`/`_left_join` macro renames the arg to a
+    //! fresh `__la__` / `__lb__` symbol; we accept that exact name (passed
+    //! in via `expectedArgName`) and reject anything else loud — the only
+    //! supported equi-join shape is `(l, r) => l.X == r.Y`, and the macro
+    //! has already validated it. This step extracts the column name.
+    if (keyLambda == null || !(keyLambda is ExprMakeBlock)) {
+        macro_error(prog, at, "_sql: _join key selector has unexpected shape (not a lambda)")
+        return ""
+    }
+    var mblk = keyLambda as ExprMakeBlock
+    var blk = mblk._block as ExprBlock
+    if (blk == null || blk.arguments |> length != 1 || blk.list |> length != 1) {
+        macro_error(prog, at, "_sql: _join key selector lambda must take exactly one arg with a single return")
+        return ""
+    }
+    if (!(blk.list[0] is ExprReturn)) {
+        macro_error(prog, at, "_sql: _join key selector lambda body must be a single return")
+        return ""
+    }
+    var ret = blk.list[0] as ExprReturn
+    var argName : string
+    var fieldName : string
+    if (!extract_arg_field(ret.subexpr, argName, fieldName)) {
+        macro_error(prog, at, "_sql: _join key selector body must be `<arg>.Field` (column ref); computed key expressions are not yet translatable to SQL — use raw SQL or restructure the join")
+        return ""
+    }
+    if (argName != expectedArgName) {
+        macro_error(prog, at, "_sql: _join key selector references arg `{argName}`, expected `{expectedArgName}` — the on-clause must read `(l, r) => l.X == r.Y` referring to the join's own params, not outer captures")
+        return ""
+    }
+    return fieldName
+}
+
+[macro_function]
+def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
+                              kind : JoinKind; prog : ProgramPtr; at : LineInfo) : bool {
+    //! Shared body for `_join` (INNER) and `_left_join` (LEFT) peels.
+    //!
+    //! Post-expansion shape from `daslib/linq_boost`:
+    //!   join(srca, srcb, $(__la__:TA) => __la__.X, $(__lb__:TB) => __lb__.Y, into_lambda)
+    //!   left_join(...)  — same 5-arg shape
+    //!
+    //! Steps:
+    //!  1. Mark multi-source mode (q.seenJoin, q.rootAlias = "t0").
+    //!  2. Recurse into srca (populates q.rootType, q.tableName, processes
+    //!     any pre-join `_where` with qualified column refs).
+    //!  3. Build a sub-`SqlQuery` for srcb with its own pre-set rootAlias
+    //!     ("t1"), recurse to analyze it. The right side accepts only
+    //!     `select_from(type<T>)` plus optional `_where(...)`; aggregates,
+    //!     `_group_by`, `_select`, terminals, and nested joins are rejected.
+    //!  4. Construct a `JoinSpec` from the sub-q's rootType / tableName /
+    //!     whereSql. Extract the equi-join field names from keya / keyb.
+    //!     Push the JoinSpec and keep the right-side `_where` SQL on
+    //!     `spec.rightWhereSql` (emitted in the JOIN's `ON ... AND (...)`
+    //!     clause, NOT outer WHERE — required for LEFT JOIN, used uniformly
+    //!     for INNER too) and its binds on `spec.rightOnBindExprs`. The
+    //!     emit-time bind builder concatenates pools in SQL clause order:
+    //!     per-join ON binds (in join order) → outer WHERE → HAVING →
+    //!     LIMIT/OFFSET, so placeholder indices line up with
+    //!     `... ON keyEq AND (rightWhereSql) ... WHERE (outer) ...`.
+    //!  5. Process the `into` projection: bind its 2 lambda args to source
+    //!     0 / source 1, then run analyze_projection on the body.
+    if (q.seenJoin) {
+        macro_error(prog, at, "_sql: only one join per chain (3+ table joins are not yet supported in chunk 5; chain multiple two-table joins or use raw SQL)")
+        return false
+    }
+    if (q.seenSelect) {
+        macro_error(prog, at, "_sql: _join must precede `_select` in source order — the join's `into` lambda is the projection. Drop the trailing `_select(...)` or restructure the chain.")
+        return false
+    }
+    if (q.seenGroupBy) {
+        macro_error(prog, at, "_sql: _join cannot follow `_group_by` (joining grouped rows is not yet supported); group AFTER the join instead")
+        return false
+    }
+    if (length(jCall.arguments) != 5) {
+        macro_error(prog, at, "_sql: _join expected 5 args (srca, srcb, keya, keyb, into) post-expansion; got {length(jCall.arguments)}")
+        return false
+    }
+    q.seenJoin = true
+    q.rootAlias = "t0"
+
+    // 2. Recurse into srca — populates q.rootType, q.tableName, processes
+    //    any inner `_where`. Inner `_where`'s pred_to_sql emits qualified
+    //    column refs (`"t0"."Col"`) because q.seenJoin is now true.
+    if (!analyze_chain(jCall.arguments[0], q, prog, at)) {
+        return false
+    }
+
+    // 3. Build sub-q for srcb. Pre-set rootAlias = "t1" so its inner
+    //    `_where` peel emits qualified columns from the start. We
+    //    deliberately do NOT pre-set `subQ.seenJoin = true` here:
+    //    `seenJoin` also gates projection parsing (multi-source arg-name
+    //    lookup via `q.argNames`) and join-duplicate guards, so forcing
+    //    it on the subQ would surface confusing errors for inner stages
+    //    that we already reject post-hoc (e.g. `_select` on the right
+    //    side). Column qualification is driven by `!empty(q.rootAlias)`
+    //    in `pred_to_sql` — the alias-emission signal is independent of
+    //    "this query contains a join".
+    var subQ = SqlQuery()
+    subQ.rootAlias = "t1"
+    if (!analyze_chain(jCall.arguments[1], subQ, prog, at)) {
+        return false
+    }
+    // Reject right-side stages we don't yet support.
+    if (subQ.seenGroupBy || !empty(subQ.havingSql)) {
+        macro_error(prog, at, "_sql: _join right side cannot use `_group_by` / `_having`")
+        return false
+    }
+    if (subQ.seenDistinct) {
+        macro_error(prog, at, "_sql: _join right side cannot use `distinct()` (apply to the joined result instead)")
+        return false
+    }
+    if (subQ.seenSelect) {
+        macro_error(prog, at, "_sql: _join right side cannot use `_select(...)` — the join's `into` lambda projects from both sources")
+        return false
+    }
+    if (subQ.seenTerminal || subQ.seenToArray) {
+        macro_error(prog, at, "_sql: _join right side cannot have a terminal (`_first`, `_count`, `_to_array`, etc.)")
+        return false
+    }
+    if (subQ.limitBindExpr != null || subQ.offsetBindExpr != null) {
+        macro_error(prog, at, "_sql: _join right side cannot use `take(n)` / `skip(n)`")
+        return false
+    }
+    if (subQ.seenOrderBy) {
+        macro_error(prog, at, "_sql: _join right side cannot use `_order_by` (apply to the joined result instead)")
+        return false
+    }
+    if (subQ.seenJoin && length(subQ.joins) > 0) {
+        macro_error(prog, at, "_sql: _join right side cannot itself contain a join (3+ table joins not yet supported)")
+        return false
+    }
+
+    // 4. Construct JoinSpec.
+    var spec <- default<JoinSpec>
+    spec.kind = kind
+    spec.rootType = subQ.rootType
+    spec.tableName = subQ.tableName
+    spec.alias = "t1"
+    spec.leftAlias = "t0"
+    spec.leftCol = extract_key_selector_field(jCall.arguments[2], "__la__", prog, at)
+    if (empty(spec.leftCol)) {
+        return false
+    }
+    spec.rightCol = extract_key_selector_field(jCall.arguments[3], "__lb__", prog, at)
+    if (empty(spec.rightCol)) {
+        return false
+    }
+    spec.rightWhereSql = subQ.whereSql
+    // Hold right-side WHERE binds on the JoinSpec (NOT the outer q.bindExprs)
+    // — the runtime bind builder concatenates per-join ON binds first, then
+    // outer WHERE / HAVING / LIMIT / OFFSET, so the placeholder index lines
+    // up with `... ON keyEq AND (rightWhereSql) ... WHERE (outer)`.
+    spec.rightOnBindExprs |> reserve(length(subQ.bindExprs))
+    for (b in subQ.bindExprs) {
+        spec.rightOnBindExprs |> push <| clone_expression(b)
+    }
+    q.joins |> emplace(spec)
+
+    // 5. Process `into` projection — 2-arg lambda; bind arg0 → source 0,
+    //    arg1 → source 1, then run analyze_projection on the body.
+    var intoLambda = jCall.arguments[4]
+    if (intoLambda == null || !(intoLambda is ExprMakeBlock)) {
+        macro_error(prog, at, "_sql: _join `into` projection has unexpected shape (not a lambda)")
+        return false
+    }
+    var imblk = intoLambda as ExprMakeBlock
+    var iblk = imblk._block as ExprBlock
+    if (iblk == null || iblk.arguments |> length != 2 || iblk.list |> length != 1
+            || !(iblk.list[0] is ExprReturn)) {
+        macro_error(prog, at, "_sql: _join `into` lambda must take 2 args with a single return")
+        return false
+    }
+    var iret = iblk.list[0] as ExprReturn
+    let arg0Name = string(iblk.arguments[0].name)
+    let arg1Name = string(iblk.arguments[1].name)
+    q.argNames |> push(arg0Name)
+    q.argSourceIdx |> push(0)
+    q.argNames |> push(arg1Name)
+    q.argSourceIdx |> push(1)
+    let projOk = analyze_projection(iret.subexpr, q, prog, at)
+    q.argNames |> clear
+    q.argSourceIdx |> clear
+    if (!projOk) {
+        return false
+    }
+    q.seenSelect = true
     return true
 }
 
@@ -643,6 +967,167 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
         }
     }
 
+    // Peel set operations: union(a, b) / intersect(a, b) / except(a, b).
+    // The LHS chain populates the outer `q`; the RHS chain analyzes into a
+    // sub-q whose SQL string + binds get stored on the outer q. Restrict to
+    // one set-op per chain (chained set-ops would need parenthesization
+    // bookkeeping not yet wired). LHS may already have joins / WHERE /
+    // _select / etc. — set-op wraps the WHOLE LHS query.
+    //
+    // RHS rejections (`seenTerminal`/`distinctFlag`/`limitBindExpr`/etc.)
+    // happen via the same checks used for subquery analyzers — set-op
+    // RHS is essentially another subquery that must be a complete SELECT.
+    {
+        var soKind = SetOpKind.None
+        var soCall : ExprCall?
+        var uCall = match_linq_call(node, "union")
+        if (uCall != null) {
+            soCall = uCall
+            soKind = SetOpKind.Union
+        } else {
+            var iCall = match_linq_call(node, "intersect")
+            if (iCall != null) {
+                soCall = iCall
+                soKind = SetOpKind.Intersect
+            } else {
+                var eCall = match_linq_call(node, "except")
+                if (eCall != null) {
+                    soCall = eCall
+                    soKind = SetOpKind.Except
+                }
+            }
+        }
+        if (soCall != null) {
+            if (q.seenSetOp) {
+                macro_error(prog, at, "_sql: only one set-op (UNION / INTERSECT / EXCEPT) per chain (chained set-ops are deferred)")
+                return false
+            }
+            if (soCall.arguments |> length != 2) {
+                macro_error(prog, at, "_sql: union/intersect/except expected 2 args (lhs, rhs) post-expansion")
+                return false
+            }
+            // Recurse into LHS — fills q with the left query.
+            if (!analyze_chain(soCall.arguments[0], q, prog, at)) {
+                return false
+            }
+            // Set-op SQL is emitted as `<inner-LHS> UNION <inner-RHS>` with no
+            // surrounding parens, so SQLite parses any per-side `ORDER BY` /
+            // `LIMIT` / `OFFSET` as a syntax error ("ORDER BY clause should
+            // come after UNION not before"). Reject those stages on either
+            // side in chunk 5; compound-query semantics (per-side parens or a
+            // single trailing ORDER BY/LIMIT) are deferred.
+            if (q.seenOrderBy) {
+                macro_error(prog, at, "_sql: set-op LHS cannot use `_order_by` (apply to the combined set-op result instead; chunk 5)")
+                return false
+            }
+            if (q.limitBindExpr != null || q.offsetBindExpr != null) {
+                macro_error(prog, at, "_sql: set-op LHS cannot use `take(n)` / `skip(n)` (chunk 5)")
+                return false
+            }
+            // Recurse into RHS in a fresh sub-q; reject set-ops within set-ops.
+            var subQ = SqlQuery()
+            if (!analyze_chain(soCall.arguments[1], subQ, prog, at)) {
+                return false
+            }
+            if (subQ.seenSetOp || subQ.setOpKind != SetOpKind.None) {
+                macro_error(prog, at, "_sql: set-ops cannot themselves contain set-ops (chunk 5)")
+                return false
+            }
+            if (subQ.seenTerminal || subQ.seenToArray) {
+                macro_error(prog, at, "_sql: set-op RHS cannot have terminals (`_first`, `_to_array`, etc.)")
+                return false
+            }
+            if (subQ.seenOrderBy) {
+                macro_error(prog, at, "_sql: set-op RHS cannot use `_order_by` (apply to the combined set-op result instead; chunk 5)")
+                return false
+            }
+            if (subQ.limitBindExpr != null || subQ.offsetBindExpr != null) {
+                macro_error(prog, at, "_sql: set-op RHS cannot use `take(n)` / `skip(n)` (chunk 5)")
+                return false
+            }
+            let rhsSql = build_sql_string(subQ)
+            // Compound-query bind ordering must follow SQL clause order:
+            // LHS(on → where → having) then RHS(on → where → having). The
+            // outer-q finalizer (in emit_sql_macro_body) prepends q.joins'
+            // ON binds and appends q.havingBindExprs to q.bindExprs at SQL
+            // emit time — that pattern is correct for a single SELECT, but
+            // for `<lhs> UNION <rhs>` we have to flatten *both* sides here
+            // and clear the per-pool sources so the finalizer doesn't re-
+            // prepend / re-append already-folded LHS binds and end up with
+            // double-binds and mis-ordered placeholders.
+            //
+            // After this block, q.bindExprs holds the COMPLETE flat bind
+            // list for the compound query, and q.joins[*].rightOnBindExprs
+            // / q.havingBindExprs are empty.
+            var folded : array<ExpressionPtr>
+            var foldedCount = 0
+            for (j in q.joins) {
+                foldedCount += length(j.rightOnBindExprs)
+            }
+            for (j in subQ.joins) {
+                foldedCount += length(j.rightOnBindExprs)
+            }
+            folded |> reserve(foldedCount + length(q.bindExprs) + length(q.havingBindExprs)
+                            + length(subQ.bindExprs) + length(subQ.havingBindExprs))
+            // LHS: on → where → having
+            for (j in q.joins) {
+                for (b in j.rightOnBindExprs) {
+                    folded |> push(b)
+                }
+            }
+            for (b in q.bindExprs) {
+                folded |> push(b)
+            }
+            for (b in q.havingBindExprs) {
+                folded |> push(b)
+            }
+            // Clear LHS per-pool sources — the finalizer must not re-prepend
+            // these. q.joins itself stays (the FROM/SELECT emitter walks it
+            // for JOIN clauses), only its bind pools are emptied.
+            for (j in q.joins) {
+                j.rightOnBindExprs |> clear
+            }
+            q.havingBindExprs |> clear
+            // RHS: on → where → having (RHS bindings come AFTER LHS in the
+            // SQL `<lhs> UNION <rhs>` placeholder order).
+            for (j in subQ.joins) {
+                for (b in j.rightOnBindExprs) {
+                    folded |> push <| clone_expression(b)
+                }
+            }
+            for (b in subQ.bindExprs) {
+                folded |> push <| clone_expression(b)
+            }
+            for (b in subQ.havingBindExprs) {
+                folded |> push <| clone_expression(b)
+            }
+            q.bindExprs <- folded
+            q.setOpKind = soKind
+            q.setOpRhsSql = rhsSql
+            q.seenSetOp = true
+            return true
+        }
+    }
+
+    // Peel join(srca, srcb, keya, keyb, into) — post-expansion of `_join`
+    // (linq_boost's macro splits the equi-join `on` into keya/keyb selectors).
+    {
+        var jCall = match_linq_call(node, "join")
+        if (jCall != null) {
+            return process_join_call(jCall, q, JoinKind.Inner, prog, at)
+        }
+    }
+
+    // Peel left_join(...) — post-expansion of `_left_join`. Same 5-arg shape
+    // as `join` but the `into` lambda's right param is `Option<TB>`; under
+    // `_sql` the right-side columns become NULL on no-match rows.
+    {
+        var ljCall = match_linq_call(node, "left_join")
+        if (ljCall != null) {
+            return process_join_call(ljCall, q, JoinKind.Left, prog, at)
+        }
+    }
+
     // Bottom: select_from(db, type<T>) — plain function in sqlite_boost.
     {
         var dbE : ExpressionPtr
@@ -681,6 +1166,81 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
 // ============================================================================
 
 [macro_function]
+def private extract_arg_field(var node : ExpressionPtr; var argName : string&; var fieldName : string&) : bool {
+    //! Extract `<argName>.<fieldName>` from an ExprField-rooted-at-ExprVar node.
+    //! Peels ExprRef2Value wrappers. Returns true on match; populates the
+    //! out-strings via reference. Used by analyze_projection / pred_to_sql to
+    //! handle both single-source (`_.Col`) and multi-source (`u.Col`) shapes
+    //! through one extractor.
+    var n = peel_ref2val(node)
+    if (n == null || !(n is ExprField)) {
+        return false
+    }
+    var ef = n as ExprField
+    var recv = peel_ref2val(ef.value)
+    if (recv == null || !(recv is ExprVar)) {
+        return false
+    }
+    argName = string((recv as ExprVar).name)
+    fieldName = string(ef.name)
+    return true
+}
+
+[macro_function]
+def private try_left_join_null_probe(var node : ExpressionPtr; q : SqlQuery;
+                                     var argName : string&; positive : bool) : string {
+    //! If `node` is a bare `ExprVar` whose name maps to a joined source
+    //! (idx > 0) AND that source is a LEFT JOIN, return the SQL fragment
+    //! that probes the right-side join key column for NULL-ness:
+    //!   positive = true  (`is_some`)  → `"alias"."rightCol" IS NOT NULL`
+    //!   positive = false (`is_none`)  → `"alias"."rightCol" IS NULL`
+    //! Returns "" otherwise — caller falls through to the default
+    //! is_some/is_none translation (which expects a column ref).
+    var n = peel_ref2val(node)
+    if (n == null || !(n is ExprVar)) {
+        return ""
+    }
+    if (!q.seenJoin) {
+        return ""
+    }
+    argName = string((n as ExprVar).name)
+    let srcIdx = lookup_arg_source(q, argName)
+    if (srcIdx <= 0) {
+        return ""
+    }
+    unsafe {
+        let spec & = q.joins[srcIdx - 1]
+        if (spec.kind != JoinKind.Left) {
+            return ""
+        }
+        if (positive) {
+            return "\"{spec.alias}\".\"{spec.rightCol}\" IS NOT NULL"
+        }
+        return "\"{spec.alias}\".\"{spec.rightCol}\" IS NULL"
+    }
+}
+
+[macro_function]
+def private resolve_proj_arg_to_source(q : SqlQuery; argName : string; prog : ProgramPtr; at : LineInfo) : int {
+    //! Map a projection-lambda arg name to its source idx. Single-source mode
+    //! accepts only `_` (idx 0). Multi-source mode looks up `q.argNames`
+    //! (populated transiently by the join peel) and macro_errors on miss.
+    if (!q.seenJoin) {
+        if (argName == "_") {
+            return 0
+        }
+        macro_error(prog, at, "_sql: _select projection refers to unbound arg `{argName}`; expected `_` in single-source mode")
+        return -1
+    }
+    let idx = lookup_arg_source(q, argName)
+    if (idx < 0) {
+        macro_error(prog, at, "_sql: _select projection refers to unbound arg `{argName}`; the `into` lambda's parameter names are the only valid receivers")
+        return -1
+    }
+    return idx
+}
+
+[macro_function]
 def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
     if (body == null) {
         macro_error(prog, at, "_sql: _select: missing projection")
@@ -696,20 +1256,37 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
         }
     }
 
-    // Single-column form: _.FieldName
+    // Single-column form: <argname>.FieldName  (`_` in single-source, `u`/`o` etc. after a join).
     {
+        var argName : string
         var fieldName : string
-        if (qmatch(body, _.$f(fieldName)).matched) {
+        if (extract_arg_field(body, argName, fieldName)) {
+            let srcIdx = resolve_proj_arg_to_source(q, argName, prog, at)
+            if (srcIdx < 0) {
+                return false
+            }
             q.selectCols |> clear
+            q.selectColAliases |> clear
+            q.selectColTypes |> clear
+            q.selectColSqlFragments |> clear
             q.selectCols |> push(fieldName)
+            if (q.seenJoin) {
+                q.selectColAliases |> push(source_alias_for_idx(q, srcIdx))
+                q.selectColSqlFragments |> push("")
+                let srcType = source_rootType_for_idx(q, srcIdx)
+                q.selectColTypes |> push(lookup_struct_field_type(srcType, fieldName))
+            }
             q.proj = ProjectionShape.SingleColumn
             return true
         }
     }
 
-    // Named-tuple form: (Name=_.Name, Price=_.Price). recordNames live on
-    // the inferred tuple type (TypeDecl.argNames) — the ExprMakeTuple's
-    // own recordNames vector isn't exposed to daslang.
+    // Named-tuple form: each value is either `<arg>.Field` (column ref) or
+    // a multi-source `is_some(arg)` / `is_none(arg)` (LEFT JOIN bool probe).
+    // `unwrap_or` and other Option<T> ops on whole-row Option<TB> are not
+    // yet supported (they require fragmenting unwrap_or's `default.Field`
+    // into per-column COALESCE — punted to follow-up work). recordNames
+    // live on the inferred tuple type's argNames.
     if (body is ExprMakeTuple) {
         var mkTup = body as ExprMakeTuple
         var tupT = mkTup._type
@@ -717,27 +1294,73 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
                 && length(tupT.argNames) > 0
                 && length(mkTup.values) == length(tupT.argNames)) {
             q.selectCols |> clear
+            q.selectColAliases |> clear
+            q.selectColTypes |> clear
+            q.selectColSqlFragments |> clear
             q.projRecordNames |> clear
             for (i in range(length(mkTup.values))) {
                 var val = mkTup.values[i]
                 if (val is ExprRef2Value) {
                     val = (val as ExprRef2Value).subexpr
                 }
+                var argName : string
                 var fieldName : string
-                if (qmatch(val, _.$f(fieldName)).matched) {
+                if (extract_arg_field(val, argName, fieldName)) {
+                    let srcIdx = resolve_proj_arg_to_source(q, argName, prog, at)
+                    if (srcIdx < 0) {
+                        return false
+                    }
                     q.selectCols |> push(fieldName)
                     q.projRecordNames |> push(string(tupT.argNames[i]))
-                } else {
-                    macro_error(prog, at, "_sql: _select named-tuple values must be `_.Field` shape; got: {describe(val)}")
-                    return false
+                    if (q.seenJoin) {
+                        q.selectColAliases |> push(source_alias_for_idx(q, srcIdx))
+                        q.selectColSqlFragments |> push("")
+                        let srcType = source_rootType_for_idx(q, srcIdx)
+                        q.selectColTypes |> push(lookup_struct_field_type(srcType, fieldName))
+                    }
+                    continue
                 }
+                // Multi-source computed projection: is_some(arg) / is_none(arg).
+                // Recognized only when one of the lambda args is a LEFT JOIN's
+                // Option<TB> param. The result type is inferred from the AST
+                // (`val._type`) — bool for is_some/is_none.
+                if (q.seenJoin && val is ExprCall) {
+                    var fcall = val as ExprCall
+                    // `fcall.func` may be unresolved when this projection
+                    // expression is reached pre-inference; fall back to the
+                    // textual call name (`fcall.name`) just like pred_to_sql /
+                    // fn_call_to_sql do for predicate-side calls.
+                    var fname = string(fcall.name)
+                    if (fcall.func != null) {
+                        fname = string(fcall.func.name)
+                        if (fcall.func.fromGeneric != null) {
+                            fname = string(fcall.func.fromGeneric.name)
+                        }
+                    }
+                    let argc = user_arg_count(fcall)
+                    if ((fname == "is_some" || fname == "is_none") && argc == 1) {
+                        var probeArg : string
+                        let frag = try_left_join_null_probe(fcall.arguments[0], q, probeArg, fname == "is_some")
+                        if (!empty(frag)) {
+                            q.selectCols |> push("")
+                            q.selectColAliases |> push("")
+                            q.selectColSqlFragments |> push(frag)
+                            q.projRecordNames |> push(string(tupT.argNames[i]))
+                            // Result type is bool for both.
+                            q.selectColTypes |> push(new TypeDecl(at = at, baseType = Type.tBool))
+                            continue
+                        }
+                    }
+                }
+                macro_error(prog, at, "_sql: _select named-tuple values must be `<arg>.Field` (column ref) or, after `_left_join`, `<arg> |> is_some` / `<arg> |> is_none` on the Option<TB> arg; got: {describe(val)}")
+                return false
             }
             q.proj = ProjectionShape.NamedTuple
             return true
         }
     }
 
-    macro_error(prog, at, "_sql: _select: supported shapes are `_.Field` (single column) and `(Name=_.Name, Price=_.Price)` (named tuple); got: {describe(body)}")
+    macro_error(prog, at, "_sql: _select: supported shapes are `<arg>.Field` (single column) and `(Name=<arg>.Name, Price=<arg>.Price)` (named tuple); got: {describe(body)}")
     return false
 }
 
@@ -1199,9 +1822,43 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
     }
 
     // Logical NOT  →  NOT (...)
+    //
+    // Special case: `_not_in` lowers to `!contains(subq, x)`; under daslang's
+    // type-inference ordering the inner `contains` call may not be resolved
+    // (call.func is null) at the time pred_to_sql recurses on it, even
+    // though `_in` (no leading `!`) is. Peek at the inner ExprCall's
+    // textual name (which is set on `ExprLooksLikeCall` even before typer
+    // overload resolution) and route to the subquery NOT IN emitter
+    // directly. Falls through to the generic `!expr` peel for other shapes.
     {
         var inner : ExpressionPtr
         if (qmatch(node, !$e(inner)).matched) {
+            if (inner != null && inner is ExprCall) {
+                var icall = inner as ExprCall
+                let iname = string(icall.name)
+                let iargc = user_arg_count(icall)
+                if (iname == "contains" && iargc == 2) {
+                    // Disambiguate string contains vs iterator contains by the
+                    // inferred type of the first arg (the subquery).
+                    var firstT = icall.arguments[0]._type
+                    if (firstT != null && (firstT.isIterator || firstT.isGoodArrayType)) {
+                        let xSql = pred_to_sql(icall.arguments[1], q, prog, at)
+                        var binds : array<ExpressionPtr>
+                        let subSql = analyze_subquery(icall.arguments[0], binds, prog, at, true)
+                        if (empty(subSql)) {
+                            return ""
+                        }
+                        for (b in binds) {
+                            if (q.inHaving) {
+                                q.havingBindExprs |> push <| clone_expression(b)
+                            } else {
+                                q.bindExprs |> push <| clone_expression(b)
+                            }
+                        }
+                        return "{xSql} NOT IN ({subSql})"
+                    }
+                }
+            }
             return "NOT ({pred_to_sql(inner, q, prog, at)})"
         }
     }
@@ -1259,11 +1916,48 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         }
     }
 
-    // Column reference: _.ColName  (ExprField rooted at lambda param `_`)
+    // Column reference: <argname>.ColName  (ExprField rooted at any lambda param).
+    // Single-source: emit unqualified `"Col"` (only `_` is bound).
+    // Multi-source: look up arg → source idx → emit `"talias"."Col"`. Unrecognized
+    // arg names in multi-source mode are a `macro_error` — they're either the
+    // group-key shape (`_._0`) handled below, or genuinely unbound (caller bug).
     {
-        var fieldName : string
-        if (qmatch(node, _.$f(fieldName)).matched) {
-            return "\"{fieldName}\""
+        var n2 = peel_ref2val(node)
+        if (n2 != null && n2 is ExprField) {
+            var ef = n2 as ExprField
+            var recv = peel_ref2val(ef.value)
+            if (recv != null && recv is ExprVar) {
+                let argName = string((recv as ExprVar).name)
+                let fieldName = string(ef.name)
+                // Alias-qualification is driven by `rootAlias` being non-
+                // empty, NOT by `seenJoin`. The two are intentionally
+                // decoupled: the right-side subQ analyzed by
+                // `process_join_call` runs with `rootAlias = "t1"` but
+                // `seenJoin = false` so `_where` in the inner chain qualifies
+                // columns ("t1"."Col") without dragging in multi-source
+                // projection-arg-lookup semantics.
+                if (!empty(q.rootAlias)) {
+                    var srcIdx = lookup_arg_source(q, argName)
+                    // Pre-join `_where` always references the root (source 0)
+                    // through `_`. The arg-binding stack is only populated
+                    // for the `into` projection's named 2-arg lambda; outside
+                    // that scope, treat `_` as source 0.
+                    if (srcIdx < 0 && argName == "_") {
+                        srcIdx = 0
+                    }
+                    if (srcIdx >= 0) {
+                        return column_sql_for_alias(source_alias_for_idx(q, srcIdx), fieldName)
+                    }
+                    // Not bound to any source — fall through to other patterns
+                    // (e.g. `_._0` group-key references which keep their own
+                    // recognition path below).
+                } else {
+                    // Single-source: only `_` is bound. Match the legacy emission.
+                    if (argName == "_") {
+                        return "\"{fieldName}\""
+                    }
+                }
+            }
         }
     }
 
@@ -1282,6 +1976,96 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
                 return ""   // helper emitted macro_error
             }
             return aggSql
+        }
+    }
+
+    // Unexpanded ExprCallMacro for `_in` / `_not_in` / `_any` / `_none`.
+    // Mode-2 expansion only recurses through call_macros and chain
+    // operators — when one of these macros lands inside a binary operator
+    // (`&&` / `||` / etc.) of a `_where` predicate, daslang doesn't deep-
+    // walk into the operator's children, so the macro stays in
+    // `ExprCallMacro` form. Recognize them here by the macro's name and
+    // emit the SQL fragment without going through expansion.
+    if (node is ExprCallMacro) {
+        var mcall = node as ExprCallMacro
+        let mname = string(mcall.name)
+        if ((mname == "_in" || mname == "_not_in") && length(mcall.arguments) == 2) {
+            // `x._in(subq)` / `x._not_in(subq)` — call_macro arg order is
+            // (element, subquery).
+            let xSql = pred_to_sql(mcall.arguments[0], q, prog, at)
+            var binds : array<ExpressionPtr>
+            let subSql = analyze_subquery(mcall.arguments[1], binds, prog, at, true)
+            if (empty(subSql)) {
+                return ""
+            }
+            for (b in binds) {
+                if (q.inHaving) {
+                    q.havingBindExprs |> push <| clone_expression(b)
+                } else {
+                    q.bindExprs |> push <| clone_expression(b)
+                }
+            }
+            if (mname == "_not_in") {
+                return "{xSql} NOT IN ({subSql})"
+            }
+            return "{xSql} IN ({subSql})"
+        }
+        if ((mname == "_any" || mname == "_none") && length(mcall.arguments) >= 1) {
+            // `subq._any()` / `subq._none()` (1 arg) or
+            // `subq._any(pred)` / `subq._none(pred)` (2 args, pred is a
+            // bare expression — the call_macro hasn't lambda-wrapped it
+            // yet because expansion didn't fire).
+            var subSql : string
+            var binds : array<ExpressionPtr>
+            if (length(mcall.arguments) == 1) {
+                subSql = analyze_subquery(mcall.arguments[0], binds, prog, at)
+            } else {
+                // Wrap the pred in a single-arg lambda manually, matching
+                // what `AstCallMacro_LinqPred2` would emit, then re-use
+                // analyze_subquery_with_pred. We don't actually have the
+                // expanded `(_:T) => pred` shape yet — but the inner
+                // analyze_predicate just walks the predicate AST, so we
+                // can pass a synthetic `ExprMakeBlock` wrapping the pred.
+                // Easier: build the subquery first, then call
+                // analyze_predicate directly on the bare pred expression.
+                var subQ = SqlQuery()
+                if (!analyze_chain(mcall.arguments[0], subQ, prog, at)) {
+                    return ""
+                }
+                if (subQ.seenJoin || length(subQ.joins) > 0) {
+                    macro_error(prog, at, "_sql: subqueries cannot themselves contain joins (chunk 5)")
+                    return ""
+                }
+                if (subQ.seenGroupBy || !empty(subQ.havingSql) || subQ.seenOrderBy
+                        || subQ.distinctFlag || subQ.limitBindExpr != null
+                        || subQ.offsetBindExpr != null || subQ.seenTerminal
+                        || subQ.seenToArray) {
+                    macro_error(prog, at, "_sql: _any/_none subquery must be a `select_from(...)` (chain stages and terminals are not yet allowed)")
+                    return ""
+                }
+                if (!analyze_predicate(mcall.arguments[1], subQ, prog, at)) {
+                    return ""
+                }
+                subSql = build_sql_string(subQ)
+                binds |> reserve(length(binds) + length(subQ.bindExprs))
+                for (b in subQ.bindExprs) {
+                    binds |> push <| clone_expression(b)
+                }
+            }
+            if (empty(subSql)) {
+                return ""
+            }
+            for (b in binds) {
+                if (q.inHaving) {
+                    q.havingBindExprs |> push <| clone_expression(b)
+                } else {
+                    q.bindExprs |> push <| clone_expression(b)
+                }
+            }
+            if (mname == "_none") {
+                return "NOT EXISTS ({subSql})"
+            }
+            return "EXISTS ({subSql})"
         }
     }
 
@@ -1348,16 +2132,136 @@ def private user_arg_count(call : ExprCall?) : int {
 }
 
 [macro_function]
+def private analyze_subquery(var subqExpr : ExpressionPtr; var binds : array<ExpressionPtr>&;
+                             prog : ProgramPtr; at : LineInfo; requireSingleColumn : bool = false) : string {
+    //! Recursively analyze a subquery chain (bare `select_from(type<T>)` or
+    //! `select_from(...) |> _where(...)` or `select_from(...) |> _select(_.Col)`)
+    //! and return its SQL string. Subquery WHERE binds are pushed to `binds`;
+    //! the caller appends them to outer `q.bindExprs` AT THE CALL SITE so the
+    //! placeholder index matches the SQL emission order (outer predicate's
+    //! own pred_to_sql may have already appended binds before us, and the
+    //! subquery's binds must come after).
+    //!
+    //! Reject subqueries that are correlated, grouped, ordered, distinct, or
+    //! have terminals — chunk-5 ships uncorrelated, single-source subqueries
+    //! only. Correlated subqueries (referring to outer columns inside the
+    //! subquery's WHERE) are deferred.
+    //!
+    //! `requireSingleColumn` is set by `_in` / `_not_in` callsites: SQLite
+    //! requires the inner SELECT to project exactly one column for `x IN (...)`,
+    //! and emits a runtime "sub-select returns N columns" error otherwise. We
+    //! reject at compile time so users see a `_sql` diagnostic instead of a
+    //! runtime panic. `_any` / `_none` use `EXISTS (...)` and don't care about
+    //! projection arity, so they leave `requireSingleColumn` at false.
+    var subQ = SqlQuery()
+    if (!analyze_chain(subqExpr, subQ, prog, at)) {
+        return ""
+    }
+    if (subQ.seenJoin || length(subQ.joins) > 0) {
+        macro_error(prog, at, "_sql: subqueries cannot themselves contain joins (chunk 5)")
+        return ""
+    }
+    if (subQ.seenGroupBy || !empty(subQ.havingSql)) {
+        macro_error(prog, at, "_sql: subqueries cannot use `_group_by` / `_having` (chunk 5)")
+        return ""
+    }
+    if (subQ.seenOrderBy || subQ.distinctFlag) {
+        macro_error(prog, at, "_sql: subqueries cannot use `_order_by` / `distinct()` (chunk 5)")
+        return ""
+    }
+    if (subQ.limitBindExpr != null || subQ.offsetBindExpr != null) {
+        macro_error(prog, at, "_sql: subqueries cannot use `take(n)` / `skip(n)` (chunk 5)")
+        return ""
+    }
+    if (subQ.seenTerminal || subQ.seenToArray) {
+        macro_error(prog, at, "_sql: subqueries cannot have terminals (`_first`, `_to_array`, `_count`, etc.)")
+        return ""
+    }
+    if (requireSingleColumn && subQ.proj != ProjectionShape.SingleColumn) {
+        macro_error(prog, at, "_sql: _in / _not_in subquery must project exactly one column via `_select(_.Col)` (got: {subQ.proj}); SQLite rejects multi-column subqueries on the right of IN")
+        return ""
+    }
+    let sql = build_sql_string(subQ)
+    binds |> reserve(length(binds) + length(subQ.bindExprs))
+    for (b in subQ.bindExprs) {
+        binds |> push <| clone_expression(b)
+    }
+    return sql
+}
+
+[macro_function]
+def private analyze_subquery_with_pred(var subqExpr : ExpressionPtr; var predLambda : ExpressionPtr;
+                                       var binds : array<ExpressionPtr>&;
+                                       prog : ProgramPtr; at : LineInfo) : string {
+    //! Like `analyze_subquery`, but injects an additional WHERE clause from
+    //! the predicate lambda body. Used for `any(subq, predLambda)` and
+    //! `none(subq, predLambda)`. The lambda's arg is bound to the subquery's
+    //! row (`_` always refers to source 0 of the subquery).
+    var subQ = SqlQuery()
+    if (!analyze_chain(subqExpr, subQ, prog, at)) {
+        return ""
+    }
+    if (subQ.seenJoin || length(subQ.joins) > 0) {
+        macro_error(prog, at, "_sql: subqueries cannot themselves contain joins (chunk 5)")
+        return ""
+    }
+    if (subQ.seenGroupBy || !empty(subQ.havingSql)) {
+        macro_error(prog, at, "_sql: subqueries cannot use `_group_by` / `_having` (chunk 5)")
+        return ""
+    }
+    if (subQ.seenOrderBy || subQ.distinctFlag) {
+        macro_error(prog, at, "_sql: subqueries cannot use `_order_by` / `distinct()` (chunk 5)")
+        return ""
+    }
+    if (subQ.limitBindExpr != null || subQ.offsetBindExpr != null) {
+        macro_error(prog, at, "_sql: subqueries cannot use `take(n)` / `skip(n)` (chunk 5)")
+        return ""
+    }
+    if (subQ.seenTerminal || subQ.seenToArray) {
+        macro_error(prog, at, "_sql: subqueries cannot have terminals (`_first`, `_to_array`, `_count`, etc.)")
+        return ""
+    }
+    var body = peel_lambda_body(predLambda)
+    if (body == null) {
+        macro_error(prog, at, "_sql: _any/_none predicate lambda has unexpected shape")
+        return ""
+    }
+    if (!analyze_predicate(body, subQ, prog, at)) {
+        return ""
+    }
+    let sql = build_sql_string(subQ)
+    binds |> reserve(length(binds) + length(subQ.bindExprs))
+    for (b in subQ.bindExprs) {
+        binds |> push <| clone_expression(b)
+    }
+    return sql
+}
+
+[macro_function]
 def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : string {
     //! Returns the SQL expression text for a recognized function call,
     //! or "" if the call name isn't in the dispatch table (caller falls
     //! through to literal/captured-var bind).
-    if (call == null || call.func == null) {
+    //!
+    //! Resolves the function name from `call.name` (the `ExprLooksLikeCall`
+    //! textual name, always set even before typer overload resolution) and
+    //! prefers the more-specific `call.func.fromGeneric.name` /
+    //! `call.func.name` when those are available. Using `call.name` as the
+    //! fallback lets us recognize calls whose overload hasn't been resolved
+    //! yet by the inferer — happens for `contains(...)` nested inside `&&`
+    //! / `!` predicates, where daslang fires the macro_function before the
+    //! inner call's typer pass completes.
+    if (call == null) {
         return ""
     }
-    var fname = string(call.func.name)
-    if (call.func.fromGeneric != null) {
-        fname = string(call.func.fromGeneric.name)
+    var fname : string
+    if (call.func != null) {
+        fname = string(call.func.name)
+        if (call.func.fromGeneric != null) {
+            fname = string(call.func.fromGeneric.name)
+        }
+    } else {
+        fname = string(call.name)
     }
     let argc = user_arg_count(call)
 
@@ -1373,12 +2277,20 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
         return "{lhs} LIKE '%' || {rhs}"
     }
     if (fname == "contains" && argc == 2) {
-        // linq.das also has `contains(array, T)` — we only translate the
-        // string form here; the array form (post-Mode-2-expansion of
-        // `array._contains(x)`) doesn't reach this codepath.
-        let lhs = pred_to_sql(call.arguments[0], q, prog, at)
-        let rhs = pred_to_sql(call.arguments[1], q, prog, at)
-        return "{lhs} LIKE '%' || {rhs} || '%'"
+        // Two `contains` overloads land here:
+        //   - string `contains(haystack, needle)` → LIKE pattern (chunk 3)
+        //   - array/iterator `contains(subquery, x)` → IN subquery
+        //     (chunk 5, post-expansion of `x._in(subq)`)
+        // Disambiguate by the first arg's type: iterator/array routes to
+        // the subquery handler below; string falls through here.
+        var firstT = call.arguments[0]._type
+        if (firstT != null && (firstT.isIterator || firstT.isGoodArrayType)) {
+            // Fall through to the subquery `contains` branch below.
+        } else {
+            let lhs = pred_to_sql(call.arguments[0], q, prog, at)
+            let rhs = pred_to_sql(call.arguments[1], q, prog, at)
+            return "{lhs} LIKE '%' || {rhs} || '%'"
+        }
     }
 
     // ---- Case folding ----
@@ -1408,11 +2320,28 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
     // explicit null-check operators. Always use IS NULL / IS NOT NULL —
     // `Col = NULL` is never true under SQL's three-valued logic, so the
     // typesafe path here is also the semantically correct one.
+    //
+    // Special case for `_left_join`: when the arg is a bare `ExprVar`
+    // referring to the join's `Option<TB>` parameter (source idx > 0),
+    // probe the join's right-key column for NULL-ness — the row missed
+    // its match exactly when that column came back NULL. Without this
+    // case, pred_to_sql would treat the bare arg as a captured var and
+    // bind it as `?`, producing semantically wrong SQL.
     if (fname == "is_some" && argc == 1) {
+        var argName : string
+        let nullProbe = try_left_join_null_probe(call.arguments[0], q, argName, true)
+        if (!empty(nullProbe)) {
+            return nullProbe
+        }
         let inner = pred_to_sql(call.arguments[0], q, prog, at)
         return "{inner} IS NOT NULL"
     }
     if (fname == "is_none" && argc == 1) {
+        var argName : string
+        let nullProbe = try_left_join_null_probe(call.arguments[0], q, argName, false)
+        if (!empty(nullProbe)) {
+            return nullProbe
+        }
         let inner = pred_to_sql(call.arguments[0], q, prog, at)
         return "{inner} IS NULL"
     }
@@ -1423,6 +2352,98 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
         let inner = pred_to_sql(call.arguments[0], q, prog, at)
         let dflt  = pred_to_sql(call.arguments[1], q, prog, at)
         return "COALESCE({inner}, {dflt})"
+    }
+
+    // ---- Subqueries ----
+    // `x._in(subquery)` post-expansion: `contains(subquery, x)`.
+    // `x._not_in(subquery)` post-expansion: `!contains(subquery, x)` —
+    // the leading `!` is handled by pred_to_sql's existing NOT peel
+    // before this function fires, recursing into `contains(...)` here.
+    // Subquery rules and rejections live in `analyze_subquery`.
+    if (fname == "contains" && argc == 2) {
+        let xSql = pred_to_sql(call.arguments[1], q, prog, at)
+        var binds : array<ExpressionPtr>
+        let subSql = analyze_subquery(call.arguments[0], binds, prog, at, true)
+        if (empty(subSql)) {
+            return ""
+        }
+        for (b in binds) {
+            if (q.inHaving) {
+                q.havingBindExprs |> push <| clone_expression(b)
+            } else {
+                q.bindExprs |> push <| clone_expression(b)
+            }
+        }
+        return "{xSql} IN ({subSql})"
+    }
+
+    // `subquery._any()` post-expansion: `any(subquery)` — emits `EXISTS (...)`.
+    // `subquery._any(pred)` post-expansion: `any(subquery, $(_:T) => pred)`
+    //   — emits `EXISTS (... WHERE pred)`.
+    if (fname == "any") {
+        if (argc == 1) {
+            var binds : array<ExpressionPtr>
+            let subSql = analyze_subquery(call.arguments[0], binds, prog, at)
+            if (empty(subSql)) {
+                return ""
+            }
+            for (b in binds) {
+                if (q.inHaving) {
+                    q.havingBindExprs |> push <| clone_expression(b)
+                } else {
+                    q.bindExprs |> push <| clone_expression(b)
+                }
+            }
+            return "EXISTS ({subSql})"
+        }
+        if (argc == 2) {
+            var binds : array<ExpressionPtr>
+            let subSql = analyze_subquery_with_pred(call.arguments[0], call.arguments[1], binds, prog, at)
+            if (empty(subSql)) {
+                return ""
+            }
+            for (b in binds) {
+                if (q.inHaving) {
+                    q.havingBindExprs |> push <| clone_expression(b)
+                } else {
+                    q.bindExprs |> push <| clone_expression(b)
+                }
+            }
+            return "EXISTS ({subSql})"
+        }
+    }
+    // `subquery._none()` / `_none(pred)` — same as `_any`, NOT EXISTS.
+    if (fname == "none") {
+        if (argc == 1) {
+            var binds : array<ExpressionPtr>
+            let subSql = analyze_subquery(call.arguments[0], binds, prog, at)
+            if (empty(subSql)) {
+                return ""
+            }
+            for (b in binds) {
+                if (q.inHaving) {
+                    q.havingBindExprs |> push <| clone_expression(b)
+                } else {
+                    q.bindExprs |> push <| clone_expression(b)
+                }
+            }
+            return "NOT EXISTS ({subSql})"
+        }
+        if (argc == 2) {
+            var binds : array<ExpressionPtr>
+            let subSql = analyze_subquery_with_pred(call.arguments[0], call.arguments[1], binds, prog, at)
+            if (empty(subSql)) {
+                return ""
+            }
+            for (b in binds) {
+                if (q.inHaving) {
+                    q.havingBindExprs |> push <| clone_expression(b)
+                } else {
+                    q.bindExprs |> push <| clone_expression(b)
+                }
+            }
+            return "NOT EXISTS ({subSql})"
+        }
     }
 
     return ""
@@ -1502,6 +2523,23 @@ def private sql_table_name_from_type(rootT : TypeDeclPtr) : string {
 
 [macro_function]
 def private build_sql_string(q : SqlQuery) : string {
+    let inner = build_sql_select(q)
+    if (q.setOpKind == SetOpKind.None) {
+        return inner
+    }
+    var op : string
+    if (q.setOpKind == SetOpKind.Union) {
+        op = "UNION"
+    } elif (q.setOpKind == SetOpKind.Intersect) {
+        op = "INTERSECT"
+    } else {
+        op = "EXCEPT"
+    }
+    return "{inner} {op} {q.setOpRhsSql}"
+}
+
+[macro_function]
+def private build_sql_select(q : SqlQuery) : string {
     return build_string() $(var w) {
         w |> write("SELECT ")
         if (q.distinctFlag) {
@@ -1523,14 +2561,72 @@ def private build_sql_string(q : SqlQuery) : string {
                 if (i > 0) {
                     w |> write(", ")
                 }
-                w |> write("\"")
-                w |> write(q.selectCols[i])
-                w |> write("\"")
+                // Multi-source: precomputed SQL fragments (e.g. `IS NOT
+                // NULL` probes) live in selectColSqlFragments; alias-
+                // qualified column refs use selectColAliases + selectCols.
+                // Single-source: emit unqualified `"Col"`.
+                if (q.seenJoin && i < length(q.selectColSqlFragments) && !empty(q.selectColSqlFragments[i])) {
+                    w |> write(q.selectColSqlFragments[i])
+                } elif (q.seenJoin && i < length(q.selectColAliases) && !empty(q.selectColAliases[i])) {
+                    w |> write("\"")
+                    w |> write(q.selectColAliases[i])
+                    w |> write("\".\"")
+                    w |> write(q.selectCols[i])
+                    w |> write("\"")
+                } else {
+                    w |> write("\"")
+                    w |> write(q.selectCols[i])
+                    w |> write("\"")
+                }
             }
         }
-        w |> write(" FROM \"")
-        w |> write(q.tableName)
-        w |> write("\"")
+        // FROM clause: alias the root table only when joins are present.
+        // Single-source mode keeps the existing unaliased `FROM "Tbl"` shape
+        // so all chunk-2/3/4 tests still match.
+        if (q.seenJoin) {
+            w |> write(" FROM \"")
+            w |> write(q.tableName)
+            w |> write("\" AS \"")
+            w |> write(q.rootAlias)
+            w |> write("\"")
+            for (j in q.joins) {
+                if (j.kind == JoinKind.Inner) {
+                    w |> write(" INNER JOIN \"")
+                } else {
+                    w |> write(" LEFT JOIN \"")
+                }
+                w |> write(j.tableName)
+                w |> write("\" AS \"")
+                w |> write(j.alias)
+                w |> write("\" ON \"")
+                w |> write(j.leftAlias)
+                w |> write("\".\"")
+                w |> write(j.leftCol)
+                w |> write("\" = \"")
+                w |> write(j.alias)
+                w |> write("\".\"")
+                w |> write(j.rightCol)
+                w |> write("\"")
+                // Right-side `_where` lives in the JOIN's ON clause (NOT the
+                // outer WHERE). Required for LEFT JOIN — a row-level filter
+                // in WHERE drops NULL-extended unmatched rows and silently
+                // turns LEFT JOIN into INNER JOIN. INNER JOIN uses the same
+                // placement for consistency / planner stability.
+                if (!empty(j.rightWhereSql)) {
+                    w |> write(" AND (")
+                    w |> write(j.rightWhereSql)
+                    w |> write(")")
+                }
+            }
+        } else {
+            w |> write(" FROM \"")
+            w |> write(q.tableName)
+            w |> write("\"")
+        }
+        // Outer WHERE only — right-side `_where` is now in the ON clause
+        // above. The outer WHERE applies to the joined result and may
+        // legally reference any source's columns (`is_some(o)`-style probes
+        // for LEFT JOIN, qualified column refs, etc.).
         if (!empty(q.whereSql)) {
             w |> write(" WHERE ")
             w |> write(q.whereSql)
@@ -1639,7 +2735,7 @@ def private lookup_struct_field_type(rootT : TypeDeclPtr; fieldName : string) : 
 }
 
 [macro_function]
-def private build_row_builder(q : SqlQuery; prog : ProgramPtr; at : LineInfo) : ExpressionPtr {
+def private build_row_builder(var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : ExpressionPtr {
     //! Build the per-row materialization expression based on q.proj.
     //! Returns null on error (macro_error already emitted).
     if (q.proj == ProjectionShape.Aggregate) {
@@ -1649,7 +2745,14 @@ def private build_row_builder(q : SqlQuery; prog : ProgramPtr; at : LineInfo) : 
     }
     if (q.proj == ProjectionShape.SingleColumn) {
         let colIdx = 0
-        var fieldType = lookup_struct_field_type(q.rootType, q.selectCols[0])
+        // Multi-source: column type is already resolved into `selectColTypes`
+        // at projection-analysis time. Single-source: look up via rootType.
+        var fieldType : TypeDeclPtr
+        if (q.seenJoin && length(q.selectColTypes) > 0) {
+            fieldType = q.selectColTypes[0]
+        } else {
+            fieldType = lookup_struct_field_type(q.rootType, q.selectCols[0])
+        }
         if (fieldType == null) {
             macro_error(prog, at, "_sql: cannot resolve type of projected column '{q.selectCols[0]}'")
             return null
@@ -1666,7 +2769,16 @@ def private build_row_builder(q : SqlQuery; prog : ProgramPtr; at : LineInfo) : 
         var mkTup = new ExprMakeTuple(at = at)
         for (i in range(n)) {
             let colIdx = i
-            var fieldType = lookup_struct_field_type(q.rootType, q.selectCols[i])
+            // Multi-source: type already resolved at projection-analysis time
+            // (covers both `<arg>.Col` field-lookup AND computed-column
+            // results like `is_some(o)` → bool). Single-source: lookup via
+            // q.rootType + selectCols[i].
+            var fieldType : TypeDeclPtr
+            if (q.seenJoin && i < length(q.selectColTypes)) {
+                fieldType = q.selectColTypes[i]
+            } else {
+                fieldType = lookup_struct_field_type(q.rootType, q.selectCols[i])
+            }
             if (fieldType == null) {
                 macro_error(prog, at, "_sql: cannot resolve type of projected column '{q.selectCols[i]}'")
                 return null
@@ -1751,6 +2863,33 @@ def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; is
     // there's no aggregate-specific bind push reachable here. The
     // `q.proj != Aggregate` exclusion below mirrors
     // `build_sql_string`'s `forced_one_row` check for hygiene.
+    //
+    // Order is fixed by SQL clause order: per-join ON binds (in join order)
+    // → outer WHERE → HAVING → LIMIT → OFFSET. Build the final list in
+    // that order; `q.bindExprs` accumulates outer WHERE during analysis,
+    // so we splice ON binds in front of it before appending the rest.
+    var joinOnCount = 0
+    for (j in q.joins) {
+        joinOnCount += length(j.rightOnBindExprs)
+    }
+    var joinOnBinds : array<ExpressionPtr>
+    joinOnBinds |> reserve(joinOnCount)
+    for (j in q.joins) {
+        for (b in j.rightOnBindExprs) {
+            joinOnBinds |> push(b)
+        }
+    }
+    if (length(joinOnBinds) > 0) {
+        var ordered : array<ExpressionPtr>
+        ordered |> reserve(length(joinOnBinds) + length(q.bindExprs))
+        for (b in joinOnBinds) {
+            ordered |> push(b)
+        }
+        for (b in q.bindExprs) {
+            ordered |> push(b)
+        }
+        q.bindExprs <- ordered
+    }
     q.bindExprs |> reserve(length(q.bindExprs) + length(q.havingBindExprs) + 2)
     for (be in q.havingBindExprs) {
         q.bindExprs |> push(be)

--- a/tests/dasSQLITE/failed_sql_macro.das
+++ b/tests/dasSQLITE/failed_sql_macro.das
@@ -7,7 +7,7 @@ options gen2
 // analyzer ever runs — e.g. `_select(_.Name) |> _select(_.Price)` is a
 // genuine type bug (string has no `Price` field) and `some_unknown_func(_)`
 // hits the unresolved function. Those cascades are expected.
-expect 40104:13, 30304:2, 30503:3
+expect 40104:21, 30304:2, 30503:3
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -18,6 +18,13 @@ struct Car {
     @sql_primary_key Id : int
     Name  : string
     Price : int
+}
+
+[sql_table(name="Owners")]
+struct Owner {
+    @sql_primary_key Id : int
+    CarId : int
+    Name  : string
 }
 
 [export]
@@ -69,4 +76,61 @@ def main() {
     //     The meaningful form is `COUNT(DISTINCT col)` (DISTINCT inside the
     //     aggregate), which is not yet wired.
     let bad13 <- _sql(db |> select_from(type<Car>) |> distinct() |> count())
+
+    // 14. Theta join (non-`==` predicate in `on`). The locked equi-join
+    //     constraint requires `(l, r) => l.X == r.Y`; theta joins force
+    //     O(n*m) nested-loop and would lose SQLite's planner hint —
+    //     macro_error redirects users to raw SQL.
+    let bad14 <- _sql(db |> select_from(type<Car>)
+                        |> _join(db |> select_from(type<Owner>),
+                                 $(c : Car, o : Owner) => c.Id < o.CarId,
+                                 $(c : Car, o : Owner) => (Name = c.Name, Owner = o.Name)))
+
+    // 15. Multi-key equi join (`&&`-chained equality in `on`). Backing
+    //     `join` fn keys are single-column; multi-key would need a
+    //     tuple-key extension — deferred. Reject loud.
+    let bad15 <- _sql(db |> select_from(type<Car>)
+                        |> _join(db |> select_from(type<Owner>),
+                                 $(c : Car, o : Owner) => c.Id == o.CarId && c.Name == o.Name,
+                                 $(c : Car, o : Owner) => (Name = c.Name, Owner = o.Name)))
+
+    // 16. Two joins in one chain (3+ table). Chunk 5 ships single-join
+    //     only — the `q.joins` slot is one-deep. The second `_join`'s
+    //     `on` must be a valid single-column equi-join (`==`), or
+    //     linq_boost rejects it before sqlite_linq's multi-join guard
+    //     fires; here we equi-join on `.Name` (cosmetically meaningless
+    //     but well-formed) so the diagnostic comes from sqlite_linq.
+    let bad16 <- _sql(db |> select_from(type<Car>)
+                        |> _join(db |> select_from(type<Owner>),
+                                 $(c : Car, o : Owner) => c.Id == o.CarId,
+                                 $(c : Car, o : Owner) => o)
+                        |> _join(db |> select_from(type<Owner>),
+                                 $(t : Owner, o : Owner) => t.Id == o.Id,
+                                 $(t : Owner, o : Owner) => o))
+
+    // 17. Set-op nested inside a set-op — chunk 5 restricts to one set-op
+    //     per chain (chained set-ops would need parenthesization
+    //     bookkeeping not yet wired).
+    let bad17 <- _sql((db |> select_from(type<Car>) |> _select(_.Price))
+                       |> union((db |> select_from(type<Car>) |> _select(_.Price))
+                                |> union(db |> select_from(type<Car>) |> _select(_.Price))))
+
+    // 18. Set-op LHS with `_order_by` — emitted SQL is unparenthesized
+    //     `<lhs> UNION <rhs>`, so a per-side ORDER BY is a SQLite syntax
+    //     error. Reject at compile time; chunk 5 doesn't yet support a
+    //     trailing ORDER BY on the combined set-op result.
+    let bad18 <- _sql((db |> select_from(type<Car>) |> _select(_.Price) |> _order_by(_))
+                       |> union(db |> select_from(type<Car>) |> _select(_.Price)))
+
+    // 19. Set-op RHS with `take(n)` — same reason: per-side LIMIT is not
+    //     valid in unparenthesized compound query.
+    let bad19 <- _sql((db |> select_from(type<Car>) |> _select(_.Price))
+                       |> union(db |> select_from(type<Car>) |> _select(_.Price) |> take(5)))
+    // (Note: the "_in subquery without _select(_.Col)" diagnostic added in
+    //  this round is also belt-and-suspenders — a daslang `contains` type-
+    //  check rejects mismatched element types before sqlite_linq even sees
+    //  the chain in most realistic shapes. We keep the macro_error path
+    //  live for the rare case where the row-vs-rowset shape type-checks
+    //  but produces a multi-column subquery; constructing that test
+    //  reliably is left for a future chunk.)
 }

--- a/tests/dasSQLITE/test_38_join.das
+++ b/tests/dasSQLITE/test_38_join.das
@@ -1,0 +1,98 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    Active : bool
+}
+
+[sql_table(name="Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "Alice", Active = true))
+    db |> insert(User(Id = 2, Name = "Bob",   Active = true))
+    db |> insert(User(Id = 3, Name = "Carol", Active = false))
+    db |> insert(Order(Id = 10, UserId = 1, Total = 100))
+    db |> insert(Order(Id = 11, UserId = 1, Total = 250))
+    db |> insert(Order(Id = 12, UserId = 2, Total = 50))
+    // Carol (id 3) has no orders.
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _join — inner equi-join. Emits `INNER JOIN ... ON ...`.
+// Multi-source mode forces table-aliased column refs (`"t0"."Col"`).
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_inner_join_emits_inner_join_on(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _join(_db |> select_from(type<Order>),
+                                   $(u : User, o : Order) => u.Id == o.UserId,
+                                   $(u : User, o : Order) => (UserName = u.Name, Total = o.Total)))
+    t |> equal(sql,
+        "SELECT \"t0\".\"Name\", \"t1\".\"Total\" FROM \"Users\" AS \"t0\" INNER JOIN \"Orders\" AS \"t1\" ON \"t0\".\"Id\" = \"t1\".\"UserId\"",
+        "_join emits SELECT aliased cols + INNER JOIN ON aliased keys")
+}
+
+[test]
+def test_inner_join_with_outer_where(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where(_.Active)
+                          |> _join(_db |> select_from(type<Order>),
+                                   $(u : User, o : Order) => u.Id == o.UserId,
+                                   $(u : User, o : Order) => (UserName = u.Name, Total = o.Total)))
+    t |> equal(sql,
+        "SELECT \"t0\".\"Name\", \"t1\".\"Total\" FROM \"Users\" AS \"t0\" INNER JOIN \"Orders\" AS \"t1\" ON \"t0\".\"Id\" = \"t1\".\"UserId\" WHERE \"t0\".\"Active\"",
+        "_where on left side qualifies as t0.Col in multi-source mode")
+}
+
+[test]
+def test_inner_join_with_inner_where(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _join(_db |> select_from(type<Order>) |> _where(_.Total > 75),
+                                   $(u : User, o : Order) => u.Id == o.UserId,
+                                   $(u : User, o : Order) => (UserName = u.Name, Total = o.Total)))
+    t |> equal(sql,
+        "SELECT \"t0\".\"Name\", \"t1\".\"Total\" FROM \"Users\" AS \"t0\" INNER JOIN \"Orders\" AS \"t1\" ON \"t0\".\"Id\" = \"t1\".\"UserId\" AND (\"t1\".\"Total\" > ?)",
+        "_where inside the right-side chain emits in JOIN's ON clause (qualified t1.Col, NOT in outer WHERE) — required for LEFT JOIN, used uniformly for INNER too")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Runtime
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_inner_join_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _join(db |> select_from(type<Order>),
+                                    $(u : User, o : Order) => u.Id == o.UserId,
+                                    $(u : User, o : Order) => (UserName = u.Name, Total = o.Total)))
+        // Alice has 2 orders, Bob has 1, Carol 0. Inner join → 3 rows.
+        t |> equal(length(rows), 3, "inner join yields 3 rows (Alice×2 + Bob×1, Carol absent)")
+        // Total across all join rows: 100 + 250 + 50 = 400
+        var sum_total = 0
+        for (r in rows) {
+            sum_total += r.Total
+        }
+        t |> equal(sum_total, 400, "Total across joined rows sums correctly")
+    }
+}

--- a/tests/dasSQLITE/test_39_left_join.das
+++ b/tests/dasSQLITE/test_39_left_join.das
@@ -1,0 +1,177 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+[sql_table(name="Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "Alice"))
+    db |> insert(User(Id = 2, Name = "Bob"))
+    db |> insert(User(Id = 3, Name = "Carol"))
+    db |> insert(Order(Id = 10, UserId = 1, Total = 100))
+    db |> insert(Order(Id = 11, UserId = 1, Total = 250))
+    db |> insert(Order(Id = 12, UserId = 2, Total = 50))
+    // Carol (id 3) has NO orders — LEFT JOIN keeps her with right side null.
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// _left_join — LEFT OUTER JOIN. Right param of `into` is `Option<TB>`;
+// `o |> is_some` / `o |> is_none` probe the join key for NULL-ness.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_left_join_emits_left_join_on(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _left_join(_db |> select_from(type<Order>),
+                                        $(u : User, o : Order) => u.Id == o.UserId,
+                                        $(u : User, o : Option<Order>) => (Name = u.Name, HasOrder = o |> is_some)))
+    t |> equal(sql,
+        "SELECT \"t0\".\"Name\", \"t1\".\"UserId\" IS NOT NULL FROM \"Users\" AS \"t0\" LEFT JOIN \"Orders\" AS \"t1\" ON \"t0\".\"Id\" = \"t1\".\"UserId\"",
+        "_left_join + o|>is_some emits LEFT JOIN + IS NOT NULL probe on right key")
+}
+
+[test]
+def test_left_join_is_none_in_select(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _left_join(_db |> select_from(type<Order>),
+                                        $(u : User, o : Order) => u.Id == o.UserId,
+                                        $(u : User, o : Option<Order>) => (Name = u.Name, NoOrder = o |> is_none)))
+    t |> equal(sql,
+        "SELECT \"t0\".\"Name\", \"t1\".\"UserId\" IS NULL FROM \"Users\" AS \"t0\" LEFT JOIN \"Orders\" AS \"t1\" ON \"t0\".\"Id\" = \"t1\".\"UserId\"",
+        "_left_join + o|>is_none emits LEFT JOIN + IS NULL probe")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Runtime — verify that unmatched left rows surface and that is_some/is_none
+// flags align with the actual presence of right-side rows.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_left_join_runtime_keeps_unmatched(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _left_join(db |> select_from(type<Order>),
+                                         $(u : User, o : Order) => u.Id == o.UserId,
+                                         $(u : User, o : Option<Order>) => (Name = u.Name, HasOrder = o |> is_some)))
+        // Alice 2 orders + Bob 1 order + Carol 1 unmatched row = 4
+        t |> equal(length(rows), 4, "left join yields 4 rows including unmatched Carol")
+        var carol_seen = false
+        var carol_has_order = true
+        for (r in rows) {
+            if (r.Name == "Carol") {
+                carol_seen = true
+                carol_has_order = r.HasOrder
+            }
+        }
+        t |> success(carol_seen)
+        t |> success(!carol_has_order)
+    }
+}
+
+[test]
+def test_left_join_with_inner_where_emits_in_on(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _left_join(_db |> select_from(type<Order>) |> _where(_.Total > 75),
+                                        $(u : User, o : Order) => u.Id == o.UserId,
+                                        $(u : User, o : Option<Order>) => (Name = u.Name, HasBigOrder = o |> is_some)))
+    // Right-side `_where` MUST emit in the ON clause for LEFT JOIN — a row
+    // filter in the outer WHERE would silently drop unmatched-NULL rows and
+    // turn LEFT JOIN into INNER JOIN.
+    t |> equal(sql,
+        "SELECT \"t0\".\"Name\", \"t1\".\"UserId\" IS NOT NULL FROM \"Users\" AS \"t0\" LEFT JOIN \"Orders\" AS \"t1\" ON \"t0\".\"Id\" = \"t1\".\"UserId\" AND (\"t1\".\"Total\" > ?)",
+        "_left_join + right-side _where emits in JOIN's ON clause (NOT outer WHERE) — required to preserve LEFT JOIN semantics for unmatched left rows")
+}
+
+[test]
+def test_left_join_with_inner_where_preserves_unmatched(t : T?) {
+    // The key semantic test: with the right-side `_where` filtering out
+    // Bob's only order (Total = 50, doesn't pass `> 75`), Bob's left row
+    // must STILL appear in the result with HasBigOrder = false. If the
+    // filter were emitted in outer WHERE, Bob would be dropped (the LEFT
+    // JOIN's NULL-extended row for Bob would have NULL Total, which fails
+    // `Total > 75` and excludes the row — silently turning LEFT into INNER).
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Result tuple shape `<string, bool, int>` is structurally distinct
+        // from any other tuple in this file (avoids daslang's typer
+        // canonicalizing tuples by arg-type list, which would collide field
+        // names with the first matching shape — see
+        // feedback_daslang_tuple_recordnames_collide).
+        // Filter `> 200` keeps only Alice's Order(Total=250); Bob's
+        // Order(Total=50) and Alice's Order(Total=100) are both excluded
+        // by the ON-clause predicate.
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _left_join(db |> select_from(type<Order>) |> _where(_.Total > 200),
+                                         $(u : User, o : Order) => u.Id == o.UserId,
+                                         $(u : User, o : Option<Order>) => (UName = u.Name, BigOrder = o |> is_some, UId = u.Id)))
+        // Alice has 2 orders, only Total=250 passes → 1 matching row.
+        // Bob has 1 order (Total=50), 0 pass → kept as 1 NULL-extended row.
+        // Carol has 0 orders → kept as 1 NULL-extended row.
+        // Total: 3 rows. If the predicate had been emitted in outer WHERE
+        // instead of ON, Bob and Carol would have been DROPPED (their
+        // NULL-extended Total fails `> 200`), leaving only 1 row — the
+        // canonical "LEFT JOIN silently became INNER JOIN" symptom.
+        t |> equal(length(rows), 3, "LEFT JOIN + right-side _where keeps unmatched left rows (Bob & Carol both NULL-extended)")
+        var bob_seen = false
+        var bob_has_big = true
+        var carol_seen = false
+        for (r in rows) {
+            if (r.UName == "Bob") {
+                bob_seen = true
+                bob_has_big = r.BigOrder
+            }
+            if (r.UName == "Carol") {
+                carol_seen = true
+            }
+        }
+        t |> success(bob_seen)
+        t |> success(!bob_has_big)
+        t |> success(carol_seen)
+    }
+}
+
+[test]
+def test_left_join_is_none_runtime(t : T?) {
+    // Three-column projection so the result tuple shape (string, int, bool)
+    // is structurally distinct from the 2-tuple in
+    // test_left_join_runtime_keeps_unmatched. daslang's typer canonicalizes
+    // structurally-identical tuples (same arg type list) into a single type
+    // and keeps the FIRST set of record names — re-using
+    // `tuple<string; bool>` here would resolve `r.NoOrder` to the previous
+    // test's `HasOrder` field.
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _left_join(db |> select_from(type<Order>),
+                                         $(u : User, o : Order) => u.Id == o.UserId,
+                                         $(u : User, o : Option<Order>) => (Name = u.Name, UserId = u.Id, NoOrder = o |> is_none)))
+        var carol_no_order = false
+        for (r in rows) {
+            if (r.Name == "Carol" && r.NoOrder) {
+                carol_no_order = true
+            }
+        }
+        t |> success(carol_no_order)
+    }
+}

--- a/tests/dasSQLITE/test_40_in_not_in.das
+++ b/tests/dasSQLITE/test_40_in_not_in.das
@@ -1,0 +1,120 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    Active : bool
+}
+
+[sql_table(name="Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "Alice", Active = true))
+    db |> insert(User(Id = 2, Name = "Bob",   Active = true))
+    db |> insert(User(Id = 3, Name = "Carol", Active = false))
+    db |> insert(Order(Id = 10, UserId = 1, Total = 100))
+    db |> insert(Order(Id = 11, UserId = 1, Total = 250))
+    db |> insert(Order(Id = 12, UserId = 2, Total = 50))
+    // Carol (id 3) has no orders.
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// `_in` / `_not_in` — IN / NOT IN with a subquery.
+// Subquery is uncorrelated; users project a single column with `_select(_.Col)`.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_in_emits_in_subquery(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where(_.Id._in(_db |> select_from(type<Order>) |> _select(_.UserId))))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Active\" FROM \"Users\" WHERE \"Id\" IN (SELECT \"UserId\" FROM \"Orders\")",
+        "_in with subquery emits IN (SELECT ...)")
+}
+
+[test]
+def test_not_in_emits_not_in_subquery(t : T?) {
+    var _db = SqlRunner()
+    // _not_in expands to !contains(subq, x); pred_to_sql's NOT peel wraps it.
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where(_.Id._not_in(_db |> select_from(type<Order>) |> _select(_.UserId))))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Active\" FROM \"Users\" WHERE \"Id\" NOT IN (SELECT \"UserId\" FROM \"Orders\")",
+        "_not_in emits explicit NOT IN (special-cased in pred_to_sql to peek through the `!contains(...)` AST shape)")
+}
+
+[test]
+def test_in_with_outer_where(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where(_.Active && _.Id._in(_db |> select_from(type<Order>) |> _select(_.UserId))))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Active\" FROM \"Users\" WHERE (\"Active\") AND (\"Id\" IN (SELECT \"UserId\" FROM \"Orders\"))",
+        "_in composes with other WHERE predicates via && — bind order preserved")
+}
+
+[test]
+def test_in_with_inner_where_binds(t : T?) {
+    var _db = SqlRunner()
+    let threshold = 100
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where(_.Id._in(_db |> select_from(type<Order>)
+                                                  |> _where(_.Total > threshold)
+                                                  |> _select(_.UserId))))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Active\" FROM \"Users\" WHERE \"Id\" IN (SELECT \"UserId\" FROM \"Orders\" WHERE \"Total\" > ?)",
+        "_in with inner _where emits subquery WHERE — bind appended after outer-WHERE binds")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Runtime — verify rows match the IN/NOT IN semantics.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_in_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Users whose Id appears in Orders.UserId — Alice and Bob.
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _where(_.Id._in(db |> select_from(type<Order>) |> _select(_.UserId))))
+        t |> equal(length(rows), 2, "Alice + Bob match (Carol absent)")
+        var saw_alice = false
+        var saw_bob = false
+        for (u in rows) {
+            if (u.Name == "Alice") {
+                saw_alice = true
+            }
+            if (u.Name == "Bob") {
+                saw_bob = true
+            }
+        }
+        t |> success(saw_alice)
+        t |> success(saw_bob)
+    }
+}
+
+[test]
+def test_not_in_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _where(_.Id._not_in(db |> select_from(type<Order>) |> _select(_.UserId))))
+        t |> equal(length(rows), 1, "only Carol (no orders) matches NOT IN")
+        t |> equal(rows[0].Name, "Carol")
+    }
+}

--- a/tests/dasSQLITE/test_41_any_none.das
+++ b/tests/dasSQLITE/test_41_any_none.das
@@ -1,0 +1,109 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    Active : bool
+}
+
+[sql_table(name="Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "Alice", Active = true))
+    db |> insert(User(Id = 2, Name = "Bob",   Active = true))
+    db |> insert(User(Id = 3, Name = "Carol", Active = false))
+    db |> insert(Order(Id = 10, UserId = 1, Total = 100))
+    db |> insert(Order(Id = 11, UserId = 1, Total = 250))
+    db |> insert(Order(Id = 12, UserId = 2, Total = 50))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// `_any` / `_none` in `_where` predicates → SQL `EXISTS` / `NOT EXISTS`.
+// Subquery is uncorrelated — the inner predicate references only the
+// subquery's own row (`_`), not outer columns.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_any_emits_exists(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where((_db |> select_from(type<Order>))._any()))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Active\" FROM \"Users\" WHERE EXISTS (SELECT \"Id\", \"UserId\", \"Total\" FROM \"Orders\")",
+        "_any with no predicate emits EXISTS (subquery)")
+}
+
+[test]
+def test_none_emits_not_exists(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where((_db |> select_from(type<Order>))._none()))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Active\" FROM \"Users\" WHERE NOT EXISTS (SELECT \"Id\", \"UserId\", \"Total\" FROM \"Orders\")",
+        "_none with no predicate emits NOT EXISTS (subquery)")
+}
+
+[test]
+def test_any_with_predicate(t : T?) {
+    var _db = SqlRunner()
+    let _threshold = 200
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where((_db |> select_from(type<Order>))._any(_.Total > _threshold)))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Active\" FROM \"Users\" WHERE EXISTS (SELECT \"Id\", \"UserId\", \"Total\" FROM \"Orders\" WHERE \"Total\" > ?)",
+        "_any(pred) emits EXISTS with WHERE pred")
+}
+
+[test]
+def test_none_with_predicate(t : T?) {
+    var _db = SqlRunner()
+    let _threshold = 1000
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where((_db |> select_from(type<Order>))._none(_.Total > _threshold)))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Active\" FROM \"Users\" WHERE NOT EXISTS (SELECT \"Id\", \"UserId\", \"Total\" FROM \"Orders\" WHERE \"Total\" > ?)",
+        "_none(pred) emits NOT EXISTS with WHERE pred")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Runtime
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_any_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // EXISTS (any orders) — Orders is non-empty, so all Users match.
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _where((db |> select_from(type<Order>))._any()))
+        t |> equal(length(rows), 3, "all 3 users (any order exists, uncorrelated)")
+    }
+}
+
+[test]
+def test_any_with_predicate_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // EXISTS Orders where Total > 200 — there's the 250 order, so all match.
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _where((db |> select_from(type<Order>))._any(_.Total > 200)))
+        t |> equal(length(rows), 3, "all 3 users (an order with Total > 200 exists)")
+        let rows_no_huge_orders <- _sql(db |> select_from(type<User>)
+                                          |> _where((db |> select_from(type<Order>))._any(_.Total > 1000)))
+        t |> equal(length(rows_no_huge_orders), 0, "0 users (no order with Total > 1000)")
+    }
+}

--- a/tests/dasSQLITE/test_42_set_ops.das
+++ b/tests/dasSQLITE/test_42_set_ops.das
@@ -1,0 +1,233 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="A")]
+struct TabA {
+    @sql_primary_key Id : int
+    Tag : int
+}
+
+[sql_table(name="B")]
+struct TabB {
+    @sql_primary_key Id : int
+    Tag : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<TabA>)
+    db |> create_table(type<TabB>)
+    db |> insert(TabA(Id = 1, Tag = 10))
+    db |> insert(TabA(Id = 2, Tag = 20))
+    db |> insert(TabA(Id = 3, Tag = 30))
+    db |> insert(TabB(Id = 100, Tag = 20))
+    db |> insert(TabB(Id = 200, Tag = 30))
+    db |> insert(TabB(Id = 300, Tag = 40))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// SQL emission — UNION / INTERSECT / EXCEPT wrap the LHS query and append
+// the RHS query separated by the set-op keyword.
+// Both sides project the same column shape (here `_.Tag`) so the resulting
+// schemas align.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_union_emits_union(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text((_db |> select_from(type<TabA>) |> _select(_.Tag))
+                        |> union(_db |> select_from(type<TabB>) |> _select(_.Tag)))
+    t |> equal(sql,
+        "SELECT \"Tag\" FROM \"A\" UNION SELECT \"Tag\" FROM \"B\"",
+        "union(a, b) emits `<a-sql> UNION <b-sql>`")
+}
+
+[test]
+def test_intersect_emits_intersect(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text((_db |> select_from(type<TabA>) |> _select(_.Tag))
+                        |> intersect(_db |> select_from(type<TabB>) |> _select(_.Tag)))
+    t |> equal(sql,
+        "SELECT \"Tag\" FROM \"A\" INTERSECT SELECT \"Tag\" FROM \"B\"",
+        "intersect(a, b) emits `<a-sql> INTERSECT <b-sql>`")
+}
+
+[test]
+def test_except_emits_except(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text((_db |> select_from(type<TabA>) |> _select(_.Tag))
+                        |> except(_db |> select_from(type<TabB>) |> _select(_.Tag)))
+    t |> equal(sql,
+        "SELECT \"Tag\" FROM \"A\" EXCEPT SELECT \"Tag\" FROM \"B\"",
+        "except(a, b) emits `<a-sql> EXCEPT <b-sql>`")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Runtime — verify the actual rows match the set-op semantics.
+// A.Tag values: {10, 20, 30}; B.Tag values: {20, 30, 40}
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_union_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        var rows <- _sql((db |> select_from(type<TabA>) |> _select(_.Tag))
+                         |> union(db |> select_from(type<TabB>) |> _select(_.Tag)))
+        // UNION dedupes: {10, 20, 30, 40}
+        sort(rows)
+        t |> equal(length(rows), 4, "UNION = 4 distinct tags")
+        t |> equal(rows[0], 10)
+        t |> equal(rows[1], 20)
+        t |> equal(rows[2], 30)
+        t |> equal(rows[3], 40)
+    }
+}
+
+[test]
+def test_intersect_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        var rows <- _sql((db |> select_from(type<TabA>) |> _select(_.Tag))
+                         |> intersect(db |> select_from(type<TabB>) |> _select(_.Tag)))
+        // {20, 30}
+        sort(rows)
+        t |> equal(length(rows), 2)
+        t |> equal(rows[0], 20)
+        t |> equal(rows[1], 30)
+    }
+}
+
+[test]
+def test_except_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        var rows <- _sql((db |> select_from(type<TabA>) |> _select(_.Tag))
+                         |> except(db |> select_from(type<TabB>) |> _select(_.Tag)))
+        // A's tags minus B's = {10}
+        sort(rows)
+        t |> equal(length(rows), 1)
+        t |> equal(rows[0], 10)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Compound-query bind ordering — set-op SQL is `<lhs> {OP} <rhs>` with no
+// per-side parens, so placeholders run left-to-right across both sides.
+// The runtime bind list must follow SQL clause order:
+//   LHS(on → where → having)  then  RHS(on → where → having)
+// These tests pin that ordering: a misordered build would produce wrong
+// runtime values OR get caught by the SQL emission check (placeholder count
+// vs. declared bind count) before runtime.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_set_op_basic_lhs_rhs_where_binds(t : T?) {
+    var _db = SqlRunner()
+    let lo = 15
+    let hi = 35
+    let sql = _sql_text(
+        (_db |> select_from(type<TabA>) |> _where(_.Tag >= lo) |> _select(_.Tag))
+        |> union(_db |> select_from(type<TabB>) |> _where(_.Tag <= hi) |> _select(_.Tag)))
+    t |> equal(sql,
+        "SELECT \"Tag\" FROM \"A\" WHERE \"Tag\" >= ? UNION SELECT \"Tag\" FROM \"B\" WHERE \"Tag\" <= ?",
+        "compound query with WHERE on both sides emits two placeholders, LHS then RHS")
+}
+
+[test]
+def test_set_op_basic_lhs_rhs_where_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let lo = 15
+        let hi = 35
+        var rows <- _sql(
+            (db |> select_from(type<TabA>) |> _where(_.Tag >= lo) |> _select(_.Tag))
+            |> union(db |> select_from(type<TabB>) |> _where(_.Tag <= hi) |> _select(_.Tag)))
+        // A.Tag where >= 15 → {20, 30}; B.Tag where <= 35 → {20, 30}; UNION → {20, 30}
+        sort(rows)
+        t |> equal(length(rows), 2, "compound runtime: bind order must match LHS-WHERE first, RHS-WHERE second")
+        t |> equal(rows[0], 20)
+        t |> equal(rows[1], 30)
+    }
+}
+
+[test]
+def test_set_op_lhs_having_then_rhs_where_runtime(t : T?) {
+    // The discriminating test for the round-3 bind-ordering fix: LHS has
+    // both _where (placeholder #1) AND _having (placeholder #2), then UNION,
+    // then RHS has _where (placeholder #3). Pre-fix, LHS HAVING binds were
+    // pushed to q.havingBindExprs which the finalizer appended LAST — so
+    // placeholders would have ended up in order [LHS-WHERE, RHS-WHERE,
+    // LHS-HAVING], silently swapping LHS-HAVING and RHS-WHERE values.
+    //
+    // Both sides project as named-tuple `(Tg : int)` so the UNION column
+    // shape matches (a `_select` after `_group_by` must be a named tuple).
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let lhs_min_tag = 15      // LHS WHERE bind value
+        let lhs_min_count = 1     // LHS HAVING bind value (each Tag occurs once in A)
+        let rhs_max_tag = 25      // RHS WHERE bind value
+        var rows <- _sql(
+            (db |> select_from(type<TabA>)
+                |> _where(_.Tag >= lhs_min_tag)
+                |> _group_by(_.Tag)
+                |> _having(_._1 |> length >= lhs_min_count)
+                |> _select((Tg = _._0)))
+            |> union(db |> select_from(type<TabB>) |> _where(_.Tag <= rhs_max_tag) |> _select((Tg = _.Tag))))
+        // LHS: A.Tag where >= 15, GROUP BY Tag, HAVING count >= 1 → {20, 30}
+        // RHS: B.Tag where <= 25 → {20}
+        // UNION: distinct {20, 30}
+        // If the misordering were present, swapping placeholders #2 and #3
+        // would assign rhs_max_tag=25 to the LHS HAVING (count >= 25 → 0
+        // rows) and lhs_min_count=1 to the RHS WHERE (Tag <= 1 → 0 rows),
+        // producing an empty result.
+        var tags : array<int>
+        for (r in rows) {
+            tags |> push(r.Tg)
+        }
+        sort(tags)
+        t |> equal(length(tags), 2, "LHS HAVING + RHS WHERE binds must occupy correct placeholder positions")
+        t |> equal(tags[0], 20)
+        t |> equal(tags[1], 30)
+    }
+}
+
+[test]
+def test_set_op_lhs_having_emits_correct_sql(t : T?) {
+    var _db = SqlRunner()
+    let lo = 15
+    let mc = 1
+    let hi = 25
+    let sql = _sql_text(
+        (_db |> select_from(type<TabA>)
+            |> _where(_.Tag >= lo)
+            |> _group_by(_.Tag)
+            |> _having(_._1 |> length >= mc)
+            |> _select((Tg = _._0)))
+        |> union(_db |> select_from(type<TabB>) |> _where(_.Tag <= hi) |> _select((Tg = _.Tag))))
+    t |> equal(sql,
+        "SELECT \"Tag\" FROM \"A\" WHERE \"Tag\" >= ? GROUP BY \"Tag\" HAVING COUNT(*) >= ? UNION SELECT \"Tag\" FROM \"B\" WHERE \"Tag\" <= ?",
+        "compound SQL preserves clause order: LHS WHERE → GROUP BY → HAVING → UNION → RHS WHERE")
+}
+
+[test]
+def test_set_op_rhs_join_on_bind_emits_correct_sql(t : T?) {
+    // RHS has a join whose right-side _where carries a bind — the bind
+    // belongs to the JOIN's ON clause (per chunk-5 ON-emission). The fix
+    // also walks subQ.joins to fold their rightOnBindExprs into the
+    // compound-query placeholder list.
+    var _db = SqlRunner()
+    let bnd = 5
+    let sql = _sql_text(
+        (_db |> select_from(type<TabA>) |> _select(_.Tag))
+        |> union(_db |> select_from(type<TabA>)
+                    |> _join(_db |> select_from(type<TabB>) |> _where(_.Tag > bnd),
+                             $(a : TabA, b : TabB) => a.Id == b.Id,
+                             $(a : TabA, b : TabB) => a.Tag)))
+    t |> equal(sql,
+        "SELECT \"Tag\" FROM \"A\" UNION SELECT \"t0\".\"Tag\" FROM \"A\" AS \"t0\" INNER JOIN \"B\" AS \"t1\" ON \"t0\".\"Id\" = \"t1\".\"Id\" AND (\"t1\".\"Tag\" > ?)",
+        "RHS join right-side _where placeholder appears inside compound query's RHS ON clause")
+}

--- a/tutorials/sql/12b-set_ops.das
+++ b/tutorials/sql/12b-set_ops.das
@@ -1,0 +1,74 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 12b — Set operations: UNION / INTERSECT / EXCEPT.
+//
+// Set operations stack two SELECT queries with compatible projections
+// and dedupe / intersect / subtract their result rows. Under `_sql(...)`:
+//
+//   `lhs |> union(rhs)`     →  `<lhs-sql> UNION <rhs-sql>`
+//   `lhs |> intersect(rhs)` →  `<lhs-sql> INTERSECT <rhs-sql>`
+//   `lhs |> except(rhs)`    →  `<lhs-sql> EXCEPT <rhs-sql>`
+//
+// These are the existing `daslib/linq.das` array/iterator fns —
+// `union`, `intersect`, `except` — being recognized by the `_sql`
+// emitter and lowered to SQL set operations.
+//
+// Both sides must project the same column shape (same column count
+// and types). Use `_select(_.Col)` to pin the shape explicitly when
+// the sources have different schemas.
+
+[sql_table(name = "Customers")]
+struct Customer {
+    @sql_primary_key Id : int
+    Tier : int
+}
+
+[sql_table(name = "Prospects")]
+struct Prospect {
+    @sql_primary_key Id : int
+    Tier : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<Customer>)
+    db |> create_table(type<Prospect>)
+    db |> insert(Customer(Id = 1, Tier = 10))
+    db |> insert(Customer(Id = 2, Tier = 20))
+    db |> insert(Customer(Id = 3, Tier = 30))
+    db |> insert(Prospect(Id = 100, Tier = 20))
+    db |> insert(Prospect(Id = 200, Tier = 30))
+    db |> insert(Prospect(Id = 300, Tier = 40))
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // UNION — distinct tags from either table.
+        let all_tiers <- _sql((db |> select_from(type<Customer>) |> _select(_.Tier))
+                              |> union(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+        to_log(LOG_INFO, "UNION — {length(all_tiers)} distinct tiers across both tables")
+        // 4 rows: 10, 20, 30, 40 (UNION dedupes).
+
+        // INTERSECT — tags present in BOTH tables.
+        let shared_tiers <- _sql((db |> select_from(type<Customer>) |> _select(_.Tier))
+                                 |> intersect(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+        to_log(LOG_INFO, "INTERSECT — {length(shared_tiers)} shared tiers")
+        // 2 rows: 20, 30.
+
+        // EXCEPT — Customer tags NOT seen in Prospects.
+        let exclusive <- _sql((db |> select_from(type<Customer>) |> _select(_.Tier))
+                              |> except(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+        to_log(LOG_INFO, "EXCEPT — {length(exclusive)} customer-only tiers")
+        // 1 row: 10.
+
+        let sql = _sql_text((db |> select_from(type<Customer>) |> _select(_.Tier))
+                            |> union(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+        to_log(LOG_INFO, "SQL: {sql}")
+    }
+}

--- a/tutorials/sql/15-join.das
+++ b/tutorials/sql/15-join.das
@@ -1,0 +1,113 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 15 — `_join`: inner equi-join across two tables.
+//
+// `_join(other, on, into)` is sugar over the existing
+// `daslib/linq.das::join` — under `_sql(...)` it emits SQL's
+// `INNER JOIN ... ON ...`.
+//
+// The `on` predicate is locked to the equi-join shape:
+//
+//     $(l : TA, r : TB) => l.X == r.Y
+//
+// — a 2-arg lambda whose body is one `==` comparison between a
+// left-side field and a right-side field. Theta joins (`<`, `>`,
+// `&&`-chained multi-key equality, function calls inside) emit a
+// compile-time `macro_error` pointing at raw SQL as the escape hatch.
+// The single-key restriction matches the backing `join` fn's
+// hash-based O(n+m) implementation; multi-key tuple joins land later.
+//
+// The `into` lambda is the projection. Its two args bind to the two
+// sources — naming is up to you (`u`, `o` here). Refer to columns
+// from each source through the arg name (`u.Name`, `o.Total`); the
+// `_sql` translator rewrites them to alias-qualified column refs
+// (`"t0"."Name"`, `"t1"."Total"`).
+//
+// In multi-source mode the FROM clause aliases the root table as
+// `t0`, the joined table as `t1`, and every column ref in the WHERE,
+// projection, and ON clauses is qualified with the matching alias.
+// Single-source chains keep the unqualified shape — only multi-source
+// queries pay the alias-noise tax.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name   : string
+    Active : bool
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "Alice", Active = true))
+    db |> insert(User(Id = 2, Name = "Bob",   Active = true))
+    db |> insert(User(Id = 3, Name = "Carol", Active = false))
+    db |> insert(Order(Id = 10, UserId = 1, Total = 100))
+    db |> insert(Order(Id = 11, UserId = 1, Total = 250))
+    db |> insert(Order(Id = 12, UserId = 2, Total =  50))
+    // Carol (id 3) has no orders. Inner join drops her.
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // Plain inner equi-join + named-tuple projection from both sources.
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _join(db |> select_from(type<Order>),
+                                    $(u : User, o : Order) => u.Id == o.UserId,
+                                    $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total)))
+        to_log(LOG_INFO, "inner join — User × Order:")
+        for (r in rows) {
+            to_log(LOG_INFO, "  {r.UserName} placed an order of {r.OrderTotal}")
+        }
+        // Expected output (3 rows, Carol absent):
+        //   Alice placed an order of 100
+        //   Alice placed an order of 250
+        //   Bob   placed an order of  50
+
+        // Pre-join `_where` filters the LEFT source before the join.
+        // Column refs qualify with the left alias `t0` automatically.
+        let active_only <- _sql(db |> select_from(type<User>)
+                                  |> _where(_.Active)
+                                  |> _join(db |> select_from(type<Order>),
+                                           $(u : User, o : Order) => u.Id == o.UserId,
+                                           $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total)))
+        to_log(LOG_INFO, "active-only join: {length(active_only)} rows")
+        // 3 rows still — both Alice and Bob are active. Carol was already
+        // dropped by the inner join above.
+
+        // _where can also live INSIDE the right-side chain. Filters there
+        // qualify with the right alias `t1` and emit into the JOIN's ON
+        // clause: `INNER JOIN "Orders" AS "t1" ON ... AND ("t1"."Total" > ?)`.
+        // (Required for LEFT JOIN to preserve unmatched rows; INNER uses the
+        // same placement for consistency with LEFT and planner stability.)
+        let big_orders <- _sql(db |> select_from(type<User>)
+                                 |> _join(db |> select_from(type<Order>) |> _where(_.Total > 75),
+                                          $(u : User, o : Order) => u.Id == o.UserId,
+                                          $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total)))
+        to_log(LOG_INFO, "big-order join (Total > 75): {length(big_orders)} rows")
+        // 2 rows — Alice's 100, Alice's 250. Bob's 50 dropped.
+
+        // Inspect the generated SQL with `_sql_text(...)`. Aliased FROM,
+        // INNER JOIN, qualified WHERE.
+        let sql = _sql_text(db |> select_from(type<User>)
+                              |> _where(_.Active)
+                              |> _join(db |> select_from(type<Order>),
+                                       $(u : User, o : Order) => u.Id == o.UserId,
+                                       $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total)))
+        to_log(LOG_INFO, "SQL: {sql}")
+    }
+}

--- a/tutorials/sql/16-left_join.das
+++ b/tutorials/sql/16-left_join.das
@@ -1,0 +1,81 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 16 — `_left_join`: left outer join with `Option<TB>` on the right.
+//
+// Same 4-arg shape as `_join` (other, on, into) but the `into` lambda's
+// second parameter is `Option<TB>` — `none` when the left row had no
+// matching right row, `some(tb)` otherwise.
+//
+// Under `_sql(...)` the right-side columns become NULL on no-match
+// rows; `Option<TB>` is the daslang lift of that NULL semantics. The
+// `into` projection can probe the option:
+//
+//   - `o |> is_some`   →  `"t1"."<rightKey>" IS NOT NULL`
+//   - `o |> is_none`   →  `"t1"."<rightKey>" IS NULL`
+//
+// (The probe column is the right-side ON-key; if THAT came back NULL
+// the row had no match. Per-column nullability inside `Option<TB>` is
+// not yet wired — for `o.Total` you'd need to drop to raw SQL.)
+//
+// `_left_join` ships INNER + LEFT only; `_right_join`, `_full_outer_join`,
+// and `_cross_join` are not shipped. RIGHT JOIN is `LEFT JOIN` with
+// swapped sources; CROSS JOIN reads as an accidental footgun in macro
+// form and belongs in raw SQL.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "Alice"))
+    db |> insert(User(Id = 2, Name = "Bob"))
+    db |> insert(User(Id = 3, Name = "Carol"))
+    db |> insert(Order(Id = 10, UserId = 1, Total = 100))
+    db |> insert(Order(Id = 11, UserId = 1, Total = 250))
+    db |> insert(Order(Id = 12, UserId = 2, Total =  50))
+    // Carol (id 3) has no orders.
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // LEFT JOIN — every User shows up, even Carol who has no orders.
+        // The `HasOrder` projection probes whether the right-side join
+        // key landed non-NULL.
+        let rows <- _sql(db |> select_from(type<User>)
+                           |> _left_join(db |> select_from(type<Order>),
+                                         $(u : User, o : Order) => u.Id == o.UserId,
+                                         $(u : User, o : Option<Order>) => (Name = u.Name, HasOrder = o |> is_some)))
+        to_log(LOG_INFO, "left join — every user surfaces:")
+        for (r in rows) {
+            to_log(LOG_INFO, "  {r.Name}: HasOrder = {r.HasOrder}")
+        }
+        // Expected — 4 rows: Alice/true × 2 (two orders), Bob/true (one
+        // order), Carol/false (no match).
+
+        // Inspect the SQL — `LEFT JOIN ... ON ...` plus the IS NOT NULL
+        // probe on `t1.UserId` (the right-side join key).
+        let sql = _sql_text(db |> select_from(type<User>)
+                              |> _left_join(db |> select_from(type<Order>),
+                                            $(u : User, o : Order) => u.Id == o.UserId,
+                                            $(u : User, o : Option<Order>) => (Name = u.Name, HasOrder = o |> is_some)))
+        to_log(LOG_INFO, "SQL: {sql}")
+    }
+}

--- a/tutorials/sql/17-subqueries.das
+++ b/tutorials/sql/17-subqueries.das
@@ -1,0 +1,98 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 17 — Subqueries: `_in`, `_not_in`, `_any`, `_none`.
+//
+// All four are `daslib/linq_boost` macros that, under `_sql(...)`,
+// emit SQL's IN / NOT IN / EXISTS / NOT EXISTS forms with a nested
+// `SELECT ...` subquery.
+//
+//   x._in(subquery)         →  `<x> IN (<subquery-sql>)`
+//   x._not_in(subquery)     →  `<x> NOT IN (<subquery-sql>)`
+//   subquery._any()         →  `EXISTS (<subquery-sql>)`
+//   subquery._any(predicate) → `EXISTS (... WHERE <predicate>)`
+//   subquery._none()        →  `NOT EXISTS (<subquery-sql>)`
+//   subquery._none(predicate) → `NOT EXISTS (... WHERE <predicate>)`
+//
+// Negated forms have **explicit names** (`_not_in`, `_none`) rather
+// than `!_in(...)` / `!_any(...)` because the `_sql` AST walker
+// pattern-matches the macro's textual name; a leading `!` would
+// require deep AST walking that fights with daslang's expansion order.
+//
+// For chunk 5, subqueries are **uncorrelated** — the inner WHERE
+// references only the subquery's own row (`_`), not outer columns.
+// Correlated subqueries (referring to outer columns from inside the
+// subquery's WHERE) land later. For IN-style subqueries, project a
+// single column with `_select(_.Col)` so the IN list shape matches.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name   : string
+    Active : bool
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "Alice", Active = true))
+    db |> insert(User(Id = 2, Name = "Bob",   Active = true))
+    db |> insert(User(Id = 3, Name = "Carol", Active = false))
+    db |> insert(Order(Id = 10, UserId = 1, Total = 100))
+    db |> insert(Order(Id = 11, UserId = 1, Total = 250))
+    db |> insert(Order(Id = 12, UserId = 2, Total =  50))
+    // Carol has no orders.
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // IN subquery — Users whose Id appears in Orders.UserId.
+        let with_orders <- _sql(db |> select_from(type<User>)
+                                  |> _where(_.Id._in(db |> select_from(type<Order>) |> _select(_.UserId))))
+        to_log(LOG_INFO, "IN subquery — users with orders: {length(with_orders)}")
+        // 2 rows: Alice, Bob.
+
+        // NOT IN subquery — Users whose Id is NOT in Orders.UserId.
+        let no_orders <- _sql(db |> select_from(type<User>)
+                                |> _where(_.Id._not_in(db |> select_from(type<Order>) |> _select(_.UserId))))
+        to_log(LOG_INFO, "NOT IN subquery — orderless users: {length(no_orders)}")
+        // 1 row: Carol.
+
+        // EXISTS subquery — uncorrelated test (`Orders` non-empty?).
+        let any_orders <- _sql(db |> select_from(type<User>)
+                                 |> _where((db |> select_from(type<Order>))._any()))
+        to_log(LOG_INFO, "EXISTS — when Orders has rows, all 3 users surface: {length(any_orders)}")
+
+        // EXISTS with a predicate — uncorrelated; references only the
+        // subquery's own row through `_`.
+        let any_big_order <- _sql(db |> select_from(type<User>)
+                                    |> _where((db |> select_from(type<Order>))._any(_.Total > 200)))
+        to_log(LOG_INFO, "EXISTS (Total > 200) — guard fires when any qualifying order exists: {length(any_big_order)}")
+
+        // NOT EXISTS with a predicate — `_none(pred)` lifts to `NOT EXISTS (... WHERE pred)`.
+        let none_huge <- _sql(db |> select_from(type<User>)
+                                |> _where((db |> select_from(type<Order>))._none(_.Total > 1000)))
+        to_log(LOG_INFO, "NOT EXISTS (Total > 1000) — when none exist, all users surface: {length(none_huge)}")
+
+        // Inspect the SQL.
+        let sql_in = _sql_text(db |> select_from(type<User>)
+                                 |> _where(_.Id._in(db |> select_from(type<Order>) |> _select(_.UserId))))
+        to_log(LOG_INFO, "SQL (IN): {sql_in}")
+        let sql_exists = _sql_text(db |> select_from(type<User>)
+                                     |> _where((db |> select_from(type<Order>))._any(_.Total > 200)))
+        to_log(LOG_INFO, "SQL (EXISTS): {sql_exists}")
+    }
+}


### PR DESCRIPTION
## Summary

Chunk 5 of the dasSQLITE rework — multi-source read-side. Adds joins, subqueries, and set operations to the `_sql` macro pipeline. Implementation lives entirely in `modules/dasSQLITE/daslib/sqlite_linq.das`; the `daslib/linq` and `daslib/linq_boost` prereqs (fns `left_join`, `none`, `union`, `intersect`, `except`; macros `_join`, `_left_join`, `_in`, `_not_in`, `_none`, `_any`) shipped with the chunk-2 prereq landing (commit `1226da6c0`).

### Joins

* `_join` (INNER) and `_left_join` (LEFT) — equi-join only, with `Option<TB>` on the LEFT JOIN's right side and `is_some` / `is_none` probing the right-side ON-key.
* Multi-source mode aliases tables (`t0`, `t1`, …) and qualifies every column ref. Single-source chains keep the unqualified shape so chunks 1–4 stay byte-identical.

### Subqueries

* `_in`, `_not_in`, `_any`, `_none` in `_where` predicates → `IN` / `NOT IN` / `EXISTS` / `NOT EXISTS`.
* Uncorrelated only for now.
* Recognized in both expanded (`ExprCall`) and unexpanded (`ExprCallMacro`) forms because Mode-2 expansion does not deep-walk into binary operators and `call.func` may be null when a `contains` lands inside `&&` / `!`.

### Set operations

* `union(a, b)`, `intersect(a, b)`, `except(a, b)` → SQL `UNION` / `INTERSECT` / `EXCEPT`.
* One set-op per chain; chained set-ops deferred.

### Tests

`test_38_join`, `test_39_left_join`, `test_40_in_not_in`, `test_41_any_none`, `test_42_set_ops` — 26 new cases. `failed_sql_macro` extended with bad14–17 (theta join, multi-key equi-join, two-joins, set-op-in-set-op).

* 7097/7097 interpreted tests pass
* 6509/6509 AOT tests pass
* 231/231 dasSQLITE green, 590/590 linq green
* lint clean
* Sphinx -W clean

### Tutorials

`15-join`, `16-left_join`, `17-subqueries`, `12b-set_ops` + matching RST stubs. Prev/next cross-references threaded through `12-distinct → 12b → 13-aggregates` and `14-group_by → 15 → 16 → 17 → 18-null_handling`.

## Test plan

- [x] `bin/Release/daslang.exe utils/lint/main.das -- <changed .das files>` — clean
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/` — 7097/7097 pass
- [x] `cmake --build build --config Release --target test_aot` — succeeds
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — 6509/6509 pass
- [x] `sphinx-build -b html source ../site/doc` — `build succeeded`, zero warnings
- [x] `format_file` on every changed `.das` — already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)