### PR TITLE
find_dupes: pattern filter for boilerplate + MCP export_corpus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/json.md` | Reading or writing JSON in `.das` code — choosing between `sprint_json`/`sscan_json`, `JV`/`from_JV` from `daslib/json_boost`, custom converters, or manual `JsonValue?` |
 | `skills/xml.md` | Reading, building, querying, or serializing XML via `dasPUGIXML` (`PUGIXML_boost`) — RAII parsing, iteration, `tag`/`attr` builder, XPath, struct↔XML round-trip |
 | `skills/filesystem.md` | Any `.das` code that builds, splits, or normalizes a file path, or touches the filesystem (existence, listing, copy/rename/remove, temp files). **Rule:** path & filename operations MUST use `fio` helpers (`base_name`/`dir_name`/`extension`/`stem`/`path_join`/`normalize`/`is_absolute`/`relative`) — never hand-rolled `rfind`/`slice`/string-interp. Filesystem ops use `fio` / `daslib/fio` (`stat`, `dir_rec`, RAII `fopen`, `_result` variants) |
+| `skills/find_dupes.md` | Detecting duplicate / near-duplicate functions in repo code — building a corpus, asking "did I just write something that already exists?" during PR authoring/review, or wiring a CI gate. Covers both the MCP tools (`export_corpus`, `find_duplicates`) and the underlying CLI (`utils/find_dupes/main.das`). Also read before editing/extending the find_dupes tool itself (adding a pattern matcher, extending the canonicalizer, wiring new MCP parameters) |
 
 Multiple skill files may apply to a single task. For example, creating a new daslib module requires reading `skills/das_formatting.md`, `skills/daslib_modules.md`, and possibly `skills/documentation_rst.md`.
 
@@ -329,7 +330,8 @@ other level) should be used instead.
 - `modules/` — External plugin modules
 - `modules/dasLiveHost/` — C++ module for live-reload host lifecycle (dynamic module)
 - `utils/daslang-live/` — Live-reloading application host (`daslang-live.exe`)
-- `utils/mcp/` — MCP server for AI coding assistants (30 tools, stdio transport, no extra deps)
+- `utils/mcp/` — MCP server for AI coding assistants (stdio transport, no extra deps)
+- `utils/find_dupes/` — Cross-file duplicate-function detector — canonicalizer, MinHash, clusterer, pattern filter (also exposed via the `export_corpus` and `find_duplicates` MCP tools)
 - `utils/daspkg/` — Package manager (install, update, build, search packages)
 - `examples/daslive/` — Live-reload examples (hello, triangle, tank_game, etc.)
 - `examples/games/` — Full game examples (arcanoid, sequence) — run under daslang-live or daslang
@@ -368,6 +370,8 @@ The daslang MCP server (`utils/mcp/main.das`) exposes compiler diagnostics, prog
 | `outline` | Manually scanning files for function/struct/enum declarations |
 | `aot` | Manually running AOT generation and extracting function C++ |
 | `lint` | Running lint/perf_lint/style_lint manually or requiring the modules for code quality, performance, and style checks |
+| `export_corpus` | Running `find_dupes --export-functions` from a shell to build a duplicate-detection corpus |
+| `find_duplicates` | Running `find_dupes --against` from a shell to ask "did I just write something that already exists?". Wraps B2 mode end-to-end |
 | `live_launch` | Manually starting `daslang-live.exe` from shell |
 | `live_status` | `curl http://localhost:9090/status` |
 | `live_error` | `curl http://localhost:9090/error` |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1486,6 +1486,18 @@ install(FILES ${PROJECT_SOURCE_DIR}/utils/benchctl/README.md DESTINATION utils/b
 # Install lint (unified linter)
 install(FILES ${PROJECT_SOURCE_DIR}/utils/lint/main.das DESTINATION utils/lint)
 
+# Install find_dupes (cross-file duplicate-function detector)
+file(GLOB DAS_FIND_DUPES_FILES ${PROJECT_SOURCE_DIR}/utils/find_dupes/*.das)
+install(FILES ${DAS_FIND_DUPES_FILES} DESTINATION utils/find_dupes)
+install(FILES
+    ${PROJECT_SOURCE_DIR}/utils/find_dupes/README.md
+    DESTINATION utils/find_dupes
+)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/utils/find_dupes/fixture/
+    DESTINATION utils/find_dupes/fixture
+    FILES_MATCHING PATTERN "*.das"
+)
+
 # Install daspkg (package manager)
 file(GLOB DAS_DASPKG_FILES ${PROJECT_SOURCE_DIR}/utils/daspkg/*.das)
 install(FILES ${DAS_DASPKG_FILES} DESTINATION utils/daspkg)

--- a/doc/source/reference/utils.rst
+++ b/doc/source/reference/utils.rst
@@ -7,8 +7,9 @@
 This section documents the command-line tools that ship with daslang:
 the live-reload application host, the test framework, the code coverage
 tool, the package manager, the MCP server for AI coding assistants,
-the runtime profiler and memory-leak tracker, and a cheat sheet for
-every built-in leak-detection mechanism.
+the cross-file duplicate-function detector, the runtime profiler and
+memory-leak tracker, and a cheat sheet for every built-in
+leak-detection mechanism.
 
 .. toctree::
    :maxdepth: 2
@@ -18,5 +19,6 @@ every built-in leak-detection mechanism.
    utils/dascov.rst
    utils/daspkg.rst
    utils/mcp.rst
+   utils/find_dupes.rst
    utils/profiler.rst
    utils/memory_leak_detection.rst

--- a/doc/source/reference/utils/find_dupes.rst
+++ b/doc/source/reference/utils/find_dupes.rst
@@ -1,0 +1,432 @@
+.. _utils_find_dupes:
+
+.. index::
+   single: Utils; find_dupes
+   single: Utils; Duplicate detection
+   single: Utils; Code similarity
+
+=====================================================
+ find_dupes --- Cross-file similar-function detector
+=====================================================
+
+``find_dupes`` walks one or more directories of ``.das`` files,
+normalises every user function into an alpha-renamed token stream
+(identifiers, types, and literals all collapsed), and reports
+near-identical functions across the corpus.  It is useful for
+surfacing test-suite boilerplate that could be factored, near-clones
+that drifted apart, or copy-pasted helpers that escaped review.
+
+Two interfaces ship together: a CLI (``utils/find_dupes/main.das``)
+and two MCP tools (``export_corpus`` and ``find_duplicates``) that
+expose the same engine to AI coding assistants.
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+What it reports
+===============
+
+Every output is one of two kinds of match:
+
+* **Exact-clone clusters** --- functions whose canonical token
+  streams are byte-identical.  Pure structural duplicates, modulo
+  identifier names, types, and literal values.
+* **Fuzzy near-duplicates** --- pairs scored as
+  ``sqrt(jaccard × len_ratio)`` over a 64-slot MinHash signature,
+  with a hard ``len_ratio >= threshold`` gate.  The length gate
+  suppresses MinHash false-positives on highly periodic boilerplate
+  (otherwise a 4-statement and a 7-statement copy of the same
+  ``t |> run(...)`` block both look 100% identical to MinHash).
+
+The geometric-mean score admits a Jaccard somewhat below
+``threshold`` when lengths match closely.  This is intentional and
+biases toward recall.
+
+
+Quick start
+===========
+
+CLI::
+
+   bin/daslang utils/find_dupes/main.das -- -p tests --json /tmp/dupes.json
+   bin/daslang utils/find_dupes/main.das -- -p tests/strings -t 0.85 -n 20
+   bin/daslang utils/find_dupes/main.das -- -p daslib --no-fuzzy --min-tokens 32
+   bin/daslang utils/find_dupes/main.das -- -p tests --keep all
+   bin/daslang utils/find_dupes/main.das -- -?
+
+JIT works too --- ``bin/daslang -jit utils/find_dupes/main.das -- ...``
+(net runtime improvement is modest because per-file cost is
+dominated by interpreter compilation of the scanned files).
+
+
+Flags
+=====
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 12 63
+
+   * - Flag
+     - Default
+     - Meaning
+   * - ``-p / --path``
+     - required
+     - File or directory to scan; repeatable
+   * - ``-t / --threshold``
+     - 0.7
+     - Fuzzy similarity floor (0..1).  Score is
+       ``sqrt(jaccard × len_ratio)`` plus a hard
+       ``len_ratio >= threshold`` gate
+   * - ``-n / --top``
+     - 20
+     - Top-N entries shown in stdout summary
+   * - ``--json``
+     - off
+     - Path for full JSON report
+   * - ``-x / --no-fuzzy``
+     - off
+     - Skip MinHash pass --- exact clusters only
+   * - ``--min-tokens``
+     - 8
+     - Drop functions with fewer than N tokens (filters trivial
+       wrappers)
+   * - ``-L / --lambdas-only``
+     - off
+     - Skip top-level functions, keep only lambdas --- useful for
+       clustering dastest ``t |> run("…") @(t) { … }`` bodies
+   * - ``--export-functions``
+     - off
+     - Write all extracted functions to a JSON file and exit before
+       clustering
+   * - ``--import-functions``
+     - off
+     - Load functions from a JSON file (produced by
+       ``--export-functions``) instead of compiling.  Mutually
+       exclusive with ``--path`` and ``--export-functions``
+   * - ``--baseline``
+     - off
+     - B1: load corpus JSON; tag records whose member identity
+       (``file:line:name``) isn't in the baseline as candidates and
+       filter to those
+   * - ``--baseline-strict``
+     - off
+     - B1 modifier: also drop clusters whose canonical exists in the
+       baseline (only fully-new clusters survive)
+   * - ``--against``
+     - off
+     - B2 candidate path (file or directory).  Repeatable.
+       Compiled in-process; their functions are tagged candidates
+       and the report is filtered
+   * - ``--against-from-stdin``
+     - off
+     - B2: read newline-delimited candidate paths from stdin
+   * - ``--check``
+     - off
+     - Exit non-zero when the post-filter report contains any
+       clusters/pairs (CI gate)
+   * - ``--flat``
+     - off
+     - In ``--against`` mode, force the flat clusters/pairs writer
+       (default in ``--against`` mode is the per-candidate rollup)
+   * - ``-k / --keep``
+     - off
+     - Pattern name to KEEP despite default skip (repeatable).
+       Special value ``all`` disables pattern filtering entirely.
+       See :ref:`utils_find_dupes_patterns`
+   * - ``-v / --verbose``
+     - off
+     - Per-file progress
+   * - ``-?``
+     -
+     - Show help
+
+``builtin.das``, ``daslib/debugger.das``, and ``daslib/profiler.das``
+are skipped automatically --- the latter two install thread-local
+debug agents at compile time, which would abort the scanner on the
+second use.
+
+
+.. _utils_find_dupes_patterns:
+
+Pattern filter
+==============
+
+A "pattern" is a structural shape that signals "this function is
+boilerplate, not real code" --- typically a wrapper or dispatcher
+whose canonical token stream contains zero unique signal beyond its
+repetition count.  Pattern-matched functions are dropped from
+clustering by default, on the theory that they explode cluster
+sizes and fuzzy-pair counts without surfacing real duplicates.
+
+Override per-pattern via ``--keep <name>`` (repeatable), or disable
+filtering wholesale via ``--keep all``.
+
+Currently shipped patterns:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 35 50
+
+   * - Name
+     - Detects
+     - Why it's boilerplate
+   * - ``dispatch``
+     - Function whose body is N >= 2 byte-identical top-level
+       statement chunks
+     - dastest's ``t |> run("X") @(t) { … }`` outer functions.
+       Lambda bodies are collapsed to ``ADDR`` upstream, so two
+       ``run`` calls look identical regardless of what the lambdas
+       do.  Same shape catches ``t |> bench(…)``, repeated-init
+       blocks, and any uniform call list.
+
+The summary line surfaces what was filtered::
+
+   collected 66 record(s); 0 compile failure(s), 1 skipped (expect-directive)
+   patterns skipped: 35 dispatch (--keep <name>|all to include)
+
+``--verbose`` prints one ``pattern-skip [name] file:line func (note)``
+line per filtered record --- useful for confirming the filter isn't
+dropping real signal on a new corpus.
+
+
+Canonical form
+==============
+
+Each function emits a flat tag stream.  Examples:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Source
+     - Canonical (excerpt)
+   * - ``def add(a,b:int):int { return a+b }``
+     - ``FN ARG <var_0> TYP ARG <var_1> TYP TYP BODY BLK STMT RET OP2:+ <var_0> <var_1> ENDBLK ENDFN``
+   * - ``def add(a,b:float):float { return a+b }``
+     - (same --- types collapse)
+   * - ``def double(a:int) { return a*2 }``
+     - ``FN ARG <var_0> TYP BODY BLK STMT RET OP2:* <var_0> LIT ENDBLK ENDFN``
+
+User identifiers become ``<var_0>``, ``<var_1>``, ...  All types
+collapse to ``TYP``.  All literals become ``LIT``.  Field/swizzle
+names use ``.FLD`` / ``.SWZ``.  Called function names are kept
+(``CALL:push`` vs ``CALL:emplace`` is real signal).
+
+
+Modes
+=====
+
+The flat report from ``-p`` is the firehose --- useful once on a
+new corpus to calibrate, less useful day-to-day.  Two filtered
+modes are layered on top via a single ``is_candidate`` flag inside
+``FuncRecord``.  A cluster or fuzzy pair is **kept** iff at least
+one of its members is a candidate.
+
+
+B1 --- baseline diff (CI gate)
+------------------------------
+
+Snapshot the corpus once, commit the JSON, and on every PR re-scan
+and diff::
+
+   # one-off: build the baseline (commit this)
+   bin/daslang utils/find_dupes/main.das -- -p tests --export-functions tests_baseline.json
+
+   # CI: scan again, surface only what isn't in the baseline
+   bin/daslang utils/find_dupes/main.das -- -p tests --baseline tests_baseline.json --check
+
+Records are tagged candidate when their **member identity**
+(``file:line:name``) is absent from the baseline.  A cluster
+appears in the report if any of its members is a candidate, which
+catches both (a) brand-new canonicals and (b) growth --- a new copy
+of an already-tracked canonical added in a new location.
+
+Use ``--baseline-strict`` to drop case (b) --- strict additionally
+filters out clusters whose canonical was already in the baseline,
+so only fully-new canonicals survive.  Pairs aren't strict-filtered
+(the baseline doesn't carry MinHash signatures), so strict is
+cluster-only.
+
+``file:line:name`` keying means an unrelated edit that shifts line
+numbers will look like a "new member" and surface its cluster ---
+acceptable for CI, since touched code is the right default to
+re-check.
+
+``--check`` turns the filtered report into a CI gate --- non-zero
+exit when any cluster or pair survives the filter.
+
+
+B2 --- PR-files / interactive
+-----------------------------
+
+"Did I just write something that already exists?"  Compare a file
+list against a pre-built corpus::
+
+   bin/daslang utils/find_dupes/main.das -- \
+       --import-functions tests_baseline.json --against tests/strings/new_helper.das
+
+   # git pipeline:
+   git diff --name-only master | grep '\.das$' | \
+       bin/daslang utils/find_dupes/main.das -- \
+           --import-functions tests_baseline.json --against-from-stdin
+
+When ``--against`` and ``--import-functions`` are both set, corpus
+records whose ``file`` matches any candidate path are dropped first,
+then the candidate is freshly compiled --- so the file is compared
+against the rest of the world, never against its own stale copy in
+the baseline.  Look for the ``dropped N corpus records overridden``
+line.
+
+The default writer in ``--against`` mode is a per-candidate rollup
+("for each function in the focus set, here are its top siblings").
+Use ``--flat`` to revert to the legacy clusters+pairs view.
+
+
+Export / import
+===============
+
+Compilation is the expensive step; the canonical-form computation
+is deterministic.  To hand the function list off to an external
+tool (visualizer, custom clusterer), or to shard compilation
+across machines and merge later, dump the post-canonicalization
+records and reload them::
+
+   bin/daslang utils/find_dupes/main.das -- -p tests --export-functions /tmp/funcs.json
+   bin/daslang utils/find_dupes/main.das -- --import-functions /tmp/funcs.json --json /tmp/dupes.json
+
+``--import-functions`` is mutually exclusive with both ``--path``
+and ``--export-functions``.  ``--export-functions`` always exits
+before the clustering pass.
+
+The on-disk schema is a small envelope:
+
+.. code-block:: json
+
+   {
+     "schema_version": 1,
+     "functions": [
+       {
+         "name": "add_int",
+         "file": "tests/foo.das",
+         "line": 4,
+         "is_lambda": false,
+         "canonical": "FN ARG <var_0> TYP ..."
+       }
+     ]
+   }
+
+MinHash signatures are not included --- they're recomputed on
+import (deterministic and cheap).  On import, ``--no-fuzzy`` and
+``--min-tokens`` apply just like in the compile path.
+
+
+MCP integration
+===============
+
+The :ref:`utils_mcp` server exposes two tools that wrap the engine
+end-to-end --- no shelling out:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Tool
+     - Purpose
+   * - ``export_corpus``
+     - Scan ``paths`` (files / directories / globs), compile each
+       ``.das`` file in-process, and write a corpus JSON to ``out``
+       in the same shape ``find_duplicates`` expects.
+       Replacement for the CLI ``--export-functions``.
+   * - ``find_duplicates``
+     - Wraps B2 mode.  Pass ``paths`` (newline- or
+       comma-delimited, or a glob) and ``corpus`` (a JSON from
+       ``export_corpus`` / ``--export-functions``); receive a
+       per-candidate JSON envelope with corpus stats, pattern-skip
+       counts, and a per-candidate report containing the top-N
+       exact and fuzzy matches.
+
+Both tools surface the pattern filter via a ``keep`` parameter
+that mirrors the CLI's ``--keep`` flag.  The envelope also
+reports ``candidate_functions_pre_filter``, so the caller can
+distinguish "no candidates compiled" from "all candidates were
+pattern-filtered out".
+
+
+Implementation
+==============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - File
+     - Role
+   * - ``canonical.das``
+     - ``CanonicalVisitor`` (extends ``daslib/ast`` ``AstVisitor``)
+       and ``tokenize_canonical``
+   * - ``minhash.das``
+     - 64-slot MinHash signatures over 5-grams, Jaccard estimate
+   * - ``cluster.das``
+     - Exact-bucket clustering + fuzzy all-pairs with length gate
+   * - ``report.das``
+     - JSON + stdout summary writer
+   * - ``main.das``
+     - CLI (``daslib/clargs``), file scan, compile-and-collect
+       orchestration
+   * - ``pipeline.das``
+     - ``compile_and_collect`` / ``collect_from_program`` ---
+       compile-and-extract orchestration, shared by ``main.das``
+       and the test suite.  Also hosts ``apply_pattern_filter``
+       and the filesystem scan helpers
+   * - ``patterns.das``
+     - Pattern matchers --- ``classify(canonical) → PatternHit``.
+       Default-skipped shapes (dispatchers etc.); override via
+       ``--keep <name>``
+   * - ``exchange.das``
+     - On-disk JSON schema + writer/reader for
+       ``--export-functions`` / ``--import-functions``
+   * - ``fixture/synth.das``
+     - Hand-crafted fixture for smoke-testing the visitor
+       end-to-end
+   * - ``fixture/canonical_cases.das``
+     - Narrowly-targeted fixture (one function per
+       canonicalization concern) for unit-testing
+       ``CanonicalVisitor``
+   * - ``test_find_dupes.das``
+     - dastest suite --- run with
+       ``bin/daslang dastest/dastest.das -- --test utils/find_dupes/test_find_dupes.das``
+
+
+Notes
+=====
+
+* Compile policy mirrors ``utils/lint``: ``ignore_shared_modules``,
+  ``export_all``.  Optimisations and infer-time folding stay ON so
+  dastest macros (e.g. ``unroll``) compile.
+* **Default mode** drops everything ``generated`` (which includes
+  lambdas).  The dispatcher already references each lambda via an
+  ``ADDR`` token, so the lambda's structural fingerprint is
+  partially preserved in the parent function.  Use ``-L`` to flip
+  this and cluster the lambda bodies themselves.
+* **Lambda-only mode (``-L``)** is dominated at the top by linq's
+  ``each`` macro emissions (a 100+-token
+  ``GOTO/LABEL/_builtin_iterator_first/next/close`` shell that
+  recurs hundreds of times).  Real test-body signal starts a few
+  clusters down; sort/grep accordingly.
+* Functions whose ``at.fileInfo`` points outside the compiled file
+  are filtered out --- without this, reified generics from required
+  modules (e.g. ``dastest/testing.das``) flood the report.
+* Per-source-line dedup: a generic reified for N types becomes N
+  ``FunctionPtr`` instances all pointing at the same
+  ``(file, line)``.  ``find_dupes`` keeps the first to avoid the
+  same source location being counted N times.
+
+
+Out of scope
+============
+
+* LSH / banding (4.4K\ :sup:`2` is fine; revisit at >50K functions).
+* Embedding-based similarity (would need an external service).
+* Auto-fix or refactor suggestions --- discovery only.

--- a/doc/source/reference/utils/mcp.rst
+++ b/doc/source/reference/utils/mcp.rst
@@ -9,7 +9,7 @@
  MCP Server --- AI Tool Integration
 ===========================================
 
-The daslang MCP server exposes 28 compiler-backed tools to AI coding
+The daslang MCP server exposes compiler-backed tools to AI coding
 assistants via the `Model Context Protocol <https://modelcontextprotocol.io/>`_.
 It provides compilation diagnostics, type inspection, go-to-definition,
 find-references, AST dump, AOT generation, expression evaluation,
@@ -57,8 +57,7 @@ session.
 Tools
 =====
 
-The server exposes 28 tools.  Each tool is invoked via MCP's
-``tools/call`` method.
+Each tool is invoked via MCP's ``tools/call`` method.
 
 Compilation and diagnostics
 ---------------------------
@@ -198,6 +197,30 @@ Parse-aware search (tree-sitter)
      - List all declarations in a file or set of files using
        tree-sitter.  Works on broken/incomplete code -- no compilation
        needed.  Conditional on ``sg`` CLI.
+
+Duplicate detection
+-------------------
+
+These tools wrap :ref:`utils_find_dupes` end-to-end (no shelling out).
+``export_corpus`` builds the corpus once over a body of code;
+``find_duplicates`` queries it.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Tool
+     - Description
+   * - ``export_corpus``
+     - Scan one or more ``.das`` files / directories / globs, compile
+       each in-process, and write a corpus JSON to ``out``.  Same shape
+       as ``find_dupes --export-functions``.
+   * - ``find_duplicates``
+     - Compare candidate file(s) against a pre-built corpus.  Returns
+       a per-candidate JSON envelope with corpus stats, pattern-skip
+       counts, and the top-N exact and fuzzy matches per candidate.
+       Supports ``keep`` to override the default pattern filter.
+
 
 Live-reload control
 -------------------

--- a/install/CLAUDE.md
+++ b/install/CLAUDE.md
@@ -85,6 +85,7 @@ Task-specific instructions are in skill files under `skills/`. Read the relevant
 | `skills/writing_tests.md` | Writing tests for your daslang code with the bundled `dastest` framework (`bin/daslang dastest/dastest.das -- --test ...`) |
 | `skills/memory_leak_detection.md` | Diagnosing leaks — `--das-profiler-leaks`, `-track-allocations -heap-report`, `GC APP LEAK` reports, `--track-smart-ptr`, `HandleRegistry` dump |
 | `skills/jobque_debugging.md` | Debugging Channel/LockBox/JobStatus/Stream/Feature leaks using `DumpJobQueLeaks` and `--track-job-status <id>` refcount tracing |
+| `skills/find_dupes.md` | Detecting duplicate / near-duplicate functions across a daslang codebase — building a corpus, asking "did I just write something that already exists?", or wiring a CI gate. Covers both the MCP tools (`export_corpus`, `find_duplicates`) and the underlying CLI (`utils/find_dupes/main.das`) |
 
 Multiple skill files may apply to a single task. For example, embedding daslang and calling its standard library requires reading both `skills/cpp_integration.md` and `skills/daslib_modules.md`.
 
@@ -283,7 +284,8 @@ If you find yourself reading older guidance about `var inscope`, `<-`, or `clone
 - `examples/` — Example scripts
 - `tutorials/` — Language, integration, and module tutorials
 - `dastest/` — Test framework (usable for testing your own code)
-- `utils/mcp/` — MCP server for AI coding assistants (30 tools, stdio transport, no extra deps)
+- `utils/mcp/` — MCP server for AI coding assistants (stdio transport, no extra deps)
+- `utils/find_dupes/` — Cross-file duplicate-function detector (also exposed via the `export_corpus` and `find_duplicates` MCP tools)
 - `utils/daspkg/` — Package manager
 - `utils/dascov/` — Code coverage tool
 - `tree-sitter-daslang/` — Tree-sitter grammar, shared library, and highlighting queries
@@ -332,6 +334,8 @@ See `skills/daspkg.md` for `.das_package` manifest format and package structure.
 | `outline` | Manually scanning files for function/struct/enum declarations |
 | `aot` | Manually running AOT generation and extracting function C++ |
 | `lint` | Running lint/perf_lint/style_lint manually or requiring the modules for code quality, performance, and style checks |
+| `export_corpus` | Running `utils/find_dupes/main.das --export-functions` from a shell to build a duplicate-detection corpus |
+| `find_duplicates` | Running `utils/find_dupes/main.das --against` from a shell to ask "did I just write something that already exists?". Wraps B2 mode end-to-end |
 | `live_launch` | Manually starting `daslang-live` from shell |
 | `live_status` | `curl http://localhost:9090/status` |
 | `live_error` | `curl http://localhost:9090/error` |

--- a/install/skills/find_dupes.md
+++ b/install/skills/find_dupes.md
@@ -1,0 +1,136 @@
+# find_dupes — duplicate-function detection for daslang code
+
+Read this skill before doing duplicate-detection work on a daslang codebase: building a corpus of canonical signatures, asking "did I just write something that already exists?", or wiring a CI gate that flags new structural duplicates. The tool ships as `utils/find_dupes/` plus two MCP tools (`export_corpus`, `find_duplicates`) on the daslang MCP server.
+
+## When to use this
+
+- A function you're writing feels familiar — you suspect it already exists somewhere in `daslib/`, `tests/`, or your project's source tree.
+- You're reviewing a PR and want a quick "is this a copy-paste of an existing helper?" check on the diff.
+- You want a CI gate that flags new structural duplicates introduced by a PR (B1 baseline mode).
+
+What it finds: functions whose **canonical token stream** (identifiers, types, and literals all alpha-renamed and collapsed) is byte-identical or close to existing functions. It is intentionally a structural matcher — `add(a, b : int)` and `add(a, b : float)` look identical to it; that's the point.
+
+What it does **not** find: semantic duplicates that have different control flow, different called helpers, or significantly different shape. Two implementations of "the same idea" written from scratch will not match.
+
+## Workflow via MCP (preferred)
+
+The MCP server exposes the entire pipeline — no shelling out:
+
+| MCP tool | Purpose |
+|---|---|
+| `export_corpus` | Scan paths/dirs/globs, compile each `.das` file, write a `corpus.json` |
+| `find_duplicates` | Compare candidate file(s) against a `corpus.json`, return per-candidate matches |
+
+### Step 1 — build a corpus
+
+```
+mcp__daslang__export_corpus(paths="daslib,utils,my_project", out="corpus.json")
+```
+
+You build the corpus once over the body of code you want to compare against. Re-run it when the code drifts enough that stale matches become a problem.
+
+Output is an envelope:
+
+```json
+{ "out": "...", "files_scanned": 86, "files_skipped": 0, "records_written": 612 }
+```
+
+`files_skipped` counts `.das` files that contain `expect ` directives — those are intentionally-broken fixtures and aren't part of the corpus. If `records_written` is much lower than expected, the corpus was filtered hard by `min_tokens` (default 0 — most callers should leave it there).
+
+### Step 2 — query against a candidate
+
+```
+mcp__daslang__find_duplicates(
+  paths="my_project/new_helper.das",
+  corpus="corpus.json"
+)
+```
+
+Pass `paths` as comma- or newline-delimited (the latter lets you pipe `git diff --name-only` through). Records in the corpus whose `file` matches a `paths` entry are dropped first, then the candidate is freshly compiled — so the file is compared against the rest of the world, never against its own stale copy in the corpus.
+
+The envelope:
+
+```json
+{
+  "corpus_records": 612,
+  "corpus_dropped_for_override": 4,
+  "candidate_files_compiled": 1,
+  "candidate_files_failed": 0,
+  "candidate_functions": 7,
+  "candidate_functions_pre_filter": 7,
+  "exact_clusters_kept": 1,
+  "fuzzy_pairs_kept": 2,
+  "patterns_skipped": {},
+  "report": { "candidates": [ ... ] }
+}
+```
+
+The `report.candidates[]` array is the actionable output: each candidate function with its top-N `exact_matches` (similarity 1.0) and `fuzzy_matches` (similarity in `[threshold, 1)`), each with `file`, `line`, `name`, `is_lambda`. Walk those to investigate.
+
+### Reading the envelope
+
+| Field | What it tells you |
+|---|---|
+| `candidate_functions_pre_filter` | How many candidates the file had before pattern filtering |
+| `candidate_functions` | How many survived the filter and were clustered |
+| `patterns_skipped` | Per-pattern count of records dropped (corpus + candidates). `{}` means the filter was a no-op |
+| `exact_clusters_kept` / `fuzzy_pairs_kept` | Aggregate match counts after the candidate filter |
+
+When `candidate_functions == 0` but `candidate_functions_pre_filter > 0`, the filter consumed every candidate. The report is empty by design; if you want to see those records anyway, retry with `keep="all"` (or with a specific pattern name from `patterns_skipped`).
+
+## Pattern filter
+
+A "pattern" is a structural shape that signals "this function is boilerplate, not real code" — a wrapper or dispatcher whose canonical token stream contains zero unique signal beyond its repetition count. Pattern-matched functions are dropped from clustering by default.
+
+Currently shipped patterns:
+
+| Name | Detects | Why it's boilerplate |
+|---|---|---|
+| `dispatch` | Body is N >= 2 byte-identical top-level statement chunks | Test runners and dispatchers (`t \|> run("X") @(t) {…}` lists, `t \|> bench(…)` lists, repeated-init blocks). Lambda bodies are collapsed to `ADDR` upstream, so two `run` calls look identical regardless of what the lambdas actually do |
+
+Override per-pattern with `keep="<name>"` (comma-separated for multiple), or disable filtering wholesale with `keep="all"`. Default (omit `keep`) skips every known pattern.
+
+The filter applies to **both** corpus records and freshly-compiled candidates. If a corpus is full of dispatch shapes and you don't filter, every candidate function will fuzzy-match every other dispatcher — pure noise. The filter is on by default for that reason; opt out only when you genuinely want to see boilerplate.
+
+## CLI workflow (advanced)
+
+The CLI ships at `utils/find_dupes/main.das` and supports a few modes the MCP tools don't expose. Use it when you need:
+
+- **B1 baseline / CI gate** — `--baseline <corpus.json> --check`. Records absent from the baseline are tagged candidates; non-zero exit when any cluster/pair survives.
+- **`--baseline-strict`** — drops clusters whose canonical was already in the baseline, so only fully-new canonicals survive.
+- **`--against-from-stdin`** — read newline-delimited candidate paths from stdin, e.g. piped from `git diff --name-only`.
+- **`-L / --lambdas-only`** — cluster lambda bodies instead of top-level functions; useful for finding duplicated dastest `run` lambdas.
+- **`--min-tokens N`** — drop trivial wrappers (default 8).
+- **`--no-fuzzy`** — exact clusters only, faster on large corpora.
+
+Quick recipes:
+
+```sh
+# one-off corpus build (commit this)
+bin/daslang utils/find_dupes/main.das -- -p src --export-functions baseline.json
+
+# CI gate: flag any new structural duplicates introduced by a PR
+bin/daslang utils/find_dupes/main.das -- -p src --baseline baseline.json --check
+
+# git pipeline against the baseline
+git diff --name-only master | grep '\.das$' | \
+    bin/daslang utils/find_dupes/main.das -- \
+        --import-functions baseline.json --against-from-stdin
+```
+
+Full flag reference: `bin/daslang utils/find_dupes/main.das -- -?` or the published docs.
+
+## Limitations
+
+- **Structural matcher.** Same shape, different semantics → match. Different shape, same semantics → no match. This is by design (it's fast, deterministic, and surfaces real copy-paste), but it means the report is a "candidates worth investigating" list, not a definitive verdict.
+- **No auto-fix.** Discovery only. Refactoring decisions are yours.
+- **Compile-required.** The candidate file must compile. If `candidate_files_failed > 0`, fix the compile error and rerun.
+- **Macro-expanded.** Canonicalization runs after macro expansion. Two functions that look different in source but collapse to the same shape after macro expansion will match. Usually this is what you want, but it can surprise you with macro-heavy daslib code.
+
+## Tip: Iteration
+
+When investigating, work top-down: most-similar matches first.
+
+1. Look at every `exact_matches` entry — similarity 1.0 means structurally identical, almost always worth a close read.
+2. Then `fuzzy_matches` sorted by `similarity` descending. Above 0.9 is usually a real near-duplicate. 0.7-0.9 is "investigate"; below the default threshold (0.7) the tool already filtered them out.
+3. If the report is dominated by one cluster of obviously-similar functions you don't care about (e.g. all your visitor methods have the same shape), see whether they fit the `dispatch` pattern — if not, that's a candidate for a new pattern in the upstream tool.

--- a/skills/find_dupes.md
+++ b/skills/find_dupes.md
@@ -1,0 +1,237 @@
+# find_dupes — duplicate-function detection
+
+Read this skill before doing duplicate-detection work in this repo, or before editing the tool itself. Two audiences are covered:
+
+- **Using the tool** — building a corpus, asking "does this function already exist?", wiring a CI gate. Lead sections.
+- **Extending the tool** — adding patterns, modifying the canonicalizer, wiring new MCP parameters, refactoring helpers. See [Maintainer notes](#maintainer-notes) at the bottom.
+
+The full user-facing reference lives at `doc/source/reference/utils/find_dupes.rst`; this skill is the operational guide.
+
+## When to use this
+
+- A function you're writing feels familiar — you suspect it already exists somewhere in `daslib/`, `tests/`, or `utils/`.
+- You're reviewing a PR and want a "is this a copy-paste of an existing helper?" check on the diff.
+- You want a CI gate that flags new structural duplicates introduced by a PR (B1 baseline mode).
+
+What it finds: functions whose **canonical token stream** (identifiers, types, and literals all alpha-renamed and collapsed) is byte-identical or close. It is intentionally a structural matcher — `add(a, b : int)` and `add(a, b : float)` look identical to it; that's the point.
+
+What it does **not** find: semantic duplicates with different control flow, different called helpers, or significantly different shape. Two implementations of "the same idea" written from scratch will not match.
+
+## Workflow via MCP (preferred)
+
+The MCP server exposes the entire pipeline — no shelling out:
+
+| MCP tool | Purpose |
+|---|---|
+| `export_corpus` | Scan paths/dirs/globs, compile each `.das` file, write a `corpus.json` |
+| `find_duplicates` | Compare candidate file(s) against a `corpus.json`, return per-candidate matches |
+
+### Step 1 — build a corpus
+
+```
+mcp__daslang__export_corpus(paths="daslib,utils,tests", out="corpus.json")
+```
+
+Build the corpus once over the body of code you want to compare against. Re-run when the code drifts enough that stale matches become a problem.
+
+Envelope:
+
+```json
+{ "out": "...", "files_scanned": 86, "files_skipped": 0, "records_written": 612 }
+```
+
+`files_skipped` counts `.das` files containing `expect ` directives — intentionally-broken fixtures, not part of the corpus.
+
+### Step 2 — query against a candidate
+
+```
+mcp__daslang__find_duplicates(
+  paths="path/to/new_helper.das",
+  corpus="corpus.json"
+)
+```
+
+Pass `paths` as comma- or newline-delimited (the latter lets you pipe `git diff --name-only` through). Records in the corpus whose `file` matches a `paths` entry are dropped first, then the candidate is freshly compiled — so the file is compared against the rest of the world, never against its own stale copy in the corpus.
+
+Envelope:
+
+```json
+{
+  "corpus_records": 612,
+  "corpus_dropped_for_override": 4,
+  "candidate_files_compiled": 1,
+  "candidate_files_failed": 0,
+  "candidate_functions": 7,
+  "candidate_functions_pre_filter": 7,
+  "exact_clusters_kept": 1,
+  "fuzzy_pairs_kept": 2,
+  "patterns_skipped": {},
+  "report": { "candidates": [ ... ] }
+}
+```
+
+`report.candidates[]` is the actionable output: each candidate with its top-N `exact_matches` (similarity 1.0) and `fuzzy_matches` (similarity in `[threshold, 1)`), each with `file`, `line`, `name`, `is_lambda`.
+
+### Reading the envelope
+
+| Field | What it tells you |
+|---|---|
+| `candidate_functions_pre_filter` | How many candidates the file had before pattern filtering |
+| `candidate_functions` | How many survived the filter and were clustered |
+| `patterns_skipped` | Per-pattern count of records dropped (corpus + candidates). `{}` means the filter was a no-op |
+| `exact_clusters_kept` / `fuzzy_pairs_kept` | Aggregate match counts after the candidate filter |
+
+When `candidate_functions == 0` but `candidate_functions_pre_filter > 0`, the filter consumed every candidate. The report is empty by design; if you want those records anyway, retry with `keep="all"` (or with a specific name from `patterns_skipped`).
+
+## Pattern filter
+
+A "pattern" is a structural shape that signals "this function is boilerplate, not real code" — a wrapper or dispatcher whose canonical token stream contains zero unique signal beyond its repetition count. Pattern-matched functions are dropped from clustering by default.
+
+Currently shipped:
+
+| Name | Detects | Why it's boilerplate |
+|---|---|---|
+| `dispatch` | Body is N >= 2 byte-identical top-level statement chunks | dastest's `t \|> run("X") @(t) {…}` lists, `t \|> bench(…)` lists, repeated-init blocks. Lambda bodies collapse to `ADDR` upstream, so two `run` calls look identical regardless of what the lambdas do |
+
+Override per-pattern with `keep="<name>"` (comma-separated for multiple), or disable filtering wholesale with `keep="all"`. Default (omit `keep`) skips every known pattern.
+
+The filter applies to **both** corpus records and freshly-compiled candidates — if a corpus is full of dispatch shapes and you don't filter, every candidate dispatcher will fuzzy-match every other one (pure noise).
+
+## CLI workflow (advanced)
+
+The CLI at `utils/find_dupes/main.das` supports modes the MCP tools don't expose. Use it for:
+
+- **B1 baseline / CI gate** — `--baseline <corpus.json> --check`. Records absent from the baseline are tagged candidates; non-zero exit when any cluster/pair survives.
+- **`--baseline-strict`** — drops clusters whose canonical was already in the baseline; only fully-new canonicals survive.
+- **`--against-from-stdin`** — read newline-delimited candidate paths from stdin, e.g. piped from `git diff --name-only`.
+- **`-L / --lambdas-only`** — cluster lambda bodies instead of top-level functions; useful for finding duplicated dastest `run` lambdas.
+- **`--min-tokens N`** — drop trivial wrappers (default 8).
+- **`--no-fuzzy`** — exact clusters only, faster on large corpora.
+
+Quick recipes:
+
+```sh
+# one-off corpus build (commit this)
+bin/Release/daslang.exe utils/find_dupes/main.das -- -p tests --export-functions tests_baseline.json
+
+# CI gate: flag any new structural duplicates introduced by a PR
+bin/Release/daslang.exe utils/find_dupes/main.das -- -p tests --baseline tests_baseline.json --check
+
+# git pipeline against the baseline
+git diff --name-only master | grep '\.das$' | \
+    bin/Release/daslang.exe utils/find_dupes/main.das -- \
+        --import-functions tests_baseline.json --against-from-stdin
+```
+
+Full flag reference: `bin/Release/daslang.exe utils/find_dupes/main.das -- -?` or `doc/source/reference/utils/find_dupes.rst`.
+
+## Limitations
+
+- **Structural matcher.** Same shape, different semantics → match. Different shape, same semantics → no match. Report is "candidates worth investigating", not a definitive verdict.
+- **No auto-fix.** Discovery only.
+- **Compile-required.** Candidate files must compile. If `candidate_files_failed > 0`, fix the compile error and rerun.
+- **Macro-expanded.** Canonicalization runs after macro expansion. Two functions that differ in source but collapse to the same shape after macros will match — usually what you want, but can surprise you with macro-heavy daslib code.
+
+## Iteration tip
+
+Work top-down: most-similar matches first.
+
+1. Walk every `exact_matches` entry — similarity 1.0 means structurally identical, almost always worth a close read.
+2. Then `fuzzy_matches` sorted by `similarity` descending. Above 0.9 is usually a real near-duplicate; 0.7-0.9 is "investigate"; below the default threshold the tool already filtered them out.
+3. If the report is dominated by one cluster of obviously-similar functions you don't care about (e.g. all your visitor methods have the same shape), check whether they fit the `dispatch` pattern; if not, that's a candidate for a new pattern in the upstream tool.
+
+---
+
+## Maintainer notes
+
+The remainder of this skill is **only relevant when editing the find_dupes tool itself** — adding patterns, modifying the canonicalizer, wiring new MCP parameters, refactoring helpers. SDK users don't need any of it; the install version of this skill (`install/skills/find_dupes.md`) deliberately omits these sections.
+
+### Architecture at a glance
+
+`utils/find_dupes/` is an in-process compile-and-canonicalize pipeline:
+
+1. **Scan** — `scan_das_files` (in `pipeline.das`) walks paths/dirs/globs; skips `builtin.das`, `daslib/debugger.das`, `daslib/profiler.das`, `_*` dirs.
+2. **Compile** — `compile_and_collect` compiles one file at a time. Compile policy mirrors `utils/lint`: `ignore_shared_modules`, `export_all`. Optimisations stay ON so dastest macros (e.g. `unroll`) compile.
+3. **Canonicalize** — `CanonicalVisitor` (in `canonical.das`) emits the alpha-renamed token stream.
+4. **Sign** — `minhash.das` computes 64-slot MinHash over 5-grams (skipped when `want_sigs=false`, e.g. export mode).
+5. **Filter** — `apply_pattern_filter` drops records matching shapes in `patterns.das`.
+6. **Cluster** — `exact_buckets` for byte-identical groups; `fuzzy_pairs` for all-pairs MinHash + length-gate scoring (`cluster.das`).
+7. **Report** — flat or per-candidate JSON + stdout summary (`report.das`).
+
+The pipeline is **shared** between the CLI (`main.das`) and the MCP tools — the MCP tools `require pipeline.das` and call the same functions. Don't duplicate logic; make pipeline helpers `def public` and call them from both.
+
+### Adding a new pattern
+
+Three-step change in `patterns.das` + `test_find_dupes.das`:
+
+1. **Predicate.** Add a `try_<name>(canonical : string; var hit : PatternHit) : bool` in `patterns.das`. Return `true` and populate `hit.name` (the user-visible identifier) and `hit.note` (a short human-readable summary, shown in `--verbose`) when the pattern matches.
+2. **Wire it.** Add the call to `classify()` in priority order — *more specific shapes first*. The first match wins.
+3. **Tests.** Add at least one positive test and one negative test in `test_find_dupes.das` under the `── patterns / classify ──` section. The negative test should be a real-looking canonical that should NOT match (mixed statements, nested blocks, single statement) — guard against the predicate over-firing.
+
+Pattern names are the user-visible contract: they appear in `--keep`, the `--verbose` skip log, the summary line, and the MCP envelope's `patterns_skipped` map. Pick a short, stable identifier.
+
+When matching against tokenized canonicals, prefer `tokenize_canonical` + `split_top_level_stmts` (already in `patterns.das`) — these are BLK-depth aware. Don't roll your own string scan.
+
+### When to extract a helper into `pipeline.das`
+
+If more than one entry point uses it (the CLI in `main.das`, the MCP `find_duplicates` tool, the MCP `export_corpus` tool, and the test suite all count), it lives in `pipeline.das` as `def public`. Examples that already follow this rule: `compile_and_collect`, `apply_pattern_filter`, `scan_das_files`, `is_skip_file`, `has_expect_directive`.
+
+If you're tempted to copy-paste a helper from `main.das` into a new MCP tool: stop, move it into `pipeline.das` first, then call it from both.
+
+### MCP wiring
+
+Two MCP tools, both in `utils/mcp/tools/`:
+
+- `export_corpus.das` — scans paths, compiles, writes the corpus JSON.
+- `find_duplicates.das` — wraps B2 mode. Loads a corpus, compiles candidates, applies pattern filter, returns a per-candidate JSON envelope.
+
+Adding parameters to either tool is a four-site change in `utils/mcp/protocol.das`:
+
+1. **Schema** — `PropertySchema(...)` entry in the tool's `make_tool` call inside `handle_tools_list`.
+2. **Argument extraction** — `arg<N> = get_string_arg(args, "<param>")` line in `handle_tools_call`.
+3. **Dispatch** — forward the new arg in the `dispatch_tool` branch for the tool.
+4. **Tool entry point** — add the parameter to the tool's `do_<tool>` signature in its `.das` file.
+
+`dispatch_tool`, `run_tool`, and `handle_tools_call` currently support `arg1..arg6` plus `project`. If you need a 7th positional slot, extend all three signatures and the `log_tool` format string in lockstep.
+
+### Empty-result handling
+
+The MCP `find_duplicates` tool distinguishes three cases when `cand_refs` is empty after filtering:
+
+1. **Compile failed** (`n_failed > 0`) — error envelope, includes the first failed file path.
+2. **No functions in file** (`candidates_pre_filter == 0`) — error envelope, "no candidate functions extracted from {paths}".
+3. **All candidates were pattern-filtered** (`candidates_pre_filter > 0` but `cand_refs` empty) — *success* envelope with empty `report.candidates`, populated `candidate_functions_pre_filter` and `patterns_skipped`. Caller can read `patterns_skipped` and retry with `keep=<name>`.
+
+When adding new failure modes, preserve this distinction. "Empty result" is not the same as "tool failed" — AI agents need that signal to make the right next call.
+
+### Tests
+
+Two test suites:
+
+- `utils/find_dupes/test_find_dupes.das` — unit tests for the pipeline (tokenizer, canonicalizer, clusterer, pattern matcher, exchange, B1/B2 modes). Run via `bin/Release/daslang.exe dastest/dastest.das -- --test utils/find_dupes/test_find_dupes.das` or the MCP `run_test` tool.
+- `utils/mcp/test_tools.das` — integration tests for the MCP tools, including `do_find_duplicates` and `do_export_corpus`.
+
+When you add a pattern, add tests in *both* places: the `classify()` unit test in `test_find_dupes.das`, and at least one envelope-shape test in `test_tools.das` if the pattern materially changes MCP output (e.g. a new envelope field).
+
+`utils/find_dupes/fixture/synth.das` and `fixture/canonical_cases.das` are hand-crafted fixtures for smoke-testing the visitor end-to-end. If you add a new canonicalization concern (a new AST node visited differently), add a one-function case to `canonical_cases.das`.
+
+### AOT registration
+
+If you add a new test file under `utils/find_dupes/`, register it in `tests/aot/CMakeLists.txt` — see `skills/aot_testing.md`. CI runs ALL tests with AOT enabled.
+
+### Linting / formatting
+
+Standard daslang rules (see `skills/das_formatting.md`). `find_dupes`-specific:
+
+- Records (`FuncRecord`) are non-copyable due to the `sig : array<...>` field. Use `<-`, `push_clone`, or `emplace` when threading them through arrays.
+- Avoid `print` outside `main.das` and the test files. Library helpers in `pipeline.das` / `patterns.das` should be quiet (the MCP tools rely on stdout staying free for JSON-RPC); when you need diagnostics, use `to_log(LOG_INFO)` or take a `verbose : bool` parameter and gate the `print`.
+
+### Updating documentation
+
+Every user-facing change touches three files in lockstep:
+
+- `utils/find_dupes/README.md` — the in-tree quick reference.
+- `doc/source/reference/utils/find_dupes.rst` — the published reference doc.
+- `install/skills/find_dupes.md` — the install-side skill that ships in the SDK.
+
+If a change is repo-dev-only (e.g. a new internal helper, a refactor that doesn't surface), update only this skill (`skills/find_dupes.md`) and skip the install side.

--- a/skills/install_instructions.md
+++ b/skills/install_instructions.md
@@ -23,7 +23,9 @@ Source files live under `install/` in the repo; CMake installs them to the SDK r
 | `install/skills/writing_tests.md` | `skills/writing_tests.md` | dastest framework usage for SDK consumers |
 | `install/skills/memory_leak_detection.md` | `skills/memory_leak_detection.md` | Heap / gc_node / smart_ptr / handle leak detection — runtime CLI flags |
 | `install/skills/jobque_debugging.md` | `skills/jobque_debugging.md` | Channel/LockBox/JobStatus/Stream/Feature leak debugging with `--track-job-status` |
+| `install/skills/find_dupes.md` | `skills/find_dupes.md` | Duplicate-function detection — corpus build, MCP tools (`export_corpus`, `find_duplicates`), CLI modes |
 | `utils/mcp/` (whole dir) | `utils/mcp/` | MCP server for AI assistants (gated on dasHV) |
+| `utils/find_dupes/` (whole dir) | `utils/find_dupes/` | Duplicate-function detector (canonicalizer, clusterer, MinHash, pattern filter) |
 
 ## What belongs in install instructions
 
@@ -106,6 +108,10 @@ After modifying install instructions:
    - `D:/daslang/skills/writing_tests.md`
    - `D:/daslang/skills/memory_leak_detection.md`
    - `D:/daslang/skills/jobque_debugging.md`
+   - `D:/daslang/skills/find_dupes.md`
    - `D:/daslang/utils/mcp/main.das` (only if built with `DAS_HV_DISABLED=OFF`)
    - `D:/daslang/utils/mcp/tools/common.das` (only if built with `DAS_HV_DISABLED=OFF`)
+   - `D:/daslang/utils/find_dupes/main.das`
+   - `D:/daslang/utils/find_dupes/patterns.das`
+   - `D:/daslang/utils/find_dupes/fixture/synth.das`
 4. Spot-check that no repo-internal paths leaked into install files

--- a/utils/find_dupes/README.md
+++ b/utils/find_dupes/README.md
@@ -26,6 +26,7 @@ review.
 ./bin/daslang utils/find_dupes/main.das -- -p tests/strings -t 0.85 -n 20
 ./bin/daslang utils/find_dupes/main.das -- -p daslib --no-fuzzy --min-tokens 32
 ./bin/daslang utils/find_dupes/main.das -- -p tests -L --min-tokens 16    # cluster dastest run() bodies
+./bin/daslang utils/find_dupes/main.das -- -p tests --keep all            # disable pattern filter (legacy view)
 ./bin/daslang utils/find_dupes/main.das -- -?
 ```
 
@@ -51,9 +52,39 @@ Flags:
 | `--against-from-stdin` | off | B2: read newline-delimited candidate paths from stdin (use with `git diff --name-only … \| find_dupes --against-from-stdin …`) |
 | `--check` | off | Exit non-zero when the post-filter report contains any clusters/pairs (CI gate) |
 | `--flat` | off | In `--against` mode, force the flat clusters+pairs writer (default is the per-candidate rollup) |
+| `-k / --keep` | (off) | Pattern name to KEEP despite default skip (repeatable). Special value `all` disables pattern filtering entirely. See "Patterns" below |
 | `-?` | | Help |
 
 `builtin.das`, `daslib/debugger.das`, and `daslib/profiler.das` are skipped automatically — the latter two install thread-local debug agents at compile time, which would abort the scanner on second use.
+
+## Patterns (default-skip filter)
+
+A "pattern" is a structural shape that signals "this function is boilerplate, not real code" — typically a wrapper or dispatcher whose canonical token stream contains zero unique signal beyond its repetition count. Pattern-matched functions are dropped from clustering by default, on the theory that they explode cluster sizes and fuzzy-pair counts without surfacing real duplicates.
+
+Override per-pattern via `--keep <name>` (repeatable), or disable filtering wholesale via `--keep all`.
+
+Currently shipped patterns:
+
+| Name | Detects | Why it's boilerplate |
+|---|---|---|
+| `dispatch` | Function whose body is `N >= 2` byte-identical top-level statement chunks (`STMT … STMT … STMT …` with all chunks equal) | dastest's `t \|> run("X") @(t) { … }` outer functions. Lambda bodies are collapsed to `ADDR` upstream, so two `run` calls look identical regardless of what the lambdas do — the outer function carries zero unique structure beyond its call count. Same shape catches `t \|> bench(…)`, repeated-init blocks, and any uniform call list |
+
+Pattern detection lives in `patterns.das`. Adding a new pattern is a three-step change:
+
+1. Add a `try_<name>(canonical, var hit) : bool` predicate that returns `true` and populates `hit.name` / `hit.note` when matched.
+2. Add the call to `classify()` in priority order (more specific shapes first).
+3. Add at least one positive test and one negative test in `test_find_dupes.das` (under `── patterns / classify ──`).
+
+Pattern names are the user-visible contract — they appear in `--keep`, in the per-record `--verbose` skip log, and in the summary line. Pick a short, stable identifier.
+
+The summary line surfaces what was filtered:
+
+```
+collected 66 record(s); 0 compile failure(s), 1 skipped (expect-directive)
+patterns skipped: 35 dispatch (--keep <name>|all to include)
+```
+
+`--verbose` prints one `pattern-skip [name] file:line func (note)` line per filtered record — useful for confirming the filter isn't dropping real signal on a new corpus.
 
 ## Canonical form
 
@@ -79,7 +110,8 @@ is real signal).
 | `cluster.das` | Exact-bucket clustering + fuzzy all-pairs with length gate |
 | `report.das` | JSON + stdout summary writer |
 | `main.das` | CLI (`daslib/clargs`), file scan, compile-and-collect orchestration |
-| `pipeline.das` | `compile_and_collect` / `collect_from_program` — compile-and-extract orchestration, shared by `main.das` and the test suite |
+| `pipeline.das` | `compile_and_collect` / `collect_from_program` — compile-and-extract orchestration, shared by `main.das` and the test suite. `apply_pattern_filter` drops records matched by `patterns.das` |
+| `patterns.das` | Pattern matchers — `classify(canonical) → PatternHit`. Default-skipped shapes (dispatchers etc.); override via `--keep <name>` |
 | `exchange.das` | On-disk JSON schema + writer/reader for `--export-functions` / `--import-functions` |
 | `fixture/synth.das` | Hand-crafted fixture for smoke-testing the visitor end-to-end |
 | `fixture/canonical_cases.das` | Narrowly-targeted fixture (one function per canonicalization concern) for unit-testing `CanonicalVisitor` |

--- a/utils/find_dupes/exchange.das
+++ b/utils/find_dupes/exchange.das
@@ -96,7 +96,11 @@ def is_well_formed(ef : ExportedFunction) : bool {
 // and `member_id` needs it. pipeline.das re-uses this via `require
 // exchange`, so callers see one canonical helper.
 def public normalize_path(p : string) : string {
-    return p |> replace("\\", "/")
+    // `fio::normalize` resolves `..`/`.` and uses the platform separator
+    // (backslash on Windows, forward slash on POSIX). The trailing
+    // `replace` lands on a canonical forward-slash form so a corpus
+    // exported on one OS matches candidates compiled on another.
+    return normalize(p) |> replace("\\", "/")
 }
 
 

--- a/utils/find_dupes/main.das
+++ b/utils/find_dupes/main.das
@@ -72,92 +72,14 @@ struct Config {
     @clarg_doc = "Force the flat clusters/pairs writer even when --against is active (default in --against mode is the per-candidate writer)"
     flat : bool
 
+    @clarg_short = "k"
+    @clarg_doc = "Pattern name to KEEP despite default skip (repeatable). Special value 'all' disables pattern filtering entirely. Known patterns: 'dispatch'."
+    keep : array<string>
+
     @clarg_short = "?"
     @clarg_name = "show-help"
     @clarg_doc = "Show this help and exit"
     help : bool
-}
-
-
-def is_daslib_skip(path : string; basename : string) : bool {
-    // `daslib/debugger.das` and `daslib/profiler.das` install thread-local
-    // agents at compile time; the second install in the same process throws
-    // and aborts the scan. Match by daslib/ path suffix, not bare basename
-    // — a project's own `myapp/debugger.das` should not be silently skipped.
-    let normalized = normalize_path(path)
-    let prefix = "daslib/{basename}"
-    return normalized == prefix || normalized |> ends_with("/{prefix}")
-}
-
-
-def is_skip_file(path : string; basename : string) : bool {
-    if (basename == "builtin.das") {
-        return true
-    }
-    return (is_daslib_skip(path, "debugger.das")
-        || is_daslib_skip(path, "profiler.das"))
-}
-
-
-def is_skip_dir(name : string) : bool {
-    return name |> starts_with(".")
-}
-
-
-def has_expect_directive(file : string) : bool {
-    let text = fread(file)
-    if (empty(text)) {
-        return false
-    }
-    let lines <- text |> split("\n")
-    for (line in lines) {
-        let trimmed = line |> strip
-        if (trimmed |> starts_with("expect ")) {
-            return true
-        }
-    }
-    return false
-}
-
-
-def scan_das_files(path : string; var files : array<string>; var cache : table<string; void?>) {
-    let st = stat(path)
-    if (!st.is_valid) {
-        return
-    }
-    if (st.is_reg) {
-        if (path |> ends_with(".das") && !cache |> key_exists(path)) {
-            let last_slash = max(rfind(path, "/"), rfind(path, "\\"))
-            let fname = last_slash >= 0 ? slice(path, last_slash + 1) : path
-            if (!is_skip_file(path, fname)) {
-                cache |> insert(path, null)
-                files |> push(path)
-            }
-        }
-        return
-    }
-    if (!st.is_dir) {
-        return
-    }
-    fio::dir(path) $(name) {
-        if (name == "." || name == "..") {
-            return
-        }
-        if (name |> starts_with("_") || is_skip_dir(name)) {
-            return
-        }
-        let full = "{path}/{name}"
-        let fst = stat(full)
-        if (!fst.is_valid) {
-            return
-        }
-        if (fst.is_dir) {
-            scan_das_files(full, files, cache)
-        } elif (fst.is_reg && name |> ends_with(".das") && !is_skip_file(full, name) && !cache |> key_exists(full)) {
-            cache |> insert(full, null)
-            files |> push(full)
-        }
-    }
 }
 
 
@@ -470,6 +392,38 @@ def main() {
         }
         print("loaded {length(baseline_canonicals)} baseline canonical(s), {length(baseline_members)} member(s) from {cfg.baseline}\n")
         tag_baseline_new_members(records, baseline_members)
+    }
+
+    // Pattern filter — drop functions that match a known "boring" shape
+    // (e.g. dastest dispatch outer functions whose body is N >= 2
+    // identical statement chunks). Default is "skip all known patterns";
+    // `--keep <name>` opts a specific pattern back in, `--keep all`
+    // disables filtering entirely. Sits before clustering so dropped
+    // records don't inflate cluster sizes or generate fuzzy pairs.
+    var keep_all = false
+    var kept_set : table<string; void?>
+    for (k in cfg.keep) {
+        if (k == "all") {
+            keep_all = true
+            continue
+        }
+        if (!key_exists(kept_set, k)) {
+            kept_set |> insert(k, null)
+        }
+    }
+    let skip_counts <- apply_pattern_filter(records, kept_set, keep_all, cfg.verbose)
+    if (length(skip_counts) > 0) {
+        var skip_pairs : array<tuple<string; int>>
+        for (k, v in keys(skip_counts), values(skip_counts)) {
+            skip_pairs |> push((k, v))
+        }
+        sort(skip_pairs) <| $(a, b) => a._0 < b._0
+        var parts : array<string>
+        for (kv in skip_pairs) {
+            parts |> push("{kv._1} {kv._0}")
+        }
+        let joined = parts |> join(", ")
+        print("patterns skipped: {joined} (--keep <name>|all to include)\n")
     }
 
     let filter_candidates = has_against || has_baseline

--- a/utils/find_dupes/patterns.das
+++ b/utils/find_dupes/patterns.das
@@ -1,0 +1,111 @@
+options gen2
+
+require strings
+require daslib/strings_boost
+require canonical
+
+
+// PatternHit is the verdict of `classify`. A non-empty `name` flags
+// the function as matching a known "boring" shape (dispatcher, repeated
+// init, etc.) — the caller drops it from clustering unless the user
+// explicitly asked to keep this pattern via `--keep <name>`.
+struct public PatternHit {
+    name : string
+    note : string
+}
+
+
+// Single entry point for "is this function carrying real signal?"
+// Returns `name == ""` when the function is interesting; non-empty
+// otherwise. Patterns are tried in priority order — the first match
+// wins, which means more specific shapes should be checked before
+// more general ones.
+def public classify(canonical : string) : PatternHit {
+    var hit = PatternHit()
+    if (try_dispatch(canonical, hit)) {
+        return hit
+    }
+    return hit
+}
+
+
+// Dispatch shape: the function body is N >= 2 byte-identical top-level
+// statement chunks. Catches dastest's `t |> run("X") @(t) { … }` lists
+// and any other "uniform call list" outer function. Lambda bodies are
+// collapsed to a single `ADDR` token upstream by the canonicalizer, so
+// two `run` statements look identical regardless of what the lambdas
+// actually do — meaning the outer function carries zero unique
+// structure beyond "this many calls".
+def try_dispatch(canonical : string; var hit : PatternHit) : bool {
+    let stmts <- split_top_level_stmts(canonical)
+    if (length(stmts) < 2) {
+        return false
+    }
+    for (i in range(1, length(stmts))) {
+        if (stmts[i] != stmts[0]) {
+            return false
+        }
+    }
+    hit.name := "dispatch"
+    hit.note := "{length(stmts)}x repeated"
+    return true
+}
+
+
+// Split a canonical token stream into its top-level statement chunks.
+// "Top-level" means within the outer `BODY BLK … ENDBLK` block, NOT
+// nested inside any inner BLK/ENDBLK pair (loop bodies, if/then/else
+// bodies, lambda bodies via MK_BLK, with/assume blocks).
+//
+// Tracks BLK depth on a flat token walk. `STMT` and `FIN_STMT` are
+// both treated as boundary markers so a function body that ends in
+// a final-expression block doesn't merge its last two statements.
+//
+// Returns an empty array for forward-declarations and other
+// body-less canonicals (no `BODY BLK` pair found).
+def public split_top_level_stmts(canonical : string) : array<string> {
+    var out : array<string>
+    let toks <- tokenize_canonical(canonical)
+    let n = length(toks)
+    var i = 0
+    while (i + 1 < n && !(toks[i] == "BODY" && toks[i + 1] == "BLK")) {
+        i++
+    }
+    if (i + 1 >= n) {
+        return <- out
+    }
+    i += 2
+    var depth = 0
+    var cur_start = -1
+    while (i < n) {
+        let tok = toks[i]
+        if (depth == 0 && (tok == "STMT" || tok == "FIN_STMT")) {
+            if (cur_start >= 0) {
+                out |> push(join_tokens(toks, cur_start, i))
+            }
+            cur_start = i
+        } elif (tok == "BLK") {
+            depth++
+        } elif (tok == "ENDBLK") {
+            if (depth == 0) {
+                if (cur_start >= 0) {
+                    out |> push(join_tokens(toks, cur_start, i))
+                }
+                return <- out
+            }
+            depth--
+        }
+        i++
+    }
+    return <- out
+}
+
+
+def join_tokens(toks : array<string>; lo : int; hi : int) : string {
+    var sb : array<string>
+    sb |> reserve(hi - lo)
+    for (k in range(lo, hi)) {
+        sb |> push(toks[k])
+    }
+    return sb |> join(" ")
+}

--- a/utils/find_dupes/pipeline.das
+++ b/utils/find_dupes/pipeline.das
@@ -2,15 +2,119 @@ options gen2
 
 require daslib/ast
 require daslib/ast_boost
+require daslib/fio
+require daslib/strings_boost
 require strings
 require canonical
 require cluster
 require exchange
+require patterns
 
 
 // `normalize_path` lives in exchange.das — pulled in via `require exchange`
 // above so callers in this file (and downstream of `require pipeline`) keep
 // working unchanged.
+
+
+// ── filesystem scanning ──────────────────────────────────────────────
+//
+// Walks a directory tree (or accepts a single file) and collects `.das`
+// paths to compile. Lives here (rather than in `main.das`) so MCP tools
+// — which can't shell out to the CLI — can build a corpus end-to-end
+// from inside the same process.
+
+// `daslib/debugger.das` and `daslib/profiler.das` install thread-local
+// agents at compile time; the second install in the same process throws
+// and aborts the scan. Match by daslib/ path suffix, not bare basename
+// — a project's own `myapp/debugger.das` should not be silently skipped.
+def public is_daslib_skip(path : string; basename : string) : bool {
+    let normalized = normalize_path(path)
+    let prefix = "daslib/{basename}"
+    return normalized == prefix || normalized |> ends_with("/{prefix}")
+}
+
+
+def public is_skip_file(path : string; basename : string) : bool {
+    if (basename == "builtin.das") {
+        return true
+    }
+    return (is_daslib_skip(path, "debugger.das")
+        || is_daslib_skip(path, "profiler.das"))
+}
+
+
+def public is_skip_dir(name : string) : bool {
+    return name |> starts_with(".")
+}
+
+
+// `expect` directives mark intentionally-broken test files (the test
+// framework runs the compiler and checks the produced error). Skipping
+// avoids polluting the corpus with junk records from files that aren't
+// supposed to compile.
+def public has_expect_directive(file : string) : bool {
+    let text = fread(file)
+    if (empty(text)) {
+        return false
+    }
+    let lines <- text |> split("\n")
+    for (line in lines) {
+        let trimmed = line |> strip
+        if (trimmed |> starts_with("expect ")) {
+            return true
+        }
+    }
+    return false
+}
+
+
+def public scan_das_files(path : string; var files : array<string>; var cache : table<string; void?>) {
+    let st = stat(path)
+    if (!st.is_valid) {
+        return
+    }
+    if (st.is_reg) {
+        if (path |> ends_with(".das")) {
+            // Normalize before keying/pushing so seeds spelled differently
+            // (`a/b/c.das` vs `a\b\c.das` on Windows, or with `./` segments)
+            // don't sneak duplicate entries past the cache.
+            let np = normalize_path(path)
+            if (!cache |> key_exists(np)) {
+                let fname = base_name(np)
+                if (!is_skip_file(np, fname)) {
+                    cache |> insert(np, null)
+                    files |> push(np)
+                }
+            }
+        }
+        return
+    }
+    if (!st.is_dir) {
+        return
+    }
+    fio::dir(path) $(name) {
+        if (name == "." || name == "..") {
+            return
+        }
+        if (name |> starts_with("_") || is_skip_dir(name)) {
+            return
+        }
+        let full = path_join(path, name)
+        let fst = stat(full)
+        if (!fst.is_valid) {
+            return
+        }
+        if (fst.is_dir) {
+            scan_das_files(full, files, cache)
+        } elif (fst.is_reg && name |> ends_with(".das") && !is_skip_file(full, name)) {
+            let np = normalize_path(full)
+            if (!cache |> key_exists(np)) {
+                cache |> insert(np, null)
+                files |> push(np)
+            }
+        }
+    }
+}
 
 
 // Walk one compiled program and append a FuncRecord per user
@@ -94,6 +198,46 @@ def public drop_records_under_files(var records : array<FuncRecord>;
     }
     records <- kept
     return dropped
+}
+
+
+// Walk records, classify each by `patterns/classify`, and drop any whose
+// matched pattern is not in `kept`. Returns a per-pattern count of what
+// was dropped so the caller can surface a summary line.
+//
+// `keep_all == true` is the legacy passthrough — no classification, no
+// drops. Useful for `--keep all` and any future "pattern-skip is broken,
+// give me everything" escape hatch.
+//
+// In-place: rebuilds `records` to keep matched-and-not-kept entries out.
+// Uses push_clone to avoid worrying about non-copyable fields (`sig`).
+def public apply_pattern_filter(var records : array<FuncRecord>;
+                                kept : table<string; void?>;
+                                keep_all : bool;
+                                verbose : bool) : table<string; int> {
+    var skip_counts : table<string; int>
+    if (keep_all) {
+        return <- skip_counts
+    }
+    var kept_records : array<FuncRecord>
+    kept_records |> reserve(length(records))
+    for (r in records) {
+        let hit = classify(r.canonical)
+        if (empty(hit.name) || key_exists(kept, hit.name)) {
+            kept_records |> push_clone(r)
+            continue
+        }
+        if (verbose) {
+            print("  pattern-skip [{hit.name}]: {r.ref.file}:{r.ref.line} {r.ref.name} ({hit.note})\n")
+        }
+        if (key_exists(skip_counts, hit.name)) {
+            skip_counts[hit.name] = skip_counts[hit.name] + 1
+        } else {
+            skip_counts |> insert(hit.name, 1)
+        }
+    }
+    records <- kept_records
+    return <- skip_counts
 }
 
 

--- a/utils/find_dupes/test_find_dupes.das
+++ b/utils/find_dupes/test_find_dupes.das
@@ -13,6 +13,7 @@ require minhash
 require cluster
 require exchange
 require pipeline
+require patterns
 require report
 
 
@@ -997,4 +998,149 @@ def test_per_candidate_rollup_shape(t : T?) {
     t |> success(pcr.candidates[0].fuzzy_matches[0].similarity > 0.6f
         && pcr.candidates[0].fuzzy_matches[0].similarity < 1.0f,
         "fuzzy similarity in (0.6, 1.0): {pcr.candidates[0].fuzzy_matches[0].similarity}")
+}
+
+
+// ── patterns / classify ──────────────────────────────────────────────
+
+[test]
+def test_pattern_dispatch_three_identical_stmts(t : T?) {
+    let canon = "FN ARG <var_0> TYP BODY BLK STMT CALL:run <var_0> LIT ADDR STMT CALL:run <var_0> LIT ADDR STMT CALL:run <var_0> LIT ADDR ENDBLK ENDFN"
+    let hit = classify(canon)
+    t |> equal(hit.name, "dispatch")
+    t |> equal(hit.note, "3x repeated")
+}
+
+
+[test]
+def test_pattern_dispatch_two_identical_stmts(t : T?) {
+    // ≥ 2 is the documented threshold; verify the boundary fires.
+    let canon = "FN ARG <var_0> TYP BODY BLK STMT CALL:run <var_0> LIT ADDR STMT CALL:run <var_0> LIT ADDR ENDBLK ENDFN"
+    let hit = classify(canon)
+    t |> equal(hit.name, "dispatch")
+    t |> equal(hit.note, "2x repeated")
+}
+
+
+[test]
+def test_pattern_single_stmt_not_dispatch(t : T?) {
+    // One statement is not a uniform-call list — keep the function.
+    let canon = "FN ARG <var_0> TYP BODY BLK STMT CALL:run <var_0> LIT ADDR ENDBLK ENDFN"
+    let hit = classify(canon)
+    t |> equal(hit.name, "")
+}
+
+
+[test]
+def test_pattern_empty_body_not_dispatch(t : T?) {
+    let canon = "FN ARG <var_0> TYP BODY BLK ENDBLK ENDFN"
+    let hit = classify(canon)
+    t |> equal(hit.name, "")
+}
+
+
+[test]
+def test_pattern_mixed_stmts_not_dispatch(t : T?) {
+    // Mixed call names (run / bench) — body isn't uniform, don't classify.
+    let canon = "FN ARG <var_0> TYP BODY BLK STMT CALL:run <var_0> LIT ADDR STMT CALL:bench <var_0> LIT ADDR ENDBLK ENDFN"
+    let hit = classify(canon)
+    t |> equal(hit.name, "")
+}
+
+
+[test]
+def test_pattern_nested_block_not_dispatch(t : T?) {
+    // Outer body has ONE top-level statement — an if/then with two nested
+    // STMTs inside. The inner STMTs must not be treated as top-level
+    // boundaries; otherwise we'd wrongly count 2 identical "STMT CALL:foo"
+    // chunks and classify as dispatch.
+    let canon = "FN ARG <var_0> TYP BODY BLK STMT IF <var_0> THEN BLK STMT CALL:foo <var_0> ENDBLK ELSE BLK STMT CALL:foo <var_0> ENDBLK ENDBLK ENDFN"
+    let hit = classify(canon)
+    t |> equal(hit.name, "")
+}
+
+
+[test]
+def test_pattern_real_code_not_dispatch(t : T?) {
+    // The "real test" canonical from strings_convert.das — long, mixed
+    // STMTs, definitely not a dispatcher.
+    let canon = "FN ARG <var_0> TYP BODY BLK STMT LET LET_VAR <var_1> STMT RET OP2:+ <var_1> LIT ENDBLK ENDFN"
+    let hit = classify(canon)
+    t |> equal(hit.name, "")
+}
+
+
+[test]
+def test_split_top_level_stmts_skips_nested(t : T?) {
+    // One top-level for-loop body containing N statements should yield
+    // exactly ONE chunk at the top level — confirms BLK depth tracking.
+    let canon = "FN ARG <var_0> TYP BODY BLK STMT FOR FOR_VAR <var_1> <var_0> FOR_BODY BLK STMT CALL:foo <var_1> STMT CALL:bar <var_1> ENDBLK ENDBLK ENDFN"
+    let stmts <- split_top_level_stmts(canon)
+    t |> equal(length(stmts), 1)
+}
+
+
+// ── apply_pattern_filter ─────────────────────────────────────────────
+
+[test]
+def test_apply_pattern_filter_drops_dispatch(t : T?) {
+    var records : array<FuncRecord> <- [
+        <- make_record("real",
+            "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, false),
+        <- make_record("dispatcher",
+            "FN ARG <var_0> TYP BODY BLK STMT CALL:run <var_0> LIT ADDR STMT CALL:run <var_0> LIT ADDR ENDBLK ENDFN", 2, false)]
+    let kept : table<string; void?>
+    var counts <- apply_pattern_filter(records, kept, false, false)
+    t |> equal(length(records), 1)
+    t |> equal(records[0].ref.name, "real")
+    t |> equal(length(counts), 1)
+    t |> success(key_exists(counts, "dispatch"), "dispatch counted")
+    t |> equal(counts["dispatch"], 1)
+}
+
+
+[test]
+def test_apply_pattern_filter_keep_all_passthrough(t : T?) {
+    // keep_all=true short-circuits classification entirely — both
+    // records survive, and skip_counts is empty.
+    var records : array<FuncRecord> <- [
+        <- make_record("real",
+            "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, false),
+        <- make_record("dispatcher",
+            "FN ARG <var_0> TYP BODY BLK STMT CALL:run <var_0> LIT ADDR STMT CALL:run <var_0> LIT ADDR ENDBLK ENDFN", 2, false)]
+    let kept : table<string; void?>
+    let counts <- apply_pattern_filter(records, kept, true, false)
+    t |> equal(length(records), 2)
+    t |> equal(length(counts), 0)
+}
+
+
+[test]
+def test_apply_pattern_filter_explicit_keep_dispatch(t : T?) {
+    // kept_set contains "dispatch" → dispatcher record is kept, no drops.
+    var records : array<FuncRecord> <- [
+        <- make_record("real",
+            "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, false),
+        <- make_record("dispatcher",
+            "FN ARG <var_0> TYP BODY BLK STMT CALL:run <var_0> LIT ADDR STMT CALL:run <var_0> LIT ADDR ENDBLK ENDFN", 2, false)]
+    var kept : table<string; void?>
+    kept |> insert("dispatch", null)
+    let counts <- apply_pattern_filter(records, kept, false, false)
+    t |> equal(length(records), 2)
+    t |> equal(length(counts), 0)
+}
+
+
+[test]
+def test_apply_pattern_filter_preserves_candidate_flag(t : T?) {
+    // Records that survive must keep their is_candidate flag (relied on
+    // by --against / --baseline modes).
+    var records : array<FuncRecord> <- [
+        <- make_record("real",
+            "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN", 1, false)]
+    records[0].is_candidate = true
+    let kept : table<string; void?>
+    let counts <- apply_pattern_filter(records, kept, false, false)
+    t |> equal(length(records), 1)
+    t |> success(records[0].is_candidate, "is_candidate flag preserved through filter")
 }

--- a/utils/mcp/protocol.das
+++ b/utils/mcp/protocol.das
@@ -35,6 +35,7 @@ require tools/outline public
 require tools/aot public
 require tools/lint_tool public
 require tools/find_duplicates public
+require tools/export_corpus public
 require tools/live public
 
 let HEAP_COLLECT_THRESHOLD = 1024ul * 1024ul  // 1 MB
@@ -424,6 +425,17 @@ def handle_tools_list(id_json : string) : string {
         ["file"]
     ))
     result.tools |> emplace(make_tool(
+        "export_corpus",
+        "Build a corpus.json from one or more .das files/dirs/globs. Output is the same shape `find_duplicates` expects: a JSON dump of every user function's canonical token stream and source location. Run this once over a body of code (e.g. 'daslib', 'tests', or your project) to produce a corpus, then point `find_duplicates` at it. This is the MCP-side replacement for `find_dupes --export-functions`; the whole workflow stays inside the MCP server with no shelling out.",
+        {
+            "paths" => PropertySchema(_type = "string", description = "Files, directories, or globs to scan. Comma- or newline-delimited. Directories are walked recursively. Skips `_*` directories, hidden directories, `builtin.das`, `daslib/debugger.das`, and `daslib/profiler.das`."),
+            "out" => PropertySchema(_type = "string", description = "Output corpus.json path. Overwrites if it exists. Refuses to write a partial corpus when any input file fails to compile (matches the CLI's --export-functions behavior)."),
+            "min_tokens" => PropertySchema(_type = "string", description = "Minimum canonical-token count per record (default 0 — keep every user function). Records below the threshold are dropped at export time. Most callers should leave this at 0 and let `find_duplicates --min-tokens` filter at query time."),
+            "project" => PROJECT_PROP
+        },
+        ["paths", "out"]
+    ))
+    result.tools |> emplace(make_tool(
         "find_duplicates",
         "Find functions in `paths` that duplicate or closely resemble functions in a pre-built corpus (an `--export-functions` JSON from `find_dupes`). Returns a per-candidate JSON report: each input function, its top exact-cluster siblings, and its top fuzzy partners with similarity scores. Use to answer 'did I just write something that already exists?' during PR authoring or review.",
         {
@@ -432,6 +444,7 @@ def handle_tools_list(id_json : string) : string {
             "threshold" => PropertySchema(_type = "string", description = "Fuzzy similarity floor 0..1 (default 0.7). Score is sqrt(jaccard × len_ratio)."),
             "min_tokens" => PropertySchema(_type = "string", description = "Minimum canonical-token count per function (default 8). Filters trivial wrappers."),
             "top" => PropertySchema(_type = "string", description = "Top-N similar matches per candidate (default 5)."),
+            "keep" => PropertySchema(_type = "string", description = "Comma-separated pattern names to KEEP despite the default-skip filter. Special value 'all' disables pattern filtering entirely. Default is empty — all known patterns are skipped (currently: 'dispatch'). The skipped count is reported in the envelope as `patterns_skipped`."),
             "project" => PROJECT_PROP
         },
         ["paths", "corpus"]
@@ -524,7 +537,7 @@ def get_string_arg(args : JsonValue?; name : string) : string {
     return ""
 }
 
-def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, project : string) : string {
+def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project : string) : string {
     if (tool_name == "compile_check") {
         return do_compile_check(arg1, project, arg2 == "true")
     } elif (tool_name == "list_functions") {
@@ -570,7 +583,9 @@ def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, project : string) : s
     } elif (tool_name == "lint") {
         return do_lint(arg1, project)
     } elif (tool_name == "find_duplicates") {
-        return do_find_duplicates(arg1, arg2, arg3, arg4, arg5, project)
+        return do_find_duplicates(arg1, arg2, arg3, arg4, arg5, arg6, project)
+    } elif (tool_name == "export_corpus") {
+        return do_export_corpus(arg1, arg2, arg3, project)
     } elif (tool_name == "live_status") {
         return do_live_status(arg1)
     } elif (tool_name == "live_error") {
@@ -593,18 +608,18 @@ def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, project : string) : s
     }
 }
 
-def run_tool(tool_name, arg1, arg2, arg3, arg4, arg5, project : string) : string {
-    log_tool(tool_name, "{arg1} {arg2} {arg3} {arg4} {arg5}")
+def run_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project : string) : string {
+    log_tool(tool_name, "{arg1} {arg2} {arg3} {arg4} {arg5} {arg6}")
     let t0 = get_clock()
     var result : string
     // Live tools run on the main thread — they use system() and sleep() which
     // don't work well from new_thread, and they don't need compilation context
     if (starts_with(tool_name, "live_")) {
-        result = dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, project)
+        result = dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project)
     } else {
         with_channel(1) $(ch) {
             new_thread() <| @() {
-                let tool_result = dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, project)
+                let tool_result = dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project)
                 ch |> push_clone(ToolMessage(text = tool_result))
                 ch |> notify_and_release()
             }
@@ -625,7 +640,7 @@ def handle_tools_call(id_json : string; params : JsonValue?) : string {
         return json_rpc_error(id_json, -32602, "missing tool name")
     }
     let name = tool_name_val.value as _string
-    var arg1, arg2, arg3, arg4, arg5 : string
+    var arg1, arg2, arg3, arg4, arg5, arg6 : string
     let project = get_string_arg(args, "project")
     if (name == "compile_check") {
         arg1 = get_string_arg(args, "file")
@@ -758,6 +773,17 @@ def handle_tools_call(id_json : string; params : JsonValue?) : string {
         arg3 = get_string_arg(args, "threshold")
         arg4 = get_string_arg(args, "min_tokens")
         arg5 = get_string_arg(args, "top")
+        arg6 = get_string_arg(args, "keep")
+    } elif (name == "export_corpus") {
+        arg1 = get_string_arg(args, "paths")
+        if (empty(arg1)) {
+            return json_rpc_error(id_json, -32602, "missing 'paths' argument")
+        }
+        arg2 = get_string_arg(args, "out")
+        if (empty(arg2)) {
+            return json_rpc_error(id_json, -32602, "missing 'out' argument")
+        }
+        arg3 = get_string_arg(args, "min_tokens")
     } elif (name == "live_status") {
         arg1 = get_string_arg(args, "port")
     } elif (name == "live_error") {
@@ -792,7 +818,7 @@ def handle_tools_call(id_json : string; params : JsonValue?) : string {
     } else {
         return json_rpc_error(id_json, -32602, "unknown tool: {name}")
     }
-    return json_rpc_response(id_json, run_tool(name, arg1, arg2, arg3, arg4, arg5, project))
+    return json_rpc_response(id_json, run_tool(name, arg1, arg2, arg3, arg4, arg5, arg6, project))
 }
 
 // ── JSON-RPC dispatcher ──────────────────────────────────────────────

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -1,4 +1,5 @@
 options gen2
+options rtti
 options no_unused_function_arguments = false
 options no_unused_block_arguments = false
 
@@ -30,6 +31,7 @@ require tools/outline public
 require tools/aot public
 require tools/lint_tool public
 require tools/find_duplicates public
+require tools/export_corpus public
 
 // helper: parse tool result JSON, return (text, isError)
 def parse_result(result : string; var text : string&; var is_error : bool&) : bool {
@@ -1284,7 +1286,7 @@ def test_find_duplicates_missing_corpus(t : T?) {
     t |> run("missing 'corpus' arg returns error envelope") <| @(t : T?) {
         var text : string
         var is_error = false
-        let ok = parse_result(do_find_duplicates("foo.das", "", "", "", "", ""), text, is_error)
+        let ok = parse_result(do_find_duplicates("foo.das", "", "", "", "", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error")
         t |> success(find(text, "corpus") >= 0, "should mention corpus: {text}")
@@ -1301,7 +1303,7 @@ def test_find_duplicates_missing_paths(t : T?) {
         }
         var text : string
         var is_error = false
-        let ok = parse_result(do_find_duplicates("", path, "", "", "", ""), text, is_error)
+        let ok = parse_result(do_find_duplicates("", path, "", "", "", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error")
         t |> success(find(text, "paths") >= 0, "should mention paths: {text}")
@@ -1324,7 +1326,7 @@ def test_find_duplicates_corpus_not_found(t : T?) {
         var text : string
         var is_error = false
         let ok = parse_result(do_find_duplicates(fixture_path("_fixture_valid.das"),
-            bogus, "", "", "", ""), text, is_error)
+            bogus, "", "", "", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error")
     }
@@ -1341,16 +1343,17 @@ def test_find_duplicates_empty_corpus(t : T?) {
         var text : string
         var is_error = false
         let ok = parse_result(do_find_duplicates(fixture_path("_fixture_valid.das"),
-            path, "", "", "", ""), text, is_error)
+            path, "", "", "", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(!is_error, "should NOT be error: {text}")
         t |> success(find(text, "candidate_functions") >= 0, "envelope has candidate_functions: {text}")
         t |> success(find(text, "exact_clusters_kept") >= 0, "envelope has exact_clusters_kept")
         t |> success(find(text, "fuzzy_pairs_kept") >= 0, "envelope has fuzzy_pairs_kept")
+        t |> success(find(text, "patterns_skipped") >= 0, "envelope has patterns_skipped")
         t |> success(find(text, "\"report\"") >= 0, "envelope has nested report")
         // Empty corpus → no matches possible.
-        t |> success(find(text, "\"exact_clusters_kept\": 0") >= 0, "zero exact clusters: {text}")
-        t |> success(find(text, "\"fuzzy_pairs_kept\": 0") >= 0, "zero fuzzy pairs: {text}")
+        t |> success(find(text, "\"exact_clusters_kept\":0") >= 0, "zero exact clusters: {text}")
+        t |> success(find(text, "\"fuzzy_pairs_kept\":0") >= 0, "zero fuzzy pairs: {text}")
         remove(path)
     }
 }
@@ -1366,11 +1369,81 @@ def test_find_duplicates_bad_schema(t : T?) {
         var text : string
         var is_error = false
         let ok = parse_result(do_find_duplicates(fixture_path("_fixture_valid.das"),
-            path, "", "", "", ""), text, is_error)
+            path, "", "", "", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error")
         t |> success(find(text, "schema_version") >= 0, "mentions schema_version: {text}")
         remove(path)
+    }
+}
+
+
+// ── export_corpus ────────────────────────────────────────────────────
+
+
+[test]
+def test_export_corpus_missing_paths(t : T?) {
+    t |> run("missing 'paths' arg returns error envelope") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_export_corpus("", "export_corpus_test_out.json", "", ""), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(is_error, "should be error")
+        t |> success(find(text, "paths") >= 0, "should mention paths: {text}")
+    }
+}
+
+
+[test]
+def test_export_corpus_missing_out(t : T?) {
+    t |> run("missing 'out' arg returns error envelope") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_export_corpus("foo.das", "", "", ""), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(is_error, "should be error")
+        t |> success(find(text, "out") >= 0, "should mention out: {text}")
+    }
+}
+
+
+[test]
+def test_export_corpus_no_match(t : T?) {
+    t |> run("paths matching nothing yields error envelope") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_export_corpus("does_not_exist_xyzzy.das", "export_corpus_test_out.json", "", ""), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(is_error, "should be error: {text}")
+    }
+}
+
+
+[test]
+def test_export_corpus_writes_envelope(t : T?) {
+    t |> run("valid fixture produces a corpus and a populated envelope") <| @(t : T?) {
+        let r = create_temp_file_result("export_corpus_mcp_test", ".json")
+        if (!(r is value)) {
+            t |> failure("create_temp_file_result failed")
+            return
+        }
+        let out_path = unsafe(r.value)
+        // create_temp_file_result returns a path to a freshly-created temp
+        // file. write_export reopens it with "wb" and overwrites, so leaving
+        // the placeholder in place is the intended path.
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_export_corpus(fixture_path("_fixture_valid.das"), out_path, "", ""), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(!is_error, "should NOT be error: {text}")
+        t |> success(find(text, "files_scanned") >= 0, "envelope has files_scanned: {text}")
+        t |> success(find(text, "records_written") >= 0, "envelope has records_written: {text}")
+        t |> success(find(text, "\"out\":") >= 0, "envelope echoes out path: {text}")
+        // Confirm the file actually exists and is non-empty.
+        let body = fread(out_path)
+        t |> success(!empty(body), "corpus file is non-empty")
+        t |> success(find(body, "\"schema_version\"") >= 0, "corpus has schema_version: {body}")
+        remove(out_path)
     }
 }
 

--- a/utils/mcp/tools/export_corpus.das
+++ b/utils/mcp/tools/export_corpus.das
@@ -1,0 +1,118 @@
+options gen2
+options rtti
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require common public
+require ../../find_dupes/pipeline.das
+require ../../find_dupes/cluster.das
+require ../../find_dupes/exchange.das
+require strings
+
+
+struct ExportCorpusEnvelope {
+    out : string
+    files_scanned : int
+    files_skipped : int
+    records_written : int
+}
+
+
+def parse_int_default(s : string; default_val : int) : int {
+    if (empty(s)) {
+        return default_val
+    }
+    return to_int(s)
+}
+
+
+// MCP entry point: scan the given paths, compile each .das file in
+// process, and write a corpus.json that `find_duplicates` can later
+// consume. This is the MCP-side replacement for the CLI's
+// `find_dupes --export-functions <out>` so the whole workflow stays
+// inside the MCP server (no shelling out to daslang).
+//
+// Args:
+//   paths     comma- or newline-delimited list of files/dirs/globs
+//   out       output corpus.json path
+//   min_tokens minimum token count per record (default 0 — keep all,
+//              matches the CLI default for export mode where it's a
+//              raw dump of the corpus and downstream callers re-filter)
+//   project   optional .das_project for module resolution
+//
+// stdio is reserved for JSON-RPC, so `compile_and_collect` runs with
+// quiet=true and we report counts via the returned envelope.
+def public do_export_corpus(paths : string; out : string;
+                            min_tokens_str : string;
+                            project : string) : string {
+    if (empty(out)) {
+        return make_tool_result("export_corpus: missing required 'out' parameter (output corpus.json path)", true)
+    }
+    if (empty(paths)) {
+        return make_tool_result("export_corpus: missing required 'paths' parameter (one or more .das files/dirs/globs)", true)
+    }
+    let min_tokens = parse_int_default(min_tokens_str, 0)
+    if (min_tokens < 0) {
+        return make_tool_result("export_corpus: min_tokens must be >= 0, got {min_tokens}", true)
+    }
+
+    // `parse_file_list` expects comma- or glob-delimited input; normalize
+    // newlines first so `git ls-files | …` style piping works the same as
+    // the find_duplicates tool.
+    let paths_normalized = paths |> replace("\n", ",")
+    var seeds : array<string>
+    parse_file_list(paths_normalized, seeds)
+    if (empty(seeds)) {
+        return make_tool_result("export_corpus: no paths matched: {paths}", true)
+    }
+
+    // scan_das_files handles dirs, files, and globs uniformly and applies
+    // the daslib-skip filter (debugger/profiler agents would crash on
+    // re-install).
+    var files : array<string>
+    var cache : table<string; void?>
+    for (s in seeds) {
+        scan_das_files(s, files, cache)
+    }
+    if (empty(files)) {
+        return make_tool_result("export_corpus: no .das files found under: {paths}", true)
+    }
+    sort(files)
+
+    var records : array<FuncRecord>
+    var seen_loc : table<string; void?>
+    var n_failed = 0
+    var n_skipped = 0
+    var failed_files : array<string>
+    for (f in files) {
+        if (has_expect_directive(f)) {
+            n_skipped++
+            continue
+        }
+        // want_sigs=false: export captures the raw token stream; MinHash
+        // sigs are recomputed on import, so signing here would just be
+        // discarded work. Mirrors the CLI's export-mode behavior.
+        if (!compile_and_collect(f, records, seen_loc, false, false, false, min_tokens, true, project)) {
+            n_failed++
+            failed_files |> push(f)
+        }
+    }
+
+    if (n_failed > 0) {
+        // Matches CLI behavior: refuse to write a partial corpus.
+        // Sharding scripts that merge exports rely on this signal.
+        let first_fail = empty(failed_files) ? "" : failed_files[0]
+        return make_tool_result("export_corpus: {n_failed} compile failure(s); refusing to write partial export (first: {first_fail})", true)
+    }
+
+    if (!write_export(records, out)) {
+        return make_tool_result("export_corpus: could not write export to {out}", true)
+    }
+
+    let envelope = ExportCorpusEnvelope(
+        out = out,
+        files_scanned = length(files),
+        files_skipped = n_skipped,
+        records_written = length(records))
+    return make_tool_result(sprint_json(envelope, false), false)
+}

--- a/utils/mcp/tools/find_duplicates.das
+++ b/utils/mcp/tools/find_duplicates.das
@@ -1,4 +1,5 @@
 options gen2
+options rtti
 options no_unused_function_arguments = false
 options no_unused_block_arguments = false
 
@@ -11,6 +12,23 @@ require ../../find_dupes/canonical.das
 require strings
 require math
 require daslib/strings_boost
+
+
+// `report` is a string holding the per-candidate report (already-serialized
+// JSON from `write_per_candidate_report`). `@embed` emits it as raw JSON,
+// preserving the existing nested-object envelope shape — no double-encoding.
+struct FindDuplicatesEnvelope {
+    corpus_records : int
+    corpus_dropped_for_override : int
+    candidate_files_compiled : int
+    candidate_files_failed : int
+    candidate_functions : int
+    candidate_functions_pre_filter : int
+    exact_clusters_kept : int
+    fuzzy_pairs_kept : int
+    patterns_skipped : table<string; int>
+    @embed report : string
+}
 
 
 def parse_float_default(s : string; default_val : float) : float {
@@ -42,9 +60,10 @@ def public do_find_duplicates(paths : string; corpus : string;
                               threshold_str : string;
                               min_tokens_str : string;
                               top_str : string;
+                              keep_str : string;
                               project : string) : string {
     if (empty(corpus)) {
-        return make_tool_result("find_duplicates: missing required 'corpus' parameter (path to a corpus.json produced by `find_dupes --export-functions`)", true)
+        return make_tool_result("find_duplicates: missing required 'corpus' parameter (path to a corpus.json produced by the `export_corpus` MCP tool or `find_dupes --export-functions`)", true)
     }
     if (empty(paths)) {
         return make_tool_result("find_duplicates: missing required 'paths' parameter (one or more .das files; comma- or newline-delimited, or a glob)", true)
@@ -115,12 +134,75 @@ def public do_find_duplicates(paths : string; corpus : string;
         n_compiled++
     }
 
+    // Count candidates BEFORE the pattern filter so we can distinguish
+    // "compile produced nothing" (real error) from "filter ate everything"
+    // (successful run, empty result). The CLI conflates these into
+    // `panic`; in MCP we want an actionable signal back to the caller.
+    var candidates_pre_filter = 0
+    for (r in records) {
+        if (r.is_candidate) {
+            candidates_pre_filter++
+        }
+    }
+
+    // Pattern filter — drops boilerplate shapes (e.g. dastest dispatch
+    // outer functions) before clustering so they don't pollute clusters
+    // or fuzzy pairs. `keep` is parsed identically to the CLI: a comma-
+    // separated list of pattern names to opt back in, or 'all' to disable
+    // filtering entirely. Default (empty) skips every known pattern.
+    var keep_all = false
+    var kept_set : table<string; void?>
+    if (!empty(keep_str)) {
+        let parts <- split_by_chars(keep_str, ", \t\n")
+        for (k in parts) {
+            if (empty(k)) {
+                continue
+            }
+            if (k == "all") {
+                keep_all = true
+                continue
+            }
+            if (!key_exists(kept_set, k)) {
+                kept_set |> insert(k, null)
+            }
+        }
+    }
+    var skip_counts <- apply_pattern_filter(records, kept_set, keep_all, false)
+
     let cand_refs <- collect_candidate_refs(records)
     if (empty(cand_refs)) {
-        let msg = (n_failed > 0
-            ? "find_duplicates: no candidate functions extracted (compile failed for {n_failed} file(s); first: {failed_files[0]})"
-            : "find_duplicates: no candidate functions extracted from {paths}")
-        return make_tool_result(msg, true)
+        // Real failure cases: compile error, or the file genuinely has
+        // no functions (header / forward-decls only). Both warrant an
+        // error envelope.
+        if (n_failed > 0) {
+            return make_tool_result(
+                "find_duplicates: no candidate functions extracted (compile failed for {n_failed} file(s); first: {failed_files[0]})",
+                true)
+        }
+        if (candidates_pre_filter == 0) {
+            return make_tool_result("find_duplicates: no candidate functions extracted from {paths}", true)
+        }
+        // Filter consumed every candidate. Skip clustering — every cluster
+        // and pair would be corpus-only and `write_per_candidate_report`
+        // gates on candidates anyway. Return the envelope directly so the
+        // caller sees `candidates_pre_filter` and `patterns_skipped` and
+        // can retry with `keep=…`.
+        var empty_envelope : FindDuplicatesEnvelope
+        empty_envelope.corpus_records = corpus_total
+        empty_envelope.corpus_dropped_for_override = dropped
+        empty_envelope.candidate_files_compiled = n_compiled
+        empty_envelope.candidate_files_failed = n_failed
+        empty_envelope.candidate_functions = 0
+        empty_envelope.candidate_functions_pre_filter = candidates_pre_filter
+        empty_envelope.exact_clusters_kept = 0
+        empty_envelope.fuzzy_pairs_kept = 0
+        empty_envelope.patterns_skipped <- skip_counts
+        var empty_rep : Report
+        empty_rep.summary.functions_analyzed = length(records)
+        empty_rep.summary.threshold = threshold
+        empty_rep.summary.min_tokens = min_tokens
+        empty_envelope.report = write_per_candidate_report(empty_rep, cand_refs, top)
+        return make_tool_result(sprint_json(empty_envelope, false), false)
     }
 
     var clusters <- exact_buckets(records, min_tokens, true)
@@ -139,19 +221,17 @@ def public do_find_duplicates(paths : string; corpus : string;
 
     // Wrap the per-candidate report in a small envelope so consumers can
     // see corpus stats and compile-failure counts without parsing stdout.
-    let pcr_body = write_per_candidate_report(rep, cand_refs, top)
-    let envelope = build_string() $(var w) {
-        w |> write("\{")
-        w |> write("\"corpus_records\": {corpus_total}, ")
-        w |> write("\"corpus_dropped_for_override\": {dropped}, ")
-        w |> write("\"candidate_files_compiled\": {n_compiled}, ")
-        w |> write("\"candidate_files_failed\": {n_failed}, ")
-        w |> write("\"candidate_functions\": {length(cand_refs)}, ")
-        w |> write("\"exact_clusters_kept\": {rep.summary.exact_clusters}, ")
-        w |> write("\"fuzzy_pairs_kept\": {rep.summary.fuzzy_pairs}, ")
-        w |> write("\"report\": ")
-        w |> write(pcr_body)
-        w |> write("\}")
-    }
-    return make_tool_result(envelope, n_failed > 0)
+    // `report` carries pre-serialized JSON via `@embed` — no double-encoding.
+    var envelope : FindDuplicatesEnvelope
+    envelope.corpus_records = corpus_total
+    envelope.corpus_dropped_for_override = dropped
+    envelope.candidate_files_compiled = n_compiled
+    envelope.candidate_files_failed = n_failed
+    envelope.candidate_functions = length(cand_refs)
+    envelope.candidate_functions_pre_filter = candidates_pre_filter
+    envelope.exact_clusters_kept = rep.summary.exact_clusters
+    envelope.fuzzy_pairs_kept = rep.summary.fuzzy_pairs
+    envelope.patterns_skipped <- skip_counts
+    envelope.report = write_per_candidate_report(rep, cand_refs, top)
+    return make_tool_result(sprint_json(envelope, false), n_failed > 0)
 }


### PR DESCRIPTION
## Summary

- Pattern filter framework for `find_dupes` — drop structurally-boilerplate functions before clustering. Ships with one pattern (`dispatch`: bodies that are N >= 2 byte-identical top-level statement chunks, e.g. dastest's `t |> run("…") @(t) {…}` outer functions). Exposed via `--keep <name>` (CLI) and `keep` (MCP).
- New MCP `export_corpus` tool — scan paths, compile in-process, write the corpus JSON. The whole find_dupes workflow now stays inside the MCP server with no shelling out.
- MCP `find_duplicates` no longer error-envelopes when the pattern filter consumes every candidate — it returns success with `candidate_functions_pre_filter` and `patterns_skipped` so the caller can react.

## Why

Most clusters surfaced by find_dupes on a dastest-style corpus were "dispatch" shapes — outer functions whose body is a uniform list of `t |> run("X") @(t) {…}` calls. Lambda bodies collapse to `ADDR` upstream, so the dispatchers carry zero unique structure beyond their call count. They polluted exact clusters and exploded fuzzy-pair counts without surfacing real duplicates.

Worked example on `tests/algorithm` (12-function file, 32-record corpus):

| metric | `keep=all` (filter off) | default (filter on) |
|---|---|---|
| candidate_functions | 12 | 0 |
| exact_clusters_kept | 6 | 0 |
| fuzzy_pairs_kept | **83** | 0 |
| patterns_skipped | `{}` | `{"dispatch": 22}` |

The 83 fuzzy pairs were noise — every `test_*` outer function looks identical to every other one. The filter eliminates them; the new envelope tells the caller exactly what happened.

## Surface

**Pattern filter framework**
- `utils/find_dupes/patterns.das` — `classify(canonical) → PatternHit`. Adding a pattern is a 3-step change documented in the new `skills/find_dupes.md`.
- `utils/find_dupes/pipeline.das` — `apply_pattern_filter` drops matched records before clustering; returns per-pattern skip counts.

**CLI**
- `-k / --keep <name>` (repeatable) opts a pattern back in; `--keep all` disables filtering wholesale. Default skips all known patterns.
- Summary line:
  ```
  collected 66 record(s); 0 compile failure(s), 1 skipped (expect-directive)
  patterns skipped: 35 dispatch (--keep <name>|all to include)
  ```

**MCP**
- `find_duplicates` gains a `keep` parameter mirroring the CLI flag. Envelope now includes `candidate_functions_pre_filter` and `patterns_skipped`.
- New `export_corpus` tool — scans paths/dirs/globs, compiles in-process, writes corpus JSON.
- `dispatch_tool` / `run_tool` / `handle_tools_call` extended from 5 to 6 positional args.

**Refactoring**
- Filesystem scan helpers (`scan_das_files`, `is_skip_file`, `has_expect_directive`) moved from `main.das` into `pipeline.das` as `def public` so the new MCP `export_corpus` and the CLI share one implementation.

## Documentation

- `doc/source/reference/utils/find_dupes.rst` — new full reference (flags, modes, patterns, MCP, implementation).
- `doc/source/reference/utils.rst` — toctree entry, description sentence.
- `doc/source/reference/utils/mcp.rst` — tool count 28→32 (also fixes a pre-existing off-by-one), new "Duplicate detection" section.
- `utils/find_dupes/README.md` — Patterns section, summary-line example, three-step "adding a pattern" recipe.
- `skills/find_dupes.md` — new repo skill (usage-first, Maintainer-notes appendix for editing/extending the tool).
- `install/skills/find_dupes.md` — new SDK-user-facing skill.
- `CLAUDE.md`, `install/CLAUDE.md`, `skills/install_instructions.md` — wiring for the new skill files and MCP tools.
- `CMakeLists.txt` — install rules so `utils/find_dupes/` ships with the SDK alongside `utils/mcp/` (no module dependencies).

## Tests

- 11 new pattern unit tests in `test_find_dupes.das` covering threshold (2-stmt boundary), nested-block guard, mixed-stmt negative, real-code negative, drops/keeps/keep-all/preserves-flag.
- 4 new envelope-shape tests in `test_tools.das` for `do_export_corpus`.
- All existing 5 `find_duplicates` tests updated for the new `keep` parameter; the empty-corpus test asserts the new `patterns_skipped` field appears in the envelope.

## Test plan

- [x] Lint changed `.das` files — clean (15 pre-existing warnings in `daslib/clargs.das` and `test_find_dupes.das` lines I didn't touch)
- [x] `dastest --test tests/` — 7045/7051 passed; one failure (`tests/language/random_numbers.das`, `random_float is in [0,1)` assertion inverted) reproduces identically on master, unrelated to this PR
- [x] `test_aot.exe -use-aot ... --test tests` — same one pre-existing failure as master, all else green
- [x] `sphinx-build -W --keep-going -b html` after `bin/daslang doc/reflections/das2rst.das` — clean, exit 0, zero warnings
- [x] MCP `format_file` on every changed `.das` — already-formatted across the board
- [x] End-to-end MCP demo: `export_corpus` → `find_duplicates` with `keep=all` and default — confirmed 12 candidates, 83 fuzzy pairs of pure noise vs. clean envelope with `"patterns_skipped": {"dispatch": 22}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)