### PR TITLE
tests/aot: fix dasHV include path to use <CONFIG>

### DIFF
--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -756,7 +756,7 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_pugixml test_aot_pugixml_modules
     test_aot_dashv test_aot_dashv_modules
 )
-target_include_directories(test_aot PRIVATE ${NEED_MODULES_PATH} ${PROJECT_SOURCE_DIR}/modules/dasUnitTest ${PROJECT_SOURCE_DIR}/modules/dasLiveHost/src ${AUDIO_INCLUDE_DIR} ${CIPIC_HRTF_INCLUDE_DIR} ${PROJECT_SOURCE_DIR}/modules/dasMinfft/minfft ${PROJECT_SOURCE_DIR}/modules/dasPUGIXML/pugixml ${PROJECT_SOURCE_DIR}/modules/dasHV/hv/include ${SQLITE_INCLUDE_DIR})
+target_include_directories(test_aot PRIVATE ${NEED_MODULES_PATH} ${PROJECT_SOURCE_DIR}/modules/dasUnitTest ${PROJECT_SOURCE_DIR}/modules/dasLiveHost/src ${AUDIO_INCLUDE_DIR} ${CIPIC_HRTF_INCLUDE_DIR} ${PROJECT_SOURCE_DIR}/modules/dasMinfft/minfft ${PROJECT_SOURCE_DIR}/modules/dasPUGIXML/pugixml ${PROJECT_SOURCE_DIR}/modules/dasHV/hv/$<CONFIG>/include ${SQLITE_INCLUDE_DIR})
 target_compile_definitions(test_aot PRIVATE DAS_TEST_AOT MINFFT_SINGLE HRTF_SAMPLE_RATE=${DAS_AUDIO_SAMPLE_RATE})
 SETUP_CPP11(test_aot)
 SETUP_LTO(test_aot)


### PR DESCRIPTION
## Summary

- `tests/aot/CMakeLists.txt:759` hardcoded `modules/dasHV/hv/include`, but libhv's `ExternalProject_Add` installs to `modules/dasHV/hv/$<CONFIG>/include` (per `modules/dasHV/CMakeLists.txt:78`).
- Match the canonical pattern that `modules/dasHV/CMakeLists.txt:109` already uses for its own `TARGET_INCLUDE_DIRECTORIES`: `${DAS_HV_DIR}/hv/$<CONFIG>/include`.

## Why CI never tripped this

No workflow simultaneously enables HV **and** runs `test_aot`:

- `build.yml` runs `test_aot` but never sets `DAS_HV_DISABLED=OFF`. With the default `ON`, the dasHV AOT sources are gated out (`tests/aot/CMakeLists.txt:191/200/448/454`), so the bad include path is added to the target but no `.cpp` ever does `#include "hv/requests.h"`.
- `pages.yml` and `doc.yml` set `DAS_HV_DISABLED=OFF` but only build docs.

So this only bites locally (or in any downstream consumer) the moment someone builds `test_aot` with HV enabled — the symptom is `'hv/requests.h' file not found` for every dasHV AOT test stub.

## Test plan

- [x] `cmake --build build --target test_aot -j 8` succeeds on Mac (Ninja, Release) with `DAS_HV_DISABLED=OFF` and **no** `modules/dasHV/hv/include` symlink workaround in place.
- [x] `bin/test_aot -use-aot dastest/dastest.das -- --use-aot --test tests/dasHV` → **132 / 132 passed, 0 failed, 0 errors, 0 skipped**.
- [x] `dasHV` is the only consumer of this kind of include path in `tests/aot/CMakeLists.txt` — audited the other entries (`dasUnitTest`, `dasLiveHost`, `dasMinfft`, `dasPUGIXML`, `dasSqlite`, `AUDIO_INCLUDE_DIR`, `CIPIC_HRTF_INCLUDE_DIR`); all are vendored source dirs or variables that resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)