### PR TITLE
cmake/apple: add -fwrapv so AOT C++ matches daslang wrap semantics

### DIFF
--- a/CMakeCommon.txt
+++ b/CMakeCommon.txt
@@ -135,6 +135,12 @@ MACRO(SETUP_COMPILER)
 	ELSEIF(APPLE)
 		ADD_DEFINITIONS(-DITS_PLATFORM_APPLE=1)
 		ADD_DEFINITIONS(-Wall -Wextra -pedantic)
+		# Treat signed integer overflow as two's-complement wrap.
+		# daslang signed arithmetic is defined to wrap. AOT lowers it to plain C++
+		# `int * int` / `int + int`, which is UB at the C++ level and AppleClang 21+
+		# exploits it (e.g. the LCG step in daslib/random.das becomes miscompiled).
+		# -fwrapv makes the C++ output faithfully match daslang's semantics.
+		ADD_COMPILE_OPTIONS(-fwrapv)
 		# UNCOMMENT FOR ASAN
 		# ADD_DEFINITIONS("-fsanitize=thread")
 		# SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")


### PR DESCRIPTION
## Summary

- daslang signed integer arithmetic is defined to wrap (two's-complement). AOT lowers it to plain C++ `int * int` / `int + int`, which is **undefined behavior** in C++.
- AppleClang 21 (Xcode 26.4) has a value-range optimization that exploits the UB and miscompiles the LCG step in `daslib/random.das`, surfacing as the `tests/language/random_numbers.das` AOT failure on `t |> equal(f < 1.0, true)`. AppleClang 17 (current CI default Xcode on `macos-26-xlarge`) does not exploit it yet, so CI was green while local builds on newer Xcode were broken.
- The bug lives in the AOT codegen layer (signed-int lowering), not in any `.das` source — `daslib/random.das` is correct daslang. `-fwrapv` operates at exactly the layer where the UB is, and makes the emitted C++ faithfully match daslang's documented wrap semantics.

## Verification (local, AppleClang 21.0.0 / Xcode 26.4)

- AOT suite: **6490/6490 passing** (1 failure before the flag — `random_float is in [0,1)`)
- Interpreted suite: **7078/7078 passing**

## Notes

A deeper architectural fix would lower daslang signed `*` / `+` through a uint-internal helper in AOT codegen, removing the dependency on host-compiler flags entirely. Left as a follow-up — the flag covers it in one line and inoculates against any other latent signed-overflow patterns in AOT output.

The Linux/Windows/Android paths still rely on the host compiler not exploiting the UB. Extend `-fwrapv` (or the MSVC equivalent) to those branches if those toolchains start to break.

## Test plan

- [x] Full `test_aot` suite passes (6490/6490)
- [x] Full interpreted suite passes (7078/7078)
- [x] `tests/language/random_numbers.das` AOT now passes on AppleClang 21
- [ ] CI green (Linux + macOS-with-Xcode-17 should still be green; this only adds a flag to the Apple branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)