### PR TITLE
utils/mcp: parse_file_list expands globs inside comma/newline lists (#2498)

### DIFF
--- a/utils/find_dupes/pipeline.das
+++ b/utils/find_dupes/pipeline.das
@@ -308,6 +308,7 @@ def public compile_and_collect(file : string; var records : array<FuncRecord>;
         using() $(var cop : CodeOfPolicies) {
             cop.ignore_shared_modules = true
             cop.export_all = true
+            cop.version_2_syntax = true
             // Leave optimisations and infer-time folding ON: dastest macros
             // (e.g. unroll) need constant folding to compile, and folded-equal
             // expressions are exactly the kind of duplicate we want to catch.

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -152,6 +152,93 @@ def test_compile_check_glob_no_match(t : T?) {
     }
 }
 
+// ── parse_file_list ──────────────────────────────────────────────────
+
+def has_path(files : array<string>; suffix : string) : bool {
+    for (f in files) {
+        if (find(f, suffix) >= 0) {
+            return true
+        }
+    }
+    return false
+}
+
+[test]
+def test_parse_file_list(t : T?) {
+    t |> run("single plain file") <| @(t : T?) {
+        var files : array<string>
+        parse_file_list("utils/mcp/tests/_fixture_valid.das", files)
+        t |> equal(length(files), 1, "1 file")
+        t |> equal(files[0], "utils/mcp/tests/_fixture_valid.das", "passes through")
+    }
+    t |> run("single glob expands") <| @(t : T?) {
+        var files : array<string>
+        parse_file_list("utils/mcp/tests/_fixture_v*.das", files)
+        t |> success(length(files) >= 1, "at least one match")
+        t |> success(has_path(files, "_fixture_valid.das"), "valid fixture matched")
+    }
+    t |> run("comma list of plain files") <| @(t : T?) {
+        var files : array<string>
+        parse_file_list("a.das,b.das,c.das", files)
+        t |> equal(length(files), 3, "3 files")
+        t |> equal(files[0], "a.das", "first")
+        t |> equal(files[1], "b.das", "second")
+        t |> equal(files[2], "c.das", "third")
+    }
+    t |> run("comma list of globs (issue #2498 repro)") <| @(t : T?) {
+        var files : array<string>
+        parse_file_list("utils/find_dupes/*.das,utils/mcp/tests/*.das", files)
+        t |> success(has_path(files, "utils/find_dupes/"), "find_dupes glob expanded")
+        t |> success(has_path(files, "utils/mcp/tests/"), "mcp/tests glob expanded")
+    }
+    t |> run("mixed plain + glob") <| @(t : T?) {
+        var files : array<string>
+        parse_file_list("utils/mcp/tests/_fixture_valid.das,utils/mcp/tests/_fixture_e*.das", files)
+        t |> success(has_path(files, "_fixture_valid.das"), "plain file present")
+        t |> success(has_path(files, "_fixture_error.das"), "glob expanded")
+    }
+    t |> run("newline-delimited") <| @(t : T?) {
+        var files : array<string>
+        parse_file_list("a.das\nb.das\nc.das", files)
+        t |> equal(length(files), 3, "3 files")
+        t |> equal(files[0], "a.das", "first")
+        t |> equal(files[1], "b.das", "second")
+        t |> equal(files[2], "c.das", "third")
+    }
+    t |> run("mixed comma + newline + whitespace") <| @(t : T?) {
+        var files : array<string>
+        parse_file_list("  a.das , b.das \n c.das ", files)
+        t |> equal(length(files), 3, "3 files (whitespace stripped)")
+        t |> equal(files[0], "a.das", "first stripped")
+        t |> equal(files[2], "c.das", "third stripped")
+    }
+    t |> run("empty parts skipped") <| @(t : T?) {
+        var files : array<string>
+        parse_file_list("a.das,,\n,b.das", files)
+        t |> equal(length(files), 2, "2 non-empty files")
+    }
+    t |> run("single fast-path strips whitespace") <| @(t : T?) {
+        var files : array<string>
+        parse_file_list("  a.das  ", files)
+        t |> equal(length(files), 1, "1 file")
+        t |> equal(files[0], "a.das", "stripped")
+    }
+    t |> run("single fast-path skips empty/whitespace-only") <| @(t : T?) {
+        var files : array<string>
+        parse_file_list("   ", files)
+        t |> equal(length(files), 0, "no files for whitespace-only input")
+    }
+    t |> run("expand_glob preserves prior entries (no global re-sort)") <| @(t : T?) {
+        // Repro for the regression Copilot caught: expand_glob's sort()
+        // used to scramble entries pushed before it. Order must be
+        // preserved across (plain, glob, plain) sequences.
+        var files : array<string>
+        parse_file_list("zzz.das,utils/mcp/tests/_fixture_v*.das,aaa.das", files)
+        t |> equal(files[0], "zzz.das", "first plain stays first")
+        t |> equal(files[length(files) - 1], "aaa.das", "last plain stays last")
+    }
+}
+
 // ── list_functions ───────────────────────────────────────────────────
 
 [test]

--- a/utils/mcp/tools/common.das
+++ b/utils/mcp/tools/common.das
@@ -344,44 +344,50 @@ def expand_glob(pattern : string; var result : array<string>) {
         dir_part = slice(pattern, 0, last_slash)
         file_pattern = slice(pattern, last_slash + 1)
     }
+    var matches : array<string>
     dir(dir_part) $(fname) {
         if (fname == "." || fname == "..") {
             return
         }
         if (glob_match(file_pattern, fname)) {
             if (dir_part == ".") {
-                result |> push(fname)
+                matches |> push(fname)
             } else {
-                result |> push("{dir_part}/{fname}")
+                matches |> push("{dir_part}/{fname}")
             }
         }
     }
-    sort(result)
+    sort(matches)
+    result |> reserve(length(result) + length(matches))
+    for (m in matches) {
+        result |> push(m)
+    }
 }
 
-// Parse file argument: glob pattern, comma-separated list, or single file
+// Parse file argument: comma- or newline-separated list of files, dirs, and
+// globs (any part may contain `*` / `?` wildcards, expanded via expand_glob).
 def parse_file_list(file : string; var result : array<string>) {
-    if (find(file, "*") >= 0 || find(file, "?") >= 0) {
-        expand_glob(file, result)
-    } elif (find(file, ",") >= 0) {
-        var rest = file
-        while (!empty(rest)) {
-            let comma = find(rest, ",")
-            if (comma >= 0) {
-                let part = strip(slice(rest, 0, comma))
-                if (!empty(part)) {
-                    result |> push(part)
-                }
-                rest = slice(rest, comma + 1)
-            } else {
-                let part = strip(rest)
-                if (!empty(part)) {
-                    result |> push(part)
-                }
-                break
-            }
+    if (find(file, ",") < 0 && find(file, "\n") < 0) {
+        let part = strip(file)
+        if (empty(part)) {
+            return
         }
-    } else {
-        result |> push(file)
+        if (find(part, "*") >= 0 || find(part, "?") >= 0) {
+            expand_glob(part, result)
+        } else {
+            result |> push(part)
+        }
+        return
+    }
+    for (raw in split_by_chars(file, ",\n")) {
+        let part = strip(raw)
+        if (empty(part)) {
+            continue
+        }
+        if (find(part, "*") >= 0 || find(part, "?") >= 0) {
+            expand_glob(part, result)
+        } else {
+            result |> push(part)
+        }
     }
 }

--- a/utils/mcp/tools/export_corpus.das
+++ b/utils/mcp/tools/export_corpus.das
@@ -56,12 +56,8 @@ def public do_export_corpus(paths : string; out : string;
         return make_tool_result("export_corpus: min_tokens must be >= 0, got {min_tokens}", true)
     }
 
-    // `parse_file_list` expects comma- or glob-delimited input; normalize
-    // newlines first so `git ls-files | …` style piping works the same as
-    // the find_duplicates tool.
-    let paths_normalized = paths |> replace("\n", ",")
     var seeds : array<string>
-    parse_file_list(paths_normalized, seeds)
+    parse_file_list(paths, seeds)
     if (empty(seeds)) {
         return make_tool_result("export_corpus: no paths matched: {paths}", true)
     }

--- a/utils/mcp/tools/find_duplicates.das
+++ b/utils/mcp/tools/find_duplicates.das
@@ -81,12 +81,8 @@ def public do_find_duplicates(paths : string; corpus : string;
         return make_tool_result("find_duplicates: top must be >= 0, got {top}", true)
     }
 
-    // `parse_file_list` only splits on commas and globs, so normalize
-    // newlines first — supports `git diff --name-only ... | …` style input
-    // that the README documents.
-    let paths_normalized = paths |> replace("\n", ",")
     var files : array<string>
-    parse_file_list(paths_normalized, files)
+    parse_file_list(paths, files)
     if (empty(files)) {
         return make_tool_result("find_duplicates: no files matched: {paths}", true)
     }


### PR DESCRIPTION
Fixes #2498.

## Summary

`parse_file_list` in `utils/mcp/tools/common.das` checked for `*`/`?` **before** splitting on commas, so the entire string was treated as a single glob whenever any wildcard was present. Inputs like `"src/*.das,tests/*.das"` produced no expansion because `expand_glob` then split at the last `/`, derived an invalid directory, and returned nothing usable.

Fixed across `compile_check`, `lint_tool`, `find_duplicates`, and `export_corpus` (all share `parse_file_list`).

## What changed

- **`utils/mcp/tools/common.das`** — split first on `,` and `\n`, strip+filter empty parts, then `expand_glob` each part that contains a wildcard. Single-file fast path preserved (no allocation when there are no separators).
- **`utils/mcp/tools/export_corpus.das`** and **`utils/mcp/tools/find_duplicates.das`** — drop the now-redundant `replace("\n", ",")` workaround; `parse_file_list` handles newlines natively.
- **`utils/mcp/test_tools.das`** — `test_parse_file_list` covers all 8 cases from the issue:
  - single plain file
  - single glob
  - comma list of plain files
  - comma list of globs (issue #2498 repro)
  - mixed plain + glob
  - newline-delimited
  - mixed comma + newline + whitespace
  - empty parts skipped
- **`utils/find_dupes/pipeline.das`** — set `cop.version_2_syntax = true` in the corpus-build CodeOfPolicies. Surfaced during this PR's `make_pr` dupe check: gen2 is the language default everywhere else, but find_dupes was running its compile pass under v1 default and choking on utility files that omit `options gen2` at the top. Small, related cleanup.

## Test plan

- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test utils/mcp/test_tools.das` — 198/198 pass (8 new sub-tests + the rest of the MCP suite)
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test utils/find_dupes/test_find_dupes.das` — 77/77 pass with the new `version_2_syntax` flag
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests` — 7104/7104 pass
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — 6516/6516 pass
- [x] Lint clean on all 5 changed `.das` files
- [x] find_duplicates against `utils/` corpus: no actionable matches for the new/changed functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)