### PR TITLE
dasSQLITE: chunk 6 — UPDATE / DELETE / Transactions

### DIFF
--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -307,6 +307,9 @@ Run any tutorial from the project root::
    tutorials/sql_16_left_join.rst
    tutorials/sql_17_subqueries.rst
    tutorials/sql_18_null_handling.rst
+   tutorials/sql_19_update.rst
+   tutorials/sql_20_delete.rst
+   tutorials/sql_22_transactions.rst
 
 .. _tutorials_dasaudio:
 

--- a/doc/source/reference/tutorials/sql_18_null_handling.rst
+++ b/doc/source/reference/tutorials/sql_18_null_handling.rst
@@ -170,3 +170,5 @@ to the outer success/failure wrapper:
     Full source: :download:`tutorials/sql/18-null_handling.das <../../../../tutorials/sql/18-null_handling.das>`
 
     Previous tutorial: :ref:`tutorial_sql_subqueries`
+
+    Next tutorial: :ref:`tutorial_sql_update`

--- a/doc/source/reference/tutorials/sql_19_update.rst
+++ b/doc/source/reference/tutorials/sql_19_update.rst
@@ -1,0 +1,121 @@
+.. _tutorial_sql_update:
+
+==========================================
+SQL-19 --- UPDATE
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; UPDATE
+    single: Tutorial; update
+    single: Tutorial; _sql_update
+    single: Tutorial; _sql_update_returning
+    single: Tutorial; try_update
+    single: Tutorial; RETURNING
+
+Five flavours, mirroring the SELECT side:
+
+==============================================  ===================================================
+Form                                            When to use
+==============================================  ===================================================
+``db |> update(row)``                           by-PK whole-row replace from a loaded struct
+``db |> _sql_update(type<T>, where, set)``      bulk: predicate + named-tuple set clause
+``db |> _sql_update_returning(...)``            bulk + capture rows AFTER the update
+``db |> exec(sql)``                             raw escape hatch for migrations / dynamic SQL
+``db |> try_update(...)`` / ``_sql_try_*``      non-panic ``Result<int, string>`` variants
+==============================================  ===================================================
+
+All forms return ``int`` rows-affected (or ``array<T>`` for
+RETURNING). 0 rows-affected is **not** an error --- the row simply
+wasn't there. ``Err`` from the ``try_`` variants is reserved for
+genuine SQL failures (constraint violation, IO, BUSY).
+
+Naming
+======
+
+The function form is plain ``update`` / ``try_update``. The macro
+form carries the ``_sql_`` prefix --- ``_sql_update`` /
+``_sql_try_update`` / ``_sql_update_returning`` /
+``_sql_try_update_returning`` --- to match the flagship
+``_sql(...)`` macro and keep the SQL provenance visible at the call
+site. RETURNING is macro-only; there is no plain
+``update_returning`` function.
+
+By-PK whole-row replace
+=======================
+
+.. code-block:: das
+
+    let n1 = db |> update(User(Id = 1, Name = "alice", Email = "alice@new.com",
+                                Active = true, LastSeen = 100l))
+    // UPDATE "Users" SET "Name"=?, "Email"=?, "Active"=?, "LastSeen"=?
+    //   WHERE "Id" = ?
+
+A non-matching PK returns 0 rows-affected. Not an error.
+
+Bulk update via the macro
+=========================
+
+``_sql_update(type<T>, where_expr, set_expr)`` translates the
+predicate to SQL and binds captured locals automatically. The set
+clause is a named-tuple literal ``(Col=expr, ...)`` whose RHS may
+reference column refs (``_.Other``) and outer-scope locals.
+
+.. code-block:: das
+
+    let cutoff : int64 = 250l
+    let stale = db |> _sql_update(type<User>, _.LastSeen < cutoff, (Active = false))
+    // UPDATE "Users" SET "Active" = ? WHERE "LastSeen" < ?
+
+Bulk RETURNING --- capture rows AFTER the update
+================================================
+
+.. code-block:: das
+
+    let touch_at : int64 = 1000l
+    let revived <- db |> _sql_update_returning(type<User>, _.Id == 4,
+        (Active = true, LastSeen = touch_at))
+    // UPDATE "Users" SET "Active" = ?, "LastSeen" = ? WHERE "Id" = ?
+    //   RETURNING "Id", "Name", "Email", "Active", "LastSeen"
+
+Useful for audit logs, "update-and-publish" pipelines, or any
+caller that needs the post-update row state in one round-trip.
+
+Raw-SQL escape hatch
+====================
+
+``exec`` runs arbitrary SQL with no parameter binding --- useful
+for migrations or queries the macro can't (or shouldn't) translate.
+For dynamic values in raw SQL, format them into the string yourself
+(taking care to escape) or stick with the macro forms.
+
+.. code-block:: das
+
+    db |> exec("UPDATE Users SET Name = 'admin' WHERE Id = 1")
+    // db |> changes() reports rows-affected from the most recent
+    // INSERT / UPDATE / DELETE on this connection.
+
+Non-panic ``try_`` variants
+===========================
+
+Return ``Result<int, string>``. 0 rows-affected is NOT an ``Err``
+(reserved for constraint violation / IO / BUSY).
+
+.. code-block:: das
+
+    let attempt = db |> try_update(User(Id = 999, Name = "phantom",
+                                         Email = "", Active = false, LastSeen = 0l))
+    if (attempt |> is_err) {
+        // "constraint failed: ..." or similar
+    } else {
+        let n = attempt |> unwrap   // 0 if PK didn't match
+    }
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/19-update.das <../../../../tutorials/sql/19-update.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_null_handling`
+
+    Next tutorial: :ref:`tutorial_sql_delete`

--- a/doc/source/reference/tutorials/sql_20_delete.rst
+++ b/doc/source/reference/tutorials/sql_20_delete.rst
@@ -1,0 +1,116 @@
+.. _tutorial_sql_delete:
+
+==========================================
+SQL-20 --- DELETE
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; DELETE
+    single: Tutorial; delete_
+    single: Tutorial; delete_by_id
+    single: Tutorial; _sql_delete
+    single: Tutorial; _sql_delete_returning
+    single: Tutorial; try_delete_
+
+Six flavours, mirroring UPDATE:
+
+==============================================  ===================================================
+Form                                            When to use
+==============================================  ===================================================
+``db |> delete_(row)``                          by-PK from a loaded struct (non-PK fields ignored)
+``db |> delete_by_id(type<T>, id)``             by-PK when you only have the id
+``db |> _sql_delete(type<T>, where)``           bulk via predicate macro
+``db |> _sql_delete_returning(...)``            bulk + capture rows BEFORE they vanish
+``db |> exec(sql)``                             raw escape hatch
+``db |> try_delete_*`` / ``_sql_try_delete*``   non-panic ``Result`` variants
+==============================================  ===================================================
+
+Naming
+======
+
+The function form is ``delete_`` (trailing underscore) because
+``delete`` is a daslang keyword. The macro form uses the ``_sql_``
+prefix and skips the underscore (``_sql_delete``).
+``delete_by_id`` and ``try_delete_by_id`` are separate helpers for
+the "I just have the id" case so callers don't have to construct
+a dummy struct just to identify the row.
+
+As with UPDATE, 0 rows-affected is **not** an error --- the row
+simply wasn't there. Reserve ``Err`` from ``try_`` variants for
+SQL failures.
+
+By-PK from a row
+================
+
+Useful when you already have the row loaded (e.g. from a SELECT).
+
+.. code-block:: das
+
+    let n1 = db |> delete_(User(Id = 2, Name = "", Active = false))
+    // DELETE FROM "Users" WHERE "Id" = ?
+
+By-PK from just an id
+=====================
+
+No dummy struct construction --- pass the id directly.
+
+.. code-block:: das
+
+    let n2 = db |> delete_by_id(type<User>, 4)
+    // DELETE FROM "Users" WHERE "Id" = ?
+
+Bulk delete via the macro
+=========================
+
+Captured-var binds and ``_.Col`` references both work.
+
+.. code-block:: das
+
+    let purged = db |> _sql_delete(type<User>, !_.Active)
+    // DELETE FROM "Users" WHERE NOT ("Active")
+
+Bulk RETURNING --- capture rows BEFORE they vanish
+==================================================
+
+Useful for audit logs, undo queues, "delete-and-publish" pipelines.
+
+.. code-block:: das
+
+    let small_threshold = 75
+    let removed_orders <- db |> _sql_delete_returning(type<Order>,
+                                                      _.Total < small_threshold)
+    // DELETE FROM "Orders" WHERE "Total" < ?
+    //   RETURNING "Id", "UserId", "Total"
+
+Raw-SQL escape hatch
+====================
+
+``exec`` runs arbitrary SQL with no parameter binding. For dynamic
+values stick to the macro forms above; this hatch is for
+migrations / DDL / statements the macro can't translate.
+
+.. code-block:: das
+
+    db |> exec("DELETE FROM Users WHERE Name LIKE 'a%'")
+
+Non-panic ``try_`` variants
+===========================
+
+.. code-block:: das
+
+    let attempt = db |> try_delete_by_id(type<User>, 999)
+    if (attempt |> is_err) {
+        // SQL failure (constraint / IO / BUSY)
+    } else {
+        let n = attempt |> unwrap   // 0 if id didn't match
+    }
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/20-delete.das <../../../../tutorials/sql/20-delete.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_update`
+
+    Next tutorial: :ref:`tutorial_sql_transactions`

--- a/doc/source/reference/tutorials/sql_22_transactions.rst
+++ b/doc/source/reference/tutorials/sql_22_transactions.rst
@@ -1,0 +1,135 @@
+.. _tutorial_sql_transactions:
+
+==========================================
+SQL-22 --- Transactions
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; transaction
+    single: Tutorial; with_transaction
+    single: Tutorial; try_transaction
+    single: Tutorial; in_transaction
+    single: Tutorial; SAVEPOINT
+    single: Tutorial; BEGIN IMMEDIATE
+
+Atomic groups of statements:
+
+==============================================  ===================================================
+Form                                            Behavior
+==============================================  ===================================================
+``db |> with_transaction() { ... }``            ``BEGIN`` / ``COMMIT`` (rolls back on panic)
+``db |> with_transaction(mode) { ... }``        same, with SQLite-specific BEGIN modifier
+``db |> try_transaction() { ... }``             non-panic; returns ``SqlError = Option<string>``
+``db |> in_transaction()``                      status query: ``true`` if a txn is active
+==============================================  ===================================================
+
+``with_transaction`` emits ``BEGIN`` on entry, ``COMMIT`` on
+normal exit, and ``ROLLBACK`` on panic / early return via
+daslang's ``finally``. When nested inside an existing transaction
+it falls back to ``SAVEPOINT`` / ``RELEASE`` / ``ROLLBACK TO`` so
+user code can compose freely without SQLite's "no nested
+transactions" rule biting.
+
+Why two overloads instead of one optional parameter
+===================================================
+
+Two overloads --- not one optional-parameter function --- because
+the trailing-block convention puts the block last; an optional
+middle ``mode`` parameter wouldn't resolve from a no-mode call
+site. Same shape for ``try_transaction``.
+
+Canonical form
+==============
+
+.. code-block:: das
+
+    db |> with_transaction() {
+        db |> insert([
+            Friend(Id = 1, Name = "tom"),
+            Friend(Id = 2, Name = "jerry")
+        ])
+    }
+    // The INSERTs commit as one unit.
+    // The inner array-insert nests via SAVEPOINT.
+
+BEGIN IMMEDIATE
+===============
+
+The ``Immediate`` mode takes the RESERVED lock at ``BEGIN``, so
+concurrent writers block at ``BEGIN`` time rather than on first
+write --- avoids the "another writer raced us between read and
+write" trap.
+
+.. code-block:: das
+
+    db |> with_transaction(SqliteTxnMode.Immediate) {
+        db |> insert(Friend(Id = 4, Name = "jasmine"))
+    }
+
+Available modes: ``Deferred`` (default), ``Immediate``,
+``Exclusive``.
+
+Status check
+============
+
+``in_transaction()`` wraps SQLite's autocommit flag. Mostly useful
+for library code that wants "join an ambient transaction if one
+is active, else start one".
+
+.. code-block:: das
+
+    if (db |> in_transaction()) {
+        // ...
+    }
+
+Nested transactions via SAVEPOINT
+=================================
+
+Nested calls fall back to ``SAVEPOINT`` --- proper LIFO
+composition, no need for the runner to track depth itself.
+
+.. code-block:: das
+
+    db |> with_transaction() {
+        db |> insert(Friend(Id = 5, Name = "max"))
+        db |> with_transaction() {
+            db |> insert(Friend(Id = 6, Name = "rover"))
+        }
+    }
+
+Non-panic ``try_transaction``
+=============================
+
+Returns ``SqlError = Option<string>``: ``some(errmsg)`` on SQL
+failure, ``none`` on success. Useful for retry-on-``SQLITE_BUSY``
+loops.
+
+.. code-block:: das
+
+    let r = db |> try_transaction() {
+        db |> insert(Friend(Id = 7, Name = "lola"))
+    }
+    if (r |> is_some) {
+        // SQL failure (BEGIN / COMMIT errors)
+    }
+
+The ``Option``-based ``try_transaction`` only converts SQL
+failures (``BEGIN`` / ``COMMIT`` errors) into ``some(errmsg)``. A
+panic from inside the block still rolls back and re-propagates ---
+wrap the block in your own ``try / recover`` if you want to convert
+a block panic into a ``SqlError`` value.
+
+Why ``Option<string>`` instead of ``Result<void, string>``
+==========================================================
+
+``Result<void, E>`` isn't supported yet --- ``void`` can't be a
+struct field. ``SqlError = Option<string>`` is the workaround:
+``none`` means success, ``some(msg)`` means failure.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/22-transactions.das <../../../../tutorials/sql/22-transactions.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_delete`

--- a/modules/dasSQLITE/API_MISSING.md
+++ b/modules/dasSQLITE/API_MISSING.md
@@ -30,7 +30,20 @@ The existing tutorials cover Create (02 INSERT) and Read (04 SELECT). They
 say nothing about Update, Delete, or Upsert — the other half of the four
 verbs every CRUD app needs.
 
-### 15-update — "change existing rows"
+### 15-update — "change existing rows" (**SHIPPED in chunk 6**)
+
+> **Update:** Shipped as tutorial 19 in chunk 6. Macro form named
+> `_sql_update` / `_sql_try_update` / `_sql_update_returning` /
+> `_sql_try_update_returning` (the `_sql_` prefix overrides the bare
+> `_update` from the strawman below). Function form: `update(row)` /
+> `try_update(row)`. See [API_REWORK.md § "Shipped — chunk 6"] for the
+> implementation summary, [tutorials/sql/19-update.das] for the live
+> tutorial, and tests/dasSQLITE/test_43..45 for runtime coverage.
+> Open questions below remain accurate as **future** considerations:
+> optimistic concurrency tokens (deferred), bulk RETURNING projection
+> (deferred — post-process with `_select`), `exec` parameter binding
+> (deferred to a small follow-up chunk).
+
 
 **What it teaches.** `UPDATE` — three flavors. (a) Update one row by primary
 key: `UPDATE users SET email=? WHERE id=?`. (b) Update many rows matching a
@@ -127,7 +140,17 @@ expression into `$(_) => expr` and forward positionally.
   `_select`: `db |> _update_returning(...) |> _select(_.Name)`. Avoids
   yet-another-function-name like `update_returning_select`.
 
-### 16-delete — "remove rows"
+### 16-delete — "remove rows" (**SHIPPED in chunk 6**)
+
+> **Update:** Shipped as tutorial 20 in chunk 6. Macro form named
+> `_sql_delete` / `_sql_try_delete` / `_sql_delete_returning` /
+> `_sql_try_delete_returning`. Function form: `delete_(row)` /
+> `delete_by_id(type<T>, id)` plus `try_*` variants. The CASCADE FK
+> example from the original strawman is deferred to tutorial 23
+> (foreign keys), since `@sql_references` is chunk 8+ surface.
+> See [API_REWORK.md § "Shipped — chunk 6"] for the implementation
+> summary and tests/dasSQLITE/test_46..48 for runtime coverage.
+
 
 **What it teaches.** `DELETE` — by PK, by predicate, in bulk; observing
 ON DELETE CASCADE side effects through declared foreign keys.

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -220,6 +220,144 @@ matrix.
 - AOT path stays green (CMake glob auto-picks new tests; reconfigure
   required after adding the first new test of a chunk).
 
+## Shipped — chunk 6: write side — UPDATE / DELETE / Transactions (branch `dassqlite-chunk6-update-delete-tx`)
+
+Chunk 6 ships **tutorials 19 (UPDATE), 20 (DELETE), 22 (Transactions)** —
+the write-side counterpart to chunks 2–5's read-side `_sql(...)` flagship.
+Tut 21 (UPSERT) is deferred to chunk 7 because it carries its own
+substantial new surface (the `_excluded` AST sentinel, multi-column
+conflict targets, `@sql_unique` annotation, four "INSERT OR X" variants,
+bulk overload).
+
+### Naming decision (override of the original mockups)
+
+Macro forms use the `_sql_` prefix:
+`_sql_update`, `_sql_try_update`, `_sql_update_returning`,
+`_sql_try_update_returning`, and the parallel `_sql_delete` set.
+The mockups (15-update.das.mockup / 16-delete.das.mockup) had the bare
+`_update` / `_delete` names — overridden during plan walkthrough so that
+SQL provenance stays visible at the call site and there's no name
+collision with hypothetical future non-SQL macros named `_update` /
+`_delete`. Function siblings stay unprefixed (`update`, `delete_`,
+`delete_by_id`, plus the `try_*` variants). RETURNING is macro-only
+in this chunk — `_sql_update_returning` / `_sql_delete_returning`
+(and the `_sql_try_*_returning` non-panic variants) — backed by the
+generic `run_dml_returning` / `try_run_dml_returning` runtime
+helpers; there are no plain `update_returning` / `delete_returning`
+function wrappers.
+
+### New `[sql_table]` generated helpers
+
+- `_sql_update_by_pk_sql(typ : T) : string` —
+  `UPDATE "T" SET "c1"=?, "c2"=?, ... WHERE "pk"=?`. PK-only or PK-less
+  structs emit a stub that panics at call time with a clear message
+  (concept_assert fires unconditionally during structure-macro apply,
+  so a runtime panic is the workable shape).
+- `_sql_delete_by_pk_sql(typ : T) : string` —
+  `DELETE FROM "T" WHERE "pk"=?`.
+- `_sql_bind_row_for_update(stmt, row)` — binds non-PK columns first
+  (positional 1..N), then the PK column at index N+1 — matches the SET-
+  then-WHERE order in the generated SQL.
+- `_sql_bind_row_pk_only(stmt, row)` — binds just the PK column at
+  index 1, used by `delete_(row)` to execute the by-PK DELETE.
+
+### Runtime additions in `sqlite_boost.das`
+
+- **`changes(db) : int`** — wraps `sqlite3_changes`. Used by raw `exec`
+  callers and by tests for "what did the last DML touch".
+- **By-PK mutators:** `update(row)` / `try_update(row)`,
+  `delete_(row)` / `try_delete_(row)`,
+  `delete_by_id(type<T>, id)` / `try_delete_by_id(...)`.
+  All return `int` rows-affected (1 or 0); `try_*` returns
+  `Result<int, string>`.
+- **Generic DML runners:** `try_run_dml` / `run_dml` (returns int),
+  `try_run_dml_returning` / `run_dml_returning` (returns `array<T>`).
+  Used by the `_sql_update` / `_sql_delete` macros — they take a SQL
+  string + bind block + (for RETURNING) a row-builder block.
+- **Transaction suite:**
+  - `enum SqliteTxnMode { Deferred, Immediate, Exclusive }`.
+  - `with_transaction(db, blk)` and
+    `with_transaction(db, mode, blk)` — two distinct overloads (per
+    tut 22 plan; trailing-block convention forbids an optional middle
+    parameter).
+  - `try_transaction(db, blk)` and `try_transaction(db, mode, blk)` —
+    return `SqlError` (`Option<string>`) rather than `Result<void, E>`
+    because daslang's `Result<T, E>` does not yet support `void`
+    payloads. `none = success`; `some(errmsg) = SQL failure at BEGIN
+    or COMMIT`. Block panics still ROLLBACK and re-propagate.
+  - `in_transaction(db) : bool` — wraps the inverse of
+    `sqlite3_get_autocommit`.
+  - **Savepoint nesting:** when entered while already in a
+    transaction, emits `SAVEPOINT das_sp` / `RELEASE das_sp` /
+    `ROLLBACK TO das_sp; RELEASE das_sp` instead of BEGIN/COMMIT/
+    ROLLBACK. SQLite resolves RELEASE / ROLLBACK TO against the
+    most-recent matching savepoint name, so proper LIFO nesting
+    composes correctly without the runner tracking depth itself.
+- **Bulk insert composability fix:** `try_insert(rows : array<T>)`
+  now branches on `in_transaction()` — uses `BEGIN IMMEDIATE` /
+  `COMMIT` when standalone, `SAVEPOINT das_ins_sp` / `RELEASE` when
+  nested inside an outer `with_transaction`. Without this fix SQLite
+  errored "cannot start a transaction within a transaction" when
+  bulk-insert was nested.
+
+### New macros in `sqlite_linq.das`
+
+Eight new `[call_macro]`s — four for UPDATE and four for DELETE.
+Each pair is `_sql_{verb}` / `_sql_try_{verb}` (with optional
+`_returning` suffix for the four RETURNING variants). All eight set
+`canVisitArgument = false` for everything except `db`, so the WHERE /
+SET expressions arrive as raw AST. Analysis runs on the AST shape
+directly: `_.Col` references → SQL column refs, captured locals /
+literals → `?` placeholders + bind expressions. Bind ordering is SET
+binds first, then WHERE binds (matches placeholder order in
+`UPDATE ... SET ... WHERE ...`).
+
+The named-tuple SET clause `(Col1=val1, Col2=val2)` carries its
+column names in `ExprMakeTuple.recordNames`, populated by the parser
+(no type inference required). Chunk 6 also exposes `recordNames` to
+daslang reflection via a one-line C++ change in
+`module_builtin_ast_annotations_2.cpp` so the macro can read it
+directly without forcing premature type inference on the SET arg.
+
+### Tutorials
+
+- [tutorials/sql/19-update.das](../../tutorials/sql/19-update.das) — by-PK,
+  bulk macro, RETURNING, raw escape hatch, try_ variants.
+- [tutorials/sql/20-delete.das](../../tutorials/sql/20-delete.das) — by-PK
+  via `delete_(row)` / `delete_by_id`, bulk macro, RETURNING, raw escape
+  hatch, try_ variants.
+- [tutorials/sql/22-transactions.das](../../tutorials/sql/22-transactions.das)
+  — 2-arg / 3-arg `with_transaction`, savepoint nesting,
+  `in_transaction()`, `try_transaction`.
+
+### Tests
+
+9 new test files: `test_43_update_by_pk.das`, `test_44_update_bulk.das`,
+`test_45_update_returning.das`, `test_46_delete_by_pk.das`,
+`test_47_delete_bulk.das`, `test_48_delete_returning.das`,
+`test_49_changes.das`, `test_50_with_transaction.das`,
+`test_51_try_transaction.das`. Plus `failed_sql_update_delete.das` for
+malformed-call diagnostics. Total dasSQLITE suite: **271 tests passing**
+(238 pre-chunk-6 + 33 new).
+
+### Deferred to chunk 7+
+
+- **UPSERT** (tut 21) — `_excluded` AST sentinel, multi-column conflict
+  targets, `@sql_unique` field annotation, INSERT OR IGNORE / INSERT OR
+  REPLACE shortcuts, bulk overload.
+- **`exec` parameter binding** — `db |> exec(sql, args...)` doesn't
+  exist; users must inline values into the SQL string for raw escape
+  hatch with dynamic data, or stick to the macro forms. Adding
+  parameterized `exec` is a small follow-up that mirrors `query_one`'s
+  variadic shape.
+- **Optimistic concurrency** (`@sql_concurrency_token`) — open question
+  in API_MISSING § 15; defer until a real ask.
+- **Multi-table DELETE** (PG `DELETE … USING` / MySQL JOIN-DELETE) —
+  dialect-divergent, deliberately skipped per API_MISSING § 16.
+- **Projection-side `_select` after `_sql_update_returning`** — for
+  RETURNING column projection, post-process the result with a chain
+  `|> _select(...)` instead of inventing a `update_returning_select`.
+
 ## Shipped — chunk 4: read-side depth — distinct/take/skip/order_by/aggregates/group_by/NULL (branch `dassqlite-chunk4-read-depth`)
 
 Chunk 4 broadens the chunk-3 framework with the rest of the read-side

--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -168,19 +168,26 @@ part re-uses the same [sql_table] from Part 1.
 
 The read story is complete. Now the write side.
 
-19. **UPDATE** — `db |> update(row)` for whole-row,
-    `_sql(..._update(...))` for partial/filtered updates, the
-    `_update_returning` / `update_returning` variants for RETURNING
-    clauses, `db |> changes()` for rows-affected counts. Introduces
-    the strict / `try_update` / `try_update_returning` fan-out on the
-    write side. Mockup: [15-update.das](tutorial-mockup/15-update.das.mockup).
-20. **DELETE** — `db |> delete_(row)` by PK,
-    `db |> delete_by_id(type<T>, id)` for the PK-only shortcut,
-    `_sql(..._delete())` for filtered deletes, `_delete_returning` /
-    `delete_returning` for RETURNING clauses, `db |> changes()` for
-    rows-affected counts. Strict / `try_delete_` /
-    `try_delete_by_id` / `try_delete_returning` fan-out. Mockup:
-    [16-delete.das](tutorial-mockup/16-delete.das.mockup).
+19. **UPDATE** — `db |> update(row)` for whole-row by-PK,
+    `_sql_update(type<T>, where, set)` for predicate-based bulk updates,
+    `_sql_update_returning` for RETURNING, `db |> changes()` for
+    rows-affected counts. Macro form carries the `_sql_` prefix so SQL
+    provenance stays visible at the call site. Strict / `try_update` /
+    `_sql_try_update` / `*_returning` / `_sql_try_*_returning` fan-out
+    on the write side. **Shipped:**
+    [tutorials/sql/19-update.das](../../tutorials/sql/19-update.das)
+    (chunk 6). Original mockup:
+    [15-update.das.mockup](tutorial-mockup/15-update.das.mockup).
+20. **DELETE** — `db |> delete_(row)` by PK (trailing underscore: `delete`
+    is a daslang keyword), `db |> delete_by_id(type<T>, id)` for the
+    PK-only shortcut, `_sql_delete(type<T>, where)` for predicate-based
+    bulk deletes, `_sql_delete_returning` for RETURNING, `db |> changes()`
+    for rows-affected counts. Strict / `try_delete_` / `try_delete_by_id`
+    / `_sql_try_delete` / `*_returning` / `_sql_try_*_returning` fan-out.
+    **Shipped:**
+    [tutorials/sql/20-delete.das](../../tutorials/sql/20-delete.das)
+    (chunk 6). Original mockup:
+    [16-delete.das.mockup](tutorial-mockup/16-delete.das.mockup).
 21. **UPSERT — INSERT ON CONFLICT** — `db |> upsert(row, on_conflict=…,
     do_update=…)` and the `array<T>` overload; `insert_or_ignore` /
     `insert_or_replace` as the no-update / clobber shortcuts;
@@ -188,14 +195,20 @@ The read story is complete. Now the write side.
     `@sql_unique` field annotation for declaring conflict keys without
     a full `[sql_index(unique=true)]`; strict / `try_insert_or_ignore`
     / `try_insert_or_replace` / `try_upsert` / `try_upsert_returning`
-    fan-out. Mockup: [17-upsert.das](tutorial-mockup/17-upsert.das.mockup).
-22. **Transactions** — `db |> with_transaction() <| $ { … }` block,
+    fan-out. **Deferred to chunk 7** (carries its own substantial
+    surface — the `_excluded` AST sentinel, multi-column conflict
+    targets, `@sql_unique`, four "INSERT OR X" variants, bulk overload).
+    Mockup: [17-upsert.das](tutorial-mockup/17-upsert.das.mockup).
+22. **Transactions** — `db |> with_transaction() { … }` block,
     `with_transaction(mode=…)` for IMMEDIATE / EXCLUSIVE, rollback on
-    panic/early return, nested transaction behavior, autocommit
-    default, `db |> in_transaction()` introspection, `try_transaction`
-    for explicit error handling. Inherited tutorials 12/13/14 are
-    merged into one conceptual tutorial per API_REWORK decision.
-    Mockup: [14-transaction.das](tutorial-mockup/14-transaction.das.mockup).
+    panic/early return, nested transaction behavior (automatic
+    SAVEPOINT fallback via `das_sp`), autocommit default,
+    `db |> in_transaction()` introspection, `try_transaction` for
+    explicit error handling. Inherited tutorials 12/13/14 are merged
+    into one conceptual tutorial per API_REWORK decision. **Shipped:**
+    [tutorials/sql/22-transactions.das](../../tutorials/sql/22-transactions.das)
+    (chunk 6). Original mockup:
+    [14-transaction.das.mockup](tutorial-mockup/14-transaction.das.mockup).
 
 ## Part 5 — Schema richness
 
@@ -362,10 +375,10 @@ E. **Forward-looking: `dasSQL` abstraction layer** — the roadmap beyond
 | 16 | `_left_join` — outer | `23-joins.das` | Has mockup (shared) |
 | 17 | Subqueries | `24-subqueries.das` | Has mockup |
 | 18 | NULL handling — `Option<T>` | `18-null_handling.das` (`25-null_handling.das.mockup` shipped largely as designed; `_.Col == none()` diagnostic + projection-side `unwrap_or` deferred) | **Shipped** (chunk 4) |
-| 19 | UPDATE | `15-update.das` | Has mockup |
-| 20 | DELETE | `16-delete.das` | Has mockup |
-| 21 | UPSERT | `17-upsert.das` | Has mockup |
-| 22 | Transactions | `14-transaction.das` | Has mockup |
+| 19 | UPDATE | `15-update.das` | **Shipped** (chunk 6); macros named `_sql_update` / `_sql_try_update` / `_sql_update_returning` / `_sql_try_update_returning`; raw `exec` parameter binding deferred to a later chunk |
+| 20 | DELETE | `16-delete.das` | **Shipped** (chunk 6); macros named `_sql_delete` / `_sql_try_delete` / `_sql_delete_returning` / `_sql_try_delete_returning`; CASCADE FK example deferred to tut 23 |
+| 21 | UPSERT | `17-upsert.das` | Has mockup — deferred to chunk 7 (the `_excluded` AST sentinel, multi-column conflict targets, `@sql_unique`, INSERT OR IGNORE/REPLACE shortcuts, bulk overload all carry their own surface) |
+| 22 | Transactions | `14-transaction.das` | **Shipped** (chunk 6); two-arity overload, `SqliteTxnMode` enum (Deferred/Immediate/Exclusive), savepoint nesting via `das_sp` name |
 | 23 | Foreign keys | `26-foreign_keys.das` | Has mockup |
 | 24 | Indexes | `27-indexes.das` | Has mockup |
 | 25 | Defaults + computed | `28-defaults_computed.das` | Has mockup |

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -142,6 +142,14 @@ def last_insert_rowid(db : SqlRunner) : int64 {
     return sqlite3_last_insert_rowid(db.sqlite_handle)
 }
 
+def changes(db : SqlRunner) : int {
+    //! Returns the number of rows affected by the most recent INSERT, UPDATE, or DELETE
+    //! on this connection. Wraps ``sqlite3_changes``; see https://sqlite.org/c3ref/changes.html
+    //! for the exact contract (DML statements only — DDL, schema changes, and triggers
+    //! count separately).
+    return sqlite3_changes(db.sqlite_handle)
+}
+
 // ============================================================================
 // Convention dispatch: sqlite_sql_type / sqlite_bind
 //
@@ -316,26 +324,9 @@ def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<auto(TT)>) : TT {
 def try_query_scalar(db : SqlRunner; sql : string; t : type<auto(TT)>) : Result<TT -const -#, string> {
     //! Prepares ``sql``, steps once, returns column 0 as ``TT``.
     //! Returns ``Err(errmsg)`` on prepare/step error or zero rows.
-    var stmt : sqlite3_stmt?
-    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
-    if (prc != SQLITE_OK) {
-        let msg = "query_scalar prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
-        sqlite3_finalize(stmt)
-        return err(msg, type<TT -const -#>)
-    }
-    let src = sqlite3_step(stmt)
-    if (src == SQLITE_DONE) {
-        sqlite3_finalize(stmt)
-        return err("query_scalar: expected one row, got 0 rows", type<TT -const -#>)
-    }
-    if (src != SQLITE_ROW) {
-        let msg = "query_scalar: step failed: {sqlite3_errmsg(db.sqlite_handle)}"
-        sqlite3_finalize(stmt)
-        return err(msg, type<TT -const -#>)
-    }
-    var result = sqlite_read(stmt, 0, type<TT -const -#>) // nolint:LINT003
-    sqlite3_finalize(stmt)
-    return move_ok(result, type<string>)
+    return <- try_one_row(db, sql, $(var stmt : sqlite3_stmt?) {}, $(stmt : sqlite3_stmt?) {
+        return sqlite_read(stmt, 0, type<TT -const -#>)
+    }, "query_scalar")
 }
 
 [unused_argument(t)]
@@ -359,24 +350,13 @@ def query_scalar(db : SqlRunner; sql : string; t : type<auto(TT)>) : TT -const -
 
 [unused_argument(t)]
 def query_scalar_opt(db : SqlRunner; sql : string; t : type<auto(TT)>) : Option<TT -const -#> {
-    var stmt : sqlite3_stmt?
-    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
-    if (prc != SQLITE_OK) {
-        sqlite3_finalize(stmt)
-        panic("query_scalar_opt prepare failed: {sqlite3_errmsg(db.sqlite_handle)}")
+    var r <- try_one_row_opt(db, sql, $(var stmt : sqlite3_stmt?) {}, $(stmt : sqlite3_stmt?) {
+        return sqlite_read(stmt, 0, type<TT -const -#>)
+    }, "query_scalar_opt")
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
     }
-    let src = sqlite3_step(stmt)
-    if (src == SQLITE_DONE) {
-        sqlite3_finalize(stmt)
-        return none(type<TT -const -#>)
-    }
-    if (src != SQLITE_ROW) {
-        sqlite3_finalize(stmt)
-        panic("query_scalar_opt step failed: {sqlite3_errmsg(db.sqlite_handle)}")
-    }
-    var result = sqlite_read(stmt, 0, type<TT -const -#>) // nolint:LINT003
-    sqlite3_finalize(stmt)
-    return move_some(result)
+    return <- r._value
 }
 
 // ============================================================================
@@ -400,12 +380,24 @@ def query_scalar_opt(db : SqlRunner; sql : string; t : type<auto(TT)>) : Option<
 // invoked once after prepare. Each public wrapper supplies the right
 // bind block for its arity.
 
-// Shared prepare/bind/step/finalize body for single-row Result-returning
-// reads. Both `try_query_one_impl` (struct-typed reads via
-// `_sql_read_row`) and `try_run_select_one` (caller-supplied row block
-// via the `_sql` macro) used to inline this whole loop verbatim. Pulled
-// up here so they share one implementation; the differences collapse to
-// (a) the row materializer block and (b) the user-visible error prefix.
+// Shared prepare/bind/step/finalize bodies for the runtime layer. Four
+// helpers cover every shape the public API needs:
+//   - `try_one_row`     — single row, ``Err`` on zero rows; consumed by
+//                         `try_query_one_impl`, `try_run_select_one`, and
+//                         `try_query_scalar`.
+//   - `try_one_row_opt` — single row, ``Ok(none)`` on zero rows; consumed
+//                         by `query_scalar_opt` and `try_run_select_one_opt`.
+//   - `try_step_dml`    — single step, returns rows-affected; consumed by
+//                         every non-RETURNING DML (`try_run_dml`,
+//                         `try_insert`, `try_update`, `try_delete_`,
+//                         `try_delete_by_id`).
+//   - `try_collect_rows` — multi-row materializer; consumed by
+//                          `try_run_select`, `try_run_dml_returning`, and
+//                          `try_select_from`.
+// Each one parameterizes only on (a) the row/bind blocks and (b) the
+// user-visible error prefix. Adding new wrappers should reuse one of
+// these instead of inlining a fifth prepare/bind loop.
+
 def private try_one_row(db : SqlRunner; sql : string;
                         bind_blk : block<(var stmt : sqlite3_stmt?) : void>;
                         row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>;
@@ -436,6 +428,85 @@ def private try_one_row(db : SqlRunner; sql : string;
     var row : TT -const -# = invoke(row_blk, stmt) // nolint:LINT003
     sqlite3_finalize(stmt)
     return move_ok(row, type<string>)
+}
+
+def private try_one_row_opt(db : SqlRunner; sql : string;
+                            bind_blk : block<(var stmt : sqlite3_stmt?) : void>;
+                            row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>;
+                            err_prefix : string) : Result<Option<TT -const -#>, string> {
+    //! Like `try_one_row`, but returns `Ok(none)` on zero rows instead of
+    //! `Err`. Use when "no row matched" is a normal outcome and only
+    //! prepare/step failures are real errors.
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        let msg = "{err_prefix}: prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<Option<TT -const -#>>)
+    }
+    invoke(bind_blk, stmt)
+    let src = sqlite3_step(stmt)
+    if (src == SQLITE_DONE) {
+        sqlite3_finalize(stmt)
+        return ok(none(type<TT -const -#>), type<string>)
+    }
+    if (src != SQLITE_ROW) {
+        let msg = "{err_prefix}: step failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<Option<TT -const -#>>)
+    }
+    var row : TT -const -# = invoke(row_blk, stmt) // nolint:LINT003
+    sqlite3_finalize(stmt)
+    return move_ok(move_some(row), type<string>)
+}
+
+def private try_step_dml(db : SqlRunner; sql : string;
+                         bind_blk : block<(var stmt : sqlite3_stmt?) : void>;
+                         err_prefix : string) : Result<int, string> {
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        let msg = "{err_prefix}: prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<int>)
+    }
+    invoke(bind_blk, stmt)
+    let src = sqlite3_step(stmt)
+    if (src != SQLITE_DONE) {
+        let msg = "{err_prefix}: step failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<int>)
+    }
+    let n = sqlite3_changes(db.sqlite_handle)
+    sqlite3_finalize(stmt)
+    return ok(n, type<string>)
+}
+
+def private try_collect_rows(db : SqlRunner; sql : string;
+                             bind_blk : block<(var stmt : sqlite3_stmt?) : void>;
+                             row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>;
+                             err_prefix : string) : Result<array<TT -const -#>, string> {
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        let msg = "{err_prefix}: prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<array<TT -const -#>>)
+    }
+    invoke(bind_blk, stmt)
+    var inscope result : array<TT -const -#>
+    var rc = sqlite3_step(stmt)
+    while (rc == SQLITE_ROW) {
+        result |> push(invoke(row_blk, stmt))
+        rc = sqlite3_step(stmt)
+    }
+    if (rc != SQLITE_DONE) {
+        let msg = "{err_prefix}: step failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return err(msg, type<array<TT -const -#>>)
+    }
+    sqlite3_finalize(stmt)
+    return move_ok(result, type<string>)
 }
 
 [unused_argument(t)]
@@ -616,21 +687,12 @@ def try_insert(db : SqlRunner; row : auto(TT)) : Result<int64, string> {
     //! When the row's integer primary key is zero, the macro-emitted no-PK INSERT runs and SQLite assigns the id.
     let pk_unset = _::_sql_pk_is_unset(row)
     let sql = pk_unset ? _::_sql_insert_no_pk_sql(row) : _::_sql_insert_with_pk_sql(row)
-    var stmt : sqlite3_stmt?
-    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
-    if (prc != SQLITE_OK) {
-        let msg = "insert prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
-        sqlite3_finalize(stmt)
-        return err(msg, type<int64>)
+    let r = db |> try_step_dml(sql, $(var stmt : sqlite3_stmt?) {
+        _::_sql_bind_row(stmt, row, !pk_unset)
+    }, "insert")
+    if (r |> is_err) {
+        return err(r |> unwrap_err, type<int64>)
     }
-    _::_sql_bind_row(stmt, row, !pk_unset)
-    let src = sqlite3_step(stmt)
-    if (src != SQLITE_DONE) {
-        let msg = "insert step failed: {sqlite3_errmsg(db.sqlite_handle)}"
-        sqlite3_finalize(stmt)
-        return err(msg, type<int64>)
-    }
-    sqlite3_finalize(stmt)
     return ok(sqlite3_last_insert_rowid(db.sqlite_handle), type<string>)
 }
 
@@ -659,7 +721,13 @@ def try_insert(db : SqlRunner; rows : array<auto(TT)>) : Result<int64, string> {
             return err("insert: rows mix PK-set and PK-unset (row 0 vs row {i}); partition the array before calling insert", type<int64>)
         }
     }
-    let begin_err = db |> try_exec("BEGIN IMMEDIATE")
+    // Choose BEGIN/COMMIT vs SAVEPOINT/RELEASE based on ambient state so
+    // bulk-insert composes inside an outer ``with_transaction`` block.
+    // Without this branch SQLite rejects ``BEGIN IMMEDIATE`` with "cannot
+    // start a transaction within a transaction" when nested.
+    let was_in_txn = db |> in_transaction()
+    let begin_sql = was_in_txn ? "SAVEPOINT das_ins_sp" : "BEGIN IMMEDIATE"
+    let begin_err = db |> try_exec(begin_sql)
     if (begin_err |> is_some) {
         return err(begin_err |> unwrap, type<int64>)
     }
@@ -669,7 +737,12 @@ def try_insert(db : SqlRunner; rows : array<auto(TT)>) : Result<int64, string> {
     if (prc != SQLITE_OK) {
         let msg = "insert prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
         sqlite3_finalize(stmt)
-        db |> try_exec("ROLLBACK") |> ignore_sql_error
+        if (was_in_txn) {
+            db |> try_exec("ROLLBACK TO das_ins_sp") |> ignore_sql_error
+            db |> try_exec("RELEASE das_ins_sp") |> ignore_sql_error
+        } else {
+            db |> try_exec("ROLLBACK") |> ignore_sql_error
+        }
         return err(msg, type<int64>)
     }
     for (row in rows) {
@@ -680,13 +753,28 @@ def try_insert(db : SqlRunner; rows : array<auto(TT)>) : Result<int64, string> {
         if (src != SQLITE_DONE) {
             let msg = "insert step failed: {sqlite3_errmsg(db.sqlite_handle)}"
             sqlite3_finalize(stmt)
-            db |> try_exec("ROLLBACK") |> ignore_sql_error
+            if (was_in_txn) {
+                db |> try_exec("ROLLBACK TO das_ins_sp") |> ignore_sql_error
+                db |> try_exec("RELEASE das_ins_sp") |> ignore_sql_error
+            } else {
+                db |> try_exec("ROLLBACK") |> ignore_sql_error
+            }
             return err(msg, type<int64>)
         }
     }
     sqlite3_finalize(stmt)
-    let commit_err = db |> try_exec("COMMIT")
+    let commit_sql = was_in_txn ? "RELEASE das_ins_sp" : "COMMIT"
+    let commit_err = db |> try_exec(commit_sql)
     if (commit_err |> is_some) {
+        // COMMIT/RELEASE can fail (SQLITE_BUSY, IO error). Roll back so the
+        // connection isn't left mid-transaction. Bulk-insert uses its own
+        // savepoint name (das_ins_sp) so the rollback path is local.
+        if (was_in_txn) {
+            db |> try_exec("ROLLBACK TO das_ins_sp") |> ignore_sql_error
+            db |> try_exec("RELEASE das_ins_sp") |> ignore_sql_error
+        } else {
+            db |> try_exec("ROLLBACK") |> ignore_sql_error
+        }
         return err(commit_err |> unwrap, type<int64>)
     }
     return ok(sqlite3_last_insert_rowid(db.sqlite_handle), type<string>)
@@ -706,6 +794,256 @@ def private ignore_sql_error(e : SqlError) : void {
     //! Discards a SqlError. Used by try_insert(array) to swallow ROLLBACK failures while preserving the original error.
 }
 
+// ============================================================================
+// by-PK UPDATE / DELETE
+//
+// Single-row mutators driven by [sql_table]'s generated `_sql_update_by_pk_sql`,
+// `_sql_delete_by_pk_sql`, and `_sql_bind_row_for_update` helpers. The struct
+// must declare exactly one @sql_primary_key field; otherwise the generated
+// helper panics with a clear message at call time (see make_update_by_pk_sql_fn
+// at the bottom of this file).
+//
+// All four functions return ``int`` (rows-affected — 1 or 0). 0 is NOT an
+// error: the row simply wasn't there. Reserve ``Err`` for genuine SQL
+// failures (constraint violation, IO, BUSY).
+// ============================================================================
+
+def try_update(db : SqlRunner; row : auto(TT)) : Result<int, string> {
+    //! Updates a single row identified by its @sql_primary_key field. Returns
+    //! ``Ok(rows_affected)`` (1 if the row matched, 0 if not), ``Err(errmsg)``
+    //! on SQL failure.
+    return <- db |> try_step_dml(_::_sql_update_by_pk_sql(row), $(var stmt : sqlite3_stmt?) {
+        _::_sql_bind_row_for_update(stmt, row)
+    }, "update")
+}
+
+def update(db : SqlRunner; row : auto(TT)) : int {
+    //! Strict variant of ``try_update(row)``. Panics with the libsqlite3 errmsg on failure.
+    let r = db |> try_update(row)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return r |> unwrap
+}
+
+def try_delete_(db : SqlRunner; row : auto(TT)) : Result<int, string> {
+    //! Deletes the row identified by ``row``'s @sql_primary_key field. Non-PK
+    //! fields are ignored. Returns ``Ok(rows_affected)`` (1 if matched, 0 if not),
+    //! ``Err(errmsg)`` on SQL failure.
+    //! Trailing underscore in the name is intentional: ``delete`` is a daslang
+    //! keyword, mirroring the convention used by ``daslib/linq``'s ``where_``.
+    // The PK is bound at index 1 (the only placeholder in `DELETE FROM T WHERE pk=?`).
+    // We can't reuse `_sql_bind_row_for_update` here because it binds non-PK
+    // columns first; instead, look up the PK field directly via the generated
+    // _sql_pk_value helper that matches each [sql_table] struct.
+    return <- db |> try_step_dml(_::_sql_delete_by_pk_sql(row), $(var stmt : sqlite3_stmt?) {
+        _::_sql_bind_row_pk_only(stmt, row)
+    }, "delete")
+}
+
+def delete_(db : SqlRunner; row : auto(TT)) : int {
+    //! Strict variant of ``try_delete_(row)``. Panics with the libsqlite3 errmsg on failure.
+    let r = db |> try_delete_(row)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return r |> unwrap
+}
+
+[unused_argument(t)]
+def try_delete_by_id(db : SqlRunner; t : type<auto(TT)>; id : auto(K)) : Result<int, string> {
+    //! Deletes the row of type ``T`` whose primary key equals ``id``. Avoids
+    //! constructing a dummy struct just to identify the row. Returns
+    //! ``Ok(rows_affected)`` (1 or 0), ``Err(errmsg)`` on SQL failure.
+    return <- db |> try_step_dml(_::_sql_delete_by_pk_sql(default<TT>), $(var stmt : sqlite3_stmt?) {
+        sqlite_bind(stmt, 1, id)
+    }, "delete_by_id")
+}
+
+[unused_argument(t)]
+def delete_by_id(db : SqlRunner; t : type<auto(TT)>; id : auto(K)) : int {
+    //! Strict variant of ``try_delete_by_id``. Panics with the libsqlite3 errmsg on failure.
+    let r = db |> try_delete_by_id(type<TT>, id)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return r |> unwrap
+}
+
+// ============================================================================
+// Transactions
+//
+// `with_transaction` blocks emit BEGIN/COMMIT/ROLLBACK or
+// SAVEPOINT/RELEASE/ROLLBACK TO depending on whether the connection is
+// already inside a transaction (detected via sqlite3_get_autocommit). All
+// nested calls use the same SAVEPOINT name `das_sp` — SQLite resolves
+// RELEASE/ROLLBACK TO against the most-recent matching savepoint, so proper
+// LIFO nesting composes correctly without the runner tracking depth itself.
+//
+// Two overloads, not one optional-parameter function: piping puts the block
+// last, so an optional middle `mode` parameter wouldn't resolve from a
+// no-mode call site. See API_REWORK.md § "12 + 13 + 14" for the full
+// rationale.
+// ============================================================================
+
+enum SqliteTxnMode {
+    //! BEGIN modifiers for SQLite. Maps to ``BEGIN [DEFERRED|IMMEDIATE|EXCLUSIVE]``.
+    Deferred    //!< Default; lock acquisition deferred to the first read/write.
+    Immediate   //!< RESERVED lock at BEGIN; concurrent writers block immediately.
+    Exclusive   //!< EXCLUSIVE lock; blocks readers and writers (legacy mode; not WAL-safe).
+}
+
+def in_transaction(db : SqlRunner) : bool {
+    //! Returns true if the connection is currently inside a BEGIN/COMMIT pair
+    //! (or a SAVEPOINT). Wraps the inverse of ``sqlite3_get_autocommit``.
+    return !sqlite3_get_autocommit_(db.sqlite_handle)
+}
+
+def private txn_begin_sql(was_in_txn : bool; mode : SqliteTxnMode) : string {
+    if (was_in_txn) {
+        return "SAVEPOINT das_sp"
+    }
+    if (mode == SqliteTxnMode.Immediate) {
+        return "BEGIN IMMEDIATE"
+    }
+    if (mode == SqliteTxnMode.Exclusive) {
+        return "BEGIN EXCLUSIVE"
+    }
+    return "BEGIN"
+}
+
+def private txn_commit_sql(was_in_txn : bool) : string {
+    return was_in_txn ? "RELEASE das_sp" : "COMMIT"
+}
+
+def private txn_best_effort_rollback(db : SqlRunner; was_in_txn : bool) : void {
+    // Best-effort: swallow rollback errors so the original failure (panic
+    // message or BEGIN/blk SQL error) reaches the caller intact.
+    if (was_in_txn) {
+        db |> try_exec("ROLLBACK TO das_sp") |> ignore_sql_error
+        db |> try_exec("RELEASE das_sp") |> ignore_sql_error
+    } else {
+        db |> try_exec("ROLLBACK") |> ignore_sql_error
+    }
+}
+
+def with_transaction(db : SqlRunner; blk : block<() : void>) : void {
+    //! 2-arg overload — abstract layer entry point. Defaults to
+    //! ``SqliteTxnMode.Deferred`` (matches SQLite's default ``BEGIN``).
+    db |> with_transaction(SqliteTxnMode.Deferred, blk)
+}
+
+def with_transaction(db : SqlRunner; mode : SqliteTxnMode; blk : block<() : void>) : void {
+    //! Wraps ``blk`` in a SQL transaction. Emits BEGIN [mode] / COMMIT, or
+    //! SAVEPOINT das_sp / RELEASE das_sp when nested inside an existing
+    //! transaction. ROLLBACK fires on panic / early return via daslang's
+    //! ``finally`` (best effort — original failure propagates).
+    let was_in_txn = db |> in_transaction()
+    db |> exec(txn_begin_sql(was_in_txn, mode))
+    var success = false
+    {
+        invoke(blk)
+        success = true
+    } finally {
+        if (success) {
+            // COMMIT/RELEASE can fail (SQLITE_BUSY, IO error). If it does, roll
+            // back so the connection isn't left mid-transaction, then panic
+            // with the commit message.
+            let commit_err = db |> try_exec(txn_commit_sql(was_in_txn))
+            if (commit_err |> is_some) {
+                txn_best_effort_rollback(db, was_in_txn)
+                panic(commit_err |> unwrap)
+            }
+        } else {
+            txn_best_effort_rollback(db, was_in_txn)
+        }
+    }
+}
+
+def try_transaction(db : SqlRunner; blk : block<() : void>) : SqlError {
+    //! Non-panic 2-arg overload. Returns ``none`` on commit success, or
+    //! ``some(errmsg)`` if BEGIN or COMMIT fails. Block panics still ROLLBACK
+    //! and re-propagate — wrap the block in your own try/recover if you want
+    //! to convert a block panic into a SqlError.
+    //!
+    //! Returns ``SqlError = Option<string>`` rather than ``Result<void, string>``
+    //! because daslang's ``Result<T, E>`` does not yet support a ``void`` payload.
+    return db |> try_transaction(SqliteTxnMode.Deferred, blk)
+}
+
+def try_transaction(db : SqlRunner; mode : SqliteTxnMode; blk : block<() : void>) : SqlError {
+    //! Non-panic 3-arg overload. Same semantics as ``try_transaction(db, blk)``
+    //! with a SQLite-specific BEGIN modifier.
+    let was_in_txn = db |> in_transaction()
+    let begin_err = db |> try_exec(txn_begin_sql(was_in_txn, mode))
+    if (begin_err |> is_some) {
+        return begin_err
+    }
+    var success = false
+    {
+        invoke(blk)
+        success = true
+    } finally {
+        if (!success) {
+            txn_best_effort_rollback(db, was_in_txn)
+        }
+    }
+    // COMMIT/RELEASE can fail (SQLITE_BUSY, IO error). If it does, roll back
+    // so the connection isn't left mid-transaction before returning the error.
+    let commit_err = db |> try_exec(txn_commit_sql(was_in_txn))
+    if (commit_err |> is_some) {
+        txn_best_effort_rollback(db, was_in_txn)
+    }
+    return commit_err
+}
+
+// ============================================================================
+// Generic DML runners — used by the `_sql_update` / `_sql_delete` macros.
+//
+// These take a SQL string + bind block (the macro fills in the
+// `sqlite_bind(stmt, idx, expr)` calls) and execute it. Return rows-affected
+// for non-RETURNING; array<T> for RETURNING.
+// ============================================================================
+
+def try_run_dml(db : SqlRunner; sql : string;
+                bind_blk : block<(var stmt : sqlite3_stmt?) : void>) : Result<int, string> {
+    //! Prepares ``sql``, invokes ``bind_blk`` to bind parameters, steps once,
+    //! and returns rows-affected. Used by the `_sql_update` / `_sql_delete`
+    //! macros for predicate-based mutations.
+    return <- db |> try_step_dml(sql, bind_blk, "DML")
+}
+
+def run_dml(db : SqlRunner; sql : string;
+            bind_blk : block<(var stmt : sqlite3_stmt?) : void>) : int {
+    //! Strict variant of ``try_run_dml``. Panics with the libsqlite3 errmsg on failure.
+    let r = db |> try_run_dml(sql, bind_blk)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return r |> unwrap
+}
+
+def try_run_dml_returning(db : SqlRunner; sql : string;
+                          bind_blk : block<(var stmt : sqlite3_stmt?) : void>;
+                          row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : Result<array<TT -const -#>, string> {
+    //! Prepares ``sql`` (which must include a ``RETURNING ...`` clause),
+    //! invokes ``bind_blk``, then steps repeatedly through ``SQLITE_ROW``
+    //! rows, calling ``row_blk`` to materialize each result row.
+    //! Used by ``_sql_update_returning`` / ``_sql_delete_returning`` macros.
+    return <- db |> try_collect_rows(sql, bind_blk, row_blk, "DML RETURNING")
+}
+
+def run_dml_returning(db : SqlRunner; sql : string;
+                      bind_blk : block<(var stmt : sqlite3_stmt?) : void>;
+                      row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : array<TT -const -#> {
+    //! Strict variant of ``try_run_dml_returning``. Panics on failure.
+    var r = db |> try_run_dml_returning(sql, bind_blk, row_blk)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return <- r._value
+}
+
 [unused_argument(t)]
 def try_select_from(db : SqlRunner; t : type<auto(TT)>) : Result<array<TT -const -#>, string> {
     //! Reads every row of the table backing ``T`` and materializes them as ``array<TT>``.
@@ -715,27 +1053,11 @@ def try_select_from(db : SqlRunner; t : type<auto(TT)>) : Result<array<TT -const
     //!
     //! NOTE: uses a regular generic (`type<auto(TT)>`) rather than `[template]` so
     //! the `type<T>` argument survives in the AST for `_sql` chain-pattern matching.
-    let sql = _::_sql_select_all_sql(type<TT -const -#>)
-    var stmt : sqlite3_stmt?
-    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
-    if (prc != SQLITE_OK) {
-        let msg = "select_from prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
-        sqlite3_finalize(stmt)
-        return err(msg, type<array<TT -const -#>>)
-    }
-    var inscope result : array<TT -const -#>
-    var rc = sqlite3_step(stmt)
-    while (rc == SQLITE_ROW) {
-        result |> emplace(_::_sql_read_row(stmt, type<TT -const -#>))
-        rc = sqlite3_step(stmt)
-    }
-    if (rc != SQLITE_DONE) {
-        let msg = "select_from step failed: {sqlite3_errmsg(db.sqlite_handle)}"
-        sqlite3_finalize(stmt)
-        return err(msg, type<array<TT -const -#>>)
-    }
-    sqlite3_finalize(stmt)
-    return move_ok(result, type<string>)
+    return <- db |> try_collect_rows(_::_sql_select_all_sql(type<TT -const -#>),
+        $(var stmt : sqlite3_stmt?) {},
+        $(stmt : sqlite3_stmt?) {
+            return _::_sql_read_row(stmt, type<TT -const -#>)
+        }, "select_from")
 }
 
 [unused_argument(t)]
@@ -762,27 +1084,7 @@ def try_run_select(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sq
     //! Prepares ``sql``, runs ``bind_blk`` once, then steps the cursor and
     //! materializes each row via ``row_blk``. Returns ``Err(errmsg)`` on
     //! prepare or step failure.
-    var stmt : sqlite3_stmt?
-    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
-    if (prc != SQLITE_OK) {
-        let msg = "_sql prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
-        sqlite3_finalize(stmt)
-        return err(msg, type<array<TT -const -#>>)
-    }
-    invoke(bind_blk, stmt)
-    var inscope result : array<TT -const -#>
-    var rc = sqlite3_step(stmt)
-    while (rc == SQLITE_ROW) {
-        result |> push(invoke(row_blk, stmt))
-        rc = sqlite3_step(stmt)
-    }
-    if (rc != SQLITE_DONE) {
-        let msg = "_sql step failed: {sqlite3_errmsg(db.sqlite_handle)}"
-        sqlite3_finalize(stmt)
-        return err(msg, type<array<TT -const -#>>)
-    }
-    sqlite3_finalize(stmt)
-    return move_ok(result, type<string>)
+    return <- db |> try_collect_rows(sql, bind_blk, row_blk, "_sql")
 }
 
 def run_select(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite3_stmt?) : void>; row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : array<TT -const -#> {
@@ -822,27 +1124,7 @@ def try_run_select_one_opt(db : SqlRunner; sql : string; bind_blk : block<(var s
     //! Prepares ``sql``, runs ``bind_blk`` once, steps once. Returns
     //! ``Ok(some(row))`` if a row is found, ``Ok(none)`` if zero rows, or
     //! ``Err(errmsg)`` on prepare/step failure.
-    var stmt : sqlite3_stmt?
-    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
-    if (prc != SQLITE_OK) {
-        let msg = "_sql prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
-        sqlite3_finalize(stmt)
-        return err(msg, type<Option<TT -const -#>>)
-    }
-    invoke(bind_blk, stmt)
-    let rc = sqlite3_step(stmt)
-    if (rc == SQLITE_DONE) {
-        sqlite3_finalize(stmt)
-        return ok(none(type<TT -const -#>), type<string>)
-    }
-    if (rc != SQLITE_ROW) {
-        let msg = "_sql step failed: {sqlite3_errmsg(db.sqlite_handle)}"
-        sqlite3_finalize(stmt)
-        return err(msg, type<Option<TT -const -#>>)
-    }
-    var row : TT -const -# = invoke(row_blk, stmt) // nolint:LINT003
-    sqlite3_finalize(stmt)
-    return move_ok(move_some(row), type<string>)
+    return <- try_one_row_opt(db, sql, bind_blk, row_blk, "_sql")
 }
 
 def run_select_one_opt(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite3_stmt?) : void>; row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : Option<TT -const -#> {
@@ -966,6 +1248,14 @@ class SqlTableMacro : AstStructureAnnotation {
         compiling_module() |> add_function(fn_select_all)
         var fn_read = make_read_row_fn(st, fields)
         compiling_module() |> add_function(fn_read)
+        var fn_upd_pk = make_update_by_pk_sql_fn(st, table_name, fields)
+        compiling_module() |> add_function(fn_upd_pk)
+        var fn_del_pk = make_delete_by_pk_sql_fn(st, table_name, fields)
+        compiling_module() |> add_function(fn_del_pk)
+        var fn_bind_upd = make_bind_row_for_update_fn(st, fields)
+        compiling_module() |> add_function(fn_bind_upd)
+        var fn_bind_pk = make_bind_row_pk_only_fn(st, fields)
+        compiling_module() |> add_function(fn_bind_pk)
 
         return true
     }
@@ -1187,6 +1477,162 @@ class SqlTableMacro : AstStructureAnnotation {
             var row = default<$t(st)>
             $b(assign_exprs)
             return <- row
+        }
+        fn.flags |= FunctionFlags.generated
+        fn.body |> force_at(st.at)
+        return <- fn
+    }
+
+    def find_pk_field(fields : array<FieldInfo>) : int {
+        for (i in range(length(fields))) {
+            if (fields[i].is_pk) {
+                return i
+            }
+        }
+        return -1
+    }
+
+    def make_update_by_pk_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>) : FunctionPtr {
+        // PK-less / SET-less structs get a stub that panics at runtime — using
+        // ``concept_assert`` here would fire at compile-time on every
+        // ``[sql_table]`` declaration (the function body is type-checked
+        // unconditionally). The stub stays unreachable in practice because
+        // ``update(row)`` panics from the same function before binding runs.
+        let pk_idx = find_pk_field(fields)
+        if (pk_idx < 0) {
+            let st_name = string(st.name)
+            let msg = "[sql_table] {st_name}: update(row) / delete_(row) / delete_by_id are unavailable — no @sql_primary_key field. Use the macro forms `_sql_update(type<{st_name}>, where, set)` / `_sql_delete(type<{st_name}>, where)` instead."
+            var fn = qmacro_function("_sql_update_by_pk_sql") $(typ : $t(st)) : string {
+                panic($v(msg))
+                return ""
+            }
+            fn.flags |= FunctionFlags.generated
+            fn.body |> force_at(st.at)
+            return <- fn
+        }
+        let pk_col = fields[pk_idx].col_name
+        let set_clause = build_string() $(var w) {
+            var first = true
+            for (info in fields) {
+                if (info.is_pk) {
+                    continue
+                }
+                if (!first) {
+                    w |> write(", ")
+                }
+                w |> write("\"")
+                w |> write(info.col_name)
+                w |> write("\" = ?")
+                first = false
+            }
+        }
+        // PK-only struct (no SET columns): `UPDATE T SET WHERE pk=?` is invalid
+        // SQL. Stub panics at call time with a clear message.
+        if (empty(set_clause)) {
+            let st_name = string(st.name)
+            let msg = "[sql_table] {st_name}: update(row) has nothing to SET — every non-PK field is missing. Add at least one non-PK column, or use raw `exec`."
+            var fn = qmacro_function("_sql_update_by_pk_sql") $(typ : $t(st)) : string {
+                panic($v(msg))
+                return ""
+            }
+            fn.flags |= FunctionFlags.generated
+            fn.body |> force_at(st.at)
+            return <- fn
+        }
+        let sql = "UPDATE \"{table_name}\" SET {set_clause} WHERE \"{pk_col}\" = ?"
+        var fn = qmacro_function("_sql_update_by_pk_sql") $(typ : $t(st)) : string {
+            return $v(sql)
+        }
+        fn.flags |= FunctionFlags.generated
+        fn.body |> force_at(st.at)
+        return <- fn
+    }
+
+    def make_delete_by_pk_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>) : FunctionPtr {
+        let pk_idx = find_pk_field(fields)
+        if (pk_idx < 0) {
+            let st_name = string(st.name)
+            let msg = "[sql_table] {st_name}: delete_(row) / delete_by_id require a @sql_primary_key field. Use `_sql_delete(type<{st_name}>, where)` instead."
+            var fn = qmacro_function("_sql_delete_by_pk_sql") $(typ : $t(st)) : string {
+                panic($v(msg))
+                return ""
+            }
+            fn.flags |= FunctionFlags.generated
+            fn.body |> force_at(st.at)
+            return <- fn
+        }
+        let pk_col = fields[pk_idx].col_name
+        let sql = "DELETE FROM \"{table_name}\" WHERE \"{pk_col}\" = ?"
+        var fn = qmacro_function("_sql_delete_by_pk_sql") $(typ : $t(st)) : string {
+            return $v(sql)
+        }
+        fn.flags |= FunctionFlags.generated
+        fn.body |> force_at(st.at)
+        return <- fn
+    }
+
+    def make_bind_row_for_update_fn(var st : StructurePtr; fields : array<FieldInfo>) : FunctionPtr {
+        // Emits SET-then-WHERE binds: every non-PK column at indices 1..N,
+        // PK column at index N+1. Mirrors the SQL emitted by
+        // `_sql_update_by_pk_sql`. For PK-less / SET-less structs the stub
+        // never runs (the SQL helper panics first), but we still emit a
+        // valid no-op body so the surface compiles.
+        let pk_idx = find_pk_field(fields)
+        if (pk_idx < 0) {
+            var fn = qmacro_function("_sql_bind_row_for_update") $(var stmt : sqlite3_stmt?; row : $t(st)) : void {
+                pass
+            }
+            fn.flags |= FunctionFlags.generated
+            fn.body |> force_at(st.at)
+            return <- fn
+        }
+
+        var bind_exprs : array<ExpressionPtr>
+        var bind_idx = 0
+        // Non-PK columns first.
+        for (i in range(length(fields))) {
+            if (fields[i].is_pk) {
+                continue
+            }
+            bind_idx++
+            let bi = bind_idx
+            let field_name = fields[i].name
+            bind_exprs |> push(qmacro_expr(${
+                sqlite_bind(stmt, $v(bi), row.$f(field_name));
+            }))
+        }
+        // PK column last (WHERE clause).
+        bind_idx++
+        let pk_bind_idx = bind_idx
+        let pk_field_name = fields[pk_idx].name
+        bind_exprs |> push(qmacro_expr(${
+            sqlite_bind(stmt, $v(pk_bind_idx), row.$f(pk_field_name));
+        }))
+
+        var fn = qmacro_function("_sql_bind_row_for_update") $(var stmt : sqlite3_stmt?; row : $t(st)) : void {
+            $b(bind_exprs)
+        }
+        fn.flags |= FunctionFlags.generated
+        fn.body |> force_at(st.at)
+        return <- fn
+    }
+
+    def make_bind_row_pk_only_fn(var st : StructurePtr; fields : array<FieldInfo>) : FunctionPtr {
+        // Binds just the PK column at index 1. Used by `try_delete_(row)` to
+        // execute `DELETE FROM T WHERE pk=?` without needing every field set.
+        // PK-less structs get a no-op stub (the SQL helper panics first).
+        let pk_idx = find_pk_field(fields)
+        if (pk_idx < 0) {
+            var fn = qmacro_function("_sql_bind_row_pk_only") $(var stmt : sqlite3_stmt?; row : $t(st)) : void {
+                pass
+            }
+            fn.flags |= FunctionFlags.generated
+            fn.body |> force_at(st.at)
+            return <- fn
+        }
+        let pk_field_name = fields[pk_idx].name
+        var fn = qmacro_function("_sql_bind_row_pk_only") $(var stmt : sqlite3_stmt?; row : $t(st)) : void {
+            sqlite_bind(stmt, 1, row.$f(pk_field_name))
         }
         fn.flags |= FunctionFlags.generated
         fn.body |> force_at(st.at)

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -485,8 +485,7 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     //    side). Column qualification is driven by `!empty(q.rootAlias)`
     //    in `pred_to_sql` — the alias-emission signal is independent of
     //    "this query contains a join".
-    var subQ = SqlQuery()
-    subQ.rootAlias = "t1"
+    var subQ = SqlQuery(rootAlias = "t1")
     if (!analyze_chain(jCall.arguments[1], subQ, prog, at)) {
         return false
     }
@@ -2999,5 +2998,468 @@ class private TrySqlMacro : AstCallMacro {
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         macro_verify(call.arguments |> length == 1, prog, call.at, "_try_sql expects one argument: a chain expression")
         return emit_sql_macro_body(prog, call, true)
+    }
+}
+
+// ============================================================================
+// `_sql_update` / `_sql_delete` — predicate-based mutations
+//
+// These macros run with `canVisitArgument = false` for everything except `db`
+// so the WHERE / SET arguments arrive as raw AST (the user writes `_.Col < x`
+// with `_` unbound). Analysis proceeds on the raw shape:
+//
+//   * `_.Col` references are recognized via the AST shape (ExprField over
+//     ExprVar named "_") and translated to SQL column refs (`"Col"`). They
+//     never become bind parameters.
+//   * Captured locals and literals classify as binds — pred_to_sql emits a
+//     `?` placeholder and the original ExprVar / ExprConst is pushed to the
+//     bind list. At the macro's output, the bind expression is passed verbatim
+//     to ``sqlite_bind(stmt, idx, expr)``; daslang's typer resolves the
+//     captured-var's type and overload-dispatches `sqlite_bind`.
+//
+// Bind ordering for SET-then-WHERE SQL: SET binds come first, then WHERE
+// binds (matches placeholder order in `UPDATE ... SET col1=?, ... WHERE ...`).
+// For RETURNING, the RETURNING clause is appended without adding binds and
+// the row materializer reuses the `[sql_table]`-generated `_sql_read_row`.
+// ============================================================================
+
+[macro_function]
+def private analyze_set_clause(var setExpr : ExpressionPtr; var q : SqlQuery&;
+                               var setSqlClauses : array<string>&;
+                               var setBindExprs : array<ExpressionPtr>&;
+                               prog : ProgramPtr; at : LineInfo) : bool {
+    //! Walk a raw `(Col1 = expr1, Col2 = expr2, ...)` named-tuple literal and
+    //! emit a list of `"Col" = <sql>` fragments + the bind expressions they
+    //! introduce. The SET clause SQL fragments are pushed into
+    //! ``setSqlClauses``; bind expressions accumulate into ``setBindExprs``.
+    //! WHERE binds (from ``q.bindExprs``) stay separate and are appended
+    //! after SET binds at SQL emission time.
+    if (setExpr == null) {
+        macro_error(prog, at, "_sql_update: set clause is null")
+        return false
+    }
+    var body = setExpr
+    if (body is ExprRef2Value) {
+        body = (body as ExprRef2Value).subexpr
+    }
+    if (!(body is ExprMakeTuple)) {
+        macro_error(prog, at, "_sql_update: set clause must be a named-tuple literal `(Col1=expr1, Col2=expr2, ...)`; got: {describe(body)}")
+        return false
+    }
+    var mkTup = body as ExprMakeTuple
+    if (length(mkTup.values) == 0) {
+        macro_error(prog, at, "_sql_update: set clause is empty — UPDATE with no columns is invalid SQL. Pass at least one (Col=expr) pair.")
+        return false
+    }
+    // The named-tuple literal's record names live on the inferred tuple type
+    // (`tupT.argNames`). When the macro runs with ``canVisitArgument=false``
+    // the SET arg arrives raw and `mkTup._type` is null — fall back to the
+    // recordNames carried directly on the MakeTuple node by the parser.
+    var tupT = mkTup._type
+    var recordNames : array<string>
+    if (tupT != null && tupT.baseType == Type.tTuple
+            && length(tupT.argNames) == length(mkTup.values)) {
+        recordNames |> reserve(length(tupT.argNames))
+        for (i in range(length(tupT.argNames))) {
+            recordNames |> push(string(tupT.argNames[i]))
+        }
+    } elif (length(mkTup.recordNames) == length(mkTup.values)) {
+        recordNames |> reserve(length(mkTup.recordNames))
+        for (i in range(length(mkTup.recordNames))) {
+            recordNames |> push(string(mkTup.recordNames[i]))
+        }
+    } else {
+        macro_error(prog, at, "_sql_update: set clause must be a NAMED-tuple literal `(Col=expr, ...)`; could not extract per-element column names")
+        return false
+    }
+    for (i in range(length(recordNames))) {
+        if (empty(recordNames[i])) {
+            macro_error(prog, at, "_sql_update: set clause: positional element at index {i} has no field name; use `(Col=expr, ...)` form")
+            return false
+        }
+    }
+    // Validate each SET column: must be a real field on T, no duplicates.
+    // The WHERE side validates `_.Field` via pred_to_sql; mirror that
+    // discipline on the SET side so typos / collisions surface as a
+    // macro_error at compile time instead of a SQLite runtime error.
+    if (q.rootType != null && q.rootType.structType != null) {
+        var st = q.rootType.structType
+        var seenCols : table<string; bool>
+        for (i in range(length(recordNames))) {
+            let colName = recordNames[i]
+            if (key_exists(seenCols, colName)) {
+                macro_error(prog, at, "_sql_update: duplicate SET column \"{colName}\"")
+                return false
+            }
+            seenCols[colName] = true
+            var found = false
+            for (f in st.fields) {
+                if (f.name == colName) {
+                    found = true
+                    break
+                }
+            }
+            if (!found) {
+                macro_error(prog, at, "_sql_update: SET column \"{colName}\" is not a field of {st.name}")
+                return false
+            }
+        }
+    }
+    // Each value is translated via the same pred_to_sql machinery as a WHERE
+    // predicate. Captured vars and `_.Col` references both work; binds are
+    // pushed into a SET-local list so we can interleave them with WHERE
+    // binds in correct placeholder order at SQL emission time.
+    var setQ = SqlQuery(
+        rootType = q.rootType,
+        tableName = q.tableName,
+        argNames <- ["_"],
+        argSourceIdx <- [0]
+    )
+    setSqlClauses |> reserve(length(setSqlClauses) + length(mkTup.values))
+    for (i in range(length(mkTup.values))) {
+        let colName = recordNames[i]
+        var val = mkTup.values[i]
+        let valSql = pred_to_sql(val, setQ, prog, at)
+        if (empty(valSql)) {
+            return false  // pred_to_sql already issued macro_error
+        }
+        setSqlClauses |> push("\"{colName}\" = {valSql}")
+    }
+    setBindExprs |> reserve(length(setBindExprs) + length(setQ.bindExprs))
+    for (b in setQ.bindExprs) {
+        setBindExprs |> push(b)
+    }
+    return true
+}
+
+[macro_function]
+def private build_returning_clause(rootT : TypeDeclPtr) : string {
+    //! Append `RETURNING "c1", "c2", ...` listing every field of T in
+    //! struct-declaration order. Mirrors `_sql_select_all_sql`'s output so
+    //! the row materializer (`_sql_read_row`) reads columns in struct order.
+    if (rootT == null || rootT.structType == null) {
+        return ""
+    }
+    var st = rootT.structType
+    return build_string() $(var w) {
+        w |> write(" RETURNING ")
+        var first = true
+        for (field in st.fields) {
+            if (!first) {
+                w |> write(", ")
+            }
+            w |> write("\"")
+            w |> write(field.name)
+            w |> write("\"")
+            first = false
+        }
+    }
+}
+
+[macro_function]
+def private emit_dml_call(var dbE : ExpressionPtr; sql : string;
+                          var bindStmts : array<ExpressionPtr>;
+                          isTry : bool; isReturning : bool;
+                          rootT : TypeDeclPtr; at : LineInfo) : ExpressionPtr {
+    //! Build the runtime call for `_sql_update*` / `_sql_delete*`. Picks one of
+    //! the four `_::run_dml*` variants from `(isTry, isReturning)` — the call
+    //! name is the only intrinsic fork (qmacro can't parameterize `_::name`);
+    //! the bind lambda and (for returning variants) the row reader are built
+    //! once and spliced into each branch.
+    var bindLambda = qmacro($(var _sql_stmt : sqlite3_stmt?) {
+        $b(bindStmts)
+    })
+    var res : ExpressionPtr
+    if (isReturning) {
+        var rootClone = clone_type(rootT)
+        var readerLambda = qmacro($(_sql_stmt : sqlite3_stmt?) => _::_sql_read_row(_sql_stmt, type<$t(rootClone)>))
+        if (isTry) {
+            res = qmacro(_::try_run_dml_returning($e(dbE), $v(sql), $e(bindLambda), $e(readerLambda)))
+        } else {
+            res = qmacro(_::run_dml_returning($e(dbE), $v(sql), $e(bindLambda), $e(readerLambda)))
+        }
+    } else {
+        if (isTry) {
+            res = qmacro(_::try_run_dml($e(dbE), $v(sql), $e(bindLambda)))
+        } else {
+            res = qmacro(_::run_dml($e(dbE), $v(sql), $e(bindLambda)))
+        }
+    }
+    res |> force_at(at)
+    return res
+}
+
+[macro_function]
+def private emit_update_body(prog : ProgramPtr; var call : ExprCallMacro?;
+                             var rootT : TypeDeclPtr;
+                             isTry : bool; isReturning : bool) : ExpressionPtr {
+    //! Shared body for the four `_sql_update*` macros. Operates on the raw
+    //! WHERE / SET argument expressions (canVisitArgument=false skipped
+    //! type inference for them); pred_to_sql analyzes the AST shape and
+    //! pushes captured vars / literals as binds. Caller supplies the already-
+    //! extracted ``rootT`` (the struct TypeDecl from `type<T>`).
+    if (rootT == null || rootT.structType == null) {
+        macro_error(prog, call.at, "_sql_update: T must be a struct (got {describe(rootT)})")
+        return null
+    }
+    var dbE = call.arguments[0]
+    var whereE = call.arguments[2]
+    var setE = call.arguments[3]
+    let tableName = sql_table_name_from_type(rootT)
+    var q = SqlQuery(
+        rootType = rootT,
+        tableName = tableName,
+        argNames <- ["_"],
+        argSourceIdx <- [0]
+    )
+    // Translate WHERE — raw AST.
+    let whereSql = pred_to_sql(whereE, q, prog, call.at)
+    if (empty(whereSql)) {
+        return null
+    }
+    // Translate SET — raw named-tuple literal.
+    var setSqlClauses : array<string>
+    var setBindExprs : array<ExpressionPtr>
+    if (!analyze_set_clause(setE, q, setSqlClauses, setBindExprs, prog, call.at)) {
+        return null
+    }
+    // Build SQL.
+    var sql = build_string() $(var w) {
+        w |> write("UPDATE \"")
+        w |> write(tableName)
+        w |> write("\" SET ")
+        for (i in range(length(setSqlClauses))) {
+            if (i > 0) {
+                w |> write(", ")
+            }
+            w |> write(setSqlClauses[i])
+        }
+        w |> write(" WHERE ")
+        w |> write(whereSql)
+    }
+    if (isReturning) {
+        sql += build_returning_clause(rootT)
+    }
+    // Combine binds: SET first, then WHERE.
+    var allBinds : array<ExpressionPtr>
+    allBinds |> reserve(length(setBindExprs) + length(q.bindExprs))
+    for (b in setBindExprs) {
+        allBinds |> push(b)
+    }
+    for (b in q.bindExprs) {
+        allBinds |> push(b)
+    }
+    var bindStmts : array<ExpressionPtr>
+    bindStmts |> reserve(length(allBinds))
+    for (i in range(length(allBinds))) {
+        let bindIdx = i + 1
+        var be = allBinds[i]
+        bindStmts |> push <| qmacro_expr(${
+            sqlite_bind(_sql_stmt, $v(bindIdx), $e(be));
+        })
+    }
+    return emit_dml_call(dbE, sql, bindStmts, isTry, isReturning, rootT, call.at)
+}
+
+[macro_function]
+def private emit_delete_body(prog : ProgramPtr; var call : ExprCallMacro?;
+                             var rootT : TypeDeclPtr;
+                             isTry : bool; isReturning : bool) : ExpressionPtr {
+    //! Shared body for the four `_sql_delete*` macros.
+    if (rootT == null || rootT.structType == null) {
+        macro_error(prog, call.at, "_sql_delete: T must be a struct (got {describe(rootT)})")
+        return null
+    }
+    var dbE = call.arguments[0]
+    var whereE = call.arguments[2]
+    let tableName = sql_table_name_from_type(rootT)
+    var q = SqlQuery(
+        rootType = rootT,
+        tableName = tableName,
+        argNames <- ["_"],
+        argSourceIdx <- [0]
+    )
+    let whereSql = pred_to_sql(whereE, q, prog, call.at)
+    if (empty(whereSql)) {
+        return null
+    }
+    var sql = "DELETE FROM \"{tableName}\" WHERE {whereSql}"
+    if (isReturning) {
+        sql += build_returning_clause(rootT)
+    }
+    var bindStmts : array<ExpressionPtr>
+    bindStmts |> reserve(length(q.bindExprs))
+    for (i in range(length(q.bindExprs))) {
+        let bindIdx = i + 1
+        var be = q.bindExprs[i]
+        bindStmts |> push <| qmacro_expr(${
+            sqlite_bind(_sql_stmt, $v(bindIdx), $e(be));
+        })
+    }
+    return emit_dml_call(dbE, sql, bindStmts, isTry, isReturning, rootT, call.at)
+}
+
+// ----------------------------------------------------------------------------
+// Outer macros — `canVisitArgument = false` for everything except db so the
+// WHERE / SET arguments stay raw (with `_` unbound). pred_to_sql operates on
+// the AST shape directly; bind expressions (captured locals, literals) are
+// passed through to ``sqlite_bind`` verbatim and resolve at the macro's
+// output type-inference pass.
+// ----------------------------------------------------------------------------
+
+[macro_function]
+def private validate_outer_update_args(prog : ProgramPtr; var call : ExprCallMacro?; var rootT : TypeDeclPtr&) : bool {
+    if (length(call.arguments) != 4) {
+        macro_error(prog, call.at, "{call.name}: expected (db, type<T>, where_expr, set_expr) — got {length(call.arguments)} args")
+        return false
+    }
+    var typeE = call.arguments[1]
+    if (!qmatch(typeE, type<$t(rootT)>).matched) {
+        macro_error(prog, call.at, "{call.name}: second argument must be a `type<T>` literal")
+        return false
+    }
+    return true
+}
+
+[macro_function]
+def private validate_outer_delete_args(prog : ProgramPtr; var call : ExprCallMacro?; var rootT : TypeDeclPtr&) : bool {
+    if (length(call.arguments) != 3) {
+        macro_error(prog, call.at, "{call.name}: expected (db, type<T>, where_expr) — got {length(call.arguments)} args")
+        return false
+    }
+    var typeE = call.arguments[1]
+    if (!qmatch(typeE, type<$t(rootT)>).matched) {
+        macro_error(prog, call.at, "{call.name}: second argument must be a `type<T>` literal")
+        return false
+    }
+    return true
+}
+
+[call_macro(name="_sql_update")]
+class private SqlUpdateMacro : AstCallMacro {
+    //! `_sql_update(db, type<T>, where_expr, set_expr)` — predicate-based UPDATE.
+    //! ``where_expr`` is an expression in the row variable `_` (e.g.
+    //! ``_.LastSeen < cutoff``). ``set_expr`` is a named-tuple literal
+    //! ``(Col1=expr1, Col2=expr2, ...)`` whose RHS may reference ``_.Col``
+    //! and captured locals. Returns ``int`` rows-affected. Panics on SQL error.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex == 0
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_update_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_update_body(prog, call, rootT, false, false)
+    }
+}
+
+[call_macro(name="_sql_try_update")]
+class private SqlTryUpdateMacro : AstCallMacro {
+    //! Non-panic sibling of `_sql_update`. Returns ``Result<int, string>``.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex == 0
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_update_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_update_body(prog, call, rootT, true, false)
+    }
+}
+
+[call_macro(name="_sql_update_returning")]
+class private SqlUpdateReturningMacro : AstCallMacro {
+    //! `_sql_update(...)` with a trailing ``RETURNING *`` clause. Returns
+    //! ``array<T>`` of post-update rows. Panics on SQL error.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex == 0
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_update_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_update_body(prog, call, rootT, false, true)
+    }
+}
+
+[call_macro(name="_sql_try_update_returning")]
+class private SqlTryUpdateReturningMacro : AstCallMacro {
+    //! Non-panic sibling of `_sql_update_returning`. Returns
+    //! ``Result<array<T>, string>``.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex == 0
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_update_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_update_body(prog, call, rootT, true, true)
+    }
+}
+
+[call_macro(name="_sql_delete")]
+class private SqlDeleteMacro : AstCallMacro {
+    //! `_sql_delete(db, type<T>, where_expr)` — predicate-based DELETE.
+    //! Returns ``int`` rows-affected. Panics on SQL error.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex == 0
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_delete_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_delete_body(prog, call, rootT, false, false)
+    }
+}
+
+[call_macro(name="_sql_try_delete")]
+class private SqlTryDeleteMacro : AstCallMacro {
+    //! Non-panic sibling of `_sql_delete`. Returns ``Result<int, string>``.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex == 0
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_delete_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_delete_body(prog, call, rootT, true, false)
+    }
+}
+
+[call_macro(name="_sql_delete_returning")]
+class private SqlDeleteReturningMacro : AstCallMacro {
+    //! `_sql_delete(...)` with a trailing ``RETURNING *`` clause. Returns
+    //! ``array<T>`` of just-deleted rows. Panics on SQL error.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex == 0
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_delete_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_delete_body(prog, call, rootT, false, true)
+    }
+}
+
+[call_macro(name="_sql_try_delete_returning")]
+class private SqlTryDeleteReturningMacro : AstCallMacro {
+    //! Non-panic sibling of `_sql_delete_returning`. Returns
+    //! ``Result<array<T>, string>``.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex == 0
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_delete_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_delete_body(prog, call, rootT, true, true)
     }
 }

--- a/src/builtin/module_builtin_ast_annotations_2.cpp
+++ b/src/builtin/module_builtin_ast_annotations_2.cpp
@@ -204,6 +204,7 @@ namespace das {
         AstExprMakeTupleAnnotation(ModuleLibrary & ml)
             :  AstExprMakeArrayAnnotation<ExprMakeTuple> ("ExprMakeTuple", ml) {
             addField<DAS_BIND_MANAGED_FIELD(isKeyValue)>("isKeyValue");
+            addField<DAS_BIND_MANAGED_FIELD(recordNames)>("recordNames");
         }
     };
 

--- a/tests/dasSQLITE/failed_sql_update_delete.das
+++ b/tests/dasSQLITE/failed_sql_update_delete.das
@@ -1,0 +1,42 @@
+options gen2
+
+// Each `_sql_update` / `_sql_delete` call below is intentionally malformed.
+// 40104 = macro_error (from the analyzer).
+expect 40104:7
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+[export]
+def main() {
+    var db = SqlRunner()
+
+    // 1. _sql_update wrong arity (3 instead of 4) → macro_error
+    let bad1 = db |> _sql_update(type<Car>, _.Id == 1)
+
+    // 2. _sql_update second arg not type<T>
+    let bad2 = db |> _sql_update(42, _.Id == 1, (Name = "x"))
+
+    // 3. _sql_update with positional (non-named) tuple in SET clause
+    let bad3 = db |> _sql_update(type<Car>, _.Id == 1, ("x", 42))
+
+    // 4. _sql_delete wrong arity (4 instead of 3)
+    let bad4 = db |> _sql_delete(type<Car>, _.Id == 1, (extra = 1))
+
+    // 5. _sql_delete second arg not type<T>
+    let bad5 = db |> _sql_delete("Cars", _.Id == 1)
+
+    // 6. _sql_update SET column is not a field of T (typo)
+    let bad6 = db |> _sql_update(type<Car>, _.Id == 1, (Nme = "x"))
+
+    // 7. _sql_update SET clause has duplicate column
+    let bad7 = db |> _sql_update(type<Car>, _.Id == 1, (Name = "a", Name = "b"))
+}

--- a/tests/dasSQLITE/test_43_update_by_pk.das
+++ b/tests/dasSQLITE/test_43_update_by_pk.das
@@ -1,0 +1,68 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    Active : bool
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "alice", Active = true))
+    db |> insert(User(Id = 2, Name = "bob",   Active = true))
+    db |> insert(User(Id = 3, Name = "carol", Active = false))
+}
+
+[test]
+def test_update_by_pk_changes_columns(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> update(User(Id = 1, Name = "ALICE", Active = false))
+        t |> equal(n, 1, "by-PK update on existing row returns rows-affected = 1")
+        let after <- db |> select_from(type<User>)
+        var found_alice = false
+        for (u in after) {
+            if (u.Id == 1) {
+                found_alice = true
+                t |> equal(u.Name, "ALICE", "Name updated on PK match")
+                t |> equal(u.Active, false, "Active updated on PK match")
+            }
+        }
+        t |> equal(found_alice, true, "row with PK 1 is still present after update")
+    }
+}
+
+[test]
+def test_update_by_pk_missing_returns_zero(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> update(User(Id = 999, Name = "ghost", Active = false))
+        t |> equal(n, 0, "by-PK update on missing PK returns 0 (not an error)")
+    }
+}
+
+[test]
+def test_try_update_ok(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let r = db |> try_update(User(Id = 2, Name = "BOB", Active = false))
+        t |> equal(r |> is_ok(), true, "try_update returns Ok on success")
+        t |> equal(r |> unwrap(), 1, "try_update Ok payload is rows-affected")
+    }
+}
+
+[test]
+def test_changes_after_update(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> update(User(Id = 1, Name = "alice2", Active = true))
+        t |> equal(db |> changes(), 1, "changes() reports last UPDATE's rows-affected")
+    }
+}

--- a/tests/dasSQLITE/test_44_update_bulk.das
+++ b/tests/dasSQLITE/test_44_update_bulk.das
@@ -1,0 +1,88 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    Active : bool
+    LastSeen : int64
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "alice", Active = true,  LastSeen = 100l))
+    db |> insert(User(Id = 2, Name = "bob",   Active = true,  LastSeen = 200l))
+    db |> insert(User(Id = 3, Name = "carol", Active = true,  LastSeen = 300l))
+    db |> insert(User(Id = 4, Name = "dave",  Active = false, LastSeen = 400l))
+}
+
+[test]
+def test_sql_update_with_predicate_and_set_literal(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cutoff : int64 = 250l
+        let n = db |> _sql_update(type<User>, _.LastSeen < cutoff, (Active = false))
+        t |> equal(n, 2, "rows with LastSeen<250 (alice, bob) are matched")
+        var alice_active = true
+        var carol_active = true
+        for (u in db |> select_from(type<User>)) {
+            if (u.Id == 1) {
+                alice_active = u.Active
+            }
+            if (u.Id == 3) {
+                carol_active = u.Active
+            }
+        }
+        t |> equal(alice_active, false, "alice flipped to Active=false")
+        t |> equal(carol_active, true, "carol untouched (LastSeen >= cutoff)")
+    }
+}
+
+[test]
+def test_sql_update_set_uses_captured_var(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let new_seen : int64 = 999l
+        let n = db |> _sql_update(type<User>, _.Id == 1, (LastSeen = new_seen))
+        t |> equal(n, 1, "single-row update by PK predicate")
+        for (u in db |> select_from(type<User>)) {
+            if (u.Id == 1) {
+                t |> equal(u.LastSeen, 999l, "captured-var bind value lands in row")
+            }
+        }
+    }
+}
+
+[test]
+def test_sql_try_update_ok(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let r = db |> _sql_try_update(type<User>, _.Id == 99, (Name = "missing"))
+        t |> equal(r |> is_ok(), true, "_sql_try_update returns Ok even when no rows match")
+        t |> equal(r |> unwrap(), 0, "Ok payload is 0 rows-affected for no-match predicate")
+    }
+}
+
+[test]
+def test_sql_update_two_set_columns(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let touch : int64 = 555l
+        let n = db |> _sql_update(type<User>, _.Active, (Name = "marker", LastSeen = touch))
+        t |> equal(n, 3, "three rows matched _.Active")
+        var marker_count = 0
+        for (u in db |> select_from(type<User>)) {
+            if (u.Name == "marker") {
+                marker_count++
+                t |> equal(u.LastSeen, 555l, "second SET column also lands")
+            }
+        }
+        t |> equal(marker_count, 3, "all matched rows updated both columns")
+    }
+}

--- a/tests/dasSQLITE/test_45_update_returning.das
+++ b/tests/dasSQLITE/test_45_update_returning.das
@@ -1,0 +1,60 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    Active : bool
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "alice", Active = false))
+    db |> insert(User(Id = 2, Name = "bob",   Active = false))
+    db |> insert(User(Id = 3, Name = "carol", Active = true))
+}
+
+[test]
+def test_sql_update_returning_returns_post_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let touched <- db |> _sql_update_returning(type<User>, _.Id == 1, (Name = "ALICE", Active = true))
+        t |> equal(length(touched), 1, "RETURNING surfaces 1 row")
+        t |> equal(touched[0].Id, 1, "RETURNING preserves PK")
+        t |> equal(touched[0].Name, "ALICE", "RETURNING reflects post-update Name")
+        t |> equal(touched[0].Active, true, "RETURNING reflects post-update Active")
+    }
+}
+
+[test]
+def test_sql_update_returning_multi_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let touched <- db |> _sql_update_returning(type<User>, !_.Active, (Active = true))
+        t |> equal(length(touched), 2, "RETURNING surfaces both flipped rows")
+        var ids_seen = 0
+        for (u in touched) {
+            t |> equal(u.Active, true, "every returned row reflects post-update Active=true")
+            ids_seen += u.Id
+        }
+        t |> equal(ids_seen, 3, "Ids 1 + 2 returned")
+    }
+}
+
+[test]
+def test_sql_try_update_returning_ok(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        var r <- db |> _sql_try_update_returning(type<User>, _.Id == 3, (Name = "CAROL", Active = false))
+        t |> equal(r |> is_ok(), true, "try_update_returning Ok on success")
+        let rows <- r._value
+        t |> equal(length(rows), 1, "Ok payload contains 1 returned row")
+        t |> equal(rows[0].Name, "CAROL", "returned row reflects post-update Name")
+    }
+}

--- a/tests/dasSQLITE/test_46_delete_by_pk.das
+++ b/tests/dasSQLITE/test_46_delete_by_pk.das
@@ -1,0 +1,62 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "alice"))
+    db |> insert(User(Id = 2, Name = "bob"))
+    db |> insert(User(Id = 3, Name = "carol"))
+}
+
+[test]
+def test_delete_underscore_by_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> delete_(User(Id = 2, Name = ""))
+        t |> equal(n, 1, "delete_ by row removes 1 matching row")
+        let after <- db |> select_from(type<User>)
+        t |> equal(length(after), 2, "table now holds 2 rows")
+        for (u in after) {
+            t |> equal(u.Id != 2, true, "Id 2 was removed")
+        }
+    }
+}
+
+[test]
+def test_delete_underscore_missing(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> delete_(User(Id = 999, Name = ""))
+        t |> equal(n, 0, "delete_ on missing PK returns 0 (not an error)")
+    }
+}
+
+[test]
+def test_delete_by_id_basic(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> delete_by_id(type<User>, 3)
+        t |> equal(n, 1, "delete_by_id removes 1 row when PK matches")
+    }
+}
+
+[test]
+def test_try_delete_by_id_missing(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let r = db |> try_delete_by_id(type<User>, 99)
+        t |> equal(r |> is_ok(), true, "try_delete_by_id returns Ok on no-match")
+        t |> equal(r |> unwrap(), 0, "Ok payload reports 0 rows-affected for no-match")
+    }
+}

--- a/tests/dasSQLITE/test_47_delete_bulk.das
+++ b/tests/dasSQLITE/test_47_delete_bulk.das
@@ -1,0 +1,66 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    Active : bool
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "alice", Active = true))
+    db |> insert(User(Id = 2, Name = "bob",   Active = false))
+    db |> insert(User(Id = 3, Name = "carol", Active = false))
+    db |> insert(User(Id = 4, Name = "dave",  Active = true))
+}
+
+[test]
+def test_sql_delete_with_predicate(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> _sql_delete(type<User>, !_.Active)
+        t |> equal(n, 2, "removed both inactive rows")
+        let after <- db |> select_from(type<User>)
+        t |> equal(length(after), 2, "table has 2 rows left")
+        for (u in after) {
+            t |> equal(u.Active, true, "all surviving rows are active")
+        }
+    }
+}
+
+[test]
+def test_sql_delete_with_captured_var(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let cutoff_id = 2
+        let n = db |> _sql_delete(type<User>, _.Id <= cutoff_id)
+        t |> equal(n, 2, "removed rows with Id<=2")
+    }
+}
+
+[test]
+def test_sql_try_delete_no_match(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let r = db |> _sql_try_delete(type<User>, _.Id == 999)
+        t |> equal(r |> is_ok(), true, "try_delete returns Ok on no-match")
+        t |> equal(r |> unwrap(), 0, "Ok payload is 0 for no-match predicate")
+    }
+}
+
+[test]
+def test_changes_after_delete(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> _sql_delete(type<User>, _.Id < 3)
+        t |> equal(n, 2, "deleted 2 rows")
+        t |> equal(db |> changes(), 2, "changes() reports last DELETE's rows-affected")
+    }
+}

--- a/tests/dasSQLITE/test_48_delete_returning.das
+++ b/tests/dasSQLITE/test_48_delete_returning.das
@@ -1,0 +1,59 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    Active : bool
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "alice", Active = true))
+    db |> insert(User(Id = 2, Name = "bob",   Active = false))
+    db |> insert(User(Id = 3, Name = "carol", Active = false))
+}
+
+[test]
+def test_sql_delete_returning_returns_just_deleted_rows(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let removed <- db |> _sql_delete_returning(type<User>, !_.Active)
+        t |> equal(length(removed), 2, "RETURNING surfaces 2 rows that were deleted")
+        var ids = 0
+        for (u in removed) {
+            ids += u.Id
+        }
+        t |> equal(ids, 5, "removed Ids 2 + 3 (sum=5)")
+        let after <- db |> select_from(type<User>)
+        t |> equal(length(after), 1, "1 row remains in the table")
+    }
+}
+
+[test]
+def test_sql_delete_returning_empty_when_no_match(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let removed <- db |> _sql_delete_returning(type<User>, _.Id == 99)
+        t |> equal(length(removed), 0, "RETURNING returns empty array on no-match")
+        t |> equal(length(db |> select_from(type<User>)), 3, "table unchanged")
+    }
+}
+
+[test]
+def test_sql_try_delete_returning_ok(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        var r <- db |> _sql_try_delete_returning(type<User>, _.Id == 1)
+        t |> equal(r |> is_ok(), true, "try_delete_returning Ok on success")
+        let rows <- r._value
+        t |> equal(length(rows), 1, "Ok payload contains 1 returned row")
+        t |> equal(rows[0].Name, "alice", "returned row carries pre-delete column data")
+    }
+}

--- a/tests/dasSQLITE/test_49_changes.das
+++ b/tests/dasSQLITE/test_49_changes.das
@@ -1,0 +1,46 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "alice"))
+    db |> insert(User(Id = 2, Name = "bob"))
+    db |> insert(User(Id = 3, Name = "carol"))
+}
+
+[test]
+def test_changes_after_raw_update(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> exec("UPDATE Users SET Name='X' WHERE Id <= 2")
+        t |> equal(db |> changes(), 2, "changes() reports rows-affected from raw exec UPDATE")
+    }
+}
+
+[test]
+def test_changes_after_raw_delete(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> exec("DELETE FROM Users WHERE Id = 1")
+        t |> equal(db |> changes(), 1, "changes() reports rows-affected from raw exec DELETE")
+    }
+}
+
+[test]
+def test_changes_after_no_match(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> exec("UPDATE Users SET Name='Z' WHERE Id = 999")
+        t |> equal(db |> changes(), 0, "changes() reports 0 for no-match predicate")
+    }
+}

--- a/tests/dasSQLITE/test_50_with_transaction.das
+++ b/tests/dasSQLITE/test_50_with_transaction.das
@@ -1,0 +1,68 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[sql_table(name = "Friends")]
+struct Friend {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+[test]
+def test_with_transaction_commits_on_normal_exit(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Friend>)
+        db |> with_transaction() {
+            db |> insert(Friend(Id = 1, Name = "tom"))
+            db |> insert(Friend(Id = 2, Name = "jerry"))
+        }
+        let rows <- db |> select_from(type<Friend>)
+        t |> equal(length(rows), 2, "both inserts visible after commit")
+    }
+}
+
+[test]
+def test_in_transaction_status_flips(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Friend>)
+        t |> equal(db |> in_transaction(), false, "default state is autocommit (not in txn)")
+        var inside_flag = false
+        db |> with_transaction() {
+            inside_flag = db |> in_transaction()
+            db |> insert(Friend(Id = 1, Name = "x"))
+        }
+        t |> equal(inside_flag, true, "in_transaction() returns true inside with_transaction")
+        t |> equal(db |> in_transaction(), false, "reverts to autocommit after exit")
+    }
+}
+
+[test]
+def test_with_transaction_immediate_mode(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Friend>)
+        db |> with_transaction(SqliteTxnMode.Immediate) {
+            db |> insert(Friend(Id = 7, Name = "imm"))
+        }
+        t |> equal(length(db |> select_from(type<Friend>)), 1, "Immediate-mode txn commits cleanly")
+    }
+}
+
+[test]
+def test_with_transaction_nesting_via_savepoint(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Friend>)
+        db |> with_transaction() {
+            db |> insert(Friend(Id = 1, Name = "outer"))
+            db |> with_transaction() {
+                db |> insert(Friend(Id = 2, Name = "inner"))
+                t |> equal(db |> in_transaction(), true, "nested call is still in-txn")
+            }
+            db |> insert(Friend(Id = 3, Name = "outer2"))
+        }
+        let rows <- db |> select_from(type<Friend>)
+        t |> equal(length(rows), 3, "all 3 inserts (outer + inner savepoint + outer) commit")
+    }
+}

--- a/tests/dasSQLITE/test_51_try_transaction.das
+++ b/tests/dasSQLITE/test_51_try_transaction.das
@@ -1,0 +1,58 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[sql_table(name = "Acct")]
+struct Acct {
+    @sql_primary_key Id : int
+    Balance : int
+}
+
+[test]
+def test_try_transaction_ok_path(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Acct>)
+        let r = db |> try_transaction() {
+            db |> insert(Acct(Id = 1, Balance = 100))
+            db |> insert(Acct(Id = 2, Balance = 200))
+        }
+        t |> equal(r |> is_none(), true, "try_transaction returns none on success")
+        t |> equal(length(db |> select_from(type<Acct>)), 2, "both rows committed")
+    }
+}
+
+[test]
+def test_try_transaction_pk_conflict_returns_err(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Acct>)
+        db |> insert(Acct(Id = 1, Balance = 100))
+        // Use try_insert inside the txn so a PK clash surfaces as an Err
+        // *inside the block* rather than panicking. The block returns
+        // normally, so try_transaction COMMITs whatever the block did
+        // (which was to fail try_insert and not insert anything).
+        let r = db |> try_transaction() {
+            let ins = db |> try_insert(Acct(Id = 1, Balance = 999))
+            // ignore the err; the transaction itself succeeds
+            t |> equal(ins |> is_err(), true, "PK collision is caught by try_insert inside txn")
+        }
+        t |> equal(r |> is_none(), true, "try_transaction commits even when block-internal SQL failed")
+        let rows <- db |> select_from(type<Acct>)
+        t |> equal(length(rows), 1, "row count unchanged (collision didn't insert)")
+        t |> equal(rows[0].Balance, 100, "original Balance preserved")
+    }
+}
+
+[test]
+def test_try_transaction_immediate_mode(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Acct>)
+        let r = db |> try_transaction(SqliteTxnMode.Immediate) {
+            db |> insert(Acct(Id = 1, Balance = 50))
+        }
+        t |> equal(r |> is_none(), true, "Immediate-mode try_transaction commits cleanly")
+        t |> equal(length(db |> select_from(type<Acct>)), 1, "row inserted")
+    }
+}

--- a/tutorials/sql/19-update.das
+++ b/tutorials/sql/19-update.das
@@ -1,0 +1,106 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 19 — UPDATE: change existing rows.
+//
+// Three flavours, mirroring the SELECT side:
+//
+//   (a) by-PK whole-row replace          db |> update(row)
+//   (b) bulk via predicate macro         db |> _sql_update(type<T>, where, set)
+//   (c) bulk RETURNING                   db |> _sql_update_returning(...)
+//   (d) raw escape hatch                 db |> exec(sql)
+//   (e) try_ non-panic variants          try_update / _sql_try_update / *_returning
+//
+// All forms return ``int`` rows-affected (or ``array<T>`` for RETURNING).
+// 0 rows-affected is **not** an error — the row simply wasn't there.
+// ``Err`` from the try_ variants is reserved for genuine SQL failures
+// (constraint violation, IO, BUSY).
+//
+// Naming: the function form is plain ``update`` / ``try_update``. The macro
+// form carries the ``_sql_`` prefix — ``_sql_update`` / ``_sql_try_update`` /
+// ``_sql_update_returning`` / ``_sql_try_update_returning`` — to match the
+// flagship ``_sql(...)`` macro and keep the SQL provenance visible. RETURNING
+// is macro-only; there is no plain ``update_returning`` function.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name     : string
+    Email    : string
+    Active   : bool
+    LastSeen : int64
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert([
+        User(Id = 1, Name = "alice", Email = "a@x.com", Active = true,  LastSeen = 100l),
+        User(Id = 2, Name = "bob",   Email = "b@x.com", Active = true,  LastSeen = 200l),
+        User(Id = 3, Name = "carol", Email = "c@x.com", Active = true,  LastSeen = 300l),
+        User(Id = 4, Name = "dave",  Email = "d@x.com", Active = false, LastSeen = 400l)
+    ])
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // (a) by-PK whole-row replace ---------------------------------------
+        // Pass a row; the PK identifies it, every other column is rewritten.
+        // Emitted SQL: ``UPDATE "Users" SET "Name"=?, "Email"=?, "Active"=?,
+        //                "LastSeen"=? WHERE "Id" = ?``.
+        let n1 = db |> update(User(Id = 1, Name = "alice", Email = "alice@new.com",
+                                    Active = true, LastSeen = 100l))
+        to_log(LOG_INFO, "by-PK update affected {n1} row(s)\n")
+
+        // 0 rows-affected when the PK doesn't match — not an error.
+        let n_missing = db |> update(User(Id = 999, Name = "ghost", Email = "",
+                                           Active = false, LastSeen = 0l))
+        to_log(LOG_INFO, "by-PK update on missing row: {n_missing} (expect 0)\n")
+
+        // (b) bulk update via the `_sql_update` macro -----------------------
+        // ``_sql_update(type<T>, where_expr, set_expr)`` translates the
+        // predicate to SQL and binds captured locals automatically. The set
+        // clause is a named-tuple literal ``(Col=expr, ...)`` whose RHS may
+        // reference column refs (``_.Other``) and outer-scope locals.
+        // Emitted SQL: ``UPDATE "Users" SET "Active" = ? WHERE "LastSeen" < ?``.
+        let cutoff : int64 = 250l
+        let stale = db |> _sql_update(type<User>, _.LastSeen < cutoff, (Active = false))
+        to_log(LOG_INFO, "marked {stale} stale users inactive\n")
+
+        // (c) bulk RETURNING — capture the rows AFTER the update -----------
+        // Emitted SQL: ``UPDATE "Users" SET "Active" = ?, "LastSeen" = ?
+        //   WHERE "Id" = ? RETURNING "Id", "Name", "Email", "Active", "LastSeen"``.
+        let touch_at : int64 = 1000l
+        let revived <- db |> _sql_update_returning(type<User>, _.Id == 4,
+            (Active = true, LastSeen = touch_at))
+        for (u in revived) {
+            to_log(LOG_INFO, "revived: {u.Name} (active={u.Active}, last={u.LastSeen})\n")
+        }
+
+        // (d) raw-SQL escape hatch -----------------------------------------
+        // ``exec`` runs arbitrary SQL with no parameter binding — useful
+        // for migrations or queries the macro can't (or shouldn't)
+        // translate. For dynamic values in raw SQL, format them into the
+        // string yourself (taking care to escape) or stick with the macro
+        // forms above. ``changes()`` reports rows-affected from the most
+        // recent INSERT / UPDATE / DELETE on this connection.
+        db |> exec("UPDATE Users SET Name = 'admin' WHERE Id = 1")
+        to_log(LOG_INFO, "raw-SQL update affected {db |> changes()} row(s)\n")
+
+        // (e) try_ variants — non-panic flow -------------------------------
+        // ``try_update`` / ``_sql_try_update`` return ``Result<int, string>``.
+        // 0 rows-affected is NOT an Err (reserved for constraint / IO / BUSY).
+        let attempt = db |> try_update(User(Id = 999, Name = "phantom",
+                                             Email = "", Active = false, LastSeen = 0l))
+        if (attempt |> is_err) {
+            to_log(LOG_ERROR, "update failed: {attempt |> unwrap_err}\n")
+        } else {
+            to_log(LOG_INFO, "phantom-update touched {attempt |> unwrap} row(s)\n")
+        }
+    }
+}

--- a/tutorials/sql/20-delete.das
+++ b/tutorials/sql/20-delete.das
@@ -1,0 +1,106 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 20 — DELETE: remove rows.
+//
+// Mirrors the UPDATE shape:
+//
+//   (a) by-PK from a row              db |> delete_(row)
+//   (b) by-PK from just an id         db |> delete_by_id(type<T>, id)
+//   (c) bulk via predicate macro      db |> _sql_delete(type<T>, where)
+//   (d) bulk RETURNING                db |> _sql_delete_returning(...)
+//   (e) raw escape hatch              db |> exec("DELETE FROM ...")
+//   (f) try_ non-panic variants
+//
+// Naming note: the function form is ``delete_`` (trailing underscore)
+// because ``delete`` is a daslang keyword. The macro form uses the
+// ``_sql_`` prefix and skips the underscore (``_sql_delete``).
+// ``delete_by_id`` and ``try_delete_by_id`` are separate helpers for the
+// "I just have the id" case so callers don't have to construct a dummy
+// struct just to identify the row.
+//
+// Like UPDATE, 0 rows-affected is **not** an error — the row simply wasn't
+// there. Reserve ``Err`` from try_ variants for SQL failures.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name   : string
+    Active : bool
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert([
+        User(Id = 1, Name = "alice", Active = true),
+        User(Id = 2, Name = "bob",   Active = true),
+        User(Id = 3, Name = "carol", Active = false),
+        User(Id = 4, Name = "dave",  Active = false)
+    ])
+    db |> insert([
+        Order(Id = 10, UserId = 1, Total = 100),
+        Order(Id = 11, UserId = 2, Total =  50)
+    ])
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // (a) by-PK from a row ---------------------------------------------
+        // ``delete_`` reads only the PK; non-PK fields are ignored. Useful
+        // when you already have the row loaded (e.g. from a SELECT).
+        // Emitted SQL: ``DELETE FROM "Users" WHERE "Id" = ?``.
+        let n1 = db |> delete_(User(Id = 2, Name = "", Active = false))
+        to_log(LOG_INFO, "delete_(row): {n1} row(s)\n")
+
+        // (b) by-PK from just an id ----------------------------------------
+        // No dummy struct construction — pass the id directly.
+        let n2 = db |> delete_by_id(type<User>, 4)
+        to_log(LOG_INFO, "delete_by_id: {n2} row(s)\n")
+
+        // (c) bulk delete via the macro ------------------------------------
+        // Captured-var binds and ``_.Col`` references both work.
+        // Emitted SQL: ``DELETE FROM "Users" WHERE NOT ("Active")``.
+        let purged = db |> _sql_delete(type<User>, !_.Active)
+        to_log(LOG_INFO, "purged {purged} inactive user(s)\n")
+
+        // (d) bulk RETURNING — capture rows BEFORE they vanish -------------
+        // Useful for audit logs, undo queues, "delete-and-publish" pipelines.
+        // Emitted SQL: ``DELETE FROM "Orders" WHERE "Total" < ?
+        //   RETURNING "Id", "UserId", "Total"``.
+        let small_threshold = 75
+        let removed_orders <- db |> _sql_delete_returning(type<Order>,
+                                                          _.Total < small_threshold)
+        for (o in removed_orders) {
+            to_log(LOG_INFO, "removed order Id={o.Id} (Total={o.Total})\n")
+        }
+
+        // (e) raw-SQL escape hatch -----------------------------------------
+        // ``exec`` runs arbitrary SQL with no parameter binding. For
+        // dynamic values stick to the macro forms above; this hatch is
+        // for migrations / DDL / statements the macro can't translate.
+        db |> exec("DELETE FROM Users WHERE Name LIKE 'a%'")
+        to_log(LOG_INFO, "raw-SQL delete affected {db |> changes()} row(s)\n")
+
+        // (f) try_ variants — non-panic flow -------------------------------
+        let attempt = db |> try_delete_by_id(type<User>, 999)
+        if (attempt |> is_err) {
+            to_log(LOG_ERROR, "delete failed: {attempt |> unwrap_err}\n")
+        } else {
+            to_log(LOG_INFO, "ghost-delete touched {attempt |> unwrap} row(s)\n")
+        }
+    }
+}

--- a/tutorials/sql/22-transactions.das
+++ b/tutorials/sql/22-transactions.das
@@ -1,0 +1,88 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+// Tutorial 22 — Transactions: atomic groups of statements.
+//
+//   db |> with_transaction() { ... }                   // BEGIN/COMMIT
+//   db |> with_transaction(SqliteTxnMode.Immediate) {} // BEGIN IMMEDIATE
+//   db |> try_transaction() { ... }                   // non-panic
+//   db |> in_transaction()                             // status query
+//
+// `with_transaction` emits ``BEGIN`` on entry, ``COMMIT`` on normal exit, and
+// ``ROLLBACK`` on panic / early return via daslang's ``finally``. When
+// nested inside an existing transaction it falls back to ``SAVEPOINT`` /
+// ``RELEASE`` / ``ROLLBACK TO`` so user code can compose freely without
+// SQLite's "no nested transactions" rule biting.
+//
+// Two overloads — not one optional-parameter function — because the
+// trailing-block convention puts the block last; an optional middle
+// ``mode`` parameter wouldn't resolve from a no-mode call site. Same shape
+// for ``try_transaction``.
+//
+// ``try_transaction`` only converts SQL failures (BEGIN / COMMIT errors) into
+// ``some(errmsg)`` and returns ``none`` on success. A panic from inside the
+// block still rolls back and re-propagates — wrap the block in your own
+// ``try / recover`` if you want to convert a block panic into a SqlError.
+
+[sql_table(name = "Friends")]
+struct Friend {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Friend>)
+
+        // Canonical form: 2-arg `with_transaction`. The INSERTs commit as
+        // one unit; the inner array-insert nests via SAVEPOINT.
+        db |> with_transaction() {
+            db |> insert([
+                Friend(Id = 1, Name = "tom"),
+                Friend(Id = 2, Name = "jerry"),
+                Friend(Id = 3, Name = "spike")
+            ])
+        }
+        to_log(LOG_INFO, "after commit: {length(db |> select_from(type<Friend>))} row(s)\n")
+
+        // 3-arg overload: SQLite-specific BEGIN modifier. ``Immediate``
+        // takes the RESERVED lock at BEGIN, so concurrent writers block at
+        // BEGIN time rather than on first write — avoids the "another
+        // writer raced us between read and write" trap.
+        db |> with_transaction(SqliteTxnMode.Immediate) {
+            db |> insert(Friend(Id = 4, Name = "jasmine"))
+        }
+
+        // Status check — `in_transaction()` wraps SQLite's autocommit flag.
+        // Mostly useful for library code that wants "join an ambient
+        // transaction if one is active, else start one".
+        to_log(LOG_INFO, "in transaction now? {db |> in_transaction()}\n")
+
+        // Nested calls fall back to SAVEPOINT — proper LIFO composition,
+        // no need for the runner to track depth itself.
+        db |> with_transaction() {
+            db |> insert(Friend(Id = 5, Name = "max"))
+            db |> with_transaction() {
+                db |> insert(Friend(Id = 6, Name = "rover"))
+                to_log(LOG_INFO, "deep in nested txn? {db |> in_transaction()}\n")
+            }
+        }
+
+        // Non-panic variant. Returns ``some(errmsg)`` on SQL failure;
+        // ``none`` on success. Useful for retry-on-SQLITE_BUSY loops.
+        let r = db |> try_transaction() {
+            db |> insert(Friend(Id = 7, Name = "lola"))
+        }
+        if (r |> is_some) {
+            to_log(LOG_ERROR, "txn failed: {r |> unwrap}\n")
+        } else {
+            to_log(LOG_INFO, "txn ok\n")
+        }
+
+        let final_rows <- db |> select_from(type<Friend>)
+        to_log(LOG_INFO, "final row count: {length(final_rows)}\n")
+    }
+}


### PR DESCRIPTION
## Summary

Chunk 6 of the dasSQLITE rework — write-side macros (`_sql_update*` / `_sql_delete*`) plus a transaction suite. Mirrors chunks 2–5's `_sql(...)` flagship for the write side. UPSERT (tutorial 21) is split off to chunk 7 — its surface (`_excluded` AST sentinel, multi-column conflict targets, `@sql_unique`, four "INSERT OR X" variants, bulk overload) is large enough to warrant its own chunk.

### UPDATE / DELETE macro families

* `_sql_update` / `_sql_try_update` / `_sql_update_returning` / `_sql_try_update_returning` — predicate-driven bulk UPDATE with named-tuple SET clause.
* `_sql_delete` / `_sql_try_delete` / `_sql_delete_returning` / `_sql_try_delete_returning` — predicate-driven bulk DELETE.
* Original mockups had bare `_update` / `_delete`; overridden to the `_sql_` prefix so SQL provenance stays visible at the call site.
* Function siblings (`update`, `delete_`, `delete_by_id`, plus `try_*` and `*_returning` variants) stay unprefixed.

### Macro design

* **Single-stage `canVisitArgument=false`** for everything except `db`. Tried a two-macro design (outer wraps in lambdas, inner analyzes typed AST) and crashed on `ExprCallMacro::macro=null` — the registry lookup the parser does isn't reachable from daslang macro returns. `pred_to_sql` works on raw AST shape; bind exprs pass verbatim to `sqlite_bind` and resolve at output type-inference.
* **`ExprMakeTuple.recordNames` exposed** in `src/builtin/module_builtin_ast_annotations_2.cpp` (1-line C++ change). Parser populates it for `(Col=val)` named-tuple syntax before any inference; reading it directly avoids forcing premature inference on the SET arg whose RHS may reference unbound `_.Col`. `analyze_set_clause` prefers `tupT.argNames` when populated and falls back to `mkTup.recordNames`.

### Transactions

* `with_transaction` 2-arg + 3-arg overloads (`Deferred` / `Immediate` / `Exclusive` modes). Two overloads, not one optional-parameter function — trailing-block convention puts the block last; an optional middle `mode` wouldn't resolve from a no-mode call site.
* `try_transaction` returns `SqlError = Option<string>` (`Result<void, E>` isn't supported yet — `void` can't be a struct field).
* `in_transaction()` wraps `sqlite3_get_autocommit`.
* **Savepoint nesting via fixed name `das_sp`.** SQLite resolves RELEASE / ROLLBACK TO against the most-recent matching name, so proper LIFO composes correctly without depth tracking on `SqlRunner`. Same pattern (`das_ins_sp`) for the bulk-insert composability fix in `try_insert(rows : array<T>)` — was hardcoded `BEGIN IMMEDIATE`, now branches on `in_transaction()`.

### Refactors (folded into the same commit)

* `SqlQuery` constructor sites in `sqlite_linq.das` use struct-init pattern — folds 4-line `var q = SqlQuery(); q.x = ...` blocks into single inline constructors with `<-` move-init for arrays.
* New `emit_dml_call` macro_function in `sqlite_linq.das` deduplicates the 28-line 4-way `_::run_dml*` qmacro fork shared by `emit_update_body` and `emit_delete_body`.
* New private runtime helpers in `sqlite_boost.das` (`try_step_dml`, `try_collect_rows`, `try_one_row_opt`) consolidate prepare/bind/step/finalize across 11 public functions: `try_run_dml`, `try_run_dml_returning`, `try_run_select`, `try_select_from`, `try_insert(row)`, `try_update`, `try_delete_`, `try_delete_by_id`, `try_query_scalar`, `query_scalar_opt`, `try_run_select_one_opt`. Each becomes a one-line forwarder. Net −85 lines in `sqlite_boost.das`.

### Tests

`test_43_update_by_pk`, `test_44_update_bulk`, `test_45_update_returning`, `test_46_delete_by_pk`, `test_47_delete_bulk`, `test_48_delete_returning`, `test_49_changes`, `test_50_with_transaction`, `test_51_try_transaction` — 33 new cases. `failed_sql_update_delete` covers macro misuse (T not a struct, missing PK, NULL set, etc.).

* 271 / 271 dasSQLITE tests pass (238 pre-chunk-6 + 33 new)
* 7137 / 7137 full interpreted suite
* 6549 / 6549 full AOT suite
* lint clean (15 changed `.das` files, 0 issues)
* format clean
* Sphinx clean build, zero warnings

### Tutorials

`19-update.das`, `20-delete.das`, `22-transactions.das` + matching RST tutorial pages (`sql_19_update.rst`, `sql_20_delete.rst`, `sql_22_transactions.rst`). Toctree updated; prev/next cross-references threaded `18-null_handling → 19-update → 20-delete → 22-transactions`.

## Test plan

- [x] `bin/Release/daslang.exe utils/lint/main.das -- <changed .das files>` — clean
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/` — 7137/7137 pass
- [x] `cmake --build build --config Release --target test_aot` — succeeds
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — 6549/6549 pass
- [x] `sphinx-build -b html source ../site/doc` — `build succeeded`, zero warnings
- [x] `format_file` on every changed `.das` — already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
