### PR TITLE
dasSQLITE: chunk 7 — UPSERT + schema annotations

### DIFF
--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -309,7 +309,11 @@ Run any tutorial from the project root::
    tutorials/sql_18_null_handling.rst
    tutorials/sql_19_update.rst
    tutorials/sql_20_delete.rst
+   tutorials/sql_21_upsert.rst
    tutorials/sql_22_transactions.rst
+   tutorials/sql_23_foreign_keys.rst
+   tutorials/sql_24_indexes.rst
+   tutorials/sql_25_defaults_computed.rst
 
 .. _tutorials_dasaudio:
 

--- a/doc/source/reference/tutorials/sql_20_delete.rst
+++ b/doc/source/reference/tutorials/sql_20_delete.rst
@@ -113,4 +113,4 @@ Non-panic ``try_`` variants
 
     Previous tutorial: :ref:`tutorial_sql_update`
 
-    Next tutorial: :ref:`tutorial_sql_transactions`
+    Next tutorial: :ref:`tutorial_sql_upsert`

--- a/doc/source/reference/tutorials/sql_21_upsert.rst
+++ b/doc/source/reference/tutorials/sql_21_upsert.rst
@@ -1,0 +1,155 @@
+.. _tutorial_sql_upsert:
+
+==========================================
+SQL-21 --- UPSERT
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; UPSERT
+    single: Tutorial; ON CONFLICT
+    single: Tutorial; insert_or_ignore
+    single: Tutorial; insert_or_replace
+    single: Tutorial; _sql_upsert
+    single: Tutorial; _sql_upsert_returning
+    single: Tutorial; _excluded
+
+Three SQL shapes for "INSERT but, if it collides with a UNIQUE / PK
+constraint, do something instead":
+
+==============================================  ===================================================
+Form                                            Behavior
+==============================================  ===================================================
+``db |> insert_or_ignore(row)``                 silent no-op on conflict (returns 0 rows affected)
+``db |> insert_or_replace(row)``                wipe-and-reinsert on conflict (loses the old row)
+``db |> _sql_upsert(row, on_conflict, ...)``    proper merge --- keep old row, update chosen cols
+``db |> _sql_upsert_returning(...)``            same, but capture the post-merge row
+``db |> _sql_try_upsert(...)``                  non-panic ``Result<int, string>``
+==============================================  ===================================================
+
+``insert_or_ignore`` / ``insert_or_replace`` also have ``try_``
+siblings and ``array<T>`` bulk overloads.
+
+INSERT OR IGNORE
+================
+
+Silent no-op on PK / UNIQUE conflict. Returns rows-affected: 1 if
+inserted, 0 if ignored.
+
+.. code-block:: das
+
+    let n = db |> insert_or_ignore(WordHit(Id = 2, Word = "world", Hits = 1, Last = 200l))
+    // INSERT OR IGNORE INTO "WordHits" (...) VALUES (?,?,?,?)
+
+INSERT OR REPLACE
+=================
+
+On conflict, the existing row is **deleted** and a fresh one is
+inserted from the new values. Columns not in the new row reset to
+their defaults --- rarely what you want for partial updates. Use
+``_sql_upsert`` for proper merging.
+
+.. code-block:: das
+
+    db |> insert_or_replace(WordHit(Id = 1, Word = "hello", Hits = 42, Last = 999l))
+    // INSERT OR REPLACE INTO "WordHits" (...) VALUES (?,?,?,?)
+
+ON CONFLICT ... DO UPDATE --- the proper merge
+==============================================
+
+``_sql_upsert(row, on_conflict, do_update)``:
+
+* ``row`` --- the values to ``INSERT``.
+* ``on_conflict`` --- ``_.Col`` for a single-column conflict target,
+  or ``tuple(_.A, _.B)`` for a composite target. Validated at
+  macro-expansion time against the struct's fields.
+* ``do_update`` --- a named-tuple ``(Col = expr, ...)``. ``_`` refers
+  to the existing row; ``_excluded`` refers to the row we tried to
+  ``INSERT``.
+
+.. code-block:: das
+
+    let bumped = db |> _sql_upsert(
+        WordHit(Id = 1, Word = "hello", Hits = 1, Last = 1234l),
+        _.Id,
+        (Hits = _.Hits + 1, Last = _excluded.Last))
+    // INSERT INTO "WordHits" (...) VALUES (?,?,?,?)
+    //   ON CONFLICT("Id") DO UPDATE SET
+    //     "Hits" = "WordHits"."Hits" + 1,
+    //     "Last" = "excluded"."Last"
+
+Composite conflict targets
+==========================
+
+``tuple(_.Email, _.Tenant)`` resolves against a UNIQUE constraint on
+the same column set. Declare the constraint via
+``[sql_index(unique = true, fields = (...))]`` (:ref:`tutorial_sql_indexes`).
+SQLite throws *"ON CONFLICT clause does not match any PRIMARY KEY or
+UNIQUE constraint"* at runtime if no constraint covers the column
+list.
+
+.. code-block:: das
+
+    [sql_table(name = "UserAccts"),
+     sql_index(fields = ("Email", "Tenant"), unique = true)]
+    struct UserAcct {
+        @sql_primary_key Id : int
+        Email : string
+        Name : string
+        Tenant : string
+    }
+
+    db |> _sql_upsert(
+        UserAcct(Id = 999, Email = "x@y.com", Name = "alice2", Tenant = "acme"),
+        tuple(_.Email, _.Tenant),
+        (Name = _excluded.Name))
+    // INSERT INTO "UserAccts" (...) VALUES (?,?,?,?)
+    //   ON CONFLICT("Email","Tenant") DO UPDATE SET
+    //     "Name" = "excluded"."Name"
+
+UPSERT RETURNING
+================
+
+Capture the post-merge row. Returns ``array<T>`` (always one row in
+practice; the array shape mirrors ``_sql_update_returning``).
+
+.. code-block:: das
+
+    let after <- db |> _sql_upsert_returning(
+        WordHit(Id = 1, Word = "hello", Hits = 1, Last = 0l),
+        _.Id,
+        (Hits = _.Hits + 1))
+    // INSERT INTO "WordHits" (...) VALUES (?,?,?,?)
+    //   ON CONFLICT("Id") DO UPDATE SET "Hits" = "WordHits"."Hits" + 1
+    //   RETURNING "Id","Word","Hits","Last"
+
+Non-panic ``try_`` variants
+===========================
+
+Each upsert has a ``try_`` sibling returning ``Result<int, string>``
+(or ``Result<array<T>, string>`` for ``_returning``). Useful for
+constraint-violation handling without a panic.
+
+.. code-block:: das
+
+    let attempt = db |> _sql_try_upsert(
+        WordHit(Id = 1, Word = "hello", Hits = 1, Last = 0l),
+        _.Id,
+        (Hits = _.Hits + 1))
+    if (attempt |> is_err) {
+        // "constraint failed: ..." or similar
+    } else {
+        let n = attempt |> unwrap
+    }
+
+``try_insert_or_ignore`` and ``try_insert_or_replace`` cover the
+non-panic shapes for the simpler forms.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/21-upsert.das <../../../../tutorials/sql/21-upsert.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_delete`
+
+    Next tutorial: :ref:`tutorial_sql_transactions`

--- a/doc/source/reference/tutorials/sql_22_transactions.rst
+++ b/doc/source/reference/tutorials/sql_22_transactions.rst
@@ -132,4 +132,6 @@ struct field. ``SqlError = Option<string>`` is the workaround:
 
     Full source: :download:`tutorials/sql/22-transactions.das <../../../../tutorials/sql/22-transactions.das>`
 
-    Previous tutorial: :ref:`tutorial_sql_delete`
+    Previous tutorial: :ref:`tutorial_sql_upsert`
+
+    Next tutorial: :ref:`tutorial_sql_foreign_keys`

--- a/doc/source/reference/tutorials/sql_23_foreign_keys.rst
+++ b/doc/source/reference/tutorials/sql_23_foreign_keys.rst
@@ -1,0 +1,136 @@
+.. _tutorial_sql_foreign_keys:
+
+==========================================
+SQL-23 --- Foreign keys
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; foreign key
+    single: Tutorial; FOREIGN KEY
+    single: Tutorial; CASCADE
+    single: Tutorial; sql_references
+    single: Tutorial; sql_on_delete
+    single: Tutorial; sql_on_update
+
+DDL-only foreign-key support: a child column names its parent struct,
+optional ``on_delete`` / ``on_update`` actions pick the integrity
+behavior. dasSQLITE deliberately ships **no navigation properties**
+--- to query across a relationship use ``_join`` (:ref:`tutorial_sql_join`),
+``_left_join`` (:ref:`tutorial_sql_left_join`), or ``_any`` / ``_in``
+correlated subqueries (:ref:`tutorial_sql_subqueries`).
+
+Annotation shape
+================
+
+==============================================  ===================================================
+Annotation                                      Meaning
+==============================================  ===================================================
+``@sql_references = "ParentTypeName"``          parent struct (must have ``@sql_primary_key``)
+``@sql_on_delete = "<action>"``                 CASCADE / SET NULL / SET DEFAULT / RESTRICT / NO ACTION
+``@sql_on_update = "<action>"``                 same value set
+==============================================  ===================================================
+
+Each decorator is a separate ``@name = value`` line --- daslang field
+annotations are scalar key/value pairs, not function-call shapes.
+``@sql_references`` resolves at ``[sql_table]`` expansion time: it
+finds the named struct in the same module, reads its ``[sql_table(name
+= ...)]``, and finds the ``@sql_primary_key`` field. Defaults when
+omitted: ``on_delete = "no_action"``, ``on_update = "no_action"``.
+
+PRAGMA foreign_keys = ON
+========================
+
+``with_sqlite`` enables the pragma on every connection. SQLite ships
+it OFF for back-compat with pre-3.6.19 databases; without it FK
+clauses are parsed and stored but never enforced --- orphans silently
+appear and CASCADE silently no-ops. dasSQLITE turns it on always.
+
+CASCADE delete
+==============
+
+.. code-block:: das
+
+    [sql_table(name = "Users")]
+    struct User {
+        @sql_primary_key Id : int
+        Name : string
+    }
+
+    [sql_table(name = "Orders")]
+    struct Order {
+        @sql_primary_key Id : int
+
+        @sql_references = "User"
+        @sql_on_delete = "cascade"
+        UserId : int
+
+        Total : float
+    }
+
+    db |> _sql_delete(type<User>, _.Id == 1)
+    // DELETE FROM "Users" WHERE "Id" = ?
+    // (SQLite cascades internally to DELETE FROM "Orders"
+    //  WHERE "UserId" = 1)
+
+SET NULL requires Option<T>
+===========================
+
+The FK column must be ``Option<T>`` so SQLite can write NULL when
+the parent goes away. ``[sql_table]`` rejects the combination at
+compile time if the column is plain ``T``.
+
+.. code-block:: das
+
+    [sql_table(name = "Comments")]
+    struct Comment {
+        @sql_primary_key Id : int
+
+        @sql_references = "User"
+        @sql_on_delete = "set_null"
+        @safe_when_uninitialized AuthorId : Option<int>
+
+        Body : string
+    }
+
+Action reference
+================
+
+==============================================  ===================================================
+Annotation value                                ``ON DELETE`` / ``ON UPDATE`` clause
+==============================================  ===================================================
+``"cascade"``                                   CASCADE  --- propagate the change to children
+``"set_null"``                                  SET NULL --- requires ``Option<T>``
+``"set_default"``                               SET DEFAULT --- requires field-init or @sql_default_fn
+``"restrict"``                                  RESTRICT --- reject the change immediately
+``"no_action"``                                 NO ACTION --- the SQL standard default
+==============================================  ===================================================
+
+FK violations through ``try_insert``
+====================================
+
+Constraint violations surface as SQLite errors at insert/update
+time. ``try_insert`` wraps them as ``Result``.
+
+.. code-block:: das
+
+    let res = db |> try_insert(Order(Id = 999, UserId = 9999, Total = 1.0f))
+    if (res |> is_err) {
+        // "FOREIGN KEY constraint failed"
+    }
+
+Drop / create order
+===================
+
+Parent before child on create; child before parent on drop. The FK
+clause names the parent table by name, so the parent must exist when
+the child is created.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/23-foreign_keys.das <../../../../tutorials/sql/23-foreign_keys.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_transactions`
+
+    Next tutorial: :ref:`tutorial_sql_indexes`

--- a/doc/source/reference/tutorials/sql_24_indexes.rst
+++ b/doc/source/reference/tutorials/sql_24_indexes.rst
@@ -1,0 +1,118 @@
+.. _tutorial_sql_indexes:
+
+==========================================
+SQL-24 --- Indexes
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; index
+    single: Tutorial; CREATE INDEX
+    single: Tutorial; sql_index
+    single: Tutorial; UNIQUE INDEX
+    single: Tutorial; composite index
+
+``[sql_index]`` is a sibling annotation to ``[sql_table]``: each
+``[sql_index]`` emits one ``CREATE [UNIQUE] INDEX`` statement, run
+right after the ``CREATE TABLE`` inside the same transaction.
+
+Sibling-annotation shape
+========================
+
+Both annotations live in the **same** bracket pair, comma-separated,
+with ``[sql_table]`` first.
+
+.. code-block:: das
+
+    [sql_table(name = "Users"),
+     sql_index(fields = "Email", unique = true),
+     sql_index(fields = ("City", "LastSeen")),
+     sql_index(fields = "LastSeen", name = "ix_users_lastseen")]
+    struct User {
+        @sql_primary_key Id : int
+        Email : string
+        Name : string
+        City : string
+        LastSeen : int64
+    }
+
+Argument reference
+==================
+
+==============================================  ===================================================
+Argument                                        Meaning / default
+==============================================  ===================================================
+``fields = "Col"`` or ``fields = ("A", "B")``   single column (string) or composite (tuple)
+``unique = true``                               UNIQUE INDEX (default ``false``)
+``name = "..."``                                explicit index name (default ``idx_<table>_<col1>_<col2>``)
+==============================================  ===================================================
+
+``[sql_table]`` validates every field name against the struct's
+fields at macro-expansion time. Misspellings produce a compile error
+listing the valid columns.
+
+DDL emitted
+===========
+
+.. code-block:: text
+
+    CREATE TABLE "Users" (...);
+    CREATE UNIQUE INDEX "idx_Users_Email" ON "Users" ("Email");
+    CREATE INDEX "idx_Users_City_LastSeen" ON "Users" ("City", "LastSeen");
+    CREATE INDEX "ix_users_lastseen" ON "Users" ("LastSeen");
+
+The DDL helper is callable directly --- handy for migration scripts
+and asserts.
+
+.. code-block:: das
+
+    let idx_sql = _sql_create_indexes_sql(type<User>)
+
+Indexes are transparent at the query side
+=========================================
+
+User queries don't change shape; the SQLite planner picks the index
+automatically.
+
+.. code-block:: das
+
+    let alice = _sql(db |> select_from(type<User>)
+                        |> _where(_.Email == "alice@x.com") |> _first())
+    // SELECT ... FROM "Users" WHERE "Email" = ? LIMIT 1
+    // (uses idx_Users_Email)
+
+UNIQUE-INDEX violations through ``try_insert``
+==============================================
+
+.. code-block:: das
+
+    let dup = User(Id = 4, Email = "alice@x.com", Name = "alice2",
+                   City = "LA", LastSeen = 0l)
+    let res = db |> try_insert(dup)
+    if (res |> is_err) {
+        // "UNIQUE constraint failed: Users.Email"
+    }
+
+Composite UNIQUE for upsert composite-conflict targets
+======================================================
+
+``_sql_upsert(row, tuple(_.A, _.B), do_update)``
+(:ref:`tutorial_sql_upsert`) requires a UNIQUE constraint covering
+the same column set. ``[sql_index(unique = true, fields = ("A", "B"))]``
+is how you declare one --- there is no separate
+``[sql_unique]`` table-level annotation.
+
+Single-column uniqueness can use either ``@sql_unique`` on the field
+(emits ``UNIQUE`` directly in the column DDL) or
+``[sql_index(unique = true, fields = "Col")]`` (separate
+``CREATE UNIQUE INDEX``). Both work for the upsert path; the index
+form is preferable when you also need to control the index name.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/24-indexes.das <../../../../tutorials/sql/24-indexes.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_foreign_keys`
+
+    Next tutorial: :ref:`tutorial_sql_defaults_computed`

--- a/doc/source/reference/tutorials/sql_25_defaults_computed.rst
+++ b/doc/source/reference/tutorials/sql_25_defaults_computed.rst
@@ -1,0 +1,140 @@
+.. _tutorial_sql_defaults_computed:
+
+==========================================
+SQL-25 --- Defaults + computed columns
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; default
+    single: Tutorial; DEFAULT
+    single: Tutorial; computed column
+    single: Tutorial; GENERATED ALWAYS AS
+    single: Tutorial; sql_default_fn
+    single: Tutorial; sql_computed
+    single: Tutorial; sql_stored
+
+Three ways to default a column, plus generated columns via
+``@sql_computed``.
+
+Three default sources
+=====================
+
+==============================================  ===================================================
+Form                                            Behavior
+==============================================  ===================================================
+``Active : bool = true``                        native daslang field-init becomes ``DEFAULT 1``
+``@sql_default_fn = "CURRENT_TIMESTAMP"``       SQL built-in (whitelist below)
+``@sql_computed = "Quantity * 2"``              generated column --- excluded from INSERT/UPDATE bind
+==============================================  ===================================================
+
+Native field-init handles bool / int / int64 / float / double /
+string literals. Non-literal initializers (e.g. ``some(5)``) are
+silently dropped from the DDL but still construct in daslang.
+
+Whitelisted ``@sql_default_fn`` values: ``CURRENT_TIMESTAMP``,
+``CURRENT_DATE``, ``CURRENT_TIME``. Anything else is a compile
+error.
+
+VIRTUAL vs STORED
+=================
+
+``@sql_computed`` defaults to ``VIRTUAL`` (recomputed on every
+``SELECT``). Add ``@sql_stored = true`` for ``STORED``
+(materialized on ``INSERT`` / ``UPDATE``, persisted on disk, read
+straight off disk on ``SELECT``).
+
+Use ``STORED`` when the expression is expensive and reads dominate
+writes. Default to ``VIRTUAL`` otherwise.
+
+Schema example
+==============
+
+.. code-block:: das
+
+    [sql_table(name = "Items")]
+    struct Item {
+        @sql_primary_key Id : int
+
+        Name : string
+
+        Active : bool = true                     // -> DEFAULT 1
+        Quantity : int = 100                     // -> DEFAULT 100
+        Tag : string = "unknown"                 // -> DEFAULT 'unknown'
+
+        @sql_default_fn = "CURRENT_TIMESTAMP"
+        CreatedAt : string
+
+        @sql_computed = "Quantity * 2"
+        DoubleQty : int                          // VIRTUAL
+
+        @sql_computed = "Quantity + 1"
+        @sql_stored = true
+        QtyPlusOne : int                         // STORED
+    }
+
+Macro INSERT binds every NON-COMPUTED column
+============================================
+
+The struct field's value is what gets written; defaults never fire
+through this path. Computed columns are skipped --- SQLite computes
+them itself, so any value the struct holds for ``DoubleQty`` /
+``QtyPlusOne`` is ignored.
+
+.. code-block:: das
+
+    db |> insert(Item(Id = 1, Name = "thing", Active = true, Quantity = 7,
+                      Tag = "t", CreatedAt = "",
+                      DoubleQty = 9999, QtyPlusOne = 9999))
+    // INSERT INTO "Items" ("Id","Name","Active","Quantity","Tag","CreatedAt")
+    //   VALUES (?,?,?,?,?,?)
+
+Defaults fire when the column is omitted
+========================================
+
+The macro ``INSERT`` always names every non-computed column, so the
+``DEFAULT`` clause only fires from raw SQL or column-list forms that
+omit the column.
+
+.. code-block:: das
+
+    db |> exec("INSERT INTO Items (Id, Name) VALUES (2, 'defaulted')")
+    // -> "Active" DEFAULT 1, "Quantity" DEFAULT 100,
+    //    "Tag" DEFAULT 'unknown', "CreatedAt" DEFAULT CURRENT_TIMESTAMP all fire
+
+UPDATE re-derives computed columns
+==================================
+
+Mutating ``Quantity`` is enough --- the SET clause omits any
+``@sql_computed`` column (typo at the macro level produces a
+``do_update column "X" is @sql_computed`` error). ``DoubleQty`` /
+``QtyPlusOne`` update behind the scenes when SQLite re-evaluates
+the expression.
+
+.. code-block:: das
+
+    db |> _sql_update(type<Item>, _.Id == 1, (Quantity = 11))
+    // UPDATE "Items" SET "Quantity" = ? WHERE "Id" = ?
+
+Validation rules
+================
+
+``[sql_table]`` rejects each of the following at compile time:
+
+* ``@sql_primary_key`` + ``@sql_computed``
+* ``@sql_computed`` + field initializer
+* ``@sql_computed`` + ``@sql_default_fn``
+* field initializer + ``@sql_default_fn``
+* ``@sql_default_fn`` value outside the whitelist
+
+Minimum SQLite version
+======================
+
+Generated columns require SQLite 3.31+ (2019-10-10).
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/25-defaults_computed.das <../../../../tutorials/sql/25-defaults_computed.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_indexes`

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -342,9 +342,6 @@ malformed-call diagnostics. Total dasSQLITE suite: **271 tests passing**
 
 ### Deferred to chunk 7+
 
-- **UPSERT** (tut 21) — `_excluded` AST sentinel, multi-column conflict
-  targets, `@sql_unique` field annotation, INSERT OR IGNORE / INSERT OR
-  REPLACE shortcuts, bulk overload.
 - **`exec` parameter binding** — `db |> exec(sql, args...)` doesn't
   exist; users must inline values into the SQL string for raw escape
   hatch with dynamic data, or stick to the macro forms. Adding
@@ -357,6 +354,182 @@ malformed-call diagnostics. Total dasSQLITE suite: **271 tests passing**
 - **Projection-side `_select` after `_sql_update_returning`** — for
   RETURNING column projection, post-process the result with a chain
   `|> _select(...)` instead of inventing a `update_returning_select`.
+
+## Shipped — chunk 7: UPSERT + schema annotations (branch `dassqlite-chunk7-upsert-schema`)
+
+Chunk 7 ships **tutorials 21 (UPSERT), 23 (foreign keys), 24 (indexes),
+25 (defaults + computed columns)**. UPSERT was deferred from chunk 6
+because it carries its own substantial macro surface; the three schema
+tutorials were already at the front of "Part 5 — schema richness" in the
+plan and naturally co-shipped because the upsert composite-conflict path
+needs `[sql_index(unique = true, ...)]` from tut 24.
+
+### UPSERT macros (`sqlite_linq.das`)
+
+- `_sql_upsert(row, on_conflict, do_update)` — INSERT … ON CONFLICT …
+  DO UPDATE SET …, returns rows-affected `int`.
+- `_sql_try_upsert(...)` — same, returns `Result<int, string>`.
+- `_sql_upsert_returning(...)` / `_sql_try_upsert_returning(...)` —
+  capture the post-merge row(s) as `array<T>` (always one row in
+  practice; the array shape mirrors `_sql_update_returning`).
+- `on_conflict` accepts `_.Col` (single) or `tuple(_.A, _.B, ...)`
+  (composite); validated against the struct's fields at macro-expansion.
+- `do_update` is a named-tuple `(Col = expr, ...)`. `_` is the existing
+  row; `_excluded` is the proposed-row sentinel (added to `pred_to_sql`
+  via the new `SqlQuery.upsertMode` flag). Computed columns and unknown
+  column names are rejected with macro_error; duplicate column names too.
+- Arithmetic operators (`+ - * / %`) added to `pred_to_sql` so the do-
+  update SET clause can express `Hits = _.Hits + 1`.
+
+### Plain "INSERT OR X" functions (`sqlite_boost.das`)
+
+- `insert_or_ignore(row)` / `insert_or_ignore(rows)` — single + bulk;
+  `try_` siblings return `Result<int, string>`.
+- `insert_or_replace(row)` / `insert_or_replace(rows)` — same fan-out.
+- All implemented via runtime substitution of `OR IGNORE` / `OR
+  REPLACE` against the existing `_sql_insert_with_pk_sql` /
+  `_sql_insert_no_pk_sql` strings — no new generated helpers needed.
+
+### Schema annotations on `[sql_table]` (`sqlite_boost.das`)
+
+Per-field decorators (every `@xxx = value` is a separate scalar line):
+
+- **`@sql_unique`** — single-column UNIQUE in the column DDL.
+- **`@sql_default_fn = "FN"`** — whitelisted SQL built-ins
+  (`CURRENT_TIMESTAMP`, `CURRENT_DATE`, `CURRENT_TIME`); emits
+  ` DEFAULT FN`.
+- **Native field initializer for literal defaults** — `Active : bool =
+  true` becomes ` DEFAULT 1`. Supported literals: bool / int / int64 /
+  float / double / string. Non-literal initializers are silently dropped
+  from the DDL but still construct in daslang.
+- **`@sql_computed = "expression"`** — generated column. Default storage
+  VIRTUAL; add **`@sql_stored = true`** for STORED. Computed columns are
+  excluded from INSERT and UPDATE bind paths automatically; SELECT reads
+  them as ordinary columns.
+- **`@sql_references = "Parent"`** + optional **`@sql_on_delete`** /
+  **`@sql_on_update`** — one of `cascade` / `set_null` / `set_default` /
+  `restrict` / `no_action`. Resolves the parent struct's table name and
+  PK column at macro-expansion. `with_sqlite` enables `PRAGMA
+  foreign_keys = ON` so the constraints actually fire.
+
+Validation rules enforced at `[sql_table]` apply (each emits
+`error[30111]`):
+
+- `@sql_primary_key` ≠ `@sql_computed` (SQLite rejects PK on a generated
+  column).
+- `@sql_computed` ≠ field initializer (the SQL expression provides the
+  value).
+- `@sql_computed` ≠ `@sql_default_fn`.
+- field initializer ≠ `@sql_default_fn` (pick one).
+- `@sql_default_fn` value must be in the whitelist.
+- `@sql_on_delete` / `@sql_on_update` value must be in the whitelist.
+- `@sql_on_delete` / `@sql_on_update` without `@sql_references`.
+- `on_delete = "set_null"` requires `Option<T>` column.
+- `on_delete = "set_default"` requires a field initializer or
+  `@sql_default_fn`.
+- `@sql_references` referencing a struct that doesn't exist or has no
+  `@sql_primary_key`.
+
+### `[sql_index]` sibling annotation
+
+- Shape: `[sql_table(name = "..."), sql_index(fields = ..., unique =
+  ..., name = ...)]` (must live in the same bracket as `[sql_table]`,
+  comma-separated, with `[sql_table]` first).
+- `fields` accepts a single string or a tuple of strings. `unique`
+  defaults to `false`. `name` defaults to `idx_<table>_<col1>_<col2>`.
+- `[sql_index]` rewrites the `_sql_create_indexes_sql` helper that
+  `[sql_table]` emits (per Boris's body-rewrite suggestion) — each
+  `[sql_index].apply()` parses the const-string return of the existing
+  helper, appends a new `CREATE INDEX` statement, and replaces the
+  body. This forces source order: `[sql_table]` must precede every
+  `[sql_index]` because the body-rewrite needs the helper to already
+  exist.
+- Unknown field names and missing `fields=` are rejected with
+  `error[30111]`.
+
+### Tutorials
+
+- [tutorials/sql/21-upsert.das](../../tutorials/sql/21-upsert.das) —
+  `insert_or_ignore` / `_or_replace`, single + composite `_sql_upsert`,
+  `_sql_upsert_returning`, `_sql_try_upsert`.
+- [tutorials/sql/23-foreign_keys.das](../../tutorials/sql/23-foreign_keys.das)
+  — CASCADE delete, SET NULL with `Option<T>`, FK violation through
+  `try_insert`.
+- [tutorials/sql/24-indexes.das](../../tutorials/sql/24-indexes.das) —
+  unique + composite + named indexes, query-side transparency, UNIQUE
+  violation through `try_insert`.
+- [tutorials/sql/25-defaults_computed.das](../../tutorials/sql/25-defaults_computed.das)
+  — native init defaults, `@sql_default_fn`, VIRTUAL + STORED computed
+  columns.
+
+### Tests
+
+9 new test files: `test_52_insert_or_ignore.das`,
+`test_53_insert_or_replace.das`, `test_54_upsert_single_col.das`,
+`test_55_upsert_composite.das`, `test_56_upsert_returning.das`,
+`test_57_sql_unique.das`, `test_58_sql_references.das`,
+`test_59_sql_index.das`, `test_60_defaults_computed.das`. Plus three
+new failed-test files: `failed_sql_table_schema.das` (12 [sql_table]
+validation rules), `failed_sql_index.das` (4 [sql_index] validation
+rules), `failed_sql_upsert.das` (10 _sql_upsert macro_errors). Total
+dasSQLITE suite: **309 tests passing** (271 pre-chunk-7 + 38 new).
+
+### Deferred to chunk 8+
+
+- **Bulk `array<T>` upsert** — `_sql_upsert` rejects `array<T>` as the
+  row argument with macro_error; pass single rows in a transaction loop
+  for now. Adding the bulk overload is straightforward but each row
+  needs its own bind cycle plus the same SQL prepared statement reused.
+- **Composite foreign keys** — `@sql_references` resolves a single PK
+  column. Composite PK targets would need a `fields = ("A", "B")`
+  syntax extension. Rare in greenfield SQLite designs.
+- **Partial / expression indexes** — SQLite supports `CREATE INDEX …
+  WHERE …` and `CREATE INDEX … ON T(lower(Email))`. Both are SQLite-
+  specific; users needing them run raw `db |> exec("CREATE INDEX …")`.
+- **Function-reference form for `@sql_computed`** — current shape passes
+  the SQL expression as a string; SQLite validates at CREATE TABLE
+  time. The principled long-term shape uses `@sql_computed(func =
+  @@compute_total)` so a regular daslang function with daslang
+  compile-time validation provides the expression. Punted; SQLite's
+  runtime error message is actionable enough as MVP.
+- **DEFAULT-firing from the macro INSERT path** — the macro INSERT
+  always names every non-computed column, so the SQL DEFAULT clause
+  only fires from raw `exec`. Detecting "user wants the default" from
+  a struct field value is fragile (zero-detection) or verbose (explicit
+  field list). Raw SQL is the escape hatch.
+- **Pre-existing duplicate cleanup pass** — `find_duplicates` over
+  `sqlite_boost.das` + `sqlite_linq.das` flagged five real merge
+  candidates carried over from chunks 3 / 6, none of which are chunk-7
+  surface but all of which would land cleanly together:
+    1. `validate_outer_update_args` (`sqlite_linq.das:3353`) ≡
+       `validate_outer_delete_args` (`:3367`) — exact dupe; differs
+       only in `length(call.arguments) != 4` vs `!= 3` and the arg-
+       name list in the error message. Collapse to
+       `validate_outer_args(prog, call, rootT, expectedArity, sigText)`.
+    2. `make_insert_with_pk_sql_fn` (`sqlite_boost.das:1951`) vs
+       `make_insert_no_pk_sql_fn` (`:1995`) — 0.96 fuzzy. Both emit
+       `INSERT INTO "T" (...) VALUES (?,?,...)`; the only structural
+       difference is whether the PK column is in the column list.
+       Single helper taking an `include_pk : bool`.
+    3. `find_bool_annotation` (`sqlite_boost.das:1353`) ≡
+       `find_string_annotation` (`:1361`) — identical loops differing
+       only in the typed accessor literal (`bValue` vs `sValue`).
+       Generic `find_annotation<T>(args, name, default)`.
+    4. `try_run_dml_returning` (`sqlite_boost.das:1213`) ≡
+       `try_run_select` (`:1270`) — identical bodies. One should
+       call the other (or share a `run_step_collect` helper).
+    5. **12-way `canVisitArgument` cluster** across
+       `Sql{Update,TryUpdate,UpdateReturning,TryUpdateReturning,
+       Delete,TryDelete,DeleteReturning,TryDeleteReturning,
+       Upsert,TryUpsert,UpsertReturning,TryUpsertReturning}Macro` —
+       every override returns `argIndex == 0`. Class-hierarchy
+       fan-out can't share without a parent class. Introduce
+       `class abstract OuterArgZeroMacro : AstCallMacro` (or
+       similar) and re-parent all 12.
+  Cleanup is independent of any new feature work and can be its own
+  small chunk; targeting it together with chunk 7's `bulk array<T>
+  upsert` (`Sql{Upsert,…}Macro` would change anyway) is one
+  reasonable bundle.
 
 ## Shipped — chunk 4: read-side depth — distinct/take/skip/order_by/aggregates/group_by/NULL (branch `dassqlite-chunk4-read-depth`)
 

--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -188,17 +188,20 @@ The read story is complete. Now the write side.
     [tutorials/sql/20-delete.das](../../tutorials/sql/20-delete.das)
     (chunk 6). Original mockup:
     [16-delete.das.mockup](tutorial-mockup/16-delete.das.mockup).
-21. **UPSERT — INSERT ON CONFLICT** — `db |> upsert(row, on_conflict=…,
-    do_update=…)` and the `array<T>` overload; `insert_or_ignore` /
-    `insert_or_replace` as the no-update / clobber shortcuts;
-    `upsert_returning` / `_upsert_returning` for RETURNING; the
-    `@sql_unique` field annotation for declaring conflict keys without
-    a full `[sql_index(unique=true)]`; strict / `try_insert_or_ignore`
-    / `try_insert_or_replace` / `try_upsert` / `try_upsert_returning`
-    fan-out. **Deferred to chunk 7** (carries its own substantial
-    surface — the `_excluded` AST sentinel, multi-column conflict
-    targets, `@sql_unique`, four "INSERT OR X" variants, bulk overload).
-    Mockup: [17-upsert.das](tutorial-mockup/17-upsert.das.mockup).
+21. **UPSERT — INSERT ON CONFLICT** — `_sql_upsert(row, on_conflict,
+    do_update)` macro for the proper merge form (`ON CONFLICT(...) DO
+    UPDATE SET ...`); `_excluded.Col` for the proposed-row sentinel;
+    single-column (`_.Id`) and composite (`tuple(_.A, _.B)`) conflict
+    targets; `_sql_upsert_returning` for capturing the post-merge row;
+    `try_` siblings for non-panic flow. Plain functions
+    `insert_or_ignore` / `insert_or_replace` (single + bulk + `try_`)
+    for the simpler "ignore conflict" / "wipe-and-reinsert" cases. The
+    `@sql_unique` field annotation declares a single-column UNIQUE for
+    the conflict key; composite uniqueness uses `[sql_index(unique =
+    true, fields = (...))]` (tut 24). **Shipped:**
+    [tutorials/sql/21-upsert.das](../../tutorials/sql/21-upsert.das)
+    (chunk 7). Original mockup:
+    [17-upsert.das.mockup](tutorial-mockup/17-upsert.das.mockup).
 22. **Transactions** — `db |> with_transaction() { … }` block,
     `with_transaction(mode=…)` for IMMEDIATE / EXCLUSIVE, rollback on
     panic/early return, nested transaction behavior (automatic
@@ -215,21 +218,38 @@ The read story is complete. Now the write side.
 Once CRUD and `_sql` feel natural, richer schema annotations fit in without
 new syntax to teach.
 
-23. **Foreign keys** — `@sql_references(type="T", on_delete=…)`. DDL-only
-    FK constraints + CASCADE; navigation properties deliberately not
-    shipped (per API_REWORK tut 26 decision). Mockup:
-    [26-foreign_keys.das](tutorial-mockup/26-foreign_keys.das.mockup).
-24. **Indexes** — stackable struct-level `[sql_index(fields=…,
-    unique=…, name=…)]`. Emits `CREATE [UNIQUE] INDEX` per annotation;
-    query side is transparent (SQLite picks indexes automatically).
-    Note: `@sql_unique` (tut 21) is the field-level shortcut for a
-    single-column UNIQUE constraint — use `[sql_index]` when the
-    uniqueness spans multiple columns or when you want a non-unique
-    index for query perf. Mockup: [27-indexes.das](tutorial-mockup/27-indexes.das.mockup).
-25. **Defaults + computed columns** — `@sql_default(value=…)` /
-    `@sql_default(sql_fn="CURRENT_TIMESTAMP")` / `@sql_computed(sql=…)`.
-    Bind-code excludes computed fields from INSERT/UPDATE. Mockup:
-    [28-defaults_computed.das](tutorial-mockup/28-defaults_computed.das.mockup).
+23. **Foreign keys** — per-field decorators `@sql_references = "Parent"`
+    + optional `@sql_on_delete` / `@sql_on_update` (cascade / set_null /
+    set_default / restrict / no_action). DDL-only FK constraints +
+    CASCADE; navigation properties deliberately not shipped (per
+    API_REWORK tut 26 decision). `with_sqlite` enables `PRAGMA
+    foreign_keys = ON` on every connection so the constraints actually
+    fire. **Shipped:**
+    [tutorials/sql/23-foreign_keys.das](../../tutorials/sql/23-foreign_keys.das)
+    (chunk 7). Original mockup:
+    [26-foreign_keys.das.mockup](tutorial-mockup/26-foreign_keys.das.mockup).
+24. **Indexes** — sibling annotation `[sql_table, sql_index(fields = ...,
+    unique = ..., name = ...)]` (must live in the same bracket as
+    `[sql_table]`, with `[sql_table]` first). Emits `CREATE [UNIQUE]
+    INDEX` per annotation; query side is transparent (SQLite picks
+    indexes automatically). Auto-naming is `idx_<table>_<col1>_<col2>`
+    when `name` is omitted. Composite UNIQUE via `[sql_index(unique =
+    true, fields = (...))]` is the prerequisite for upsert composite-
+    conflict targets. **Shipped:**
+    [tutorials/sql/24-indexes.das](../../tutorials/sql/24-indexes.das)
+    (chunk 7). Original mockup:
+    [27-indexes.das.mockup](tutorial-mockup/27-indexes.das.mockup).
+25. **Defaults + computed columns** — three default sources: native
+    daslang field initializer (`Active : bool = true` becomes
+    `DEFAULT 1`), `@sql_default_fn = "CURRENT_TIMESTAMP"` for SQLite
+    built-ins (CURRENT_TIMESTAMP / CURRENT_DATE / CURRENT_TIME), and
+    `@sql_computed = "expression"` for generated columns (default
+    VIRTUAL; add `@sql_stored = true` for STORED). Bind-code excludes
+    computed fields from INSERT/UPDATE; SELECT reads them as ordinary
+    columns. **Shipped:**
+    [tutorials/sql/25-defaults_computed.das](../../tutorials/sql/25-defaults_computed.das)
+    (chunk 7). Original mockup:
+    [28-defaults_computed.das.mockup](tutorial-mockup/28-defaults_computed.das.mockup).
 26. **Custom type adapters** — name-based `bind_X` / `extract_X` pair;
     no registration step; `DateTime`, enums, GUIDs via this rail.
     Mockup: [29-custom_types.das](tutorial-mockup/29-custom_types.das.mockup).
@@ -377,11 +397,11 @@ E. **Forward-looking: `dasSQL` abstraction layer** — the roadmap beyond
 | 18 | NULL handling — `Option<T>` | `18-null_handling.das` (`25-null_handling.das.mockup` shipped largely as designed; `_.Col == none()` diagnostic + projection-side `unwrap_or` deferred) | **Shipped** (chunk 4) |
 | 19 | UPDATE | `15-update.das` | **Shipped** (chunk 6); macros named `_sql_update` / `_sql_try_update` / `_sql_update_returning` / `_sql_try_update_returning`; raw `exec` parameter binding deferred to a later chunk |
 | 20 | DELETE | `16-delete.das` | **Shipped** (chunk 6); macros named `_sql_delete` / `_sql_try_delete` / `_sql_delete_returning` / `_sql_try_delete_returning`; CASCADE FK example deferred to tut 23 |
-| 21 | UPSERT | `17-upsert.das` | Has mockup — deferred to chunk 7 (the `_excluded` AST sentinel, multi-column conflict targets, `@sql_unique`, INSERT OR IGNORE/REPLACE shortcuts, bulk overload all carry their own surface) |
+| 21 | UPSERT | `21-upsert.das` | **Shipped** (chunk 7); `_sql_upsert` / `_sql_try_upsert` / `_sql_upsert_returning` / `_sql_try_upsert_returning`, `_excluded` sentinel, single + composite conflict targets via `tuple(_.A, _.B)`, plain-fn `insert_or_ignore` / `insert_or_replace` (single + bulk + `try_` for both) |
 | 22 | Transactions | `14-transaction.das` | **Shipped** (chunk 6); two-arity overload, `SqliteTxnMode` enum (Deferred/Immediate/Exclusive), savepoint nesting via `das_sp` name |
-| 23 | Foreign keys | `26-foreign_keys.das` | Has mockup |
-| 24 | Indexes | `27-indexes.das` | Has mockup |
-| 25 | Defaults + computed | `28-defaults_computed.das` | Has mockup |
+| 23 | Foreign keys | `23-foreign_keys.das` | **Shipped** (chunk 7); `@sql_references = "Parent"` + optional `@sql_on_delete` / `@sql_on_update` (cascade / set_null / set_default / restrict / no_action); `with_sqlite` enables `PRAGMA foreign_keys = ON` |
+| 24 | Indexes | `24-indexes.das` | **Shipped** (chunk 7); `[sql_table, sql_index(fields = ..., unique = ..., name = ...)]` sibling annotation, single + composite, auto-name `idx_<table>_<col1>_<col2>` |
+| 25 | Defaults + computed | `25-defaults_computed.das` | **Shipped** (chunk 7); native field init for literal defaults (`Active : bool = true`), `@sql_default_fn` for SQL built-ins (CURRENT_TIMESTAMP / CURRENT_DATE / CURRENT_TIME), `@sql_computed = "expr"` (+ optional `@sql_stored = true`) |
 | 26 | Custom type adapters | `29-custom_types.das` | Has mockup |
 | 27 | BLOB round-trip | — | **Needs mockup** (merges inherited 07+08) |
 | 28 | JSON columns | `37-json.das` | Has mockup |

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -111,8 +111,14 @@ def open_sqlite(path : string) : SqlRunner {
 }
 
 def with_sqlite(path : string; blk : block<(db : SqlRunner) : void>) : void {
-    //! RAII helper. Opens the DB, invokes the block, finalizes on exit (including on panic / early return).
+    //! RAII helper. Opens the DB, sets ``PRAGMA foreign_keys=ON`` (SQLite ships
+    //! it OFF by default for back-compat with pre-3.6.19 databases — without
+    //! the pragma, FK clauses are parsed and stored but not enforced), invokes
+    //! the block, finalizes on exit (including on panic / early return). Users
+    //! who need FKs disabled can ``db |> exec("PRAGMA foreign_keys=OFF")`` from
+    //! inside the block.
     var inscope db = open_sqlite(path)
+    db |> exec("PRAGMA foreign_keys = ON")
     invoke(blk, db)
 }
 
@@ -652,9 +658,19 @@ def query_one_opt(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(
 
 [template(t)]
 def try_create_table(db : SqlRunner; t : auto(TT)) : SqlError {
-    //! Emits CREATE TABLE for the type ``T`` based on its `[sql_table]` definition.
-    //! Returns ``none`` on success, ``some(errmsg)`` on failure.
-    return db |> try_exec(_::_sql_create_table_sql(type<TT>))
+    //! Emits CREATE TABLE (and any ``[sql_index(...)]`` CREATE INDEX statements
+    //! attached to the struct) for the type ``T`` based on its `[sql_table]`
+    //! definition. Returns ``none`` on success, ``some(errmsg)`` on failure.
+    let table_sql = _::_sql_create_table_sql(type<TT>)
+    let err = db |> try_exec(table_sql)
+    if (err |> is_some) {
+        return err
+    }
+    let indexes_sql = _::_sql_create_indexes_sql(type<TT>)
+    if (empty(indexes_sql)) {
+        return none(type<string>)
+    }
+    return db |> try_exec(indexes_sql)
 }
 
 [template(t)]
@@ -792,6 +808,177 @@ def insert(db : SqlRunner; rows : array<auto(TT)>) : int64 {
 [unused_argument(e)]
 def private ignore_sql_error(e : SqlError) : void {
     //! Discards a SqlError. Used by try_insert(array) to swallow ROLLBACK failures while preserving the original error.
+}
+
+// ============================================================================
+// INSERT OR IGNORE / INSERT OR REPLACE
+//
+// Variants of ``insert`` that change SQLite's conflict resolution. Both reuse
+// the per-struct ``_sql_insert_with_pk_sql`` / ``_sql_insert_no_pk_sql`` SQL
+// emitters and ``_sql_bind_row`` bind code; the only difference is a textual
+// ``OR IGNORE`` / ``OR REPLACE`` modifier inserted after ``INSERT`` and a
+// rows-affected return (via ``sqlite3_changes``) rather than ``last_insert_rowid``.
+//
+// ``OR IGNORE``: silent no-op on PK / UNIQUE violation. Returns 0 for the
+//   conflicting row, 1 for the inserted row.
+// ``OR REPLACE``: deletes the conflicting row, then inserts the new one. Be
+//   careful — any column not in the new row gets its DEFAULT (rarely what you
+//   want for partial updates; tut 21's UPSERT ON CONFLICT DO UPDATE is the
+//   proper merge form).
+// ============================================================================
+
+def private with_or_clause(plain_sql : string; or_clause : string) : string {
+    //! Insert `OR IGNORE` / `OR REPLACE` between `INSERT` and `INTO` /
+    //! `DEFAULT VALUES`. The plain SQL always begins with ``INSERT `` so the
+    //! substitution target is unambiguous.
+    if (empty(or_clause)) {
+        return plain_sql
+    }
+    return replace(plain_sql, "INSERT ", "INSERT {or_clause} ")
+}
+
+def private try_insert_or(db : SqlRunner; row : auto(TT); or_clause : string) : Result<int, string> {
+    //! Shared body for `try_insert_or_ignore` / `try_insert_or_replace` (single row).
+    //! Returns ``Ok(rows_affected)`` — 0 if the row was IGNORE-d, 1 otherwise.
+    let pk_unset = _::_sql_pk_is_unset(row)
+    let plain_sql = pk_unset ? _::_sql_insert_no_pk_sql(row) : _::_sql_insert_with_pk_sql(row)
+    let sql = with_or_clause(plain_sql, or_clause)
+    let r = db |> try_step_dml(sql, $(var stmt : sqlite3_stmt?) {
+        _::_sql_bind_row(stmt, row, !pk_unset)
+    }, "insert_or_{or_clause}")
+    if (r |> is_err) {
+        return err(r |> unwrap_err, type<int>)
+    }
+    return ok(sqlite3_changes(db.sqlite_handle), type<string>)
+}
+
+def private try_insert_or(db : SqlRunner; rows : array<auto(TT)>; or_clause : string) : Result<int, string> {
+    //! Shared body for `try_insert_or_ignore` / `try_insert_or_replace` (bulk).
+    //! Wraps the per-row prepared-statement loop in a transaction (BEGIN/COMMIT
+    //! at the outer level, SAVEPOINT/RELEASE when nested). Returns the SUM of
+    //! per-statement ``sqlite3_changes`` over the batch.
+    if (empty(rows)) {
+        return ok(0, type<string>)
+    }
+    let pk_unset = _::_sql_pk_is_unset(rows[0])
+    for (i in 1..length(rows)) {
+        if (_::_sql_pk_is_unset(rows[i]) != pk_unset) {
+            return err("insert_or_{or_clause}: rows mix PK-set and PK-unset (row 0 vs row {i}); partition the array before calling", type<int>)
+        }
+    }
+    let was_in_txn = db |> in_transaction()
+    let begin_sql = was_in_txn ? "SAVEPOINT das_inso_sp" : "BEGIN IMMEDIATE"
+    let begin_err = db |> try_exec(begin_sql)
+    if (begin_err |> is_some) {
+        return err(begin_err |> unwrap, type<int>)
+    }
+    let plain_sql = pk_unset ? _::_sql_insert_no_pk_sql(rows[0]) : _::_sql_insert_with_pk_sql(rows[0])
+    let sql = with_or_clause(plain_sql, or_clause)
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        let msg = "insert_or_{or_clause} prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        if (was_in_txn) {
+            db |> try_exec("ROLLBACK TO das_inso_sp") |> ignore_sql_error
+            db |> try_exec("RELEASE das_inso_sp") |> ignore_sql_error
+        } else {
+            db |> try_exec("ROLLBACK") |> ignore_sql_error
+        }
+        return err(msg, type<int>)
+    }
+    var total_changes = 0
+    for (row in rows) {
+        sqlite3_reset(stmt)
+        sqlite3_clear_bindings(stmt)
+        _::_sql_bind_row(stmt, row, !pk_unset)
+        let src = sqlite3_step(stmt)
+        if (src != SQLITE_DONE) {
+            let msg = "insert_or_{or_clause} step failed: {sqlite3_errmsg(db.sqlite_handle)}"
+            sqlite3_finalize(stmt)
+            if (was_in_txn) {
+                db |> try_exec("ROLLBACK TO das_inso_sp") |> ignore_sql_error
+                db |> try_exec("RELEASE das_inso_sp") |> ignore_sql_error
+            } else {
+                db |> try_exec("ROLLBACK") |> ignore_sql_error
+            }
+            return err(msg, type<int>)
+        }
+        total_changes += sqlite3_changes(db.sqlite_handle)
+    }
+    sqlite3_finalize(stmt)
+    let commit_sql = was_in_txn ? "RELEASE das_inso_sp" : "COMMIT"
+    let commit_err = db |> try_exec(commit_sql)
+    if (commit_err |> is_some) {
+        if (was_in_txn) {
+            db |> try_exec("ROLLBACK TO das_inso_sp") |> ignore_sql_error
+            db |> try_exec("RELEASE das_inso_sp") |> ignore_sql_error
+        } else {
+            db |> try_exec("ROLLBACK") |> ignore_sql_error
+        }
+        return err(commit_err |> unwrap, type<int>)
+    }
+    return ok(total_changes, type<string>)
+}
+
+def try_insert_or_ignore(db : SqlRunner; row : auto(TT)) : Result<int, string> {
+    //! Single-row INSERT OR IGNORE. Returns ``Ok(1)`` when the row was
+    //! inserted, ``Ok(0)`` when a PK / UNIQUE violation was silently ignored.
+    return <- db |> try_insert_or(row, "OR IGNORE")
+}
+
+def insert_or_ignore(db : SqlRunner; row : auto(TT)) : int {
+    //! Strict variant of ``try_insert_or_ignore(row)``. Panics on SQL error.
+    let r = db |> try_insert_or_ignore(row)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return r |> unwrap
+}
+
+def try_insert_or_ignore(db : SqlRunner; rows : array<auto(TT)>) : Result<int, string> {
+    //! Bulk INSERT OR IGNORE inside a single transaction. Returns the sum of
+    //! per-row changes — total rows actually inserted (ignored rows count 0).
+    return <- db |> try_insert_or(rows, "OR IGNORE")
+}
+
+def insert_or_ignore(db : SqlRunner; rows : array<auto(TT)>) : int {
+    //! Strict variant of ``try_insert_or_ignore(array<T>)``. Panics on SQL error (after ROLLBACK).
+    let r = db |> try_insert_or_ignore(rows)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return r |> unwrap
+}
+
+def try_insert_or_replace(db : SqlRunner; row : auto(TT)) : Result<int, string> {
+    //! Single-row INSERT OR REPLACE. Returns ``Ok(rows_affected)`` — typically
+    //! 1; can be more when CASCADE deletes ripple from a PK collision.
+    return <- db |> try_insert_or(row, "OR REPLACE")
+}
+
+def insert_or_replace(db : SqlRunner; row : auto(TT)) : int {
+    //! Strict variant of ``try_insert_or_replace(row)``. Panics on SQL error.
+    let r = db |> try_insert_or_replace(row)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return r |> unwrap
+}
+
+def try_insert_or_replace(db : SqlRunner; rows : array<auto(TT)>) : Result<int, string> {
+    //! Bulk INSERT OR REPLACE inside a single transaction. Returns the sum of
+    //! per-row changes.
+    return <- db |> try_insert_or(rows, "OR REPLACE")
+}
+
+def insert_or_replace(db : SqlRunner; rows : array<auto(TT)>) : int {
+    //! Strict variant of ``try_insert_or_replace(array<T>)``. Panics on SQL error (after ROLLBACK).
+    let r = db |> try_insert_or_replace(rows)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return r |> unwrap
 }
 
 // ============================================================================
@@ -1179,12 +1366,84 @@ def private find_string_annotation(args : AnnotationArgumentList; argn : string;
     return default_value
 }
 
+def private find_string_array_annotation(args : AnnotationArgumentList; argn : string) : array<string> {
+    //! Reads a parens-list field annotation `@argn=("A","B",...)` or the bare single
+    //! `@argn="A"` form. The parser flattens parens-lists into multiple flat entries
+    //! all sharing the parent name, so a single by-name walk handles both shapes.
+    return <- [for (a in args); string(a.sValue); where a.name == argn && a.basicType == Type.tString]
+}
+
+// Whitelisted SQL-side default functions (`@sql_default_fn=...`). These are
+// deliberately enumerated rather than passed-through verbatim — typo-detection
+// at macro-expansion time gives a clearer error than a runtime SQLite parse error.
+let private SQL_DEFAULT_FN_WHITELIST = ["CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME"]
+
+let private SQL_FK_ACTION_WHITELIST = ["cascade", "set_null", "set_default", "restrict", "no_action"]
+
+def private fk_action_to_sql(action : string) : string {
+    //! Map `@sql_on_delete` / `@sql_on_update` value to its DDL form.
+    //! Caller has already validated against `SQL_FK_ACTION_WHITELIST`.
+    if (action == "cascade") {
+        return "CASCADE"
+    } elif (action == "set_null") {
+        return "SET NULL"
+    } elif (action == "set_default") {
+        return "SET DEFAULT"
+    } elif (action == "restrict") {
+        return "RESTRICT"
+    }
+    return "NO ACTION"
+}
+
+def private sql_quote_string_literal(s : string) : string {
+    //! Wrap `s` in single quotes, doubling any embedded single quote. Used for
+    //! string-typed `field : string = "default"` initializers in the DDL emitter.
+    let escaped = replace(s, "'", "''")
+    return "'{escaped}'"
+}
+
+def private literal_init_to_default_clause(init : ExpressionPtr) : string {
+    //! Translate a daslang field initializer expression to `" DEFAULT <literal>"`.
+    //! Returns `""` when the expression is null or not a recognized literal — non-
+    //! literal initializers (e.g. `some(5)` for `Option<int>`) are silently
+    //! ignored so the daslang in-memory default still compiles, just without an
+    //! SQL-side counterpart.
+    if (init == null) {
+        return ""
+    }
+    if (init is ExprConstBool) {
+        return (init as ExprConstBool).getValue ? " DEFAULT 1" : " DEFAULT 0"
+    }
+    if (init is ExprConstInt) {
+        return " DEFAULT {(init as ExprConstInt).getValue}"
+    }
+    if (init is ExprConstInt64) {
+        return " DEFAULT {(init as ExprConstInt64).getValue}"
+    }
+    if (init is ExprConstFloat) {
+        return " DEFAULT {(init as ExprConstFloat).getValue}"
+    }
+    if (init is ExprConstDouble) {
+        return " DEFAULT {(init as ExprConstDouble).getValue}"
+    }
+    if (init is ExprConstString) {
+        return " DEFAULT {sql_quote_string_literal(string((init as ExprConstString).value))}"
+    }
+    return ""
+}
+
 struct private FieldInfo {
     name : string
     col_name : string
     is_pk : bool
     is_int_pk : bool
     is_optional : bool
+    is_unique : bool
+    is_computed : bool
+    is_stored : bool                //!< false → VIRTUAL (SQLite default), true → STORED
+    computed_sql : string           //!< body of `GENERATED ALWAYS AS (...)`; non-empty iff is_computed
+    default_clause : string         //!< pre-built ` DEFAULT <expr>` or `""` when no default applies
+    references_clause : string      //!< pre-built ` REFERENCES "T"("Pk") ON DELETE X ON UPDATE Y` or `""`
 }
 
 def private is_option_field_type(td : TypeDeclPtr) : bool {
@@ -1208,6 +1467,230 @@ def private is_option_field_type(td : TypeDeclPtr) : bool {
         && td.structType._module.name == "option")
 }
 
+def private build_create_indexes_sql(st : StructurePtr; table_name : string; field_names : array<string>; var errors : das_string; var ok : bool&) : string {
+    //! Walk every `[sql_index(...)]` on ``st`` and concatenate the CREATE INDEX
+    //! statements. Each `fields=` entry is cross-checked against ``field_names``.
+    //! On validation failure, sets ``ok = false``, populates ``errors``, and
+    //! returns ``""``. Returns ``""`` when no indexes are present (also with
+    //! ``ok = true``) so the caller can skip a sqlite3_exec call.
+    ok = true
+    var stmt_count = 0
+    let sql = build_string() $(var w) {
+        for (ann in st.annotations) {
+            if (string(ann.annotation.name) != "sql_index") {
+                continue
+            }
+            let idx_name_arg = find_string_annotation(ann.arguments, "name", "")
+            let is_unique = find_bool_annotation(ann.arguments, "unique", false)
+            let cols = find_string_array_annotation(ann.arguments, "fields")
+            if (length(cols) == 0) {
+                errors := "[sql_index]: missing or empty `fields=` argument. Use `fields=\"ColName\"` for a single-column index or `fields=(\"A\", \"B\")` for a composite."
+                ok = false
+                return
+            }
+            for (col in cols) {
+                var found = false
+                for (fn in field_names) {
+                    if (fn == col) {
+                        found = true
+                    }
+                }
+                if (!found) {
+                    errors := "[sql_index]: field '{col}' is not a column of struct '{st.name}'. Available: {field_names}"
+                    ok = false
+                    return
+                }
+            }
+            let auto_name = build_string() $(var w2) {
+                w2 |> write("idx_")
+                w2 |> write(table_name)
+                for (col in cols) {
+                    w2 |> write("_")
+                    w2 |> write(col)
+                }
+            }
+            let idx_name = empty(idx_name_arg) ? auto_name : idx_name_arg
+            let kind = is_unique ? "UNIQUE INDEX" : "INDEX"
+            if (stmt_count > 0) {
+                w |> write("; ")
+            }
+            stmt_count++
+            w |> write("CREATE {kind} \"{idx_name}\" ON \"{table_name}\" (")
+            for (j in range(length(cols))) {
+                if (j > 0) {
+                    w |> write(", ")
+                }
+                w |> write("\"")
+                w |> write(cols[j])
+                w |> write("\"")
+            }
+            w |> write(")")
+        }
+    }
+    return sql
+}
+
+def private extract_string_return(var fn : FunctionPtr) : string {
+    //! Read back a `return "literal"` body emitted by `qmacro_function ... {
+    //! return $v(sql) }`. Returns the string value or `""` when the body
+    //! doesn't match the expected single-return-of-string-literal shape.
+    if (fn == null || fn.body == null || !(fn.body is ExprBlock)) {
+        return ""
+    }
+    let blk = fn.body as ExprBlock
+    if (length(blk.list) == 0) {
+        return ""
+    }
+    let stmt = blk.list[0]
+    if (!(stmt is ExprReturn)) {
+        return ""
+    }
+    let ret = stmt as ExprReturn
+    let val = ret.subexpr
+    if (val == null || !(val is ExprConstString)) {
+        return ""
+    }
+    return string((val as ExprConstString).value)
+}
+
+def private find_struct_helper_fn(name : string; st : StructurePtr) : FunctionPtr {
+    //! Locate a `[sql_table]`-generated helper function by name whose first
+    //! parameter type resolves to ``st``. Returns ``null`` when no overload
+    //! matches the struct (e.g. ``[sql_index]`` was placed before its
+    //! ``[sql_table]`` and the helper isn't generated yet).
+    var found : FunctionPtr
+    for_each_function(compiling_module(), name) $(var fn) {
+        if (length(fn.arguments) > 0
+                && fn.arguments[0]._type != null
+                && fn.arguments[0]._type.structType == st) {
+            found = fn
+        }
+    }
+    return found
+}
+
+[structure_macro(name=sql_index)]
+class SqlIndexMacro : AstStructureAnnotation {
+    //! Stackable struct-level annotation:
+    //!   ``[sql_index(fields="ColName", unique=true, name="explicit_name")]``
+    //!   ``[sql_index(fields=("A", "B"))]``
+    //! Reads the per-struct ``_sql_create_indexes_sql`` helper that
+    //! `[sql_table]` previously emitted (must appear earlier in the same
+    //! annotation list — typically ``[sql_table(...), sql_index(...), ...]``)
+    //! and rewrites its body to append one ``CREATE [UNIQUE] INDEX``
+    //! statement per annotation, joined by ``;``.
+    def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
+        let cols = find_string_array_annotation(args, "fields")
+        if (length(cols) == 0) {
+            errors := "[sql_index]: missing or empty `fields=` argument. Use `fields=\"ColName\"` for a single-column index or `fields=(\"A\", \"B\")` for a composite."
+            return false
+        }
+        let is_unique = find_bool_annotation(args, "unique", false)
+        let idx_name_arg = find_string_annotation(args, "name", "")
+
+        // Cross-check every named column against the struct's fields.
+        for (col in cols) {
+            var has_field = false
+            for (field in st.fields) {
+                if (field.name == col) {
+                    has_field = true
+                }
+            }
+            if (!has_field) {
+                errors := "[sql_index]: field '{col}' is not a column of struct '{st.name}'."
+                return false
+            }
+        }
+
+        // Locate the per-struct `_sql_create_indexes_sql` placeholder emitted
+        // by [sql_table]. Source-order rule: [sql_table] must precede
+        // [sql_index] in the annotation list.
+        var idx_fn = find_struct_helper_fn("_sql_create_indexes_sql", st)
+        if (idx_fn == null) {
+            errors := "[sql_index] on struct '{st.name}': no [sql_table] declared earlier in the annotation list. Use `[sql_table(...), sql_index(...), ...]` order so the index helper is in scope."
+            return false
+        }
+        var name_fn = find_struct_helper_fn("_sql_table_name", st)
+        if (name_fn == null) {
+            errors := "[sql_index] on struct '{st.name}': cannot resolve table name (no [sql_table] visible). Same source-order rule as above."
+            return false
+        }
+        let table_name = extract_string_return(name_fn)
+        if (empty(table_name)) {
+            errors := "[sql_index] on struct '{st.name}': internal — _sql_table_name body did not match expected shape."
+            return false
+        }
+
+        // Build the CREATE INDEX statement for THIS annotation.
+        let auto_name = build_string() $(var w) {
+            w |> write("idx_")
+            w |> write(table_name)
+            for (col in cols) {
+                w |> write("_")
+                w |> write(col)
+            }
+        }
+        let idx_name = empty(idx_name_arg) ? auto_name : idx_name_arg
+        let kind = is_unique ? "UNIQUE INDEX" : "INDEX"
+        let this_stmt = build_string() $(var w) {
+            w |> write("CREATE {kind} \"{idx_name}\" ON \"{table_name}\" (")
+            for (j in range(length(cols))) {
+                if (j > 0) {
+                    w |> write(", ")
+                }
+                w |> write("\"")
+                w |> write(cols[j])
+                w |> write("\"")
+            }
+            w |> write(")")
+        }
+
+        // Read the current accumulated SQL (empty after [sql_table], or the
+        // result of earlier [sql_index] applies on the same struct), append
+        // this statement, and replace fn.body.
+        let prev_sql = extract_string_return(idx_fn)
+        let new_sql = empty(prev_sql) ? this_stmt : "{prev_sql}; {this_stmt}"
+        idx_fn.body = qmacro_block() {
+            return $v(new_sql)
+        }
+        idx_fn.body |> force_at(st.at)
+        return true
+    }
+}
+
+def private find_parent_table_and_pk(var st : StructurePtr; parent_name : string) : tuple<tab_name : string; pk_col : string; found : bool> {
+    //! Resolve `@sql_references="ParentName"` to the parent struct's
+    //! `[sql_table(name=...)]` table name and `@sql_primary_key` column. Walks
+    //! `compiling_module()`; self-reference (`parent_name == st.name`) short-
+    //! circuits to the current struct since `[sql_table]` is being applied to
+    //! it right now.
+    var found_st : StructurePtr
+    if (st.name == parent_name) {
+        found_st = st
+    } else {
+        for_each_structure(compiling_module()) $(var ps) {
+            if (string(ps.name) == parent_name) {
+                found_st = ps
+            }
+        }
+    }
+    if (found_st == null) {
+        return ("", "", false)
+    }
+    var tab = string(found_st.name)
+    for (ann in found_st.annotations) {
+        if (ann.annotation.name == "sql_table") {
+            tab = find_string_annotation(ann.arguments, "name", tab)
+        }
+    }
+    for (pf in found_st.fields) {
+        if (find_bool_annotation(pf.annotation, "sql_primary_key", false)) {
+            return (tab, string(pf.name), true)
+        }
+    }
+    return (tab, "", false)
+}
+
 [structure_macro(name=sql_table)]
 class SqlTableMacro : AstStructureAnnotation {
     def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
@@ -1215,27 +1698,143 @@ class SqlTableMacro : AstStructureAnnotation {
 
         var fields : array<FieldInfo>
         for (field in st.fields) {
+            let fname = string(field.name)
             let is_pk = find_bool_annotation(field.annotation, "sql_primary_key", false)
+            let is_unique = find_bool_annotation(field.annotation, "sql_unique", false)
             let is_optional = is_option_field_type(field._type)
+
+            // @sql_computed expression
+            let computed_sql = find_string_annotation(field.annotation, "sql_computed", "")
+            let is_computed = !empty(computed_sql)
+            let is_stored = find_bool_annotation(field.annotation, "sql_stored", false)
+
+            // Defaults — native daslang field init OR @sql_default_fn (mutually exclusive)
+            let sql_default_fn = find_string_annotation(field.annotation, "sql_default_fn", "")
+
+            // Foreign key — @sql_references + optional @sql_on_delete / @sql_on_update
+            let references = find_string_annotation(field.annotation, "sql_references", "")
+            let on_delete = find_string_annotation(field.annotation, "sql_on_delete", "no_action")
+            let on_update = find_string_annotation(field.annotation, "sql_on_update", "no_action")
+            let has_on_delete_attr = !empty(find_string_annotation(field.annotation, "sql_on_delete", ""))
+            let has_on_update_attr = !empty(find_string_annotation(field.annotation, "sql_on_update", ""))
+
+            // ---- validation ----
             if (is_pk && is_optional) {
-                errors := "[sql_table]: @sql_primary_key on field '{field.name}' must not be Option<T> — primary keys cannot be NULL in SQL. Use a non-optional type."
+                errors := "[sql_table]: @sql_primary_key on field '{fname}' must not be Option<T> — primary keys cannot be NULL in SQL. Use a non-optional type."
                 return false
             }
+            if (is_computed && is_pk) {
+                errors := "[sql_table]: field '{fname}' cannot be both @sql_primary_key and @sql_computed — SQLite rejects PRIMARY KEY on a generated column."
+                return false
+            }
+            if (is_computed && field.init != null) {
+                errors := "[sql_table]: field '{fname}' is @sql_computed; remove the daslang field initializer (the SQL expression provides the value)."
+                return false
+            }
+            if (is_computed && !empty(sql_default_fn)) {
+                errors := "[sql_table]: field '{fname}' is @sql_computed; @sql_default_fn does not apply (computed columns derive their value from the expression)."
+                return false
+            }
+            if (field.init != null && !empty(sql_default_fn)) {
+                errors := "[sql_table]: field '{fname}' has both a daslang field initializer and @sql_default_fn — pick one. Use the field init for literal defaults, @sql_default_fn for SQL built-ins like CURRENT_TIMESTAMP."
+                return false
+            }
+            if (!empty(sql_default_fn)) {
+                var fn_ok = false
+                for (allowed in SQL_DEFAULT_FN_WHITELIST) {
+                    if (allowed == sql_default_fn) {
+                        fn_ok = true
+                    }
+                }
+                if (!fn_ok) {
+                    errors := "[sql_table]: field '{fname}' @sql_default_fn=\"{sql_default_fn}\" is not in the supported set (CURRENT_TIMESTAMP / CURRENT_DATE / CURRENT_TIME). Use raw SQL via `db |> exec(...)` for other expressions."
+                    return false
+                }
+            }
+            if ((has_on_delete_attr || has_on_update_attr) && empty(references)) {
+                errors := "[sql_table]: field '{fname}' has @sql_on_delete / @sql_on_update without @sql_references — these annotations only apply to a foreign-key relationship."
+                return false
+            }
+            if (!empty(references)) {
+                var od_ok = false
+                var ou_ok = false
+                for (allowed in SQL_FK_ACTION_WHITELIST) {
+                    if (allowed == on_delete) {
+                        od_ok = true
+                    }
+                    if (allowed == on_update) {
+                        ou_ok = true
+                    }
+                }
+                if (!od_ok) {
+                    errors := "[sql_table]: field '{fname}' @sql_on_delete=\"{on_delete}\" must be one of cascade / set_null / set_default / restrict / no_action."
+                    return false
+                }
+                if (!ou_ok) {
+                    errors := "[sql_table]: field '{fname}' @sql_on_update=\"{on_update}\" must be one of cascade / set_null / set_default / restrict / no_action."
+                    return false
+                }
+                if (on_delete == "set_null" && !is_optional) {
+                    errors := "[sql_table]: field '{fname}' @sql_on_delete=\"set_null\" requires column type Option<T> so the column can hold NULL. Either change the column type or pick a different action (cascade / restrict / no_action)."
+                    return false
+                }
+                if (on_delete == "set_default" && field.init == null && empty(sql_default_fn)) {
+                    errors := "[sql_table]: field '{fname}' @sql_on_delete=\"set_default\" requires a daslang field initializer (`{fname} : T = <literal>`) or @sql_default_fn. Otherwise SET DEFAULT has nothing to set."
+                    return false
+                }
+            }
+
+            // ---- DDL fragment construction ----
+            var default_clause = ""
+            if (!empty(sql_default_fn)) {
+                default_clause = " DEFAULT {sql_default_fn}"
+            } elif (field.init != null) {
+                default_clause = literal_init_to_default_clause(field.init)
+            }
+
+            var references_clause = ""
+            if (!empty(references)) {
+                let pk_lookup = find_parent_table_and_pk(st, references)
+                if (!pk_lookup.found) {
+                    if (empty(pk_lookup.tab_name)) {
+                        errors := "[sql_table]: field '{fname}' @sql_references=\"{references}\" — no struct named '{references}' is visible in this module."
+                    } else {
+                        errors := "[sql_table]: field '{fname}' @sql_references=\"{references}\" — parent struct '{references}' has no @sql_primary_key field; FK target column cannot be resolved."
+                    }
+                    return false
+                }
+                references_clause = " REFERENCES \"{pk_lookup.tab_name}\"(\"{pk_lookup.pk_col}\") ON DELETE {fk_action_to_sql(on_delete)} ON UPDATE {fk_action_to_sql(on_update)}"
+            }
+
             fields |> push(FieldInfo(
-                name = string(field.name),
-                col_name = string(field.name),
+                name = fname,
+                col_name = fname,
                 is_pk = is_pk,
                 is_int_pk = is_pk && (field._type.baseType == Type.tInt || field._type.baseType == Type.tInt64),
-                is_optional = is_optional
+                is_optional = is_optional,
+                is_unique = is_unique,
+                is_computed = is_computed,
+                is_stored = is_stored,
+                computed_sql = computed_sql,
+                default_clause = default_clause,
+                references_clause = references_clause
             ))
         }
 
+        // [sql_index] sibling-annotation processing happens in finish() —
+        // st.annotations is not yet populated during apply(). The helper
+        // function `_sql_create_indexes_sql` is added to the module there.
         var fn_table_name = make_table_name_fn(st, table_name)
         compiling_module() |> add_function(fn_table_name)
         var fn_drop = make_drop_sql_fn(st, table_name)
         compiling_module() |> add_function(fn_drop)
         var fn_create = make_create_table_sql_fn(st, table_name, fields)
         compiling_module() |> add_function(fn_create)
+        // Empty `_sql_create_indexes_sql` placeholder. Sibling [sql_index]
+        // annotations rewrite this body to accumulate CREATE INDEX statements.
+        // User-facing source order requirement: [sql_table, sql_index, ...].
+        var fn_indexes = make_create_indexes_sql_fn(st, "")
+        compiling_module() |> add_function(fn_indexes)
         var fn_ins_pk = make_insert_with_pk_sql_fn(st, table_name, fields)
         compiling_module() |> add_function(fn_ins_pk)
         var fn_ins_nopk = make_insert_no_pk_sql_fn(st, table_name, fields)
@@ -1260,6 +1859,7 @@ class SqlTableMacro : AstStructureAnnotation {
         return true
     }
 
+
     def make_table_name_fn(var st : StructurePtr; table_name : string) : FunctionPtr {
         var fn = qmacro_function("_sql_table_name") $(typ : $t(st)) : string {
             return $v(table_name)
@@ -1279,6 +1879,19 @@ class SqlTableMacro : AstStructureAnnotation {
         return <- fn
     }
 
+    def make_create_indexes_sql_fn(var st : StructurePtr; indexes_sql : string) : FunctionPtr {
+        //! Per-struct helper returning the concatenated CREATE INDEX statements
+        //! for every `[sql_index(...)]` attached to the struct, joined by ``;``.
+        //! Returns ``""`` when the struct has no indexes; ``try_create_table``
+        //! short-circuits sqlite3_exec on empty input.
+        var fn = qmacro_function("_sql_create_indexes_sql") $(typ : $t(st)) : string {
+            return $v(indexes_sql)
+        }
+        fn.flags |= FunctionFlags.generated
+        fn.body |> force_at(st.at)
+        return <- fn
+    }
+
     def make_create_table_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>) : FunctionPtr {
         var write_exprs : array<ExpressionPtr>
         write_exprs |> reserve(3 * length(fields) + 2)
@@ -1289,10 +1902,30 @@ class SqlTableMacro : AstStructureAnnotation {
         for (i in range(length(fields))) {
             let info = fields[i]
             let prefix = i == 0 ? "\"{info.col_name}\" " : ", \"{info.col_name}\" "
-            // Nullability is type-driven: Option<T> fields drop NOT NULL.
-            // PK columns are implicitly NOT NULL in SQLite for INTEGER PRIMARY KEY,
-            // and rejected as Option<T> earlier in apply().
-            let suffix = info.is_pk ? " PRIMARY KEY" : (info.is_optional ? "" : " NOT NULL")
+            // Compose the column suffix:
+            //   - computed: ` GENERATED ALWAYS AS (...) VIRTUAL|STORED` and nothing
+            //     else; SQLite rejects NOT NULL / DEFAULT / UNIQUE / FK on a
+            //     generated column.
+            //   - PK: ` PRIMARY KEY`. UNIQUE is implied; DEFAULT may still fire if
+            //     the user gave a literal init.
+            //   - Otherwise: NOT NULL (unless Option<T>), UNIQUE, DEFAULT,
+            //     REFERENCES — in DDL order.
+            var suffix = ""
+            if (info.is_computed) {
+                let storage = info.is_stored ? "STORED" : "VIRTUAL"
+                suffix = " GENERATED ALWAYS AS ({info.computed_sql}) {storage}"
+            } else {
+                if (info.is_pk) {
+                    suffix = " PRIMARY KEY"
+                } elif (!info.is_optional) {
+                    suffix = " NOT NULL"
+                }
+                if (info.is_unique && !info.is_pk) {
+                    suffix += " UNIQUE"
+                }
+                suffix += info.default_clause
+                suffix += info.references_clause
+            }
             write_exprs |> push(qmacro_expr(${ writer |> write($v(prefix)); }))
             write_exprs |> push(qmacro_expr(${ writer |> write(sqlite_sql_type(type<$t(st.fields[i]._type)>)); }))
             write_exprs |> push(qmacro_expr(${ writer |> write($v(suffix)); }))
@@ -1310,28 +1943,14 @@ class SqlTableMacro : AstStructureAnnotation {
     }
 
     def make_insert_with_pk_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>) : FunctionPtr {
-        let placeholders = build_string() $(var w) {
-            for (i in range(length(fields))) {
-                if (i > 0) {
-                    w |> write(", ")
-                }
-                w |> write("?")
-            }
-        }
-        let sql = "INSERT INTO \"{table_name}\" VALUES ({placeholders})"
-        var fn = qmacro_function("_sql_insert_with_pk_sql") $(typ : $t(st)) : string {
-            return $v(sql)
-        }
-        fn.flags |= FunctionFlags.generated
-        fn.body |> force_at(st.at)
-        return <- fn
-    }
-
-    def make_insert_no_pk_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>) : FunctionPtr {
+        // Always emit explicit column list so computed (GENERATED) columns can be
+        // skipped — SQLite rejects writes to generated columns. Without computed
+        // columns this is functionally equivalent to the previous positional
+        // `INSERT INTO T VALUES (?,?,...)` form.
         let cols = build_string() $(var w) {
             var first = true
             for (info in fields) {
-                if (info.is_pk) {
+                if (info.is_computed) {
                     continue
                 }
                 if (!first) {
@@ -1346,7 +1965,7 @@ class SqlTableMacro : AstStructureAnnotation {
         let placeholders = build_string() $(var w) {
             var first = true
             for (info in fields) {
-                if (info.is_pk) {
+                if (info.is_computed) {
                     continue
                 }
                 if (!first) {
@@ -1356,9 +1975,48 @@ class SqlTableMacro : AstStructureAnnotation {
                 first = false
             }
         }
-        // PK-only structs have no non-PK columns. SQLite rejects `INSERT INTO T () VALUES ()`,
-        // so fall back to `DEFAULT VALUES` — the canonical way to insert a row with all defaults
-        // (here, just the auto-assigned rowid).
+        let sql = (empty(cols)
+            ? "INSERT INTO \"{table_name}\" DEFAULT VALUES"
+            : "INSERT INTO \"{table_name}\" ({cols}) VALUES ({placeholders})")
+        var fn = qmacro_function("_sql_insert_with_pk_sql") $(typ : $t(st)) : string {
+            return $v(sql)
+        }
+        fn.flags |= FunctionFlags.generated
+        fn.body |> force_at(st.at)
+        return <- fn
+    }
+
+    def make_insert_no_pk_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>) : FunctionPtr {
+        let cols = build_string() $(var w) {
+            var first = true
+            for (info in fields) {
+                if (info.is_pk || info.is_computed) {
+                    continue
+                }
+                if (!first) {
+                    w |> write(", ")
+                }
+                w |> write("\"")
+                w |> write(info.col_name)
+                w |> write("\"")
+                first = false
+            }
+        }
+        let placeholders = build_string() $(var w) {
+            var first = true
+            for (info in fields) {
+                if (info.is_pk || info.is_computed) {
+                    continue
+                }
+                if (!first) {
+                    w |> write(", ")
+                }
+                w |> write("?")
+                first = false
+            }
+        }
+        // PK-only / all-computed structs have no non-PK bindable columns. SQLite
+        // rejects `INSERT INTO T () VALUES ()`, so fall back to `DEFAULT VALUES`.
         let sql = (empty(cols)
             ? "INSERT INTO \"{table_name}\" DEFAULT VALUES"
             : "INSERT INTO \"{table_name}\" ({cols}) VALUES ({placeholders})")
@@ -1397,23 +2055,31 @@ class SqlTableMacro : AstStructureAnnotation {
     }
 
     def make_bind_row_fn(var st : StructurePtr; fields : array<FieldInfo>) : FunctionPtr {
+        // Bind indices follow the column-list emitted by `_sql_insert_with_pk_sql`
+        // / `_sql_insert_no_pk_sql` — both skip computed columns. The index is
+        // a running counter over bindable (non-computed) columns; it is NOT
+        // the field's position in `fields`.
         var with_pk_exprs : array<ExpressionPtr>
         var no_pk_exprs : array<ExpressionPtr>
         with_pk_exprs |> reserve(length(fields))
         no_pk_exprs |> reserve(length(fields))
 
-        for (i in range(length(fields))) {
-            let info = fields[i]
-            let with_idx = i + 1
+        var with_pk_idx = 0
+        for (info in fields) {
+            if (info.is_computed) {
+                continue
+            }
+            with_pk_idx++
+            let wi = with_pk_idx
             let field_name = info.name
             with_pk_exprs |> push(qmacro_expr(${
-                sqlite_bind(stmt, $v(with_idx), row.$f(field_name));
+                sqlite_bind(stmt, $v(wi), row.$f(field_name));
             }))
         }
 
         var no_pk_idx = 0
         for (info in fields) {
-            if (info.is_pk) {
+            if (info.is_pk || info.is_computed) {
                 continue
             }
             no_pk_idx++
@@ -1514,7 +2180,7 @@ class SqlTableMacro : AstStructureAnnotation {
         let set_clause = build_string() $(var w) {
             var first = true
             for (info in fields) {
-                if (info.is_pk) {
+                if (info.is_pk || info.is_computed) {
                     continue
                 }
                 if (!first) {
@@ -1526,11 +2192,11 @@ class SqlTableMacro : AstStructureAnnotation {
                 first = false
             }
         }
-        // PK-only struct (no SET columns): `UPDATE T SET WHERE pk=?` is invalid
-        // SQL. Stub panics at call time with a clear message.
+        // PK-only / all-computed struct (no SET columns): `UPDATE T SET WHERE pk=?`
+        // is invalid SQL. Stub panics at call time with a clear message.
         if (empty(set_clause)) {
             let st_name = string(st.name)
-            let msg = "[sql_table] {st_name}: update(row) has nothing to SET — every non-PK field is missing. Add at least one non-PK column, or use raw `exec`."
+            let msg = "[sql_table] {st_name}: update(row) has nothing to SET — every non-PK column is missing or @sql_computed. Add at least one writable non-PK column, or use raw `exec`."
             var fn = qmacro_function("_sql_update_by_pk_sql") $(typ : $t(st)) : string {
                 panic($v(msg))
                 return ""
@@ -1589,9 +2255,9 @@ class SqlTableMacro : AstStructureAnnotation {
 
         var bind_exprs : array<ExpressionPtr>
         var bind_idx = 0
-        // Non-PK columns first.
+        // Non-PK, non-computed columns first.
         for (i in range(length(fields))) {
-            if (fields[i].is_pk) {
+            if (fields[i].is_pk || fields[i].is_computed) {
                 continue
             }
             bind_idx++

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -181,6 +181,7 @@ struct private SqlQuery {
     argNames    : array<string>
     argSourceIdx : array<int>             //!< parallel to argNames
     dbExpr      : ExpressionPtr
+    upsertMode  : bool                    //!< _upsert do_update body context — recognize `_excluded.Col` as the SQLite ``excluded.col`` proposed-row reference. Only set inside `emit_upsert_body`.
 }
 
 // ============================================================================
@@ -1914,6 +1915,40 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             return "{pred_to_sql(lhs, q, prog, at)} >= {pred_to_sql(rhs, q, prog, at)}"
         }
     }
+    // Arithmetic operators — SQL uses the same `+ - * / %` syntax as daslang.
+    // Used in DO UPDATE SET RHS (e.g. `Hits = _.Hits + 1`) and any other
+    // expression-position SET / projection. Parens around recursive calls keep
+    // precedence safe in the emitted SQL.
+    {
+        var lhs, rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) + $e(rhs)).matched) {
+            return "({pred_to_sql(lhs, q, prog, at)}) + ({pred_to_sql(rhs, q, prog, at)})"
+        }
+    }
+    {
+        var lhs, rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) - $e(rhs)).matched) {
+            return "({pred_to_sql(lhs, q, prog, at)}) - ({pred_to_sql(rhs, q, prog, at)})"
+        }
+    }
+    {
+        var lhs, rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) * $e(rhs)).matched) {
+            return "({pred_to_sql(lhs, q, prog, at)}) * ({pred_to_sql(rhs, q, prog, at)})"
+        }
+    }
+    {
+        var lhs, rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) / $e(rhs)).matched) {
+            return "({pred_to_sql(lhs, q, prog, at)}) / ({pred_to_sql(rhs, q, prog, at)})"
+        }
+    }
+    {
+        var lhs, rhs : ExpressionPtr
+        if (qmatch(node, $e(lhs) % $e(rhs)).matched) {
+            return "({pred_to_sql(lhs, q, prog, at)}) % ({pred_to_sql(rhs, q, prog, at)})"
+        }
+    }
 
     // Column reference: <argname>.ColName  (ExprField rooted at any lambda param).
     // Single-source: emit unqualified `"Col"` (only `_` is bound).
@@ -1954,6 +1989,13 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
                     // Single-source: only `_` is bound. Match the legacy emission.
                     if (argName == "_") {
                         return "\"{fieldName}\""
+                    }
+                    // Upsert-only sentinel: `_excluded.Col` → SQLite's
+                    // ``excluded.col`` reference to the proposed row inside
+                    // ON CONFLICT DO UPDATE SET. Gated on q.upsertMode so
+                    // unrelated chains don't accidentally accept it.
+                    if (q.upsertMode && argName == "_excluded") {
+                        return "excluded.\"{fieldName}\""
                     }
                 }
             }
@@ -3461,5 +3503,400 @@ class private SqlTryDeleteReturningMacro : AstCallMacro {
             return null
         }
         return emit_delete_body(prog, call, rootT, true, true)
+    }
+}
+
+// ============================================================================
+// _sql_upsert / _sql_try_upsert / _sql_upsert_returning / _sql_try_upsert_returning
+//
+// SQLite INSERT...ON CONFLICT DO UPDATE — the proper merge form. Three positional
+// args after ``db``:
+//   - row : T (single-row only for v1; bulk overload deferred to a follow-up)
+//   - on_conflict : either `_.Col` (single column) or `tuple(_.C1, _.C2, ...)` (composite)
+//   - do_update : named-tuple literal `(Col=expr, ...)` referencing `_` (existing row)
+//                 and/or `_excluded` (proposed row — SQLite's built-in sentinel)
+//
+// Like `_sql_update`, args 1..3 stay raw (canVisitArgument=true only for arg 0,
+// the db). The do_update walker runs `pred_to_sql` with `q.upsertMode = true` so
+// `_excluded.Col` resolves to SQLite's `excluded.col`; `_.Col` resolves to the
+// unqualified column reference (existing-row in DO UPDATE SET context).
+// ============================================================================
+
+[macro_function]
+def private is_field_computed(field) : bool {
+    let v = find_arg(field.annotation, "sql_computed")
+    if (v is tString) {
+        return !empty(v as tString)
+    }
+    return false
+}
+
+[macro_function]
+def private validate_outer_upsert_args(prog : ProgramPtr; var call : ExprCallMacro?; var rootT : TypeDeclPtr&) : bool {
+    if (length(call.arguments) != 4) {
+        macro_error(prog, call.at, "{call.name}: expected (db, row, on_conflict, do_update) — got {length(call.arguments)} args")
+        return false
+    }
+    var rowE = call.arguments[1]
+    if (rowE._type == null || rowE._type.structType == null) {
+        macro_error(prog, call.at, "{call.name}: second argument must be a [sql_table] struct value (got {describe(rowE._type)})")
+        return false
+    }
+    if (rowE._type.isGoodArrayType) {
+        macro_error(prog, call.at, "{call.name}: bulk array<T> upsert is deferred to a follow-up — pass a single row for now and call inside a transaction loop if you need batching")
+        return false
+    }
+    rootT = clone_type(rowE._type)
+    return true
+}
+
+[macro_function]
+def private analyze_upsert_conflict(var conflictExpr : ExprCallMacro?; rootT : TypeDeclPtr;
+                                    var conflictCols : array<string>&;
+                                    prog : ProgramPtr; at : LineInfo) : bool {
+    //! Extract the conflict-target column list from the on_conflict expression.
+    //! Accepted shapes:
+    //!     _.Col              → single column
+    //!     tuple(_.A, _.B)    → composite
+    //! Anything else is a macro_error.
+    var node : ExpressionPtr = conflictExpr
+    return analyze_upsert_conflict_inner(node, rootT, conflictCols, prog, at)
+}
+
+[macro_function]
+def private analyze_upsert_conflict_inner(var node : ExpressionPtr; rootT : TypeDeclPtr;
+                                          var conflictCols : array<string>&;
+                                          prog : ProgramPtr; at : LineInfo) : bool {
+    if (node == null) {
+        macro_error(prog, at, "_sql_upsert: on_conflict is null")
+        return false
+    }
+    var n = node
+    if (n is ExprRef2Value) {
+        n = (n as ExprRef2Value).subexpr
+    }
+    // Single column form: `_.Col`
+    if (n is ExprField) {
+        let ef = n as ExprField
+        var recv = ef.value
+        if (recv is ExprRef2Value) {
+            recv = (recv as ExprRef2Value).subexpr
+        }
+        if (recv != null && recv is ExprVar && (recv as ExprVar).name == "_") {
+            conflictCols |> push(string(ef.name))
+            return validate_conflict_cols(rootT, conflictCols, prog, at)
+        }
+        macro_error(prog, at, "_sql_upsert: on_conflict column ref must be `_.Col`; got {describe(node)}")
+        return false
+    }
+    // Tuple form: `tuple(_.A, _.B, ...)` or `(_.A, _.B, ...)` — both parse as ExprMakeTuple.
+    if (n is ExprMakeTuple) {
+        let mkt = n as ExprMakeTuple
+        if (length(mkt.values) == 0) {
+            macro_error(prog, at, "_sql_upsert: on_conflict tuple is empty")
+            return false
+        }
+        for (sub in mkt.values) {
+            var s = sub
+            if (s is ExprRef2Value) {
+                s = (s as ExprRef2Value).subexpr
+            }
+            if (s == null || !(s is ExprField)) {
+                macro_error(prog, at, "_sql_upsert: on_conflict tuple elements must be `_.Col`; got {describe(sub)}")
+                return false
+            }
+            let ef = s as ExprField
+            var recv = ef.value
+            if (recv is ExprRef2Value) {
+                recv = (recv as ExprRef2Value).subexpr
+            }
+            if (recv == null || !(recv is ExprVar) || (recv as ExprVar).name != "_") {
+                macro_error(prog, at, "_sql_upsert: on_conflict tuple element receiver must be `_`; got {describe(sub)}")
+                return false
+            }
+            conflictCols |> push(string(ef.name))
+        }
+        return validate_conflict_cols(rootT, conflictCols, prog, at)
+    }
+    macro_error(prog, at, "_sql_upsert: on_conflict must be `_.Col` (single) or `tuple(_.C1, _.C2, ...)` (composite); got {describe(node)}")
+    return false
+}
+
+[macro_function]
+def private validate_conflict_cols(rootT : TypeDeclPtr; conflictCols : array<string>; prog : ProgramPtr; at : LineInfo) : bool {
+    //! Cross-check every conflict-target column name against the struct's
+    //! fields. (We don't try to verify a UNIQUE constraint exists at macro
+    //! time — composite uniqueness via [sql_index(unique=true, fields=(...))]
+    //! is hard to inspect from here. SQLite rejects at runtime if no
+    //! constraint matches, with a clear "ON CONFLICT clause does not match"
+    //! error.)
+    if (rootT == null || rootT.structType == null) {
+        macro_error(prog, at, "_sql_upsert: row type has no struct (got {describe(rootT)})")
+        return false
+    }
+    var st = rootT.structType
+    for (col in conflictCols) {
+        var found = false
+        for (f in st.fields) {
+            if (f.name == col) {
+                found = true
+            }
+        }
+        if (!found) {
+            macro_error(prog, at, "_sql_upsert: on_conflict column \"{col}\" is not a field of {st.name}")
+            return false
+        }
+    }
+    return true
+}
+
+[macro_function]
+def private analyze_upsert_set_clause(var setExpr : ExpressionPtr; var rootT : TypeDeclPtr; tableName : string;
+                                      var setSqlClauses : array<string>&;
+                                      var setBindExprs : array<ExpressionPtr>&;
+                                      prog : ProgramPtr; at : LineInfo) : bool {
+    //! Walk the do_update named-tuple body. Identical to analyze_set_clause
+    //! except the per-value SqlQuery has ``upsertMode = true`` so
+    //! ``pred_to_sql`` recognizes ``_excluded.Col`` references.
+    if (setExpr == null) {
+        macro_error(prog, at, "_sql_upsert: do_update is null")
+        return false
+    }
+    var body = setExpr
+    if (body is ExprRef2Value) {
+        body = (body as ExprRef2Value).subexpr
+    }
+    if (!(body is ExprMakeTuple)) {
+        macro_error(prog, at, "_sql_upsert: do_update must be a named-tuple literal `(Col=expr, ...)`; got: {describe(body)}")
+        return false
+    }
+    var mkTup = body as ExprMakeTuple
+    if (length(mkTup.values) == 0) {
+        macro_error(prog, at, "_sql_upsert: do_update is empty — pass at least one (Col=expr) pair")
+        return false
+    }
+    var tupT = mkTup._type
+    var recordNames : array<string>
+    if (tupT != null && tupT.baseType == Type.tTuple
+            && length(tupT.argNames) == length(mkTup.values)) {
+        recordNames <- [for (n in tupT.argNames); string(n)]
+    } elif (length(mkTup.recordNames) == length(mkTup.values)) {
+        recordNames <- [for (n in mkTup.recordNames); string(n)]
+    } else {
+        macro_error(prog, at, "_sql_upsert: do_update must be a NAMED-tuple literal `(Col=expr, ...)`; could not extract per-element column names")
+        return false
+    }
+    for (i in range(length(recordNames))) {
+        if (empty(recordNames[i])) {
+            macro_error(prog, at, "_sql_upsert: do_update positional element at index {i} has no field name; use `(Col=expr, ...)` form")
+            return false
+        }
+    }
+    if (rootT != null && rootT.structType != null) {
+        var st = rootT.structType
+        var seenCols : table<string; bool>
+        for (i in range(length(recordNames))) {
+            let colName = recordNames[i]
+            if (key_exists(seenCols, colName)) {
+                macro_error(prog, at, "_sql_upsert: duplicate do_update column \"{colName}\"")
+                return false
+            }
+            seenCols[colName] = true
+            var found = false
+            var is_computed = false
+            for (f in st.fields) {
+                if (f.name == colName) {
+                    found = true
+                    if (is_field_computed(f)) {
+                        is_computed = true
+                    }
+                    break
+                }
+            }
+            if (!found) {
+                macro_error(prog, at, "_sql_upsert: do_update column \"{colName}\" is not a field of {st.name}")
+                return false
+            }
+            if (is_computed) {
+                macro_error(prog, at, "_sql_upsert: do_update column \"{colName}\" is @sql_computed; SQLite rejects writes to generated columns. Update the source columns and the computed value follows.")
+                return false
+            }
+        }
+    }
+    var setQ = SqlQuery(
+        rootType = rootT,
+        tableName = tableName,
+        argNames <- ["_"],
+        argSourceIdx <- [0],
+        upsertMode = true
+    )
+    for (i in range(length(mkTup.values))) {
+        let colName = recordNames[i]
+        var val = mkTup.values[i]
+        let valSql = pred_to_sql(val, setQ, prog, at)
+        if (empty(valSql)) {
+            return false
+        }
+        setSqlClauses |> push("\"{colName}\" = {valSql}")
+    }
+    for (b in setQ.bindExprs) {
+        setBindExprs |> push(b)
+    }
+    return true
+}
+
+[macro_function]
+def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
+                             var rootT : TypeDeclPtr;
+                             isTry : bool; isReturning : bool) : ExpressionPtr {
+    //! Shared body for the four `_sql_upsert*` macros.
+    if (rootT == null || rootT.structType == null) {
+        macro_error(prog, call.at, "_sql_upsert: row type must be a [sql_table] struct (got {describe(rootT)})")
+        return null
+    }
+    var st = rootT.structType
+    var dbE = call.arguments[0]
+    var rowE = call.arguments[1]
+    var conflictE = call.arguments[2]
+    var doUpdateE = call.arguments[3]
+    let tableName = sql_table_name_from_type(rootT)
+
+    // 1) on_conflict columns
+    var conflictCols : array<string>
+    if (!analyze_upsert_conflict_inner(conflictE, rootT, conflictCols, prog, call.at)) {
+        return null
+    }
+
+    // 2) do_update SET clauses (with upsertMode=true so `_excluded.Col` resolves)
+    var setSqlClauses : array<string>
+    var setBindExprs : array<ExpressionPtr>
+    if (!analyze_upsert_set_clause(doUpdateE, rootT, tableName, setSqlClauses, setBindExprs, prog, call.at)) {
+        return null
+    }
+
+    // 3) Build INSERT column list (non-computed only — matches `_sql_bind_row`).
+    var nonComputedCols : array<string>
+    var nRowBinds = 0
+    for (f in st.fields) {
+        if (is_field_computed(f)) {
+            continue
+        }
+        nonComputedCols |> push(string(f.name))
+        nRowBinds++
+    }
+
+    // 4) Assemble SQL.
+    var sql = build_string() $(var w) {
+        w |> write("INSERT INTO \"{tableName}\" (")
+        for (i in range(length(nonComputedCols))) {
+            if (i > 0) {
+                w |> write(", ")
+            }
+            w |> write("\"{nonComputedCols[i]}\"")
+        }
+        w |> write(") VALUES (")
+        for (i in range(length(nonComputedCols))) {
+            if (i > 0) {
+                w |> write(", ")
+            }
+            w |> write("?")
+        }
+        w |> write(") ON CONFLICT(")
+        for (i in range(length(conflictCols))) {
+            if (i > 0) {
+                w |> write(", ")
+            }
+            w |> write("\"{conflictCols[i]}\"")
+        }
+        w |> write(") DO UPDATE SET ")
+        for (i in range(length(setSqlClauses))) {
+            if (i > 0) {
+                w |> write(", ")
+            }
+            w |> write(setSqlClauses[i])
+        }
+    }
+    if (isReturning) {
+        sql += build_returning_clause(rootT)
+    }
+
+    // 5) Build bindStmts. Row binds come first (via per-struct `_sql_bind_row`
+    //    which uses indices 1..N_row), then SET binds at N_row+1, N_row+2, ...
+    var rowClone = clone_expression(rowE)
+    var bindStmts : array<ExpressionPtr>
+    bindStmts |> push <| qmacro_expr(${
+        _::_sql_bind_row(_sql_stmt, $e(rowClone), true);
+    })
+    for (i in range(length(setBindExprs))) {
+        let bindIdx = nRowBinds + i + 1
+        var be = setBindExprs[i]
+        bindStmts |> push <| qmacro_expr(${
+            sqlite_bind(_sql_stmt, $v(bindIdx), $e(be));
+        })
+    }
+
+    return emit_dml_call(dbE, sql, bindStmts, isTry, isReturning, rootT, call.at)
+}
+
+[call_macro(name="_sql_upsert")]
+class private SqlUpsertMacro : AstCallMacro {
+    //! `_sql_upsert(db, row, on_conflict, do_update)` — INSERT...ON CONFLICT
+    //! DO UPDATE. Returns ``int`` rows-affected. Panics on SQL error.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex < 2
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_upsert_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_upsert_body(prog, call, rootT, false, false)
+    }
+}
+
+[call_macro(name="_sql_try_upsert")]
+class private SqlTryUpsertMacro : AstCallMacro {
+    //! Non-panic sibling of `_sql_upsert`. Returns ``Result<int, string>``.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex < 2
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_upsert_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_upsert_body(prog, call, rootT, true, false)
+    }
+}
+
+[call_macro(name="_sql_upsert_returning")]
+class private SqlUpsertReturningMacro : AstCallMacro {
+    //! `_sql_upsert(...)` with a trailing ``RETURNING *`` clause. Returns
+    //! ``array<T>`` of post-merge rows. Panics on SQL error.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex < 2
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_upsert_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_upsert_body(prog, call, rootT, false, true)
+    }
+}
+
+[call_macro(name="_sql_try_upsert_returning")]
+class private SqlTryUpsertReturningMacro : AstCallMacro {
+    //! Non-panic sibling of `_sql_upsert_returning`. Returns
+    //! ``Result<array<T>, string>``.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex < 2
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        var rootT : TypeDeclPtr
+        if (!validate_outer_upsert_args(prog, call, rootT)) {
+            return null
+        }
+        return emit_upsert_body(prog, call, rootT, true, true)
     }
 }

--- a/tests/dasSQLITE/failed_sql_index.das
+++ b/tests/dasSQLITE/failed_sql_index.das
@@ -1,0 +1,45 @@
+options gen2
+
+// [sql_index] validation rules introduced in chunk 7. Each struct triggers
+// exactly one error; macro [sql_index] failures emit error 30111.
+expect 30111:4
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+// 1. [sql_index] without `fields=` — at least one column is required.
+//    Pass only `name=` to omit fields=.
+[sql_table(name = "I1"),
+ sql_index(name = "ix_nofields")]
+struct I1 {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+// 2. [sql_index] referencing a column that is not in the struct.
+[sql_table(name = "I2"),
+ sql_index(fields = ("Bogus"))]
+struct I2 {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+// 3. [sql_index] composite with one valid + one bogus column — same error.
+[sql_table(name = "I3"),
+ sql_index(fields = ("Name", "Bogus"))]
+struct I3 {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+// 4. [sql_index] before [sql_table] in source order — the helper function
+//    isn't in scope yet, so the body-rewrite cannot proceed.
+[sql_index(fields = ("Name")),
+ sql_table(name = "I4")]
+struct I4 {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+[export]
+def main() {}

--- a/tests/dasSQLITE/failed_sql_table_schema.das
+++ b/tests/dasSQLITE/failed_sql_table_schema.das
@@ -1,0 +1,144 @@
+options gen2
+
+// Each struct below intentionally violates one [sql_table] schema-validation
+// rule introduced in chunk 7 (defaults / computed / foreign keys). Each
+// failure produces error 30111 = "macro [sql_table] failed to apply to the
+// structure". Validation is fail-fast (first error aborts that struct's
+// apply()) so each struct contributes exactly one error.
+expect 30111:12
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+// 1. @sql_computed on a @sql_primary_key column — SQLite rejects PRIMARY KEY
+//    on a generated column.
+[sql_table(name = "C1")]
+struct C1 {
+    @sql_primary_key
+    @sql_computed = "1"
+    Id : int
+}
+
+// 2. @sql_computed combined with a daslang field initializer — the SQL
+//    expression is the only source of value for a computed column.
+[sql_table(name = "C2")]
+struct C2 {
+    @sql_primary_key Id : int
+    @sql_computed = "Id * 2"
+    DoubleId : int = 7
+}
+
+// 3. @sql_computed combined with @sql_default_fn — defaults don't apply to
+//    generated columns.
+[sql_table(name = "C3")]
+struct C3 {
+    @sql_primary_key Id : int
+    @sql_computed = "Id * 2"
+    @sql_default_fn = "CURRENT_TIMESTAMP"
+    DoubleId : int
+}
+
+// 4. Native field initializer combined with @sql_default_fn — pick one.
+[sql_table(name = "C4")]
+struct C4 {
+    @sql_primary_key Id : int
+    @sql_default_fn = "CURRENT_TIMESTAMP"
+    CreatedAt : string = "fixed"
+}
+
+// 5. @sql_default_fn outside the supported whitelist (CURRENT_TIMESTAMP /
+//    CURRENT_DATE / CURRENT_TIME).
+[sql_table(name = "C5")]
+struct C5 {
+    @sql_primary_key Id : int
+    @sql_default_fn = "now()"
+    Ts : string
+}
+
+// 6. @sql_on_delete without @sql_references — FK actions only apply to a
+//    foreign-key relationship.
+[sql_table(name = "C6")]
+struct C6 {
+    @sql_primary_key Id : int
+    @sql_on_delete = "cascade"
+    OrphanFk : int
+}
+
+// 7. @sql_on_update without @sql_references — same rule, update side.
+[sql_table(name = "C7")]
+struct C7 {
+    @sql_primary_key Id : int
+    @sql_on_update = "cascade"
+    OrphanFk : int
+}
+
+// 8. @sql_on_delete action outside the whitelist.
+//    Need a real referenced struct so we hit the action check, not the
+//    "missing reference" branch.
+[sql_table(name = "C8Parent")]
+struct C8Parent {
+    @sql_primary_key Id : int
+}
+
+[sql_table(name = "C8")]
+struct C8 {
+    @sql_primary_key Id : int
+    @sql_references = "C8Parent"
+    @sql_on_delete = "blow_up"
+    ParentId : int
+}
+
+// 9. @sql_on_delete = "set_null" on a non-Option<T> column — SQLite cannot
+//    set a NOT NULL column to NULL.
+[sql_table(name = "C9Parent")]
+struct C9Parent {
+    @sql_primary_key Id : int
+}
+
+[sql_table(name = "C9")]
+struct C9 {
+    @sql_primary_key Id : int
+    @sql_references = "C9Parent"
+    @sql_on_delete = "set_null"
+    ParentId : int
+}
+
+// 10. @sql_on_delete = "set_default" without a default — SET DEFAULT has
+//     nothing to set.
+[sql_table(name = "C10Parent")]
+struct C10Parent {
+    @sql_primary_key Id : int
+}
+
+[sql_table(name = "C10")]
+struct C10 {
+    @sql_primary_key Id : int
+    @sql_references = "C10Parent"
+    @sql_on_delete = "set_default"
+    ParentId : int
+}
+
+// 11. @sql_references naming a struct that doesn't exist in this module.
+[sql_table(name = "C11")]
+struct C11 {
+    @sql_primary_key Id : int
+    @sql_references = "NoSuchStruct"
+    OtherId : int
+}
+
+// 12. @sql_references naming a struct that exists but has no
+//     @sql_primary_key — FK target column cannot be resolved.
+[sql_table(name = "C12NoPk")]
+struct C12NoPk {
+    Marker : int
+}
+
+[sql_table(name = "C12")]
+struct C12 {
+    @sql_primary_key Id : int
+    @sql_references = "C12NoPk"
+    ParentId : int
+}
+
+[export]
+def main() {}

--- a/tests/dasSQLITE/failed_sql_upsert.das
+++ b/tests/dasSQLITE/failed_sql_upsert.das
@@ -1,0 +1,69 @@
+options gen2
+
+// Each `_sql_upsert` call below is intentionally malformed and must emit
+// a macro_error (40104) from the analyzer.
+expect 40104:10
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+    @sql_computed = "Price * 2"
+    DoublePrice : int
+}
+
+[export]
+def main() {
+    var db = SqlRunner()
+
+    // 1. Wrong arity — _sql_upsert needs (row, on_conflict, do_update)
+    let bad1 = db |> _sql_upsert(Car(Id = 1, Name = "x", Price = 0, DoublePrice = 0), _.Id)
+
+    // 2. Second arg not a struct value (bare int)
+    let bad2 = db |> _sql_upsert(42, _.Id, (Name = "x"))
+
+    // 3. Bulk array<T> form is deferred — pass a single row, not an array
+    var rows : array<Car>
+    rows |> emplace(Car(Id = 1, Name = "x", Price = 0, DoublePrice = 0))
+    let bad3 = db |> _sql_upsert(rows, _.Id, (Name = "x"))
+
+    // 4. on_conflict is not `_.Col` — bare integer literal
+    let bad4 = db |> _sql_upsert(Car(Id = 1, Name = "x", Price = 0, DoublePrice = 0),
+                                  42, (Name = "x"))
+
+    // 5. on_conflict tuple element is not `_.Col`
+    let bad5 = db |> _sql_upsert(Car(Id = 1, Name = "x", Price = 0, DoublePrice = 0),
+                                  tuple(_.Id, 42), (Name = "x"))
+
+    // (Empty `tuple()` is a parse error, so the on_conflict-empty-tuple
+    // validation rule is unreachable through normal source. Skipped.)
+
+    // 7. on_conflict references column not on the struct
+    let bad7 = db |> _sql_upsert(Car(Id = 1, Name = "x", Price = 0, DoublePrice = 0),
+                                  _.NotAColumn, (Name = "x"))
+
+    // 8. do_update is not a named-tuple — bare integer literal
+    let bad8 = db |> _sql_upsert(Car(Id = 1, Name = "x", Price = 0, DoublePrice = 0),
+                                  _.Id, 42)
+
+    // (Empty tuple `()` is a parse error, so the do_update-empty validation
+    // rule is unreachable through normal source. Skipped.)
+
+    // 10. do_update has duplicate column names
+    let bad10 = db |> _sql_upsert(Car(Id = 1, Name = "x", Price = 0, DoublePrice = 0),
+                                   _.Id, (Name = "a", Name = "b"))
+
+    // 11. do_update column is not a field of the struct
+    let bad11 = db |> _sql_upsert(Car(Id = 1, Name = "x", Price = 0, DoublePrice = 0),
+                                   _.Id, (NotAColumn = 1))
+
+    // 12. do_update column is @sql_computed — SQLite rejects writes to
+    //     generated columns.
+    let bad12 = db |> _sql_upsert(Car(Id = 1, Name = "x", Price = 0, DoublePrice = 0),
+                                   _.Id, (DoublePrice = 999))
+}

--- a/tests/dasSQLITE/test_02_insert.das
+++ b/tests/dasSQLITE/test_02_insert.das
@@ -28,7 +28,7 @@ def test_macro_emits_create_ddl(t : T?) {
 def test_macro_emits_insert_shapes(t : T?) {
     let with_pk = _sql_insert_with_pk_sql(type<Car>)
     let no_pk = _sql_insert_no_pk_sql(type<Car>)
-    t |> equal(with_pk, "INSERT INTO \"Cars\" VALUES (?, ?, ?)", "with-PK insert form")
+    t |> equal(with_pk, "INSERT INTO \"Cars\" (\"Id\", \"Name\", \"Price\") VALUES (?, ?, ?)", "with-PK insert form (chunk 7: column-list form is now mandatory so computed columns can be skipped)")
     t |> equal(no_pk, "INSERT INTO \"Cars\" (\"Name\", \"Price\") VALUES (?, ?)", "no-PK insert form")
 }
 

--- a/tests/dasSQLITE/test_52_insert_or_ignore.das
+++ b/tests/dasSQLITE/test_52_insert_or_ignore.das
@@ -1,0 +1,65 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Email : string
+    Name : string
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Email = "a@x.com", Name = "alice"))
+}
+
+[test]
+def test_insert_or_ignore_inserts_new_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> insert_or_ignore(User(Id = 2, Email = "b@x.com", Name = "bob"))
+        t |> equal(n, 1, "fresh PK insert returns 1 row affected")
+        let total = db |> query_scalar("SELECT COUNT(*) FROM Users", type<int>)
+        t |> equal(total, 2, "row count after fresh insert")
+    }
+}
+
+[test]
+def test_insert_or_ignore_silently_ignores_pk_conflict(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> insert_or_ignore(User(Id = 1, Email = "z@x.com", Name = "zoe"))
+        t |> equal(n, 0, "PK conflict returns 0 rows affected")
+        let name = db |> query_scalar("SELECT Name FROM Users WHERE Id = 1", type<string>)
+        t |> equal(name, "alice", "original row left untouched by IGNORE")
+    }
+}
+
+[test]
+def test_insert_or_ignore_bulk_partitions_by_conflict(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> insert_or_ignore([
+            User(Id = 1, Email = "ignored@x.com", Name = "dup"),
+            User(Id = 2, Email = "b@x.com", Name = "bob"),
+            User(Id = 3, Email = "c@x.com", Name = "cat")
+        ])
+        t |> equal(n, 2, "two of three rows actually inserted")
+        let total = db |> query_scalar("SELECT COUNT(*) FROM Users", type<int>)
+        t |> equal(total, 3, "row count: original alice + bob + cat")
+    }
+}
+
+[test]
+def test_try_insert_or_ignore_ok_path(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let r = db |> try_insert_or_ignore(User(Id = 1, Email = "z@x.com", Name = "zoe"))
+        t |> success(r |> is_ok, "try_insert_or_ignore on conflict still returns Ok")
+        t |> equal(r |> unwrap, 0, "rows-affected = 0 because IGNORE silenced the conflict")
+    }
+}

--- a/tests/dasSQLITE/test_53_insert_or_replace.das
+++ b/tests/dasSQLITE/test_53_insert_or_replace.das
@@ -1,0 +1,66 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Email : string
+    Name : string
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Email = "a@x.com", Name = "alice"))
+}
+
+[test]
+def test_insert_or_replace_overwrites_existing(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> insert_or_replace(User(Id = 1, Email = "a2@x.com", Name = "alice2"))
+        t |> equal(n, 1, "replace returns 1 row affected")
+        let name = db |> query_scalar("SELECT Name FROM Users WHERE Id = 1", type<string>)
+        t |> equal(name, "alice2", "row was overwritten")
+        let total = db |> query_scalar("SELECT COUNT(*) FROM Users", type<int>)
+        t |> equal(total, 1, "no duplicate row created")
+    }
+}
+
+[test]
+def test_insert_or_replace_inserts_when_pk_free(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> insert_or_replace(User(Id = 5, Email = "e@x.com", Name = "eve"))
+        t |> equal(n, 1, "fresh PK gives 1 row affected")
+        let total = db |> query_scalar("SELECT COUNT(*) FROM Users", type<int>)
+        t |> equal(total, 2, "two rows now")
+    }
+}
+
+[test]
+def test_insert_or_replace_bulk(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> insert_or_replace([
+            User(Id = 1, Email = "a3@x.com", Name = "alice3"),
+            User(Id = 2, Email = "b@x.com", Name = "bob")
+        ])
+        t |> equal(n, 2, "both rows applied (one replace, one insert)")
+        let alice_name = db |> query_scalar("SELECT Name FROM Users WHERE Id = 1", type<string>)
+        t |> equal(alice_name, "alice3", "row 1 replaced")
+    }
+}
+
+[test]
+def test_try_insert_or_replace_returns_result(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let r = db |> try_insert_or_replace(User(Id = 1, Email = "ar@x.com", Name = "alice_r"))
+        t |> success(r |> is_ok, "ok path")
+        t |> equal(r |> unwrap, 1, "1 row affected")
+    }
+}

--- a/tests/dasSQLITE/test_54_upsert_single_col.das
+++ b/tests/dasSQLITE/test_54_upsert_single_col.das
@@ -1,0 +1,67 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "WordHits")]
+struct WordHit {
+    @sql_primary_key Id : int
+    Word : string
+    Hits : int
+    Last : int64
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<WordHit>)
+    db |> insert(WordHit(Id = 1, Word = "hello", Hits = 1, Last = 100l))
+}
+
+[test]
+def test_upsert_inserts_when_no_conflict(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> _sql_upsert(
+            WordHit(Id = 2, Word = "world", Hits = 1, Last = 200l),
+            _.Id,
+            (Hits = _.Hits + 1, Last = _excluded.Last))
+        t |> equal(n, 1, "fresh insert returns 1")
+        let world_hits = db |> query_scalar("SELECT Hits FROM WordHits WHERE Id = 2", type<int>)
+        t |> equal(world_hits, 1, "fresh row used the INSERT values, not DO UPDATE")
+    }
+}
+
+[test]
+def test_upsert_merges_on_pk_collision(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = db |> _sql_upsert(
+            WordHit(Id = 1, Word = "ignored", Hits = 99, Last = 300l),
+            _.Id,
+            (Hits = _.Hits + 1, Last = _excluded.Last))
+        t |> equal(n, 1, "merge counts 1 row affected")
+        let h = db |> query_scalar("SELECT Hits FROM WordHits WHERE Id = 1", type<int>)
+        t |> equal(h, 2, "Hits incremented from existing 1 to 2")
+        let last = db |> query_scalar("SELECT Last FROM WordHits WHERE Id = 1", type<int64>)
+        t |> equal(last, 300l, "Last was updated from _excluded.Last (300)")
+        let word = db |> query_scalar("SELECT Word FROM WordHits WHERE Id = 1", type<string>)
+        t |> equal(word, "hello", "Word column unchanged because do_update doesn't touch it")
+    }
+}
+
+[test]
+def test_upsert_excluded_and_dot_underscore_compose(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Exercises both `_.Hits` (existing) and `_excluded.Hits` (proposed)
+        // in the same DO UPDATE expression.
+        db |> _sql_upsert(
+            WordHit(Id = 1, Word = "x", Hits = 7, Last = 0l),
+            _.Id,
+            (Hits = _.Hits + _excluded.Hits, Last = _excluded.Last))
+        let h = db |> query_scalar("SELECT Hits FROM WordHits WHERE Id = 1", type<int>)
+        t |> equal(h, 8, "1 (existing) + 7 (proposed) = 8")
+    }
+}

--- a/tests/dasSQLITE/test_55_upsert_composite.das
+++ b/tests/dasSQLITE/test_55_upsert_composite.das
@@ -1,0 +1,53 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Composite UNIQUE on (Email, Tenant) via [sql_index(unique=true, fields=...)].
+[sql_table(name = "UserAccts"),
+ sql_index(fields = ("Email", "Tenant"), unique = true, name = "ux_useraccts_email_tenant")]
+struct UserAcct {
+    @sql_primary_key Id : int
+    Email : string
+    Name : string
+    Tenant : string
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<UserAcct>)
+    db |> insert(UserAcct(Id = 1, Email = "x@y.com", Name = "alice", Tenant = "acme"))
+}
+
+[test]
+def test_upsert_composite_conflict_fires(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Same (Email, Tenant) → conflict → DO UPDATE
+        let n = db |> _sql_upsert(
+            UserAcct(Id = 999, Email = "x@y.com", Name = "alice2", Tenant = "acme"),
+            tuple(_.Email, _.Tenant),
+            (Name = _excluded.Name))
+        t |> equal(n, 1, "merge counted 1")
+        let name = db |> query_scalar("SELECT Name FROM UserAccts WHERE Email='x@y.com' AND Tenant='acme'", type<string>)
+        t |> equal(name, "alice2", "Name updated via _excluded.Name")
+        let total = db |> query_scalar("SELECT COUNT(*) FROM UserAccts", type<int>)
+        t |> equal(total, 1, "still one row — composite conflict merged into existing")
+    }
+}
+
+[test]
+def test_upsert_composite_no_conflict_inserts(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Different Tenant → no conflict → fresh insert
+        db |> _sql_upsert(
+            UserAcct(Id = 2, Email = "x@y.com", Name = "alice_other", Tenant = "other"),
+            tuple(_.Email, _.Tenant),
+            (Name = _excluded.Name))
+        let total = db |> query_scalar("SELECT COUNT(*) FROM UserAccts", type<int>)
+        t |> equal(total, 2, "two rows — different Tenant doesn't conflict")
+    }
+}

--- a/tests/dasSQLITE/test_56_upsert_returning.das
+++ b/tests/dasSQLITE/test_56_upsert_returning.das
@@ -1,0 +1,63 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "WordHits")]
+struct WordHit {
+    @sql_primary_key Id : int
+    Word : string
+    Hits : int
+    Last : int64
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<WordHit>)
+    db |> insert(WordHit(Id = 1, Word = "hello", Hits = 1, Last = 100l))
+}
+
+[test]
+def test_upsert_returning_yields_post_merge_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- db |> _sql_upsert_returning(
+            WordHit(Id = 1, Word = "x", Hits = 7, Last = 999l),
+            _.Id,
+            (Hits = _.Hits + 1, Last = _excluded.Last))
+        t |> equal(length(rows), 1, "RETURNING yields one row")
+        t |> equal(rows[0].Hits, 2, "post-merge Hits = existing 1 + 1")
+        t |> equal(rows[0].Last, 999l, "post-merge Last = _excluded.Last")
+        t |> equal(rows[0].Word, "hello", "Word unchanged")
+    }
+}
+
+[test]
+def test_upsert_returning_for_fresh_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- db |> _sql_upsert_returning(
+            WordHit(Id = 2, Word = "world", Hits = 5, Last = 0l),
+            _.Id,
+            (Hits = _.Hits + 1, Last = _excluded.Last))
+        t |> equal(length(rows), 1, "RETURNING yields the just-inserted row")
+        t |> equal(rows[0].Hits, 5, "fresh insert kept the proposed Hits=5")
+    }
+}
+
+[test]
+def test_try_upsert_returning_ok_path(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let r <- db |> _sql_try_upsert_returning(
+            WordHit(Id = 1, Word = "x", Hits = 0, Last = 0l),
+            _.Id,
+            (Hits = _.Hits + 10, Last = _excluded.Last))
+        t |> success(r |> is_ok, "try-returning succeeded")
+        let rows <- r |> unwrap
+        t |> equal(length(rows), 1, "one row returned")
+        t |> equal(rows[0].Hits, 11, "existing 1 + 10 = 11")
+    }
+}

--- a/tests/dasSQLITE/test_57_sql_unique.das
+++ b/tests/dasSQLITE/test_57_sql_unique.das
@@ -1,0 +1,44 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    @sql_unique Email : string
+    Name : string
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Email = "a@x.com", Name = "alice"))
+}
+
+[test]
+def test_unique_emitted_in_ddl(t : T?) {
+    let ddl = _sql_create_table_sql(type<User>)
+    t |> success(ddl |> ends_with("\"Email\" TEXT NOT NULL UNIQUE, \"Name\" TEXT NOT NULL)"),
+                 "@sql_unique appends UNIQUE to the column declaration")
+}
+
+[test]
+def test_unique_constraint_rejects_duplicate(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let r = db |> try_insert(User(Id = 2, Email = "a@x.com", Name = "anne"))
+        t |> success(r |> is_err, "duplicate Email should violate UNIQUE")
+    }
+}
+
+[test]
+def test_unique_does_not_block_distinct_emails(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> insert(User(Id = 2, Email = "b@x.com", Name = "bob"))
+        let total = db |> query_scalar("SELECT COUNT(*) FROM Users", type<int>)
+        t |> equal(total, 2, "different Email values insert fine")
+    }
+}

--- a/tests/dasSQLITE/test_58_sql_references.das
+++ b/tests/dasSQLITE/test_58_sql_references.das
@@ -1,0 +1,70 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require daslib/option
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+
+    @sql_references = "User"
+    @sql_on_delete = "cascade"
+    UserId : int
+
+    Total : float
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "alice"))
+    db |> insert(User(Id = 2, Name = "bob"))
+    db |> insert(Order(Id = 100, UserId = 1, Total = 42.0f))
+    db |> insert(Order(Id = 101, UserId = 1, Total = 99.0f))
+    db |> insert(Order(Id = 102, UserId = 2, Total = 7.5f))
+}
+
+[test]
+def test_references_emitted_in_ddl(t : T?) {
+    let ddl = _sql_create_table_sql(type<Order>)
+    t |> success(find(ddl, "REFERENCES \"Users\"(\"Id\") ON DELETE CASCADE ON UPDATE NO ACTION") >= 0,
+                 "@sql_references emits the FK clause with the parent's PK column resolved")
+}
+
+[test]
+def test_pragma_foreign_keys_on(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let pragma = db |> query_scalar("PRAGMA foreign_keys", type<int>)
+        t |> equal(pragma, 1, "with_sqlite turns FKs on")
+    }
+}
+
+[test]
+def test_cascade_delete_propagates(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> exec("DELETE FROM Users WHERE Id = 1")
+        let alice_orders = db |> query_scalar("SELECT COUNT(*) FROM Orders WHERE UserId = 1", type<int>)
+        t |> equal(alice_orders, 0, "alice's orders cascade-deleted")
+        let bob_orders = db |> query_scalar("SELECT COUNT(*) FROM Orders WHERE UserId = 2", type<int>)
+        t |> equal(bob_orders, 1, "bob's orders untouched")
+    }
+}
+
+[test]
+def test_orphan_insert_rejected(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let r = db |> try_insert(Order(Id = 999, UserId = 9999, Total = 1.0f))
+        t |> success(r |> is_err, "FK violation on missing parent row")
+    }
+}

--- a/tests/dasSQLITE/test_59_sql_index.das
+++ b/tests/dasSQLITE/test_59_sql_index.das
@@ -1,0 +1,45 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+[sql_table(name = "Posts"),
+ sql_index(fields = "AuthorId"),
+ sql_index(fields = ("AuthorId", "Published"), name = "idx_posts_author_published"),
+ sql_index(fields = "Slug", unique = true)]
+struct Post {
+    @sql_primary_key Id : int
+    AuthorId : int
+    Slug : string
+    Published : int64
+    Title : string
+}
+
+[test]
+def test_indexes_helper_concatenates(t : T?) {
+    let sql = _sql_create_indexes_sql(type<Post>)
+    t |> success(find(sql, "CREATE INDEX \"idx_Posts_AuthorId\"") >= 0, "auto-named single-col index")
+    t |> success(find(sql, "CREATE INDEX \"idx_posts_author_published\"") >= 0, "explicit-named composite index")
+    t |> success(find(sql, "CREATE UNIQUE INDEX \"idx_Posts_Slug\"") >= 0, "auto-named unique index")
+}
+
+[test]
+def test_indexes_actually_created_in_sqlite(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Post>)
+        let n = db |> query_scalar("SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name='Posts' AND name LIKE 'idx_%'", type<int>)
+        t |> equal(n, 3, "all three indexes registered with SQLite")
+    }
+}
+
+[test]
+def test_unique_index_rejects_duplicate(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Post>)
+        db |> insert(Post(Id = 1, AuthorId = 1, Slug = "first", Published = 0l, Title = "First"))
+        let r = db |> try_insert(Post(Id = 2, AuthorId = 1, Slug = "first", Published = 0l, Title = "Dup"))
+        t |> success(r |> is_err, "duplicate Slug rejected by UNIQUE INDEX")
+    }
+}

--- a/tests/dasSQLITE/test_60_defaults_computed.das
+++ b/tests/dasSQLITE/test_60_defaults_computed.das
@@ -1,0 +1,159 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Native daslang field-init becomes the SQL DEFAULT clause: literals only
+// (int/int64/bool/float/double/string). Non-literal initializers are silently
+// dropped from the DDL but still run in daslang construction. @sql_default_fn
+// covers the SQLite built-ins (CURRENT_TIMESTAMP / CURRENT_DATE / CURRENT_TIME).
+// @sql_computed emits ` GENERATED ALWAYS AS (...) VIRTUAL|STORED` and skips the
+// column from INSERT/UPDATE bind paths.
+
+[sql_table(name = "Items")]
+struct Item {
+    @sql_primary_key Id : int
+
+    Name : string
+
+    // Native field init becomes ` DEFAULT 1`.
+    Active : bool = true
+
+    // Native field init becomes ` DEFAULT 100`.
+    Quantity : int = 100
+
+    // Native field init becomes ` DEFAULT 'unknown'` (single quotes doubled).
+    Tag : string = "unknown"
+
+    // SQL-side built-in default.
+    @sql_default_fn = "CURRENT_TIMESTAMP"
+    CreatedAt : string
+
+    // VIRTUAL generated column (the default storage class).
+    @sql_computed = "Quantity * 2"
+    DoubleQty : int
+
+    // STORED generated column.
+    @sql_computed = "Quantity + 1"
+    @sql_stored = true
+    QtyPlusOne : int
+}
+
+[test]
+def test_native_init_emits_default_in_ddl(t : T?) {
+    let ddl = _sql_create_table_sql(type<Item>)
+    t |> success(find(ddl, "\"Active\" INTEGER NOT NULL DEFAULT 1") >= 0,
+                 "bool field-init = true → DEFAULT 1")
+    t |> success(find(ddl, "\"Quantity\" INTEGER NOT NULL DEFAULT 100") >= 0,
+                 "int field-init = 100 → DEFAULT 100")
+    t |> success(find(ddl, "\"Tag\" TEXT NOT NULL DEFAULT 'unknown'") >= 0,
+                 "string field-init = \"unknown\" → DEFAULT 'unknown'")
+}
+
+[test]
+def test_default_fn_emits_in_ddl(t : T?) {
+    let ddl = _sql_create_table_sql(type<Item>)
+    t |> success(find(ddl, "\"CreatedAt\" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP") >= 0,
+                 "@sql_default_fn=CURRENT_TIMESTAMP → DEFAULT CURRENT_TIMESTAMP (no quotes)")
+}
+
+[test]
+def test_computed_emits_generated_clause(t : T?) {
+    let ddl = _sql_create_table_sql(type<Item>)
+    t |> success(find(ddl, "\"DoubleQty\" INTEGER GENERATED ALWAYS AS (Quantity * 2) VIRTUAL") >= 0,
+                 "@sql_computed without @sql_stored → VIRTUAL")
+    t |> success(find(ddl, "\"QtyPlusOne\" INTEGER GENERATED ALWAYS AS (Quantity + 1) STORED") >= 0,
+                 "@sql_computed + @sql_stored=true → STORED")
+}
+
+[test]
+def test_insert_sql_skips_computed_columns(t : T?) {
+    let sql = _sql_insert_with_pk_sql(type<Item>)
+    // Computed columns must be absent from the INSERT column list.
+    t |> success(find(sql, "DoubleQty") == -1, "INSERT does not name computed column DoubleQty")
+    t |> success(find(sql, "QtyPlusOne") == -1, "INSERT does not name computed column QtyPlusOne")
+    // Non-computed columns must all be present.
+    t |> success(find(sql, "\"Id\"") >= 0, "INSERT names Id")
+    t |> success(find(sql, "\"Quantity\"") >= 0, "INSERT names Quantity")
+    t |> success(find(sql, "\"CreatedAt\"") >= 0, "INSERT names CreatedAt")
+}
+
+[test]
+def test_native_default_applied_when_field_left_zero(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Item>)
+        // Insert raw row — let SQLite fill in DEFAULTs by going through the SQL
+        // path. We use `exec` so SQLite handles the DEFAULT on omitted columns;
+        // the daslang `insert` macro always binds every non-computed column.
+        db |> exec("INSERT INTO Items (Id, Name) VALUES (1, 'x')")
+        let n = db |> query_scalar("SELECT Quantity FROM Items WHERE Id=1", type<int>)
+        t |> equal(n, 100, "Quantity got DEFAULT 100")
+        let s = db |> query_scalar("SELECT Tag FROM Items WHERE Id=1", type<string>)
+        t |> equal(s, "unknown", "Tag got DEFAULT 'unknown'")
+        let active = db |> query_scalar("SELECT Active FROM Items WHERE Id=1", type<int>)
+        t |> equal(active, 1, "Active got DEFAULT 1 (true)")
+    }
+}
+
+[test]
+def test_default_fn_populates_created_at(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Item>)
+        db |> exec("INSERT INTO Items (Id, Name) VALUES (1, 'x')")
+        let s = db |> query_scalar("SELECT CreatedAt FROM Items WHERE Id=1", type<string>)
+        // Just check it's non-empty and looks like a SQLite timestamp
+        // (YYYY-MM-DD HH:MM:SS — at least 19 chars, has the dashes/colons).
+        t |> success(length(s) >= 19, "CreatedAt populated by CURRENT_TIMESTAMP (length {length(s)})")
+    }
+}
+
+[test]
+def test_computed_columns_round_trip_via_insert(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Item>)
+        // The daslang struct Quantity = 7; the computed columns get their
+        // values from SQLite. Construction-side values for DoubleQty /
+        // QtyPlusOne are ignored on INSERT (SQL bind path skips them).
+        db |> insert(Item(Id = 1, Name = "thing", Active = true, Quantity = 7,
+                          Tag = "t", CreatedAt = "",
+                          DoubleQty = 9999, QtyPlusOne = 9999))
+        let dq = db |> query_scalar("SELECT DoubleQty FROM Items WHERE Id=1", type<int>)
+        t |> equal(dq, 14, "VIRTUAL DoubleQty = Quantity*2 = 14")
+        let qp1 = db |> query_scalar("SELECT QtyPlusOne FROM Items WHERE Id=1", type<int>)
+        t |> equal(qp1, 8, "STORED QtyPlusOne = Quantity+1 = 8")
+    }
+}
+
+[test]
+def test_first_reads_computed_columns(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Item>)
+        db |> insert(Item(Id = 1, Name = "thing", Active = true, Quantity = 5,
+                          Tag = "t", CreatedAt = "",
+                          DoubleQty = 0, QtyPlusOne = 0))
+        let r = _sql(db |> select_from(type<Item>) |> _first())
+        t |> equal(r.Quantity, 5, "Quantity round-trips")
+        t |> equal(r.DoubleQty, 10, "VIRTUAL DoubleQty round-trips through SELECT")
+        t |> equal(r.QtyPlusOne, 6, "STORED QtyPlusOne round-trips through SELECT")
+    }
+}
+
+[test]
+def test_update_skips_computed_columns(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Item>)
+        db |> insert(Item(Id = 1, Name = "thing", Active = true, Quantity = 3,
+                          Tag = "t", CreatedAt = "",
+                          DoubleQty = 0, QtyPlusOne = 0))
+        // Mutate Quantity via the macro update — computed columns must NOT
+        // appear in the SET list, otherwise SQLite rejects the write.
+        db |> _sql_update(type<Item>, _.Id == 1, (Quantity = 11))
+        let dq = db |> query_scalar("SELECT DoubleQty FROM Items WHERE Id=1", type<int>)
+        t |> equal(dq, 22, "DoubleQty re-derived from new Quantity (11*2=22)")
+        let qp1 = db |> query_scalar("SELECT QtyPlusOne FROM Items WHERE Id=1", type<int>)
+        t |> equal(qp1, 12, "QtyPlusOne re-derived from new Quantity (11+1=12)")
+    }
+}

--- a/tutorials/sql/21-upsert.das
+++ b/tutorials/sql/21-upsert.das
@@ -1,0 +1,138 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 21 — UPSERT: INSERT-or-update-on-conflict.
+//
+// Three SQL shapes for "INSERT but, if it collides with a UNIQUE / PK
+// constraint, do something instead":
+//
+//   (a) INSERT OR IGNORE          silent no-op on conflict
+//   (b) INSERT OR REPLACE         wipe-and-reinsert (loses the old row)
+//   (c) ON CONFLICT … DO UPDATE   proper merge (keeps the old row;
+//                                  updates only the columns you choose)
+//   (d) UPSERT RETURNING          capture the post-merge row
+//   (e) try_ non-panic variants   Result<int, string> instead of panic
+//
+// (a) and (b) are plain functions — no on_conflict / do_update blocks.
+// (c) is the macro `_sql_upsert(row, on_conflict, do_update)`. The
+// `_` sigil in `do_update` means "the existing row"; `_excluded` is
+// "the row we tried to INSERT". The composite-conflict form passes
+// `tuple(_.A, _.B)` and the underlying UNIQUE constraint must be a
+// composite index (see tutorial 24).
+
+[sql_table(name = "WordHits")]
+struct WordHit {
+    @sql_primary_key Id : int
+    Word : string
+    Hits : int
+    Last : int64
+}
+
+// Composite-conflict demo — tutorial 24 covers `[sql_index]` itself.
+[sql_table(name = "UserAccts"),
+ sql_index(fields = ("Email", "Tenant"), unique = true)]
+struct UserAcct {
+    @sql_primary_key Id : int
+    Email : string
+    Name : string
+    Tenant : string
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<WordHit>)
+    db |> create_table(type<UserAcct>)
+    db |> insert(WordHit(Id = 1, Word = "hello", Hits = 1, Last = 100l))
+    db |> insert(UserAcct(Id = 1, Email = "x@y.com", Name = "alice", Tenant = "acme"))
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // (a) INSERT OR IGNORE -------------------------------------------
+        // Silent no-op on PK / UNIQUE conflict. Returns rows-affected:
+        // 1 if inserted, 0 if ignored.
+        // SQL: INSERT OR IGNORE INTO "WordHits" (...) VALUES (?,?,?,?)
+        let n_first = db |> insert_or_ignore(
+            WordHit(Id = 2, Word = "world", Hits = 1, Last = 200l))
+        let n_again = db |> insert_or_ignore(
+            WordHit(Id = 1, Word = "hello", Hits = 99, Last = 0l))
+        to_log(LOG_INFO, "ignore: inserted {n_first}, ignored {1 - n_again}\n")
+
+        // (b) INSERT OR REPLACE ------------------------------------------
+        // On conflict, the existing row is DELETED and a fresh one is
+        // inserted from the new values. Columns not in the new row reset
+        // to defaults — rarely what you want for partial updates. Use
+        // (c) for proper merging.
+        // SQL: INSERT OR REPLACE INTO "WordHits" (...) VALUES (?,?,?,?)
+        db |> insert_or_replace(
+            WordHit(Id = 1, Word = "hello", Hits = 42, Last = 999l))
+
+        // (c) ON CONFLICT … DO UPDATE — the proper merge -----------------
+        // `_sql_upsert(row, on_conflict, do_update)`.
+        //   row          the values to INSERT
+        //   on_conflict  `_.Col` (single) or `tuple(_.A, _.B)` (composite)
+        //   do_update    named-tuple `(Col = expr, ...)` — `_` is the
+        //                existing row, `_excluded` is the row we tried to
+        //                INSERT
+        // SQL: INSERT INTO "WordHits" (...) VALUES (?,?,?,?)
+        //      ON CONFLICT("Id") DO UPDATE SET
+        //         "Hits" = "WordHits"."Hits" + 1,
+        //         "Last" = "excluded"."Last"
+        let bumped = db |> _sql_upsert(
+            WordHit(Id = 1, Word = "hello", Hits = 1, Last = 1234l),
+            _.Id,
+            (Hits = _.Hits + 1, Last = _excluded.Last))
+        to_log(LOG_INFO, "single-key upsert touched {bumped} row(s)\n")
+
+        // Composite conflict target — `tuple(_.Email, _.Tenant)` resolves
+        // against the UNIQUE index on `(Email, Tenant)` declared on the
+        // struct. SQLite throws "ON CONFLICT clause does not match any
+        // PRIMARY KEY or UNIQUE constraint" at runtime if no constraint
+        // covers the column list.
+        // SQL: INSERT INTO "UserAccts" (...) VALUES (?,?,?,?)
+        //      ON CONFLICT("Email","Tenant") DO UPDATE SET
+        //         "Name" = "excluded"."Name"
+        db |> _sql_upsert(
+            UserAcct(Id = 999, Email = "x@y.com", Name = "alice2", Tenant = "acme"),
+            tuple(_.Email, _.Tenant),
+            (Name = _excluded.Name))
+
+        // (d) UPSERT RETURNING — capture the post-merge row --------------
+        // `_sql_upsert_returning` returns `array<T>` (always one row in
+        // practice; the array shape mirrors `_sql_update_returning`).
+        // SQL: INSERT INTO "WordHits" (...) VALUES (?,?,?,?)
+        //      ON CONFLICT("Id") DO UPDATE SET "Hits" = "WordHits"."Hits" + 1
+        //      RETURNING "Id","Word","Hits","Last"
+        let after <- db |> _sql_upsert_returning(
+            WordHit(Id = 1, Word = "hello", Hits = 1, Last = 0l),
+            _.Id,
+            (Hits = _.Hits + 1))
+        for (w in after) {
+            to_log(LOG_INFO, "after upsert: {w.Word} hits = {w.Hits}\n")
+        }
+
+        // (e) try_ non-panic variants ------------------------------------
+        // Each upsert variant has a `try_` sibling returning
+        // `Result<int, string>` (or `Result<array<T>, string>` for
+        // `_returning`). Useful when callers want to handle constraint
+        // violations without a panic.
+        let attempt = db |> _sql_try_upsert(
+            WordHit(Id = 1, Word = "hello", Hits = 1, Last = 0l),
+            _.Id,
+            (Hits = _.Hits + 1))
+        if (attempt |> is_err) {
+            to_log(LOG_ERROR, "upsert failed: {attempt |> unwrap_err}\n")
+        } else {
+            to_log(LOG_INFO, "try_upsert touched {attempt |> unwrap} row(s)\n")
+        }
+
+        let try_ig = db |> try_insert_or_ignore(
+            WordHit(Id = 5, Word = "five", Hits = 1, Last = 0l))
+        to_log(LOG_INFO, "try_insert_or_ignore: {try_ig |> unwrap}\n")
+    }
+}

--- a/tutorials/sql/23-foreign_keys.das
+++ b/tutorials/sql/23-foreign_keys.das
@@ -1,0 +1,143 @@
+options gen2
+
+require daslib/sql
+require daslib/option
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 23 — foreign keys: the DDL-side of relationships.
+//
+// dasSQLITE ships only the DDL half of the FK story: a child column
+// names its parent struct via `@sql_references`, optional `@sql_on_delete`
+// and `@sql_on_update` pick the integrity action. There are no
+// navigation properties (no `_include`, no `u.Orders` shortcut) — to
+// query across a relationship use `_join` (tutorial 15) or `_any` /
+// `_in` correlated subqueries (tutorial 17).
+//
+// `with_sqlite` enables `PRAGMA foreign_keys=ON` on every connection.
+// SQLite ships the pragma OFF for back-compat with pre-3.6.19 databases;
+// without it FK clauses are parsed and stored but never enforced — orphans
+// silently appear and CASCADE silently no-ops. dasSQLITE turns it on
+// always.
+
+// --- annotation shape (per-field decorators) --------------------------
+//
+//   @sql_references = "ParentTypeName"
+//   @sql_on_delete  = "cascade" | "set_null" | "set_default"
+//                       | "restrict" | "no_action"
+//   @sql_on_update  = (same value set as on_delete)
+//
+// Each decorator is a separate `@name = value` line — daslang field
+// annotations are scalar key/value pairs, not function-call shapes.
+//
+// `@sql_references` resolves at `[sql_table]` expansion time: it finds
+// the named struct in the same module, reads its `[sql_table(name=...)]`
+// to get the table name, and finds the `@sql_primary_key` field. Defaults
+// when omitted: `on_delete = "no_action"`, `on_update = "no_action"`.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+
+    // CASCADE: deleting a User auto-deletes their Orders.
+    @sql_references = "User"
+    @sql_on_delete = "cascade"
+    UserId : int
+
+    Total : float
+}
+
+// `set_null` requires the column be `Option<T>` so SQLite can write NULL
+// when the parent goes away. The `[sql_table]` macro rejects the
+// combination at compile time if the column is plain `T`.
+[sql_table(name = "Comments")]
+struct Comment {
+    @sql_primary_key Id : int
+
+    @sql_references = "User"
+    @sql_on_delete = "set_null"
+    @safe_when_uninitialized AuthorId : Option<int>
+
+    Body : string
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        // Drop in child-first order; create parent-first. The FK clause in
+        // Orders names Users, so Users must exist when Orders is created.
+        db |> drop_table_if_exists(type<Comment>)
+        db |> drop_table_if_exists(type<Order>)
+        db |> drop_table_if_exists(type<User>)
+        db |> create_table(type<User>)
+        db |> create_table(type<Order>)
+        db |> create_table(type<Comment>)
+
+        // --- seed data --------------------------------------------------
+        db |> insert([
+            User(Id = 1, Name = "alice"),
+            User(Id = 2, Name = "bob")
+        ])
+        db |> insert([
+            Order(Id = 100, UserId = 1, Total = 42.0f),
+            Order(Id = 101, UserId = 1, Total = 99.0f),
+            Order(Id = 102, UserId = 2, Total = 7.5f)
+        ])
+        db |> insert([
+            Comment(Id = 1000, AuthorId = some(1), Body = "alice's"),
+            Comment(Id = 1001, AuthorId = some(2), Body = "bob's")
+        ])
+
+        // (a) ON DELETE CASCADE — child rows follow the parent ----------
+        // SQL: DELETE FROM "Users" WHERE "Id" = ?
+        //      (SQLite cascades internally to DELETE FROM "Orders"
+        //       WHERE "UserId" = 1)
+        db |> _sql_delete(type<User>, _.Id == 1)
+        let alice_orders = _sql(db |> select_from(type<Order>) |> _where(_.UserId == 1) |> count())
+        to_log(LOG_INFO, "alice's orders after cascade: {alice_orders} (expect 0)\n")
+
+        // (b) ON DELETE SET NULL — child column nulled out ---------------
+        // The first DELETE above (alice) already nulled out comment 1000
+        // because Comments.AuthorId points at Users with `set_null`.
+        // Deleting bob nulls out his comment too. Both AuthorId columns
+        // now hold NULL — surfaced as `Option<int>::None` in daslang.
+        // SQL: DELETE FROM "Users" WHERE "Id" = ?
+        //      (SQLite cascades internally to UPDATE "Comments"
+        //       SET "AuthorId" = NULL WHERE "AuthorId" = 2)
+        db |> _sql_delete(type<User>, _.Id == 2)
+        let comments <- _sql(db |> select_from(type<Comment>) |> _to_array())
+        for (c in comments) {
+            let author_str = c.AuthorId |> is_some ? "{c.AuthorId |> unwrap}" : "<null>"
+            to_log(LOG_INFO, "comment {c.Id}: author = {author_str}\n")
+        }
+
+        // (c) FK violations surface through try_insert -------------------
+        // The orphan UserId 9999 has no matching parent row; SQLite
+        // rejects the INSERT with "FOREIGN KEY constraint failed".
+        let res = db |> try_insert(Order(Id = 999, UserId = 9999, Total = 1.0f))
+        if (res |> is_err) {
+            to_log(LOG_ERROR, "orphan rejected: {res |> unwrap_err}\n")
+        }
+    }
+}
+
+// --- on_delete / on_update reference table ----------------------------
+//
+//   "cascade"      → CASCADE        propagate the change to children
+//   "set_null"     → SET NULL       (requires Option<T> on the FK column)
+//   "set_default"  → SET DEFAULT    (requires a daslang field initializer
+//                                    or @sql_default_fn — see tut 25)
+//   "restrict"     → RESTRICT       reject the change immediately
+//   "no_action"    → NO ACTION      reject at constraint-check time (the
+//                                    SQL standard default)
+//
+// Querying across the relationship is always explicit — no nav properties.
+// See tutorial 15 for `_join` (inner) and tutorial 16 for `_left_join`,
+// or tutorial 17 for `_any` / `_in` correlated subqueries when only the
+// existence of a match matters.

--- a/tutorials/sql/24-indexes.das
+++ b/tutorials/sql/24-indexes.das
@@ -1,0 +1,114 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 24 — indexes: declaring `CREATE INDEX` from struct annotations.
+//
+// SHAPE: `[sql_index(fields = ..., unique = ..., name = ...)]` is a
+// sibling annotation alongside `[sql_table]`. Both must live in the
+// **same** bracket pair, comma-separated, and `[sql_table]` must come
+// first — `[sql_index]` rewrites a helper that `[sql_table]` emits.
+//
+//   [sql_table(name = "Users"),
+//    sql_index(fields = "Email", unique = true),
+//    sql_index(fields = ("City", "LastSeen")),
+//    sql_index(fields = "LastSeen")]
+//   struct User { ... }
+//
+// `fields=` accepts a single string or a tuple of strings (composite
+// index). `unique` defaults to `false`. `name` defaults to
+// `idx_<table>_<col1>[_<col2>...]`.
+//
+// `[sql_table]` validates every field name against the struct fields at
+// macro-expansion time. Misspellings produce a compile error with the
+// list of valid columns.
+//
+// Indexes themselves are transparent to query code — the SQLite planner
+// uses them automatically. The only user-visible effect outside DDL is
+// that a `UNIQUE INDEX` lets the upsert composite-conflict path (tut 21)
+// resolve `tuple(_.A, _.B)` against a real constraint.
+
+[sql_table(name = "Users"),
+ sql_index(fields = "Email", unique = true),
+ sql_index(fields = ("City", "LastSeen")),
+ sql_index(fields = "LastSeen", name = "ix_users_lastseen")]
+struct User {
+    @sql_primary_key Id : int
+    Email : string
+    Name : string
+    City : string
+    LastSeen : int64
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        // `create_table` runs the CREATE TABLE statement followed by the
+        // accumulated CREATE INDEX statements in source order, all inside
+        // a single transaction (so a failing index rolls the whole table
+        // creation back).
+        // SQL emitted:
+        //   CREATE TABLE "Users" (...);
+        //   CREATE UNIQUE INDEX "idx_Users_Email" ON "Users" ("Email");
+        //   CREATE INDEX "idx_Users_City_LastSeen" ON "Users" ("City", "LastSeen");
+        //   CREATE INDEX "ix_users_lastseen" ON "Users" ("LastSeen");
+        db |> create_table(type<User>)
+
+        // The DDL helper that the macro generates is callable directly —
+        // useful for migration scripts and test asserts.
+        let idx_sql = _sql_create_indexes_sql(type<User>)
+        to_log(LOG_INFO, "index DDL: {idx_sql}\n")
+
+        // Querying ignores indexes entirely — the planner uses them
+        // automatically. Same chain regardless of what's indexed.
+        // SQL: SELECT ... FROM "Users" WHERE "Email" = ? LIMIT 1
+        //      (uses idx_Users_Email)
+        db |> insert([
+            User(Id = 1, Email = "alice@x.com", Name = "alice", City = "SF",  LastSeen = 100l),
+            User(Id = 2, Email = "bob@x.com",   Name = "bob",   City = "SF",  LastSeen = 200l),
+            User(Id = 3, Email = "carol@x.com", Name = "carol", City = "NYC", LastSeen = 300l)
+        ])
+        let alice = _sql(db |> select_from(type<User>)
+                            |> _where(_.Email == "alice@x.com") |> _first())
+        to_log(LOG_INFO, "lookup-by-email hit {alice.Name}\n")
+
+        // The composite index supports queries that filter on `City`
+        // (or `City + LastSeen`) and order by `LastSeen` — SQLite walks
+        // the index in order without a separate sort step.
+        // SQL: SELECT ... FROM "Users" WHERE "City" = ?
+        //                                ORDER BY "LastSeen" DESC
+        //      (uses idx_Users_City_LastSeen for both filter and sort)
+        let sf_recent <- _sql(db |> select_from(type<User>)
+                                  |> _where(_.City == "SF")
+                                  |> _order_by_descending(_.LastSeen)
+                                  |> _to_array())
+        for (u in sf_recent) {
+            to_log(LOG_INFO, "SF user (recent first): {u.Name} @ {u.LastSeen}\n")
+        }
+
+        // UNIQUE-INDEX violations surface through `try_insert`.
+        // SQL: INSERT INTO "Users" (...) VALUES (?,...,?)
+        //      → SQLite rejects: "UNIQUE constraint failed: Users.Email"
+        let dup = User(Id = 4, Email = "alice@x.com", Name = "alice2",
+                       City = "LA", LastSeen = 0l)
+        let res = db |> try_insert(dup)
+        if (res |> is_err) {
+            to_log(LOG_ERROR, "duplicate email rejected: {res |> unwrap_err}\n")
+        }
+    }
+}
+
+// --- composite UNIQUE for upsert composite-conflict --------------------
+//
+// `_sql_upsert(row, tuple(_.A, _.B), do_update)` (tutorial 21) requires
+// a UNIQUE constraint covering the same column set. `[sql_index(unique
+// = true, fields = ("A", "B"))]` is how you declare one — there is no
+// separate `[sql_unique]` table-level annotation.
+//
+// Single-column uniqueness can use either `@sql_unique` on the field
+// (emits `UNIQUE` directly in the column DDL) or `[sql_index(unique =
+// true, fields = "Col")]` (separate `CREATE UNIQUE INDEX`). Both work
+// for the upsert path; the index form is preferable when you also need
+// to control the index name.

--- a/tutorials/sql/25-defaults_computed.das
+++ b/tutorials/sql/25-defaults_computed.das
@@ -1,0 +1,131 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 25 — column defaults and computed (generated) columns.
+//
+// THREE WAYS TO DEFAULT A COLUMN:
+//
+//   (1) Native daslang field initializer — the literal becomes the SQL
+//       DEFAULT clause:
+//           Active : bool = true            -> DEFAULT 1
+//           Quantity : int = 100            -> DEFAULT 100
+//           Tag : string = "unknown"        -> DEFAULT 'unknown'
+//       Supports bool / int / int64 / float / double / string literals.
+//       Non-literal initializers (e.g. `some(5)`) are silently dropped
+//       from the DDL but still construct in daslang.
+//
+//   (2) `@sql_default_fn = "FN"` — whitelisted SQL built-ins:
+//           CURRENT_TIMESTAMP, CURRENT_DATE, CURRENT_TIME
+//       Use this when SQLite must compute the default at INSERT time
+//       (e.g. timestamps).
+//
+// COMPUTED COLUMNS via `@sql_computed = "expression"`:
+//   - Default storage is VIRTUAL (recomputed on every read).
+//   - Add `@sql_stored = true` for STORED (materialized on write).
+//   - The expression is passed verbatim to SQLite — column refs and
+//     function names are validated by SQLite at CREATE TABLE time.
+//   - INSERT and UPDATE bind paths skip computed columns automatically;
+//     SELECT reads them as ordinary columns.
+//   - `[sql_table]` rejects: `@sql_primary_key + @sql_computed`,
+//     `@sql_computed + field initializer`, `@sql_computed +
+//     @sql_default_fn`, `field initializer + @sql_default_fn`.
+
+[sql_table(name = "Items")]
+struct Item {
+    @sql_primary_key Id : int
+
+    Name : string
+
+    // (1) literal default via daslang field init.
+    Active : bool = true
+    Quantity : int = 100
+    Tag : string = "unknown"
+
+    // (2) SQL built-in default.
+    @sql_default_fn = "CURRENT_TIMESTAMP"
+    CreatedAt : string
+
+    // VIRTUAL computed column — re-derived on every SELECT.
+    @sql_computed = "Quantity * 2"
+    DoubleQty : int
+
+    // STORED computed column — materialized on INSERT/UPDATE, read
+    // straight off disk on SELECT.
+    @sql_computed = "Quantity + 1"
+    @sql_stored = true
+    QtyPlusOne : int
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Item>)
+
+        // The DDL helper is callable directly — handy for inspection
+        // and migration scripts.
+        // Sample fragment of what `_sql_create_table_sql(type<Item>)`
+        // emits for the columns above:
+        //   "Active"     INTEGER NOT NULL DEFAULT 1,
+        //   "Quantity"   INTEGER NOT NULL DEFAULT 100,
+        //   "Tag"        TEXT    NOT NULL DEFAULT 'unknown',
+        //   "CreatedAt"  TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        //   "DoubleQty"  INTEGER GENERATED ALWAYS AS (Quantity * 2) VIRTUAL,
+        //   "QtyPlusOne" INTEGER GENERATED ALWAYS AS (Quantity + 1) STORED
+        let ddl = _sql_create_table_sql(type<Item>)
+        to_log(LOG_INFO, "DDL:\n{ddl}\n")
+
+        // (a) Macro-generated INSERT binds every NON-COMPUTED column ----
+        // The struct field's value is what gets written; defaults never
+        // fire through this path. Computed columns are skipped — SQLite
+        // computes them itself, so any value the struct holds for
+        // `DoubleQty` / `QtyPlusOne` is ignored.
+        // SQL: INSERT INTO "Items" ("Id","Name","Active","Quantity","Tag",
+        //                           "CreatedAt") VALUES (?,?,?,?,?,?)
+        db |> insert(Item(Id = 1, Name = "thing", Active = true, Quantity = 7,
+                          Tag = "t", CreatedAt = "",
+                          DoubleQty = 9999, QtyPlusOne = 9999))
+        let r1 = _sql(db |> select_from(type<Item>) |> _where(_.Id == 1) |> _first())
+        to_log(LOG_INFO, "row 1: Quantity={r1.Quantity} DoubleQty={r1.DoubleQty} QtyPlusOne={r1.QtyPlusOne}\n")
+
+        // (b) Defaults fire when the column is omitted from the INSERT --
+        // The macro INSERT always names every non-computed column, so
+        // the DEFAULT clause only fires from raw SQL or column-list
+        // forms that omit the column.
+        // SQL: INSERT INTO "Items" ("Id","Name") VALUES (?,?)
+        //      → "Active" DEFAULT 1, "Quantity" DEFAULT 100,
+        //        "Tag" DEFAULT 'unknown', "CreatedAt" DEFAULT
+        //        CURRENT_TIMESTAMP all fire
+        db |> exec("INSERT INTO Items (Id, Name) VALUES (2, 'defaulted')")
+        let r2 = _sql(db |> select_from(type<Item>) |> _where(_.Id == 2) |> _first())
+        to_log(LOG_INFO, "row 2 (defaulted): Active={r2.Active} Quantity={r2.Quantity} Tag={r2.Tag}\n")
+        to_log(LOG_INFO, "row 2 CreatedAt length: {length(r2.CreatedAt)} (expect ≥ 19)\n")
+
+        // (c) UPDATE re-derives computed columns automatically ----------
+        // Mutating `Quantity` is enough — the SET clause omits any
+        // `@sql_computed` column (rejected at macro-compile time, so a
+        // typo reaches the user). DoubleQty / QtyPlusOne update behind
+        // the scenes when SQLite re-evaluates the expression.
+        // SQL: UPDATE "Items" SET "Quantity" = ? WHERE "Id" = ?
+        db |> _sql_update(type<Item>, _.Id == 1, (Quantity = 11))
+        let r1b = _sql(db |> select_from(type<Item>) |> _where(_.Id == 1) |> _first())
+        to_log(LOG_INFO, "after update: Quantity={r1b.Quantity} DoubleQty={r1b.DoubleQty} QtyPlusOne={r1b.QtyPlusOne}\n")
+    }
+}
+
+// --- VIRTUAL vs STORED ------------------------------------------------
+//
+// VIRTUAL (the default): the expression is recomputed on every SELECT.
+// Cheap to write, slightly more expensive to read, no disk cost.
+//
+// STORED: the expression is evaluated on INSERT/UPDATE and persisted.
+// Faster reads, more disk, the computed value is part of the row layout
+// (so changing the expression requires drop + recreate — neither form
+// supports ALTER TABLE on the expression).
+//
+// Use STORED when the expression is expensive and reads dominate writes.
+// Default to VIRTUAL otherwise.
+//
+// SQLITE 3.31+ is required for generated columns.


### PR DESCRIPTION
## Summary

Adds the merge-on-conflict write path and the rest of the `[sql_table]` schema decorators (defaults / computed columns / foreign keys / indexes), shipping tutorials 21 / 23 / 24 / 25. Builds on chunk 6 (UPDATE / DELETE / Transactions, PR #2507).

### UPSERT macros (`sqlite_linq.das`)

- `_sql_upsert(row, on_conflict, do_update)` — `INSERT … ON CONFLICT … DO UPDATE SET …`, returns rows-affected `int`.
- `_sql_try_upsert` (Result), plus `_sql_upsert_returning` / `_sql_try_upsert_returning` (`array<T>` of post-merge rows).
- `on_conflict` accepts `_.Col` (single) or `tuple(_.A, _.B)` (composite); `do_update` is a named-tuple `(Col = expr, ...)` with `_` for the existing row and `_excluded` for the proposed row.
- Composite conflict targets need a UNIQUE constraint over the same columns — declared via `[sql_index(unique = true, fields = (...))]`.
- Arithmetic operators (`+ - * / %`) added to `pred_to_sql` so the SET clause can express `Hits = _.Hits + 1`.

### Plain "INSERT OR X" functions (`sqlite_boost.das`)

`insert_or_ignore` / `insert_or_replace` (single + bulk + `try_` siblings). Implemented via runtime SQL substitution (`OR IGNORE` / `OR REPLACE`) against the existing INSERT-prepared statements — no new generated helpers.

### `[sql_table]` schema decorators (per-field)

- `@sql_unique` — single-column UNIQUE in the column DDL.
- `@sql_default_fn = "FN"` — whitelisted SQL built-ins (`CURRENT_TIMESTAMP` / `CURRENT_DATE` / `CURRENT_TIME`).
- Native field initializer for literal SQL DEFAULTs: `Active : bool = true` becomes ` DEFAULT 1` (bool / int / int64 / float / double / string).
- `@sql_computed = "expression"` (+ optional `@sql_stored = true` for STORED instead of VIRTUAL); excluded from INSERT / UPDATE bind paths automatically.
- `@sql_references = "Parent"` + optional `@sql_on_delete` / `@sql_on_update` (cascade / set_null / set_default / restrict / no_action).

Validation is fail-fast — every non-sensical combination produces a `30111` structure_macro error pointing at the offending struct (12 rules covered in `failed_sql_table_schema.das`).

### `[sql_index]` sibling annotation

Lives inside the same bracket as `[sql_table]`, comma-separated, with `[sql_table]` first. Each `[sql_index].apply()` body-rewrites the empty `_sql_create_indexes_sql` helper that `[sql_table]` emits to append a `CREATE INDEX` statement (Boris's body-rewrite pattern, since the annotation list isn't fully populated during `apply()`).

### Other

- Computed columns are skipped from INSERT and UPDATE bind paths (`test_02` expectation tightened to require column-list form); SELECT and read paths read them as ordinary columns.
- `with_sqlite` enables `PRAGMA foreign_keys = ON` so FK constraints actually fire.

## Test plan

- [x] `bin/Release/daslang.exe utils/lint/main.das -- modules/dasSQLITE/daslib/sqlite_boost.das modules/dasSQLITE/daslib/sqlite_linq.das tests/dasSQLITE/...` (PERF007 cleanups; PERF006 left in cold macro paths)
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/dasSQLITE/` — **309 / 309 pass** (271 + 38 new across `test_52`–`test_60` and three `failed_*.das` files)
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/` — **7175 / 7175 interpreted pass**
- [x] `cmake --build build --config Release --target test_aot` then `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — **6587 / 6587 AOT pass**
- [x] MCP `format_file` clean across all 19 changed `.das` files
- [x] No GC leaks in dasSQLITE suite