### PR TITLE
dasSQLITE: chunk 8 — custom-types adapter rail + BLOB + backlog drain

### DIFF
--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -314,6 +314,8 @@ Run any tutorial from the project root::
    tutorials/sql_23_foreign_keys.rst
    tutorials/sql_24_indexes.rst
    tutorials/sql_25_defaults_computed.rst
+   tutorials/sql_26_custom_types.rst
+   tutorials/sql_27_blob.rst
 
 .. _tutorials_dasaudio:
 

--- a/doc/source/reference/tutorials/sql_25_defaults_computed.rst
+++ b/doc/source/reference/tutorials/sql_25_defaults_computed.rst
@@ -138,3 +138,5 @@ Generated columns require SQLite 3.31+ (2019-10-10).
     Full source: :download:`tutorials/sql/25-defaults_computed.das <../../../../tutorials/sql/25-defaults_computed.das>`
 
     Previous tutorial: :ref:`tutorial_sql_indexes`
+
+    Next tutorial: :ref:`tutorial_sql_custom_types`

--- a/doc/source/reference/tutorials/sql_26_custom_types.rst
+++ b/doc/source/reference/tutorials/sql_26_custom_types.rst
@@ -1,0 +1,202 @@
+.. _tutorial_sql_custom_types:
+
+==========================================
+SQL-26 --- Custom type adapters
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; sql_bind
+    single: Tutorial; sql_extract
+    single: Tutorial; custom type
+    single: Tutorial; type adapter
+    single: Tutorial; DateTime
+    single: Tutorial; Guid
+    single: Tutorial; enum
+
+Convention-based type adapters: every SQL-addressable user type ``T``
+defines a bidirectional pair of named functions, and the
+``[sql_table]`` macro picks them up automatically. No registration
+step.
+
+The two-function pair
+=====================
+
+.. code-block:: das
+
+    def sql_bind    (v : T)            : P              // T -> primitive
+    def sql_extract (v : P; t : type<T>) : T            // primitive -> T
+
+``P`` must be one of the four SQLite storage primitives:
+
+==================   ====================
+Return type          SQLite column type
+==================   ====================
+``int64``            ``INTEGER``
+``double``           ``REAL``
+``string``           ``TEXT``
+``array<uint8>``     ``BLOB``
+==================   ====================
+
+The **return type of** ``sql_bind`` **is the storage type**. The
+``[sql_table]`` macro reads it via ``typedecl`` at expansion time and
+emits the matching ``sqlite3_bind_*`` / ``sqlite3_column_*`` calls,
+plus the matching DDL column type.
+
+NULL is handled orthogonally by ``Option<T>`` from tut 18; this rail
+covers four storage forms, not five.
+
+How dispatch works
+==================
+
+The ``[sql_table]`` macro emits ``_::sql_bind(...)`` and
+``_::sql_extract(...)``. ``_::`` is "calling-module name lookup", so
+every ``sql_bind`` overload in scope at the call site --- including
+the user's type-specific pair --- participates in overload
+resolution. Same mechanism as ``_::clone`` and ``_::finalize``.
+
+Built-in adapters ship in ``sqlite_boost`` for:
+
+* The four primitives (passthrough).
+* Stdlib widenings: ``int`` / ``int8`` / ``int16`` / ``uint`` /
+  ``uint8`` / ``uint16`` / ``uint64`` round-trip through ``int64``;
+  ``float`` round-trips through ``double``; ``bool`` round-trips
+  through ``int64`` (``true`` -> ``1``).
+* A single enum generic ``def sql_bind $T (e : T) : int64 where T :
+  enum`` (and the matching ``sql_extract``) so any enum auto-
+  round-trips through ``INTEGER``.
+
+User code only writes adapters for domain types.
+
+Example: DateTime as INTEGER
+============================
+
+.. code-block:: das
+
+    struct DateTime {
+        unix_seconds : int64
+    }
+
+    def sql_bind(dt : DateTime) : int64 {
+        return dt.unix_seconds
+    }
+
+    [unused_argument(t)]
+    def sql_extract(v : int64; t : type<DateTime>) : DateTime {
+        return DateTime(unix_seconds = v)
+    }
+
+The ``[unused_argument(t)]`` annotation is there because the
+``type<DateTime>`` parameter is a compile-time tag for overload
+discrimination only; the function body never reads it.
+
+Storage choice rationale: integer is indexable, compact, and
+math-friendly. For ISO8601 text storage instead, write a pair whose
+``sql_bind`` returns ``string`` --- one storage form per type at
+module level (``@sql_as(type<P>)`` per-field override is deferred).
+
+Example: Guid as BLOB
+=====================
+
+Same pattern, different primitive. ``array<uint8>`` selects the
+``BLOB`` column type:
+
+.. code-block:: das
+
+    struct Guid {
+        @safe_when_uninitialized bytes : array<uint8>
+    }
+
+    def sql_bind(g : Guid) : array<uint8> {
+        var copy : array<uint8>
+        copy := g.bytes
+        return <- copy
+    }
+
+    [unused_argument(t)]
+    def sql_extract(var v : array<uint8>; t : type<Guid>) : Guid {
+        return Guid(bytes <- v)
+    }
+
+For multi-MB asset blobs, prefer SQLite's ``sqlite3_blob_open``
+streaming API over an adapter that copies on every bind.
+
+Schema using all three custom types
+===================================
+
+.. code-block:: das
+
+    enum OrderStatus {
+        Pending
+        Paid
+        Shipped
+        Cancelled
+    }
+
+    [sql_table(name = "Orders")]
+    struct Order {
+        @sql_primary_key Id : int
+        ExternalId : Guid           // BLOB column
+        PlacedAt   : DateTime       // INTEGER column
+        Status     : OrderStatus    // INTEGER column (enum generic)
+        Total      : float          // REAL column (stdlib widening)
+    }
+
+Emitted DDL:
+
+.. code-block:: sql
+
+    CREATE TABLE "Orders"(
+        "Id"         INTEGER PRIMARY KEY,
+        "ExternalId" BLOB    NOT NULL,
+        "PlacedAt"   INTEGER NOT NULL,
+        "Status"     INTEGER NOT NULL,
+        "Total"      REAL    NOT NULL
+    )
+
+``Option<T>`` composes automatically
+====================================
+
+``Option<DateTime>`` works as long as ``DateTime`` has the adapter
+pair. The macro unwraps the ``Option`` at runtime: ``some(dt)`` binds
+through ``sql_bind(dt)``; ``none()`` binds NULL. Read-side, ``NULL``
+becomes ``none()`` and a present value is decoded through
+``sql_extract``.
+
+.. code-block:: das
+
+    [sql_table(name = "Events")]
+    struct Event {
+        @sql_primary_key Id : int
+        At : DateTime
+        @safe_when_uninitialized StartsAt : Option<DateTime>
+    }
+
+Missing-adapter compile error
+=============================
+
+If a ``[sql_table]`` field has no ``sql_bind`` / ``sql_extract`` pair
+in scope, overload resolution fails at the macro-emitted ``_::sql_bind``
+call:
+
+.. code-block:: das
+
+    struct Color { r, g, b : float }
+
+    [sql_table(name = "Styles")]
+    struct Style {
+        @sql_primary_key Id : int
+        Bg : Color           // no sql_bind(Color) - compile error
+    }
+
+Compiler message names the offending struct + field type. No runtime
+"type not registered" error --- this is all compile-time.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/26-custom_types.das <../../../../tutorials/sql/26-custom_types.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_defaults_computed`
+
+    Next tutorial: :ref:`tutorial_sql_blob`

--- a/doc/source/reference/tutorials/sql_27_blob.rst
+++ b/doc/source/reference/tutorials/sql_27_blob.rst
@@ -1,0 +1,127 @@
+.. _tutorial_sql_blob:
+
+==========================================
+SQL-27 --- BLOB round-trip
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; BLOB
+    single: Tutorial; binary data
+    single: Tutorial; array<uint8>
+
+``array<uint8>`` is one of the four primitive storage types in the
+:ref:`tut-26 adapter rail <tutorial_sql_custom_types>`, so a
+``[sql_table]`` field of that type round-trips through a ``BLOB``
+column with no extra annotation:
+
+.. code-block:: das
+
+    [sql_table(name = "Images")]
+    struct Image {
+        @sql_primary_key Id : int
+        Name : string
+        @safe_when_uninitialized Data : array<uint8>
+    }
+
+The ``[sql_table]`` macro:
+
+* Emits the ``BLOB`` column type in the DDL.
+* Routes ``INSERT`` through ``sqlite3_bind_blob`` with
+  ``SQLITE_TRANSIENT`` (SQLite copies into its own buffer).
+* Materializes a fresh ``array<uint8>`` per row on ``SELECT``,
+  copying from the column pointer (which is only valid until the
+  next ``step`` / ``reset``).
+
+Three tradeoffs to keep in mind
+===============================
+
+* **Two copies on insert.** ``SQLITE_TRANSIENT`` makes SQLite's own
+  copy after the bind call. For multi-MB asset blobs, prefer
+  SQLite's ``sqlite3_blob_open`` streaming API or chunked storage.
+* **One copy on read.** Each row materializes a fresh
+  ``array<uint8>`` --- the column pointer can't escape the cursor
+  position. Streaming reads need ``sqlite3_blob_read`` directly.
+* **Nullable BLOB columns** use ``Option<array<uint8>>``, the same
+  pattern as nullable scalars in :ref:`tut 18 <tutorial_sql_null_handling>`.
+
+End-to-end example
+==================
+
+.. code-block:: das
+
+    require daslib/sql
+    require sqlite/sqlite_boost
+    require sqlite/sqlite_linq
+
+    [sql_table(name = "Images")]
+    struct Image {
+        @sql_primary_key Id : int
+        Name : string
+        @safe_when_uninitialized Data : array<uint8>
+    }
+
+    [export]
+    def main {
+        with_sqlite(":memory:") $(db) {
+            db |> create_table(type<Image>)
+
+            var hello : array<uint8>
+            hello |> resize(11)
+            for (i in range(11)) {
+                hello[i] = uint8(0x40 + i)
+            }
+            db |> insert(Image(Id = 1, Name = "hello", Data <- hello))
+
+            // SELECT: read_via_adapter routes through the BLOB
+            // primitive case, allocates a fresh array per row.
+            let images <- _sql(db |> select_from(type<Image>))
+            for (img in images) {
+                to_log(LOG_INFO, "{img.Name} ({length(img.Data)} bytes)\n")
+            }
+
+            // query_scalar over a BLOB function (LENGTH() returns int64).
+            let total = db |> query_scalar(
+                "SELECT SUM(LENGTH(Data)) FROM Images", type<int64>)
+            to_log(LOG_INFO, "total bytes: {total}\n")
+        }
+    }
+
+Empty BLOB vs NULL
+==================
+
+An empty ``array<uint8>`` (length 0) binds as a zero-length BLOB ---
+distinct from NULL. SQLite's ``LENGTH()`` on an empty BLOB returns 0;
+``LENGTH()`` on NULL returns NULL. Use ``Option<array<uint8>>`` to
+represent the absent-value case.
+
+Internally the macro guards length-zero arrays and emits
+``sqlite3_bind_zeroblob(stmt, idx, 0)`` to avoid a panic on
+``addr(data[0])`` for empty arrays. The result is observationally
+identical to a non-zero-length empty BLOB.
+
+Future: streaming BLOB I/O
+==========================
+
+SQLite offers ``sqlite3_blob_open`` / ``sqlite3_blob_read`` /
+``sqlite3_blob_write`` for incremental access without materializing
+the whole blob in daslang's heap. Likely shape:
+
+.. code-block:: das
+
+    db |> open_blob(type<Image>, rowid, "Data") <| $(blob) {
+        var buf : array<uint8>
+        buf |> resize(4096)
+        blob |> read(offset, buf)
+    }
+
+EF Core doesn't expose this --- game asset and large-binary use cases
+typically live outside the ORM in dedicated APIs. dasSQLITE keeps the
+streaming path on the deferred list until a real workload demands it.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/27-blob.das <../../../../tutorials/sql/27-blob.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_custom_types`

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -531,6 +531,130 @@ dasSQLITE suite: **309 tests passing** (271 pre-chunk-7 + 38 new).
   upsert` (`Sql{Upsert,…}Macro` would change anyway) is one
   reasonable bundle.
 
+## Shipped — chunk 8: custom-types adapter rail + BLOB + backlog drain (branch `dassqlite-chunk8-custom-types`)
+
+Chunk 8 ships **tutorial 26 (custom type adapters)** and **tutorial 27
+(BLOB round-trip)**, plus two small deferred features and the dupe
+cleanup carried over from chunk 7. Tut 28 (JSON) was cut from this
+chunk — its `_sql` JSON-path walker rule deserves its own attention.
+
+### Custom-types adapter rail (`sqlite_boost.das`)
+
+- **Two-function name-based pair** — `_::sql_bind(value : T) : P` and
+  `_::sql_extract(stored : P; type<T>) : T`, where `P` is one of four
+  primitive storage types (`int64`, `double`, `string`, `array<uint8>`)
+  selected at macro-expansion from `_::sql_bind`'s return type.
+- **Module-scope overloads** for the four primitives (passthrough),
+  stdlib widenings (`int`/`int8`/`int16`/`uint`/`uint8`/`uint16`/
+  `uint64`/`float`/`bool` → primitives), and a single enum generic
+  guarded by `static_if (typeinfo is_enum(default<TT>))`. Users add
+  their own overloads at any module scope to register `DateTime`,
+  `Guid`, etc.
+- **Macro emission migrated** — the `[sql_table]` codegen routes
+  through the new `sql_bind_to_stmt(stmt, idx, v)` and
+  `read_via_adapter(stmt, col, type<T>)` helpers, plus a
+  `sql_storage_type_for(type<T>)` DDL emitter that derives the
+  column type from `_::sql_bind`'s return type via `typedecl`. Runtime
+  paths (`query_one` / `query_scalar` / raw `_sql` positional binds)
+  also route through these so user-defined adapters work uniformly.
+- **`Option<T>` over a custom adapter** — the bind/read sites unwrap
+  `Option<T>` to `T` and recurse, so `Option<DateTime>` Just Works as
+  long as `_::sql_bind`/`_::sql_extract` are defined for `DateTime`.
+- **Legacy rail removed** — `sqlite_bind` / `sqlite_read` /
+  `sqlite_sql_type` overload tables are gone.
+
+### Tut 27 — BLOB round-trip
+
+`array<uint8>` is one of the four adapter primitives, so a struct
+field of that type round-trips through a BLOB column with no extra
+annotation. No new core macro work was needed.
+
+### Backlog drain — small features
+
+- **`exec` / `try_exec` parameter binding** — 0/1/2/3-arg overloads
+  mirror the `query_one` shape (chunk 6 deferred). Routes through a
+  new private `try_exec_with_binds` helper.
+- **`_.Col == none()` → fixit `macro_error`** — `pred_to_sql`'s
+  equality handler detects `none()` on either side (both pre-typer
+  qmatch and post-typer `operator==(...)` shapes) and emits a
+  `macro_error` pointing the user at `is_none()` (chunk 4 D4 deferred).
+
+### Side bug fixes
+
+- **`sqlite3_bind_blob` wrapper had a hardcoded `index = 1`** —
+  pre-existing; never noticed because nothing tested BLOB from
+  `[sql_table]` before. Now uses the caller's `index` parameter.
+- **Empty `array<uint8>` bind** — guarded with
+  `length == 0 → sqlite3_bind_zeroblob(stmt, index, 0)` to avoid
+  `addr(data[0])` panic on zero-length arrays.
+- **`is_const_or_captured_var` missed enum / bitfield literals** —
+  `_where(_.Status == OrderStatus.Paid)` was emitting incomplete SQL
+  (`WHERE "Status" = ` with no bind). Added `ExprConstEnumeration`,
+  `ExprConstBitfield`, and the missing int8/16 / uint8/16 forms to
+  the recognizer.
+
+### Pre-existing dupe cleanup (5 items, all from chunk-7 deferred list)
+
+1. **`validate_outer_args(prog, call, rootT, expected_arity, sig_text)`**
+   — collapses `validate_outer_update_args` /
+   `validate_outer_delete_args`. All 8 callers updated.
+2. **`make_insert_sql_fn(st, name, fields, include_pk : bool)`** —
+   collapses `make_insert_with_pk_sql_fn` / `make_insert_no_pk_sql_fn`.
+   Emitted helper names stay stable
+   (`_sql_insert_with_pk_sql` / `_sql_insert_no_pk_sql`).
+3. **`find_annotation(args, argn, default_value : auto(TT)) : TT`** —
+   collapses `find_bool_annotation` / `find_string_annotation` via
+   `static_if (typeinfo is_string(default_value))` dispatch on
+   `tString` / `tBool`. ~20 call sites updated.
+4. **`try_run_dml_returning` ≡ `try_run_select`** — flagged by the
+   dupe agent but already factored: both are 1-line wrappers around
+   `try_collect_rows` with different `err_prefix`. The existing
+   factoring IS the dedupe; no code change needed.
+5. **`OuterArgZeroMacro` / `OuterArgTwoMacro` parents** —
+   `class private OuterArgZeroMacro : AstCallMacro` (overrides
+   `canVisitArgument` → `argIndex == 0`) and
+   `class private OuterArgTwoMacro : AstCallMacro`
+   (`argIndex < 2`). The 8 update/delete macros and 4 upsert macros
+   re-parent to these and drop their local `canVisitArgument`
+   overrides; each subclass keeps its own `[call_macro(name=...)]`
+   annotation since annotations don't inherit. Net: 12 × 3-line
+   override deletions, 2 × 4-line parent-class additions.
+
+### Tutorials
+
+- [tutorials/sql/26-custom_types.das](../../tutorials/sql/26-custom_types.das)
+  — `DateTime` via INTEGER, `Guid` via BLOB, enum auto-roundtrip,
+  `query_scalar` through adapters, `Option<DateTime>`, enum-in-where
+  predicate, DDL storage-type derivation.
+- [tutorials/sql/27-blob.das](../../tutorials/sql/27-blob.das) —
+  `array<uint8>` round-trip; derived from inherited
+  `tutorial/07-insert_image.das` + `08-read_image.das`.
+
+### Tests
+
+3 new test files: `test_61_custom_types.das` (7 tests),
+`test_62_blob.das` (6 tests), `test_63_exec_params.das` (6 tests).
+Plus 2 new entries in `failed_sql_macro.das` (`bad20` / `bad21` —
+the `_.Col == none()` fixit). Total dasSQLITE suite: **328 tests
+passing** (309 pre-chunk-8 + 19 new).
+
+### Deferred to chunk 9+
+
+- **Tut 28 — JSON columns** (`@sql_json` / `@sql_blob` annotations
+  + `_sql` JSON-path walker rule) — was cut from this chunk; ships
+  as its own headline.
+- **Per-field `@sql_as(type<P>)` override** — pick a non-default
+  storage primitive for a custom-type column when multiple
+  `_::sql_bind` overloads exist. Locked shape; awaiting user demand.
+- **Struct-type `_select(type<T2>)` projection** — needs a
+  `[sql_table]`-emitted compile-time field-list metadata helper.
+- **Bulk `array<T>` upsert** — carried from chunk 7 deferred.
+- **Composite foreign keys**, **partial / expression indexes**,
+  **function-reference `@sql_computed`**, **DEFAULT-firing from the
+  macro INSERT path** — all carried from chunk 7 deferred.
+- **Optimistic concurrency token, multi-table DELETE, named-tuple
+  bind for `query_one` / `exec`** — carried from earlier chunks.
+
 ## Shipped — chunk 4: read-side depth — distinct/take/skip/order_by/aggregates/group_by/NULL (branch `dassqlite-chunk4-read-depth`)
 
 Chunk 4 broadens the chunk-3 framework with the rest of the read-side

--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -250,9 +250,12 @@ new syntax to teach.
     [tutorials/sql/25-defaults_computed.das](../../tutorials/sql/25-defaults_computed.das)
     (chunk 7). Original mockup:
     [28-defaults_computed.das.mockup](tutorial-mockup/28-defaults_computed.das.mockup).
-26. **Custom type adapters** — name-based `bind_X` / `extract_X` pair;
-    no registration step; `DateTime`, enums, GUIDs via this rail.
-    Mockup: [29-custom_types.das](tutorial-mockup/29-custom_types.das.mockup).
+26. **Custom type adapters** — name-based `_::sql_bind` / `_::sql_extract`
+    overload pair, no registration step; four primitive storage types
+    (INTEGER / REAL / TEXT / BLOB) selected by the `sql_bind` return
+    type; `DateTime`, enums, GUIDs via this rail. Tutorial:
+    [26-custom_types.das](../../tutorials/sql/26-custom_types.das).
+    Original mockup: [29-custom_types.das](tutorial-mockup/29-custom_types.das.mockup).
 
 ## Part 6 — Non-scalar columns
 
@@ -261,10 +264,13 @@ here because by now the reader understands custom-type adapters.
 
 27. **BLOB round-trip** — insert a binary file, read it back. Merges
     inherited tutorials 07 + 08 since the API makes them a single
-    round-trip story. Introduces the `@sql_blob` field annotation (for
-    byte-sequence columns that shouldn't go through the custom-type
-    adapter rail). Mockup: **none yet — write new** (derived from
-    `tutorial/07-insert_image.das` + `tutorial/08-read_image.das`).
+    round-trip story. `array<uint8>` is one of the four primitive
+    storage types from the tut-26 adapter rail, so a `[sql_table]`
+    field of that type round-trips through a BLOB column with no
+    extra annotation. Tutorial:
+    [27-blob.das](../../tutorials/sql/27-blob.das). The
+    `@sql_blob` annotation for opaque struct serialization is a
+    different concept and lands with tut 28 (JSON / serialization).
 28. **JSON columns** — `@sql_json` field annotation, `_sql` JSON-path
     walker rule, round-tripping daslang types through SQLite JSON1.
     Mockup: [37-json.das](tutorial-mockup/37-json.das.mockup).
@@ -394,16 +400,16 @@ E. **Forward-looking: `dasSQL` abstraction layer** — the roadmap beyond
 | 15 | `_join` — inner equi-join | `23-joins.das` | Has mockup |
 | 16 | `_left_join` — outer | `23-joins.das` | Has mockup (shared) |
 | 17 | Subqueries | `24-subqueries.das` | Has mockup |
-| 18 | NULL handling — `Option<T>` | `18-null_handling.das` (`25-null_handling.das.mockup` shipped largely as designed; `_.Col == none()` diagnostic + projection-side `unwrap_or` deferred) | **Shipped** (chunk 4) |
-| 19 | UPDATE | `15-update.das` | **Shipped** (chunk 6); macros named `_sql_update` / `_sql_try_update` / `_sql_update_returning` / `_sql_try_update_returning`; raw `exec` parameter binding deferred to a later chunk |
+| 18 | NULL handling — `Option<T>` | `18-null_handling.das` (`25-null_handling.das.mockup` shipped largely as designed; `_.Col == none()` diagnostic shipped chunk 8; projection-side `unwrap_or` deferred) | **Shipped** (chunk 4); `_.Col == none()` fixit added in chunk 8 |
+| 19 | UPDATE | `15-update.das` | **Shipped** (chunk 6); macros named `_sql_update` / `_sql_try_update` / `_sql_update_returning` / `_sql_try_update_returning`; raw `exec` parameter binding shipped in chunk 8 |
 | 20 | DELETE | `16-delete.das` | **Shipped** (chunk 6); macros named `_sql_delete` / `_sql_try_delete` / `_sql_delete_returning` / `_sql_try_delete_returning`; CASCADE FK example deferred to tut 23 |
 | 21 | UPSERT | `21-upsert.das` | **Shipped** (chunk 7); `_sql_upsert` / `_sql_try_upsert` / `_sql_upsert_returning` / `_sql_try_upsert_returning`, `_excluded` sentinel, single + composite conflict targets via `tuple(_.A, _.B)`, plain-fn `insert_or_ignore` / `insert_or_replace` (single + bulk + `try_` for both) |
 | 22 | Transactions | `14-transaction.das` | **Shipped** (chunk 6); two-arity overload, `SqliteTxnMode` enum (Deferred/Immediate/Exclusive), savepoint nesting via `das_sp` name |
 | 23 | Foreign keys | `23-foreign_keys.das` | **Shipped** (chunk 7); `@sql_references = "Parent"` + optional `@sql_on_delete` / `@sql_on_update` (cascade / set_null / set_default / restrict / no_action); `with_sqlite` enables `PRAGMA foreign_keys = ON` |
 | 24 | Indexes | `24-indexes.das` | **Shipped** (chunk 7); `[sql_table, sql_index(fields = ..., unique = ..., name = ...)]` sibling annotation, single + composite, auto-name `idx_<table>_<col1>_<col2>` |
 | 25 | Defaults + computed | `25-defaults_computed.das` | **Shipped** (chunk 7); native field init for literal defaults (`Active : bool = true`), `@sql_default_fn` for SQL built-ins (CURRENT_TIMESTAMP / CURRENT_DATE / CURRENT_TIME), `@sql_computed = "expr"` (+ optional `@sql_stored = true`) |
-| 26 | Custom type adapters | `29-custom_types.das` | Has mockup |
-| 27 | BLOB round-trip | — | **Needs mockup** (merges inherited 07+08) |
+| 26 | Custom type adapters | `26-custom_types.das` | **Shipped** (chunk 8); `_::sql_bind` / `_::sql_extract` adapter pair, four primitive storage types (INTEGER / REAL / TEXT / BLOB), enum auto-roundtrip, return-type-driven DDL, `Option<T>` over a custom adapter; per-field `@sql_as(type<P>)` override deferred |
+| 27 | BLOB round-trip | `27-blob.das` | **Shipped** (chunk 8); `array<uint8>` is one of the four adapter primitives — falls out of tut 26 |
 | 28 | JSON columns | `37-json.das` | Has mockup |
 | 29 | Column names | — | **Needs mockup** (from inherited 09) |
 | 30 | Listing tables | — | **Needs mockup** (from inherited 10) |

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -30,9 +30,19 @@ def sqlite3_free(std : string) {
 
 [expect_any_array(data)]
 def sqlite3_bind_blob(stmt : sqlite3_stmt?; index : int; data) {
-    //! Binds a blob value to a prepared statement.
+    //! Binds a blob value to a prepared statement at ``index``. SQLite
+    //! makes its own copy via ``SQLITE_TRANSIENT`` (the default in this
+    //! wrapper), so the caller's array can release after the call.
+    //! Empty blobs route through ``sqlite3_bind_zeroblob`` with ``n=0``
+    //! to avoid taking ``addr(data[0])`` on a zero-length array.
+    if (data |> length == 0) {
+        return sqlite3_bind_zeroblob(stmt, index, 0)
+    }
     unsafe {
-        return sqlite3_bind_blob(stmt, 1, unsafe(addr(data[0])), data |> length)
+        // Byte count = element_count * sizeof(element). The wrapper
+        // accepts any array via [expect_any_array]; ``length`` alone is
+        // only correct for ``array<uint8>``.
+        return sqlite3_bind_blob(stmt, index, unsafe(addr(data[0])), (data |> length) * typeinfo sizeof(data[0]))
     }
 }
 
@@ -135,6 +145,78 @@ def try_exec(db : SqlRunner; sql : string) : SqlError {
     return none(type<string>)
 }
 
+def private try_exec_with_binds(db : SqlRunner; sql : string;
+                                bind_blk : block<(var stmt : sqlite3_stmt?) : void>) : SqlError {
+    //! Single-statement ``exec`` with positional binds. Used by the 1/2/3-arg
+    //! ``try_exec`` / ``exec`` overloads below.  Routes through prepare /
+    //! bind / step / finalize because ``sqlite3_exec`` doesn't accept bind
+    //! parameters directly.
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        let msg = "exec failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return some(msg)
+    }
+    invoke(bind_blk, stmt)
+    let src = sqlite3_step(stmt)
+    if (src != SQLITE_DONE && src != SQLITE_ROW) {
+        let msg = "exec failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        return some(msg)
+    }
+    sqlite3_finalize(stmt)
+    return none(type<string>)
+}
+
+def try_exec(db : SqlRunner; sql : string; arg0 : auto(A0)) : SqlError {
+    //! 1-arg positional bind. ``sql`` must contain exactly one ``?``.
+    return db |> try_exec_with_binds(sql, $(var stmt : sqlite3_stmt?) {
+        sql_bind_to_stmt(stmt, 1, arg0)
+    })
+}
+
+def try_exec(db : SqlRunner; sql : string; arg0 : auto(A0); arg1 : auto(A1)) : SqlError {
+    //! 2-arg positional bind.
+    return db |> try_exec_with_binds(sql, $(var stmt : sqlite3_stmt?) {
+        sql_bind_to_stmt(stmt, 1, arg0)
+        sql_bind_to_stmt(stmt, 2, arg1)
+    })
+}
+
+def try_exec(db : SqlRunner; sql : string; arg0 : auto(A0); arg1 : auto(A1); arg2 : auto(A2)) : SqlError {
+    //! 3-arg positional bind.
+    return db |> try_exec_with_binds(sql, $(var stmt : sqlite3_stmt?) {
+        sql_bind_to_stmt(stmt, 1, arg0)
+        sql_bind_to_stmt(stmt, 2, arg1)
+        sql_bind_to_stmt(stmt, 3, arg2)
+    })
+}
+
+def exec(db : SqlRunner; sql : string; arg0 : auto(A0)) : void {
+    //! Strict variant of 1-arg ``try_exec``.
+    let err = db |> try_exec(sql, arg0)
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
+def exec(db : SqlRunner; sql : string; arg0 : auto(A0); arg1 : auto(A1)) : void {
+    //! Strict variant of 2-arg ``try_exec``.
+    let err = db |> try_exec(sql, arg0, arg1)
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
+def exec(db : SqlRunner; sql : string; arg0 : auto(A0); arg1 : auto(A1); arg2 : auto(A2)) : void {
+    //! Strict variant of 3-arg ``try_exec``.
+    let err = db |> try_exec(sql, arg0, arg1, arg2)
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
 def exec(db : SqlRunner; sql : string) : void {
     //! Strict variant of ``try_exec``. Panics with the libsqlite3 errmsg on failure.
     let err = db |> try_exec(sql)
@@ -157,170 +239,372 @@ def changes(db : SqlRunner) : int {
 }
 
 // ============================================================================
-// Convention dispatch: sqlite_sql_type / sqlite_bind
+// SQL adapter rail: sql_bind / sql_extract  (tut 26)
 //
-// `[sql_table]`-generated DDL and INSERT helpers emit calls to these two
-// functions for every column. Built-in primitive types are handled by the
-// overloads below. User-defined types extend the same surface with their own
-// overloads — no registration step:
+// Convention-by-name dispatch. Every SQL-addressable type T has a pair:
 //
-//     def sqlite_sql_type(witness : MyType) : string { return "TEXT" }
-//     def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : MyType) : void { ... }
+//     def sql_bind    (v : T) : P                 // T → primitive
+//     def sql_extract (v : P; t : type<T>) : T    // primitive → T
 //
-// The generic catch-alls fire `concept_assert(false, ...)` for any type
-// that doesn't have a specific overload. `concept_assert` reports the error
-// at the *caller's* line (the user's `[sql_table]` struct), not deep inside
-// this module.
+// where P is one of {int64, double, string, array<uint8>} — the four
+// SQLite storage classes. dasSQLITE ships pairs for all standard types
+// plus a generic enum overload; user code adds pairs for domain types in
+// their own modules. The [sql_table] macro emits ``_::sql_bind`` /
+// ``_::sql_extract`` calls (tut 26 lock 4) so the caller's-module
+// overloads are always visible.
+//
+// The return type of ``sql_bind`` IS the storage type — the macro reads
+// it via ``typedecl`` and emits the matching ``sqlite3_bind_*`` /
+// ``sqlite3_column_*`` call. Single source of truth, no separate
+// ``sql_column_type(type<T>)`` registration function.
 // ============================================================================
 
-[unused_argument(witness)]
-def sqlite_sql_type(witness : int) : string {
-    return "INTEGER"
+// --- four primitive identity overloads ---
+
+def sql_bind(v : int64) : int64 {
+    return v
 }
 
-[unused_argument(witness)]
-def sqlite_sql_type(witness : int64) : string {
-    return "INTEGER"
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<int64>) : int64 {
+    return v
 }
 
-[unused_argument(witness)]
-def sqlite_sql_type(witness : float) : string {
-    return "REAL"
+def sql_bind(v : double) : double {
+    return v
 }
 
-[unused_argument(witness)]
-def sqlite_sql_type(witness : double) : string {
-    return "REAL"
+[unused_argument(t)]
+def sql_extract(v : double; t : type<double>) : double {
+    return v
 }
 
-[unused_argument(witness)]
-def sqlite_sql_type(witness : string) : string {
-    return "TEXT"
+def sql_bind(s : string) : string {
+    return s
 }
 
-[unused_argument(witness)]
-def sqlite_sql_type(witness : bool) : string {
-    return "INTEGER"
+[unused_argument(t)]
+def sql_extract(s : string; t : type<string>) : string {
+    return s
 }
 
-[unused_argument(witness)]
-def sqlite_sql_type(witness : $Option < auto(TT) >) : string {
-    //! Option<T> nullability is type-driven — the column's SQL type comes from the inner ``T``.
-    //! Whether a NOT NULL constraint is emitted is decided at macro-expansion time by the
-    //! [sql_table] DDL emitter, not here.
-    return sqlite_sql_type(default<TT>)
+def sql_bind(b : array<uint8>) : array<uint8> {
+    //! Identity passthrough for BLOB columns. ``array<uint8>`` is non-
+    //! copyable, so the const-reference parameter forces a clone on
+    //! return. SQLite's ``sqlite3_bind_blob`` with ``SQLITE_TRANSIENT``
+    //! adds a second copy. For very large BLOBs (multi-MB asset
+    //! payloads), prefer the streaming ``sqlite3_blob_open`` API to
+    //! avoid extra copying.
+    return <- clone_to_move(b)
 }
 
-[unused_argument(witness)]
-def sqlite_sql_type(witness : auto(TT)) : string {
-    concept_assert(false, "sqlite_sql_type: unsupported field type. Define `def sqlite_sql_type(witness : YourType) : string` to extend.")
-    return ""
+[unused_argument(t)]
+def sql_extract(b : array<uint8>; t : type<array<uint8>>) : array<uint8> {
+    return <- clone_to_move(b)
 }
 
-def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : int) : void {
-    sqlite3_bind_int64(stmt, idx, int64(value))
+// --- stdlib widenings (all integer kinds widen to int64; float widens to double) ---
+
+def sql_bind(v : int) : int64 {
+    return int64(v)
 }
 
-def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : int64) : void {
-    sqlite3_bind_int64(stmt, idx, value)
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<int>) : int {
+    return int(v)
 }
 
-def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : float) : void {
-    sqlite3_bind_double(stmt, idx, double(value))
+def sql_bind(v : int8) : int64 {
+    return int64(v)
 }
 
-def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : double) : void {
-    sqlite3_bind_double(stmt, idx, value)
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<int8>) : int8 {
+    return int8(v)
 }
 
-def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : string) : void {
-    sqlite3_bind_text(stmt, idx, value)
+def sql_bind(v : int16) : int64 {
+    return int64(v)
 }
 
-def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : bool) : void {
-    sqlite3_bind_int64(stmt, idx, value ? 1l : 0l)
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<int16>) : int16 {
+    return int16(v)
 }
 
-def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : $Option < auto(TT) >) : void {
-    //! Option<T>: bind the underlying value when ``some``, SQL NULL when ``none``.
-    if (value._has_value) {
-        sqlite_bind(stmt, idx, value._value)
+def sql_bind(v : uint) : int64 {
+    return int64(v)
+}
+
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<uint>) : uint {
+    return uint(v)
+}
+
+def sql_bind(v : uint8) : int64 {
+    return int64(v)
+}
+
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<uint8>) : uint8 {
+    return uint8(v)
+}
+
+def sql_bind(v : uint16) : int64 {
+    return int64(v)
+}
+
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<uint16>) : uint16 {
+    return uint16(v)
+}
+
+def sql_bind(v : uint64) : int64 {
+    //! Reinterpret cast — values above ``int64.max`` round-trip through
+    //! the sign bit (SQLite has no UNSIGNED type). For workloads that
+    //! actually exceed that range, store as ``string`` via a custom adapter.
+    return int64(v)
+}
+
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<uint64>) : uint64 {
+    return uint64(v)
+}
+
+def sql_bind(v : float) : double {
+    return double(v)
+}
+
+[unused_argument(t)]
+def sql_extract(v : double; t : type<float>) : float {
+    return float(v)
+}
+
+def sql_bind(v : bool) : int64 {
+    return v ? 1l : 0l
+}
+
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<bool>) : bool {
+    return v != 0l
+}
+
+// --- enum generic (lock 6) ---
+//
+// Any enum T round-trips through INTEGER via ``int64(value)`` /
+// ``T(int64)``. The catch-all generic uses ``static_if (typeinfo
+// is_enum)`` to gate; non-enum non-primitive types trip the
+// ``concept_assert`` and surface a clean error at the [sql_table]
+// expansion site (or any other _::sql_bind caller).
+//
+// Tradeoff: enum-value reordering silently corrupts data (value 2 means
+// something different in the new schema version). Text-backed enums
+// (``@sql_enum_as_string``) are deferred until a user opts in.
+
+def sql_bind(value : auto(TT)) : int64 {
+    static_if (typeinfo is_enum(value)) {
+        return int64(value)
+    } else {
+        concept_assert(false, "sql_bind: unsupported field type. Define `def sql_bind(v : YourType) : int64 | double | string | array<uint8>` (and a matching sql_extract) in YourType's module.")
+        return 0l
+    }
+}
+
+[unused_argument(t)]
+def sql_extract(value : int64; t : type<auto(TT)>) : TT {
+    static_if (typeinfo is_enum(default<TT>)) {
+        // int64 → enum via reinterpret. Mirrors typemacro_boost's
+        // ``int64_to_enum``; inlined here to avoid pulling that module
+        // into every dasSQLITE consumer.
+        static_if (typeinfo sizeof(type<TT>) == 1) {
+            return unsafe(reinterpret<TT>(int8(value)))
+        } static_elif (typeinfo sizeof(type<TT>) == 2) {
+            return unsafe(reinterpret<TT>(int16(value)))
+        } else {
+            return unsafe(reinterpret<TT>(int(value)))
+        }
+    } else {
+        concept_assert(false, "sql_extract: unsupported field type. Define `def sql_extract(v : int64 | double | string | array<uint8>; t : type<YourType>) : YourType` (and a matching sql_bind) in YourType's module.")
+        return default<TT>
+    }
+}
+
+// ============================================================================
+// Internal bridge: sql_bind/sql_extract ↔ libsqlite3 C API
+//
+// The [sql_table] macro emits ``_::sql_bind(row.field)`` (resolves the user's
+// adapter at the caller's module) and routes the resulting primitive into
+// libsqlite3 via the four ``sql_bind_to_stmt`` overloads below. For reads,
+// ``read_via_adapter`` uses ``typedecl`` to resolve the storage primitive at
+// compile time, calls the matching ``sqlite3_column_*``, and feeds the
+// primitive into ``_::sql_extract`` to materialize the user type.
+//
+// ``sql_storage_type_for`` does the same compile-time resolution for the DDL
+// emitter — column type strings are picked from the four-primitive table.
+// ============================================================================
+
+def sqlite3_column_blob_(stmt : sqlite3_stmt?; col : int) : array<uint8> {
+    //! Reads a BLOB column as a fresh ``array<uint8>``. Allocates on
+    //! daslang's heap and copies — SQLite's blob pointer is only valid
+    //! until the next ``step`` / ``reset`` / ``finalize``, so the copy
+    //! is mandatory for safe out-of-statement use.
+    let n = sqlite3_column_bytes(stmt, col)
+    var r : array<uint8>
+    r |> resize(n)
+    if (n > 0) {
+        unsafe {
+            // sqlite3_column_blob returns ``const void *``; AOT codegen's
+            // das_memcpy wants a non-const source, so strip the const here.
+            memcpy(addr(r[0]), reinterpret<void?>(sqlite3_column_blob(stmt, col)), n)
+        }
+    }
+    return <- r
+}
+
+// --- bind direction ---
+//
+// Dispatch table: four primitive overloads route directly to libsqlite3;
+// the Option<T> overload handles NULL semantics; the catch-all generic
+// routes any other type through the user's ``_::sql_bind`` adapter and
+// recurses on the resulting primitive (or the inner value of an Option).
+
+def sql_bind_to_stmt(var stmt : sqlite3_stmt?; idx : int; v : int64) : void {
+    sqlite3_bind_int64(stmt, idx, v)
+}
+
+def sql_bind_to_stmt(var stmt : sqlite3_stmt?; idx : int; v : double) : void {
+    sqlite3_bind_double(stmt, idx, v)
+}
+
+def sql_bind_to_stmt(var stmt : sqlite3_stmt?; idx : int; v : string) : void {
+    sqlite3_bind_text(stmt, idx, v)
+}
+
+def sql_bind_to_stmt(var stmt : sqlite3_stmt?; idx : int; v : array<uint8>) : void {
+    sqlite3_bind_blob(stmt, idx, v)
+}
+
+def sql_bind_to_stmt(var stmt : sqlite3_stmt?; idx : int; v : $Option < auto(TT) >) : void {
+    //! ``some(x)`` recurses on ``x`` (which routes through the user's
+    //! ``_::sql_bind`` adapter for non-primitive ``T``); ``none`` binds NULL.
+    if (v._has_value) {
+        sql_bind_to_stmt(stmt, idx, v._value)
     } else {
         sqlite3_bind_null(stmt, idx)
     }
 }
 
-[unused_argument(stmt, idx, value)]
-def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : auto(TT)) : void {
-    concept_assert(false, "sqlite_bind: unsupported field type. Define `def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : YourType) : void` to extend.")
+def sql_bind_to_stmt(var stmt : sqlite3_stmt?; idx : int; v : auto(TT)) : void {
+    //! Catch-all: route through the user's ``_::sql_bind`` adapter, then
+    //! recurse on the primitive return value. ``_::``-dispatched so the
+    //! caller's-module overloads (the user's adapter pair) are visible.
+    sql_bind_to_stmt(stmt, idx, _::sql_bind(v))
 }
 
-// ============================================================================
-// Read-side dispatch: sqlite_read
+// --- read direction ---
 //
-// Mirrors `sqlite_bind` for the read direction. `[sql_table]`-generated
-// `_sql_read_row` and the `_sql` macro's row materializer emit calls to
-// `sqlite_read(stmt, col, type<T>) : T` for every column. Built-in primitive
-// types are handled by the overloads below; user-defined types extend the
-// surface with their own overload — no registration step:
-//
-//     def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<MyType>) : MyType { ... }
-//
-// The generic catch-all fires `concept_assert(false, ...)` for any type that
-// doesn't have a specific overload. Reports at the caller's line.
-// ============================================================================
+// Dispatch table: four primitive ``sql_read_witness`` overloads read the
+// matching ``sqlite3_column_*``; ``read_via_adapter`` resolves the storage
+// primitive at compile time via ``typedecl(_::sql_bind(default<T>))`` and
+// then dispatches to the matching witness overload, feeding the primitive
+// into ``_::sql_extract``. The ``Option<T>`` overload of
+// ``read_via_adapter`` handles NULL detection.
 
-[unused_argument(t)]
-def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<int>) : int {
-    return sqlite3_column_int(stmt, col)
-}
-
-[unused_argument(t)]
-def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<int64>) : int64 {
+[unused_argument(witness)]
+def sql_read_witness(stmt : sqlite3_stmt?; col : int; witness : int64) : int64 {
     return sqlite3_column_int64(stmt, col)
 }
 
-[unused_argument(t)]
-def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<float>) : float {
-    return float(sqlite3_column_double(stmt, col))
-}
-
-[unused_argument(t)]
-def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<double>) : double {
+[unused_argument(witness)]
+def sql_read_witness(stmt : sqlite3_stmt?; col : int; witness : double) : double {
     return sqlite3_column_double(stmt, col)
 }
 
-[unused_argument(t)]
-def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<string>) : string {
+[unused_argument(witness)]
+def sql_read_witness(stmt : sqlite3_stmt?; col : int; witness : string) : string {
     return sqlite3_column_text_(stmt, col)
 }
 
-[unused_argument(t)]
-def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<bool>) : bool {
-    return sqlite3_column_int(stmt, col) != 0
+[unused_argument(witness)]
+def sql_read_witness(stmt : sqlite3_stmt?; col : int; witness : array<uint8>) : array<uint8> {
+    return <- sqlite3_column_blob_(stmt, col)
+}
+
+[unused_argument(stmt, col, witness)]
+def sql_read_witness(stmt : sqlite3_stmt?; col : int; witness : auto(SS)) : SS {
+    concept_assert(false, "sql_bind must return one of int64 / double / string / array<uint8>")
+    return default<SS>
 }
 
 [unused_argument(t)]
-def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<$Option<auto(TT)>>) : Option<TT -const -#> {
-    //! Option<T>: SQLITE_NULL → ``none``; otherwise read the inner ``T`` and wrap in ``some``.
+def read_via_adapter(stmt : sqlite3_stmt?; col : int; t : type<$Option<auto(TT)>>) : Option<TT -const -#> {
+    //! ``Option<T>`` overload: SQLITE_NULL → ``none``, otherwise read the
+    //! inner ``T`` via the generic ``read_via_adapter`` and wrap in ``some``.
     if (sqlite3_column_type(stmt, col) == SQLITE_NULL) {
         return none(type<TT -const -#>)
     }
-    return some(sqlite_read(stmt, col, type<TT -const -#>))
+    return some(read_via_adapter(stmt, col, type<TT -const -#>))
 }
 
-[unused_argument(stmt, col, t)]
-def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<auto(TT)>) : TT {
-    concept_assert(false, "sqlite_read: unsupported field type. Define `def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<YourType>) : YourType` to extend.")
-    return default<TT>
+[unused_argument(t)]
+def read_via_adapter(stmt : sqlite3_stmt?; col : int; t : type<auto(TT)>) : TT {
+    //! Reads a single column as the storage primitive
+    //! ``_::sql_bind(default<TT>)`` returns, then materializes ``TT`` via
+    //! ``_::sql_extract``. The primitive type is resolved at compile time
+    //! via ``typedecl`` — no runtime call to the user's adapter.
+    return _::sql_extract(
+        sql_read_witness(stmt, col, default<typedecl(_::sql_bind(default<TT>))>),
+        type<TT>
+    )
+}
+
+// --- DDL: column-type string from sql_bind's return type ---
+
+[unused_argument(witness)]
+def sql_storage_type_witness(witness : int64) : string {
+    return "INTEGER"
+}
+
+[unused_argument(witness)]
+def sql_storage_type_witness(witness : double) : string {
+    return "REAL"
+}
+
+[unused_argument(witness)]
+def sql_storage_type_witness(witness : string) : string {
+    return "TEXT"
+}
+
+[unused_argument(witness)]
+def sql_storage_type_witness(witness : array<uint8>) : string {
+    return "BLOB"
+}
+
+[unused_argument(witness)]
+def sql_storage_type_witness(witness : auto(SS)) : string {
+    concept_assert(false, "sql_bind must return one of int64 / double / string / array<uint8>")
+    return ""
+}
+
+[unused_argument(t)]
+def sql_storage_type_for(t : type<auto(TT)>) : string {
+    return sql_storage_type_witness(default<typedecl(_::sql_bind(default<TT>))>)
+}
+
+[unused_argument(t)]
+def sql_storage_type_for(t : type<$Option<auto(TT)>>) : string {
+    //! Option<T> nullability is decided by the [sql_table] DDL emitter; the
+    //! column type comes from the inner ``T``'s storage primitive.
+    return sql_storage_type_for(type<TT>)
 }
 
 // ============================================================================
 // query_scalar — read column 0 of the first row as ``TT``
 //
-// Generic over any type with a ``sqlite_read(stmt, col, type<TT>) : TT``
-// overload. Built-ins: string, int, int64, float, double, bool. User types
-// extend by adding their own ``sqlite_read`` overload — no registration step.
+// Routes through the tut-26 ``_::sql_bind`` / ``_::sql_extract`` adapter
+// rail via ``read_via_adapter``. Built-ins: every ``int*`` / ``uint*``,
+// ``float`` / ``double``, ``bool``, ``string``, ``array<uint8>``, every
+// enum, and any user type that ships an adapter pair.
 //
 // `try_*` returns ``Result<TT, string>`` (prepare/step error or zero rows).
 // `query_scalar` is the strict variant — panics on err.
@@ -331,7 +615,11 @@ def try_query_scalar(db : SqlRunner; sql : string; t : type<auto(TT)>) : Result<
     //! Prepares ``sql``, steps once, returns column 0 as ``TT``.
     //! Returns ``Err(errmsg)`` on prepare/step error or zero rows.
     return <- try_one_row(db, sql, $(var stmt : sqlite3_stmt?) {}, $(stmt : sqlite3_stmt?) {
-        return sqlite_read(stmt, 0, type<TT -const -#>)
+        static_if (typeinfo can_copy(default<TT -const -#>)) {
+            return read_via_adapter(stmt, 0, type<TT -const -#>)
+        } else {
+            return <- clone_to_move(read_via_adapter(stmt, 0, type<TT -const -#>))
+        }
     }, "query_scalar")
 }
 
@@ -357,7 +645,11 @@ def query_scalar(db : SqlRunner; sql : string; t : type<auto(TT)>) : TT -const -
 [unused_argument(t)]
 def query_scalar_opt(db : SqlRunner; sql : string; t : type<auto(TT)>) : Option<TT -const -#> {
     var r <- try_one_row_opt(db, sql, $(var stmt : sqlite3_stmt?) {}, $(stmt : sqlite3_stmt?) {
-        return sqlite_read(stmt, 0, type<TT -const -#>)
+        static_if (typeinfo can_copy(default<TT -const -#>)) {
+            return read_via_adapter(stmt, 0, type<TT -const -#>)
+        } else {
+            return <- clone_to_move(read_via_adapter(stmt, 0, type<TT -const -#>))
+        }
     }, "query_scalar_opt")
     if (r |> is_err) {
         panic(r |> unwrap_err)
@@ -431,9 +723,18 @@ def private try_one_row(db : SqlRunner; sql : string;
         sqlite3_finalize(stmt)
         return err(msg, type<TT -const -#>)
     }
-    var row : TT -const -# = invoke(row_blk, stmt) // nolint:LINT003
-    sqlite3_finalize(stmt)
-    return move_ok(row, type<string>)
+    // Capture the function-call result. Copyable rows initialize via ``=``;
+    // non-copyable (e.g. user types containing ``array<uint8>``) route
+    // through ``clone_to_move`` so the rvalue is movable.
+    static_if (typeinfo can_copy(default<TT -const -#>)) {
+        var row : TT -const -# = invoke(row_blk, stmt) // nolint:LINT003
+        sqlite3_finalize(stmt)
+        return move_ok(row, type<string>)
+    } else {
+        var row : TT -const -# <- clone_to_move(invoke(row_blk, stmt))
+        sqlite3_finalize(stmt)
+        return move_ok(row, type<string>)
+    }
 }
 
 def private try_one_row_opt(db : SqlRunner; sql : string;
@@ -461,9 +762,15 @@ def private try_one_row_opt(db : SqlRunner; sql : string;
         sqlite3_finalize(stmt)
         return err(msg, type<Option<TT -const -#>>)
     }
-    var row : TT -const -# = invoke(row_blk, stmt) // nolint:LINT003
-    sqlite3_finalize(stmt)
-    return move_ok(move_some(row), type<string>)
+    static_if (typeinfo can_copy(default<TT -const -#>)) {
+        var row : TT -const -# = invoke(row_blk, stmt) // nolint:LINT003
+        sqlite3_finalize(stmt)
+        return move_ok(move_some(row), type<string>)
+    } else {
+        var row : TT -const -# <- clone_to_move(invoke(row_blk, stmt))
+        sqlite3_finalize(stmt)
+        return move_ok(move_some(row), type<string>)
+    }
 }
 
 def private try_step_dml(db : SqlRunner; sql : string;
@@ -503,7 +810,14 @@ def private try_collect_rows(db : SqlRunner; sql : string;
     var inscope result : array<TT -const -#>
     var rc = sqlite3_step(stmt)
     while (rc == SQLITE_ROW) {
-        result |> push(invoke(row_blk, stmt))
+        // Copyable rows ``push`` directly; non-copyable rows (e.g.
+        // structs containing ``array<uint8>``) ``emplace`` from the
+        // invoke rvalue so we don't deep-clone on every row.
+        static_if (typeinfo can_copy(default<TT -const -#>)) {
+            result |> push(invoke(row_blk, stmt))
+        } else {
+            result |> emplace(invoke(row_blk, stmt))
+        }
         rc = sqlite3_step(stmt)
     }
     if (rc != SQLITE_DONE) {
@@ -520,7 +834,11 @@ def private try_query_one_impl(db : SqlRunner; sql : string; t : type<auto(TT)>;
                                bind_blk : block<(var stmt : sqlite3_stmt?) : void>) : Result<TT -const -#, string> {
     return <- try_one_row(db, sql, bind_blk,
                           $(stmt : sqlite3_stmt?) {
-                              return _::_sql_read_row(stmt, type<TT -const -#>)
+                              static_if (typeinfo can_copy(default<TT -const -#>)) {
+                                  return _::_sql_read_row(stmt, type<TT -const -#>)
+                              } else {
+                                  return <- clone_to_move(_::_sql_read_row(stmt, type<TT -const -#>))
+                              }
                           },
                           "query_one")
 }
@@ -552,9 +870,15 @@ def private query_one_opt_impl(db : SqlRunner; sql : string; t : type<auto(TT)>;
         sqlite3_finalize(stmt)
         panic("query_one_opt step failed: {sqlite3_errmsg(db.sqlite_handle)}")
     }
-    var row : TT -const -# = _::_sql_read_row(stmt, type<TT -const -#>) // nolint:LINT003
-    sqlite3_finalize(stmt)
-    return move_some(row)
+    static_if (typeinfo can_copy(default<TT -const -#>)) {
+        var row : TT -const -# = _::_sql_read_row(stmt, type<TT -const -#>) // nolint:LINT003
+        sqlite3_finalize(stmt)
+        return move_some(row)
+    } else {
+        var row : TT -const -# <- clone_to_move(_::_sql_read_row(stmt, type<TT -const -#>))
+        sqlite3_finalize(stmt)
+        return move_some(row)
+    }
 }
 
 // ---- try_query_one — Result<TT, string>; 0..3 positional args ----
@@ -567,24 +891,24 @@ def try_query_one(db : SqlRunner; sql : string; t : type<auto(TT)>) : Result<TT 
 def try_query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0)) : Result<TT -const -#, string> {
     //! 1-arg positional bind.
     return <- try_query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
-        sqlite_bind(stmt, 1, arg0)
+        sql_bind_to_stmt(stmt, 1, arg0)
     })
 }
 
 def try_query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1)) : Result<TT -const -#, string> {
     //! 2-arg positional bind.
     return <- try_query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
-        sqlite_bind(stmt, 1, arg0)
-        sqlite_bind(stmt, 2, arg1)
+        sql_bind_to_stmt(stmt, 1, arg0)
+        sql_bind_to_stmt(stmt, 2, arg1)
     })
 }
 
 def try_query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1); arg2 : auto(A2)) : Result<TT -const -#, string> {
     //! 3-arg positional bind.
     return <- try_query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
-        sqlite_bind(stmt, 1, arg0)
-        sqlite_bind(stmt, 2, arg1)
-        sqlite_bind(stmt, 3, arg2)
+        sql_bind_to_stmt(stmt, 1, arg0)
+        sql_bind_to_stmt(stmt, 2, arg1)
+        sql_bind_to_stmt(stmt, 3, arg2)
     })
 }
 
@@ -598,24 +922,24 @@ def query_one(db : SqlRunner; sql : string; t : type<auto(TT)>) : TT -const -# {
 [unused_argument(t)]
 def query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0)) : TT -const -# {
     return <- query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
-        sqlite_bind(stmt, 1, arg0)
+        sql_bind_to_stmt(stmt, 1, arg0)
     })
 }
 
 [unused_argument(t)]
 def query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1)) : TT -const -# {
     return <- query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
-        sqlite_bind(stmt, 1, arg0)
-        sqlite_bind(stmt, 2, arg1)
+        sql_bind_to_stmt(stmt, 1, arg0)
+        sql_bind_to_stmt(stmt, 2, arg1)
     })
 }
 
 [unused_argument(t)]
 def query_one(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1); arg2 : auto(A2)) : TT -const -# {
     return <- query_one_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
-        sqlite_bind(stmt, 1, arg0)
-        sqlite_bind(stmt, 2, arg1)
-        sqlite_bind(stmt, 3, arg2)
+        sql_bind_to_stmt(stmt, 1, arg0)
+        sql_bind_to_stmt(stmt, 2, arg1)
+        sql_bind_to_stmt(stmt, 3, arg2)
     })
 }
 
@@ -627,22 +951,22 @@ def query_one_opt(db : SqlRunner; sql : string; t : type<auto(TT)>) : Option<TT 
 
 def query_one_opt(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0)) : Option<TT -const -#> {
     return <- query_one_opt_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
-        sqlite_bind(stmt, 1, arg0)
+        sql_bind_to_stmt(stmt, 1, arg0)
     })
 }
 
 def query_one_opt(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1)) : Option<TT -const -#> {
     return <- query_one_opt_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
-        sqlite_bind(stmt, 1, arg0)
-        sqlite_bind(stmt, 2, arg1)
+        sql_bind_to_stmt(stmt, 1, arg0)
+        sql_bind_to_stmt(stmt, 2, arg1)
     })
 }
 
 def query_one_opt(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg1 : auto(A1); arg2 : auto(A2)) : Option<TT -const -#> {
     return <- query_one_opt_impl(db, sql, type<TT -const -#>, $(var stmt : sqlite3_stmt?) {
-        sqlite_bind(stmt, 1, arg0)
-        sqlite_bind(stmt, 2, arg1)
-        sqlite_bind(stmt, 3, arg2)
+        sql_bind_to_stmt(stmt, 1, arg0)
+        sql_bind_to_stmt(stmt, 2, arg1)
+        sql_bind_to_stmt(stmt, 3, arg2)
     })
 }
 
@@ -1043,7 +1367,7 @@ def try_delete_by_id(db : SqlRunner; t : type<auto(TT)>; id : auto(K)) : Result<
     //! constructing a dummy struct just to identify the row. Returns
     //! ``Ok(rows_affected)`` (1 or 0), ``Err(errmsg)`` on SQL failure.
     return <- db |> try_step_dml(_::_sql_delete_by_pk_sql(default<TT>), $(var stmt : sqlite3_stmt?) {
-        sqlite_bind(stmt, 1, id)
+        sql_bind_to_stmt(stmt, 1, id)
     }, "delete_by_id")
 }
 
@@ -1188,7 +1512,7 @@ def try_transaction(db : SqlRunner; mode : SqliteTxnMode; blk : block<() : void>
 // Generic DML runners — used by the `_sql_update` / `_sql_delete` macros.
 //
 // These take a SQL string + bind block (the macro fills in the
-// `sqlite_bind(stmt, idx, expr)` calls) and execute it. Return rows-affected
+// `sql_bind_to_stmt(stmt, idx, expr)` calls) and execute it. Return rows-affected
 // for non-RETURNING; array<T> for RETURNING.
 // ============================================================================
 
@@ -1243,7 +1567,11 @@ def try_select_from(db : SqlRunner; t : type<auto(TT)>) : Result<array<TT -const
     return <- db |> try_collect_rows(_::_sql_select_all_sql(type<TT -const -#>),
         $(var stmt : sqlite3_stmt?) {},
         $(stmt : sqlite3_stmt?) {
-            return _::_sql_read_row(stmt, type<TT -const -#>)
+            static_if (typeinfo can_copy(default<TT -const -#>)) {
+                return _::_sql_read_row(stmt, type<TT -const -#>)
+            } else {
+                return <- clone_to_move(_::_sql_read_row(stmt, type<TT -const -#>))
+            }
         }, "select_from")
 }
 
@@ -1332,13 +1660,13 @@ def run_select_one_opt(db : SqlRunner; sql : string; bind_blk : block<(var stmt 
 // to the user's struct type, a fixed family of helper functions consumed by
 // `create_table` / `drop_table_if_exists` / `insert` below.
 //
-// All generated function bodies emit `sqlite_sql_type(type<T>)` and
-// `sqlite_bind(stmt, idx, row.field)` calls — so primitive and user-defined
-// field types travel the same code path. The witness on `sqlite_sql_type` is
-// a type tag for overload dispatch only; bodies must not read it. Type
-// resolution defers to each generated function's own typecheck pass; the
-// macro itself does not depend on field types being fully resolved at
-// apply() time.
+// All generated function bodies emit `sql_storage_type_for(type<T>)` and
+// `sql_bind_to_stmt(stmt, idx, row.field)` calls — so primitive and user-
+// defined field types travel the same code path. ``sql_bind_to_stmt``'s
+// catch-all routes the value through the user's ``_::sql_bind`` adapter
+// (resolved at the caller's-module overload set). Type resolution defers
+// to each generated function's own typecheck pass; the macro itself does
+// not depend on field types being fully resolved at apply() time.
 //
 // TODO: 5 of the 7 emitted helpers (_sql_table_name, _sql_drop_table_if_exists_sql,
 // _sql_create_table_sql, _sql_insert_with_pk_sql, _sql_insert_no_pk_sql) take
@@ -1350,18 +1678,19 @@ def run_select_one_opt(db : SqlRunner; sql : string; bind_blk : block<(var stmt 
 // chunk-1 review.
 // ============================================================================
 
-def private find_bool_annotation(args : AnnotationArgumentList; argn : string; default_value : bool) : bool {
+def private find_annotation(args : AnnotationArgumentList; argn : string; default_value : auto(TT)) : TT {
+    //! Generic annotation reader. ``TT`` must be ``bool`` or ``string``;
+    //! daslang's ``static_if (typeinfo is_string …)`` picks the matching
+    //! ``tString`` / ``tBool`` accessor on the AnnotationArgument variant.
     let v = find_arg(args, argn)
-    if (v is tBool) {
-        return v as tBool
-    }
-    return default_value
-}
-
-def private find_string_annotation(args : AnnotationArgumentList; argn : string; default_value : string) : string {
-    let v = find_arg(args, argn)
-    if (v is tString) {
-        return v as tString
+    static_if (typeinfo is_string(default_value)) {
+        if (v is tString) {
+            return v as tString
+        }
+    } else {
+        if (v is tBool) {
+            return v as tBool
+        }
     }
     return default_value
 }
@@ -1480,8 +1809,8 @@ def private build_create_indexes_sql(st : StructurePtr; table_name : string; fie
             if (string(ann.annotation.name) != "sql_index") {
                 continue
             }
-            let idx_name_arg = find_string_annotation(ann.arguments, "name", "")
-            let is_unique = find_bool_annotation(ann.arguments, "unique", false)
+            let idx_name_arg = find_annotation(ann.arguments, "name", "")
+            let is_unique = find_annotation(ann.arguments, "unique", false)
             let cols = find_string_array_annotation(ann.arguments, "fields")
             if (length(cols) == 0) {
                 errors := "[sql_index]: missing or empty `fields=` argument. Use `fields=\"ColName\"` for a single-column index or `fields=(\"A\", \"B\")` for a composite."
@@ -1585,8 +1914,8 @@ class SqlIndexMacro : AstStructureAnnotation {
             errors := "[sql_index]: missing or empty `fields=` argument. Use `fields=\"ColName\"` for a single-column index or `fields=(\"A\", \"B\")` for a composite."
             return false
         }
-        let is_unique = find_bool_annotation(args, "unique", false)
-        let idx_name_arg = find_string_annotation(args, "name", "")
+        let is_unique = find_annotation(args, "unique", false)
+        let idx_name_arg = find_annotation(args, "name", "")
 
         // Cross-check every named column against the struct's fields.
         for (col in cols) {
@@ -1680,11 +2009,11 @@ def private find_parent_table_and_pk(var st : StructurePtr; parent_name : string
     var tab = string(found_st.name)
     for (ann in found_st.annotations) {
         if (ann.annotation.name == "sql_table") {
-            tab = find_string_annotation(ann.arguments, "name", tab)
+            tab = find_annotation(ann.arguments, "name", tab)
         }
     }
     for (pf in found_st.fields) {
-        if (find_bool_annotation(pf.annotation, "sql_primary_key", false)) {
+        if (find_annotation(pf.annotation, "sql_primary_key", false)) {
             return (tab, string(pf.name), true)
         }
     }
@@ -1694,29 +2023,29 @@ def private find_parent_table_and_pk(var st : StructurePtr; parent_name : string
 [structure_macro(name=sql_table)]
 class SqlTableMacro : AstStructureAnnotation {
     def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
-        let table_name = find_string_annotation(args, "name", string(st.name))
+        let table_name = find_annotation(args, "name", string(st.name))
 
         var fields : array<FieldInfo>
         for (field in st.fields) {
             let fname = string(field.name)
-            let is_pk = find_bool_annotation(field.annotation, "sql_primary_key", false)
-            let is_unique = find_bool_annotation(field.annotation, "sql_unique", false)
+            let is_pk = find_annotation(field.annotation, "sql_primary_key", false)
+            let is_unique = find_annotation(field.annotation, "sql_unique", false)
             let is_optional = is_option_field_type(field._type)
 
             // @sql_computed expression
-            let computed_sql = find_string_annotation(field.annotation, "sql_computed", "")
+            let computed_sql = find_annotation(field.annotation, "sql_computed", "")
             let is_computed = !empty(computed_sql)
-            let is_stored = find_bool_annotation(field.annotation, "sql_stored", false)
+            let is_stored = find_annotation(field.annotation, "sql_stored", false)
 
             // Defaults — native daslang field init OR @sql_default_fn (mutually exclusive)
-            let sql_default_fn = find_string_annotation(field.annotation, "sql_default_fn", "")
+            let sql_default_fn = find_annotation(field.annotation, "sql_default_fn", "")
 
             // Foreign key — @sql_references + optional @sql_on_delete / @sql_on_update
-            let references = find_string_annotation(field.annotation, "sql_references", "")
-            let on_delete = find_string_annotation(field.annotation, "sql_on_delete", "no_action")
-            let on_update = find_string_annotation(field.annotation, "sql_on_update", "no_action")
-            let has_on_delete_attr = !empty(find_string_annotation(field.annotation, "sql_on_delete", ""))
-            let has_on_update_attr = !empty(find_string_annotation(field.annotation, "sql_on_update", ""))
+            let references = find_annotation(field.annotation, "sql_references", "")
+            let on_delete = find_annotation(field.annotation, "sql_on_delete", "no_action")
+            let on_update = find_annotation(field.annotation, "sql_on_update", "no_action")
+            let has_on_delete_attr = !empty(find_annotation(field.annotation, "sql_on_delete", ""))
+            let has_on_update_attr = !empty(find_annotation(field.annotation, "sql_on_update", ""))
 
             // ---- validation ----
             if (is_pk && is_optional) {
@@ -1835,9 +2164,9 @@ class SqlTableMacro : AstStructureAnnotation {
         // User-facing source order requirement: [sql_table, sql_index, ...].
         var fn_indexes = make_create_indexes_sql_fn(st, "")
         compiling_module() |> add_function(fn_indexes)
-        var fn_ins_pk = make_insert_with_pk_sql_fn(st, table_name, fields)
+        var fn_ins_pk = make_insert_sql_fn(st, table_name, fields, true)
         compiling_module() |> add_function(fn_ins_pk)
-        var fn_ins_nopk = make_insert_no_pk_sql_fn(st, table_name, fields)
+        var fn_ins_nopk = make_insert_sql_fn(st, table_name, fields, false)
         compiling_module() |> add_function(fn_ins_nopk)
         var fn_pk_unset = make_pk_is_unset_fn(st, fields)
         compiling_module() |> add_function(fn_pk_unset)
@@ -1927,7 +2256,7 @@ class SqlTableMacro : AstStructureAnnotation {
                 suffix += info.references_clause
             }
             write_exprs |> push(qmacro_expr(${ writer |> write($v(prefix)); }))
-            write_exprs |> push(qmacro_expr(${ writer |> write(sqlite_sql_type(type<$t(st.fields[i]._type)>)); }))
+            write_exprs |> push(qmacro_expr(${ writer |> write(sql_storage_type_for(type<$t(st.fields[i]._type)>)); }))
             write_exprs |> push(qmacro_expr(${ writer |> write($v(suffix)); }))
         }
         write_exprs |> push(qmacro_expr(${ writer |> write(")"); }))
@@ -1942,15 +2271,18 @@ class SqlTableMacro : AstStructureAnnotation {
         return <- fn
     }
 
-    def make_insert_with_pk_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>) : FunctionPtr {
+    def make_insert_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>; include_pk : bool) : FunctionPtr {
         // Always emit explicit column list so computed (GENERATED) columns can be
-        // skipped — SQLite rejects writes to generated columns. Without computed
-        // columns this is functionally equivalent to the previous positional
-        // `INSERT INTO T VALUES (?,?,...)` form.
+        // skipped — SQLite rejects writes to generated columns. ``include_pk``
+        // toggles whether the primary key column participates: with-PK is the
+        // user-specified-keys path, without-PK is the AUTOINCREMENT path.
+        // Both fall back to `DEFAULT VALUES` when no bindable columns remain
+        // (PK-only struct without PK, or all-computed struct).
+        let helper_name = include_pk ? "_sql_insert_with_pk_sql" : "_sql_insert_no_pk_sql"
         let cols = build_string() $(var w) {
             var first = true
             for (info in fields) {
-                if (info.is_computed) {
+                if (info.is_computed || (!include_pk && info.is_pk)) {
                     continue
                 }
                 if (!first) {
@@ -1965,7 +2297,7 @@ class SqlTableMacro : AstStructureAnnotation {
         let placeholders = build_string() $(var w) {
             var first = true
             for (info in fields) {
-                if (info.is_computed) {
+                if (info.is_computed || (!include_pk && info.is_pk)) {
                     continue
                 }
                 if (!first) {
@@ -1978,49 +2310,7 @@ class SqlTableMacro : AstStructureAnnotation {
         let sql = (empty(cols)
             ? "INSERT INTO \"{table_name}\" DEFAULT VALUES"
             : "INSERT INTO \"{table_name}\" ({cols}) VALUES ({placeholders})")
-        var fn = qmacro_function("_sql_insert_with_pk_sql") $(typ : $t(st)) : string {
-            return $v(sql)
-        }
-        fn.flags |= FunctionFlags.generated
-        fn.body |> force_at(st.at)
-        return <- fn
-    }
-
-    def make_insert_no_pk_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>) : FunctionPtr {
-        let cols = build_string() $(var w) {
-            var first = true
-            for (info in fields) {
-                if (info.is_pk || info.is_computed) {
-                    continue
-                }
-                if (!first) {
-                    w |> write(", ")
-                }
-                w |> write("\"")
-                w |> write(info.col_name)
-                w |> write("\"")
-                first = false
-            }
-        }
-        let placeholders = build_string() $(var w) {
-            var first = true
-            for (info in fields) {
-                if (info.is_pk || info.is_computed) {
-                    continue
-                }
-                if (!first) {
-                    w |> write(", ")
-                }
-                w |> write("?")
-                first = false
-            }
-        }
-        // PK-only / all-computed structs have no non-PK bindable columns. SQLite
-        // rejects `INSERT INTO T () VALUES ()`, so fall back to `DEFAULT VALUES`.
-        let sql = (empty(cols)
-            ? "INSERT INTO \"{table_name}\" DEFAULT VALUES"
-            : "INSERT INTO \"{table_name}\" ({cols}) VALUES ({placeholders})")
-        var fn = qmacro_function("_sql_insert_no_pk_sql") $(typ : $t(st)) : string {
+        var fn = qmacro_function(helper_name) $(typ : $t(st)) : string {
             return $v(sql)
         }
         fn.flags |= FunctionFlags.generated
@@ -2073,7 +2363,7 @@ class SqlTableMacro : AstStructureAnnotation {
             let wi = with_pk_idx
             let field_name = info.name
             with_pk_exprs |> push(qmacro_expr(${
-                sqlite_bind(stmt, $v(wi), row.$f(field_name));
+                sql_bind_to_stmt(stmt, $v(wi), row.$f(field_name));
             }))
         }
 
@@ -2085,7 +2375,7 @@ class SqlTableMacro : AstStructureAnnotation {
             no_pk_idx++
             let field_name = info.name
             no_pk_exprs |> push(qmacro_expr(${
-                sqlite_bind(stmt, $v(no_pk_idx), row.$f(field_name));
+                sql_bind_to_stmt(stmt, $v(no_pk_idx), row.$f(field_name));
             }))
         }
 
@@ -2130,7 +2420,12 @@ class SqlTableMacro : AstStructureAnnotation {
             let col_idx = i
             let field_name = info.name
             assign_exprs |> push(qmacro_expr(${
-                row.$f(field_name) = sqlite_read(stmt, $v(col_idx), type<$t(st.fields[i]._type)>);
+                static_if (typeinfo can_copy(default<$t(st.fields[i]._type)>)) {
+                    row.$f(field_name) = read_via_adapter(stmt, $v(col_idx), type<$t(st.fields[i]._type)>);
+                } else {
+                    var field_tmp <- clone_to_move(read_via_adapter(stmt, $v(col_idx), type<$t(st.fields[i]._type)>));
+                    row.$f(field_name) <- field_tmp;
+                }
             }))
         }
 
@@ -2264,7 +2559,7 @@ class SqlTableMacro : AstStructureAnnotation {
             let bi = bind_idx
             let field_name = fields[i].name
             bind_exprs |> push(qmacro_expr(${
-                sqlite_bind(stmt, $v(bi), row.$f(field_name));
+                sql_bind_to_stmt(stmt, $v(bi), row.$f(field_name));
             }))
         }
         // PK column last (WHERE clause).
@@ -2272,7 +2567,7 @@ class SqlTableMacro : AstStructureAnnotation {
         let pk_bind_idx = bind_idx
         let pk_field_name = fields[pk_idx].name
         bind_exprs |> push(qmacro_expr(${
-            sqlite_bind(stmt, $v(pk_bind_idx), row.$f(pk_field_name));
+            sql_bind_to_stmt(stmt, $v(pk_bind_idx), row.$f(pk_field_name));
         }))
 
         var fn = qmacro_function("_sql_bind_row_for_update") $(var stmt : sqlite3_stmt?; row : $t(st)) : void {
@@ -2298,7 +2593,7 @@ class SqlTableMacro : AstStructureAnnotation {
         }
         let pk_field_name = fields[pk_idx].name
         var fn = qmacro_function("_sql_bind_row_pk_only") $(var stmt : sqlite3_stmt?; row : $t(st)) : void {
-            sqlite_bind(stmt, 1, row.$f(pk_field_name))
+            sql_bind_to_stmt(stmt, 1, row.$f(pk_field_name))
         }
         fn.flags |= FunctionFlags.generated
         fn.body |> force_at(st.at)

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -81,7 +81,7 @@ enum private Materializer {
 
 enum private ProjectionShape {
     FullRow             //!< no `_select`: SELECT cols-of(rootT); reads via _::_sql_read_row
-    SingleColumn        //!< `_select(_.Field)`: SELECT one col; reads via sqlite_read
+    SingleColumn        //!< `_select(_.Field)`: SELECT one col; reads via read_via_adapter
     NamedTuple          //!< `_select((Name=_.Name, Price=_.Price))`: SELECT cols; reads via tuple builder
     Aggregate           //!< `_count()` etc.: raw SQL expression in SELECT; scalar reader
     GroupedNamedTuple   //!< `_select` after `_group_by`: tuple of group keys + group-scope aggregates
@@ -667,7 +667,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             q.aggregateExpr = "COUNT(*)"
             // SQLite's COUNT(*) is int64 internally, but daslang's
             // `length(arr)` / `count(arr)` return `int`, so narrow via
-            // `sqlite_read(stmt, 0, type<int>)`. Matches the grouped
+            // `read_via_adapter(stmt, 0, type<int>)`. Matches the grouped
             // form (`_._1 |> length`) which also lands as `int`. Any
             // plausible row count fits.
             q.aggregateType = new TypeDecl(at = at, baseType = Type.tInt)
@@ -1460,7 +1460,7 @@ def private try_translate_group_aggregate(var node : ExpressionPtr; q : SqlQuery
 
     // length(_._1) / count(_._1) → COUNT(*)
     // Result type is `int` to match daslang's `length`/`count` return on
-    // arrays. SQLite COUNT(*) returns int64 internally but sqlite_read
+    // arrays. SQLite COUNT(*) returns int64 internally but read_via_adapter
     // narrows to int via sqlite3_column_int — fine for any plausible row
     // count and matches the user's projection-tuple inferred type.
     if ((fname == "length" || fname == "count") && argc == 1
@@ -1882,12 +1882,25 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
     {
         var lhs, rhs : ExpressionPtr
         if (qmatch(node, $e(lhs) == $e(rhs)).matched) {
+            // ``_.Col == none()`` is a common footgun: the user probably
+            // meant ``_.Col |> is_none()``. ``none()`` returns
+            // ``Option<T>``, comparing it to a column value would auto-bind
+            // a 0-byte placeholder and produce wrong results, so emit a
+            // fixit-style ``macro_error`` pointing at the right spelling.
+            if (is_none_call(lhs) || is_none_call(rhs)) {
+                macro_error(prog, at, "_sql: `_.Col == none()` is not translated. Use `_.Col |> is_none()` (or `is_some()` for the negation) — `none()` returns Option<T>, equality against it would silently bind an empty placeholder.")
+                return ""
+            }
             return "{pred_to_sql(lhs, q, prog, at)} = {pred_to_sql(rhs, q, prog, at)}"
         }
     }
     {
         var lhs, rhs : ExpressionPtr
         if (qmatch(node, $e(lhs) != $e(rhs)).matched) {
+            if (is_none_call(lhs) || is_none_call(rhs)) {
+                macro_error(prog, at, "_sql: `_.Col != none()` is not translated. Use `_.Col |> is_some()` (the inverse of is_none).")
+                return ""
+            }
             return "{pred_to_sql(lhs, q, prog, at)} <> {pred_to_sql(rhs, q, prog, at)}"
         }
     }
@@ -2121,7 +2134,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
     }
 
     // Literal / captured var → bind param. Clone the *peeled* expression so
-    // when we re-emit it as a `sqlite_bind` argument the runtime reads the
+    // when we re-emit it as a `sql_bind_to_stmt` argument the runtime reads the
     // captured value cleanly (without re-wrapping into ExprRef2Value).
     // Inside `_having`, route to havingBindExprs so the placeholder index
     // matches the SQL emission order (WHERE → HAVING → LIMIT).
@@ -2132,6 +2145,27 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             q.bindExprs |> push <| clone_expression(node)
         }
         return "?"
+    }
+
+    // Common footgun: equality / inequality against ``none()``. After the
+    // typer rewrites ``a == b`` into ``operator==(a, b)`` we lose the
+    // qmatch-friendly binary shape, so detect the call form here and emit
+    // a fixit pointing at ``is_none()`` / ``is_some()``.
+    if (node is ExprCall) {
+        let c = node as ExprCall
+        let cname = string(c.name)
+        if (cname |> find("eq") >= 0 && length(c.arguments) >= 2) {
+            for (a in c.arguments) {
+                if (is_none_call(a)) {
+                    let positive = cname |> find("not") < 0
+                    macro_error(prog, at,
+                        positive
+                            ? "_sql: `_.Col == none()` is not translated. Use `_.Col |> is_none()` (or `is_some()` for the negation) — `none()` returns Option<T>, equality against it would silently bind an empty placeholder."
+                            : "_sql: `_.Col != none()` is not translated. Use `_.Col |> is_some()` (the inverse of is_none).")
+                    return ""
+                }
+            }
+        }
     }
 
     macro_error(prog, at, "_sql: _where: unsupported expression. Got: {describe(node)}")
@@ -2491,6 +2525,35 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
 }
 
 [macro_function]
+def private is_none_call(node : ExpressionPtr) : bool {
+    //! Detect ``none()`` (or ``none(type<T>)``) so the equality walker can
+    //! emit a fixit error pointing at ``is_none()``. ``none`` lives in
+    //! daslib/option; once the typer reifies the template the call's name
+    //! becomes a mangled form like ``_::`template`0x…`option`none`…``, so
+    //! we substring-match instead of exact-equality.
+    if (node == null) {
+        return false
+    }
+    var peeled = node
+    if (peeled is ExprRef2Value) {
+        peeled = (peeled as ExprRef2Value).subexpr
+        if (peeled == null) {
+            return false
+        }
+    }
+    if (peeled is ExprCall) {
+        let c = peeled as ExprCall
+        let cname = string(c.name)
+        if (cname == "none") {
+            return true
+        }
+        // Reified template form: contains both "option" and "none".
+        return cname |> find("option") >= 0 && cname |> find("none") >= 0
+    }
+    return false
+}
+
+[macro_function]
 def private is_const_or_captured_var(var node : ExpressionPtr) : bool {
     //! Recognize a literal or a captured-var read so the predicate walker can
     //! emit a `?` placeholder + bind. After Mode-2 inner expansion captured
@@ -2505,8 +2568,10 @@ def private is_const_or_captured_var(var node : ExpressionPtr) : bool {
             return false
         }
     }
-    if (node is ExprConstInt || node is ExprConstInt64 || node is ExprConstUInt || node is ExprConstUInt64
-        || node is ExprConstFloat || node is ExprConstDouble || node is ExprConstBool || node is ExprConstString) {
+    if (node is ExprConstInt || node is ExprConstInt8 || node is ExprConstInt16 || node is ExprConstInt64
+        || node is ExprConstUInt || node is ExprConstUInt8 || node is ExprConstUInt16 || node is ExprConstUInt64
+        || node is ExprConstFloat || node is ExprConstDouble || node is ExprConstBool || node is ExprConstString
+        || node is ExprConstEnumeration || node is ExprConstBitfield) {
         return true
     }
     if (node is ExprVar) {
@@ -2756,9 +2821,9 @@ class private SqlTextMacro : AstCallMacro {
 //
 // The row-builder block is determined by q.proj:
 //   - FullRow      → _::_sql_read_row(stmt, type<T>)
-//   - SingleColumn → sqlite_read(stmt, 0, type<FieldType>)
+//   - SingleColumn → read_via_adapter(stmt, 0, type<FieldType>)
 //   - NamedTuple   → tuple row builder for the projected fields
-//   - Aggregate    → sqlite_read(stmt, 0, type<aggregateType>)
+//   - Aggregate    → read_via_adapter(stmt, 0, type<aggregateType>)
 // ============================================================================
 
 [macro_function]
@@ -2782,7 +2847,7 @@ def private build_row_builder(var q : SqlQuery&; prog : ProgramPtr; at : LineInf
     if (q.proj == ProjectionShape.Aggregate) {
         let colIdx = 0
         var aggT = clone_type(q.aggregateType)
-        return qmacro(sqlite_read(_sql_stmt, $v(colIdx), type<$t(aggT)>))
+        return qmacro(read_via_adapter(_sql_stmt, $v(colIdx), type<$t(aggT)>))
     }
     if (q.proj == ProjectionShape.SingleColumn) {
         let colIdx = 0
@@ -2798,10 +2863,10 @@ def private build_row_builder(var q : SqlQuery&; prog : ProgramPtr; at : LineInf
             macro_error(prog, at, "_sql: cannot resolve type of projected column '{q.selectCols[0]}'")
             return null
         }
-        return qmacro(sqlite_read(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
+        return qmacro(read_via_adapter(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
     }
     if (q.proj == ProjectionShape.NamedTuple) {
-        // Build  (Name = sqlite_read(stmt, 0, type<...>), Price = sqlite_read(stmt, 1, type<...>))
+        // Build  (Name = read_via_adapter(stmt, 0, type<...>), Price = read_via_adapter(stmt, 1, type<...>))
         // recordNames live on the tuple TypeDecl's argNames — set those via
         // recordType so the typer reads them back into the ExprMakeTuple.
         let n = length(q.selectCols)
@@ -2824,7 +2889,7 @@ def private build_row_builder(var q : SqlQuery&; prog : ProgramPtr; at : LineInf
                 macro_error(prog, at, "_sql: cannot resolve type of projected column '{q.selectCols[i]}'")
                 return null
             }
-            var readExpr = qmacro(sqlite_read(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
+            var readExpr = qmacro(read_via_adapter(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
             emplace(mkTup.values, readExpr)
             tupT.argTypes |> emplace_new(clone_type(fieldType))
             tupT.argNames[i] := q.projRecordNames[i]
@@ -2843,7 +2908,7 @@ def private build_row_builder(var q : SqlQuery&; prog : ProgramPtr; at : LineInf
         for (i in range(n)) {
             let colIdx = i
             var fieldType = clone_type(q.groupedSelectTypes[i])
-            var readExpr = qmacro(sqlite_read(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
+            var readExpr = qmacro(read_via_adapter(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
             emplace(mkTup.values, readExpr)
             tupT.argTypes |> emplace_new(clone_type(fieldType))
             tupT.argNames[i] := q.projRecordNames[i]
@@ -2945,14 +3010,14 @@ def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; is
     }
     let sql = build_sql_string(q)
 
-    // Build bind statements: sqlite_bind(stmt, i+1, $e(boundExpr))
+    // Build bind statements: sql_bind_to_stmt(stmt, i+1, $e(boundExpr))
     var bind_stmts : array<ExpressionPtr>
     bind_stmts |> reserve(length(q.bindExprs))
     for (i in range(length(q.bindExprs))) {
         let bindIdx = i + 1
         var be = q.bindExprs[i]
         bind_stmts |> push <| qmacro_expr(${
-            sqlite_bind(_sql_stmt, $v(bindIdx), $e(be));
+            sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
         })
     }
 
@@ -3056,8 +3121,8 @@ class private TrySqlMacro : AstCallMacro {
 //   * Captured locals and literals classify as binds — pred_to_sql emits a
 //     `?` placeholder and the original ExprVar / ExprConst is pushed to the
 //     bind list. At the macro's output, the bind expression is passed verbatim
-//     to ``sqlite_bind(stmt, idx, expr)``; daslang's typer resolves the
-//     captured-var's type and overload-dispatches `sqlite_bind`.
+//     to ``sql_bind_to_stmt(stmt, idx, expr)``; daslang's typer resolves the
+//     captured-var's type and overload-dispatches `sql_bind_to_stmt`.
 //
 // Bind ordering for SET-then-WHERE SQL: SET binds come first, then WHERE
 // binds (matches placeholder order in `UPDATE ... SET col1=?, ... WHERE ...`).
@@ -3297,7 +3362,7 @@ def private emit_update_body(prog : ProgramPtr; var call : ExprCallMacro?;
         let bindIdx = i + 1
         var be = allBinds[i]
         bindStmts |> push <| qmacro_expr(${
-            sqlite_bind(_sql_stmt, $v(bindIdx), $e(be));
+            sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
         })
     }
     return emit_dml_call(dbE, sql, bindStmts, isTry, isReturning, rootT, call.at)
@@ -3335,7 +3400,7 @@ def private emit_delete_body(prog : ProgramPtr; var call : ExprCallMacro?;
         let bindIdx = i + 1
         var be = q.bindExprs[i]
         bindStmts |> push <| qmacro_expr(${
-            sqlite_bind(_sql_stmt, $v(bindIdx), $e(be));
+            sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
         })
     }
     return emit_dml_call(dbE, sql, bindStmts, isTry, isReturning, rootT, call.at)
@@ -3345,14 +3410,19 @@ def private emit_delete_body(prog : ProgramPtr; var call : ExprCallMacro?;
 // Outer macros — `canVisitArgument = false` for everything except db so the
 // WHERE / SET arguments stay raw (with `_` unbound). pred_to_sql operates on
 // the AST shape directly; bind expressions (captured locals, literals) are
-// passed through to ``sqlite_bind`` verbatim and resolve at the macro's
+// passed through to ``sql_bind_to_stmt`` verbatim and resolve at the macro's
 // output type-inference pass.
 // ----------------------------------------------------------------------------
 
 [macro_function]
-def private validate_outer_update_args(prog : ProgramPtr; var call : ExprCallMacro?; var rootT : TypeDeclPtr&) : bool {
-    if (length(call.arguments) != 4) {
-        macro_error(prog, call.at, "{call.name}: expected (db, type<T>, where_expr, set_expr) — got {length(call.arguments)} args")
+def private validate_outer_args(prog : ProgramPtr; var call : ExprCallMacro?; var rootT : TypeDeclPtr&;
+                                expected_arity : int; sig_text : string) : bool {
+    //! Shared validator for outer call_macros (``_sql_update`` / ``_sql_delete``
+    //! and their ``_sql_try_*_returning`` variants). Each caller supplies the
+    //! expected arg count (3 for delete, 4 for update) and a human-readable
+    //! signature like ``"(db, type<T>, where_expr)"``.
+    if (length(call.arguments) != expected_arity) {
+        macro_error(prog, call.at, "{call.name}: expected {sig_text} — got {length(call.arguments)} args")
         return false
     }
     var typeE = call.arguments[1]
@@ -3363,33 +3433,38 @@ def private validate_outer_update_args(prog : ProgramPtr; var call : ExprCallMac
     return true
 }
 
-[macro_function]
-def private validate_outer_delete_args(prog : ProgramPtr; var call : ExprCallMacro?; var rootT : TypeDeclPtr&) : bool {
-    if (length(call.arguments) != 3) {
-        macro_error(prog, call.at, "{call.name}: expected (db, type<T>, where_expr) — got {length(call.arguments)} args")
-        return false
+class private OuterArgZeroMacro : AstCallMacro {
+    //! Shared parent for the 8 `_sql_update*` / `_sql_delete*` outer macros.
+    //! Only argument 0 (``db``) is visited by the typer; the remaining args
+    //! (``type<T>``, ``where_expr``, optional ``set_expr``) stay raw so
+    //! ``pred_to_sql`` and the named-tuple walker can read the unresolved AST
+    //! shape with ``_`` unbound. ``[call_macro(name=...)]`` does not inherit,
+    //! so each concrete subclass keeps its own annotation.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex == 0
     }
-    var typeE = call.arguments[1]
-    if (!qmatch(typeE, type<$t(rootT)>).matched) {
-        macro_error(prog, call.at, "{call.name}: second argument must be a `type<T>` literal")
-        return false
+}
+
+class private OuterArgTwoMacro : AstCallMacro {
+    //! Shared parent for the 4 `_sql_upsert*` outer macros. Args 0 (``db``)
+    //! and 1 (``row``) are visited by the typer (the row needs to be a
+    //! resolved struct value); args 2 (``on_conflict``) and 3 (``do_update``)
+    //! stay raw for the analyzer to walk.
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return argIndex < 2
     }
-    return true
 }
 
 [call_macro(name="_sql_update")]
-class private SqlUpdateMacro : AstCallMacro {
+class private SqlUpdateMacro : OuterArgZeroMacro {
     //! `_sql_update(db, type<T>, where_expr, set_expr)` — predicate-based UPDATE.
     //! ``where_expr`` is an expression in the row variable `_` (e.g.
     //! ``_.LastSeen < cutoff``). ``set_expr`` is a named-tuple literal
     //! ``(Col1=expr1, Col2=expr2, ...)`` whose RHS may reference ``_.Col``
     //! and captured locals. Returns ``int`` rows-affected. Panics on SQL error.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex == 0
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
-        if (!validate_outer_update_args(prog, call, rootT)) {
+        if (!validate_outer_args(prog, call, rootT, 4, "(db, type<T>, where_expr, set_expr)")) {
             return null
         }
         return emit_update_body(prog, call, rootT, false, false)
@@ -3397,14 +3472,11 @@ class private SqlUpdateMacro : AstCallMacro {
 }
 
 [call_macro(name="_sql_try_update")]
-class private SqlTryUpdateMacro : AstCallMacro {
+class private SqlTryUpdateMacro : OuterArgZeroMacro {
     //! Non-panic sibling of `_sql_update`. Returns ``Result<int, string>``.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex == 0
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
-        if (!validate_outer_update_args(prog, call, rootT)) {
+        if (!validate_outer_args(prog, call, rootT, 4, "(db, type<T>, where_expr, set_expr)")) {
             return null
         }
         return emit_update_body(prog, call, rootT, true, false)
@@ -3412,15 +3484,12 @@ class private SqlTryUpdateMacro : AstCallMacro {
 }
 
 [call_macro(name="_sql_update_returning")]
-class private SqlUpdateReturningMacro : AstCallMacro {
+class private SqlUpdateReturningMacro : OuterArgZeroMacro {
     //! `_sql_update(...)` with a trailing ``RETURNING *`` clause. Returns
     //! ``array<T>`` of post-update rows. Panics on SQL error.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex == 0
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
-        if (!validate_outer_update_args(prog, call, rootT)) {
+        if (!validate_outer_args(prog, call, rootT, 4, "(db, type<T>, where_expr, set_expr)")) {
             return null
         }
         return emit_update_body(prog, call, rootT, false, true)
@@ -3428,15 +3497,12 @@ class private SqlUpdateReturningMacro : AstCallMacro {
 }
 
 [call_macro(name="_sql_try_update_returning")]
-class private SqlTryUpdateReturningMacro : AstCallMacro {
+class private SqlTryUpdateReturningMacro : OuterArgZeroMacro {
     //! Non-panic sibling of `_sql_update_returning`. Returns
     //! ``Result<array<T>, string>``.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex == 0
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
-        if (!validate_outer_update_args(prog, call, rootT)) {
+        if (!validate_outer_args(prog, call, rootT, 4, "(db, type<T>, where_expr, set_expr)")) {
             return null
         }
         return emit_update_body(prog, call, rootT, true, true)
@@ -3444,15 +3510,12 @@ class private SqlTryUpdateReturningMacro : AstCallMacro {
 }
 
 [call_macro(name="_sql_delete")]
-class private SqlDeleteMacro : AstCallMacro {
+class private SqlDeleteMacro : OuterArgZeroMacro {
     //! `_sql_delete(db, type<T>, where_expr)` — predicate-based DELETE.
     //! Returns ``int`` rows-affected. Panics on SQL error.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex == 0
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
-        if (!validate_outer_delete_args(prog, call, rootT)) {
+        if (!validate_outer_args(prog, call, rootT, 3, "(db, type<T>, where_expr)")) {
             return null
         }
         return emit_delete_body(prog, call, rootT, false, false)
@@ -3460,14 +3523,11 @@ class private SqlDeleteMacro : AstCallMacro {
 }
 
 [call_macro(name="_sql_try_delete")]
-class private SqlTryDeleteMacro : AstCallMacro {
+class private SqlTryDeleteMacro : OuterArgZeroMacro {
     //! Non-panic sibling of `_sql_delete`. Returns ``Result<int, string>``.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex == 0
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
-        if (!validate_outer_delete_args(prog, call, rootT)) {
+        if (!validate_outer_args(prog, call, rootT, 3, "(db, type<T>, where_expr)")) {
             return null
         }
         return emit_delete_body(prog, call, rootT, true, false)
@@ -3475,15 +3535,12 @@ class private SqlTryDeleteMacro : AstCallMacro {
 }
 
 [call_macro(name="_sql_delete_returning")]
-class private SqlDeleteReturningMacro : AstCallMacro {
+class private SqlDeleteReturningMacro : OuterArgZeroMacro {
     //! `_sql_delete(...)` with a trailing ``RETURNING *`` clause. Returns
     //! ``array<T>`` of just-deleted rows. Panics on SQL error.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex == 0
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
-        if (!validate_outer_delete_args(prog, call, rootT)) {
+        if (!validate_outer_args(prog, call, rootT, 3, "(db, type<T>, where_expr)")) {
             return null
         }
         return emit_delete_body(prog, call, rootT, false, true)
@@ -3491,15 +3548,12 @@ class private SqlDeleteReturningMacro : AstCallMacro {
 }
 
 [call_macro(name="_sql_try_delete_returning")]
-class private SqlTryDeleteReturningMacro : AstCallMacro {
+class private SqlTryDeleteReturningMacro : OuterArgZeroMacro {
     //! Non-panic sibling of `_sql_delete_returning`. Returns
     //! ``Result<array<T>, string>``.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex == 0
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
-        if (!validate_outer_delete_args(prog, call, rootT)) {
+        if (!validate_outer_args(prog, call, rootT, 3, "(db, type<T>, where_expr)")) {
             return null
         }
         return emit_delete_body(prog, call, rootT, true, true)
@@ -3516,10 +3570,11 @@ class private SqlTryDeleteReturningMacro : AstCallMacro {
 //   - do_update : named-tuple literal `(Col=expr, ...)` referencing `_` (existing row)
 //                 and/or `_excluded` (proposed row — SQLite's built-in sentinel)
 //
-// Like `_sql_update`, args 1..3 stay raw (canVisitArgument=true only for arg 0,
-// the db). The do_update walker runs `pred_to_sql` with `q.upsertMode = true` so
-// `_excluded.Col` resolves to SQLite's `excluded.col`; `_.Col` resolves to the
-// unqualified column reference (existing-row in DO UPDATE SET context).
+// Args 2 and 3 stay raw (canVisitArgument visits only args 0 and 1 — the db
+// and the row, since the row needs to be a typed struct value). The do_update
+// walker runs `pred_to_sql` with `q.upsertMode = true` so `_excluded.Col`
+// resolves to SQLite's `excluded.col`; `_.Col` resolves to the unqualified
+// column reference (existing-row in DO UPDATE SET context).
 // ============================================================================
 
 [macro_function]
@@ -3831,7 +3886,7 @@ def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
         let bindIdx = nRowBinds + i + 1
         var be = setBindExprs[i]
         bindStmts |> push <| qmacro_expr(${
-            sqlite_bind(_sql_stmt, $v(bindIdx), $e(be));
+            sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
         })
     }
 
@@ -3839,12 +3894,9 @@ def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
 }
 
 [call_macro(name="_sql_upsert")]
-class private SqlUpsertMacro : AstCallMacro {
+class private SqlUpsertMacro : OuterArgTwoMacro {
     //! `_sql_upsert(db, row, on_conflict, do_update)` — INSERT...ON CONFLICT
     //! DO UPDATE. Returns ``int`` rows-affected. Panics on SQL error.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex < 2
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_upsert_args(prog, call, rootT)) {
@@ -3855,11 +3907,8 @@ class private SqlUpsertMacro : AstCallMacro {
 }
 
 [call_macro(name="_sql_try_upsert")]
-class private SqlTryUpsertMacro : AstCallMacro {
+class private SqlTryUpsertMacro : OuterArgTwoMacro {
     //! Non-panic sibling of `_sql_upsert`. Returns ``Result<int, string>``.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex < 2
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_upsert_args(prog, call, rootT)) {
@@ -3870,12 +3919,9 @@ class private SqlTryUpsertMacro : AstCallMacro {
 }
 
 [call_macro(name="_sql_upsert_returning")]
-class private SqlUpsertReturningMacro : AstCallMacro {
+class private SqlUpsertReturningMacro : OuterArgTwoMacro {
     //! `_sql_upsert(...)` with a trailing ``RETURNING *`` clause. Returns
     //! ``array<T>`` of post-merge rows. Panics on SQL error.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex < 2
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_upsert_args(prog, call, rootT)) {
@@ -3886,12 +3932,9 @@ class private SqlUpsertReturningMacro : AstCallMacro {
 }
 
 [call_macro(name="_sql_try_upsert_returning")]
-class private SqlTryUpsertReturningMacro : AstCallMacro {
+class private SqlTryUpsertReturningMacro : OuterArgTwoMacro {
     //! Non-panic sibling of `_sql_upsert_returning`. Returns
     //! ``Result<array<T>, string>``.
-    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        return argIndex < 2
-    }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_upsert_args(prog, call, rootT)) {

--- a/tests/dasSQLITE/failed_sql_macro.das
+++ b/tests/dasSQLITE/failed_sql_macro.das
@@ -7,7 +7,7 @@ options gen2
 // analyzer ever runs — e.g. `_select(_.Name) |> _select(_.Price)` is a
 // genuine type bug (string has no `Price` field) and `some_unknown_func(_)`
 // hits the unresolved function. Those cascades are expected.
-expect 40104:21, 30304:2, 30503:3
+expect 40104:23, 30304:2, 30503:3
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -126,6 +126,16 @@ def main() {
     //     valid in unparenthesized compound query.
     let bad19 <- _sql((db |> select_from(type<Car>) |> _select(_.Price))
                        |> union(db |> select_from(type<Car>) |> _select(_.Price) |> take(5)))
+
+    // 20. `_.Col == none()` — fixit error redirects to is_none(). The
+    //     locked decision (chunk-4 D4) is "explicit-over-magic": the
+    //     compiler refuses to translate the equality and points at the
+    //     correct spelling. See pred_to_sql `==` handler.
+    var nullable_owner = Owner(Id = 0, CarId = 0, Name = "")
+    let bad20 <- _sql(db |> select_from(type<Owner>) |> _where(_.CarId == none(type<int>)))
+
+    // 21. `_.Col != none()` — same fixit; the inverse is `is_some()`.
+    let bad21 <- _sql(db |> select_from(type<Owner>) |> _where(_.CarId != none(type<int>)))
     // (Note: the "_in subquery without _select(_.Col)" diagnostic added in
     //  this round is also belt-and-suspenders — a daslang `contains` type-
     //  check rejects mismatched element types before sqlite_linq even sees

--- a/tests/dasSQLITE/test_04_user_types.das
+++ b/tests/dasSQLITE/test_04_user_types.das
@@ -6,27 +6,21 @@ require daslib/sql
 require daslib/strings_boost
 require sqlite/sqlite_boost
 
-// User-defined column type. Stored as TEXT, formatted "r,g,b" on bind, parsed
-// on read-back.
+// User-defined column type. Stored as TEXT (sql_bind returns string), formatted
+// "r,g,b" on bind, parsed on read-back. Exercises the tut-26 sql_bind /
+// sql_extract adapter rail.
 struct Color {
     r : int
     g : int
     b : int
 }
 
-[unused_argument(witness)]
-def sqlite_sql_type(witness : Color) : string {
-    return "TEXT"
-}
-
-def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : Color) : void {
-    let s = "{value.r},{value.g},{value.b}"
-    sqlite3_bind_text(stmt, idx, s)
+def sql_bind(value : Color) : string {
+    return "{value.r},{value.g},{value.b}"
 }
 
 [unused_argument(t)]
-def sqlite_read(stmt : sqlite3_stmt?; col : int; t : type<Color>) : Color {
-    let s = sqlite3_column_text_(stmt, col)
+def sql_extract(s : string; t : type<Color>) : Color {
     let parts <- split(s, ",")
     return Color(r = to_int(parts[0]), g = to_int(parts[1]), b = to_int(parts[2]))
 }
@@ -40,7 +34,7 @@ struct Pixel {
 [test]
 def test_user_type_in_create_ddl(t : T?) {
     let ddl = _sql_create_table_sql(type<Pixel>)
-    t |> success(ddl |> find("\"Tint\" TEXT NOT NULL") >= 0, "user sqlite_sql_type used in DDL")
+    t |> success(ddl |> find("\"Tint\" TEXT NOT NULL") >= 0, "user sql_bind return type drives DDL column type")
 }
 
 [test]
@@ -49,7 +43,7 @@ def test_user_type_round_trip(t : T?) {
         db |> create_table(type<Pixel>)
         db |> insert(Pixel(Id = 1, Tint = Color(r = 255, g = 64, b = 0)))
         let s = db |> query_scalar("SELECT Tint FROM Pixels WHERE Id = 1", type<string>)
-        t |> equal(s, "255,64,0", "user sqlite_bind formatted the value on insert")
+        t |> equal(s, "255,64,0", "user sql_bind formatted the value on insert")
     }
 }
 
@@ -62,7 +56,7 @@ def test_user_type_select_from(t : T?) {
         let rows <- db |> select_from(type<Pixel>)
         t |> equal(length(rows), 2, "select_from returns all rows")
         t |> equal(rows[0].Id, 1, "row 0 Id")
-        t |> equal(rows[0].Tint.r, 255, "row 0 Tint.r — round-tripped through user sqlite_read")
+        t |> equal(rows[0].Tint.r, 255, "row 0 Tint.r — round-tripped through user sql_extract")
         t |> equal(rows[0].Tint.g, 64, "row 0 Tint.g")
         t |> equal(rows[0].Tint.b, 0, "row 0 Tint.b")
         t |> equal(rows[1].Tint.r, 0, "row 1 Tint.r")

--- a/tests/dasSQLITE/test_05a_select_from_compat.das
+++ b/tests/dasSQLITE/test_05a_select_from_compat.das
@@ -30,7 +30,7 @@ def private fixture(db : SqlRunner) {
 // `select_from(db, type<T>) : array<T>` is a regular runtime function. It
 // prepares `SELECT col1, col2, ... FROM Table`, steps the cursor, and
 // materializes every row via the chunk-1 `[sql_table]`-emitted
-// `_sql_read_row` helper + `sqlite_read` dispatch rail. Anything chained on
+// `_sql_read_row` helper + `read_via_adapter` dispatch rail. Anything chained on
 // top in compat mode is plain daslib/linq running client-side over the
 // already-materialized array — no SQL push-down. `_sql` is the optimization
 // path; `select_from` standalone is the always-works baseline.

--- a/tests/dasSQLITE/test_30_count_canary.das
+++ b/tests/dasSQLITE/test_30_count_canary.das
@@ -27,7 +27,7 @@ def private fixture(db : SqlRunner) {
 //   - ProjectionShape.Aggregate sets the SELECT-list to "COUNT(*)"
 //   - Materializer.One reads back a single int (matches daslang's
 //     `length(arr)`/`count(arr)` return type; SQLite COUNT(*) is int64
-//     internally but `sqlite_read(stmt, 0, type<int>)` narrows it)
+//     internally but `read_via_adapter(stmt, 0, type<int>)` narrows it)
 //
 // `_count` is reserved as a 2-arg call_macro in linq_boost (predicate form,
 // chunk 4 territory). For the bare aggregate we use linq.das's `count(src)`

--- a/tests/dasSQLITE/test_61_custom_types.das
+++ b/tests/dasSQLITE/test_61_custom_types.das
@@ -1,0 +1,193 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 26 — sql_bind / sql_extract adapter rail. Tests cover:
+//   - DateTime via INTEGER (default storage choice — 64-bit unix seconds)
+//   - Guid via BLOB (16 raw bytes)
+//   - Domain enum via INTEGER (auto-handled by dasSQLITE's enum generic)
+//   - Standard-type widenings (int → int64, float → double, bool → int64)
+//   - Option<T> over a custom adapter — NULL on the bind/read sides
+//   - DDL column types come from sql_bind's RETURN type
+//   - _sql(... where _.EnumCol == EnumValue) translates to bind param
+
+struct DateTime {
+    unix_seconds : int64
+}
+
+def sql_bind(dt : DateTime) : int64 {
+    return dt.unix_seconds
+}
+
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<DateTime>) : DateTime {
+    return DateTime(unix_seconds = v)
+}
+
+struct Guid {
+    @safe_when_uninitialized bytes : array<uint8>
+}
+
+def sql_bind(g : Guid) : array<uint8> {
+    var copy : array<uint8>
+    copy := g.bytes
+    return <- copy
+}
+
+[unused_argument(t)]
+def sql_extract(var v : array<uint8>; t : type<Guid>) : Guid {
+    return Guid(bytes <- v)
+}
+
+enum OrderStatus {
+    Pending
+    Paid
+    Shipped
+    Cancelled
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    ExternalId : Guid           // BLOB
+    PlacedAt   : DateTime       // INTEGER
+    Status     : OrderStatus    // INTEGER (enum generic)
+    Total      : float          // REAL (float → double widening)
+}
+
+[sql_table(name = "Events")]
+struct Event {
+    @sql_primary_key Id : int
+    At                                : DateTime
+    @safe_when_uninitialized StartsAt : Option<DateTime>
+}
+
+def make_guid_filled(b : uint8) : Guid {
+    var bytes : array<uint8>
+    bytes |> resize(16)
+    for (i in range(16)) {
+        bytes[i] = b
+    }
+    return Guid(bytes <- bytes)
+}
+
+[test]
+def test_ddl_picks_storage_type_per_adapter(t : T?) {
+    let ddl = _sql_create_table_sql(type<Order>)
+    t |> success(ddl |> find("\"ExternalId\" BLOB") >= 0, "Guid (sql_bind→array<uint8>) → BLOB column")
+    t |> success(ddl |> find("\"PlacedAt\" INTEGER") >= 0, "DateTime (sql_bind→int64) → INTEGER column")
+    t |> success(ddl |> find("\"Status\" INTEGER") >= 0, "enum (generic sql_bind→int64) → INTEGER column")
+    t |> success(ddl |> find("\"Total\" REAL") >= 0, "float (widening sql_bind→double) → REAL column")
+    t |> success(ddl |> find("\"Id\" INTEGER PRIMARY KEY") >= 0, "int PK (widening sql_bind→int64) → INTEGER PRIMARY KEY")
+}
+
+[test]
+def test_datetime_round_trip(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Order>)
+        db |> insert(Order(
+            Id = 1,
+            ExternalId = make_guid_filled(uint8(0)),
+            PlacedAt = DateTime(unix_seconds = 1713000000l),
+            Status = OrderStatus.Pending,
+            Total = 0.0
+        ))
+        let stored = db |> query_scalar("SELECT PlacedAt FROM Orders WHERE Id = 1", type<int64>)
+        t |> equal(stored, 1713000000l, "DateTime stored as int64 unix seconds")
+        let rows <- db |> select_from(type<Order>)
+        t |> equal(rows[0].PlacedAt.unix_seconds, 1713000000l, "DateTime round-trips through sql_extract")
+    }
+}
+
+[test]
+def test_guid_blob_round_trip(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Order>)
+        db |> insert(Order(
+            Id = 1,
+            ExternalId = make_guid_filled(uint8(0xAB)),
+            PlacedAt = DateTime(unix_seconds = 0l),
+            Status = OrderStatus.Pending,
+            Total = 0.0
+        ))
+        let rows <- db |> select_from(type<Order>)
+        t |> equal(length(rows), 1, "one row inserted + read back")
+        t |> equal(length(rows[0].ExternalId.bytes), 16, "Guid round-tripped 16 bytes")
+        t |> equal(int(rows[0].ExternalId.bytes[0]), int(0xAB), "first byte preserved")
+        t |> equal(int(rows[0].ExternalId.bytes[15]), int(0xAB), "last byte preserved")
+    }
+}
+
+[test]
+def test_enum_round_trip(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Order>)
+        db |> insert(Order(
+            Id = 1, ExternalId = make_guid_filled(uint8(0)),
+            PlacedAt = DateTime(unix_seconds = 0l),
+            Status = OrderStatus.Shipped, Total = 0.0
+        ))
+        let rows <- db |> select_from(type<Order>)
+        t |> equal(int(rows[0].Status), int(OrderStatus.Shipped), "enum round-trips through INTEGER")
+        let stored = db |> query_scalar("SELECT Status FROM Orders WHERE Id = 1", type<int64>)
+        t |> equal(stored, int64(OrderStatus.Shipped), "enum stored as int64 ordinal")
+    }
+}
+
+[test]
+def test_enum_in_where_predicate(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Order>)
+        db |> insert(Order(
+            Id = 1, ExternalId = make_guid_filled(uint8(0)),
+            PlacedAt = DateTime(unix_seconds = 0l),
+            Status = OrderStatus.Paid, Total = 0.0
+        ))
+        db |> insert(Order(
+            Id = 2, ExternalId = make_guid_filled(uint8(0)),
+            PlacedAt = DateTime(unix_seconds = 0l),
+            Status = OrderStatus.Cancelled, Total = 0.0
+        ))
+        let paid <- _sql(db |> select_from(type<Order>) |> _where(_.Status == OrderStatus.Paid))
+        t |> equal(length(paid), 1, "WHERE Status = OrderStatus.Paid matches one row")
+        t |> equal(paid[0].Id, 1, "matched the right row")
+    }
+}
+
+[test]
+def test_option_over_custom_adapter(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Event>)
+        db |> insert(Event(Id = 1, At = DateTime(unix_seconds = 100l), StartsAt = none(type<DateTime>)))
+        db |> insert(Event(Id = 2, At = DateTime(unix_seconds = 200l), StartsAt = some(DateTime(unix_seconds = 300l))))
+
+        let r1 = db |> query_one("SELECT * FROM Events WHERE Id = 1", type<Event>)
+        t |> success(r1.StartsAt |> is_none(), "none() Option<DateTime> binds as NULL, reads as none")
+
+        let r2 = db |> query_one("SELECT * FROM Events WHERE Id = 2", type<Event>)
+        t |> success(r2.StartsAt |> is_some(), "some(...) Option<DateTime> binds and reads back as some")
+        t |> equal(r2.StartsAt._value.unix_seconds, 300l, "Option<DateTime> inner value preserved")
+    }
+}
+
+[test]
+def test_query_scalar_through_adapter(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Order>)
+        db |> insert(Order(
+            Id = 42, ExternalId = make_guid_filled(uint8(0)),
+            PlacedAt = DateTime(unix_seconds = 1234567890l),
+            Status = OrderStatus.Paid, Total = 99.5
+        ))
+        // query_scalar routes through read_via_adapter, so user adapters
+        // work transparently in raw-SQL paths too.
+        let dt = db |> query_scalar("SELECT PlacedAt FROM Orders WHERE Id = 42", type<DateTime>)
+        t |> equal(dt.unix_seconds, 1234567890l, "DateTime extracted via custom adapter from raw SQL")
+        let st = db |> query_scalar("SELECT Status FROM Orders WHERE Id = 42", type<OrderStatus>)
+        t |> equal(int(st), int(OrderStatus.Paid), "enum extracted via generic adapter from raw SQL")
+    }
+}

--- a/tests/dasSQLITE/test_62_blob.das
+++ b/tests/dasSQLITE/test_62_blob.das
@@ -1,0 +1,142 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 27 — BLOB column round-trip via array<uint8>.
+//
+// `array<uint8>` is one of the four storage primitives, so it works as
+// a [sql_table] field type without user adapter code. Tests cover
+// DDL emission, byte-level round-trip, large blob (SQLITE_TRANSIENT
+// correctness across step), Option<array<uint8>> nullability, and
+// inline byte-array predicates.
+
+[sql_table(name = "Images")]
+struct Image {
+    @sql_primary_key Id : int
+    Name : string
+    @safe_when_uninitialized Data : array<uint8>
+}
+
+[sql_table(name = "Files")]
+struct FileRow {
+    @sql_primary_key Id : int
+    @safe_when_uninitialized Body : Option<array<uint8>>
+}
+
+def make_bytes(n : int; pattern : uint8) : array<uint8> {
+    var bytes : array<uint8>
+    bytes |> resize(n)
+    for (i in range(n)) {
+        bytes[i] = uint8((int(pattern) + i) & int(0xff))
+    }
+    return <- bytes
+}
+
+[test]
+def test_blob_ddl_is_BLOB_NOT_NULL(t : T?) {
+    let ddl = _sql_create_table_sql(type<Image>)
+    t |> success(ddl |> find("\"Data\" BLOB NOT NULL") >= 0, "array<uint8> field DDL is BLOB NOT NULL")
+}
+
+[test]
+def test_blob_round_trip(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Image>)
+        var payload = make_bytes(64, uint8(0x10))
+        let payload_len = length(payload)
+        let payload_first = int(payload[0])
+        let payload_last = int(payload[63])
+        db |> insert(Image(Id = 1, Name = "thumb", Data <- payload))
+
+        let rows <- db |> select_from(type<Image>)
+        t |> equal(length(rows), 1, "one row")
+        t |> equal(length(rows[0].Data), payload_len, "all bytes round-tripped")
+        t |> equal(int(rows[0].Data[0]), payload_first, "first byte preserved")
+        t |> equal(int(rows[0].Data[63]), payload_last, "last byte preserved")
+    }
+}
+
+[test]
+def test_large_blob_survives_step(t : T?) {
+    //! 256 KB blob. Verifies SQLITE_TRANSIENT in sqlite3_bind_blob and the
+    //! per-row copy in sqlite3_column_blob_ both behave correctly when the
+    //! daslang heap allocations don't outlive the C-side buffer pointers.
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Image>)
+        let n = 256 * 1024
+        var bytes = make_bytes(n, uint8(0x55))
+        let expected_first = int(bytes[0])
+        let expected_mid = int(bytes[n / 2])
+        let expected_last = int(bytes[n - 1])
+        db |> insert(Image(Id = 1, Name = "big", Data <- bytes))
+
+        let rows <- db |> select_from(type<Image>)
+        t |> equal(length(rows[0].Data), n, "256 KB blob length preserved")
+        t |> equal(int(rows[0].Data[0]), expected_first, "byte 0 preserved")
+        t |> equal(int(rows[0].Data[n / 2]), expected_mid, "midpoint byte preserved")
+        t |> equal(int(rows[0].Data[n - 1]), expected_last, "last byte preserved")
+    }
+}
+
+[test]
+def test_query_scalar_blob(t : T?) {
+    //! Raw-SQL path goes through read_via_adapter just like [sql_table];
+    //! query_scalar with type<array<uint8>> reads the BLOB column directly.
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Image>)
+        var bytes = make_bytes(8, uint8(0xA0))
+        db |> insert(Image(Id = 1, Name = "scalar", Data <- bytes))
+
+        let blob = db |> query_scalar("SELECT Data FROM Images WHERE Id = 1", type<array<uint8>>)
+        t |> equal(length(blob), 8, "scalar BLOB read length")
+        t |> equal(int(blob[0]), int(0xA0), "byte 0 via query_scalar")
+    }
+}
+
+[test]
+def test_optional_blob_null_round_trip(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<FileRow>)
+        db |> insert(FileRow(Id = 1, Body = default<Option<array<uint8>>>))
+
+        var bytes = make_bytes(4, uint8(0xCD))
+        db |> insert(FileRow(Id = 2, Body = move_some(bytes)))
+
+        let rows <- db |> select_from(type<FileRow>)
+        t |> equal(length(rows), 2, "two rows")
+
+        // Find by Id; iteration order is rowid here.
+        for (r in rows) {
+            if (r.Id == 1) {
+                t |> success(r.Body |> is_none(), "NULL BLOB → none")
+            } elif (r.Id == 2) {
+                t |> success(r.Body |> is_some(), "non-NULL BLOB → some")
+                t |> equal(length(r.Body._value), 4, "non-null blob length")
+            }
+        }
+    }
+}
+
+[test]
+def test_empty_blob_distinct_from_null(t : T?) {
+    //! SQLite's BLOB literal vs NULL: a zero-length BLOB and NULL are
+    //! distinct values. Verifies the bind/read path preserves the
+    //! distinction (some(empty array) ≠ none).
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<FileRow>)
+        var empty_bytes : array<uint8>
+        db |> insert(FileRow(Id = 1, Body = move_some(empty_bytes)))
+        db |> insert(FileRow(Id = 2, Body = default<Option<array<uint8>>>))
+
+        let r1 = db |> query_one("SELECT * FROM Files WHERE Id = 1", type<FileRow>)
+        t |> success(r1.Body |> is_some(), "empty blob is some, not none")
+        t |> equal(length(r1.Body._value), 0, "empty blob has zero bytes")
+
+        let r2 = db |> query_one("SELECT * FROM Files WHERE Id = 2", type<FileRow>)
+        t |> success(r2.Body |> is_none(), "NULL blob is none")
+    }
+}

--- a/tests/dasSQLITE/test_63_exec_params.das
+++ b/tests/dasSQLITE/test_63_exec_params.das
@@ -1,0 +1,82 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+// Item A — exec/try_exec parameterized binds (chunk-6 deferred).
+//
+// `query_one` shipped 0/1/2/3-arg variadic overloads in chunk 3; `exec`
+// got the same fan-out in chunk 8 so raw DDL/DML can take captured
+// daslang values without inlining them into the SQL string.
+
+[sql_table(name = "T")]
+struct Row {
+    @sql_primary_key Id : int
+    Name : string
+    Score : int
+}
+
+[test]
+def test_exec_one_arg(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Row>)
+        let id = 7
+        db |> exec("INSERT INTO T(Id, Name, Score) VALUES (?, 'a', 0)", id)
+        let row = db |> query_one("SELECT * FROM T WHERE Id = ?", type<Row>, 7)
+        t |> equal(row.Id, 7, "1-arg exec bound id")
+    }
+}
+
+[test]
+def test_exec_two_args(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Row>)
+        db |> exec("INSERT INTO T(Id, Name, Score) VALUES (?, ?, 0)", 1, "alpha")
+        let row = db |> query_one("SELECT * FROM T WHERE Id = ?", type<Row>, 1)
+        t |> equal(row.Name, "alpha", "2-arg exec bound id + name")
+    }
+}
+
+[test]
+def test_exec_three_args(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Row>)
+        db |> exec("INSERT INTO T(Id, Name, Score) VALUES (?, ?, ?)", 1, "alpha", 100)
+        let row = db |> query_one("SELECT * FROM T WHERE Id = ?", type<Row>, 1)
+        t |> equal(row.Score, 100, "3-arg exec bound all three columns")
+    }
+}
+
+[test]
+def test_try_exec_returns_error(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        // bind to a non-existent table — try_exec returns some(errmsg)
+        let err = db |> try_exec("INSERT INTO NoTable VALUES (?)", 1)
+        t |> success(err |> is_some(), "missing table → some(err)")
+    }
+}
+
+[test]
+def test_try_exec_success_returns_none(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Row>)
+        let err = db |> try_exec("INSERT INTO T(Id, Name, Score) VALUES (?, 'x', 0)", 42)
+        t |> success(err |> is_none(), "successful exec → none")
+        let count = db |> query_scalar("SELECT COUNT(*) FROM T", type<int>)
+        t |> equal(count, 1, "row visible after try_exec success")
+    }
+}
+
+[test]
+def test_exec_no_args_still_works(t : T?) {
+    //! Regression: the chunk-8 variadic overloads must not break the
+    //! existing 0-arg ``exec(sql)`` path used everywhere in dasSQLITE
+    //! for DDL.
+    with_sqlite(":memory:") $(db) {
+        db |> exec("CREATE TABLE X(a INT)")
+        let count = db |> query_scalar("SELECT COUNT(*) FROM X", type<int>)
+        t |> equal(count, 0, "0-arg exec still works")
+    }
+}

--- a/tutorials/sql/26-custom_types.das
+++ b/tutorials/sql/26-custom_types.das
@@ -1,0 +1,221 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 26 — custom column types via the sql_bind / sql_extract pair.
+//
+// Every SQL-addressable type T has a bidirectional pair of named functions:
+//
+//     def sql_bind    (v : T) : P                 // T → primitive
+//     def sql_extract (v : P; t : type<T>) : T    // primitive → T
+//
+// where P is one of {int64, double, string, array<uint8>} — the four
+// SQLite storage classes. The RETURN TYPE of sql_bind IS the storage
+// type; the [sql_table] macro reads it and emits the matching
+// sqlite3_bind_* / sqlite3_column_* call. NULL is handled orthogonally
+// by tut 25's Option<T>, so this rail covers four storage forms, not five.
+//
+// Convention dispatch — no register_sql_type() call, no runtime lookup
+// table. Defining the pair next to the type IS the registration. The
+// [sql_table] macro emits `_::sql_bind(...)` so the user's-module
+// overloads are visible at expansion (same mechanism as `_::clone` /
+// `_::finalize`).
+//
+// Standard daslang types (every int*/uint*, float, double, bool, string,
+// array<uint8>) ship with adapter pairs in dasSQLITE itself. Enums round-
+// trip through INTEGER via a generic overload. User code only writes
+// adapters for domain types.
+
+// --- DateTime as INTEGER (unix seconds) ----------------------------------
+// Default storage choice for DateTime: integer is indexable, compact, and
+// math-friendly. The user provides the pair next to the type definition.
+
+struct DateTime {
+    unix_seconds : int64
+}
+
+def sql_bind(dt : DateTime) : int64 {
+    return dt.unix_seconds
+}
+
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<DateTime>) : DateTime {
+    return DateTime(unix_seconds = v)
+}
+
+// --- Guid as BLOB (16 raw bytes) -----------------------------------------
+// Same pattern, different primitive: the return type ``array<uint8>`` picks
+// BLOB storage automatically. Anything that round-trips through bytes —
+// asset hashes, network IDs, fingerprints — fits this shape.
+
+struct Guid {
+    @safe_when_uninitialized bytes : array<uint8>
+}
+
+def sql_bind(g : Guid) : array<uint8> {
+    //! Clones bytes into a fresh array so the returned value is owned. The
+    //! BLOB is then copied again by ``sqlite3_bind_blob`` (SQLITE_TRANSIENT).
+    //! For multi-MB asset blobs, prefer the ``sqlite3_blob_open`` streaming
+    //! API instead of round-tripping through a copy-on-bind adapter.
+    var copy : array<uint8>
+    copy := g.bytes
+    return <- copy
+}
+
+[unused_argument(t)]
+def sql_extract(var v : array<uint8>; t : type<Guid>) : Guid {
+    return Guid(bytes <- v)
+}
+
+// --- Domain enum (auto-handled by dasSQLITE's generic overload) ----------
+// dasSQLITE ships ``def sql_bind $T (e : T) : int64 where T : enum`` and
+// the matching extract, so any enum round-trips through INTEGER without
+// per-enum boilerplate. Tradeoff: reordering enum values silently corrupts
+// existing data (value 2 means something different in the new schema). For
+// rename-safe storage, the deferred `@sql_enum_as_string` annotation will
+// flip the rail to TEXT-backed; ship int-backed by default.
+
+enum OrderStatus {
+    Pending
+    Paid
+    Shipped
+    Cancelled
+}
+
+// --- Schema using all three custom types + a stdlib type -----------------
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    ExternalId : Guid           // BLOB column — Guid pair
+    PlacedAt   : DateTime       // INTEGER column — DateTime pair
+    Status     : OrderStatus    // INTEGER column — enum generic
+    Total      : float          // REAL column — stdlib float widening
+}
+
+// Emitted DDL (formatted for readability):
+//   CREATE TABLE "Orders"(
+//       "Id"         INTEGER PRIMARY KEY,
+//       "ExternalId" BLOB    NOT NULL,
+//       "PlacedAt"   INTEGER NOT NULL,
+//       "Status"     INTEGER NOT NULL,
+//       "Total"      REAL    NOT NULL
+//   )
+
+// --- Option<T> composes automatically ------------------------------------
+// Tut 25 already handles nullability: ``Option<DateTime>`` works iff
+// DateTime has the adapter pair. The [sql_table] macro unwraps Option<T>
+// at runtime and emits NULL-aware bind/read code. Zero extra adapters
+// needed.
+
+[sql_table(name = "Events")]
+struct Event {
+    @sql_primary_key Id : int
+    At       : DateTime                                    // NOT NULL INTEGER
+    @safe_when_uninitialized StartsAt : Option<DateTime>   // NULL INTEGER — same adapter under the Option
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Order>)
+        db |> create_table(type<Event>)
+
+        // The macro emits, per column:
+        //     sqlite3_bind_blob (..., _::sql_bind(o.ExternalId))   // array<uint8>
+        //     sqlite3_bind_int64(..., _::sql_bind(o.PlacedAt))     // int64
+        //     sqlite3_bind_int64(..., _::sql_bind(o.Status))       // enum → int64
+        //     sqlite3_bind_double(..., _::sql_bind(o.Total))       // float → double widening
+        var bytes : array<uint8>
+        for (_ in range(16)) {
+            bytes |> push(uint8(0xAB))
+        }
+        db |> insert(Order(
+            Id = 1,
+            ExternalId = Guid(bytes <- bytes),
+            PlacedAt = DateTime(unix_seconds = 1713000000l),
+            Status = OrderStatus.Paid,
+            Total = 99.5
+        ))
+
+        // SELECT round-trips the adapters in reverse:
+        //     _::sql_extract(sqlite3_column_blob (...), type<Guid>)
+        //     _::sql_extract(sqlite3_column_int64(...), type<DateTime>)
+        //     _::sql_extract(sqlite3_column_int64(...), type<OrderStatus>)
+        let paid <- _sql(db |> select_from(type<Order>) |> _where(_.Status == OrderStatus.Paid))
+        to_log(LOG_INFO, "paid orders: {length(paid)}\n")
+        if (length(paid) > 0) {
+            to_log(LOG_INFO, "first paid: PlacedAt unix_seconds={paid[0].PlacedAt.unix_seconds}\n")
+        }
+
+        // Option<DateTime> reads as Option — NULL column → none.
+        db |> insert(Event(Id = 1, At = DateTime(unix_seconds = 0l), StartsAt = none(type<DateTime>)))
+        db |> insert(Event(Id = 2, At = DateTime(unix_seconds = 0l), StartsAt = some(DateTime(unix_seconds = 1713000000l))))
+        let events <- _sql(db |> select_from(type<Event>))
+        for (e in events) {
+            if (e.StartsAt |> is_none()) {
+                to_log(LOG_INFO, "event {e.Id} not scheduled\n")
+            } else {
+                to_log(LOG_INFO, "event {e.Id} starts at {e.StartsAt._value.unix_seconds}\n")
+            }
+        }
+    }
+}
+
+// --- DateTime as TEXT (alternate storage form) ---------------------------
+// If ISO8601 text is preferred — for human-readable sqlite3 shell output
+// or compatibility with a schema that already stores dates as strings —
+// the user writes a pair whose ``sql_bind`` RETURNS string instead of
+// int64. Schema picks one storage form per type at module level (no
+// per-field override yet — see DEFERRED below).
+//
+//   def sql_bind(dt : DateTime) : string {
+//       return to_iso8601(dt.unix_seconds)
+//   }
+//   [unused_argument(t)]
+//   def sql_extract(s : string; t : type<DateTime>) : DateTime {
+//       return DateTime(unix_seconds = parse_iso8601(s))
+//   }
+
+// --- Missing-adapter compile error ---------------------------------------
+// If a [sql_table] struct has a field whose type has no ``sql_bind`` /
+// ``sql_extract`` pair in scope, the macro emits a literal call to
+// ``_::sql_bind(obj.field)`` and overload resolution falls through to the
+// catch-all generic, which tells the user to define the pair:
+//
+//     struct Color { r, g, b : float }
+//     [sql_table(name = "styles")]
+//     struct Style {
+//         @sql_primary_key Id : int
+//         Bg : Color           // no sql_bind(Color) — compile error
+//     }
+//
+// Error message names the offending struct + field type and gives the
+// signature template for the missing adapter. No runtime "type not
+// registered" error — this is all compile-time.
+
+// --- DEFERRED ------------------------------------------------------------
+//
+// @sql_as(type<P>) per-field override. Picks a specific primitive-returning
+// overload for ONE column when multiple adapter shapes exist for the same
+// type. Lock 8 in API_REWORK §29 specifies the shape; ships when a user
+// files an issue (the 95% case is one adapter per type).
+//
+//     [sql_table(name = "Meetings")]
+//     struct Meeting {
+//         @sql_primary_key Id : int
+//         At      : DateTime                  // default INTEGER adapter
+//         @sql_as(type<string>)               // FUTURE — string-returning overload
+//         HumanAt : DateTime                  // would emit TEXT column with ISO8601
+//     }
+//
+// Other deferred:
+//   - @sql_enum_as_string (rename-safe text storage for enums).
+//   - Fully-generic user adapters (`$T` templated on traits other than
+//     `enum`). Enum is the one concession; further genericity ships on
+//     concrete demand.
+//   - Adapter validators (`def sql_validate(v : T) : bool` for CHECK
+//     constraints). Column-level CHECK stays in tut 25's string form.
+//   - JSON / BLOB struct columns — tut 28 territory. Builds on this rail.

--- a/tutorials/sql/27-blob.das
+++ b/tutorials/sql/27-blob.das
@@ -1,0 +1,103 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 27 — BLOB columns: storing and reading raw bytes.
+//
+// ``array<uint8>`` is one of the four primitives in the tut-26 adapter
+// rail, so it works as a [sql_table] field type with no user adapter:
+//
+//     @sql_primary_key Id : int
+//     Data : array<uint8>            -> BLOB column, NOT NULL
+//
+// The [sql_table] DDL emits the BLOB type, INSERT binds the bytes via
+// ``sqlite3_bind_blob`` with ``SQLITE_TRANSIENT`` (SQLite copies into
+// its own buffer), and SELECT allocates a fresh ``array<uint8>`` on
+// daslang's heap and copies from the column pointer (which is only
+// valid until the next ``step``/``reset``).
+//
+// Three tradeoffs to be aware of:
+//
+//   - **Two copies on insert.** SQLite's ``SQLITE_TRANSIENT`` makes its
+//     own copy after the bind call. For multi-MB asset blobs, prefer
+//     SQLite's ``sqlite3_blob_open`` streaming API or chunked storage.
+//   - **One copy on read.** Each row materializes a fresh
+//     ``array<uint8>`` — the column pointer can't escape the cursor
+//     position. Streaming reads need ``sqlite3_blob_read`` directly.
+//   - **Nullable BLOB columns** use ``Option<array<uint8>>``, the same
+//     pattern as nullable scalars in tut 18.
+
+[sql_table(name = "Images")]
+struct Image {
+    @sql_primary_key Id : int
+    Name : string
+    @safe_when_uninitialized Data : array<uint8>
+}
+
+def make_demo_image(payload : string) : array<uint8> {
+    //! Tiny synthetic byte payload. Real apps load from fopen / fmap,
+    //! game asset packs, network sockets, etc.
+    var bytes : array<uint8>
+    peek_data(payload) $(arr) {
+        bytes |> resize(length(arr))
+        for (i in range(length(arr))) {
+            bytes[i] = arr[i]
+        }
+    }
+    return <- bytes
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Image>)
+
+        // Inspect the emitted DDL — Data column is BLOB NOT NULL because
+        // sql_bind(array<uint8>) returns array<uint8> and the field has
+        // no Option wrapper.
+        let ddl = _sql_create_table_sql(type<Image>)
+        to_log(LOG_INFO, "DDL: {ddl}\n")
+
+        // INSERT — the macro emits sqlite3_bind_blob(stmt, idx,
+        // _::sql_bind(row.Data)). For ``array<uint8>``, sql_bind is the
+        // identity-clone passthrough; SQLite then copies the bytes via
+        // SQLITE_TRANSIENT.
+        var hello = make_demo_image("hello, blob")
+        var world = make_demo_image("blob round-trip works")
+        db |> insert(Image(Id = 1, Name = "hello", Data <- hello))
+        db |> insert(Image(Id = 2, Name = "world", Data <- world))
+
+        // SELECT — read_via_adapter dispatches on the storage primitive
+        // (array<uint8>) and calls sqlite3_column_blob_ to allocate a
+        // fresh array; sql_extract is the identity-clone for the
+        // primitive case.
+        let images <- _sql(db |> select_from(type<Image>))
+        for (img in images) {
+            to_log(LOG_INFO, "{img.Name} ({length(img.Data)} bytes)\n")
+        }
+
+        // Filter by raw byte length using a parameterized scalar query —
+        // routes through query_scalar, which goes through the same
+        // read_via_adapter path.
+        let total = db |> query_scalar("SELECT SUM(LENGTH(Data)) FROM Images", type<int64>)
+        to_log(LOG_INFO, "total blob bytes stored: {total}\n")
+    }
+}
+
+// --- Future work: streaming BLOB I/O ------------------------------------
+//
+// SQLite offers ``sqlite3_blob_open`` / ``sqlite3_blob_read`` /
+// ``sqlite3_blob_write`` for incremental access without materializing
+// the whole blob in daslang's heap. Likely shape:
+//
+//     db |> open_blob(type<Image>, rowid, "Data") <| $(blob) {
+//         var buf : array<uint8>
+//         buf |> resize(4096)
+//         blob |> read(offset, buf)
+//     }
+//
+// EF Core doesn't expose this — game asset and large-binary use cases
+// typically live outside the ORM in dedicated APIs. dasSQLITE keeps the
+// streaming path on the deferred list until a real workload demands it.


### PR DESCRIPTION
## Summary

- **Custom-types rail (tut 26).** Replaces the witness-based `sqlite_bind` / `sqlite_read` trio with a public, name-based `_::sql_bind` / `_::sql_extract` overload pair. Four primitive storage types (`int64` / `double` / `string` / `array&lt;uint8&gt;`) selected by `sql_bind`'s return type; macro emits matching `sqlite3_bind_*` / `sqlite3_column_*` calls plus the matching DDL column type. Built-in adapters cover the four primitives, stdlib widenings, and a single enum generic. `Option&lt;T&gt;` composes for free. Missing-adapter is a compile-time error.
- **Tut 27 — BLOB round-trip.** `array&lt;uint8&gt;` is one of the four primitives, so a `[sql_table]` field of that type round-trips through a BLOB column with no extra annotation.
- **Backlog drain.** `exec` / `try_exec` 0/1/2/3-arg parameter binding (chunk-6 deferred). `_.Col == none()` → `macro_error` fixit pointing at `is_none()` / `is_some()` (chunk-4 D4 deferred).
- **Side bug fixes** the chunk-8 BLOB / enum-literal paths exercised: hardcoded `index = 1` in `sqlite3_bind_blob`; empty `array&lt;uint8&gt;` bind panic; `is_const_or_captured_var` missing enum / bitfield / int8 / int16 / uint8 / uint16 literals; `sqlite3_column_blob_` AOT codegen const-strip.
- **5 dupe targets from chunk-7 deferred list collapsed.** `validate_outer_args`, `make_insert_sql_fn(include_pk : bool)`, `find_annotation(default_value : auto(TT))`, doc note that `try_run_dml_returning` ≡ `try_run_select` were already factored, and `OuterArgZeroMacro` / `OuterArgTwoMacro` parents re-parent the 12-way `canVisitArgument` macro fan-out (each subclass keeps its own `[call_macro(name=...)]` since annotations don't inherit).

Tut 28 (JSON) was cut from this chunk so the `_sql` JSON-path walker can land on its own.

## Test plan

- [x] dasSQLITE suite — 328/328 (309 + 19 new across `test_61_custom_types.das` / `test_62_blob.das` / `test_63_exec_params.das`, plus 2 new `failed_sql_macro` entries for the `none()` fixit)
- [x] Full interpreted suite (`tests/`) — 7194/7194, no GC / heap leaks
- [x] AOT suite — 6606/6606, no leaks
- [x] Lint — clean (3 chunk-8 lints fixed; 7 pre-existing `PERF006` / `LINT003` warnings on master baseline left alone)
- [x] Format — clean
- [x] Sphinx — clean build, zero warnings (after fixing one malformed-table)
- [x] find_dupes — only the four-primitive dispatch table fan-out (by-design — overload resolution requires distinct signatures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
