### PR TITLE
ast_match: peel ExprRef2Value on both pattern and source sides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,65 +24,14 @@ See `doc/source/reference/design_philosophy.rst` for the full design philosophy 
 
 ## Build & Run
 
-- **Build system:** CMake + MSVC (Visual Studio 2022)
-- **Generate:** `generate_msvc_2022.bat` → creates `build/DAS.sln`
-- **Build:** `cmake --build build --config Release -j 64 -- /nodeReuse:false`
-- **Compiler binary:** `bin/Release/daslang.exe`
-- **Live-reload host:** `bin/Release/daslang-live.exe` — same script runs in both; see `utils/daslang-live/main.cpp`
-- **Run a script:** `bin/Release/daslang.exe path/to/script.das`
-- **Compile-only check:** `bin/Release/daslang.exe -compile-only path/to/script.das` — compiles without simulation or execution, useful for syntax/type checking without needing a window or GL context. Use `-dry-run` to also simulate (but not execute).
-- **Run tests:** `bin/Release/daslang.exe dastest/dastest.das -- --test path/to/test.das`
-- **AOT tests:** `cmake --build build --config Release --target test_aot -- /nodeReuse:false` then `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests`
-- **IMPORTANT:** When adding a new test directory under `tests/`, register it in `tests/aot/CMakeLists.txt` for AOT compilation. See `skills/aot_testing.md` for the step-by-step pattern. CI runs ALL tests with AOT enabled — unregistered test directories cause `error[50101]: AOT link failed`
+CMake-based build, supported on Windows / Linux / macOS / iOS / Android / WASM (CI runs the full matrix). Quick start: `cmake --build build --config Release -j 64`, then run `bin/Release/daslang path/to/script.das` (Windows MSVC layout) or `build/daslang ...` (single-config Make/Ninja). Builds are slow (15-25 min clean, 2-10 min incremental) — always pass `timeout: 0` to long `cmake --build` commands, do NOT assume "no output" means failure.
 
-### Build Timing
-
-- **Builds are slow** — clean builds take **15-25 minutes**, incremental builds take **2-10 minutes** depending on what changed
-- **Always use `timeout: 0`** (no timeout) when running `cmake --build` commands in the terminal. Never set a short timeout on build commands — a build that hasn't finished is not stuck or broken, it's just compiling
-- **Do not assume build failure** from lack of output — MSVC is silent during compilation and only prints when there are warnings/errors or when it finishes
-- **Wait for the build to complete** before drawing any conclusions. If a terminal command times out, check the output — it likely just needed more time
-- For incremental builds after editing a single `.cpp` file, expect ~2-5 minutes. For changes touching headers, expect longer
-
-### Debugging
-
-- **Always check the exit code** after running `daslang.exe` — a crash may produce no output at all, looking like a silent success
-- On Windows, check `$LASTEXITCODE` in PowerShell after every run. Exit code `0` = success, non-zero = error
-- Exit code `-1073741819` (`0xC0000005`) = **Access Violation** — indicates a native crash (segfault)
-- If the program crashes with no error message, the bug is in native code (C++ bindings or smart pointer misuse) — check exit code first
-- **Don't truncate output** with `head`/`tail` — daslang stack traces and `DAS_GC_BREAK_ON_ID` traces are easily clipped. Capture full output, then `grep` if needed
-- **`options log_infer_passes`** — append at the end of a failing `.das` file to dump per-pass infer activity (which generics got reified, when finalize ran, where lookups missed). Smaller and more targeted than `options log` for template/generic reification bugs; `options log` stays the right tool when you need the final program text
-
-### Build Configurations (Module Flags)
-
-Optional modules are controlled by CMake flags (`DAS_*_DISABLED`). The active configuration lives in `.vscode/settings.json` under `cmake.configureSettings` (the "WIP" block is the active one; others are commented-out presets).
-
-Key flags (all default to `ON` = disabled in CMakeLists.txt):
-- `DAS_HV_DISABLED` — dasHV (HTTP/WebSocket via libhv)
-- `DAS_PUGIXML_DISABLED` — dasPUGIXML (XML parsing)
-- `DAS_GLFW_DISABLED` — GLFW (OpenGL windowing)
-- `DAS_IMGUI_DISABLED` — ImGui
-- `DAS_LLVM_DISABLED` — LLVM JIT
-- `DAS_CLANG_BIND_DISABLED` — Clang bindings
-- `DAS_AUDIO_DISABLED`, `DAS_STBIMAGE_DISABLED`, `DAS_STBTRUETYPE_DISABLED`, `DAS_STDDLG_DISABLED`, `DAS_SQLITE_DISABLED`
-
-**To change modules:** Edit the active `cmake.configureSettings` in `.vscode/settings.json`, then reconfigure:
-```
-cmake --no-warn-unused-cli -B./build -G "Visual Studio 17 2022" -A x64 -DFLAG=VALUE ...
-```
-Or let VSCode CMake Tools pick up the settings change automatically.
-
-**Documentation generation** (`doc/reflections/das2rst.das`) requires `DAS_HV_DISABLED=OFF` and `DAS_PUGIXML_DISABLED=OFF` because it documents all modules. Temporarily enable them, rebuild `daslang`, run das2rst, then revert settings.
-
-### AOT Hash Debugging
-
-When AOT fails with `error[50101]: AOT link failed`, the issue is a **semantic hash mismatch** between the generated C++ stubs and runtime. Each generated `.cpp` file has hash comments showing function hashes and dependency hashes. The runtime error also prints the same breakdown. Compare them to find the diverging function or dependency. See `skills/aot_testing.md` for the full debugging guide (hash architecture, debug macros, common causes).
-
-The AOT C++ emitter lives in **`daslib/aot_cpp.das`** (the old `src/ast/ast_aot_cpp.cpp` was emptied by commit `581363ebc`). When codegen output diverges, edit `daslib/aot_cpp.das` — not the C++ stub in `src/ast/`.
+Full reference (per-platform generator commands, build flags, AOT debugging, exit code meanings, runtime crash diagnostics): **`skills/build_and_debug.md`**.
 
 ## GitHub Operations
 
 - **Use GitHub MCP tools** (`mcp__github__*`) for all GitHub operations (creating PRs, listing issues, reading PRs, etc.) — they avoid shell escaping issues entirely
-- **Fallback:** If MCP tools are unavailable, use `gh` CLI with `--body-file` for any text containing backticks (backticks are shell escape characters in both PowerShell and bash heredocs on MSYS2)
+- **Fallback:** If MCP tools are unavailable, use `gh` CLI with `--body-file` for any text containing backticks (they're shell escape characters in every supported shell)
 
 ## Skill Files (REQUIRED)
 
@@ -90,35 +39,38 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 
 | Skill file | Read BEFORE... |
 |---|---|
-| `skills/das_formatting.md` | Creating or modifying any `.das` file (tutorials, tests, daslib modules, utilities) |
+| `skills/build_and_debug.md` | Build flags, AOT build commands, exit-code/crash diagnosis, `options log_infer_passes` |
+| `skills/mcp_tools.md` | Full MCP tool table + live-API reference |
+| `skills/das_formatting.md` | Creating or modifying any `.das` file |
 | `skills/writing_tests.md` | Writing or editing test files under `tests/` |
-| `skills/documentation_rst.md` | Editing RST files in `doc/source/`, editing `//!` doc-comments in `daslib/*.das`, writing tutorial RST pages |
-| `skills/tutorials.md` | Creating, moving, or restructuring tutorial `.das` files. **Always check before editing anything that looks like a tutorial** — tutorials live under `/tutorials/<area>/`, NEVER inside `modules/<X>/tutorial/` (which holds inherited examples) |
-| `skills/cpp_integration.md` | Writing or editing C++ files in `src/`, `modules/`, or `tutorials/integration/cpp/` |
-| `skills/daslib_modules.md` | Working with `daslib/` modules (linq, json, regex, functional, match, etc.), channels, or extending the standard library |
-| `skills/das_macros.md` | Writing compile-time macros, AST manipulation, qmacro/quote code generation, gc_node AST-pointer patterns |
-| `skills/writing_benchmarks.md` | Writing or running benchmark files under `benchmarks/` |
-| `skills/daspkg.md` | Running daspkg commands, creating `.das_package` manifests, package structure |
-| `skills/dynamic_modules.md` | Creating or editing `.das_module` descriptors, adding new modules under `modules/` |
-| `skills/install_instructions.md` | Creating or updating AI instruction files (`install/CLAUDE.md`, `install/skills/`) for the installed SDK |
-| `skills/aot_testing.md` | Adding AOT test files, working with the `test_aot` binary, `Module::aotRequire()`, CMake AOT macros, **debugging AOT hash mismatches** |
-| `skills/visitor_gen_bind.md` | Adding or modifying `Visitor` virtual methods, `canVisit*` gates, running `gen_bind.das`, updating adapter bindings in `ast_gen.inc` |
-| `skills/daslang_live.md` | Working with `daslang-live.exe`, live-reload lifecycle, REST API, `[live_command]`, `[before_reload]`/`[after_reload]`, persistent store, `live/glfw_live`, `live/live_api` |
-| `skills/perf_lint.md` | Adding new performance lint rules to `daslib/perf_lint.das` |
-| `skills/style_lint.md` | Adding new style lint rules to `daslib/style_lint.das` |
-| `skills/gc_migration.md` | Migrating older `.das` or C++ code (external repos, archived branches) from `smart_ptr<T>` AST patterns to the current gc_node form. The in-tree migration is **complete** — only TypeDecl, Expression, Function, Structure, Enumeration, Variable, MakeFieldDecl, MakeStruct, every Annotation subclass; only `Program`, `Context`, `FileAccess` remain `smart_ptr` |
-| `skills/version_update.md` | Bumping the daslang version number (all files that need updating) |
-| `skills/jobque_debugging.md` | Debugging Channel/LockBox/JobStatus/Feature leaks using the tracking system (`--track-job-status`, `DumpJobQueLeaks`, refcount tracing) |
-| `skills/make_pr.md` | Creating a pull request (lint, test, AOT build+test, format checklist) |
-| `skills/strudel_port.md` | Copy-pasting a strudel.cc pattern (user-level live-coding expression) into daslang |
-| `skills/gc_use_after_sweep.md` | Debugging crashes in `TypeDecl`/`Expression` copy-ctors (`bad_alloc`, `length_error`, `basic_string::_M_create`) — gc_node use-after-sweep, `DAS_GC_DEBUG`, `DAS_GC_BREAK_ON_ID`, copy-on-mutate fix pattern |
-| `skills/clargs_migration.md` | Editing any in-tree tool that still calls `get_command_line_arguments()` directly — migrate its argv parsing to `daslib/clargs` in the same PR (`utils/lint`, `utils/aot`, `utils/dasFormatter`, `utils/benchctl`, `utils/mcp`, `utils/daslang-live`, `daslib/debug`, `daslib/ansi_colors`, etc.) |
-| `skills/json.md` | Reading or writing JSON in `.das` code — choosing between `sprint_json`/`sscan_json`, `JV`/`from_JV` from `daslib/json_boost`, custom converters, or manual `JsonValue?` |
-| `skills/xml.md` | Reading, building, querying, or serializing XML via `dasPUGIXML` (`PUGIXML_boost`) — RAII parsing, iteration, `tag`/`attr` builder, XPath, struct↔XML round-trip |
-| `skills/filesystem.md` | Any `.das` code that builds, splits, or normalizes a file path, or touches the filesystem (existence, listing, copy/rename/remove, temp files). **Rule:** path & filename operations MUST use `fio` helpers (`base_name`/`dir_name`/`extension`/`stem`/`path_join`/`normalize`/`is_absolute`/`relative`) — never hand-rolled `rfind`/`slice`/string-interp. Filesystem ops use `fio` / `daslib/fio` (`stat`, `dir_rec`, RAII `fopen`, `_result` variants) |
-| `skills/detect_dupe.md` | Detecting duplicate / near-duplicate functions in repo code — building a corpus, asking "did I just write something that already exists?" during PR authoring/review, or wiring a CI gate. Covers both the MCP tools (`export_corpus`, `detect_duplicates`) and the underlying CLI (`utils/detect-dupe/main.das`). Also read before editing/extending the detect-dupe tool itself (adding a pattern matcher, extending the canonicalizer, wiring new MCP parameters) |
-| `skills/find_dupe.md` | AI-judging a detect-dupe report — turning a noisy clusters JSON into actionable real/partial/false-positive verdicts via Claude (`utils/find-dupe/`). Read before invoking the `judge_duplicates` or `find_dupe` MCP tools, before running the CLI on a fresh repo, or when wiring the daspkg `anthropic/anthropic` install. Also covers cost guardrails (`--dry-run`, `--max-clusters`, `--positives-only`) |
-| `skills/linq.md` | Any `.das` code that filters, maps, sorts, groups, aggregates, or otherwise transforms a sequence into another sequence, array, or table. **Preference order:** comprehension (`[for (x in src); expr; where cond]`) when one expression covers the whole transformation → LINQ (`daslib/linq_boost` shorthand `_select` / `_where` / `_to_array`, or pipe-form `arr \|> where_(...) \|> ...`) for chains, lazy iterators, set ops, joins, aggregations → plain `for` loop for side-effecting iteration. **Do not use `daslib/functional`** (`map` / `filter` / `each` / `to_array`) for new code — older surface, less integrated. |
+| `skills/documentation_rst.md` | Editing RST in `doc/source/`, `//!` doc-comments in `daslib/*.das`, tutorial RST pages |
+| `skills/tutorials.md` | Anything that looks like a tutorial — they live under `/tutorials/<area>/`, NEVER `modules/<X>/tutorial/` |
+| `skills/cpp_integration.md` | Writing/editing C++ in `src/`, `modules/`, `tutorials/integration/cpp/` |
+| `skills/daslib_modules.md` | Working with `daslib/` modules or extending the stdlib |
+| `skills/das_macros.md` | Compile-time macros, AST manipulation, qmacro/quote, gc_node patterns |
+| `skills/writing_benchmarks.md` | Writing/running `benchmarks/` files |
+| `skills/daspkg.md` | Running daspkg commands, `.das_package` manifests |
+| `skills/dynamic_modules.md` | `.das_module` descriptors, adding modules under `modules/` |
+| `skills/install_instructions.md` | Updating `install/CLAUDE.md` or `install/skills/` for the shipped SDK |
+| `skills/aot_testing.md` | AOT test files, `test_aot` binary, `Module::aotRequire()`, AOT hash mismatches |
+| `skills/visitor_gen_bind.md` | Adding `Visitor` virtual methods / `canVisit*` gates / `gen_bind.das` regen |
+| `skills/daslang_live.md` | `daslang-live`, live-reload lifecycle, `[live_command]`, `[before_reload]`/`[after_reload]` |
+| `skills/perf_lint.md` | Adding rules to `daslib/perf_lint.das` |
+| `skills/style_lint.md` | Adding rules to `daslib/style_lint.das` |
+| `skills/gc_migration.md` | Migrating external/archived code from `smart_ptr<T>` AST patterns to gc_node (in-tree migration is complete) |
+| `skills/version_update.md` | Bumping the daslang version number |
+| `skills/jobque_debugging.md` | Channel/LockBox/JobStatus/Feature leaks (`--track-job-status`, `DumpJobQueLeaks`) |
+| `skills/make_pr.md` | Creating a pull request (lint, test, AOT, format checklist) |
+| `skills/strudel_port.md` | Porting strudel.cc patterns into daslang |
+| `skills/gc_use_after_sweep.md` | Debugging `bad_alloc` / `length_error` in TypeDecl/Expression copy-ctors (use-after-sweep) |
+| `skills/clargs_migration.md` | Editing any tool that still parses `get_command_line_arguments()` directly — migrate to `daslib/clargs` in the same PR |
+| `skills/json.md` | Reading/writing JSON in `.das` code (`sprint_json`/`sscan_json`, `JV`, manual `JsonValue?`) |
+| `skills/xml.md` | XML via `dasPUGIXML`/`PUGIXML_boost` (RAII parsing, builder, XPath, struct round-trip) |
+| `skills/filesystem.md` | Any `.das` path/filename/filesystem op — must use `fio` helpers, never `rfind`/`slice` |
+| `skills/detect_dupe.md` | Duplicate-function detection (corpus build, MCP tools `export_corpus`/`detect_duplicates`, CLI under `utils/detect-dupe/`) |
+| `skills/find_dupe.md` | AI-judging a detect-dupe report via Claude (MCP tools `judge_duplicates`/`find_dupe`, CLI under `utils/find-dupe/`); cost guardrails (`--dry-run`, `--max-clusters`, `--positives-only`) |
+| `skills/linq.md` | Filter/map/sort/group/aggregate transforms — preference order: comprehension → linq_boost → plain `for`. Avoid `daslib/functional` for new code |
+| `skills/aot_hash_desync_debugging.md` | `error[50101]: AOT link failed` — semantic-hash desync diagnostics |
 
 Multiple skill files may apply to a single task. For example, creating a new daslib module requires reading `skills/das_formatting.md`, `skills/daslib_modules.md`, and possibly `skills/documentation_rst.md`.
 
@@ -159,60 +111,34 @@ All code MUST use gen2 syntax (add `options gen2` at the top of every file). Key
 
 ### Important defaults
 
-- `strict_smart_pointers` is ON — but the only types that are still `smart_ptr` are `Program` (`ProgramPtr`), `Context` (`ContextPtr`), `FileAccess` (`FileAccessPtr`), and a handful of internal helpers (`DebugAgentPtr`, `VisitorAdapterPtr` from `make_visitor`). Only those need `var inscope`. **All AST types** (TypeDecl, Expression, Function, Structure, Enumeration, Variable, MakeFieldDecl, MakeStruct, every `Annotation` subclass) are now plain raw pointers (gc_node), and `var inscope` does NOT apply to them — see "AST nodes (gc_node)" below
 - No implicit type promotion: `int + float` is a compile error — both sides must match
 - No `bool(int)` cast — use `x != 0`; no `string(bool)` — use `"{flag}"`
 - `int("123")` does NOT work — use `to_int` from `require strings`. **`to_int` silently returns `0` on garbage** (`to_int("foo")` → `0`, `to_int("12abc")` → `12`). When you need to validate user/external input — including any string that flows into a shell command, file path, or system call — use `try_to_int` / `try_to_float` from `daslib/strings_convert` instead. Those return `Result<T; ConversionError>` distinguishing `invalid_argument` / `out_of_range` / `trailing_garbage`, so `";rm -rf;"` rejects cleanly instead of becoming `0`. Same for `to_float` → `try_to_float`
 - Hex literals are `uint` by default — use `int(0x3F)` for int
-- **`default<T>`** — the default (zero) value of type `T`: `default<int>` is `0`, `default<string>` is `""`, `default<float>` is `0.0f`. The body of the called function CAN use the value freely.
-- **`type<T>`** vs **`default<T>`** as a witness argument — they are **not** interchangeable:
-  - `type<T>` is a no-stack, no-construction compile-time type tag. The function body must NOT use the parameter (it will fail to compile if it does). Annotate with `[unused_argument(t)]`.
-  - `default<T>` is a real zero-value of `T`. The body can read/pass it. Use `default<T>` when the called function's body might touch the witness; use `type<T>` only when the parameter exists purely for overload discrimination.
-  - Smell: if you find yourself wanting to read a `type<T>` parameter inside the body, switch the call site to `default<T>` — don't rewrite the function.
-- **`typedecl(expr)`** — compile-time type-of expression, usable inside `default<>`: `default<typedecl(field)>` gives the zero value of `field`'s type. Useful in generic code with `static_if` to compare against defaults.
-- **Bitfield sizes**: `bitfield Name : uint8 { ... }`, `: uint16`, `: uint64`; default is `uint` (32-bit). Always unsigned.
-- **Bitfield from expression**: `bitfield64(1ul << 13ul)` — use the constructor to create a bitfield value from an integer expression. Similarly `bitfield8()`, `bitfield16()`.
+- **`default<T>`** — the zero value of `T`. Body of the called function CAN use it.
+- **`type<T>`** vs **`default<T>`** as a witness argument: `type<T>` is a no-stack tag (compile error if body reads it; annotate `[unused_argument(t)]`); `default<T>` is a real zero value (body can read/pass it). Pick by whether the body needs to touch the param. If you want to read a `type<T>` param, switch the caller to `default<T>` — don't rewrite the function.
+- **`typedecl(expr)`** — compile-time type-of, usable inside `default<>`: `default<typedecl(field)>`.
+- **Bitfields**: `bitfield Name : uint8 { ... }` (also `uint16`/`uint64`; default `uint`, always unsigned). From an int: `bitfield64(1ul << 13ul)` (also `bitfield8`/`bitfield16`).
 
 ### Pass-by-value vs pass-by-reference
 
-- Most types (structs, arrays, tables) always pass by reference — `&` is unnecessary on them
-- Only **workhorse types** (`int`, `float`, `bool`, `string`, etc. — `isWorkhorseType` on the C++ side) pass by value
-- **AST pointers (gc_node) pass by value** — `ExpressionPtr`, `TypeDeclPtr`, `FunctionPtr`, `StructurePtr`, `EnumerationPtr`, `VariablePtr`, `MakeFieldDeclPtr`, `MakeStructPtr`, `AnnotationPtr` and friends are all plain raw pointers. Passing them by value just copies the pointer — no refcount bump, no allocation. The underlying gc_node is owned by its `gc_root` (typically the Module), not by the caller.
-  - `def foo(p : ExpressionPtr)` — caller passes a pointer; both sides reference the same node
-  - `def foo(var p : ExpressionPtr)` — `var` lets you reassign `p` locally
-  - `def foo(var p : ExpressionPtr&)` — pass by reference, so `p = newExpr` propagates back
-  - Use `TypeDecl?` (never `TypeDecl const?`) — for mutable field access through the pointer, take the parameter as `var`
-- **The few remaining `smart_ptr<T>` types** (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`, `DebugAgentPtr`, `VisitorAdapterPtr`) **still use refcount semantics** — pass by value copies the smart_ptr (no refcount bump in daslang, since it's a raw pointer copy at the daslang level), but variables holding them require `var inscope` for cleanup. This is the narrow remaining surface where the smart_ptr rules in older docs still apply
-- **`var s : string`** — writable local copy, changes do NOT propagate back to the caller
-- **`var s : string&`** — pass by reference, changes propagate back. Use `&` for string out-parameters
-- **`clone_string(s)`** — clones a string into the current context's heap. Required for cross-context calls where the source context may be destroyed
-- **`:=`** on strings performs a clone (allocates in current context). Plain `=` copies the pointer
+- Structs/arrays/tables always pass by reference — no `&` needed.
+- Only **workhorse types** (`int`, `float`, `bool`, `string`, …, `isWorkhorseType` on the C++ side) pass by value.
+- **AST pointers (gc_node) pass by value** — copying the pointer, no refcount, no allocation. `def foo(p : ExpressionPtr)` shares the node; `var p` lets you reassign locally; `var p : ExpressionPtr&` propagates reassignment back. For mutable field access, take the param as `var`.
+- **Strings:** `var s : string` is a writable local copy (no propagation). `var s : string&` propagates. `:=` clones into current context's heap (required across contexts); plain `=` copies the pointer.
+- **Residual `smart_ptr` types** (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`, `DebugAgentPtr`, `VisitorAdapterPtr`) still use refcount semantics — variables holding them need `var inscope`. AST types do NOT — see below.
 
-### AST nodes (gc_node) — unique ownership, clone to duplicate
+### AST nodes (gc_node) and memory
 
-Every AST node lives at exactly one location. Multiple `ExpressionPtr` or `TypeDeclPtr` values pointing at the same node are **shared references to one object**, not independent copies. The garbage collector tracks the node by its address; sticking the same pointer in two places does not create a second node.
+AST types (TypeDecl, Expression, Function, Structure, Enumeration, Variable, MakeFieldDecl, MakeStruct, every `Annotation` subclass) are plain raw pointers tracked by gc_node. The only types still using `smart_ptr` are `Program`, `Context`, `FileAccess`, plus a couple of internal helpers (`DebugAgentPtr`, `VisitorAdapterPtr`).
 
-- **Don't copy by value.** Inserting the same `ExpressionPtr` into two different parent expressions creates aliasing — both parents think they own the child, gc_collect walks it twice, mutations on one parent show up in the other, and the AST validator flags it.
-- **Use the matching `clone_*` to duplicate:**
-  - `clone_type(t)` for `TypeDeclPtr`
-  - `clone_expression(e)` for `ExpressionPtr` (recursive deep clone)
-  - `clone_function(f)` for `FunctionPtr` — note: still returns via move (`var x <- clone_function(f)`)
-  - `clone_variable(v)` for `VariablePtr`
-  - `clone_structure(s)` for `StructurePtr`
-- **Don't use `var inscope`** for AST pointer types — the gc_node owns its own lifetime via `gc_root`. `var inscope` is for the residual smart_ptr types only (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`).
-- **Don't use `<-`** when assigning AST pointers — plain `=` is correct (`fn.body = newBlock`, `td.firstType = elemType`). `<-` was needed when these were smart_ptr; now it just memcpy+memset(0) a raw pointer slot, which is harmless but stylistically wrong. Keep `<-` only where the API still demands it (`clone_function`, `qmacro_function` returns).
-- **Tools/utilities that build AST at runtime** (outside the normal compile pipeline) must wrap the scope in `ast_gc_guard() { ... }` from `daslib/ast`, or the leak detector reports `GC APP LEAK` at exit.
-- **Don't use `clone_to_move`** on AST pointers as a substitute for `clone_*` — `clone_to_move` is the generic copy-then-move helper for non-copyable values like `array<T>`. For AST nodes the right call is the type-specific `clone_type` / `clone_expression` / etc.
+Quick rules:
+- AST nodes have **unique ownership** — don't insert the same pointer into two parents; use `clone_type` / `clone_expression` / `clone_function` / `clone_variable` / `clone_structure` to duplicate.
+- AST pointers use plain `=` and pass-by-value. **No `var inscope`, no `<-`** for them. `var inscope` is only for the residual smart_ptr types.
+- Tools that build AST at runtime (outside the compile pipeline) must wrap their scope in `ast_gc_guard() { ... }` from `daslib/ast`, or the leak detector reports `GC APP LEAK` at exit.
+- daslang has garbage collection, but plain `var arr : array<T>` does NOT finalize on scope exit. Either declare with `var inscope` (smart_ptr only), call `delete` explicitly, or move out via `<-`. Per-frame leaks in hot paths usually trace to a local `var arr` never deleted.
 
-This is the post-migration state. If you find yourself reading older guidance about `var inscope`, `<-`, or `clone_to_move` for AST types, the source is pre-migration — see `skills/gc_migration.md` for the conversion table.
-
-### Memory and move semantics
-
-- daslang has garbage collection — `delete` is not required in most code
-- **No C++/Rust-style scope RAII for plain `var`** — a local `var arr : array<T>` declared in any scope (function body, if-block, loop body) does NOT finalize on scope exit; the heap allocation stays alive until the context tears down. To get cleanup you must either (a) declare with `var inscope` (smart_ptrs), (b) call `delete arr` explicitly before scope exit, or (c) move ownership out via `<-`. Per-frame leaks in hot paths usually trace back to a local `var arr : array<...>` that was never deleted (e.g. the strudel_visualizer 384 KB/frame leak fixed by adding `delete verts`)
-- `var inscope` declares automatic cleanup; struct fields need defaults or `@safe_when_uninitialized`
-- `var inscope` is legal inside `for` / `while` loop bodies — the loop's `finally` runs per iteration (on fall-through, `continue`, `break`, `return`), so each iteration finalizes its own scoped variables
-- `<-` is memcpy+memset(0), NOT smart_ptr-aware. For the residual smart_ptrs (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`) it bypasses refcount handling — see `skills/das_macros.md` for the patterns. For AST raw pointers it just shuffles a pointer slot, harmless but stylistically wrong (use `=`)
+Full migration table (when reading older docs that say `var inscope` or `<-` for AST types): **`skills/gc_migration.md`**.
 
 ### Context heaps and threading
 
@@ -293,117 +219,37 @@ This is the post-migration state. If you find yourself reading older guidance ab
 - **`is`/`as` on handled types checks EXACT type**, not C++ inheritance — `expr is ExprField` is `false` when `expr` is `ExprSafeField`. `as` on wrong type crashes. Must handle each concrete type explicitly.
 - `#pragma optimize` in AOT-generated code must be wrapped in `#ifdef _MSC_VER` — Clang warns on unknown pragmas
 - **Macro-generated struct variables** need `default<$t(st)>` initialization (not `var x : $t(st)`) — avoids "uninitialized variable" errors for structs without field defaults
-- `print` should not be used in `tests`, `daslib`, or `utils` folders. `to_log(LOG_INFO)` (or
-other level) should be used instead. CI pipes `to_log` through the same stdout the user
-sees, so there is no behavior loss — the win is consistent log levels (`LOG_INFO`,
-`LOG_WARNING`, `LOG_ERROR`) and the ability to filter / route output later. See
-`utils/detect-dupe/main.das` for the canonical pattern (zero `print()` calls; everything
-flows through `to_log`).
-
+- `print` is for user-facing scripts only. In `tests/`, `daslib/`, `utils/`: use `to_log(LOG_INFO|LOG_WARNING|LOG_ERROR)` — same stdout, but level-tagged and filterable. Canonical example: `utils/detect-dupe/main.das`
 
 ### Code style — prefer idiomatic forms
 
 | Don't write | Write instead | Why |
 |---|---|---|
 | `string(x.__rtti) == "ExprFoo"` | `x is ExprFoo` | `is` works directly on AST pointers |
-| `get_ptr(x) == null` | `x == null` | AST pointers compare to `null` directly (also still works for the residual smart_ptrs) |
-| `get_ptr(x).field` | `x.field` | AST pointers auto-dereference for field access; `get_ptr` is leftover from the smart_ptr era |
-| `string(das_str) == "lit"` | `das_str == "lit"` | `das_string` compares directly with `string` |
-| `!empty(string(das_str))` | `!empty(das_str)` | `empty()` works on `das_string` |
-| `let v = string(x.name); $i(v)` | `$i(x.name)` | qmacro `$i`/`$f` accept `das_string` directly |
-| `var copy = val; $v(copy)` | `$v(val)` | qmacro `$v` works with `let` vars and loop vars |
+| `get_ptr(x) == null` / `get_ptr(x).field` | `x == null` / `x.field` | AST pointers auto-dereference; `get_ptr` is smart_ptr-era residue |
+| `string(das_str) == "lit"`, `!empty(string(das_str))` | drop the `string(...)` cast | `das_string` compares with `string` directly; `empty()` works on it |
+| `let v = string(x.name); $i(v)` / `var copy = val; $v(copy)` | `$i(x.name)` / `$v(val)` | qmacro tags accept `das_string`, `let` vars, loop vars directly |
 | `if (true) { ... }` | `{ ... }` | bare blocks create lexical scope in gen2 |
 | `var inscope r <- expr; return <- r` | `return <- expr` | direct return avoids intermediate |
-| `unsafe { (reinterpret<ExprBlock?> blk).list }` | `blk.list` | AST pointers auto-dereference |
-| `unsafe(reinterpret<T?> x)` | make param `var` + plain `x` | `var` param gives non-const access, no reinterpret needed |
-| `let i = max(rfind(p, "/"), rfind(p, "\\")); slice(p, i+1)` | `base_name(p)` | `fio.base_name` is cross-platform; manual `rfind` misses Windows separators or trailing slashes |
-| `slice(p, 0, max(rfind(p, "/"), rfind(p, "\\")))` | `dir_name(p)` | same — use `fio.dir_name`/`parent`, never hand-roll directory splitting |
-| `"{a}/{b}"` for file paths | `path_join(a, b)` | handles separator collisions and platform separators |
+| `unsafe { (reinterpret<ExprBlock?> blk).list }` / `unsafe(reinterpret<T?> x)` | make param `var` + plain `x.list` | `var` param gives non-const field access without reinterpret |
+
+For path/filename ops use `fio` helpers (`base_name`/`dir_name`/`path_join`/etc.) — see `skills/filesystem.md`. Never hand-roll `rfind("/")` / slice — misses Windows separators.
 
 **Minimize `unsafe`:** Most `unsafe(reinterpret<T?>)` in macro code exists to strip `const` from raw-pointer field access. Fix the root cause: make the function parameter `var` so field access returns non-const pointers. Reserve `unsafe` for genuinely unsafe operations (pointer arithmetic, `reinterpret` across unrelated types).
 
 ## Key Directories
 
-- `src/` — C++ compiler/runtime source
-- `include/daScript/` — C++ headers
-- `daslib/` — Standard library modules (86 .das files)
-- `dastest/` — Test framework
-- `tests/` — Test suite. See `tests/README.md` for full index
-- `tests/aot/` — AOT compilation tests (built into `test_aot` binary)
-- `doc/source/reference/language/` — RST language documentation
-- `tutorials/language/` — Language tutorial `.das` files
-- `tutorials/integration/cpp/` — C++ integration tutorials
-- `modules/` — External plugin modules
-- `modules/dasLiveHost/` — C++ module for live-reload host lifecycle (dynamic module)
-- `utils/daslang-live/` — Live-reloading application host (`daslang-live.exe`)
-- `utils/mcp/` — MCP server for AI coding assistants (stdio transport, no extra deps)
-- `utils/detect-dupe/` — Cross-file duplicate-function detector — canonicalizer, MinHash, clusterer, pattern filter (also exposed via the `export_corpus` and `detect_duplicates` MCP tools)
-- `utils/find-dupe/` — AI judge for detect-dupe clusters — partitions duplicate suspects into real / partial / false-positive via Claude. Requires `daspkg install --root utils/find-dupe` (anthropic/anthropic) and `ANTHROPIC_API_KEY`. Also exposed via the `judge_duplicates` and `find_dupe` MCP tools
-- `utils/daspkg/` — Package manager (install, update, build, search packages)
-- `examples/daslive/` — Live-reload examples (hello, triangle, tank_game, etc.)
-- `examples/games/` — Full game examples (arcanoid, sequence) — run under daslang-live or daslang
-- `examples/daspkg/` — Package manager example projects
-- `examples/crash/` — Crash handler example (native + daslang stack traces)
-- `tests/live_host/` — Unit tests for dasLiveHost module (lifecycle, commands, store)
-- `include/daScript/misc/crash_handler.h` — Crash handler with daslang stack walk support
+Most layout is obvious from `ls`. Non-obvious ones worth knowing:
+
+- `daslib/aot_cpp.das` — AOT C++ emitter lives here, NOT in the (emptied) `src/ast/ast_aot_cpp.cpp`
+- `tests/aot/CMakeLists.txt` — register new test directories here for AOT compilation
+- `dastest/` — test framework (used by both `tests/` and external repos)
+- `utils/detect-dupe/` (in-repo dupe finder) and `utils/find-dupe/` (Claude-based judge that needs `daspkg install --root utils/find-dupe` + `ANTHROPIC_API_KEY`) — both also exposed as MCP tools
+- `utils/mcp/`, `utils/daslang-live/`, `utils/daspkg/` — in-tree tools (most also have skills under `skills/`)
+- `tutorials/language/` (language tour) vs `tutorials/<area>/` (per-area) — never put tutorials in `modules/<X>/tutorial/`
 
 ## MCP Server (AI Tool Integration)
 
-The daslang MCP server (`utils/mcp/main.das`) exposes compiler diagnostics, program introspection, and live-reload control to AI coding assistants via the [Model Context Protocol](https://modelcontextprotocol.io/). Uses stdio transport — no extra build dependencies.
+The daslang MCP server (`utils/mcp/main.das`) exposes compiler diagnostics, program introspection, and live-reload control. **Prefer MCP tools** over manual compilation and grep — `grep_usage` is parse-aware (tree-sitter), `find_references` resolves cross-module symbols, and `live_*` tools talk to `daslang-live` directly instead of curl.
 
-**When MCP tools are available**, prefer them over manual compilation and grep-based exploration. **For searching `.das` files, prefer MCP tools over built-in Grep/Glob** — `grep_usage` is parse-aware (tree-sitter), `find_references` resolves cross-module symbols, `find_symbol` searches all loaded modules. **For interacting with `daslang-live`, always use MCP live tools** — not curl.
-
-| Tool | Use instead of... |
-|---|---|
-| `compile_check` | Running `daslang.exe` manually and parsing errors |
-| `list_functions` | Grepping for `def ` in `.das` files |
-| `list_types` | Grepping for `struct`/`class`/`enum` definitions |
-| `find_symbol` | Searching across modules for function/type names |
-| `list_module_api` | Reading daslib source to find available functions |
-| `list_modules` | Guessing module names or scanning `daslib/` directory |
-| `ast_dump` | Manually inspecting AST or post-macro output (supports `lineinfo` for source locations) |
-| `program_log` | Running with `options log` to see full post-compilation program text |
-| `run_script` | Running scripts via shell and capturing output |
-| `run_test` | Running dastest via shell and parsing results |
-| `format_file` | Running the formatter script manually |
-| `convert_to_gen2` | Running `das-fmt` manually to convert gen1→gen2 syntax |
-| `goto_definition` | Manually tracing symbol definitions across files |
-| `type_of` | Manually inspecting expression types |
-| `list_requires` | Grepping for `require` statements and guessing transitive deps |
-| `find_references` | Manually searching for all usages of a symbol across files |
-| `eval_expression` | Evaluating expressions by writing throwaway scripts |
-| `describe_type` | Reading source to understand type fields, methods, and values |
-| `grep_usage` | Using built-in Grep tool to search for symbol names in `.das` files (parse-aware via ast-grep + tree-sitter — no false positives from comments/strings) |
-| `outline` | Manually scanning files for function/struct/enum declarations |
-| `aot` | Manually running AOT generation and extracting function C++ |
-| `lint` | Running lint/perf_lint/style_lint manually or requiring the modules for code quality, performance, and style checks |
-| `export_corpus` | Running `detect-dupe --export-functions` from a shell to build a duplicate-detection corpus |
-| `detect_duplicates` | Running `detect-dupe --against` from a shell to ask "did I just write something that already exists?". Wraps B2 mode end-to-end |
-| `judge_duplicates` | Manually invoking `find-dupe` over a `detect-dupe` JSON report. Returns Claude-judged verdicts (real / partial / false_positive) for each cluster. Requires daspkg-installed `anthropic/anthropic` and `ANTHROPIC_API_KEY` |
-| `find_dupe` | One-shot duplicate-finder + judge. Use when starting fresh on a directory or PR; `detect_duplicates` + `judge_duplicates` separately when you already have a curated corpus |
-| `live_launch` | Manually starting `daslang-live.exe` from shell |
-| `live_status` | `curl http://localhost:9090/status` |
-| `live_error` | `curl http://localhost:9090/error` |
-| `live_reload` | `curl -X POST http://localhost:9090/reload` |
-| `live_pause` | `curl -X POST http://localhost:9090/pause` or `/unpause` |
-| `live_command` | `curl -X POST http://localhost:9090/command -d '{"name":"..."}` |
-| `live_shutdown` | `curl -X POST http://localhost:9090/shutdown` |
-| `shutdown` | Manually restarting the MCP server process |
-
-Cursor-based tools (`goto_definition`, `type_of`, `find_references`) support a `no_opt` parameter that disables compiler optimizations to preserve the full AST — useful when globals, enum values, or bitfield constants get constant-folded away.
-
-**Live tools:** The `live_*` tools interact with a running `daslang-live.exe` instance via its REST API. `live_launch` starts one if not already running (sets working directory to the script's folder). All live tools accept an optional `port` parameter (default 9090). When a compilation error is active, `live_command`, `live_pause` return HTTP 503 with the error. Use `live_reload` to fix. Hitting any unknown endpoint on the live API returns JSON help with all endpoints and curl examples.
-
-**`shutdown` tool:** Shuts down the MCP server process. Claude Code auto-restarts it, picking up code changes to `.das` tool files. Tool registration changes (adding/removing tools) still require a manual MCP restart.
-
-**Configuration:** Configure `.mcp.json` with `"command": "bin/Release/daslang.exe", "args": ["utils/mcp/main.das"]`. See `utils/mcp/README.md` for details and Claude Code permissions.
-
-**Tests:** `bin/Release/daslang.exe dastest/dastest.das -- --test utils/mcp/test_tools.das`
-
-## Keywords Reference
-
-`aka` — variable name alias (`var a aka alpha = 42`)
-`inscope` — declares variable owns a smart_ptr lifetime; only relevant for the residual smart_ptr types (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`, `DebugAgentPtr`, `VisitorAdapterPtr`). AST pointers (gc_node) do NOT use `inscope`
-`is type<T>` — compile-time type check
-`expect` — suppress specific compilation errors in test files
-`template` — generic type constraint in function signatures
+Full tool table (including `detect_duplicates`/`judge_duplicates`/`find_dupe`), live-API caveats, and `.mcp.json` configuration: **`skills/mcp_tools.md`**.

--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -5,10 +5,6 @@ options no_unused_function_arguments = false
 options strict_smart_pointers = true
 options stack = 1_048_576
 
-// this module is not AOT compiled. there are major issues with current ExpressionPtr and TypeDeclPtr
-// return-call patterns, which we are not going to address - until we get rid of smart_ptr altogether on das side
-options no_aot
-
 module ast_match shared public
 
 //! AST pattern matching — reverse reification.
@@ -18,25 +14,19 @@ module ast_match shared public
 //! system as ``qmacro`` but in reverse: ``$e`` clones a matched expression,
 //! ``$v`` extracts a constant value, ``$i`` extracts an identifier name.
 //!
-//! TODO — ExprRef2Value transparency. Post-inference, a read of a ``var``
-//! local can appear wrapped in ``ExprRef2Value(inner)`` (the ref-to-value
-//! adapter that fires when daslang dereferences a reference to consume its
-//! value). The current matcher is RTTI-strict, so a pattern like
-//! ``$e(lhs) == $e(rhs)`` matches the literal LHS/RHS shape but ``$e(rhs)``
-//! captures the wrapper, not the underlying ``ExprVar``/``ExprConst`` —
-//! callers that then check ``rhs is ExprVar`` will miss it. Two fixes:
-//!   1. **Auto-peel in $e capture** — ``generate_match`` could strip
-//!      ``ExprRef2Value`` wrappers when binding to ``$e(name)`` so the
-//!      captured expression is the underlying value.
-//!   2. **Auto-peel in fixed sub-patterns** — when matching a literal-shaped
-//!      sub-pattern (``a + b``), peel ``ExprRef2Value`` from the actual
-//!      before the RTTI guard fires.
-//! Either fix would let downstream callers (e.g. ``modules/dasSQLITE/daslib/
-//! sqlite_linq.das`` ``is_const_or_captured_var``) drop their own peel logic.
-//! Not urgent — current chunk-2 tests all pass because the captured-var
-//! inputs reach the macro before the wrapper is inserted — but the next
-//! complex case (struct-field reads, array indexing, anything that goes
-//! through more inference passes) will hit it.
+//! ``ExprRef2Value`` transparency. Post-inference, a read of a ``var`` local
+//! can appear wrapped in ``ExprRef2Value(inner)`` — the ref-to-value adapter
+//! the typer inserts when a reference is dereferenced for its value. The
+//! wrapper is invisible (no surface syntax, no user-visible semantics), so
+//! ``generate_match`` peels it on both sides:
+//!   - **Pattern side** (compile time): ``ExprRef2Value`` in the pattern is
+//!     stripped at the top of ``generate_match`` before dispatch.
+//!   - **Source side** (runtime): every dispatch emits a
+//!     ``qm_peel_ref2value(actual_var)`` call that strips the wrapper from
+//!     the runtime expression before the RTTI guard fires.
+//! ``ExprPtr2Ref`` (the ``*foo`` operator) is intentionally NOT peeled —
+//! it is user-visible, semantically meaningful, and ``*foo`` should NOT
+//! match ``foo``.
 
 require daslib/ast public
 require daslib/rtti
@@ -72,6 +62,17 @@ def qm_run(var expr : Expression?; blk : block<(var arg : Expression?) : QMatchR
     //! Invoke a matching block on the expression.
     //! Used internally by the ``qmatch`` macro.
     return invoke(blk, expr)
+}
+
+def qm_peel_ref2value(var e : Expression?&) : void {
+    //! Strip ``ExprRef2Value`` wrappers from ``e`` in place. The typer inserts
+    //! these post-inference around any read of a reference; they are invisible
+    //! to user-written code and the matcher peels them so a clean pattern
+    //! (``_.X``) matches a wrapped source (``ExprRef2Value(_.X)``) and vice
+    //! versa. Emitted at the top of every ``generate_match`` dispatch.
+    while (e != null && e is ExprRef2Value) {
+        e = (e as ExprRef2Value).subexpr
+    }
 }
 
 def qm_run_function(var func : FunctionPtr&; blk : block<(var body : Expression?; var func_ptr : Function?) : QMatchResult>) : QMatchResult {
@@ -1067,6 +1068,18 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
     if (pattern == null) {
         return
     }
+
+    // Pattern-side peel: ExprRef2Value is a typer artifact, not user-visible.
+    // Descend into the wrapped expression and discard the wrapper. Recursive
+    // call handles nested wrappers naturally.
+    if (pattern is ExprRef2Value) {
+        generate_match((pattern as ExprRef2Value).subexpr, actual_var, body, index, at)
+        return
+    }
+
+    // Source-side peel: emit a runtime call that strips ExprRef2Value from
+    // the actual expression before any RTTI/field guards fire.
+    body |> push <| qmacro_expr(${ qm_peel_ref2value($i(actual_var)); })
 
     let rtti = string(pattern.__rtti)
 

--- a/include/daScript/simulate/cast.h
+++ b/include/daScript/simulate/cast.h
@@ -300,7 +300,7 @@ namespace das
     template <>
     struct cast <long double> {
         static __forceinline long double to(vec4f x)            { union { vec4f v; long double t; } A; A.v = x; return A.t; }
-        static __forceinline vec4f from ( long double x )       { union { vec4f v; long double t; } A; A.t = x; return A.v; }
+        static __forceinline vec4f from ( long double x )       { union { vec4f v; long double t; } A; A.v = v_zero(); A.t = x; return A.v; }
     };
 
     template <>
@@ -370,7 +370,7 @@ namespace das
     template <>
     struct cast <double> {
         static __forceinline double to(vec4f x)                { union { vec4f v; double t; } A; A.v = x; return A.t; }
-        static __forceinline vec4f from ( double x )           { union { vec4f v; double t; } A; A.t = x; return A.v; }
+        static __forceinline vec4f from ( double x )           { union { vec4f v; double t; } A; A.v = v_zero(); A.t = x; return A.v; }
     };
 
     template <>

--- a/install/CLAUDE.md
+++ b/install/CLAUDE.md
@@ -25,7 +25,7 @@ daslang was created at Gaijin Entertainment to solve a concrete problem: **inter
 - **Run a script:** `bin/daslang path/to/script.das`
 - **Compile-only check:** `bin/daslang -compile-only path/to/script.das` — compiles without simulation or execution. Use `-dry-run` to also simulate (but not execute).
 - **AOT generation:** `bin/daslang -aot input.das output.cpp` — emit C++ stubs ahead-of-time. Add `-aot-macros` to include macros in the output.
-- **JIT execution:** `bin/daslang -jit path/to/script.das` — compile to native via LLVM JIT before running. Available only in builds compiled with the JIT module. `bin/daslang -exe path/to/script.das -output out.exe` JITs to a standalone executable (implies `-dry-run`).
+- **JIT execution:** `bin/daslang -jit path/to/script.das` — compile to native via LLVM JIT before running. Available only in builds compiled with the JIT module. `bin/daslang -exe path/to/script.das -output out` JITs to a standalone executable (implies `-dry-run`); the platform's executable extension is appended automatically (e.g. `.exe` on Windows).
 - **AOT-linked execution:** `bin/daslang -use-aot path/to/script.das` — run with AOT stubs that have been linked into the binary (host-side flag).
 - **Pass arguments to the script:** everything after `--` is forwarded to the script. `bin/daslang script.das -- arg1 arg2`. Use `daslib/clargs` to parse them — see `skills/clargs_usage.md`.
 - **Example:** `bin/daslang examples/hello_world.das`
@@ -57,9 +57,8 @@ The compiler sets `DAS_PAK_ROOT` to the project directory before evaluating call
 
 ### Debugging
 
-- **Always check the exit code** after running `daslang` — a crash may produce no output at all, looking like a silent success
-- On Windows, check `$LASTEXITCODE` in PowerShell after every run. Exit code `0` = success, non-zero = error
-- Exit code `-1073741819` (`0xC0000005`) = **Access Violation** — indicates a native crash (segfault)
+- **Always check the exit code** after running `daslang` — a crash may produce no output at all, looking like a silent success. PowerShell: `$LASTEXITCODE`. Bash/zsh: `$?`. Exit code `0` = success.
+- Exit code `-1073741819` / `0xC0000005` (Windows) or `139` / `134` (Linux/macOS) = native crash — Access Violation / SIGSEGV / SIGABRT
 - If the program crashes with no error message, the bug is in native code (C++ bindings or smart pointer misuse) — check exit code first
 - **Don't truncate output** with `head`/`tail` — daslang stack traces are easily clipped. Capture full output, then `grep` if needed
 - **`options log`** — append at the end of a `.das` file to dump the final post-compilation program text. Useful for confirming what the compiler actually produces (constant folding, generic reification, macro expansion).
@@ -71,22 +70,23 @@ Task-specific instructions are in skill files under `skills/`. Read the relevant
 
 | Skill file | Read BEFORE... |
 |---|---|
+| `skills/mcp_tools.md` | Full MCP tool table + live-API reference |
 | `skills/das_formatting.md` | Creating or modifying any `.das` file |
-| `skills/cpp_integration.md` | Embedding daslang in C++ host applications, binding types/functions/enums |
-| `skills/daslib_modules.md` | Using `daslib/` modules (linq, json, regex, functional, match, etc.), channels |
-| `skills/das_macros.md` | Writing compile-time macros, AST manipulation, qmacro/quote code generation, gc_node AST-pointer patterns |
-| `skills/daspkg.md` | Creating `.das_package` manifests, package structure, daspkg commands |
-| `skills/clargs_usage.md` | Writing your own daslang command-line tools — declarative argv parsing via `daslib/clargs` |
-| `skills/dynamic_modules.md` | Understanding `.das_module` descriptors, module resolution, `register_native_path`, `register_dynamic_module` |
-| `skills/daslang_live.md` | Working with `daslang-live`, live-reload lifecycle, REST API, `[live_command]`, persistent state |
-| `skills/json.md` | Reading or writing JSON in `.das` code — choosing between `sprint_json`/`sscan_json`, `JV`/`from_JV` from `daslib/json_boost`, custom converters, or manual `JsonValue?` |
-| `skills/xml.md` | Reading, building, querying, or serializing XML via `dasPUGIXML` (`PUGIXML_boost`) — RAII parsing, iteration, `tag`/`attr` builder, XPath, struct↔XML round-trip |
-| `skills/filesystem.md` | Any `.das` code that builds, splits, or normalizes a file path, or touches the filesystem (existence, listing, copy/rename/remove, temp files). **Rule:** path & filename operations MUST use `fio` helpers (`base_name`/`dir_name`/`extension`/`stem`/`path_join`/`normalize`/`is_absolute`/`relative`) — never hand-rolled `rfind`/`slice`/string-interp. Filesystem ops use `fio` / `daslib/fio` (`stat`, `dir_rec`, RAII `fopen`, `_result` variants) |
-| `skills/writing_tests.md` | Writing tests for your daslang code with the bundled `dastest` framework (`bin/daslang dastest/dastest.das -- --test ...`) |
-| `skills/memory_leak_detection.md` | Diagnosing leaks — `--das-profiler-leaks`, `-track-allocations -heap-report`, `GC APP LEAK` reports, `--track-smart-ptr`, `HandleRegistry` dump |
-| `skills/jobque_debugging.md` | Debugging Channel/LockBox/JobStatus/Stream/Feature leaks using `DumpJobQueLeaks` and `--track-job-status <id>` refcount tracing |
-| `skills/detect_dupe.md` | Detecting duplicate / near-duplicate functions across a daslang codebase — building a corpus, asking "did I just write something that already exists?", or wiring a CI gate. Covers both the MCP tools (`export_corpus`, `detect_duplicates`) and the underlying CLI (`utils/detect-dupe/main.das`) |
-| `skills/linq.md` | Any `.das` code that filters, maps, sorts, groups, aggregates, or otherwise transforms a sequence into another sequence, array, or table. Preference order: comprehension `[for (x in src); expr; where cond]` when one expression covers it → LINQ (`daslib/linq_boost` shorthand `_select` / `_where` / `_to_array`, or pipe-form `arr \|> where_(...) \|> ...`) for chains, lazy iterators, set ops, joins, aggregations → plain `for` loop for side-effecting iteration. Avoid `daslib/functional` (`map` / `filter` / `each` / `to_array`) for new code |
+| `skills/cpp_integration.md` | Embedding daslang in C++; binding types/functions/enums |
+| `skills/daslib_modules.md` | Using `daslib/` modules (linq, json, regex, etc.) |
+| `skills/das_macros.md` | Compile-time macros, AST manipulation, qmacro/quote, gc_node patterns |
+| `skills/daspkg.md` | Creating `.das_package` manifests, daspkg commands |
+| `skills/clargs_usage.md` | Writing daslang CLI tools — declarative argv parsing via `daslib/clargs` |
+| `skills/dynamic_modules.md` | `.das_module` descriptors, module resolution, `register_native_path` |
+| `skills/daslang_live.md` | `daslang-live` lifecycle, REST API, `[live_command]`, persistent state |
+| `skills/json.md` | Reading/writing JSON (`sprint_json`/`sscan_json`, `JV`, manual `JsonValue?`) |
+| `skills/xml.md` | XML via `dasPUGIXML`/`PUGIXML_boost` (RAII, builder, XPath, struct round-trip) |
+| `skills/filesystem.md` | Any `.das` path/filename/filesystem op — must use `fio` helpers, never `rfind`/`slice` |
+| `skills/writing_tests.md` | Writing tests with the bundled `dastest` framework |
+| `skills/memory_leak_detection.md` | Diagnosing leaks (`--das-profiler-leaks`, `--track-smart-ptr`, `GC APP LEAK`, `HandleRegistry`) |
+| `skills/jobque_debugging.md` | Channel/LockBox/JobStatus/Stream/Feature leaks |
+| `skills/detect_dupe.md` | Duplicate-function detection (corpus, MCP tools `export_corpus`/`detect_duplicates`, CLI under `utils/detect-dupe/`) |
+| `skills/linq.md` | Filter/map/sort/group/aggregate transforms — prefer comprehension → linq_boost → plain `for`; avoid `daslib/functional` for new code |
 
 Multiple skill files may apply to a single task. For example, embedding daslang and calling its standard library requires reading both `skills/cpp_integration.md` and `skills/daslib_modules.md`.
 
@@ -121,59 +121,34 @@ All code MUST use gen2 syntax (add `options gen2` at the top of every file). Key
 
 ### Important defaults
 
-- `strict_smart_pointers` is ON — but the only types that are still `smart_ptr` are `Program` (`ProgramPtr`), `Context` (`ContextPtr`), `FileAccess` (`FileAccessPtr`), and a few internals (`DebugAgentPtr`, `VisitorAdapterPtr` from `make_visitor`). Only those need `var inscope`. **All AST types** (TypeDecl, Expression, Function, Structure, Enumeration, Variable, MakeFieldDecl, MakeStruct, every `Annotation` subclass) are now plain raw pointers (gc_node) — see "AST nodes (gc_node)" below
 - No implicit type promotion: `int + float` is a compile error — both sides must match
 - No `bool(int)` cast — use `x != 0`; no `string(bool)` — use `"{flag}"`
 - `int("123")` does NOT work — use `to_int` from `require strings`. **`to_int` silently returns `0` on garbage** (`to_int("foo")` → `0`, `to_int("12abc")` → `12`). When you need to validate user/external input — including any string that flows into a shell command, file path, or system call — use `try_to_int` / `try_to_float` from `daslib/strings_convert` instead. Those return `Result<T; ConversionError>` distinguishing `invalid_argument` / `out_of_range` / `trailing_garbage`, so `";rm -rf;"` rejects cleanly instead of becoming `0`. Same for `to_float` → `try_to_float`
 - Hex literals are `uint` by default — use `int(0x3F)` for int
-- **`default<T>`** — the default (zero) value of type `T`: `default<int>` is `0`, `default<string>` is `""`, `default<float>` is `0.0f`. The body of the called function CAN use the value freely.
-- **`type<T>`** vs **`default<T>`** as a witness argument — they are **not** interchangeable:
-  - `type<T>` is a no-stack, no-construction compile-time type tag. The function body must NOT use the parameter (compile error if it does). Annotate with `[unused_argument(t)]`.
-  - `default<T>` is a real zero-value of `T`. The body can read/pass it. Use `default<T>` when the called function's body might touch the witness; use `type<T>` only when the parameter exists purely for overload discrimination.
-  - Smell: if you find yourself wanting to read a `type<T>` parameter inside the body, switch the call site to `default<T>` — don't rewrite the function.
-- **`typedecl(expr)`** — compile-time type-of expression, usable inside `default<>`: `default<typedecl(field)>` gives the zero value of `field`'s type. Useful in generic code with `static_if` to compare against defaults.
-- **Bitfield sizes**: `bitfield Name : uint8 { ... }`, `: uint16`, `: uint64`; default is `uint` (32-bit). Always unsigned.
-- **Bitfield from expression**: `bitfield64(1ul << 13ul)` — use the constructor to create a bitfield value from an integer expression. Similarly `bitfield8()`, `bitfield16()`.
+- **`default<T>`** — the zero value of `T`. Body of the called function CAN use it.
+- **`type<T>`** vs **`default<T>`** as a witness argument: `type<T>` is a no-stack tag (compile error if body reads it; annotate `[unused_argument(t)]`); `default<T>` is a real zero value (body can read/pass it). Pick by whether the body needs to touch the param. If you want to read a `type<T>` param, switch the caller to `default<T>` — don't rewrite the function.
+- **`typedecl(expr)`** — compile-time type-of, usable inside `default<>`: `default<typedecl(field)>`.
+- **Bitfields**: `bitfield Name : uint8 { ... }` (also `uint16`/`uint64`; default `uint`, always unsigned). From an int: `bitfield64(1ul << 13ul)` (also `bitfield8`/`bitfield16`).
 
 ### Pass-by-value vs pass-by-reference
 
-- Most types (structs, arrays, tables) always pass by reference — `&` is unnecessary on them
-- Only **workhorse types** (`int`, `float`, `bool`, `string`, etc. — `isWorkhorseType` on the C++ side) pass by value
-- **AST pointers (gc_node) pass by value** — `ExpressionPtr`, `TypeDeclPtr`, `FunctionPtr`, `StructurePtr`, `EnumerationPtr`, `VariablePtr`, `MakeFieldDeclPtr`, `MakeStructPtr`, `AnnotationPtr` and friends are all plain raw pointers. Passing them by value just copies the pointer — no refcount bump, no allocation. The underlying gc_node is owned by its `gc_root` (typically the Module), not by the caller.
-  - `def foo(p : ExpressionPtr)` — caller passes a pointer; both sides reference the same node
-  - `def foo(var p : ExpressionPtr)` — `var` lets you reassign `p` locally
-  - `def foo(var p : ExpressionPtr&)` — pass by reference, so `p = newExpr` propagates back
-- **The few remaining `smart_ptr<T>` types** (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`, `DebugAgentPtr`, `VisitorAdapterPtr`) **still use refcount semantics**. Variables holding them require `var inscope` for cleanup. This is the narrow remaining surface where the smart_ptr rules in older docs still apply
-- **`var s : string`** — writable local copy, changes do NOT propagate back to the caller
-- **`var s : string&`** — pass by reference, changes propagate back. Use `&` for string out-parameters
-- **`clone_string(s)`** — clones a string into the current context's heap. Required for cross-context calls where the source context may be destroyed
-- **`:=`** on strings performs a clone (allocates in current context). Plain `=` copies the pointer
+- Structs/arrays/tables always pass by reference — no `&` needed.
+- Only **workhorse types** (`int`, `float`, `bool`, `string`, …, `isWorkhorseType` on the C++ side) pass by value.
+- **AST pointers (gc_node) pass by value** — copying the pointer, no refcount, no allocation. `def foo(p : ExpressionPtr)` shares the node; `var p` lets you reassign locally; `var p : ExpressionPtr&` propagates reassignment back. For mutable field access, take the param as `var`.
+- **Strings:** `var s : string` is a writable local copy (no propagation). `var s : string&` propagates. `:=` clones into current context's heap (required across contexts); plain `=` copies the pointer.
+- **Residual `smart_ptr` types** (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`, `DebugAgentPtr`, `VisitorAdapterPtr`) still use refcount semantics — variables holding them need `var inscope`. AST types do NOT — see below.
 
-### AST nodes (gc_node) — unique ownership, clone to duplicate
+### AST nodes (gc_node) and memory
 
-Every AST node lives at exactly one location. Multiple `ExpressionPtr` or `TypeDeclPtr` values pointing at the same node are **shared references to one object**, not independent copies. The garbage collector tracks the node by its address; sticking the same pointer in two places does not create a second node.
+AST types (TypeDecl, Expression, Function, Structure, Enumeration, Variable, MakeFieldDecl, MakeStruct, every `Annotation` subclass) are plain raw pointers tracked by gc_node. The only types still using `smart_ptr` are `Program`, `Context`, `FileAccess`, plus a couple of internal helpers (`DebugAgentPtr`, `VisitorAdapterPtr`).
 
-- **Don't insert the same pointer into two parent expressions** — that creates aliasing. Both parents think they own the child, gc_collect walks it twice, mutations on one parent show up in the other.
-- **Use the matching `clone_*` to duplicate:**
-  - `clone_type(t)` for `TypeDeclPtr`
-  - `clone_expression(e)` for `ExpressionPtr` (recursive deep clone)
-  - `clone_function(f)` for `FunctionPtr` — note: still returns via move (`var x <- clone_function(f)`)
-  - `clone_variable(v)` for `VariablePtr`
-  - `clone_structure(s)` for `StructurePtr`
-- **Don't use `var inscope`** for AST pointer types — the gc_node owns its own lifetime via `gc_root`. `var inscope` is for the residual smart_ptr types only (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`).
-- **Don't use `<-`** when assigning AST pointers — plain `=` is correct (`fn.body = newBlock`, `td.firstType = elemType`). Keep `<-` only where the API still demands it (`clone_function`, `qmacro_function` returns).
-- **Tools/utilities that build AST at runtime** (outside the normal compile pipeline) must wrap the scope in `ast_gc_guard() { ... }` from `daslib/ast`, or the leak detector reports `GC APP LEAK` at exit.
-- **Don't use `clone_to_move`** on AST pointers as a substitute for `clone_*` — `clone_to_move` is the generic copy-then-move helper for non-copyable values like `array<T>`. For AST nodes the right call is the type-specific `clone_type` / `clone_expression` / etc.
+Quick rules:
+- AST nodes have **unique ownership** — don't insert the same pointer into two parents; use `clone_type` / `clone_expression` / `clone_function` / `clone_variable` / `clone_structure` to duplicate.
+- AST pointers use plain `=` and pass-by-value. **No `var inscope`, no `<-`** for them. `var inscope` is only for the residual smart_ptr types.
+- Tools that build AST at runtime (outside the compile pipeline) must wrap their scope in `ast_gc_guard() { ... }` from `daslib/ast`, or the leak detector reports `GC APP LEAK` at exit.
+- daslang has garbage collection, but plain `var arr : array<T>` does NOT finalize on scope exit. Either declare with `var inscope` (smart_ptr only), call `delete` explicitly, or move out via `<-`. Per-frame leaks in hot paths usually trace to a local `var arr` never deleted.
 
-If you find yourself reading older guidance about `var inscope`, `<-`, or `clone_to_move` for AST types, the source is pre-migration — see `skills/das_macros.md` for the current rules.
-
-### Memory and move semantics
-
-- daslang has garbage collection — `delete` is not required in most code
-- **No C++/Rust-style scope RAII for plain `var`** — a local `var arr : array<T>` declared in any scope (function body, if-block, loop body) does NOT finalize on scope exit; the heap allocation stays alive until the context tears down. To get cleanup you must either (a) declare with `var inscope` (smart_ptrs only — Program/Context/FileAccess), (b) call `delete arr` explicitly before scope exit, or (c) move ownership out via `<-`. Per-frame leaks in hot paths usually trace back to a local `var arr : array<...>` that was never deleted
-- `var inscope` declares automatic cleanup; struct fields need defaults or `@safe_when_uninitialized`
-- `var inscope` is legal inside `for` / `while` loop bodies — the loop's `finally` runs per iteration (on fall-through, `continue`, `break`, `return`), so each iteration finalizes its own scoped variables
-- `<-` is memcpy+memset(0), NOT smart_ptr-aware. For the residual smart_ptrs (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`) it bypasses refcount handling. For AST raw pointers it just shuffles a pointer slot, harmless but stylistically wrong (use `=`)
+For migrating older code that uses `var inscope`/`<-` on AST types, see `skills/das_macros.md`.
 
 ### Context heaps and threading
 
@@ -259,21 +234,14 @@ If you find yourself reading older guidance about `var inscope`, `<-`, or `clone
 | Don't write | Write instead | Why |
 |---|---|---|
 | `string(x.__rtti) == "ExprFoo"` | `x is ExprFoo` | `is` works directly on AST pointers |
-| `get_ptr(x) == null` | `x == null` | AST pointers compare to `null` directly (also still works for residual smart_ptrs) |
-| `get_ptr(x).field` | `x.field` | AST pointers auto-dereference for field access; `get_ptr` is leftover from the smart_ptr era |
-| `string(das_str) == "lit"` | `das_str == "lit"` | `das_string` compares directly with `string` |
-| `!empty(string(das_str))` | `!empty(das_str)` | `empty()` works on `das_string` |
-| `let v = string(x.name); $i(v)` | `$i(x.name)` | qmacro `$i`/`$f` accept `das_string` directly |
-| `var copy = val; $v(copy)` | `$v(val)` | qmacro `$v` works with `let` vars and loop vars |
+| `get_ptr(x) == null` / `get_ptr(x).field` | `x == null` / `x.field` | AST pointers auto-dereference; `get_ptr` is smart_ptr-era residue |
+| `string(das_str) == "lit"`, `!empty(string(das_str))` | drop the `string(...)` cast | `das_string` compares with `string` directly; `empty()` works on it |
+| `let v = string(x.name); $i(v)` / `var copy = val; $v(copy)` | `$i(x.name)` / `$v(val)` | qmacro tags accept `das_string`, `let` vars, loop vars directly |
 | `if (true) { ... }` | `{ ... }` | bare blocks create lexical scope in gen2 |
 | `var inscope r <- expr; return <- r` | `return <- expr` | direct return avoids intermediate |
-| `unsafe { (reinterpret<ExprBlock?> blk).list }` | `blk.list` | AST pointers auto-dereference |
-| `unsafe(reinterpret<T?> x)` | make param `var` + plain `x` | `var` param gives non-const access, no reinterpret needed |
-| `let i = max(rfind(p, "/"), rfind(p, "\\")); slice(p, i+1)` | `base_name(p)` | `fio.base_name` is cross-platform; manual `rfind` misses Windows separators or trailing slashes |
-| `slice(p, 0, max(rfind(p, "/"), rfind(p, "\\")))` | `dir_name(p)` | same — use `fio.dir_name`/`parent`, never hand-roll directory splitting |
-| `"{a}/{b}"` for file paths | `path_join(a, b)` | handles separator collisions and platform separators |
+| `unsafe { (reinterpret<ExprBlock?> blk).list }` / `unsafe(reinterpret<T?> x)` | make param `var` + plain `x.list` | `var` param gives non-const field access without reinterpret |
 
-**Minimize `unsafe`:** Most `unsafe(reinterpret<T?>)` in macro code exists to strip `const` from raw-pointer field access. Fix the root cause: make the function parameter `var` so field access returns non-const pointers. Reserve `unsafe` for genuinely unsafe operations (pointer arithmetic, `reinterpret` across unrelated types).
+For path/filename ops use `fio` helpers (`base_name`/`dir_name`/`path_join`/etc.) — see `skills/filesystem.md`. Never hand-roll `rfind("/")` / slice — misses Windows separators.
 
 ## SDK Directory Layout
 
@@ -307,55 +275,6 @@ See `skills/daspkg.md` for `.das_package` manifest format and package structure.
 
 ## MCP Server (AI Tool Integration)
 
-`utils/mcp/` contains a [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes compiler diagnostics and program introspection to AI coding assistants. Uses stdio transport — no extra build dependencies.
+`utils/mcp/` contains a [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes compiler diagnostics and program introspection to AI coding assistants. Stdio transport — no extra build dependencies. **Prefer MCP tools** over manual compilation and grep — `grep_usage` is parse-aware (tree-sitter), `find_references` resolves cross-module symbols, and `live_*` tools talk to `daslang-live` directly instead of curl.
 
-**When MCP tools are available**, prefer them over manual compilation and grep-based exploration:
-
-| Tool | Use instead of... |
-|---|---|
-| `compile_check` | Running `daslang` manually and parsing errors |
-| `list_functions` | Grepping for `def ` in `.das` files |
-| `list_types` | Grepping for `struct`/`class`/`enum` definitions |
-| `find_symbol` | Searching across modules for function/type names |
-| `list_module_api` | Reading daslib source to find available functions |
-| `list_modules` | Guessing module names or scanning `daslib/` directory |
-| `ast_dump` | Manually inspecting AST or post-macro output (supports `lineinfo` for source locations) |
-| `program_log` | Running with `options log` to see full post-compilation program text |
-| `run_script` | Running scripts via shell and capturing output |
-| `run_test` | Running dastest via shell and parsing results |
-| `format_file` | Running the formatter script manually |
-| `convert_to_gen2` | Running `das-fmt` manually to convert gen1→gen2 syntax |
-| `goto_definition` | Manually tracing symbol definitions across files |
-| `type_of` | Manually inspecting expression types |
-| `list_requires` | Grepping for `require` statements and guessing transitive deps |
-| `find_references` | Manually searching for all usages of a symbol across files |
-| `eval_expression` | Evaluating expressions by writing throwaway scripts |
-| `describe_type` | Reading source to understand type fields, methods, and values |
-| `grep_usage` | Grepping for symbol names across files (parse-aware via ast-grep + tree-sitter) |
-| `outline` | Manually scanning files for function/struct/enum declarations |
-| `aot` | Manually running AOT generation and extracting function C++ |
-| `lint` | Running lint/perf_lint/style_lint manually or requiring the modules for code quality, performance, and style checks |
-| `export_corpus` | Running `utils/detect-dupe/main.das --export-functions` from a shell to build a duplicate-detection corpus |
-| `detect_duplicates` | Running `utils/detect-dupe/main.das --against` from a shell to ask "did I just write something that already exists?". Wraps B2 mode end-to-end |
-| `live_launch` | Manually starting `daslang-live` from shell |
-| `live_status` | `curl http://localhost:9090/status` |
-| `live_error` | `curl http://localhost:9090/error` |
-| `live_reload` | `curl -X POST http://localhost:9090/reload` |
-| `live_pause` | `curl -X POST http://localhost:9090/pause` or `/unpause` |
-| `live_command` | `curl -X POST http://localhost:9090/command -d '{"name":"..."}` |
-| `live_shutdown` | `curl -X POST http://localhost:9090/shutdown` |
-| `shutdown` | Manually restarting the MCP server process |
-
-Cursor-based tools (`goto_definition`, `type_of`, `find_references`) support a `no_opt` parameter that disables compiler optimizations to preserve the full AST — useful when globals, enum values, or bitfield constants get constant-folded away.
-
-**Live tools:** The `live_*` tools interact with a running `daslang-live` instance via its REST API. `live_launch` starts one if not already running. All live tools accept optional `port` (default 9090). When a compilation error is active, `live_command` and `live_pause` return 503 with the error. Hitting any unknown endpoint returns JSON help.
-
-**Configuration:** Configure `.mcp.json` with `"command": "bin/daslang", "args": ["utils/mcp/main.das"]`. See `utils/mcp/README.md` for details and permissions.
-
-## Keywords Reference
-
-`aka` — variable name alias (`var a aka alpha = 42`)
-`inscope` — declares variable owns a smart_ptr lifetime; only relevant for the residual smart_ptr types (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`, `DebugAgentPtr`, `VisitorAdapterPtr`). AST pointers (gc_node) do NOT use `inscope`
-`is type<T>` — compile-time type check
-`expect` — suppress specific compilation errors
-`template` — generic type constraint in function signatures
+Full tool table (including `detect_duplicates`/`judge_duplicates`/`find_dupe`), live-API caveats, and `.mcp.json` configuration: **`skills/mcp_tools.md`**.

--- a/install/skills/mcp_tools.md
+++ b/install/skills/mcp_tools.md
@@ -1,0 +1,52 @@
+# MCP Tools Reference
+
+The daslang MCP server (`utils/mcp/main.das`) exposes compiler diagnostics, program introspection, and live-reload control to AI coding assistants via the [Model Context Protocol](https://modelcontextprotocol.io/). Stdio transport — no extra build dependencies.
+
+**When MCP tools are available, prefer them** over manual compilation and grep-based exploration. **For searching `.das` files, prefer MCP tools over built-in Grep/Glob** — `grep_usage` is parse-aware (tree-sitter), `find_references` resolves cross-module symbols, `find_symbol` searches all loaded modules. **For interacting with `daslang-live`, always use MCP live tools** — not curl.
+
+## Tool table
+
+| Tool | Use instead of... |
+|---|---|
+| `compile_check` | Running `daslang` manually and parsing errors |
+| `list_functions` | Grepping for `def ` in `.das` files |
+| `list_types` | Grepping for `struct`/`class`/`enum` definitions |
+| `find_symbol` | Searching across modules for function/type names |
+| `list_module_api` | Reading daslib source to find available functions |
+| `list_modules` | Guessing module names or scanning `daslib/` directory |
+| `ast_dump` | Manually inspecting AST or post-macro output (supports `lineinfo` for source locations) |
+| `program_log` | Running with `options log` to see full post-compilation program text |
+| `run_script` | Running scripts via shell and capturing output |
+| `run_test` | Running dastest via shell and parsing results |
+| `format_file` | Running the formatter script manually |
+| `convert_to_gen2` | Running `das-fmt` manually to convert gen1→gen2 syntax |
+| `goto_definition` | Manually tracing symbol definitions across files |
+| `type_of` | Manually inspecting expression types |
+| `list_requires` | Grepping for `require` statements and guessing transitive deps |
+| `find_references` | Manually searching for all usages of a symbol across files |
+| `eval_expression` | Evaluating expressions by writing throwaway scripts |
+| `describe_type` | Reading source to understand type fields, methods, and values |
+| `grep_usage` | Built-in Grep across `.das` files (parse-aware via ast-grep + tree-sitter) |
+| `outline` | Manually scanning files for function/struct/enum declarations |
+| `aot` | Manually running AOT generation and extracting function C++ |
+| `lint` | Running lint/perf_lint/style_lint manually |
+| `export_corpus` | `detect-dupe --export-functions` from a shell |
+| `detect_duplicates` | `detect-dupe --against` to ask "did I just write this?" — wraps B2 mode end-to-end |
+| `judge_duplicates` | Manually invoking `find-dupe` over a `detect-dupe` JSON report. Returns Claude-judged verdicts (real / partial / false_positive). Requires daspkg-installed `anthropic/anthropic` and `ANTHROPIC_API_KEY` |
+| `find_dupe` | One-shot duplicate-finder + judge. Use when starting fresh on a directory or PR; `detect_duplicates` + `judge_duplicates` separately when you already have a curated corpus |
+| `live_launch` | Manually starting `daslang-live` from shell |
+| `live_status` | `curl http://localhost:9090/status` |
+| `live_error` | `curl http://localhost:9090/error` |
+| `live_reload` | `curl -X POST http://localhost:9090/reload` |
+| `live_pause` | `curl -X POST http://localhost:9090/pause` or `/unpause` |
+| `live_command` | `curl -X POST http://localhost:9090/command -d '{"name":"..."}` |
+| `live_shutdown` | `curl -X POST http://localhost:9090/shutdown` |
+| `shutdown` | Manually restarting the MCP server process |
+
+## Notes
+
+**Cursor-based tools** (`goto_definition`, `type_of`, `find_references`) accept a `no_opt` parameter that disables compiler optimizations to preserve the full AST — useful when globals, enum values, or bitfield constants get constant-folded away.
+
+**Live tools.** `live_*` interact with a running `daslang-live` instance via its REST API. `live_launch` starts one if not already running (sets working directory to the script's folder). All live tools accept an optional `port` parameter (default 9090). When a compilation error is active, `live_command` and `live_pause` return HTTP 503 with the error — use `live_reload` to fix. Hitting any unknown endpoint returns JSON help with all endpoints + curl examples.
+
+**Configuration.** Configure `.mcp.json` with `"command": "bin/daslang", "args": ["utils/mcp/main.das"]`. See `utils/mcp/README.md` for details and Claude Code permissions.

--- a/skills/aot_hash_desync_debugging.md
+++ b/skills/aot_hash_desync_debugging.md
@@ -1,0 +1,160 @@
+# Debugging AOT Hash Desync (`error[50101]: AOT link failed`)
+
+When `test_aot.exe -use-aot` (or any binary that links pre-built AOT stubs) reports `error[50101]: AOT link failed on <fn>`, it means the runtime computed a different semantic hash for `<fn>` than the AOT generator recorded. The AOT stub map has entries keyed by hash; lookup miss → link fails.
+
+Background on the hash machinery is in [`skills/aot_testing.md`](aot_testing.md). This skill is the playbook for *finding why* the hashes disagree.
+
+## First checks before investigating codegen
+
+1. **Stale `test_aot.exe` vs `libDaScript_runtime.lib`.** If CI is green and only your local build fails, the first suspect is a local mismatch between the executable and the runtime static library. Compare timestamps:
+   ```
+   stat -c "%y %n" bin/Release/test_aot.exe lib/Release/libDaScript_runtime.lib
+   ```
+   If the runtime lib is older than `test_aot.exe`, force a static-lib rebuild (touch a runtime source or `cmake --build build --target libDaScript_runtime`) before chasing codegen.
+
+2. **Stale per-test AOT cache after touching cross-module deps.** Editing `daslib` doesn't automatically invalidate per-test `_aot_generated/*.das.cpp`. The cached stub still encodes the old hash and link fails. Wipe and rebuild:
+   ```
+   rm -rf tests/<area>/_aot_generated/ daslib/_aot_generated/
+   cmake --build build --config Release --target test_aot -- /nodeReuse:false
+   ```
+
+If neither applies, you have a real desync. Continue.
+
+## Step 1 — Read the diagnostic
+
+The error dumps the runtime's view:
+
+```
+error[50101]: AOT link failed on test_double_match C1<S<testing::T>>?
+semantic hash is 5fa4c638bec10ddb
+// test_double_match C1<S<testing::T>>? hash=0xedef0d103b30be69, @dep_a=0x..., @dep_b=0x..., ...
+... full SimNode dump of <fn>'s body ...
+```
+
+What each piece means:
+
+- **`semantic hash is X`** — runtime's *combined* hash (own-hash + sorted dep hashes), `getFunctionAotHash` in [`src/simulate/simulate_fn_hash.cpp`](../src/simulate/simulate_fn_hash.cpp).
+- **`hash=0xY`** in the comment line — runtime's *own* hash for `<fn>` (`getFunctionHash`).
+- **`@dep::name=0xZ`** — runtime's own-hash for each dependency.
+- **The SimNode dump that follows** — the runtime function body, with per-node sub-hashes printed via `displayHash=true`.
+
+The AOT-recorded values live in the generated `.cpp`:
+
+```
+grep "<fn>.*hash=" tests/<area>/_aot_generated/<file>.das.cpp
+```
+
+You'll see the AOT-time `hash=0x...` and matching dep entries. The numeric registration line `{ 0x..., false, (void*)&<fn>_..., ... }` holds the AOT-time *combined* hash.
+
+## Step 2 — Localize the disagreement
+
+Compare runtime vs AOT recorded.
+
+**Case A — own hash matches, combined doesn't.** Some dep's runtime hash differs from AOT. Diff the `@dep::*=0x...` lists in the AOT comment vs the runtime printout. The first dep with a different hex is the one to investigate next (recurse: it now becomes the `<fn>` to debug).
+
+**Case B — own hash itself differs.** The function body hashes differently between AOT-gen and runtime. The body diverges in *some* node. Continue to step 3.
+
+## Step 3 — Side-by-side SimNode dumps
+
+The trick: get the *same* function dumped from both code paths and `diff` them.
+
+Add to the failing `.das` file:
+```
+options log_nodes
+options log_nodes_aot_hash
+```
+
+`log_nodes` triggers `printSimFunction` in [`src/ast/ast_simulate.cpp`](../src/ast/ast_simulate.cpp) line ~3814. `log_nodes_aot_hash` adds per-node hash annotations.
+
+Then capture from both directions:
+
+```
+# Runtime dump (the failing path):
+bin/Release/daslang.exe -dry-run tests/<area>/<failing_test>.das > /tmp/runtime.txt 2>&1
+
+# AOT-generation dump (the recorded path):
+bin/Release/daslang.exe utils/aot/main.das -- -aot tests/<area>/<failing_test>.das /tmp/aot.cpp > /tmp/aot.txt 2>&1
+```
+
+If the AOT-tool side surfaces only `[I] Aot to ...` without log_nodes output, that path runs `compile_and_simulate` from [`daslib/aot_cpp.das`](../daslib/aot_cpp.das), which discards logs. Use `daslang.exe -dry-run` on the same file as a **second runtime path** and diff the two — both runtime paths going through `simulate()` should produce identical hashes for the same source. If they DON'T, the issue is non-deterministic codegen (your bug) and the diff pinpoints it. If they DO match, the AOT-recorded value differs from both — search for special handling along the AOT-generation pipeline (e.g. `is_in_aot()`, `set_aot()`, `policies.aot_module`).
+
+In the dump, find the failing function:
+```
+grep -n "^// <fn> <fn>" /tmp/runtime.txt   # the function body block starts here
+awk 'NR==<line>,/^$/' /tmp/runtime.txt > /tmp/runtime_fn.txt
+# repeat for the other dump
+diff /tmp/runtime_fn.txt /tmp/other_fn.txt | head -60
+```
+
+The first differing line is the divergence point. Each SimNode prints with hex hashes annotated; the change of hash on a particular node tells you which subtree differs.
+
+## Step 4 — Two common divergence shapes
+
+### Shape 1 — Constant value bytes differ (this PR's bug)
+
+Diff shows a single `ConstValue` brace with **same low half, different high half**:
+
+```
+< {1374389535,1074339512, 2265841977,32766}
+> {1374389535,1074339512, 3662712544,32759}
+```
+
+The first 8 bytes are the actual scalar (here `3.14lf`); the trailing 8 bytes look like pointer addresses (`0x7FFE...`/`0x7FF7...`).
+
+**Diagnosis: a `cast<T>::from` or similar conversion is leaking uninitialized stack/union bytes into the `vec4f` it returns.** Some primitive's `cast` specialization in [`include/daScript/simulate/cast.h`](../include/daScript/simulate/cast.h) is using the union trick:
+
+```cpp
+union { vec4f v; T t; } A;   // A.v UNINITIALIZED
+A.t = x;                     // writes sizeof(T) bytes
+return A.v;                  // returns 16 bytes — high bytes = stack garbage
+```
+
+Compare with the proper pattern (e.g. `cast<int64_t>::from`):
+```cpp
+return v_cast_vec4f(v_ldui_half(&x));   // v_ldui_half = _mm_loadl_epi64 → zeros upper
+```
+
+Fix the broken specialization to either zero the union first (`A.v = v_zero(); A.t = x;`) or use the SSE intrinsic. SimSource hashes the full vec4f via `V_ARG(value)` in [`src/simulate/simulate_visit.cpp`](../src/simulate/simulate_visit.cpp) — there's no type info at hash time, so the fix has to be at the construction site, not the visit site.
+
+### Shape 2 — `is_in_aot()` branching
+
+Diff shows entire SimNode subtrees that exist in one path but not the other. The macro expansion produced different code in AOT mode vs runtime mode.
+
+**Diagnosis: something in the macro chain checks `is_in_aot()` (or `set_aot()`'s `g_isInAot` flag) and emits different AST in each mode.** Grep:
+
+```
+grep -rln "is_in_aot\|set_aot\|aot_module" daslib/ <required modules>
+```
+
+The AOT tool sets `g_isInAot = true` via `set_aot()` in [`daslib/aot_cpp.das:3988`](../daslib/aot_cpp.das). Code that branches on it is fundamentally non-portable across AOT-gen ↔ runtime — fix by removing the branch (produce the same AST in both contexts) or by ensuring the branch only affects details that don't reach the SimNode tree.
+
+## Step 5 — Verify the fix
+
+After fixing:
+
+1. **Wipe the AOT cache** (the fix likely changed bytes the AOT-side had recorded):
+   ```
+   rm -rf tests/<area>/_aot_generated/ daslib/_aot_generated/test_aot_daslib_modules_*.das.cpp
+   ```
+2. **Rebuild and re-run**:
+   ```
+   cmake --build build --config Release --target test_aot -- /nodeReuse:false
+   bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests/<area>
+   ```
+3. **Strip the debug options** from the test file before committing.
+
+## C++ debug helpers (last resort)
+
+If `log_nodes` isn't enough, [`src/simulate/simulate_fn_hash.cpp`](../src/simulate/simulate_fn_hash.cpp) has two `#if 1` switches at the top:
+
+```cpp
+#if 1
+#define debug_hash(...)
+#else
+#define debug_hash  printf
+#endif
+```
+
+Flip `1` → `0` to turn on byte-by-byte hash trace (`debug_hash`) or per-function combined-hash trace (`debug_aot_hash`). **Caveat:** these print on every hash call during compilation. Cmake AOT custom-commands re-run daslang.exe per AOT file and capture stdout; if the build invokes daslang for many files, the build log explodes (~30k lines per file). Only enable when you can isolate one file with `daslang.exe -dry-run` outside of cmake.
+
+For one-off byte inspection at SimSource construction, drop a `fprintf(stderr, ...)` into `setConstValue` or wherever you want to verify the bytes the simulator stores. Just remember to revert before rebuilding the static libs (`libDaScript`, `libDaScript_runtime`) — debug printf in a hot path is fine for diagnosis, never check it in.

--- a/skills/build_and_debug.md
+++ b/skills/build_and_debug.md
@@ -1,0 +1,65 @@
+# Build & Debug
+
+Repo-internal build, run, and crash-diagnostic reference. Read this when running `cmake`, debugging a `daslang` crash, flipping module flags, or tracking down an AOT hash mismatch. Day-to-day editing doesn't require it — only operations that touch the build system or runtime exit codes.
+
+The repo builds on **Windows, Linux, macOS, iOS, Android, and WASM** (CI runs the full matrix). Most commands below are platform-neutral. Where a platform detail differs, it's noted.
+
+## Build & run
+
+- **Build system:** CMake. On Windows the default generator is MSVC (Visual Studio 2022); on Linux/macOS use Ninja or Make; on Android/iOS/WASM see the platform docs.
+- **Generate** (Windows convenience):
+  - `generate_msvc_2022.bat` → creates `build/DAS.sln`
+  - On Linux/macOS: `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release` (or omit `-G Ninja` to use the system default)
+- **Build:** `cmake --build build --config Release -j 64 -- /nodeReuse:false` (the `/nodeReuse:false` is MSBuild-only; drop it on Ninja/Make)
+- **Compiler binary:**
+  - Windows MSVC (multi-config): `bin/Release/daslang.exe`
+  - Linux/macOS (single-config): `build/daslang`
+- **Live-reload host:** `bin/Release/daslang-live.exe` (Windows) / `build/daslang-live` (Linux/macOS) — same script runs in both; see `utils/daslang-live/main.cpp`
+- **Run a script:** `<daslang-binary> path/to/script.das`
+- **Compile-only check:** `<daslang-binary> -compile-only path/to/script.das` — compiles without simulation or execution, useful for syntax/type checking without needing a window or GL context. Use `-dry-run` to also simulate (but not execute).
+- **Run tests:** `<daslang-binary> dastest/dastest.das -- --test path/to/test.das`
+- **AOT tests:** `cmake --build build --config Release --target test_aot` then `<test_aot-binary> -use-aot dastest/dastest.das -- --use-aot --test tests`
+- **IMPORTANT:** When adding a new test directory under `tests/`, register it in `tests/aot/CMakeLists.txt` for AOT compilation. See `skills/aot_testing.md` for the step-by-step pattern. CI runs ALL tests with AOT enabled — unregistered test directories cause `error[50101]: AOT link failed`
+
+This skill uses `bin/Release/daslang.exe` in examples below (the dominant local-dev case); substitute the right path on other platforms.
+
+## Build timing
+
+- **Builds are slow** — clean builds take **15-25 minutes**, incremental builds take **2-10 minutes** depending on what changed
+- **Always use `timeout: 0`** (no timeout) when running `cmake --build` commands. A build that hasn't finished is not stuck or broken, it's just compiling
+- **Do not assume build failure** from lack of output — MSVC and most generators are silent during compilation and only print when there are warnings/errors or when it finishes
+- For incremental builds after editing a single `.cpp` file, expect ~2-5 minutes. For changes touching headers, expect longer
+
+## Debugging runtime crashes
+
+- **Always check the exit code** after running `daslang` — a crash may produce no output, looking like a silent success
+  - Windows / PowerShell: `$LASTEXITCODE`
+  - Bash / zsh (Linux, macOS, Git Bash): `$?`
+- Exit code `-1073741819` (`0xC0000005`) on Windows = **Access Violation** — native crash (segfault). On Linux/macOS the equivalent shows up as exit code `139` (SIGSEGV) or similar. The bug is in C++ bindings or smart-pointer misuse
+- **Don't truncate output** with `head`/`tail` — daslang stack traces and `DAS_GC_BREAK_ON_ID` traces are easily clipped. Capture full output, then `grep` if needed
+- **`options log_infer_passes`** — append at the end of a failing `.das` file to dump per-pass infer activity (which generics got reified, when finalize ran, where lookups missed). Smaller and more targeted than `options log` for template/generic reification bugs. `options log` stays the right tool when you need the final program text
+
+## Build configurations (module flags)
+
+Optional modules are controlled by CMake flags (`DAS_*_DISABLED`). The active configuration lives in `.vscode/settings.json` under `cmake.configureSettings` (the "WIP" block is the active one; others are commented-out presets).
+
+Key flags (all default to `ON` = disabled in CMakeLists.txt):
+- `DAS_HV_DISABLED` — dasHV (HTTP/WebSocket via libhv)
+- `DAS_PUGIXML_DISABLED` — dasPUGIXML (XML parsing)
+- `DAS_GLFW_DISABLED` — GLFW (OpenGL windowing)
+- `DAS_IMGUI_DISABLED` — ImGui
+- `DAS_LLVM_DISABLED` — LLVM JIT
+- `DAS_CLANG_BIND_DISABLED` — Clang bindings
+- `DAS_AUDIO_DISABLED`, `DAS_STBIMAGE_DISABLED`, `DAS_STBTRUETYPE_DISABLED`, `DAS_STDDLG_DISABLED`, `DAS_SQLITE_DISABLED`
+
+**To change modules:** edit the active `cmake.configureSettings` in `.vscode/settings.json`, then reconfigure. Or pass `-DFLAG=VALUE` to your `cmake -B build ...` command. VSCode CMake Tools will pick up settings changes automatically.
+
+**Documentation generation** (`doc/reflections/das2rst.das`) requires `DAS_HV_DISABLED=OFF` and `DAS_PUGIXML_DISABLED=OFF` because it documents all modules. Temporarily enable them, rebuild `daslang`, run das2rst, then revert settings.
+
+## AOT hash mismatches
+
+When AOT fails with `error[50101]: AOT link failed`, the issue is a **semantic hash mismatch** between the generated C++ stubs and runtime. Each generated `.cpp` file has hash comments showing function hashes and dependency hashes. The runtime error also prints the same breakdown. Compare them to find the diverging function or dependency.
+
+For the full debugging workflow, see `skills/aot_hash_desync_debugging.md` (side-by-side SimNode dumps via `options log_nodes`/`log_nodes_aot_hash`, common shapes, C++ debug switches).
+
+The AOT C++ emitter lives in **`daslib/aot_cpp.das`** (the old `src/ast/ast_aot_cpp.cpp` was emptied by commit `581363ebc`). When codegen output diverges, edit `daslib/aot_cpp.das` — not the C++ stub in `src/ast/`.

--- a/skills/clargs_migration.md
+++ b/skills/clargs_migration.md
@@ -1,11 +1,11 @@
 # Skill: Migrate hand-rolled argv to `daslib/clargs`
 
 **Read this skill before** editing any in-tree tool that still calls
-`get_command_line_arguments()` directly. The standing rule (Boris,
-2026-04-24): whenever you touch such a tool for any reason, migrate its
-argv parsing to `daslib/clargs` in the same PR. Do **not** open a
-dedicated "migrate every tool" PR — keep migrations opportunistic so
-they ride along with whatever you were already doing.
+`get_command_line_arguments()` directly. Standing rule: whenever you
+touch such a tool for any reason, migrate its argv parsing to
+`daslib/clargs` in the same PR. Do **not** open a dedicated
+"migrate every tool" PR — keep migrations opportunistic so they ride
+along with whatever you were already doing.
 
 ## Why
 

--- a/skills/cpp_integration.md
+++ b/skills/cpp_integration.md
@@ -364,7 +364,7 @@ TextPrinter tp;
 tp << "leaked " << count << " handles\n";
 ```
 
-`fprintf(stderr, ...)` has three concrete problems Boris flagged:
+`fprintf(stderr, ...)` has three concrete problems:
 
 - **No sink override** — `TextPrinter` can be subclassed/redirected;
   `fprintf` writes wherever the OS `stderr` happens to point.

--- a/skills/das_macros.md
+++ b/skills/das_macros.md
@@ -113,8 +113,8 @@ When a macro walks an AST and pattern-matches specific call shapes to
 route them differently (e.g. `_sql` detects nested
 `select_from(...)._any(...)` and emits SQL `EXISTS`, vs. `_none(...)`
 emitting `NOT EXISTS`), **do not rely on detecting `!expr` to flip the
-emitted output**. Boris's standing rule (2026-04-24): "we don't have
-leading `!` support" for AST walkers. The `!` often sits across
+emitted output**. Standing rule: AST walkers do not have leading-`!`
+support. The `!` often sits across
 intermediate AST nodes — parentheses, `if` expressions, local `let`
 bindings, constant-folded wrappers — that break a naive pattern match.
 Pattern-matching `!any(...)` is correct for some cases, silently wrong

--- a/skills/install_instructions.md
+++ b/skills/install_instructions.md
@@ -24,6 +24,7 @@ Source files live under `install/` in the repo; CMake installs them to the SDK r
 | `install/skills/memory_leak_detection.md` | `skills/memory_leak_detection.md` | Heap / gc_node / smart_ptr / handle leak detection — runtime CLI flags |
 | `install/skills/jobque_debugging.md` | `skills/jobque_debugging.md` | Channel/LockBox/JobStatus/Stream/Feature leak debugging with `--track-job-status` |
 | `install/skills/detect_dupe.md` | `skills/detect_dupe.md` | Duplicate-function detection — corpus build, MCP tools (`export_corpus`, `detect_duplicates`), CLI modes |
+| `install/skills/mcp_tools.md` | `skills/mcp_tools.md` | Full MCP tool table + live-API reference (CLAUDE.md only carries a 2-line pointer) |
 | `utils/mcp/` (whole dir) | `utils/mcp/` | MCP server for AI assistants (gated on dasHV) |
 | `utils/detect-dupe/` (whole dir) | `utils/detect-dupe/` | Duplicate-function detector (canonicalizer, clusterer, MinHash, pattern filter) |
 
@@ -88,30 +89,31 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/install/skills DESTINATION ${DAS_INSTALL
 
 ## Verification
 
-After modifying install instructions:
+After modifying install instructions, install to a scratch prefix and verify the layout. Replace `<prefix>` with whatever directory you prefer (e.g. `~/daslang-test`, `/tmp/daslang`, `D:/daslang`).
 
 1. Rebuild: `cmake --build build --config Release --target daslang`
-2. Install: `cmake --install build --config Release --prefix D:/daslang`
-3. Verify files exist:
-   - `D:/daslang/CLAUDE.md`
-   - `D:/daslang/skills/das_formatting.md`
-   - `D:/daslang/skills/cpp_integration.md`
-   - `D:/daslang/skills/daslib_modules.md`
-   - `D:/daslang/skills/das_macros.md`
-   - `D:/daslang/skills/daspkg.md`
-   - `D:/daslang/skills/dynamic_modules.md`
-   - `D:/daslang/skills/daslang_live.md`
-   - `D:/daslang/skills/clargs_usage.md`
-   - `D:/daslang/skills/json.md`
-   - `D:/daslang/skills/xml.md`
-   - `D:/daslang/skills/filesystem.md`
-   - `D:/daslang/skills/writing_tests.md`
-   - `D:/daslang/skills/memory_leak_detection.md`
-   - `D:/daslang/skills/jobque_debugging.md`
-   - `D:/daslang/skills/detect_dupe.md`
-   - `D:/daslang/utils/mcp/main.das` (only if built with `DAS_HV_DISABLED=OFF`)
-   - `D:/daslang/utils/mcp/tools/common.das` (only if built with `DAS_HV_DISABLED=OFF`)
-   - `D:/daslang/utils/detect-dupe/main.das`
-   - `D:/daslang/utils/detect-dupe/patterns.das`
-   - `D:/daslang/utils/detect-dupe/fixture/synth.das`
+2. Install: `cmake --install build --config Release --prefix <prefix>`
+3. Verify files exist under `<prefix>/`:
+   - `CLAUDE.md`
+   - `skills/das_formatting.md`
+   - `skills/cpp_integration.md`
+   - `skills/daslib_modules.md`
+   - `skills/das_macros.md`
+   - `skills/daspkg.md`
+   - `skills/dynamic_modules.md`
+   - `skills/daslang_live.md`
+   - `skills/clargs_usage.md`
+   - `skills/json.md`
+   - `skills/xml.md`
+   - `skills/filesystem.md`
+   - `skills/writing_tests.md`
+   - `skills/memory_leak_detection.md`
+   - `skills/jobque_debugging.md`
+   - `skills/detect_dupe.md`
+   - `skills/mcp_tools.md`
+   - `utils/mcp/main.das` (only if built with `DAS_HV_DISABLED=OFF`)
+   - `utils/mcp/tools/common.das` (only if built with `DAS_HV_DISABLED=OFF`)
+   - `utils/detect-dupe/main.das`
+   - `utils/detect-dupe/patterns.das`
+   - `utils/detect-dupe/fixture/synth.das`
 4. Spot-check that no repo-internal paths leaked into install files

--- a/skills/mcp_tools.md
+++ b/skills/mcp_tools.md
@@ -1,0 +1,56 @@
+# MCP Tools Reference
+
+The daslang MCP server (`utils/mcp/main.das`) exposes compiler diagnostics, program introspection, and live-reload control to AI coding assistants via the [Model Context Protocol](https://modelcontextprotocol.io/). Stdio transport — no extra build dependencies.
+
+**When MCP tools are available, prefer them** over manual compilation and grep-based exploration. **For searching `.das` files, prefer MCP tools over built-in Grep/Glob** — `grep_usage` is parse-aware (tree-sitter), `find_references` resolves cross-module symbols, `find_symbol` searches all loaded modules. **For interacting with `daslang-live`, always use MCP live tools** — not curl.
+
+## Tool table
+
+| Tool | Use instead of... |
+|---|---|
+| `compile_check` | Running `daslang` manually and parsing errors |
+| `list_functions` | Grepping for `def ` in `.das` files |
+| `list_types` | Grepping for `struct`/`class`/`enum` definitions |
+| `find_symbol` | Searching across modules for function/type names |
+| `list_module_api` | Reading daslib source to find available functions |
+| `list_modules` | Guessing module names or scanning `daslib/` directory |
+| `ast_dump` | Manually inspecting AST or post-macro output (supports `lineinfo` for source locations) |
+| `program_log` | Running with `options log` to see full post-compilation program text |
+| `run_script` | Running scripts via shell and capturing output |
+| `run_test` | Running dastest via shell and parsing results |
+| `format_file` | Running the formatter script manually |
+| `convert_to_gen2` | Running `das-fmt` manually to convert gen1→gen2 syntax |
+| `goto_definition` | Manually tracing symbol definitions across files |
+| `type_of` | Manually inspecting expression types |
+| `list_requires` | Grepping for `require` statements and guessing transitive deps |
+| `find_references` | Manually searching for all usages of a symbol across files |
+| `eval_expression` | Evaluating expressions by writing throwaway scripts |
+| `describe_type` | Reading source to understand type fields, methods, and values |
+| `grep_usage` | Built-in Grep across `.das` files (parse-aware via ast-grep + tree-sitter) |
+| `outline` | Manually scanning files for function/struct/enum declarations |
+| `aot` | Manually running AOT generation and extracting function C++ |
+| `lint` | Running lint/perf_lint/style_lint manually |
+| `export_corpus` | `detect-dupe --export-functions` from a shell |
+| `detect_duplicates` | `detect-dupe --against` to ask "did I just write this?" — wraps B2 mode end-to-end |
+| `judge_duplicates` | Manually invoking `find-dupe` over a `detect-dupe` JSON report. Returns Claude-judged verdicts (real / partial / false_positive). Requires daspkg-installed `anthropic/anthropic` and `ANTHROPIC_API_KEY` |
+| `find_dupe` | One-shot duplicate-finder + judge. Use when starting fresh on a directory or PR; `detect_duplicates` + `judge_duplicates` separately when you already have a curated corpus |
+| `live_launch` | Manually starting `daslang-live` from shell |
+| `live_status` | `curl http://localhost:9090/status` |
+| `live_error` | `curl http://localhost:9090/error` |
+| `live_reload` | `curl -X POST http://localhost:9090/reload` |
+| `live_pause` | `curl -X POST http://localhost:9090/pause` or `/unpause` |
+| `live_command` | `curl -X POST http://localhost:9090/command -d '{"name":"..."}` |
+| `live_shutdown` | `curl -X POST http://localhost:9090/shutdown` |
+| `shutdown` | Manually restarting the MCP server process |
+
+## Notes
+
+**Cursor-based tools** (`goto_definition`, `type_of`, `find_references`) accept a `no_opt` parameter that disables compiler optimizations to preserve the full AST — useful when globals, enum values, or bitfield constants get constant-folded away.
+
+**Live tools.** `live_*` interact with a running `daslang-live` instance via its REST API. `live_launch` starts one if not already running (sets working directory to the script's folder). All live tools accept an optional `port` parameter (default 9090). When a compilation error is active, `live_command` and `live_pause` return HTTP 503 with the error — use `live_reload` to fix. Hitting any unknown endpoint returns JSON help with all endpoints + curl examples.
+
+**`shutdown` tool.** Shuts down the MCP server process. Claude Code auto-restarts it, picking up code changes to `.das` tool files. Tool registration changes (adding/removing tools) still require a manual MCP restart.
+
+**Configuration.** Configure `.mcp.json` with `"command"` pointing at the daslang binary (`bin/Release/daslang.exe` on Windows MSVC, `build/daslang` on Linux/macOS, `bin/daslang` for the installed SDK), `"args": ["utils/mcp/main.das"]`. See `utils/mcp/README.md` for details and Claude Code permissions.
+
+**Tests:** run `dastest/dastest.das -- --test utils/mcp/test_tools.das` through the daslang binary.

--- a/skills/writing_benchmarks.md
+++ b/skills/writing_benchmarks.md
@@ -25,18 +25,30 @@ bin/Release/daslang.exe -jit dastest/dastest.das -- --bench --test benchmarks/co
 
 The Copilot terminal tool truncates output at ~16KB and mixes it with prior scrollback. **Always pipe benchmark output to a file**, then read the file:
 
+From the repo root, on Windows / PowerShell:
+
 ```powershell
 # Run a single benchmark file
-Push-Location D:\Work\daScript
-D:\Work\daScript\bin\Release\daslang.exe D:\Work\daScript\dastest\dastest.das -- --bench --test D:\Work\daScript\benchmarks\core\hash\test02.das 2>&1 | Out-File D:\Work\daScript\_bench_out.txt -Encoding ascii
-Pop-Location
+bin\Release\daslang.exe dastest\dastest.das -- --bench --test benchmarks\core\hash\test02.das 2>&1 | Out-File _bench_out.txt -Encoding ascii
 
 # Run a whole directory — run files one at a time to avoid multi-hour waits
 $tests = 2..12
 foreach ($t in $tests) {
-    $f = "D:\Work\daScript\benchmarks\core\hash\test{0:D2}.das" -f $t
-    D:\Work\daScript\bin\Release\daslang.exe D:\Work\daScript\dastest\dastest.das -- --bench --test $f 2>&1 | Out-File D:\Work\daScript\_bench_out.txt -Append -Encoding ascii
+    $f = "benchmarks\core\hash\test{0:D2}.das" -f $t
+    bin\Release\daslang.exe dastest\dastest.das -- --bench --test $f 2>&1 | Out-File _bench_out.txt -Append -Encoding ascii
 }
+```
+
+On Linux / macOS:
+
+```bash
+# Single file
+build/daslang dastest/dastest.das -- --bench --test benchmarks/core/hash/test02.das > _bench_out.txt 2>&1
+
+# Whole directory, one at a time
+for t in $(seq -f "%02g" 2 12); do
+    build/daslang dastest/dastest.das -- --bench --test "benchmarks/core/hash/test${t}.das" >> _bench_out.txt 2>&1
+done
 ```
 
 Then read results with `read_file` on `_bench_out.txt` — **not** from terminal output.

--- a/tests/ast_match/_qmatch_r2v_helper.das
+++ b/tests/ast_match/_qmatch_r2v_helper.das
@@ -1,0 +1,56 @@
+// Helper module for tests/ast_match/test_ref2value_skip.das.
+//
+// Provides ``test_emit_qmatch_with_wrapped_pattern(source)`` — a [call_macro]
+// that hand-builds an ``ExprCallMacro(name="qmatch")`` whose pattern argument
+// is an ``ExprRef2Value(...)`` wrapper around a clean inner pattern. This
+// exercises the pattern-side peel in ``generate_match``, which is reachable
+// in production through macro composition (a meta-macro can construct a
+// ``qmatch(...)`` call and feed it a pattern AST that already carries
+// typer-inserted ``ExprRef2Value`` wrappers from a value-context read).
+//
+// Lives in a separate ``.das`` with a leading underscore so dastest's file
+// discovery skips it as a test (per ``feedback_dastest_underscore_skip``).
+options gen2
+options indenting = 4
+
+module _qmatch_r2v_helper public
+
+require daslib/ast public
+require daslib/ast_boost
+require daslib/templates_boost
+require daslib/ast_match public
+
+[call_macro(name = "test_emit_qmatch_with_wrapped_pattern")]
+class private EmitQMatchWithWrappedPattern : AstCallMacro {
+    def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
+        return false
+    }
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        if (call.arguments |> length != 1) {
+            macro_error(prog, call.at, "expecting test_emit_qmatch_with_wrapped_pattern(source)")
+            return null
+        }
+        let at = call.at
+
+        // Inner pattern — clean ExprField shape (a.foo).
+        var inner_pattern = qmacro(a.foo)
+
+        // Wrap the pattern in ExprRef2Value, exactly the shape the typer
+        // would insert if a meta-macro fed a typed-as-value expression
+        // into qmatch's pattern slot.
+        var wrapped_pattern : Expression? = new ExprRef2Value(at = at, subexpr = inner_pattern)
+
+        // Build qmatch via qmacro (which sets ExprCallMacro.macro correctly
+        // through the normal parser path), then patch arguments[1] with the
+        // wrapped pattern. Naive `qmacro(qmatch($e(src), $e(wrapped)))` would
+        // fail because qmatch.canVisitArgument(1)=false keeps the pattern
+        // arg raw — qmacro's `$e` tag survives into qmatch's pattern slot
+        // where qmatch reads it as its own capture syntax. Using a literal
+        // `0` placeholder for the pattern slot avoids the collision; we
+        // overwrite it post-build.
+        var src_arg = call.arguments[0]
+        var qm = qmacro(qmatch($e(src_arg), 0))
+        (qm as ExprCallMacro).arguments[1] = wrapped_pattern
+        return qm
+    }
+}

--- a/tests/ast_match/test_ref2value_skip.das
+++ b/tests/ast_match/test_ref2value_skip.das
@@ -1,0 +1,154 @@
+options gen2
+options indenting = 4
+options rtti
+
+require daslib/ast
+require daslib/ast_match
+require daslib/ast_boost
+require daslib/templates_boost
+require dastest/testing_boost public
+require _qmatch_r2v_helper
+
+// ============================================================================
+// ExprRef2Value transparency tests
+//
+// Post-inference, the typer wraps reference reads in ExprRef2Value(inner). The
+// wrapper is invisible to user-written code, so the matcher peels it on both
+// the source side (runtime) and the pattern side (compile time). These tests
+// build the wrapper manually via `new ExprRef2Value(...)` since daslang has no
+// surface syntax for it.
+//
+// Pattern-side coverage is exercised via `test_emit_qmatch_with_wrapped_pattern`
+// in `_qmatch_r2v_helper.das`, a [call_macro] that hand-builds an
+// `ExprCallMacro(name="qmatch")` whose pattern argument is wrapped in
+// `ExprRef2Value`. This is the realistic macro-composition shape that motivates
+// the pattern-side peel.
+//
+// ExprPtr2Ref (`*foo`) is intentionally NOT peeled — those tests pin the
+// design decision so a future "consistency" refactor doesn't accidentally
+// equate `*foo` with `foo`.
+// ============================================================================
+
+[test]
+def test_source_wrapped_field(t : T?) {
+    ast_gc_guard() {
+        var inner = qmacro(a.foo)
+        var wrapped : ExpressionPtr = new ExprRef2Value(at = inner.at, subexpr = inner)
+        let r = qmatch(wrapped, a.foo)
+        t |> success(r.matched, "ExprRef2Value(a.foo) should match pattern a.foo")
+    }
+}
+
+[test]
+def test_source_wrapped_var(t : T?) {
+    ast_gc_guard() {
+        var inner = qmacro(somevar)
+        var wrapped : ExpressionPtr = new ExprRef2Value(at = inner.at, subexpr = inner)
+        let r = qmatch(wrapped, somevar)
+        t |> success(r.matched, "ExprRef2Value(somevar) should match pattern somevar")
+    }
+}
+
+[test]
+def test_source_wrapped_op(t : T?) {
+    ast_gc_guard() {
+        var inner = qmacro(a + b)
+        var wrapped : ExpressionPtr = new ExprRef2Value(at = inner.at, subexpr = inner)
+        let r = qmatch(wrapped, a + b)
+        t |> success(r.matched, "ExprRef2Value(a + b) should match pattern a + b")
+    }
+}
+
+[test]
+def test_nested_wrappers(t : T?) {
+    ast_gc_guard() {
+        var inner = qmacro(a.foo)
+        var w1 : ExpressionPtr = new ExprRef2Value(at = inner.at, subexpr = inner)
+        var w2 : ExpressionPtr = new ExprRef2Value(at = inner.at, subexpr = w1)
+        var w3 : ExpressionPtr = new ExprRef2Value(at = inner.at, subexpr = w2)
+        let r = qmatch(w3, a.foo)
+        t |> success(r.matched, "triple-wrapped ExprRef2Value should peel down to a.foo")
+    }
+}
+
+[test]
+def test_capture_e_peels_wrapper(t : T?) {
+    // $e(var) capture must yield the underlying expression, not the wrapper —
+    // downstream callers check `captured is ExprField`, not `is ExprRef2Value`.
+    ast_gc_guard() {
+        var inner = qmacro(target.col)
+        var wrapped : ExpressionPtr = new ExprRef2Value(at = inner.at, subexpr = inner)
+        var captured : ExpressionPtr
+        let r = qmatch(wrapped, $e(captured))
+        t |> success(r.matched, "$e on wrapped expression should match")
+        if (r.matched) {
+            t |> equal(string(captured.__rtti), "ExprField",
+                       "captured value should be the inner ExprField, not ExprRef2Value")
+        }
+    }
+}
+
+[test]
+def test_capture_f_peels_wrapper(t : T?) {
+    // The hand-rolled is_underscore_field in sqlite_linq existed to do exactly
+    // this: peel ExprRef2Value, then capture the field name. With auto-peel,
+    // the matcher does it directly.
+    ast_gc_guard() {
+        var inner = qmacro(a.colname)
+        var wrapped : ExpressionPtr = new ExprRef2Value(at = inner.at, subexpr = inner)
+        var fname = ""
+        let r = qmatch(wrapped, a.$f(fname))
+        t |> success(r.matched, "a.$f(...) should match through ExprRef2Value wrapper")
+        t |> equal(fname, "colname", "should capture field name through wrapper")
+    }
+}
+
+[test]
+def test_clean_source_still_matches(t : T?) {
+    // Regression — peeling logic must not break the no-wrapper case.
+    ast_gc_guard() {
+        var expr = qmacro(a.foo)
+        let r = qmatch(expr, a.foo)
+        t |> success(r.matched, "unwrapped source should still match")
+    }
+}
+
+// ── ExprPtr2Ref NOT auto-peeled (negative tests) ─────────────────────────
+
+[test]
+def test_ptr2ref_not_peeled(t : T?) {
+    // *foo is user-visible — should NOT match a pattern of bare foo.
+    ast_gc_guard() {
+        var inner = qmacro(a.foo)
+        var wrapped : ExpressionPtr = new ExprPtr2Ref(at = inner.at, subexpr = inner)
+        let r = qmatch(wrapped, a.foo)
+        t |> success(!r.matched, "ExprPtr2Ref(a.foo) must NOT match pattern a.foo")
+    }
+}
+
+[test]
+def test_ref2value_around_ptr2ref(t : T?) {
+    // Mixed: ExprRef2Value(ExprPtr2Ref(inner)). The Ref2Value layer peels
+    // away, but the Ptr2Ref must remain — so a bare-inner pattern still fails.
+    ast_gc_guard() {
+        var inner = qmacro(a.foo)
+        var ptr2ref : ExpressionPtr = new ExprPtr2Ref(at = inner.at, subexpr = inner)
+        var wrapped : ExpressionPtr = new ExprRef2Value(at = inner.at, subexpr = ptr2ref)
+        let r = qmatch(wrapped, a.foo)
+        t |> success(!r.matched, "ExprRef2Value(ExprPtr2Ref(...)) must not match unwrapped pattern")
+    }
+}
+
+// ── Pattern-side peel (via helper macro that emits qmatch with wrapped pattern) ──
+
+[test]
+def test_pattern_side_wrapper_peeled(t : T?) {
+    // The helper macro emits: qmatch(<source>, ExprRef2Value(qmacro(a.foo))).
+    // generate_match's pattern-side peel must strip the wrapper so a clean
+    // a.foo source still matches.
+    ast_gc_guard() {
+        var src = qmacro(a.foo)
+        let r = test_emit_qmatch_with_wrapped_pattern(src)
+        t |> success(r.matched, "wrapped pattern (ExprRef2Value(a.foo)) should peel and match clean a.foo source")
+    }
+}


### PR DESCRIPTION
## Summary

Three tightly related changes — the cast.h fix is a latent bug exposed by re-enabling AOT for `ast_match`, and the new skill documents the diagnostic methodology that found it.

### `daslib/ast_match.das` — peel `ExprRef2Value` on both sides

The typer inserts `ExprRef2Value(inner)` wrappers post-inference around any read of a reference (e.g. captured `var` locals dereferenced for value). The wrapper has no surface syntax and no user-visible semantics, so the matcher peels it transparently:

- **Pattern side** (compile time): `generate_match` recursively descends into `(pattern as ExprRef2Value).subexpr` and discards the wrapper.
- **Source side** (runtime): every dispatch emits a `qm_peel_ref2value(actual_var)` call that strips wrappers in place before any RTTI/field guard fires.

`ExprPtr2Ref` (the `*foo` operator) is intentionally NOT peeled — it is user-visible, semantically meaningful, and `*foo` should not match `foo`. The 9 new tests in `tests/ast_match/test_ref2value_skip.das` pin both behaviors (positive: wrapper-transparent matching, negative: `*foo` stays opaque).

This also drops the stale `options no_aot` from `ast_match` — the smart_ptr → gc_node migration is done; AST nodes round-trip cleanly through AOT codegen now.

### `include/daScript/simulate/cast.h` — uninit-byte fix in `cast<double>::from` / `cast<long double>::from`

Removing `no_aot` from `ast_match` exposed a latent bug. The pattern

```cpp
union { vec4f v; double t; } A; A.t = x; return A.v;
```

left the upper 8 bytes of `vec4f` uninitialized, leaking stack bytes through the value path. The semantic-hash visit reads all 16 bytes, so a double constant produced different hashes at AOT-generation time vs runtime, yielding `error[50101]: AOT link failed` on any test using a const double (e.g. `tests/ast_match/test_const_types.das::test_double_match`).

Fixed by zeroing `A.v = v_zero()` before writing `A.t = x`.

### `skills/aot_hash_desync_debugging.md` — new skill

Captures the diagnostic methodology that found the cast.h bug, so the next AOT hash desync goes faster. Covers:

- Stale-binary checks (test_aot.exe vs libDaScript_runtime.lib timestamps — the first suspect when CI is green but local fails)
- AOT per-test cache busting (editing daslib doesn't regenerate `_aot_generated/*.das.cpp`)
- Side-by-side `options log_nodes` / `log_nodes_aot_hash` dumps
- Common desync shapes: cast-leak constants (this PR), `is_in_aot()` branching
- C++ `debug_hash` / `debug_aot_hash` printf switches in `simulate_fn_hash.cpp`

Registered in `CLAUDE.md` skill table.

## Test plan

- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests` — 7203/7203 interpreted
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — 6606/6606 AOT
- [x] No GC leaks in either run
- [x] `mcp__daslang__lint` clean on touched files
- [x] `mcp__daslang__format_file` clean on touched files
- [x] New tests `tests/ast_match/test_ref2value_skip.das` (9 assertions) pass under both interpreted and AOT
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)