### PR TITLE
class_method on generics: add isAppliedToGeneric flag

### DIFF
--- a/daslib/ast.das
+++ b/daslib/ast.das
@@ -109,6 +109,12 @@ class AstFunctionAnnotation {
     def abstract isCompatible(var func : FunctionPtr; var types : VectorTypeDeclPtr; decl : AnnotationDeclaration; var errors : das_string) : bool
     def abstract isSpecialized : bool
     def abstract appendToMangledName(func : FunctionPtr; decl : AnnotationDeclaration; var mangledName : das_string) : void
+    //! Returns true if this annotation's ``apply`` should also run on generic
+    //! function templates at parse time. Default is false. Annotations that
+    //! perform purely structural rewrites (no type information needed) override
+    //! this to ``true`` so the rewrite happens once on the template and every
+    //! instantiation inherits it. See ``[class_method]`` for an example.
+    def abstract isAppliedToGeneric : bool
 }
 
 [macro_interface]

--- a/daslib/class_boost.das
+++ b/daslib/class_boost.das
@@ -24,7 +24,11 @@ class ClassMethodMacro : AstFunctionAnnotation {
     explicitConstClassMethod : bool = false
     def override apply(var func : FunctionPtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
         if (func.classParent == null) {
-            errors := "class_method can be applied only to class methods";
+            errors := "class_method can be applied only to class methods"
+            return false
+        }
+        if (!func.moreFlags.isStaticClassMethod) {
+            errors := "class_method can be applied only to static class methods"
             return false
         }
         var tt = new TypeDecl(baseType = Type.tStructure, structType = func.classParent)
@@ -41,6 +45,9 @@ class ClassMethodMacro : AstFunctionAnnotation {
                 $e(func.body)
             }
         }
+        return true
+    }
+    def override isAppliedToGeneric : bool {
         return true
     }
 }

--- a/doc/source/reference/language/macros.rst
+++ b/doc/source/reference/language/macros.rst
@@ -115,6 +115,7 @@ There is additionally the ``[function_macro]`` annotation which accomplishes the
         def abstract transform ( var call : ExprCallFunc?; var errors : das_string ) : ExpressionPtr
         def abstract verifyCall ( var call : ExprCallFunc?; args,progArgs:AnnotationArgumentList; var errors : das_string ) : bool
         def abstract apply ( var func:FunctionPtr; var group:ModuleGroup; args:AnnotationArgumentList; var errors : das_string ) : bool
+        def abstract generic_apply ( var func:FunctionPtr; var group:ModuleGroup; args:AnnotationArgumentList; var errors : das_string ) : bool
         def abstract finish ( var func:FunctionPtr; var group:ModuleGroup; args,progArgs:AnnotationArgumentList; var errors : das_string ) : bool
         def abstract patch ( var func:FunctionPtr; var group:ModuleGroup; args,progArgs:AnnotationArgumentList; var errors : das_string; var astChanged:bool& ) : bool
         def abstract fixup ( var func:FunctionPtr; var group:ModuleGroup; args,progArgs:AnnotationArgumentList; var errors : das_string ) : bool
@@ -123,6 +124,7 @@ There is additionally the ``[function_macro]`` annotation which accomplishes the
         def abstract isCompatible ( var func:FunctionPtr; var types:VectorTypeDeclPtr; decl:AnnotationDeclaration; var errors:das_string ) : bool
         def abstract isSpecialized : bool
         def abstract appendToMangledName ( func:FunctionPtr; decl:AnnotationDeclaration; var mangledName:das_string ) : void
+        def abstract isAppliedToGeneric : bool
     }
 
 ``transform`` lets you change calls to the function and is applied at the infer pass.
@@ -132,6 +134,12 @@ Transform is the best way to replace or modify function calls with other semanti
 
 ``apply`` is applied to the function itself before the infer pass.
 Apply is typically where global function body modifications or instancing occurs.
+
+``generic_apply`` is applied to each instance of a generic function as it is specialized,
+after the type substitution. Use it for transformations that need the resolved types of the
+instance. For purely structural rewrites that do not need types resolved, override
+``apply`` and return true from ``isAppliedToGeneric`` so the rewrite happens once on the
+generic template instead.
 
 ``finish`` is applied to the function itself after the infer pass.
 It's only called on non-generic functions or instances of the generic functions.
@@ -154,6 +162,13 @@ If a function is not compatible, the errors field must be specified.
 
 ``appendToMangledName`` is called to append a mangled name to the function.
 That way multiple functions with the same type signature can exist and be differentiated between.
+
+``isAppliedToGeneric`` returns true if the annotation's ``apply`` should also run on
+generic function templates at parse time. By default it is false, meaning ``apply`` only
+runs on non-generic functions; generic instances receive ``generic_apply`` instead.
+Annotations that perform purely structural rewrites (no type information needed) — for
+example, ``[class_method]`` injecting a ``self`` argument — return true so that the
+rewrite happens once on the template and every instantiation inherits it.
 
 Lets review the following example from ``ast_boost`` of how the ``macro`` annotation is implemented:
 

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -463,6 +463,7 @@ namespace das
         virtual bool isCompatible ( const FunctionPtr &, const vector<TypeDeclPtr> &, const AnnotationDeclaration &, string &  ) const { return true; }
         virtual bool isSpecialized() const { return false; }
         virtual void appendToMangledName( const FunctionPtr &, const AnnotationDeclaration &, string & /* mangledName */ ) const { }
+        virtual bool isAppliedToGeneric() const { return false; }
     };
 
     struct TransformFunctionAnnotation : FunctionAnnotation {

--- a/include/daScript/builtin/ast_gen.inc
+++ b/include/daScript/builtin/ast_gen.inc
@@ -13,9 +13,10 @@ protected:
     __fn_isCompatible = 9,
     __fn_isSpecialized = 10,
     __fn_appendToMangledName = 11,
+    __fn_isAppliedToGeneric = 12,
   };
 protected:
-  int _das_class_method_offset[12];
+  int _das_class_method_offset[13];
 public:
   AstFunctionAnnotation_Adapter ( const StructInfo * info ) {
       _das_class_method_offset[__fn_transform] = info->fields[2]->offset;
@@ -30,6 +31,7 @@ public:
       _das_class_method_offset[__fn_isCompatible] = info->fields[11]->offset;
       _das_class_method_offset[__fn_isSpecialized] = info->fields[12]->offset;
       _das_class_method_offset[__fn_appendToMangledName] = info->fields[13]->offset;
+      _das_class_method_offset[__fn_isAppliedToGeneric] = info->fields[14]->offset;
   }
   __forceinline Func get_transform ( void * self ) const {
     return getDasClassMethod(self,_das_class_method_offset[__fn_transform]);
@@ -138,6 +140,15 @@ public:
       <void *,Function * const ,AnnotationDeclaration const  &,das::string &>
         (__context__,nullptr,__funcCall__,
           self,func,decl,mangledName);
+  }
+  __forceinline Func get_isAppliedToGeneric ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_isAppliedToGeneric]);
+  }
+  __forceinline bool invoke_isAppliedToGeneric ( Context * __context__, Func __funcCall__, void * self ) const {
+    return das_invoke_function<bool>::invoke
+      <void *>
+        (__context__,nullptr,__funcCall__,
+          self);
   }
 };
 

--- a/src/builtin/module_builtin_ast_adapters.cpp
+++ b/src/builtin/module_builtin_ast_adapters.cpp
@@ -1340,6 +1340,17 @@ namespace das {
                 return false;
             }
         }
+        virtual bool isAppliedToGeneric () const override {
+            if ( auto fnIsAppliedToGeneric = get_isAppliedToGeneric(classPtr) ) {
+                bool result = false;
+                runMacroFunction(context, "isAppliedToGeneric", [&]() {
+                    result = invoke_isAppliedToGeneric(context,fnIsAppliedToGeneric,classPtr);
+                });
+                return result;
+            } else {
+                return false;
+            }
+        }
         virtual bool isCompatible ( const FunctionPtr & fn, const vector<TypeDeclPtr> & types,
             const AnnotationDeclaration & decl, string & err  ) const override {
             if ( auto fnIsCompatible = get_isCompatible(classPtr) ) {

--- a/src/parser/parser_impl.cpp
+++ b/src/parser/parser_impl.cpp
@@ -163,13 +163,17 @@ namespace das {
         }
     }
 
-    void runFunctionAnnotations ( yyscan_t scanner, DasParserState * extra, Function * func, AnnotationList * annL, const LineInfo & at ) {
+    void runFunctionAnnotations ( yyscan_t scanner, DasParserState * extra, Function * func, AnnotationList * annL, const LineInfo & at, bool genericMode ) {
         if ( annL ) {
             for ( auto itA = annL->begin(); itA!=annL->end();  ) {
                 auto pA = *itA;
                 if ( pA->annotation ) {
                     if ( pA->annotation->rtti_isFunctionAnnotation() ) {
                         auto ann = static_cast<FunctionAnnotation*>(pA->annotation);
+                        if ( genericMode && !ann->isAppliedToGeneric() ) {
+                            itA ++;
+                            continue;
+                        }
                         string err;
                         if ( !ann->apply(func, *yyextra->g_Program->thisModuleGroup, pA->arguments, err) ) {
                             das_yyerror(scanner,"macro [" +pA->annotation->name + "] failed to apply to a function " + func->name + "\n" + err, at,
@@ -799,9 +803,10 @@ namespace das {
             }
             assignDefaultArguments(func);
             if ( isGeneric ) {
+                runFunctionAnnotations(scanner, yyextra, func, annL, annLAt, /*genericMode=*/true);
                 implAddGenericFunction(scanner, func);
             } else {
-                runFunctionAnnotations(scanner, nullptr, func, annL, annLAt);
+                runFunctionAnnotations(scanner, yyextra, func, annL, annLAt);
                 if ( !yyextra->g_Program->addFunction(func) ) {
                     das_yyerror(scanner,"function is already defined " + func->getMangledName(),
                         func->at, CompilationError::function_already_declared);

--- a/src/parser/parser_impl.h
+++ b/src/parser/parser_impl.h
@@ -78,7 +78,7 @@ namespace das {
     void deleteNameExprList ( vector<tuple<string,Expression *>> * list );
     void varDeclToTypeDecl ( yyscan_t scanner, TypeDecl * pType, vector<VariableDeclaration*> * list, bool needNames = true );
     Annotation * findAnnotation ( yyscan_t scanner, const string & name, const LineInfo & at );
-    void runFunctionAnnotations ( yyscan_t scanner, DasParserState * extra, Function * func, AnnotationList * annL, const LineInfo & at );
+    void runFunctionAnnotations ( yyscan_t scanner, DasParserState * extra, Function * func, AnnotationList * annL, const LineInfo & at, bool genericMode = false );
     void appendDimExpr ( TypeDecl * typeDecl, Expression * dimExpr );
     void implAddGenericFunction ( yyscan_t scanner, Function * func );
     Expression * ast_arrayComprehension (yyscan_t scanner, const LineInfo & loc, vector<VariableNameAndPosition> * iters,

--- a/tests/README.md
+++ b/tests/README.md
@@ -478,6 +478,8 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | failed_function_argument_already_declared.das | Duplicate function argument name | **expect** `30202` |
 | failed_function_not_found_ambiguous.das | Ambiguous function call — same name in two modules | **expect** `30304` |
 | generators.das | Generator mechanics — yield, ranges, nested, early return | |
+| generic_class_method.das | `[class_method]` on generic static methods — verifies `isAppliedToGeneric` flag | |
+| failed_class_method_non_static.das | `[class_method]` rejected on non-static class method | **expect** `30111` |
 | failed_global_init_type_mismatch.das | Global variable type mismatch on init | **expect** `30113` |
 | global_order.das | Global variable initialization ordering with clone | |
 | global_ptr_init.das | Global pointer struct initialization | |

--- a/tests/language/failed_class_method_non_static.das
+++ b/tests/language/failed_class_method_non_static.das
@@ -1,0 +1,15 @@
+// [class_method] applied to a non-static class method
+// verifies the static-only guard in daslib/class_boost.das ClassMethodMacro.apply
+options gen2
+expect 30111    // invalid_annotation
+
+require daslib/class_boost
+
+class C {
+    value : int = 0
+
+    [class_method]
+    def put(v : int) {
+        value = v
+    }
+}

--- a/tests/language/generic_class_method.das
+++ b/tests/language/generic_class_method.das
@@ -1,0 +1,52 @@
+options gen2
+
+require dastest/testing_boost public
+require daslib/class_boost
+
+// Verifies that [class_method] applies correctly to generic static methods
+// on a struct. Before the isAppliedToGeneric flag, the [class_method]
+// transformation (inject `self`, wrap body in `with(self)`) was skipped for
+// generic methods because runFunctionAnnotations was not called on them.
+
+struct Box {
+    value : int = 0
+
+    [class_method]
+    def static put(v : auto) {
+        value = int(v)
+    }
+
+    [class_method]
+    def static get : int {
+        return value
+    }
+
+    [class_method]
+    def static add(v : auto) : int {
+        value += int(v)
+        return value
+    }
+}
+
+[test]
+def test_generic_class_method(t : T?) {
+    t |> run("instantiate generic put with int") @(it : T?) {
+        var b = Box()
+        b.put(42)
+        it |> equal(b.get(), 42)
+    }
+    t |> run("instantiate generic put with float") @(it : T?) {
+        var b = Box()
+        b.put(7.5)
+        it |> equal(b.get(), 7)
+    }
+    t |> run("multiple instantiations on the same value") @(it : T?) {
+        var b = Box()
+        b.put(10)
+        let r1 = b.add(5)
+        let r2 = b.add(2.0)
+        it |> equal(r1, 15)
+        it |> equal(r2, 17)
+        it |> equal(b.get(), 17)
+    }
+}

--- a/tutorials/language/18_classes.das
+++ b/tutorials/language/18_classes.das
@@ -187,6 +187,9 @@ def main {
     // Note: structs can also have methods via [class_method] annotation
     // from daslib/class_boost. It adds an implicit 'self' parameter to
     // 'def static' functions, enabling obj.method() syntax on structs.
+    // Generic static methods (with `auto` parameters) are also supported —
+    // the macro rewrites the template once and every instantiation inherits
+    // the injected `self`. See tests/language/generic_class_method.das.
 }
 
 // output:


### PR DESCRIPTION
Fixes #2513.

## Summary

Generic static class methods annotated with `[class_method]` previously had their `apply()` silently skipped. The parser's class-method generic branch (`src/parser/parser_impl.cpp:801`) called `implAddGenericFunction` directly without `runFunctionAnnotations`, so `ClassMethodMacro.apply` — which injects `self` and wraps the body in `with(self) { ... }` — never ran. Generic class methods compiled with the struct's fields invisible to the body, manifesting as the errors reported in #2513:

```
error[30301]: casting to undefined type auto
error[30503]: field 'auto_test' not found in Test? -const
```

This PR adds an opt-in flag so annotations whose `apply()` is purely structural (no type information needed) can have it run on the generic template at parse time. Every later instantiation inherits the rewrite, and `generic_apply` (which runs at specialization time) stays for type-aware annotations.

### Changes

- **`FunctionAnnotation::isAppliedToGeneric()`** — new C++ virtual, defaults `false` ([ast.h:466](include/daScript/ast/ast.h)). Mirror in [daslib/ast.das](daslib/ast.das) (abstract method with `//!` doc-comment) and the C++ adapter ([module_builtin_ast_adapters.cpp](src/builtin/module_builtin_ast_adapters.cpp)). `ast_gen.inc` regenerated via `dasgen/gen_bind.das`.
- **Parser** — `runFunctionAnnotations` gets a `genericMode` parameter ([parser_impl.cpp:166](src/parser/parser_impl.cpp)). The class-method generic branch passes `genericMode=true` and filters to annotations where `isAppliedToGeneric()` returns true. All annotations still propagate to `func->annotations` for the later `generic_apply` pass at specialization time.
- **`daslib/class_boost.das`** — `ClassMethodMacro` opts in via `def override isAppliedToGeneric : bool { return true }`. `apply()` now also rejects `[class_method]` on non-static methods explicitly (previously silently double-injected `self` for instance methods).
- **Test** — [tests/language/generic_class_method.das](tests/language/generic_class_method.das): a struct with generic `def static put(v : auto)` / `add(v : auto)` exercising multiple instantiations on the same value. The reproduction from #2513 now compiles and runs.
- **Docs** — `doc/source/reference/language/macros.rst` adds `generic_apply` and `isAppliedToGeneric` to the `AstFunctionAnnotation` reference + prose paragraphs.

### Things to keep in mind

- **No double-rewrite.** `ClassMethodMacro` does not override `generic_apply`; it stays the default no-op. The transformation runs once on the template, the specialization clone inherits it, and `generic_apply` does nothing extra.
- **`isAppliedToGeneric` is appended at the end** of both `FunctionAnnotation` (C++) and `AstFunctionAnnotation` (daslang) to preserve existing field offsets in `ast_gen.inc` and AOT-cached `static_assert(offsetof(...))` checks. The new field is at offset 14 (was 13 = appendToMangledName).
- **Top-level generic functions are unaffected.** They already ran `runFunctionAnnotations` unconditionally via the bison-generated grammar — only the class-method path was inconsistent.
- **Existing `[class_method]` users** (`flat_hash_table`, `cuckoo_hash_table`, `stbimage_boost` — all `def static` only) are unchanged. The new static-only guard does not affect them.

## Test plan

- [x] Reproduction from #2513 now compiles and runs (verified with `examples/wip.das`)
- [x] Lint: `mcp__daslang__lint` — no issues on changed `.das` files
- [x] Format: all `.das` files already formatted
- [x] Interpreted suite: 7194 / 7200 passed (6 skipped, 0 failed, 0 errors)
- [x] AOT suite: 6596 / 6602 passed (6 skipped, 0 failed, 0 errors)
- [x] AOT cache offsets verified: `isSpecialized==96`, `appendToMangledName==104`, `isAppliedToGeneric==112`
- [x] Negative case: `[class_method]` on a non-static method now rejected with a clear error
- [x] Existing `[class_method]` users (`tests/hash_map/all_hash_table.das`) unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)