### PR TITLE
strudel: per-orbit chorus + per-event HRTF positioning

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -1434,7 +1434,7 @@ def document_module_strudel_synth(root : string) {
 def document_module_strudel_scheduler(root : string) {
     var mod = find_module("strudel_scheduler")
     var groups <- array<DocGroup>(
-        group_by_regex("Orbit effects", mod, %regex~(init_reverb|init_chorus|init_delay|get_orbit_reverb|get_orbit_delay)$%%),
+        group_by_regex("Orbit effects", mod, %regex~(init_reverb|init_delay|get_orbit_reverb|get_orbit_delay|get_orbit_chorus)$%%),
         group_by_regex("Scheduler lifecycle", mod, %regex~(tick|shutdown_scheduler)$%%)
     )
     document("Voice allocation, effect bus routing, and per-tick mixing", mod, "strudel_scheduler.rst", groups)
@@ -1510,6 +1510,7 @@ def document_module_strudel_pattern(root : string) {
         group_by_regex("Combinators", mod, %regex~(rev|jux|off|layer|superimpose|euclid|palindrome|ply|iter|iterBack|when_cycle|linger|hurry|compress|chunk|striate|struct_|mask|choose|wchoose|randcat|chooseCycles|shuffle|scramble|echo|stut|transpose|add|innerJoin|combineWith|combineWithStr|degrade|degradeBy|every|bjorklund|sometimes|often|sometimesby)$%%),
         group_by_regex("Setter primitives", mod, %regex~set_.*$%%),
         group_by_regex("Fluent control: dynamics and routing", mod, %regex~(gain|velocity|vel|pan|speed|note|sound|cut|orbit|begin|end_pos)$%%),
+        group_by_regex("Fluent control: 3D positioning (HRTF)", mod, %regex~(hrtf|hrtf_azimuth|hrtf_elevation)$%%),
         group_by_regex("Fluent control: effects sends", mod, %regex~(room|roomsize|size|delay|delaytime|dt|delayfeedback|dfb|delaysync|chorus)$%%),
         group_by_regex("Fluent control: filters", mod, %regex~(lpf|lp|hpf|hp|lpq|resonance|hpq|bpf|bpq|djf)$%%),
         group_by_regex("Fluent control: envelope", mod, %regex~(attack|att|decay|dec|sustain|sus|release|rel)$%%),

--- a/doc/source/reference/strudel_vs_strudel_cc.rst
+++ b/doc/source/reference/strudel_vs_strudel_cc.rst
@@ -220,13 +220,14 @@ Orbit bus model
 ---------------
 
 **Divergence:** daslang has an explicit ``OrbitBus`` per orbit
-number.  ``room`` sends to that orbit's reverb; ``delay`` to that
-orbit's delay; ``chorus`` is per-voice, **not** per-orbit.
-strudel.cc routes reverb/delay through SuperDirt differently.
+number.  ``room`` sends to that orbit's reverb, ``delay`` to that
+orbit's delay, and ``chorus`` to that orbit's chorus — each FX
+instance is allocated lazily on first send.  strudel.cc routes
+reverb/delay through SuperDirt differently.
 
 **How to apply:** if your strudel.cc pattern mixes two orbits to
 share a reverb, in daslang they need the same ``orbit`` number.
-If you want independent reverbs per voice, split orbits.
+If you want independent reverbs/choruses per voice, split orbits.
 
 Mini-notation parsing
 ---------------------
@@ -267,6 +268,59 @@ strudel.cc allocates voices dynamically per hap.
 **How to apply:** very dense polyphony may drop notes in daslang.
 Raise the pool size at ``Scheduler`` construction or thin the
 pattern.
+
+
+.. _strudel_cc_extensions:
+
+Extensions over strudel.cc
+==========================
+
+daslang adds a few primitives strudel.cc does not have.  These ride
+on top of the underlying ``audio_boost`` engine, so the existing
+strudel.cc syntax keeps working — the extensions only activate when
+you reach for them.
+
+HRTF positional override
+------------------------
+
+**Extension:** per-event ``hrtf_azimuth`` / ``hrtf_elevation`` (and
+the combined ``hrtf(az, el)``) replace the equal-power stereo
+``pan`` *render path* with a binaural-stereo HRTF: each input
+channel becomes a virtual source at azimuth -/+ 30° (the standard
+ITU listening triangle), each through its own ``ma_hrtf``
+instance, summed at the output.  Pan and HRTF become orthogonal —
+``pan`` shapes the inherent stereo width / image of the source,
+``hrtf`` positions the source in 3D.  Same CIPIC-based dataset
+``audio_boost`` uses; baked into the binary at compile time, no
+extra setup needed.
+
+**API:**
+
+.. code-block:: das
+
+   pat |> hrtf_azimuth(deg)        // numeric, -180..180
+   pat |> hrtf_elevation(deg)      // numeric, -90..90
+   pat |> hrtf(az, el)             // combined numeric
+
+   // pattern-valued (animated):
+   pat |> hrtf_azimuth(sine() |> range(-90.0, 90.0) |> slow(4.0lf))
+
+Setting any of the three flips the event's ``hrtf_active`` flag.
+The two HRTF outputs are summed and re-used for the
+reverb / delay / chorus sends, so the entire wet path follows the
+spatialised source (full physical accuracy) before being scaled
+into the orbit effect buses.
+
+**Cost:** each HRTF voice carries *two* ``ma_hrtf`` instances
+(one per input channel, both allocated lazily on first render).
+Practical for a handful of simultaneous voices; reach for plain
+``pan`` when you don't need externalisation, depth, or front/back
+disambiguation.
+
+**See also:**
+- Tutorial: :ref:`tutorial_dastrudel_hrtf_position`
+- Demo: ``examples/daStrudel/hrtf/``
+- Engine reference: :ref:`ma_hrtf <handle-audio-ma_hrtf>`
 
 
 .. _strudel_cc_naming:

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -377,6 +377,7 @@ For the strudel-to-strudel.cc feature comparison, see
    tutorials/daStrudel_13_sf2_soundfont.rst
    tutorials/daStrudel_14_midi_files.rst
    tutorials/daStrudel_15_live_reloading.rst
+   tutorials/daStrudel_16_hrtf_position.rst
 
 .. _tutorials_daspeg:
 

--- a/doc/source/reference/tutorials/daStrudel_13_sf2_soundfont.rst
+++ b/doc/source/reference/tutorials/daStrudel_13_sf2_soundfont.rst
@@ -107,9 +107,9 @@ layers at different expression levels to thicken the pad:
         note("<[g3,b3,d4] [a3,c4,e4]>") |> sf2("string_ensemble") |> sf2_expression(1.0) |> gain(0.5)
     ])
 
-SF2 playback in daStrudel is a daslang-only extension — there is no
-equivalent in strudel.cc.  See :ref:`strudel_vs_strudel_cc` for the full
-list of daslang-only features.
+SF2 playback in daStrudel is a daslang-only extension beyond the
+standard mini-notation.  See :ref:`mini-notation compatibility
+<strudel_vs_strudel_cc>` for the full list of daslang-only features.
 
 .. seealso::
 

--- a/doc/source/reference/tutorials/daStrudel_15_live_reloading.rst
+++ b/doc/source/reference/tutorials/daStrudel_15_live_reloading.rst
@@ -156,6 +156,8 @@ Workflow Tips
 
    Previous tutorial: :ref:`tutorial_dastrudel_midi_files`
 
-   Comparison with strudel.cc: :ref:`strudel_vs_strudel_cc`
+   Next tutorial: :ref:`tutorial_dastrudel_hrtf_position`
+
+   Mini-notation compatibility: :ref:`mini-notation compatibility <strudel_vs_strudel_cc>`
 
    Full daStrudel reference: :ref:`stdlib_strudel_section`

--- a/doc/source/reference/tutorials/daStrudel_16_hrtf_position.rst
+++ b/doc/source/reference/tutorials/daStrudel_16_hrtf_position.rst
@@ -1,0 +1,147 @@
+.. _tutorial_dastrudel_hrtf_position:
+
+====================================================
+STRUDEL-16 — HRTF: 3D Positional Override for Pan
+====================================================
+
+.. index::
+    single: Tutorial; Strudel; HRTF
+    single: Tutorial; Strudel; 3D positioning
+    single: Tutorial; Strudel; hrtf_azimuth
+    single: Tutorial; Strudel; hrtf_elevation
+
+daslang exposes a per-event HRTF position (azimuth, elevation) on
+top of the standard mini-notation.  When set, the equal-power
+stereo ``pan`` render is replaced by a **binaural-stereo HRTF**:
+the dry signal and the orbit-effect sends are run through the same
+CIPIC-based ``ma_hrtf`` engine that ``audio_boost`` uses for 3D
+sources.  Pan still shapes source width / L/R balance feeding the
+spatialiser; HRTF places the source in 3D.
+
+Why bother — equal-power ``pan`` only places sources on a horizontal
+stereo line between the speakers.  HRTF adds:
+
+- depth / externalisation (sources feel "outside the head" on
+  headphones),
+- front-back disambiguation (centre-front is no longer ambiguous with
+  centre-rear),
+- elevation cues.
+
+Cost — under the binaural-stereo render, each HRTF-positioned voice
+carries **two** ``ma_hrtf`` instances (``hrtf_l`` + ``hrtf_r``,
+lazy-allocated on first render: one per virtual-speaker channel at
+azimuth -/+ 30°).  Practical for 3-8 simultaneous HRTF voices on
+modern hardware.  Plain ``pan`` is far cheaper; reach for HRTF only
+when you want spatial cues plain pan can't provide.
+
+API
+===
+
+.. code-block:: das
+
+    pat |> hrtf_azimuth(deg)        // numeric or pattern-valued, -180..180
+    pat |> hrtf_elevation(deg)      // numeric or pattern-valued, -90..90
+    pat |> hrtf(az, el)             // combined numeric setter
+
+Setting any of the three flips the event's ``hrtf_active`` flag.
+**Pan and HRTF are orthogonal under the binaural-stereo render**:
+``pan`` controls the inherent stereo width / image of the source (it
+shapes the L/R balance of the input feeding the spatialiser), and
+``hrtf`` positions the resulting source in 3D.  Best heard on
+headphones.
+
+Part A: Static positions
+========================
+
+``hrtf(az, el)`` takes both axes at once.  ``0/0`` is directly ahead,
+``+90/0`` is right, ``-90/0`` is left, ``0/+45`` is up-front:
+
+.. code-block:: das
+
+    let pat <- stack([
+        note("c4", "sine") |> hrtf(0.0,    0.0) |> attack(0.01) |> release(0.5) |> gain(0.4),
+        note("e4", "sine") |> hrtf(-90.0,  0.0) |> attack(0.01) |> release(0.5) |> gain(0.4),
+        note("g4", "sine") |> hrtf(+90.0,  0.0) |> attack(0.01) |> release(0.5) |> gain(0.4),
+        note("c5", "sine") |> hrtf(0.0,   45.0) |> attack(0.01) |> release(0.5) |> gain(0.4)
+    ])
+
+Four notes from four directions: ahead, hard-left, hard-right,
+up-front.
+
+Part B: Animated azimuth
+========================
+
+The setters accept patterns.  Each event samples the modulation
+pattern at its onset to get its azimuth.  With
+``sine() |> range(-180, 180) |> slow(4)``, the source orbits the
+listener once every 8 cycles (on a 0.5 cps stream):
+
+.. code-block:: das
+
+    var pat <- (
+        note("c4 e4 g4 c5", "triangle")
+        |> hrtf_azimuth(sine() |> range(-180.0, 180.0) |> slow(4.0lf))
+        |> attack(0.005) |> release(0.3) |> gain(0.4)
+    )
+
+``hrtf_elevation`` works the same way; combine the two for full
+spherical motion.
+
+Part C: Pan and HRTF combine — HRTF positions, pan widens
+=========================================================
+
+The render branch is selected per voice.  When ``hrtf_active`` is
+true the equal-power L/R mixer is replaced by a binaural-stereo HRTF:
+the L and R input channels become virtual sources at azimuth - 30°
+and azimuth + 30°, each through its own HRTF instance, summed at the
+output.  The pre-pan stereo image (whatever ``pan`` produced) is
+preserved as source width; HRTF places the source in 3D.  The same
+binaural render is reused for the reverb / delay / chorus sends.
+
+.. code-block:: das
+
+    var pat <- stack([
+        note("c4", "sine") |> pan(0.5)                     |> gain(0.4),
+        note("e4", "sine") |> pan(0.5) |> hrtf(-90.0, 0.0) |> gain(0.4)
+    ])
+
+The second voice has both ``pan(0.5)`` and ``hrtf(-90, 0)``.  The
+voice is positioned to the left by HRTF; the slight L/R imbalance
+that ``pan(0.5)`` produced is preserved as source width inside that
+3D position (rather than being thrown away).
+
+Part D: Mixing HRTF and plain pan
+=================================
+
+HRTF is heavier than pan and works best on headphones.  For drum
+machines or beats where you just want left/right separation, plain
+``pan`` is cheaper and works fine on speakers.  Mix-and-match in the
+same stack: HRTF the lead voice, pan the rhythm section:
+
+.. code-block:: das
+
+    var pat <- stack([
+        s("bd ~ sd ~")                  |> orbit(0) |> gain(0.6),
+        s("hh*8")                       |> orbit(0) |> pan(0.7) |> gain(0.3),
+        note("c4 e4 g4 e4", "triangle") |> orbit(1)
+            |> hrtf_azimuth(sine() |> range(-60.0, 60.0) |> slow(2.0lf))
+            |> room(0.4) |> roomsize(2.0) |> gain(0.35)
+    ])
+
+Because the lead is on a separate orbit, its reverb stays distinct
+from the (dry) drum bus.  The reverb send for the lead voice is
+itself HRTF-positioned, so the room follows the source through space.
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_16_hrtf_position.das <../../../../tutorials/daStrudel/daStrudel_16_hrtf_position.das>`
+
+   Standalone examples: ``examples/daStrudel/features/hrtf_basic.das``,
+   ``examples/daStrudel/features/hrtf_animated.das``,
+   ``examples/daStrudel/features/hrtf_overrides_pan.das``
+
+   Previous tutorial: :ref:`tutorial_dastrudel_live_reloading`
+
+   Mini-notation compatibility: :ref:`mini-notation compatibility <strudel_vs_strudel_cc>`
+
+   Full daStrudel reference: :ref:`stdlib_strudel_section`

--- a/doc/source/stdlib/sec_strudel.rst
+++ b/doc/source/stdlib/sec_strudel.rst
@@ -8,7 +8,7 @@ Pattern-based live-coding music library: cycle-space time, mini-notation DSL,
 pattern algebra and combinators, synthesis, samples, SF2 soundfonts, MIDI
 playback, per-voice effect chains, and a threaded playback harness.
 
-See also :ref:`tutorials_dastrudel` and :ref:`strudel_vs_strudel_cc`.
+See also :ref:`tutorials_dastrudel` and :ref:`mini-notation compatibility <strudel_vs_strudel_cc>`.
 
 .. toctree::
 

--- a/examples/daStrudel/README.md
+++ b/examples/daStrudel/README.md
@@ -1,0 +1,55 @@
+# daStrudel examples
+
+Audio examples and live-coding demos built on the daslang
+[strudel module](../../modules/dasAudio/strudel/). All examples compile
+under interpreter, AOT, and JIT.
+
+## Layout
+
+| Directory | Purpose |
+|---|---|
+| [features/](features/) | ~100 short, single-feature snippets — one combinator or effect per file. Built around [`feature_common`](features/feature_common.das); render to WAV with `--wav PATH` for offline inspection. |
+| [hrtf/](hrtf/) | 3D positional ("bumblebee") demo using the per-event HRTF override (azimuth + elevation). Three sources rendered simultaneously: one orbiting source plus two stationary positions. |
+| [drum_compare/](drum_compare/) | A/B drum kit comparison (built-in synth vs sample bank). |
+| [synth_demo/](synth_demo/) | 100% synthesised mini-track (no sample files). |
+| [piano_demo/](piano_demo/) | Piano patterns over the SF2 synth. |
+| [sf2_demo/](sf2_demo/) | SoundFont rendering with bank/program selection. |
+| [midi_demo/](midi_demo/) | MIDI file playback through the strudel scheduler. |
+| [midi_sf2_demo/](midi_sf2_demo/) | MIDI files + SF2 rendering. See its own [README](midi_sf2_demo/README.md). |
+| [player_demo/](player_demo/) | Foundational `strudel_player` API usage. |
+| [strudel_live/](strudel_live/) | Live-coding harness with `daslang-live` hot-reload. |
+| [strudel_sf2_live/](strudel_sf2_live/) | Live-coding with SF2 synthesis. |
+| [strudel_visualizer/](strudel_visualizer/) | Pattern + scope visualiser. |
+
+## Running
+
+```sh
+# Interpreter (fastest iteration)
+bin/daslang examples/daStrudel/synth_demo/main.das
+
+# AOT (production performance)
+test_aot examples/daStrudel/synth_demo/main.das -- --use-aot
+
+# JIT (hybrid; falls back to interpreter for changed functions)
+bin/daslang examples/daStrudel/synth_demo/main.das -jit
+```
+
+### Feature snippets
+
+Each `features/*.das` file uses `play_feature_cps` from `feature_common.das`
+and supports three flags:
+
+```sh
+bin/daslang examples/daStrudel/features/orbit_chorus_only.das               # play 10s
+bin/daslang examples/daStrudel/features/orbit_chorus_only.das --duration 4  # play N seconds
+bin/daslang examples/daStrudel/features/orbit_chorus_only.das --wav out.wav # render offline
+bin/daslang examples/daStrudel/features/orbit_chorus_only.das --track-memory
+```
+
+## See also
+
+- Module reference: [doc/source/stdlib/sec_strudel.rst](../../doc/source/stdlib/sec_strudel.rst)
+- Tutorials: [tutorials/daStrudel/](../../tutorials/daStrudel/)
+- Mini-notation compatibility & daslang extensions (HRTF, etc.):
+  [doc/source/reference/strudel_vs_strudel_cc.rst](../../doc/source/reference/strudel_vs_strudel_cc.rst)
+- Porting notes: [skills/strudel_port.md](../../skills/strudel_port.md)

--- a/examples/daStrudel/features/chorus_basic.das
+++ b/examples/daStrudel/features/chorus_basic.das
@@ -4,7 +4,7 @@ options persistent_heap
 
 // Sawtooth chord with chorus effect — warm detuned pad with gentle stereo widening.
 // Hear: rich sawtooth chords shimmer and spread as chorus adds subtle detuning.
-// Note: chorus here is a per-voice effect send (not pattern audio chopping).
+// Note: chorus is a per-orbit effect send (independent per orbit, like reverb / delay).
 
 require feature_common
 

--- a/examples/daStrudel/features/hrtf_animated.das
+++ b/examples/daStrudel/features/hrtf_animated.das
@@ -1,0 +1,25 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Animated HRTF azimuth — pluck sweeps left-to-right via 3D positioning.
+// Pattern-valued setter: each event samples the sine signal for its azimuth in degrees.
+// Hear: the source orbits the listener, with HRTF cues (not just panning) doing the work.
+/*
+note("c4 e4 g4 c5").s("triangle").hrtf_azimuth(sine.range(-90, 90).slow(2)).hrtf_elevation(0)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- (
+        note("c4 e4 g4 c5", "triangle")
+        |> hrtf_azimuth(sine() |> range(-90.0, 90.0) |> slow(2.0lf))
+        |> hrtf_elevation(0.0)
+        |> attack(0.005)
+        |> release(0.25)
+        |> gain(0.5)
+    )
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/hrtf_basic.das
+++ b/examples/daStrudel/features/hrtf_basic.das
@@ -1,0 +1,15 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Static HRTF position — sawtooth pulse positioned 45° to the right of the listener.
+// Hear: a clear "off to the right" feeling that plain pan can't reproduce; HRTF adds
+// front/back disambiguation and a sense of depth that changes with elevation.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- note("c4 ~ e4 ~ g4 ~ c5 ~", "sawtooth") |> hrtf(45.0, 0.0) |> attack(0.005) |> release(0.2) |> gain(0.5)
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/hrtf_overrides_pan.das
+++ b/examples/daStrudel/features/hrtf_overrides_pan.das
@@ -1,0 +1,22 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// HRTF positions; pan widens — pan and HRTF combine, they don't fight.
+// Two layers: identical sine notes, both with pan(0.5).
+//   Layer 0: pan only — equal-power stereo, source feels "centred-ish" but flat.
+//   Layer 1: pan(0.5) plus hrtf(-90, 0) — HRTF places the source far-left in 3D;
+//            the pre-pan L/R imbalance is preserved as source width.
+// Hear: only layer 1 has the externalised left-side feeling; pan(0.5) tilts the
+// width but does not move it from the HRTF-set position.
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- stack([
+        note("c4", "sine") |> pan(0.5)                       |> attack(0.01) |> release(0.4) |> gain(0.4),
+        note("e4", "sine") |> pan(0.5) |> hrtf(-90.0, 0.0)   |> attack(0.01) |> release(0.4) |> gain(0.4)
+    ])
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/features/orbit_chorus_only.das
+++ b/examples/daStrudel/features/orbit_chorus_only.das
@@ -1,0 +1,25 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Two orbits, only one with chorus — proves chorus is per-orbit (not shared across orbits).
+// Orbit 0: sawtooth chord with chorus shimmer.
+// Orbit 1: same chord shape on triangle, dry (no chorus).
+// Hear: orbit 0 detunes/widens; orbit 1 stays clean even though both play simultaneously.
+/*
+stack(
+  note("<[c3,e3,g3] [f3,a3,c4]>").s("sawtooth").chorus(0.7).orbit(0),
+  note("<[c4,e4,g4] [f4,a4,c5]>").s("triangle").orbit(1)
+).cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- stack([
+        note("<[c3,e3,g3] [f3,a3,c4]>", "sawtooth") |> chorus(0.7) |> orbit(0) |> attack(0.05) |> release(0.3) |> gain(0.4),
+        note("<[c4,e4,g4] [f4,a4,c5]>", "triangle") |> orbit(1) |> attack(0.05) |> release(0.3) |> gain(0.4)
+    ])
+    play_feature_cps(pat, 0.5lf)
+}

--- a/examples/daStrudel/hrtf/main.das
+++ b/examples/daStrudel/hrtf/main.das
@@ -1,0 +1,76 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// daStrudel HRTF demo — three sources rendered together, ambient flavour.
+//
+//   Source A (orbit 0) — "the bumblebee": a fast chromatic 16th-note line on
+//     sawtooth, HRTF azimuth following sine(-180..180) over 4s, elevation
+//     gently rising/falling on cos(-30..30). Sounds like the source is
+//     circling the listener while moving up and down.
+//   Source B (orbit 1) — "left pad": sustained triangle pad fixed at HRTF
+//     azimuth = -90, elevation = 0 (full left).
+//   Source C (orbit 1) — "right-front pluck": arpeggiated sine pluck fixed
+//     at azimuth = +30, elevation = 0 (right-front).
+//
+// Orbit 0 (bumblebee) has a long, lush reverb. Orbit 1 (the steady sources)
+// shares a smaller, drier reverb. Demonstrates per-orbit reverb still works
+// alongside HRTF positioning.
+
+require strudel/strudel
+require strudel/strudel_player
+require audio/audio_boost
+require daslib/fio
+
+def strudel_main() {
+    strudel_set_bpm(140.0lf)
+    // Source A — bumblebee: rapid chromatic line, animated HRTF position
+    var bumblebee <- (
+        note("c5 c#5 d5 d#5 e5 f5 f#5 g5 g#5 a5 a#5 b5 b5 a#5 a5 g#5 g5 f#5 f5 e5 d#5 d5 c#5 c5", "sawtooth")
+        |> hrtf_azimuth(sine() |> range(-180.0, 180.0) |> slow(4.0lf))
+        |> hrtf_elevation(cosine() |> range(-30.0, 30.0) |> slow(3.0lf))
+        |> orbit(0)
+        |> attack(0.005)
+        |> release(0.05)
+        |> room(0.6)
+        |> roomsize(6.0)
+        |> gain(0.45)
+    )
+    // Source B — left pad
+    var left_pad <- (
+        note("<c3 g2>", "triangle")
+        |> hrtf(-90.0, 0.0)
+        |> orbit(1)
+        |> attack(0.4)
+        |> release(0.6)
+        |> sustain(0.6)
+        |> room(0.4)
+        |> roomsize(2.0)
+        |> gain(0.3)
+    )
+    // Source C — right-front pluck
+    var right_pluck <- (
+        note("c4 e4 g4 e4", "sine")
+        |> hrtf(30.0, 0.0)
+        |> orbit(1)
+        |> attack(0.005)
+        |> release(0.25)
+        |> room(0.4)
+        |> roomsize(2.0)
+        |> gain(0.35)
+    )
+    strudel_add_track(stack([bumblebee, left_pad, right_pluck]))
+    strudel_play()
+}
+
+[export]
+def main() {
+    print("daStrudel HRTF demo — bumblebee circling + left pad + right-front pluck\n")
+    with_audio_system() {
+        strudel_init(@@strudel_main)
+        print("playing 30 seconds...\n")
+        sleep(30000u)
+        strudel_shutdown()
+    }
+    print("done\n")
+}

--- a/modules/dasAudio/strudel/strudel_event.das
+++ b/modules/dasAudio/strudel/strudel_event.das
@@ -108,6 +108,15 @@ struct Event {
         //! Compressor attack time in seconds.
     compressor_release : float = 0.05   // release time seconds
         //! Compressor release time in seconds.
+    // HRTF positional override — when active, the equal-power stereo pan render is replaced by a
+    // binaural-stereo HRTF (two ma_hrtf instances per voice; pan still controls source width).
+    // Shares the ma_hrtf engine used by audio_boost; CIPIC dataset is baked in at compile time.
+    hrtf_active    : bool = false   // explicit "is HRTF position set?" flag (azimuth=0 alone is ambiguous — means "in front")
+        //! True when HRTF positioning is active for this event; setters flip this on.
+    hrtf_azimuth   : float = 0.0    // azimuth in degrees: -180..180 (0 = directly ahead, +90 = right, -90 = left)
+        //! HRTF azimuth in degrees (-180..180; 0 = ahead, +90 = right, -90 = left). Ignored unless `hrtf_active`.
+    hrtf_elevation : float = 0.0    // elevation in degrees: -90..90 (0 = horizontal plane)
+        //! HRTF elevation in degrees (-90..90; 0 = horizontal). Ignored unless `hrtf_active`.
     // SF2 SoundFont
     sf2_program    : int = -1   // SF2 GM program number (-1 = not SF2, use sample/oscillator)
         //! SF2 GM program number (-1 = not SF2; use sample/oscillator instead).
@@ -121,7 +130,7 @@ struct Event {
         //! SF2 pitch bend 0.0–1.0 (0.5 = center, -1 = use default).
 }
 
-// Resolve ADSR fields from their "user set / unset" form (−1 = unset) into concrete
+// Resolve ADSR fields from their "user set / unset" form (-1 = unset) into concrete
 // envelope parameters. The rules are designed so that intuitive shorthand sounds right:
 //
 //   • Nothing set           → a=0.001, d=0.001, s=1.0, r=0.01 (a held tone with tiny envelope edges)

--- a/modules/dasAudio/strudel/strudel_pattern.das
+++ b/modules/dasAudio/strudel/strudel_pattern.das
@@ -336,6 +336,40 @@ def set_pan(var pat : Pattern; p : float) : Pattern {
     return <- fmap(pat, fn)
 }
 
+// pat |> set_hrtf_azimuth(-45.0) — set 3D HRTF azimuth (degrees, -180..180); pan still controls source width.
+def set_hrtf_azimuth(var pat : Pattern; deg : float) : Pattern {
+    //! Sets the HRTF azimuth (degrees, -180..180) on every event in `pat` and engages HRTF positioning.
+    //! 0 = directly ahead, +90 = right, -90 = left. Under the binaural-stereo HRTF render `pan` still
+    //! controls source width / L/R balance feeding the spatialiser; HRTF controls 3D position.
+    let fn <- @capture(= deg) (e : Event) : Event {
+        var r = e; r.hrtf_azimuth = deg; r.hrtf_active = true; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+// pat |> set_hrtf_elevation(15.0) — set 3D HRTF elevation (degrees, -90..90); pan still controls source width.
+def set_hrtf_elevation(var pat : Pattern; deg : float) : Pattern {
+    //! Sets the HRTF elevation (degrees, -90..90) on every event in `pat` and engages HRTF positioning.
+    //! 0 = horizontal plane, positive = up. Under the binaural-stereo HRTF render `pan` still controls
+    //! source width / L/R balance feeding the spatialiser; HRTF controls 3D position.
+    let fn <- @capture(= deg) (e : Event) : Event {
+        var r = e; r.hrtf_elevation = deg; r.hrtf_active = true; return r
+    }
+    return <- fmap(pat, fn)
+}
+
+// pat |> set_hrtf(-45.0, 0.0) — set both HRTF azimuth and elevation in one call; pan still controls source width.
+def set_hrtf(var pat : Pattern; az, el : float) : Pattern {
+    //! Sets HRTF azimuth and elevation in one call and engages HRTF positioning.
+    //! Azimuth (-180..180): 0 = ahead, +90 = right, -90 = left. Elevation (-90..90): 0 = horizontal.
+    //! Under the binaural-stereo HRTF render `pan` still controls source width / L/R balance feeding
+    //! the spatialiser; HRTF controls 3D position.
+    let fn <- @capture(= az, = el) (e : Event) : Event {
+        var r = e; r.hrtf_azimuth = az; r.hrtf_elevation = el; r.hrtf_active = true; return r
+    }
+    return <- fmap(pat, fn)
+}
+
 // pat |> set_speed(2.0) — set sample playback speed
 def private set_speed(var pat : Pattern; spd : float) : Pattern {
     let fn <- @capture(= spd) (e : Event) : Event {
@@ -869,7 +903,7 @@ def jux(var pat : Pattern; transform : PatternTransform) : Pattern {
     var transformed <- invoke(transform, pat) // nolint:LINT003
     var left <- pat |> set_pan(0.0)
     var right <- transformed |> set_pan(1.0)
-    var layers : array<Pattern>
+    var layers : array<Pattern> // nolint:STYLE012
     layers |> emplace <| left
     layers |> emplace <| right
     return <- stack(layers)
@@ -880,7 +914,7 @@ def jux(var pat : Pattern; transform : PatternTransform) : Pattern {
 def off(var pat : Pattern; time : double; transform : PatternTransform) : Pattern {
     //! Overlays `pat` with a time-shifted copy transformed by `transform`. Example: `s("bd sd") |> off(0.125, @@(x) => transpose(x, 7.0))` — canon at the fifth.
     var shifted <- invoke(transform, pat) |> late(time)
-    var layers : array<Pattern>
+    var layers : array<Pattern> // nolint:STYLE012
     layers |> emplace <| pat
     layers |> emplace <| shifted
     return <- stack(layers)
@@ -930,7 +964,7 @@ def sometimesby(var pat : Pattern; prob : float; transform : PatternTransform) :
     var degraded <- degrade_keep(pat, prob)
     var undegraded <- degrade_drop(pat, prob) // nolint:LINT003
     var transformed <- invoke(transform, undegraded) // nolint:LINT003
-    var layers : array<Pattern>
+    var layers : array<Pattern> // nolint:STYLE012
     layers |> emplace <| degraded
     layers |> emplace <| transformed
     return <- stack(layers)
@@ -1220,6 +1254,22 @@ def set_pan(var pat : Pattern; var mod_pat : Pattern) : Pattern {
     //! Pattern-valued `set_pan` — samples `mod_pat` at each event onset to set `pan`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.pan = val; return r
+    })
+}
+
+def set_hrtf_azimuth(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_hrtf_azimuth` — samples `mod_pat` at each event onset to set the HRTF azimuth (degrees, -180..180).
+    //! Engages HRTF positioning on every event; `pan` still controls source width / L/R balance feeding the spatialiser.
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.hrtf_azimuth = val; r.hrtf_active = true; return r
+    })
+}
+
+def set_hrtf_elevation(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_hrtf_elevation` — samples `mod_pat` at each event onset to set the HRTF elevation (degrees, -90..90).
+    //! Engages HRTF positioning on every event; `pan` still controls source width / L/R balance feeding the spatialiser.
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.hrtf_elevation = val; r.hrtf_active = true; return r
     })
 }
 
@@ -1634,7 +1684,7 @@ def palindrome(var pat : Pattern) : Pattern {
 def superimpose(var pat : Pattern; transform : PatternTransform) : Pattern {
     //! Stacks `pat` with `transform(pat)`, both playing simultaneously. Example: `pat |> superimpose(@@(x) => fast(x, 2.0lf))`.
     var transformed <- invoke(transform, pat)
-    var layers : array<Pattern>
+    var layers : array<Pattern> // nolint:STYLE012
     layers |> emplace <| pat
     layers |> emplace <| transformed
     return <- stack(layers)
@@ -2359,6 +2409,19 @@ def pan(var pat : Pattern; p : float) : Pattern {
     //! Fluent shorthand for `set_pan`. Sets stereo position (0=L, 0.5=C, 1=R).
     return <- set_pan(pat, p)
 }
+def hrtf_azimuth(var pat : Pattern; deg : float) : Pattern {
+    //! Fluent shorthand for `set_hrtf_azimuth`. Engages HRTF positioning; `pan` still controls source width.
+    return <- set_hrtf_azimuth(pat, deg)
+}
+def hrtf_elevation(var pat : Pattern; deg : float) : Pattern {
+    //! Fluent shorthand for `set_hrtf_elevation`. Engages HRTF positioning; `pan` still controls source width.
+    return <- set_hrtf_elevation(pat, deg)
+}
+def hrtf(var pat : Pattern; az, el : float) : Pattern {
+    //! Fluent shorthand for `set_hrtf` — sets HRTF azimuth + elevation and engages 3D positioning;
+    //! `pan` still controls source width.
+    return <- set_hrtf(pat, az, el)
+}
 def speed(var pat : Pattern; spd : float) : Pattern {
     //! Fluent shorthand for `set_speed`. Sets sample playback speed.
     return <- set_speed(pat, spd)
@@ -2657,6 +2720,14 @@ def vel(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 def pan(var pat : Pattern; var mod_pat : Pattern) : Pattern {
     //! Pattern-modulated `pan` — sampled from `mod_pat` per event.
     return <- set_pan(pat, mod_pat)
+}
+def hrtf_azimuth(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated HRTF azimuth — sampled from `mod_pat` per event. Engages HRTF positioning.
+    return <- set_hrtf_azimuth(pat, mod_pat)
+}
+def hrtf_elevation(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated HRTF elevation — sampled from `mod_pat` per event. Engages HRTF positioning.
+    return <- set_hrtf_elevation(pat, mod_pat)
 }
 def speed(var pat : Pattern; var mod_pat : Pattern) : Pattern {
     //! Pattern-modulated `speed` — sampled from `mod_pat` per event.

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -295,7 +295,6 @@ def public strudel_add_track(var pat : Pattern; gain : float = 1.0) : int {
     track.sched.cps = g_cps
     track.sched.lastQueryEnd = g_wall_time * g_cps
     track.sched.sf2 = g_sf2 != null ? unsafe(reinterpret<SF2File const?>(g_sf2)) : null
-    init_chorus(track.sched)
     if (g_sf2 != null) {
         init_reverb(track.sched)
     }

--- a/modules/dasAudio/strudel/strudel_scheduler.das
+++ b/modules/dasAudio/strudel/strudel_scheduler.das
@@ -4,7 +4,7 @@ options indenting = 4
 module strudel_scheduler shared public
 //! Voice allocation, effect bus routing, and per-tick mixing for strudel playback.
 //! Maintains pre-rendered sample voices, streaming oscillator voices, and real-time SF2 voices,
-//! routing each through per-orbit reverb/delay buses plus a shared chorus bus.
+//! routing each through per-orbit reverb/delay/chorus buses (one independent FX chain per orbit).
 
 require strudel/strudel_event
 require strudel/strudel_time
@@ -37,6 +37,16 @@ struct Voice {
         //! Delay send amount (0.0–1.0) from Event.delay_amount.
     orbit : int = 0            // effect bus routing
         //! Orbit index — selects which per-orbit effect bus receives this voice's sends.
+    hrtf_active    : bool  = false   // HRTF positional override
+        //! True when this voice uses HRTF positioning instead of equal-power stereo pan.
+    hrtf_azimuth   : float = 0.0
+        //! HRTF azimuth in degrees (-180..180; 0 = ahead).
+    hrtf_elevation : float = 0.0
+        //! HRTF elevation in degrees (-90..90; 0 = horizontal).
+    hrtf_l         : ma_hrtf?
+        //! HRTF state for the left input channel (virtual source at azimuth - 30°); allocated lazily.
+    hrtf_r         : ma_hrtf?
+        //! HRTF state for the right input channel (virtual source at azimuth + 30°); allocated lazily.
 }
 
 //! Per-voice metadata for SF2 voices (companion to the C ma_sf2_voice struct).
@@ -66,16 +76,29 @@ struct StrudelSF2Meta {
         //! Per-voice audio effects (crush/shape/filter/etc.), applied post-render.
     pan              : float = 0.0   // stereo pan (-1..1) used when fx routes through temp buffer
         //! Stereo pan (-1..1), used when FX routing goes through a temp buffer.
+    hrtf_active      : bool  = false // HRTF positional override
+        //! True when this SF2 voice uses HRTF positioning. Pan still controls stereo width / image.
+    hrtf_azimuth     : float = 0.0
+        //! HRTF azimuth in degrees (-180..180; 0 = ahead).
+    hrtf_elevation   : float = 0.0
+        //! HRTF elevation in degrees (-90..90; 0 = horizontal).
+    hrtf_l           : ma_hrtf?
+        //! HRTF state for the left input channel (virtual source at azimuth - 30°); allocated lazily.
+    hrtf_r           : ma_hrtf?
+        //! HRTF state for the right input channel (virtual source at azimuth + 30°); allocated lazily.
 }
 
-//! Per-orbit effect bus. Each orbit has independent reverb + delay instances.
-//! Orbits are created on demand when a voice with that orbit index is spawned.
+//! Per-orbit effect bus. Each orbit has independent reverb + delay + chorus instances.
+//! Orbits are created on demand when a voice with that orbit index is spawned;
+//! each FX instance within the bus is allocated lazily on first send.
 [safe_when_uninitialized]
 struct OrbitBus {
     reverb            : ConvolutionReverb?
         //! Convolution reverb instance (null until a voice requests reverb).
     delay_proc        : ma_delay?
         //! Stereo delay instance (null until a voice requests delay).
+    chorus            : ma_chorus?
+        //! Chorus instance (null until a voice requests chorus).
     reverb_send_buf   : array<float>
         //! Scratch buffer accumulating reverb sends from all voices routed to this orbit.
     reverb_out_buf    : array<float>
@@ -84,6 +107,10 @@ struct OrbitBus {
         //! Scratch buffer accumulating delay sends from all voices routed to this orbit.
     delay_out_buf     : array<float>
         //! Scratch buffer receiving the delay's wet output for mixing into the master.
+    chorus_send_buf   : array<float>
+        //! Scratch buffer accumulating chorus sends from all voices routed to this orbit.
+    chorus_out_buf    : array<float>
+        //! Scratch buffer receiving the chorus's wet output for mixing into the master.
     current_roomsize      : float = -1.0
         //! Most recently applied reverb roomsize (-1 = uninitialized).
     current_delaytime     : float = -1.0
@@ -94,7 +121,7 @@ struct OrbitBus {
 
 //! Bridges the pattern engine and audio output.
 //! Maintains three voice pools (pre-rendered samples, streaming oscillators, real-time SF2)
-//! and routes each voice's sends through per-orbit effect buses plus a shared chorus.
+//! and routes each voice's sends through per-orbit effect buses (independent reverb / delay / chorus per orbit).
 [safe_when_uninitialized]
 struct Scheduler {
     cps          : double = 0.5lf   // cycles per second (0.5 = 120 BPM at 4 beats/cycle)
@@ -123,16 +150,18 @@ struct Scheduler {
     // Per-orbit effect buses (created on demand)
     orbit_buses   : array<OrbitBus?>
         //! Per-orbit effect buses, indexed by orbit number and allocated on demand.
-    // Chorus (SF2-only, not orbit-routed)
-    chorus          : ma_chorus?
-        //! Shared chorus unit (null until any voice requests chorus).
-    chorus_send_buf : array<float>
-        //! Chorus send accumulation buffer shared across orbits.
-    chorus_out_buf  : array<float>
-        //! Chorus wet-output buffer mixed into the master.
     // Shared scratch buffer for per-voice FX processing (sized per-tick)
     voice_fx_buf    : array<float>
         //! Scratch buffer for per-voice FX processing, sized on demand each tick.
+    // Shared HRTF scratch buffers, sized per-tick when any HRTF voice is active.
+    // Stereo input is split L/R; each channel runs through its own HRTF instance and the two
+    // stereo outputs are summed to produce a binaural-stereo virtual-speaker render.
+    hrtf_mono_buf      : array<float>
+        //! Mono input scratch for HRTF processing; one element per frame.
+    hrtf_stereo_buf    : array<float>
+        //! Stereo output scratch (left-channel HRTF result); interleaved L/R per frame.
+    hrtf_stereo_buf_r  : array<float>
+        //! Stereo output scratch (right-channel HRTF result); interleaved L/R per frame.
 }
 
 // Convert wall-clock time to cycle position.
@@ -204,13 +233,13 @@ def init_reverb(var sched : Scheduler) {
     init_orbit_reverb(*sched.orbit_buses[0])
 }
 
-def init_chorus(var sched : Scheduler) {
-    //! Initialize the scheduler's shared chorus unit with default parameters (no-op if already initialized).
-    if (sched.chorus == null) {
-        sched.chorus = new ma_chorus
-        chorus_init(sched.chorus, float(SAMPLE_RATE))
+// Initialize chorus on an orbit bus (no-op if already initialized).
+def private init_orbit_chorus(var bus : OrbitBus) {
+    if (bus.chorus == null) {
+        bus.chorus = new ma_chorus
+        chorus_init(bus.chorus, float(SAMPLE_RATE))
         let cfg = chorus_config_default()
-        chorus_set_config(sched.chorus, cfg)
+        chorus_set_config(bus.chorus, cfg)
     }
 }
 
@@ -240,7 +269,7 @@ def private setup_orbit_for_event(var sched : Scheduler; event : Event) {
         }
     }
     if (event.chorus > 0.0) {
-        init_chorus(sched)
+        init_orbit_chorus(*bus)
     }
 }
 
@@ -299,6 +328,9 @@ def private sf2_spawn_voices(var sched : Scheduler; event : Event; durSec : floa
             }
             let rsend = sf2_get_reverb_send(*sched.sf2, z.x, z.y, pzone, preset.global_zone)
             let csend = max(sf2_get_chorus_send(*sched.sf2, z.x, z.y, pzone, preset.global_zone), event.chorus)
+            if (csend > 0.0 && sched.orbit_buses[event.orbit].chorus == null) {
+                init_orbit_chorus(*sched.orbit_buses[event.orbit])
+            }
             sched.sf2_voices |> push(voice)
             var meta = StrudelSF2Meta(
                 note = note,
@@ -310,7 +342,10 @@ def private sf2_spawn_voices(var sched : Scheduler; event : Event; durSec : floa
                 cut = cutGroup,
                 gain = eventGain,
                 orbit = event.orbit,
-                pan = event.pan * 2.0 - 1.0
+                pan = event.pan * 2.0 - 1.0,
+                hrtf_active = event.hrtf_active,
+                hrtf_azimuth = event.hrtf_azimuth,
+                hrtf_elevation = event.hrtf_elevation
             )
             fx_init_from_event(meta.fx, event, float(SAMPLE_RATE))
             sched.sf2_meta |> push(meta)
@@ -336,10 +371,140 @@ def private get_orbit_delay_send(var sched : Scheduler; orbit : int) : array<flo
     return null
 }
 
+// Get the chorus send buffer for a given orbit. Returns null if no chorus on that orbit.
+def private get_orbit_chorus_send(var sched : Scheduler; orbit : int) : array<float>? {
+    if (orbit < length(sched.orbit_buses) && sched.orbit_buses[orbit] != null && sched.orbit_buses[orbit].chorus != null) {
+        return unsafe(addr(sched.orbit_buses[orbit].chorus_send_buf))
+    }
+    return null
+}
+
+// Ensure the scheduler-level HRTF mono / stereo scratch buffers are sized for a tick of the given length.
+def private prepare_hrtf_scratch(var sched : Scheduler; chunkFrames : int) {
+    let chunkSamples_ = chunkFrames * 2
+    if (length(sched.hrtf_mono_buf) < chunkFrames) {
+        sched.hrtf_mono_buf |> resize(chunkFrames)
+    }
+    if (length(sched.hrtf_stereo_buf) < chunkSamples_) {
+        sched.hrtf_stereo_buf |> resize(chunkSamples_)
+    }
+    if (length(sched.hrtf_stereo_buf_r) < chunkSamples_) {
+        sched.hrtf_stereo_buf_r |> resize(chunkSamples_)
+    }
+}
+
+// Render a stereo voice contribution through the binaural-stereo HRTF.
+// Treats the L input channel as a virtual source at (azimuth - 30°) and the R input channel
+// as a virtual source at (azimuth + 30°), runs each through its own HRTF instance, and sums
+// the two stereo outputs into `sched.hrtf_stereo_buf`. This makes pan and HRTF orthogonal:
+// pan controls the inherent stereo width / image of the source, HRTF positions it in 3D.
+// Lazily creates both HRTF instances on first use.
+def private hrtf_render_voice(
+                              var sched : Scheduler;
+                              var voice_hrtf_l : ma_hrtf?&;// L-channel HRTF — virtual source at az - 30°
+                              var voice_hrtf_r : ma_hrtf?&;// R-channel HRTF — virtual source at az + 30°
+                              azimuth, elevation : float;
+                              var stereo_in : array<float>;
+                              src_start : int;// source offset (interleaved sample index)
+                              voice_gain : float;
+                              chunkFrames : int
+                              ) {
+    if (voice_hrtf_l == null) {
+        voice_hrtf_l = new ma_hrtf
+        ma_hrtf_init(voice_hrtf_l, uint(SAMPLE_RATE))
+    }
+    if (voice_hrtf_r == null) {
+        voice_hrtf_r = new ma_hrtf
+        ma_hrtf_init(voice_hrtf_r, uint(SAMPLE_RATE))
+    }
+    let chunkSamples = chunkFrames * 2
+    let limit = min(chunkSamples, length(stereo_in) - src_start)
+    let nf = max(0, limit / 2)
+    // L channel at (azimuth - 30°): build mono L into hrtf_mono_buf, process into hrtf_stereo_buf.
+    ma_hrtf_set_direction(voice_hrtf_l, int(azimuth - 30.0), int(elevation))
+    for (f in range(nf)) {
+        let si = src_start + f * 2
+        sched.hrtf_mono_buf[f] = stereo_in[si] * voice_gain
+    }
+    for (f in range(nf, chunkFrames)) {
+        sched.hrtf_mono_buf[f] = 0.0
+    }
+    unsafe {
+        ma_hrtf_process_frames(addr(*voice_hrtf_l),
+            addr(sched.hrtf_stereo_buf[0]),
+            addr(sched.hrtf_mono_buf[0]),
+            1u,
+            uint(chunkFrames))
+    }
+    // R channel at (azimuth + 30°): build mono R into hrtf_mono_buf, process into hrtf_stereo_buf_r.
+    ma_hrtf_set_direction(voice_hrtf_r, int(azimuth + 30.0), int(elevation))
+    for (f in range(nf)) {
+        let si = src_start + f * 2
+        sched.hrtf_mono_buf[f] = stereo_in[si + 1] * voice_gain
+    }
+    for (f in range(nf, chunkFrames)) {
+        sched.hrtf_mono_buf[f] = 0.0
+    }
+    unsafe {
+        ma_hrtf_process_frames(addr(*voice_hrtf_r),
+            addr(sched.hrtf_stereo_buf_r[0]),
+            addr(sched.hrtf_mono_buf[0]),
+            1u,
+            uint(chunkFrames))
+    }
+    // Sum the right-channel HRTF output into hrtf_stereo_buf so the caller sees one combined buffer.
+    for (s in range(chunkSamples)) {
+        sched.hrtf_stereo_buf[s] += sched.hrtf_stereo_buf_r[s]
+    }
+}
+
+// Dispatch an osc voice to osc_render_chunk, picking each per-orbit send buffer when present
+// and falling back to a caller-provided empty array otherwise (osc_render_chunk bounds-checks each).
+def private osc_render_chunk_routed(
+                                    var voice : OscVoice;
+                                    var output : array<float>;
+                                    var reverb_buf : array<float>?;
+                                    var delay_buf : array<float>?;
+                                    var chorus_buf : array<float>?;
+                                    var empty_r : array<float>;
+                                    var empty_d : array<float>;
+                                    var empty_c : array<float>;
+                                    chunkFrames : int
+                                    ) {
+    if (reverb_buf != null) {
+        if (delay_buf != null) {
+            if (chorus_buf != null) {
+                osc_render_chunk(voice, output, *reverb_buf, *delay_buf, *chorus_buf, chunkFrames)
+            } else {
+                osc_render_chunk(voice, output, *reverb_buf, *delay_buf, empty_c, chunkFrames)
+            }
+        } else {
+            if (chorus_buf != null) {
+                osc_render_chunk(voice, output, *reverb_buf, empty_d, *chorus_buf, chunkFrames)
+            } else {
+                osc_render_chunk(voice, output, *reverb_buf, empty_d, empty_c, chunkFrames)
+            }
+        }
+    } else {
+        if (delay_buf != null) {
+            if (chorus_buf != null) {
+                osc_render_chunk(voice, output, empty_r, *delay_buf, *chorus_buf, chunkFrames)
+            } else {
+                osc_render_chunk(voice, output, empty_r, *delay_buf, empty_c, chunkFrames)
+            }
+        } else {
+            if (chorus_buf != null) {
+                osc_render_chunk(voice, output, empty_r, empty_d, *chorus_buf, chunkFrames)
+            } else {
+                osc_render_chunk(voice, output, empty_r, empty_d, empty_c, chunkFrames)
+            }
+        }
+    }
+}
+
 // Render all active SF2 voices into the output buffer. Handles note-off scheduling,
 // reverb/chorus/delay send, and voice cleanup.
-// Reverb and delay sends accumulate into per-orbit bus buffers.
-// Chorus send is self-contained (SF2-only, not orbit-routed).
+// Reverb, delay, and chorus sends all accumulate into per-orbit bus buffers.
 def private sf2_render_voices(var sched : Scheduler; var output : array<float>; chunkFrames : int) {
     if (length(sched.sf2_voices) == 0 || sched.sf2 == null) {
         return
@@ -357,7 +522,47 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
             let chorus_send = meta.chorus_send
             let delay_send_amt = meta.delay_send
             let has_sends = reverb_send > 0.001 || chorus_send > 0.001 || delay_send_amt > 0.001
-            if (meta.fx.active) {
+            if (meta.hrtf_active) {
+                // HRTF path: render dry into voice_fx_buf, optionally apply per-voice FX,
+                // then HRTF the result and accumulate stereo into output + per-orbit sends.
+                let chunkSamples = chunkFrames * 2
+                if (length(sched.voice_fx_buf) < chunkSamples) {
+                    sched.voice_fx_buf |> resize(chunkSamples)
+                }
+                for (s in range(chunkSamples)) {
+                    sched.voice_fx_buf[s] = 0.0
+                }
+                unsafe {
+                    ma_sf2_voice_render(
+                        addr(sched.sf2_voices[si]),
+                        addr(sched.sf2.sample_data[0]),
+                        length(sched.sf2.sample_data),
+                        addr(sched.voice_fx_buf[0]),
+                        0, chunkFrames
+                    )
+                }
+                if (meta.fx.active) {
+                    fx_apply(sched.sf2_meta[si].fx, sched.voice_fx_buf, chunkFrames)
+                }
+                prepare_hrtf_scratch(sched, chunkFrames)
+                hrtf_render_voice(sched, sched.sf2_meta[si].hrtf_l, sched.sf2_meta[si].hrtf_r,
+                    meta.hrtf_azimuth, meta.hrtf_elevation,
+                    sched.voice_fx_buf, 0, 1.0, chunkFrames)
+                var reverb_buf = get_orbit_reverb_send(sched, meta.orbit)
+                var delay_buf = get_orbit_delay_send(sched, meta.orbit)
+                var chorus_buf = get_orbit_chorus_send(sched, meta.orbit)
+                let mix_reverb = reverb_buf != null && reverb_send > 0.001
+                let mix_delay  = delay_buf != null && delay_send_amt > 0.001
+                let mix_chorus = chorus_buf != null && chorus_send > 0.001
+                let dry_gain = has_sends ? max(0.0, 1.0 - reverb_send - chorus_send) : 1.0
+                for (s in range(chunkSamples)) {
+                    let v = sched.hrtf_stereo_buf[s]
+                    output[s] += v * dry_gain
+                    if (mix_reverb) { (*reverb_buf)[s] += v * reverb_send; }
+                    if (mix_delay)  { (*delay_buf)[s]  += v * delay_send_amt; }
+                    if (mix_chorus) { (*chorus_buf)[s] += v * chorus_send; }
+                }
+            } elif (meta.fx.active) {
                 // FX path: render dry into scratch, apply effects, then mix post-FX
                 // into output + sends. Uses the same temp buffer as osc voices.
                 let chunkSamples = chunkFrames * 2
@@ -379,23 +584,25 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
                 fx_apply(sched.sf2_meta[si].fx, sched.voice_fx_buf, chunkFrames)
                 var reverb_buf = get_orbit_reverb_send(sched, meta.orbit)
                 var delay_buf = get_orbit_delay_send(sched, meta.orbit)
+                var chorus_buf = get_orbit_chorus_send(sched, meta.orbit)
                 let mix_reverb = reverb_buf != null && reverb_send > 0.001
                 let mix_delay  = delay_buf != null && delay_send_amt > 0.001
-                let mix_chorus = sched.chorus != null && chorus_send > 0.001 && length(sched.chorus_send_buf) >= chunkSamples
+                let mix_chorus = chorus_buf != null && chorus_send > 0.001
                 let dry_gain = has_sends ? max(0.0, 1.0 - reverb_send - chorus_send) : 1.0
                 for (s in range(chunkSamples)) {
                     let v = sched.voice_fx_buf[s]
                     output[s] += v * dry_gain
                     if (mix_reverb) { (*reverb_buf)[s] += v * reverb_send; }
                     if (mix_delay)  { (*delay_buf)[s]  += v * delay_send_amt; }
-                    if (mix_chorus) { sched.chorus_send_buf[s] += v * chorus_send; }
+                    if (mix_chorus) { (*chorus_buf)[s] += v * chorus_send; }
                 }
             } elif (has_sends) {
                 var reverb_buf = get_orbit_reverb_send(sched, meta.orbit)
                 var delay_buf = get_orbit_delay_send(sched, meta.orbit)
+                var chorus_buf = get_orbit_chorus_send(sched, meta.orbit)
                 let has_reverb = reverb_buf != null && reverb_send > 0.001
                 let has_delay = delay_buf != null && delay_send_amt > 0.001
-                let has_chorus = sched.chorus != null && chorus_send > 0.001
+                let has_chorus = chorus_buf != null && chorus_send > 0.001
                 if (has_reverb || has_chorus || has_delay) {
                     let dry_gain = max(0.0, 1.0 - reverb_send - chorus_send)
                     if (has_delay && has_reverb && has_chorus) {
@@ -406,7 +613,7 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
                                 length(sched.sf2.sample_data),
                                 addr(output[0]),
                                 addr((*reverb_buf)[0]),
-                                addr(sched.chorus_send_buf[0]),
+                                addr((*chorus_buf)[0]),
                                 addr((*delay_buf)[0]),
                                 0, chunkFrames,
                                 dry_gain, reverb_send, chorus_send, delay_send_amt
@@ -420,7 +627,7 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
                                 length(sched.sf2.sample_data),
                                 addr(output[0]),
                                 addr((*reverb_buf)[0]),
-                                addr(sched.chorus_send_buf[0]),
+                                addr((*chorus_buf)[0]),
                                 0, chunkFrames,
                                 dry_gain, reverb_send, chorus_send
                             )
@@ -457,7 +664,7 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
                                 addr(sched.sf2.sample_data[0]),
                                 length(sched.sf2.sample_data),
                                 addr(output[0]),
-                                addr(sched.chorus_send_buf[0]),
+                                addr((*chorus_buf)[0]),
                                 0, chunkFrames,
                                 max(0.0, 1.0 - chorus_send), chorus_send
                             )
@@ -489,6 +696,16 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
             sched.sf2_meta[si].samples_elapsed += chunkFrames
         }
         if (sched.sf2_voices[si].finished != 0) {
+            if (sched.sf2_meta[si].hrtf_l != null) {
+                ma_hrtf_uninit(sched.sf2_meta[si].hrtf_l)
+                unsafe { delete sched.sf2_meta[si].hrtf_l; }
+                sched.sf2_meta[si].hrtf_l = null
+            }
+            if (sched.sf2_meta[si].hrtf_r != null) {
+                ma_hrtf_uninit(sched.sf2_meta[si].hrtf_r)
+                unsafe { delete sched.sf2_meta[si].hrtf_r; }
+                sched.sf2_meta[si].hrtf_r = null
+            }
             sched.sf2_voices |> erase(si)
             sched.sf2_meta |> erase(si)
         }
@@ -497,8 +714,7 @@ def private sf2_render_voices(var sched : Scheduler; var output : array<float>; 
 }
 
 // Render all active streaming oscillator voices into the output buffer.
-// Sends accumulate into per-orbit bus buffers based on each voice's orbit.
-// Chorus send accumulates into the scheduler-level chorus_send_buf.
+// Sends (reverb / delay / chorus) accumulate into per-orbit bus buffers based on each voice's orbit.
 // When a voice has active FX, render dry (no sends) into voice_fx_buf,
 // apply effects, then mix post-FX into output + sends.
 def private osc_render_voices(var sched : Scheduler; var output : array<float>; chunkFrames : int) {
@@ -507,15 +723,55 @@ def private osc_render_voices(var sched : Scheduler; var output : array<float>; 
     while (i >= 0) {
         let orb = sched.osc_voices[i].orbit
         let has_fx = sched.osc_voices[i].fx.active
+        let hrtf_active = sched.osc_voices[i].hrtf_active
         var reverb_buf : array<float>?
         var delay_buf : array<float>?
+        var chorus_buf : array<float>?
         if (sched.osc_voices[i].reverb_send > 0.0) {
             reverb_buf = get_orbit_reverb_send(sched, orb)
         }
         if (sched.osc_voices[i].delay_send > 0.0) {
             delay_buf = get_orbit_delay_send(sched, orb)
         }
-        if (has_fx) {
+        if (sched.osc_voices[i].chorus_send > 0.0) {
+            chorus_buf = get_orbit_chorus_send(sched, orb)
+        }
+        if (hrtf_active) {
+            // HRTF: render dry into voice_fx_buf (no sends), optionally apply per-voice FX,
+            // then HRTF the result and add the stereo HRTF output into master + per-orbit sends.
+            if (length(sched.voice_fx_buf) < chunkSamples) {
+                sched.voice_fx_buf |> resize(chunkSamples)
+            }
+            for (s in range(chunkSamples)) {
+                sched.voice_fx_buf[s] = 0.0
+            }
+            var empty1 : array<float>
+            var empty2 : array<float>
+            var empty3 : array<float>
+            osc_render_chunk(sched.osc_voices[i], sched.voice_fx_buf, empty1, empty2, empty3, chunkFrames)
+            if (has_fx) {
+                fx_apply(sched.osc_voices[i].fx, sched.voice_fx_buf, chunkFrames)
+            }
+            prepare_hrtf_scratch(sched, chunkFrames)
+            // gain + pan are already baked into voice_fx_buf via osc_render_chunk's lGain/rGain.
+            // Pan now controls source width (L/R virtual-speaker spread); HRTF positions in 3D.
+            hrtf_render_voice(sched, sched.osc_voices[i].hrtf_l, sched.osc_voices[i].hrtf_r,
+                sched.osc_voices[i].hrtf_azimuth, sched.osc_voices[i].hrtf_elevation,
+                sched.voice_fx_buf, 0, 1.0, chunkFrames)
+            let rev_send = sched.osc_voices[i].reverb_send
+            let del_send = sched.osc_voices[i].delay_send
+            let cho_send = sched.osc_voices[i].chorus_send
+            let mix_reverb = reverb_buf != null && rev_send > 0.0
+            let mix_delay  = delay_buf != null && del_send > 0.0
+            let mix_chorus = chorus_buf != null && cho_send > 0.0
+            for (s in range(chunkSamples)) {
+                let v = sched.hrtf_stereo_buf[s]
+                output[s] += v
+                if (mix_reverb) { (*reverb_buf)[s] += v * rev_send; }
+                if (mix_delay)  { (*delay_buf)[s]  += v * del_send; }
+                if (mix_chorus) { (*chorus_buf)[s] += v * cho_send; }
+            }
+        } elif (has_fx) {
             // route through scratch buffer: render dry (no sends), apply FX, mix into output + sends
             if (length(sched.voice_fx_buf) < chunkSamples) {
                 sched.voice_fx_buf |> resize(chunkSamples)
@@ -533,31 +789,33 @@ def private osc_render_voices(var sched : Scheduler; var output : array<float>; 
             let cho_send = sched.osc_voices[i].chorus_send
             let mix_reverb = reverb_buf != null && rev_send > 0.0
             let mix_delay  = delay_buf != null && del_send > 0.0
-            let mix_chorus = sched.chorus != null && cho_send > 0.0 && length(sched.chorus_send_buf) >= chunkSamples
+            let mix_chorus = chorus_buf != null && cho_send > 0.0
             for (s in range(chunkSamples)) {
                 let v = sched.voice_fx_buf[s]
                 output[s] += v
                 if (mix_reverb) { (*reverb_buf)[s] += v * rev_send; }
                 if (mix_delay)  { (*delay_buf)[s]  += v * del_send; }
-                if (mix_chorus) { sched.chorus_send_buf[s] += v * cho_send; }
+                if (mix_chorus) { (*chorus_buf)[s] += v * cho_send; }
             }
         } else {
-            // osc_render_chunk needs non-null array refs — use empty locals if no bus
-            if (reverb_buf != null && delay_buf != null) {
-                osc_render_chunk(sched.osc_voices[i], output, *reverb_buf, *delay_buf, sched.chorus_send_buf, chunkFrames)
-            } elif (reverb_buf != null) {
-                var empty : array<float>
-                osc_render_chunk(sched.osc_voices[i], output, *reverb_buf, empty, sched.chorus_send_buf, chunkFrames)
-            } elif (delay_buf != null) {
-                var empty : array<float>
-                osc_render_chunk(sched.osc_voices[i], output, empty, *delay_buf, sched.chorus_send_buf, chunkFrames)
-            } else {
-                var empty1 : array<float>
-                var empty2 : array<float>
-                osc_render_chunk(sched.osc_voices[i], output, empty1, empty2, sched.chorus_send_buf, chunkFrames)
-            }
+            // osc_render_chunk needs non-null array refs — pass per-orbit buffers when present,
+            // empty locals otherwise (osc_render_chunk bounds-checks each).
+            var empty_r : array<float>
+            var empty_d : array<float>
+            var empty_c : array<float>
+            osc_render_chunk_routed(sched.osc_voices[i], output, reverb_buf, delay_buf, chorus_buf, empty_r, empty_d, empty_c, chunkFrames)
         }
         if (sched.osc_voices[i].finished) {
+            if (sched.osc_voices[i].hrtf_l != null) {
+                ma_hrtf_uninit(sched.osc_voices[i].hrtf_l)
+                unsafe { delete sched.osc_voices[i].hrtf_l; }
+                sched.osc_voices[i].hrtf_l = null
+            }
+            if (sched.osc_voices[i].hrtf_r != null) {
+                ma_hrtf_uninit(sched.osc_voices[i].hrtf_r)
+                unsafe { delete sched.osc_voices[i].hrtf_r; }
+                sched.osc_voices[i].hrtf_r = null
+            }
             sched.osc_voices |> erase(i)
         }
         i --
@@ -588,15 +846,14 @@ def private prepare_orbit_buses(var sched : Scheduler; chunkSamples : int) {
                 bus.delay_send_buf[s] = 0.0
             }
         }
-    }
-    // chorus is scheduler-level (not per-orbit)
-    if (sched.chorus != null) {
-        if (length(sched.chorus_send_buf) < chunkSamples) {
-            sched.chorus_send_buf |> resize(chunkSamples)
-            sched.chorus_out_buf |> resize(chunkSamples)
-        }
-        for (s in range(chunkSamples)) {
-            sched.chorus_send_buf[s] = 0.0
+        if (bus.chorus != null) {
+            if (length(bus.chorus_send_buf) < chunkSamples) {
+                bus.chorus_send_buf |> resize(chunkSamples)
+                bus.chorus_out_buf |> resize(chunkSamples)
+            }
+            for (s in range(chunkSamples)) {
+                bus.chorus_send_buf[s] = 0.0
+            }
         }
     }
 }
@@ -632,39 +889,32 @@ def private process_orbit_buses(var sched : Scheduler; var output : array<float>
                 output[s] += bus.delay_out_buf[s]
             }
         }
-    }
-}
-
-// Process chorus send bus and mix into output (all voice types).
-def private process_chorus(var sched : Scheduler; var output : array<float>; chunkFrames : int) {
-    if (sched.chorus == null) {
-        return
-    }
-    let buf_samples = chunkFrames * 2
-    // check if anything was sent to chorus
-    var has_send = false
-    for (s in range(buf_samples)) {
-        if (abs(sched.chorus_send_buf[s]) > 0.00001) {
-            has_send = true
-            break
+        // Process chorus when it exists — gated by send activity since chorus is delay-line based and dry input is silent
+        if (bus.chorus != null) {
+            var has_send = false
+            for (s in range(chunkSamples)) {
+                if (abs(bus.chorus_send_buf[s]) > 0.00001) {
+                    has_send = true
+                    break
+                }
+            }
+            if (has_send) {
+                for (s in range(chunkSamples)) {
+                    bus.chorus_out_buf[s] = 0.0
+                }
+                unsafe {
+                    chorus_process(bus.chorus, addr(bus.chorus_send_buf[0]), addr(bus.chorus_out_buf[0]), chunkFrames)
+                }
+                for (s in range(chunkSamples)) {
+                    output[s] += bus.chorus_out_buf[s]
+                }
+            }
         }
-    }
-    if (!has_send) {
-        return
-    }
-    for (s in range(buf_samples)) {
-        sched.chorus_out_buf[s] = 0.0
-    }
-    unsafe {
-        chorus_process(sched.chorus, addr(sched.chorus_send_buf[0]), addr(sched.chorus_out_buf[0]), chunkFrames)
-    }
-    for (s in range(buf_samples)) {
-        output[s] += sched.chorus_out_buf[s]
     }
 }
 
 def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time : double; chunk_seconds : float = 0.05; lookAhead : float = 0.1) : void {
-    //! Advance one audio block: query the pattern for new events, spawn voices, mix all voices through the orbit/chorus buses into sched.output.
+    //! Advance one audio block: query the pattern for new events, spawn voices, mix all voices through the per-orbit reverb/delay/chorus buses into sched.output.
     //! chunk_seconds controls how much audio is produced this tick; lookAhead is how far ahead in time to query for new events.
     let cycleNow = current_cycle(sched, wall_time)
     let cycleEnd = current_cycle(sched, wall_time + double(lookAhead))
@@ -687,6 +937,16 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                     var k = length(sched.voices) - 1
                     while (k >= 0) {
                         if (sched.voices[k].cut == cutGroup) {
+                            if (sched.voices[k].hrtf_l != null) {
+                                ma_hrtf_uninit(sched.voices[k].hrtf_l)
+                                unsafe { delete sched.voices[k].hrtf_l; }
+                                sched.voices[k].hrtf_l = null
+                            }
+                            if (sched.voices[k].hrtf_r != null) {
+                                ma_hrtf_uninit(sched.voices[k].hrtf_r)
+                                unsafe { delete sched.voices[k].hrtf_r; }
+                                sched.voices[k].hrtf_r = null
+                            }
                             unsafe { delete sched.voices[k]; }
                             sched.voices |> erase(k)
                         }
@@ -695,6 +955,16 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                     var ko = length(sched.osc_voices) - 1
                     while (ko >= 0) {
                         if (sched.osc_voices[ko].cut == cutGroup) {
+                            if (sched.osc_voices[ko].hrtf_l != null) {
+                                ma_hrtf_uninit(sched.osc_voices[ko].hrtf_l)
+                                unsafe { delete sched.osc_voices[ko].hrtf_l; }
+                                sched.osc_voices[ko].hrtf_l = null
+                            }
+                            if (sched.osc_voices[ko].hrtf_r != null) {
+                                ma_hrtf_uninit(sched.osc_voices[ko].hrtf_r)
+                                unsafe { delete sched.osc_voices[ko].hrtf_r; }
+                                sched.osc_voices[ko].hrtf_r = null
+                            }
                             sched.osc_voices |> erase(ko)
                         }
                         ko --
@@ -727,7 +997,10 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                         reverb_send = h.value.room,
                         chorus_send = h.value.chorus,
                         delay_send = h.value.delay_amount,
-                        orbit = h.value.orbit
+                        orbit = h.value.orbit,
+                        hrtf_active = h.value.hrtf_active,
+                        hrtf_azimuth = h.value.hrtf_azimuth,
+                        hrtf_elevation = h.value.hrtf_elevation
                     )
                     osc_voice_init_filters(oscv, h.value.lpf, h.value.hpf, h.value.lpq, h.value.hpq)
                     if (!empty(h.value.vowel)) {
@@ -754,7 +1027,10 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                         reverb_send = h.value.room,
                         chorus_send = h.value.chorus,
                         delay_send = h.value.delay_amount,
-                        orbit = h.value.orbit
+                        orbit = h.value.orbit,
+                        hrtf_active = h.value.hrtf_active,
+                        hrtf_azimuth = h.value.hrtf_azimuth,
+                        hrtf_elevation = h.value.hrtf_elevation
                     ))
                 }
             }
@@ -789,64 +1065,120 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
         let space = chunkSamples - dstStart
         let count = min(available, space)
         if (count > 0) {
-            ma_volume_mixer_set_volume(unsafe(addr(sched.mixer)), voice.gain)
-            ma_volume_mixer_set_pan_immediate(unsafe(addr(sched.mixer)), voice.pan)
-            let nFrames = uint64(count / 2)
-            unsafe {
-                ma_volume_mixer_process_pcm_frames(
-                    addr(sched.mixer),
-                    addr(voice.samples[srcStart]),
-                    addr(sched.output[dstStart]),
-                    nFrames
-                )
-            }
-            // reverb send for pre-rendered voices
             var reverb_buf = get_orbit_reverb_send(sched, voice.orbit)
-            if (voice.reverb_send > 0.0 && reverb_buf != null) {
-                let pan = clamp(voice.pan, -1.0, 1.0)
-                let angle = (pan + 1.0) * 0.25 * float(TWO_PI / 2.0)
-                let sL = voice.gain * voice.reverb_send * cos(angle)
-                let sR = voice.gain * voice.reverb_send * sin(angle)
-                let nf = count / 2
-                for (f in range(nf)) {
-                    let si = srcStart + f * 2
-                    let di = dstStart + f * 2
-                    (*reverb_buf)[di]     += voice.samples[si]     * sL
-                    (*reverb_buf)[di + 1] += voice.samples[si + 1] * sR
-                }
-            }
-            // delay send for pre-rendered voices
             var delay_buf = get_orbit_delay_send(sched, voice.orbit)
-            if (voice.delay_send > 0.0 && delay_buf != null) {
-                let pan = clamp(voice.pan, -1.0, 1.0)
-                let angle = (pan + 1.0) * 0.25 * float(TWO_PI / 2.0)
-                let dL = voice.gain * voice.delay_send * cos(angle)
-                let dR = voice.gain * voice.delay_send * sin(angle)
-                let nf = count / 2
-                for (f in range(nf)) {
-                    let si = srcStart + f * 2
-                    let di = dstStart + f * 2
-                    (*delay_buf)[di]     += voice.samples[si]     * dL
-                    (*delay_buf)[di + 1] += voice.samples[si + 1] * dR
+            var chorus_buf = get_orbit_chorus_send(sched, voice.orbit)
+            let nf = count / 2
+            if (voice.hrtf_active) {
+                // HRTF-positioned dry path: each input channel becomes a virtual source at
+                // azimuth -/+ 30°; the two HRTF outputs sum to a binaural-stereo render.
+                // Sends are also spatialised — the resulting stereo is reused for output and per-orbit sends.
+                // Pass `nf` (not chunkFrames): the per-voice HRTF state must advance only over the
+                // frames actually emitted this tick, otherwise leading-silence delays or end-of-sample
+                // truncation would feed silent frames through the filter and skew its history.
+                // Bake equal-power pan + voice gain into voice_fx_buf before HRTF (consistent with the
+                // osc/sf2 paths). `voice.samples` is raw PCM with no pan/gain applied, so without this
+                // step pan(...) would be silently ignored on the sample-voice HRTF path.
+                let chunk_samples = nf * 2
+                if (length(sched.voice_fx_buf) < chunk_samples) {
+                    sched.voice_fx_buf |> resize(chunk_samples)
                 }
-            }
-            // chorus send for pre-rendered voices
-            if (voice.chorus_send > 0.0 && sched.chorus != null && length(sched.chorus_send_buf) >= chunkSamples) {
                 let pan = clamp(voice.pan, -1.0, 1.0)
                 let angle = (pan + 1.0) * 0.25 * float(TWO_PI / 2.0)
-                let cL = voice.gain * voice.chorus_send * cos(angle)
-                let cR = voice.gain * voice.chorus_send * sin(angle)
-                let nf = count / 2
+                let lGain = voice.gain * cos(angle)
+                let rGain = voice.gain * sin(angle)
                 for (f in range(nf)) {
                     let si = srcStart + f * 2
+                    let di = f * 2
+                    sched.voice_fx_buf[di]     = voice.samples[si]     * lGain
+                    sched.voice_fx_buf[di + 1] = voice.samples[si + 1] * rGain
+                }
+                prepare_hrtf_scratch(sched, nf)
+                hrtf_render_voice(sched, voice.hrtf_l, voice.hrtf_r, voice.hrtf_azimuth, voice.hrtf_elevation,
+                    sched.voice_fx_buf, 0, 1.0, nf)
+                let mix_reverb = reverb_buf != null && voice.reverb_send > 0.0
+                let mix_delay  = delay_buf  != null && voice.delay_send  > 0.0
+                let mix_chorus = chorus_buf != null && voice.chorus_send > 0.0
+                for (f in range(nf)) {
                     let di = dstStart + f * 2
-                    sched.chorus_send_buf[di]     += voice.samples[si]     * cL
-                    sched.chorus_send_buf[di + 1] += voice.samples[si + 1] * cR
+                    let hl = sched.hrtf_stereo_buf[f * 2]
+                    let hr = sched.hrtf_stereo_buf[f * 2 + 1]
+                    sched.output[di]     += hl
+                    sched.output[di + 1] += hr
+                    if (mix_reverb) {
+                        (*reverb_buf)[di]     += hl * voice.reverb_send
+                        (*reverb_buf)[di + 1] += hr * voice.reverb_send
+                    }
+                    if (mix_delay) {
+                        (*delay_buf)[di]      += hl * voice.delay_send
+                        (*delay_buf)[di + 1]  += hr * voice.delay_send
+                    }
+                    if (mix_chorus) {
+                        (*chorus_buf)[di]     += hl * voice.chorus_send
+                        (*chorus_buf)[di + 1] += hr * voice.chorus_send
+                    }
+                }
+            } else {
+                ma_volume_mixer_set_volume(unsafe(addr(sched.mixer)), voice.gain)
+                ma_volume_mixer_set_pan_immediate(unsafe(addr(sched.mixer)), voice.pan)
+                let nFrames = uint64(count / 2)
+                unsafe {
+                    ma_volume_mixer_process_pcm_frames(
+                        addr(sched.mixer),
+                        addr(voice.samples[srcStart]),
+                        addr(sched.output[dstStart]),
+                        nFrames
+                    )
+                }
+                let pan = clamp(voice.pan, -1.0, 1.0)
+                let angle = (pan + 1.0) * 0.25 * float(TWO_PI / 2.0)
+                // reverb send for pre-rendered voices
+                if (voice.reverb_send > 0.0 && reverb_buf != null) {
+                    let sL = voice.gain * voice.reverb_send * cos(angle)
+                    let sR = voice.gain * voice.reverb_send * sin(angle)
+                    for (f in range(nf)) {
+                        let si = srcStart + f * 2
+                        let di = dstStart + f * 2
+                        (*reverb_buf)[di]     += voice.samples[si]     * sL
+                        (*reverb_buf)[di + 1] += voice.samples[si + 1] * sR
+                    }
+                }
+                // delay send for pre-rendered voices
+                if (voice.delay_send > 0.0 && delay_buf != null) {
+                    let dL = voice.gain * voice.delay_send * cos(angle)
+                    let dR = voice.gain * voice.delay_send * sin(angle)
+                    for (f in range(nf)) {
+                        let si = srcStart + f * 2
+                        let di = dstStart + f * 2
+                        (*delay_buf)[di]     += voice.samples[si]     * dL
+                        (*delay_buf)[di + 1] += voice.samples[si + 1] * dR
+                    }
+                }
+                // chorus send for pre-rendered voices (per-orbit)
+                if (voice.chorus_send > 0.0 && chorus_buf != null) {
+                    let cL = voice.gain * voice.chorus_send * cos(angle)
+                    let cR = voice.gain * voice.chorus_send * sin(angle)
+                    for (f in range(nf)) {
+                        let si = srcStart + f * 2
+                        let di = dstStart + f * 2
+                        (*chorus_buf)[di]     += voice.samples[si]     * cL
+                        (*chorus_buf)[di + 1] += voice.samples[si + 1] * cR
+                    }
                 }
             }
         }
         voice.position += chunkSamples
         if (voice.position >= voiceLen) {
+            if (sched.voices[i].hrtf_l != null) {
+                ma_hrtf_uninit(sched.voices[i].hrtf_l)
+                unsafe { delete sched.voices[i].hrtf_l; }
+                sched.voices[i].hrtf_l = null
+            }
+            if (sched.voices[i].hrtf_r != null) {
+                ma_hrtf_uninit(sched.voices[i].hrtf_r)
+                unsafe { delete sched.voices[i].hrtf_r; }
+                sched.voices[i].hrtf_r = null
+            }
             unsafe {
                 delete sched.voices[i]
             }
@@ -861,11 +1193,8 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
     // render streaming oscillator voices (accumulates into per-orbit send bufs)
     osc_render_voices(sched, sched.output, chunkFrames)
 
-    // process all orbit bus effects and mix into output
+    // process all orbit bus effects (reverb / delay / chorus) and mix into output
     process_orbit_buses(sched, sched.output, chunkFrames)
-
-    // process chorus send bus and mix into output (all voice types)
-    process_chorus(sched, sched.output, chunkFrames)
 
     // output stays in sched.output — caller reads it directly
 }
@@ -886,20 +1215,63 @@ def get_orbit_delay(var sched : Scheduler; orbit : int = 0) : ma_delay? {
     return null
 }
 
+def get_orbit_chorus(var sched : Scheduler; orbit : int = 0) : ma_chorus? {
+    //! Fetch the chorus instance for the given orbit (for inspection or tests). Returns null if no bus or no chorus configured.
+    if (orbit < length(sched.orbit_buses) && sched.orbit_buses[orbit] != null) {
+        return sched.orbit_buses[orbit].chorus
+    }
+    return null
+}
+
 def shutdown_scheduler(var sched : Scheduler) {
-    //! Release every resource owned by the scheduler: native reverb/delay/chorus instances,
-    //! pre-rendered sample voices (each carrying a large PCM buffer), SF2/oscillator voice pools,
-    //! per-orbit effect buses and their scratch buffers, and the per-tick output buffer.
+    //! Release every resource owned by the scheduler: pre-rendered sample voices (each carrying
+    //! a large PCM buffer), SF2/oscillator voice pools, per-orbit effect buses (reverb / delay /
+    //! chorus) and their scratch buffers, and the per-tick output buffer.
     // pre-rendered sample voices — their `samples` arrays are the biggest leaked allocations
     for (i in range(length(sched.voices))) {
         if (sched.voices[i] != null) {
+            if (sched.voices[i].hrtf_l != null) {
+                ma_hrtf_uninit(sched.voices[i].hrtf_l)
+                unsafe { delete sched.voices[i].hrtf_l; }
+                sched.voices[i].hrtf_l = null
+            }
+            if (sched.voices[i].hrtf_r != null) {
+                ma_hrtf_uninit(sched.voices[i].hrtf_r)
+                unsafe { delete sched.voices[i].hrtf_r; }
+                sched.voices[i].hrtf_r = null
+            }
             unsafe { delete sched.voices[i]; }
             sched.voices[i] = null
         }
     }
     delete sched.voices
-    // streaming oscillator / SF2 voices
+    // streaming oscillator voices — release any HRTF state
+    for (i in range(length(sched.osc_voices))) {
+        if (sched.osc_voices[i].hrtf_l != null) {
+            ma_hrtf_uninit(sched.osc_voices[i].hrtf_l)
+            unsafe { delete sched.osc_voices[i].hrtf_l; }
+            sched.osc_voices[i].hrtf_l = null
+        }
+        if (sched.osc_voices[i].hrtf_r != null) {
+            ma_hrtf_uninit(sched.osc_voices[i].hrtf_r)
+            unsafe { delete sched.osc_voices[i].hrtf_r; }
+            sched.osc_voices[i].hrtf_r = null
+        }
+    }
     delete sched.osc_voices
+    // SF2 voices — release HRTF state from parallel meta
+    for (i in range(length(sched.sf2_meta))) {
+        if (sched.sf2_meta[i].hrtf_l != null) {
+            ma_hrtf_uninit(sched.sf2_meta[i].hrtf_l)
+            unsafe { delete sched.sf2_meta[i].hrtf_l; }
+            sched.sf2_meta[i].hrtf_l = null
+        }
+        if (sched.sf2_meta[i].hrtf_r != null) {
+            ma_hrtf_uninit(sched.sf2_meta[i].hrtf_r)
+            unsafe { delete sched.sf2_meta[i].hrtf_r; }
+            sched.sf2_meta[i].hrtf_r = null
+        }
+    }
     delete sched.sf2_voices
     delete sched.sf2_meta
     // per-orbit buses — free native effect instances then send/output scratch buffers
@@ -913,10 +1285,16 @@ def shutdown_scheduler(var sched : Scheduler) {
                 conv_reverb_uninit(bus.reverb)
                 unsafe { delete bus.reverb; }
             }
+            if (bus.chorus != null) {
+                unsafe { delete bus.chorus; }
+                bus.chorus = null
+            }
             delete bus.reverb_send_buf
             delete bus.reverb_out_buf
             delete bus.delay_send_buf
             delete bus.delay_out_buf
+            delete bus.chorus_send_buf
+            delete bus.chorus_out_buf
         }
     }
     for (i in range(length(sched.orbit_buses))) {
@@ -926,14 +1304,10 @@ def shutdown_scheduler(var sched : Scheduler) {
         }
     }
     delete sched.orbit_buses
-    // shared chorus and its buffers
-    if (sched.chorus != null) {
-        unsafe { delete sched.chorus; }
-        sched.chorus = null
-    }
-    delete sched.chorus_send_buf
-    delete sched.chorus_out_buf
-    // per-tick scratch buffers
+    // per-tick scratch buffers (including HRTF mono/stereo)
+    delete sched.hrtf_mono_buf
+    delete sched.hrtf_stereo_buf
+    delete sched.hrtf_stereo_buf_r
     delete sched.voice_fx_buf
     delete sched.output
     // mixer — symmetric teardown to ma_volume_mixer_init in tick()

--- a/modules/dasAudio/strudel/strudel_synth.das
+++ b/modules/dasAudio/strudel/strudel_synth.das
@@ -939,6 +939,18 @@ struct OscVoice {
     // per-voice audio effects (crush/coarse/shape/djf/bpf/bpq)
     @safe_when_uninitialized fx : VoiceFX
         //! Per-voice FX chain (bitcrush/waveshaper/DJ filter/bandpass/phaser/tremolo/compressor).
+    // HRTF positional override (when active, places this voice in 3D via virtual-stereo HRTF;
+    // L/R channels become virtual sources at azimuth -/+ 30°, each through its own HRTF instance).
+    hrtf_active    : bool  = false
+        //! True when this voice uses HRTF positioning. Pan still controls stereo width / image.
+    hrtf_azimuth   : float = 0.0
+        //! HRTF azimuth in degrees (-180..180; 0 = ahead).
+    hrtf_elevation : float = 0.0
+        //! HRTF elevation in degrees (-90..90; 0 = horizontal).
+    hrtf_l         : ma_hrtf?
+        //! HRTF state for the left input channel (virtual source at azimuth - 30°); allocated lazily.
+    hrtf_r         : ma_hrtf?
+        //! HRTF state for the right input channel (virtual source at azimuth + 30°); allocated lazily.
 }
 
 def osc_voice_init_supersaw(var voice : OscVoice) {

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -35,13 +35,32 @@ Fix significant issues (unused variables that indicate bugs, performance warning
 
 ## 1.5. Check for duplicates against the corpus
 
-Run `detect-dupe` against the **changed `.das` files only**, with a pre-built corpus of the rest of the tree. This is the "did I just write something that already exists?" check — catches structural copy-paste before review.
+Run `detect-dupe` against the **changed `.das` files only**, with a per-PR corpus scoped to the **directories the PR actually touches** (plus their sibling test/example/tutorial dirs). This is the "did I just write something that already exists?" check — catches structural copy-paste before review.
+
+**Don't run a full-tree corpus.** Exporting all of `daslib`, `tests`, `utils`, `modules` is slow and the noise floor swamps real signal — the dupes that matter are the ones near the code you changed (sibling functions in the same module, parallel tests, copy-pasted tutorial scaffolds). Build a narrow corpus.
+
+**How to scope:**
 
 ```bash
-# One-off: build the corpus over the rest of the tree (re-build occasionally as the codebase drifts)
-bin/Release/daslang.exe utils/detect-dupe/main.das -- -p daslib -p tests -p utils --export-functions /tmp/corpus.json
+# 1. List the unique top-level dirs touched by the PR
+git diff --name-only origin/master..HEAD -- '*.das' | awk -F/ 'NF>=2 {print $1"/"$2}' | sort -u
 
-# Per-PR: compare the diff against the corpus
+# Example output for a strudel-only PR:
+#   examples/daStrudel
+#   modules/dasAudio
+#   tests/strudel
+#   tutorials/daStrudel
+```
+
+Use those dirs (or trim further to a single module subfolder, e.g. `modules/dasAudio/strudel`) as the corpus scope.
+
+```bash
+# Per-PR: corpus over the touched scope only
+bin/Release/daslang.exe utils/detect-dupe/main.das -- \
+  -p modules/dasAudio/strudel -p tests/strudel -p tutorials/daStrudel -p examples/daStrudel \
+  --export-functions /tmp/corpus.json
+
+# Compare the diff against it
 git diff --name-only origin/master..HEAD -- '*.das' | \
   bin/Release/daslang.exe utils/detect-dupe/main.das -- \
     --import-functions /tmp/corpus.json --against-from-stdin
@@ -50,9 +69,13 @@ git diff --name-only origin/master..HEAD -- '*.das' | \
 Or via MCP (preferred when available):
 
 ```
-mcp__daslang__export_corpus(paths="daslib,tests,utils", out="/tmp/corpus.json")
+mcp__daslang__export_corpus(paths="modules/dasAudio/strudel,tests/strudel,tutorials/daStrudel,examples/daStrudel", out="/tmp/corpus.json")
 mcp__daslang__detect_duplicates(paths="<git-diff list>", corpus="/tmp/corpus.json")
 ```
+
+The candidate files are auto-stripped from the corpus before comparison, so it's fine for the corpus scope to overlap the changed-files list.
+
+**When to widen the scope** — if the PR introduces a generic helper (`pattern_*`, `time_*`, etc.), add the obvious adjacent directory (`daslib`) to catch dupes against the standard library. But still avoid a tree-wide sweep.
 
 **Triage policy:**
 - **Exact match (similarity 1.0)** with an existing function — almost always a real concern. Either (a) reuse the existing one, (b) document why a sibling is needed, or (c) extract a shared helper.

--- a/skills/strudel_port.md
+++ b/skills/strudel_port.md
@@ -202,6 +202,37 @@ effort:
 
    See :ref:`tutorial_dastrudel_sf2_soundfont`.
 
+## Orbit semantics (per-orbit FX)
+
+In daslang, ``orbit`` selects a per-orbit effect bus with **independent
+reverb / delay / chorus** instances. ``room`` sends to the orbit's
+reverb, ``delay`` to its delay, ``chorus`` to its chorus. Voices on
+different orbits don't share FX state — splitting orbits is how you
+get separate reverb tails or chorus rates for the kick vs the lead.
+``orbit(0)`` is the default. See ``examples/daStrudel/features/orbit_*.das``
+for canonical patterns.
+
+## HRTF position (daslang extension)
+
+Per-event 3D positioning on top of stereo ``pan``:
+
+```das
+pat |> hrtf_azimuth(deg)       // numeric or pattern-valued
+pat |> hrtf_elevation(deg)     // numeric or pattern-valued
+pat |> hrtf(az, el)            // combined numeric setter
+```
+
+Setters flip an ``hrtf_active`` flag on the event; the scheduler
+routes the dry signal and the orbit-FX sends through **two**
+per-voice ``ma_hrtf`` instances (``hrtf_l`` + ``hrtf_r``) for
+binaural-stereo HRTF: each input channel becomes a virtual source
+at azimuth -/+ 30°, summed at the output. Pan and HRTF are
+orthogonal — pan controls source width, HRTF controls position.
+Best on headphones; cheaper to skip and use ``pan`` alone when
+externalisation isn't needed. See
+:ref:`tutorial_dastrudel_hrtf_position` and
+``examples/daStrudel/hrtf/`` for the bumblebee demo.
+
 ## Common friction points when pasting
 
 ### Mini-notation ``bd(3,8)`` Euclidean form

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -160,9 +160,11 @@ IF(NOT DAS_AUDIO_DISABLED)
         tests/strudel/test_sf2_modulators.das
         tests/strudel/test_adsr_resolver.das
         tests/strudel/test_aliases.das
+        tests/strudel/test_chorus_per_orbit.das
         tests/strudel/test_combinators.das
         tests/strudel/test_delay.das
         tests/strudel/test_effects.das
+        tests/strudel/test_hrtf_pos.das
         tests/strudel/test_new_combinators.das
         tests/strudel/test_integration.das
         tests/strudel/test_memory.das

--- a/tests/strudel/test_chorus_per_orbit.das
+++ b/tests/strudel/test_chorus_per_orbit.das
@@ -1,0 +1,82 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost
+require strudel/strudel
+require strudel/strudel_synth
+require strudel/strudel_scheduler
+require strudel/strudel_samples
+require math
+
+[test]
+def test_chorus_orbit_lazy_init(t : T?) {
+    t |> run("chorus on orbit allocated only when event uses chorus") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        // Dry orbit 0 — no chorus should be created
+        let pat <- atom("sine") |> set_orbit(0)
+        let bank : SampleBank
+        tick(sched, pat, bank, 0.0lf, 0.05)
+        t |> success(get_orbit_chorus(sched, 0) == null, "dry orbit should have no chorus instance")
+    }
+}
+
+[test]
+def test_chorus_orbit_init_on_send(t : T?) {
+    t |> run("chorus instance created when an event with chorus arrives") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        let pat <- atom("sine") |> chorus(0.6) |> set_orbit(2)
+        let bank : SampleBank
+        tick(sched, pat, bank, 0.0lf, 0.05)
+        t |> success(get_orbit_chorus(sched, 2) != null, "orbit 2 should have chorus instance")
+        t |> success(get_orbit_chorus(sched, 0) == null, "orbit 0 should remain dry")
+    }
+}
+
+[test]
+def test_chorus_per_orbit_independence(t : T?) {
+    t |> run("two orbits with chorus get independent chorus instances") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        let pat <- stack([
+            atom("sine") |> chorus(0.5) |> set_orbit(0),
+            atom("sine") |> chorus(0.5) |> set_orbit(1)
+        ])
+        let bank : SampleBank
+        tick(sched, pat, bank, 0.0lf, 0.05)
+        t |> success(get_orbit_chorus(sched, 0) != null, "orbit 0 should have chorus")
+        t |> success(get_orbit_chorus(sched, 1) != null, "orbit 1 should have chorus")
+        t |> success(get_orbit_chorus(sched, 0) != get_orbit_chorus(sched, 1), "orbits should have different chorus instances")
+    }
+}
+
+[test]
+def test_chorus_isolation_between_orbits(t : T?) {
+    t |> run("chorus on orbit 0 leaves orbit 1 dry") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        // Only orbit 0 has chorus; orbit 1 plays the same note dry.
+        let pat <- stack([
+            atom("sine") |> chorus(0.7) |> set_orbit(0),
+            atom("sine") |> set_orbit(1)
+        ])
+        let bank : SampleBank
+        tick(sched, pat, bank, 0.0lf, 0.05)
+        t |> success(get_orbit_chorus(sched, 0) != null, "orbit 0 should have chorus")
+        t |> success(get_orbit_chorus(sched, 1) == null, "orbit 1 should NOT have chorus (regression guard for the old shared-chorus behaviour)")
+    }
+}
+
+[test]
+def test_chorus_voice_field(t : T?) {
+    t |> run("OscVoice carries chorus_send from Event.chorus") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        let pat <- atom("sine") |> chorus(0.4)
+        let bank : SampleBank
+        tick(sched, pat, bank, 0.0lf, 0.05)
+        t |> equal(length(sched.osc_voices), 1)
+        t |> numericEqual(sched.osc_voices[0].chorus_send, 0.4)
+    }
+}

--- a/tests/strudel/test_hrtf_pos.das
+++ b/tests/strudel/test_hrtf_pos.das
@@ -1,0 +1,124 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost
+require strudel/strudel
+require strudel/strudel_synth
+require strudel/strudel_scheduler
+require strudel/strudel_event
+require strudel/strudel_pattern
+require strudel/strudel_samples
+require math
+
+[test]
+def test_hrtf_setters_engage_active(t : T?) {
+    t |> run("hrtf_azimuth flips hrtf_active true on every event") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        let pat <- atom("sine") |> hrtf_azimuth(-45.0)
+        let bank : SampleBank
+        tick(sched, pat, bank, 0.0lf, 0.05)
+        t |> equal(length(sched.osc_voices), 1)
+        t |> success(sched.osc_voices[0].hrtf_active, "voice should have hrtf_active = true")
+        t |> numericEqual(sched.osc_voices[0].hrtf_azimuth, -45.0)
+    }
+}
+
+[test]
+def test_hrtf_combined_setter(t : T?) {
+    t |> run("hrtf(az, el) sets both axes and engages") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        let pat <- atom("sine") |> hrtf(60.0, 15.0)
+        let bank : SampleBank
+        tick(sched, pat, bank, 0.0lf, 0.05)
+        t |> equal(length(sched.osc_voices), 1)
+        t |> success(sched.osc_voices[0].hrtf_active)
+        t |> numericEqual(sched.osc_voices[0].hrtf_azimuth, 60.0)
+        t |> numericEqual(sched.osc_voices[0].hrtf_elevation, 15.0)
+    }
+}
+
+[test]
+def test_no_hrtf_means_inactive(t : T?) {
+    t |> run("plain pattern leaves hrtf_active = false") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        let pat <- atom("sine") |> pan(0.5)
+        let bank : SampleBank
+        tick(sched, pat, bank, 0.0lf, 0.05)
+        t |> equal(length(sched.osc_voices), 1)
+        t |> success(!sched.osc_voices[0].hrtf_active, "voice without hrtf setter must keep hrtf_active = false")
+    }
+}
+
+[test]
+def test_hrtf_overrides_pan(t : T?) {
+    t |> run("setting hrtf alongside pan still engages HRTF (pan path is bypassed)") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        // Pan first, then hrtf — hrtf must win.
+        let pat <- atom("sine") |> pan(0.5) |> hrtf(-90.0, 0.0)
+        let bank : SampleBank
+        tick(sched, pat, bank, 0.0lf, 0.05)
+        t |> success(sched.osc_voices[0].hrtf_active, "hrtf must still be active after also setting pan")
+        t |> numericEqual(sched.osc_voices[0].hrtf_azimuth, -90.0)
+    }
+}
+
+[test]
+def test_hrtf_renders_audible_output(t : T?) {
+    t |> run("HRTF-positioned sine produces audible stereo output without crashing") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 0.5lf
+        let pat <- atom("sine") |> hrtf(-90.0, 0.0) |> set_gain(0.8) |> set_release(0.2)
+        let bank : SampleBank
+        // tick a few chunks to ensure HRTF renders without bounds issues
+        for (c in range(8)) {
+            tick(sched, pat, bank, double(c) * 0.05lf, 0.05)
+        }
+        // some sample produced (RMS check across whole tick)
+        var energy = 0.0
+        for (s in sched.output) {
+            energy += s * s
+        }
+        t |> success(energy > 0.0, "HRTF rendering should produce non-silent output")
+    }
+}
+
+[test]
+def test_hrtf_pattern_modulated(t : T?) {
+    t |> run("pattern-valued hrtf_azimuth animates per event") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 1.0lf
+        // 4 events per cycle, azimuths -90, -30, 30, 90
+        let pat <- s("sine sine sine sine") |> hrtf_azimuth(s("-90 -30 30 90"))
+        let bank : SampleBank
+        // process one full cycle
+        for (c in range(20)) {
+            tick(sched, pat, bank, double(c) * 0.05lf, 0.05)
+        }
+        // every spawned voice should have hrtf_active = true
+        var any_voice = false
+        for (v in sched.osc_voices) {
+            t |> success(v.hrtf_active, "every voice with pattern-valued hrtf_azimuth must be HRTF-active")
+            any_voice = true
+        }
+        t |> success(any_voice || length(sched.osc_voices) == 0, "ok — voices may have all completed by end of tick")
+    }
+}
+
+[test]
+def test_hrtf_lazy_alloc(t : T?) {
+    t |> run("ma_hrtf instances allocated lazily on first render") @(t : T?) {
+        var sched : Scheduler
+        sched.cps = 0.5lf
+        let pat <- atom("sine") |> hrtf(45.0, 0.0) |> set_release(0.1)
+        let bank : SampleBank
+        // first tick should allocate the per-voice hrtf pair (one per channel: az - 30°, az + 30°)
+        tick(sched, pat, bank, 0.0lf, 0.05)
+        t |> equal(length(sched.osc_voices), 1)
+        t |> success(sched.osc_voices[0].hrtf_l != null, "voice.hrtf_l should be allocated after first render")
+        t |> success(sched.osc_voices[0].hrtf_r != null, "voice.hrtf_r should be allocated after first render")
+    }
+}

--- a/tutorials/daStrudel/daStrudel_16_hrtf_position.das
+++ b/tutorials/daStrudel/daStrudel_16_hrtf_position.das
@@ -1,0 +1,151 @@
+// Tutorial DASTRUDEL-16: HRTF — 3D positional override for stereo pan
+//
+// daslang exposes a per-event HRTF position (azimuth, elevation). When set,
+// HRTF positioning REPLACES the equal-power stereo pan path: the dry signal
+// and the orbit-effect sends are run through the same CIPIC-based HRTF
+// engine that audio_boost uses for 3D sources.
+//
+// Why bother — equal-power pan only places sources on a horizontal stereo
+// line between the speakers. HRTF adds:
+//   • depth / externalisation (sources feel "outside the head" on headphones),
+//   • front-back disambiguation (centre-front is no longer ambiguous with
+//     centre-rear),
+//   • elevation cues.
+//
+// Cost — under the binaural-stereo render, each HRTF-positioned voice carries
+// two ma_hrtf instances (hrtf_l + hrtf_r, lazy-allocated on first render: one
+// per virtual-speaker channel at azimuth -/+ 30°). Practical for 3-8
+// simultaneous HRTF voices on modern hardware. Plain pan is far cheaper;
+// reach for HRTF only when you want spatial cues plain pan can't provide.
+//
+// API:
+//   pat |> hrtf_azimuth(deg)        -- numeric or pattern-valued
+//   pat |> hrtf_elevation(deg)      -- numeric or pattern-valued
+//   pat |> hrtf(az, el)             -- combined numeric setter
+//
+// Setting any of the three flips the event's `hrtf_active = true`. Pan
+// and HRTF are orthogonal: pan controls the inherent stereo width / image
+// of the source (L/R balance feeding the spatialiser), HRTF positions the
+// source in 3D.
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_16_hrtf_position.das
+
+options gen2
+options persistent_heap
+options indenting = 4
+
+require strudel/strudel public
+require strudel/strudel_player public
+require audio/audio_boost
+require daslib/fio
+
+def play(var pat : Pattern; cps : double = 0.5lf; seconds : double = 4.0lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (double(get_time_usec(t0)) / 1000000.0lf < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Static positions: ahead, left, right, above
+// ──────────────────────────────────────────────────────────────────────────
+//
+// hrtf(az, el) takes both axes at once. 0/0 = directly ahead, +90/0 = right,
+// -90/0 = left, 0/+45 = up-front. Try headphones for the strongest effect.
+
+def example_static_positions() {
+    print("\n=== Section 1: four static HRTF positions ===\n")
+    let pat <- stack([
+        note("c4", "sine") |> hrtf(0.0,  0.0) |> attack(0.01) |> release(0.5) |> gain(0.4),
+        note("e4", "sine") |> hrtf(-90.0,  0.0) |> attack(0.01) |> release(0.5) |> gain(0.4),
+        note("g4", "sine") |> hrtf(+90.0,  0.0) |> attack(0.01) |> release(0.5) |> gain(0.4),
+        note("c5", "sine") |> hrtf(0.0, 45.0) |> attack(0.01) |> release(0.5) |> gain(0.4)
+    ])
+    play(pat, 0.5lf, 6.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Animated azimuth: sine sweep
+// ──────────────────────────────────────────────────────────────────────────
+//
+// The setters accept patterns. Each event samples the modulation pattern
+// at its onset to get its azimuth. With sine().range(-180, 180).slow(4),
+// the source orbits the listener once every 8 cycles (slow(4) on a 0.5cps
+// stream).
+
+def example_animated_azimuth() {
+    print("\n=== Section 2: azimuth follows a sine sweep ===\n")
+    let pat <- (
+        note("c4 e4 g4 c5", "triangle")
+        |> hrtf_azimuth(sine() |> range(-180.0, 180.0) |> slow(4.0lf))
+        |> attack(0.005)
+        |> release(0.3)
+        |> gain(0.4)
+    )
+    play(pat, 0.5lf, 8.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Pan and HRTF combine — HRTF positions, pan widens
+// ──────────────────────────────────────────────────────────────────────────
+//
+// When hrtf_active is true the equal-power L/R mixer is replaced by a
+// binaural-stereo HRTF: L becomes a virtual source at (azimuth - 30°) and
+// R at (azimuth + 30°), each through its own HRTF instance. The pre-pan
+// stereo image is preserved as source width; HRTF places the source in 3D.
+// The same binaural render is reused for the reverb/delay/chorus sends.
+//
+// Below, the second voice has BOTH pan(0.5) and hrtf(-90, 0). HRTF places
+// the voice to the left; pan(0.5)'s slight L/R imbalance is preserved as
+// source width inside that 3D position.
+
+def example_hrtf_combines_with_pan() {
+    print("\n=== Section 3: hrtf places, pan widens ===\n")
+    let pat <- stack([
+        note("c4", "sine") |> pan(0.5)                       |> attack(0.01) |> release(0.4) |> gain(0.4),
+        note("e4", "sine") |> pan(0.5) |> hrtf(-90.0, 0.0)   |> attack(0.01) |> release(0.4) |> gain(0.4)
+    ])
+    play(pat, 0.5lf, 4.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — When NOT to use HRTF
+// ──────────────────────────────────────────────────────────────────────────
+//
+// HRTF is heavier than pan and works best on headphones. For drum machines
+// or beats where you just want left/right separation, plain pan is cheaper
+// and works fine on speakers. Mix-and-match in the same stack: HRTF the
+// "lead voice" and pan the rhythm section.
+//
+// In this example the kick/snare go through plain pan; the lead pluck
+// gets HRTF positioning. Because the pluck is on a different orbit, its
+// reverb stays distinct from the (dry) drum bus.
+
+def example_mixed() {
+    print("\n=== Section 4: mixing HRTF and plain pan in one stack ===\n")
+    let pat <- stack([
+        s("bd ~ sd ~")                  |> orbit(0) |> gain(0.6),
+        s("hh*8")                       |> orbit(0) |> pan(0.7) |> gain(0.3),
+        note("c4 e4 g4 e4", "triangle") |> orbit(1) |> hrtf_azimuth(sine() |> range(-60.0, 60.0) |> slow(2.0lf))
+                                         |> room(0.4) |> roomsize(2.0) |> attack(0.005) |> release(0.25) |> gain(0.35)
+    ])
+    play(pat, 0.5lf, 8.0lf)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-16: HRTF — 3D positional override for stereo pan\n")
+    print("Best heard on headphones.\n")
+    example_static_positions()
+    example_animated_azimuth()
+    example_hrtf_combines_with_pan()
+    example_mixed()
+    print("\nDone.\n")
+}


### PR DESCRIPTION
## Summary

Two strudel-divergent features (relative to strudel.cc):

- **chorus is now per-orbit** — was a single global chorus bus, now lives alongside `room`/`delay` on each orbit. Lets a single stack mix dry, room-only, and chorus-only voices without manual send wiring. The shared `chorus*` setters route to the active orbit.
- **per-event HRTF positional override** — new `hrtf_azimuth` / `hrtf_elevation` / `hrtf(az, el)` setters replace the equal-power stereo `pan` with 3D positioning via `audio_boost`'s CIPIC `ma_hrtf` engine. Setting any of the three flips `hrtf_active`; reverb / delay / chorus sends from an HRTF voice flow through the per-voice HRTF too. Lazy-allocated; practical for ~10 voices.

## What's in here

- Module changes: `modules/dasAudio/strudel/strudel_{event,pattern,player,scheduler,synth}.das` (scheduler is the bulk — chorus moves out of the global pipeline into the per-orbit bus).
- Tests: `tests/strudel/test_chorus_per_orbit.das`, `tests/strudel/test_hrtf_pos.das`. Both registered for AOT in `tests/aot/CMakeLists.txt`.
- Tutorial 16: `tutorials/daStrudel/daStrudel_16_hrtf_position.das` + RST page, linked from the daStrudel toctree and the strudel-vs-strudel.cc comparison.
- Examples: `examples/daStrudel/features/{hrtf_basic,hrtf_animated,hrtf_overrides_pan,orbit_chorus_only}.das`, bumblebee-style 3D demo at `examples/daStrudel/hrtf/`, plus a top-level `examples/daStrudel/README.md` indexing the demo set.
- Doc generation: new "Fluent control: 3D positioning (HRTF)" group in `doc/reflections/das2rst.das`; engine cross-ref retargeted to `:ref:`ma_hrtf <handle-audio-ma_hrtf>``.
- Skill updates:
  - `skills/strudel_port.md` — port notes for chorus + HRTF.
  - `skills/make_pr.md` — narrow dupe-corpus scope to PR-touched directories (the previous tree-wide recipe was too noisy to be useful).

## Known follow-up (not in this PR)

The "Inline literals over temp-var-and-push" lint (STYLE012) hits four sites in `strudel_pattern.das` (`jux`/`off`/`sometimesby`/`superimpose`) where the array elements are non-copyable Patterns. Both array-literal forms (`[<- a, <- b]` and `array<Pattern>(<- a, <- b)`) compile and pass interpreter, but **fail under AOT with `invoke null lambda`** at runtime. The push/emplace pattern is the only AOT-safe form, so those four sites carry `// nolint:STYLE012`. AOT codegen for non-copyable lambda array literals looks worth a separate bug.

## Test plan

- [x] Lint: 0 issues across all 15 changed `.das` files
- [x] Dupe detection: corpus scoped to touched dirs (`modules/dasAudio/strudel`, `tests/strudel`, `tutorials/daStrudel`, `examples/daStrudel`); only template / boilerplate matches, no real overlap
- [x] Interpreter: `tests/strudel` 573/573 pass, 0 errors, 6 skipped (FluidR3_GM.sf2 not present locally — same on master)
- [x] AOT: `test_aot -use-aot dastest -- --use-aot --test tests/strudel` 573/573 pass, 0 errors, same 6 skips
- [x] Format: every changed `.das` round-trips through `format_file` (only `strudel_pattern.das` needed re-formatting)
- [x] Sphinx: clean build, **0 warnings**
- [x] Tutorial 16 RST cross-references resolve (toctree + previous/next/seealso)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
