### PR TITLE
detect-dupe: parallel export + explicit paths-list inputs

### DIFF
--- a/daslib/clargs.das
+++ b/daslib/clargs.das
@@ -539,7 +539,7 @@ class ArgsMacro : AstStructureAnnotation {
                 if (r |> is_err) {
                     return "{$v(arg.flag_name)}: {r |> unwrap_err}"
                 }
-                var opt <- r |> move_unwrap
+                var opt <- r |> move_unwrap   // nolint:LINT003 — non-copyable static_if branch below consumes `opt` via `move_unwrap`, so it must stay `var`
                 if (opt |> is_some) {
                     static_if (typeinfo can_copy(type<$t(st.fields[field_index]._type)>)) {
                         dst.$f(arg.field_name) = opt |> unwrap

--- a/doc/source/reference/utils/detect_dupe.rst
+++ b/doc/source/reference/utils/detect_dupe.rst
@@ -72,8 +72,31 @@ Flags
      - Default
      - Meaning
    * - ``-p / --path``
-     - required
-     - File or directory to scan; repeatable
+     - required\*
+     - File or directory to scan; repeatable.  ``*`` one of ``-p``,
+       ``--paths-from``, ``--paths-stdin`` is required (or
+       ``--import-functions`` / ``--against``)
+   * - ``--paths-from``
+     - off
+     - Read newline-delimited paths from a file (``#``-comments and
+       blank lines skipped).  Composes with ``-p``.  Each entry can
+       be a file or directory; directories recurse via the same
+       scanner as ``-p``
+   * - ``--paths-stdin``
+     - off
+     - Read newline-delimited paths from stdin (``#``-comments and
+       blank lines skipped).  Composes with ``-p``.  Mutually
+       exclusive with ``--against-from-stdin`` (one stdin reader per
+       run)
+   * - ``-j / --workers``
+     - 0 (auto)
+     - Worker count for parallel ``--export-functions`` runs.  0 =
+       hardware threads.  1 = sequential.  Files are sorted, split
+       into N contiguous chunks, each compiled by a child detect-dupe
+       process; shards are merged in chunk-index order so output is
+       byte-identical across worker counts.  Below 16 input files the
+       export stays sequential regardless.  Ignored without
+       ``--export-functions``
    * - ``-t / --threshold``
      - 0.7
      - Fuzzy similarity floor (0..1).  Score is
@@ -327,6 +350,55 @@ records and reload them::
 ``--import-functions`` is mutually exclusive with both ``--path``
 and ``--export-functions``.  ``--export-functions`` always exits
 before the clustering pass.
+
+Parallel export (``-j / --workers``)
+------------------------------------
+
+For large corpora the dominant cost is per-file compilation.
+``--workers N`` fans the export across N child detect-dupe
+processes:
+
+* The full file list is sorted, split into N contiguous chunks,
+  and written to per-worker temp files.
+* Each child runs ``--paths-from <chunk> --export-functions
+  <shard> --workers 1`` and produces its own envelope.
+* The parent reads shards back **in chunk-index order** and
+  concatenates their ``functions`` arrays.  Output is therefore
+  byte-identical to a sequential ``--workers 1`` run on the same
+  inputs.
+* Below 16 input files the export stays sequential regardless ---
+  child-process startup dominates the savings on small lists.
+
+Default (``-j 0``) is auto, equal to the host's hardware thread
+count.  Compile is CPU-bound, so oversubscription does not help.
+``-j 1`` forces sequential.  Compile failures in any child fail
+the whole export (no partial corpus shipped) --- same gate as the
+sequential path.
+
+Explicit file-list inputs
+-------------------------
+
+``--paths-from <file>`` and ``--paths-stdin`` accept newline-
+delimited file lists (``#``-comments and blank lines skipped).
+They compose with ``-p`` (union, deduplicated) and are typically
+used to scope an export to the files in a PR diff:
+
+.. code-block:: sh
+
+   # via file (avoids ARG_MAX on big PRs)
+   git diff --name-only master | grep '\.das$' > /tmp/pr.txt
+   bin/daslang utils/detect-dupe/main.das -- \
+       --paths-from /tmp/pr.txt --export-functions pr.json
+
+   # via stdin (same idea, no temp file)
+   git diff --name-only master | grep '\.das$' | \
+       bin/daslang utils/detect-dupe/main.das -- \
+           --paths-stdin --export-functions pr.json
+
+Each entry can be a file or a directory; directories recurse via
+the same scanner ``-p`` uses.  ``--paths-stdin`` is mutually
+exclusive with ``--against-from-stdin`` (one stdin reader per
+run).
 
 The on-disk schema is a small envelope:
 

--- a/install/skills/detect_dupe.md
+++ b/install/skills/detect_dupe.md
@@ -29,6 +29,17 @@ mcp__daslang__export_corpus(paths="daslib,utils,my_project", out="corpus.json")
 
 You build the corpus once over the body of code you want to compare against. Re-run it when the code drifts enough that stale matches become a problem.
 
+`workers="0"` (or omitted) parallelizes across hardware threads. `workers="1"` keeps the run sequential. Output is byte-identical across worker counts.
+
+`paths_file="<path>"` scopes the export to a precomputed file list — handy for PR-scoped runs:
+
+```
+git diff --name-only master | grep '\.das$' > /tmp/pr.txt
+mcp__daslang__export_corpus(paths_file="/tmp/pr.txt", out="pr.json")
+```
+
+`paths_file` composes with `paths` (union, deduped). The file format is one path per line; blank lines and `#`-comment lines are skipped.
+
 Output is an envelope:
 
 ```json
@@ -103,6 +114,8 @@ The CLI ships at `utils/detect-dupe/main.das` and supports a few modes the MCP t
 - **B1 baseline / CI gate** — `--baseline <corpus.json> --check`. Records absent from the baseline are tagged candidates; non-zero exit when any cluster/pair survives.
 - **`--baseline-strict`** — drops clusters whose canonical was already in the baseline, so only fully-new canonicals survive.
 - **`--against-from-stdin`** — read newline-delimited candidate paths from stdin, e.g. piped from `git diff --name-only`.
+- **`--paths-from <file>` / `--paths-stdin`** — read the *primary* file list from a file or stdin (skips blank lines and `#`-comments). Composes with `-p`. Use the file form when an inline list would hit ARG_MAX, the stdin form to plug into `git diff --name-only` pipelines for PR-scoped corpus builds.
+- **`-j / --workers N`** — parallel `--export-functions` across N child detect-dupe processes. 0 (default) = hardware threads. 1 = sequential. Output is byte-identical to a sequential run (sorted-then-chunked, shards merged in order). Below 16 files the export stays sequential.
 - **`-L / --lambdas-only`** — cluster lambda bodies instead of top-level functions; useful for finding duplicated dastest `run` lambdas.
 - **`--min-tokens N`** — drop trivial wrappers (default 8).
 - **`--no-fuzzy`** — exact clusters only, faster on large corpora.
@@ -110,11 +123,18 @@ The CLI ships at `utils/detect-dupe/main.das` and supports a few modes the MCP t
 Quick recipes:
 
 ```sh
-# one-off corpus build (commit this)
+# one-off corpus build (commit this) — parallel by default for large runs
 bin/daslang utils/detect-dupe/main.das -- -p src --export-functions baseline.json
+
+# explicit worker count (1 = sequential)
+bin/daslang utils/detect-dupe/main.das -- -p src -j 8 --export-functions baseline.json
 
 # CI gate: flag any new structural duplicates introduced by a PR
 bin/daslang utils/detect-dupe/main.das -- -p src --baseline baseline.json --check
+
+# PR-scoped corpus build via file list (avoids ARG_MAX on big diffs)
+git diff --name-only master | grep '\.das$' > /tmp/pr.txt
+bin/daslang utils/detect-dupe/main.das -- --paths-from /tmp/pr.txt --export-functions pr.json
 
 # git pipeline against the baseline
 git diff --name-only master | grep '\.das$' | \

--- a/skills/detect_dupe.md
+++ b/skills/detect_dupe.md
@@ -34,6 +34,17 @@ mcp__daslang__export_corpus(paths="daslib,utils,tests", out="corpus.json")
 
 Build the corpus once over the body of code you want to compare against. Re-run when the code drifts enough that stale matches become a problem.
 
+`workers="0"` parallelizes across hardware threads (auto). `workers="1"` keeps the run sequential. The output JSON is byte-identical across worker counts — the file list is sorted before chunking, and shards are merged in chunk-index order. Below 16 input files the export stays sequential regardless (child-process startup dominates).
+
+`paths_file="<path>"` scopes the export to an explicit precomputed list — useful for PR-scoped runs:
+
+```
+git diff --name-only master | grep '\.das$' > /tmp/pr.txt
+mcp__daslang__export_corpus(paths_file="/tmp/pr.txt", out="pr.json")
+```
+
+`paths_file` composes with `paths` (union, deduped). Use it whenever you'd otherwise hit ARG_MAX with thousands of comma-separated entries.
+
 Envelope:
 
 ```json
@@ -92,6 +103,8 @@ The CLI at `utils/detect-dupe/main.das` supports modes the MCP tools don't expos
 - **B1 baseline / CI gate** — `--baseline <corpus.json> --check`. Records absent from the baseline are tagged candidates; non-zero exit when any cluster/pair survives.
 - **`--baseline-strict`** — drops clusters whose canonical was already in the baseline; only fully-new canonicals survive.
 - **`--against-from-stdin`** — read newline-delimited candidate paths from stdin, e.g. piped from `git diff --name-only`.
+- **`--paths-from <file>` / `--paths-stdin`** — read the *primary* file list from a file or stdin (skips blank lines and `#`-comments). Composes with `-p`. Use the file form when you'd hit ARG_MAX with thousands of entries; the stdin form to plug into `git diff --name-only` pipelines for PR-scoped corpus builds.
+- **`-j / --workers N`** — parallel `--export-functions` across N child detect-dupe processes. 0 (default) = hardware threads. Output is byte-identical to a sequential run (sorted-then-chunked, shards merged in order). Below 16 files the export stays sequential.
 - **`-L / --lambdas-only`** — cluster lambda bodies instead of top-level functions; useful for finding duplicated dastest `run` lambdas.
 - **`--min-tokens N`** — drop trivial wrappers (default 8).
 - **`--no-fuzzy`** — exact clusters only, faster on large corpora.
@@ -99,13 +112,24 @@ The CLI at `utils/detect-dupe/main.das` supports modes the MCP tools don't expos
 Quick recipes:
 
 ```sh
-# one-off corpus build (commit this)
+# one-off corpus build (commit this) — parallel by default for big runs
 bin/Release/daslang.exe utils/detect-dupe/main.das -- -p tests --export-functions tests_baseline.json
+
+# explicit worker count (1 = sequential)
+bin/Release/daslang.exe utils/detect-dupe/main.das -- -p tests -j 8 --export-functions tests_baseline.json
 
 # CI gate: flag any new structural duplicates introduced by a PR
 bin/Release/daslang.exe utils/detect-dupe/main.das -- -p tests --baseline tests_baseline.json --check
 
-# git pipeline against the baseline
+# PR-scoped corpus build via file list (avoids ARG_MAX on big diffs)
+git diff --name-only master | grep '\.das$' > /tmp/pr.txt
+bin/Release/daslang.exe utils/detect-dupe/main.das -- --paths-from /tmp/pr.txt --export-functions pr.json
+
+# Same thing piped via stdin
+git diff --name-only master | grep '\.das$' | \
+    bin/Release/daslang.exe utils/detect-dupe/main.das -- --paths-stdin --export-functions pr.json
+
+# git pipeline against the baseline (detect_duplicates flow, B2 mode)
 git diff --name-only master | grep '\.das$' | \
     bin/Release/daslang.exe utils/detect-dupe/main.das -- \
         --import-functions tests_baseline.json --against-from-stdin

--- a/utils/detect-dupe/README.md
+++ b/utils/detect-dupe/README.md
@@ -27,6 +27,11 @@ review.
 ./bin/daslang utils/detect-dupe/main.das -- -p daslib --no-fuzzy --min-tokens 32
 ./bin/daslang utils/detect-dupe/main.das -- -p tests -L --min-tokens 16    # cluster dastest run() bodies
 ./bin/daslang utils/detect-dupe/main.das -- -p tests --keep all            # disable pattern filter (legacy view)
+./bin/daslang utils/detect-dupe/main.das -- -p daslib -p tests -j 8 --export-functions corpus.json
+                                                                            # parallel export across 8 child processes
+git diff --name-only master | grep '\.das$' \
+  | ./bin/daslang utils/detect-dupe/main.das -- --paths-stdin --export-functions pr.json
+                                                                            # PR-scoped export
 ./bin/daslang utils/detect-dupe/main.das -- -?
 ```
 
@@ -36,7 +41,10 @@ Flags:
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `-p / --path` | required | File or directory to scan; repeatable |
+| `-p / --path` | required* | File or directory to scan; repeatable. `*` one of `-p`, `--paths-from`, `--paths-stdin` is required (or `--import-functions` / `--against`) |
+| `--paths-from` | (off) | Read newline-delimited paths from a file (`#`-comments and blank lines skipped). Composes with `-p`. Each entry can be a file or directory; directories recurse |
+| `--paths-stdin` | off | Read newline-delimited paths from stdin (`#`-comments and blank lines skipped). Composes with `-p`. Mutually exclusive with `--against-from-stdin` (one stdin reader per run) |
+| `-j / --workers` | 0 (auto) | Worker count for parallel `--export-functions` runs. 0 = hardware threads. 1 = sequential. Files are sorted, split into N contiguous chunks, each compiled by a child detect-dupe process; shards are merged in chunk-index order so output is byte-identical across worker counts. Below 16 input files the export stays sequential regardless. Ignored without `--export-functions` |
 | `-t / --threshold` | 0.7 | Fuzzy similarity floor (0..1). Score is `sqrt(jaccard × len_ratio)` plus a hard `len_ratio ≥ threshold` gate |
 | `-n / --top` | 20 | Top-N entries shown in stdout summary |
 | `--json` | (off) | Path for full JSON report |

--- a/utils/detect-dupe/exchange.das
+++ b/utils/detect-dupe/exchange.das
@@ -62,18 +62,16 @@ def public derive_sig_and_count(var rec : FuncRecord; want_sigs : bool; min_toke
 
 
 def public write_export(records : array<FuncRecord>; path : string) : bool {
-    var env = ExportEnvelope()
-    env.schema_version = EXCHANGE_SCHEMA_VERSION
+    var env = ExportEnvelope(schema_version = EXCHANGE_SCHEMA_VERSION)
     env.functions |> reserve(length(records))
     for (rec in records) {
-        var ef : ExportedFunction
-        ef.name := rec.ref.name
-        ef.file := rec.ref.file
-        ef.line = rec.ref.line
-        ef.end_line = rec.ref.end_line
-        ef.is_lambda = rec.ref.is_lambda
-        ef.canonical := rec.canonical
-        env.functions |> emplace(ef)
+        env.functions |> emplace(ExportedFunction(
+            name = rec.ref.name,
+            file = rec.ref.file,
+            line = rec.ref.line,
+            end_line = rec.ref.end_line,
+            is_lambda = rec.ref.is_lambda,
+            canonical = rec.canonical))
     }
     let body = sprint_json(env, true)
     var ok = false
@@ -83,6 +81,54 @@ def public write_export(records : array<FuncRecord>; path : string) : bool {
         }
         ok = true
         fw |> fprint(body)
+    }
+    return ok
+}
+
+
+// Merge N shard ExportEnvelope JSON files (each produced by `write_export`)
+// into a single envelope written to `out_path`. Functions are concatenated
+// in the order shards are listed — caller controls determinism by listing
+// shards in stable chunk-index order. Used by the parallel `--workers`
+// path: each child writes its own shard, the parent merges in order.
+//
+// Strict: any unreadable shard, parse failure, or schema_version mismatch
+// fails the whole merge (no partial output). Same gate `read_import` uses.
+def public merge_envelope_files(shard_paths : array<string>; out_path : string;
+                                var error : string&) : bool {
+    var merged = ExportEnvelope()
+    merged.schema_version = EXCHANGE_SCHEMA_VERSION
+    for (p in shard_paths) {
+        let text = fread(p)
+        if (empty(text)) {
+            error := "could not read shard (empty or missing): {p}"
+            return false
+        }
+        var env = ExportEnvelope()
+        if (!sscan_json(text, env)) {
+            error := "could not parse shard JSON: {p}"
+            return false
+        }
+        if (env.schema_version != EXCHANGE_SCHEMA_VERSION) {
+            error := "shard schema_version {env.schema_version} (expected {EXCHANGE_SCHEMA_VERSION}): {p}"
+            return false
+        }
+        merged.functions |> reserve(length(merged.functions) + length(env.functions))
+        for (ef in env.functions) {
+            merged.functions |> emplace(ef)
+        }
+    }
+    let body = sprint_json(merged, true)
+    var ok = false
+    fopen(out_path, "wb") $(fw) {
+        if (fw == null) {
+            return
+        }
+        ok = true
+        fw |> fprint(body)
+    }
+    if (!ok) {
+        error := "could not write merged envelope to {out_path}"
     }
     return ok
 }

--- a/utils/detect-dupe/main.das
+++ b/utils/detect-dupe/main.das
@@ -5,6 +5,7 @@ require daslib/clargs
 require daslib/ast
 require daslib/ast_boost
 require daslib/fio
+require daslib/jobque_boost
 require daslib/strings_boost
 require math
 require strings
@@ -21,6 +22,16 @@ struct Config {
     @clarg_short = "p"
     @clarg_doc = "Path(s) to scan (file or directory). Repeatable."
     path : array<string>
+
+    @clarg_doc = "Read newline-delimited paths from a file (#-comments and blank lines skipped). Composes with -p; can be combined with --paths-stdin. Each entry can be a file or directory; directories recurse via the same scanner as -p."
+    paths_from : string
+
+    @clarg_doc = "Read newline-delimited paths from stdin (#-comments and blank lines skipped). Composes with -p / --paths-from. Mutually exclusive with --against-from-stdin (one stdin reader at a time)."
+    paths_stdin : bool
+
+    @clarg_short = "j"
+    @clarg_doc = "Worker count for parallel --export-functions runs. 0 = auto (= hardware threads). 1 = sequential. Files are sorted, split into N contiguous chunks, each compiled by a child detect-dupe process; shards merged in chunk-index order so output is byte-identical across worker counts. Below 16 input files the export stays sequential regardless. Ignored without --export-functions."
+    workers : int
 
     @clarg_short = "t"
     @clarg_doc = "Fuzzy similarity threshold 0..1 (default 0.7)"
@@ -83,24 +94,6 @@ struct Config {
 }
 
 
-// Read newline-delimited paths from stdin. Used by --against-from-stdin
-// to plug into shell pipelines: `git diff --name-only master |
-// daslang utils/detect-dupe/main.das -- --against-from-stdin
-// --import-functions corpus.json`. Skips blank lines.
-def read_stdin_paths(var paths : array<string>) {
-    let f = fstdin()
-    if (f == null) {
-        return
-    }
-    while (!feof(f)) {
-        let line = fgets(f) |> strip
-        if (!empty(line)) {
-            paths |> push(line)
-        }
-    }
-}
-
-
 // Expand each `--against` argument (file or directory) into a normalized
 // set of `.das` file paths. Reuses scan_das_files so the same skip
 // rules (`builtin.das`, debugger/profiler) apply.
@@ -112,7 +105,7 @@ def resolve_against_files(against : array<string>; from_stdin : bool;
         raw |> push(p)
     }
     if (from_stdin) {
-        read_stdin_paths(raw)
+        read_path_lines(fstdin(), raw)
     }
     var cache : table<string; void?>
     var files : array<string>
@@ -181,6 +174,223 @@ def strict_drop_baseline_clusters(var clusters : array<Cluster>;
 }
 
 
+// Below this many input files, parallel export is a loss — each child
+// pays a daslang startup cost (a few hundred ms), so 16 files split 8
+// ways is slower than running sequentially in one process. Tune by
+// re-timing daslib (~80 files) and tests/language (~600 files) if the
+// startup cost shifts materially.
+let PARALLEL_THRESHOLD = 16
+
+
+def should_parallelize(n_files : int; workers_setting : int) : bool {
+    if (workers_setting == 1) {
+        return false
+    }
+    return n_files >= PARALLEL_THRESHOLD
+}
+
+
+def compute_worker_count(n_files : int; workers_setting : int) : int {
+    var w = workers_setting
+    if (w == 0) {
+        w = get_total_hw_threads()
+        if (w < 1) {
+            w = 1
+        }
+    }
+    if (w > n_files) {
+        w = n_files
+    }
+    if (w < 1) {
+        w = 1
+    }
+    return w
+}
+
+
+// One pre-built work item per chunk. argv is the full popen_argv
+// vector (including the daslang exe + main.das path) so workers don't
+// have to know anything about the parent's invocation.
+struct ShardInput {
+    index : int
+    chunk_path : string
+    shard_path : string
+    argv : array<string>
+}
+
+
+struct ShardResult {
+    index : int
+    exit_code : int
+    stdout : string
+}
+
+
+// Lay out chunk + shard temp paths next to the user's --export-functions
+// output. Avoids relying on $TMPDIR / %TEMP%, and the path the caller
+// supplied is by definition writable.
+def shard_path_for(out_path : string; tag : string; kind : string; index : int) : string {
+    return "{out_path}.{tag}.{kind}-{index}"
+}
+
+
+def run_parallel_export(files : array<string>; cfg : Config) {
+    let workers = compute_worker_count(length(files), cfg.workers)
+    let total = length(files)
+    let raw_args <- get_command_line_arguments()
+    if (length(raw_args) < 2) {
+        to_log(LOG_ERROR, "error: --workers requires `daslang main.das` invocation (raw_args has {length(raw_args)} entries)\n")
+        panic("detect-dupe parallel export failed: cannot self-spawn")
+    }
+    let exe = raw_args[0]
+    let script = raw_args[1]
+    let tag = "{ref_time_ticks()}"
+
+    let chunks <- chunk_files(files, workers)
+    let n_chunks = length(chunks)
+
+    var inputs : array<ShardInput>
+    inputs |> reserve(n_chunks)
+    var chunk_paths : array<string>
+    chunk_paths |> reserve(n_chunks)
+    var shard_paths : array<string>
+    shard_paths |> reserve(n_chunks)
+    for (k in range(n_chunks)) {
+        let cp = shard_path_for(cfg.export_functions, tag, "chunk", k) + ".txt"
+        let sp = shard_path_for(cfg.export_functions, tag, "shard", k) + ".json"
+        var write_ok = false
+        fopen(cp, "wb") $(fw) {
+            if (fw == null) {
+                return
+            }
+            write_ok = true
+            for (entry in chunks[k]) {
+                fw |> fprint("{entry}\n")
+            }
+        }
+        if (!write_ok) {
+            for (p in chunk_paths) {
+                remove(p)
+            }
+            to_log(LOG_ERROR, "error: could not write chunk file {cp}\n")
+            panic("detect-dupe parallel export failed: chunk write")
+        }
+        chunk_paths |> push(cp)
+        shard_paths |> push(sp)
+        var argv : array<string>
+        argv |> reserve(12)
+        argv |> push(exe)
+        argv |> push(script)
+        argv |> push("--")
+        argv |> push("--paths-from")
+        argv |> push(cp)
+        argv |> push("--export-functions")
+        argv |> push(sp)
+        argv |> push("--workers")
+        argv |> push("1")
+        argv |> push("--min-tokens")
+        argv |> push("{cfg.min_tokens}")
+        if (cfg.lambdas_only) {
+            argv |> push("--lambdas-only")
+        }
+        if (cfg.no_fuzzy) {
+            argv |> push("--no-fuzzy")
+        }
+        inputs |> emplace(ShardInput(
+            index = k,
+            chunk_path = cp,
+            shard_path = sp,
+            argv <- argv))
+    }
+
+    to_log(LOG_INFO, "parallel export: {n_chunks} worker(s) over {total} file(s)\n")
+
+    var results : array<ShardResult>
+    results |> resize(n_chunks)
+    for (i in range(n_chunks)) {
+        results[i].index = i
+        results[i].exit_code = -1
+    }
+
+    with_channel(n_chunks) $(inCh) {
+        with_channel(n_chunks) $(outCh) {
+            with_job_status(n_chunks) $(done) {
+                for (_t in range(n_chunks)) {
+                    new_thread <| @ {
+                        for_each_clone(inCh) $(input : ShardInput#) {
+                            var output : string
+                            let exit_code = unsafe(popen_argv(input.argv, 0.0, $(f) {
+                                if (f != null) {
+                                    output := unsafe(fread_to_eof(f))
+                                }
+                            }))
+                            outCh |> push_clone(ShardResult(
+                                index = input.index,
+                                exit_code = exit_code,
+                                stdout = output))
+                            outCh |> notify()
+                        }
+                        inCh |> release()
+                        outCh |> release()
+                        done |> notify_and_release()
+                    }
+                }
+                for (inp in inputs) {
+                    inCh |> push_clone(inp)
+                    inCh |> notify()
+                }
+                for (r in each_clone(outCh, type<ShardResult>)) {
+                    if (r.index >= 0 && r.index < length(results)) {
+                        results[r.index].index = r.index
+                        results[r.index].exit_code = r.exit_code
+                        results[r.index].stdout := r.stdout
+                    }
+                }
+                done |> join()
+            }
+        }
+    }
+
+    var any_failed = false
+    for (k in range(n_chunks)) {
+        let r = results[k]
+        if (!empty(r.stdout)) {
+            for (line in split(r.stdout, "\n")) {
+                if (!empty(line)) {
+                    to_log(LOG_INFO, "[worker {k}] {line}\n")
+                }
+            }
+        }
+        if (r.exit_code != 0) {
+            to_log(LOG_ERROR, "worker {k} failed (exit code {r.exit_code})\n")
+            any_failed = true
+        }
+    }
+
+    for (p in chunk_paths) {
+        remove(p)
+    }
+
+    if (any_failed) {
+        for (p in shard_paths) {
+            remove(p)
+        }
+        panic("detect-dupe parallel export failed: at least one worker exited non-zero")
+    }
+
+    var merr : string
+    let merged = merge_envelope_files(shard_paths, cfg.export_functions, merr)
+    for (p in shard_paths) {
+        remove(p)
+    }
+    if (!merged) {
+        to_log(LOG_ERROR, "error: {merr}\n")
+        panic("detect-dupe parallel export failed: shard merge")
+    }
+    to_log(LOG_INFO, "merged {n_chunks} shard(s) into {cfg.export_functions}\n")
+}
+
+
 [export]
 def main() {
     var cfg = Config()
@@ -198,8 +408,11 @@ def main() {
     let exporting = !empty(cfg.export_functions)
     let has_against = length(cfg.against) > 0 || cfg.against_from_stdin
     let has_baseline = !empty(cfg.baseline)
-    if (importing && length(cfg.path) > 0) {
-        to_log(LOG_ERROR, "error: --import-functions and --path are mutually exclusive\n")
+    let has_paths_input = (length(cfg.path) > 0
+        || !empty(cfg.paths_from)
+        || cfg.paths_stdin)
+    if (importing && has_paths_input) {
+        to_log(LOG_ERROR, "error: --import-functions is mutually exclusive with --path / --paths-from / --paths-stdin\n")
         return
     }
     if (importing && exporting) {
@@ -210,13 +423,21 @@ def main() {
         to_log(LOG_ERROR, "error: --export-functions is incompatible with --against / --baseline (export captures the raw corpus, not a filtered view)\n")
         return
     }
+    if (cfg.paths_stdin && cfg.against_from_stdin) {
+        to_log(LOG_ERROR, "error: --paths-stdin and --against-from-stdin both consume stdin; only one is allowed per run\n")
+        return
+    }
     if (cfg.baseline_strict && !has_baseline) {
         to_log(LOG_ERROR, "error: --baseline-strict requires --baseline\n")
         return
     }
-    if (!importing && !has_against && length(cfg.path) == 0) {
-        to_log(LOG_ERROR, "error: at least one --path is required (or pass --import-functions, or --against)\n\n")
+    if (!importing && !has_against && !has_paths_input) {
+        to_log(LOG_ERROR, "error: at least one of --path / --paths-from / --paths-stdin is required (or pass --import-functions, or --against)\n\n")
         print_help(get_command_info(type<Config>), "detect-dupe")
+        return
+    }
+    if (cfg.workers < 0) {
+        to_log(LOG_ERROR, "error: --workers must be >= 0, got {cfg.workers}\n")
         return
     }
     if (cfg.threshold < 0.0f || cfg.threshold > 1.0f) {
@@ -272,35 +493,88 @@ def main() {
             }
         }
     } else {
+        var seeds : array<string>
+        seeds |> reserve(length(cfg.path))
+        for (p in cfg.path) {
+            seeds |> push(p)
+        }
+        if (!empty(cfg.paths_from)) {
+            var perr : string
+            if (!read_path_lines_from_file(cfg.paths_from, seeds, perr)) {
+                to_log(LOG_ERROR, "error: {perr}\n")
+                return
+            }
+        }
+        if (cfg.paths_stdin) {
+            read_path_lines(fstdin(), seeds)
+        }
+
         var files : array<string>
         var cache : table<string; void?>
-        for (p in cfg.path) {
+        for (p in seeds) {
             scan_das_files(p, files, cache)
         }
         if (length(files) == 0 && !has_against) {
             to_log(LOG_ERROR, "error: no .das files found under given paths\n")
             return
         }
-        if (length(files) > 0) {
-            to_log(LOG_INFO, "scanning {length(files)} file(s)...\n")
+        // Sort the file list before any compile happens. Two reasons:
+        //   * parallel mode chunks contiguously, so deterministic input
+        //     order is required for byte-identical output across worker
+        //     counts.
+        //   * sequential mode used to follow filesystem-iteration order,
+        //     which is platform-dependent. Sorting once unifies both.
+        sort(files)
+
+        // Drop expect-directive fixtures once, before deciding sequential
+        // vs parallel. The parallel-mode threshold check has to run
+        // against the *compilable* count — otherwise an input list
+        // dominated by fixtures (e.g. tests/ has dozens of expect-broken
+        // files) might trip a 16-file gate while the real work is
+        // sub-threshold, paying child-process startup for nothing.
+        // Sequential mode also benefits: no per-iteration I/O for the
+        // expect-check, just compile the filtered list.
+        var compile_files : array<string>
+        compile_files |> reserve(length(files))
+        var n_skipped = 0
+        for (f in files) {
+            if (has_expect_directive(f)) {
+                n_skipped++
+                continue
+            }
+            compile_files |> push(f)
+        }
+        if (n_skipped > 0) {
+            to_log(LOG_INFO, "{n_skipped} file(s) skipped (expect-directive)\n")
+        }
+        files_scanned = length(files)
+
+        // Parallel export fast-path: skip the in-process compile loop
+        // entirely. Workers see the pre-filtered list, so they don't
+        // waste startup cost on fixtures.
+        if (exporting && should_parallelize(length(compile_files), cfg.workers)) {
+            if (length(compile_files) == 0) {
+                to_log(LOG_ERROR, "error: every input file contains an `expect` directive; nothing to export\n")
+                panic("detect-dupe export failed: no compilable files")
+            }
+            run_parallel_export(compile_files, cfg)
+            return
+        }
+
+        if (length(compile_files) > 0) {
+            to_log(LOG_INFO, "scanning {length(compile_files)} file(s)...\n")
         }
 
         var n_failed = 0
-        var n_skipped = 0
-        for (i in range(length(files))) {
-            let file = files[i]
+        for (i in range(length(compile_files))) {
+            let file = compile_files[i]
             if (cfg.verbose) {
-                to_log(LOG_INFO, "[{i + 1}/{length(files)}] {file}\n")
-            }
-            if (has_expect_directive(file)) {
-                n_skipped++
-                continue
+                to_log(LOG_INFO, "[{i + 1}/{length(compile_files)}] {file}\n")
             }
             if (!compile_and_collect(file, records, seen_loc, cfg.verbose, cfg.lambdas_only, want_sigs, min_tokens)) {
                 n_failed++
             }
         }
-        files_scanned = length(files)
         to_log(LOG_INFO, "collected {length(records)} function record(s); {n_failed} compile failure(s), {n_skipped} skipped (expect-directive)\n")
 
         if (exporting) {
@@ -414,11 +688,13 @@ def main() {
     let skip_counts <- apply_pattern_filter(records, kept_set, keep_all, cfg.verbose)
     if (length(skip_counts) > 0) {
         var skip_pairs : array<tuple<string; int>>
+        skip_pairs |> reserve(length(skip_counts))
         for (k, v in keys(skip_counts), values(skip_counts)) {
             skip_pairs |> push((k, v))
         }
         sort(skip_pairs) <| $(a, b) => a._0 < b._0
         var parts : array<string>
+        parts |> reserve(length(skip_pairs))
         for (kv in skip_pairs) {
             parts |> push("{kv._1} {kv._0}")
         }

--- a/utils/detect-dupe/pipeline.das
+++ b/utils/detect-dupe/pipeline.das
@@ -4,6 +4,7 @@ require daslib/ast
 require daslib/ast_boost
 require daslib/fio
 require daslib/strings_boost
+require math
 require strings
 require canonical
 require cluster
@@ -22,6 +23,87 @@ require patterns
 // paths to compile. Lives here (rather than in `main.das`) so MCP tools
 // — which can't shell out to the CLI — can build a corpus end-to-end
 // from inside the same process.
+
+// Read newline-delimited paths from `f` (either `fstdin()` for the
+// `--paths-stdin`/`--against-from-stdin` flows, or a freshly-opened file
+// for `--paths-from`). Skips blank lines and `#`-prefixed comments so
+// callers can hand-roll a path list with annotations. Lives here (rather
+// than main.das) so the unit tests can exercise it directly without
+// shelling out to a subprocess.
+def public read_path_lines(f : FILE const?; var paths : array<string>) {
+    if (f == null) {
+        return
+    }
+    while (!feof(f)) {
+        let line = fgets(f) |> strip
+        if (empty(line)) {
+            continue
+        }
+        if (line |> starts_with("#")) {
+            continue
+        }
+        paths |> push(line)
+    }
+}
+
+
+// Read newline-delimited paths from a file. Wraps `read_path_lines` and
+// returns false (with `error` populated) if the file can't be opened, so
+// the caller can emit a usage error rather than silently producing an
+// empty seed list.
+def public read_path_lines_from_file(path : string; var paths : array<string>;
+                                     var error : string&) : bool {
+    var ok = false
+    fopen(path, "rb") $(f) {
+        if (f == null) {
+            return
+        }
+        ok = true
+        read_path_lines(f, paths)
+    }
+    if (!ok) {
+        error := "could not open paths-from file: {path}"
+    }
+    return ok
+}
+
+
+// Split a flat file list into N contiguous chunks for parallel export.
+// Contiguous (not round-robin) so each worker's shard preserves
+// file:line ordering, and so the merged envelope is byte-identical to
+// the sequential one. `n_chunks` is clamped to `[1, length(files)]`.
+// Empty trailing chunks are NOT emitted: when `length(files) <
+// n_chunks` the result has exactly `length(files)` chunks.
+def public chunk_files(files : array<string>; n_chunks : int) : array<array<string>> {
+    var out : array<array<string>>
+    let total = length(files)
+    if (total == 0) {
+        return <- out
+    }
+    var n = n_chunks
+    if (n < 1) {
+        n = 1
+    }
+    if (n > total) {
+        n = total
+    }
+    let per_chunk = (total + n - 1) / n
+    for (k in range(n)) {
+        let start_idx = k * per_chunk
+        if (start_idx >= total) {
+            break
+        }
+        let end_excl = min((k + 1) * per_chunk, total)
+        var chunk : array<string>
+        chunk |> reserve(end_excl - start_idx)
+        for (j in range(start_idx, end_excl)) {
+            chunk |> push(files[j])
+        }
+        out |> emplace(chunk)
+    }
+    return <- out
+}
+
 
 // `daslib/debugger.das` and `daslib/profiler.das` install thread-local
 // agents at compile time; the second install in the same process throws

--- a/utils/detect-dupe/test_detect_dupe.das
+++ b/utils/detect-dupe/test_detect_dupe.das
@@ -148,10 +148,7 @@ def test_tokenize_trailing_space(t : T?) {
 
 [test]
 def test_minhash_signature_length(t : T?) {
-    var toks : array<string>
-    toks |> push("alpha")
-    toks |> push("beta")
-    toks |> push("gamma")
+    let toks <- ["alpha", "beta", "gamma"]
     let sig <- minhash_signature(toks)
     t |> equal(length(sig), 64)
 }
@@ -161,8 +158,7 @@ def test_minhash_signature_length(t : T?) {
 def test_minhash_padding_for_short_input(t : T?) {
     // 1 token is below N_GRAM (=5) — padding kicks in so we still get
     // a stable 64-slot signature.
-    var toks : array<string>
-    toks |> push("only_one")
+    let toks <- ["only_one"]
     let sig <- minhash_signature(toks)
     t |> equal(length(sig), 64)
 }
@@ -172,6 +168,8 @@ def test_minhash_padding_for_short_input(t : T?) {
 def test_minhash_deterministic(t : T?) {
     var toks_a : array<string>
     var toks_b : array<string>
+    toks_a |> reserve(20)
+    toks_b |> reserve(20)
     for (i in range(20)) {
         toks_a |> push("token_{i}")
         toks_b |> push("token_{i}")
@@ -191,6 +189,7 @@ def test_minhash_deterministic(t : T?) {
 [test]
 def test_jaccard_identical(t : T?) {
     var toks : array<string>
+    toks |> reserve(15)
     for (i in range(15)) {
         toks |> push("t{i}")
     }
@@ -210,12 +209,9 @@ def test_jaccard_empty(t : T?) {
 
 [test]
 def test_jaccard_length_mismatch(t : T?) {
-    var toks : array<string>
-    toks |> push("x")
-    toks |> push("y")
+    let toks <- ["x", "y"]
     let sig <- minhash_signature(toks)
-    var short_sig : array<uint64>
-    short_sig |> push(0ul)
+    let short_sig <- [0ul]
     t |> equal(jaccard_estimate(sig, short_sig), 0.0f)
 }
 
@@ -227,6 +223,8 @@ def test_jaccard_unrelated_low(t : T?) {
     // estimate is far below "duplicate" territory.
     var toks_a : array<string>
     var toks_b : array<string>
+    toks_a |> reserve(30)
+    toks_b |> reserve(30)
     for (i in range(30)) {
         toks_a |> push("aaa_{i}")
         toks_b |> push("zzz_{i + 1000}")
@@ -242,12 +240,12 @@ def test_jaccard_unrelated_low(t : T?) {
 
 [test]
 def test_exact_groups_duplicates(t : T?) {
-    var records : array<FuncRecord>
-    records |> emplace <| make_record("a", "FN ARG <var_0> RET <var_0> ENDFN", 1, false)
-    records |> emplace <| make_record("b", "FN ARG <var_0> RET <var_0> ENDFN", 2, false)
-    records |> emplace <| make_record("c", "FN ARG <var_0> RET LIT ENDFN", 3, false)
-    records |> emplace <| make_record("d", "FN ARG <var_0> RET <var_0> ENDFN", 4, false)
-    var clusters <- exact_buckets(records, 0)
+    var records <- array<FuncRecord>(
+        <- make_record("a", "FN ARG <var_0> RET <var_0> ENDFN", 1, false),
+        <- make_record("b", "FN ARG <var_0> RET <var_0> ENDFN", 2, false),
+        <- make_record("c", "FN ARG <var_0> RET LIT ENDFN", 3, false),
+        <- make_record("d", "FN ARG <var_0> RET <var_0> ENDFN", 4, false))
+    let clusters <- exact_buckets(records, 0)
     // 3 records share canonical → 1 cluster of size 3; record "c" is
     // alone → not reported.
     t |> equal(length(clusters), 1)
@@ -261,12 +259,12 @@ def test_exact_groups_duplicates(t : T?) {
 
 [test]
 def test_exact_min_tokens_filter(t : T?) {
-    var records : array<FuncRecord>
-    records |> emplace <| make_record("a", "FN ENDFN", 1, false)            // 2 tokens
-    records |> emplace <| make_record("b", "FN ENDFN", 2, false)            // 2 tokens
-    records |> emplace <| make_record("c", "FN BODY BLK STMT ENDBLK ENDFN", 3, false)
-    records |> emplace <| make_record("d", "FN BODY BLK STMT ENDBLK ENDFN", 4, false)
-    var clusters <- exact_buckets(records, 5)
+    var records <- array<FuncRecord>(
+        <- make_record("a", "FN ENDFN", 1, false),                          // 2 tokens
+        <- make_record("b", "FN ENDFN", 2, false),                          // 2 tokens
+        <- make_record("c", "FN BODY BLK STMT ENDBLK ENDFN", 3, false),
+        <- make_record("d", "FN BODY BLK STMT ENDBLK ENDFN", 4, false))
+    let clusters <- exact_buckets(records, 5)
     // a/b at 2 tokens are below min_tokens=5; only c/d remain.
     t |> equal(length(clusters), 1)
     t |> equal(length(clusters[0].members), 2)
@@ -277,11 +275,11 @@ def test_exact_min_tokens_filter(t : T?) {
 
 [test]
 def test_exact_assigns_cluster_id(t : T?) {
-    var records : array<FuncRecord>
-    records |> emplace <| make_record("a", "FN X Y Z ENDFN", 1, false)
-    records |> emplace <| make_record("b", "FN X Y Z ENDFN", 2, false)
-    records |> emplace <| make_record("c", "FN P Q R ENDFN", 3, false)
-    var clusters <- exact_buckets(records, 0)
+    var records <- array<FuncRecord>(
+        <- make_record("a", "FN X Y Z ENDFN", 1, false),
+        <- make_record("b", "FN X Y Z ENDFN", 2, false),
+        <- make_record("c", "FN P Q R ENDFN", 3, false))
+    let clusters <- exact_buckets(records, 0)
     let i_a = find_record_by_name(records, "a")
     let i_b = find_record_by_name(records, "b")
     let i_c = find_record_by_name(records, "c")
@@ -296,7 +294,7 @@ def test_exact_assigns_cluster_id(t : T?) {
 def test_exact_singleton_not_reported(t : T?) {
     var records : array<FuncRecord>
     records |> emplace <| make_record("solo", "FN UNIQUE STREAM ENDFN", 1, false)
-    var clusters <- exact_buckets(records, 0)
+    let clusters <- exact_buckets(records, 0)
     t |> equal(length(clusters), 0)
 }
 
@@ -305,13 +303,13 @@ def test_exact_singleton_not_reported(t : T?) {
 
 [test]
 def test_sort_clusters_by_size(t : T?) {
-    var records : array<FuncRecord>
-    // Two clusters: AAA size 2, BBB size 3. After sort, BBB comes first.
-    records |> emplace <| make_record("a1", "FN AAA ENDFN", 1, false)
-    records |> emplace <| make_record("a2", "FN AAA ENDFN", 2, false)
-    records |> emplace <| make_record("b1", "FN BBB ENDFN", 3, false)
-    records |> emplace <| make_record("b2", "FN BBB ENDFN", 4, false)
-    records |> emplace <| make_record("b3", "FN BBB ENDFN", 5, false)
+    var records <- array<FuncRecord>(
+        // Two clusters: AAA size 2, BBB size 3. After sort, BBB comes first.
+        <- make_record("a1", "FN AAA ENDFN", 1, false),
+        <- make_record("a2", "FN AAA ENDFN", 2, false),
+        <- make_record("b1", "FN BBB ENDFN", 3, false),
+        <- make_record("b2", "FN BBB ENDFN", 4, false),
+        <- make_record("b3", "FN BBB ENDFN", 5, false))
     var clusters <- exact_buckets(records, 0)
     sort_clusters(clusters)
     t |> equal(length(clusters), 2)
@@ -358,7 +356,7 @@ def test_fuzzy_near_duplicates_pair(t : T?) {
     let canon_b = "FN ARG <var_0> TYP BODY BLK STMT LET LET_VAR <var_1> LIT STMT FOR FOR_VAR <var_2> <var_0> FOR_BODY BLK STMT OP2:*= <var_1> <var_2> ENDBLK STMT RET <var_1> ENDBLK ENDFN"
     records |> emplace <| make_record("a", canon_a, 1, true)
     records |> emplace <| make_record("b", canon_b, 2, true)
-    var pairs <- fuzzy_pairs(records, 0.7f, 0)
+    let pairs <- fuzzy_pairs(records, 0.7f, 0)
     t |> equal(length(pairs), 1)
     t |> success(pairs[0].similarity >= 0.7f, "similarity above threshold, got {pairs[0].similarity}")
 }
@@ -372,7 +370,7 @@ def test_fuzzy_skips_identical(t : T?) {
     let canon = "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN"
     records |> emplace <| make_record("a", canon, 1, true)
     records |> emplace <| make_record("b", canon, 2, true)
-    var pairs <- fuzzy_pairs(records, 0.7f, 0)
+    let pairs <- fuzzy_pairs(records, 0.7f, 0)
     t |> equal(length(pairs), 0)
 }
 
@@ -385,9 +383,9 @@ def test_fuzzy_skips_same_cluster(t : T?) {
     let canon = "FN ARG <var_0> TYP BODY BLK STMT RET OP2:+ <var_0> LIT ENDBLK ENDFN"
     records |> emplace <| make_record("a", canon, 1, true)
     records |> emplace <| make_record("b", canon, 2, true)
-    var clusters <- exact_buckets(records, 0)
+    let clusters <- exact_buckets(records, 0)
     t |> equal(length(clusters), 1)
-    var pairs <- fuzzy_pairs(records, 0.7f, 0)
+    let pairs <- fuzzy_pairs(records, 0.7f, 0)
     t |> equal(length(pairs), 0)
 }
 
@@ -396,26 +394,26 @@ def test_fuzzy_skips_same_cluster(t : T?) {
 def test_fuzzy_length_ratio_gate(t : T?) {
     // Very different lengths → length_ratio gate drops the pair regardless
     // of MinHash similarity.
-    var records : array<FuncRecord>
-    records |> emplace <| make_record(
-        "short",
-        "FN ARG <var_0> TYP BODY BLK STMT RET <var_0> ENDBLK ENDFN",
-        1, true)
-    records |> emplace <| make_record(
-        "long",
-        "FN ARG <var_0> TYP ARG <var_1> TYP ARG <var_2> TYP TYP BODY BLK STMT LET LET_VAR <var_3> LIT STMT FOR FOR_VAR <var_4> <var_0> FOR_BODY BLK STMT OP2:+= <var_3> <var_4> ENDBLK STMT FOR FOR_VAR <var_5> <var_1> FOR_BODY BLK STMT OP2:*= <var_3> <var_5> ENDBLK STMT RET <var_3> ENDBLK ENDFN",
-        2, true)
-    var pairs <- fuzzy_pairs(records, 0.7f, 0)
+    let records <- array<FuncRecord>(
+        <- make_record(
+            "short",
+            "FN ARG <var_0> TYP BODY BLK STMT RET <var_0> ENDBLK ENDFN",
+            1, true),
+        <- make_record(
+            "long",
+            "FN ARG <var_0> TYP ARG <var_1> TYP ARG <var_2> TYP TYP BODY BLK STMT LET LET_VAR <var_3> LIT STMT FOR FOR_VAR <var_4> <var_0> FOR_BODY BLK STMT OP2:+= <var_3> <var_4> ENDBLK STMT FOR FOR_VAR <var_5> <var_1> FOR_BODY BLK STMT OP2:*= <var_3> <var_5> ENDBLK STMT RET <var_3> ENDBLK ENDFN",
+            2, true))
+    let pairs <- fuzzy_pairs(records, 0.7f, 0)
     t |> equal(length(pairs), 0)
 }
 
 
 [test]
 def test_fuzzy_min_tokens_filter(t : T?) {
-    var records : array<FuncRecord>
-    records |> emplace <| make_record("a", "FN A B C ENDFN", 1, true)
-    records |> emplace <| make_record("b", "FN A B C ENDFN", 2, true)
-    var pairs <- fuzzy_pairs(records, 0.7f, 100)
+    let records <- array<FuncRecord>(
+        <- make_record("a", "FN A B C ENDFN", 1, true),
+        <- make_record("b", "FN A B C ENDFN", 2, true))
+    let pairs <- fuzzy_pairs(records, 0.7f, 100)
     t |> equal(length(pairs), 0)
 }
 
@@ -441,9 +439,9 @@ def make_temp_export_path(t : T?) : string {
 def test_export_import_basic(t : T?) {
     let path = make_temp_export_path(t)
     if (empty(path)) return
-    var records : array<FuncRecord>
-    records |> emplace <| make_record("alpha", "FN A B C ENDFN", 10, false)
-    records |> emplace <| make_record("beta", "FN X Y Z ENDFN", 20, false)
+    var records <- array<FuncRecord>(
+        <- make_record("alpha", "FN A B C ENDFN", 10, false),
+        <- make_record("beta", "FN X Y Z ENDFN", 20, false))
     records[1].ref.is_lambda = true
 
     let wrote = write_export(records, path)
@@ -595,6 +593,251 @@ def test_import_rejects_zero_line(t : T?) {
     t |> success(ok, "envelope is valid; line=0 record is dropped as malformed")
     t |> equal(length(loaded), 0)
     remove(path)
+}
+
+
+// ── path-list helpers (read_path_lines) ──────────────────────────────
+
+[test]
+def test_read_path_lines_basic(t : T?) {
+    let path = make_temp_export_path(t)
+    if (empty(path)) return
+    fopen(path, "wb") $(fw) {
+        if (fw != null) {
+            fw |> fprint("# comment line\n")
+            fw |> fprint("\n")
+            fw |> fprint("daslib/foo.das\n")
+            fw |> fprint("    \n")
+            fw |> fprint("  daslib/bar.das  \n")
+            fw |> fprint("# trailing comment\n")
+        }
+    }
+    var paths : array<string>
+    var err : string
+    let ok = read_path_lines_from_file(path, paths, err)
+    t |> success(ok, "read_path_lines_from_file returned true; err={err}")
+    t |> equal(length(paths), 2)
+    t |> equal(paths[0], "daslib/foo.das")
+    t |> equal(paths[1], "daslib/bar.das")
+    remove(path)
+}
+
+
+[test]
+def test_read_path_lines_missing_file(t : T?) {
+    let path = make_temp_export_path(t)
+    if (empty(path)) return
+    remove(path)
+    var paths : array<string>
+    var err : string
+    let ok = read_path_lines_from_file(path, paths, err)
+    t |> success(!ok, "read_path_lines_from_file returns false for missing file")
+    t |> success(!empty(err), "error message set: {err}")
+    t |> equal(length(paths), 0)
+}
+
+
+// ── input-file dedup (scan_das_files cache) ──────────────────────────
+//
+// `scan_das_files` shares a cache table across multiple seed paths so
+// overlapping `-p` + `--paths-from` entries don't double-count. This
+// is the load-bearing invariant for the union semantics in main.das.
+
+let SCAN_FIXTURE_DIR = "utils/detect-dupe/fixture"
+
+
+[test]
+def test_scan_das_files_dedup(t : T?) {
+    var files1 : array<string>
+    var cache1 : table<string; void?>
+    scan_das_files(SCAN_FIXTURE_DIR, files1, cache1)
+    let n1 = length(files1)
+    t |> success(n1 > 0, "fixture dir scan picked up at least one file")
+    if (n1 == 0) {
+        return
+    }
+    // Re-scan the same dir using the same cache — must yield zero new entries.
+    let before = length(files1)
+    scan_das_files(SCAN_FIXTURE_DIR, files1, cache1)
+    t |> equal(length(files1), before, "second scan with same cache adds nothing")
+    // Re-scan via a different seed (same dir) using the same cache.
+    var files2 : array<string>
+    scan_das_files(SCAN_FIXTURE_DIR, files2, cache1)
+    t |> equal(length(files2), 0, "second scan with different out-array but same cache yields zero")
+}
+
+
+// ── chunk_files ──────────────────────────────────────────────────────
+
+def synth_paths(n : int) : array<string> {
+    var out : array<string>
+    out |> reserve(n)
+    for (i in range(n)) {
+        out |> push("file_{i}.das")
+    }
+    return <- out
+}
+
+
+[test]
+def test_chunk_files_contiguous_and_complete(t : T?) {
+    let files <- synth_paths(11)
+    let chunks <- chunk_files(files, 4)
+    t |> equal(length(chunks), 4, "11 files / 4 workers => 4 chunks")
+    // Round-up per-chunk = ceil(11/4) = 3, last chunk shorter.
+    t |> equal(length(chunks[0]), 3)
+    t |> equal(length(chunks[1]), 3)
+    t |> equal(length(chunks[2]), 3)
+    t |> equal(length(chunks[3]), 2)
+    // Concat must equal original.
+    var rebuilt : array<string>
+    rebuilt |> reserve(11)
+    for (c in chunks) {
+        for (s in c) {
+            rebuilt |> push(s)
+        }
+    }
+    t |> equal(length(rebuilt), 11)
+    for (i in range(11)) {
+        t |> equal(rebuilt[i], "file_{i}.das")
+    }
+}
+
+
+[test]
+def test_chunk_files_workers_one(t : T?) {
+    let files <- synth_paths(7)
+    let chunks <- chunk_files(files, 1)
+    t |> equal(length(chunks), 1, "workers=1 => single chunk")
+    t |> equal(length(chunks[0]), 7)
+}
+
+
+[test]
+def test_chunk_files_workers_more_than_files(t : T?) {
+    let files <- synth_paths(3)
+    let chunks <- chunk_files(files, 8)
+    t |> equal(length(chunks), 3, "workers > files => one chunk per file, no empty trailers")
+    for (c in chunks) {
+        t |> equal(length(c), 1)
+    }
+}
+
+
+[test]
+def test_chunk_files_empty_input(t : T?) {
+    let files : array<string>
+    let chunks <- chunk_files(files, 4)
+    t |> equal(length(chunks), 0, "empty input => empty chunk list")
+}
+
+
+// ── merge_envelope_files ─────────────────────────────────────────────
+
+def write_shard(t : T?; functions : array<ExportedFunction>; schema : int) : string {
+    let path = make_temp_export_path(t)
+    if (empty(path)) return ""
+    var env = ExportEnvelope(schema_version = schema)
+    env.functions |> reserve(length(functions))
+    for (ef in functions) {
+        env.functions |> emplace(ExportedFunction(
+            name = ef.name,
+            file = ef.file,
+            line = ef.line,
+            end_line = ef.end_line,
+            is_lambda = ef.is_lambda,
+            canonical = ef.canonical))
+    }
+    let body = sprint_json(env, false)
+    fopen(path, "wb") $(fw) {
+        if (fw != null) {
+            fw |> fprint(body)
+        }
+    }
+    return path
+}
+
+
+def make_export_func(name : string; line : int) : ExportedFunction {
+    return ExportedFunction(
+        name = name,
+        file = "test.das",
+        line = line,
+        end_line = line + 5,
+        is_lambda = false,
+        canonical = "FN {name}")
+}
+
+
+[test]
+def test_merge_envelope_files_concat_in_order(t : T?) {
+    let s0 <- [make_export_func("alpha", 10), make_export_func("beta", 20)]
+    let s1 <- [make_export_func("gamma", 30)]
+    let s2 <- [make_export_func("delta", 40), make_export_func("epsilon", 50)]
+
+    let p0 = write_shard(t, s0, EXCHANGE_SCHEMA_VERSION)
+    let p1 = write_shard(t, s1, EXCHANGE_SCHEMA_VERSION)
+    let p2 = write_shard(t, s2, EXCHANGE_SCHEMA_VERSION)
+    if (empty(p0) || empty(p1) || empty(p2)) return
+
+    let out = make_temp_export_path(t)
+    if (empty(out)) return
+    let shards <- [p0, p1, p2]
+    var err : string
+    let ok = merge_envelope_files(shards, out, err)
+    t |> success(ok, "merge_envelope_files returned true; err={err}")
+
+    var loaded : array<FuncRecord>
+    var rerr : string
+    let read_ok = read_import(out, loaded, false, 0, rerr)
+    t |> success(read_ok, "read_import on merged file; err={rerr}")
+    t |> equal(length(loaded), 5)
+    t |> equal(loaded[0].ref.name, "alpha")
+    t |> equal(loaded[1].ref.name, "beta")
+    t |> equal(loaded[2].ref.name, "gamma")
+    t |> equal(loaded[3].ref.name, "delta")
+    t |> equal(loaded[4].ref.name, "epsilon")
+    remove(p0)
+    remove(p1)
+    remove(p2)
+    remove(out)
+}
+
+
+[test]
+def test_merge_envelope_files_rejects_bad_schema(t : T?) {
+    let good <- [make_export_func("ok", 10)]
+    let bad <- [make_export_func("nope", 20)]
+    let p_good = write_shard(t, good, EXCHANGE_SCHEMA_VERSION)
+    let p_bad = write_shard(t, bad, /*schema=*/ 99)
+    if (empty(p_good) || empty(p_bad)) return
+
+    let out = make_temp_export_path(t)
+    if (empty(out)) return
+    let shards <- [p_good, p_bad]
+    var err : string
+    let ok = merge_envelope_files(shards, out, err)
+    t |> success(!ok, "merge rejects bad schema_version")
+    t |> success(find(err, "schema_version") >= 0, "error mentions schema_version: {err}")
+    remove(p_good)
+    remove(p_bad)
+    remove(out)
+}
+
+
+[test]
+def test_merge_envelope_files_missing_shard(t : T?) {
+    let missing = make_temp_export_path(t)
+    if (empty(missing)) return
+    remove(missing)
+    let out = make_temp_export_path(t)
+    if (empty(out)) return
+    let shards <- [missing]
+    var err : string
+    let ok = merge_envelope_files(shards, out, err)
+    t |> success(!ok, "merge rejects missing shard")
+    t |> success(!empty(err), "error message set: {err}")
+    remove(out)
 }
 
 
@@ -772,8 +1015,8 @@ def test_pipeline_synth_exact_clusters(t : T?) {
 def test_pipeline_synth_fuzzy_pair(t : T?) {
     var records : array<FuncRecord>
     compile_fixture(SYNTH_FIXTURE, records, false, true)
-    var clusters <- exact_buckets(records, 0)
-    var pairs <- fuzzy_pairs(records, 0.7f, 0)
+    let clusters <- exact_buckets(records, 0)
+    let pairs <- fuzzy_pairs(records, 0.7f, 0)
     t |> equal(length(pairs), 1)
     let names_match = (
         (pairs[0].a.name == "loop_sum" && pairs[0].b.name == "loop_product") ||
@@ -1028,9 +1271,7 @@ def test_per_candidate_rollup_shape(t : T?) {
     var pairs <- fuzzy_pairs(records, 0.6f, 0, true)
     sort_pairs(pairs)
 
-    var rep : Report
-    rep.exact_clusters <- clusters
-    rep.fuzzy_pairs <- pairs
+    let rep = Report(exact_clusters <- clusters, fuzzy_pairs <- pairs)
 
     let cand_refs <- collect_candidate_refs(records)
     let pcr = build_per_candidate_report(rep, cand_refs, 5)

--- a/utils/mcp/protocol.das
+++ b/utils/mcp/protocol.das
@@ -428,13 +428,15 @@ def handle_tools_list(id_json : string) : string {
     ))
     result.tools |> emplace(make_tool(
         "export_corpus",
-        "Build a corpus.json from one or more .das files/dirs/globs. Output is the same shape `detect_duplicates` expects: a JSON dump of every user function's canonical token stream and source location. Run this once over a body of code (e.g. 'daslib', 'tests', or your project) to produce a corpus, then point `detect_duplicates` at it. Shells out to `daslang utils/detect-dupe/main.das` (daslang's `require` grammar can't use hyphenated path components, so the wrapper invokes the CLI as a subprocess).",
+        "Build a corpus.json from one or more .das files/dirs/globs. Output is the same shape `detect_duplicates` expects: a JSON dump of every user function's canonical token stream and source location. Run this once over a body of code (e.g. 'daslib', 'tests', or your project) to produce a corpus, then point `detect_duplicates` at it. Shells out to `daslang utils/detect-dupe/main.das` (daslang's `require` grammar can't use hyphenated path components, so the wrapper invokes the CLI as a subprocess). Pass `paths_file` to scope the export to an explicit precomputed list (e.g. files in a PR diff); pass `workers` to parallelize across child processes.",
         {
-            "paths" => PropertySchema(_type = "string", description = "Files, directories, or globs to scan. Comma- or newline-delimited. Directories are walked recursively. Skips `_*` directories, hidden directories, `builtin.das`, `daslib/debugger.das`, and `daslib/profiler.das`."),
+            "paths" => PropertySchema(_type = "string", description = "Files, directories, or globs to scan. Comma- or newline-delimited. Directories are walked recursively. Skips `_*` directories, hidden directories, `builtin.das`, `daslib/debugger.das`, and `daslib/profiler.das`. Optional when `paths_file` is given; otherwise required."),
+            "paths_file" => PropertySchema(_type = "string", description = "Path to a newline-delimited file of paths. Skips blank lines and lines starting with `#`. Composes with `paths` (union; deduped). Use this for PR-scoped runs where you'd otherwise hit ARG_MAX (e.g. piping `git diff --name-only` to a file)."),
             "out" => PropertySchema(_type = "string", description = "Output corpus.json path. Overwrites if it exists. Refuses to write a partial corpus when any input file fails to compile (matches the CLI's --export-functions behavior)."),
-            "min_tokens" => PropertySchema(_type = "string", description = "Minimum canonical-token count per record (default 0 — keep every user function). Records below the threshold are dropped at export time. Most callers should leave this at 0 and let `detect_duplicates --min-tokens` filter at query time.")
+            "min_tokens" => PropertySchema(_type = "string", description = "Minimum canonical-token count per record (default 0 — keep every user function). Records below the threshold are dropped at export time. Most callers should leave this at 0 and let `detect_duplicates --min-tokens` filter at query time."),
+            "workers" => PropertySchema(_type = "string", description = "Worker count for parallel compilation. 0 = auto (= hardware threads). 1 = sequential. Files are split into N contiguous chunks; each chunk is compiled by a child detect-dupe process; shards are merged in chunk-index order so the output is byte-identical across worker counts. Below 16 input files the export stays sequential regardless.")
         },
-        ["paths", "out"]
+        ["out"]
     ))
     result.tools |> emplace(make_tool(
         "detect_duplicates",
@@ -611,7 +613,7 @@ def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project : strin
     } elif (tool_name == "detect_duplicates") {
         return do_detect_duplicates(arg1, arg2, arg3, arg4, arg5, arg6)
     } elif (tool_name == "export_corpus") {
-        return do_export_corpus(arg1, arg2, arg3)
+        return do_export_corpus(arg1, arg2, arg3, arg4, arg5)
     } elif (tool_name == "judge_duplicates") {
         return do_judge_duplicates(arg1, arg2, arg3, arg4, arg5, arg6)
     } elif (tool_name == "find_dupe") {
@@ -806,14 +808,16 @@ def handle_tools_call(id_json : string; params : JsonValue?) : string {
         arg6 = get_string_arg(args, "keep")
     } elif (name == "export_corpus") {
         arg1 = get_string_arg(args, "paths")
-        if (empty(arg1)) {
-            return json_rpc_error(id_json, -32602, "missing 'paths' argument")
+        arg2 = get_string_arg(args, "paths_file")
+        if (empty(arg1) && empty(arg2)) {
+            return json_rpc_error(id_json, -32602, "missing input — provide 'paths' and/or 'paths_file'")
         }
-        arg2 = get_string_arg(args, "out")
-        if (empty(arg2)) {
+        arg3 = get_string_arg(args, "out")
+        if (empty(arg3)) {
             return json_rpc_error(id_json, -32602, "missing 'out' argument")
         }
-        arg3 = get_string_arg(args, "min_tokens")
+        arg4 = get_string_arg(args, "min_tokens")
+        arg5 = get_string_arg(args, "workers")
     } elif (name == "judge_duplicates") {
         arg1 = get_string_arg(args, "input")
         if (empty(arg1)) {

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -1352,8 +1352,11 @@ def test_lint_no_match(t : T?) {
 // ── detect_duplicates ────────────────────────────────────────────────
 
 
-def make_temp_corpus_file(t : T?; body : string) : string {
-    let r = create_temp_file_result("detect_dupe_mcp_test", ".json")
+// Generic write-temp-file helper: creates a unique temp file with `prefix`
+// and `ext`, writes `body` to it, returns the path. Returns "" and calls
+// `t |> failure` on temp-file allocation failure.
+def make_temp_text_file(t : T?; prefix : string; ext : string; body : string) : string {
+    let r = create_temp_file_result(prefix, ext)
     if (!(r is value)) {
         t |> failure("create_temp_file_result failed")
         return ""
@@ -1365,6 +1368,11 @@ def make_temp_corpus_file(t : T?; body : string) : string {
         }
     }
     return path
+}
+
+
+def make_temp_corpus_file(t : T?; body : string) : string {
+    return make_temp_text_file(t, "detect_dupe_mcp_test", ".json", body)
 }
 
 
@@ -1465,10 +1473,10 @@ def test_detect_duplicates_bad_schema(t : T?) {
 
 [test]
 def test_export_corpus_missing_paths(t : T?) {
-    t |> run("missing 'paths' arg returns error envelope") <| @(t : T?) {
+    t |> run("missing 'paths' / 'paths_file' returns error envelope") <| @(t : T?) {
         var text : string
         var is_error = false
-        let ok = parse_result(do_export_corpus("", "export_corpus_test_out.json", ""), text, is_error)
+        let ok = parse_result(do_export_corpus("", "", "export_corpus_test_out.json", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error")
         t |> success(find(text, "paths") >= 0, "should mention paths: {text}")
@@ -1481,7 +1489,7 @@ def test_export_corpus_missing_out(t : T?) {
     t |> run("missing 'out' arg returns error envelope") <| @(t : T?) {
         var text : string
         var is_error = false
-        let ok = parse_result(do_export_corpus("foo.das", "", ""), text, is_error)
+        let ok = parse_result(do_export_corpus("foo.das", "", "", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error")
         t |> success(find(text, "out") >= 0, "should mention out: {text}")
@@ -1494,7 +1502,7 @@ def test_export_corpus_no_match(t : T?) {
     t |> run("paths matching nothing yields error envelope") <| @(t : T?) {
         var text : string
         var is_error = false
-        let ok = parse_result(do_export_corpus("does_not_exist_xyzzy.das", "export_corpus_test_out.json", ""), text, is_error)
+        let ok = parse_result(do_export_corpus("does_not_exist_xyzzy.das", "", "export_corpus_test_out.json", "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(is_error, "should be error: {text}")
     }
@@ -1515,7 +1523,7 @@ def test_export_corpus_writes_envelope(t : T?) {
         // the placeholder in place is the intended path.
         var text : string
         var is_error = false
-        let ok = parse_result(do_export_corpus(fixture_path("_fixture_valid.das"), out_path, ""), text, is_error)
+        let ok = parse_result(do_export_corpus(fixture_path("_fixture_valid.das"), "", out_path, "", ""), text, is_error)
         t |> success(ok, "parse result JSON")
         t |> success(!is_error, "should NOT be error: {text}")
         t |> success(find(text, "\"exit_code\":0") >= 0, "envelope has exit_code 0: {text}")
@@ -1525,6 +1533,192 @@ def test_export_corpus_writes_envelope(t : T?) {
         let body = fread(out_path)
         t |> success(!empty(body), "corpus file is non-empty")
         t |> success(find(body, "\"schema_version\"") >= 0, "corpus has schema_version: {body}")
+        remove(out_path)
+    }
+}
+
+
+// Helper: write `content` to a temp .txt and return its path. Used by
+// the paths_file / workers integration tests. Thin wrapper around
+// `make_temp_text_file` to keep the call sites readable.
+def make_temp_paths_file(t : T?; content : string) : string {
+    return make_temp_text_file(t, "export_corpus_paths", ".txt", content)
+}
+
+
+[test]
+def test_export_corpus_paths_file(t : T?) {
+    t |> run("paths_file alone produces a corpus") <| @(t : T?) {
+        let paths_body = "{fixture_path("_fixture_valid.das")}\n"
+        let paths_file = make_temp_paths_file(t, paths_body)
+        if (empty(paths_file)) return
+        let r = create_temp_file_result("export_corpus_paths_file", ".json")
+        if (!(r is value)) {
+            t |> failure("create_temp_file_result failed")
+            remove(paths_file)
+            return
+        }
+        let out_path = unsafe(r.value)
+        var text : string
+        var is_error = false
+        let ok = parse_result(do_export_corpus("", paths_file, out_path, "", ""), text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(!is_error, "should NOT be error: {text}")
+        let body = fread(out_path)
+        t |> success(!empty(body), "corpus file is non-empty")
+        t |> success(find(body, "\"schema_version\"") >= 0, "corpus has schema_version")
+        t |> success(find(body, "_fixture_valid.das") >= 0, "corpus references the fixture file")
+        remove(paths_file)
+        remove(out_path)
+    }
+}
+
+
+[test]
+def test_export_corpus_paths_and_paths_file_union(t : T?) {
+    t |> run("paths and paths_file unioned (no duplicate records)") <| @(t : T?) {
+        // paths and paths_file each contribute one fixture; the union
+        // should compile both, with no (file, name, line) triple
+        // appearing twice — verifies the input dedup, not just that
+        // both filenames show up somewhere in the JSON text.
+        let paths_body = "{fixture_path("_fixture_test.das")}\n"
+        let paths_file = make_temp_paths_file(t, paths_body)
+        if (empty(paths_file)) return
+        let r = create_temp_file_result("export_corpus_union", ".json")
+        if (!(r is value)) {
+            t |> failure("create_temp_file_result failed")
+            remove(paths_file)
+            return
+        }
+        let out_path = unsafe(r.value)
+        var text : string
+        var is_error = false
+        let ok = parse_result(
+            do_export_corpus(fixture_path("_fixture_valid.das"), paths_file,
+                             out_path, "", ""),
+            text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(!is_error, "should NOT be error: {text}")
+        let body = fread(out_path)
+        var jerr : string
+        var parsed = read_json(body, jerr)
+        t |> success(parsed != null, "envelope parses: {jerr}")
+        if (parsed == null) {
+            remove(paths_file)
+            remove(out_path)
+            return
+        }
+        let funcs = parsed?["functions"]
+        t |> success(funcs != null && funcs.value is _array, "functions array present")
+        var seen : table<string; int>
+        var have_valid = false
+        var have_test = false
+        if (funcs != null && funcs.value is _array) {
+            for (ef in funcs.value as _array) {
+                if (ef == null) {
+                    continue
+                }
+                var f = ""
+                var n = ""
+                var ln = 0
+                let fv = ef?["file"]
+                if (fv != null && fv.value is _string) {
+                    f = fv.value as _string
+                }
+                let nv = ef?["name"]
+                if (nv != null && nv.value is _string) {
+                    n = nv.value as _string
+                }
+                let lv = ef?["line"]
+                if (lv != null && lv.value is _number) {
+                    ln = int(lv.value as _number)
+                }
+                let key = "{f}:{n}:{ln}"
+                seen[key] = (seen?[key] ?? 0) + 1
+                if (find(f, "_fixture_valid.das") >= 0) {
+                    have_valid = true
+                }
+                if (find(f, "_fixture_test.das") >= 0) {
+                    have_test = true
+                }
+            }
+        }
+        t |> success(have_valid, "valid fixture contributed records")
+        t |> success(have_test, "test fixture contributed records")
+        var dupes = 0
+        for (count in values(seen)) {
+            if (count > 1) {
+                dupes++
+            }
+        }
+        t |> equal(dupes, 0)
+        unsafe { delete parsed; }
+        remove(paths_file)
+        remove(out_path)
+    }
+}
+
+
+[test]
+def test_export_corpus_workers_one(t : T?) {
+    t |> run("workers param parses and runs the sequential path") <| @(t : T?) {
+        // Argv-plumbing test only. The fixture is a single file —
+        // far below `PARALLEL_THRESHOLD = 16` — so both `workers=""`
+        // (default) and `workers="1"` go through the same in-process
+        // sequential loop. There is no parallel-vs-sequential
+        // equivalence to verify here; that's covered by the
+        // multi-stage manual determinism check (sequential vs
+        // parallel byte-equality on daslib / tests/language). What
+        // we DO verify: the `--workers 1` argv reaches the child
+        // and the child produces a well-formed envelope.
+        let r = create_temp_file_result("export_corpus_w1", ".json")
+        if (!(r is value)) {
+            t |> failure("create_temp_file_result failed")
+            return
+        }
+        let out_path = unsafe(r.value)
+        var text : string
+        var is_error = false
+        let ok = parse_result(
+            do_export_corpus(fixture_path("_fixture_valid.das"), "",
+                             out_path, "", "1"),
+            text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(!is_error, "should NOT be error: {text}")
+        let body = fread(out_path)
+        t |> success(!empty(body), "corpus non-empty")
+        t |> success(find(body, "\"schema_version\"") >= 0, "schema_version present")
+        remove(out_path)
+    }
+}
+
+
+[test]
+def test_export_corpus_workers_failure_propagates(t : T?) {
+    t |> run("compile error in input fails the run, even with workers") <| @(t : T?) {
+        // _fixture_error.das deliberately fails to compile. Whether the
+        // run goes parallel (large list) or sequential (small list),
+        // detect-dupe panics on compile failure → parent exit non-zero
+        // → MCP envelope reports is_error.
+        let paths_body = "{fixture_path("_fixture_error.das")}\n"
+        let paths_file = make_temp_paths_file(t, paths_body)
+        if (empty(paths_file)) return
+        let r = create_temp_file_result("export_corpus_fail", ".json")
+        if (!(r is value)) {
+            t |> failure("create_temp_file_result failed")
+            remove(paths_file)
+            return
+        }
+        let out_path = unsafe(r.value)
+        var text : string
+        var is_error = false
+        let ok = parse_result(
+            do_export_corpus("", paths_file, out_path, "", "1"),
+            text, is_error)
+        t |> success(ok, "parse result JSON")
+        t |> success(is_error, "should be error: {text}")
+        t |> success(find(text, "exit code") >= 0, "envelope mentions exit code: {text}")
+        remove(paths_file)
         remove(out_path)
     }
 }

--- a/utils/mcp/tools/export_corpus.das
+++ b/utils/mcp/tools/export_corpus.das
@@ -22,8 +22,8 @@ struct ExportCorpusEnvelope {
 }
 
 
-def public do_export_corpus(paths : string; out : string;
-                            min_tokens_str : string) : string {
+def public do_export_corpus(paths : string; paths_file : string; out : string;
+                            min_tokens_str : string; workers_str : string) : string {
     let exe = get_daslang_exe()
     if (empty(exe)) {
         return make_tool_result("Cannot determine daslang executable path", true)
@@ -31,40 +31,96 @@ def public do_export_corpus(paths : string; out : string;
     if (empty(out)) {
         return make_tool_result("export_corpus: missing required 'out' parameter (output corpus.json path)", true)
     }
-    if (empty(paths)) {
-        return make_tool_result("export_corpus: missing required 'paths' parameter (one or more .das files/dirs/globs)", true)
+    if (empty(paths) && empty(paths_file)) {
+        return make_tool_result("export_corpus: missing input — provide 'paths' (comma/newline list, dirs, globs) and/or 'paths_file' (path to a newline-delimited file)", true)
     }
     let detect_dupe_main = "{get_das_root()}/utils/detect-dupe/main.das"
     let detect_dupe_st = stat(detect_dupe_main)
     if (!detect_dupe_st.is_valid || !detect_dupe_st.is_reg) {
         return make_tool_result("export_corpus: utils/detect-dupe/main.das not found at {detect_dupe_main}", true)
     }
+    // Union the two path sources into one seed list. parse_file_list
+    // handles comma/newline splitting + glob expansion; paths_file
+    // contributes raw newline-delimited entries.
     var seeds : array<string>
-    parse_file_list(paths, seeds)
+    if (!empty(paths)) {
+        parse_file_list(paths, seeds)
+    }
+    if (!empty(paths_file)) {
+        let resolved_pf = resolve_path(paths_file)
+        let pf_st = stat(resolved_pf)
+        if (!pf_st.is_valid || !pf_st.is_reg) {
+            return make_tool_result("export_corpus: paths_file not found: {resolved_pf}", true)
+        }
+        let body = fread(resolved_pf)
+        for (raw in split_by_chars(body, "\n")) {
+            let line = strip(raw)
+            if (empty(line)) {
+                continue
+            }
+            if (line |> starts_with("#")) {
+                continue
+            }
+            seeds |> push(line)
+        }
+    }
     if (empty(seeds)) {
-        return make_tool_result("export_corpus: no paths matched: {paths}", true)
+        return make_tool_result("export_corpus: no paths matched (paths=\"{paths}\", paths_file=\"{paths_file}\")", true)
     }
     let resolved_out = resolve_path(out)
-    var argv <- [exe, detect_dupe_main, "--", "--export-functions", resolved_out]
-    argv |> reserve(length(argv) + 2 * length(seeds))
-    for (s in seeds) {
-        argv |> push("-p")
-        argv |> push(resolve_path(s))
+    // Always pass the seed list via a temp --paths-from file. Avoids
+    // ARG_MAX blow-ups on PR-sized lists, and keeps the argv path the
+    // same whether the input came from `paths`, `paths_file`, or both.
+    let temp_paths_file = "{resolved_out}.mcp.paths.{ref_time_ticks()}.txt"
+    var write_ok = false
+    fopen(temp_paths_file, "wb") $(fw) {
+        if (fw == null) {
+            return
+        }
+        write_ok = true
+        for (s in seeds) {
+            fw |> fprint("{resolve_path(s)}\n")
+        }
     }
+    if (!write_ok) {
+        return make_tool_result("export_corpus: could not write temp paths file: {temp_paths_file}", true)
+    }
+    var argv <- [
+        exe, detect_dupe_main, "--",
+        "--paths-from", temp_paths_file,
+        "--export-functions", resolved_out
+    ]
     if (!empty(min_tokens_str)) {
         let parsed = try_to_int(min_tokens_str)
         if (is_err(parsed)) {
+            remove(temp_paths_file)
             return make_tool_result("export_corpus: 'min_tokens' must be a non-negative integer (got '{min_tokens_str}')", true)
         }
         let n = unwrap(parsed)
         if (n < 0) {
+            remove(temp_paths_file)
             return make_tool_result("export_corpus: 'min_tokens' must be >= 0 (got {n})", true)
         }
         argv |> push("--min-tokens")
         argv |> push("{n}")
     }
+    if (!empty(workers_str)) {
+        let parsed = try_to_int(workers_str)
+        if (is_err(parsed)) {
+            remove(temp_paths_file)
+            return make_tool_result("export_corpus: 'workers' must be a non-negative integer (got '{workers_str}')", true)
+        }
+        let n = unwrap(parsed)
+        if (n < 0) {
+            remove(temp_paths_file)
+            return make_tool_result("export_corpus: 'workers' must be >= 0 (got {n})", true)
+        }
+        argv |> push("--workers")
+        argv |> push("{n}")
+    }
     var output : string
     let exit_code = run_and_capture(argv, output, 0.0)
+    remove(temp_paths_file)
     if (exit_code != 0) {
         return make_tool_result("export_corpus: detect-dupe failed (exit code {exit_code}):\n{output}", true)
     }


### PR DESCRIPTION
## Summary

Two pain points addressed for `--export-functions` runs:

- **Slow on big corpora.** Compile is sequential and dominates wall clock. Add `-j / --workers N` to fan out across child detect-dupe processes using the dastest channel/job-status pattern. Files are sorted, split into N contiguous chunks, each chunk compiled by a child via `--paths-from`/`--export-functions`; parent merges shards in chunk-index order so output is byte-identical across worker counts. Default 0 = `get_total_hw_threads()`. Below 16 files the export stays sequential.

- **No way to scope to a specific file list.** The only inputs were repeated `-p` flags + recursive walk; no way to say "just these N files in the PR". Add `--paths-from <file>` and `--paths-stdin` (skip blank/`#`-comment lines, compose with `-p`). MCP `export_corpus` gets a `paths_file` param; the wrapper now always writes seeds to a temp `--paths-from` file instead of fanning back out into many `-p` argv entries (sidesteps ARG_MAX on big PRs).

End-to-end speedup on `daslib + tests` (~750 files, ~7900 functions): 112s → 34s (3.3x). Output of `--workers 1` and `--workers 8` is byte-identical at every stage tested.

## Test plan

- [x] `mcp__daslang__lint` — clean across all 8 changed `.das` files
- [x] `mcp__daslang__format_file` — all already formatted
- [x] Interpreter: 7332 tests, 7326 passed, 6 skipped (sf2 fixture not local), 0 failed
- [x] AOT: 6720 tests, all pass after rebuilding `test_aot`
- [x] 5 new in-process unit tests in `utils/detect-dupe/test_detect_dupe.das`: `read_path_lines` mixed input, `scan_das_files` dedup, `chunk_files` contiguous/complete/W=1/W>N/empty, `merge_envelope_files` order + bad-schema rejection + missing-shard
- [x] 4 new MCP integration tests in `utils/mcp/test_tools.das`: `paths_file`, `paths` + `paths_file` union, `workers=1` arg plumbing, compile-failure propagation
- [x] Determinism: `diff /tmp/seq.json /tmp/par.json` clean on `daslib`, `tests/language`, and `daslib + tests`
- [x] PR-scoped recipes verified: `--paths-from` and `--paths-stdin` produce identical envelopes
- [x] detect-dupe self-check: deduplicated `make_temp_paths_file` / `make_temp_corpus_file` into a shared `make_temp_text_file` (the only actionable hit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)