### PR TITLE
dasSQLITE chunk 10: operational SQLite (views / pragma / vacuum / backup / streaming / register_function)

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -736,7 +736,8 @@ def document_module_ast_match(root : string) {
         group_by_regex("Argument filtering", mod, %regex~.*(qm_count_real_args|qm_real_arg_index|qm_extract_remaining_args|qm_is_fake_arg|qm_count_real_call_args|qm_real_call_arg_index)$%%),
         group_by_regex("Block scanning", mod, %regex~.*(qm_scan|qm_extract_stmts)$%%),
         group_by_regex("Constant construction", mod, %regex~.*(qm_make_zero_const)$%%),
-        group_by_regex("AST reconstruction", mod, %regex~.*(qm_convert_local_function|qm_resolve_local_function|qm_convert_comprehension|qm_resolve_comprehension)$%%)
+        group_by_regex("AST reconstruction", mod, %regex~.*(qm_convert_local_function|qm_resolve_local_function|qm_convert_comprehension|qm_resolve_comprehension)$%%),
+        group_by_regex("AST normalization", mod, %regex~.*(qm_peel_ref2value)$%%)
     )
     document("AST pattern matching", mod, "ast_match.rst", groups)
 }

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -319,6 +319,11 @@ Run any tutorial from the project root::
    tutorials/sql_28_json.rst
    tutorials/sql_29_column_names.rst
    tutorials/sql_30_list_tables.rst
+   tutorials/sql_31_views.rst
+   tutorials/sql_32_sql_functions.rst
+   tutorials/sql_33_pragma.rst
+   tutorials/sql_34_backup_vacuum.rst
+   tutorials/sql_35_streaming.rst
 
 .. _tutorials_dasaudio:
 

--- a/doc/source/reference/tutorials/sql_30_list_tables.rst
+++ b/doc/source/reference/tutorials/sql_30_list_tables.rst
@@ -123,3 +123,5 @@ Deferred
     Full source: :download:`tutorials/sql/30-list_tables.das <../../../../tutorials/sql/30-list_tables.das>`
 
     Previous tutorial: :ref:`tutorial_sql_column_names`
+
+    Next tutorial: :ref:`tutorial_sql_views`

--- a/doc/source/reference/tutorials/sql_31_views.rst
+++ b/doc/source/reference/tutorials/sql_31_views.rst
@@ -1,0 +1,181 @@
+.. _tutorial_sql_views:
+
+==========================================
+SQL-31 --- Views
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; sql_view
+    single: Tutorial; views
+    single: Tutorial; create view
+
+A view is a saved ``SELECT``: a virtual table whose rows are produced
+on demand by re-running its body. dasSQLITE represents a view with the
+same struct-driven story as a table --- declare a struct describing the
+projected columns, attach ``[sql_view]``, and the same read-side helpers
+work without any view-specific dispatch.
+
+The contract
+============
+
+* ``[sql_view(name = "...")]`` on a struct registers it as a view shape.
+  Field annotations are the read-only subset of ``[sql_table]``:
+  ``@sql_column = "..."`` (rename) and ``@sql_json`` / ``@sql_blob``
+  (non-scalar storage). DDL-affecting annotations on the underlying
+  table --- keys, uniqueness, computed columns, defaults, foreign keys
+  --- are rejected at compile time.
+* ``_create_view(type<V>, chain)`` builds the ``CREATE VIEW`` from a
+  LINQ-shaped chain. The macro walks it, validates the projection
+  against ``V``'s fields (count + per-position type), and emits a
+  ``db |> exec`` of ``CREATE VIEW name(c1, ...) AS SELECT ...``.
+* Reading the view uses ``select_from(type<V>)`` --- the same call site
+  as a table. ``column_info(type<V>)`` works too (note ``is_pk`` is
+  always ``false`` for views).
+* ``drop_view_if_exists(type<V>)`` is the idempotent teardown; the
+  ``try_`` form returns ``SqlError`` instead of panicking.
+
+Mutation paths
+==============
+
+Views are read-only. Any mutation attempt is blocked:
+
+* **Compile-time rejection.** ``_sql_update(type<V>, ...)``,
+  ``_sql_delete(type<V>, ...)``, and ``_sql_upsert(viewRow, ...)`` fail
+  with: *"cannot mutate [sql_view] '<name>' --- views are read-only.
+  Mutate the underlying table(s) and re-query the view."*
+* **Runtime rejection.** Row-form mutations
+  (``insert(viewRow)`` / ``update(...)`` / ``delete_(...)``) panic with
+  the same message.
+
+Real mutating workflows update the underlying tables and re-query the
+view to see the new state.
+
+End-to-end
+==========
+
+.. code-block:: das
+
+    [sql_table(name = "Customers")]
+    struct Customer {
+        @sql_primary_key Id : int
+        Name : string
+        City : string
+    }
+
+    [sql_table(name = "Orders")]
+    struct Order {
+        @sql_primary_key Id : int
+        @sql_references = "Customer" CustomerId : int
+        Amount : int
+        Status : string
+    }
+
+    [sql_view(name = "BigOrders")]
+    struct BigOrder {
+        Id : int
+        CustomerId : int
+        Amount : int
+        Status : string
+    }
+
+    [export]
+    def main {
+        with_sqlite(":memory:") $(db) {
+            db |> create_table(type<Customer>)
+            db |> create_table(type<Order>)
+            // ... insert rows ...
+
+            // CREATE VIEW BigOrders(Id, CustomerId, Amount, Status) AS
+            //   SELECT Id, CustomerId, Amount, Status FROM Orders
+            //   WHERE Amount >= 100
+            db |> _create_view(type<BigOrder>,
+                db |> select_from(type<Order>) |> _where(_.Amount >= 100))
+
+            for (b in db |> select_from(type<BigOrder>)) {
+                to_log(LOG_INFO, "BigOrder #{b.Id}: amt={b.Amount}\n")
+            }
+        }
+    }
+
+A second view with a join + named-tuple projection follows the same
+shape; the view's struct supplies the column names and the
+``_select((... = ...))`` aliases just have to match by position and
+type:
+
+.. code-block:: das
+
+    [sql_view(name = "OrderSummary")]
+    struct OrderSummary {
+        OrderId  : int
+        Customer : string
+        Amount   : int
+    }
+
+    db |> _create_view(type<OrderSummary>,
+        db |> select_from(type<Order>)
+            |> _join(db |> select_from(type<Customer>),
+                     $(o : Order, c : Customer) => o.CustomerId == c.Id,
+                     $(o : Order, c : Customer) =>
+                        (OrderId = o.Id, Customer = c.Name, Amount = o.Amount)))
+
+Bound parameters are rejected
+=============================
+
+SQLite stores view bodies as text in ``sqlite_schema``, so ``?``
+placeholders are not allowed inside a view definition. ``_create_view``
+rejects chains that reference captured locals at compile time:
+
+.. code-block:: das
+
+    let cutoff = 100
+    db |> _create_view(type<BigOrder>,                       // compile error
+        db |> select_from(type<Order>) |> _where(_.Amount >= cutoff))
+
+The fix is to inline literals into the view body and apply runtime
+filtering at the query site:
+
+.. code-block:: das
+
+    db |> _create_view(type<BigOrder>,
+        db |> select_from(type<Order>) |> _where(_.Amount >= 100))
+
+    let recent <- _sql(db |> select_from(type<BigOrder>)
+                         |> _where(_.Amount >= cutoff))      // bind here
+
+Raw-SQL escape hatch
+====================
+
+``_create_view`` accepts the same chain shapes as ``_sql`` (single
+source or join, FullRow / NamedTuple / GroupedNamedTuple /
+SingleColumn / Aggregate). Anything outside that --- window functions,
+recursive CTEs, custom SQL functions --- needs raw
+``db |> exec("CREATE VIEW ... AS ...")``. The view is queryable
+through the same ``select_from(type<V>)`` rail as long as a matching
+``[sql_view]`` struct is declared:
+
+.. code-block:: das
+
+    db |> exec(
+        "CREATE VIEW IF NOT EXISTS CustomerRank AS " +
+        "SELECT CustomerId, " +
+        "       ROW_NUMBER() OVER (ORDER BY SUM(Amount) DESC) AS Rank, " +
+        "       SUM(Amount) AS Total " +
+        "FROM Orders GROUP BY CustomerId")
+
+Production tip
+==============
+
+In production, view DDL belongs in a migration body so the schema
+lives alongside table DDL. The migration story ships in a future
+chunk; for now the inline ``_create_view`` form is fine for app setup
+and tests.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/31-views.das <../../../../tutorials/sql/31-views.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_list_tables`
+
+    Next tutorial: :ref:`tutorial_sql_register_function`

--- a/doc/source/reference/tutorials/sql_32_sql_functions.rst
+++ b/doc/source/reference/tutorials/sql_32_sql_functions.rst
@@ -1,0 +1,201 @@
+.. _tutorial_sql_register_function:
+
+============================================
+SQL-32 --- User-defined SQL scalar functions
+============================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; register_function
+    single: Tutorial; user-defined function
+    single: Tutorial; UDF
+    single: Tutorial; sqlite3_create_function
+
+SQL is fluent at filtering and grouping but speaks a small built-in
+vocabulary. When an expression doesn't fit (a custom hash, a
+domain-specific scoring formula, a string normalizer),
+``register_function`` binds an ordinary daslang function as a SQL
+scalar so it can be used inside any expression --- ``WHERE``,
+projection, ``ORDER BY``, indexes, view bodies, anywhere a built-in
+scalar would go.
+
+The contract
+============
+
+.. code-block:: das
+
+    db |> register_function(name : string, fn : @@<...>;
+                            deterministic : bool = false;
+                            directonly    : bool = false)
+
+* ``name`` --- the SQL identifier the function will be invoked under.
+  Re-registering the same name replaces the prior binding.
+* ``fn`` --- a daslang **function pointer** (``@@`` form). The macro
+  inspects the pointer's signature at compile time, derives the per-arg
+  + return type tags, and ships them to the C++ trampoline.
+* ``deterministic = true`` --- same inputs always yield the same
+  output. Required to use the fn inside ``CREATE INDEX ... ON
+  tbl(myfn(col))`` or in a generated column.
+* ``directonly = true`` --- the fn cannot be called from triggers,
+  views, or ``CHECK(...)`` constraints. Useful to lock down
+  side-effecting helpers that should run only from application SQL.
+
+**Lifetime.** Registration is per-connection. The function is available
+until the connection closes (or until ``DROP FUNCTION`` if exposed in
+a future chunk).
+
+**NULL handling.** If any argument is SQL ``NULL``, the trampoline
+emits ``NULL`` without invoking the daslang function --- the standard
+SQL behavior of built-in scalars (``abs(NULL) -> NULL``,
+``length(NULL) -> NULL``). Explicit ``Option<T>`` arg types for
+in-function NULL handling are planned but not yet shipped.
+
+**Panic recovery.** A panic inside the daslang function is caught and
+surfaced to SQLite as an error on that statement; ``try_query``
+returns ``Err`` carrying the panic message. The connection itself is
+unaffected and the next statement runs normally.
+
+Supported types
+===============
+
+``register_function`` maps daslang scalar types to SQLite cells:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - daslang type
+     - SQLite cell
+   * - ``int`` / ``int64`` / ``bool``
+     - INTEGER
+   * - ``float`` / ``double``
+     - REAL
+   * - ``string``
+     - TEXT
+
+Unsupported types (structs, arrays, pointers, lambdas, classes) fail
+at compile time with a per-position diagnostic. Up to 4 arguments are
+supported in v1.
+
+End-to-end
+==========
+
+A scoring formula, a string hasher, a 2-D distance: three real-shaped
+SQL helpers, all marked deterministic so SQLite is allowed to factor
+them out of inner loops or use them as the indexed expression in a
+``CREATE INDEX``.
+
+.. code-block:: das
+
+    require sqlite/sqlite_boost
+    require sqlite/sqlite_linq
+    require math
+
+    def damage_formula(base : float; armor : int; mult : float) : float {
+        return base * (1.0f - float(armor) / 100.0f) * mult
+    }
+
+    def short_hash(s : string) : int64 {
+        var h = 1469598103934665603l
+        for (c in s) {
+            h = (h ^ int64(c)) * 1099511628211l
+        }
+        return h
+    }
+
+    def euclid(x1 : float; y1 : float; x2 : float; y2 : float) : float {
+        let dx = x2 - x1
+        let dy = y2 - y1
+        return sqrt(dx * dx + dy * dy)
+    }
+
+    [sql_table(name = "Enemies")]
+    struct Enemy {
+        @sql_primary_key Id : int
+        Name : string
+        Hp : float
+        Armor : int
+    }
+
+    [export]
+    def main {
+        with_sqlite(":memory:") $(db) {
+            db |> create_table(type<Enemy>)
+            // ... insert rows ...
+
+            db |> register_function("damage_formula", @@damage_formula, true)
+            db |> register_function("short_hash",     @@short_hash,     true)
+            db |> register_function("euclid",         @@euclid,         true)
+        }
+    }
+
+Once registered, the function is just another SQL scalar:
+
+**Inside a projection** (per-row SELECT result) ---
+
+.. code-block:: das
+
+    let dmg <- (db |> try_run_select(
+        "SELECT damage_formula(100.0, Armor, 1.5) FROM Enemies ORDER BY Id",
+        $(var stmt : sqlite3_stmt?) {},
+        $(stmt : sqlite3_stmt?) : float {
+            return float(sqlite3_column_double(stmt, 0))
+        })) |> unwrap
+
+**Inside a WHERE clause** (filter predicate) ---
+
+.. code-block:: das
+
+    let weak_count : int = db |> query_scalar(
+        "SELECT COUNT(*) FROM Enemies WHERE damage_formula(100.0, Armor, 1.5) > 50",
+        type<int>)
+
+**Inside ORDER BY** (sort key) ---
+
+.. code-block:: das
+
+    let first_by_hash = db |> query_scalar(
+        "SELECT Name FROM Enemies ORDER BY short_hash(Name) LIMIT 1",
+        type<string>)
+
+**Inside an aggregate** (multi-arg numeric fn) ---
+
+.. code-block:: das
+
+    let total = db |> query_scalar(
+        "SELECT SUM(euclid(StartX, StartY, EndX, EndY)) FROM Trips",
+        type<double>)
+
+Provider-specific
+=================
+
+``register_function`` is **SQLite-provider-specific**. Other backends
+have their own user-defined-function registration rails (PostgreSQL's
+``CREATE FUNCTION`` with PL/pgSQL, MySQL's UDF interface, MSSQL's
+``CREATE FUNCTION`` + assemblies). A future cross-provider abstraction
+would have to round-trip across all of them; for now, the daslang
+function lives behind ``sqlite/sqlite_boost``.
+
+Deferred
+========
+
+* **Aggregate functions** (``sqlite3_create_function`` with step +
+  finalize callbacks). Useful for custom ``GROUP BY`` aggregates ---
+  ``MEDIAN``, ``STDEV``, percentile families. Defer until a real
+  consumer asks.
+* **Window functions** (``sqlite3_create_window_function``). Specialized
+  enough to wait for a real use case.
+* **Explicit** ``Option<T>`` **arg types.** Today the trampoline
+  short-circuits ``NULL`` arguments; an explicit ``Option<T>`` arg
+  would let the function decide what ``NULL`` means. Planned.
+* **Variadic + > 4 args.** v1 caps at 4 positional args. Lift the cap
+  when something real wants it.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/32-sql_functions.das <../../../../tutorials/sql/32-sql_functions.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_views`
+
+    Next tutorial: :ref:`tutorial_sql_pragma`

--- a/doc/source/reference/tutorials/sql_33_pragma.rst
+++ b/doc/source/reference/tutorials/sql_33_pragma.rst
@@ -1,0 +1,165 @@
+.. _tutorial_sql_pragma:
+
+==========================================
+SQL-33 --- PRAGMA tuning
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; pragma
+    single: Tutorial; set_pragma
+    single: Tutorial; WAL
+    single: Tutorial; journal_mode
+
+PRAGMA is SQLite's per-connection control surface. It covers
+performance toggles (``journal_mode``, ``synchronous``, ``cache_size``,
+``mmap_size``), behavior switches (``foreign_keys``,
+``recursive_triggers``, ``trusted_schema``), and diagnostics
+(``integrity_check`` / ``quick_check`` --- see
+:ref:`tut 34 <tutorial_sql_backup_vacuum>`).
+
+Some PRAGMAs are connection-scoped (``foreign_keys``,
+``busy_timeout``); others are database-scoped and persist on disk
+(``journal_mode``, ``page_size`` after VACUUM). dasSQLITE's helpers
+make no distinction --- they emit ``PRAGMA "<name>" = <value>`` and
+let SQLite handle the rest.
+
+The contract
+============
+
+Three typed ``value`` overloads cover the common shapes:
+
+.. code-block:: das
+
+    set_pragma(db; name; value : string)    // 'WAL', 'NORMAL', 'utf8'
+    set_pragma(db; name; value : int64)     // 5000, 50000, 4096
+    set_pragma(db; name; value : bool)      // ON / OFF
+
+Each has a ``try_set_pragma`` sibling returning ``SqlError`` for
+non-panic recovery. PRAGMA values can't be bound with ``?`` ---
+SQLite parses them at prepare time, so the helpers format the value
+into the SQL inline. String values are single-quoted with ``''``
+doubling for safety. PRAGMA names + values are admin-controlled (not
+user input), so this is fine.
+
+Reading PRAGMAs back uses the typed ``query_scalar`` rail
+(:ref:`tut 13 <tutorial_sql_aggregates>`):
+
+.. code-block:: das
+
+    let mode = db |> query_scalar("PRAGMA journal_mode", type<string>)
+    let busy = db |> query_scalar("PRAGMA busy_timeout", type<int>)
+    let fks  = db |> query_scalar("PRAGMA foreign_keys", type<int>)
+
+End-to-end
+==========
+
+.. code-block:: das
+
+    require daslib/sql
+    require sqlite/sqlite_boost
+
+    [export]
+    def main {
+        with_sqlite(":memory:") $(db) {
+            // Strict variants --- panic on a malformed pragma.
+            db |> set_pragma("journal_mode", "WAL")     // string
+            db |> set_pragma("busy_timeout", 5000l)     // int64 (note `l` suffix)
+            db |> set_pragma("foreign_keys", true)      // bool
+
+            let mode = db |> query_scalar("PRAGMA journal_mode", type<string>)
+            to_log(LOG_INFO, "journal_mode = {mode}\n")
+        }
+    }
+
+Recovery: ``try_set_pragma``
+============================
+
+SQLite rejects ``journal_mode`` changes inside an open transaction.
+The strict form would panic; the ``try_`` form returns ``SqlError``:
+
+.. code-block:: das
+
+    db |> with_transaction() {
+        let err = db |> try_set_pragma("journal_mode", "DELETE")
+        if (err |> is_some) {
+            to_log(LOG_INFO, "journal_mode rejected mid-tx: {err |> unwrap}\n")
+        }
+    }
+
+``apply_recommended_pragmas``
+=============================
+
+For typical app-server workloads dasSQLITE ships a curated bundle ---
+call it right after ``with_sqlite`` opens the connection:
+
+.. code-block:: das
+
+    let setup_err = db |> try_apply_recommended_pragmas()
+    if (setup_err |> is_some) {
+        to_log(LOG_ERROR, "failed to apply pragmas: {setup_err |> unwrap}\n")
+    }
+
+The current bundle is documented in ``sqlite_boost.das``; today it is:
+``journal_mode = WAL``, ``busy_timeout = 5000``,
+``foreign_keys = ON``, ``synchronous = NORMAL``. Workloads with
+different needs (durability-first servers want ``synchronous = FULL``;
+ROM-like data wants ``journal_mode = OFF``) call ``set_pragma``
+directly.
+
+Multi-row PRAGMAs
+=================
+
+PRAGMAs that emit one row per item (``table_info``, ``index_list``,
+``integrity_check``, ``foreign_key_list``) ride the ``query`` family
+with a typed row struct:
+
+.. code-block:: das
+
+    [sql_table(name = "pragma_columns")]
+    struct PragmaColumn {
+        cid : int
+        name : string
+        @sql_column = "type"
+        col_type : string
+        notnull : int
+        dflt_value : string
+        pk : int
+    }
+
+    for (col in db |> query("PRAGMA table_info(Cars)", type<PragmaColumn>)) {
+        to_log(LOG_INFO, "{col.name} : {col.col_type} pk={col.pk}\n")
+    }
+
+See :ref:`tut 29 <tutorial_sql_column_names>` for ``column_info`` ---
+the compile-time alternative when the schema is in your code.
+
+The unknown-PRAGMA quirk
+========================
+
+SQLite is famously permissive with PRAGMA: typos succeed silently
+(no error), and the corresponding ``query_scalar`` read returns ``0``
+/ ``""`` / row count ``0`` depending on shape. The lookup table is
+closed; sqlite3 just ignores names it doesn't recognize. Verify
+spelling by reading the value back via ``query_scalar``.
+
+Deferred
+========
+
+* **Compile-time enum surface for booleans + well-known string
+  PRAGMAs** (e.g. ``set_journal_mode(JournalMode.WAL)``). Adds typo
+  protection at the cost of needing maintenance every time SQLite
+  ships a new mode. Defer until the surface stabilizes.
+* **Open-time PRAGMA bundle on** ``with_sqlite``
+  (``with_sqlite(path, pragmas = (journal_mode = "WAL", ...))``)
+  --- shaves a few lines per call site. Defer until a real consumer
+  asks for it.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/33-pragma.das <../../../../tutorials/sql/33-pragma.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_register_function`
+
+    Next tutorial: :ref:`tutorial_sql_backup_vacuum`

--- a/doc/source/reference/tutorials/sql_34_backup_vacuum.rst
+++ b/doc/source/reference/tutorials/sql_34_backup_vacuum.rst
@@ -1,0 +1,185 @@
+.. _tutorial_sql_backup_vacuum:
+
+==========================================
+SQL-34 --- Backup, VACUUM, integrity check
+==========================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; vacuum
+    single: Tutorial; backup_to
+    single: Tutorial; integrity_check
+    single: Tutorial; optimize
+
+This tutorial covers the maintenance / hygiene side of SQLite. Each
+helper has a strict variant (panics on failure) and a ``try_*`` sibling
+returning ``SqlError`` / ``Result<...>`` for non-panic recovery.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 74
+
+   * - Helper
+     - What it does
+   * - ``vacuum``
+     - Defragment the file, reclaim deleted-row space.
+   * - ``vacuum_into("path")``
+     - Snapshot the live DB to a new file (one-off copy, no source
+       mutation).
+   * - ``optimize``
+     - ``PRAGMA optimize``: refresh query-planner statistics.
+   * - ``integrity_check``
+     - Full corruption scan. Returns ``["ok"]`` on a healthy DB; one
+       row per detected issue otherwise.
+   * - ``quick_check``
+     - Cheaper sibling of ``integrity_check`` (skips index/table
+       cross-walk).
+   * - ``backup_to(dest)`` / ``backup_to("path")``
+     - Online hot backup. Two overloads: into another open runner, or
+       directly to a path on disk.
+
+End-to-end
+==========
+
+.. code-block:: das
+
+    require daslib/sql
+    require sqlite/sqlite_boost
+
+    [sql_table(name = "Logs")]
+    struct LogEntry {
+        @sql_primary_key Id : int
+        Severity : int
+        Message  : string
+    }
+
+    [export]
+    def main {
+        with_sqlite(":memory:") $(db) {
+            db |> create_table(type<LogEntry>)
+            for (i in range(100)) {
+                db |> insert(LogEntry(
+                    Id = i + 1,
+                    Severity = (i % 4),
+                    Message = "msg #{i}"))
+            }
+
+            // VACUUM ----------------------------------------------------
+            // Rewrites the file from scratch. After large DELETE
+            // workloads this reclaims free pages and packs surviving
+            // rows densely. Cannot run inside an active transaction ---
+            // the helper rejects that case before reaching SQLite.
+            db |> exec("DELETE FROM Logs WHERE Severity = 0")
+            db |> vacuum()
+
+            // OPTIMIZE -------------------------------------------------
+            // Cheap; recommended at connection close on long-lived
+            // connections. No-op when nothing has changed.
+            db |> optimize()
+
+            // INTEGRITY CHECK -----------------------------------------
+            let issues <- db |> integrity_check()
+            if (length(issues) == 1 && issues[0] == "ok") {
+                to_log(LOG_INFO, "integrity_check: db is healthy\n")
+            } else {
+                for (msg in issues) {
+                    to_log(LOG_ERROR, "  - {msg}\n")
+                }
+            }
+        }
+    }
+
+VACUUM in a transaction returns ``Err``
+=======================================
+
+The strict form would panic mid-transaction; ``try_vacuum`` surfaces
+the error so the caller can recover:
+
+.. code-block:: das
+
+    db |> with_transaction() {
+        let err = db |> try_vacuum()
+        if (err |> is_some) {
+            to_log(LOG_INFO, "try_vacuum mid-tx: {err |> unwrap}\n")
+        }
+    }
+
+VACUUM INTO --- file snapshot
+=============================
+
+``VACUUM INTO '<path>'`` writes a one-off copy of the live DB to a new
+file without touching the source. The path is single-quoted with
+``''`` doubling --- SQLite doesn't accept ``?`` binds for VACUUM:
+
+.. code-block:: das
+
+    db |> vacuum_into("/tmp/snapshot.sqlite")
+    db |> vacuum_into("with'apostrophe.sqlite")  // quotes are escaped
+
+Use ``vacuum_into`` when you want a defragmented snapshot. For a hot
+copy of the live DB without re-packing, use ``backup_to`` (below).
+
+Online hot backup --- ``backup_to``
+===================================
+
+The Backup API copies a live database into another open connection or
+directly to disk. The destination receives the full state of the
+source; transient ``SQLITE_BUSY`` / ``SQLITE_LOCKED`` responses
+(concurrent writers on the source) are retried automatically with a
+50 ms backoff.
+
+Snapshot into another runner (e.g. an in-memory clone):
+
+.. code-block:: das
+
+    with_sqlite(":memory:") $(snapshot) {
+        db |> backup_to(snapshot)
+        // ... query `snapshot` to inspect a frozen view ...
+    }
+
+Snapshot directly to disk (the file is opened, populated, and closed
+for you):
+
+.. code-block:: das
+
+    db |> backup_to("/tmp/hot_snapshot.sqlite")
+
+The strict form panics on any non-completion; the ``try_`` form
+returns ``SqlError``. ``backup_to`` replaces the destination
+wholesale --- pre-existing tables on the destination are gone after
+the call.
+
+Integrity check return shape
+============================
+
+``integrity_check`` returns ``array<string>``:
+
+* ``["ok"]`` --- the database is healthy.
+* One row per detected issue otherwise (truncated file, missing index
+  entry, dangling page chain, ...).
+
+The helper returns rows verbatim; the caller decides how to react.
+``quick_check`` has the same return shape but skips the per-index
+cross-table walk --- useful as a fast pre-flight before running the
+full ``integrity_check``.
+
+Deferred
+========
+
+* **Backup progress callback.** ``sqlite3_backup_step(bp, N)``
+  returning remaining + pagecount, surfaced to a daslang block.
+  Useful for long-running backups under a "saving..." progress bar.
+* **First-N rows for** ``integrity_check`` / ``quick_check``.
+  SQLite's pragma accepts a row-cap argument
+  (``PRAGMA integrity_check(10)`` stops after 10 issues). The current
+  helper always runs the full scan; add an optional ``N`` once a real
+  consumer asks.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/34-backup_vacuum.das <../../../../tutorials/sql/34-backup_vacuum.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_pragma`
+
+    Next tutorial: :ref:`tutorial_sql_streaming`

--- a/doc/source/reference/tutorials/sql_35_streaming.rst
+++ b/doc/source/reference/tutorials/sql_35_streaming.rst
@@ -1,0 +1,198 @@
+.. _tutorial_sql_streaming:
+
+===============================================
+SQL-35 --- Streaming results with ``_each_sql``
+===============================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; streaming
+    single: Tutorial; _each_sql
+    single: Tutorial; iterator
+
+``_sql(...)`` materializes the result set as ``array<T>`` up front.
+That's fine for hundreds of rows; it's problematic for millions ---
+every row sits in memory at the same time, and the first user-visible
+row only arrives after the whole array is built.
+
+``_each_sql(...)`` is the streaming variant. Same chain shape (any
+``select_from`` + ``_where`` / ``_select`` / ``_order_by`` / ``_join``
+that ``_sql`` accepts), but instead of returning ``array<T>`` it
+returns ``iterator<T>``. Rows are produced lazily, one per
+``sqlite3_step``.
+
+Lifecycle (handled for you)::
+
+    prepare -> bind -> step+yield -> step+yield -> ... -> finalize
+
+The underlying prepared statement is finalized in the generator's
+``finally`` block, which runs on:
+
+* normal exhaustion (loop runs to completion);
+* early ``break`` from the for-loop;
+* panic from inside the loop body.
+
+In every case the statement is released, so subsequent writes to the
+same DB are not blocked by a stale read transaction.
+
+End-to-end
+==========
+
+.. code-block:: das
+
+    require daslib/sql
+    require sqlite/sqlite_boost
+    require sqlite/sqlite_linq
+
+    [sql_table(name = "Logs")]
+    struct LogEntry {
+        @sql_primary_key Id : int
+        Severity : int       // 0 = trace, 1 = info, 2 = warn, 3 = error
+        Message  : string
+    }
+
+    [export]
+    def main {
+        with_sqlite(":memory:") $(db) {
+            db |> create_table(type<LogEntry>)
+            for (i in range(20)) {
+                db |> insert(LogEntry(
+                    Id = i + 1,
+                    Severity = (i % 4),
+                    Message = "msg #{i}"))
+            }
+
+            // Streaming iteration ---------------------------------------
+            // `for (row in _each_sql(...))` lazily materializes one row
+            // at a time. The iterator's lifetime is the for-loop body;
+            // the statement is finalized when the loop exits.
+            var n = 0
+            for (e in _each_sql(db |> select_from(type<LogEntry>)
+                                 |> _where(_.Severity >= 2))) {
+                n++
+                to_log(LOG_INFO, "  [{e.Severity}] #{e.Id} -- {e.Message}\n")
+            }
+            to_log(LOG_INFO, "streamed {n} severe logs\n")
+        }
+    }
+
+Early ``break`` finalizes the statement
+=======================================
+
+Process rows until a condition is met, then ``break``. The generator's
+``finally`` finalizes the prepared statement, so a follow-up INSERT on
+the same DB succeeds without contention:
+
+.. code-block:: das
+
+    var first_error_id = 0
+    for (e in _each_sql(db |> select_from(type<LogEntry>))) {
+        if (e.Severity == 3) {
+            first_error_id = e.Id
+            break
+        }
+    }
+    // The INSERT below would block (or panic) if the iterator's
+    // statement leaked. It succeeds -> finally ran.
+    db |> insert(LogEntry(Id = 100, Severity = 0, Message = "after break"))
+
+Projection follows the chain
+============================
+
+The iterator's element type follows the projection: ``_select(_.Field)``
+streams scalars, ``_select((A = ..., B = ...))`` streams tuples,
+FullRow streams structs:
+
+.. code-block:: das
+
+    var total_chars = 0
+    for (msg in _each_sql(db |> select_from(type<LogEntry>) |> _select(_.Message))) {
+        total_chars += length(msg)
+    }
+
+Captured locals in predicates
+=============================
+
+Unlike ``_create_view`` (:ref:`tut 31 <tutorial_sql_views>`),
+``_each_sql`` accepts captured locals in the chain --- they bind to
+the prepared statement at run time via the standard ``?`` placeholder
+mechanism:
+
+.. code-block:: das
+
+    let cutoff = 2
+    for (e in _each_sql(db |> select_from(type<LogEntry>)
+                         |> _where(_.Severity >= cutoff))) {
+        to_log(LOG_INFO, "  bound-cutoff: id={e.Id}\n")
+    }
+
+When to pick ``_each_sql`` vs ``_sql``
+======================================
+
+Pick ``_each_sql`` when:
+
+* the result set is large (millions of rows) and per-row processing is
+  cheap;
+* you break out early on a condition ("find first matching row",
+  "process until budget exhausted");
+* you're piping rows into another iterator-shaped pipeline (linq /
+  algorithm functions that take an iterator).
+
+Pick ``_sql`` when:
+
+* the result set is small (hundreds of rows) --- array materialization
+  overhead is negligible;
+* you want to index into the result, count rows up front, or pass the
+  array to a function expecting ``array<T>``;
+* the downstream code mutates the same DB while iterating; with
+  ``_each_sql`` the iterator holds a read transaction (under WAL) or a
+  shared lock (default) that may interact poorly with concurrent
+  writes.
+
+Concurrent-writer note + WAL mitigation
+=======================================
+
+While the iterator is stepping, SQLite holds a read transaction on
+the connection. The default journal mode (``DELETE``) blocks writes
+from the same connection until the cursor finalizes. If you need to
+write to the DB while iterating from the **same** connection, switch
+to write-ahead logging:
+
+.. code-block:: das
+
+    db |> set_pragma("journal_mode", "WAL")
+
+Under WAL, readers and one writer can coexist on the same connection,
+at the cost of an extra ``-wal`` / ``-shm`` file alongside the
+database. See :ref:`tut 33 <tutorial_sql_pragma>` for the pragma
+surface.
+
+One-shot semantics
+==================
+
+A daslang generator is consumed once. To re-run the same query, write
+the ``_each_sql(...)`` call site again --- each evaluation builds a
+fresh prepared statement. Don't try to "rewind" an iterator; it has
+no rewind operation, and capturing the iterator into a variable then
+iterating twice will fail (the second pass yields zero rows).
+
+Restrictions vs ``_sql``
+========================
+
+``_each_sql`` rejects materializing terminals at compile time, with a
+clear pointer to ``_sql(...)`` as the alternative:
+
+* ``_to_array`` --- redundant; the iterator is already a row-stream.
+* ``_first`` / ``_first_opt`` --- single-row materializers.
+* ``_count`` / ``_sum`` / ``_avg`` / ``_min`` / ``_max`` --- aggregates
+  emit one scalar row.
+
+For all of these, use ``_sql(...)`` --- the macro emits the right
+runtime to materialize one scalar / row / array.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/35-streaming.das <../../../../tutorials/sql/35-streaming.das>`
+
+    Previous tutorial: :ref:`tutorial_sql_backup_vacuum`

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -655,6 +655,208 @@ passing** (309 pre-chunk-8 + 19 new).
 - **Optimistic concurrency token, multi-table DELETE, named-tuple
   bind for `query_one` / `exec`** — carried from earlier chunks.
 
+## Shipped — chunk 10: operational SQLite (branch `dassqlite-chunk10-operational-sqlite`)
+
+Chunk 10 ships **tut 31 (views)**, **tut 33 (PRAGMA tuning)**, **tut 34
+(backup + VACUUM)**, **tut 35 (streaming `_each_sql`)**, and **tut 39
+(user-defined SQL scalar functions)** — five tutorials covering the
+"operational" surface of SQLite that wasn't yet in the daslang rail.
+Migrations (originally listed as tut 30) deferred to chunk 11. No new
+language prerequisites; chunk 10 sits entirely on the chunk-2..9
+foundation.
+
+### Tut 31 — `[sql_view]` + `_create_view`
+
+- **`[sql_view(name="...")]` structure annotation.** Read-only sibling
+  of `[sql_table]`. Generates the same `_sql_table_name` /
+  `_sql_select_all_sql` / `_sql_read_row` / `_sql_column_info` /
+  `_sql_drop_view_if_exists_sql` helpers under the same names so
+  `select_from(type<V>)` and the `_sql(...)` rail dispatch on view
+  types without case-splitting.
+- **Field annotations:** `@sql_column` (rename), `@sql_json`,
+  `@sql_blob` accepted; six DDL-flavored annotations rejected
+  (`@sql_primary_key`, `@sql_unique`, `@sql_computed`/`@sql_stored`,
+  `@sql_default_fn`, `@sql_references`/`@sql_on_delete`/`@sql_on_update`).
+  Sibling `[sql_index]` rejected too.
+- **JSON/BLOB adapter codegen factored** out of `[sql_table]`'s body
+  into a shared `emit_json_blob_adapters_for_struct(st, fields, tag,
+  errors)` helper — `[sql_view]` reuses the exact same adapter
+  machinery for transparent JSON/BLOB-typed view columns.
+- **Mutation-path rejection:** predicate-form (`_sql_update` /
+  `_sql_delete` / `_sql_upsert` and try / returning siblings) caught at
+  compile time inside `validate_outer_args`'s view check; row-form
+  (`insert(viewRow)` / `update(viewRow)` / `delete_(viewRow)` /
+  `upsert(viewRow)`) caught at compile time via macro-emitted
+  `concept_assert(false, ...)` stubs that fire on first reference.
+- **`_create_view(db, type<V>, chain)` call macro.** Validates: `type<V>`
+  carries `[sql_view]`; chain projection's column count matches V's
+  field count; per-position type matches V's field type (compared via
+  `describe()`); chain has no bound-parameter expressions (SQLite
+  rejects `?` placeholders inside CREATE VIEW). Emits `db |> exec(...)`
+  with the view's column list using V's field names (and `@sql_column`
+  renames) authoritative.
+- **Literal-inlining** for `_create_view`: chain bind-exprs that are
+  `ExprConst*` (Int/Bool/Float/Double/String with `'` doubling) are
+  formatted into the SQL text; captured locals rejected with a clear
+  pointer at the literal-only requirement. Acknowledged as a hack for
+  this chunk; replacement design is the SQL-fragment refactor
+  (deferred — see "Carried" below).
+- **`drop_view_if_exists(type<V>)` / `try_drop_view_if_exists`** template
+  wrappers.
+- Tutorial: [tutorials/sql/31-views.das](../../tutorials/sql/31-views.das).
+  Tests: `test_72_view_basic.das` (5 positive),
+  `failed_sql_view_schema.das` (9 errors),
+  `failed_sql_view_mutations.das` (8 errors),
+  `failed_create_view.das` (6 errors).
+
+### Tut 33 — Pragma tuning
+
+- **`set_pragma` / `try_set_pragma`** with three typed overloads
+  (string / int64 / bool with ON/OFF). Inlined into `PRAGMA "..." = ...`
+  since SQLite parses pragma values at prepare time (no `?` binds).
+- **`apply_recommended_pragmas` / `try_apply_recommended_pragmas`**:
+  WAL + busy_timeout=5000 + foreign_keys=ON + synchronous=NORMAL.
+  Errors short-circuit through `Result`-style early return so the
+  caller learns which pragma failed.
+- Tutorial: [tutorials/sql/33-pragma.das](../../tutorials/sql/33-pragma.das).
+  Tests: `test_80_pragma_basic.das` (6 cases incl. PRAGMA-in-tx
+  rejection).
+
+### Tut 34 — Vacuum / optimize / integrity / backup
+
+- **`vacuum` / `try_vacuum`** — rejects active transactions before
+  reaching SQLite (the strict form would surface SQLite's error
+  message; the wrapper-side preflight is friendlier).
+- **`vacuum_into(path)` / `try_vacuum_into`** — `''`-doubling
+  single-quote escape on `path` (SQLite rejects `?` binds for VACUUM).
+- **`optimize` / `try_optimize`** — thin `PRAGMA optimize` wrapper.
+- **`integrity_check` / `quick_check` / `try_*`** — `array<string>`
+  return; healthy DB returns `["ok"]`, corruption returns one row per
+  detected issue. Backed by a private `try_check_impl` using
+  `try_run_select` with `read_via_adapter` (NOT `try_query`, which
+  expects a struct + `_sql_read_row`).
+- **`backup_to(dest)` / `backup_to(path)` + `try_*` siblings** — online
+  Backup API (`sqlite3_backup_init` / `_step` / `_finish`). C++ shim
+  `sqlite3_backup_run` lives in `dasSQLITE.backup.cpp`; loops with
+  100-page steps and falls back to a 50 ms `sqlite3_sleep` on
+  transient SQLITE_BUSY/LOCKED responses. Path overload opens the
+  destination internally and finalizes via `var inscope`. The C++ shim
+  returns `SQLITE_OK` on a fully-completed backup and any other rc on
+  failure; the daslang side maps that to `SqlError`.
+- Tutorial: [tutorials/sql/34-backup_vacuum.das](../../tutorials/sql/34-backup_vacuum.das).
+  Tests: `test_85_vacuum.das` (5 cases) +
+  `test_83_backup_to.das` (3 cases — memory-runner snapshot, on-disk
+  round-trip, destination overwrite).
+
+### Tut 35 — Streaming (`_each_sql`)
+
+- **`_each_sql(chain)` call macro** returning `iterator<T>` via
+  `run_each_select` runtime helper. Same chain shape as `_sql`;
+  rejects materializing terminals (`_to_array`, `_first`, `_first_opt`,
+  aggregates) at compile time, pointing at `_sql` for the
+  materializing form.
+- **Generator pattern that worked** (after debugging "can't yield from
+  inside the block" + "implicit capture by move"): explicit
+  `capture(<- name1, <- name2)` with `<-` on every captured name;
+  `var row_lam : lambda<...>` in the runtime helper signature;
+  `for (_ in range(0x7FFFFFFF))` with `break` on `SQLITE_DONE`
+  (daslang generators reject `while`); yield as the LAST statement in
+  the for body.
+- **Cleanup via `finally`:** the generator's `finally { sqlite3_finalize(stmt) }`
+  runs on normal exhaustion, early `break`, outer return, and panic —
+  no leaked stmt blocks subsequent writes on the same connection.
+  Captured-local binds work (CREATE-VIEW-style inlining is NOT needed
+  since `?` placeholders are honored at run time).
+- **API_REWORK §35 revision:** §35 originally said streaming was a
+  "behavior of existing iterator-based `for (row in _sql(...))`" — but
+  that iterator form was never shipped. Streaming is therefore real
+  new API: a new `_each_sql` macro returning `iterator<T>`.
+- Tutorial: [tutorials/sql/35-streaming.das](../../tutorials/sql/35-streaming.das).
+  Tests: `test_90_each_sql_basic.das` (5 positive incl. break +
+  stmt-cleanup proof), `failed_each_sql_terminals.das` (4 errors).
+
+### Tut 39 — `register_function`
+
+- **`register_function(db, name, @@fn[, deterministic[, directonly]])`
+  call macro.** Inspects the function pointer's static type at compile
+  time (`_type.argTypes` + `_type.firstType`), derives an `SqlFnTag`
+  per arg + return, and emits a call to a C++ trampoline-registration
+  shim with per-position tags. Up to 4 arguments supported in v1.
+- **Supported scalar set** (compile error otherwise, with per-position
+  diagnostic naming the offender): `int`, `int64`, `float`, `double`,
+  `bool`, `string`. Pointer types, structs, arrays, lambdas, classes
+  rejected.
+- **C++ trampoline** in `dasSQLITE.userfn.cpp`. `RegisteredScalarFn`
+  user-data struct stores `(Context*, Func, retTag, nArgs, argTags[4])`;
+  freed by SQLite-managed `xDestroy` callback (registered via
+  `sqlite3_create_function_v2`'s last param) on connection close /
+  function replacement / explicit drop.
+- **NULL handling (v1):** any SQLITE_NULL argument short-circuits to
+  `sqlite3_result_null` without invoking the daslang function — the
+  idiomatic SQL behavior of built-in scalars (`abs(NULL)` → NULL).
+  Explicit `Option<T>` arg types for in-function NULL handling are
+  deferred to a follow-up.
+- **Panic recovery:** `Context::runWithCatch` wraps the daslang
+  invocation. On panic, the message is read via `getException()`, the
+  context's `exception` / `stopFlags` are cleared (matching the
+  recovery shape from `simulate_exceptions.cpp:217`), and the panic is
+  surfaced via `sqlite3_result_error`. The connection itself is
+  unaffected — subsequent statements on the same connection run
+  normally.
+- **`deterministic=true`** maps to `SQLITE_DETERMINISTIC` (allows the
+  fn in `CREATE INDEX … ON tbl(myfn(col))` and lets the planner
+  factor it out of inner loops). **`directonly=true`** maps to
+  `SQLITE_DIRECTONLY` (blocks invocation from triggers / views /
+  CHECK constraints).
+- **Tag transport:** four scalar `uint8_t` slots (`tag0..tag3`) on the
+  C++ binding instead of a `TArray<uint8_t>`, sidestepping the
+  array-construction overhead in the macro emit. Unused slots
+  ignored according to nArgs.
+- Tutorial: [tutorials/sql/32-sql_functions.das](../../tutorials/sql/32-sql_functions.das).
+  Tests: `test_74_register_function_basic.das` (10 — every supported
+  type and arity), `test_75_register_function_null_panic.das`
+  (3 — NULL short-circuit, panic recovery, post-panic connection
+  health), `test_76_register_function_use_in_chains.das`
+  (3 — UDF in WHERE / ORDER BY / projection),
+  `test_77_register_function_lifetime.das` (3 — replacement,
+  per-connection scope, no-survive-reopen),
+  `failed_register_function.das` (5 errors — struct arg, struct
+  return, pointer arg, lambda instead of `@@fn`, > 4 args).
+
+### Cumulative state after chunk 10
+
+381 (chunk 9) + 21 (chunk 10) = ~402 dasSQLITE tests passing.
+
+### Carried / deferred to chunk 11+
+
+- **SQL-fragment refactor** — replace `_create_view`'s literal-inlining
+  hack with a polymorphic emitter. Design: `variant SqlFragment {
+  Text : string; Bind : ExpressionPtr }`; two render modes —
+  `render_placeholders` for `_sql` / `_each_sql` (today's behavior,
+  returns `(sql, binds)`), `render_inlined` for `_create_view`
+  (formats const literals into text or fails on captured locals). Same
+  machinery applies to future DDL contexts where `?` is illegal:
+  `CREATE INDEX … ON t(<expr>)`, `CHECK(<expr>)`, `GENERATED ALWAYS AS
+  (<expr>)`. ~200-300 lines touched in sqlite_linq.das (8-10 sites).
+- **Migrations (chunk 11)** — `daslib/sql_migrate` module,
+  `[sql_migration]` annotation collected across translation units,
+  `migrate_to_latest` runner, `__schema_version` table, multi-row
+  audit semantics.
+- **Aggregate / window UDFs** — `xStep` / `xFinal` / `xValue` /
+  `xInverse`. v1's `register_function` is scalar-only.
+- **`[sql_function]` annotation macro** — auto-registration on
+  connect, custom-type adapter composition.
+- **Updatable views via INSTEAD OF triggers.**
+- **ATTACH DATABASE** (tut 36 — independent SQLite extension).
+- **`_try_each_sql`** — Result-yielding iterator variant.
+- **Backup progress callback** — `sqlite3_backup_step(bp, N)` +
+  `remaining` / `pagecount` surfaced to a daslang block.
+- **Compile-time enum surface for pragmas** — `set_journal_mode(JournalMode.WAL)`
+  rather than the stringly-typed name.
+- **Open-time named-tuple pragma bundle** — `with_sqlite(path,
+  pragmas=(...))`.
+- **Option<T> args / blob args / blob return** for `register_function`.
+
 ## Shipped — chunk 9: JSON / BLOB columns + column metadata + raw `query` family (branch `dassqlite-chunk9-json-introspection`)
 
 Chunk 9 ships the headline JSON / opaque-blob feature plus the

--- a/modules/dasSQLITE/CMakeLists.txt
+++ b/modules/dasSQLITE/CMakeLists.txt
@@ -26,6 +26,8 @@ IF ((NOT DAS_SQLITE_INCLUDED) AND ((NOT ${DAS_SQLITE_DISABLED}) OR (NOT DEFINED 
 		${DAS_SQLITE_DIR}/src/dasSQLITE.cpp
 	# user include
 		${DAS_SQLITE_DIR}/src/dasSQLITE.main.cpp
+		${DAS_SQLITE_DIR}/src/dasSQLITE.userfn.cpp
+		${DAS_SQLITE_DIR}/src/dasSQLITE.backup.cpp
 	# generated binding includes
 		${DAS_SQLITE_DIR}/src/dasSQLITE.alias.add.inc
 		${DAS_SQLITE_DIR}/src/dasSQLITE.dummy.add.inc

--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -419,15 +419,15 @@ E. **Forward-looking: `dasSQL` abstraction layer** — the roadmap beyond
 | 28 | JSON + BLOB columns | `28-json.das` | **Shipped** (chunk 9); `@sql_json` (TEXT via daslib/json + json_boost) + `@sql_blob` (BLOB via daslib/archive); `_sql` walker JSON-path descent (pred + projection, arbitrary depth) emits `json_extract`; `@sql_blob` opaque to walker (compile error on descent); adapter dedup across tables; mockup was 37-json |
 | 29 | Column metadata | `29-column_names.das` | **Shipped** (chunk 9); Band 1 `column_info(type<T>) : array<ColumnInfo>` (compile-time walk) + abstract `SqlType` enum + `sqlite_sql_type` dialect renderer; Band 3 raw `PRAGMA table_info` via the typed `query` family |
 | 30 | Listing tables | `30-list_tables.das` | **Shipped** (chunk 9); raw `query` against `sqlite_master`; no abstract `list_tables` helper (catalog spelling diverges per backend) |
-| 31 | Views | `31-views.das` | Has mockup |
-| 32 | Migrations | `30-migrations.das` | Has mockup |
-| 33 | PRAGMA tuning | `33-pragma.das` | Has mockup |
-| 34 | Backup + VACUUM | `34-backup_vacuum.das` | Has mockup |
-| 35 | ATTACH DATABASE | `36-attach.das` | Has mockup |
-| 36 | Streaming results | — | No-API — concept tutorial |
+| 31 | Views | `31-views.das` | **Shipped** (chunk 10); `[sql_view(name=...)]` annotation + `_create_view` macro + `drop_view_if_exists`; mutation-path rejection at compile time (predicate form) and runtime (row form) |
+| 32 | Migrations | `30-migrations.das` | Has mockup — deferred to chunk 11 |
+| 33 | PRAGMA tuning | `33-pragma.das` | **Shipped** (chunk 10); `set_pragma` / `try_set_pragma` (string/int64/bool overloads) + `apply_recommended_pragmas` (WAL + busy_timeout + foreign_keys + synchronous=NORMAL) |
+| 34 | Backup + VACUUM | `34-backup_vacuum.das` | **Shipped** (chunk 10); `vacuum` / `vacuum_into` / `optimize` / `integrity_check` / `quick_check` + `backup_to(dest)` / `backup_to(path)` (online Backup API with SQLITE_BUSY/LOCKED retry) |
+| 35 | Streaming results | `35-streaming.das` | **Shipped** (chunk 10); `_each_sql(chain)` returning `iterator<T>`, generator-based; rejects materializing terminals (`_to_array`, `_first`, aggregates); `sqlite3_finalize` runs in `finally` so stmt is released on break/exhaustion/panic |
+| 36 | ATTACH DATABASE | `36-attach.das` | Has mockup |
 | 37 | Bulk operations | — | No-API — concept tutorial |
 | 38 | Concurrency | — | No-API — concept tutorial |
-| 39 | UD SQL functions | `32-sql_functions.das` | Has mockup |
+| 39 | UD SQL functions | `32-sql_functions.das` | **Shipped** (chunk 10); `register_function(db, name, @@fn[, deterministic[, directonly]])` call macro; arity 0..4; arg/return tags derived from function-pointer type; NULL short-circuit; panic recovery via `Context::runWithCatch` |
 | 40 | FTS5 | `39-fts5.das` | Has mockup |
 | 41 | Triggers | — | No-API — concept tutorial |
 

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -13,6 +13,7 @@ require daslib/contracts
 require daslib/option public
 require daslib/sql public
 require daslib/ast_boost
+require daslib/macro_boost
 require daslib/templates
 require daslib/templates_boost
 require daslib/json public          // [sql_table] @sql_json adapter codegen calls JV / read_json / write_json
@@ -1165,6 +1166,22 @@ def drop_table_if_exists(db : SqlRunner; t : auto(TT)) : void {
     }
 }
 
+[template(t)]
+def try_drop_view_if_exists(db : SqlRunner; t : auto(TT)) : SqlError {
+    //! Emits DROP VIEW IF EXISTS for a `[sql_view]`-tagged type ``T``.
+    //! Returns ``none`` on success, ``some(errmsg)`` on failure.
+    return db |> try_exec(_::_sql_drop_view_if_exists_sql(type<TT>))
+}
+
+[template(t)]
+def drop_view_if_exists(db : SqlRunner; t : auto(TT)) : void {
+    //! Strict variant of ``try_drop_view_if_exists``. Panics with the libsqlite3 errmsg on failure.
+    let err = db |> try_drop_view_if_exists(type<TT>)
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
 [unused_argument(t), template(t)]
 def column_info(t : type<auto(TT)>) : array<ColumnInfo> {
     //! Returns the column metadata for a `[sql_table]`-tagged struct ``T``.
@@ -1662,6 +1679,300 @@ def try_transaction(db : SqlRunner; mode : SqliteTxnMode; blk : block<() : void>
 }
 
 // ============================================================================
+// PRAGMA helpers — `set_pragma` / `try_set_pragma` / `apply_recommended_pragmas`.
+//
+// PRAGMA values are parsed at prepare time (no `?` placeholder), so values are
+// formatted into the SQL inline. Pragma names + values are admin-controlled
+// (not user input) — they are not escaped or validated; a bad name surfaces as
+// SQLite's own prepare-time error. Three typed `value` overloads cover the common
+// shapes: string ('WAL' / 'NORMAL'), int64 (busy_timeout, cache_size), bool
+// (foreign_keys, recursive_triggers).
+// ============================================================================
+
+def try_set_pragma(db : SqlRunner; name : string; value : string) : SqlError {
+    //! Sets ``PRAGMA "<name>" = '<value>'``. Returns ``none`` on success,
+    //! ``some(errmsg)`` on failure. The value is single-quoted; embedded
+    //! single quotes in ``value`` are doubled to keep SQLite happy.
+    let escaped = value |> replace("'", "''")
+    return db |> try_exec("PRAGMA \"{name}\" = '{escaped}'")
+}
+
+def try_set_pragma(db : SqlRunner; name : string; value : int64) : SqlError {
+    //! Sets ``PRAGMA "<name>" = <int>``. Used for numeric pragmas like
+    //! ``busy_timeout`` (ms), ``cache_size`` (pages or KB), ``page_size``.
+    return db |> try_exec("PRAGMA \"{name}\" = {value}")
+}
+
+def try_set_pragma(db : SqlRunner; name : string; value : bool) : SqlError {
+    //! Sets ``PRAGMA "<name>" = ON|OFF``. Used for boolean pragmas like
+    //! ``foreign_keys``, ``recursive_triggers``, ``trusted_schema``.
+    let onoff = value ? "ON" : "OFF"
+    return db |> try_exec("PRAGMA \"{name}\" = {onoff}")
+}
+
+def set_pragma(db : SqlRunner; name : string; value : string) : void {
+    //! Strict variant of ``try_set_pragma`` (string overload). Panics on error.
+    let err = db |> try_set_pragma(name, value)
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
+def set_pragma(db : SqlRunner; name : string; value : int64) : void {
+    //! Strict variant of ``try_set_pragma`` (int64 overload). Panics on error.
+    let err = db |> try_set_pragma(name, value)
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
+def set_pragma(db : SqlRunner; name : string; value : bool) : void {
+    //! Strict variant of ``try_set_pragma`` (bool overload). Panics on error.
+    let err = db |> try_set_pragma(name, value)
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
+def try_apply_recommended_pragmas(db : SqlRunner) : SqlError {
+    //! Applies a curated set of pragmas that's appropriate for typical
+    //! application use (write-ahead logging, foreign keys, sane busy
+    //! behavior). Stops at the first failure and returns its error.
+    //!
+    //!   journal_mode = WAL        // concurrent reads + one writer
+    //!   busy_timeout = 5000       // wait 5 s on contention before SQLITE_BUSY
+    //!   foreign_keys = ON         // enforce FK constraints (off by default)
+    //!   synchronous = NORMAL      // good safety+speed balance under WAL
+    //!
+    //! If your workload demands different defaults (durability-first servers
+    //! → ``synchronous = FULL``, embedded ROM-like data → ``journal_mode =
+    //! OFF``) call ``set_pragma`` directly. ``journal_mode`` cannot be
+    //! changed inside an active transaction — call this at connection setup,
+    //! not mid-flow.
+    let e1 = db |> try_set_pragma("journal_mode", "WAL")
+    if (e1 |> is_some) {
+        return e1
+    }
+    let e2 = db |> try_set_pragma("busy_timeout", 5000l)
+    if (e2 |> is_some) {
+        return e2
+    }
+    let e3 = db |> try_set_pragma("foreign_keys", true)
+    if (e3 |> is_some) {
+        return e3
+    }
+    let e4 = db |> try_set_pragma("synchronous", "NORMAL")
+    if (e4 |> is_some) {
+        return e4
+    }
+    return none(type<string>)
+}
+
+def apply_recommended_pragmas(db : SqlRunner) : void {
+    //! Strict variant of ``try_apply_recommended_pragmas``. Panics on the
+    //! first failing pragma.
+    let err = db |> try_apply_recommended_pragmas()
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
+// ============================================================================
+// VACUUM / OPTIMIZE / integrity check / quick check.
+//
+// VACUUM rewrites the database file from scratch — pages defragmented, free
+// pages reclaimed, on-disk order optimized. It is most useful after large
+// DELETE/TRUNCATE workloads. Cannot run inside an active transaction; the
+// helpers reject that case at runtime.
+//
+// `optimize` analyzes the schema and updates the query planner's stats.
+// Recommended at connection close on long-lived connections.
+//
+// `integrity_check` / `quick_check` walk the database checking for
+// corruption. ``"ok"`` is returned as a single-row result on a healthy
+// database; on corruption, multiple rows describe the issues. The helpers
+// surface the rows verbatim — caller decides what to do.
+//
+// (`backup_to` lives in a separate `dasSQLITE.backup.cpp` C++ wrapper; not
+// included in the daslang-only subset shipped here.)
+// ============================================================================
+
+def private escape_sqlite_quoted(s : string) : string {
+    //! Doubles embedded single quotes for SQLite's quoted-string syntax.
+    //! Used by helpers that must inline a path/value into SQL where `?`
+    //! placeholders are not allowed (e.g. VACUUM INTO).
+    return s |> replace("'", "''")
+}
+
+def try_vacuum(db : SqlRunner) : SqlError {
+    //! VACUUM rewrites the database file. Cannot run inside an active
+    //! transaction; if one is in progress this returns an error rather
+    //! than letting SQLite emit a confusing "cannot VACUUM" message.
+    if (db |> in_transaction()) {
+        return some("VACUUM cannot run inside an active transaction; commit or rollback first")
+    }
+    return db |> try_exec("VACUUM")
+}
+
+def vacuum(db : SqlRunner) : void {
+    //! Strict variant of ``try_vacuum``. Panics on failure.
+    let err = db |> try_vacuum()
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
+def try_vacuum_into(db : SqlRunner; path : string) : SqlError {
+    //! VACUUM INTO '<path>' — write a snapshot of the live database to
+    //! ``path`` without modifying the source. Useful for "save as" / hot
+    //! backup scenarios where you don't want VACUUM's lock contention on
+    //! the live file. The path is single-quoted with `''` doubling for
+    //! safety; SQLite's ``VACUUM INTO`` does not accept `?` placeholders.
+    if (db |> in_transaction()) {
+        return some("VACUUM INTO cannot run inside an active transaction; commit or rollback first")
+    }
+    let escaped = escape_sqlite_quoted(path)
+    return db |> try_exec("VACUUM INTO '{escaped}'")
+}
+
+def vacuum_into(db : SqlRunner; path : string) : void {
+    //! Strict variant of ``try_vacuum_into``. Panics on failure.
+    let err = db |> try_vacuum_into(path)
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
+def try_optimize(db : SqlRunner) : SqlError {
+    //! ``PRAGMA optimize`` — refresh the query planner's stats. Recommended
+    //! at connection close on long-lived connections; cheap on short-lived
+    //! ones (it short-circuits when nothing has changed).
+    return db |> try_exec("PRAGMA optimize")
+}
+
+def optimize(db : SqlRunner) : void {
+    //! Strict variant of ``try_optimize``. Panics on failure.
+    let err = db |> try_optimize()
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
+def private try_check_impl(db : SqlRunner; sql : string) : Result<array<string>, string> {
+    //! Shared body for ``try_integrity_check`` / ``try_quick_check``.
+    //! PRAGMA integrity_check / quick_check return scalar string rows, so
+    //! we route through ``try_run_select`` with an explicit per-row reader
+    //! rather than ``try_query`` (which expects a struct + ``_sql_read_row``).
+    return <- db |> try_run_select(sql,
+        $(var stmt : sqlite3_stmt?) {},
+        $(stmt : sqlite3_stmt?) {
+            return read_via_adapter(stmt, 0, type<string>)
+        })
+}
+
+def try_integrity_check(db : SqlRunner) : Result<array<string>, string> {
+    //! Runs ``PRAGMA integrity_check`` and returns the result rows.
+    //! On a healthy database, returns ``["ok"]``. On corruption returns
+    //! one row per detected issue (free-page corruption, missing index
+    //! entry, etc.). Returns ``Err`` only on prepare/step failure.
+    return <- db |> try_check_impl("PRAGMA integrity_check")
+}
+
+def integrity_check(db : SqlRunner) : array<string> {
+    //! Strict variant of ``try_integrity_check``. Panics on
+    //! prepare/step failure (NOT on detected corruption — corruption is
+    //! reported via the returned rows).
+    var r <- db |> try_integrity_check()
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return <- r._value
+}
+
+def try_quick_check(db : SqlRunner) : Result<array<string>, string> {
+    //! Cheaper sibling of ``try_integrity_check`` — same return shape,
+    //! but skips the index-vs-table cross check. Useful as a fast
+    //! pre-flight before deciding whether to run the full check.
+    return <- db |> try_check_impl("PRAGMA quick_check")
+}
+
+def quick_check(db : SqlRunner) : array<string> {
+    //! Strict variant of ``try_quick_check``. Panics on prepare/step failure.
+    var r <- db |> try_quick_check()
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return <- r._value
+}
+
+// ============================================================================
+// backup_to — copy the live database into another (open) connection or
+// directly to a file on disk.
+//
+// SQLite's online backup API copies pages incrementally and tolerates
+// concurrent writes on the source — the destination receives the full
+// state at the time the backup completes. Useful for snapshotting
+// :memory: databases, hot backups of long-running on-disk databases, or
+// cloning into a fresh file before applying destructive migrations.
+//
+// Two overloads:
+//   - ``backup_to(dest : SqlRunner)`` — caller owns ``dest``.
+//   - ``backup_to(path : string)`` — opens ``path`` here, performs the
+//     copy, and closes ``path`` on return. Useful for the common
+//     "snapshot to disk" case.
+// ============================================================================
+
+def try_backup_to(db : SqlRunner; dest : SqlRunner) : SqlError {
+    //! Copies all of ``db`` into the open connection ``dest`` using
+    //! SQLite's online backup API. Tolerates concurrent writers on
+    //! ``db`` (transient SQLITE_BUSY/LOCKED responses are retried with
+    //! a 50 ms backoff). Returns ``some(errmsg)`` if the backup did not
+    //! complete; ``none`` on success.
+    //!
+    //! The C++ shim returns ``SQLITE_OK`` on a fully-completed backup
+    //! (the result of ``sqlite3_backup_finish`` after a clean
+    //! ``SQLITE_DONE`` from the step loop) and any other rc on failure.
+    let rc = sqlite3_backup_run(db.sqlite_handle, dest.sqlite_handle)
+    if (rc != SQLITE_OK) {
+        return some("backup_to: sqlite3_backup_run failed (rc={rc}): {sqlite3_errmsg(dest.sqlite_handle)}")
+    }
+    return SqlError()
+}
+
+def backup_to(db : SqlRunner; dest : SqlRunner) : void {
+    //! Strict variant of ``try_backup_to``. Panics with the libsqlite3
+    //! errmsg on any non-completion.
+    let err = db |> try_backup_to(dest)
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
+def try_backup_to(db : SqlRunner; path : string) : SqlError {
+    //! Opens ``path`` (creating the file if it does not exist), copies
+    //! ``db`` into it, and closes ``path`` on return. Returns ``some(err)``
+    //! on either an open failure or a backup failure; on backup failure
+    //! the destination file is finalized regardless, leaving a partially-
+    //! populated file on disk that the caller can ``fio::remove`` or
+    //! keep for diagnostics.
+    var dest_result <- try_open_sqlite(path)
+    if (dest_result |> is_err) {
+        return some(dest_result |> unwrap_err)
+    }
+    var inscope dest = dest_result |> move_unwrap
+    return <- db |> try_backup_to(dest)
+}
+
+def backup_to(db : SqlRunner; path : string) : void {
+    //! Strict variant of the path-form ``try_backup_to``. Panics on
+    //! open or backup failure.
+    let err = db |> try_backup_to(path)
+    if (err |> is_some) {
+        panic(err |> unwrap)
+    }
+}
+
+// ============================================================================
 // Generic DML runners — used by the `_sql_update` / `_sql_delete` macros.
 //
 // These take a SQL string + bind block (the macro fills in the
@@ -1736,6 +2047,81 @@ def select_from(db : SqlRunner; t : type<auto(TT)>) : array<TT -const -#> {
         panic(r |> unwrap_err)
     }
     return <- r._value
+}
+
+// ============================================================================
+// _each_sql macro runtime: run_each_select
+//
+// Lazy-iterating sibling of `run_select` — instead of materializing every
+// row into an array, it returns a `generator<TT>` that yields one row at
+// a time. Useful for streaming over large result sets where the array
+// materialization would dominate memory or latency.
+//
+// Lifetime: the prepared statement is owned by the generator. SQLite's
+// `sqlite3_finalize` runs in the generator's `finally` block, so the
+// statement is released on:
+//   - normal exhaustion (loop runs to completion)
+//   - early `break` from the for-loop
+//   - panic from inside the loop body
+// In every case, no statement leaks; subsequent writes to the same DB are
+// not blocked by a stale read transaction.
+//
+// **One-shot semantics**: a generator can only be iterated once. To re-run
+// the same query, re-evaluate the `_each_sql(...)` call site (each call
+// builds a fresh statement).
+// ============================================================================
+
+[unsafe_outside_of_for, nodiscard]
+def run_each_select(db : SqlRunner; sql : string;
+                    bind_blk : block<(var stmt : sqlite3_stmt?) : void>;
+                    var row_lam : lambda<(stmt : sqlite3_stmt?) : auto(TT)>) {
+    //! Prepares ``sql``, runs ``bind_blk`` once, then returns a generator
+    //! that lazily ``sqlite3_step``s the cursor. Each yielded value is
+    //! produced by ``row_lam(stmt)``.
+    //!
+    //! ``row_lam`` is a lambda (not a block) because it must be captured
+    //! into the generator body and outlive the surrounding stack frame.
+    //! ``bind_blk`` runs once before the generator is constructed and can
+    //! stay a block.
+    //!
+    //! Panics on prepare failure (with the libsqlite3 errmsg). Step
+    //! failures inside the loop also panic; the generator's ``finally``
+    //! finalizes the stmt regardless. The strict semantics match
+    //! ``run_select``; for non-panic recovery catch the panic at a higher
+    //! level (try/recover).
+    var stmt : sqlite3_stmt?
+    let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
+    if (prc != SQLITE_OK) {
+        let msg = "_each_sql: prepare failed: {sqlite3_errmsg(db.sqlite_handle)}"
+        sqlite3_finalize(stmt)
+        panic(msg)
+    }
+    invoke(bind_blk, stmt)
+    // Explicit-capture form (matches `daslib/functional`'s filter / map
+    // generators): captures `row_lam` (lambda — move) and `stmt` (raw
+    // pointer — value). The connection pointer is read off the stmt via
+    // `sqlite3_db_handle` for the errmsg path; no extra capture needed.
+    // The generator's `finally` finalizes the statement on exhaustion /
+    // early break / panic.
+    return <- generator<TT -const -#> capture(<- row_lam, <- stmt) {
+        // Loop shape: daslang restricts `yield` to be the LAST statement
+        // inside a `for` body (or its terminal `if` arm). We sqlite3_step
+        // first, branch on the result code, and yield the materialized row
+        // as the for-body's tail. SQLITE_DONE / step errors break the loop.
+        for (_ in range(0x7FFFFFFF)) {
+            let rc = sqlite3_step(stmt)
+            if (rc != SQLITE_ROW) {
+                if (rc != SQLITE_DONE) {
+                    panic("_each_sql: step failed: rc={rc}: {sqlite3_errmsg(sqlite3_db_handle(stmt))}")
+                }
+                break
+            }
+            yield invoke(row_lam, stmt)
+        }
+        return false
+    } finally {
+        sqlite3_finalize(stmt)
+    }
 }
 
 // ============================================================================
@@ -2393,63 +2779,9 @@ class SqlTableMacro : AstStructureAnnotation {
         }
 
         // ---- @sql_json / @sql_blob adapter codegen ----
-        // Emit FIRST (before the per-table helpers below) so the adapter
-        // overloads are visible to overload resolution when the helpers
-        // (`_sql_read_row` / `_sql_bind_row`) get type-checked, both of which
-        // call into the chunk-8 `_::sql_bind` / `_::sql_extract` rail.
-        //
-        // Dedup is **per-(T, kind)**: an existing `sql_bind(T) : string`
-        // satisfies a fresh @sql_json field, `sql_bind(T) : array<uint8>`
-        // satisfies @sql_blob — but using the same T with a different kind
-        // (across structs in this module, or across fields of one struct)
-        // would silently miscompile, so it's rejected as a compile error.
-        // Within-struct: `seen_kinds` maps describe(T) -> expected return
-        // (`"string"` for JSON, `"array<uint8>"` for BLOB). Cross-struct:
-        // `find_user_adapter_return_type` looks up any existing `sql_bind(T)`
-        // overload in the module and reports its return primitive.
-        var seen_kinds : table<string; SqlAdapterKind>
-        for (i in range(length(fields))) {
-            let info = fields[i]
-            if (!info.is_json && !info.is_blob) {
-                continue
-            }
-            let ft = st.fields[i]._type
-            if (ft == null) {
-                continue
-            }
-            let key = describe(ft)
-            let expected_kind = info.is_json ? SqlAdapterKind.Json : SqlAdapterKind.Blob
-            let kind_label = info.is_json ? "@sql_json" : "@sql_blob"
-            let prev_kind = seen_kinds?[key] ?? SqlAdapterKind.None
-            if (prev_kind != SqlAdapterKind.None) {
-                if (prev_kind != expected_kind) {
-                    let prev_label = prev_kind == SqlAdapterKind.Json ? "@sql_json" : "@sql_blob"
-                    errors := "[sql_table]: field '{info.name}' is {kind_label}, but an earlier field of struct '{st.name}' already used type '{key}' with {prev_label}. Adapter dedup is per-(T, kind); the same T must be used with one storage kind across this struct. Pick one kind, or wrap '{key}' in a typedef so the two storage views are distinct types."
-                    return false
-                }
-                continue
-            }
-            seen_kinds |> insert(key, expected_kind)
-            let existing_kind = find_sql_bind_kind_for_type(compiling_module(), ft)
-            if (existing_kind != SqlAdapterKind.None) {
-                if (existing_kind != expected_kind) {
-                    let existing_label = existing_kind == SqlAdapterKind.Json ? "@sql_json (sql_bind returns string)" : (existing_kind == SqlAdapterKind.Blob ? "@sql_blob (sql_bind returns array<uint8>)" : "an unrelated `sql_bind` overload")
-                    errors := "[sql_table]: field '{info.name}' is {kind_label}, but type '{key}' is already bound by {existing_label} (from a sibling annotation or a hand-written adapter). Adapter dedup is per-(T, kind); the same T must be used with one storage kind. Pick one kind, or wrap '{key}' in a typedef so the two storage views are distinct types."
-                    return false
-                }
-                continue
-            }
-            if (info.is_json) {
-                var fn_b = make_json_sql_bind_fn(ft, st.at)
-                compiling_module() |> add_function(fn_b)
-                var fn_e = make_json_sql_extract_fn(ft, st.at)
-                compiling_module() |> add_function(fn_e)
-            } else {
-                var fn_b = make_blob_sql_bind_fn(ft, st.at)
-                compiling_module() |> add_function(fn_b)
-                var fn_e = make_blob_sql_extract_fn(ft, st.at)
-                compiling_module() |> add_function(fn_e)
-            }
+        // Shared with `[sql_view]` — see `emit_json_blob_adapters_for_struct`.
+        if (!emit_json_blob_adapters_for_struct(st, fields, "[sql_table]", errors)) {
+            return false
         }
 
         // [sql_index] sibling-annotation processing happens in finish() —
@@ -2972,116 +3304,120 @@ class SqlTableMacro : AstStructureAnnotation {
         return <- fn
     }
 
-    // ---- @sql_json adapter codegen ----
-    //
-    //   def sql_bind    (v : T) : string          { return write_json(JV(v)) }
-    //   def sql_extract (v : string; t : type<T>) : T {
-    //       var err = ""
-    //       let jv = read_json(v, err)
-    //       if (err != "") {
-    //           panic("sql_extract: malformed JSON in column data: {err}")
-    //       }
-    //       return from_JV(jv, default<T>)
-    //   }
-    //
-    // The pair plugs into the chunk-8 `_::sql_bind` / `_::sql_extract` rail.
-    // Storage class is TEXT (driven by the `string` return of `sql_bind`).
-    // Round-trip fidelity matches `daslib/json_boost`'s `JV` / `from_JV`
-    // surface (struct, tuple, array, table, variant, enum, primitives).
-    //
-    // Note on `clone_type`: a field's `_type` arrives with the field-context
-    // modifier flags (ref/const/etc.) that come from being read inside a struct.
-    // Substituting the raw decl into a function parameter yields a slightly
-    // different type than a hand-written `(v : T)` — overload resolution then
-    // fails to pick the emitted adapter and falls through to the chunk-8
-    // catch-all. Clone the decl and use the fresh copy so the substituted type
-    // matches a hand-written reference exactly.
-    def make_json_sql_bind_fn(field_type : TypeDeclPtr; at : LineInfo) : FunctionPtr {
-        // The hand-written form `def sql_bind(v : tuple<...>) : string` is
-        // parsed with `TypeDeclFlags.constant = true` on the parameter
-        // (struct/tuple params are pass-by-ref and the parser implicitly
-        // marks them as ``const`` to keep the body immutable). When
-        // `[sql_table]` calls `_::sql_bind(v)` through the chunk-8 catch-
-        // all, the argument arrives with `const explicit` flags from the
-        // generic instantiation — and a non-const parameter rejects a
-        // const argument, dropping our overload from the candidate set.
-        // Match the parsed form: clone the field type and turn on
-        // ``constant`` so resolution accepts the const argument.
-        var t1 <- clone_type(field_type)
-        t1.flags |= TypeDeclFlags.constant
-        var fn = qmacro_function("sql_bind") $(v : $t(t1)) : string {
-            return _::write_json(_::JV(v))
-        }
-        fn.body |> force_at(at)
-        return <- fn
-    }
+}
 
-    def make_json_sql_extract_fn(field_type : TypeDeclPtr; at : LineInfo) : FunctionPtr {
-        var t1 <- clone_type(field_type)
-        t1.flags |= TypeDeclFlags.constant
-        var t2 <- clone_type(field_type)
-        var t3 <- clone_type(field_type)
-        // Panic on malformed JSON (matching the @sql_blob symmetry where
-        // `mem_archive_load` panics on corrupt bytes). Without the check,
-        // `read_json` returning null silently feeds into `from_JV` which
-        // returns `default<T>` — schema drift / disk corruption then
-        // surfaces as zero-initialized rows, masking real data loss.
-        var fn = qmacro_function("sql_extract") $(v : string; t : type<$t(t1)>) : $t(t2) {
-            var err = ""
-            let jv = _::read_json(v, err)
-            if (err != "") {
-                panic("sql_extract: malformed JSON in column data: {err}")
-            }
-            return _::from_JV(jv, default<$t(t3)>)
-        }
-        fn.body |> force_at(at)
-        return <- fn
+// ---- @sql_json adapter codegen ----
+//
+//   def sql_bind    (v : T) : string          { return write_json(JV(v)) }
+//   def sql_extract (v : string; t : type<T>) : T {
+//       var err = ""
+//       let jv = read_json(v, err)
+//       if (err != "") {
+//           panic("sql_extract: malformed JSON in column data: {err}")
+//       }
+//       return from_JV(jv, default<T>)
+//   }
+//
+// The pair plugs into the chunk-8 `_::sql_bind` / `_::sql_extract` rail.
+// Storage class is TEXT (driven by the `string` return of `sql_bind`).
+// Round-trip fidelity matches `daslib/json_boost`'s `JV` / `from_JV`
+// surface (struct, tuple, array, table, variant, enum, primitives).
+//
+// Note on `clone_type`: a field's `_type` arrives with the field-context
+// modifier flags (ref/const/etc.) that come from being read inside a struct.
+// Substituting the raw decl into a function parameter yields a slightly
+// different type than a hand-written `(v : T)` — overload resolution then
+// fails to pick the emitted adapter and falls through to the chunk-8
+// catch-all. Clone the decl and use the fresh copy so the substituted type
+// matches a hand-written reference exactly.
+//
+// Module-scope (private) so both `[sql_table]` and `[sql_view]` can share
+// the same adapter codegen via `emit_json_blob_adapters_for_struct`.
+def private make_json_sql_bind_fn(field_type : TypeDeclPtr; at : LineInfo) : FunctionPtr {
+    // The hand-written form `def sql_bind(v : tuple<...>) : string` is
+    // parsed with `TypeDeclFlags.constant = true` on the parameter
+    // (struct/tuple params are pass-by-ref and the parser implicitly
+    // marks them as ``const`` to keep the body immutable). When
+    // `[sql_table]` calls `_::sql_bind(v)` through the chunk-8 catch-
+    // all, the argument arrives with `const explicit` flags from the
+    // generic instantiation — and a non-const parameter rejects a
+    // const argument, dropping our overload from the candidate set.
+    // Match the parsed form: clone the field type and turn on
+    // ``constant`` so resolution accepts the const argument.
+    var t1 <- clone_type(field_type)
+    t1.flags |= TypeDeclFlags.constant
+    var fn = qmacro_function("sql_bind") $(v : $t(t1)) : string {
+        return _::write_json(_::JV(v))
     }
+    fn.body |> force_at(at)
+    return <- fn
+}
 
-    // ---- @sql_blob adapter codegen ----
-    //
-    //   def sql_bind    (v : T) : array<uint8>            { var v_local : T; v_local := v; return <- mem_archive_save(v_local) }
-    //   def sql_extract (v : array<uint8>; t : type<T>) : T {
-    //       var r = default<T>
-    //       _::mem_archive_load(v, r)   // panics on failure (canfail=false)
-    //       return r
-    //   }
-    //
-    // Storage class is BLOB. The opaqueness is enforced by `_sql`'s walker:
-    // any `_.<blob_col>.<path>` chain in a predicate produces a compile error
-    // pointing at the field, since `daslib/archive` data is positional binary
-    // and SQL has no way to introspect it.
-    //
-    // `mem_archive_save(var t : auto&)` requires a mutable reference, but our
-    // adapter is reached through the chunk-8 generic `sql_bind_to_stmt(... v :
-    // auto(TT))` which holds `v` as a non-var binding. Clone into a local var
-    // to bridge the const/var gap without taking `var v` ourselves (which would
-    // force the catch-all to also take var, rippling up to the row binder).
-    def make_blob_sql_bind_fn(field_type : TypeDeclPtr; at : LineInfo) : FunctionPtr {
-        var t1 <- clone_type(field_type)
-        t1.flags |= TypeDeclFlags.constant
-        var fn = qmacro_function("sql_bind") $(v : $t(t1)) : array<uint8> {
-            var v_local <- clone_to_move(v)
-            return <- _::mem_archive_save(v_local)
+def private make_json_sql_extract_fn(field_type : TypeDeclPtr; at : LineInfo) : FunctionPtr {
+    var t1 <- clone_type(field_type)
+    t1.flags |= TypeDeclFlags.constant
+    var t2 <- clone_type(field_type)
+    var t3 <- clone_type(field_type)
+    // Panic on malformed JSON (matching the @sql_blob symmetry where
+    // `mem_archive_load` panics on corrupt bytes). Without the check,
+    // `read_json` returning null silently feeds into `from_JV` which
+    // returns `default<T>` — schema drift / disk corruption then
+    // surfaces as zero-initialized rows, masking real data loss.
+    var fn = qmacro_function("sql_extract") $(v : string; t : type<$t(t1)>) : $t(t2) {
+        var err = ""
+        let jv = _::read_json(v, err)
+        if (err != "") {
+            panic("sql_extract: malformed JSON in column data: {err}")
         }
-        fn.body |> force_at(at)
-        return <- fn
+        return _::from_JV(jv, default<$t(t3)>)
     }
+    fn.body |> force_at(at)
+    return <- fn
+}
 
-    def make_blob_sql_extract_fn(field_type : TypeDeclPtr; at : LineInfo) : FunctionPtr {
-        var t1 <- clone_type(field_type)
-        t1.flags |= TypeDeclFlags.constant
-        var t2 <- clone_type(field_type)
-        var t3 <- clone_type(field_type)
-        var fn = qmacro_function("sql_extract") $(v : array<uint8>; t : type<$t(t1)>) : $t(t2) {
-            var r = default<$t(t3)>
-            var v_local <- clone_to_move(v)
-            _::mem_archive_load(v_local, r)
-            return <- r
-        }
-        fn.body |> force_at(at)
-        return <- fn
+// ---- @sql_blob adapter codegen ----
+//
+//   def sql_bind    (v : T) : array<uint8>            { var v_local : T; v_local := v; return <- mem_archive_save(v_local) }
+//   def sql_extract (v : array<uint8>; t : type<T>) : T {
+//       var r = default<T>
+//       _::mem_archive_load(v, r)   // panics on failure (canfail=false)
+//       return r
+//   }
+//
+// Storage class is BLOB. The opaqueness is enforced by `_sql`'s walker:
+// any `_.<blob_col>.<path>` chain in a predicate produces a compile error
+// pointing at the field, since `daslib/archive` data is positional binary
+// and SQL has no way to introspect it.
+//
+// `mem_archive_save(var t : auto&)` requires a mutable reference, but our
+// adapter is reached through the chunk-8 generic `sql_bind_to_stmt(... v :
+// auto(TT))` which holds `v` as a non-var binding. Clone into a local var
+// to bridge the const/var gap without taking `var v` ourselves (which would
+// force the catch-all to also take var, rippling up to the row binder).
+def private make_blob_sql_bind_fn(field_type : TypeDeclPtr; at : LineInfo) : FunctionPtr {
+    var t1 <- clone_type(field_type)
+    t1.flags |= TypeDeclFlags.constant
+    var fn = qmacro_function("sql_bind") $(v : $t(t1)) : array<uint8> {
+        var v_local <- clone_to_move(v)
+        return <- _::mem_archive_save(v_local)
     }
+    fn.body |> force_at(at)
+    return <- fn
+}
+
+def private make_blob_sql_extract_fn(field_type : TypeDeclPtr; at : LineInfo) : FunctionPtr {
+    var t1 <- clone_type(field_type)
+    t1.flags |= TypeDeclFlags.constant
+    var t2 <- clone_type(field_type)
+    var t3 <- clone_type(field_type)
+    var fn = qmacro_function("sql_extract") $(v : array<uint8>; t : type<$t(t1)>) : $t(t2) {
+        var r = default<$t(t3)>
+        var v_local <- clone_to_move(v)
+        _::mem_archive_load(v_local, r)
+        return <- r
+    }
+    fn.body |> force_at(at)
+    return <- fn
 }
 
 // SqlAdapterKind — discriminates an existing `sql_bind(T)` overload by its
@@ -3134,4 +3470,576 @@ def private find_sql_bind_kind_for_type(mod : Module?; td : TypeDeclPtr) : SqlAd
         }
     }
     return kind
+}
+
+def private emit_json_blob_adapters_for_struct(var st : StructurePtr; fields : array<FieldInfo>; tag : string; var errors : das_string) : bool {
+    //! Shared @sql_json / @sql_blob adapter codegen for `[sql_table]` and
+    //! `[sql_view]`. ``tag`` is the user-facing annotation label used in
+    //! error messages (``"[sql_table]"`` or ``"[sql_view]"``).
+    //!
+    //! Emits FIRST (before the per-struct read/bind helpers) so the adapter
+    //! overloads are visible to overload resolution when the helpers
+    //! (`_sql_read_row` / `_sql_bind_row`) get type-checked, both of which
+    //! call into the chunk-8 `_::sql_bind` / `_::sql_extract` rail.
+    //!
+    //! Dedup is **per-(T, kind)**: an existing `sql_bind(T) : string`
+    //! satisfies a fresh @sql_json field, `sql_bind(T) : array<uint8>`
+    //! satisfies @sql_blob — but using the same T with a different kind
+    //! (across structs in this module, or across fields of one struct)
+    //! would silently miscompile, so it's rejected as a compile error.
+    //! Within-struct: `seen_kinds` maps describe(T) -> expected return
+    //! (`"string"` for JSON, `"array<uint8>"` for BLOB). Cross-struct:
+    //! `find_sql_bind_kind_for_type` looks up any existing `sql_bind(T)`
+    //! overload in the module and reports its return primitive.
+    var seen_kinds : table<string; SqlAdapterKind>
+    for (i in range(length(fields))) {
+        let info = fields[i]
+        if (!info.is_json && !info.is_blob) {
+            continue
+        }
+        let ft = st.fields[i]._type
+        if (ft == null) {
+            continue
+        }
+        let key = describe(ft)
+        let expected_kind = info.is_json ? SqlAdapterKind.Json : SqlAdapterKind.Blob
+        let kind_label = info.is_json ? "@sql_json" : "@sql_blob"
+        let prev_kind = seen_kinds?[key] ?? SqlAdapterKind.None
+        if (prev_kind != SqlAdapterKind.None) {
+            if (prev_kind != expected_kind) {
+                let prev_label = prev_kind == SqlAdapterKind.Json ? "@sql_json" : "@sql_blob"
+                errors := "{tag}: field '{info.name}' is {kind_label}, but an earlier field of struct '{st.name}' already used type '{key}' with {prev_label}. Adapter dedup is per-(T, kind); the same T must be used with one storage kind across this struct. Pick one kind, or wrap '{key}' in a typedef so the two storage views are distinct types."
+                return false
+            }
+            continue
+        }
+        seen_kinds |> insert(key, expected_kind)
+        let existing_kind = find_sql_bind_kind_for_type(compiling_module(), ft)
+        if (existing_kind != SqlAdapterKind.None) {
+            if (existing_kind != expected_kind) {
+                let existing_label = existing_kind == SqlAdapterKind.Json ? "@sql_json (sql_bind returns string)" : (existing_kind == SqlAdapterKind.Blob ? "@sql_blob (sql_bind returns array<uint8>)" : "an unrelated `sql_bind` overload")
+                errors := "{tag}: field '{info.name}' is {kind_label}, but type '{key}' is already bound by {existing_label} (from a sibling annotation or a hand-written adapter). Adapter dedup is per-(T, kind); the same T must be used with one storage kind. Pick one kind, or wrap '{key}' in a typedef so the two storage views are distinct types."
+                return false
+            }
+            continue
+        }
+        if (info.is_json) {
+            var fn_b = make_json_sql_bind_fn(ft, st.at)
+            compiling_module() |> add_function(fn_b)
+            var fn_e = make_json_sql_extract_fn(ft, st.at)
+            compiling_module() |> add_function(fn_e)
+        } else {
+            var fn_b = make_blob_sql_bind_fn(ft, st.at)
+            compiling_module() |> add_function(fn_b)
+            var fn_e = make_blob_sql_extract_fn(ft, st.at)
+            compiling_module() |> add_function(fn_e)
+        }
+    }
+    return true
+}
+
+// ============================================================================
+// `[sql_view]` — read-only struct view backed by a SQLite VIEW.
+//
+// Companion of `[sql_table]`: the struct describes a result-set shape (one
+// field per projected column), and `[sql_view]` emits the same read-path
+// helpers (``_sql_table_name``, ``_sql_select_all_sql``, ``_sql_read_row``,
+// ``_sql_column_info``, ``_sql_drop_view_if_exists_sql``) so existing
+// queries (``select_from(type<V>)`` and the `_sql` chain rail) work without
+// a dispatch on view-vs-table.
+//
+// Mutation paths are stubbed:
+//   - Predicate-form (`_sql_update` / `_sql_delete` / `_sql_upsert`) is
+//     gated at compile time by `validate_outer_args` / `validate_outer_upsert_args`
+//     reading the `[sql_view]` annotation off the type<T> argument.
+//   - Row-form (`insert(row)` / `update(row)` / `delete_(row)`) resolves
+//     to the per-struct `_sql_*` helpers below, all of which `panic` at
+//     runtime with a "views are read-only" message. The compile-time
+//     gate handles the more important predicate-form case.
+//
+// View DDL is emitted by the `_create_view(db, type<V>, <pipeline>)` call
+// macro in `daslib/sqlite_linq` (writes "CREATE VIEW ... AS SELECT ...").
+// ============================================================================
+
+[structure_macro(name=sql_view)]
+class private SqlViewMacro : AstStructureAnnotation {
+    def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
+        let view_name = find_annotation(args, "name", string(st.name))
+
+        // Reject sibling [sql_index] before doing any per-field work, so the
+        // user gets a structural error pointing at the macro stack rather
+        // than a follow-on per-field error from the `[sql_index]` apply.
+        for (annDecl in st.annotations) {
+            if (annDecl.annotation.name == "sql_index") {
+                errors := "[sql_view] on struct '{st.name}': [sql_index] cannot apply to a view — views are read-only and inherit indexing from the underlying table. Move the index to the underlying table's struct."
+                return false
+            }
+        }
+
+        // ---- per-field validation ----
+        // Views accept ONLY: @sql_column (rename), @sql_json, @sql_blob.
+        // Everything that affects DDL emission of an underlying table — keys,
+        // uniqueness, computed columns, defaults, FKs — is rejected loud.
+        var fields : array<FieldInfo>
+        fields |> reserve(length(st.fields))
+        for (field in st.fields) {
+            let fname = string(field.name)
+
+            if (find_annotation(field.annotation, "sql_primary_key", false)) {
+                errors := "[sql_view]: field '{fname}' has @sql_primary_key — views are read-only and cannot declare keys; primary keys belong on the underlying table."
+                return false
+            }
+            if (find_annotation(field.annotation, "sql_unique", false)) {
+                errors := "[sql_view]: field '{fname}' has @sql_unique — uniqueness constraints belong on the underlying table, not the view."
+                return false
+            }
+            let computed_sql = find_annotation(field.annotation, "sql_computed", "")
+            if (!empty(computed_sql)) {
+                errors := "[sql_view]: field '{fname}' has @sql_computed — view bodies are arbitrary SELECT expressions (write the expression directly inside `_create_view`'s chain), not GENERATED ALWAYS columns."
+                return false
+            }
+            if (find_annotation(field.annotation, "sql_stored", false)) {
+                errors := "[sql_view]: field '{fname}' has @sql_stored — only @sql_computed columns can be STORED, and views don't have @sql_computed. Remove the annotation."
+                return false
+            }
+            if (!empty(find_annotation(field.annotation, "sql_default_fn", ""))) {
+                errors := "[sql_view]: field '{fname}' has @sql_default_fn — defaults belong on the underlying table, not the view."
+                return false
+            }
+            if (field.init != null) {
+                errors := "[sql_view]: field '{fname}' has a daslang field initializer — view fields are read-only projections of the SELECT body. Remove the initializer."
+                return false
+            }
+            if (!empty(find_annotation(field.annotation, "sql_references", ""))) {
+                errors := "[sql_view]: field '{fname}' has @sql_references — foreign keys belong on the underlying table, not the view."
+                return false
+            }
+            if (!empty(find_annotation(field.annotation, "sql_on_delete", ""))) {
+                errors := "[sql_view]: field '{fname}' has @sql_on_delete — FK actions belong on the underlying table, not the view."
+                return false
+            }
+            if (!empty(find_annotation(field.annotation, "sql_on_update", ""))) {
+                errors := "[sql_view]: field '{fname}' has @sql_on_update — FK actions belong on the underlying table, not the view."
+                return false
+            }
+
+            let is_optional = is_option_field_type(field._type)
+            let is_json = find_annotation(field.annotation, "sql_json", false)
+            let is_blob = find_annotation(field.annotation, "sql_blob", false)
+            if (is_json && is_blob) {
+                errors := "[sql_view]: field '{fname}' has both @sql_json and @sql_blob — pick one. Use @sql_json for queryable, schema-tolerant TEXT storage; use @sql_blob for opaque binary storage."
+                return false
+            }
+
+            // @sql_column = "<sql_name>" — same rename rules as [sql_table].
+            // find_arg + is tString to distinguish "absent" from `= ""`.
+            var col_name = fname
+            let col_anno = find_arg(field.annotation, "sql_column")
+            if (col_anno is tString) {
+                let cv = string(col_anno as tString)
+                if (empty(cv)) {
+                    errors := "[sql_view]: field '{fname}' @sql_column = \"\" is invalid — provide a non-empty SQL column name."
+                    return false
+                }
+                if (find(cv, "\"") >= 0 || find(cv, "\\") >= 0) {
+                    errors := "[sql_view]: field '{fname}' @sql_column=\"{cv}\" — embedded `\"` / `\\` are rejected (SQL identifier hygiene). Use a plain identifier."
+                    return false
+                }
+                col_name = cv
+            }
+
+            fields |> push(FieldInfo(
+                name = fname,
+                col_name = col_name,
+                is_pk = false,
+                is_int_pk = false,
+                is_optional = is_optional,
+                is_unique = false,
+                is_computed = false,
+                is_stored = false,
+                is_json = is_json,
+                is_blob = is_blob,
+                computed_sql = "",
+                default_clause = "",
+                references_clause = ""))
+        }
+
+        // ---- @sql_column collision detection ----
+        {
+            var seen_cols : table<string; string>
+            for (info in fields) {
+                if (key_exists(seen_cols, info.col_name)) {
+                    let first_owner = seen_cols[info.col_name]
+                    errors := "[sql_view]: SQL column name '{info.col_name}' is claimed by both field '{first_owner}' and field '{info.name}'. @sql_column renames must produce a unique column name across the struct."
+                    return false
+                }
+                seen_cols |> insert(info.col_name, info.name)
+            }
+        }
+
+        // ---- @sql_json / @sql_blob adapter codegen ----
+        if (!emit_json_blob_adapters_for_struct(st, fields, "[sql_view]", errors)) {
+            return false
+        }
+
+        // ---- read-path helpers (same names as [sql_table]) ----
+        var fn_table_name = make_view_table_name_fn(st, view_name)
+        compiling_module() |> add_function(fn_table_name)
+        var fn_drop = make_view_drop_sql_fn(st, view_name)
+        compiling_module() |> add_function(fn_drop)
+        var fn_select_all = make_view_select_all_sql_fn(st, view_name, fields)
+        compiling_module() |> add_function(fn_select_all)
+        var fn_read = make_view_read_row_fn(st, fields)
+        compiling_module() |> add_function(fn_read)
+        var fn_col_info = make_view_column_info_fn(st, fields)
+        compiling_module() |> add_function(fn_col_info)
+
+        // ---- mutation stubs (panic at runtime with a clear message) ----
+        let st_name = string(st.name)
+        var fn_ins_pk = make_view_string_panic_stub_fn(st, "_sql_insert_with_pk_sql", st_name, "insert")
+        compiling_module() |> add_function(fn_ins_pk)
+        var fn_ins_nopk = make_view_string_panic_stub_fn(st, "_sql_insert_no_pk_sql", st_name, "insert")
+        compiling_module() |> add_function(fn_ins_nopk)
+        var fn_upd_pk = make_view_string_panic_stub_fn(st, "_sql_update_by_pk_sql", st_name, "update")
+        compiling_module() |> add_function(fn_upd_pk)
+        var fn_del_pk = make_view_string_panic_stub_fn(st, "_sql_delete_by_pk_sql", st_name, "delete")
+        compiling_module() |> add_function(fn_del_pk)
+        var fn_pk_unset = make_view_pk_is_unset_stub_fn(st)
+        compiling_module() |> add_function(fn_pk_unset)
+        var fn_bind = make_view_bind_row_panic_stub_fn(st, "_sql_bind_row", st_name, "insert", true)
+        compiling_module() |> add_function(fn_bind)
+        var fn_bind_upd = make_view_bind_row_panic_stub_fn(st, "_sql_bind_row_for_update", st_name, "update", false)
+        compiling_module() |> add_function(fn_bind_upd)
+        var fn_bind_pk = make_view_bind_row_panic_stub_fn(st, "_sql_bind_row_pk_only", st_name, "delete", false)
+        compiling_module() |> add_function(fn_bind_pk)
+
+        return true
+    }
+}
+
+def private make_view_table_name_fn(var st : StructurePtr; view_name : string) : FunctionPtr {
+    var fn = qmacro_function("_sql_table_name") $(typ : $t(st)) : string {
+        return $v(view_name)
+    }
+    fn.flags |= FunctionFlags.generated
+    fn.body |> force_at(st.at)
+    return <- fn
+}
+
+def private make_view_drop_sql_fn(var st : StructurePtr; view_name : string) : FunctionPtr {
+    let sql = "DROP VIEW IF EXISTS \"{view_name}\""
+    var fn = qmacro_function("_sql_drop_view_if_exists_sql") $(typ : $t(st)) : string {
+        return $v(sql)
+    }
+    fn.flags |= FunctionFlags.generated
+    fn.body |> force_at(st.at)
+    return <- fn
+}
+
+def private make_view_select_all_sql_fn(var st : StructurePtr; view_name : string; fields : array<FieldInfo>) : FunctionPtr {
+    let col_list = build_string() $(var w) {
+        for (i in range(length(fields))) {
+            if (i > 0) {
+                w |> write(", ")
+            }
+            w |> write("\"")
+            w |> write(fields[i].col_name)
+            w |> write("\"")
+        }
+    }
+    let sql = "SELECT {col_list} FROM \"{view_name}\""
+    var fn = qmacro_function("_sql_select_all_sql") $(typ : $t(st)) : string {
+        return $v(sql)
+    }
+    fn.flags |= FunctionFlags.generated
+    fn.body |> force_at(st.at)
+    return <- fn
+}
+
+def private make_view_read_row_fn(var st : StructurePtr; fields : array<FieldInfo>) : FunctionPtr {
+    //! Mirrors `[sql_table]`'s `make_read_row_fn`. Adapter dispatch
+    //! (chunk-8 `read_via_adapter`) handles @sql_json / @sql_blob fields
+    //! via the JSON/BLOB sql_extract overloads emitted above.
+    var assign_exprs : array<ExpressionPtr>
+    assign_exprs |> reserve(length(fields))
+    for (i in range(length(fields))) {
+        let info = fields[i]
+        let col_idx = i
+        let field_name = info.name
+        assign_exprs |> push(qmacro_expr(${
+            static_if (typeinfo can_copy(default<$t(st.fields[i]._type)>)) {
+                row.$f(field_name) = read_via_adapter(stmt, $v(col_idx), type<$t(st.fields[i]._type)>);
+            } else {
+                var field_tmp <- clone_to_move(read_via_adapter(stmt, $v(col_idx), type<$t(st.fields[i]._type)>));
+                row.$f(field_name) <- field_tmp;
+            }
+        }))
+    }
+    var fn = qmacro_function("_sql_read_row") $(stmt : sqlite3_stmt?; typ : $t(st)) : $t(st) {
+        var row = default<$t(st)>
+        $b(assign_exprs)
+        return <- row
+    }
+    fn.flags |= FunctionFlags.generated
+    fn.body |> force_at(st.at)
+    return <- fn
+}
+
+def private make_view_column_info_fn(var st : StructurePtr; fields : array<FieldInfo>) : FunctionPtr {
+    //! Per-view ColumnInfo helper. `is_pk` is always false (views don't
+    //! have primary keys). `default_expr` is always empty (defaults belong
+    //! to the underlying table).
+    var push_exprs : array<ExpressionPtr>
+    push_exprs |> reserve(length(fields))
+    for (i in range(length(fields))) {
+        let info = fields[i]
+        let name = info.col_name
+        let is_nullable = info.is_optional
+        if (info.is_json) {
+            push_exprs |> push(qmacro_expr(${ result |> push(ColumnInfo(
+                name = $v(name),
+                data_type = SqlType.Text,
+                is_pk = false,
+                is_nullable = $v(is_nullable),
+                default_expr = "")); }))
+        } elif (info.is_blob) {
+            push_exprs |> push(qmacro_expr(${ result |> push(ColumnInfo(
+                name = $v(name),
+                data_type = SqlType.Blob,
+                is_pk = false,
+                is_nullable = $v(is_nullable),
+                default_expr = "")); }))
+        } else {
+            push_exprs |> push(qmacro_expr(${ result |> push(ColumnInfo(
+                name = $v(name),
+                data_type = sql_storage_enum_for(type<$t(st.fields[i]._type)>),
+                is_pk = false,
+                is_nullable = $v(is_nullable),
+                default_expr = "")); }))
+        }
+    }
+    var fn = qmacro_function("_sql_column_info") $(typ : $t(st)) : array<ColumnInfo> {
+        var result : array<ColumnInfo>
+        $b(push_exprs)
+        return <- result
+    }
+    fn.flags |= FunctionFlags.generated
+    fn.body |> force_at(st.at)
+    return <- fn
+}
+
+def private make_view_string_panic_stub_fn(var st : StructurePtr; helper_name : string;
+                                           st_name : string; verb : string) : FunctionPtr {
+    //! Emits `def _sql_X(typ : V) : string { panic(...); return "" }` —
+    //! returns "" never executes; the panic body fires on the first call
+    //! from a row-form mutation template (`insert(row)` / `update(row)` /
+    //! `delete_(row)`). Predicate-form mutations are caught at compile
+    //! time by `validate_outer_args` / `validate_outer_upsert_args`.
+    let msg = "[sql_view] {st_name}: cannot {verb} into a view — views are read-only. Mutate the underlying table(s) and re-query the view."
+    var fn = qmacro_function(helper_name) $(typ : $t(st)) : string {
+        panic($v(msg))
+        return ""
+    }
+    fn.flags |= FunctionFlags.generated
+    fn.body |> force_at(st.at)
+    return <- fn
+}
+
+def private make_view_pk_is_unset_stub_fn(var st : StructurePtr) : FunctionPtr {
+    //! `_sql_pk_is_unset(row : V) : bool` — never reached at runtime
+    //! (the caller — `try_insert` / `try_insert_many` — calls
+    //! `_::_sql_insert_with_pk_sql` next, which panics). Returns false
+    //! to satisfy the boolean signature.
+    var fn = qmacro_function("_sql_pk_is_unset") $(row : $t(st)) : bool {
+        return false
+    }
+    fn.flags |= FunctionFlags.generated
+    fn.body |> force_at(st.at)
+    return <- fn
+}
+
+def private make_view_bind_row_panic_stub_fn(var st : StructurePtr; helper_name : string;
+                                             st_name : string; verb : string;
+                                             has_include_pk : bool) : FunctionPtr {
+    //! Emits the void-returning bind helpers. Argument shape matches the
+    //! `[sql_table]` versions exactly so overload resolution finds them.
+    let msg = "[sql_view] {st_name}: cannot {verb} into a view — views are read-only. Mutate the underlying table(s) and re-query the view."
+    if (has_include_pk) {
+        var fn = qmacro_function(helper_name) $(var stmt : sqlite3_stmt?; row : $t(st); include_pk : bool) : void {
+            panic($v(msg))
+        }
+        fn.flags |= FunctionFlags.generated
+        fn.body |> force_at(st.at)
+        return <- fn
+    } else {
+        var fn = qmacro_function(helper_name) $(var stmt : sqlite3_stmt?; row : $t(st)) : void {
+            panic($v(msg))
+        }
+        fn.flags |= FunctionFlags.generated
+        fn.body |> force_at(st.at)
+        return <- fn
+    }
+}
+
+// ============================================================================
+// register_function — bind a daslang function as a SQL scalar UDF
+//
+// Surface:
+//
+//   db |> register_function("damage", @@damage_formula)
+//   db |> register_function("color", @@hex_to_color, true)              // deterministic
+//   db |> register_function("now_iso", @@now_iso, false, true)          // direct-only
+//
+// Implementation: a `[call_macro]` reads the function pointer's static
+// type, derives an SqlFnTag for each argument and the return, and emits a
+// call to the C++-side `sqlite3_register_function` trampoline. The macro
+// intentionally enforces the supported scalar set (Int / Int64 / Float /
+// Double / Bool / String) at compile time so misuse surfaces as a
+// `macro_error` rather than as a runtime mystery.
+//
+// NULL handling (v1): if any argument is SQLITE_NULL the trampoline
+// short-circuits to SQLITE_NULL without invoking the daslang function —
+// the idiomatic SQL behavior for built-in scalars (`abs(NULL)` -> `NULL`).
+// Explicit Option<T> arguments + Blob support are deferred to a later chunk.
+//
+// Panic recovery: a panic inside the daslang function is caught via
+// `Context::runWithCatch` and surfaced to SQLite as
+// `sqlite3_result_error`, so `try_query_scalar(... my_fn(...))` returns
+// `Err` containing the panic message; the connection itself is unaffected.
+// ============================================================================
+
+enum SqlFnTag {
+    //! Type tag matching the C++-side SqlFnTag enum in dasSQLITE.userfn.cpp.
+    //! Order is wire-stable; do NOT renumber without also updating the C++.
+    Int    = 0
+    Int64  = 1
+    Float  = 2
+    Double = 3
+    Bool   = 4
+    String = 5
+}
+
+[macro_function]
+def private sql_fn_tag_for_type(td : TypeDeclPtr) : tuple<tag : uint8; ok : bool> {
+    //! Map an AST type to its SqlFnTag. Returns ok=false for unsupported
+    //! types so the macro can emit a precise diagnostic naming the offender.
+    if (td == null) {
+        return (uint8(0), false)
+    }
+    if (td.dim |> length != 0) {
+        return (uint8(0), false)
+    }
+    if (td.baseType == Type.tInt) {
+        return (uint8(SqlFnTag.Int), true)
+    }
+    if (td.baseType == Type.tInt64) {
+        return (uint8(SqlFnTag.Int64), true)
+    }
+    if (td.baseType == Type.tFloat) {
+        return (uint8(SqlFnTag.Float), true)
+    }
+    if (td.baseType == Type.tDouble) {
+        return (uint8(SqlFnTag.Double), true)
+    }
+    if (td.baseType == Type.tBool) {
+        return (uint8(SqlFnTag.Bool), true)
+    }
+    if (td.baseType == Type.tString) {
+        return (uint8(SqlFnTag.String), true)
+    }
+    return (uint8(0), false)
+}
+
+[call_macro(name="register_function")]
+class private RegisterFunctionMacro : AstCallMacro {
+    //! Pipe form: `db |> register_function(name, fn[, deterministic[, directonly]])`.
+    //! Direct form: `register_function(db, name, fn[, deterministic[, directonly]])`.
+    //!
+    //! The function pointer's static signature drives tag derivation; reject
+    //! unsupported arg/return types here rather than let SQLite produce
+    //! mystery results.
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        let nCallArgs = call.arguments |> length
+        macro_verify(nCallArgs >= 3 && nCallArgs <= 5, prog, call.at,
+            "register_function expects (db, name, fn[, deterministic[, directonly]]) — got {nCallArgs} args")
+
+        // Function pointer must already have an inferred type; otherwise the
+        // call macro is firing too early and the inner `@@fn` hasn't resolved
+        // yet. Bail with a clear message rather than a null-deref later.
+        var fnExpr = call.arguments[2]
+        macro_verify(fnExpr._type != null, prog, call.at,
+            "register_function: function-pointer argument is not inferred yet — make sure the symbol exists at this point")
+        macro_verify(!fnExpr._type.isAutoOrAlias, prog, call.at,
+            "register_function: function-pointer type is auto/alias after inference")
+        macro_verify(fnExpr._type.baseType == Type.tFunction, prog, call.at,
+            "register_function: third argument must be a function pointer (e.g. `@@my_fn`); got {describe(fnExpr._type)}")
+
+        let nArgs = fnExpr._type.argTypes |> length
+        macro_verify(nArgs <= 4, prog, call.at,
+            "register_function: SQLite scalar functions support up to 4 arguments; got {nArgs}")
+
+        // Derive per-arg + return tags. Reject unsupported types up front
+        // with a per-position diagnostic so the user knows exactly which
+        // parameter to fix.
+        var tags : array<uint8>
+        tags |> reserve(4)
+        for (i in range(nArgs)) {
+            let r = sql_fn_tag_for_type(fnExpr._type.argTypes[i])
+            if (!r.ok) {
+                macro_error(prog, call.at,
+                    "register_function: argument #{i + 1} of fn has unsupported type '{describe(fnExpr._type.argTypes[i])}' — supported: int, int64, float, double, bool, string")
+                return null
+            }
+            tags |> push(r.tag)
+        }
+        // Pad tag slots to 4 — unused slots are ignored by the C++ side
+        // according to nArgs, but the binding takes 4 scalar uint8s.
+        while (tags |> length < 4) {
+            tags |> push(uint8(0))
+        }
+
+        let retR = sql_fn_tag_for_type(fnExpr._type.firstType)
+        if (!retR.ok) {
+            macro_error(prog, call.at,
+                "register_function: return type '{describe(fnExpr._type.firstType)}' is unsupported — supported: int, int64, float, double, bool, string")
+            return null
+        }
+
+        var dbExpr   = clone_expression(call.arguments[0])
+        var nameExpr = clone_expression(call.arguments[1])
+        var fnClone  = clone_expression(fnExpr)
+
+        // Optional positional flags. Default both to false.
+        var detExpr : ExpressionPtr = nCallArgs >= 4 ? clone_expression(call.arguments[3]) : qmacro(false)
+        var donExpr : ExpressionPtr = nCallArgs >= 5 ? clone_expression(call.arguments[4]) : qmacro(false)
+
+        let nArgsLit = int(nArgs)
+        let tag0 = tags[0]
+        let tag1 = tags[1]
+        let tag2 = tags[2]
+        let tag3 = tags[3]
+        let retTag = retR.tag
+
+        // Emit: helper checks rc and panics on failure with the libsqlite3 errmsg.
+        var res = qmacro(_::_register_function_check_rc(
+            $e(dbExpr), $e(nameExpr), $e(fnClone), $v(nArgsLit),
+            $v(tag0), $v(tag1), $v(tag2), $v(tag3),
+            $v(retTag), $e(detExpr), $e(donExpr)))
+        res.force_at(call.at)
+        return res
+    }
+}
+
+def _register_function_check_rc(db : SqlRunner; name : string; fn : auto(FN);
+                                nArgs : int;
+                                tag0 : uint8; tag1 : uint8; tag2 : uint8; tag3 : uint8;
+                                retTag : uint8; deterministic : bool; directonly : bool) : void {
+    //! Runtime tail of the `register_function` macro. Calls the C++ trampoline-
+    //! registration shim and panics with the libsqlite3 errmsg on failure.
+    let rc = sqlite3_register_function(db.sqlite_handle, name, fn, nArgs,
+        tag0, tag1, tag2, tag3,
+        retTag, deterministic, directonly)
+    if (rc != SQLITE_OK) {
+        panic("register_function('{name}') failed: {sqlite3_errmsg(db.sqlite_handle)}")
+    }
 }

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -2818,6 +2818,152 @@ def private is_none_call(node : ExpressionPtr) : bool {
 }
 
 [macro_function]
+def private is_const_literal(var node : ExpressionPtr) : bool {
+    //! True iff `node` is a literal constant expression that can be inlined
+    //! directly into SQL text (used by `_create_view` since CREATE VIEW does
+    //! not accept `?` placeholders). Peels through ExprRef2Value the same
+    //! way `is_const_or_captured_var` does. Captured-variable reads
+    //! (`ExprVar`) are deliberately rejected here — they would need to bind
+    //! at runtime, which CREATE VIEW cannot do. Enum and bitfield constants
+    //! are accepted: their underlying integer value is emitted into the SQL,
+    //! matching the wire shape SQLite stores for the column.
+    if (node == null) {
+        return false
+    }
+    if (node is ExprRef2Value) {
+        node = (node as ExprRef2Value).subexpr
+        if (node == null) {
+            return false
+        }
+    }
+    return (node is ExprConstInt || node is ExprConstInt8 || node is ExprConstInt16 || node is ExprConstInt64 ||
+            node is ExprConstUInt || node is ExprConstUInt8 || node is ExprConstUInt16 || node is ExprConstUInt64 ||
+            node is ExprConstFloat || node is ExprConstDouble || node is ExprConstBool || node is ExprConstString ||
+            node is ExprConstEnumeration || node is ExprConstBitfield)
+}
+
+[macro_function]
+def private format_const_as_sql_literal(var node : ExpressionPtr) : string {
+    //! Render a literal AST node as a SQLite SQL literal token. Caller has
+    //! already validated via `is_const_literal`. String values escape `'`
+    //! by doubling, matching SQLite's quoted-string syntax.
+    if (node is ExprRef2Value) {
+        node = (node as ExprRef2Value).subexpr
+    }
+    if (node is ExprConstInt) {
+        return "{(node as ExprConstInt).getValue}"
+    }
+    if (node is ExprConstInt8) {
+        return "{(node as ExprConstInt8).getValue}"
+    }
+    if (node is ExprConstInt16) {
+        return "{(node as ExprConstInt16).getValue}"
+    }
+    if (node is ExprConstInt64) {
+        return "{(node as ExprConstInt64).getValue}"
+    }
+    if (node is ExprConstUInt) {
+        return "{(node as ExprConstUInt).getValue}"
+    }
+    if (node is ExprConstUInt8) {
+        return "{(node as ExprConstUInt8).getValue}"
+    }
+    if (node is ExprConstUInt16) {
+        return "{(node as ExprConstUInt16).getValue}"
+    }
+    if (node is ExprConstUInt64) {
+        return "{(node as ExprConstUInt64).getValue}"
+    }
+    if (node is ExprConstFloat) {
+        return "{(node as ExprConstFloat).getValue}"
+    }
+    if (node is ExprConstDouble) {
+        return "{(node as ExprConstDouble).getValue}"
+    }
+    if (node is ExprConstBool) {
+        return (node as ExprConstBool).getValue ? "1" : "0"
+    }
+    if (node is ExprConstString) {
+        let raw = string((node as ExprConstString).value)
+        // SQLite-quoted: wrap in single quotes, double any embedded `'`.
+        let doubled = raw |> replace("'", "''")
+        return "'{doubled}'"
+    }
+    if (node is ExprConstEnumeration) {
+        // Emit the underlying integer value so the comparison matches the
+        // INTEGER cell SQLite stores for the column. The enum's name string
+        // (`MyEnum.Value`) means nothing to SQLite.
+        let c = node as ExprConstEnumeration
+        let value = find_enum_value(unsafe(reinterpret<EnumerationPtr> c._type.enumType), string(c.value))
+        return "{value}"
+    }
+    if (node is ExprConstBitfield) {
+        return "{(node as ExprConstBitfield).getValue}"
+    }
+    return ""
+}
+
+[macro_function]
+def private next_bind_placeholder(sql : string) : int {
+    //! Find the next `?` placeholder in `sql`, skipping any `?` that lives
+    //! inside a single-quoted SQL string literal (e.g. JSON-path arguments
+    //! `'$.foo.bar'`). Doubled single quotes (`''`) are treated as escapes
+    //! and stay inside the quoted region. Returns -1 if no placeholder is
+    //! found.
+    var found = -1
+    peek_data(sql) $(bytes) {
+        let n = length(bytes)
+        var i = 0
+        var in_quote = false
+        while (i < n) {
+            let ch = bytes[i]
+            if (ch == uint8('\'')) {
+                if (in_quote && i + 1 < n && bytes[i + 1] == uint8('\'')) {
+                    i += 2
+                    continue
+                }
+                in_quote = !in_quote
+                i += 1
+                continue
+            }
+            if (!in_quote && ch == uint8('?')) {
+                found = i
+                return
+            }
+            i += 1
+        }
+    }
+    return found
+}
+
+[macro_function]
+def private inline_binds_into_sql(sql : string; var ordered_binds : array<ExpressionPtr>) : string {
+    //! Walk `sql` left-to-right replacing each `?` placeholder with the
+    //! formatted SQL literal of the corresponding bind expression. Caller
+    //! must have validated all binds with `is_const_literal` first.
+    //!
+    //! `build_sql_string` can emit single-quoted SQL string literals — for
+    //! example JSON-path arguments like `'$.foo.bar'` from `@sql_json`
+    //! columns — so the substitution skips any `?` that appears inside a
+    //! quoted string (and treats `''` as an in-quote escape).
+    var rest = sql
+    return build_string() $(var w) {
+        for (i in range(length(ordered_binds))) {
+            let pos = next_bind_placeholder(rest)
+            if (pos < 0) {
+                w |> write(rest)
+                rest = ""
+                break
+            }
+            w |> write(rest |> slice(0, pos))
+            w |> write(format_const_as_sql_literal(ordered_binds[i]))
+            rest = rest |> slice(pos + 1)
+        }
+        w |> write(rest)
+    }
+}
+
+[macro_function]
 def private is_const_or_captured_var(var node : ExpressionPtr) : bool {
     //! Recognize a literal or a captured-var read so the predicate walker can
     //! emit a `?` placeholder + bind. After Mode-2 inner expansion captured
@@ -2862,20 +3008,19 @@ def private fill_default_columns(var q : SqlQuery&; rootT : TypeDeclPtr; prog : 
 def private sql_table_name_from_type(rootT : TypeDeclPtr) : string {
     // At macro-expansion time we cannot directly call the user's
     // _::_sql_table_name helper because it lives in the user's module, not in
-    // sqlite_linq's macro context. Instead, derive the table name here from
-    // the struct metadata: use [sql_table(name="...")] when present, else
-    // fall back to the struct name.
+    // sqlite_linq's macro context. Instead, derive the table-or-view name
+    // here from the struct metadata: read `[sql_table(name="...")]` or
+    // `[sql_view(name="...")]` (whichever is present), else fall back to
+    // the struct name.
     if (rootT == null || rootT.structType == null) {
         return ""
     }
     var st = rootT.structType
-    // Try to read the [sql_table(name="...")] override from the structure
-    // annotation list. `[sql_table]` cannot appear twice on the same struct
-    // (daslang rejects duplicate annotations), so once we find it and finish
-    // scanning its arguments, break out — no other `sql_table` annotation
-    // can exist in the list.
+    // [sql_table] / [sql_view] cannot appear twice on the same struct
+    // (daslang rejects duplicate annotations), and a struct shouldn't carry
+    // both — but if it did, the first one wins.
     for (annDecl in st.annotations) {
-        if (annDecl.annotation.name == "sql_table") {
+        if (annDecl.annotation.name == "sql_table" || annDecl.annotation.name == "sql_view") {
             for (arg in annDecl.arguments) {
                 if (arg.name == "name" && arg.basicType == Type.tString) {
                     return string(arg.sValue)
@@ -2885,6 +3030,24 @@ def private sql_table_name_from_type(rootT : TypeDeclPtr) : string {
         }
     }
     return string(st.name)
+}
+
+[macro_function]
+def private is_view_type(rootT : TypeDeclPtr) : bool {
+    //! True iff `rootT` is a struct value carrying a `[sql_view]`
+    //! annotation. Used by mutation macros (`_sql_update` / `_sql_delete`
+    //! / `_sql_upsert` and their try/returning variants) to reject the
+    //! user before they hit a runtime panic from the per-struct stubs.
+    if (rootT == null || rootT.structType == null) {
+        return false
+    }
+    var st = rootT.structType
+    for (annDecl in st.annotations) {
+        if (annDecl.annotation.name == "sql_view") {
+            return true
+        }
+    }
+    return false
 }
 
 // ============================================================================
@@ -3098,6 +3261,186 @@ class private SqlTextMacro : AstCallMacro {
         }
         let sql = build_sql_string(q)
         var res = qmacro($v(sql))
+        res.force_at(call.at)
+        return res
+    }
+}
+
+// ============================================================================
+// _create_view — emit a CREATE VIEW statement from a `[sql_view]` struct +
+// a SELECT chain. The chain is the same shape `_sql` accepts (single-source
+// or joined; FullRow / NamedTuple / GroupedNamedTuple / SingleColumn / Aggregate).
+//
+// Validation rules:
+//   - Arg 1 must be `type<V>` where V carries `[sql_view]`.
+//   - Projection column count must match V's field count.
+//   - Per-column type must match V's field type (compared via `describe()`).
+//   - The chain must NOT use bound parameters (literal values only — SQLite
+//     rejects `?` placeholders inside CREATE VIEW … AS SELECT).
+//   - `_to_array()` is rejected as redundant (views are by definition arrays
+//     of rows).
+//
+// SQL emission uses the `CREATE VIEW name(col1, col2, …) AS SELECT …` form so
+// V's field names define the view's column names regardless of whether the
+// user used record-name aliasing in `_select` (`(Foo=_.Bar)`) — the user is
+// trusted to set field names per their public-facing schema.
+// ============================================================================
+
+[call_macro(name="_create_view")]
+class private SqlCreateViewMacro : AstCallMacro {
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        macro_verify(call.arguments |> length == 3, prog, call.at,
+            "_create_view expects (db, type<V>, chain) — got {length(call.arguments)} args")
+
+        var viewT : TypeDeclPtr
+        var typeE = call.arguments[1]
+        if (!qmatch(typeE, type<$t(viewT)>).matched) {
+            macro_error(prog, call.at, "_create_view: second argument must be a `type<V>` literal")
+            return null
+        }
+        if (viewT == null || viewT.structType == null) {
+            macro_error(prog, call.at, "_create_view: type<V> must be a struct (got {describe(viewT)})")
+            return null
+        }
+        if (!is_view_type(viewT)) {
+            macro_error(prog, call.at,
+                "_create_view: type<V> must carry [sql_view] — got '{viewT.structType.name}' without [sql_view]. Add `[sql_view(name=\"…\")]` to the struct.")
+            return null
+        }
+
+        // View name from `[sql_view(name="…")]`, fallback to struct name.
+        var view_name = string(viewT.structType.name)
+        for (annDecl in viewT.structType.annotations) {
+            if (annDecl.annotation.name == "sql_view") {
+                for (arg in annDecl.arguments) {
+                    if (arg.name == "name" && arg.basicType == Type.tString) {
+                        view_name = string(arg.sValue)
+                    }
+                }
+                break
+            }
+        }
+
+        // Analyze the SELECT chain.
+        var argChainT = call.arguments[2]._type
+        macro_verify(argChainT != null, prog, call.at, "_create_view: chain argument is not inferred yet")
+        macro_verify(!argChainT.isAutoOrAlias, prog, call.at, "_create_view: chain type is auto/alias after inference")
+        var q = SqlQuery()
+        if (!analyze_chain(call.arguments[2], q, prog, call.at)) {
+            return null
+        }
+
+        if (q.seenToArray) {
+            macro_error(prog, call.at, "_create_view: chain ends in `_to_array()` — views are by definition arrays of rows; drop the `_to_array()` terminal.")
+            return null
+        }
+
+        // Collect every bind expression in the same order build_sql_string lays
+        // out `?` placeholders: per-join ON binds (in join order) → outer WHERE
+        // → HAVING → LIMIT → OFFSET. CREATE VIEW … AS SELECT does not accept
+        // `?` placeholders, so each bind must be a literal constant we can
+        // inline; captured-variable references are rejected with a clear error.
+        var n_join_binds = 0
+        for (j in q.joins) {
+            n_join_binds += length(j.rightOnBindExprs)
+        }
+        let total_binds = (n_join_binds + length(q.bindExprs) + length(q.havingBindExprs) +
+                           (q.limitBindExpr != null ? 1 : 0) + (q.offsetBindExpr != null ? 1 : 0))
+        var ordered_binds : array<ExpressionPtr>
+        ordered_binds |> reserve(total_binds)
+        for (j in q.joins) {
+            for (b in j.rightOnBindExprs) {
+                ordered_binds |> push(b)
+            }
+        }
+        for (b in q.bindExprs) {
+            ordered_binds |> push(b)
+        }
+        for (b in q.havingBindExprs) {
+            ordered_binds |> push(b)
+        }
+        if (q.limitBindExpr != null) {
+            ordered_binds |> push(q.limitBindExpr)
+        }
+        if (q.offsetBindExpr != null) {
+            ordered_binds |> push(q.offsetBindExpr)
+        }
+        for (be in ordered_binds) {
+            if (!is_const_literal(be)) {
+                macro_error(prog, call.at, "_create_view: view bodies cannot reference local variables — only literal values are allowed (got `{describe(be._type)}`). Captured locals would need `?` placeholders, which SQLite rejects inside CREATE VIEW.")
+                return null
+            }
+        }
+
+        // Validate projection column count vs V's fields.
+        let nFields = length(viewT.structType.fields)
+        var nProj = 0
+        if (q.proj == ProjectionShape.Aggregate) {
+            nProj = 1
+        } elif (q.proj == ProjectionShape.GroupedNamedTuple) {
+            nProj = length(q.groupedSelectExprs)
+        } else {
+            nProj = length(q.selectCols)
+        }
+        if (nProj != nFields) {
+            macro_error(prog, call.at, "_create_view: column count mismatch — projection has {nProj} columns, [sql_view] '{viewT.structType.name}' has {nFields} fields")
+            return null
+        }
+
+        // Per-position type check via describe().
+        for (i in range(nFields)) {
+            var projType : TypeDeclPtr
+            if (q.proj == ProjectionShape.Aggregate) {
+                projType = q.aggregateType
+            } elif (q.proj == ProjectionShape.GroupedNamedTuple) {
+                projType = q.groupedSelectTypes[i]
+            } elif (i < length(q.selectColTypes) && q.selectColTypes[i] != null) {
+                projType = q.selectColTypes[i]
+            } else {
+                projType = lookup_struct_field_type(q.rootType, q.selectCols[i])
+            }
+            if (projType == null) {
+                macro_error(prog, call.at, "_create_view: cannot resolve type of projected column #{i+1}")
+                return null
+            }
+            let fieldT = viewT.structType.fields[i]._type
+            if (fieldT == null) {
+                continue
+            }
+            let projDesc = describe(projType)
+            let fieldDesc = describe(fieldT)
+            if (projDesc != fieldDesc) {
+                macro_error(prog, call.at, "_create_view: column #{i+1} type mismatch — projection emits '{projDesc}', [sql_view] '{viewT.structType.name}.{viewT.structType.fields[i].name}' is '{fieldDesc}'")
+                return null
+            }
+        }
+
+        // Build the column-name list using V's @sql_column-renamed names.
+        let col_list = build_string() $(var w) {
+            for (i in range(nFields)) {
+                if (i > 0) {
+                    w |> write(", ")
+                }
+                var col_name = string(viewT.structType.fields[i].name)
+                let col_anno = find_arg(viewT.structType.fields[i].annotation, "sql_column")
+                if (col_anno is tString) {
+                    col_name = string(col_anno as tString)
+                }
+                w |> write("\"")
+                w |> write(col_name)
+                w |> write("\"")
+            }
+        }
+
+        let select_sql_with_placeholders = build_sql_string(q)
+        let select_sql = inline_binds_into_sql(select_sql_with_placeholders, ordered_binds)
+        let create_sql = "CREATE VIEW \"{view_name}\"({col_list}) AS {select_sql}"
+
+        // Use the user's outer db argument (call.arguments[0]) — pipe-rewrite
+        // turns `db |> _create_view(...)` into `_create_view(db, ...)`, so
+        // arg 0 is exactly what the user wrote.
+        var dbExpr = clone_expression(call.arguments[0])
+        var res = qmacro(_::exec($e(dbExpr), $v(create_sql)))
         res.force_at(call.at)
         return res
     }
@@ -3507,6 +3850,134 @@ class private TrySqlMacro : AstCallMacro {
 }
 
 // ============================================================================
+// _each_sql — streaming iterator over a SELECT chain.
+//
+// Same chain shape as `_sql(...)`, but instead of materializing the result
+// set into an array up front, the macro emits a `_::run_each_select(...)`
+// call returning a `generator<TT>`. The generator yields one row at a time
+// and finalizes the prepared statement on:
+//   - normal exhaustion
+//   - early `break` from the surrounding for-loop
+//   - panic from inside the for-loop body
+//
+// Restrictions vs `_sql`:
+//   - terminals are rejected: `_first()` / `_first_opt()` / `_to_array()`
+//     are not iterators (they materialize one row or the whole array)
+//   - aggregates are rejected: `_count()` / `_sum()` / etc. produce a
+//     scalar; iteration is degenerate
+// For these shapes use `_sql(...)` directly.
+// ============================================================================
+
+[macro_function]
+def private emit_each_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?) : ExpressionPtr {
+    var argT = call.arguments[0]._type
+    macro_verify(argT != null, prog, call.at, "_each_sql: chain argument is not inferred yet")
+    macro_verify(!argT.isAutoOrAlias, prog, call.at, "_each_sql: chain type is auto/alias after inference")
+    var q = SqlQuery()
+    if (!analyze_chain(call.arguments[0], q, prog, call.at)) {
+        return null
+    }
+
+    // Reject terminals — _each_sql produces an iterator, not a scalar /
+    // single row / explicit array. Each error points the user at `_sql`
+    // for the materializing form.
+    //
+    // Order matters: aggregates (which set both q.proj=Aggregate AND
+    // q.matr=One internally) get the aggregate-specific message; plain
+    // _first / _first_opt fall through to the single-row message.
+    if (q.seenToArray) {
+        macro_error(prog, call.at, "_each_sql: chain ends in `_to_array()` — _each_sql streams rows lazily; drop the terminal, or switch to `_sql(...)` for materialization")
+        return null
+    }
+    if (q.proj == ProjectionShape.Aggregate) {
+        macro_error(prog, call.at, "_each_sql: chain ends in an aggregate (_count/_sum/_avg/_min/_max) — aggregates collapse to one scalar; iteration is degenerate. Use `_sql(...)` for the scalar value, or drop the aggregate to iterate over rows.")
+        return null
+    }
+    if (q.matr == Materializer.One || q.matr == Materializer.OneOpt) {
+        macro_error(prog, call.at, "_each_sql: chain ends in `_first()` / `_first_opt()` — those terminals materialize a single row. Use `_sql(...)` for the same chain, or drop the terminal to iterate.")
+        return null
+    }
+
+    // Bind ordering — same as emit_sql_macro_body: per-join ON binds → outer
+    // WHERE → HAVING → LIMIT → OFFSET. Limit/offset binds are still allowed
+    // (e.g. `_each_sql(... |> take(100))` streams up to 100 rows).
+    var joinOnCount = 0
+    for (j in q.joins) {
+        joinOnCount += length(j.rightOnBindExprs)
+    }
+    var joinOnBinds : array<ExpressionPtr>
+    joinOnBinds |> reserve(joinOnCount)
+    for (j in q.joins) {
+        for (b in j.rightOnBindExprs) {
+            joinOnBinds |> push(b)
+        }
+    }
+    if (length(joinOnBinds) > 0) {
+        var ordered : array<ExpressionPtr>
+        ordered |> reserve(length(joinOnBinds) + length(q.bindExprs))
+        for (b in joinOnBinds) {
+            ordered |> push(b)
+        }
+        for (b in q.bindExprs) {
+            ordered |> push(b)
+        }
+        q.bindExprs <- ordered
+    }
+    q.bindExprs |> reserve(length(q.bindExprs) + length(q.havingBindExprs) + 2)
+    for (be in q.havingBindExprs) {
+        q.bindExprs |> push(be)
+    }
+    if (q.limitBindExpr != null) {
+        q.bindExprs |> push(q.limitBindExpr)
+    }
+    if (q.offsetBindExpr != null) {
+        q.bindExprs |> push(q.offsetBindExpr)
+    }
+
+    let sql = build_sql_string(q)
+
+    var bind_stmts : array<ExpressionPtr>
+    bind_stmts |> reserve(length(q.bindExprs))
+    for (i in range(length(q.bindExprs))) {
+        let bindIdx = i + 1
+        var be = q.bindExprs[i]
+        bind_stmts |> push <| qmacro_expr(${
+            sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
+        })
+    }
+
+    var rowBuilder = build_row_builder(q, prog, call.at)
+    if (rowBuilder == null) {
+        return null
+    }
+
+    var dbExpr = q.dbExpr
+    // bind_blk is a `block` (one-shot, runs before the generator). row_blk
+    // is a capturing `lambda` so it can outlive the run_each_select call
+    // inside the generator body.
+    var res = qmacro(_::run_each_select($e(dbExpr), $v(sql),
+        $(var _sql_stmt : sqlite3_stmt?) {
+            $b(bind_stmts)
+        },
+        @(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
+    res.force_at(call.at)
+    return res
+}
+
+[call_macro(name="_each_sql")]
+class private EachSqlMacro : AstCallMacro {
+    //! _each_sql(chain) -> iterator<T>. Same chain shape as `_sql(...)`,
+    //! but yields rows lazily rather than materializing the whole array.
+    //! Iterate via `for (row in _each_sql(db |> select_from(type<T>)))`.
+    //! The underlying prepared statement is finalized on loop exit (normal
+    //! exhaustion / break / panic) by the generator's `finally`.
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        macro_verify(call.arguments |> length == 1, prog, call.at, "_each_sql expects one argument: a chain expression")
+        return emit_each_sql_macro_body(prog, call)
+    }
+}
+
+// ============================================================================
 // `_sql_update` / `_sql_delete` — predicate-based mutations
 //
 // These macros run with `canVisitArgument = false` for everything except `db`
@@ -3841,6 +4312,10 @@ def private validate_outer_args(prog : ProgramPtr; var call : ExprCallMacro?; va
         macro_error(prog, call.at, "{call.name}: second argument must be a `type<T>` literal")
         return false
     }
+    if (is_view_type(rootT)) {
+        macro_error(prog, call.at, "{call.name}: cannot mutate [sql_view] '{rootT.structType.name}' — views are read-only. Mutate the underlying table(s) and re-query the view.")
+        return false
+    }
     return true
 }
 
@@ -4010,6 +4485,10 @@ def private validate_outer_upsert_args(prog : ProgramPtr; var call : ExprCallMac
     }
     if (rowE._type.isGoodArrayType) {
         macro_error(prog, call.at, "{call.name}: bulk array<T> upsert is deferred to a follow-up — pass a single row for now and call inside a transaction loop if you need batching")
+        return false
+    }
+    if (is_view_type(rowE._type)) {
+        macro_error(prog, call.at, "{call.name}: cannot upsert into [sql_view] '{rowE._type.structType.name}' — views are read-only. Mutate the underlying table(s) and re-query the view.")
         return false
     }
     rootT = clone_type(rowE._type)

--- a/modules/dasSQLITE/src/aot_sqlite.h
+++ b/modules/dasSQLITE/src/aot_sqlite.h
@@ -11,4 +11,10 @@ namespace das {
     int sqlite3_bind_blob_ ( sqlite3_stmt * stmt, int index, void * data, int size );
     int sqlite3_bind_text_ ( sqlite3_stmt * stmt, int index, const char * data );
     int sqlite3_prepare_v2_no_tail ( sqlite3 * db, const char * sql, sqlite3_stmt ** stmt );
+    int sqlite3_register_function (
+        sqlite3 * db, const char * name, Func fn, int nArgs,
+        uint8_t tag0, uint8_t tag1, uint8_t tag2, uint8_t tag3,
+        uint8_t retTag, bool deterministic, bool directonly,
+        Context * context, LineInfoArg * at );
+    int sqlite3_backup_run ( sqlite3 * src, sqlite3 * dst );
 }

--- a/modules/dasSQLITE/src/dasSQLITE.backup.cpp
+++ b/modules/dasSQLITE/src/dasSQLITE.backup.cpp
@@ -1,0 +1,44 @@
+#include "daScript/misc/platform.h"
+
+#include "daScript/ast/ast.h"
+#include "daScript/ast/ast_interop.h"
+#include "daScript/ast/ast_typefactory_bind.h"
+#include "daScript/ast/ast_handle.h"
+
+#include "dasSQLITE.h"
+#include "aot_sqlite.h"
+
+namespace das {
+
+// ============================================================================
+// sqlite3_backup_run — copy the contents of `src` into `dst` using SQLite's
+// online backup API. Loops until the entire database has been copied;
+// transient SQLITE_BUSY/SQLITE_LOCKED responses fall back to a 50 ms sleep
+// before retrying, matching SQLite's documented recommendation.
+//
+// Returns the result of sqlite3_backup_finish() once the step loop ends in
+// SQLITE_DONE -- i.e. SQLITE_OK on success, or any non-SQLITE_OK rc the
+// finish call surfaces. If the step loop exits with a non-SQLITE_DONE rc
+// (e.g. SQLITE_IOERR / SQLITE_FULL), that rc is returned directly. The
+// caller (daslang `backup_to`) maps SQLITE_OK -> success and anything else
+// -> SqlError carrying `sqlite3_errmsg(dst)` (or, if dst-side failed to
+// even initialize the backup, `sqlite3_errmsg(dst)` from before the backup
+// started).
+// ============================================================================
+
+int sqlite3_backup_run ( sqlite3 * src, sqlite3 * dst ) {
+    if ( !src || !dst ) return SQLITE_MISUSE;
+    sqlite3_backup * bp = sqlite3_backup_init(dst, "main", src, "main");
+    if ( !bp ) return sqlite3_errcode(dst);
+    int rc;
+    do {
+        rc = sqlite3_backup_step(bp, 100);  // 100 pages per step
+        if ( rc == SQLITE_BUSY || rc == SQLITE_LOCKED ) {
+            sqlite3_sleep(50);
+        }
+    } while ( rc == SQLITE_OK || rc == SQLITE_BUSY || rc == SQLITE_LOCKED );
+    int frc = sqlite3_backup_finish(bp);
+    return rc == SQLITE_DONE ? frc : rc;
+}
+
+}

--- a/modules/dasSQLITE/src/dasSQLITE.main.cpp
+++ b/modules/dasSQLITE/src/dasSQLITE.main.cpp
@@ -89,6 +89,14 @@ void Module_dasSQLITE::initMain() {
     addExtern<DAS_BIND_FUN(sqlite3_prepare_v2_no_tail)>(*this,lib,"sqlite3_prepare_v2_no_tail",
         SideEffects::worstDefault, "sqlite3_prepare_v2_no_tail")
             ->args({"db","sql","stmt"});
+    addExtern<DAS_BIND_FUN(sqlite3_register_function)>(*this,lib,"sqlite3_register_function",
+        SideEffects::worstDefault, "sqlite3_register_function")
+            ->args({"db","name","fn","nArgs",
+                    "tag0","tag1","tag2","tag3",
+                    "retTag","deterministic","directonly","context","at"});
+    addExtern<DAS_BIND_FUN(sqlite3_backup_run)>(*this,lib,"sqlite3_backup_run",
+        SideEffects::worstDefault, "sqlite3_backup_run")
+            ->args({"src","dst"});
 
     for ( auto & pfn : this->functions.each() ) {
         // ok, lets fix up everything returning uint8? into returning string# and make it unsafe operation

--- a/modules/dasSQLITE/src/dasSQLITE.userfn.cpp
+++ b/modules/dasSQLITE/src/dasSQLITE.userfn.cpp
@@ -1,0 +1,220 @@
+#include "daScript/misc/platform.h"
+
+#include "daScript/ast/ast.h"
+#include "daScript/ast/ast_interop.h"
+#include "daScript/ast/ast_typefactory_bind.h"
+#include "daScript/ast/ast_handle.h"
+#include "daScript/simulate/aot.h"
+
+#include "dasSQLITE.h"
+#include "aot_sqlite.h"
+
+namespace das {
+
+// ============================================================================
+// User-defined SQL scalar functions: register_function trampoline.
+//
+// The daslang `register_function` call macro emits a call to
+// `sqlite3_register_function` with the function pointer, the per-arg
+// SqlFnTag array, and the return-type tag. We pick a trampoline for the
+// arity (0..4) and stash a heap-owned `RegisteredScalarFn` as the SQLite
+// user-data; SQLite calls `register_fn_destroy` when the connection is
+// closed (or the function is replaced), so the daslang allocation is
+// freed deterministically.
+//
+// NULL handling (v1): if any input cell is SQLITE_NULL, we short-circuit
+// and emit SQLITE_NULL without invoking the daslang function — matches the
+// idiomatic SQL behavior of built-in scalars (`abs(NULL) -> NULL` etc.).
+// The Option<T> path planned in the chunk-10 design is deferred to v2.
+// Panic in the daslang function is caught via Context::runWithCatch and
+// surfaced to SQLite via sqlite3_result_error.
+// ============================================================================
+
+enum class SqlFnTag : uint8_t {
+    Int    = 0,  // 32-bit signed
+    Int64  = 1,  // 64-bit signed
+    Float  = 2,  // 32-bit IEEE 754
+    Double = 3,  // 64-bit IEEE 754
+    Bool   = 4,  // marshaled via int64 (0/1)
+    String = 5,
+};
+
+static constexpr int MAX_SQL_FN_ARGS = 4;
+
+struct RegisteredScalarFn {
+    Context * context = nullptr;
+    Func      fn;
+    SqlFnTag  retTag = SqlFnTag::Int64;
+    uint8_t   nArgs  = 0;
+    SqlFnTag  argTags[MAX_SQL_FN_ARGS] = { SqlFnTag::Int64, SqlFnTag::Int64, SqlFnTag::Int64, SqlFnTag::Int64 };
+    LineInfo  at;
+};
+
+static void register_fn_destroy ( void * p ) {
+    delete static_cast<RegisteredScalarFn *>(p);
+}
+
+static __forceinline bool marshal_one_arg (
+        sqlite3_value * v, SqlFnTag tag, vec4f & out, sqlite3_context * sctx ) {
+    switch ( tag ) {
+        case SqlFnTag::Int: {
+            int32_t x = (int32_t) sqlite3_value_int64(v);
+            out = cast<int32_t>::from(x);
+            return true;
+        }
+        case SqlFnTag::Int64: {
+            int64_t x = sqlite3_value_int64(v);
+            out = cast<int64_t>::from(x);
+            return true;
+        }
+        case SqlFnTag::Float: {
+            float x = (float) sqlite3_value_double(v);
+            out = cast<float>::from(x);
+            return true;
+        }
+        case SqlFnTag::Double: {
+            double x = sqlite3_value_double(v);
+            out = cast<double>::from(x);
+            return true;
+        }
+        case SqlFnTag::Bool: {
+            bool x = sqlite3_value_int64(v) != 0;
+            out = cast<bool>::from(x);
+            return true;
+        }
+        case SqlFnTag::String: {
+            // sqlite returns const unsigned char *; the daslang side expects
+            // a `string` (pointer + null terminator). Lifetime: SQLite owns
+            // the buffer for the duration of the function call (until the
+            // next sqlite3_value_* call on the same value), which is more
+            // than enough — we invoke immediately and don't retain.
+            const char * s = (const char *) sqlite3_value_text(v);
+            if ( !s ) s = "";
+            out = cast<const char *>::from(s);
+            return true;
+        }
+    }
+    sqlite3_result_error(sctx, "register_function: internal: unknown SqlFnTag", -1);
+    return false;
+}
+
+static __forceinline void marshal_result (
+        sqlite3_context * sctx, vec4f result, SqlFnTag retTag ) {
+    switch ( retTag ) {
+        case SqlFnTag::Int:
+            sqlite3_result_int64(sctx, (int64_t) cast<int32_t>::to(result));
+            return;
+        case SqlFnTag::Int64:
+            sqlite3_result_int64(sctx, cast<int64_t>::to(result));
+            return;
+        case SqlFnTag::Float:
+            sqlite3_result_double(sctx, (double) cast<float>::to(result));
+            return;
+        case SqlFnTag::Double:
+            sqlite3_result_double(sctx, cast<double>::to(result));
+            return;
+        case SqlFnTag::Bool:
+            sqlite3_result_int64(sctx, cast<bool>::to(result) ? 1 : 0);
+            return;
+        case SqlFnTag::String: {
+            const char * s = cast<const char *>::to(result);
+            if ( !s ) {
+                sqlite3_result_null(sctx);
+            } else {
+                // SQLITE_TRANSIENT — sqlite makes its own copy.
+                sqlite3_result_text(sctx, s, -1, SQLITE_TRANSIENT);
+            }
+            return;
+        }
+    }
+    // Defensive: matches the fallback in marshal_one_arg. The macro emit
+    // always passes a valid tag, but if a future contributor adds an
+    // SqlFnTag without extending the switch, SQLite gets a defined error
+    // instead of an undefined no-result-was-set call.
+    sqlite3_result_error(sctx, "register_function: internal: unknown SqlFnTag", -1);
+}
+
+static void scalar_trampoline ( sqlite3_context * sctx, int argc, sqlite3_value ** argv ) {
+    auto R = (RegisteredScalarFn *) sqlite3_user_data(sctx);
+    if ( !R || !R->context || !R->fn.PTR ) {
+        sqlite3_result_error(sctx, "register_function: invalid registration", -1);
+        return;
+    }
+    if ( argc != R->nArgs ) {
+        sqlite3_result_error(sctx, "register_function: argument count mismatch", -1);
+        return;
+    }
+    // NULL short-circuit: any NULL input ⇒ NULL output, no invocation.
+    for ( int i = 0; i < argc; ++i ) {
+        if ( sqlite3_value_type(argv[i]) == SQLITE_NULL ) {
+            sqlite3_result_null(sctx);
+            return;
+        }
+    }
+    vec4f args[MAX_SQL_FN_ARGS] = { v_zero(), v_zero(), v_zero(), v_zero() };
+    for ( int i = 0; i < argc; ++i ) {
+        if ( !marshal_one_arg(argv[i], R->argTags[i], args[i], sctx) ) {
+            return;
+        }
+    }
+    vec4f result = v_zero();
+    bool ok = R->context->runWithCatch([&]() {
+        result = R->context->callOrFastcall(R->fn.PTR, args, &R->at);
+    });
+    if ( !ok ) {
+        // Read the panic message, then clear the context's exception state
+        // so the outer daslang stack (which is currently running the SQL
+        // statement that called us) sees a clean recovery — otherwise the
+        // exception leaks past the SQLite layer and re-throws on the caller.
+        const char * msg = R->context->getException();
+        std::string copy = msg ? msg : "register_function: panic in daslang function";
+        R->context->last_exception = R->context->exception;
+        R->context->exception = nullptr;
+        R->context->stopFlags = 0;
+        sqlite3_result_error(sctx, copy.c_str(), -1);
+        return;
+    }
+    marshal_result(sctx, result, R->retTag);
+}
+
+// Daslang-facing entry. Owns the RegisteredScalarFn allocation; on success,
+// SQLite takes ownership via xDestroy. On failure to register, we delete
+// here (sqlite3_create_function_v2 documents that xDestroy is NOT called
+// if the registration call itself fails).
+//
+// Tags are passed as four scalar uint8 slots rather than a TArray to keep
+// the daslang-side macro emit simple — unused slots are ignored according
+// to nArgs (0..MAX_SQL_FN_ARGS).
+int sqlite3_register_function (
+        sqlite3 * db, const char * name, Func fn, int nArgs,
+        uint8_t tag0, uint8_t tag1, uint8_t tag2, uint8_t tag3,
+        uint8_t retTag, bool deterministic, bool directonly,
+        Context * context, LineInfoArg * at ) {
+    if ( !db ) return SQLITE_MISUSE;
+    if ( !name || !*name ) return SQLITE_MISUSE;
+    if ( !fn.PTR ) return SQLITE_MISUSE;
+    if ( nArgs < 0 || nArgs > MAX_SQL_FN_ARGS ) return SQLITE_MISUSE;
+    auto R = new RegisteredScalarFn();
+    R->context = context;
+    R->fn      = fn;
+    R->retTag  = SqlFnTag(retTag);
+    R->nArgs   = uint8_t(nArgs);
+    R->at      = at ? *at : LineInfo();
+    const uint8_t tagSlots[MAX_SQL_FN_ARGS] = { tag0, tag1, tag2, tag3 };
+    for ( int i = 0; i < nArgs; ++i ) {
+        R->argTags[i] = SqlFnTag(tagSlots[i]);
+    }
+    int eTextRep = SQLITE_UTF8;
+    if ( deterministic ) eTextRep |= SQLITE_DETERMINISTIC;
+    if ( directonly )    eTextRep |= SQLITE_DIRECTONLY;
+    int rc = sqlite3_create_function_v2(
+        db, name, nArgs, eTextRep,
+        R, scalar_trampoline, nullptr, nullptr,
+        register_fn_destroy);
+    if ( rc != SQLITE_OK ) {
+        delete R;
+    }
+    return rc;
+}
+
+}

--- a/tests/dasSQLITE/failed_create_view.das
+++ b/tests/dasSQLITE/failed_create_view.das
@@ -1,0 +1,76 @@
+options gen2
+
+// _create_view shape errors. Each block triggers exactly one macro_error
+// (40104) from `SqlCreateViewMacro`.
+expect 40104:6
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+}
+
+// Right number of fields (3), correct types — for control reference.
+[sql_view(name = "CarNames3")]
+struct CarName3 {
+    Id : int
+    Name : string
+    Price : int
+}
+
+// Too few — only 2 fields vs Car's 3.
+[sql_view(name = "TooFew")]
+struct TooFew {
+    Id : int
+    Name : string
+}
+
+// Too many — 4 fields vs Car's 3.
+[sql_view(name = "TooMany")]
+struct TooMany {
+    Id : int
+    Name : string
+    Price : int
+    Extra : int
+}
+
+// Type mismatch on column 2 — Car.Name is string, V says int.
+[sql_view(name = "BadType")]
+struct BadType {
+    Id : int
+    Name : int
+    Price : int
+}
+
+// Plain struct (no [sql_view]) — must reject.
+struct NotAView {
+    Id : int
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+
+        // 1. column count mismatch — too few fields
+        db |> _create_view(type<TooFew>, db |> select_from(type<Car>))
+        // 2. column count mismatch — too many fields
+        db |> _create_view(type<TooMany>, db |> select_from(type<Car>))
+        // 3. column type mismatch
+        db |> _create_view(type<BadType>, db |> select_from(type<Car>))
+        // 4. type<V> lacks [sql_view]
+        db |> _create_view(type<NotAView>, db |> select_from(type<Car>))
+        // 5. captured-local in chain — bound parameters not allowed in CREATE VIEW
+        let cutoff = 200
+        db |> _create_view(type<CarName3>,
+            db |> select_from(type<Car>) |> _where(_.Price >= cutoff))
+        // 6. _to_array() terminal — redundant for a view
+        db |> _create_view(type<CarName3>,
+            db |> select_from(type<Car>) |> _to_array())
+    }
+}

--- a/tests/dasSQLITE/failed_each_sql_terminals.das
+++ b/tests/dasSQLITE/failed_each_sql_terminals.das
@@ -1,0 +1,36 @@
+options gen2
+
+// _each_sql rejects materializing terminals — _to_array, _first, _first_opt,
+// and aggregates each fire a macro_error pointing at `_sql(...)` for the
+// scalar / single-row form.
+expect 40104:4
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+
+        // 1. _to_array — redundant terminal
+        for (c in _each_sql(db |> select_from(type<Car>) |> _to_array())) {}
+
+        // 2. _first — single-row terminal
+        for (c in _each_sql(db |> select_from(type<Car>) |> _first())) {}
+
+        // 3. _first_opt — single-row terminal
+        for (c in _each_sql(db |> select_from(type<Car>) |> _first_opt())) {}
+
+        // 4. sum() — aggregate (scalar)
+        for (c in _each_sql(db |> select_from(type<Car>) |> _select(_.Price) |> sum())) {}
+    }
+}

--- a/tests/dasSQLITE/failed_register_function.das
+++ b/tests/dasSQLITE/failed_register_function.das
@@ -1,0 +1,50 @@
+options gen2
+
+// register_function rejects unsupported argument and return types at compile
+// time with a per-position diagnostic naming the offender.
+//
+//   1. struct argument
+//   2. struct return
+//   3. pointer argument
+//   4. lambda passed instead of @@fn (not a function pointer)
+//   5. > 4 arguments
+expect 40104:5
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+struct Foo {
+    x : int
+}
+
+def fn_struct_arg(f : Foo) : int {
+    return f.x
+}
+
+def fn_struct_return(x : int) : Foo {
+    return Foo(x = x)
+}
+
+def fn_ptr_arg(p : void?) : int {
+    return p == null ? 0 : 1
+}
+
+def fn_ok_two(a : int; b : int) : int {
+    return a + b
+}
+
+def fn_five_args(a : int; b : int; c : int; d : int; e : int) : int {
+    return a + b + c + d + e
+}
+
+[export]
+def main {
+    var inscope db = open_sqlite(":memory:")
+    db |> register_function("a", @@fn_struct_arg)
+    db |> register_function("b", @@fn_struct_return)
+    db |> register_function("c", @@fn_ptr_arg)
+    let lam = @(x : int) => x + 1
+    db |> register_function("d", lam)
+    db |> register_function("e", @@fn_five_args)
+}

--- a/tests/dasSQLITE/failed_sql_view_mutations.das
+++ b/tests/dasSQLITE/failed_sql_view_mutations.das
@@ -1,0 +1,50 @@
+options gen2
+
+// Predicate-form mutations against a [sql_view] type. Every call_macro
+// (_sql_update / _sql_delete / _sql_upsert and the try / returning
+// variants) must macro_error at compile time with the "views are
+// read-only" message — never reach the runtime panic stubs.
+expect 40104:8
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+[sql_view(name = "CarNames")]
+struct CarName {
+    Id : int
+    Name : string
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        db |> _create_view(type<CarName>, db |> select_from(type<Car>))
+
+        let dummy = CarName(Id = 1, Name = "x")
+
+        // 1. _sql_update — predicate update against view
+        _sql_update(db, type<CarName>, _.Id == 1, (Name = "y"))
+        // 2. _sql_try_update
+        _sql_try_update(db, type<CarName>, _.Id == 1, (Name = "y"))
+        // 3. _sql_update_returning
+        _sql_update_returning(db, type<CarName>, _.Id == 1, (Name = "y"))
+        // 4. _sql_try_update_returning
+        _sql_try_update_returning(db, type<CarName>, _.Id == 1, (Name = "y"))
+        // 5. _sql_delete
+        _sql_delete(db, type<CarName>, _.Id == 1)
+        // 6. _sql_try_delete
+        _sql_try_delete(db, type<CarName>, _.Id == 1)
+        // 7. _sql_upsert — uses validate_outer_upsert_args (different gate)
+        _sql_upsert(db, dummy, _.Id, (Name = "y"))
+        // 8. _sql_try_upsert
+        _sql_try_upsert(db, dummy, _.Id, (Name = "y"))
+    }
+}

--- a/tests/dasSQLITE/failed_sql_view_schema.das
+++ b/tests/dasSQLITE/failed_sql_view_schema.das
@@ -1,0 +1,78 @@
+options gen2
+
+// Each struct intentionally violates one [sql_view] schema-validation rule.
+// Each failure produces error 30111 = "macro [sql_view] failed to apply to
+// the structure". Validation is fail-fast (first error aborts that struct's
+// apply()) so each struct contributes exactly one error.
+expect 30111:9
+
+require daslib/sql
+require sqlite/sqlite_boost
+
+// 1. @sql_primary_key — views are read-only and don't declare keys.
+[sql_view(name = "V1")]
+struct V1 {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+// 2. @sql_unique — uniqueness belongs to the underlying table.
+[sql_view(name = "V2")]
+struct V2 {
+    Id : int
+    @sql_unique Name : string
+}
+
+// 3. @sql_computed — view body expressions live inside _create_view, not
+//    GENERATED ALWAYS columns.
+[sql_view(name = "V3")]
+struct V3 {
+    Id : int
+    @sql_computed = "Id * 2" Doubled : int
+}
+
+// 4. @sql_default_fn — defaults belong to the underlying table.
+[sql_view(name = "V4")]
+struct V4 {
+    Id : int
+    @sql_default_fn = "CURRENT_TIMESTAMP" CreatedAt : string
+}
+
+// 5. Daslang field initializer — view fields are read-only projections.
+[sql_view(name = "V5")]
+struct V5 {
+    Id : int
+    Name : string = "default"
+}
+
+// 6. @sql_references — FKs belong to the underlying table.
+[sql_table(name = "Parent")]
+struct Parent {
+    @sql_primary_key Id : int
+}
+[sql_view(name = "V6")]
+struct V6 {
+    Id : int
+    @sql_references = "Parent" ParentId : int
+}
+
+// 7. @sql_on_delete — FK action belongs to the underlying table.
+[sql_view(name = "V7")]
+struct V7 {
+    Id : int
+    @sql_on_delete = "cascade" ParentId : int
+}
+
+// 8. Both @sql_json and @sql_blob on the same field.
+[sql_view(name = "V8")]
+struct V8 {
+    Id : int
+    @sql_json @sql_blob Payload : tuple<a : int; b : string>
+}
+
+// 9. @sql_column collision — two fields renaming to the same SQL column.
+[sql_view(name = "V9")]
+struct V9 {
+    @sql_column = "name" A : string
+    @sql_column = "name" B : string
+}

--- a/tests/dasSQLITE/test_72_view_basic.das
+++ b/tests/dasSQLITE/test_72_view_basic.das
@@ -1,0 +1,176 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+[sql_view(name="ExpensiveCars")]
+struct ExpensiveCar {
+    Id    : int
+    Name  : string
+    Price : int
+}
+
+[sql_view(name="CarPrices")]
+struct CarPrice {
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 800))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+[test]
+def test_view_create_and_select_full_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> _create_view(type<ExpensiveCar>,
+            db |> select_from(type<Car>) |> _where(_.Price > 200))
+        let rows <- db |> select_from(type<ExpensiveCar>)
+        t |> equal(length(rows), 2, "Tesla + Lambo over 200")
+        t |> equal(rows[0].Name, "Tesla", "row 0 Tesla")
+        t |> equal(rows[1].Name, "Lambo", "row 1 Lambo")
+    }
+}
+
+[test]
+def test_view_named_tuple_projection(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> _create_view(type<CarPrice>,
+            db |> select_from(type<Car>) |> _select((Name = _.Name, Price = _.Price)))
+        let rows <- db |> select_from(type<CarPrice>)
+        t |> equal(length(rows), 5, "5 rows expected")
+        t |> equal(rows[0].Name, "BMW", "row 0 Name")
+        t |> equal(rows[0].Price, 100, "row 0 Price")
+    }
+}
+
+[test]
+def test_view_select_via_sql_macro(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> _create_view(type<ExpensiveCar>,
+            db |> select_from(type<Car>) |> _where(_.Price >= 200))
+        let names <- _sql(db |> select_from(type<ExpensiveCar>) |> _select(_.Name))
+        t |> equal(length(names), 3, "Audi + Tesla + Lambo")
+        t |> equal(names[0], "Audi", "names[0]")
+    }
+}
+
+[test]
+def test_drop_view_if_exists(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> _create_view(type<ExpensiveCar>,
+            db |> select_from(type<Car>) |> _where(_.Price > 200))
+        let before <- db |> select_from(type<ExpensiveCar>)
+        t |> equal(length(before), 2, "view exists before drop")
+        db |> drop_view_if_exists(type<ExpensiveCar>)
+        // re-creating with a different filter validates that drop succeeded
+        db |> _create_view(type<ExpensiveCar>,
+            db |> select_from(type<Car>) |> _where(_.Price > 100))
+        let after <- db |> select_from(type<ExpensiveCar>)
+        t |> equal(length(after), 3, "view re-created with looser filter")
+    }
+}
+
+[test]
+def test_try_drop_view_if_exists_idempotent(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        // dropping a non-existent view is a no-op (IF EXISTS)
+        let err = db |> try_drop_view_if_exists(type<ExpensiveCar>)
+        t |> equal(err |> is_some, false, "no error dropping a non-existent view")
+    }
+}
+
+// --- Enum + bitfield literals in `_create_view` predicates -------------
+// `is_const_or_captured_var` (collection side) recognized
+// ExprConstEnumeration / ExprConstBitfield as bindable constants, but
+// `is_const_literal` (CREATE VIEW inlining) didn't — so a chain like
+// `_where(_.Status == Status.Shipped)` failed with "cannot reference local
+// variables" even though the enum value is a compile-time constant.
+// These tests exercise both shapes; before the fix, both failed at
+// _create_view's compile-time inlining pass.
+
+enum Status {
+    Pending = 1
+    Shipped = 2
+    Delivered = 3
+}
+
+bitfield Permissions : uint8 {
+    Read
+    Write
+    Execute
+}
+
+[sql_table(name="Orders")]
+struct OrderRec {
+    @sql_primary_key Id : int
+    StatusVal : int
+    PermBits  : uint8
+}
+
+[sql_view(name="ShippedOrders")]
+struct ShippedOrder {
+    Id        : int
+    StatusVal : int
+    PermBits  : uint8
+}
+
+[sql_view(name="WriteableOrders")]
+struct WriteableOrder {
+    Id        : int
+    StatusVal : int
+    PermBits  : uint8
+}
+
+[test]
+def test_view_predicate_with_enum_literal(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<OrderRec>)
+        db |> insert(OrderRec(Id = 1, StatusVal = int(Status.Pending),   PermBits = uint8(0)))
+        db |> insert(OrderRec(Id = 2, StatusVal = int(Status.Shipped),   PermBits = uint8(0)))
+        db |> insert(OrderRec(Id = 3, StatusVal = int(Status.Delivered), PermBits = uint8(0)))
+        // Status.Shipped == 2 — must inline as the integer 2 inside the
+        // CREATE VIEW body since SQLite rejects ? placeholders there.
+        db |> _create_view(type<ShippedOrder>,
+            db |> select_from(type<OrderRec>) |> _where(_.StatusVal == int(Status.Shipped)))
+        let rows <- db |> select_from(type<ShippedOrder>)
+        t |> equal(length(rows), 1, "exactly one shipped order")
+        t |> equal(rows[0].Id, 2, "Id 2 is the shipped one")
+    }
+}
+
+[test]
+def test_view_predicate_with_bitfield_literal(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<OrderRec>)
+        let write_only = Permissions.Write
+        db |> insert(OrderRec(Id = 1, StatusVal = 0, PermBits = uint8(0)))
+        db |> insert(OrderRec(Id = 2, StatusVal = 0, PermBits = uint8(write_only)))
+        db |> insert(OrderRec(Id = 3, StatusVal = 0, PermBits = uint8(Permissions.Read | Permissions.Write)))
+        // Bitfield literal must inline as its underlying integer value.
+        db |> _create_view(type<WriteableOrder>,
+            db |> select_from(type<OrderRec>) |> _where(_.PermBits == uint8(Permissions.Write)))
+        let rows <- db |> select_from(type<WriteableOrder>)
+        t |> equal(length(rows), 1, "exactly one row with permbits == Write")
+        t |> equal(rows[0].Id, 2, "Id 2 has just Write")
+    }
+}

--- a/tests/dasSQLITE/test_74_register_function_basic.das
+++ b/tests/dasSQLITE/test_74_register_function_basic.das
@@ -1,0 +1,141 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Basic shapes: 0/1/2/3/4-arg, every supported type round-trips correctly.
+
+def fn_zero() : int64 {
+    return 42l
+}
+
+def fn_one_int(a : int) : int {
+    return a * 2
+}
+
+def fn_one_int64(a : int64) : int64 {
+    return a + 1l
+}
+
+def fn_one_double(a : double) : double {
+    return a * 2.5lf
+}
+
+def fn_one_float(a : float) : float {
+    return a * 0.5f
+}
+
+def fn_one_string(a : string) : string {
+    return a
+}
+
+def fn_one_bool(a : bool) : bool {
+    return !a
+}
+
+def fn_two_mixed(a : int; b : double) : double {
+    return double(a) + b
+}
+
+def fn_three_strings(a : string; b : string; c : string) : string {
+    return a + b + c
+}
+
+def fn_four_int(a : int; b : int; c : int; d : int) : int {
+    return a + b + c + d
+}
+
+[test]
+def test_zero_arg(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_zero", @@fn_zero)
+        let v = db |> query_scalar("SELECT fn_zero()", type<int64>)
+        t |> equal(v, 42l, "zero-arg int64 result")
+    }
+}
+
+[test]
+def test_one_arg_int(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_one_int", @@fn_one_int)
+        let v = db |> query_scalar("SELECT fn_one_int(7)", type<int>)
+        t |> equal(v, 14, "int*2")
+    }
+}
+
+[test]
+def test_one_arg_int64(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_one_int64", @@fn_one_int64)
+        let v = db |> query_scalar("SELECT fn_one_int64(100)", type<int64>)
+        t |> equal(v, 101l, "int64+1")
+    }
+}
+
+[test]
+def test_one_arg_double(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_one_double", @@fn_one_double)
+        let v = db |> query_scalar("SELECT fn_one_double(2.0)", type<double>)
+        t |> equal(v, 5.0lf, "double*2.5")
+    }
+}
+
+[test]
+def test_one_arg_float(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_one_float", @@fn_one_float)
+        let v = db |> query_scalar("SELECT fn_one_float(8.0)", type<float>)
+        t |> equal(v, 4.0f, "float*0.5")
+    }
+}
+
+[test]
+def test_one_arg_string(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_one_string", @@fn_one_string)
+        let v = db |> query_scalar("SELECT fn_one_string('hello')", type<string>)
+        t |> equal(v, "hello", "string round-trip")
+    }
+}
+
+[test]
+def test_one_arg_bool(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_one_bool", @@fn_one_bool)
+        let r = db |> query_scalar("SELECT fn_one_bool(0)", type<int>)
+        t |> equal(r, 1, "bool: !false = true (1)")
+        let r2 = db |> query_scalar("SELECT fn_one_bool(1)", type<int>)
+        t |> equal(r2, 0, "bool: !true = false (0)")
+    }
+}
+
+[test]
+def test_two_arg_mixed(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_two_mixed", @@fn_two_mixed)
+        let v = db |> query_scalar("SELECT fn_two_mixed(3, 0.5)", type<double>)
+        t |> equal(v, 3.5lf, "int+double mixed")
+    }
+}
+
+[test]
+def test_three_arg_string(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_three_strings", @@fn_three_strings)
+        let v = db |> query_scalar("SELECT fn_three_strings('a', 'b', 'c')", type<string>)
+        t |> equal(v, "abc", "concat 3 strings")
+    }
+}
+
+[test]
+def test_four_arg_int(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_four_int", @@fn_four_int)
+        let v = db |> query_scalar("SELECT fn_four_int(1, 2, 3, 4)", type<int>)
+        t |> equal(v, 10, "sum of 4 ints")
+    }
+}

--- a/tests/dasSQLITE/test_75_register_function_null_panic.das
+++ b/tests/dasSQLITE/test_75_register_function_null_panic.das
@@ -1,0 +1,79 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// NULL short-circuit + panic recovery semantics.
+//
+// NULL: if any argument cell is SQL NULL, the trampoline must NOT invoke
+// the daslang function and the SELECT must produce NULL. We assert this
+// via SUM(...) IS NULL plus a side-channel counter that records every
+// invocation.
+//
+// Panic: a `panic(...)` inside the daslang function is caught and the
+// SELECT statement fails with an error message that includes the panic
+// text. The connection itself stays usable for subsequent statements.
+
+var g_call_count = 0
+
+def fn_count(x : int) : int {
+    g_call_count = g_call_count + 1
+    return x + 1
+}
+
+def fn_panic(x : int) : int {
+    if (x < 0) {
+        panic("negative input rejected")
+    }
+    return x * 2
+}
+
+def fn_panic2(x : int) : int {
+    return x * x
+}
+
+[test]
+def test_null_short_circuits_invocation(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_count", @@fn_count)
+        g_call_count = 0
+        // NULL arg should NOT invoke fn_count and SELECT should produce NULL.
+        let r <- db |> try_query_scalar("SELECT fn_count(NULL) IS NULL", type<int>)
+        t |> equal(r |> is_ok, true, "NULL-input SELECT succeeds")
+        t |> equal(r |> unwrap, 1, "fn_count(NULL) yields NULL")
+        t |> equal(g_call_count, 0, "daslang fn was NOT called when input was NULL")
+        // Non-NULL arg DOES invoke.
+        let r2 = db |> query_scalar("SELECT fn_count(5)", type<int>)
+        t |> equal(r2, 6, "fn_count(5) = 6")
+        t |> equal(g_call_count, 1, "daslang fn called exactly once for non-NULL input")
+    }
+}
+
+[test]
+def test_panic_surfaces_as_error_and_connection_survives(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_panic", @@fn_panic)
+        let r <- db |> try_query_scalar("SELECT fn_panic(-1)", type<int>)
+        t |> equal(r |> is_err, true, "panic surfaces as Err")
+        let msg = r |> unwrap_err
+        t |> equal(find(msg, "negative input rejected") >= 0, true,
+            "Err message contains the panic text — got: '{msg}'")
+        // Connection stays usable; a subsequent successful query works.
+        let r2 = db |> query_scalar("SELECT fn_panic(7)", type<int>)
+        t |> equal(r2, 14, "post-panic call succeeds")
+    }
+}
+
+[test]
+def test_panic_inside_aggregation(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn_panic2", @@fn_panic2)
+        // Square some values; verify normal aggregation works.
+        let r = db |> query_scalar(
+            "SELECT fn_panic2(2) + fn_panic2(3)", type<int>)
+        t |> equal(r, 13, "4 + 9 = 13")
+    }
+}

--- a/tests/dasSQLITE/test_76_register_function_use_in_chains.das
+++ b/tests/dasSQLITE/test_76_register_function_use_in_chains.das
@@ -1,0 +1,68 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Registered functions should be usable in WHERE / ORDER BY / projection
+// just like a built-in scalar. We verify that a deterministic UDF embeds
+// into common chain shapes.
+
+[sql_table(name = "Items")]
+struct Item {
+    @sql_primary_key Id : int
+    Name : string
+    Score : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<Item>)
+    db |> insert(Item(Id = 1, Name = "alpha", Score = 10))
+    db |> insert(Item(Id = 2, Name = "beta",  Score = 30))
+    db |> insert(Item(Id = 3, Name = "gamma", Score = 20))
+    db |> insert(Item(Id = 4, Name = "delta", Score = 50))
+}
+
+def doubler(x : int) : int {
+    return x * 2
+}
+
+def add_prefix(s : string) : string {
+    return "X_" + s
+}
+
+[test]
+def test_udf_in_where(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> register_function("doubler", @@doubler, true)
+        // doubler(Score) > 30 means Score > 15 → Items 2,3,4 match.
+        let n = db |> query_scalar("SELECT COUNT(*) FROM Items WHERE doubler(Score) > 30", type<int>)
+        t |> equal(n, 3, "doubler(Score) > 30 — 3 rows")
+    }
+}
+
+[test]
+def test_udf_in_order_by(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> register_function("doubler", @@doubler, true)
+        // ORDER BY doubler(Score) DESC ⇒ items by Score desc: 50, 30, 20, 10
+        let top = db |> query_scalar(
+            "SELECT Name FROM Items ORDER BY doubler(Score) DESC LIMIT 1",
+            type<string>)
+        t |> equal(top, "delta", "highest score is delta")
+    }
+}
+
+[test]
+def test_udf_string_in_projection(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        db |> register_function("add_prefix", @@add_prefix, true)
+        let v = db |> query_scalar("SELECT add_prefix(Name) FROM Items WHERE Id = 1", type<string>)
+        t |> equal(v, "X_alpha", "prefix prepended")
+    }
+}

--- a/tests/dasSQLITE/test_77_register_function_lifetime.das
+++ b/tests/dasSQLITE/test_77_register_function_lifetime.das
@@ -1,0 +1,64 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Lifetime semantics:
+//   1. Re-registering the same name replaces the prior binding cleanly.
+//   2. A registered function lives only on its connection — it is not
+//      visible from a different connection (per-DB scope).
+//   3. Across connection close + open the binding does not survive.
+
+def fn_v1(x : int) : int {
+    return x + 100
+}
+
+def fn_v2(x : int) : int {
+    return x + 200
+}
+
+[test]
+def test_replace_by_re_registering(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> register_function("fn", @@fn_v1)
+        let r1 = db |> query_scalar("SELECT fn(0)", type<int>)
+        t |> equal(r1, 100, "v1 active")
+        // Re-register with a different daslang fn under the same name.
+        db |> register_function("fn", @@fn_v2)
+        let r2 = db |> query_scalar("SELECT fn(0)", type<int>)
+        t |> equal(r2, 200, "v2 replaces v1")
+    }
+}
+
+[test]
+def test_per_connection_scope(t : T?) {
+    var inscope db_a = open_sqlite(":memory:")
+    var inscope db_b = open_sqlite(":memory:")
+    db_a |> register_function("fn", @@fn_v1)
+    // db_a sees it.
+    let ra = db_a |> query_scalar("SELECT fn(1)", type<int>)
+    t |> equal(ra, 101, "fn registered on db_a")
+    // db_b does NOT see it — query should error with "no such function".
+    let rb <- db_b |> try_query_scalar("SELECT fn(1)", type<int>)
+    t |> equal(rb |> is_err, true, "fn not visible on db_b")
+    let msg = rb |> unwrap_err
+    t |> equal(find(msg, "no such function") >= 0, true,
+        "error mentions 'no such function' — got: '{msg}'")
+}
+
+[test]
+def test_does_not_persist_across_open(t : T?) {
+    {
+        var inscope db = open_sqlite(":memory:")
+        db |> register_function("fn", @@fn_v1)
+        let v = db |> query_scalar("SELECT fn(2)", type<int>)
+        t |> equal(v, 102, "registered on first connection")
+    }
+    // Fresh `:memory:` connection has its own (empty) function table.
+    var inscope db2 = open_sqlite(":memory:")
+    let r <- db2 |> try_query_scalar("SELECT fn(0)", type<int>)
+    t |> equal(r |> is_err, true, "fn does not survive new connection")
+}

--- a/tests/dasSQLITE/test_80_pragma_basic.das
+++ b/tests/dasSQLITE/test_80_pragma_basic.das
@@ -1,0 +1,77 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[test]
+def test_set_pragma_string_journal_mode(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        // :memory: databases ignore journal_mode at the disk level but
+        // accept the pragma syntax — fine for round-tripping the value.
+        db |> set_pragma("journal_mode", "MEMORY")
+        let mode = db |> query_scalar("PRAGMA journal_mode", type<string>)
+        // SQLite normalizes pragma values to lowercase.
+        t |> equal(mode, "memory", "journal_mode round-trips")
+    }
+}
+
+[test]
+def test_set_pragma_int_busy_timeout(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> set_pragma("busy_timeout", 1500l)
+        let ms = db |> query_scalar("PRAGMA busy_timeout", type<int>)
+        t |> equal(ms, 1500, "busy_timeout round-trips")
+    }
+}
+
+[test]
+def test_set_pragma_bool_foreign_keys(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        // with_sqlite turns FKs on by default; toggle off + on to exercise both branches.
+        db |> set_pragma("foreign_keys", false)
+        let off = db |> query_scalar("PRAGMA foreign_keys", type<int>)
+        t |> equal(off, 0, "foreign_keys = OFF")
+
+        db |> set_pragma("foreign_keys", true)
+        let on = db |> query_scalar("PRAGMA foreign_keys", type<int>)
+        t |> equal(on, 1, "foreign_keys = ON")
+    }
+}
+
+[test]
+def test_try_set_pragma_unknown_succeeds_silently(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        // SQLite is famously permissive with unknown pragma names — they
+        // succeed silently rather than erroring. Document the behavior.
+        let err = db |> try_set_pragma("not_a_real_pragma_xyzzy", "any")
+        t |> equal(err |> is_some, false, "unknown pragma is a no-op")
+    }
+}
+
+[test]
+def test_apply_recommended_pragmas(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let err = db |> try_apply_recommended_pragmas()
+        t |> equal(err |> is_some, false, "recommended pragmas applied without error")
+        // Verify the boolean / int values landed (journal_mode/synchronous are
+        // accepted but :memory: normalizes journal_mode to memory).
+        let busy = db |> query_scalar("PRAGMA busy_timeout", type<int>)
+        t |> equal(busy, 5000, "busy_timeout = 5000")
+        let fks = db |> query_scalar("PRAGMA foreign_keys", type<int>)
+        t |> equal(fks, 1, "foreign_keys ON")
+    }
+}
+
+[test]
+def test_pragma_string_value_with_quote_escapes(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        // The string overload doubles embedded single quotes so the SQL
+        // stays well-formed. Use a synthetic pragma name (which SQLite
+        // ignores) so the test is portable across versions.
+        let err = db |> try_set_pragma("xyzzy_test_pragma", "a''b")
+        t |> equal(err |> is_some, false, "embedded quotes don't break the SQL")
+    }
+}

--- a/tests/dasSQLITE/test_83_backup_to.das
+++ b/tests/dasSQLITE/test_83_backup_to.das
@@ -1,0 +1,94 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+require daslib/fio
+
+[sql_table(name = "Items")]
+struct Item {
+    @sql_primary_key Id : int
+    Name : string
+    Qty : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<Item>)
+    db |> insert(Item(Id = 1, Name = "alpha", Qty = 10))
+    db |> insert(Item(Id = 2, Name = "beta",  Qty = 20))
+    db |> insert(Item(Id = 3, Name = "gamma", Qty = 30))
+}
+
+[test]
+def test_backup_to_memory_runner(t : T?) {
+    with_sqlite(":memory:") $(src) {
+        fixture(src)
+        with_sqlite(":memory:") $(dst) {
+            src |> backup_to(dst)
+            let n = dst |> query_scalar("SELECT COUNT(*) FROM Items", type<int>)
+            t |> equal(n, 3, "snapshot row count")
+            let names <- dst |> select_from(type<Item>)
+            t |> equal(length(names), 3, "snapshot rows materialize")
+            t |> equal(names[1].Name, "beta", "row content preserved")
+        }
+    }
+}
+
+[test]
+def test_backup_to_path_round_trip(t : T?) {
+    let r = create_temp_file_result("dastest_backup", ".db")
+    t |> equal(r is value, true, "temp file path obtained")
+    let path = unsafe(r.value)
+    // create_temp_file_result already created the file as empty; remove
+    // it so sqlite3_open creates a fresh database for the backup.
+    remove(path)
+    with_sqlite(":memory:") $(src) {
+        fixture(src)
+        src |> backup_to(path)
+    }
+    t |> equal(fexist(path), true, "snapshot file written")
+    {
+        var inscope reopened = open_sqlite(path)
+        let qty_total = reopened |> query_scalar("SELECT SUM(Qty) FROM Items", type<int>)
+        t |> equal(qty_total, 60, "10 + 20 + 30 = 60")
+        let r3 = reopened |> query_one("SELECT * FROM Items WHERE Id = 3", type<Item>)
+        t |> equal(r3.Name, "gamma", "row 3 round-tripped")
+    }
+    remove(path)
+}
+
+[test]
+def test_try_backup_to_unwritable_path_returns_err(t : T?) {
+    // try_backup_to(string) used to call open_sqlite(...) which panics on
+    // a path SQLite can't open; that broke the try_* contract. After the
+    // fix it threads through try_open_sqlite and surfaces the error as
+    // some(errmsg) for the caller to recover from.
+    with_sqlite(":memory:") $(src) {
+        fixture(src)
+        // A directory that doesn't exist — sqlite3_open returns an error
+        // rather than creating intermediate dirs.
+        let bogus = "/this/path/should/not/exist/snapshot.db"
+        let err = src |> try_backup_to(bogus)
+        t |> equal(err |> is_some, true, "open failure surfaces as Err, not panic")
+    }
+}
+
+[test]
+def test_backup_overwrites_existing_destination_runner(t : T?) {
+    // sqlite3_backup_run replaces the destination wholesale.
+    with_sqlite(":memory:") $(src) {
+        fixture(src)
+        with_sqlite(":memory:") $(dst) {
+            dst |> create_table(type<Item>)
+            dst |> insert(Item(Id = 99, Name = "stale", Qty = 0))
+            src |> backup_to(dst)
+            let n = dst |> query_scalar("SELECT COUNT(*) FROM Items", type<int>)
+            t |> equal(n, 3, "stale row gone, src rows now present")
+            let stale <- dst |> try_query_one("SELECT * FROM Items WHERE Id = 99", type<Item>)
+            t |> equal(stale |> is_err, true, "stale row 99 not in snapshot")
+        }
+    }
+}

--- a/tests/dasSQLITE/test_85_vacuum.das
+++ b/tests/dasSQLITE/test_85_vacuum.das
@@ -1,0 +1,68 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+[test]
+def test_vacuum_in_memory_runs(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        for (i in range(50)) {
+            db |> insert(Car(Id = i + 1, Name = "C{i}"))
+        }
+        // VACUUM on :memory: just rebuilds the in-memory database in place.
+        db |> vacuum()
+        let n = db |> query_scalar("SELECT COUNT(*) FROM Cars", type<int>)
+        t |> equal(n, 50, "rows survived VACUUM")
+    }
+}
+
+[test]
+def test_try_vacuum_in_transaction_returns_err(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        var saw_err = false
+        db |> with_transaction() {
+            let err = db |> try_vacuum()
+            saw_err = (err |> is_some)
+        }
+        t |> equal(saw_err, true, "try_vacuum returned Err while inside a transaction")
+    }
+}
+
+[test]
+def test_optimize_no_op_on_empty_db(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let err = db |> try_optimize()
+        t |> equal(err |> is_some, false, "PRAGMA optimize on a fresh db is a no-op")
+    }
+}
+
+[test]
+def test_integrity_check_reports_ok(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        db |> insert(Car(Id = 1, Name = "BMW"))
+        let issues <- db |> integrity_check()
+        t |> equal(length(issues), 1, "one row reported")
+        t |> equal(issues[0], "ok", "healthy db reports 'ok'")
+    }
+}
+
+[test]
+def test_quick_check_reports_ok(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let issues <- db |> quick_check()
+        t |> equal(length(issues), 1, "one row reported")
+        t |> equal(issues[0], "ok", "healthy db reports 'ok'")
+    }
+}

--- a/tests/dasSQLITE/test_90_each_sql_basic.das
+++ b/tests/dasSQLITE/test_90_each_sql_basic.das
@@ -1,0 +1,101 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 800))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+[test]
+def test_each_sql_iterate_full_rows(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        var seen : array<string>
+        for (c in _each_sql(db |> select_from(type<Car>))) {
+            seen |> push(c.Name)
+        }
+        t |> equal(length(seen), 5, "5 rows yielded")
+        t |> equal(seen[0], "BMW",   "row 0")
+        t |> equal(seen[4], "Lambo", "row 4")
+    }
+}
+
+[test]
+def test_each_sql_break_finalizes_stmt(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Break after 2 rows. If the stmt isn't finalized, a follow-up
+        // INSERT on the same DB would block (SQLite locks held by the
+        // open read cursor). The fact that the INSERT below succeeds
+        // proves the generator's finally ran.
+        var count = 0
+        for (_ in _each_sql(db |> select_from(type<Car>))) {
+            count++
+            if (count >= 2) {
+                break
+            }
+        }
+        t |> equal(count, 2, "broke after 2 rows")
+        // Mutating insert must succeed — would error/block if stmt leaked.
+        db |> insert(Car(Id = 99, Name = "Test", Price = 1))
+        let n = db |> query_scalar("SELECT COUNT(*) FROM Cars", type<int>)
+        t |> equal(n, 6, "insert succeeded after early break")
+    }
+}
+
+[test]
+def test_each_sql_with_where_filter(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let threshold = 200
+        var matched = 0
+        for (c in _each_sql(db |> select_from(type<Car>) |> _where(_.Price >= threshold))) {
+            matched++
+            t |> equal(c.Price >= 200, true, "row matches predicate")
+        }
+        t |> equal(matched, 3, "Audi + Tesla + Lambo (>= 200)")
+    }
+}
+
+[test]
+def test_each_sql_single_column_projection(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        var names : array<string>
+        for (n in _each_sql(db |> select_from(type<Car>) |> _select(_.Name))) {
+            names |> push(n)
+        }
+        t |> equal(length(names), 5, "5 names")
+        t |> equal(names[2], "Tesla", "row 2")
+    }
+}
+
+[test]
+def test_each_sql_named_tuple_projection(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        var pairs : array<int>
+        for (p in _each_sql(db |> select_from(type<Car>) |> _select((Id = _.Id, Price = _.Price)))) {
+            pairs |> push(p.Id * 1000 + p.Price)
+        }
+        t |> equal(length(pairs), 5, "5 named-tuple rows")
+        t |> equal(pairs[0], 1100, "row 0: 1*1000+100")
+        t |> equal(pairs[4], 5999, "row 4: 5*1000+999")
+    }
+}

--- a/tutorials/sql/31-views.das
+++ b/tutorials/sql/31-views.das
@@ -1,0 +1,176 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 31 — SQL views.
+//
+// A view is a saved SELECT: a virtual table whose rows are produced on
+// demand by re-running its body. dasSQLITE represents a view with the
+// same struct-driven story as a table — declare a struct describing the
+// projected columns, attach `[sql_view]`, and the same read-side helpers
+// (`select_from(type<V>)`, `_sql(db |> select_from(type<V>) |> ...)`,
+// `column_info(type<V>)`) work without dispatching on table-vs-view.
+//
+// Mutation paths are blocked: views are read-only.
+//   - Predicate-form: `_sql_update(type<V>, ...)`,  `_sql_delete(...)`,
+//     `_sql_upsert(...)` — caught at compile time with a clear error.
+//   - Row-form: `insert(viewRow)` / `update(...)` / `delete_(...)` —
+//     panics at runtime with a "views are read-only" message.
+//
+// In production, view DDL belongs in a migration body so the schema
+// lives alongside table DDL — see a future tut covering migrations.
+// For now we create views inline at app setup.
+
+[sql_table(name = "Customers")]
+struct Customer {
+    @sql_primary_key Id : int
+    Name : string
+    City : string
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    @sql_references = "Customer" CustomerId : int
+    Amount : int
+    Status : string
+}
+
+// --- A view describing a derived shape ----------------------------------
+// `[sql_view]` accepts the same field-level annotations as `[sql_table]`
+// in the read-only subset:
+//   - `@sql_column = "..."`           rename the on-disk column
+//   - `@sql_json` / `@sql_blob`       opt non-scalar storage adapters
+// Anything that affects DDL of the underlying table is rejected loud:
+// keys, uniqueness, computed columns, defaults, foreign keys.
+[sql_view(name = "BigOrders")]
+struct BigOrder {
+    Id : int
+    CustomerId : int
+    Amount : int
+    Status : string
+}
+
+// A second view projecting a join + alias. View column names come from
+// the struct field names — the projection's record-name aliases (the
+// `Name = ...` in `_select((Name = ...))`) only have to match by count
+// and per-column type; the view's column names are taken from the V
+// struct's field names (and `@sql_column` renames).
+[sql_view(name = "OrderSummary")]
+struct OrderSummary {
+    OrderId : int
+    Customer : string
+    Amount : int
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Customer>)
+        db |> create_table(type<Order>)
+        db |> insert(Customer(Id = 1, Name = "Alice",   City = "Berlin"))
+        db |> insert(Customer(Id = 2, Name = "Bob",     City = "Lyon"))
+        db |> insert(Customer(Id = 3, Name = "Carmen",  City = "Madrid"))
+        db |> insert(Order(Id = 10, CustomerId = 1, Amount = 50,  Status = "shipped"))
+        db |> insert(Order(Id = 11, CustomerId = 1, Amount = 250, Status = "shipped"))
+        db |> insert(Order(Id = 12, CustomerId = 2, Amount = 800, Status = "pending"))
+        db |> insert(Order(Id = 13, CustomerId = 3, Amount = 30,  Status = "shipped"))
+
+        // --- _create_view: filtered full-row view --------------------------
+        // The chain looks identical to an `_sql(...)` chain. The macro
+        // walks it, builds the SELECT, validates the projection vs V's
+        // fields (count + per-position type), and emits a `db |> exec`
+        // of the resulting `CREATE VIEW name(c1, c2, …) AS SELECT …`.
+        db |> _create_view(type<BigOrder>,
+            db |> select_from(type<Order>) |> _where(_.Amount >= 100))
+
+        // --- Querying the view: same surface as a table --------------------
+        // `select_from(type<V>)` works directly — the macro emits the
+        // same `_sql_select_all_sql` helper that `[sql_table]` does, so
+        // there is no view-specific call site.
+        for (b in db |> select_from(type<BigOrder>)) {
+            to_log(LOG_INFO, "BigOrder #{b.Id}: cust={b.CustomerId} amt={b.Amount} status={b.Status}\n")
+        }
+
+        // --- _create_view with a JOIN + named-tuple projection -------------
+        // Multi-source chains (`_join_inner` / `_join_left` from chunk 5)
+        // produce a SELECT with table aliases. The view's struct supplies
+        // the column names; the `_select((... = ...))` aliases here just
+        // have to match by position and type.
+        db |> _create_view(type<OrderSummary>,
+            db |> select_from(type<Order>)
+                |> _join(db |> select_from(type<Customer>),
+                         $(o : Order, c : Customer) => o.CustomerId == c.Id,
+                         $(o : Order, c : Customer) => (OrderId = o.Id, Customer = c.Name, Amount = o.Amount)))
+
+        for (s in db |> select_from(type<OrderSummary>)) {
+            to_log(LOG_INFO, "OrderSummary #{s.OrderId} for {s.Customer}: {s.Amount}\n")
+        }
+
+        // --- column_info over a view --------------------------------------
+        // The same metadata helper that works on tables works on views.
+        // Note `is_pk` is always false (views don't have primary keys
+        // even when the underlying table does).
+        for (c in column_info(type<BigOrder>)) {
+            to_log(LOG_INFO, "  col {c.name}  type={int(c.data_type)}  pk={c.is_pk}  nullable={c.is_nullable}\n")
+        }
+
+        // --- drop_view_if_exists --------------------------------------
+        // Idempotent; missing-view is a no-op (matching DROP TABLE IF
+        // EXISTS semantics). The strict form panics on real errors; the
+        // try form returns SqlError.
+        db |> drop_view_if_exists(type<BigOrder>)
+        // Re-create with a tighter filter — proves the drop succeeded.
+        db |> _create_view(type<BigOrder>,
+            db |> select_from(type<Order>) |> _where(_.Amount >= 500))
+        to_log(LOG_INFO, "rows in re-created BigOrder: {length(db |> select_from(type<BigOrder>))}\n")
+
+        // --- Raw-SQL escape hatch ----------------------------------------
+        // `_create_view`'s chain is the LINQ-shaped subset (single source
+        // or join, FullRow / NamedTuple / GroupedNamedTuple / SingleColumn /
+        // Aggregate). Anything outside that — window functions, recursive
+        // CTEs, custom SQL functions — needs raw `db |> exec("CREATE VIEW
+        // … AS …")`. The view created this way is queryable through the
+        // same `select_from(type<V>)` rail as long as you declare a
+        // matching V struct with `[sql_view]`.
+        db |> exec(
+            "CREATE VIEW IF NOT EXISTS CustomerRank AS " +
+            "SELECT CustomerId, ROW_NUMBER() OVER (ORDER BY SUM(Amount) DESC) AS Rank, " +
+            "       SUM(Amount) AS Total " +
+            "FROM Orders GROUP BY CustomerId")
+    }
+}
+
+// --- Mutation attempts fail loud ---------------------------------------
+//
+// The compile-time gate fires on:
+//   - `_sql_update(type<BigOrder>, ...)`
+//   - `_sql_delete(type<BigOrder>, ...)`
+//   - `_sql_upsert(bigOrderRow, ...)`
+// each with: "cannot mutate [sql_view] 'BigOrder' — views are read-only.
+// Mutate the underlying table(s) and re-query the view."
+//
+// The runtime gate fires on row-form mutations (`insert(bigOrderRow)`,
+// `update(bigOrderRow)`, `delete_(bigOrderRow)`) — these panic with the
+// same message. Real mutating workflows update the underlying tables
+// (Customer / Order here) and re-query the view to see the new state.
+
+// --- Bound-parameter limitation ---------------------------------------
+//
+// SQLite stores view bodies as text in `sqlite_schema`, so `?`
+// placeholders are not allowed inside a view definition. `_create_view`
+// rejects chains that reference captured locals:
+//
+//     let cutoff = 100
+//     db |> _create_view(type<BigOrder>,                  // ← compile error
+//         db |> select_from(type<Order>) |> _where(_.Amount >= cutoff))
+//
+// Use literal values inside the view body (compile-time constants
+// inline into the SQL); apply runtime filtering at the call site:
+//
+//     db |> _create_view(type<BigOrder>,
+//         db |> select_from(type<Order>) |> _where(_.Amount >= 100))
+//     let recent <- _sql(db |> select_from(type<BigOrder>)
+//                         |> _where(_.Amount >= cutoff))   // ← bind at query

--- a/tutorials/sql/32-sql_functions.das
+++ b/tutorials/sql/32-sql_functions.das
@@ -1,0 +1,155 @@
+options gen2
+
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+require math
+
+// Tutorial 32 — User-defined SQL scalar functions.
+//
+// SQL is fluent at filtering and grouping but speaks a small built-in
+// vocabulary. When an expression doesn't fit (a custom hash, a domain-
+// specific scoring formula, a string normalizer), `register_function`
+// binds an ordinary daslang function as a SQL scalar so it can be used
+// inside any expression — `WHERE`, projection, `ORDER BY`, indexes,
+// view bodies, anywhere a built-in scalar would go.
+//
+// Lifetime: the registration is per-connection. The function is
+// available until the connection closes (or `DROP FUNCTION` if exposed
+// in a future chunk). Re-registering the same name replaces the prior
+// binding.
+//
+// NULL handling: if any argument is SQL NULL, the trampoline emits NULL
+// without invoking the daslang function — the standard SQL behavior of
+// built-in scalars (`abs(NULL) -> NULL`, `length(NULL) -> NULL`).
+// Explicit `Option<T>` arg types for in-function NULL handling are
+// planned but not in this chunk.
+//
+// Panic recovery: a panic inside the daslang function is caught and
+// surfaced to SQLite as an error on that statement; `try_query` returns
+// `Err` carrying the panic message. The connection itself is unaffected
+// and the next statement runs normally.
+
+// --- Supported types ---------------------------------------------------
+// register_function maps daslang scalar types to SQLite cells:
+//
+//   int, int64, bool   ↔ INTEGER
+//   float, double      ↔ REAL
+//   string             ↔ TEXT
+//
+// Unsupported types (structs, arrays, pointers, lambdas, classes) fail
+// at compile time with a per-position diagnostic.
+
+// --- Example 1 — A scoring formula -------------------------------------
+// Game-style damage calculation: base × (1 − armor/100) × multiplier.
+// Marked deterministic so SQLite is allowed to factor it out of inner
+// loops or use it as the indexed expression in a `CREATE INDEX … ON …`.
+def damage_formula(base : float; armor : int; mult : float) : float {
+    return base * (1.0f - float(armor) / 100.0f) * mult
+}
+
+// --- Example 2 — String normalization ----------------------------------
+// A trivial "hash" — in real code this would be a domain hasher.
+def short_hash(s : string) : int64 {
+    var h = 1469598103934665603l
+    for (c in s) {
+        h = (h ^ int64(c)) * 1099511628211l
+    }
+    return h
+}
+
+// --- Example 3 — Trip-by-trip distance ---------------------------------
+def euclid(x1 : float; y1 : float; x2 : float; y2 : float) : float {
+    let dx = x2 - x1
+    let dy = y2 - y1
+    return sqrt(dx * dx + dy * dy)
+}
+
+[sql_table(name = "Enemies")]
+struct Enemy {
+    @sql_primary_key Id : int
+    Name : string
+    Hp : float
+    Armor : int
+}
+
+[sql_table(name = "Trips")]
+struct Trip {
+    @sql_primary_key Id : int
+    StartX : float
+    StartY : float
+    EndX : float
+    EndY : float
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Enemy>)
+        db |> create_table(type<Trip>)
+
+        db |> insert(Enemy(Id = 1, Name = "goblin",  Hp = 100.0f, Armor = 10))
+        db |> insert(Enemy(Id = 2, Name = "ogre",    Hp = 800.0f, Armor = 30))
+        db |> insert(Enemy(Id = 3, Name = "dragon",  Hp = 5000.0f, Armor = 60))
+        db |> insert(Trip(Id = 1, StartX = 0.0f, StartY = 0.0f, EndX = 3.0f, EndY = 4.0f))
+        db |> insert(Trip(Id = 2, StartX = 0.0f, StartY = 0.0f, EndX = 6.0f, EndY = 8.0f))
+
+        // --- Register: type-derived from the function pointer's signature
+        // The macro inspects `@@damage_formula` at compile time, derives
+        // (float, int, float) -> float, and ships per-arg + return tags
+        // to the C++ trampoline. Up to 4 arguments supported in v1.
+        db |> register_function("damage_formula", @@damage_formula, true)
+        db |> register_function("short_hash",     @@short_hash,     true)
+        db |> register_function("euclid",         @@euclid,         true)
+
+        // --- Use it inside a SELECT projection -----------------------------
+        // A 100-base attack with a 1.5× multiplier, factored against each
+        // enemy's armor. The expression embeds the registered fn just like
+        // any built-in SQLite scalar. For per-row aggregates we drop to
+        // `try_run_select` with an explicit row block so single-column
+        // results can land in `array<float>`.
+        let dmg <- (db |> try_run_select(
+            "SELECT damage_formula(100.0, Armor, 1.5) FROM Enemies ORDER BY Id",
+            $(var stmt : sqlite3_stmt?) {},
+            $(stmt : sqlite3_stmt?) : float {
+                return float(sqlite3_column_double(stmt, 0))
+            })) |> unwrap
+        for (i in range(dmg |> length)) {
+            to_log(LOG_INFO, "enemy #{i + 1} -> dmg={dmg[i]}\n")
+        }
+
+        // --- Use it in a WHERE clause --------------------------------------
+        // A custom predicate works the same way. Determinism lets SQLite
+        // apply normal CSE/optimizer treatment.
+        let weak_count : int = db |> query_scalar(
+            "SELECT COUNT(*) FROM Enemies WHERE damage_formula(100.0, Armor, 1.5) > 50",
+            type<int>)
+        to_log(LOG_INFO, "enemies that take >50 damage: {weak_count}\n")
+
+        // --- Use it in ORDER BY -------------------------------------------
+        // String → int64 fn used as the sort key. The first row after
+        // sorting:
+        let first_by_hash = db |> query_scalar(
+            "SELECT Name FROM Enemies ORDER BY short_hash(Name) LIMIT 1",
+            type<string>)
+        to_log(LOG_INFO, "first enemy by short_hash: {first_by_hash}\n")
+
+        // --- Multi-arg numeric fn -----------------------------------------
+        let total = db |> query_scalar(
+            "SELECT SUM(euclid(StartX, StartY, EndX, EndY)) FROM Trips",
+            type<double>)
+        to_log(LOG_INFO, "total trip distance: {total}\n")
+
+        // --- Optional flags: deterministic, directonly --------------------
+        // - deterministic=true (default false): same inputs always yield
+        //   the same output — required to use the fn inside `CREATE
+        //   INDEX … ON tbl(myfn(col))` or in a generated column.
+        // - directonly=true: the fn cannot be called from triggers, views,
+        //   or `CHECK(...)` constraints — used to lock down side-effecting
+        //   helpers that should run only from application SQL.
+        //
+        //     db |> register_function("now_iso", @@iso_now, false, true)
+        //
+        // The arity is positional: `register_function(db, name, fn,
+        // deterministic, directonly)`. Pipe form just reorders db.
+    }
+}

--- a/tutorials/sql/33-pragma.das
+++ b/tutorials/sql/33-pragma.das
@@ -1,0 +1,104 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 33 — PRAGMA: tuning the connection.
+//
+// PRAGMA is SQLite's per-connection control surface. It covers:
+//   - Performance toggles (journal_mode, synchronous, cache_size, mmap_size)
+//   - Behavior switches (foreign_keys, recursive_triggers, trusted_schema)
+//   - Diagnostics (integrity_check, quick_check — see tut 34)
+//
+// Some PRAGMAs are connection-scoped (`foreign_keys`, `busy_timeout`).
+// Others are database-scoped and persist on disk (`journal_mode`,
+// `page_size` after VACUUM). dasSQLITE's helpers make no distinction —
+// they just emit `PRAGMA "<name>" = <value>` and let SQLite handle it.
+//
+// Three typed `value` overloads cover the common shapes:
+//   set_pragma(db; name; value : string)   // 'WAL', 'NORMAL', 'utf8'
+//   set_pragma(db; name; value : int64)    // 5000, 50000, 4096
+//   set_pragma(db; name; value : bool)     // ON / OFF
+//
+// PRAGMA values can't be bound with `?` — SQLite parses them at prepare
+// time. The helpers format the value into the SQL inline; string values
+// are single-quoted with `''` doubling for safety. PRAGMA names + values
+// are admin-controlled (not user input), so this is fine.
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        // --- Strict variants — panic on a malformed pragma --------------
+        db |> set_pragma("journal_mode", "WAL")     // string
+        db |> set_pragma("busy_timeout", 5000l)     // int64 (note `l` suffix)
+        db |> set_pragma("foreign_keys", true)      // bool
+
+        // --- Read pragmas back through the typed query rail ------------
+        // PRAGMA `<name>` is a SELECT-shaped statement returning a single
+        // column row, so `query_scalar(sql, type<T>)` (tut 13) reads it.
+        let mode = db |> query_scalar("PRAGMA journal_mode", type<string>)
+        to_log(LOG_INFO, "journal_mode = {mode}\n")
+        let busy = db |> query_scalar("PRAGMA busy_timeout", type<int>)
+        to_log(LOG_INFO, "busy_timeout = {busy}\n")
+        let fks = db |> query_scalar("PRAGMA foreign_keys", type<int>)
+        to_log(LOG_INFO, "foreign_keys = {fks}\n")
+
+        // --- try_ variant — non-panic recovery -------------------------
+        // SQLite rejects `journal_mode` changes inside an open transaction;
+        // the strict form would panic, the try form returns SqlError.
+        db |> with_transaction() {
+            let err = db |> try_set_pragma("journal_mode", "DELETE")
+            // :memory: ignores journal mode at the disk level so this may
+            // succeed depending on build flags. The point of the try form
+            // is recovery — a real disk DB would surface SQLITE_BUSY here.
+            if (err |> is_some) {
+                to_log(LOG_INFO, "journal_mode change rejected mid-transaction: {err |> unwrap}\n")
+            }
+        }
+
+        // --- apply_recommended_pragmas — connection-setup curated set --
+        // Call this right after `with_sqlite` opens the connection. The
+        // exact contents are documented in `sqlite_boost.das`; today they
+        // are: WAL + busy_timeout=5s + foreign_keys=ON + synchronous=NORMAL.
+        // If your workload demands different defaults (durability-first
+        // servers → synchronous=FULL; embedded ROM-like data → journal_mode
+        // = OFF) call `set_pragma` directly.
+        let setup_err = db |> try_apply_recommended_pragmas()
+        if (setup_err |> is_some) {
+            to_log(LOG_ERROR, "failed to apply pragmas: {setup_err |> unwrap}\n")
+        }
+
+        // --- Unknown-pragma quirk --------------------------------------
+        // SQLite is famously permissive with PRAGMA: typos succeed silently
+        // (no error), and the corresponding `query_scalar` read returns 0
+        // / "" / row count 0 depending on shape. The lookup table is
+        // closed; sqlite3 simply ignores names it doesn't recognize.
+        // Verify your spelling by reading back via `query_scalar`.
+    }
+}
+
+// --- Reading PRAGMAs ---------------------------------------------------
+//
+// Always-set pragmas (booleans / ints):
+//   PRAGMA foreign_keys                      -> 0 or 1   query_scalar(sql, type<int>)
+//   PRAGMA busy_timeout                       -> ms      query_scalar(sql, type<int>)
+//   PRAGMA cache_size                         -> pages   query_scalar(sql, type<int>)
+//   PRAGMA journal_mode                       -> string  query_scalar(sql, type<string>)
+//
+// Multi-row pragmas (use `query` family):
+//   PRAGMA table_info('Cars')                 -> rows    query(sql, type<TableInfoRow>)
+//   PRAGMA index_list('Cars')                 -> rows    ...
+//   PRAGMA integrity_check                    -> rows    (see tut 34)
+
+// --- DEFERRED ---------------------------------------------------------
+//
+//   1. Compile-time enum surface for booleans / well-known string pragmas
+//      (e.g. set_journal_mode(JournalMode.WAL)) — adds a layer of typo
+//      protection at the cost of needing maintenance whenever SQLite ships
+//      a new mode. Defer until the surface stabilizes.
+//
+//   2. Open-time pragma bundle on `with_sqlite`
+//      (`with_sqlite(path, pragmas=(journal_mode="WAL", ...))`) — would
+//      shave a few lines at every call site. Defer until a real consumer
+//      asks for it.

--- a/tutorials/sql/34-backup_vacuum.das
+++ b/tutorials/sql/34-backup_vacuum.das
@@ -1,0 +1,131 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 34 — VACUUM, OPTIMIZE, integrity check, backup.
+//
+// This tutorial covers the maintenance / hygiene side of SQLite:
+//
+//   vacuum            — defragment the file, reclaim deleted-row space
+//   vacuum_into       — write a snapshot of the live DB to a new file
+//   optimize          — refresh the query planner's statistics
+//   integrity_check   — full corruption scan ("ok" or list of issues)
+//   quick_check       — cheaper corruption scan, skips index/table cross
+//   backup_to         — copy the live DB to another connection or file
+//
+// Each helper has a strict variant (panics on failure) and a `try_*`
+// variant returning `SqlError` / `Result<...>`.
+
+[sql_table(name = "Logs")]
+struct LogEntry {
+    @sql_primary_key Id : int
+    Severity : int
+    Message  : string
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<LogEntry>)
+        for (i in range(100)) {
+            db |> insert(LogEntry(
+                Id = i + 1,
+                Severity = (i % 4),
+                Message = "msg #{i}"))
+        }
+
+        // --- VACUUM ---------------------------------------------------
+        // Rewrites the file from scratch. After large DELETE workloads
+        // this reclaims free pages and packs surviving rows densely.
+        // Cannot run inside an active transaction — the helper rejects
+        // that case before reaching SQLite.
+        db |> exec("DELETE FROM Logs WHERE Severity = 0")
+        db |> vacuum()
+        let n = db |> query_scalar("SELECT COUNT(*) FROM Logs", type<int>)
+        to_log(LOG_INFO, "after VACUUM: {n} rows remain\n")
+
+        // --- VACUUM in a transaction returns Err ---------------------
+        // The strict form would panic; the try form surfaces the error
+        // so the caller can recover without crashing.
+        db |> with_transaction() {
+            let err = db |> try_vacuum()
+            if (err |> is_some) {
+                to_log(LOG_INFO, "try_vacuum mid-tx: {err |> unwrap}\n")
+            }
+        }
+
+        // --- VACUUM INTO (snapshot to a file) ------------------------
+        // VACUUM INTO '<path>' writes a one-off copy of the live DB to
+        // a new file without touching the source. The path is single-
+        // quoted with `''` doubling — SQLite doesn't accept `?` binds
+        // for VACUUM. Useful when you want a defragmented snapshot;
+        // for a hot copy of the live DB without re-packing, use
+        // `backup_to` (below) instead.
+        //
+        //     db |> vacuum_into("/tmp/snapshot.sqlite")
+        //     db |> vacuum_into("with'apostrophe.sqlite")  // quotes are escaped
+
+        // --- backup_to (online hot backup) ---------------------------
+        // The Backup API copies a live database into another open
+        // connection or to a path on disk. The destination receives the
+        // full state of the source; transient SQLITE_BUSY/LOCKED
+        // responses (concurrent writers on the source) are retried
+        // automatically with a 50 ms backoff. Two overloads:
+        //
+        //     // Snapshot into another runner (e.g. an in-memory clone):
+        //     with_sqlite(":memory:") $(snapshot) {
+        //         db |> backup_to(snapshot)
+        //         // ... query `snapshot` to inspect a frozen view ...
+        //     }
+        //
+        //     // Snapshot directly to disk (file is opened, populated,
+        //     // and closed for you):
+        //     db |> backup_to("/tmp/hot_snapshot.sqlite")
+        //
+        // The strict form panics on any non-completion; the `try_`
+        // form returns SqlError. backup_to replaces the destination
+        // wholesale — pre-existing tables on the destination are gone
+        // after the call.
+
+        // --- OPTIMIZE -------------------------------------------------
+        // `PRAGMA optimize` updates query-planner stats. Cheap; recommended
+        // at connection close on long-lived connections, no-op when nothing
+        // has changed.
+        db |> optimize()
+
+        // --- integrity_check ----------------------------------------
+        // Walks every page checking for corruption. Returns ["ok"] on a
+        // healthy database; on corruption returns one row per detected
+        // issue (truncated file, missing index entry, etc.). The helper
+        // returns the rows verbatim — the caller decides how to react.
+        let issues <- db |> integrity_check()
+        if (length(issues) == 1 && issues[0] == "ok") {
+            to_log(LOG_INFO, "integrity_check: db is healthy\n")
+        } else {
+            to_log(LOG_ERROR, "integrity_check: {length(issues)} issue(s):\n")
+            for (msg in issues) {
+                to_log(LOG_ERROR, "  - {msg}\n")
+            }
+        }
+
+        // --- quick_check --------------------------------------------
+        // Cheaper sibling; same return shape, but skips the per-index
+        // cross-table walk. Useful as a fast pre-flight before deciding
+        // whether to run the expensive integrity_check.
+        let quick <- db |> quick_check()
+        to_log(LOG_INFO, "quick_check returned {length(quick)} row(s); first: {quick[0]}\n")
+    }
+}
+
+// --- DEFERRED ---------------------------------------------------------
+//
+//   1. Backup progress callback (`sqlite3_backup_step(bp, N)` returning
+//      remaining/pagecount, surfaced to a daslang block). Useful for
+//      long-running backups under a "saving…" progress bar.
+//
+//   2. integrity_check / quick_check first-N rows mode. SQLite's
+//      pragma accepts a row-cap argument (`PRAGMA integrity_check(10)`
+//      stops after 10 issues). The current helper always runs the full
+//      scan; add an optional N parameter once a real consumer asks.

--- a/tutorials/sql/35-streaming.das
+++ b/tutorials/sql/35-streaming.das
@@ -1,0 +1,154 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 35 — _each_sql: streaming iteration over a SELECT.
+//
+// `_sql(...)` materializes the result set as `array<T>` up front. Fine for
+// hundreds of rows, problematic for millions: every row sits in memory at
+// the same time, and the first user-visible row only arrives after the
+// whole array is built.
+//
+// `_each_sql(...)` is the streaming variant. Same chain shape (any
+// `select_from + _where + _select + _order_by + _join`-style query that
+// `_sql` accepts), but instead of returning `array<T>`, it returns
+// `iterator<T>` — rows are produced lazily, one per `sqlite3_step`.
+//
+// Lifecycle (handled for you):
+//   prepare → bind → step+yield → step+yield → ... → finalize
+//
+// The underlying prepared statement is finalized in the generator's
+// `finally` block, which runs on:
+//   - normal exhaustion (loop runs to completion)
+//   - early `break` from the for-loop
+//   - panic from inside the loop body
+// In every case, the statement is released; subsequent writes to the
+// same DB are NOT blocked by a stale read transaction.
+
+[sql_table(name = "Logs")]
+struct LogEntry {
+    @sql_primary_key Id : int
+    Severity : int       // 0 = trace, 1 = info, 2 = warn, 3 = error
+    Message  : string
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<LogEntry>)
+    for (i in range(20)) {
+        db |> insert(LogEntry(
+            Id = i + 1,
+            Severity = (i % 4),
+            Message = "msg #{i}"))
+    }
+}
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // --- Streaming iteration --------------------------------------
+        // `for (row in _each_sql(...))` lazily materializes one row at a
+        // time. The iterator's lifetime is the for-loop body; the
+        // statement is finalized when the loop exits.
+        var n = 0
+        for (e in _each_sql(db |> select_from(type<LogEntry>) |> _where(_.Severity >= 2))) {
+            n++
+            to_log(LOG_INFO, "  [{e.Severity}] #{e.Id} — {e.Message}\n")
+        }
+        to_log(LOG_INFO, "streamed {n} severe logs\n")
+
+        // --- Early break ---------------------------------------------
+        // Process rows until a condition is met, then `break`. The
+        // generator's `finally` finalizes the prepared statement, so a
+        // subsequent INSERT on the same DB succeeds without contention.
+        var first_error_id = 0
+        for (e in _each_sql(db |> select_from(type<LogEntry>))) {
+            if (e.Severity == 3) {
+                first_error_id = e.Id
+                break
+            }
+        }
+        to_log(LOG_INFO, "first error has id {first_error_id}\n")
+        // The INSERT below would block (or panic) if the iterator's
+        // statement leaked. It succeeds → finally ran.
+        db |> insert(LogEntry(Id = 100, Severity = 0, Message = "after break"))
+
+        // --- Single-column projection in a stream --------------------
+        // The iterator type follows the projection — `_select(_.Field)`
+        // streams scalars, named-tuple `_select((A=..., B=...))` streams
+        // tuples, FullRow streams structs.
+        var total_chars = 0
+        for (msg in _each_sql(db |> select_from(type<LogEntry>) |> _select(_.Message))) {
+            total_chars += length(msg)
+        }
+        to_log(LOG_INFO, "total Message bytes streamed: {total_chars}\n")
+
+        // --- Captured local in the predicate -------------------------
+        // Unlike `_create_view`, `_each_sql` accepts captured locals in
+        // the chain — they bind to the prepared statement at run time
+        // (the standard `?` placeholder mechanism).
+        let cutoff = 2
+        for (e in _each_sql(db |> select_from(type<LogEntry>) |> _where(_.Severity >= cutoff))) {
+            to_log(LOG_INFO, "  bound-cutoff: id={e.Id}\n")
+        }
+    }
+}
+
+// --- One-shot semantics ----------------------------------------------
+//
+// A daslang generator is consumed once. To re-run the same query, write
+// the `_each_sql(...)` call site again — each evaluation builds a fresh
+// prepared statement. Don't try to "rewind" an iterator; it has no
+// rewind operation, and capturing the iterator into a variable then
+// iterating twice will fail (the second pass yields zero rows).
+
+// --- When to pick _each_sql vs _sql ----------------------------------
+//
+// Pick `_each_sql` when:
+//   - The result set is large (millions of rows) and per-row processing
+//     is cheap.
+//   - You break out early on a condition (e.g. "find first matching
+//     row" or "process until budget exhausted").
+//   - You're piping rows into another iterator-shaped pipeline (linq /
+//     algorithm functions that take an iterator).
+//
+// Pick `_sql` when:
+//   - The result set is small (hundreds of rows) — array materialization
+//     overhead is negligible.
+//   - You want to index into the result, count rows up front, or pass
+//     the array to a function that expects `array<T>`.
+//   - The downstream code mutates the same DB while iterating; with
+//     `_each_sql` the iterator holds a read transaction (under WAL) or
+//     a shared lock (default) that may interact poorly with concurrent
+//     writes.
+
+// --- Concurrent-writer note + WAL mitigation -------------------------
+//
+// While the iterator is stepping, SQLite holds a read transaction on
+// the connection. Default journal mode (`DELETE`) blocks writes from
+// the same connection until the cursor finalizes. If you need to write
+// to the DB while iterating from the SAME connection, switch to
+// write-ahead logging:
+//
+//     db |> set_pragma("journal_mode", "WAL")
+//
+// Under WAL, readers and one writer can coexist on the same connection,
+// at the cost of an extra `-wal` / `-shm` file alongside the database.
+// See tut 33 for the pragma surface.
+
+// --- Restrictions vs _sql --------------------------------------------
+//
+// `_each_sql` rejects the following terminals at compile time, with a
+// clear pointer to `_sql(...)` as the alternative:
+//
+//   _to_array       — `_each_sql` already streams rows; `_to_array` would
+//                     force materialization, which is what `_sql(...)` is for
+//   _first          — single-row materializer
+//   _first_opt      — single-row Option<T> materializer
+//   _count / _sum / _avg / _min / _max — aggregates (one scalar row)
+//
+// For all of these, use `_sql(...)` — the macro emits the right
+// runtime to materialize one scalar / row / array.


### PR DESCRIPTION
## Summary

Chunk 10 of the dasSQLITE rework — ships the five "operational" tutorials covering the SQLite surface that wasn't yet on the daslang rail:

- **Tut 31 — Views.** `[sql_view(name="...")]` annotation + `_create_view(db, type<V>, chain)` macro. Shares the same read-path helpers as `[sql_table]` (`select_from(type<V>)`, `column_info(type<V>)`, etc.). Mutation paths (`_sql_update` / row-form `insert` / etc.) blocked at compile time. Literal-inlining of `ExprConst*` chain binds (CREATE VIEW rejects `?` placeholders).
- **Tut 33 — PRAGMA.** `set_pragma` / `try_set_pragma` (string / int64 / bool overloads) + `apply_recommended_pragmas` (WAL + busy_timeout=5s + foreign_keys=ON + synchronous=NORMAL).
- **Tut 34 — VACUUM / OPTIMIZE / integrity / backup.** `vacuum` / `vacuum_into` / `optimize` / `integrity_check` / `quick_check` + online `backup_to(SqlRunner)` / `backup_to(string)` (Backup API with SQLITE_BUSY/LOCKED retry).
- **Tut 35 — Streaming.** `_each_sql(chain)` returning `iterator<T>`; rejects materializing terminals (`_to_array`, `_first`, aggregates) at compile time. Generator's `finally` finalizes the stmt on exhaustion / break / panic so subsequent writes don't contend.
- **Tut 39 — `register_function`.** Bind a daslang function as a SQLite scalar via `db |> register_function(name, @@fn, deterministic, directonly)`. Up to 4 args, type-derived from the function-pointer signature. NULL short-circuits to NULL; panics caught via `Context::runWithCatch` and surfaced as `sqlite3_result_error` without breaking the connection.

5 new RST tutorial pages registered under `doc/source/reference/tutorials/`. API_REWORK.md / TUTORIALS.md updated to mark tuts 31/33/34/35/39 shipped.

### Drive-by fix

Registers `qm_peel_ref2value` (added in PR #2515 / commit 304edd1ff) under a new "AST normalization" group in `document_module_ast_match`. Without this, das2rst put the function in an Uncategorized section, which the CI gate rejects. Bundled here so master CI stays green.

## Test plan

- [x] Lint clean across all 21 changed `.das` files (`utils/lint/main.das`)
- [x] dedup — `find-dupe` over `modules/dasSQLITE/daslib` + `tests/dasSQLITE` + `tutorials/sql` (corpus 891 fns; 18 "real" verdicts all confirmed as intentional `try_*`-wrap pattern + typed overloads)
- [x] 7397 / 7397 interpreted tests pass, no GC leak output
- [x] 7397 / 7397 AOT tests pass (`test_aot.exe -use-aot`)
- [x] MCP `format_file` clean across all changed `.das` files
- [x] `das2rst` clean — 0 Uncategorized after the `qm_peel_ref2value` group registration
- [x] Sphinx clean — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
