### PR TITLE
clargs: detect standalone-exe mode via LLVM JIT intrinsic (issue #2501)

### DIFF
--- a/daslib/clargs.das
+++ b/daslib/clargs.das
@@ -63,6 +63,20 @@ def public get_program_args() : array<string> {
     return <- get_program_args(get_command_line_arguments())
 }
 
+// Mode-aware argv source.  Returns argv[1..] when running as a standalone exe
+// (built via `daslang -exe`), and the post-`--` slice when running under the
+// interpreter or in-process JIT.  This is what the macro-generated default
+// `parse_args()` uses, so utilities work the same whether interpreted or
+// shipped as a binary.
+def public get_user_args() : array<string> {
+    let argv <- get_command_line_arguments()
+    if (is_standalone_exe()) {
+        return <- get_program_args(argv)
+    } else {
+        return <- get_cli_arguments(argv)
+    }
+}
+
 def clargs_flag_name(field_name : string) : string {
     return "--" + replace_multiple(field_name, [("_", "-")])
 }
@@ -308,8 +322,11 @@ def public parse_argument(args : array<string>; arg_info : CommandArgumentInfo; 
 // `format_help` builds the help text as a string (testable, redirectable).
 // `print_help` is a thin wrapper that prints it to stdout.
 //
-// Layout:
+// Layout (standalone exe — `is_standalone_exe() == true`):
 //   Usage: <prog_name> [flags]
+//
+// Layout (interpreted script):
+//   Usage: daslang <prog_name> -- [flags]
 //
 //   Flags:
 //     -X, --long=PLACEHOLDER    doc_string (required) (repeated)
@@ -395,7 +412,11 @@ def public format_help(info : CommandInfo; prog_name : string) : string {
     }
     let gutter = 4
     return build_string() $(var w) {
-        write(w, "Usage: {prog_name} [flags]\n\nFlags:\n")
+        if (is_standalone_exe()) {
+            write(w, "Usage: {prog_name} [flags]\n\nFlags:\n")
+        } else {
+            write(w, "Usage: daslang {prog_name} -- [flags]\n\nFlags:\n")
+        }
         for (i, arg in range(length(info.args)), info.args) {
             let s = specs[i]
             let pad = max_spec_len - length(s) + gutter
@@ -525,7 +546,7 @@ class ArgsMacro : AstStructureAnnotation {
 
     def make_parse_default_fn(var st : StructurePtr) : FunctionPtr {
         var fn = qmacro_function("parse_args") $(var dst : $t(st)) : string {
-            return parse_args(dst, get_cli_arguments())
+            return parse_args(dst, get_user_args())
         }
         fn.flags |= FunctionFlags.generated
         fn.body |> force_at(st.at)

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -168,7 +168,7 @@ get_value|insert_clone|emplace_new|insert_default|emplace_default|get_with_defau
         group_by_regex("Binary serializer", mod, %regex~(binary_load|binary_save)$%%),
         group_by_regex("Path and command line", mod, %regex~(get_command_line_arguments|with_argv)$%%),
         group_by_regex("Time and date", mod, %regex~(get_time_usec|ref_time_ticks|get_clock|get_time_nsec|mktime)$%%),
-        group_by_regex("Platform queries", mod, %regex~(get_context_share_counter|das_is_dll_build|get_platform_name|get_architecture_name)$%%),
+        group_by_regex("Platform queries", mod, %regex~(get_context_share_counter|das_is_dll_build|is_standalone_exe|get_platform_name|get_architecture_name)$%%),
         group_by_regex("String formatting", mod, %regex~(fmt)$%%),
         group_by_regex("Argument consumption", mod, %regex~(consume_argument)$%%),
         group_by_regex("Lock checking", mod, %regex~(lock_count)$%%),

--- a/doc/source/stdlib/handmade/function-builtin-is_standalone_exe-0xf20b00e99d5b5418.rst
+++ b/doc/source/stdlib/handmade/function-builtin-is_standalone_exe-0xf20b00e99d5b5418.rst
@@ -1,0 +1,1 @@
+Returns `true` when the current binary was produced by `daslang -exe` (a standalone executable). Returns `false` under the interpreter, in-process LLVM JIT, and AOT C++ builds. The LLVM JIT replaces this call with a constant at codegen time, so the value is folded with no runtime cost.

--- a/include/daScript/simulate/aot_builtin.h
+++ b/include/daScript/simulate/aot_builtin.h
@@ -16,6 +16,7 @@ namespace das {
 
     DAS_API bool is_compiling ( );
     DAS_API bool is_compiling_macros ( );
+    DAS_API bool is_standalone_exe ( );
     DAS_API uint64_t get_context_share_counter ( Context * context );
 
     DAS_API char * builtin_das_root ( Context * context, LineInfoArg * at );

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -18,10 +18,15 @@ struct JitCtx {
     builder : LLVMOpaqueBuilder -const? -const
 }
 
+// Set by llvm_macro before codegen when prog.policies.jit_exe_mode is true.
+// Read by intrinsic_is_standalone_exe to fold $::is_standalone_exe() into a constant.
+var public g_jit_exe_mode = false
+
 let g_intrin_lookup <- {
 // $, aka builtin
     // misc
         "$::length" => @@intrinsic_builtin_length,
+        "$::is_standalone_exe" => @@intrinsic_is_standalone_exe,
     // pointer math
         "$::i_das_ptr_set_add" => @@intrinsic_das_ptr_set_add,
         "$::i_das_ptr_add" => @@intrinsic_das_ptr_add,
@@ -171,6 +176,10 @@ def intrinsic_builtin_length(var ctx : JitCtx; expr : ExprCallFunc?; arguments :
     } else {
         return null
     }
+}
+
+def intrinsic_is_standalone_exe(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    return LLVMConstInt(ctx.types.t_int1, g_jit_exe_mode ? 1ul : 0ul, 0)
 }
 
 def intrinsic_builtin_int(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -8,9 +8,11 @@ require llvm/daslib/llvm_dll_utils
 require llvm/daslib/llvm_exe
 require llvm/daslib/llvm_jit
 require llvm/daslib/llvm_jit_common
+require llvm/daslib/llvm_jit_intrin
 
 require daslib/ast_boost
 require daslib/strings_boost
+require daslib/defer
 
 require daslib/fio
 require jit
@@ -139,6 +141,10 @@ class JIT_LLVM : AstSimulateMacro {
                 "daslang build is static, disabling dll mode.\n")
         }
         let gen_exe = prog.policies.jit_exe_mode
+        // Drives the $::is_standalone_exe JIT intrinsic in llvm_jit_intrin so daslang
+        // code can constant-fold to true when this codegen run produces a standalone exe.
+        llvm_jit_intrin::g_jit_exe_mode = gen_exe
+        defer() { llvm_jit_intrin::g_jit_exe_mode = false; }
         let exe_main = "main" // prog.policies.jit_entry_point |> empty() ? "main" : prog.policies.jit_entry_point
         let use_dll = prog.policies.jit_dll_mode && das_is_dll_build() && !gen_exe
         let opt_level = prog.policies.jit_opt_level

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1335,6 +1335,10 @@ namespace das
 
     }
 
+    bool is_standalone_exe ( ) {
+        return false;
+    }
+
     DAS_API uint64_t get_context_share_counter ( Context * context ) {
         return (uint64_t) context->code.use_count();
     }
@@ -1849,6 +1853,8 @@ namespace das
         addExtern<DAS_BIND_FUN(getCommandLineArguments)>(*this, lib, "builtin_get_command_line_arguments",
             SideEffects::accessExternal,"getCommandLineArguments")
                 ->arg("arguments");
+        addExtern<DAS_BIND_FUN(is_standalone_exe)>(*this, lib, "is_standalone_exe",
+            SideEffects::accessExternal, "is_standalone_exe");
         addExtern<DAS_BIND_FUN(withCommandLineArguments)>(*this, lib,  "with_argv",
             SideEffects::invoke, "withArgv")
                 ->args({"new_arguments", "block","context","line"});

--- a/tests/daslib/clargs_test.das
+++ b/tests/daslib/clargs_test.das
@@ -424,7 +424,8 @@ def test_get_program_args_only_argv0(t : T?) {
 def test_format_help_smoke(t : T?) {
     let info <- get_command_info(type<ShortFlagsConfig>)
     let help = format_help(info, "demo")
-    t |> success(starts_with(help, "Usage: demo [flags]\n"), "starts with usage line")
+    // Test runs under the interpreter, so format_help emits the daslang-script invocation form.
+    t |> success(starts_with(help, "Usage: daslang demo -- [flags]\n"), "starts with usage line")
     t |> success(find(help, "-n, --name=STRING") != -1, "renders short+long flag spec")
     t |> success(find(help, "-v, --verbose") != -1, "bool flag has no =placeholder")
     t |> success(find(help, "-p, --color=ENUM") != -1, "enum flag uses ENUM placeholder")


### PR DESCRIPTION
## Summary

Fixes #2501. Standalone utilities built with `daslang -exe` (`bin/detect-dupe.exe`, `bin/aot.exe`, `bin/daspkg.exe`, etc.) silently dropped user flags unless prefixed with `--`, because the `@[CommandLineArgs]` macro defaulted to `get_cli_arguments()` — which strips everything before `--` (the daslang-script convention).

- Introduce `is_standalone_exe()` builtin. C++ implementation returns `false`; the LLVM JIT replaces the call with a constant `true` when `jit_exe_mode` is set, using the existing intrinsic-replacement table (`g_intrin_lookup` in `modules/dasLLVM/daslib/llvm_jit_intrin.das`). Zero runtime cost — folded into the LLVM IR.
- `daslib/clargs`: new `get_user_args()` branches on `is_standalone_exe()` — `argv[1..]` for exe mode, post-`--` slice otherwise. The macro-generated default `parse_args()` now uses it, so existing utilities work without code changes.
- `format_help` renders the matching usage line: `Usage: <prog> [flags]` for exe mode, `Usage: daslang <prog> -- [flags]` for interpreter mode.

| Mode | argv shape | `is_standalone_exe()` |
|---|---|---|
| Interpreter | `daslang script.das -- args…` | `false` |
| In-process LLVM JIT | same | `false` (intrinsic emits `0`) |
| Standalone exe | `./detect-dupe.exe args…` | `true` (intrinsic emits `1`) |

Plumbing: `llvm_jit_intrin::g_jit_exe_mode` global is set in `llvm_macro.das` from `prog.policies.jit_exe_mode` at codegen start, reset via `defer()`.

## Test plan

- [x] Interpreter regression: `daslang utils/detect-dupe/main.das -- -p tutorials/sql -x -n 3` still works; help shows `Usage: daslang detect-dupe -- [flags]`.
- [x] In-process JIT: `daslang -jit utils/detect-dupe/main.das -- ...` still works (intrinsic folds to `false`).
- [x] Standalone exe (the bug): `bin/detect-dupe.exe -p tutorials/sql -x -n 3` now consumes flags directly without `--`; help shows `Usage: detect-dupe [flags]`.
- [x] Lint clean on all changed `.das` files.
- [x] `tests/daslib/clargs_test.das` — 46/46 pass (updated `test_format_help_smoke` snapshot for the new mode-aware usage line).
- [x] Full test suite — 7332 tests, 7326 passed, 0 failed, 6 skipped.
- [x] AOT build + tests — 6726 tests, 6720 passed, 0 failed.
- [x] Docs: added `is_standalone_exe` to "Platform queries" group in `das2rst.das`, filled in handmade stub. Clean Sphinx build, zero warnings.
- [x] All changed `.das` files pass `format_file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)