### PR TITLE
Aleksisch/various fixes

### DIFF
--- a/.github/workflows/build_eastl.yml
+++ b/.github/workflows/build_eastl.yml
@@ -1,0 +1,24 @@
+name: build_eastl
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build_eastl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lukka/get-cmake@latest
+      - run: sudo apt-get update -y && sudo apt-get install -y bison flex
+      - run: git clone --depth 1 --recurse-submodules https://github.com/electronicarts/EASTL.git eastl
+      - run: |
+          CC=clang CXX=clang++ cmake -B build -G Ninja \
+            -DDAS_LLVM_DISABLED=ON -DDAS_GLFW_DISABLED=ON \
+            -DDAS_TESTS_DISABLED=ON -DDAS_TUTORIAL_DISABLED=ON \
+            -DDAS_AOT_EXAMPLES_DISABLED=ON \
+            -DDAS_CONFIG_INCLUDE_DIR=cmake/das_config_eastl \
+            -DCMAKE_CXX_FLAGS="-isystem $PWD/eastl/include -isystem $PWD/eastl/test/packages/EABase/include/Common"
+      - run: cmake --build build --target daslang --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -764,6 +764,7 @@ include/daScript/misc/handle_registry.h
 include/daScript/misc/uric.h
 include/daScript/misc/lexer_alloc_track.h
 src/misc/gc_node.cpp
+src/misc/globals.cpp
 src/misc/sysos.cpp
 src/misc/string_writer.cpp
 src/misc/memory_model.cpp

--- a/cmake/das_config_eastl/das_config.h
+++ b/cmake/das_config_eastl/das_config.h
@@ -1,0 +1,149 @@
+#pragma once
+
+// EASTL-flavored das_config.h for CI compile-coverage.
+//
+// Goal: catch type-conversion bugs (e.g. eastl::string -> std::filesystem::path)
+// that don't surface with the default std-only config. The job is satisfied if
+// daslang compiles; full test execution is not required.
+//
+// Notes:
+// - EASTL's smart pointers come from EASTL/shared_ptr.h / EASTL/unique_ptr.h.
+// - We deliberately do NOT pull dagor-engine headers (dag::Vector etc.).
+
+#ifndef DAS_CUSTOM_HASH
+#define DAS_CUSTOM_HASH 1
+#endif
+
+#include <EASTL/sort.h>
+#include <EASTL/shared_ptr.h>
+#include <EASTL/unique_ptr.h>
+#include <EASTL/set.h>
+#include <EASTL/map.h>
+#include <EASTL/unordered_set.h>
+#include <EASTL/unordered_map.h>
+#include <EASTL/string.h>
+#include <EASTL/vector.h>
+#include <EASTL/deque.h>
+#include <EASTL/memory.h>
+#include <EASTL/type_traits.h>
+#include <EASTL/initializer_list.h>
+#include <EASTL/functional.h>
+#include <EASTL/algorithm.h>
+
+#include <atomic>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <iosfwd>
+#include <climits>
+#include <limits.h>
+#include <setjmp.h>
+#ifdef _MSC_VER
+#include <malloc.h>
+#endif
+
+namespace das {
+using namespace eastl;
+using std::atomic;
+using std::condition_variable;
+using std::lock_guard;
+using std::mutex;
+using std::nullptr_t;
+using std::recursive_mutex;
+using std::stringstream;
+using std::thread;
+using std::unique_lock;
+} // namespace das
+
+#if (!defined(DAS_ENABLE_EXCEPTIONS)) || (!DAS_ENABLE_EXCEPTIONS)
+#define FMT_THROW(x)    das::das_throw(((x).what()))
+namespace das {
+    void das_throw(const char * msg);
+}
+#endif
+
+#if DAS_CUSTOM_HASH
+#include <das_hash_map/das_hash_map.h>
+namespace das {
+template <typename K, typename V, typename H = das::daslang_hash<K>, typename E = das::equal_to<K>>
+using das_map = das::daslang_hash_map<K,V,H,E>;
+template <typename K, typename H = das::daslang_hash<K>, typename E = das::equal_to<K>>
+using das_set = das::daslang_hash_set<K,H,E>;
+template <typename K, typename V, typename H = das::daslang_hash<K>, typename E = das::equal_to<K>>
+using das_hash_map = das::daslang_hash_map<K,V,H,E>;
+template <typename K, typename H = das::daslang_hash<K>, typename E = das::equal_to<K>>
+using das_hash_set = das::daslang_hash_set<K,H,E>;
+template <typename K, typename V>
+using das_safe_map = eastl::map<K,V>;
+template <typename K, typename C=eastl::less<K>>
+using das_safe_set = eastl::set<K,C>;
+}
+#else
+namespace das {
+template <typename K, typename V, typename H = eastl::hash<K>, typename E = eastl::equal_to<K>>
+using das_map = eastl::unordered_map<K,V,H,E>;
+template <typename K, typename H = eastl::hash<K>, typename E = eastl::equal_to<K>>
+using das_set = eastl::unordered_set<K,H,E>;
+template <typename K, typename V, typename H = eastl::hash<K>, typename E = eastl::equal_to<K>>
+using das_hash_map = eastl::unordered_map<K,V,H,E>;
+template <typename K, typename H = eastl::hash<K>, typename E = eastl::equal_to<K>>
+using das_hash_set = eastl::unordered_set<K,H,E>;
+template <typename K, typename V>
+using das_safe_map = eastl::map<K,V>;
+template <typename K, typename C=eastl::less<K>>
+using das_safe_set = eastl::set<K,C>;
+}
+#endif
+
+#define DAS_STD_HAS_BIND 1
+
+#ifndef DAS_SLOW_CALL_INTEROP
+  #define DAS_SLOW_CALL_INTEROP 0
+#endif
+
+#ifndef DAS_MAX_FUNCTION_ARGUMENTS
+#define DAS_MAX_FUNCTION_ARGUMENTS 32
+#endif
+
+#ifndef DAS_FUSION
+  #define DAS_FUSION  0
+#endif
+
+#if DAS_SLOW_CALL_INTEROP
+  #undef DAS_FUSION
+  #define DAS_FUSION  0
+#endif
+
+#ifndef DAS_DEBUGGER
+  #define DAS_DEBUGGER  1
+#endif
+
+#ifndef DAS_BIND_EXTERNAL
+  #if defined(_WIN32) && defined(_WIN64)
+    #define DAS_BIND_EXTERNAL 1
+  #elif defined(__APPLE__)
+    #define DAS_BIND_EXTERNAL 1
+  #elif defined(__linux__)
+    #define DAS_BIND_EXTERNAL 1
+  #elif defined __HAIKU__
+    #define DAS_BIND_EXTERNAL 1
+  #else
+    #define DAS_BIND_EXTERNAL 0
+  #endif
+#endif
+
+#ifndef DAS_PRINT_VEC_SEPARATROR
+#define DAS_PRINT_VEC_SEPARATROR ","
+#endif
+
+#ifndef DAS_USE_BASE_CRASH_HANDLER
+#if defined(_WIN32) || ((defined(__linux__) || defined(__APPLE__)) && !defined(__EMSCRIPTEN__))
+#define DAS_USE_BASE_CRASH_HANDLER 1
+#else
+#define DAS_USE_BASE_CRASH_HANDLER 0
+#endif
+#endif
+
+#ifndef das_to_stdout_level_prefix_text
+#define das_to_stdout_level_prefix_text(level, prefix, text) { if (level >= LogLevel::error) { fprintf(stderr, "%s", text); fflush(stderr); } else { fprintf(stdout, "%s%s", prefix, text); fflush(stdout); } }
+#endif

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -2375,7 +2375,7 @@ class public CppAot : AstVisitor {
     }
     def override visitExprConstRange64(var c : ExprConstRange64?) : ExpressionPtr {
         let val = c.getValue;
-        write(*ss, "range64({val.x:d},{val.y:d})");
+        write(*ss, "range64({val.x:d}ll,{val.y:d}ll)");
         return c;
     }
     def override visitExprConstInt3(var c : ExprConstInt3?) : ExpressionPtr {
@@ -2400,7 +2400,7 @@ class public CppAot : AstVisitor {
     }
     def override visitExprConstURange64(var c : ExprConstURange64?) : ExpressionPtr {
         let val = c.getValue;
-        write(*ss, "urange64({val.x:d},{val.y:d})");
+        write(*ss, "urange64({val.x:d}ull,{val.y:d}ull)");
         return c;
     }
     def override visitExprConstUInt3(var c : ExprConstUInt3?) : ExpressionPtr {

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -415,13 +415,15 @@ def describeCppTypeEx(typeDecl : TypeDeclPtr;
         }
         // Value-annotation handles (e.g. Handle<T>) are POD and always passed by value,
         // even when daslang marks the expression result as ref (stack temp). Skip the
-        // &/* suffix so "var T* = ...; return T&" mismatches don't break the AOT build.
+        // & suffix so "var T* = ...; return T&" mismatches don't break the AOT build.
+        // Keep the * suffix when substitute_ref is requested (e.g. iteration variables),
+        // since das_iterator::first(Context*, QQ*&) demands a real pointer regardless.
         let valueHandle = baseType == Type.tHandle && !typeDecl.isRefType
-        if (typeDecl.flags.ref && cfg.skip_ref == false && !valueHandle) {
-            if (cfg.substitute_ref == false) {
-                write(writer, " &");
-            } else {
+        if (typeDecl.flags.ref && cfg.skip_ref == false) {
+            if (cfg.substitute_ref) {
                 write(writer, " *");
+            } elif (!valueHandle) {
+                write(writer, " &");
             }
         }
     }

--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -1,6 +1,7 @@
 options gen2
 options indenting = 4
 options remove_unused_symbols = false
+options strict_unsafe_delete = false
 
 // This is builtin module. It included by default
 // in every other module. Compiler can freely
@@ -1138,7 +1139,9 @@ def clone(var args; var nargs : array<auto(TT)?>) {
     for (narg in nargs) {
         _::push(args, narg)
     }
-    delete nargs
+    unsafe {
+        delete nargs
+    }
 }
 
 [unsafe_outside_of_for, nodiscard]

--- a/daslib/cpp_bind.das
+++ b/daslib/cpp_bind.das
@@ -118,5 +118,4 @@ def log_cpp_class_adapter(cpp_file : file; name : string; var cinfo : TypeDeclPt
         fwrite(cpp_file, "  \}\n")
     }
     fwrite(cpp_file, "};\n\n")
-    delete types
 }

--- a/daslib/delegate.das
+++ b/daslib/delegate.das
@@ -211,14 +211,14 @@ def public delegate(macroArgument, passArgument : TypeDeclPtr; FuncType : TypeDe
     if (passArgument != null) {
         // try DelegateReturn
         if (is_typemacro_template_instance(passArgument, template_type_ret, extra_template_arguments)) {
-            var inscope args_ret <- [TypeMacroTemplateArgument(name = "DelegateLambda", argument_type = clone_type(FuncType))]
+            var args_ret <- [TypeMacroTemplateArgument(name = "DelegateLambda", argument_type = clone_type(FuncType))]
             if (infer_struct_aliases(passArgument.structType, args_ret)) {
                 return infer_template_types(passArgument, args_ret)
             }
         }
         // try DelegateVoid
         if (is_typemacro_template_instance(passArgument, template_type_void, extra_template_arguments)) {
-            var inscope args_void <- [TypeMacroTemplateArgument(name = "DelegateLambda", argument_type = clone_type(FuncType))]
+            var args_void <- [TypeMacroTemplateArgument(name = "DelegateLambda", argument_type = clone_type(FuncType))]
             if (infer_struct_aliases(passArgument.structType, args_void)) {
                 return infer_template_types(passArgument, args_void)
             }
@@ -227,7 +227,7 @@ def public delegate(macroArgument, passArgument : TypeDeclPtr; FuncType : TypeDe
     }
 
     // ── concrete path ──────────────────────────────────────────────────
-    var inscope template_arguments <- [
+    var template_arguments <- [
         TypeMacroTemplateArgument(name = "DelegateLambda", argument_type = clone_type(lambdaType))
     ]
     if (!verify_arguments(template_arguments)) {

--- a/daslib/instance_function.das
+++ b/daslib/instance_function.das
@@ -30,7 +30,7 @@ class InstanceFunctionAnnotation : AstFunctionAnnotation {
     //!     def inst {}
     def override apply(var func : FunctionPtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
         var generic_name = ""
-        var inscope rules : Template
+        var rules : Template
         for (argv in args) {
             let val = get_annotation_argument_value(argv)
             if (val is tBool) {

--- a/daslib/linq_boost.das
+++ b/daslib/linq_boost.das
@@ -473,7 +473,7 @@ def private rename_var_in_expr(var src : Expression?; from_name, to_name : strin
     //! Clone ``src`` and rename every ``ExprVar`` named ``from_name``
     //! to ``to_name``. Same approach as fold_linq_cond.
     var res = clone_expression(src)
-    var inscope rules : Template
+    var rules : Template
     rules |> renameVariable(from_name, to_name)
     apply_template(rules, res.at, res)
     return res
@@ -691,7 +691,7 @@ def private fold_linq_cond(var expr : Expression?; argName : string) : Expressio
             var ret = blk.list[0] as ExprReturn
             if (ret.subexpr != null) {
                 var res = clone_expression(ret.subexpr)
-                var inscope rules : Template
+                var rules : Template
                 rules |> renameVariable(string(blk.arguments[0].name), argName)
                 apply_template(rules, res.at, res)
                 return res

--- a/daslib/match.das
+++ b/daslib/match.das
@@ -442,12 +442,12 @@ def match_guards(what : TypeDeclPtr; wth : ExprOp2?; access : Expression?; var t
 
 [macro_function]
 def match_or(what : TypeDeclPtr; wth : ExprOp2?; access : Expression?; var to : MatchTo) {
-    var inscope toL : MatchTo
+    var toL : MatchTo
     toL.declarations := to.declarations
     if (!match_any(what, wth.left, access, toL)) {
         return false
     }
-    var inscope toR : MatchTo
+    var toR : MatchTo
     if (!match_any(what, wth.right, access, toR)) {
         return false
     }
@@ -465,7 +465,6 @@ def match_or(what : TypeDeclPtr; wth : ExprOp2?; access : Expression?; var to : 
             return false
         }
     }
-    delete to.declarations
     unsafe {
         to.declarations <- toL.declarations // because its a superset
     }
@@ -684,7 +683,7 @@ class MatchMacro : AstCallMacro {
         for (ei in range(eli)) {
             {
                 var eto = (eblk.list[multi_match ? ei : eli - ei - 1]) as ExprIfThenElse
-                var inscope to : MatchTo
+                var to : MatchTo
                 if (match_any(what._type, eto.cond, access, to)) {
                     log_m("match_any ok\n\n")
                     var new_iff = new ExprIfThenElse(at = eto.at, cond = join_conditions(to.conditions, eto.at))

--- a/daslib/profiler.das
+++ b/daslib/profiler.das
@@ -437,7 +437,9 @@ class PerformanceProfilerAgent : ProfilerBaseAgent {
         dump_context_stack(tid)
         dump_meta(ctx, tid)
         dump_events(tid)
-        delete events[tid].events
+        unsafe {
+            delete events[tid].events
+        }
         events |> erase(tid)
     }
 }

--- a/daslib/quote.das
+++ b/daslib/quote.das
@@ -76,7 +76,6 @@ def public clone(var args : rtti::AnnotationList; var nargs : array<rtti::Annota
     for (narg in nargs) {
         _::emplace(args, narg)
     }
-    delete nargs
 }
 
 

--- a/daslib/typemacro_boost.das
+++ b/daslib/typemacro_boost.das
@@ -435,7 +435,7 @@ class TemplateTypeMacroMacro : AstFunctionAnnotation {
             }
         }
         body.list |> emplace_new <| qmacro_expr() {
-            var inscope template_arguments <- to_array_move($e(mk_array_expr))
+            var template_arguments <- to_array_move($e(mk_array_expr))
         }
         // we need to build extra arguments list
         var mk_extra_array_expr = new ExprMakeArray(at = func.at, makeType = new TypeDecl(baseType = Type.autoinfer))

--- a/daslib/unroll.das
+++ b/daslib/unroll.das
@@ -66,7 +66,7 @@ class UnrollMacro : AstFunctionAnnotation {
             {
                 var iblk = clone_expression(efor.body)
                 remove_deref(van, iblk)
-                var inscope rules : Template
+                var rules : Template
                 rules |> replaceVariable(van) <| new ExprConstInt(at = call.at, value = i)
                 rules |> apply_template(call.at, iblk, false)
                 nblk.list |> emplace(iblk)

--- a/doc/source/reference/language/options.rst
+++ b/doc/source/reference/language/options.rst
@@ -306,7 +306,7 @@ Safety and Strictness
        See :ref:`Move, Copy, and Clone <move_copy_clone>`.
    * - ``strict_unsafe_delete``
      - bool
-     - false
+     - true
      - Makes ``delete`` of types that contain ``unsafe`` delete an unsafe operation.
    * - ``no_local_class_members``
      - bool

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1546,7 +1546,7 @@ namespace das
         /*option*/ bool no_aliasing = false;                       // if true, aliasing will be reported as error, otherwise will turn off optimization
         /*option*/ bool strict_smart_pointers = true;              // collection of tests for smart pointers, like van inscope for any local, etc
         /*option*/ bool no_init = false;                           // if true, then no [init] is allowed in any shape or form
-        /*option*/ bool strict_unsafe_delete = false;              // if true, delete of type which contains 'unsafe' delete is unsafe // TODO: enable when need be
+        /*option*/ bool strict_unsafe_delete = true;              // if true, delete of type which contains 'unsafe' delete is unsafe // TODO: enable when need be
         bool no_members_functions_in_struct = false;    // structures can't have member functions
         /*option*/ bool no_local_class_members = true;             // members of the class can't be classes
         /*option*/ bool report_invisible_functions = true;         // report invisible functions (report functions not visible from current module)

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -710,7 +710,9 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
             g_tracks[i] = null
         }
     }
-    delete g_tracks
+    unsafe {
+        delete g_tracks
+    }
     if (total_samples > 0ul) {
         let SPEED = total_time / double(total_samples)
         let SPEED_OF_LIGHT = 1000.lf / 48000.lf
@@ -822,9 +824,9 @@ def public strudel_shutdown() {
             g_tracks[i] = null
         }
     }
-    delete g_tracks
-    delete g_track_pcm
-    delete g_master_pcm
+    unsafe {
+        delete g_tracks
+    }
     g_sid = 0ul
     // release SF2 soundfont (finalizer recursively frees instruments/presets/zones)
     if (g_sf2 != null) {

--- a/modules/dasAudio/strudel/strudel_scheduler.das
+++ b/modules/dasAudio/strudel/strudel_scheduler.das
@@ -1250,7 +1250,9 @@ def finalize(var sched : Scheduler) {
             sched.voices[i] = null
         }
     }
-    delete sched.voices
+    unsafe {
+        delete sched.voices
+    }
     // streaming oscillator voices — release any HRTF state
     for (i in range(length(sched.osc_voices))) {
         if (sched.osc_voices[i].hrtf_l != null) {
@@ -1264,7 +1266,9 @@ def finalize(var sched : Scheduler) {
             sched.osc_voices[i].hrtf_r = null
         }
     }
-    delete sched.osc_voices
+    unsafe {
+        delete sched.osc_voices
+    }
     // SF2 voices — release HRTF state from parallel meta
     for (i in range(length(sched.sf2_meta))) {
         if (sched.sf2_meta[i].hrtf_l != null) {
@@ -1278,8 +1282,9 @@ def finalize(var sched : Scheduler) {
             sched.sf2_meta[i].hrtf_r = null
         }
     }
-    delete sched.sf2_voices
-    delete sched.sf2_meta
+    unsafe {
+        delete sched.sf2_voices
+    }
     // per-orbit buses — free native effect instances then send/output scratch buffers
     for (bus in sched.orbit_buses) {
         if (bus != null) {
@@ -1309,7 +1314,9 @@ def finalize(var sched : Scheduler) {
             sched.orbit_buses[i] = null
         }
     }
-    delete sched.orbit_buses
+    unsafe {
+        delete sched.orbit_buses
+    }
     // per-tick scratch buffers (including HRTF mono/stereo)
     delete sched.hrtf_mono_buf
     delete sched.hrtf_stereo_buf

--- a/modules/dasAudio/strudel/strudel_sf2.das
+++ b/modules/dasAudio/strudel/strudel_sf2.das
@@ -196,7 +196,9 @@ def finalize(var d : SF2InstrumentDef explicit) {
             delete z
         }
     }
-    delete d.zones
+    unsafe {
+        delete d.zones
+    }
 }
 
 def finalize(var d : SF2PresetDef explicit) {
@@ -211,7 +213,9 @@ def finalize(var d : SF2PresetDef explicit) {
             delete z
         }
     }
-    delete d.zones
+    unsafe {
+        delete d.zones
+    }
 }
 
 def finalize(var f : SF2File explicit) {
@@ -221,13 +225,17 @@ def finalize(var f : SF2File explicit) {
             delete inst
         }
     }
-    delete f.instruments
+    unsafe {
+        delete f.instruments
+    }
     for (preset in f.presets) {
         unsafe {
             delete preset
         }
     }
-    delete f.presets
+    unsafe {
+        delete f.presets
+    }
     // explicit finalizer replaces the default cascade — must delete remaining heap-owning fields
     delete f.sample_data
     delete f.samples

--- a/modules/dasPEG/peg/parse_macro.das
+++ b/modules/dasPEG/peg/parse_macro.das
@@ -154,7 +154,7 @@ def into_rule_(var expr : ExpressionPtr) : Rule_? {
         var as_expr <- expr as ExprAsVariant
         var subrule = ((expr as ExprAsVariant).value as ExprCall).arguments[0] |> into_rule_
         subrule.name := as_expr.name
-        var inscope t <- Rule(option <- subrule)
+        var t <- Rule(option <- subrule)
         return <- new Rule_(rule <- t, name = as_expr.name |> string())
     } elif (expr is ExprAsVariant && ((expr as ExprAsVariant).value is ExprPtr2Ref)) {
         var as_expr <- expr as ExprAsVariant
@@ -277,7 +277,7 @@ def transform(var rule : MacroRule) : Definition {
 
     // Transform array<ExprCall?> into an array of Rules
 
-    var inscope alternatives : array<Alternative>
+    var alternatives : array<Alternative>
 
     for (alt in rule.alternatives) {
         {// creates scope for inscope
@@ -371,9 +371,9 @@ class ParseMacro : AstCallMacro {
 
         // Transform
 
-        var inscope gram : array<Definition>
+        var gram : array<Definition>
 
-        var inscope gen <- ParserGenerator(id = times_invoked++)
+        var gen <- ParserGenerator(id = times_invoked++)
 
         for (mrule in rules_) {
             gram |> emplace(mrule |> transform)
@@ -406,7 +406,7 @@ class ParseMacro : AstCallMacro {
         let parse_main_func = "parse_{first_method_name}`id_{gen.id}"
 
         return <- qmacro_block() {
-            var inscope parser : $t(gen.parser_type)
+            var parser : $t(gen.parser_type)
 
             parser.suppress_errors |> push <| false
 
@@ -428,7 +428,7 @@ class ParseMacro : AstCallMacro {
 
             // Create an error-reporting parser and emit errors
 
-            var inscope error_reporting_parser : $t(gen.parser_type)
+            var error_reporting_parser : $t(gen.parser_type)
             error_reporting_parser.suppress_errors |> push <| false
 
             peek_data($i(name)) $(inp) {

--- a/modules/dasPEG/peg/parser_generator.das
+++ b/modules/dasPEG/peg/parser_generator.das
@@ -350,7 +350,7 @@ def generate_result_types(var gen : ParserGenerator) {
 def generate(var gen : ParserGenerator; var def_ : Definition) {
     gen.current_context = def_.name
 
-    var inscope function_body <- gen |> generate(def_.rule)
+    var function_body <- gen |> generate(def_.rule)
     var return_type = gen.return_types |> get_value_and_clone_type(gen.current_context)
 
     var fun = qmacro_function("parse_{def_.name}_inner`id_{gen.id}") $(var parser : $t(gen.parser_type)) : $t(return_type) {
@@ -549,7 +549,7 @@ def generate(var gen : ParserGenerator; var rule_ : Rule) : array<ExpressionPtr>
         if (Rule(text_extraction = $v(subrule))) {
             let result_handle = subrule.name
             let i = gen.rule_counter["extract"]++
-            var inscope subrule_ <- gen |> generate(subrule.rule)
+            var subrule_ <- gen |> generate(subrule.rule)
             var return_type = gen.return_types |> get_value_and_clone_type(gen.current_context)
 
             var t <- qmacro_block() {
@@ -621,7 +621,7 @@ def generate_maybe_repeat(var gen : ParserGenerator; var rule_ : Rule_?) : array
     let result_handle = rule_.name
 
     if (rule_.name == "") {// Rule not bound by name, discard result
-        var inscope rule_code <- gen |> with_context("__repetition__") {
+        var rule_code <- gen |> with_context("__repetition__") {
             return <- gen |> generate(rule_.rule)
         }
 
@@ -648,7 +648,7 @@ def generate_maybe_repeat(var gen : ParserGenerator; var rule_ : Rule_?) : array
     set_rule_handle(rule_, "temp_name")
     var type_decl = gen |> get_rule_type(rule_.rule)
 
-    var inscope rule_code <- gen |> with_context("__repetition__") {
+    var rule_code <- gen |> with_context("__repetition__") {
         return <- gen |> generate(rule_.rule)
     }
 
@@ -680,7 +680,7 @@ def generate_not(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expressi
     let mark_name = "__not_mark_{not_id}"
     let success_name = "__not_success_{not_id}"
 
-    var inscope rule_code <- gen |> with_context("__PEEK__") {
+    var rule_code <- gen |> with_context("__PEEK__") {
         return <- gen |> generate(rule_.rule)
     }
 
@@ -729,7 +729,7 @@ def generate_and(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expressi
     let mark_name = "__and_mark_{and_id}"
     let success_name = "__and_success_{and_id}"
 
-    var inscope rule_code <- gen |> with_context("__PEEK__") {
+    var rule_code <- gen |> with_context("__PEEK__") {
         return <- gen |> generate(rule_.rule)
     }
 
@@ -770,7 +770,7 @@ def generate_repeat(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expre
     let first_result_name = "__repeat_result_{gen.rule_counter["repeat"]++}"
 
     if (rule_.name == "") {// Rule not bound by name, discard result
-        var inscope rule_code <- gen |> with_context("__repetition__") {
+        var rule_code <- gen |> with_context("__repetition__") {
             return <- gen |> generate(rule_.rule)
         }
 
@@ -812,7 +812,7 @@ def generate_repeat(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expre
     // Bind result to the provided name
 
     set_rule_handle(rule_, "temp_name")
-    var inscope rule_code <- gen |> with_context("__repetition__") {
+    var rule_code <- gen |> with_context("__repetition__") {
         return <- gen |> generate(rule_.rule)
     }
 
@@ -985,7 +985,7 @@ def generate_option(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expre
     let result_handle = rule_.name
 
     if (rule_.name == "") {// Rule not bound by name, discard result
-        var inscope rule_code <- gen |> with_context("__option__") {
+        var rule_code <- gen |> with_context("__option__") {
             return <- gen |> generate(rule_.rule)
         }
 
@@ -1007,7 +1007,7 @@ def generate_option(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expre
     var type_decl = gen |> get_rule_type(rule_.rule)
     var result_type = gen.return_types |> get_value_and_clone_type(gen.current_context)
 
-    var inscope rule_code <- gen |> with_context("__option__") {
+    var rule_code <- gen |> with_context("__option__") {
         return <- gen |> generate(rule_.rule)
     }
 
@@ -1036,7 +1036,7 @@ def with_context(var gen : ParserGenerator; context : string; block_) {
     let last_context = gen.current_context
     gen.current_context = context
 
-    var inscope r <- invoke(block_)
+    var r <- invoke(block_)
 
     gen.current_context = last_context
     return <- r
@@ -1051,7 +1051,7 @@ def generate_one_alternative(var gen : ParserGenerator; var alt : Alternative; i
     var action <- alt.action
     var return_type = gen.return_types |> get_value_and_clone_type(gen.current_context)
     var action_block = unsafe(action as ExprBlock) |> flatten_block
-    var inscope block_contents <- gen |> generate(alt.rule.rule)
+    var block_contents <- gen |> generate(alt.rule.rule)
 
     // Add epilogue (code that executes the associated action)
 

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -1868,8 +1868,8 @@ namespace das
             }
             return result;
         } else if ( expr->subexpr->type->isGoodArrayType() ) {
-            auto prv = getE(expr->subexpr);
-            auto pidx = getE(expr->index);
+            auto prv = simulateExpression(expr->subexpr);
+            auto pidx = simulateExpression(expr->index);
             uint32_t stride = expr->subexpr->type->firstType->getSizeOf();
             if ( r2vType->baseType!=Type::none ) {
                 return context.code->makeValueNode<SimNode_ArrayAtR2V>(r2vType->getR2VType(), at, prv, pidx, stride, extraOffset);
@@ -1878,8 +1878,8 @@ namespace das
             }
         } else if ( expr->subexpr->type->isPointer() ) {
             uint32_t stride = expr->subexpr->type->firstType->getSizeOf();
-            auto prv = getE(expr->subexpr);
-            auto pidx = getE(expr->index);
+            auto prv = simulateExpression(expr->subexpr);
+            auto pidx = simulateExpression(expr->index);
             if ( r2vType->baseType!=Type::none ) {
                 switch ( expr->index->type->baseType ) {
                 case Type::tInt:    return context.code->makeValueNode<SimNode_PtrAtR2V_Int>(r2vType->getR2VType(), at, prv, pidx, stride, extraOffset);
@@ -1919,8 +1919,8 @@ namespace das
                 }
             }
             // regular scenario
-            auto prv = getE(expr->subexpr);
-            auto pidx = getE(expr->index);
+            auto prv = simulateExpression(expr->subexpr);
+            auto pidx = simulateExpression(expr->index);
             auto errorMessage = context.code->allocateName(", "+expr->describe());
             if ( r2vType->baseType!=Type::none ) {
                 return context.code->makeValueNode<SimNode_AtR2V>(r2vType->getR2VType(), at, prv, pidx, stride, extraOffset, range, errorMessage);
@@ -2327,14 +2327,14 @@ namespace das
         DAS_ASSERTF(fieldOffset>=0,"field offset is somehow not there");
         if (expr->value->type->isPointer()) {
             if ( expr->unsafeDeref ) {
-                auto simV = getE(expr->value);
+                auto simV = simulateExpression(expr->value);
                 if ( r2vType->baseType!=Type::none ) {
                     return context.code->makeValueNode<SimNode_FieldDerefR2V>(r2vType->getR2VType(), at, simV, fieldOffset + extraOffset);
                 } else {
                     return context.code->makeNode<SimNode_FieldDeref>(at, simV, fieldOffset + extraOffset);
                 }
             } else {
-                auto simV = getE(expr->value);
+                auto simV = simulateExpression(expr->value);
                 auto errorMessage = context.code->allocateName(", "+expr->value->describe()+" is null");
                 if ( r2vType->baseType!=Type::none ) {
                     return context.code->makeValueNode<SimNode_PtrFieldDerefR2V>(r2vType->getR2VType(), at, simV, fieldOffset + extraOffset, errorMessage);
@@ -2346,7 +2346,7 @@ namespace das
             if ( auto chain = sv_trySimulate(expr->value, extraOffset + fieldOffset, r2vType) ) {
                 return chain;
             }
-            auto simV = getE(expr->value);
+            auto simV = simulateExpression(expr->value);
             if ( r2vType->baseType!=Type::none ) {
                 return context.code->makeValueNode<SimNode_FieldDerefR2V>(r2vType->getR2VType(), at, simV, extraOffset + fieldOffset);
             } else {

--- a/src/ast/ast_validate.cpp
+++ b/src/ast/ast_validate.cpp
@@ -275,8 +275,9 @@ namespace das {
         for ( auto mod : modules ) {
             for ( auto & [key, ann] : mod->handleTypes ) {
                 if ( ann ) {
+                    const auto &ann_name = ann->name;
                     ann->visitTypeDecls([&]( TypeDecl * td ) {
-                        vis.trackAnnotationTypeDecl(td, ann->name);
+                        vis.trackAnnotationTypeDecl(td, ann_name);
                     });
                 }
             }

--- a/src/hal/debug_break.cpp
+++ b/src/hal/debug_break.cpp
@@ -5,20 +5,6 @@
 
 #include <signal.h>
 
-uint64_t               das::ptr_ref_count::ref_count_total = 0;
-uint64_t               das::ptr_ref_count::ref_count_track = 0;
-uint64_t               das::ptr_ref_count::ref_count_track_destructor = 0;
-das::ptr_ref_count *   das::ptr_ref_count::ref_count_head = nullptr;
-das::mutex             das::ptr_ref_count::ref_count_mutex;
-
-DAS_API das::atomic<uint64_t> das::g_smart_ptr_total {0};
-
-// JobStatus / Feature tracking
-DAS_API das::atomic<uint64_t> das::g_jobque_track_total {0};
-DAS_API das::atomic<uint64_t> das::g_jobque_track_id {0};
-das::JobStatus *    das::JobStatus::sTrackHead = nullptr;
-das::mutex          das::JobStatus::sTrackMutex;
-
 DAS_API void os_debug_break()
 {
 #ifdef _MSC_VER

--- a/src/misc/gc_node.cpp
+++ b/src/misc/gc_node.cpp
@@ -4,9 +4,6 @@
 
 #include <inttypes.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <signal.h>
-#endif
 
 namespace das {
 

--- a/src/misc/globals.cpp
+++ b/src/misc/globals.cpp
@@ -1,0 +1,23 @@
+// Provides storage for daScript globals that upstream lives in src/hal/debug_break.cpp.
+// Dagor's jamfile doesn't build src/hal/ (games supply their own os_debug_break, crash
+// handlers, file access hooks), but the smart_ptr and JobStatus tracking globals are
+// referenced unconditionally after the `smart_ptr: remove debug macros, always-on
+// tracking` change -- put them here so every dagor executable gets them via daScript.lib.
+
+#include "daScript/misc/platform.h"
+
+#include "daScript/misc/smart_ptr.h"
+#include "daScript/misc/job_que.h"
+
+uint64_t               das::ptr_ref_count::ref_count_total = 0;
+uint64_t               das::ptr_ref_count::ref_count_track = 0;
+uint64_t               das::ptr_ref_count::ref_count_track_destructor = 0;
+das::ptr_ref_count *   das::ptr_ref_count::ref_count_head = nullptr;
+das::mutex             das::ptr_ref_count::ref_count_mutex;
+
+DAS_API das::atomic<uint64_t> das::g_smart_ptr_total {0};
+
+DAS_API das::atomic<uint64_t> das::g_jobque_track_total {0};
+DAS_API das::atomic<uint64_t> das::g_jobque_track_id {0};
+das::JobStatus *    das::JobStatus::sTrackHead = nullptr;
+das::mutex          das::JobStatus::sTrackMutex;

--- a/src/misc/sysos.cpp
+++ b/src/misc/sysos.cpp
@@ -136,7 +136,7 @@
                 FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                 nullptr, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
                 (LPSTR)&buf, 0, nullptr);
-            string msg = (n && buf) ? string(buf, n) : ("error code " + std::to_string(err));
+            string msg = (n && buf) ? string(buf, n) : ("error code " + to_string(err));
             if ( buf ) LocalFree(buf);
             while ( !msg.empty() && (msg.back()=='\r' || msg.back()=='\n') ) msg.pop_back();
             return msg;

--- a/src/simulate/fs_file_info.cpp
+++ b/src/simulate/fs_file_info.cpp
@@ -245,8 +245,8 @@ namespace das {
             bool dasRoot = (req.size() >= 2 && req[0] == '%' && req[1] == '/');
             if ( relCur || relPar || dasRoot ) {
                 namespace fs = std::filesystem;
-                fs::path base = dasRoot ? fs::path(getDasRoot()) : fs::path(from).parent_path();
-                fs::path rel  = dasRoot ? fs::path(req.substr(2)) : fs::path(req);
+                fs::path base = dasRoot ? fs::path(getDasRoot().c_str()) : fs::path(from.c_str()).parent_path();
+                fs::path rel  = dasRoot ? fs::path(req.substr(2).c_str()) : fs::path(req.c_str());
                 // refuse absolute paths in the right-hand side: fs::path::operator/
                 // discards the LHS when RHS is absolute, which would let `%//etc/x.das`
                 // (or `%/C:/x.das` on Windows) escape getDasRoot() and the `from` dir.
@@ -263,8 +263,8 @@ namespace das {
                 }
                 fs::path full = (base / rel).lexically_normal();
                 ModuleInfo info;
-                info.fileName   = full.generic_string();
-                info.moduleName = full.stem().generic_string();
+                info.fileName   = full.generic_string().c_str();
+                info.moduleName = full.stem().generic_string().c_str();
                 info.importName = info.moduleName;
                 return info;
             }

--- a/tests/aot/test_value_handle_iter.das
+++ b/tests/aot/test_value_handle_iter.das
@@ -1,0 +1,57 @@
+options gen2
+require dastest/testing_boost public
+require fio
+
+//! Regression: iterating a vector-like container of a value-annotation handle
+//! (ManagedValueAnnotation<T>, e.g. `clock` / `das::Time`) used to emit a value
+//! variable declaration in AOT C++ but pointer-dereference usage, breaking the
+//! AOT build. The AOT emitter must keep the `*` suffix when substitute_ref is
+//! requested, even for value handles.
+
+def sum_clocks(clocks : array<clock>) : int64 {
+    var total = 0l
+    for (c in clocks) {
+        total += int64(c)
+    }
+    return total
+}
+
+def sum_clocks_const(clocks : array<clock> const) : int64 {
+    var total = 0l
+    for (c in clocks) {
+        total += int64(c)
+    }
+    return total
+}
+
+def first_clock(clocks : array<clock>) : clock {
+    for (c in clocks) {
+        return c
+    }
+    return mktime(1970, 1, 1, 0, 0, 0)
+}
+
+[test]
+def test_iter_value_handle(t : T?) {
+    t |> run("for over array<clock>") @(t : T?) {
+        var clocks : array<clock>
+        clocks |> push(mktime(2024, 1, 1, 0, 0, 0))
+        clocks |> push(mktime(2024, 1, 2, 0, 0, 0))
+        clocks |> push(mktime(2024, 1, 3, 0, 0, 0))
+        let expected = int64(clocks[0]) + int64(clocks[1]) + int64(clocks[2])
+        t |> equal(sum_clocks(clocks), expected)
+    }
+    t |> run("for over array<clock> const") @(t : T?) {
+        var clocks : array<clock>
+        clocks |> push(mktime(2024, 1, 1, 0, 0, 0))
+        clocks |> push(mktime(2024, 1, 2, 0, 0, 0))
+        let expected = int64(clocks[0]) + int64(clocks[1])
+        t |> equal(sum_clocks_const(clocks), expected)
+    }
+    t |> run("return element from iteration") @(t : T?) {
+        var clocks : array<clock>
+        clocks |> push(mktime(2024, 1, 1, 0, 0, 0))
+        clocks |> push(mktime(2024, 1, 2, 0, 0, 0))
+        t |> equal(int64(first_clock(clocks)), int64(clocks[0]))
+    }
+}

--- a/tests/math/mat_let_handle.das
+++ b/tests/math/mat_let_handle.das
@@ -47,3 +47,20 @@ def test_mat_let_handle(t : T?) {
     test_mat(t, m)
     test_transpose(t)
 }
+
+struct S { m : float3x4; }
+
+def get_col3(s : S?&) : float3 {
+    // s.m[3] through ptr-ref arg used to trip SimulateVisitor::getE
+    return s.m[3]
+}
+
+[test]
+def test_mat_field_idx_through_ptr(t : T?) {
+    var s : S
+    s.m[3] = float3(1.0, 2.0, 3.0)
+    unsafe {
+        var p : S? = addr(s)
+        t |> equal(get_col3(p), float3(1.0, 2.0, 3.0))
+    }
+}

--- a/utils/aot/main.das
+++ b/utils/aot/main.das
@@ -165,7 +165,7 @@ def main() {
             ast_gc_guard() {
                 let res = aot(aot_in, false, cross_platform, cop)
                 if (res |> empty()) {
-                    to_log(LOG_ERROR, "Failed to compile `{aot_in}` in standalone.\n")
+                    to_log(LOG_ERROR, "Failed to compile `{aot_in}` in aot.\n")
                     result = false
                 } else {
                     let written = write_result(res, aot_out, "Aot", force_overwrite)

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -439,6 +439,7 @@ SET(MISC_SRC
 ../src/misc/job_que.cpp
 ../src/misc/free_list.cpp
 ../src/misc/gc_node.cpp
+../src/misc/globals.cpp
 ../src/misc/daScriptC.cpp
 ../src/misc/handle_registry.cpp
 ../src/misc/uric.cpp


### PR DESCRIPTION
## Summary

Bundle of various fixes accumulated on this branch.

### Compiler / runtime
- **`compiler: fix trySimulate implementation`** — `ExprAt::trySimulate` was calling `getE()` after extraction from `Expression`, which broke array/pointer indexing in tail positions. Switched to `simulateExpression()`. Added [tests/math/mat_let_handle.das](tests/math/mat_let_handle.das) repro.
- **`compiler: fix structured binding`** — replaced C++20 structured binding in `ast_validate.cpp` with a named temporary so the build works under older toolchains.
- **`compiler: add no_strict_delete`** — flipped `strict_unsafe_delete` default to `true` ([include/daScript/ast/ast.h](include/daScript/ast/ast.h)). `delete` of a type containing an `unsafe` finalizer is now reported as unsafe by default.
- **`compiler: remove unused gc_node import`** — `<signal.h>` is unavailable on consoles; removed from `gc_node.cpp`.
- **`compiler: add link to bug reports to crash handler`** — Win32 + POSIX crash handlers print a GitHub issues URL alongside the stack trace.

### AOT
- **`aot: apply fix for iterators`** ([daslib/aot_cpp.das](daslib/aot_cpp.das)) — when `substitute_ref` is requested (iteration variables), keep the `*` suffix even on value-annotation handles. `das_iterator::first(Context*, T*&)` requires a real pointer regardless of POD-ness. Repro: [tests/aot/test_value_handle_iter.das](tests/aot/test_value_handle_iter.das).
- **`aot: do not overflow on ConstInt64`** — emit `range64(x ll, y ll)` / `urange64(x ull, y ull)` so 64-bit literals don't truncate through `int`.
- **`aot: fix typo`**.
