### PR TITLE
dasSQLITE chunk 11: SqlFrag + pragma/vacuum + runtime _order_by

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ modules/dasStbImage/dasModuleStbImage.pdb
 modules/dasStdDlg/dasModuleStdDlg.pdb
 modules/dasUnitTest/dasModuleUnitTest.pdb
 tree-sitter-daslang/daslang.pdb
-libhv.20260408.log
+libhv.*.log
 modules/dasAudio/dasModuleAudio_debug.pdb
 modules/dasHV/dasModuleHV_debug.pdb
 modules/dasLiveHost/dasModuleLiveHost_debug.pdb

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/daslang_live.md` | `daslang-live`, live-reload lifecycle, `[live_command]`, `[before_reload]`/`[after_reload]` |
 | `skills/perf_lint.md` | Adding rules to `daslib/perf_lint.das` |
 | `skills/style_lint.md` | Adding rules to `daslib/style_lint.das` |
+| `skills/regex.md` | Writing regular expressions in `.das` code |
 | `skills/gc_migration.md` | Migrating external/archived code from `smart_ptr<T>` AST patterns to gc_node (in-tree migration is complete) |
 | `skills/version_update.md` | Bumping the daslang version number |
 | `skills/jobque_debugging.md` | Channel/LockBox/JobStatus/Feature leaks (`--track-job-status`, `DumpJobQueLeaks`) |
@@ -229,6 +230,7 @@ Full migration table (when reading older docs that say `var inscope` or `<-` for
 | `get_ptr(x) == null` / `get_ptr(x).field` | `x == null` / `x.field` | AST pointers auto-dereference; `get_ptr` is smart_ptr-era residue |
 | `string(das_str) == "lit"`, `!empty(string(das_str))` | drop the `string(...)` cast | `das_string` compares with `string` directly; `empty()` works on it |
 | `let v = string(x.name); $i(v)` / `var copy = val; $v(copy)` | `$i(x.name)` / `$v(val)` | qmacro tags accept `das_string`, `let` vars, loop vars directly |
+| 6 qmacro arms differing only in the call target (`if isTry { qmacro(_::try_run_select(…)) } elif … { … }`) | `let fname = (isTry ? "try_run_select" : "run_select") + suffix; qmacro($c(fname)(…))` | `$c(stringVar)` splices a function name; resolution at splice site uses user's `require` chain. Note: `_::$c(…)` is a parse error — drop `_::` |
 | `if (true) { ... }` | `{ ... }` | bare blocks create lexical scope in gen2 |
 | `var inscope r <- expr; return <- r` | `return <- expr` | direct return avoids intermediate |
 | `unsafe { (reinterpret<ExprBlock?> blk).list }` / `unsafe(reinterpret<T?> x)` | make param `var` + plain `x.list` | `var` param gives non-const field access without reinterpret |
@@ -236,6 +238,14 @@ Full migration table (when reading older docs that say `var inscope` or `<-` for
 For path/filename ops use `fio` helpers (`base_name`/`dir_name`/`path_join`/etc.) — see `skills/filesystem.md`. Never hand-roll `rfind("/")` / slice — misses Windows separators.
 
 **Minimize `unsafe`:** Most `unsafe(reinterpret<T?>)` in macro code exists to strip `const` from raw-pointer field access. Fix the root cause: make the function parameter `var` so field access returns non-const pointers. Reserve `unsafe` for genuinely unsafe operations (pointer arithmetic, `reinterpret` across unrelated types).
+
+**Comment hygiene.** Comments are 1–2 lines max. Strict rules:
+
+1. **No banner comments above a documented function.** When a function carries `//!` inside its body, drop the `// ===== name — desc =====` block above. The banner duplicates the doc.
+2. **No multi-paragraph architectural prose at the head of a section.** Don't write 10–30 line preambles explaining design decisions, surface examples, NULL handling, panic semantics, etc. above `// Section name`. Code reads well; design docs (plans, `API_REWORK.md`, RST tutorials) carry the WHY. If a reader genuinely needs that context, it goes in those docs, not the source.
+3. **Private functions and types don't get public-style docs.** `//!` / `//!<` is for tooling-visible public API. On `def private`, `struct private`, `enum private`, `variant private`, drop the docstring entirely — the symbol isn't exported, so no doc generator ever sees it, and the docstring just restates the function name / field name to a reader who already has them. If a function or field genuinely needs a 1-line WHY (non-obvious invariant, surprising behavior), write a plain `// ...` line, not `//!`. The bar for keeping any comment on a private symbol is "a maintainer reading the symbol alone would be surprised."
+4. **What stays:** terse 2-line section dividers (`// ===== Section name =====`), `//!` docstrings on PUBLIC functions/types (visible to tooling), and inline `//` comments that flag a non-obvious WHY at the *exact* line — a workaround for a specific bug, a subtle invariant, behavior that would surprise a reader. Don't restate what the code says.
+5. **When in doubt:** delete. If reading the code + the relevant docstring(s) doesn't make the WHY clear, the comment was load-bearing. Otherwise it was noise.
 
 ## Key Directories
 

--- a/install/CLAUDE.md
+++ b/install/CLAUDE.md
@@ -87,6 +87,7 @@ Task-specific instructions are in skill files under `skills/`. Read the relevant
 | `skills/jobque_debugging.md` | Channel/LockBox/JobStatus/Stream/Feature leaks |
 | `skills/detect_dupe.md` | Duplicate-function detection (corpus, MCP tools `export_corpus`/`detect_duplicates`, CLI under `utils/detect-dupe/`) |
 | `skills/linq.md` | Filter/map/sort/group/aggregate transforms — prefer comprehension → linq_boost → plain `for`; avoid `daslib/functional` for new code |
+| `skills/regex.md` | Writing regular expressions in `.das` code |
 
 Multiple skill files may apply to a single task. For example, embedding daslang and calling its standard library requires reading both `skills/cpp_integration.md` and `skills/daslib_modules.md`.
 

--- a/install/skills/regex.md
+++ b/install/skills/regex.md
@@ -1,0 +1,147 @@
+# Regular expressions in daslang
+
+## When to use this skill
+
+Read this skill when writing regular expressions in `.das` code — anywhere you reach for `regex_compile`, `regex_match`, `regex_search`, the `%regex~...%%` reader macro, or any of the `regex_replace` / `regex_split` / `regex_foreach` family.
+
+## API
+
+Two modules: `daslib/regex` (the engine, all runtime functions) and `daslib/regex_boost` (the compile-time `%regex~...%%` reader macro).
+
+```daslang
+require daslib/regex
+require daslib/regex_boost
+```
+
+### Compiling
+
+```daslang
+def regex_compile(expr : string; case_insensitive : bool = false; dot_all : bool = false) : Regex
+def regex_compile(var re : Regex; expr : string; case_insensitive : bool = false; dot_all : bool = false) : bool
+def is_valid(var re : Regex) : bool
+```
+
+For literal patterns, prefer the **reader macro** over runtime compilation:
+
+```daslang
+var private RE <- %regex~^\s*(?:def|struct)\s+private\b%%
+var private RE_I <- %regex~hello%%i        // case-insensitive
+var private RE_S <- %regex~start.*end%%s   // dot-all (`.` matches `\n`)
+var private RE_IS <- %regex~Foo%%is        // both flags
+```
+
+The macro compiles the pattern at parse time and embeds the resulting `Regex` directly into the AST. Three benefits: (1) no escape-doubling — write `\s+` not `"\\s+"`; (2) parse-time validation — bad patterns surface as compile errors; (3) no per-call compilation cost. Module-scope `var` (mutable, since matching mutates internal state) is the standard pattern.
+
+### Matching
+
+```daslang
+def regex_match(var regex : Regex; str : string; offset : int = 0) : int
+```
+Anchored at `offset` — checks "does the regex match starting here?". Returns the **length** of the match in bytes consumed, or `-1` if no match. Pattern starting with `^` and `regex_match(re, line)` is the common idiom for "does this line begin with...".
+
+```daslang
+def regex_search(var regex : Regex; str : string; offset : int = 0) : int2
+```
+Scans forward — returns `int2(start, end)` of the first match, or `int2(-1, -1)` if not found. Use this for substring search.
+
+```daslang
+def regex_match_all(var regex : Regex; str : string) : array<range>
+```
+Returns every match position as an `array<range>` (each `range.x` = start, `range.y` = end+1).
+
+### Group access
+
+```daslang
+def regex_group(regex : Regex; index : int; match : string) : string
+def regex_group_by_name(regex : Regex; name : string; str : string) : string
+def operator [](regex : Regex; index : int) : range
+def operator [](regex : Regex; name : string) : range
+```
+
+Group `0` is the whole match; numbered groups follow parenthesization order. Named groups via `(?P<name>...)`.
+
+### Iteration and replacement
+
+```daslang
+def regex_foreach(var regex : Regex; str : string; blk : block<(at : range) : bool>)
+def regex_replace(var regex : Regex; str : string; replacement : string) : string
+def regex_replace(var regex : Regex; str : string; blk : block<(matched : string) : string>) : string
+def regex_split(var regex : Regex; str : string) : array<string>
+```
+
+Block form lets you compute each replacement; template-string form handles the common case:
+
+```daslang
+let rewritten = regex_replace(re, src, "$1=$2")              // template
+let rewritten = regex_replace(re, src) <| $(matched) {       // callback
+    return upper(matched)
+}
+```
+
+### Template replacement references
+
+| Token | Meaning |
+|---|---|
+| `$0` or `$&` | the whole match |
+| `$1`–`$9` | numbered capture groups |
+| `${name}` | named capture group |
+| `$$` | literal `$` |
+
+## Syntax (this engine)
+
+Pure NFA implementation — not PCRE, not POSIX. Supports:
+
+| Feature | Syntax |
+|---|---|
+| Anchors | `^` (start), `$` (end) |
+| Character classes | `\w` `\W` `\d` `\D` `\s` `\S` `\t` `\n` `\r` `\f` `\v` |
+| Quantifiers (greedy) | `+` `*` `?` `{n}` `{n,}` `{n,m}` |
+| Quantifiers (lazy) | `+?` `*?` `??` `{n,m}?` |
+| Capturing group | `(...)` |
+| Non-capturing group | `(?:...)` |
+| Named group | `(?P<name>...)` |
+| Lookahead | `(?=...)` (positive), `(?!...)` (negative) |
+| Word boundary | `\b` (boundary), `\B` (non-boundary) |
+| Char set | `[a-z]`, `[^abc]`; meta-classes inside: `[\d_]` |
+| Alternation | `|` (use `\|` for a literal pipe) |
+| Hex escape | `\xHH` |
+| Metacharacter escape | `\.` `\+` `\*` `\(` `\)` `\[` `\]` `\|` `\\` `\^` `\{` `\}` |
+| Any char | `.` (matches anything but `\n` unless `dot_all=true`) |
+
+## Gotchas
+
+- **`regex_match` is anchored, not substring.** `regex_match(re, "abc")` only matches at offset 0; for "find anywhere" use `regex_search`.
+- **ASCII-only.** The engine's char sets are 256-bit; no Unicode classes, no Unicode-aware case folding. `case_insensitive=true` only folds ASCII A–Z.
+- **Pure NFA.** Catastrophic backtracking is possible on poorly-anchored patterns with nested quantifiers — anchor with `^`, use atomic-style non-capturing groups, and avoid nested `*`/`+` whenever possible.
+- **Escape doubling in plain string literals.** `regex_compile("\\d+")` versus `%regex~\d+%%` — reader macro wins for literal patterns. Reach for runtime `regex_compile` only when the pattern is constructed dynamically.
+- **`Regex` is mutable.** Match functions take `var regex : Regex` and mutate scratch state. Module-scope `var` (not `let`) for shared compiled patterns.
+
+## Idiomatic example
+
+```daslang
+require daslib/regex public
+require daslib/regex_boost
+
+var private IDENT_RE <- %regex~[A-Za-z_][A-Za-z0-9_]*%%
+var private NUM_RE <- %regex~([+-]?)(\d+)(?:\.(\d+))?%%
+
+def starts_with_ident(s : string) : bool {
+    return regex_match(IDENT_RE, s) >= 0
+}
+
+def parse_signed_int(s : string) : int {
+    let pos = regex_search(NUM_RE, s)
+    if (pos.x < 0) {
+        return 0
+    }
+    let sign = regex_group(NUM_RE, 1, s)
+    let mag = regex_group(NUM_RE, 2, s)
+    let n = to_int(mag)
+    return sign == "-" ? -n : n
+}
+```
+
+## Reference
+
+- Engine: `daslib/regex.das`
+- Compile-time reader macro: `daslib/regex_boost.das`

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -661,8 +661,8 @@ Chunk 10 ships **tut 31 (views)**, **tut 33 (PRAGMA tuning)**, **tut 34
 (backup + VACUUM)**, **tut 35 (streaming `_each_sql`)**, and **tut 39
 (user-defined SQL scalar functions)** — five tutorials covering the
 "operational" surface of SQLite that wasn't yet in the daslang rail.
-Migrations (originally listed as tut 30) deferred to chunk 11. No new
-language prerequisites; chunk 10 sits entirely on the chunk-2..9
+Migrations (originally listed as tut 30) deferred to the last chunk. No
+new language prerequisites; chunk 10 sits entirely on the chunk-2..9
 foundation.
 
 ### Tut 31 — `[sql_view]` + `_create_view`
@@ -829,16 +829,27 @@ foundation.
 
 ### Carried / deferred to chunk 11+
 
-- **SQL-fragment refactor** — replace `_create_view`'s literal-inlining
-  hack with a polymorphic emitter. Design: `variant SqlFragment {
-  Text : string; Bind : ExpressionPtr }`; two render modes —
-  `render_placeholders` for `_sql` / `_each_sql` (today's behavior,
-  returns `(sql, binds)`), `render_inlined` for `_create_view`
-  (formats const literals into text or fails on captured locals). Same
-  machinery applies to future DDL contexts where `?` is illegal:
-  `CREATE INDEX … ON t(<expr>)`, `CHECK(<expr>)`, `GENERATED ALWAYS AS
-  (<expr>)`. ~200-300 lines touched in sqlite_linq.das (8-10 sites).
-- **Migrations (chunk 11)** — `daslib/sql_migrate` module,
+- **SQL-fragment refactor** — SHIPPED in chunk 11 (`SqlFrag` variant +
+  `fold_to_string` / `fold_to_builder` consumers in sqlite_linq.das).
+  All 13 macro emissions route through `fold_to_builder`; const-folding
+  collapses all-text/all-bind chains to a single `ExprConstString` so
+  AOT codegen is byte-identical to the previous `$v(sql)` baking path.
+  PR-B follow-on adds `_sql_pragma(db, name, value)` and
+  `_sql_vacuum_into(db, path)` macros that exercise the
+  `inline_id` / `inline_lit` SqlFrag kinds — both fold to literal SQL
+  when args are compile-time constants, falling back to a builder
+  with `sql_quote_id` / `sql_quote_lit` calls otherwise. PR-C extends
+  `_order_by` / `_order_by_descending` to accept a `string`-typed
+  expression (single col or tuple element) — the SQL build emits a
+  `\x01` placeholder consumed by `sql_to_frags_ex`, which routes the
+  expression through `fold_to_builder` as an `inline_id` frag. Const
+  strings still fold to compile-time-quoted SQL; runtime variables emit
+  `sql_quote_id(<expr>)` so embedded `"` is doubled safely. Mixed
+  tuples (e.g. `(_.Price, runtimeName)`) work — each entry independently
+  picks the compile-time `_.Field` or runtime-string path. `_create_view`
+  rejects runtime ORDER BY (DDL is run-once; runtime column would bake at
+  view-creation time).
+- **Migrations (last chunk)** — `daslib/sql_migrate` module,
   `[sql_migration]` annotation collected across translation units,
   `migrate_to_latest` runner, `__schema_version` table, multi-row
   audit semantics.

--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -420,7 +420,7 @@ E. **Forward-looking: `dasSQL` abstraction layer** — the roadmap beyond
 | 29 | Column metadata | `29-column_names.das` | **Shipped** (chunk 9); Band 1 `column_info(type<T>) : array<ColumnInfo>` (compile-time walk) + abstract `SqlType` enum + `sqlite_sql_type` dialect renderer; Band 3 raw `PRAGMA table_info` via the typed `query` family |
 | 30 | Listing tables | `30-list_tables.das` | **Shipped** (chunk 9); raw `query` against `sqlite_master`; no abstract `list_tables` helper (catalog spelling diverges per backend) |
 | 31 | Views | `31-views.das` | **Shipped** (chunk 10); `[sql_view(name=...)]` annotation + `_create_view` macro + `drop_view_if_exists`; mutation-path rejection at compile time (predicate form) and runtime (row form) |
-| 32 | Migrations | `30-migrations.das` | Has mockup — deferred to chunk 11 |
+| 32 | Migrations | `30-migrations.das` | Has mockup — deferred to last chunk |
 | 33 | PRAGMA tuning | `33-pragma.das` | **Shipped** (chunk 10); `set_pragma` / `try_set_pragma` (string/int64/bool overloads) + `apply_recommended_pragmas` (WAL + busy_timeout + foreign_keys + synchronous=NORMAL) |
 | 34 | Backup + VACUUM | `34-backup_vacuum.das` | **Shipped** (chunk 10); `vacuum` / `vacuum_into` / `optimize` / `integrity_check` / `quick_check` + `backup_to(dest)` / `backup_to(path)` (online Backup API with SQLITE_BUSY/LOCKED retry) |
 | 35 | Streaming results | `35-streaming.das` | **Shipped** (chunk 10); `_each_sql(chain)` returning `iterator<T>`, generator-based; rejects materializing terminals (`_to_array`, `_first`, aggregates); `sqlite3_finalize` runs in `finally` so stmt is released on break/exhaustion/panic |

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -68,17 +68,7 @@ def sqlite3_prepare_v2(db : sqlite3?; sql : string; var stmt : sqlite3_stmt?&) {
     return sqlite3_prepare_v2_no_tail(db, sql, unsafe(addr(stmt)))
 }
 
-// ============================================================================
-// High-level API — runner, RAII, scalar query, exec, last_insert_rowid
-//
-// Error-handling shape: each fallible operation has a `try_*` form that does
-// the work and returns the failure-or-result via daslib/option +
-// daslib/result. The strict form (no `try_`) is a thin wrapper that unwraps
-// and panics on failure — so the panic message is always the libsqlite3
-// errmsg, never a generic "unwrap called on err". For void-returning
-// operations the try_ form returns `SqlError = Option<string>` where
-// `none = success` and `some(errmsg) = failure`.
-// ============================================================================
+// ===== High-level API: runner, RAII, exec, last_insert_rowid =====
 
 struct SqlRunner {
     //! Owns a libsqlite3 connection. Closed by `finalize` on `var inscope` scope exit.
@@ -151,10 +141,6 @@ def try_exec(db : SqlRunner; sql : string) : SqlError {
 
 def private try_exec_with_binds(db : SqlRunner; sql : string;
                                 bind_blk : block<(var stmt : sqlite3_stmt?) : void>) : SqlError {
-    //! Single-statement ``exec`` with positional binds. Used by the 1/2/3-arg
-    //! ``try_exec`` / ``exec`` overloads below.  Routes through prepare /
-    //! bind / step / finalize because ``sqlite3_exec`` doesn't accept bind
-    //! parameters directly.
     var stmt : sqlite3_stmt?
     let prc = sqlite3_prepare_v2(db.sqlite_handle, sql, stmt)
     if (prc != SQLITE_OK) {
@@ -242,26 +228,7 @@ def changes(db : SqlRunner) : int {
     return sqlite3_changes(db.sqlite_handle)
 }
 
-// ============================================================================
-// SQL adapter rail: sql_bind / sql_extract  (tut 26)
-//
-// Convention-by-name dispatch. Every SQL-addressable type T has a pair:
-//
-//     def sql_bind    (v : T) : P                 // T → primitive
-//     def sql_extract (v : P; t : type<T>) : T    // primitive → T
-//
-// where P is one of {int64, double, string, array<uint8>} — the four
-// SQLite storage classes. dasSQLITE ships pairs for all standard types
-// plus a generic enum overload; user code adds pairs for domain types in
-// their own modules. The [sql_table] macro emits ``_::sql_bind`` /
-// ``_::sql_extract`` calls (tut 26 lock 4) so the caller's-module
-// overloads are always visible.
-//
-// The return type of ``sql_bind`` IS the storage type — the macro reads
-// it via ``typedecl`` and emits the matching ``sqlite3_bind_*`` /
-// ``sqlite3_column_*`` call. Single source of truth, no separate
-// ``sql_column_type(type<T>)`` registration function.
-// ============================================================================
+// ===== SQL adapter rail: sql_bind / sql_extract  (tut 26) =====
 
 // --- four primitive identity overloads ---
 
@@ -393,17 +360,7 @@ def sql_extract(v : int64; t : type<bool>) : bool {
     return v != 0l
 }
 
-// --- enum generic (lock 6) ---
-//
-// Any enum T round-trips through INTEGER via ``int64(value)`` /
-// ``T(int64)``. The catch-all generic uses ``static_if (typeinfo
-// is_enum)`` to gate; non-enum non-primitive types trip the
-// ``concept_assert`` and surface a clean error at the [sql_table]
-// expansion site (or any other _::sql_bind caller).
-//
-// Tradeoff: enum-value reordering silently corrupts data (value 2 means
-// something different in the new schema version). Text-backed enums
-// (``@sql_enum_as_string``) are deferred until a user opts in.
+// --- enum generic ---
 
 def sql_bind(value : auto(TT)) : int64 {
     static_if (typeinfo is_enum(value)) {
@@ -433,19 +390,7 @@ def sql_extract(value : int64; t : type<auto(TT)>) : TT {
     }
 }
 
-// ============================================================================
-// Internal bridge: sql_bind/sql_extract ↔ libsqlite3 C API
-//
-// The [sql_table] macro emits ``_::sql_bind(row.field)`` (resolves the user's
-// adapter at the caller's module) and routes the resulting primitive into
-// libsqlite3 via the four ``sql_bind_to_stmt`` overloads below. For reads,
-// ``read_via_adapter`` uses ``typedecl`` to resolve the storage primitive at
-// compile time, calls the matching ``sqlite3_column_*``, and feeds the
-// primitive into ``_::sql_extract`` to materialize the user type.
-//
-// ``sql_storage_type_for`` does the same compile-time resolution for the DDL
-// emitter — column type strings are picked from the four-primitive table.
-// ============================================================================
+// ===== Internal bridge: sql_bind/sql_extract ↔ libsqlite3 C API =====
 
 def sqlite3_column_blob_(stmt : sqlite3_stmt?; col : int) : array<uint8> {
     //! Reads a BLOB column as a fresh ``array<uint8>``. Allocates on
@@ -466,11 +411,6 @@ def sqlite3_column_blob_(stmt : sqlite3_stmt?; col : int) : array<uint8> {
 }
 
 // --- bind direction ---
-//
-// Dispatch table: four primitive overloads route directly to libsqlite3;
-// the Option<T> overload handles NULL semantics; the catch-all generic
-// routes any other type through the user's ``_::sql_bind`` adapter and
-// recurses on the resulting primitive (or the inner value of an Option).
 
 def sql_bind_to_stmt(var stmt : sqlite3_stmt?; idx : int; v : int64) : void {
     sqlite3_bind_int64(stmt, idx, v)
@@ -506,13 +446,6 @@ def sql_bind_to_stmt(var stmt : sqlite3_stmt?; idx : int; v : auto(TT)) : void {
 }
 
 // --- read direction ---
-//
-// Dispatch table: four primitive ``sql_read_witness`` overloads read the
-// matching ``sqlite3_column_*``; ``read_via_adapter`` resolves the storage
-// primitive at compile time via ``typedecl(_::sql_bind(default<T>))`` and
-// then dispatches to the matching witness overload, feeding the primitive
-// into ``_::sql_extract``. The ``Option<T>`` overload of
-// ``read_via_adapter`` handles NULL detection.
 
 [unused_argument(witness)]
 def sql_read_witness(stmt : sqlite3_stmt?; col : int; witness : int64) : int64 {
@@ -603,13 +536,6 @@ def sql_storage_type_for(t : type<$Option<auto(TT)>>) : string {
 }
 
 // --- column_info: same compile-time walk, abstract-typed view ---
-//
-// Mirror of the DDL string-witness machinery, returning the abstract
-// `SqlType` enum from `daslib/sql` instead of the SQLite spelling. The
-// per-table `_sql_column_info` helper synthesized by `[sql_table]` calls
-// `sql_storage_enum_for(type<F>)` per non-`@sql_json`/`@sql_blob` field;
-// `@sql_json` and `@sql_blob` fields short-circuit to `Text` and `Blob`
-// respectively (mirrors the DDL bypass at `make_create_table_sql_fn`).
 
 [unused_argument(witness)]
 def sql_storage_enum_witness(witness : int64) : SqlType {
@@ -667,21 +593,12 @@ def sqlite_sql_type(t : SqlType) : string {
     return "NULL"
 }
 
-// ============================================================================
-// query_scalar — read column 0 of the first row as ``TT``
-//
-// Routes through the tut-26 ``_::sql_bind`` / ``_::sql_extract`` adapter
-// rail via ``read_via_adapter``. Built-ins: every ``int*`` / ``uint*``,
-// ``float`` / ``double``, ``bool``, ``string``, ``array<uint8>``, every
-// enum, and any user type that ships an adapter pair.
-//
-// `try_*` returns ``Result<TT, string>`` (prepare/step error or zero rows).
-// `query_scalar` is the strict variant — panics on err.
-// ============================================================================
-
 [unused_argument(t)]
 def try_query_scalar(db : SqlRunner; sql : string; t : type<auto(TT)>) : Result<TT -const -#, string> {
-    //! Prepares ``sql``, steps once, returns column 0 as ``TT``.
+    //! Prepares ``sql``, steps once, returns column 0 as ``TT``. Routes
+    //! through the ``_::sql_bind`` / ``_::sql_extract`` adapter rail (tut 26)
+    //! via ``read_via_adapter``, so ``TT`` can be any primitive, enum, or
+    //! user type that ships an adapter pair.
     //! Returns ``Err(errmsg)`` on prepare/step error or zero rows.
     return <- try_one_row(db, sql, $(var stmt : sqlite3_stmt?) {}, $(stmt : sqlite3_stmt?) {
         static_if (typeinfo can_copy(default<TT -const -#>)) {
@@ -702,17 +619,12 @@ def query_scalar(db : SqlRunner; sql : string; t : type<auto(TT)>) : TT -const -
     return r |> unwrap
 }
 
-// ============================================================================
-// query_scalar_opt — Option<TT> variant for "0 rows is expected"
-//
-// Returns ``some(val)`` if a row is found, ``none`` if zero rows. Panics
-// only on prepare/step failure (genuine errors). Use when 0 rows is a
-// normal outcome (lookups by primary key, etc.); use ``query_scalar`` when
-// 0 rows is a programmer error.
-// ============================================================================
-
 [unused_argument(t)]
 def query_scalar_opt(db : SqlRunner; sql : string; t : type<auto(TT)>) : Option<TT -const -#> {
+    //! ``Option<TT>`` variant of ``query_scalar`` for when "0 rows" is a
+    //! normal outcome (e.g. lookup by primary key). Returns ``some(val)``
+    //! if a row is found, ``none`` if zero rows. Panics only on
+    //! prepare/step failure (genuine errors).
     var r <- try_one_row_opt(db, sql, $(var stmt : sqlite3_stmt?) {}, $(stmt : sqlite3_stmt?) {
         static_if (typeinfo can_copy(default<TT -const -#>)) {
             return read_via_adapter(stmt, 0, type<TT -const -#>)
@@ -726,52 +638,7 @@ def query_scalar_opt(db : SqlRunner; sql : string; t : type<auto(TT)>) : Option<
     return <- r._value
 }
 
-// ============================================================================
-// query_one — full-row read with positional bind args
-//
-// Each [sql_table] struct gets a generated ``_sql_read_row`` helper at macro
-// time; ``query_one`` family uses that to materialize the row. Bind args go
-// to positional placeholders in declaration order. Currently only 0..3
-// positional args are supported (one explicit overload per arity). 4+ args
-// and named-tuple bind (``query_one(sql, type<T>, (a=1, b=2, ...))`` for
-// ``:name`` placeholders) are deferred to chunk 4 — the named-tuple form
-// needs a ``[call_macro]`` to walk the trailing tuple's argNames.
-//
-// `try_*` returns ``Result<T, string>`` (bind/prepare/step errors AND zero
-// rows); strict panics on err; ``*_opt`` returns ``Option<T>`` (``none`` on
-// zero rows; panic only on bind/prepare/step error).
-// ============================================================================
-
-// All 12 public variants below delegate to one of three private impls
-// that take a `bind_blk : block<(var stmt : sqlite3_stmt?) : void>`,
-// invoked once after prepare. Each public wrapper supplies the right
-// bind block for its arity.
-
-// Shared prepare/bind/step/finalize bodies for the runtime layer. Four
-// helpers cover every shape the public API needs:
-//   - `try_one_row`     — single row, ``Err`` on zero rows; consumed by
-//                         `try_query_one_impl`, `try_run_select_one`, and
-//                         `try_query_scalar`.
-//   - `try_one_row_opt` — single row, ``Ok(none)`` on zero rows; consumed
-//                         by `query_scalar_opt` and `try_run_select_one_opt`.
-//   - `try_step_dml`    — single step, returns rows-affected; consumed by
-//                         every non-RETURNING DML (`try_run_dml`,
-//                         `try_insert`, `try_update`, `try_delete_`,
-//                         `try_delete_by_id`).
-//   - `try_collect_rows` — multi-row materializer; consumed by
-//                          `try_run_select`, `try_run_dml_returning`, and
-//                          `try_select_from`.
-// Each one parameterizes only on (a) the row/bind blocks and (b) the
-// user-visible error prefix. Adding new wrappers should reuse one of
-// these instead of inlining a fifth prepare/bind loop.
-//
-// All four executors share an identical 6-line prologue (prepare +
-// error-on-failure + bind) and a finalize-on-every-exit epilogue.
-// `try_with_stmt` owns that boilerplate; each executor only has to
-// describe its step-result strategy in `body_blk`.
-//
-// Error format is normalized to `{err_prefix}: <what>` across all
-// failure paths. No consumers parse these strings.
+// ===== query_one — full-row read with positional bind args =====
 
 def private try_with_stmt(db : SqlRunner; sql : string; err_prefix : string;
                           bind_blk : block<(var stmt : sqlite3_stmt?) : void>;
@@ -819,9 +686,6 @@ def private try_one_row_opt(db : SqlRunner; sql : string;
                             bind_blk : block<(var stmt : sqlite3_stmt?) : void>;
                             row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>;
                             err_prefix : string) : Result<Option<TT -const -#>, string> {
-    //! Like `try_one_row`, but returns `Ok(none)` on zero rows instead of
-    //! `Err`. Use when "no row matched" is a normal outcome and only
-    //! prepare/step failures are real errors.
     return <- try_with_stmt(db, sql, err_prefix, bind_blk,
         $(stmt : sqlite3_stmt?) : Result<Option<TT -const -#>, string> {
             let src = sqlite3_step(stmt)
@@ -1008,25 +872,7 @@ def query_one_opt(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(
     })
 }
 
-// ============================================================================
-// query / try_query — typed multi-row raw-SQL read.
-//
-// The fourth member of the `query_*` family. Unlike `select_from(type<T>)`
-// (which builds a `SELECT cols-of(T) FROM <table>` and runs it), `query` takes
-// the user's own SQL — useful for catalog reads (`PRAGMA table_info`,
-// `sqlite_master`), `SELECT … JOIN` shapes outside the `_sql` macro, and any
-// raw-SQL projection the LINQ chain can't (or shouldn't) translate.
-//
-// Row-shape constraint: T must be a `[sql_table]` struct so the macro-emitted
-// `_sql_read_row(stmt, type<T>) : T` is in scope. The struct does not have to
-// correspond to a real table — `[sql_table]` on a read-only row shape is the
-// idiomatic way to opt in to the typed materializer without committing to a
-// CREATE TABLE.
-//
-// Column order is positional: SELECT projection order must match the struct's
-// field declaration order. For name-driven mapping, drop to `try_run_select` /
-// `run_select` with an explicit row block.
-// ============================================================================
+// ===== query / try_query — typed multi-row raw-SQL read =====
 
 [unused_argument(t)]
 def private try_query_impl(db : SqlRunner; sql : string; t : type<auto(TT)>;
@@ -1114,15 +960,7 @@ def query(db : SqlRunner; sql : string; t : type<auto(TT)>; arg0 : auto(A0); arg
     })
 }
 
-// ============================================================================
-// User-facing CRUD over [sql_table] structs
-//
-// Each generic forwards to the per-struct helpers emitted by the macro.
-// Type witness is passed through to the helper as `t` (`type<Car>`-style call
-// site) or via a row instance (`row` argument also matches the helper's
-// `(typ : Car)` parameter — daslang accepts type-witness AND value-witness in
-// the same param slot).
-// ============================================================================
+// ===== User-facing CRUD over [sql_table] structs =====
 
 [template(t)]
 def try_create_table(db : SqlRunner; t : auto(TT)) : SqlError {
@@ -1231,10 +1069,7 @@ def try_insert(db : SqlRunner; rows : array<auto(TT)>) : Result<int64, string> {
             return err("insert: rows mix PK-set and PK-unset (row 0 vs row {i}); partition the array before calling insert", type<int64>)
         }
     }
-    // Choose BEGIN/COMMIT vs SAVEPOINT/RELEASE based on ambient state so
-    // bulk-insert composes inside an outer ``with_transaction`` block.
-    // Without this branch SQLite rejects ``BEGIN IMMEDIATE`` with "cannot
-    // start a transaction within a transaction" when nested.
+    // BEGIN/COMMIT vs SAVEPOINT/RELEASE depending on ambient state, so this composes inside with_transaction.
     let was_in_txn = db |> in_transaction()
     let begin_sql = was_in_txn ? "SAVEPOINT das_ins_sp" : "BEGIN IMMEDIATE"
     let begin_err = db |> try_exec(begin_sql)
@@ -1276,9 +1111,7 @@ def try_insert(db : SqlRunner; rows : array<auto(TT)>) : Result<int64, string> {
     let commit_sql = was_in_txn ? "RELEASE das_ins_sp" : "COMMIT"
     let commit_err = db |> try_exec(commit_sql)
     if (commit_err |> is_some) {
-        // COMMIT/RELEASE can fail (SQLITE_BUSY, IO error). Roll back so the
-        // connection isn't left mid-transaction. Bulk-insert uses its own
-        // savepoint name (das_ins_sp) so the rollback path is local.
+        // COMMIT/RELEASE can fail (SQLITE_BUSY/IO); roll back so the connection isn't left mid-transaction.
         if (was_in_txn) {
             db |> try_exec("ROLLBACK TO das_ins_sp") |> ignore_sql_error
             db |> try_exec("RELEASE das_ins_sp") |> ignore_sql_error
@@ -1301,30 +1134,11 @@ def insert(db : SqlRunner; rows : array<auto(TT)>) : int64 {
 
 [unused_argument(e)]
 def private ignore_sql_error(e : SqlError) : void {
-    //! Discards a SqlError. Used by try_insert(array) to swallow ROLLBACK failures while preserving the original error.
 }
 
-// ============================================================================
-// INSERT OR IGNORE / INSERT OR REPLACE
-//
-// Variants of ``insert`` that change SQLite's conflict resolution. Both reuse
-// the per-struct ``_sql_insert_with_pk_sql`` / ``_sql_insert_no_pk_sql`` SQL
-// emitters and ``_sql_bind_row`` bind code; the only difference is a textual
-// ``OR IGNORE`` / ``OR REPLACE`` modifier inserted after ``INSERT`` and a
-// rows-affected return (via ``sqlite3_changes``) rather than ``last_insert_rowid``.
-//
-// ``OR IGNORE``: silent no-op on PK / UNIQUE violation. Returns 0 for the
-//   conflicting row, 1 for the inserted row.
-// ``OR REPLACE``: deletes the conflicting row, then inserts the new one. Be
-//   careful — any column not in the new row gets its DEFAULT (rarely what you
-//   want for partial updates; tut 21's UPSERT ON CONFLICT DO UPDATE is the
-//   proper merge form).
-// ============================================================================
+// ===== INSERT OR IGNORE / INSERT OR REPLACE =====
 
 def private with_or_clause(plain_sql : string; or_clause : string) : string {
-    //! Insert `OR IGNORE` / `OR REPLACE` between `INSERT` and `INTO` /
-    //! `DEFAULT VALUES`. The plain SQL always begins with ``INSERT `` so the
-    //! substitution target is unambiguous.
     if (empty(or_clause)) {
         return plain_sql
     }
@@ -1332,8 +1146,6 @@ def private with_or_clause(plain_sql : string; or_clause : string) : string {
 }
 
 def private try_insert_or(db : SqlRunner; row : auto(TT); or_clause : string) : Result<int, string> {
-    //! Shared body for `try_insert_or_ignore` / `try_insert_or_replace` (single row).
-    //! Returns ``Ok(rows_affected)`` — 0 if the row was IGNORE-d, 1 otherwise.
     let pk_unset = _::_sql_pk_is_unset(row)
     let plain_sql = pk_unset ? _::_sql_insert_no_pk_sql(row) : _::_sql_insert_with_pk_sql(row)
     let sql = with_or_clause(plain_sql, or_clause)
@@ -1347,10 +1159,6 @@ def private try_insert_or(db : SqlRunner; row : auto(TT); or_clause : string) : 
 }
 
 def private try_insert_or(db : SqlRunner; rows : array<auto(TT)>; or_clause : string) : Result<int, string> {
-    //! Shared body for `try_insert_or_ignore` / `try_insert_or_replace` (bulk).
-    //! Wraps the per-row prepared-statement loop in a transaction (BEGIN/COMMIT
-    //! at the outer level, SAVEPOINT/RELEASE when nested). Returns the SUM of
-    //! per-statement ``sqlite3_changes`` over the batch.
     if (empty(rows)) {
         return ok(0, type<string>)
     }
@@ -1475,19 +1283,7 @@ def insert_or_replace(db : SqlRunner; rows : array<auto(TT)>) : int {
     return r |> unwrap
 }
 
-// ============================================================================
-// by-PK UPDATE / DELETE
-//
-// Single-row mutators driven by [sql_table]'s generated `_sql_update_by_pk_sql`,
-// `_sql_delete_by_pk_sql`, and `_sql_bind_row_for_update` helpers. The struct
-// must declare exactly one @sql_primary_key field; otherwise the generated
-// helper panics with a clear message at call time (see make_update_by_pk_sql_fn
-// at the bottom of this file).
-//
-// All four functions return ``int`` (rows-affected — 1 or 0). 0 is NOT an
-// error: the row simply wasn't there. Reserve ``Err`` for genuine SQL
-// failures (constraint violation, IO, BUSY).
-// ============================================================================
+// ===== by-PK UPDATE / DELETE =====
 
 def try_update(db : SqlRunner; row : auto(TT)) : Result<int, string> {
     //! Updates a single row identified by its @sql_primary_key field. Returns
@@ -1513,10 +1309,6 @@ def try_delete_(db : SqlRunner; row : auto(TT)) : Result<int, string> {
     //! ``Err(errmsg)`` on SQL failure.
     //! Trailing underscore in the name is intentional: ``delete`` is a daslang
     //! keyword, mirroring the convention used by ``daslib/linq``'s ``where_``.
-    // The PK is bound at index 1 (the only placeholder in `DELETE FROM T WHERE pk=?`).
-    // We can't reuse `_sql_bind_row_for_update` here because it binds non-PK
-    // columns first; instead, look up the PK field directly via the generated
-    // _sql_pk_value helper that matches each [sql_table] struct.
     return <- db |> try_step_dml(_::_sql_delete_by_pk_sql(row), $(var stmt : sqlite3_stmt?) {
         _::_sql_bind_row_pk_only(stmt, row)
     }, "delete")
@@ -1551,21 +1343,7 @@ def delete_by_id(db : SqlRunner; t : type<auto(TT)>; id : auto(K)) : int {
     return r |> unwrap
 }
 
-// ============================================================================
-// Transactions
-//
-// `with_transaction` blocks emit BEGIN/COMMIT/ROLLBACK or
-// SAVEPOINT/RELEASE/ROLLBACK TO depending on whether the connection is
-// already inside a transaction (detected via sqlite3_get_autocommit). All
-// nested calls use the same SAVEPOINT name `das_sp` — SQLite resolves
-// RELEASE/ROLLBACK TO against the most-recent matching savepoint, so proper
-// LIFO nesting composes correctly without the runner tracking depth itself.
-//
-// Two overloads, not one optional-parameter function: piping puts the block
-// last, so an optional middle `mode` parameter wouldn't resolve from a
-// no-mode call site. See API_REWORK.md § "12 + 13 + 14" for the full
-// rationale.
-// ============================================================================
+// ===== Transactions =====
 
 enum SqliteTxnMode {
     //! BEGIN modifiers for SQLite. Maps to ``BEGIN [DEFERRED|IMMEDIATE|EXCLUSIVE]``.
@@ -1598,8 +1376,7 @@ def private txn_commit_sql(was_in_txn : bool) : string {
 }
 
 def private txn_best_effort_rollback(db : SqlRunner; was_in_txn : bool) : void {
-    // Best-effort: swallow rollback errors so the original failure (panic
-    // message or BEGIN/blk SQL error) reaches the caller intact.
+    // Swallow rollback errors so the original failure reaches the caller intact.
     if (was_in_txn) {
         db |> try_exec("ROLLBACK TO das_sp") |> ignore_sql_error
         db |> try_exec("RELEASE das_sp") |> ignore_sql_error
@@ -1627,9 +1404,7 @@ def with_transaction(db : SqlRunner; mode : SqliteTxnMode; blk : block<() : void
         success = true
     } finally {
         if (success) {
-            // COMMIT/RELEASE can fail (SQLITE_BUSY, IO error). If it does, roll
-            // back so the connection isn't left mid-transaction, then panic
-            // with the commit message.
+            // COMMIT/RELEASE can fail (SQLITE_BUSY/IO); roll back, then panic with the commit message.
             let commit_err = db |> try_exec(txn_commit_sql(was_in_txn))
             if (commit_err |> is_some) {
                 txn_best_effort_rollback(db, was_in_txn)
@@ -1669,8 +1444,7 @@ def try_transaction(db : SqlRunner; mode : SqliteTxnMode; blk : block<() : void>
             txn_best_effort_rollback(db, was_in_txn)
         }
     }
-    // COMMIT/RELEASE can fail (SQLITE_BUSY, IO error). If it does, roll back
-    // so the connection isn't left mid-transaction before returning the error.
+    // COMMIT/RELEASE can still fail (SQLITE_BUSY/IO); roll back so the connection isn't left mid-transaction.
     let commit_err = db |> try_exec(txn_commit_sql(was_in_txn))
     if (commit_err |> is_some) {
         txn_best_effort_rollback(db, was_in_txn)
@@ -1678,36 +1452,46 @@ def try_transaction(db : SqlRunner; mode : SqliteTxnMode; blk : block<() : void>
     return commit_err
 }
 
-// ============================================================================
-// PRAGMA helpers — `set_pragma` / `try_set_pragma` / `apply_recommended_pragmas`.
-//
-// PRAGMA values are parsed at prepare time (no `?` placeholder), so values are
-// formatted into the SQL inline. Pragma names + values are admin-controlled
-// (not user input) — they are not escaped or validated; a bad name surfaces as
-// SQLite's own prepare-time error. Three typed `value` overloads cover the common
-// shapes: string ('WAL' / 'NORMAL'), int64 (busy_timeout, cache_size), bool
-// (foreign_keys, recursive_triggers).
-// ============================================================================
+// ===== SQL quoting helpers =====
+
+def sql_quote_id(s : string) : string {
+    //! Wraps ``s`` in double quotes; SQLite-portable form for a quoted
+    //! identifier (table / column / view name). Embedded double quotes
+    //! are doubled. Used by ``fold_to_builder`` for ``inline_id`` fragments
+    //! and by ``_sql_pragma`` / ``_sql_vacuum_into`` for runtime-built SQL.
+    let escaped = s |> replace("\"", "\"\"")
+    return "\"{escaped}\""
+}
+
+def sql_quote_lit(s : string) : string {
+    //! Wraps ``s`` in single quotes (SQL string literal). Embedded single
+    //! quotes are doubled. Used by ``fold_to_builder`` for ``inline_lit``
+    //! fragments where the value must be inlined into the SQL text
+    //! (CREATE VIEW, PRAGMA, VACUUM INTO — none accept ``?`` placeholders).
+    let escaped = s |> replace("'", "''")
+    return "'{escaped}'"
+}
+
+// ===== PRAGMA helpers =====
 
 def try_set_pragma(db : SqlRunner; name : string; value : string) : SqlError {
     //! Sets ``PRAGMA "<name>" = '<value>'``. Returns ``none`` on success,
     //! ``some(errmsg)`` on failure. The value is single-quoted; embedded
     //! single quotes in ``value`` are doubled to keep SQLite happy.
-    let escaped = value |> replace("'", "''")
-    return db |> try_exec("PRAGMA \"{name}\" = '{escaped}'")
+    return db |> try_exec("PRAGMA {sql_quote_id(name)} = {sql_quote_lit(value)}")
 }
 
 def try_set_pragma(db : SqlRunner; name : string; value : int64) : SqlError {
     //! Sets ``PRAGMA "<name>" = <int>``. Used for numeric pragmas like
     //! ``busy_timeout`` (ms), ``cache_size`` (pages or KB), ``page_size``.
-    return db |> try_exec("PRAGMA \"{name}\" = {value}")
+    return db |> try_exec("PRAGMA {sql_quote_id(name)} = {value}")
 }
 
 def try_set_pragma(db : SqlRunner; name : string; value : bool) : SqlError {
     //! Sets ``PRAGMA "<name>" = ON|OFF``. Used for boolean pragmas like
     //! ``foreign_keys``, ``recursive_triggers``, ``trusted_schema``.
     let onoff = value ? "ON" : "OFF"
-    return db |> try_exec("PRAGMA \"{name}\" = {onoff}")
+    return db |> try_exec("PRAGMA {sql_quote_id(name)} = {onoff}")
 }
 
 def set_pragma(db : SqlRunner; name : string; value : string) : void {
@@ -1777,32 +1561,7 @@ def apply_recommended_pragmas(db : SqlRunner) : void {
     }
 }
 
-// ============================================================================
-// VACUUM / OPTIMIZE / integrity check / quick check.
-//
-// VACUUM rewrites the database file from scratch — pages defragmented, free
-// pages reclaimed, on-disk order optimized. It is most useful after large
-// DELETE/TRUNCATE workloads. Cannot run inside an active transaction; the
-// helpers reject that case at runtime.
-//
-// `optimize` analyzes the schema and updates the query planner's stats.
-// Recommended at connection close on long-lived connections.
-//
-// `integrity_check` / `quick_check` walk the database checking for
-// corruption. ``"ok"`` is returned as a single-row result on a healthy
-// database; on corruption, multiple rows describe the issues. The helpers
-// surface the rows verbatim — caller decides what to do.
-//
-// (`backup_to` lives in a separate `dasSQLITE.backup.cpp` C++ wrapper; not
-// included in the daslang-only subset shipped here.)
-// ============================================================================
-
-def private escape_sqlite_quoted(s : string) : string {
-    //! Doubles embedded single quotes for SQLite's quoted-string syntax.
-    //! Used by helpers that must inline a path/value into SQL where `?`
-    //! placeholders are not allowed (e.g. VACUUM INTO).
-    return s |> replace("'", "''")
-}
+// ===== VACUUM / OPTIMIZE / integrity check / quick check =====
 
 def try_vacuum(db : SqlRunner) : SqlError {
     //! VACUUM rewrites the database file. Cannot run inside an active
@@ -1831,8 +1590,7 @@ def try_vacuum_into(db : SqlRunner; path : string) : SqlError {
     if (db |> in_transaction()) {
         return some("VACUUM INTO cannot run inside an active transaction; commit or rollback first")
     }
-    let escaped = escape_sqlite_quoted(path)
-    return db |> try_exec("VACUUM INTO '{escaped}'")
+    return db |> try_exec("VACUUM INTO {sql_quote_lit(path)}")
 }
 
 def vacuum_into(db : SqlRunner; path : string) : void {
@@ -1859,10 +1617,6 @@ def optimize(db : SqlRunner) : void {
 }
 
 def private try_check_impl(db : SqlRunner; sql : string) : Result<array<string>, string> {
-    //! Shared body for ``try_integrity_check`` / ``try_quick_check``.
-    //! PRAGMA integrity_check / quick_check return scalar string rows, so
-    //! we route through ``try_run_select`` with an explicit per-row reader
-    //! rather than ``try_query`` (which expects a struct + ``_sql_read_row``).
     return <- db |> try_run_select(sql,
         $(var stmt : sqlite3_stmt?) {},
         $(stmt : sqlite3_stmt?) {
@@ -1905,29 +1659,14 @@ def quick_check(db : SqlRunner) : array<string> {
     return <- r._value
 }
 
-// ============================================================================
-// backup_to — copy the live database into another (open) connection or
-// directly to a file on disk.
-//
-// SQLite's online backup API copies pages incrementally and tolerates
-// concurrent writes on the source — the destination receives the full
-// state at the time the backup completes. Useful for snapshotting
-// :memory: databases, hot backups of long-running on-disk databases, or
-// cloning into a fresh file before applying destructive migrations.
-//
-// Two overloads:
-//   - ``backup_to(dest : SqlRunner)`` — caller owns ``dest``.
-//   - ``backup_to(path : string)`` — opens ``path`` here, performs the
-//     copy, and closes ``path`` on return. Useful for the common
-//     "snapshot to disk" case.
-// ============================================================================
-
 def try_backup_to(db : SqlRunner; dest : SqlRunner) : SqlError {
     //! Copies all of ``db`` into the open connection ``dest`` using
-    //! SQLite's online backup API. Tolerates concurrent writers on
-    //! ``db`` (transient SQLITE_BUSY/LOCKED responses are retried with
-    //! a 50 ms backoff). Returns ``some(errmsg)`` if the backup did not
-    //! complete; ``none`` on success.
+    //! SQLite's online backup API. Pages are copied incrementally and
+    //! concurrent writers on ``db`` are tolerated (transient
+    //! SQLITE_BUSY/LOCKED responses are retried with a 50 ms backoff).
+    //! Useful for snapshotting :memory: databases, hot backups, or
+    //! cloning before destructive migrations. Returns ``some(errmsg)``
+    //! if the backup did not complete; ``none`` on success.
     //!
     //! The C++ shim returns ``SQLITE_OK`` on a fully-completed backup
     //! (the result of ``sqlite3_backup_finish`` after a clean
@@ -1972,13 +1711,7 @@ def backup_to(db : SqlRunner; path : string) : void {
     }
 }
 
-// ============================================================================
-// Generic DML runners — used by the `_sql_update` / `_sql_delete` macros.
-//
-// These take a SQL string + bind block (the macro fills in the
-// `sql_bind_to_stmt(stmt, idx, expr)` calls) and execute it. Return rows-affected
-// for non-RETURNING; array<T> for RETURNING.
-// ============================================================================
+// ===== Generic DML runners (used by `_sql_update` / `_sql_delete` macros) =====
 
 def try_run_dml(db : SqlRunner; sql : string;
                 bind_blk : block<(var stmt : sqlite3_stmt?) : void>) : Result<int, string> {
@@ -2049,40 +1782,27 @@ def select_from(db : SqlRunner; t : type<auto(TT)>) : array<TT -const -#> {
     return <- r._value
 }
 
-// ============================================================================
-// _each_sql macro runtime: run_each_select
-//
-// Lazy-iterating sibling of `run_select` — instead of materializing every
-// row into an array, it returns a `generator<TT>` that yields one row at
-// a time. Useful for streaming over large result sets where the array
-// materialization would dominate memory or latency.
-//
-// Lifetime: the prepared statement is owned by the generator. SQLite's
-// `sqlite3_finalize` runs in the generator's `finally` block, so the
-// statement is released on:
-//   - normal exhaustion (loop runs to completion)
-//   - early `break` from the for-loop
-//   - panic from inside the loop body
-// In every case, no statement leaks; subsequent writes to the same DB are
-// not blocked by a stale read transaction.
-//
-// **One-shot semantics**: a generator can only be iterated once. To re-run
-// the same query, re-evaluate the `_each_sql(...)` call site (each call
-// builds a fresh statement).
-// ============================================================================
-
 [unsafe_outside_of_for, nodiscard]
 def run_each_select(db : SqlRunner; sql : string;
                     bind_blk : block<(var stmt : sqlite3_stmt?) : void>;
                     var row_lam : lambda<(stmt : sqlite3_stmt?) : auto(TT)>) {
-    //! Prepares ``sql``, runs ``bind_blk`` once, then returns a generator
-    //! that lazily ``sqlite3_step``s the cursor. Each yielded value is
-    //! produced by ``row_lam(stmt)``.
+    //! `_each_sql` macro runtime: lazy-iterating sibling of ``run_select``.
+    //! Prepares ``sql``, runs ``bind_blk`` once, then returns a
+    //! ``generator<TT>`` that lazily ``sqlite3_step``s the cursor; each
+    //! yielded value is produced by ``row_lam(stmt)``. Useful for
+    //! streaming over large result sets where the array materialization
+    //! would dominate memory or latency.
     //!
     //! ``row_lam`` is a lambda (not a block) because it must be captured
     //! into the generator body and outlive the surrounding stack frame.
     //! ``bind_blk`` runs once before the generator is constructed and can
     //! stay a block.
+    //!
+    //! Lifetime: the prepared statement is owned by the generator;
+    //! ``sqlite3_finalize`` runs in the generator's ``finally`` block —
+    //! statement is released on normal exhaustion, early break, or panic.
+    //! One-shot semantics: a generator can only be iterated once; re-run
+    //! the same query by re-evaluating the ``_each_sql(...)`` call site.
     //!
     //! Panics on prepare failure (with the libsqlite3 errmsg). Step
     //! failures inside the loop also panic; the generator's ``finally``
@@ -2097,17 +1817,8 @@ def run_each_select(db : SqlRunner; sql : string;
         panic(msg)
     }
     invoke(bind_blk, stmt)
-    // Explicit-capture form (matches `daslib/functional`'s filter / map
-    // generators): captures `row_lam` (lambda — move) and `stmt` (raw
-    // pointer — value). The connection pointer is read off the stmt via
-    // `sqlite3_db_handle` for the errmsg path; no extra capture needed.
-    // The generator's `finally` finalizes the statement on exhaustion /
-    // early break / panic.
     return <- generator<TT -const -#> capture(<- row_lam, <- stmt) {
-        // Loop shape: daslang restricts `yield` to be the LAST statement
-        // inside a `for` body (or its terminal `if` arm). We sqlite3_step
-        // first, branch on the result code, and yield the materialized row
-        // as the for-body's tail. SQLITE_DONE / step errors break the loop.
+        // `yield` must be the LAST statement of the for-body; step first, then yield the row.
         for (_ in range(0x7FFFFFFF)) {
             let rc = sqlite3_step(stmt)
             if (rc != SQLITE_ROW) {
@@ -2124,20 +1835,11 @@ def run_each_select(db : SqlRunner; sql : string;
     }
 }
 
-// ============================================================================
-// _sql macro runtime: try_run_select / run_select
-//
-// The `_sql` macro emits a call to one of these. `bind_blk` runs once after
-// prepare to push bound values; `row_blk` is invoked per row to materialize
-// the typed result. Generic on the row type (`auto(TT)`) so the call site
-// determines whether the array is `array<Car>`, `array<string>`, or any
-// other projected shape.
-// ============================================================================
-
 def try_run_select(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite3_stmt?) : void>; row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : Result<array<TT -const -#>, string> {
-    //! Prepares ``sql``, runs ``bind_blk`` once, then steps the cursor and
-    //! materializes each row via ``row_blk``. Returns ``Err(errmsg)`` on
-    //! prepare or step failure.
+    //! `_sql` macro runtime. Prepares ``sql``, runs ``bind_blk`` once,
+    //! then steps the cursor and materializes each row via ``row_blk``.
+    //! Generic on row type so the call site determines the array element
+    //! shape. Returns ``Err(errmsg)`` on prepare or step failure.
     return <- db |> try_collect_rows(sql, bind_blk, row_blk, "_sql")
 }
 
@@ -2150,18 +1852,13 @@ def run_select(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite
     return <- r._value
 }
 
-// ============================================================================
-// _sql macro runtime: single-row materializers (One / OneOpt)
-//
-// Used by `_sql(...)` chains that end in `_first()`, `_first_opt()`, or
-// `_count()` (and chunk-4 aggregates). One panics-on-empty (for `_first`,
-// `_count`, future `_sum`-on-empty); OneOpt returns Option<T>.
-// ============================================================================
-
 def try_run_select_one(db : SqlRunner; sql : string; bind_blk : block<(var stmt : sqlite3_stmt?) : void>; row_blk : block<(stmt : sqlite3_stmt?) : auto(TT)>) : Result<TT -const -#, string> {
-    //! Prepares ``sql``, runs ``bind_blk`` once, steps once, materializes
-    //! the first row via ``row_blk``. Returns ``Err(errmsg)`` on prepare or
-    //! step failure or zero rows.
+    //! `_sql` macro runtime: single-row materializer used by `_sql(...)`
+    //! chains ending in `_first()`, `_count()`, or aggregates. Prepares
+    //! ``sql``, runs ``bind_blk`` once, steps once, materializes the first
+    //! row via ``row_blk``. Returns ``Err(errmsg)`` on prepare or step
+    //! failure or zero rows. (Sibling ``run_select_one_opt`` returns
+    //! ``Ok(none)`` for "0 rows is expected" call sites.)
     return <- try_one_row(db, sql, bind_blk, row_blk, "_sql")
 }
 
@@ -2191,36 +1888,9 @@ def run_select_one_opt(db : SqlRunner; sql : string; bind_blk : block<(var stmt 
     return <- r._value
 }
 
-// ============================================================================
-// [sql_table] structure macro
-//
-// Reads struct-level args (`name="..."` overrides the on-disk table name)
-// and per-field annotations (`@sql_primary_key` for now). Generates, attached
-// to the user's struct type, a fixed family of helper functions consumed by
-// `create_table` / `drop_table_if_exists` / `insert` below.
-//
-// All generated function bodies emit `sql_storage_type_for(type<T>)` and
-// `sql_bind_to_stmt(stmt, idx, row.field)` calls — so primitive and user-
-// defined field types travel the same code path. ``sql_bind_to_stmt``'s
-// catch-all routes the value through the user's ``_::sql_bind`` adapter
-// (resolved at the caller's-module overload set). Type resolution defers
-// to each generated function's own typecheck pass; the macro itself does
-// not depend on field types being fully resolved at apply() time.
-//
-// TODO: 5 of the 7 emitted helpers (_sql_table_name, _sql_drop_table_if_exists_sql,
-// _sql_create_table_sql, _sql_insert_with_pk_sql, _sql_insert_no_pk_sql) take
-// `typ : T` and never read it — and so does the no-PK fallback variant of
-// _sql_pk_is_unset. Currently silenced by the module-level
-// `options no_unused_function_arguments = false`. Switch to per-fn
-// `[unused_argument(typ)]` annotations attached at macro-expansion time so
-// stricter callers/linters get clean per-function info. Settle after
-// chunk-1 review.
-// ============================================================================
+// ===== [sql_table] structure macro =====
 
 def private find_annotation(args : AnnotationArgumentList; argn : string; default_value : auto(TT)) : TT {
-    //! Generic annotation reader. ``TT`` must be ``bool`` or ``string``;
-    //! daslang's ``static_if (typeinfo is_string …)`` picks the matching
-    //! ``tString`` / ``tBool`` accessor on the AnnotationArgument variant.
     let v = find_arg(args, argn)
     static_if (typeinfo is_string(default_value)) {
         if (v is tString) {
@@ -2235,22 +1905,15 @@ def private find_annotation(args : AnnotationArgumentList; argn : string; defaul
 }
 
 def private find_string_array_annotation(args : AnnotationArgumentList; argn : string) : array<string> {
-    //! Reads a parens-list field annotation `@argn=("A","B",...)` or the bare single
-    //! `@argn="A"` form. The parser flattens parens-lists into multiple flat entries
-    //! all sharing the parent name, so a single by-name walk handles both shapes.
     return <- [for (a in args); string(a.sValue); where a.name == argn && a.basicType == Type.tString]
 }
 
-// Whitelisted SQL-side default functions (`@sql_default_fn=...`). These are
-// deliberately enumerated rather than passed-through verbatim — typo-detection
-// at macro-expansion time gives a clearer error than a runtime SQLite parse error.
+// Whitelisted to surface typos at macro-expansion instead of as a runtime SQLite parse error.
 let private SQL_DEFAULT_FN_WHITELIST = ["CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME"]
 
 let private SQL_FK_ACTION_WHITELIST = ["cascade", "set_null", "set_default", "restrict", "no_action"]
 
 def private fk_action_to_sql(action : string) : string {
-    //! Map `@sql_on_delete` / `@sql_on_update` value to its DDL form.
-    //! Caller has already validated against `SQL_FK_ACTION_WHITELIST`.
     if (action == "cascade") {
         return "CASCADE"
     } elif (action == "set_null") {
@@ -2264,18 +1927,11 @@ def private fk_action_to_sql(action : string) : string {
 }
 
 def private sql_quote_string_literal(s : string) : string {
-    //! Wrap `s` in single quotes, doubling any embedded single quote. Used for
-    //! string-typed `field : string = "default"` initializers in the DDL emitter.
     let escaped = replace(s, "'", "''")
     return "'{escaped}'"
 }
 
 def private literal_init_to_default_clause(init : ExpressionPtr) : string {
-    //! Translate a daslang field initializer expression to `" DEFAULT <literal>"`.
-    //! Returns `""` when the expression is null or not a recognized literal — non-
-    //! literal initializers (e.g. `some(5)` for `Option<int>`) are silently
-    //! ignored so the daslang in-memory default still compiles, just without an
-    //! SQL-side counterpart.
     if (init == null) {
         return ""
     }
@@ -2308,22 +1964,15 @@ struct private FieldInfo {
     is_optional : bool
     is_unique : bool
     is_computed : bool
-    is_stored : bool                //!< false → VIRTUAL (SQLite default), true → STORED
-    is_json : bool                  //!< @sql_json — TEXT-backed via daslib/json round-trip; `_sql` walker descends as JSON path
-    is_blob : bool                  //!< @sql_blob — BLOB-backed via daslib/archive; opaque to `_sql`
-    computed_sql : string           //!< body of `GENERATED ALWAYS AS (...)`; non-empty iff is_computed
-    default_clause : string         //!< pre-built ` DEFAULT <expr>` or `""` when no default applies
-    references_clause : string      //!< pre-built ` REFERENCES "T"("Pk") ON DELETE X ON UPDATE Y` or `""`
+    is_stored : bool
+    is_json : bool
+    is_blob : bool
+    computed_sql : string
+    default_clause : string
+    references_clause : string
 }
 
 def private is_option_field_type(td : TypeDeclPtr) : bool {
-    //! Recognize ``Option<T>`` for the [sql_table] DDL emitter (drop NOT NULL,
-    //! reject @sql_primary_key on the field). Structure macros run before the
-    //! ``[template_structure]`` typemacro has been resolved, so a field
-    //! declared as ``Option<int>`` arrives as ``Type.typeMacro`` with the
-    //! macro name in ``dimExpr[0]``. We also accept the post-resolution form
-    //! (``Type.tStructure`` with structType.name == "Option", module ==
-    //! "option") so the helper works even if a later pass reaches it.
     if (td == null) {
         return false
     }
@@ -2338,11 +1987,6 @@ def private is_option_field_type(td : TypeDeclPtr) : bool {
 }
 
 def private build_create_indexes_sql(st : StructurePtr; table_name : string; field_names : array<string>; var errors : das_string; var ok : bool&) : string {
-    //! Walk every `[sql_index(...)]` on ``st`` and concatenate the CREATE INDEX
-    //! statements. Each `fields=` entry is cross-checked against ``field_names``.
-    //! On validation failure, sets ``ok = false``, populates ``errors``, and
-    //! returns ``""``. Returns ``""`` when no indexes are present (also with
-    //! ``ok = true``) so the caller can skip a sqlite3_exec call.
     ok = true
     var stmt_count = 0
     let sql = build_string() $(var w) {
@@ -2401,9 +2045,6 @@ def private build_create_indexes_sql(st : StructurePtr; table_name : string; fie
 }
 
 def private extract_string_return(var fn : FunctionPtr) : string {
-    //! Read back a `return "literal"` body emitted by `qmacro_function ... {
-    //! return $v(sql) }`. Returns the string value or `""` when the body
-    //! doesn't match the expected single-return-of-string-literal shape.
     if (fn == null || fn.body == null || !(fn.body is ExprBlock)) {
         return ""
     }
@@ -2424,10 +2065,6 @@ def private extract_string_return(var fn : FunctionPtr) : string {
 }
 
 def private find_struct_helper_fn(name : string; st : StructurePtr) : FunctionPtr {
-    //! Locate a `[sql_table]`-generated helper function by name whose first
-    //! parameter type resolves to ``st``. Returns ``null`` when no overload
-    //! matches the struct (e.g. ``[sql_index]`` was placed before its
-    //! ``[sql_table]`` and the helper isn't generated yet).
     var found : FunctionPtr
     for_each_function(compiling_module(), name) $(var fn) {
         if (length(fn.arguments) > 0
@@ -2458,11 +2095,7 @@ class SqlIndexMacro : AstStructureAnnotation {
         let is_unique = find_annotation(args, "unique", false)
         let idx_name_arg = find_annotation(args, "name", "")
 
-        // Cross-check every named column against the struct's fields, and
-        // build the daslang→SQL column-name mapping in the same pass. The
-        // user writes `fields="col_type"` (the DASLANG field name); the
-        // emitted DDL uses the @sql_column-renamed SQL identifier. Annotations
-        // stay in daslang-space; renames are transparent at emission time.
+        // User writes daslang field names; emit @sql_column-renamed SQL identifiers in DDL.
         var sql_cols : array<string>
         sql_cols |> reserve(length(cols))
         for (col in cols) {
@@ -2484,9 +2117,7 @@ class SqlIndexMacro : AstStructureAnnotation {
             sql_cols |> push(resolved)
         }
 
-        // Locate the per-struct `_sql_create_indexes_sql` placeholder emitted
-        // by [sql_table]. Source-order rule: [sql_table] must precede
-        // [sql_index] in the annotation list.
+        // [sql_table] must precede [sql_index] in the annotation list (source-order rule).
         var idx_fn = find_struct_helper_fn("_sql_create_indexes_sql", st)
         if (idx_fn == null) {
             errors := "[sql_index] on struct '{st.name}': no [sql_table] declared earlier in the annotation list. Use `[sql_table(...), sql_index(...), ...]` order so the index helper is in scope."
@@ -2503,9 +2134,7 @@ class SqlIndexMacro : AstStructureAnnotation {
             return false
         }
 
-        // Build the CREATE INDEX statement for THIS annotation. Auto-name uses
-        // SQL column names so two structs with the same daslang field name
-        // mapped to different SQL columns get distinct index names.
+        // Auto-name uses SQL (post-rename) column names so distinct schemas don't collide.
         let auto_name = build_string() $(var w) {
             w |> write("idx_")
             w |> write(table_name)
@@ -2529,9 +2158,7 @@ class SqlIndexMacro : AstStructureAnnotation {
             w |> write(")")
         }
 
-        // Read the current accumulated SQL (empty after [sql_table], or the
-        // result of earlier [sql_index] applies on the same struct), append
-        // this statement, and replace fn.body.
+        // Append this statement to whatever earlier [sql_index] siblings already accumulated.
         let prev_sql = extract_string_return(idx_fn)
         let new_sql = empty(prev_sql) ? this_stmt : "{prev_sql}; {this_stmt}"
         idx_fn.body = qmacro_block() {
@@ -2543,11 +2170,6 @@ class SqlIndexMacro : AstStructureAnnotation {
 }
 
 def private find_parent_table_and_pk(var st : StructurePtr; parent_name : string) : tuple<tab_name : string; pk_col : string; found : bool> {
-    //! Resolve `@sql_references="ParentName"` to the parent struct's
-    //! `[sql_table(name=...)]` table name and `@sql_primary_key` column. Walks
-    //! `compiling_module()`; self-reference (`parent_name == st.name`) short-
-    //! circuits to the current struct since `[sql_table]` is being applied to
-    //! it right now.
     var found_st : StructurePtr
     if (st.name == parent_name) {
         found_st = st
@@ -2569,9 +2191,7 @@ def private find_parent_table_and_pk(var st : StructurePtr; parent_name : string
     }
     for (pf in found_st.fields) {
         if (find_annotation(pf.annotation, "sql_primary_key", false)) {
-            // The PK column may have been renamed via @sql_column on the
-            // parent struct's PK field — read that here so the FK references
-            // the SQL identifier, not the daslang field name.
+            // FK references the SQL identifier (post @sql_column rename), not the daslang field name.
             var pk_col = string(pf.name)
             let pk_anno = find_arg(pf.annotation, "sql_column")
             if (pk_anno is tString) {
@@ -2601,10 +2221,7 @@ class SqlTableMacro : AstStructureAnnotation {
             let is_computed = !empty(computed_sql)
             let is_stored = find_annotation(field.annotation, "sql_stored", false)
 
-            // @sql_json / @sql_blob — opt in to non-scalar column storage. `[sql_table]`
-            // generates a `sql_bind` / `sql_extract` adapter pair for the field's
-            // declared type; `_sql` walker descends into @sql_json columns as JSON
-            // paths and rejects descent into @sql_blob columns.
+            // @sql_json / @sql_blob — non-scalar column storage with an emitted sql_bind/sql_extract pair.
             let is_json = find_annotation(field.annotation, "sql_json", false)
             let is_blob = find_annotation(field.annotation, "sql_blob", false)
 
@@ -2618,13 +2235,7 @@ class SqlTableMacro : AstStructureAnnotation {
             let has_on_delete_attr = !empty(find_annotation(field.annotation, "sql_on_delete", ""))
             let has_on_update_attr = !empty(find_annotation(field.annotation, "sql_on_update", ""))
 
-            // @sql_column = "<sql_name>" — rename the field's SQL column so a
-            // daslang struct field can shadow a SQL keyword (`type`, `for`, …)
-            // or use a different on-disk column name. We DON'T use
-            // find_annotation here because that helper can't distinguish
-            // "absent" from `= ""`; both return the default. find_arg + is tString
-            // surfaces the missing-vs-empty case so we can reject the empty
-            // form with a clear error.
+            // @sql_column rename. find_arg distinguishes absent from `= ""` (find_annotation can't).
             var col_name = fname
             let col_anno = find_arg(field.annotation, "sql_column")
             if (col_anno is tString) {
@@ -2759,13 +2370,6 @@ class SqlTableMacro : AstStructureAnnotation {
         }
 
         // ---- @sql_column collision detection ----
-        // After all per-field annotation reads complete, sweep `fields` once
-        // for duplicate `col_name` values. A collision can come from two
-        // fields renaming to the same SQL column, OR from one renamed field
-        // shadowing another field's daslang name (e.g. `@sql_column = "B"` on
-        // field `A` when there's already a sibling field literally named `B`).
-        // Either case would emit malformed DDL (CREATE TABLE with two
-        // `"X"` columns) — fail loud at macro time with a precise pointer.
         {
             var seen_cols : table<string; string>  // sql_col -> first daslang field it came from
             for (info in fields) {
@@ -2778,24 +2382,19 @@ class SqlTableMacro : AstStructureAnnotation {
             }
         }
 
-        // ---- @sql_json / @sql_blob adapter codegen ----
-        // Shared with `[sql_view]` — see `emit_json_blob_adapters_for_struct`.
+        // ---- @sql_json / @sql_blob adapter codegen (shared with [sql_view]) ----
         if (!emit_json_blob_adapters_for_struct(st, fields, "[sql_table]", errors)) {
             return false
         }
 
-        // [sql_index] sibling-annotation processing happens in finish() —
-        // st.annotations is not yet populated during apply(). The helper
-        // function `_sql_create_indexes_sql` is added to the module there.
+        // [sql_index] siblings rewrite the placeholder body in finish() (st.annotations not populated yet here).
         var fn_table_name = make_table_name_fn(st, table_name)
         compiling_module() |> add_function(fn_table_name)
         var fn_drop = make_drop_sql_fn(st, table_name)
         compiling_module() |> add_function(fn_drop)
         var fn_create = make_create_table_sql_fn(st, table_name, fields)
         compiling_module() |> add_function(fn_create)
-        // Empty `_sql_create_indexes_sql` placeholder. Sibling [sql_index]
-        // annotations rewrite this body to accumulate CREATE INDEX statements.
-        // User-facing source order requirement: [sql_table, sql_index, ...].
+        // Empty `_sql_create_indexes_sql` placeholder; [sql_index] siblings accumulate into it.
         var fn_indexes = make_create_indexes_sql_fn(st, "")
         compiling_module() |> add_function(fn_indexes)
         var fn_ins_pk = make_insert_sql_fn(st, table_name, fields, true)
@@ -2867,14 +2466,7 @@ class SqlTableMacro : AstStructureAnnotation {
         for (i in range(length(fields))) {
             let info = fields[i]
             let prefix = i == 0 ? "\"{info.col_name}\" " : ", \"{info.col_name}\" "
-            // Compose the column suffix:
-            //   - computed: ` GENERATED ALWAYS AS (...) VIRTUAL|STORED` and nothing
-            //     else; SQLite rejects NOT NULL / DEFAULT / UNIQUE / FK on a
-            //     generated column.
-            //   - PK: ` PRIMARY KEY`. UNIQUE is implied; DEFAULT may still fire if
-            //     the user gave a literal init.
-            //   - Otherwise: NOT NULL (unless Option<T>), UNIQUE, DEFAULT,
-            //     REFERENCES — in DDL order.
+            // computed columns reject NOT NULL/DEFAULT/UNIQUE/FK; non-computed get them in DDL order.
             var suffix = ""
             if (info.is_computed) {
                 let storage = info.is_stored ? "STORED" : "VIRTUAL"
@@ -2892,11 +2484,7 @@ class SqlTableMacro : AstStructureAnnotation {
                 suffix += info.references_clause
             }
             write_exprs |> push(qmacro_expr(${ writer |> write($v(prefix)); }))
-            // @sql_json / @sql_blob short-circuit `sql_storage_type_for` (which would
-            // fail for struct/tuple T anyway). The annotation pins storage class:
-            // TEXT for json, BLOB for blob — adapter codegen below produces the
-            // matching `sql_bind` / `sql_extract` overloads that bind the column
-            // through that storage class.
+            // @sql_json/@sql_blob pin storage to TEXT/BLOB; sql_storage_type_for would fail on struct/tuple T.
             if (info.is_json) {
                 write_exprs |> push(qmacro_expr(${ writer |> write("TEXT"); }))
             } elif (info.is_blob) {
@@ -2934,10 +2522,7 @@ class SqlTableMacro : AstStructureAnnotation {
             let name = info.col_name
             let is_pk = info.is_pk
             let is_nullable = info.is_optional
-            // Strip the leading " DEFAULT " prefix that `default_clause` carries
-            // for direct DDL concatenation. ``default_expr`` is the raw SQL
-            // expression (`"1"` / `"'x'"` / `"CURRENT_TIMESTAMP"`) — readable
-            // and aligned with PRAGMA table_info's ``dflt_value`` column.
+            // Strip leading " DEFAULT " so default_expr matches PRAGMA table_info's dflt_value column.
             var default_expr = ""
             if (length(info.default_clause) > length(" DEFAULT ")) {
                 default_expr = info.default_clause |> slice(length(" DEFAULT "))
@@ -2976,12 +2561,7 @@ class SqlTableMacro : AstStructureAnnotation {
     }
 
     def make_insert_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>; include_pk : bool) : FunctionPtr {
-        // Always emit explicit column list so computed (GENERATED) columns can be
-        // skipped — SQLite rejects writes to generated columns. ``include_pk``
-        // toggles whether the primary key column participates: with-PK is the
-        // user-specified-keys path, without-PK is the AUTOINCREMENT path.
-        // Both fall back to `DEFAULT VALUES` when no bindable columns remain
-        // (PK-only struct without PK, or all-computed struct).
+        // Explicit column list skips GENERATED columns; falls back to `DEFAULT VALUES` when no bindable cols remain.
         let helper_name = include_pk ? "_sql_insert_with_pk_sql" : "_sql_insert_no_pk_sql"
         let cols = build_string() $(var w) {
             var first = true
@@ -3049,10 +2629,7 @@ class SqlTableMacro : AstStructureAnnotation {
     }
 
     def make_bind_row_fn(var st : StructurePtr; fields : array<FieldInfo>) : FunctionPtr {
-        // Bind indices follow the column-list emitted by `_sql_insert_with_pk_sql`
-        // / `_sql_insert_no_pk_sql` — both skip computed columns. The index is
-        // a running counter over bindable (non-computed) columns; it is NOT
-        // the field's position in `fields`.
+        // Bind index counts bindable (non-computed) columns, NOT field position.
         var with_pk_exprs : array<ExpressionPtr>
         var no_pk_exprs : array<ExpressionPtr>
         with_pk_exprs |> reserve(length(fields))
@@ -3133,11 +2710,7 @@ class SqlTableMacro : AstStructureAnnotation {
             }))
         }
 
-        // `var row = default<$t(st)>` — explicit default so structs with
-        // Option<T> fields (which lack a builtin per-field default and rely
-        // on `@safe_when_uninitialized` only in the value position) still
-        // satisfy strict_smart_pointers' uninitialized-var check inside the
-        // generated `_sql_read_row` body.
+        // Explicit default<>: Option<T> fields don't satisfy strict_smart_pointers' uninit check otherwise.
         var fn = qmacro_function("_sql_read_row") $(stmt : sqlite3_stmt?; typ : $t(st)) : $t(st) {
             var row = default<$t(st)>
             $b(assign_exprs)
@@ -3158,11 +2731,7 @@ class SqlTableMacro : AstStructureAnnotation {
     }
 
     def make_update_by_pk_sql_fn(var st : StructurePtr; table_name : string; fields : array<FieldInfo>) : FunctionPtr {
-        // PK-less / SET-less structs get a stub that panics at runtime — using
-        // ``concept_assert`` here would fire at compile-time on every
-        // ``[sql_table]`` declaration (the function body is type-checked
-        // unconditionally). The stub stays unreachable in practice because
-        // ``update(row)`` panics from the same function before binding runs.
+        // PK-less structs get a runtime-panic stub (concept_assert would fire on every [sql_table] decl).
         let pk_idx = find_pk_field(fields)
         if (pk_idx < 0) {
             let st_name = string(st.name)
@@ -3191,8 +2760,7 @@ class SqlTableMacro : AstStructureAnnotation {
                 first = false
             }
         }
-        // PK-only / all-computed struct (no SET columns): `UPDATE T SET WHERE pk=?`
-        // is invalid SQL. Stub panics at call time with a clear message.
+        // No SET columns -> `UPDATE T SET WHERE pk=?` is invalid SQL; emit a runtime-panic stub.
         if (empty(set_clause)) {
             let st_name = string(st.name)
             let msg = "[sql_table] {st_name}: update(row) has nothing to SET — every non-PK column is missing or @sql_computed. Add at least one writable non-PK column, or use raw `exec`."
@@ -3237,11 +2805,7 @@ class SqlTableMacro : AstStructureAnnotation {
     }
 
     def make_bind_row_for_update_fn(var st : StructurePtr; fields : array<FieldInfo>) : FunctionPtr {
-        // Emits SET-then-WHERE binds: every non-PK column at indices 1..N,
-        // PK column at index N+1. Mirrors the SQL emitted by
-        // `_sql_update_by_pk_sql`. For PK-less / SET-less structs the stub
-        // never runs (the SQL helper panics first), but we still emit a
-        // valid no-op body so the surface compiles.
+        // SET-then-WHERE: non-PK cols at indices 1..N, PK at N+1 (mirrors _sql_update_by_pk_sql).
         let pk_idx = find_pk_field(fields)
         if (pk_idx < 0) {
             var fn = qmacro_function("_sql_bind_row_for_update") $(var stmt : sqlite3_stmt?; row : $t(st)) : void {
@@ -3283,9 +2847,7 @@ class SqlTableMacro : AstStructureAnnotation {
     }
 
     def make_bind_row_pk_only_fn(var st : StructurePtr; fields : array<FieldInfo>) : FunctionPtr {
-        // Binds just the PK column at index 1. Used by `try_delete_(row)` to
-        // execute `DELETE FROM T WHERE pk=?` without needing every field set.
-        // PK-less structs get a no-op stub (the SQL helper panics first).
+        // Binds the PK at index 1 for `DELETE FROM T WHERE pk=?`; no-op stub for PK-less.
         let pk_idx = find_pk_field(fields)
         if (pk_idx < 0) {
             var fn = qmacro_function("_sql_bind_row_pk_only") $(var stmt : sqlite3_stmt?; row : $t(st)) : void {
@@ -3306,44 +2868,10 @@ class SqlTableMacro : AstStructureAnnotation {
 
 }
 
-// ---- @sql_json adapter codegen ----
-//
-//   def sql_bind    (v : T) : string          { return write_json(JV(v)) }
-//   def sql_extract (v : string; t : type<T>) : T {
-//       var err = ""
-//       let jv = read_json(v, err)
-//       if (err != "") {
-//           panic("sql_extract: malformed JSON in column data: {err}")
-//       }
-//       return from_JV(jv, default<T>)
-//   }
-//
-// The pair plugs into the chunk-8 `_::sql_bind` / `_::sql_extract` rail.
-// Storage class is TEXT (driven by the `string` return of `sql_bind`).
-// Round-trip fidelity matches `daslib/json_boost`'s `JV` / `from_JV`
-// surface (struct, tuple, array, table, variant, enum, primitives).
-//
-// Note on `clone_type`: a field's `_type` arrives with the field-context
-// modifier flags (ref/const/etc.) that come from being read inside a struct.
-// Substituting the raw decl into a function parameter yields a slightly
-// different type than a hand-written `(v : T)` — overload resolution then
-// fails to pick the emitted adapter and falls through to the chunk-8
-// catch-all. Clone the decl and use the fresh copy so the substituted type
-// matches a hand-written reference exactly.
-//
-// Module-scope (private) so both `[sql_table]` and `[sql_view]` can share
-// the same adapter codegen via `emit_json_blob_adapters_for_struct`.
+// ===== @sql_json adapter codegen =====
+
 def private make_json_sql_bind_fn(field_type : TypeDeclPtr; at : LineInfo) : FunctionPtr {
-    // The hand-written form `def sql_bind(v : tuple<...>) : string` is
-    // parsed with `TypeDeclFlags.constant = true` on the parameter
-    // (struct/tuple params are pass-by-ref and the parser implicitly
-    // marks them as ``const`` to keep the body immutable). When
-    // `[sql_table]` calls `_::sql_bind(v)` through the chunk-8 catch-
-    // all, the argument arrives with `const explicit` flags from the
-    // generic instantiation — and a non-const parameter rejects a
-    // const argument, dropping our overload from the candidate set.
-    // Match the parsed form: clone the field type and turn on
-    // ``constant`` so resolution accepts the const argument.
+    // Parser marks struct/tuple params const; clone + set constant so generic resolution picks this overload.
     var t1 <- clone_type(field_type)
     t1.flags |= TypeDeclFlags.constant
     var fn = qmacro_function("sql_bind") $(v : $t(t1)) : string {
@@ -3358,11 +2886,7 @@ def private make_json_sql_extract_fn(field_type : TypeDeclPtr; at : LineInfo) : 
     t1.flags |= TypeDeclFlags.constant
     var t2 <- clone_type(field_type)
     var t3 <- clone_type(field_type)
-    // Panic on malformed JSON (matching the @sql_blob symmetry where
-    // `mem_archive_load` panics on corrupt bytes). Without the check,
-    // `read_json` returning null silently feeds into `from_JV` which
-    // returns `default<T>` — schema drift / disk corruption then
-    // surfaces as zero-initialized rows, masking real data loss.
+    // Panic on malformed JSON (mirrors @sql_blob); else schema drift surfaces as silent zero rows.
     var fn = qmacro_function("sql_extract") $(v : string; t : type<$t(t1)>) : $t(t2) {
         var err = ""
         let jv = _::read_json(v, err)
@@ -3375,25 +2899,8 @@ def private make_json_sql_extract_fn(field_type : TypeDeclPtr; at : LineInfo) : 
     return <- fn
 }
 
-// ---- @sql_blob adapter codegen ----
-//
-//   def sql_bind    (v : T) : array<uint8>            { var v_local : T; v_local := v; return <- mem_archive_save(v_local) }
-//   def sql_extract (v : array<uint8>; t : type<T>) : T {
-//       var r = default<T>
-//       _::mem_archive_load(v, r)   // panics on failure (canfail=false)
-//       return r
-//   }
-//
-// Storage class is BLOB. The opaqueness is enforced by `_sql`'s walker:
-// any `_.<blob_col>.<path>` chain in a predicate produces a compile error
-// pointing at the field, since `daslib/archive` data is positional binary
-// and SQL has no way to introspect it.
-//
-// `mem_archive_save(var t : auto&)` requires a mutable reference, but our
-// adapter is reached through the chunk-8 generic `sql_bind_to_stmt(... v :
-// auto(TT))` which holds `v` as a non-var binding. Clone into a local var
-// to bridge the const/var gap without taking `var v` ourselves (which would
-// force the catch-all to also take var, rippling up to the row binder).
+// ===== @sql_blob adapter codegen =====
+
 def private make_blob_sql_bind_fn(field_type : TypeDeclPtr; at : LineInfo) : FunctionPtr {
     var t1 <- clone_type(field_type)
     t1.flags |= TypeDeclFlags.constant
@@ -3420,13 +2927,7 @@ def private make_blob_sql_extract_fn(field_type : TypeDeclPtr; at : LineInfo) : 
     return <- fn
 }
 
-// SqlAdapterKind — discriminates an existing `sql_bind(T)` overload by its
-// return-type shape, used for [sql_table] @sql_json / @sql_blob dedup.
-//   None — no overload of `sql_bind(T)` exists for T in the module.
-//   Json — overload returns `string` (matches @sql_json codegen).
-//   Blob — overload returns `array<uint8>` (matches @sql_blob codegen).
-//   Other — overload exists but returns something else (user-supplied or
-//           a stale generated form); always treated as a kind conflict.
+// Classifies an existing `sql_bind(T)` overload's return-type shape for @sql_json / @sql_blob dedup.
 enum private SqlAdapterKind {
     None
     Json
@@ -3435,9 +2936,6 @@ enum private SqlAdapterKind {
 }
 
 def private classify_sql_bind_return(td : TypeDeclPtr) : SqlAdapterKind {
-    //! Map a `sql_bind(T)` return type to its adapter kind. JSON returns are
-    //! `string`; BLOB returns are `array<uint8>`. Anything else is "Other"
-    //! and treated as a conflict.
     if (td == null) {
         return SqlAdapterKind.None
     }
@@ -3451,13 +2949,6 @@ def private classify_sql_bind_return(td : TypeDeclPtr) : SqlAdapterKind {
 }
 
 def private find_sql_bind_kind_for_type(mod : Module?; td : TypeDeclPtr) : SqlAdapterKind {
-    //! Walk every overload of ``sql_bind`` in ``mod`` and report the kind of
-    //! the one whose first parameter is type-equivalent to ``td`` (ignoring
-    //! const/ref/temp). Returns ``None`` when no matching overload exists.
-    //! Used by [sql_table] @sql_json / @sql_blob adapter codegen for
-    //! kind-aware dedup: a JSON kind matches @sql_json reuse, Blob kind
-    //! matches @sql_blob reuse; ``Other`` (or kind mismatch) is a compile
-    //! error.
     if (td == null) {
         return SqlAdapterKind.None
     }
@@ -3473,24 +2964,6 @@ def private find_sql_bind_kind_for_type(mod : Module?; td : TypeDeclPtr) : SqlAd
 }
 
 def private emit_json_blob_adapters_for_struct(var st : StructurePtr; fields : array<FieldInfo>; tag : string; var errors : das_string) : bool {
-    //! Shared @sql_json / @sql_blob adapter codegen for `[sql_table]` and
-    //! `[sql_view]`. ``tag`` is the user-facing annotation label used in
-    //! error messages (``"[sql_table]"`` or ``"[sql_view]"``).
-    //!
-    //! Emits FIRST (before the per-struct read/bind helpers) so the adapter
-    //! overloads are visible to overload resolution when the helpers
-    //! (`_sql_read_row` / `_sql_bind_row`) get type-checked, both of which
-    //! call into the chunk-8 `_::sql_bind` / `_::sql_extract` rail.
-    //!
-    //! Dedup is **per-(T, kind)**: an existing `sql_bind(T) : string`
-    //! satisfies a fresh @sql_json field, `sql_bind(T) : array<uint8>`
-    //! satisfies @sql_blob — but using the same T with a different kind
-    //! (across structs in this module, or across fields of one struct)
-    //! would silently miscompile, so it's rejected as a compile error.
-    //! Within-struct: `seen_kinds` maps describe(T) -> expected return
-    //! (`"string"` for JSON, `"array<uint8>"` for BLOB). Cross-struct:
-    //! `find_sql_bind_kind_for_type` looks up any existing `sql_bind(T)`
-    //! overload in the module and reports its return primitive.
     var seen_kinds : table<string; SqlAdapterKind>
     for (i in range(length(fields))) {
         let info = fields[i]
@@ -3538,53 +3011,24 @@ def private emit_json_blob_adapters_for_struct(var st : StructurePtr; fields : a
     return true
 }
 
-// ============================================================================
-// `[sql_view]` — read-only struct view backed by a SQLite VIEW.
-//
-// Companion of `[sql_table]`: the struct describes a result-set shape (one
-// field per projected column), and `[sql_view]` emits the same read-path
-// helpers (``_sql_table_name``, ``_sql_select_all_sql``, ``_sql_read_row``,
-// ``_sql_column_info``, ``_sql_drop_view_if_exists_sql``) so existing
-// queries (``select_from(type<V>)`` and the `_sql` chain rail) work without
-// a dispatch on view-vs-table.
-//
-// Mutation paths are stubbed:
-//   - Predicate-form (`_sql_update` / `_sql_delete` / `_sql_upsert`) is
-//     gated at compile time by `validate_outer_args` / `validate_outer_upsert_args`
-//     reading the `[sql_view]` annotation off the type<T> argument.
-//   - Row-form (`insert(row)` / `update(row)` / `delete_(row)`) resolves
-//     to the per-struct `_sql_*` helpers below, all of which `panic` at
-//     runtime with a "views are read-only" message. The compile-time
-//     gate handles the more important predicate-form case.
-//
-// View DDL is emitted by the `_create_view(db, type<V>, <pipeline>)` call
-// macro in `daslib/sqlite_linq` (writes "CREATE VIEW ... AS SELECT ...").
-// ============================================================================
+// ===== [sql_view] — read-only struct view backed by a SQLite VIEW =====
 
 [structure_macro(name=sql_view)]
 class private SqlViewMacro : AstStructureAnnotation {
     def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
         let view_name = find_annotation(args, "name", string(st.name))
-
-        // Reject sibling [sql_index] before doing any per-field work, so the
-        // user gets a structural error pointing at the macro stack rather
-        // than a follow-on per-field error from the `[sql_index]` apply.
+        // Reject sibling [sql_index] up front so the error points at the macro stack, not a per-field follow-on.
         for (annDecl in st.annotations) {
             if (annDecl.annotation.name == "sql_index") {
                 errors := "[sql_view] on struct '{st.name}': [sql_index] cannot apply to a view — views are read-only and inherit indexing from the underlying table. Move the index to the underlying table's struct."
                 return false
             }
         }
-
-        // ---- per-field validation ----
-        // Views accept ONLY: @sql_column (rename), @sql_json, @sql_blob.
-        // Everything that affects DDL emission of an underlying table — keys,
-        // uniqueness, computed columns, defaults, FKs — is rejected loud.
+        // ---- per-field validation: views accept only @sql_column / @sql_json / @sql_blob ----
         var fields : array<FieldInfo>
         fields |> reserve(length(st.fields))
         for (field in st.fields) {
             let fname = string(field.name)
-
             if (find_annotation(field.annotation, "sql_primary_key", false)) {
                 errors := "[sql_view]: field '{fname}' has @sql_primary_key — views are read-only and cannot declare keys; primary keys belong on the underlying table."
                 return false
@@ -3622,7 +3066,6 @@ class private SqlViewMacro : AstStructureAnnotation {
                 errors := "[sql_view]: field '{fname}' has @sql_on_update — FK actions belong on the underlying table, not the view."
                 return false
             }
-
             let is_optional = is_option_field_type(field._type)
             let is_json = find_annotation(field.annotation, "sql_json", false)
             let is_blob = find_annotation(field.annotation, "sql_blob", false)
@@ -3630,9 +3073,7 @@ class private SqlViewMacro : AstStructureAnnotation {
                 errors := "[sql_view]: field '{fname}' has both @sql_json and @sql_blob — pick one. Use @sql_json for queryable, schema-tolerant TEXT storage; use @sql_blob for opaque binary storage."
                 return false
             }
-
-            // @sql_column = "<sql_name>" — same rename rules as [sql_table].
-            // find_arg + is tString to distinguish "absent" from `= ""`.
+            // @sql_column rename, same rules as [sql_table].
             var col_name = fname
             let col_anno = find_arg(field.annotation, "sql_column")
             if (col_anno is tString) {
@@ -3647,7 +3088,6 @@ class private SqlViewMacro : AstStructureAnnotation {
                 }
                 col_name = cv
             }
-
             fields |> push(FieldInfo(
                 name = fname,
                 col_name = col_name,
@@ -3663,7 +3103,6 @@ class private SqlViewMacro : AstStructureAnnotation {
                 default_clause = "",
                 references_clause = ""))
         }
-
         // ---- @sql_column collision detection ----
         {
             var seen_cols : table<string; string>
@@ -3676,12 +3115,10 @@ class private SqlViewMacro : AstStructureAnnotation {
                 seen_cols |> insert(info.col_name, info.name)
             }
         }
-
         // ---- @sql_json / @sql_blob adapter codegen ----
         if (!emit_json_blob_adapters_for_struct(st, fields, "[sql_view]", errors)) {
             return false
         }
-
         // ---- read-path helpers (same names as [sql_table]) ----
         var fn_table_name = make_view_table_name_fn(st, view_name)
         compiling_module() |> add_function(fn_table_name)
@@ -3693,7 +3130,6 @@ class private SqlViewMacro : AstStructureAnnotation {
         compiling_module() |> add_function(fn_read)
         var fn_col_info = make_view_column_info_fn(st, fields)
         compiling_module() |> add_function(fn_col_info)
-
         // ---- mutation stubs (panic at runtime with a clear message) ----
         let st_name = string(st.name)
         var fn_ins_pk = make_view_string_panic_stub_fn(st, "_sql_insert_with_pk_sql", st_name, "insert")
@@ -3712,7 +3148,6 @@ class private SqlViewMacro : AstStructureAnnotation {
         compiling_module() |> add_function(fn_bind_upd)
         var fn_bind_pk = make_view_bind_row_panic_stub_fn(st, "_sql_bind_row_pk_only", st_name, "delete", false)
         compiling_module() |> add_function(fn_bind_pk)
-
         return true
     }
 }
@@ -3757,9 +3192,6 @@ def private make_view_select_all_sql_fn(var st : StructurePtr; view_name : strin
 }
 
 def private make_view_read_row_fn(var st : StructurePtr; fields : array<FieldInfo>) : FunctionPtr {
-    //! Mirrors `[sql_table]`'s `make_read_row_fn`. Adapter dispatch
-    //! (chunk-8 `read_via_adapter`) handles @sql_json / @sql_blob fields
-    //! via the JSON/BLOB sql_extract overloads emitted above.
     var assign_exprs : array<ExpressionPtr>
     assign_exprs |> reserve(length(fields))
     for (i in range(length(fields))) {
@@ -3786,9 +3218,6 @@ def private make_view_read_row_fn(var st : StructurePtr; fields : array<FieldInf
 }
 
 def private make_view_column_info_fn(var st : StructurePtr; fields : array<FieldInfo>) : FunctionPtr {
-    //! Per-view ColumnInfo helper. `is_pk` is always false (views don't
-    //! have primary keys). `default_expr` is always empty (defaults belong
-    //! to the underlying table).
     var push_exprs : array<ExpressionPtr>
     push_exprs |> reserve(length(fields))
     for (i in range(length(fields))) {
@@ -3830,11 +3259,6 @@ def private make_view_column_info_fn(var st : StructurePtr; fields : array<Field
 
 def private make_view_string_panic_stub_fn(var st : StructurePtr; helper_name : string;
                                            st_name : string; verb : string) : FunctionPtr {
-    //! Emits `def _sql_X(typ : V) : string { panic(...); return "" }` —
-    //! returns "" never executes; the panic body fires on the first call
-    //! from a row-form mutation template (`insert(row)` / `update(row)` /
-    //! `delete_(row)`). Predicate-form mutations are caught at compile
-    //! time by `validate_outer_args` / `validate_outer_upsert_args`.
     let msg = "[sql_view] {st_name}: cannot {verb} into a view — views are read-only. Mutate the underlying table(s) and re-query the view."
     var fn = qmacro_function(helper_name) $(typ : $t(st)) : string {
         panic($v(msg))
@@ -3846,10 +3270,6 @@ def private make_view_string_panic_stub_fn(var st : StructurePtr; helper_name : 
 }
 
 def private make_view_pk_is_unset_stub_fn(var st : StructurePtr) : FunctionPtr {
-    //! `_sql_pk_is_unset(row : V) : bool` — never reached at runtime
-    //! (the caller — `try_insert` / `try_insert_many` — calls
-    //! `_::_sql_insert_with_pk_sql` next, which panics). Returns false
-    //! to satisfy the boolean signature.
     var fn = qmacro_function("_sql_pk_is_unset") $(row : $t(st)) : bool {
         return false
     }
@@ -3861,8 +3281,6 @@ def private make_view_pk_is_unset_stub_fn(var st : StructurePtr) : FunctionPtr {
 def private make_view_bind_row_panic_stub_fn(var st : StructurePtr; helper_name : string;
                                              st_name : string; verb : string;
                                              has_include_pk : bool) : FunctionPtr {
-    //! Emits the void-returning bind helpers. Argument shape matches the
-    //! `[sql_table]` versions exactly so overload resolution finds them.
     let msg = "[sql_view] {st_name}: cannot {verb} into a view — views are read-only. Mutate the underlying table(s) and re-query the view."
     if (has_include_pk) {
         var fn = qmacro_function(helper_name) $(var stmt : sqlite3_stmt?; row : $t(st); include_pk : bool) : void {
@@ -3881,32 +3299,7 @@ def private make_view_bind_row_panic_stub_fn(var st : StructurePtr; helper_name 
     }
 }
 
-// ============================================================================
-// register_function — bind a daslang function as a SQL scalar UDF
-//
-// Surface:
-//
-//   db |> register_function("damage", @@damage_formula)
-//   db |> register_function("color", @@hex_to_color, true)              // deterministic
-//   db |> register_function("now_iso", @@now_iso, false, true)          // direct-only
-//
-// Implementation: a `[call_macro]` reads the function pointer's static
-// type, derives an SqlFnTag for each argument and the return, and emits a
-// call to the C++-side `sqlite3_register_function` trampoline. The macro
-// intentionally enforces the supported scalar set (Int / Int64 / Float /
-// Double / Bool / String) at compile time so misuse surfaces as a
-// `macro_error` rather than as a runtime mystery.
-//
-// NULL handling (v1): if any argument is SQLITE_NULL the trampoline
-// short-circuits to SQLITE_NULL without invoking the daslang function —
-// the idiomatic SQL behavior for built-in scalars (`abs(NULL)` -> `NULL`).
-// Explicit Option<T> arguments + Blob support are deferred to a later chunk.
-//
-// Panic recovery: a panic inside the daslang function is caught via
-// `Context::runWithCatch` and surfaced to SQLite as
-// `sqlite3_result_error`, so `try_query_scalar(... my_fn(...))` returns
-// `Err` containing the panic message; the connection itself is unaffected.
-// ============================================================================
+// ===== register_function — bind a daslang function as a SQL scalar UDF =====
 
 enum SqlFnTag {
     //! Type tag matching the C++-side SqlFnTag enum in dasSQLITE.userfn.cpp.
@@ -3921,8 +3314,6 @@ enum SqlFnTag {
 
 [macro_function]
 def private sql_fn_tag_for_type(td : TypeDeclPtr) : tuple<tag : uint8; ok : bool> {
-    //! Map an AST type to its SqlFnTag. Returns ok=false for unsupported
-    //! types so the macro can emit a precise diagnostic naming the offender.
     if (td == null) {
         return (uint8(0), false)
     }
@@ -3952,20 +3343,11 @@ def private sql_fn_tag_for_type(td : TypeDeclPtr) : tuple<tag : uint8; ok : bool
 
 [call_macro(name="register_function")]
 class private RegisterFunctionMacro : AstCallMacro {
-    //! Pipe form: `db |> register_function(name, fn[, deterministic[, directonly]])`.
-    //! Direct form: `register_function(db, name, fn[, deterministic[, directonly]])`.
-    //!
-    //! The function pointer's static signature drives tag derivation; reject
-    //! unsupported arg/return types here rather than let SQLite produce
-    //! mystery results.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         let nCallArgs = call.arguments |> length
         macro_verify(nCallArgs >= 3 && nCallArgs <= 5, prog, call.at,
             "register_function expects (db, name, fn[, deterministic[, directonly]]) — got {nCallArgs} args")
-
-        // Function pointer must already have an inferred type; otherwise the
-        // call macro is firing too early and the inner `@@fn` hasn't resolved
-        // yet. Bail with a clear message rather than a null-deref later.
+        // Need the inferred function-pointer type; otherwise the inner @@fn hasn't resolved yet.
         var fnExpr = call.arguments[2]
         macro_verify(fnExpr._type != null, prog, call.at,
             "register_function: function-pointer argument is not inferred yet — make sure the symbol exists at this point")
@@ -3973,14 +3355,10 @@ class private RegisterFunctionMacro : AstCallMacro {
             "register_function: function-pointer type is auto/alias after inference")
         macro_verify(fnExpr._type.baseType == Type.tFunction, prog, call.at,
             "register_function: third argument must be a function pointer (e.g. `@@my_fn`); got {describe(fnExpr._type)}")
-
         let nArgs = fnExpr._type.argTypes |> length
         macro_verify(nArgs <= 4, prog, call.at,
             "register_function: SQLite scalar functions support up to 4 arguments; got {nArgs}")
-
-        // Derive per-arg + return tags. Reject unsupported types up front
-        // with a per-position diagnostic so the user knows exactly which
-        // parameter to fix.
+        // Derive per-arg + return tags; reject unsupported types per position.
         var tags : array<uint8>
         tags |> reserve(4)
         for (i in range(nArgs)) {
@@ -3992,34 +3370,28 @@ class private RegisterFunctionMacro : AstCallMacro {
             }
             tags |> push(r.tag)
         }
-        // Pad tag slots to 4 — unused slots are ignored by the C++ side
-        // according to nArgs, but the binding takes 4 scalar uint8s.
+        // Pad tag slots to 4: C++ side reads nArgs but the binding takes 4 scalar uint8s.
         while (tags |> length < 4) {
             tags |> push(uint8(0))
         }
-
         let retR = sql_fn_tag_for_type(fnExpr._type.firstType)
         if (!retR.ok) {
             macro_error(prog, call.at,
                 "register_function: return type '{describe(fnExpr._type.firstType)}' is unsupported — supported: int, int64, float, double, bool, string")
             return null
         }
-
         var dbExpr   = clone_expression(call.arguments[0])
         var nameExpr = clone_expression(call.arguments[1])
         var fnClone  = clone_expression(fnExpr)
-
         // Optional positional flags. Default both to false.
         var detExpr : ExpressionPtr = nCallArgs >= 4 ? clone_expression(call.arguments[3]) : qmacro(false)
         var donExpr : ExpressionPtr = nCallArgs >= 5 ? clone_expression(call.arguments[4]) : qmacro(false)
-
         let nArgsLit = int(nArgs)
         let tag0 = tags[0]
         let tag1 = tags[1]
         let tag2 = tags[2]
         let tag3 = tags[3]
         let retTag = retR.tag
-
         // Emit: helper checks rc and panics on failure with the libsqlite3 errmsg.
         var res = qmacro(_::_register_function_check_rc(
             $e(dbExpr), $e(nameExpr), $e(fnClone), $v(nArgsLit),

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -20,14 +20,6 @@ require daslib/rtti
 require strings public
 require daslib/strings_convert
 
-// ============================================================================
-// _to_array passthrough
-//
-// Recognized by the `_sql` macro as a no-op terminal. In compatibility mode
-// (no `_sql` wrapper) it forwards to the bare materialization done by
-// `select_from` (which already returns `array<T>`).
-// ============================================================================
-
 [unused_argument(arr)]
 def _to_array(var arr : array<auto(TT)>) : array<TT -const -#> {
     //! Passthrough terminal. In compat mode `select_from` has already materialized
@@ -35,14 +27,6 @@ def _to_array(var arr : array<auto(TT)>) : array<TT -const -#> {
     //! the call and treats it as a no-op terminal.
     return <- arr
 }
-
-// ============================================================================
-// _first_opt — Option<T>-returning sibling of linq.das's `first`.
-//
-// Inside `_sql(...)` the macro recognizes the call, emits `LIMIT 1`, and
-// uses the OneOpt materializer. In compat mode (no `_sql` wrapper) the
-// fallback inspects the materialized array.
-// ============================================================================
 
 def _first_opt(arr : array<auto(TT)>) : Option<TT -const -#> {
     //! Compat-mode fallback: returns ``some(arr[0])`` if non-empty, ``none`` otherwise.
@@ -64,147 +48,294 @@ def _first(arr : array<auto(TT)>) : TT -const -& {
 }
 
 
-// ============================================================================
-// SqlQuery — accumulator for chain analysis (compile-time only).
-//
-// Materializer and ProjectionShape are the framework discriminators. Each
-// chain operator recognized in `analyze_chain` sets one or both, then the
-// emit pass in `_sql.visit()` switches on them to choose runtime helper +
-// row builder.
-// ============================================================================
+// ===== SqlQuery — accumulator for chain analysis =====
 
 enum private Materializer {
-    Array        //!< default: `array<T>` via run_select
-    One          //!< exactly-one row (panic on 0); covers `_first`, `_count`
-    OneOpt       //!< 0-or-1 row, returns `Option<T>`; covers `_first_opt`
+    Array
+    One
+    OneOpt
 }
 
 enum private ProjectionShape {
-    FullRow             //!< no `_select`: SELECT cols-of(rootT); reads via _::_sql_read_row
-    SingleColumn        //!< `_select(_.Field)`: SELECT one col; reads via read_via_adapter
-    NamedTuple          //!< `_select((Name=_.Name, Price=_.Price))`: SELECT cols; reads via tuple builder
-    Aggregate           //!< `_count()` etc.: raw SQL expression in SELECT; scalar reader
-    GroupedNamedTuple   //!< `_select` after `_group_by`: tuple of group keys + group-scope aggregates
+    FullRow
+    SingleColumn
+    NamedTuple
+    Aggregate
+    GroupedNamedTuple
 }
 
 enum private JoinKind {
-    Inner   //!< INNER JOIN — `_join` macro
-    Left    //!< LEFT JOIN — `_left_join` macro; right-side row is `Option<TB>`
+    Inner
+    Left
 }
 
 enum private SetOpKind {
-    None       //!< no set operation in the chain
-    // Compound queries are emitted WITHOUT surrounding parens — SQLite parses
-    // a per-side `ORDER BY` / `LIMIT` / `OFFSET` as a syntax error in that
-    // shape, which is why chunk 5 rejects those stages on either side. Per-
-    // side parens (and the corresponding compound-trailing-clause support)
-    // are deferred to a future chunk.
-    Union      //!< `union(a, b)`     → `<a> UNION <b>`
-    Intersect  //!< `intersect(a, b)` → `<a> INTERSECT <b>`
-    Except     //!< `except(a, b)`    → `<a> EXCEPT <b>`
+    None
+    Union
+    Intersect
+    Except
 }
 
 struct private JoinSpec {
-    //! Single `_join` / `_left_join` recognized by chunk 5: the root source
-    //! is alias `t0`, the joined source is alias `t1`. `process_join_call`
-    //! rejects a second join in the same chain (3+ table joins are deferred
-    //! to a future chunk). The `joins : array<JoinSpec>` field on `SqlQuery`
-    //! holds the future shape — chunk 5 fills at most one entry.
     kind        : JoinKind
-    rootType    : TypeDeclPtr     //!< right-side row type
-    tableName   : string          //!< right-side table name (unquoted)
-    alias       : string          //!< right-side alias (currently always `t1`)
-    leftCol     : string          //!< left side of equi-join `on` (field name on the LEFT source)
-    leftAlias   : string          //!< alias of the LEFT source (currently always `t0`)
-    rightCol    : string          //!< right side of equi-join `on` (field name on the JOINED source)
-    // Right-side `_where` filter — emitted into the JOIN's `ON` clause
-    // (NOT the outer WHERE) as `... ON t0.k = t1.k AND (rightWhereSql)`.
-    // Required for `LEFT JOIN`: a per-row predicate in the outer WHERE
-    // would filter out NULL-extended unmatched rows and silently turn
-    // LEFT JOIN into INNER JOIN. INNER JOIN uses the same ON-clause path
-    // for consistency (semantically equivalent to a WHERE merge for INNER,
-    // but more idiomatic SQL and stable across query planners).
+    rootType    : TypeDeclPtr
+    tableName   : string
+    alias       : string
+    leftCol     : string
+    leftAlias   : string
+    rightCol    : string
     rightWhereSql     : string
-    // Right-side bind exprs are stored per-JoinSpec rather than appended
-    // to outer q.bindExprs, because ON binds must precede outer-WHERE
-    // binds in the runtime placeholder order (`SELECT ... ON ?_on ...
-    // WHERE ?_outer`). The runtime bind builder concatenates them in this
-    // order: per-join ON binds (in join order) → outer WHERE → HAVING →
-    // LIMIT/OFFSET.
     rightOnBindExprs  : array<ExpressionPtr>
 }
 
 struct private SqlQuery {
     rootType    : TypeDeclPtr
     tableName   : string
-    rootAlias   : string                  //!< `""` in single-source mode; `"t0"` once a join is peeled (see seenJoin)
-    selectCols  : array<string>           //!< SingleColumn / FullRow / NamedTuple: column names (quoted in SQL); empty entry when the column is a computed expression (selectColSqlFragments[i] holds the SQL).
-    selectColAliases : array<string>      //!< multi-source: alias for each column's owning source (parallel to selectCols); empty for single-source columns and for computed expressions.
-    selectColTypes : array<TypeDeclPtr>   //!< multi-source: the RESOLVED column type (already field-looked-up). Used by build_row_builder directly — no further lookup needed. Empty in single-source mode (build_row_builder falls back to q.rootType + lookup_struct_field_type).
-    selectColSqlFragments : array<string> //!< multi-source: precomputed SQL fragment for non-trivial projection values (e.g. `"t1"."Id" IS NOT NULL` for `o |> is_some`). Empty entry → emit `"alias"."col"` from selectColAliases/selectCols.
-    projRecordNames : array<string>       //!< NamedTuple: per-column tuple field names (parallel to selectCols)
-    aggregateExpr : string                //!< Aggregate: raw SELECT-list text (e.g. "COUNT(*)")
-    aggregateType : TypeDeclPtr           //!< Aggregate: resolved scalar result type; varies by aggregate expression (int for COUNT, double for AVG, column type for SUM/MIN/MAX)
+    rootAlias   : string
+    selectCols  : array<string>
+    selectColAliases : array<string>
+    selectColTypes : array<TypeDeclPtr>
+    selectColSqlFragments : array<string>
+    projRecordNames : array<string>
+    aggregateExpr : string
+    aggregateType : TypeDeclPtr
     whereSql    : string
-    bindExprs   : array<ExpressionPtr>    //!< WHERE binds, populated during analyze_chain
-    limitBindExpr : ExpressionPtr         //!< take(n) bind expr (null = no LIMIT, except terminal-induced)
-    offsetBindExpr : ExpressionPtr        //!< skip(n) bind expr (null = no OFFSET)
-    distinctFlag : bool                   //!< distinct() seen → emits "SELECT DISTINCT"
-    orderByCols : array<string>           //!< each entry like `"Col" ASC` / `"Col" DESC`
-    groupByCols : array<string>           //!< each entry like `"Col"` (already SQL-quoted)
-    havingSql : string                    //!< pre-formatted HAVING clause (without leading "HAVING ")
-    havingBindExprs : array<ExpressionPtr>  //!< HAVING binds, kept separate so they sort after WHERE binds
-    groupedSelectExprs : array<string>    //!< GroupedNamedTuple: raw SQL fragment per column
-    groupedSelectTypes : array<TypeDeclPtr>  //!< GroupedNamedTuple: resolved scalar type per column
+    bindExprs   : array<ExpressionPtr>
+    limitBindExpr : ExpressionPtr
+    offsetBindExpr : ExpressionPtr
+    distinctFlag : bool
+    orderByCols : array<string>
+    orderByInlineExprs : array<ExpressionPtr>
+    groupByCols : array<string>
+    havingSql : string
+    havingBindExprs : array<ExpressionPtr>
+    groupedSelectExprs : array<string>
+    groupedSelectTypes : array<TypeDeclPtr>
     matr        : Materializer = Materializer.Array
     proj        : ProjectionShape = ProjectionShape.FullRow
     seenSelect  : bool
     seenToArray : bool
-    seenTerminal : bool                   //!< true once a single-row/scalar terminal has been peeled
-    seenDistinct : bool                   //!< duplicate-stage guard for distinct()
-    seenTake    : bool                    //!< duplicate-stage guard for take(n)
-    seenSkip    : bool                    //!< duplicate-stage guard for skip(n)
-    seenOrderBy : bool                    //!< duplicate-stage guard for _order_by
-    seenGroupBy : bool                    //!< _group_by seen — group-scope context for downstream _select / _having
-    seenHaving  : bool                    //!< duplicate-stage guard for _having
-    inHaving    : bool                    //!< pred_to_sql writes binds to havingBindExprs while this is true
-    seenJoin    : bool                    //!< multi-source mode flag (any join peeled) — qualifies column refs as `"talias"."Col"`
-    joins       : array<JoinSpec>         //!< joined sources in chain order
-    setOpKind     : SetOpKind = SetOpKind.None  //!< set-op (UNION/INTERSECT/EXCEPT) wrapping the LHS query
-    setOpRhsSql   : string                 //!< RHS query's SQL string (already built via build_sql_string on the sub-q)
-    seenSetOp     : bool                  //!< guard: only one set-op per chain in chunk 5 (chained set-ops are deferred)
-    // Lambda-arg → source-idx binding stack. Populated transiently around
-    // `analyze_predicate` / `analyze_projection` calls to teach `pred_to_sql`
-    // / projection analyzers which source a 2-arg `into` lambda's named
-    // parameters refer to. Single-source mode keeps this empty (`_` in
-    // `_where` predicates always means source 0; we don't need a mapping).
+    seenTerminal : bool
+    seenDistinct : bool
+    seenTake    : bool
+    seenSkip    : bool
+    seenOrderBy : bool
+    seenGroupBy : bool
+    seenHaving  : bool
+    inHaving    : bool
+    seenJoin    : bool
+    joins       : array<JoinSpec>
+    setOpKind     : SetOpKind = SetOpKind.None
+    setOpRhsSql   : string
+    seenSetOp     : bool
     argNames    : array<string>
-    argSourceIdx : array<int>             //!< parallel to argNames
+    argSourceIdx : array<int>
     dbExpr      : ExpressionPtr
-    upsertMode  : bool                    //!< _upsert do_update body context — recognize `_excluded.Col` as the SQLite ``excluded.col`` proposed-row reference. Only set inside `emit_upsert_body`.
-    hadError    : bool                    //!< pred_to_sql / projection / subquery analyzer raised a `macro_error` somewhere in the recursion. Top-level callers (analyze_predicate, etc.) must check this *after* the recursive walk — relying on `empty(s)` is unsafe because operator handlers wrap empty children in non-empty SQL fragments (e.g. `lhs = rhs` becomes `" = ?"` when only the lhs failed).
+    upsertMode  : bool
+    hadError    : bool
 }
 
-// ============================================================================
-// Multi-source column qualification helpers.
-//
-// Single-source mode emits unqualified `"Col"`. Multi-source mode (any join
-// peeled) emits `"talias"."Col"` so column refs are unambiguous when
-// SQLite's planner sees JOIN clauses.
-//
-// `column_sql_for_alias(alias, field)` is the single emission point that
-// every column-ref site routes through. Callers compute the alias via
-// `source_alias_for_idx(q, idx)` (idx 0 = root, 1+ = join idx 0+) and pass
-// the alias here.
-// ============================================================================
+// ===== SqlFrag fragment stream =====
+
+variant private SqlFrag {
+    text       : string
+    bind       : ExpressionPtr
+    inline_id  : ExpressionPtr
+    inline_lit : ExpressionPtr
+}
+
+[macro_function]
+def private push_text(var out : array<SqlFrag>; s : string) {
+    if (empty(s)) {
+        return
+    }
+    let n = length(out)
+    if (n > 0 && out[n - 1] is text) {
+        out[n - 1] = SqlFrag(text = string(out[n - 1] as text) + s)
+        return
+    }
+    out |> push(SqlFrag(text = s))
+}
+
+[macro_function]
+def private push_bind(var out : array<SqlFrag>; e : ExpressionPtr) {
+    out |> push(SqlFrag(bind = clone_expression(e)))
+}
+
+[macro_function]
+def private push_inline_id(var out : array<SqlFrag>; e : ExpressionPtr) {
+    out |> push(SqlFrag(inline_id = clone_expression(e)))
+}
+
+[macro_function]
+def private push_inline_lit(var out : array<SqlFrag>; e : ExpressionPtr) {
+    out |> push(SqlFrag(inline_lit = clone_expression(e)))
+}
+
+[macro_function]
+def private push_frags(var dst : array<SqlFrag>; var src : array<SqlFrag>) {
+    for (f in src) {
+        dst |> push(f) // nolint:PERF006 macro-function, runs once per compile
+    }
+}
+
+[macro_function]
+def private has_bind_frag(var frags : array<SqlFrag>) : bool {
+    for (f in frags) {
+        if (f is bind) {
+            return true
+        }
+    }
+    return false
+}
+
+[macro_function]
+def private extract_const_string(e : ExpressionPtr) : tuple<bool; string> {
+    if (e == null || !(e is ExprConstString)) {
+        return (false, "")
+    }
+    let cs = e as ExprConstString
+    return (true, string(cs.value))
+}
+
+[macro_function]
+def private fold_to_string(var frags : array<SqlFrag>; var hadError : bool&; prog : ProgramPtr; at : LineInfo) : string {
+    return build_string() $(var w) {
+        for (f in frags) {
+            if (f is text) {
+                w |> write(f as text)
+            } elif (f is bind) {
+                w |> write("?")
+            } elif (f is inline_id) {
+                let r = extract_const_string(f as inline_id)
+                if (!r._0) {
+                    hadError = true
+                    macro_error(prog, at, "_sql_text / _create_view requires compile-time identifiers; use _sql / query for runtime-built SQL")
+                    return
+                }
+                w |> write("\"")
+                w |> write(r._1 |> replace("\"", "\"\""))
+                w |> write("\"")
+            } elif (f is inline_lit) {
+                let r = extract_const_string(f as inline_lit)
+                if (!r._0) {
+                    hadError = true
+                    macro_error(prog, at, "_sql_text / _create_view requires compile-time literals; use _sql / query for runtime-built SQL")
+                    return
+                }
+                w |> write("'")
+                w |> write(r._1 |> replace("'", "''"))
+                w |> write("'")
+            }
+        }
+    }
+}
+
+[macro_function]
+def private fold_to_builder(var frags : array<SqlFrag>; at : LineInfo;
+                            var sqlExpr : ExpressionPtr&;
+                            var bindExprs : array<ExpressionPtr>) {
+    var sb = new ExprStringBuilder(at = at)
+    var pending = ""
+    // macro-function: short-burst string accumulation, flushed into ExprConstString nodes
+    for (f in frags) {
+        if (f is text) {
+            pending += string(f as text) // nolint:PERF001
+        } elif (f is bind) {
+            pending += "?" // nolint:PERF001
+            var be : ExpressionPtr = f as bind
+            bindExprs |> push(be)
+        } elif (f is inline_id) {
+            let r = extract_const_string(f as inline_id)
+            if (r._0) {
+                pending += "\"" // nolint:PERF001
+                pending += r._1 |> replace("\"", "\"\"") // nolint:PERF001
+                pending += "\"" // nolint:PERF001
+            } else {
+                if (!empty(pending)) {
+                    sb.elements |> push <| new ExprConstString(at = at, value := pending)
+                    pending = ""
+                }
+                sb.elements |> push <| qmacro(_::sql_quote_id($e(f as inline_id)))
+            }
+        } elif (f is inline_lit) {
+            let r = extract_const_string(f as inline_lit)
+            if (r._0) {
+                pending += "'" // nolint:PERF001
+                pending += r._1 |> replace("'", "''") // nolint:PERF001
+                pending += "'" // nolint:PERF001
+            } else {
+                if (!empty(pending)) {
+                    sb.elements |> push <| new ExprConstString(at = at, value := pending)
+                    pending = ""
+                }
+                sb.elements |> push <| qmacro(_::sql_quote_lit($e(f as inline_lit)))
+            }
+        }
+    }
+    if (!empty(pending)) {
+        sb.elements |> push <| new ExprConstString(at = at, value := pending)
+    }
+    sqlExpr = sb
+}
+
+[macro_function]
+def private sql_to_frags(sql : string; var orderedBinds : array<ExpressionPtr>; var out : array<SqlFrag>) {
+    var noInlineIds : array<ExpressionPtr>
+    sql_to_frags_ex(sql, orderedBinds, noInlineIds, out)
+}
+
+// Walks `sql` token by token, splitting `?` (binds) and `\x01` (runtime ids) into their respective frags.
+// Each marker pulls the next expression from the matching list in occurrence order. When a list is
+// exhausted, the marker is preserved as text — `_sql_text` deliberately passes empty binds to keep `?` in
+// the rendered SQL.
+[macro_function]
+def private sql_to_frags_ex(sql : string;
+                            var orderedBinds : array<ExpressionPtr>;
+                            var orderedInlineIds : array<ExpressionPtr>;
+                            var out : array<SqlFrag>) {
+    var rest = sql
+    var bindIdx = 0
+    var idIdx = 0
+    while (true) {
+        let p = next_placeholder(rest)
+        if (p._0 < 0) {
+            break
+        }
+        if (p._1 == uint8('?')) {
+            if (bindIdx >= length(orderedBinds)) {
+                out |> push_text(rest |> slice(0, p._0 + 1))
+                rest = rest |> slice(p._0 + 1)
+                continue
+            }
+            if (p._0 > 0) {
+                out |> push_text(rest |> slice(0, p._0))
+            }
+            out |> push_bind(orderedBinds[bindIdx])
+            bindIdx++
+        } else {
+            if (idIdx >= length(orderedInlineIds)) {
+                out |> push_text(rest |> slice(0, p._0 + 1))
+                rest = rest |> slice(p._0 + 1)
+                continue
+            }
+            if (p._0 > 0) {
+                out |> push_text(rest |> slice(0, p._0))
+            }
+            out |> push_inline_id(orderedInlineIds[idIdx])
+            idIdx++
+        }
+        rest = rest |> slice(p._0 + 1)
+    }
+    if (!empty(rest)) {
+        out |> push_text(rest)
+    }
+}
+
+// ===== Multi-source column qualification helpers =====
 
 [macro_function]
 def private source_alias_for_idx(q : SqlQuery; idx : int) : string {
-    //! Alias of source `idx`: 0 = root (`q.rootAlias`), 1.. = `q.joins[idx-1].alias`.
-    //! Returns `""` when no rootAlias is set (single-source mode); a non-empty
-    //! rootAlias is the alias-emission signal, not `q.seenJoin` — the right-
-    //! side subQ analyzed by `process_join_call` has `rootAlias = "t1"` but
-    //! `seenJoin = false` (see process_join_call step 3).
     if (empty(q.rootAlias)) {
         return ""
     }
@@ -216,12 +347,6 @@ def private source_alias_for_idx(q : SqlQuery; idx : int) : string {
 
 [macro_function]
 def private source_rootType_for_idx(var q : SqlQuery&; idx : int) : TypeDeclPtr {
-    //! Look up the rootType (struct TypeDecl) of source `idx`. Source 0 is
-    //! `q.rootType`; sources 1.. live on `q.joins[idx-1].rootType`. Used by
-    //! `build_row_builder` for column-type lookup in multi-source projections.
-    //! `var q&` is required because daslang's const-q field access yields
-    //! `TypeDecl const?` (pointer-to-const), incompatible with the
-    //! `lookup_struct_field_type` signature.
     if (idx == 0) {
         return q.rootType
     }
@@ -230,12 +355,6 @@ def private source_rootType_for_idx(var q : SqlQuery&; idx : int) : TypeDeclPtr 
 
 [macro_function]
 def private source_rootType_for_alias(var q : SqlQuery&; alias : string) : TypeDeclPtr {
-    //! Reverse lookup of `source_rootType_for_idx` — find the source whose
-    //! alias matches and return its rootType. Used at SQL emission time when
-    //! we have the alias on hand (from `q.selectColAliases[i]`) but not the
-    //! source index. Falls back to `q.rootType` if no match (defensive: should
-    //! never happen because every alias in `selectColAliases` was placed by an
-    //! analyzer that knew the source idx).
     if (alias == q.rootAlias) {
         return q.rootType
     }
@@ -249,13 +368,6 @@ def private source_rootType_for_alias(var q : SqlQuery&; alias : string) : TypeD
 
 [macro_function]
 def private column_sql_for_alias(alias : string; rootT : TypeDeclPtr; field : string) : string {
-    //! Format a column SQL fragment. Empty alias → unqualified `"Col"` (single-
-    //! source mode). Non-empty alias → `"talias"."Col"`. ``field`` is the
-    //! daslang field name; this helper translates it to the SQL column via
-    //! `@sql_column` (using ``rootT``'s field annotations) so renames are
-    //! transparent at every emission site. ``rootT`` may be null when the
-    //! caller doesn't have a struct type in hand (e.g. a literal projection);
-    //! in that case the daslang name passes through unchanged.
     let sqlCol = field_to_column_name(rootT, field)
     if (empty(alias)) {
         return "\"{sqlCol}\""
@@ -265,15 +377,6 @@ def private column_sql_for_alias(alias : string; rootT : TypeDeclPtr; field : st
 
 [macro_function]
 def private render_json_extract(rootT : TypeDeclPtr; alias : string; col : string; path : array<string>) : string {
-    //! SQLite ``json_extract(<column-ref>, '$.p1.p2…')``. ``alias`` empty in
-    //! single-source mode (unqualified column ref); non-empty multi-source
-    //! mode emits ``"alias"."col"``. ``rootT`` is the struct type that owns
-    //! ``col`` — used to resolve `@sql_column` on the JSON column itself.
-    //! ``path`` lists JSON-path elements outer-to-inner (struct field names
-    //! or tuple ``_N`` accessors — both pass through unchanged because tuples
-    //! serialize via ``JV`` as objects keyed by their record-name, mirroring
-    //! the daslang-side accessor; @sql_column does NOT apply to JSON-path
-    //! segments since the path navigates the JSON value, not the SQL schema).
     let p = build_string() $(var w) {
         w |> write("'$")
         for (s in path) {
@@ -288,9 +391,6 @@ def private render_json_extract(rootT : TypeDeclPtr; alias : string; col : strin
 
 [macro_function]
 def private lookup_arg_source(q : SqlQuery; argName : string) : int {
-    //! Resolve a lambda-arg name to its source index. Returns -1 if not
-    //! bound (caller falls back to source 0 in single-source mode, or
-    //! emits a macro_error in multi-source mode).
     let n = length(q.argNames)
     for (i in range(n)) {
         if (q.argNames[i] == argName) {
@@ -300,31 +400,10 @@ def private lookup_arg_source(q : SqlQuery; argName : string) : int {
     return -1
 }
 
-// ============================================================================
-// Chain analysis — walk a pipe-composed chain backwards.
-//
-// `_sql` runs as a normal call_macro (no `canVisitArgument` override), so by
-// the time `analyze_chain` runs daslang has already expanded all inner
-// call_macros bottom-up. The chain we see is the post-expansion shape:
-//
-//   _where(it, expr)  →  where_(it, $(_ : T) => expr)         [from linq_boost]
-//   _select(it, expr) →  select(it,  $(_ : T) => expr)        [from linq_boost]
-//   _first(it)        →  first(it)                             [linq.das fn]
-//   _count(it)        →  count(it)                             [linq.das fn]
-//   _to_array(arr)    →  _to_array(arr)                        [plain fn, stays]
-//   _first_opt(arr)   →  _first_opt(arr)                       [plain fn, stays]
-//   select_from(db, type<T>) → unchanged                       [plain fn]
-//
-// Because expansion is complete, `_` inside the lambda body is a real bound
-// parameter with type T, captured vars carry their `_type`, and any
-// user-defined wrapper macro (e.g. `when_its_cold(it)` → `_where(it, ...)`)
-// has already cascaded into a `where_` / `select` we recognize.
-// ============================================================================
+// ===== Chain analysis (walk pipe-composed chain backwards) =====
 
 [macro_function]
 def private peel_lambda_body(var lam : ExpressionPtr) : ExpressionPtr {
-    //! Peel `$(_ : T) => body` (post-expansion linq lambda) → body expression.
-    //! Returns null if shape is unexpected. Mirrors `linq_boost.fold_linq_cond`.
     if (lam == null || !(lam is ExprMakeBlock)) {
         return null
     }
@@ -342,9 +421,6 @@ def private peel_lambda_body(var lam : ExpressionPtr) : ExpressionPtr {
 
 [macro_function]
 def private match_linq_call(var expr : ExpressionPtr; name : string) : ExprCall? {
-    //! Match a fully-resolved call to `name` from module `linq`. Walks
-    //! through `fromGeneric` so generic instances are recognized. Mirrors
-    //! `linq_boost.is_call_or_generic`.
     if (expr == null || !(expr is ExprCall)) {
         return null
     }
@@ -366,10 +442,6 @@ def private match_linq_call(var expr : ExpressionPtr; name : string) : ExprCall?
 
 [macro_function]
 def private match_module_call(var expr : ExpressionPtr; name : string; modName : string) : ExprCall? {
-    //! Like match_linq_call but matches against any named module — used to
-    //! recognize sqlite_linq's own plain functions like `_first_opt` after
-    //! expansion (linq_boost recognizes `_first_opt` only as a fall-through
-    //! to its underlying call; for `_sql` we want to peel the call here).
     if (expr == null || !(expr is ExprCall)) {
         return null
     }
@@ -393,14 +465,6 @@ def private match_module_call(var expr : ExpressionPtr; name : string; modName :
 def private peel_column_aggregate(var node : ExpressionPtr; var q : SqlQuery&;
                                   linqName : string; sqlOp : string; promote_to_double : bool;
                                   prog : ProgramPtr; at : LineInfo) : bool {
-    //! Peel a column aggregate (sum/average/min/max) wrapping a SingleColumn
-    //! projection. Returns true if this node matched (regardless of success);
-    //! the caller treats `q.aggregateExpr != ""` as success and returns true,
-    //! else propagates the macro_error already emitted.
-    //!
-    //! Strategy: recurse into the inner chain FIRST so the inner `_select` /
-    //! `select_from` populates q.selectCols, then wrap selectCols[0] in
-    //! `sqlOp(...)`. This lets the same slot serve any column aggregate.
     var aCall = match_linq_call(node, linqName)
     if (aCall == null) {
         return false
@@ -437,12 +501,6 @@ def private peel_column_aggregate(var node : ExpressionPtr; var q : SqlQuery&;
 [macro_function]
 def private extract_key_selector_field(var keyLambda : ExpressionPtr; expectedArgName : string;
                                        prog : ProgramPtr; at : LineInfo) : string {
-    //! Pull the `<arg>.<field>` out of a 1-arg key-selector lambda body.
-    //! `linq_boost`'s `_join`/`_left_join` macro renames the arg to a
-    //! fresh `__la__` / `__lb__` symbol; we accept that exact name (passed
-    //! in via `expectedArgName`) and reject anything else loud — the only
-    //! supported equi-join shape is `(l, r) => l.X == r.Y`, and the macro
-    //! has already validated it. This step extracts the column name.
     if (keyLambda == null || !(keyLambda is ExprMakeBlock)) {
         macro_error(prog, at, "_sql: _join key selector has unexpected shape (not a lambda)")
         return ""
@@ -460,10 +518,7 @@ def private extract_key_selector_field(var keyLambda : ExpressionPtr; expectedAr
     var ret = blk.list[0] as ExprReturn
     var receiver : ExpressionPtr
     var fieldName : string
-    // Require the receiver be an ExprVar — `$e(recv).$f(field)` matches any
-    // ExprField, including nested chains like `l.opt.X` whose receiver is
-    // itself an ExprField. Without the explicit ExprVar gate, qmatch would
-    // silently accept the chain and we would extract a meaningless argName.
+    // Pin receiver to ExprVar so nested chains (`l.opt.X`) don't match silently with a meaningless argName.
     if (!qmatch(ret.subexpr, $e(receiver).$f(fieldName)).matched
             || receiver == null || !(receiver is ExprVar)) {
         macro_error(prog, at, "_sql: _join key selector body must be `<arg>.Field` (column ref); computed key expressions are not yet translatable to SQL — use raw SQL or restructure the join")
@@ -480,32 +535,6 @@ def private extract_key_selector_field(var keyLambda : ExpressionPtr; expectedAr
 [macro_function]
 def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
                               kind : JoinKind; prog : ProgramPtr; at : LineInfo) : bool {
-    //! Shared body for `_join` (INNER) and `_left_join` (LEFT) peels.
-    //!
-    //! Post-expansion shape from `daslib/linq_boost`:
-    //!   join(srca, srcb, $(__la__:TA) => __la__.X, $(__lb__:TB) => __lb__.Y, into_lambda)
-    //!   left_join(...)  — same 5-arg shape
-    //!
-    //! Steps:
-    //!  1. Mark multi-source mode (q.seenJoin, q.rootAlias = "t0").
-    //!  2. Recurse into srca (populates q.rootType, q.tableName, processes
-    //!     any pre-join `_where` with qualified column refs).
-    //!  3. Build a sub-`SqlQuery` for srcb with its own pre-set rootAlias
-    //!     ("t1"), recurse to analyze it. The right side accepts only
-    //!     `select_from(type<T>)` plus optional `_where(...)`; aggregates,
-    //!     `_group_by`, `_select`, terminals, and nested joins are rejected.
-    //!  4. Construct a `JoinSpec` from the sub-q's rootType / tableName /
-    //!     whereSql. Extract the equi-join field names from keya / keyb.
-    //!     Push the JoinSpec and keep the right-side `_where` SQL on
-    //!     `spec.rightWhereSql` (emitted in the JOIN's `ON ... AND (...)`
-    //!     clause, NOT outer WHERE — required for LEFT JOIN, used uniformly
-    //!     for INNER too) and its binds on `spec.rightOnBindExprs`. The
-    //!     emit-time bind builder concatenates pools in SQL clause order:
-    //!     per-join ON binds (in join order) → outer WHERE → HAVING →
-    //!     LIMIT/OFFSET, so placeholder indices line up with
-    //!     `... ON keyEq AND (rightWhereSql) ... WHERE (outer) ...`.
-    //!  5. Process the `into` projection: bind its 2 lambda args to source
-    //!     0 / source 1, then run analyze_projection on the body.
     if (q.seenJoin) {
         macro_error(prog, at, "_sql: only one join per chain (3+ table joins are not yet supported in chunk 5; chain multiple two-table joins or use raw SQL)")
         return false
@@ -524,24 +553,13 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     }
     q.seenJoin = true
     q.rootAlias = "t0"
-
     // 2. Recurse into srca — populates q.rootType, q.tableName, processes
     //    any inner `_where`. Inner `_where`'s pred_to_sql emits qualified
     //    column refs (`"t0"."Col"`) because q.seenJoin is now true.
     if (!analyze_chain(jCall.arguments[0], q, prog, at)) {
         return false
     }
-
-    // 3. Build sub-q for srcb. Pre-set rootAlias = "t1" so its inner
-    //    `_where` peel emits qualified columns from the start. We
-    //    deliberately do NOT pre-set `subQ.seenJoin = true` here:
-    //    `seenJoin` also gates projection parsing (multi-source arg-name
-    //    lookup via `q.argNames`) and join-duplicate guards, so forcing
-    //    it on the subQ would surface confusing errors for inner stages
-    //    that we already reject post-hoc (e.g. `_select` on the right
-    //    side). Column qualification is driven by `!empty(q.rootAlias)`
-    //    in `pred_to_sql` — the alias-emission signal is independent of
-    //    "this query contains a join".
+    // 3. Build sub-q for srcb. rootAlias="t1" drives column qualification; do NOT set seenJoin (it gates other paths we already reject post-hoc).
     var subQ = SqlQuery(rootAlias = "t1")
     if (!analyze_chain(jCall.arguments[1], subQ, prog, at)) {
         return false
@@ -575,7 +593,6 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
         macro_error(prog, at, "_sql: _join right side cannot itself contain a join (3+ table joins not yet supported)")
         return false
     }
-
     // 4. Construct JoinSpec.
     let leftCol = extract_key_selector_field(jCall.arguments[2], "__la__", prog, at)
     return false if (empty(leftCol))
@@ -590,16 +607,12 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
         leftAlias = "t0",
         rightCol = rightCol,
         rightWhereSql = subQ.whereSql)
-    // Hold right-side WHERE binds on the JoinSpec (NOT the outer q.bindExprs)
-    // — the runtime bind builder concatenates per-join ON binds first, then
-    // outer WHERE / HAVING / LIMIT / OFFSET, so the placeholder index lines
-    // up with `... ON keyEq AND (rightWhereSql) ... WHERE (outer)`.
+    // ON binds live on JoinSpec, not q.bindExprs — runtime concats per-join ON before outer WHERE so placeholder order matches SQL.
     spec.rightOnBindExprs |> reserve(length(subQ.bindExprs))
     for (b in subQ.bindExprs) {
         spec.rightOnBindExprs |> push <| clone_expression(b)
     }
     q.joins |> emplace(spec)
-
     // 5. Process `into` projection — 2-arg lambda; bind arg0 → source 0,
     //    arg1 → source 1, then run analyze_projection on the body.
     var intoLambda = jCall.arguments[4]
@@ -637,17 +650,8 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
         macro_error(prog, at, "_sql: empty chain")
         return false
     }
-
-    // ---- Terminal recognition (must come before _select / _where peel) ----
-    // These set the materializer and (sometimes) the projection, then recurse
-    // into the inner chain. Only one terminal allowed per chain.
-
-    // Peel _to_array(prev) — plain function in this module, no expansion.
-    // _to_array() is a materializer-mode flag (sets `q.matr = Array`); it
-    // doesn't change emitted SQL, so its position in the chain is
-    // irrelevant — `select_from |> _select(...) |> _to_array()` and
-    // `select_from |> _to_array() |> _select(...)` produce identical SQL.
-    // Only the duplicate-terminal guard remains.
+    // ---- Terminals (one per chain, must precede _select / _where peel) ----
+    // Peel _to_array(prev) — materializer flag only; position-irrelevant.
     {
         var inner : ExpressionPtr
         if (qmatch(node, _to_array($e(inner))).matched) {
@@ -660,9 +664,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return analyze_chain(inner, q, prog, at)
         }
     }
-
-    // Peel first(prev) — written as either `|> first()` (linq.das `first`)
-    // or `|> _first()` (sqlite_linq's underscore-form passthrough).
+    // Peel first(prev) — `|> first()` or `|> _first()`.
     {
         var fCall = match_linq_call(node, "first")
         if (fCall == null) {
@@ -682,7 +684,6 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return analyze_chain(fCall.arguments[0], q, prog, at)
         }
     }
-
     // Peel _first_opt(prev) — plain function in this module.
     {
         var foCall = match_module_call(node, "_first_opt", "sqlite_linq")
@@ -696,10 +697,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return analyze_chain(foCall.arguments[0], q, prog, at)
         }
     }
-
-    // Peel count(prev) — post-expansion of `_count()` (linq.das `count`).
-    // Sets MaterializeOne + ProjAggregate("COUNT(*)", int64). Canary for the
-    // chunk-3 aggregate framework; chunk 4 broadens to _sum / _avg / etc.
+    // Peel count(prev) — `|> _count()` → SELECT COUNT(*) ...
     {
         var cCall = match_linq_call(node, "count")
         if (cCall != null) {
@@ -715,22 +713,12 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             q.seenTerminal = true
             q.proj = ProjectionShape.Aggregate
             q.aggregateExpr = "COUNT(*)"
-            // SQLite's COUNT(*) is int64 internally, but daslang's
-            // `length(arr)` / `count(arr)` return `int`, so narrow via
-            // `read_via_adapter(stmt, 0, type<int>)`. Matches the grouped
-            // form (`_._1 |> length`) which also lands as `int`. Any
-            // plausible row count fits.
+            // Narrow SQLite int64 to daslang int — matches length()/count() return type.
             q.aggregateType = new TypeDecl(at = at, baseType = Type.tInt)
             return analyze_chain(cCall.arguments[0], q, prog, at)
         }
     }
-
     // ---- Column aggregates: sum / average / min / max ----
-    // Pattern: `... |> _select(_.Col) |> sum()` (or average/min/max).
-    // Implementation note: recurse into the inner chain FIRST so selectCols
-    // is populated, then wrap selectCols[0] in the SQL aggregate. This lets
-    // the same emitter slot serve any column-aggregate primitive — adding a
-    // new one is a one-line entry plus a column-type rule.
     {
         if (peel_column_aggregate(node, q, "sum",     "SUM", false, prog, at)) {
             return q.aggregateExpr != ""
@@ -751,14 +739,8 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return q.aggregateExpr != ""
         }
     }
-
     // ---- Stage operators ----
-
-    // Peel distinct(prev) — linq.das's `distinct` plain function. Sets
-    // SELECT DISTINCT on the emitted SQL. The SELECT-list itself comes from
-    // the rest of the chain (FullRow / SingleColumn / NamedTuple); aggregates
-    // pair with DISTINCT only via the function-internal form (e.g.
-    // COUNT(DISTINCT col)) which is not yet wired — flag a guard for that.
+    // Peel distinct(prev) — emits SELECT DISTINCT.
     {
         var dCall = match_linq_call(node, "distinct")
         if (dCall != null) {
@@ -775,7 +757,6 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return analyze_chain(dCall.arguments[0], q, prog, at)
         }
     }
-
     // Peel take(prev, n) — linq.das's `take(arr, int)`. Sets LIMIT n.
     // `n` is stashed on q.limitBindExpr; the bind statement is emitted in
     // emit_sql_macro_body AFTER the WHERE binds so the placeholder index
@@ -796,17 +777,9 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return analyze_chain(tCall.arguments[0], q, prog, at)
         }
     }
-
     // Peel order_by(prev, lambda) — post-expansion of `_order_by(prev, expr)`.
     // Single-column: body is `_.Col` → push `"Col" ASC`.
-    // Multi-column: body is a tuple literal `(_.k1, _.k2)` → push each
-    // `"k_i" ASC`. After `_group_by`, body is `_._0` (single key) or
-    // `_._0._N` (multi-key). Mixed ASC/DESC across columns is out of
-    // chunk-4 scope (use the raw-SQL escape hatch); see plan D2.
-    //
-    // Recurse FIRST so `q.seenGroupBy` / `q.groupByCols` are populated by
-    // the time `collect_order_keys` runs, letting it route `_._0` to the
-    // correct group-by column.
+    // Recurse first so q.seenGroupBy/groupByCols are populated before collect_order_keys routes `_._0`.
     {
         var obCall = match_linq_call(node, "order_by")
         if (obCall != null) {
@@ -829,9 +802,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return true
         }
     }
-
-    // Peel order_by_descending(prev, lambda) — post-expansion of
-    // `_order_by_descending(prev, expr)`. Same shape as order_by; emits DESC.
+    // Peel order_by_descending — same shape as order_by, emits DESC.
     {
         var odCall = match_linq_call(node, "order_by_descending")
         if (odCall != null) {
@@ -854,11 +825,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return true
         }
     }
-
-    // Peel skip(prev, n) — linq.das's `skip(arr, int)`. Sets OFFSET n.
-    // OFFSET in SQL requires LIMIT; SQLite accepts `LIMIT -1 OFFSET n` to
-    // skip-without-limit, which build_sql_string emits when seenSkip without
-    // seenTake.
+    // Peel skip(prev, n) → OFFSET n. build_sql_string emits `LIMIT -1 OFFSET n` when no take.
     {
         var sCall = match_linq_call(node, "skip")
         if (sCall != null) {
@@ -875,13 +842,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return analyze_chain(sCall.arguments[0], q, prog, at)
         }
     }
-
-    // Peel select(prev, lambda) — post-expansion of `_select(prev, expr)`.
-    // Recurses into the inner chain FIRST so any downstream `_group_by` has
-    // populated `q.seenGroupBy` by the time we analyze the projection body.
-    // The grouped path uses `analyze_grouped_projection` (mixed group keys +
-    // group-scope aggregate primitives); the row-scope path uses
-    // `analyze_projection`.
+    // Peel select(prev, lambda) — recurse first so q.seenGroupBy is set before projection analysis routes grouped vs row-scope.
     {
         var sCall = match_linq_call(node, "select")
         if (sCall != null) {
@@ -890,12 +851,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
                 return false
             }
             if (q.proj == ProjectionShape.Aggregate) {
-                // Soft pass-through: aggregate terminals (count/sum/...) emit their
-                // own projection (e.g. COUNT(*)) and ignore any prior _select.
-                // Mark seenSelect so select_from doesn't fill default columns —
-                // the aggregate's projection wins. The inner _select's body is
-                // still walked for side-effect-free typing but its column choice
-                // does not affect the emitted SQL.
+                // Aggregate terminal wins; mark seenSelect so select_from doesn't fill defaults.
                 q.seenSelect = true
                 return analyze_chain(sCall.arguments[0], q, prog, at)
             }
@@ -922,12 +878,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return true
         }
     }
-
-    // Peel having_(prev, lambda) — post-expansion of `_having(prev, predicate)`.
-    // Recurses into the inner chain FIRST so we can validate that `_group_by`
-    // is downstream (HAVING without GROUP BY is meaningless in SQL). Binds
-    // captured by the predicate go to `q.havingBindExprs` so they can be
-    // appended after WHERE binds in the placeholder index sequence.
+    // Peel _having — recurse first to validate that _group_by sits inside; HAVING binds land in q.havingBindExprs (after WHERE).
     {
         var hCall = match_linq_call(node, "having_")
         if (hCall != null) {
@@ -972,14 +923,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return true
         }
     }
-
-    // Peel group_by_lazy(prev, lambda) — post-expansion of both `_group_by`
-    // and `_group_by_lazy` (linq_boost lowers both to the same backing call).
-    // Inside `_sql` both forms emit GROUP BY; the IGrouping per-group
-    // iterators never materialize at runtime because `_sql` rewrites the
-    // entire chain into a `run_select` call before evaluation. Users who
-    // want the actual IGrouping per-group iterator should not wrap in
-    // `_sql(...)`.
+    // Peel _group_by / _group_by_lazy — both lower to group_by_lazy; emits GROUP BY.
     {
         var gbCall = match_linq_call(node, "group_by_lazy")
         if (gbCall != null) {
@@ -1003,13 +947,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return analyze_chain(gbCall.arguments[0], q, prog, at)
         }
     }
-
-    // Peel where_(prev, lambda) — post-expansion of `_where(prev, predicate)`.
-    // Recurse into the inner chain FIRST so `q.rootType` is set before the
-    // predicate analyzer runs — pred_to_sql's `@sql_json` / `@sql_blob` field-
-    // descent recognizer reads field annotations off `q.rootType`. Multiple
-    // chained `_where`s still compose with AND (innermost recurse-first
-    // populates `q.whereSql`, each outer wrap adds `(prev) AND (cur)`).
+    // Peel _where — recurse first so q.rootType is set before pred_to_sql runs (needs it for @sql_json/@sql_blob descent).
     {
         var wCall = match_linq_call(node, "where_")
         if (wCall != null) {
@@ -1024,17 +962,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return analyze_predicate(body, q, prog, at)
         }
     }
-
-    // Peel set operations: union(a, b) / intersect(a, b) / except(a, b).
-    // The LHS chain populates the outer `q`; the RHS chain analyzes into a
-    // sub-q whose SQL string + binds get stored on the outer q. Restrict to
-    // one set-op per chain (chained set-ops would need parenthesization
-    // bookkeeping not yet wired). LHS may already have joins / WHERE /
-    // _select / etc. — set-op wraps the WHOLE LHS query.
-    //
-    // RHS rejections (`seenTerminal`/`distinctFlag`/`limitBindExpr`/etc.)
-    // happen via the same checks used for subquery analyzers — set-op
-    // RHS is essentially another subquery that must be a complete SELECT.
+    // Peel set operations (union/intersect/except). One set-op per chain; chained set-ops are deferred.
     {
         var soKind = SetOpKind.None
         var soCall : ExprCall?
@@ -1068,12 +996,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             if (!analyze_chain(soCall.arguments[0], q, prog, at)) {
                 return false
             }
-            // Set-op SQL is emitted as `<inner-LHS> UNION <inner-RHS>` with no
-            // surrounding parens, so SQLite parses any per-side `ORDER BY` /
-            // `LIMIT` / `OFFSET` as a syntax error ("ORDER BY clause should
-            // come after UNION not before"). Reject those stages on either
-            // side in chunk 5; compound-query semantics (per-side parens or a
-            // single trailing ORDER BY/LIMIT) are deferred.
+            // SQLite syntax-errors on per-side ORDER BY / LIMIT in compound queries — reject both sides.
             if (q.seenOrderBy) {
                 macro_error(prog, at, "_sql: set-op LHS cannot use `_order_by` (apply to the combined set-op result instead; chunk 5)")
                 return false
@@ -1104,19 +1027,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
                 return false
             }
             let rhsSql = build_sql_string(subQ)
-            // Compound-query bind ordering must follow SQL clause order:
-            // LHS(on → where → having) then RHS(on → where → having). The
-            // outer-q finalizer (in emit_sql_macro_body) prepends q.joins'
-            // ON binds and appends q.havingBindExprs to q.bindExprs at SQL
-            // emit time — that pattern is correct for a single SELECT, but
-            // for `<lhs> UNION <rhs>` we have to flatten *both* sides here
-            // and clear the per-pool sources so the finalizer doesn't re-
-            // prepend / re-append already-folded LHS binds and end up with
-            // double-binds and mis-ordered placeholders.
-            //
-            // After this block, q.bindExprs holds the COMPLETE flat bind
-            // list for the compound query, and q.joins[*].rightOnBindExprs
-            // / q.havingBindExprs are empty.
+            // Flatten both sides into q.bindExprs and clear per-pool sources, so the outer finalizer doesn't re-prepend/append (would double-bind).
             var folded : array<ExpressionPtr>
             var foldedCount = 0
             for (j in q.joins) {
@@ -1139,15 +1050,12 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             for (b in q.havingBindExprs) {
                 folded |> push(b)
             }
-            // Clear LHS per-pool sources — the finalizer must not re-prepend
-            // these. q.joins itself stays (the FROM/SELECT emitter walks it
-            // for JOIN clauses), only its bind pools are emptied.
+            // Clear LHS per-pool bind sources (q.joins itself stays for FROM/SELECT emission).
             for (j in q.joins) {
                 j.rightOnBindExprs |> clear
             }
             q.havingBindExprs |> clear
-            // RHS: on → where → having (RHS bindings come AFTER LHS in the
-            // SQL `<lhs> UNION <rhs>` placeholder order).
+            // RHS on → where → having (after LHS in `<lhs> UNION <rhs>`).
             for (j in subQ.joins) {
                 for (b in j.rightOnBindExprs) {
                     folded |> push <| clone_expression(b)
@@ -1166,26 +1074,20 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return true
         }
     }
-
-    // Peel join(srca, srcb, keya, keyb, into) — post-expansion of `_join`
-    // (linq_boost's macro splits the equi-join `on` into keya/keyb selectors).
+    // Peel _join (linq_boost expands `on` into keya/keyb selectors).
     {
         var jCall = match_linq_call(node, "join")
         if (jCall != null) {
             return process_join_call(jCall, q, JoinKind.Inner, prog, at)
         }
     }
-
-    // Peel left_join(...) — post-expansion of `_left_join`. Same 5-arg shape
-    // as `join` but the `into` lambda's right param is `Option<TB>`; under
-    // `_sql` the right-side columns become NULL on no-match rows.
+    // Peel _left_join — same shape as `join`, right side becomes NULL on no-match.
     {
         var ljCall = match_linq_call(node, "left_join")
         if (ljCall != null) {
             return process_join_call(ljCall, q, JoinKind.Left, prog, at)
         }
     }
-
     // Bottom: select_from(db, type<T>) — plain function in sqlite_boost.
     {
         var dbE : ExpressionPtr
@@ -1202,37 +1104,15 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return true
         }
     }
-
     macro_error(prog, at, "_sql: unsupported chain root or operator. Got: {describe(node)}")
     return false
 }
 
-// ============================================================================
-// Projection analysis (_select).
-//
-// Supported projection shapes:
-//   _select(_.FieldName)                 -> single-column projection
-//   _select((Name=_.X, Other=_.Y))       -> named-tuple projection (recordNames preserved)
-//
-// Struct-type projection (_select(type<T2>)) is deferred to chunk 4.
-//
-// `body` is the projection expression (e.g. `_.Name`) after Mode-2
-// expansion has already lambda-wrapped it via `select(it, $(_:T) => body)`,
-// so what we receive is the inner body extracted by `peel_lambda_body`.
-// The typer wraps field reads in `ExprRef2Value` post-expansion, so we
-// peel that adapter before pattern-matching the column shape.
-// ============================================================================
+// ===== Projection analysis (_select) =====
 
 [macro_function]
 def private try_left_join_null_probe(var node : ExpressionPtr; q : SqlQuery;
                                      var argName : string&; positive : bool) : string {
-    //! If `node` is a bare `ExprVar` whose name maps to a joined source
-    //! (idx > 0) AND that source is a LEFT JOIN, return the SQL fragment
-    //! that probes the right-side join key column for NULL-ness:
-    //!   positive = true  (`is_some`)  → `"alias"."rightCol" IS NOT NULL`
-    //!   positive = false (`is_none`)  → `"alias"."rightCol" IS NULL`
-    //! Returns "" otherwise — caller falls through to the default
-    //! is_some/is_none translation (which expects a column ref).
     if (!q.seenJoin) {
         return ""
     }
@@ -1269,14 +1149,6 @@ def private try_left_join_null_probe(var node : ExpressionPtr; q : SqlQuery;
 def private try_recognize_json_path_proj(val : ExpressionPtr; var q : SqlQuery&;
                                          var outFrag : string&; var outLeafType : TypeDeclPtr&;
                                          prog : ProgramPtr; at : LineInfo) : int {
-    //! Multi-level field-chain recognizer for the projection side. Returns
-    //! 1 = matched (outFrag carries the `json_extract(...)` SQL, outLeafType
-    //! the resolved daslang scalar type at the leaf), 0 = didn't match
-    //! (caller falls through to single-level / is_some recognizers), or -1 =
-    //! matched as `@sql_blob` descent OR JSON-path-resolution error
-    //! (macro_error already emitted; caller propagates failure). Mirror of
-    //! the inline recognizer in `pred_to_sql` — keeps the logic in one place
-    //! so single-column and named-tuple projections share it.
     if (val == null || !(val is ExprField)) {
         return 0
     }
@@ -1344,9 +1216,6 @@ def private try_recognize_json_path_proj(val : ExpressionPtr; var q : SqlQuery&;
 
 [macro_function]
 def private resolve_proj_arg_to_source(q : SqlQuery; argName : string; prog : ProgramPtr; at : LineInfo) : int {
-    //! Map a projection-lambda arg name to its source idx. Single-source mode
-    //! accepts only `_` (idx 0). Multi-source mode looks up `q.argNames`
-    //! (populated transiently by the join peel) and macro_errors on miss.
     if (!q.seenJoin) {
         if (argName == "_") {
             return 0
@@ -1368,10 +1237,7 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
         macro_error(prog, at, "_sql: _select: missing projection")
         return false
     }
-    // Peel the ExprRef2Value wrapper the typer inserts around field reads
-    // post-Mode-2 — qmatch in the single-column branch below auto-peels, but
-    // the multi-shape `is ExprMakeTuple` dispatch further down needs a
-    // peeled body to compare RTTI directly.
+    // Peel ExprRef2Value — `is ExprMakeTuple` dispatch needs the unwrapped node.
     if (body is ExprRef2Value) {
         body = (body as ExprRef2Value).subexpr
         if (body == null) {
@@ -1379,13 +1245,7 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
             return false
         }
     }
-
-    // Multi-level field chain — `<arg>.Col.path1.path2…`. When `Col` carries
-    // `@sql_json`, descend via `json_extract`; `@sql_blob` is a compile error
-    // per API_REWORK §37 lock 6. `try_recognize_json_path_proj` returns
-    // 1 = matched (frag + leafType set), -1 = matched-as-error (macro_error
-    // emitted), 0 = didn't match (fall through to single-level qmatch). Mirror
-    // of the pred_to_sql recognizer above the single-level qmatch.
+    // Multi-level field chain `<arg>.Col.path…` — descends via json_extract for @sql_json.
     {
         var frag : string
         var leafType : TypeDeclPtr
@@ -1398,7 +1258,7 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
             q.selectColAliases |> clear
             q.selectColTypes |> clear
             q.selectColSqlFragments |> clear
-            q.selectCols |> push("")              //!< discriminator-only — fragment carries the SQL
+            q.selectCols |> push("")
             q.selectColAliases |> push("")
             q.selectColSqlFragments |> push(frag)
             q.selectColTypes |> push(leafType)
@@ -1406,11 +1266,7 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
             return true
         }
     }
-
-    // Single-column form: <argname>.FieldName  (`_` in single-source, `u`/`o` etc. after a join).
-    // Receiver must be ExprVar — `$e(recv).$f(field)` would otherwise accept
-    // nested chains (`_.opt.X`, `a.b.c`) and silently extract the inner
-    // field name as the argName.
+    // Single-column form: <argname>.FieldName. Receiver must be ExprVar (else nested chains slip through).
     {
         var receiver : ExpressionPtr
         var fieldName : string
@@ -1426,10 +1282,7 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
             q.selectColTypes |> clear
             q.selectColSqlFragments |> clear
             q.selectCols |> push(fieldName)
-            // Always push to the parallel arrays — single-source emits empty
-            // alias / fragment (build_sql_string + build_row_builder discriminate
-            // on emptiness, not on `q.seenJoin`, so the same machinery handles
-            // both modes uniformly).
+            // Parallel arrays always populated — emitter discriminates on emptiness, not q.seenJoin.
             q.selectColAliases |> push(source_alias_for_idx(q, srcIdx))
             q.selectColSqlFragments |> push("")
             let srcType = source_rootType_for_idx(q, srcIdx)
@@ -1438,13 +1291,7 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
             return true
         }
     }
-
-    // Named-tuple form: each value is either `<arg>.Field` (column ref) or
-    // a multi-source `is_some(arg)` / `is_none(arg)` (LEFT JOIN bool probe).
-    // `unwrap_or` and other Option<T> ops on whole-row Option<TB> are not
-    // yet supported (they require fragmenting unwrap_or's `default.Field`
-    // into per-column COALESCE — punted to follow-up work). recordNames
-    // live on the inferred tuple type's argNames.
+    // Named-tuple form: `<arg>.Field` cols or multi-source `is_some/is_none` LEFT JOIN probes.
     if (body is ExprMakeTuple) {
         var mkTup = body as ExprMakeTuple
         var tupT = mkTup._type
@@ -1458,14 +1305,10 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
             q.projRecordNames |> clear
             for (i in range(length(mkTup.values))) {
                 var val = mkTup.values[i]
-                // Peel for the `val is ExprCall` dispatch below; the
-                // qmatch column-ref branch peels independently.
                 if (val is ExprRef2Value) {
                     val = (val as ExprRef2Value).subexpr
                 }
-                // Multi-level JSON-path descent (`<arg>.Col.path…`) — runs
-                // before the single-level qmatch which only matches ExprVar
-                // receivers and would otherwise reject these.
+                // JSON-path descent — must run before single-level qmatch.
                 {
                     var jfrag : string
                     var jleaf : TypeDeclPtr
@@ -1493,24 +1336,16 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
                     }
                     q.selectCols |> push(fieldName)
                     q.projRecordNames |> push(string(tupT.argNames[i]))
-                    // Always push parallel-array entries — see SingleColumn
-                    // branch above for rationale.
                     q.selectColAliases |> push(source_alias_for_idx(q, srcIdx))
                     q.selectColSqlFragments |> push("")
                     let srcType = source_rootType_for_idx(q, srcIdx)
                     q.selectColTypes |> push(lookup_struct_field_type(srcType, fieldName))
                     continue
                 }
-                // Multi-source computed projection: is_some(arg) / is_none(arg).
-                // Recognized only when one of the lambda args is a LEFT JOIN's
-                // Option<TB> param. The result type is inferred from the AST
-                // (`val._type`) — bool for is_some/is_none.
+                // is_some / is_none on a LEFT JOIN's Option<TB> arg → bool computed projection.
                 if (q.seenJoin && val is ExprCall) {
                     var fcall = val as ExprCall
-                    // `fcall.func` may be unresolved when this projection
-                    // expression is reached pre-inference; fall back to the
-                    // textual call name (`fcall.name`) just like pred_to_sql /
-                    // fn_call_to_sql do for predicate-side calls.
+                    // fcall.func may be null pre-inference — fall back to textual name.
                     var fname = string(fcall.name)
                     if (fcall.func != null) {
                         fname = string(fcall.func.name)
@@ -1540,39 +1375,14 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
             return true
         }
     }
-
     macro_error(prog, at, "_sql: _select: supported shapes are `<arg>.Field` (single column) and `(Name=<arg>.Name, Price=<arg>.Price)` (named tuple); got: {describe(body)}")
     return false
 }
 
-// ============================================================================
-// Grouped projection analysis (_select after _group_by) — IGrouping shape.
-//
-// `_group_by` lowers to ``group_by_lazy`` which yields per-bucket tuples
-// of shape ``tuple<KeyType; array<RowType>>`` — index ``_0`` is the group
-// key, index ``_1`` is the array of group elements. The user expresses
-// SQL aggregates against that shape, and `_sql` translates the patterns
-// to GROUP BY + the corresponding SQL aggregate function:
-//
-//   _._0                                    → group key column (single-key)
-//   _._0._N                                 → multi-key Nth column
-//   _._1 |> length                                 → COUNT(*)
-//   _._1 |> count                                  → COUNT(*)
-//   _._1 |> select($(u:T) => u.X) |> sum           → SUM("X")
-//   _._1 |> select($(u:T) => u.X) |> average       → AVG("X")  (result type double)
-//   _._1 |> select($(u:T) => u.X) |> min           → MIN("X")
-//   _._1 |> select($(u:T) => u.X) |> max           → MAX("X")
-//
-// Required projection shape is a NAMED tuple literal so the result row
-// schema (column names) is explicit. The same aggregate recognition is
-// reused inside `_having` predicates by `try_translate_group_aggregate`.
-// ============================================================================
+// ===== Grouped projection analysis (_select after _group_by) =====
 
 [macro_function]
 def private group_key_column_name(q : SqlQuery; idx : int) : string {
-    //! Return the unquoted column name of the idx-th group-by key.
-    //! ``q.groupByCols[idx]`` is already SQL-quoted (e.g. ``"\"City\""``);
-    //! strip the surrounding quotes.
     let raw = q.groupByCols[idx]
     let n = length(raw)
     if (n >= 2 && raw |> starts_with("\"") && raw |> ends_with("\"")) {
@@ -1584,11 +1394,6 @@ def private group_key_column_name(q : SqlQuery; idx : int) : string {
 [macro_function]
 def private try_translate_group_aggregate(var node : ExpressionPtr; q : SqlQuery; prog : ProgramPtr; at : LineInfo;
                                           var sqlOut : string&; var typeOut : TypeDeclPtr&) : bool {
-    //! Recognize one of the IGrouping-shape SQL aggregate patterns and
-    //! fill ``sqlOut`` / ``typeOut``. Returns true on a recognized
-    //! aggregate (even on column-resolution failure — caller checks
-    //! ``empty(sqlOut)``); false if the node isn't one of the recognized
-    //! aggregate forms.
     var n = node
     if (n is ExprRef2Value) {
         n = (n as ExprRef2Value).subexpr
@@ -1605,24 +1410,14 @@ def private try_translate_group_aggregate(var node : ExpressionPtr; q : SqlQuery
         fname = string(call.func.fromGeneric.name)
     }
     let argc = user_arg_count(call)
-
-    // length(_._1) / count(_._1) → COUNT(*)
-    // Result type is `int` to match daslang's `length`/`count` return on
-    // arrays. SQLite COUNT(*) returns int64 internally but read_via_adapter
-    // narrows to int via sqlite3_column_int — fine for any plausible row
-    // count and matches the user's projection-tuple inferred type.
+    // length(_._1) / count(_._1) → COUNT(*) (narrowed to int).
     if ((fname == "length" || fname == "count") && argc == 1
             && qmatch(call.arguments[0], _._1).matched) {
         sqlOut = "COUNT(*)"
         typeOut = new TypeDecl(at = at, baseType = Type.tInt)
         return true
     }
-
-    // sum / average / min / max applied to select(_._1, $(p:T) => p.X) → SUM("X") / etc.
-    // The inner lambda's parameter name is intentionally NOT required to be
-    // `_` — daslang flags `_` shadowing across nested lambdas as a compile
-    // error (the outer lambda's `_` is the group tuple, the inner is a row),
-    // so users name the inner parameter explicitly (`$(u : User) => u.Age`).
+    // sum/average/min/max over `_._1 |> select($(p:T)=>p.X)` → SUM("X") etc.
     if ((fname == "sum" || fname == "average" || fname == "min" || fname == "max") && argc == 1) {
         var inner : ExpressionPtr = call.arguments[0]
         var innerCall = match_linq_call(inner, "select")
@@ -1633,12 +1428,7 @@ def private try_translate_group_aggregate(var node : ExpressionPtr; q : SqlQuery
                 macro_error(prog, at, "_sql: aggregate's inner select lambda has unexpected shape")
                 return true
             }
-            // Body must be `<param>.<field>` — an ExprField rooted at a
-            // single ExprVar (the lambda's parameter, whatever its name).
-            // The receiver gate is load-bearing here: without it,
-            // `$(u : User) => u.opt.X` would over-match with col="X" and
-            // emit a silently-wrong SUM("X") referring to a sibling column
-            // on the root type. Pin the receiver to ExprVar.
+            // Receiver-gate ExprVar: without it, `u.opt.X` over-matches as col="X" and emits silently-wrong SUM("X").
             var receiver : ExpressionPtr
             var col : string
             if (qmatch(lamBody, $e(receiver).$f(col)).matched
@@ -1679,8 +1469,6 @@ def private analyze_grouped_projection(var body : ExpressionPtr; var q : SqlQuer
         macro_error(prog, at, "_sql: _select after _group_by: missing projection")
         return false
     }
-    // Peel for the multi-shape `is ExprMakeTuple` dispatch — qmatch in the
-    // per-element branches below auto-peels independently.
     if (body is ExprRef2Value) {
         body = (body as ExprRef2Value).subexpr
         if (body == null) {
@@ -1706,14 +1494,7 @@ def private analyze_grouped_projection(var body : ExpressionPtr; var q : SqlQuer
     let nKeys = length(q.groupByCols)
     for (i in range(length(mkTup.values))) {
         var val = mkTup.values[i]
-        // No explicit ExprRef2Value peel here: qmatch auto-peels at every
-        // dispatch level, try_translate_group_aggregate peels its own
-        // input, and describe() unwraps the shell for diagnostic output.
-
-        // Recognized group-key projection shapes:
-        //   single-key:  `_._0`
-        //   multi-key:   `_._0._<n>`  (n = key column index)
-        // Case A: single-key `_._0` — direct group-key reference.
+        // single-key `_._0` — direct group-key reference.
         if (nKeys == 1 && qmatch(val, _._0).matched) {
             let col = group_key_column_name(q, 0)
             var fieldType = lookup_struct_field_type(q.rootType, col)
@@ -1726,7 +1507,7 @@ def private analyze_grouped_projection(var body : ExpressionPtr; var q : SqlQuer
             q.projRecordNames |> push(string(tupT.argNames[i]))
             continue
         }
-        // Case B: multi-key `_._0._<n>` — capture the trailing field name and parse the suffix.
+        // multi-key `_._0._<n>` — N-th key column.
         if (nKeys > 1) {
             var outerName : string
             if (qmatch(val, _._0.$f(outerName)).matched) {
@@ -1755,7 +1536,6 @@ def private analyze_grouped_projection(var body : ExpressionPtr; var q : SqlQuer
                 return false
             }
         }
-
         // Aggregate over the group's elements (`_._1`).
         var sqlFrag : string
         var resType : TypeDeclPtr
@@ -1775,24 +1555,10 @@ def private analyze_grouped_projection(var body : ExpressionPtr; var q : SqlQuer
     return true
 }
 
-// ============================================================================
-// Predicate analysis (_where) — recursive AST walk emitting SQL.
-//
-// Bind capture: literals and free-variable references become `?` placeholders;
-// each captured ExpressionPtr is appended to q.bindExprs in left-to-right order
-// matching the placeholder index sequence.
-//
-// Capture-leak protocol: every qmatch attempt uses fresh capture variables in
-// its own bare block so partial writes from a failed earlier attempt cannot
-// leak into a later attempt.
-// ============================================================================
+// ===== Predicate analysis (_where) =====
 
 [macro_function]
 def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; direction : string; prog : ProgramPtr; at : LineInfo) : bool {
-    //! Walk the body of an order_by lambda and push column entries onto
-    //! q.orderByCols. Accepts a single `_.Field` reference (one column) or a
-    //! tuple literal `(_.k1, _.k2)` (multi-column). All columns get the same
-    //! direction (ASC or DESC) per chunk-4 scope; mixed-direction is plan D2.
     if (body == null) {
         macro_error(prog, at, "_sql: _order_by: missing key expression")
         return false
@@ -1804,10 +1570,7 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
             return false
         }
     }
-    // Group-key form (after `_group_by`): `_._0` (single key) or `_._0._N`
-    // (multi-key Nth column). The chain element type post-group is
-    // `tuple<K; array<T>>` so plain `_.Field` no longer typechecks; users
-    // sort by the group key explicitly.
+    // Group-key form: `_._0` (single key) or `_._0._N` (multi-key).
     if (q.seenGroupBy && body is ExprField) {
         var ef = body as ExprField
         var recv = ef.value
@@ -1818,7 +1581,6 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
         let nKeys = length(q.groupByCols)
         // Single-key: `_._0` → first group-by column.
         // groupByCols stores daslang names; translate to SQL identifier here
-        // since orderByCols entries are emitted directly into ORDER BY.
         if (nKeys == 1 && recv != null && recv is ExprVar
                 && (recv as ExprVar).name == "_"
                 && outerName == "_0") {
@@ -1858,9 +1620,8 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
             return true
         }
     }
-    // Multi-column form: tuple literal `(_.k1, _.k2)`. Each entry must be
-    // a `_.Field` ref (after ExprRef2Value peel). Anonymous tuple (no
-    // recordNames) is the natural shape; named tuples also work.
+    // Multi-column form: tuple literal `(_.k1, _.k2)` — each entry independently
+    // chooses compile-time `_.Field` or runtime string column name.
     if (body is ExprMakeTuple) {
         var mkTup = body as ExprMakeTuple
         if (length(mkTup.values) == 0) {
@@ -1869,30 +1630,33 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
         }
         for (i in range(length(mkTup.values))) {
             var val = mkTup.values[i]
-            // qmatch auto-peels ExprRef2Value; describe() does the same for
-            // the diagnostic — no explicit peel needed here.
             var fieldName : string
             if (qmatch(val, _.$f(fieldName)).matched) {
                 let sqlCol = field_to_column_name(q.rootType, fieldName)
                 q.orderByCols |> push("\"{sqlCol}\" {direction}")
+            } elif (val._type != null && val._type.baseType == Type.tString) {
+                q.orderByInlineExprs |> push <| clone_expression(val)
+                q.orderByCols |> push("\x01 {direction}")
             } else {
-                macro_error(prog, at, "_sql: _order_by: tuple-key entries must be `_.Field`; got: {describe(val)}")
+                macro_error(prog, at, "_sql: _order_by: tuple-key entries must be `_.Field` or a `string` expression; got: {describe(val)}")
                 return false
             }
         }
         return true
     }
-    macro_error(prog, at, "_sql: _order_by: key must be `_.Field` or a tuple of `_.Field`s; got: {describe(body)}")
+    // Runtime form: a string-typed expression naming the column at runtime.
+    // Quoted via sql_quote_id at emission so embedded `"` is escaped safely.
+    if (body._type != null && body._type.baseType == Type.tString) {
+        q.orderByInlineExprs |> push <| clone_expression(body)
+        q.orderByCols |> push("\x01 {direction}")
+        return true
+    }
+    macro_error(prog, at, "_sql: _order_by: key must be `_.Field`, a `string` expression, or a tuple of either; got: {describe(body)}")
     return false
 }
 
 [macro_function]
 def private collect_group_keys(var body : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
-    //! Walk the body of a `_group_by` lambda and push column entries onto
-    //! ``q.groupByCols``. Accepts a single ``_.Field`` reference or a tuple
-    //! literal of ``_.Field`` references for multi-column grouping. SQL
-    //! functions in the key (e.g. ``year(_.SignupDate)``) are not yet
-    //! supported in chunk 4 — see API_REWORK § 19 / mockup section (c).
     if (body == null) {
         macro_error(prog, at, "_sql: _group_by: missing key expression")
         return false
@@ -1904,12 +1668,7 @@ def private collect_group_keys(var body : ExpressionPtr; var q : SqlQuery&; prog
             return false
         }
     }
-    // Single-column form: _.FieldName
-    //
-    // groupByCols stores DASLANG names (quoted) — `group_key_column_name`
-    // strips the quotes and feeds the daslang name to `lookup_struct_field_type`
-    // in the projection analyzer. Translation to the SQL identifier (via
-    // `field_to_column_name`) happens at build_sql_string emission, not here.
+    // Single-column form: _.FieldName. groupByCols stores DASLANG names; SQL translation deferred to emission.
     {
         var fieldName : string
         if (qmatch(body, _.$f(fieldName)).matched) {
@@ -1917,8 +1676,7 @@ def private collect_group_keys(var body : ExpressionPtr; var q : SqlQuery&; prog
             return true
         }
     }
-    // Multi-column form: tuple literal `(_.k1, _.k2)`. Both anonymous and
-    // named tuples accepted (the names don't affect SQL emission).
+    // Multi-column form: tuple literal `(_.k1, _.k2)`.
     if (body is ExprMakeTuple) {
         var mkTup = body as ExprMakeTuple
         if (length(mkTup.values) == 0) {
@@ -1927,8 +1685,6 @@ def private collect_group_keys(var body : ExpressionPtr; var q : SqlQuery&; prog
         }
         for (i in range(length(mkTup.values))) {
             var val = mkTup.values[i]
-            // qmatch auto-peels ExprRef2Value; describe() does the same for
-            // the diagnostic — no explicit peel needed here.
             var fieldName : string
             if (qmatch(val, _.$f(fieldName)).matched) {
                 q.groupByCols |> push("\"{fieldName}\"")
@@ -1945,21 +1701,16 @@ def private collect_group_keys(var body : ExpressionPtr; var q : SqlQuery&; prog
 
 [macro_function]
 def private analyze_predicate(var body : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
-    //! `body` is the predicate expression (e.g. `_.Id == 5`) extracted by
-    //! `peel_lambda_body` from the post-expansion `where_(prev, $(_:T) => body)`.
     if (body == null) {
         macro_error(prog, at, "_sql: _where: missing predicate")
         return false
     }
     let s = pred_to_sql(body, q, prog, at)
     if (q.hadError) {
-        return false   // pred_to_sql (or a deeper walker) issued a macro_error;
-                       // operator handlers wrap empty children in non-empty SQL
-                       // (e.g. `lhs = rhs` becomes `" = ?"` when lhs failed),
-                       // so the empty(s) check below is not sufficient on its own.
+        return false   // operator handlers wrap empty children (`lhs = rhs` -> `" = ?"`); empty(s) alone isn't reliable
     }
     if (empty(s)) {
-        return false   // top-level pred_to_sql returned "" without setting hadError
+        return false
     }
     if (empty(q.whereSql)) {
         q.whereSql = s
@@ -1971,14 +1722,6 @@ def private analyze_predicate(var body : ExpressionPtr; var q : SqlQuery&; prog 
 
 [macro_function]
 def private pred_fail(var q : SqlQuery&; prog : ProgramPtr; at : LineInfo; msg : string) : string {
-    //! Single failure path for `pred_to_sql` and the analyze_* helpers that
-    //! recurse through it. Sets `q.hadError` so analyze_predicate /
-    //! analyze_set_clause / analyze_upsert_set_clause / emit_update_body /
-    //! emit_delete_body can detect a macro_error from anywhere in the
-    //! recursion. Operator handlers (`==` / `+` / `&&` / etc.) wrap empty
-    //! children in non-empty SQL fragments — `lhs = rhs` becomes `" = ?"`
-    //! when only the lhs failed — so `empty(s)` at the top level isn't a
-    //! reliable failure signal on its own. Always returns "".
     q.hadError = true
     macro_error(prog, at, msg)
     return ""
@@ -1989,24 +1732,15 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
     if (node == null) {
         return pred_fail(q, prog, at, "_sql: _where: null sub-expression")
     }
-    // Peel ExprRef2Value (value-from-ref adapter that the typer inserts
-    // around field reads after Mode-2 inner expansion).
     if (node is ExprRef2Value) {
         node = (node as ExprRef2Value).subexpr
         if (node == null) {
             return pred_fail(q, prog, at, "_sql: _where: ExprRef2Value with null subexpr")
         }
     }
-
-    // Logical NOT  →  NOT (...)
-    //
-    // Special case: `_not_in` lowers to `!contains(subq, x)`; under daslang's
-    // type-inference ordering the inner `contains` call may not be resolved
-    // (call.func is null) at the time pred_to_sql recurses on it, even
-    // though `_in` (no leading `!`) is. Peek at the inner ExprCall's
-    // textual name (which is set on `ExprLooksLikeCall` even before typer
-    // overload resolution) and route to the subquery NOT IN emitter
-    // directly. Falls through to the generic `!expr` peel for other shapes.
+    // Logical NOT — special case `_not_in` (which lowers to `!contains(subq, x)`):
+    // the inner contains call may be unresolved at this point, so dispatch on
+    // textual name (ExprLooksLikeCall populates `.name` pre-typer).
     {
         var inner : ExpressionPtr
         if (qmatch(node, !$e(inner)).matched) {
@@ -2056,15 +1790,11 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             return "({pred_to_sql(lhs, q, prog, at)}) OR ({pred_to_sql(rhs, q, prog, at)})"
         }
     }
-    // Comparison ops — six shapes, each in its own scope.
+    // Comparison ops.
     {
         var lhs, rhs : ExpressionPtr
         if (qmatch(node, $e(lhs) == $e(rhs)).matched) {
-            // ``_.Col == none()`` is a common footgun: the user probably
-            // meant ``_.Col |> is_none()``. ``none()`` returns
-            // ``Option<T>``, comparing it to a column value would auto-bind
-            // a 0-byte placeholder and produce wrong results, so emit a
-            // fixit-style ``macro_error`` pointing at the right spelling.
+            // `== none()` would silently bind a 0-byte placeholder; nudge to is_some/is_none.
             if (is_none_call(lhs) || is_none_call(rhs)) {
                 return pred_fail(q, prog, at, "_sql: `_.Col == none()` is not translated. Use `_.Col |> is_none()` (or `is_some()` for the negation) — `none()` returns Option<T>, equality against it would silently bind an empty placeholder.")
             }
@@ -2104,10 +1834,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             return "{pred_to_sql(lhs, q, prog, at)} >= {pred_to_sql(rhs, q, prog, at)}"
         }
     }
-    // Arithmetic operators — SQL uses the same `+ - * / %` syntax as daslang.
-    // Used in DO UPDATE SET RHS (e.g. `Hits = _.Hits + 1`) and any other
-    // expression-position SET / projection. Parens around recursive calls keep
-    // precedence safe in the emitted SQL.
+    // Arithmetic — parens preserve precedence in emitted SQL.
     {
         var lhs, rhs : ExpressionPtr
         if (qmatch(node, $e(lhs) + $e(rhs)).matched) {
@@ -2138,15 +1865,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             return "({pred_to_sql(lhs, q, prog, at)}) % ({pred_to_sql(rhs, q, prog, at)})"
         }
     }
-
-    // Multi-level field chain — `<arg>.Col.path1.path2…`. Runs BEFORE the
-    // single-level qmatch below (which deliberately rejects `a.b.c` to avoid
-    // arg-name collisions in multi-source mode). When `Col` carries
-    // `@sql_json`, descend into the JSON storage via SQLite's `json_extract`.
-    // `@sql_blob` columns are opaque — descent is a compile error per
-    // API_REWORK §37 lock 6. Unannotated nested chains fall through (the
-    // single-level qmatch fails to match a multi-level shape, and downstream
-    // diagnostics report the unsupported access).
+    // Multi-level field chain `<arg>.Col.path…` — descends @sql_json via json_extract; @sql_blob is a compile error.
     if (node is ExprField) {
         var ef0 = node as ExprField
         var recv0 = ef0.value
@@ -2155,9 +1874,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         }
         // Need at least two ExprField levels to be a multi-level chain.
         if (recv0 != null && recv0 is ExprField) {
-            // Walk down receiver chain, collecting names outer-to-inner.
-            // Innermost ExprField name is the SQL column on the source struct;
-            // earlier names are the JSON path through nested struct/tuple fields.
+            // Walk receiver chain outer-to-inner; innermost name is the SQL column, earlier names form the JSON path.
             var chain : array<string>
             chain |> push(string(ef0.name))
             var cur : ExpressionPtr = recv0
@@ -2169,8 +1886,6 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
                     cur = (cur as ExprRef2Value).subexpr
                 }
             }
-            // Receiver must end at an ExprVar (lambda arg) for this to be a
-            // column-rooted path. Anything else falls through.
             if (cur != null && cur is ExprVar) {
                 let argName = string((cur as ExprVar).name)
                 var srcIdx = -1
@@ -2190,23 +1905,13 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
                         return pred_fail(q, prog, at, "_sql: cannot descend into @sql_blob column '{colName}'; filter in daslang after round-trip, or use raw SQL")
                     }
                     if (has_field_annotation(srcType, colName, "sql_json")) {
-                        // Reverse the outer-to-inner chain into a path that
-                        // walks from the column outward (drop the column name).
+                        // Reverse outer-to-inner chain into column-out path (drop the column name).
                         var jsonPath : array<string>
                         jsonPath |> reserve(nChain - 1)
                         for (i in range(nChain - 1)) {
                             jsonPath |> push(chain[nChain - 2 - i])
                         }
-                        // Mirror the SELECT-side guard (try_recognize_json_path_proj):
-                        // walk the daslang-side type to confirm every path segment
-                        // resolves on a struct/tuple field. Without this, typos in a
-                        // WHERE-clause JSON path silently produce SQL (e.g.
-                        // `json_extract("Prefs", '$.cuty')`) that always returns NULL
-                        // and matches nothing — daslang's typer cannot catch these
-                        // because `_where(it, expr)` returns the same array<T> as the
-                        // input, so the lambda body's type is never required to
-                        // resolve the chain (`_sql` consumes the AST before typer
-                        // would otherwise report `can't get tuple field`).
+                        // Validate every path segment — the typer never sees `_where`'s lambda body so silent NULL-on-typo is the failure mode.
                         let leaf = resolve_nested_field_type(srcType, colName, jsonPath)
                         if (leaf == null) {
                             return pred_fail(q, prog, at, "_sql: JSON path on @sql_json column '{colName}' walks into a field that isn't a struct/tuple member at depth {length(jsonPath)}")
@@ -2217,34 +1922,17 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             }
         }
     }
-
-    // Column reference: <argname>.ColName  (ExprField rooted at any lambda param).
-    // Single-source: emit unqualified `"Col"` (only `_` is bound).
-    // Multi-source: look up arg → source idx → emit `"talias"."Col"`. Unrecognized
-    // arg names in multi-source mode are a `macro_error` — they're either the
-    // group-key shape (`_._0`) handled below, or genuinely unbound (caller bug).
-    // Pin the receiver to ExprVar — `$e(recv).$f(field)` would otherwise match
-    // nested chains (`a.b.c`) and silently treat the inner field name as the
-    // arg, which can collide with a real join-arg name in multi-source mode.
+    // Column reference: <arg>.Col. Pin receiver to ExprVar so nested chains can't slip through.
     {
         var receiver : ExpressionPtr
         var fieldName : string
         if (qmatch(node, $e(receiver).$f(fieldName)).matched
                 && receiver != null && receiver is ExprVar) {
             let argName = string((receiver as ExprVar).name)
-            // Alias-qualification is driven by `rootAlias` being non-
-            // empty, NOT by `seenJoin`. The two are intentionally
-            // decoupled: the right-side subQ analyzed by
-            // `process_join_call` runs with `rootAlias = "t1"` but
-            // `seenJoin = false` so `_where` in the inner chain qualifies
-            // columns ("t1"."Col") without dragging in multi-source
-            // projection-arg-lookup semantics.
+            // Alias-qualification is driven by rootAlias != "", NOT seenJoin (right-side subQ runs with rootAlias="t1" but seenJoin=false).
             if (!empty(q.rootAlias)) {
                 var srcIdx = lookup_arg_source(q, argName)
-                // Pre-join `_where` always references the root (source 0)
-                // through `_`. The arg-binding stack is only populated
-                // for the `into` projection's named 2-arg lambda; outside
-                // that scope, treat `_` as source 0.
+                // Pre-join `_where` references root through `_` — arg-binding stack only populated inside `into` projection.
                 if (srcIdx < 0 && argName == "_") {
                     srcIdx = 0
                 }
@@ -2252,20 +1940,13 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
                     let rootT = source_rootType_for_idx(q, srcIdx)
                     return column_sql_for_alias(source_alias_for_idx(q, srcIdx), rootT, fieldName)
                 }
-                // Not bound to any source — fall through to other patterns
-                // (e.g. `_._0` group-key references which keep their own
-                // recognition path below).
+                // Not bound — fall through (e.g. `_._0` group-key handled later).
             } else {
-                // Single-source: only `_` is bound. Match the legacy emission.
+                // Single-source: only `_` is bound.
                 if (argName == "_") {
                     return column_sql_for_alias("", q.rootType, fieldName)
                 }
-                // Upsert-only sentinel: `_excluded.Col` → SQLite's
-                // ``excluded.col`` reference to the proposed row inside
-                // ON CONFLICT DO UPDATE SET. Gated on q.upsertMode so
-                // unrelated chains don't accidentally accept it. The SQL
-                // identifier is the rename-aware column name (so
-                // @sql_column = "type" emits `excluded."type"`).
+                // `_excluded.Col` inside upsertMode → SQLite's `excluded.col` (proposed-row sentinel).
                 if (q.upsertMode && argName == "_excluded") {
                     let sqlCol = field_to_column_name(q.rootType, fieldName)
                     return "excluded.\"{sqlCol}\""
@@ -2273,42 +1954,24 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             }
         }
     }
-
-    // Group-scope aggregate (IGrouping shape) in expression position —
-    // typically inside HAVING (`_._1 |> length > 5l`). The same patterns
-    // recognized by `analyze_grouped_projection`. The aggregate's SQL
-    // fragment doesn't depend on WHERE/HAVING context, so we accept it in
-    // either (SQLite will reject aggregates inside WHERE at runtime with a
-    // clear "misuse of aggregate" error). The result type is discarded
-    // here — the surrounding comparison handles type matching.
+    // Group-scope aggregate in expression position (typically HAVING).
     {
         var aggSql : string
         var aggType : TypeDeclPtr
         if (try_translate_group_aggregate(node, q, prog, at, aggSql, aggType)) {
             if (empty(aggSql)) {
-                // helper emitted macro_error; mark q.hadError so the
-                // analyzer-side checks fire even if an outer operator
-                // handler wraps this empty fragment.
                 q.hadError = true
                 return ""
             }
             return aggSql
         }
     }
-
-    // Unexpanded ExprCallMacro for `_in` / `_not_in` / `_any` / `_none`.
-    // Mode-2 expansion only recurses through call_macros and chain
-    // operators — when one of these macros lands inside a binary operator
-    // (`&&` / `||` / etc.) of a `_where` predicate, daslang doesn't deep-
-    // walk into the operator's children, so the macro stays in
-    // `ExprCallMacro` form. Recognize them here by the macro's name and
-    // emit the SQL fragment without going through expansion.
+    // Unexpanded `_in`/`_not_in`/`_any`/`_none` — Mode-2 doesn't deep-walk into operator children, so dispatch by name.
     if (node is ExprCallMacro) {
         var mcall = node as ExprCallMacro
         let mname = string(mcall.name)
         if ((mname == "_in" || mname == "_not_in") && length(mcall.arguments) == 2) {
-            // `x._in(subq)` / `x._not_in(subq)` — call_macro arg order is
-            // (element, subquery).
+            // arg order: (element, subquery)
             let xSql = pred_to_sql(mcall.arguments[0], q, prog, at)
             var binds : array<ExpressionPtr>
             let subSql = analyze_subquery(mcall.arguments[1], binds, prog, at, true)
@@ -2338,14 +2001,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             if (length(mcall.arguments) == 1) {
                 subSql = analyze_subquery(mcall.arguments[0], binds, prog, at)
             } else {
-                // Wrap the pred in a single-arg lambda manually, matching
-                // what `AstCallMacro_LinqPred2` would emit, then re-use
-                // analyze_subquery_with_pred. We don't actually have the
-                // expanded `(_:T) => pred` shape yet — but the inner
-                // analyze_predicate just walks the predicate AST, so we
-                // can pass a synthetic `ExprMakeBlock` wrapping the pred.
-                // Easier: build the subquery first, then call
-                // analyze_predicate directly on the bare pred expression.
+                // Build subquery, then run analyze_predicate on the bare pred (skips lambda wrapping).
                 var subQ = SqlQuery()
                 if (!analyze_chain(mcall.arguments[0], subQ, prog, at)) {
                     q.hadError = true   // analyze_chain emitted macro_error on subQ
@@ -2387,22 +2043,14 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             return "EXISTS ({subSql})"
         }
     }
-
-    // Function call → SQL function dispatch (table-driven entries below).
-    // Handles `_.Name |> starts_with("F")` (post-pipe-expansion: starts_with(_.Name, "F")),
-    // `length(_.Name)`, `_.Price |> abs()`, `to_lower(_.Name)`, etc.
+    // Function call → SQL function dispatch (table-driven below).
     if (node is ExprCall) {
         let sql = fn_call_to_sql(node as ExprCall, q, prog, at)
         if (!empty(sql)) {
             return sql
         }
     }
-
-    // Literal / captured var → bind param. Clone the *peeled* expression so
-    // when we re-emit it as a `sql_bind_to_stmt` argument the runtime reads the
-    // captured value cleanly (without re-wrapping into ExprRef2Value).
-    // Inside `_having`, route to havingBindExprs so the placeholder index
-    // matches the SQL emission order (WHERE → HAVING → LIMIT).
+    // Literal / captured var → bind param. Inside `_having`, route to havingBindExprs to keep placeholder order.
     if (is_const_or_captured_var(node)) {
         if (q.inHaving) {
             q.havingBindExprs |> push <| clone_expression(node)
@@ -2411,11 +2059,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         }
         return "?"
     }
-
-    // Common footgun: equality / inequality against ``none()``. After the
-    // typer rewrites ``a == b`` into ``operator==(a, b)`` we lose the
-    // qmatch-friendly binary shape, so detect the call form here and emit
-    // a fixit pointing at ``is_none()`` / ``is_some()``.
+    // Detect post-typer `operator==(a, none())` (qmatch shape is gone) — fixit for is_none/is_some.
     if (node is ExprCall) {
         let c = node as ExprCall
         let cname = string(c.name)
@@ -2431,28 +2075,13 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             }
         }
     }
-
     return pred_fail(q, prog, at, "_sql: _where: unsupported expression. Got: {describe(node)}")
 }
 
-// ============================================================================
-// SQL function dispatch — daslang call → SQL expression
-//
-// Table-driven shape: each entry maps `(daslang_name, arity)` to a SQL
-// template where ``$0`` / ``$1`` are placeholders for the recursively-
-// translated arguments. Adding a new operator is a one-row change here
-// plus a test.
-//
-// Per Appendix A of TUTORIALS.md: chunk 3 ships LIKE-pattern strings,
-// case folding, length, and abs. Chunk 4 broadens with date/time and
-// aggregates that can appear in projections.
-// ============================================================================
+// ===== SQL function dispatch (daslang call -> SQL expression) =====
 
 [macro_function]
 def private user_arg_count(call : ExprCall?) : int {
-    //! Daslang builtins (string ops, etc.) inject hidden trailing args:
-    //! ``__context__`` (ExprFakeContext), ``__line__`` (ExprFakeLineInfo).
-    //! Count only user-supplied args by stripping the trailing builtin ones.
     if (call == null) {
         return 0
     }
@@ -2472,25 +2101,6 @@ def private user_arg_count(call : ExprCall?) : int {
 [macro_function]
 def private analyze_subquery(var subqExpr : ExpressionPtr; var binds : array<ExpressionPtr>&;
                              prog : ProgramPtr; at : LineInfo; requireSingleColumn : bool = false) : string {
-    //! Recursively analyze a subquery chain (bare `select_from(type<T>)` or
-    //! `select_from(...) |> _where(...)` or `select_from(...) |> _select(_.Col)`)
-    //! and return its SQL string. Subquery WHERE binds are pushed to `binds`;
-    //! the caller appends them to outer `q.bindExprs` AT THE CALL SITE so the
-    //! placeholder index matches the SQL emission order (outer predicate's
-    //! own pred_to_sql may have already appended binds before us, and the
-    //! subquery's binds must come after).
-    //!
-    //! Reject subqueries that are correlated, grouped, ordered, distinct, or
-    //! have terminals — chunk-5 ships uncorrelated, single-source subqueries
-    //! only. Correlated subqueries (referring to outer columns inside the
-    //! subquery's WHERE) are deferred.
-    //!
-    //! `requireSingleColumn` is set by `_in` / `_not_in` callsites: SQLite
-    //! requires the inner SELECT to project exactly one column for `x IN (...)`,
-    //! and emits a runtime "sub-select returns N columns" error otherwise. We
-    //! reject at compile time so users see a `_sql` diagnostic instead of a
-    //! runtime panic. `_any` / `_none` use `EXISTS (...)` and don't care about
-    //! projection arity, so they leave `requireSingleColumn` at false.
     var subQ = SqlQuery()
     if (!analyze_chain(subqExpr, subQ, prog, at)) {
         return ""
@@ -2531,10 +2141,6 @@ def private analyze_subquery(var subqExpr : ExpressionPtr; var binds : array<Exp
 def private analyze_subquery_with_pred(var subqExpr : ExpressionPtr; var predLambda : ExpressionPtr;
                                        var binds : array<ExpressionPtr>&;
                                        prog : ProgramPtr; at : LineInfo) : string {
-    //! Like `analyze_subquery`, but injects an additional WHERE clause from
-    //! the predicate lambda body. Used for `any(subq, predLambda)` and
-    //! `none(subq, predLambda)`. The lambda's arg is bound to the subquery's
-    //! row (`_` always refers to source 0 of the subquery).
     var subQ = SqlQuery()
     if (!analyze_chain(subqExpr, subQ, prog, at)) {
         return ""
@@ -2577,18 +2183,6 @@ def private analyze_subquery_with_pred(var subqExpr : ExpressionPtr; var predLam
 
 [macro_function]
 def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : string {
-    //! Returns the SQL expression text for a recognized function call,
-    //! or "" if the call name isn't in the dispatch table (caller falls
-    //! through to literal/captured-var bind).
-    //!
-    //! Resolves the function name from `call.name` (the `ExprLooksLikeCall`
-    //! textual name, always set even before typer overload resolution) and
-    //! prefers the more-specific `call.func.fromGeneric.name` /
-    //! `call.func.name` when those are available. Using `call.name` as the
-    //! fallback lets us recognize calls whose overload hasn't been resolved
-    //! yet by the inferer — happens for `contains(...)` nested inside `&&`
-    //! / `!` predicates, where daslang fires the macro_function before the
-    //! inner call's typer pass completes.
     if (call == null) {
         return ""
     }
@@ -2602,7 +2196,6 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
         fname = string(call.name)
     }
     let argc = user_arg_count(call)
-
     // ---- String predicates: LIKE patterns ----
     if (fname == "starts_with" && argc == 2) {
         let lhs = pred_to_sql(call.arguments[0], q, prog, at)
@@ -2615,22 +2208,16 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
         return "{lhs} LIKE '%' || {rhs}"
     }
     if (fname == "contains" && argc == 2) {
-        // Two `contains` overloads land here:
-        //   - string `contains(haystack, needle)` → LIKE pattern (chunk 3)
-        //   - array/iterator `contains(subquery, x)` → IN subquery
-        //     (chunk 5, post-expansion of `x._in(subq)`)
-        // Disambiguate by the first arg's type: iterator/array routes to
-        // the subquery handler below; string falls through here.
+        // String contains → LIKE; iterator/array contains → IN subquery (handled below).
         var firstT = call.arguments[0]._type
         if (firstT != null && (firstT.isIterator || firstT.isGoodArrayType)) {
-            // Fall through to the subquery `contains` branch below.
+            // Fall through to subquery branch.
         } else {
             let lhs = pred_to_sql(call.arguments[0], q, prog, at)
             let rhs = pred_to_sql(call.arguments[1], q, prog, at)
             return "{lhs} LIKE '%' || {rhs} || '%'"
         }
     }
-
     // ---- Case folding ----
     if (fname == "to_lower" && argc == 1) {
         let inner = pred_to_sql(call.arguments[0], q, prog, at)
@@ -2640,31 +2227,18 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
         let inner = pred_to_sql(call.arguments[0], q, prog, at)
         return "UPPER({inner})"
     }
-
     // ---- String length ----
     if (fname == "length" && argc == 1) {
         let inner = pred_to_sql(call.arguments[0], q, prog, at)
         return "LENGTH({inner})"
     }
-
     // ---- Numeric scalar ----
     if (fname == "abs" && argc == 1) {
         let inner = pred_to_sql(call.arguments[0], q, prog, at)
         return "ABS({inner})"
     }
-
-    // ---- Option<T> nullability ----
-    // `_.Col |> is_some()` / `_.Col |> is_none()` translate to SQL's
-    // explicit null-check operators. Always use IS NULL / IS NOT NULL —
-    // `Col = NULL` is never true under SQL's three-valued logic, so the
-    // typesafe path here is also the semantically correct one.
-    //
-    // Special case for `_left_join`: when the arg is a bare `ExprVar`
-    // referring to the join's `Option<TB>` parameter (source idx > 0),
-    // probe the join's right-key column for NULL-ness — the row missed
-    // its match exactly when that column came back NULL. Without this
-    // case, pred_to_sql would treat the bare arg as a captured var and
-    // bind it as `?`, producing semantically wrong SQL.
+    // ---- Option<T> nullability (IS NULL / IS NOT NULL) ----
+    // _left_join special case: a bare ExprVar referring to the Option<TB> arg probes the right-key column for NULL.
     if (fname == "is_some" && argc == 1) {
         var argName : string
         let nullProbe = try_left_join_null_probe(call.arguments[0], q, argName, true)
@@ -2691,13 +2265,9 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
         let dflt  = pred_to_sql(call.arguments[1], q, prog, at)
         return "COALESCE({inner}, {dflt})"
     }
-
     // ---- Subqueries ----
     // `x._in(subquery)` post-expansion: `contains(subquery, x)`.
-    // `x._not_in(subquery)` post-expansion: `!contains(subquery, x)` —
-    // the leading `!` is handled by pred_to_sql's existing NOT peel
-    // before this function fires, recursing into `contains(...)` here.
-    // Subquery rules and rejections live in `analyze_subquery`.
+    // `x._not_in(subq)` post-expansion: `!contains(subq, x)` — leading `!` peeled by pred_to_sql.
     if (fname == "contains" && argc == 2) {
         let xSql = pred_to_sql(call.arguments[1], q, prog, at)
         var binds : array<ExpressionPtr>
@@ -2715,10 +2285,7 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
         }
         return "{xSql} IN ({subSql})"
     }
-
-    // `subquery._any()` post-expansion: `any(subquery)` — emits `EXISTS (...)`.
-    // `subquery._any(pred)` post-expansion: `any(subquery, $(_:T) => pred)`
-    //   — emits `EXISTS (... WHERE pred)`.
+    // `_any` → EXISTS (...), `_any(pred)` → EXISTS (... WHERE pred).
     if (fname == "any") {
         if (argc == 1) {
             var binds : array<ExpressionPtr>
@@ -2784,17 +2351,11 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
             return "NOT EXISTS ({subSql})"
         }
     }
-
     return ""
 }
 
 [macro_function]
 def private is_none_call(node : ExpressionPtr) : bool {
-    //! Detect ``none()`` (or ``none(type<T>)``) so the equality walker can
-    //! emit a fixit error pointing at ``is_none()``. ``none`` lives in
-    //! daslib/option; once the typer reifies the template the call's name
-    //! becomes a mangled form like ``_::`template`0x…`option`none`…``, so
-    //! we substring-match instead of exact-equality.
     if (node == null) {
         return false
     }
@@ -2819,14 +2380,6 @@ def private is_none_call(node : ExpressionPtr) : bool {
 
 [macro_function]
 def private is_const_literal(var node : ExpressionPtr) : bool {
-    //! True iff `node` is a literal constant expression that can be inlined
-    //! directly into SQL text (used by `_create_view` since CREATE VIEW does
-    //! not accept `?` placeholders). Peels through ExprRef2Value the same
-    //! way `is_const_or_captured_var` does. Captured-variable reads
-    //! (`ExprVar`) are deliberately rejected here — they would need to bind
-    //! at runtime, which CREATE VIEW cannot do. Enum and bitfield constants
-    //! are accepted: their underlying integer value is emitted into the SQL,
-    //! matching the wire shape SQLite stores for the column.
     if (node == null) {
         return false
     }
@@ -2844,9 +2397,6 @@ def private is_const_literal(var node : ExpressionPtr) : bool {
 
 [macro_function]
 def private format_const_as_sql_literal(var node : ExpressionPtr) : string {
-    //! Render a literal AST node as a SQLite SQL literal token. Caller has
-    //! already validated via `is_const_literal`. String values escape `'`
-    //! by doubling, matching SQLite's quoted-string syntax.
     if (node is ExprRef2Value) {
         node = (node as ExprRef2Value).subexpr
     }
@@ -2890,9 +2440,7 @@ def private format_const_as_sql_literal(var node : ExpressionPtr) : string {
         return "'{doubled}'"
     }
     if (node is ExprConstEnumeration) {
-        // Emit the underlying integer value so the comparison matches the
-        // INTEGER cell SQLite stores for the column. The enum's name string
-        // (`MyEnum.Value`) means nothing to SQLite.
+        // Emit underlying integer (matches SQLite's INTEGER cell, name string is meaningless).
         let c = node as ExprConstEnumeration
         let value = find_enum_value(unsafe(reinterpret<EnumerationPtr> c._type.enumType), string(c.value))
         return "{value}"
@@ -2905,12 +2453,15 @@ def private format_const_as_sql_literal(var node : ExpressionPtr) : string {
 
 [macro_function]
 def private next_bind_placeholder(sql : string) : int {
-    //! Find the next `?` placeholder in `sql`, skipping any `?` that lives
-    //! inside a single-quoted SQL string literal (e.g. JSON-path arguments
-    //! `'$.foo.bar'`). Doubled single quotes (`''`) are treated as escapes
-    //! and stay inside the quoted region. Returns -1 if no placeholder is
-    //! found.
-    var found = -1
+    return next_placeholder(sql)._0
+}
+
+// Walks the SQL string honoring single-quote literals; returns (position, marker).
+// Markers: '?' = bind, '\x01' = runtime inline_id (column name supplied at runtime).
+[macro_function]
+def private next_placeholder(sql : string) : tuple<int; uint8> {
+    var found_pos = -1
+    var found_ch = uint8(0)
     peek_data(sql) $(bytes) {
         let n = length(bytes)
         var i = 0
@@ -2926,26 +2477,19 @@ def private next_bind_placeholder(sql : string) : int {
                 i += 1
                 continue
             }
-            if (!in_quote && ch == uint8('?')) {
-                found = i
+            if (!in_quote && (ch == uint8('?') || ch == uint8(0x01))) {
+                found_pos = i
+                found_ch = ch
                 return
             }
             i += 1
         }
     }
-    return found
+    return (found_pos, found_ch)
 }
 
 [macro_function]
 def private inline_binds_into_sql(sql : string; var ordered_binds : array<ExpressionPtr>) : string {
-    //! Walk `sql` left-to-right replacing each `?` placeholder with the
-    //! formatted SQL literal of the corresponding bind expression. Caller
-    //! must have validated all binds with `is_const_literal` first.
-    //!
-    //! `build_sql_string` can emit single-quoted SQL string literals — for
-    //! example JSON-path arguments like `'$.foo.bar'` from `@sql_json`
-    //! columns — so the substitution skips any `?` that appears inside a
-    //! quoted string (and treats `''` as an in-quote escape).
     var rest = sql
     return build_string() $(var w) {
         for (i in range(length(ordered_binds))) {
@@ -2965,10 +2509,6 @@ def private inline_binds_into_sql(sql : string; var ordered_binds : array<Expres
 
 [macro_function]
 def private is_const_or_captured_var(var node : ExpressionPtr) : bool {
-    //! Recognize a literal or a captured-var read so the predicate walker can
-    //! emit a `?` placeholder + bind. After Mode-2 inner expansion captured
-    //! local-var reads can arrive wrapped in `ExprRef2Value` (the read-from-ref
-    //! adapter); peel through it before classifying.
     if (node == null) {
         return false
     }
@@ -2986,8 +2526,7 @@ def private is_const_or_captured_var(var node : ExpressionPtr) : bool {
     }
     if (node is ExprVar) {
         let v = node as ExprVar
-        // The lambda parameter `_` is not a captured var; it's the row.
-        return v.name != "_"
+        return v.name != "_"   // `_` is the row, not a captured var
     }
     return false
 }
@@ -3006,19 +2545,11 @@ def private fill_default_columns(var q : SqlQuery&; rootT : TypeDeclPtr; prog : 
 
 [macro_function]
 def private sql_table_name_from_type(rootT : TypeDeclPtr) : string {
-    // At macro-expansion time we cannot directly call the user's
-    // _::_sql_table_name helper because it lives in the user's module, not in
-    // sqlite_linq's macro context. Instead, derive the table-or-view name
-    // here from the struct metadata: read `[sql_table(name="...")]` or
-    // `[sql_view(name="...")]` (whichever is present), else fall back to
-    // the struct name.
+    // Read [sql_table]/[sql_view] name from struct metadata directly — we can't reach the user's _::_sql_table_name from this module's macro context.
     if (rootT == null || rootT.structType == null) {
         return ""
     }
     var st = rootT.structType
-    // [sql_table] / [sql_view] cannot appear twice on the same struct
-    // (daslang rejects duplicate annotations), and a struct shouldn't carry
-    // both — but if it did, the first one wins.
     for (annDecl in st.annotations) {
         if (annDecl.annotation.name == "sql_table" || annDecl.annotation.name == "sql_view") {
             for (arg in annDecl.arguments) {
@@ -3034,10 +2565,6 @@ def private sql_table_name_from_type(rootT : TypeDeclPtr) : string {
 
 [macro_function]
 def private is_view_type(rootT : TypeDeclPtr) : bool {
-    //! True iff `rootT` is a struct value carrying a `[sql_view]`
-    //! annotation. Used by mutation macros (`_sql_update` / `_sql_delete`
-    //! / `_sql_upsert` and their try/returning variants) to reject the
-    //! user before they hit a runtime panic from the per-struct stubs.
     if (rootT == null || rootT.structType == null) {
         return false
     }
@@ -3050,9 +2577,7 @@ def private is_view_type(rootT : TypeDeclPtr) : bool {
     return false
 }
 
-// ============================================================================
-// SQL string assembly
-// ============================================================================
+// ===== SQL string assembly =====
 
 [macro_function]
 def private build_sql_string(var q : SqlQuery&) : string {
@@ -3081,8 +2606,7 @@ def private build_sql_select(var q : SqlQuery&) : string {
         if (q.proj == ProjectionShape.Aggregate) {
             w |> write(q.aggregateExpr)
         } elif (q.proj == ProjectionShape.GroupedNamedTuple) {
-            // Already-formatted SQL fragments (e.g. `"City"`, `COUNT(*)`,
-            // `AVG("Age")`); emit verbatim, no extra quoting.
+            // Pre-formatted SQL fragments — emit verbatim.
             for (i in range(length(q.groupedSelectExprs))) {
                 if (i > 0) {
                     w |> write(", ")
@@ -3094,23 +2618,7 @@ def private build_sql_select(var q : SqlQuery&) : string {
                 if (i > 0) {
                     w |> write(", ")
                 }
-                // Discriminator-on-emptiness (NOT on `q.seenJoin`): a
-                // non-empty SQL fragment wins (precomputed `IS NOT NULL`
-                // probes from is_some / is_none, or `json_extract(...)` from
-                // single-source JSON-path projections); else a non-empty
-                // alias produces `"alias"."Col"`; else fall through to the
-                // unqualified single-source `"Col"`. Same machinery for
-                // single-source and multi-source — both populate the parallel
-                // arrays uniformly.
-                //
-                // `q.selectCols[i]` holds the DASLANG field name (used by
-                // downstream type lookups via lookup_struct_field_type which
-                // matches on `field.name`). At SQL emission, translate to the
-                // SQL column name via `@sql_column` (multi-source case routes
-                // through the per-column owning source's rootType — held in
-                // `q.selectColTypes[i]`'s containing struct, but we only have
-                // the leaf type here, so for multi-source we look up via
-                // q.rootType / each join's rootType from the alias).
+                // Emit precedence: SQL fragment > aliased col > unqualified col. Discriminator is array-emptiness, not q.seenJoin.
                 if (i < length(q.selectColSqlFragments) && !empty(q.selectColSqlFragments[i])) {
                     w |> write(q.selectColSqlFragments[i])
                 } elif (i < length(q.selectColAliases) && !empty(q.selectColAliases[i])) {
@@ -3130,8 +2638,7 @@ def private build_sql_select(var q : SqlQuery&) : string {
             }
         }
         // FROM clause: alias the root table only when joins are present.
-        // Single-source mode keeps the existing unaliased `FROM "Tbl"` shape
-        // so all chunk-2/3/4 tests still match.
+        // Single-source mode keeps the unaliased `FROM "Tbl"` shape.
         if (q.seenJoin) {
             w |> write(" FROM \"")
             w |> write(q.tableName)
@@ -3150,10 +2657,7 @@ def private build_sql_select(var q : SqlQuery&) : string {
                 w |> write("\" ON \"")
                 w |> write(j.leftAlias)
                 w |> write("\".\"")
-                // leftCol/rightCol are daslang field names; translate via
-                // @sql_column on each side's owning struct. Left side's owner
-                // is the source whose alias is `j.leftAlias` (root or an
-                // earlier join); right side's owner is `j.rootType`.
+                // Translate daslang names via @sql_column on each side's owning struct.
                 let leftOwnerT = source_rootType_for_alias(q, j.leftAlias)
                 w |> write(field_to_column_name(leftOwnerT, j.leftCol))
                 w |> write("\" = \"")
@@ -3161,11 +2665,7 @@ def private build_sql_select(var q : SqlQuery&) : string {
                 w |> write("\".\"")
                 w |> write(field_to_column_name(j.rootType, j.rightCol))
                 w |> write("\"")
-                // Right-side `_where` lives in the JOIN's ON clause (NOT the
-                // outer WHERE). Required for LEFT JOIN — a row-level filter
-                // in WHERE drops NULL-extended unmatched rows and silently
-                // turns LEFT JOIN into INNER JOIN. INNER JOIN uses the same
-                // placement for consistency / planner stability.
+                // Right-side _where in ON clause (LEFT JOIN: row-level WHERE filter would drop unmatched rows).
                 if (!empty(j.rightWhereSql)) {
                     w |> write(" AND (")
                     w |> write(j.rightWhereSql)
@@ -3177,20 +2677,11 @@ def private build_sql_select(var q : SqlQuery&) : string {
             w |> write(q.tableName)
             w |> write("\"")
         }
-        // Outer WHERE only — right-side `_where` is now in the ON clause
-        // above. The outer WHERE applies to the joined result and may
-        // legally reference any source's columns (`is_some(o)`-style probes
-        // for LEFT JOIN, qualified column refs, etc.).
         if (!empty(q.whereSql)) {
             w |> write(" WHERE ")
             w |> write(q.whereSql)
         }
-        // GROUP BY / HAVING come between WHERE and ORDER BY in SQL clause
-        // order. groupByCols entries hold daslang field names (`"col_type"`)
-        // — `group_key_column_name` strips the quotes for projection-side
-        // type lookups via `lookup_struct_field_type` which matches on
-        // `field.name`. Translate to the SQL identifier (post-`@sql_column`)
-        // here at emission so the daslang-name invariant holds upstream.
+        // groupByCols hold daslang field names (quoted); translate to SQL identifier here.
         if (length(q.groupByCols) > 0) {
             w |> write(" GROUP BY ")
             for (i in range(length(q.groupByCols))) {
@@ -3217,12 +2708,7 @@ def private build_sql_select(var q : SqlQuery&) : string {
                 w |> write(q.orderByCols[i])
             }
         }
-        // LIMIT / OFFSET. Single-row terminals (One/OneOpt) force LIMIT 1
-        // regardless of any user-supplied _take() — except aggregates, which
-        // intrinsically return one row (LIMIT 1 would be redundant noise on
-        // SELECT COUNT/SUM/AVG/MIN/MAX). User _take wins only when the
-        // materializer is Array. SQLite requires LIMIT to precede OFFSET,
-        // and OFFSET without LIMIT needs LIMIT -1 (= no upper bound).
+        // LIMIT/OFFSET. One/OneOpt force LIMIT 1 (skip for Aggregate — intrinsically 1-row). OFFSET-only needs LIMIT -1.
         let forced_one_row = ((q.matr == Materializer.One || q.matr == Materializer.OneOpt)
                               && q.proj != ProjectionShape.Aggregate)
         if (forced_one_row) {
@@ -3238,18 +2724,8 @@ def private build_sql_select(var q : SqlQuery&) : string {
     }
 }
 
-// ============================================================================
-// _sql_text — emit the compiled SQL string at the call site.
-// ============================================================================
-
 [call_macro(name="_sql_text")]
 class private SqlTextMacro : AstCallMacro {
-    //! _sql_text(chain) -> string. Returns the SQL that _sql(chain) would emit,
-    //! with `?` placeholders for binds. Used for testing the macro's output.
-    //!
-    //! Default `canVisitArgument=true` → daslang expands inner call_macros
-    //! (`_where`, `_select`, user wrappers like `when_its_cold`) bottom-up
-    //! before this fires. We then pattern-match the post-expansion shape.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         macro_verify(call.arguments |> length == 1, prog, call.at, "_sql_text expects one argument: a chain expression")
         var argT = call.arguments[0]._type
@@ -3260,38 +2736,24 @@ class private SqlTextMacro : AstCallMacro {
             return null
         }
         let sql = build_sql_string(q)
-        var res = qmacro($v(sql))
-        res.force_at(call.at)
-        return res
+        var noBinds : array<ExpressionPtr>
+        var frags : array<SqlFrag>
+        sql_to_frags_ex(sql, noBinds, q.orderByInlineExprs, frags)
+        var sqlExpr : ExpressionPtr
+        var bindExprs : array<ExpressionPtr>
+        fold_to_builder(frags, call.at, sqlExpr, bindExprs)
+        sqlExpr.force_at(call.at)
+        return sqlExpr
     }
 }
 
-// ============================================================================
-// _create_view — emit a CREATE VIEW statement from a `[sql_view]` struct +
-// a SELECT chain. The chain is the same shape `_sql` accepts (single-source
-// or joined; FullRow / NamedTuple / GroupedNamedTuple / SingleColumn / Aggregate).
-//
-// Validation rules:
-//   - Arg 1 must be `type<V>` where V carries `[sql_view]`.
-//   - Projection column count must match V's field count.
-//   - Per-column type must match V's field type (compared via `describe()`).
-//   - The chain must NOT use bound parameters (literal values only — SQLite
-//     rejects `?` placeholders inside CREATE VIEW … AS SELECT).
-//   - `_to_array()` is rejected as redundant (views are by definition arrays
-//     of rows).
-//
-// SQL emission uses the `CREATE VIEW name(col1, col2, …) AS SELECT …` form so
-// V's field names define the view's column names regardless of whether the
-// user used record-name aliasing in `_select` (`(Foo=_.Bar)`) — the user is
-// trusted to set field names per their public-facing schema.
-// ============================================================================
+// ===== _create_view =====
 
 [call_macro(name="_create_view")]
 class private SqlCreateViewMacro : AstCallMacro {
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         macro_verify(call.arguments |> length == 3, prog, call.at,
             "_create_view expects (db, type<V>, chain) — got {length(call.arguments)} args")
-
         var viewT : TypeDeclPtr
         var typeE = call.arguments[1]
         if (!qmatch(typeE, type<$t(viewT)>).matched) {
@@ -3307,7 +2769,6 @@ class private SqlCreateViewMacro : AstCallMacro {
                 "_create_view: type<V> must carry [sql_view] — got '{viewT.structType.name}' without [sql_view]. Add `[sql_view(name=\"…\")]` to the struct.")
             return null
         }
-
         // View name from `[sql_view(name="…")]`, fallback to struct name.
         var view_name = string(viewT.structType.name)
         for (annDecl in viewT.structType.annotations) {
@@ -3320,7 +2781,6 @@ class private SqlCreateViewMacro : AstCallMacro {
                 break
             }
         }
-
         // Analyze the SELECT chain.
         var argChainT = call.arguments[2]._type
         macro_verify(argChainT != null, prog, call.at, "_create_view: chain argument is not inferred yet")
@@ -3329,17 +2789,16 @@ class private SqlCreateViewMacro : AstCallMacro {
         if (!analyze_chain(call.arguments[2], q, prog, call.at)) {
             return null
         }
-
         if (q.seenToArray) {
             macro_error(prog, call.at, "_create_view: chain ends in `_to_array()` — views are by definition arrays of rows; drop the `_to_array()` terminal.")
             return null
         }
-
-        // Collect every bind expression in the same order build_sql_string lays
-        // out `?` placeholders: per-join ON binds (in join order) → outer WHERE
-        // → HAVING → LIMIT → OFFSET. CREATE VIEW … AS SELECT does not accept
-        // `?` placeholders, so each bind must be a literal constant we can
-        // inline; captured-variable references are rejected with a clear error.
+        // CREATE VIEW DDL is run once; baking a runtime column name at view-creation time is surprising. Reject.
+        if (length(q.orderByInlineExprs) > 0) {
+            macro_error(prog, call.at, "_create_view: `_order_by(<runtime string>)` not supported — the runtime column name would be baked in at CREATE VIEW time. Use a compile-time `_.Field` ordering inside the view, or build a chain with `_sql(...)` outside.")
+            return null
+        }
+        // Collect binds in placeholder order (joins ON → WHERE → HAVING → LIMIT → OFFSET); each must be inlinable since CREATE VIEW rejects `?`.
         var n_join_binds = 0
         for (j in q.joins) {
             n_join_binds += length(j.rightOnBindExprs)
@@ -3371,7 +2830,6 @@ class private SqlCreateViewMacro : AstCallMacro {
                 return null
             }
         }
-
         // Validate projection column count vs V's fields.
         let nFields = length(viewT.structType.fields)
         var nProj = 0
@@ -3386,7 +2844,6 @@ class private SqlCreateViewMacro : AstCallMacro {
             macro_error(prog, call.at, "_create_view: column count mismatch — projection has {nProj} columns, [sql_view] '{viewT.structType.name}' has {nFields} fields")
             return null
         }
-
         // Per-position type check via describe().
         for (i in range(nFields)) {
             var projType : TypeDeclPtr
@@ -3414,7 +2871,6 @@ class private SqlCreateViewMacro : AstCallMacro {
                 return null
             }
         }
-
         // Build the column-name list using V's @sql_column-renamed names.
         let col_list = build_string() $(var w) {
             for (i in range(nFields)) {
@@ -3431,35 +2887,90 @@ class private SqlCreateViewMacro : AstCallMacro {
                 w |> write("\"")
             }
         }
-
         let select_sql_with_placeholders = build_sql_string(q)
         let select_sql = inline_binds_into_sql(select_sql_with_placeholders, ordered_binds)
         let create_sql = "CREATE VIEW \"{view_name}\"({col_list}) AS {select_sql}"
-
+        // create_sql has all binds inlined (CREATE VIEW rejects `?`); fold to builder for AOT-uniformity.
+        var noBinds : array<ExpressionPtr>
+        var frags : array<SqlFrag>
+        sql_to_frags(create_sql, noBinds, frags)
+        var sqlExpr : ExpressionPtr
+        var bindExprs : array<ExpressionPtr>
+        fold_to_builder(frags, call.at, sqlExpr, bindExprs)
         // Use the user's outer db argument (call.arguments[0]) — pipe-rewrite
         // turns `db |> _create_view(...)` into `_create_view(db, ...)`, so
         // arg 0 is exactly what the user wrote.
         var dbExpr = clone_expression(call.arguments[0])
-        var res = qmacro(_::exec($e(dbExpr), $v(create_sql)))
+        var res = qmacro(_::exec($e(dbExpr), $e(sqlExpr)))
         res.force_at(call.at)
         return res
     }
 }
 
-// ============================================================================
-// _sql — emit the runtime materialization at the call site.
-//
-// The framework switches on (q.matr, q.proj):
-//   - Materializer.Array  → _::run_select(...)            returns array<T>
-//   - Materializer.One    → _::run_select_one(...)        returns T
-//   - Materializer.OneOpt → _::run_select_one_opt(...)    returns Option<T>
-//
-// The row-builder block is determined by q.proj:
-//   - FullRow      → _::_sql_read_row(stmt, type<T>)
-//   - SingleColumn → read_via_adapter(stmt, 0, type<FieldType>)
-//   - NamedTuple   → tuple row builder for the projected fields
-//   - Aggregate    → read_via_adapter(stmt, 0, type<aggregateType>)
-// ============================================================================
+// ===== _sql_pragma / _sql_vacuum_into =====
+
+[macro_function]
+def private emit_pragma_or_vacuum(prog : ProgramPtr; var call : ExprCallMacro?;
+                                  isPragma : bool) : ExpressionPtr {
+    let macroName = isPragma ? "_sql_pragma" : "_sql_vacuum_into"
+    let argCount = isPragma ? 3 : 2
+    let argShape = isPragma ? "(db, name : string, value : string)" : "(db, path : string)"
+    if (call.arguments |> length != argCount) {
+        macro_error(prog, call.at, "{macroName} expects {argCount} args {argShape} — got {length(call.arguments)}")
+        return null
+    }
+    if (isPragma) {
+        let nameT = call.arguments[1]._type
+        let valueT = call.arguments[2]._type
+        if (nameT == null || nameT.baseType != Type.tString) {
+            macro_error(prog, call.at, "_sql_pragma: name must be `string` — got '{describe(nameT)}'")
+            return null
+        }
+        if (valueT == null || valueT.baseType != Type.tString) {
+            macro_error(prog, call.at, "_sql_pragma: value must be `string` — for int / bool pragmas use `try_set_pragma` (or `set_pragma`)")
+            return null
+        }
+    } else {
+        let pathT = call.arguments[1]._type
+        if (pathT == null || pathT.baseType != Type.tString) {
+            macro_error(prog, call.at, "_sql_vacuum_into: path must be `string` — got '{describe(pathT)}'")
+            return null
+        }
+    }
+    var frags : array<SqlFrag>
+    if (isPragma) {
+        frags |> push_text("PRAGMA ")
+        frags |> push_inline_id(clone_expression(call.arguments[1]))
+        frags |> push_text(" = ")
+        frags |> push_inline_lit(clone_expression(call.arguments[2]))
+    } else {
+        frags |> push_text("VACUUM INTO ")
+        frags |> push_inline_lit(clone_expression(call.arguments[1]))
+    }
+    var sqlExpr : ExpressionPtr
+    var bindExprs : array<ExpressionPtr>
+    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
+    var dbExpr = clone_expression(call.arguments[0])
+    var res = qmacro(_::try_exec($e(dbExpr), $e(sqlExpr)))
+    res.force_at(call.at)
+    return res
+}
+
+[call_macro(name="_sql_pragma")]
+class private SqlPragmaMacro : AstCallMacro {
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        return emit_pragma_or_vacuum(prog, call, true)
+    }
+}
+
+[call_macro(name="_sql_vacuum_into")]
+class private SqlVacuumIntoMacro : AstCallMacro {
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        return emit_pragma_or_vacuum(prog, call, false)
+    }
+}
+
+// ===== _sql runtime materialization =====
 
 [macro_function]
 def private lookup_struct_field_type(rootT : TypeDeclPtr; fieldName : string) : TypeDeclPtr {
@@ -3477,10 +2988,6 @@ def private lookup_struct_field_type(rootT : TypeDeclPtr; fieldName : string) : 
 
 [macro_function]
 def private has_field_annotation(rootT : TypeDeclPtr; fieldName : string; annoName : string) : bool {
-    //! True iff the named field on `rootT`'s struct carries `@<annoName>` set
-    //! to true. Used by the JSON-path descent recognizer to gate `_.Col.path…`
-    //! chains on `@sql_json` (descend) vs `@sql_blob` (compile error per
-    //! API_REWORK §37 lock 6).
     if (rootT == null || rootT.structType == null) {
         return false
     }
@@ -3497,11 +3004,6 @@ def private has_field_annotation(rootT : TypeDeclPtr; fieldName : string; annoNa
 [macro_function]
 def private find_field_annotation_string(rootT : TypeDeclPtr; fieldName : string;
                                          annoName : string; defaultV : string) : string {
-    //! Sibling of `has_field_annotation` for string-valued field annotations
-    //! like `@sql_column = "type"`. Returns the annotation's string value or
-    //! `defaultV` when absent / non-string. The validation layer in
-    //! `[sql_table]` rejects empty strings before this helper is reached at
-    //! `_sql` analysis time, so a present-but-empty value never surfaces here.
     if (rootT == null || rootT.structType == null) {
         return defaultV
     }
@@ -3520,25 +3022,11 @@ def private find_field_annotation_string(rootT : TypeDeclPtr; fieldName : string
 
 [macro_function]
 def private field_to_column_name(rootT : TypeDeclPtr; fieldName : string) : string {
-    //! Translate a daslang-side field name to its SQL column name. Reads the
-    //! `@sql_column = "<sql_name>"` field annotation; falls back to
-    //! `fieldName` when the field has no rename. Every site in `_sql`'s
-    //! walker that emits a SQL identifier from a daslang field reference
-    //! routes through this helper so renames are transparent end-to-end —
-    //! `[sql_index(fields=…)]` / `@sql_references` / projection / predicate /
-    //! _order_by / _group_by / upsert all stay in daslang-name terms in user
-    //! code and translate at SQL emission.
     return find_field_annotation_string(rootT, fieldName, "sql_column", fieldName)
 }
 
 [macro_function]
 def private resolve_nested_field_type(rootT : TypeDeclPtr; colName : string; jsonPath : array<string>) : TypeDeclPtr {
-    //! Walk `jsonPath` (outer-to-inner) starting from the daslang type of the
-    //! `@sql_json` column `colName` on `rootT`. At each step, descend into a
-    //! struct field (matched by name) or a tuple slot (matched against
-    //! `argNames` for named tuples). Returns the leaf scalar type used by
-    //! `read_via_adapter<T>` to materialize the projected value, or null when
-    //! any step can't be resolved (caller emits a macro_error).
     var cur = lookup_struct_field_type(rootT, colName)
     if (cur == null) {
         return null
@@ -3580,8 +3068,6 @@ def private resolve_nested_field_type(rootT : TypeDeclPtr; colName : string; jso
 
 [macro_function]
 def private build_row_builder(var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : ExpressionPtr {
-    //! Build the per-row materialization expression based on q.proj.
-    //! Returns null on error (macro_error already emitted).
     if (q.proj == ProjectionShape.Aggregate) {
         let colIdx = 0
         var aggT = clone_type(q.aggregateType)
@@ -3589,11 +3075,6 @@ def private build_row_builder(var q : SqlQuery&; prog : ProgramPtr; at : LineInf
     }
     if (q.proj == ProjectionShape.SingleColumn) {
         let colIdx = 0
-        // Type is resolved at projection-analysis time and pushed into
-        // `selectColTypes` for both single-source and multi-source modes
-        // (covers `<arg>.Col` field-lookup AND `json_extract` paths). Fall
-        // back to `lookup_struct_field_type(rootType, selectCols[0])` only
-        // when the array is empty (legacy callers / future-proofing).
         var fieldType : TypeDeclPtr
         if (length(q.selectColTypes) > 0) {
             fieldType = q.selectColTypes[0]
@@ -3607,19 +3088,13 @@ def private build_row_builder(var q : SqlQuery&; prog : ProgramPtr; at : LineInf
         return qmacro(read_via_adapter(_sql_stmt, $v(colIdx), type<$t(fieldType)>))
     }
     if (q.proj == ProjectionShape.NamedTuple) {
-        // Build  (Name = read_via_adapter(stmt, 0, type<...>), Price = read_via_adapter(stmt, 1, type<...>))
-        // recordNames live on the tuple TypeDecl's argNames — set those via
-        // recordType so the typer reads them back into the ExprMakeTuple.
+        // (Name=read_via_adapter(stmt,0,type<…>), …); recordNames go on tupT.argNames via recordType.
         let n = length(q.selectCols)
         var tupT = new TypeDecl(at = at, baseType = Type.tTuple)
         tupT.argNames.resize(n)
         var mkTup = new ExprMakeTuple(at = at)
         for (i in range(n)) {
             let colIdx = i
-            // selectColTypes is populated per-element for both single-source
-            // and multi-source projections (covers `<arg>.Col` lookups,
-            // `is_some(o)` → bool probes, and `json_extract` JSON paths).
-            // Fall through to rootType lookup only when the array is empty.
             var fieldType : TypeDeclPtr
             if (i < length(q.selectColTypes)) {
                 fieldType = q.selectColTypes[i]
@@ -3639,9 +3114,7 @@ def private build_row_builder(var q : SqlQuery&; prog : ProgramPtr; at : LineInf
         return mkTup
     }
     if (q.proj == ProjectionShape.GroupedNamedTuple) {
-        // Same shape as NamedTuple, but column types come from
-        // `groupedSelectTypes` (filled at projection-analysis time —
-        // mixes group-key column types with aggregate result types).
+        // Same shape as NamedTuple; column types come from groupedSelectTypes.
         let n = length(q.groupedSelectExprs)
         var tupT = new TypeDecl(at = at, baseType = Type.tTuple)
         tupT.argNames.resize(n)
@@ -3664,9 +3137,6 @@ def private build_row_builder(var q : SqlQuery&; prog : ProgramPtr; at : LineInf
 
 [macro_function]
 def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; isTry : bool) : ExpressionPtr {
-    //! Shared body for `_sql` and `_try_sql`. Difference: `isTry=true` emits
-    //! the `try_run_*` variants returning `Result<..., string>`; `isTry=false`
-    //! emits the strict `run_*` variants that panic on prepare/step failure.
     var argT = call.arguments[0]._type
     macro_verify(argT != null, prog, call.at, "_sql/_try_sql: chain argument is not inferred yet")
     macro_verify(!argT.isAutoOrAlias, prog, call.at, "_sql/_try_sql: chain type is auto/alias after inference")
@@ -3678,43 +3148,18 @@ def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; is
     // min / max / count) is degenerate in SQL: the aggregate already
     // collapses to one row, so `LIMIT n` / `OFFSET n` become no-ops
     // (e.g. `SELECT SUM(p) FROM Cars LIMIT 2` returns the sum of
-    // ALL rows). The user almost certainly wants "<agg> over the
-    // first n rows", which requires a subquery
-    // (`SELECT SUM(c) FROM (SELECT p AS c FROM Cars LIMIT 2)`) —
-    // landing with joins / subqueries in chunk 5+. Reject loud now
-    // so users see a clear pointer instead of silently-wrong sums.
+    // take(n)/skip(n) AFTER an aggregate is a no-op in SQL; users likely want a subquery — reject loudly.
     if (q.proj == ProjectionShape.Aggregate
             && (q.limitBindExpr != null || q.offsetBindExpr != null)) {
         macro_error(prog, call.at, "_sql: take(n)/skip(n) before an aggregate is not translatable — `LIMIT`/`OFFSET` after an aggregate has no effect (aggregate collapses to one row); use `_where(...)` for pre-aggregate filtering, or wait for subquery support in chunk 5+")
         return null
     }
-    // `distinct()` upstream of an aggregate (sum / average / min /
-    // max / count) is degenerate in SQL: `SELECT DISTINCT SUM(...)`
-    // / `SELECT DISTINCT COUNT(*)` etc. dedupe a single-row result,
-    // which is always a no-op. The meaningful form is
-    // `COUNT(DISTINCT col)` (DISTINCT *inside* the aggregate), which
-    // would need a separate analyzer path — not yet wired. Reject
-    // loud rather than emit silently-meaningless SQL.
+    // distinct() upstream of an aggregate is a no-op in SQL — meaningful form is COUNT(DISTINCT col), not yet implemented.
     if (q.proj == ProjectionShape.Aggregate && q.distinctFlag) {
         macro_error(prog, call.at, "_sql: distinct() before an aggregate is not translatable — `SELECT DISTINCT` over a single-row aggregate result is always a no-op; the meaningful form is `COUNT(DISTINCT col)` etc. (aggregate-distinct), which is not yet implemented")
         return null
     }
-    // Append HAVING / LIMIT / OFFSET binds AFTER WHERE binds so the
-    // placeholder index matches the SQL order
-    // (WHERE … HAVING … LIMIT ? OFFSET ?). Single-row terminals
-    // (`_first` / `_first_opt`) emit a literal `LIMIT 1` (no bind),
-    // so skip the limit push in that case. Aggregate terminals
-    // (`sum` / `average` / `min` / `max` / `count`) with upstream
-    // `take(n)` / `skip(n)` are rejected at compile time above
-    // (degenerate SQL — `LIMIT` after an aggregate is a no-op), so
-    // there's no aggregate-specific bind push reachable here. The
-    // `q.proj != Aggregate` exclusion below mirrors
-    // `build_sql_string`'s `forced_one_row` check for hygiene.
-    //
-    // Order is fixed by SQL clause order: per-join ON binds (in join order)
-    // → outer WHERE → HAVING → LIMIT → OFFSET. Build the final list in
-    // that order; `q.bindExprs` accumulates outer WHERE during analysis,
-    // so we splice ON binds in front of it before appending the rest.
+    // Bind order: per-join ON → WHERE → HAVING → LIMIT → OFFSET. Splice ON in front of q.bindExprs, then append the rest.
     var joinOnCount = 0
     for (j in q.joins) {
         joinOnCount += length(j.rightOnBindExprs)
@@ -3750,87 +3195,41 @@ def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; is
         q.bindExprs |> push(q.offsetBindExpr)
     }
     let sql = build_sql_string(q)
-
+    // Convert (sqlString, q.bindExprs) → ExprStringBuilder + binds; const-fold keeps AOT byte-identical to the legacy $v(sql) path.
+    var frags : array<SqlFrag>
+    sql_to_frags_ex(sql, q.bindExprs, q.orderByInlineExprs, frags)
+    var sqlExpr : ExpressionPtr
+    var bindExprs : array<ExpressionPtr>
+    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
     // Build bind statements: sql_bind_to_stmt(stmt, i+1, $e(boundExpr))
     var bind_stmts : array<ExpressionPtr>
-    bind_stmts |> reserve(length(q.bindExprs))
-    for (i in range(length(q.bindExprs))) {
+    bind_stmts |> reserve(length(bindExprs))
+    for (i in range(length(bindExprs))) {
         let bindIdx = i + 1
-        var be = q.bindExprs[i]
+        var be = bindExprs[i]
         bind_stmts |> push <| qmacro_expr(${
             sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
         })
     }
-
     var rowBuilder = build_row_builder(q, prog, call.at)
     if (rowBuilder == null) {
         return null
     }
-
     var dbExpr = q.dbExpr
-    var res : ExpressionPtr
-    if (isTry) {
-        if (q.matr == Materializer.One) {
-            res = qmacro(_::try_run_select_one($e(dbExpr), $v(sql),
-                $(var _sql_stmt : sqlite3_stmt?) {
-                    $b(bind_stmts)
-                },
-                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
-        } elif (q.matr == Materializer.OneOpt) {
-            res = qmacro(_::try_run_select_one_opt($e(dbExpr), $v(sql),
-                $(var _sql_stmt : sqlite3_stmt?) {
-                    $b(bind_stmts)
-                },
-                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
-        } else {
-            res = qmacro(_::try_run_select($e(dbExpr), $v(sql),
-                $(var _sql_stmt : sqlite3_stmt?) {
-                    $b(bind_stmts)
-                },
-                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
-        }
-    } else {
-        if (q.matr == Materializer.One) {
-            res = qmacro(_::run_select_one($e(dbExpr), $v(sql),
-                $(var _sql_stmt : sqlite3_stmt?) {
-                    $b(bind_stmts)
-                },
-                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
-        } elif (q.matr == Materializer.OneOpt) {
-            res = qmacro(_::run_select_one_opt($e(dbExpr), $v(sql),
-                $(var _sql_stmt : sqlite3_stmt?) {
-                    $b(bind_stmts)
-                },
-                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
-        } else {
-            res = qmacro(_::run_select($e(dbExpr), $v(sql),
-                $(var _sql_stmt : sqlite3_stmt?) {
-                    $b(bind_stmts)
-                },
-                $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
-        }
-    }
+    let suffix = (q.matr == Materializer.One ? "_one"
+                  : (q.matr == Materializer.OneOpt ? "_one_opt" : ""))
+    let fname = (isTry ? "try_run_select" : "run_select") + suffix
+    var res = qmacro($c(fname)($e(dbExpr), $e(sqlExpr),
+        $(var _sql_stmt : sqlite3_stmt?) {
+            $b(bind_stmts)
+        },
+        $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
     res.force_at(call.at)
     return res
 }
 
 [call_macro(name="_sql")]
 class private SqlMacro : AstCallMacro {
-    //! _sql(chain) -> array<T> | T | Option<T>. Compile-time LINQ-to-SQL
-    //! translator. Pattern-matches the chain, emits SQL + a runtime
-    //! materialization via run_select / run_select_one / run_select_one_opt.
-    //!
-    //! **Default `canVisitArgument=true`.** Daslang's macro pass expands
-    //! inner call_macros bottom-up *before* this `visit()` fires. By the
-    //! time we run, `_where(it, expr)` has become `where_(it, $(_:T) => expr)`,
-    //! `_select(it, expr)` has become `select(it, $(_:T) => expr)`, and any
-    //! user-defined wrapper macro (e.g. `when_its_cold(it)` →
-    //! `_where(it, _.temp < 0)`) has cascaded into the same shape.
-    //!
-    //! **Entry guard:** the chain argument's `_type` must be resolved before
-    //! `_sql` runs — if it's null, inner call_macros didn't expand (typically a
-    //! missing `require` for an operator/wrapper); if it's still auto/alias,
-    //! type inference didn't finish. Both fail loudly via `macro_verify`.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         macro_verify(call.arguments |> length == 1, prog, call.at, "_sql expects one argument: a chain expression")
         return emit_sql_macro_body(prog, call, false)
@@ -3839,34 +3238,11 @@ class private SqlMacro : AstCallMacro {
 
 [call_macro(name="_try_sql")]
 class private TrySqlMacro : AstCallMacro {
-    //! _try_sql(chain) -> Result<T, string> | Result<Option<T>, string> |
-    //! Result<array<T>, string>. Non-panicking sibling of _sql. Same
-    //! analyzer; emits `try_run_*` runtime helpers that wrap the result in
-    //! `Result<..., string>` instead of panicking on prepare/step failure.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         macro_verify(call.arguments |> length == 1, prog, call.at, "_try_sql expects one argument: a chain expression")
         return emit_sql_macro_body(prog, call, true)
     }
 }
-
-// ============================================================================
-// _each_sql — streaming iterator over a SELECT chain.
-//
-// Same chain shape as `_sql(...)`, but instead of materializing the result
-// set into an array up front, the macro emits a `_::run_each_select(...)`
-// call returning a `generator<TT>`. The generator yields one row at a time
-// and finalizes the prepared statement on:
-//   - normal exhaustion
-//   - early `break` from the surrounding for-loop
-//   - panic from inside the for-loop body
-//
-// Restrictions vs `_sql`:
-//   - terminals are rejected: `_first()` / `_first_opt()` / `_to_array()`
-//     are not iterators (they materialize one row or the whole array)
-//   - aggregates are rejected: `_count()` / `_sum()` / etc. produce a
-//     scalar; iteration is degenerate
-// For these shapes use `_sql(...)` directly.
-// ============================================================================
 
 [macro_function]
 def private emit_each_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?) : ExpressionPtr {
@@ -3877,14 +3253,7 @@ def private emit_each_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro
     if (!analyze_chain(call.arguments[0], q, prog, call.at)) {
         return null
     }
-
-    // Reject terminals — _each_sql produces an iterator, not a scalar /
-    // single row / explicit array. Each error points the user at `_sql`
-    // for the materializing form.
-    //
-    // Order matters: aggregates (which set both q.proj=Aggregate AND
-    // q.matr=One internally) get the aggregate-specific message; plain
-    // _first / _first_opt fall through to the single-row message.
+    // Reject terminals (iterator, not scalar/row/array). Order matters: aggregates set both Aggregate+One, so dispatch on proj first.
     if (q.seenToArray) {
         macro_error(prog, call.at, "_each_sql: chain ends in `_to_array()` — _each_sql streams rows lazily; drop the terminal, or switch to `_sql(...)` for materialization")
         return null
@@ -3897,10 +3266,7 @@ def private emit_each_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro
         macro_error(prog, call.at, "_each_sql: chain ends in `_first()` / `_first_opt()` — those terminals materialize a single row. Use `_sql(...)` for the same chain, or drop the terminal to iterate.")
         return null
     }
-
-    // Bind ordering — same as emit_sql_macro_body: per-join ON binds → outer
-    // WHERE → HAVING → LIMIT → OFFSET. Limit/offset binds are still allowed
-    // (e.g. `_each_sql(... |> take(100))` streams up to 100 rows).
+    // Same bind ordering as emit_sql_macro_body. take/skip binds OK here (lazy stream).
     var joinOnCount = 0
     for (j in q.joins) {
         joinOnCount += length(j.rightOnBindExprs)
@@ -3933,29 +3299,30 @@ def private emit_each_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro
     if (q.offsetBindExpr != null) {
         q.bindExprs |> push(q.offsetBindExpr)
     }
-
     let sql = build_sql_string(q)
-
+    var frags : array<SqlFrag>
+    sql_to_frags_ex(sql, q.bindExprs, q.orderByInlineExprs, frags)
+    var sqlExpr : ExpressionPtr
+    var bindExprs : array<ExpressionPtr>
+    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
     var bind_stmts : array<ExpressionPtr>
-    bind_stmts |> reserve(length(q.bindExprs))
-    for (i in range(length(q.bindExprs))) {
+    bind_stmts |> reserve(length(bindExprs))
+    for (i in range(length(bindExprs))) {
         let bindIdx = i + 1
-        var be = q.bindExprs[i]
+        var be = bindExprs[i]
         bind_stmts |> push <| qmacro_expr(${
             sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
         })
     }
-
     var rowBuilder = build_row_builder(q, prog, call.at)
     if (rowBuilder == null) {
         return null
     }
-
     var dbExpr = q.dbExpr
     // bind_blk is a `block` (one-shot, runs before the generator). row_blk
     // is a capturing `lambda` so it can outlive the run_each_select call
     // inside the generator body.
-    var res = qmacro(_::run_each_select($e(dbExpr), $v(sql),
+    var res = qmacro(_::run_each_select($e(dbExpr), $e(sqlExpr),
         $(var _sql_stmt : sqlite3_stmt?) {
             $b(bind_stmts)
         },
@@ -3966,50 +3333,19 @@ def private emit_each_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro
 
 [call_macro(name="_each_sql")]
 class private EachSqlMacro : AstCallMacro {
-    //! _each_sql(chain) -> iterator<T>. Same chain shape as `_sql(...)`,
-    //! but yields rows lazily rather than materializing the whole array.
-    //! Iterate via `for (row in _each_sql(db |> select_from(type<T>)))`.
-    //! The underlying prepared statement is finalized on loop exit (normal
-    //! exhaustion / break / panic) by the generator's `finally`.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         macro_verify(call.arguments |> length == 1, prog, call.at, "_each_sql expects one argument: a chain expression")
         return emit_each_sql_macro_body(prog, call)
     }
 }
 
-// ============================================================================
-// `_sql_update` / `_sql_delete` — predicate-based mutations
-//
-// These macros run with `canVisitArgument = false` for everything except `db`
-// so the WHERE / SET arguments arrive as raw AST (the user writes `_.Col < x`
-// with `_` unbound). Analysis proceeds on the raw shape:
-//
-//   * `_.Col` references are recognized via the AST shape (ExprField over
-//     ExprVar named "_") and translated to SQL column refs (`"Col"`). They
-//     never become bind parameters.
-//   * Captured locals and literals classify as binds — pred_to_sql emits a
-//     `?` placeholder and the original ExprVar / ExprConst is pushed to the
-//     bind list. At the macro's output, the bind expression is passed verbatim
-//     to ``sql_bind_to_stmt(stmt, idx, expr)``; daslang's typer resolves the
-//     captured-var's type and overload-dispatches `sql_bind_to_stmt`.
-//
-// Bind ordering for SET-then-WHERE SQL: SET binds come first, then WHERE
-// binds (matches placeholder order in `UPDATE ... SET col1=?, ... WHERE ...`).
-// For RETURNING, the RETURNING clause is appended without adding binds and
-// the row materializer reuses the `[sql_table]`-generated `_sql_read_row`.
-// ============================================================================
+// ===== _sql_update / _sql_delete — predicate-based mutations =====
 
 [macro_function]
 def private analyze_set_clause(var setExpr : ExpressionPtr; var q : SqlQuery&;
                                var setSqlClauses : array<string>&;
                                var setBindExprs : array<ExpressionPtr>&;
                                prog : ProgramPtr; at : LineInfo) : bool {
-    //! Walk a raw `(Col1 = expr1, Col2 = expr2, ...)` named-tuple literal and
-    //! emit a list of `"Col" = <sql>` fragments + the bind expressions they
-    //! introduce. The SET clause SQL fragments are pushed into
-    //! ``setSqlClauses``; bind expressions accumulate into ``setBindExprs``.
-    //! WHERE binds (from ``q.bindExprs``) stay separate and are appended
-    //! after SET binds at SQL emission time.
     if (setExpr == null) {
         macro_error(prog, at, "_sql_update: set clause is null")
         return false
@@ -4027,10 +3363,7 @@ def private analyze_set_clause(var setExpr : ExpressionPtr; var q : SqlQuery&;
         macro_error(prog, at, "_sql_update: set clause is empty — UPDATE with no columns is invalid SQL. Pass at least one (Col=expr) pair.")
         return false
     }
-    // The named-tuple literal's record names live on the inferred tuple type
-    // (`tupT.argNames`). When the macro runs with ``canVisitArgument=false``
-    // the SET arg arrives raw and `mkTup._type` is null — fall back to the
-    // recordNames carried directly on the MakeTuple node by the parser.
+    // recordNames may live on tupT.argNames (typed) or mkTup.recordNames (raw, canVisitArgument=false).
     var tupT = mkTup._type
     var recordNames : array<string>
     if (tupT != null && tupT.baseType == Type.tTuple
@@ -4054,10 +3387,7 @@ def private analyze_set_clause(var setExpr : ExpressionPtr; var q : SqlQuery&;
             return false
         }
     }
-    // Validate each SET column: must be a real field on T, no duplicates.
-    // The WHERE side validates `_.Field` via pred_to_sql; mirror that
-    // discipline on the SET side so typos / collisions surface as a
-    // macro_error at compile time instead of a SQLite runtime error.
+    // Validate each SET column against T's fields (no typos, no duplicates).
     if (q.rootType != null && q.rootType.structType != null) {
         var st = q.rootType.structType
         var seenCols : table<string; bool>
@@ -4081,10 +3411,7 @@ def private analyze_set_clause(var setExpr : ExpressionPtr; var q : SqlQuery&;
             }
         }
     }
-    // Each value is translated via the same pred_to_sql machinery as a WHERE
-    // predicate. Captured vars and `_.Col` references both work; binds are
-    // pushed into a SET-local list so we can interleave them with WHERE
-    // binds in correct placeholder order at SQL emission time.
+    // Translate via pred_to_sql; binds collected SET-local for proper interleave with WHERE.
     var setQ = SqlQuery(
         rootType = q.rootType,
         tableName = q.tableName,
@@ -4114,12 +3441,6 @@ def private analyze_set_clause(var setExpr : ExpressionPtr; var q : SqlQuery&;
 
 [macro_function]
 def private build_returning_clause(rootT : TypeDeclPtr) : string {
-    //! Append `RETURNING "c1", "c2", ...` listing every field of T in
-    //! struct-declaration order. Mirrors `_sql_select_all_sql`'s output so
-    //! the row materializer (`_sql_read_row`) reads columns in struct order.
-    //! `field_to_column_name` translates `@sql_column` renames to the on-disk
-    //! SQL identifier (positional column index is what `_sql_read_row` uses,
-    //! so the daslang-side row-builder is unaffected by the rename).
     if (rootT == null || rootT.structType == null) {
         return ""
     }
@@ -4140,15 +3461,10 @@ def private build_returning_clause(rootT : TypeDeclPtr) : string {
 }
 
 [macro_function]
-def private emit_dml_call(var dbE : ExpressionPtr; sql : string;
+def private emit_dml_call(var dbE : ExpressionPtr; var sqlExpr : ExpressionPtr;
                           var bindStmts : array<ExpressionPtr>;
                           isTry : bool; isReturning : bool;
                           rootT : TypeDeclPtr; at : LineInfo) : ExpressionPtr {
-    //! Build the runtime call for `_sql_update*` / `_sql_delete*`. Picks one of
-    //! the four `_::run_dml*` variants from `(isTry, isReturning)` — the call
-    //! name is the only intrinsic fork (qmacro can't parameterize `_::name`);
-    //! the bind lambda and (for returning variants) the row reader are built
-    //! once and spliced into each branch.
     var bindLambda = qmacro($(var _sql_stmt : sqlite3_stmt?) {
         $b(bindStmts)
     })
@@ -4156,17 +3472,11 @@ def private emit_dml_call(var dbE : ExpressionPtr; sql : string;
     if (isReturning) {
         var rootClone = clone_type(rootT)
         var readerLambda = qmacro($(_sql_stmt : sqlite3_stmt?) => _::_sql_read_row(_sql_stmt, type<$t(rootClone)>))
-        if (isTry) {
-            res = qmacro(_::try_run_dml_returning($e(dbE), $v(sql), $e(bindLambda), $e(readerLambda)))
-        } else {
-            res = qmacro(_::run_dml_returning($e(dbE), $v(sql), $e(bindLambda), $e(readerLambda)))
-        }
+        let fname = (isTry ? "try_run_dml_returning" : "run_dml_returning")
+        res = qmacro($c(fname)($e(dbE), $e(sqlExpr), $e(bindLambda), $e(readerLambda)))
     } else {
-        if (isTry) {
-            res = qmacro(_::try_run_dml($e(dbE), $v(sql), $e(bindLambda)))
-        } else {
-            res = qmacro(_::run_dml($e(dbE), $v(sql), $e(bindLambda)))
-        }
+        let fname = (isTry ? "try_run_dml" : "run_dml")
+        res = qmacro($c(fname)($e(dbE), $e(sqlExpr), $e(bindLambda)))
     }
     res |> force_at(at)
     return res
@@ -4176,11 +3486,6 @@ def private emit_dml_call(var dbE : ExpressionPtr; sql : string;
 def private emit_update_body(prog : ProgramPtr; var call : ExprCallMacro?;
                              var rootT : TypeDeclPtr;
                              isTry : bool; isReturning : bool) : ExpressionPtr {
-    //! Shared body for the four `_sql_update*` macros. Operates on the raw
-    //! WHERE / SET argument expressions (canVisitArgument=false skipped
-    //! type inference for them); pred_to_sql analyzes the AST shape and
-    //! pushes captured vars / literals as binds. Caller supplies the already-
-    //! extracted ``rootT`` (the struct TypeDecl from `type<T>`).
     if (rootT == null || rootT.structType == null) {
         macro_error(prog, call.at, "_sql_update: T must be a struct (got {describe(rootT)})")
         return null
@@ -4235,23 +3540,27 @@ def private emit_update_body(prog : ProgramPtr; var call : ExprCallMacro?;
     for (b in q.bindExprs) {
         allBinds |> push(b)
     }
+    var frags : array<SqlFrag>
+    sql_to_frags(sql, allBinds, frags)
+    var sqlExpr : ExpressionPtr
+    var bindExprs : array<ExpressionPtr>
+    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
     var bindStmts : array<ExpressionPtr>
-    bindStmts |> reserve(length(allBinds))
-    for (i in range(length(allBinds))) {
+    bindStmts |> reserve(length(bindExprs))
+    for (i in range(length(bindExprs))) {
         let bindIdx = i + 1
-        var be = allBinds[i]
+        var be = bindExprs[i]
         bindStmts |> push <| qmacro_expr(${
             sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
         })
     }
-    return emit_dml_call(dbE, sql, bindStmts, isTry, isReturning, rootT, call.at)
+    return emit_dml_call(dbE, sqlExpr, bindStmts, isTry, isReturning, rootT, call.at)
 }
 
 [macro_function]
 def private emit_delete_body(prog : ProgramPtr; var call : ExprCallMacro?;
                              var rootT : TypeDeclPtr;
                              isTry : bool; isReturning : bool) : ExpressionPtr {
-    //! Shared body for the four `_sql_delete*` macros.
     if (rootT == null || rootT.structType == null) {
         macro_error(prog, call.at, "_sql_delete: T must be a struct (got {describe(rootT)})")
         return null
@@ -4276,33 +3585,30 @@ def private emit_delete_body(prog : ProgramPtr; var call : ExprCallMacro?;
     if (isReturning) {
         sql += build_returning_clause(rootT)
     }
+    var frags : array<SqlFrag>
+    sql_to_frags(sql, q.bindExprs, frags)
+    var sqlExpr : ExpressionPtr
+    var bindExprs : array<ExpressionPtr>
+    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
     var bindStmts : array<ExpressionPtr>
-    bindStmts |> reserve(length(q.bindExprs))
-    for (i in range(length(q.bindExprs))) {
+    bindStmts |> reserve(length(bindExprs))
+    for (i in range(length(bindExprs))) {
         let bindIdx = i + 1
-        var be = q.bindExprs[i]
+        var be = bindExprs[i]
         bindStmts |> push <| qmacro_expr(${
             sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
         })
     }
-    return emit_dml_call(dbE, sql, bindStmts, isTry, isReturning, rootT, call.at)
+    return emit_dml_call(dbE, sqlExpr, bindStmts, isTry, isReturning, rootT, call.at)
 }
 
 // ----------------------------------------------------------------------------
-// Outer macros — `canVisitArgument = false` for everything except db so the
-// WHERE / SET arguments stay raw (with `_` unbound). pred_to_sql operates on
-// the AST shape directly; bind expressions (captured locals, literals) are
-// passed through to ``sql_bind_to_stmt`` verbatim and resolve at the macro's
-// output type-inference pass.
+// Outer macros — args 1+ stay raw via canVisitArgument so `_` is unbound for pred_to_sql.
 // ----------------------------------------------------------------------------
 
 [macro_function]
 def private validate_outer_args(prog : ProgramPtr; var call : ExprCallMacro?; var rootT : TypeDeclPtr&;
                                 expected_arity : int; sig_text : string) : bool {
-    //! Shared validator for outer call_macros (``_sql_update`` / ``_sql_delete``
-    //! and their ``_sql_try_*_returning`` variants). Each caller supplies the
-    //! expected arg count (3 for delete, 4 for update) and a human-readable
-    //! signature like ``"(db, type<T>, where_expr)"``.
     if (length(call.arguments) != expected_arity) {
         macro_error(prog, call.at, "{call.name}: expected {sig_text} — got {length(call.arguments)} args")
         return false
@@ -4320,22 +3626,12 @@ def private validate_outer_args(prog : ProgramPtr; var call : ExprCallMacro?; va
 }
 
 class private OuterArgZeroMacro : AstCallMacro {
-    //! Shared parent for the 8 `_sql_update*` / `_sql_delete*` outer macros.
-    //! Only argument 0 (``db``) is visited by the typer; the remaining args
-    //! (``type<T>``, ``where_expr``, optional ``set_expr``) stay raw so
-    //! ``pred_to_sql`` and the named-tuple walker can read the unresolved AST
-    //! shape with ``_`` unbound. ``[call_macro(name=...)]`` does not inherit,
-    //! so each concrete subclass keeps its own annotation.
     def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
         return argIndex == 0
     }
 }
 
 class private OuterArgTwoMacro : AstCallMacro {
-    //! Shared parent for the 4 `_sql_upsert*` outer macros. Args 0 (``db``)
-    //! and 1 (``row``) are visited by the typer (the row needs to be a
-    //! resolved struct value); args 2 (``on_conflict``) and 3 (``do_update``)
-    //! stay raw for the analyzer to walk.
     def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
         return argIndex < 2
     }
@@ -4343,11 +3639,6 @@ class private OuterArgTwoMacro : AstCallMacro {
 
 [call_macro(name="_sql_update")]
 class private SqlUpdateMacro : OuterArgZeroMacro {
-    //! `_sql_update(db, type<T>, where_expr, set_expr)` — predicate-based UPDATE.
-    //! ``where_expr`` is an expression in the row variable `_` (e.g.
-    //! ``_.LastSeen < cutoff``). ``set_expr`` is a named-tuple literal
-    //! ``(Col1=expr1, Col2=expr2, ...)`` whose RHS may reference ``_.Col``
-    //! and captured locals. Returns ``int`` rows-affected. Panics on SQL error.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_args(prog, call, rootT, 4, "(db, type<T>, where_expr, set_expr)")) {
@@ -4359,7 +3650,6 @@ class private SqlUpdateMacro : OuterArgZeroMacro {
 
 [call_macro(name="_sql_try_update")]
 class private SqlTryUpdateMacro : OuterArgZeroMacro {
-    //! Non-panic sibling of `_sql_update`. Returns ``Result<int, string>``.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_args(prog, call, rootT, 4, "(db, type<T>, where_expr, set_expr)")) {
@@ -4371,8 +3661,6 @@ class private SqlTryUpdateMacro : OuterArgZeroMacro {
 
 [call_macro(name="_sql_update_returning")]
 class private SqlUpdateReturningMacro : OuterArgZeroMacro {
-    //! `_sql_update(...)` with a trailing ``RETURNING *`` clause. Returns
-    //! ``array<T>`` of post-update rows. Panics on SQL error.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_args(prog, call, rootT, 4, "(db, type<T>, where_expr, set_expr)")) {
@@ -4384,8 +3672,6 @@ class private SqlUpdateReturningMacro : OuterArgZeroMacro {
 
 [call_macro(name="_sql_try_update_returning")]
 class private SqlTryUpdateReturningMacro : OuterArgZeroMacro {
-    //! Non-panic sibling of `_sql_update_returning`. Returns
-    //! ``Result<array<T>, string>``.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_args(prog, call, rootT, 4, "(db, type<T>, where_expr, set_expr)")) {
@@ -4397,8 +3683,6 @@ class private SqlTryUpdateReturningMacro : OuterArgZeroMacro {
 
 [call_macro(name="_sql_delete")]
 class private SqlDeleteMacro : OuterArgZeroMacro {
-    //! `_sql_delete(db, type<T>, where_expr)` — predicate-based DELETE.
-    //! Returns ``int`` rows-affected. Panics on SQL error.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_args(prog, call, rootT, 3, "(db, type<T>, where_expr)")) {
@@ -4410,7 +3694,6 @@ class private SqlDeleteMacro : OuterArgZeroMacro {
 
 [call_macro(name="_sql_try_delete")]
 class private SqlTryDeleteMacro : OuterArgZeroMacro {
-    //! Non-panic sibling of `_sql_delete`. Returns ``Result<int, string>``.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_args(prog, call, rootT, 3, "(db, type<T>, where_expr)")) {
@@ -4422,8 +3705,6 @@ class private SqlTryDeleteMacro : OuterArgZeroMacro {
 
 [call_macro(name="_sql_delete_returning")]
 class private SqlDeleteReturningMacro : OuterArgZeroMacro {
-    //! `_sql_delete(...)` with a trailing ``RETURNING *`` clause. Returns
-    //! ``array<T>`` of just-deleted rows. Panics on SQL error.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_args(prog, call, rootT, 3, "(db, type<T>, where_expr)")) {
@@ -4435,8 +3716,6 @@ class private SqlDeleteReturningMacro : OuterArgZeroMacro {
 
 [call_macro(name="_sql_try_delete_returning")]
 class private SqlTryDeleteReturningMacro : OuterArgZeroMacro {
-    //! Non-panic sibling of `_sql_delete_returning`. Returns
-    //! ``Result<array<T>, string>``.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_args(prog, call, rootT, 3, "(db, type<T>, where_expr)")) {
@@ -4446,22 +3725,7 @@ class private SqlTryDeleteReturningMacro : OuterArgZeroMacro {
     }
 }
 
-// ============================================================================
-// _sql_upsert / _sql_try_upsert / _sql_upsert_returning / _sql_try_upsert_returning
-//
-// SQLite INSERT...ON CONFLICT DO UPDATE — the proper merge form. Three positional
-// args after ``db``:
-//   - row : T (single-row only for v1; bulk overload deferred to a follow-up)
-//   - on_conflict : either `_.Col` (single column) or `tuple(_.C1, _.C2, ...)` (composite)
-//   - do_update : named-tuple literal `(Col=expr, ...)` referencing `_` (existing row)
-//                 and/or `_excluded` (proposed row — SQLite's built-in sentinel)
-//
-// Args 2 and 3 stay raw (canVisitArgument visits only args 0 and 1 — the db
-// and the row, since the row needs to be a typed struct value). The do_update
-// walker runs `pred_to_sql` with `q.upsertMode = true` so `_excluded.Col`
-// resolves to SQLite's `excluded.col`; `_.Col` resolves to the unqualified
-// column reference (existing-row in DO UPDATE SET context).
-// ============================================================================
+// ===== _sql_upsert family (INSERT...ON CONFLICT DO UPDATE) =====
 
 [macro_function]
 def private is_field_computed(field) : bool {
@@ -4499,11 +3763,6 @@ def private validate_outer_upsert_args(prog : ProgramPtr; var call : ExprCallMac
 def private analyze_upsert_conflict(var conflictExpr : ExprCallMacro?; rootT : TypeDeclPtr;
                                     var conflictCols : array<string>&;
                                     prog : ProgramPtr; at : LineInfo) : bool {
-    //! Extract the conflict-target column list from the on_conflict expression.
-    //! Accepted shapes:
-    //!     _.Col              → single column
-    //!     tuple(_.A, _.B)    → composite
-    //! Anything else is a macro_error.
     var node : ExpressionPtr = conflictExpr
     return analyze_upsert_conflict_inner(node, rootT, conflictCols, prog, at)
 }
@@ -4516,7 +3775,7 @@ def private analyze_upsert_conflict_inner(var node : ExpressionPtr; rootT : Type
         macro_error(prog, at, "_sql_upsert: on_conflict is null")
         return false
     }
-    // Single column form: `_.Col` — qmatch auto-peels any ExprRef2Value layers.
+    // Single column form: `_.Col`.
     {
         var col : string
         if (qmatch(node, _.$f(col)).matched) {
@@ -4524,17 +3783,16 @@ def private analyze_upsert_conflict_inner(var node : ExpressionPtr; rootT : Type
             return validate_conflict_cols(rootT, conflictCols, prog, at)
         }
     }
-    // Peel for the multi-shape `is ExprMakeTuple` and ExprField fallthroughs.
     var n = node
     if (n is ExprRef2Value) {
         n = (n as ExprRef2Value).subexpr
     }
     if (n is ExprField) {
-        // ExprField that didn't match `_.<f>` — receiver isn't `_`.
+        // ExprField but receiver isn't `_`.
         macro_error(prog, at, "_sql_upsert: on_conflict column ref must be `_.Col`; got {describe(node)}")
         return false
     }
-    // Tuple form: `tuple(_.A, _.B, ...)` or `(_.A, _.B, ...)` — both parse as ExprMakeTuple.
+    // Tuple form: `tuple(_.A, _.B, ...)` parses as ExprMakeTuple.
     if (n is ExprMakeTuple) {
         var mkt = n as ExprMakeTuple
         if (length(mkt.values) == 0) {
@@ -4559,12 +3817,6 @@ def private analyze_upsert_conflict_inner(var node : ExpressionPtr; rootT : Type
 
 [macro_function]
 def private validate_conflict_cols(rootT : TypeDeclPtr; conflictCols : array<string>; prog : ProgramPtr; at : LineInfo) : bool {
-    //! Cross-check every conflict-target column name against the struct's
-    //! fields. (We don't try to verify a UNIQUE constraint exists at macro
-    //! time — composite uniqueness via [sql_index(unique=true, fields=(...))]
-    //! is hard to inspect from here. SQLite rejects at runtime if no
-    //! constraint matches, with a clear "ON CONFLICT clause does not match"
-    //! error.)
     if (rootT == null || rootT.structType == null) {
         macro_error(prog, at, "_sql_upsert: row type has no struct (got {describe(rootT)})")
         return false
@@ -4590,9 +3842,6 @@ def private analyze_upsert_set_clause(var setExpr : ExpressionPtr; var rootT : T
                                       var setSqlClauses : array<string>&;
                                       var setBindExprs : array<ExpressionPtr>&;
                                       prog : ProgramPtr; at : LineInfo) : bool {
-    //! Walk the do_update named-tuple body. Identical to analyze_set_clause
-    //! except the per-value SqlQuery has ``upsertMode = true`` so
-    //! ``pred_to_sql`` recognizes ``_excluded.Col`` references.
     if (setExpr == null) {
         macro_error(prog, at, "_sql_upsert: do_update is null")
         return false
@@ -4690,7 +3939,6 @@ def private analyze_upsert_set_clause(var setExpr : ExpressionPtr; var rootT : T
 def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
                              var rootT : TypeDeclPtr;
                              isTry : bool; isReturning : bool) : ExpressionPtr {
-    //! Shared body for the four `_sql_upsert*` macros.
     if (rootT == null || rootT.structType == null) {
         macro_error(prog, call.at, "_sql_upsert: row type must be a [sql_table] struct (got {describe(rootT)})")
         return null
@@ -4701,23 +3949,18 @@ def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
     var conflictE = call.arguments[2]
     var doUpdateE = call.arguments[3]
     let tableName = sql_table_name_from_type(rootT)
-
     // 1) on_conflict columns
     var conflictCols : array<string>
     if (!analyze_upsert_conflict_inner(conflictE, rootT, conflictCols, prog, call.at)) {
         return null
     }
-
     // 2) do_update SET clauses (with upsertMode=true so `_excluded.Col` resolves)
     var setSqlClauses : array<string>
     var setBindExprs : array<ExpressionPtr>
     if (!analyze_upsert_set_clause(doUpdateE, rootT, tableName, setSqlClauses, setBindExprs, prog, call.at)) {
         return null
     }
-
-    // 3) Build INSERT column list (non-computed only — matches `_sql_bind_row`).
-    //    `nonComputedCols` holds the SQL-side names (post-`@sql_column`); bind
-    //    indices are positional, so the daslang-side bind helper is unaffected.
+    // 3) INSERT column list (non-computed only) — SQL-side names, positional bind indices.
     var nonComputedCols : array<string>
     var nRowBinds = 0
     for (f in st.fields) {
@@ -4727,10 +3970,7 @@ def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
         nonComputedCols |> push(field_to_column_name(rootT, string(f.name)))
         nRowBinds++
     }
-
-    // 4) Assemble SQL. `conflictCols` arrived here as daslang field names
-    //    (via `analyze_upsert_conflict_inner` validating against `f.name`);
-    //    translate to SQL identifiers at emission so renames are transparent.
+    // 4) Assemble SQL. conflictCols arrive in daslang names — translate via field_to_column_name at emission.
     var sql = build_string() $(var w) {
         w |> write("INSERT INTO \"{tableName}\" (")
         for (i in range(length(nonComputedCols))) {
@@ -4765,9 +4005,7 @@ def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
     if (isReturning) {
         sql += build_returning_clause(rootT)
     }
-
-    // 5) Build bindStmts. Row binds come first (via per-struct `_sql_bind_row`
-    //    which uses indices 1..N_row), then SET binds at N_row+1, N_row+2, ...
+    // 5) Bind order: row binds (1..N_row) via `_sql_bind_row`, then SET binds (N_row+1..).
     var rowClone = clone_expression(rowE)
     var bindStmts : array<ExpressionPtr>
     bindStmts |> reserve(1 + length(setBindExprs))
@@ -4781,14 +4019,18 @@ def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
             sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
         })
     }
-
-    return emit_dml_call(dbE, sql, bindStmts, isTry, isReturning, rootT, call.at)
+    // Row binds come from `_sql_bind_row` (not enumerated as `?` walking targets); pass empty binds to fold.
+    var noBinds : array<ExpressionPtr>
+    var frags : array<SqlFrag>
+    sql_to_frags(sql, noBinds, frags)
+    var sqlExpr : ExpressionPtr
+    var bindExprs : array<ExpressionPtr>
+    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
+    return emit_dml_call(dbE, sqlExpr, bindStmts, isTry, isReturning, rootT, call.at)
 }
 
 [call_macro(name="_sql_upsert")]
 class private SqlUpsertMacro : OuterArgTwoMacro {
-    //! `_sql_upsert(db, row, on_conflict, do_update)` — INSERT...ON CONFLICT
-    //! DO UPDATE. Returns ``int`` rows-affected. Panics on SQL error.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_upsert_args(prog, call, rootT)) {
@@ -4800,7 +4042,6 @@ class private SqlUpsertMacro : OuterArgTwoMacro {
 
 [call_macro(name="_sql_try_upsert")]
 class private SqlTryUpsertMacro : OuterArgTwoMacro {
-    //! Non-panic sibling of `_sql_upsert`. Returns ``Result<int, string>``.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_upsert_args(prog, call, rootT)) {
@@ -4812,8 +4053,6 @@ class private SqlTryUpsertMacro : OuterArgTwoMacro {
 
 [call_macro(name="_sql_upsert_returning")]
 class private SqlUpsertReturningMacro : OuterArgTwoMacro {
-    //! `_sql_upsert(...)` with a trailing ``RETURNING *`` clause. Returns
-    //! ``array<T>`` of post-merge rows. Panics on SQL error.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_upsert_args(prog, call, rootT)) {
@@ -4825,8 +4064,6 @@ class private SqlUpsertReturningMacro : OuterArgTwoMacro {
 
 [call_macro(name="_sql_try_upsert_returning")]
 class private SqlTryUpsertReturningMacro : OuterArgTwoMacro {
-    //! Non-panic sibling of `_sql_upsert_returning`. Returns
-    //! ``Result<array<T>, string>``.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         var rootT : TypeDeclPtr
         if (!validate_outer_upsert_args(prog, call, rootT)) {

--- a/skills/install_instructions.md
+++ b/skills/install_instructions.md
@@ -25,6 +25,7 @@ Source files live under `install/` in the repo; CMake installs them to the SDK r
 | `install/skills/jobque_debugging.md` | `skills/jobque_debugging.md` | Channel/LockBox/JobStatus/Stream/Feature leak debugging with `--track-job-status` |
 | `install/skills/detect_dupe.md` | `skills/detect_dupe.md` | Duplicate-function detection — corpus build, MCP tools (`export_corpus`, `detect_duplicates`), CLI modes |
 | `install/skills/mcp_tools.md` | `skills/mcp_tools.md` | Full MCP tool table + live-API reference (CLAUDE.md only carries a 2-line pointer) |
+| `install/skills/regex.md` | `skills/regex.md` | Regular expressions — `daslib/regex` API + `%regex~...%%` reader macro |
 | `utils/mcp/` (whole dir) | `utils/mcp/` | MCP server for AI assistants (gated on dasHV) |
 | `utils/detect-dupe/` (whole dir) | `utils/detect-dupe/` | Duplicate-function detector (canonicalizer, clusterer, MinHash, pattern filter) |
 
@@ -111,6 +112,7 @@ After modifying install instructions, install to a scratch prefix and verify the
    - `skills/jobque_debugging.md`
    - `skills/detect_dupe.md`
    - `skills/mcp_tools.md`
+   - `skills/regex.md`
    - `utils/mcp/main.das` (only if built with `DAS_HV_DISABLED=OFF`)
    - `utils/mcp/tools/common.das` (only if built with `DAS_HV_DISABLED=OFF`)
    - `utils/detect-dupe/main.das`

--- a/skills/regex.md
+++ b/skills/regex.md
@@ -1,0 +1,145 @@
+# Regular expressions in daslang
+
+## When to use this skill
+
+Read this skill when writing regular expressions in `.das` code — anywhere you reach for `regex_compile`, `regex_match`, `regex_search`, the `%regex~...%%` reader macro, or any of the `regex_replace` / `regex_split` / `regex_foreach` family.
+
+## API
+
+Two modules: `daslib/regex` (the engine, all runtime functions) and `daslib/regex_boost` (the compile-time `%regex~...%%` reader macro).
+
+```daslang
+require daslib/regex
+require daslib/regex_boost
+```
+
+### Compiling
+
+```daslang
+def regex_compile(expr : string; case_insensitive : bool = false; dot_all : bool = false) : Regex
+def regex_compile(var re : Regex; expr : string; case_insensitive : bool = false; dot_all : bool = false) : bool
+def is_valid(var re : Regex) : bool
+```
+
+For literal patterns, prefer the **reader macro** over runtime compilation:
+
+```daslang
+var private RE <- %regex~^\s*(?:def|struct)\s+private\b%%
+var private RE_I <- %regex~hello%%i        // case-insensitive
+var private RE_S <- %regex~start.*end%%s   // dot-all (`.` matches `\n`)
+var private RE_IS <- %regex~Foo%%is        // both flags
+```
+
+The macro compiles the pattern at parse time and embeds the resulting `Regex` directly into the AST. Three benefits: (1) no escape-doubling — write `\s+` not `"\\s+"`; (2) parse-time validation — bad patterns surface as compile errors; (3) no per-call compilation cost. Module-scope `var` (mutable, since matching mutates internal state) is the standard pattern — see `daslib/cpp_gen.das:810` and `daslib/faker.das:70` for production use.
+
+### Matching
+
+```daslang
+def regex_match(var regex : Regex; str : string; offset : int = 0) : int
+```
+Anchored at `offset` — checks "does the regex match starting here?". Returns the **length** of the match in bytes consumed, or `-1` if no match. Pattern starting with `^` and `regex_match(re, line)` is the common idiom for "does this line begin with...".
+
+```daslang
+def regex_search(var regex : Regex; str : string; offset : int = 0) : int2
+```
+Scans forward — returns `int2(start, end)` of the first match, or `int2(-1, -1)` if not found. Use this for substring search.
+
+```daslang
+def regex_match_all(var regex : Regex; str : string) : array<range>
+```
+Returns every match position as an `array<range>` (each `range.x` = start, `range.y` = end+1).
+
+### Group access
+
+```daslang
+def regex_group(regex : Regex; index : int; match : string) : string
+def regex_group_by_name(regex : Regex; name : string; str : string) : string
+def operator [](regex : Regex; index : int) : range
+def operator [](regex : Regex; name : string) : range
+```
+
+Group `0` is the whole match; numbered groups follow parenthesization order. Named groups via `(?P<name>...)`.
+
+### Iteration and replacement
+
+```daslang
+def regex_foreach(var regex : Regex; str : string; blk : block<(at : range) : bool>)
+def regex_replace(var regex : Regex; str : string; replacement : string) : string
+def regex_replace(var regex : Regex; str : string; blk : block<(matched : string) : string>) : string
+def regex_split(var regex : Regex; str : string) : array<string>
+```
+
+Block form lets you compute each replacement; template-string form handles the common case:
+
+```daslang
+let rewritten = regex_replace(re, src, "$1=$2")              // template
+let rewritten = regex_replace(re, src) <| $(matched) {       // callback
+    return upper(matched)
+}
+```
+
+### Template replacement references
+
+| Token | Meaning |
+|---|---|
+| `$0` or `$&` | the whole match |
+| `$1`–`$9` | numbered capture groups |
+| `${name}` | named capture group |
+| `$$` | literal `$` |
+
+## Syntax (this engine)
+
+Pure NFA implementation in `daslib/regex.das` — not PCRE, not POSIX. Supports:
+
+| Feature | Syntax |
+|---|---|
+| Anchors | `^` (start), `$` (end) |
+| Character classes | `\w` `\W` `\d` `\D` `\s` `\S` `\t` `\n` `\r` `\f` `\v` |
+| Quantifiers (greedy) | `+` `*` `?` `{n}` `{n,}` `{n,m}` |
+| Quantifiers (lazy) | `+?` `*?` `??` `{n,m}?` |
+| Capturing group | `(...)` |
+| Non-capturing group | `(?:...)` |
+| Named group | `(?P<name>...)` |
+| Lookahead | `(?=...)` (positive), `(?!...)` (negative) |
+| Word boundary | `\b` (boundary), `\B` (non-boundary) |
+| Char set | `[a-z]`, `[^abc]`; meta-classes inside: `[\d_]` |
+| Alternation | `|` (use `\|` for a literal pipe) |
+| Hex escape | `\xHH` |
+| Metacharacter escape | `\.` `\+` `\*` `\(` `\)` `\[` `\]` `\|` `\\` `\^` `\{` `\}` |
+| Any char | `.` (matches anything but `\n` unless `dot_all=true`) |
+
+## Gotchas
+
+- **`regex_match` is anchored, not substring.** `regex_match(re, "abc")` only matches at offset 0; for "find anywhere" use `regex_search`.
+- **ASCII-only.** The engine's char sets are 256-bit; no Unicode classes, no Unicode-aware case folding. `case_insensitive=true` only folds ASCII A–Z.
+- **Pure NFA.** Catastrophic backtracking is possible on poorly-anchored patterns with nested quantifiers — anchor with `^`, use atomic-style non-capturing groups, and avoid nested `*`/`+` whenever possible.
+- **Escape doubling in plain string literals.** `regex_compile("\\d+")` versus `%regex~\d+%%` — reader macro wins for literal patterns. Reach for runtime `regex_compile` only when the pattern is constructed dynamically.
+- **`Regex` is mutable.** Match functions take `var regex : Regex` and mutate scratch state. Module-scope `var` (not `let`) for shared compiled patterns.
+
+## Idiomatic example
+
+From `utils/hygiene/rule_private_docs.das`:
+
+```daslang
+require daslib/regex public
+require daslib/regex_boost
+
+var private HEADER_RE <- %regex~^\s*(?:def|struct|enum|variant|class)\s+private\b%%
+var private TRAILING_RE <- %regex~\s*//!<?[^\n]*$%%
+
+def is_private_decl_start(line : string) : bool {
+    return regex_match(HEADER_RE, line) >= 0
+}
+
+def strip_trailing_doc(line : string) : string {
+    let pos = regex_search(TRAILING_RE, line)
+    return pos.x < 0 ? line : slice(line, 0, pos.x)
+}
+```
+
+## Reference
+
+- Engine: `daslib/regex.das`
+- Compile-time reader macro: `daslib/regex_boost.das`
+- Tutorial: `doc/source/reference/tutorials/31_regex.rst`
+- Generated stdlib reference: `doc/source/stdlib/generated/regex.rst`, `regex_boost.rst`

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -76,9 +76,30 @@ namespace das {
                 while ( src < src_end && src[0]!='"' ) {
                     if ( src[0]=='\n' )
                         line ++;
-                    src ++;
+                    if ( src[0]=='\\' && src+1<src_end ) {
+                        // Skip the escaped character so that \" inside a string literal does not terminate the string (likewise \\, \n, etc.).
+                        if ( src[1]=='\n' ) line ++;
+                        src += 2;
+                    } else {
+                        src ++;
+                    }
                 }
+                if ( src < src_end ) src ++;
+                wb = true;
+                continue;
+            } else if ( src[0]=='\'' ) {
                 src ++;
+                while ( src < src_end && src[0]!='\'' ) {
+                    if ( src[0]=='\n' )
+                        line ++;
+                    if ( src[0]=='\\' && src+1<src_end ) {
+                        if ( src[1]=='\n' ) line ++;
+                        src += 2;
+                    } else {
+                        src ++;
+                    }
+                }
+                if ( src < src_end ) src ++;
                 wb = true;
                 continue;
             } else if ( src[0]=='/' && src[1]=='/' ) {

--- a/tests/dasSQLITE/failed_create_view.das
+++ b/tests/dasSQLITE/failed_create_view.das
@@ -2,7 +2,7 @@ options gen2
 
 // _create_view shape errors. Each block triggers exactly one macro_error
 // (40104) from `SqlCreateViewMacro`.
-expect 40104:6
+expect 40104:7
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -72,5 +72,9 @@ def main {
         // 6. _to_array() terminal — redundant for a view
         db |> _create_view(type<CarName3>,
             db |> select_from(type<Car>) |> _to_array())
+        // 7. runtime _order_by(string) — column name would be baked at view-creation
+        let runtime_col = "Price"
+        db |> _create_view(type<CarName3>,
+            db |> select_from(type<Car>) |> _order_by(runtime_col))
     }
 }

--- a/tests/dasSQLITE/failed_sql_pragma_vacuum.das
+++ b/tests/dasSQLITE/failed_sql_pragma_vacuum.das
@@ -1,0 +1,25 @@
+options gen2
+
+// _sql_pragma / _sql_vacuum_into argument-shape errors. Each line triggers
+// exactly one macro_error (40104).
+expect 40104:5
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[export]
+def main {
+    with_sqlite(":memory:") $(db) {
+        // 1. _sql_pragma with int64 value — must use try_set_pragma instead.
+        db |> _sql_pragma("busy_timeout", 1500l)
+        // 2. _sql_pragma with bool value — must use try_set_pragma instead.
+        db |> _sql_pragma("foreign_keys", true)
+        // 3. _sql_pragma with non-string name.
+        db |> _sql_pragma(42, "value")
+        // 4. _sql_pragma with wrong arg count.
+        db |> _sql_pragma("only_two_args")
+        // 5. _sql_vacuum_into with non-string path.
+        db |> _sql_vacuum_into(123l)
+    }
+}

--- a/tests/dasSQLITE/test_91_sql_pragma_macro.das
+++ b/tests/dasSQLITE/test_91_sql_pragma_macro.das
@@ -1,0 +1,59 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[test]
+def test_sql_pragma_const_args(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let err = db |> _sql_pragma("journal_mode", "MEMORY")
+        t |> equal(err |> is_some, false, "const args succeed")
+        let mode = db |> query_scalar("PRAGMA journal_mode", type<string>)
+        t |> equal(mode, "memory", "round-trips through SQLite")
+    }
+}
+
+[test]
+def test_sql_pragma_runtime_value(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let dynamic_value = "MEMORY"
+        let err = db |> _sql_pragma("journal_mode", dynamic_value)
+        t |> equal(err |> is_some, false, "runtime value succeeds")
+        let mode = db |> query_scalar("PRAGMA journal_mode", type<string>)
+        t |> equal(mode, "memory", "runtime path produces same SQL")
+    }
+}
+
+[test]
+def test_sql_pragma_runtime_name(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let dynamic_name = "journal_mode"
+        let err = db |> _sql_pragma(dynamic_name, "MEMORY")
+        t |> equal(err |> is_some, false, "runtime name succeeds")
+        let mode = db |> query_scalar("PRAGMA journal_mode", type<string>)
+        t |> equal(mode, "memory", "runtime name path works")
+    }
+}
+
+[test]
+def test_sql_pragma_value_quote_safety(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        // Embedded single quote in the value — must be doubled to keep SQLite
+        // happy. SQLite ignores unknown pragma names silently (returns no
+        // error) so we can assert against the no-crash path.
+        let tricky = "it's tricky"
+        let err = db |> _sql_pragma("not_real_pragma", tricky)
+        t |> equal(err |> is_some, false, "single-quote in value parses cleanly")
+    }
+}
+
+[test]
+def test_sql_pragma_unknown_name_silently_succeeds(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        let err = db |> _sql_pragma("xyzzy_not_a_pragma", "any")
+        t |> equal(err |> is_some, false, "unknown pragma is a no-op (matches try_set_pragma)")
+    }
+}

--- a/tests/dasSQLITE/test_91_sql_vacuum_into_macro.das
+++ b/tests/dasSQLITE/test_91_sql_vacuum_into_macro.das
@@ -1,0 +1,77 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+require daslib/fio
+
+[sql_table(name = "Items")]
+struct Item {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<Item>)
+    db |> insert(Item(Id = 1, Name = "alpha"))
+    db |> insert(Item(Id = 2, Name = "beta"))
+}
+
+[test]
+def test_sql_vacuum_into_runtime_path(t : T?) {
+    let r = create_temp_file_result("dastest_vacuum_into", ".db")
+    t |> equal(r is value, true, "temp file path obtained")
+    let path = unsafe(r.value)
+    remove(path)
+    with_sqlite(":memory:") $(src) {
+        fixture(src)
+        let err = src |> _sql_vacuum_into(path)
+        t |> equal(err |> is_some, false, "vacuum into runtime path")
+    }
+    t |> equal(fexist(path), true, "snapshot written")
+    {
+        var inscope reopened = open_sqlite(path)
+        let n = reopened |> query_scalar("SELECT COUNT(*) FROM Items", type<int>)
+        t |> equal(n, 2, "rows survived VACUUM INTO")
+    }
+    remove(path)
+}
+
+[test]
+def test_sql_vacuum_into_quote_safety_in_path(t : T?) {
+    // VACUUM INTO requires the path string literal embedded in the SQL —
+    // any embedded `'` must be doubled. The macro routes through
+    // sql_quote_lit. Using a path that resolves to a real file (we can't
+    // freely use weird characters on Windows fs), but we can check the
+    // SQL text path via _sql_text on a sibling builder. Practical assert:
+    // a path with no special chars round-trips.
+    let r = create_temp_file_result("with_special", ".db")
+    t |> equal(r is value, true, "temp file path obtained")
+    let path = unsafe(r.value)
+    remove(path)
+    with_sqlite(":memory:") $(src) {
+        fixture(src)
+        let err = src |> _sql_vacuum_into(path)
+        t |> equal(err |> is_some, false, "runtime path with no quotes round-trips")
+    }
+    remove(path)
+}
+
+[test]
+def test_sql_vacuum_into_in_transaction_errors(t : T?) {
+    with_sqlite(":memory:") $(src) {
+        fixture(src)
+        var saw_err = false
+        src |> with_transaction() {
+            // SQLite itself rejects VACUUM INTO inside a transaction with
+            // "cannot VACUUM from within a transaction"; the macro doesn't
+            // add its own guard, so the error surfaces as an SqlError.
+            let err = src |> _sql_vacuum_into("/dev/null/should_not_matter")
+            saw_err = (err |> is_some)
+        }
+        t |> equal(saw_err, true, "VACUUM INTO inside txn returns SqlError")
+    }
+}

--- a/tests/dasSQLITE/test_92_order_by_runtime.das
+++ b/tests/dasSQLITE/test_92_order_by_runtime.das
@@ -1,0 +1,149 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW", Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi", Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 100))
+    db |> insert(Car(Id = 4, Name = "Lada", Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Runtime _order_by(string) — column name supplied as a `string` expression.
+// The compile-time path (_.Field) still emits a literal `"col" ASC`. The
+// runtime path emits `sql_quote_id(<expr>)` so the column name is quoted at
+// execution time, with embedded `"` properly doubled.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_order_by_const_string_emits_quoted(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _order_by("Price"))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" ORDER BY \"Price\" ASC",
+        "_order_by(const string) folds to compile-time quoted ORDER BY")
+}
+
+[test]
+def test_order_by_descending_const_string(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _order_by_descending("Price"))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" ORDER BY \"Price\" DESC",
+        "_order_by_descending(const string) folds DESC")
+}
+
+[test]
+def test_order_by_runtime_string_variable(t : T?) {
+    var _db = SqlRunner()
+    let col = "Name"
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _order_by(col))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" ORDER BY \"Name\" ASC",
+        "_order_by(<runtime var>) quotes the column name at runtime")
+}
+
+[test]
+def test_order_by_runtime_string_with_embedded_quote(t : T?) {
+    var _db = SqlRunner()
+    // Identifier with embedded `"` must be doubled, per SQLite identifier rules.
+    let col = "We\"ird"
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _order_by(col))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" ORDER BY \"We\"\"ird\" ASC",
+        "embedded quote in runtime column name is doubled")
+}
+
+[test]
+def test_order_by_runtime_string_executes(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let col = "Price"
+        let rows <- _sql(db |> select_from(type<Car>) |> _order_by(col))
+        t |> equal(length(rows), 5, "5 rows")
+        t |> equal(rows[0].Price, 50, "Price ASC: Lada first")
+        t |> equal(rows[4].Price, 999, "Price ASC: Lambo last")
+    }
+}
+
+[test]
+def test_order_by_descending_runtime_string_executes(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let col = "Price"
+        let rows <- _sql(db |> select_from(type<Car>) |> _order_by_descending(col))
+        t |> equal(rows[0].Price, 999, "Price DESC: Lambo first")
+        t |> equal(rows[4].Price, 50, "Price DESC: Lada last")
+    }
+}
+
+[test]
+def test_order_by_tuple_runtime_strings(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let primary = "Price"
+        let secondary = "Name"
+        // BMW(100) and Tesla(100) tie on Price; Name ASC breaks the tie.
+        let rows <- _sql(db |> select_from(type<Car>) |> _order_by((primary, secondary)))
+        t |> equal(rows[0].Name, "Lada", "Price=50 first")
+        t |> equal(rows[1].Name, "BMW", "Price=100, Name=BMW")
+        t |> equal(rows[2].Name, "Tesla", "Price=100, Name=Tesla")
+    }
+}
+
+[test]
+def test_order_by_tuple_mixed_field_and_string(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let secondary = "Name"
+        // Mixed: compile-time _.Price + runtime secondary.
+        let rows <- _sql(db |> select_from(type<Car>) |> _order_by((_.Price, secondary)))
+        t |> equal(rows[0].Name, "Lada", "Price=50 first")
+        t |> equal(rows[1].Name, "BMW", "tie broken by Name ASC")
+        t |> equal(rows[2].Name, "Tesla", "tie second")
+    }
+}
+
+[test]
+def test_order_by_runtime_string_with_where_and_take(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let col = "Price"
+        let rows <- _sql(db |> select_from(type<Car>)
+            |> _where(_.Price > 100)
+            |> _order_by(col)
+            |> take(2))
+        t |> equal(length(rows), 2, "two rows past the WHERE filter")
+        t |> equal(rows[0].Price, 200, "Audi (200) is smallest >100")
+        t |> equal(rows[1].Price, 999, "Lambo (999) is next")
+    }
+}
+
+[test]
+def test_order_by_runtime_string_each_sql(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let col = "Price"
+        var prices : array<int>
+        for (row in _each_sql(db |> select_from(type<Car>) |> _order_by_descending(col))) {
+            prices |> push(row.Price)
+        }
+        t |> equal(length(prices), 5, "_each_sql streams 5 rows in order")
+        t |> equal(prices[0], 999, "DESC first")
+        t |> equal(prices[4], 50, "DESC last")
+    }
+}

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -13,6 +13,7 @@ set(DAS_UTILS
     dascov
     daspkg
     detect-dupe
+    hygiene
 )
 
 if(NOT DAS_SQLITE_DISABLED)
@@ -74,6 +75,7 @@ SET(DAS_UTILS_TO_TEST
     lint
     detect-dupe
     find-dupe/tests
+    hygiene
 )
 
 FOREACH(_das ${DAS_UTILS_TO_TEST})

--- a/utils/hygiene/main.das
+++ b/utils/hygiene/main.das
@@ -1,0 +1,91 @@
+options gen2
+
+require strings
+require daslib/clargs
+require daslib/strings_boost
+
+require process
+
+
+[CommandLineArgs]
+struct Config {
+    @clarg_doc = "report would-be changes; exit 1 if any; don't write"
+    check : bool
+
+    @clarg_short = "?"
+    @clarg_name = "show-help"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+
+def collect_files(args : array<string>) : array<string> {
+    // Files are positional: anything that doesn't start with `-`. The known
+    // flags (--check, --help, -?) all start with `-`, and none of them take
+    // a separate-token value, so this filter is unambiguous.
+    var files : array<string>
+    for (a in args) {
+        if (starts_with(a, "-")) {
+            continue
+        }
+        files |> push(a)
+    }
+    return <- files
+}
+
+
+[export]
+def main() : int {
+    var cfg = Config()
+    let err = parse_args(cfg)
+    if (cfg.help) {
+        print_help(get_command_info(type<Config>), "hygiene")
+        return 0
+    }
+    if (err != "") {
+        to_log(LOG_ERROR, "error: {err}\n\n")
+        print_help(get_command_info(type<Config>), "hygiene")
+        return 1
+    }
+    let files <- collect_files(get_user_args())
+    if (empty(files)) {
+        to_log(LOG_ERROR, "error: no files specified\n\n")
+        print_help(get_command_info(type<Config>), "hygiene")
+        return 1
+    }
+    var any_changed = false
+    var any_missing = false
+    for (f in files) {
+        let r = process_path(f, cfg.check)
+        if (r.kind == ProcessResultKind.missing_file) {
+            to_log(LOG_ERROR, "error: file not found: {f}\n")
+            any_missing = true
+            continue
+        }
+        if (r.kind == ProcessResultKind.not_a_file) {
+            to_log(LOG_ERROR, "error: not a regular file: {f}\n")
+            any_missing = true
+            continue
+        }
+        if (r.kind == ProcessResultKind.write_failed) {
+            to_log(LOG_ERROR, "error: failed to write {f}\n")
+            return 2
+        }
+        if (r.kind == ProcessResultKind.no_change) {
+            continue
+        }
+        any_changed = true
+        if (r.kind == ProcessResultKind.would_change) {
+            to_log(LOG_INFO, "would trim: {f}\n")
+        } elif (r.kind == ProcessResultKind.changed) {
+            to_log(LOG_INFO, "trimmed {f} ({r.lines_removed} lines removed)\n")
+        }
+    }
+    if (any_missing) {
+        return 2
+    }
+    if (cfg.check && any_changed) {
+        return 1
+    }
+    return 0
+}

--- a/utils/hygiene/process.das
+++ b/utils/hygiene/process.das
@@ -1,0 +1,48 @@
+options gen2
+
+module process shared private
+
+require strings
+require daslib/fio
+require daslib/strings_boost
+require rules
+
+
+enum public ProcessResultKind {
+    no_change
+    would_change
+    changed
+    missing_file
+    not_a_file
+    write_failed
+}
+
+
+struct public ProcessResult {
+    kind : ProcessResultKind
+    lines_removed : int
+}
+
+
+def public process_path(path : string; check : bool) : ProcessResult {
+    let st = stat(path)
+    if (!st.is_valid) {
+        return ProcessResult(kind = ProcessResultKind.missing_file)
+    }
+    if (!st.is_reg) {
+        return ProcessResult(kind = ProcessResultKind.not_a_file)
+    }
+    let original = fread(path)
+    let trimmed = apply_all_rules(original)
+    if (original == trimmed) {
+        return ProcessResult(kind = ProcessResultKind.no_change)
+    }
+    if (check) {
+        return ProcessResult(kind = ProcessResultKind.would_change)
+    }
+    if (!fwrite(path, trimmed)) {
+        return ProcessResult(kind = ProcessResultKind.write_failed)
+    }
+    let removed = length(split(original, "\n")) - length(split(trimmed, "\n"))
+    return ProcessResult(kind = ProcessResultKind.changed, lines_removed = removed)
+}

--- a/utils/hygiene/rule_private_docs.das
+++ b/utils/hygiene/rule_private_docs.das
@@ -1,0 +1,180 @@
+options gen2
+
+module rule_private_docs shared private
+
+require strings
+require daslib/regex public
+require daslib/regex_boost
+require daslib/strings_boost
+
+
+var private HEADER_RE <- %regex~^\s*(?:def|struct|enum|variant|class)\s+private\b%%
+var private TRAILING_RE <- %regex~\s*//!<?[^\n]*$%%
+
+
+def private count_braces(s : string; var block_depth : int&) : tuple<int; int> {
+    // Returns (opens, closes) of `{`/`}` outside string and char literals,
+    // `//` line comments, and `/* ... */` block comments (which nest).
+    // `block_depth` is in/out: caller passes the depth at line start; on
+    // return it reflects the depth at line end (0 = not inside a block).
+    var opens = 0
+    var closes = 0
+    var in_string = false
+    var quote = uint8(0)
+    var escape = false
+    var prev_slash = false
+    var prev_star = false
+    peek_data(s) $(arr) {
+        for (b in arr) {
+            if (block_depth > 0) {
+                // Inside a block comment — only `*/` (close) and `/*` (nest)
+                // matter; strings, escapes, `//` are inert.
+                if (prev_star && b == uint8('/')) {
+                    block_depth--
+                    prev_star = false
+                    prev_slash = false
+                } elif (prev_slash && b == uint8('*')) {
+                    block_depth++
+                    prev_slash = false
+                    prev_star = false
+                } else {
+                    prev_star = b == uint8('*')
+                    prev_slash = b == uint8('/')
+                }
+                continue
+            }
+            if (escape) {
+                escape = false
+                prev_slash = false
+                prev_star = false
+                continue
+            }
+            if (in_string) {
+                if (b == uint8('\\')) {
+                    escape = true
+                } elif (b == quote) {
+                    in_string = false
+                }
+                prev_slash = false
+                prev_star = false
+                continue
+            }
+            if (b == uint8('"') || b == uint8('\'')) {
+                in_string = true
+                quote = b
+                prev_slash = false
+                prev_star = false
+                continue
+            }
+            if (prev_slash && b == uint8('/')) {
+                return  // `//` line comment — rest of line is comment text
+            }
+            if (prev_slash && b == uint8('*')) {
+                block_depth = 1
+                prev_slash = false
+                prev_star = false
+                continue
+            }
+            prev_slash = b == uint8('/')
+            prev_star = false
+            if (b == uint8('{')) {
+                opens++
+            } elif (b == uint8('}')) {
+                closes++
+            }
+        }
+    }
+    return (opens, closes)
+}
+
+
+def private is_private_decl_start(line : string) : bool {
+    return regex_match(HEADER_RE, line) >= 0
+}
+
+
+def private strip_trailing_doc(line : string) : string {
+    let pos = regex_search(TRAILING_RE, line)
+    if (pos.x < 0) {
+        return line
+    }
+    let new_body = slice(line, 0, pos.x)
+    if (empty(strip(new_body))) {
+        return ""
+    }
+    return new_body
+}
+
+
+def public trim_private_docstrings(src : string) : string {
+    // The brace-depth counter is reliable once string/char literals, `//`
+    // line comments, and `/* ... */` block comments (which nest in daslang)
+    // are skipped — see `count_braces`. `block_depth` is threaded across
+    // lines so multi-line block comments are handled correctly.
+    var lines <- split(src, "\n")
+    // Detect line-ending style so CRLF input round-trips byte-for-byte instead
+    // of being silently rewritten to LF on every run.
+    var crlf = false
+    for (raw_line in lines) {
+        if (ends_with(raw_line, "\r")) {
+            crlf = true
+            break
+        }
+    }
+    let nl = crlf ? "\r\n" : "\n"
+    var out : array<string>
+    var state = 0   // 0 = normal, 1 = awaiting_brace, 2 = in_body
+    var body_depth = 0
+    var block_depth = 0
+    for (raw_line in lines) {
+        let line = ends_with(raw_line, "\r") ? slice(raw_line, 0, length(raw_line) - 1) : raw_line
+        // If the line starts inside a `/* ... */` block comment, no
+        // line-level decision (private-decl detect, //! strip) applies —
+        // the contents are inert. Just walk to update block_depth and push.
+        if (block_depth > 0) {
+            count_braces(line, block_depth)
+            out |> push(line)
+            continue
+        }
+        if (state == 0) {
+            out |> push(line)
+            if (is_private_decl_start(line)) {
+                let braces = count_braces(line, block_depth)
+                if (braces._0 > 0) {
+                    body_depth = braces._0 - braces._1
+                    state = body_depth > 0 ? 2 : 0
+                } else {
+                    state = 1
+                }
+            } else {
+                count_braces(line, block_depth)
+            }
+            continue
+        }
+        if (state == 1) {
+            out |> push(line)
+            let braces = count_braces(line, block_depth)
+            if (braces._0 > 0) {
+                body_depth = braces._0 - braces._1
+                state = body_depth > 0 ? 2 : 0
+            }
+            continue
+        }
+        // state == 2 (inside a private declaration body)
+        let stripped = strip(line)
+        if (starts_with(stripped, "//!")) {
+            continue
+        }
+        let new_line = strip_trailing_doc(line)
+        if (empty(new_line)) {
+            continue
+        }
+        let braces = count_braces(new_line, block_depth)
+        body_depth += braces._0 - braces._1
+        out |> push(new_line)
+        if (body_depth <= 0) {
+            state = 0
+        }
+    }
+    return out |> join(nl)
+}

--- a/utils/hygiene/rules.das
+++ b/utils/hygiene/rules.das
@@ -1,0 +1,10 @@
+options gen2
+
+module rules shared private
+
+require rule_private_docs public
+
+
+def public apply_all_rules(src : string) : string {
+    return trim_private_docstrings(src)
+}

--- a/utils/hygiene/test_hygiene.das
+++ b/utils/hygiene/test_hygiene.das
@@ -1,0 +1,188 @@
+options gen2
+
+require dastest/testing_boost public
+require strings
+
+require rule_private_docs
+require process
+
+
+[test]
+def test_strip_private_function_docstring(t : T?) {
+    let input = "def private foo() \{\n    //! description\n    return 1\n\}\n"
+    let want = "def private foo() \{\n    return 1\n\}\n"
+    t |> equal(trim_private_docstrings(input), want)
+}
+
+
+[test]
+def test_preserve_public_function_docstring(t : T?) {
+    let input = "def foo() \{\n    //! description\n    return 1\n\}\n"
+    t |> equal(trim_private_docstrings(input), input)
+}
+
+
+[test]
+def test_strip_struct_field_trailing_doc(t : T?) {
+    let input = "struct private S \{\n    x : int        //!< desc\n\}\n"
+    let want = "struct private S \{\n    x : int\n\}\n"
+    t |> equal(trim_private_docstrings(input), want)
+}
+
+
+[test]
+def test_preserve_plain_why_comment(t : T?) {
+    let input = "def private foo() \{\n    // why\n    return 1\n\}\n"
+    t |> equal(trim_private_docstrings(input), input)
+}
+
+
+[test]
+def test_multiline_signature(t : T?) {
+    let input = "def private foo(\n    a : int\n) : int \{\n    //! description\n    return a\n\}\n"
+    let want = "def private foo(\n    a : int\n) : int \{\n    return a\n\}\n"
+    t |> equal(trim_private_docstrings(input), want)
+}
+
+
+[test]
+def test_class_private_with_base(t : T?) {
+    let input = "class private C : Base \{\n    //! private class docstring\n    f : int        //!< field doc\n\}\n"
+    let want = "class private C : Base \{\n    f : int\n\}\n"
+    t |> equal(trim_private_docstrings(input), want)
+}
+
+
+[test]
+def test_idempotent(t : T?) {
+    let input = "def private foo() \{\n    //! description\n    return 1\n\}\n"
+    let once = trim_private_docstrings(input)
+    let twice = trim_private_docstrings(once)
+    t |> equal(once, twice)
+}
+
+
+[test]
+def test_strip_only_inside_private(t : T?) {
+    let input = "def public_fn() \{\n    //! kept\n\}\ndef private foo() \{\n    //! stripped\n\}\ndef public_again() \{\n    //! also kept\n\}\n"
+    let want = "def public_fn() \{\n    //! kept\n\}\ndef private foo() \{\n\}\ndef public_again() \{\n    //! also kept\n\}\n"
+    t |> equal(trim_private_docstrings(input), want)
+}
+
+
+[test]
+def test_no_changes_when_clean(t : T?) {
+    let input = "def public_only() \{\n    return 42\n\}\n"
+    t |> equal(trim_private_docstrings(input), input)
+}
+
+
+[test]
+def test_string_literal_unbalanced_close_brace(t : T?) {
+    // `}` inside a string literal must not exit the private body early.
+    // Without the fix, the brace counter underflows on line 2 and the //! on
+    // line 3 escapes stripping.
+    let input = "def private foo() \{\n    let s = \"\}\"\n    //! description\n\}\n"
+    let want = "def private foo() \{\n    let s = \"\}\"\n\}\n"
+    t |> equal(trim_private_docstrings(input), want)
+}
+
+
+[test]
+def test_string_literal_unbalanced_open_brace(t : T?) {
+    // `{` inside a string literal must not push body_depth past the actual
+    // close. Without the fix, body_depth stays > 0 after the real `}` and the
+    // following public function's //! is wrongly stripped.
+    let input = "def private foo() \{\n    let s = \"\{\"\n\}\ndef public_fn() \{\n    //! kept\n\}\n"
+    t |> equal(trim_private_docstrings(input), input)
+}
+
+
+[test]
+def test_preserve_crlf_when_no_strip(t : T?) {
+    // CRLF input with no private docstrings must round-trip byte-for-byte.
+    // Without the fix, \r is stripped on read and join uses \n on emit,
+    // rewriting the file to LF every run.
+    let input = "def public() \{\r\n    return 1\r\n\}\r\n"
+    t |> equal(trim_private_docstrings(input), input)
+}
+
+
+[test]
+def test_preserve_crlf_when_stripping(t : T?) {
+    // CRLF input with a private docstring strips correctly AND keeps CRLF.
+    let input = "def private foo() \{\r\n    //! description\r\n    return 1\r\n\}\r\n"
+    let want = "def private foo() \{\r\n    return 1\r\n\}\r\n"
+    t |> equal(trim_private_docstrings(input), want)
+}
+
+
+[test]
+def test_brace_in_line_comment(t : T?) {
+    // `{` / `}` inside a `//` comment must not desync the brace counter.
+    // Without the fix, the `{` in the comment on line 2 keeps body_depth > 0
+    // after the real `}` on line 3, and the next public function's //! gets
+    // wrongly stripped.
+    let input = "def private foo() \{\n    // brace in comment \{\n\}\ndef public_fn() \{\n    //! kept\n\}\n"
+    t |> equal(trim_private_docstrings(input), input)
+}
+
+
+[test]
+def test_close_brace_in_line_comment(t : T?) {
+    // `}` inside a `//` comment must not exit the body early. Without the
+    // fix, the `}` in the comment on line 2 underflows body_depth and the
+    // //! on line 3 escapes stripping.
+    let input = "def private foo() \{\n    // close brace \}\n    //! description\n\}\n"
+    let want = "def private foo() \{\n    // close brace \}\n\}\n"
+    t |> equal(trim_private_docstrings(input), want)
+}
+
+
+[test]
+def test_brace_in_single_line_block_comment(t : T?) {
+    // `{` inside a `/* ... */` block comment that opens and closes on the
+    // same line must not desync the brace counter.
+    let input = "def private foo() \{\n    /* literal \{ inside */\n\}\ndef public_fn() \{\n    //! kept\n\}\n"
+    t |> equal(trim_private_docstrings(input), input)
+}
+
+
+[test]
+def test_brace_in_multiline_block_comment(t : T?) {
+    // Block comment spanning multiple lines — braces inside any line of the
+    // comment must be ignored; counter resumes only after `*/`.
+    let input = "def private foo() \{\n    /* line1\n       \{ middle line\n       last */\n\}\ndef public_fn() \{\n    //! kept\n\}\n"
+    t |> equal(trim_private_docstrings(input), input)
+}
+
+
+[test]
+def test_brace_in_nested_block_comment(t : T?) {
+    // daslang's lexer supports nested `/* /* */ */`. Braces at any nesting
+    // level must be ignored; the counter resumes only after the outermost
+    // `*/`.
+    let input = "def private foo() \{\n    /* outer /* inner \{ */ middle */\n\}\ndef public_fn() \{\n    //! kept\n\}\n"
+    t |> equal(trim_private_docstrings(input), input)
+}
+
+
+[test]
+def test_process_path_missing_file(t : T?) {
+    // Missing input must surface as missing_file, not be silently treated
+    // as no_change. Without the fix, fread returns "" on missing files and
+    // the tool exits 0.
+    let r = process_path("/_no_such_file_for_hygiene_test_xyz_42.das", false)
+    t |> equal(r.kind, ProcessResultKind.missing_file)
+}
+
+
+[test]
+def test_process_path_directory(t : T?) {
+    // Passing a directory must surface as not_a_file. Without the fix,
+    // stat(dir).is_valid is true, fread(dir) returns "", and the function
+    // would silently report no_change (treating a mistakenly-passed dir as
+    // a clean file).
+    let r = process_path(".", false)
+    t |> equal(r.kind, ProcessResultKind.not_a_file)
+}


### PR DESCRIPTION
## Summary

dasSQLITE chunk 11 reworks the SQL macro internals around a unified `SqlFrag` fragment stream, ships two new mode-2 macros (`_sql_pragma` / `_sql_vacuum_into`), adds a runtime `_order_by(string)` overload, and lands a few side detours (require pre-scanner fix, `.gitignore` glob, comment-hygiene policy + sweep, new `utils/hygiene` tool, new `skills/regex.md`).

## What's in this PR

### dasSQLITE chunk 11 (the headline)
- **`SqlFrag` fragment builder** — `_sql` / `_sql_text` / `_create_view` macros now emit a typed fragment stream (`text` / `bind` / `inline_id` / `inline_lit`) instead of hand-built strings. A single `fold_to_builder` consumes the stream and produces an `ExprStringBuilder` that mixes literal SQL with runtime `sql_quote_id` / `sql_quote_lit` calls when an identifier or literal isn't compile-time constant.
- **`_sql_pragma(name, value)` / `_sql_vacuum_into(path)`** — mode-2 macros that accept const args (compile-time path) and runtime args (runtime path through the same fragment pipeline).
- **Runtime `_order_by(query, "field ASC, other DESC")`** — accepts a string ORDER BY clause, validates field names against the schema, integrates with the existing `_order_by(...)` macro family.
- **`sql_quote_id` / `sql_quote_lit`** — runtime helpers used by the SqlFrag builder for non-const fragments.
- **Tests:** `test_91_sql_pragma_macro.das`, `test_91_sql_vacuum_into_macro.das`, `test_92_order_by_runtime.das`, plus `failed_sql_pragma_vacuum.das` / `failed_create_view.das` for compile-time error coverage.

### Drive-by fixes
- **`ast_parse`**: require pre-scanner now skips `\X` backslash escapes inside `"..."` and `'...'`. Without this, `getAllRequireReq` phantom-matched `require X` inside string literals (e.g. test fixtures emitting source code as strings).
- **`.gitignore`**: glob `libhv.*.log` instead of hardcoded date.

### Comment-hygiene policy (`CLAUDE.md`) + sweep
New guidance:
1. No banner comments above documented functions (`// === name === ` blocks above a function whose body has `//!` are noise).
2. No multi-paragraph architectural prose at section heads — that belongs in plans / API docs / RST tutorials.
3. `private` declarations don't get public-style `//!` / `//!<` docs.

Applied across `sqlite_boost.das` / `sqlite_linq.das` for a net **~478-line reduction** (1586 insertions, 2063 deletions overall).

### New `utils/hygiene` tool
A daslang-native rule-based hygiene linter. Ships one initial rule:
- `rule_private_docs` — strips `//!` / `//!<` from `private` declarations.

Built and run alongside the other in-tree utils via `utils/CMakeLists.txt`. Includes its own test file `test_hygiene.das`.

(This replaces an earlier python-script prototype `scripts/trim_private_docstrings.py` that was committed during the chunk-11 sweep and is now removed in favor of the daslang version.)

### New skill: `skills/regex.md` (+ `install/skills/regex.md`)
Regex authoring guide for `.das` code: the daslang `regex` API surface, escape table, common gotchas, links to the canonical examples.

### Deferred
Migration helpers planned for chunk 11 are deferred to the final dasSQLITE chunk; only the pragma/vacuum/order-by surface ships here.

## Test plan

- [x] Lint: 0 issues / 0 errors on changed `.das` files
- [x] Interpreted tests: **7422 / 7422 pass**, no GC leaks
- [x] AOT tests: **6816 / 6816 pass**, no leaks
- [x] dupe-detect over `modules/dasSQLITE` + `tests/dasSQLITE` + `utils/hygiene` + `daslib`: no new-code collisions; all hits are pre-existing parallel APIs in `sqlite_boost.das`
- [x] Format: all 11 changed `.das` files clean per MCP `format_file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
