### PR TITLE
tests: add class_boost coverage

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -1474,26 +1474,30 @@ namespace das {
                                 reportAstChanged();
                                 return newCall;
                             }
-                            // lets try static class method
+                            // lets try static class method (and their parents)
                             if (valueType->baseType == Type::tStructure) {
-                                callName = "_::" + valueType->structType->name + "`" + methodName;
-                                newCall->name = callName;
-                                fcall = inferFunctionCall(newCall, InferCallError::tryOperator);
-                                if ((fcall != nullptr && fcall->isStaticClassMethod) || newCall->name != callName) {
-                                    reportAstChanged();
-                                    return newCall;
+                                for ( auto st = valueType->structType; st; st = st->parent ) {
+                                     callName = "_::" + st->name + "`" + methodName;
+                                     newCall->name = callName;
+                                     fcall = inferFunctionCall(newCall, InferCallError::tryOperator);
+                                     if ((fcall != nullptr && fcall->isStaticClassMethod) || newCall->name != callName) {
+                                         reportAstChanged();
+                                         return newCall;
+                                     }
                                 }
                             } else if (valueType->baseType == Type::tPointer && valueType->firstType && valueType->firstType->baseType == Type::tStructure) {
-                                callName = "_::" + valueType->firstType->structType->name + "`" + methodName;
-                                newCall->name = callName;
                                 auto derefValue = new ExprPtr2Ref(value->at, value);
                                 derefValue->type = new TypeDecl(*valueType->firstType);
                                 derefValue->type->constant |= valueType->constant;
                                 newCall->arguments[0] = derefValue;
-                                fcall = inferFunctionCall(newCall, InferCallError::tryOperator);
-                                if ((fcall != nullptr && fcall->isStaticClassMethod) || newCall->name != callName) {
-                                    reportAstChanged();
-                                    return newCall;
+                                for ( auto st = valueType->firstType->structType; st; st = st->parent ) {
+                                    callName = "_::" + st->name + "`" + methodName;
+                                    newCall->name = callName;
+                                    fcall = inferFunctionCall(newCall, InferCallError::tryOperator);
+                                    if ((fcall != nullptr && fcall->isStaticClassMethod) || newCall->name != callName) {
+                                        reportAstChanged();
+                                        return newCall;
+                                    }
                                 }
                             }
                         }

--- a/tests/README.md
+++ b/tests/README.md
@@ -82,6 +82,13 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | test_bool_array.das | BoolArray — push, index, clear, resize, iteration, operators | |
 | test_bool_array_iterator_crash.das | BoolArray iterator context mismatch repro — benchmark context isolation | |
 
+## class_boost/
+
+| File | Description | Expects errors |
+|---|---|---|
+| test_class_boost.das | class_boost annotations on classes — self injection, inheritance calls, explicit const overload dispatch | |
+| failed_explicit_const_non_static.das | Non-static method annotated with `explicit_const_class_method` is rejected | **expect** `30111` |
+
 ## bare_block/
 
 | File | Description | Expects errors |
@@ -767,9 +774,7 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 | strings_properties.das | length, empty, starts_with, ends_with with fuzzing | |
 | strings_replace_multiple.das | replace_multiple — multiple replacements, special chars, empty | |
 | strings_search.das | find (string and char) with fuzzing | |
-| utf8_word_boundary.das | utf32_is_word_char / utf32_to_lower / each_word — Unicode word-boundary primitives | |
-| fts5_query.das | FTS5 query parser — terms, phrases, AND/OR/NOT, NEAR, parens, error reporting | |
-| fts5_query_eval.das | FTS5 query evaluator — match semantics including Unicode case-fold and prefix phrases | |
+| strings_text_match.das | text_match — FTS5-subset AND/prefix matcher, panic on unsupported syntax | |
 | strings_traits.das | is_alpha, is_new_line, is_white_space, is_number with fuzzing | |
 | temporary_intern_strings.das | temp_string with intern_strings option | |
 | temporary_strings.das | temp_string, build_temp_string — no heap allocations | |

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,6 +34,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | test_lambdas.das | AOT lambda codegen — capture, invoke, nested | |
 | test_strings.das | AOT string operations — interpolation, comparison, builder | |
 | test_structures.das | AOT struct codegen — construction, fields, methods, inheritance | |
+| t_invoke_void.das | AOT `invoke` dispatch — void-returning function pointer via AOT path | |
 
 ## apply/
 
@@ -164,6 +165,101 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | test_02_insert.das | `[sql_table]` macro emissions (table name, DDL, two INSERT shapes), `create_table` / `drop_table_if_exists` round-trip, single-row + array `insert`, `try_insert` constraint violation | |
 | test_03_last_rowid.das | `INTEGER PRIMARY KEY` ↔ ROWID — no-PK insert auto-assigns rowid, explicit-PK insert preserves Id, array insert returns last rowid, `_sql_pk_is_unset` predicate, drop+recreate resets rowid | |
 | test_04_user_types.das | User-defined SQL-mapped types — `sqlite_sql_type` / `sqlite_bind` overloads for a user `Color` struct, `[sql_table]` DDL emission with the user type, INSERT round-trip through the custom bind path | |
+| test_05_sql_macro.das | `_sql` bare `select_from` chain with `_where` / `_select` / `_to_array` composability (bind captures, literals, boolean ops) | |
+| test_05a_select_from_compat.das | Compatibility mode: `select_from(db, type<T>)` bare function vs `_sql` macro optimizer (client-side `_where` filtering via linq) | |
+| test_06_sql_text.das | `_sql_text` compile-time SQL emission (bare select, projections, WHERE with captures, AND/OR/NOT, composed chains, no-op `_to_array`) | |
+| test_07_macros.das | Macro support module: `when_price_lt` and `when_lt` user-defined call_macro examples for composability testing | |
+| test_07_sql_composability.das | Mode 2 composability: user-defined call_macros expand bottom-up, interleave with canonical `_where` / `_select`, produce identical SQL | |
+| test_08_first.das | `_first()` single-row terminal (LIMIT 1, panic on empty, with `_where` filter, named-tuple projection) | |
+| test_09_first_opt.das | `_first_opt()` returns Option<T> (some on match, none on empty or no-match) | |
+| test_10_query_one_positional.das | `query_one` 0/1-arg positional bind (zero-arg returns first row, single-arg filters by bind param) | |
+| test_11_query_one_variadic.das | `query_one` 2/3-arg positional binds (mixed types: string+int, three mixed args) | |
+| test_13_query_one_opt.das | `query_one_opt` returns Option<T> on 0-row case (some on match, none on no-match, zero-arg empty table) | |
+| test_15_query_scalar_int.das | `query_scalar` scalar return types: int (positive, negative) | |
+| test_16_query_scalar_int64.das | `query_scalar` int64 (max value, COUNT(*) narrowing) | |
+| test_17_query_scalar_double.das | `query_scalar` double precision floating-point | |
+| test_18_query_scalar_bool.das | `query_scalar` boolean (1→true, 0→false, predicates) | |
+| test_19_query_scalar_opt.das | `query_scalar_opt` returns Option<T> (string, int, int64, double, bool; none on empty) | |
+| test_20_try_query_scalar_overloads.das | `try_query_scalar` all type overloads (int, int64, double, bool) and error on no rows | |
+| test_21_try_sql_macro.das | `_try_sql` wrapper (non-panicking Result sibling of `_sql`; array, `_first`, `_first_opt`, count, empty-table error handling) | |
+| test_22_select_named_tuple.das | `_select` with named-tuple projection `(Name=_.Name, Price=_.Price)` (2-field, 3-field, emits SELECT distinct cols) | |
+| test_24_where_starts_with.das | `starts_with` string predicate (LIKE pattern escape, literal `%` handling) | |
+| test_25_where_ends_with.das | `ends_with` string predicate (LIKE pattern escape, literal `_` handling) | |
+| test_26_where_contains.das | `contains` substring match (LIKE wildcards, escape, literal `\` handling) | |
+| test_27_where_to_lower.das | `to_lower()` / `to_upper()` case-insensitive matching (emits LOWER/UPPER SQL functions) | |
+| test_28_where_length.das | `length()` string function in predicates (emits LENGTH SQL function) | |
+| test_29_where_abs.das | `abs()` mathematical function (emits ABS SQL function) | |
+| test_30_count_canary.das | `count()` aggregate canary — emits COUNT(*), empty table returns 0, `_select` pass-through | |
+| test_31_count_with_where.das | `count()` with `_where` filter (emits COUNT(*) FROM ... WHERE) | |
+| test_32_distinct.das | `distinct()` emits SELECT DISTINCT (full-row dedup, composes with `_where`) | |
+| test_33_take_skip.das | `take(n)` / `skip(n)` emit LIMIT / OFFSET; bind ordering, `_first` overrides take | |
+| test_34_order_by.das | `_order_by` ASC and `_order_by_descending` DESC; tuple-key multi-column sorting | |
+| test_35_aggregates.das | Column aggregates: `sum()` / `average()` / `min()` / `max()` with `_select(_.Col)` | |
+| test_36_group_by.das | `_group_by` with IGrouping shape (`_._0`=key, `_._1`=rows for COUNT/SUM/AVG/MIN/MAX) | |
+| test_37_null_handling.das | Option<T> type-driven nullability (NOT NULL vs nullable, DDL, INSERT/SELECT round-trip) | |
+| test_38_join.das | `_join` inner equi-join (INNER JOIN ON, table aliases, named-tuple result projection) | |
+| test_39_left_join.das | `_left_join` LEFT OUTER JOIN (right param Option<TB>, `is_some()` / `is_none()` probes for NULL) | |
+| test_40_in_not_in.das | `_in` / `_not_in` subquery operators (emits IN (SELECT ...), `_select(_.Col)` projection required) | |
+| test_41_any_none.das | `_any` / `_none` EXISTS / NOT EXISTS operators (uncorrelated subqueries in WHERE) | |
+| test_42_set_ops.das | Set operations: `union()` / `intersect()` / `except()` (UNION SELECT, same column projections) | |
+| test_43_update_by_pk.das | `update(row)` row-based by-PK update (PK match returns 1, missing PK returns 0) | |
+| test_44_update_bulk.das | `_sql_update(type<T>, predicate, set_dict)` bulk predicate-based update with literal/captured values | |
+| test_45_update_returning.das | `_sql_update_returning` UPDATE ... RETURNING (surfaces post-update row, multi-row with WHERE filters) | |
+| test_46_delete_by_pk.das | `delete_(row)` and `delete_by_id(type<T>, pk)` by-PK deletion (1 row affected on match, 0 on missing) | |
+| test_47_delete_bulk.das | `_sql_delete(type<T>, predicate)` bulk predicate-based delete | |
+| test_48_delete_returning.das | `_sql_delete_returning` DELETE ... RETURNING (surfaces deleted rows, empty on no-match) | |
+| test_49_changes.das | `changes()` queries rows-affected count from last exec UPDATE/DELETE | |
+| test_50_with_transaction.das | `with_transaction()` / `in_transaction()` autocommit/manual mode (Deferred / Immediate modes) | |
+| test_51_try_transaction.das | `try_transaction()` non-panicking transaction wrapper (error recovery, immediate mode) | |
+| test_52_insert_or_ignore.das | `insert_or_ignore` CONFLICT IGNORE strategy (fresh insert, silent on PK clash, bulk array partitioning) | |
+| test_53_insert_or_replace.das | `insert_or_replace` CONFLICT REPLACE strategy (overwrite on PK match, fresh insert, bulk) | |
+| test_54_upsert_single_col.das | `_sql_upsert(row, _.Col, set_dict)` single-column ON CONFLICT key (insert vs merge branch, _excluded reference) | |
+| test_55_upsert_composite.das | `_sql_upsert` multi-column composite conflict keys via tuple `(_.Email, _.Tenant)` | |
+| test_56_upsert_returning.das | `_sql_upsert_returning` UPSERT ... RETURNING (post-merge row on conflict, fresh row on insert) | |
+| test_57_sql_unique.das | `@sql_unique` column annotation (DDL emission, constraint enforcement, distinct values allowed) | |
+| test_58_sql_references.das | `@sql_references` / `@sql_on_delete` foreign-key relationships (DDL REFERENCES clause, CASCADE delete semantics) | |
+| test_59_sql_index.das | `[sql_index]` DDL emission (single-col, composite, unique indexes with auto-naming) | |
+| test_60_defaults_computed.das | Defaults (native field init → DEFAULT, `@sql_default_fn` built-ins) and computed columns (`@sql_computed` VIRTUAL/STORED) | |
+| test_61_custom_types.das | `sql_bind` / `sql_extract` adapter rail (DateTime via int64, Guid via array<uint8>, enum via int, Option<T> nullability) | |
+| test_62_blob.das | `array<uint8>` BLOB storage (DDL, byte-level round-trip, large blobs, Option<array<uint8>>) | |
+| test_63_exec_params.das | `exec` parameterized binds (0/1/2/3-arg variadic overloads for raw DDL/DML) | |
+| test_64_json_columns.das | `@sql_json` tuple storage (TEXT storage via daslib/json JV/from_JV, DDL override, round-trip) | |
+| test_65_blob_struct.das | `@sql_blob` struct storage (archive-based via daslib/archive, multiple BLOB fields, nested shapes, mixed plain+blob+json) | |
+| test_66_column_info.das | `column_info(type<T>)` compile-time struct walk (ColumnInfo array, nullable probes, `sqlite_sql_type` rendering) | |
+| test_67_query_raw.das | Raw SQL query shapes (PRAGMA, sqlite_master; position-based field mapping without name alignment) | |
+| test_68_sql_column_rename.das | `@sql_column = "<sql_name>"` renames on-disk column (DDL, _sql predicates, _order_by, column_info, INSERT/UPDATE/DELETE) | |
+| test_69_sql_column_join.das | `@sql_column` rename through JOIN ON clause (both sides renamed to SQL keywords) | |
+| test_70_sql_column_upsert.das | `@sql_column` rename across UPSERT (ON CONFLICT/DO UPDATE SET emit renamed SQL identifiers) | |
+| test_71_sql_column_index_fk.das | `@sql_column` rename with `[sql_index]` and `@sql_references` (FK target PK rename) | |
+| test_72_view_basic.das | `[sql_view]` read-only views (macro emit, `_create_view`, select_from on view type, named projections) | |
+| test_74_register_function_basic.das | `register_function("name", @@fn)` UDF registration (0–4-arg overloads, all scalar types) | |
+| test_75_register_function_null_panic.das | NULL short-circuit (no invocation on NULL arg → NULL result) and panic recovery | |
+| test_76_register_function_use_in_chains.das | Registered UDFs usable in WHERE / ORDER BY / projection (deterministic UDF embed in `_sql` chains) | |
+| test_77_register_function_lifetime.das | UDF registration lifetime (re-register replaces binding, per-connection scope) | |
+| test_80_pragma_basic.das | `set_pragma` string/int64/bool values (journal_mode, busy_timeout, foreign_keys round-trip) | |
+| test_83_backup_to.das | `backup_to(dst_db)` snapshot copy (memory-to-memory, row count preservation, content verification) | |
+| test_85_vacuum.das | `vacuum()` database rebuild (in-memory rebuilds, `try_vacuum()` errors in transactions) | |
+| test_90_each_sql_basic.das | `_each_sql` iterator form (for loop over cursor, break finalizes stmt, streaming without materializing) | |
+| test_91_sql_pragma_macro.das | `_sql_pragma("name", value)` macro form (const/runtime string values and names) | |
+| test_91_sql_vacuum_into_macro.das | `_sql_vacuum_into(path)` macro form (vacuum into file path, runtime string path, verification across reopen) | |
+| test_92_order_by_runtime.das | Runtime `_order_by(string)` column-name binding (const string folds to compile-time, runtime path uses sql_quote_id) | |
+| test_93_attach.das | `with_attached(path, alias)` attach secondary database file (query across attached, temp-file cleanup) | |
+| test_94_fts5.das | `[sql_fts5]` full-text search (CREATE VIRTUAL TABLE fts5, `@sql_fts_rank` hidden rank column, INSERT skips rank) | |
+| failed_create_view.das | `_create_view` macro validation failures (column count/type mismatches, non-annotated struct, bound parameters) | **expect** `40104:7` |
+| failed_each_sql_terminals.das | `_each_sql` rejects materializing terminals (`_to_array`, `_first`, `_first_opt`, aggregates) | **expect** `40104:4` |
+| failed_pred_json_path_typo.das | Predicate-side JSON-path validation (typo detection in `_.Field.nested` chains) | **expect** `40104:3, 30503:3` |
+| failed_register_function.das | `register_function` compile-time type validation (struct args, struct returns, pointers, non-function references) | **expect** `40104:5` |
+| failed_sql_column.das | `@sql_column` annotation validation (empty value, embedded quotes/backslashes, cross-field collisions) | **expect** `30111:5` |
+| failed_sql_fts5.das | `[sql_fts5]` field-annotation rejections (`@sql_column` on `@sql_fts_rank`) | **expect** `30111:1` |
+| failed_sql_index.das | `[sql_index]` validation (missing fields, nonexistent columns, ordering with `[sql_table]`) | **expect** `30111:4` |
+| failed_sql_json_blob_kind_collision.das | Payload type kind collision rejection (same type in `@sql_json` vs `@sql_blob`) | **expect** `30111:3` |
+| failed_sql_macro.das | `_sql` / `_sql_text` analyzer failures (22 malformed chains: invalid roots, duplicate modifiers, unsupported expressions) | **expect** `40104:22, 30304:2, 30503:2` |
+| failed_sql_pragma_vacuum.das | `_sql_pragma` / `_sql_vacuum_into` argument-shape validation (wrong types, arg counts) | **expect** `40104:5` |
+| failed_sql_table_schema.das | `[sql_table]` schema-validation failures (computed+PK collision, defaults+initializers, FK actions, reference resolution) | **expect** `30111:12` |
+| failed_sql_update_delete.das | `_sql_update` / `_sql_delete` analyzer failures (wrong arity, non-type args, typos, duplicate columns) | **expect** `40104:7` |
+| failed_sql_upsert.das | `_sql_upsert` analyzer failures (wrong arity, on_conflict/do_update validation, duplicate columns) | **expect** `40104:10` |
+| failed_sql_view_mutations.das | `_sql_update` / `_sql_delete` / `_sql_upsert` against `[sql_view]` types (read-only rejection) | **expect** `40104:8` |
+| failed_sql_view_schema.das | `[sql_view]` field-annotation rejections (PK, UNIQUE, COMPUTED, DEFAULT, initializers, FK, column collisions) | **expect** `30111:9` |
 
 ## daslib/
 
@@ -171,6 +267,8 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 |---|---|---|
 | ast_cursor_fixture.das | *(helper)* Fixture file for ast_cursor tests | |
 | ast_cursor_test.das | `daslib/ast_cursor` — cursor-based AST navigation and query | |
+| clargs_test.das | `daslib/clargs` — string flags, `=`-style assignment, array flags, int/float flags, bool/help flags | |
+| keyword_test.das | `daslib/keyword` — `is_cpp_keyword`, `is_das_keyword`, `is_keyword` predicates | |
 
 ## dastest/
 
@@ -263,6 +361,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | fio_errors.das | Path manipulation and error handling — extension, dir_name, base_name, normalize, mkdir/rmdir edge cases | |
 | fio_file.das | File I/O — fopen, fread, fwrite with fuzzing | |
 | fio_utils.das | File utilities — fexist, rmdir, rmdir_rec, fread/fwrite by path, get_das_version | |
+| popen_argv.das | `popen_argv` — basic invocation, non-zero exit on unknown flag, exit code capture | |
 
 ## functional/
 
@@ -307,7 +406,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 
 ## jit_tests/
 
-48 files testing JIT compilation code generation. None have `expect` directives.
+50 files testing JIT compilation code generation. None have `expect` directives.
 
 | File | Description | Expects errors |
 |---|---|---|
@@ -324,6 +423,8 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | compare.das | Comparison operators | |
 | dim.das | Fixed-size arrays (dim) | |
 | dim2d.das | 2D fixed arrays | |
+| default_fn_ptr.das | Default function pointer argument — invoke with default `@@noop_handler` | |
+| dll_cache.das | JIT DLL content-addressed caching — identical source → cache hit, changed source → cache miss | |
 | extern_call.das | External function calls | |
 | finally.das | Finally blocks | |
 | for_loop.das | For loop codegen | |
@@ -370,8 +471,11 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | test_jobque_edge.das | Channel edge cases — single-item, large batch | |
 | test_jobque_jobs.das | JobStatus, new_job with channels and messages | |
 | test_jobque_lockbox.das | LockBox basics — create, destroy, validity | |
+| test_jobque_lockbox_fill_grab.das | LockBox `fill`/`grab` — fill marks ready, grab returns data and resets, multi-element batch | |
 | test_jobque_parallel.das | parallel_for, parallel work distribution | |
+| test_jobque_stream.das | Channel stream — push/pop bytes, structured data serialization via archive | |
 | test_jobque_try_pop.das | try_pop_clone — non-blocking pop, empty/data/drain | |
+| test_jobque_tracking.das | Job status leak tracking — channel create+remove leaves no leak, `--track-job-status` canary | |
 | test_jobque_wait_group.das | with_wait_group — convenience wrapper for job completion | |
 
 ## json/
@@ -567,7 +671,6 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | safe_index.das | Safe index `?[]` on arrays, tables, vectors, strings | |
 | safe_ptr_at.das | Safe index `?[]` on pointer types — null safety, struct pointer arrays | |
 | safe_operators.das | Custom `operator []`, `?[]`, `.`, `?.` on user struct | |
-| scatter_gather.das | SIMD gather/scatter ops — int, uint, float arrays with uint4 indices | |
 | serialization.das | Archive serialization — structs, custom serialize, arrays, tables | |
 | set_table.das | `table<int>` as set — insert, erase, keys iteration, clone, literal | |
 | setand_and_setor_bool.das | Short-circuit `\|\|=` and `&&=` operators | |
@@ -575,7 +678,6 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | simple_string.das | String pass semantics — by value, by ref, clone, return, struct fields | |
 | failed_sizeof_reference.das | `sizeof` on reference types | **expect** `39902:2` |
 | smart_ptr.das | `smart_ptr<TestObjectSmart>` — scope, move, ref count, clone, use_count | |
-| failed_smart_ptr_move.das | Unsafe `<-` move on `smart_ptr<>` type | **expect** `31300:1` |
 | sort.das | Sort on arrays/fixed_arrays — int, uint, int64, float, double, string, custom struct, vector | |
 | static.das | Static class members and methods | |
 | failed_static_assert_in_infer.das | Static assertion during type inference | **expect** `40100` |
@@ -593,6 +695,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | super_finalize.das | `delete super.self` — base-class finalizer chain (class, 3-level, free struct finalizer) | |
 | cant_delete_super_self.das | `delete super.self` misuse — outside finalizer, no base, wrong arg shape | **expect** `31002:6` `30305:6` `30503:6` |
 | table.das | Table tombstone handling and iteration | |
+| table_get_key.das | `get_key(table, value)` — retrieve key by iterator value for int↔float, string↔int, const table, tombstones, empty, single entry | |
 | table_operations.das | Table find, insert, delete, key_exists, erase collision, lock panic, defaults, modify | |
 | test_value_table_key.das | `table<EntityId; string>` — value-type table key ops, set operations | |
 | testing_tools.das | Faker, fuzzer, testing_boost tools | |
@@ -649,9 +752,12 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 | test_linq_concat.das | append, prepend, concat operations | |
 | test_linq_element.das | element_at, first, last, single | |
 | test_linq_fold.das | Comprehension fold, method chaining syntax | |
+| test_linq_fold_ast.das | Compile-time AST fold — `_where` rewrite to comprehension, pattern recognition in macro | |
 | test_linq_from_decs.das | LINQ querying decs entities | |
 | test_linq_generation.das | default_empty, repeat, range generation | |
+| test_linq_group_by.das | `_group_by_lazy` on arrays — primitive key, string key, `_having` filter | |
 | test_linq_join.das | join, group_join operations | |
+| test_linq_join_errors.das | `_join` / `_left_join` non-equi-join rejection (theta joins, AND-chained keys) | **expect** `40104:5` |
 | test_linq_partition.das | skip, take, skip_while, take_while | |
 | test_linq_querying.das | any, all, contains, where | |
 | test_linq_set.das | distinct, union, intersect, except | |
@@ -685,6 +791,7 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 |---|---|---|
 | fake_numeric.das | *(helper)* Macro module — FakeNumericMacro for comprehensive faker tests | |
 | inf_and_nan.das | Infinity and NaN comparisons | |
+| double_math.das | `double` math functions — floor, ceil, round, fract, saturate, min/max, clamp, abs, sign, sqrt, large-cycle precision | |
 | math_matrix.das | Matrix operations — multiply, equality, transpose with fuzzing | |
 | math_numeric.das | Numeric math functions (sin, cos, tan, etc.) via fake_numeric macro | |
 | mat_ctors.das | Matrix constructors — float3x3, float3x4, float4x4, identity, sequence, row verification | |
@@ -698,7 +805,7 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 | File | Description | Expects errors |
 |---|---|---|
 | test_option.das | `Option<T>` — some/none constructors, map/filter/and_then/or_else/or_value, unwrap family, operators `??`/`==`, zip, if_some/if_none, chaining | |
-| _test_option_non_copyable.das | **DISABLED** (leading `_` skips dastest discovery). `Option<array<int>>` — every constructor/combinator/unwrap/operator with a non-copyable payload, plus `move_some`. Disabled because `test_chaining` fails to compile in `test_aot -use-aot` on darwin26-Release runners (passes everywhere else, including darwin26-Debug). Re-enable by renaming back once the underlying daslang generic-resolution bug is fixed. | |
+| test_option_non_copyable.das | `Option<array<int>>` — every constructor/combinator/unwrap/operator with a non-copyable payload, plus `move_some` | |
 | test_result.das | `Result<T, E>` — ok/err constructors, map/map_err/and_then/or_else, unwrap family, operators `??`/`==`, to_option/err_to_option bridges, if_ok/if_err, chaining | |
 | test_result_non_copyable.das | `Result<array<int>, string>` — every constructor/combinator/unwrap/operator with a non-copyable T, plus `move_ok` and `move_err` | |
 
@@ -750,6 +857,7 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 | test_load_info.das | Image info queries — dimensions, channels, format detection without full load | |
 | test_raster.das | Rasterization — draw_line, draw_rect, fill_rect, draw_circle, pixel blending | |
 | test_raster_blit.das | Blit operations — copy, scale, alpha-blend, region transfer | |
+| scatter_gather.das | SIMD gather/scatter — `gather_scatter` for int, uint, float, float2/3/4, int2/3/4 via uint4 index pairs | |
 | test_resize.das | Image resize — nearest, bilinear, bicubic, different target sizes | |
 | test_settings.das | Image load/save settings — quality, compression, flip | |
 | test_stbimage_ttf.das | stbimage_ttf — safe TrueType font rendering via stbimage_boost + stbtruetype | |
@@ -774,7 +882,9 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 | strings_properties.das | length, empty, starts_with, ends_with with fuzzing | |
 | strings_replace_multiple.das | replace_multiple — multiple replacements, special chars, empty | |
 | strings_search.das | find (string and char) with fuzzing | |
-| strings_text_match.das | text_match — FTS5-subset AND/prefix matcher, panic on unsupported syntax | |
+| utf8_word_boundary.das | utf32_is_word_char / utf32_to_lower / each_word — Unicode word-boundary primitives | |
+| fts5_query.das | FTS5 query parser — terms, phrases, AND/OR/NOT, NEAR, parens, error reporting | |
+| fts5_query_eval.das | FTS5 query evaluator — match semantics including Unicode case-fold and prefix phrases | |
 | strings_traits.das | is_alpha, is_new_line, is_white_space, is_number with fuzzing | |
 | temporary_intern_strings.das | temp_string with intern_strings option | |
 | temporary_strings.das | temp_string, build_temp_string — no heap allocations | |

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -71,6 +71,11 @@ FILE(GLOB AOT_BITFIELDS_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "
 # AOT for bool_array test files
 FILE(GLOB AOT_BOOL_ARRAY_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/bool_array/*.das")
 
+# AOT for class_boost test files
+FILE(GLOB AOT_CLASS_BOOST_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/class_boost/*.das")
+# Exclude expect-error tests (they intentionally fail to compile)
+list(FILTER AOT_CLASS_BOOST_FILES EXCLUDE REGEX "failed_")
+
 # AOT for data_walker test files
 FILE(GLOB AOT_DATA_WALKER_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/data_walker/*.das")
 
@@ -381,6 +386,10 @@ add_custom_target(test_aot_bool_array)
 SET(BOOL_ARRAY_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_BOOL_ARRAY_FILES}" BOOL_ARRAY_AOT_GENERATED_SRC test_aot_bool_array daslang)
 
+add_custom_target(test_aot_class_boost)
+SET(CLASS_BOOST_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_CLASS_BOOST_FILES}" CLASS_BOOST_AOT_GENERATED_SRC test_aot_class_boost daslang)
+
 add_custom_target(test_aot_data_walker)
 SET(DATA_WALKER_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_DATA_WALKER_FILES}" DATA_WALKER_AOT_GENERATED_SRC test_aot_data_walker daslang)
@@ -613,6 +622,7 @@ SOURCE_GROUP_FILES("aot generated" BARE_BLOCK_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" BASE64_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" BITFIELDS_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" BOOL_ARRAY_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" CLASS_BOOST_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DATA_WALKER_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DEBUG_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DEBUG_AGENT_AOT_GENERATED_SRC)
@@ -678,6 +688,7 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
     ${BASE64_AOT_GENERATED_SRC}
     ${BITFIELDS_AOT_GENERATED_SRC}
     ${BOOL_ARRAY_AOT_GENERATED_SRC}
+    ${CLASS_BOOST_AOT_GENERATED_SRC}
     ${DATA_WALKER_AOT_GENERATED_SRC}
     ${DEBUG_AOT_GENERATED_SRC}
     ${DEBUG_AGENT_AOT_GENERATED_SRC}
@@ -736,6 +747,7 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_algorithm test_aot_apply test_aot_archive test_aot_ast_match
     test_aot_assert_once test_aot_async test_aot_bare_block test_aot_base64
     test_aot_bitfields test_aot_bool_array
+    test_aot_class_boost
     test_aot_data_walker test_aot_debug
     test_aot_debug_agent test_aot_daspeg test_aot_decs test_aot_live_host test_aot_live_host_modules test_aot_dynamic_cast_rtti
     test_aot_fio test_aot_fs test_aot_functional

--- a/tests/class_boost/failed_explicit_const_non_static.das
+++ b/tests/class_boost/failed_explicit_const_non_static.das
@@ -1,0 +1,15 @@
+// [explicit_const_class_method] applied to a non-static class method
+// verifies the static-only guard in daslib/class_boost.das ClassMethodMacro.apply
+options gen2
+expect 30111    // invalid_annotation
+
+require daslib/class_boost
+
+class C {
+    value : int = 0
+
+    [explicit_const_class_method]
+    def put(v : int) {
+        value = v
+    }
+}

--- a/tests/class_boost/test_class_boost.das
+++ b/tests/class_boost/test_class_boost.das
@@ -1,0 +1,83 @@
+options gen2
+
+require dastest/testing_boost public
+require daslib/class_boost
+
+class Animal {
+    meals : int = 0
+
+    [class_method]
+    def static eat(extra : int) : int {
+        meals += extra
+        return meals
+    }
+
+    [class_method]
+    def static const meal_count() : int {
+        return meals
+    }
+}
+
+class Dog : Animal {
+    bark_count : int = 0
+
+    [class_method]
+    def static bark() : int {
+        bark_count += 1
+        return bark_count
+    }
+}
+
+class Counter {
+    value : int = 0
+
+    [explicit_const_class_method]
+    def static touch() : int {
+        value += 1
+        return value
+    }
+
+    [explicit_const_class_method]
+    def static const touch() : int {
+        return value
+    }
+}
+
+[test]
+def test_class_method_on_classes(t : T?) {
+    t |> run("class_method mutates self") @(it : T?) {
+        var a : Animal? = new Animal()
+        it |> equal(a.meal_count(), 0)
+        it |> equal(a.eat(2), 2)
+        it |> equal(a.eat(3), 5)
+        it |> equal(a.meal_count(), 5)
+    }
+
+    t |> run("class_method supports inheritance") @(it : T?) {
+        var d : Dog? = new Dog()
+        it |> equal(d.meal_count(), 0)
+        it |> equal(d.eat(4), 4)
+        it |> equal(d.meal_count(), 4)
+        it |> equal(d.bark(), 1)
+        it |> equal(d.bark(), 2)
+    }
+}
+
+[test]
+def test_explicit_const_class_method_overload(t : T?) {
+    t |> run("non-const overload mutates") @(it : T?) {
+        var c : Counter? = new Counter()
+        it |> equal(c.touch(), 1)
+        it |> equal(c.touch(), 2)
+    }
+
+    t |> run("const overload is selected for const self") @(it : T?) {
+        var c : Counter? = new Counter()
+        c.touch()
+        c.touch()
+        let cc : Counter const? = c
+        it |> equal(cc.touch(), 2)
+        it |> equal(c.touch(), 3)
+        it |> equal(cc.touch(), 3)
+    }
+}


### PR DESCRIPTION
## Summary
- updated infer pass to also iterate through parent classes for static variables
- add new class_boost test suite under tests/class_boost/
- cover [class_method] on classes: self mutation and inheritance behavior
- cover [explicit_const_class_method] const/non-const overload dispatch
- add expect-error guard for non-static [explicit_const_class_method]
- register tests/class_boost/*.das in tests/aot/CMakeLists.txt (excluding failed_ files)
- update tests/README.md index with new entries

## Validation
- lint
  - bin/Release/daslang.exe utils/lint/main.das -- tests/class_boost/test_class_boost.das tests/class_boost/failed_explicit_const_non_static.das
- tests
  - bin/Release/daslang.exe dastest/dastest.das -- --test tests/class_boost
  - result: 7 tests, 7 passed, 0 failed, 0 errors, 0 skipped
