### PR TITLE
Fix shifted CompilationError enum descriptions in generated docs

### DIFF
--- a/doc/source/stdlib/handmade/enumeration-rtti-CompilationError.rst
+++ b/doc/source/stdlib/handmade/enumeration-rtti-CompilationError.rst
@@ -103,5 +103,6 @@ No global heap is specified, but program requests it.
 No global variables are allowed in this context.
 Unused function argument.
 Unsafe function.
+Performance lint warning.
 Too many infer passes.
 Missing simulation node.


### PR DESCRIPTION
## Summary
Fixes #2535 by adding the missing handmade description line for CompilationError.performance_lint.

## What changed
- Added one missing line in doc/source/stdlib/handmade/enumeration-rtti-CompilationError.rst:
  - Performance lint warning.

## Why this fixes the issue
- The enum topic mapper expects one summary line plus one description per enum value.
- The handmade file had one fewer description than enum values, causing all generated descriptions to shift by one.
- Adding the missing line restores proper alignment in generated docs.

## Validation
- Regenerated stdlib docs with:
  - in/Release/daslang.exe doc/reflections/das2rst.das
- Verified CompilationError in generated docs now aligns correctly, including:
  - unspecified = 0 - Unspecified error.
  - performance_lint = 40217 - Performance lint warning.
