### PR TITLE
Add compilation callbacks

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1900,4 +1900,26 @@ namespace das
         daScriptEnvironmentGuard(das::daScriptEnvironment *bound = nullptr, das::daScriptEnvironment *owned = nullptr);
         ~daScriptEnvironmentGuard();
     };
+
+    typedef void (*daScriptCompilationCallback)(const string & moduleName, const string & fileName, const string & status);
+
+    DAS_API void setCompilationCallback(daScriptCompilationCallback callback);
+    DAS_API void callCompilationCallback(const string & moduleName, const string & fileName, const string & status);
+
+    struct CompilationCallbackGuard {
+        CompilationCallbackGuard(const string & _moduleName, const string & _fileName, const string & _prefix = "compilation")
+        : moduleName(_moduleName), fileName(_fileName), prefix(_prefix) {
+            callCompilationCallback(moduleName, fileName, prefix + " start");
+        }
+        CompilationCallbackGuard(const CompilationCallbackGuard &) = delete;
+        CompilationCallbackGuard & operator = (const CompilationCallbackGuard &) = delete;
+        CompilationCallbackGuard(CompilationCallbackGuard &&) = delete;
+        CompilationCallbackGuard & operator = (CompilationCallbackGuard &&) = delete;
+        ~CompilationCallbackGuard() {
+            callCompilationCallback(moduleName, fileName, prefix + " end");
+        }
+        string moduleName;
+        string fileName;
+        string prefix;
+    };
 }

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -678,7 +678,6 @@ namespace das {
         }
     };
 
-
     ProgramPtr parseDaScript ( const string & fileName,
                                const string & moduleName,
                               const FileAccessPtr & access,
@@ -687,6 +686,7 @@ namespace das {
                               bool exportAll,
                               bool isDep,
                               CodeOfPolicies policies ) {
+        CompilationCallbackGuard compilationCallbackGuard(moduleName, fileName);
         ProgramPtr program = make_smart<Program>();
         gc_guard parse_gc_scope;
         GcCollectOnExit parse_gc_collect(parse_gc_scope, program.get());
@@ -723,6 +723,7 @@ namespace das {
         yyscan_t scanner = nullptr;
         int64_t file_mtime = access->getFileMtime(fileName.c_str());
         if ( auto fi = access->getFileInfo(fileName) ) {
+            callCompilationCallback(moduleName, fileName, "parse");
             parserState.g_FileAccessStack.push_back(fi);
             const char * src = nullptr;
             uint32_t len = 0;
@@ -799,6 +800,7 @@ namespace das {
             if ( policies.solid_context || program->options.getBoolOption("solid_context",false) ) {
                 program->thisModule->isSolidContext = true;
             }
+            callCompilationCallback(moduleName, fileName, "infer");
             auto timeI = ref_time_ticks();
             restartInfer: program->inferTypes(logs, libGroup);
             if ( policies.macro_context_collect ) libGroup.collectMacroContexts();
@@ -822,6 +824,7 @@ namespace das {
                 auto timeO = ref_time_ticks();
                 if (!program->failed()) {
                     if (program->getOptimize()) {
+                        callCompilationCallback(moduleName, fileName, "optimize");
                         program->optimize(logs,libGroup);
                     } else {
                         program->buildAccessFlags(logs);
@@ -868,6 +871,7 @@ namespace das {
                             "module Module_Name is required", "", LineInfo(),
                                 CompilationError::module_does_not_have_a_name);
                     }
+                    callCompilationCallback(moduleName, fileName, "macro_module");
                     auto timeM = ref_time_ticks();
                     if (!program->failed())
                         program->markMacroSymbolUse();

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -3565,6 +3565,7 @@ namespace das
     }
 
     bool Program::simulate ( Context & context, TextWriter & logs, StackAllocator * sharedStack ) {
+        CompilationCallbackGuard callbackGuard("", thisModule->fileName, "simulation");
         auto time0 = ref_time_ticks();
     #if !(DAS_ENABLE_KEEPALIVE)
         if ( policies.keep_alive ) {

--- a/src/ast/ast_tls.cpp
+++ b/src/ast/ast_tls.cpp
@@ -5,6 +5,25 @@
 
 namespace das {
 
+static daScriptCompilationCallback compilationCallback = nullptr;
+static mutex compilationCallbackMutex;
+
+void setCompilationCallback(daScriptCompilationCallback callback) {
+    lock_guard<mutex> lock(compilationCallbackMutex);
+    compilationCallback = callback;
+}
+
+void callCompilationCallback(const string & moduleName, const string & fileName, const string & status) {
+    daScriptCompilationCallback callback = nullptr;
+    {
+        lock_guard<mutex> lock(compilationCallbackMutex);
+        callback = compilationCallback;
+    }
+    if (callback) {
+        callback(moduleName, fileName, status);
+    }
+}
+
 DynamicModuleInfo::~DynamicModuleInfo() {
     for (auto handler : dll_handlers) {
         closeLibrary(handler);

--- a/tests-cpp/small/test_compilation_callback.cpp
+++ b/tests-cpp/small/test_compilation_callback.cpp
@@ -1,0 +1,95 @@
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+
+#include <algorithm>
+#include <mutex>
+#include <string>
+#include <vector>
+
+using namespace das;
+
+namespace {
+
+struct CallbackEvent {
+    string moduleName;
+    string fileName;
+    string status;
+};
+
+static mutex gCallbackEventsMutex;
+static vector<CallbackEvent> gCallbackEvents;
+
+static void testCompilationCallback(const string & moduleName, const string & fileName, const string & status) {
+    lock_guard<mutex> lock(gCallbackEventsMutex);
+    gCallbackEvents.push_back({moduleName, fileName, status});
+}
+
+static void clearCallbackEvents() {
+    lock_guard<mutex> lock(gCallbackEventsMutex);
+    gCallbackEvents.clear();
+}
+
+static vector<string> statusesForFile(const string & fileName) {
+    lock_guard<mutex> lock(gCallbackEventsMutex);
+    vector<string> statuses;
+    for (const auto & ev : gCallbackEvents) {
+        if (ev.fileName == fileName) {
+            statuses.push_back(ev.status);
+        }
+    }
+    return statuses;
+}
+
+struct CompilationCallbackScope {
+    CompilationCallbackScope() {
+        clearCallbackEvents();
+        setCompilationCallback(&testCompilationCallback);
+    }
+
+    ~CompilationCallbackScope() {
+        setCompilationCallback(nullptr);
+    }
+};
+
+}  // namespace
+
+#define OK_SCRIPT_PATH "/tests-cpp/small/test_compilation_callback_ok.das"
+#define FAIL_SCRIPT_PATH "/tests-cpp/small/test_compilation_callback_fail.das"
+
+TEST_CASE("compilation callback reports success and failure phases") {
+    TextPrinter tout;
+    ModuleGroup dummyLibGroup;
+    auto fAccess = make_smart<FsFileAccess>();
+
+    SUBCASE("successful compile emits start/parse/infer/end for target file") {
+        CompilationCallbackScope callbackScope;
+        const string scriptPath = getDasRoot() + OK_SCRIPT_PATH;
+
+        auto program = compileDaScript(scriptPath, fAccess, tout, dummyLibGroup);
+        REQUIRE(program);
+        REQUIRE_FALSE(program->failed());
+
+        auto statuses = statusesForFile(scriptPath);
+        REQUIRE_FALSE(statuses.empty());
+        CHECK(statuses.front() == "compilation start");
+        CHECK(statuses.back() == "compilation end");
+        CHECK(std::find(statuses.begin(), statuses.end(), "parse") != statuses.end());
+        CHECK(std::find(statuses.begin(), statuses.end(), "infer") != statuses.end());
+    }
+
+    SUBCASE("failed compile still emits start and end for target file") {
+        CompilationCallbackScope callbackScope;
+        const string scriptPath = getDasRoot() + FAIL_SCRIPT_PATH;
+
+        auto program = compileDaScript(scriptPath, fAccess, tout, dummyLibGroup);
+        REQUIRE(program);
+        REQUIRE(program->failed());
+
+        auto statuses = statusesForFile(scriptPath);
+        REQUIRE_FALSE(statuses.empty());
+        CHECK(statuses.front() == "compilation start");
+        CHECK(statuses.back() == "compilation end");
+        CHECK(std::find(statuses.begin(), statuses.end(), "parse") != statuses.end());
+    }
+}

--- a/tests-cpp/small/test_compilation_callback_fail.das
+++ b/tests-cpp/small/test_compilation_callback_fail.das
@@ -1,0 +1,7 @@
+options gen2
+
+[export]
+def main() : int {
+    let value : int = "not an int"
+    return value
+}

--- a/tests-cpp/small/test_compilation_callback_ok.das
+++ b/tests-cpp/small/test_compilation_callback_ok.das
@@ -1,0 +1,6 @@
+options gen2
+
+[export]
+def main() : int {
+    return 0
+}


### PR DESCRIPTION
## Summary

Adds a thread-safe compilation callback mechanism that lets embedders observe the progress of daScript compilation and simulation.

## API

```cpp
// Function pointer type
typedef void (*daScriptCompilationCallback)(
    const string & moduleName,
    const string & fileName,
    const string & status);

void setCompilationCallback(daScriptCompilationCallback callback);
void callCompilationCallback(const string & moduleName, const string & fileName, const string & status);
```

The callback is a global, protected by a mutex, so it is safe to set/clear from any thread.

### Status values emitted during `parseDaScript`

| Status | Meaning |
|---|---|
| `"compilation start"` | `parseDaScript` entered |
| `"parse"` | source file read, lexer/parser about to run |
| `"infer"` | type-inference pass starting |
| `"optimize"` | optimizer about to run (only if `getOptimize()`) |
| `"macro_module"` | macro-module finalization pass |
| `"compilation end"` | `parseDaScript` returning |

### Status values emitted during `Program::simulate`

| Status | Meaning |
|---|---|
| `"simulation start"` | `simulate()` entered |
| `"simulation end"` | `simulate()` returning |

### RAII helper

`CompilationCallbackGuard` emits `"<prefix> start"` on construction and `"<prefix> end"` on destruction. Both `parseDaScript` and `Program::simulate` use it internally.

## Implementation

- `setCompilationCallback` / `callCompilationCallback` live in `src/ast/ast_tls.cpp` (alongside other global state) and are protected by `std::mutex`.
- `CompilationCallbackGuard` is declared in `include/daScript/ast/ast.h`.
- Call sites added in `src/ast/ast_parse.cpp` (5 points) and `src/ast/ast_simulate.cpp` (1 point).

## Tests

`tests-cpp/small/test_compilation_callback.cpp` — doctest cases:
- **ok** path: compile a valid script, assert all expected status strings arrive in order.
- **fail** path: compile a deliberately broken script, assert that `"compilation start"` / `"compilation end"` still bracket the run (callback fires even on error).
