### PR TITLE
opengl: avoid reserved generated identifiers

### DIFF
--- a/modules/dasGlsl/glsl/glsl_internal.das
+++ b/modules/dasGlsl/glsl/glsl_internal.das
@@ -1372,7 +1372,7 @@ class GlslExport : AstVisitor {
             *writer |> write("{repeat("\t",tab)}int {expr.iteratorVariables[index].name} = 0; //")
         } elif (self->isRangeFor(source)) {
             let svtype = "{self->describe_glsl_type(source._type)}"
-            *writer |> write("{repeat("\t",tab)}{svtype} _for_range_{expr.iteratorVariables[index].name} = ")
+            *writer |> write("{repeat("\t",tab)}{svtype} _for_range_v{expr.iteratorVariables[index].name} = ")
         }
     }
     def override visitExprForSource(expr : ExprFor?; source : ExpressionPtr; last : bool) : ExpressionPtr {
@@ -1384,7 +1384,7 @@ class GlslExport : AstVisitor {
             self->newLine(1)
             let sname = "{expr.iteratorVariables[index].name}"
             let stype = "{self->describe_glsl_type(expr.iteratorVariables[index]._type)}"
-            *writer |> write("{repeat("\t",tab)}{stype} {sname} = _for_range_{sname}.x;")
+            *writer |> write("{repeat("\t",tab)}{stype} {sname} = _for_range_v{sname}.x;")
         }
         return source
     }
@@ -1401,7 +1401,7 @@ class GlslExport : AstVisitor {
                 let newsrc = "{self->describe_subexpression(source)}[{svar.name}]"
                 renames |> push(("{iter}", newsrc))
             } elif (self->isRangeFor(source)) {
-                *writer |> write("{svar.name}!=_for_range_{svar.name}.y")
+                *writer |> write("{svar.name}!=_for_range_v{svar.name}.y")
             }
         }
         *writer |> write(" )")

--- a/modules/dasOpenGL/glsl/glsl_opengl.das
+++ b/modules/dasOpenGL/glsl/glsl_opengl.das
@@ -46,7 +46,7 @@ def private generate_bind_uniform_dummy(fnMain : FunctionPtr) {
     fn.flags |= FunctionFlags.exports   // note: this is temporary, until we are done with dependency collecting etc
     fn.result = new TypeDecl(baseType = Type.tVoid, at = fnMain.at)
     fn.arguments |> emplace_new() <| new Variable(at = fnMain.at,
-        name := "__program",
+        name := "_opengl_program",
         _type <- new TypeDecl(at = fnMain.at, baseType = Type.tUInt)
     )
     fn.body = new ExprBlock(at = fnMain.at)
@@ -75,7 +75,7 @@ def private generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr) {
                     blk.list |> emplace(cll_bind)
                     // glUniformAny(gl_GetUniformLocation("varName"),binding)
                     var cll_gul = new ExprCall(at = vv.at, name := "glGetUniformLocation")
-                    cll_gul.arguments |> emplace_new() <| new ExprVar(at = vv.at, name := "__program")
+                    cll_gul.arguments |> emplace_new() <| new ExprVar(at = vv.at, name := "_opengl_program")
                     cll_gul.arguments |> emplace_new() <| new ExprConstString(at = vv.at, value := vv.name)
                     var cll_uni = new ExprCall(at = vv.at, name := "glUniformAny")
                     cll_uni.arguments |> emplace(cll_gul)
@@ -94,7 +94,7 @@ def private generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr) {
                     blk.list |> emplace(cll_bind)
                     // glUniformAny(gl_GetUniformLocation("varName"),binding)
                     var cll_gul = new ExprCall(at = vv.at, name := "glGetUniformLocation")
-                    cll_gul.arguments |> emplace_new() <| new ExprVar(at = vv.at, name := "__program")
+                    cll_gul.arguments |> emplace_new() <| new ExprVar(at = vv.at, name := "_opengl_program")
                     cll_gul.arguments |> emplace_new() <| new ExprConstString(at = vv.at, value := vv.name)
                     var cll_uni = new ExprCall(at = vv.at, name := "glUniformAny")
                     cll_uni.arguments |> emplace(cll_gul)
@@ -126,7 +126,7 @@ def private generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr) {
                 } else {
                     // glUniformAny(gl_GetUniformLocation("varName"),varName)
                     var cll_gul = new ExprCall(at = vv.at, name := "glGetUniformLocation")
-                    cll_gul.arguments |> emplace_new() <| new ExprVar(at = vv.at, name := "__program")
+                    cll_gul.arguments |> emplace_new() <| new ExprVar(at = vv.at, name := "_opengl_program")
                     cll_gul.arguments |> emplace_new() <| new ExprConstString(at = vv.at, value := vv.name)
                     var cll_uni = new ExprCall(at = vv.at, name := "glUniformAny")
                     cll_uni.arguments |> emplace(cll_gul)

--- a/modules/dasOpenGL/opengl/opengl_boost.das
+++ b/modules/dasOpenGL/opengl/opengl_boost.das
@@ -178,8 +178,8 @@ def create_shader(src : string implicit; shaderType : uint; canfail : bool = fal
                 resize(log, 16384)
                 let slog = reinterpret<string> addr(log[0])
                 glGetShaderInfoLog(s, 16384, null, slog)
-                panic("{slog}\n\nFAILED TO CREATE SHADER ({status}):\n{src}\n")
-                delete log
+                to_log(LOG_ERROR, "Shader source:\n{src}\n")
+                panic("{slog}\n\nFAILED TO CREATE SHADER ({status})\n")
             }
         }
         return 0u


### PR DESCRIPTION
﻿Renames generated identifiers that conflict with OpenGL/GLSL reserved naming conventions: __program to _opengl_program and _for_range_<name> to _for_range_v<name>. Also logs shader source separately before panic. Validation: cmake --build D:\Work\daScript\build --config Release --parallel --target daslang.
