### PR TITLE
support for static class methods - with and without self

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -5463,19 +5463,38 @@ namespace das {
                             }
                         }
                     } else {
-                        auto staticName = bt->structType->name + "`" + expr->name;
-                        vector<TypeDeclPtr> types;
-                        if (inferArguments(types, expr->arguments)) {
-                            auto functions = findMatchingFunctions(staticName, types, true);
-                            if (functions.size() == 1) {
-                                auto staticFunc = functions.back();
-                                if (staticFunc->isStaticClassMethod) {
-                                    reportAstChanged();
-                                    expr->name = staticName;
-                                    return Visitor::visit(expr);
-                                }
+                        auto newCall = new ExprCall(expr->at, expr->name);
+                        newCall->atEnclosure = expr->atEnclosure;
+                        newCall->alwaysSafe = expr->alwaysSafe;
+                        for (size_t i = 0; i != expr->arguments.size(); ++i) {
+                            newCall->arguments.push_back(expr->arguments[i]);
+                        }
+                        for ( auto st = bt->structType; st; st = st->parent ) {
+                            auto callName = "_::" + st->name + "`" + expr->name;
+                            newCall->name = callName;
+                            auto fcall = inferFunctionCall(newCall, InferCallError::tryOperator);
+                            if ((fcall != nullptr && fcall->isStaticClassMethod) || newCall->name != callName) {
+                                reportAstChanged();
+                                return newCall;
                             }
                         }
+                        auto self = new ExprVar(expr->at, "self");
+                        self->type = new TypeDecl(*bt);
+                        self->type->baseType = Type::tStructure;
+                        self->type->structType = bt->structType;
+                        newCall->arguments.insert(newCall->arguments.begin(), self);
+                        for ( auto st = bt->structType; st; st = st->parent ) {
+                            auto callName = "_::" + st->name + "`" + expr->name;
+                            newCall->name = callName;
+                            auto fcall = inferFunctionCall(newCall, InferCallError::tryOperator);
+                            if ((fcall != nullptr && fcall->isClassMethod) || newCall->name != callName) {
+                                reportAstChanged();
+                                return newCall;
+                            }
+                        }
+                        // note: gc will collect, but why waste memory
+                        newCall->gc_unlink(); delete newCall;
+                        self->gc_unlink(); delete self;
                     }
                 }
             }

--- a/tests/class_boost/test_class_boost.das
+++ b/tests/class_boost/test_class_boost.das
@@ -28,6 +28,36 @@ class Dog : Animal {
     }
 }
 
+class Food {
+    calories : int = 100
+}
+
+class Biscuits {
+    health : int = 25
+}
+
+class GenericAnimal {
+    meals : int = 0
+
+    [class_method]
+    def static eat(var food : auto ?) : void {
+        meals += 1
+    }
+
+    def drink() : int {
+        eat(self, new Food())   // version with self
+        return meals
+    }
+}
+
+class GenericDog : GenericAnimal {
+    def lazy() : int {
+        eat(new Biscuits())     // version without self
+        drink()
+        return meals
+    }
+}
+
 class Counter {
     value : int = 0
 
@@ -79,5 +109,20 @@ def test_explicit_const_class_method_overload(t : T?) {
         it |> equal(cc.touch(), 2)
         it |> equal(c.touch(), 3)
         it |> equal(cc.touch(), 3)
+    }
+}
+
+[test]
+def test_unqualified_generic_class_method_calls(t : T?) {
+    t |> run("base_regular_method_calls_generic_static_without_self") @(it : T?) {
+        var a : GenericAnimal? = new GenericAnimal()
+        it |> equal(a.drink(), 1)
+        it |> equal(a.meals, 1)
+    }
+
+    t |> run("derived_regular_method_calls_generic_static_without_self") @(it : T?) {
+        var d : GenericDog? = new GenericDog()
+        it |> equal(d.lazy(), 2)
+        it |> equal(d.meals, 2)
     }
 }


### PR DESCRIPTION
fixes https://github.com/GaijinEntertainment/daScript/issues/2542

When resolving an unqualified method call inside a class body (the `else` branch in `ast_infer_type.cpp`), walk the full inheritance chain (`structType->parent`) and try both the static-without-`self` form and the static-with-`self` form at each level.

Previously only the immediate struct's static method was probed, without walking parent classes. This meant inherited static class methods weren't reachable from a derived class without explicit qualification.

Generic static methods are supported as well.

**Changes:**
- `src/ast/ast_infer_type.cpp` — walk inheritance chain for static method lookup; probe both `name(args…)` and `name(self, args…)` forms at each level
- `tests/class_boost/test_class_boost.das` — test for static methods with inheritance, with and without `self`
