### PR TITLE
Aleksisch/more flags

### DIFF
--- a/daslib/clargs.das
+++ b/daslib/clargs.das
@@ -433,6 +433,38 @@ def public print_help(info : CommandInfo; prog_name : string) : void {
     print(format_help(info, prog_name))
 }
 
+def option_inner_type(t : TypeDeclPtr) : TypeDeclPtr {
+    if (t.baseType == Type.typeMacro) {
+        if (length(t.dimExpr) < 2 || t.dimExpr[0] == null || !(t.dimExpr[0] is ExprConstString)) {
+            return null
+        }
+        if (string((t.dimExpr[0] as ExprConstString).value) != "Option") {
+            return null
+        }
+        if (t.dimExpr[1] == null || !(t.dimExpr[1] is ExprTypeDecl)) {
+            return null
+        }
+        return clone_type((t.dimExpr[1] as ExprTypeDecl).typeexpr)
+    }
+    if (t.baseType != Type.tStructure || t.structType == null) {
+        return null
+    }
+    var has_flag = false
+    var value_t : TypeDeclPtr = null
+    for (f in t.structType.fields) {
+        if ("{f.name}" == "_has_value" && f._type.baseType == Type.tBool) {
+            has_flag = true
+        } elif ("{f.name}" == "_value") {
+            value_t = clone_type(f._type)
+        }
+    }
+    if (!has_flag || value_t == null) {
+        return null
+    }
+    return value_t
+}
+
+
 [structure_macro(name=CommandLineArgs)]
 class ArgsMacro : AstStructureAnnotation {
     def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
@@ -516,6 +548,11 @@ class ArgsMacro : AstStructureAnnotation {
             if (field._type.baseType == Type.tArray) {
                 arg.value_type = field._type.firstType.baseType
                 arg.is_array = true
+            } else {
+                let inner = option_inner_type(field._type)
+                if (inner != null) {
+                    arg.value_type = inner.baseType
+                }
             }
             if (arg.value_type == Type.tEnumeration) {
                 if (arg.is_array) {
@@ -572,6 +609,18 @@ class ArgsMacro : AstStructureAnnotation {
         }
     }
 
+    def make_optional_init_expr(var st : StructurePtr; i : int; arg : CommandArgumentInfo; field_index : int; inner_t : TypeDeclPtr) : ExpressionPtr {
+        return qmacro_block() {
+            {
+                var r <- parse_argument(args, command_info.args[$v(i)], type<$t(inner_t)>)
+                if (r |> is_err) {
+                    return "{$v(arg.flag_name)}: {r |> unwrap_err}"
+                }
+                dst.$f(arg.field_name) <- r |> move_unwrap
+            }
+        }
+    }
+
     def make_enum_init_expr(var st : StructurePtr; i : int; arg : CommandArgumentInfo; field_index : int) : ExpressionPtr {
         return qmacro_block() {
             {
@@ -596,6 +645,11 @@ class ArgsMacro : AstStructureAnnotation {
         var init_exprs : array<ExpressionPtr>
         for (i, arg in range(length(info.args)), info.args) {
             let field_index = field_index_by_name[arg.field_name]
+            let inner_t = option_inner_type(st.fields[field_index]._type)
+            if (inner_t != null) {
+                init_exprs |> push(make_optional_init_expr(st, i, arg, field_index, inner_t))
+                continue
+            }
             if (arg.value_type != Type.tEnumeration) {
                 init_exprs |> push(make_simple_init_expr(st, i, arg, field_index))
                 continue

--- a/daslib/option.das
+++ b/daslib/option.das
@@ -26,7 +26,7 @@ require daslib/typemacro_boost
 //!
 //! When ``_has_value`` is ``false``, ``value`` holds the zero value of ``T`` and
 //! must not be read. Accessor functions should be used for reads/writes.
-[template_structure(T)]
+[template_structure(T), safe_when_uninitialized]
 struct template Option {
     _has_value : bool = false
     @safe_when_uninitialized

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1495,6 +1495,7 @@ namespace das
     // End aot config
         bool        completion = false;                 // this code is being compiled for 'completion' mode
         bool        lint_check = false;                 // this code is being compiled for lint/style checking
+        bool        no_lint = false;                    // skip Program::lint() entirely
         bool        export_all = false;                 // when user compiles, export all (public?) functions
         bool        serialize_main_module = true;       // if false, then we recompile main module each time
         bool        keep_alive = false;                 // produce keep-alive noodes

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -341,6 +341,8 @@ class public LlvmJitVisitor : AstVisitor {
     def debug_before_function(fun : FunctionPtr) {
         if (debug_info_enabled()) {
             clear_builder_location()
+            di_function = null
+            return
             let unit = get_debug_file_location(fun.at)
             let implName = uid.get_dll_fn_name(fun).impl()
             var ty = LLVMDIBuilderCreateSubroutineType(     // TODO: generate correct function type

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -15,6 +15,7 @@ require daslib/strings_boost
 require daslib/defer
 
 require daslib/fio
+require daslib/clargs
 require jit
 
 module llvm_macro shared private
@@ -126,6 +127,28 @@ def finalize_jit(use_dll : bool; gen_exe : bool; lib_handle : DLLHandle?) : JitS
 }
 
 
+[CommandLineArgs]
+struct JitCliOptions {
+    @clarg_name = "jit-opt-level"
+    @clarg_doc = "JIT: LLVM optimization level (0..3); 0 disables all passes"
+    opt_level : Option<int>
+
+    @clarg_name = "jit-size-level"
+    @clarg_doc = "JIT: LLVM size-optimization level (0..2)"
+    size_level : Option<int>
+
+    @clarg_short = "g"
+    @clarg_name = "jit-debug"
+    @clarg_doc = "JIT: emit debug info / symbols"
+    debug_info : Option<bool>
+
+    @clarg_short = "d"
+    @clarg_name = "jit-dump"
+    @clarg_doc = "JIT: dump generated LLVM IR"
+    dump_ir : Option<bool>
+}
+
+
 [simulate_macro(name="jit_llvm")]
 class JIT_LLVM : AstSimulateMacro {
     def override simulate(prog : Program?; var ctx : Context?) : bool {
@@ -134,8 +157,11 @@ class JIT_LLVM : AstSimulateMacro {
         var disabled : array<FunctionPtr>
         var disableJitVisitor = new DisableJitVisitor()
 
+        var cli_opts = JitCliOptions()
+        let _ = parse_args(cli_opts)
         assume jit_all_functions = prog.policies.jit_jit_all_functions
-        assume debug_info = prog.policies.jit_debug_info
+        let debug_info = cli_opts.debug_info |> unwrap_or(prog.policies.jit_debug_info)
+        let dump_ir = cli_opts.dump_ir |> unwrap_or(false)
         if (prog.policies.jit_dll_mode && !das_is_dll_build()) {
             to_log(LOG_WARNING, "LLVM JIT: dll mode is enabled, however " +
                 "daslang build is static, disabling dll mode.\n")
@@ -147,8 +173,8 @@ class JIT_LLVM : AstSimulateMacro {
         defer() { llvm_jit_intrin::g_jit_exe_mode = false; }
         let exe_main = "main" // prog.policies.jit_entry_point |> empty() ? "main" : prog.policies.jit_entry_point
         let use_dll = prog.policies.jit_dll_mode && das_is_dll_build() && !gen_exe
-        let opt_level = prog.policies.jit_opt_level
-        let size_level = prog.policies.jit_size_level
+        let opt_level = cli_opts.opt_level |> unwrap_or(prog.policies.jit_opt_level)
+        let size_level = cli_opts.size_level |> unwrap_or(prog.policies.jit_size_level)
         let emit_prologue = prog.policies.emit_prologue
         // If you're sure `dynamic` functions is not reachable set this flag
         // to `true` and fail in runtime on `jit_trap` if they turns
@@ -265,7 +291,7 @@ class JIT_LLVM : AstSimulateMacro {
                 }
                 generate_global_ctors_dtors(g_prim_t, !(use_dll || gen_exe))
                 optimize_llvm_module(opt_level |> uint(), size_level |> uint(), LLVM_INLINE_THRESHOLD)
-                if (false) {
+                if (dump_ir) {
                     // Let's remove unused attributes before we print IR.
                     var pm = LLVMCreatePassManager()
                     LLVMAddGlobalDCEPass(pm)
@@ -274,7 +300,7 @@ class JIT_LLVM : AstSimulateMacro {
                     let module_str = LLVMPrintModuleToString(g_mod)
                     let msg = clone_string(module_str)
                     LLVMDisposeMessage(module_str)
-                    to_log(LOG_DEBUG, "LLVM JIT: {msg}\n");
+                    to_log(LOG_INFO, "LLVM JIT: {msg}\n");
                 }
                 if (!LLVMVerifyModule(g_mod, LLVMVerifierFailureAction.LLVMPrintMessageAction, false)) {
                     g_failed = true

--- a/src/ast/ast_lint.cpp
+++ b/src/ast/ast_lint.cpp
@@ -1126,7 +1126,7 @@ namespace das {
     vector<pair<string,Type>> getCodeOfPolicyOptions();
 
     void Program::lint ( TextWriter & /*logs*/, ModuleGroup & libGroup ) {
-        if (!options.getBoolOption("lint", true)) {
+        if (!options.getBoolOption("lint", !policies.no_lint)) {
             return;
         }
         // note: build access flags is now called before patchAnnotations, and is no longer needed in lint

--- a/tests/daslib/clargs_test.das
+++ b/tests/daslib/clargs_test.das
@@ -65,6 +65,18 @@ struct ShortFlagsRequiredConfig {
     file : string
 }
 
+[CommandLineArgs]
+struct OptionalConfig {
+    @clarg_doc = "verbose flag (None when absent)"
+    verbose : Option<bool>
+
+    @clarg_doc = "iteration count (None when absent)"
+    count : Option<int>
+
+    @clarg_doc = "user name (None when absent)"
+    name : Option<string>
+}
+
 [test]
 def test_string_flag(t : T?) {
     var cfg = Config()
@@ -447,4 +459,61 @@ def test_format_help_no_short_alignment(t : T?) {
     // No fields have short flags — every flag line should start with "      --"
     // (two spaces of margin + four spaces where "-X, " would go).
     t |> success(find(help, "      --name") != -1, "long-only flags align with short slot blank")
+}
+
+// --- Option<T> fields ----------------------------------------------------
+
+[test]
+def test_optional_bool_absent_is_none(t : T?) {
+    var cfg = OptionalConfig()
+    let a : array<string>
+    t |> success(parse_args(cfg, a) == "", "parse succeeds with no args")
+    t |> success(cfg.verbose |> is_none, "verbose stays None when flag absent")
+    t |> success(cfg.count |> is_none, "count stays None when flag absent")
+    t |> success(cfg.name |> is_none, "name stays None when flag absent")
+}
+
+[test]
+def test_optional_bool_set_true(t : T?) {
+    var cfg = OptionalConfig()
+    let a <- ["--verbose"]
+    t |> success(parse_args(cfg, a) == "", "parse succeeds")
+    t |> success(cfg.verbose |> is_some, "verbose becomes Some")
+    t |> equal(cfg.verbose |> unwrap, true)
+}
+
+[test]
+def test_optional_bool_set_false_explicit(t : T?) {
+    var cfg = OptionalConfig()
+    let a <- ["--verbose=false"]
+    t |> success(parse_args(cfg, a) == "", "parse succeeds")
+    t |> success(cfg.verbose |> is_some, "explicit --verbose=false produces Some(false)")
+    t |> equal(cfg.verbose |> unwrap, false)
+}
+
+[test]
+def test_optional_int_set(t : T?) {
+    var cfg = OptionalConfig()
+    let a <- ["--count", "7"]
+    t |> success(parse_args(cfg, a) == "", "parse succeeds")
+    t |> success(cfg.count |> is_some, "count Some")
+    t |> equal(cfg.count |> unwrap, 7)
+}
+
+[test]
+def test_optional_string_set(t : T?) {
+    var cfg = OptionalConfig()
+    let a <- ["--name=Alice"]
+    t |> success(parse_args(cfg, a) == "", "parse succeeds")
+    t |> success(cfg.name |> is_some, "name Some")
+    t |> equal(cfg.name |> unwrap, "Alice")
+}
+
+[test]
+def test_optional_int_invalid_value(t : T?) {
+    var cfg = OptionalConfig()
+    let a <- ["--count=notanumber"]
+    let err = parse_args(cfg, a)
+    t |> success(err != "", "parse fails on bad int")
+    t |> success(find(err, "--count") != -1, "error mentions flag name")
 }

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -44,6 +44,7 @@ static JitMode jitEnabled = JitMode::None; // Disabled by default.
 static string jitOutPath = ""; // Empty, JIT module will choose default.
 
 static bool noDynamicModules = false;
+static bool noLint = false;
 #ifdef DAS_TEST_AOT
 static bool useAot = true;
 #else
@@ -69,6 +70,7 @@ static CodeOfPolicies getPolicies() {
     policies.gen2_make_syntax = gen2MakeSyntax;
     policies.scoped_stack_allocator = scopedStackAllocator;
     policies.track_allocations = trackAllocations;
+    policies.no_lint = noLint;
     return policies;
 }
 
@@ -139,7 +141,7 @@ int das_aot_main ( int argc, char * argv[] ) {
     _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
     #endif
     if ( argc<=3 ) {
-        tout << "daslang -aot <in_script.das> <out_script.das.cpp> [-v2Syntax] [-v1Syntax] [-v2makeSyntax] [-project <project file>] [-dasroot <dasroot folder>] [-q] [-j] [-aot-macros] [-cross-platform]\n";
+        tout << "daslang -aot <in_script.das> <out_script.das.cpp> [-v2Syntax] [-v1Syntax] [-v2makeSyntax] [-project <project file>] [-dasroot <dasroot folder>] [-q] [-j] [-aot-macros] [-cross-platform] [-no-lint]\n";
         return -1;
     }
     bool dryRun = false;
@@ -195,6 +197,8 @@ int das_aot_main ( int argc, char * argv[] ) {
                 gen2MakeSyntax = true;
             } else if ( strcmp(argv[ai],"-no-dynamic-modules")==0 ) {
                 noDynamicModules = true;
+            } else if ( strcmp(argv[ai],"-no-lint")==0 ) {
+                noLint = true;
             } else if ( strcmp(argv[ai],"--")==0 ) {
                 scriptArgs = true;
             } else if ( !scriptArgs ) {
@@ -271,6 +275,7 @@ int compile_and_run ( const string & fn, const string & mainFnName, bool outputP
     policies.gen2_make_syntax = gen2MakeSyntax;
     policies.scoped_stack_allocator = scopedStackAllocator;
     policies.track_allocations = trackAllocations;
+    policies.no_lint = noLint;
     if ( auto program = compileDaScript(fn,access,tout,dummyGroup,policies) ) {
         if ( program->failed() ) {
             for ( auto & err : program->errors ) {
@@ -432,6 +437,7 @@ void print_help() {
         << "    --das-profiler-global install profiler as singleton agent (default with --das-profiler-memory)\n"
         << "    --das-profiler-leaks track live heap allocations and dump leaks on context destroy\n"
         << "    -no-dynamic-modules  skip loading dynamic modules from dasroot and project root\n"
+        << "    -no-lint    skip the lint pass (Program::lint)\n"
         << "    --          separator for script arguments\n"
         << "daslang -aot <in_script.das> <out_script.das.cpp> {-q} {-p}\n"
         << "    -project <path.das_project> path to project file\n"
@@ -550,6 +556,8 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
                 dryRun = true;
             } else if ( cmd=="compile-only" ) {
                 compileOnly = true;
+            } else if ( cmd=="no-lint" ) {
+                noLint = true;
             } else if ( cmd=="project-root" || cmd=="project_root" ) {
                 project_root = argv[i + 1];
                 i++;


### PR DESCRIPTION
## Summary

### `compiler: add no-lint to daslang command line options`
- New `-no-lint` CLI flag on `daslang` ([utils/daScript/main.cpp](utils/daScript/main.cpp)) — works in both AOT and script-execute paths, plus AOT usage line and `print_help()`.
- New `CodeOfPolicies::no_lint` field ([include/daScript/ast/ast.h](include/daScript/ast/ast.h#L1497)) wired into the existing per-file `options lint` early-out at [src/ast/ast_lint.cpp:1129](src/ast/ast_lint.cpp#L1129) — flag flips the default off, but `options lint = true` per-file can still re-enable.

### `clargs: support Option<T> fields in [CommandLineArgs]`
Lets [CommandLineArgs] structs distinguish "flag absent" (None) from "flag set to default value" by declaring fields as `Option<T>`. Mirrors how `parse_argument` already returns `Result<Option<T>>`.

- Detects `Option<T>` at structure-macro apply time, both in unexpanded `typeMacro` form (name in `dimExpr[0]`, inner type as `ExprTypeDecl` in `dimExpr[1]`) and post-instantiation `tStructure` form (struct with `_has_value : bool` + `_value : T`).
- Generated `parse_args()` assigns the resulting `Option<T>` directly, leaving the field `None` when the flag is absent.
- [daslib/option.das](daslib/option.das) marked `[safe_when_uninitialized]` so users can declare `x : Option<T>` without an explicit default initializer.
- Tests: 6 new cases in [tests/daslib/clargs_test.das](tests/daslib/clargs_test.das) covering absent → None, present → Some(true), explicit `--flag=false`, `Option<int>`, `Option<string>`, and invalid-int error.

### `jit: add CLI`
Per-run JIT knobs as `[CommandLineArgs]` post-`--` flags ([modules/dasLLVM/daslib/llvm_macro.das](modules/dasLLVM/daslib/llvm_macro.das)):
- `--jit-opt-level=N` — LLVM optimization level; falls back to `prog.policies.jit_opt_level` when absent.
- `--jit-size-level=N` — size-optimization level; falls back to `prog.policies.jit_size_level`.
- `-g` / `--jit-debug` — emit debug info; falls back to `prog.policies.jit_debug_info`.
- `-d` / `--jit-dump` — print generated LLVM IR.

`unwrap_or(policy)` at each call site cleanly maps `None → policy`. The IR-dump branch (previously dead `if (false)`) is reused, log level upgraded to `LOG_INFO`.

[modules/dasLLVM/daslib/llvm_jit.das](modules/dasLLVM/daslib/llvm_jit.das): `--jit-debug` previously crashed the IR verifier ("subprogram definitions must have a compile unit") because the JIT emitted `DISubprogram(IsDefinition=1)` without a containing `DICompileUnit`. `LLVMDIBuilderCreateCompileUnit` has 19 C arguments, exceeding daslang's 16-arg `[extern]` wrapper limit. As a stop-gap, DISubprogram emission is disabled; `flags.need_di` still drives linkage choices (`internal` vs `private`), so debugger symbol visibility is preserved. Source-level DI to be restored once a `CreateCompileUnit` shim is available.
