### PR TITLE
Partial fixes for #2483: null guards and inference fallbacks

### DIFF
--- a/include/daScript/simulate/simulate_visit.h
+++ b/include/daScript/simulate/simulate_visit.h
@@ -33,7 +33,7 @@ namespace das {
         V_OP_TT(ForRange1);
         V_SP(this->stackTop[0]);
         V_SUB(this->sources[0]);
-        V_SUB(this->list[0]);
+        if (this->list) V_SUB(this->list[0]);
         V_FINAL();
         V_END();
     }
@@ -45,7 +45,7 @@ namespace das {
         V_OP_TT(ForRangeNF1);
         V_SP(this->stackTop[0]);
         V_SUB(this->sources[0]);
-        V_SUB(this->list[0]);
+        if (this->list) V_SUB(this->list[0]);
         V_FINAL();
         V_END();
     }

--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -951,8 +951,12 @@ namespace das {
                         DAS_ASSERTF ( !runProgram->failed(), "internal error while folding (allocate stack)?" );
                         runProgram->updateSemanticHash();
                         runProgram->simulate(ctx, dummy);
-                        DAS_ASSERTF ( !runProgram->failed(), "internal error while folding (simulate)?" );
                         runProgram->folding = false;
+                        if ( runProgram->failed() ) {
+                            // its ok to not reset anySimulated here, because if it failed here - it will fail on final simulate
+                            // not resetting will make it fail faster, hence cutting time of the failed compilation anyway
+                            return Visitor::visit(expr);
+                        }
                     }
                     if ( expr->func->index==-1 ) {
                         runProgram->error("internal compilation error, folding symbol was not marked as used","","",

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -1846,7 +1846,12 @@ namespace das {
         if (expr->typeexpr->isExprType()) {
             return Visitor::visit(expr);
         }
-        if (!expr->subexpr->type || expr->subexpr->type->isAutoOrAlias()) {
+        if (!expr->subexpr->type) {
+            return Visitor::visit(expr);
+        }
+        if (expr->subexpr->type->isAutoOrAlias()) {
+            error("is expression type can't be inferred, subexpression type is not fully inferred yet: " + describeType(expr->subexpr->type), "", "",
+                  expr->at, CompilationError::type_not_found);
             return Visitor::visit(expr);
         }
         // generic operator

--- a/src/ast/ast_infer_type_function.cpp
+++ b/src/ast/ast_infer_type_function.cpp
@@ -1129,7 +1129,10 @@ namespace das {
                             auto mkBlock = static_cast<ExprMakeBlock*>(arg);
                             auto block = static_cast<ExprBlock*>(mkBlock->block);
                             auto retT = TypeDecl::inferGenericType(mkBlock->type, funcC->arguments[iF]->type, true, true, nullptr);
-                            DAS_ASSERTF(retT, "how? it matched during findMatchingFunctions the same way");
+                            if ( !retT ) {
+                                error("default arguments don't match the function signature of '" + funcC->name + "'", "", "", expr->at, CompilationError::invalid_type);
+                                return nullptr;
+                            }
                             TypeDecl::applyAutoContracts(mkBlock->type, funcC->arguments[iF]->type);
                             TypeDecl::clone(block->returnType, retT->firstType);
                             for (size_t ba = 0, bas = retT->argTypes.size(); ba != bas; ++ba) {


### PR DESCRIPTION
## Summary
Partial fixes for issue #2483 with additional null/type-inference guardrails.

## Changes
- `simulate_visit.h`: Guard `list` access in `visit(ExprForRange*)` and `visit(ExprForRangeNF*)` when `list` is null.
- `ast_const_folding.cpp`: If const-fold simulation fails, fall back to regular visitor flow instead of asserting.
- `ast_infer_type.cpp`: Separate missing-type vs auto/alias cases for `ExprIs`; emit a clear inference error for unresolved auto/alias subexpression types.
- `ast_infer_type_function.cpp`: Replace assert on inferred default-argument block type mismatch with user-facing compilation error and early return.

## Notes
- This PR intentionally addresses part of #2483 (defensive handling + diagnostics) and does not claim full closure.
