### PR TITLE
safe-index of the pointer is now always unsafe

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -3127,6 +3127,7 @@ namespace das {
                 if (!safeExpression(expr)) {
                     error("safe-index of pointer must be inside the 'unsafe' block", "", "",
                           expr->at, CompilationError::unsafe);
+                    return Visitor::visit(expr);
                 }
                 expr->type = new TypeDecl(*expr->subexpr->type);
                 expr->type->constant |= seT->constant;


### PR DESCRIPTION
fixes
```
// SIGSEGV in das::SimNode_NullCoalescing<int>::evalInt
//   das::SimNode_Set<int>::eval
let var3=[0]?[8]??[0]?[0]?[~uint3()[0]]??0;var{}bitfield r{}[export]def a{print("{var3}");}finally{}
```
from https://github.com/GaijinEntertainment/daScript/issues/2483 - but only that