### PR TITLE
clargs: expand parsing API and migrate daspkg

### DIFF
--- a/daslib/clargs.das
+++ b/daslib/clargs.das
@@ -13,17 +13,22 @@ require daslib/enum_trait public
 
 struct public CommandArgumentInfo {
     field_name : string
-    flag_name : string
-    short_flag_name : string  // e.g. "-v"; empty if no short flag declared
+    flag_name : string         // long form, e.g. "--verbose"; for positionals this is "<field_name>"
+    short_flag_name : string   // e.g. "-v"; empty if no short flag declared
     doc_string : string
     value_type : Type
     is_array : bool
     is_required : bool
+    is_positional : bool       // declared with @clarg_positional; consumed in declaration order
+    is_optional_wrap : bool    // declared as Option<T> (positional or flag); affects required-ness
+    is_count : bool            // declared with @clarg_count; sums every flag occurrence
+    mutex_group : string       // declared with @clarg_mutex_group="name"; "" if not in any group
     enum_values : array<string>
 }
 
 struct public CommandInfo {
     args : array<CommandArgumentInfo>
+    has_user_help : bool       // true if the user already declared a --help/-h flag (suppresses auto-injection)
 }
 
 // Returns the slice of `all_args` after a "--" separator (or empty if no "--").
@@ -155,6 +160,9 @@ def public find_array_flag_raw_values(args : array<string>; flag_name : string) 
 // above), so e.g. `-n Alice --name Bob` resolves to "Bob".
 
 def public find_flag_raw_value(args : array<string>; arg_info : CommandArgumentInfo) : Option<string> {
+    if (arg_info.is_positional) {
+        return none(type<string>)
+    }
     let has_short = !empty(arg_info.short_flag_name)
     let long_prefix = "{arg_info.flag_name}="
     let short_prefix = has_short ? "{arg_info.short_flag_name}=" : ""
@@ -175,6 +183,9 @@ def public find_flag_raw_value(args : array<string>; arg_info : CommandArgumentI
 }
 
 def public find_bool_flag_raw_value(args : array<string>; arg_info : CommandArgumentInfo) : Option<string> {
+    if (arg_info.is_positional) {
+        return none(type<string>)
+    }
     let has_short = !empty(arg_info.short_flag_name)
     let long_prefix = "{arg_info.flag_name}="
     let short_prefix = has_short ? "{arg_info.short_flag_name}=" : ""
@@ -196,6 +207,9 @@ def public find_bool_flag_raw_value(args : array<string>; arg_info : CommandArgu
 // (e.g. --tags=a -t b --tags=c -> ["a", "b", "c"]).
 def public find_array_flag_raw_values(args : array<string>; arg_info : CommandArgumentInfo) : array<string> {
     var result : array<string>
+    if (arg_info.is_positional) {
+        return <- result
+    }
     let long_prefix = "{arg_info.flag_name}="
     let has_short = !empty(arg_info.short_flag_name)
     let short_prefix = has_short ? "{arg_info.short_flag_name}=" : ""
@@ -317,6 +331,161 @@ def public parse_argument(args : array<string>; arg_info : CommandArgumentInfo; 
     }
 }
 
+// Positional-argument collection.
+//
+// Walks `args` and returns the tokens that should be treated as positionals —
+// i.e. tokens that don't match any declared flag (long or short, with or
+// without `=value`).  When a known value-bearing flag appears in its
+// space-separated form (e.g. "--root /tmp"), the next token is consumed as
+// the value (NOT a positional).  Tokens that look flag-shaped but don't match
+// any declared flag (`--unknown`, `-x`) are skipped one-by-one so they don't
+// land in the positional list either.
+
+def public collect_positional_args(args : array<string>; info : CommandInfo) : array<string> {
+    var result : array<string>
+    var i = 0
+    while (i < length(args)) {
+        let arg = args[i]
+        var matched_flag = false
+        var consumes_value = false
+        for (a in info.args) {
+            if (a.is_positional) {
+                continue
+            }
+            let has_short = !empty(a.short_flag_name)
+            let exact_long = (arg == a.flag_name)
+            let exact_short = has_short && (arg == a.short_flag_name)
+            let prefix_long = starts_with(arg, "{a.flag_name}=")
+            let prefix_short = has_short && starts_with(arg, "{a.short_flag_name}=")
+            if (exact_long || exact_short || prefix_long || prefix_short) {
+                matched_flag = true
+                let is_bool_simple = (a.value_type == Type.tBool && !a.is_array)
+                // Bool flags and count flags never consume the next token as a value.
+                if (!is_bool_simple && !a.is_count && (exact_long || exact_short)) {
+                    consumes_value = true
+                }
+                break
+            }
+        }
+        if (matched_flag) {
+            i++
+            if (consumes_value && i < length(args)) {
+                i++
+            }
+            continue
+        }
+        // Unknown flag-shaped tokens — skip without consuming next.  Avoids
+        // them landing in the positional list and matches today's silent-
+        // ignore behavior for unknown flags.
+        if (length(arg) >= 2 && first_character(arg) == int(0x2D) /* '-' */) {
+            i++
+            continue
+        }
+        result |> push(arg)
+        i++
+    }
+    return <- result
+}
+
+// Counts every occurrence of `arg_info.flag_name` and `arg_info.short_flag_name`
+// in `args`.  Backs `@clarg_count` fields.  v1 does not implement short-flag
+// clustering ("-vvv"); only `-v -v -v` and `--verbose --verbose` style sums.
+def public count_flag(args : array<string>; arg_info : CommandArgumentInfo) : int {
+    if (arg_info.is_positional) {
+        return 0
+    }
+    let has_short = !empty(arg_info.short_flag_name)
+    var n = 0
+    for (a in args) {
+        if (a == arg_info.flag_name) {
+            n++
+        } elif (has_short && a == arg_info.short_flag_name) {
+            n++
+        }
+    }
+    return n
+}
+
+// Walks `args` to detect `--flag=value` against a count flag, which is
+// rejected (count flags don't accept values).  Returns "" if clean.
+def public count_flag_value_violation(args : array<string>; arg_info : CommandArgumentInfo) : string {
+    if (arg_info.is_positional || !arg_info.is_count) {
+        return ""
+    }
+    let has_short = !empty(arg_info.short_flag_name)
+    let long_prefix = "{arg_info.flag_name}="
+    let short_prefix = has_short ? "{arg_info.short_flag_name}=" : ""
+    for (a in args) {
+        if (starts_with(a, long_prefix)) {
+            return "{arg_info.flag_name}: count flag does not accept a value"
+        }
+        if (has_short && starts_with(a, short_prefix)) {
+            return "{arg_info.flag_name}: count flag does not accept a value"
+        }
+    }
+    return ""
+}
+
+// Returns "" if every mutex group has at most one member present, or an
+// error string identifying the conflicting flags otherwise.
+def public find_mutex_violation(args : array<string>; info : CommandInfo) : string {
+    var groups : table<string; array<string>>
+    for (a in info.args) {
+        if (empty(a.mutex_group)) {
+            continue
+        }
+        if (!flag_present(args, a)) {
+            continue
+        }
+        if (!key_exists(groups, a.mutex_group)) {
+            groups[a.mutex_group] <- [a.flag_name]
+        } else {
+            groups[a.mutex_group] |> push(a.flag_name)
+        }
+    }
+    for (gname, members in keys(groups), values(groups)) {
+        if (length(members) > 1) {
+            return build_string() $(var w) {
+                for (i, m in range(length(members)), members) {
+                    if (i > 0) {
+                        write(w, ", ")
+                    }
+                    write(w, m)
+                }
+                write(w, ": mutually exclusive (group '")
+                write(w, gname)
+                write(w, "')")
+            }
+        }
+    }
+    return ""
+}
+
+// Synthetic --help/-h argument used by `parse_args_with_help` and friends.
+// Not pushed into the user's CommandInfo unless the user explicitly opts in.
+def public make_auto_help_arg() : CommandArgumentInfo {
+    return CommandArgumentInfo(
+        field_name = "_auto_help",
+        flag_name = "--help",
+        short_flag_name = "-h",
+        doc_string = "show this help and exit",
+        value_type = Type.tBool
+    )
+}
+
+// Convenience: render help with the auto-injected --help row appended unless
+// the user already declared their own.  Used by `parse_args_with_help`.
+def public format_help_with_auto_help(info : CommandInfo; prog_name : string) : string {
+    if (info.has_user_help) {
+        return format_help(info, prog_name)
+    }
+    var augmented : CommandInfo
+    augmented.has_user_help = info.has_user_help
+    augmented.args := info.args
+    augmented.args |> push_clone(make_auto_help_arg())
+    return format_help(augmented, prog_name)
+}
+
 // Help rendering.
 //
 // `format_help` builds the help text as a string (testable, redirectable).
@@ -335,6 +504,9 @@ def public parse_argument(args : array<string>; arg_info : CommandArgumentInfo; 
 // Bool flags omit the =PLACEHOLDER. Enum flag docs include `(V1|V2|...)`.
 
 def value_placeholder(arg : CommandArgumentInfo) : string {
+    if (arg.is_positional || arg.is_count) {
+        return ""
+    }
     if (arg.value_type == Type.tBool && !arg.is_array) {
         return ""
     }
@@ -351,6 +523,10 @@ def value_placeholder(arg : CommandArgumentInfo) : string {
 }
 
 def render_flag_spec(arg : CommandArgumentInfo) : string {
+    if (arg.is_positional) {
+        // arg.flag_name is already wrapped as "<name>" by collect_command_info.
+        return arg.flag_name
+    }
     var spec = ""
     if (!empty(arg.short_flag_name)) {
         spec = "{arg.short_flag_name}, "
@@ -394,16 +570,58 @@ def render_doc_column(arg : CommandArgumentInfo) : string {
             if (!first) {
                 write(w, " ")
             }
+            first = false
             write(w, "(repeated)")
+        }
+        if (arg.is_count) {
+            if (!first) {
+                write(w, " ")
+            }
+            first = false
+            write(w, "(repeats)")
+        }
+        if (!empty(arg.mutex_group)) {
+            if (!first) {
+                write(w, " ")
+            }
+            write(w, "(mutex: {arg.mutex_group})")
         }
     }
 }
 
+// Renders a positional arg's slot in the usage line: `<name>` for required,
+// `[<name>]` for optional, `[<name>...]` for the array tail.
+def render_positional_usage_token(arg : CommandArgumentInfo) : string {
+    if (arg.is_array) {
+        return "[{arg.flag_name}...]"
+    }
+    if (arg.is_required) {
+        return "{arg.flag_name}"
+    }
+    return "[{arg.flag_name}]"
+}
+
 def public format_help(info : CommandInfo; prog_name : string) : string {
+    var positionals : array<CommandArgumentInfo>
+    var flags : array<CommandArgumentInfo>
+    for (arg in info.args) {
+        if (arg.is_positional) {
+            positionals |> push_clone(arg)
+        } else {
+            flags |> push_clone(arg)
+        }
+    }
     var specs : array<string>
     specs |> reserve(length(info.args))
     var max_spec_len = 0
-    for (arg in info.args) {
+    for (arg in positionals) {
+        let s = render_flag_spec(arg)
+        if (length(s) > max_spec_len) {
+            max_spec_len = length(s)
+        }
+        specs |> push(s)
+    }
+    for (arg in flags) {
         let s = render_flag_spec(arg)
         if (length(s) > max_spec_len) {
             max_spec_len = length(s)
@@ -413,18 +631,43 @@ def public format_help(info : CommandInfo; prog_name : string) : string {
     let gutter = 4
     return build_string() $(var w) {
         if (is_standalone_exe()) {
-            write(w, "Usage: {prog_name} [flags]\n\nFlags:\n")
+            write(w, "Usage: {prog_name}")
         } else {
-            write(w, "Usage: daslang {prog_name} -- [flags]\n\nFlags:\n")
+            write(w, "Usage: daslang {prog_name} --")
         }
-        for (i, arg in range(length(info.args)), info.args) {
-            let s = specs[i]
-            let pad = max_spec_len - length(s) + gutter
-            write(w, "  ")
-            write(w, s)
-            write(w, repeat(" ", pad))
-            write(w, render_doc_column(arg))
-            write(w, "\n")
+        for (arg in positionals) {
+            write(w, " ")
+            write(w, render_positional_usage_token(arg))
+        }
+        if (!empty(flags)) {
+            write(w, " [flags]")
+        }
+        write(w, "\n")
+
+        if (!empty(positionals)) {
+            write(w, "\nPositional arguments:\n")
+            for (i, arg in range(length(positionals)), positionals) {
+                let s = specs[i]
+                let pad = max_spec_len - length(s) + gutter
+                write(w, "  ")
+                write(w, s)
+                write(w, repeat(" ", pad))
+                write(w, render_doc_column(arg))
+                write(w, "\n")
+            }
+        }
+        if (!empty(flags)) {
+            write(w, "\nFlags:\n")
+            let pos_count = length(positionals)
+            for (i, arg in range(length(flags)), flags) {
+                let s = specs[pos_count + i]
+                let pad = max_spec_len - length(s) + gutter
+                write(w, "  ")
+                write(w, s)
+                write(w, repeat(" ", pad))
+                write(w, render_doc_column(arg))
+                write(w, "\n")
+            }
         }
     }
 }
@@ -438,7 +681,7 @@ def option_inner_type(t : TypeDeclPtr) : TypeDeclPtr {
         if (length(t.dimExpr) < 2 || t.dimExpr[0] == null || !(t.dimExpr[0] is ExprConstString)) {
             return null
         }
-        if (string((t.dimExpr[0] as ExprConstString).value) != "Option") {
+        if ((t.dimExpr[0] as ExprConstString).value != "Option") {
             return null
         }
         if (t.dimExpr[1] == null || !(t.dimExpr[1] is ExprTypeDecl)) {
@@ -482,6 +725,13 @@ class ArgsMacro : AstStructureAnnotation {
         var parse_args_default_fn = make_parse_default_fn(st)
         compiling_module() |> add_function(parse_args_default_fn)
 
+        // Auto --help/-h is only injected when the user did not declare their
+        // own help flag.  If they did, they're responsible for handling it.
+        if (!command_info.has_user_help) {
+            var parse_args_with_help_fn = make_parse_args_with_help_fn(st)
+            compiling_module() |> add_function(parse_args_with_help_fn)
+        }
+
         return true
     }
 
@@ -514,16 +764,29 @@ class ArgsMacro : AstStructureAnnotation {
         var result : CommandInfo
         result.args |> reserve(length(st.fields))
         var seen_short : table<string; string>
+        var has_array_tail = false       // an array<string> positional terminates the positional list
+        var saw_optional_positional = false
         for (field in st.fields) {
             if (find_bool_annotation(field.annotation, "clarg_skip", false)) {
                 continue
             }
+            let is_positional = find_bool_annotation(field.annotation, "clarg_positional", false)
+            let is_count = find_bool_annotation(field.annotation, "clarg_count", false)
+            let raw_name = find_string_annotation(field.annotation, "clarg_name", "{field.name}")
             var arg = CommandArgumentInfo(
                 field_name = "{field.name}",
-                flag_name = clargs_flag_name(find_string_annotation(field.annotation, "clarg_name", "{field.name}"))
+                flag_name = is_positional ? "<{raw_name}>" : clargs_flag_name(raw_name),
+                is_positional = is_positional,
+                is_count = is_count,
+                mutex_group = find_string_annotation(field.annotation, "clarg_mutex_group", "")
             )
+
             let short_char = find_string_annotation(field.annotation, "clarg_short", "")
             if (!empty(short_char)) {
+                if (is_positional) {
+                    errors := "field '{arg.field_name}': @clarg_short cannot be combined with @clarg_positional"
+                    return <- result
+                }
                 if (length(short_char) != 1) {
                     errors := "field '{arg.field_name}': @clarg_short must be a single character (got '{short_char}')"
                     return <- result
@@ -552,6 +815,7 @@ class ArgsMacro : AstStructureAnnotation {
                 let inner = option_inner_type(field._type)
                 if (inner != null) {
                     arg.value_type = inner.baseType
+                    arg.is_optional_wrap = true
                 }
             }
             if (arg.value_type == Type.tEnumeration) {
@@ -565,7 +829,54 @@ class ArgsMacro : AstStructureAnnotation {
                     }
                 }
             }
+
+            if (is_positional) {
+                // Allowed types: string, Option<string>, array<string>.
+                if (arg.value_type != Type.tString) {
+                    errors := "field '{arg.field_name}': @clarg_positional only supports string, Option<string>, and array<string>"
+                    return <- result
+                }
+                if (has_array_tail) {
+                    errors := "field '{arg.field_name}': another @clarg_positional cannot follow an array<string> positional"
+                    return <- result
+                }
+                let is_required_positional = !arg.is_array && !arg.is_optional_wrap
+                if (is_required_positional && saw_optional_positional) {
+                    errors := "field '{arg.field_name}': required @clarg_positional cannot follow an optional one"
+                    return <- result
+                }
+                if (arg.is_array) {
+                    has_array_tail = true
+                } elif (arg.is_optional_wrap) {
+                    saw_optional_positional = true
+                }
+                arg.is_required = is_required_positional
+                if (find_bool_annotation(field.annotation, "clarg_required", false) && arg.is_optional_wrap) {
+                    errors := "field '{arg.field_name}': @clarg_required cannot be combined with Option<...> @clarg_positional (declare the field as plain string instead)"
+                    return <- result
+                }
+            }
+
+            if (is_count) {
+                if (is_positional) {
+                    errors := "field '{arg.field_name}': @clarg_count cannot be combined with @clarg_positional"
+                    return <- result
+                }
+                if (arg.is_array || arg.is_optional_wrap) {
+                    errors := "field '{arg.field_name}': @clarg_count requires a plain int field"
+                    return <- result
+                }
+                if (arg.value_type != Type.tInt) {
+                    errors := "field '{arg.field_name}': @clarg_count requires int field type"
+                    return <- result
+                }
+            }
+
             arg.doc_string = find_string_annotation(field.annotation, "clarg_doc", "")
+            // Detect a user-declared --help/-h flag — suppresses auto-injection by parse_args_with_help.
+            if (!is_positional && (arg.flag_name == "--help" || arg.short_flag_name == "-h")) {
+                result.has_user_help = true
+            }
             result.args |> emplace(arg)
         }
         return <- result
@@ -584,6 +895,28 @@ class ArgsMacro : AstStructureAnnotation {
     def make_parse_default_fn(var st : StructurePtr) : FunctionPtr {
         var fn = qmacro_function("parse_args") $(var dst : $t(st)) : string {
             return parse_args(dst, get_user_args())
+        }
+        fn.flags |= FunctionFlags.generated
+        fn.body |> force_at(st.at)
+        return <- fn
+    }
+
+    def make_parse_args_with_help_fn(var st : StructurePtr) : FunctionPtr {
+        // Auto-handles --help/-h by printing format_help_with_auto_help and
+        // returning 0.  Returns -1 on clean parse, 1 on parse error.
+        var fn = qmacro_function("parse_args_with_help") $(var dst : $t(st); prog_name : string) : int {
+            let auto_args <- get_user_args()
+            if (find_index(auto_args, "--help") != -1 || find_index(auto_args, "-h") != -1) {
+                let auto_info <- get_command_info(type<$t(st)>)
+                print(format_help_with_auto_help(auto_info, prog_name))
+                return 0
+            }
+            let auto_err = parse_args(dst, auto_args)
+            if (!empty(auto_err)) {
+                print("error: {auto_err}\n")
+                return 1
+            }
+            return -1
         }
         fn.flags |= FunctionFlags.generated
         fn.body |> force_at(st.at)
@@ -638,13 +971,91 @@ class ArgsMacro : AstStructureAnnotation {
         }
     }
 
+    def make_required_positional_init_expr(arg : CommandArgumentInfo; positional_index : int) : ExpressionPtr {
+        return qmacro_block() {
+            {
+                if ($v(positional_index) < length(positionals)) {
+                    dst.$f(arg.field_name) = positionals[$v(positional_index)]
+                } else {
+                    return "{$v(arg.flag_name)}: missing required positional argument"
+                }
+            }
+        }
+    }
+
+    def make_optional_positional_init_expr(arg : CommandArgumentInfo; positional_index : int) : ExpressionPtr {
+        return qmacro_block() {
+            {
+                if ($v(positional_index) < length(positionals)) {
+                    dst.$f(arg.field_name) <- some(positionals[$v(positional_index)])
+                }
+            }
+        }
+    }
+
+    def make_array_positional_init_expr(arg : CommandArgumentInfo; positional_index : int) : ExpressionPtr {
+        return qmacro_block() {
+            {
+                var rest_pos : array<string>
+                let start = $v(positional_index)
+                if (start < length(positionals)) {
+                    rest_pos |> reserve(length(positionals) - start)
+                }
+                for (j in range(start, length(positionals))) {
+                    rest_pos |> push(positionals[j])
+                }
+                dst.$f(arg.field_name) <- rest_pos
+            }
+        }
+    }
+
+    def make_count_init_expr(arg : CommandArgumentInfo; i : int) : ExpressionPtr {
+        return qmacro_block() {
+            {
+                let count_viol = count_flag_value_violation(args, command_info.args[$v(i)])
+                if (!empty(count_viol)) {
+                    return count_viol
+                }
+                dst.$f(arg.field_name) = count_flag(args, command_info.args[$v(i)])
+            }
+        }
+    }
+
     def make_parse_fn(var st : StructurePtr; info : CommandInfo) : FunctionPtr {
         var name_to_index <- { for (i in range(length(st.fields))); string(st.fields[i].name) => i }
         var field_index_by_name <- { for (arg in info.args); arg.field_name => name_to_index[arg.field_name]; where key_exists(name_to_index, arg.field_name) }
 
+        var has_positional = false
+        var has_mutex = false
+        for (arg in info.args) {
+            if (arg.is_positional) {
+                has_positional = true
+            }
+            if (!empty(arg.mutex_group)) {
+                has_mutex = true
+            }
+        }
+
         var init_exprs : array<ExpressionPtr>
+        var positional_idx = 0
         for (i, arg in range(length(info.args)), info.args) {
             let field_index = field_index_by_name[arg.field_name]
+            if (arg.is_positional) {
+                let pi = positional_idx
+                positional_idx ++
+                if (arg.is_array) {
+                    init_exprs |> push(make_array_positional_init_expr(arg, pi))
+                } elif (arg.is_optional_wrap) {
+                    init_exprs |> push(make_optional_positional_init_expr(arg, pi))
+                } else {
+                    init_exprs |> push(make_required_positional_init_expr(arg, pi))
+                }
+                continue
+            }
+            if (arg.is_count) {
+                init_exprs |> push(make_count_init_expr(arg, i))
+                continue
+            }
             let inner_t = option_inner_type(st.fields[field_index]._type)
             if (inner_t != null) {
                 init_exprs |> push(make_optional_init_expr(st, i, arg, field_index, inner_t))
@@ -657,11 +1068,66 @@ class ArgsMacro : AstStructureAnnotation {
             init_exprs |> push(make_enum_init_expr(st, i, arg, field_index))
         }
 
+        if (has_positional && has_mutex) {
+            var fn = qmacro_function("parse_args") $(var dst : $t(st); args : array<string>) : string {
+                let command_info <- get_command_info(type<$t(st)>)
+                let positionals <- collect_positional_args(args, command_info)
+                $b(init_exprs)
+                let mutex_err = find_mutex_violation(args, command_info)
+                if (!empty(mutex_err)) {
+                    return mutex_err
+                }
+                for (arg in command_info.args) {
+                    if (arg.is_required && !arg.is_positional && !arg.is_count && !flag_present(args, arg)) {
+                        return "{arg.flag_name}: missing required flag"
+                    }
+                }
+                return ""
+            }
+            fn.flags |= FunctionFlags.generated
+            fn.body |> force_at(st.at)
+            return <- fn
+        }
+        if (has_positional) {
+            var fn = qmacro_function("parse_args") $(var dst : $t(st); args : array<string>) : string {
+                let command_info <- get_command_info(type<$t(st)>)
+                let positionals <- collect_positional_args(args, command_info)
+                $b(init_exprs)
+                for (arg in command_info.args) {
+                    if (arg.is_required && !arg.is_positional && !arg.is_count && !flag_present(args, arg)) {
+                        return "{arg.flag_name}: missing required flag"
+                    }
+                }
+                return ""
+            }
+            fn.flags |= FunctionFlags.generated
+            fn.body |> force_at(st.at)
+            return <- fn
+        }
+        if (has_mutex) {
+            var fn = qmacro_function("parse_args") $(var dst : $t(st); args : array<string>) : string {
+                let command_info <- get_command_info(type<$t(st)>)
+                $b(init_exprs)
+                let mutex_err = find_mutex_violation(args, command_info)
+                if (!empty(mutex_err)) {
+                    return mutex_err
+                }
+                for (arg in command_info.args) {
+                    if (arg.is_required && !arg.is_count && !flag_present(args, arg)) {
+                        return "{arg.flag_name}: missing required flag"
+                    }
+                }
+                return ""
+            }
+            fn.flags |= FunctionFlags.generated
+            fn.body |> force_at(st.at)
+            return <- fn
+        }
         var fn = qmacro_function("parse_args") $(var dst : $t(st); args : array<string>) : string {
             let command_info <- get_command_info(type<$t(st)>)
             $b(init_exprs)
             for (arg in command_info.args) {
-                if (arg.is_required && !flag_present(args, arg)) {
+                if (arg.is_required && !arg.is_count && !flag_present(args, arg)) {
                     return "{arg.flag_name}: missing required flag"
                 }
             }

--- a/tests/daslib/clargs_test.das
+++ b/tests/daslib/clargs_test.das
@@ -77,6 +77,70 @@ struct OptionalConfig {
     name : Option<string>
 }
 
+[CommandLineArgs]
+struct PositionalConfig {
+    @clarg_positional
+    @clarg_doc = "subcommand name"
+    command : string
+
+    @clarg_positional
+    @clarg_doc = "subcommand argument"
+    command_arg : Option<string>
+
+    @clarg_doc = "project root"
+    root : string = "."
+
+    @clarg_doc = "force"
+    force : bool
+
+    @clarg_short = "v"
+    @clarg_doc = "verbose"
+    verbose : bool
+}
+
+[CommandLineArgs]
+struct PositionalArrayTailConfig {
+    @clarg_positional
+    @clarg_doc = "first arg"
+    head : string
+
+    @clarg_positional
+    @clarg_doc = "remaining args"
+    rest : array<string>
+}
+
+[CommandLineArgs]
+struct AutoHelpConfig {
+    @clarg_doc = "user name"
+    name : string
+}
+
+[CommandLineArgs]
+struct MutexConfig {
+    @clarg_mutex_group = "color"
+    color : bool
+
+    @clarg_name = "no-color"
+    @clarg_mutex_group = "color"
+    no_color : bool
+
+    @clarg_mutex_group = "verbosity"
+    quiet : bool
+
+    @clarg_mutex_group = "verbosity"
+    loud : bool
+
+    flag_outside_groups : bool
+}
+
+[CommandLineArgs]
+struct CountConfig {
+    @clarg_count
+    @clarg_short = "v"
+    @clarg_doc = "verbosity"
+    verbose : int
+}
+
 [test]
 def test_string_flag(t : T?) {
     var cfg = Config()
@@ -516,4 +580,238 @@ def test_optional_int_invalid_value(t : T?) {
     let err = parse_args(cfg, a)
     t |> success(err != "", "parse fails on bad int")
     t |> success(find(err, "--count") != -1, "error mentions flag name")
+}
+
+// --- Positional arguments -------------------------------------------------
+// `@clarg_positional` lets a struct field be filled from non-flag tokens,
+// in declaration order.  Required positionals (plain `string`) error if
+// missing; optional positionals (`Option<string>`) silently default; an
+// `array<string>` positional collects all remaining tokens.
+
+[test]
+def test_positional_basic(t : T?) {
+    var cfg = PositionalConfig()
+    let a <- ["install", "dasImgui"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> equal(cfg.command, "install")
+    t |> success(cfg.command_arg |> is_some, "command_arg present")
+    t |> equal(cfg.command_arg |> unwrap, "dasImgui")
+}
+
+[test]
+def test_positional_only_required(t : T?) {
+    var cfg = PositionalConfig()
+    let a <- ["list"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> equal(cfg.command, "list")
+    t |> success(cfg.command_arg |> is_none, "command_arg absent")
+}
+
+[test]
+def test_positional_missing_required(t : T?) {
+    var cfg = PositionalConfig()
+    let a : array<string>
+    let err = parse_args(cfg, a)
+    t |> success(err != "", "parse fails when required positional missing")
+    t |> success(find(err, "command") != -1, "error mentions positional name")
+}
+
+[test]
+def test_positional_mixed_with_flags(t : T?) {
+    var cfg = PositionalConfig()
+    let a <- ["--root", "/tmp", "install", "dasImgui", "--force"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> equal(cfg.command, "install")
+    t |> equal(cfg.command_arg |> unwrap, "dasImgui")
+    t |> equal(cfg.root, "/tmp")
+    t |> success(cfg.force, "force flag set")
+}
+
+[test]
+def test_positional_equals_form_flag_no_consumption(t : T?) {
+    // `--root=/tmp` MUST NOT consume `install` as the flag value.
+    var cfg = PositionalConfig()
+    let a <- ["--root=/tmp", "install"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> equal(cfg.root, "/tmp")
+    t |> equal(cfg.command, "install")
+    t |> success(cfg.command_arg |> is_none, "no second positional")
+}
+
+[test]
+def test_positional_short_flag_with_value(t : T?) {
+    // Space-separated short flag form takes the next token as value.
+    var cfg = PositionalConfig()
+    let a <- ["-v", "install", "foo"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> success(cfg.verbose, "verbose set")
+    t |> equal(cfg.command, "install")
+    t |> equal(cfg.command_arg |> unwrap, "foo")
+}
+
+[test]
+def test_positional_unknown_flag_skipped(t : T?) {
+    // Unknown `--unknown` is silently dropped, NOT treated as positional.
+    var cfg = PositionalConfig()
+    let a <- ["--unknown", "install"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> equal(cfg.command, "install")
+}
+
+[test]
+def test_positional_array_tail(t : T?) {
+    var cfg = PositionalArrayTailConfig()
+    let a <- ["a", "b", "c", "d"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> equal(cfg.head, "a")
+    t |> equal(cfg.rest, ["b", "c", "d"])
+}
+
+[test]
+def test_positional_array_tail_empty(t : T?) {
+    var cfg = PositionalArrayTailConfig()
+    let a <- ["only"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> equal(cfg.head, "only")
+    t |> equal(length(cfg.rest), 0)
+}
+
+[test]
+def test_positional_help_renders_usage(t : T?) {
+    let info = get_command_info(type<PositionalConfig>)
+    let help = format_help(info, "test")
+    t |> success(find(help, "<command>") != -1, "required positional in usage")
+    t |> success(find(help, "[<command_arg>]") != -1, "optional positional bracketed in usage")
+    t |> success(find(help, "Positional arguments:") != -1, "positionals section header")
+}
+
+// --- Auto --help / -h -----------------------------------------------------
+// `parse_args_with_help` is auto-generated when the user did not declare
+// their own `--help` / `-h` flag.  It returns -1 on clean parse, 0 on help,
+// 1 on parse error.
+
+[test]
+def test_auto_help_long(t : T?) {
+    // format_help_with_auto_help injects --help / -h into the help table when
+    // the user did not declare their own (AutoHelpConfig has none).
+    let info = get_command_info(type<AutoHelpConfig>)
+    let help = format_help_with_auto_help(info, "test")
+    t |> success(find(help, "--help") != -1, "auto-injected --help row")
+    t |> success(find(help, "-h, --help") != -1, "auto-injected -h short alias")
+}
+
+[test]
+def test_auto_help_user_help_no_inject(t : T?) {
+    // ShortFlagsConfig (defined above) declares its OWN help field; auto-help
+    // must NOT add a duplicate row.
+    let info = get_command_info(type<ShortFlagsConfig>)
+    let help = format_help_with_auto_help(info, "test")
+    // count occurrences of "--help" — should be exactly 1 (the user's one).
+    var n = 0
+    var search_from = 0
+    while (true) {
+        let idx = find(help, "--help", search_from)
+        if (idx == -1) {
+            break
+        }
+        n++
+        search_from = idx + 1
+    }
+    t |> equal(n, 1, "exactly one --help row")
+}
+
+// --- Mutex groups ---------------------------------------------------------
+
+[test]
+def test_mutex_group_one_member(t : T?) {
+    var cfg = MutexConfig()
+    let a <- ["--color"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> success(cfg.color, "color set")
+    t |> success(!cfg.no_color, "no_color clear")
+}
+
+[test]
+def test_mutex_group_violation(t : T?) {
+    var cfg = MutexConfig()
+    let a <- ["--color", "--no-color"]
+    let err = parse_args(cfg, a)
+    t |> success(err != "", "mutex violation reported")
+    t |> success(find(err, "--color") != -1, "error mentions --color")
+    t |> success(find(err, "--no-color") != -1, "error mentions --no-color")
+    t |> success(find(err, "color") != -1, "error mentions group name")
+}
+
+[test]
+def test_mutex_group_none_set(t : T?) {
+    var cfg = MutexConfig()
+    let a : array<string>
+    t |> equal(parse_args(cfg, a), "")
+}
+
+[test]
+def test_mutex_different_groups_coexist(t : T?) {
+    var cfg = MutexConfig()
+    let a <- ["--color", "--quiet"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> success(cfg.color, "color set")
+    t |> success(cfg.quiet, "quiet set")
+}
+
+[test]
+def test_mutex_help_decoration(t : T?) {
+    let info = get_command_info(type<MutexConfig>)
+    let help = format_help(info, "test")
+    t |> success(find(help, "(mutex: color)") != -1, "color group annotated")
+    t |> success(find(help, "(mutex: verbosity)") != -1, "verbosity group annotated")
+}
+
+// --- Count action ---------------------------------------------------------
+
+[test]
+def test_count_default(t : T?) {
+    var cfg = CountConfig()
+    let a : array<string>
+    t |> equal(parse_args(cfg, a), "")
+    t |> equal(cfg.verbose, 0)
+}
+
+[test]
+def test_count_long_once(t : T?) {
+    var cfg = CountConfig()
+    let a <- ["--verbose"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> equal(cfg.verbose, 1)
+}
+
+[test]
+def test_count_short_thrice(t : T?) {
+    var cfg = CountConfig()
+    let a <- ["-v", "-v", "-v"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> equal(cfg.verbose, 3)
+}
+
+[test]
+def test_count_mixed_long_short(t : T?) {
+    var cfg = CountConfig()
+    let a <- ["-v", "--verbose"]
+    t |> equal(parse_args(cfg, a), "")
+    t |> equal(cfg.verbose, 2)
+}
+
+[test]
+def test_count_rejects_value_form(t : T?) {
+    var cfg = CountConfig()
+    let a <- ["--verbose=2"]
+    let err = parse_args(cfg, a)
+    t |> success(err != "", "value form rejected")
+    t |> success(find(err, "--verbose") != -1, "error mentions flag")
+}
+
+[test]
+def test_count_help_decoration(t : T?) {
+    let info = get_command_info(type<CountConfig>)
+    let help = format_help(info, "test")
+    t |> success(find(help, "(repeats)") != -1, "count flag annotated as repeats")
 }

--- a/utils/daspkg/commands.das
+++ b/utils/daspkg/commands.das
@@ -13,6 +13,7 @@ require daslib/json
 require daslib/json_boost
 
 require daslib/ansi_colors
+require daslib/clargs public
 
 require lockfile
 require utils
@@ -20,55 +21,59 @@ require index
 require package_runner
 
 
-struct ParsedArgs {
-    root : string
-    command : string
-    command_arg : string
+[CommandLineArgs]
+struct DaspkgArgs {
+    @clarg_positional
+    @clarg_doc = "Subcommand (install / remove / list / search / ...)"
+    command : Option<string>
+
+    @clarg_positional
+    @clarg_doc = "Argument to the subcommand (package name, search query, ...)"
+    command_arg : Option<string>
+
+    @clarg_doc = "Project root (default: current directory)"
+    root : string = "."
+
+    @clarg_doc = "Force reinstall"
     force : bool
-    json : bool
+
+    @clarg_name = "global"
+    @clarg_short = "g"
+    @clarg_doc = "Operate on global modules (das_root/modules/)"
     global_flag : bool
+
+    @clarg_short = "v"
+    @clarg_doc = "Print detailed progress"
+    verbose : bool
+
+    @clarg_doc = "Machine-readable JSON output (list, check, search)"
+    json : bool
+
+    @clarg_short = "b"
+    @clarg_doc = "Install from a branch instead of a tag"
     branch : string
+
+    @clarg_mutex_group = "color"
+    @clarg_doc = "Enable colored output"
+    color : bool
+
+    @clarg_name = "no-color"
+    @clarg_mutex_group = "color"
+    @clarg_doc = "Disable colored output"
+    no_color : bool
 }
 
-def parse_args(args : array<string>) : ParsedArgs {
-    var result = ParsedArgs(root = ".")
-    // args: [exe, script.das, --, command, ...]
-    var i = 0
-    while (i < length(args)) {
-        if (args[i] == "--") {
-            i ++
-            break
-        }
-        i ++
+// Apply parsed flags that flip module-level globals.  Called by main after
+// a successful parse so the rest of daspkg sees the right state.
+def public apply_global_flags(args : DaspkgArgs) {
+    if (args.verbose) {
+        log_verbose_flag = true
     }
-    while (i < length(args)) {
-        let arg = args[i]
-        if (arg == "--force") {
-            result.force = true
-        } elif (arg == "--color") {
-            use_tty_colors = true
-        } elif (arg == "--no-color") {
-            use_tty_colors = false
-        } elif (arg == "--json") {
-            result.json = true
-        } elif (arg == "--global" || arg == "-g") {
-            result.global_flag = true
-        } elif (arg == "--verbose" || arg == "-v") {
-            log_verbose_flag = true
-        } elif (arg == "--root" && i + 1 < length(args)) {
-            i ++
-            result.root = args[i]
-        } elif ((arg == "--branch" || arg == "-b") && i + 1 < length(args)) {
-            i ++
-            result.branch = args[i]
-        } elif (empty(result.command)) {
-            result.command = arg
-        } elif (empty(result.command_arg)) {
-            result.command_arg = arg
-        }
-        i ++
+    if (args.no_color) {
+        use_tty_colors = false
+    } elif (args.color) {
+        use_tty_colors = true
     }
-    return result
 }
 
 def cmd_list(root : string; json : bool = false; is_global : bool = false) {

--- a/utils/daspkg/main.das
+++ b/utils/daspkg/main.das
@@ -9,6 +9,7 @@ require daslib/fio
 require strings
 
 require daslib/ansi_colors
+require daslib/clargs
 
 require lockfile
 require utils
@@ -17,9 +18,10 @@ require commands
 
 // daspkg — daslang package manager
 
+// daspkg's help mixes a hand-written subcommand block (which clargs doesn't
+// model) with the auto-generated flag table from clargs.
 def print_usage() {
     print("daspkg — daslang package manager\n\n")
-    print("Usage: daspkg <command> [args...]\n\n")
     print("Commands:\n")
     print("  install <url|name|path>[@version]  Install a package\n")
     print("  remove <name>                      Remove a package\n")
@@ -33,60 +35,70 @@ def print_usage() {
     print("  build                              Build C/C++ packages\n")
     print("  check                              Verify installed packages\n")
     print("  cleanup                            Remove modules/ and daspkg.lock for a fresh install\n")
-    print("  doctor                             Check environment (git, cmake, gh)\n")
-    print("\nOptions:\n")
-    print("  --root <path>   Project root (default: current directory)\n")
-    print("  --force         Force reinstall\n")
-    print("  --global, -g    Operate on global modules (das_root/modules/)\n")
-    print("  --color         Enable colored output\n")
-    print("  --no-color      Disable colored output\n")
-    print("  --verbose, -v   Print detailed progress\n")
-    print("  --json          Machine-readable JSON output (list, check, search)\n")
-    print("  --branch <name>, -b <name>  Install from a branch (e.g. master) instead of a tag\n")
+    print("  doctor                             Check environment (git, cmake, gh)\n\n")
+    print(format_help_with_auto_help(get_command_info(type<DaspkgArgs>), "daspkg"))
 }
 
 [export]
 def main() {
-    let args = get_command_line_arguments()
-    let parsed = parse_args(args)
+    let argv <- get_user_args()
 
-    if (empty(parsed.command)) {
+    // Help / no-args path: print the full daspkg usage (subcommand block +
+    // clargs flags) and exit 0.  Done manually rather than via
+    // parse_args_with_help so we can prepend the subcommand block.
+    if (empty(argv) || find_index(argv, "--help") != -1 || find_index(argv, "-h") != -1) {
+        print_usage()
+        return 0
+    }
+
+    var parsed = DaspkgArgs()
+    let parse_err = parse_args(parsed, argv)
+    if (!empty(parse_err)) {
+        to_log(LOG_ERROR, "daspkg: {parse_err}\n\n")
+        print_usage()
+        return 1
+    }
+    apply_global_flags(parsed)
+
+    let command = parsed.command ?? ""
+    let command_arg = parsed.command_arg ?? ""
+
+    if (empty(command)) {
         print_usage()
         return 0
     }
 
     let root = get_full_file_name(parsed.root)
     log_init(root)
-    let command = parsed.command
     let is_global = parsed.global_flag
 
     var rc = 0
     if (command == "list") {
         rc = cmd_list(root, parsed.json, is_global)
     } elif (command == "install") {
-        if (empty(parsed.command_arg)) {
+        if (empty(command_arg)) {
             rc = cmd_install_all(root, parsed.force, is_global)
         } else {
-            rc = cmd_install(root, parsed.command_arg, parsed.force, is_global, "", parsed.branch)
+            rc = cmd_install(root, command_arg, parsed.force, is_global, "", parsed.branch)
         }
     } elif (command == "remove") {
-        if (empty(parsed.command_arg)) {
+        if (empty(command_arg)) {
             to_log(LOG_ERROR, "Error: remove requires a package name\n")
             rc = 1
         } else {
-            rc = cmd_remove(root, parsed.command_arg, is_global)
+            rc = cmd_remove(root, command_arg, is_global)
         }
     } elif (command == "update") {
-        if (empty(parsed.command_arg)) {
+        if (empty(command_arg)) {
             rc = cmd_update_all(root, is_global)
         } else {
-            rc = cmd_update(root, parsed.command_arg, is_global)
+            rc = cmd_update(root, command_arg, is_global)
         }
     } elif (command == "upgrade") {
-        if (empty(parsed.command_arg)) {
+        if (empty(command_arg)) {
             rc = cmd_upgrade_all(root, is_global)
         } else {
-            rc = cmd_upgrade(root, parsed.command_arg, is_global)
+            rc = cmd_upgrade(root, command_arg, is_global)
         }
     } elif (command == "build") {
         rc = cmd_build(root, is_global)
@@ -97,21 +109,21 @@ def main() {
     } elif (command == "doctor") {
         rc = cmd_doctor()
     } elif (command == "search") {
-        if (empty(parsed.command_arg)) {
+        if (empty(command_arg)) {
             rc = cmd_search_all(root, parsed.json)
         } else {
-            rc = cmd_search(root, parsed.command_arg, parsed.json)
+            rc = cmd_search(root, command_arg, parsed.json)
         }
     } elif (command == "update-index") {
         rc = cmd_update_index(root)
     } elif (command == "introduce") {
-        rc = cmd_introduce(root, parsed.command_arg)
+        rc = cmd_introduce(root, command_arg)
     } elif (command == "withdraw") {
-        if (empty(parsed.command_arg)) {
+        if (empty(command_arg)) {
             to_log(LOG_ERROR, "Error: withdraw requires a package name\n")
             rc = 1
         } else {
-            rc = cmd_withdraw(root, parsed.command_arg)
+            rc = cmd_withdraw(root, command_arg)
         }
     } else {
         to_log(LOG_ERROR, "Unknown command: {command}\n\n")

--- a/utils/daspkg/test_daspkg.das
+++ b/utils/daspkg/test_daspkg.das
@@ -91,50 +91,60 @@ def test_is_index_name(t : T?) {
 [test]
 def test_parse_args(t : T?) {
     t |> run("install command") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--", "install", "dasImgui"])
-        t |> equal(parsed.command, "install")
-        t |> equal(parsed.command_arg, "dasImgui")
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["install", "dasImgui"]), "")
+        t |> equal(parsed.command ?? "", "install")
+        t |> equal(parsed.command_arg ?? "", "dasImgui")
         t |> success(!parsed.force)
     }
     t |> run("install with force") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--", "install", "dasImgui", "--force"])
-        t |> equal(parsed.command, "install")
-        t |> equal(parsed.command_arg, "dasImgui")
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["install", "dasImgui", "--force"]), "")
+        t |> equal(parsed.command ?? "", "install")
+        t |> equal(parsed.command_arg ?? "", "dasImgui")
         t |> success(parsed.force)
     }
     t |> run("install with root") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--", "--root", "/tmp/proj", "install", "foo"])
-        t |> equal(parsed.command, "install")
-        t |> equal(parsed.command_arg, "foo")
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["--root", "/tmp/proj", "install", "foo"]), "")
+        t |> equal(parsed.command ?? "", "install")
+        t |> equal(parsed.command_arg ?? "", "foo")
         t |> equal(parsed.root, "/tmp/proj")
     }
     t |> run("list command no arg") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--", "list"])
-        t |> equal(parsed.command, "list")
-        t |> success(empty(parsed.command_arg))
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["list"]), "")
+        t |> equal(parsed.command ?? "", "list")
+        t |> success(parsed.command_arg |> is_none)
     }
     t |> run("no command") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--"])
-        t |> success(empty(parsed.command))
+        var parsed = DaspkgArgs()
+        let empty_args : array<string>
+        t |> equal(parse_args(parsed, empty_args), "")
+        t |> success(parsed.command |> is_none)
     }
     t |> run("cleanup command") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--", "cleanup"])
-        t |> equal(parsed.command, "cleanup")
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["cleanup"]), "")
+        t |> equal(parsed.command ?? "", "cleanup")
         t |> success(!parsed.force)
     }
     t |> run("cleanup with force") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--", "cleanup", "--force"])
-        t |> equal(parsed.command, "cleanup")
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["cleanup", "--force"]), "")
+        t |> equal(parsed.command ?? "", "cleanup")
         t |> success(parsed.force)
     }
     t |> run("cleanup with global and force") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--", "cleanup", "--global", "--force"])
-        t |> equal(parsed.command, "cleanup")
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["cleanup", "--global", "--force"]), "")
+        t |> equal(parsed.command ?? "", "cleanup")
         t |> success(parsed.force)
         t |> success(parsed.global_flag)
     }
     t |> run("default root is dot") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--", "list"])
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["list"]), "")
         t |> equal(parsed.root, ".")
     }
 }
@@ -1287,19 +1297,33 @@ def test_ansi_colors(t : T?) {
 }
 
 // --- parse_args color flags ---
+// Under clargs, --color/--no-color populate parsed.color/.no_color and
+// main.das's apply_global_flags flips use_tty_colors.  We test the parse +
+// apply pipeline together so the integration stays covered.
 
 [test]
 def test_parse_args_color_flags(t : T?) {
     t |> run("--color sets use_tty_colors") @(t : T?) {
         use_tty_colors = false
-        parse_args(["exe", "main.das", "--", "list", "--color"])
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["list", "--color"]), "")
+        t |> success(parsed.color, "color flag parsed")
+        apply_global_flags(parsed)
         t |> success(use_tty_colors)
         use_tty_colors = false
     }
     t |> run("--no-color clears use_tty_colors") @(t : T?) {
         use_tty_colors = true
-        parse_args(["exe", "main.das", "--", "list", "--no-color"])
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["list", "--no-color"]), "")
+        t |> success(parsed.no_color, "no_color flag parsed")
+        apply_global_flags(parsed)
         t |> success(!use_tty_colors)
+    }
+    t |> run("--color and --no-color together is mutex error") @(t : T?) {
+        var parsed = DaspkgArgs()
+        let err = parse_args(parsed, ["list", "--color", "--no-color"])
+        t |> success(!empty(err), "mutex group rejects both")
     }
 }
 
@@ -1327,18 +1351,21 @@ def test_read_manifest_rich(t : T?) {
 [test]
 def test_parse_args_global_flag(t : T?) {
     t |> run("--global flag parsed") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--", "install", "foo", "--global"])
-        t |> equal(parsed.command, "install")
-        t |> equal(parsed.command_arg, "foo")
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["install", "foo", "--global"]), "")
+        t |> equal(parsed.command ?? "", "install")
+        t |> equal(parsed.command_arg ?? "", "foo")
         t |> success(parsed.global_flag)
     }
     t |> run("-g shorthand") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--", "-g", "list"])
-        t |> equal(parsed.command, "list")
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["-g", "list"]), "")
+        t |> equal(parsed.command ?? "", "list")
         t |> success(parsed.global_flag)
     }
     t |> run("default global is false") @(t : T?) {
-        let parsed = parse_args(["daslang.exe", "main.das", "--", "install", "foo"])
+        var parsed = DaspkgArgs()
+        t |> equal(parse_args(parsed, ["install", "foo"]), "")
         t |> success(!parsed.global_flag)
     }
 }


### PR DESCRIPTION
## Summary
- Expand `daslib/clargs.das` with broader argument parsing capabilities.
- Add and extend coverage in `tests/daslib/clargs_test.das`.
- Migrate daspkg CLI entrypoints to the updated clargs helpers in `utils/daspkg/commands.das`, `utils/daspkg/main.das`, and `utils/daspkg/test_daspkg.das`.

## Why
This aligns daspkg argument handling with the improved clargs API and adds tests around the new behavior.

## Validation
- Committed staged changes only.
- Pushed branch `better-clargs-better-daspkg` to `origin`.
- Additional test execution was not run as part of this PR creation step.