### PR TITLE
jit: fix Handle<T> return ABI for MSVC (CMRES vs RAX)

### DIFF
--- a/include/daScript/ast/ast_handle.h
+++ b/include/daScript/ast/ast_handle.h
@@ -871,8 +871,10 @@ namespace das
     template <typename T>
     struct WrapArgType<Handle<T>> { typedef uint64_t type; };
 
+    // Must stay Handle<T> (not uint64_t): explicit Handle(uint64_t) makes MSVC return via CMRES,
+    // not RAX -- the FuncType cast in jit_abi.h must preserve the actual return ABI.
     template <typename T>
-    struct WrapRetType<Handle<T>> { typedef uint64_t type; };
+    struct WrapRetType<Handle<T>> { typedef Handle<T> type; };
 
     template <typename T>
     struct typeName<Handle<T>> {


### PR DESCRIPTION
## Summary

Calling any C++ function that returns `Handle<T>` from JIT-compiled code crashed under MSVC x64 (e.g. `make_web_socket_server` in dasHV under JIT — AV writing to address `0x4e1f`, which was the port int treated as a hidden return-slot pointer).

## Root cause

`Handle<T>` has an explicit `Handle(uint64_t)` constructor, which makes the type **non-trivial-for-purposes-of-calls** under the MSVC x64 ABI. MSVC therefore returns `Handle<T>` via a **hidden CMRES pointer** (return slot in RCX), NOT in RAX like `uint64_t`.

The wrapper in `jit_abi.h`'s `ImplWrapCall` builds `FuncType` from `WrapRetType<RetT>::type` and `reinterpret_cast`s the original function pointer to it. With `WrapRetType<Handle<T>>::type = uint64_t` (the previous value in `ast_handle.h`), the wrapper called the actual function expecting RAX-return semantics while the function used CMRES — the first real arg got clobbered with the synthesized return-pointer and all real args shifted down. For `make_web_socket_server(19999, ...)` this surfaced as an AV writing to address `0x4e1f` (= 19999, the port int treated as the return-slot pointer).

Verified empirically with minimal MSVC repros: removing the user-defined `Handle(uint64_t)` ctor fixes return ABI; arg-passing ABI is unaffected because 8-byte trivially copyable structs share the arg register with `uint64_t`.

## Fix

Follows the **EntityId precedent** in `modules/dasUnitTest/unitTest.h`: leave `WrapRetType` at the actual return type (`Handle<T>`) so the `FuncType` cast preserves the return ABI; the `static_cast<uint64_t>` at the end of `static_call` uses Handle's existing `explicit operator uint64_t()` to bridge to the JIT-side type.

`WrapArgType<Handle<T>>::type` stays `uint64_t` — 8-byte trivially copyable structs and `uint64_t` share the arg-passing register on both MSVC x64 and SysV.

## Note for follow-up

`EntityId` (`modules/dasUnitTest/unitTest.h`) and `Time` (`include/daScript/simulate/aot_builtin_time.h`) have the same latent bug — they just aren't returned through the JIT wrapper today. The same one-line `WrapRetType` change would apply if they were ever exercised that way. Not fixing them in this PR to keep the diff scoped to the actual JIT crash.

## Test plan

- [x] `bin/Release/daslang.exe -jit` on a real `HvWebServer` repro: previously AV at `0x4e1f`, now `is_alive`/`==`/`!=` all work
- [x] Full interpreter test suite: 7557/7557 pass
- [x] Full AOT test suite: 6951/6951 pass
- [x] dasHV-only suite: 132/132 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)