### PR TITLE
dasSQLITE: parity audit + multi-Q lowering for `_sql` (F1/F2/F4 resolved)

### DIFF
--- a/daslib/if_not_null.das
+++ b/daslib/if_not_null.das
@@ -43,10 +43,15 @@ class ApplyMacro : AstCallMacro {
             if (!PTR._type.flags.constant) {
                 vtype.flags |= TypeDeclFlags.removeConstant
             }
+            var ptrClone = clone_expression(PTR)
+            var argClones : array<ExpressionPtr>
+            for (a in fcall.arguments) {
+                argClones |> push(clone_expression(a))
+            }
             return <- qmacro_block() {
-                let $i(ifnn_name) : $t(vtype) = $e(PTR)
+                let $i(ifnn_name) : $t(vtype) = $e(ptrClone)
                 if ($i(ifnn_name) != null) {
-                    $c(fcall.name)(*$i(ifnn_name), $a(fcall.arguments))
+                    $c(fcall.name)(*$i(ifnn_name), $a(argClones))
                 }
             }
         }

--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -1370,49 +1370,28 @@ def sum(src : array<auto(TT)>) : TT -const -& {
     }
 }
 
-[unused_argument(tt)]
-def private average_impl(var src; tt : auto(TT)) : TT -const -& {
-    var total : TT -const -&
-    var count : uint64
+def average(var src : iterator<auto(TT)>) : double {
+    //! Averages elements in an iterator. Always returns ``double``
+    //! (matches SQL ``AVG`` / C# ``Average``); element type must cast to ``double``.
+    var total : double = 0lf
+    var count : uint64 = 0ul
     for (x in src) {
-        total += x
+        total += double(x)
         count ++
     }
-    if (count != 0ul) {
-        static_if (typeinfo is_workhorse(type<TT>)) {
-            total /= TT(count)
-        } else {
-            total /= count
-        }
-    }
-    return <- total
+    return count != 0ul ? total / double(count) : 0lf
 }
 
-[unused_argument(tt)]
-def private average_impl_const(src : auto(ARGT); tt : auto(TT)) : TT -const -& {
-    static_if (typeinfo is_workhorse(type<TT>)) {
-        return average_impl(unsafe(reinterpret<ARGT -const>(src)), type<TT -const -&>)
-    } else {
-        return <- average_impl(unsafe(reinterpret<ARGT -const>(src)), type<TT -const -&>)
+def average(src : array<auto(TT)>) : double {
+    //! Averages elements in an array. Always returns ``double``
+    //! (matches SQL ``AVG`` / C# ``Average``); element type must cast to ``double``.
+    var total : double = 0lf
+    var count : uint64 = 0ul
+    for (x in src) {
+        total += double(x)
+        count ++
     }
-}
-
-def average(var src : iterator<auto(TT)>) : TT -const -& {
-    //! Averages elements in an iterator
-    static_if (typeinfo is_workhorse(type<TT>)) {
-        return average_impl(src, type<TT -const -&>)
-    } else {
-        return <- average_impl(src, type<TT -const -&>)
-    }
-}
-
-def average(src : array<auto(TT)>) : TT -const -& {
-    //! Averages elements in an array
-    static_if (typeinfo is_workhorse(type<TT>)) {
-        return average_impl_const(src, type<TT -const -&>)
-    } else {
-        return <- average_impl_const(src, type<TT -const -&>)
-    }
+    return count != 0ul ? total / double(count) : 0lf
 }
 
 [unused_argument(tt)]

--- a/daslib/linq_boost.das
+++ b/daslib/linq_boost.das
@@ -43,6 +43,9 @@ class private AstCallMacro_LinqPred2 : AstCallMacro {
         // replacing function
         var iterType = clone_iterator_type(arg0type)
         var res = qmacro($c(predName)($e(arg0), $(_ : $t(iterType)) => $e(call.arguments[1])))
+        // allow inner `_` to shadow an outer `_` when chains nest
+        // (e.g. `_where(_.x._in(arr |> _select(_.y)))`)
+        (((res as ExprCall).arguments[1] as ExprMakeBlock)._block as ExprBlock).arguments[0].flags |= VariableFlags.can_shadow
         res.force_at(call.at)
         return res
     }
@@ -293,6 +296,8 @@ class private AstCallMacro_LinqPredII2 : AstCallMacro {
         // replacing function
         var iterType = clone_iterator_type(call.arguments[0]._type)
         var res = qmacro($c(predName)($e(call.arguments[0]), $e(call.arguments[1]), $(_ : $t(iterType)) => $e(call.arguments[2])))
+        // allow inner `_` to shadow an outer `_` when chains nest
+        (((res as ExprCall).arguments[2] as ExprMakeBlock)._block as ExprBlock).arguments[0].flags |= VariableFlags.can_shadow
         res.force_at(call.at)
         return res
     }

--- a/doc/source/reference/tutorials/28_linq.rst
+++ b/doc/source/reference/tutorials/28_linq.rst
@@ -109,7 +109,7 @@ Aggregation
    * - ``sum(iter)``
      - Sum of elements
    * - ``average(iter)``
-     - Arithmetic mean
+     - Arithmetic mean (always returns ``double``)
    * - ``min(iter)`` / ``max(iter)``
      - Minimum / maximum
    * - ``aggregate(iter, seed, func)``

--- a/doc/source/reference/tutorials/sql_01_hello.rst
+++ b/doc/source/reference/tutorials/sql_01_hello.rst
@@ -92,9 +92,11 @@ finalizes, and returns the value:
     }
 
 The result type is passed as a ``type<...>`` witness — daslang's gen2
-convention for type-parameterized functions. Chunk 1 ships the ``string``
-overload; ``int``, ``int64``, and ``double`` overloads follow with the
-read-side rework.
+convention for type-parameterized functions. ``query_scalar`` is generic
+over the daslang reader-adapter rail (tutorial 26), so any type with an
+``sql_extract`` adapter works: ``string``, ``int``, ``int64``, ``double``,
+``float``, ``bool``, ``array<uint8>`` (BLOB), and user-defined custom
+types all read through the same call.
 
 ``query_scalar`` panics on prepare/step error and on zero rows. The
 ``try_query_scalar(db, sql, type<T>) : Result<T, string>`` sibling

--- a/doc/source/reference/tutorials/sql_05_parametrized.rst
+++ b/doc/source/reference/tutorials/sql_05_parametrized.rst
@@ -12,8 +12,8 @@ SQL-05 --- Parameter Binding
     single: Tutorial; _first
     single: Tutorial; _first_opt
 
-Parameter binding has two stories in dasSQLITE, and the chunk-3 design
-is to keep the everyday one **invisible**.
+Parameter binding has two stories in dasSQLITE, and the design keeps
+the everyday one **invisible**.
 
 LINQ form: capture is binding
 =============================
@@ -70,8 +70,8 @@ the right ``sqlite_bind`` for each arg:
         "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id = ? AND Name = ?",
         type<Car>, 2, "Audi")
 
-Chunk 3 ships 0..3 positional args. Named-tuple bind for ``:name``
-placeholders ships in a follow-up.
+Today 0..3 positional args are supported. Named-tuple bind for
+``:name`` placeholders is planned.
 
 Strict / Result / Option triples
 ================================

--- a/doc/source/reference/tutorials/sql_08_where.rst
+++ b/doc/source/reference/tutorials/sql_08_where.rst
@@ -15,9 +15,9 @@ SQL-08 --- ``_where`` Predicates: the Full Surface
 
 Inside ``_sql(...)``, ``_where(predicate)`` accumulates a ``WHERE``
 clause via a recursive AST walk. Multiple ``_where`` calls compose
-with ``AND``. This tutorial walks every predicate shape the chunk-3
-analyzer recognizes; anything outside this surface raises a
-compile-time ``macro_error`` pointing at the offending node.
+with ``AND``. This tutorial walks every predicate shape the analyzer
+recognizes; anything outside this surface raises a compile-time
+``macro_error`` pointing at the offending node.
 
 Recognized predicate shapes
 ===========================

--- a/doc/source/reference/tutorials/sql_09_select.rst
+++ b/doc/source/reference/tutorials/sql_09_select.rst
@@ -13,7 +13,7 @@ SQL-09 --- ``_select`` Projections
     single: Tutorial; tuple recordNames
 
 ``_select(...)`` controls *what* columns the SQL emits and *what shape*
-the result has. Three forms ship in chunk 3:
+the result has. Three forms are supported:
 
 ==============================================================  ==========================================================
 Form                                                            Result shape
@@ -125,10 +125,6 @@ default (no ``_select``)                                        Full row; ``arra
 ``_select((Name=_.X, Other=_.Y))``                              Named tuple; ``array<tuple<Name:..;Other:..>>``
 ``_select((Renamed=_.Id, ...))``                                Result fields can rename source columns
 ==============================================================  ==========================================================
-
-Deferred to chunk 4: struct-type projection ``_select(type<T2>)`` for
-projecting into a different ``[sql_table]`` struct. Today users get
-the same result via named-tuple projection.
 
 .. seealso::
 

--- a/doc/source/reference/tutorials/sql_10_order_by.rst
+++ b/doc/source/reference/tutorials/sql_10_order_by.rst
@@ -58,9 +58,8 @@ Mixed ASC/DESC
 
 A single ``_order_by`` step emits all columns in the same direction.
 Mixed ASC/DESC across columns (e.g. ``ORDER BY a ASC, b DESC``) is
-**out of chunk-4 scope**. Until a marker syntax lands, drop down to
-the raw-SQL escape hatch (``query_one`` / ``query_scalar`` /
-``exec``) when you need it.
+**not yet supported**. Drop down to the raw-SQL escape hatch
+(``query_one`` / ``query_scalar`` / ``exec``) when you need it.
 
 Composes with ``_where`` and ``take``
 =====================================

--- a/doc/source/reference/tutorials/sql_11_take_skip.rst
+++ b/doc/source/reference/tutorials/sql_11_take_skip.rst
@@ -18,7 +18,8 @@ Source shape                                    Emitted SQL
 ==============================================  =================================================
 ``take(n)``                                     ``LIMIT ?``
 ``skip(n)`` (alone)                             ``LIMIT -1 OFFSET ?``
-``take(n) |> skip(m)``                          ``LIMIT ? OFFSET ?``
+``skip(m) |> take(n)``                          ``LIMIT ? OFFSET ?`` (canonical pagination)
+``take(n) |> skip(m)``                          nested SELECT (preserves linq positional semantics)
 ``take`` followed by ``_first()``               ``LIMIT 1`` (single-row terminal wins)
 ==============================================  =================================================
 
@@ -45,17 +46,33 @@ SQLite's "no limit"):
 Combined --- a paging window
 ============================
 
-Combine ``take`` and ``skip`` for a window. Order in the chain
-doesn't change the SQL --- the macro accumulates both into a single
-``LIMIT ... OFFSET ...`` clause. Note that ``take(n) skip(m)`` is
-``LIMIT n OFFSET m`` --- rows ``m..m+n-1``, NOT "page (m+1) of
-size n" --- standard paging is ``page k of size n`` =
-``take(n) skip((k-1) * n)``:
+Chain order matters --- ``_sql`` honors linq's positional
+semantics. The canonical pagination shape is
+``skip(m) |> take(n)`` (skip first, then take), which lowers to a
+flat ``LIMIT n OFFSET m``. Standard paging is ``page k of size n``
+= ``skip((k-1) * n) |> take(n)``:
 
 .. code-block:: das
 
-    let window <- _sql(db |> select_from(type<Car>) |> take(2) |> skip(1))
-    // ... LIMIT ? OFFSET ?     (rows 2..3)
+    let window <- _sql(db |> select_from(type<Car>) |> skip(2) |> take(2))
+    // ... LIMIT ? OFFSET ?     (rows 3..4 = page 2 of size 2)
+
+The reverse, ``take(n) |> skip(m)``, means "take first n rows,
+then drop m of those" --- a strictly smaller result of
+``max(0, n - m)`` rows. ``_sql`` preserves that meaning by lowering
+to a nested SELECT:
+
+.. code-block:: das
+
+    let trimmed <- _sql(db |> select_from(type<Car>) |> take(2) |> skip(1))
+    // SELECT ... FROM (SELECT ... LIMIT ?) AS "t0" LIMIT -1 OFFSET ?
+    // result: 1 row (take 2, then drop 1)
+
+Same chain, same answer in all three modes (``_sql`` over SQL
+source, plain chain over SQL source, plain chain over
+``array<T>``). Use the canonical ``skip|take`` form when you want
+the flat fast-path SQL; the reverse is honest about its meaning
+but pays the subquery cost.
 
 Bind ordering
 =============
@@ -96,7 +113,7 @@ SQLite can return rows in any order. Pair ``take``/``skip`` with
 
     let stable_page <- _sql(db |> select_from(type<Car>)
                               |> _order_by(_.Price)
-                              |> take(2) |> skip(1))
+                              |> skip(1) |> take(2))
     // ... ORDER BY "Price" ASC LIMIT ? OFFSET ?
 
 .. seealso::

--- a/doc/source/reference/tutorials/sql_12_distinct.rst
+++ b/doc/source/reference/tutorials/sql_12_distinct.rst
@@ -9,7 +9,6 @@ SQL-12 --- ``distinct``
     single: Tutorial; SQLite
     single: Tutorial; distinct
     single: Tutorial; DISTINCT
-    single: Tutorial; UNION
 
 ``distinct()`` flips a single bool flag on the analyzer's
 ``SqlQuery`` and emits ``SELECT DISTINCT`` instead of plain
@@ -50,19 +49,7 @@ Composes with ``_where``
                                  |> distinct())
     // SELECT DISTINCT "Name" FROM "Cars" WHERE "Price" > ?
 
-Set operations --- deferred
-===========================
-
-``UNION`` / ``INTERSECT`` / ``EXCEPT`` are **out of chunk-4 scope**.
-The chain analyzer is single-source today: every ``SELECT`` comes
-from one ``select_from(type<T>)``. Set operations bring in a second
-``SqlQuery`` and need a multi-stage emitter --- the same engine work
-joins and subqueries need.
-
-Until that lands, work around set ops via the raw-SQL escape hatch
-(``db |> exec(...)`` for DDL plus ``CREATE TEMP VIEW``, then
-``select_from`` the view; or drive the SQLite C API directly for
-multi-row reads of arbitrary SQL).
+For ``UNION`` / ``INTERSECT`` / ``EXCEPT`` see :ref:`tutorial_sql_set_ops`.
 
 .. seealso::
 

--- a/doc/source/reference/tutorials/sql_17_subqueries.rst
+++ b/doc/source/reference/tutorials/sql_17_subqueries.rst
@@ -70,13 +70,13 @@ EXISTS / NOT EXISTS
                           |> _where((db |> select_from(type<Order>))._none(_.Total > 1000)))
     // ... WHERE NOT EXISTS (SELECT ... FROM "Orders" WHERE "Total" > ?)
 
-Uncorrelated only (chunk 5)
-===========================
+Uncorrelated only
+=================
 
-Chunk 5 ships **uncorrelated** subqueries --- the inner WHERE
+Only **uncorrelated** subqueries are supported --- the inner WHERE
 references only the subquery's own row (``_``), not outer columns.
 Correlated subqueries (referring to outer columns from inside the
-subquery's WHERE) land in a follow-up.
+subquery's WHERE) are not yet supported.
 
 .. seealso::
 

--- a/doc/source/reference/tutorials/sql_28_json.rst
+++ b/doc/source/reference/tutorials/sql_28_json.rst
@@ -146,9 +146,9 @@ Descent is arbitrary depth --- nested struct paths concatenate dotted:
     }
 
 The macro emits the archive variant of the adapter pair. The parameter
-is ``const`` because the chunk-8 catch-all binder passes ``v`` non-\
-``var``; ``mem_archive_save`` / ``mem_archive_load`` need a mutable
-reference, so the body clones into a local through ``clone_to_move``:
+is ``const`` because the catch-all binder passes ``v`` non-\ ``var``;
+``mem_archive_save`` / ``mem_archive_load`` need a mutable reference, so
+the body clones into a local through ``clone_to_move``:
 
 .. code-block:: das
 

--- a/modules/dasSQLITE/API_CHECKED.md
+++ b/modules/dasSQLITE/API_CHECKED.md
@@ -1,0 +1,467 @@
+# dasSQLITE API Checked — Equivalence-Harness Plan
+
+Companion to `API_REWORK.md` (master design doc) and `API_MISSING.md`
+(strawman workshop). This file tracks a *verification* workstream: an
+explicit, code-driven audit that the public design promise holds.
+
+## The promise being audited
+
+The dasSQLITE `_sql(...)` macro is, by design, a **pushdown optimizer
+on top of plain linq**. As of the multi-Q lowering work (F1
+resolution), this promise is unconditional for the shipped chain
+shapes — `_sql` honors linq's positional chain semantics, lowering
+divergent orders to nested SELECTs (`SELECT ... FROM (subquery) AS t0
+...`) instead of silently reordering into canonical SQL eval order.
+Same chain → same answer in all three modes.
+
+The same chain shape:
+
+```das
+src |> _where(_.Price > 100)
+    |> _group_by(_.City)
+    |> _select((City=_._0, N=_._1 |> length, Total=_._1 |> select($(u:T) => u.Salary) |> sum))
+```
+
+…is meaningful in three execution modes:
+
+1. **Inside `_sql(...)`** with a SQL source (`db |> select_from(type<T>)`).
+   The macro pattern-matches the chain and emits a single
+   `SELECT … FROM … WHERE … GROUP BY …` query — pushdown.
+2. **Without `_sql(...)`** with a SQL source. `select_from` materializes
+   the full table into `array<T>`; the same chain operators run as plain
+   `linq_boost` macros over that array — client-side aggregation, same
+   answer.
+3. **Without `_sql(...)`** with a plain container source (`array<T>`,
+   table, generator). Pure in-memory linq, identical operators, same
+   answer.
+
+Mode 1 and Mode 2 must agree numerically (this is what makes `_sql` a
+safe optimizer). Mode 2 and Mode 3 must agree (this is what makes the
+operator vocabulary genuinely unified, not a SQL-specific dialect).
+
+This invariant is the load-bearing claim behind every tutorial that
+shows a `_sql(...)` chain. Today it is asserted by design and by ad-hoc
+testing, not by mechanical coverage.
+
+## In scope vs out of scope
+
+**In scope:** linq chain operators — anything that participates in a
+`src |> op1 |> op2 |> ... |> terminal` chain and is meaningful both
+inside and outside `_sql(...)`. `_where`, `_select`, `_group_by`,
+`_having`, `_order_by`, `_join`, `_left_join`, `_first`, `_first_opt`,
+`_count`, `take`, `skip`, `distinct`, set operations (`union`/`intersect`/`except`),
+subqueries (`_in`/`_not_in`/`_any`/`_none`), aggregates (`length`/`sum`/`average`/`min`/`max`),
+`text_match` (FTS5), `_to_array`. The parity claim is that these
+operators have a single semantic, regardless of source.
+
+**Out of scope:** raw-SQL escape-hatch helpers — `query_one`,
+`query_scalar`, `exec`, `try_exec`, and their `try_`/`_opt` variants.
+These are not linq chains — they take a literal SQL string + bind
+arguments and return a row or scalar. They have no Mode-2 (no chain
+to run "without `_sql`") and no Mode-3 (no plain-array analog of "run
+this SQL string"). The parity story does not apply.
+
+Also out of scope: `_sql_text(...)` (SQL-text debug emitter, not a
+runtime operator) and DDL helpers like `create_table` / `_create_view`.
+
+## What the harness should produce
+
+For every tutorial example (and ideally every test) that contains a
+`_sql(...)` chain over a SQL source:
+
+- **Mode-1 vs Mode-2 equivalence.** Run the same chain `with`/`without`
+  the surrounding `_sql(...)` macro and assert the materialized result is
+  equal. Failures here mean either the macro is mis-translating or the
+  in-memory linq path has a divergent semantic.
+- **Mode-2 vs Mode-3 equivalence.** Construct the same logical dataset
+  as a plain `array<T>` (no DB), run the chain, and assert the result
+  matches the SQL-source-without-`_sql` run. Failures here mean an
+  operator behaves differently against a SQL-backed array than a plain
+  array — a leak of provider knowledge into ostensibly generic operators.
+- **Negative coverage — operator unsupported on container.** If a chain
+  uses an operator that intentionally only makes sense inside `_sql`
+  (none planned today, but the door is open — e.g. a `_raw_sql_fragment`
+  escape hatch), the Mode-3 run must produce a *clear* compile-time
+  error, not a silent wrong answer or a runtime panic deep inside linq.
+- **Negative coverage — operator unsupported by `_sql`.** Conversely, if
+  a tutorial constructs a chain using linq operators the `_sql` macro
+  cannot translate, wrapping it in `_sql(...)` must produce a clear
+  `macro_error` pointing at the offending node. (This direction is
+  already mostly covered — every `_sql` rejection is a `macro_error`
+  today; the harness just needs to assert the rejection actually fires
+  for the listed cases instead of silently falling through.)
+
+## Scope
+
+Every tutorial under `tutorials/sql/` whose body contains `_sql(...)` —
+roughly tutorials 06 onward. The chains-without-`_sql` story isn't
+documented in any tutorial today (it's stated implicitly via the
+`_sql_text` debug macro), and the harness is what would let a future
+tutorial point at "and here, same chain, no macro, plain array" with
+confidence.
+
+## Harness shape (sketch)
+
+The harness is not a feature; it's an `[export]`-test pattern. Each
+case has three runs and two equality assertions:
+
+```das
+// fixture: same dataset, two sources
+db |> create_table(type<User>) // populated from `users_seed`
+let users <- users_seed         // plain in-memory copy
+
+// the chain — written ONCE, used three times
+def make_chain(src) {
+    return src |> _where(_.Price > 100)
+                |> _group_by(_.City)
+                |> _select((City=_._0, N=_._1 |> length))
+}
+
+// runs
+let r_sql_pushdown   <- _sql(make_chain(db |> select_from(type<User>)))
+let r_sql_in_memory  <- make_chain(db |> select_from(type<User>))
+let r_plain_array    <- make_chain(users)
+
+// assertions
+assert(r_sql_pushdown   == r_sql_in_memory)
+assert(r_sql_in_memory  == r_plain_array)
+```
+
+Open questions before this can be a real harness, not a sketch:
+
+- Can the chain literally be factored into one `make_chain` helper, or
+  does the macro require the chain to be syntactically present at the
+  `_sql(...)` call site? (Suspect the latter; if so, the harness has
+  to repeat the chain three times — manageable, but means the harness
+  needs `dastest`-style equality fixtures, not a one-shot helper.)
+- Lambda bodies inside the chain (`$(u:User) => u.X`) are types that
+  cross between the macro and the linq runtime — does an
+  `_sql(make_chain(...))` form fail to recognize the chain because the
+  pattern matcher looks for the literal AST shape rather than expansion?
+  Likely yes; this dictates harness ergonomics.
+- Negative-coverage assertions need a way to assert "this file fails to
+  compile with this specific `macro_error`." `dastest` has a pattern
+  for this (compile-fail tests with expected error excerpt) — confirm
+  applicability and standardize before rolling the harness out.
+
+## Coverage gaps
+
+Tutorials currently teaching a thin slice of what the API surface
+should support. Tracked separately from findings — these are
+not-yet-shipped capabilities, not divergences in shipped behavior.
+
+### G1 — Tutorial 16 covers only INNER + LEFT joins
+
+Missing: `_right_join`, `_full_outer_join`, `_cross_join` — none
+implemented in `daslib/linq_boost` or `modules/dasSQLITE/daslib/sqlite_linq`.
+Tutorial 16's note dismisses them as "not shipped" / "raw SQL". Issue
+[#2558](https://github.com/GaijinEntertainment/daScript/issues/2558)
+tracks the work: add all three as first-class chain operators in linq,
+extend `_sql` emission, expand the tutorial (.das + .rst), extend the
+parity test. Surfaced 2026-05-02; Boris flagged as "huge gap."
+
+## Findings
+
+Findings accumulate here as the harness walks the tutorials. Each entry
+names the operator pattern, the modes that disagree, what each mode
+produces, and the size of the impact (silent miscompute vs. clearly
+divergent shapes).
+
+**Resolution rule (Boris, 2026-05-02):** *we never just document
+incorrect behaviour. should work or fail to compile.* Every finding
+ends in either (a) make-it-work code change, or (c) reject-the-shape
+`macro_error` that points at a canonical equivalent. (b) "work via
+different emission" is allowed when (a) and (c) are both worse, but
+"document and move on" is not a resolution. Tutorials demonstrating a
+rejected form must be updated to the canonical form in the same PR.
+
+### F1 — `take(n) |> skip(m)` interpreted differently in `_sql` vs linq — RESOLVED
+
+Tutorial 11. The same chain produced different row counts across modes:
+
+| Mode | Chain                                              | Old lowering              | Rows |
+|------|----------------------------------------------------|---------------------------|------|
+| 1    | `_sql(... \|> take(n) \|> skip(m))`                | `LIMIT n OFFSET m`        | n    |
+| 2    | `... \|> take(n) \|> skip(m)` (no `_sql`, SQL src) | linq positional, in order | max(0, n − m) |
+| 3    | `arr \|> take(n) \|> skip(m)`                      | linq positional, in order | max(0, n − m) |
+
+`_sql` collapsed any combination of `take` and `skip` into one
+`LIMIT/OFFSET` pair (skip-then-take semantics) regardless of chain order.
+Plain linq honored chain order: `take(n)` first narrowed to n rows, then
+`skip(m)` dropped m of those. With the tutorial's fixture
+(`take(2) |> skip(1)`, 5-row table), Mode 1 returned 2 rows and Modes 2/3
+returned 1 row.
+
+**Decision (Boris, 2026-05-02):** initial plan was **(c)** — reject the
+divergent shape with a `macro_error` and a fixit. After discussion, pivoted
+to **(a) + (b) by lowering**: the `_sql` analyzer was rewritten to honor
+linq's positional chain semantics across the board. Same chain → same
+answer in all three modes. Matches the EF Core mental model
+(`project_dassqlite_ef_only.md`). No fixit, no minefield.
+
+**Fix:** multi-Q lowering in `daslib/sqlite_linq.das`. When a chain op's
+SQL eval phase exceeds `q.minPhaseSeen` (e.g. `take` (phase 8) appearing
+inside a `skip` (phase 7) or `_where` (phase 2)), the inner subtree is
+analyzed into a fresh `SqlQuery` and snapshotted to SQL string + bind list
+on the outer Q's `innerSql` / `innerBindExprs` fields. The outer SELECT's
+FROM clause renders as `(<innerSql>) AS "t0"`. Bind collection
+recurses inner-first via `collect_query_binds`. Phase divert checks live
+in 5 peel blocks (TAKE / SKIP / ORDER_BY / ORDER_BY_DESC / DISTINCT — the
+ops where chain-order divergence is real with default-row inner). WHERE
+stays commutative (no divert). Set-ops / joins are unchanged for v1.
+
+**Side-effects:** `take(n) |> _where(p)`, `take(n) |> _order_by(k)`,
+`take(n) |> _order_by(k) |> take(m)` (multi-level), and
+`skip(n) |> _where(p)` shapes that previously silently miscomputed in
+`_sql` now lower to subqueries with the linq-correct semantics.
+
+**Tutorial 11 (`tutorials/sql/11-take_skip.das` + `sql_11_take_skip.rst`):**
+canonical pagination shape promoted to `skip(m) |> take(n)` (flat fast
+SQL). The reverse `take(n) |> skip(m)` is shown as the "honest, slower
+subquery" form, with the row-count change explained.
+
+**Coverage** (`tests/dasSQLITE/`):
+- `parity_check_11_take_skip.das` — divergence pin removed; replaced
+  with three positive parity cases (`take|skip` 1-row, `n>m` 2-rows,
+  degenerate `m>n` 0-rows).
+- `parity_check_11b_take_then_where.das` — 5 cases covering basic
+  outer-where, two-where AND-fold, inner+outer where coexistence,
+  `_to_array` terminal, `_first_opt` terminal.
+- `parity_check_11c_take_then_order.das` — 3 cases: take|order ASC,
+  take|order DESC, three-level nesting.
+- `parity_check_11d_skip_then_where.das` — 2 cases: skip|where, plus
+  skip|where|order_desc.
+
+**v2 deferred:** inner-Q-with-`_select` (aggregate-then-filter:
+`_select(... |> sum) |> _where`) and multi-join
+(`_join |> _where |> _join`) require alias-aware column resolution
+in `pred_to_sql` and a `process_join_call` rework — see "v2 capabilities"
+below for the punch list.
+
+**v2 capabilities (deferred to follow-up PR):**
+- **Aggregate-then-filter** — divert on `_select` (P=5) when outer is
+  `_where` (P=2). Requires `pred_to_sql` to resolve `_.<alias>` against
+  the inner Q's projected named-tuple (a new `q.fromRowType` consult path)
+  and inner Q to emit `AS "<alias>"` SQL aliases on grouped/named-tuple
+  projections.
+- **Multi-join** (`_join |> _where |> _join`) — `process_join_call`
+  needs to accept an inner-subquery LHS (FROM `(innerSql) AS t0 JOIN ...`)
+  and the single-join restriction lifted.
+- A `divert_to_inner` v1 stub (`subQ.proj != FullRow`) currently emits
+  a clear `macro_error` pointing at this v2 boundary, so users hit the
+  v2 cases get a precise error message instead of a silent miscompute
+  or a deep typer trace.
+
+### F2 — `average(array<int>)` truncates in linq, promotes to double in `_sql` — RESOLVED
+
+Tutorial 13. Same chain produced different *types and values*:
+
+| Mode | Chain                                                        | Returns           | Value (Price=[100,200,300,50,999]) |
+|------|--------------------------------------------------------------|-------------------|-------------------------------------|
+| 1    | `_sql(... \|> _select(_.Price) \|> average())`               | `double`          | `329.8` (SQL `AVG` promotes)        |
+| 2    | `... \|> _select(_.Price) \|> average()` (no `_sql`, SQL src) | `int` (input TT) | `329` (integer division)            |
+| 3    | `arr \|> _select(_.Price) \|> average()`                     | `int`             | `329` (integer division)            |
+
+Worse than F1: not only did the chain mean different things across
+modes, the two results didn't even typecheck (`equal(double, int)`
+errors at the `==` site).
+
+The defect was on the linq side. The old `daslib/linq.das`:
+```das
+def average(src : array<auto(TT)>) : TT -const -& {
+```
+returned the input element type. For `array<int>` that was `int`, so
+`(sum / count : int / int)` truncated. SQL's `AVG` always promotes to
+floating point; C# LINQ's `Average(IEnumerable<int>)` returns `double`
+for the same reason. daslang's linq was the outlier.
+
+**Fix:** `daslib/linq.das` `average(iterator<TT>)` and `average(array<TT>)`
+both unconditionally return `double` and accumulate in `double` from
+element zero (uniform path for every numeric `TT`, no integer overflow
+hazard up to ~2⁵³, more precise than naive `float` sum). The private
+`average_impl` / `average_impl_const` helpers were removed — the simple
+loop is the implementation. The `min_max_average` family is unchanged
+(still TT-preserving).
+
+**Caller-side fallout:** the deliberate "complex average" test case in
+`tests/linq/test_linq_aggregation.das` (averaging an `array<ComplexType>`
+with custom `+=` and `/= uint64` operators) was deleted; users with
+custom non-numeric types must roll their own averager. All other linq
+tests had assertion-type updates (`equal(query, 2)` → `equal(query, 2.0lf)`).
+The Mode-1-vs-Mode-2-vs-Mode-3 parity assertion `M1 ≡ M2 ≡ M3` now
+holds against `double 329.8` everywhere. `parity_check_13_aggregates.das`
+flipped from divergence-pin to equality assertion.
+
+### F4 — `_in` / `_not_in` / `_any` / `_none` shadow `_` inside `_where` — RESOLVED
+
+Tutorial 17. The two `linq_boost` predicate base classes
+(`AstCallMacro_LinqPred2` / `AstCallMacro_LinqPredII2`) synthesize a
+`$(_ : T) => …` lambda for the predicate body. Whenever such a chain
+nested inside another `_`-binding macro (canonical case:
+`arr |> _where(_.Id._in(other |> _select(_.UserId)))`), the inner
+lambda's `_` shadowed the outer's `_` and the typer rejected the
+chain at `linq_boost.das:45` — far from the user's call site.
+
+Fix: set `VariableFlags.can_shadow` on the synthesized `_`
+parameter. The flag was already used elsewhere in `linq_boost.das`
+for macro-generated bindings; the predicate path was missing it.
+Two-line patch in both base classes' `visit` overrides.
+
+`parity_check_17_subqueries.das` covers all four operators across
+the three modes; the previously-pinned `failed_parity_check_17_…`
+file has been removed.
+
+The 1-arg `_any()` / `_none()` form (test if the subquery is
+non-empty, lifts to plain `EXISTS (...)` / `NOT EXISTS (...)` under
+`_sql`) remains Mode-1-only — `LinqAny` / `LinqNone` inherit
+`AstCallMacro_LinqPred2` which `macro_verify`s on a 2-arg shape, so
+the zero-predicate form errors with `expecting any(iterator,
+predicate)` outside `_sql`. In plain linq the equivalent is
+`length(...) > 0` or the function-form `any(...)`; this is a
+different surface, not a parity divergence. Out of scope here.
+
+### F3 — `_having |> _order_by` after `_group_by` fails to compile in plain linq
+
+Tutorial 14. Chains like:
+
+```das
+arr |> _group_by(_.City) |> _having(_._1 |> length >= 1) |> _order_by(_._0) |> _select(...)
+```
+
+Mode 1 (`_sql`) emits `SELECT ... GROUP BY "City" HAVING ... ORDER BY "City"` and runs.
+Modes 2/3 fail to compile with a deep typer error:
+
+```
+error[30304]: no matching functions or generics:
+  _::clone(tuple<string;array<User>> aka TT&, tuple<string;array<User>> aka TT const&)
+  d:/Work/daScript/daslib/builtin.das:999:15
+  ...
+  instanced from linq`order_by` ... at d:/Work/daScript/daslib/linq.das:413:8
+```
+
+The trigger is the **combination** `_having |> _order_by`, not bare
+`_order_by` after `_group_by`. Without `_having`, the linq fusion of
+`_group_by + _order_by + _select(...)` apparently follows a path that
+doesn't materialize the grouped array for sorting; once `_having`
+is in the chain, post-aggregate filtering forces a real
+`array<tuple<K, array<T>>>` to be produced, then sorted. linq's
+`order_by` calls `clone_to_move` on the input (`linq.das:413`), which
+needs a generic `_::clone` for the per-element type — and the nested
+`array<T>` (T = User, contains strings) has no synthesizable clone.
+The error fires deep inside `builtin.das`, far from the user's chain.
+
+Two distinct issues stacked on top of each other:
+1. **Functional defect in linq:** `order_by` should be able to sort an
+   `array<tuple<...>>` whose elements contain non-cloneable nested
+   arrays. Sorting only needs move/swap, not deep clone — the
+   `clone_to_move` defensive copy is the part that should yield to
+   plain move semantics.
+2. **Diagnostic defect:** even if (1) is intentionally rejected, the
+   error must point at the user's `_order_by(_._0)` call and explain
+   "can't sort grouped results in linq because the grouping holds
+   owned arrays of T, and T isn't cloneable" — not at `builtin.das:999`.
+
+`parity_check_14_group_by.das` routes around F3 by **post-sorting**
+each mode's result manually with a `sort_by_city` helper, after
+removing inline `_order_by` from the chains. Negative-coverage test:
+[failed_parity_check_14_order_after_group.das](../../tests/dasSQLITE/failed_parity_check_14_order_after_group.das)
+pins the cryptic error so we'll notice when linq is fixed.
+
+**Canonical form (today):** sort outside the chain, after materialization,
+when `_having` is involved.
+
+**Decision (Boris, 2026-05-02):** **(b)**. Add a `static_if` /
+`concept_assert` guard in linq's `order_by` (or its caller) that
+detects the case at compile-time and emits a clear error:
+"`order_by` cannot sort `array<tuple<K, array<T>>>` when T is not
+cloneable — sort outside the chain after materialization, or extend
+T with a `clone` overload." The error must point at the user's
+`_order_by` call site, not `builtin.das:999`. Plain linq stays
+unchanged for the cases that already work; `_sql` keeps full pushdown.
+Tutorials remain truthful — the error tells the user to either drop
+to post-sort or wrap in `_sql(...)`. This is the diagnostic-as-
+architecture path: the harness still surfaces the divergence, but the
+compiler now communicates it instead of the user discovering it via a
+deep typer trace. Implementation lives near `daslib/linq.das:411-413`.
+
+## Walkthrough — complete (2026-05-02)
+
+Every tutorial under `tutorials/sql/01..41` has been audited. Tests live
+under `tests/dasSQLITE/parity_check_<NN>_*.das` (passing) and
+`tests/dasSQLITE/failed_parity_check_<NN>_*.das` (pinning known
+divergences for regression-detection).
+
+### Tutorials with parity tests (23 files, ~70 [test] cases)
+
+| Tutorial | File | Coverage |
+|----------|------|----------|
+| 04 select_all | parity_check_04_select_all.das | full row, _where, _select scalar |
+| 05 parametrized | parity_check_05_parametrized.das | _first, _first_opt miss/hit |
+| 06 error_handling | parity_check_06_error_handling.das | _try_sql variants |
+| 07 anatomy | parity_check_07_anatomy.das | symmetric _where, chained AND, starts_with |
+| 08 where | parity_check_08_where.das | OR+string, ends_with, contains, to_lower, length, abs |
+| 09 select | parity_check_09_select.das | named-tuple, renamed, named-tuple+_first |
+| 10 order_by | parity_check_10_order_by.das | single ASC/DESC, tuple-key, where|order|take |
+| 11 take_skip | parity_check_11_take_skip.das | F1 RESOLVED (multi-Q); + 3 take|skip equivalence cases |
+| 11 take|where (multi-Q) | parity_check_11b_take_then_where.das | inner-take + outer-where, multi-where, inner+outer where, terminals |
+| 11 take|order (multi-Q) | parity_check_11c_take_then_order.das | inner-take + outer-order ASC/DESC, three-level nesting |
+| 11 skip|where (multi-Q) | parity_check_11d_skip_then_where.das | inner-skip + outer-where, outer-where + outer-order |
+| 12 distinct | parity_check_12_distinct.das | full-row, single-col, where|select|distinct |
+| 12b set_ops | parity_check_12b_set_ops.das | union, intersect, except |
+| 13 aggregates | parity_check_13_aggregates.das | + F2 divergence pin |
+| 14 group_by | parity_check_14_group_by.das | post-sort to dodge F3 |
+| 15 join | parity_check_15_join.das | inner join, left/right filter |
+| 16 left_join | parity_check_16_left_join.das | _left_join + Option<TB> projection |
+| 17 subqueries | parity_check_17_subqueries.das | `_in`/`_not_in`/`_any(pred)`/`_none(pred)` |
+| 18 null_handling | parity_check_18_null_handling.das | round-trip, is_some, is_none, unwrap_or |
+| 23 foreign_keys | parity_check_23_foreign_keys.das | _where|count, _to_array |
+| 24 indexes | parity_check_24_indexes.das | _where + _order_by_descending + _to_array (int64) |
+| 26 custom_types | parity_check_26_custom_types.das | enum filter (Guid+DateTime+enum), Option<DateTime> |
+| 28 json | parity_check_28_json.das | JSON path WHERE/SELECT/count, nested struct path |
+| 32 sql_functions | parity_check_32_sql_functions.das | `[sql_function]` transparency |
+| 35 streaming | parity_check_35_streaming.das | `_each_sql` ≡ `_sql` ≡ M2 ≡ M3 |
+| 36 attach | parity_check_36_attach.das | `with_attached`, manual attach + `with_schema` |
+| 40 fts5 | parity_check_40_fts5.das | `text_match` AND/prefix/phrase/OR/NEAR |
+
+### Tutorials skipped (no linq chain shape)
+
+| # | File | Why skipped |
+|---|------|-------------|
+| 01 | version.das | metadata, no chain |
+| 02 | insert_data.das | write-side only |
+| 03 | last_row_id.das | write-side only |
+| 19 | update.das | write-side only |
+| 20 | delete.das | write-side only |
+| 21 | upsert.das | write-side only |
+| 22 | transactions.das | transaction lifecycle, no chain |
+| 25 | defaults_computed.das | DDL-only |
+| 27 | blob.das | adapter rail, no new chain |
+| 29 | column_names.das | `column_info` is compile-time, raw PRAGMA otherwise |
+| 30 | list_tables.das | raw `query("SELECT … FROM sqlite_master")` |
+| 31 | views.das | DDL chain inside `_create_view`; no plain-array analog |
+| 33 | pragma.das | connection admin, no chain |
+| 34 | backup_vacuum.das | DB maintenance, no chain |
+| 37 | bulk_operations.das | write-side perf; only chain is `_where|count` (covered by tut 13) |
+| 38 | concurrency.das | thread/lock patterns, no new chain |
+| 41 | triggers.das | raw `exec("CREATE TRIGGER …")`, no chain |
+
+### Findings summary
+
+| ID | Tutorial | Decision | Status |
+|----|----------|----------|--------|
+| F1 | 11 take_skip | multi-Q lowering — `take \| skip` and latent siblings (`take \| where`, `take \| order`, `skip \| where`) all preserve linq positional semantics | resolved |
+| F2 | 13 aggregates | (a) fix `daslib/linq.das` `average` → always `double` | resolved |
+| F3 | 14 group_by | (b) `static_if` guard in `order_by` over `array<tuple<K, array<T>>>` | deferred fix |
+| F4 | 17 subqueries | set `can_shadow` on synthesized `_` in `AstCallMacro_LinqPred2`/`LinqPredII2` | resolved (issue [#2559](https://github.com/GaijinEntertainment/daScript/issues/2559)) |
+| G1 | 16 left_join | add `_right_join` / `_full_outer_join` / `_cross_join` | issue [#2558](https://github.com/GaijinEntertainment/daScript/issues/2558) |
+| (lang) | 14 group_by | strongly-named tuple support (recordNames in cache key) | issue [#2557](https://github.com/GaijinEntertainment/daScript/issues/2557) |
+
+## Next steps
+
+- Land the four findings (F1–F4) as separate PRs, each with its parity
+  test flipping from `failed_parity_check_*.das` to `parity_check_*.das`
+  (or the workaround removed from the existing parity test).
+- G1 + #2557 are language-level — schedule independently of the
+  parity-test work.
+- After F1–F4 are resolved, re-run every `parity_check_*.das` and assert
+  zero divergences remain; promote the suite to a CI-required job.

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -1214,6 +1214,107 @@ the inner parameter sidesteps it; the macro recognizes the body as
   `sql_13_aggregates.rst`, `sql_14_group_by.rst`,
   `sql_18_null_handling.rst`. Sphinx `-W` clean.
 
+## Shipped — multi-Q lowering: F1 resolution (branch `better-docs-and-fixes`)
+
+Pivots `_sql(...)` from a "canonical-order pushdown optimizer" to an
+unconditional "same chain → same answer in all three modes" guarantee
+for the v1 chain shapes.
+
+### Problem
+
+The parity audit (`API_CHECKED.md` F1) surfaced that `_sql` collapsed
+any combination of `take` and `skip` into one `LIMIT/OFFSET` pair
+regardless of chain order. Latent siblings: `take(n) |> _where(p)`
+silently emitted `WHERE p LIMIT n` (filter-then-take) instead of
+linq's "take-then-filter" semantics. Same chain, different answers.
+
+### Solution — multi-Q tree
+
+`SqlQuery` gains four fields:
+
+```das
+innerSql       : string                 // null/empty = base-table FROM; else nested SELECT
+innerBindExprs : array<ExpressionPtr>   // FROM-subquery placeholders, parsed first
+minPhaseSeen   : int = 0x7fffffff       // sentinel; lowest phase added to this Q
+fromRowType    : TypeDeclPtr            // reserved for v2 alias-aware resolution
+```
+
+Each chain op gets a phase number matching SQL eval order
+(0=FROM, 1=JOIN, 2=WHERE, 3=GROUP_BY/DISTINCT/SET_OP, 4=HAVING,
+5=SELECT, 6=ORDER_BY, 7=SKIP, 8=TAKE, 9=TERMINAL). Higher phase =
+later in eval = outer in SQL nesting.
+
+`analyze_chain` walks outermost-first as before. Five peel blocks
+(TAKE / SKIP / ORDER_BY / ORDER_BY_DESC / DISTINCT — the ops where
+chain-order divergence is real with default-row inner) check
+`P > q.minPhaseSeen` and divert via `divert_to_inner` when true.
+WHERE stays commutative (no divert).
+
+`divert_to_inner` allocates a fresh `subQ`, recursively analyzes the
+peeled op + remainder of the chain into it, then snapshots the inner
+SELECT to SQL string + flat bind list on the outer Q. Inner subQ is
+constrained to default-row projection (v1 scope); v2 will lift this
+to support inner with `_select`.
+
+### Emission
+
+`build_sql_select` adds one branch: when `q.innerSql` is non-empty,
+FROM renders as `(<innerSql>) AS "t0"` instead of the base-table.
+Outer Q's WHERE / ORDER / GROUP / HAVING / SELECT clauses reference
+the inner's columns by their original names (default-row projection
+exposes the source struct's field names through the subquery).
+
+`collect_query_binds` centralizes bind ordering across the multi-Q
+tree: `innerBindExprs → joins-ON → bindExprs (WHERE) → havingBindExprs →
+setOpRhsBinds → LIMIT → OFFSET`. Replaces the inline splice in
+`emit_sql_macro_body` / `emit_each_sql_macro_body` / `_create_view`.
+Set-op fold simplified: `setOpRhsBinds` stores RHS's flattened binds
+instead of inline-folding everything into `q.bindExprs`.
+
+### v1 capabilities (parity tests added)
+
+- `take(n) |> skip(m)` — F1 RESOLVED. `max(0, n-m)` rows in all 3 modes.
+- `take(n) |> _where(p)` — outer-where over inner-take subquery.
+- `take(n) |> _order_by(k)` — re-sort the n taken rows.
+- `take(n) |> _order_by(k) |> take(m)` — three-level nesting.
+- `skip(n) |> _where(p)` — outer-where over inner-skip subquery.
+
+Existing canonical-order chains stay flat: `_where |> _order_by |>
+take`, single-join + post-join `_where`, set-ops, all subqueries
+(`_in`/`_any`/`_none`) — no inner subquery pushed, byte-identical SQL.
+
+### v2 deferred (separate PR)
+
+- **Aggregate-then-filter** (`_select(... |> sum) |> _where`) —
+  divert on `_select` (P=5), thread `q.fromRowType` through
+  `pred_to_sql` for alias-aware column resolution. Inner Q must emit
+  `AS "<alias>"` SQL aliases on grouped/named-tuple projections.
+- **Multi-join** (`_join |> _where |> _join`) — `process_join_call`
+  rework to accept inner-subquery LHS; lift the single-join restriction.
+
+The v1 `divert_to_inner` emits a clear `macro_error` when the inner
+Q has a non-`FullRow` projection, pointing users at the v2 boundary.
+
+### Coverage
+
+- 24 existing `parity_check_*.das` files — every previously-passing
+  case still passes, byte-identical SQL for canonical-order chains.
+- New `parity_check_11_take_skip.das` (8 cases — divergence pin removed,
+  3 new equivalence cases added).
+- New `parity_check_11b_take_then_where.das` (5 cases).
+- New `parity_check_11c_take_then_order.das` (3 cases).
+- New `parity_check_11d_skip_then_where.das` (2 cases).
+- `failed_parity_check_14_order_after_group.das` (F3 pin) still
+  reports `30304:1` as expected — F3 is orthogonal (linq side, not
+  `_sql`).
+
+### Tutorial 11
+
+`tutorials/sql/11-take_skip.das` + `doc/source/reference/tutorials/sql_11_take_skip.rst`
+updated: canonical pagination promoted to `skip(m) |> take(n)`
+(flat fast SQL); the reverse `take(n) |> skip(m)` is shown as the
+"honest, slower subquery" form with the row-count change explained.
+
 ## Appendix C — `_sql` translation boundary (cross-reference for tutorial 7)
 
 What `_sql(chain)` translates and what it refuses, in one place. The

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -92,6 +92,26 @@ def to_sql_literal(value : auto(TT)) : string {
 
 // ===== SqlQuery — accumulator for chain analysis =====
 
+let private INT_MAX_PHASE : int = int(0x7fffffff)
+
+// Phase numbers match SQL eval order: lower = earlier in eval = innermost in SQL nesting.
+// Multiple ops at the SAME phase coexist in one Q (e.g. two `_where` AND-fold).
+// On peel: P > q.minPhaseSeen → push inner subQ (this op runs AFTER something already
+// in q per chain order, but its eval phase says BEFORE — preserve linq positional
+// semantics by lowering to a nested SELECT).
+let private PHASE_SOURCE     : int = 0
+let private PHASE_JOIN       : int = 1
+let private PHASE_WHERE      : int = 2
+let private PHASE_GROUP_BY   : int = 3
+let private PHASE_DISTINCT   : int = 3
+let private PHASE_SET_OP     : int = 3
+let private PHASE_HAVING     : int = 4
+let private PHASE_SELECT     : int = 5
+let private PHASE_ORDER_BY   : int = 5   // same phase as SELECT — they commute in SQL (ORDER BY can reference projected aliases or source columns); prevents spurious divert on canonical `_group_by |> _order_by |> _select`
+let private PHASE_SKIP       : int = 7
+let private PHASE_TAKE       : int = 8
+let private PHASE_TERMINAL   : int = 9   // _first / _first_opt / _to_array / aggregate
+
 enum private Materializer {
     Array
     One
@@ -169,6 +189,7 @@ struct private SqlQuery {
     joins       : array<JoinSpec>
     setOpKind     : SetOpKind = SetOpKind.None
     setOpRhsSql   : string
+    setOpRhsBinds : array<ExpressionPtr>   // RHS placeholders, parsed AFTER LHS in `<lhs> UNION <rhs>`
     seenSetOp     : bool
     argNames    : array<string>
     argSourceIdx : array<int>
@@ -177,6 +198,14 @@ struct private SqlQuery {
     inView      : bool     //! `_create_view` body context — rejects `[sql_function(directonly=true)]` UDF calls
     hadError    : bool
     lastError   : string   //! First `pred_fail` message, re-emitted by call_macros if their deeper macro_error gets eaten by AST cascade
+    // Multi-Q lowering: when a chain conflicts with canonical SQL phase order
+    // (e.g. `take(n) |> _where(p)`), the inner subtree is analyzed into a fresh
+    // SqlQuery, snapshotted to SQL string + binds here, and the outer SELECT's
+    // FROM clause renders as `(<innerSql>) AS t0` instead of a base-table name.
+    innerSql       : string                 // null/empty = base-table FROM; else nested SELECT body
+    innerBindExprs : array<ExpressionPtr>   // FROM-subquery placeholders, parsed first
+    minPhaseSeen   : int = int(0x7fffffff)  // INT_MAX_PHASE sentinel; lowest phase added to this Q
+    fromRowType    : TypeDeclPtr            // `_` row type for outer-Q lambdas (= inner's projected output)
 }
 
 // ===== SqlFrag fragment stream =====
@@ -600,7 +629,7 @@ def private extract_key_selector_field(var keyLambda : ExpressionPtr; expectedAr
 def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
                               kind : JoinKind; prog : ProgramPtr; at : LineInfo) : bool {
     if (q.seenJoin) {
-        macro_error(prog, at, "_sql: only one join per chain (3+ table joins are not yet supported in chunk 5; chain multiple two-table joins or use raw SQL)")
+        macro_error(prog, at, "_sql: only one join per chain (3+ table joins are not yet supported; chain multiple two-table joins or use raw SQL)")
         return false
     }
     if (q.seenSelect) {
@@ -705,6 +734,99 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     return true
 }
 
+// ===== Multi-Q lowering — phase model + bind collection =====
+
+[macro_function]
+def private collect_query_binds(var q : SqlQuery&; var out : array<ExpressionPtr>&) {
+    // Placeholder order matches SQL parse order, depth-first inner-first:
+    //   1. Inner-Q (FROM subquery) binds — innermost SELECT parsed first
+    //   2. Per-join ON binds — within outer FROM clause
+    //   3. WHERE binds
+    //   4. HAVING binds
+    //   5. Set-op RHS binds (compound `<lhs> UNION <rhs>` — RHS parsed before any outer LIMIT)
+    //   6. LIMIT bind (compound applies to combined result, parsed last)
+    //   7. OFFSET bind
+    for (b in q.innerBindExprs) {
+        out |> push(b)
+    }
+    for (j in q.joins) {
+        for (b in j.rightOnBindExprs) {
+            out |> push(b)
+        }
+    }
+    for (b in q.bindExprs) {
+        out |> push(b)
+    }
+    for (b in q.havingBindExprs) {
+        out |> push(b)
+    }
+    for (b in q.setOpRhsBinds) {
+        out |> push(b)
+    }
+    let forced_one_row = ((q.matr == Materializer.One || q.matr == Materializer.OneOpt)
+                          && q.proj != ProjectionShape.Aggregate)
+    if (!forced_one_row && q.limitBindExpr != null) {
+        out |> push(q.limitBindExpr)
+    }
+    if (!forced_one_row && q.offsetBindExpr != null) {
+        out |> push(q.offsetBindExpr)
+    }
+}
+
+// Inner Q's projection-output type, used by the outer Q's lambdas to resolve `_.Field`.
+// Default-row inner: returns rootType (the source struct). Outer references original column
+// names as if FROM were the base table — works automatically through existing pred_to_sql.
+// v2 (projected inner with _select): would return the projection's named-tuple TypeDecl.
+[macro_function]
+def private inner_projection_type(var inner : SqlQuery&) : TypeDeclPtr {
+    return inner.rootType
+}
+
+// Phase-conflict diversion: the peeled op + the rest of the chain are analyzed into a
+// fresh sub-Q, snapshotted as SQL string + flat bind list, and attached to outer q's
+// FROM clause. Same node is re-passed: the divert handles the outer-Q decision; the
+// inner Q sees the op as a normal first peel (no conflict, since subQ.minPhaseSeen
+// starts at INT_MAX_PHASE).
+[macro_function]
+def private divert_to_inner(var node : ExpressionPtr; var q : SqlQuery&;
+                            prog : ProgramPtr; at : LineInfo) : bool {
+    var subQ = SqlQuery(inView = q.inView)
+    if (!analyze_chain(node, subQ, prog, at)) {
+        return false
+    }
+    if (subQ.seenTerminal || subQ.seenToArray) {
+        macro_error(prog, at, "_sql: terminals (`_first`, `_to_array`, etc.) cannot appear inside a subquery — keep the terminal at the outermost chain position")
+        return false
+    }
+    if (subQ.proj != ProjectionShape.FullRow) {
+        // v2 capability: outer Q must reference the inner's projected aliases.
+        macro_error(prog, at, "_sql: chain shape with projection-changing inner subquery (e.g. `_select |> _where`, `_select(... |> sum) |> _where`) is a v2 capability — not yet supported. Restructure the chain to put the divergent op AFTER the projection, or use raw SQL.")
+        return false
+    }
+    let innerSql = build_sql_string(subQ)
+    var innerBinds : array<ExpressionPtr>
+    collect_query_binds(subQ, innerBinds)
+    q.innerSql := innerSql
+    q.innerBindExprs <- innerBinds
+    q.fromRowType = inner_projection_type(subQ)
+    if (q.rootType == null) {
+        q.rootType = subQ.rootType
+    }
+    if (empty(q.tableName)) {
+        q.tableName := subQ.tableName
+    }
+    if (q.dbExpr == null) {
+        q.dbExpr = subQ.dbExpr
+    }
+    // Outer Q sees the inner subquery as a default-row source: same column names as the
+    // base table, since inner emits `SELECT col1, col2, ... FROM ...`. Fill outer's
+    // selectCols so build_sql_select emits a non-empty SELECT clause.
+    if (q.proj == ProjectionShape.FullRow && length(q.selectCols) == 0 && q.rootType != null) {
+        fill_default_columns(q, q.rootType, prog, at)
+    }
+    return true
+}
+
 [macro_function]
 def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
     if (node == null) {
@@ -736,7 +858,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
                 return false
             }
             if (fCall.arguments |> length != 1) {
-                macro_error(prog, at, "_sql: _first(predicate) is chunk 4; chunk 3 supports `|> _first()` only")
+                macro_error(prog, at, "_sql: `_first(predicate)` is not yet supported — use `|> _where(predicate) |> _first()` instead")
                 return false
             }
             q.matr = Materializer.One
@@ -766,7 +888,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
                 return false
             }
             if (cCall.arguments |> length != 1) {
-                macro_error(prog, at, "_sql: _count(predicate) is chunk 4; chunk 3 supports `|> _count()` only")
+                macro_error(prog, at, "_sql: `_count(predicate)` is not yet supported — use `|> _where(predicate) |> _count()` instead")
                 return false
             }
             q.matr = Materializer.One
@@ -803,6 +925,10 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
     {
         var dCall = match_linq_call(node, "distinct")
         if (dCall != null) {
+            if (q.minPhaseSeen != INT_MAX_PHASE && PHASE_DISTINCT > q.minPhaseSeen) {
+                return divert_to_inner(node, q, prog, at)
+            }
+            if (PHASE_DISTINCT < q.minPhaseSeen) { q.minPhaseSeen = PHASE_DISTINCT; }
             if (q.seenDistinct) {
                 macro_error(prog, at, "_sql: distinct() can appear at most once in the chain")
                 return false
@@ -820,6 +946,10 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
     {
         var tCall = match_linq_call(node, "take")
         if (tCall != null) {
+            if (q.minPhaseSeen != INT_MAX_PHASE && PHASE_TAKE > q.minPhaseSeen) {
+                return divert_to_inner(node, q, prog, at)
+            }
+            if (PHASE_TAKE < q.minPhaseSeen) { q.minPhaseSeen = PHASE_TAKE; }
             if (q.seenTake) {
                 macro_error(prog, at, "_sql: take(n) can appear at most once in the chain")
                 return false
@@ -837,6 +967,10 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
     {
         var obCall = match_linq_call(node, "order_by")
         if (obCall != null) {
+            if (q.minPhaseSeen != INT_MAX_PHASE && PHASE_ORDER_BY > q.minPhaseSeen) {
+                return divert_to_inner(node, q, prog, at)
+            }
+            if (PHASE_ORDER_BY < q.minPhaseSeen) { q.minPhaseSeen = PHASE_ORDER_BY; }
             if (q.seenOrderBy) {
                 macro_error(prog, at, "_sql: _order_by() can appear at most once in the chain (use a tuple key for multi-column ordering: `_order_by((_.k1, _.k2))`)")
                 return false
@@ -860,6 +994,10 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
     {
         var odCall = match_linq_call(node, "order_by_descending")
         if (odCall != null) {
+            if (q.minPhaseSeen != INT_MAX_PHASE && PHASE_ORDER_BY > q.minPhaseSeen) {
+                return divert_to_inner(node, q, prog, at)
+            }
+            if (PHASE_ORDER_BY < q.minPhaseSeen) { q.minPhaseSeen = PHASE_ORDER_BY; }
             if (q.seenOrderBy) {
                 macro_error(prog, at, "_sql: _order_by() can appear at most once in the chain (use a tuple key for multi-column ordering)")
                 return false
@@ -883,6 +1021,10 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
     {
         var sCall = match_linq_call(node, "skip")
         if (sCall != null) {
+            if (q.minPhaseSeen != INT_MAX_PHASE && PHASE_SKIP > q.minPhaseSeen) {
+                return divert_to_inner(node, q, prog, at)
+            }
+            if (PHASE_SKIP < q.minPhaseSeen) { q.minPhaseSeen = PHASE_SKIP; }
             if (q.seenSkip) {
                 macro_error(prog, at, "_sql: skip(n) can appear at most once in the chain")
                 return false
@@ -900,6 +1042,8 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
     {
         var sCall = match_linq_call(node, "select")
         if (sCall != null) {
+            // v1: no divert on _select. v2 will divert + thread projected-alias resolution to outer-Q lambdas.
+            if (PHASE_SELECT < q.minPhaseSeen) { q.minPhaseSeen = PHASE_SELECT; }
             if (q.seenSelect) {
                 macro_error(prog, at, "_sql: _select can only appear once in the chain")
                 return false
@@ -935,6 +1079,8 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
     {
         var hCall = match_linq_call(node, "having_")
         if (hCall != null) {
+            // v1: no divert on _having (paired with _group_by below; v2 handles divert when needed).
+            if (PHASE_HAVING < q.minPhaseSeen) { q.minPhaseSeen = PHASE_HAVING; }
             if (hCall.arguments |> length != 2) {
                 macro_error(prog, at, "_sql: _having has unexpected shape; expected having_(prev, predicate)")
                 return false
@@ -979,6 +1125,8 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
     {
         var gbCall = match_linq_call(node, "group_by_lazy")
         if (gbCall != null) {
+            // v1: no divert on _group_by; v2 handles when paired with post-aggregate filter.
+            if (PHASE_GROUP_BY < q.minPhaseSeen) { q.minPhaseSeen = PHASE_GROUP_BY; }
             if (q.seenGroupBy) {
                 macro_error(prog, at, "_sql: _group_by can appear at most once in the chain")
                 return false
@@ -1003,6 +1151,8 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
     {
         var wCall = match_linq_call(node, "where_")
         if (wCall != null) {
+            // _where is broadly commutative with JOIN / GROUP / SELECT in SQL — no divert; just track min phase.
+            if (PHASE_WHERE < q.minPhaseSeen) { q.minPhaseSeen = PHASE_WHERE; }
             var body = peel_lambda_body(wCall.arguments[1])
             if (body == null) {
                 macro_error(prog, at, "_sql: _where predicate lambda has unexpected shape")
@@ -1050,11 +1200,11 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             }
             // SQLite syntax-errors on per-side ORDER BY / LIMIT in compound queries — reject both sides.
             if (q.seenOrderBy) {
-                macro_error(prog, at, "_sql: set-op LHS cannot use `_order_by` (apply to the combined set-op result instead; chunk 5)")
+                macro_error(prog, at, "_sql: set-op LHS cannot use `_order_by` (apply to the combined set-op result instead)")
                 return false
             }
             if (q.limitBindExpr != null || q.offsetBindExpr != null) {
-                macro_error(prog, at, "_sql: set-op LHS cannot use `take(n)` / `skip(n)` (chunk 5)")
+                macro_error(prog, at, "_sql: set-op LHS cannot use `take(n)` / `skip(n)` (apply to the combined set-op result instead)")
                 return false
             }
             // Recurse into RHS in a fresh sub-q; reject set-ops within set-ops.
@@ -1063,7 +1213,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
                 return false
             }
             if (subQ.seenSetOp || subQ.setOpKind != SetOpKind.None) {
-                macro_error(prog, at, "_sql: set-ops cannot themselves contain set-ops (chunk 5)")
+                macro_error(prog, at, "_sql: set-ops cannot themselves contain set-ops")
                 return false
             }
             if (subQ.seenTerminal || subQ.seenToArray) {
@@ -1071,55 +1221,24 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
                 return false
             }
             if (subQ.seenOrderBy) {
-                macro_error(prog, at, "_sql: set-op RHS cannot use `_order_by` (apply to the combined set-op result instead; chunk 5)")
+                macro_error(prog, at, "_sql: set-op RHS cannot use `_order_by` (apply to the combined set-op result instead)")
                 return false
             }
             if (subQ.limitBindExpr != null || subQ.offsetBindExpr != null) {
-                macro_error(prog, at, "_sql: set-op RHS cannot use `take(n)` / `skip(n)` (chunk 5)")
+                macro_error(prog, at, "_sql: set-op RHS cannot use `take(n)` / `skip(n)` (apply to the combined set-op result instead)")
                 return false
             }
             let rhsSql = build_sql_string(subQ)
-            // Flatten both sides into q.bindExprs and clear per-pool sources, so the outer finalizer doesn't re-prepend/append (would double-bind).
-            var folded : array<ExpressionPtr>
-            var foldedCount = 0
-            for (j in q.joins) {
-                foldedCount += length(j.rightOnBindExprs)
+            // Collect RHS binds (in their internal placeholder order) into a separate slot;
+            // collect_query_binds(q) splices them after LHS WHERE/HAVING, before any outer LIMIT/OFFSET.
+            var rhsBinds : array<ExpressionPtr>
+            collect_query_binds(subQ, rhsBinds)
+            var rhsClones : array<ExpressionPtr>
+            rhsClones |> reserve(length(rhsBinds))
+            for (b in rhsBinds) {
+                rhsClones |> push <| clone_expression(b)
             }
-            for (j in subQ.joins) {
-                foldedCount += length(j.rightOnBindExprs)
-            }
-            folded |> reserve(foldedCount + length(q.bindExprs) + length(q.havingBindExprs)
-                            + length(subQ.bindExprs) + length(subQ.havingBindExprs))
-            // LHS: on → where → having
-            for (j in q.joins) {
-                for (b in j.rightOnBindExprs) {
-                    folded |> push(b)
-                }
-            }
-            for (b in q.bindExprs) {
-                folded |> push(b)
-            }
-            for (b in q.havingBindExprs) {
-                folded |> push(b)
-            }
-            // Clear LHS per-pool bind sources (q.joins itself stays for FROM/SELECT emission).
-            for (j in q.joins) {
-                j.rightOnBindExprs |> clear
-            }
-            q.havingBindExprs |> clear
-            // RHS on → where → having (after LHS in `<lhs> UNION <rhs>`).
-            for (j in subQ.joins) {
-                for (b in j.rightOnBindExprs) {
-                    folded |> push <| clone_expression(b)
-                }
-            }
-            for (b in subQ.bindExprs) {
-                folded |> push <| clone_expression(b)
-            }
-            for (b in subQ.havingBindExprs) {
-                folded |> push <| clone_expression(b)
-            }
-            q.bindExprs <- folded
+            q.setOpRhsBinds <- rhsClones
             q.setOpKind = soKind
             q.setOpRhsSql = rhsSql
             q.seenSetOp = true
@@ -2108,7 +2227,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
                     return ""
                 }
                 if (subQ.seenJoin || length(subQ.joins) > 0) {
-                    return pred_fail(q, prog, at, "_sql: subqueries cannot themselves contain joins (chunk 5)")
+                    return pred_fail(q, prog, at, "_sql: subqueries cannot themselves contain joins")
                 }
                 if (subQ.seenGroupBy || !empty(subQ.havingSql) || subQ.seenOrderBy
                         || subQ.distinctFlag || subQ.limitBindExpr != null
@@ -2212,19 +2331,19 @@ def private analyze_subquery(var subqExpr : ExpressionPtr; var binds : array<Exp
         return ""
     }
     if (subQ.seenJoin || length(subQ.joins) > 0) {
-        macro_error(prog, at, "_sql: subqueries cannot themselves contain joins (chunk 5)")
+        macro_error(prog, at, "_sql: subqueries cannot themselves contain joins")
         return ""
     }
     if (subQ.seenGroupBy || !empty(subQ.havingSql)) {
-        macro_error(prog, at, "_sql: subqueries cannot use `_group_by` / `_having` (chunk 5)")
+        macro_error(prog, at, "_sql: subqueries cannot use `_group_by` / `_having`")
         return ""
     }
     if (subQ.seenOrderBy || subQ.distinctFlag) {
-        macro_error(prog, at, "_sql: subqueries cannot use `_order_by` / `distinct()` (chunk 5)")
+        macro_error(prog, at, "_sql: subqueries cannot use `_order_by` / `distinct()`")
         return ""
     }
     if (subQ.limitBindExpr != null || subQ.offsetBindExpr != null) {
-        macro_error(prog, at, "_sql: subqueries cannot use `take(n)` / `skip(n)` (chunk 5)")
+        macro_error(prog, at, "_sql: subqueries cannot use `take(n)` / `skip(n)`")
         return ""
     }
     if (subQ.seenTerminal || subQ.seenToArray) {
@@ -2253,19 +2372,19 @@ def private analyze_subquery_with_pred(var subqExpr : ExpressionPtr; var predLam
         return ""
     }
     if (subQ.seenJoin || length(subQ.joins) > 0) {
-        macro_error(prog, at, "_sql: subqueries cannot themselves contain joins (chunk 5)")
+        macro_error(prog, at, "_sql: subqueries cannot themselves contain joins")
         return ""
     }
     if (subQ.seenGroupBy || !empty(subQ.havingSql)) {
-        macro_error(prog, at, "_sql: subqueries cannot use `_group_by` / `_having` (chunk 5)")
+        macro_error(prog, at, "_sql: subqueries cannot use `_group_by` / `_having`")
         return ""
     }
     if (subQ.seenOrderBy || subQ.distinctFlag) {
-        macro_error(prog, at, "_sql: subqueries cannot use `_order_by` / `distinct()` (chunk 5)")
+        macro_error(prog, at, "_sql: subqueries cannot use `_order_by` / `distinct()`")
         return ""
     }
     if (subQ.limitBindExpr != null || subQ.offsetBindExpr != null) {
-        macro_error(prog, at, "_sql: subqueries cannot use `take(n)` / `skip(n)` (chunk 5)")
+        macro_error(prog, at, "_sql: subqueries cannot use `take(n)` / `skip(n)`")
         return ""
     }
     if (subQ.seenTerminal || subQ.seenToArray) {
@@ -2719,6 +2838,7 @@ def private build_sql_select(var q : SqlQuery&) : string {
             }
         }
         // FROM clause: alias the root table only when joins are present (single-source keeps unaliased `FROM "Tbl"`).
+        // Multi-Q lowering: when innerSql is set, FROM renders as `(<innerSql>) AS t0` instead of base-table.
         if (q.seenJoin) {
             w |> write(" FROM \"")
             w |> write(q.tableName)
@@ -2752,6 +2872,12 @@ def private build_sql_select(var q : SqlQuery&) : string {
                     w |> write(")")
                 }
             }
+        } elif (!empty(q.innerSql)) {
+            // Outer Q wrapping a phase-conflict-pushed subquery. Inner emits default-row projection
+            // (column names visible to outer's `_.<field>` resolution against q.rootType).
+            w |> write(" FROM (")
+            w |> write(q.innerSql)
+            w |> write(") AS \"t0\"")
         } else {
             w |> write(" FROM \"")
             w |> write(q.tableName)
@@ -2886,35 +3012,13 @@ class private SqlCreateViewMacro : AstCallMacro {
             macro_error(prog, call.at, "_create_view: `_order_by(<runtime string>)` not supported — the runtime column name would be baked in at CREATE VIEW time. Use a compile-time `_.Field` ordering inside the view, or build a chain with `_sql(...)` outside.")
             return null
         }
-        // Collect binds in placeholder order (joins ON → WHERE → HAVING → LIMIT → OFFSET).
-        // Each bind expression goes through `_::to_sql_literal(...)` at runtime — the
-        // value is evaluated once when CREATE VIEW DDL executes and inlined into the
-        // view body text stored in sqlite_schema.
-        var n_join_binds = 0
-        for (j in q.joins) {
-            n_join_binds += length(j.rightOnBindExprs)
-        }
-        let total_binds = (n_join_binds + length(q.bindExprs) + length(q.havingBindExprs) +
-                           (q.limitBindExpr != null ? 1 : 0) + (q.offsetBindExpr != null ? 1 : 0))
+        // Collect binds in placeholder order via collect_query_binds (handles inner-Q
+        // subqueries + set-op RHS; for views the chain is bounded but we use the same
+        // helper for consistency). Each bind expression goes through `_::to_sql_literal(...)`
+        // at runtime — value is evaluated once when CREATE VIEW DDL executes and inlined
+        // into the view body text stored in sqlite_schema.
         var ordered_binds : array<ExpressionPtr>
-        ordered_binds |> reserve(total_binds)
-        for (j in q.joins) {
-            for (b in j.rightOnBindExprs) {
-                ordered_binds |> push(b)
-            }
-        }
-        for (b in q.bindExprs) {
-            ordered_binds |> push(b)
-        }
-        for (b in q.havingBindExprs) {
-            ordered_binds |> push(b)
-        }
-        if (q.limitBindExpr != null) {
-            ordered_binds |> push(q.limitBindExpr)
-        }
-        if (q.offsetBindExpr != null) {
-            ordered_binds |> push(q.offsetBindExpr)
-        }
+        collect_query_binds(q, ordered_binds)
         // Validate projection column count vs V's fields.
         let nFields = length(viewT.structType.fields)
         var nProj = 0
@@ -3249,7 +3353,7 @@ def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; is
     // take(n)/skip(n) before an aggregate is degenerate in SQL — aggregate collapses to one row, LIMIT/OFFSET no-op; reject loudly.
     if (q.proj == ProjectionShape.Aggregate
             && (q.limitBindExpr != null || q.offsetBindExpr != null)) {
-        macro_error(prog, call.at, "_sql: take(n)/skip(n) before an aggregate is not translatable — `LIMIT`/`OFFSET` after an aggregate has no effect (aggregate collapses to one row); use `_where(...)` for pre-aggregate filtering, or wait for subquery support in chunk 5+")
+        macro_error(prog, call.at, "_sql: take(n)/skip(n) before an aggregate is not translatable — `LIMIT`/`OFFSET` after an aggregate has no effect (aggregate collapses to one row); use `_where(...)` for pre-aggregate filtering")
         return null
     }
     // distinct() upstream of an aggregate is a no-op in SQL — meaningful form is COUNT(DISTINCT col), not yet implemented.
@@ -3257,45 +3361,14 @@ def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; is
         macro_error(prog, call.at, "_sql: distinct() before an aggregate is not translatable — `SELECT DISTINCT` over a single-row aggregate result is always a no-op; the meaningful form is `COUNT(DISTINCT col)` etc. (aggregate-distinct), which is not yet implemented")
         return null
     }
-    // Bind order: per-join ON → WHERE → HAVING → LIMIT → OFFSET. Splice ON in front of q.bindExprs, then append the rest.
-    var joinOnCount = 0
-    for (j in q.joins) {
-        joinOnCount += length(j.rightOnBindExprs)
-    }
-    var joinOnBinds : array<ExpressionPtr>
-    joinOnBinds |> reserve(joinOnCount)
-    for (j in q.joins) {
-        for (b in j.rightOnBindExprs) {
-            joinOnBinds |> push(b)
-        }
-    }
-    if (length(joinOnBinds) > 0) {
-        var ordered : array<ExpressionPtr>
-        ordered |> reserve(length(joinOnBinds) + length(q.bindExprs))
-        for (b in joinOnBinds) {
-            ordered |> push(b)
-        }
-        for (b in q.bindExprs) {
-            ordered |> push(b)
-        }
-        q.bindExprs <- ordered
-    }
-    q.bindExprs |> reserve(length(q.bindExprs) + length(q.havingBindExprs) + 2)
-    for (be in q.havingBindExprs) {
-        q.bindExprs |> push(be)
-    }
-    let forced_one_row = ((q.matr == Materializer.One || q.matr == Materializer.OneOpt)
-        && q.proj != ProjectionShape.Aggregate)
-    if (!forced_one_row && q.limitBindExpr != null) {
-        q.bindExprs |> push(q.limitBindExpr)
-    }
-    if (!forced_one_row && q.offsetBindExpr != null) {
-        q.bindExprs |> push(q.offsetBindExpr)
-    }
+    // Bind order: inner-Q (FROM subquery) → per-join ON → WHERE → HAVING → set-op-RHS → LIMIT → OFFSET.
+    // Centralized in collect_query_binds; recurses into inner subqueries for multi-Q lowering.
+    var allBinds : array<ExpressionPtr>
+    collect_query_binds(q, allBinds)
     let sql = build_sql_string(q)
-    // Convert (sqlString, q.bindExprs) → ExprStringBuilder + binds; const-fold keeps AOT byte-identical to the legacy $v(sql) path.
+    // Convert (sqlString, allBinds) → ExprStringBuilder + binds; const-fold keeps AOT byte-identical to the legacy $v(sql) path.
     var frags : array<SqlFrag>
-    sql_to_frags_ex(sql, q.bindExprs, q.orderByInlineExprs, frags)
+    sql_to_frags_ex(sql, allBinds, q.orderByInlineExprs, frags)
     var sqlExpr : ExpressionPtr
     var bindExprs : array<ExpressionPtr>
     fold_to_builder(frags, call.at, sqlExpr, bindExprs)
@@ -3364,42 +3437,12 @@ def private emit_each_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro
         macro_error(prog, call.at, "_each_sql: chain ends in `_first()` / `_first_opt()` — those terminals materialize a single row. Use `_sql(...)` for the same chain, or drop the terminal to iterate.")
         return null
     }
-    // Same bind ordering as emit_sql_macro_body. take/skip binds OK here (lazy stream).
-    var joinOnCount = 0
-    for (j in q.joins) {
-        joinOnCount += length(j.rightOnBindExprs)
-    }
-    var joinOnBinds : array<ExpressionPtr>
-    joinOnBinds |> reserve(joinOnCount)
-    for (j in q.joins) {
-        for (b in j.rightOnBindExprs) {
-            joinOnBinds |> push(b)
-        }
-    }
-    if (length(joinOnBinds) > 0) {
-        var ordered : array<ExpressionPtr>
-        ordered |> reserve(length(joinOnBinds) + length(q.bindExprs))
-        for (b in joinOnBinds) {
-            ordered |> push(b)
-        }
-        for (b in q.bindExprs) {
-            ordered |> push(b)
-        }
-        q.bindExprs <- ordered
-    }
-    q.bindExprs |> reserve(length(q.bindExprs) + length(q.havingBindExprs) + 2)
-    for (be in q.havingBindExprs) {
-        q.bindExprs |> push(be)
-    }
-    if (q.limitBindExpr != null) {
-        q.bindExprs |> push(q.limitBindExpr)
-    }
-    if (q.offsetBindExpr != null) {
-        q.bindExprs |> push(q.offsetBindExpr)
-    }
+    // Same bind ordering as emit_sql_macro_body via collect_query_binds. take/skip binds OK here (lazy stream).
+    var allBinds : array<ExpressionPtr>
+    collect_query_binds(q, allBinds)
     let sql = build_sql_string(q)
     var frags : array<SqlFrag>
-    sql_to_frags_ex(sql, q.bindExprs, q.orderByInlineExprs, frags)
+    sql_to_frags_ex(sql, allBinds, q.orderByInlineExprs, frags)
     var sqlExpr : ExpressionPtr
     var bindExprs : array<ExpressionPtr>
     fold_to_builder(frags, call.at, sqlExpr, bindExprs)

--- a/tests/dasSQLITE/failed_parity_check_14_order_after_group.das
+++ b/tests/dasSQLITE/failed_parity_check_14_order_after_group.das
@@ -1,0 +1,48 @@
+// Negative-coverage parity for tutorial 14 — `_having |> _order_by`
+// after `_group_by(_.City)` over a struct (User) compiles in `_sql(...)`
+// but fails to compile in plain linq with a deep typer error pointing
+// at `daslib/builtin.das:999`, far from the user's chain.
+//
+// Root cause: linq's `order_by` calls `clone_to_move` on its input,
+// which requires cloneable elements. Post-`_group_by + _having`, the
+// element is `tuple<key, array<User>>`; the nested `array<User>` is not
+// generically cloneable, so `_::clone(tuple<...>, ...)` resolution fails.
+//
+// The bare `_group_by |> _order_by |> _select(...)` chain (without
+// `_having`) compiles — linq's expansion must follow a different path
+// when there's no post-aggregate filter. The `_having` peeling forces
+// a separate sort step that needs cloneable elements.
+//
+// See API_CHECKED.md F3 for the resolution direction.
+expect 30304:1
+
+options gen2
+
+require daslib/linq_boost
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name   : string
+    City   : string
+    Age    : int
+    Salary : int
+}
+
+[export]
+def main {
+    var arr : array<User>
+    arr |> emplace(User(Id = 1, Name = "A", City = "NYC", Age = 30, Salary = 100))
+
+    // Mode 3: chain with `_having` + `_order_by` after `_group_by`. The
+    // `clone(tuple<string, array<User>>, ...)` resolution fails inside
+    // linq's `order_by`. The same shape inside `_sql(...)` lowers to
+    // `GROUP BY ... HAVING ... ORDER BY ...` and runs.
+    let m3 <- (arr |> _group_by(_.City)
+                   |> _having(_._1 |> length >= 1)
+                   |> _order_by(_._0)
+                   |> _select((City = _._0, N = _._1 |> length)))
+}

--- a/tests/dasSQLITE/failed_sql_macro.das
+++ b/tests/dasSQLITE/failed_sql_macro.das
@@ -6,7 +6,7 @@ options gen2
 // some malformed chains additionally cascade real type errors before the
 // analyzer ever runs — e.g. `_select(_.Name) |> _select(_.Price)` is a
 // genuine type bug (string has no `Price` field). Those cascades are expected.
-expect 40104:21, 30304:1, 30503:2
+expect 40104:20, 30304:1, 30503:2
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -64,12 +64,9 @@ def main() {
     // 11. _select after _group_by must be a NAMED tuple — bare scalar rejected
     let bad11 <- _sql(db |> select_from(type<Car>) |> _group_by(_.Name) |> _select(_._0))
 
-    // 12. take(n) before an aggregate is degenerate in SQL — `LIMIT` after
-    //     an aggregate is a no-op (aggregate already returns one row).
-    //     User almost certainly wants the subquery form
-    //     `SELECT SUM(c) FROM (SELECT p AS c FROM Cars LIMIT n)`, which lands
-    //     with joins/subqueries in chunk 5+. Reject loud now.
-    let bad12 <- _sql(db |> select_from(type<Car>) |> take(2) |> _select(_.Price) |> sum())
+    // (bad12 removed: `take(2) |> _select(_.Price) |> sum()` now lowers
+    // correctly via multi-Q to `SELECT SUM("Price") FROM (SELECT "Price" FROM "Cars" LIMIT ?) AS "t0"`.
+    // Coverage moved to test_33_take_skip.das as `test_take_then_select_then_aggregate_runtime`.)
 
     // 13. distinct() before an aggregate is degenerate — `SELECT DISTINCT
     //     SUM(...)` / `SELECT DISTINCT COUNT(*)` dedupes a single-row result.

--- a/tests/dasSQLITE/parity_check_04_select_all.das
+++ b/tests/dasSQLITE/parity_check_04_select_all.das
@@ -1,0 +1,101 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 04 — `_sql` chain ≡ no-`_sql` chain (over the
+// same SQL source) ≡ same chain over a plain `array<T>`. Three modes
+// must produce identical results for every chain shape the tutorial uses.
+//
+// See modules/dasSQLITE/API_CHECKED.md for the equivalence-harness plan.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "BMW",   Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Audi",  Price = 200))
+    arr |> emplace(Car(Id = 3, Name = "Tesla", Price = 300))
+    arr |> emplace(Car(Id = 4, Name = "Lada",  Price = 50))
+    arr |> emplace(Car(Id = 5, Name = "Lambo", Price = 999))
+    return <- arr
+}
+
+def cars_equal(a : array<Car>; b : array<Car>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i].Id != b[i].Id || a[i].Name != b[i].Name || a[i].Price != b[i].Price) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_select_all(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>))
+        let m2 <- (db |> select_from(type<Car>))
+
+        t |> success(cars_equal(m1, m2),  "select_all: Mode 1 (_sql) ≡ Mode 2 (no _sql, SQL source)")
+        t |> success(cars_equal(m2, arr), "select_all: Mode 2 (SQL source) ≡ Mode 3 (plain array)")
+    }
+}
+
+[test]
+def parity_where_filter(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+        let threshold = 200
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _where(_.Price > threshold))
+        let m2 <- (db |> select_from(type<Car>) |> _where(_.Price > threshold))
+        let m3 <- (arr |> _where(_.Price > threshold))
+
+        t |> success(cars_equal(m1, m2), "where: Mode 1 (_sql) ≡ Mode 2 (no _sql, SQL source)")
+        t |> success(cars_equal(m2, m3), "where: Mode 2 (SQL source) ≡ Mode 3 (plain array)")
+    }
+}
+
+[test]
+def parity_project_name(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _select(_.Name))
+        let m2 <- (db |> select_from(type<Car>) |> _select(_.Name))
+        let m3 <- (arr |> _select(_.Name))
+
+        t |> equal(length(m1), length(m2), "project: Mode 1 length ≡ Mode 2 length")
+        t |> equal(length(m2), length(m3), "project: Mode 2 length ≡ Mode 3 length")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i], m2[i], "project[{i}]: Mode 1 ≡ Mode 2")
+            t |> equal(m2[i], m3[i], "project[{i}]: Mode 2 ≡ Mode 3")
+        }
+    }
+}

--- a/tests/dasSQLITE/parity_check_05_parametrized.das
+++ b/tests/dasSQLITE/parity_check_05_parametrized.das
@@ -1,0 +1,93 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 05 — `_where(...) |> _first()` and
+// `_where(...) |> _first_opt()`. Chain semantics across the three modes.
+//
+// The raw-SQL escape hatch (`query_one(sql, type<T>, args...)`) is NOT
+// covered here — it is a non-chain code path with no Mode-3 analog.
+//
+// See modules/dasSQLITE/API_CHECKED.md for the equivalence-harness plan.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "BMW",   Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Audi",  Price = 200))
+    arr |> emplace(Car(Id = 3, Name = "Tesla", Price = 300))
+    return <- arr
+}
+
+def car_eq(a : Car; b : Car) : bool {
+    return a.Id == b.Id && a.Name == b.Name && a.Price == b.Price
+}
+
+[test]
+def parity_first_match(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+        let target = 3
+
+        let m1 = _sql(db |> select_from(type<Car>) |> _where(_.Id == target) |> _first())
+        let m2 = db |> select_from(type<Car>) |> _where(_.Id == target) |> _first()
+        let m3 = arr |> _where(_.Id == target) |> _first()
+
+        t |> success(car_eq(m1, m2), "first: Mode 1 (_sql) ≡ Mode 2 (no _sql, SQL source)")
+        t |> success(car_eq(m2, m3), "first: Mode 2 (SQL source) ≡ Mode 3 (plain array)")
+    }
+}
+
+[test]
+def parity_first_opt_miss(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 = _sql(db |> select_from(type<Car>) |> _where(_.Id == 999) |> _first_opt())
+        let m2 = db |> select_from(type<Car>) |> _where(_.Id == 999) |> _first_opt()
+        let m3 = arr |> _where(_.Id == 999) |> _first_opt()
+
+        t |> success(m1 |> is_none, "first_opt(miss): Mode 1 produces none")
+        t |> success(m2 |> is_none, "first_opt(miss): Mode 2 produces none")
+        t |> success(m3 |> is_none, "first_opt(miss): Mode 3 produces none")
+    }
+}
+
+[test]
+def parity_first_opt_hit(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+        let target = 2
+
+        let m1 = _sql(db |> select_from(type<Car>) |> _where(_.Id == target) |> _first_opt())
+        let m2 = db |> select_from(type<Car>) |> _where(_.Id == target) |> _first_opt()
+        let m3 = arr |> _where(_.Id == target) |> _first_opt()
+
+        t |> success(m1 |> is_some, "first_opt(hit): Mode 1 produces some")
+        t |> success(m2 |> is_some, "first_opt(hit): Mode 2 produces some")
+        t |> success(m3 |> is_some, "first_opt(hit): Mode 3 produces some")
+        t |> success(car_eq(m1 |> unwrap, m2 |> unwrap), "first_opt(hit): Mode 1 ≡ Mode 2 value")
+        t |> success(car_eq(m2 |> unwrap, m3 |> unwrap), "first_opt(hit): Mode 2 ≡ Mode 3 value")
+    }
+}

--- a/tests/dasSQLITE/parity_check_06_error_handling.das
+++ b/tests/dasSQLITE/parity_check_06_error_handling.das
@@ -1,0 +1,114 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require daslib/option
+require daslib/result
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 06 — `_try_sql(chain)` is `_sql(chain)` wrapped
+// in `Result<T, string>` for SQL-side prepare/step failures. The INNER chain
+// (`_first()`, `_first_opt()`) is the same linq we verified in tut 05; the
+// new piece is that `_try_sql(...).unwrap()` on the ok path must agree with
+// the Mode-2 / Mode-3 results.
+//
+// On the err path (e.g. `_first()` on an empty table), Modes 2 and 3 PANIC —
+// no parity assertion is possible there; the file only confirms Mode 1
+// returns Err as a sanity check.
+//
+// Raw-SQL helpers (`try_open_sqlite`, `try_insert`, `query_scalar_opt`,
+// `try_exec`) are out of scope per API_CHECKED.md — non-chain code paths.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "alice"))
+    db |> insert(User(Id = 2, Name = "bob"))
+}
+
+def fixture_array() : array<User> {
+    var arr : array<User>
+    arr |> emplace(User(Id = 1, Name = "alice"))
+    arr |> emplace(User(Id = 2, Name = "bob"))
+    return <- arr
+}
+
+def user_eq(a : User; b : User) : bool {
+    return a.Id == b.Id && a.Name == b.Name
+}
+
+[test]
+def parity_try_sql_first_ok(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        // Mode 1: _try_sql(...) returns Result<User, string>; ok-path here.
+        let r1 = _try_sql(db |> select_from(type<User>) |> _first())
+        // Mode 2 / Mode 3: same inner chain, no error wrapping.
+        let m2 = db |> select_from(type<User>) |> _first()
+        let m3 = arr |> _first()
+
+        t |> success(r1 |> is_ok, "try_sql(_first): ok on populated table")
+        t |> success(user_eq(r1 |> unwrap, m2), "try_sql(_first).unwrap() ≡ Mode 2")
+        t |> success(user_eq(m2, m3),            "Mode 2 ≡ Mode 3")
+    }
+}
+
+[test]
+def parity_try_sql_first_opt_some(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        // Mode 1: _try_sql(... |> _first_opt()) → Result<Option<User>, string>.
+        let r1 = _try_sql(db |> select_from(type<User>) |> _first_opt())
+        let m2 = db |> select_from(type<User>) |> _first_opt()
+        let m3 = arr |> _first_opt()
+
+        t |> success(r1 |> is_ok, "try_sql(_first_opt): ok on populated table")
+        let o1 = r1 |> unwrap
+        t |> success(o1 |> is_some && m2 |> is_some && m3 |> is_some,
+            "all three: some on populated table")
+        t |> success(user_eq(o1 |> unwrap, m2 |> unwrap), "try_sql(_first_opt).unwrap().unwrap() ≡ Mode 2")
+        t |> success(user_eq(m2 |> unwrap, m3 |> unwrap), "Mode 2 ≡ Mode 3")
+    }
+}
+
+[test]
+def parity_try_sql_first_opt_none(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        // Empty table — _first_opt returns none across all three modes.
+        db |> create_table(type<User>)
+        var arr : array<User>
+
+        let r1 = _try_sql(db |> select_from(type<User>) |> _first_opt())
+        let m2 = db |> select_from(type<User>) |> _first_opt()
+        let m3 = arr |> _first_opt()
+
+        t |> success(r1 |> is_ok, "try_sql(_first_opt): ok on empty (0 rows is not an error)")
+        t |> success((r1 |> unwrap) |> is_none, "Mode 1: none on empty")
+        t |> success(m2 |> is_none,             "Mode 2: none on empty")
+        t |> success(m3 |> is_none,             "Mode 3: none on empty")
+    }
+}
+
+[test]
+def sanity_try_sql_first_empty_errs(t : T?) {
+    // Sanity check (Mode 1 only): _try_sql(... |> _first()) on empty table
+    // returns Err. Modes 2 and 3 PANIC on empty `_first()` — no parity
+    // assertion is possible (a panic would terminate the test process).
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<User>)
+        let r1 = _try_sql(db |> select_from(type<User>) |> _first())
+        t |> success(r1 |> is_err, "try_sql(_first) on empty table → Err (Mode 1 only; M2/M3 would panic)")
+    }
+}

--- a/tests/dasSQLITE/parity_check_07_anatomy.das
+++ b/tests/dasSQLITE/parity_check_07_anatomy.das
@@ -1,0 +1,115 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require daslib/strings_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 07 — `_where` mechanics introduced beyond
+// tut 04: symmetric column-vs-bind sides (`_.Price > cutoff` ≡ `cutoff < _.Price`),
+// chained `_where` (composes with AND), and the `starts_with` string
+// predicate inside `_where`.
+//
+// `_sql_text` (debug emitter) and `query_scalar` (raw SQL) are out of scope
+// per API_CHECKED.md.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "BMW",   Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Audi",  Price = 200))
+    arr |> emplace(Car(Id = 3, Name = "Tesla", Price = 300))
+    return <- arr
+}
+
+def cars_equal(a : array<Car>; b : array<Car>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i].Id != b[i].Id || a[i].Name != b[i].Name || a[i].Price != b[i].Price) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_where_symmetric(t : T?) {
+    // The translation should be order-independent: `_.Price > cutoff` and
+    // `cutoff < _.Price` must produce the same row set across all three modes.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+        let cutoff = 150
+
+        let m1_a <- _sql(db |> select_from(type<Car>) |> _where(_.Price > cutoff))
+        let m1_b <- _sql(db |> select_from(type<Car>) |> _where(cutoff < _.Price))
+        let m2_a <- (db |> select_from(type<Car>) |> _where(_.Price > cutoff))
+        let m2_b <- (db |> select_from(type<Car>) |> _where(cutoff < _.Price))
+        let m3_a <- (arr |> _where(_.Price > cutoff))
+        let m3_b <- (arr |> _where(cutoff < _.Price))
+
+        t |> success(cars_equal(m1_a, m1_b), "Mode 1: column-left ≡ column-right")
+        t |> success(cars_equal(m2_a, m2_b), "Mode 2: column-left ≡ column-right")
+        t |> success(cars_equal(m3_a, m3_b), "Mode 3: column-left ≡ column-right")
+        t |> success(cars_equal(m1_a, m2_a), "Mode 1 ≡ Mode 2 (column-left form)")
+        t |> success(cars_equal(m2_a, m3_a), "Mode 2 ≡ Mode 3 (column-left form)")
+    }
+}
+
+[test]
+def parity_where_chained_and(t : T?) {
+    // Two `_where` calls compose with AND in `_sql` (and trivially in linq —
+    // each filter narrows the array further).
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>)
+                         |> _where(_.Price > 100)
+                         |> _where(_.Name |> starts_with("T")))
+        let m2 <- (db |> select_from(type<Car>)
+                     |> _where(_.Price > 100)
+                     |> _where(_.Name |> starts_with("T")))
+        let m3 <- (arr |> _where(_.Price > 100)
+                       |> _where(_.Name |> starts_with("T")))
+
+        t |> success(cars_equal(m1, m2), "chained-where: Mode 1 ≡ Mode 2")
+        t |> success(cars_equal(m2, m3), "chained-where: Mode 2 ≡ Mode 3")
+    }
+}
+
+[test]
+def parity_where_starts_with(t : T?) {
+    // `starts_with` as a string predicate inside `_where`. SQL emits
+    // `LIKE ? ESCAPE '\'` with the appropriate pattern; the in-memory linq
+    // path calls `strings_boost::starts_with`. Results must agree.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _where(_.Name |> starts_with("T")))
+        let m2 <- (db |> select_from(type<Car>) |> _where(_.Name |> starts_with("T")))
+        let m3 <- (arr |> _where(_.Name |> starts_with("T")))
+
+        t |> success(cars_equal(m1, m2), "starts_with: Mode 1 ≡ Mode 2")
+        t |> success(cars_equal(m2, m3), "starts_with: Mode 2 ≡ Mode 3")
+    }
+}

--- a/tests/dasSQLITE/parity_check_08_where.das
+++ b/tests/dasSQLITE/parity_check_08_where.das
@@ -1,0 +1,154 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require daslib/strings_boost
+require math
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 08 — the full `_where` predicate surface.
+// Each shape recognized by the `_sql` predicate analyzer must produce
+// the same row set in Mode 1, Mode 2, and Mode 3.
+//
+// Shapes covered (NEW vs tut 04/05/07):
+//   - logic op `||` mixed with string predicate
+//   - `ends_with(s)`
+//   - `contains(s)`
+//   - case folding (`to_lower() == ...`)
+//   - free-function `length(_.Field)`
+//   - numeric `abs(_.Field)`
+//
+// `_sql_text` (debug emitter) is out of scope per API_CHECKED.md.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "Ford",        Price = 100))
+    db |> insert(Car(Id = 2, Name = "Ferrari",     Price = 9999))
+    db |> insert(Car(Id = 3, Name = "Honda",       Price = 200))
+    db |> insert(Car(Id = 4, Name = "Lada",        Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lamborghini", Price = 88888))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "Ford",        Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Ferrari",     Price = 9999))
+    arr |> emplace(Car(Id = 3, Name = "Honda",       Price = 200))
+    arr |> emplace(Car(Id = 4, Name = "Lada",        Price = 50))
+    arr |> emplace(Car(Id = 5, Name = "Lamborghini", Price = 88888))
+    return <- arr
+}
+
+def cars_equal(a : array<Car>; b : array<Car>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i].Id != b[i].Id || a[i].Name != b[i].Name || a[i].Price != b[i].Price) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_where_or_with_string(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>)
+                         |> _where(_.Price < 100 || (_.Name |> starts_with("F"))))
+        let m2 <- (db |> select_from(type<Car>)
+                     |> _where(_.Price < 100 || (_.Name |> starts_with("F"))))
+        let m3 <- (arr |> _where(_.Price < 100 || (_.Name |> starts_with("F"))))
+
+        t |> success(cars_equal(m1, m2), "OR + starts_with: Mode 1 ≡ Mode 2")
+        t |> success(cars_equal(m2, m3), "OR + starts_with: Mode 2 ≡ Mode 3")
+    }
+}
+
+[test]
+def parity_where_ends_with(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _where(_.Name |> ends_with("da")))
+        let m2 <- (db |> select_from(type<Car>) |> _where(_.Name |> ends_with("da")))
+        let m3 <- (arr |> _where(_.Name |> ends_with("da")))
+
+        t |> success(cars_equal(m1, m2), "ends_with: Mode 1 ≡ Mode 2")
+        t |> success(cars_equal(m2, m3), "ends_with: Mode 2 ≡ Mode 3")
+    }
+}
+
+[test]
+def parity_where_contains(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _where(_.Name |> contains("o")))
+        let m2 <- (db |> select_from(type<Car>) |> _where(_.Name |> contains("o")))
+        let m3 <- (arr |> _where(_.Name |> contains("o")))
+
+        t |> success(cars_equal(m1, m2), "contains: Mode 1 ≡ Mode 2")
+        t |> success(cars_equal(m2, m3), "contains: Mode 2 ≡ Mode 3")
+    }
+}
+
+[test]
+def parity_where_to_lower_eq(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _where(_.Name |> to_lower() == "ford"))
+        let m2 <- (db |> select_from(type<Car>) |> _where(_.Name |> to_lower() == "ford"))
+        let m3 <- (arr |> _where(_.Name |> to_lower() == "ford"))
+
+        t |> success(cars_equal(m1, m2), "to_lower==: Mode 1 ≡ Mode 2")
+        t |> success(cars_equal(m2, m3), "to_lower==: Mode 2 ≡ Mode 3")
+    }
+}
+
+[test]
+def parity_where_string_length(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _where(length(_.Name) > 5))
+        let m2 <- (db |> select_from(type<Car>) |> _where(length(_.Name) > 5))
+        let m3 <- (arr |> _where(length(_.Name) > 5))
+
+        t |> success(cars_equal(m1, m2), "length(string): Mode 1 ≡ Mode 2")
+        t |> success(cars_equal(m2, m3), "length(string): Mode 2 ≡ Mode 3")
+    }
+}
+
+[test]
+def parity_where_abs(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _where((_.Price |> abs()) > 5000))
+        let m2 <- (db |> select_from(type<Car>) |> _where((_.Price |> abs()) > 5000))
+        let m3 <- (arr |> _where((_.Price |> abs()) > 5000))
+
+        t |> success(cars_equal(m1, m2), "abs(int): Mode 1 ≡ Mode 2")
+        t |> success(cars_equal(m2, m3), "abs(int): Mode 2 ≡ Mode 3")
+    }
+}

--- a/tests/dasSQLITE/parity_check_09_select.das
+++ b/tests/dasSQLITE/parity_check_09_select.das
@@ -1,0 +1,108 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 09 — `_select` projections.
+//
+// Default (full row) and single-column `_select(_.Field)` were covered in
+// tut 04. New here:
+//   - named-tuple projection `_select((Name = _.Name, Price = _.Price))`
+//   - renaming via named tuple
+//   - named-tuple + terminal: `_select((...)) |> _first()`
+//
+// `_sql_text` is out of scope per API_CHECKED.md.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "BMW",   Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Audi",  Price = 200))
+    arr |> emplace(Car(Id = 3, Name = "Tesla", Price = 300))
+    return <- arr
+}
+
+[test]
+def parity_select_named_tuple(t : T?) {
+    // Named-tuple projection: result element is tuple<Name:string;Price:int>
+    // in all three modes; recordNames preserved so .Name / .Price access works.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _select((Name = _.Name, Price = _.Price)))
+        let m2 <- (db |> select_from(type<Car>) |> _select((Name = _.Name, Price = _.Price)))
+        let m3 <- (arr |> _select((Name = _.Name, Price = _.Price)))
+
+        t |> equal(length(m1), length(m2), "named-tuple length: M1 ≡ M2")
+        t |> equal(length(m2), length(m3), "named-tuple length: M2 ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].Name,  m2[i].Name,  "row[{i}].Name: M1 ≡ M2")
+            t |> equal(m1[i].Price, m2[i].Price, "row[{i}].Price: M1 ≡ M2")
+            t |> equal(m2[i].Name,  m3[i].Name,  "row[{i}].Name: M2 ≡ M3")
+            t |> equal(m2[i].Price, m3[i].Price, "row[{i}].Price: M2 ≡ M3")
+        }
+    }
+}
+
+[test]
+def parity_select_renamed(t : T?) {
+    // Renaming: result fields differ from source columns. The tuple shape
+    // (Identifier:int; Label:string) must agree across all three modes.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _select((Identifier = _.Id, Label = _.Name)))
+        let m2 <- (db |> select_from(type<Car>) |> _select((Identifier = _.Id, Label = _.Name)))
+        let m3 <- (arr |> _select((Identifier = _.Id, Label = _.Name)))
+
+        t |> equal(length(m1), length(m2), "renamed length: M1 ≡ M2")
+        t |> equal(length(m2), length(m3), "renamed length: M2 ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].Identifier, m2[i].Identifier, "row[{i}].Identifier: M1 ≡ M2")
+            t |> equal(m1[i].Label,      m2[i].Label,      "row[{i}].Label: M1 ≡ M2")
+            t |> equal(m2[i].Identifier, m3[i].Identifier, "row[{i}].Identifier: M2 ≡ M3")
+            t |> equal(m2[i].Label,      m3[i].Label,      "row[{i}].Label: M2 ≡ M3")
+        }
+    }
+}
+
+[test]
+def parity_select_named_tuple_first(t : T?) {
+    // Named-tuple projection + `_first()` terminal: result is the tuple itself.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 = _sql(db |> select_from(type<Car>)
+                        |> _select((Name = _.Name, Price = _.Price))
+                        |> _first())
+        let m2 = (db |> select_from(type<Car>)
+                    |> _select((Name = _.Name, Price = _.Price))
+                    |> _first())
+        let m3 = arr |> _select((Name = _.Name, Price = _.Price)) |> _first()
+
+        t |> equal(m1.Name,  m2.Name,  "head.Name: M1 ≡ M2")
+        t |> equal(m1.Price, m2.Price, "head.Price: M1 ≡ M2")
+        t |> equal(m2.Name,  m3.Name,  "head.Name: M2 ≡ M3")
+        t |> equal(m2.Price, m3.Price, "head.Price: M2 ≡ M3")
+    }
+}

--- a/tests/dasSQLITE/parity_check_10_order_by.das
+++ b/tests/dasSQLITE/parity_check_10_order_by.das
@@ -1,0 +1,161 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 10 — `_order_by` and `_order_by_descending`.
+//
+// Shapes:
+//   - `_order_by(_.Price)`            → ORDER BY single column ASC
+//   - `_order_by_descending(_.Price)` → DESC variant
+//   - `_order_by((_.Price, _.Name))`  → multi-column tuple key (tie-break)
+//   - composed: `_where |> _order_by |> take`
+//
+// Note: the tutorial fixture has Price ties (BMW=100, Tesla=100). For the
+// single-column `_order_by(_.Price)` test, sort stability is *not* part of
+// the parity claim — we only assert the resulting Price sequence matches
+// across modes, ignoring the relative order of tied rows. The tuple-key
+// test eliminates ties by design.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 100))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "BMW",   Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Audi",  Price = 200))
+    arr |> emplace(Car(Id = 3, Name = "Tesla", Price = 100))
+    arr |> emplace(Car(Id = 4, Name = "Lada",  Price = 50))
+    arr |> emplace(Car(Id = 5, Name = "Lambo", Price = 999))
+    return <- arr
+}
+
+def cars_equal(a : array<Car>; b : array<Car>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i].Id != b[i].Id || a[i].Name != b[i].Name || a[i].Price != b[i].Price) {
+            return false
+        }
+    }
+    return true
+}
+
+def prices_of(cars : array<Car>) : array<int> {
+    var out : array<int>
+    for (c in cars) {
+        out |> push(c.Price)
+    }
+    return <- out
+}
+
+def int_array_eq(a : array<int>; b : array<int>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i] != b[i]) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_order_by_single_asc(t : T?) {
+    // Sort-stability is not part of the parity claim — compare Price sequence.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price))
+        let m3 <- (arr |> _order_by(_.Price))
+
+        let p1 <- prices_of(m1)
+        let p2 <- prices_of(m2)
+        let p3 <- prices_of(m3)
+
+        t |> success(int_array_eq(p1, p2), "ASC: Price sequence M1 ≡ M2")
+        t |> success(int_array_eq(p2, p3), "ASC: Price sequence M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_order_by_single_desc(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by_descending(_.Price))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by_descending(_.Price))
+        let m3 <- (arr |> _order_by_descending(_.Price))
+
+        let p1 <- prices_of(m1)
+        let p2 <- prices_of(m2)
+        let p3 <- prices_of(m3)
+
+        t |> success(int_array_eq(p1, p2), "DESC: Price sequence M1 ≡ M2")
+        t |> success(int_array_eq(p2, p3), "DESC: Price sequence M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_order_by_tuple_key(t : T?) {
+    // Tuple-key (_.Price, _.Name) eliminates ties — exact full-row order
+    // must agree across all three modes.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by((_.Price, _.Name)))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by((_.Price, _.Name)))
+        let m3 <- (arr |> _order_by((_.Price, _.Name)))
+
+        t |> success(cars_equal(m1, m2), "tuple-key: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "tuple-key: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_where_orderby_take(t : T?) {
+    // Composed chain: filter, sort, limit. The tuple key avoids tie ambiguity
+    // in the sort step.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>)
+                         |> _where(_.Price > 50)
+                         |> _order_by((_.Price, _.Name))
+                         |> take(3))
+        let m2 <- (db |> select_from(type<Car>)
+                     |> _where(_.Price > 50)
+                     |> _order_by((_.Price, _.Name))
+                     |> take(3))
+        let m3 <- (arr |> _where(_.Price > 50)
+                       |> _order_by((_.Price, _.Name))
+                       |> take(3))
+
+        t |> success(cars_equal(m1, m2), "where|order_by|take: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "where|order_by|take: M2 ≡ M3")
+    }
+}

--- a/tests/dasSQLITE/parity_check_11_take_skip.das
+++ b/tests/dasSQLITE/parity_check_11_take_skip.das
@@ -1,0 +1,212 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 11 — `take(n)` / `skip(n)` pagination.
+//
+// IMPORTANT: SQLite's LIMIT/OFFSET without ORDER BY is not deterministic
+// (the tutorial explicitly warns about this), and a plain in-memory `take`
+// over an array IS positional. Bare `take(2)` therefore has no parity
+// claim — Mode 1's row order is provider-specific, Mode 3's is fixed.
+// All parity tests below pair take/skip with `_order_by` so the order is
+// well-defined in every mode.
+//
+// Shapes:
+//   - `_order_by |> take(n)`
+//   - `_order_by |> skip(n)`
+//   - `_order_by |> take(n) |> skip(m)` (windowed)
+//   - `_where |> _order_by |> take(n)` (composed)
+//   - `_order_by |> take(n) |> _first()` (terminal override)
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "BMW",   Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Audi",  Price = 200))
+    arr |> emplace(Car(Id = 3, Name = "Tesla", Price = 300))
+    arr |> emplace(Car(Id = 4, Name = "Lada",  Price = 50))
+    arr |> emplace(Car(Id = 5, Name = "Lambo", Price = 999))
+    return <- arr
+}
+
+def cars_equal(a : array<Car>; b : array<Car>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i].Id != b[i].Id || a[i].Name != b[i].Name || a[i].Price != b[i].Price) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_order_take(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> take(2))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price) |> take(2))
+        let m3 <- (arr |> _order_by(_.Price) |> take(2))
+
+        t |> success(cars_equal(m1, m2), "order|take: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "order|take: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_order_skip(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> skip(3))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price) |> skip(3))
+        let m3 <- (arr |> _order_by(_.Price) |> skip(3))
+
+        t |> success(cars_equal(m1, m2), "order|skip: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "order|skip: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_order_take_skip(t : T?) {
+    // F1 RESOLVED via multi-Q lowering. `take(2) |> skip(1)` (linq positional:
+    // take 2, then drop 1) lowers to a nested SELECT under `_sql`:
+    //
+    //   SELECT … FROM (SELECT … LIMIT 2) AS "t0" LIMIT -1 OFFSET 1
+    //
+    // All three modes now agree. For the canonical `LIMIT n OFFSET m` shape
+    // (`skip(1) |> take(2)`), see `parity_order_skip_then_take` below — that
+    // stays a flat SELECT.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> take(2) |> skip(1))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price) |> take(2) |> skip(1))
+        let m3 <- (arr |> _order_by(_.Price) |> take(2) |> skip(1))
+
+        t |> success(cars_equal(m1, m2), "order|take|skip: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "order|take|skip: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_order_take_skip_n_gt_m(t : T?) {
+    // n > m: take(4) → 4 rows, skip(2) drops 2 → 2 rows. All three modes agree.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> take(4) |> skip(2))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price) |> take(4) |> skip(2))
+        let m3 <- (arr |> _order_by(_.Price) |> take(4) |> skip(2))
+
+        t |> success(cars_equal(m1, m2), "order|take(4)|skip(2): M1 ≡ M2 (2 rows)")
+        t |> success(cars_equal(m2, m3), "order|take(4)|skip(2): M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_order_take_skip_degenerate(t : T?) {
+    // m > n: take(2), skip(5) drops everything → 0 rows. All three modes agree.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> take(2) |> skip(5))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price) |> take(2) |> skip(5))
+        let m3 <- (arr |> _order_by(_.Price) |> take(2) |> skip(5))
+
+        t |> equal(length(m1), 0, "order|take(2)|skip(5): M1 → 0 rows")
+        t |> equal(length(m2), 0, "order|take(2)|skip(5): M2 → 0 rows")
+        t |> equal(length(m3), 0, "order|take(2)|skip(5): M3 → 0 rows")
+    }
+}
+
+[test]
+def parity_order_skip_then_take(t : T?) {
+    // Workaround for the divergence: writing `skip(m) |> take(n)` instead of
+    // `take(n) |> skip(m)` makes the chain order match SQL's LIMIT/OFFSET
+    // semantics (skip first, then take). All three modes agree.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> skip(1) |> take(2))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price) |> skip(1) |> take(2))
+        let m3 <- (arr |> _order_by(_.Price) |> skip(1) |> take(2))
+
+        t |> success(cars_equal(m1, m2), "skip|take: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "skip|take: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_where_order_take(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+        let threshold = 100
+
+        let m1 <- _sql(db |> select_from(type<Car>)
+                         |> _where(_.Price > threshold)
+                         |> _order_by(_.Price)
+                         |> take(2))
+        let m2 <- (db |> select_from(type<Car>)
+                     |> _where(_.Price > threshold)
+                     |> _order_by(_.Price)
+                     |> take(2))
+        let m3 <- (arr |> _where(_.Price > threshold)
+                       |> _order_by(_.Price)
+                       |> take(2))
+
+        t |> success(cars_equal(m1, m2), "where|order|take: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "where|order|take: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_take_first_terminal(t : T?) {
+    // `_first()` overrides take in `_sql` (emits LIMIT 1). In linq,
+    // take(5) |> _first() also returns the first element. Result should
+    // be the same Car in all three modes.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 = _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> take(5) |> _first())
+        let m2 = (db |> select_from(type<Car>) |> _order_by(_.Price) |> take(5) |> _first())
+        let m3 = (arr |> _order_by(_.Price) |> take(5) |> _first())
+
+        t |> equal(m1.Id,    m2.Id,    "take|_first: M1.Id ≡ M2.Id")
+        t |> equal(m1.Name,  m2.Name,  "take|_first: M1.Name ≡ M2.Name")
+        t |> equal(m1.Price, m2.Price, "take|_first: M1.Price ≡ M2.Price")
+        t |> equal(m2.Id,    m3.Id,    "take|_first: M2.Id ≡ M3.Id")
+        t |> equal(m2.Name,  m3.Name,  "take|_first: M2.Name ≡ M3.Name")
+        t |> equal(m2.Price, m3.Price, "take|_first: M2.Price ≡ M3.Price")
+    }
+}

--- a/tests/dasSQLITE/parity_check_11b_take_then_where.das
+++ b/tests/dasSQLITE/parity_check_11b_take_then_where.das
@@ -1,0 +1,167 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Multi-Q lowering parity check: outer-Q `_where` over inner-Q `take`.
+//
+//   `... |> _order_by(_.Price) |> take(3) |> _where(_.Price > 100)`
+//
+// `_sql` lowers the divergent shape to:
+//   SELECT … FROM (SELECT … ORDER BY "Price" ASC LIMIT 3) AS "t0" WHERE "Price" > ?
+//
+// Linq positional semantics: order by price, take first 3, then filter those 3
+// rows by `Price > 100`. All three modes must agree.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "BMW",   Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Audi",  Price = 200))
+    arr |> emplace(Car(Id = 3, Name = "Tesla", Price = 300))
+    arr |> emplace(Car(Id = 4, Name = "Lada",  Price = 50))
+    arr |> emplace(Car(Id = 5, Name = "Lambo", Price = 999))
+    return <- arr
+}
+
+def cars_equal(a : array<Car>; b : array<Car>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i].Id != b[i].Id || a[i].Name != b[i].Name || a[i].Price != b[i].Price) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_take_then_where(t : T?) {
+    // Order by price (Lada=50, BMW=100, Audi=200), take first 3, filter Price > 100.
+    // Result: only Audi (Lada and BMW dropped by the filter; Tesla and Lambo never reached).
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> take(3) |> _where(_.Price > 100))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price) |> take(3) |> _where(_.Price > 100))
+        let m3 <- (arr |> _order_by(_.Price) |> take(3) |> _where(_.Price > 100))
+
+        t |> success(cars_equal(m1, m2), "take|where: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "take|where: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_take_then_two_wheres(t : T?) {
+    // Two outer wheres AND-fold in the same outer Q (same phase, no extra divert).
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> take(4)
+                         |> _where(_.Price > 100)
+                         |> _where(_.Name != "BMW"))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price) |> take(4)
+                     |> _where(_.Price > 100)
+                     |> _where(_.Name != "BMW"))
+        let m3 <- (arr |> _order_by(_.Price) |> take(4)
+                       |> _where(_.Price > 100)
+                       |> _where(_.Name != "BMW"))
+
+        t |> success(cars_equal(m1, m2), "take|where|where: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "take|where|where: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_inner_where_take_outer_where(t : T?) {
+    // Inner Q has its own `_where` (Price > 50 keeps 4 rows), then `_order_by`,
+    // then `take(3)`. Outer Q filters those 3 by `Name != "Lambo"`. Both inner
+    // and outer wheres co-exist without conflict.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>)
+                         |> _where(_.Price > 50)
+                         |> _order_by(_.Price)
+                         |> take(3)
+                         |> _where(_.Name != "Lambo"))
+        let m2 <- (db |> select_from(type<Car>)
+                     |> _where(_.Price > 50)
+                     |> _order_by(_.Price)
+                     |> take(3)
+                     |> _where(_.Name != "Lambo"))
+        let m3 <- (arr |> _where(_.Price > 50)
+                       |> _order_by(_.Price)
+                       |> take(3)
+                       |> _where(_.Name != "Lambo"))
+
+        t |> success(cars_equal(m1, m2), "where|order|take|where: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "where|order|take|where: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_take_then_where_to_array(t : T?) {
+    // Terminal `_to_array()` in outer Q.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> take(3)
+                         |> _where(_.Price > 100) |> _to_array())
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price) |> take(3)
+                     |> _where(_.Price > 100) |> _to_array())
+        let m3 <- (arr |> _order_by(_.Price) |> take(3)
+                       |> _where(_.Price > 100) |> _to_array())
+
+        t |> success(cars_equal(m1, m2), "take|where|to_array: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "take|where|to_array: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_take_then_where_first_opt(t : T?) {
+    // Outer single-row terminal (`_first_opt`) wraps the take|where subquery.
+    // Outer LIMIT 1 must NOT collapse the inner LIMIT 3.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 = _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> take(3)
+                        |> _where(_.Price > 100) |> _first_opt())
+        let m2 = (db |> select_from(type<Car>) |> _order_by(_.Price) |> take(3)
+                    |> _where(_.Price > 100) |> _first_opt())
+        let m3 = (arr |> _order_by(_.Price) |> take(3)
+                      |> _where(_.Price > 100) |> _first_opt())
+
+        t |> success(is_some(m1), "take|where|first_opt: M1 has value (Audi)")
+        t |> success(is_some(m2), "take|where|first_opt: M2 has value")
+        t |> success(is_some(m3), "take|where|first_opt: M3 has value")
+        t |> equal((m1 |> unwrap_or(Car(Id = 0, Name = "?", Price = 0))).Name, "Audi", "M1 first match is Audi")
+        t |> equal((m2 |> unwrap_or(Car(Id = 0, Name = "?", Price = 0))).Name, "Audi", "M2 first match is Audi")
+        t |> equal((m3 |> unwrap_or(Car(Id = 0, Name = "?", Price = 0))).Name, "Audi", "M3 first match is Audi")
+    }
+}

--- a/tests/dasSQLITE/parity_check_11c_take_then_order.das
+++ b/tests/dasSQLITE/parity_check_11c_take_then_order.das
@@ -1,0 +1,118 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Multi-Q lowering parity check: outer-Q `_order_by` over inner-Q `take`.
+//
+//   `... |> _order_by(_.Id) |> take(3) |> _order_by(_.Price)`
+//
+// Lowers under `_sql` to:
+//   SELECT … FROM (SELECT … ORDER BY "Id" ASC LIMIT 3) AS "t0" ORDER BY "Price" ASC
+//
+// Linq positional semantics: order by Id (deterministic), take first 3, then
+// re-sort those 3 by Price.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "BMW",   Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Audi",  Price = 200))
+    arr |> emplace(Car(Id = 3, Name = "Tesla", Price = 300))
+    arr |> emplace(Car(Id = 4, Name = "Lada",  Price = 50))
+    arr |> emplace(Car(Id = 5, Name = "Lambo", Price = 999))
+    return <- arr
+}
+
+def cars_equal(a : array<Car>; b : array<Car>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i].Id != b[i].Id || a[i].Name != b[i].Name || a[i].Price != b[i].Price) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_take_then_order(t : T?) {
+    // Order by Id, take 3 (BMW=100, Audi=200, Tesla=300), re-sort by Price ascending
+    // (BMW=100 < Audi=200 < Tesla=300 — same order; just covers the divert path).
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Id) |> take(3) |> _order_by(_.Price))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Id) |> take(3) |> _order_by(_.Price))
+        let m3 <- (arr |> _order_by(_.Id) |> take(3) |> _order_by(_.Price))
+
+        t |> success(cars_equal(m1, m2), "order|take|order: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "order|take|order: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_take_then_order_desc(t : T?) {
+    // Inner: order by Id, take 3 (BMW, Audi, Tesla). Outer: order by Price DESC
+    // (Tesla=300, Audi=200, BMW=100).
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Id) |> take(3) |> _order_by_descending(_.Price))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Id) |> take(3) |> _order_by_descending(_.Price))
+        let m3 <- (arr |> _order_by(_.Id) |> take(3) |> _order_by_descending(_.Price))
+
+        t |> success(cars_equal(m1, m2), "order|take|order_desc: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "order|take|order_desc: M2 ≡ M3")
+        t |> equal(length(m1), 3, "result has 3 rows")
+        t |> equal(m1[0].Name, "Tesla", "highest price first")
+    }
+}
+
+[test]
+def parity_three_level_nesting(t : T?) {
+    // Inner Q: order by Id, take 4 (BMW, Audi, Tesla, Lada). Mid Q: order by Price ASC
+    // (Lada=50, BMW=100, Audi=200, Tesla=300). Outer Q: take 2 (Lada, BMW).
+    //
+    // SQL:
+    //   SELECT … FROM (
+    //       SELECT … FROM (SELECT … ORDER BY "Id" ASC LIMIT 4) AS "t0"
+    //       ORDER BY "Price" ASC
+    //   ) AS "t0" LIMIT 2
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Id) |> take(4) |> _order_by(_.Price) |> take(2))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Id) |> take(4) |> _order_by(_.Price) |> take(2))
+        let m3 <- (arr |> _order_by(_.Id) |> take(4) |> _order_by(_.Price) |> take(2))
+
+        t |> success(cars_equal(m1, m2), "three-level: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "three-level: M2 ≡ M3")
+        t |> equal(length(m1), 2, "result has 2 rows")
+        t |> equal(m1[0].Name, "Lada", "lowest of inner-4 first")
+        t |> equal(m1[1].Name, "BMW", "second-lowest second")
+    }
+}

--- a/tests/dasSQLITE/parity_check_11d_skip_then_where.das
+++ b/tests/dasSQLITE/parity_check_11d_skip_then_where.das
@@ -1,0 +1,98 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Multi-Q lowering parity check: outer-Q `_where` over inner-Q `skip`.
+//
+//   `... |> _order_by(_.Price) |> skip(2) |> _where(_.Price > 100)`
+//
+// Lowers under `_sql` to:
+//   SELECT … FROM (SELECT … ORDER BY "Price" ASC LIMIT -1 OFFSET 2) AS "t0" WHERE "Price" > ?
+//
+// Linq positional semantics: order by price, skip first 2, then filter the rest.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "BMW",   Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Audi",  Price = 200))
+    arr |> emplace(Car(Id = 3, Name = "Tesla", Price = 300))
+    arr |> emplace(Car(Id = 4, Name = "Lada",  Price = 50))
+    arr |> emplace(Car(Id = 5, Name = "Lambo", Price = 999))
+    return <- arr
+}
+
+def cars_equal(a : array<Car>; b : array<Car>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i].Id != b[i].Id || a[i].Name != b[i].Name || a[i].Price != b[i].Price) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_skip_then_where(t : T?) {
+    // Order by price (Lada=50, BMW=100, Audi=200, Tesla=300, Lambo=999), skip 2
+    // (drops Lada, BMW), then filter Price > 100 (keeps all 3 remaining since
+    // Audi=200, Tesla=300, Lambo=999 all > 100).
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> skip(2) |> _where(_.Price > 100))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price) |> skip(2) |> _where(_.Price > 100))
+        let m3 <- (arr |> _order_by(_.Price) |> skip(2) |> _where(_.Price > 100))
+
+        t |> success(cars_equal(m1, m2), "order|skip|where: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "order|skip|where: M2 ≡ M3")
+        t |> equal(length(m1), 3, "3 rows after skip+filter")
+    }
+}
+
+[test]
+def parity_skip_then_where_then_order_desc(t : T?) {
+    // Inner: order ASC + skip(1) → drops Lada. Outer: where(Price>50) keeps the rest,
+    // then order_descending(Price). All in outer Q after the skip's divert.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> _order_by(_.Price) |> skip(1)
+                         |> _where(_.Price > 50)
+                         |> _order_by_descending(_.Price))
+        let m2 <- (db |> select_from(type<Car>) |> _order_by(_.Price) |> skip(1)
+                     |> _where(_.Price > 50)
+                     |> _order_by_descending(_.Price))
+        let m3 <- (arr |> _order_by(_.Price) |> skip(1)
+                       |> _where(_.Price > 50)
+                       |> _order_by_descending(_.Price))
+
+        t |> success(cars_equal(m1, m2), "order|skip|where|order_desc: M1 ≡ M2")
+        t |> success(cars_equal(m2, m3), "order|skip|where|order_desc: M2 ≡ M3")
+        t |> equal(m1[0].Name, "Lambo", "highest price first")
+    }
+}

--- a/tests/dasSQLITE/parity_check_12_distinct.das
+++ b/tests/dasSQLITE/parity_check_12_distinct.das
@@ -51,8 +51,8 @@ def sorted_strings(var a : array<string>) : array<string> {
     return <- a
 }
 
-def sorted_int_pairs(cars : array<Car>) : array<tuple<int;int>> {
-    var pairs : array<tuple<int;int>>
+def sorted_int_pairs(cars : array<Car>) : array<tuple<int; int>> {
+    var pairs : array<tuple<int; int>>
     for (c in cars) {
         pairs |> push((c.Id, c.Price))
     }
@@ -77,7 +77,7 @@ def string_arrays_eq(a : array<string>; b : array<string>) : bool {
     return true
 }
 
-def pair_arrays_eq(a : array<tuple<int;int>>; b : array<tuple<int;int>>) : bool {
+def pair_arrays_eq(a : array<tuple<int; int>>; b : array<tuple<int; int>>) : bool {
     if (length(a) != length(b)) {
         return false
     }

--- a/tests/dasSQLITE/parity_check_12_distinct.das
+++ b/tests/dasSQLITE/parity_check_12_distinct.das
@@ -1,0 +1,156 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 12 — `distinct()` row dedupe.
+//
+// Shapes:
+//   - `select_from |> distinct()`                    full-row DISTINCT
+//   - `_select(_.Name) |> distinct()`                single-column DISTINCT
+//   - `_where |> _select |> distinct()`              composed
+//
+// Result-order note: SQL DISTINCT does not guarantee any order, while
+// linq's `distinct` preserves first-occurrence order. To keep parity
+// assertions order-independent, all tests below compare *sorted*
+// results — the multiset of distinct values must agree across modes.
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "BMW",   Price = 150))
+    db |> insert(Car(Id = 4, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 5, Name = "Audi",  Price = 200))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "BMW",   Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Audi",  Price = 200))
+    arr |> emplace(Car(Id = 3, Name = "BMW",   Price = 150))
+    arr |> emplace(Car(Id = 4, Name = "Tesla", Price = 300))
+    arr |> emplace(Car(Id = 5, Name = "Audi",  Price = 200))
+    return <- arr
+}
+
+def sorted_strings(var a : array<string>) : array<string> {
+    a |> sort()
+    return <- a
+}
+
+def sorted_int_pairs(cars : array<Car>) : array<tuple<int;int>> {
+    var pairs : array<tuple<int;int>>
+    for (c in cars) {
+        pairs |> push((c.Id, c.Price))
+    }
+    pairs |> sort() <| $(a, b) {
+        if (a._0 != b._0) {
+            return a._0 < b._0
+        }
+        return a._1 < b._1
+    }
+    return <- pairs
+}
+
+def string_arrays_eq(a : array<string>; b : array<string>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i] != b[i]) {
+            return false
+        }
+    }
+    return true
+}
+
+def pair_arrays_eq(a : array<tuple<int;int>>; b : array<tuple<int;int>>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i]._0 != b[i]._0 || a[i]._1 != b[i]._1) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_full_row_distinct(t : T?) {
+    // All PKs are unique, so DISTINCT survives every row. The point of
+    // the test: full-row DISTINCT must produce the same multiset across
+    // all three modes. Compare via sorted (Id, Price) pairs to ignore
+    // result ordering.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<Car>) |> distinct())
+        let m2 <- (db |> select_from(type<Car>) |> distinct())
+        let m3 <- (arr |> distinct())
+
+        let s1 <- sorted_int_pairs(m1)
+        let s2 <- sorted_int_pairs(m2)
+        let s3 <- sorted_int_pairs(m3)
+
+        t |> success(pair_arrays_eq(s1, s2), "full-row distinct multiset: M1 ≡ M2")
+        t |> success(pair_arrays_eq(s2, s3), "full-row distinct multiset: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_single_col_distinct(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var m1 <- _sql(db |> select_from(type<Car>) |> _select(_.Name) |> distinct())
+        var m2 <- (db |> select_from(type<Car>) |> _select(_.Name) |> distinct())
+        var m3 <- (arr |> _select(_.Name) |> distinct())
+
+        m1 |> sort()
+        m2 |> sort()
+        m3 |> sort()
+
+        t |> equal(length(m1), 3, "Mode 1: 3 unique names")
+        t |> equal(length(m2), 3, "Mode 2: 3 unique names")
+        t |> equal(length(m3), 3, "Mode 3: 3 unique names")
+        t |> success(string_arrays_eq(m1, m2), "single-col distinct multiset: M1 ≡ M2")
+        t |> success(string_arrays_eq(m2, m3), "single-col distinct multiset: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_where_select_distinct(t : T?) {
+    // Filter, project, dedupe. After Price > 100 we have rows 2,3,4,5
+    // with names {Audi, BMW, Tesla, Audi} → distinct {Audi, BMW, Tesla}.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var m1 <- _sql(db |> select_from(type<Car>) |> _where(_.Price > 100) |> _select(_.Name) |> distinct())
+        var m2 <- (db |> select_from(type<Car>) |> _where(_.Price > 100) |> _select(_.Name) |> distinct())
+        var m3 <- (arr |> _where(_.Price > 100) |> _select(_.Name) |> distinct())
+
+        m1 |> sort()
+        m2 |> sort()
+        m3 |> sort()
+
+        t |> success(string_arrays_eq(m1, m2), "where|select|distinct: M1 ≡ M2")
+        t |> success(string_arrays_eq(m2, m3), "where|select|distinct: M2 ≡ M3")
+    }
+}

--- a/tests/dasSQLITE/parity_check_12b_set_ops.das
+++ b/tests/dasSQLITE/parity_check_12b_set_ops.das
@@ -1,0 +1,137 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 12b — UNION / INTERSECT / EXCEPT.
+//
+// Both sides must project the same shape (`_select(_.Col)`). The
+// `_sql` macro lowers `lhs |> union(rhs)` etc. to SQL set operations;
+// `daslib/linq` already implements `union`/`intersect`/`except` over
+// arrays. Set-op output order is unspecified — assertions compare
+// sorted multisets.
+
+[sql_table(name = "Customers")]
+struct Customer {
+    @sql_primary_key Id : int
+    Tier : int
+}
+
+[sql_table(name = "Prospects")]
+struct Prospect {
+    @sql_primary_key Id : int
+    Tier : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Customer>)
+    db |> create_table(type<Prospect>)
+    db |> insert(Customer(Id = 1, Tier = 10))
+    db |> insert(Customer(Id = 2, Tier = 20))
+    db |> insert(Customer(Id = 3, Tier = 30))
+    db |> insert(Prospect(Id = 100, Tier = 20))
+    db |> insert(Prospect(Id = 200, Tier = 30))
+    db |> insert(Prospect(Id = 300, Tier = 40))
+}
+
+def fixture_customers() : array<Customer> {
+    var arr : array<Customer>
+    arr |> emplace(Customer(Id = 1, Tier = 10))
+    arr |> emplace(Customer(Id = 2, Tier = 20))
+    arr |> emplace(Customer(Id = 3, Tier = 30))
+    return <- arr
+}
+
+def fixture_prospects() : array<Prospect> {
+    var arr : array<Prospect>
+    arr |> emplace(Prospect(Id = 100, Tier = 20))
+    arr |> emplace(Prospect(Id = 200, Tier = 30))
+    arr |> emplace(Prospect(Id = 300, Tier = 40))
+    return <- arr
+}
+
+def int_arrays_eq(a : array<int>; b : array<int>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i] != b[i]) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_union(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var customers <- fixture_customers()
+        var prospects <- fixture_prospects()
+
+        var m1 <- _sql((db |> select_from(type<Customer>) |> _select(_.Tier))
+                       |> union(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+        var m2 <- ((db |> select_from(type<Customer>) |> _select(_.Tier))
+                   |> union(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+        var m3 <- ((customers |> _select(_.Tier)) |> union(prospects |> _select(_.Tier)))
+
+        m1 |> sort()
+        m2 |> sort()
+        m3 |> sort()
+
+        t |> equal(length(m1), 4, "UNION distinct count: 4 (10, 20, 30, 40)")
+        t |> success(int_arrays_eq(m1, m2), "union: M1 ≡ M2 (sorted multiset)")
+        t |> success(int_arrays_eq(m2, m3), "union: M2 ≡ M3 (sorted multiset)")
+    }
+}
+
+[test]
+def parity_intersect(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var customers <- fixture_customers()
+        var prospects <- fixture_prospects()
+
+        var m1 <- _sql((db |> select_from(type<Customer>) |> _select(_.Tier))
+                       |> intersect(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+        var m2 <- ((db |> select_from(type<Customer>) |> _select(_.Tier))
+                   |> intersect(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+        var m3 <- ((customers |> _select(_.Tier)) |> intersect(prospects |> _select(_.Tier)))
+
+        m1 |> sort()
+        m2 |> sort()
+        m3 |> sort()
+
+        t |> equal(length(m1), 2, "INTERSECT count: 2 (20, 30)")
+        t |> success(int_arrays_eq(m1, m2), "intersect: M1 ≡ M2 (sorted multiset)")
+        t |> success(int_arrays_eq(m2, m3), "intersect: M2 ≡ M3 (sorted multiset)")
+    }
+}
+
+[test]
+def parity_except(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var customers <- fixture_customers()
+        var prospects <- fixture_prospects()
+
+        var m1 <- _sql((db |> select_from(type<Customer>) |> _select(_.Tier))
+                       |> except(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+        var m2 <- ((db |> select_from(type<Customer>) |> _select(_.Tier))
+                   |> except(db |> select_from(type<Prospect>) |> _select(_.Tier)))
+        var m3 <- ((customers |> _select(_.Tier)) |> except(prospects |> _select(_.Tier)))
+
+        m1 |> sort()
+        m2 |> sort()
+        m3 |> sort()
+
+        t |> equal(length(m1), 1, "EXCEPT count: 1 (just 10)")
+        t |> success(int_arrays_eq(m1, m2), "except: M1 ≡ M2 (sorted multiset)")
+        t |> success(int_arrays_eq(m2, m3), "except: M2 ≡ M3 (sorted multiset)")
+    }
+}

--- a/tests/dasSQLITE/parity_check_13_aggregates.das
+++ b/tests/dasSQLITE/parity_check_13_aggregates.das
@@ -1,0 +1,142 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 13 — column aggregates: count, sum, average, min, max.
+// Each is a chain terminal returning a scalar.
+//
+// Result-type expectation per the tutorial header:
+//   - sum / min / max: column's daslang type (int for Price)
+//   - average:         double (always promoted)
+//   - count:           int (matches `length(arr)`)
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Name = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Name = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Name = "Tesla", Price = 300))
+    db |> insert(Car(Id = 4, Name = "Lada",  Price = 50))
+    db |> insert(Car(Id = 5, Name = "Lambo", Price = 999))
+}
+
+def fixture_array() : array<Car> {
+    var arr : array<Car>
+    arr |> emplace(Car(Id = 1, Name = "BMW",   Price = 100))
+    arr |> emplace(Car(Id = 2, Name = "Audi",  Price = 200))
+    arr |> emplace(Car(Id = 3, Name = "Tesla", Price = 300))
+    arr |> emplace(Car(Id = 4, Name = "Lada",  Price = 50))
+    arr |> emplace(Car(Id = 5, Name = "Lambo", Price = 999))
+    return <- arr
+}
+
+[test]
+def parity_count(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 = _sql(db |> select_from(type<Car>) |> count())
+        let m2 = db |> select_from(type<Car>) |> count()
+        let m3 = arr |> count()
+
+        t |> equal(m1, m2, "count: M1 ≡ M2")
+        t |> equal(m2, m3, "count: M2 ≡ M3")
+        t |> equal(m1, 5,  "count: 5 rows")
+    }
+}
+
+[test]
+def parity_sum(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> sum())
+        let m2 = db |> select_from(type<Car>) |> _select(_.Price) |> sum()
+        let m3 = arr |> _select(_.Price) |> sum()
+
+        t |> equal(m1, m2, "sum: M1 ≡ M2")
+        t |> equal(m2, m3, "sum: M2 ≡ M3")
+        t |> equal(m1, 100 + 200 + 300 + 50 + 999, "sum: 1649")
+    }
+}
+
+[test]
+def parity_average(t : T?) {
+    // F2 resolved: linq `average` always returns `double` (matching SQL
+    // `AVG` and C# LINQ `Average`). All three modes agree on type and value.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> average())
+        let m2 = db |> select_from(type<Car>) |> _select(_.Price) |> average()
+        let m3 = arr |> _select(_.Price) |> average()
+
+        t |> equal(m1, m2, "average: M1 ≡ M2")
+        t |> equal(m2, m3, "average: M2 ≡ M3")
+        t |> equal(m1, 329.8lf, "average: 1649 / 5 = 329.8")
+    }
+}
+
+[test]
+def parity_min(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> min())
+        let m2 = db |> select_from(type<Car>) |> _select(_.Price) |> min()
+        let m3 = arr |> _select(_.Price) |> min()
+
+        t |> equal(m1, m2, "min: M1 ≡ M2")
+        t |> equal(m2, m3, "min: M2 ≡ M3")
+        t |> equal(m1, 50, "min: 50")
+    }
+}
+
+[test]
+def parity_max(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> max())
+        let m2 = db |> select_from(type<Car>) |> _select(_.Price) |> max()
+        let m3 = arr |> _select(_.Price) |> max()
+
+        t |> equal(m1, m2, "max: M1 ≡ M2")
+        t |> equal(m2, m3, "max: M2 ≡ M3")
+        t |> equal(m1, 999, "max: 999")
+    }
+}
+
+[test]
+def parity_where_sum(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+        let cutoff = 100
+
+        let m1 = _sql(db |> select_from(type<Car>) |> _where(_.Price > cutoff) |> _select(_.Price) |> sum())
+        let m2 = db |> select_from(type<Car>) |> _where(_.Price > cutoff) |> _select(_.Price) |> sum()
+        let m3 = arr |> _where(_.Price > cutoff) |> _select(_.Price) |> sum()
+
+        t |> equal(m1, m2, "where|sum: M1 ≡ M2")
+        t |> equal(m2, m3, "where|sum: M2 ≡ M3")
+        t |> equal(m1, 200 + 300 + 999, "where|sum: 1499")
+    }
+}

--- a/tests/dasSQLITE/parity_check_14_group_by.das
+++ b/tests/dasSQLITE/parity_check_14_group_by.das
@@ -1,0 +1,305 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 14 — `_group_by` and `_having`.
+//
+// Important: chains that combine `_group_by` with `_order_by(_._0)`
+// fail to compile in plain linq when the grouped element has non-
+// trivially-cloneable types (notably `array<User>` for User containing
+// strings). See API_CHECKED.md F3. To keep parity assertions alive,
+// each test below computes results without inline `_order_by` and
+// post-sorts each mode's result by the projected key for comparison.
+// Tests that demonstrate the F3 failure live in a separate `failed_*`
+// file.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name   : string
+    City   : string
+    Age    : int
+    Salary : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "Alice", City = "NYC",     Age = 30, Salary = 100))
+    db |> insert(User(Id = 2, Name = "Bob",   City = "NYC",     Age = 25, Salary = 80))
+    db |> insert(User(Id = 3, Name = "Carol", City = "Chicago", Age = 40, Salary = 120))
+    db |> insert(User(Id = 4, Name = "Dave",  City = "Chicago", Age = 35, Salary = 90))
+    db |> insert(User(Id = 5, Name = "Eve",   City = "Chicago", Age = 50, Salary = 200))
+    db |> insert(User(Id = 6, Name = "Frank", City = "Boston",  Age = 28, Salary = 70))
+    db |> insert(User(Id = 7, Name = "Adam",  City = "NYC",     Age = 30, Salary = 110))
+}
+
+def fixture_array() : array<User> {
+    var arr : array<User>
+    arr |> emplace(User(Id = 1, Name = "Alice", City = "NYC",     Age = 30, Salary = 100))
+    arr |> emplace(User(Id = 2, Name = "Bob",   City = "NYC",     Age = 25, Salary = 80))
+    arr |> emplace(User(Id = 3, Name = "Carol", City = "Chicago", Age = 40, Salary = 120))
+    arr |> emplace(User(Id = 4, Name = "Dave",  City = "Chicago", Age = 35, Salary = 90))
+    arr |> emplace(User(Id = 5, Name = "Eve",   City = "Chicago", Age = 50, Salary = 200))
+    arr |> emplace(User(Id = 6, Name = "Frank", City = "Boston",  Age = 28, Salary = 70))
+    arr |> emplace(User(Id = 7, Name = "Adam",  City = "NYC",     Age = 30, Salary = 110))
+    return <- arr
+}
+
+def sort_by_city(var rows : array<auto(R)>) : array<R> {
+    rows |> sort() <| $(a, b) {
+        return a.City < b.City
+    }
+    return <- rows
+}
+
+[test]
+def parity_group_by_count(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _group_by(_.City)
+                         |> _select((City = _._0, N = _._1 |> length)))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _group_by(_.City)
+                     |> _select((City = _._0, N = _._1 |> length)))
+        var m3 <- (arr |> _group_by(_.City)
+                       |> _select((City = _._0, N = _._1 |> length)))
+
+        m1 <- sort_by_city(m1)
+        m2 <- sort_by_city(m2)
+        m3 <- sort_by_city(m3)
+
+        t |> equal(length(m1), length(m2), "group+count: M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "group+count: M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].City, m2[i].City, "row[{i}].City: M1 ≡ M2")
+            t |> equal(m1[i].N,    m2[i].N,    "row[{i}].N:    M1 ≡ M2")
+            t |> equal(m2[i].City, m3[i].City, "row[{i}].City: M2 ≡ M3")
+            t |> equal(m2[i].N,    m3[i].N,    "row[{i}].N:    M2 ≡ M3")
+        }
+    }
+}
+
+[test]
+def parity_group_by_multi_aggregate(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _group_by(_.City)
+                         |> _select((
+                             City   = _._0,
+                             N      = _._1 |> length,
+                             MinAge = _._1 |> select($(u : User) => u.Age)    |> min,
+                             MaxAge = _._1 |> select($(u : User) => u.Age)    |> max,
+                             Total  = _._1 |> select($(u : User) => u.Salary) |> sum)))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _group_by(_.City)
+                     |> _select((
+                         City   = _._0,
+                         N      = _._1 |> length,
+                         MinAge = _._1 |> select($(u : User) => u.Age)    |> min,
+                         MaxAge = _._1 |> select($(u : User) => u.Age)    |> max,
+                         Total  = _._1 |> select($(u : User) => u.Salary) |> sum)))
+        var m3 <- (arr |> _group_by(_.City)
+                       |> _select((
+                           City   = _._0,
+                           N      = _._1 |> length,
+                           MinAge = _._1 |> select($(u : User) => u.Age)    |> min,
+                           MaxAge = _._1 |> select($(u : User) => u.Age)    |> max,
+                           Total  = _._1 |> select($(u : User) => u.Salary) |> sum)))
+
+        m1 <- sort_by_city(m1)
+        m2 <- sort_by_city(m2)
+        m3 <- sort_by_city(m3)
+
+        t |> equal(length(m1), length(m2), "multi-agg length: M1 ≡ M2")
+        t |> equal(length(m2), length(m3), "multi-agg length: M2 ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].City,   m2[i].City,   "row[{i}].City:   M1 ≡ M2")
+            t |> equal(m1[i].N,      m2[i].N,      "row[{i}].N:      M1 ≡ M2")
+            t |> equal(m1[i].MinAge, m2[i].MinAge, "row[{i}].MinAge: M1 ≡ M2")
+            t |> equal(m1[i].MaxAge, m2[i].MaxAge, "row[{i}].MaxAge: M1 ≡ M2")
+            t |> equal(m1[i].Total,  m2[i].Total,  "row[{i}].Total:  M1 ≡ M2")
+            t |> equal(m2[i].City,   m3[i].City,   "row[{i}].City:   M2 ≡ M3")
+            t |> equal(m2[i].N,      m3[i].N,      "row[{i}].N:      M2 ≡ M3")
+            t |> equal(m2[i].MinAge, m3[i].MinAge, "row[{i}].MinAge: M2 ≡ M3")
+            t |> equal(m2[i].MaxAge, m3[i].MaxAge, "row[{i}].MaxAge: M2 ≡ M3")
+            t |> equal(m2[i].Total,  m3[i].Total,  "row[{i}].Total:  M2 ≡ M3")
+        }
+    }
+}
+
+[test]
+def parity_where_group_count(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _where(_.Age >= 30)
+                         |> _group_by(_.City)
+                         |> _select((City = _._0, N = _._1 |> length)))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _where(_.Age >= 30)
+                     |> _group_by(_.City)
+                     |> _select((City = _._0, N = _._1 |> length)))
+        var m3 <- (arr |> _where(_.Age >= 30)
+                       |> _group_by(_.City)
+                       |> _select((City = _._0, N = _._1 |> length)))
+
+        m1 <- sort_by_city(m1)
+        m2 <- sort_by_city(m2)
+        m3 <- sort_by_city(m3)
+
+        t |> equal(length(m1), length(m2), "where|group|count: M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "where|group|count: M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].City, m2[i].City, "row[{i}].City: M1 ≡ M2")
+            t |> equal(m1[i].N,    m2[i].N,    "row[{i}].N:    M1 ≡ M2")
+            t |> equal(m2[i].City, m3[i].City, "row[{i}].City: M2 ≡ M3")
+            t |> equal(m2[i].N,    m3[i].N,    "row[{i}].N:    M2 ≡ M3")
+        }
+    }
+}
+
+[test]
+def parity_group_having(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _group_by(_.City)
+                         |> _having(_._1 |> length > 1)
+                         |> _select((City = _._0, N = _._1 |> length)))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _group_by(_.City)
+                     |> _having(_._1 |> length > 1)
+                     |> _select((City = _._0, N = _._1 |> length)))
+        var m3 <- (arr |> _group_by(_.City)
+                       |> _having(_._1 |> length > 1)
+                       |> _select((City = _._0, N = _._1 |> length)))
+
+        m1 <- sort_by_city(m1)
+        m2 <- sort_by_city(m2)
+        m3 <- sort_by_city(m3)
+
+        t |> equal(length(m1), length(m2), "group|having: M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "group|having: M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].City, m2[i].City, "row[{i}].City: M1 ≡ M2")
+            t |> equal(m1[i].N,    m2[i].N,    "row[{i}].N:    M1 ≡ M2")
+            t |> equal(m2[i].City, m3[i].City, "row[{i}].City: M2 ≡ M3")
+            t |> equal(m2[i].N,    m3[i].N,    "row[{i}].N:    M2 ≡ M3")
+        }
+    }
+}
+
+[test]
+def parity_multi_key_group(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _group_by((_.City, _.Age))
+                         |> _having(_._1 |> length > 1)
+                         |> _select((City = _._0._0, Age = _._0._1, N = _._1 |> length)))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _group_by((_.City, _.Age))
+                     |> _having(_._1 |> length > 1)
+                     |> _select((City = _._0._0, Age = _._0._1, N = _._1 |> length)))
+        var m3 <- (arr |> _group_by((_.City, _.Age))
+                       |> _having(_._1 |> length > 1)
+                       |> _select((City = _._0._0, Age = _._0._1, N = _._1 |> length)))
+
+        m1 <- sort_by_city(m1)
+        m2 <- sort_by_city(m2)
+        m3 <- sort_by_city(m3)
+
+        t |> equal(length(m1), length(m2), "multi-key length: M1 ≡ M2")
+        t |> equal(length(m2), length(m3), "multi-key length: M2 ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].City, m2[i].City, "row[{i}].City: M1 ≡ M2")
+            t |> equal(m1[i].Age,  m2[i].Age,  "row[{i}].Age:  M1 ≡ M2")
+            t |> equal(m1[i].N,    m2[i].N,    "row[{i}].N:    M1 ≡ M2")
+            t |> equal(m2[i].City, m3[i].City, "row[{i}].City: M2 ≡ M3")
+            t |> equal(m2[i].Age,  m3[i].Age,  "row[{i}].Age:  M2 ≡ M3")
+            t |> equal(m2[i].N,    m3[i].N,    "row[{i}].N:    M2 ≡ M3")
+        }
+    }
+}
+
+[test]
+def parity_full_reporting_chain(t : T?) {
+    // Full reporting: WHERE → GROUP BY → HAVING → SELECT → take.
+    // (Inline `_order_by` removed due to F3 — tracked in API_CHECKED.md.)
+    //
+    // Tuple is 4-field (City, N, TotSalary, OldestAge) to avoid a
+    // recordNames collision with parity_multi_key_group's
+    // tuple<string;int;int> — daslang canonicalizes tuple types by
+    // arg-type list, "first recordNames wins."
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+        let min_age = 25
+        let min_count = 1
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _where(_.Age >= min_age)
+                         |> _group_by(_.City)
+                         |> _having(_._1 |> length >= min_count)
+                         |> _select((
+                             City      = _._0,
+                             N         = _._1 |> length,
+                             TotSalary = _._1 |> select($(u : User) => u.Salary) |> sum,
+                             OldestAge = _._1 |> select($(u : User) => u.Age)    |> max))
+                         |> take(10))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _where(_.Age >= min_age)
+                     |> _group_by(_.City)
+                     |> _having(_._1 |> length >= min_count)
+                     |> _select((
+                         City      = _._0,
+                         N         = _._1 |> length,
+                         TotSalary = _._1 |> select($(u : User) => u.Salary) |> sum,
+                         OldestAge = _._1 |> select($(u : User) => u.Age)    |> max))
+                     |> take(10))
+        var m3 <- (arr |> _where(_.Age >= min_age)
+                       |> _group_by(_.City)
+                       |> _having(_._1 |> length >= min_count)
+                       |> _select((
+                           City      = _._0,
+                           N         = _._1 |> length,
+                           TotSalary = _._1 |> select($(u : User) => u.Salary) |> sum,
+                           OldestAge = _._1 |> select($(u : User) => u.Age)    |> max))
+                       |> take(10))
+
+        m1 <- sort_by_city(m1)
+        m2 <- sort_by_city(m2)
+        m3 <- sort_by_city(m3)
+
+        t |> equal(length(m1), length(m2), "full chain length: M1 ≡ M2")
+        t |> equal(length(m2), length(m3), "full chain length: M2 ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].City,      m2[i].City,      "row[{i}].City:      M1 ≡ M2")
+            t |> equal(m1[i].N,         m2[i].N,         "row[{i}].N:         M1 ≡ M2")
+            t |> equal(m1[i].TotSalary, m2[i].TotSalary, "row[{i}].TotSalary: M1 ≡ M2")
+            t |> equal(m1[i].OldestAge, m2[i].OldestAge, "row[{i}].OldestAge: M1 ≡ M2")
+            t |> equal(m2[i].City,      m3[i].City,      "row[{i}].City:      M2 ≡ M3")
+            t |> equal(m2[i].N,         m3[i].N,         "row[{i}].N:         M2 ≡ M3")
+            t |> equal(m2[i].TotSalary, m3[i].TotSalary, "row[{i}].TotSalary: M2 ≡ M3")
+            t |> equal(m2[i].OldestAge, m3[i].OldestAge, "row[{i}].OldestAge: M2 ≡ M3")
+        }
+    }
+}

--- a/tests/dasSQLITE/parity_check_15_join.das
+++ b/tests/dasSQLITE/parity_check_15_join.das
@@ -1,0 +1,208 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 15 — `_join`: inner equi-join.
+//
+// Shapes:
+//   1. plain inner equi-join + named-tuple projection
+//   2. pre-join `_where` (filters left source before join)
+//   3. right-side `_where` inside the joined chain (filter via JOIN ON)
+//
+// Each test uses a structurally distinct projection tuple to avoid
+// the generic-instantiation recordNames collision: any two
+// `tuple<string;int>` literals flowing through the same linq generic
+// in this compilation unit would share the cached instantiation and
+// lose the second's recordNames. (See feedback memory.)
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name   : string
+    Active : bool
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "Alice", Active = true))
+    db |> insert(User(Id = 2, Name = "Bob",   Active = true))
+    db |> insert(User(Id = 3, Name = "Carol", Active = false))
+    db |> insert(Order(Id = 10, UserId = 1, Total = 100))
+    db |> insert(Order(Id = 11, UserId = 1, Total = 250))
+    db |> insert(Order(Id = 12, UserId = 2, Total =  50))
+}
+
+def fixture_users() : array<User> {
+    var arr : array<User>
+    arr |> emplace(User(Id = 1, Name = "Alice", Active = true))
+    arr |> emplace(User(Id = 2, Name = "Bob",   Active = true))
+    arr |> emplace(User(Id = 3, Name = "Carol", Active = false))
+    return <- arr
+}
+
+def fixture_orders() : array<Order> {
+    var arr : array<Order>
+    arr |> emplace(Order(Id = 10, UserId = 1, Total = 100))
+    arr |> emplace(Order(Id = 11, UserId = 1, Total = 250))
+    arr |> emplace(Order(Id = 12, UserId = 2, Total =  50))
+    return <- arr
+}
+
+def sort_by_pair(var rows : array<auto(R)>) : array<R> {
+    rows |> sort() <| $(a, b) {
+        if (a.UserName != b.UserName) {
+            return a.UserName < b.UserName
+        }
+        return a.OrderTotal < b.OrderTotal
+    }
+    return <- rows
+}
+
+[test]
+def parity_inner_join_basic(t : T?) {
+    // Tuple shape: (UserName : string, OrderTotal : int) → tuple<string;int>
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _join(db |> select_from(type<Order>),
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total)))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _join(db |> select_from(type<Order>),
+                              $(u : User, o : Order) => u.Id == o.UserId,
+                              $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total)))
+        var m3 <- (users |> _join(orders,
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total)))
+
+        m1 <- sort_by_pair(m1)
+        m2 <- sort_by_pair(m2)
+        m3 <- sort_by_pair(m3)
+
+        t |> equal(length(m1), 3, "inner join row count: 3 (Carol absent)")
+        t |> equal(length(m1), length(m2), "join: M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "join: M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].UserName,   m2[i].UserName,   "row[{i}].UserName:   M1 ≡ M2")
+            t |> equal(m1[i].OrderTotal, m2[i].OrderTotal, "row[{i}].OrderTotal: M1 ≡ M2")
+            t |> equal(m2[i].UserName,   m3[i].UserName,   "row[{i}].UserName:   M2 ≡ M3")
+            t |> equal(m2[i].OrderTotal, m3[i].OrderTotal, "row[{i}].OrderTotal: M2 ≡ M3")
+        }
+    }
+}
+
+def sort_by_pair_with_active(var rows : array<auto(R)>) : array<R> {
+    rows |> sort() <| $(a, b) {
+        if (a.UserName != b.UserName) {
+            return a.UserName < b.UserName
+        }
+        return a.OrderTotal < b.OrderTotal
+    }
+    return <- rows
+}
+
+[test]
+def parity_left_filter_join(t : T?) {
+    // Tuple shape: (UserName, OrderTotal, IsActive) → tuple<string;int;bool> —
+    // structurally distinct from parity_inner_join_basic.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _where(_.Active)
+                         |> _join(db |> select_from(type<Order>),
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total, IsActive = u.Active)))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _where(_.Active)
+                     |> _join(db |> select_from(type<Order>),
+                              $(u : User, o : Order) => u.Id == o.UserId,
+                              $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total, IsActive = u.Active)))
+        var m3 <- (users |> _where(_.Active)
+                         |> _join(orders,
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total, IsActive = u.Active)))
+
+        m1 <- sort_by_pair_with_active(m1)
+        m2 <- sort_by_pair_with_active(m2)
+        m3 <- sort_by_pair_with_active(m3)
+
+        t |> equal(length(m1), length(m2), "where|join: M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "where|join: M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].UserName,   m2[i].UserName,   "row[{i}].UserName:   M1 ≡ M2")
+            t |> equal(m1[i].OrderTotal, m2[i].OrderTotal, "row[{i}].OrderTotal: M1 ≡ M2")
+            t |> equal(m1[i].IsActive,   m2[i].IsActive,   "row[{i}].IsActive:   M1 ≡ M2")
+            t |> equal(m2[i].UserName,   m3[i].UserName,   "row[{i}].UserName:   M2 ≡ M3")
+            t |> equal(m2[i].OrderTotal, m3[i].OrderTotal, "row[{i}].OrderTotal: M2 ≡ M3")
+            t |> equal(m2[i].IsActive,   m3[i].IsActive,   "row[{i}].IsActive:   M2 ≡ M3")
+        }
+    }
+}
+
+def sort_by_pair_with_orderid(var rows : array<auto(R)>) : array<R> {
+    rows |> sort() <| $(a, b) {
+        if (a.UserName != b.UserName) {
+            return a.UserName < b.UserName
+        }
+        return a.OrderId < b.OrderId
+    }
+    return <- rows
+}
+
+[test]
+def parity_right_filter_join(t : T?) {
+    // Tuple shape: (UserName, OrderTotal, OrderId) → tuple<string;int;int>.
+    // Right-side `_where` filters the joined source before the equi-join.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _join(db |> select_from(type<Order>) |> _where(_.Total > 75),
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total, OrderId = o.Id)))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _join(db |> select_from(type<Order>) |> _where(_.Total > 75),
+                              $(u : User, o : Order) => u.Id == o.UserId,
+                              $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total, OrderId = o.Id)))
+        var m3 <- (users |> _join(orders |> _where(_.Total > 75),
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total, OrderId = o.Id)))
+
+        m1 <- sort_by_pair_with_orderid(m1)
+        m2 <- sort_by_pair_with_orderid(m2)
+        m3 <- sort_by_pair_with_orderid(m3)
+
+        t |> equal(length(m1), 2, "right-filter join row count: 2 (Bob's 50 dropped)")
+        t |> equal(length(m1), length(m2), "right-filter: M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "right-filter: M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].UserName,   m2[i].UserName,   "row[{i}].UserName:   M1 ≡ M2")
+            t |> equal(m1[i].OrderTotal, m2[i].OrderTotal, "row[{i}].OrderTotal: M1 ≡ M2")
+            t |> equal(m1[i].OrderId,    m2[i].OrderId,    "row[{i}].OrderId:    M1 ≡ M2")
+            t |> equal(m2[i].UserName,   m3[i].UserName,   "row[{i}].UserName:   M2 ≡ M3")
+            t |> equal(m2[i].OrderTotal, m3[i].OrderTotal, "row[{i}].OrderTotal: M2 ≡ M3")
+            t |> equal(m2[i].OrderId,    m3[i].OrderId,    "row[{i}].OrderId:    M2 ≡ M3")
+        }
+    }
+}

--- a/tests/dasSQLITE/parity_check_16_left_join.das
+++ b/tests/dasSQLITE/parity_check_16_left_join.das
@@ -1,0 +1,102 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require daslib/option
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 16 — `_left_join` with `Option<TB>` projection.
+//
+// Every left row surfaces; unmatched ones get `none`. Multi-match on the
+// right duplicates the left row (Alice's 2 orders → 2 result rows).
+// The `into` lambda's second param is `Option<Order>` and the projection
+// can probe it via `is_some` / `is_none` (lowers to right-key IS NOT NULL
+// in SQL).
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "Alice"))
+    db |> insert(User(Id = 2, Name = "Bob"))
+    db |> insert(User(Id = 3, Name = "Carol"))
+    db |> insert(Order(Id = 10, UserId = 1, Total = 100))
+    db |> insert(Order(Id = 11, UserId = 1, Total = 250))
+    db |> insert(Order(Id = 12, UserId = 2, Total =  50))
+}
+
+def fixture_users() : array<User> {
+    var arr : array<User>
+    arr |> emplace(User(Id = 1, Name = "Alice"))
+    arr |> emplace(User(Id = 2, Name = "Bob"))
+    arr |> emplace(User(Id = 3, Name = "Carol"))
+    return <- arr
+}
+
+def fixture_orders() : array<Order> {
+    var arr : array<Order>
+    arr |> emplace(Order(Id = 10, UserId = 1, Total = 100))
+    arr |> emplace(Order(Id = 11, UserId = 1, Total = 250))
+    arr |> emplace(Order(Id = 12, UserId = 2, Total =  50))
+    return <- arr
+}
+
+def sort_rows(var rows : array<auto(R)>) : array<R> {
+    // Both Alice rows are content-identical ((Name=Alice, HasOrder=true)),
+    // so ordering between them doesn't matter — sort by Name alone.
+    rows |> sort() <| $(a, b) {
+        return a.Name < b.Name
+    }
+    return <- rows
+}
+
+[test]
+def parity_left_join_basic(t : T?) {
+    // 4 rows expected: Alice/true × 2, Bob/true, Carol/false.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _left_join(db |> select_from(type<Order>),
+                                       $(u : User, o : Order)         => u.Id == o.UserId,
+                                       $(u : User, o : Option<Order>) => (Name = u.Name, HasOrder = o |> is_some)))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _left_join(db |> select_from(type<Order>),
+                                   $(u : User, o : Order)         => u.Id == o.UserId,
+                                   $(u : User, o : Option<Order>) => (Name = u.Name, HasOrder = o |> is_some)))
+        var m3 <- (users |> _left_join(orders,
+                                       $(u : User, o : Order)         => u.Id == o.UserId,
+                                       $(u : User, o : Option<Order>) => (Name = u.Name, HasOrder = o |> is_some)))
+
+        m1 <- sort_rows(m1)
+        m2 <- sort_rows(m2)
+        m3 <- sort_rows(m3)
+
+        t |> equal(length(m1), 4, "left join row count: 4 (Alice ×2, Bob, Carol)")
+        t |> equal(length(m1), length(m2), "left join: M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "left join: M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].Name,     m2[i].Name,     "row[{i}].Name:     M1 ≡ M2")
+            t |> equal(m1[i].HasOrder, m2[i].HasOrder, "row[{i}].HasOrder: M1 ≡ M2")
+            t |> equal(m2[i].Name,     m3[i].Name,     "row[{i}].Name:     M2 ≡ M3")
+            t |> equal(m2[i].HasOrder, m3[i].HasOrder, "row[{i}].HasOrder: M2 ≡ M3")
+        }
+    }
+}

--- a/tests/dasSQLITE/parity_check_17_subqueries.das
+++ b/tests/dasSQLITE/parity_check_17_subqueries.das
@@ -1,0 +1,160 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 17 — subqueries.
+//
+// Shapes (each must produce identical row sets across the three modes):
+//   1. `_in(subquery)`     — IN
+//   2. `_not_in(subquery)` — NOT IN
+//   3. `_any(predicate)`   — EXISTS WHERE
+//   4. `_none(predicate)`  — NOT EXISTS WHERE
+//
+// The 1-arg form `subquery._any()` (test if non-empty, lifts to plain
+// `EXISTS (...)` under `_sql`) is Mode-1-only. The `_any` linq_boost
+// call_macro requires a predicate; the 1-arg "is non-empty" semantics
+// in plain linq are spelled `length(...) > 0` or `any(...)` (function
+// form), not `_any(...)`. No parity to check.
+//
+// All four covered shapes nest a `_`-binding macro inside an outer
+// `_where`'s `_`-binding macro — they regression-test the
+// `can_shadow` synthesis on linq_boost's predicate-lambda parameter.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name   : string
+    Active : bool
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "Alice", Active = true))
+    db |> insert(User(Id = 2, Name = "Bob",   Active = true))
+    db |> insert(User(Id = 3, Name = "Carol", Active = false))
+    db |> insert(Order(Id = 10, UserId = 1, Total = 100))
+    db |> insert(Order(Id = 11, UserId = 1, Total = 250))
+    db |> insert(Order(Id = 12, UserId = 2, Total =  50))
+}
+
+def fixture_users() : array<User> {
+    var arr : array<User>
+    arr |> emplace(User(Id = 1, Name = "Alice", Active = true))
+    arr |> emplace(User(Id = 2, Name = "Bob",   Active = true))
+    arr |> emplace(User(Id = 3, Name = "Carol", Active = false))
+    return <- arr
+}
+
+def fixture_orders() : array<Order> {
+    var arr : array<Order>
+    arr |> emplace(Order(Id = 10, UserId = 1, Total = 100))
+    arr |> emplace(Order(Id = 11, UserId = 1, Total = 250))
+    arr |> emplace(Order(Id = 12, UserId = 2, Total =  50))
+    return <- arr
+}
+
+def users_equal(a : array<User>; b : array<User>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i].Id != b[i].Id || a[i].Name != b[i].Name || a[i].Active != b[i].Active) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_in_subquery(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
+        let m1 <- _sql(db |> select_from(type<User>)
+                         |> _where(_.Id._in(db |> select_from(type<Order>) |> _select(_.UserId))))
+        let m2 <- (db |> select_from(type<User>)
+                     |> _where(_.Id._in(db |> select_from(type<Order>) |> _select(_.UserId))))
+        let m3 <- (users |> _where(_.Id._in(orders |> _select(_.UserId))))
+
+        t |> equal(length(m1), 2, "_in: 2 users with orders (Carol absent)")
+        t |> success(users_equal(m1, m2), "_in: M1 ≡ M2")
+        t |> success(users_equal(m2, m3), "_in: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_not_in_subquery(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
+        let m1 <- _sql(db |> select_from(type<User>)
+                         |> _where(_.Id._not_in(db |> select_from(type<Order>) |> _select(_.UserId))))
+        let m2 <- (db |> select_from(type<User>)
+                     |> _where(_.Id._not_in(db |> select_from(type<Order>) |> _select(_.UserId))))
+        let m3 <- (users |> _where(_.Id._not_in(orders |> _select(_.UserId))))
+
+        t |> equal(length(m1), 1, "_not_in: 1 orderless user (Carol)")
+        t |> success(users_equal(m1, m2), "_not_in: M1 ≡ M2")
+        t |> success(users_equal(m2, m3), "_not_in: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_any_predicate(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
+        // Uncorrelated EXISTS: when ANY order has Total > 200, every
+        // user surfaces; when none do, none surface. Predicate
+        // references only the subquery's own row through `_`.
+        let m1 <- _sql(db |> select_from(type<User>)
+                         |> _where((db |> select_from(type<Order>))._any(_.Total > 200)))
+        let m2 <- (db |> select_from(type<User>)
+                     |> _where((db |> select_from(type<Order>))._any(_.Total > 200)))
+        let m3 <- (users |> _where((orders)._any(_.Total > 200)))
+
+        t |> equal(length(m1), 3, "_any(>200): all 3 users surface")
+        t |> success(users_equal(m1, m2), "_any: M1 ≡ M2")
+        t |> success(users_equal(m2, m3), "_any: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_none_predicate(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
+        // Uncorrelated NOT EXISTS: when no order has Total > 1000, all
+        // users surface.
+        let m1 <- _sql(db |> select_from(type<User>)
+                         |> _where((db |> select_from(type<Order>))._none(_.Total > 1000)))
+        let m2 <- (db |> select_from(type<User>)
+                     |> _where((db |> select_from(type<Order>))._none(_.Total > 1000)))
+        let m3 <- (users |> _where((orders)._none(_.Total > 1000)))
+
+        t |> equal(length(m1), 3, "_none(>1000): all 3 users surface")
+        t |> success(users_equal(m1, m2), "_none: M1 ≡ M2")
+        t |> success(users_equal(m2, m3), "_none: M2 ≡ M3")
+    }
+}

--- a/tests/dasSQLITE/parity_check_18_null_handling.das
+++ b/tests/dasSQLITE/parity_check_18_null_handling.das
@@ -1,0 +1,161 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/option
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 18 — NULL handling via `Option<T>`.
+//
+// Shapes:
+//   1. Round-trip: full Option<T> fields survive Mode-1/2/3 paths
+//   2. `_where(_.Col |> is_some)`     → "Col" IS NOT NULL
+//   3. `_where(_.Col |> is_none)`     → "Col" IS NULL
+//   4. `_where(_.Col |> unwrap_or(d) >= n)`  → COALESCE("Col", ?) >= ?
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name      : string
+    @safe_when_uninitialized Age       : Option<int>
+    @safe_when_uninitialized Nick      : Option<string>
+    @safe_when_uninitialized DeletedAt : Option<int64>
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "alice", Age = some(30), Nick = none(type<string>), DeletedAt = none(type<int64>)))
+    db |> insert(User(Id = 2, Name = "bob",   Age = none(type<int>), Nick = some("bobby"), DeletedAt = none(type<int64>)))
+    db |> insert(User(Id = 3, Name = "carol", Age = some(40), Nick = some("c"), DeletedAt = some(1000l)))
+}
+
+def fixture_array() : array<User> {
+    var arr : array<User>
+    arr |> emplace(User(Id = 1, Name = "alice", Age = some(30), Nick = none(type<string>), DeletedAt = none(type<int64>)))
+    arr |> emplace(User(Id = 2, Name = "bob",   Age = none(type<int>), Nick = some("bobby"), DeletedAt = none(type<int64>)))
+    arr |> emplace(User(Id = 3, Name = "carol", Age = some(40), Nick = some("c"), DeletedAt = some(1000l)))
+    return <- arr
+}
+
+def opt_int_eq(a : Option<int>; b : Option<int>) : bool {
+    if ((a |> is_some) != (b |> is_some)) {
+        return false
+    }
+    if (a |> is_none) {
+        return true
+    }
+    return a |> unwrap == b |> unwrap
+}
+
+def opt_str_eq(a : Option<string>; b : Option<string>) : bool {
+    if ((a |> is_some) != (b |> is_some)) {
+        return false
+    }
+    if (a |> is_none) {
+        return true
+    }
+    return a |> unwrap == b |> unwrap
+}
+
+def opt_i64_eq(a : Option<int64>; b : Option<int64>) : bool {
+    if ((a |> is_some) != (b |> is_some)) {
+        return false
+    }
+    if (a |> is_none) {
+        return true
+    }
+    return a |> unwrap == b |> unwrap
+}
+
+def user_eq(a : User; b : User) : bool {
+    return (a.Id == b.Id
+        && a.Name == b.Name
+        && opt_int_eq(a.Age, b.Age)
+        && opt_str_eq(a.Nick, b.Nick)
+        && opt_i64_eq(a.DeletedAt, b.DeletedAt))
+}
+
+def users_eq(a : array<User>; b : array<User>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (!user_eq(a[i], b[i])) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_round_trip(t : T?) {
+    // Full row materialization across modes — Option<T> fields survive
+    // SQL prep/step + adapter-rail decode in Mode 1/2; trivially in Mode 3.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<User>) |> _order_by(_.Id))
+        let m2 <- (db |> select_from(type<User>) |> _order_by(_.Id))
+        let m3 <- (arr |> _order_by(_.Id))
+
+        t |> success(users_eq(m1, m2), "round-trip: M1 ≡ M2")
+        t |> success(users_eq(m2, m3), "round-trip: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_where_is_some(t : T?) {
+    // _where(_.Age |> is_some) — keeps alice and carol; drops bob.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<User>) |> _where(_.Age |> is_some) |> _order_by(_.Id))
+        let m2 <- (db |> select_from(type<User>) |> _where(_.Age |> is_some) |> _order_by(_.Id))
+        let m3 <- (arr |> _where(_.Age |> is_some) |> _order_by(_.Id))
+
+        t |> equal(length(m1), 2, "is_some: 2 rows (alice, carol)")
+        t |> success(users_eq(m1, m2), "is_some: M1 ≡ M2")
+        t |> success(users_eq(m2, m3), "is_some: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_where_is_none(t : T?) {
+    // _where(_.DeletedAt |> is_none) — keeps alive users (alice, bob); drops carol.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<User>) |> _where(_.DeletedAt |> is_none) |> _order_by(_.Id))
+        let m2 <- (db |> select_from(type<User>) |> _where(_.DeletedAt |> is_none) |> _order_by(_.Id))
+        let m3 <- (arr |> _where(_.DeletedAt |> is_none) |> _order_by(_.Id))
+
+        t |> equal(length(m1), 2, "is_none: 2 rows (alice, bob)")
+        t |> success(users_eq(m1, m2), "is_none: M1 ≡ M2")
+        t |> success(users_eq(m2, m3), "is_none: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_where_unwrap_or(t : T?) {
+    // _where(_.Age |> unwrap_or(0) >= 18) — alice (30) and carol (40) pass;
+    // bob (none → 0) fails. Mode 1: SQL `COALESCE("Age", ?) >= ?`.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+        let cutoff = 18
+
+        let m1 <- _sql(db |> select_from(type<User>) |> _where(_.Age |> unwrap_or(0) >= cutoff) |> _order_by(_.Id))
+        let m2 <- (db |> select_from(type<User>) |> _where(_.Age |> unwrap_or(0) >= cutoff) |> _order_by(_.Id))
+        let m3 <- (arr |> _where(_.Age |> unwrap_or(0) >= cutoff) |> _order_by(_.Id))
+
+        t |> equal(length(m1), 2, "unwrap_or: 2 rows (alice, carol)")
+        t |> success(users_eq(m1, m2), "unwrap_or: M1 ≡ M2")
+        t |> success(users_eq(m2, m3), "unwrap_or: M2 ≡ M3")
+    }
+}

--- a/tests/dasSQLITE/parity_check_23_foreign_keys.das
+++ b/tests/dasSQLITE/parity_check_23_foreign_keys.das
@@ -1,0 +1,121 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/option
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 23 — foreign keys.
+//
+// FK cascade / set_null are DDL/runtime SQLite behavior with no plain-linq
+// analog (plain arrays have no FK concept). This file verifies only the
+// CHAIN SHAPES introduced by the tutorial:
+//   - `_where(...) |> count()`     count after filter
+//   - `_to_array()`                terminal that materializes the chain
+//
+// Both ride on chains already covered in earlier tutorials but with the
+// specific shape tutorial 23 demonstrates. Fixture is intentionally
+// FK-free — the parity claim is about the chain emission, not the
+// DDL-driven cascade behavior.
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    UserId : int
+    Total  : float
+}
+
+[sql_table(name = "Comments")]
+struct Comment {
+    @sql_primary_key Id : int
+    @safe_when_uninitialized AuthorId : Option<int>
+    Body : string
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Order>)
+    db |> create_table(type<Comment>)
+    db |> insert(Order(Id = 100, UserId = 1, Total = 42.0f))
+    db |> insert(Order(Id = 101, UserId = 1, Total = 99.0f))
+    db |> insert(Order(Id = 102, UserId = 2, Total =  7.5f))
+    db |> insert(Comment(Id = 1000, AuthorId = none(type<int>), Body = "alice's"))
+    db |> insert(Comment(Id = 1001, AuthorId = none(type<int>), Body = "bob's"))
+}
+
+def fixture_orders() : array<Order> {
+    var arr : array<Order>
+    arr |> emplace(Order(Id = 100, UserId = 1, Total = 42.0f))
+    arr |> emplace(Order(Id = 101, UserId = 1, Total = 99.0f))
+    arr |> emplace(Order(Id = 102, UserId = 2, Total =  7.5f))
+    return <- arr
+}
+
+def fixture_comments() : array<Comment> {
+    var arr : array<Comment>
+    arr |> emplace(Comment(Id = 1000, AuthorId = none(type<int>), Body = "alice's"))
+    arr |> emplace(Comment(Id = 1001, AuthorId = none(type<int>), Body = "bob's"))
+    return <- arr
+}
+
+def comment_eq(a : Comment; b : Comment) : bool {
+    if (a.Id != b.Id || a.Body != b.Body) {
+        return false
+    }
+    if ((a.AuthorId |> is_some) != (b.AuthorId |> is_some)) {
+        return false
+    }
+    if (a.AuthorId |> is_none) {
+        return true
+    }
+    return a.AuthorId |> unwrap == b.AuthorId |> unwrap
+}
+
+def comments_eq(a : array<Comment>; b : array<Comment>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (!comment_eq(a[i], b[i])) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_where_count(t : T?) {
+    // _where(_.UserId == n) |> count() — alice has 2 orders.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_orders()
+
+        let m1 = _sql(db |> select_from(type<Order>) |> _where(_.UserId == 1) |> count())
+        let m2 = db |> select_from(type<Order>) |> _where(_.UserId == 1) |> count()
+        let m3 = arr |> _where(_.UserId == 1) |> count()
+
+        t |> equal(m1, 2,  "where|count: 2 rows for UserId=1")
+        t |> equal(m1, m2, "where|count: M1 ≡ M2")
+        t |> equal(m2, m3, "where|count: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_to_array_terminal(t : T?) {
+    // `_to_array()` is the explicit materialization terminal. Result
+    // type is the same as the default-no-terminal form (array<T>).
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_comments()
+
+        let m1 <- _sql(db |> select_from(type<Comment>) |> _to_array())
+        let m2 <- (db |> select_from(type<Comment>) |> _to_array())
+        let m3 <- (arr |> _to_array())
+
+        t |> equal(length(m1), 2, "to_array: 2 rows")
+        t |> success(comments_eq(m1, m2), "to_array: M1 ≡ M2")
+        t |> success(comments_eq(m2, m3), "to_array: M2 ≡ M3")
+    }
+}

--- a/tests/dasSQLITE/parity_check_24_indexes.das
+++ b/tests/dasSQLITE/parity_check_24_indexes.das
@@ -1,0 +1,94 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 24 — indexes.
+//
+// Indexes are transparent to query semantics — the SQLite planner uses
+// them automatically; no chain shape changes. The tutorial's first
+// chain (`_where(_.Email == s) |> _first()`) is covered by tut 05.
+// The new shape here is `_where + _order_by_descending + _to_array()`
+// over an int64 column. The DDL side (`[sql_index]` annotation,
+// `_sql_create_indexes_sql`) and unique-constraint write-path are
+// out of scope.
+
+[sql_table(name = "Users"),
+ sql_index(fields = "Email", unique = true),
+ sql_index(fields = ("City", "LastSeen")),
+ sql_index(fields = "LastSeen", name = "ix_users_lastseen")]
+struct User {
+    @sql_primary_key Id : int
+    Email    : string
+    Name     : string
+    City     : string
+    LastSeen : int64
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Email = "alice@x.com", Name = "alice", City = "SF",  LastSeen = 100l))
+    db |> insert(User(Id = 2, Email = "bob@x.com",   Name = "bob",   City = "SF",  LastSeen = 200l))
+    db |> insert(User(Id = 3, Email = "carol@x.com", Name = "carol", City = "NYC", LastSeen = 300l))
+}
+
+def fixture_array() : array<User> {
+    var arr : array<User>
+    arr |> emplace(User(Id = 1, Email = "alice@x.com", Name = "alice", City = "SF",  LastSeen = 100l))
+    arr |> emplace(User(Id = 2, Email = "bob@x.com",   Name = "bob",   City = "SF",  LastSeen = 200l))
+    arr |> emplace(User(Id = 3, Email = "carol@x.com", Name = "carol", City = "NYC", LastSeen = 300l))
+    return <- arr
+}
+
+def user_eq(a : User; b : User) : bool {
+    return (a.Id == b.Id
+        && a.Email == b.Email
+        && a.Name == b.Name
+        && a.City == b.City
+        && a.LastSeen == b.LastSeen)
+}
+
+def users_eq(a : array<User>; b : array<User>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (!user_eq(a[i], b[i])) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_where_order_desc_to_array(t : T?) {
+    // _where(_.City == "SF") narrows to alice + bob; _order_by_descending(_.LastSeen)
+    // sorts so bob (200) precedes alice (100). int64 column.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<User>)
+                         |> _where(_.City == "SF")
+                         |> _order_by_descending(_.LastSeen)
+                         |> _to_array())
+        let m2 <- (db |> select_from(type<User>)
+                     |> _where(_.City == "SF")
+                     |> _order_by_descending(_.LastSeen)
+                     |> _to_array())
+        let m3 <- (arr |> _where(_.City == "SF")
+                       |> _order_by_descending(_.LastSeen)
+                       |> _to_array())
+
+        t |> equal(length(m1), 2, "where|order_desc|to_array: 2 SF users")
+        t |> success(users_eq(m1, m2), "where|order_desc|to_array: M1 ≡ M2")
+        t |> success(users_eq(m2, m3), "where|order_desc|to_array: M2 ≡ M3")
+        // Sanity on order: bob (LastSeen=200) should precede alice (100).
+        t |> equal(m1[0].Name, "bob",   "first row: bob (LastSeen=200)")
+        t |> equal(m1[1].Name, "alice", "second row: alice (LastSeen=100)")
+    }
+}

--- a/tests/dasSQLITE/parity_check_26_custom_types.das
+++ b/tests/dasSQLITE/parity_check_26_custom_types.das
@@ -1,0 +1,206 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/option
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 26 — custom types via sql_bind / sql_extract.
+//
+// Chain shapes:
+//   - `_where(_.Status == OrderStatus.Paid)`   filter on enum field
+//   - full-row read of struct with Option<custom> field
+//
+// The adapter rail (sql_bind / sql_extract) is invisible to Mode 3 — plain
+// arrays don't go through SQL, so the custom types just live as structs.
+// Parity should hold because the round-trip preserves data.
+
+struct DateTime {
+    unix_seconds : int64
+}
+
+def sql_bind(dt : DateTime) : int64 {
+    return dt.unix_seconds
+}
+
+[unused_argument(t)]
+def sql_extract(v : int64; t : type<DateTime>) : DateTime {
+    return DateTime(unix_seconds = v)
+}
+
+struct Guid {
+    @safe_when_uninitialized bytes : array<uint8>
+}
+
+def sql_bind(g : Guid) : array<uint8> {
+    var copy : array<uint8>
+    copy := g.bytes
+    return <- copy
+}
+
+[unused_argument(t)]
+def sql_extract(var v : array<uint8>; t : type<Guid>) : Guid {
+    return Guid(bytes <- v)
+}
+
+enum OrderStatus {
+    Pending
+    Paid
+    Shipped
+    Cancelled
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    ExternalId : Guid
+    PlacedAt   : DateTime
+    Status     : OrderStatus
+    Total      : float
+}
+
+[sql_table(name = "Events")]
+struct Event {
+    @sql_primary_key Id : int
+    At : DateTime
+    @safe_when_uninitialized StartsAt : Option<DateTime>
+}
+
+def sample_bytes() : array<uint8> {
+    var bytes : array<uint8>
+    for (_ in range(16)) {
+        bytes |> push(uint8(0xAB))
+    }
+    return <- bytes
+}
+
+def fixture_orders_db(db : SqlRunner) {
+    db |> create_table(type<Order>)
+    var b1 <- sample_bytes()
+    var b2 <- sample_bytes()
+    var b3 <- sample_bytes()
+    db |> insert(Order(Id = 1, ExternalId = Guid(bytes <- b1), PlacedAt = DateTime(unix_seconds = 100l), Status = OrderStatus.Pending, Total = 10.0))
+    db |> insert(Order(Id = 2, ExternalId = Guid(bytes <- b2), PlacedAt = DateTime(unix_seconds = 200l), Status = OrderStatus.Paid,    Total = 20.0))
+    db |> insert(Order(Id = 3, ExternalId = Guid(bytes <- b3), PlacedAt = DateTime(unix_seconds = 300l), Status = OrderStatus.Paid,    Total = 30.0))
+}
+
+def fixture_orders_array() : array<Order> {
+    var arr : array<Order>
+    var b1 <- sample_bytes()
+    var b2 <- sample_bytes()
+    var b3 <- sample_bytes()
+    arr |> emplace(Order(Id = 1, ExternalId = Guid(bytes <- b1), PlacedAt = DateTime(unix_seconds = 100l), Status = OrderStatus.Pending, Total = 10.0))
+    arr |> emplace(Order(Id = 2, ExternalId = Guid(bytes <- b2), PlacedAt = DateTime(unix_seconds = 200l), Status = OrderStatus.Paid,    Total = 20.0))
+    arr |> emplace(Order(Id = 3, ExternalId = Guid(bytes <- b3), PlacedAt = DateTime(unix_seconds = 300l), Status = OrderStatus.Paid,    Total = 30.0))
+    return <- arr
+}
+
+def fixture_events_db(db : SqlRunner) {
+    db |> create_table(type<Event>)
+    db |> insert(Event(Id = 1, At = DateTime(unix_seconds = 0l), StartsAt = none(type<DateTime>)))
+    db |> insert(Event(Id = 2, At = DateTime(unix_seconds = 0l), StartsAt = some(DateTime(unix_seconds = 1713000000l))))
+}
+
+def fixture_events_array() : array<Event> {
+    var arr : array<Event>
+    arr |> emplace(Event(Id = 1, At = DateTime(unix_seconds = 0l), StartsAt = none(type<DateTime>)))
+    arr |> emplace(Event(Id = 2, At = DateTime(unix_seconds = 0l), StartsAt = some(DateTime(unix_seconds = 1713000000l))))
+    return <- arr
+}
+
+def bytes_eq(a : array<uint8>; b : array<uint8>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i] != b[i]) {
+            return false
+        }
+    }
+    return true
+}
+
+def order_eq(a : Order; b : Order) : bool {
+    return (a.Id == b.Id
+        && bytes_eq(a.ExternalId.bytes, b.ExternalId.bytes)
+        && a.PlacedAt.unix_seconds == b.PlacedAt.unix_seconds
+        && a.Status == b.Status
+        && a.Total == b.Total)
+}
+
+def orders_eq(a : array<Order>; b : array<Order>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (!order_eq(a[i], b[i])) {
+            return false
+        }
+    }
+    return true
+}
+
+def opt_dt_eq(a : Option<DateTime>; b : Option<DateTime>) : bool {
+    if ((a |> is_some) != (b |> is_some)) {
+        return false
+    }
+    if (a |> is_none) {
+        return true
+    }
+    return a._value.unix_seconds == b._value.unix_seconds
+}
+
+def event_eq(a : Event; b : Event) : bool {
+    return (a.Id == b.Id
+        && a.At.unix_seconds == b.At.unix_seconds
+        && opt_dt_eq(a.StartsAt, b.StartsAt))
+}
+
+def events_eq(a : array<Event>; b : array<Event>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (!event_eq(a[i], b[i])) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_where_enum_filter(t : T?) {
+    // Filter by enum field. SQL emits "Status" = ? with the enum lowered to int64.
+    with_sqlite(":memory:") $(db) {
+        fixture_orders_db(db)
+        var arr <- fixture_orders_array()
+
+        let m1 <- _sql(db |> select_from(type<Order>) |> _where(_.Status == OrderStatus.Paid) |> _order_by(_.Id))
+        let m2 <- (db |> select_from(type<Order>) |> _where(_.Status == OrderStatus.Paid) |> _order_by(_.Id))
+        let m3 <- (arr |> _where(_.Status == OrderStatus.Paid) |> _order_by(_.Id))
+
+        t |> equal(length(m1), 2, "enum filter: 2 paid orders")
+        t |> success(orders_eq(m1, m2), "enum filter: M1 ≡ M2")
+        t |> success(orders_eq(m2, m3), "enum filter: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_event_option_custom_type(t : T?) {
+    // Full-row read of Event whose StartsAt is Option<DateTime> (a custom type).
+    with_sqlite(":memory:") $(db) {
+        fixture_events_db(db)
+        var arr <- fixture_events_array()
+
+        let m1 <- _sql(db |> select_from(type<Event>) |> _order_by(_.Id))
+        let m2 <- (db |> select_from(type<Event>) |> _order_by(_.Id))
+        let m3 <- (arr |> _order_by(_.Id))
+
+        t |> equal(length(m1), 2, "events: 2 rows")
+        t |> success(events_eq(m1, m2), "Option<DateTime>: M1 ≡ M2")
+        t |> success(events_eq(m2, m3), "Option<DateTime>: M2 ≡ M3")
+    }
+}

--- a/tests/dasSQLITE/parity_check_28_json.das
+++ b/tests/dasSQLITE/parity_check_28_json.das
@@ -1,0 +1,255 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 28 — `@sql_json` columns and `_sql` walker
+// descent into JSON paths.
+//
+// Chain shapes (NEW vs earlier tutorials):
+//   - `_where(_.Prefs.theme == "...")`             field descent in WHERE
+//   - `_select(_.Prefs.theme)`                     field descent in SELECT
+//   - `_select((Name = ..., Theme = _.Prefs.theme))` mixed projection
+//   - `_where(_.Prefs.notify == true) |> count()`  JSON predicate + count
+//   - `_where(_.Profile.Addr.City == "...")`        nested struct path
+//
+// In Mode 1 these lower to `json_extract("Col", '$.path')`. In Modes 2/3
+// the field access is plain daslang struct/tuple access on the
+// materialized values. Parity hinges on the SQL JSON round-trip
+// preserving the values exactly (and on the nested path producing the
+// same field as direct access).
+//
+// `@sql_blob` is opaque to `_sql` (compile error to descend); no chain
+// to verify. Out of scope.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name  : string
+    @sql_json Prefs : tuple<theme : string; lang : string; notify : bool>
+}
+
+def fixture_users_db(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "alice", Prefs = (theme = "dark",  lang = "en", notify = true)))
+    db |> insert(User(Id = 2, Name = "bob",   Prefs = (theme = "light", lang = "ru", notify = false)))
+    db |> insert(User(Id = 3, Name = "carol", Prefs = (theme = "dark",  lang = "fr", notify = false)))
+}
+
+def fixture_users_array() : array<User> {
+    var arr : array<User>
+    arr |> emplace(User(Id = 1, Name = "alice", Prefs = (theme = "dark",  lang = "en", notify = true)))
+    arr |> emplace(User(Id = 2, Name = "bob",   Prefs = (theme = "light", lang = "ru", notify = false)))
+    arr |> emplace(User(Id = 3, Name = "carol", Prefs = (theme = "dark",  lang = "fr", notify = false)))
+    return <- arr
+}
+
+def user_eq(a : User; b : User) : bool {
+    return (a.Id == b.Id
+        && a.Name == b.Name
+        && a.Prefs.theme == b.Prefs.theme
+        && a.Prefs.lang == b.Prefs.lang
+        && a.Prefs.notify == b.Prefs.notify)
+}
+
+def users_eq(a : array<User>; b : array<User>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (!user_eq(a[i], b[i])) {
+            return false
+        }
+    }
+    return true
+}
+
+def sort_by_id(var users : array<User>) : array<User> {
+    users |> sort() <| $(a, b) {
+        return a.Id < b.Id
+    }
+    return <- users
+}
+
+[test]
+def parity_json_where_descend(t : T?) {
+    // _where(_.Prefs.theme == "dark") — keeps alice + carol.
+    with_sqlite(":memory:") $(db) {
+        fixture_users_db(db)
+        var arr <- fixture_users_array()
+
+        var m1 <- _sql(db |> select_from(type<User>) |> _where(_.Prefs.theme == "dark"))
+        var m2 <- (db |> select_from(type<User>) |> _where(_.Prefs.theme == "dark"))
+        var m3 <- (arr |> _where(_.Prefs.theme == "dark"))
+
+        m1 <- sort_by_id(m1)
+        m2 <- sort_by_id(m2)
+        m3 <- sort_by_id(m3)
+
+        t |> equal(length(m1), 2, "json where: 2 dark users")
+        t |> success(users_eq(m1, m2), "json where: M1 ≡ M2")
+        t |> success(users_eq(m2, m3), "json where: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_json_select_scalar(t : T?) {
+    // _select(_.Prefs.theme) — projects the json-path leaf as array<string>.
+    with_sqlite(":memory:") $(db) {
+        fixture_users_db(db)
+        var arr <- fixture_users_array()
+
+        var m1 <- _sql(db |> select_from(type<User>) |> _select(_.Prefs.theme))
+        var m2 <- (db |> select_from(type<User>) |> _select(_.Prefs.theme))
+        var m3 <- (arr |> _select(_.Prefs.theme))
+
+        m1 |> sort()
+        m2 |> sort()
+        m3 |> sort()
+
+        t |> equal(length(m1), 3, "json select scalar: 3 themes")
+        t |> equal(length(m1), length(m2), "json select scalar: M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "json select scalar: M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i], m2[i], "theme[{i}]: M1 ≡ M2")
+            t |> equal(m2[i], m3[i], "theme[{i}]: M2 ≡ M3")
+        }
+    }
+}
+
+[test]
+def parity_json_select_named_tuple(t : T?) {
+    // _select((Name = _.Name, Theme = _.Prefs.theme, Notify = _.Prefs.notify))
+    // Tuple shape (string, string, bool) — distinct from earlier tests.
+    with_sqlite(":memory:") $(db) {
+        fixture_users_db(db)
+        var arr <- fixture_users_array()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _select((Name = _.Name, Theme = _.Prefs.theme, Notify = _.Prefs.notify)))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _select((Name = _.Name, Theme = _.Prefs.theme, Notify = _.Prefs.notify)))
+        var m3 <- (arr |> _select((Name = _.Name, Theme = _.Prefs.theme, Notify = _.Prefs.notify)))
+
+        m1 |> sort() <| $(a, b) {
+            return a.Name < b.Name
+        }
+        m2 |> sort() <| $(a, b) {
+            return a.Name < b.Name
+        }
+        m3 |> sort() <| $(a, b) {
+            return a.Name < b.Name
+        }
+
+        t |> equal(length(m1), 3, "json named-tuple: 3 rows")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].Name,   m2[i].Name,   "row[{i}].Name:   M1 ≡ M2")
+            t |> equal(m1[i].Theme,  m2[i].Theme,  "row[{i}].Theme:  M1 ≡ M2")
+            t |> equal(m1[i].Notify, m2[i].Notify, "row[{i}].Notify: M1 ≡ M2")
+            t |> equal(m2[i].Name,   m3[i].Name,   "row[{i}].Name:   M2 ≡ M3")
+            t |> equal(m2[i].Theme,  m3[i].Theme,  "row[{i}].Theme:  M2 ≡ M3")
+            t |> equal(m2[i].Notify, m3[i].Notify, "row[{i}].Notify: M2 ≡ M3")
+        }
+    }
+}
+
+[test]
+def parity_json_where_count(t : T?) {
+    // _where(_.Prefs.notify == true) |> count()
+    with_sqlite(":memory:") $(db) {
+        fixture_users_db(db)
+        var arr <- fixture_users_array()
+
+        let m1 = _sql(db |> select_from(type<User>) |> _where(_.Prefs.notify == true) |> count())
+        let m2 = db |> select_from(type<User>) |> _where(_.Prefs.notify == true) |> count()
+        let m3 = arr |> _where(_.Prefs.notify == true) |> count()
+
+        t |> equal(m1, 1,  "json where|count: 1 notifiable user (alice)")
+        t |> equal(m1, m2, "json where|count: M1 ≡ M2")
+        t |> equal(m2, m3, "json where|count: M2 ≡ M3")
+    }
+}
+
+// --- Nested struct paths ---
+
+struct Address {
+    City : string
+    Zip  : string
+}
+struct Profile {
+    Addr : Address
+    Bio  : string
+}
+
+[sql_table(name = "Accounts")]
+struct Account {
+    @sql_primary_key Id : int
+    @sql_json Profile : Profile
+}
+
+def account_eq(a : Account; b : Account) : bool {
+    return (a.Id == b.Id
+        && a.Profile.Addr.City == b.Profile.Addr.City
+        && a.Profile.Addr.Zip == b.Profile.Addr.Zip
+        && a.Profile.Bio == b.Profile.Bio)
+}
+
+def accounts_eq(a : array<Account>; b : array<Account>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (!account_eq(a[i], b[i])) {
+            return false
+        }
+    }
+    return true
+}
+
+def fixture_accounts_db(db : SqlRunner) {
+    db |> create_table(type<Account>)
+    db |> insert(Account(Id = 1, Profile = Profile(Addr = Address(City = "SF", Zip = "94000"), Bio = "engineer")))
+    db |> insert(Account(Id = 2, Profile = Profile(Addr = Address(City = "NYC", Zip = "10000"), Bio = "writer")))
+    db |> insert(Account(Id = 3, Profile = Profile(Addr = Address(City = "SF", Zip = "94100"), Bio = "designer")))
+}
+
+def fixture_accounts_array() : array<Account> {
+    var arr : array<Account>
+    arr |> emplace(Account(Id = 1, Profile = Profile(Addr = Address(City = "SF", Zip = "94000"), Bio = "engineer")))
+    arr |> emplace(Account(Id = 2, Profile = Profile(Addr = Address(City = "NYC", Zip = "10000"), Bio = "writer")))
+    arr |> emplace(Account(Id = 3, Profile = Profile(Addr = Address(City = "SF", Zip = "94100"), Bio = "designer")))
+    return <- arr
+}
+
+def sort_accounts_by_id(var rows : array<Account>) : array<Account> {
+    rows |> sort() <| $(a, b) {
+        return a.Id < b.Id
+    }
+    return <- rows
+}
+
+[test]
+def parity_json_nested_path(t : T?) {
+    // _where(_.Profile.Addr.City == "SF") — 2-level nested path through
+    // a JSON-stored struct. SQL emits json_extract("Profile", '$.Addr.City').
+    with_sqlite(":memory:") $(db) {
+        fixture_accounts_db(db)
+        var arr <- fixture_accounts_array()
+
+        var m1 <- _sql(db |> select_from(type<Account>) |> _where(_.Profile.Addr.City == "SF"))
+        var m2 <- (db |> select_from(type<Account>) |> _where(_.Profile.Addr.City == "SF"))
+        var m3 <- (arr |> _where(_.Profile.Addr.City == "SF"))
+
+        m1 <- sort_accounts_by_id(m1)
+        m2 <- sort_accounts_by_id(m2)
+        m3 <- sort_accounts_by_id(m3)
+
+        t |> equal(length(m1), 2, "nested json path: 2 SF accounts")
+        t |> success(accounts_eq(m1, m2), "nested json path: M1 ≡ M2")
+        t |> success(accounts_eq(m2, m3), "nested json path: M2 ≡ M3")
+    }
+}

--- a/tests/dasSQLITE/parity_check_32_sql_functions.das
+++ b/tests/dasSQLITE/parity_check_32_sql_functions.das
@@ -1,0 +1,102 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 32 — `[sql_function]` user-defined SQL scalars.
+//
+// Chain shape: `_where(score(_.Hp, _.Armor) >= 100.0lf)` — a daslang
+// function tagged `[sql_function]` invoked inside the predicate. The
+// annotation does two things at once:
+//   1. Auto-registers the function as a SQLite scalar at open() time
+//   2. Tells the `_sql` analyzer it's safe to lower the call to SQL
+//      (instead of falling back to per-row binds)
+//
+// Mode 1 emits `WHERE score("Hp", "Armor") >= ?` — SQLite calls back
+// into the registered trampoline.
+// Mode 2/3 just call `score(...)` as a normal daslang function over each
+// row. Same function body, different execution path.
+//
+// Parity hinges on `[sql_function]` being a TRANSPARENT annotation: the
+// function works identically from daslang code regardless of the
+// SQL-binding side.
+
+[sql_function(deterministic=true)]
+def score(hp : float; armor : int) : double {
+    return double(hp) * (1.0lf - double(armor) / 100.0lf)
+}
+
+[sql_table(name = "Enemies")]
+struct Enemy {
+    @sql_primary_key Id : int
+    Name : string
+    Hp   : float
+    Armor : int
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Enemy>)
+    db |> insert(Enemy(Id = 1, Name = "goblin", Hp = 100.0f, Armor = 10))   // score = 90
+    db |> insert(Enemy(Id = 2, Name = "ogre",   Hp = 800.0f, Armor = 30))   // score = 560
+    db |> insert(Enemy(Id = 3, Name = "dragon", Hp = 5000.0f, Armor = 60))  // score = 2000
+}
+
+def fixture_array() : array<Enemy> {
+    var arr : array<Enemy>
+    arr |> emplace(Enemy(Id = 1, Name = "goblin", Hp = 100.0f, Armor = 10))
+    arr |> emplace(Enemy(Id = 2, Name = "ogre",   Hp = 800.0f, Armor = 30))
+    arr |> emplace(Enemy(Id = 3, Name = "dragon", Hp = 5000.0f, Armor = 60))
+    return <- arr
+}
+
+def enemy_eq(a : Enemy; b : Enemy) : bool {
+    return (a.Id == b.Id
+        && a.Name == b.Name
+        && a.Hp == b.Hp
+        && a.Armor == b.Armor)
+}
+
+def enemies_eq(a : array<Enemy>; b : array<Enemy>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (!enemy_eq(a[i], b[i])) {
+            return false
+        }
+    }
+    return true
+}
+
+def sort_by_id(var rows : array<Enemy>) : array<Enemy> {
+    rows |> sort() <| $(a, b) {
+        return a.Id < b.Id
+    }
+    return <- rows
+}
+
+[test]
+def parity_sql_function_in_where(t : T?) {
+    // _where(score(_.Hp, _.Armor) >= 100.0lf) — keeps ogre + dragon
+    // (scores 560 and 2000); drops goblin (score 90).
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var m1 <- _sql(db |> select_from(type<Enemy>) |> _where(score(_.Hp, _.Armor) >= 100.0lf))
+        var m2 <- (db |> select_from(type<Enemy>) |> _where(score(_.Hp, _.Armor) >= 100.0lf))
+        var m3 <- (arr |> _where(score(_.Hp, _.Armor) >= 100.0lf))
+
+        m1 <- sort_by_id(m1)
+        m2 <- sort_by_id(m2)
+        m3 <- sort_by_id(m3)
+
+        t |> equal(length(m1), 2, "sql_function where: 2 strong enemies")
+        t |> success(enemies_eq(m1, m2), "sql_function where: M1 ≡ M2")
+        t |> success(enemies_eq(m2, m3), "sql_function where: M2 ≡ M3")
+    }
+}

--- a/tests/dasSQLITE/parity_check_35_streaming.das
+++ b/tests/dasSQLITE/parity_check_35_streaming.das
@@ -1,0 +1,177 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 35 — `_each_sql` streaming iteration.
+//
+// Same chain shape as `_sql(...)`, but the terminal is `iterator<T>`
+// instead of `array<T>`. The parity claim is that streaming and
+// materialization produce IDENTICAL row sequences:
+//
+//   M1a (materialized) : var rows <- _sql(chain); iterate rows
+//   M1b (streamed)     : for (r in _each_sql(chain)) { collect }
+//   M2                 : for (r in (db |> chain))   { collect }
+//   M3                 : for (r in (arr |> chain))  { collect }
+//
+// The fourth shape (M3) is plain-array iteration — no SQL, no streaming
+// machinery. M1/M2/M3 row order matches the chain's `_order_by`. M1a vs
+// M1b is the interesting comparison: does `_each_sql` match `_sql`
+// row-for-row at the same chain.
+
+[sql_table(name = "Logs")]
+struct LogEntry {
+    @sql_primary_key Id : int
+    Severity : int
+    Message  : string
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<LogEntry>)
+    for (i in range(20)) {
+        db |> insert(LogEntry(
+            Id = i + 1,
+            Severity = (i % 4),
+            Message = "msg #{i}"))
+    }
+}
+
+def fixture_array() : array<LogEntry> {
+    var arr : array<LogEntry>
+    for (i in range(20)) {
+        arr |> emplace(LogEntry(
+            Id = i + 1,
+            Severity = (i % 4),
+            Message = "msg #{i}"))
+    }
+    return <- arr
+}
+
+def log_eq(a : LogEntry; b : LogEntry) : bool {
+    return (a.Id == b.Id
+        && a.Severity == b.Severity
+        && a.Message == b.Message)
+}
+
+def logs_eq(a : array<LogEntry>; b : array<LogEntry>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (!log_eq(a[i], b[i])) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def parity_each_sql_vs_materialized(t : T?) {
+    // Same `_where + _order_by` chain, four delivery shapes. Streaming
+    // (M1b) must match the materialized variant (M1a) row-for-row.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var m1a <- _sql(db |> select_from(type<LogEntry>) |> _where(_.Severity >= 2) |> _order_by(_.Id))
+
+        var m1b : array<LogEntry>
+        for (e in _each_sql(db |> select_from(type<LogEntry>) |> _where(_.Severity >= 2) |> _order_by(_.Id))) {
+            m1b |> push(e)
+        }
+
+        var m2 : array<LogEntry>
+        for (e in (db |> select_from(type<LogEntry>) |> _where(_.Severity >= 2) |> _order_by(_.Id))) {
+            m2 |> push(e)
+        }
+
+        var m3 : array<LogEntry>
+        for (e in (arr |> _where(_.Severity >= 2) |> _order_by(_.Id))) {
+            m3 |> push(e)
+        }
+
+        t |> equal(length(m1a), 10, "stream: 10 severe logs")
+        t |> success(logs_eq(m1a, m1b), "stream: M1a (materialized) ≡ M1b (streamed)")
+        t |> success(logs_eq(m1b, m2),  "stream: M1b ≡ M2")
+        t |> success(logs_eq(m2, m3),   "stream: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_each_sql_early_break(t : T?) {
+    // Iterate until predicate, then break. The first matching row's Id
+    // must be the same across modes.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var first_id_m1 = 0
+        for (e in _each_sql(db |> select_from(type<LogEntry>) |> _order_by(_.Id))) {
+            if (e.Severity == 3) {
+                first_id_m1 = e.Id
+                break
+            }
+        }
+
+        var first_id_m2 = 0
+        for (e in (db |> select_from(type<LogEntry>) |> _order_by(_.Id))) {
+            if (e.Severity == 3) {
+                first_id_m2 = e.Id
+                break
+            }
+        }
+
+        var first_id_m3 = 0
+        for (e in (arr |> _order_by(_.Id))) {
+            if (e.Severity == 3) {
+                first_id_m3 = e.Id
+                break
+            }
+        }
+
+        t |> equal(first_id_m1, 4, "early break: first severity=3 is Id=4")
+        t |> equal(first_id_m1, first_id_m2, "early break: M1 ≡ M2")
+        t |> equal(first_id_m2, first_id_m3, "early break: M2 ≡ M3")
+
+        // Sanity that the iterator's finally ran — a subsequent INSERT must succeed.
+        db |> insert(LogEntry(Id = 100, Severity = 0, Message = "after break"))
+        let n = db |> query_scalar("SELECT COUNT(*) FROM Logs", type<int>)
+        t |> equal(n, 21, "after break: insert succeeded (finally ran)")
+    }
+}
+
+[test]
+def parity_each_sql_scalar_projection(t : T?) {
+    // _select(_.Message) — streaming a single-column projection.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var m1 : array<string>
+        for (s in _each_sql(db |> select_from(type<LogEntry>) |> _order_by(_.Id) |> _select(_.Message))) {
+            m1 |> push(s)
+        }
+
+        var m2 : array<string>
+        for (s in (db |> select_from(type<LogEntry>) |> _order_by(_.Id) |> _select(_.Message))) {
+            m2 |> push(s)
+        }
+
+        var m3 : array<string>
+        for (s in (arr |> _order_by(_.Id) |> _select(_.Message))) {
+            m3 |> push(s)
+        }
+
+        t |> equal(length(m1), 20, "scalar stream: 20 messages")
+        t |> equal(length(m1), length(m2), "scalar stream: M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "scalar stream: M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i], m2[i], "msg[{i}]: M1 ≡ M2")
+            t |> equal(m2[i], m3[i], "msg[{i}]: M2 ≡ M3")
+        }
+    }
+}

--- a/tests/dasSQLITE/parity_check_36_attach.das
+++ b/tests/dasSQLITE/parity_check_36_attach.das
@@ -1,0 +1,128 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Parity check for tutorial 36 — ATTACH DATABASE.
+//
+// Chain shapes (`select_from + _where`) are unchanged from earlier
+// tutorials; the attach-specific concept is the schema-qualified runner
+// produced by `with_attached(db, path, name) $(scoped) { ... }` (or
+// the manual `attach + with_schema(name)` pair).
+//
+// Parity claim: a chain run through a schema-qualified runner emits
+// `"<schema>"."<table>"` instead of `"<table>"`, but the result rows are
+// the same data. M3 (plain array) doesn't go through the attach rail at
+// all — it just iterates the source array. So:
+//
+//   M1 : `_sql(scoped |> chain)` over an attached :memory: DB
+//   M2 : `scoped |> chain`       over the same scoped runner
+//   M3 : `arr |> chain`          over the array used to populate it
+//
+// If `with_schema`'s rewriter mangles a chain in a way that changes
+// row content, this test catches it.
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name   : string
+    Active : bool
+}
+
+def fixture_users(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "Alice", Active = true))
+    db |> insert(User(Id = 2, Name = "Bob",   Active = true))
+    db |> insert(User(Id = 3, Name = "Carol", Active = false))
+    db |> insert(User(Id = 4, Name = "Dave",  Active = false))
+}
+
+def fixture_array() : array<User> {
+    var arr : array<User>
+    arr |> emplace(User(Id = 1, Name = "Alice", Active = true))
+    arr |> emplace(User(Id = 2, Name = "Bob",   Active = true))
+    arr |> emplace(User(Id = 3, Name = "Carol", Active = false))
+    arr |> emplace(User(Id = 4, Name = "Dave",  Active = false))
+    return <- arr
+}
+
+def user_eq(a : User; b : User) : bool {
+    return (a.Id == b.Id
+        && a.Name == b.Name
+        && a.Active == b.Active)
+}
+
+def users_eq(a : array<User>; b : array<User>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (!user_eq(a[i], b[i])) {
+            return false
+        }
+    }
+    return true
+}
+
+def sort_by_id(var rows : array<User>) : array<User> {
+    rows |> sort() <| $(a, b) {
+        return a.Id < b.Id
+    }
+    return <- rows
+}
+
+[test]
+def parity_attach_with_attached(t : T?) {
+    // _where(_.Active) over a schema-qualified runner. Should produce
+    // alice + bob (Id=1, Id=2).
+    with_sqlite(":memory:") $(db) {
+        var arr <- fixture_array()
+
+        db |> with_attached(":memory:", "tenant") $(scoped) {
+            fixture_users(scoped)
+
+            var m1 <- _sql(scoped |> select_from(type<User>) |> _where(_.Active))
+            var m2 <- (scoped |> select_from(type<User>) |> _where(_.Active))
+            var m3 <- (arr |> _where(_.Active))
+
+            m1 <- sort_by_id(m1)
+            m2 <- sort_by_id(m2)
+            m3 <- sort_by_id(m3)
+
+            t |> equal(length(m1), 2, "attached _where: 2 active users")
+            t |> success(users_eq(m1, m2), "attached _where: M1 ≡ M2")
+            t |> success(users_eq(m2, m3), "attached _where: M2 ≡ M3")
+        }
+    }
+}
+
+[test]
+def parity_attach_manual(t : T?) {
+    // Manual `attach + with_schema + detach` lifecycle. Same parity claim
+    // as `with_attached`; just exercises the lower-level surface.
+    with_sqlite(":memory:") $(db) {
+        var arr <- fixture_array()
+
+        db |> attach(":memory:", "archive")
+        db |> with_schema("archive") $(scoped) {
+            fixture_users(scoped)
+
+            var m1 <- _sql(scoped |> select_from(type<User>) |> _where(!_.Active))
+            var m2 <- (scoped |> select_from(type<User>) |> _where(!_.Active))
+            var m3 <- (arr |> _where(!_.Active))
+
+            m1 <- sort_by_id(m1)
+            m2 <- sort_by_id(m2)
+            m3 <- sort_by_id(m3)
+
+            t |> equal(length(m1), 2, "manual attach _where !Active: 2 inactive users")
+            t |> success(users_eq(m1, m2), "manual attach: M1 ≡ M2")
+            t |> success(users_eq(m2, m3), "manual attach: M2 ≡ M3")
+        }
+        db |> detach("archive")
+    }
+}

--- a/tests/dasSQLITE/parity_check_40_fts5.das
+++ b/tests/dasSQLITE/parity_check_40_fts5.das
@@ -1,0 +1,123 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require daslib/linq_boost
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+require daslib/fts5_query
+
+// Parity check for tutorial 40 — FTS5 full-text search.
+//
+// The interesting parity claim: `text_match(col, query)` produces the
+// SAME hit set whether evaluated by SQLite's FTS5 engine (M1, lowered
+// to `MATCH ?`) or by `daslib/fts5_query`'s in-memory parser (M2/M3,
+// plain daslang call per-row).
+//
+// Chain shape: `_where(_.Body |> text_match(q))`. The Rank column is
+// SQL-only (filled by SQLite from BM25) — it's left at default in M2/M3,
+// so parity is on the set of matching Body strings, not on Rank values.
+//
+// Coverage:
+//   - whitespace-AND  ("quick fox")
+//   - prefix          ("quick*")
+//   - phrase          ("\"quick brown\"")
+//   - boolean OR      ("fox OR boot")
+//   - NEAR            ("NEAR(quick fox, 3)")
+
+[sql_fts5(name = "docs_idx")]
+struct Doc {
+    Body : string
+    @sql_fts_rank Rank : float
+}
+
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<Doc>)
+    db |> insert(Doc(Body = "The quick brown fox jumps over the lazy dog"))
+    db |> insert(Doc(Body = "A swift red fox escaped the hounds at dawn"))
+    db |> insert(Doc(Body = "Quicksand swallowed the hiker's boot yesterday"))
+    db |> insert(Doc(Body = "Code review is the most cost-effective bug filter"))
+}
+
+def fixture_array() : array<Doc> {
+    var arr : array<Doc>
+    arr |> emplace(Doc(Body = "The quick brown fox jumps over the lazy dog"))
+    arr |> emplace(Doc(Body = "A swift red fox escaped the hounds at dawn"))
+    arr |> emplace(Doc(Body = "Quicksand swallowed the hiker's boot yesterday"))
+    arr |> emplace(Doc(Body = "Code review is the most cost-effective bug filter"))
+    return <- arr
+}
+
+def bodies_of(rows : array<Doc>) : array<string> {
+    var out : array<string>
+    for (r in rows) {
+        out |> push(r.Body)
+    }
+    out |> sort()
+    return <- out
+}
+
+def strings_eq(a : array<string>; b : array<string>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i] != b[i]) {
+            return false
+        }
+    }
+    return true
+}
+
+def assert_text_match_parity(t : T?; query : string; expected_count : int; tag : string) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var arr <- fixture_array()
+
+        var m1 <- _sql(db |> select_from(type<Doc>) |> _where(_.Body |> text_match(query)))
+        var m2 <- (db |> select_from(type<Doc>) |> _where(_.Body |> text_match(query)))
+        var m3 <- (arr |> _where(_.Body |> text_match(query)))
+
+        let b1 <- bodies_of(m1)
+        let b2 <- bodies_of(m2)
+        let b3 <- bodies_of(m3)
+
+        t |> equal(length(b1), expected_count, "{tag}: M1 hit count")
+        t |> success(strings_eq(b1, b2), "{tag}: M1 ≡ M2 (bodies)")
+        t |> success(strings_eq(b2, b3), "{tag}: M2 ≡ M3 (bodies)")
+    }
+}
+
+[test]
+def parity_text_match_and(t : T?) {
+    // Whitespace = AND. "quick fox" needs both tokens. Hits doc 1
+    // ("quick brown fox jumps") only — doc 3 has "quicksand" but no "fox".
+    assert_text_match_parity(t, "quick fox", 1, "AND quick+fox")
+}
+
+[test]
+def parity_text_match_prefix(t : T?) {
+    // "quick*" matches "quick" + "quicksand". Docs 1 and 3.
+    assert_text_match_parity(t, "quick*", 2, "prefix quick*")
+}
+
+[test]
+def parity_text_match_phrase(t : T?) {
+    // Quoted phrase = adjacent tokens in order. Only doc 1.
+    assert_text_match_parity(t, "\"quick brown\"", 1, "phrase quick brown")
+}
+
+[test]
+def parity_text_match_or(t : T?) {
+    // "fox OR boot" — docs 1, 2 (fox), 3 (boot). Three hits.
+    assert_text_match_parity(t, "fox OR boot", 3, "OR fox|boot")
+}
+
+[test]
+def parity_text_match_near(t : T?) {
+    // NEAR(quick fox, 3) — both tokens within 3 of each other. Doc 1
+    // ("quick brown fox" — distance 2) qualifies. Doc 3 has only
+    // "quicksand" (no "fox"), doesn't qualify.
+    assert_text_match_parity(t, "NEAR(quick fox, 3)", 1, "NEAR quick fox 3")
+}

--- a/tests/dasSQLITE/test_33_take_skip.das
+++ b/tests/dasSQLITE/test_33_take_skip.das
@@ -46,12 +46,27 @@ def test_skip_emits_limit_neg1_offset(t : T?) {
 }
 
 [test]
-def test_take_then_skip_emits_limit_and_offset(t : T?) {
+def test_take_then_skip_emits_subquery(t : T?) {
     var _db = SqlRunner()
+    // Multi-Q lowering: `take(3) |> skip(1)` is divergent from canonical SQL
+    // phase order (linq positional says "take 3, drop 1"; flat `LIMIT 3 OFFSET 1`
+    // would skip-then-take = 3 rows). Lower to nested SELECT so all three modes
+    // agree (`max(0, n-m)` rows).
     let sql = _sql_text(_db |> select_from(type<Car>) |> take(3) |> skip(1))
     t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Price\" FROM (SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" LIMIT ?) AS \"t0\" LIMIT -1 OFFSET ?",
+        "take + skip lowers to nested SELECT (take in inner, skip in outer)")
+}
+
+[test]
+def test_skip_then_take_emits_flat_limit_offset(t : T?) {
+    var _db = SqlRunner()
+    // Canonical pagination: `skip(m) |> take(n)` matches SQL `LIMIT n OFFSET m`
+    // semantics (skip-then-take). Stays a flat SELECT.
+    let sql = _sql_text(_db |> select_from(type<Car>) |> skip(1) |> take(3))
+    t |> equal(sql,
         "SELECT \"Id\", \"Name\", \"Price\" FROM \"Cars\" LIMIT ? OFFSET ?",
-        "take + skip combine into LIMIT … OFFSET …")
+        "skip + take stays flat — canonical pagination shape")
 }
 
 [test]
@@ -88,13 +103,38 @@ def test_skip_runtime_skips_n_rows(t : T?) {
 }
 
 [test]
-def test_take_and_skip_combined_runtime(t : T?) {
+def test_take_then_skip_combined_runtime(t : T?) {
     with_sqlite(":memory:") $(db) {
         fixture(db)
+        // Multi-Q lowering: `take(2) |> skip(1)` = "take 2 rows, then drop 1".
+        // n - m = 1 row remains (BMW taken, skipped, leaving Audi).
         let rows <- _sql(db |> select_from(type<Car>) |> take(2) |> skip(1))
-        t |> equal(length(rows), 2, "take(2) skip(1) returns 2 rows starting from row 1")
+        t |> equal(length(rows), 1, "take(2) |> skip(1) returns max(0, n-m) = 1 row")
+        t |> equal(rows[0].Name, "Audi",  "the second row of the inner take, after dropping the first")
+    }
+}
+
+[test]
+def test_skip_then_take_combined_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Canonical pagination: `skip(1) |> take(2)` = "skip 1, take next 2".
+        let rows <- _sql(db |> select_from(type<Car>) |> skip(1) |> take(2))
+        t |> equal(length(rows), 2, "skip(1) |> take(2) returns 2 rows starting from row 1")
         t |> equal(rows[0].Name, "Audi",  "row[1]")
         t |> equal(rows[1].Name, "Tesla", "row[2]")
+    }
+}
+
+[test]
+def test_take_then_select_then_aggregate_runtime(t : T?) {
+    // bad12 promoted to a positive case: multi-Q lowers `take(n) |> _select(...) |> sum`
+    // to `SELECT SUM(col) FROM (SELECT col FROM table LIMIT n)`. Sum of the first n
+    // rows' projected column.
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let total = _sql(db |> select_from(type<Car>) |> take(2) |> _select(_.Price) |> sum())
+        t |> equal(total, 100 + 200, "SUM over first 2 rows' Price (BMW+Audi)")
     }
 }
 

--- a/tests/linq/test_linq_aggregation.das
+++ b/tests/linq/test_linq_aggregation.das
@@ -251,24 +251,18 @@ def test_average(t : T?) {
         var query = average(
             [iterator for(x in 0..5); x]
         )
-        t |> equal(query, 2)
+        t |> equal(query, 2.0lf)
     }
-    t |> run("complex average") @(t : T?) {
+    t |> run("float average") @(t : T?) {
         var queryf = average(
             [iterator for(x in 0..5); float(x)]
         )
-        t |> equal(queryf, 2.0)
-    }
-    t |> run("complex average") @(t : T?) {
-        var qcomplex = average(
-            [iterator for(x in 0..5); ComplexType(a = [x, x * 10])]
-        )
-        t |> success(qcomplex.a.Equal([2, 20]))
+        t |> equal(queryf, 2.0lf)
     }
     t |> run("average from array of floats") @(t : T?) {
         var floats = [1.0, 2.0, 3.0, 4.0, 5.0]
         var avgFloat = average(floats.to_sequence())
-        t |> equal(avgFloat, 3.0)
+        t |> equal(avgFloat, 3.0lf)
     }
 }
 

--- a/tests/linq/test_linq_bugs.das
+++ b/tests/linq/test_linq_bugs.das
@@ -445,7 +445,7 @@ def test_aggregation_empty(t : T?) {
         var avg = average(
             [iterator for(x in 0..1); 42]
         )
-        t |> equal(avg, 42)
+        t |> equal(avg, 42.0lf)
     }
 }
 

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -272,8 +272,8 @@ def test_generic_fold_aggregates(t : T?) {
             .average()
             ._fold()
         )
-        t |> equal(typeinfo typename(t2), "int")
-        t |> equal(4, t2)
+        t |> equal(typeinfo typename(t2), "double")
+        t |> equal(4.5lf, t2)
     }
     t |> run("min_max_avarage fold") @(t : T?) {
         var (tmin, tmax, tavg) = ([1, 2, 3, 4, 5, 6, 7, 8]

--- a/tutorials/sql/05-parametrized.das
+++ b/tutorials/sql/05-parametrized.das
@@ -18,9 +18,8 @@ require sqlite/sqlite_linq
 //
 //  2. For raw SQL (migrations, ad-hoc queries, statements `_sql` can't
 //     translate), the `query_one(sql, type<T>, args...)` family takes
-//     positional `?` arguments via variadic trailing args (chunk 3 ships
-//     0..3 args; named-tuple bind for `:name` placeholders ships in a
-//     follow-up).
+//     positional `?` arguments via variadic trailing args (0..3 args
+//     supported; named-tuple bind for `:name` placeholders is planned).
 
 [sql_table(name = "Cars")]
 struct Car {
@@ -62,8 +61,8 @@ def main() {
         to_log(LOG_INFO, "Raw lookup ID = {raw.Id}, name = {raw.Name}\n")
 
         // ── Multi-arg positional bind ────────────────────────────────────
-        // Up to 3 positional args this chunk; named-tuple `(id=…, name=…)`
-        // form for `:name` placeholders is a chunk-4 follow-up.
+        // Up to 3 positional args supported today; named-tuple
+        // `(id=…, name=…)` form for `:name` placeholders is planned.
         let multi = db |> query_one(
             "SELECT \"Id\", \"Name\", \"Price\" FROM Cars WHERE Id = ? AND Name = ?",
             type<Car>, 2, "Audi")

--- a/tutorials/sql/09-select.das
+++ b/tutorials/sql/09-select.das
@@ -7,7 +7,7 @@ require sqlite/sqlite_linq
 // Tutorial 09 — `_select` projections.
 //
 // `_select(...)` controls what columns the SQL emits and what shape the
-// result has. Three forms ship in chunk 3:
+// result has. Three forms are supported:
 //
 //   - default (no _select): SELECT all columns, materialize as the source
 //                           struct  →  array<Car>
@@ -21,8 +21,7 @@ require sqlite/sqlite_linq
 //
 // The named-tuple form lets you rename columns at the result-type level
 // (`(Identifier=_.Id, Label=_.Name)` returns rows whose `Identifier` field
-// holds the underlying `Id`). Struct-type projection (`_select(type<T2>)`)
-// for projecting into a different `[sql_table]` struct is a chunk-4 follow-up.
+// holds the underlying `Id`).
 
 [sql_table(name = "Cars")]
 struct Car {

--- a/tutorials/sql/10-order_by.das
+++ b/tutorials/sql/10-order_by.das
@@ -13,8 +13,8 @@ require sqlite/sqlite_linq
 //   - `(_.k1, _.k2, …)`      → ORDER BY "k1" ASC, "k2" ASC, …
 //   - `_order_by_descending` flips ASC to DESC for the whole chain step
 //
-// Mixed ASC/DESC across columns in a single chain step is **out of
-// scope** for chunk 4 — use the raw-SQL escape hatch
+// Mixed ASC/DESC across columns in a single chain step is **not
+// supported** — use the raw-SQL escape hatch
 // (`db |> query_one("...ORDER BY a, b DESC", ...)`) when you need it.
 
 [sql_table(name = "Cars")]

--- a/tutorials/sql/11-take_skip.das
+++ b/tutorials/sql/11-take_skip.das
@@ -10,6 +10,12 @@ require sqlite/sqlite_linq
 // (without `take`), SQLite requires `LIMIT -1 OFFSET ?` (LIMIT-of-
 // negative-one means no limit), and the macro emits exactly that.
 //
+// Chain order matters. `_sql` honors linq's positional semantics:
+// `skip(m) |> take(n)` is the canonical pagination shape (skip first,
+// then take) and lowers to flat `LIMIT n OFFSET m`. The reverse,
+// `take(n) |> skip(m)`, means "take n, then drop m" — lowered to a
+// nested SELECT to preserve that meaning.
+//
 // Bind ordering: LIMIT and OFFSET binds always go *after* WHERE
 // binds in the placeholder index sequence, so a `_where(...) |>
 // take(n)` chain produces `WHERE col > ? LIMIT ?` with binds in
@@ -53,20 +59,19 @@ def main() {
             to_log(LOG_INFO, "  {c.Name}\n")
         }
 
-        // ── take + skip — pagination window ──────────────────────────────
-        // take(n) skip(m) = LIMIT n OFFSET m → rows m..m+n-1. So take(2)
-        // skip(1) returns rows 2..3. (For pages of size 2, page 1 = rows
-        // 1..2 with no skip; page 2 = rows 3..4 with skip(2).) Combine
-        // in either order — the SQL is identical.
-        let window <- _sql(db |> select_from(type<Car>) |> take(2) |> skip(1))
-        to_log(LOG_INFO, "take(2) skip(1) — rows 2-3:\n")
+        // ── skip + take — canonical pagination window ────────────────────
+        // `skip(m) |> take(n)` = "skip m rows, then take n" — page k of size n
+        // = `skip((k-1)*n) |> take(n)`. So `skip(2) |> take(2)` returns rows
+        // 3..4 (page 2 of size 2). Lowers to a flat `LIMIT n OFFSET m`.
+        let window <- _sql(db |> select_from(type<Car>) |> skip(2) |> take(2))
+        to_log(LOG_INFO, "skip(2) take(2) — rows 3-4:\n")
         for (c in window) {
             to_log(LOG_INFO, "  {c.Name}\n")
         }
 
         // ── take with WHERE — placeholder ordering ───────────────────────
-        // SQL emitted: WHERE Price > ? LIMIT ?
-        // Binds:       [threshold, 2]
+        // Canonical: `_where(...) |> take(n)` = filter then take; lowers
+        // flat to `WHERE Price > ? LIMIT ?` with binds `[threshold, 2]`.
         let threshold = 100
         let cheap_two <- _sql(db |> select_from(type<Car>)
                                 |> _where(_.Price > threshold)
@@ -77,12 +82,12 @@ def main() {
         }
 
         // ── Pair with order_by for stable pagination ─────────────────────
-        // LIMIT/OFFSET without ORDER BY isn't deterministic — SQLite
-        // can return rows in any order. Always combine the two when
-        // you actually care about page boundaries.
+        // LIMIT/OFFSET without ORDER BY isn't deterministic — SQLite can
+        // return rows in any order. Always combine the two when you care
+        // about page boundaries.
         let stable_page <- _sql(db |> select_from(type<Car>)
                                   |> _order_by(_.Price)
-                                  |> take(2) |> skip(1))
+                                  |> skip(1) |> take(2))
         to_log(LOG_INFO, "ORDER BY Price ASC LIMIT 2 OFFSET 1:\n")
         for (c in stable_page) {
             to_log(LOG_INFO, "  {c.Name}: {c.Price}\n")
@@ -96,7 +101,7 @@ def main() {
         // ── Inspect emitted SQL ──────────────────────────────────────────
         let sql = _sql_text(db |> select_from(type<Car>)
                               |> _order_by(_.Price)
-                              |> take(2) |> skip(1))
+                              |> skip(1) |> take(2))
         to_log(LOG_INFO, "  emitted SQL: {sql}\n")
     }
 }

--- a/tutorials/sql/13-aggregates.das
+++ b/tutorials/sql/13-aggregates.das
@@ -5,8 +5,7 @@ require sqlite/sqlite_boost
 require sqlite/sqlite_linq
 
 // Tutorial 13 — Column aggregates: `sum`, `average`, `min`, `max`,
-// plus `count` (already shown in tutorial 6 and used as a canary in
-// chunk 3).
+// plus `count` (already shown in tutorial 6).
 //
 // All five are *terminals* — they end the chain and produce a
 // scalar, not an array. The translation pattern is the same for the

--- a/tutorials/sql/17-subqueries.das
+++ b/tutorials/sql/17-subqueries.das
@@ -22,10 +22,10 @@ require sqlite/sqlite_linq
 // pattern-matches the macro's textual name; a leading `!` would
 // require deep AST walking that fights with daslang's expansion order.
 //
-// For chunk 5, subqueries are **uncorrelated** — the inner WHERE
-// references only the subquery's own row (`_`), not outer columns.
-// Correlated subqueries (referring to outer columns from inside the
-// subquery's WHERE) land later. For IN-style subqueries, project a
+// Subqueries are **uncorrelated** — the inner WHERE references only
+// the subquery's own row (`_`), not outer columns. Correlated
+// subqueries (referring to outer columns from inside the subquery's
+// WHERE) are not yet supported. For IN-style subqueries, project a
 // single column with `_select(_.Col)` so the IN list shape matches.
 
 [sql_table(name = "Users")]

--- a/tutorials/sql/28-json.das
+++ b/tutorials/sql/28-json.das
@@ -65,7 +65,7 @@ struct User {
 // --- @sql_blob: opaque binary archive -----------------------------------
 // SessionSnapshot is a struct with arrays + tables. @sql_blob generates
 // the daslib/archive variant of the adapter pair (const param + local
-// `clone_to_move` because the chunk-8 catch-all binder passes `v` non-`var`,
+// `clone_to_move` because the catch-all binder passes `v` non-`var`,
 // while `mem_archive_save` / `mem_archive_load` need a mutable reference):
 //
 //     def sql_bind    (v : T) : array<uint8> {

--- a/tutorials/sql/31-views.das
+++ b/tutorials/sql/31-views.das
@@ -95,10 +95,10 @@ def main {
         }
 
         // --- _create_view with a JOIN + named-tuple projection -------------
-        // Multi-source chains (`_join_inner` / `_join_left` from chunk 5)
-        // produce a SELECT with table aliases. The view's struct supplies
-        // the column names; the `_select((... = ...))` aliases here just
-        // have to match by position and type.
+        // Multi-source chains (`_join_inner` / `_join_left`) produce a
+        // SELECT with table aliases. The view's struct supplies the column
+        // names; the `_select((... = ...))` aliases here just have to
+        // match by position and type.
         db |> _create_view(type<OrderSummary>,
             db |> select_from(type<Order>)
                 |> _join(db |> select_from(type<Customer>),

--- a/tutorials/sql/40-fts5.das
+++ b/tutorials/sql/40-fts5.das
@@ -15,15 +15,15 @@ require daslib/fts5_query   // for in-memory text_match against the same query s
 // over text columns and exposes relevance ranking + Boolean / phrase
 // / prefix / NEAR query operators.
 //
-// API surface added in chunk 12:
+// API surface:
 //
 //   [sql_fts5(name="...")]    — struct annotation: virtual table
 //   @sql_fts_rank             — read-only float column → FTS5 `rank`
 //   text_match(col, query)    — _where predicate → `col MATCH ?`
 //
-// The same `text_match` is also a Phase 0.4 strings_boost predicate
-// (full FTS5-grammar parser in `daslib/fts5_query`); user code gets
-// in-memory and SQL-side matching from one call site.
+// The same `text_match` is also a `strings_boost` predicate (full
+// FTS5-grammar parser in `daslib/fts5_query`); user code gets in-memory
+// and SQL-side matching from one call site.
 
 [sql_fts5(name = "docs_idx")]
 struct Doc {


### PR DESCRIPTION
## Summary

Three-mode parity audit of the `_sql(...)` macro (M1 = `_sql` over SQL source, M2 = chain over SQL source no `_sql`, M3 = chain over plain `array<T>`) plus the first three fix passes from the audit findings. Pivots `_sql` from a "canonical-order pushdown optimizer" to an unconditional **same chain → same answer in all three modes** guarantee for the v1 chain shapes.

## Audit harness — 24 `parity_check_*.das` files (~70 `[test]` cases)

Every shipped SQL tutorial chain now has a parity test asserting M1 ≡ M2 ≡ M3. Coverage table + per-tutorial reasons in `modules/dasSQLITE/API_CHECKED.md`. 14 tutorials (write-side / DDL-only / no chain) deliberately skipped; the rest run all three modes against a shared fixture and assert numerical + structural equivalence.

## F1 — `_sql` multi-Q lowering (was: divergent take/skip)

`_sql` previously collapsed any combination of `take` and `skip` into one `LIMIT/OFFSET` regardless of chain order; latent siblings (`take(n) |> _where(p)`, `take(n) |> _order_by(k)`, etc.) silently diverged from linq positional semantics.

**Fix:** `daslib/sqlite_linq.das` analyzer rewritten to honor linq's positional chain semantics across the board. Each chain op gets a phase number matching SQL eval order:

| Phase | Op |
|------:|---|
| 0 | source (FROM) |
| 1 | `_join`, `_left_join` |
| 2 | `_where` |
| 3 | `_group_by`, `distinct`, set-ops |
| 4 | `_having` |
| 5 | `_select`, `_order_by` |
| 7 | `skip` |
| 8 | `take` |
| 9 | terminals |

When peeling an op whose phase exceeds `q.minPhaseSeen`, the inner subtree is analyzed into a fresh `SqlQuery` and snapshotted to SQL string + bind list on the outer Q's new `innerSql` / `innerBindExprs` fields. The outer SELECT's FROM clause renders as `(<innerSql>) AS "t0"`. Bind collection recurses inner-first via `collect_query_binds` (centralized helper covering join-ON / WHERE / HAVING / set-op-RHS / LIMIT / OFFSET).

Phase divert checks live in 5 peel blocks: TAKE, SKIP, ORDER_BY, ORDER_BY_DESC, DISTINCT — the ops where chain-order divergence is real with default-row inner. WHERE stays commutative (no divert). Set-ops / joins unchanged for v1.

Same chain → same answer in all three modes; matches the EF Core mental model. Canonical-order chains stay flat (byte-identical SQL); divergent shapes get a subquery (correct semantics, slower path).

**v1 capabilities unlocked** (parity tests added):
- `take(n) |> skip(m)` — F1 RESOLVED
- `take(n) |> _where(p)` — outer-where over inner-take subquery
- `take(n) |> _order_by(k)` — re-sort the n taken rows
- `take(n) |> _order_by(k) |> take(m)` — three-level nesting
- `skip(n) |> _where(p)` — outer-where over inner-skip subquery
- `take(n) |> _select(...) |> sum()` — bonus: aggregate over inner subquery

**v2 deferred to follow-up PR:** aggregate-then-filter (`_select(... |> sum) |> _where`) and multi-join (`_join |> _where |> _join`) — both need alias-aware column resolution in `pred_to_sql` and a `process_join_call` rework. The v1 `divert_to_inner` emits a clear `macro_error` at the v2 boundary (`subQ.proj != FullRow`).

**Tutorial 11** (`tutorials/sql/11-take_skip.das` + RST): canonical pagination promoted to `skip(m) |> take(n)` (flat fast SQL); the reverse `take(n) |> skip(m)` shown as the "honest, slower subquery" form with the row-count change explained.

## F2 — `average(array<int>)` always returns `double`

`daslib/linq.das` `average(iterator<TT>)` and `average(array<TT>)` both unconditionally return `double` and accumulate in `double` from element zero (uniform path for every numeric `TT`, no integer overflow hazard up to ~2^53, more precise than naive `float` sum). Closes the M1≠M2/M3 divergence on `_select(_.Price) |> average()` over `array<int>` (linq returned `int` with truncation; SQL `AVG` returned `double`).

The deliberate "complex average" test case in `tests/linq/test_linq_aggregation.das` (averaging an `array<ComplexType>` with custom `+=` and `/= uint64` operators) was deleted; users with custom non-numeric types must roll their own averager. Other linq tests got assertion-type updates (`equal(query, 2)` → `equal(query, 2.0lf)`).

## F4 — `_in` / `_not_in` / `_any` / `_none` shadow `_` inside `_where`

`linq_boost.das` `AstCallMacro_LinqPred2` / `AstCallMacro_LinqPredII2` synthesized `$(_ : T) => ...` lambdas whose `_` shadowed the outer `_`-binding macro's `_`, breaking nested chains like `arr |> _where(_.Id._in(other |> _select(_.UserId)))`. Fix: set `VariableFlags.can_shadow` on the synthesized `_` parameter (precedent already in `linq_boost` for other macro-generated bindings). Two-line patch in both base classes' `visit` overrides. Closes #2559.

## Test plan

- [x] Full `tests/` interpreter sweep — 7709/7709 pass, 0 regressions
- [x] Full `tests/` AOT sweep (`bin/Release/test_aot.exe dastest/dastest.das -- --test tests`) — 7709/7709 pass under AOT
- [x] dasSQLITE parity sweep: 28 `parity_check_*.das` files (24 existing + 3 new + 1 F3 pin) all green
- [x] Inspect emitted SQL via `_sql_text` for representative shapes:
  - `take(2) |> skip(1)` → `SELECT … FROM (SELECT … LIMIT ?) AS "t0" LIMIT -1 OFFSET ?` ✓
  - `skip(1) |> take(2)` → flat `SELECT … LIMIT ? OFFSET ?` (no subquery) ✓
- [x] `failed_sql_macro.das` updated: `bad12` (`take(2) |> _select(_.Price) |> sum()`) removed — multi-Q now handles it correctly; coverage moved to `test_33_take_skip.das::test_take_then_select_then_aggregate_runtime`
- [x] Tutorial 11 smoke: `bin/Release/daslang.exe tutorials/sql/11-take_skip.das` matches the revised RST
- [x] MCP `format_file` clean on every edited `.das` file

## Deferred (separate PRs)

- **F3** — `_having |> _order_by` linq-side defect (`order_by` calls `clone_to_move` on `array<tuple<K, array<T>>>`). Pinned by `failed_parity_check_14_order_after_group.das`.
- **v2 multi-Q capabilities** — see `API_REWORK.md` / `API_CHECKED.md` for the v2 punch list (aggregate-then-filter + multi-join + alias resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)