### PR TITLE
dasSQLITE: multi-Q v2.1 — outer WHERE on JOIN's projected alias

### DIFF
--- a/include/daScript/ast/ast_infer_type.h
+++ b/include/daScript/ast/ast_infer_type.h
@@ -418,6 +418,7 @@ namespace das {
         virtual ExpressionPtr visit(ExprVar *expr) override;
         // ExprOp1
         bool isBitfieldOp(const Function *fnc) const;
+        bool hasExtraCloneFor(const TypeDeclPtr & cloneType, bool srcConst) const;
         virtual ExpressionPtr visit(ExprOp1 *expr) override;
         // ExprOp2
         bool isAssignmentOperator(const string &op);

--- a/modules/dasSQLITE/API_CHECKED.md
+++ b/modules/dasSQLITE/API_CHECKED.md
@@ -232,7 +232,8 @@ subquery" form, with the row-count change explained.
 - `parity_check_11d_skip_then_where.das` — 2 cases: skip|where, plus
   skip|where|order_desc.
 
-**v2 RESOLVED:** Both deferred capabilities below now ship.
+**v2.1 RESOLVED:** All multi-Q lowering capabilities below now ship; v2.1 closes
+the outer-WHERE-on-projected-alias gap.
 
 **v2 capabilities — shipped:**
 - **Aggregate-then-filter** — `_select` peel diverts when outer chain pinned
@@ -256,15 +257,20 @@ subquery" form, with the row-count change explained.
   `source_rootType_for_idx`'s new fromRowType fallback +
   `lookup_struct_field_type`'s new tuple-handling.
 
-**v2.1 deferred (next follow-up):**
-- **Outer WHERE on a multi-join's projected alias**
-  (`_join(...) |> _join(...) |> _where(_.outerProjAlias)`). Currently
-  errors at SQL prepare with "no such column: t0.<alias>". Needs the
-  WHERE peel to detect post-projection state without double-wrapping the
-  `_select |> _where` path (which already arrives wrapped via the SELECT
-  peel divert). Naive `if (q.proj != FullRow) wrap` triggers a typer
-  cascade in linq Mode-2/3 generic instantiation; the right shape requires
-  distinguishing "first wrap" from "passthrough wrap".
+**v2.1 capability — shipped:**
+- **Outer WHERE on a JOIN's projected alias**
+  (`_join(...) |> _where(_.alias)` and `_join(_join(A,B,...), C, ...) |> _where(_.alias)`).
+  The WHERE peel now snapshots the analyzed q in place via
+  `snapshot_q_to_subquery_wrap(q, prog, at, fillPassthrough = true)` when
+  `q.seenJoin && q.proj == NamedTuple`. Discriminator skips the
+  `_select |> _where` path (`q.seenJoin` is false there — the SELECT peel
+  already wrapped). Using the in-place snapshot helper instead of
+  `divert_to_inner` avoids the linq Mode-2/3 typer cascade that re-analysis
+  triggers; the new `fillPassthrough` mode emits passthrough column
+  fragments from the synthesized `fromRowType` so the outer WHERE renders as
+  `... FROM (joinSql) AS "t0" WHERE "alias" = …`. Coverage:
+  `parity_check_15_join.das parity_join_with_outer_where`,
+  `parity_check_15b_multi_join.das parity_three_table_join_with_outer_where[_int]`.
 
 ### F2 — `average(array<int>)` truncates in linq, promotes to double in `_sql` — RESOLVED
 

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -1321,17 +1321,35 @@ Both v2 capabilities now ship.
 the 5 peel-divert sites + the SELECT one (which uses a tighter
 `max_outer_phase = PHASE_WHERE`) into one helper.
 
-### v2.1 deferred (next follow-up)
+### v2.1 shipped
 
-- **Outer WHERE on a multi-join's projected alias**
-  (`_join(...) |> _join(...) |> _where(_.outerProjAlias)`).
-  Currently errors at SQL prepare with `no such column: t0.<alias>`.
-  Needs the WHERE peel to detect post-projection state without
-  double-wrapping the `_select |> _where` path (which already
-  arrives wrapped via the SELECT peel divert). Naive
-  `if (q.proj != FullRow) wrap` in WHERE peel triggers a typer
-  cascade in linq Mode-2/3 generic instantiation; the right shape
-  requires distinguishing "first wrap" from "passthrough wrap".
+- **Outer WHERE on a JOIN's projected alias** —
+  `_join(...) |> _where(_.outerAlias)` and
+  `_join(_join(A, B, …), C, …) |> _where(_.outerAlias)`. The WHERE peel
+  now snapshots the analyzed q in place (`snapshot_q_to_subquery_wrap`
+  with new `fillPassthrough = true` mode) when
+  `q.seenJoin && q.proj == NamedTuple`. Discriminator skips the
+  `_select |> _where` path (`q.seenJoin` is false there — the SELECT
+  peel already wrapped via `divert_to_inner`). Using the in-place
+  snapshot helper instead of `divert_to_inner` avoids the linq Mode-2/3
+  typer cascade that re-analysis triggers (the deferred-note's
+  hypothesised "first vs passthrough wrap" distinction was a red
+  herring — re-analysis itself was the cascade trigger). The new
+  `fillPassthrough` mode mirrors `divert_to_inner`'s NamedTuple branch:
+  emit passthrough column fragments from the synthesized `fromRowType`
+  so the outer SELECT renders as
+  `SELECT "alias", … FROM (joinSql) AS "t0" WHERE "alias" = ?`.
+  Coverage:
+  - `parity_check_15_join.das parity_join_with_outer_where` — single
+    `_join` + outer WHERE on `_.Spend` (numeric predicate, 4-arg
+    projection tuple `(Buyer, Spend, OrderId, Win)`).
+  - `parity_check_15b_multi_join.das parity_three_table_join_with_outer_where`
+    — 3-table join + outer `_where(_.Sku == "BOOK")`.
+  - `parity_check_15b_multi_join.das parity_three_table_join_with_outer_where_int`
+    — 3-table join + outer `_where(_.Qty >= 2 && _.UserName == "Alice")`
+    (multi-arg AND on numeric + string aliases).
+
+### v2.1 deferred (next follow-up)
 
 - **Daslang typedef in lambda parameter type position works in
   isolation but fails in the multi-join chain context** — possibly

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -640,10 +640,12 @@ def private extract_key_selector_field(var keyLambda : ExpressionPtr; expectedAr
 [macro_function]
 def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at : LineInfo;
                                         fillPassthrough : bool = false) : bool {
-    if (q.seenTerminal || q.seenToArray) {
-        macro_error(prog, at, "_sql: multi-join LHS chain cannot end in a terminal (`_first`, `_to_array`, `_count`, etc.); restructure so terminals are outermost")
-        return false
-    }
+    // NOTE: don't gate on q.seenTerminal / q.seenToArray here — analyze_chain peels
+    // outermost-first, so by the time snapshot is called, those flags reflect the OUTER
+    // chain's terminal (which is fine) and there's no way to distinguish that from an
+    // inner-chain terminal. The "inner LHS can't end in a terminal" check is hoisted
+    // to the call sites that can do save-and-compare across analyze_chain (currently
+    // process_join_call's srca recursion).
     if (q.proj == ProjectionShape.SingleColumn || q.proj == ProjectionShape.Aggregate) {
         macro_error(prog, at, "_sql: multi-join LHS must project a named row (use `into` to produce a tuple); got scalar/aggregate projection — reshape so each LHS column is named")
         return false
@@ -771,7 +773,17 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     q.rootAlias = "t0"
     // 1. Recurse into srca FIRST. If srca itself is a `_join` chain (multi-join), the inner
     // process_join_call will set q.seenJoin / fill q.joins[]. Detect that on return below.
+    // Capture seenTerminal/seenToArray pre-recursion: if srca itself peels a terminal, we
+    // reject — the LHS of a join can't terminate in `_first`/`_count`/`_to_array`. This is
+    // the discrimination snapshot_q_to_subquery_wrap can't do (it sees the OUTER terminal
+    // flag indistinguishably set in chains like `_join(...) |> _first()`).
+    let savedSeenTerminal = q.seenTerminal
+    let savedSeenToArray = q.seenToArray
     if (!analyze_chain(jCall.arguments[0], q, prog, at)) {
+        return false
+    }
+    if ((q.seenTerminal && !savedSeenTerminal) || (q.seenToArray && !savedSeenToArray)) {
+        macro_error(prog, at, "_sql: _join LHS chain cannot end in a terminal (`_first`, `_to_array`, `_count`, etc.); restructure so terminals are outermost")
         return false
     }
     // 2. Multi-join: srca contained a _join. Snapshot q as an inner subquery and reset for

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -650,6 +650,36 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
         macro_error(prog, at, "_sql: multi-join LHS must project a named row (use `into` to produce a tuple); got scalar/aggregate projection — reshape so each LHS column is named")
         return false
     }
+    // Save outer-terminal state pre-set by outer-peeled ops (`_first` / `_count` / `_take` /
+    // `_skip` / `_order_by` / `_distinct` etc.). Without this, `build_sql_string(q, true)` below
+    // serializes those clauses into the INNER subquery (e.g. `LIMIT 1` lands BEFORE the outer
+    // WHERE filter → wrong row), and the reset further down drops them entirely so the OUTER
+    // SELECT loses them too. Save → clear → build inner → reset → restore.
+    let savedMatr = q.matr
+    var savedLimitBindExpr = q.limitBindExpr
+    var savedOffsetBindExpr = q.offsetBindExpr
+    let savedDistinctFlag = q.distinctFlag
+    var savedOrderByCols : array<string>
+    savedOrderByCols <- q.orderByCols
+    var savedOrderByInlineExprs : array<ExpressionPtr>
+    savedOrderByInlineExprs <- q.orderByInlineExprs
+    let savedSeenTake = q.seenTake
+    let savedSeenSkip = q.seenSkip
+    let savedSeenOrderBy = q.seenOrderBy
+    let savedSeenDistinct = q.seenDistinct
+    let savedSeenTerminal = q.seenTerminal
+    let savedSeenToArray = q.seenToArray
+    // Clear them on q so the inner SQL emits without outer-only clauses.
+    q.matr = Materializer.Array
+    q.limitBindExpr = null
+    q.offsetBindExpr = null
+    q.distinctFlag = false
+    q.seenTake = false
+    q.seenSkip = false
+    q.seenOrderBy = false
+    q.seenDistinct = false
+    q.seenTerminal = false
+    q.seenToArray = false
     var savedDb = q.dbExpr
     let savedInView = q.inView
     let savedHadError = q.hadError
@@ -708,6 +738,20 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.dbExpr = savedDb
     q.inView = savedInView
     q.hadError = savedHadError
+    // Restore outer-terminal state so the outer SELECT renders WITH it (LIMIT 1 from
+    // `_first`, ORDER BY from `_order_by`, etc. all belong on outer post-wrap).
+    q.matr = savedMatr
+    q.limitBindExpr = savedLimitBindExpr
+    q.offsetBindExpr = savedOffsetBindExpr
+    q.distinctFlag = savedDistinctFlag
+    q.orderByCols <- savedOrderByCols
+    q.orderByInlineExprs <- savedOrderByInlineExprs
+    q.seenTake = savedSeenTake
+    q.seenSkip = savedSeenSkip
+    q.seenOrderBy = savedSeenOrderBy
+    q.seenDistinct = savedSeenDistinct
+    q.seenTerminal = savedSeenTerminal
+    q.seenToArray = savedSeenToArray
     if (fillPassthrough) {
         // Terminal wrap (e.g. WHERE peel on a JOIN'd named-tuple projection): no outer op
         // will fill the projection. Emit `SELECT "alias1", "alias2", ... FROM (<innerSql>) AS "t0"`

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -638,7 +638,8 @@ def private extract_key_selector_field(var keyLambda : ExpressionPtr; expectedAr
 // `into` projection resolves `<lhsArg>.<alias>` against q.fromRowType (named tuple
 // from inner_projection_type), which now also feeds source_rootType_for_idx(0).
 [macro_function]
-def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
+def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at : LineInfo;
+                                        fillPassthrough : bool = false) : bool {
     if (q.seenTerminal || q.seenToArray) {
         macro_error(prog, at, "_sql: multi-join LHS chain cannot end in a terminal (`_first`, `_to_array`, `_count`, etc.); restructure so terminals are outermost")
         return false
@@ -705,6 +706,52 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.dbExpr = savedDb
     q.inView = savedInView
     q.hadError = savedHadError
+    if (fillPassthrough) {
+        // Terminal wrap (e.g. WHERE peel on a JOIN'd named-tuple projection): no outer op
+        // will fill the projection. Emit `SELECT "alias1", "alias2", ... FROM (<innerSql>) AS "t0"`
+        // via passthrough fragments — same shape divert_to_inner uses for NamedTuple inner.
+        if (!apply_passthrough_projection(q, projType, prog, at)) {
+            return false
+        }
+    }
+    return true
+}
+
+// Replace q's projection state with passthrough column references against the
+// named-tuple `projType` (typically q.fromRowType after a divert/snapshot). Sets
+// q.proj = NamedTuple. Used both by divert_to_inner (NamedTuple inner case) and
+// snapshot_q_to_subquery_wrap with fillPassthrough = true.
+[macro_function]
+def private apply_passthrough_projection(var q : SqlQuery&; projType : TypeDeclPtr;
+                                         prog : ProgramPtr; at : LineInfo) : bool {
+    if (projType == null || projType.baseType != Type.tTuple) {
+        macro_error(prog, at, "_sql multi-Q: passthrough projection expected named-tuple type (internal)")
+        return false
+    }
+    let n = length(projType.argNames)
+    if (n != length(projType.argTypes)) {
+        macro_error(prog, at, "_sql multi-Q: passthrough projection alias count {n} != type count {length(projType.argTypes)} (internal)")
+        return false
+    }
+    q.selectCols |> clear
+    q.selectColAliases |> clear
+    q.selectColSqlFragments |> clear
+    q.selectColTypes |> clear
+    q.projRecordNames |> clear
+    q.selectCols |> reserve(n)
+    q.selectColAliases |> reserve(n)
+    q.selectColSqlFragments |> reserve(n)
+    q.selectColTypes |> reserve(n)
+    q.projRecordNames |> reserve(n)
+    for (i in range(n)) {
+        let alias = string(projType.argNames[i])
+        q.selectCols |> push(alias) // nolint:PERF006 reserved above
+        q.selectColAliases |> push("") // nolint:PERF006 reserved above
+        q.selectColSqlFragments |> push("\"{alias}\"") // nolint:PERF006 reserved above
+        q.selectColTypes |> push(clone_type(projType.argTypes[i])) // nolint:PERF006 reserved above
+        q.projRecordNames |> push(alias) // nolint:PERF006 reserved above
+    }
+    q.proj = ProjectionShape.NamedTuple
     return true
 }
 
@@ -1001,37 +1048,8 @@ def private divert_to_inner(var node : ExpressionPtr; var q : SqlQuery&;
         // struct. rootType stays null; passthrough-project all aliases via SQL fragments so the
         // outer SELECT renders as `SELECT "alias1", "alias2", ... FROM (<innerSql>) AS t0`.
         // pred_to_sql resolves `_.alias` against q.fromRowType (set above).
-        var aliasTypes : array<TypeDeclPtr>
-        if (subQ.proj == ProjectionShape.NamedTuple) {
-            aliasTypes := subQ.selectColTypes
-        } else {
-            aliasTypes := subQ.groupedSelectTypes
-        }
-        let n = length(subQ.projRecordNames)
-        if (n != length(aliasTypes)) {
-            macro_error(prog, at, "_sql multi-Q: inner projection alias count {n} != type count {length(aliasTypes)} (internal)")
+        if (!apply_passthrough_projection(q, q.fromRowType, prog, at)) {
             return false
-        }
-        q.selectCols |> clear
-        q.selectColAliases |> clear
-        q.selectColSqlFragments |> clear
-        q.selectColTypes |> clear
-        q.projRecordNames |> clear
-        q.selectCols |> reserve(n)
-        q.selectColAliases |> reserve(n)
-        q.selectColSqlFragments |> reserve(n)
-        q.selectColTypes |> reserve(n)
-        q.projRecordNames |> reserve(n)
-        for (i in range(n)) {
-            let alias = subQ.projRecordNames[i]
-            q.selectCols |> push(alias) // nolint:PERF006 reserved above
-            q.selectColAliases |> push("") // nolint:PERF006 reserved above
-            q.selectColSqlFragments |> push("\"{alias}\"") // nolint:PERF006 reserved above
-            q.selectColTypes |> push(clone_type(aliasTypes[i])) // nolint:PERF006 reserved above
-            q.projRecordNames |> push(alias) // nolint:PERF006 reserved above
-        }
-        if (q.proj == ProjectionShape.FullRow) {
-            q.proj = ProjectionShape.NamedTuple
         }
     }
     return true
@@ -1403,12 +1421,18 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             if (!analyze_chain(wCall.arguments[0], q, prog, at)) {
                 return false
             }
-            // V2 deferred: outer WHERE on a `_join(...) |> _where(_.alias)` chain would need the
-            // same wrap-and-resolve pattern as `_select |> _where`, but the SELECT case is handled
-            // by the SELECT peel's divert. For _join we'd need to detect post-projection state
-            // here (q.proj != FullRow) and snapshot — but that double-wraps the SELECT path and
-            // tickles a typer cascade in linq Mode-2/3 generic instantiation. Tracking as
-            // follow-up; for now this case is rejected at SQL prepare time with "no such column".
+            // v2.1: outer WHERE on a JOIN's named-tuple `into` projection filters PROJECTED rows;
+            // pred_to_sql against base-table scope emits `t0.alias` which doesn't exist. Snapshot
+            // the analyzed q in place so WHERE renders as `... FROM (joinSql) AS "t0" WHERE "alias" = ...`,
+            // resolved through q.fromRowType. The `_select |> _where` case is already handled by
+            // the SELECT peel's divert (q.seenJoin is false there). Use the in-place snapshot
+            // helper, NOT divert_to_inner — re-analyzing here re-instantiates the generic chain
+            // and tickles a typer cascade in linq Mode-2/3.
+            if (q.seenJoin && q.proj == ProjectionShape.NamedTuple) {
+                if (!snapshot_q_to_subquery_wrap(q, prog, at, [fillPassthrough = true])) {
+                    return false
+                }
+            }
             return analyze_predicate(body, q, prog, at)
         }
     }

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -646,8 +646,12 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     // inner-chain terminal. The "inner LHS can't end in a terminal" check is hoisted
     // to the call sites that can do save-and-compare across analyze_chain (currently
     // process_join_call's srca recursion).
-    if (q.proj == ProjectionShape.SingleColumn || q.proj == ProjectionShape.Aggregate) {
-        macro_error(prog, at, "_sql: multi-join LHS must project a named row (use `into` to produce a tuple); got scalar/aggregate projection — reshape so each LHS column is named")
+    // Aggregate is acceptable here: outer-peeled `_count`/`_sum` set proj=Aggregate before
+    // recursing; we save/clear/restore it below so the inner subquery emits projection columns
+    // and the outer SELECT renders the aggregate. SingleColumn rejection still stands because
+    // inner_projection_type expects a named tuple.
+    if (q.proj == ProjectionShape.SingleColumn) {
+        macro_error(prog, at, "_sql: multi-join LHS must project a named row (use `into` to produce a tuple); got scalar projection — reshape so each LHS column is named")
         return false
     }
     // Save outer-terminal state pre-set by outer-peeled ops (`_first` / `_count` / `_take` /
@@ -669,6 +673,11 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     let savedSeenDistinct = q.seenDistinct
     let savedSeenTerminal = q.seenTerminal
     let savedSeenToArray = q.seenToArray
+    // Aggregate state set by outer-peeled `_count` / `_sum` / etc. The inner subquery must
+    // emit the projection columns (so the outer can wrap them); the OUTER SELECT renders
+    // `COUNT(*)` / `SUM(...)`. Save → clear → build inner → restore on outer post-wrap.
+    let savedAggExpr := q.aggregateExpr
+    var savedAggType = q.aggregateType
     // Clear them on q so the inner SQL emits without outer-only clauses.
     q.matr = Materializer.Array
     q.limitBindExpr = null
@@ -680,6 +689,14 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.seenDistinct = false
     q.seenTerminal = false
     q.seenToArray = false
+    q.aggregateExpr := ""
+    q.aggregateType = null
+    if (savedAggExpr != "") {
+        // selectCols were populated by analyze_projection (preserved by process_join_call's
+        // save/restore); inner build_sql_string must read them as a NamedTuple projection,
+        // not as an aggregate (which would emit the now-empty aggregateExpr).
+        q.proj = ProjectionShape.NamedTuple
+    }
     var savedDb = q.dbExpr
     let savedInView = q.inView
     let savedHadError = q.hadError
@@ -752,7 +769,13 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.seenDistinct = savedSeenDistinct
     q.seenTerminal = savedSeenTerminal
     q.seenToArray = savedSeenToArray
-    if (fillPassthrough) {
+    q.aggregateExpr := savedAggExpr
+    q.aggregateType = savedAggType
+    if (savedAggExpr != "") {
+        // Outer renders `SELECT COUNT(*) FROM (...) AS t0 [WHERE ...]` — no row projection.
+        // Override the FullRow that the reset block installed; ignore fillPassthrough.
+        q.proj = ProjectionShape.Aggregate
+    } elif (fillPassthrough) {
         // Terminal wrap (e.g. WHERE peel on a JOIN'd named-tuple projection): no outer op
         // will fill the projection. Emit `SELECT "alias1", "alias2", ... FROM (<innerSql>) AS "t0"`
         // via passthrough fragments — same shape divert_to_inner uses for NamedTuple inner.
@@ -924,11 +947,27 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     q.argSourceIdx |> push(0)
     q.argNames |> push(arg1Name)
     q.argSourceIdx |> push(1)
+    // Save aggregate state across analyze_projection: outer-peeled `_count`/`_sum`/etc. set
+    // q.aggregateExpr + q.proj=Aggregate before recursion; analyze_projection unconditionally
+    // writes q.proj=NamedTuple (and clears nothing else) which would clobber that intent.
+    // selectCols still need to be populated for the inner subquery in the multi-join /
+    // WHERE-peel snapshot paths, so we let analyze_projection run normally and restore the
+    // aggregate state afterwards. Invariant: aggregateExpr non-empty ⇒ proj=Aggregate.
+    let savedAggExpr := q.aggregateExpr
+    var savedAggType = q.aggregateType
+    let savedAggProj = q.proj == ProjectionShape.Aggregate
     let projOk = analyze_projection(iret.subexpr, q, prog, at)
     q.argNames |> clear
     q.argSourceIdx |> clear
     if (!projOk) {
         return false
+    }
+    if (savedAggExpr != "") {
+        q.aggregateExpr := savedAggExpr
+        q.aggregateType = savedAggType
+        if (savedAggProj) {
+            q.proj = ProjectionShape.Aggregate
+        }
     }
     q.seenSelect = true
     return true
@@ -1484,7 +1523,9 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             // the SELECT peel's divert (q.seenJoin is false there). Use the in-place snapshot
             // helper, NOT divert_to_inner — re-analyzing here re-instantiates the generic chain
             // and tickles a typer cascade in linq Mode-2/3.
-            if (q.seenJoin && q.proj == ProjectionShape.NamedTuple) {
+            // Aggregate-with-WHERE (`_join | _where | _count`) needs the same wrap so the WHERE
+            // can reference the projected alias; snapshot preserves aggregate state on the outer.
+            if (q.seenJoin && (q.proj == ProjectionShape.NamedTuple || q.aggregateExpr != "")) {
                 if (!snapshot_q_to_subquery_wrap(q, prog, at, [fillPassthrough = true])) {
                     return false
                 }

--- a/src/ast/ast_infer_type_function.cpp
+++ b/src/ast/ast_infer_type_function.cpp
@@ -792,7 +792,12 @@ namespace das {
             const auto &funType = fn->arguments[i]->type;
             if (!argType->isSameType(*funType, RefMatters::no, ConstMatters::no,
                                      TemporaryMatters::no, AllowSubstitute::no)) {
-                distance++;
+                distance += 100;
+            }
+            // tiebreaker: a candidate that exactly matches caller's constness
+            // is more specific than one accepting a wider const range.
+            if (funType->constant != argType->constant) {
+                distance += 1;
             }
         }
         return distance;

--- a/src/ast/ast_infer_type_op.cpp
+++ b/src/ast/ast_infer_type_op.cpp
@@ -12,6 +12,19 @@ namespace das {
         }
         return false;
     }
+
+    bool InferTypes::hasExtraCloneFor(const TypeDeclPtr & cloneType, bool srcConst) const {
+        for (auto & ef : extraFunctions) {
+            if (ef->name != "clone") continue;
+            if (ef->arguments.size() != 2) continue;
+            auto & destT = ef->arguments[0]->type;
+            if (!destT->isSameType(*cloneType, RefMatters::no, ConstMatters::no, TemporaryMatters::no, AllowSubstitute::no, true, true)) continue;
+            auto & srcT = ef->arguments[1]->type;
+            if (srcT->constant != srcConst) continue;
+            return true;
+        }
+        return false;
+    }
     ExpressionPtr InferTypes::visit(ExprOp1 *expr) {
         if (!expr->subexpr->type || expr->subexpr->type->isAliasOrExpr())
             return Visitor::visit(expr); // failed to infer
@@ -768,9 +781,11 @@ namespace das {
                 }
             } else if (cloneType->isTuple()) {
                 reportAstChanged();
-                auto fnList = getCloneFunc(cloneType, cloneType);
+                auto rhsType = new TypeDecl(*cloneType);
+                rhsType->constant = expr->right->type->constant;
+                auto fnList = getCloneFunc(cloneType, rhsType);
                 if (verifyCloneFunc(fnList, expr->at)) {
-                    if (fnList.size() == 0) {
+                    if (fnList.size() == 0 && !hasExtraCloneFor(cloneType, expr->right->type->constant)) {
                         auto clf = makeCloneTuple(expr->at, cloneType, expr->right->type->constant);
                         clf->privateFunction = true;
                         extraFunctions.push_back(clf);
@@ -784,9 +799,11 @@ namespace das {
                 }
             } else if (cloneType->isVariant()) {
                 reportAstChanged();
-                auto fnList = getCloneFunc(cloneType, cloneType);
+                auto rhsType = new TypeDecl(*cloneType);
+                rhsType->constant = expr->right->type->constant;
+                auto fnList = getCloneFunc(cloneType, rhsType);
                 if (verifyCloneFunc(fnList, expr->at)) {
-                    if (fnList.size() == 0) {
+                    if (fnList.size() == 0 && !hasExtraCloneFor(cloneType, expr->right->type->constant)) {
                         auto clf = makeCloneVariant(expr->at, cloneType, expr->right->type->constant);
                         clf->privateFunction = true;
                         extraFunctions.push_back(clf);

--- a/tests/dasSQLITE/parity_check_14_order_after_group.das
+++ b/tests/dasSQLITE/parity_check_14_order_after_group.das
@@ -14,7 +14,7 @@
 // a separate sort step that needs cloneable elements.
 //
 // See API_CHECKED.md F3 for the resolution direction.
-expect 30304:1
+// expect 30304:1
 
 options gen2
 

--- a/tests/dasSQLITE/parity_check_15_join.das
+++ b/tests/dasSQLITE/parity_check_15_join.das
@@ -168,6 +168,62 @@ def sort_by_pair_with_orderid(var rows : array<auto(R)>) : array<R> {
     return <- rows
 }
 
+def sort_by_buyer_orderid(var rows : array<auto(R)>) : array<R> {
+    rows |> sort() <| $(a, b) {
+        if (a.Buyer != b.Buyer) {
+            return a.Buyer < b.Buyer
+        }
+        return a.OrderId < b.OrderId
+    }
+    return <- rows
+}
+
+[test]
+def parity_join_with_outer_where(t : T?) {
+    // v2.1: outer WHERE on a single _join's projected alias must filter PROJECTED rows.
+    // The WHERE peel snapshots the analyzed q in place; SQL renders as
+    // `... FROM (joinSql) AS "t0" WHERE "alias" = ?` with the alias resolved through
+    // q.fromRowType. Tuple shape: (Buyer:string, Spend:int, OrderId:int, Win:bool) →
+    // tuple<string;int;int;bool> — structurally distinct from the other tests in this file.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _join(db |> select_from(type<Order>),
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (Buyer = u.Name, Spend = o.Total, OrderId = o.Id, Win = u.Active))
+                         |> _where(_.Spend > 75))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _join(db |> select_from(type<Order>),
+                              $(u : User, o : Order) => u.Id == o.UserId,
+                              $(u : User, o : Order) => (Buyer = u.Name, Spend = o.Total, OrderId = o.Id, Win = u.Active))
+                     |> _where(_.Spend > 75))
+        var m3 <- (users |> _join(orders,
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (Buyer = u.Name, Spend = o.Total, OrderId = o.Id, Win = u.Active))
+                         |> _where(_.Spend > 75))
+
+        m1 <- sort_by_buyer_orderid(m1)
+        m2 <- sort_by_buyer_orderid(m2)
+        m3 <- sort_by_buyer_orderid(m3)
+
+        // Alice: orders 100, 250 → both > 75. Bob: 50 → dropped. Expect 2 rows.
+        t |> equal(length(m1), 2, "join + outer WHERE Spend>75: 2 rows (Alice ×2, Bob's 50 dropped)")
+        t |> equal(length(m1), length(m2), "M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].Buyer,   m2[i].Buyer,   "row[{i}].Buyer:   M1 ≡ M2")
+            t |> equal(m1[i].Spend,   m2[i].Spend,   "row[{i}].Spend:   M1 ≡ M2")
+            t |> equal(m1[i].OrderId, m2[i].OrderId, "row[{i}].OrderId: M1 ≡ M2")
+            t |> equal(m2[i].Buyer,   m3[i].Buyer,   "row[{i}].Buyer:   M2 ≡ M3")
+            t |> equal(m2[i].Spend,   m3[i].Spend,   "row[{i}].Spend:   M2 ≡ M3")
+            t |> equal(m2[i].OrderId, m3[i].OrderId, "row[{i}].OrderId: M2 ≡ M3")
+        }
+    }
+}
+
 [test]
 def parity_right_filter_join(t : T?) {
     // Tuple shape: (UserName, OrderTotal, OrderId) → tuple<string;int;int>.

--- a/tests/dasSQLITE/parity_check_15_join.das
+++ b/tests/dasSQLITE/parity_check_15_join.das
@@ -179,6 +179,44 @@ def sort_by_buyer_orderid(var rows : array<auto(R)>) : array<R> {
 }
 
 [test]
+def parity_join_with_outer_where_then_first(t : T?) {
+    // v2.1 regression: chain `_join(...) |> _where(_.alias) |> _first()` previously
+    // failed at compile time with the misleading "_join LHS chain cannot end in a
+    // terminal" error — the snapshot helper conflated the OUTER terminal flag with
+    // an INNER terminal it was meant to reject. Hoisted check now lives in
+    // process_join_call's srca recursion (save-and-compare across analyze_chain),
+    // so outer terminals are accepted. Tuple shape: (RefId:int, Label:string,
+    // Amount:int) → tuple<int;string;int> — leading int makes the arg-type list
+    // structurally distinct from every other test in this file.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+
+        let m1 = _sql(db |> select_from(type<User>)
+                        |> _join(db |> select_from(type<Order>),
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (RefId = o.Id, Label = u.Name, Amount = o.Total))
+                        |> _where(_.Amount > 75)
+                        |> _first())
+        let m2 = (db |> select_from(type<User>)
+                    |> _join(db |> select_from(type<Order>),
+                             $(u : User, o : Order) => u.Id == o.UserId,
+                             $(u : User, o : Order) => (RefId = o.Id, Label = u.Name, Amount = o.Total))
+                    |> _where(_.Amount > 75)
+                    |> _first())
+
+        // _first picks an arbitrary row from the matching set; without ORDER BY the
+        // chosen row may differ between modes. Just assert the chain compiled and the
+        // returned row satisfies the predicate (the regression was a compile-time
+        // error — the macro analyzer rejected the chain shape, value-correctness
+        // didn't matter). Same applies to M3 — first() over the linq path on an
+        // unordered iterator picks an arbitrary match.
+        t |> equal(m1.Amount > 75, true, "M1 row passes the WHERE predicate")
+        t |> equal(m2.Amount > 75, true, "M2 row passes the WHERE predicate")
+        t |> equal(m1.Label != "" && m2.Label != "", true, "Label populated in both")
+    }
+}
+
+[test]
 def parity_join_with_outer_where(t : T?) {
     // v2.1: outer WHERE on a single _join's projected alias must filter PROJECTED rows.
     // The WHERE peel snapshots the analyzed q in place; SQL renders as

--- a/tests/dasSQLITE/parity_check_15_join.das
+++ b/tests/dasSQLITE/parity_check_15_join.das
@@ -241,21 +241,47 @@ def parity_join_outer_where_first_inner_limit_leak(t : T?) {
     // and restores it post-reset; inner emits no LIMIT, outer is
     // `WHERE OrderAmount == 50 LIMIT 1` → picks Bob 50 correctly.
     //
+    // M2/M3 (linq over `select_from`'s materialized array / plain in-memory array) don't go
+    // through the SQL builder at all — they serve as oracles confirming the post-fix M1 picks
+    // the same row the in-memory references do. The bug only ever existed in M1.
+    //
     // Tuple shape (IsActive:bool, BuyerName:string, OrderAmount:int) → tuple<bool;string;int>
     // — structurally distinct from every other test in this file.
     with_sqlite(":memory:") $(db) {
         fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
         let m1 = _sql(db |> select_from(type<User>)
                         |> _join(db |> select_from(type<Order>),
                                  $(u : User, o : Order) => u.Id == o.UserId,
                                  $(u : User, o : Order) => (IsActive = u.Active, BuyerName = u.Name, OrderAmount = o.Total))
                         |> _where(_.OrderAmount == 50)
                         |> _first())
+        let m2 = (db |> select_from(type<User>)
+                    |> _join(db |> select_from(type<Order>),
+                             $(u : User, o : Order) => u.Id == o.UserId,
+                             $(u : User, o : Order) => (IsActive = u.Active, BuyerName = u.Name, OrderAmount = o.Total))
+                    |> _where(_.OrderAmount == 50)
+                    |> _first())
+        let m3 = (users |> _join(orders,
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (IsActive = u.Active, BuyerName = u.Name, OrderAmount = o.Total))
+                        |> _where(_.OrderAmount == 50)
+                        |> _first())
+
         // Without the fix: m1 would be garbage (0 rows from outer WHERE → _first panic
         // or zeroed). With the fix: deterministically Bob's order 12 (UserId 2, Total 50).
         t |> equal(m1.BuyerName,   "Bob", "WHERE OrderAmount==50 picks Bob (only matching row)")
         t |> equal(m1.OrderAmount, 50,    "Picked-row Total is 50")
         t |> equal(m1.IsActive,    true,  "Bob is active")
+        // M2/M3 oracles: in-memory references confirm M1 picks the same row.
+        t |> equal(m1.BuyerName,   m2.BuyerName,   "M1 ≡ M2 BuyerName")
+        t |> equal(m1.OrderAmount, m2.OrderAmount, "M1 ≡ M2 OrderAmount")
+        t |> equal(m1.IsActive,    m2.IsActive,    "M1 ≡ M2 IsActive")
+        t |> equal(m2.BuyerName,   m3.BuyerName,   "M2 ≡ M3 BuyerName")
+        t |> equal(m2.OrderAmount, m3.OrderAmount, "M2 ≡ M3 OrderAmount")
+        t |> equal(m2.IsActive,    m3.IsActive,    "M2 ≡ M3 IsActive")
     }
 }
 
@@ -341,5 +367,83 @@ def parity_right_filter_join(t : T?) {
             t |> equal(m2[i].OrderTotal, m3[i].OrderTotal, "row[{i}].OrderTotal: M2 ≡ M3")
             t |> equal(m2[i].OrderId,    m3[i].OrderId,    "row[{i}].OrderId:    M2 ≡ M3")
         }
+    }
+}
+
+[test]
+def parity_join_then_count(t : T?) {
+    // v2.1 review-3 regression for E1 (no-snapshot path): bare `_join(...) |> count()`
+    // (no _where, no snapshot). Pre-fix: process_join_call's analyze_projection
+    // unconditionally wrote q.proj=NamedTuple and clobbered the aggregateExpr=COUNT(*)
+    // set by the upstream count() peel; build emitted `SELECT t0."Name", t1."Total" FROM
+    // Users JOIN Orders LIMIT 1` and returned a tuple instead of an int. Post-fix:
+    // process_join_call saves/restores aggregate state across analyze_projection.
+    //
+    // Inner `into` tuple: (Pay:int, Holder:string, Premium:bool) → tuple<int;string;bool>
+    // — structurally distinct from every other test in this file.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
+        let n1 = _sql(db |> select_from(type<User>)
+                        |> _join(db |> select_from(type<Order>),
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (Pay = o.Total, Holder = u.Name, Premium = u.Active))
+                        |> count())
+        let n2 = (db |> select_from(type<User>)
+                    |> _join(db |> select_from(type<Order>),
+                             $(u : User, o : Order) => u.Id == o.UserId,
+                             $(u : User, o : Order) => (Pay = o.Total, Holder = u.Name, Premium = u.Active))
+                    |> count())
+        let n3 = (users |> _join(orders,
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (Pay = o.Total, Holder = u.Name, Premium = u.Active))
+                        |> count())
+
+        // 3 INNER-join rows (Alice ×2, Bob ×1; Carol absent).
+        t |> equal(n1, 3, "_join | count(): 3 INNER-join rows")
+        t |> equal(n1, n2, "M1 ≡ M2 count")
+        t |> equal(n2, n3, "M2 ≡ M3 count")
+    }
+}
+
+[test]
+def parity_join_outer_where_then_count(t : T?) {
+    // v2.1 review-3 regression for E2 (snapshot path): `_join(...) |> _where(_.alias) |>
+    // count()` exercises the WHERE-peel snapshot. Pre-fix: snapshot reset dropped
+    // aggregateExpr/aggregateType, OUTER rendered projection columns instead of COUNT(*)
+    // and returned a tuple. Post-fix: snapshot saves/clears/restores aggregate state and
+    // post-restore overrides q.proj=Aggregate.
+    //
+    // Inner `into` tuple: (Live:bool, Pay:int, Tag:string) → tuple<bool;int;string>
+    // — structurally distinct from every other test in this file.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+
+        let n1 = _sql(db |> select_from(type<User>)
+                        |> _join(db |> select_from(type<Order>),
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (Live = u.Active, Pay = o.Total, Tag = u.Name))
+                        |> _where(_.Pay > 75)
+                        |> count())
+        let n2 = (db |> select_from(type<User>)
+                    |> _join(db |> select_from(type<Order>),
+                             $(u : User, o : Order) => u.Id == o.UserId,
+                             $(u : User, o : Order) => (Live = u.Active, Pay = o.Total, Tag = u.Name))
+                    |> _where(_.Pay > 75)
+                    |> count())
+        let n3 = (users |> _join(orders,
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (Live = u.Active, Pay = o.Total, Tag = u.Name))
+                        |> _where(_.Pay > 75)
+                        |> count())
+
+        // Alice's 100 + 250 pass `Pay > 75`; Bob's 50 dropped → 2 rows.
+        t |> equal(n1, 2, "_join | _where(Pay>75) | count(): 2 rows (Alice ×2)")
+        t |> equal(n1, n2, "M1 ≡ M2 count")
+        t |> equal(n2, n3, "M2 ≡ M3 count")
     }
 }

--- a/tests/dasSQLITE/parity_check_15_join.das
+++ b/tests/dasSQLITE/parity_check_15_join.das
@@ -180,39 +180,82 @@ def sort_by_buyer_orderid(var rows : array<auto(R)>) : array<R> {
 
 [test]
 def parity_join_with_outer_where_then_first(t : T?) {
-    // v2.1 regression: chain `_join(...) |> _where(_.alias) |> _first()` previously
-    // failed at compile time with the misleading "_join LHS chain cannot end in a
-    // terminal" error — the snapshot helper conflated the OUTER terminal flag with
-    // an INNER terminal it was meant to reject. Hoisted check now lives in
-    // process_join_call's srca recursion (save-and-compare across analyze_chain),
-    // so outer terminals are accepted. Tuple shape: (RefId:int, Label:string,
-    // Amount:int) → tuple<int;string;int> — leading int makes the arg-type list
-    // structurally distinct from every other test in this file.
+    // v2.1 regression: `_join(...) |> _where(_.alias) |> _order_by(_.alias) |> _first()`
+    // previously failed at compile time with the misleading "_join LHS chain cannot
+    // end in a terminal" error — the snapshot helper conflated the OUTER terminal
+    // flag with an INNER terminal it was meant to reject. Hoisted check now lives in
+    // process_join_call's srca recursion. Explicit `_order_by` on the projected alias
+    // pins the chosen row deterministically across all three modes (M1=_sql,
+    // M2=linq via select_from, M3=plain linq over array). Tuple shape:
+    // (RefId:int, Label:string, Amount:int) → tuple<int;string;int> — leading int
+    // makes the arg-type list structurally distinct from every other test in this file.
     with_sqlite(":memory:") $(db) {
         fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
 
         let m1 = _sql(db |> select_from(type<User>)
                         |> _join(db |> select_from(type<Order>),
                                  $(u : User, o : Order) => u.Id == o.UserId,
                                  $(u : User, o : Order) => (RefId = o.Id, Label = u.Name, Amount = o.Total))
                         |> _where(_.Amount > 75)
+                        |> _order_by(_.Amount)
                         |> _first())
         let m2 = (db |> select_from(type<User>)
                     |> _join(db |> select_from(type<Order>),
                              $(u : User, o : Order) => u.Id == o.UserId,
                              $(u : User, o : Order) => (RefId = o.Id, Label = u.Name, Amount = o.Total))
                     |> _where(_.Amount > 75)
+                    |> _order_by(_.Amount)
                     |> _first())
+        let m3 = (users |> _join(orders,
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (RefId = o.Id, Label = u.Name, Amount = o.Total))
+                        |> _where(_.Amount > 75)
+                        |> _order_by(_.Amount)
+                        |> _first())
 
-        // _first picks an arbitrary row from the matching set; without ORDER BY the
-        // chosen row may differ between modes. Just assert the chain compiled and the
-        // returned row satisfies the predicate (the regression was a compile-time
-        // error — the macro analyzer rejected the chain shape, value-correctness
-        // didn't matter). Same applies to M3 — first() over the linq path on an
-        // unordered iterator picks an arbitrary match.
-        t |> equal(m1.Amount > 75, true, "M1 row passes the WHERE predicate")
-        t |> equal(m2.Amount > 75, true, "M2 row passes the WHERE predicate")
-        t |> equal(m1.Label != "" && m2.Label != "", true, "Label populated in both")
+        // Alice's orders 100 / 250 both pass `> 75`; ORDER BY Amount ASC picks 100
+        // (Order Id 10 = "Alice" / 100). Same row in all three modes.
+        t |> equal(m1.Amount, 100,    "M1 _first picks the ASC-min passing row")
+        t |> equal(m1.Label,  "Alice", "M1 row is Alice's")
+        t |> equal(m1.Amount, m2.Amount, "M1 ≡ M2 Amount")
+        t |> equal(m1.Label,  m2.Label,  "M1 ≡ M2 Label")
+        t |> equal(m1.RefId,  m2.RefId,  "M1 ≡ M2 RefId")
+        t |> equal(m2.Amount, m3.Amount, "M2 ≡ M3 Amount")
+        t |> equal(m2.Label,  m3.Label,  "M2 ≡ M3 Label")
+        t |> equal(m2.RefId,  m3.RefId,  "M2 ≡ M3 RefId")
+    }
+}
+
+[test]
+def parity_join_outer_where_first_inner_limit_leak(t : T?) {
+    // v2.1 review-2 regression for the inner-LIMIT leak: pre-fix, snapshot's
+    // `build_sql_string(q, true)` ran with q.matr=One pre-set by outer `_first` →
+    // inner subquery emitted `LIMIT 1` BEFORE the outer WHERE filtered. With the
+    // fixture's natural JOIN order (Alice 100, Alice 250, Bob 50), inner LIMIT 1
+    // picked Alice 100; outer WHERE OrderAmount == 50 filtered it → 0 rows →
+    // `_first()` (Materializer.One) panicked on empty result.
+    //
+    // After the fix, snapshot save→clears outer-terminal state pre-build_sql_string
+    // and restores it post-reset; inner emits no LIMIT, outer is
+    // `WHERE OrderAmount == 50 LIMIT 1` → picks Bob 50 correctly.
+    //
+    // Tuple shape (IsActive:bool, BuyerName:string, OrderAmount:int) → tuple<bool;string;int>
+    // — structurally distinct from every other test in this file.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        let m1 = _sql(db |> select_from(type<User>)
+                        |> _join(db |> select_from(type<Order>),
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (IsActive = u.Active, BuyerName = u.Name, OrderAmount = o.Total))
+                        |> _where(_.OrderAmount == 50)
+                        |> _first())
+        // Without the fix: m1 would be garbage (0 rows from outer WHERE → _first panic
+        // or zeroed). With the fix: deterministically Bob's order 12 (UserId 2, Total 50).
+        t |> equal(m1.BuyerName,   "Bob", "WHERE OrderAmount==50 picks Bob (only matching row)")
+        t |> equal(m1.OrderAmount, 50,    "Picked-row Total is 50")
+        t |> equal(m1.IsActive,    true,  "Bob is active")
     }
 }
 

--- a/tests/dasSQLITE/parity_check_15b_multi_join.das
+++ b/tests/dasSQLITE/parity_check_15b_multi_join.das
@@ -152,6 +152,43 @@ def parity_three_table_join(t : T?) {
 }
 
 [test]
+def parity_three_table_join_then_first(t : T?) {
+    // V2 latent regression: `_join(_join(A,B,...), C, ...) |> _first()` previously
+    // failed at compile time with "_join LHS chain cannot end in a terminal" — the
+    // snapshot helper mistook the OUTER `_first` for an INNER terminal. Same fix as
+    // the v2.1 single-join+terminal case (hoisted check in process_join_call). Reuses
+    // case 1's projection shape (UserName, OrderTotal, Sku, Qty); the named tuple is
+    // already cached from `parity_three_table_join`, so field names match.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+
+        let m1 = _sql(db |> select_from(type<User>)
+                        |> _join(db |> select_from(type<Order>),
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                        |> _join(db |> select_from(type<Item>),
+                                 $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                                 $(uo : UserOrder, it : Item) => (UserName = uo.UserName, OrderTotal = uo.OrderTotal, Sku = it.Sku, Qty = it.Qty))
+                        |> _first())
+        let m2 = (db |> select_from(type<User>)
+                    |> _join(db |> select_from(type<Order>),
+                             $(u : User, o : Order) => u.Id == o.UserId,
+                             $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                    |> _join(db |> select_from(type<Item>),
+                             $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                             $(uo : UserOrder, it : Item) => (UserName = uo.UserName, OrderTotal = uo.OrderTotal, Sku = it.Sku, Qty = it.Qty))
+                    |> _first())
+
+        // Without ORDER BY, _first returns an arbitrary matching row — exact M1/M2/M3
+        // values may differ. Just assert the chain compiled and a plausible row came
+        // back (was a compile-time error pre-fix).
+        t |> equal(m1.UserName != "", true, "M1 _first produced a row")
+        t |> equal(m2.UserName != "", true, "M2 _first produced a row")
+        t |> equal(m1.Qty > 0 && m2.Qty > 0, true, "Qty populated in both")
+    }
+}
+
+[test]
 def parity_three_table_join_with_outer_where(t : T?) {
     // Case 2 (v2.1): outer WHERE on a multi-join's projected alias. The WHERE peel
     // snapshots the analyzed q in place (in-place to avoid the linq Mode-2/3 typer
@@ -192,8 +229,9 @@ def parity_three_table_join_with_outer_where(t : T?) {
         m2 <- sort_by_user_sku(m2)
         m3 <- sort_by_user_sku(m3)
 
-        // Fixture has 3 BOOK items (Item 100, 102 — Item 101 is PEN, 103 is PAPER). Item 102 belongs to
-        // Order 11 (Alice, total 250); Item 100 to Order 10 (Alice, 100). Bob has no BOOK item. Expect 2 rows.
+        // Fixture has 2 BOOK items: Item 100 (Order 10, Alice, total 100) and
+        // Item 102 (Order 11, Alice, total 250). Item 101 is PEN, 103 is PAPER.
+        // Bob has no BOOK item. Expect 2 rows.
         t |> equal(length(m1), 2, "3-table + WHERE Sku=BOOK: 2 rows")
         t |> equal(length(m1), length(m2), "M1 length ≡ M2")
         t |> equal(length(m2), length(m3), "M2 length ≡ M3")
@@ -253,9 +291,14 @@ def parity_three_table_join_with_outer_where_int(t : T?) {
         t |> equal(length(m1), length(m2), "M1 length ≡ M2")
         t |> equal(length(m2), length(m3), "M2 length ≡ M3")
         for (i in range(length(m1))) {
-            t |> equal(m1[i].UserName, m2[i].UserName, "row[{i}].UserName: M1 ≡ M2")
-            t |> equal(m1[i].Sku,      m2[i].Sku,      "row[{i}].Sku:      M1 ≡ M2")
-            t |> equal(m1[i].Qty,      m2[i].Qty,      "row[{i}].Qty:      M1 ≡ M2")
+            t |> equal(m1[i].UserName,   m2[i].UserName,   "row[{i}].UserName:   M1 ≡ M2")
+            t |> equal(m1[i].OrderTotal, m2[i].OrderTotal, "row[{i}].OrderTotal: M1 ≡ M2")
+            t |> equal(m1[i].Sku,        m2[i].Sku,        "row[{i}].Sku:        M1 ≡ M2")
+            t |> equal(m1[i].Qty,        m2[i].Qty,        "row[{i}].Qty:        M1 ≡ M2")
+            t |> equal(m2[i].UserName,   m3[i].UserName,   "row[{i}].UserName:   M2 ≡ M3")
+            t |> equal(m2[i].OrderTotal, m3[i].OrderTotal, "row[{i}].OrderTotal: M2 ≡ M3")
+            t |> equal(m2[i].Sku,        m3[i].Sku,        "row[{i}].Sku:        M2 ≡ M3")
+            t |> equal(m2[i].Qty,        m3[i].Qty,        "row[{i}].Qty:        M2 ≡ M3")
         }
     }
 }

--- a/tests/dasSQLITE/parity_check_15b_multi_join.das
+++ b/tests/dasSQLITE/parity_check_15b_multi_join.das
@@ -151,9 +151,111 @@ def parity_three_table_join(t : T?) {
     }
 }
 
-// V2 deferred: outer WHERE on a multi-join's projected alias (`_join |> _join |> _where(_.alias)`)
-// needs an additional divert in the WHERE peel. The simple "wrap when q.proj != FullRow"
-// triggers a typer cascade in linq Mode-2/3 generic instantiation; the right shape requires
-// distinguishing "first wrap" from "passthrough wrap" and threading carefully. Tracked as v2.1.
-// In the meantime, the chain compiles via _sql but errors at SQL prepare with `no such column`,
-// which surfaces the gap to the user.
+[test]
+def parity_three_table_join_with_outer_where(t : T?) {
+    // Case 2 (v2.1): outer WHERE on a multi-join's projected alias. The WHERE peel
+    // snapshots the analyzed q in place (in-place to avoid the linq Mode-2/3 typer
+    // cascade that re-analysis would tickle) and renders as
+    // `... FROM (3-table joinSql) AS "t0" WHERE "alias" = ?`, with `alias` resolved
+    // through q.fromRowType set by the snapshot.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+        var items  <- fixture_items()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _join(db |> select_from(type<Order>),
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                         |> _join(db |> select_from(type<Item>),
+                                  $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                                  $(uo : UserOrder, it : Item) => (UserName = uo.UserName, OrderTotal = uo.OrderTotal, Sku = it.Sku, Qty = it.Qty))
+                         |> _where(_.Sku == "BOOK"))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _join(db |> select_from(type<Order>),
+                              $(u : User, o : Order) => u.Id == o.UserId,
+                              $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                     |> _join(db |> select_from(type<Item>),
+                              $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                              $(uo : UserOrder, it : Item) => (UserName = uo.UserName, OrderTotal = uo.OrderTotal, Sku = it.Sku, Qty = it.Qty))
+                     |> _where(_.Sku == "BOOK"))
+        var m3 <- (users |> _join(orders,
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                         |> _join(items,
+                                  $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                                  $(uo : UserOrder, it : Item) => (UserName = uo.UserName, OrderTotal = uo.OrderTotal, Sku = it.Sku, Qty = it.Qty))
+                         |> _where(_.Sku == "BOOK"))
+
+        m1 <- sort_by_user_sku(m1)
+        m2 <- sort_by_user_sku(m2)
+        m3 <- sort_by_user_sku(m3)
+
+        // Fixture has 3 BOOK items (Item 100, 102 — Item 101 is PEN, 103 is PAPER). Item 102 belongs to
+        // Order 11 (Alice, total 250); Item 100 to Order 10 (Alice, 100). Bob has no BOOK item. Expect 2 rows.
+        t |> equal(length(m1), 2, "3-table + WHERE Sku=BOOK: 2 rows")
+        t |> equal(length(m1), length(m2), "M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].UserName,   m2[i].UserName,   "row[{i}].UserName:   M1 ≡ M2")
+            t |> equal(m1[i].OrderTotal, m2[i].OrderTotal, "row[{i}].OrderTotal: M1 ≡ M2")
+            t |> equal(m1[i].Sku,        m2[i].Sku,        "row[{i}].Sku:        M1 ≡ M2")
+            t |> equal(m1[i].Qty,        m2[i].Qty,        "row[{i}].Qty:        M1 ≡ M2")
+            t |> equal(m2[i].UserName,   m3[i].UserName,   "row[{i}].UserName:   M2 ≡ M3")
+            t |> equal(m2[i].OrderTotal, m3[i].OrderTotal, "row[{i}].OrderTotal: M2 ≡ M3")
+            t |> equal(m2[i].Sku,        m3[i].Sku,        "row[{i}].Sku:        M2 ≡ M3")
+            t |> equal(m2[i].Qty,        m3[i].Qty,        "row[{i}].Qty:        M2 ≡ M3")
+            t |> equal(m1[i].Sku,        "BOOK",           "row[{i}].Sku == BOOK (predicate)")
+        }
+    }
+}
+
+[test]
+def parity_three_table_join_with_outer_where_int(t : T?) {
+    // v2.1: outer WHERE on a numeric outer-projection alias (Qty), with multi-arg AND.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+        var items  <- fixture_items()
+
+        var m1 <- _sql(db |> select_from(type<User>)
+                         |> _join(db |> select_from(type<Order>),
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                         |> _join(db |> select_from(type<Item>),
+                                  $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                                  $(uo : UserOrder, it : Item) => (UserName = uo.UserName, OrderTotal = uo.OrderTotal, Sku = it.Sku, Qty = it.Qty))
+                         |> _where(_.Qty >= 2 && _.UserName == "Alice"))
+        var m2 <- (db |> select_from(type<User>)
+                     |> _join(db |> select_from(type<Order>),
+                              $(u : User, o : Order) => u.Id == o.UserId,
+                              $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                     |> _join(db |> select_from(type<Item>),
+                              $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                              $(uo : UserOrder, it : Item) => (UserName = uo.UserName, OrderTotal = uo.OrderTotal, Sku = it.Sku, Qty = it.Qty))
+                     |> _where(_.Qty >= 2 && _.UserName == "Alice"))
+        var m3 <- (users |> _join(orders,
+                                  $(u : User, o : Order) => u.Id == o.UserId,
+                                  $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                         |> _join(items,
+                                  $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                                  $(uo : UserOrder, it : Item) => (UserName = uo.UserName, OrderTotal = uo.OrderTotal, Sku = it.Sku, Qty = it.Qty))
+                         |> _where(_.Qty >= 2 && _.UserName == "Alice"))
+
+        m1 <- sort_by_user_sku(m1)
+        m2 <- sort_by_user_sku(m2)
+        m3 <- sort_by_user_sku(m3)
+
+        // Alice's items with Qty >= 2: Item 100 (BOOK, Qty 2), Item 101 (PEN, Qty 5). Two rows.
+        t |> equal(length(m1), 2, "3-table + WHERE Qty>=2 AND UserName=Alice: 2 rows")
+        t |> equal(length(m1), length(m2), "M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].UserName, m2[i].UserName, "row[{i}].UserName: M1 ≡ M2")
+            t |> equal(m1[i].Sku,      m2[i].Sku,      "row[{i}].Sku:      M1 ≡ M2")
+            t |> equal(m1[i].Qty,      m2[i].Qty,      "row[{i}].Qty:      M1 ≡ M2")
+        }
+    }
+}

--- a/tests/dasSQLITE/parity_check_15b_multi_join.das
+++ b/tests/dasSQLITE/parity_check_15b_multi_join.das
@@ -156,11 +156,16 @@ def parity_three_table_join_then_first(t : T?) {
     // V2 latent regression: `_join(_join(A,B,...), C, ...) |> _first()` previously
     // failed at compile time with "_join LHS chain cannot end in a terminal" — the
     // snapshot helper mistook the OUTER `_first` for an INNER terminal. Same fix as
-    // the v2.1 single-join+terminal case (hoisted check in process_join_call). Reuses
-    // case 1's projection shape (UserName, OrderTotal, Sku, Qty); the named tuple is
-    // already cached from `parity_three_table_join`, so field names match.
+    // the v2.1 single-join+terminal case (hoisted check in process_join_call).
+    // Explicit `_order_by(_.OrderTotal)` pins the chosen row so all three modes
+    // (M1=_sql, M2=linq via select_from, M3=plain linq over array) agree on the
+    // _first() result. Reuses case 1's projection shape (UserName/OrderTotal/Sku/Qty);
+    // the named tuple is already cached from `parity_three_table_join`.
     with_sqlite(":memory:") $(db) {
         fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+        var items  <- fixture_items()
 
         let m1 = _sql(db |> select_from(type<User>)
                         |> _join(db |> select_from(type<Order>),
@@ -169,6 +174,7 @@ def parity_three_table_join_then_first(t : T?) {
                         |> _join(db |> select_from(type<Item>),
                                  $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
                                  $(uo : UserOrder, it : Item) => (UserName = uo.UserName, OrderTotal = uo.OrderTotal, Sku = it.Sku, Qty = it.Qty))
+                        |> _order_by(_.OrderTotal)
                         |> _first())
         let m2 = (db |> select_from(type<User>)
                     |> _join(db |> select_from(type<Order>),
@@ -177,14 +183,29 @@ def parity_three_table_join_then_first(t : T?) {
                     |> _join(db |> select_from(type<Item>),
                              $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
                              $(uo : UserOrder, it : Item) => (UserName = uo.UserName, OrderTotal = uo.OrderTotal, Sku = it.Sku, Qty = it.Qty))
+                    |> _order_by(_.OrderTotal)
                     |> _first())
+        let m3 = (users |> _join(orders,
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                        |> _join(items,
+                                 $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                                 $(uo : UserOrder, it : Item) => (UserName = uo.UserName, OrderTotal = uo.OrderTotal, Sku = it.Sku, Qty = it.Qty))
+                        |> _order_by(_.OrderTotal)
+                        |> _first())
 
-        // Without ORDER BY, _first returns an arbitrary matching row — exact M1/M2/M3
-        // values may differ. Just assert the chain compiled and a plausible row came
-        // back (was a compile-time error pre-fix).
-        t |> equal(m1.UserName != "", true, "M1 _first produced a row")
-        t |> equal(m2.UserName != "", true, "M2 _first produced a row")
-        t |> equal(m1.Qty > 0 && m2.Qty > 0, true, "Qty populated in both")
+        // 4-row joined result; ORDER BY OrderTotal ASC: Bob's Order 12 (Total 50, PAPER, Qty 10) wins.
+        t |> equal(m1.UserName,   "Bob",   "M1 _first picks Bob's row (lowest OrderTotal)")
+        t |> equal(m1.OrderTotal, 50,      "M1 OrderTotal is 50")
+        t |> equal(m1.Sku,        "PAPER", "M1 Sku matches Bob's only item")
+        t |> equal(m1.UserName,   m2.UserName,   "M1 ≡ M2 UserName")
+        t |> equal(m1.OrderTotal, m2.OrderTotal, "M1 ≡ M2 OrderTotal")
+        t |> equal(m1.Sku,        m2.Sku,        "M1 ≡ M2 Sku")
+        t |> equal(m1.Qty,        m2.Qty,        "M1 ≡ M2 Qty")
+        t |> equal(m2.UserName,   m3.UserName,   "M2 ≡ M3 UserName")
+        t |> equal(m2.OrderTotal, m3.OrderTotal, "M2 ≡ M3 OrderTotal")
+        t |> equal(m2.Sku,        m3.Sku,        "M2 ≡ M3 Sku")
+        t |> equal(m2.Qty,        m3.Qty,        "M2 ≡ M3 Qty")
     }
 }
 

--- a/tests/dasSQLITE/parity_check_15b_multi_join.das
+++ b/tests/dasSQLITE/parity_check_15b_multi_join.das
@@ -323,3 +323,99 @@ def parity_three_table_join_with_outer_where_int(t : T?) {
         }
     }
 }
+
+[test]
+def parity_three_table_join_then_count(t : T?) {
+    // v2.1 review-3 regression for E1 + multi-join: `_join(_join(A,B), C) |> count()`
+    // (no WHERE). Pre-fix: outer process_join_call's analyze_projection clobbered
+    // q.proj=NamedTuple after the multi-join snapshot ran, dropping aggregateExpr=COUNT(*).
+    // Post-fix: process_join_call's save/restore preserves aggregate state across BOTH
+    // inner and outer analyze_projection calls.
+    //
+    // Outer projection: (PayPlus:int, Stock:int, Code:string, Holder:string)
+    // → tuple<int;int;string;string> — structurally distinct from every other test here.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+        var items  <- fixture_items()
+
+        let n1 = _sql(db |> select_from(type<User>)
+                        |> _join(db |> select_from(type<Order>),
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                        |> _join(db |> select_from(type<Item>),
+                                 $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                                 $(uo : UserOrder, it : Item) => (PayPlus = uo.OrderTotal, Stock = it.Qty, Code = it.Sku, Holder = uo.UserName))
+                        |> count())
+        let n2 = (db |> select_from(type<User>)
+                    |> _join(db |> select_from(type<Order>),
+                             $(u : User, o : Order) => u.Id == o.UserId,
+                             $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                    |> _join(db |> select_from(type<Item>),
+                             $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                             $(uo : UserOrder, it : Item) => (PayPlus = uo.OrderTotal, Stock = it.Qty, Code = it.Sku, Holder = uo.UserName))
+                    |> count())
+        let n3 = (users |> _join(orders,
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                        |> _join(items,
+                                 $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                                 $(uo : UserOrder, it : Item) => (PayPlus = uo.OrderTotal, Stock = it.Qty, Code = it.Sku, Holder = uo.UserName))
+                        |> count())
+
+        // 4 items each join their order's user → 4 rows total.
+        t |> equal(n1, 4, "3-table | count(): 4 INNER-join rows")
+        t |> equal(n1, n2, "M1 ≡ M2 count")
+        t |> equal(n2, n3, "M2 ≡ M3 count")
+    }
+}
+
+[test]
+def parity_three_table_join_outer_where_then_count(t : T?) {
+    // v2.1 review-3 regression for stacked snapshots: multi-join (v2 snapshot via
+    // process_join_call) + WHERE-peel (v2.1 snapshot) + count() — exercises BOTH snapshot
+    // paths preserving aggregate state across the OUTER COUNT(*) projection.
+    //
+    // Outer projection: (Holder:string, PayPlus:int, Stock:int, Code:string)
+    // → tuple<string;int;int;string> — structurally distinct from every other test here.
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users  <- fixture_users()
+        var orders <- fixture_orders()
+        var items  <- fixture_items()
+
+        let n1 = _sql(db |> select_from(type<User>)
+                        |> _join(db |> select_from(type<Order>),
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                        |> _join(db |> select_from(type<Item>),
+                                 $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                                 $(uo : UserOrder, it : Item) => (Holder = uo.UserName, PayPlus = uo.OrderTotal, Stock = it.Qty, Code = it.Sku))
+                        |> _where(_.PayPlus > 75)
+                        |> count())
+        let n2 = (db |> select_from(type<User>)
+                    |> _join(db |> select_from(type<Order>),
+                             $(u : User, o : Order) => u.Id == o.UserId,
+                             $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                    |> _join(db |> select_from(type<Item>),
+                             $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                             $(uo : UserOrder, it : Item) => (Holder = uo.UserName, PayPlus = uo.OrderTotal, Stock = it.Qty, Code = it.Sku))
+                    |> _where(_.PayPlus > 75)
+                    |> count())
+        let n3 = (users |> _join(orders,
+                                 $(u : User, o : Order) => u.Id == o.UserId,
+                                 $(u : User, o : Order) => (UserName = u.Name, OrderId = o.Id, OrderTotal = o.Total))
+                        |> _join(items,
+                                 $(uo : UserOrder, it : Item) => uo.OrderId == it.OrderId,
+                                 $(uo : UserOrder, it : Item) => (Holder = uo.UserName, PayPlus = uo.OrderTotal, Stock = it.Qty, Code = it.Sku))
+                        |> _where(_.PayPlus > 75)
+                        |> count())
+
+        // Items joined to Order.Total > 75: order 10 (100, BOOK), order 11 (250, PEN+BOOK).
+        // 3 rows. Order 12 (Total=50, PAPER) excluded.
+        t |> equal(n1, 3, "3-table | WHERE PayPlus>75 | count(): 3 rows")
+        t |> equal(n1, n2, "M1 ≡ M2 count")
+        t |> equal(n2, n3, "M2 ≡ M3 count")
+    }
+}

--- a/tests/language/clone.das
+++ b/tests/language/clone.das
@@ -96,12 +96,50 @@ def test_clone_table(t : T?) {
     }
 }
 
+// custom clone overloads on a struct: regression for synthesized
+// tuple/variant clone constness propagation. The outer `:= ` on the
+// tuple must propagate the RHS constness to each field, so the user's
+// const-flavor clone fires for `let` (const) tuples and the non-const
+// flavor fires for `var` (non-const) tuples.
+struct CFoo {
+    a : int
+    b : array<int>
+    via : int   // 1 = const path, 2 = non-const path
+}
+
+def clone(var res : CFoo; var src : CFoo ==const) {
+    res.a = src.a
+    res.b := src.b
+    res.via = 2
+}
+
+def clone(var res : CFoo; src : CFoo) {
+    res.a = src.a
+    res.b := src.b
+    res.via = 1
+}
+
+[sideeffects]
+def test_clone_tuple_constness_dispatch(t : T?) {
+    let tup1 = (10, CFoo(a = 1))
+    var tup2 = (20, CFoo(a = 2))
+    var c1 := tup1
+    var c2 := tup2
+    t |> equal(c1._0, 10)
+    t |> equal(c1._1.a, 1)
+    t |> equal(c1._1.via, 1)
+    t |> equal(c2._0, 20)
+    t |> equal(c2._1.a, 2)
+    t |> equal(c2._1.via, 2)
+}
+
 [test]
 def test_clone(t : T?) {
     test_clone_array(t)
     test_clone_table(t)
     test_clone_struct(t)
     test_clone_complex(t)
+    test_clone_tuple_constness_dispatch(t)
 }
 
 [export]


### PR DESCRIPTION
## Summary

Closes the F1 v2.1 backlog item from PR #2563 and resolves the F3 finding from `API_CHECKED.md` as a bonus carried on this branch.

**dasSQLITE multi-Q v2.1** — outer WHERE on a JOIN's named-tuple `into` projection (`_join(...) |> _where(_.alias)` and `_join(_join(A,B,...), C, ...) |> _where(_.alias)`) previously errored at SQLite prepare with `no such column: t0.`. The WHERE peel now snapshots the analyzed q in place via `snapshot_q_to_subquery_wrap(..., [fillPassthrough = true])` when `q.seenJoin && (q.proj == NamedTuple || q.aggregateExpr != "")`. The discriminator skips the `_select |> _where` path (already handled by the SELECT peel's `divert_to_inner`). Using the in-place snapshot helper instead of `divert_to_inner` avoids the linq Mode-2/3 typer cascade that re-analysis triggers.

**F3 — synthesized tuple/variant clone constness propagation** (compiler-side, separate session, carried on this branch). `_having |> _order_by` chains over grouped results previously failed deep inside `daslib/builtin.das:999` with no matching `_::clone(tuple<...>, ...)` overload. Fixed in `src/ast/ast_generate.cpp` / `ast_infer_type_op.cpp` / `ast_infer_type_function.cpp`: tuple/variant clone synthesis now generates one flavor per call-site constness, with the lowering site driving the choice. `failed_parity_check_14_order_after_group.das` (the F3 pin) flips to `parity_check_14_order_after_group.das` and passes.

**Review fixes** addressed three rounds of Copilot feedback inline.

## Branch commits (vs `origin/master`)

1. `11803a739` — multi-Q v2.1 — outer WHERE on JOIN's projected alias (initial)
2. `129f05121` — review-1: hoist `seenTerminal/seenToArray` check from `snapshot_q_to_subquery_wrap` into `process_join_call`'s srca recursion (where save-and-compare across `analyze_chain` correctly distinguishes inner vs outer terminal). Fixes both v2.1 (`_join | _where | _first/_count/_to_array`) AND a v2 latent bug (`_first(_join(_join, C))`). Plus fixture-comment fix and M2≡M3 row-content assertions.
3. `3704cece7` — F3 typer fix (tuple/variant clone constness propagation).
4. `1a009b30a` — F3 regression test (`tests/language/clone.das`).
5. `2c6d591eb` — review-2: fix snapshot's outer-terminal state leak — outer-peeled `_first`/`_take`/`_skip`/`_order_by`/`_distinct` state was leaking into the inner SQL via `build_sql_string(q, true)` (e.g. `LIMIT 1` lands BEFORE the outer WHERE filters → wrong row), then dropped from the outer entirely by the existing reset. Save → clear → build inner → reset → restore in `snapshot_q_to_subquery_wrap`. Plus M3+ORDER BY extension to both `_then_first` regression tests for cross-mode parity, and a new deterministic LIMIT-leak demonstration test.
6. `8e60d9daf` — review-3: fix aggregate state leak across JOIN — `_join(...) [|> _where(...)] |> count()` returned the wrong shape because `q.aggregateExpr` ("COUNT(*)") and `q.aggregateType` were not preserved through (a) `analyze_projection` inside `process_join_call`, and (b) the subquery snapshot. Fixed in lockstep so `aggregateExpr non-empty ⇒ proj=Aggregate` holds across all chain shapes. WHERE-peel snapshot guard tightened to also fire on aggregate intent. Snapshot's line-649 Aggregate rejection dropped (the seenTerminal hoist already covers inner-LHS user-terminals). Plus M2/M3 oracles on the LIMIT-leak demo.

## New parity tests (dasSQLITE side)

* `parity_check_15_join.das` — `parity_join_with_outer_where` (single `_join` + outer `_where(_.Spend > 75)`); `parity_join_with_outer_where_then_first` (M1/M2/M3 triplet with `_order_by` for deterministic `_first`); `parity_join_outer_where_first_inner_limit_leak` (deterministic LIMIT-leak repro using `_where(_.OrderAmount == 50)`, M1/M2/M3 oracle); `parity_join_then_count` (no-snapshot aggregate path); `parity_join_outer_where_then_count` (snapshot aggregate path).
* `parity_check_15b_multi_join.das` — `parity_three_table_join_with_outer_where` (3-table join + `_where(_.Sku == "BOOK")`); `parity_three_table_join_with_outer_where_int` (3-table join + `_where(_.Qty >= 2 && _.UserName == "Alice")`, M1≡M2≡M3); `parity_three_table_join_then_first` (M1/M2/M3 triplet with `_order_by` for deterministic multi-join `_first`); `parity_three_table_join_then_count` (v2 multi-join snapshot + aggregate); `parity_three_table_join_outer_where_then_count` (stacked v2 multi-join + v2.1 WHERE-peel snapshots + aggregate).
* F3: `failed_parity_check_14_order_after_group.das` flipped to `parity_check_14_order_after_group.das` (now passing) + new `tests/language/clone.das` regression.

## Test plan

- [x] Full interpreter suite: `daslang dastest/dastest.das -- --color --failures-only --test tests` — **7723 / 7723 pass**
- [x] Full AOT round-trip: `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --color --failures-only --test tests` — **7117 / 7117 pass**
- [x] Targeted regression checks: `parity_check_08_where`, `parity_check_09_select`, `parity_check_14b_aggregate_then_filter`, `parity_check_14_order_after_group` (F3-fixed), `parity_check_15_join`, `parity_check_15b_multi_join`, `parity_check_16_left_join`, `parity_check_17_subqueries` — all pass
- [x] Inner-SQL inspection via `options log`: confirms `_join | count()` and `_join | _where | count()` both emit `SELECT COUNT(*) FROM ...` (was projection columns + spurious LIMIT 1 pre-fix)
- [x] `mcp format_file` — already formatted
- [ ] CI green

## Doc updates

- [`API_CHECKED.md`](modules/dasSQLITE/API_CHECKED.md): F1 entry promoted to "v2.1 RESOLVED"; multi-join WHERE capability documented under shipped capabilities.
- [`API_REWORK.md`](modules/dasSQLITE/API_REWORK.md): v2.1 deferred section replaced with v2.1 shipped notes; the typedef-in-multi-join-lambda gotcha kept as the only remaining v2.1 deferred item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
