### PR TITLE
Tuple field names are part of the type

### DIFF
--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -113,12 +113,6 @@ jobs:
         ./vcpkg/vcpkg install openssl:x64-windows --binarycaching
         echo "VCPKG_ROOT=$(pwd)/vcpkg" >> $GITHUB_ENV
 
-    - name: "Clone required repos"
-      uses: actions/checkout@v4
-      with:
-        repository: profelis/das-fmt
-        path: das-fmt
-
     - name: "Build: Daslang (Release)"
       run: |
         set -eux
@@ -172,12 +166,12 @@ jobs:
       run: |
         set -eux
         cmake --build ./build --config Release --target all_utils_exe
-        $BIN/daslang -exe -output ./bin/das-fmt ./das-fmt/dasfmt.das
+        $BIN/daslang -exe -output ./bin/das-fmt ./utils/das-fmt/dasfmt.das
 
     - name: "Run formatter"
       run: |
         set -eux
-        $BIN/daslang ./das-fmt/dasfmt.das -- --path ./ --verify
+        $BIN/daslang ./utils/das-fmt/dasfmt.das -- --path ./ --verify
         $BIN/das-fmt.exe --path ./ --verify
 
     - name: "Test daslang_static"

--- a/daslib/base64.das
+++ b/daslib/base64.das
@@ -69,7 +69,7 @@ def public base64_decode(_in : string) : tuple<text : string; size : int> {
     peek_data(_in) $(inp) {
         outlen = base64_decode(inp, out)
     }
-    return (string(out), outlen)
+    return (text = string(out), size = outlen)
 }
 
 def public base64_decode(_in : string; var out : array<uint8>) : int {

--- a/daslib/clargs.das
+++ b/daslib/clargs.das
@@ -83,7 +83,7 @@ def public get_user_args() : array<string> {
 }
 
 def clargs_flag_name(field_name : string) : string {
-    return "--" + replace_multiple(field_name, [("_", "-")])
+    return "--" + replace_multiple(field_name, [(text="_", replacement="-")])
 }
 
 // Duplicate-flag policy: last occurrence wins.  Matches GNU getopt, Python

--- a/daslib/cpp_bind.das
+++ b/daslib/cpp_bind.das
@@ -81,7 +81,7 @@ def log_cpp_class_adapter(cpp_file : file; name : string; var cinfo : TypeDeclPt
         if (!fld._type.isFunction || fld.name == "__finalize" || fld.init != null) {
             continue
         }
-        push(methods, ("{fld.name}", idx))
+        push(methods, (name = "{fld.name}", index = idx))
         push_clone(types, fld._type)
     }
     let nmet = length(methods)

--- a/daslib/debug.das
+++ b/daslib/debug.das
@@ -1395,7 +1395,7 @@ class private DAgent : DapiDebugAgent {
                         return
                     }
                 }
-                frame.state |> emplace <| (STATE_VARS + uint64(length(frame.state)), category, [ variable])
+                frame.state |> emplace <| (uid = STATE_VARS + uint64(length(frame.state)), name = category, vars = [ variable])
             }
         })
     }

--- a/daslib/debug_eval.das
+++ b/daslib/debug_eval.das
@@ -277,7 +277,7 @@ def expr_value(var st : TokenStream) : Result {
     return st |> error("unexpected token {token}, expecting number or (")
 }
 
-def getStructFieldOffset(var st : TokenStream; ident : string; var result : Result) : tuple<int; TypeInfo> {
+def getStructFieldOffset(var st : TokenStream; ident : string; var result : Result) : tuple<offset : int; tinfo : TypeInfo> {
     var size = 0
     for (field in *result.tinfo.structType) {
         var tinfo : TypeInfo?
@@ -285,52 +285,52 @@ def getStructFieldOffset(var st : TokenStream; ident : string; var result : Resu
             tinfo = reinterpret<TypeInfo?>(unsafe(addr(field)))
         }
         if (field.name == ident) {
-            return (size, *tinfo)
+            return (offset = size, tinfo = *tinfo)
         }
         let al = get_type_align(tinfo) - 1
         size = (size + al) & ~al
         size += get_type_size(tinfo)
     }
-    return (-1, TypeInfo(uninitialized))
+    return (offset = -1, tinfo = TypeInfo(uninitialized))
 }
 
-def getTupleFieldOffset(var st : TokenStream; ident : string; var result : Result) : tuple<int; TypeInfo> {
+def getTupleFieldOffset(var st : TokenStream; ident : string; var result : Result) : tuple<offset : int; tinfo : TypeInfo> {
     var size = 0
     for (cnt in range(result.tinfo.argCount)) {
         let tinfo = unsafe(result.tinfo.argTypes[cnt])
         if (ident == "_{cnt}") {
-            return (size, *tinfo)
+            return (offset = size, tinfo = *tinfo)
         }
         let al = get_type_align(tinfo) - 1
         size = (size + al) & ~al
         size += get_type_size(tinfo)
     }
-    return (-1, TypeInfo(uninitialized))
+    return (offset = -1, tinfo = TypeInfo(uninitialized))
 }
 
-def getVectorOffset(var st : TokenStream; ident : string; var result : Result) : tuple<int; TypeInfo> {
+def getVectorOffset(var st : TokenStream; ident : string; var result : Result) : tuple<offset : int; tinfo : TypeInfo> {
     let ofs = getVectorOffset(result.tinfo.basicType, ident)
-    return (-1, TypeInfo(uninitialized)) if (ofs < 0)
+    return (offset = -1, tinfo = TypeInfo(uninitialized)) if (ofs < 0)
     let fieldSize = getVectorElementSize(result.tinfo.basicType)
     let tinfo = TypeInfo(
         basicType = getVectorElementType(result.tinfo.basicType),
         size = uint(fieldSize)
     )
-    return (ofs * fieldSize, tinfo)
+    return (offset = ofs * fieldSize, tinfo = tinfo)
 }
 
-def getHandleFieldOffset(var st : TokenStream; ident : string; var result : Result) : tuple<int; TypeInfo> {
+def getHandleFieldOffset(var st : TokenStream; ident : string; var result : Result) : tuple<offset : int; tinfo : TypeInfo> {
     unsafe {
         var ann = unsafe(reinterpret<TypeAnnotation?> result.tinfo.annotation)
         if (ann == null) {
-            return (-1, TypeInfo(uninitialized))
+            return (offset = -1, tinfo = TypeInfo(uninitialized))
         }
         let ofs  = int(get_handled_type_field_offset(ann, ident))
         if (ofs == -1) {
-            return (-1, TypeInfo(uninitialized))
+            return (offset = -1, tinfo = TypeInfo(uninitialized))
         }
         let tinfo = get_handled_type_field_type(ann, ident)
-        return (ofs, *tinfo)
+        return (offset = ofs, tinfo = *tinfo)
     }
 }
 

--- a/daslib/decs.das
+++ b/daslib/decs.das
@@ -414,7 +414,7 @@ def private new_entity_id() {
         decsState.entityFreeList |> pop
     } else {
         eid.id = uint(length(decsState.entityLookup))
-        decsState.entityLookup |> push((0, 0ul, 0))
+        decsState.entityLookup |> push((generation = 0, archetype = ComponentHash(0ul), index = 0))
     }
     eid.generation ++
     return eid
@@ -618,14 +618,14 @@ def private can_process_request(var erq : EcsRequest; var arch : Archetype) {
 def public verify_request(var erq : EcsRequest) : tuple<ok : bool; error : string> {
     //! Verifies ECS request. Returns pair of boolean (true for OK) and error message.
     if (erq.hash == 0ul || (empty(erq.req) && empty(erq.reqn))) {
-        return (true, "")     // this queries just about everything
+        return (ok = true, error = "")     // this queries just about everything
     }
     for (N in erq.reqn) {// assuming require_not is typically shorter
         if (erq.req |> binary_search(N)) {
-            return (false, "duplicate req and neq {N}")
+            return (ok = false, error = "duplicate req and neq {N}")
         }
     }
-    return (true, "")
+    return (ok = true, error = "")
 }
 
 def public compile_request(var erq : EcsRequest) {
@@ -900,7 +900,7 @@ def private update_entity_imm(eid : EntityId; blk : lambda<(eid : EntityId; var 
                 narch |> create_archetype(cmp, idx)
             }
             let neidx = narch |> create_entity(eid, cmp)
-            decsState.entityLookup[eid.id] =  (eid.generation, new_ahash, neidx)
+            decsState.entityLookup[eid.id] = (generation = eid.generation, archetype = new_ahash, index = neidx)
         }
     }
     delete cmp
@@ -917,7 +917,7 @@ def private create_entity_imm(eid : EntityId; blk : lambda<(eid : EntityId; var 
             arch |> create_archetype(cmp, idx)
         }
         let eidx = arch |> create_entity(eid, cmp)
-        decsState.entityLookup[eid.id] =  (eid.generation, ahash, eidx)
+        decsState.entityLookup[eid.id] = (generation = eid.generation, archetype = ahash, index = eidx)
     }
     delete cmp
 }
@@ -992,7 +992,7 @@ def public create_entities(count : int; blk : block<(eid : EntityId; i : int; va
                 memcpy(addr(c.data[base * c.stride]), addr(comp.data), c.stride)
             }
         }
-        decsState.entityLookup[first_eid.id] = (first_eid.generation, ahash, base)
+        decsState.entityLookup[first_eid.id] = (generation = first_eid.generation, archetype = ahash, index = base)
         // Fill remaining entities (reuse cmp — set overwrites existing entries)
         for (i in range(1, count)) {
             var eid = new_entity_id()
@@ -1008,7 +1008,7 @@ def public create_entities(count : int; blk : block<(eid : EntityId; i : int; va
                     memcpy(addr(c.data[eidx * c.stride]), addr(comp.data), c.stride)
                 }
             }
-            decsState.entityLookup[eid.id] = (eid.generation, ahash, eidx)
+            decsState.entityLookup[eid.id] = (generation = eid.generation, archetype = ahash, index = eidx)
         }
         arch.size += count
     }
@@ -1046,7 +1046,7 @@ def public create_entities_from_cmp(count : int; var cmp : ComponentMap;
             let eid = EntityId(id = id_base + uint(i), generation = 1)
             let eidx = base + i
             invoke(fill_blk, arch, eidx, eid, i)
-            decsState.entityLookup[eid.id] = (eid.generation, ahash, eidx)
+            decsState.entityLookup[eid.id] = (generation = eid.generation, archetype = ahash, index = eidx)
         }
         arch.size += count
     }

--- a/daslib/decs_boost.das
+++ b/daslib/decs_boost.das
@@ -687,8 +687,10 @@ class FromDecsMacro : AstCallMacro {
         }
         // tuple to push
         var mkTuple = new ExprMakeTuple(at = expr.at)
-        for (arg in qblk.arguments) {
+        mkTuple.recordNames.resize(qblk.arguments.length())
+        for (arg, idx in qblk.arguments, count()) {
             mkTuple.values |> push(new ExprVar(at = arg.at, name := arg.name))
+            mkTuple.recordNames[idx] := arg.name
         }
         // block with arguments
         var qblock = qmacro(${

--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -93,25 +93,25 @@ def call_macro_label_name(mod, value) {
 def public safe_function_name(name : string) : string {
     //! Replaces special characters in a function name to produce a safe RST label identifier.
     return name |> replace_multiple([
-        (" ", "_"),
-        ("$", "_builtin_"),
-        ("#", "_hh_"),
-        (":", "_c_"),
-        ("@", "_at_"),
-        ("<", "_ls_"),
-        (">", "_gr_"),
-        ("`", "_rq_"),
-        ("!", "_ex_"),
-        ("=", "_eq_"),
-        ("*", "_st_"),
-        (".", "_dot_"),
-        ("?", "_q_"),
-        ("&", "_ref_"),
-        ("(", ""),
-        (")", ""),
-        ("[", "_lb_"),
-        ("]", "_rb_"),
-        ("|", "")])
+        (text = " ", replacement = "_"),
+        (text = "$", replacement = "_builtin_"),
+        (text = "#", replacement = "_hh_"),
+        (text = ":", replacement = "_c_"),
+        (text = "@", replacement = "_at_"),
+        (text = "<", replacement = "_ls_"),
+        (text = ">", replacement = "_gr_"),
+        (text = "`", replacement = "_rq_"),
+        (text = "!", replacement = "_ex_"),
+        (text = "=", replacement = "_eq_"),
+        (text = "*", replacement = "_st_"),
+        (text = ".", replacement = "_dot_"),
+        (text = "?", replacement = "_q_"),
+        (text = "&", replacement = "_ref_"),
+        (text = "(", replacement = ""),
+        (text = ")", replacement = ""),
+        (text = "[", replacement = "_lb_"),
+        (text = "]", replacement = "_rb_"),
+        (text = "|", replacement = "")])
 }
 
 def public function_label_file(value : FunctionPtr; drop_args : int = 0) {
@@ -605,9 +605,9 @@ def make_label(name : string) {
 
 def make_ref(name, text : string) {
     let t = (text |> replace_multiple([
-        ("<", "\\<"),
-        (">", "\\>"),
-        ("!", "\\!"
+        (text = "<", replacement = "\\<"),
+        (text = ">", replacement = "\\>"),
+        (text = "!", replacement = "\\!"
     )]))
     return " :ref:`{t} <{name}>`"
 }
@@ -1634,7 +1634,7 @@ def document_structure_annotation(doc_file : file; mod : Module?; value) {
     tab |> emplace(array<string>("field", "type"))
     var fields : array<tuple<name : string; typ : string; offset : uint>>
     for_each_field(*ann) $(name, cppName, xtype, offset) {
-        fields |> emplace((name, describe_type(xtype), offset))
+        fields |> emplace((name = name, typ = describe_type(xtype), offset = offset))
     }
 
     fields |> sort($(a, b) => a.offset < b.offset)
@@ -2203,14 +2203,14 @@ def public append_to_group_by_regex(var group : DocGroup; var mod : Module?; var
     for_each_function(mod, "") $(func) {
         if (function_needs_documenting(func)) {
             if (regex_match(reg, string(func.name)) != -1) {
-                push(group.func, (func, mod))
+                push(group.func, (fn = func, mod = mod))
             }
         }
     }
     for_each_generic(mod) $(func) {
         if (function_needs_documenting(func)) {
             if (regex_match(reg, string(func.name)) != -1) {
-                push(group.func, (func, mod))
+                push(group.func, (fn = func, mod = mod))
             }
         }
     }

--- a/daslib/rst_comment.das
+++ b/daslib/rst_comment.das
@@ -437,7 +437,7 @@ class RstComment : AstCommentReader {
             }
         } else {
             if (function_comment != "") {
-                field_comments |> push( ("function",function_label_file(fn),function_comment))
+                field_comments |> push( (kind = "function", name = function_label_file(fn), comment = function_comment))
             }
             state = ParserState.structure
         }
@@ -458,7 +458,7 @@ class RstComment : AstCommentReader {
         state = ParserState.field
         if (field_comment != "") {
             debug_rst("\t-> push {name} // {field_comment}")
-            field_comments |> push( ("field",clone_string(name),field_comment))
+            field_comments |> push( (kind = "field", name = clone_string(name), comment = field_comment))
         }
     }
     def override afterStructureFields ( prog:ProgramPtr; mod:Module?; info:LineInfo ) : void {

--- a/daslib/spoof.das
+++ b/daslib/spoof.das
@@ -19,23 +19,23 @@ require strings
 let SPOOF_SPEFICAL = '%'
 
 [macro_function]
-def spoof_args(invocation : string; blk : block<(var res : array<tuple<string; string>>; errors : array<ParsingError>) : void>) {
+def spoof_args(invocation : string; blk : block<(var res : array<tuple<argName : string; init : string>>; errors : array<ParsingError>) : void>) {
     parse(invocation) {
-        var element_list : array<tuple<string; string>>
+        var element_list : array<tuple<argName : string; init : string>>
         rule(WS, "(", WS, *comma_separated_elements as els, WS, element as last, WS, ")") {
             els |> push <| last
             return <- els
         }
-        var comma_separated_elements : tuple<string; string>
+        var comma_separated_elements : tuple<argName : string; init : string>
         rule(WS, element as e, WS, ",") {
             return e
         }
-        var element : tuple<string; string>
+        var element : tuple<argName : string; init : string>
         rule(ident_ as e, WS, "=", WS, element_value as v) {
-            return (e, v)
+            return (argName = e, init = v)
         }
         rule(ident_ as e) {
-            return (e, "")
+            return (argName = e, init = "")
         }
         var sub_element : string
         rule("\\", "{set(0..255)}" as Ch) {    // escape
@@ -92,7 +92,7 @@ def instance_spoof(temp : string; passed_arguments : array<string>) : tuple<resu
         }
     }
     if (args |> length == 0) {
-        return (error, false)
+        return (result = error, ok = false)
     }
     // compare argument counts
     var instance_arguments : array<string>
@@ -102,7 +102,7 @@ def instance_spoof(temp : string; passed_arguments : array<string>) : tuple<resu
         } elif (!empty(a.init)) {
             instance_arguments |> push <| a.init
         } else {
-            return ("invalid number of arguments", false)
+            return (result = "invalid number of arguments", ok = false)
         }
     }
     // skip to next line
@@ -117,7 +117,7 @@ def instance_spoof(temp : string; passed_arguments : array<string>) : tuple<resu
         Ch = -1
     }
     if (Ch == -1) {
-        return ("unexpected end of file", false)
+        return (result = "unexpected end of file", ok = false)
     }
     // now, lets apply the arguments
     var result : array<uint8>
@@ -149,13 +149,13 @@ def instance_spoof(temp : string; passed_arguments : array<string>) : tuple<resu
             } elif (Ch == -1) {
                 break   // eof
             } else {
-                return ("invalid sequence after %", false)
+                return (result = "invalid sequence after %", ok = false)
             }
         } else {
             result |> push(uint8(Ch))
         }
     }
-    return (string(result), true)
+    return (result = string(result), ok = true)
 }
 
 [reader_macro(name="spoof_template")]

--- a/daslib/static_let.das
+++ b/daslib/static_let.das
@@ -101,7 +101,7 @@ class StaticLetMacro : AstFunctionAnnotation {
                     let old_name = "{vclone.name}"
                     let new_name = "{prefix}{vclone.name}"
                     vclone.name := new_name
-                    renames |> push((old_name, new_name))
+                    renames |> push((old_name = old_name, new_name = new_name))
                     if (!(compiling_module() |> add_variable(vclone))) {
                         errors := "can't add global variable {new_name}"
                         return null

--- a/daslib/templates_boost.das
+++ b/daslib/templates_boost.das
@@ -40,7 +40,7 @@ struct Template {
 def kaboomVarField(var self : Template; name, prefix, suffix : string) {
     //! Adds a rule to to the template to replace a variable field access with a prefix and suffix.
     //! I.e. foo.bar into prefix + bar + suffix
-    self.kaboomVar |> emplace(name,  (prefix, suffix))
+    self.kaboomVar |> emplace(name,  (prefix = prefix, suffix = suffix))
 }
 
 def replaceVariable(var self : Template; name : string; var expr : ast::Expression?) {
@@ -984,7 +984,7 @@ def private apply_qrules(var expr : Expression?&) : ExprBlock? {
     if (astVisitor.failed) {
         eblk = null
     } else {
-        let annot_rules =  ("rules", RttiValue(tBool = true))
+        let annot_rules =  (argname = "rules", argvalue = RttiValue(tBool = true))
         eblk |> append_annotation("$", "unused_argument", [ annot_rules ])
     }
     unsafe { delete astVisitor; }
@@ -1008,7 +1008,7 @@ def private apply_function_qrules(var func : FunctionPtr) : ExprBlock? {
     if (astVisitor.failed) {
         eblk = null
     } else {
-        let annot_rules =  ("rules", RttiValue(tBool = true))
+        let annot_rules =  (argname = "rules", argvalue = RttiValue(tBool = true))
         eblk |> append_annotation("$", "unused_argument", [ annot_rules ])
     }
     unsafe { delete astVisitor; }
@@ -1045,7 +1045,7 @@ def private apply_template_qrules(prog : ProgramPtr; var template_structure : St
     if (astVisitor.failed) {
         eblk = null
     } else {
-        let annot_rules =  ("rules", RttiValue(tBool = true))
+        let annot_rules =  (argname = "rules", argvalue = RttiValue(tBool = true))
         eblk |> append_annotation("$", "unused_argument", [ annot_rules ])
     }
     unsafe { delete astVisitor; }

--- a/daslib/typemacro_boost.das
+++ b/daslib/typemacro_boost.das
@@ -99,9 +99,9 @@ class TypeMacroInfo : AstStructureAnnotation {
 
 [macro_function]
 def private append_arguments_annotation(var cls : StructurePtr; var func : FunctionPtr) {
-    var ann_args : array<tuple<string; RttiValue>>
+    var ann_args : array<tuple<argname : string; argvalue : RttiValue>>
     ann_args |> reserve(length(func.arguments) - 1)
-    var name = (string(func.name), RttiValue(tBool = true))
+    var name = (argname = string(func.name), argvalue = RttiValue(tBool = true))
     ann_args |> emplace(name)
     for (i in range(2, length(func.arguments))) {
         var value = RttiValue(tString = "```empty```type```")
@@ -117,7 +117,7 @@ def private append_arguments_annotation(var cls : StructurePtr; var func : Funct
                 value = RttiValue(tString = describe(argInit))
             }
         }
-        var blah = (string(func.arguments[i].name), value)
+        var blah = (argname = string(func.arguments[i].name), argvalue = value)
         ann_args |> emplace(blah)
     }
     cls |> append_annotation("typemacro_boost", "typemacro_documentation", ann_args)
@@ -152,7 +152,7 @@ class TypeMacroMacro : AstFunctionAnnotation {
             return false
         }
         field.init = qmacro(cast<auto>(@@$i(visitName)))
-        let name =  ("name", RttiValue(tString = string(func.name)))
+        let name =  (argname = "name", argvalue = RttiValue(tString = string(func.name)))
         cls |> append_annotation("ast_boost", "type_macro", [
             name
         ])
@@ -243,11 +243,11 @@ class TypeMacroTemplate : AstStructureAnnotation {
 [macro_function]
 def public make_typemacro_template_instance(instance_type, template_type : Structure?; ex : array<tuple<string, string>> = array<tuple<string, string>>()) {
     //! Annotates a structure as a typemacro template instance of the given template type.
-    var extra : array<tuple<string, RttiValue>>
+    var extra : array<tuple<argname : string, argvalue : RttiValue>>
     extra |> reserve(1 + length(ex))
-    extra.emplace(("parent", RttiValue(tString = "{template_type._module.name}::{template_type.name}")), 0)
+    extra.emplace((argname = "parent", argvalue = RttiValue(tString = "{template_type._module.name}::{template_type.name}")), 0)
     for (e in ex) {
-        extra.emplace((e._0, RttiValue(tString = e._1)), 0)
+        extra.emplace((argname = e._0, argvalue = RttiValue(tString = e._1)), 0)
     }
     unsafe {
         var append_structure <- reinterpret<Structure?>(instance_type)
@@ -534,7 +534,7 @@ class TemplateStructure : AstStructureAnnotation {
             return <- default<TypeDeclPtr>
         }
         append_annotation(makeFunction, "typemacro_boost", "typemacro_template_function", [
-             (("{st.name}", RttiValue(tBool=true))
+             ((argname="{st.name}", argvalue=RttiValue(tBool=true))
         )])
         if (!(compiling_module() |> add_function(makeFunction))) {
             panic("can't add function {makeFuncName}")

--- a/daslib/uriparser_boost.das
+++ b/daslib/uriparser_boost.das
@@ -50,7 +50,7 @@ def uri_compose_query_in_order(query : table<string; string>) {
     //! Compose a query string from a table of key-value pairs, in the sorted order.
     var vq : array<tuple<key : string; value : string>>
     for (key, value in keys(query), values(query)) {
-        vq |> push((key, value))
+        vq |> push((key = key, value = value))
     }
     sort(vq) $(a, b) {
         if (a.key == b.key) {

--- a/doc/source/reference/language/tuples.rst
+++ b/doc/source/reference/language/tuples.rst
@@ -13,13 +13,34 @@ A tuple type is declared with the ``tuple`` keyword followed by a list of elemen
     tuple<int; float>               // unnamed elements
     tuple<i:int; f:float>           // named elements
 
-Two tuple declarations are the same if they have the same number of types, and their respective types are the same:
+Tuple field names are part of the type. Two tuple declarations are the same only if
+they have the same number of elements, the same element types, **and the same
+field names** (in the same positions). An unnamed tuple is **not** assignable to a
+named tuple, and a named tuple is **not** assignable to a tuple with different
+names — even when the element types match:
 
 .. code-block:: das
 
-    var a : tuple<int, float>
-    var b : tuple<i:int, f:float>
-    a = b
+    var a : tuple<int; float>
+    var b : tuple<i:int; f:float>
+    var c : tuple<x:int; y:float>
+    // a = b   // error: tuple<int;float> is not the same type as tuple<i:int;f:float>
+    // b = c   // error: tuple<i:int;f:float> is not the same type as tuple<x:int;y:float>
+    var d : tuple<i:int; f:float>
+    b = d      // ok — same names, same types
+
+The same rule applies to construction: a bare positional literal ``(1, 2.0)``
+produces an unnamed ``tuple<int;float>`` and is not accepted where a named
+tuple type is expected. Use the named-field literal form to construct a named
+tuple directly:
+
+.. code-block:: das
+
+    var b : tuple<i:int; f:float> = (i = 1, f = 2.0)   // ok
+    // var b : tuple<i:int; f:float> = (1, 2.0)         // error: not the same type
+
+Mixing named and positional fields in the same literal is **not** supported —
+either every field is named or none are.
 
 Tuple elements can be accessed via nameless fields, i.e. _ followed by the 0 base field index:
 

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -989,7 +989,7 @@ def public audio_system_create : AudioSystemChannels {
     g_command_stream = s
     g_sound_sid = atomic64_create()
     unsafe(invoke_in_context(mixer_context(), "setup_command_processor", s))
-    return (s, g_sound_sid)
+    return (command = s, next_sid = g_sound_sid)
 }
 
 def public audio_system_finalize(var s : Stream?&; var next_sid : Atomic64?) {
@@ -1152,7 +1152,7 @@ def public play_3d_sound_loop_from_pcm(position : float3; attenuation : Attenuat
 
 def public append_to_pcm(sid : SID; var samples : array<float>) {
     //! append samples to PCM stream
-    push_cmd(AudioCommand(append_pcm <-  (sid, samples)))
+    push_cmd(AudioCommand(append_pcm <- (sid = sid, samples <- samples)))
     return sid
 }
 
@@ -1160,31 +1160,31 @@ def public append_box_to_pcm(sid : SID; box : LockBox?; var samples : array<floa
     //! append samples from lock box to PCM stream. Box is grabbed and released on audio thread.
     //! samples buffer must outlive the grab — caller keeps it alive until box.isReady.
     _builtin_lockbox_fill(box, unsafe(addr(samples)))
-    push_cmd(AudioCommand(append_box_pcm = (sid, intptr(box))))
+    push_cmd(AudioCommand(append_box_pcm = (sid = sid, box = intptr(box))))
     return sid
 }
 
 def public set_pause(sid : SID; paused : bool) {
     //! pause or unpause sound
-    push_cmd(AudioCommand(pause = (sid, paused)))
+    push_cmd(AudioCommand(pause = (sid = sid, paused = paused)))
     return sid
 }
 
 def public set_volume(sid : SID; volume : float; time : float = 0.002f) {
     //! set volume of sound
-    push_cmd(AudioCommand(volume = (sid, volume, time)))
+    push_cmd(AudioCommand(volume = (sid = sid, volume = volume, time = time)))
     return sid
 }
 
 def public set_pan(sid : SID; pan : float) {
     //! set pan of sound
-    push_cmd(AudioCommand(pan = (sid, pan)))
+    push_cmd(AudioCommand(pan = (sid = sid, pan = pan)))
     return sid
 }
 
 def public set_pitch(sid : SID; pitch : float) {
     //! set pitch of sound
-    push_cmd(AudioCommand(pitch = (sid, pitch)))
+    push_cmd(AudioCommand(pitch = (sid = sid, pitch = pitch)))
     return sid
 }
 
@@ -1200,7 +1200,7 @@ def public set_global_pause(pause : bool) {
 
 def public stop(sid : SID; time : float = 0.0f) {
     //! stop sound
-    push_cmd(AudioCommand(stop = (sid, time)))
+    push_cmd(AudioCommand(stop = (sid = sid, time = time)))
     return sid
 }
 
@@ -1237,7 +1237,7 @@ def public unset_status_update(sid : SID) {
 
 def public set_reverb(sid : SID; reverb : I3DL2ReverbProperties) {
     //! set reverb for sound
-    push_cmd(AudioCommand(reverb = (sid, reverb)))
+    push_cmd(AudioCommand(reverb = (sid = sid, properties = reverb)))
     return sid
 }
 
@@ -1275,7 +1275,7 @@ def public set_reverb_preset(sid : SID; preset : ReverbPreset) {
 
 def public set_chorus(sid : SID; config : ma_chorus_config) {
     //! set chorus effect for sound
-    push_cmd(AudioCommand(chorus_cmd = (sid, config)))
+    push_cmd(AudioCommand(chorus_cmd = (sid = sid, config = config)))
     return sid
 }
 
@@ -1286,7 +1286,7 @@ def public set_chorus_default(sid : SID) {
 
 def public set_playback_position(sid : SID; position : uint64) {
     //! set playback position for sound (in frames)
-    push_cmd(AudioCommand(set_playback_position = (sid, position)))
+    push_cmd(AudioCommand(set_playback_position = (sid = sid, position = position)))
     return sid
 }
 

--- a/modules/dasAudio/strudel/strudel_midi_player.das
+++ b/modules/dasAudio/strudel/strudel_midi_player.das
@@ -1144,7 +1144,7 @@ def public midi_set_volume(name : string; volume : float; fade : float = 0.0) {
     if (!g_midi_running || g_midi_cmd_stream == null) {
         return
     }
-    g_midi_cmd_stream |> push_archive(MidiCommand(set_volume = (name, volume, fade)))
+    g_midi_cmd_stream |> push_archive(MidiCommand(set_volume = (name = name, volume = volume, fade = fade)))
 }
 
 def public midi_set_pause(paused : bool) {

--- a/modules/dasClangBind/cbind/cbind_boost.das
+++ b/modules/dasClangBind/cbind/cbind_boost.das
@@ -156,7 +156,7 @@ def clang_getCursorLocationFullPath(var c : CXCursor) {
     var line, column, offset : uint
     clang_getSpellingLocation(clang_getCursorLocation(c), safe_addr(file), safe_addr(line), safe_addr(column), safe_addr(offset))
     // libclang returns backslashes on Windows; normalize to '/' so prefix matching is OS-independent
-    let fname = string(clang_getFileName(file)) |> replace_multiple([("\\", "/")])
+    let fname = string(clang_getFileName(file)) |> replace_multiple([(text = "\\", replacement = "/")])
     return "{fname}:{int(line)}:{int(column)}"
 }
 
@@ -1548,7 +1548,7 @@ class CppGenBind : AnyGenBind {
         if (clang_isForwardDeclaration(cursor)) {
             return
         }
-        enumDecl |> push((ns_en, enum_name))
+        enumDecl |> push((ns_en = ns_en, enum_name = enum_name))
         let dashing_name = namespace_name(enum_name, "_")
         fprint(enum_class_file, "// from {clang_getCursorLocationDescription(cursor)}\n")
         fprint(enum_class_file, "class Enumeration_{dashing_name} : public das::Enumeration \{\n")

--- a/modules/dasGlsl/glsl/geom_gen.das
+++ b/modules/dasGlsl/glsl/geom_gen.das
@@ -422,9 +422,9 @@ def private split_sptn(sptn : string) : tuple<p : int; t : int; n : int> {
     let ptn <- split(sptn, "/")
 
     if (length(ptn) == 1) {
-        return (s_to_int(ptn[0]), -1, -1)
+        return (p = s_to_int(ptn[0]), t = -1, n = -1)
     } else {
-        return (s_to_int(ptn[0]), s_to_int(ptn[1]), s_to_int(ptn[2]))
+        return (p = s_to_int(ptn[0]), t = s_to_int(ptn[1]), n = s_to_int(ptn[2]))
     }
 }
 

--- a/modules/dasGlsl/glsl/glsl_internal.das
+++ b/modules/dasGlsl/glsl/glsl_internal.das
@@ -1251,21 +1251,21 @@ class GlslExport : AstVisitor {
 // op2
     def getReplaceOp2(expr : ExprOp2?) : tuple<fun : string; replOp : bool> {
         if (expr.op == "%" && !expr._type.isInteger) {
-            return ("mod", true)
+            return (fun = "mod", replOp = true)
         }
         if (caps.replace_hlsl_incompatible_operations) {
             if (expr.op == "*") {
                 if (is_any_matrix(expr.left._type) || is_any_matrix(expr.right._type)) {
-                    return ("MUL", true)
+                    return (fun = "MUL", replOp = true)
                 }
             }
             if (expr.op == "==" || expr.op == "!=") {
                 if (is_any_matrix(expr.left._type) || expr.left._type.isVectorType || is_any_matrix(expr.right._type) || expr.right._type.isVectorType) {
-                    return ("all", false)
+                    return (fun = "all", replOp = false)
                 }
             }
         }
-        return ("", false)
+        return (fun = "", replOp = false)
     }
     def override preVisitExprOp2(expr : ExprOp2?) {
         let repl = self->getReplaceOp2(expr)
@@ -1399,7 +1399,7 @@ class GlslExport : AstVisitor {
                 let sdim = source._type.dim[length(source._type.dim) - 1]
                 *writer |> write("{svar.name}!={sdim}")
                 let newsrc = "{self->describe_subexpression(source)}[{svar.name}]"
-                renames |> push(("{iter}", newsrc))
+                renames |> push((name = "{iter}", repl = newsrc))
             } elif (self->isRangeFor(source)) {
                 *writer |> write("{svar.name}!=_for_range_v{svar.name}.y")
             }
@@ -1908,7 +1908,7 @@ def generate_glsl(fnMain : FunctionPtr; var errors : array<string>; shaderType :
     if (DEBUG_SHADER_TEXT) {
         print("{st}\n\n")
     }
-    return (st, inout_stub, inout_decl)
+    return (body = st, inout_stub = inout_stub, inout_decl = inout_decl)
 }
 
 [macro_function]
@@ -1960,7 +1960,7 @@ def get_decl_type_from_name(name : string) {
 [macro_function]
 def get_decl_info(typ : TypeDeclPtr; arguments : AnnotationArgumentList) : tuple<ok : bool; info : FieldDeclInfo> {
     if (length(typ.dim) > 0 || !(typ.isNumeric || typ.isVectorType)) {
-        return (false, FieldDeclInfo())
+        return (ok = false, info = FieldDeclInfo())
     }
     var fdi = FieldDeclInfo(
         sizei = arguments |> find_arg("size") ?as tInt ?? -1,
@@ -1978,7 +1978,7 @@ def get_decl_info(typ : TypeDeclPtr; arguments : AnnotationArgumentList) : tuple
             fdi.typet = typ.baseType
         }
     }
-    return fdi.typet != Type.none ?  (true, fdi) :  (false, FieldDeclInfo())
+    return fdi.typet != Type.none ? (ok = true, info = fdi) : (ok = false, info = FieldDeclInfo())
 }
 
 var public glsl_supported_semantics <- {

--- a/modules/dasLLVM/daslib/llvm_dll_utils.das
+++ b/modules/dasLLVM/daslib/llvm_dll_utils.das
@@ -12,7 +12,7 @@ struct public DllName {
     name : string
 
     def DllName(s : string) {
-        name = s |> replace_multiple([("@", "`At`"), ("=", "`Eq`"), ("<", "`Lt`"), (">", "`Gt`"), (",", "`C`")])
+        name = s |> replace_multiple([(text = "@", replacement = "`At`"), (text = "=", replacement = "`Eq`"), (text = "<", replacement = "`Lt`"), (text = ">", replacement = "`Gt`"), (text = ",", replacement = "`C`")])
     }
 
     def const impl() {

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -556,7 +556,7 @@ def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVM
     extern_resolver.uid = null
     extern_resolver.types = null
     unsafe { delete extern_resolver; }
-    return (any_unimp, whole_lib)
+    return (any_unimplemented = any_unimp, needs_whole_lib = whole_lib)
 }
 
 // Creates main function that initializes a standalone JIT context, registers
@@ -596,7 +596,7 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     }
     if (strict && has_no_jit) {
         to_log(LOG_ERROR, "Cannot build standalone exe: some functions are no_jit in strict mode\n")
-        return (null, false)
+        return (fn = null, link_whole_lib = false)
     }
 
     var start_fn_name = ""
@@ -615,7 +615,7 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     }
     if (start_fn_name |> empty()) {
         to_log(LOG_ERROR, "entrypoint `{entry_point}()` not found in input file.\n")
-        return (null, false)
+        return (fn = null, link_whole_lib = false)
     }
 
     let main_fn_type = LLVMFunctionType(types.t_int32,
@@ -761,7 +761,7 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     let (any_unimplemented, sort_needs_whole_lib) = collect_external_functions(global_context, ctx, builder, mod, types, funcs, uids, used_modules, dynamic_modules)
     if (strict && any_unimplemented) {
         to_log(LOG_ERROR, "Some of the nodes above are unimplemented!\n")
-        return (null, false)
+        return (fn = null, link_whole_lib = false)
     }
     // Determine if exe needs the whole compiler lib (rtti, ast, debugger, jit, sort-with-cblock)
     var needs_whole_lib = sort_needs_whole_lib
@@ -842,5 +842,5 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
         LLVMBuildRet(builder, main_ret)
     }
     to_log(LOG_INFO, "LLVM JIT: standalone exe entry point generated '{start_fn_name}', {length(funcs)} functions\n")
-    return (main_fn, needs_whole_lib)
+    return (fn = main_fn, link_whole_lib = needs_whole_lib)
 }

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -449,7 +449,7 @@ class public LlvmJitVisitor : AstVisitor {
                 }
             }
         }
-        return <-  (noalias, nocapture)
+        return <- (noalias <- noalias, nocapture <- nocapture)
     }
 
     def append_basic_block(name : string) {
@@ -5276,7 +5276,7 @@ class public LlvmJitVisitor : AstVisitor {
         unsafe {
             delete astVisitor
         }
-        return (result, impl)
+        return (func = result, impl = impl)
     }
 
     def override canVisitMakeBlockBody(expr : ExprMakeBlock?) : bool {

--- a/modules/dasOpenGL/opengl/opengl_boost_internal.das
+++ b/modules/dasOpenGL/opengl/opengl_boost_internal.das
@@ -167,7 +167,7 @@ class GlslVertexBuffer : AstStructureAnnotation {
         stype := null
         fn.body <- blk
         append_annotation(fn, "templates", "template", [(
-            ("self", RttiValue(tBool=true))
+            (argname = "self", argvalue = RttiValue(tBool=true))
         )])
         if (!(compiling_module() |> add_function(fn))) {
             panic("can't setup")

--- a/modules/dasOpenGL/opengl/opengl_ttf.das
+++ b/modules/dasOpenGL/opengl/opengl_ttf.das
@@ -105,7 +105,7 @@ def public create_quads(font : Font; text : string; at : float2 = float2(0.)) {
 def public quads_dim(quads : array<FontVertex>) : tuple<vmin : float2; vmax : float2> {
     //! Compute the axis-aligned bounding box of a quad array.
     if (empty(quads)) {
-        return (float2(0.), float2(0.))
+        return (vmin = float2(0.), vmax = float2(0.))
     }
     var vmin = float2(FLT_MAX, FLT_MAX)
     var vmax = float2(-FLT_MAX, -FLT_MAX)
@@ -113,7 +113,7 @@ def public quads_dim(quads : array<FontVertex>) : tuple<vmin : float2; vmax : fl
         vmin = min(vmin, q.xy)
         vmax = max(vmax, q.xy)
     }
-    return (vmin, vmax)
+    return (vmin = vmin, vmax = vmax)
 }
 
 enum public HJust {
@@ -192,7 +192,7 @@ def public create_ttf_objects {
 }
 
 def public get_ttf_program : tuple<vtx : string; frag : string> {
-    return (TTF_VERTEX_SRC, TTF_FRAGMENT_SRC)
+    return (vtx = TTF_VERTEX_SRC, frag = TTF_FRAGMENT_SRC)
 }
 
 def public set_ttf_objects(prog : uint) {

--- a/modules/dasPEG/peg/parse_macro.das
+++ b/modules/dasPEG/peg/parse_macro.das
@@ -67,12 +67,12 @@ def add_name(var rule : Rule; var name : string) {
 }
 
 
-def into_terminal(var expr : ExpressionPtr) : tuple<int; int> {
+def into_terminal(var expr : ExpressionPtr) : tuple<from : int; to : int> {
     if (expr is ExprConstInt) {
         // Single character '\n', '1', 'a'
 
         let v = (expr as ExprConstInt).value
-        return <-  (v, v)
+        return <- (from = v, to = v)
     } elif (expr is ExprCall && (expr as ExprCall).name == "interval") {
         // Range of charachters '1'..'9'
 
@@ -86,15 +86,15 @@ def into_terminal(var expr : ExpressionPtr) : tuple<int; int> {
         let left <- (left_exp as ExprConstInt).value
         let right <- (right_exp as ExprConstInt).value
 
-        return <-  (left, right)
+        return <- (from = left, to = right)
     }
 
     transfrom_error(expr.at, "Unknown rule passed to `rule` as argument {describe(expr)} into terminal")
-    return <-  (0, 0)
+    return <- (from = 0, to = 0)
 }
 
 [macro_function]
-def flatten_intervals(charset : array<tuple<from : int; to : int>>; invert : bool) {
+def flatten_intervals(charset : array<tuple<from : int; to : int>>; invert : bool) : tuple<chars : bool[256]; intervals : array<tuple<int; int>>> {
     var chars : bool[256]
 
     for (r in charset) {
@@ -128,7 +128,7 @@ def flatten_intervals(charset : array<tuple<from : int; to : int>>; invert : boo
         result |> push <|  (start, 256)
     }
 
-    return <-  (chars, result)
+    return <- (chars = chars, intervals <- result)
 }
 
 [macro_function]
@@ -228,7 +228,7 @@ def into_rule_(var expr : ExpressionPtr) : Rule_? {
         var set = expr as ExprCall
         let inverting = set.name == "not_set"
 
-        var terms : array<tuple<int; int>>
+        var terms : array<tuple<from : int; to : int>>
 
         for (arg in set.arguments) {
             terms |> push(arg |> into_terminal)

--- a/modules/dasPEG/peg/parser_generator.das
+++ b/modules/dasPEG/peg/parser_generator.das
@@ -626,7 +626,7 @@ def generate_maybe_repeat(var gen : ParserGenerator; var rule_ : Rule_?) : array
         }
 
         rule_code |> append_block_new <| (qmacro_block() {
-            return <-  (true, 0, parser.index);
+            return <- (success = true, value = 0, endpos = parser.index);
         })
 
         var t <- qmacro_block() {
@@ -654,7 +654,7 @@ def generate_maybe_repeat(var gen : ParserGenerator; var rule_ : Rule_?) : array
 
     rule_code |> append_block_new <| (qmacro_block() {
         $i(result_handle) |> emplace <| temp_name;
-        return <-  (true, 0, 0);
+        return <- (success = true, value = 0, endpos = 0);
     })
 
     var t <- qmacro_block() {
@@ -685,7 +685,7 @@ def generate_not(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expressi
     }
 
     rule_code |> append_block_new <| (qmacro_block() {
-        return <-  (true, 0, parser.index);
+        return <- (success = true, value = 0, endpos = parser.index);
     })
 
     var t <- qmacro_block() {
@@ -734,7 +734,7 @@ def generate_and(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expressi
     }
 
     rule_code |> append_block_new <| (qmacro_block() {
-        return <-  (true, 0, parser.index);
+        return <- (success = true, value = 0, endpos = parser.index);
     })
 
     var t <- qmacro_block() {
@@ -775,7 +775,7 @@ def generate_repeat(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expre
         }
 
         rule_code |> append_block_new <| (qmacro_block() {
-            return <-  (true, 0, parser.index);
+            return <- (success = true, value = 0, endpos = parser.index);
         })
 
         var t <- qmacro_block() {
@@ -818,7 +818,7 @@ def generate_repeat(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expre
 
     rule_code |> append_block_new <| (qmacro_block() {
         $i(result_handle) |> emplace <| temp_name;
-        return <-  (true, 0, parser.index);
+        return <- (success = true, value = 0, endpos = parser.index);
     })
 
     var type_decl = gen |> get_rule_type(rule_.rule)
@@ -993,7 +993,7 @@ def generate_option(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expre
             parser.suppress_errors |> push <| true
             invoke() {
                 $b(rule_code)
-                return <-  (false, 0, 0)
+                return <- (success = false, value = 0, endpos = 0)
             }
             parser.suppress_errors |> pop
         }
@@ -1013,7 +1013,7 @@ def generate_option(var gen : ParserGenerator; var rule_ : Rule_?) : array<Expre
 
     rule_code |> append_block_new <| (qmacro_block() {
         $i(result_handle) |> emplace <| temp_name;
-        return <-  (false, 0, 0);
+        return <- (success = false, value = 0, endpos = 0);
     })
 
     var t <- qmacro_block() {
@@ -1123,7 +1123,7 @@ def alternative_add_epilogue(var block_contents : array<ExpressionPtr>; var gen 
             parser |> log_plain <| "Returning result at index {parser.index}"
         }
 
-        var result : $t(return_type) <-  (true, val, parser.index) // nolint:PERF009 macro-generated tuple
+        var result : $t(return_type) <- (success = true, value <- val, endpos = parser.index) // nolint:PERF009 macro-generated tuple
         return <- result
     }
 
@@ -1220,8 +1220,8 @@ def generate_terminal(var gen : ParserGenerator; var terminal : Terminal) : Expr
         if (Terminal(number = $v(handle))) {
 
             return <- qmacro_block() {
-                let $i(name) : tuple<bool; int; int> = parser |> match_decimal_literal
-                if (!$i(name)._0) {
+                let $i(name) : tuple<success : bool; value : int; endpos : int> = parser |> match_decimal_literal
+                if (!$i(name).success) {
 
                     if ($v(gen.tracing)) {
                         parser |> log_fail <| "Could not match a decimal number"
@@ -1236,10 +1236,10 @@ def generate_terminal(var gen : ParserGenerator; var terminal : Terminal) : Expr
                 }
 
                 if ($v(gen.tracing)) {
-                    parser |> log_success <| "Matched a decimal number {$i(name)._1}"
+                    parser |> log_success <| "Matched a decimal number {$i(name).value}"
                 }
 
-                var $i(handle) = $i(name)._1 // nolint:LINT003
+                var $i(handle) = $i(name).value // nolint:LINT003
             }
         }
 
@@ -1343,9 +1343,9 @@ def generate_terminal(var gen : ParserGenerator; var terminal : Terminal) : Expr
                 }
 
                 if ($v(gen.tracing)) {
-                    parser |> log_success <| "Matched a string {$i(name)._1}"
+                    parser |> log_success <| "Matched a string {$i(name).value}"
                 }
-                var $i(handle) : string = $i(name)._1 // nolint:LINT003
+                var $i(handle) : string = $i(name).value // nolint:LINT003
             }
         }
 
@@ -1368,9 +1368,9 @@ def generate_terminal(var gen : ParserGenerator; var terminal : Terminal) : Expr
                 }
 
                 if ($v(gen.tracing)) {
-                    parser |> log_success <| "Matched a double {$i(name)._1}"
+                    parser |> log_success <| "Matched a double {$i(name).value}"
                 }
-                var $i(handle) = $i(name)._1 // nolint:LINT003
+                var $i(handle) = $i(name).value // nolint:LINT003
             }
         }
     }

--- a/modules/dasPEG/peg/peg.das
+++ b/modules/dasPEG/peg/peg.das
@@ -138,10 +138,10 @@ def public match_decimal_literal(var parser) : tuple<success : bool; value : int
         parser |> move(1)
     }
 
-    return (true, result, parser.index)
+    return (success = true, value = result, endpos = parser.index)
 }
 
-def public match_string_literal(var parser) : tuple<success : bool; string> {
+def public match_string_literal(var parser) : tuple<success : bool; value : string> {
     //! Tries to match everything inside ""
 
     // Define buffer to store string literal characters
@@ -150,7 +150,7 @@ def public match_string_literal(var parser) : tuple<success : bool; string> {
     var current_char = parser |> get_current_char
 
     // If the current character is not a double quote, the rule is not a string
-    return (false, "") if (current_char != '"');
+    return (success = false, value = "") if (current_char != '"');
 
     parser |> move(1);
     current_char = parser |> get_current_char;
@@ -162,21 +162,21 @@ def public match_string_literal(var parser) : tuple<success : bool; string> {
     }
 
     // If we've reached EOF file without finding a closing quote
-    return (false, "") if (parser |> reached_EOF)
+    return (success = false, value = "") if (parser |> reached_EOF)
 
     parser |> move(1)
-    return (true, buffer |> string())
+    return (success = true, value = buffer |> string())
 }
 
 
-def public match_double_literal(var parser) : tuple<success : bool; double> {
+def public match_double_literal(var parser) : tuple<success : bool; value : double> {
     //! Matches doubles in the form of [-+]? [0-9]* .? [0-9]+ ([eE] [-+]? [0-9]+)?
     //! The number is not checked to be representable as defined in IEEE-754
 
     var current_char = parser |> get_current_char
 
     if (!current_char |> is_number && current_char != '+' && current_char != '-') {
-        return <-  (false, 0.0 |> double())
+        return <- (success = false, value = 0.0 |> double())
     }
 
     var inscope buffer : array<uint8>
@@ -216,5 +216,5 @@ def public match_double_literal(var parser) : tuple<success : bool; double> {
         }
     }
 
-    return (true, buffer |> string() |> double())
+    return (success = true, value = buffer |> string() |> double())
 }

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -2172,7 +2172,7 @@ def private find_parent_table_and_pk(var st : StructurePtr; parent_name : string
         }
     }
     if (found_st == null) {
-        return ("", "", false)
+        return (tab_name = "", pk_col = "", found = false)
     }
     var tab = string(found_st.name)
     for (ann in found_st.annotations) {
@@ -2188,10 +2188,10 @@ def private find_parent_table_and_pk(var st : StructurePtr; parent_name : string
             if (pk_anno is tString) {
                 pk_col = string(pk_anno as tString)
             }
-            return (tab, pk_col, true)
+            return (tab_name = tab, pk_col = pk_col, found = true)
         }
     }
-    return (tab, "", false)
+    return (tab_name = tab, pk_col = "", found = false)
 }
 
 [structure_macro(name=sql_table)]
@@ -3627,30 +3627,30 @@ enum SqlFnTag {
 [macro_function]
 def private sql_fn_tag_for_type(td : TypeDeclPtr) : tuple<tag : uint8; ok : bool> {
     if (td == null) {
-        return (uint8(0), false)
+        return (tag = uint8(0), ok = false)
     }
     if (td.dim |> length != 0) {
-        return (uint8(0), false)
+        return (tag = uint8(0), ok = false)
     }
     if (td.baseType == Type.tInt) {
-        return (uint8(SqlFnTag.Int), true)
+        return (tag = uint8(SqlFnTag.Int), ok = true)
     }
     if (td.baseType == Type.tInt64) {
-        return (uint8(SqlFnTag.Int64), true)
+        return (tag = uint8(SqlFnTag.Int64), ok = true)
     }
     if (td.baseType == Type.tFloat) {
-        return (uint8(SqlFnTag.Float), true)
+        return (tag = uint8(SqlFnTag.Float), ok = true)
     }
     if (td.baseType == Type.tDouble) {
-        return (uint8(SqlFnTag.Double), true)
+        return (tag = uint8(SqlFnTag.Double), ok = true)
     }
     if (td.baseType == Type.tBool) {
-        return (uint8(SqlFnTag.Bool), true)
+        return (tag = uint8(SqlFnTag.Bool), ok = true)
     }
     if (td.baseType == Type.tString) {
-        return (uint8(SqlFnTag.String), true)
+        return (tag = uint8(SqlFnTag.String), ok = true)
     }
-    return (uint8(0), false)
+    return (tag = uint8(0), ok = false)
 }
 
 [call_macro(name="register_function")]

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -3035,10 +3035,10 @@ def private sql_function_info_from_func(func : FunctionPtr) : tuple<name : strin
             if (donArg is tBool) {
                 directonly = donArg as tBool
             }
-            return (name, directonly)
+            return (name = name, directonly = directonly)
         }
     }
-    return ("", false)
+    return (name = "", directonly = false)
 }
 
 [macro_function]

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -498,7 +498,9 @@ namespace das
             secondType->getLookupHash(hash);
         }
         if (baseType == Type::tBitfield || baseType == Type::tBitfield8 ||
-            baseType == Type::tBitfield16 || baseType == Type::tBitfield64) {
+            baseType == Type::tBitfield16 || baseType == Type::tBitfield64 ||
+            baseType == Type::tVariant || baseType == Type::tTuple
+        ) {
             for ( const auto & name : argNames ) {
                 hash = hashmix(hash, hash_block64(reinterpret_cast<const uint8_t *>(name.c_str()), name.size()));
             }
@@ -1733,7 +1735,7 @@ namespace das
                 if ( argTypes.size() != decl.argTypes.size() ) {
                     return false;
                 }
-                if (baseType == Type::tVariant) {
+                if (baseType == Type::tVariant || baseType == Type::tTuple) {
                     if (argNames.size() != decl.argNames.size()) {
                         return false;
                     }

--- a/tests/apply/test_apply.das
+++ b/tests/apply/test_apply.das
@@ -100,7 +100,7 @@ def test_apply_tuple(t : T?) {
 
 [test]
 def test_apply_named_tuple(t : T?) {
-    var foo : tuple<a : int; b : string> = (1, "hello")
+    var foo = (a = 1, b = "hello")
     apply(foo) $(name, field) {
         if (name != "a" && name != "b") {
             t->fatal("unknown field")

--- a/tests/dasHV/test_server_routes.das
+++ b/tests/dasHV/test_server_routes.das
@@ -76,7 +76,7 @@ class RouteTestServer : HvWebServer {
         }
         // JSON response
         GET("/api/status") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
-            let payload : tuple<status : string; version : int> = ("ok", 3)
+            let payload = (status = "ok", version = 3)
             return resp |> JSON(write_json(JV(payload)))
         }
     }

--- a/tests/jit_tests/tuple.das
+++ b/tests/jit_tests/tuple.das
@@ -13,30 +13,30 @@ def tuple_field(var f : FooT) {
 }
 
 def make_tuple_cmres : FooT {
-    return (1, 0.0, "bar", 0)
+    return (a = 1, b = 0.0, c = "bar", d = 0)
 }
 
 def make_tuple_with_subtuple_cmres : BarT {
-    return (1,  (2, 3., "", 0), 4)
+    return (a = 1, foo = (a = 2, b = 3., c = "", d = 0), b = 4)
 }
 
 def FooT : FooT {
-    return (1234, 1234.0, "1234", 1234)
+    return (a = 1234, b = 1234.0, c = "1234", d = 1234)
 }
 
 def make_tuple_with_field_call_to_cmres : BarT {
-    return (1, FooT(), 4)
+    return (a = 1, foo = FooT(), b = 4)
 }
 
 def make_tuple_on_stack(which : bool) : FooT {
-    var a =  (1, 2.0, "3", 4)
-    var b =  (2, 3.0, "4", 5)
+    var a : FooT = (a = 1, b = 2.0, c = "3", d = 4)
+    var b : FooT = (a = 2, b = 3.0, c = "4", d = 5)
     return which ? a : b
 }
 
 def make_tuple_with_subtuple_on_stack(which : bool) : BarT {
-    var a =  (1,  (2, 3., "", 0), 4)
-    var b =  (2,  (3, 4., "", 0), 5)
+    var a : BarT = (a = 1, foo = (a = 2, b = 3., c = "", d = 0), b = 4)
+    var b : BarT = (a = 2, foo = (a = 3, b = 4., c = "", d = 0), b = 5)
     return which ? a : b
 }
 

--- a/tests/jobque/test_jobque_stream.das
+++ b/tests/jobque/test_jobque_stream.das
@@ -169,9 +169,9 @@ def test_stream_archive_struct(t : T?) {
 def test_stream_archive_variant(t : T?) {
     t |> run("variant with uint64 handles serializes end-to-end") @(t : T?) {
         with_stream() $(var s : Stream?) {
-            s |> push_archive(CmdVariant(play = (1, "kick")))
+            s |> push_archive(CmdVariant(play = (id = 1, name = "kick")))
             s |> push_archive(CmdVariant(stop = 42))
-            s |> push_archive(CmdVariant(handle = (99, 0xDEADBEEFul)))
+            s |> push_archive(CmdVariant(handle = (id = 99, ptr = 0xDEADBEEFul)))
             s |> push_archive(CmdVariant(shutdown = true))
             var plays = 0
             var stops = 0

--- a/tests/language/tuple.das
+++ b/tests/language/tuple.das
@@ -4,18 +4,18 @@ require dastest/testing_boost public
 // Tests tuple creation, named fields, positional access, sizeof, heap allocation,
 // make_tuple syntax, fixed_array of tuples, and finalize/clone operations.
 
-def testI(arg : tuple<i : int; float>) {
+def testI(arg : tuple<i : int; f : float>) {
     return arg.i == 1
 }
 
-def testF(arg : tuple<int; f : float>) {
+def testF(arg : tuple<i : int; f : float>) {
     return arg.f == 3.14
 }
 
 [test]
 def test_tuple(t : T?) {
     t |> run("basic creation and named fields") @(t : T?) {
-        let ttt = (1, 3.14)
+        let ttt = (i = 1, f = 3.14)
         t |> equal(testI(ttt), true)
         t |> equal(testF(ttt), true)
         t |> equal(ttt._first, 1)

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -25,12 +25,12 @@ def test_from_decs(t : T?) {
         )
         t |> equal(qq.length(), 2)
         var expected = [
-            (1, "1"),
-            (0, "0")
+            (index = 1, text = "1"),
+            (index = 0, text = "0")
         ]
         for (c, e in qq, expected) {
-            t |> equal(c.index, e._0)
-            t |> equal(c.text, e._1)
+            t |> equal(c.index, e.index)
+            t |> equal(c.text, e.text)
         }
     }
 }

--- a/tests/strings/strings_replace_multiple.das
+++ b/tests/strings/strings_replace_multiple.das
@@ -8,34 +8,34 @@ require daslib/fuzzer
 def test_replace_multiple(t : T?) {
     t |> run("replace multiple") @@(t : T?) {
         // Test with multiple occurrences of different substrings
-        t |> equal("_1_2_1_2", replace_multiple("_foo_bar_foo_bar", [("foo", "1"), ("bar", "2")]))
+        t |> equal("_1_2_1_2", replace_multiple("_foo_bar_foo_bar", [(text = "foo", replacement = "1"), (text = "bar", replacement = "2")]))
 
         // Test with multiple occurrences of the same substring
-        t |> equal("1_1_1", replace_multiple("foo_foo_foo", [("foo", "1")]))
+        t |> equal("1_1_1", replace_multiple("foo_foo_foo", [(text = "foo", replacement = "1")]))
 
         // Test with substring as a prefix and a suffix
-        t |> equal("1_text_2", replace_multiple("foo_text_bar", [("foo", "1"), ("bar", "2")]))
+        t |> equal("1_text_2", replace_multiple("foo_text_bar", [(text = "foo", replacement = "1"), (text = "bar", replacement = "2")]))
 
         // Test with no matching substring (no replacement)
-        t |> equal("hello_world", replace_multiple("hello_world", [("foo", "1"), ("bar", "2")]))
+        t |> equal("hello_world", replace_multiple("hello_world", [(text = "foo", replacement = "1"), (text = "bar", replacement = "2")]))
 
         // Test with special characters in the substrings
         // we do not support overlap, otherwise 1_2_3 occurs
-        t |> equal("1$23", replace_multiple("@#$_*&^_%$", [("@#", "1"), ("_*&^", "2"), ("_%$", "3")]))
+        t |> equal("1$23", replace_multiple("@#$_*&^_%$", [(text = "@#", replacement = "1"), (text = "_*&^", replacement = "2"), (text = "_%$", replacement = "3")]))
 
         // Test with an empty source string
-        t |> equal("", replace_multiple("", [("foo", "1"), ("bar", "2")]))
+        t |> equal("", replace_multiple("", [(text = "foo", replacement = "1"), (text = "bar", replacement = "2")]))
 
         // Test with an empty array of replacements
-        let empty : array<tuple<string; string>>
+        let empty : array<tuple<text : string; replacement : string>>
         t |> equal("hello_world", replace_multiple("hello_world", empty))
 
         // Test with overlapping replacements
         // we do not support overlap, otherwise 1_23 occurs
-        t |> equal("13baz", replace_multiple("foobarbaz", [("foo", "1"), ("oob", "2"), ("bar", "3")]))
+        t |> equal("13baz", replace_multiple("foobarbaz", [(text = "foo", replacement = "1"), (text = "oob", replacement = "2"), (text = "bar", replacement = "3")]))
 
         // Test with multiple replacements in the same substring
-        t |> equal("1_2_3", replace_multiple("foo_bar_baz", [("foo", "1"), ("bar", "2"), ("baz", "3")]))
+        t |> equal("1_2_3", replace_multiple("foo_bar_baz", [(text = "foo", replacement = "1"), (text = "bar", replacement = "2"), (text = "baz", replacement = "3")]))
     }
 }
 

--- a/tutorials/dasHV/03_http_server.das
+++ b/tutorials/dasHV/03_http_server.das
@@ -103,7 +103,7 @@ class TutorialHttpServer : HvWebServer {
         // and the body.  Combine with daslib/json_boost for structured data.
         // JV() accepts structs and named tuples — field names become JSON keys.
         GET("/api/status") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
-            let payload : tuple<status : string; version : int> = ("ok", 3)
+            let payload = (status = "ok", version = 3)
             return resp |> JSON(write_json(JV(payload)))
         }
         POST("/api/echo") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {

--- a/tutorials/dasHV/04_http_server_advanced.das
+++ b/tutorials/dasHV/04_http_server_advanced.das
@@ -123,14 +123,14 @@ class AdvancedServer : HvWebServer {
         // JSON() and TEXT_PLAIN() accept an optional status parameter
         // (defaults to http_status.OK).
         GET("/not-found") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
-            let payload : tuple<error : string; code : int> = ("resource not found", 404)
+            let payload = (error = "resource not found", code = 404)
             return resp |> JSON(write_json(JV(payload)), http_status.NOT_FOUND)
         }
 
         // 201 Created with Location header
         POST("/items") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             set_header(resp, "Location", "/items/42")
-            let payload : tuple<id : int; body : string> = (42, string(req.body))
+            let payload = (id = 42, body = string(req.body))
             return resp |> JSON(write_json(JV(payload)), http_status.CREATED)
         }
 

--- a/tutorials/dasHV/05_cookies_and_forms.das
+++ b/tutorials/dasHV/05_cookies_and_forms.das
@@ -80,7 +80,7 @@ class CookieFormServer : HvWebServer {
             let prefs = get_cookie(req, "prefs")
             let s = !empty(session) ? string(session) : "not found"
             let p = !empty(prefs) ? string(prefs) : "not found"
-            let payload : tuple<session : string; prefs : string> = (s, p)
+            let payload = (session = s, prefs = p)
             return resp |> JSON(write_json(JV(payload)))
         }
 
@@ -118,7 +118,7 @@ class CookieFormServer : HvWebServer {
 
             let t = !empty(title) ? string(title) : ""
             let d = !empty(description) ? string(description) : ""
-            let payload : tuple<title : string; description : string; save_status : int; field_count : int> = (t, d, save_status, length(fields))
+            let payload = (title = t, description = d, save_status = save_status, field_count = length(fields))
             return resp |> JSON(write_json(JV(payload)))
         }
 

--- a/tutorials/language/48_apply.das
+++ b/tutorials/language/48_apply.das
@@ -147,7 +147,7 @@ def demo_tuples() {
     //     _1 = hello
 
     // Named tuple
-    let point : tuple<x : float; y : float> = (1.0, 2.0)
+    let point = (x = 1.0, y = 2.0)
     print("  Named tuple:\n")
     apply(point) $(name, field) {
         print("    {name} = {field}\n")

--- a/utils/benchctl/utils.das
+++ b/utils/benchctl/utils.das
@@ -34,12 +34,12 @@ def read_file(filename : string) : string {
 
 def bare_str(str : string) : string {
     return replace_multiple(str, [
-        ("\x1B[0m", ""),
+        (text = "\x1B[0m", replacement = ""),
 
-        ("\x1B[31m", ""),
-        ("\x1B[32m", ""),
-        ("\x1B[33m", ""),
-        ("\x1B[34m", ""),
+        (text = "\x1B[31m", replacement = ""),
+        (text = "\x1B[32m", replacement = ""),
+        (text = "\x1B[33m", replacement = ""),
+        (text = "\x1B[34m", replacement = ""),
     ])
 }
 

--- a/utils/das-fmt/LICENSE
+++ b/utils/das-fmt/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright © 2022 <Dmitri Granetchi>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/utils/das-fmt/README.md
+++ b/utils/das-fmt/README.md
@@ -1,0 +1,15 @@
+## Introduction
+
+dasfmt is a tool that automatically formats daScript source code.
+
+## Usage
+
+- `dascript dasfmt.das -- --path folderWithScriptsOrSingleScript [--path anotherPath]`
+
+### dastest.das arguments
+- `--path`: Path to the folder with scripts or single script name
+- `--exclude-mask <mask>`: A path with given masks as part of the path will be ignored
+- `--verify`: (dry run) Doesn't change files, just make sure that all files are already formatted
+- `--t`: Max number of used threads
+- `--verbose`: Print more information about the formatting process
+- `--no-color`, `--color`: Disable or enable color output

--- a/utils/das-fmt/dasfmt.das
+++ b/utils/das-fmt/dasfmt.das
@@ -1,0 +1,215 @@
+options gen2
+options indenting = 4
+
+require daslib/fio
+require strings
+require math
+
+require fs
+require log
+
+require daslib/jobque_boost
+require daslib/das_source_formatter
+require daslib/strings_boost
+
+
+def private normalize_line_endings(text : string) : string {
+    // Convert all line endings to LF for consistent comparison
+    var result = text
+    result = replace(result, "\r\n", "\n")  // Windows CRLF -> LF
+    result = replace(result, "\r", "\n")    // Old Mac CR -> LF
+    return result
+}
+
+
+def private collect_diff(before, after : string) : tuple<differ : bool; log : string> {
+    // Normalize line endings for comparison
+    let normalized_before = normalize_line_endings(before)
+    let normalized_after = normalize_line_endings(after)
+
+    // If identical after normalization, no differences
+    if (normalized_before == normalized_after) {
+        return (differ = false, log = "")
+    }
+
+    // Split into lines for line-by-line comparison
+    let lines_before = split(normalized_before, "\n")
+    let lines_after = split(normalized_after, "\n")
+    var diff_output = ""
+
+    let len_before = length(lines_before)
+    let len_after = length(lines_after)
+    let max_lines = max(len_before, len_after)
+
+    for (i in range(max_lines)) {
+        if (i >= len_before) {
+            // Added lines
+            diff_output += green_str("{i+1}a1\n> {lines_after[i]}\n")
+        } elif (i >= len_after) {
+            // Removed lines
+            diff_output += red_str("{i+1}d1\n< {lines_before[i]}\n")
+        } elif (lines_before[i] != lines_after[i]) {
+            // Changed lines
+            diff_output += (blue_str("{i+1}c1\n")
+                        + red_str("< {lines_before[i]}\n")
+                        + "---\n"
+                        + green_str("> {lines_after[i]}\n"))
+        }
+    }
+
+    return (differ = true, log = diff_output)
+}
+
+def private collect_input_paths(args : array<string>; key : string; var paths : array<string>) {
+    for (i in range(length(args) - 1)) {
+        if (args[i] == key) {
+            paths |> push <| args[i + 1]
+        }
+    }
+}
+
+
+def private collect_files(input_paths : array<string>; var files : array<string>) : bool {
+    var cache : table<string; void?>
+    for (path in input_paths) {
+        if (path |> ends_with(".das")) {
+            if (!cache |> key_exists(path)) {
+                cache.insert(path, null)
+                files |> push <| path
+            }
+        } else {
+            if (!fs::scan_dir(path, cache, files, ".das")) {
+                log::error("Unable to scan given path '{path}'")
+                return false
+            }
+        }
+    }
+    delete cache
+    return true
+}
+
+
+def private get_arg(args : array<string>; name : string; def_val : int = 0) : int {
+    let idx = find_index(args, name)
+    return idx >= 0 && idx + 1 < length(args) ? int(args[idx + 1]) : def_val
+}
+
+
+[export]
+def main() {
+    var args <- get_command_line_arguments()
+    log::init_log(args)
+    let threadsNum = max(args |> get_arg("--t") <| get_total_hw_threads(), 1)
+    let verify = args |> find_index("--verify") >= 0
+    let verbose = args |> find_index("--verbose") >= 0
+
+    let startTime = ref_time_ticks()
+
+    var inputPaths : array<string>
+    collect_input_paths(args, "--path", inputPaths)
+    var files : array<string>
+    if (!collect_files(inputPaths, files)) {
+        log::error("Unable to collect files list\n")
+        unsafe {
+            fio::exit(1)
+        }
+        return
+    }
+
+    var excludeMasks : array<string>
+    collect_input_paths(args, "--exclude-mask", excludeMasks)
+    var idx = length(files) - 1
+    while (idx >= 0) {
+        let path = files[idx]
+        for (excludePath in excludeMasks) {
+            if (path |> find(excludePath) >= 0) {
+                log::info("Excluding file '{path}' mask '{excludePath}'")
+                files |> erase(idx)
+                break
+            }
+        }
+        idx--
+    }
+
+    let filesNum = length(files)
+    var verified = true
+
+    with_job_que <| $() {
+        while (length(files) > 0) {
+            let batchNum = min(length(files), threadsNum)
+            with_job_status(batchNum) <| $(status) {
+                for (i in range(batchNum)) {
+                    let file = files[length(files) - 1]
+                    files |> pop()
+                    unsafe {
+                        new_job <| @ capture(& verified, := args) {
+                            log::init_log(args)
+                            var before : string
+                            var after : string
+                            var open = false
+                            fopen(file, "rb") <| $(fr) {
+                                if (fr != null) {
+                                    fmap(fr) <| $(data) {
+                                        open = true
+                                        before = string(data)
+                                        after = format_source(data)
+                                    }
+                                }
+                            }
+                            let diff_result = collect_diff(before, after)
+                            let changed = diff_result.differ
+                            if (!open) {
+                                log::info("-- {file}")
+                                log::error("Unable to open '{file}'")
+                            } elif (verify) {
+                                if (changed) {
+                                    log::error("Unformatted file '{file}'")
+                                    log::info(diff_result.log)
+                                    verified = false
+                                }
+                            } elif (!changed) {
+                                log::info("-- {file}")
+                            } else {
+                                var write = false
+                                fopen(file, "wb") <| $(fw) {
+                                    if (fw != null) {
+                                        fwrite(fw, after)
+                                        write = true
+                                    }
+                                }
+                                if (write) {
+                                    log::info("++ {file}")
+                                    if (verbose) {
+                                        log::info(diff_result.log)
+                                    }
+                                } else {
+                                    log::info("-- {file}")
+                                    log::error("Unable to open '{file}' for writing")
+                                }
+                            }
+                            status |> notify_and_release
+                        }
+                    }
+                }
+                status |> join
+            }
+        }
+    }
+
+    if (verify) {
+        if (verified) {
+            log::info("Verified! {filesNum} files in {time_dt_hr(get_time_usec(startTime))}")
+            return
+        } else {
+            log::info("Verification failed! {filesNum} files in {time_dt_hr(get_time_usec(startTime))}")
+            unsafe {
+                fio::exit(1)
+            }
+        }
+    }
+
+    log::info("Complete! {filesNum} files in {time_dt_hr(get_time_usec(startTime))}")
+}
+
+// options debugger
+// require daslib/debug

--- a/utils/das-fmt/fs.das
+++ b/utils/das-fmt/fs.das
@@ -1,0 +1,94 @@
+options gen2
+options indenting = 4
+
+module fs
+
+require daslib/fio
+require strings
+require uriparser
+
+
+def private ends_with_separator(str : string) : bool {
+    for (c in "\\/") {
+        if (ends_with(str, to_char(c))) {
+            return true
+        }
+    }
+    return false
+}
+
+
+def private starts_with_separator(str : string) : bool {
+    for (c in "\\/") {
+        if (starts_with(str, to_char(c))) {
+            return true
+        }
+    }
+    return false
+}
+
+
+def private trim_path(path : string) : string {
+    if (path == ".") {
+        return ""
+    }
+    if (path |> starts_with("./") || path |> starts_with(".\\")) {
+        return path |> slice(2)
+    }
+    return path
+}
+
+
+def join_path(a, path_b : string) : string {
+    let b = trim_path(path_b)
+    if (length(a) == 0) {
+        return fix_path(b)
+    }
+    if (length(b) == 0) {
+        return fix_path(a)
+    }
+    var res = build_string() <| $(builder) {
+        builder |> write(a)
+        let ends = ends_with_separator(a)
+        let starts = starts_with_separator(b)
+        if (ends && starts) {
+            builder |> write(slice(b, 1))
+        } elif (!ends && !starts) {
+            builder |> write("/")
+            builder |> write(b)
+        } else {
+            builder |> write(b)
+        }
+    }
+    return fix_path(res)
+}
+
+
+def fix_path(path : string) : string {
+    return path |> trim_path() |> file_name_to_uri() |> normalize_uri() |> uri_to_file_name()
+}
+
+
+def scan_dir(path : string; var cache : table<string; void?>; var res : array<string>; suffix = ".das") : bool {
+    let dirStat = stat(path)
+    if (!dirStat.is_dir) {
+        return false
+    }
+    fio::dir(path) <| $(n) {
+        if (n == "." || n == "..") {
+            return
+        }
+        let f = path |> join_path(n)
+        let fStat = stat(f)
+        if (!fStat.is_valid) {
+            return
+        }
+        if (fStat.is_dir) {
+            f |> scan_dir(cache, res, suffix)
+        } elif (fStat.is_reg && f |> ends_with(suffix) && !cache |> key_exists(f)) {
+            cache.insert(f, null)
+            res |> push(f)
+        }
+    }
+    return true
+}

--- a/utils/das-fmt/log.das
+++ b/utils/das-fmt/log.das
@@ -1,0 +1,119 @@
+options gen2
+options indenting = 4
+
+module log
+
+require daslib/rtti
+require uriparser
+require strings
+require daslib/fio
+
+
+let private verbose = false
+let private uriPaths = false
+
+var useTtyColors = false
+
+def info_raw(msg : string | #) {
+    print("{msg}")
+}
+
+def info(msg : string | #) {
+    if (!verbose) {
+        print("{msg}\n")
+    } else {
+        print("{msg} @{file_info_hr(get_line_info(1), uriPaths)}\n")
+    }
+}
+
+
+def warn(msg : string | #) {
+    if (!verbose) {
+        print(yellow_str("[W] {msg}\n"))
+    } else {
+        print(yellow_str("[W] {msg} @{file_info_hr(get_line_info(1), uriPaths)}\n"))
+    }
+}
+
+
+def error(msg : string | #) {
+    if (!verbose) {
+        print(red_str("[E] {msg}\n"))
+    } else {
+        print(red_str("[E] {msg} @{file_info_hr(get_line_info(1), uriPaths)}\n"))
+    }
+}
+
+
+def green(msg : string | #) {
+    if (!verbose) {
+        print(green_str("{msg}\n"))
+    } else {
+        print(green_str("{msg} @{file_info_hr(get_line_info(1), uriPaths)}\n"))
+    }
+}
+
+
+def red(msg : string | #) {
+    if (!verbose) {
+        print(red_str("{msg}\n"))
+    } else {
+        print(red_str("{msg} @{file_info_hr(get_line_info(1), uriPaths)}\n"))
+    }
+}
+
+
+def blue(msg : string | #) {
+    if (!verbose) {
+        print(blue_str("{msg}\n"))
+    } else {
+        print(blue_str("{msg} @{file_info_hr(get_line_info(1), uriPaths)}\n"))
+    }
+}
+
+
+def file_info_hr(at : LineInfo; uri_path : bool) {
+    return (uri_path
+        ? "{file_name_to_uri(at.fileInfo != null ? string(at.fileInfo.name) : "")}#{int(at.line)}"
+        : "{at.fileInfo != null ? string(at.fileInfo.name) : ""}:{int(at.line)}"
+    )
+}
+
+
+def red_str(str : string) {
+    return useTtyColors ? "\x1B[31m{str}\x1B[0m" : str
+}
+def green_str(str : string) {
+    return useTtyColors ? "\x1B[32m{str}\x1B[0m" : str
+}
+def yellow_str(str : string) {
+    return useTtyColors ? "\x1B[33m{str}\x1B[0m" : str
+}
+def blue_str(str : string) {
+    return useTtyColors ? "\x1B[34m{str}\x1B[0m" : str
+}
+
+def time_dt_hr(dt : int) : string {
+    return build_string <| $(str) {
+        str |> write("(")
+        str |> fmt(":.6f", double(dt) / 1000000.0lf)
+        str |> write("s)")
+    }
+}
+
+def init_log() {
+    init_log(get_command_line_arguments())
+}
+
+
+def init_log(args : array<string>) {
+    let noColor = has_env_variable("NO_COLOR") ? get_env_variable("NO_COLOR") : "0"
+    let forceNoColor = noColor != "0" && noColor != "false"
+    if (forceNoColor || has_value(args, "--no-color")) {
+        useTtyColors = false
+    } else {
+        let term = get_env_variable("TERM")
+        let probabblyColor = length(term) > 3 && (find(term, "xterm") >= 0 || find(term, "color") >= 0 || find(term, "ansi") >= 0 || find(term, "vt100") >= 0)
+        useTtyColors = has_value(args, "--color") || probabblyColor
+    }
+}

--- a/utils/das-fmt/pre-commit
+++ b/utils/das-fmt/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+root="$(git rev-parse --show-toplevel)"
+
+files=$((git diff --cached --name-only --diff-filter=ACMR | grep -Ei "\.das$") || true)
+
+if [ ! -z "${files}" ]; then
+    result=0
+    paths=""
+    for it in $files; do
+        paths+="--path ${it} "
+    done
+    daScript dasfmt.das -- ${paths} || result=1
+
+    for it in $files; do
+        git add "${it}"
+    done
+    exit $result
+fi


### PR DESCRIPTION
## Damage report

```
def take ( t ) => t

[export]
def main() {
    var a = take((foo=1,bar=2.))
    var b = take((goo=1,dar=3.))
    print("a = {typeinfo typename(a)}\n")   // tuple<foo:int,bar:float>
    print("b = {typeinfo typename(b)}\n")  // wrong tuple<foo:int,bar:float>
}
```
The reason is that take(tuple<int;float>) was instantiating once due to types being compatible. This PR is how we address it.

## Summary

- Tuple field names are now part of the type. `tuple<int;float>` and `tuple<a:int;b:float>` are no longer the same type, and two named tuples with different names don't match either, even when their element types are identical. Implemented in `TypeDecl::isSameType` / `TypeDecl::getLookupHash` — variants already worked this way; this extends the rule to tuples.
- All callers updated to construct named-field tuple literals (`(a = 1, b = 2.0)`) where the target type has names. Touches `daslib`, `modules/{dasAudio, dasGlsl, dasLLVM, dasOpenGL, dasPEG, dasSQLITE}`, several tests, tutorials, and `utils/benchctl`.
- `daslib/decs_boost`: `from_decs($(...))` now populates `ExprMakeTuple.recordNames`, so the generated `res |> push((field1, field2))` matches the iterator's named tuple type.
- Documentation: `doc/source/reference/language/tuples.rst` describes the new rule and the named-literal construction form.

## Test plan

- [x] `dastest -- --test tests/` — all folders pass (language, decs, linq, jit, jobque, dasSQLITE, dasPEG, strudel, dasHV, etc.)
- [x] `daslang -compile-only` over every `.das` under `daslib/`, `modules/`, `tests/`, `tutorials/`, `examples/`, `utils/` — clean (remaining failures on `master` were missing-prereq stubs and unrelated bugs, not tuple strictness)
- [x] `doc/reflections/das2rst.das` regenerates clean
- [x] Sphinx build clean (`sphinx-build -b html ... source ../site/doc` — `build succeeded.`, no warnings)
- [x] `format_file` reports all changed `.das` files formatted with spaces around `=` in named args
