### PR TITLE
dasSQLITE F3 cleanup: flip pin to positive parity, drop post-sort dodge

### DIFF
--- a/modules/dasSQLITE/API_CHECKED.md
+++ b/modules/dasSQLITE/API_CHECKED.md
@@ -340,7 +340,7 @@ predicate)` outside `_sql`. In plain linq the equivalent is
 `length(...) > 0` or the function-form `any(...)`; this is a
 different surface, not a parity divergence. Out of scope here.
 
-### F3 — `_having |> _order_by` after `_group_by` fails to compile in plain linq
+### F3 — `_having |> _order_by` after `_group_by` failed to compile in plain linq — RESOLVED
 
 Tutorial 14. Chains like:
 
@@ -348,8 +348,8 @@ Tutorial 14. Chains like:
 arr |> _group_by(_.City) |> _having(_._1 |> length >= 1) |> _order_by(_._0) |> _select(...)
 ```
 
-Mode 1 (`_sql`) emits `SELECT ... GROUP BY "City" HAVING ... ORDER BY "City"` and runs.
-Modes 2/3 fail to compile with a deep typer error:
+Mode 1 (`_sql`) emitted `SELECT ... GROUP BY "City" HAVING ... ORDER BY "City"` and ran.
+Modes 2/3 used to fail to compile with a deep typer error:
 
 ```
 error[30304]: no matching functions or generics:
@@ -359,59 +359,48 @@ error[30304]: no matching functions or generics:
   instanced from linq`order_by` ... at d:/Work/daScript/daslib/linq.das:413:8
 ```
 
-The trigger is the **combination** `_having |> _order_by`, not bare
-`_order_by` after `_group_by`. Without `_having`, the linq fusion of
-`_group_by + _order_by + _select(...)` apparently follows a path that
-doesn't materialize the grouped array for sorting; once `_having`
-is in the chain, post-aggregate filtering forces a real
+The trigger was the **combination** `_having |> _order_by`. Without
+`_having`, linq's fusion of `_group_by + _order_by + _select(...)`
+followed a path that didn't materialize the grouped array for sorting;
+once `_having` was in the chain, post-aggregate filtering forced a real
 `array<tuple<K, array<T>>>` to be produced, then sorted. linq's
-`order_by` calls `clone_to_move` on the input (`linq.das:413`), which
-needs a generic `_::clone` for the per-element type — and the nested
-`array<T>` (T = User, contains strings) has no synthesizable clone.
-The error fires deep inside `builtin.das`, far from the user's chain.
+`order_by` called `clone_to_move` on the input
+([daslib/linq.das:413](../../daslib/linq.das#L413)), which needed a
+generic `_::clone` for the per-element type — and the synthesized clone
+for `tuple<string, array<User>>` was emitted with the wrong constness,
+so resolution failed inside `builtin.das`, far from the user's chain.
 
-Two distinct issues stacked on top of each other:
-1. **Functional defect in linq:** `order_by` should be able to sort an
-   `array<tuple<...>>` whose elements contain non-cloneable nested
-   arrays. Sorting only needs move/swap, not deep clone — the
-   `clone_to_move` defensive copy is the part that should yield to
-   plain move semantics.
-2. **Diagnostic defect:** even if (1) is intentionally rejected, the
-   error must point at the user's `_order_by(_._0)` call and explain
-   "can't sort grouped results in linq because the grouping holds
-   owned arrays of T, and T isn't cloneable" — not at `builtin.das:999`.
+**Initial decision (Boris, 2026-05-02):** **(b)**. Add a `static_if`
+guard in linq's `order_by` to surface a clear error pointing at the
+user's `_order_by` call site rather than `builtin.das:999`.
 
-`parity_check_14_group_by.das` routes around F3 by **post-sorting**
-each mode's result manually with a `sort_by_city` helper, after
-removing inline `_order_by` from the chains. Negative-coverage test:
-[failed_parity_check_14_order_after_group.das](../../tests/dasSQLITE/failed_parity_check_14_order_after_group.das)
-pins the cryptic error so we'll notice when linq is fixed.
+**Actual resolution (2026-05-03):** **(a)** — fixed at the compiler
+level by [PR #2563](https://github.com/GaijinEntertainment/daScript/pull/2563)
+("synthesized tuple/variant clone constness"). `makeCloneTuple` /
+`makeCloneVariant` now keep `explicitConst=true`; the lowering site
+picks the flavor-per-constness, so `_::clone(tuple<K, array<T>>, ...)`
+resolves cleanly. linq's `clone_to_move` no longer hits the deep error;
+no `static_if` guard is needed.
 
-**Canonical form (today):** sort outside the chain, after materialization,
-when `_having` is involved.
-
-**Decision (Boris, 2026-05-02):** **(b)**. Add a `static_if` /
-`concept_assert` guard in linq's `order_by` (or its caller) that
-detects the case at compile-time and emits a clear error:
-"`order_by` cannot sort `array<tuple<K, array<T>>>` when T is not
-cloneable — sort outside the chain after materialization, or extend
-T with a `clone` overload." The error must point at the user's
-`_order_by` call site, not `builtin.das:999`. Plain linq stays
-unchanged for the cases that already work; `_sql` keeps full pushdown.
-Tutorials remain truthful — the error tells the user to either drop
-to post-sort or wrap in `_sql(...)`. This is the diagnostic-as-
-architecture path: the harness still surfaces the divergence, but the
-compiler now communicates it instead of the user discovering it via a
-deep typer trace. Implementation lives near `daslib/linq.das:411-413`.
+**Coverage** (`tests/dasSQLITE/`):
+- [parity_check_14_order_after_group.das](../../tests/dasSQLITE/parity_check_14_order_after_group.das) —
+  flipped from `expect 30304:1` divergence pin to a positive 3-mode
+  parity test on the exact `_having |> _order_by` chain.
+- [parity_check_14_group_by.das](../../tests/dasSQLITE/parity_check_14_group_by.das) —
+  `sort_by_city` post-sort workaround removed; 5 of 6 tests now use
+  inline `|> _order_by(_._0)`. The multi-key test stays on post-sort
+  (with a local `sort_by_city_age` helper) because the `_sql` analyzer's
+  tuple-key validator only accepts `_.Field` / string expressions, not
+  nested `_._0._N` walks — separate from F3.
 
 ## Walkthrough — complete (2026-05-02)
 
 Every tutorial under `tutorials/sql/01..41` has been audited. Tests live
-under `tests/dasSQLITE/parity_check_<NN>_*.das` (passing) and
-`tests/dasSQLITE/failed_parity_check_<NN>_*.das` (pinning known
-divergences for regression-detection).
+under `tests/dasSQLITE/parity_check_<NN>_*.das`. v2/v2.1 multi-Q parity
+coverage (`14b`, `15b`, `11b`/`c`/`d`) added 2026-05-03; F3 pin flipped
+to positive parity in the same sweep.
 
-### Tutorials with parity tests (23 files, ~70 [test] cases)
+### Tutorials with parity tests
 
 | Tutorial | File | Coverage |
 |----------|------|----------|
@@ -428,9 +417,12 @@ divergences for regression-detection).
 | 11 skip|where (multi-Q) | parity_check_11d_skip_then_where.das | inner-skip + outer-where, outer-where + outer-order |
 | 12 distinct | parity_check_12_distinct.das | full-row, single-col, where|select|distinct |
 | 12b set_ops | parity_check_12b_set_ops.das | union, intersect, except |
-| 13 aggregates | parity_check_13_aggregates.das | + F2 divergence pin |
-| 14 group_by | parity_check_14_group_by.das | post-sort to dodge F3 |
+| 13 aggregates | parity_check_13_aggregates.das | F2 RESOLVED — average promotes to double in all modes |
+| 14 group_by | parity_check_14_group_by.das | _group_by, _having, _order_by, multi-key, full reporting chain |
+| 14 having\|order_by | parity_check_14_order_after_group.das | F3 RESOLVED — inline `_order_by` after `_having` works in all modes |
+| 14 group_by (multi-Q) | parity_check_14b_aggregate_then_filter.das | aggregate-then-filter (v2 multi-Q lowering) |
 | 15 join | parity_check_15_join.das | inner join, left/right filter |
+| 15 multi-join (multi-Q) | parity_check_15b_multi_join.das | three-table multi-join with outer WHERE (v2.1) |
 | 16 left_join | parity_check_16_left_join.das | _left_join + Option<TB> projection |
 | 17 subqueries | parity_check_17_subqueries.das | `_in`/`_not_in`/`_any(pred)`/`_none(pred)` |
 | 18 null_handling | parity_check_18_null_handling.das | round-trip, is_some, is_none, unwrap_or |
@@ -471,17 +463,17 @@ divergences for regression-detection).
 |----|----------|----------|--------|
 | F1 | 11 take_skip | multi-Q lowering — `take \| skip` and latent siblings (`take \| where`, `take \| order`, `skip \| where`) all preserve linq positional semantics | resolved |
 | F2 | 13 aggregates | (a) fix `daslib/linq.das` `average` → always `double` | resolved |
-| F3 | 14 group_by | (b) `static_if` guard in `order_by` over `array<tuple<K, array<T>>>` | deferred fix |
+| F3 | 14 group_by | (a) compiler-side fix for synthesized tuple/variant clone constness | resolved (PR [#2563](https://github.com/GaijinEntertainment/daScript/pull/2563)) |
 | F4 | 17 subqueries | set `can_shadow` on synthesized `_` in `AstCallMacro_LinqPred2`/`LinqPredII2` | resolved (issue [#2559](https://github.com/GaijinEntertainment/daScript/issues/2559)) |
 | G1 | 16 left_join | add `_right_join` / `_full_outer_join` / `_cross_join` | issue [#2558](https://github.com/GaijinEntertainment/daScript/issues/2558) |
-| (lang) | 14 group_by | strongly-named tuple support (recordNames in cache key) | issue [#2557](https://github.com/GaijinEntertainment/daScript/issues/2557) |
+| (lang) | 14 group_by | strongly-named tuple support (recordNames in cache key) | resolved (PR [#2565](https://github.com/GaijinEntertainment/daScript/pull/2565), 2026-05-03) |
 
 ## Next steps
 
-- Land the four findings (F1–F4) as separate PRs, each with its parity
-  test flipping from `failed_parity_check_*.das` to `parity_check_*.das`
-  (or the workaround removed from the existing parity test).
-- G1 + #2557 are language-level — schedule independently of the
-  parity-test work.
-- After F1–F4 are resolved, re-run every `parity_check_*.das` and assert
-  zero divergences remain; promote the suite to a CI-required job.
+- F1, F2, F4 landed as separate PRs; F3 cleanup (this PR) flips the pin
+  test to a positive parity test and removes the post-sort workaround
+  in `parity_check_14_group_by.das`. The (lang) tuple-strict finding
+  was resolved in PR [#2565](https://github.com/GaijinEntertainment/daScript/pull/2565).
+- G1 ([#2558](https://github.com/GaijinEntertainment/daScript/issues/2558))
+  remains independent: `_right_join` / `_full_outer_join` / `_cross_join`
+  as first-class linq + `_sql` operators, plus tutorial 16 expansion.

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -1366,9 +1366,6 @@ the 5 peel-divert sites + the SELECT one (which uses a tighter
 - New `parity_check_11b_take_then_where.das` (5 cases).
 - New `parity_check_11c_take_then_order.das` (3 cases).
 - New `parity_check_11d_skip_then_where.das` (2 cases).
-- `failed_parity_check_14_order_after_group.das` (F3 pin) still
-  reports `30304:1` as expected — F3 is orthogonal (linq side, not
-  `_sql`).
 
 ### Tutorial 11
 

--- a/tests/dasSQLITE/parity_check_14_group_by.das
+++ b/tests/dasSQLITE/parity_check_14_group_by.das
@@ -9,15 +9,6 @@ require sqlite/sqlite_boost
 require sqlite/sqlite_linq
 
 // Parity check for tutorial 14 — `_group_by` and `_having`.
-//
-// Important: chains that combine `_group_by` with `_order_by(_._0)`
-// fail to compile in plain linq when the grouped element has non-
-// trivially-cloneable types (notably `array<User>` for User containing
-// strings). See API_CHECKED.md F3. To keep parity assertions alive,
-// each test below computes results without inline `_order_by` and
-// post-sorts each mode's result by the projected key for comparison.
-// Tests that demonstrate the F3 failure live in a separate `failed_*`
-// file.
 
 [sql_table(name = "Users")]
 struct User {
@@ -51,9 +42,9 @@ def fixture_array() : array<User> {
     return <- arr
 }
 
-def sort_by_city(var rows : array<auto(R)>) : array<R> {
-    rows |> sort() <| $(a, b) {
-        return a.City < b.City
+def sort_by_city_age(var rows : array<auto(R)>) : array<R> {
+    rows |> sort() $(a, b) {
+        return a.City == b.City ? a.Age < b.Age : a.City < b.City
     }
     return <- rows
 }
@@ -62,20 +53,19 @@ def sort_by_city(var rows : array<auto(R)>) : array<R> {
 def parity_group_by_count(t : T?) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db)
-        var arr <- fixture_array()
+        let arr <- fixture_array()
 
-        var m1 <- _sql(db |> select_from(type<User>)
+        let m1 <- _sql(db |> select_from(type<User>)
                          |> _group_by(_.City)
+                         |> _order_by(_._0)
                          |> _select((City = _._0, N = _._1 |> length)))
-        var m2 <- (db |> select_from(type<User>)
+        let m2 <- (db |> select_from(type<User>)
                      |> _group_by(_.City)
+                     |> _order_by(_._0)
                      |> _select((City = _._0, N = _._1 |> length)))
-        var m3 <- (arr |> _group_by(_.City)
+        let m3 <- (arr |> _group_by(_.City)
+                       |> _order_by(_._0)
                        |> _select((City = _._0, N = _._1 |> length)))
-
-        m1 <- sort_by_city(m1)
-        m2 <- sort_by_city(m2)
-        m3 <- sort_by_city(m3)
 
         t |> equal(length(m1), length(m2), "group+count: M1 length ≡ M2")
         t |> equal(length(m2), length(m3), "group+count: M2 length ≡ M3")
@@ -92,35 +82,34 @@ def parity_group_by_count(t : T?) {
 def parity_group_by_multi_aggregate(t : T?) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db)
-        var arr <- fixture_array()
+        let arr <- fixture_array()
 
-        var m1 <- _sql(db |> select_from(type<User>)
+        let m1 <- _sql(db |> select_from(type<User>)
                          |> _group_by(_.City)
+                         |> _order_by(_._0)
                          |> _select((
                              City   = _._0,
                              N      = _._1 |> length,
                              MinAge = _._1 |> select($(u : User) => u.Age)    |> min,
                              MaxAge = _._1 |> select($(u : User) => u.Age)    |> max,
                              Total  = _._1 |> select($(u : User) => u.Salary) |> sum)))
-        var m2 <- (db |> select_from(type<User>)
+        let m2 <- (db |> select_from(type<User>)
                      |> _group_by(_.City)
+                     |> _order_by(_._0)
                      |> _select((
                          City   = _._0,
                          N      = _._1 |> length,
                          MinAge = _._1 |> select($(u : User) => u.Age)    |> min,
                          MaxAge = _._1 |> select($(u : User) => u.Age)    |> max,
                          Total  = _._1 |> select($(u : User) => u.Salary) |> sum)))
-        var m3 <- (arr |> _group_by(_.City)
+        let m3 <- (arr |> _group_by(_.City)
+                       |> _order_by(_._0)
                        |> _select((
                            City   = _._0,
                            N      = _._1 |> length,
                            MinAge = _._1 |> select($(u : User) => u.Age)    |> min,
                            MaxAge = _._1 |> select($(u : User) => u.Age)    |> max,
                            Total  = _._1 |> select($(u : User) => u.Salary) |> sum)))
-
-        m1 <- sort_by_city(m1)
-        m2 <- sort_by_city(m2)
-        m3 <- sort_by_city(m3)
 
         t |> equal(length(m1), length(m2), "multi-agg length: M1 ≡ M2")
         t |> equal(length(m2), length(m3), "multi-agg length: M2 ≡ M3")
@@ -143,23 +132,22 @@ def parity_group_by_multi_aggregate(t : T?) {
 def parity_where_group_count(t : T?) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db)
-        var arr <- fixture_array()
+        let arr <- fixture_array()
 
-        var m1 <- _sql(db |> select_from(type<User>)
+        let m1 <- _sql(db |> select_from(type<User>)
                          |> _where(_.Age >= 30)
                          |> _group_by(_.City)
+                         |> _order_by(_._0)
                          |> _select((City = _._0, N = _._1 |> length)))
-        var m2 <- (db |> select_from(type<User>)
+        let m2 <- (db |> select_from(type<User>)
                      |> _where(_.Age >= 30)
                      |> _group_by(_.City)
+                     |> _order_by(_._0)
                      |> _select((City = _._0, N = _._1 |> length)))
-        var m3 <- (arr |> _where(_.Age >= 30)
+        let m3 <- (arr |> _where(_.Age >= 30)
                        |> _group_by(_.City)
+                       |> _order_by(_._0)
                        |> _select((City = _._0, N = _._1 |> length)))
-
-        m1 <- sort_by_city(m1)
-        m2 <- sort_by_city(m2)
-        m3 <- sort_by_city(m3)
 
         t |> equal(length(m1), length(m2), "where|group|count: M1 length ≡ M2")
         t |> equal(length(m2), length(m3), "where|group|count: M2 length ≡ M3")
@@ -176,23 +164,22 @@ def parity_where_group_count(t : T?) {
 def parity_group_having(t : T?) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db)
-        var arr <- fixture_array()
+        let arr <- fixture_array()
 
-        var m1 <- _sql(db |> select_from(type<User>)
+        let m1 <- _sql(db |> select_from(type<User>)
                          |> _group_by(_.City)
                          |> _having(_._1 |> length > 1)
+                         |> _order_by(_._0)
                          |> _select((City = _._0, N = _._1 |> length)))
-        var m2 <- (db |> select_from(type<User>)
+        let m2 <- (db |> select_from(type<User>)
                      |> _group_by(_.City)
                      |> _having(_._1 |> length > 1)
+                     |> _order_by(_._0)
                      |> _select((City = _._0, N = _._1 |> length)))
-        var m3 <- (arr |> _group_by(_.City)
+        let m3 <- (arr |> _group_by(_.City)
                        |> _having(_._1 |> length > 1)
+                       |> _order_by(_._0)
                        |> _select((City = _._0, N = _._1 |> length)))
-
-        m1 <- sort_by_city(m1)
-        m2 <- sort_by_city(m2)
-        m3 <- sort_by_city(m3)
 
         t |> equal(length(m1), length(m2), "group|having: M1 length ≡ M2")
         t |> equal(length(m2), length(m3), "group|having: M2 length ≡ M3")
@@ -207,9 +194,14 @@ def parity_group_having(t : T?) {
 
 [test]
 def parity_multi_key_group(t : T?) {
+    // No inline `_order_by` here: the `_sql` analyzer's tuple-key
+    // validator accepts only `_.Field` / string expressions, not nested
+    // walks like `_._0._N`, so multi-component sorts after `_group_by`
+    // can't be expressed as a single `_order_by` clause across all
+    // three modes. Post-sort by (City, Age) instead.
     with_sqlite(":memory:") $(db) {
         fixture_db(db)
-        var arr <- fixture_array()
+        let arr <- fixture_array()
 
         var m1 <- _sql(db |> select_from(type<User>)
                          |> _group_by((_.City, _.Age))
@@ -223,9 +215,9 @@ def parity_multi_key_group(t : T?) {
                        |> _having(_._1 |> length > 1)
                        |> _select((City = _._0._0, Age = _._0._1, N = _._1 |> length)))
 
-        m1 <- sort_by_city(m1)
-        m2 <- sort_by_city(m2)
-        m3 <- sort_by_city(m3)
+        m1 <- sort_by_city_age(m1)
+        m2 <- sort_by_city_age(m2)
+        m3 <- sort_by_city_age(m3)
 
         t |> equal(length(m1), length(m2), "multi-key length: M1 ≡ M2")
         t |> equal(length(m2), length(m3), "multi-key length: M2 ≡ M3")
@@ -242,52 +234,45 @@ def parity_multi_key_group(t : T?) {
 
 [test]
 def parity_full_reporting_chain(t : T?) {
-    // Full reporting: WHERE → GROUP BY → HAVING → SELECT → take.
-    // (Inline `_order_by` removed due to F3 — tracked in API_CHECKED.md.)
-    //
-    // Tuple is 4-field (City, N, TotSalary, OldestAge) to avoid a
-    // recordNames collision with parity_multi_key_group's
-    // tuple<string;int;int> — daslang canonicalizes tuple types by
-    // arg-type list, "first recordNames wins."
+    // Full reporting: WHERE → GROUP BY → HAVING → ORDER BY → SELECT → take.
     with_sqlite(":memory:") $(db) {
         fixture_db(db)
-        var arr <- fixture_array()
+        let arr <- fixture_array()
         let min_age = 25
         let min_count = 1
 
-        var m1 <- _sql(db |> select_from(type<User>)
+        let m1 <- _sql(db |> select_from(type<User>)
                          |> _where(_.Age >= min_age)
                          |> _group_by(_.City)
                          |> _having(_._1 |> length >= min_count)
+                         |> _order_by(_._0)
                          |> _select((
                              City      = _._0,
                              N         = _._1 |> length,
                              TotSalary = _._1 |> select($(u : User) => u.Salary) |> sum,
                              OldestAge = _._1 |> select($(u : User) => u.Age)    |> max))
                          |> take(10))
-        var m2 <- (db |> select_from(type<User>)
+        let m2 <- (db |> select_from(type<User>)
                      |> _where(_.Age >= min_age)
                      |> _group_by(_.City)
                      |> _having(_._1 |> length >= min_count)
+                     |> _order_by(_._0)
                      |> _select((
                          City      = _._0,
                          N         = _._1 |> length,
                          TotSalary = _._1 |> select($(u : User) => u.Salary) |> sum,
                          OldestAge = _._1 |> select($(u : User) => u.Age)    |> max))
                      |> take(10))
-        var m3 <- (arr |> _where(_.Age >= min_age)
+        let m3 <- (arr |> _where(_.Age >= min_age)
                        |> _group_by(_.City)
                        |> _having(_._1 |> length >= min_count)
+                       |> _order_by(_._0)
                        |> _select((
                            City      = _._0,
                            N         = _._1 |> length,
                            TotSalary = _._1 |> select($(u : User) => u.Salary) |> sum,
                            OldestAge = _._1 |> select($(u : User) => u.Age)    |> max))
                        |> take(10))
-
-        m1 <- sort_by_city(m1)
-        m2 <- sort_by_city(m2)
-        m3 <- sort_by_city(m3)
 
         t |> equal(length(m1), length(m2), "full chain length: M1 ≡ M2")
         t |> equal(length(m2), length(m3), "full chain length: M2 ≡ M3")

--- a/tests/dasSQLITE/parity_check_14_order_after_group.das
+++ b/tests/dasSQLITE/parity_check_14_order_after_group.das
@@ -1,25 +1,14 @@
-// Negative-coverage parity for tutorial 14 — `_having |> _order_by`
-// after `_group_by(_.City)` over a struct (User) compiles in `_sql(...)`
-// but fails to compile in plain linq with a deep typer error pointing
-// at `daslib/builtin.das:999`, far from the user's chain.
-//
-// Root cause: linq's `order_by` calls `clone_to_move` on its input,
-// which requires cloneable elements. Post-`_group_by + _having`, the
-// element is `tuple<key, array<User>>`; the nested `array<User>` is not
-// generically cloneable, so `_::clone(tuple<...>, ...)` resolution fails.
-//
-// The bare `_group_by |> _order_by |> _select(...)` chain (without
-// `_having`) compiles — linq's expansion must follow a different path
-// when there's no post-aggregate filter. The `_having` peeling forces
-// a separate sort step that needs cloneable elements.
-//
-// See API_CHECKED.md F3 for the resolution direction.
-// expect 30304:1
+// Coverage for `_having |> _order_by` after `_group_by` across all
+// three modes — was F3 in API_CHECKED.md (resolved by PR #2563,
+// 2026-05-03 synthesized tuple/variant clone-constness fix).
 
 options gen2
 
-require daslib/linq_boost
+require dastest/testing_boost public
+
 require daslib/sql
+require daslib/linq
+require daslib/linq_boost
 require sqlite/sqlite_boost
 require sqlite/sqlite_linq
 
@@ -32,17 +21,55 @@ struct User {
     Salary : int
 }
 
-[export]
-def main {
-    var arr : array<User>
-    arr |> emplace(User(Id = 1, Name = "A", City = "NYC", Age = 30, Salary = 100))
+def fixture_db(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> insert(User(Id = 1, Name = "Alice", City = "NYC",     Age = 30, Salary = 100))
+    db |> insert(User(Id = 2, Name = "Bob",   City = "NYC",     Age = 25, Salary = 80))
+    db |> insert(User(Id = 3, Name = "Carol", City = "Chicago", Age = 40, Salary = 120))
+    db |> insert(User(Id = 4, Name = "Dave",  City = "Chicago", Age = 35, Salary = 90))
+    db |> insert(User(Id = 5, Name = "Eve",   City = "Boston",  Age = 50, Salary = 200))
+}
 
-    // Mode 3: chain with `_having` + `_order_by` after `_group_by`. The
-    // `clone(tuple<string, array<User>>, ...)` resolution fails inside
-    // linq's `order_by`. The same shape inside `_sql(...)` lowers to
-    // `GROUP BY ... HAVING ... ORDER BY ...` and runs.
-    let m3 <- (arr |> _group_by(_.City)
-                   |> _having(_._1 |> length >= 1)
-                   |> _order_by(_._0)
-                   |> _select((City = _._0, N = _._1 |> length)))
+def fixture_array() : array<User> {
+    var arr : array<User>
+    arr |> emplace(User(Id = 1, Name = "Alice", City = "NYC",     Age = 30, Salary = 100))
+    arr |> emplace(User(Id = 2, Name = "Bob",   City = "NYC",     Age = 25, Salary = 80))
+    arr |> emplace(User(Id = 3, Name = "Carol", City = "Chicago", Age = 40, Salary = 120))
+    arr |> emplace(User(Id = 4, Name = "Dave",  City = "Chicago", Age = 35, Salary = 90))
+    arr |> emplace(User(Id = 5, Name = "Eve",   City = "Boston",  Age = 50, Salary = 200))
+    return <- arr
+}
+
+[test]
+def parity_having_then_order_by(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        let arr <- fixture_array()
+
+        let m1 <- _sql(db |> select_from(type<User>)
+                         |> _group_by(_.City)
+                         |> _having(_._1 |> length > 1)
+                         |> _order_by(_._0)
+                         |> _select((City = _._0, N = _._1 |> length)))
+        let m2 <- (db |> select_from(type<User>)
+                     |> _group_by(_.City)
+                     |> _having(_._1 |> length > 1)
+                     |> _order_by(_._0)
+                     |> _select((City = _._0, N = _._1 |> length)))
+        let m3 <- (arr |> _group_by(_.City)
+                       |> _having(_._1 |> length > 1)
+                       |> _order_by(_._0)
+                       |> _select((City = _._0, N = _._1 |> length)))
+
+        // Fixture has NYC=2, Chicago=2, Boston=1; HAVING > 1 drops Boston.
+        t |> equal(length(m1), 2,           "having|order_by: HAVING > 1 keeps 2 groups")
+        t |> equal(length(m1), length(m2), "having|order_by: M1 length ≡ M2")
+        t |> equal(length(m2), length(m3), "having|order_by: M2 length ≡ M3")
+        for (i in range(length(m1))) {
+            t |> equal(m1[i].City, m2[i].City, "row[{i}].City: M1 ≡ M2")
+            t |> equal(m1[i].N,    m2[i].N,    "row[{i}].N:    M1 ≡ M2")
+            t |> equal(m2[i].City, m3[i].City, "row[{i}].City: M2 ≡ M3")
+            t |> equal(m2[i].N,    m3[i].N,    "row[{i}].N:    M2 ≡ M3")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

F3 in [modules/dasSQLITE/API_CHECKED.md](modules/dasSQLITE/API_CHECKED.md) — `_having |> _order_by` after `_group_by` failing to compile in plain linq with a deep `_::clone(tuple<string;array<User>>, ...)` typer error — was silently resolved by [PR #2563](https://github.com/GaijinEntertainment/daScript/pull/2563) (synthesized tuple/variant clone constness) and [PR #2565](https://github.com/GaijinEntertainment/daScript/pull/2565) (tuple-strict typer). The audit doc + tests hadn't caught up: the pin test still asserted `expect 30304:1`, and `parity_check_14_group_by.das` still post-sorted via a `sort_by_city` helper to dodge the original error.

This PR brings the doc and tests in line with shipped reality.

- **`tests/dasSQLITE/parity_check_14_order_after_group.das`** — flipped from divergence pin (`def main` + `// expect 30304:1`) to a positive 3-mode `[test] def parity_having_then_order_by` covering inline `_order_by` after `_having` across Mode 1 / 2 / 3.
- **`tests/dasSQLITE/parity_check_14_group_by.das`** — `sort_by_city` helper deleted; inline `|> _order_by(_._0)` restored in 5 of 6 tests. The `parity_multi_key_group` test keeps post-sort with a brief comment: the `_sql` analyzer's tuple-key validator only accepts `_.Field` / string expressions, not nested walks like `_._0._N`, so multi-component sort after `_group_by` can't be expressed inline across all three modes today.
- **`modules/dasSQLITE/API_CHECKED.md`** — F3 finding retitled `RESOLVED`, with credit to PR #2563 and a note that the originally-deferred (b) `static_if` guard is no longer needed since (a) was fixed at the compiler level. Tutorials table gained 3 rows (14 having|order_by, 14b multi-Q aggregate-then-filter, 15b multi-Q multi-join). Findings summary: F3 → resolved; the `(lang) #2557` row is now resolved (PR #2565). "Walkthrough — complete" header notes v2/v2.1 multi-Q parity coverage. Per-conversation: CI-promotion bullet dropped from "Next steps".
- **`modules/dasSQLITE/API_REWORK.md`** — stale `failed_parity_check_14_order_after_group.das (F3 pin) still reports 30304:1` paragraph removed.

## Test plan

- [x] `dastest tests/dasSQLITE/` — **638/638 pass** (interpreter)
- [x] `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests/dasSQLITE` — **638/638 pass** (AOT)
- [x] Lint (`utils/lint/main.das`) on both changed `.das` files — only pre-existing STYLE012 (`emplace`-chain fixture pattern, used in every parity_check file)
- [x] MCP `format_file` on both `.das` files — already formatted
- [x] `detect-dupe` against `tests/dasSQLITE` corpus — exact matches between fixture helpers in 14 / 14b are pre-existing parallel parity-test scaffolds (expected pattern, not a regression)
- [x] No `failed_parity_check_14` / `expect 30304:1` references remain in repo
- [x] No `GC COMPILE LEAK` / `GC APP LEAK` lines in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
