### PR TITLE
River Run: shadows, pickup burst, rich music, 3D HUD, juice pass

### DIFF
--- a/examples/games/river_run/gameplay.das
+++ b/examples/games/river_run/gameplay.das
@@ -22,6 +22,30 @@ def spawn_trail(origin, color : float3) {
     }
 }
 
+def bonus_color(t : BonusType) : float3 {
+    return (t == BonusType.fuel ? float3(0.15, 0.9, 0.95)
+        : (t == BonusType.multishot ? float3(1.0, 0.45, 0.12)
+        : (t == BonusType.fastshot ? float3(1.0, 0.7, 0.05)
+        : float3(0.95, 1.0, 0.3))))
+}
+
+def spawn_pickup_burst(origin, color : float3) {
+    create_entities`Particle(14) $(eid : EntityId; i : int; var p : Particle) {
+        let angle = random_f() * 2.0 * PI
+        let elev = random_range(-0.25, 0.85)
+        let dir = normalize(float3(cos(angle), sin(angle), elev))
+        let speed = random_range(4.5, 8.5)
+        p.pos = origin
+        p.vel = dir * speed
+        p.color = color
+        p.lifetime = random_range(0.18, 0.32)
+        p.max_life = p.lifetime
+        p.size = random_range(0.06, 0.14)
+        p.spin_speed = random_range(-15.0, 15.0)
+        p.spin_phase = random_f() * 2.0 * PI
+    }
+}
+
 def spawn_particles(origin, color : float3; object_radius : float; count : int) {
     create_entities`Particle(count) $(eid : EntityId; i : int; var p : Particle) {
         let angle = random_f() * 2.0 * PI
@@ -435,6 +459,9 @@ def reset_game() {
     current_section = 0
     section_dist = 0.0
     section_banner_timer = 0.0
+    restart_input_lock = 0.0
+    screen_shake_amount = 0.0
+    slow_mo_timer = 0.0
     low_fuel_beep_timer = 0.0
     refuel_sound_timer = 0.0
     river_color_from = section_colors[0]
@@ -555,6 +582,10 @@ def on_player_killed() {
     player_lives -= 1
     spawn_particles(player_pos, float3(1.0, 0.5, 0.2), PLAYER_SIZE * 2.6, 34)
     play_sfx(snd_player_hit)
+    add_screen_shake(SHAKE_MED)
+    if (player_lives > 0) {
+        slow_mo_timer = SLOW_MO_DURATION
+    }
     player_respawn_timer = PLAYER_RESPAWN_HIDE + PLAYER_RESPAWN_BLINK
     player_invuln_timer = player_respawn_timer + PLAYER_INVULN_TIME
     player_fuel = PLAYER_FUEL_MAX * 0.7
@@ -563,6 +594,7 @@ def on_player_killed() {
     if (player_lives <= 0) {
         play_sfx(snd_game_over)
         game_state = GameState.game_over_state
+        restart_input_lock = 1.5
     }
 }
 
@@ -624,6 +656,7 @@ def update_section() {
 
         if (current_section >= MAX_SECTIONS) {
             game_state = GameState.win_state
+            restart_input_lock = 1.5
         } else {
             spawn_section_objects()
         }
@@ -1026,6 +1059,13 @@ def process_collisions() {
                 spawn_particles(h.pos, float3(1.0, 0.65, 0.1), h.blast_radius, c)
             }
             play_sfx(is_bridge ? snd_bridge_destroy : snd_enemy_explode)
+            if (is_bridge) {
+                add_screen_shake(SHAKE_BIG)
+            } elif (is_depot) {
+                add_screen_shake(SHAKE_MED)
+            } else {
+                add_screen_shake(SHAKE_SMALL)
+            }
             score += h.score_value
 
             let drop_chance = (
@@ -1079,7 +1119,10 @@ def process_collisions() {
         }
     }
 
-    // Player vs bonuses
+    // Player vs bonuses — collect burst origins/colors and spawn AFTER the
+    // query (create_entities can't run inside a decs query).
+    var burst_origins : array<float3>
+    var burst_colors : array<float3>
     query() $(eid : EntityId; b : BonusPickup) {
         let r = PLAYER_SIZE + BONUS_PICKUP_RADIUS
         if (dist2d_sq(b.pos, player_pos) < r * r) {
@@ -1096,8 +1139,13 @@ def process_collisions() {
                 player_lives += 1
                 play_sfx(snd_bonus_life)
             }
+            burst_origins |> push(b.pos + float3(0.0, 0.0, 0.55))
+            burst_colors |> push(bonus_color(b.bonus_type))
             delete_entity(eid)
         }
+    }
+    for (i in range(length(burst_origins))) {
+        spawn_pickup_burst(burst_origins[i], burst_colors[i])
     }
     commit()
 
@@ -1152,6 +1200,10 @@ def quat_x_rot(angle : float) : float4 {
     return float4(sin(angle * 0.5), 0.0, 0.0, cos(angle * 0.5))
 }
 
+def quat_z_rot(angle : float) : float4 {
+    return float4(0.0, 0.0, sin(angle * 0.5), cos(angle * 0.5))
+}
+
 // Rotate unit Z to direction v (for aligning cylinders along a velocity vector)
 def quat_align_z(v : float3) : float4 {
     let from = float3(0.0, 0.0, 1.0)
@@ -1161,6 +1213,121 @@ def quat_align_z(v : float3) : float4 {
     let axis = normalize(cross(from, v))
     let half = acos(d) * 0.5
     return float4(axis * sin(half), cos(half))
+}
+
+// --- Shadows ---
+// Flat shadow projection along LIGHT_DIR (matches phong lighting direction).
+// LIGHT_DIR = (0.4, -0.6, -1.0) — only x/z and y/z ratios matter for projection.
+
+let SHADOW_Z = 0.02
+let SHADOW_OFFSET_X = 0.4
+let SHADOW_OFFSET_Y = -0.6
+
+def shadow_pos(p : float3) : float3 {
+    return float3(p.x + p.z * SHADOW_OFFSET_X, p.y + p.z * SHADOW_OFFSET_Y, SHADOW_Z)
+}
+
+def draw_shadow(pos : float3; sx, sy, alpha : float; round : bool) {
+    v_model = compose(shadow_pos(pos), float4(0.0, 0.0, 0.0, 1.0), float3(sx, sy, 0.001))
+    f_Color = float4(0.0, 0.0, 0.0, alpha)
+    vs_flat_bind_uniform(active_program)
+    fs_flat_bind_uniform(active_program)
+    if (round) {
+        geo_cylinder |> draw_geometry_fragment()
+    } else {
+        geo_cube |> draw_geometry_fragment()
+    }
+}
+
+// Shadow streak for a vertical pillar standing on the water (base at z=0).
+// Anchors at base XY and stretches along LIGHT_DIR projection so the shadow
+// visibly connects to the foot of the pillar.
+def draw_pillar_shadow(base_x, base_y : float; height, half_thickness, alpha : float) {
+    let dx = height * SHADOW_OFFSET_X
+    let dy = height * SHADOW_OFFSET_Y
+    let cx = base_x + dx * 0.5
+    let cy = base_y + dy * 0.5
+    let len = sqrt(dx * dx + dy * dy)
+    let angle = atan2(dy, dx)
+    v_model = compose(
+        float3(cx, cy, SHADOW_Z),
+        quat_z_rot(angle),
+        float3(len * 0.5, half_thickness, 0.001)
+    )
+    f_Color = float4(0.0, 0.0, 0.0, alpha)
+    vs_flat_bind_uniform(active_program)
+    fs_flat_bind_uniform(active_program)
+    geo_cube |> draw_geometry_fragment()
+}
+
+def render_shadows(game_time : float) {
+    glUseProgram(flat_program)
+    active_program = flat_program
+    glEnable(GL_BLEND)
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+    glDepthMask(false)
+
+    if (player_respawn_timer < PLAYER_RESPAWN_BLINK) {
+        let blinking = player_respawn_timer > 0.0
+        if (!blinking || int(game_time * 16.0) % 2 != 0) {
+            draw_shadow(player_pos, PLAYER_SIZE * 0.95, PLAYER_SIZE * 0.95, 0.55, true)
+        }
+    }
+
+    query() $(b : EnemyBoat) {
+        draw_shadow(b.pos, BOAT_SIZE * 0.65, BOAT_SIZE * 1.65, 0.45, false)
+    }
+
+    query() $(p : EnemyPlane) {
+        draw_shadow(p.pos, PLANE_SIZE * 1.5, PLANE_SIZE * 0.65, 0.45, true)
+    }
+
+    query() $(h : EnemyHelicopter) {
+        draw_shadow(h.pos, ENEMY_HELI_SIZE * 1.25, ENEMY_HELI_SIZE * 1.25, 0.5, true)
+    }
+
+    query() $(b : BonusPickup) {
+        let bob = sin(game_time * BONUS_BOB_SPEED + b.bob_phase) * BONUS_BOB_AMPLITUDE
+        draw_shadow(b.pos + float3(0.0, 0.0, 0.55 + bob), 0.32, 0.32, 0.5, true)
+    }
+
+    query() $(t : RiverTree) {
+        let r = t.size * 0.6
+        draw_shadow(t.pos + float3(0.0, 0.0, t.size * 0.7), r, r, 0.5, true)
+    }
+
+    query() $(h : RiverHouse) {
+        // Project from near top of body so shadow extends past the building
+        // footprint instead of being eaten by the body it's under.
+        draw_shadow(h.pos + float3(0.0, 0.0, h.size * 1.0),
+            h.size * 0.85, h.size * 1.05, 0.5, false)
+    }
+
+    query() $(d : FuelDepot) {
+        draw_shadow(d.pos + float3(0.0, 0.0, FUEL_DEPOT_SIZE * 0.4),
+            FUEL_DEPOT_SIZE * 1.0, FUEL_DEPOT_SIZE * 1.8, 0.5, false)
+    }
+
+    query() $(br : Bridge) {
+        let pylon_h = BRIDGE_SPAN_Z + 0.5
+        draw_pillar_shadow(br.left_x, br.pos.y, pylon_h, 0.22, 0.55)
+        draw_pillar_shadow(br.right_x, br.pos.y, pylon_h, 0.22, 0.55)
+        let gap_left = br.gap_center_x - BRIDGE_GAP_WIDTH * 0.5
+        let gap_right = br.gap_center_x + BRIDGE_GAP_WIDTH * 0.5
+        let lw = gap_left - br.left_x
+        if (lw > 0.1) {
+            let cx = (br.left_x + gap_left) * 0.5
+            draw_shadow(float3(cx, br.pos.y, BRIDGE_SPAN_Z), lw * 0.5, 0.35, 0.45, false)
+        }
+        let rw = br.right_x - gap_right
+        if (rw > 0.1) {
+            let cx = (gap_right + br.right_x) * 0.5
+            draw_shadow(float3(cx, br.pos.y, BRIDGE_SPAN_Z), rw * 0.5, 0.35, 0.45, false)
+        }
+    }
+
+    glDepthMask(true)
+    glDisable(GL_BLEND)
 }
 
 def render_player(game_time : float) {
@@ -1331,23 +1498,16 @@ def render_obstacles(game_time : float) {
         geo_prism |> draw_geometry_fragment()
     }
 
-    // Bonuses: distinct silhouettes + color (not color-only).
+    // Bonuses: spinning horizontal cylinders, color-coded by type.
+    let q_tilt = quat_y_rot(PI * 0.5)
     query() $(b : BonusPickup) {
         let bob = sin(game_time * BONUS_BOB_SPEED + b.bob_phase) * BONUS_BOB_AMPLITUDE
         let p = b.pos + float3(0.0, 0.0, 0.55 + bob)
-        if (b.bonus_type == BonusType.fuel) {
-            draw_with_phong(p, float3(0.28, 0.28, 0.28), float3(0.15, 0.9, 0.95))
-            geo_sphere |> draw_geometry_fragment()
-        } elif (b.bonus_type == BonusType.multishot) {
-            draw_with_phong(p, float3(0.26, 0.26, 0.36), float3(1.0, 0.45, 0.12))
-            geo_prism |> draw_geometry_fragment()
-        } elif (b.bonus_type == BonusType.fastshot) {
-            draw_with_phong(p, float3(0.23, 0.23, 0.42), float3(1.0, 0.7, 0.05))
-            geo_cone |> draw_geometry_fragment()
-        } else {
-            draw_with_phong(p, float3(0.2, 0.2, 0.36), float3(0.95, 1.0, 0.3))
-            geo_cylinder |> draw_geometry_fragment()
-        }
+        let color = bonus_color(b.bonus_type)
+        let spin = quat_z_rot(game_time * BONUS_SPIN_SPEED + b.bob_phase)
+        let rot = quat_mul(spin, q_tilt)
+        draw_with_phong(p, float3(0.22, 0.22, 0.55), color, rot)
+        geo_cylinder |> draw_geometry_fragment()
     }
     glEnable(GL_CULL_FACE)
 }
@@ -1464,6 +1624,7 @@ def render_rotors(game_time : float) {
 }
 
 def render_all(game_time : float) {
+    render_shadows(game_time)
     render_player(game_time)
     render_enemies(game_time)
     render_obstacles(game_time)

--- a/examples/games/river_run/hud.das
+++ b/examples/games/river_run/hud.das
@@ -24,27 +24,6 @@ def draw_text_centered(text : string; cx, y : int; tint : float3 = float3(1.0)) 
     delete quads
 }
 
-def draw_fuel_bar() {
-    // Draw fuel label
-    let low = player_fuel < LOW_FUEL_THRESHOLD
-    let blink = low && int(get_uptime() * 6.0) % 2 == 0
-    let bar_color = (
-        low ? (blink ? float3(1.0, 0.2, 0.2) : float3(1.0, 0.5, 0.1)) : float3(0.2, 0.9, 0.3)
-    )
-    draw_text("FUEL", 10, display_h - 28, bar_color)
-    // Represent fuel as bar of characters
-    let bar_chars = 20
-    let filled = int(player_fuel / PLAYER_FUEL_MAX * float(bar_chars))
-    let bar_str = build_string() $(var w) {
-        w |> write("[")
-        for (i in range(bar_chars)) {
-            w |> write(i < filled ? "#" : "-")
-        }
-        w |> write("]")
-    }
-    draw_text(bar_str, 52, display_h - 28, bar_color)
-}
-
 def draw_hud() {
     let cx = display_w / 2
     let cy = display_h / 2
@@ -58,39 +37,11 @@ def draw_hud() {
         return
     }
 
-    // In-game HUD
+    // In-game HUD: SCORE + SECTION number remain as text;
+    // lives / fuel / active powerups are drawn as 3D HUD geometry in hud3d.das.
     let display_section = min(current_section + 1, MAX_SECTIONS)
-    draw_text("SCORE: {score}", 10, 24, float3(1.0))
-    draw_text("LIVES: {player_lives}", 10, 52, float3(1.0, 0.9, 0.5))
-    draw_text("SECTION: {display_section}", 10, 80, float3(0.6, 1.0, 0.7))
-
-    let speed_max = PLAYER_FWD_SPEED_MAX * section_speed_mult()
-    let speed_den = max(speed_max - PLAYER_FWD_SPEED_MIN, 0.001)
-    let speed_t = clamp((player_fwd_speed - PLAYER_FWD_SPEED_MIN) / speed_den, 0.0, 1.0)
-    let speed_pct = int(speed_t * 100.0)
-    draw_text("SPD: {speed_pct}%", 10, 108, float3(0.7, 0.8, 1.0))
-
-    // Active timed bonuses
-    var bonus_y = 136
-    if (player_multishot_timer > 0.0 || player_fastshot_timer > 0.0) {
-        draw_text("ACTIVE BONUS", 10, bonus_y, float3(0.9, 1.0, 0.65))
-        bonus_y += 22
-    }
-    if (player_multishot_timer > 0.0) {
-        let secs = int(player_multishot_timer + 0.99)
-        draw_text("MULTISHOT: {secs}s", 10, bonus_y, float3(1.0, 0.55, 0.2))
-        bonus_y += 22
-    }
-    if (player_fastshot_timer > 0.0) {
-        let secs = int(player_fastshot_timer + 0.99)
-        draw_text("FAST SHOT: {secs}s", 10, bonus_y, float3(1.0, 0.78, 0.12))
-    }
-
-    draw_fuel_bar()
-
-    // Controls hint
-    draw_text("Arrows/A,D: steer  W/S: speed  SPC: fire  ESC: pause",
-        10, display_h - 54, float3(0.5, 0.5, 0.6))
+    draw_text_centered("SCORE: {score}", cx, 18, float3(1.0))
+    draw_text_centered("SECTION: {display_section}", cx, 44, float3(0.6, 1.0, 0.7))
 
     // Section banner
     if (section_banner_timer > 0.0) {

--- a/examples/games/river_run/hud3d.das
+++ b/examples/games/river_run/hud3d.das
@@ -1,0 +1,176 @@
+options gen2
+options persistent_heap
+
+require rr_globals public
+require gameplay
+
+// Layout constants
+
+let LIFE_ICON_SIZE = 18.0
+let LIFE_ICON_GAP = 14.0
+let LIFE_ICON_RIGHT_PAD = 30.0
+let LIFE_ICON_TOP = 38.0
+
+let FUEL_BAR_X = 24.0
+let FUEL_BAR_Y = 28.0
+let FUEL_BAR_W = 220.0
+let FUEL_BAR_H = 18.0
+let FUEL_BAR_PAD = 2.0
+
+let PWR_ICON_X = 56.0
+let PWR_ICON_Y0 = 78.0
+let PWR_ROW_H = 56.0
+let PWR_ICON_RADIUS = 16.0
+let PWR_RING_RADIUS = 28.0
+let PWR_RING_TICKS = 8
+let PWR_TICK_SIZE = 3.5
+
+let LIFE_BODY_COLOR = float3(0.7, 0.85, 1.0)
+
+def hud_set_uniforms() {
+    let near = -100.0
+    let far  = 100.0
+    v_projection = ortho_rh(0.0, float(display_w), float(display_h), 0.0, near, far)
+    v_view = compose(float3(0.0), float4(0.0, 0.0, 0.0, 1.0), float3(1.0))
+}
+
+def draw_lives_3d(game_time : float) {
+    if (player_lives <= 0) {
+        return
+    }
+    let cy = LIFE_ICON_TOP
+    let step = LIFE_ICON_SIZE * 2.0 + LIFE_ICON_GAP
+
+    // Bodies (phong-shaded spheres)
+    glUseProgram(phong_program)
+    active_program = phong_program
+    for (i in range(player_lives)) {
+        let cx = float(display_w) - LIFE_ICON_RIGHT_PAD - float(i) * step - LIFE_ICON_SIZE
+        draw_with_phong(float3(cx, cy, 0.0), float3(LIFE_ICON_SIZE), LIFE_BODY_COLOR)
+        geo_sphere |> draw_geometry_fragment()
+    }
+
+    // Rotors (alpha-blended cross, spinning in screen XY plane)
+    glEnable(GL_BLEND)
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+    glDepthMask(false)
+    glUseProgram(rotor_program)
+    active_program = rotor_program
+    let face_camera = quat_x_rot(PI * 0.5)
+    let rotor_radius = LIFE_ICON_SIZE * 1.55
+    let rotor_z = LIFE_ICON_SIZE * 0.6
+    for (i in range(player_lives)) {
+        let cx = float(display_w) - LIFE_ICON_RIGHT_PAD - float(i) * step - LIFE_ICON_SIZE
+        let angle = game_time * 12.0 + float(i) * 0.7
+        let spin = quat_z_rot(angle)
+        let rot = quat_mul(spin, face_camera)
+        v_model = compose(float3(cx, cy, rotor_z), rot, float3(rotor_radius, 0.5, rotor_radius))
+        f_Color = float4(0.9, 0.9, 0.95, 0.9)
+        vs_rotor_bind_uniform(active_program)
+        fs_rotor_bind_uniform(active_program)
+        geo_plane_xz |> draw_geometry_fragment()
+    }
+    glDepthMask(true)
+    glDisable(GL_BLEND)
+}
+
+def draw_fuel_bar_3d() {
+    glUseProgram(flat_program)
+    active_program = flat_program
+
+    // Frame
+    let frame_cx = FUEL_BAR_X + FUEL_BAR_W * 0.5
+    let frame_cy = FUEL_BAR_Y + FUEL_BAR_H * 0.5
+    let frame_color = float3(0.05, 0.06, 0.10)
+    draw_with_flat(float3(frame_cx, frame_cy, -0.5), float3(FUEL_BAR_W * 0.5, FUEL_BAR_H * 0.5, 0.5), frame_color)
+    geo_cube |> draw_geometry_fragment()
+
+    // Fill
+    let fill_max_w = FUEL_BAR_W - 2.0 * FUEL_BAR_PAD
+    let fill_w = fill_max_w * clamp(player_fuel / PLAYER_FUEL_MAX, 0.0, 1.0)
+    if (fill_w > 0.001) {
+        let fill_x = FUEL_BAR_X + FUEL_BAR_PAD + fill_w * 0.5
+        let fill_h = FUEL_BAR_H - 2.0 * FUEL_BAR_PAD
+        draw_with_flat(float3(fill_x, frame_cy, 0.5), float3(fill_w * 0.5, fill_h * 0.5, 0.5), fuel_bar_color())
+        geo_cube |> draw_geometry_fragment()
+    }
+}
+
+def draw_powerup_icon_3d(game_time : float; cx, cy : float; t : BonusType; timer, max_timer : float) {
+    let color = bonus_color(t)
+    let q_tilt = quat_y_rot(PI * 0.5)
+    let spin = quat_z_rot(game_time * BONUS_SPIN_SPEED)
+    let rot = quat_mul(spin, q_tilt)
+
+    // Spinning cylinder (phong)
+    glUseProgram(phong_program)
+    active_program = phong_program
+    draw_with_phong(
+        float3(cx, cy, 0.5),
+        float3(PWR_ICON_RADIUS * 0.42, PWR_ICON_RADIUS * 0.42, PWR_ICON_RADIUS * 1.05),
+        color,
+        rot
+    )
+    geo_cylinder |> draw_geometry_fragment()
+
+    // Tick ring (flat)
+    glUseProgram(flat_program)
+    active_program = flat_program
+    let frac = clamp(timer / max(max_timer, 0.001), 0.0, 1.0)
+    let lit_count = int(frac * float(PWR_RING_TICKS) + 0.99)
+    for (i in range(PWR_RING_TICKS)) {
+        let angle = float(i) * (2.0 * PI / float(PWR_RING_TICKS)) - PI * 0.5
+        let tx = cx + cos(angle) * PWR_RING_RADIUS
+        let ty = cy + sin(angle) * PWR_RING_RADIUS
+        let lit = i < lit_count
+        let tick_col = (lit ? color : color * 0.22)
+        draw_with_flat(
+            float3(tx, ty, -0.25),
+            float3(PWR_TICK_SIZE),
+            tick_col
+        )
+        geo_cube |> draw_geometry_fragment()
+    }
+}
+
+def draw_powerups_3d(game_time : float) {
+    var row = 0
+    if (player_multishot_timer > 0.0) {
+        let cy = PWR_ICON_Y0 + float(row) * PWR_ROW_H
+        draw_powerup_icon_3d(game_time, PWR_ICON_X, cy, BonusType.multishot,
+            player_multishot_timer, BONUS_MULTISHOT_TIME)
+        row += 1
+    }
+    if (player_fastshot_timer > 0.0) {
+        let cy = PWR_ICON_Y0 + float(row) * PWR_ROW_H
+        draw_powerup_icon_3d(game_time, PWR_ICON_X, cy, BonusType.fastshot,
+            player_fastshot_timer, BONUS_FASTSHOT_TIME)
+        row += 1
+    }
+}
+
+def draw_hud_3d(game_time : float) {
+    if (game_state == GameState.menu) {
+        return
+    }
+
+    // Save 3D state
+    let saved_proj = v_projection
+    let saved_view = v_view
+    let saved_fog = f_FogParams
+
+    hud_set_uniforms()
+    f_FogParams = float2(1.0e9, 1.0e9 + 1.0)
+
+    // Fresh depth space for HUD geometry — sorts correctly among itself.
+    glClear(GL_DEPTH_BUFFER_BIT)
+    glEnable(GL_DEPTH_TEST)
+
+    draw_fuel_bar_3d()
+    draw_powerups_3d(game_time)
+    draw_lives_3d(game_time)
+
+    v_projection = saved_proj
+    v_view = saved_view
+    f_FogParams = saved_fog
+}

--- a/examples/games/river_run/main.das
+++ b/examples/games/river_run/main.das
@@ -6,6 +6,7 @@ require rr_audio
 require river
 require gameplay
 require hud
+require hud3d
 
 // --- GL Setup ---
 
@@ -14,6 +15,7 @@ def create_gl_objects() {
     phong_program = cache_shader_program(vs_phong`shader_text, fs_phong`shader_text)
     river_program = cache_shader_program(vs_river`shader_text, fs_river`shader_text)
     rotor_program = cache_shader_program(vs_rotor`shader_text, fs_rotor`shader_text)
+    grass_program = cache_shader_program(vs_grass`shader_text, fs_grass`shader_text)
 
     geo_sphere <- create_geometry_fragment <| gen_sphere(10, 7, false)
     geo_cube <- create_geometry_fragment <| gen_cube()
@@ -32,7 +34,17 @@ def update_camera() {
     // Camera lags behind player X
     cam_x += (player_pos.x - cam_x) * CAM_X_LAG
 
-    let eye = float3(cam_x, player_pos.y - CAM_BACK, CAM_HEIGHT)
+    // Pitch lerps with current player speed: slow → CAM_PITCH_SLOW_DEG, fast → CAM_PITCH_FAST_DEG.
+    let speed_max = PLAYER_FWD_SPEED_MAX * section_speed_mult()
+    let speed_den = max(speed_max - PLAYER_FWD_SPEED_MIN, 0.001)
+    let speed_t = clamp((player_fwd_speed - PLAYER_FWD_SPEED_MIN) / speed_den, 0.0, 1.0)
+    let pitch_deg = CAM_PITCH_SLOW_DEG + (CAM_PITCH_FAST_DEG - CAM_PITCH_SLOW_DEG) * speed_t
+    let cam_height = (CAM_BACK + CAM_LOOK_AHEAD) * tan(pitch_deg * PI / 180.0)
+
+    let t = float(get_uptime())
+    let shake = float3(sin(t * 47.0), sin(t * 53.0), sin(t * 61.0)) * screen_shake_amount
+
+    let eye = float3(cam_x, player_pos.y - CAM_BACK, cam_height) + shake
     let center = float3(player_pos.x, player_pos.y + CAM_LOOK_AHEAD, 0.0)
     let up = float3(0.0, 0.0, 1.0)
     v_view = look_at_rh(eye, center, up)
@@ -50,7 +62,8 @@ def handle_menu_input() {
 
     if (game_state == GameState.menu && space_just) {
         reset_game()
-    } elif ((game_state == GameState.game_over_state || game_state == GameState.win_state) && space_just) {
+    } elif ((game_state == GameState.game_over_state || game_state == GameState.win_state)
+            && space_just && restart_input_lock <= 0.0) {
         reset_game()
     }
 }
@@ -118,8 +131,19 @@ def update() {
     v_projection = perspective_rh_opengl(50.0 * PI / 180.0, aspect, 0.1, 500.0)
     update_camera()
 
-    let dt = get_dt()
-    tick_dt = min(dt, 1.0 / 30.0)
+    let real_dt = get_dt()
+    tick_dt = min(real_dt, 1.0 / 30.0)
+
+    if (slow_mo_timer > 0.0) {
+        slow_mo_timer -= real_dt
+        tick_dt *= SLOW_MO_SCALE
+    }
+
+    screen_shake_amount = max(screen_shake_amount - SHAKE_DECAY * real_dt, 0.0)
+
+    if (restart_input_lock > 0.0) {
+        restart_input_lock -= tick_dt
+    }
 
     let game_time = float(get_uptime())
 
@@ -157,6 +181,7 @@ def update() {
     render_all(game_time)
 
     glDisable(GL_CULL_FACE)
+    draw_hud_3d(game_time)
     draw_hud()
     glEnable(GL_CULL_FACE)
 

--- a/examples/games/river_run/river.das
+++ b/examples/games/river_run/river.das
@@ -417,12 +417,12 @@ def render_river(game_time : float) {
     fs_river_bind_uniform(active_program)
     river_surface_geo |> draw_geometry_fragment()
 
-    // Banks (flat shader, terrain color)
-    glUseProgram(flat_program)
-    active_program = flat_program
+    // Banks (grass shader, terrain color + per-pixel noise tint)
+    glUseProgram(grass_program)
+    active_program = grass_program
     v_model = compose(float3(0.0), float4(0.0, 0.0, 0.0, 1.0), float3(1.0))
     f_Color = float4(get_bank_color(), 1.0)
-    vs_flat_bind_uniform(active_program)
-    fs_flat_bind_uniform(active_program)
+    vs_grass_bind_uniform(active_program)
+    fs_grass_bind_uniform(active_program)
     river_bank_geo |> draw_geometry_fragment()
 }

--- a/examples/games/river_run/rr_audio.das
+++ b/examples/games/river_run/rr_audio.das
@@ -165,13 +165,20 @@ def update_engine_sound(active : bool; speed, max_speed : float) {
         let hi = max(max_speed, PLAYER_FWD_SPEED_MIN + 0.01)
         let t = clamp((speed - PLAYER_FWD_SPEED_MIN) / (hi - PLAYER_FWD_SPEED_MIN), 0.0, 1.0)
         set_pitch(engine_sid, 0.75 + t * 0.80)
-        set_volume(engine_sid, 0.55, 0.05)
+        set_volume(engine_sid, 0.30, 0.05)
     } else {
         set_volume(engine_sid, 0.0, 0.1)
     }
 }
 
 // --- Music ---
+
+def replace_named_track(name : string; var pat : Pattern; gain : float) {
+    if (key_exists(g_music_tracks, name)) {
+        strudel_remove_track(g_music_tracks[name])
+    }
+    g_music_tracks[name] = strudel_add_track(pat, gain)
+}
 
 def music_cmd(cmd : string) {
     let parts <- split(cmd, ":")
@@ -197,6 +204,28 @@ def music_cmd(cmd : string) {
             let fade_time = (length(parts) >= 3 ? float(to_double(parts[2])) : 0.5)
             strudel_fade_track(g_music_tracks[name], 0.0, fade_time)
         }
+    } elif (action == "rich") {
+        // Rich tracks built directly here on the strudel thread so they can
+        // use the full Pattern API (chunk/sometimesby/jux/etc.).
+        if (name == "0") {
+            build_section0_rich()
+        } elif (name == "1") {
+            build_section1_rich()
+        } elif (name == "2") {
+            build_section2_rich()
+        } elif (name == "3") {
+            build_section3_rich()
+        } elif (name == "4") {
+            build_section4_rich()
+        } elif (name == "menu") {
+            build_menu_rich()
+        } elif (name == "tension") {
+            build_tension_rich()
+        } elif (name == "gameover") {
+            build_game_over_rich()
+        } elif (name == "win") {
+            build_win_rich()
+        }
     }
 }
 
@@ -209,76 +238,171 @@ def stop_all_tracks(fade : float) {
 
 def start_menu_music() {
     strudel_set_bpm(96.0lf)
-    strudel_command("play:drums:<bd ~ ~ ~> <~ ~ hh ~>:0.18")
-    strudel_command("note:bass:<e2 ~ ~ ~> <d2 ~ ~ ~> <c2 ~ ~ ~> <b1 ~ ~ ~>:sine:0.2")
-    strudel_command("note:lead:<e4 ~ g4 ~> <d4 ~ f4 ~> <c4 ~ e4 ~> <b3 ~ d4 ~>:triangle:0.1")
-}
-
-def start_play_music() {
-    strudel_set_bpm(128.0lf)
-    strudel_command("play:drums:<bd [~ hh] sd [hh ~]> <bd [~ hh] ~ [hh cp?0.3]> <bd [hh ~] sd [~ hh]> <bd [hh hh] sd [hh ~]>:0.48")
-    strudel_command("note:bass:<[e2 e2] ~ [b1 b1] ~> <[g2 g2] ~ [d2 d2] ~> <[c2 c2] ~ [g1 g1] ~> <[a1 a1] [b1 b1] [c2 c2] [d2 d2]>:square:0.24")
-    strudel_command("note:lead:<e4 g4 b4 e5> <d4 f4 a4 d5> <c4 e4 g4 c5> <b3 d4 f4 b4>:sawtooth:0.18")
-    strudel_command("note:arp:<[e5 b4 g4 e4]> <[d5 a4 f4 d4]> <[c5 g4 e4 c4]> <[b4 fs4 d4 b3]>:triangle:0.09")
+    strudel_command("rich:menu")
 }
 
 def start_tension_music() {
     strudel_set_bpm(110.0lf)
-    strudel_command("play:drums:<bd ~ ~ ~> <bd ~ hh ~> <bd ~ ~ hh> <bd ~ hh ~>:0.22")
-    strudel_command("note:bass:<e2 ~ d2 ~> <c2 ~ b1 ~> <a1 ~ g1 ~> <e2 ~ ~ ~>:sine:0.26")
-    strudel_command("note:lead:<e4 ~ d4 ~> <c4 ~ b3 ~> <a3 ~ g3 ~> <e4 ~ ~ ~>:triangle:0.14")
-    strudel_command("stop:arp:0.4")
+    strudel_command("rich:tension")
 }
 
 def start_game_over_music() {
     strudel_set_bpm(80.0lf)
-    strudel_command("play:drums:<bd ~ ~ ~> <bd ~ ~ ~> <bd ~ ~ ~> <bd ~ ~ ~>:0.18")
-    strudel_command("note:bass:<e2 d2 c2 b1> <a1 ~ g1 ~> <e2 d2 c2 b1> <a1 ~ ~ ~>:sine:0.26")
-    strudel_command("note:lead:<g4 ~ e4 ~> <d4 ~ c4 ~> <b3 ~ a3 ~> <g3 ~ ~ ~>:triangle:0.16")
-    strudel_command("stop:arp:0.3")
+    strudel_command("rich:gameover")
 }
 
 def start_win_music() {
     strudel_set_bpm(148.0lf)
-    strudel_command("play:drums:<bd [hh hh] sd [hh cp]> <bd [hh hh] [sd sd] [hh hh]> <bd [hh cp] sd [hh hh]> <bd [hh hh] [sd cp] [hh hh]>:0.54")
-    strudel_command("note:bass:<[e2 e2] [g2 g2] [b2 b2] [e3 e3]> <[d3 d3] [b2 b2] [a2 a2] [g2 g2]> <[c3 c3] [a2 a2] [g2 g2] [b2 b2]> <[e2 e2] [g2 g2] [b2 b2] [e3 e3]>:square:0.28")
-    strudel_command("note:lead:<e5 g5 b5 e6> <g5 b5 d6 g6> <a5 c6 e6 a6> <b5 d6 fs6 b6>:sawtooth:0.22")
-    strudel_command("note:arp:<[e6 b5 g5 e5]> <[g6 d6 b5 g5]> <[a6 e6 c6 a5]> <[b6 fs6 d6 b5]>:triangle:0.12")
+    strudel_command("rich:win")
 }
 
-// 5 distinct gameplay music variants (cycles through sections 0..4)
+// ─── Per-voice rich builders ─────────────────────────────────────────
+// Same effect chain across every music mode:
+//   lead  — chunk(4, fast(2)) rotates a stuttered quarter per cycle so
+//           the 16-note loop never repeats identically; sometimesby
+//           sprinkles octave jumps; jux(rev) gives stereo motion;
+//           phaser adds slow phase shimmer; perlin gain breathes.
+//   bass  — sub-octave layer for low end; ply(2) double-taps occasionally.
+//   arp   — jux(rev) + occasional double-time bursts.
+//   drums — half-bar gain swell.
+// Run on the strudel thread (called from music_cmd "rich:..."). BPM is
+// set separately by the main-thread caller.
+
+def rich_drums(pattern : string; g : float) {
+    replace_named_track("drums",
+        s(pattern) |> gain(saw() |> range(0.7, 1.0) |> fast(2.0lf)),
+        g)
+}
+
+def rich_bass(pattern, osc : string; g : float) {
+    replace_named_track("bass",
+        note_pattern(pattern, osc)
+        |> superimpose(@(var x : Pattern) => x |> add(-12.0) |> gain(0.6))
+        |> sometimesby(0.15, @(var x : Pattern) => x |> ply(2))
+        |> attack(0.005)
+        |> release(0.18),
+        g)
+}
+
+def rich_lead(pattern, osc : string; g : float) {
+    replace_named_track("lead",
+        note_pattern(pattern, osc)
+        |> chunk(4, @(var x : Pattern) => x |> fast(2.0lf))
+        |> sometimesby(0.18, @(var x : Pattern) => x |> add(12.0))
+        |> jux(@(var x : Pattern) => rev(x))
+        |> phaser(0.25)
+        |> attack(0.006)
+        |> release(0.16)
+        |> gain(perlin() |> range(0.75, 1.0) |> slow(3.0lf)),
+        g)
+}
+
+def rich_arp(pattern : string; g : float) {
+    replace_named_track("arp",
+        note_pattern(pattern, "triangle")
+        |> jux(@(var x : Pattern) => rev(x))
+        |> sometimesby(0.20, @(var x : Pattern) => x |> fast(2.0lf))
+        |> attack(0.005)
+        |> release(0.12),
+        g)
+}
+
+def fade_arp(fade : float) {
+    if (key_exists(g_music_tracks, "arp")) {
+        strudel_fade_track(g_music_tracks["arp"], 0.0, fade)
+    }
+}
+
+// ─── Section builders (gameplay loop, square+saw+triangle stack) ─────
+
+def build_section0_rich() {
+    rich_drums("<bd [~ hh] sd [hh ~]> <bd [~ hh] ~ [hh cp?0.3]> <bd [hh ~] sd [~ hh]> <bd [hh hh] sd [hh ~]>", 0.48)
+    rich_bass("<[e2 e2] ~ [b1 b1] ~> <[g2 g2] ~ [d2 d2] ~> <[c2 c2] ~ [g1 g1] ~> <[a1 a1] [b1 b1] [c2 c2] [d2 d2]>", "square", 0.30)
+    rich_lead("<e4 g4 b4 e5> <d4 f4 a4 d5> <c4 e4 g4 c5> <b3 d4 f4 b4>", "sawtooth", 0.20)
+    rich_arp("<[e5 b4 g4 e4]> <[d5 a4 f4 d4]> <[c5 g4 e4 c4]> <[b4 fs4 d4 b3]>", 0.10)
+}
+
+def build_section1_rich() {
+    rich_drums("<bd [hh hh] sd hh> <bd [hh cp] sd [hh hh]> <bd [hh ~] [sd sd] hh> <bd hh sd [hh cp]>", 0.52)
+    rich_bass("<[a1 a1] ~ [e2 e2] ~> <[c2 c2] ~ [g1 g1] ~> <[d2 d2] ~ [a1 a1] ~> <[f2 f2] [e2 e2] [d2 d2] [c2 c2]>", "square", 0.32)
+    rich_lead("<a4 c5 e5 a5> <g4 b4 d5 g5> <f4 a4 c5 f5> <e4 g4 b4 e5>", "sawtooth", 0.22)
+    rich_arp("<[a5 e5 c5 a4]> <[g5 d5 b4 g4]> <[f5 c5 a4 f4]> <[e5 b4 g4 e4]>", 0.10)
+}
+
+def build_section2_rich() {
+    rich_drums("<[bd bd] [hh hh] [sd sd] [hh hh]> <[bd bd] [hh cp] [sd sd] [cp hh]> <bd [hh hh] [sd cp] [hh hh]> <[bd bd] hh sd [hh hh]>", 0.56)
+    rich_bass("<[d2 d2] ~ [a1 a1] ~> <[f2 f2] ~ [c2 c2] ~> <[g2 g2] ~ [d2 d2] ~> <[a2 a2] [g2 g2] [f2 f2] [e2 e2]>", "square", 0.34)
+    rich_lead("<d4 f4 a4 d5> <c4 e4 g4 c5> <bf3 d4 f4 bf4> <a3 c4 e4 a4>", "sawtooth", 0.24)
+    rich_arp("<[d5 a4 f4 d4]> <[c5 g4 e4 c4]> <[bf4 f4 d4 bf3]> <[a4 e4 c4 a3]>", 0.11)
+}
+
+def build_section3_rich() {
+    rich_drums("<[bd bd] [hh hh] [sd cp] [hh hh]> <[bd bd] [hh hh] [sd sd] [cp cp]> <bd [hh cp] [sd sd] [hh cp]> <[bd bd] [hh hh] [sd cp] [hh hh]>", 0.60)
+    rich_bass("<[b1 b1] ~ [fs2 fs2] ~> <[d2 d2] ~ [a1 a1] ~> <[e2 e2] ~ [b1 b1] ~> <[g2 g2] [fs2 fs2] [e2 e2] [d2 d2]>", "square", 0.36)
+    rich_lead("<b4 d5 fs5 b5> <a4 c5 e5 a5> <g4 b4 d5 g5> <fs4 a4 c5 fs5>", "sawtooth", 0.26)
+    rich_arp("<[b5 fs5 d5 b4]> <[a5 e5 c5 a4]> <[g5 d5 b4 g4]> <[fs5 c5 a4 fs4]>", 0.13)
+}
+
+def build_section4_rich() {
+    rich_drums("<[bd bd] [hh hh] [sd cp] [hh cp]> <[bd cp] [hh hh] [sd sd] [hh cp]> <[bd bd] [hh cp] [sd cp] [cp hh]> <[bd bd] [hh hh] [sd cp] [hh hh]>", 0.64)
+    rich_bass("<[g1 g1] ~ [d2 d2] ~> <[bf1 bf1] ~ [f2 f2] ~> <[c2 c2] ~ [g1 g1] ~> <[d2 d2] [c2 c2] [bf1 bf1] [a1 a1]>", "square", 0.38)
+    rich_lead("<g4 bf4 d5 g5> <f4 a4 c5 f5> <ef4 g4 bf4 ef5> <d4 f4 a4 d5>", "sawtooth", 0.28)
+    rich_arp("<[g5 d5 bf4 g4]> <[f5 c5 a4 f4]> <[ef5 bf4 g4 ef4]> <[d5 a4 f4 d4]>", 0.14)
+}
+
+// ─── Transition builders (menu / tension / game-over / win) ──────────
+// Same effect chain, but oscillator/density per their original mood:
+//   menu/tension/game-over use sine bass + triangle lead (sparser),
+//   win uses square+saw+triangle like the gameplay sections.
+
+def build_menu_rich() {
+    rich_drums("<bd ~ ~ ~> <~ ~ hh ~>", 0.18)
+    rich_bass("<e2 ~ ~ ~> <d2 ~ ~ ~> <c2 ~ ~ ~> <b1 ~ ~ ~>", "sine", 0.20)
+    rich_lead("<e4 ~ g4 ~> <d4 ~ f4 ~> <c4 ~ e4 ~> <b3 ~ d4 ~>", "triangle", 0.10)
+    fade_arp(0.4)
+}
+
+def build_tension_rich() {
+    rich_drums("<bd ~ ~ ~> <bd ~ hh ~> <bd ~ ~ hh> <bd ~ hh ~>", 0.22)
+    rich_bass("<e2 ~ d2 ~> <c2 ~ b1 ~> <a1 ~ g1 ~> <e2 ~ ~ ~>", "sine", 0.26)
+    rich_lead("<e4 ~ d4 ~> <c4 ~ b3 ~> <a3 ~ g3 ~> <e4 ~ ~ ~>", "triangle", 0.14)
+    fade_arp(0.4)
+}
+
+def build_game_over_rich() {
+    rich_drums("<bd ~ ~ ~> <bd ~ ~ ~> <bd ~ ~ ~> <bd ~ ~ ~>", 0.18)
+    rich_bass("<e2 d2 c2 b1> <a1 ~ g1 ~> <e2 d2 c2 b1> <a1 ~ ~ ~>", "sine", 0.26)
+    rich_lead("<g4 ~ e4 ~> <d4 ~ c4 ~> <b3 ~ a3 ~> <g3 ~ ~ ~>", "triangle", 0.16)
+    fade_arp(0.3)
+}
+
+def build_win_rich() {
+    rich_drums("<bd [hh hh] sd [hh cp]> <bd [hh hh] [sd sd] [hh hh]> <bd [hh cp] sd [hh hh]> <bd [hh hh] [sd cp] [hh hh]>", 0.54)
+    rich_bass("<[e2 e2] [g2 g2] [b2 b2] [e3 e3]> <[d3 d3] [b2 b2] [a2 a2] [g2 g2]> <[c3 c3] [a2 a2] [g2 g2] [b2 b2]> <[e2 e2] [g2 g2] [b2 b2] [e3 e3]>", "square", 0.28)
+    rich_lead("<e5 g5 b5 e6> <g5 b5 d6 g6> <a5 c6 e6 a6> <b5 d6 fs6 b6>", "sawtooth", 0.22)
+    rich_arp("<[e6 b5 g5 e5]> <[g6 d6 b5 g5]> <[a6 e6 c6 a5]> <[b6 fs6 d6 b5]>", 0.12)
+}
+
+// 5 distinct gameplay music variants (cycles through sections 0..4).
+// BPM is set on the main thread (matching menu/tension/win functions);
+// the rich track build runs on the strudel thread via music_cmd.
 def start_section_music(section : int) {
     let s = section % 5
     if (s == 0) {
         strudel_set_bpm(128.0lf)
-        strudel_command("play:drums:<bd [~ hh] sd [hh ~]> <bd [~ hh] ~ [hh cp?0.3]> <bd [hh ~] sd [~ hh]> <bd [hh hh] sd [hh ~]>:0.48")
-        strudel_command("note:bass:<[e2 e2] ~ [b1 b1] ~> <[g2 g2] ~ [d2 d2] ~> <[c2 c2] ~ [g1 g1] ~> <[a1 a1] [b1 b1] [c2 c2] [d2 d2]>:square:0.24")
-        strudel_command("note:lead:<e4 g4 b4 e5> <d4 f4 a4 d5> <c4 e4 g4 c5> <b3 d4 f4 b4>:sawtooth:0.18")
-        strudel_command("note:arp:<[e5 b4 g4 e4]> <[d5 a4 f4 d4]> <[c5 g4 e4 c4]> <[b4 fs4 d4 b3]>:triangle:0.09")
+        strudel_command("rich:0")
     } elif (s == 1) {
         strudel_set_bpm(136.0lf)
-        strudel_command("play:drums:<bd [hh hh] sd hh> <bd [hh cp] sd [hh hh]> <bd [hh ~] [sd sd] hh> <bd hh sd [hh cp]>:0.52")
-        strudel_command("note:bass:<[a1 a1] ~ [e2 e2] ~> <[c2 c2] ~ [g1 g1] ~> <[d2 d2] ~ [a1 a1] ~> <[f2 f2] [e2 e2] [d2 d2] [c2 c2]>:square:0.26")
-        strudel_command("note:lead:<a4 c5 e5 a5> <g4 b4 d5 g5> <f4 a4 c5 f5> <e4 g4 b4 e5>:sawtooth:0.2")
-        strudel_command("note:arp:<[a5 e5 c5 a4]> <[g5 d5 b4 g4]> <[f5 c5 a4 f4]> <[e5 b4 g4 e4]>:triangle:0.1")
+        strudel_command("rich:1")
     } elif (s == 2) {
         strudel_set_bpm(140.0lf)
-        strudel_command("play:drums:<[bd bd] [hh hh] [sd sd] [hh hh]> <[bd bd] [hh cp] [sd sd] [cp hh]> <bd [hh hh] [sd cp] [hh hh]> <[bd bd] hh sd [hh hh]>:0.56")
-        strudel_command("note:bass:<[d2 d2] ~ [a1 a1] ~> <[f2 f2] ~ [c2 c2] ~> <[g2 g2] ~ [d2 d2] ~> <[a2 a2] [g2 g2] [f2 f2] [e2 e2]>:square:0.28")
-        strudel_command("note:lead:<d4 f4 a4 d5> <c4 e4 g4 c5> <bf3 d4 f4 bf4> <a3 c4 e4 a4>:sawtooth:0.22")
-        strudel_command("note:arp:<[d5 a4 f4 d4]> <[c5 g4 e4 c4]> <[bf4 f4 d4 bf3]> <[a4 e4 c4 a3]>:triangle:0.11")
+        strudel_command("rich:2")
     } elif (s == 3) {
         strudel_set_bpm(148.0lf)
-        strudel_command("play:drums:<[bd bd] [hh hh] [sd cp] [hh hh]> <[bd bd] [hh hh] [sd sd] [cp cp]> <bd [hh cp] [sd sd] [hh cp]> <[bd bd] [hh hh] [sd cp] [hh hh]>:0.6")
-        strudel_command("note:bass:<[b1 b1] ~ [fs2 fs2] ~> <[d2 d2] ~ [a1 a1] ~> <[e2 e2] ~ [b1 b1] ~> <[g2 g2] [fs2 fs2] [e2 e2] [d2 d2]>:square:0.3")
-        strudel_command("note:lead:<b4 d5 fs5 b5> <a4 c5 e5 a5> <g4 b4 d5 g5> <fs4 a4 c5 fs5>:sawtooth:0.24")
-        strudel_command("note:arp:<[b5 fs5 d5 b4]> <[a5 e5 c5 a4]> <[g5 d5 b4 g4]> <[fs5 c5 a4 fs4]>:triangle:0.13")
+        strudel_command("rich:3")
     } else {
         strudel_set_bpm(158.0lf)
-        strudel_command("play:drums:<[bd bd] [hh hh] [sd cp] [hh cp]> <[bd cp] [hh hh] [sd sd] [hh cp]> <[bd bd] [hh cp] [sd cp] [cp hh]> <[bd bd] [hh hh] [sd cp] [hh hh]>:0.64")
-        strudel_command("note:bass:<[g1 g1] ~ [d2 d2] ~> <[bf1 bf1] ~ [f2 f2] ~> <[c2 c2] ~ [g1 g1] ~> <[d2 d2] [c2 c2] [bf1 bf1] [a1 a1]>:square:0.32")
-        strudel_command("note:lead:<g4 bf4 d5 g5> <f4 a4 c5 f5> <ef4 g4 bf4 ef5> <d4 f4 a4 d5>:sawtooth:0.26")
-        strudel_command("note:arp:<[g5 d5 bf4 g4]> <[f5 c5 a4 f4]> <[ef5 bf4 g4 ef4]> <[d5 a4 f4 d4]>:triangle:0.14")
+        strudel_command("rich:4")
     }
 }
 

--- a/examples/games/river_run/rr_globals.das
+++ b/examples/games/river_run/rr_globals.das
@@ -67,6 +67,7 @@ let BONUS_MULTISHOT_TIME = 12.0
 let BONUS_FASTSHOT_TIME = 7.0
 let BONUS_BOB_AMPLITUDE = 0.22
 let BONUS_BOB_SPEED = 2.6
+let BONUS_SPIN_SPEED = 2.4
 
 let ENEMY_BULLET_SPEED = 10.0
 let ENEMY_HELI_BULLET_SPEED = 18.0
@@ -103,9 +104,18 @@ let PARTICLE_LIFETIME = 0.7
 let TRAIL_LIFETIME = 0.12
 
 let CAM_BACK = 14.0
-let CAM_HEIGHT = 19.0
-let CAM_LOOK_AHEAD = 9.0
+let CAM_LOOK_AHEAD = 8.2
 let CAM_X_LAG = 0.08
+let CAM_PITCH_SLOW_DEG = 42.0   // pitch at PLAYER_FWD_SPEED_MIN
+let CAM_PITCH_FAST_DEG = 36.0   // pitch at top speed (PLAYER_FWD_SPEED_MAX * section_speed_mult)
+
+let SHAKE_SMALL = 0.20
+let SHAKE_MED   = 0.55
+let SHAKE_BIG   = 1.05
+let SHAKE_DECAY = 5.0
+
+let SLOW_MO_DURATION = 0.6
+let SLOW_MO_SCALE = 0.4
 
 let WAVE_BANNER_DURATION = 2.5
 
@@ -275,6 +285,9 @@ var @live current_section = 0
 var @live section_dist = 0.0
 var @live section_banner_timer = 0.0
 var @live section_score_bonus_pending = false
+var @live restart_input_lock = 0.0
+var @live screen_shake_amount = 0.0
+var @live slow_mo_timer = 0.0
 
 var @live river_segments : array<RiverSegment>
 var @live river_dirty = true
@@ -357,6 +370,7 @@ var @uniform v_projection : float4x4
 var @inout f_normal : float3
 var @inout f_tex_pos : float3
 var @inout f_fog_t : float
+var @inout f_grass_world : float2
 var @uniform f_Color : float4
 var @uniform f_RiverColor : float4
 var @uniform f_GameTime : float
@@ -378,6 +392,29 @@ def fs_flat {
     let fog_t = saturate((f_fog_t - f_FogParams.x) / (f_FogParams.y - f_FogParams.x))
     let fog_alpha = fog_t * fog_t * 0.5
     let col = f_Color.xyz * (1.0 - fog_alpha) + f_FogColor * fog_alpha
+    f_FragColor = float4(col, f_Color.w)
+}
+
+// grass shader — river banks with subtle world-space noise tint
+
+[vertex_program]
+def vs_grass {
+    let world_pos = v_model * float4(v_position, 1.0)
+    f_grass_world = world_pos.xy
+    f_fog_t = world_pos.y
+    gl_Position = v_projection * v_view * world_pos
+}
+
+[fragment_program]
+def fs_grass {
+    let p = f_grass_world * 0.35
+    let h = sin(dot(floor(p), float2(12.9898, 78.233))) * 43758.5
+    let n = h - floor(h)
+    let tint = 1.0 + (n - 0.5) * 0.18
+    let base = f_Color.xyz * tint
+    let fog_t = saturate((f_fog_t - f_FogParams.x) / (f_FogParams.y - f_FogParams.x))
+    let fog_alpha = fog_t * fog_t * 0.5
+    let col = base * (1.0 - fog_alpha) + f_FogColor * fog_alpha
     f_FragColor = float4(col, f_Color.w)
 }
 
@@ -455,6 +492,7 @@ var flat_program : uint
 var phong_program : uint
 var river_program : uint
 var rotor_program : uint
+var grass_program : uint
 var active_program : uint
 
 var geo_sphere : OpenGLGeometryFragment
@@ -508,6 +546,18 @@ def get_fog_color() : float3 {
 
 def section_speed_mult() : float {
     return 1.0 + float(current_section) * 0.15
+}
+
+def add_screen_shake(amount : float) {
+    screen_shake_amount = max(screen_shake_amount, amount)
+}
+
+def fuel_bar_color() : float3 {
+    let low = player_fuel < LOW_FUEL_THRESHOLD
+    let blink = low && int(get_uptime() * 6.0) % 2 == 0
+    return (
+        low ? (blink ? float3(1.0, 0.2, 0.2) : float3(1.0, 0.5, 0.1)) : float3(0.2, 0.9, 0.3)
+    )
 }
 
 def draw_with_flat(pos, scale, color : float3; rot_quat : float4 = float4(0.0, 0.0, 0.0, 1.0)) {


### PR DESCRIPTION
## Summary

Builds out the in-tree River Run example into a more complete arcade game pass. **No public-API or stdlib changes** — everything lives under `examples/games/river_run/`.

### Visuals
- Bonus pickups are uniform horizontal-spinning cylinders (no more mish-mash of sphere/prism/cone/cylinder), color-coded by `BonusType`.
- One-shot particle burst in the pickup color when collected.
- Flat ground shadows for everything that flies/floats: player, planes, helis, bonuses, trees, houses, fuel depots, boats, bridges. Bridge pylons get a stretched shadow streak (`draw_pillar_shadow`) anchored at the base so the bridge no longer floats above its shadow.
- New `grass_program` shader: river banks get a subtle world-XY value noise tint instead of reading as flat single-color strips.

### 3D HUD overlay (new `hud3d.das`)
- Ortho overlay pass after the world render: fuel bar (3D quads with low/critical color blink), mini-helicopter life icons (sphere body + spinning rotor cross), and active-powerup indicators (horizontal-spinning cylinder + 8-tick radial timer ring per powerup).
- Trims `hud.das` down to SCORE/SECTION (centered), state overlays, and the menu screen.

### Camera + juice
- Speed-driven pitch: lerps between `CAM_PITCH_SLOW_DEG` and `CAM_PITCH_FAST_DEG` based on `player_fwd_speed` (height derived each frame from `CAM_BACK + CAM_LOOK_AHEAD`).
- Screen shake with three intensities (`SHAKE_SMALL/MED/BIG`) — fires on enemy explosions, fuel-depot kills, player hits, and bridge destruction. Decays per frame.
- Death slow-mo: 0.6 s @ 0.4× `tick_dt` after losing a life (audio stays full-speed; final death keeps the existing instant game-over flow).
- 1.5 s restart-input lock on game-over / win so SPACE doesn't bypass the screen.

### Music (`rr_audio.das`)
- Per-section "rich" strudel pipelines (`chunk` / `sometimesby` / `jux` / `phaser` / perlin gain pulse) for sections 0–4 + menu / tension / game-over / win modes — same melodic ideas, much less repetitive feel. Music construction stays on the strudel thread; bpm changes stay on the main thread.
- Engine sound volume tuned down so it stops fighting the music.

### Files
`examples/games/river_run/{gameplay,hud,hud3d,main,river,rr_audio,rr_globals}.das`

## Test plan

- [x] Lint: `bin/daslang utils/lint/main.das -- <changed files>` — 7 files, 0 issues
- [x] Format: MCP `format_file` — all 7 already formatted
- [x] Live launch + play: confirmed visually for shadows, HUD overlay, camera shake on each impact tier, slow-mo on non-final death, grass noise variation, restart-input lock
- [ ] CI: Linux/macOS/Windows builds + extended_checks
- [ ] Manual playthrough on a clean checkout (one full run from menu → win)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
