### PR TITLE
style_lint: surface STYLE014/015 via MCP + dasSQLITE comment cleanup + doc policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ Multiple skill files may apply to a single task. For example, creating a new das
 
 When you discover something new about daslang syntax, semantics, or conventions — whether through compiler errors, user corrections, or experimentation — **update this file** with the new knowledge. If it relates to a specific skill area, update the relevant `skills/*.md` file instead.
 
+**Doc improvements at stopping points.** When a task wraps and you spot a typo or factual error in CLAUDE.md or `skills/*.md` — fix it in-place and flag the edit in the end-of-turn summary. Anything more — clarifications, additions, restructuring, removing existing guidance, **or proposing a new skill file when you see a recurring pattern that no existing skill covers** — propose first. Default toward propose-first; doc edits direct future Claude behavior and silent diffs are not OK.
+
 ## daslang Language — Gen2 Syntax (REQUIRED)
 
 All code MUST use gen2 syntax (add `options gen2` at the top of every file). Key rules:

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -119,12 +119,9 @@ def sqlite_version() : string {
 }
 
 def try_open_sqlite(path : string) : Result<SqlRunner, string> {
-    //! Opens a connection to ``path`` (``:memory:`` for an in-memory DB).
-    //! Returns ``ok(runner)`` on success, ``err(errmsg)`` on failure.
-    //! On failure, the partial libsqlite3 handle is closed per the SQLite contract.
-    //! On success, every ``[sql_function]``-tagged function in scope is registered
-    //! against the new connection (see ``_install_sql_function_registry``); a
-    //! registration error closes the handle and surfaces as ``err(...)``.
+    //! Opens a connection to ``path`` (``:memory:`` for an in-memory DB). Returns
+    //! ``err(...)`` on failure (handle closed); on success, registers every in-scope
+    //! ``[sql_function]`` against the connection.
     var db = SqlRunner()
     let rc = sqlite3_open(path, db.sqlite_handle)
     if (rc != SQLITE_OK) {
@@ -3745,9 +3742,7 @@ def _register_function_check_rc(db : SqlRunner; name : string; fn : auto(FN);
 }
 
 def private _is_valid_sql_function_name(s : string) : bool {
-    // Accept the standard SQLite unquoted identifier shape: [A-Za-z_][A-Za-z0-9_]*.
-    // SQLite is more permissive at the C API, but anything outside this set
-    // would need quoting in the chain analyzer's emitted SQL — reject early.
+    // SQLite unquoted identifier shape: [A-Za-z_][A-Za-z0-9_]* — anything else would need quoting in emitted SQL.
     if (empty(s)) {
         return false
     }
@@ -3777,13 +3772,8 @@ struct private SqlFunctionThunk {
     install : lambda<(db : SqlRunner) : SqlError>
 }
 
+// Populated by [init] thunks; replayed on every try_open_sqlite. (name, nArgs) pair detects cross-module collisions (SQLite would silently replace).
 var private sql_function_registry : array<SqlFunctionThunk>
-//! Compile-time-built registry of `[sql_function]` registration thunks. Populated by
-//! generated `[init]` functions via ``_add_sql_function_thunk``; iterated by
-//! ``_install_sql_function_registry`` on every ``try_open_sqlite``. Each entry carries
-//! its SQL ``name`` + ``nArgs`` so the install loop can detect cross-module collisions
-//! (SQLite dispatches by name+arity, with later registrations silently replacing earlier
-//! ones — surface that here as an explicit ``err(...)`` instead).
 
 def _add_sql_function_thunk(name : string; nArgs : int;
                             var install : lambda<(db : SqlRunner) : SqlError>) : void {
@@ -3794,10 +3784,6 @@ def _add_sql_function_thunk(name : string; nArgs : int;
 }
 
 def private _install_sql_function_registry(db : SqlRunner) : SqlError {
-    //! Walk the registry; bail on first failure so ``try_open_sqlite`` preserves
-    //! its ``Result`` contract (no panic, no leaked handle). Detects duplicate
-    //! ``(name, nArgs)`` registrations across modules — silent SQLite override is a
-    //! footgun, so surface it as an err.
     var seen : table<string; bool>
     for (thunk in sql_function_registry) {
         let key = "{thunk.name}/{thunk.nArgs}"
@@ -3815,11 +3801,9 @@ def private _install_sql_function_registry(db : SqlRunner) : SqlError {
 
 [function_macro(name="sql_function")]
 class SqlFunctionMacro : AstFunctionAnnotation {
-    //! Marks a daslang function as a SQLite scalar UDF.
-    //! At context init the function is registered against every opened SQL connection;
-    //! inside `_sql(...)` chains, calls to the function emit `<name>(args)` SQL instead
-    //! of binding the value at compile time. Optional args: `name`, `deterministic`,
-    //! `directonly`.
+    //! Marks a daslang function as a SQLite scalar UDF: registered against every opened
+    //! connection, and emitted as ``<name>(args)`` inside ``_sql(...)`` chains rather than
+    //! bound at compile time. Optional args: ``name``, ``deterministic``, ``directonly``.
     def override apply(var func : FunctionPtr; var group : ModuleGroup;
                        args : AnnotationArgumentList; var errors : das_string) : bool {
         if (func.fromGeneric != null) {

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -94,6 +94,7 @@ def to_sql_literal(value : auto(TT)) : string {
 
 let private INT_MAX_PHASE : int = int(0x7fffffff)
 
+// nolint:STYLE014
 // Phase numbers match SQL eval order: lower = earlier in eval = innermost in SQL nesting.
 // Multiple ops at the SAME phase coexist in one Q (e.g. two `_where` AND-fold).
 // On peel: P > q.minPhaseSeen → push inner subQ (this op runs AFTER something already
@@ -151,11 +152,8 @@ struct private JoinSpec {
     rightCol    : string
     rightWhereSql     : string
     rightOnBindExprs  : array<ExpressionPtr>
-    // For RIGHT / FULL OUTER with a non-empty RHS WHERE, the RHS gets wrapped as
-    // `(SELECT * FROM "<table>" WHERE <pred>)` baked into tableName here. Outer-WHERE
-    // semantics on a preserved-side join would drop the wrong rows; subquery body
-    // filters before the join. Flag tells emission to write tableName as raw SQL
-    // (with parens) instead of as a quoted identifier.
+    // RIGHT/FULL OUTER w/ RHS WHERE: tableName is `(SELECT * FROM ... WHERE ...)` raw SQL,
+    // not a quoted identifier — filters BEFORE the join to preserve null-padded rows.
     tableSqlIsRaw     : bool
 }
 
@@ -207,10 +205,8 @@ struct private SqlQuery {
     inView      : bool     //! `_create_view` body context — rejects `[sql_function(directonly=true)]` UDF calls
     hadError    : bool
     lastError   : string   //! First `pred_fail` message, re-emitted by call_macros if their deeper macro_error gets eaten by AST cascade
-    // Multi-Q lowering: when a chain conflicts with canonical SQL phase order
-    // (e.g. `take(n) |> _where(p)`), the inner subtree is analyzed into a fresh
-    // SqlQuery, snapshotted to SQL string + binds here, and the outer SELECT's
-    // FROM clause renders as `(<innerSql>) AS t0` instead of a base-table name.
+    // Multi-Q lowering: phase-order conflict (e.g. `take(n) |> _where(p)`) snapshots
+    // the inner subtree's SQL+binds here; outer FROM renders as `(<innerSql>) AS t0`.
     innerSql       : string                 // null/empty = base-table FROM; else nested SELECT body
     innerBindExprs : array<ExpressionPtr>   // FROM-subquery placeholders, parsed first
     minPhaseSeen   : int = int(0x7fffffff)  // INT_MAX_PHASE sentinel; lowest phase added to this Q
@@ -641,14 +637,12 @@ def private extract_key_selector_field(var keyLambda : ExpressionPtr; expectedAr
     return fieldName
 }
 
-// Multi-join LHS wrap: snapshot q (which contains an inner _join chain) into a SQL
-// subquery + bind list, then reset q so the outer join can install its own state.
-// Outer FROM clause renders as `(<innerSql>) AS "t0" INNER JOIN ...`. The outer's
-// `into` projection resolves `<lhsArg>.<alias>` against q.fromRowType (named tuple
-// from inner_projection_type), which now also feeds source_rootType_for_idx(0).
+// Multi-join LHS wrap: snapshot q's inner-join chain into a subquery (innerSql + binds),
+// then reset q so the outer join installs its own state. Outer's `into` resolves against q.fromRowType.
 [macro_function]
 def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at : LineInfo;
                                         fillPassthrough : bool = false) : bool {
+    // nolint:STYLE015
     // NOTE: don't gate on q.seenTerminal / q.seenToArray here — analyze_chain peels
     // outermost-first, so by the time snapshot is called, those flags reflect the OUTER
     // chain's terminal (which is fine) and there's no way to distinguish that from an
@@ -663,6 +657,7 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
         macro_error(prog, at, "_sql: multi-join LHS must project a named row (use `into` to produce a tuple); got scalar projection — reshape so each LHS column is named")
         return false
     }
+    // nolint:STYLE015
     // Save outer-terminal state pre-set by outer-peeled ops (`_first` / `_count` / `_take` /
     // `_skip` / `_order_by` / `_distinct` etc.). Without this, `build_sql_string(q, true)` below
     // serializes those clauses into the INNER subquery (e.g. `LIMIT 1` lands BEFORE the outer
@@ -672,19 +667,15 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     var savedLimitBindExpr = q.limitBindExpr
     var savedOffsetBindExpr = q.offsetBindExpr
     let savedDistinctFlag = q.distinctFlag
-    var savedOrderByCols : array<string>
-    savedOrderByCols <- q.orderByCols
-    var savedOrderByInlineExprs : array<ExpressionPtr>
-    savedOrderByInlineExprs <- q.orderByInlineExprs
+    var savedOrderByCols <- q.orderByCols
+    var savedOrderByInlineExprs <- q.orderByInlineExprs
     let savedSeenTake = q.seenTake
     let savedSeenSkip = q.seenSkip
     let savedSeenOrderBy = q.seenOrderBy
     let savedSeenDistinct = q.seenDistinct
     let savedSeenTerminal = q.seenTerminal
     let savedSeenToArray = q.seenToArray
-    // Aggregate state set by outer-peeled `_count` / `_sum` / etc. The inner subquery must
-    // emit the projection columns (so the outer can wrap them); the OUTER SELECT renders
-    // `COUNT(*)` / `SUM(...)`. Save → clear → build inner → restore on outer post-wrap.
+    // Aggregate state save: inner subquery emits projection cols, outer renders COUNT/SUM.
     let savedAggExpr := q.aggregateExpr
     var savedAggType = q.aggregateType
     // Clear them on q so the inner SQL emits without outer-only clauses.
@@ -701,9 +692,7 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.aggregateExpr := ""
     q.aggregateType = null
     if (savedAggExpr != "") {
-        // selectCols were populated by analyze_projection (preserved by process_join_call's
-        // save/restore); inner build_sql_string must read them as a NamedTuple projection,
-        // not as an aggregate (which would emit the now-empty aggregateExpr).
+        // Force NamedTuple so inner emits selectCols (analyze_projection populated them); empty aggregateExpr would emit nothing.
         q.proj = ProjectionShape.NamedTuple
     }
     var savedDb = q.dbExpr
@@ -764,8 +753,7 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.dbExpr = savedDb
     q.inView = savedInView
     q.hadError = savedHadError
-    // Restore outer-terminal state so the outer SELECT renders WITH it (LIMIT 1 from
-    // `_first`, ORDER BY from `_order_by`, etc. all belong on outer post-wrap).
+    // Restore outer-terminal state — LIMIT/ORDER BY/DISTINCT belong on the outer SELECT post-wrap.
     q.matr = savedMatr
     q.limitBindExpr = savedLimitBindExpr
     q.offsetBindExpr = savedOffsetBindExpr
@@ -781,13 +769,10 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.aggregateExpr := savedAggExpr
     q.aggregateType = savedAggType
     if (savedAggExpr != "") {
-        // Outer renders `SELECT COUNT(*) FROM (...) AS t0 [WHERE ...]` — no row projection.
-        // Override the FullRow that the reset block installed; ignore fillPassthrough.
+        // Override FullRow installed by reset; aggregate outer ignores fillPassthrough.
         q.proj = ProjectionShape.Aggregate
     } elif (fillPassthrough) {
-        // Terminal wrap (e.g. WHERE peel on a JOIN'd named-tuple projection): no outer op
-        // will fill the projection. Emit `SELECT "alias1", "alias2", ... FROM (<innerSql>) AS "t0"`
-        // via passthrough fragments — same shape divert_to_inner uses for NamedTuple inner.
+        // Terminal wrap: outer projects passthrough columns from inner's named-tuple aliases.
         if (!apply_passthrough_projection(q, projType, prog, at)) {
             return false
         }
@@ -795,10 +780,7 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     return true
 }
 
-// Replace q's projection state with passthrough column references against the
-// named-tuple `projType` (typically q.fromRowType after a divert/snapshot). Sets
-// q.proj = NamedTuple. Used both by divert_to_inner (NamedTuple inner case) and
-// snapshot_q_to_subquery_wrap with fillPassthrough = true.
+// Replace q's projection with passthrough column refs against named-tuple projType (= NamedTuple).
 [macro_function]
 def private apply_passthrough_projection(var q : SqlQuery&; projType : TypeDeclPtr;
                                          prog : ProgramPtr; at : LineInfo) : bool {
@@ -844,9 +826,9 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
         macro_error(prog, at, "_sql: _join expected 5 args (srca, srcb, keya, keyb, into) post-expansion; got {length(jCall.arguments)}")
         return false
     }
-    // Pre-set rootAlias so srca's inner `_where` pred_to_sql qualifies columns as "t0"."col"
-    // (v1 single-join behavior). Multi-join wrap below resets and re-sets this.
+    // Pre-set rootAlias = "t0" so srca's inner `_where` qualifies cols as "t0"."col" (v1 path).
     q.rootAlias = "t0"
+    // nolint:STYLE015
     // 1. Recurse into srca FIRST. If srca itself is a `_join` chain (multi-join), the inner
     // process_join_call will set q.seenJoin / fill q.joins[]. Detect that on return below.
     // Capture seenTerminal/seenToArray pre-recursion: if srca itself peels a terminal, we
@@ -862,9 +844,9 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
         macro_error(prog, at, "_sql: _join LHS chain cannot end in a terminal (`_first`, `_to_array`, `_count`, etc.); restructure so terminals are outermost")
         return false
     }
-    // V1 path: srca was a simple chain. Now check that srca didn't end in _select/_group_by
-    // — those would conflict with this join's `into` projection. Run BEFORE snapshot below
-    // (snapshot clears these flags so the check would silently pass).
+    // nolint:STYLE015 — ordering invariant: must run BEFORE snapshot below, which clears these flags.
+    // V1 path: srca was a simple chain. Reject _select/_group_by which would conflict with this
+    // join's `into` projection.
     if (!q.seenJoin) {
         if (q.seenSelect) {
             macro_error(prog, at, "_sql: _join must precede `_select` in source order — the join's `into` lambda is the projection. Drop the trailing `_select(...)` or restructure the chain.")
@@ -875,12 +857,13 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
             return false
         }
     }
+    // nolint:STYLE015 — table of cases where snapshot-and-wrap is required; the (b) branch
+    // documents non-obvious NULL-on-preserved-side semantics.
     // 2. Snapshot q as an inner subquery and reset for outer wrap when:
     //    (a) srca contained a _join (multi-join chain); OR
-    //    (b) kind ∈ {Right, FullOuter} AND q.whereSql is non-empty — preserved-side
-    //        rows have NULL on the LHS columns, so an outer WHERE on those columns
-    //        would drop them. Wrapping LHS as `(SELECT * FROM Users WHERE …) AS t0`
-    //        applies the filter BEFORE the join, matching M2/M3 linq semantics.
+    //    (b) kind ∈ {Right, FullOuter} AND q.whereSql is non-empty — preserved-side LHS
+    //        columns are NULL after the join, so outer WHERE on them would drop the row;
+    //        wrap as `(SELECT * FROM Users WHERE …) AS t0` to filter BEFORE the join.
     let needsLhsWrapForPreservedSide = ((kind == JoinKind.Right || kind == JoinKind.FullOuter)
                                         && !empty(q.whereSql))
     if (q.seenJoin || needsLhsWrapForPreservedSide) {
@@ -929,21 +912,20 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     return false if (empty(leftCol))
     let rightCol = extract_key_selector_field(jCall.arguments[3], "__lb__", prog, at)
     return false if (empty(rightCol))
-    // For RIGHT / FULL OUTER with RHS WHERE, bake the WHERE into a derived-table subquery
-    // here so the row filter applies BEFORE the join — matches M2/M3 linq semantics. For
-    // LEFT/INNER the existing ON-AND attachment is correct (preserved-LHS sees NULL on
-    // unmatched RHS regardless), so leave those paths untouched.
+    // nolint:STYLE015 — explains why RIGHT/FULL OUTER need RHS-WHERE wrapping while LEFT/INNER don't.
+    // For RIGHT/FULL OUTER with RHS WHERE: bake into a derived-table subquery so the filter
+    // applies BEFORE the join (preserved-side semantics). LEFT/INNER are fine via ON-AND
+    // attachment since unmatched RHS becomes NULL regardless.
     let needsRhsWrapForPreservedSide = ((kind == JoinKind.Right || kind == JoinKind.FullOuter)
                                         && !empty(subQ.whereSql))
     var rhsTableName : string
     var rhsRightWhereSql : string
     var rhsTableSqlIsRaw = false
     if (needsRhsWrapForPreservedSide) {
-        // SELECT * is fine here — derived table propagates the underlying column names
-        // verbatim, and the outer query references t1.<col> by those names.
-        // Inner AS "t1" is required because subQ.whereSql may contain alias-qualified
-        // refs like `"t1"."Total"` built when subQ.rootAlias was "t1". Outer-most "t1"
-        // shadows the inner; SQLite scopes them by parens.
+        // nolint:STYLE015 — explains why inner AS "t1" is required (alias-qualified refs in subQ.whereSql).
+        // SELECT * propagates underlying column names; outer references t1.<col> by name.
+        // Inner AS "t1" is required because subQ.whereSql may carry refs like `"t1"."Total"`
+        // built when subQ.rootAlias was "t1". Outer-most "t1" shadows inner via parens-scope.
         rhsTableName := "(SELECT * FROM \"{subQ.tableName}\" AS \"t1\" WHERE {subQ.whereSql})"
         rhsRightWhereSql := ""
         rhsTableSqlIsRaw = true
@@ -961,9 +943,9 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
         rightCol = rightCol,
         rightWhereSql = rhsRightWhereSql,
         tableSqlIsRaw = rhsTableSqlIsRaw)
-    // ON binds live on JoinSpec, not q.bindExprs — runtime concats per-join ON before outer WHERE so placeholder order matches SQL.
-    // For the wrapped-RHS path, the binds are still emitted at the t1 source position (subquery body),
-    // which is BEFORE the ON keys — same SQL position as the unwrapped case, so bind ordering is preserved.
+    // nolint:STYLE015 — bind-order invariant across wrapped vs unwrapped RHS paths.
+    // ON binds live on JoinSpec (not q.bindExprs); runtime concats per-join ON before outer
+    // WHERE. Wrapped-RHS binds emit at the t1 subquery body — same SQL position as unwrapped.
     spec.rightOnBindExprs |> reserve(length(subQ.bindExprs))
     for (b in subQ.bindExprs) {
         spec.rightOnBindExprs |> push <| clone_expression(b)
@@ -989,12 +971,9 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     q.argSourceIdx |> push(0)
     q.argNames |> push(arg1Name)
     q.argSourceIdx |> push(1)
-    // Save aggregate state across analyze_projection: outer-peeled `_count`/`_sum`/etc. set
-    // q.aggregateExpr + q.proj=Aggregate before recursion; analyze_projection unconditionally
-    // writes q.proj=NamedTuple (and clears nothing else) which would clobber that intent.
-    // selectCols still need to be populated for the inner subquery in the multi-join /
-    // WHERE-peel snapshot paths, so we let analyze_projection run normally and restore the
-    // aggregate state afterwards. Invariant: aggregateExpr non-empty ⇒ proj=Aggregate.
+    // nolint:STYLE015 — save/restore explanation: analyze_projection clobbers proj=Aggregate
+    // set by outer-peeled `_count`/`_sum`/etc. We still need it to populate selectCols for
+    // the inner subquery, so run normally then restore. Invariant: aggregateExpr non-empty ⇒ proj=Aggregate.
     let savedAggExpr := q.aggregateExpr
     var savedAggType = q.aggregateType
     let savedAggProj = q.proj == ProjectionShape.Aggregate
@@ -1018,8 +997,7 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
 [macro_function]
 def private process_cross_join_call(var jCall : ExprCall?; var q : SqlQuery&;
                                     prog : ProgramPtr; at : LineInfo) : bool {
-    // 3-arg shape (srca, srcb, into) — no on-clause, no key extraction.
-    // Mirrors process_join_call's reject envelope and projection handling.
+    // 3-arg shape (srca, srcb, into); mirrors process_join_call's reject + projection handling.
     if (q.seenJoin) {
         macro_error(prog, at, "_sql: internal — process_cross_join_call entered with q.seenJoin already true (chain shape error)")
         return false
@@ -1102,6 +1080,7 @@ def private process_cross_join_call(var jCall : ExprCall?; var q : SqlQuery&;
         } else {
             q.whereSql := "({q.whereSql}) AND ({subQ.whereSql})"
         }
+        q.bindExprs |> reserve(q.bindExprs |> length + length(subQ.bindExprs))
         for (b in subQ.bindExprs) {
             q.bindExprs |> push <| clone_expression(b)
         }
@@ -1150,6 +1129,7 @@ def private process_cross_join_call(var jCall : ExprCall?; var q : SqlQuery&;
 
 [macro_function]
 def private collect_query_binds(var q : SqlQuery&; var out : array<ExpressionPtr>&) {
+    // nolint:STYLE015
     // Placeholder order matches SQL parse order, depth-first inner-first:
     //   1. Inner-Q (FROM subquery) binds — innermost SELECT parsed first
     //   2. Per-join ON binds — within outer FROM clause
@@ -1158,6 +1138,11 @@ def private collect_query_binds(var q : SqlQuery&; var out : array<ExpressionPtr
     //   5. Set-op RHS binds (compound `<lhs> UNION <rhs>` — RHS parsed before any outer LIMIT)
     //   6. LIMIT bind (compound applies to combined result, parsed last)
     //   7. OFFSET bind
+    var total = length(q.innerBindExprs) + length(q.bindExprs) + length(q.havingBindExprs) + length(q.setOpRhsBinds) + 2
+    for (j in q.joins) {
+        total += length(j.rightOnBindExprs)
+    }
+    out |> reserve(out |> length + total)
     for (b in q.innerBindExprs) {
         out |> push(b)
     }
@@ -1224,6 +1209,7 @@ def private fromrow_alias_list(rowT : TypeDeclPtr) : string {
     }
 }
 
+// nolint:STYLE014
 // Inner Q's projection-output type, used by the outer Q's lambdas to resolve `_.Field`.
 //   FullRow              → rootType (struct); outer's `_.Col` resolves through the source struct's columns.
 //   NamedTuple           → synthesized tuple<col0type;col1type;…> with argNames = projRecordNames; outer resolves `_.alias` by argNames lookup.
@@ -1259,16 +1245,12 @@ def private inner_projection_type(var inner : SqlQuery&; at : LineInfo) : TypeDe
         }
         return tupT
     }
-    // SingleColumn / Aggregate aren't valid as a divert source for the v2 path (the outer
-    // would have nothing meaningful to filter on by name). Caller rejects via shape check.
+    // SingleColumn / Aggregate: not a valid divert source — caller rejects via shape check.
     return inner.rootType
 }
 
-// Phase-conflict diversion: the peeled op + the rest of the chain are analyzed into a
-// fresh sub-Q, snapshotted as SQL string + flat bind list, and attached to outer q's
-// FROM clause. Same node is re-passed: the divert handles the outer-Q decision; the
-// inner Q sees the op as a normal first peel (no conflict, since subQ.minPhaseSeen
-// starts at INT_MAX_PHASE).
+// Phase-conflict diversion: rest of chain → fresh sub-Q, snapshotted as SQL+binds and
+// attached to outer's FROM. Same node re-passed; sub-Q starts fresh (no phase conflict).
 [macro_function]
 def private divert_to_inner(var node : ExpressionPtr; var q : SqlQuery&;
                             prog : ProgramPtr; at : LineInfo) : bool {
@@ -1281,14 +1263,12 @@ def private divert_to_inner(var node : ExpressionPtr; var q : SqlQuery&;
         return false
     }
     if (subQ.proj == ProjectionShape.SingleColumn || subQ.proj == ProjectionShape.Aggregate) {
-        // SingleColumn / Aggregate inner has no row to filter — the outer would either re-project
-        // the same scalar (no-op) or filter on an unaliased anonymous column. Reject both shapes.
+        // SingleColumn / Aggregate inner has no row for the outer to filter — reject both shapes.
         macro_error(prog, at, "_sql: cannot lower a chain whose inner subquery projects a single value (`_select(_.X)` or an aggregate) into an outer query — there is no named row to filter on. Restructure the chain so the divergent op runs before the projection, or wrap the projection in a named tuple `(X=_.X)`.")
         return false
     }
-    // force_aliases: outer Q references inner projection columns by alias name. Without AS,
-    // SQLite reports the column name as the raw expression (e.g. `COUNT(*)`), and the outer
-    // can't bind `_.alias` → `"alias"` to that. Standalone snapshot SQL keeps the minimal form.
+    // nolint:STYLE015 force_aliases=true: outer references inner cols by alias. Without AS, SQLite
+    // names the column as the raw expr (e.g. `COUNT(*)`); outer can't bind `_.alias` → `"alias"`.
     let innerSql = build_sql_string(subQ, true)
     var innerBinds : array<ExpressionPtr>
     collect_query_binds(subQ, innerBinds)
@@ -1302,9 +1282,7 @@ def private divert_to_inner(var node : ExpressionPtr; var q : SqlQuery&;
         q.dbExpr = subQ.dbExpr
     }
     if (subQ.proj == ProjectionShape.FullRow) {
-        // FullRow inner: outer treats the wrapped subquery as if it were the original table.
-        // rootType inherits, selectCols filled from struct fields, pred_to_sql `_.Col` resolves
-        // through q.rootType. v1 path — unchanged.
+        // FullRow inner: outer treats wrapped subquery as the original table; v1 path — unchanged.
         if (q.rootType == null) {
             q.rootType = subQ.rootType
         }
@@ -1312,10 +1290,7 @@ def private divert_to_inner(var node : ExpressionPtr; var q : SqlQuery&;
             fill_default_columns(q, q.rootType, prog, at)
         }
     } else {
-        // NamedTuple / GroupedNamedTuple inner: outer's "row" is the inner's named tuple, not a
-        // struct. rootType stays null; passthrough-project all aliases via SQL fragments so the
-        // outer SELECT renders as `SELECT "alias1", "alias2", ... FROM (<innerSql>) AS t0`.
-        // pred_to_sql resolves `_.alias` against q.fromRowType (set above).
+        // NamedTuple/Grouped: passthrough aliases as SQL frags → `SELECT "a1", ... FROM (<innerSql>) AS t0`.
         if (!apply_passthrough_projection(q, q.fromRowType, prog, at)) {
             return false
         }
@@ -1323,6 +1298,7 @@ def private divert_to_inner(var node : ExpressionPtr; var q : SqlQuery&;
     return true
 }
 
+// nolint:STYLE014
 // Phase-divert dispatcher used by every peel that participates in multi-Q lowering.
 // Encodes the standard "this op runs in eval phase `my_phase` but appears later in the
 // chain than something at a lower phase — divert OR track" pattern.
@@ -1562,12 +1538,10 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
     {
         var sCall = match_linq_call(node, "select")
         if (sCall != null) {
-            // v2 divert: only when outer chain pinned a WHERE (phase 2) — SQL `WHERE` filters source
-            // rows, but linq positional `_select |> _where` filters PROJECTED rows; the wrap pushes
-            // _select into a subquery so the outer WHERE can reference projection aliases.
-            // DISTINCT / TAKE / SKIP / ORDER_BY / set-op apply to the projected output in both SQL
-            // (`SELECT DISTINCT proj`, `SELECT proj LIMIT`, `... ORDER BY proj`) and linq positional
-            // — same semantics, no wrap needed.
+            // nolint:STYLE015 v2 divert only behind outer WHERE (phase 2) — SQL `WHERE` filters source rows,
+            // but linq `_select |> _where` filters PROJECTED rows; wrap pushes _select into a subquery so the
+            // outer WHERE can reference projection aliases. DISTINCT / TAKE / SKIP / ORDER_BY / set-op apply
+            // to projected output in both SQL and linq positional — same semantics, no wrap needed.
             let dr = maybe_divert(q, PHASE_SELECT, node, prog, at, PHASE_WHERE)
             if (dr != 0) {
                 return dr > 0
@@ -1689,15 +1663,14 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             if (!analyze_chain(wCall.arguments[0], q, prog, at)) {
                 return false
             }
-            // v2.1: outer WHERE on a JOIN's named-tuple `into` projection filters PROJECTED rows;
-            // pred_to_sql against base-table scope emits `t0.alias` which doesn't exist. Snapshot
-            // the analyzed q in place so WHERE renders as `... FROM (joinSql) AS "t0" WHERE "alias" = ...`,
-            // resolved through q.fromRowType. The `_select |> _where` case is already handled by
-            // the SELECT peel's divert (q.seenJoin is false there). Use the in-place snapshot
-            // helper, NOT divert_to_inner — re-analyzing here re-instantiates the generic chain
+            // nolint:STYLE015 v2.1: outer WHERE on JOIN's named-tuple `into` filters PROJECTED rows;
+            // pred_to_sql against base scope emits `t0.alias` which doesn't exist. Snapshot in place so
+            // WHERE renders as `... FROM (joinSql) AS "t0" WHERE "alias" = ...`, resolved through
+            // q.fromRowType. The `_select |> _where` case is handled by SELECT peel's divert (no seenJoin).
+            // Use snapshot helper, NOT divert_to_inner — re-analyzing re-instantiates the generic chain
             // and tickles a typer cascade in linq Mode-2/3.
-            // Aggregate-with-WHERE (`_join | _where | _count`) needs the same wrap so the WHERE
-            // can reference the projected alias; snapshot preserves aggregate state on the outer.
+            // Aggregate-with-WHERE (`_join | _where | _count`) needs same wrap for alias reference;
+            // snapshot preserves aggregate state on the outer.
             if (q.seenJoin && (q.proj == ProjectionShape.NamedTuple || q.aggregateExpr != "")) {
                 if (!snapshot_q_to_subquery_wrap(q, prog, at, [fillPassthrough = true])) {
                     return false
@@ -1771,8 +1744,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
                 return false
             }
             let rhsSql = build_sql_string(subQ)
-            // Collect RHS binds (in their internal placeholder order) into a separate slot;
-            // collect_query_binds(q) splices them after LHS WHERE/HAVING, before any outer LIMIT/OFFSET.
+            // RHS binds spliced (by collect_query_binds) after LHS WHERE/HAVING, before outer LIMIT.
             var rhsBinds : array<ExpressionPtr>
             collect_query_binds(subQ, rhsBinds)
             var rhsClones : array<ExpressionPtr>
@@ -2745,10 +2717,8 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             } else {
                 // Single-source: only `_` is bound.
                 if (argName == "_") {
-                    // Multi-Q outer over a NamedTuple/GroupedNamedTuple inner: rootType is null,
-                    // fromRowType is the inner's projected named-tuple. Resolve `_.alias` against
-                    // the tuple's argNames; outer FROM is `(<innerSql>) AS t0`, so unqualified
-                    // "<alias>" suffices (single source, no need for t0. prefix).
+                    // nolint:STYLE015 Multi-Q outer over named-tuple inner: rootType is null, resolve `_.alias`
+                    // against fromRowType.argNames; FROM is `(<innerSql>) AS t0` so unqualified suffices.
                     if (q.rootType == null && q.fromRowType != null) {
                         if (!fromrow_alias_exists(q.fromRowType, fieldName)) {
                             return pred_fail(q, prog, at, "_sql: column `{fieldName}` is not a projection alias of the inner subquery; valid aliases are {fromrow_alias_list(q.fromRowType)}")
@@ -2862,8 +2832,8 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             return ""
         }
     }
-    // Detect post-typer `operator==(a, none())` (qmatch shape is gone) — fixit for is_none/is_some.
-    // Must run BEFORE the bind fallthrough, otherwise `none()` would silently bind an empty placeholder.
+    // nolint:STYLE015 Detect post-typer `operator==(a, none())` for is_none/is_some fixit. Must run
+    // BEFORE the bind fallthrough, otherwise `none()` would silently bind an empty placeholder.
     if (node is ExprCall) {
         let c = node as ExprCall
         let cname = string(c.name)
@@ -2879,10 +2849,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             }
         }
     }
-    // Bind fallthrough — anything not recognized as column/operator/subquery/SQL-fn is treated as
-    // a runtime value. Splice goes through `sql_bind_to_stmt(stmt, idx, $e(node))`; daslang's
-    // typer + the catch-all `sql_bind(auto(TT))` with `concept_assert` produce the user-facing
-    // error if the type isn't bindable.
+    // Bind fallthrough: unrecognized exprs become `?`; sql_bind catch-all + concept_assert error if not bindable.
     if (q.inHaving) {
         q.havingBindExprs |> push <| clone_expression(node)
     } else {
@@ -3388,10 +3355,8 @@ def private build_sql_select(var q : SqlQuery&; force_aliases : bool = false) : 
         if (q.proj == ProjectionShape.Aggregate) {
             w |> write(q.aggregateExpr)
         } elif (q.proj == ProjectionShape.GroupedNamedTuple) {
-            // Pre-formatted SQL fragments — emit verbatim. AS "<alias>" emitted only when
-            // `force_aliases` (set by `divert_to_inner` so a multi-Q outer can resolve `_.alias`)
-            // OR when the alias doesn't match the fragment's natural identifier and we're
-            // ALWAYS-aliasing a renamed projection. Standalone snapshot SQL stays stable.
+            // nolint:STYLE015 Pre-formatted frags emit verbatim; AS "<alias>" only when force_aliases
+            // (multi-Q outer resolution) or when alias differs from natural identifier (renamed projection).
             for (i in range(length(q.groupedSelectExprs))) {
                 if (i > 0) {
                     w |> write(", ")
@@ -3431,8 +3396,7 @@ def private build_sql_select(var q : SqlQuery&; force_aliases : bool = false) : 
                 }
             }
         }
-        // FROM clause: alias the root table only when joins are present (single-source keeps unaliased `FROM "Tbl"`).
-        // Multi-Q lowering: when innerSql is set, FROM renders as `(<innerSql>) AS t0` instead of base-table.
+        // FROM clause: alias root only with joins; with innerSql renders `(<innerSql>) AS t0` instead of base-table.
         if (q.seenJoin) {
             // Multi-join LHS subquery: outer `FROM (<innerSql>) AS "t0"` instead of base table.
             if (!empty(q.innerSql)) {
@@ -3494,8 +3458,7 @@ def private build_sql_select(var q : SqlQuery&; force_aliases : bool = false) : 
                 // Cross joins have no ON / no rightWhereSql (process_cross_join_call hoists into outer WHERE).
             }
         } elif (!empty(q.innerSql)) {
-            // Outer Q wrapping a phase-conflict-pushed subquery. Inner emits default-row projection
-            // (column names visible to outer's `_.<field>` resolution against q.rootType).
+            // Outer wrapping phase-conflict-pushed subquery; inner's default-row projection feeds outer's `_.<field>`.
             w |> write(" FROM (")
             w |> write(q.innerSql)
             w |> write(") AS \"t0\"")
@@ -3503,9 +3466,8 @@ def private build_sql_select(var q : SqlQuery&; force_aliases : bool = false) : 
             w |> write(" FROM \"")
             w |> write(q.tableName)
             w |> write("\"")
-            // When emitting as an inner subquery (snapshot wrap path), q.whereSql can carry
-            // alias-qualified column refs like `"t0"."Id"` built when q.rootAlias was set.
-            // Without AS here, those refs reference an undefined alias inside the parens.
+            // nolint:STYLE015 Inner-subquery snapshot wrap: q.whereSql may carry `"t0"."Id"` refs built
+            // when rootAlias was set; without AS here they'd reference an undefined alias inside the parens.
             if (force_aliases && !empty(q.rootAlias)) {
                 w |> write(" AS \"")
                 w |> write(q.rootAlias)
@@ -3623,10 +3585,8 @@ class private SqlCreateViewMacro : AstCallMacro {
         var q = SqlQuery()
         q.inView = true
         if (!analyze_chain(call.arguments[2], q, prog, call.at)) {
-            // Deeper pred_fail macro_errors can be eaten by the AST cascade after the
-            // call_macro returns null (free `_` references in the un-replaced original
-            // expression confuse the typer). Re-emit the captured first error so the
-            // user sees the actual cause.
+            // nolint:STYLE015 Deeper pred_fail errors get eaten by the AST cascade after call_macro
+            // returns null (free `_` refs confuse the typer); re-emit captured first error.
             if (!empty(q.lastError)) {
                 macro_error(prog, call.at, q.lastError)
             }
@@ -3641,11 +3601,7 @@ class private SqlCreateViewMacro : AstCallMacro {
             macro_error(prog, call.at, "_create_view: `_order_by(<runtime string>)` not supported — the runtime column name would be baked in at CREATE VIEW time. Use a compile-time `_.Field` ordering inside the view, or build a chain with `_sql(...)` outside.")
             return null
         }
-        // Collect binds in placeholder order via collect_query_binds (handles inner-Q
-        // subqueries + set-op RHS; for views the chain is bounded but we use the same
-        // helper for consistency). Each bind expression goes through `_::to_sql_literal(...)`
-        // at runtime — value is evaluated once when CREATE VIEW DDL executes and inlined
-        // into the view body text stored in sqlite_schema.
+        // Each bind goes through `_::to_sql_literal(...)`: evaluated once at CREATE VIEW DDL time, inlined into view body.
         var ordered_binds : array<ExpressionPtr>
         collect_query_binds(q, ordered_binds)
         // Validate projection column count vs V's fields.
@@ -3705,10 +3661,8 @@ class private SqlCreateViewMacro : AstCallMacro {
                 w |> write("\"")
             }
         }
-        // Emit ExprStringBuilder = "CREATE VIEW … AS " + text frags interleaved with
-        // `_::to_sql_literal(<bind>)` runtime calls. `_::` resolves at the user's call
-        // site, so user-defined `to_sql_literal` overloads (for enums, structs, etc.)
-        // take precedence over the defaults shipped in this module.
+        // nolint:STYLE015 ExprStringBuilder of text frags + `_::to_sql_literal(<bind>)` calls; `_::` resolves
+        // at user call site so user-defined to_sql_literal overloads override module defaults.
         let select_sql_template = build_sql_string(q)
         var sb = new ExprStringBuilder(at = call.at)
         var pending = "CREATE VIEW \"{view_name}\"({col_list}) AS "
@@ -4002,8 +3956,7 @@ def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; is
         macro_error(prog, call.at, "_sql: distinct() before an aggregate is not translatable — `SELECT DISTINCT` over a single-row aggregate result is always a no-op; the meaningful form is `COUNT(DISTINCT col)` etc. (aggregate-distinct), which is not yet implemented")
         return null
     }
-    // Bind order: inner-Q (FROM subquery) → per-join ON → WHERE → HAVING → set-op-RHS → LIMIT → OFFSET.
-    // Centralized in collect_query_binds; recurses into inner subqueries for multi-Q lowering.
+    // Bind order (centralized in collect_query_binds): inner-Q FROM → per-join ON → WHERE → HAVING → set-op-RHS → LIMIT → OFFSET.
     var allBinds : array<ExpressionPtr>
     collect_query_binds(q, allBinds)
     let sql = build_sql_string(q)

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -228,6 +228,12 @@ CI's `extended_checks` job runs `./bin/Release/daslang ./das-fmt/dasfmt.das -- -
 
 **Before pushing:** mentally format named-arg constructor / call sites with spaces around `=`. If CI `extended_checks` fails on a format diff after MCP said "already formatted", fix the spacing and re-push (or amend, on a squashed branch).
 
+## 5.5. `.md` stop-rule — STOP before push if any `.md` changed
+
+If `git diff --name-only origin/master..HEAD` includes ANY `.md` file (CLAUDE.md, `skills/`, `**/README.md`, design docs like `API_REWORK.md`), **STOP before `git push`**. List each modified `.md` with a one-line summary of what changed, and ask the user to review. Do not push until they greenlight.
+
+**Why:** doc edits direct future Claude behavior. Code edits get caught by tests; doc edits don't. Silent .md diffs in a PR are not OK — every .md change in a PR must be acknowledged by the user before it goes live.
+
 ## 6. Create the PR
 
 Stage, commit, push, and create the PR using GitHub MCP tools or `gh` CLI. Follow the commit message conventions from the repository (see recent `git log` for style).
@@ -247,5 +253,6 @@ Stage, commit, push, and create the PR using GitHub MCP tools or `gh` CLI. Follo
 | AOT tests | `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` | Same as regular tests |
 | Docs | `das2rst.das` + stubs + Sphinx | Only if daslib/C++ bindings/RST changed |
 | Format | MCP `format_file` with comma-separated list or glob of changed `.das` files (single call) | Only changed files |
+| `.md` stop | `git diff --name-only origin/master..HEAD \| grep '\.md$'` | If any match: STOP, list changes, ask user to review BEFORE push |
 | PR | GitHub MCP `create_pull_request` or `gh pr create` | — |
 | Review iter | Follow `skills/pr_review_iteration.md` | One round per Copilot pass; convergence in 1-3 rounds is normal |

--- a/tests-cpp/big/style_lint/CMakeLists.txt
+++ b/tests-cpp/big/style_lint/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Big test: utils/lint must surface STYLE014/STYLE015 on the canonical
+# comment-hygiene fixtures. Catches regressions in the option/flag plumbing
+# and the scan_long_comment_blocks pass.
+
+file(GLOB STYLE_LINT_FIXTURES CONFIGURE_DEPENDS
+    ${PROJECT_SOURCE_DIR}/utils/lint/tests/style014_*.das
+    ${PROJECT_SOURCE_DIR}/utils/lint/tests/style015_*.das)
+
+foreach(_fixture ${STYLE_LINT_FIXTURES})
+    get_filename_component(_name ${_fixture} NAME_WE)
+    add_test(
+        NAME style_lint_${_name}
+        COMMAND $<TARGET_FILE:daslang>
+                ${PROJECT_SOURCE_DIR}/utils/lint/main.das
+                -- --comment-hygiene true ${_fixture}
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    set_tests_properties(style_lint_${_name} PROPERTIES
+        LABELS "big;style_lint"
+        PASS_REGULAR_EXPRESSION "STYLE014|STYLE015")
+endforeach()
+
+add_dependencies(test-big daslang)

--- a/utils/mcp/tools/lint_tool.das
+++ b/utils/mcp/tools/lint_tool.das
@@ -6,6 +6,7 @@ require common public
 require daslib/lint
 require daslib/perf_lint
 require daslib/style_lint
+require daslib/ast_boost
 require strings
 
 def has_expect_directive(file : string) : bool {
@@ -43,7 +44,8 @@ def do_lint_single(file : string; project : string = "") : string {
             all_issues |> push(w)
         }
         var style_issues : array<string>
-        count += style_lint_collect(program, style_issues)
+        let hygiene = program._options |> find_arg("_comment_hygiene") ?as tBool ?? false
+        count += style_lint_collect(program, style_issues, false, hygiene)
         for (w in style_issues) {
             all_issues |> push(w)
         }
@@ -89,7 +91,8 @@ def do_lint_file(file : string; project : string = "") : LintFileResult {
                         result.errors |> push(w)
                     }
                     var style_issues : array<string>
-                    result.count += style_lint_collect(program, style_issues)
+                    let hygiene = program._options |> find_arg("_comment_hygiene") ?as tBool ?? false
+                    result.count += style_lint_collect(program, style_issues, false, hygiene)
                     for (w in style_issues) {
                         result.errors |> push(w)
                     }


### PR DESCRIPTION
## Summary

Three threads, one PR:

### 1. MCP `lint` now surfaces STYLE014/015 (the actual bug fix)

`utils/mcp/tools/lint_tool.das` was hardcoded to call `style_lint_collect(program, style_issues)` with no `comment_hygiene` arg, so STYLE014/STYLE015 silently never fired through MCP. Both call sites (`do_lint_single`, `do_lint_file`) now read `_comment_hygiene` from `program._options` and forward it. The opt-in remains `options _comment_hygiene = true` in the file being linted (or any module it requires).

New CTest suite `tests-cpp/big/style_lint/CMakeLists.txt` runs the canonical fixtures (`utils/lint/tests/style01[45]_*.das`) through the lint binary and asserts `STYLE014|STYLE015` appears in the output. Catches regressions in this exact wiring class.

### 2. dasSQLITE comment-hygiene cleanup (the result)

Ran the now-working lint on `modules/dasSQLITE/daslib/sqlite_boost.das` + `sqlite_linq.das` and resolved every hit:
- **Trim** (~17): WHY compressed cleanly into 1–2 lines.
- **Suppress with `// nolint:STYLE015` / `//!@nolint`** (~25): bind-order invariants, save/clear/restore patterns, NULL-on-preserved-side join semantics, phase-divert dispatcher contracts — load-bearing comments where the explanation IS the value and trimming would lose the WHY.
- **`//!` → `//` + drop/trim** (4): private symbols carrying `//!` docstrings, per CLAUDE.md "private symbols don't get public-style docs".
- **Bonus**: 6× PERF006 (push-without-reserve in `collect_query_binds` + `process_cross_join_call`) and 2× STYLE011 (decl-then-assign in `snapshot_q_to_subquery_wrap`) fixed in the same pass since they were trivially adjacent.

### 3. Doc-improvement policy in CLAUDE.md + skills/make_pr.md

- **CLAUDE.md**: extended the existing "Updating Instructions with New Knowledge" section. Trivial doc fixes (typos, factual errors) land in-place during a task and get flagged in the end-of-turn summary; anything bigger (clarifications, restructuring, removing guidance, new skill files) — propose first.
- **skills/make_pr.md step 5.5**: STOP before `git push` if any `.md` is in `git diff --name-only origin/master..HEAD`. List each `.md` change for explicit user review. Doc edits direct future Claude behavior; tests catch code, nothing catches docs.

## Test plan

- [x] MCP `lint utils/lint/tests/style014_long_comment.das` → fires 2× STYLE014
- [x] MCP `lint modules/dasSQLITE/daslib/sqlite_boost.das` → PASS (post-cleanup)
- [x] MCP `lint modules/dasSQLITE/daslib/sqlite_linq.das` → PASS (post-cleanup)
- [x] CLI `bin/Release/daslang.exe utils/lint/main.das -- --comment-hygiene true utils/lint/tests/style01[45]_*.das` → both fixtures fire correctly
- [x] `ctest --test-dir build -C Release -L style_lint` → 2/2 PASS
- [x] dasSQLITE interp tests: 646/646 pass
- [x] dasSQLITE AOT tests: 646/646 pass
- [x] `mcp__daslang__format_file` clean on all touched `.das` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)