### PR TITLE
daslib/fio: promote expand_glob/parse_file_list; add strings skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/daslang_live.md` | `daslang-live`, live-reload lifecycle, `[live_command]`, `[before_reload]`/`[after_reload]` |
 | `skills/perf_lint.md` | Adding rules to `daslib/perf_lint.das` |
 | `skills/style_lint.md` | Adding rules to `daslib/style_lint.das` |
+| `skills/strings.md` | Any `.das` string operation — `find`/`replace`/`split`/parsing/`build_string`/`peek_data` (covers `strings`, `daslib/strings_boost`, `daslib/strings_convert`) |
 | `skills/regex.md` | Writing regular expressions in `.das` code |
 | `skills/glob.md` | Writing or reviewing any glob/wildcard pattern handling — file selection, include/exclude masks, pattern-match-on-paths (`*` / `?` / `**` / `[abc]`) |
 | `skills/gc_migration.md` | Migrating external/archived code from `smart_ptr<T>` AST patterns to gc_node (in-tree migration is complete) |

--- a/daslib/fio.das
+++ b/daslib/fio.das
@@ -402,6 +402,134 @@ def is_glob_pattern(pattern : string) : bool {
     return find(pattern, '*') >= 0 || find(pattern, '?') >= 0 || find(pattern, '[') >= 0
 }
 
+//! Expand a single glob pattern (e.g. `src/**/*.das`) into a sorted list of matching file paths.
+//! The literal directory prefix (everything before the first glob metacharacter) becomes the walk root;
+//! the rest stays as a pathname-glob pattern matched against entries via `match_glob` / `glob`.
+//! `**` or any `/` in the remainder triggers a recursive walk; otherwise a shallow `dir` walk.
+//! The pattern is normalized to forward slashes via `to_generic_path`, so backslash patterns (`src\sub\*.das`)
+//! work the same as the POSIX form. Results are sorted and **appended** to `result` (does not clear it),
+//! so callers can build a single list from multiple `expand_glob` calls.
+def expand_glob(pattern : string; var result : array<string>) {
+    let normalized_pattern = to_generic_path(pattern)
+    let split = _split_literal_prefix(normalized_pattern)
+    let dir_part = split._0
+    let file_pattern = split._1
+    // Pattern is already `/`-normalized (see normalize above), so no need to also check for `\` here.
+    let recursive = (find(file_pattern, "**") >= 0
+                     || find(file_pattern, "/") >= 0)
+    var matches : array<string>
+    if (recursive) {
+        glob(dir_part, file_pattern) $(fname, is_dir) {
+            if (is_dir) {
+                return
+            }
+            matches |> push(_join_path(dir_part, fname))
+        }
+    } else {
+        // Shallow walk: `dir(...)` yields names without an `is_dir` flag, so stat each match
+        // and skip directories — callers expect file paths only.
+        dir(dir_part) $(fname) {
+            if (fname == "." || fname == "..") {
+                return
+            }
+            if (match_glob(file_pattern, fname)) {
+                let full = _join_path(dir_part, fname)
+                let st = stat(full)
+                if (st.is_valid && st.is_dir) {
+                    return
+                }
+                matches |> push(full)
+            }
+        }
+    }
+    sort(matches)
+    result |> reserve(length(result) + length(matches))
+    for (m in matches) {
+        result |> push(m)
+    }
+}
+
+// Join `dir_part` and `fname` with `/`, but skip the inserted separator when `dir_part`
+// is `.` or already ends with `/` or `\` (filesystem root, drive root).
+def private _join_path(dir_part : string; fname : string) : string {
+    if (dir_part == ".") {
+        return fname
+    }
+    if (dir_part |> ends_with("/") || dir_part |> ends_with("\\")) {
+        return "{dir_part}{fname}"
+    }
+    return "{dir_part}/{fname}"
+}
+
+// Split a pattern into (literal_dir, glob_remainder) at the last separator before the first
+// glob metacharacter. Pattern with no metacharacters splits at its last separator. Returned
+// dir_part is "." when no separator precedes the meta.
+def private _split_literal_prefix(pattern : string) : tuple<string; string> {
+    var first_meta = find(pattern, '*')
+    let qmark = find(pattern, '?')
+    if (qmark >= 0 && (first_meta < 0 || qmark < first_meta)) {
+        first_meta = qmark
+    }
+    let lbrack = find(pattern, '[')
+    if (lbrack >= 0 && (first_meta < 0 || lbrack < first_meta)) {
+        first_meta = lbrack
+    }
+    let scan_end = first_meta < 0 ? length(pattern) : first_meta
+    let prefix = slice(pattern, 0, scan_end)
+    let sep_fwd = rfind(prefix, "/")
+    let sep_back = rfind(prefix, "\\")
+    let sep = sep_fwd >= sep_back ? sep_fwd : sep_back
+    if (sep < 0) {
+        return "." => pattern
+    }
+    let raw_dir = slice(pattern, 0, sep)
+    let raw_sep = slice(pattern, sep, sep + 1)
+    let remainder = slice(pattern, sep + 1)
+    // POSIX absolute root: pattern starts with `/` (or `\`). Empty prefix would tell
+    // `glob`/`dir` to walk an empty path; keep the separator.
+    if (empty(raw_dir)) {
+        return raw_sep => remainder
+    }
+    // Windows drive root like `C:` (or `C:/foo` after normalization with sep at index 2).
+    // Without the trailing separator `dir_rec` interprets `C:` as "current directory on drive C".
+    if (length(raw_dir) == 2 && raw_dir |> ends_with(":")) {
+        return "{raw_dir}{raw_sep}" => remainder
+    }
+    return raw_dir => remainder
+}
+
+//! Parse a comma- or newline-separated list of files / dirs / globs into a flat list of paths.
+//! Each entry is stripped of leading/trailing whitespace; empty entries are skipped. Literal entries
+//! pass through; glob entries (containing `*`, `?`, or `[`) are expanded via `expand_glob`. Results
+//! are **appended** to `result` (does not clear it).
+def parse_file_list(file : string; var result : array<string>) {
+    if (find(file, ",") < 0 && find(file, "\n") < 0) {
+        let part = strip(file)
+        if (empty(part)) {
+            return
+        }
+        if (is_glob_pattern(part)) {
+            expand_glob(part, result)
+        } else {
+            result |> push(part)
+        }
+        return
+    }
+    builtin_string_split_by_char(file, ",\n") $(arr : array<string>#) : void {
+        for (raw in arr) {
+            let part = strip(raw)
+            if (empty(part)) {
+                continue
+            }
+            if (is_glob_pattern(part)) {
+                expand_glob(part, result)
+            } else {
+                result |> push(part)
+            }
+        }
+    }
+}
+
 // convenience: disk_space returning struct
 [generic]
 def disk_space(path : string) : DiskSpaceInfo {

--- a/daslib/fio.das
+++ b/daslib/fio.das
@@ -332,16 +332,7 @@ def match_glob(pattern : string; path : string) : bool {
     return false if (plen == 0)
     if (slen == 0) {
         // Empty path matches a pattern only when every char is `*` (any number of stars or **).
-        var ok = true
-        peek_data(pattern) $(arr) {
-            for (i in range(length(arr))) {
-                if (arr[i] != uint8('*')) {
-                    ok = false
-                    break
-                }
-            }
-        }
-        return ok
+        return empty(replace(pattern, "*", ""))
     }
     var result = false
     peek_data(pattern) $(parr) {
@@ -359,13 +350,7 @@ def match_glob(pattern : string; path : string) : bool {
 //! separator (`\` on Windows). Use `to_generic_path` when you want stable
 //! `/`-separated output independent of host.
 def to_generic_path(s : string) : string {
-    return modify_data(s) $(var arr) {
-        for (i in range(length(arr))) {
-            if (arr[i] == uint8('\\')) {
-                arr[i] = uint8('/')
-            }
-        }
-    }
+    return replace(s, "\\", "/")
 }
 
 //! Walk `root` recursively and invoke `blk` for every entry whose path (relative to `root`)
@@ -414,17 +399,7 @@ def glob_filtered(root : string; includes : array<string>; excludes : array<stri
 //! Returns true if `pattern` contains any glob metacharacter (`*`, `?`, `[`).
 //! Used by callers that treat literal patterns differently from glob patterns.
 def is_glob_pattern(pattern : string) : bool {
-    var has_meta = false
-    peek_data(pattern) $(arr) {
-        for (i in range(length(arr))) {
-            let c = arr[i]
-            if (c == uint8('*') || c == uint8('?') || c == uint8('[')) {
-                has_meta = true
-                break
-            }
-        }
-    }
-    return has_meta
+    return find(pattern, '*') >= 0 || find(pattern, '?') >= 0 || find(pattern, '[') >= 0
 }
 
 // convenience: disk_space returning struct

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -191,7 +191,7 @@ def document_module_fio(root : string) {
         group_by_regex("File manipulation", mod, %regex~(f|stat$|getchar|remove|rename|copy_file|file_size|equivalent|is_symlink|set_mtime)%%),
         group_by_regex("Path manipulation", mod, %regex~(base_name|dir_name|get_full_file_name|extension|stem|replace_extension|path_join|normalize|to_generic_path|is_absolute|relative|relative_result|parent)$%%),
         group_by_regex("Directory manipulation", mod, %regex~(dir|dir_rec|mkdir|mkdir_rec|mkdir_result|rmdir|rmdir_rec|rmdir_rec_result|rmdir_result|chdir|getcwd)$%%),
-        group_by_regex("Glob and pattern matching", mod, %regex~(match_glob|glob|glob_filtered|is_glob_pattern)$%%),
+        group_by_regex("Glob and pattern matching", mod, %regex~(match_glob|glob|glob_filtered|is_glob_pattern|expand_glob|parse_file_list)$%%),
         group_by_regex("Filesystem queries", mod, %regex~(temp_directory|temp_directory_result|create_temp_file|create_temp_file_result|create_temp_directory|create_temp_directory_result|disk_space)$%%),
         group_by_regex("OS specific routines", mod, %regex~(sleep|exit|system|popen|popen_binary|popen_timeout|popen_argv|popen_timed_out|get_env_variable|sanitize_command_line|has_env_variable)$%%),
         group_by_regex("Dynamic modules", mod, %regex~(register_dynamic_module|register_native_path)$%%)

--- a/doc/source/reference/tutorials/54_glob.rst
+++ b/doc/source/reference/tutorials/54_glob.rst
@@ -125,6 +125,50 @@ A common convention used by build/release tools:
 - A **glob** pattern that matches no file is a *warning* (the pattern was
   conditional and simply did not apply on this run).
 
+Pattern to file list with ``expand_glob``
+==========================================
+
+``expand_glob(pattern, var result)`` is the higher-level helper for the common
+"single glob argument from the command line" case.  It splits the literal
+directory prefix from the glob remainder, picks recursive (``glob``) vs shallow
+(``dir``) walk based on whether the remainder contains ``**`` or ``/``,
+filters out directories so callers receive regular files only, sorts the
+matches **locally**, and *appends* them to ``result``.  Backslash patterns
+(``src\sub\*.das``) are normalized to ``/`` form internally.
+
+.. code-block:: das
+
+    var das_files : array<string>
+    expand_glob("src/**/*.das", das_files)
+    // das_files is sorted; only contains regular files; previously-existing
+    // entries in das_files keep their position because the sort is local.
+
+
+Comma/newline lists with ``parse_file_list``
+=============================================
+
+``parse_file_list(file, var result)`` is the canonical
+"user-supplied paths argument → expanded file list" expander used by every
+MCP tool with a ``paths`` / ``file`` argument.  Input is a comma- or
+newline-separated list; whitespace is stripped; empty entries are skipped.
+Literal entries pass through unchanged; glob entries (those containing
+``*``, ``?``, or ``[``) go through ``expand_glob``.  Order is preserved
+across plain entries — globs sort within their own slice.
+
+.. code-block:: das
+
+    var inputs : array<string>
+    parse_file_list("README.md,daslib/*.das,tests/fio/*.das", inputs)
+    // inputs:
+    //   README.md           (plain, position preserved)
+    //   daslib/<sorted>     (glob expansion, sorted within its slice)
+    //   tests/fio/<sorted>  (glob expansion, sorted within its slice)
+
+Reach for ``parse_file_list`` from any new CLI tool that accepts a
+``--files`` / ``--paths`` argument.  Reach for ``expand_glob`` when the
+caller already split its argument into individual glob patterns.
+
+
 Choosing between the two flavors
 =================================
 
@@ -161,15 +205,28 @@ Performance notes
 Summary
 ========
 
-==================================  =============================================
-Function                            Description
-==================================  =============================================
-``match_glob(pattern, path)``       Pathname-aware glob match (true/false).
-``glob(root, pattern, blk)``        Walk ``root`` recursively, yield matches.
-``glob_filtered(root, in, ex, b)``  Walk + filter via include/exclude lists.
-``is_glob_pattern(s)``              Detect whether a string is a glob or literal.
-``glob_match(pattern, text)``       Filename-style match (``*`` crosses ``/``).
-==================================  =============================================
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Function
+     - Description
+   * - ``match_glob(pattern, path)``
+     - Pathname-aware glob match (true/false).
+   * - ``glob(root, pattern, blk)``
+     - Walk ``root`` recursively, yield matches.
+   * - ``glob_filtered(root, in, ex, b)``
+     - Walk + filter via include/exclude lists.
+   * - ``is_glob_pattern(s)``
+     - Detect whether a string is a glob or literal.
+   * - ``to_generic_path(s)``
+     - Convert a path to forward slashes regardless of host.
+   * - ``expand_glob(pattern, var result)``
+     - Pattern → sorted file list, appends.
+   * - ``parse_file_list(file, var result)``
+     - Comma/newline list of files / dirs / globs → flat list.
+   * - ``glob_match(pattern, text)``
+     - Filename-style match (``*`` crosses ``/``).
 
 .. seealso::
 

--- a/doc/source/reference/utils/detect_dupe.rst
+++ b/doc/source/reference/utils/detect_dupe.rst
@@ -400,6 +400,13 @@ the same scanner ``-p`` uses.  ``--paths-stdin`` is mutually
 exclusive with ``--against-from-stdin`` (one stdin reader per
 run).
 
+For tools that take a comma- or newline-separated list of files,
+directories, and globs in a single argument (the format used by
+all MCP file/glob tools), the canonical expander lives in
+``daslib/fio.parse_file_list`` --- it strips whitespace, dispatches
+literals through and globs through ``expand_glob``, and preserves
+the order of plain entries across glob expansions.
+
 The on-disk schema is a small envelope:
 
 .. code-block:: json

--- a/doc/source/stdlib/handmade/module-fio.rst
+++ b/doc/source/stdlib/handmade/module-fio.rst
@@ -29,3 +29,44 @@ Example:
         }
         // output:
         // hello, daslang!
+
+Glob and pattern matching
+-------------------------
+
+The fio module also provides path-aware glob matching and expansion. ``match_glob``,
+``glob``, ``glob_filtered``, ``is_glob_pattern`` and ``to_generic_path`` are the low-level
+primitives; ``expand_glob`` and ``parse_file_list`` are the higher-level helpers used by
+CLI tools that take a user-supplied pattern or a comma/newline-separated list of paths.
+
+* ``match_glob(pattern, path) : bool`` — pure path-string match. ``*`` does not cross ``/``;
+  ``**`` does. ``[abc]`` / ``[a-z]`` / ``[!abc]`` / ``[^abc]`` character classes are supported.
+* ``glob(root, pattern, blk)`` — recursive walk + match in one pass. Callback receives
+  ``/``-normalized paths regardless of host OS.
+* ``glob_filtered(root, includes, excludes, blk)`` — multi-pattern walk; excludes win on conflict.
+* ``is_glob_pattern(pattern) : bool`` — true if the string contains ``*``, ``?``, or ``[``.
+* ``to_generic_path(s) : string`` — convert a path to use forward slashes regardless of host.
+* ``expand_glob(pattern, var result)`` — expand a single glob pattern (e.g. ``src/**/*.das``)
+  into a sorted list of matching file paths. Splits the literal directory prefix from the glob
+  remainder, picks recursive vs shallow walk based on whether the remainder contains ``**`` or ``/``,
+  filters out directories, sorts locally, and **appends** to ``result``.
+* ``parse_file_list(file, var result)`` — parse a comma- or newline-separated list of files,
+  directories, and globs into a flat list of paths. Strips whitespace, skips empty entries,
+  literal entries pass through, glob entries go through ``expand_glob``. Also **appends** to ``result``.
+
+.. code-block:: das
+
+    require daslib/fio
+
+    [export]
+    def main() {
+        // expand a single pattern
+        var das_files : array<string>
+        expand_glob("daslib/**/*.das", das_files)
+        for (f in das_files) { print("{f}\n") }
+
+        // parse a user-supplied paths argument: any mix of plain paths and globs
+        var inputs : array<string>
+        parse_file_list("README.md,daslib/*.das,tests/fio/*.das", inputs)
+    }
+
+For runnable examples covering every flavor, see ``tutorials/language/54_glob.das``.

--- a/examples/daspkg/packages/daspkg-example-c/CMakeLists.txt
+++ b/examples/daspkg/packages/daspkg-example-c/CMakeLists.txt
@@ -16,21 +16,13 @@ target_include_directories(dasModuleFastMath PRIVATE
     "${DASLANG_DIR}/include"
 )
 
-if(WIN32)
-    if(EXISTS "${DASLANG_DIR}/lib/Release/libDaScriptDyn.lib")
-        target_link_libraries(dasModuleFastMath PRIVATE
-            "${DASLANG_DIR}/lib/Release/libDaScriptDyn.lib"
-        )
-    else()
-        target_link_libraries(dasModuleFastMath PRIVATE
-            "${DASLANG_DIR}/lib/libDaScriptDyn.lib"
-        )
-    endif()
-else()
-    target_link_libraries(dasModuleFastMath PRIVATE
-        "${DASLANG_DIR}/lib/libDaScriptDyn.so"
-    )
-endif()
+find_library(DASCRIPT_DYN_LIB
+    NAMES libDaScriptDyn DaScriptDyn
+    PATHS "${DASLANG_DIR}/lib/Release" "${DASLANG_DIR}/lib"
+    NO_DEFAULT_PATH
+    REQUIRED
+)
+target_link_libraries(dasModuleFastMath PRIVATE ${DASCRIPT_DYN_LIB})
 
 set_target_properties(dasModuleFastMath PROPERTIES
     SUFFIX ".shared_module"

--- a/skills/filesystem.md
+++ b/skills/filesystem.md
@@ -10,7 +10,16 @@ Runnable examples: [tests/fio/fio_utils.das](tests/fio/fio_utils.das), [tutorial
 require daslib/fio
 ```
 
-`daslib/fio` does `require fio_core public` internally, so this single require pulls in both the C++ builtins and the daslang-side wrappers (RAII `fopen`, `_result` variants, `mkdir_rec`, `disk_space` struct return, whole-file `fread(path)`/`fwrite(path, text)`).
+Always require `daslib/fio` — never `fio_core` directly. `daslib/fio` does `require fio_core public` internally, so this single require pulls in both layers transitively.
+
+### `fio_core` vs `daslib/fio`
+
+Two layers, one require:
+
+- **`fio_core`** (C++ builtins) — the path primitives that are basically free function calls into `std::filesystem`: `path_join`, `is_absolute`, `normalize`, `relative` (3-arg with error out-param), `dir_name`, `base_name`, `parent`, `extension`, `stem`, `replace_extension`, `fexist`, `stat`, `dir`, `dir_rec` (builtin), `fopen` (2-arg returning `FILE?`), `mkdir`/`rmdir`, `remove`/`rename`, `copy_file`, temp files/dirs, env vars, `popen`/`system`. Listed via `mcp__daslang__list_module_api fio_core`.
+- **`daslib/fio`** (the daslang wrapper) — adds RAII `fopen` with block, `dir_rec` generic, `FStat` daslib overload (sets `is_valid`), `disk_space` struct return, whole-file `fread(path)`/`fwrite(path, text)`, `mkdir_rec`, the `_result` variants that wrap error out-params into a `fs_result_string`/`fs_result_bool` variant, and the **glob bundle**: `match_glob`, `glob`, `glob_filtered`, `is_glob_pattern`, `to_generic_path`, `expand_glob`, `parse_file_list`. Source: [daslib/fio.das](daslib/fio.das).
+
+The "Pick the right tool first" table below mixes both — it doesn't matter which layer a function lives in, only that you use the right one. Hand-rolling any of these (typically with `find`/`rfind`/`slice` on `/` or `\\`) is wrong on Windows or in edge cases.
 
 ## Pick the right tool first
 
@@ -24,9 +33,12 @@ Fixed order of preference. If the row on the left fits, the row on the right is 
 | Get the filename without extension | `stem(p)` | basename + slice-off-extension |
 | Replace the extension | `replace_extension(p, ".new")` | string concat with stem |
 | Join two path components | `path_join(a, b)` | `"{a}/{b}"` string interp |
-| Resolve `..`, `.`, fix separators | `normalize(p)` | hand-rolled normalizer |
+| Resolve `..`, `.`, fix separators | `normalize(p)` (uses platform-preferred separator) | hand-rolled normalizer |
+| Force forward slashes regardless of host | `to_generic_path(p)` | `replace(p, "\\", "/")` |
 | Is this path absolute? | `is_absolute(p)` | check leading `/` or drive letter |
-| Compute a relative path | `relative(p, base, error)` or `relative_result(p, base)` | manual prefix strip |
+| Compute a relative path | `relative(p, base, error)` or `relative_result(p, base)` | manual prefix strip with `find`/`slice` |
+| Expand a single glob into a sorted file list | `expand_glob(pattern, var result)` | manual `dir_rec` + `match_glob` walk |
+| Parse user `paths` arg (comma/newline list of files/dirs/globs) | `parse_file_list(file, var result)` | manual split + per-entry dispatch |
 | Check existence | `fexist(p)` | open-and-check |
 | Get file size / mtime / type | `stat(p) : FStat` (daslib overload) | platform `stat` syscall |
 | Walk a directory | `dir(p) $(name) { ... }` | platform `opendir` |
@@ -176,6 +188,8 @@ Fields: `capacity`, `free`, `available` (all `uint64`).
 
 - **Never split paths with `rfind("/")` and `rfind("\\")` followed by `slice`.** Always `base_name` / `dir_name` / `parent`. The manual form misses Windows backslashes, mishandles trailing separators, and returns the wrong slice when no separator is present.
 - **Never build paths with string interpolation.** `"{a}/{b}"` produces `"foo//bar"` if `a` has a trailing slash and breaks on Windows when one side uses backslashes. Use `path_join`.
+- **Never strip prefixes with `find(p, root) == 0` + `slice`.** Use `relative(p, root, err)` (or `relative_result`) — handles the trailing-separator case, refuses partial-component matches (`/foo/bar` vs `/foo/barx`), and produces correct `..`-relative paths when `p` is outside `root`. Pair with `to_generic_path` if the consumer needs forward slashes.
+- **`normalize` and `to_generic_path` are NOT the same.** `normalize` uses the platform-preferred separator (`\` on Windows). `to_generic_path` always emits `/`. Pick by what the consumer needs: shells/system calls want `normalize`, JSON/log output and stable test fixtures want `to_generic_path`.
 - `fread(file)` requires **binary mode** (`"rb"`). Text mode causes a partial-read error.
 - `fopen(path, mode, blk)` (3-arg block form) auto-closes on block exit; the 2-arg `FILE?` form needs explicit `fclose`. Prefer the 3-arg form unless you need the file handle to outlive the call.
 - `dir(path)` callback yields `.` and `..` on POSIX — skip them.
@@ -185,9 +199,11 @@ Fields: `capacity`, `free`, `available` (all `uint64`).
 
 ## Reference
 
-- [daslib/fio.das](daslib/fio.das) — daslang wrapper layer (RAII `fopen`, `_result` variants, `mkdir_rec`, `disk_space`, whole-file `fread`/`fwrite` by path)
-- [src/builtin/module_builtin_fio.cpp:1218-1457](src/builtin/module_builtin_fio.cpp#L1218-L1457) — C++ registrations
+- [daslib/fio.das](daslib/fio.das) — daslang wrapper layer (RAII `fopen`, `_result` variants, `mkdir_rec`, `disk_space`, whole-file `fread`/`fwrite` by path, glob bundle)
+- [src/builtin/module_builtin_fio.cpp:1218-1457](src/builtin/module_builtin_fio.cpp#L1218-L1457) — C++ registrations (the `fio_core` layer)
 - [include/daScript/simulate/aot_builtin_fio.h](include/daScript/simulate/aot_builtin_fio.h) — `FStat`, `DiskSpaceInfo` structs
 - [doc/source/stdlib/handmade/module-fio.rst](doc/source/stdlib/handmade/module-fio.rst) — auto-generated module reference
 - [tests/fio/fio_utils.das](tests/fio/fio_utils.das) — read/write by path, recursive `rmdir`, `_result` variants
+- [tests/fio/glob_test.das](tests/fio/glob_test.das) and [tests/fio/expand_glob_test.das](tests/fio/expand_glob_test.das) — glob primitives + expander/parser tests
 - [tutorials/dasAudio/02_playing_files.das](tutorials/dasAudio/02_playing_files.das) — `fopen` + `fmap` for binary data
+- [skills/glob.md](skills/glob.md) — pathname glob matching, when to use `match_glob` vs `glob_match`, full `expand_glob` / `parse_file_list` cookbook

--- a/skills/glob.md
+++ b/skills/glob.md
@@ -23,6 +23,8 @@ def glob_filtered(root : string; includes, excludes : array<string>;
                   blk : block<(filename : string; is_dir : bool) : void>)
 def is_glob_pattern(pattern : string) : bool
 def to_generic_path(s : string) : string
+def expand_glob(pattern : string; var result : array<string>)
+def parse_file_list(file : string; var result : array<string>)
 ```
 
 - `match_glob` — pure path-string match, no filesystem access. Both pattern and path use `/`.
@@ -30,6 +32,8 @@ def to_generic_path(s : string) : string
 - `glob_filtered` — multi-pattern walk. An entry is yielded if it matches ≥1 include and 0 excludes. **Excludes win** on conflict. Callback receives `/`-normalized paths.
 - `is_glob_pattern` — true if the string contains `*`, `?`, or `[`. Detects character classes that the inline `find(s, "*") >= 0 || find(s, "?") >= 0` check misses.
 - `to_generic_path` — convert a path to use forward slashes regardless of host. Use when feeding `dir_rec` output (native separator) into `match_glob` directly, or anywhere else you need stable `/`-separated paths. **Not** the same as `fio.normalize`, which uses the platform-preferred separator (`\` on Windows).
+- `expand_glob` — turn a single glob pattern (e.g. `src/**/*.das`) into a sorted list of matching file paths. Splits the literal directory prefix from the glob remainder, picks recursive (`glob`) vs shallow (`dir`) walk based on whether the remainder contains `**` or `/`, normalizes input via `to_generic_path` (so backslash patterns work), filters out directories, sorts the matches locally, and **appends** to `result`. The local sort + append is deliberate: it preserves the order of any plain entries pushed to `result` before the glob.
+- `parse_file_list` — parse a comma- or newline-separated list of files / dirs / globs into a flat list of paths. Strips whitespace, skips empty entries, dispatches each entry through `is_glob_pattern`: literal entries pass through, glob entries go through `expand_glob`. Also **appends** to `result`. The canonical "user-supplied paths argument → expanded file list" expander used by every MCP tool with a `paths` / `file` argument; reach for it from any new CLI tool that takes file/glob input.
 
 ## Idioms
 
@@ -78,25 +82,19 @@ Excludes win — a file matching both an include and an exclude is dropped.
 
 ### Order preservation across plain + glob mixed input
 
-When expanding a comma- or newline-separated list of paths-or-patterns, sort each glob expansion **locally** and append to the result, instead of sorting the whole result at the end. This preserves the user's intended order across plain entries:
+`parse_file_list` and `expand_glob` already implement the right pattern: each glob expansion sorts **locally** and appends, so plain entries the user listed in a specific order stay where they were. Don't reach for a global `sort(result)` at the end of a mixed-input parse — it would scramble the user's intended order.
 
 ```das
-def expand_one(part : string; var result : array<string>) {
-    if (is_glob_pattern(part)) {
-        var matches : array<string>
-        glob(".", part) $(filename, is_dir) {
-            if (!is_dir) { matches |> push_clone(filename) }
-        }
-        sort(matches)                                  // local sort only
-        result |> reserve(length(result) + length(matches))
-        for (m in matches) { result |> push_clone(m) }
-    } else {
-        result |> push_clone(part)
-    }
-}
+require daslib/fio
+
+var files : array<string>
+parse_file_list("zzz.das,assets/**/*.png,aaa.das", files)
+// files[0] == "zzz.das" — first plain stays first
+// files[length(files) - 1] == "aaa.das" — last plain stays last
+// the glob's matches sit between them, sorted within their slice
 ```
 
-Globally re-sorting `result` at the end would scramble plain entries the user listed in a specific order. See the regression test in `utils/mcp/test_tools.das` ("expand_glob preserves prior entries").
+If you're rolling your own expansion (don't, unless `parse_file_list` doesn't fit), the same pattern: per-glob `sort()` + `append`, never a final global sort. See the regression test in [tests/fio/expand_glob_test.das](tests/fio/expand_glob_test.das) (`test_parse_file_list_order_preserved`).
 
 ## Performance and correctness gotchas
 

--- a/skills/strings.md
+++ b/skills/strings.md
@@ -1,0 +1,183 @@
+# Strings in daslang
+
+Read this skill before writing or editing `.das` code that searches, splits, replaces, parses, formats, or otherwise manipulates strings — anywhere you'd reach for `find`, `replace`, `split`, `to_int`, `build_string`, or `peek_data` / `modify_data`.
+
+## Modules
+
+```das
+require strings                  // core: most ops live here
+require daslib/strings_boost     // extras: split, contains, count, join, levenshtein, pad, replace_multiple
+require daslib/strings_convert   // safe parsing: try_to_int / try_to_float (Result-returning)
+```
+
+`strings` is the always-on built-in — `find`, `replace`, `slice`, `length`, `to_int`, `build_string`, `format`, `peek_data`/`modify_data`, the `is_*` char predicates, etc. `strings_boost` is the daslang-side companion (multi-result `split`, `contains`, `count`, generic `join`, `pad_left`/`pad_right`, `levenshtein_distance`, `replace_multiple`, `glob_match`, `is_null_or_whitespace`). `strings_convert` is the validating-parse layer.
+
+## Don't iterate bytes when a built-in does it
+
+The single most common antipattern in this codebase is opening `peek_data` and writing a `for (i in range(length(arr)))` loop to do something that `find` / `replace` / `starts_with` / `split` already does. Reach for byte-level access **only** when the operation is genuinely not expressible as a built-in (state machines, custom parsers, multi-byte transforms with cross-byte context).
+
+| If you want to | Use | Don't |
+|---|---|---|
+| Find a char or substring | `find(s, '*')` / `find(s, "foo")` (returns -1 on miss) | byte loop with `c == uint8('*')` |
+| Find from the right | `rfind(s, '/')` / `rfind(s, "ab")` | reverse byte loop |
+| "Does it contain X" | `contains(s, "foo")` (boost) or `find(s, "foo") >= 0` | byte loop |
+| "Does it start/end with X" | `starts_with(s, "foo")` / `ends_with(s, ".das")` | `slice(s, 0, n) == "foo"` |
+| Replace all `a` with `b` | `replace(s, "a", "b")` | `modify_data` byte loop |
+| Replace many pairs in one pass | `replace_multiple(s, [("a","x"), ("b","y")])` (boost) | nested `replace` calls |
+| "Is every char X" | `empty(replace(s, "X", ""))` | byte loop accumulating a flag |
+| Count occurrences | `count(s, "foo")` (boost) | byte loop |
+| Split on a separator | `split(s, ",")` (boost) → `array<string>` | manual `find` + `slice` loop |
+| Split on any of several chars | `split_by_chars(s, " \t\n")` (boost) | byte loop with branching |
+| Trim whitespace | `trim(s)` / `strip(s)`, or `ltrim`/`rtrim`/`strip_left`/`strip_right` | manual leading/trailing scan |
+| Strip a known prefix/suffix | `trim_prefix(s, "foo/")` / `trim_suffix(s, ".das")` (boost) | `starts_with` + `slice` |
+| Uppercase / lowercase | `to_upper(s)` / `to_lower(s)` (allocate); `_in_place` variants mutate in place | manual case-fold loop |
+| Pad to width | `pad_left(s, w, ' ')` / `pad_right(s, w, ' ')` (boost) | manual `repeat` + concat |
+| Repeat a unit | `repeat(unit, n)` | concat loop |
+| Reverse | `reverse(s)` | byte loop |
+| Case-insensitive compare | `compare_ignore_case(a, b) == 0` | `to_lower(a) == to_lower(b)` (allocates twice) |
+
+The refactor that motivated this skill (commits in fio.das around `is_glob_pattern`, `to_generic_path`, the empty-path branch of `match_glob`) collapsed three byte-level loops into one-liners using `find`, `replace`, and `empty(replace(s, "*", ""))`. If you're staring at a `peek_data` block that only reads bytes, ask "does `find` or `replace` already do this?" first.
+
+## Parsing numbers — validate at boundaries
+
+Two families of parse functions, picked by what the caller does on garbage input:
+
+```das
+require strings
+require daslib/strings_convert
+
+let n = to_int(s)              // silent — returns 0 for "foo", 12 for "12abc"
+let r = try_to_int(s)          // Result<int; ConversionError>
+if (r is value) {
+    use(r as value)
+} else {
+    bail("bad input: {s} ({r as error})")
+}
+```
+
+- **`to_int(s)` / `to_float(s)`** silently return `0` / `0.0` for unparseable input and partial-parse for `"12abc"`. Fine for trusted internal data; **never** for user input, env vars, file contents, command-line args, or anything that flows into a shell call, file path, or system call. `";rm -rf;"` parses as `0` with `to_int`.
+- **`try_to_int` / `try_to_float`** in `daslib/strings_convert` return a `Result<T; ConversionError>` distinguishing `invalid_argument` (no digits), `out_of_range` (overflow), and `trailing_garbage` (`"12abc"`). The whole `try_to_*` family covers `int8`/`uint8`/.../`int64`/`uint64`/`float`/`double`.
+- The 3-arg `int(s, var conv_result, var consumed, accept_hex)` builtins also surface a `ConversionResult` enum if you want the boundary check without pulling in `strings_convert`.
+
+When in doubt: **use `try_to_*` at the input boundary, plain `to_*` once the value is known to be clean.**
+
+## Building strings
+
+For multi-piece output, prefer `build_string` over chain concatenation. The writer does one allocation pass; concat in a loop reallocates on every append.
+
+```das
+let result = build_string() $(var writer) {
+    writer |> write("prefix=")
+    writer |> write(name)
+    for (x in items) {
+        writer |> write(", ")
+        writer |> write(x)
+    }
+}
+```
+
+- `build_string() $(var writer) { ... }` — returns the assembled string. The block receives a `StringBuilderWriter`.
+- `build_hash() $(var writer) { ... }` — same pattern, returns `uint64` hash of what would have been written. Useful for cache keys without allocating the string.
+- `writer |> write(any)` — generic write; calls the appropriate per-type formatter.
+- `writer |> write_char(c)` — single int-as-char.
+- `writer |> write_chars(c, n)` — repeat one char n times.
+- `writer |> write_escape_string(s)` — write with escape sequences applied (use for emitting JSON-like literals).
+- `writer |> fmt(spec, val)` / `writer |> format(spec, val)` — printf-style formatting for one numeric value. `fmt` takes the per-type overloads (int8…double); `format` is the int/uint/int64/uint64/float/double set.
+- **String interpolation** `"{x} {y}"` is sugar for `build_string` — fine for one-off small constructions, but inside a loop or for long pipelines, write the explicit `build_string` so the writer is reused.
+
+`perf_lint` flags some bad patterns here (PERF002 string concat in loops, PERF005 unnecessary `string(das_string)` casts) — see `skills/perf_lint.md`.
+
+If the result must outlive the calling block (returned, stored), `build_string` requires `unsafe(...)` or `options persistent_heap`. Most call sites use `unsafe(build_string()) $(var writer) { ... }`.
+
+## Char-level access — `peek_data` and `modify_data`
+
+When you genuinely need byte-level scanning that isn't a built-in (custom lexer, byte-by-byte hex dump, in-place transforms with cross-byte state):
+
+```das
+peek_data(s) $(arr) {              // arr : array<uint8> const#
+    for (c in arr) {                // loop var is the byte value (or const ref for arrays of structs)
+        if (is_white_space(int(c))) { ... }
+    }
+}
+
+let out = modify_data(s) $(var arr) {   // arr : array<uint8>#  — mutating block returns a new string
+    for (c in arr) {                     // here c is a mutable element reference
+        if (c == uint8('\\')) { c = uint8('/') }
+    }
+}
+```
+
+- **`peek_data(s) $(arr)`** — single `strlen` + bounds check up front, then O(1) per-byte read. Use for hot loops over string contents.
+- **`modify_data(s) $(var arr)`** — opens a mutable byte view, returns a new string with the modifications. Allocates one new string.
+- **`character_at(s, i)`** — O(n) per call (it re-walks `strlen` and bounds-checks). Fine for one-off character tests; never use inside a loop. CLAUDE.md's "Don't iterate via `character_at`" rule lives here.
+- **Empty-string caveat**: `peek_data("")` does NOT invoke its block. Any function that processes an external pattern/path through `peek_data` must handle empty-input explicitly at the top. `fio.match_glob` does this; copy the pattern.
+- **Loop-var mutation in `modify_data`**: `for (c in arr) { c = uint8('/') }` works because `arr` is `array<uint8>` and the loop variable is a mutable element reference. No need for `for (i in range(length(arr)))` + `arr[i] = ...` unless you actually need the index.
+- **Pointer-based access** (`reinterpret<uint8?>(s)`) is for the core library implementation only — user code and daslib should always go through `peek_data` / `modify_data`.
+
+## Joining
+
+`join` (boost) handles three shapes:
+
+```das
+let csv = join(["a", "b", "c"], ", ")              // simple string-array
+let line = join(it, " ")                            // any iterable
+let formatted = join(items, ", ") $(var w, elem) {  // custom per-element formatter
+    w |> write(elem.name); w |> write("=")
+    w |> write(elem.value)
+}
+```
+
+The block form composes with `build_string` internally, so it's the right tool when you'd otherwise write a manual `for` + `if (skip_first) ... else writer |> write(sep)` loop.
+
+## Comparison and predicates
+
+- **`==` and `!=`** between `string` and `string`, between `string` and `das_string`, work directly. Don't write `string(das_str) == "foo"` — drop the cast.
+- **`compare_ignore_case(a, b)`** — `< 0` / `0` / `> 0`, like `strcmp`.
+- **`is_null_or_whitespace(s)`** (boost) — `s == ""` or every char is whitespace.
+- **`is_alpha`/`is_alnum`/`is_hex`/`is_number`/`is_white_space`/`is_tab_or_space`/`is_new_line`** — all take an `int` (the int-as-char form). When using with `peek_data`, write `is_white_space(int(c))`.
+- **`set_total` / `set_element` / `is_char_in_set`** — bitset over the 256-byte alphabet. Compile-time-buildable char sets; faster than `find(charset, c) >= 0` for hot loops.
+
+## Escape and unescape
+
+- **`escape(s)`** — produces a string literal ready for embedding (quotes added, control chars escaped).
+- **`unescape(s)`** — inverse; panics on bad escape sequence.
+- **`safe_unescape(s)`** — same, returns `""` on bad input instead of panicking. Use at boundaries.
+
+## Levenshtein
+
+```das
+let d = levenshtein_distance(a, b)         // exact
+let d = levenshtein_distance_fast(a, b)    // bit-parallel; same result for short strings
+```
+
+Use for "did you mean" suggestions. The `_fast` variant is meaningfully faster for short strings; both have identical semantics.
+
+## Glob matching
+
+`daslib/strings_boost` exports `glob_match(pattern, text)` — single-pattern shell-style match, **no `**` and no `/` boundary**. For path-aware globbing (`**`, `/`-segment boundaries, character classes, recursive walk + match), use `daslib/fio`'s `match_glob` / `glob` / `glob_filtered` instead. Full guidance: **`skills/glob.md`**.
+
+## Common gotchas
+
+- **`replace(s, "*", "")` is a fast "is every char X" probe** — collapses to a one-line `empty(replace(s, ch, ""))`. Beats hand-rolled byte loops.
+- **`find(s, '*')` accepts a char (int) directly** — no need to wrap as `"*"`. Same for `rfind`. Mixing the int and string overloads is fine.
+- **`find` returns `int`, not `int?`** — `< 0` means not found, **never** compare `find(...) == false`.
+- **`split` (boost) returns `array<string>`** — non-copyable, so move-receive: `let parts <- split(s, ",")`. The `split_by_chars` block-form generic is the no-allocation choice when you only need to iterate.
+- **`replace_multiple` (boost) does ONE pass** — replacements don't see each other's output. `replace_multiple(s, [("a","b"),("b","a")])` swaps `a`↔`b`; nested `replace` calls would not.
+- **`to_lower` / `to_upper` allocate**; `to_lower_in_place` / `to_upper_in_place` mutate the input string buffer (still O(n), but no extra alloc). Pick by whether you still need the original.
+- **`character_at(s, i)` is O(n)**, not O(1). The compiler does not memoize. CLAUDE.md flags this; perf_lint may catch it (PERF003).
+- **String comparison with `das_string`** works directly — `if (das_str == "foo")`, `if (empty(das_str))`. Don't write `string(das_str)`.
+- **Hex literals are `uint`** — `int(0x3F)` for int. Same for `to_int("0x3F", true)` (the `accept_hex` bool).
+- **`int(s)` / `float(s)` are the silent parsers** — same caveat as `to_int`/`to_float`. Always use `try_to_*` from `strings_convert` for external input.
+- **`peek_data("")` does not call the block.** Empty-input checks go at the top of any wrapping function.
+- **String-builder result must escape unsafe gates if it outlives the block** — `unsafe(build_string()) $(...) { ... }` or `options persistent_heap` is the standard pattern when returning a built string.
+- **Never compare `find(s, sub) == false`** — `find` returns an `int` (offset or `-1`), not a bool. `find >= 0` for "found".
+
+## Cross-references
+
+- `skills/glob.md` — pathname matching with `*`, `?`, `**`, `[abc]` (`fio.match_glob`, `glob`, `glob_filtered`).
+- `skills/regex.md` — when you need full regex (lookarounds, named groups, repetition counts) instead of `find`/`split`.
+- `skills/perf_lint.md` — PERF002 (concat in loops), PERF003 (`character_at` in loops), PERF005 (`string(das_string)`), PERF010 (`get_ptr` on string).
+- `skills/style_lint.md` — STYLE-rules around string-builder pipe form, redundant casts.
+- `skills/json.md` — `sprint_json` / `sscan_json` / `JV` / `from_JV` — never hand-build JSON via string concat.
+- `daslib/strings_boost.das` — source for the boost layer.
+- `daslib/strings_convert.das` — source for `try_to_*`.

--- a/tests/fio/expand_glob_test.das
+++ b/tests/fio/expand_glob_test.das
@@ -1,0 +1,337 @@
+options gen2
+
+require dastest/testing_boost
+require daslib/fio
+require strings
+
+def make_fixture_tree(t : T?; root : string) {
+    mkdir_rec("{root}/sub")
+    mkdir_rec("{root}/sub/deep")
+    mkdir_rec("{root}/empty_subdir")
+    mkdir_rec("{root}/other")
+    t |> success(fwrite("{root}/foo.das", "// foo\n"))
+    t |> success(fwrite("{root}/bar.das", "// bar\n"))
+    t |> success(fwrite("{root}/baz.txt", "baz"))
+    t |> success(fwrite("{root}/sub/inner.das", "// inner\n"))
+    t |> success(fwrite("{root}/sub/deep/deeper.das", "// deeper\n"))
+    t |> success(fwrite("{root}/other/o1.das", "// o1\n"))
+}
+
+def cleanup_tree(root : string) {
+    var error : string
+    rmdir_rec(root, error)
+}
+
+def has_path(files : array<string>; suffix : string) : bool {
+    for (f in files) {
+        if (find(f, suffix) >= 0) {
+            return true
+        }
+    }
+    return false
+}
+
+[test]
+def test_parse_file_list_single_plain(t : T?) {
+    t |> run("single plain file passes through unchanged") @(t : T?) {
+        var files : array<string>
+        parse_file_list("path/to/file.das", files)
+        t |> equal(length(files), 1)
+        t |> equal(files[0], "path/to/file.das")
+    }
+}
+
+[test]
+def test_parse_file_list_single_glob(t : T?) {
+    let tmp = create_temp_directory_result("expand_glob_single_")
+    if (!(tmp is value)) {
+        t |> failure("could not create temp directory: {tmp as error}")
+        return
+    }
+    let root = tmp as value
+    make_fixture_tree(t, root)
+    t |> run("single glob expands to matches") @(t : T?) {
+        var files : array<string>
+        parse_file_list("{root}/*.das", files)
+        t |> success(length(files) >= 2, "at least foo.das and bar.das")
+        t |> success(has_path(files, "foo.das"), "foo.das matched")
+        t |> success(has_path(files, "bar.das"), "bar.das matched")
+    }
+    cleanup_tree(root)
+}
+
+[test]
+def test_parse_file_list_comma_plain(t : T?) {
+    t |> run("comma list of plain files") @(t : T?) {
+        var files : array<string>
+        parse_file_list("a.das,b.das,c.das", files)
+        t |> equal(length(files), 3)
+        t |> equal(files[0], "a.das")
+        t |> equal(files[1], "b.das")
+        t |> equal(files[2], "c.das")
+    }
+}
+
+[test]
+def test_parse_file_list_comma_globs(t : T?) {
+    let tmp = create_temp_directory_result("expand_glob_comma_")
+    if (!(tmp is value)) {
+        t |> failure("could not create temp directory: {tmp as error}")
+        return
+    }
+    let root = tmp as value
+    make_fixture_tree(t, root)
+    t |> run("comma list of globs (issue #2498 repro)") @(t : T?) {
+        var files : array<string>
+        parse_file_list("{root}/*.das,{root}/other/*.das", files)
+        t |> success(has_path(files, "foo.das"), "first glob expanded")
+        t |> success(has_path(files, "o1.das"), "second glob expanded")
+    }
+    cleanup_tree(root)
+}
+
+[test]
+def test_parse_file_list_mixed(t : T?) {
+    let tmp = create_temp_directory_result("expand_glob_mixed_")
+    if (!(tmp is value)) {
+        t |> failure("could not create temp directory: {tmp as error}")
+        return
+    }
+    let root = tmp as value
+    make_fixture_tree(t, root)
+    t |> run("mixed plain + glob") @(t : T?) {
+        var files : array<string>
+        parse_file_list("literal.das,{root}/foo.das,{root}/sub/*.das", files)
+        t |> success(has_path(files, "literal.das"), "plain entry preserved")
+        t |> success(has_path(files, "foo.das"), "explicit file resolved")
+        t |> success(has_path(files, "inner.das"), "glob expanded")
+    }
+    cleanup_tree(root)
+}
+
+[test]
+def test_parse_file_list_newline(t : T?) {
+    t |> run("newline-delimited") @(t : T?) {
+        var files : array<string>
+        parse_file_list("a.das\nb.das\nc.das", files)
+        t |> equal(length(files), 3)
+        t |> equal(files[0], "a.das")
+        t |> equal(files[1], "b.das")
+        t |> equal(files[2], "c.das")
+    }
+}
+
+[test]
+def test_parse_file_list_whitespace(t : T?) {
+    t |> run("mixed comma + newline + whitespace") @(t : T?) {
+        var files : array<string>
+        parse_file_list("  a.das , b.das \n c.das ", files)
+        t |> equal(length(files), 3)
+        t |> equal(files[0], "a.das")
+        t |> equal(files[2], "c.das")
+    }
+    t |> run("single fast-path strips whitespace") @(t : T?) {
+        var files : array<string>
+        parse_file_list("  a.das  ", files)
+        t |> equal(length(files), 1)
+        t |> equal(files[0], "a.das")
+    }
+}
+
+[test]
+def test_parse_file_list_empty_parts(t : T?) {
+    t |> run("empty parts skipped") @(t : T?) {
+        var files : array<string>
+        parse_file_list("a.das,,\n,b.das", files)
+        t |> equal(length(files), 2, "2 non-empty files")
+    }
+    t |> run("single fast-path skips empty/whitespace-only") @(t : T?) {
+        var files : array<string>
+        parse_file_list("   ", files)
+        t |> equal(length(files), 0)
+    }
+}
+
+[test]
+def test_parse_file_list_order_preserved(t : T?) {
+    let tmp = create_temp_directory_result("expand_glob_order_")
+    if (!(tmp is value)) {
+        t |> failure("could not create temp directory: {tmp as error}")
+        return
+    }
+    let root = tmp as value
+    make_fixture_tree(t, root)
+    t |> run("expand_glob preserves prior entries (no global re-sort)") @(t : T?) {
+        // Regression Copilot caught: expand_glob's sort() once scrambled
+        // entries pushed before it. Order must hold across (plain, glob, plain).
+        var files : array<string>
+        parse_file_list("zzz.das,{root}/*.das,aaa.das", files)
+        t |> equal(files[0], "zzz.das", "first plain stays first")
+        t |> equal(files[length(files) - 1], "aaa.das", "last plain stays last")
+    }
+    cleanup_tree(root)
+}
+
+[test]
+def test_expand_glob_recursive(t : T?) {
+    let tmp = create_temp_directory_result("expand_glob_recursive_")
+    if (!(tmp is value)) {
+        t |> failure("could not create temp directory: {tmp as error}")
+        return
+    }
+    let root = tmp as value
+    make_fixture_tree(t, root)
+    t |> run("** in middle of pattern walks from literal prefix") @(t : T?) {
+        // Pattern with `**` must walk from the literal prefix, not from a
+        // literal `**` directory that does not exist.
+        var files : array<string>
+        parse_file_list("{root}/**/inner.das", files)
+        t |> success(has_path(files, "inner.das"))
+    }
+    cleanup_tree(root)
+}
+
+[test]
+def test_expand_glob_shallow(t : T?) {
+    let tmp = create_temp_directory_result("expand_glob_shallow_")
+    if (!(tmp is value)) {
+        t |> failure("could not create temp directory: {tmp as error}")
+        return
+    }
+    let root = tmp as value
+    make_fixture_tree(t, root)
+    t |> run("shallow pattern does not descend into subdirectories") @(t : T?) {
+        // Patterns without `**` use the non-recursive walker. `{root}/*.das`
+        // must NOT pick up files under `{root}/sub/` or `{root}/other/`.
+        var files : array<string>
+        parse_file_list("{root}/*.das", files)
+        for (f in files) {
+            t |> success(find(f, "/sub/") < 0, "shallow * did not descend into sub/")
+            t |> success(find(f, "/other/") < 0, "shallow * did not descend into other/")
+        }
+    }
+    cleanup_tree(root)
+}
+
+[test]
+def test_expand_glob_multi_segment(t : T?) {
+    let tmp = create_temp_directory_result("expand_glob_multiseg_")
+    if (!(tmp is value)) {
+        t |> failure("could not create temp directory: {tmp as error}")
+        return
+    }
+    let root = tmp as value
+    make_fixture_tree(t, root)
+    t |> run("multi-segment pattern without ** still recurses") @(t : T?) {
+        // A pattern like `{root}/*/inner.das` has no `**` but it crosses
+        // a `/`, so the recursive walk must be used.
+        var files : array<string>
+        parse_file_list("{root}/*/inner.das", files)
+        t |> success(has_path(files, "inner.das"),
+            "multi-segment pattern matched sub/inner.das")
+    }
+    cleanup_tree(root)
+}
+
+[test]
+def test_expand_glob_backslash(t : T?) {
+    let tmp = create_temp_directory_result("expand_glob_backslash_")
+    if (!(tmp is value)) {
+        t |> failure("could not create temp directory: {tmp as error}")
+        return
+    }
+    let root = tmp as value
+    make_fixture_tree(t, root)
+    t |> run("backslash-style pattern matches the same as forward-slash") @(t : T?) {
+        // The pattern is normalized to `/` inside expand_glob, so backslash
+        // patterns produce the same result as POSIX `/` patterns. Build the
+        // backslash pattern by replacing `/` with `\` in the same input.
+        let fwd = "{root}/sub/*.das"
+        let back = replace(fwd, "/", "\\")
+        var slash : array<string>
+        var bs : array<string>
+        parse_file_list(fwd, slash)
+        parse_file_list(back, bs)
+        sort(slash)
+        sort(bs)
+        t |> equal(length(slash), length(bs), "same number of matches")
+        for (i in range(length(slash))) {
+            t |> equal(slash[i], bs[i], "entry {i} matches")
+        }
+    }
+    cleanup_tree(root)
+}
+
+[test]
+def test_expand_glob_absolute(t : T?) {
+    let tmp = create_temp_directory_result("expand_glob_abs_")
+    if (!(tmp is value)) {
+        t |> failure("could not create temp directory: {tmp as error}")
+        return
+    }
+    let root = tmp as value
+    make_fixture_tree(t, root)
+    t |> run("absolute path patterns walk the root, not cwd") @(t : T?) {
+        // _split_literal_prefix keeps the separator in dir_part when the
+        // pattern starts at the filesystem root, so glob walks the right
+        // place rather than an empty path.
+        var files : array<string>
+        parse_file_list("{root}/*.das", files)
+        t |> success(length(files) > 0, "absolute pattern matched at least one file")
+        t |> success(has_path(files, "foo.das"), "foo.das present")
+    }
+    t |> run("absolute root prefix produces clean paths (no double slash)") @(t : T?) {
+        // When dir_part ends with `/` (POSIX root or Windows drive root),
+        // expand_glob must not insert another `/` when concatenating with
+        // the matched entry.
+        var files : array<string>
+        parse_file_list("{root}/*.das", files)
+        for (f in files) {
+            t |> success(find(f, "//") < 0, "no double slashes in '{f}'")
+        }
+    }
+    cleanup_tree(root)
+}
+
+[test]
+def test_expand_glob_charclass(t : T?) {
+    let tmp = create_temp_directory_result("expand_glob_charclass_")
+    if (!(tmp is value)) {
+        t |> failure("could not create temp directory: {tmp as error}")
+        return
+    }
+    let root = tmp as value
+    make_fixture_tree(t, root)
+    t |> run("character class triggers glob expansion") @(t : T?) {
+        // parse_file_list dispatches via fio.is_glob_pattern, which
+        // recognizes `[` (not just `*` / `?`).
+        var files : array<string>
+        parse_file_list("{root}/[fb]*.das", files)
+        t |> success(has_path(files, "foo.das"), "[fb]* matched foo.das")
+        t |> success(has_path(files, "bar.das"), "[fb]* matched bar.das")
+    }
+    cleanup_tree(root)
+}
+
+[test]
+def test_expand_glob_filters_dirs(t : T?) {
+    let tmp = create_temp_directory_result("expand_glob_dirs_")
+    if (!(tmp is value)) {
+        t |> failure("could not create temp directory: {tmp as error}")
+        return
+    }
+    let root = tmp as value
+    make_fixture_tree(t, root)
+    t |> run("shallow expand_glob filters out directories") @(t : T?) {
+        // The shallow `dir(...)` branch must stat each match and skip dirs
+        // — downstream tools (format/lint/compile_check) take regular files.
+        var files : array<string>
+        parse_file_list("{root}/*", files)
+        for (f in files) {
+            let st = stat(f)
+            t |> success(!(st.is_valid && st.is_dir),
+                "expand_glob must not emit directory '{f}'")
+        }
+    }
+    cleanup_tree(root)
+}

--- a/tutorials/language/54_glob.das
+++ b/tutorials/language/54_glob.das
@@ -5,6 +5,8 @@
 //   - glob: walk a directory tree and yield matching paths
 //   - glob_filtered: include + exclude patterns, excludes win
 //   - is_glob_pattern: detect literal vs glob to dispatch correctly
+//   - expand_glob: pattern -> sorted file list (the higher-level helper)
+//   - parse_file_list: comma/newline-separated list of files / dirs / globs
 //   - When to use fio.match_glob vs strings_boost.glob_match (the two flavors)
 //
 // Prerequisites: Tutorial 07 (Strings), Tutorial 13 (Blocks)
@@ -173,6 +175,42 @@ def main() {
     let generic = to_generic_path(mixed)
     print("  input  : {mixed}\n")
     print("  output : {generic}\n")
+
+    // ============================================================
+    // Section 7: expand_glob — pattern to sorted file list
+    // ============================================================
+    // `expand_glob(pattern, var result)` is the higher-level helper:
+    // it splits the literal directory prefix from the glob remainder,
+    // picks recursive vs shallow walk based on the pattern, filters out
+    // directories, sorts locally, and APPENDS to `result`. Reach for it
+    // whenever a CLI tool takes a single glob argument.
+
+    print("\n=== expand_glob ===\n")
+    var by_pattern : array<string>
+    expand_glob("{tmpdir}/**/*.das", by_pattern)
+    print("  expand_glob {tmpdir}/**/*.das (count={length(by_pattern)}):\n")
+    for (f in by_pattern) {
+        print("    {f}\n")
+    }
+
+    // ============================================================
+    // Section 8: parse_file_list — comma/newline list of files/dirs/globs
+    // ============================================================
+    // `parse_file_list(file, var result)` is the canonical
+    // "user-supplied paths argument -> expanded file list" expander.
+    // Comma- or newline-separated; whitespace stripped; literal entries
+    // pass through; glob entries go through `expand_glob`. Order is
+    // preserved across plain entries — globs sort within their slice.
+
+    print("\n=== parse_file_list ===\n")
+    var inputs : array<string>
+    let raw = "zzz_literal.das,{tmpdir}/src/*.das\n{tmpdir}/assets/**/*.png ,aaa_literal.das"
+    parse_file_list(raw, inputs)
+    print("  input: {raw}\n")
+    print("  parsed (count={length(inputs)}; plain entries keep position):\n")
+    for (f in inputs) {
+        print("    {f}\n")
+    }
 
     cleanup(tmpdir)
     print("\nDone.\n")

--- a/utils/daspkg/test_daspkg.das
+++ b/utils/daspkg/test_daspkg.das
@@ -17,6 +17,7 @@ require lockfile
 require utils
 require index
 require commands
+require daslib/result
 require package_runner public
 
 [test]
@@ -91,69 +92,69 @@ def test_is_index_name(t : T?) {
 [test]
 def test_parse_args(t : T?) {
     t |> run("install command") @(t : T?) {
-        let r <- parse_args(type<DaspkgArgs>, ["install", "dasImgui"])
+        var r <- parse_args(type<DaspkgArgs>, ["install", "dasImgui"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> equal(parsed.command ?? "", "install")
         t |> equal(parsed.command_arg ?? "", "dasImgui")
         t |> success(!parsed.force)
     }
     t |> run("install with force") @(t : T?) {
-        let r <- parse_args(type<DaspkgArgs>, ["install", "dasImgui", "--force"])
+        var r <- parse_args(type<DaspkgArgs>, ["install", "dasImgui", "--force"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> equal(parsed.command ?? "", "install")
         t |> equal(parsed.command_arg ?? "", "dasImgui")
         t |> success(parsed.force)
     }
     t |> run("install with root") @(t : T?) {
-        let r <- parse_args(type<DaspkgArgs>, ["--root", "/tmp/proj", "install", "foo"])
+        var r <- parse_args(type<DaspkgArgs>, ["--root", "/tmp/proj", "install", "foo"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> equal(parsed.command ?? "", "install")
         t |> equal(parsed.command_arg ?? "", "foo")
         t |> equal(parsed.root, "/tmp/proj")
     }
     t |> run("list command no arg") @(t : T?) {
-        let r <- parse_args(type<DaspkgArgs>, ["list"])
+        var r <- parse_args(type<DaspkgArgs>, ["list"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> equal(parsed.command ?? "", "list")
         t |> success(parsed.command_arg |> is_none)
     }
     t |> run("no command") @(t : T?) {
         let empty_args : array<string>
-        let r <- parse_args(type<DaspkgArgs>, empty_args)
+        var r <- parse_args(type<DaspkgArgs>, empty_args)
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> success(parsed.command |> is_none)
     }
     t |> run("cleanup command") @(t : T?) {
-        let r <- parse_args(type<DaspkgArgs>, ["cleanup"])
+        var r <- parse_args(type<DaspkgArgs>, ["cleanup"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> equal(parsed.command ?? "", "cleanup")
         t |> success(!parsed.force)
     }
     t |> run("cleanup with force") @(t : T?) {
-        let r <- parse_args(type<DaspkgArgs>, ["cleanup", "--force"])
+        var r <- parse_args(type<DaspkgArgs>, ["cleanup", "--force"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> equal(parsed.command ?? "", "cleanup")
         t |> success(parsed.force)
     }
     t |> run("cleanup with global and force") @(t : T?) {
-        let r <- parse_args(type<DaspkgArgs>, ["cleanup", "--global", "--force"])
+        var r <- parse_args(type<DaspkgArgs>, ["cleanup", "--global", "--force"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> equal(parsed.command ?? "", "cleanup")
         t |> success(parsed.force)
         t |> success(parsed.global_flag)
     }
     t |> run("default root is dot") @(t : T?) {
-        let r <- parse_args(type<DaspkgArgs>, ["list"])
+        var r <- parse_args(type<DaspkgArgs>, ["list"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> equal(parsed.root, ".")
     }
 }
@@ -1314,9 +1315,9 @@ def test_ansi_colors(t : T?) {
 def test_parse_args_color_flags(t : T?) {
     t |> run("--color sets use_tty_colors") @(t : T?) {
         use_tty_colors = false
-        let r <- parse_args(type<DaspkgArgs>, ["list", "--color"])
+        var r <- parse_args(type<DaspkgArgs>, ["list", "--color"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> success(parsed.color, "color flag parsed")
         apply_global_flags(parsed)
         t |> success(use_tty_colors)
@@ -1324,9 +1325,9 @@ def test_parse_args_color_flags(t : T?) {
     }
     t |> run("--no-color clears use_tty_colors") @(t : T?) {
         use_tty_colors = true
-        let r <- parse_args(type<DaspkgArgs>, ["list", "--no-color"])
+        var r <- parse_args(type<DaspkgArgs>, ["list", "--no-color"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> success(parsed.no_color, "no_color flag parsed")
         apply_global_flags(parsed)
         t |> success(!use_tty_colors)
@@ -1360,24 +1361,24 @@ def test_read_manifest_rich(t : T?) {
 [test]
 def test_parse_args_global_flag(t : T?) {
     t |> run("--global flag parsed") @(t : T?) {
-        let r <- parse_args(type<DaspkgArgs>, ["install", "foo", "--global"])
+        var r <- parse_args(type<DaspkgArgs>, ["install", "foo", "--global"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> equal(parsed.command ?? "", "install")
         t |> equal(parsed.command_arg ?? "", "foo")
         t |> success(parsed.global_flag)
     }
     t |> run("-g shorthand") @(t : T?) {
-        let r <- parse_args(type<DaspkgArgs>, ["-g", "list"])
+        var r <- parse_args(type<DaspkgArgs>, ["-g", "list"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> equal(parsed.command ?? "", "list")
         t |> success(parsed.global_flag)
     }
     t |> run("default global is false") @(t : T?) {
-        let r <- parse_args(type<DaspkgArgs>, ["install", "foo"])
+        var r <- parse_args(type<DaspkgArgs>, ["install", "foo"])
         t |> success(r |> is_ok, "parse succeeds")
-        var parsed <- r |> move_unwrap
+        let parsed <- r |> move_unwrap
         t |> success(!parsed.global_flag)
     }
 }

--- a/utils/mcp/README.md
+++ b/utils/mcp/README.md
@@ -113,7 +113,7 @@ Claude Code starts and stops the server automatically with each session.
 - **Exception:** `live_*` tools run on the main thread (they use `system()` and `sleep()` which don't work well from `new_thread`)
 - Protocol logic lives in `protocol.das`, the entry point is `main.das`
 - Heap is collected after each request when over threshold (1 MB)
-- Tool handlers are modular: each tool lives in `tools/*.das`, shared utilities in `tools/common.das`
+- Tool handlers are modular: each tool lives in `tools/*.das`, MCP-specific shared utilities in `tools/common.das`. The general "comma/newline list of files / globs → file array" expander (`expand_glob`, `parse_file_list`) lives in `daslib/fio`
 
 ## Configuring Claude Code
 

--- a/utils/mcp/ROADMAP.md
+++ b/utils/mcp/ROADMAP.md
@@ -31,7 +31,7 @@ Future tools for the daslang MCP server, organized by priority and difficulty.
 
 - **`.das_project` support** — all file-based tools accept an optional `project` parameter pointing to a `.das_project` file for custom module resolution and sandboxing
 - **Request logging** — file-based logging with timestamps for debugging
-- **Unified file utilities** — shared `resolve_path()`, `make_relative_path()`, `expand_glob()`, `parse_file_list()` in `tools/common.das` used by `compile_check` and `grep_usage`. Glob patterns support `!pattern` exclusion (gitignore-style)
+- **Unified file utilities** — `resolve_path()` and `make_relative_path()` live in `tools/common.das`; `expand_glob()` and `parse_file_list()` were promoted to `daslib/fio` so any CLI tool can use them, not just MCP. Glob patterns: `*` / `?` / `**` / `[abc]` / `[!abc]`. (`!pattern` gitignore-style exclusion is not implemented; use `glob_filtered` with explicit excludes)
 
 ### Cursor-based tools implementation notes
 

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -152,7 +152,13 @@ def test_compile_check_glob_no_match(t : T?) {
     }
 }
 
-// ── parse_file_list ──────────────────────────────────────────────────
+// ── parse_file_list (smoke) ──────────────────────────────────────────
+// Canonical unit tests for `parse_file_list` and `expand_glob` live in
+// `tests/fio/expand_glob_test.das` (the helpers moved to `daslib/fio`).
+// Tools-side coverage of comma-list / glob / mixed inputs continues
+// further down via `do_format_file` / `do_compile_check` / `do_lint`
+// integration tests. This single subtest only confirms that the helper
+// is reachable through the MCP `require` chain after the move.
 
 def has_path(files : array<string>; suffix : string) : bool {
     for (f in files) {
@@ -164,184 +170,12 @@ def has_path(files : array<string>; suffix : string) : bool {
 }
 
 [test]
-def test_parse_file_list(t : T?) {
-    t |> run("single plain file") <| @(t : T?) {
+def test_parse_file_list_smoke(t : T?) {
+    t |> run("parse_file_list reachable through MCP require chain") <| @(t : T?) {
         var files : array<string>
-        parse_file_list("utils/mcp/tests/_fixture_valid.das", files)
-        t |> equal(length(files), 1, "1 file")
-        t |> equal(files[0], "utils/mcp/tests/_fixture_valid.das", "passes through")
-    }
-    t |> run("single glob expands") <| @(t : T?) {
-        var files : array<string>
-        parse_file_list("utils/mcp/tests/_fixture_v*.das", files)
-        t |> success(length(files) >= 1, "at least one match")
-        t |> success(has_path(files, "_fixture_valid.das"), "valid fixture matched")
-    }
-    t |> run("comma list of plain files") <| @(t : T?) {
-        var files : array<string>
-        parse_file_list("a.das,b.das,c.das", files)
-        t |> equal(length(files), 3, "3 files")
-        t |> equal(files[0], "a.das", "first")
-        t |> equal(files[1], "b.das", "second")
-        t |> equal(files[2], "c.das", "third")
-    }
-    t |> run("comma list of globs (issue #2498 repro)") <| @(t : T?) {
-        var files : array<string>
-        parse_file_list("utils/detect-dupe/*.das,utils/mcp/tests/*.das", files)
-        t |> success(has_path(files, "utils/detect-dupe/"), "detect-dupe glob expanded")
-        t |> success(has_path(files, "utils/mcp/tests/"), "mcp/tests glob expanded")
-    }
-    t |> run("mixed plain + glob") <| @(t : T?) {
-        var files : array<string>
-        parse_file_list("utils/mcp/tests/_fixture_valid.das,utils/mcp/tests/_fixture_e*.das", files)
-        t |> success(has_path(files, "_fixture_valid.das"), "plain file present")
+        parse_file_list("{fixture_path("_fixture_valid.das")},utils/mcp/tests/_fixture_e*.das", files)
+        t |> success(has_path(files, "_fixture_valid.das"), "plain entry preserved")
         t |> success(has_path(files, "_fixture_error.das"), "glob expanded")
-    }
-    t |> run("newline-delimited") <| @(t : T?) {
-        var files : array<string>
-        parse_file_list("a.das\nb.das\nc.das", files)
-        t |> equal(length(files), 3, "3 files")
-        t |> equal(files[0], "a.das", "first")
-        t |> equal(files[1], "b.das", "second")
-        t |> equal(files[2], "c.das", "third")
-    }
-    t |> run("mixed comma + newline + whitespace") <| @(t : T?) {
-        var files : array<string>
-        parse_file_list("  a.das , b.das \n c.das ", files)
-        t |> equal(length(files), 3, "3 files (whitespace stripped)")
-        t |> equal(files[0], "a.das", "first stripped")
-        t |> equal(files[2], "c.das", "third stripped")
-    }
-    t |> run("empty parts skipped") <| @(t : T?) {
-        var files : array<string>
-        parse_file_list("a.das,,\n,b.das", files)
-        t |> equal(length(files), 2, "2 non-empty files")
-    }
-    t |> run("single fast-path strips whitespace") <| @(t : T?) {
-        var files : array<string>
-        parse_file_list("  a.das  ", files)
-        t |> equal(length(files), 1, "1 file")
-        t |> equal(files[0], "a.das", "stripped")
-    }
-    t |> run("single fast-path skips empty/whitespace-only") <| @(t : T?) {
-        var files : array<string>
-        parse_file_list("   ", files)
-        t |> equal(length(files), 0, "no files for whitespace-only input")
-    }
-    t |> run("expand_glob preserves prior entries (no global re-sort)") <| @(t : T?) {
-        // Repro for the regression Copilot caught: expand_glob's sort()
-        // used to scramble entries pushed before it. Order must be
-        // preserved across (plain, glob, plain) sequences.
-        var files : array<string>
-        parse_file_list("zzz.das,utils/mcp/tests/_fixture_v*.das,aaa.das", files)
-        t |> equal(files[0], "zzz.das", "first plain stays first")
-        t |> equal(files[length(files) - 1], "aaa.das", "last plain stays last")
-    }
-    t |> run("recursive ** in middle of pattern") <| @(t : T?) {
-        // PR #2576 follow-up: split at the last `/` before the first glob meta
-        // so `utils/mcp/**/test_tools.das` walks from `utils/mcp/`, not from
-        // a literal `**` directory that does not exist.
-        var files : array<string>
-        parse_file_list("utils/mcp/**/test_tools.das", files)
-        t |> success(has_path(files, "test_tools.das"), "** matched test_tools.das somewhere under utils/mcp/")
-    }
-    t |> run("shallow pattern does not descend into subdirectories") <| @(t : T?) {
-        // PR #2576 follow-up: patterns without `**` use the non-recursive
-        // walker. `utils/mcp/*.das` must NOT pick up files under
-        // `utils/mcp/tools/` or `utils/mcp/tests/`.
-        var files : array<string>
-        parse_file_list("utils/mcp/*.das", files)
-        for (f in files) {
-            t |> success(find(f, "utils/mcp/tools/") < 0, "shallow * did not descend into tools/")
-            t |> success(find(f, "utils/mcp/tests/") < 0, "shallow * did not descend into tests/")
-        }
-    }
-    t |> run("multi-segment pattern without ** still recurses") <| @(t : T?) {
-        // PR #2576 round-2: a pattern like `utils/mcp/*/common.das` has no
-        // `**` but it crosses a `/`, so the recursive walk must be used —
-        // otherwise it can never match `utils/mcp/tools/common.das`.
-        var files : array<string>
-        parse_file_list("utils/mcp/*/common.das", files)
-        t |> success(has_path(files, "tools/common.das"), "multi-segment pattern matched tools/common.das")
-    }
-    t |> run("backslash-style pattern matches the same as forward-slash") <| @(t : T?) {
-        // PR #2576 round-3: the pattern is normalized to `/` at the top of
-        // expand_glob, so Windows-style `\` patterns produce the same
-        // result as POSIX `/` patterns.
-        var slash : array<string>
-        var back : array<string>
-        parse_file_list("utils/mcp/*/common.das", slash)
-        parse_file_list("utils\\mcp\\*\\common.das", back)
-        sort(slash)
-        sort(back)
-        t |> equal(length(slash), length(back), "same number of matches")
-        for (i in range(length(slash))) {
-            t |> equal(slash[i], back[i], "entry {i} matches")
-        }
-    }
-    t |> run("absolute path patterns walk the root, not cwd") <| @(t : T?) {
-        // PR #2576 round-3: `_split_literal_prefix` keeps the separator in
-        // `dir_part` when the pattern starts at the filesystem root, so
-        // `glob` walks the right place rather than an empty path.
-        let abs = "{get_das_root()}/utils/mcp/tools/*.das"
-        var files : array<string>
-        parse_file_list(abs, files)
-        t |> success(length(files) > 0, "absolute pattern matched at least one file")
-        t |> success(has_path(files, "common.das"), "common.das present")
-    }
-    t |> run("absolute root prefix produces clean paths (no double slash)") <| @(t : T?) {
-        // PR #2576 round-4: when `_split_literal_prefix` returns a dir_part
-        // that ends with `/` (POSIX root or Windows drive root), expand_glob
-        // must not insert another `/` when concatenating with the matched
-        // entry. Use a real temp dir — fully portable across hosts.
-        let tmp = create_temp_directory_result("expand_glob_doubleslash_")
-        if (!(tmp is value)) {
-            t |> failure("could not create temp directory: {tmp as error}")
-            return
-        }
-        let abs_root = tmp as value
-        fwrite("{abs_root}/marker.das", "")
-        var files : array<string>
-        parse_file_list("{abs_root}/*.das", files)
-        for (f in files) {
-            t |> success(find(f, "//") < 0, "no double slashes in '{f}'")
-        }
-        var rm_err : string
-        rmdir_rec(abs_root, rm_err)
-    }
-    t |> run("character class triggers glob expansion") <| @(t : T?) {
-        // Round-5 regression: parse_file_list previously detected globs by
-        // looking for `*` / `?` only. A pattern like `_fixture_[ev]*.das`
-        // would be treated as a literal path and dropped. Now dispatch goes
-        // through fio.is_glob_pattern, which also recognizes `[`.
-        var files : array<string>
-        parse_file_list("utils/mcp/tests/_fixture_[ev]*.das", files)
-        var saw_valid = false
-        var saw_error = false
-        for (f in files) {
-            if (find(f, "_fixture_valid.das") >= 0) {
-                saw_valid = true
-            }
-            if (find(f, "_fixture_error.das") >= 0) {
-                saw_error = true
-            }
-        }
-        t |> success(saw_valid, "char class glob picks _fixture_valid.das")
-        t |> success(saw_error, "char class glob picks _fixture_error.das")
-    }
-    t |> run("shallow expand_glob filters out directories") <| @(t : T?) {
-        // Round-6 regression: the shallow `dir(...)` branch did not filter
-        // directories, so `parse_file_list("utils/mcp/*")` emitted entries
-        // like `utils/mcp/tools` (a subdirectory) alongside actual files.
-        // Downstream tools (format/lint/compile_check) take regular files
-        // only. After the fix, expand_glob stats each match and skips dirs.
-        var files : array<string>
-        parse_file_list("utils/mcp/*", files)
-        for (f in files) {
-            let st = stat(f)
-            t |> success(!(st.is_valid && st.is_dir),
-                "expand_glob must not emit directory '{f}'")
-        }
     }
 }
 

--- a/utils/mcp/tools/common.das
+++ b/utils/mcp/tools/common.das
@@ -312,6 +312,12 @@ def resolve_path(path : string) : string {
     if (is_absolute(path)) {
         return path
     }
+    // Preserve Windows drive-relative paths (`C:foo`). std::filesystem
+    // doesn't classify them as absolute (no trailing separator), so they'd
+    // otherwise be joined under das_root and produce an invalid path.
+    if (find(path, ":") == 1) {
+        return path
+    }
     return path_join(get_das_root(), path)
 }
 

--- a/utils/mcp/tools/common.das
+++ b/utils/mcp/tools/common.das
@@ -300,7 +300,7 @@ def run_and_capture(args : array<string>; var output : string&; timeout_sec : fl
 
 // Returns a unique temp .das file path that won't collide with concurrent processes.
 def make_temp_das_file() : string {
-    return "{get_das_root()}/_mcp_stub_{ref_time_ticks()}.das"
+    return path_join(get_das_root(), "_mcp_stub_{ref_time_ticks()}.das")
 }
 
 // ── File path utilities ──────────────────────────────────────────────
@@ -309,157 +309,14 @@ def resolve_path(path : string) : string {
     if (empty(path)) {
         return get_das_root()
     }
-    if (length(path) > 0 && first_character(path) != '/' && find(path, ":") < 0) {
-        return "{get_das_root()}/{path}"
+    if (is_absolute(path)) {
+        return path
     }
-    return path
+    return path_join(get_das_root(), path)
 }
 
 def make_relative_path(path, root : string) : string {
-    var result = path
-    if (find(result, root) == 0) {
-        result = slice(result, length(root) + 1)
-    }
-    return replace(result, "\\", "/")
-}
-
-// Expand a glob pattern (e.g. "utils/mcp/tools/*.das") into a list of file paths.
-// The literal directory prefix (everything before the first glob metacharacter)
-// becomes the walk root; the rest stays as a pathname-glob pattern matched
-// against entries via `fio.match_glob` / `fio.glob`. So `**/*.das` walks from
-// `.`, `src/**/test*.das` walks from `src`, `utils/mcp/*.das` walks one level
-// under `utils/mcp`. Single-segment patterns (no `/`, `\`, or `**`) take a
-// shallow non-recursive walk; multi-segment or `**` patterns recurse.
-//
-// The input pattern is normalized to forward slashes via `to_generic_path`,
-// so Windows-style backslash patterns (`src\sub\*.das`) work the same as
-// the POSIX form. `glob`/`match_glob` see only `/`-form paths.
-def expand_glob(pattern : string; var result : array<string>) {
-    let normalized_pattern = to_generic_path(pattern)
-    let split = _split_literal_prefix(normalized_pattern)
-    let dir_part = split._0
-    let file_pattern = split._1
-    // Pattern is already `/`-normalized (see normalize above), so no
-    // need to also check for `\` here.
-    let recursive = (find(file_pattern, "**") >= 0
-                     || find(file_pattern, "/") >= 0)
-    var matches : array<string>
-    if (recursive) {
-        glob(dir_part, file_pattern) $(fname, is_dir) {
-            if (is_dir) {
-                return
-            }
-            matches |> push(_join_path(dir_part, fname))
-        }
-    } else {
-        // Single-segment shallow pattern: walk only the immediate directory.
-        // `dir(...)` yields names without an `is_dir` flag, so stat each match
-        // and skip directories — caller tools (format/lint/compile_check) take
-        // file paths only and produce confusing errors on a directory entry.
-        dir(dir_part) $(fname) {
-            if (fname == "." || fname == "..") {
-                return
-            }
-            if (match_glob(file_pattern, fname)) {
-                let full = _join_path(dir_part, fname)
-                let st = stat(full)
-                if (st.is_valid && st.is_dir) {
-                    return
-                }
-                matches |> push(full)
-            }
-        }
-    }
-    sort(matches)
-    result |> reserve(length(result) + length(matches))
-    for (m in matches) {
-        result |> push(m)
-    }
-}
-
-// Join `dir_part` and `fname` with `/`, but skip the inserted separator
-// when `dir_part` is `.` (just yield `fname`) or already ends with `/` or
-// `\` (filesystem root, drive root) so callers don't end up with paths
-// like `//etc/x` or `C://x`.
-def private _join_path(dir_part : string; fname : string) : string {
-    if (dir_part == ".") {
-        return fname
-    }
-    if (dir_part |> ends_with("/") || dir_part |> ends_with("\\")) {
-        return "{dir_part}{fname}"
-    }
-    return "{dir_part}/{fname}"
-}
-
-// Split a pattern into (literal_dir, glob_remainder) at the last separator
-// before the first glob metacharacter. A pattern with no metacharacters is
-// split at its last separator (legacy behavior used by literal-pass-through
-// callers). The returned dir_part is "." when no separator precedes the meta.
-def private _split_literal_prefix(pattern : string) : tuple<string; string> {
-    var first_meta = -1
-    peek_data(pattern) $(arr) {
-        for (i in range(length(arr))) {
-            let c = arr[i]
-            if (c == uint8('*') || c == uint8('?') || c == uint8('[')) {
-                first_meta = i
-                break
-            }
-        }
-    }
-    let scan_end = first_meta < 0 ? length(pattern) : first_meta
-    var sep = -1
-    peek_data(pattern) $(arr) {
-        for (i in range(scan_end)) {
-            if (arr[i] == uint8('/') || arr[i] == uint8('\\')) {
-                sep = i
-            }
-        }
-    }
-    if (sep < 0) {
-        return "." => pattern
-    }
-    let raw_dir = slice(pattern, 0, sep)
-    let raw_sep = slice(pattern, sep, sep + 1)
-    let remainder = slice(pattern, sep + 1)
-    // POSIX absolute root: pattern starts with `/` (or `\`). Empty prefix
-    // would tell `glob`/`dir` to walk an empty path; keep the separator.
-    if (empty(raw_dir)) {
-        return raw_sep => remainder
-    }
-    // Windows drive root like `C:` (or `C:/foo` after normalization with
-    // sep at index 2). Without the trailing separator `dir_rec` interprets
-    // `C:` as "current directory on drive C", not the drive root.
-    if (length(raw_dir) == 2 && raw_dir |> ends_with(":")) {
-        return "{raw_dir}{raw_sep}" => remainder
-    }
-    return raw_dir => remainder
-}
-
-// Parse file argument: comma- or newline-separated list of files, dirs, and
-// globs. Any part containing glob metacharacters (`*` / `?` / `[`) is expanded
-// via expand_glob; otherwise it's pushed as a literal path.
-def parse_file_list(file : string; var result : array<string>) {
-    if (find(file, ",") < 0 && find(file, "\n") < 0) {
-        let part = strip(file)
-        if (empty(part)) {
-            return
-        }
-        if (is_glob_pattern(part)) {
-            expand_glob(part, result)
-        } else {
-            result |> push(part)
-        }
-        return
-    }
-    for (raw in split_by_chars(file, ",\n")) {
-        let part = strip(raw)
-        if (empty(part)) {
-            continue
-        }
-        if (is_glob_pattern(part)) {
-            expand_glob(part, result)
-        } else {
-            result |> push(part)
-        }
-    }
+    var err : string
+    let rel = relative(path, root, err)
+    return to_generic_path(empty(rel) ? path : rel)
 }

--- a/utils/migrate-tables/test.das
+++ b/utils/migrate-tables/test.das
@@ -1,4 +1,9 @@
 options gen2
+// This file is a FIXTURE for the migrate-tables rewriter — it intentionally
+// contains the pre-migration `tab[k].insert(k2, tab[k].get_value(k2) ± expr)`
+// patterns that the tool detects and rewrites. The table-collision lint
+// (40216) flags exactly those patterns, so disable lint here.
+options lint = false
 require daslib/safe_addr
 
 struct GameState {


### PR DESCRIPTION
## Summary

- **Promote `expand_glob` and `parse_file_list` from `utils/mcp/tools/common.das` into `daslib/fio`** so any CLI tool can use them, not just the MCP server. Closes #2498 (globs inside comma-separated lists are now expanded instead of silently dropped).
- **Refactor `utils/mcp/tools/common.das`** to lean on existing fio helpers (`is_absolute`, `path_join`, `relative`, `to_generic_path`) instead of hand-rolled `find` + `slice` for `resolve_path` / `make_relative_path` / `make_temp_das_file`.
- **Collapse three peek_data/modify_data byte-loops in `daslib/fio.das`** to `find`/`replace` one-liners (`match_glob` empty-path branch, `to_generic_path`, `is_glob_pattern`).
- **Add `skills/strings.md`** — strings + `daslib/strings_boost` + `daslib/strings_convert` cheat sheet, with the don't-iterate-bytes cookbook (find / replace / starts_with / split) as the centerpiece. Linked from CLAUDE.md.
- **Bundled fix:** `examples/daspkg/packages/daspkg-example-c/CMakeLists.txt` — replaces the hand-rolled `if(WIN32)/else` libDaScriptDyn lookup with `find_library`. The old non-Windows branch hard-coded `libDaScriptDyn.so`, but the actual artifact on macOS is `liblibDaScriptDyn.dylib`, which broke 3 tests in `utils/daspkg/test_daspkg_git.das` on macOS.

## What's new in `daslib/fio`

```das
require daslib/fio

var das_files : array<string>
expand_glob("src/**/*.das", das_files)
// das_files is sorted; only contains regular files; previously-existing
// entries in das_files keep their position because the sort is local.

var inputs : array<string>
parse_file_list("README.md,daslib/*.das,tests/fio/*.das", inputs)
// inputs preserves the order of plain entries; globs sort within their slice.
```

`expand_glob` splits the literal directory prefix from the glob remainder, picks recursive (`glob`) vs shallow (`dir`) walk based on whether the remainder contains `**` or `/`, normalizes input via `to_generic_path` (so backslash patterns work), filters out directories, sorts the matches locally, and **appends** to `result`.

`parse_file_list` strips whitespace, skips empty entries, dispatches each entry through `is_glob_pattern`: literals pass through, globs go through `expand_glob`. The canonical "user-supplied paths argument → expanded file list" expander.

## Test coverage

`tests/fio/expand_glob_test.das` — 35 cases against isolated tmpdir fixtures:
- single plain file passes through, single glob expands
- comma list of plain files, comma list of globs (#2498 repro), mixed plain+glob
- newline delimited, mixed comma + newline + whitespace, empty parts skipped
- order preservation across mixed plain+glob (Copilot regression caught earlier)
- shallow doesn't descend, multi-segment without `**` still recurses
- `**` in middle of pattern walks from literal prefix
- backslash patterns match the same as forward-slash
- absolute paths walk root, no double-slash artifacts
- character class triggers glob expansion
- shallow `expand_glob` filters out directories

The previous in-MCP coverage shrinks to a smoke test that confirms the helper is reachable through the require chain. **All 7,816 tests in `tests/` pass; 202/202 MCP tests pass; 70/70 `test_daspkg_git.das` pass on macOS** (was 67/70 before the CMakeLists fix).

## Docs / skills

- `doc/source/reference/tutorials/54_glob.rst` — new `expand_glob` / `parse_file_list` section, summary table converted to a list-table to fit the new signatures
- `doc/source/reference/utils/detect_dupe.rst` — points to `parse_file_list` as the canonical comma/newline expander
- `doc/source/stdlib/handmade/module-fio.rst` — adds a `disk_space` worked example
- `doc/reflections/das2rst.das` — registers the new functions in the "Glob and pattern matching" group
- `tutorials/language/54_glob.das` — runnable mirror of the new RST section
- `skills/filesystem.md` — `fio_core` vs `daslib/fio` layering breakdown; two pitfalls (`relative` vs hand-rolled prefix strip; `normalize` vs `to_generic_path`); new helpers in the "pick the right tool" table
- `skills/glob.md` — swap hand-rolled `expand_one` cookbook for a `parse_file_list` example, point at the new regression test
- **`skills/strings.md` (new)** + `CLAUDE.md` link — string-ops cookbook for any `.das` author

Sphinx HTML build is clean (zero warnings).

## Test plan

- [x] `mcp__daslang__format_file` on all changed `.das` — already formatted
- [x] `mcp__daslang__lint` on all changed `.das` — 0 issues
- [x] `mcp__daslang__detect_duplicates` on changed daslib + utils — only pre-existing fuzzy hits in unchanged `*_result` wrappers; no real concerns introduced
- [x] `dastest -- --test tests/` — 7,816/7,822 pass, 0 fail, 0 error, 6 skipped (master parity)
- [x] `dastest -- --test tests/fio/` — 163/163
- [x] `dastest -- --test utils/mcp/test_tools.das` — 202/202
- [x] `dastest -- --test utils/daspkg/test_daspkg_git.das` — 70/70 (macOS, was 67/70 before CMakeLists fix)
- [x] Local Sphinx HTML build — `build succeeded`, zero warnings/errors
- [ ] CI matrix — Linux/Windows/Mac Release/Debug, sanitizers, AOT, extended-checks, docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)