### PR TITLE
daslang -exe: 3-tier shared-module resolution (exe_dir → das_root → absolute)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1227,6 +1227,10 @@ get_target_property(DAS_FMT_LIBS das-fmt LINK_LIBRARIES)
     # Owns ALL C++-test-related CMake. enable_testing() lives at the top of this file.
     add_subdirectory(tests-cpp)
 
+    # Standalone-exe module-resolution integration test (uses daslang -exe at
+    # test time + dasModuleSQLITE; both must already be defined as targets).
+    add_subdirectory(tests/exe-paths)
+
     # Build daslang utilities as standalone executables (-exe mode)
     add_subdirectory(utils)
 

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -515,22 +515,27 @@ def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVM
     for (mod_name in keys(extern_resolver.extern_modules)) {
         used_modules[mod_name] = true
     }
-    // Finalize initialize_modules(): emit dynamic modules, native paths, Module::Initialize, ret
+    // Finalize initialize_modules(): emit dynamic modules, native paths, Module::Initialize, ret.
+    // Use the same 3-tier resolve helper as inject_main so a standalone exe doesn't
+    // double-register the same module from two different filesystem paths (the
+    // resolved bundle path here AND a baked absolute somewhere else).
     let ib = extern_resolver.init_builder
     let t = extern_resolver.types
     let reg_dyn_mod_type = LLVMFunctionType(t.LLVMVoidPtrType(),
-        fixed_array<LLVMTypeRef>(t.LLVMVoidPtrType(), t.LLVMVoidPtrType())
+        fixed_array<LLVMTypeRef>(t.LLVMVoidPtrType(), t.LLVMVoidPtrType(), t.LLVMVoidPtrType())
     )
-    var jit_reg_dyn_mod = LLVMGetNamedFunction(g_mod, "jit_register_dynamic_module")
+    var jit_reg_dyn_mod = LLVMGetNamedFunction(g_mod, "jit_register_dynamic_module_resolve")
     if (jit_reg_dyn_mod == null) {
-        jit_reg_dyn_mod = LLVMAddFunctionWithType(g_mod, "jit_register_dynamic_module", reg_dyn_mod_type)
+        jit_reg_dyn_mod = LLVMAddFunctionWithType(g_mod, "jit_register_dynamic_module_resolve", reg_dyn_mod_type)
     }
     for_each_registered_dynamic_module() <| $(path, mod_name, das_name) {
         if (key_exists(used_modules, das_name)) {
             to_log(LOG_INFO, "LLVM EXE: include dynamic module: `{das_name}`\n")
-            let path_str = get_string_constant_ptr(ib, path)
+            let rel = compute_modules_relative_suffix(path)
+            let rel_str = get_string_constant_ptr(ib, rel)
+            let abs_str = get_string_constant_ptr(ib, path)
             let name_str = get_string_constant_ptr(ib, mod_name)
-            LLVMBuildCall2(ib, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(path_str, name_str), "")
+            LLVMBuildCall2(ib, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(rel_str, abs_str, name_str), "")
         }
     }
     let reg_native_path_type = LLVMFunctionType(t.t_void,
@@ -557,6 +562,14 @@ def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVM
     extern_resolver.types = null
     unsafe { delete extern_resolver; }
     return (any_unimplemented = any_unimp, needs_whole_lib = whole_lib)
+}
+
+// Suffix from the last "modules/" segment onwards; "" → caller falls back to abs path.
+// to_generic_path normalizes Windows backslashes so the search needs only one form.
+def private compute_modules_relative_suffix(p : string) : string {
+    let pn = to_generic_path(p)
+    let idx = rfind(pn, "/modules/")
+    return idx < 0 ? "" : slice(pn, idx + 1)
 }
 
 // Creates main function that initializes a standalone JIT context, registers
@@ -658,21 +671,27 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
         }
     }
 
-    // Register dynamic modules that were loaded during compilation
+    // Register dynamic modules that were loaded during compilation. The runtime
+    // helper tries <exe_dir>/<rel_path> (daspkg release bundles), then
+    // <das_root>/<rel_path> (SDK install / local dev), then the baked absolute
+    // path (legacy fallback).
     let reg_dyn_mod_type = LLVMFunctionType(types.LLVMVoidPtrType(),
         fixed_array<LLVMTypeRef>(
-            types.LLVMVoidPtrType(), // const char * path
+            types.LLVMVoidPtrType(), // const char * rel_path
+            types.LLVMVoidPtrType(), // const char * fallback_abs_path
             types.LLVMVoidPtrType()  // const char * mod_name
         )
     )
-    var jit_reg_dyn_mod = LLVMAddFunctionWithType(g_mod, "jit_register_dynamic_module", reg_dyn_mod_type)
+    var jit_reg_dyn_mod = LLVMAddFunctionWithType(g_mod, "jit_register_dynamic_module_resolve", reg_dyn_mod_type)
     for_each_registered_dynamic_module() <| $(path, mod_name, das_name) {
         if (key_exists(used_modules, das_name)) {
             has_cpp_modules = true
             to_log(LOG_INFO, "LLVM EXE: include dynamic module: `{das_name}`\n")
-            let path_str = get_string_constant_ptr(builder, path)
+            let rel = compute_modules_relative_suffix(path)
+            let rel_str = get_string_constant_ptr(builder, rel)
+            let abs_str = get_string_constant_ptr(builder, path)
             let name_str = get_string_constant_ptr(builder, mod_name)
-            LLVMBuildCall2(builder, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(path_str, name_str), "")
+            LLVMBuildCall2(builder, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(rel_str, abs_str, name_str), "")
         }
     }
 

--- a/skills/filesystem.md
+++ b/skills/filesystem.md
@@ -37,6 +37,7 @@ Fixed order of preference. If the row on the left fits, the row on the right is 
 | Force forward slashes regardless of host | `to_generic_path(p)` | `replace(p, "\\", "/")` |
 | Is this path absolute? | `is_absolute(p)` | check leading `/` or drive letter |
 | Compute a relative path | `relative(p, base, error)` or `relative_result(p, base)` | manual prefix strip with `find`/`slice` |
+| Find a known component anywhere in a path (e.g. `/modules/...`) | `to_generic_path(p)` then `find`/`rfind("/<name>/")` on the result | scanning for both `/<name>/` AND `\<name>\` |
 | Expand a single glob into a sorted file list | `expand_glob(pattern, var result)` | manual `dir_rec` + `match_glob` walk |
 | Parse user `paths` arg (comma/newline list of files/dirs/globs) | `parse_file_list(file, var result)` | manual split + per-entry dispatch |
 | Check existence | `fexist(p)` | open-and-check |
@@ -186,7 +187,7 @@ Fields: `capacity`, `free`, `available` (all `uint64`).
 
 ## Common gotchas
 
-- **Never split paths with `rfind("/")` and `rfind("\\")` followed by `slice`.** Always `base_name` / `dir_name` / `parent`. The manual form misses Windows backslashes, mishandles trailing separators, and returns the wrong slice when no separator is present.
+- **Never split paths with `rfind("/")` and `rfind("\\")` followed by `slice`.** Always `base_name` / `dir_name` / `parent`. The manual form misses Windows backslashes, mishandles trailing separators, and returns the wrong slice when no separator is present. Exception: when the substring you're searching for is a **named component** (e.g. `/modules/`, `/.git/`), normalize once via `to_generic_path(p)` and search for forward slashes only: `rfind(to_generic_path(p), "/modules/")`. The normalize step is what makes the rule "search for `/` only" safe; never search for both `/X/` and `\X\` separately.
 - **Never build paths with string interpolation.** `"{a}/{b}"` produces `"foo//bar"` if `a` has a trailing slash and breaks on Windows when one side uses backslashes. Use `path_join`.
 - **Never strip prefixes with `find(p, root) == 0` + `slice`.** Use `relative(p, root, err)` (or `relative_result`) — handles the trailing-separator case, refuses partial-component matches (`/foo/bar` vs `/foo/barx`), and produces correct `..`-relative paths when `p` is outside `root`. Pair with `to_generic_path` if the consumer needs forward slashes.
 - **`normalize` and `to_generic_path` are NOT the same.** `normalize` uses the platform-preferred separator (`\` on Windows). `to_generic_path` always emits `/`. Pick by what the consumer needs: shells/system calls want `normalize`, JSON/log output and stable test fixtures want `to_generic_path`.

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -33,11 +33,13 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
+#include <filesystem>
 
 namespace das {
     // forward declarations from module_builtin_fio.cpp
     void * register_dynamic_module(const char *, const char *, int, Context *, LineInfoArg *);
     void register_native_path(const char *, const char *, const char *, Context *, LineInfoArg *);
+    bool builtin_fexist ( const char * path );
 
     typedef vec4f ( * JitFunction ) ( Context * , vec4f *, void * );
 
@@ -1041,6 +1043,105 @@ DAS_API void jit_initialize_modules_done () {
 
 DAS_API void * jit_register_dynamic_module ( const char * path, const char * mod_name ) {
     return das::register_dynamic_module(path, mod_name, 0/*Quiet*/, nullptr, nullptr);
+}
+
+// Test seam: unit tests override the exe-path source so resolution can be
+// exercised with synthetic layouts. nullptr = use real getExecutableFileName.
+// Returned char* must remain valid for the duration of one resolve call.
+static const char * (*g_jit_exe_file_for_test)() = nullptr;
+DAS_API void jit_set_exe_file_for_test_( const char * (*fn)() ) {
+    g_jit_exe_file_for_test = fn;
+}
+
+// Test predicate "does this path exist?" (default: real filesystem). Tests
+// can swap in a mock predicate to exercise resolution without touching disk.
+static bool (*g_jit_path_exists_for_test)(const char *) = nullptr;
+DAS_API void jit_set_path_exists_for_test_( bool (*fn)(const char *) ) {
+    g_jit_path_exists_for_test = fn;
+}
+
+static bool jit_path_exists ( const char * p ) {
+    return g_jit_path_exists_for_test ? g_jit_path_exists_for_test(p) : das::builtin_fexist(p);
+}
+
+// Try a candidate dir / rel_path; if it (or its _debug variant in debug
+// builds, gated on DAS_NO_ASSERTIONS to match register_dynamic_module's
+// rewrite at module_builtin_fio.cpp:1099) exists, return the path to load.
+// Empty string = miss.
+//
+// Returns the non-_debug name even when the _debug variant is what exists —
+// register_dynamic_module applies the _debug rewrite itself in debug builds,
+// so we mustn't double-rewrite. std::filesystem::path::operator/ handles
+// trailing-separator and root cases correctly (POSIX `/` + `modules/X` →
+// `/modules/X`, not `//modules/X`).
+static das::string pick_at_dir ( const std::filesystem::path & dir, const char * rel_path ) {
+    namespace fs = std::filesystem;
+    if ( dir.empty() || !rel_path || !*rel_path ) return "";
+    fs::path candidate = dir / rel_path;
+    das::string candidate_str = candidate.string().c_str();
+    if ( jit_path_exists(candidate_str.c_str()) ) return candidate_str;
+#ifndef DAS_NO_ASSERTIONS
+    if ( candidate.extension() == ".shared_module" ) {
+        fs::path dbg = candidate.parent_path() / (candidate.stem().string() + "_debug" + candidate.extension().string());
+        if ( jit_path_exists(dbg.string().c_str()) ) return candidate_str;
+    }
+#endif
+    return "";
+}
+
+// Pure resolution: pick the path to load, in priority order:
+//   1. <exe_dir>/<rel_path>   — daspkg release bundle layout (modules sit next to the exe)
+//   2. <das_root>/<rel_path>  — SDK install layout AND local dev build
+//   3. <fallback_abs_path>    — baked-at-codegen absolute path (legacy / paths without /modules/ segment)
+//
+// Tiers 1+2 are skipped when rel_path is empty/null. Returns the chosen path;
+// tier 3 is unconditional, so the result is never empty when fallback is set.
+static das::string resolve_dynamic_module_path ( const char * rel_path, const char * fallback_abs_path ) {
+    namespace fs = std::filesystem;
+    // tier 1 — exe_dir (parent_path correctly preserves filesystem root: "/myapp" → "/", "C:\myapp.exe" → "C:\")
+    das::string exeFile;
+    if ( g_jit_exe_file_for_test ) {
+        const char * s = g_jit_exe_file_for_test();
+        if ( s ) exeFile = s;
+    } else {
+        exeFile = das::getExecutableFileName();
+    }
+    if ( !exeFile.empty() ) {
+        fs::path exeDir = fs::path(exeFile.c_str()).parent_path();
+        if ( exeDir.empty() ) exeDir = ".";  // exe is a bare filename relative to cwd
+        das::string p = pick_at_dir(exeDir, rel_path);
+        if ( !p.empty() ) return p;
+    }
+    // tier 2 — das_root
+    {
+        das::string p = pick_at_dir(fs::path(das::getDasRoot().c_str()), rel_path);
+        if ( !p.empty() ) return p;
+    }
+    // tier 3 — baked absolute (legacy fallback)
+    return fallback_abs_path ? fallback_abs_path : "";
+}
+
+// Test entry point: invoke pure resolution and return the chosen path via
+// caller-owned buffer. Returns true on success (buf populated, NUL-terminated),
+// false if buffer is too small. Unit tests use this to assert resolution order
+// without dlopening anything.
+DAS_API bool jit_resolve_dynamic_module_path_for_test_ ( const char * rel_path,
+                                                         const char * fallback_abs_path,
+                                                         char * out_buf,
+                                                         size_t buf_size ) {
+    das::string r = resolve_dynamic_module_path(rel_path, fallback_abs_path);
+    if ( r.size() + 1 > buf_size ) return false;
+    memcpy(out_buf, r.c_str(), r.size() + 1);
+    return true;
+}
+
+// Resolve and load a dynamic module. Used by standalone exes (emitted by
+// inject_main in llvm_exe.das).
+DAS_API void * jit_register_dynamic_module_resolve ( const char * rel_path,
+                                                     const char * fallback_abs_path,
+                                                     const char * mod_name ) {
+    das::string chosen = resolve_dynamic_module_path(rel_path, fallback_abs_path);
+    return das::register_dynamic_module(chosen.c_str(), mod_name, 0/*Quiet*/, nullptr, nullptr);
 }
 
 DAS_API void jit_register_native_path ( const char * mod_name, const char * src_path, const char * dst_path ) {

--- a/tests-cpp/small/test_jit_module_resolve.cpp
+++ b/tests-cpp/small/test_jit_module_resolve.cpp
@@ -1,0 +1,178 @@
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+#include "daScript/misc/sysos.h"
+
+#include <filesystem>
+#include <set>
+#include <string>
+
+// Test entry points exposed by src/builtin/module_jit.cpp.
+extern "C" {
+    DAS_API void jit_set_exe_file_for_test_( const char * (*fn)() );
+    DAS_API void jit_set_path_exists_for_test_( bool (*fn)(const char *) );
+    DAS_API bool jit_resolve_dynamic_module_path_for_test_(
+        const char * rel_path,
+        const char * fallback_abs_path,
+        char * out_buf,
+        size_t buf_size );
+}
+
+namespace {
+
+// Synthetic exe-file source for the resolve helper to read.
+static std::string g_exe_file;
+static const char * fake_exe_file() { return g_exe_file.c_str(); }
+
+// Synthetic existence predicate — succeeds for any path in the set, fails for
+// everything else. No real filesystem access.
+//
+// Both sides are normalized to forward-slash form via `generic_string()` so
+// the test is host-agnostic: on Windows the resolver builds candidates via
+// std::filesystem::path which emits backslashes, but the test inputs and
+// expectations all use forward slashes for readability.
+static std::set<std::string> g_existing;
+static bool fake_path_exists(const char * p) {
+    return g_existing.count(std::filesystem::path(p).generic_string()) != 0;
+}
+
+struct TestSeams {
+    TestSeams() {
+        g_exe_file.clear();
+        g_existing.clear();
+        jit_set_exe_file_for_test_(fake_exe_file);
+        jit_set_path_exists_for_test_(fake_path_exists);
+    }
+    ~TestSeams() {
+        jit_set_exe_file_for_test_(nullptr);
+        jit_set_path_exists_for_test_(nullptr);
+        // Leave das_root untouched — we don't override it; tests pick rel_paths
+        // that don't accidentally match getDasRoot()/<rel> on the dev machine
+        // by populating g_existing exclusively via fake_path_exists.
+    }
+};
+
+static std::string resolve(const char * rel, const char * abs) {
+    char buf[4096] = {0};
+    REQUIRE(jit_resolve_dynamic_module_path_for_test_(rel, abs, buf, sizeof(buf)));
+    // Normalize to forward-slash form so CHECK comparisons are host-agnostic.
+    return std::filesystem::path(buf).generic_string();
+}
+
+} // anon
+
+TEST_CASE("jit module resolve — exe-relative wins when present") {
+    TestSeams seams;
+    g_exe_file = "/bundle/myapp";
+    g_existing.insert("/bundle/modules/dasFoo/dasFoo.shared_module");
+    auto chosen = resolve("modules/dasFoo/dasFoo.shared_module",
+                          "/build/abs/modules/dasFoo/dasFoo.shared_module");
+    CHECK(chosen == "/bundle/modules/dasFoo/dasFoo.shared_module");
+}
+
+TEST_CASE("jit module resolve — falls back to das_root when exe-relative misses") {
+    TestSeams seams;
+    g_exe_file = "/somewhere/myapp";
+    // exe-relative does NOT exist; das_root path DOES (use the dev machine's
+    // real das_root so existence check passes against our fake predicate)
+    auto dasRoot = das::getDasRoot();
+    auto dasRootCandidate = dasRoot + "/modules/dasFoo/dasFoo.shared_module";
+    g_existing.insert(dasRootCandidate);
+    auto chosen = resolve("modules/dasFoo/dasFoo.shared_module",
+                          "/build/abs/modules/dasFoo/dasFoo.shared_module");
+    CHECK(chosen == dasRootCandidate);
+}
+
+TEST_CASE("jit module resolve — falls back to baked absolute when both miss") {
+    TestSeams seams;
+    g_exe_file = "/somewhere/myapp";
+    // No path exists anywhere
+    auto chosen = resolve("modules/dasFoo/dasFoo.shared_module",
+                          "/build/abs/modules/dasFoo/dasFoo.shared_module");
+    CHECK(chosen == "/build/abs/modules/dasFoo/dasFoo.shared_module");
+}
+
+TEST_CASE("jit module resolve — exe-relative wins over das_root when both exist") {
+    TestSeams seams;
+    g_exe_file = "/bundle/myapp";
+    g_existing.insert("/bundle/modules/dasFoo/dasFoo.shared_module");
+    auto dasRoot = das::getDasRoot();
+    g_existing.insert(dasRoot + "/modules/dasFoo/dasFoo.shared_module");
+    auto chosen = resolve("modules/dasFoo/dasFoo.shared_module",
+                          "/build/abs/modules/dasFoo/dasFoo.shared_module");
+    CHECK(chosen == "/bundle/modules/dasFoo/dasFoo.shared_module");
+}
+
+TEST_CASE("jit module resolve — empty rel_path skips tier 1+2 and uses absolute") {
+    TestSeams seams;
+    g_exe_file = "/bundle/myapp";
+    auto chosen = resolve("", "/baked/abs/path.shared_module");
+    CHECK(chosen == "/baked/abs/path.shared_module");
+}
+
+TEST_CASE("jit module resolve — empty exe_file still tries das_root") {
+    TestSeams seams;
+    g_exe_file = "";  // platform with no exe-file (fall through to tier 2)
+    auto dasRoot = das::getDasRoot();
+    auto dasRootCandidate = dasRoot + "/modules/dasFoo/dasFoo.shared_module";
+    g_existing.insert(dasRootCandidate);
+    auto chosen = resolve("modules/dasFoo/dasFoo.shared_module",
+                          "/build/abs/modules/dasFoo/dasFoo.shared_module");
+    CHECK(chosen == dasRootCandidate);
+}
+
+#ifndef DAS_NO_ASSERTIONS
+TEST_CASE("jit module resolve — picks rel_path even when only _debug variant exists (debug builds)") {
+    TestSeams seams;
+    g_exe_file = "/bundle/myapp";
+    // Only the _debug variant exists in the bundle. The helper should still
+    // return the non-_debug name (register_dynamic_module rewrites internally).
+    g_existing.insert("/bundle/modules/dasFoo/dasFoo_debug.shared_module");
+    auto chosen = resolve("modules/dasFoo/dasFoo.shared_module",
+                          "/build/abs/modules/dasFoo/dasFoo.shared_module");
+    CHECK(chosen == "/bundle/modules/dasFoo/dasFoo.shared_module");
+}
+#endif
+
+TEST_CASE("jit module resolve — POSIX filesystem root exe path is handled") {
+    // Bundle layout where the exe lives at filesystem root (e.g. minimal Docker
+    // image, embedded). std::filesystem::path("/myapp").parent_path() is "/",
+    // which path::operator/ joins correctly without doubling separators.
+    TestSeams seams;
+    g_exe_file = "/myapp";
+    g_existing.insert("/modules/dasFoo/dasFoo.shared_module");
+    auto chosen = resolve("modules/dasFoo/dasFoo.shared_module",
+                          "/build/abs/modules/dasFoo/dasFoo.shared_module");
+    CHECK(chosen == "/modules/dasFoo/dasFoo.shared_module");
+}
+
+#ifdef _WIN32
+// Backslash-separator paths are only meaningful on Windows; std::filesystem on
+// POSIX treats `\` as a regular filename character. The two cases below verify
+// the resolver builds correct candidates on Windows for both an exe in a
+// subdirectory and an exe in the drive root.
+//
+// Inputs use backslashes (the form Windows produces from getExecutableFileName);
+// expected values use forward slashes because the test helper normalizes via
+// generic_string() — see fake_path_exists and resolve() above.
+TEST_CASE("jit module resolve — Windows backslash exe path is handled") {
+    TestSeams seams;
+    g_exe_file = "C:\\bundle\\myapp.exe";
+    g_existing.insert("C:/bundle/modules/dasFoo/dasFoo.shared_module");
+    auto chosen = resolve("modules/dasFoo/dasFoo.shared_module",
+                          "C:\\build\\abs\\modules\\dasFoo\\dasFoo.shared_module");
+    CHECK(chosen == "C:/bundle/modules/dasFoo/dasFoo.shared_module");
+}
+
+TEST_CASE("jit module resolve — Windows drive-root exe path is handled") {
+    // Exe at C:\myapp.exe — drive root. parent_path must return "C:\" (not
+    // "C:") so the joined candidate stays on the drive root rather than
+    // becoming the malformed drive-relative "C:modules\...".
+    TestSeams seams;
+    g_exe_file = "C:\\myapp.exe";
+    g_existing.insert("C:/modules/dasFoo/dasFoo.shared_module");
+    auto chosen = resolve("modules/dasFoo/dasFoo.shared_module",
+                          "C:\\build\\abs\\modules\\dasFoo\\dasFoo.shared_module");
+    CHECK(chosen == "C:/modules/dasFoo/dasFoo.shared_module");
+}
+#endif

--- a/tests/exe-paths/CMakeLists.txt
+++ b/tests/exe-paths/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Integration test for daslang -exe's 3-tier dynamic-module resolution.
+# See run_layouts.cmake for the per-scenario logic.
+
+if(NOT TARGET daslang OR NOT TARGET dasModuleSQLITE OR NOT DAS_LLVM_INCLUDED)
+    # daslang -exe (the codegen exercised by this integration test) requires
+    # LLVM/JIT support; skip when LLVM is disabled.
+    return()
+endif()
+
+# Locate the dasSQLITE shared module artifact for the active build configuration.
+# In multi-config generators (MSVC, Xcode) the path includes $<CONFIG>; in
+# single-config (Make/Ninja) it's flat. Use a generator expression to evaluate
+# at test-run time.
+set(_sqlite_mod_path "$<TARGET_FILE:dasModuleSQLITE>")
+
+add_test(
+    NAME exe_paths_module_resolve
+    COMMAND ${CMAKE_COMMAND}
+        -DDASLANG=$<TARGET_FILE:daslang>
+        -DSRC_DAS=${CMAKE_CURRENT_SOURCE_DIR}/_uses_sqlite.das
+        -DSQLITE_MOD=${_sqlite_mod_path}
+        -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}/wk
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/run_layouts.cmake
+)
+# Label `small` is what CI's `ctest -L small` step picks up (.github/workflows/build.yml).
+# `exe-paths` / `integration` are descriptive — useful for local `ctest -L exe-paths`.
+set_tests_properties(exe_paths_module_resolve PROPERTIES LABELS "small;exe-paths;integration")

--- a/tests/exe-paths/_uses_sqlite.das
+++ b/tests/exe-paths/_uses_sqlite.das
@@ -1,0 +1,21 @@
+options gen2
+
+// Tiny standalone program used by tests/exe-paths/CMakeLists.txt to verify
+// the standalone exe's 3-tier dynamic-module resolution (exe_dir → das_root →
+// baked absolute). Requires dasSQLITE — if the module fails to load at startup
+// the open call would surface an error / crash. Prints "ok\n" on success so
+// the integration test can grep for it.
+
+require sqlite/sqlite_boost
+
+[export]
+def main {
+    var db : sqlite3?
+    let rc = sqlite3_open(":memory:", unsafe(addr(db)))
+    if (rc != 0) {
+        print("open failed: {rc}\n")
+        return
+    }
+    sqlite3_close(db)
+    print("ok\n")
+}

--- a/tests/exe-paths/run_layouts.cmake
+++ b/tests/exe-paths/run_layouts.cmake
@@ -1,0 +1,98 @@
+# Integration test driver — verifies daslang -exe's 3-tier dynamic-module
+# resolution works for the three real-world deployment layouts.
+#
+# Inputs (passed via -D on the cmake -P invocation):
+#   DASLANG       — path to daslang binary
+#   SRC_DAS       — path to uses_sqlite.das (the test program)
+#   SQLITE_MOD    — path to dasModuleSQLITE(.shared_module|*_debug.shared_module)
+#   WORKDIR       — temporary working directory (test-specific)
+#
+# The script compiles SRC_DAS to a standalone exe, then drives it through:
+#   1. Bundle layout      (exe at <bundle>/, modules at <bundle>/modules/...) —
+#                         tier 1 wins (exe_dir resolution).
+#   2. SDK install layout (exe at <root>/bin/, modules at <root>/modules/...) —
+#                         tier 2 wins (das_root: getDasRoot strips bin/).
+#   3. Local dev layout   (exe in build tree, baked absolute path still valid) —
+#                         tier 3 wins (legacy absolute fallback).
+#
+# All three are positive — each asserts the exe loads dasSQLITE and prints "ok".
+# A negative case (no modules anywhere) is omitted: tier 3 fallback would still
+# find the source-tree module on the dev machine, so distinguishing "broken
+# bundle" from "ok bundle" requires runtime override machinery that doesn't
+# exist yet. Each run uses a NEUTRAL cwd to isolate from cwd-relative fallbacks.
+
+if(NOT DASLANG OR NOT SRC_DAS OR NOT SQLITE_MOD OR NOT WORKDIR)
+    message(FATAL_ERROR "run_layouts.cmake: missing required -D inputs")
+endif()
+if(NOT EXISTS "${DASLANG}")
+    message(FATAL_ERROR "DASLANG not found: ${DASLANG}")
+endif()
+if(NOT EXISTS "${SRC_DAS}")
+    message(FATAL_ERROR "SRC_DAS not found: ${SRC_DAS}")
+endif()
+if(NOT EXISTS "${SQLITE_MOD}")
+    message(FATAL_ERROR "SQLITE_MOD not found: ${SQLITE_MOD}")
+endif()
+
+# Fresh workdir
+file(REMOVE_RECURSE "${WORKDIR}")
+file(MAKE_DIRECTORY "${WORKDIR}")
+
+# Step 1 — compile to standalone exe (daslang appends .exe)
+set(EXE_BASE "${WORKDIR}/uses_sqlite")
+message(STATUS "compiling: ${DASLANG} -exe ${SRC_DAS} -output ${EXE_BASE}")
+execute_process(
+    COMMAND "${DASLANG}" -exe "${SRC_DAS}" -output "${EXE_BASE}"
+    WORKING_DIRECTORY "${WORKDIR}"
+    RESULT_VARIABLE _rc OUTPUT_VARIABLE _out ERROR_VARIABLE _err)
+if(_rc)
+    message(FATAL_ERROR "daslang -exe failed (rc=${_rc}):\n${_out}\n${_err}")
+endif()
+set(EXE "${EXE_BASE}.exe")
+if(NOT EXISTS "${EXE}")
+    message(FATAL_ERROR "compile produced no output at ${EXE}")
+endif()
+
+# Helper — run the exe from CWD, capture output, verify "ok\n"
+function(run_layout SCENARIO EXE_PATH CWD)
+    message(STATUS "[${SCENARIO}] exe=${EXE_PATH} cwd=${CWD}")
+    execute_process(
+        COMMAND "${EXE_PATH}"
+        WORKING_DIRECTORY "${CWD}"
+        RESULT_VARIABLE _rc OUTPUT_VARIABLE _out ERROR_VARIABLE _err
+        TIMEOUT 30)
+    if(_rc)
+        message(FATAL_ERROR "[${SCENARIO}] exit ${_rc}\nstdout:${_out}\nstderr:${_err}")
+    endif()
+    if(NOT _out MATCHES "ok")
+        message(FATAL_ERROR "[${SCENARIO}] expected 'ok' in stdout, got: ${_out}\nstderr:${_err}")
+    endif()
+    message(STATUS "[${SCENARIO}] PASS")
+endfunction()
+
+# Neutral cwd — guarantees nothing resolves via cwd
+set(NEUTRAL "${WORKDIR}/cwd")
+file(MAKE_DIRECTORY "${NEUTRAL}")
+
+# Scenario 1 — bundle (release) layout: exe at <bundle>/, modules at <bundle>/modules/dasSQLITE/
+set(BUNDLE "${WORKDIR}/bundle")
+file(MAKE_DIRECTORY "${BUNDLE}/modules/dasSQLITE")
+file(COPY "${EXE}" DESTINATION "${BUNDLE}")
+file(COPY "${SQLITE_MOD}" DESTINATION "${BUNDLE}/modules/dasSQLITE")
+get_filename_component(_exe_name "${EXE}" NAME)
+run_layout("bundle" "${BUNDLE}/${_exe_name}" "${NEUTRAL}")
+
+# Scenario 2 — SDK install layout: exe at <root>/bin/, modules at <root>/modules/
+# getDasRoot() strips trailing /bin to recover <root>, so <root>/modules wins.
+set(INSTALL "${WORKDIR}/install")
+file(MAKE_DIRECTORY "${INSTALL}/bin" "${INSTALL}/modules/dasSQLITE")
+file(COPY "${EXE}" DESTINATION "${INSTALL}/bin")
+file(COPY "${SQLITE_MOD}" DESTINATION "${INSTALL}/modules/dasSQLITE")
+run_layout("sdk_install" "${INSTALL}/bin/${_exe_name}" "${NEUTRAL}")
+
+# Scenario 3 — local dev build sanity: run the exe from its build location.
+# (Compiled exe baked an absolute path to the SOURCE-tree dasSQLITE; that file
+# still exists, so tier-3 fallback wins. Verifies we don't break today.)
+run_layout("local_dev" "${EXE}" "${NEUTRAL}")
+
+message(STATUS "All exe-path layouts resolved successfully.")


### PR DESCRIPTION
## Summary

Standalone executables built with `daslang -exe` now resolve dynamic shared modules at startup by trying:

1. `<exe_dir>/<rel_path>` — daspkg release bundles (modules sit next to exe)
2. `<das_root>/<rel_path>` — SDK install AND local dev build
3. `<fallback_abs_path>` — baked-at-codegen absolute (legacy fallback)

Previously only tier 3 existed: the absolute path captured at compile time was baked verbatim into the binary. This worked for in-place dev builds (the path stays valid as long as the exe doesn't move) but **broke two real scenarios** that ship today:

| Scenario | Layout | Before | After |
|---|---|---|---|
| Local dev build | exe at `<repo>/bin/<cfg>/`, modules at `<repo>/modules/` | ✅ baked absolute | ✅ tier 2 (`getDasRoot()` strips `bin/<cfg>` → `<repo>`) |
| CMake install / CI SDK download | exe at `<install>/bin/`, modules at `<install>/modules/` | ❌ baked absolute → build-machine FS | ✅ tier 2 (`<install>/modules/...`) |
| daspkg release bundle | exe at `<bundle>/`, modules at `<bundle>/modules/` | ❌ same | ✅ tier 1 (`<bundle>/modules/...`) |

This is the prerequisite for the upcoming `daspkg release` command (PR #2 of the daspkg release plan) and also fixes the SDK-install case independently.

## Implementation

- `src/builtin/module_jit.cpp` — new `jit_register_dynamic_module_resolve(rel_path, fallback_abs_path, mod_name)` runtime helper. Plus test seams: `jit_set_exe_file_for_test_` and `jit_set_path_exists_for_test_` so the resolution logic is unit-testable without dlopening anything.
- `modules/dasLLVM/daslib/llvm_exe.das` — `inject_main` emits the new helper instead of `jit_register_dynamic_module`. New private `compute_modules_relative_suffix` extracts the `modules/<X>/...` suffix at codegen time via `to_generic_path` + substring search (cross-platform; never scans for both `/X/` and `\X\`).

## Test plan

- [x] `tests-cpp/small/test_jit_module_resolve.cpp` — 7 cases covering resolution priority, _debug-variant detection, Windows backslash exe paths, empty-input edge cases (uses test seams to drive logic with synthetic exe paths and a mock filesystem predicate).
- [x] `tests/exe-paths/_uses_sqlite.das` + `run_layouts.cmake` — end-to-end integration: builds a standalone exe via `daslang -exe`, deploys it to bundle / sdk-install / local-dev layouts in tmp dirs, runs each from a neutral cwd. Labeled `small` so CI's `ctest -L small` step (`build.yml:340/343`) picks it up across the full platform matrix.
- [x] Existing utils (`aot.exe`, `daspkg.exe`, `benchctl.exe`, `mcp.exe` — all built via `daslang -exe`) re-run cleanly after the change. Verified locally.
- [x] `dastest --test tests/`: 7822 tests, 7816 passed, 0 failed, 0 errors, 6 skipped.
- [x] `test_aot --use-aot --test tests/`: 7216 tests, 7210 passed, 0 failed, 0 errors, 6 skipped.

## Doc note

`skills/filesystem.md` — clarifies that the existing "never `rfind('/')` / `rfind('\\\\')` on paths" rule has one legitimate exception: searching for a **named component** (e.g. `/modules/`, `/.git/`) after `to_generic_path` normalize. Single-line addition + one row in the "pick the right tool" table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)