### PR TITLE
dasSQLITE: chunk 14a — versioned schema migrations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,16 +298,6 @@ jobs:
             # tracked separately, real fix is in the binding).
             printf 'leak:format_error\nleak:uriParseSingleUriA\nleak:uriMakeOwner\n' > suppressions.txt
             export LSAN_OPTIONS="suppressions=$(pwd)/suppressions.txt"
-            # TSan suppressions: fusion-engine SimNodes load function arguments via
-            # v_ldu (16-byte unaligned load) regardless of the actual arg size. For
-            # 4-byte / 8-byte args at the tail of an array struct, the upper bytes
-            # of the load fall just past the struct end. Functionally fine — the
-            # callee uses cast<T>::to which only reads the relevant bytes — but
-            # TSan flags the over-read whenever the adjacent memory was just freed
-            # (e.g., issues TextWriter buffer freed during error formatting). All
-            # the matched fusion-point classes share this v_ldu pattern.
-            printf 'race:das::FusionPoint_FastCall_StringPtr\nrace:das::FusionPoint_Call_StringPtr\nrace:das::FusionPoint_CallAndCopyOrMove_StringPtr\nrace:das::Op1FusionPoint_Return_vec4f\nrace:das::Op1FusionPoint_Call_vec4f\n' > tsan_suppressions.txt
-            export TSAN_OPTIONS="suppressions=$(pwd)/tsan_suppressions.txt"
             # Use more time to pass UBSAN and disable leaks in JIT mode because we exit using exit(), and do not call destructors.
             [ "${{ env.das_llvm_disabled }}" = "ON" ] || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --timeout 900 --test ../tests || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build-track/
 build-rwdi/
 build-asan/
 build-ubsan/
+build-linux-asan/
 # All build binaries stored here
 bin/
 # JIT stores dll's here

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -51,3 +51,9 @@ Every `.das` benchmark file in this directory tree is listed below, grouped by s
 | File | Description |
 |---|---|
 | `test01.das` | emplace, emplace_grow, move, and reserve on arrays of locked vs `[skip_field_lock_check]` struct elements — measures array lock overhead |
+
+## fusion/
+
+| File | Description |
+|---|---|
+| `bench_v_ldu.das` | Fusion-engine `Op2At` array-indexed read at sizeof(T) ∈ {4,8,12,16} — int, int64, float3, float4. Used to compare DAS_FUSION=0 vs current `DAS_LDU_WORKHORSE` ladder vs `v_zero+memcpy(sizeof(CTYPE))` |

--- a/benchmarks/fusion/bench_v_ldu.das
+++ b/benchmarks/fusion/bench_v_ldu.das
@@ -1,0 +1,92 @@
+options gen2
+options persistent_heap
+
+require dastest/testing_boost
+
+// Micro-benches for the fusion-engine v_ldu/workhorse load path.
+// Op2At (array<T>[idx]) at different sizeof(T):
+//   int    (4)  — at.cpp scalar path, *(int*)slot, no v_ldu
+//   int64  (8)  — at.cpp scalar path, *(int64*)slot, no v_ldu
+//   float3 (12) — at.cpp VECTOR path, v_ldu_p3_safe target
+//   float4 (16) — at.cpp VECTOR path, v_ldu target
+//
+// int/int64 benches act as control variables (unaffected by the macro
+// choice); float3/float4 are the actual targets. Compare four builds:
+//   DAS_FUSION=0 (no fusion floor)
+//   raw v_ldu (current/unsafe baseline)
+//   DAS_LDU_WORKHORSE if-constexpr ladder
+//   v_zero+memcpy(sizeof(CTYPE))
+
+let private N = 100000
+
+[benchmark]
+def at_int_4(b : B?) {
+    var arr : array<int>
+    arr |> resize(N)
+    for (i in range(N)) {
+        arr[i] = i
+    }
+    var sum = 0
+    b |> run("at_int", N) {
+        for (i in range(N)) {
+            sum += arr[i]
+        }
+    }
+    if (sum == 0) {
+        b->failNow()
+    }
+}
+
+[benchmark]
+def at_int64_8(b : B?) {
+    var arr : array<int64>
+    arr |> resize(N)
+    for (i in range(N)) {
+        arr[i] = int64(i)
+    }
+    var sum = 0l
+    b |> run("at_int64", N) {
+        for (i in range(N)) {
+            sum += arr[i]
+        }
+    }
+    if (sum == 0l) {
+        b->failNow()
+    }
+}
+
+[benchmark]
+def at_float3_12(b : B?) {
+    var arr : array<float3>
+    arr |> resize(N)
+    for (i in range(N)) {
+        arr[i] = float3(i, i + 1, i + 2)
+    }
+    var sum = float3(0.0, 0.0, 0.0)
+    b |> run("at_float3", N) {
+        for (i in range(N)) {
+            sum += arr[i]
+        }
+    }
+    if (sum.x == 0.0) {
+        b->failNow()
+    }
+}
+
+[benchmark]
+def at_float4_16(b : B?) {
+    var arr : array<float4>
+    arr |> resize(N)
+    for (i in range(N)) {
+        arr[i] = float4(i, i + 1, i + 2, i + 3)
+    }
+    var sum = float4(0.0, 0.0, 0.0, 0.0)
+    b |> run("at_float4", N) {
+        for (i in range(N)) {
+            sum += arr[i]
+        }
+    }
+    if (sum.x == 0.0) {
+        b->failNow()
+    }
+}

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -332,6 +332,7 @@ Run any tutorial from the project root::
    tutorials/sql_40_fts5.rst
    tutorials/sql_41_triggers.rst
    tutorials/sql_42_schema_evolution.rst
+   tutorials/sql_43_migrations.rst
 
 .. _tutorials_dasaudio:
 

--- a/doc/source/reference/tutorials/sql_43_migrations.rst
+++ b/doc/source/reference/tutorials/sql_43_migrations.rst
@@ -1,0 +1,249 @@
+.. _tutorial_sql_migrations:
+
+================================================
+SQL-43 --- versioned schema migrations
+================================================
+
+.. index::
+    single: Tutorial; SQL
+    single: Tutorial; SQLite
+    single: Tutorial; migrations
+    single: Tutorial; sql_migration
+    single: Tutorial; baseline
+    single: Tutorial; with_latest_sqlite
+
+A DB file holds *schema* (tables, columns, indexes) and *data*
+(rows). When v1 of an app ships, users start filling tables.
+When v2 ships with a new column, the user's existing ``app.db``
+still has the v1 shape --- v2 code that queries the new column
+panics on the first call. Migrations solve this: each schema
+change ships as a numbered, frozen step, and the runtime applies
+whatever is missing on every startup.
+
+Three rules make this work:
+
+1. **Migrations are append-only.** Once shipped, a migration is
+   FROZEN --- to change anything, write a new one with a higher
+   version number. A user whose DB is already past version K
+   never re-runs anything ``<= K``; edits to old migrations are
+   invisible to existing DBs and silent divergence between fresh
+   and existing DBs is the result. So: don't edit, add.
+
+2. **Versions are unique across the whole program.** Two devs
+   picking ``version=N`` on parallel branches is a compile-time
+   error --- the macro scans every loaded module's
+   ``[sql_migration]`` annotations and refuses the dup. The
+   error message names both function names + both module paths,
+   and a runtime belt-and-suspenders check guards against any
+   case that slips through (dynamic plugin loading, etc.).
+
+3. **The runner uses one transaction per call.** All pending
+   migrations + their audit-table inserts run inside a single
+   ``BEGIN IMMEDIATE`` / ``COMMIT``. If any migration fails,
+   every effect rolls back --- including prior migrations that
+   succeeded earlier in the same call. Re-run replays the whole
+   pending list cleanly.
+
+The struct describes the CURRENT schema. Old shapes live ONLY in
+the migration body's raw SQL --- daslang has no model-snapshot
+system on disk per migration. Migrations 1 through N-1 use raw
+``db |> exec(...)`` for whatever the schema looked like at that
+point.
+
+Define a schema and write migrations
+=====================================
+
+.. code-block:: das
+
+    require sqlite/sql_migrate
+
+    [sql_table(name = "users")]
+    struct User {
+        @sql_primary_key Id : int
+        Name : string
+        Email : string                 // added in migration 2
+        Score : int = 0                // added in migration 3
+    }
+
+    [sql_migration(version = 1, description = "create users")]
+    def migration_001(db : SqlRunner) {
+        db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+    }
+
+    [sql_migration(version = 2, description = "add email column")]
+    def migration_002(db : SqlRunner) {
+        db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
+    }
+
+    [sql_migration(version = 3, description = "add score; backfill", analyze = true)]
+    def migration_003(db : SqlRunner) {
+        db |> exec("ALTER TABLE users ADD COLUMN Score INTEGER NOT NULL DEFAULT 0")
+        db |> exec("UPDATE users SET Score = 100 WHERE Email != ''")
+    }
+
+A migration body is just a daslang function. Inside it: raw
+``exec``, parameterized ``exec``, ``_sql_update``, helper
+function calls, ``for``/``if`` --- whatever it takes to advance
+one step. Multiple statements run inside the same transaction;
+DDL and DML mix freely (SQLite supports transactional DDL).
+
+Annotation parameters:
+
+- ``version=N`` --- required, positive integer, unique across
+  the program.
+- ``description=...`` --- optional. Shown in ``LOG_INFO``
+  and stored in ``__schema_version``.
+- ``vacuum=true`` --- optional. Runs ``VACUUM`` once after the
+  call commits, regardless of how many migrations in the batch
+  set the flag.
+- ``analyze=true`` --- same shape, runs ``ANALYZE``. If both
+  appear in a batch, ANALYZE runs first, then VACUUM.
+
+App startup
+============
+
+Preferred form combines ``with_sqlite`` +
+``apply_recommended_pragmas`` + ``migrate_to_latest`` into one
+call:
+
+.. code-block:: das
+
+    [export]
+    def main() {
+        with_latest_sqlite("app.db") <| $(db) {
+            // DB is now at the latest schema. App-level logic goes here.
+            db |> exec("INSERT INTO users (Name, Email) VALUES ('alice', 'alice@x')")
+        }
+    }
+
+The explicit two-step form (``with_sqlite`` then
+``db |> migrate_to_latest()``) stays available for tools / CI
+that want to inspect state before migrating.
+
+Cost on a fully-up-to-date DB is a few cheap reads ---
+``CREATE TABLE IF NOT EXISTS`` is a no-op on the existing audit table,
+plus a ``COUNT(*)`` adoption probe and a ``MAX(version)`` lookup.
+Microseconds total. Safe to call every startup.
+
+Inspection: pure reads, no side effects
+========================================
+
+Three functions answer "what's the migration state?" without
+running anything:
+
+.. code-block:: das
+
+    db |> current_schema_version()    // int (0 if no audit table yet)
+    db |> pending_migrations()        // array<PendingMigration>
+    db |> migration_history()         // array<MigrationRecord>
+
+All three never create the audit table, never write a row, never
+run a migration. Safe to call from ``mytool db status`` against a
+brand-new DB. ``Result``-bound ``try_*`` siblings exist for tools
+that want explicit error handling.
+
+Description sourcing differs by call:
+
+- ``pending_migrations`` reads from the **annotation** (current
+  code; reflects what *will be*).
+- ``migration_history`` reads from the **audit row** (frozen
+  at apply-time; reflects what *was*).
+
+So editing a description on an already-shipped migration is a
+no-op for any DB that's already past it --- the audit row keeps
+the old text. Fresh installs pick up the new text on first
+apply.
+
+Adopting migrations on an existing DB
+======================================
+
+Common case: the app has been shipping without migrations for a
+year. Existing user DBs already have ``users`` from hand-rolled
+DDL. A naive swap to ``with_latest_sqlite`` would crash ---
+``migration_001``'s ``CREATE TABLE`` fails because the table
+already exists.
+
+``baseline(db, version=N)`` stamps v1..vN as already-applied
+without running their bodies. Idempotent (versions already in
+the audit are skipped); safe to leave the call permanently
+in startup code, though removing it after one release cycle
+keeps things tidy.
+
+.. code-block:: das
+
+    [export]
+    def main() {
+        with_sqlite("app.db") <| $(db) {
+            db |> baseline(1)             // mark v1 as already applied
+            db |> migrate_to_latest()     // applies v2 + v3 only
+        }
+    }
+
+The runner gives two layers of UX safety net for the naive
+adoption shape:
+
+- **Layer 1 (proactive warning).** When ``migrate_to_latest``
+  detects user objects in a freshly-empty audit table, it logs a
+  ``LOG_WARNING`` with the baseline recipe before running any
+  migration body.
+
+- **Layer 2 (enriched panic).** If the first migration body
+  fails AND the audit was empty before the call, the panic
+  message appends the same baseline hint. Same hint reaches
+  ``try_migrate_to_latest``'s ``Result::Err``.
+
+Recommended default in new code: prefer first-change-as-first-
+migration --- your first new migration ALTERs the existing
+schema rather than recreating it. ``baseline`` is the explicit
+escape for when you want CREATE-TABLE-shaped retroactive
+history.
+
+What does NOT ship
+===================
+
+- **Down migrations / rollback.** No ``[sql_migration_down]``,
+  no ``migrate_to(version=N-1)``. Down migrations are a design
+  anti-pattern --- implicit data loss, retroactive maintenance
+  burden, never tested in production conditions, the thing
+  people actually want is "go back to before I deployed v7"
+  which is a backup-restore concern. Recommended response to a
+  bad migration: write the next migration to fix it forward.
+
+- **Concurrent runners across NFS / shared volumes.** OS file
+  locking is unreliable on NFS, SMB, GlusterFS, EFS. SQLite
+  docs explicitly warn against this; ``migrate_to_latest``'s
+  concurrency safety degrades to "mostly works." Run migrations
+  as a separate explicit step before launching app instances on
+  shared storage.
+
+- **Compile-time DDL emission to a .sql file.** ``dotnet ef
+  migrations script`` analogue. Future work; not blocking.
+
+- **Squash tool.** Hand-recipe in API_MIGRATION.md when a
+  project accumulates 100+ migrations and needs collapsing.
+  Future ``daspkg sql-migrate squash`` is plausible but
+  deferred.
+
+- **A separate CLI** for running migrations outside the app.
+  Future work, also dovetails with the eventual ``dasSQL``
+  abstraction layer.
+
+- **Typed ``ALTER`` macros** (``add_column``, ``create_index``,
+  ``drop_index_if_exists``). Coming in chunk 14b. For now,
+  every ALTER is raw SQL --- which works for every form on the
+  bundled SQLite 3.41.2, including ``DROP COLUMN`` and
+  ``RENAME COLUMN``.
+
+- **Struct-to-struct rebuild support** (``struct_convert``,
+  ``[sql_table(legacy=true)]``, ``name=`` overrides). Coming
+  in chunk 14c. For now, schema rebuilds are hand-written
+  ``CREATE TABLE T_new`` + ``INSERT ... SELECT`` --- works,
+  just verbose.
+
+.. seealso::
+
+    Full source: :download:`tutorials/sql/43-migrations.das <../../../../tutorials/sql/43-migrations.das>`
+
+    Read-side multi-version ETL: :ref:`tutorial_sql_schema_evolution`
+
+    Schema introspection from existing DBs: :ref:`tutorial_sql_schema_from`

--- a/include/daScript/simulate/simulate_fusion.h
+++ b/include/daScript/simulate/simulate_fusion.h
@@ -7,6 +7,20 @@
     #define DAS_FUSION  0
 #endif
 
+// Safe vec4f load for a workhorse-sized source. Picks the load width by sizeof(CTYPE)
+// at compile time so we never v_ldu past a 4/8/12-byte source — important when the
+// source sits within 16 bytes of an unmapped page (real SIGSEGV under TSan, not just
+// a sanitizer over-read warning). Each branch is a single SIMD intrinsic; memcpy
+// fallback only on exotic sizes.
+#define DAS_LDU_WORKHORSE(dst, src_ptr, CTYPE) \
+    do { \
+        if constexpr (sizeof(CTYPE) == sizeof(vec4f))         (dst) = v_ldu((const float *)(src_ptr)); \
+        else if constexpr (sizeof(CTYPE) == sizeof(float) * 3) (dst) = v_ldu_p3_safe((const float *)(src_ptr)); \
+        else if constexpr (sizeof(CTYPE) == sizeof(float) * 2) (dst) = v_ldu_half((const float *)(src_ptr)); \
+        else if constexpr (sizeof(CTYPE) == sizeof(float))     (dst) = v_set_x(*(const float *)(src_ptr)); \
+        else { vec4f __r = v_zero(); memcpy(&__r, (src_ptr), sizeof(CTYPE)); (dst) = __r; } \
+    } while (0)
+
 namespace das {
 
     typedef char * StringPtr;

--- a/include/vecmath/dag_vecMathDecl.h
+++ b/include/vecmath/dag_vecMathDecl.h
@@ -39,6 +39,14 @@ typedef const struct bsph3f& bsph3f_cref;
 # endif
 #endif
 
+#if defined(__SANITIZE_THREAD__)
+# define DAGOR_TSAN_ENABLED
+#elif defined(__has_feature)
+# if __has_feature(thread_sanitizer)
+#   define DAGOR_TSAN_ENABLED
+# endif
+#endif
+
 #ifndef VECMATH_FINLINE
   #define VECMATH_FINLINE __forceinline
 #endif
@@ -58,9 +66,15 @@ typedef const struct bsph3f& bsph3f_cref;
   #endif
 #endif
 
-#if defined(DAGOR_ASAN_ENABLED) && (defined(__clang__) || __GNUC__ >= 7)
-# define NO_ASAN_INLINE inline __attribute__((no_sanitize_address))
-//loads have to switch off address sanitize. It is common (and ok) to load data from stack, even if data partially is not allocated (i.e. .xyzU).
+// Suppresses ASan AND TSan on intentional 16-byte unaligned loads. v_ldu may legitimately
+// read past a 4/8-byte struct end (caller uses cast<T>::to which only consumes the relevant
+// bytes). ASan flags this on stack-near-allocation; TSan flags it when the adjacent memory
+// was just freed in the racy way (e.g., compile-error TextWriter buffer freed during
+// rtti_builtin_compile_file). The unused upper bytes never escape the v_ldu callee.
+// Use the split-attribute form for compatibility with older GCC (no_sanitize_address /
+// no_sanitize_thread are GCC-4.8+; the multi-arg no_sanitize("a","b") string form is GCC-8+).
+#if (defined(DAGOR_ASAN_ENABLED) || defined(DAGOR_TSAN_ENABLED)) && (defined(__clang__) || __GNUC__ >= 7)
+# define NO_ASAN_INLINE inline __attribute__((no_sanitize_address)) __attribute__((no_sanitize_thread))
 #elif defined(DAGOR_ASAN_ENABLED) && defined(_MSC_VER)
 # define NO_ASAN_INLINE __declspec(no_sanitize_address) __forceinline
 #else

--- a/modules/dasSQLITE/.das_module
+++ b/modules/dasSQLITE/.das_module
@@ -6,7 +6,7 @@ def initialize(project_path : string) {
     if (das_is_dll_build()) {
         register_dynamic_module("{project_path}/dasModuleSQLITE.shared_module", "Module_dasSQLITE")
     }
-    let sqlite_paths = ["sqlite_boost", "sqlite_linq"]
+    let sqlite_paths = ["sqlite_boost", "sqlite_linq", "sql_migrate"]
     for (path in sqlite_paths) {
         register_native_path("sqlite", "{path}", "{project_path}/daslib/{path}.das")
     }

--- a/modules/dasSQLITE/daslib/sql_migrate.das
+++ b/modules/dasSQLITE/daslib/sql_migrate.das
@@ -1,0 +1,625 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+options strict_smart_pointers
+
+module sql_migrate shared public
+
+// Intentionally opt in for user-facing docs: keep comments concise and actionable.
+options _comment_hygiene = true
+
+require sqlite_boost public
+
+require strings public
+require daslib/strings_boost
+require daslib/option public
+require daslib/rtti               // this_context().last_exception inside recover blocks
+require daslib/ast_boost
+require daslib/macro_boost
+require daslib/templates
+require daslib/templates_boost
+
+
+// ===== Public types =====
+
+struct PendingMigration {
+    //! One row from `pending_migrations(db)` — a registered migration that has not yet been applied.
+    //! `description` reflects the *current* annotation text (compile-time source); annotation edits
+    //! propagate until the migration is applied, after which `migration_history` carries the frozen text.
+    version : int
+    description : string
+}
+
+struct MigrationRecord {
+    //! One row from `migration_history(db)` — a migration that has been applied to this DB.
+    //! `description` is the text that was on the annotation at the moment of apply, frozen in the
+    //! audit row; subsequent annotation edits do NOT propagate. `applied_at` is unix epoch seconds.
+    version : int
+    description : string
+    applied_at : int64
+}
+
+
+// ===== Private registry types =====
+
+struct private MigrationEntry {
+    version : int
+    description : string
+    vacuum : bool
+    analyze : bool
+    body : function<(db : SqlRunner) : void>
+    func_name : string
+    module_name : string
+}
+
+
+// ===== Audit table constants =====
+
+let private AUDIT_CREATE_DDL = "CREATE TABLE IF NOT EXISTS __schema_version (version INTEGER PRIMARY KEY, description TEXT NOT NULL DEFAULT '', applied_at INTEGER NOT NULL)"
+
+
+// ===== Process-global registry =====
+
+// Populated by per-module [init] thunks emitted by the [sql_migration] macro.
+// Loaded once at program startup, before main(). Never mutated thereafter except
+// by additional module loads.
+var private _registry : array<MigrationEntry>
+
+
+def _add_migration_entry(version : int; description : string; vacuum : bool; analyze : bool;
+                         body : function<(db : SqlRunner) : void>;
+                         func_name : string; module_name : string) : void {
+    //! Public entry point used by ``[sql_migration]``-generated init blocks to register a
+    //! migration. End users never call this directly.
+    var entry <- MigrationEntry(
+        version = version,
+        description = description,
+        vacuum = vacuum,
+        analyze = analyze,
+        body = body,
+        func_name = func_name,
+        module_name = module_name)
+    _registry |> emplace(entry)
+}
+
+
+def private _registry_max_version() : int {
+    var m = 0
+    for (e in _registry) {
+        if (e.version > m) {
+            m = e.version
+        }
+    }
+    return m
+}
+
+
+def private _registry_sorted() : array<MigrationEntry> {
+    var out := _registry
+    sort(out, $(a, b) => a.version < b.version)
+    return <- out
+}
+
+
+def private _registry_find_description(version : int) : string {
+    for (e in _registry) {
+        if (e.version == version) {
+            return e.description
+        }
+    }
+    return ""
+}
+
+
+def private _verify_no_duplicate_versions() : void {
+    // Belt-and-suspenders runtime defense for dynamic plugin loading past compile-time visibility.
+    var seen : table<int; string>
+    for (e in _registry) {
+        if (key_exists(seen, e.version)) {
+            let prev = seen[e.version]
+            panic("duplicate [sql_migration(version={e.version})] at runtime: '{prev}' and '{e.func_name}' (in '{e.module_name}')")
+        }
+        seen |> insert(e.version, "{e.func_name} (in '{e.module_name}')")
+    }
+}
+
+
+// ===== Internal helpers — audit table I/O and diagnostics =====
+
+let private ADOPTION_HINT = "this DB has existing tables/views/indexes but __schema_version is empty (no migration history yet). If your first migration creates tables that already exist, it will fail. To adopt migrations on an existing DB, call `db |> baseline(version = N)` before `migrate_to_latest()` to mark v1..vN as already applied. See tut 43 § \"Adopting migrations on an existing DB\"."
+
+
+def private _scalar_int_or_zero(db : SqlRunner; sql : string) : int {
+    // Treats query failure (e.g. "no such table") as 0 — natural default for COUNT/MAX probes.
+    let r = db |> try_query_scalar(sql, type<int>)
+    return (r |> is_ok) ? (r |> unwrap) : 0
+}
+
+
+def private _has_user_objects(db : SqlRunner) : bool {
+    // sqlite_* names are reserved for internals (sqlite_sequence, sqlite_autoindex_*).
+    return _scalar_int_or_zero(db,
+        "SELECT COUNT(*) FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' AND name != '__schema_version'") > 0
+}
+
+
+def private _audit_insert(db : SqlRunner; version : int; description : string) : SqlError {
+    return db |> try_exec(
+        "INSERT INTO __schema_version (version, description, applied_at) VALUES (?, ?, unixepoch())",
+        version, description)
+}
+
+
+def private _format_versions_csv(pending : array<MigrationEntry>; applied_count : int; failed_version : int) : string {
+    // "v4, v5" — every applied migration (inside the txn) plus the failing one — all rolled back.
+    var parts : array<string>
+    let limit = applied_count + 1
+    var i = 0
+    for (m in pending) {
+        if (i >= limit) {
+            break
+        }
+        parts |> push("v{m.version}")
+        i += 1
+    }
+    return parts |> join(", ")
+}
+
+
+def private _build_enriched_err(failed_version : int; failed_desc : string; underlying : string;
+                                rolled_back : string; layer2_hint : bool) : string {
+    var msg = "migration v{failed_version} '{failed_desc}' failed:\n  {underlying}\n\nnote: this migrate_to_latest call's transaction was rolled back — {rolled_back} are NOT applied. Fix the migration body and re-run; the corrected migration set will replay on the next call. The DB does not need to be reset."
+    if (layer2_hint) {
+        msg += "\n\nnote: This is the first migration on this DB and __schema_version was empty before this call. Looks like an adoption attempt on an existing schema. Call `db |> baseline(version = N)` once before `migrate_to_latest()` to mark v1..vN as already applied. See tut 43 § \"Adopting migrations on an existing DB\"."
+    }
+    return msg
+}
+
+
+def private _log_warn_on_some(err : SqlError) : void {
+    if (err |> is_some) {
+        to_log(LOG_WARNING, "{err |> unwrap}\n")
+    }
+}
+
+
+// ===== Internal runner — _migrate_inner =====
+
+def private _migrate_inner(db : SqlRunner) : Result<int, string> {
+    // Eager audit table; idempotent across concurrent runners.
+    let create_err = db |> try_exec(AUDIT_CREATE_DDL)
+    if (create_err |> is_some) {
+        return err(create_err |> unwrap, type<int>)
+    }
+    // Was the audit table empty at the start of this call? (Used by Layer-1 + Layer-2.)
+    let audit_was_empty_before = _scalar_int_or_zero(db, "SELECT COUNT(*) FROM __schema_version") == 0
+    let max_registered = _registry_max_version()
+    // Layer-1 only fires when there's something to migrate — empty registry + pre-existing schema is benign.
+    if (audit_was_empty_before && max_registered > 0 && _has_user_objects(db)) {
+        to_log(LOG_WARNING, "{ADOPTION_HINT}\n")
+    }
+    // Belt-and-suspenders runtime dup check.
+    _verify_no_duplicate_versions()
+    // Read current; downgrade detection (Scenario 4).
+    let current = _scalar_int_or_zero(db, "SELECT COALESCE(MAX(version), 0) FROM __schema_version")
+    if (current > max_registered) {
+        let bin_max = max_registered
+        to_log(LOG_WARNING, "DB at schema v{current} but this binary only knows up to v{bin_max} — DB appears to be running ahead of the binary. No migrations applied.\n")
+        return ok(0, type<string>)
+    }
+    var pending <- _registry_sorted()
+    var pending_idx = 0
+    while (pending_idx < pending |> length) {
+        if (pending[pending_idx].version <= current) {
+            pending |> erase(pending_idx)
+        } else {
+            pending_idx += 1
+        }
+    }
+    if (pending |> empty) {
+        return ok(0, type<string>)
+    }
+    // BEGIN IMMEDIATE — soft-error path (lock contention surfaces here as SQLITE_BUSY).
+    let begin_err = db |> try_exec("BEGIN IMMEDIATE")
+    if (begin_err |> is_some) {
+        return err(begin_err |> unwrap, type<int>)
+    }
+    // Mutables shared between try and recover.
+    var applied_count = 0
+    var any_vacuum = false
+    var any_analyze = false
+    var failed_version = 0
+    var failed_desc = ""
+    var inner_err = ""
+    var commit_err = ""
+    try {
+        for (m in pending) {
+            to_log(LOG_INFO, "applying migration v{m.version}: {m.description}\n")
+            failed_version = m.version
+            failed_desc = m.description
+            m.body(db)                          // user body — may panic
+            let ins_err = _audit_insert(db, m.version, m.description)
+            if (ins_err |> is_some) {
+                panic(ins_err |> unwrap)        // promote to panic so recover-block ROLLBACK runs
+            }
+            applied_count += 1
+            any_vacuum ||= m.vacuum
+            any_analyze ||= m.analyze
+        }
+        let cerr = db |> try_exec("COMMIT")
+        if (cerr |> is_some) {
+            db |> try_exec("ROLLBACK") |> _log_warn_on_some
+            commit_err = cerr |> unwrap
+        }
+    } recover {
+        let underlying = string(this_context().last_exception) |> rtrim
+        let rolled_back_str = _format_versions_csv(pending, applied_count, failed_version)
+        to_log(LOG_ERROR, "migration v{failed_version} '{failed_desc}' FAILED — rolled back call\n  underlying error: {underlying}\n  rolled back: {rolled_back_str}\n")
+        db |> try_exec("ROLLBACK") |> _log_warn_on_some
+        let layer2_hint = audit_was_empty_before && (failed_version == pending[0].version)
+        inner_err = _build_enriched_err(failed_version, failed_desc, underlying, rolled_back_str, layer2_hint)
+    }
+    if (!empty(commit_err)) {
+        return err(commit_err, type<int>)
+    }
+    if (!empty(inner_err)) {
+        return err(inner_err, type<int>)
+    }
+    // Post-COMMIT VACUUM/ANALYZE — Scenario 3: failures = LOG_WARNING, never block success.
+    if (any_analyze) {
+        (db |> try_exec("ANALYZE")) |> _log_warn_on_some
+    }
+    if (any_vacuum) {
+        (db |> try_exec("VACUUM")) |> _log_warn_on_some
+    }
+    to_log(LOG_INFO, "migrate_to_latest: applied {applied_count} migration(s)\n")
+    return ok(applied_count, type<string>)
+}
+
+
+// ===== Inspection — pure reads, no side effects =====
+// Never create the audit table or write a row; absent __schema_version → 0 / all-pending / [].
+
+def private _try_audit_table_exists(db : SqlRunner) : Result<bool, string> {
+    // sqlite_master itself never reports "no such table"; transient errors here propagate.
+    let r <- db |> try_query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='__schema_version'", type<int>)
+    if (r |> is_err) {
+        return err(r |> unwrap_err, type<bool>)
+    }
+    return ok((r |> unwrap) > 0, type<string>)
+}
+
+
+def private _audit_table_exists(db : SqlRunner) : bool {
+    // Strict-form callers swallow transient errors (treat as "absent" → return 0/empty).
+    let r <- _try_audit_table_exists(db)
+    return (r |> is_ok) && (r |> unwrap)
+}
+
+
+def current_schema_version(db : SqlRunner) : int {
+    //! Highest applied migration version, or 0 if no migrations have ever been applied
+    //! to this DB (or the audit table doesn't exist yet).
+    if (!_audit_table_exists(db)) {
+        return 0
+    }
+    return _scalar_int_or_zero(db, "SELECT COALESCE(MAX(version), 0) FROM __schema_version")
+}
+
+
+def try_current_schema_version(db : SqlRunner) : Result<int, string> {
+    //! ``ok(0)`` when the audit table is absent or empty; ``err`` on transient SQLite errors
+    //! (lock contention etc.) — including failures of the sqlite_master probe.
+    let exists <- _try_audit_table_exists(db)
+    if (exists |> is_err) {
+        return err(exists |> unwrap_err, type<int>)
+    }
+    if (!(exists |> unwrap)) {
+        return ok(0, type<string>)
+    }
+    return <- db |> try_query_scalar("SELECT COALESCE(MAX(version), 0) FROM __schema_version", type<int>)
+}
+
+
+def try_pending_migrations(db : SqlRunner) : Result<array<PendingMigration>, string> {
+    //! Registered migrations whose ``version > current_schema_version(db)``, in ascending order.
+    //! Description sourced from the annotation (current code), not the audit table.
+    let cv <- db |> try_current_schema_version()
+    if (cv |> is_err) {
+        return err(cv |> unwrap_err, type<array<PendingMigration>>)
+    }
+    let current = cv |> unwrap
+    var inscope out : array<PendingMigration>
+    let sorted <- _registry_sorted()
+    for (m in sorted) {
+        if (m.version > current) {
+            out |> push(PendingMigration(version = m.version, description = m.description))
+        }
+    }
+    return move_ok(out, type<string>)
+}
+
+
+def pending_migrations(db : SqlRunner) : array<PendingMigration> {
+    //! Strict variant. Panics on transient errors; ``empty`` when no pending migrations.
+    var r <- db |> try_pending_migrations()
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return <- r._value
+}
+
+
+def try_migration_history(db : SqlRunner) : Result<array<MigrationRecord>, string> {
+    //! Every row in ``__schema_version``, in ascending version order. Description here is the
+    //! frozen-at-apply text from the audit row (NOT the current annotation). ``ok([])`` when the
+    //! audit table is absent; ``err`` on transient SQLite errors (incl. the sqlite_master probe).
+    let exists <- _try_audit_table_exists(db)
+    if (exists |> is_err) {
+        return err(exists |> unwrap_err, type<array<MigrationRecord>>)
+    }
+    if (!(exists |> unwrap)) {
+        return ok(default<array<MigrationRecord>>, type<string>)
+    }
+    return <- try_run_select(db,
+        "SELECT version, description, applied_at FROM __schema_version ORDER BY version",
+        $(var stmt : sqlite3_stmt?) {},
+        $(stmt : sqlite3_stmt?) {
+            return MigrationRecord(
+                version = sqlite3_column_int(stmt, 0),
+                description = sqlite3_column_text_(stmt, 1),
+                applied_at = sqlite3_column_int64(stmt, 2))
+        })
+}
+
+
+def migration_history(db : SqlRunner) : array<MigrationRecord> {
+    //! Strict variant of ``try_migration_history``.
+    var r <- db |> try_migration_history()
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return <- r._value
+}
+
+
+// ===== Public runner surfaces =====
+
+def migrate_to_latest(db : SqlRunner) : int {
+    //! Applies every pending migration in ascending order inside one transaction; returns
+    //! the count applied. Panics with an enriched message on soft failure or body panic.
+    let r <- _migrate_inner(db)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+    return r |> unwrap
+}
+
+
+def try_migrate_to_latest(db : SqlRunner) : Result<int, string> {
+    //! Non-panic variant of ``migrate_to_latest``. Returns ``ok(count)`` on success or
+    //! ``err(enriched_message)`` for both soft failures and body panics. ROLLBACK is
+    //! guaranteed before the ``Err`` is returned (recover-block).
+    return <- _migrate_inner(db)
+}
+
+
+// ===== Adoption — baseline =====
+
+def private _audit_has_version(db : SqlRunner; version : int) : bool {
+    // Version is an int we control (registered-migration number, not user input) — string format is safe.
+    return _scalar_int_or_zero(db, "SELECT COUNT(*) FROM __schema_version WHERE version = {version}") > 0
+}
+
+
+def try_baseline(db : SqlRunner; version : int) : Result<int, string> {
+    //! Stamps v1..``version`` as already-applied without running their bodies. Idempotent
+    //! (versions already in the audit are skipped). Returns ``ok(stamped_count)`` or ``err``.
+    //! Rejects ``version > _registry_max_version()`` as almost-certainly a typo.
+    if (version <= 0) {
+        return err("baseline(version={version}) must be a positive integer", type<int>)
+    }
+    let max_reg = _registry_max_version()
+    if (version > max_reg) {
+        return err("baseline(version={version}) is above the highest registered migration (v{max_reg}) — looks like a typo", type<int>)
+    }
+    let create_err = db |> try_exec(AUDIT_CREATE_DDL)
+    if (create_err |> is_some) {
+        return err(create_err |> unwrap, type<int>)
+    }
+    let begin_err = db |> try_exec("BEGIN IMMEDIATE")
+    if (begin_err |> is_some) {
+        return err(begin_err |> unwrap, type<int>)
+    }
+    var stamped = 0
+    var inner_err = ""
+    var commit_err = ""
+    try {
+        for (v in range(1, version + 1)) {
+            if (_audit_has_version(db, v)) {
+                continue
+            }
+            let desc_from_reg = _registry_find_description(v)
+            let desc = empty(desc_from_reg) ? "[baseline]" : desc_from_reg
+            let ins_err = _audit_insert(db, v, desc)
+            if (ins_err |> is_some) {
+                panic(ins_err |> unwrap)        // recover handles ROLLBACK + Err propagation
+            }
+            stamped += 1
+        }
+        let cerr = db |> try_exec("COMMIT")
+        if (cerr |> is_some) {
+            db |> try_exec("ROLLBACK") |> _log_warn_on_some
+            commit_err = cerr |> unwrap
+        }
+    } recover {
+        let underlying = string(this_context().last_exception) |> rtrim
+        db |> try_exec("ROLLBACK") |> _log_warn_on_some
+        inner_err = "baseline(version={version}) failed: {underlying}"
+    }
+    if (!empty(commit_err)) {
+        return err(commit_err, type<int>)
+    }
+    if (!empty(inner_err)) {
+        return err(inner_err, type<int>)
+    }
+    return ok(stamped, type<string>)
+}
+
+
+def baseline(db : SqlRunner; version : int) : void {
+    //! Strict variant of ``try_baseline``. Panics on error.
+    let r <- db |> try_baseline(version)
+    if (r |> is_err) {
+        panic(r |> unwrap_err)
+    }
+}
+
+
+// ===== with_latest_sqlite — convenience wrapper =====
+
+def with_latest_sqlite(path : string; blk : block<(db : SqlRunner) : void>) : void {
+    //! Combines ``with_sqlite(path)`` + ``apply_recommended_pragmas`` + ``migrate_to_latest``.
+    //! Preferred form for app code; the explicit two-step ``with_sqlite + migrate_to_latest``
+    //! sequence stays available for tools/CI that may want to inspect before migrating.
+    with_sqlite(path) $(db) {
+        db |> apply_recommended_pragmas()
+        db |> migrate_to_latest()
+        invoke(blk, db)
+    }
+}
+
+
+// ===== Compile-time migration registry helpers (used by [sql_migration] dup detection) =====
+
+struct private RegisteredMigration {
+    version : int
+    fn_name : string
+    mod_name : string
+}
+
+
+def private _collect_registered_migrations(var out : array<RegisteredMigration>) : void {
+    // Single pass over compiling_program() — collects (version, fn, mod) for every [sql_migration].
+    let prog = compiling_program() |> get_ptr()
+    prog |> for_each_module_no_order($(mod) {
+        mod |> for_each_module_function($(var f : FunctionPtr) {
+            for (ann in f.annotations) {
+                if (ann == null) {
+                    continue
+                }
+                if (ann.annotation.name != "sql_migration") {
+                    continue
+                }
+                let vArg = ann.arguments |> find_arg("version")
+                if (!(vArg is tInt)) {
+                    continue
+                }
+                var entry <- RegisteredMigration(
+                    version = vArg as tInt,
+                    fn_name = "{f.name}",
+                    mod_name = "{mod.name}")
+                out |> push_clone(entry)
+            }
+        })
+    })
+}
+
+
+// ===== [sql_migration] annotation =====
+
+[function_macro(name="sql_migration")]
+class SqlMigrationMacro : AstFunctionAnnotation {
+    //! Marks ``def fn(db : SqlRunner)`` as a versioned schema migration; runs once per DB.
+    //! Args: ``version=<int>`` (required, positive, unique), optional ``description``/``vacuum``/``analyze``.
+    def override apply(var func : FunctionPtr; var group : ModuleGroup;
+                       args : AnnotationArgumentList; var errors : das_string) : bool {
+        if (func.fromGeneric != null) {
+            errors := "[sql_migration] is not supported on generic functions"
+            return false
+        }
+        // Args
+        let versionArg = args |> find_arg("version")
+        if (!(versionArg is tInt)) {
+            errors := "[sql_migration]: version=<int> is required (positive integer)"
+            return false
+        }
+        let version = versionArg as tInt
+        if (version <= 0) {
+            errors := "[sql_migration]: version={version} must be a positive integer"
+            return false
+        }
+        var description = ""
+        let descArg = args |> find_arg("description")
+        if (descArg is tString) {
+            description = descArg as tString
+        } elif (!(descArg is nothing)) {
+            errors := "[sql_migration]: description= must be a string literal"
+            return false
+        }
+        var vacuum = false
+        let vacArg = args |> find_arg("vacuum")
+        if (vacArg is tBool) {
+            vacuum = vacArg as tBool
+        } elif (!(vacArg is nothing)) {
+            errors := "[sql_migration]: vacuum= must be a bool literal (true/false)"
+            return false
+        }
+        var analyze = false
+        let anaArg = args |> find_arg("analyze")
+        if (anaArg is tBool) {
+            analyze = anaArg as tBool
+        } elif (!(anaArg is nothing)) {
+            errors := "[sql_migration]: analyze= must be a bool literal (true/false)"
+            return false
+        }
+        // Signature: def fn(db : SqlRunner) : void
+        let nArgs = func.arguments |> length
+        if (nArgs != 1) {
+            errors := "[sql_migration] '{func.name}' must take exactly one argument of type SqlRunner; got {nArgs}"
+            return false
+        }
+        let arg0Type = func.arguments[0]._type
+        if (arg0Type.structType == null || arg0Type.structType.name != "SqlRunner") {
+            errors := "[sql_migration] '{func.name}': single argument must be of type SqlRunner; got '{describe(arg0Type)}'"
+            return false
+        }
+        if (func.result.baseType != Type.tVoid && func.result.baseType != Type.autoinfer) {
+            errors := "[sql_migration] '{func.name}': must return void; got '{describe(func.result)}'"
+            return false
+        }
+        let funcDasName = "{func.name}"
+        let modName = "{compiling_module().name}"
+        // Cross-module dup-version detection. The compile-time scan catches the typical
+        // "two devs picked version=N" merge case; runtime _verify_no_duplicate_versions()
+        // catches anything that slips past (dynamic plugin loading, etc.).
+        var registered : array<RegisteredMigration>
+        _collect_registered_migrations(registered)
+        for (e in registered) {
+            if (e.version != version) {
+                continue
+            }
+            if (e.fn_name == funcDasName && e.mod_name == modName) {
+                continue                     // self
+            }
+            errors := "duplicate [sql_migration(version={version})]:\n  registered: {e.fn_name} in module '{e.mod_name}'\n  duplicate:  {funcDasName} in module '{modName}'\nhint: pick a different version number for one of them, or merge the bodies"
+            return false
+        }
+        // Build ExprAddr to the user's function with explicit funcType
+        var fnType = new TypeDecl(at = func.at, baseType = Type.tFunction)
+        for (a in func.arguments) {
+            fnType.argTypes |> emplace_new <| clone_type(a._type)
+        }
+        fnType.firstType = clone_type(func.result)
+        var fnAddr = new ExprAddr(at = func.at, target := "__::{funcDasName}", funcType <- fnType)
+        // Append registration into per-module init function `register`sql`migrations`
+        var reg <- setup_call_list("register`sql`migrations", func.at, true/*isInit*/, true/*isPrivate*/)
+        reg.list |> emplace_new <| qmacro_block() {
+            sql_migrate::_add_migration_entry($v(version), $v(description), $v(vacuum), $v(analyze),
+                $e(fnAddr), $v(funcDasName), $v(modName))
+        }
+        return true
+    }
+}

--- a/modules/dasSQLITE/daslib/sql_migrate.das
+++ b/modules/dasSQLITE/daslib/sql_migrate.das
@@ -151,7 +151,7 @@ def private _audit_insert(db : SqlRunner; version : int; description : string) :
 }
 
 
-def private _format_versions_csv(pending : array<MigrationEntry>; applied_count : int; failed_version : int) : string {
+def private _format_versions_csv(pending : array<MigrationEntry>; applied_count : int) : string {
     // "v4, v5" — every applied migration (inside the txn) plus the failing one — all rolled back.
     var parts : array<string>
     let limit = applied_count + 1
@@ -225,6 +225,23 @@ def private _migrate_inner(db : SqlRunner) : Result<int, string> {
     if (begin_err |> is_some) {
         return err(begin_err |> unwrap, type<int>)
     }
+    // Concurrent-runner guard (Scenario 8): re-read MAX(version) under the write lock and drop pending entries another runner already applied between our optimistic read and BEGIN IMMEDIATE.
+    let current_locked = _scalar_int_or_zero(db, "SELECT COALESCE(MAX(version), 0) FROM __schema_version")
+    if (current_locked != current) {
+        pending_idx = 0
+        while (pending_idx < pending |> length) {
+            if (pending[pending_idx].version <= current_locked) {
+                pending |> erase(pending_idx)
+            } else {
+                pending_idx += 1
+            }
+        }
+        if (pending |> empty) {
+            // Another runner did our work. COMMIT releases the lock cleanly (no DDL was issued).
+            db |> try_exec("COMMIT") |> _log_warn_on_some
+            return ok(0, type<string>)
+        }
+    }
     // Mutables shared between try and recover.
     var applied_count = 0
     var any_vacuum = false
@@ -254,7 +271,7 @@ def private _migrate_inner(db : SqlRunner) : Result<int, string> {
         }
     } recover {
         let underlying = string(this_context().last_exception) |> rtrim
-        let rolled_back_str = _format_versions_csv(pending, applied_count, failed_version)
+        let rolled_back_str = _format_versions_csv(pending, applied_count)
         to_log(LOG_ERROR, "migration v{failed_version} '{failed_desc}' FAILED — rolled back call\n  underlying error: {underlying}\n  rolled back: {rolled_back_str}\n")
         db |> try_exec("ROLLBACK") |> _log_warn_on_some
         let layer2_hint = audit_was_empty_before && (failed_version == pending[0].version)
@@ -300,8 +317,8 @@ def private _audit_table_exists(db : SqlRunner) : bool {
 
 
 def current_schema_version(db : SqlRunner) : int {
-    //! Highest applied migration version, or 0 if no migrations have ever been applied
-    //! to this DB (or the audit table doesn't exist yet).
+    //! Highest applied migration version, or 0 if no migrations were applied, the audit table is absent, or a transient SQLite error (e.g. ``SQLITE_BUSY``) blocks the read.
+    //! Use ``try_current_schema_version`` to distinguish "nothing applied" from "couldn't tell".
     if (!_audit_table_exists(db)) {
         return 0
     }

--- a/src/simulate/simulate_fusion_at.cpp
+++ b/src/simulate/simulate_fusion_at.cpp
@@ -87,7 +87,9 @@ namespace das {
             auto pl = l.compute##COMPUTEL(context); \
             auto rr = uint32_t(r.subexpr->evalInt(context)); \
             if ( rr >= range ) context.throw_error_at(debugInfo,"index out of range, %u of %u%s", rr, range, errorMessage); \
-            return v_ldu((const float *)(pl + rr*stride + offset)); \
+            vec4f __r; \
+            DAS_LDU_WORKHORSE(__r, pl + rr*stride + offset, CTYPE); \
+            return __r; \
         } \
     };
 
@@ -99,7 +101,9 @@ namespace das {
             auto pl = l.compute##COMPUTEL(context); \
             auto rr = *((uint32_t *)r.compute##COMPUTER(context)); \
             if ( rr >= range ) context.throw_error_at(debugInfo,"index out of range, %u of %u%s", rr, range, errorMessage); \
-            return v_ldu((const float *)(pl + rr*stride + offset)); \
+            vec4f __r; \
+            DAS_LDU_WORKHORSE(__r, pl + rr*stride + offset, CTYPE); \
+            return __r; \
         } \
     };
 

--- a/src/simulate/simulate_fusion_at_array.cpp
+++ b/src/simulate/simulate_fusion_at_array.cpp
@@ -85,7 +85,9 @@ namespace das {
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = uint32_t(r.subexpr->evalInt(context)); \
             if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %u", rr, pl->size); \
-            return v_ldu((const float *)(pl->data + rr*stride + offset)); \
+            vec4f __r; \
+            DAS_LDU_WORKHORSE(__r, pl->data + rr*stride + offset, CTYPE); \
+            return __r; \
         } \
     };
 
@@ -97,7 +99,9 @@ namespace das {
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = *((uint32_t *)r.compute##COMPUTER(context)); \
             if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %u", rr, pl->size); \
-            return v_ldu((const float *)(pl->data + rr*stride + offset)); \
+            vec4f __r; \
+            DAS_LDU_WORKHORSE(__r, pl->data + rr*stride + offset, CTYPE); \
+            return __r; \
         } \
     };
 

--- a/src/simulate/simulate_fusion_call1.cpp
+++ b/src/simulate/simulate_fusion_call1.cpp
@@ -47,8 +47,8 @@ namespace das {
         }
         SimFunction * fnPtr = nullptr;
         SimNode * cmresEval = nullptr;
-        // Operand byte size; stamped at fuse-time. Default 16 mirrors legacy v_ldu over-read.
-        uint8_t loadSize = 16;
+        // Operand byte size; always overwritten by IMPLEMENT_OP1_SETUP_NODE.
+        uint8_t loadSize = 0;
     };
 
 #define EVAL_NODE(TYPE,CTYPE)\
@@ -75,7 +75,16 @@ namespace das {
     rn->fnPtr = sn->fnPtr; \
     rn->cmresEval = sn->cmresEval; \
     rn->baseType = Type::none; \
-    rn->loadSize = (sn->types && sn->types[0] && sn->types[0]->size <= 16) ? (uint8_t)sn->types[0]->size : 16;
+    DAS_VERIFYF(sn->fnPtr && sn->fnPtr->debugInfo && sn->fnPtr->debugInfo->count >= 1 \
+        && sn->fnPtr->debugInfo->fields && sn->fnPtr->debugInfo->fields[0], \
+        "fusion call1: fnPtr/debugInfo/fields missing\n"); \
+    { \
+        auto t0 = sn->fnPtr->debugInfo->fields[0]; \
+        uint32_t s0 = (t0->isRef() || t0->isRefType()) ? (uint32_t)sizeof(void*) : t0->size; \
+        DAS_VERIFYF(s0 <= 16, "fusion call1: load size %u oversized fn=%s\n", \
+            (unsigned)s0, sn->fnPtr->name ? sn->fnPtr->name : "?"); \
+        rn->loadSize = (uint8_t)s0; \
+    }
 
 __forceinline SimNode * safeArg1 ( SimNode * node, int index ) {
     auto cb = static_cast<SimNode_CallBase *>(node);

--- a/src/simulate/simulate_fusion_call1.cpp
+++ b/src/simulate/simulate_fusion_call1.cpp
@@ -47,6 +47,8 @@ namespace das {
         }
         SimFunction * fnPtr = nullptr;
         SimNode * cmresEval = nullptr;
+        // Operand byte size; stamped at fuse-time. Default 16 mirrors legacy v_ldu over-read.
+        uint8_t loadSize = 16;
     };
 
 #define EVAL_NODE(TYPE,CTYPE)\
@@ -72,7 +74,8 @@ namespace das {
     auto sn = (SimNode_CallBase *)node; \
     rn->fnPtr = sn->fnPtr; \
     rn->cmresEval = sn->cmresEval; \
-    rn->baseType = Type::none;
+    rn->baseType = Type::none; \
+    rn->loadSize = (sn->types && sn->types[0] && sn->types[0]->size <= 16) ? (uint8_t)sn->types[0]->size : 16;
 
 __forceinline SimNode * safeArg1 ( SimNode * node, int index ) {
     auto cb = static_cast<SimNode_CallBase *>(node);
@@ -90,7 +93,8 @@ __forceinline SimNode * safeArg1 ( SimNode * node, int index ) {
         NO_ASAN_INLINE vec4f compute(Context & context) { \
             DAS_PROFILE_NODE \
             vec4f argValues[1]; \
-            argValues[0] = v_ldu((const float *)subexpr.compute##COMPUTE(context)); \
+            argValues[0] = v_zero(); \
+            memcpy(&argValues[0], subexpr.compute##COMPUTE(context), loadSize); \
             auto aa = context.abiArg; \
             context.abiArg = argValues; \
             auto res = fnPtr->code->eval(context); \
@@ -117,7 +121,8 @@ __forceinline SimNode * safeArg1 ( SimNode * node, int index ) {
         NO_ASAN_INLINE vec4f compute(Context & context) { \
             DAS_PROFILE_NODE \
             vec4f argValues[1]; \
-            argValues[0] = v_ldu((const float *)subexpr.compute##COMPUTE(context)); \
+            argValues[0] = v_zero(); \
+            memcpy(&argValues[0], subexpr.compute##COMPUTE(context), loadSize); \
             return context.call(fnPtr, argValues, &debugInfo); \
         } \
         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \

--- a/src/simulate/simulate_fusion_call2.cpp
+++ b/src/simulate/simulate_fusion_call2.cpp
@@ -44,6 +44,9 @@ namespace das {
         }
         SimFunction * fnPtr = nullptr;
         SimNode * cmresEval = nullptr;
+        // Per-side operand byte size; stamped at fuse-time. Default 16 mirrors legacy v_ldu over-read.
+        uint8_t leftLoadSize = 16;
+        uint8_t rightLoadSize = 16;
     };
 
 
@@ -72,7 +75,8 @@ namespace das {
             DAS_PROFILE_NODE \
             vec4f argValues[2]; \
             argValues[0] = l.subexpr->eval(context); \
-            argValues[1] = v_ldu((const float *)r.compute##COMPUTEL(context)); \
+            argValues[1] = v_zero(); \
+            memcpy(&argValues[1], r.compute##COMPUTEL(context), rightLoadSize); \
             return context.call(fnPtr, argValues, &debugInfo); \
         } \
         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
@@ -88,7 +92,8 @@ namespace das {
         NO_ASAN_INLINE auto compute ( Context & context ) { \
             DAS_PROFILE_NODE \
             vec4f argValues[2]; \
-            argValues[0] = v_ldu((const float *)l.compute##COMPUTER(context)); \
+            argValues[0] = v_zero(); \
+            memcpy(&argValues[0], l.compute##COMPUTER(context), leftLoadSize); \
             argValues[1] = r.subexpr->eval(context); \
             return context.call(fnPtr, argValues, &debugInfo); \
         } \
@@ -105,8 +110,10 @@ namespace das {
         NO_ASAN_INLINE auto compute ( Context & context ) { \
             DAS_PROFILE_NODE \
             vec4f argValues[2]; \
-            argValues[0] = v_ldu((const float *)l.compute##COMPUTEL(context)); \
-            argValues[1] = v_ldu((const float *)r.compute##COMPUTER(context)); \
+            argValues[0] = v_zero(); \
+            memcpy(&argValues[0], l.compute##COMPUTEL(context), leftLoadSize); \
+            argValues[1] = v_zero(); \
+            memcpy(&argValues[1], r.compute##COMPUTER(context), rightLoadSize); \
             return context.call(fnPtr, argValues, &debugInfo); \
         } \
         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
@@ -121,7 +128,9 @@ namespace das {
     auto sn = (SimNode_CallBase *)node; \
     rn->fnPtr = sn->fnPtr; \
     rn->cmresEval = sn->cmresEval; \
-    rn->baseType = Type::none;
+    rn->baseType = Type::none; \
+    rn->leftLoadSize  = (sn->types && sn->types[0] && sn->types[0]->size <= 16) ? (uint8_t)sn->types[0]->size : 16; \
+    rn->rightLoadSize = (sn->types && sn->types[1] && sn->types[1]->size <= 16) ? (uint8_t)sn->types[1]->size : 16;
 
 __forceinline SimNode * safeArg2 ( SimNode * node, int index ) {
     auto cb = static_cast<SimNode_CallBase *>(node);
@@ -146,7 +155,8 @@ IMPLEMENT_ANY_OP2(__forceinline, Call, Ptr, StringPtr)
             auto cmres = cmresEval->evalPtr(context); \
             vec4f argValues[2]; \
             argValues[0] = l.subexpr->eval(context); \
-            argValues[1] = v_ldu((const float *)r.compute##COMPUTEL(context)); \
+            argValues[1] = v_zero(); \
+            memcpy(&argValues[1], r.compute##COMPUTEL(context), rightLoadSize); \
             return cast<char *>::to(context.callWithCopyOnReturn(fnPtr, argValues, cmres, &debugInfo)); \
         } \
         DAS_PTR_NODE; \
@@ -160,7 +170,8 @@ IMPLEMENT_ANY_OP2(__forceinline, Call, Ptr, StringPtr)
             DAS_PROFILE_NODE \
             auto cmres = cmresEval->evalPtr(context); \
             vec4f argValues[2]; \
-            argValues[0] = v_ldu((const float *)l.compute##COMPUTER(context)); \
+            argValues[0] = v_zero(); \
+            memcpy(&argValues[0], l.compute##COMPUTER(context), leftLoadSize); \
             argValues[1] = r.subexpr->eval(context); \
             return cast<char *>::to(context.callWithCopyOnReturn(fnPtr, argValues, cmres, &debugInfo)); \
         } \
@@ -175,8 +186,10 @@ IMPLEMENT_ANY_OP2(__forceinline, Call, Ptr, StringPtr)
             DAS_PROFILE_NODE \
             auto cmres = cmresEval->evalPtr(context); \
             vec4f argValues[2]; \
-            argValues[0] = v_ldu((const float *)l.compute##COMPUTEL(context)); \
-            argValues[1] = v_ldu((const float *)r.compute##COMPUTER(context)); \
+            argValues[0] = v_zero(); \
+            memcpy(&argValues[0], l.compute##COMPUTEL(context), leftLoadSize); \
+            argValues[1] = v_zero(); \
+            memcpy(&argValues[1], r.compute##COMPUTER(context), rightLoadSize); \
             return cast<char *>::to(context.callWithCopyOnReturn(fnPtr, argValues, cmres, &debugInfo)); \
         } \
         DAS_PTR_NODE; \
@@ -196,7 +209,8 @@ IMPLEMENT_ANY_OP2(__forceinline, CallAndCopyOrMove, Ptr, StringPtr)
             DAS_PROFILE_NODE \
             vec4f argValues[2]; \
             argValues[0] = l.subexpr->eval(context); \
-            argValues[1] = v_ldu((const float *)r.compute##COMPUTEL(context)); \
+            argValues[1] = v_zero(); \
+            memcpy(&argValues[1], r.compute##COMPUTEL(context), rightLoadSize); \
             auto aa = context.abiArg; \
             context.abiArg = argValues; \
             auto res = fnPtr->code->eval(context); \
@@ -217,7 +231,8 @@ IMPLEMENT_ANY_OP2(__forceinline, CallAndCopyOrMove, Ptr, StringPtr)
         NO_ASAN_INLINE auto compute ( Context & context ) { \
             DAS_PROFILE_NODE \
             vec4f argValues[2]; \
-            argValues[0] = v_ldu((const float *)l.compute##COMPUTER(context)); \
+            argValues[0] = v_zero(); \
+            memcpy(&argValues[0], l.compute##COMPUTER(context), leftLoadSize); \
             argValues[1] = r.subexpr->eval(context); \
             auto aa = context.abiArg; \
             context.abiArg = argValues; \
@@ -239,8 +254,10 @@ IMPLEMENT_ANY_OP2(__forceinline, CallAndCopyOrMove, Ptr, StringPtr)
         NO_ASAN_INLINE auto compute ( Context & context ) { \
             DAS_PROFILE_NODE \
             vec4f argValues[2]; \
-            argValues[0] = v_ldu((const float *)l.compute##COMPUTEL(context)); \
-            argValues[1] = v_ldu((const float *)r.compute##COMPUTER(context)); \
+            argValues[0] = v_zero(); \
+            memcpy(&argValues[0], l.compute##COMPUTEL(context), leftLoadSize); \
+            argValues[1] = v_zero(); \
+            memcpy(&argValues[1], r.compute##COMPUTER(context), rightLoadSize); \
             auto aa = context.abiArg; \
             context.abiArg = argValues; \
             auto res = fnPtr->code->eval(context); \

--- a/src/simulate/simulate_fusion_call2.cpp
+++ b/src/simulate/simulate_fusion_call2.cpp
@@ -44,9 +44,9 @@ namespace das {
         }
         SimFunction * fnPtr = nullptr;
         SimNode * cmresEval = nullptr;
-        // Per-side operand byte size; stamped at fuse-time. Default 16 mirrors legacy v_ldu over-read.
-        uint8_t leftLoadSize = 16;
-        uint8_t rightLoadSize = 16;
+        // Per-side operand byte size; always overwritten by IMPLEMENT_OP2_SETUP_NODE.
+        uint8_t leftLoadSize = 0;
+        uint8_t rightLoadSize = 0;
     };
 
 
@@ -129,8 +129,20 @@ namespace das {
     rn->fnPtr = sn->fnPtr; \
     rn->cmresEval = sn->cmresEval; \
     rn->baseType = Type::none; \
-    rn->leftLoadSize  = (sn->types && sn->types[0] && sn->types[0]->size <= 16) ? (uint8_t)sn->types[0]->size : 16; \
-    rn->rightLoadSize = (sn->types && sn->types[1] && sn->types[1]->size <= 16) ? (uint8_t)sn->types[1]->size : 16;
+    DAS_VERIFYF(sn->fnPtr && sn->fnPtr->debugInfo && sn->fnPtr->debugInfo->count >= 2 \
+        && sn->fnPtr->debugInfo->fields && sn->fnPtr->debugInfo->fields[0] && sn->fnPtr->debugInfo->fields[1], \
+        "fusion call2: fnPtr/debugInfo/fields missing\n"); \
+    { \
+        auto t0 = sn->fnPtr->debugInfo->fields[0]; \
+        auto t1 = sn->fnPtr->debugInfo->fields[1]; \
+        uint32_t s0 = (t0->isRef() || t0->isRefType()) ? (uint32_t)sizeof(void*) : t0->size; \
+        uint32_t s1 = (t1->isRef() || t1->isRefType()) ? (uint32_t)sizeof(void*) : t1->size; \
+        DAS_VERIFYF(s0 <= 16 && s1 <= 16, \
+            "fusion call2: load size oversized L=%u R=%u fn=%s\n", \
+            (unsigned)s0, (unsigned)s1, sn->fnPtr->name ? sn->fnPtr->name : "?"); \
+        rn->leftLoadSize  = (uint8_t)s0; \
+        rn->rightLoadSize = (uint8_t)s1; \
+    }
 
 __forceinline SimNode * safeArg2 ( SimNode * node, int index ) {
     auto cb = static_cast<SimNode_CallBase *>(node);

--- a/src/simulate/simulate_fusion_op1_return.cpp
+++ b/src/simulate/simulate_fusion_op1_return.cpp
@@ -24,7 +24,7 @@ namespace das {
             DAS_PROFILE_NODE \
             auto lv =  subexpr.compute##COMPUTE(context); \
             context.stopFlags |= EvalFlags::stopForReturn; \
-            context.abiResult() = v_ldu((const float *) lv); \
+            DAS_LDU_WORKHORSE(context.abiResult(), lv, CTYPE); \
             return v_zero(); \
         } \
         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
@@ -72,7 +72,7 @@ IMPLEMENT_ANY_OP1_FUSION_POINT(__forceinline,Return,,vec4f,vec4f)
             DAS_PROFILE_NODE \
             auto lv =  subexpr.compute##COMPUTE(context); \
             context.stopFlags |= EvalFlags::stopForReturn; \
-            context.abiResult() = v_ldu((const float *) lv); \
+            DAS_LDU_WORKHORSE(context.abiResult(), lv, CTYPE); \
             return v_zero(); \
         } \
         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \

--- a/src/simulate/simulate_fusion_op2_scalar_vec.cpp
+++ b/src/simulate/simulate_fusion_op2_scalar_vec.cpp
@@ -29,7 +29,7 @@ namespace das {
     IMPLEMENT_OP2_NUMERIC_VEC(DivVecScal);
 
 #undef FUSION_OP_PTR_VALUE_RIGHT
-#define FUSION_OP_PTR_VALUE_RIGHT(CTYPE,expr)   (v_ldu((const float *)(expr)))
+#define FUSION_OP_PTR_VALUE_RIGHT(CTYPE,expr)   ([&]() -> vec4f { vec4f __v; DAS_LDU_WORKHORSE(__v, (expr), CTYPE); return __v; }())
 
 #undef FUSION_OP_PTR_VALUE_LEFT
 #define FUSION_OP_PTR_VALUE_LEFT(CTYPE,expr)    (v_ldu_x((const float *)(expr)))

--- a/src/simulate/simulate_fusion_ptrfdr.cpp
+++ b/src/simulate/simulate_fusion_ptrfdr.cpp
@@ -133,7 +133,9 @@ namespace das {
             DAS_PROFILE_NODE \
             auto prv = (char **) subexpr.compute##COMPUTE(context); \
             if ( !prv || !*prv ) context.throw_error_at(debugInfo,"dereferencing null pointer%s",errorMessage); \
-            return v_ldu((const float *) ((*prv)+offset)); \
+            vec4f __r; \
+            DAS_LDU_WORKHORSE(__r, (*prv)+offset, CTYPE); \
+            return __r; \
         } \
     };
 
@@ -150,7 +152,9 @@ namespace das {
         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
             DAS_PROFILE_NODE \
             auto prv = (char **) subexpr.compute##COMPUTE(context); \
-            return v_ldu((const float *) ((*prv)+offset)); \
+            vec4f __r; \
+            DAS_LDU_WORKHORSE(__r, (*prv)+offset, CTYPE); \
+            return __r; \
         } \
     };
 

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -114,6 +114,7 @@ IF(NOT DAS_SQLITE_DISABLED)
     SET(AOT_DASSQLITE_MODULE_FILES
         modules/dasSQLITE/daslib/sqlite_boost.das
         modules/dasSQLITE/daslib/sqlite_linq.das
+        modules/dasSQLITE/daslib/sql_migrate.das
     )
 ENDIF()
 

--- a/tests/dasSQLITE/failed_sql_migration_dup_version.das
+++ b/tests/dasSQLITE/failed_sql_migration_dup_version.das
@@ -1,0 +1,17 @@
+options gen2
+
+// Two migrations with version=2 in the same module — must fail at compile time
+// with the [sql_migration] dup-version error (error 30111).
+expect 30111:1
+
+require sqlite/sql_migrate
+
+[sql_migration(version=2, description="first")]
+def migration_a(db : SqlRunner) {
+    db |> exec("SELECT 1")
+}
+
+[sql_migration(version=2, description="second — same version, should fail to compile")]
+def migration_b(db : SqlRunner) {
+    db |> exec("SELECT 2")
+}

--- a/tests/dasSQLITE/migrate_01_fresh_creates_audit.das
+++ b/tests/dasSQLITE/migrate_01_fresh_creates_audit.das
@@ -1,0 +1,40 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "create users")]
+def m_users(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+}
+
+[test]
+def test_audit_table_appears_after_migrate(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let exists = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='__schema_version'",
+        type<int>)
+    t |> equal(exists, 1, "__schema_version must exist after migrate_to_latest")
+}
+
+[test]
+def test_audit_table_has_locked_3_column_shape(t : T?) {
+    // Shape locked 2026-05-04: (version INTEGER PK, description TEXT NOT NULL DEFAULT '', applied_at INTEGER NOT NULL).
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let cols = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('__schema_version')", type<int>)
+    t |> equal(cols, 3, "audit table must have exactly 3 columns")
+    let ver_pk = db |> query_scalar(
+        "SELECT pk FROM pragma_table_info('__schema_version') WHERE name='version'", type<int>)
+    t |> equal(ver_pk, 1, "version column must be the PK")
+    let desc_notnull = db |> query_scalar(
+        "SELECT \"notnull\" FROM pragma_table_info('__schema_version') WHERE name='description'",
+        type<int>)
+    t |> equal(desc_notnull, 1, "description must be NOT NULL")
+    let applied_notnull = db |> query_scalar(
+        "SELECT \"notnull\" FROM pragma_table_info('__schema_version') WHERE name='applied_at'",
+        type<int>)
+    t |> equal(applied_notnull, 1, "applied_at must be NOT NULL")
+}

--- a/tests/dasSQLITE/migrate_02_fresh_runs_all.das
+++ b/tests/dasSQLITE/migrate_02_fresh_runs_all.das
@@ -1,0 +1,51 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "create users")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+}
+
+[sql_migration(version = 2, description = "add email")]
+def m2(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
+}
+
+[sql_migration(version = 3, description = "add score")]
+def m3(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Score INTEGER NOT NULL DEFAULT 0")
+}
+
+[test]
+def test_fresh_runs_all_three(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let n = db |> migrate_to_latest()
+    t |> equal(n, 3, "fresh DB must apply all 3 registered migrations")
+}
+
+[test]
+def test_fresh_returns_count(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    t |> equal(db |> migrate_to_latest(), 3, "first call applies 3")
+    t |> equal(db |> migrate_to_latest(), 0, "second call applies 0 (no-op rerun)")
+}
+
+[test]
+def test_fresh_runs_each_body(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let cols = db |> query_scalar("SELECT COUNT(*) FROM pragma_table_info('users')", type<int>)
+    t |> equal(cols, 4, "users must have Id+Name+Email+Score (4 columns) after all migrations")
+}
+
+[test]
+def test_audit_has_three_rows_with_versions(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let n = db |> query_scalar("SELECT COUNT(*) FROM __schema_version", type<int>)
+    t |> equal(n, 3, "__schema_version must have one row per applied migration")
+    let max_v = db |> query_scalar("SELECT MAX(version) FROM __schema_version", type<int>)
+    t |> equal(max_v, 3, "MAX(version) must be 3")
+}

--- a/tests/dasSQLITE/migrate_06_idempotent_rerun.das
+++ b/tests/dasSQLITE/migrate_06_idempotent_rerun.das
@@ -1,0 +1,26 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "create users")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+}
+
+[test]
+def test_second_call_returns_zero(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    t |> equal(db |> migrate_to_latest(), 0, "rerun on up-to-date DB must return 0")
+}
+
+[test]
+def test_second_call_does_not_add_audit_rows(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let before = db |> query_scalar("SELECT COUNT(*) FROM __schema_version", type<int>)
+    db |> migrate_to_latest()
+    let after = db |> query_scalar("SELECT COUNT(*) FROM __schema_version", type<int>)
+    t |> equal(before, after, "rerun must not add audit rows")
+}

--- a/tests/dasSQLITE/migrate_09_steady_state.das
+++ b/tests/dasSQLITE/migrate_09_steady_state.das
@@ -1,0 +1,33 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "users")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+}
+
+[sql_migration(version = 2, description = "add email")]
+def m2(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
+}
+
+[test]
+def test_steady_state_v1_to_v2(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    // Simulate user already at v1 by inserting an audit row.
+    db |> exec("CREATE TABLE __schema_version (version INTEGER PRIMARY KEY, description TEXT NOT NULL DEFAULT '', applied_at INTEGER NOT NULL)")
+    db |> exec("INSERT INTO __schema_version (version, description, applied_at) VALUES (1, 'pre-existing', 1000)")
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+
+    let n = db |> migrate_to_latest()
+    t |> equal(n, 1, "should apply only v2")
+
+    let max_v = db |> query_scalar("SELECT MAX(version) FROM __schema_version", type<int>)
+    t |> equal(max_v, 2, "audit max must be 2")
+
+    let has_email = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='Email'", type<int>)
+    t |> equal(has_email, 1, "Email column must be present after v2")
+}

--- a/tests/dasSQLITE/migrate_10_strict_forward.das
+++ b/tests/dasSQLITE/migrate_10_strict_forward.das
@@ -1,0 +1,40 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+// Strict-forward pending detection (Scenario 2 lock): pending = registered with version > MAX(applied),
+// NOT set-difference. If audit has {1,3}, v2 is silently skipped because MAX > 2.
+
+[sql_migration(version = 1, description = "users")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+}
+
+[sql_migration(version = 2, description = "v2 — should be skipped")]
+def m2(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
+}
+
+[sql_migration(version = 3, description = "v3 — already in audit")]
+def m3(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Score INTEGER NOT NULL DEFAULT 0")
+}
+
+[test]
+def test_skips_gap_silently(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    // Set up: applied = {1, 3} (manually, simulating dev-branch divergence).
+    db |> exec("CREATE TABLE __schema_version (version INTEGER PRIMARY KEY, description TEXT NOT NULL DEFAULT '', applied_at INTEGER NOT NULL)")
+    db |> exec("INSERT INTO __schema_version (version, description, applied_at) VALUES (1, 'a', 1000)")
+    db |> exec("INSERT INTO __schema_version (version, description, applied_at) VALUES (3, 'c', 1000)")
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Score INTEGER NOT NULL DEFAULT 0)")
+
+    let n = db |> migrate_to_latest()
+    t |> equal(n, 0, "must apply 0 — strict-forward sees MAX=3, nothing > 3")
+
+    // v2's body did NOT run — Email column must NOT exist.
+    let has_email = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='Email'", type<int>)
+    t |> equal(has_email, 0, "Email column must NOT exist (v2 skipped)")
+}

--- a/tests/dasSQLITE/migrate_12_description_persists.das
+++ b/tests/dasSQLITE/migrate_12_description_persists.das
@@ -1,0 +1,18 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "add email column")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+}
+
+[test]
+def test_description_lands_in_audit_row(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let desc = db |> query_scalar(
+        "SELECT description FROM __schema_version WHERE version=1", type<string>)
+    t |> equal(desc, "add email column", "audit row description must match the annotation")
+}

--- a/tests/dasSQLITE/migrate_13_data_preserved.das
+++ b/tests/dasSQLITE/migrate_13_data_preserved.das
@@ -1,0 +1,32 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "create users")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+}
+
+[sql_migration(version = 2, description = "add email default ''")]
+def m2(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
+}
+
+[test]
+def test_existing_rows_preserved_after_alter(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    // Apply v1 only (manually, then INSERT some data).
+    db |> exec("CREATE TABLE __schema_version (version INTEGER PRIMARY KEY, description TEXT NOT NULL DEFAULT '', applied_at INTEGER NOT NULL)")
+    db |> exec("INSERT INTO __schema_version (version, description, applied_at) VALUES (1, 'pre', 1000)")
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+    db |> exec("INSERT INTO users (Name) VALUES ('alice')")
+    db |> exec("INSERT INTO users (Name) VALUES ('bob')")
+
+    db |> migrate_to_latest()                  // applies v2
+
+    let count = db |> query_scalar("SELECT COUNT(*) FROM users", type<int>)
+    t |> equal(count, 2, "existing rows must survive ADD COLUMN")
+    let alice_email = db |> query_scalar("SELECT Email FROM users WHERE Name='alice'", type<string>)
+    t |> equal(alice_email, "", "default '' must apply to pre-existing rows")
+}

--- a/tests/dasSQLITE/migrate_22_failure_rolls_back.das
+++ b/tests/dasSQLITE/migrate_22_failure_rolls_back.das
@@ -1,0 +1,83 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "good")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+}
+
+[sql_migration(version = 2, description = "bad")]
+def m2(db : SqlRunner) {
+    db |> exec("CREATE TABLE side_effect (a INT)")
+    db |> exec("THIS IS NOT VALID SQL")          // panic from strict exec
+}
+
+[sql_migration(version = 3, description = "never runs")]
+def m3(db : SqlRunner) {
+    db |> exec("CREATE TABLE three (x INT)")
+}
+
+[test]
+def test_v1_rolls_back_when_v2_fails(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let r <- db |> try_migrate_to_latest()
+    t |> success(r |> is_err, "try_migrate_to_latest must return Err when a migration panics")
+
+    // α-shape: v1 rolls back too. users table must NOT exist.
+    let users_exists = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name='users'", type<int>)
+    t |> equal(users_exists, 0, "v1's effect must roll back too (α-shape)")
+
+    // v2's partial effect (side_effect table) must NOT exist.
+    let side_exists = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name='side_effect'", type<int>)
+    t |> equal(side_exists, 0, "v2's partial effect must roll back")
+
+    // v3 never ran.
+    let three_exists = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name='three'", type<int>)
+    t |> equal(three_exists, 0, "v3 must not have run")
+
+    // Audit table created (eager) but contains zero rows.
+    let audit_rows = db |> query_scalar("SELECT COUNT(*) FROM __schema_version", type<int>)
+    t |> equal(audit_rows, 0, "no audit rows on full rollback")
+
+    // Connection is back in autocommit (transaction closed).
+    t |> success(sqlite3_get_autocommit_(db.sqlite_handle),
+        "autocommit must be restored after failed migrate")
+}
+
+[test]
+def test_strict_form_panics_on_body_failure(t : T?) {
+    // The detailed message-content assertions live in migrate_64 against the try_ form
+    // (Result::Err.unwrap_err is directly inspectable without going through panic
+    // propagation, which AOT-compiled code may not preserve verbatim through
+    // last_exception).
+    var inscope db = open_sqlite(":memory:")
+    var caught = false
+    try {
+        db |> migrate_to_latest()
+    } recover {
+        caught = true
+    }
+    t |> success(caught, "strict migrate_to_latest must panic on body failure")
+}
+
+[test]
+def test_rerun_after_fix_succeeds(t : T?) {
+    // Simulating "fix v2 and re-run" needs the same registry shape, just a working v2.
+    // We can't easily replace the [sql_migration] body at runtime, so this test verifies
+    // the next-best property: after the failure, re-calling try_migrate_to_latest with the
+    // SAME (still-broken) registry produces the SAME failure shape — no DB drift, no
+    // half-state. The "fix and rerun applies cleanly" guarantee is a static property of
+    // the algorithm: pending list rebuilds from MAX(version), which is unchanged.
+    var inscope db = open_sqlite(":memory:")
+    let r1 <- db |> try_migrate_to_latest()
+    let r2 <- db |> try_migrate_to_latest()
+    t |> success(r1 |> is_err, "first call returns Err")
+    t |> success(r2 |> is_err, "rerun against unchanged broken registry still Err")
+    let max_v = db |> query_scalar("SELECT COALESCE(MAX(version), 0) FROM __schema_version", type<int>)
+    t |> equal(max_v, 0, "MAX unchanged across both failed calls")
+}

--- a/tests/dasSQLITE/migrate_24_vacuum.das
+++ b/tests/dasSQLITE/migrate_24_vacuum.das
@@ -1,0 +1,28 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "create table; vacuum after", vacuum = true)]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE big (x BLOB)")
+    db |> exec("INSERT INTO big SELECT randomblob(1024) FROM (WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM n WHERE i<200) SELECT i FROM n)")
+    db |> exec("DELETE FROM big WHERE rowid > 100")
+}
+
+[test]
+def test_vacuum_runs_post_commit(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    // After VACUUM, freelist_count is 0 (all freed pages reclaimed).
+    let freelist = db |> query_scalar("PRAGMA freelist_count", type<int>)
+    t |> equal(freelist, 0, "VACUUM must zero the freelist")
+}
+
+[test]
+def test_audit_row_present_with_vacuum_flag_set(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let n = db |> query_scalar("SELECT COUNT(*) FROM __schema_version", type<int>)
+    t |> equal(n, 1, "audit row present even though VACUUM ran")
+}

--- a/tests/dasSQLITE/migrate_25_analyze.das
+++ b/tests/dasSQLITE/migrate_25_analyze.das
@@ -1,0 +1,23 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "create + analyze", analyze = true)]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+    db |> exec("CREATE INDEX idx_users_name ON users(Name)")
+    db |> exec("INSERT INTO users (Name) VALUES ('alice'), ('bob'), ('charlie')")
+}
+
+[test]
+def test_analyze_populates_sqlite_stat1(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    // ANALYZE creates sqlite_stat1 if missing, populates with index stats.
+    let stat1_exists = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name='sqlite_stat1'", type<int>)
+    t |> equal(stat1_exists, 1, "sqlite_stat1 must exist after ANALYZE")
+    let rows = db |> query_scalar("SELECT COUNT(*) FROM sqlite_stat1", type<int>)
+    t |> success(rows > 0, "sqlite_stat1 must have at least one row for the index")
+}

--- a/tests/dasSQLITE/migrate_28_no_vacuum_no_analyze_default.das
+++ b/tests/dasSQLITE/migrate_28_no_vacuum_no_analyze_default.das
@@ -1,0 +1,19 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "no flags")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+}
+
+[test]
+def test_no_analyze_unless_flagged(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    // ANALYZE was not requested → sqlite_stat1 must NOT exist.
+    let stat1_exists = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name='sqlite_stat1'", type<int>)
+    t |> equal(stat1_exists, 0, "sqlite_stat1 must NOT exist when no migration sets analyze=true")
+}

--- a/tests/dasSQLITE/migrate_29_inspection_pure.das
+++ b/tests/dasSQLITE/migrate_29_inspection_pure.das
@@ -1,0 +1,69 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "alpha")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE x (a INT)")
+}
+
+[sql_migration(version = 2, description = "beta")]
+def m2(db : SqlRunner) {
+    db |> exec("CREATE TABLE y (b INT)")
+}
+
+[test]
+def test_current_zero_on_empty_db(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    t |> equal(db |> current_schema_version(), 0, "fresh DB current must be 0")
+}
+
+[test]
+def test_current_does_not_create_audit(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let v = db |> current_schema_version()
+    t |> equal(v, 0, "first call returns 0")
+    let exists = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name='__schema_version'", type<int>)
+    t |> equal(exists, 0, "current_schema_version must NOT create the audit table")
+}
+
+[test]
+def test_pending_lists_all_on_fresh_db(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let p <- db |> pending_migrations()
+    t |> equal(p |> length, 2, "fresh DB sees both registered migrations as pending")
+    t |> equal(p[0].version, 1, "first pending is v1")
+    t |> equal(p[1].version, 2, "second pending is v2")
+    t |> equal(p[0].description, "alpha", "description from annotation")
+}
+
+[test]
+def test_pending_empty_when_current(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let p <- db |> pending_migrations()
+    t |> equal(p |> length, 0, "pending must be empty after migrate_to_latest")
+}
+
+[test]
+def test_history_empty_on_fresh_db(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let h <- db |> migration_history()
+    t |> equal(h |> length, 0, "fresh DB history must be empty")
+    let exists = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name='__schema_version'", type<int>)
+    t |> equal(exists, 0, "migration_history must NOT create the audit table")
+}
+
+[test]
+def test_inspectors_have_no_side_effects_on_fresh_db(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let _v = db |> current_schema_version()
+    let _p <- db |> pending_migrations()
+    let _h <- db |> migration_history()
+    let exists = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name='__schema_version'", type<int>)
+    t |> equal(exists, 0, "all three inspectors combined must leave fresh DB unchanged")
+}

--- a/tests/dasSQLITE/migrate_35_history_after_migrate.das
+++ b/tests/dasSQLITE/migrate_35_history_after_migrate.das
@@ -1,0 +1,41 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "alpha")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE x (a INT)")
+}
+
+[sql_migration(version = 2, description = "beta")]
+def m2(db : SqlRunner) {
+    db |> exec("CREATE TABLE y (b INT)")
+}
+
+[sql_migration(version = 3, description = "gamma")]
+def m3(db : SqlRunner) {
+    db |> exec("CREATE TABLE z (c INT)")
+}
+
+[test]
+def test_history_contains_all_applied_in_version_order(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let h <- db |> migration_history()
+    t |> equal(h |> length, 3, "history must have 3 rows")
+    t |> equal(h[0].version, 1, "row 0 = v1")
+    t |> equal(h[1].version, 2, "row 1 = v2")
+    t |> equal(h[2].version, 3, "row 2 = v3")
+    t |> equal(h[0].description, "alpha", "v1 description preserved")
+    t |> equal(h[2].description, "gamma", "v3 description preserved")
+    t |> success(h[0].applied_at > 0l, "applied_at must be > 0")
+    t |> success(h[2].applied_at >= h[0].applied_at, "applied_at must be monotonic")
+}
+
+[test]
+def test_current_after_migrate(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    t |> equal(db |> current_schema_version(), 3, "current must equal MAX(version)")
+}

--- a/tests/dasSQLITE/migrate_39_downgrade_warning.das
+++ b/tests/dasSQLITE/migrate_39_downgrade_warning.das
@@ -1,0 +1,40 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+// DB ahead of binary: audit has v=9 but the running binary's registered max is v=2.
+// migrate_to_latest must return 0 + leave the audit unchanged + log a warning (warning
+// capture isn't tested here — production observation is enough; covered by Scenario 4).
+
+[sql_migration(version = 1, description = "v1")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+}
+
+[sql_migration(version = 2, description = "v2")]
+def m2(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
+}
+
+[test]
+def test_db_ahead_of_binary_returns_zero(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> exec("CREATE TABLE __schema_version (version INTEGER PRIMARY KEY, description TEXT NOT NULL DEFAULT '', applied_at INTEGER NOT NULL)")
+    db |> exec("INSERT INTO __schema_version (version, description, applied_at) VALUES (1, 'v1', 1000)")
+    db |> exec("INSERT INTO __schema_version (version, description, applied_at) VALUES (9, 'future', 1000)")
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Email TEXT NOT NULL DEFAULT '')")
+
+    let n = db |> migrate_to_latest()
+    t |> equal(n, 0, "downgrade case must return 0 (no migrations applied)")
+    let max_v = db |> query_scalar("SELECT MAX(version) FROM __schema_version", type<int>)
+    t |> equal(max_v, 9, "audit unchanged after downgrade detection")
+}
+
+[test]
+def test_current_schema_version_reads_max(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> exec("CREATE TABLE __schema_version (version INTEGER PRIMARY KEY, description TEXT NOT NULL DEFAULT '', applied_at INTEGER NOT NULL)")
+    db |> exec("INSERT INTO __schema_version (version, description, applied_at) VALUES (9, 'future', 1000)")
+    t |> equal(db |> current_schema_version(), 9, "current_schema_version must return raw MAX, even when ahead of binary")
+}

--- a/tests/dasSQLITE/migrate_41_baseline_fresh.das
+++ b/tests/dasSQLITE/migrate_41_baseline_fresh.das
@@ -1,0 +1,41 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "v1")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+}
+
+[sql_migration(version = 2, description = "v2")]
+def m2(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
+}
+
+[sql_migration(version = 3, description = "v3")]
+def m3(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Score INTEGER NOT NULL DEFAULT 0")
+}
+
+[test]
+def test_baseline_stamps_v1_through_n(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let r <- db |> try_baseline(3)
+    t |> success(r |> is_ok, "try_baseline(3) must succeed")
+    t |> equal(r |> unwrap, 3, "stamped 3 rows (v1 + v2 + v3)")
+
+    let h <- db |> migration_history()
+    t |> equal(h |> length, 3, "history has 3 rows")
+    t |> equal(h[0].version, 1, "first row is v1")
+    t |> equal(h[2].version, 3, "third row is v3")
+}
+
+[test]
+def test_baseline_uses_annotation_description_when_available(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> baseline(2)
+    let desc = db |> query_scalar(
+        "SELECT description FROM __schema_version WHERE version=1", type<string>)
+    t |> equal(desc, "v1", "baseline picks up the annotation description for registered versions")
+}

--- a/tests/dasSQLITE/migrate_42_baseline_idempotent.das
+++ b/tests/dasSQLITE/migrate_42_baseline_idempotent.das
@@ -1,0 +1,26 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "v1")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE x (a INT)")
+}
+
+[sql_migration(version = 2, description = "v2")]
+def m2(db : SqlRunner) {
+    db |> exec("CREATE TABLE y (b INT)")
+}
+
+[test]
+def test_baseline_twice_is_idempotent(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let r1 <- db |> try_baseline(2)
+    let r2 <- db |> try_baseline(2)
+    t |> equal(r1 |> unwrap, 2, "first call stamps 2 rows")
+    t |> equal(r2 |> unwrap, 0, "second call stamps 0 rows (idempotent)")
+
+    let n = db |> query_scalar("SELECT COUNT(*) FROM __schema_version", type<int>)
+    t |> equal(n, 2, "audit row count unchanged after idempotent rerun")
+}

--- a/tests/dasSQLITE/migrate_44_baseline_above_max.das
+++ b/tests/dasSQLITE/migrate_44_baseline_above_max.das
@@ -1,0 +1,46 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "v1")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE x (a INT)")
+}
+
+[sql_migration(version = 2, description = "v2")]
+def m2(db : SqlRunner) {
+    db |> exec("CREATE TABLE y (b INT)")
+}
+
+[test]
+def test_try_baseline_rejects_above_max(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let r <- db |> try_baseline(5)               // registered max is 2
+    t |> success(r |> is_err, "try_baseline(5) must return Err — above registered max")
+
+    let audit_exists = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name='__schema_version'", type<int>)
+    t |> equal(audit_exists, 0, "rejected baseline must not create the audit table")
+}
+
+[test]
+def test_strict_baseline_panics_above_max(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    var caught = false
+    try {
+        db |> baseline(5)
+    } recover {
+        caught = true
+    }
+    t |> success(caught, "strict baseline must panic when above max")
+}
+
+[test]
+def test_baseline_zero_or_negative_rejected(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let r0 <- db |> try_baseline(0)
+    let rn <- db |> try_baseline(-1)
+    t |> success(r0 |> is_err, "version=0 must be rejected")
+    t |> success(rn |> is_err, "version=-1 must be rejected")
+}

--- a/tests/dasSQLITE/migrate_45_baseline_then_migrate.das
+++ b/tests/dasSQLITE/migrate_45_baseline_then_migrate.das
@@ -1,0 +1,45 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+[sql_migration(version = 1, description = "create users")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+}
+
+[sql_migration(version = 2, description = "add email")]
+def m2(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
+}
+
+[sql_migration(version = 3, description = "add score")]
+def m3(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Score INTEGER NOT NULL DEFAULT 0")
+}
+
+[test]
+def test_baseline_then_migrate_applies_only_remainder(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    // Simulate existing v1 schema.
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+
+    db |> baseline(1)
+    let n = db |> migrate_to_latest()
+    t |> equal(n, 2, "only v2 + v3 should run after baseline(1)")
+
+    // History has all 3 rows: v1 baselined, v2 + v3 applied.
+    let h <- db |> migration_history()
+    t |> equal(h |> length, 3, "history has 3 rows total")
+    t |> equal(h[0].version, 1, "first row is the baselined v1")
+    t |> equal(h[1].version, 2, "second row is v2")
+    t |> equal(h[2].version, 3, "third row is v3")
+
+    // Email and Score columns must exist (v2 and v3 actually ran).
+    let has_email = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='Email'", type<int>)
+    let has_score = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='Score'", type<int>)
+    t |> equal(has_email, 1, "Email column added by v2")
+    t |> equal(has_score, 1, "Score column added by v3")
+}

--- a/tests/dasSQLITE/migrate_56_gap_allowed_versions.das
+++ b/tests/dasSQLITE/migrate_56_gap_allowed_versions.das
@@ -1,0 +1,37 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+// Versions can be gappy (1, 5, 10) — strict-forward pending detection works on gaps.
+
+[sql_migration(version = 1, description = "first")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE a (x INT)")
+}
+
+[sql_migration(version = 5, description = "fifth")]
+def m5(db : SqlRunner) {
+    db |> exec("CREATE TABLE b (x INT)")
+}
+
+[sql_migration(version = 10, description = "tenth")]
+def m10(db : SqlRunner) {
+    db |> exec("CREATE TABLE c (x INT)")
+}
+
+[test]
+def test_gappy_versions_run_in_order(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let n = db |> migrate_to_latest()
+    t |> equal(n, 3, "all three migrations apply despite gaps")
+
+    let h <- db |> migration_history()
+    t |> equal(h |> length, 3, "history has 3 rows")
+    t |> equal(h[0].version, 1, "ascending order: v1")
+    t |> equal(h[1].version, 5, "ascending order: v5")
+    t |> equal(h[2].version, 10, "ascending order: v10")
+
+    let max_v = db |> current_schema_version()
+    t |> equal(max_v, 10, "current is the gappy max")
+}

--- a/tests/dasSQLITE/migrate_64_try_form_returns_err.das
+++ b/tests/dasSQLITE/migrate_64_try_form_returns_err.das
@@ -1,0 +1,30 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+require daslib/strings_boost
+
+[sql_migration(version = 1, description = "good")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE x (a INT)")
+}
+
+[sql_migration(version = 2, description = "broken — references missing function")]
+def m2(db : SqlRunner) {
+    db |> exec("SELECT not_a_real_function(1)")
+}
+
+[test]
+def test_try_form_returns_err_with_enriched_message(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let r <- db |> try_migrate_to_latest()
+    t |> success(r |> is_err, "try_migrate_to_latest must return Err")
+
+    let msg = r |> unwrap_err
+    t |> success(msg |> contains("v2"), "Err must name the failing version")
+    t |> success(msg |> contains("broken"), "Err must include the description")
+    t |> success(msg |> contains("DB does not need to be reset"),
+        "Err must contain the no-reset reassurance")
+    t |> success(msg |> contains("rolled back"),
+        "Err must mention rollback")
+}

--- a/tests/dasSQLITE/migrate_77_drop_column_native.das
+++ b/tests/dasSQLITE/migrate_77_drop_column_native.das
@@ -25,3 +25,13 @@ def test_drop_column_works_natively(t : T?) {
         "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='Legacy'", type<int>)
     t |> equal(has_legacy, 0, "Legacy column must be gone")
 }
+
+
+[test]
+def test_sqlite_version_at_least_3_35(t : T?) {
+    // 3.35.0+ supports DROP COLUMN (the feature this file tests).
+    // sqlite3_libversion_number() encodes 3.35.0 as 3*1000000 + 35*1000 + 0 = 3035000.
+    let n = sqlite3_libversion_number()
+    t |> success(n >= 3035000,
+        "bundled SQLite must be >= 3.35.0 for DROP COLUMN (got '{sqlite_version()}', code {n})")
+}

--- a/tests/dasSQLITE/migrate_77_drop_column_native.das
+++ b/tests/dasSQLITE/migrate_77_drop_column_native.das
@@ -1,0 +1,27 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+// Bundled SQLite 3.41.2 supports DROP COLUMN natively (since 3.35.0). No 12-step recipe.
+
+[sql_migration(version = 1, description = "create with extra")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL, Legacy TEXT)")
+}
+
+[sql_migration(version = 2, description = "drop legacy")]
+def m2(db : SqlRunner) {
+    db |> exec("ALTER TABLE users DROP COLUMN Legacy")
+}
+
+[test]
+def test_drop_column_works_natively(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let cols = db |> query_scalar("SELECT COUNT(*) FROM pragma_table_info('users')", type<int>)
+    t |> equal(cols, 2, "users must have only Id+Name after DROP COLUMN")
+    let has_legacy = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='Legacy'", type<int>)
+    t |> equal(has_legacy, 0, "Legacy column must be gone")
+}

--- a/tests/dasSQLITE/migrate_78_rename_column_native.das
+++ b/tests/dasSQLITE/migrate_78_rename_column_native.das
@@ -31,10 +31,10 @@ def test_rename_column_preserves_data(t : T?) {
 }
 
 [test]
-def test_sqlite_version_at_least_3_35(t : T?) {
-    // 3.35.0+ supports DROP COLUMN. 3.25.0+ supports RENAME COLUMN.
-    // sqlite3_libversion_number() encodes 3.35.0 as 3*1000000 + 35*1000 + 0 = 3035000.
+def test_sqlite_version_at_least_3_25(t : T?) {
+    // 3.25.0+ supports RENAME COLUMN (the feature this file tests).
+    // sqlite3_libversion_number() encodes 3.25.0 as 3*1000000 + 25*1000 + 0 = 3025000.
     let n = sqlite3_libversion_number()
-    t |> success(n >= 3035000,
-        "bundled SQLite must be >= 3.35.0 (got '{sqlite_version()}', code {n})")
+    t |> success(n >= 3025000,
+        "bundled SQLite must be >= 3.25.0 for RENAME COLUMN (got '{sqlite_version()}', code {n})")
 }

--- a/tests/dasSQLITE/migrate_78_rename_column_native.das
+++ b/tests/dasSQLITE/migrate_78_rename_column_native.das
@@ -1,0 +1,40 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sql_migrate
+
+// SQLite 3.41.2 supports RENAME COLUMN natively (since 3.25.0).
+
+[sql_migration(version = 1, description = "create")]
+def m1(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, OldName TEXT NOT NULL)")
+    db |> exec("INSERT INTO users (OldName) VALUES ('alice')")
+}
+
+[sql_migration(version = 2, description = "rename column")]
+def m2(db : SqlRunner) {
+    db |> exec("ALTER TABLE users RENAME COLUMN OldName TO Name")
+}
+
+[test]
+def test_rename_column_preserves_data(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let has_old = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='OldName'", type<int>)
+    let has_new = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='Name'", type<int>)
+    t |> equal(has_old, 0, "OldName must be gone")
+    t |> equal(has_new, 1, "Name must be present")
+    let alice = db |> query_scalar("SELECT Name FROM users WHERE Id=1", type<string>)
+    t |> equal(alice, "alice", "row data preserved across RENAME")
+}
+
+[test]
+def test_sqlite_version_at_least_3_35(t : T?) {
+    // 3.35.0+ supports DROP COLUMN. 3.25.0+ supports RENAME COLUMN.
+    // sqlite3_libversion_number() encodes 3.35.0 as 3*1000000 + 35*1000 + 0 = 3035000.
+    let n = sqlite3_libversion_number()
+    t |> success(n >= 3035000,
+        "bundled SQLite must be >= 3.35.0 (got '{sqlite_version()}', code {n})")
+}

--- a/tests/dasSQLITE/test_95_schema_from_basic.das
+++ b/tests/dasSQLITE/test_95_schema_from_basic.das
@@ -60,7 +60,7 @@ def test_nullable_schema_wraps_in_option(t : T?) {
 def test_round_trip_select(t : T?) {
     let cols <- column_info(type<AllAffinities>)
     t |> equal(length(cols), 5, "selectable shape")
-    with_sqlite("tests/dasSQLITE/test_data/schema_from_all_affinities.db") $(db) {
+    with_sqlite("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_all_affinities.db") $(db) {
         let rows <- _sql(db |> select_from(type<AllAffinities>))
         t |> equal(length(rows), 0, "fresh fixture has no rows")
     }

--- a/tests/dasSQLITE/test_98_check_schema.das
+++ b/tests/dasSQLITE/test_98_check_schema.das
@@ -71,7 +71,7 @@ struct LogRenamedField {
 
 [test]
 def test_check_schema_match_via_schema_from(t : T?) {
-    with_sqlite("tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
+    with_sqlite("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
         let r = db |> try_check_schema(type<LogV2>)
         t |> equal(r |> is_some, false, "schema matches → none")
     }
@@ -79,7 +79,7 @@ def test_check_schema_match_via_schema_from(t : T?) {
 
 [test]
 def test_check_schema_match_hand_written(t : T?) {
-    with_sqlite("tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
+    with_sqlite("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
         let r = db |> try_check_schema(type<LogHand>)
         t |> equal(r |> is_some, false, "hand-written struct also matches")
     }
@@ -87,7 +87,7 @@ def test_check_schema_match_hand_written(t : T?) {
 
 [test]
 def test_check_schema_column_count_mismatch(t : T?) {
-    with_sqlite("tests/dasSQLITE/test_data/schema_from_v1.db") $(db) {
+    with_sqlite("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_v1.db") $(db) {
         let r = db |> try_check_schema(type<LogV2>)
         t |> equal(r |> is_some, true, "v2 struct vs v1 DB: should err")
         let msg = r |> unwrap
@@ -97,7 +97,7 @@ def test_check_schema_column_count_mismatch(t : T?) {
 
 [test]
 def test_check_schema_type_mismatch(t : T?) {
-    with_sqlite("tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
+    with_sqlite("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
         let r = db |> try_check_schema(type<LogTypeMismatch>)
         t |> equal(r |> is_some, true, "string vs INTEGER: should err")
         let msg = r |> unwrap
@@ -107,7 +107,7 @@ def test_check_schema_type_mismatch(t : T?) {
 
 [test]
 def test_check_schema_nullability_mismatch(t : T?) {
-    with_sqlite("tests/dasSQLITE/test_data/schema_from_nullable.db") $(db) {
+    with_sqlite("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_nullable.db") $(db) {
         let r = db |> try_check_schema(type<ItemNonOpt>)
         t |> equal(r |> is_some, true, "non-optional vs nullable: should err")
         let msg = r |> unwrap
@@ -118,7 +118,7 @@ def test_check_schema_nullability_mismatch(t : T?) {
 [test]
 def test_check_schema_table_not_found(t : T?) {
     // Open the v2 DB (which has Logs), look for a struct named after a non-existent table.
-    with_sqlite("tests/dasSQLITE/test_data/schema_from_blob.db") $(db) {
+    with_sqlite("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_blob.db") $(db) {
         let r = db |> try_check_schema(type<LogV2>)
         t |> equal(r |> is_some, true, "Logs not in blob.db: should err")
     }
@@ -128,7 +128,7 @@ def test_check_schema_table_not_found(t : T?) {
 def test_check_schema_field_order_independent(t : T?) {
     // Struct field order is independent of DB column order — [sql_table] emits SELECTs with
     // explicit column names, so reordered structs round-trip correctly. check_schema agrees.
-    with_sqlite("tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
+    with_sqlite("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
         let r = db |> try_check_schema(type<LogReordered>)
         t |> equal(r |> is_some, false, "reordered struct must match — same names, types, nullability, pk")
     }
@@ -137,7 +137,7 @@ def test_check_schema_field_order_independent(t : T?) {
 [test]
 def test_check_schema_struct_field_missing_in_db(t : T?) {
     // A struct field with no matching DB column — diagnostic names the offender.
-    with_sqlite("tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
+    with_sqlite("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
         let r = db |> try_check_schema(type<LogStrayField>)
         t |> equal(r |> is_some, true, "struct has Stray, DB doesn't")
         let msg = r |> unwrap
@@ -149,7 +149,7 @@ def test_check_schema_struct_field_missing_in_db(t : T?) {
 [test]
 def test_check_schema_renamed_field(t : T?) {
     // Same column count but a struct field that's not in the DB — by-name lookup misses.
-    with_sqlite("tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
+    with_sqlite("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_v2.db") $(db) {
         let r = db |> try_check_schema(type<LogRenamedField>)
         t |> equal(r |> is_some, true, "Body is not in DB")
         let msg = r |> unwrap
@@ -164,7 +164,7 @@ def test_check_schema_attached_schema(t : T?) {
     // attached schema's table_info, not main's. Without the schema-qualified PRAGMA,
     // this would report "table not found" because the in-memory main schema is empty.
     with_sqlite(":memory:") $(db) {
-        db |> with_attached("tests/dasSQLITE/test_data/schema_from_v2.db", "archive") $(arch) {
+        db |> with_attached("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_v2.db", "archive") $(arch) {
             let r = arch |> try_check_schema(type<LogV2>)
             t |> equal(r |> is_some, false, "schema-qualified PRAGMA must find Logs in attached schema")
         }
@@ -176,7 +176,7 @@ def test_check_schema_attached_schema(t : T?) {
 def test_check_schema_panics_on_mismatch(t : T?) {
     var caught = false
     try {
-        with_sqlite("tests/dasSQLITE/test_data/schema_from_v1.db") $(db) {
+        with_sqlite("{get_das_root()}/tests/dasSQLITE/test_data/schema_from_v1.db") $(db) {
             db |> check_schema(type<LogV2>)
         }
     } recover {

--- a/tutorials/sql/43-migrations.das
+++ b/tutorials/sql/43-migrations.das
@@ -1,0 +1,162 @@
+options gen2
+
+// Versioned schema migrations for SQLite.
+//
+// A DB file holds *schema* (tables, columns, indexes) and *data* (rows). When
+// v1 of an app ships, users start filling tables. When v2 ships with a new
+// column, the user's existing `app.db` still has the v1 shape — v2 code that
+// queries the new column panics on the first call. Migrations solve this:
+// each schema change ships as a numbered, frozen step, and the runtime
+// applies whatever is missing on every startup.
+//
+// Three rules make this work:
+//
+//   1. Migrations are append-only. Once shipped, a migration is FROZEN —
+//      to change anything, write a new one with a higher version number.
+//   2. Versions are unique across the whole program. Two devs picking
+//      `version=N` on parallel branches is a compile-time error.
+//   3. The runner uses one transaction per call. If any migration fails,
+//      every effect rolls back — re-run replays the whole pending list.
+//
+// The struct describes the CURRENT schema. Old shapes live ONLY in the
+// migration body's raw SQL — daslang has no model-snapshot system.
+//
+// See: API_MIGRATION.md (design notes), tut 39 (schema_from), tut 42
+// (multi-version ETL with schema_from for the *read* side).
+
+require sqlite/sql_migrate
+
+// =====================================================================
+// PART 1 — Define a schema and write a few migrations
+// =====================================================================
+
+// Current shape. Migrations 1-3 below describe the path from empty to here.
+
+[sql_table(name = "users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    Email : string                    // added in migration 2
+    Score : int = 0                   // added in migration 3 with default
+}
+
+// Migration 1 — bootstrap.
+//
+// Annotation parameters:
+//   version=N           required
+//   description=...     optional; appears in __schema_version + logs
+//   vacuum=true         optional; runs `VACUUM` after this call commits
+//   analyze=true        optional; runs `ANALYZE` after this call commits
+//
+// Body uses raw SQL because at v=1 the struct's *current* shape (Id, Name,
+// Email, Score) doesn't match v=1's schema (Id, Name). Migrations always
+// reference prior schemas via raw SQL; only the current struct knows the
+// current shape.
+
+[sql_migration(version = 1, description = "create users")]
+def migration_001(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+}
+
+// Migration 2 — add a column.
+
+[sql_migration(version = 2, description = "add email column")]
+def migration_002(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
+}
+
+// Migration 3 — multiple statements. All run inside the call's single
+// transaction; failure of any one rolls back the whole call. DDL and DML
+// mix freely.
+
+[sql_migration(version = 3, description = "add score; backfill", analyze = true)]
+def migration_003(db : SqlRunner) {
+    db |> exec("ALTER TABLE users ADD COLUMN Score INTEGER NOT NULL DEFAULT 0")
+    db |> exec("UPDATE users SET Score = 100 WHERE Email != ''")
+    // analyze=true on the annotation runs `ANALYZE` once after the call
+    // commits — refreshes stats after the column add. VACUUM works the
+    // same way (cheap-then-expensive ordering: ANALYZE, then VACUUM).
+}
+
+[export]
+def main() : int {
+    // =================================================================
+    // PART 2 — App startup with with_latest_sqlite
+    // =================================================================
+    //
+    // Preferred form: with_latest_sqlite combines with_sqlite +
+    // apply_recommended_pragmas + migrate_to_latest. Less ceremony,
+    // harder to ship a binary that opens the DB without bringing it up
+    // to date. The explicit two-step (with_sqlite + migrate_to_latest)
+    // remains available for tools/CI that may want to inspect first.
+
+    with_latest_sqlite(":memory:") $(db) {
+        // DB is now at the latest schema. App-level logic goes here.
+        db |> exec("INSERT INTO users (Name, Email) VALUES ('alice', 'alice@x')")
+        let count = db |> query_scalar("SELECT COUNT(*) FROM users", type<int>)
+        print("inserted {count} user(s)\n")
+
+        // ================================================================
+        // PART 3 — Inspection (CLI / health endpoint / CI gate)
+        // ================================================================
+        //
+        // current_schema_version / pending_migrations / migration_history
+        // are pure reads. They never create the audit table or write a
+        // row — safe to call from `mytool db status` against a brand-new
+        // DB without side effects.
+
+        print("current schema version: {db |> current_schema_version()}\n")
+
+        let pending <- db |> pending_migrations()
+        print("pending migrations: {pending |> length}\n")
+
+        let history <- db |> migration_history()
+        print("history: {history |> length} row(s)\n")
+        for (h in history) {
+            print("  v{h.version}: '{h.description}'\n")
+        }
+    }
+
+    // =================================================================
+    // PART 4 — Adoption: baseline an existing DB
+    // =================================================================
+    //
+    // Real-world story: the app has been shipping without migrations.
+    // Existing user DBs already have `users` from v1 hand-rolled DDL.
+    // Naive swap to with_latest_sqlite would crash — migration_001's
+    // CREATE TABLE fails because the table already exists.
+    //
+    // baseline(db, version=N) stamps v1..vN as already-applied without
+    // running their bodies. Idempotent — safe to call repeatedly.
+    //
+    // Layer-1: when migrate_to_latest detects user objects in a
+    //   freshly-empty audit table, it logs a WARNING with the baseline
+    //   recipe.
+    // Layer-2: if the first migration fails because of pre-existing
+    //   tables, the panic message appends the same baseline hint.
+    //
+    // Recommended in tut 43: prefer first-change-as-first-migration —
+    // your first new migration ALTERs the existing schema rather than
+    // recreating it. Reach for baseline only when you specifically want
+    // CREATE-TABLE-shaped retroactive history.
+
+    with_sqlite(":memory:") $(db) {
+        // Simulate a pre-existing v1-era DB.
+        db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+        db |> exec("INSERT INTO users (Name) VALUES ('legacy bob')")
+
+        // Stamp v1 as already-applied so migration_001 won't re-run.
+        db |> baseline(1)
+        print("baseline(1): stamped v1 from existing schema\n")
+
+        // Now run the rest. Only v2 + v3 actually execute.
+        let n = db |> migrate_to_latest()
+        print("applied {n} migration(s) after baseline\n")
+
+        // Pre-existing data is preserved across the ALTERs.
+        let bob_score = db |> query_scalar(
+            "SELECT Score FROM users WHERE Name = 'legacy bob'", type<int>)
+        print("legacy bob's Score (default applied): {bob_score}\n")
+    }
+    return 0
+}


### PR DESCRIPTION
## Summary

Ships the migrations spine described in `modules/dasSQLITE/API_MIGRATION.md` (12-scenario design walk, locked 2026-05-04, commit `64c596f40`). Tag a function `[sql_migration(version=N)]` and call `with_latest_sqlite(path)` at startup; the runtime applies whatever's missing inside one transaction per call. No down-migrations, no model snapshots, no separate CLI.

```das
require sqlite/sql_migrate

[sql_migration(version=1, description="create users")]
def migration_001(db : SqlRunner) {
    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
}

[sql_migration(version=2, description="add email column")]
def migration_002(db : SqlRunner) {
    db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
}

[export]
def main() : int {
    with_latest_sqlite(":memory:") $(db) {
        // DB is at the latest schema. App-level logic goes here.
    }
    return 0
}
```

## Public surface (`require sqlite/sql_migrate`)

- **`[sql_migration(version, description, vacuum, analyze)]`** — annotation. Cross-module dup-version detection at compile time (walks `compiling_program()` and matches by annotation marker; no body inspection). Runtime belt-and-suspenders re-check at first migrate call defends against dynamic plugin loading.
- **`migrate_to_latest(db)` / `try_migrate_to_latest(db)`** — strict-panic and `Result` forms. ROLLBACK guaranteed in `recover` on any body panic, with an enriched error message that names the failing version, the underlying panic text (via `this_context().last_exception`), and the rolled-back versions list.
- **`current_schema_version` / `pending_migrations` / `migration_history` (+ try_ siblings)** — pure reads, never create the audit table; safe to call from `mytool db status` against a brand-new DB without side effects.
- **`baseline(db, version=N)` / `try_baseline`** — stamp v1..vN as already-applied for adoption on existing DBs. Idempotent.
- **`with_latest_sqlite(path) $(db) { ... }`** — combines `with_sqlite` + `apply_recommended_pragmas` + `migrate_to_latest`.

## Adoption UX (loud-by-default, two layers)

When the audit table is brand-new but the DB already has user objects (sqlite_master holds tables/views/indexes outside `__schema_version`), the first call to `migrate_to_latest` logs a `LOG_WARNING` with the baseline recipe. If the first migration then fails because of pre-existing tables (e.g. `CREATE TABLE` on an existing table), the panic message appends the same baseline hint — so a naive `with_sqlite → with_latest_sqlite` swap on a hand-rolled DB fails fast with an actionable next step.

## Tutorial + docs

- `tutorials/sql/43-migrations.das` — runnable tutorial covering define-schema-and-write-migrations / app startup with `with_latest_sqlite` / inspection (CLI `db status` shape) / adoption via baseline.
- `doc/source/reference/tutorials/sql_43_migrations.rst` — companion RST page wired into the toctree at `doc/source/reference/tutorials.rst`.

## Tests

26 `tests/dasSQLITE/migrate_NN_*.das` files covering scenarios 1–10 + 1 `failed_sql_migration_dup_version.das` for the cross-module compile-error dup-version case. AOT cache requires `sql_migrate.das` in `tests/aot/CMakeLists.txt`'s `AOT_DASSQLITE_MODULE_FILES` (cross-module template instantiations get picked up that way).

Chunks 14b (typed ALTER) and 14c (struct rebuild) follow as separate PRs.

## Bundled fusion-engine v_ldu fix (commit `1e1760059`)

Pre-existing TSan SIGSEGV in the fusion engine that surfaced on chunk-14a's CI run. Bundled into this PR rather than split out so the chunk-14a tests can land green; the fix is small and contained to the fusion-node load sites.

**Root cause.** Seven `simulate_fusion_*.cpp` files unconditionally read 16 bytes (`v_ldu`) from a workhorse-typed source that may be 4/8/12 bytes wide. Under the TSan allocator's tighter page layout, a sub-16-byte source within 16 bytes of an unmapped page produces a real SIGSEGV — not a sanitizer-only warning. C++-side `__attribute__((no_sanitize_thread))` suppression does NOT help (already tested on prior force-push); only reading the right number of bytes does.

**Fix shape, two patterns.**

- **5 static-width files** (`at`, `at_array`, `ptrfdr`, `op2_scalar_vec`, `op1_return`): CTYPE in the per-file `IMPLEMENT_*_NODE` macros IS the operand type. Replaced raw `v_ldu` with the new `DAS_LDU_WORKHORSE(dst, src_ptr, CTYPE)` macro in `include/daScript/simulate/simulate_fusion.h` — an `if constexpr` ladder on `sizeof(CTYPE)` that bakes in the right SIMD intrinsic per instantiation: `v_ldu` (16) / `v_ldu_p3_safe` (12) / `v_ldu_half` (8) / `v_set_x` (4). Single-SIMD codegen identical to the old raw `v_ldu`, but width-correct.
- **2 dynamic-width files** (`call1`, `call2`): CTYPE there is the function-storage tag (e.g. `StringPtr`, 8 bytes), NOT the operand width — the bound subexpr's width is only known at fuse time. Stamp `uint8_t loadSize` (or per-side `leftLoadSize`/`rightLoadSize` for op2) on the per-file struct in `IMPLEMENT_OP*_SETUP_NODE`, sourced from `SimNode_CallBase::types[i]->size` clamped to ≤16. Eval body uses `vec4f r = v_zero(); memcpy(&r, src, loadSize);`.

**Bench-driven decision** (`benchmarks/fusion/bench_v_ldu.das`, new). 4×N benchmark over `array<T>[i]` reads at sizeof(T) ∈ {4, 8, 12, 16}. Compared four builds:

| Width | Pre-fix (raw v_ldu, unsafe) | DAS_LDU_WORKHORSE | memcpy(_, _, sizeof(CTYPE)) | DAS_FUSION=0 (floor) |
|-------|---:|---:|---:|---:|
| int    (4)  | 3 | 3 | 3 | 7 |
| int64  (8)  | 3 | 3 | 3 | 7 |
| float3 (12) | 5 | 4 | **11** | 10 |
| float4 (16) | 4 | 4 | 4 | 9 |

ns/op, median of 5 runs, MSVC Release. Plain `memcpy(_, _, sizeof(CTYPE))` regresses 2.5× on the 12-byte path (constant size doesn't get inlined into a single SIMD load by MSVC for that shape) — kept the macro for static-width sites because of this. For dynamic-width call/return the size IS runtime data, runtime memcpy is the only option, and call/return is rarely a hot inner-loop, so the cost is acceptable.

## Test plan

- [x] `daslang.exe dastest/dastest.das -- --test tests/dasSQLITE/` — 728/728 passed (interpreter)
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests/dasSQLITE` — 728/728 passed (AOT)
- [x] `daslang.exe tutorials/sql/43-migrations.das` — runs clean with expected log lines
- [x] `daslang.exe dastest/dastest.das -- --bench --test benchmarks/fusion/bench_v_ldu.das` — 4 benches, fusion verified via `options log_nodes`, post-fix matches pre-fix raw v_ldu
- [x] Spot-check: `tests/{aot, algorithm, decs, strudel, jit, option, linq}` — all green interpreter + AOT (~2500 tests)
- [x] No GC compile/app leaks across the dasSQLITE suite
- [x] MCP `format_file` clean across all changed `.das` files
- [x] MCP `lint` clean (with `options _comment_hygiene = true` in sql_migrate.das)
- [x] MCP `detect_duplicates` against PR-scoped corpus — only known patterns
- [x] Sphinx clean build — `build succeeded.` with zero warnings
- [ ] Linux TSan CI (the original blocker; in_progress on the latest push at time of this update)
