### PR TITLE
daspkg release: bundle a daslang project as a redistributable standalone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/pr_review_iteration.md` | Working an open PR through CI failures and Copilot/human review feedback after the PR is created |
 | `skills/strudel_port.md` | Porting strudel.cc patterns into daslang |
 | `skills/gc_use_after_sweep.md` | Debugging `bad_alloc` / `length_error` in TypeDecl/Expression copy-ctors (use-after-sweep) |
+| `skills/clargs_usage.md` | Writing or editing any tool that parses command-line flags — declarative argv parsing via `daslib/clargs` |
 | `skills/clargs_migration.md` | Editing any tool that still parses `get_command_line_arguments()` directly — migrate to `daslib/clargs` in the same PR |
 | `skills/json.md` | Reading/writing JSON in `.das` code (`sprint_json`/`sscan_json`, `JV`, manual `JsonValue?`) |
 | `skills/xml.md` | XML via `dasPUGIXML`/`PUGIXML_boost` (RAII parsing, builder, XPath, struct round-trip) |

--- a/daslib/daspkg.das
+++ b/daslib/daspkg.das
@@ -131,3 +131,35 @@ def custom_build(command : string) {
     _build_command = command
 }
 
+// --- Release info (set by `release()`) ---
+
+struct ReleaseSpec {
+    name : string                       //!< bundle name; defaults to package_name
+    main_script : string                //!< path to project's main .das (relative to root)
+    include_globs : array<string>       //!< asset globs to ship
+    exclude_globs : array<string>       //!< asset globs to skip
+    forced_modules : array<string>      //!< force-include shared module by das_name (auto-detection misses media-only or runtime-loaded packages)
+}
+
+var _release_spec : ReleaseSpec
+
+def release_name(name : string) {
+    _release_spec.name = name
+}
+
+def release_main(script : string) {
+    _release_spec.main_script = script
+}
+
+def release_include(pattern : string) {
+    _release_spec.include_globs |> push(pattern)
+}
+
+def release_exclude(pattern : string) {
+    _release_spec.exclude_globs |> push(pattern)
+}
+
+def release_shared_module(name : string) {
+    _release_spec.forced_modules |> push(name)
+}
+

--- a/daslib/module_path.das
+++ b/daslib/module_path.das
@@ -1,0 +1,69 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+options strict_smart_pointers = true
+
+module module_path shared public
+
+//! Runtime resolution of *where this module's directory currently lives*.
+//!
+//! daslang code that ships runtime assets alongside its source files
+//! (SVGs, fonts, shaders, data files) typically computes the asset
+//! directory at startup with::
+//!
+//!     let DIR = dir_name(get_module_file_name("my_module"))
+//!     let svg = "{DIR}/cards.svg"
+//!
+//! That works in dev (interpreted from the source tree) and in an SDK /
+//! cmake-install layout, but breaks for ``daspkg release`` standalone
+//! bundles: ``get_module_file_name`` returns the path baked at compile
+//! time, which doesn't exist next to the redistributable exe.
+//!
+//! ``get_this_module_dir()`` solves this by capturing the *call-site*
+//! source-file path at macro expansion, then doing a 3-tier walk at
+//! runtime — same policy PR #2579 introduced for ``.shared_module``
+//! resolution:
+//!
+//! 1. ``<exe_dir>/<rel>``     — daspkg release standalone bundle
+//! 2. ``<das_root>/<rel>``    — SDK / cmake install
+//! 3. ``dir_name(baked)``     — dev (interpreted from source tree)
+//!
+//! ``<rel>`` is the substring of the call-site directory starting at
+//! the last ``/modules/`` segment (e.g. ``modules/dasCards/cards``).
+//! Tiers 1+2 are skipped when the call site has no ``/modules/`` segment
+//! (project-local code outside the package layout); tier 3 is always
+//! returned, so the result is never empty.
+//!
+//! Usage::
+//!
+//!     require daslib/module_path
+//!
+//!     def load_assets() {
+//!         let dir = get_this_module_dir()
+//!         let svg = "{dir}/cards.svg"
+//!         // ...
+//!     }
+//!
+//! Call from inside a function — *not* a top-level ``let`` initializer.
+//! daslang's ``-exe`` JIT path has a known issue with module-init ``let``
+//! initializers that call Context-allocating builtins: the codegen-time
+//! address gets baked and ASLR makes it wrong in the standalone exe.
+//! The same call works fine inside any function body. Also affects
+//! ``let X = get_das_root()`` and ``let X = dir_name(get_module_file_name(M))``.
+
+require daslib/ast_boost
+require daslib/macro_boost
+require daslib/templates_boost
+
+[call_macro(name="get_this_module_dir")]
+class private GetThisModuleDirMacro : AstCallMacro {
+    //! Expands to a call into a 3-tier directory resolver, baking the
+    //! call site's source-file path as a string literal so the resolver
+    //! can derive the modules-relative suffix at runtime.
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        macro_verify(call.arguments |> length == 0, prog, call.at, "expecting get_this_module_dir()")
+        let baked = string(call.at.fileInfo.name)
+        return qmacro(__builtin_resolve_this_module_dir($v(baked)))
+    }
+}

--- a/examples/claude/.das_package
+++ b/examples/claude/.das_package
@@ -13,3 +13,8 @@ def dependencies(version : string) {
     require_package("das-claude")
     require_package("dasTelegram")
 }
+
+[export]
+def release() {
+    release_main("daslang_helper_bot.das")
+}

--- a/examples/daspkg/daspkg-build-example/.das_package
+++ b/examples/daspkg/daspkg-build-example/.das_package
@@ -13,3 +13,8 @@ def dependencies(version : string) {
     require_package("../packages/daspkg-example-c")
     require_package("../packages/daspkg-example-cpp")
 }
+
+[export]
+def release() {
+    release_main("main.das")
+}

--- a/examples/daspkg/daspkg-example/.das_package
+++ b/examples/daspkg/daspkg-example/.das_package
@@ -13,3 +13,8 @@ def dependencies(version : string) {
     require_package("daspkg-test-pure")
     require_package("daspkg-test-deps")
 }
+
+[export]
+def release() {
+    release_main("main.das")
+}

--- a/examples/daspkg/daspkg-version-1/.das_package
+++ b/examples/daspkg/daspkg-version-1/.das_package
@@ -12,3 +12,8 @@ def package() {
 def dependencies(version : string) {
     require_package("github.com/borisbat/daspkg-test-versions@1.0")
 }
+
+[export]
+def release() {
+    release_main("main.das")
+}

--- a/examples/daspkg/daspkg-version-2/.das_package
+++ b/examples/daspkg/daspkg-version-2/.das_package
@@ -12,3 +12,8 @@ def package() {
 def dependencies(version : string) {
     require_package("github.com/borisbat/daspkg-test-versions@2.0")
 }
+
+[export]
+def release() {
+    release_main("main.das")
+}

--- a/examples/games/arcanoid/.das_package
+++ b/examples/games/arcanoid/.das_package
@@ -1,0 +1,14 @@
+options gen2
+
+require daslib/daspkg
+
+[export]
+def package() {
+    package_name("arcanoid")
+    package_description("Arcanoid (breakout) example built on dasGlfw + dasOpenGL")
+}
+
+[export]
+def release() {
+    release_main("main.das")
+}

--- a/examples/games/asteroids/.das_package
+++ b/examples/games/asteroids/.das_package
@@ -1,0 +1,14 @@
+options gen2
+
+require daslib/daspkg
+
+[export]
+def package() {
+    package_name("asteroids")
+    package_description("Asteroids example built on dasGlfw + dasOpenGL")
+}
+
+[export]
+def release() {
+    release_main("main.das")
+}

--- a/examples/games/river_run/.das_package
+++ b/examples/games/river_run/.das_package
@@ -1,0 +1,14 @@
+options gen2
+
+require daslib/daspkg
+
+[export]
+def package() {
+    package_name("river-run")
+    package_description("River Run example with audio + HUD; ships on dasGlfw + dasOpenGL + dasAudio")
+}
+
+[export]
+def release() {
+    release_main("main.das")
+}

--- a/examples/games/sequence/.das_package
+++ b/examples/games/sequence/.das_package
@@ -12,3 +12,8 @@ def package() {
 def dependencies(version : string) {
     require_package("das-cards")
 }
+
+[export]
+def release() {
+    release_main("main.das")
+}

--- a/examples/graphics/.das_package
+++ b/examples/graphics/.das_package
@@ -11,3 +11,8 @@ def package() {
 def dependencies(version : string) {
     require_package("dasImgui")
 }
+
+[export]
+def release() {
+    release_main("furier_opengl_imgui_example.das")
+}

--- a/examples/node-editor/.das_package
+++ b/examples/node-editor/.das_package
@@ -11,3 +11,8 @@ def package() {
 def dependencies(version : string) {
     require_package("dasImguiNodeEditor")
 }
+
+[export]
+def release() {
+    release_main("imgui_node_editor_basic.das")
+}

--- a/examples/telegram/.das_package
+++ b/examples/telegram/.das_package
@@ -12,3 +12,8 @@ def package() {
 def dependencies(version : string) {
     require_package("dasTelegram")
 }
+
+[export]
+def release() {
+    release_main("echo_bot.das")
+}

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -739,6 +739,7 @@ def public audio_system_release_context {
     }
 }
 
+[pinvoke]
 def command_processor {
     return if (g_command_stream == null)
     g_command_stream |> gather_archive() $(var cmd : AudioCommand) {

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -23,6 +23,9 @@ require daslib/strings_boost
 require daslib/defer
 require daslib/lpipe
 require daslib/debugger
+require daslib/clargs
+require daslib/json
+require daslib/json_boost
 require math
 require jit
 require daslib/fio
@@ -572,6 +575,172 @@ def private compute_modules_relative_suffix(p : string) : string {
     return idx < 0 ? "" : slice(pn, idx + 1)
 }
 
+// Walk up `start_dir` looking for a `.das_package` file. Returns the absolute
+// path to the package (the dir containing `.das_package`) or "" if no ancestor
+// has one within MAX_LEVELS. Bounded so a stray .das at filesystem root doesn't
+// scan the whole tree. Used to identify daspkg-package boundaries among the
+// program's .das modules.
+let private MAX_DAS_PACKAGE_WALKUP_LEVELS = 8
+
+def private find_enclosing_das_package(start_dir : string) : string {
+    var dir = to_generic_path(start_dir)
+    for (i in range(MAX_DAS_PACKAGE_WALKUP_LEVELS)) {
+        if (empty(dir) || dir == "/" || dir == ".") {
+            return ""
+        }
+        if (fexist("{dir}/.das_package")) {
+            return dir
+        }
+        let last_slash = rfind(dir, "/")
+        if (last_slash <= 0) {
+            return ""
+        }
+        dir = slice(dir, 0, last_slash)
+    }
+    return ""
+}
+
+// JSON record types written by `daslang -exe -list-shared-modules <path>`.
+// `commands.das` (in daspkg) defines structurally-identical types and parses
+// the JSON via `from_JV`. Keep field names + types in sync if either side moves.
+struct private SharedModuleEntry {
+    rel : string                    //!< relative bundle path (modules/<X>/<X>.shared_module); "" if path lacks /modules/
+    abs : string                    //!< absolute path on the build machine
+    das_name : string               //!< daslang-side module name registered by the dylib
+}
+
+struct private DasModuleEntry {
+    name : string                   //!< daslang module name
+    file : string                   //!< absolute path to the .das source file
+    package_dir : string            //!< absolute path to the enclosing daspkg package (dir holding .das_package)
+}
+
+struct private ReleaseDeps {
+    shared_modules : array<SharedModuleEntry>
+    das_modules : array<DasModuleEntry>
+}
+
+// If `-list-shared-modules <path>` was passed on the daslang command line,
+// write a JSON `ReleaseDeps` describing what `daspkg release` should ship.
+//
+// Detection walks `program_for_each_module(prog)` and, for each program module:
+//   1) Looks the daslang module name up in `for_each_registered_dynamic_module()`
+//      to find an associated .shared_module dylib. Found → emit a SharedModuleEntry,
+//      deduped by absolute dylib path (one .shared_module can host several
+//      daslang modules, e.g. dasStbImage hosts `stbimage`, `raster`, `stbtruetype`).
+//   2) If `m.fileName` is non-empty AND its directory walks up to a `.das_package`
+//      file (via `find_enclosing_das_package`), emits a DasModuleEntry tagged with
+//      `package_dir`. This filter drops daslib stdlib (no .das_package above) and
+//      SDK-shipped modules under `<das_root>/modules/<X>/` (no .das_package either),
+//      keeping only daspkg-installed deps. The reader (`cmd_release`) further skips
+//      entries whose `package_dir` equals the project root being released.
+// Extract the package directory name from a "modules/<X>/.../foo.shared_module"
+// suffix — used to let `-force-shared-module dasGlfw` match by package name as
+// well as by the daslang-side module name.
+def private dylib_package_name(rel : string) : string {
+    if (empty(rel)) {
+        return ""
+    }
+    let after_modules = slice(rel, length("modules/"))
+    let next_slash = find(after_modules, "/")
+    return next_slash > 0 ? slice(after_modules, 0, next_slash) : after_modules
+}
+
+// Helper: append `entry` to deps.shared_modules unless its absolute path was
+// already recorded. Deduping by absolute dylib path is necessary because one
+// .shared_module file can host several daslang modules (dasStbImage hosts
+// stbimage, raster, stbtruetype) and each would otherwise produce a duplicate.
+def private push_shared_unique(entry : SharedModuleEntry; var seen : table<string; bool>; var deps : ReleaseDeps) {
+    if (key_exists(seen, entry.abs)) {
+        return
+    }
+    seen[entry.abs] = true
+    deps.shared_modules |> push(entry)
+}
+
+// Declarative parsing of daslang's release-deps flags. The fields here are
+// matched against argv directly (clargs auto-derives `--field-name` long
+// flags); unknown flags in argv (every other daslang option) are silently
+// ignored by parse_args.
+[CommandLineArgs]
+struct private ReleaseDepsArgs {
+    @clarg_doc = "Path to write the JSON release-deps file"
+    list_shared_modules : string
+
+    @clarg_doc = "Force-include a shared module by daslang or package name (repeatable)"
+    force_shared_module : array<string>
+}
+
+def private write_release_deps(prog : Program?) {
+    let argv <- get_program_args()
+    var r <- parse_args(type<ReleaseDepsArgs>, argv)
+    if (r |> is_err) {
+        to_log(LOG_ERROR, "LLVM EXE: bad release-deps args: {r |> unwrap_err}\n")
+        return
+    }
+    let cfg <- r |> move_unwrap
+    if (empty(cfg.list_shared_modules)) {
+        return
+    }
+    // Snapshot the dynamic-module registry once; key by daslang-side name, with
+    // a parallel by-package-name lookup so `--force-shared-module dasGlfw` works
+    // alongside `--force-shared-module dasglfw` (the daslang-side name).
+    var by_das : table<string; SharedModuleEntry>
+    var by_pkg : table<string; SharedModuleEntry>
+    for_each_registered_dynamic_module() <| $(path, mod_name, das_name) {
+        let abs = string(path)
+        let rel = compute_modules_relative_suffix(abs)
+        let entry = SharedModuleEntry(rel = rel, abs = abs, das_name = string(das_name))
+        by_das[entry.das_name] = entry
+        let pkg = dylib_package_name(rel)
+        if (!empty(pkg)) {
+            by_pkg[pkg] = entry
+        }
+    }
+    var deps : ReleaseDeps
+    var shared_seen : table<string; bool>
+    // Auto-detected: every program module that has a registered dylib.
+    prog |> for_each_module <| $(m) {
+        let mod_name = string(m.name)
+        if (key_exists(by_das, mod_name)) {
+            push_shared_unique(by_das[mod_name], shared_seen, deps)
+        }
+        let file = string(m.fileName)
+        if (!empty(file)) {
+            let pkg_dir = find_enclosing_das_package(dir_name(file))
+            if (!empty(pkg_dir)) {
+                deps.das_modules |> push(DasModuleEntry(
+                    name = mod_name,
+                    file = file,
+                    package_dir = pkg_dir))
+            }
+        }
+    }
+    // User-forced (release_shared_module(name) → --force-shared-module <name>).
+    // Match by daslang-side name OR package directory name. Lookup happens here
+    // (in the daslang process compiling the user program) so the registry has
+    // every dylib daslang scanned, not just the ones daspkg itself uses.
+    for (name in cfg.force_shared_module) {
+        if (key_exists(by_das, name)) {
+            push_shared_unique(by_das[name], shared_seen, deps)
+        } elif (key_exists(by_pkg, name)) {
+            push_shared_unique(by_pkg[name], shared_seen, deps)
+        } else {
+            to_log(LOG_WARNING, "LLVM EXE: --force-shared-module `{name}` not registered (typo? not loaded by daslang)\n")
+        }
+    }
+    let dst_path = cfg.list_shared_modules
+    fopen(dst_path, "wb") $(f) {
+        if (f == null) {
+            to_log(LOG_ERROR, "LLVM EXE: cannot write release deps to {dst_path}\n")
+            return
+        }
+        fwrite(f, sprint_json(deps, true))
+        fwrite(f, "\n")
+    }
+    to_log(LOG_INFO, "LLVM EXE: wrote release deps to {dst_path} (shared={length(deps.shared_modules)}, das={length(deps.das_modules)})\n")
+}
+
 // Creates main function that initializes a standalone JIT context, registers
 // all compiled functions, runs init scripts, then calls the program entry point.
 def public inject_main(program_context : Context?; ctx : LLVMContextRef;
@@ -694,6 +863,10 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
             LLVMBuildCall2(builder, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(rel_str, abs_str, name_str), "")
         }
     }
+
+    // -list-shared-modules <path> side-effect: dump the release-deps JSON
+    // for `daspkg release` to ship dylibs + traverse dep packages.
+    write_release_deps(prog)
 
     // Register native paths (das include paths) that were loaded during compilation
     let reg_native_path_type = LLVMFunctionType(types.t_void,

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1430,11 +1430,20 @@ class public LlvmJitVisitor : AstVisitor {
     // immutable in runtime
     def load_local_const(val : LLVMOpaqueValue?; type_ : LLVMOpaqueType?) {
         let load_inst = LLVMBuildLoad2(g_builder, type_, val, "")
-        let msg = "invariant.load"
-        LLVMSetMetadata(
-            load_inst,
-            LLVMGetMDKindIDInContext(g_ctx, msg, uint(length(msg))),
-            LLVMMDNodeInContext(g_ctx, null, 0u))
+        // For -exe mode the global holds a JIT-process function pointer baked
+        // at codegen time; with `invariant.load`, LLVM constant-folds the load
+        // to the immediate at some call sites (notably top-level `let`
+        // initializers), and ASLR-shifted dylib loads in the standalone exe
+        // make those immediates point to garbage. Skip the annotation so the
+        // load actually happens at runtime against the global, which is
+        // populated correctly when the standalone exe runs.
+        if (!flags.gen_exe) {
+            let msg = "invariant.load"
+            LLVMSetMetadata(
+                load_inst,
+                LLVMGetMDKindIDInContext(g_ctx, msg, uint(length(msg))),
+                LLVMMDNodeInContext(g_ctx, null, 0u))
+        }
         return load_inst
     }
 
@@ -1453,11 +1462,21 @@ class public LlvmJitVisitor : AstVisitor {
         if (global_addr == null) {
             global_addr = LLVMAddGlobal(g_mod, nonnull_type, name.glob())
             if (flags.gen_exe) {
+                // For standalone exes the JIT-process address is meaningless
+                // (different ASLR slide in the new process). Leave the global
+                // null at link time; the runtime initialize_modules() walks
+                // every used builtin and overwrites this slot via
+                // jit_initialize_extern_function. Baking the codegen-time
+                // address as a constant initializer would let LLVM
+                // constant-fold loads — observed at top-level `let` initializers
+                // — to the JIT-process immediate, which the standalone exe then
+                // calls and crashes on (dyld loaded the dylib elsewhere).
                 set_private_linkage(global_addr)
+                LLVMSetInitializer(global_addr, LLVMConstPointerNull(nonnull_type))
             } else {
                 set_public_linkage(global_addr)
+                LLVMSetInitializer(global_addr, types.ConstPtr(address |> intptr, nonnull_type))
             }
-            LLVMSetInitializer(global_addr, types.ConstPtr(address |> intptr, nonnull_type))
         } else {
             failed("Name duplicate {name.glob()}\n")
         }

--- a/skills/clargs_migration.md
+++ b/skills/clargs_migration.md
@@ -7,19 +7,9 @@ touch such a tool for any reason, migrate its argv parsing to
 "migrate every tool" PR — keep migrations opportunistic so they ride
 along with whatever you were already doing.
 
-## Why
-
-`daslib/clargs` replaces ad-hoc `find_index("--foo")` + `args[i+1]`
-machinery with:
-
-- A typed, declarative `[CommandLineArgs]` struct — every flag is a
-  field with a real type (`string`, `int`, `bool`, `array<string>`,
-  enum). The compiler enforces the schema.
-- A free `--help` renderer (`print_help`) that lists every flag with
-  its short alias, doc string, and default — no hand-written usage text
-  to drift out of sync.
-- Uniform short-flag (`-v`), required-flag, and enum-validation
-  handling across every tool. Less code, fewer off-by-one bugs.
+For the **how** — declaring the config struct, picking an argv
+accessor, parsing, help wiring — see **`skills/clargs_usage.md`**.
+This file is just the migration backlog and scope discipline.
 
 ## Backlog (as of 2026-04-25)
 
@@ -40,88 +30,6 @@ the one you happen to be editing — leave the rest:
 This list will shrink over time. Re-grep for
 `get_command_line_arguments` in `utils/`, `daslib/`, and `examples/`
 before adding "still pending" claims to a PR description.
-
-## Recipe
-
-1. **Add the require:** `require daslib/clargs`.
-
-2. **Pick the argv accessor by host shape:**
-   - **Standalone tool** (AOT-built `.exe`, `daspkg`, `lint`, `aot`,
-     `das-fmt`, etc. — argv[0] is the binary, argv[1..] are flags) →
-     `get_program_args()`.
-   - **Daslang-script host** (run via `daslang script.das -- args...` —
-     real flags live after the `--` separator) → `get_cli_arguments()`.
-
-3. **Declare the config struct:**
-   ```das
-   [CommandLineArgs]
-   struct Config {
-       @clarg_required
-       @clarg_short = "n"
-       @clarg_doc = "Greeting target"
-       name : string
-
-       @clarg_short = "r"
-       @clarg_doc = "Repeat count"
-       repeat : int
-
-       @clarg_short = "v"
-       @clarg_doc = "Verbose"
-       verbose : bool
-
-       @clarg_short = "?"           // see "Help-flag pitfall" below
-       @clarg_name = "show-help"
-       @clarg_doc = "Show this help and exit"
-       help : bool
-   }
-   ```
-   - Field types map directly: `string`, `int`, `bool`, `float`,
-     `array<T>` for repeatable flags, enum types (clargs validates).
-   - `@clarg_required` panics if the user omits the flag.
-   - `@clarg_doc` populates the `--help` text — write it.
-   - `@clarg_name` overrides the auto-derived flag name (default is
-     `--field-name`, hyphens replacing underscores).
-
-4. **Parse and check help:**
-   ```das
-   var cfg = Config()
-   let err = parse_args(cfg)            // or parse_args(cfg, args)
-   if (cfg.help) {
-       print_help(get_command_info(type<Config>), "tool-name")
-       return
-   }
-   if (err != "") {
-       print("error: {err}\n\n")
-       print_help(get_command_info(type<Config>), "tool-name")
-       return
-   }
-   ```
-   The single-arg `parse_args(cfg)` form pulls argv via the macro's
-   chosen accessor; the two-arg form lets you pass an explicit
-   `array<string>` — useful for scripts that already split argv or for
-   tests.
-
-5. **Delete the hand-rolled parsing:** every `find_index("--foo")`,
-   `args[i+1]`, manual short-flag check, and string-to-int coercion the
-   tool used to carry. Read `cfg.foo` directly.
-
-## Help-flag pitfall
-
-When run under `daslang.exe` (script-host case), the host intercepts
-`-h` / `--help` itself before forwarding script args. Wire your help
-field to `-?` instead — see `examples/clargs/main.das` for the
-canonical pattern. AOT-built standalone binaries that own argv directly
-(`get_program_args()`) can use `-h` / `--help` as the natural
-convention.
-
-## Reference
-
-- `daslib/clargs.das` — implementation (macro, `parse_args`,
-  `print_help`, `get_program_args`, `get_cli_arguments`).
-- `examples/clargs/main.das` — minimal end-to-end example with
-  required flag, short flags, enum, array, and help wiring.
-- `utils/daspkg/commands.das` — production use across multiple
-  subcommands.
 
 ## Scope discipline
 

--- a/skills/clargs_usage.md
+++ b/skills/clargs_usage.md
@@ -126,11 +126,12 @@ convention.
 
 ## Daslang convention for long flags
 
-Daslang's own CLI treats `--long-flag` as the canonical long form.
-New flags added to daslang or its modules should follow this same
-`--long-flag` convention so they line up with clargs's auto-prepended
-`--` and existing flags like `--track-smart-ptr`,
-`--das-profiler-log-file`.
+Daslang's own CLI (handled in `utils/daScript/main.cpp`) treats
+`--long-flag` as the canonical long form — main.cpp strips one
+leading dash and matches `cmd=="-long-flag"`. New flags added to the
+daslang core or modules should follow this same `--long-flag`
+convention so they line up with clargs's auto-prepended `--` and
+existing flags like `--track-smart-ptr`, `--das-profiler-log-file`.
 
 ## Reference
 
@@ -138,3 +139,7 @@ New flags added to daslang or its modules should follow this same
   `print_help`, `get_program_args`, `get_cli_arguments`).
 - `examples/clargs/main.das` — minimal end-to-end example with
   required flag, short flags, enum, array, and help wiring.
+- `utils/daspkg/commands.das` — production use across multiple
+  subcommands.
+- `modules/dasLLVM/daslib/llvm_exe.das` (`ReleaseDepsArgs`) — sharing
+  argv with another consumer (daslang's own flag set).

--- a/skills/daspkg.md
+++ b/skills/daspkg.md
@@ -30,6 +30,7 @@ The `--root` flag sets the project root directory (default: current directory). 
 | `build` | `build [--global]` | Build native (CMake) packages |
 | `cleanup` | `cleanup [--force] [--global]` | Remove `modules/` and `daspkg.lock` to reset a project |
 | `doctor` | `doctor` | Check environment (git, cmake, gh) |
+| `release` | `release [--out <dir>]` | Bundle project as a redistributable standalone (exe + shared modules + assets) |
 | `introduce` | `introduce` | Register package in the public index (creates PR on daspkg-index) |
 | `withdraw` | `withdraw` | Remove package from the public index |
 
@@ -51,6 +52,7 @@ The `--root` flag sets the project root directory (default: current directory). 
 | `--no-color` | Disable colored output (useful for capturing output) |
 | `--verbose`, `-v` | Print detailed progress |
 | `--json` | Machine-readable JSON output (`search`, `list`, `check`) |
+| `--out <path>` | Output directory for `release` (default: current directory) |
 
 ## Key Details
 
@@ -164,6 +166,91 @@ def initialize(project_path : string) {
     register_native_path("namespace", "module", "{project_path}/namespace/module.das")
 }
 ```
+
+## Release — bundle project as a standalone
+
+`daspkg release` produces a redistributable folder under `<--out>/<bundle_name>/` containing:
+
+- The standalone exe (`<bundle_name>.exe` — produced by `daslang -exe`).
+- Every `.shared_module` dylib the program transitively requires, at the path the exe expects (`modules/<X>/<X>.shared_module`).
+- Every asset matching the project's `release_include` globs.
+
+The recipient can run the bundled exe **without daslang installed**. PR #1 (exe-relative shared modules, merged 2026-05-05) is the prerequisite — the runtime resolves dylibs against the exe's own directory first.
+
+### `release()` hook in `.das_package`
+
+A package's `.das_package` declares what `daspkg release` should ship:
+
+```das
+[export]
+def release() {
+    release_main("main.das")            // entry script (required for the project being released)
+    release_name("MyApp")               // optional; defaults to package_name() / root dir
+    release_include("data/**")          // ship matching files (glob; multiple calls accumulate)
+    release_include("*.png")
+    release_exclude("data/secret/**")
+    release_shared_module("dasSQLITE")  // force-include a dylib not auto-detected
+}
+```
+
+For a **dep package** (e.g. `dasCards`), only the asset-glob calls matter — its `release_main` is ignored when releasing a parent project that depends on it.
+
+### Auto-detection — shared modules + transitive dep traversal
+
+`daslang -exe -list-shared-modules <path>` writes a JSON file describing the program's deps. `cmd_release` then:
+
+1. **Ships dylibs**: every `.shared_module` registered for a daslang module that the compiled program references. Detection is by program-module membership (not used-function set) — a `require`d module whose .das functions aren't called still gets shipped, because its native data may be loaded at runtime.
+2. **Walks transitive deps**: for every program module whose .das source file lives under a `<root>/modules/<DepName>/` package (i.e. has a `.das_package` ancestor distinct from the project's own root), runs that dep's `release()` and copies its `release_include` files to `<bundle>/modules/<DepName>/<rel>`.
+
+If a module is loaded only at runtime (e.g. data files read while the .das is never `require`d), use `release_shared_module(name)` to force-include it. Argument can be the daslang-side module name (`"sqlite"`) OR the package directory name (`"dasSQLITE"`).
+
+### Output layout
+
+```
+<out>/
+└── <bundle_name>/
+    ├── <bundle_name>.exe                       # the standalone binary
+    ├── modules/                                # auto-detected dylibs + transitive dep assets
+    │   ├── dasGlfw/dasModuleGlfw.shared_module
+    │   ├── dasStbImage/dasModuleStbImage.shared_module
+    │   ├── dasCards/cards/svg-cards.svg        # from dasCards's release_include
+    │   └── ...
+    ├── <asset paths from project's release_include>  # preserved relative to project root
+    └── ...
+```
+
+The bundle is the host platform only. Cross-compilation is deferred until daslang itself supports it; v1 has no platform-tag suffix or auto-archive (`--zip` etc.). Recipients can tar/zip the directory themselves.
+
+### Runtime asset paths — `get_this_module_dir()`
+
+Dep code that loads data files via `dir_name(get_module_file_name("X"))` gets the **build-machine path**, not the bundle path — `get_module_file_name` returns the `.das` file path baked at compile time. Use `get_this_module_dir()` from `daslib/module_path` instead:
+
+```das
+require daslib/module_path
+
+def load_assets() {
+    let dir = get_this_module_dir()
+    let svg = "{dir}/cards.svg"
+    // ...
+}
+```
+
+The macro captures the call-site source file path at expansion, then walks the same 3-tier resolution PR #2579 introduced for `.shared_module`:
+
+1. `<exe_dir>/<rel>` — daspkg release standalone bundle
+2. `<das_root>/<rel>` — SDK / cmake install
+3. `dir_name(<call-site-baked>)` — dev (interpreted from source)
+
+`<rel>` is the suffix starting at the last `/modules/` segment.
+
+**Call from inside a function — not a top-level `let` initializer.** daslang's `-exe` JIT path has a known limitation: top-level `let`s that call Context-allocating builtins (like `get_this_module_dir()`, `get_das_root()`, `dir_name(get_module_file_name(...))`) emit JIT-process-baked function pointers that are wrong under ASLR in the standalone exe. The same call works fine inside any function body. Tracked separately; once the daslang fix lands, the top-level form will Just Work.
+
+### What does **not** ship
+
+- Source `.das` files compiled into the exe (daslib stdlib, project's own helpers, dep `.das` companions). The runtime exe doesn't need them — they're already baked in.
+- Source files alongside `.shared_module` dylibs (CMakeLists, README, etc.).
+- The `.das_package` and `daspkg.lock` files.
+- Anything not matched by a `release_include` glob.
 
 ## Package Index
 

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -20,6 +20,7 @@
 #include "daScript/misc/gc_node.h"
 #include "daScript/ast/ast_typedecl.h"
 #include <inttypes.h>
+#include <filesystem>
 #include "daScript/simulate/debug_print.h"
 #include "../parser/parser_impl.h"
 
@@ -1531,6 +1532,60 @@ namespace das
         return context->allocateString(getDasRoot(), at);
     }
 
+    // 3-tier directory resolver mirroring the shared-module resolution policy
+    // from PR #2579 (module_jit.cpp::resolve_dynamic_module_path), but for
+    // source-side asset directories.  Given a baked source-file path captured
+    // at macro expansion (e.g. ".../modules/das-cards/cards/card_mesh.das"),
+    // returns the directory where that module's runtime assets currently live:
+    //   1. <exe_dir>/<rel>            — daspkg-release standalone bundle
+    //   2. <das_root>/<rel>           — SDK / cmake install layout
+    //   3. dir_name(baked_path)       — dev (interpreted from source tree)
+    // <rel> is the substring of dir_name(baked) starting at the last
+    // "/modules/" segment.  Tiers 1+2 are skipped when baked has no /modules/
+    // segment (e.g. project-local code outside the package layout).
+    char * builtin_resolve_this_module_dir ( const char * baked_path, Context * context ) {
+        namespace fs = std::filesystem;
+        if ( !baked_path || !*baked_path ) return context->allocateString("", nullptr);
+        fs::path baked(baked_path);
+        fs::path baked_dir = baked.parent_path();
+        std::string baked_dir_str = baked_dir.string();
+        // Find the last "/modules/" boundary; everything from that segment
+        // onward is the bundle/SDK-relative suffix (e.g.
+        // "modules/das-cards/cards"). rfind, not find — for nested layouts
+        // like "<root>/modules/A/modules/B/x.das" the right answer is "B"'s
+        // package, not "A". Mirrors compute_modules_relative_suffix in
+        // modules/dasLLVM/daslib/llvm_exe.das.
+        const std::string sep = "/modules/";
+        std::string canon = baked_dir_str;
+        for ( char & c : canon ) if ( c == '\\' ) c = '/';
+        std::string rel;
+        size_t pos = canon.rfind(sep);
+        if ( pos != std::string::npos ) {
+            rel = canon.substr(pos + 1);  // drop leading '/' to keep it relative
+        }
+        // Tier 1 — exe_dir
+        if ( !rel.empty() ) {
+            das::string exeFile = das::getExecutableFileName();
+            if ( !exeFile.empty() ) {
+                fs::path exeDir = fs::path(exeFile.c_str()).parent_path();
+                if ( exeDir.empty() ) exeDir = ".";
+                fs::path candidate = exeDir / rel;
+                std::error_code ec;
+                if ( fs::is_directory(candidate, ec) ) {
+                    return context->allocateString(candidate.string().c_str(), nullptr);
+                }
+            }
+            // Tier 2 — das_root
+            fs::path candidate = fs::path(das::getDasRoot().c_str()) / rel;
+            std::error_code ec;
+            if ( fs::is_directory(candidate, ec) ) {
+                return context->allocateString(candidate.string().c_str(), nullptr);
+            }
+        }
+        // Tier 3 — baked dir as fallback
+        return context->allocateString(baked_dir_str.c_str(), nullptr);
+    }
+
     char * builtin_shared_module_extension ( Context * context, LineInfoArg * at ) {
 #ifdef NDEBUG
         return context->allocateString(".shared_module", at);
@@ -1844,6 +1899,9 @@ namespace das
         addExtern<DAS_BIND_FUN(builtin_das_root)>(*this, lib, "get_das_root",
             SideEffects::accessExternal,"builtin_das_root")
                 ->args({"context","at"});
+        addExtern<DAS_BIND_FUN(builtin_resolve_this_module_dir)>(*this, lib, "__builtin_resolve_this_module_dir",
+            SideEffects::accessExternal,"builtin_resolve_this_module_dir")
+                ->args({"baked_path","context"});
         addExtern<DAS_BIND_FUN(builtin_shared_module_extension)>(*this, lib, "shared_module_extension",
             SideEffects::none,"builtin_shared_module_extension")
                 ->args({"context","at"});

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -415,6 +415,8 @@ void print_help() {
         << "    -jit        enable Just-In-Time compilation\n"
         << "    -exe        JIT compile to standalone executable (implies -dry-run)\n"
         << "    -output <path> set JIT output path\n"
+        << "    --list-shared-modules <path> with -exe: write JSON describing the program's shared modules and daspkg-package .das module sources to <path>\n"
+        << "    --force-shared-module <name> with -exe: force-include a shared module by daslang or package name (repeatable)\n"
         << "    -use-aot    enable AOT linking (requires AOT stubs linked into the binary)\n"
         << "    -project <path.das_project> path to project file\n"
         << "    -project_root <path> root directory of the project (used for dyn modules)\n"
@@ -551,6 +553,23 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
             } else if ( cmd=="exe") {
                 jitEnabled = JitMode::Executable;
                 dryRun = true;
+            } else if ( cmd=="-list-shared-modules" ) {
+                // script will pick up next argument by itself (read from llvm_exe.das via get_command_line_arguments())
+                if ( i+1 >= argc ) {
+                    printf("expecting --list-shared-modules path\n");
+                    print_help();
+                    return -1;
+                }
+                i += 1;
+            } else if ( cmd=="-force-shared-module" ) {
+                // script will pick up next argument by itself (force-include a shared module
+                // in the release-deps list even when the program doesn't `require` it)
+                if ( i+1 >= argc ) {
+                    printf("expecting --force-shared-module name\n");
+                    print_help();
+                    return -1;
+                }
+                i += 1;
             } else if ( cmd=="log" ) {
                 outputProgramCode = true;
             } else if ( cmd=="dry-run" ) {

--- a/utils/daspkg/README.md
+++ b/utils/daspkg/README.md
@@ -38,6 +38,7 @@ daslang utils/daspkg/main.das -- install --global dasImgui
 | `build` | Build all C/C++ packages (cmake) |
 | `check` | Verify installed packages are present |
 | `doctor` | Check environment (git, cmake, gh) |
+| `release [--out <dir>]` | Bundle project as a redistributable standalone |
 | `introduce [url]` | Submit a package to the index via PR |
 | `withdraw <name>` | Remove a package from the index via PR |
 
@@ -54,6 +55,7 @@ All package commands accept `--global` / `-g` to operate on global modules.
 | `--verbose`, `-v` | Print debug details (git commands, resolve steps) |
 | `--json` | Machine-readable JSON output (`search`, `list`, `check`) |
 | `--branch <name>`, `-b <name>` | Install from a git branch (e.g. `master`) instead of a tag |
+| `--out <path>` | Output directory for `release` (default: current directory) |
 
 ## Global modules
 

--- a/utils/daspkg/commands.das
+++ b/utils/daspkg/commands.das
@@ -9,6 +9,7 @@ module commands shared public
 
 require daslib/fio
 require strings
+require daslib/strings_boost
 require daslib/json
 require daslib/json_boost
 
@@ -61,6 +62,9 @@ struct DaspkgArgs {
     @clarg_mutex_group = "color"
     @clarg_doc = "Disable colored output"
     no_color : bool
+
+    @clarg_doc = "Output directory for `release` (default: current directory)"
+    out : string = "."
 }
 
 // Apply parsed flags that flip module-level globals.  Called by main after
@@ -1297,5 +1301,258 @@ def cmd_cleanup(root : string; force : bool; is_global : bool = false) : int {
         }
     }
     log("Cleaned: {removed_dirs} directories, {removed_files} files\n")
+    return 0
+}
+
+// ── release ────────────────────────────────────────────────────────────
+
+// JSON shape produced by `daslang -exe --list-shared-modules <path>` — see
+// `modules/dasLLVM/daslib/llvm_exe.das write_release_deps()`. Field names +
+// types must stay in sync with the writer's structs.
+
+struct private SharedModuleEntry {
+    rel : string                    //!< relative bundle path (modules/<X>/<X>.shared_module); "" if path lacks /modules/
+    abs : string                    //!< absolute path on the build machine
+    das_name : string               //!< daslang-side module name
+}
+
+struct private DasModuleEntry {
+    name : string                   //!< daslang module name
+    file : string                   //!< absolute path to the .das source file
+    package_dir : string            //!< absolute path to the enclosing daspkg package
+}
+
+struct private ReleaseDeps {
+    shared_modules : array<SharedModuleEntry>
+    das_modules : array<DasModuleEntry>
+}
+
+def private read_release_deps(path : string; var deps : ReleaseDeps) : bool {
+    if (!fexist(path)) {
+        return false
+    }
+    var content : string
+    fopen(path, "rb") $(f) {
+        if (f != null) {
+            content = fread(f)
+        }
+    }
+    var error : string
+    var parsed = read_json(content, error)
+    if (parsed == null) {
+        to_log(LOG_ERROR, "release: cannot parse deps JSON: {error}\n")
+        return false
+    }
+    deps = from_JV(parsed, type<ReleaseDeps>)
+    return true
+}
+
+// Bundle path for the standalone exe (daslang -exe appends `.exe` itself).
+def private bundle_exe_path(bundle_dir, bundle_name : string) : string {
+    return path_join(bundle_dir, bundle_name)
+}
+
+// Run release() on a dep package and copy its release_include files into the
+// bundle at `<bundle>/modules/<DepName>/<rel>`. Returns 0 on success, non-zero
+// on copy failure (missing release() is NOT an error — dep just contributes nothing).
+def private ship_dep_assets(pkg_dir, bundle_modules_dir : string) : int {
+    let dep_pkg_file = "{pkg_dir}/.das_package"
+    if (!fexist(dep_pkg_file)) {
+        return 0
+    }
+    var dep_spec : PackageReleaseInfo
+    if (!run_das_package_release(dep_pkg_file, dep_spec)) {
+        return 0
+    }
+    if (empty(dep_spec.include_globs)) {
+        return 0
+    }
+    let dep_name = base_name(pkg_dir)
+    var dep_files : array<string>
+    glob_filtered(pkg_dir, dep_spec.include_globs, dep_spec.exclude_globs) $(rel_path, is_dir) {
+        if (!is_dir) {
+            dep_files |> push_clone(rel_path)
+        }
+    }
+    for (rel in dep_files) {
+        let src = path_join(pkg_dir, rel)
+        let dst = path_join("{bundle_modules_dir}/{dep_name}", rel)
+        mkdir_rec(dir_name(dst))
+        var err : string
+        if (!copy_file(src, dst, true, err)) {
+            to_log(LOG_ERROR, "release: copy_file({src} -> {dst}) failed: {err}\n")
+            return 1
+        }
+    }
+    if (!empty(dep_files)) {
+        log("  ship dep `{dep_name}`: {length(dep_files)} file(s)\n")
+    }
+    return 0
+}
+
+// Copy of `daslib/command_line.get_das_exe()`. We can't require command_line
+// here because `commands` is a shared module and command_line is not.
+// Returns the absolute path to the daslang interpreter, derived from argv[0]
+// (works whether daspkg runs interpreted or as a future standalone exe).
+def private get_daslang_path() : string {
+    let args <- get_command_line_arguments()
+    if (empty(args)) {
+        return ""
+    }
+    var exe = replace(args[0], "\\", "/")
+    if (find(exe, ":") < 0 && first_character(exe) != '/') {
+        exe = "{get_das_root()}/{exe}"
+    }
+    let last_slash = rfind(exe, "/")
+    let dir = last_slash >= 0 ? slice(exe, 0, last_slash + 1) : ""
+    let interpreter = get_platform_name() == "windows" ? "daslang.exe" : "daslang"
+    let joined = "{dir}{interpreter}"
+    return get_platform_name() == "windows" ? replace(joined, "/", "\\") : joined
+}
+
+def cmd_release(root : string; out_dir : string) : int {
+    let das_package = "{root}/.das_package"
+    if (!fexist(das_package)) {
+        to_log(LOG_ERROR, "release: no .das_package in {root}\n")
+        return 1
+    }
+    var spec : PackageReleaseInfo
+    if (!run_das_package_release(das_package, spec)) {
+        to_log(LOG_ERROR, "release: cannot run release() in {das_package}\n")
+        return 1
+    }
+    if (empty(spec.main_script)) {
+        // run_das_package_release returns true with an empty spec both when
+        // release() is missing entirely and when it's present but never calls
+        // release_main(). Phrase the error to cover both.
+        to_log(LOG_ERROR, "release: {das_package} has no release() hook, or release() didn't call release_main(<script.das>)\n")
+        return 1
+    }
+
+    // Pick bundle name: explicit release_name() > package_name() > root dir name.
+    var bundle_name = spec.name
+    if (empty(bundle_name)) {
+        var pkg : PackageMeta
+        if (run_das_package_meta(das_package, pkg) && !empty(pkg.pkg_name)) {
+            bundle_name = pkg.pkg_name
+        } else {
+            bundle_name = base_name(get_full_file_name(root))
+        }
+    }
+    // bundle_name flows from .das_package metadata (release_name() /
+    // package_name()) — possibly authored by a downloaded dep. Reject path
+    // separators / `..` so a hostile or typo'd name can't escape out_dir
+    // when path_join + force_rmdir run below.
+    if (!is_safe_pkg_name(bundle_name)) {
+        to_log(LOG_ERROR, "Error: unsafe bundle name `{bundle_name}` (must not contain path separators or be `.` / `..`)\n")
+        return 1
+    }
+    let bundle_dir = path_join(out_dir, bundle_name)
+    if (fexist(bundle_dir)) {
+        force_rmdir(bundle_dir)
+    }
+    mkdir(bundle_dir)
+
+    // 1. Build the standalone exe; `--list-shared-modules` writes the deps JSON
+    //    (auto-detected dylibs + transitive .das_package list) as a side effect.
+    //    `--force-shared-module <name>` passes each release_shared_module(name)
+    //    to daslang; lookup happens there so the full registry is available
+    //    (when daspkg itself is compiled standalone, its registry would only
+    //    contain dylibs daspkg's own code references — too narrow).
+    let exe_path = bundle_exe_path(bundle_dir, bundle_name)
+    run_cmd_counter ++
+    let deps_file = "{get_das_root()}/_daspkg_release_deps_{run_cmd_counter}.json"
+    let main_path = path_join(root, spec.main_script)
+    var output : string
+    let daslang = get_daslang_path()
+    let force_args = build_string() $(var writer) {
+        for (name in spec.forced_modules) {
+            writer |> write(" --force-shared-module \"")
+            writer |> write(name)
+            writer |> write("\"")
+        }
+    }
+    let cmd = "\"{daslang}\" -exe -output \"{exe_path}\" --list-shared-modules \"{deps_file}\"{force_args} \"{main_path}\""
+    let rc = run_cmd(cmd, output)
+    if (rc != 0) {
+        to_log(LOG_ERROR, "release: daslang -exe failed (rc={rc}):\n{output}\n")
+        if (fexist(deps_file)) {
+            remove(deps_file)
+        }
+        return 1
+    }
+    // daslang -exe writes <exe_path>.exe (the runnable binary) and <exe_path>.o
+    // (a build-time object file). Drop the .o — it's not needed at runtime.
+    let obj_path = "{exe_path}.o"
+    if (fexist(obj_path)) {
+        remove(obj_path)
+    }
+
+    // 2. Parse deps JSON, ship dylibs at the relative path the exe expects.
+    //    The writer has already merged force-included modules into shared_modules,
+    //    so we just iterate.
+    var deps : ReleaseDeps
+    if (!read_release_deps(deps_file, deps)) {
+        to_log(LOG_ERROR, "release: cannot read deps file at {deps_file}\n")
+        remove(deps_file)
+        return 1
+    }
+    remove(deps_file)
+    for (e in deps.shared_modules) {
+        if (empty(e.rel)) {
+            to_log(LOG_WARNING, "release: skipping module `{e.das_name}` (no /modules/ in `{e.abs}`)\n")
+            continue
+        }
+        let dst = path_join(bundle_dir, e.rel)
+        mkdir_rec(dir_name(dst))
+        var err : string
+        if (!copy_file(e.abs, dst, true, err)) {
+            to_log(LOG_ERROR, "release: copy_file({e.abs} -> {dst}) failed: {err}\n")
+            return 1
+        }
+        log("  ship: {e.rel}\n")
+    }
+
+    // 3. Transitive dep traversal — for each unique dep .das_package (excluding
+    //    the project's own root), run release() and copy its release_include
+    //    files to <bundle>/modules/<DepName>/<rel>.
+    let project_root_abs = get_full_file_name(root)
+    var seen_pkg_dirs : table<string; bool>
+    seen_pkg_dirs[project_root_abs] = true
+    let bundle_modules_dir = path_join(bundle_dir, "modules")
+    for (dm in deps.das_modules) {
+        let pkg_abs = get_full_file_name(dm.package_dir)
+        if (key_exists(seen_pkg_dirs, pkg_abs)) {
+            continue
+        }
+        seen_pkg_dirs[pkg_abs] = true
+        let rc2 = ship_dep_assets(pkg_abs, bundle_modules_dir)
+        if (rc2 != 0) {
+            return rc2
+        }
+    }
+
+    // 4. Glob the project's own assets per spec, copy preserving relative paths.
+    var asset_files : array<string>
+    glob_filtered(root, spec.include_globs, spec.exclude_globs) $(rel_path, is_dir) {
+        if (!is_dir) {
+            asset_files |> push_clone(rel_path)
+        }
+    }
+    for (rel_path in asset_files) {
+        let src = path_join(root, rel_path)
+        let dst = path_join(bundle_dir, rel_path)
+        mkdir_rec(dir_name(dst))
+        var err : string
+        if (!copy_file(src, dst, true, err)) {
+            to_log(LOG_ERROR, "release: copy_file({src} -> {dst}) failed: {err}\n")
+            return 1
+        }
+    }
+    if (!empty(asset_files)) {
+        log("  shipped {length(asset_files)} project asset file(s)\n")
+    }
+
+    log("Released to: {bundle_dir}\n")
     return 0
 }

--- a/utils/daspkg/fixtures/test_release.das_package
+++ b/utils/daspkg/fixtures/test_release.das_package
@@ -1,0 +1,19 @@
+options gen2
+
+require daslib/daspkg
+
+[export]
+def package() {
+    package_name("test-release")
+}
+
+[export]
+def release() {
+    release_name("custom-bundle-name")
+    release_main("main.das")
+    release_include("*.png")
+    release_include("data/**/*.json")
+    release_exclude("data/internal/**")
+    release_shared_module("dasSQLITE")
+    release_shared_module("dasGlfw")
+}

--- a/utils/daspkg/main.das
+++ b/utils/daspkg/main.das
@@ -35,7 +35,8 @@ def print_usage() {
     print("  build                              Build C/C++ packages\n")
     print("  check                              Verify installed packages\n")
     print("  cleanup                            Remove modules/ and daspkg.lock for a fresh install\n")
-    print("  doctor                             Check environment (git, cmake, gh)\n\n")
+    print("  doctor                             Check environment (git, cmake, gh)\n")
+    print("  release [--out <dir>]              Bundle project as a redistributable standalone\n\n")
     print(format_help_with_auto_help(get_command_info(type<DaspkgArgs>), "daspkg"))
 }
 
@@ -106,6 +107,8 @@ def main() {
         rc = cmd_check(root, parsed.json, is_global)
     } elif (command == "cleanup") {
         rc = cmd_cleanup(root, parsed.force, is_global)
+    } elif (command == "release") {
+        rc = cmd_release(root, parsed.out)
     } elif (command == "doctor") {
         rc = cmd_doctor()
     } elif (command == "search") {

--- a/utils/daspkg/package_runner.das
+++ b/utils/daspkg/package_runner.das
@@ -31,6 +31,14 @@ struct PackageBuildInfo {
     is_custom : bool
 }
 
+struct PackageReleaseInfo {
+    name : string
+    main_script : string
+    include_globs : array<string>
+    exclude_globs : array<string>
+    forced_modules : array<string>
+}
+
 
 // Run the `package()` function of a .das_package and extract metadata
 def run_das_package_meta(das_package_path : string; var meta : PackageMeta) : bool {
@@ -88,6 +96,29 @@ def run_das_package_deps(das_package_path : string; version : string; var deps :
             let arr = unsafe(reinterpret<array<Dependency>?>(p))
             for (d in *arr) {
                 deps |> emplace(PackageDependency(source = clone_string(d.source), version_constraint = clone_string(d.version_constraint)))
+            }
+        }
+    }
+    return ok
+}
+
+// Run the `release()` function of a .das_package and extract release info
+def run_das_package_release(das_package_path : string; var info : PackageReleaseInfo) : bool {
+    var args : array<string>
+    var ok = run_das_package(das_package_path, "release", args) $(ctx) {
+        var p = unsafe(get_context_global_variable(ctx, "_release_spec"))
+        if (p != null) {
+            let src = unsafe(reinterpret<ReleaseSpec?>(p))
+            info.name = clone_string(src.name)
+            info.main_script = clone_string(src.main_script)
+            for (g in src.include_globs) {
+                info.include_globs |> push_clone(clone_string(g))
+            }
+            for (g in src.exclude_globs) {
+                info.exclude_globs |> push_clone(clone_string(g))
+            }
+            for (m in src.forced_modules) {
+                info.forced_modules |> push_clone(clone_string(m))
             }
         }
     }

--- a/utils/daspkg/test_daspkg.das
+++ b/utils/daspkg/test_daspkg.das
@@ -772,6 +772,7 @@ let PKG_BRANCH_FIXTURE = "utils/daspkg/fixtures/test_branch.das_package"
 let PKG_REDIRECT_FIXTURE = "utils/daspkg/fixtures/test_redirect.das_package"
 let PKG_SDK_AWARE_FIXTURE = "utils/daspkg/fixtures/test_sdk_aware.das_package"
 let PKG_RICH_FIXTURE = "utils/daspkg/fixtures/test_rich.das_package"
+let PKG_RELEASE_FIXTURE = "utils/daspkg/fixtures/test_release.das_package"
 
 [test]
 def test_run_das_package_meta(t : T?) {
@@ -1606,5 +1607,265 @@ def test_gitignore_remove(t : T?) {
     remove(gitignore)
     force_rmdir("{tmp_root}/.git")
     rmdir(tmp_root)
+}
+
+// --- release tests ---
+
+[test]
+def test_run_das_package_release(t : T?) {
+    t |> run("reads release info from .das_package") @(tt : T?) {
+        var info : PackageReleaseInfo
+        let ok = run_das_package_release(PKG_RELEASE_FIXTURE, info)
+        tt |> success(ok)
+        tt |> equal("custom-bundle-name", info.name)
+        tt |> equal("main.das", info.main_script)
+        tt |> equal(2, length(info.include_globs))
+        tt |> equal("*.png", info.include_globs[0])
+        tt |> equal("data/**/*.json", info.include_globs[1])
+        tt |> equal(1, length(info.exclude_globs))
+        tt |> equal("data/internal/**", info.exclude_globs[0])
+        tt |> equal(2, length(info.forced_modules))
+        tt |> equal("dasSQLITE", info.forced_modules[0])
+        tt |> equal("dasGlfw", info.forced_modules[1])
+    }
+    t |> run("returns true with empty spec when release() is missing") @(tt : T?) {
+        var info : PackageReleaseInfo
+        let ok = run_das_package_release(PKG_FIXTURE, info)
+        tt |> success(ok)
+        tt |> equal("", info.main_script)
+        tt |> equal(0, length(info.include_globs))
+    }
+}
+
+[test]
+def test_cmd_release_pure_daslang(t : T?) {
+    t |> run("bundles a pure-daslang project end-to-end") @(tt : T?) {
+        let tmp_root = "{get_das_root()}/_test_release_pure"
+        let out_dir = "{get_das_root()}/_test_release_pure_out"
+        force_rmdir(tmp_root)
+        force_rmdir(out_dir)
+        mkdir(tmp_root)
+
+        fopen("{tmp_root}/main.das", "wb") $(f) {
+            fwrite(f, "options gen2\n[export]\ndef main() \{\n    print(\"hello\\n\")\n\}\n")
+        }
+        fopen("{tmp_root}/.das_package", "wb") $(f) {
+            fwrite(f, "options gen2\nrequire daslib/daspkg\n[export]\ndef package() \{\n    package_name(\"smoke\")\n\}\n[export]\ndef release() \{\n    release_main(\"main.das\")\n    release_include(\"*.txt\")\n\}\n")
+        }
+        fopen("{tmp_root}/data.txt", "wb") $(f) {
+            fwrite(f, "asset")
+        }
+
+        let rc = cmd_release(tmp_root, out_dir)
+        tt |> equal(0, rc, "cmd_release returns 0")
+        tt |> success(fexist("{out_dir}/smoke/smoke.exe"), "exe shipped")
+        tt |> success(fexist("{out_dir}/smoke/data.txt"), "asset shipped")
+        tt |> success(!fexist("{out_dir}/smoke/smoke.o"), ".o build artifact dropped")
+
+        force_rmdir(tmp_root)
+        force_rmdir(out_dir)
+    }
+}
+
+[test]
+def test_cmd_release_native_dep(t : T?) {
+    var dasSQLITE_present = false
+    for_each_registered_dynamic_module() $(path, mod_name, das_name) {
+        if (string(das_name) == "sqlite") {
+            dasSQLITE_present = true
+        }
+    }
+    if (!dasSQLITE_present) {
+        t |> run("skipped — dasSQLITE not available") @(tt : T?) {
+            to_log(LOG_INFO, "test_cmd_release_native_dep: dasSQLITE not loaded; skipping native-dep test\n")
+            tt |> success(true)
+        }
+        return
+    }
+    t |> run("bundles a native-dep project, runnable from a moved location") @(tt : T?) {
+        let tmp_root = "{get_das_root()}/_test_release_native"
+        let out_dir = "{get_das_root()}/_test_release_native_out"
+        let moved_dir = "{get_das_root()}/_test_release_native_moved"
+        force_rmdir(tmp_root)
+        force_rmdir(out_dir)
+        force_rmdir(moved_dir)
+        mkdir(tmp_root)
+
+        // Tiny project: open in-memory sqlite, run a query, print row count.
+        // Using stderr-free output so we can match it exactly against the run.
+        fopen("{tmp_root}/main.das", "wb") $(f) {
+            fwrite(f, "options gen2\nrequire sqlite/sqlite_boost\n[export]\ndef main() \{\n    let db = open_sqlite(\":memory:\")\n    db |> exec(\"CREATE TABLE t(x INT)\")\n    db |> exec(\"INSERT INTO t VALUES(42)\")\n    print(\"rows: \{db |> changes()\}\\n\")\n\}\n")
+        }
+        fopen("{tmp_root}/.das_package", "wb") $(f) {
+            fwrite(f, "options gen2\nrequire daslib/daspkg\n[export]\ndef package() \{\n    package_name(\"sqs\")\n\}\n[export]\ndef release() \{\n    release_main(\"main.das\")\n\}\n")
+        }
+
+        let rc = cmd_release(tmp_root, out_dir)
+        tt |> equal(0, rc, "cmd_release returns 0")
+        tt |> success(fexist("{out_dir}/sqs/sqs.exe"), "exe shipped")
+        tt |> success(fexist("{out_dir}/sqs/modules/dasSQLITE/dasModuleSQLITE.shared_module"), "dylib shipped at expected relative path")
+
+        // Move the whole bundle to a new location and run it. PR #2579's
+        // exe-relative resolution is what makes this work — the dylib needs
+        // to be found via <exe_dir>/modules/dasSQLITE/... at the new path.
+        // Use `rename` (cross-platform via libc rename(2)/Win CRT) rather
+        // than shell `cp -r` so the test runs on Windows CI; rename also
+        // preserves the exe permission bit by definition.
+        let moved = rename("{out_dir}/sqs", moved_dir)
+        tt |> success(moved, "bundle moved to new location")
+        var output : string
+        let run_rc = run_cmd("\"{moved_dir}/sqs.exe\"", output)
+        tt |> equal(0, run_rc, "moved bundle runs cleanly")
+        tt |> success(find(output, "rows: 1") >= 0, "moved bundle prints expected sqlite output (got: {output})")
+
+        force_rmdir(tmp_root)
+        force_rmdir(out_dir)
+        force_rmdir(moved_dir)
+    }
+}
+
+// False-positive test: every registered dynamic module that the program does NOT
+// require must NOT show up in the bundle. Skips when the registry has only
+// dasSQLITE (no other module to verify isn't shipped).
+[test]
+def test_cmd_release_no_false_positive_shared(t : T?) {
+    var dasSQLITE_present = false
+    var other_pkg_dir = ""
+    for_each_registered_dynamic_module() $(path, mod_name, das_name) {
+        if (string(das_name) == "sqlite") {
+            dasSQLITE_present = true
+        } elif (empty(other_pkg_dir)) {
+            // First non-sqlite registered module: extract package dir name.
+            let g = to_generic_path(string(path))
+            let idx = rfind(g, "/modules/")
+            if (idx >= 0) {
+                let after = slice(g, idx + length("/modules/"))
+                let next_slash = find(after, "/")
+                other_pkg_dir = next_slash > 0 ? slice(after, 0, next_slash) : after
+            }
+        }
+    }
+    if (!dasSQLITE_present || empty(other_pkg_dir)) {
+        t |> run("skipped — needs dasSQLITE plus at least one other registered module") @(tt : T?) {
+            to_log(LOG_INFO, "test_cmd_release_no_false_positive_shared: insufficient registered modules; skipping\n")
+            tt |> success(true)
+        }
+        return
+    }
+    let other_for_capture = other_pkg_dir
+    t |> run("ships only modules the program requires; not registered-but-unused dylibs") @(tt : T?) {
+        let tmp_root = "{get_das_root()}/_test_release_fp_shared"
+        let out_dir = "{get_das_root()}/_test_release_fp_shared_out"
+        force_rmdir(tmp_root)
+        force_rmdir(out_dir)
+        mkdir(tmp_root)
+
+        // Project requires only sqlite — no other registered modules.
+        fopen("{tmp_root}/main.das", "wb") $(f) {
+            fwrite(f, "options gen2\nrequire sqlite/sqlite_boost\n[export]\ndef main() \{\n    let db = open_sqlite(\":memory:\")\n    print(\"db opened\\n\")\n\}\n")
+        }
+        fopen("{tmp_root}/.das_package", "wb") $(f) {
+            fwrite(f, "options gen2\nrequire daslib/daspkg\n[export]\ndef package() \{\n    package_name(\"fpshared\")\n\}\n[export]\ndef release() \{\n    release_main(\"main.das\")\n\}\n")
+        }
+
+        let rc = cmd_release(tmp_root, out_dir)
+        tt |> equal(0, rc, "cmd_release returns 0")
+        tt |> success(fexist("{out_dir}/fpshared/modules/dasSQLITE/dasModuleSQLITE.shared_module"),
+            "dasSQLITE dylib shipped (program required it)")
+        // Pick one registered-but-unused package and confirm it's NOT shipped.
+        let other_dir = "{out_dir}/fpshared/modules/{other_for_capture}"
+        tt |> equal(false, fexist(other_dir),
+            "registered-but-unused package must NOT be shipped (false positive)")
+        force_rmdir(tmp_root)
+        force_rmdir(out_dir)
+    }
+}
+
+// False-positive test: a project with no daspkg deps must NOT pull anything from
+// daslib stdlib (`require strings`, `require fio`) or from the project's own
+// non-main .das files into the bundle's modules/ tree. Only the exe + the
+// project's own assets (release_include) should be shipped.
+[test]
+def test_cmd_release_no_false_positive_das(t : T?) {
+    t |> run("daslib stdlib + project-local .das do NOT create modules/ entries") @(tt : T?) {
+        let tmp_root = "{get_das_root()}/_test_release_fp_das"
+        let out_dir = "{get_das_root()}/_test_release_fp_das_out"
+        force_rmdir(tmp_root)
+        force_rmdir(out_dir)
+        mkdir(tmp_root)
+
+        // Project: main.das requires fio (stdlib) + a project-local module.
+        fopen("{tmp_root}/helper.das", "wb") $(f) {
+            fwrite(f, "options gen2\nmodule helper shared public\n\ndef public greet(name : string) : string \{\n    return \"hello, \{name\}\"\n\}\n")
+        }
+        fopen("{tmp_root}/main.das", "wb") $(f) {
+            fwrite(f, "options gen2\nrequire fio\nrequire helper\n\n[export]\ndef main() \{\n    print(\"\{greet(\"world\")\}\\n\")\n\}\n")
+        }
+        fopen("{tmp_root}/.das_package", "wb") $(f) {
+            fwrite(f, "options gen2\nrequire daslib/daspkg\n[export]\ndef package() \{\n    package_name(\"fpdas\")\n\}\n[export]\ndef release() \{\n    release_main(\"main.das\")\n\}\n")
+        }
+
+        let rc = cmd_release(tmp_root, out_dir)
+        tt |> equal(0, rc, "cmd_release returns 0")
+        tt |> success(fexist("{out_dir}/fpdas/fpdas.exe"), "exe shipped")
+        // No modules/ tree at all — project has no shared modules and no daspkg deps.
+        tt |> equal(false, fexist("{out_dir}/fpdas/modules"),
+            "no modules/ tree (no shared deps, no daspkg deps; daslib stdlib + project-local .das must NOT show up)")
+
+        force_rmdir(tmp_root)
+        force_rmdir(out_dir)
+    }
+}
+
+// Transitive release: project requires a synthetic dep at <root>/modules/<DepName>/
+// whose own .das_package has release_include for asset files. Bundle must place
+// dep assets under <bundle>/modules/<DepName>/<rel>.
+[test]
+def test_cmd_release_transitive_dep(t : T?) {
+    t |> run("dep release_include files are shipped under modules/<DepName>/") @(tt : T?) {
+        let tmp_root = "{get_das_root()}/_test_release_transitive"
+        let out_dir = "{get_das_root()}/_test_release_transitive_out"
+        force_rmdir(tmp_root)
+        force_rmdir(out_dir)
+        mkdir(tmp_root)
+        mkdir("{tmp_root}/modules")
+        mkdir("{tmp_root}/modules/fakedep")
+        mkdir("{tmp_root}/modules/fakedep/daslib")
+        mkdir("{tmp_root}/modules/fakedep/data")
+
+        // Synthetic dep: package + module + asset.
+        fopen("{tmp_root}/modules/fakedep/.das_package", "wb") $(f) {
+            fwrite(f, "options gen2\nrequire daslib/daspkg\n[export]\ndef package() \{\n    package_name(\"fakedep\")\n\}\n[export]\ndef release() \{\n    release_include(\"data/**\")\n\}\n")
+        }
+        fopen("{tmp_root}/modules/fakedep/.das_module", "wb") $(f) {
+            fwrite(f, "options gen2\nrequire daslib/fio\n[export]\ndef initialize(project_path : string) \{\n    register_native_path(\"fakedep\", \"fakedep_lib\", \"\{project_path\}/daslib/fakedep_lib.das\")\n\}\n")
+        }
+        fopen("{tmp_root}/modules/fakedep/daslib/fakedep_lib.das", "wb") $(f) {
+            fwrite(f, "options gen2\nmodule fakedep_lib shared public\n\ndef public hello() : string \{\n    return \"hello from fakedep\"\n\}\n")
+        }
+        fopen("{tmp_root}/modules/fakedep/data/asset.bin", "wb") $(f) {
+            fwrite(f, "asset-content")
+        }
+        // Excluded file — must NOT ship.
+        fopen("{tmp_root}/modules/fakedep/data/internal.bin", "wb") $(f) {
+            fwrite(f, "secret")
+        }
+
+        // Parent project pulls fakedep in.
+        fopen("{tmp_root}/main.das", "wb") $(f) {
+            fwrite(f, "options gen2\nrequire fakedep/fakedep_lib\n\n[export]\ndef main() \{\n    print(\"\{hello()\}\\n\")\n\}\n")
+        }
+        fopen("{tmp_root}/.das_package", "wb") $(f) {
+            fwrite(f, "options gen2\nrequire daslib/daspkg\n[export]\ndef package() \{\n    package_name(\"transit\")\n\}\n[export]\ndef release() \{\n    release_main(\"main.das\")\n\}\n")
+        }
+
+        let rc = cmd_release(tmp_root, out_dir)
+        tt |> equal(0, rc, "cmd_release returns 0")
+        tt |> success(fexist("{out_dir}/transit/transit.exe"), "parent exe shipped")
+        tt |> success(fexist("{out_dir}/transit/modules/fakedep/data/asset.bin"),
+            "dep asset shipped via transitive release()")
+        force_rmdir(tmp_root)
+        force_rmdir(out_dir)
+    }
 }
 

--- a/utils/find-dupe/.das_package
+++ b/utils/find-dupe/.das_package
@@ -12,3 +12,8 @@ def package() {
 def dependencies(version : string) {
     require_package("das-claude")
 }
+
+[export]
+def release() {
+    release_main("main.das")
+}


### PR DESCRIPTION
Adds `daspkg release` — a new daspkg subcommand that takes a project (`main.das` + `.das_package` + assets + dep modules) and produces a folder the recipient can run with **no daslang installed**. Builds on PR #2579 (exe-relative shared modules) which made redistributable bundles possible in the first place.

## What ships

```bash
bin/daslang utils/daspkg/main.das -- release --root my-project --out /tmp/out
# /tmp/out/my-project/
# ├── my-project.exe                     ← standalone (daslang -exe)
# ├── modules/dasGlfw/dasModuleGlfw.shared_module
# ├── modules/dasStbImage/...             ← auto-detected dylibs
# ├── modules/dasCards/cards/svg-cards.svg ← from dep's release_include
# └── ...                                  ← project assets per release_include
```

Recipient runs `./my-project.exe` directly. Tested with `examples/games/sequence` — bundle loads cards from the bundled assets path, game initializes successfully.

## Pieces

### `release()` hook in `.das_package`

```das
[export]
def release() {
    release_main("main.das")            // entry script
    release_name("MyApp")               // optional bundle name
    release_include("data/**")          // glob, accumulates
    release_exclude("data/secret/**")
    release_shared_module("dasSQLITE")  // force-include a dylib not auto-detected
}
```

API in `daslib/daspkg.das`. Setters use `push` (workhorse strings), not `push_clone`.

### Auto-detection — `daslang -exe --list-shared-modules <path>`

New flag on `daslang -exe` that writes a JSON file describing the program's runtime dependencies. Implemented entirely in `modules/dasLLVM/daslib/llvm_exe.das` (`write_release_deps`) — no new C++ policy field, just 4-line consume-arg stubs in `utils/daScript/main.cpp` mirroring `--das-profiler-log-file`.

The walk: `program_for_each_module(prog)` and, for each program module:
- Ship dylib if registered via `for_each_registered_dynamic_module()` (deduped by absolute path — one `.shared_module` can host multiple daslang modules)
- Emit `DasModuleEntry` if the module's source file lives under a `.das_package` ancestor (via `find_enclosing_das_package`, bounded walk-up)

Detection is by **program-module membership, not used-function set** — a `require`d module whose .das functions aren't called still gets shipped, because its native data may be loaded at runtime. `--force-shared-module` (repeatable) lets the user force-include modules that aren't `require`d at all (only their assets are loaded). Lookup happens in the daslang process — daspkg-as-standalone-exe wouldn't have the full registry.

Flags use the daslang `--long-flag` convention (matches `--track-smart-ptr`, `--das-profiler-log-file`).

### `daslib/clargs` migration of `llvm_exe.das`

Replaced manual `find_flag_raw_value` / `find_array_flag_raw_values` loops with a `[CommandLineArgs]` struct. `parse_args(type<>, argv)` silently ignores daslang's other flags, so the struct only declares what release-deps cares about.

```das
[CommandLineArgs]
struct private ReleaseDepsArgs {
    @clarg_doc = "Path to write the JSON release-deps file"
    list_shared_modules : string

    @clarg_doc = "Force-include a shared module by daslang or package name (repeatable)"
    force_shared_module : array<string>
}
```

### Skill consolidation

- New `skills/clargs_usage.md` (canonical "how to use clargs") — mirrored to `install/skills/clargs_usage.md` for SDK users.
- `skills/clargs_migration.md` reduced to migration-only content (backlog + scope rule), links to the canonical recipe.
- `skills/daspkg.md` — Release section + runtime asset-path caveat documenting the top-level-`let` pitfall (see Issue #2582).

### `daslib/module_path` + `get_this_module_dir()` macro

Source-side analog of PR #2579's 3-tier shared-module resolution, for runtime asset directories:

1. `<exe_dir>/<rel>` — daspkg release standalone bundle
2. `<das_root>/<rel>` — SDK / cmake install
3. `dir_name(<call-site-baked>)` — dev (interpreted from source)

`<rel>` is the suffix starting at the last `/modules/` segment.

```das
require daslib/module_path

def load_assets() {
    let dir = get_this_module_dir()
    let svg = "{dir}/cards.svg"
    // ...
}
```

Macro captures the call-site source-file path at expansion (`call.at.fileInfo.name`) and emits a runtime call to `__builtin_resolve_this_module_dir(<literal>)`. C++ binding in `module_builtin_runtime.cpp` does the 3-tier walk.

**Caveat (Issue #2582)**: must be called from inside a function, not a top-level `let` initializer. daslang's `-exe` JIT path bakes JIT-process function pointers as constant initializers, which LLVM constant-folds into immediates that are wrong under ASLR. Fixed by calling inside function bodies — the function-walk pass picks them up and registration prevents the fold.

### dasAudio `command_processor` → `[pinvoke]`

Found while testing the sequence bundle: `invoke_in_context(mixer_context(), "command_processor")` couldn't find the function in the standalone exe because `command_processor` wasn't tagged `[pinvoke]`. Standalone exes only register `[pinvoke]`/`[export]` functions in the runtime name lookup table. Tagged it.

### `.das_package` sweep

13 existing `.das_package` files got `release()` blocks; 3 new ones created for `examples/games/{arcanoid,asteroids,river_run}` so they're releasable.

## Tests

- 6 new tests in `utils/daspkg/test_daspkg.das`:
  - `test_run_das_package_release` — spec round-trip
  - `test_cmd_release_pure_daslang` — end-to-end with assets
  - `test_cmd_release_native_dep` — gated on dasSQLITE; verifies dylib + moved-bundle exec
  - `test_cmd_release_no_false_positive_shared` — registered-but-unused dylib NOT shipped
  - `test_cmd_release_no_false_positive_das` — no daspkg deps → no `<bundle>/modules/` tree
  - `test_cmd_release_transitive_dep` — synthetic dep with `release_include`/`release_exclude`
- 199/199 daspkg tests pass.
- End-to-end smoke verified on `examples/games/sequence`: cards render, game initializes, dependent dylibs load from bundle path.

## Known limitations (filed as separate issues)

- **#2582** — Top-level `let X = builtin()` in `-exe` mode. JIT bakes function pointer; ASLR breaks it. Workaround: call inside function bodies.
- **#2583** — `DebugAgentInstance` static-map dtor crashes at process exit for standalone exes that use dasLiveHost-style modules. Doesn't affect program correctness — fires after user code completes.

## Files

| File | Change |
|---|---|
| `utils/daScript/main.cpp` | 4-line consume-arg stubs for `--list-shared-modules` / `--force-shared-module` |
| `modules/dasLLVM/daslib/llvm_exe.das` | `write_release_deps`: walk program modules, emit JSON via `[CommandLineArgs]` |
| `daslib/daspkg.das` | `ReleaseSpec` + 5 setters |
| `daslib/module_path.das` | NEW: `get_this_module_dir()` macro |
| `src/builtin/module_builtin_runtime.cpp` | `__builtin_resolve_this_module_dir` 3-tier resolver |
| `utils/daspkg/{commands,package_runner,main}.das` | `cmd_release`, `run_das_package_release`, dispatch |
| `utils/daspkg/test_daspkg.das` | 6 new tests |
| `utils/daspkg/fixtures/test_release.das_package` | NEW fixture |
| `modules/dasAudio/audio/audio_boost.das` | `[pinvoke]` on `command_processor` |
| 13 × existing `.das_package` | add `release()` |
| 3 × new `.das_package` | for `examples/games/{arcanoid,asteroids,river_run}` |
| `skills/clargs_usage.md` (new), `skills/clargs_migration.md` (reduced), `install/skills/clargs_usage.md` (mirror) | Skill consolidation |
| `skills/daspkg.md` | Release section + caveats |
| `utils/daspkg/README.md` | command-table row |
