### PR TITLE
fix #2583: standalone-exe shutdown crash; sequence-game retina + font fixes

### DIFF
--- a/examples/games/sequence/main.das
+++ b/examples/games/sequence/main.das
@@ -11,6 +11,7 @@ require live_host
 require opengl/opengl_boost
 require glfw/glfw_boost
 require cards/opengl_cards
+require cards/card_mesh
 require daslib/json_boost
 require daslib/safe_addr
 require daslib/math_boost
@@ -565,9 +566,25 @@ def screen_to_cell(mx, my : float) : int2 {
     return int2(col, row)
 }
 
-def handle_mouse() {
+// glfwGetCursorPos returns window points; layout/draw use framebuffer pixels
+// (live_get_framebuffer_size). On macOS Retina the two differ by the content
+// scale (~2x). All hit-testing is in pixel space (matches draw_*), so this
+// helper returns the cursor in pixel coordinates.
+def mouse_pos_pixels() : float2 {
+    var win_w_pts = 0
+    var win_h_pts = 0
+    glfwGetWindowSize(live_window, unsafe(addr(win_w_pts)), unsafe(addr(win_h_pts)))
+    let scale_x = win_w_pts > 0 ? float(screen_w) / float(win_w_pts) : 1.0
+    let scale_y = win_h_pts > 0 ? float(screen_h) / float(win_h_pts) : 1.0
     let mpos = glfwGetCursorPos(live_window)
-    let cell = screen_to_cell(mpos.x, mpos.y)
+    return float2(float(mpos.x) * scale_x, float(mpos.y) * scale_y)
+}
+
+def handle_mouse() {
+    let mp = mouse_pos_pixels()
+    let mx = mp.x
+    let my = mp.y
+    let cell = screen_to_cell(mx, my)
     hover_col = cell.x
     hover_row = cell.y
     let pressed = glfwGetMouseButton(live_window, int(GLFW_MOUSE_BUTTON_1)) == int(GLFW_PRESS)
@@ -677,7 +694,7 @@ def draw_hand_by_suit(player_idx : int; anchor_x, anchor_y : float; scale : floa
     }
     // Handle click on human hand cards
     if (is_human && game.phase == GamePhase.playing && game.current_player == 0 && mouse_clicked) {
-        let mpos = glfwGetCursorPos(live_window)
+        let mp = mouse_pos_pixels()
         var clicked = -1
         for (row in range(num_suits)) {
             let row_start = suit_starts[row]
@@ -688,7 +705,7 @@ def draw_hand_by_suit(player_idx : int; anchor_x, anchor_y : float; scale : floa
                 let rx = grow_right ? float(ci) : -float(ci) - 1.0
                 let card_x = anchor_x + rx * step_x + (grow_right ? 0.0 : (step_x - cs_w))
                 let card_y = anchor_y + ry * row_step
-                if (mpos.x >= card_x && mpos.x <= card_x + cs_w && mpos.y >= card_y && mpos.y <= card_y + cs_h) {
+                if (mp.x >= card_x && mp.x <= card_x + cs_w && mp.y >= card_y && mp.y <= card_y + cs_h) {
                     clicked = c
                 }
             }
@@ -1004,17 +1021,16 @@ def init() {
     compute_board_card_indices()
     if (!ui_font_loaded) {
         create_ttf_objects()
-        let font_dir = dir_name(get_module_file_name("card_mesh"))
-        ui_font <- load_ttf("{font_dir}/DejaVuSerif.ttf", [pixel_height = 24.0, oversampling = 2])
+        let primary_ttf = card_mesh_ttf_path()
+        ui_font <- load_ttf(primary_ttf, [pixel_height = 24.0, oversampling = 2])
         if (empty(ui_font.bitmap.bytes)) {
-            ui_font <- load_ttf("{get_das_root()}/modules/dasOpenGL/examples/droidsansmono.ttf",
-                [pixel_height = 24.0, oversampling = 2])
+            let fallback_ttf = "{get_das_root()}/modules/dasOpenGL/examples/droidsansmono.ttf"
+            ui_font <- load_ttf(fallback_ttf, [pixel_height = 24.0, oversampling = 2])
         }
         if (!empty(ui_font.bitmap.bytes)) {
             upload_font_texture(ui_font)
             // Small font for hints
-            let font_dir2 = dir_name(get_module_file_name("card_mesh"))
-            ui_font_small <- load_ttf("{font_dir2}/DejaVuSerif.ttf", [pixel_height = 14.0, oversampling = 2])
+            ui_font_small <- load_ttf(primary_ttf, [pixel_height = 14.0, oversampling = 2])
             if (empty(ui_font_small.bitmap.bytes)) {
                 ui_font_small <- load_ttf("{get_das_root()}/modules/dasOpenGL/examples/droidsansmono.ttf",
                     [pixel_height = 14.0, oversampling = 2])
@@ -1023,6 +1039,8 @@ def init() {
                 upload_font_texture(ui_font_small)
             }
             ui_font_loaded = true
+        } else {
+            to_log(LOG_ERROR, "ui_font: failed to load '{primary_ttf}' — text will not render\n")
         }
     }
     if (game.phase == GamePhase.not_started) {

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1158,6 +1158,9 @@ namespace das
         static void Initialize();
         static void CollectFileInfo(das::vector<FileInfoPtr> &accesses);
         static void Shutdown( bool dumpHandleLeaks = true );
+        // Runtime-only shutdown — for standalone exes built with `daslang -exe`,
+        // which link libDaScript*_runtime without the fusion engine. See issue #2583.
+        static void ShutdownStandalone( bool dumpHandleLeaks = false );
         static uint64_t CountHandleLeaks();
         static void Reset(bool debAg);
         static void ClearSharedModules();
@@ -1254,6 +1257,7 @@ namespace das
         Module * next = nullptr;
         unique_ptr<FileInfo>    ownFileInfo;
         FileAccessPtr           promotedAccess;
+        static void shutdownInternal ( bool dumpHandleLeaks, bool resetFusion );
     };
 
     #define REGISTER_MODULE(ClassName) \

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -1028,6 +1028,15 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     }
 
     let main_ret = LLVMBuildCall2(builder, g_fn_types[start_fn_name], LLVMGetNamedFunction(g_mod, start_fn_name), main_params, "")
+    // Drain debug agents, modules, AOT library, env — mirrors what the interpreter
+    // driver does at shutdown. Without this the static g_DebugAgents map dtor
+    // races ref_count_mutex during __cxa_finalize_ranges (issue #2583).
+    let shutdown_fn_type = LLVMFunctionType(types.t_void, array<LLVMTypeRef>())
+    var shutdown_fn = LLVMGetNamedFunction(g_mod, "jit_shutdown")
+    if (shutdown_fn == null) {
+        shutdown_fn = LLVMAddFunctionWithType(g_mod, "jit_shutdown", shutdown_fn_type)
+    }
+    LLVMBuildCall2(builder, shutdown_fn_type, shutdown_fn, array<LLVMValueRef>(), "")
     if (no_return) {
         LLVMBuildRet(builder, types.ConstI32(uint64(0)))
     } else {

--- a/skills/daspkg.md
+++ b/skills/daspkg.md
@@ -243,6 +243,8 @@ The macro captures the call-site source file path at expansion, then walks the s
 
 `<rel>` is the suffix starting at the last `/modules/` segment.
 
+**Project-local code (no `/modules/` in path) currently falls straight to tier 3** — `get_this_module_dir()` from user code like `main.das` returns the dev-time baked dir, which doesn't exist in a relocated bundle. Symptom: silent asset-load failures (e.g. fonts) when running the released bundle on a fresh machine, even though library code under `/modules/` works fine. Workaround: expose the asset dir via a `def public` getter from a library module under `/modules/`, then call it from user code. See [skills/filesystem.md](skills/filesystem.md) ("Finding bundled asset files at runtime") for the details.
+
 **Call from inside a function — not a top-level `let` initializer.** daslang's `-exe` JIT path has a known limitation: top-level `let`s that call Context-allocating builtins (like `get_this_module_dir()`, `get_das_root()`, `dir_name(get_module_file_name(...))`) emit JIT-process-baked function pointers that are wrong under ASLR in the standalone exe. The same call works fine inside any function body. Tracked separately; once the daslang fix lands, the top-level form will Just Work.
 
 ### What does **not** ship

--- a/skills/filesystem.md
+++ b/skills/filesystem.md
@@ -185,6 +185,31 @@ let free_gb = info.free / (1ul << 30ul)
 
 Fields: `capacity`, `free`, `available` (all `uint64`).
 
+## Finding bundled asset files at runtime
+
+For loading data files (fonts, SVGs, configs) that ship next to your `.das` source, use `get_this_module_dir()` from `daslib/module_path` — **never** `dir_name(get_module_file_name(name))`. The latter returns the path baked at compile time, which is wrong in a relocated daspkg-release standalone bundle (`get_module_file_name` returns empty for some standalone exe lookups).
+
+```das
+require daslib/module_path
+
+def load_assets() {
+    let dir = get_this_module_dir()
+    let svg = path_join(dir, "cards.svg")
+    // ...
+}
+```
+
+The macro captures the call-site source-file path at expansion, then a 3-tier resolver walks `<exe_dir>/<rel>` → `<das_root>/<rel>` → `dir_name(baked)`. `<rel>` is the suffix starting at the last `/modules/` segment.
+
+**Caveat for project-local code (no `/modules/` in source path):** `get_this_module_dir()` from a user's `main.das` (or anywhere outside `/modules/...`) currently falls straight to tier 3 — i.e. returns the dev-time baked dir, which doesn't exist on a relocated bundle's machine. This makes `"{get_this_module_dir()}/<asset>"` from `main.das` resolve to a non-existent path post-release. Two workarounds until the resolver learns to fall back to `<exe_dir>` when baked is gone:
+
+1. Have a sibling module under `/modules/` expose its dir as a public function (`def public my_module_dir() : string { return get_this_module_dir() }`) and call that from user code.
+2. If the user app needs only the exe-relative root, plumb it via a builtin (none exists yet — `getExecutableFileName` is C++-only).
+
+See [skills/daspkg.md](skills/daspkg.md#L224) for the bundle-shipping side of the same topic.
+
+**Don't call from a top-level `let` initializer** — `-exe` JIT-bakes function pointers in module-init code and ASLR breaks them in standalone exes (issue #2582). Inside any `def` body it's fine.
+
 ## Common gotchas
 
 - **Never split paths with `rfind("/")` and `rfind("\\")` followed by `slice`.** Always `base_name` / `dir_name` / `parent`. The manual form misses Windows backslashes, mishandles trailing separators, and returns the wrong slice when no separator is present. Exception: when the substring you're searching for is a **named component** (e.g. `/modules/`, `/.git/`), normalize once via `to_generic_path(p)` and search for forward slashes only: `rfind(to_generic_path(p), "/modules/")`. The normalize step is what makes the rule "search for `/` only" safe; never search for both `/X/` and `\X\` separately.

--- a/src/ast/ast_module.cpp
+++ b/src/ast/ast_module.cpp
@@ -215,7 +215,7 @@ namespace das {
         return handleRegistry_countAll();
     }
 
-    void Module::Shutdown( bool dumpHandleLeaks ) {
+    void Module::shutdownInternal ( bool dumpHandleLeaks, bool resetFusion ) {
         DAS_ASSERT(daScriptEnvironment::getOwned()!=nullptr);
         DAS_ASSERT(daScriptEnvironment::getBound()!=nullptr);
         g_envTotal --;
@@ -237,13 +237,28 @@ namespace das {
         delete daScriptEnvironment::getBound()->g_dyn_modules_resolve;
 
         clearGlobalAotLibrary();
-        DAS_ASSERTF(g_resetFusionEngineFn, "fusion library not loaded");
-        g_resetFusionEngineFn();
+        if ( resetFusion ) {
+            DAS_ASSERTF(g_resetFusionEngineFn, "fusion library not loaded");
+            g_resetFusionEngineFn();
+        }
         daScriptEnvironment::setBound(nullptr);
         if ( daScriptEnvironment::getOwned() ) {
             delete daScriptEnvironment::getOwned();
             daScriptEnvironment::setOwned(nullptr);
         }
+    }
+
+    void Module::Shutdown( bool dumpHandleLeaks ) {
+        shutdownInternal(dumpHandleLeaks, /*resetFusion=*/true);
+    }
+
+    // Standalone exes built with `daslang -exe` link only libDaScript*_runtime
+    // (no fusion). They call this from the LLVM-generated main right before
+    // returning, so the static g_DebugAgents map and module list drain while
+    // the runtime is still alive — avoids the __cxa_finalize_ranges race on
+    // ref_count_mutex documented in issue #2583.
+    void Module::ShutdownStandalone( bool dumpHandleLeaks ) {
+        shutdownInternal(dumpHandleLeaks, /*resetFusion=*/false);
     }
 
     void Module::Reset(bool debAg) {

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -1041,6 +1041,14 @@ DAS_API void jit_initialize_modules_done () {
     das::Module::Initialize();
 }
 
+// Standalone-exe teardown. Emitted by inject_main right before main returns,
+// so debug agents and modules drain while the runtime is alive. Without this,
+// the static g_DebugAgents map dtor races ref_count_mutex during
+// __cxa_finalize_ranges and terminate() fires (issue #2583).
+DAS_API void jit_shutdown () {
+    das::Module::ShutdownStandalone();
+}
+
 DAS_API void * jit_register_dynamic_module ( const char * path, const char * mod_name ) {
     return das::register_dynamic_module(path, mod_name, 0/*Quiet*/, nullptr, nullptr);
 }


### PR DESCRIPTION
## Summary

- **#2583 fix** — `daslang -exe` standalone binaries crashed at process exit with `mutex lock failed: Invalid argument`. Static `g_DebugAgents` map dtor raced `ref_count_mutex` during `__cxa_finalize_ranges`. Interpreter mode was fine because `utils/daScript/main.cpp` calls `Module::Shutdown()` explicitly to drain agents while the runtime is alive; standalone exes had no equivalent.

  - Split `Module::Shutdown` body into private `shutdownInternal(dump, resetFusion)`. `Module::Shutdown` keeps current semantics (asserts fusion + resets); new `Module::ShutdownStandalone` skips fusion (`libDaScript*_runtime` doesn't link the fusion engine).
  - Add `DAS_API jit_shutdown()` C helper calling `ShutdownStandalone`.
  - Emit a call to `jit_shutdown` in `inject_main` between user `main()` return and `LLVMBuildRet`, so the static map drains while contexts are live.

- **Sequence-game text rendering in bundle** — `dir_name(get_module_file_name("card_mesh"))` returns empty for user `.das` modules in standalone exes, so the font path resolved to `/DejaVuSerif.ttf`. Switch to a new `card_mesh_ttf_path()` getter exposed by dasCards (companion change [borisbat/dasCards@f2502ec](https://github.com/borisbat/dasCards/commit/f2502ec)) which uses `get_this_module_dir()` and goes through the 3-tier resolver (exe_dir → das_root → baked).

- **Sequence-game mouse hit-test on macOS Retina** — `glfwGetCursorPos` returns window points, but board layout uses framebuffer pixels (`live_get_framebuffer_size`). On Retina, the two differ by ~2x, so cursor coordinates fell outside the board's hit region. Add `mouse_pos_pixels()` helper that scales cursor up to pixel space via `glfwGetWindowSize` + `screen_w` ratio. Used at both cursor-read sites (`handle_mouse` and the hand-card click handler).

- **Skills** — `skills/daspkg.md` + `skills/filesystem.md` document the `get_this_module_dir()` 3-tier-walk gap for project-local code: paths without `/modules/` segment fall through to the dev-time baked dir, breaking asset loads from user-side `main.das` in relocated bundles. Workaround: library exposes `def public dir_getter()`; user calls it.

## A/B verification

`examples/games/sequence` from PR #2584's daspkg release path.

**Without #2583 fix:**
```
sequence: shutdown
libc++abi: terminating due to uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
exit code: 134
```

**With #2583 fix:**
```
sequence: shutdown
exit code: 0
```

Daspkg release bundle (`/tmp/sequence-release/sequence/sequence.exe`) loads cards, renders text via `card_mesh_ttf_path()`, mouse clicks land on the right board cells on Retina, and exits cleanly.

## Test plan

- [x] Lint changed `.das` files via `utils/lint/main.das` — clean (only pre-existing warnings in `llvm_exe.das`; project-local resolution gap on `examples/games/sequence/main.das` will be addressed separately).
- [x] Full interpreter test suite: 7859 passed / 0 failed / 0 errors / 6 skipped.
- [x] Full AOT test suite (after rebuilding `test_aot` to pick up new dasSQLITE tests from PR #2581): 7253 passed / 0 failed / 0 errors / 6 skipped.
- [x] `examples/games/sequence` bundle ran end-to-end on macOS Retina — cards drew, text rendered, mouse clicks hit correct cells, clean exit.
- [x] `bin/daslang -exe -output /tmp/seq main.das` standalone repro reproduces #2583 crash without the fix; clean exit with the fix.
- [x] All 14 ctest small/integration/exe-paths tests pass.
- [x] Format check via `mcp__daslang__format_file` — both `.das` files already-formatted.

## Out of scope

- Issue #2582 (top-level `let X = builtin()` SIGBUS under ASLR) — separate JIT/LLVM constant-folding issue.
- The `get_this_module_dir()` 3-tier-walk gap for project-local code itself — documented but the resolver fix in `builtin_resolve_this_module_dir` is deferred. Sketch in the skill files notes the single-branch change.
- macOS `.app` bundle generation in daspkg release — distinct fix; not needed since the keyboard "issue" we suspected turned out to be the Retina coordinate mismatch above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)