### PR TITLE
daslang plugin fails to perform completion, every time there is any

### DIFF
--- a/src/builtin/module_builtin_dasbind.cpp
+++ b/src/builtin/module_builtin_dasbind.cpp
@@ -444,9 +444,6 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
         }
 
         virtual bool apply ( const FunctionPtr & fun, ModuleGroup &, const AnnotationArgumentList & args, string & err )  override {
-            if (is_in_completion()) {
-                return false;
-            }
             if (!verifyCallCorrect(fun, args, err)) {
                 return false;
             }


### PR DESCRIPTION
external binding - for example anything "opengl". silent falltrhough, though, is not exactly an option - it can prevent some macros from working, things like GLSL preprocessor etc. So, we drop the early out and let those API's exist and fully function at copmletion time.