### PR TITLE
dasSQLITE chunk 14b: typed ALTER macros + module rename

### DIFF
--- a/doc/source/reference/tutorials/sql_39_schema_from.rst
+++ b/doc/source/reference/tutorials/sql_39_schema_from.rst
@@ -146,10 +146,10 @@ today is what the script reads/writes. ETL between two DBs,
 archival readers, admin tooling --- all good fits.
 
 For "the DB grows over time, run versioned schema migrations at
-startup", a future ``daslib/sql_migrate`` module ships
+startup", a future ``daslib/sqlite_migrate`` module ships
 ``[sql_migration(version=N)]`` + a runtime runner. The two are
 orthogonal: ``schema_from`` gives compile-time contract checks
-against a known schema; ``sql_migrate`` evolves the schema over
+against a known schema; ``sqlite_migrate`` evolves the schema over
 time. See :ref:`tutorial_sql_schema_evolution` for the
 multi-version ETL pattern.
 

--- a/doc/source/reference/tutorials/sql_42_schema_evolution.rst
+++ b/doc/source/reference/tutorials/sql_42_schema_evolution.rst
@@ -113,11 +113,11 @@ surfaces, you add a third struct + a third loop and the type
 system tells you exactly where to wire it up.
 
 For "my app's schema evolves at runtime; I run migrations at
-startup", a future ``daslib/sql_migrate`` module ships a
+startup", a future ``daslib/sqlite_migrate`` module ships a
 different shape: versioned ``[sql_migration(version=N)]``
 functions applied in order, tracked in ``__schema_version``,
 transactional per migration. The two patterns coexist:
-``schema_from`` for *code-on-current-schema*, ``sql_migrate``
+``schema_from`` for *code-on-current-schema*, ``sqlite_migrate``
 for the *schema-grows-over-time* runner.
 
 .. seealso::

--- a/doc/source/reference/tutorials/sql_43_migrations.rst
+++ b/doc/source/reference/tutorials/sql_43_migrations.rst
@@ -72,12 +72,12 @@ Define a schema and write migrations
 
     [sql_migration(version = 2, description = "add email column")]
     def migration_002(db : SqlRunner) {
-        db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
+        db |> add_column(type<User>, "Email", "")
     }
 
     [sql_migration(version = 3, description = "add score; backfill", analyze = true)]
     def migration_003(db : SqlRunner) {
-        db |> exec("ALTER TABLE users ADD COLUMN Score INTEGER NOT NULL DEFAULT 0")
+        db |> add_column(type<User>, "Score", 0)
         db |> exec("UPDATE users SET Score = 100 WHERE Email != ''")
     }
 
@@ -154,6 +154,68 @@ no-op for any DB that's already past it --- the audit row keeps
 the old text. Fresh installs pick up the new text on first
 apply.
 
+Typed ALTER: when daslang has enough info to validate
+======================================================
+
+Migrations 2 and 3 above use the typed surface in
+``daslib/sqlite_boost``:
+
+.. code-block:: das
+
+    db |> add_column(type<T>, "Field" [, defaultLit])
+    db |> create_index(type<T>, "Field" | ("A","B") [, "name"])
+    db |> create_unique_index(type<T>, ... same shape ...)
+    db |> drop_index_if_exists("name")
+
+Field selectors are **string literals**, not ``.Field`` syntax:
+gen2's parser only accepts ``.Field`` inside an ``_sql {...}``
+block. Plain call sites pass explicit string field names ---
+the same convention ``[sql_index(fields="A")]`` already uses.
+
+What the typed forms buy you:
+
+1. **Compile-time field-name checks.**
+   ``add_column(type<T>, "Emial")`` fails at compile time, not
+   on the user's DB at startup.
+
+2. **Type-derived NOT NULL.** Forgetting ``NOT NULL + DEFAULT``
+   used to mean existing rows panic on the next read after the
+   migration. The macro derives nullability from
+   ``Option<>`` wrapping and refuses to ADD a non-nullable
+   column without a literal default.
+
+3. **Annotation reuse.** ``@sql_column`` rename + ``@sql_json``
+   / ``@sql_blob`` storage are honored automatically --- same
+   conventions as ``[sql_table]`` / ``[sql_index]``, no
+   double-bookkeeping.
+
+A second migration that adds an index and a unique composite,
+with an idempotent rebuild pattern via
+``drop_index_if_exists``:
+
+.. code-block:: das
+
+    [sql_migration(version = 4, description = "index Email")]
+    def migration_004(db : SqlRunner) {
+        db |> create_index(type<User>, "Email")
+    }
+
+    [sql_migration(version = 5, description = "unique (Email, Name)")]
+    def migration_005(db : SqlRunner) {
+        db |> drop_index_if_exists("ux_email_name")
+        db |> create_unique_index(type<User>, ("Email", "Name"), "ux_email_name")
+    }
+
+What stays on raw ``db |> exec(...)``:
+
+- DROP COLUMN / RENAME COLUMN --- old names aren't in the
+  current struct, so daslang has nothing to validate against.
+- PK / UNIQUE inline / generated columns added post-hoc ---
+  SQLite can't ALTER these in place; needs a table rebuild
+  (chunk 14c, ``struct_convert``).
+- ``CHECK`` constraints, FK ADD/DROP, column type changes.
+- Anything ad-hoc that doesn't map to a struct field.
+
 Adopting migrations on an existing DB
 ======================================
 
@@ -228,17 +290,14 @@ What does NOT ship
   Future work, also dovetails with the eventual ``dasSQL``
   abstraction layer.
 
-- **Typed ``ALTER`` macros** (``add_column``, ``create_index``,
-  ``drop_index_if_exists``). Coming in chunk 14b. For now,
-  every ALTER is raw SQL --- which works for every form on the
-  bundled SQLite 3.41.2, including ``DROP COLUMN`` and
-  ``RENAME COLUMN``.
-
 - **Struct-to-struct rebuild support** (``struct_convert``,
   ``[sql_table(legacy=true)]``, ``name=`` overrides). Coming
   in chunk 14c. For now, schema rebuilds are hand-written
   ``CREATE TABLE T_new`` + ``INSERT ... SELECT`` --- works,
-  just verbose.
+  just verbose. The typed ALTER surface above covers the
+  additive cases (ADD COLUMN, CREATE INDEX); ``DROP COLUMN`` /
+  ``RENAME COLUMN`` stay on raw ``db |> exec(...)`` until that
+  chunk lands.
 
 .. seealso::
 

--- a/doc/source/reference/tutorials/sql_43_migrations.rst
+++ b/doc/source/reference/tutorials/sql_43_migrations.rst
@@ -55,7 +55,7 @@ Define a schema and write migrations
 
 .. code-block:: das
 
-    require sqlite/sql_migrate
+    require sqlite/sqlite_migrate
 
     [sql_table(name = "users")]
     struct User {

--- a/modules/dasSQLITE/.das_module
+++ b/modules/dasSQLITE/.das_module
@@ -6,7 +6,7 @@ def initialize(project_path : string) {
     if (das_is_dll_build()) {
         register_dynamic_module("{project_path}/dasModuleSQLITE.shared_module", "Module_dasSQLITE")
     }
-    let sqlite_paths = ["sqlite_boost", "sqlite_linq", "sql_migrate"]
+    let sqlite_paths = ["sqlite_boost", "sqlite_linq", "sqlite_migrate"]
     for (path in sqlite_paths) {
         register_native_path("sqlite", "{path}", "{project_path}/daslib/{path}.das")
     }

--- a/modules/dasSQLITE/API_MIGRATION.md
+++ b/modules/dasSQLITE/API_MIGRATION.md
@@ -74,7 +74,7 @@ with_sqlite("app.db") <| $(db) {
 ```
 
 **Convenience wrapper (decided 2026-05-04):** ship `with_latest_sqlite(path)`
-in `daslib/sql_migrate` that combines `with_sqlite` + `migrate_to_latest`
+in `daslib/sqlite_migrate` that combines `with_sqlite` + `migrate_to_latest`
 into one call. Less ceremony, harder to ship a binary that opens the DB
 without bringing it up to date. Preferred form for app code; the explicit
 two-step form remains for tools/CI that may want to inspect before
@@ -351,7 +351,7 @@ when (if) a concrete use case shows up.
 
 `detect_duplicates` from chunk 13 is fuzzy — produces false positives.
 Wrong shape for a compile-time hard error. Right shape for a PR-review
-helper: a `daslib/sql_migrate_lint` (or similar) tool that scans the
+helper: a `daslib/sqlite_migrate_lint` (or similar) tool that scans the
 migration registry and flags suspiciously-similar bodies for human
 review. Useful for catching copy-paste mistakes during merges, but
 the dev keeps the final call. Out of scope for v1; revisit when the
@@ -510,7 +510,7 @@ body, possibly with intermediate `with_transaction { … }` savepoints
 
 **Future polish (not blocking v1) — `chunked_update` helper.**
 
-A `daslib/sql_migrate_chunk` follow-up could ship `db |>
+A `daslib/sqlite_migrate_chunk` follow-up could ship `db |>
 chunked_update(type<T>, where, set, chunk_size = 10000)` for large data
 backfills with controlled lock contention. Logged for if real demand
 surfaces.
@@ -664,8 +664,8 @@ attempted-write boundary (`migrate_to_latest`).
 Closes Q4 from the open-questions list.
 
 **Setup.** User has been shipping the app for a year *without*
-`daslib/sql_migrate`. Their `app.db` already has `users`, `orders`, etc.
-Dev pulls in `daslib/sql_migrate`, writes `[sql_migration(version=1)]`
+`daslib/sqlite_migrate`. Their `app.db` already has `users`, `orders`, etc.
+Dev pulls in `daslib/sqlite_migrate`, writes `[sql_migration(version=1)]`
 that does `db |> exec("CREATE TABLE users (…)")` representing the v1
 shape, swaps `with_sqlite` → `with_latest_sqlite`. Boom — runtime crashes
 with "table users already exists."
@@ -829,7 +829,7 @@ runs once per call.
 Catching two distinct version numbers with semantically-similar bodies
 (copy-paste merge mistakes) is fuzzy — `detect_duplicates` produces
 false positives. Wrong shape for a build gate. Right shape for a
-`daslib/sql_migrate_lint` (or similar) PR-review helper that flags
+`daslib/sqlite_migrate_lint` (or similar) PR-review helper that flags
 suspect bodies for human review. Out of scope for v1; revisit when the
 ecosystem matures.
 
@@ -1066,7 +1066,7 @@ answer they get when they ask.
 API_REWORK §30 deferred-list item #1 originally left the door slightly
 ajar ("Future: if shipped, live as a separate function macro"). The
 discussion in this scenario closes it. Down-migrations are a *design
-anti-pattern*, not a missing feature. Future versions / `daslib/sql_migrate_*`
+anti-pattern*, not a missing feature. Future versions / `daslib/sqlite_migrate_*`
 follow-ups should not ship them either. If a real use case forces our
 hand, revisit then; default posture is permanent "no."
 
@@ -1474,9 +1474,9 @@ union of:
 - **Typed ALTER:** `add_column(type<T>, .Field, default=…)`;
   `create_index(type<T>, fields=…, unique=…, name=…)`;
   `drop_index_if_exists(name)`.
-- **Module:** all of the above lives in `daslib/sql_migrate`
+- **Module:** all of the above lives in `daslib/sqlite_migrate`
   (separate from core `daslib/sql`); `[sql_migration]` annotation
-  is the only thing that registers without `require daslib/sql_migrate`
+  is the only thing that registers without `require daslib/sqlite_migrate`
   if convenient (TBD during impl).
 - **Audit table:** `__schema_version` 3-column shape (`version`,
   `description`, `applied_at`).

--- a/modules/dasSQLITE/API_MIGRATION.md
+++ b/modules/dasSQLITE/API_MIGRATION.md
@@ -357,18 +357,24 @@ review. Useful for catching copy-paste mistakes during merges, but
 the dev keeps the final call. Out of scope for v1; revisit when the
 ecosystem matures.
 
-**Decision (locked 2026-05-04) — ship typed ALTER surface for the
-additive cases.**
+**Decision (locked 2026-05-04, shipped 14b chunk) — typed ALTER surface
+for the additive cases.**
 
 Migration bodies don't have to stay raw-SQL-only. The cases where
 daslang has enough information to validate against the current struct
 ship as typed macros; everything else stays raw `db |> exec(…)`.
 
+Field selectors use **string literals**, not `.Field` syntax: gen2's
+parser only parses `.Field` inside `_sql {…}` blocks where `_` is a
+synthetic placeholder. Plain call sites need explicit string field
+names — same convention `[sql_index(fields="A")]` already uses.
+
 | Form | Shipped surface | Emits |
 |---|---|---|
-| ADD COLUMN | `db \|> add_column(type<T>, .Field [, default = expr])` | `ALTER TABLE t ADD COLUMN Field <SQL_TYPE> [NOT NULL] [DEFAULT …]`. SQL type from `_::sql_bind` adapter rail; NOT NULL derived from absence of `Option<>` wrapping; default from the expression via `to_sql_literal`. |
-| CREATE INDEX | `db \|> create_index(type<T>, fields = (.A, .B), unique = true [, name = "ix_…"])` | `CREATE [UNIQUE] INDEX <name> ON t(A, B)`. Name auto-derived as `idx_<table>_<col1>_<col2>` to match the `[sql_index]` annotation convention from tut 24. |
-| DROP INDEX | `db \|> drop_index_if_exists("ix_users_email")` | `DROP INDEX IF EXISTS ix_users_email`. Just a name string — no struct typing. |
+| ADD COLUMN | `db \|> add_column(type<T>, "Field" [, defaultLit])` | `ALTER TABLE t ADD COLUMN Field <SQL_TYPE> [NOT NULL] [DEFAULT …]`. SQL type from `_::sql_storage_type_for` (the `_::sql_bind` adapter rail); NOT NULL derived from absence of `Option<>` wrapping; DEFAULT from the literal via `literal_init_to_default_clause`. `@sql_column` rename + `@sql_json` / `@sql_blob` storage are honored. |
+| CREATE INDEX | `db \|> create_index(type<T>, "Field" \| ("A","B") [, "ix_…"])` | `CREATE INDEX <name> ON t(A, B)`. Name auto-derived as `idx_<table>_<col1>_<col2>` to match the `[sql_index]` annotation convention from tut 24. |
+| CREATE UNIQUE INDEX | `db \|> create_unique_index(type<T>, … same shape …)` | `CREATE UNIQUE INDEX <name> ON t(A, B)`. Separate macro (no boolean named arg, since gen2 named-args use `[name=val]` bracket form which call_macros don't intercept). |
+| DROP INDEX | `db \|> drop_index_if_exists("ix_users_email")` | Plain runtime function. `DROP INDEX IF EXISTS "ix_users_email"`. |
 
 **Reasoning:**
 
@@ -397,16 +403,26 @@ escape is `db |> exec(…)`):
 The reader's mental model is consistent: *typed when daslang has enough
 info to validate, raw when it doesn't.*
 
-**Test cases (typed ALTER):**
+**Test cases (typed ALTER) — shipped 14b:**
 
 | File | What it asserts |
 |---|---|
-| `15_add_column_simple.das` | `add_column(type<User>, .Email, default = "")` emits the expected DDL; column appears in `pragma_table_info` with TEXT NOT NULL DEFAULT ''. |
-| `16_add_column_optional.das` | `add_column(type<User>, .LastLoginAt)` for `Option<int64>` field emits INTEGER (no NOT NULL, no default). |
-| `17_create_index_default_name.das` | `create_index(type<User>, fields = (.Email,))` emits `idx_users_email`; visible in `sqlite_master`. |
-| `18_create_index_unique_composite.das` | `create_index(type<User>, fields = (.Email, .LastLoginAt), unique = true, name = "ix_lookup")` emits `CREATE UNIQUE INDEX ix_lookup ON users(Email, LastLoginAt)`. |
-| `19_drop_index_if_exists.das` | Drop nonexistent index → no error; create + drop → second pragma shows it gone. |
-| `20_typed_and_raw_mix.das` | Migration body using both `add_column` (typed) and `db \|> exec("DROP COLUMN OldField")` (raw) compiles and applies cleanly. Locks the "mix freely" claim. |
+| `migrate_14_add_column_optional.das` | `Option<string>` field emits nullable TEXT (no NOT NULL, no DEFAULT); `pragma_table_info` confirms. |
+| `migrate_15_add_column_default.das` | `add_column(type<T>, "Score", 0)` emits NOT NULL INTEGER DEFAULT 0; pre-existing rows backfill via SQLite's ALTER. |
+| `migrate_16_add_column_string_quoting.das` | Embedded single-quote (`"O'Reilly"`) escapes correctly via `sql_quote_string_literal`; round-trips. |
+| `migrate_17_add_column_renamed.das` | `@sql_column("email_addr")` propagates: emitted DDL uses the renamed identifier, not the daslang field name. |
+| `migrate_18_add_column_json.das` | `@sql_json` field of struct type emits TEXT storage. |
+| `migrate_19_add_column_blob.das` | `@sql_blob` field of struct type emits BLOB storage; `Option<T>` keeps it nullable. |
+| `migrate_20_create_index_basic.das` | Auto-name `idx_<table>_<col>`, non-unique by default. |
+| `migrate_21_create_index_unique_composite.das` | Composite UNIQUE with explicit name; `drop_index_if_exists` is idempotent across missing/existing/missing names. |
+| `migrate_22_add_column_dup_runtime.das` | Re-adding the same column at runtime panics inside the migration; α-shape transaction rolls back the whole call (audit table empty, table doesn't exist). |
+| `failed_add_column_unknown_field.das` | macro_error: field not on struct. |
+| `failed_add_column_no_sql_table.das` | macro_error: type<T> lacks `[sql_table]`. |
+| `failed_add_column_pk_rejected.das` | macro_error: cannot ADD a PK column (recreate table). |
+| `failed_add_column_unique_rejected.das` | macro_error: cannot ADD UNIQUE inline (use `create_unique_index`). |
+| `failed_add_column_nonliteral_default.das` | macro_error: DEFAULT must be a compile-time literal. |
+| `failed_create_index_unknown_field.das` | macro_error: field not on struct. |
+| `failed_create_index_empty_fields.das` | macro_error: empty fields list. |
 
 ---
 

--- a/modules/dasSQLITE/API_MISSING.md
+++ b/modules/dasSQLITE/API_MISSING.md
@@ -1074,7 +1074,7 @@ with_sqlite("app.db") <| $(db) {
 - **Where does `__schema_version` live?** Reserved table name? User-
   configurable via a setting? Single integer or migration-name-set?
 - **Out of scope for the dasSQLITE rework itself.** Probably ships as
-  `daslib/sql_migrate` (separate module) once the core API stabilizes.
+  `daslib/sqlite_migrate` (separate module) once the core API stabilizes.
   Design constraint: the `[sql_table]` machinery must not preclude a
   future struct-diff implementation — keep field metadata
   introspectable.
@@ -1697,7 +1697,7 @@ layer" or "this lives in the provider." Quick sweep:
 | 27 indexes | abstract |
 | 28 defaults_computed | abstract surface; raw-SQL defaults inherently provider-specific |
 | 29 custom_types | abstract registration API; per-provider type table |
-| 30 migrations | separate module (`daslib/sql_migrate`) |
+| 30 migrations | separate module (`daslib/sqlite_migrate`) |
 | 31 views | abstract |
 | 32 sql_functions | abstract registration; per-provider built-in baseline |
 | 33 PRAGMA | provider-only (`sqlite/sqlite_boost`) |

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -3722,13 +3722,14 @@ Adoption:
 | `baseline(db, version)` | `(db : SqlRunner, version : int) : void` | stamp v1..N rows in `__schema_version` without running their bodies (Flyway-style adoption) |
 | `try_baseline(db, version)` | `(db : SqlRunner, version : int) : Result<int, string>` | Result form |
 
-Typed ALTER (additive cases that align with the current struct):
+Typed ALTER (additive cases that align with the current struct, shipped 14b):
 
 | Name | Shape | Role |
 |---|---|---|
-| `add_column(db, type<T>, .Field [, default = expr])` | call macro | `ALTER TABLE … ADD COLUMN`; SQL type from `_::sql_bind` adapter; NOT NULL from absence of `Option<>` wrapping |
-| `create_index(db, type<T>, fields = (…), [unique=true,] [name="…"])` | call macro | `CREATE [UNIQUE] INDEX`; auto-name `idx_<table>_<col1>_<col2>` |
-| `drop_index_if_exists(db, name)` | function | `DROP INDEX IF EXISTS …` |
+| `add_column(db, type<T>, "Field" [, defaultLit])` | call macro | `ALTER TABLE … ADD COLUMN`; SQL type from `_::sql_storage_type_for` (the `_::sql_bind` adapter rail); NOT NULL from absence of `Option<>` wrapping; honors `@sql_column` rename + `@sql_json` / `@sql_blob`. Field selectors are string literals (gen2's `.Field` syntax only parses inside `_sql {…}` blocks). |
+| `create_index(db, type<T>, "Field" \| ("A","B") [, "ix_…"])` | call macro | `CREATE INDEX`; auto-name `idx_<table>_<col1>_<col2>` on the post-`@sql_column` SQL identifiers |
+| `create_unique_index(db, type<T>, … same shape …)` | call macro | `CREATE UNIQUE INDEX`. Separate macro (gen2 named-args use `[name=val]` brackets which call_macros don't intercept; positional separation is cleaner) |
+| `drop_index_if_exists(db, name)` | function | `DROP INDEX IF EXISTS "name"` (idempotent via SQLite's IF EXISTS) |
 
 Schema rebuild (the 12-step pattern as building blocks):
 

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -935,7 +935,7 @@ bind).
   picks the compile-time `_.Field` or runtime-string path. `_create_view`
   rejects runtime ORDER BY (DDL is run-once; runtime column would bake at
   view-creation time).
-- **Migrations (last chunk)** — `daslib/sql_migrate` module,
+- **Migrations (last chunk)** — `daslib/sqlite_migrate` module,
   `[sql_migration]` annotation collected across translation units,
   `migrate_to_latest` runner, `__schema_version` table, multi-row
   audit semantics.
@@ -3646,7 +3646,7 @@ stdlib-type passthrough overloads plus the enum generic.
 > rest of §30 stays as the original design rationale.
 
 **Verdict:** sixth consecutive tut with **zero linq prereqs.**
-Ships as a **separate, optional module** — `daslib/sql_migrate`
+Ships as a **separate, optional module** — `daslib/sqlite_migrate`
 — so users who don't need migrations don't pay for them, and
 the migration story evolves on its own schedule without
 destabilizing core dasSQLITE. Tutorial opens with an explicit
@@ -3665,7 +3665,7 @@ transactional) and explicitly defers everything else.
 
 ```das
 require daslib/sql
-require daslib/sql_migrate
+require daslib/sqlite_migrate
 require sqlite/sqlite_boost
 
 [sql_migration(version=1)]
@@ -3760,7 +3760,7 @@ matches Flyway's ergonomics at zero extra cost.
 
 **Ten locks:**
 
-1. **Separate module `daslib/sql_migrate`.** Sibling of
+1. **Separate module `daslib/sqlite_migrate`.** Sibling of
    `daslib/sql`, not merged into it. Users who don't need
    migrations don't `require` it; the migration API never
    appears in their symbol table.
@@ -3813,7 +3813,7 @@ This is the meat of the tutorial — what users need to know
 *isn't* shipping:
 
 - **Down migrations / rollback.** A user writing `migrate_down(db, target_version)` is on their own. Future: if shipped, live as a separate function macro `[sql_migration_down(version=N)]` pairing with the up one.
-- **Autogenerate from struct diff.** EF's `dotnet ef migrations add Foo` diffs the current model against a saved snapshot and emits the migration body automatically. Requires a model-snapshot system daslang doesn't have. Future: a separate `daslib/sql_migrate_gen` module (name TBD) with its own design discussion.
+- **Autogenerate from struct diff.** EF's `dotnet ef migrations add Foo` diffs the current model against a saved snapshot and emits the migration body automatically. Requires a model-snapshot system daslang doesn't have. Future: a separate `daslib/sqlite_migrate_gen` module (name TBD) with its own design discussion.
 - **Model snapshots** (v1's `User` shape preserved after v4 rewrites it). EF saves snapshot C# files per migration; daslang would need frozen-struct tooling. Not attempting.
 - **SQLite 12-step `ALTER TABLE` helper** (`recreate_table(db, type<T>, copy_from=...)` for drop/rename column on pre-3.25 SQLite). Highest-value migration helper and the single biggest pain point that distinguishes SQLite migrations from Postgres. Deliberately *not* shipped in v1 because getting it right is a mini-framework. Users writing `ALTER TABLE ... DROP COLUMN` on old SQLite versions write the 12-step by hand or bump the SQLite version requirement.
 - **Zero-downtime / expand-contract pattern.** The multi-deploy pattern where schema changes stay compatible with both old and new app versions running simultaneously. Needs migration-pairing, dry-run validation, and a deploy contract. Out of scope; users who need this are running live services and can wire it up externally.
@@ -3827,7 +3827,7 @@ This is the meat of the tutorial — what users need to know
 
 The tutorial's tone is "here's the 100-line MVP that makes
 dasSQLITE honest for production; the real migration framework
-is a future effort — likely a separate `daslib/sql_migrate_*`
+is a future effort — likely a separate `daslib/sqlite_migrate_*`
 module or at the future `dasSQL` abstraction layer." Users
 who need more than MVP know that on page one.
 
@@ -3839,7 +3839,7 @@ per-item "if you need this in v1, here's your escape."
 
 **Phase-0.3 impact:** zero. Zero linq additions. Advances
 dasSQLITE-phase scope: a **new module file**
-(`daslib/sql_migrate.das` — physical location TBD per the
+(`daslib/sqlite_migrate.das` — physical location TBD per the
 locked module-layout table), a function-level annotation macro
 (`[sql_migration]`), six public functions, one struct, one
 auto-created table.
@@ -3856,7 +3856,7 @@ auto-created table.
 | 27 indexes | 0 | 0 | `[sql_index]` stackable DDL |
 | 28 defaults_computed | 0 | 0 | `@sql_default` / `@sql_computed` DDL + bind-exclusion |
 | 29 custom_types | 0 | 0 | `_::sql_bind`/`_::sql_extract` emission + stdlib overloads |
-| 30 migrations | 0 | 0 | new `daslib/sql_migrate` module; `[sql_migration]` + runner |
+| 30 migrations | 0 | 0 | new `daslib/sqlite_migrate` module; `[sql_migration]` + runner |
 | **Total** | **2 fns** | **9 macros** | (emitter complexity accumulates) |
 
 ### 31-views — "`[sql_view]` as read-only `[sql_table]`; DDL in migrations" (decided 2026-04-24)
@@ -4036,7 +4036,7 @@ struct); one new function `drop_view_if_exists(type<V>)`
 | 27 indexes | 0 | 0 | `[sql_index]` stackable DDL |
 | 28 defaults_computed | 0 | 0 | `@sql_default` / `@sql_computed` DDL + bind-exclusion |
 | 29 custom_types | 0 | 0 | `_::sql_bind`/`_::sql_extract` emission + stdlib overloads |
-| 30 migrations | 0 | 0 | new `daslib/sql_migrate` module; `[sql_migration]` + runner |
+| 30 migrations | 0 | 0 | new `daslib/sqlite_migrate` module; `[sql_migration]` + runner |
 | 31 views | 0 | 0 | `[sql_view]` + `_create_view` (linq-based DDL, raw-SQL escape) + `drop_view_if_exists` |
 | **Total** | **2 fns** | **9 macros** | (emitter complexity accumulates) |
 
@@ -4268,7 +4268,7 @@ one new function (`register_function`), one new C++ binding
 | 27 indexes | 0 | 0 | `[sql_index]` stackable DDL |
 | 28 defaults_computed | 0 | 0 | `@sql_default` / `@sql_computed` DDL + bind-exclusion |
 | 29 custom_types | 0 | 0 | `_::sql_bind`/`_::sql_extract` emission + stdlib overloads |
-| 30 migrations | 0 | 0 | new `daslib/sql_migrate` module; `[sql_migration]` + runner |
+| 30 migrations | 0 | 0 | new `daslib/sqlite_migrate` module; `[sql_migration]` + runner |
 | 31 views | 0 | 0 | `[sql_view]` + `_create_view` (linq-based DDL, raw-SQL escape) + `drop_view_if_exists` |
 | 32 sql_functions | 0 | 0 | `sqlite/sqlite_boost::register_function` (SQLite-only, scalar-only) |
 | **Total** | **2 fns** | **9 macros** | (emitter complexity accumulates) |
@@ -4454,7 +4454,7 @@ All thin wrappers over `exec` / `sqlite3_exec`.
 | 27 indexes | 0 | 0 | `[sql_index]` stackable DDL |
 | 28 defaults_computed | 0 | 0 | `@sql_default` / `@sql_computed` DDL + bind-exclusion |
 | 29 custom_types | 0 | 0 | `_::sql_bind`/`_::sql_extract` emission + stdlib overloads |
-| 30 migrations | 0 | 0 | new `daslib/sql_migrate` module; `[sql_migration]` + runner |
+| 30 migrations | 0 | 0 | new `daslib/sqlite_migrate` module; `[sql_migration]` + runner |
 | 31 views | 0 | 0 | `[sql_view]` + `_create_view` (linq-based DDL, raw-SQL escape) + `drop_view_if_exists` |
 | 32 sql_functions | 0 | 0 | `sqlite/sqlite_boost::register_function` (SQLite-only, scalar-only) |
 | 33 pragma | 0 | 0 | `sqlite/sqlite_boost::set_pragma` × 3 + `apply_recommended_pragmas` (SQLite-only) |
@@ -4616,7 +4616,7 @@ over `query<string>`.
 | 27 indexes | 0 | 0 | `[sql_index]` stackable DDL |
 | 28 defaults_computed | 0 | 0 | `@sql_default` / `@sql_computed` DDL + bind-exclusion |
 | 29 custom_types | 0 | 0 | `_::sql_bind`/`_::sql_extract` emission + stdlib overloads |
-| 30 migrations | 0 | 0 | new `daslib/sql_migrate` module; `[sql_migration]` + runner |
+| 30 migrations | 0 | 0 | new `daslib/sqlite_migrate` module; `[sql_migration]` + runner |
 | 31 views | 0 | 0 | `[sql_view]` + `_create_view` (linq-based DDL, raw-SQL escape) + `drop_view_if_exists` |
 | 32 sql_functions | 0 | 0 | `sqlite/sqlite_boost::register_function` (SQLite-only, scalar-only) |
 | 33 pragma | 0 | 0 | `sqlite/sqlite_boost::set_pragma` × 3 + `apply_recommended_pragmas` (SQLite-only) |
@@ -4810,7 +4810,7 @@ schema, 5-item deferred list.
 | 27 indexes | 0 | 0 | `[sql_index]` stackable DDL |
 | 28 defaults_computed | 0 | 0 | `@sql_default` / `@sql_computed` DDL + bind-exclusion |
 | 29 custom_types | 0 | 0 | `_::sql_bind`/`_::sql_extract` emission + stdlib overloads |
-| 30 migrations | 0 | 0 | new `daslib/sql_migrate` module; `[sql_migration]` + runner |
+| 30 migrations | 0 | 0 | new `daslib/sqlite_migrate` module; `[sql_migration]` + runner |
 | 31 views | 0 | 0 | `[sql_view]` + `_create_view` (linq-based DDL, raw-SQL escape) + `drop_view_if_exists` |
 | 32 sql_functions | 0 | 0 | `sqlite/sqlite_boost::register_function` (SQLite-only, scalar-only) |
 | 33 pragma | 0 | 0 | `sqlite/sqlite_boost::set_pragma` × 3 + `apply_recommended_pragmas` (SQLite-only) |
@@ -4972,7 +4972,7 @@ walker JSON-path rule, per-provider `json_extract` emission in
 | 27 indexes | 0 | 0 | `[sql_index]` stackable DDL |
 | 28 defaults_computed | 0 | 0 | `@sql_default` / `@sql_computed` DDL + bind-exclusion |
 | 29 custom_types | 0 | 0 | `_::sql_bind`/`_::sql_extract` emission + stdlib overloads |
-| 30 migrations | 0 | 0 | new `daslib/sql_migrate` module; `[sql_migration]` + runner |
+| 30 migrations | 0 | 0 | new `daslib/sqlite_migrate` module; `[sql_migration]` + runner |
 | 31 views | 0 | 0 | `[sql_view]` + `_create_view` (linq-based DDL, raw-SQL escape) + `drop_view_if_exists` |
 | 32 sql_functions | 0 | 0 | `sqlite/sqlite_boost::register_function` (SQLite-only, scalar-only) |
 | 33 pragma | 0 | 0 | `sqlite/sqlite_boost::set_pragma` × 3 + `apply_recommended_pragmas` (SQLite-only) |
@@ -5188,7 +5188,7 @@ rules for `starts_with`/`ends_with`/`contains`/`text_match`
 | 27 indexes | 0 | 0 | `[sql_index]` stackable DDL |
 | 28 defaults_computed | 0 | 0 | `@sql_default` / `@sql_computed` DDL + bind-exclusion |
 | 29 custom_types | 0 | 0 | `_::sql_bind`/`_::sql_extract` emission + stdlib overloads |
-| 30 migrations | 0 | 0 | new `daslib/sql_migrate` module; `[sql_migration]` + runner |
+| 30 migrations | 0 | 0 | new `daslib/sqlite_migrate` module; `[sql_migration]` + runner |
 | 31 views | 0 | 0 | `[sql_view]` + `_create_view` (linq-based DDL, raw-SQL escape) + `drop_view_if_exists` |
 | 32 sql_functions | 0 | 0 | `sqlite/sqlite_boost::register_function` (SQLite-only, scalar-only) |
 | 33 pragma | 0 | 0 | `sqlite/sqlite_boost::set_pragma` × 3 + `apply_recommended_pragmas` (SQLite-only) |
@@ -5359,7 +5359,7 @@ Three namespaces:
 | require path | Contents | Future physical location |
 |---|---|---|
 | `daslib/sql` (or similar — TBD) | Abstract layer: `SqlRunner` handle type, `_sql` call macro, `[sql_table]` structure macro, `select_from` / `_where` / `_order_by` / `_select`, typed query helpers (`query_one` / `query_scalar` / `insert` / `exec` + their `_opt` / `try_` variants), `Option`/`Result` integration, provider registration API. | `modules/dasSQL/` |
-| `daslib/sql_migrate` | **Optional** migration MVP (tut 30): `[sql_migration(version=N)]` annotation, `migrate_to_latest(db)` / `try_migrate_to_latest(db)` runners, `current_schema_version` / `pending_migrations` / `migration_history` inspectors, `__schema_version` tracking table. Up-only, raw-SQL-inside. Not required unless the user wants migrations. | `modules/dasSQL/migrate/` |
+| `daslib/sqlite_migrate` | **Optional** migration MVP (tut 30): `[sql_migration(version=N)]` annotation, `migrate_to_latest(db)` / `try_migrate_to_latest(db)` runners, `current_schema_version` / `pending_migrations` / `migration_history` inspectors, `__schema_version` tracking table. Up-only, raw-SQL-inside. Not required unless the user wants migrations. | `modules/dasSQL/migrate/` |
 | `sqlite/sqlite_boost` | SQLite-specific provider: `open_sqlite(path) : SqlRunner`, `with_sqlite(path) <| $(runner) { … }` (tbd — see naming Q below), SQLite dialect table, runner interface impl, `sqlite_version()`. Plus unchanged: `sqlite/sqlite` raw C binding. | `modules/dasSQLITE/` (stays) |
 
 A tutorial's typical top:

--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -314,8 +314,9 @@ Everything a real app needs once it leaves the developer's machine.
     sub-module. **Walk locked 2026-05-04;** see
     [API_MIGRATION.md](API_MIGRATION.md). Mockup refreshed:
     [30-migrations.das.mockup](tutorial-mockup/30-migrations.das.mockup).
-    Implementation split into chunks 14a (core + adoption), 14b
-    (typed ALTER), 14c (rebuild).
+    Implementation split into chunks 14a (core + adoption — shipped
+    2026-05-06), 14b (typed ALTER — shipped 2026-05-06), 14c (rebuild
+    — pending).
 33. **PRAGMA tuning** — WAL mode, `busy_timeout`, `foreign_keys`,
     `synchronous`. Ad-hoc `db |> set_pragma(name, value)` /
     `try_set_pragma`, the batch shortcut
@@ -433,7 +434,7 @@ E. **Forward-looking: `dasSQL` abstraction layer** — the roadmap beyond
 | 29 | Column metadata | `29-column_names.das` | **Shipped** (chunk 9); Band 1 `column_info(type<T>) : array<ColumnInfo>` (compile-time walk) + abstract `SqlType` enum + `sqlite_sql_type` dialect renderer; Band 3 raw `PRAGMA table_info` via the typed `query` family |
 | 30 | Listing tables | `30-list_tables.das` | **Shipped** (chunk 9); raw `query` against `sqlite_master`; no abstract `list_tables` helper (catalog spelling diverges per backend) |
 | 31 | Views | `31-views.das` | **Shipped** (chunk 10); `[sql_view(name=...)]` annotation + `_create_view` macro + `drop_view_if_exists`; mutation-path rejection at compile time (predicate form) and runtime (row form) |
-| 32 | Migrations | `30-migrations.das` (refreshed 2026-05-04) | Walk locked 2026-05-04 — see [API_MIGRATION.md](API_MIGRATION.md); chunks 14a/14b/14c queued |
+| 32 | Migrations | `tutorials/sql/43-migrations.das` | **Shipped 14a + 14b** (2026-05-06); spine + typed ALTER (`add_column` / `create_index` / `create_unique_index` / `drop_index_if_exists`). See [API_MIGRATION.md](API_MIGRATION.md). Chunk 14c (struct rebuild) pending. |
 | 33 | PRAGMA tuning | `33-pragma.das` | **Shipped** (chunk 10); `set_pragma` / `try_set_pragma` (string/int64/bool overloads) + `apply_recommended_pragmas` (WAL + busy_timeout + foreign_keys + synchronous=NORMAL) |
 | 34 | Backup + VACUUM | `34-backup_vacuum.das` | **Shipped** (chunk 10); `vacuum` / `vacuum_into` / `optimize` / `integrity_check` / `quick_check` + `backup_to(dest)` / `backup_to(path)` (online Backup API with SQLITE_BUSY/LOCKED retry) |
 | 35 | Streaming results | `35-streaming.das` | **Shipped** (chunk 10); `_each_sql(chain)` returning `iterator<T>`, generator-based; rejects materializing terminals (`_to_array`, `_first`, aggregates); `sqlite3_finalize` runs in `finally` so stmt is released on break/exhaustion/panic |

--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -310,7 +310,7 @@ Everything a real app needs once it leaves the developer's machine.
     type<T>)` + `[sql_table(legacy=true)]` + `name=` overloads on
     `create_table` / `insert_to`. Concurrency via SQLite RESERVED lock
     (one transaction per call, α-shape). Permanent NO on rollback /
-    migrate-to-version. Ships in **optional** `daslib/sql_migrate`
+    migrate-to-version. Ships in **optional** `daslib/sqlite_migrate`
     sub-module. **Walk locked 2026-05-04;** see
     [API_MIGRATION.md](API_MIGRATION.md). Mockup refreshed:
     [30-migrations.das.mockup](tutorial-mockup/30-migrations.das.mockup).

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -2147,14 +2147,20 @@ def private is_option_field_type(td : TypeDeclPtr) : bool {
     if (td == null) {
         return false
     }
+    // Pre-instantiation form: typeMacro `$Option<T>` — what [sql_table] sees during structure_macro apply().
     if (td.baseType == Type.typeMacro && length(td.dimExpr) > 0 && (td.dimExpr[0] is ExprConstString)) {
         return (td.dimExpr[0] as ExprConstString).value == "Option"
     }
-    return (td.baseType == Type.tStructure
-        && td.structType != null
-        && td.structType.name == "Option"
-        && td.structType._module != null
-        && td.structType._module.name == "option")
+    // Post-instantiation form: tStructure named `Option<T>` (the [template_structure] machinery stamps
+    // the type-arg into the struct name). Templates instantiated downstream show _module=<callee>, not
+    // the original "option" module — match on the name shape instead.
+    if (td.baseType == Type.tStructure && td.structType != null) {
+        let sname = string(td.structType.name)
+        if (sname == "Option" || sname |> starts_with("Option<")) {
+            return true
+        }
+    }
+    return false
 }
 
 def private unwrap_option_payload_type(var td : TypeDeclPtr) : TypeDeclPtr {
@@ -2278,6 +2284,18 @@ def private find_struct_helper_fn(name : string; st : StructurePtr) : FunctionPt
     return found
 }
 
+def private derive_index_name(table_name : string; sql_cols : array<string>) : string {
+    // Shared between [sql_index] structure annotation and create_index call macro: idx_<table>_<col1>_<col2>… on the post-@sql_column SQL identifiers.
+    return build_string() $(var w) {
+        w |> write("idx_")
+        w |> write(table_name)
+        for (col in sql_cols) {
+            w |> write("_")
+            w |> write(col)
+        }
+    }
+}
+
 [structure_macro(name=sql_index)]
 class SqlIndexMacro : AstStructureAnnotation {
     //! Stackable struct-level annotation: ``[sql_index(fields="A"|("A","B"), unique=?, name=?)]``.
@@ -2331,14 +2349,7 @@ class SqlIndexMacro : AstStructureAnnotation {
         }
 
         // Auto-name uses SQL (post-rename) column names so distinct schemas don't collide.
-        let auto_name = build_string() $(var w) {
-            w |> write("idx_")
-            w |> write(table_name)
-            for (col in sql_cols) {
-                w |> write("_")
-                w |> write(col)
-            }
-        }
+        let auto_name = derive_index_name(table_name, sql_cols)
         let idx_name = empty(idx_name_arg) ? auto_name : idx_name_arg
         let kind = is_unique ? "UNIQUE INDEX" : "INDEX"
         let this_stmt = build_string() $(var w) {
@@ -4231,4 +4242,310 @@ class SqlFunctionMacro : AstFunctionAnnotation {
         }
         return true
     }
+}
+
+// ===== Typed ALTER macros — migration-context ergonomics =====
+// Used inside [sql_migration] bodies. Emit SQLite-dialect ALTER TABLE / CREATE INDEX
+// from struct + field-name strings. Per the design lock in API_MIGRATION.md §2:
+// typed when daslang has enough info to validate, raw when it doesn't (PK / UNIQUE
+// post-hoc / RENAME / DROP COLUMN stay on `db |> exec(…)`).
+
+[macro_function]
+def private resolve_sql_table(prog : ProgramPtr; at : LineInfo; var typeArg : ExpressionPtr;
+                              macroName : string; var st : StructurePtr&; var table_name : string&) : bool {
+    // Decode `type<T>` arg: T must be a struct carrying the [sql_table]-generated
+    // `_sql_table_name` helper, otherwise we have no table identifier to ALTER.
+    if (typeArg._type == null) {
+        macro_error(prog, at, "{macroName}: `type<T>` argument has no inferred type yet")
+        return false
+    }
+    if (typeArg._type.baseType != Type.tStructure || typeArg._type.structType == null) {
+        macro_error(prog, at, "{macroName}: second argument must be `type<SomeStruct>` — got '{describe(typeArg._type)}'")
+        return false
+    }
+    st = typeArg._type.structType
+    var tname_fn = find_struct_helper_fn("_sql_table_name", st)
+    if (tname_fn == null) {
+        macro_error(prog, at, "{macroName}: type '{st.name}' has no [sql_table] declaration; only [sql_table]-decorated structs can drive typed ALTER")
+        return false
+    }
+    table_name = extract_string_return(tname_fn)
+    if (empty(table_name)) {
+        macro_error(prog, at, "{macroName}: internal — _sql_table_name body did not match expected shape on '{st.name}'")
+        return false
+    }
+    return true
+}
+
+[macro_function]
+def private resolve_field_index(var st : StructurePtr; field_name : string) : int {
+    // -1 if missing. Caller emits the macro_error with full context (macro name + struct name).
+    for (i in range(length(st.fields))) {
+        if (st.fields[i].name == field_name) {
+            return i
+        }
+    }
+    return -1
+}
+
+[macro_function]
+def private field_sql_name_at(var st : StructurePtr; idx : int) : string {
+    // @sql_column("X") rename → X; otherwise daslang field name. idx must be in range.
+    let ca = find_arg(st.fields[idx].annotation, "sql_column")
+    if (ca is tString) {
+        return string(ca as tString)
+    }
+    return string(st.fields[idx].name)
+}
+
+[macro_function]
+def private decode_string_const(e : ExpressionPtr) : tuple<ok : bool; value : string> {
+    // Strict literal-only: peel ExprRef2Value, accept ExprConstString.
+    var inner = e
+    if (inner != null && inner is ExprRef2Value) {
+        inner = (inner as ExprRef2Value).subexpr
+    }
+    if (inner == null || !(inner is ExprConstString)) {
+        return (ok = false, value = "")
+    }
+    return (ok = true, value = string((inner as ExprConstString).value))
+}
+
+[call_macro(name="add_column")]
+class private AddColumnMacro : AstCallMacro {
+    //! Migration-context typed ADD COLUMN macro. Form:
+    //!   ``db |> add_column(type<T>, "FieldName" [, defaultLiteral])``.
+    //! Emits ``ALTER TABLE "<t>" ADD COLUMN "<col>" <SQL_TYPE>[ NOT NULL][ DEFAULT …]``.
+    //! Honors @sql_column rename, @sql_json / @sql_blob storage. Rejects PK / UNIQUE /
+    //! computed / @sql_default_fn at macro time (those need a table rebuild).
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        // call.arguments = [db, type<T>, "FieldName"] (3) or [..., defaultLit] (4) after the `db |>` desugar.
+        let nArgs = call.arguments |> length
+        macro_verify(nArgs == 3 || nArgs == 4, prog, call.at,
+            "add_column expects (db, type<T>, \"Field\" [, defaultLit]) — got {nArgs} args")
+        var st : StructurePtr
+        var table_name : string
+        if (!resolve_sql_table(prog, call.at, call.arguments[1], "add_column", st, table_name)) {
+            return null
+        }
+        // Field-name string literal.
+        let nameRes = decode_string_const(call.arguments[2])
+        if (!nameRes.ok) {
+            macro_error(prog, call.at, "add_column: third argument must be a string literal naming the field — got '{describe(call.arguments[2])}'")
+            return null
+        }
+        let field_name = nameRes.value
+        let idx = resolve_field_index(st, field_name)
+        if (idx < 0) {
+            macro_error(prog, call.at, "add_column: field '{field_name}' is not a column of struct '{st.name}'")
+            return null
+        }
+        // Reject shapes that need a table rebuild.
+        let pk_arg = find_arg(st.fields[idx].annotation, "sql_primary_key")
+        if (pk_arg is tBool && (pk_arg as tBool)) {
+            macro_error(prog, call.at,
+                "add_column cannot add a PRIMARY KEY column to an existing table; recreate the table — see chunk 14c struct_convert")
+            return null
+        }
+        let uniq_arg = find_arg(st.fields[idx].annotation, "sql_unique")
+        if (uniq_arg is tBool && (uniq_arg as tBool)) {
+            macro_error(prog, call.at,
+                "add_column cannot add a UNIQUE column to an existing table; create_unique_index(type<T>, \"{field_name}\") instead")
+            return null
+        }
+        let computed_arg = find_arg(st.fields[idx].annotation, "sql_computed")
+        if (computed_arg is tString || (computed_arg is tBool && (computed_arg as tBool))) {
+            macro_error(prog, call.at,
+                "add_column cannot add a generated/computed column to an existing table; recreate the table — see chunk 14c struct_convert")
+            return null
+        }
+        let default_fn_arg = find_arg(st.fields[idx].annotation, "sql_default_fn")
+        if (default_fn_arg is tString) {
+            macro_error(prog, call.at,
+                "add_column does not support @sql_default_fn fields yet; use a literal default or `db |> exec(…)`")
+            return null
+        }
+        // Read storage hints + nullability.
+        let json_arg = find_arg(st.fields[idx].annotation, "sql_json")
+        let is_json = json_arg is tBool && (json_arg as tBool)
+        let blob_arg = find_arg(st.fields[idx].annotation, "sql_blob")
+        let is_blob = blob_arg is tBool && (blob_arg as tBool)
+        let is_optional = is_option_field_type(st.fields[idx]._type)
+        let col_name = field_sql_name_at(st, idx)
+        // DEFAULT clause from optional 4th arg (compile-time literal only).
+        var default_clause = ""
+        if (nArgs == 4) {
+            if (is_json || is_blob) {
+                macro_error(prog, call.at,
+                    "add_column: explicit default not supported for @sql_json / @sql_blob columns; the column accepts NULL by default — wrap the field in Option<T> if nullability is desired")
+                return null
+            }
+            var defArg = call.arguments[3]
+            if (defArg != null && defArg is ExprRef2Value) {
+                defArg = (defArg as ExprRef2Value).subexpr
+            }
+            default_clause = literal_init_to_default_clause(defArg)
+            if (empty(default_clause)) {
+                macro_error(prog, call.at,
+                    "add_column: DEFAULT must be a compile-time literal (int / int64 / float / double / bool / string); got '{describe(call.arguments[3])}'. Inline the value, or use `db |> exec(…)` for runtime expressions.")
+                return null
+            }
+        } elif (!is_optional && !is_json && !is_blob) {
+            // SQLite ADD COLUMN against existing rows: NOT NULL without DEFAULT panics for any pre-existing row.
+            macro_error(prog, call.at,
+                "add_column: field '{field_name}' on '{st.name}' is non-nullable; provide a literal default (e.g. `add_column(type<T>, \"{field_name}\", 0)`) or wrap the field in Option<T>")
+            return null
+        }
+        // Build prefix + suffix at macro time; SQL type comes from the runtime adapter rail
+        // (sql_storage_type_for) unless the field is explicitly @sql_json / @sql_blob.
+        let null_clause = is_optional ? "" : " NOT NULL"
+        let prefix = "ALTER TABLE \"{table_name}\" ADD COLUMN \"{col_name}\" "
+        let suffix = "{null_clause}{default_clause}"
+        var dbExpr = clone_expression(call.arguments[0])
+        var res : ExpressionPtr
+        if (is_json) {
+            let full = "{prefix}TEXT{suffix}"
+            res = qmacro(_::exec($e(dbExpr), $v(full)))
+        } elif (is_blob) {
+            let full = "{prefix}BLOB{suffix}"
+            res = qmacro(_::exec($e(dbExpr), $v(full)))
+        } else {
+            var fieldType <- clone_type(st.fields[idx]._type)
+            res = qmacro(_::exec($e(dbExpr), build_string() $(var w) {
+                w |> write($v(prefix))
+                w |> write(_::sql_storage_type_for(type<$t(fieldType)>))
+                w |> write($v(suffix))
+            }))
+        }
+        res.force_at(call.at)
+        return res
+    }
+}
+
+[macro_function]
+def private resolve_field_columns(prog : ProgramPtr; at : LineInfo; var st : StructurePtr;
+                                  fieldsArg : ExpressionPtr; macroName : string;
+                                  var sql_cols : array<string>&) : bool {
+    // Accept a single string literal ("Email") or a tuple literal of string literals ("A", "B").
+    // Array literals like ["A", "B"] parse as `to_array_move(fixed_array(…))` — too hairy to AST-match.
+    if (fieldsArg == null) {
+        macro_error(prog, at, "{macroName}: missing fields argument")
+        return false
+    }
+    var inner = fieldsArg
+    if (inner is ExprRef2Value) {
+        inner = (inner as ExprRef2Value).subexpr
+    }
+    var col_names : array<string>
+    if (inner is ExprConstString) {
+        col_names |> push(string((inner as ExprConstString).value))
+    } elif (inner is ExprMakeTuple) {
+        let mkt = inner as ExprMakeTuple
+        for (v in mkt.values) {
+            var item = v
+            if (item is ExprRef2Value) {
+                item = (item as ExprRef2Value).subexpr
+            }
+            if (item == null || !(item is ExprConstString)) {
+                macro_error(prog, at, "{macroName}: tuple fields entries must be string literals — got '{describe(v)}'")
+                return false
+            }
+            col_names |> push(string((item as ExprConstString).value))
+        }
+    } else {
+        macro_error(prog, at, "{macroName}: fields argument must be a string literal (\"Field\") or a tuple of string literals (\"A\", \"B\") — got '{describe(fieldsArg)}'")
+        return false
+    }
+    if (length(col_names) == 0) {
+        macro_error(prog, at, "{macroName}: empty fields list. Provide \"Field\" for a single-column index or (\"A\", \"B\") for a composite.")
+        return false
+    }
+    sql_cols |> reserve(length(col_names))
+    for (cn in col_names) {
+        let idx = resolve_field_index(st, cn)
+        if (idx < 0) {
+            macro_error(prog, at, "{macroName}: field '{cn}' is not a column of struct '{st.name}'")
+            return false
+        }
+        sql_cols |> push(field_sql_name_at(st, idx))
+    }
+    return true
+}
+
+[macro_function]
+def private emit_create_index(prog : ProgramPtr; var call : ExprCallMacro?; is_unique : bool) : ExpressionPtr {
+    let macroName = is_unique ? "create_unique_index" : "create_index"
+    let nArgs = call.arguments |> length
+    if (nArgs < 3 || nArgs > 4) {
+        macro_error(prog, call.at,
+            "{macroName} expects (db, type<T>, fields [, \"name\"]) — got {nArgs} args")
+        return null
+    }
+    var st : StructurePtr
+    var table_name : string
+    if (!resolve_sql_table(prog, call.at, call.arguments[1], macroName, st, table_name)) {
+        return null
+    }
+    var sql_cols : array<string>
+    if (!resolve_field_columns(prog, call.at, st, call.arguments[2], macroName, sql_cols)) {
+        return null
+    }
+    var idx_name = derive_index_name(table_name, sql_cols)
+    if (nArgs == 4) {
+        let nameRes = decode_string_const(call.arguments[3])
+        if (!nameRes.ok) {
+            macro_error(prog, call.at,
+                "{macroName}: optional `name` argument must be a string literal — got '{describe(call.arguments[3])}'")
+            return null
+        }
+        if (empty(nameRes.value)) {
+            macro_error(prog, call.at, "{macroName}: index name string is empty")
+            return null
+        }
+        idx_name = nameRes.value
+    }
+    let kind = is_unique ? "UNIQUE INDEX" : "INDEX"
+    let ddl = build_string() $(var w) {
+        w |> write("CREATE {kind} \"{idx_name}\" ON \"{table_name}\" (")
+        for (j in range(length(sql_cols))) {
+            if (j > 0) {
+                w |> write(", ")
+            }
+            w |> write("\"")
+            w |> write(sql_cols[j])
+            w |> write("\"")
+        }
+        w |> write(")")
+    }
+    var dbExpr = clone_expression(call.arguments[0])
+    var res = qmacro(_::exec($e(dbExpr), $v(ddl)))
+    res.force_at(call.at)
+    return res
+}
+
+[call_macro(name="create_index")]
+class private CreateIndexMacro : AstCallMacro {
+    //! Migration-context typed CREATE INDEX. Form:
+    //!   ``db |> create_index(type<T>, "Field" | ["A", "B"] [, "idx_name"])``.
+    //! Auto-name follows the [sql_index] convention: ``idx_<table>_<col1>_<col2>``.
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        return emit_create_index(prog, call, false)
+    }
+}
+
+[call_macro(name="create_unique_index")]
+class private CreateUniqueIndexMacro : AstCallMacro {
+    //! Migration-context typed CREATE UNIQUE INDEX. Same shape as ``create_index`` plus
+    //! the UNIQUE constraint. SQLite emits a duplicate-violation panic at INSERT time
+    //! if existing rows already conflict; wrap in a migration body for atomic rollback.
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        return emit_create_index(prog, call, true)
+    }
+}
+
+def drop_index_if_exists(db : SqlRunner; name : string) {
+    //! Idempotent DROP INDEX. SQLite supports IF EXISTS natively; safe to call on a
+    //! missing index. Pair with ``create_unique_index`` for migration patterns that
+    //! rebuild an index under a new name.
+    db |> exec("DROP INDEX IF EXISTS \"{name}\"")
 }

--- a/modules/dasSQLITE/daslib/sqlite_migrate.das
+++ b/modules/dasSQLITE/daslib/sqlite_migrate.das
@@ -4,7 +4,7 @@ options no_unused_block_arguments = false
 options no_unused_function_arguments = false
 options strict_smart_pointers
 
-module sql_migrate shared public
+module sqlite_migrate shared public
 
 // Intentionally opt in for user-facing docs: keep comments concise and actionable.
 options _comment_hygiene = true
@@ -631,10 +631,10 @@ class SqlMigrationMacro : AstFunctionAnnotation {
         }
         fnType.firstType = clone_type(func.result)
         var fnAddr = new ExprAddr(at = func.at, target := "__::{funcDasName}", funcType <- fnType)
-        // Append registration into per-module init function `register`sql`migrations`
-        var reg <- setup_call_list("register`sql`migrations", func.at, true/*isInit*/, true/*isPrivate*/)
+        // Append registration into per-module init function `register`sqlite`migrations`
+        var reg <- setup_call_list("register`sqlite`migrations", func.at, true/*isInit*/, true/*isPrivate*/)
         reg.list |> emplace_new <| qmacro_block() {
-            sql_migrate::_add_migration_entry($v(version), $v(description), $v(vacuum), $v(analyze),
+            sqlite_migrate::_add_migration_entry($v(version), $v(description), $v(vacuum), $v(analyze),
                 $e(fnAddr), $v(funcDasName), $v(modName))
         }
         return true

--- a/modules/dasSQLITE/tutorial-mockup/30-migrations.das.mockup
+++ b/modules/dasSQLITE/tutorial-mockup/30-migrations.das.mockup
@@ -22,12 +22,12 @@ options gen2
 //   The DEFERRED list at the bottom names what we explicitly
 //   don't ship and what to do instead.
 //
-// SEPARATE MODULE: `daslib/sql_migrate`. Users who don't need
+// SEPARATE MODULE: `daslib/sqlite_migrate`. Users who don't need
 // migrations don't `require` it. The migration symbols never
 // appear in their namespace.
 
 require daslib/sql
-require daslib/sql_migrate
+require daslib/sqlite_migrate
 require sqlite/sqlite_boost
 require daslib/result
 require daslib/option
@@ -176,7 +176,7 @@ def cli_upgrade() {
 // PART 4 — Adopting migrations on an existing DB ("baseline")
 // ======================================================================
 //
-// You've been shipping the app without `daslib/sql_migrate`. Your DB
+// You've been shipping the app without `daslib/sqlite_migrate`. Your DB
 // already has tables. Now you want to start tracking migrations. You
 // can either:
 //
@@ -461,7 +461,7 @@ def migration_005(db : SqlRunner) {
 //   add`). Requires a model-snapshot system. The struct_convert
 //   approach in Part 5 is the daslang-native answer for the rebuild
 //   half; full autogen of ALTERs would be a separate
-//   `daslib/sql_migrate_gen` follow-up.
+//   `daslib/sqlite_migrate_gen` follow-up.
 //
 // • `daspkg sql-migrate snapshot` / `daspkg sql-migrate squash`. CLI
 //   tools for snapshot-rotation and hand-squash automation. Overlap
@@ -470,7 +470,7 @@ def migration_005(db : SqlRunner) {
 // • SEMANTIC-DUPE LINT. Fuzzy detection of "two migrations with
 //   suspiciously-similar bodies" via the chunk-13 detect_duplicates
 //   machinery — wrong shape for a build gate, right shape for a
-//   PR-review helper. Future `daslib/sql_migrate_lint` (or similar).
+//   PR-review helper. Future `daslib/sqlite_migrate_lint` (or similar).
 //
 // Documented limitations (escape hatches inline in tut 32):
 //
@@ -501,4 +501,4 @@ def migration_005(db : SqlRunner) {
 // chunks (14a/14b/14c). Anything in this deferred list is its own
 // project. If you hit one of these and it's blocking, open an issue
 // with a concrete use case — that's the signal we use to prioritize
-// the next `daslib/sql_migrate_*` module.
+// the next `daslib/sqlite_migrate_*` module.

--- a/modules/dasSQLITE/tutorial-mockup/31-views.das.mockup
+++ b/modules/dasSQLITE/tutorial-mockup/31-views.das.mockup
@@ -29,7 +29,7 @@ options gen2
 // the existing `_sql` translator.
 
 require daslib/sql
-require daslib/sql_migrate
+require daslib/sqlite_migrate
 require sqlite/sqlite_boost
 
 // --- base tables (for the view to project over) -----------------------

--- a/skills/sql.md
+++ b/skills/sql.md
@@ -1,6 +1,6 @@
 # SQL — dasSQLITE
 
-Read this skill before writing or editing any `.das` code that talks to a SQL database. The companion tutorials live under [tutorials/sql/](../tutorials/sql/) (43 files, numbered by teaching order — `01-version.das` through `43-migrations.das`); read the relevant ones for runnable examples of every pattern below. Implementation is in [modules/dasSQLITE/daslib/sqlite_boost.das](../modules/dasSQLITE/daslib/sqlite_boost.das) (runtime + `[sql_table]` / `[sql_view]` / `[sql_fts5]` / `[sql_function]` macros), [modules/dasSQLITE/daslib/sqlite_linq.das](../modules/dasSQLITE/daslib/sqlite_linq.das) (the `_sql(...)` family of call macros), and [modules/dasSQLITE/daslib/sql_migrate.das](../modules/dasSQLITE/daslib/sql_migrate.das) (`[sql_migration]` + `migrate_to_latest` runner). Design notes, decision logs, and the deferred-feature list live next to the implementation in [modules/dasSQLITE/API_REWORK.md](../modules/dasSQLITE/API_REWORK.md), [TUTORIALS.md](../modules/dasSQLITE/TUTORIALS.md), and [API_MIGRATION.md](../modules/dasSQLITE/API_MIGRATION.md).
+Read this skill before writing or editing any `.das` code that talks to a SQL database. The companion tutorials live under [tutorials/sql/](../tutorials/sql/) (43 files, numbered by teaching order — `01-version.das` through `43-migrations.das`); read the relevant ones for runnable examples of every pattern below. Implementation is in [modules/dasSQLITE/daslib/sqlite_boost.das](../modules/dasSQLITE/daslib/sqlite_boost.das) (runtime + `[sql_table]` / `[sql_view]` / `[sql_fts5]` / `[sql_function]` macros), [modules/dasSQLITE/daslib/sqlite_linq.das](../modules/dasSQLITE/daslib/sqlite_linq.das) (the `_sql(...)` family of call macros), and [modules/dasSQLITE/daslib/sqlite_migrate.das](../modules/dasSQLITE/daslib/sqlite_migrate.das) (`[sql_migration]` + `migrate_to_latest` runner). Design notes, decision logs, and the deferred-feature list live next to the implementation in [modules/dasSQLITE/API_REWORK.md](../modules/dasSQLITE/API_REWORK.md), [TUTORIALS.md](../modules/dasSQLITE/TUTORIALS.md), and [API_MIGRATION.md](../modules/dasSQLITE/API_MIGRATION.md).
 
 The shipped backend is **SQLite only**. The split between `daslib/sql` (provider-neutral types — `SqlRunner`, `SqlError`, `SqlType`, `ColumnInfo`, `Option`/`Result`) and `sqlite/sqlite_boost` (provider-specific runtime + macros) keeps user code portable for the day a second backend lands. Until then the names "SQL" and "SQLite" are interchangeable in this skill.
 
@@ -10,12 +10,12 @@ The shipped backend is **SQLite only**. The split between `daslib/sql` (provider
 require daslib/sql                  // abstract layer — SqlRunner, SqlType, ColumnInfo
 require sqlite/sqlite_boost         // runtime, [sql_table], [sql_view], [sql_fts5], [sql_function]
 require sqlite/sqlite_linq          // _sql / _try_sql / _each_sql / _sql_update / _sql_delete / _sql_upsert / _create_view / _sql_text
-require sqlite/sql_migrate          // OPTIONAL — [sql_migration], migrate_to_latest, with_latest_sqlite, baseline
+require sqlite/sqlite_migrate          // OPTIONAL — [sql_migration], migrate_to_latest, with_latest_sqlite, baseline
 ```
 
 `sqlite_boost` re-exports the raw `sqlite` C-binding module publicly. **Never `require sqlite` directly** — it's the auto-generated thin C binding (`sqlite3_open`, `sqlite3_prepare_v2`, `sqlite3_step`, …). Going through `sqlite_boost` gets you `SqlRunner` + the typed surface; the raw functions are still reachable when you genuinely need them, but reaching for them is almost always wrong.
 
-`sqlite/sql_migrate` is the only optional sub-module — only require it when the app uses versioned migrations. It transitively brings in `sqlite_boost`, so don't double-require.
+`sqlite/sqlite_migrate` is the only optional sub-module — only require it when the app uses versioned migrations. It transitively brings in `sqlite_boost`, so don't double-require.
 
 The path uses **forward slash** (`require sqlite/sqlite_boost` — not backslash). All four `sqlite/*` paths are wired through the [.das_module](../modules/dasSQLITE/.das_module) descriptor.
 
@@ -77,7 +77,7 @@ db |> create_table(type<Car>)            // ... use freely; closes when `db` goe
 
 `SqlRunner` is a `smart_ptr`-style scoped resource (one of the residual types still using refcount semantics — see `skills/gc_migration.md`). Variables holding it need `var inscope` and move-binding (`<-`), not plain `=`. Inside an existing transaction or a `with_sqlite` block, the runner is just passed by value to helpers — no extra ceremony.
 
-`open_sqlite(path)` is the strict form and panics on failure. The third form `with_latest_sqlite(path)` (from `sqlite/sql_migrate`) combines `with_sqlite` + `apply_recommended_pragmas` + `migrate_to_latest` into one call — the preferred app-startup form when migrations are in play.
+`open_sqlite(path)` is the strict form and panics on failure. The third form `with_latest_sqlite(path)` (from `sqlite/sqlite_migrate`) combines `with_sqlite` + `apply_recommended_pragmas` + `migrate_to_latest` into one call — the preferred app-startup form when migrations are in play.
 
 ## `[sql_table]` — declare a row shape
 
@@ -499,12 +499,12 @@ let strong <- _sql(db |> select_from(type<Enemy>)
 
 `[sql_function]` is the right shape for ambient SQL helpers that should be visible to chain analysis everywhere; `register_function` is for one-off / per-connection registrations.
 
-## Migrations — `daslib/sql_migrate`
+## Migrations — `daslib/sqlite_migrate`
 
-Versioned, append-only schema evolution. Optional sub-module — `require sqlite/sql_migrate` only when needed.
+Versioned, append-only schema evolution. Optional sub-module — `require sqlite/sqlite_migrate` only when needed.
 
 ```das
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_table(name = "users")]
 struct User {
@@ -698,7 +698,7 @@ Strings produced by `query` / `_sql` are allocated on the calling context's heap
 ## Reference
 
 - Tutorials — every shipped feature has a runnable file under [tutorials/sql/](../tutorials/sql/) (43 files). Teaching order is documented in [modules/dasSQLITE/TUTORIALS.md](../modules/dasSQLITE/TUTORIALS.md).
-- Implementation — [daslib/sqlite_boost.das](../modules/dasSQLITE/daslib/sqlite_boost.das), [daslib/sqlite_linq.das](../modules/dasSQLITE/daslib/sqlite_linq.das), [daslib/sql_migrate.das](../modules/dasSQLITE/daslib/sql_migrate.das).
+- Implementation — [daslib/sqlite_boost.das](../modules/dasSQLITE/daslib/sqlite_boost.das), [daslib/sqlite_linq.das](../modules/dasSQLITE/daslib/sqlite_linq.das), [daslib/sqlite_migrate.das](../modules/dasSQLITE/daslib/sqlite_migrate.das).
 - Design notes — [API_REWORK.md](../modules/dasSQLITE/API_REWORK.md) (the master plan; per-chunk decision log), [API_MIGRATION.md](../modules/dasSQLITE/API_MIGRATION.md) (migrations design walk), [API_CHECKED.md](../modules/dasSQLITE/API_CHECKED.md) (parity audit), [API_MISSING.md](../modules/dasSQLITE/API_MISSING.md) (deferred-feature list).
 - Tests — `tests/dasSQLITE/` — every operator + macro has a focused test, plus `failed_*.das` files for compile-error cases.
 - Related skills — `skills/json.md` (`@sql_json` columns), `skills/linq.md` (`_sql` is LINQ-shaped), `skills/das_macros.md` (`[sql_table]` / `_sql` are macros), `skills/gc_migration.md` (`SqlRunner` is one of the residual smart_ptr types).

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -114,7 +114,7 @@ IF(NOT DAS_SQLITE_DISABLED)
     SET(AOT_DASSQLITE_MODULE_FILES
         modules/dasSQLITE/daslib/sqlite_boost.das
         modules/dasSQLITE/daslib/sqlite_linq.das
-        modules/dasSQLITE/daslib/sql_migrate.das
+        modules/dasSQLITE/daslib/sqlite_migrate.das
     )
 ENDIF()
 

--- a/tests/dasSQLITE/failed_add_column_no_sql_table.das
+++ b/tests/dasSQLITE/failed_add_column_no_sql_table.das
@@ -1,0 +1,17 @@
+options gen2
+
+// AddColumnMacro must reject a struct without [sql_table] — there's no table
+// identifier to ALTER, so the call is meaningless.
+expect 40104:1
+
+require sqlite/sqlite_migrate
+
+struct Plain {
+    Id : int64
+    Name : string
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> add_column(type<Plain>, "Name")
+}

--- a/tests/dasSQLITE/failed_add_column_nonliteral_default.das
+++ b/tests/dasSQLITE/failed_add_column_nonliteral_default.das
@@ -1,0 +1,23 @@
+options gen2
+
+// AddColumnMacro requires the DEFAULT to be a compile-time literal: int / float /
+// double / bool / string. Runtime expressions (function calls, variables, arithmetic)
+// are rejected with a fixit pointing to db |> exec(…).
+expect 40104:1
+
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    Score : int
+}
+
+def compute_default() : int {
+    return 42
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> add_column(type<User>, "Score", compute_default())
+}

--- a/tests/dasSQLITE/failed_add_column_pk_rejected.das
+++ b/tests/dasSQLITE/failed_add_column_pk_rejected.das
@@ -1,0 +1,18 @@
+options gen2
+
+// AddColumnMacro must reject @sql_primary_key fields — SQLite cannot add a PK column
+// to an existing table; this requires a table rebuild (chunk 14c struct_convert).
+expect 40104:1
+
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    @sql_primary_key
+    Id : int64
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> add_column(type<User>, "Id")
+}

--- a/tests/dasSQLITE/failed_add_column_unique_rejected.das
+++ b/tests/dasSQLITE/failed_add_column_unique_rejected.das
@@ -1,0 +1,19 @@
+options gen2
+
+// AddColumnMacro must reject @sql_unique fields — SQLite cannot add a UNIQUE
+// column to an existing table inline; the user should use create_unique_index instead.
+expect 40104:1
+
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    @sql_unique
+    Email : string
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> add_column(type<User>, "Email", "")
+}

--- a/tests/dasSQLITE/failed_add_column_unknown_field.das
+++ b/tests/dasSQLITE/failed_add_column_unknown_field.das
@@ -1,0 +1,17 @@
+options gen2
+
+// AddColumnMacro must reject a field name that doesn't exist on the struct,
+// with the same wording the [sql_index] structure annotation uses.
+expect 40104:1
+
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> add_column(type<User>, "NotARealField")
+}

--- a/tests/dasSQLITE/failed_create_index_empty_fields.das
+++ b/tests/dasSQLITE/failed_create_index_empty_fields.das
@@ -1,0 +1,17 @@
+options gen2
+
+// CreateIndexMacro must reject an empty-string field name — equivalent to "fields=()".
+// Mirrors [sql_index]'s "missing or empty `fields=`" error.
+expect 40104:1
+
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> create_index(type<User>, "")
+}

--- a/tests/dasSQLITE/failed_create_index_unknown_field.das
+++ b/tests/dasSQLITE/failed_create_index_unknown_field.das
@@ -1,0 +1,18 @@
+options gen2
+
+// CreateIndexMacro must reject field names that don't exist on the struct,
+// with the same wording the [sql_index] structure annotation uses.
+expect 40104:1
+
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    Email : string
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> create_index(type<User>, "NotAField")
+}

--- a/tests/dasSQLITE/failed_sql_migration_dup_version.das
+++ b/tests/dasSQLITE/failed_sql_migration_dup_version.das
@@ -4,7 +4,7 @@ options gen2
 // with the [sql_migration] dup-version error (error 30111).
 expect 30111:1
 
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version=2, description="first")]
 def migration_a(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_01_fresh_creates_audit.das
+++ b/tests/dasSQLITE/migrate_01_fresh_creates_audit.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "create users")]
 def m_users(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_02_fresh_runs_all.das
+++ b/tests/dasSQLITE/migrate_02_fresh_runs_all.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "create users")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_06_idempotent_rerun.das
+++ b/tests/dasSQLITE/migrate_06_idempotent_rerun.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "create users")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_09_steady_state.das
+++ b/tests/dasSQLITE/migrate_09_steady_state.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "users")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_10_strict_forward.das
+++ b/tests/dasSQLITE/migrate_10_strict_forward.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 // Strict-forward pending detection (Scenario 2 lock): pending = registered with version > MAX(applied),
 // NOT set-difference. If audit has {1,3}, v2 is silently skipped because MAX > 2.

--- a/tests/dasSQLITE/migrate_12_description_persists.das
+++ b/tests/dasSQLITE/migrate_12_description_persists.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "add email column")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_13_data_preserved.das
+++ b/tests/dasSQLITE/migrate_13_data_preserved.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "create users")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_14_add_column_optional.das
+++ b/tests/dasSQLITE/migrate_14_add_column_optional.das
@@ -1,0 +1,37 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    Name : string
+    Email : Option<string>
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+}
+
+[sql_migration(version = 2)]
+def m_002(db : SqlRunner) {
+    db |> add_column(type<User>, "Email")
+}
+
+[test]
+def test_option_field_is_nullable_no_default(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let notnull = db |> query_scalar(
+        "SELECT \"notnull\" FROM pragma_table_info('users') WHERE name='Email'", type<int>)
+    t |> equal(notnull, 0, "Option<string> field must be nullable")
+    let dflt = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='Email' AND dflt_value IS NULL",
+        type<int>)
+    t |> equal(dflt, 1, "Option<string> field must have NULL default (i.e. no DEFAULT clause)")
+    let stype = db |> query_scalar(
+        "SELECT type FROM pragma_table_info('users') WHERE name='Email'", type<string>)
+    t |> equal(stype, "TEXT", "string maps to TEXT storage")
+}

--- a/tests/dasSQLITE/migrate_15_add_column_default.das
+++ b/tests/dasSQLITE/migrate_15_add_column_default.das
@@ -1,0 +1,46 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    Name : string
+    Score : int
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+    db |> exec("INSERT INTO users (Id, Name) VALUES (1, 'Alice')")
+}
+
+[sql_migration(version = 2)]
+def m_002(db : SqlRunner) {
+    db |> add_column(type<User>, "Score", 0)
+}
+
+[test]
+def test_int_default_emits_not_null_default_zero(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let notnull = db |> query_scalar(
+        "SELECT \"notnull\" FROM pragma_table_info('users') WHERE name='Score'", type<int>)
+    t |> equal(notnull, 1, "int field with default must be NOT NULL")
+    let dflt = db |> query_scalar(
+        "SELECT dflt_value FROM pragma_table_info('users') WHERE name='Score'", type<string>)
+    t |> equal(dflt, "0", "DEFAULT 0 must be in the column DDL")
+    let stype = db |> query_scalar(
+        "SELECT type FROM pragma_table_info('users') WHERE name='Score'", type<string>)
+    t |> equal(stype, "INTEGER", "int maps to INTEGER storage")
+}
+
+[test]
+def test_existing_rows_get_default_value(t : T?) {
+    // SQLite ALTER TABLE … ADD COLUMN with DEFAULT backfills pre-existing rows.
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let alice_score = db |> query_scalar("SELECT Score FROM users WHERE Id=1", type<int>)
+    t |> equal(alice_score, 0, "Alice (inserted at v1) must read Score=0 after v2 ALTER")
+}

--- a/tests/dasSQLITE/migrate_16_add_column_string_quoting.das
+++ b/tests/dasSQLITE/migrate_16_add_column_string_quoting.das
@@ -1,0 +1,41 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    Name : string
+    Author : string
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+    db |> exec("INSERT INTO users (Id, Name) VALUES (1, 'Alice')")
+}
+
+[sql_migration(version = 2)]
+def m_002(db : SqlRunner) {
+    // Embedded single-quote must be escaped as '' in the emitted DDL.
+    db |> add_column(type<User>, "Author", "O'Reilly")
+}
+
+[test]
+def test_single_quote_escapes_in_default(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let alice_author = db |> query_scalar("SELECT Author FROM users WHERE Id=1", type<string>)
+    t |> equal(alice_author, "O'Reilly", "Embedded single-quote must round-trip via escape")
+}
+
+[test]
+def test_default_clause_in_pragma(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let dflt = db |> query_scalar(
+        "SELECT dflt_value FROM pragma_table_info('users') WHERE name='Author'", type<string>)
+    // PRAGMA reports the literal as it appears in the DDL: a SQL-quoted string.
+    t |> equal(dflt, "'O''Reilly'", "DEFAULT must show SQL-quoted form with doubled single-quote")
+}

--- a/tests/dasSQLITE/migrate_17_add_column_renamed.das
+++ b/tests/dasSQLITE/migrate_17_add_column_renamed.das
@@ -1,0 +1,35 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    Name : string
+    @sql_column = "email_addr"
+    Email : Option<string>
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+}
+
+[sql_migration(version = 2)]
+def m_002(db : SqlRunner) {
+    // User passes the daslang field name; emitted DDL uses the @sql_column-renamed identifier.
+    db |> add_column(type<User>, "Email")
+}
+
+[test]
+def test_sql_column_rename_propagates_to_alter(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let renamed_count = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='email_addr'", type<int>)
+    t |> equal(renamed_count, 1, "Column must appear under the @sql_column-renamed SQL identifier")
+    let daslang_count = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='Email'", type<int>)
+    t |> equal(daslang_count, 0, "Column must NOT appear under the daslang field name")
+}

--- a/tests/dasSQLITE/migrate_18_add_column_json.das
+++ b/tests/dasSQLITE/migrate_18_add_column_json.das
@@ -1,0 +1,39 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sqlite_migrate
+
+struct Profile {
+    nickname : string
+    avatar_url : string
+}
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    Name : string
+    @sql_json
+    Profile : Option<Profile>
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+}
+
+[sql_migration(version = 2)]
+def m_002(db : SqlRunner) {
+    db |> add_column(type<User>, "Profile")
+}
+
+[test]
+def test_sql_json_field_emits_text_storage(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let stype = db |> query_scalar(
+        "SELECT type FROM pragma_table_info('users') WHERE name='Profile'", type<string>)
+    t |> equal(stype, "TEXT", "@sql_json column must use TEXT storage regardless of payload struct")
+    let notnull = db |> query_scalar(
+        "SELECT \"notnull\" FROM pragma_table_info('users') WHERE name='Profile'", type<int>)
+    t |> equal(notnull, 0, "Option<Profile> must be nullable")
+}

--- a/tests/dasSQLITE/migrate_19_add_column_blob.das
+++ b/tests/dasSQLITE/migrate_19_add_column_blob.das
@@ -1,0 +1,39 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sqlite_migrate
+
+struct AvatarPayload {
+    width : int
+    height : int
+}
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    Name : string
+    @sql_blob
+    Avatar : Option<AvatarPayload>
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
+}
+
+[sql_migration(version = 2)]
+def m_002(db : SqlRunner) {
+    db |> add_column(type<User>, "Avatar")
+}
+
+[test]
+def test_sql_blob_struct_field_emits_blob_storage(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let stype = db |> query_scalar(
+        "SELECT type FROM pragma_table_info('users') WHERE name='Avatar'", type<string>)
+    t |> equal(stype, "BLOB", "@sql_blob column must use BLOB storage")
+    let notnull = db |> query_scalar(
+        "SELECT \"notnull\" FROM pragma_table_info('users') WHERE name='Avatar'", type<int>)
+    t |> equal(notnull, 0, "Option<AvatarPayload> must be nullable")
+}

--- a/tests/dasSQLITE/migrate_20_create_index_basic.das
+++ b/tests/dasSQLITE/migrate_20_create_index_basic.das
@@ -1,0 +1,38 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    Email : string
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Email TEXT NOT NULL)")
+}
+
+[sql_migration(version = 2)]
+def m_002(db : SqlRunner) {
+    db |> create_index(type<User>, "Email")
+}
+
+[test]
+def test_auto_named_single_col_index(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let idx_count = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name='users' AND name NOT LIKE 'sqlite_%'",
+        type<int>)
+    t |> equal(idx_count, 1, "exactly one user-defined index expected")
+    let auto_name = db |> query_scalar(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='users' AND name NOT LIKE 'sqlite_%'",
+        type<string>)
+    t |> equal(auto_name, "idx_users_Email",
+        "auto-name follows [sql_index] convention idx_<table>_<col>")
+    let is_unique = db |> query_scalar(
+        "SELECT \"unique\" FROM pragma_index_list('users') WHERE name='idx_users_Email'", type<int>)
+    t |> equal(is_unique, 0, "create_index defaults to non-unique")
+}

--- a/tests/dasSQLITE/migrate_21_create_index_unique_composite.das
+++ b/tests/dasSQLITE/migrate_21_create_index_unique_composite.das
@@ -1,0 +1,60 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    Email : string
+    Name : string
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Email TEXT NOT NULL, Name TEXT NOT NULL)")
+}
+
+[sql_migration(version = 2)]
+def m_002(db : SqlRunner) {
+    db |> create_unique_index(type<User>, ("Email", "Name"), "ux_email_name")
+}
+
+[sql_migration(version = 3)]
+def m_003(db : SqlRunner) {
+    // Idempotence: existing name → drops; second call → no-op (SQLite IF EXISTS).
+    db |> drop_index_if_exists("ux_email_name")
+    db |> drop_index_if_exists("ux_email_name")
+    db |> drop_index_if_exists("never_existed")
+}
+
+[test]
+def test_all_three_migrations_apply(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let n = db |> migrate_to_latest()
+    t |> equal(n, 3, "all three migrations applied (CREATE TABLE + CREATE UNIQUE INDEX + drop trio)")
+}
+
+[test]
+def test_drop_index_if_exists_idempotent(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    db |> migrate_to_latest()
+    let idx_count = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name='users' AND name NOT LIKE 'sqlite_%'",
+        type<int>)
+    t |> equal(idx_count, 0, "All three drop_index_if_exists calls succeeded silently; no indexes remain")
+}
+
+[test]
+def test_unique_composite_was_created_first(t : T?) {
+    // Run only v1 + v2 (skip v3 which drops the index) by walking history.
+    var inscope db = open_sqlite(":memory:")
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Email TEXT NOT NULL, Name TEXT NOT NULL)")
+    db |> create_unique_index(type<User>, ("Email", "Name"), "ux_email_name")
+    let is_unique = db |> query_scalar(
+        "SELECT \"unique\" FROM pragma_index_list('users') WHERE name='ux_email_name'", type<int>)
+    t |> equal(is_unique, 1, "create_unique_index must produce a UNIQUE index")
+    let col_count = db |> query_scalar(
+        "SELECT COUNT(*) FROM pragma_index_info('ux_email_name')", type<int>)
+    t |> equal(col_count, 2, "composite index must reference both columns")
+}

--- a/tests/dasSQLITE/migrate_22_add_column_dup_runtime.das
+++ b/tests/dasSQLITE/migrate_22_add_column_dup_runtime.das
@@ -1,0 +1,42 @@
+options gen2
+
+require dastest/testing_boost public
+require sqlite/sqlite_migrate
+
+[sql_table(name = "users")]
+struct User {
+    Id : int64
+    Score : int
+}
+
+[sql_migration(version = 1)]
+def m_001(db : SqlRunner) {
+    db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY)")
+}
+
+[sql_migration(version = 2)]
+def m_002(db : SqlRunner) {
+    db |> add_column(type<User>, "Score", 0)
+}
+
+[sql_migration(version = 3)]
+def m_003(db : SqlRunner) {
+    // Re-add the same column — SQLite ALTER TABLE … ADD COLUMN errors at runtime
+    // ("duplicate column name: Score"). The α-shape transaction in migrate_to_latest
+    // must roll back v=2 + v=3 atomically; the framework must not swallow the panic.
+    db |> add_column(type<User>, "Score", 1)
+}
+
+[test]
+def test_runtime_alter_failure_rolls_back_transaction(t : T?) {
+    var inscope db = open_sqlite(":memory:")
+    let res = db |> try_migrate_to_latest()
+    t |> equal(res |> is_err, true, "try_migrate_to_latest must surface the duplicate-column failure as Err")
+    // After rollback, neither v=2 nor v=3 are applied — applied_max is still 0 (no rows).
+    let max_applied = db |> query_scalar(
+        "SELECT COALESCE(MAX(version), 0) FROM __schema_version", type<int>)
+    t |> equal(max_applied, 0, "α-shape rollback: v=2 and v=3 must both be unrecorded after v=3 fails")
+    let table_exists = db |> query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='users'", type<int>)
+    t |> equal(table_exists, 0, "v=1's CREATE TABLE rolls back too — α-shape wraps the whole call")
+}

--- a/tests/dasSQLITE/migrate_22_failure_rolls_back.das
+++ b/tests/dasSQLITE/migrate_22_failure_rolls_back.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "good")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_24_vacuum.das
+++ b/tests/dasSQLITE/migrate_24_vacuum.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "create table; vacuum after", vacuum = true)]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_25_analyze.das
+++ b/tests/dasSQLITE/migrate_25_analyze.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "create + analyze", analyze = true)]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_28_no_vacuum_no_analyze_default.das
+++ b/tests/dasSQLITE/migrate_28_no_vacuum_no_analyze_default.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "no flags")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_29_inspection_pure.das
+++ b/tests/dasSQLITE/migrate_29_inspection_pure.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "alpha")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_35_history_after_migrate.das
+++ b/tests/dasSQLITE/migrate_35_history_after_migrate.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "alpha")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_39_downgrade_warning.das
+++ b/tests/dasSQLITE/migrate_39_downgrade_warning.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 // DB ahead of binary: audit has v=9 but the running binary's registered max is v=2.
 // migrate_to_latest must return 0 + leave the audit unchanged + log a warning (warning

--- a/tests/dasSQLITE/migrate_41_baseline_fresh.das
+++ b/tests/dasSQLITE/migrate_41_baseline_fresh.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "v1")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_42_baseline_idempotent.das
+++ b/tests/dasSQLITE/migrate_42_baseline_idempotent.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "v1")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_44_baseline_above_max.das
+++ b/tests/dasSQLITE/migrate_44_baseline_above_max.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "v1")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_45_baseline_then_migrate.das
+++ b/tests/dasSQLITE/migrate_45_baseline_then_migrate.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 [sql_migration(version = 1, description = "create users")]
 def m1(db : SqlRunner) {

--- a/tests/dasSQLITE/migrate_56_gap_allowed_versions.das
+++ b/tests/dasSQLITE/migrate_56_gap_allowed_versions.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 // Versions can be gappy (1, 5, 10) — strict-forward pending detection works on gaps.
 

--- a/tests/dasSQLITE/migrate_64_try_form_returns_err.das
+++ b/tests/dasSQLITE/migrate_64_try_form_returns_err.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 require daslib/strings_boost
 
 [sql_migration(version = 1, description = "good")]

--- a/tests/dasSQLITE/migrate_77_drop_column_native.das
+++ b/tests/dasSQLITE/migrate_77_drop_column_native.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 // Bundled SQLite 3.41.2 supports DROP COLUMN natively (since 3.35.0). No 12-step recipe.
 

--- a/tests/dasSQLITE/migrate_78_rename_column_native.das
+++ b/tests/dasSQLITE/migrate_78_rename_column_native.das
@@ -1,7 +1,7 @@
 options gen2
 
 require dastest/testing_boost public
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 // SQLite 3.41.2 supports RENAME COLUMN natively (since 3.25.0).
 

--- a/tutorials/sql/39-schema_from.das
+++ b/tutorials/sql/39-schema_from.das
@@ -90,7 +90,7 @@ def main() {
 // admin tooling — all good fits.
 //
 // For "the DB grows over time, run versioned schema migrations at startup",
-// `daslib/sql_migrate` (separate, optional module — coming soon) ships a
+// `daslib/sqlite_migrate` (separate, optional module — coming soon) ships a
 // `[sql_migration(version=N)]` annotation + `migrate_to_latest(db)` runner.
 // The two are orthogonal — schema_from gives compile-time contract checks
-// against a known schema; sql_migrate evolves the schema over time.
+// against a known schema; sqlite_migrate evolves the schema over time.

--- a/tutorials/sql/41-triggers.das
+++ b/tutorials/sql/41-triggers.das
@@ -21,7 +21,7 @@ require sqlite/sqlite_linq
 //     pseudo-tables). A portable abstraction would lose the parts
 //     people actually use triggers for.
 //   - Schema migrations are the right home for trigger DDL — see
-//     tutorial 32 (`[sql_migration]` + `daslib/sql_migrate`). Each
+//     tutorial 32 (`[sql_migration]` + `daslib/sqlite_migrate`). Each
 //     migration can `exec` a `CREATE TRIGGER` so the trigger
 //     ships with the schema version that needs it.
 

--- a/tutorials/sql/42-schema_evolution.das
+++ b/tutorials/sql/42-schema_evolution.das
@@ -86,8 +86,8 @@ def main() {
 // a third loop and the type system tells you exactly where to wire it up.
 //
 // For "my app's schema evolves at runtime; I run migrations at startup",
-// see `daslib/sql_migrate` (coming soon) — that's a different problem with
+// see `daslib/sqlite_migrate` (coming soon) — that's a different problem with
 // a different shape: versioned `[sql_migration(version=N)]` functions
 // applied in order, tracked in `__schema_version`, transactional per
 // migration. The two patterns coexist: schema_from for code-on-current-
-// schema, sql_migrate for the schema-grows-over-time runner.
+// schema, sqlite_migrate for the schema-grows-over-time runner.

--- a/tutorials/sql/43-migrations.das
+++ b/tutorials/sql/43-migrations.das
@@ -58,24 +58,57 @@ def migration_001(db : SqlRunner) {
     db |> exec("CREATE TABLE users (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL)")
 }
 
-// Migration 2 — add a column.
+// Migration 2 — add a column, typed form.
+//
+// `add_column(type<T>, "FieldName" [, defaultLit])` reads the field on the
+// current `[sql_table]` struct: SQL type comes from the daslang type via the
+// `_::sql_bind` adapter rail, NOT NULL is derived from the absence of
+// `Option<>` wrapping, DEFAULT from the literal you pass. The macro honors
+// `@sql_column` rename, `@sql_json`, `@sql_blob`. PK / UNIQUE / generated
+// columns can't be ADDed post-hoc — those need a table rebuild
+// (chunk 14c, struct_convert).
+//
+// Raw equivalent (typed form errors at compile time if the field name or
+// daslang shape changes; raw form silently drifts):
+//
+//     db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
 
 [sql_migration(version = 2, description = "add email column")]
 def migration_002(db : SqlRunner) {
-    db |> exec("ALTER TABLE users ADD COLUMN Email TEXT NOT NULL DEFAULT ''")
+    db |> add_column(type<User>, "Email", "")
 }
 
-// Migration 3 — multiple statements. All run inside the call's single
-// transaction; failure of any one rolls back the whole call. DDL and DML
-// mix freely.
+// Migration 3 — typed ADD COLUMN + raw DML. All run inside the call's
+// single transaction; failure of any one rolls back the whole call.
+// `analyze=true` on the annotation runs `ANALYZE` once after the call
+// commits — refreshes stats after the column add. VACUUM works the same
+// way (cheap-then-expensive ordering: ANALYZE, then VACUUM).
 
 [sql_migration(version = 3, description = "add score; backfill", analyze = true)]
 def migration_003(db : SqlRunner) {
-    db |> exec("ALTER TABLE users ADD COLUMN Score INTEGER NOT NULL DEFAULT 0")
+    db |> add_column(type<User>, "Score", 0)
     db |> exec("UPDATE users SET Score = 100 WHERE Email != ''")
-    // analyze=true on the annotation runs `ANALYZE` once after the call
-    // commits — refreshes stats after the column add. VACUUM works the
-    // same way (cheap-then-expensive ordering: ANALYZE, then VACUUM).
+}
+
+// Migration 4 — typed CREATE INDEX. Auto-name follows [sql_index]:
+// `idx_<table>_<col1>_<col2>`, on the post-`@sql_column` SQL identifiers.
+// Pass a custom name as the third positional arg if you want one. For
+// composite indexes, pass a tuple: ("Email", "Name").
+
+[sql_migration(version = 4, description = "index Email")]
+def migration_004(db : SqlRunner) {
+    db |> create_index(type<User>, "Email")
+}
+
+// Migration 5 — UNIQUE composite + idempotent rebuild via
+// `drop_index_if_exists` (SQLite supports IF EXISTS natively, so a missing
+// name is a clean no-op). Pattern: drop → create — safe if a previous
+// version already had the index, safe if it didn't.
+
+[sql_migration(version = 5, description = "unique (Email, Name)")]
+def migration_005(db : SqlRunner) {
+    db |> drop_index_if_exists("ux_email_name")
+    db |> create_unique_index(type<User>, ("Email", "Name"), "ux_email_name")
 }
 
 [export]
@@ -115,6 +148,44 @@ def main() : int {
         for (h in history) {
             print("  v{h.version}: '{h.description}'\n")
         }
+
+        // ================================================================
+        // PART 3.5 — Typed ALTER: when daslang has enough info to validate
+        // ================================================================
+        //
+        // Migrations 2-5 above use the typed surface in `daslib/sqlite_boost`:
+        //
+        //   db |> add_column(type<T>, "Field" [, defaultLit])
+        //   db |> create_index(type<T>, "Field" | ("A","B") [, "name"])
+        //   db |> create_unique_index(type<T>, … same shape …)
+        //   db |> drop_index_if_exists("name")
+        //
+        // What the typed forms buy you:
+        //
+        //  1. Compile-time field-name checks. `add_column(type<T>, "Emial")`
+        //     fails at compile time, not on the user's DB at startup.
+        //  2. Type-derived NOT NULL: forgetting NOT NULL+DEFAULT used to
+        //     mean existing rows panic on the next read. The macro derives
+        //     nullability from `Option<>` and refuses to ADD a non-nullable
+        //     column without a literal default.
+        //  3. `@sql_column` rename + `@sql_json` / `@sql_blob` storage are
+        //     honored automatically — same conventions as `[sql_table]` /
+        //     `[sql_index]`, no double-bookkeeping.
+        //
+        // What stays on `db |> exec(…)` (raw SQL):
+        //
+        //   - DROP COLUMN / RENAME COLUMN — old names aren't in the current
+        //     struct, so daslang has nothing to validate against.
+        //   - PK / UNIQUE inline / generated columns added post-hoc — SQLite
+        //     can't ALTER these in place; needs a table rebuild
+        //     (chunk 14c, struct_convert).
+        //   - CHECK constraints, FK ADD/DROP, column type changes.
+        //   - Anything ad-hoc that doesn't map to a struct field.
+
+        let n_idx = db |> query_scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name='users' AND name NOT LIKE 'sqlite_%'",
+            type<int>)
+        print("user indexes after migration 5: {n_idx}\n")
     }
 
     // =================================================================

--- a/tutorials/sql/43-migrations.das
+++ b/tutorials/sql/43-migrations.das
@@ -24,7 +24,7 @@ options gen2
 // See: API_MIGRATION.md (design notes), tut 39 (schema_from), tut 42
 // (multi-version ETL with schema_from for the *read* side).
 
-require sqlite/sql_migrate
+require sqlite/sqlite_migrate
 
 // =====================================================================
 // PART 1 — Define a schema and write a few migrations


### PR DESCRIPTION
Two commits, in order:

### 1. `dasSQLITE: rename daslib/sql_migrate -> daslib/sqlite_migrate`

Migrations as currently designed are SQLite-specific (the `__schema_version` audit table, `BEGIN IMMEDIATE`, `unixepoch()`, busy-timeout-based concurrent-runner contract). Sitting under the `daslib/sql_*` namespace would lie about provider neutrality. When the dasSQL abstraction lands, an abstract migration runner naturally takes the `daslib/sql_migrate` name; this provider-specific piece moves to `daslib/sqlite_migrate`. Doing the rename now keeps the public surface honest and avoids a churn migration when the abstraction lands.

Mechanical search-replace across 40 sites: file move + `module sql_migrate` -> `module sqlite_migrate`, internal qmacro `sql_migrate::_add_migration_entry` -> `sqlite_migrate::`, internal init thunk `register'sql'migrations` -> `register'sqlite'migrations`, all 23 test-side `require sqlite/sql_migrate` -> `require sqlite/sqlite_migrate`, mockup `daslib/sql_migrate` -> `daslib/sqlite_migrate`, prose references in API_REWORK / API_MIGRATION / API_MISSING / TUTORIALS / tutorials/sql/{39,41,42}-*.das + matching RST files, `modules/dasSQLITE/.das_module` `sqlite_paths` array, `tests/aot/CMakeLists.txt` AOT module list.

The annotation `[sql_migration]` is unchanged (SQL-level conceptual noun; an abstract migration layer landing later could reuse it).

### 2. `dasSQLITE chunk 14b: typed ALTER macros`

Adds the typed-ALTER ergonomics layer designed in `API_MIGRATION.md` Scenario 2 on top of the 14a migrations spine. New macros under `daslib/sqlite_boost` (transitively visible via `daslib/sqlite_migrate`'s existing `public` re-export):

```das
db |> add_column(type<T>, "Field" [, defaultLit])
db |> create_index(type<T>, "Field" | ("A","B") [, "name"])
db |> create_unique_index(type<T>, ... same shape ...)
db |> drop_index_if_exists("name")
```

**What the macros buy:**
- compile-time field-name + struct-shape checks (no more "user's DB panics on startup" surprises),
- type-derived NOT NULL: macro refuses to ADD a non-nullable column without a literal default; `Option<T>` wrapping = nullable,
- `@sql_column` rename + `@sql_json` / `@sql_blob` storage are honored, same conventions `[sql_table]` / `[sql_index]` already use,
- compile-time rejection for shapes that need a table rebuild (PK / UNIQUE inline / generated columns / `@sql_default_fn`).

**Field selectors are string literals**, not the `.Field` syntax used inside `_sql {...}` blocks — gen2's parser only synthesizes `_` as a placeholder inside that block scope. Plain call sites pass explicit string field names, same convention `[sql_index(fields="A")]` already uses.

`create_unique_index` is a separate macro rather than a `unique=true` named arg because gen2's named-arg form `[name=val]` produces an `ExprNamedCall` that `[call_macro]` doesn't intercept; positional separation is cleaner.

**Implementation notes:**
- `AddColumnMacro` emits `qmacro(_::exec($e(db), build_string $(w) { ... }))` writing `prefix + sql_storage_type_for(type<T>) + suffix` — runtime SQL-type derivation via the existing `_::sql_bind` adapter rail.
- `CreateIndex(Unique)Macro`: pure macro-time DDL build via `derive_index_name` (extracted from `SqlIndexMacro` for reuse).
- `drop_index_if_exists`: 5-line runtime function, IF EXISTS native.
- `is_option_field_type` relaxed: now matches both the typeMacro pre-instantiation form (what `[sql_table]` sees during structure_macro `apply()`) AND the post-template-instantiation `tStructure` form (what call_macros see at infer time). The latter has `_module=<callee>` (downstream of the template instantiation site), so module-name matching was unsound — switched to "Option<...>" name-shape match.

### Tests

16 new under `tests/dasSQLITE/`:

- 8 positives (`migrate_14_*` through `migrate_21_*`): `Option<T>` -> nullable; `int + default=0` -> NOT NULL DEFAULT + backfill; embedded single-quote escaping in DEFAULT; `@sql_column` rename propagation; `@sql_json` -> TEXT; `@sql_blob` struct -> BLOB; auto-named single-col index; UNIQUE composite + named index + `drop_index_if_exists` idempotence.
- 1 runtime-error positive (`migrate_22_add_column_dup_runtime`): re-adding the same column at runtime panics inside the migration; α-shape transaction rolls back the whole call (audit table empty, table doesn't exist).
- 7 `failed_*` compile-error negatives: unknown field, no `[sql_table]`, PK rejected, UNIQUE rejected, non-literal default, unknown index field, empty fields list.

`tests/dasSQLITE`: 748/748 pass interpreted **and** AOT, no GC leaks, lint clean, Sphinx clean (no warnings or errors).

### Tutorial

`tutorials/sql/43-migrations.das` + `doc/source/reference/tutorials/sql_43_migrations.rst` refreshed:
- migrations 002 / 003 rewritten to use the typed forms (raw-SQL equivalent kept as a sidebar comment),
- new "Typed ALTER: when daslang has enough info to validate" section between Inspection and Adoption,
- migrations 004 / 005 added showing `create_index` + idempotent rebuild via `drop_index_if_exists`.

`API_MIGRATION.md`, `API_REWORK.md`, `TUTORIALS.md` updated to mark 14b as shipped. Chunk 14c (struct rebuild) remains pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)