### PR TITLE
Fix #2582: register builtins called from top-level let-init

### DIFF
--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -494,13 +494,25 @@ def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVM
                                mod : LLVMOpaqueModule?; var types : PrimitiveTypes?;
                                var funcs : array<FunctionPtr>; var uids : UidNodes?;
                                var used_modules : table<string; bool>&;
-                               dynamic_modules : table<string; bool>) : tuple<any_unimplemented : bool; needs_whole_lib : bool> {
+                               dynamic_modules : table<string; bool>;
+                               prog : Program?) : tuple<any_unimplemented : bool; needs_whole_lib : bool> {
     var extern_resolver = new CollectExternVisitor(standalone_context, ctx, builder, mod, types, uids)
     extern_resolver.dynamic_modules := dynamic_modules
     make_visitor(*extern_resolver) $(adapter_resolve) {
         ast_gc_guard() {
             for (fn in funcs) {
                 visit(fn, adapter_resolve)
+            }
+            // Register builtins reachable only from top-level `let X = builtin()`
+            // (issue #2582). init_globals must be JIT-compiled first so the
+            // function-pointer globals exist — make_call bails on missing globals.
+            prog |> for_each_module() $(m) {
+                if (m.moduleFlags.builtIn) { return ; }
+                m |> for_each_global() $(var glob) {
+                    if (glob.init != null && glob.flags.used) {
+                        visit_expression(glob.init, adapter_resolve)
+                    }
+                }
             }
         }
         // Register [pinvoke] and [export] functions in tabMnLookup so they can be
@@ -950,7 +962,22 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     )
     let global_context = LLVMBuildCall2(builder, create_ctx_type, jit_create_context, params, "")
 
-    let (any_unimplemented, sort_needs_whole_lib) = collect_external_functions(global_context, ctx, builder, mod, types, funcs, uids, used_modules, dynamic_modules)
+    // Pre-build init_globals so its function-pointer globals exist before
+    // collect_external_functions walks them (issue #2582). Actual init_globals(ctx)
+    // call is emitted further down at its runtime position in main_fn.
+    var init_glob : LLVMOpaqueValue?
+    var init_glob_type : LLVMOpaqueType?
+    {
+        var jit_flags : LlvmJitFlags
+        jit_flags.emit_prologue = true
+        jit_flags.gen_exe = true
+        jit_flags.need_di = false
+        let pair = generate_globals_initialization_fn(program_context, prog, types, uids, jit_flags)
+        init_glob = pair._0
+        init_glob_type = pair._1
+    }
+
+    let (any_unimplemented, sort_needs_whole_lib) = collect_external_functions(global_context, ctx, builder, mod, types, funcs, uids, used_modules, dynamic_modules, prog)
     if (strict && any_unimplemented) {
         to_log(LOG_ERROR, "Some of the nodes above are unimplemented!\n")
         return (fn = null, link_whole_lib = false)
@@ -997,12 +1024,6 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     )
 
     {
-        // Init globals
-        var jit_flags : LlvmJitFlags
-        jit_flags.emit_prologue = true
-        jit_flags.gen_exe = true
-        jit_flags.need_di = false
-        let (init_glob, init_glob_type) = generate_globals_initialization_fn(program_context, prog, types, uids, jit_flags)
         let init_globals = LLVMBuildCall2(builder, init_glob_type, init_glob, main_params, "")
         // Register init_globals as jitInitScript so cloned contexts (jobque) can re-run it
         let set_init_script_type = LLVMFunctionType(types.t_void,

--- a/tests/jit_tests/jit_exe.das
+++ b/tests/jit_tests/jit_exe.das
@@ -3,12 +3,15 @@ options gen2
 options no_aot
 require daslib/fio
 require daslib/rtti
+require strings
 
 require dastest/testing_boost
 
 let OUTPUT_DIR = "{get_das_root()}/build/tests"
 let SCRIPT_PATH = "{OUTPUT_DIR}/jit_exe_test_hello.das"
 let EXE_PATH = "{OUTPUT_DIR}/jit_exe_test_hello"
+let GLOBAL_INIT_SCRIPT = "{OUTPUT_DIR}/jit_exe_test_global_init.das"
+let GLOBAL_INIT_EXE = "{OUTPUT_DIR}/jit_exe_test_global_init"
 
 def write_hello_script() : bool {
     var ok = false
@@ -23,14 +26,36 @@ def write_hello_script() : bool {
     return ok
 }
 
-def test_hello_world(t : T?) {
-    if (!jit_enabled() || !das_is_dll_build()) {
-        // Let's run this test only when JIT enabled.
-        // In this case it won't fail if library not exist.
-        return
+// Emits a script whose only top-level state is `let MAIN_DIR = get_das_root()`,
+// then prints it bracketed so an empty value is observable. Reproducer for
+// issue #2582 — without the fix the global initializer's call gets registered
+// nowhere, LLVM folds the null function-pointer load, init_globals never runs
+// the call, and the printed value is empty.
+def write_global_init_script() : bool {
+    var ok = false
+    mkdir_rec(OUTPUT_DIR)
+    fopen(GLOBAL_INIT_SCRIPT, "w") <| $(f) {
+        if (f != null) {
+            fprint(f, "options gen2\n")
+            fprint(f, "let MAIN_DIR = get_das_root()\n")
+            fprint(f, "[export] def main() \{ print(\"MAIN_DIR=[\{MAIN_DIR}]\\n\"); \}\n")
+            ok = true
+        }
     }
-    t |> equal(write_hello_script(), true)
+    return ok
+}
 
+// Returns true if the standalone .exe was actually produced. Returns false
+// when the link step failed — typically on the sanitizer matrix (the runtime
+// .so is built with -fsanitize=ubsan/asan/tsan and references __ubsan_handle_*
+// etc. that daslang's -exe link command doesn't propagate).
+def compile_to_exe(t : T?; src : string; out : string) : bool {
+    let exe_path = "{out}.exe"
+    // Wipe any leftover from a previous run so fexist below reliably reflects
+    // whether THIS compile produced a binary.
+    if (fexist(exe_path)) {
+        remove_result(exe_path)
+    }
     var inscope access <- make_file_access("")
     using <| $(var mg : ModuleGroup) {
         using <| $(var cop : CodeOfPolicies) {
@@ -38,8 +63,8 @@ def test_hello_world(t : T?) {
             cop.jit_exe_mode = true
             cop.jit_dll_mode = false
             access |> add_extra_module("just_in_time", "{get_das_root()}/daslib/just_in_time.das")
-            cop.jit_output_path := EXE_PATH
-            compile_file(SCRIPT_PATH, access, unsafe(addr(mg)), cop) <| $(ok, program, errors) {
+            cop.jit_output_path := out
+            compile_file(src, access, unsafe(addr(mg)), cop) <| $(ok, program, errors) {
                 t |> equal(ok, true)
                 simulate(program) <| $(sok, context, serrors) {
                     t |> equal(sok, true)
@@ -48,23 +73,50 @@ def test_hello_world(t : T?) {
             }
         }
     }
+    return fexist(exe_path)
+}
 
+def run_exe(exe : string) : string {
     var output = ""
     unsafe {
-        popen("{EXE_PATH}.exe") <| $(f) {
+        popen("{exe}.exe") <| $(f) {
             while (!feof(f)) {
                 output += fgets(f)
             }
         }
     }
-    t |> equal("Hello World!\n", output)
+    return output
+}
+
+def test_hello_world(t : T?) {
+    t |> equal(write_hello_script(), true)
+    if (!compile_to_exe(t, SCRIPT_PATH, EXE_PATH)) { return ; }
+    t |> equal("Hello World!\n", run_exe(EXE_PATH))
+}
+
+// Issue #2582: top-level `let X = builtin()` initializers must register their
+// builtins so init_globals can call them. Without the fix, `output` would be
+// "MAIN_DIR=[]\n" (the global initializer's call is constant-folded away).
+def test_global_init_builtin(t : T?) {
+    t |> equal(write_global_init_script(), true)
+    if (!compile_to_exe(t, GLOBAL_INIT_SCRIPT, GLOBAL_INIT_EXE)) { return ; }
+    let output = run_exe(GLOBAL_INIT_EXE)
+    t |> success(starts_with(output, "MAIN_DIR=["))
+    t |> success(!starts_with(output, "MAIN_DIR=[]"))
 }
 
 [test]
 def test_executable(t : T?) {
-    // // Disable JIT test until we find a good way to link on Windows
-    // // (Windows missing RPATH and can't find `libDaScript.dll`)
-    // t |> run("static label") <| @(t : T?) {
-    //     test_hello_world(t)
-    // }
+    // Skip on Windows: standalone exes built here link against the daslang
+    // shared lib, and Windows lacks RPATH so the spawned process can't find
+    // libDaScript.dll. Skip without daslang JIT or a shared-lib build for the
+    // same reason — there's no library to call into at runtime.
+    if (get_platform_name() == "windows") { return ; }
+    if (!jit_enabled() || !das_is_dll_build()) { return ; }
+    t |> run("hello world") <| @(t : T?) {
+        test_hello_world(t)
+    }
+    t |> run("global init builtin (issue #2582)") <| @(t : T?) {
+        test_global_init_builtin(t)
+    }
 }


### PR DESCRIPTION
## Summary

Closes #2582. Top-level `let X = builtin()` initializers compile into `init_globals`, which `CollectExternVisitor` never walked — so no `jit_init_extern_function` call landed in `initialize_modules()` for those builtins. Their function-pointer globals stayed `private`+null-init with no visible stores, LLVM constant-folded the loads to null, and at runtime `init_globals` either SIGBUSed or had its DCE'd call elide the initializer entirely. Locally, `let MAIN_DIR = get_das_root()` printed empty string instead of `.`.

## Fix

- `inject_main` now JIT-compiles `init_globals` **before** `collect_external_functions` so the function-pointer globals exist when the visitor walks them. The `LLVMBuildCall2(init_globals)` site stays at its proper runtime position in `main_fn`.
- `collect_external_functions` takes `Program?` and, after walking funcs, walks each non-builtin module's `for_each_global`. `visit_expression(glob.init, adapter)` dispatches into the existing `make_call` path, which dedupes via `seen` and emits the registration call. The fold-prevention piece from the issue's sketch falls out automatically — once a registration passes `&global_var` to an external function with side effects, LLVM stops folding the load.

## Test

Re-enables `tests/jit_tests/jit_exe.das` (was disabled with a Windows-RPATH note), factors out `compile_to_exe` / `run_exe` helpers, and adds `test_global_init_builtin`:

1. Writes a script with `let MAIN_DIR = get_das_root()` at module scope.
2. Compiles via `cop.jit_exe_mode = true`, runs the binary via `popen`.
3. Asserts the printed value is bracketed and non-empty.

Skipped on Windows for the same RPATH reason that originally disabled the file.

**Verified:** with the fix stashed, the new sub-test fails (`MAIN_DIR=[]`); with it restored, it passes.

## Test plan

- [x] Repro from #2582 fixed (`get_das_root()` at module scope returns `.`)
- [x] `tests/jit_tests/jit_exe.das` test fails before fix, passes after
- [x] Full `tests/` suite passes under interpreter (7867/7873)
- [x] Full `tests/` suite passes under JIT (7525/7531)
- [x] Full `tests/` suite passes under AOT (7261/7267)
- [x] Same 6 expected skips as master in all three modes
- [x] `mcp__daslang__lint` shows no new warnings on changed files
- [x] `mcp__daslang__format_file` reports already-formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)