### PR TITLE
Option<T> / Result<T,E>: structural named-tuple via [template_tuple]

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -2935,7 +2935,7 @@ class public CppAot : AstVisitor {
         tab ++;
         if (!expr.makeStructFlags.isNewHandle) {
             if (!needTempSrc(expr)) {
-                let expr_type = describeCppType(expr._type, DescribeConfig(skip_ref = true, cross_platform = cross_platform));
+                let expr_type = describeCppType(expr._type, DescribeConfig(skip_ref = true, skip_const = true, cross_platform = cross_platform));
                 write(*ss, "{tabs()}{expr_type} {mksName(expr)}");
                 if (expr.constructor != null) {
                     write(*ss, " = ");

--- a/daslib/option.das
+++ b/daslib/option.das
@@ -24,13 +24,15 @@ require daslib/typemacro_boost
 
 //! Tagged ``some``/``none`` pair over payload type ``T``.
 //!
-//! When ``_has_value`` is ``false``, ``value`` holds the zero value of ``T`` and
-//! must not be read. Accessor functions should be used for reads/writes.
-[template_structure(T), safe_when_uninitialized]
+//! Resolves to ``tuple<_has_value : bool; _value : T>`` — a structural type with
+//! no module home, so ``Option<T>`` reached through any chain of ``require ...
+//! public`` collapses to one canonical ``tTuple`` candidate (issue #2598).
+//! When ``_has_value`` is ``false``, ``_value`` holds the zero value of ``T``
+//! and must not be read. Use the accessor functions below for reads / writes.
+[template_tuple(T)]
 struct template Option {
     _has_value : bool = false
-    @safe_when_uninitialized
-    _value : T
+    @safe_when_uninitialized _value : T
 }
 
 //! Construct ``Option<T>`` carrying ``v``. Payload type is inferred from ``v``.
@@ -55,8 +57,7 @@ def some(v : auto(TT)) {
 //! clone; for workhorse types (``int``, ``float``, ``string``, …) ``some`` is
 //! equivalent and cheaper to read.
 def move_some(var v : auto(TT)) {
-    typedef OT = $Option < TT - const >
-    return <- OT(_has_value = true, _value <- v)
+    return <- (_has_value = true, _value <- v)
 }
 
 //! Construct an empty ``Option<T>``. Pass the payload type as a witness::

--- a/daslib/result.das
+++ b/daslib/result.das
@@ -26,17 +26,18 @@ require daslib/option public
 
 //! Tagged ``ok``/``err`` pair over payload ``T`` and error ``E``.
 //!
-//! When ``is_ok`` is ``true``, ``value`` is meaningful and ``error`` holds the zero
-//! value of ``E``. When ``is_ok`` is ``false``, ``error`` is meaningful and ``value``
-//! holds the zero value of ``T``. Prefer the accessor functions below over direct
-//! field reads.
-[template_structure(T, E)]
+//! Resolves to ``tuple<_is_ok : bool; _value : T; _error : E>`` — a structural
+//! type with no module home, so ``Result<T, E>`` reached through any chain of
+//! ``require ... public`` collapses to one canonical ``tTuple`` candidate
+//! (issue #2598). When ``is_ok`` is ``true``, ``value`` is meaningful and
+//! ``error`` holds the zero value of ``E``; when ``is_ok`` is ``false``,
+//! ``error`` is meaningful and ``value`` holds the zero value of ``T``. Prefer
+//! the accessor functions below over direct field reads.
+[template_tuple(T, E)]
 struct template Result {
     _is_ok : bool = false
-    @safe_when_uninitialized
-    _value : T
-    @safe_when_uninitialized
-    _error : E
+    @safe_when_uninitialized _value : T
+    @safe_when_uninitialized _error : E
 }
 
 //! Construct ``Result<T, E>`` carrying successful ``v``. Pass the error type as a witness::
@@ -64,8 +65,7 @@ def ok(v : auto(TT); etype : auto(EE)) {
 //! payloads where ``ok`` would clone.
 [template(etype)]
 def move_ok(var v : auto(TT); etype : auto(EE)) {
-    typedef RT = $Result < TT - const; EE - const >
-    return <- RT(_is_ok = true, _value <- v)
+    return <- (_is_ok = true, _value <- v, _error = default<EE>)
 }
 
 //! Construct ``Result<T, E>`` carrying error ``e``. Pass the value type as a witness::
@@ -93,8 +93,7 @@ def err(e : auto(EE); ttype : auto(TT)) {
 //! payloads where ``err`` would clone.
 [template(ttype)]
 def move_err(var e : auto(EE); ttype : auto(TT)) {
-    typedef RT = $Result < TT - const; EE - const >
-    return <- RT(_is_ok = false, _error <- e)
+    return <- (_is_ok = false, _value = default<TT>, _error <- e)
 }
 
 //! ``true`` iff the result is a successful ``ok``.

--- a/daslib/typemacro_boost.das
+++ b/daslib/typemacro_boost.das
@@ -555,6 +555,134 @@ class TemplateStructure : AstStructureAnnotation {
     }
 }
 
+[structure_macro(name="template_tuple")]
+class TemplateTuple : AstStructureAnnotation {
+    //! Like ``[template_structure]``, but produces a typemacro that returns a
+    //! named tuple instead of cloning a structure. Result is structural — no
+    //! module home, no per-consumer cloning. Use for sum-type / discriminated-
+    //! pair shapes (``Option``, ``Result``) where structural identity across
+    //! transitive ``require ... public`` is the desired behavior (issue #2598).
+    //!
+    //! Field types may be arbitrary type expressions referencing the template
+    //! arguments — ``T``, ``array<T>``, ``tuple<int; T; E>``, etc. The runtime
+    //! body uses ``apply_template`` (templates_boost) to walk each field's
+    //! TypeDecl and substitute alias slots with the corresponding typemacro arg.
+    //!
+    //! ``@safe_when_uninitialized`` on a source field propagates to the
+    //! corresponding tuple element's ``TypeDeclFlags.safeWhenUninitialized``,
+    //! so ``default<Foo<T>>`` succeeds even when that field's payload type is
+    //! itself unsafe-when-uninitialized. The tuple's recursive ``unsafeInit``
+    //! walks its element types, so per-element marking gives the same effect
+    //! as the legacy struct-level ``[safe_when_uninitialized]`` did.
+    def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
+        if (length(args) == 0) {
+            errors := "expecting at least one template argument name"
+            return false
+        }
+        var argNames : array<string>
+        var ctxFnArguments : array<VariablePtr>
+        for (arg in args) {
+            if (arg.basicType != Type.tBool) {
+                errors := "template_tuple only supports type-arg names; got '{arg.name}' of {arg.basicType}"
+                return false
+            }
+            argNames |> push(string(arg.name))
+            var argVar <- new Variable(name := string(arg.name), at = st.at)
+            argVar._type = new TypeDecl(baseType = Type.alias, alias := "TypeDeclPtr")
+            ctxFnArguments.emplace(argVar)
+        }
+        let typeMacroFunctionName = string(st.name)
+        let nFields = length(st.fields)
+        // Alias TypeDecl for the source struct — at typemacro-execution time
+        // ``typeinfo ast_typedecl(type<$t(aliasT)>)`` resolves through the
+        // module-scoped alias to the source struct, giving us its field list
+        // (with template aliases like ``T`` / ``array<T>`` preserved).
+        var aliasT = new TypeDecl(baseType = Type.alias, alias := string(st.name))
+        // Per-field argName checks — guard the generic path before the
+        // recursive unifier runs.
+        var perFieldArgNameChecks : array<ExpressionPtr>
+        for (i, fld in iter_range(st.fields), st.fields) {
+            let fname = string(fld.name)
+            perFieldArgNameChecks |> push(qmacro_block() {
+                if (passArgument.argNames[$v(i)] != $v(fname)) {
+                    return null
+                }
+            })
+        }
+        // Rules-block statements — substitute each template-arg alias
+        // (``T``, ``E``, ...) with the runtime arg. The same rules drive
+        // both paths: in the concrete path the runtime arg is a fully
+        // resolved type (``int``), and in the generic path it's
+        // ``auto(<caller-name>)`` — exactly the binding-slot the recursive
+        // unifier (``inferGenericType`` / ``updateAliasMap``) needs.
+        var rulesStmts : array<ExpressionPtr>
+        for (an in argNames) {
+            rulesStmts |> push(qmacro_expr() {
+                rules |> replaceTypeWithTypeDecl($v(an), clone_type($i(an)));
+            })
+        }
+        var typeMacroFunction = qmacro_function(typeMacroFunctionName) $(macroArgument, passArgument : TypeDeclPtr; $a(ctxFnArguments)) : TypeDeclPtr {
+            if (passArgument != null) {
+                if (passArgument.baseType != Type.tTuple) {
+                    return null
+                }
+                if (length(passArgument.argTypes) != $v(nFields)) {
+                    return null
+                }
+                if (length(passArgument.argNames) != $v(nFields)) {
+                    return null
+                }
+                $b(perFieldArgNameChecks)
+                // Build (argument_type, inferred_type) pairs from the source
+                // struct's fields and let ``infer_template_types`` run the
+                // standard unifier loop. ``apply_template`` substitutes each
+                // alias (``T``, ``E``, ...) with the runtime arg — concrete
+                // type when caller passed one, ``auto(<caller-name>)`` in
+                // generic context. Either form is what
+                // ``infer_template_types`` expects in ``argument_type``.
+                var src_type_g = typeinfo ast_typedecl(type<$t(aliasT)>)
+                var src_g = src_type_g.structType
+                var template_arguments : array<TypeMacroTemplateArgument>
+                for (i, fld in iter_range(src_g.fields), src_g.fields) {
+                    var fldType <- clone_type(fld._type)
+                    var fldAuto <- apply_template(fld.at, fldType) <| $(var rules : Template) {
+                        $b(rulesStmts)
+                    }
+                    template_arguments |> push(TypeMacroTemplateArgument(
+                        name = string(fld.name),
+                        argument_type = fldAuto,
+                        inferred_type = clone_type(passArgument.argTypes[i])))
+                }
+                return <- infer_template_types(passArgument, template_arguments)
+            }
+            // Concrete path: walk the source struct's fields and substitute
+            // template aliases with the runtime args via templates_boost's
+            // existing TypeDecl visitor — handles array<T>, tuple<int; T>, etc.
+            var src_type = typeinfo ast_typedecl(type<$t(aliasT)>)
+            var src = src_type.structType
+            var tt = new TypeDecl(baseType = Type.tTuple, at = macroArgument.at)
+            tt.argNames |> resize($v(nFields))
+            for (i, fld in iter_range(src.fields), src.fields) {
+                var fldType <- clone_type(fld._type)
+                var elt <- apply_template(fld.at, fldType) <| $(var rules : Template) {
+                    $b(rulesStmts)
+                }
+                tt.argTypes |> emplace_new <| elt
+                tt.argNames[i] := string(fld.name)
+                if (!(find_arg(fld.annotation, "safe_when_uninitialized") is nothing)) {
+                    tt.argTypes[i].flags |= TypeDeclFlags.safeWhenUninitialized
+                }
+            }
+            return <- tt
+        }
+        append_annotation(typeMacroFunction, "typemacro_boost", "typemacro_function", [])
+        if (!(compiling_module() |> add_function(typeMacroFunction))) {
+            panic("can't add function {typeMacroFunctionName}")
+        }
+        return true
+    }
+}
+
 [macro_function]
 def public is_custom_work_done(structType : Structure?) : bool {
     //! Returns true if custom work has already been performed on the template structure.

--- a/include/daScript/ast/ast_typedecl.h
+++ b/include/daScript/ast/ast_typedecl.h
@@ -275,6 +275,7 @@ namespace das {
                 bool    explicitRef : 1;
                 bool    isPrivateAlias : 1;    // this is a private alias. only matters in the context of module aliasTypes (for now)
                 bool    autoToAlias : 1;       // this allows conversion of auto to alias
+                bool    safeWhenUninitialized : 1; // exempt this type from "Uninitialized variable/field is unsafe" — analog of struct-level safe_when_uninitialized for tuples / variants / aliases
             };
             uint32_t flags = 0;
         };

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -2203,20 +2203,23 @@ def is_option_field_type(td : TypeDeclPtr) : bool {
     if (td.baseType == Type.typeMacro && length(td.dimExpr) > 0 && (td.dimExpr[0] is ExprConstString)) {
         return (td.dimExpr[0] as ExprConstString).value == "Option"
     }
-    // Post-instantiation form: tStructure named `Option<T>` (the [template_structure] machinery stamps
-    // the type-arg into the struct name). Templates instantiated downstream show _module=<callee>, not
-    // the original "option" module — match on the name shape instead.
-    if (td.baseType == Type.tStructure && td.structType != null) {
-        let sname = string(td.structType.name)
-        if (sname == "Option" || sname |> starts_with("Option<")) {
-            return true
-        }
+    // Post-instantiation form: structural named tuple ``tuple<_has_value:bool; _value:T>``.
+    // Option is built by daslib/option's typemacro_function as a structural tuple — no
+    // module home, no Structure clone. Match the canonical shape.
+    if (td.baseType == Type.tTuple
+            && length(td.argTypes) == 2
+            && length(td.argNames) == 2
+            && td.argNames[0] == "_has_value"
+            && td.argNames[1] == "_value"
+            && td.argTypes[0].baseType == Type.tBool) {
+        return true
     }
     return false
 }
 
 def unwrap_option_payload_type(var td : TypeDeclPtr) : TypeDeclPtr {
-    // Unwrap Option<T> → T (or td unchanged); typeMacro carries T in dimExpr[1], structType in `_value`.
+    // Unwrap Option<T> → T (or td unchanged); typeMacro carries T in dimExpr[1], the
+    // structural tuple form carries T in argTypes[1] (the `_value` slot).
     if (td == null) {
         return td
     }
@@ -2232,18 +2235,14 @@ def unwrap_option_payload_type(var td : TypeDeclPtr) : TypeDeclPtr {
         }
         return clone_type((td.dimExpr[1] as ExprTypeDecl).typeexpr)
     }
-    // Post-instantiation form: tStructure named `Option` or `Option<T>`. Mirrors is_option_field_type's
-    // shape detection — module identity doesn't load-bear once we're inside an Option-shaped struct;
-    // template instantiation downstream of "option" stamps the callee's _module, not "option".
-    if (td.baseType == Type.tStructure && td.structType != null) {
-        let sname = string(td.structType.name)
-        if (sname == "Option" || sname |> starts_with("Option<")) {
-            for (f in td.structType.fields) {
-                if ("{f.name}" == "_value") {
-                    return clone_type(f._type)
-                }
-            }
-        }
+    // Post-instantiation form: structural named tuple ``tuple<_has_value:bool; _value:T>``.
+    if (td.baseType == Type.tTuple
+            && length(td.argTypes) == 2
+            && length(td.argNames) == 2
+            && td.argNames[0] == "_has_value"
+            && td.argNames[1] == "_value"
+            && td.argTypes[0].baseType == Type.tBool) {
+        return clone_type(td.argTypes[1])
     }
     return td
 }

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -4479,16 +4479,26 @@ namespace das {
         } else {
             auto clashAlias = findAlias(name);
             if (clashAlias) {
-                string extra;
-                if (verbose) {
-                    auto atClash = clashAlias->getDeclarationLocation();
-                    if (!atClash.empty()) {
-                        extra = "previously declarated at " + atClash.describe();
+                // Silent dedupe: if `assume X : T` redeclares an alias that already
+                // resolves to the exact same type, treat it as a no-op. This covers
+                // the auto-injected `assume TT : T` placed at the start of a generic
+                // instance body when an outer scope (e.g. a typemacro-expanded
+                // result type carrying ``int aka TT``) already binds TT to T.
+                if (expr->assumeType && expr->assumeType->isSameType(*clashAlias,
+                        RefMatters::no, ConstMatters::no, TemporaryMatters::no)) {
+                    // fall through — the duplicate is harmless
+                } else {
+                    string extra;
+                    if (verbose) {
+                        auto atClash = clashAlias->getDeclarationLocation();
+                        if (!atClash.empty()) {
+                            extra = "previously declared at " + atClash.describe();
+                        }
                     }
+                    error("can't assume " + name + ", type or alias name is already used", extra, "",
+                          expr->at, CompilationError::already_declared_assume_alias);
+                    return;
                 }
-                error("can't assume " + name + ", type or alias name is already used", extra, "",
-                      expr->at, CompilationError::already_declared_assume_alias);
-                return;
             }
             if (!expr->assumeType) {
                 error("assume without subexpression must have type", "", "",
@@ -4562,7 +4572,18 @@ namespace das {
             }
             assume.push_back(AssumeEntry{expr, move(collector.vars)});
         } else {
-            assumeType.emplace_back(expr);
+            // Skip recording when preVisit silently deduped a same-type
+            // re-assume — keeps assumeType free of self-shadowing duplicates
+            // that would otherwise add findAlias lookup cost and confuse
+            // diagnostics.
+            auto existing = findAlias(expr->alias);
+            if (existing && expr->assumeType && expr->assumeType->isSameType(*existing,
+                    RefMatters::no, ConstMatters::no, TemporaryMatters::no)) {
+                // already bound to the same type — preVisit let it through,
+                // and we leave assumeType untouched so the original wins.
+            } else {
+                assumeType.emplace_back(expr);
+            }
         }
         return expr;
     }

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -220,6 +220,7 @@ namespace das
         TT->ref = (TT->ref || autoT->ref) && !autoT->removeRef && !TT->removeRef;
         TT->constant = (TT->constant || autoT->constant) && !autoT->removeConstant && !TT->removeConstant;
         TT->temporary = (TT->temporary || autoT->temporary) && !autoT->removeTemporary && !TT->removeTemporary;
+        TT->safeWhenUninitialized = TT->safeWhenUninitialized || autoT->safeWhenUninitialized;
         if ( (autoT->removeDim || TT->removeDim) && TT->dim.size() ) TT->dim.erase(TT->dim.begin());
         TT->removeConstant = false;
         TT->removeDim = false;
@@ -1260,6 +1261,7 @@ namespace das
     }
 
     bool TypeDecl::unsafeInit( das_set<Structure*> & dep ) const {
+        if ( safeWhenUninitialized ) return false;
         if ( baseType==Type::tHandle ) {
             return  annotation->hasNonTrivialCtor();
         } if ( baseType==Type::tStructure ) {

--- a/src/ast/ast_unused.cpp
+++ b/src/ast/ast_unused.cpp
@@ -568,6 +568,12 @@ namespace das {
             if ( expr->func && expr->func->name == "finalize" && expr->arguments.size()==1 ) {
                 propagateWrite(expr->arguments[0]);
             }
+            // call with no resolved function — nothing to propagate; the typer
+            // either left this as an unresolved generic (error elsewhere) or it's
+            // a desugar artifact carrying no side-effect contract.
+            if ( !expr->func ) {
+                return;
+            }
             // if modified, modify NEW
             auto sef = getSideEffects(expr->func);
             if ( sef & uint32_t(SideEffects::modifyArgument) ) {

--- a/src/builtin/module_builtin_ast_flags.cpp
+++ b/src/builtin/module_builtin_ast_flags.cpp
@@ -157,7 +157,7 @@ namespace das {
             "removeRef", "removeConstant", "removeDim",
             "removeTemporary", "explicitConst", "aotAlias", "smartPtr",
             "smartPtrNative", "isExplicit", "isNativeDim", "isTag", "explicitRef",
-            "isPrivateAlias", "autoToAlias" };
+            "isPrivateAlias", "autoToAlias", "safeWhenUninitialized" };
         return ft;
     }
 

--- a/tests/option/_test_option_user_struct_mod.das
+++ b/tests/option/_test_option_user_struct_mod.das
@@ -1,0 +1,28 @@
+options gen2
+
+module _test_option_user_struct_mod shared public
+
+require daslib/option public
+
+struct public Foo {
+    id : int
+    name : string
+}
+
+def public make_foo(id : int; name : string) : Foo {
+    return Foo(id = id, name = name)
+}
+
+def public operator ==(a, b : Foo) : bool {
+    return a.id == b.id && a.name == b.name
+}
+
+// Cross-module Option<UserStruct> path. Exercises the bracket-aware
+// splitTypeName fix from feedback_option_cross_module_template_bug, and
+// guards against re-introducing it under the typemacro+tuple shape.
+def public lookup_foo(id : int) : Option<Foo> {
+    if (id <= 0) {
+        return none(type<Foo>)
+    }
+    return some(make_foo(id, "name-{id}"))
+}

--- a/tests/option/_test_template_tuple_composite_mod.das
+++ b/tests/option/_test_template_tuple_composite_mod.das
@@ -1,0 +1,46 @@
+options gen2
+options indenting = 4
+
+module _test_template_tuple_composite_mod shared public
+
+require daslib/typemacro_boost public
+
+// ``Bag<T>`` — single-arg, composite field shape (``items : array<T>``).
+// Pre-fix, the typemacro generic path failed to match ``$Bag<auto(TT)>``
+// against a concrete ``Bag<int>`` because the per-field detection only
+// caught direct alias and the bind-extraction was wrong-shaped for any
+// wrapper.
+[template_tuple(T)]
+struct template public Bag {
+    count : int = 0
+    items : array<T>
+}
+
+// ``Pair<K, V>`` — multi-arg, top-level alias fields.
+[template_tuple(K, V)]
+struct template public Pair {
+    key : K
+    value : V
+}
+
+// ``KVList<K, V>`` — multi-arg, composite field shapes for both args.
+[template_tuple(K, V)]
+struct template public KVList {
+    keys : array<K>
+    values : array<V>
+}
+
+// Generic-path consumers — these are the call sites that were broken
+// pre-fix. Resolution invokes the typemacro's generic path and binds
+// the auto-named template arg through the field shape.
+def public bag_size(b : $Bag < auto(TT) >) : int {
+    return length(b.items)
+}
+
+def public pair_first(p : $Pair < auto(KK), auto(VV) >) : KK {
+    return p.key
+}
+
+def public kvlist_size(l : $KVList < auto(KK), auto(VV) >) : int {
+    return length(l.keys)
+}

--- a/tests/option/test_option_unsafe_uninitialized.das
+++ b/tests/option/test_option_unsafe_uninitialized.das
@@ -1,0 +1,53 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require daslib/option
+
+// Regression for typemacro+tuple Option carrying a payload that's
+// "unsafe-when-uninitialized" — i.e. a struct with hasInitFields = true.
+// Without TypeDeclFlags.safeWhenUninitialized on the value field,
+// default<Option<Brittle>> would trip ast_infer_type.cpp:5032's
+// "Uninitialized variable" check.
+
+struct Brittle {
+    must_init : int = 42
+    name : string = "default"
+}
+
+[test]
+def option_brittle_constructors(t : T?) {
+    t |> run("default<Option<Brittle>> compiles and reads as none") @(t : T?) {
+        let o = none(type<Brittle>)
+        t |> success(o |> is_none)
+        t |> success(!(o |> is_some))
+    }
+    t |> run("bare var Option<Brittle> compiles via @safe_when_uninitialized on _value") @(t : T?) {
+        // Without @safe_when_uninitialized on the _value field of the tuple
+        // produced by [template_tuple(T)] in daslib/option.das, this would
+        // trigger "Uninitialized variable is unsafe" at ast_infer_type.cpp:5040.
+        // The bare var (no init) is the only form that exercises this check —
+        // ``let`` requires an initializer.
+        var bare : Option<Brittle> // nolint:LINT003
+        t |> success(bare |> is_none)
+    }
+    t |> run("some(Brittle(...)) round-trips") @(t : T?) {
+        let o = some(Brittle(must_init = 7, name = "x"))
+        t |> success(o |> is_some)
+        let v = o |> unwrap
+        t |> equal(v.must_init, 7)
+        t |> equal(v.name, "x")
+    }
+}
+
+[test]
+def option_brittle_unwrap_or_default(t : T?) {
+    t |> run("unwrap_or_default returns default<Brittle> on none") @(t : T?) {
+        let o = none(type<Brittle>)
+        let v = o |> unwrap_or_default
+        t |> equal(v.must_init, 42)
+        t |> equal(v.name, "default")
+    }
+}

--- a/tests/option/test_option_user_struct.das
+++ b/tests/option/test_option_user_struct.das
@@ -1,0 +1,42 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require daslib/option
+require _test_option_user_struct_mod
+
+// Regression for feedback_option_cross_module_template_bug.md (splitTypeName
+// must be bracket-aware so Option<_mod::UserStruct> doesn't split at the
+// inner ::). With Option as a structural tuple (typemacro_function), tuples
+// are not module-keyed, so this should be even more robust — the test exists
+// to prove that conclusion under future refactors.
+
+[test]
+def cross_module_option_some(t : T?) {
+    t |> run("Option<Foo> across module boundary — some path") @(t : T?) {
+        let hit = lookup_foo(7)
+        t |> success(hit |> is_some)
+        let v = hit |> unwrap
+        t |> equal(v.id, 7)
+        t |> equal(v.name, "name-7")
+    }
+}
+
+[test]
+def cross_module_option_none(t : T?) {
+    t |> run("Option<Foo> across module boundary — none path") @(t : T?) {
+        let miss = lookup_foo(0)
+        t |> success(miss |> is_none)
+    }
+}
+
+[test]
+def cross_module_option_equality(t : T?) {
+    t |> run("Option<Foo> structural equality across module boundary") @(t : T?) {
+        t |> success(lookup_foo(3) == some(make_foo(3, "name-3")))
+        t |> success(!(lookup_foo(0) == some(make_foo(3, "name-3"))))
+        t |> success(!(lookup_foo(3) == some(make_foo(4, "name-4"))))
+    }
+}

--- a/tests/option/test_template_tuple_composite.das
+++ b/tests/option/test_template_tuple_composite.das
@@ -1,0 +1,82 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require _test_template_tuple_composite_mod
+
+// Regression coverage for ``[template_tuple]`` field shapes with template
+// args INSIDE a wrapper (``array<T>``, etc.). Production ``Option<T>`` /
+// ``Result<T,E>`` use only top-level-alias fields, so they did not exercise
+// the generic-path bind for composite shapes. See the helper module for
+// details on what was broken pre-fix.
+
+[test]
+def template_tuple_composite_single_arg(t : T?) {
+    t |> run("Bag<int>: default + concrete construction") @(t : T?) {
+        var b = default<Bag<int>>
+        t |> equal(b.count, 0)
+        t |> equal(length(b.items), 0)
+    }
+    t |> run("Bag<int>: move payload, read fields") @(t : T?) {
+        var items : array<int>
+        items |> push(1)
+        items |> push(2)
+        items |> push(3)
+        var b : Bag<int>
+        b.count = length(items)
+        b.items <- items
+        t |> equal(b.count, 3)
+        t |> equal(length(b.items), 3)
+        t |> equal(b.items[1], 2)
+    }
+    t |> run("Bag<string>: generic dispatch infers TT through array<T>") @(t : T?) {
+        var b : Bag<string>
+        b.items |> push("a")
+        b.items |> push("b")
+        t |> equal(bag_size(b), 2)
+    }
+}
+
+[test]
+def template_tuple_top_level_multi_arg(t : T?) {
+    t |> run("Pair<int, string>: concrete construction") @(t : T?) {
+        var p : Pair<int, string>
+        p.key = 7
+        p.value = "x"
+        t |> equal(p.key, 7)
+        t |> equal(p.value, "x")
+    }
+    t |> run("Pair<int, string>: generic dispatch infers KK + VV") @(t : T?) {
+        var p : Pair<int, string>
+        p.key = 42
+        p.value = "y"
+        t |> equal(pair_first(p), 42)
+    }
+}
+
+[test]
+def template_tuple_composite_multi_arg(t : T?) {
+    t |> run("KVList<int, string>: concrete construction") @(t : T?) {
+        var l : KVList<int, string>
+        l.keys |> push(1)
+        l.keys |> push(2)
+        l.values |> push("a")
+        l.values |> push("b")
+        t |> equal(length(l.keys), 2)
+        t |> equal(length(l.values), 2)
+        t |> equal(l.keys[0], 1)
+        t |> equal(l.values[1], "b")
+    }
+    t |> run("KVList<int, string>: generic dispatch through both array<K> and array<V>") @(t : T?) {
+        var l : KVList<int, string>
+        l.keys |> push(10)
+        l.keys |> push(20)
+        l.keys |> push(30)
+        l.values |> push("p")
+        l.values |> push("q")
+        l.values |> push("r")
+        t |> equal(kvlist_size(l), 3)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2598. Combining `daslib/clargs` and `modules/dasSQLITE/daslib/sqlite_boost` (directly or via `require ... public` chains) made every `Option<string>` ambiguous — `[template_structure]` cloned an instance struct into each consuming module via `qmacro_template_class`, producing N module-aliased views of the same source decl. Candidate collection treated them as distinct and emitted `error[30341]: too many matching functions or generics _::Option<string>` with three identical-looking candidates pointing at the same line.

Rather than a typer-side dedupe of candidates by source decl (broader scope, not gated on this PR), `Option` and `Result` now resolve to **structural named tuples**. Tuples have no module home; multiple transitive re-exports collapse to one canonical `tTuple` TypeDecl regardless of which alias the user lands on.

```das
[template_tuple(T)]
struct template Option {
    _has_value : bool = false
    @safe_when_uninitialized _value : T
}
```

- `Option<T>`   → `tuple<_has_value : bool; _value : T>`
- `Result<T,E>` → `tuple<_is_ok : bool; _value : T; _error : E>`

## Pieces

**`daslib/typemacro_boost.das`** — new `[template_tuple(T...)]` `[structure_macro]`. At apply time it generates a `[typemacro_function]`; at typemacro-execution time the body has two paths:
- *generic*: shape-matches a `tTuple` by `argNames` + literal-field `baseType`, and feeds template-arg fields into `infer_template_types` via `passArgument.argTypes[i]`.
- *concrete*: looks up the source struct via `typeinfo ast_typedecl(type<X>)` (X = the struct's module-scoped alias) and applies `templates_boost`'s existing TypeDecl visitor (`apply_template` + `replaceTypeWithTypeDecl`) to each field. The visitor walks `T`, `array<T>`, `tuple<int; T; E>`, etc. uniformly — no apply-time recursion over field shapes is needed.

Field-level `@safe_when_uninitialized` propagates: when a source field carries the annotation, the corresponding tuple element's TypeDecl gets `TypeDeclFlags.safeWhenUninitialized`. The tuple's recursive `unsafeInit` walks its `argTypes`, so per-element marking gives the same effect the legacy struct-level `[safe_when_uninitialized]` used to.

**`daslib/option.das`, `daslib/result.das`** — collapse to near-original struct declarations with annotation swap + `move_some` / `move_ok` / `move_err` rewrites that drop the `typedef RT` shorthand in favor of anonymous named-tuple construction.

**Compiler-side support** for safe-when-uninitialized at TypeDecl granularity:
- `TypeDecl::safeWhenUninitialized` flag bit + `unsafeInit` short-circuit. Lets a typemacro mark a tuple component (e.g. `Option`'s `_value` field) safe to leave uninitialized even when the underlying `T` isn't.
- `TypeDecl::applyAutoContracts` OR-merges the new flag the same way it merges `ref` / `constant` / `temporary`, so generic resolution preserves it across `auto`.
- `TypeDeclFlags` exposes the bit to daslang code.
- `InferTypes::preVisit(ExprAssume*)` silently dedupes `assume X : T` when an outer scope already binds `X` to the same type. Handles the auto-injected assume placed at the start of a generic instance body when a typemacro-built result type carries an alias the body also references. `InferTypes::visit(ExprAssume*)` mirrors the same predicate so a deduped re-assume is also kept out of `assumeType`, leaving `findAlias` lookups clean.
- AOT codegen: emit local make-struct destinations without `const`. Aggregate types holding `TTuple<>` need to be value-init'd at declaration; the const qualifier was making C++ reject `T const x;` for those shapes.

**dasSQLITE adapter rail** — `is_option_field_type` / `unwrap_option_payload_type` detect the typeMacro form (during `[sql_table]` `apply`) and the post-instantiation `tTuple` form. The legacy struct-shape detection drops out — no in-tree code emits a struct-shaped `Option` after this PR.

## Test plan

- [x] `daslang dastest/dastest.das -- --test tests/option/`  → 205/205 pass
- [x] `daslang dastest/dastest.das -- --test tests/dasSQLITE/`  → 771/771 pass
- [x] `daslang dastest/dastest.das -- --test tests/`  → 7961/7961 interpreted
- [x] `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests/`  → 7355/7355 AOT
- [x] Issue #2598 repro (`require daslib/clargs` + `require sqlite/sqlite_boost` + `Option<string>` field) compiles cleanly
- [x] Bare-var regression: removing `@safe_when_uninitialized` from `_value : T` and recompiling `tests/option/test_option_unsafe_uninitialized.das` produces `error[31016]` on the bare `var x : Option<Brittle>` line — the per-field annotation is doing real work
- [x] Composite literal field types (`array<T>`, `tuple<int; T; E>`) substitute correctly via the visitor — verified with a hand-rolled `[template_tuple]` probe carrying `array<T>` and `tuple<int; T; E>` field shapes
- [x] Lint clean on all changed `.das` files
- [x] MCP `format_file` clean on all changed `.das` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)