### PR TITLE
dasSQLITE: _in / _not_in for captured collections via SQLite json_each

### DIFF
--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -153,6 +153,9 @@ part re-uses the same [sql_table] from Part 1.
     NOT EXISTS / IN / NOT IN, correlated and uncorrelated. Introduces:
     why negated names exist (`!expr` isn't AST-walkable — see
     API_REWORK pattern note). Mockup: [24-subqueries.das](tutorial-mockup/24-subqueries.das.mockup).
+    The captured-runtime-collection form of `_in` / `_not_in` (lowering
+    to `IN (SELECT value FROM json_each(?))`) ships as a separate
+    tutorial — see #42 below.
 18. **NULL handling — `Option<T>` everywhere** — nullable columns typed
     as `Option<T>` in the struct, `_.Col |> is_some()` / `is_none()` in
     predicates emit IS NOT NULL / IS NULL, `|> unwrap_or(x)` emits
@@ -365,6 +368,11 @@ Niche, but tractable once the base is down.
 41. **Triggers** — DB-level callbacks via raw SQL inside migrations.
     Deliberately *no* daslang-side trigger DSL. Per API_REWORK §41.
     Mockup: **no API impact — concept tutorial**.
+42. **`_in` / `_not_in` — captured-collection form** — bind a runtime
+    `array<T>` and lower to `WHERE Col IN (SELECT value FROM json_each(?))`
+    via SQLite's table-valued JSON1. Single bind, any size, plan-cache-
+    friendly (matches EF Core 8's default). NULL-correct `_not_in` on
+    nullable columns via the defensive `OR Col IS NULL` form.
 
 ---
 
@@ -444,12 +452,14 @@ E. **Forward-looking: `dasSQL` abstraction layer** — the roadmap beyond
 | 39 | UD SQL functions | `32-sql_functions.das` | **Shipped** (chunk 10); `register_function(db, name, @@fn[, deterministic[, directonly]])` call macro; arity 0..4; arg/return tags derived from function-pointer type; NULL short-circuit; panic recovery via `Context::runWithCatch` |
 | 40 | FTS5 | `39-fts5.das` | Has mockup |
 | 41 | Triggers | — | No-API — concept tutorial |
+| 42 | `_in` / `_not_in` — captured-collection form | `tutorials/sql/44-in_not_in_collections.das` | **Shipped** (2026-05-08); JSON-bridge lowering to `IN (SELECT value FROM json_each(?))` for runtime `array<T>`; defensive `OR IS NULL` for `_not_in` on `Option<T>` columns; subquery form of `_in` / `_not_in` (tutorial 17) unchanged |
 
 **Mockup coverage:** 27 tutorials have a mockup already. 7 need a new mockup
 (mostly in Part 3 — the `_sql` chain deep-dives — plus BLOB round-trip and
 two introspection tutorials). 4 are no-API concept tutorials and don't get
 a mockup by design. 5 concept appendices (A-E) are prose-only reference
-docs.
+docs. Tutorial 42 (captured-collection `_in` / `_not_in`) shipped without
+a prior mockup — extends the subquery form from tutorial 17.
 
 **Inherited-file cross-reference:** see [API_REWORK.md](API_REWORK.md)'s
 per-section headers (`### NN-topic` prefix) for the decision log behind

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -491,6 +491,122 @@ def private lookup_arg_source(q : SqlQuery; argName : string) : int {
     return -1
 }
 
+[macro_function]
+def private call_resolved_name(var call : ExprCall?) : string {
+    if (call == null || call.func == null) {
+        return ""
+    }
+    if (call.func.fromGeneric != null) {
+        return string(call.func.fromGeneric.name)
+    }
+    return string(call.func.name)
+}
+
+[macro_function]
+def private emit_in_collection_json_bridge(var collArg : ExpressionPtr; var q : SqlQuery&;
+                                           xSql : string; negated : bool; nullable : bool) : string {
+    // Captured-collection lowering for `_in` / `_not_in`: encode arr as JSON TEXT,
+    // single bind, query via SQLite's table-valued json_each. EF Core 8's default.
+    var rawArg : ExpressionPtr = clone_expression(collArg)
+    var wrapped : ExpressionPtr = qmacro(_::write_json(_::JV($e(rawArg))))
+    if (q.inHaving) {
+        q.havingBindExprs |> push(wrapped)
+    } else {
+        q.bindExprs |> push(wrapped)
+    }
+    if (negated) {
+        // Three-valued logic: `x != NULL` is unknown, so naive NOT IN drops rows
+        // whose column is NULL. Defensive form preserves them on nullable columns.
+        if (nullable) {
+            return "({xSql} NOT IN (SELECT value FROM json_each(?)) OR {xSql} IS NULL)"
+        }
+        return "{xSql} NOT IN (SELECT value FROM json_each(?))"
+    }
+    return "{xSql} IN (SELECT value FROM json_each(?))"
+}
+
+[macro_function]
+def private looks_like_subquery_chain(var arg : ExpressionPtr) : bool {
+    // Walks `arg.arguments[0]` repeatedly; chain shape bottoms out at `select_from(...)`.
+    // Captured arrays / inline literals / user functions returning array<T> never reach it.
+    // Handles both expanded ExprCall (e.g. `select(...)`) and unexpanded ExprCallMacro
+    // (`_select(...)`, `_where(...)`) on intermediate chain links — Mode-2 doesn't deep-walk
+    // into `_in`'s arguments, so we may see either form depending on local expansion order.
+    var cur = arg
+    let max_depth = 32
+    for (_ in range(max_depth)) {
+        if (cur == null) {
+            return false
+        }
+        if (cur is ExprCall) {
+            var call = cur as ExprCall
+            if (call_resolved_name(call) == "select_from") {
+                return true
+            }
+            if (length(call.arguments) == 0) {
+                return false
+            }
+            cur = call.arguments[0]
+        } elif (cur is ExprCallMacro) {
+            var mcall = cur as ExprCallMacro
+            if (mcall.name == "select_from") {
+                return true
+            }
+            if (length(mcall.arguments) == 0) {
+                return false
+            }
+            cur = mcall.arguments[0]
+        } else {
+            return false
+        }
+    }
+    return false
+}
+
+[macro_function]
+def private is_nullable_column_ref(var node : ExpressionPtr; var q : SqlQuery&) : bool {
+    // Matches `_.<Field>` / `<alias>._.<Field>` (mirrors the column-ref qmatch arm in
+    // pred_to_sql) and consults is_option_field_type on the matching struct field.
+    // Returns true on shapes we don't recognize so the caller emits the safer NOT IN
+    // form by default.
+    if (node is ExprRef2Value) {
+        node = (node as ExprRef2Value).subexpr
+    }
+    if (node == null) {
+        return true
+    }
+    var receiver : ExpressionPtr
+    var fieldName : string
+    if (!qmatch(node, $e(receiver).$f(fieldName)).matched
+            || receiver == null || !(receiver is ExprVar)) {
+        return true
+    }
+    let argName = string((receiver as ExprVar).name)
+    var srcIdx = -1
+    if (!empty(q.rootAlias)) {
+        srcIdx = lookup_arg_source(q, argName)
+        if (srcIdx < 0 && argName == "_") {
+            srcIdx = 0
+        }
+    } elif (argName == "_") {
+        srcIdx = 0
+    }
+    if (srcIdx < 0) {
+        return true
+    }
+    let rootT = source_rootType_for_idx(q, srcIdx)
+    if (rootT == null || rootT.structType == null) {
+        return true
+    }
+    var st = rootT.structType
+    for (field in st.fields) {
+        if (field.name == fieldName) {
+            return is_option_field_type(field._type)
+        }
+    }
+    return true
+}
+
 // ===== Chain analysis (walk pipe-composed chain backwards) =====
 
 [macro_function]
@@ -2513,6 +2629,13 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
                     var firstT = icall.arguments[0]._type
                     if (firstT != null && (firstT.isIterator || firstT.isGoodArrayType)) {
                         let xSql = pred_to_sql(icall.arguments[1], q, prog, at)
+                        return "" if (q.hadError)
+                        // Captured-collection form: arg1 is `array<T>` and not a chain → JSON bridge.
+                        if (!looks_like_subquery_chain(icall.arguments[0])
+                                && firstT.isGoodArrayType) {
+                            let nullable = is_nullable_column_ref(icall.arguments[1], q)
+                            return emit_in_collection_json_bridge(icall.arguments[0], q, xSql, true, nullable)
+                        }
                         var binds : array<ExpressionPtr>
                         let subSql = analyze_subquery(icall.arguments[0], binds, prog, at, true, q.inView)
                         if (empty(subSql)) {
@@ -2738,12 +2861,46 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         var mcall = node as ExprCallMacro
         let mname = string(mcall.name)
         if ((mname == "_in" || mname == "_not_in") && length(mcall.arguments) == 2) {
-            // arg order: (element, subquery)
+            // arg order: (element, collection-or-subquery)
             let xSql = pred_to_sql(mcall.arguments[0], q, prog, at)
+            return "" if (q.hadError)
+            var collArg : ExpressionPtr = mcall.arguments[1]
+            // Subquery form first: `select_from(...) |> ...` chains have array type
+            // post-typer, so isGoodArrayType alone can't distinguish them from a
+            // captured runtime array — pick by AST shape (chain bottoms out at
+            // `select_from`).
+            if (looks_like_subquery_chain(collArg)) {
+                var binds : array<ExpressionPtr>
+                let subSql = analyze_subquery(collArg, binds, prog, at, true, q.inView)
+                if (empty(subSql)) {
+                    q.hadError = true   // analyze_subquery emitted macro_error
+                    return ""
+                }
+                for (b in binds) {
+                    if (q.inHaving) {
+                        q.havingBindExprs |> push <| clone_expression(b)
+                    } else {
+                        q.bindExprs |> push <| clone_expression(b)
+                    }
+                }
+                if (mname == "_not_in") {
+                    return "{xSql} NOT IN ({subSql})"
+                }
+                return "{xSql} IN ({subSql})"
+            }
+            // Captured-collection form: arg2 is `array<T>` (variable, function result,
+            // literal). Bind JSON-encoded TEXT and use SQLite's table-valued json_each —
+            // single bind, any size, plan-cache-friendly (matches EF Core 8's default).
+            if (collArg._type != null && collArg._type.isGoodArrayType) {
+                let negated = mname == "_not_in"
+                let nullable = negated && is_nullable_column_ref(mcall.arguments[0], q)
+                return emit_in_collection_json_bridge(collArg, q, xSql, negated, nullable)
+            }
+            // Neither shape — let the existing subquery analyzer surface the diagnostic.
             var binds : array<ExpressionPtr>
-            let subSql = analyze_subquery(mcall.arguments[1], binds, prog, at, true, q.inView)
+            let subSql = analyze_subquery(collArg, binds, prog, at, true, q.inView)
             if (empty(subSql)) {
-                q.hadError = true   // analyze_subquery emitted macro_error
+                q.hadError = true
                 return ""
             }
             for (b in binds) {
@@ -3077,6 +3234,12 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
     if (fname == "contains" && argc == 2) {
         let xSql = pred_to_sql(call.arguments[1], q, prog, at)
         return "" if (q.hadError)
+        // Captured-collection form: arg0 is `array<T>` and not a chain → JSON bridge.
+        var firstT = call.arguments[0]._type
+        if (firstT != null && firstT.isGoodArrayType
+                && !looks_like_subquery_chain(call.arguments[0])) {
+            return emit_in_collection_json_bridge(call.arguments[0], q, xSql, false, false)
+        }
         var binds : array<ExpressionPtr>
         let subSql = analyze_subquery(call.arguments[0], binds, prog, at, true, q.inView)
         if (empty(subSql)) {

--- a/tests/dasSQLITE/parity_check_17_subqueries.das
+++ b/tests/dasSQLITE/parity_check_17_subqueries.das
@@ -10,10 +10,12 @@ require sqlite/sqlite_linq
 // Parity check for tutorial 17 — subqueries.
 //
 // Shapes (each must produce identical row sets across the three modes):
-//   1. `_in(subquery)`     — IN
-//   2. `_not_in(subquery)` — NOT IN
-//   3. `_any(predicate)`   — EXISTS WHERE
-//   4. `_none(predicate)`  — NOT EXISTS WHERE
+//   1. `_in(subquery)`            — IN
+//   2. `_not_in(subquery)`        — NOT IN
+//   3. `_any(predicate)`          — EXISTS WHERE
+//   4. `_none(predicate)`         — NOT EXISTS WHERE
+//   5. `_in(captured_array)`      — IN (SELECT value FROM json_each(?))
+//   6. `_not_in(captured_array)`  — NOT IN (SELECT value FROM json_each(?))
 //
 // The 1-arg form `subquery._any()` (test if non-empty, lifts to plain
 // `EXISTS (...)` under `_sql`) is Mode-1-only. The `_any` linq_boost
@@ -156,5 +158,40 @@ def parity_none_predicate(t : T?) {
         t |> equal(length(m1), 3, "_none(>1000): all 3 users surface")
         t |> success(users_equal(m1, m2), "_none: M1 ≡ M2")
         t |> success(users_equal(m2, m3), "_none: M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_in_collection(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users <- fixture_users()
+        let want_ids <- [1, 2]
+
+        let m1 <- _sql(db |> select_from(type<User>) |> _where(_.Id._in(want_ids)))
+        let m2 <- (db |> select_from(type<User>) |> _where(_.Id._in(want_ids)))
+        let m3 <- (users |> _where(_.Id._in(want_ids)))
+
+        t |> equal(length(m1), 2, "_in(arr): Alice + Bob match")
+        t |> success(users_equal(m1, m2), "_in(arr): M1 ≡ M2")
+        t |> success(users_equal(m2, m3), "_in(arr): M2 ≡ M3")
+    }
+}
+
+[test]
+def parity_not_in_collection(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db)
+        var users <- fixture_users()
+        let want_ids <- [1, 2]
+
+        // Id is non-nullable PK → naive NOT IN form, identical across all three modes.
+        let m1 <- _sql(db |> select_from(type<User>) |> _where(_.Id._not_in(want_ids)))
+        let m2 <- (db |> select_from(type<User>) |> _where(_.Id._not_in(want_ids)))
+        let m3 <- (users |> _where(_.Id._not_in(want_ids)))
+
+        t |> equal(length(m1), 1, "_not_in(arr): only Carol survives")
+        t |> success(users_equal(m1, m2), "_not_in(arr): M1 ≡ M2")
+        t |> success(users_equal(m2, m3), "_not_in(arr): M2 ≡ M3")
     }
 }

--- a/tests/dasSQLITE/test_44_in_not_in_collection.das
+++ b/tests/dasSQLITE/test_44_in_not_in_collection.das
@@ -1,0 +1,157 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    Active : bool
+}
+
+[sql_table(name = "Items")]
+struct Item {
+    @sql_primary_key Id : int
+    Tag : string
+    @safe_when_uninitialized OwnerId : Option<int>
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Item>)
+    db |> insert(User(Id = 1, Name = "Alice", Active = true))
+    db |> insert(User(Id = 2, Name = "Bob",   Active = true))
+    db |> insert(User(Id = 3, Name = "Carol", Active = false))
+    db |> insert(User(Id = 4, Name = "Dave",  Active = true))
+    db |> insert(Item(Id = 10, Tag = "alpha", OwnerId = some(1)))
+    db |> insert(Item(Id = 11, Tag = "beta",  OwnerId = some(2)))
+    db |> insert(Item(Id = 12, Tag = "gamma", OwnerId = none(type<int>)))
+    db |> insert(Item(Id = 13, Tag = "delta", OwnerId = some(3)))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// `_in` / `_not_in` over a captured runtime collection — JSON-bridge form.
+// Lowers to `WHERE col IN (SELECT value FROM json_each(?))` with a single
+// JSON-encoded TEXT bind. Single bind, any size, plan-cache-friendly.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_in_collection_emits_json_each(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>) |> _where(_.Id._in([1, 2])))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Active\" FROM \"Users\" WHERE \"Id\" IN (SELECT value FROM json_each(?))",
+        "_in(arr) lowers to json_each(?) with one bind")
+}
+
+[test]
+def test_not_in_collection_non_nullable_emits_naive(t : T?) {
+    var _db = SqlRunner()
+    // User.Id is non-nullable (primary key) — no defensive `OR IS NULL` needed.
+    let sql = _sql_text(_db |> select_from(type<User>) |> _where(_.Id._not_in([1, 2])))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Active\" FROM \"Users\" WHERE \"Id\" NOT IN (SELECT value FROM json_each(?))",
+        "_not_in on non-nullable column emits naive NOT IN")
+}
+
+[test]
+def test_not_in_collection_nullable_emits_defensive(t : T?) {
+    var _db = SqlRunner()
+    // Item.OwnerId is Option<int> — defensive `OR IS NULL` so NULL rows survive NOT IN.
+    let sql = _sql_text(_db |> select_from(type<Item>) |> _where(_.OwnerId._not_in([1, 2])))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Tag\", \"OwnerId\" FROM \"Items\" WHERE (\"OwnerId\" NOT IN (SELECT value FROM json_each(?)) OR \"OwnerId\" IS NULL)",
+        "_not_in on Option<T> column emits defensive form: rows with NULL column survive")
+}
+
+[test]
+def test_in_collection_with_outer_where(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<User>)
+                          |> _where(_.Active && _.Id._in([1, 2, 4])))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Name\", \"Active\" FROM \"Users\" WHERE (\"Active\") AND (\"Id\" IN (SELECT value FROM json_each(?)))",
+        "_in(arr) composes with other WHERE predicates via &&")
+}
+
+[test]
+def test_in_collection_string_array(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Item>) |> _where(_.Tag._in(["alpha", "delta"])))
+    t |> equal(sql,
+        "SELECT \"Id\", \"Tag\", \"OwnerId\" FROM \"Items\" WHERE \"Tag\" IN (SELECT value FROM json_each(?))",
+        "_in(arr<string>) emits the same json_each form — JSON encodes any scalar element type")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Runtime — verify the rows match the IN / NOT IN semantics.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_in_collection_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<User>) |> _where(_.Id._in([1, 4])))
+        t |> equal(length(rows), 2, "Alice (1) + Dave (4) match")
+        var saw_alice = false
+        var saw_dave = false
+        for (u in rows) {
+            if (u.Name == "Alice") {
+                saw_alice = true
+            }
+            if (u.Name == "Dave") {
+                saw_dave = true
+            }
+        }
+        t |> success(saw_alice)
+        t |> success(saw_dave)
+    }
+}
+
+[test]
+def test_not_in_collection_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<User>) |> _where(_.Id._not_in([1, 4])))
+        t |> equal(length(rows), 2, "Bob (2) + Carol (3) survive (Alice + Dave excluded)")
+    }
+}
+
+[test]
+def test_not_in_collection_nullable_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Items 10 (owner 1) + 11 (owner 2) excluded. Item 13 (owner 3) survives, AND
+        // item 12 (NULL owner) survives via the defensive `OR IS NULL` clause —
+        // naive NOT IN would drop NULL-owner rows.
+        let rows <- _sql(db |> select_from(type<Item>) |> _where(_.OwnerId._not_in([1, 2])))
+        t |> equal(length(rows), 2, "items 12 (NULL owner) + 13 (owner 3) survive")
+        var saw_null = false
+        var saw_three = false
+        for (it in rows) {
+            if (it.Id == 12) {
+                saw_null = true
+            }
+            if (it.Id == 13) {
+                saw_three = true
+            }
+        }
+        t |> success(saw_null, "NULL-owner row survived NOT IN — defensive form working")
+        t |> success(saw_three)
+    }
+}
+
+[test]
+def test_in_empty_collection_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Empty array → json_each over '[]' yields zero rows → IN is false.
+        var empty : array<int>  // nolint:LINT003 — explicit-type empty-array declaration; `let` can't init typed-empty
+        let rows <- _sql(db |> select_from(type<User>) |> _where(_.Id._in(empty)))
+        t |> equal(length(rows), 0, "_in([]) returns no rows")
+    }
+}

--- a/tutorials/sql/44-in_not_in_collections.das
+++ b/tutorials/sql/44-in_not_in_collections.das
@@ -1,0 +1,100 @@
+options gen2
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+// Tutorial 44 — `_in` / `_not_in` against a captured collection.
+//
+// `_.Col._in(arr)` lowers to `WHERE Col IN (SELECT value FROM json_each(?))`
+// — the captured array is JSON-encoded and bound as a single TEXT parameter.
+// Single bind, any size (SQLite accepts 1G TEXT), no plan-cache pollution
+// (one parameterized SQL string regardless of collection size). Same shape
+// EF Core 8 picked as the default for `Contains(coll, x)` translations.
+//
+// Element types covered: int, int64, string, double, bool, float — anything
+// `daslib/json`'s `JV(...)` handles (which is "any scalar daslang type").
+//
+// Subquery form (`_.Col._in(other_chain)`) coexists in the same operator —
+// see tutorial 17. This file covers the captured-runtime-collection form.
+//
+// `_not_in` on a nullable (`Option<T>`) column emits the defensive
+// `… NOT IN (…) OR Col IS NULL` form so rows with NULL Col survive the
+// predicate. SQL three-valued logic would otherwise drop them silently
+// (`x != NULL` is unknown, never true).
+
+[sql_table(name = "Users")]
+struct User {
+    @sql_primary_key Id : int
+    Name : string
+    Active : bool
+}
+
+[sql_table(name = "Orders")]
+struct Order {
+    @sql_primary_key Id : int
+    @safe_when_uninitialized OwnerId : Option<int>
+    Total : int
+}
+
+def fixture(db : SqlRunner) {
+    db |> create_table(type<User>)
+    db |> create_table(type<Order>)
+    db |> insert(User(Id = 1, Name = "Alice", Active = true))
+    db |> insert(User(Id = 2, Name = "Bob",   Active = true))
+    db |> insert(User(Id = 3, Name = "Carol", Active = false))
+    db |> insert(User(Id = 4, Name = "Dave",  Active = true))
+    db |> insert(Order(Id = 10, OwnerId = some(1), Total = 100))
+    db |> insert(Order(Id = 11, OwnerId = some(2), Total = 250))
+    db |> insert(Order(Id = 12, OwnerId = none(type<int>), Total = 50))
+    db |> insert(Order(Id = 13, OwnerId = some(3), Total = 80))
+}
+
+[export]
+def main() {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+
+        // ── Positive: _in(arr) ───────────────────────────────────────────
+        // SQL: WHERE "Id" IN (SELECT value FROM json_each(?))
+        // Bind: '[1,4]'
+        let picked <- _sql(db |> select_from(type<User>) |> _where(_.Id._in([1, 4])))
+        to_log(LOG_INFO, "_in([1,4]) -> {length(picked)} user(s)\n")
+
+        // ── Negative on non-nullable column: naive NOT IN ────────────────
+        // SQL: WHERE "Id" NOT IN (SELECT value FROM json_each(?))
+        // (User.Id is the primary key — non-nullable — so the simpler form is
+        // safe.)
+        let not_picked <- _sql(db |> select_from(type<User>) |> _where(_.Id._not_in([1, 4])))
+        to_log(LOG_INFO, "_not_in([1,4]) -> {length(not_picked)} user(s)\n")
+
+        // ── Negative on nullable column: defensive NOT IN ────────────────
+        // SQL: WHERE ("OwnerId" NOT IN (SELECT value FROM json_each(?))
+        //             OR "OwnerId" IS NULL)
+        // Order.OwnerId is Option<int>. Order 12 has OwnerId=NULL — without
+        // the OR-IS-NULL clause it would silently drop from the result.
+        let other_orders <- _sql(db |> select_from(type<Order>) |> _where(_.OwnerId._not_in([1])))
+        to_log(LOG_INFO, "_not_in([1]) on Option<int> -> {length(other_orders)} order(s) (NULL row survives)\n")
+
+        // ── Composes with other WHERE predicates ────────────────────────
+        // SQL: WHERE ("Active") AND ("Id" IN (SELECT value FROM json_each(?)))
+        let active_picked <- _sql(db |> select_from(type<User>)
+                                     |> _where(_.Active && _.Id._in([1, 4])))
+        to_log(LOG_INFO, "Active AND _in([1,4]) -> {length(active_picked)} user(s)\n")
+
+        // ── String collections work the same ────────────────────────────
+        // JSON encodes any scalar; bind type is TEXT for both.
+        let by_name <- _sql(db |> select_from(type<User>) |> _where(_.Name._in(["Alice", "Carol"])))
+        to_log(LOG_INFO, "_in([\"Alice\",\"Carol\"]) -> {length(by_name)} user(s)\n")
+
+        // ── Empty collection ─────────────────────────────────────────────
+        // json_each over '[]' yields zero rows → `IN (SELECT value FROM ...)`
+        // is false everywhere → no rows match.
+        var empty : array<int>  // nolint:LINT003 — explicit-type empty-array declaration; `let` can't init typed-empty
+        let none_match <- _sql(db |> select_from(type<User>) |> _where(_.Id._in(empty)))
+        to_log(LOG_INFO, "_in([]) -> {length(none_match)} user(s) (always 0)\n")
+
+        // ── Inspect emitted SQL while debugging ──────────────────────────
+        to_log(LOG_INFO, "SQL: {_sql_text(db |> select_from(type<User>) |> _where(_.Id._in([1, 2])))}\n")
+    }
+}

--- a/utils/benchctl/main.das
+++ b/utils/benchctl/main.das
@@ -233,21 +233,20 @@ def run_compare_cmd(db : SqlRunner; parsed : ParsedArgs) : string {
     }
 
     let old_entries <- query_benchmarks(db, parsed.old_commit, parsed.old_tag)
-    let raw_new_entries <- query_benchmarks(db, parsed.new_commit, parsed.new_tag)
 
-    // Exclude rows already in --old from --new so identical / overlapping filters
-    // (e.g. both empty) cannot compare a result set against itself.
-    var old_id_set : table<int; bool>
+    // Exclude rows already in --old from --new so identical / overlapping
+    // filters (e.g. both empty) cannot compare a result set against itself.
+    // Push to SQL via `_not_in(old_ids)` — JSON-bridge handles arbitrary size.
+    var old_ids : array<int>
+    old_ids |> reserve(length(old_entries))
     for (e in old_entries) {
-        old_id_set |> insert(e.id, true)
+        old_ids |> push(e.id)
     }
-    var new_entries : array<Benchmark>
-    new_entries |> reserve(length(raw_new_entries))
-    for (e in raw_new_entries) {
-        if (!key_exists(old_id_set, e.id)) {
-            new_entries |> push_clone(e)
-        }
-    }
+    let new_want_tag = (parsed.new_tag == "" ? "" : "[{parsed.new_tag}]")
+    let new_entries <- _sql(db |> select_from(type<Benchmark>)
+        |> _where(parsed.new_commit == "" || _.commit_hash == parsed.new_commit)
+        |> _where(new_want_tag == "" || _.tags |> contains(new_want_tag))
+        |> _where(_.id._not_in(old_ids)))
 
     if (length(old_entries) == 0) {
         return "no rows match --old-commit / --old-tag"


### PR DESCRIPTION
## Summary

Adds the **captured-collection form** of `_in` / `_not_in` inside `_sql(...)` chains.

`_.Col._in(arr)` and `_.Col._not_in(arr)` where `arr` is a runtime `array<T>` now lower to `WHERE Col IN (SELECT value FROM json_each(?))` (or `NOT IN`) — a single TEXT bind holding the JSON-encoded collection. Single bind, any size, plan-cache-friendly. Matches EF Core 8's default for the same shape.

The subquery form (`_.Col._in(_sql_chain)`) was already shipped in PR #2534 (chunk 12, test_40); this PR extends the same operator with the runtime-array path that was filed as backlog in `project_dassqlite_in_predicates.md`.

### Three lowering sites

`_in` / `_not_in` typer-expand to `contains(arr, x)` / `!contains(arr, x)` when arg2's type resolves. The classifier and JSON-bridge emission therefore land in three places in `sqlite_linq.das`:

- the unexpanded `ExprCallMacro` arm (`pred_to_sql`)
- the `!contains(arr, x)` peel inside the logical-NOT arm (negative form)
- the `contains(arr, x)` arm in `fn_call_to_sql` (positive form)

A small `looks_like_subquery_chain` walker disambiguates by AST shape — chains bottom out at `select_from(...)`; captured arrays / inline literals / user functions never reach it. Subquery path unchanged.

### NULL-correct `_not_in`

For `_not_in` on a nullable column (`Option<T>` per `is_option_field_type`), the emitted SQL is the defensive form:

```
WHERE (Col NOT IN (SELECT value FROM json_each(?)) OR Col IS NULL)
```

so rows with `Col = NULL` survive — naive `NOT IN` would silently drop them under SQL three-valued logic. Non-nullable columns (PK, plain `T`) get the naive form.

### benchctl `compare` rewrite

`utils/benchctl/main.das:run_compare_cmd` motivated the feature (the `--old`/`--new` filter overlap exclusion). Old: build `table<int;bool>` from old IDs and post-filter `raw_new_entries` in a daslang loop. New: project `old_ids : array<int>`, push the filter into SQL via `_where(_.id._not_in(old_ids))`. Same observable behavior; ~4 lines smaller; work moves to SQLite where it belongs.

## Test plan

- [x] 9 new tests in `tests/dasSQLITE/test_44_in_not_in_collection.das` — `_sql_text` SQL-shape assertions for positive / negative / nullable / outer-`_where` / `array<string>` / empty cases, plus runtime row-set verification incl. the NULL-survives case
- [x] `parity_check_17_subqueries.das` extended with two new three-mode parity tests (M1 SQL via `_sql`, M2 SQL no-`_sql`, M3 in-memory linq) for captured-int-array `_in` and `_not_in`
- [x] Existing test_40 (subquery form) — all 6 tests pass unchanged
- [x] Full dasSQLITE suite — 782 tests pass
- [x] Full daslang suite — 7982 tests pass
- [x] AOT suite — 7376 tests pass
- [x] benchctl smoke: `compare --db ':memory:' --old-tag before --new-tag after` returns the expected "no rows match --old" diagnostic on empty DB
- [x] Tutorial `tutorials/sql/44-in_not_in_collections.das` runs and produces correct counts incl. the NULL-survives case
- [x] Lint clean on all changed files (only pre-existing `var users` style warnings on parity_check_17 remain — consistent across the file)
- [x] `format_file` clean on all changed files

## Notes

- New tutorial slot 42 in `modules/dasSQLITE/TUTORIALS.md` (file `44-in_not_in_collections.das`)
- One pre-existing constraint surfaced: pipe-form `_.Col |> _in(arr)` doesn't type — `_.Col` is unbound at the point `_in.visit()` fires. Dot-form `_.Col._in(arr)` works because the `invoke(...)` indirection delays resolution. Test_40 already used dot-form; tutorial 44 / test_44 / benchctl follow suit. Not a regression — pipe-form was never supported for these operators.
