### PR TITLE
parser: propagate field annotations on block-form global variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ web/output/.idea/
 yzg.code-workspace
 
 examples/wip.das
+examples/wip_macro.das
 
 utils/dasFormatter/ds_parser.output
 src/parser/ds2_parser.output

--- a/src/parser/parser_impl.cpp
+++ b/src/parser/parser_impl.cpp
@@ -546,6 +546,9 @@ namespace das {
                     }
                     pVar->global_shared = glob_shar;
                     pVar->private_variable = !pub_var;
+                    if ( pDecl->annotation ) {
+                        pVar->annotation = *pDecl->annotation;
+                    }
                     if ( !yyextra->g_Program->addVariable(pVar) )
                         das_yyerror(scanner,"global variable is already declared " + name_at.name,name_at.at,
                             CompilationError::already_declared_global);

--- a/tests/language/_global_var_annotation_helper.das
+++ b/tests/language/_global_var_annotation_helper.das
@@ -1,0 +1,33 @@
+options gen2
+
+module _global_var_annotation_helper shared private
+
+require daslib/ast_boost
+require strings
+
+def has_arg(list : AnnotationArgumentList; name : string) : bool {
+    for (a in list) {
+        if (a.name == name) {
+            return true
+        }
+    }
+    return false
+}
+
+[lint_macro]
+class CheckColorAnnotation : AstPassMacro {
+    def override apply(prog : ProgramPtr; mod : Module?) : bool {
+        for_each_global(mod) $(gvar) {
+            var matches = false
+            peek(gvar.name) $(n : string#) {
+                matches = n |> starts_with("assert_color_")
+            }
+            if (matches && !has_arg(gvar.annotation, "color")) {
+                macro_error(prog, gvar.at,
+                    "global '{gvar.name}': expected @color annotation, " +
+                    "got [{describe(gvar.annotation)}]")
+            }
+        }
+        return true
+    }
+}

--- a/tests/language/global_var_annotation.das
+++ b/tests/language/global_var_annotation.das
@@ -1,0 +1,31 @@
+options gen2
+
+require dastest/testing_boost public
+require _global_var_annotation_helper
+
+// Regression test: parser must propagate the `@name` field annotation onto
+// the resulting Variable for BOTH the single-form and block-form global
+// declarations. Earlier, ast_globalLetList (the var{...} block path) dropped
+// the annotation on the floor — only the single-form path attached it.
+// The CheckColorAnnotation lint_macro fires at compile time and fails the
+// build via macro_error if any `assert_color_*` global is missing @color.
+
+// single-form
+var @color assert_color_single = 1
+
+// block-form (the previously broken path)
+var {
+    @color assert_color_block_a = 2
+    @color assert_color_block_b = 3
+}
+
+[test]
+def test_global_var_annotation(t : T?) {
+    t |> run("globals carry their field annotations") @(t : T?) {
+        // If this file compiles, the lint_macro's macro_error did not fire,
+        // which means all assert_color_* globals had @color attached.
+        t |> equal(assert_color_single, 1)
+        t |> equal(assert_color_block_a, 2)
+        t |> equal(assert_color_block_b, 3)
+    }
+}


### PR DESCRIPTION
## Summary

The `var { @ann name = ... }` block form silently dropped field annotations — the resulting `Variable` always had an empty `annotation` list. The single-form path `var @ann name = ...` worked correctly.

```das
var {
    @color tint = float3(1)        // BEFORE: annotation=[]      count=0  ❌
}
var @color tint2 = float3(1, 0, 0) // BEFORE: annotation=[color] count=1  ✅
```

Any macro that introspects `Variable.annotation` (e.g. `live_vars`, color/UI tags) only worked when authors happened to use the single-form syntax.

## Root cause

`ast_globalLetList` in `src/parser/parser_impl.cpp` constructs a `Variable` from each `VariableDeclaration` but never reads `pDecl->annotation`. The grammar rule at [ds2_parser.ypp:2738-2748](src/parser/ds2_parser.ypp#L2738-L2748) correctly stashed the annotation onto `$decl->annotation`, but the helper that turns decls into `Variable`s ignored that field. Compare with `ast_globalLet` (the single-form path) at [parser_impl.cpp:607-612](src/parser/parser_impl.cpp#L607-L612) which already does `pVar->annotation = das::move(*ann)`.

## Fix

Copy `*pDecl->annotation` into each constructed `Variable`. `AnnotationArgumentList` is `vector<AnnotationArgument>` with an explicit per-element copy ctor, so each `Variable` ends up owning an independent copy — no sharing. The source decl's annotation list is freed by `~VariableDeclaration` via `deleteVariableDeclarationList`. The `aList` field is irrelevant here: it's only produced by the `key=(a,b,c)` arg syntax, which is unreachable from `metadata_argument_list` (the `@name` form on globals).

## Regression test

`tests/language/global_var_annotation.das` declares `assert_color_*` globals in both the single-form and block-form. The companion module `_global_var_annotation_helper.das` registers a `[lint_macro]` that walks `for_each_global` and emits `macro_error` if any `assert_color_*` global is missing `@color`. The test file compiles only when both forms attach the annotation; reverting the fix produces:

```
error[50503]: global 'assert_color_block_a': expected @color annotation, got []
error[50503]: global 'assert_color_block_b': expected @color annotation, got []
```

## Test plan

- [x] Lint passes on changed `.das` files
- [x] Full `tests/` suite: 7984 / 7984 pass
- [x] AOT `tests/` suite: 7378 / 7378 pass
- [x] New regression test fails on master, passes with fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)