### PR TITLE
docs: 0.6.2 changelist post-RC1 + site mirror; install utils/das-fmt

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -4,15 +4,16 @@
 
 ### New Features
 
-#### daSQLite: Typed SQLite Query Layer Expansion (#2481, #2485, #2487, #2489, #2492, #2496, #2507, #2509, #2511, #2518, #2524, #2528, #2534)
+#### daSQLite: Typed SQLite Query Layer Expansion (#2481, #2485, #2487, #2489, #2492, #2496, #2507, #2509, #2511, #2518, #2524, #2528, #2534, #2551, #2553, #2561, #2563, #2564, #2566, #2568, #2575, #2581, #2592, #2595, #2603)
 
 `modules/dasSQLITE` now extends `daslib/linq` with SQL-backed queries, letting familiar linq-style transforms compile down to typed SQLite operations. This release then broadens that foundation with a large tutorial-driven expansion across the rest of the SQLite layer.
 
-- **Insert + query macros** — typed insert flows, raw `query` / `try_query` helpers, and much deeper `_sql(...)` analysis
-- **Read-side operators** — `distinct`, `take`, `skip`, ordering, aggregates, grouping, joins, set operations, and multi-source queries
-- **Write-side operations** — typed update/delete flows, transaction helpers, and UPSERT with schema annotations for foreign keys, indexes, defaults, and computed columns
+- **Insert + query macros** — typed insert flows, raw `query` / `try_query` helpers, much deeper `_sql(...)` analysis with multi-quantifier (multi-Q) lowering, and a parity audit comparing in-memory linq vs. SQL emission
+- **Read-side operators** — `distinct`, `take`, `skip`, ordering, aggregates, grouping, the full join family (`_left_join`, `_inner_join`, `_right_join`, `_full_outer_join`, `_cross_join`), set operations, multi-source queries, and `_in` / `_not_in` against captured collections via SQLite `json_each`
+- **Write-side operations** — typed update/delete flows, transaction helpers, UPSERT with schema annotations for foreign keys, indexes, defaults, and computed columns, plus user-defined SQL functions via `[sql_function]` (auto-registered and visible inside `_sql` chains)
 - **Custom storage types** — custom adapters plus `@sql_json` and `@sql_blob` field support, JSON-path descent inside `_sql`, and column metadata introspection
-- **Operational SQLite features** — SQL fragment building, `ATTACH DATABASE`, FTS5 groundwork, and pre-migration utilities
+- **Schema introspection and migrations** — `[sql_table(schema_from=...)]` + `check_schema` validate live database schema against the daslang struct at compile time; `daslib/sqlite_migrate` ships versioned `[sql_migration]` blocks with typed ALTER macros (`add_column` / `drop_column` / `rename_column`) and full-table rebuilds via `[struct_convert]` + `convert_and_rename` + `[sql_table(legacy=true)]` for non-trivial schema changes
+- **Operational SQLite features** — SQL fragment building, `ATTACH DATABASE`, FTS5 (`[sql_fts5]` + `text_match`), and pre-migration utilities
 
 #### Style Lint and Unified Linting (#2386, #2390, #2391, #2417, #2441, #2516, #2517, #2533, #2538)
 
@@ -47,6 +48,16 @@ daslang now has a much clearer leak-debugging story for both language-side and C
 - **Cheat-sheet documentation** — unified guidance explains GC leaks, heap reports, smart-pointer tracking, jobque leaks, and handle-registry dumps
 - **Profiler and heap tooling** — better reporting and supporting leak-audit work across the runtime
 
+#### daspkg: Project Bundling for Distribution (#2579, #2584, #2588, #2590)
+
+`daspkg release` produces a redistributable bundle of a daslang project — a directory containing the standalone exe, every transitively-required `.shared_module` dylib, every asset matching the project's release globs, and every transitive dep package's release assets. The bundle runs on a machine with no daslang installed.
+
+- **`daspkg release` command** — `release()` hook in `.das_package` declares `release_main`, `release_name`, `release_include` / `release_exclude` globs, and force-included shared modules
+- **Exe-relative shared-module resolution** — `daslang -exe` resolves shared modules in three tiers (exe directory → `das_root` → absolute path), making relocated bundles portable
+- **`-list-shared-modules`** — auxiliary flag walks `program_for_each_module` and writes a JSON manifest of every dylib the program touches; `daspkg release` consumes it for auto-detection
+- **Project-local + relocated-bundle support** — `get_this_module_dir`, the JIT runtime, and the daspkg resolver all honor project-local layouts, so a moved or copied bundle continues to find its modules
+- **Native shared deps** — packages can ship platform-specific dylibs alongside their `.das` sources via `release_include_dll`; dasPUGIXML is enabled by default for Info.plist generation on macOS
+
 ### Improvements
 
 #### Strudel Audio Engine: Second Wave (#2403, #2423, #2425, #2426, #2427, #2428, #2429, #2430, #2435, #2440, #2457, #2464, #2519)
@@ -57,13 +68,21 @@ The new Strudel engine from `0.6.1` received a broad follow-up pass across synth
 - Reduced memory usage and multiple leak fixes in the threaded player, visualizer, and shutdown path
 - Expanded documentation and examples for the newer audio stack
 
-#### Compiler, AOT, and JIT Work (#2396, #2402, #2405, #2406, #2416, #2422, #2433, #2442, #2445, #2458, #2461, #2480, #2499, #2500)
+#### Compiler, AOT, and JIT Work (#2396, #2402, #2405, #2406, #2416, #2422, #2433, #2442, #2445, #2458, #2461, #2480, #2499, #2500, #2460, #2554, #2565, #2569, #2585, #2594, #2596, #2601, #2604, #2605)
 
 A substantial runtime/compiler pass improved code generation, packaging flexibility, and test coverage.
 
 - Continued push toward more daslang-authored AOT logic and cleaner AOT/JIT boundaries
 - Better standalone-exe behavior, transitive JIT type resolution, prologue sizing, and function registration
 - More build configurations (`RelWithDebInfo`, static PIC), more daslib AOT coverage, and platform-specific AOT fixes
+- **Tuple-strict typer** (#2565) — tuple field names are now part of the type, so `tuple<a:int;b:int>` and `tuple<x:int;y:int>` no longer collide and unnamed tuples remain distinct from named ones
+- **`Option<T>` / `Result<T,E>` via `[template_tuple]`** (#2601) — both types are now structural named-tuples generated through a generic mechanism, replacing bespoke handling
+- **Call-site block arrow body** (#2554) — `def f(...) : T => expr` shorthand parses alongside the existing block form
+- **Error reporting audit** (#2596) — diagnostics retagged for consistency, with `Program::deduplicateErrors` suppressing repeated identical errors from the same site
+- **`super` walks past empty intermediates** (#2594) — `super` now skips empty intermediate base classes when looking for a method
+- **Block-form global variable annotations** (#2604) — `@field` annotations now propagate to globals declared inside `variable { ... }` blocks
+- **`cbind` prefixes** (#2585) — generated bindings can be namespaced with a per-include prefix
+- **Compiler refactor** (#2460, #2569, #2605) — `Program` and `Context` extracted from `simulate` / `ast` into their own translation units; serialization unified with eden / daNetGame; large-file split for build-time and editor-friendliness
 
 #### GC / AST / Ownership Cleanup (#2400, #2404, #2407, #2409, #2410, #2411, #2415, #2420, #2421, #2470, #2506)
 
@@ -73,21 +92,38 @@ Core compiler internals continued the transition away from older `smart_ptr`-sty
 - Macro, visitor, binding, and validator code no longer has to fight as many `smart_ptr`-era ownership patterns and pointer conversions
 - Tracker stability improved when GC is active, reducing false crashes during debugging
 
-#### Runtime Libraries and Infrastructure (#2393, #2398, #2399, #2412, #2413, #2414, #2431, #2443, #2451, #2455, #2466, #2467, #2474, #2488, #2494, #2495, #2512, #2514, #2536, #2539)
+#### Runtime Libraries and Infrastructure (#2393, #2398, #2399, #2412, #2413, #2414, #2431, #2443, #2451, #2455, #2466, #2467, #2474, #2488, #2494, #2495, #2512, #2514, #2536, #2539, #2555, #2572, #2576, #2577)
 
 A broad utility pass landed across libraries, docs, and developer workflow.
 
 - **dasPEG** — more tests, docs, CI coverage, and standalone/LLVM fixes
-- **Core libraries** — validated numeric conversions in `daslib/strings_convert`, continued `Option` / `Result` work including non-copyable support, and C API completeness fixes
+- **Core libraries** — validated numeric conversions in `daslib/strings_convert`, continued `Option` / `Result` work including non-copyable support, and C API completeness fixes; `daslib/clargs` now returns `Result` from parsing for cleaner error handling
 - **Runtime data structures** — new in-tree `das_hash_map` backend to avoid empty-construction allocations and behave better in thread-local usage
+- **Path-aware glob in `daslib/fio`** (#2576, #2577) — `match_glob`, `glob`, `glob_filtered`, plus `expand_glob` / `parse_file_list` promoted from the MCP utility into the stdlib; byte-loops collapsed to `find` / `replace` with a new `skills/strings.md` rollup
+- **Math: common numeric functions** (#2555) — `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `log10`, `log1p`, `expm1`, `cbrt`, `trunc`, `hypot`, `fmod`, `remainder` added to the math module
+- **das-fmt vendored in-tree** — `utils/das-fmt/` now holds a local copy of the formatter; CI runs against it instead of an external clone
 - **Tooling/docs** — filesystem guidance, handle-registry tutorial work, class-boost coverage, integer-returning `main()` for tools, compilation progress reporting, and assorted AST/class-method polish
+
+#### Build, CI, and Web (#2578, #2600, #2602)
+
+- **Tutorials build in CI** (#2578) — every tutorial now compiles in CI as part of the regular check run
+- **Web target reuses the main `CMakeLists`** (#2600) — `daslang-web` picks up tests and tracks the same build configuration as the native targets, removing the duplicated CMake graph
+- **MCP: parse-aware C++ source-search tools** (#2602) — `cpp_find_symbol`, `cpp_grep_usage`, `cpp_outline`, `cpp_goto_definition` join the existing daslang-side tools, with a configurable search root and git-signature staleness detection
 
 ### Bug Fixes
 
-- **Build, tooling, and CI fixes** (#2385, #2394, #2395, #2424, #2447, #2521, #2537) — package `.gitignore` handling, PEG standalone/LLVM issues, `require` fixes, `dasbind` fixes, glob dependency tracking, and documentation/error-position corrections
-- **Runtime/compiler correctness** (#2387, #2392, #2486, #2520, #2526, #2531) — JIT global-function arguments, handled-type property write propagation, function-lookup cache pointer reuse, `runWithCatch` state cleanup, and ASAN/diagnostic follow-up
+- **Build, tooling, and CI fixes** (#2385, #2394, #2395, #2424, #2447, #2521, #2537, #2591) — package `.gitignore` handling, PEG standalone/LLVM issues, `require` fixes, `dasbind` fixes, glob dependency tracking, documentation/error-position corrections, and daslang plugin: completion no longer silently bails when an external binding (e.g. OpenGL, GLSL preprocessor) is in scope
+- **Runtime/compiler correctness** (#2387, #2392, #2486, #2520, #2526, #2531, #2587, #2593) — JIT global-function arguments, handled-type property write propagation, function-lookup cache pointer reuse, `runWithCatch` state cleanup, ASAN/diagnostic follow-up, fix #2583 (standalone-exe shutdown crash), and fix #2582 (top-level `let`-init now correctly registers builtins)
+- **Fusion engine** — TSan-safe `v_ldu` via `DAS_LDU_WORKHORSE`, `call1` / `call2` `loadSize` stamped from `fnPtr->debugInfo`, and a TSan suppression for the over-read in fusion call/return shells
 - **Language/runtime edge cases** (#2444, #2446, #2463, #2468) — `finally` loop rework, clearer inference failure on bad calls, GCC reference shadow fixes, and strict-weak-ordering cleanup
 - **Graphics and platform fixes** (#2540) — OpenGL/package integration cleanup after the daspkg migration work
+- **Architecture-specific** — skipped `#pragma float_control` on `__e2k__` to silence warnings on the Elbrus toolchain
+
+### Examples
+
+- **Asteroids** (#2552, #2556) — full asteroid-shooter game with waves, audio, and powerups; later migrated to DECS for the entity model with a polish pass on visuals and powerup VFX
+- **Pacman** (#2589) — classic arcade game added to the `examples/` lineup
+- **River Run** (#2560, #2562, #2567) — top-down river shooter built across three rounds: initial gameplay (river splits, combat, VFX, audio, HUD, collisions), then scenery / bonus / engine sound / tuning, and finally shadows, pickup burst, rich music, 3D HUD, and a juice pass
 
 ## 0.6.1 (April 2026)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1555,6 +1555,16 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/utils/daspkg/fixtures/
     FILES_MATCHING PATTERN "*.das_package"
 )
 
+# Install das-fmt (daslang formatter)
+file(GLOB DAS_FMT_FILES ${PROJECT_SOURCE_DIR}/utils/das-fmt/*.das)
+install(FILES ${DAS_FMT_FILES} DESTINATION utils/das-fmt)
+install(FILES
+    ${PROJECT_SOURCE_DIR}/utils/das-fmt/README.md
+    ${PROJECT_SOURCE_DIR}/utils/das-fmt/LICENSE
+    ${PROJECT_SOURCE_DIR}/utils/das-fmt/pre-commit
+    DESTINATION utils/das-fmt
+)
+
 # Install daspkg examples
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/examples/daspkg/
     DESTINATION examples/daspkg

--- a/site/index.html
+++ b/site/index.html
@@ -701,11 +701,12 @@ def fibI(n)
         <h4>dasSQLITE: Typed SQLite Query Layer</h4>
         <p>modules/dasSQLITE extends daslib/linq with SQL-backed queries &mdash; familiar linq-style transforms compile down to typed SQLite operations. After the initial landing, the layer was broadened tutorial-by-tutorial across the rest of the SQLite surface.</p>
         <ul>
-            <li><b>Insert + query macros</b> &mdash; typed insert flows, raw query / try_query helpers, much deeper _sql(...) analysis</li>
-            <li><b>Read-side operators</b> &mdash; distinct, take, skip, ordering, aggregates, grouping, joins, set operations, multi-source queries</li>
-            <li><b>Write-side</b> &mdash; typed update/delete flows, transaction helpers, UPSERT with schema annotations for foreign keys, indexes, defaults, and computed columns</li>
+            <li><b>Insert + query macros</b> &mdash; typed insert flows, raw query / try_query helpers, deeper _sql(...) analysis with multi-quantifier (multi-Q) lowering, and a parity audit comparing in-memory linq vs. SQL emission</li>
+            <li><b>Read-side operators</b> &mdash; distinct, take, skip, ordering, aggregates, grouping, the full join family (_left_join, _inner_join, _right_join, _full_outer_join, _cross_join), set operations, multi-source queries, and _in / _not_in against captured collections via SQLite json_each</li>
+            <li><b>Write-side</b> &mdash; typed update/delete flows, transaction helpers, UPSERT with schema annotations for foreign keys, indexes, defaults, and computed columns, plus user-defined SQL functions via [sql_function] (auto-registered and visible inside _sql chains)</li>
             <li><b>Custom storage types</b> &mdash; user-defined adapters plus @sql_json and @sql_blob field support, JSON-path descent inside _sql, column metadata introspection</li>
-            <li><b>Operational</b> &mdash; SQL fragment building, ATTACH DATABASE, FTS5 groundwork, pre-migration utilities</li>
+            <li><b>Schema introspection and migrations</b> &mdash; [sql_table(schema_from=...)] + check_schema validate live database schema against the daslang struct at compile time; daslib/sqlite_migrate ships versioned [sql_migration] blocks with typed ALTER macros (add_column / drop_column / rename_column) and full-table rebuilds via [struct_convert] + [sql_table(legacy=true)] for non-trivial changes</li>
+            <li><b>Operational</b> &mdash; SQL fragment building, ATTACH DATABASE, FTS5 ([sql_fts5] + text_match), pre-migration utilities</li>
         </ul>
 
         <h4>Style Lint and Unified Linting</h4>
@@ -738,6 +739,16 @@ def fibI(n)
             <li>Profiler and heap tooling polish supporting leak-audit work across the runtime</li>
         </ul>
 
+        <h4>daspkg: Project Bundling for Distribution</h4>
+        <p><code>daspkg release</code> produces a redistributable bundle of a daslang project &mdash; the standalone exe, every transitively-required .shared_module dylib, every asset matching the project's release globs, and every transitive dep package's release assets. The bundle runs on a machine with no daslang installed.</p>
+        <ul>
+            <li><b>release() hook in .das_package</b> &mdash; declares release_main, release_name, release_include / release_exclude globs, and force-included shared modules</li>
+            <li><b>Exe-relative shared-module resolution</b> &mdash; daslang -exe resolves shared modules in three tiers (exe directory &rarr; das_root &rarr; absolute path), making relocated bundles portable</li>
+            <li><b>-list-shared-modules</b> &mdash; auxiliary flag walks program_for_each_module and writes a JSON manifest of every dylib the program touches; daspkg release consumes it for auto-detection</li>
+            <li><b>Project-local + relocated-bundle support</b> &mdash; get_this_module_dir, the JIT runtime, and the daspkg resolver all honor project-local layouts</li>
+            <li><b>Native shared deps</b> &mdash; packages can ship platform-specific dylibs alongside their .das sources via release_include_dll; dasPUGIXML enabled by default for Info.plist generation on macOS</li>
+        </ul>
+
         <h4>daStrudel: Second Wave</h4>
         <ul>
             <li>Better synth and drum voices, more SF2 support, offline/WAV rendering workflows, further live and demo polish</li>
@@ -759,22 +770,49 @@ def fibI(n)
             <li>Continued push toward more daslang-authored AOT logic and cleaner AOT/JIT boundaries</li>
             <li>Better standalone-exe behavior, transitive JIT type resolution, prologue sizing, function registration</li>
             <li>More build configurations (RelWithDebInfo, static PIC), more daslib AOT coverage, platform-specific AOT fixes</li>
+            <li><b>Tuple-strict typer</b> &mdash; tuple field names are now part of the type, so <code>tuple&lt;a:int;b:int&gt;</code> and <code>tuple&lt;x:int;y:int&gt;</code> no longer collide and unnamed tuples remain distinct from named ones</li>
+            <li><b>Option&lt;T&gt; / Result&lt;T,E&gt; via [template_tuple]</b> &mdash; both types are now structural named-tuples generated through a generic mechanism, replacing bespoke handling</li>
+            <li><b>Call-site block arrow body</b> &mdash; <code>def f(...) : T =&gt; expr</code> shorthand parses alongside the existing block form</li>
+            <li><b>Error reporting audit</b> &mdash; diagnostics retagged for consistency, with <code>Program::deduplicateErrors</code> suppressing repeated identical errors from the same site</li>
+            <li><b>super walks past empty intermediates</b> &mdash; <code>super</code> now skips empty intermediate base classes when looking for a method</li>
+            <li><b>Block-form global variable annotations</b> &mdash; <code>@field</code> annotations now propagate to globals declared inside <code>variable { ... }</code> blocks</li>
+            <li><b>cbind prefixes</b> &mdash; generated bindings can be namespaced with a per-include prefix</li>
+            <li><b>Compiler refactor</b> &mdash; <code>Program</code> and <code>Context</code> extracted from <code>simulate</code> / <code>ast</code> into their own translation units; serialization unified with eden / daNetGame</li>
         </ul>
 
         <h4>Runtime Libraries and Infrastructure</h4>
         <ul>
             <li><b>dasPEG</b> &mdash; more tests, docs, CI coverage, and standalone/LLVM fixes</li>
-            <li><b>Core libraries</b> &mdash; validated numeric conversions in daslib/strings_convert, continued Option/Result work including non-copyable support, C API completeness</li>
+            <li><b>Core libraries</b> &mdash; validated numeric conversions in daslib/strings_convert, continued Option/Result work including non-copyable support, C API completeness; daslib/clargs now returns Result from parsing for cleaner error handling</li>
             <li><b>das_hash_map</b> &mdash; new in-tree hash map backend that avoids empty-construction allocations and behaves better in thread-local usage</li>
+            <li><b>Path-aware glob in daslib/fio</b> &mdash; match_glob, glob, glob_filtered, plus expand_glob / parse_file_list promoted from the MCP utility into the stdlib</li>
+            <li><b>Math: common numeric functions</b> &mdash; sinh, cosh, tanh, asinh, acosh, atanh, log10, log1p, expm1, cbrt, trunc, hypot, fmod, remainder added to the math module</li>
+            <li><b>das-fmt vendored in-tree</b> &mdash; utils/das-fmt/ now holds a local copy of the formatter; CI runs against it instead of an external clone</li>
             <li>Filesystem guidance, handle-registry tutorial work, class-boost coverage, integer-returning main() for tools, compilation progress reporting</li>
+        </ul>
+
+        <h4>Build, CI, and Web</h4>
+        <ul>
+            <li><b>Tutorials build in CI</b> &mdash; every tutorial now compiles in CI as part of the regular check run</li>
+            <li><b>Web target reuses the main CMakeLists</b> &mdash; daslang-web picks up tests and tracks the same build configuration as the native targets, removing the duplicated CMake graph</li>
+            <li><b>MCP: parse-aware C++ source-search tools</b> &mdash; cpp_find_symbol, cpp_grep_usage, cpp_outline, cpp_goto_definition join the existing daslang-side tools, with a configurable search root and git-signature staleness detection</li>
         </ul>
 
         <h4>Bug Fixes</h4>
         <ul>
-            <li><b>Build, tooling, CI</b> &mdash; package .gitignore handling, PEG standalone/LLVM, require fixes, dasbind fixes, glob dependency tracking, doc/error-position corrections</li>
-            <li><b>Runtime/compiler correctness</b> &mdash; JIT global-function arguments, handled-type property write propagation, function-lookup cache pointer reuse, runWithCatch state cleanup, ASAN follow-up</li>
+            <li><b>Build, tooling, CI</b> &mdash; package .gitignore handling, PEG standalone/LLVM, require fixes, dasbind fixes, glob dependency tracking, doc/error-position corrections, and daslang plugin: completion no longer silently bails when an external binding (e.g. OpenGL, GLSL preprocessor) is in scope</li>
+            <li><b>Runtime/compiler correctness</b> &mdash; JIT global-function arguments, handled-type property write propagation, function-lookup cache pointer reuse, runWithCatch state cleanup, ASAN follow-up, fix for the standalone-exe shutdown crash, and fix for top-level let-init now correctly registering builtins</li>
+            <li><b>Fusion engine</b> &mdash; TSan-safe v_ldu via DAS_LDU_WORKHORSE, call1 / call2 loadSize stamped from fnPtr-&gt;debugInfo, and a TSan suppression for the over-read in fusion call/return shells</li>
             <li><b>Language edge cases</b> &mdash; finally loop rework, clearer inference failure on bad calls, GCC reference shadow fixes, strict-weak-ordering cleanup</li>
             <li><b>Graphics and platform</b> &mdash; OpenGL/package integration cleanup after the daspkg migration</li>
+            <li><b>Architecture-specific</b> &mdash; skipped #pragma float_control on __e2k__ to silence warnings on the Elbrus toolchain</li>
+        </ul>
+
+        <h4>Examples</h4>
+        <ul>
+            <li><b>Asteroids</b> &mdash; full asteroid-shooter game with waves, audio, and powerups; later migrated to DECS for the entity model with a polish pass on visuals and powerup VFX</li>
+            <li><b>Pacman</b> &mdash; classic arcade game added to the examples/ lineup</li>
+            <li><b>River Run</b> &mdash; top-down river shooter built across three rounds: initial gameplay (river splits, combat, VFX, audio, HUD, collisions), then scenery / bonus / engine sound / tuning, and finally shadows, pickup burst, rich music, 3D HUD, and a juice pass</li>
         </ul>
 
         <h3>0.6.1 (April 2026)</h3>


### PR DESCRIPTION
## Summary

Pre-release prep for 0.6.2-RC2. Folds every PR merged since [v0.6.2-RC1](https://github.com/GaijinEntertainment/daScript/releases/tag/v0.6.2-RC1) into the changelist + site overview, and adds the missing `install` rules for `utils/das-fmt/`.

### `CHANGELIST.md` — 0.6.2 section

- **dasSQLITE** (extended PR list): full join family (`_left_join` / `_inner_join` / `_right_join` / `_full_outer_join` / `_cross_join`), multi-Q lowering with parity audit, `_in` / `_not_in` against captured collections via `json_each`, `[sql_function]` for UDFs, schema introspection (`schema_from` + `check_schema`), and the migration trio — `daslib/sqlite_migrate` with versioned `[sql_migration]` blocks, typed ALTER macros, and full-table rebuilds via `[struct_convert]` + `[sql_table(legacy=true)]`.
- **New: daspkg: Project Bundling for Distribution** — `daspkg release` produces a redistributable bundle (standalone exe + transitive `.shared_module` dylibs + release-glob assets); exe-relative shared-module resolution; `-list-shared-modules` JSON manifest; project-local + relocated-bundle support; native shared deps via `release_include_dll`.
- **New: Build, CI, and Web** — tutorials build in CI, web target reuses the main CMakeLists, parse-aware C++ MCP tools (`cpp_find_symbol` / `cpp_grep_usage` / `cpp_outline` / `cpp_goto_definition`).
- **New: Examples** — Asteroids (with DECS migration), Pacman, River Run (three rounds).
- **Compiler / AOT / JIT** (extended): tuple-strict typer (#2565), `Option<T>` / `Result<T,E>` via `[template_tuple]` (#2601), call-site block arrow body (#2554), error reporting audit + `Program::deduplicateErrors` (#2596), `super` walk-up past empty intermediates (#2594), block-form global variable annotations (#2604), `cbind` prefixes (#2585), `Program` / `Context` / serialization split (#2460, #2569, #2605).
- **Runtime libraries** (extended): path-aware glob in `daslib/fio`, common math functions (`sinh`/`cosh`/`tanh`, …, `hypot`/`fmod`/`remainder`), `daslib/clargs` returns `Result`, das-fmt vendored under `utils/das-fmt/`.
- **Bug Fixes** (extended): standalone-exe shutdown crash (#2583/#2587), top-level `let`-init builtins (#2582/#2593), fusion engine TSan-safe `v_ldu` and `loadSize` stamping, plugin completion silent fallthrough on external bindings (#2591), `__e2k__` `#pragma float_control` skip.

### `site/index.html`

0.6.2 overview mirrors all of the changelist additions above. News block left alone — that's a publication-time edit when you cut the next pre-release.

### `CMakeLists.txt`

Adds install rules for `utils/das-fmt/` so the SDK ships the formatter alongside the other in-tree utilities — the `.das` sources (`dasfmt.das`, `fs.das`, `log.das`), `README.md`, `LICENSE`, and the `pre-commit` hook script. Matches the install pattern used for daspkg, lint, hygiene, etc.

## Test plan

- [ ] Eyeball CHANGELIST.md and site/index.html 0.6.2 sections render correctly
- [ ] Confirm the `install` step picks up `utils/das-fmt/` (CI's install/test job, or local `cmake --install build --prefix ...` then check `utils/das-fmt/` under the install root)
- [ ] No `.das` touched, so no lint / test / AOT runs needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
