### PR TITLE
feat(lint): 9 new perf/style rules — PERF013–017, STYLE016–019

### DIFF
--- a/daslib/perf_lint.das
+++ b/daslib/perf_lint.das
@@ -25,6 +25,11 @@ module perf_lint shared private
 //!   PERF010 — unnecessary get_ptr() for null comparison
 //!   PERF011 — unnecessary get_ptr() for field access
 //!   PERF012 — string(das_string) passed to strings module function
+//!   PERF013 — a += 1 / a -= 1 — use a++ / a--
+//!   PERF014 — closed-interval char-class range — see is_alpha / is_alnum / is_number etc.
+//!   PERF015 — ternary min/max — use min(a, b) / max(a, b)
+//!   PERF016 — ternary abs — use abs(x)
+//!   PERF017 — length(s) == 0 / != 0 — use empty(s) / !empty(s)
 
 require daslib/ast_boost
 require strings
@@ -108,7 +113,10 @@ class PerfLintVisitor : AstVisitor {
     }
 
     def perf_warning(text : string; at : LineInfo) : void {
-        if (in_template) {
+        // Suppress in templates and inside macro-generated functions —
+        // the user didn't write that code.
+        if (in_template
+            || (current_function != null && current_function.flags.generated)) {
             return
         }
         // Deduplicate warnings — same source location reported once, regardless of generic instantiations
@@ -123,7 +131,7 @@ class PerfLintVisitor : AstVisitor {
         }
         warning_count++
         var msg = text
-        if (current_function != null && current_function.fromGeneric != null && length(current_function.inferStack) > 0) {
+        if (current_function != null && current_function.fromGeneric != null && !empty(current_function.inferStack)) {
             msg = build_string() $(var w) {
                 w |> write(text)
                 w |> write("\n  while compiling {current_function.name}")
@@ -156,10 +164,7 @@ class PerfLintVisitor : AstVisitor {
     }
 
     def is_defined_outside_loop(v : Variable?) : bool {
-        if (v == null || loop_depth == 0) {
-            return false
-        }
-        if (self->is_loop_variable(v)) {
+        if (v == null || loop_depth == 0 || self->is_loop_variable(v)) {
             return false
         }
         for (entry in var_stack) {
@@ -186,10 +191,8 @@ class PerfLintVisitor : AstVisitor {
     def is_array_func(expr : ExprCall?; fname : string) : bool {
         // Builtin generics (push, reserve, etc.) have fromGeneric set.
         // Verify first argument is an array type.
-        if (expr.func == null || expr.func.fromGeneric == null || expr.func.fromGeneric.name != fname) {
-            return false
-        }
-        if (length(expr.arguments) < 1) {
+        if (expr.func == null || expr.func.fromGeneric == null
+            || expr.func.fromGeneric.name != fname || empty(expr.arguments)) {
             return false
         }
         let arg = expr.arguments[0]
@@ -280,12 +283,9 @@ class PerfLintVisitor : AstVisitor {
         }
         return false if (inner == null || !(inner is ExprCall))
         var call = inner as ExprCall
-        if (length(call.arguments) < 1) {
-            return false
-        }
         // After inference, string() calls may have FakeContext/FakeLineInfo extra args.
         // Check the function name and first argument type.
-        if (call.name != "string") {
+        if (empty(call.arguments) || call.name != "string") {
             return false
         }
         var arg = call.arguments[0]
@@ -307,15 +307,123 @@ class PerfLintVisitor : AstVisitor {
 
     def is_get_ptr_vs_null(maybe_get_ptr : Expression?; maybe_null : Expression?) : bool {
         //! Returns true if maybe_get_ptr is get_ptr() and maybe_null is null.
-        if (!self->is_get_ptr_of_smart_ptr(maybe_get_ptr)) {
+        if (!self->is_get_ptr_of_smart_ptr(maybe_get_ptr) || maybe_null == null) {
             return false
         }
-        return false if (maybe_null == null)
         if (maybe_null is ExprConstPtr) {
             var cptr = maybe_null as ExprConstPtr
             return cptr.value == null
         }
         return false
+    }
+
+    // --- generic constant / structural helpers (PERF013-017) ---
+
+    def is_const_zero(expr : Expression? const) : bool {
+        if (expr == null) {
+            return false
+        }
+        if (expr is ExprConstInt) {
+            return (expr as ExprConstInt).value == 0
+        }
+        if (expr is ExprConstUInt) {
+            return (expr as ExprConstUInt).value == 0u
+        }
+        if (expr is ExprConstInt64) {
+            return (expr as ExprConstInt64).value == 0l
+        }
+        if (expr is ExprConstUInt64) {
+            return (expr as ExprConstUInt64).value == 0ul
+        }
+        if (expr is ExprConstFloat) {
+            return (expr as ExprConstFloat).value == 0.0f
+        }
+        if (expr is ExprConstDouble) {
+            return (expr as ExprConstDouble).value == 0.0lf
+        }
+        return false
+    }
+
+    def is_const_one(expr : Expression? const) : bool {
+        if (expr == null) {
+            return false
+        }
+        if (expr is ExprConstInt) {
+            return (expr as ExprConstInt).value == 1
+        }
+        if (expr is ExprConstUInt) {
+            return (expr as ExprConstUInt).value == 1u
+        }
+        if (expr is ExprConstInt64) {
+            return (expr as ExprConstInt64).value == 1l
+        }
+        if (expr is ExprConstUInt64) {
+            return (expr as ExprConstUInt64).value == 1ul
+        }
+        if (expr is ExprConstFloat) {
+            return (expr as ExprConstFloat).value == 1.0f
+        }
+        if (expr is ExprConstDouble) {
+            return (expr as ExprConstDouble).value == 1.0lf
+        }
+        return false
+    }
+
+    def is_const_neg_one(expr : Expression? const) : bool {
+        if (expr == null) {
+            return false
+        }
+        if (expr is ExprConstInt) {
+            return (expr as ExprConstInt).value == -1
+        }
+        if (expr is ExprConstInt64) {
+            return (expr as ExprConstInt64).value == -1l
+        }
+        if (expr is ExprConstFloat) {
+            return (expr as ExprConstFloat).value == -1.0f
+        }
+        if (expr is ExprConstDouble) {
+            return (expr as ExprConstDouble).value == -1.0lf
+        }
+        return false
+    }
+
+    def expr_equal_struct(a : Expression? const; b : Expression? const; require_pure : bool = true) : bool {
+        //! Structural equality via describe(). With `require_pure=true` (default),
+        //! returns false when either side has side effects — protects rules that
+        //! suggest collapsing duplicated subexpressions (PERF014/015/016) from
+        //! silently changing evaluation count.
+        if ((a == null || b == null)
+            || (require_pure && (!a.flags.noSideEffects || !b.flags.noSideEffects))) {
+            return false
+        }
+        return describe(a) == describe(b)
+    }
+
+    def is_workhorse_numeric(t : TypeDecl?) : bool {
+        //! True if the type is one of the six numeric workhorse scalars (int, uint,
+        //! int64, uint64, float, double). Vectors/bitfields/enums do NOT qualify.
+        if (t == null || !empty(t.dim)) {
+            return false
+        }
+        let bt = t.baseType
+        return (bt == Type.tInt || bt == Type.tUInt
+                || bt == Type.tInt64 || bt == Type.tUInt64
+                || bt == Type.tFloat || bt == Type.tDouble)
+    }
+
+    def is_collection_length_call(expr : Expression? const) : bool {
+        //! True for length(string) / length(das_string) / length(array) / length(table).
+        //! Excludes math::length(float2/3/4) which returns vector magnitude.
+        if (expr == null || !(expr is ExprCall)) {
+            return false
+        }
+        let call = expr as ExprCall
+        if (call.func == null || call.func.name != "length") {
+            return false
+        }
+        let modname = string(call.func._module.name)
+        return modname == "strings" || modname == "$" || modname == "builtin"
     }
 
     // --- function tracking ---
@@ -345,12 +453,12 @@ class PerfLintVisitor : AstVisitor {
     def override visitExprBlock(var blk : ExprBlock?) : ExpressionPtr {
         if (blk.blockFlags.isClosure) {
             in_closure--
-            if (length(string_builder_save_stack) > 0) {
+            if (!empty(string_builder_save_stack)) {
                 string_builder_target_var = string_builder_save_stack |> back()
                 string_builder_save_stack |> pop()
             }
         }
-        if (length(scope_stack) > 0) {
+        if (!empty(scope_stack)) {
             var_stack |> resize(scope_stack |> back())
             scope_stack |> pop()
         }
@@ -419,17 +527,12 @@ class PerfLintVisitor : AstVisitor {
             return false
         }
         let bt = src._type.baseType
-        if (bt == Type.tArray || bt == Type.tString) {
-            return true
-        }
-        if (bt == Type.tRange || bt == Type.tRange64 || bt == Type.tURange || bt == Type.tURange64) {
-            return true
-        }
-        // fixed arrays have dim > 0
-        if (src._type.dim |> length > 0) {
-            return true
-        }
-        return false
+        // fixed arrays have dim > 0; otherwise we accept any baseType whose
+        // length is determined at the start of the loop.
+        return (bt == Type.tArray || bt == Type.tString
+                || bt == Type.tRange || bt == Type.tRange64
+                || bt == Type.tURange || bt == Type.tURange64
+                || !empty(src._type.dim))
     }
 
     def override preVisitExprForSource(expr : ExprFor?; src : ExpressionPtr; last : bool) : void {
@@ -456,14 +559,14 @@ class PerfLintVisitor : AstVisitor {
             if (current_for_known_length) {
                 known_length_loop_depth--
             }
-            if (length(scope_stack) > 0) {
+            if (!empty(scope_stack)) {
                 var_stack |> resize(scope_stack |> back())
                 scope_stack |> pop()
             }
-            if (length(if_depth_stack) > 0) {
+            if (!empty(if_depth_stack)) {
                 if_depth_stack |> pop()
             }
-            if (length(loop_has_early_exit) > 0) {
+            if (!empty(loop_has_early_exit)) {
                 loop_has_early_exit |> pop()
             }
         }
@@ -487,14 +590,14 @@ class PerfLintVisitor : AstVisitor {
     def override visitExprWhile(var expr : ExprWhile?) : ExpressionPtr {
         if (in_closure == 0) {
             loop_depth--
-            if (length(scope_stack) > 0) {
+            if (!empty(scope_stack)) {
                 var_stack |> resize(scope_stack |> back())
                 scope_stack |> pop()
             }
-            if (length(if_depth_stack) > 0) {
+            if (!empty(if_depth_stack)) {
                 if_depth_stack |> pop()
             }
-            if (length(loop_has_early_exit) > 0) {
+            if (!empty(loop_has_early_exit)) {
                 loop_has_early_exit |> pop()
             }
         }
@@ -505,13 +608,13 @@ class PerfLintVisitor : AstVisitor {
     // --- break/continue tracking (for PERF006 early-exit suppression) ---
 
     def override preVisitExprBreak(expr : ExprBreak?) : void {
-        if (in_closure == 0 && length(loop_has_early_exit) > 0) {
+        if (in_closure == 0 && !empty(loop_has_early_exit)) {
             loop_has_early_exit[length(loop_has_early_exit) - 1] = true
         }
     }
 
     def override preVisitExprContinue(expr : ExprContinue?) : void {
-        if (in_closure == 0 && length(loop_has_early_exit) > 0) {
+        if (in_closure == 0 && !empty(loop_has_early_exit)) {
             loop_has_early_exit[length(loop_has_early_exit) - 1] = true
         }
     }
@@ -519,13 +622,13 @@ class PerfLintVisitor : AstVisitor {
     // --- if-depth tracking (for PERF006 conditional suppression) ---
 
     def override preVisitExprIfThenElse(ifte : ExprIfThenElse?) : void {
-        if (length(if_depth_stack) > 0) {
+        if (!empty(if_depth_stack)) {
             if_depth_stack[length(if_depth_stack) - 1]++
         }
     }
 
     def override visitExprIfThenElse(var ifte : ExprIfThenElse?) : ExpressionPtr {
-        if (length(if_depth_stack) > 0) {
+        if (!empty(if_depth_stack)) {
             if_depth_stack[length(if_depth_stack) - 1]--
         }
         return <- ifte
@@ -536,9 +639,10 @@ class PerfLintVisitor : AstVisitor {
     // --- PERF008: unnecessary get_ptr() for is/as ---
 
     def override preVisitExprOp2(expr : ExprOp2?) : void {
-        if (in_closure > 0) {
-            return
-        }
+        // No in_closure check needed — loop_depth doesn't increment inside
+        // closure bodies (see preVisitExprFor/While), so PERF001's loop check
+        // is already correctly scoped. The other rules below are syntactic
+        // patterns that misbehave identically inside or outside closures.
         if (loop_depth > 0 && expr.op == "+=") {
             let v = self->find_string_var_from_expr(expr.left)
             if (v != null && self->is_defined_outside_loop(v)) {
@@ -571,6 +675,327 @@ class PerfLintVisitor : AstVisitor {
         if (self->is_get_ptr_vs_null(expr.left, expr.right) || self->is_get_ptr_vs_null(expr.right, expr.left)) {
             self->perf_warning("PERF010: get_ptr() is unnecessary for null comparison; smart_ptr supports == and != null directly", expr.at)
         }
+        // PERF013: a += ±1 / a -= ±1 → a++ / a--
+        // Derive the actual delta from (op, RHS) so each branch can suggest the
+        // correct postfix operator. RHS is one of {+1, -1}; op flips the sign.
+        if (expr.op == "+=" || expr.op == "-=") {
+            if (expr.left != null && self->is_workhorse_numeric(expr.left._type)) {
+                let rhs_one = self->is_const_one(expr.right)
+                let rhs_neg = self->is_const_neg_one(expr.right)
+                var delta = 0
+                if (rhs_one) {
+                    delta = expr.op == "+=" ? 1 : -1
+                } elif (rhs_neg) {
+                    delta = expr.op == "+=" ? -1 : 1
+                }
+                if (delta == 1) {
+                    self->perf_warning("PERF013: '{expr.op} {rhs_one ? 1 : -1}' on a numeric scalar; use postfix '++' for a faster, idiomatic increment", expr.at)
+                } elif (delta == -1) {
+                    self->perf_warning("PERF013: '{expr.op} {rhs_one ? 1 : -1}' on a numeric scalar; use postfix '--' for a faster, idiomatic decrement", expr.at)
+                }
+            }
+        }
+        // PERF014: closed-interval char-class range check
+        if (expr.op == "&&") {
+            self->check_perf014_char_class(expr)
+        }
+        // PERF017: length(s) <op> 0 / 1 → empty(s) / !empty(s)
+        if (expr.op == "==" || expr.op == "!=" || expr.op == "<" || expr.op == "<=" || expr.op == ">" || expr.op == ">=") {
+            self->check_perf017_length_zero(expr)
+        }
+    }
+
+    // --- PERF014: closed-interval char-class range checks ---
+
+    def parse_range_leg(leg : Expression?; var v_out : Expression?&; var bound_out : int&; var is_hi_out : bool&) : bool {
+        //! Parse `var <op> const` or `const <op> var` where op is `<=` or `>=`.
+        //! Returns true and fills outputs with: the variable expression,
+        //! the int bound, and whether this leg expresses an upper bound on var.
+        if (leg == null || !(leg is ExprOp2)) {
+            return false
+        }
+        var op2 = leg as ExprOp2
+        let opname = string(op2.op)
+        if (opname != "<=" && opname != ">=") {
+            return false
+        }
+        if (op2.right is ExprConstInt && op2.left != null) {
+            v_out = op2.left
+            bound_out = (op2.right as ExprConstInt).value
+            is_hi_out = opname == "<="
+            return true
+        }
+        if (op2.left is ExprConstInt && op2.right != null) {
+            v_out = op2.right
+            bound_out = (op2.left as ExprConstInt).value
+            is_hi_out = opname == ">="
+            return true
+        }
+        return false
+    }
+
+    def is_known_char_class_range(lo : int; hi : int) : bool {
+        //! Three closed ranges hint at the strings is_*() helpers.
+        //! Hex extras ('a'..'f', 'A'..'F') are excluded — is_hex is broader.
+        return ((lo == 48 && hi == 57)         // '0'..'9' — is_number
+                || (lo == 97 && hi == 122)     // 'a'..'z' — is_alpha (lower half)
+                || (lo == 65 && hi == 90))     // 'A'..'Z' — is_alpha (upper half)
+    }
+
+    def check_perf014_char_class(expr : ExprOp2?) : void {
+        var va : Expression? = null
+        var vb : Expression? = null
+        var bound_a = 0
+        var bound_b = 0
+        var hi_a = false
+        var hi_b = false
+        // Both legs must parse, constrain the SAME expression, and split into
+        // one upper / one lower bound.
+        if (!self->parse_range_leg(expr.left, va, bound_a, hi_a)
+            || !self->parse_range_leg(expr.right, vb, bound_b, hi_b)
+            || !self->expr_equal_struct(va, vb)
+            || hi_a == hi_b) {
+            return
+        }
+        let lo = hi_a ? bound_b : bound_a
+        let hi = hi_a ? bound_a : bound_b
+        if (lo >= hi || !self->is_known_char_class_range(lo, hi)) {
+            return
+        }
+        // Pick the helper that matches the detected range. Note: is_alpha covers
+        // BOTH cases, so for a single-case range ('a'..'z' or 'A'..'Z') it's a
+        // broader replacement, not an exact one — call that out so the user
+        // doesn't replace lower-only with a both-cases check.
+        if (lo == 48 && hi == 57) {
+            self->perf_warning("PERF014: char-class range check '0'..'9' — use 'is_number(c)' from strings module", expr.at)
+        } else {
+            // 'a'..'z' or 'A'..'Z'
+            let case_kind = (lo == 97) ? "lowercase" : "uppercase"
+            self->perf_warning("PERF014: char-class range check ({case_kind} only) — consider 'is_alpha(c)' from strings module (note: is_alpha matches both cases, broader than this range)", expr.at)
+        }
+    }
+
+    // --- PERF017: length(collection) <op> 0/1 → empty / !empty ---
+
+    def peel_ref2value(e : Expression? const) : Expression? const {
+        if (e != null && e is ExprRef2Value) {
+            return (e as ExprRef2Value.subexpr)
+        }
+        return e
+    }
+
+    def const_int_value(e : Expression? const; var v : int&) : bool {
+        let inner = self->peel_ref2value(e)
+        if (inner == null) {
+            return false
+        }
+        if (inner is ExprConstInt) {
+            v = (inner as ExprConstInt).value
+            return true
+        }
+        if (inner is ExprConstUInt) {
+            v = int((inner as ExprConstUInt).value)
+            return true
+        }
+        return false
+    }
+
+    def check_perf017_length_zero(expr : ExprOp2?) : void {
+        // Skip the canonical implementation of empty() in daslib/builtin.das —
+        // empty(x) is literally `return length(x) == 0`, and the rule's whole job
+        // is to suggest `empty(x)`. Self-flagging the suggestion's own body is
+        // noise. Generic instantiations of empty<T> hit this path with
+        // current_function.fromGeneric pointing at the source `empty`. Both arms
+        // also gate on _module.name == "builtin" so unrelated user methods named
+        // empty() (e.g. delegate.empty(), AOT cache empty()) keep getting linted.
+        if (current_function != null) {
+            let direct_match = (current_function.name == "empty"
+                && current_function._module != null
+                && current_function._module.name == "builtin")
+            let generic_match = (current_function.fromGeneric != null
+                && current_function.fromGeneric.name == "empty"
+                && current_function.fromGeneric._module != null
+                && current_function.fromGeneric._module.name == "builtin")
+            if (direct_match || generic_match) {
+                return
+            }
+        }
+        let lhs = self->peel_ref2value(expr.left)
+        let rhs = self->peel_ref2value(expr.right)
+        var len_on_left = true
+        if (self->is_collection_length_call(lhs)) {
+            len_on_left = true
+        } elif (self->is_collection_length_call(rhs)) {
+            len_on_left = false
+        } else {
+            return
+        }
+        let const_side = len_on_left ? rhs : lhs
+        var k = 0
+        if (!self->const_int_value(const_side, k) || (k != 0 && k != 1)) {
+            return
+        }
+        let opname = string(expr.op)
+        // Canonicalize so that length is on the left; flip op if needed.
+        var canon_op = opname
+        if (!len_on_left) {
+            if (opname == "<") {
+                canon_op = ">"
+            } elif (opname == "<=") {
+                canon_op = ">="
+            } elif (opname == ">") {
+                canon_op = "<"
+            } elif (opname == ">=") {
+                canon_op = "<="
+            }
+        }
+        // Map (canon_op, k) → empty / !empty
+        //   k=0: ==, <=             → empty
+        //        !=, >              → !empty
+        //   k=1: <                  → empty   (length < 1 means length == 0)
+        //        >=                 → !empty  (length >= 1 means length > 0)
+        var is_empty_pattern = false
+        var is_nonempty_pattern = false
+        if (k == 0) {
+            if (canon_op == "==" || canon_op == "<=") {
+                is_empty_pattern = true
+            } elif (canon_op == "!=" || canon_op == ">") {
+                is_nonempty_pattern = true
+            }
+        } else {
+            if (canon_op == "<") {
+                is_empty_pattern = true
+            } elif (canon_op == ">=") {
+                is_nonempty_pattern = true
+            }
+        }
+        // Diagnostic uses canon_op so Yoda forms (e.g. `1 <= length(x)`) print
+        // the canonical equivalent (`length(x) >= 1`), matching what we matched.
+        if (is_empty_pattern) {
+            self->perf_warning("PERF017: 'length(x) {canon_op} {k}' — use 'empty(x)' (avoids unnecessary strlen on strings)", expr.at)
+        } elif (is_nonempty_pattern) {
+            self->perf_warning("PERF017: 'length(x) {canon_op} {k}' — use '!empty(x)' (avoids unnecessary strlen on strings)", expr.at)
+        }
+    }
+
+    // --- PERF015 / PERF016: ternary min/max/abs ---
+
+    def override preVisitExprOp3(expr : ExprOp3?) : void {
+        if (in_closure > 0 || expr.op != "?"
+            || expr.subexpr == null || !(expr.subexpr is ExprOp2)) {
+            return
+        }
+        var cmp = expr.subexpr as ExprOp2
+        let cop = string(cmp.op)
+        if ((cop != "<" && cop != "<=" && cop != ">" && cop != ">=")
+            || expr.left == null || expr.right == null) {
+            return
+        }
+        let t_branch = expr.left
+        let f_branch = expr.right
+        // PERF016 first — a ternary that matches abs may also superficially match
+        // min/max if x and -x ever describe-equal, but they can't. So order is fine.
+        if (self->try_perf016_abs(expr, cmp, t_branch, f_branch, cop)) {
+            return
+        }
+        self->try_perf015_minmax(expr, cmp, t_branch, f_branch, cop)
+    }
+
+    def try_perf015_minmax(expr : ExprOp3?; cmp : ExprOp2?; t_branch, f_branch : Expression? const; cop : string) : bool {
+        let cl = cmp.left
+        let cr = cmp.right
+        if (cl == null || cr == null) {
+            return false
+        }
+        // ternary branches must be a permutation of (cl, cr)
+        let tcl = self->expr_equal_struct(t_branch, cl)
+        let tcr = self->expr_equal_struct(t_branch, cr)
+        let fcl = self->expr_equal_struct(f_branch, cl)
+        let fcr = self->expr_equal_struct(f_branch, cr)
+        let same_order = tcl && fcr   // T==L, F==R
+        let swap_order = tcr && fcl   // T==R, F==L
+        if (!same_order && !swap_order) {
+            return false
+        }
+        // Mapping
+        //   <  / <=  : T==L,F==R → min;  T==R,F==L → max
+        //   >  / >=  : T==L,F==R → max;  T==R,F==L → min
+        var is_min = false
+        if (cop == "<" || cop == "<=") {
+            is_min = same_order
+        } else {
+            is_min = swap_order
+        }
+        let which = is_min ? "min" : "max"
+        self->perf_warning("PERF015: ternary {which} — use '{which}(a, b)' from math module", expr.at)
+        return true
+    }
+
+    def try_perf016_abs(expr : ExprOp3?; cmp : ExprOp2?; t_branch, f_branch : Expression? const; cop : string) : bool {
+        // One side of the comparison must be const-zero
+        var x_on_left = false
+        if (self->is_const_zero(cmp.right)) {
+            x_on_left = true
+        } elif (self->is_const_zero(cmp.left)) {
+            x_on_left = false
+        } else {
+            return false
+        }
+        let x_expr = x_on_left ? cmp.left : cmp.right
+        if (x_expr == null) {
+            return false
+        }
+        // Identify negated branch (-x) and plain branch (x)
+        var neg_then = false
+        var ok = false
+        if (self->is_neg_of(t_branch, x_expr) && self->expr_equal_struct(f_branch, x_expr)) {
+            neg_then = true
+            ok = true
+        } elif (self->expr_equal_struct(t_branch, x_expr) && self->is_neg_of(f_branch, x_expr)) {
+            neg_then = false
+            ok = true
+        }
+        if (!ok) {
+            return false
+        }
+        // Determine canonical sign of x in comparison: x < 0 or x > 0 etc.
+        // Reduce to: "is x's value-relation `negative` or `positive`" in the true branch
+        // Forms that produce abs:
+        //   x < 0 → -x  (T branch is -x, x is on left)        — neg_then=true , x_on_left=true , cop in {<, <=}
+        //   x > 0 → x   (T branch is x,  x is on left)        — neg_then=false, x_on_left=true , cop in {>, >=}
+        //   0 > x → -x                                         — neg_then=true , x_on_left=false, cop in {>, >=}
+        //   0 < x → x                                          — neg_then=false, x_on_left=false, cop in {<, <=}
+        var is_abs = false
+        if (x_on_left) {
+            if ((cop == "<" || cop == "<=") && neg_then) {
+                is_abs = true
+            } elif ((cop == ">" || cop == ">=") && !neg_then) {
+                is_abs = true
+            }
+        } else {
+            if ((cop == ">" || cop == ">=") && neg_then) {
+                is_abs = true
+            } elif ((cop == "<" || cop == "<=") && !neg_then) {
+                is_abs = true
+            }
+        }
+        if (!is_abs) {
+            return false
+        }
+        self->perf_warning("PERF016: ternary abs — use 'abs(x)' from math module", expr.at)
+        return true
+    }
+
+    def is_neg_of(maybe_neg : Expression? const; ref : Expression? const) : bool {
+        //! True when `maybe_neg` is `-ref` structurally.
+        if (maybe_neg == null || !(maybe_neg is ExprOp1)) {
+            return false
+        }
+        let op1 = maybe_neg as ExprOp1
+        if (op1.op != "-") {
+            return false
+        }
+        return self->expr_equal_struct(op1.subexpr, ref)
     }
 
     // --- PERF011: unnecessary get_ptr() for field access ---
@@ -644,8 +1069,8 @@ class PerfLintVisitor : AstVisitor {
                 }
             }
         }
-        let in_conditional = length(if_depth_stack) > 0 && if_depth_stack[length(if_depth_stack) - 1] > 0
-        let has_early_exit = length(loop_has_early_exit) > 0 && loop_has_early_exit[length(loop_has_early_exit) - 1]
+        let in_conditional = !empty(if_depth_stack) && if_depth_stack[length(if_depth_stack) - 1] > 0
+        let has_early_exit = !empty(loop_has_early_exit) && loop_has_early_exit[length(loop_has_early_exit) - 1]
         if (in_closure == 0 && known_length_loop_depth > 0 && !in_conditional && !has_early_exit) {
             if (self->is_array_func(expr, "push") || self->is_array_func(expr, "push_clone") || self->is_array_func(expr, "emplace")) {
                 var path = ""

--- a/daslib/style_lint.das
+++ b/daslib/style_lint.das
@@ -24,6 +24,10 @@ module style_lint shared private
 //!   STYLE013 — struct var with default/empty init followed by a run of field assignments
 //!   STYLE014 — comment block exceeds 3 lines at module/public scope (opt-in via ``options _comment_hygiene = true``, suppress with '//!@nolint' or '// nolint:STYLE014')
 //!   STYLE015 — comment block exceeds 1 line inside a 'def private' (opt-in via ``options _comment_hygiene = true``, suppress with '// nolint:STYLE015')
+//!   STYLE016 — adjacent guards leading to identical early-exit can be combined with '||'
+//!   STYLE017 — 'if (cond) return true; else return false' — use 'return cond' (or 'return !cond')
+//!   STYLE018 — redundant boolean comparison ('b == true' / 'b != false') — use 'b' / '!b'
+//!   STYLE019 — nested min/max — use 'clamp(x, lo, hi)' from math module
 
 require daslib/ast_boost
 require strings
@@ -76,6 +80,10 @@ class StyleLintVisitor : AstVisitor {
     }
 
     def style_warning(text : string; at : LineInfo) : void {
+        // Suppress warnings for macro-generated functions — the user didn't write that code.
+        if (current_function != null && current_function.flags.generated) {
+            return
+        }
         let key = self->location_key(at)
         if (reported_locations |> has_value(key)) {
             return
@@ -86,7 +94,7 @@ class StyleLintVisitor : AstVisitor {
         }
         warning_count++
         var msg = text
-        if (current_function != null && current_function.fromGeneric != null && length(current_function.inferStack) > 0) {
+        if (current_function != null && current_function.fromGeneric != null && !empty(current_function.inferStack)) {
             msg = build_string() $(var w) {
                 w |> write(text)
                 w |> write("\n  while compiling {current_function.name}")
@@ -233,6 +241,45 @@ class StyleLintVisitor : AstVisitor {
 
     def override preVisitExprCall(var expr : ExprCall?) : void {
         self->check_block_pipe(expr.at, expr.arguments)
+        self->check_style019_clamp(expr)
+    }
+
+    // --- STYLE019: nested min/max → clamp ---
+
+    def is_math_call(expr : Expression? const; fname : string) : bool {
+        //! True iff `expr` is `math::<fname>(_, _)` with exactly two arguments
+        //! (peeling ExprRef2Value). Conservatively skips any non-math overload.
+        let inner = self->peel_ref2value_const(expr)
+        if (inner == null || !(inner is ExprCall)) {
+            return false
+        }
+        let call = inner as ExprCall
+        if (call.func == null || call.func.name != fname
+            || call.func._module.name != "math") {
+            return false
+        }
+        return length(call.arguments) == 2
+    }
+
+    def check_style019_clamp(expr : ExprCall?) : void {
+        if (expr.func == null || expr.func._module.name != "math"
+            || length(expr.arguments) != 2) {
+            return
+        }
+        let outer_name = string(expr.func.name)
+        if (outer_name != "min" && outer_name != "max") {
+            return
+        }
+        let inner_name = outer_name == "min" ? "max" : "min"
+        // min(max(x, lo), hi) — inner is arg[0]
+        // max(min(x, hi), lo) — inner is arg[0] (mirror)
+        if (self->is_math_call(expr.arguments[0], inner_name)) {
+            self->style_warning("STYLE019: nested {outer_name}({inner_name}(...)) — use 'clamp(x, lo, hi)' from math module", expr.at)
+            return
+        }
+        if (self->is_math_call(expr.arguments[1], inner_name)) {
+            self->style_warning("STYLE019: nested {outer_name}({inner_name}(...)) — use 'clamp(x, lo, hi)' from math module", expr.at)
+        }
     }
 
     def override preVisitExprInvoke(var expr : ExprInvoke?) : void {
@@ -290,16 +337,14 @@ class StyleLintVisitor : AstVisitor {
             return
         }
         var eblk = blk as ExprBlock
-        if (!eblk.blockFlags.isClosure || eblk.blockFlags.isLambdaBlock || length(eblk.arguments) != 0) {
+        if (!eblk.blockFlags.isClosure || eblk.blockFlags.isLambdaBlock || !empty(eblk.arguments)) {
             return
         }
         let src = self->source_line_between(expr.at, eblk.at)
         let dollar_pos = find(src, "$()")
-        if (dollar_pos < 0) {
-            return
-        }
-        // Skip if <| pipe is present — STYLE002 already covers that case
-        if (find(src, "<|") >= 0) {
+        // Skip when there is no $() at all, or when <| pipe is present
+        // (STYLE002 already covers the piped form).
+        if (dollar_pos < 0 || find(src, "<|") >= 0) {
             return
         }
         // Skip if explicit return type follows: $() : Type { ... }
@@ -311,18 +356,137 @@ class StyleLintVisitor : AstVisitor {
     }
 
     // --- STYLE006: string(__rtti) == "..." should use `is` ---
+    // --- STYLE018: b == true / b == false / b != true / b != false ---
+
+    def peel_ref2value_const(e : Expression? const) : Expression? const {
+        if (e != null && e is ExprRef2Value) {
+            return (e as ExprRef2Value.subexpr)
+        }
+        return e
+    }
+
+    def expr_equal_struct(a : Expression? const; b : Expression? const) : bool {
+        //! Structural equality via describe(). No purity filter.
+        if (a == null || b == null) {
+            return false
+        }
+        return describe(a) == describe(b)
+    }
 
     def override preVisitExprOp2(expr : ExprOp2?) : void {
-        if (expr.op != "==") {
-            return
+        if (expr.op == "==") {
+            if (self->is_string_rtti_comparison(expr.left) || self->is_string_rtti_comparison(expr.right)) {
+                self->style_warning("STYLE006: string(__rtti) comparison should use `is` operator; e.g. expr is ExprFoo", expr.at)
+            }
         }
-        if (self->is_string_rtti_comparison(expr.left) || self->is_string_rtti_comparison(expr.right)) {
-            self->style_warning("STYLE006: string(__rtti) comparison should use `is` operator; e.g. expr is ExprFoo", expr.at)
+        // STYLE018: b == true / b == false / b != true / b != false
+        if (expr.op == "==" || expr.op == "!=") {
+            let lhs = self->peel_ref2value_const(expr.left)
+            let rhs = self->peel_ref2value_const(expr.right)
+            let lbool = lhs != null && lhs is ExprConstBool
+            let rbool = rhs != null && rhs is ExprConstBool
+            // Avoid double-flagging `true == false` on both sides — flag only when
+            // exactly one side is a bool literal (the other side is the bool var/expr).
+            if (lbool != rbool) {
+                let const_side = lbool ? lhs : rhs
+                let cval = (const_side as ExprConstBool).value
+                let positive = (expr.op == "==" && cval) || (expr.op == "!=" && !cval)
+                let suggestion = positive ? "b" : "!b"
+                self->style_warning("STYLE018: redundant boolean comparison — use '{suggestion}' directly (drop the '{expr.op} {cval}')", expr.at)
+            }
         }
     }
 
     // --- STYLE005: postfix conditionals (configurable) ---
     // --- STYLE010: if (true) should be bare block ---
+    // --- STYLE016(b): if (a) { return X } else if (b) { return X } ---
+    // --- STYLE017(a): if (cond) return true else return false ---
+
+    def single_terminator_body(body : Expression? const) : Expression? const {
+        //! If `body` is a bare ExprReturn/Break/Continue, or a 1-statement ExprBlock
+        //! wrapping one, return the inner terminator. Otherwise null.
+        if (body == null) {
+            return null
+        }
+        if (body is ExprReturn || body is ExprBreak || body is ExprContinue) {
+            return body
+        }
+        if (body is ExprBlock) {
+            let blk = body as ExprBlock
+            if (length(blk.list) == 1 && empty(blk.finalList)) {
+                let stmt = blk.list[0]
+                if (stmt is ExprReturn || stmt is ExprBreak || stmt is ExprContinue) {
+                    return stmt
+                }
+            }
+        }
+        return null
+    }
+
+    def terminators_payload_equal(a : Expression? const; b : Expression? const) : bool {
+        //! Two terminators have the same payload iff they are the same kind and
+        //! their return-subexpr (if any) is structurally equal. Break==Break and
+        //! Continue==Continue have no payload.
+        if (a == null || b == null) {
+            return false
+        }
+        if (a is ExprBreak) {
+            return b is ExprBreak
+        }
+        if (a is ExprContinue) {
+            return b is ExprContinue
+        }
+        if (a is ExprReturn) {
+            if (!(b is ExprReturn)) {
+                return false
+            }
+            let ra = a as ExprReturn
+            let rb = b as ExprReturn
+            if (ra.subexpr == null && rb.subexpr == null) {
+                return true
+            }
+            if (ra.subexpr == null || rb.subexpr == null) {
+                return false
+            }
+            return self->expr_equal_struct(ra.subexpr, rb.subexpr)
+        }
+        return false
+    }
+
+    def is_const_bool_return(term : Expression? const; var b_out : bool&) : bool {
+        //! True if `term` is `return ExprConstBool(b)`. Writes the bool to b_out.
+        if (term == null || !(term is ExprReturn)) {
+            return false
+        }
+        let ret = term as ExprReturn
+        let sub = self->peel_ref2value_const(ret.subexpr)
+        if (sub == null || !(sub is ExprConstBool)) {
+            return false
+        }
+        b_out = (sub as ExprConstBool).value
+        return true
+    }
+
+    def unwrap_inner_ifte(if_false : Expression? const) : ExprIfThenElse? {
+        //! Strip a 1-stmt ExprBlock wrapping an ExprIfThenElse, returning the inner if.
+        //! Otherwise return the if_false directly cast to ExprIfThenElse?, or null.
+        if (if_false == null) {
+            return null
+        }
+        if (if_false is ExprIfThenElse) {
+            return (if_false as ExprIfThenElse)
+        }
+        if (if_false is ExprBlock) {
+            let blk = if_false as ExprBlock
+            if (length(blk.list) == 1 && empty(blk.finalList)) {
+                let stmt = blk.list[0]
+                if (stmt is ExprIfThenElse) {
+                    return (stmt as ExprIfThenElse)
+                }
+            }
+        }
+        return null
+    }
 
     def override preVisitExprIfThenElse(ifte : ExprIfThenElse?) : void {
         if (ifte.if_flags.isStatic) {
@@ -336,18 +500,33 @@ class StyleLintVisitor : AstVisitor {
                 self->style_warning("STYLE010: if (true) is always taken; use a bare block instead", ifte.at)
             }
         }
-        if (postfix_conditionals && ifte.if_false == null) {
-            var then_expr = ifte.if_true
-            if (then_expr is ExprBlock) {
-                var blk = then_expr as ExprBlock
-                if (length(blk.list) == 1 && length(blk.finalList) == 0) {
-                    var stmt = blk.list[0]
-                    if (stmt is ExprReturn || stmt is ExprBreak || stmt is ExprContinue) {
-                        // Skip if already on one line (already postfix or one-liner)
-                        if (ifte.at.line != stmt.at.line) {
-                            self->style_warning("STYLE005: single-statement if can use postfix form; e.g. return val if (cond)", ifte.at)
-                        }
-                    }
+        // Detect terminator in the `then` branch — used by STYLE005, STYLE016(b), STYLE017(a)
+        let outer_term = self->single_terminator_body(ifte.if_true)
+        if (postfix_conditionals && ifte.if_false == null && outer_term != null) {
+            // Reproduce STYLE005's "skip if already on one line" check
+            if (ifte.at.line != outer_term.at.line) {
+                self->style_warning("STYLE005: single-statement if can use postfix form; e.g. return val if (cond)", ifte.at)
+            }
+        }
+        // STYLE016(b): if (a) { return X } else if (b) { return X }
+        if (outer_term != null && ifte.if_false != null) {
+            let inner = self->unwrap_inner_ifte(ifte.if_false)
+            if (inner != null && inner.if_false == null) {
+                let inner_term = self->single_terminator_body(inner.if_true)
+                if (inner_term != null && self->terminators_payload_equal(outer_term, inner_term)) {
+                    self->style_warning("STYLE016: adjacent guards leading to identical early-exit can be combined with '||'", ifte.at)
+                }
+            }
+        }
+        // STYLE017(a): if (cond) return true else return false (or vice versa)
+        if (outer_term != null && ifte.if_false != null) {
+            let else_term = self->single_terminator_body(ifte.if_false)
+            if (else_term != null) {
+                var b1 = false
+                var b2 = false
+                if (self->is_const_bool_return(outer_term, b1) && self->is_const_bool_return(else_term, b2) && b1 != b2) {
+                    let suggestion = b1 ? "return cond" : "return !cond"
+                    self->style_warning("STYLE017: 'if (cond) return {b1}; else return {b2}' — use '{suggestion}' directly", ifte.at)
                 }
             }
         }
@@ -370,8 +549,48 @@ class StyleLintVisitor : AstVisitor {
         return (inner as ExprVar.variable)
     }
 
+    // --- STYLE016(a): adjacent guards `if (a) { return X }; if (b) { return X }` ---
+    // --- STYLE017(b): adjacent `if (cond) { return b1 }; return b2` (b1 != b2) ---
+
+    def override preVisitExprBlock(blk : ExprBlock?) : void {
+        let n = length(blk.list)
+        for (i in range(n - 1)) {
+            let cur = blk.list[i]
+            let nxt = blk.list[i + 1]
+            if (!(cur is ExprIfThenElse)) {
+                continue
+            }
+            let outer_if = cur as ExprIfThenElse
+            if (outer_if.if_false != null) {
+                continue
+            }
+            let outer_term = self->single_terminator_body(outer_if.if_true)
+            if (outer_term == null) {
+                continue
+            }
+            // STYLE016(a): adjacent guard with same payload
+            if (nxt is ExprIfThenElse) {
+                let nxt_if = nxt as ExprIfThenElse
+                if (nxt_if.if_false == null) {
+                    let nxt_term = self->single_terminator_body(nxt_if.if_true)
+                    if (nxt_term != null && self->terminators_payload_equal(outer_term, nxt_term)) {
+                        self->style_warning("STYLE016: adjacent guards leading to identical early-exit can be combined with '||'", outer_if.at)
+                        continue
+                    }
+                }
+            }
+            // STYLE017(b): adjacent return-true-then-return-false
+            var b1 = false
+            var b2 = false
+            if (self->is_const_bool_return(outer_term, b1) && self->is_const_bool_return(nxt, b2) && b1 != b2) {
+                let suggestion = b1 ? "return cond" : "return !cond"
+                self->style_warning("STYLE017: 'if (cond) return {b1}; return {b2}' — use '{suggestion}' directly", outer_if.at)
+            }
+        }
+    }
+
     def override preVisitExprBlockExpression(blk : ExprBlock?; expr : ExpressionPtr) : void {
-        if (length(pending_uninit_vars) > 0) {
+        if (!empty(pending_uninit_vars)) {
             if (expr is ExprCopy) {
                 let v = self->find_assign_var((expr as ExprCopy).left)
                 if (v != null && pending_uninit_vars |> has_value(v)) {
@@ -415,25 +634,18 @@ class StyleLintVisitor : AstVisitor {
             return
         }
         for (v in elet.variables) {
-            if (v.init != null) {
-                continue
-            }
-            if (v.flags.generated || v.flags.inScope) {
-                continue
-            }
-            if (v._type == null || v._type.baseType != Type.tArray) {
-                continue
-            }
-            if (length(v._type.dim) != 0) {
+            // Only flag uninitialized array<T> locals from user code (skip generic
+            // host instantiations and compiler-synthesized vars).
+            if (v.init != null
+                || v.flags.generated || v.flags.inScope
+                || v._type == null || v._type.baseType != Type.tArray
+                || !empty(v._type.dim)) {
                 continue
             }
             var count = 0
             for (j in range(idx + 1, n)) {
                 let stmt = blk.list[j]
-                if (!(stmt is ExprCall)) {
-                    break
-                }
-                if (!self->is_push_or_emplace_of(stmt as ExprCall, v)) {
+                if (!(stmt is ExprCall) || !self->is_push_or_emplace_of(stmt as ExprCall, v)) {
                     break
                 }
                 count++
@@ -462,16 +674,10 @@ class StyleLintVisitor : AstVisitor {
             return
         }
         for (v in elet.variables) {
-            if (v.flags.generated || v.flags.inScope) {
-                continue
-            }
-            if (v._type == null || v._type.baseType != Type.tStructure) {
-                continue
-            }
-            if (length(v._type.dim) != 0) {
-                continue
-            }
-            if (!self->is_default_struct_init(v)) {
+            // Skip generic-host instantiations and any non-struct or non-default-init local
+            if (v.flags.generated || v.flags.inScope
+                || v._type == null || v._type.baseType != Type.tStructure
+                || !empty(v._type.dim) || !self->is_default_struct_init(v)) {
                 continue
             }
             var count = 0
@@ -524,13 +730,9 @@ class StyleLintVisitor : AstVisitor {
     }
 
     def is_push_or_emplace_of(call : ExprCall?; target : Variable?) : bool {
-        if (call.func == null || call.func.fromGeneric == null) {
-            return false
-        }
-        if (call.func.fromGeneric.name != "push" && call.func.fromGeneric.name != "emplace") {
-            return false
-        }
-        if (length(call.arguments) < 2) {
+        if (call.func == null || call.func.fromGeneric == null
+            || (call.func.fromGeneric.name != "push" && call.func.fromGeneric.name != "emplace")
+            || length(call.arguments) < 2) {
             return false
         }
         var arg = call.arguments[0]
@@ -557,13 +759,9 @@ class StyleLintVisitor : AstVisitor {
         var fn_ends : array<uint>
         var fn_private : array<bool>
         for_each_function(mod, "") $(var fn) {
-            if (fn.body == null || fn.at.fileInfo == null || fn.at.line == 0u) {
-                return
-            }
-            if (fn.flags.generated || fn.fromGeneric != null || fn._module != mod) {
-                return
-            }
-            if (fn.moreFlags.isTemplate) {
+            if (fn.body == null || fn.at.fileInfo == null || fn.at.line == 0u
+                || fn.flags.generated || fn.fromGeneric != null
+                || fn._module != mod || fn.moreFlags.isTemplate) {
                 return
             }
             let fname = string(fn.at.fileInfo.name)
@@ -586,10 +784,8 @@ class StyleLintVisitor : AstVisitor {
             fn_private |> push(fn.flags.privateFunction)
         }
         for_each_structure(mod) $(var st) {
-            if (st.at.fileInfo == null || st.at.line == 0u) {
-                return
-            }
-            if (st.flags.generated || st._module != mod || st.flags.isTemplate) {
+            if (st.at.fileInfo == null || st.at.line == 0u
+                || st.flags.generated || st._module != mod || st.flags.isTemplate) {
                 return
             }
             var is_template_instance = false
@@ -632,10 +828,7 @@ class StyleLintVisitor : AstVisitor {
             }
         }
         for_each_global(mod) $(var v) {
-            if (v.at.fileInfo == null || v.at.line == 0u) {
-                return
-            }
-            if (v.flags.generated) {
+            if (v.at.fileInfo == null || v.at.line == 0u || v.flags.generated) {
                 return
             }
             let fname = string(v.at.fileInfo.name)
@@ -672,17 +865,12 @@ class StyleLintVisitor : AstVisitor {
         }
         var seen : table<string; bool>
         for_each_function(mod, "") $(var fn) {
-            if (fn.at.fileInfo == null || fn._module != mod) {
-                return
-            }
-            if (fn.flags.generated || fn.fromGeneric != null || fn.moreFlags.isTemplate) {
+            if (fn.at.fileInfo == null || fn._module != mod
+                || fn.flags.generated || fn.fromGeneric != null || fn.moreFlags.isTemplate) {
                 return
             }
             let fname = string(fn.at.fileInfo.name)
-            if (seen |> key_exists(fname)) {
-                return
-            }
-            if (!file_first_decl |> key_exists(fname)) {
+            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) {
                 return
             }
             seen |> insert(fname, true)
@@ -691,10 +879,8 @@ class StyleLintVisitor : AstVisitor {
                 fn_file, fn_starts, fn_ends, fn_private)
         }
         for_each_structure(mod) $(var st) {
-            if (st.at.fileInfo == null || st._module != mod) {
-                return
-            }
-            if (st.flags.generated || st.flags.isTemplate) {
+            if (st.at.fileInfo == null || st._module != mod
+                || st.flags.generated || st.flags.isTemplate) {
                 return
             }
             var is_template_instance = false
@@ -705,10 +891,7 @@ class StyleLintVisitor : AstVisitor {
                 return
             }
             let fname = string(st.at.fileInfo.name)
-            if (seen |> key_exists(fname)) {
-                return
-            }
-            if (!file_first_decl |> key_exists(fname)) {
+            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) {
                 return
             }
             seen |> insert(fname, true)
@@ -721,10 +904,7 @@ class StyleLintVisitor : AstVisitor {
                 return
             }
             let fname = string(en.at.fileInfo.name)
-            if (seen |> key_exists(fname)) {
-                return
-            }
-            if (!file_first_decl |> key_exists(fname)) {
+            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) {
                 return
             }
             seen |> insert(fname, true)
@@ -737,10 +917,7 @@ class StyleLintVisitor : AstVisitor {
                 return
             }
             let fname = string(v.at.fileInfo.name)
-            if (seen |> key_exists(fname)) {
-                return
-            }
-            if (!file_first_decl |> key_exists(fname)) {
+            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) {
                 return
             }
             seen |> insert(fname, true)
@@ -753,10 +930,7 @@ class StyleLintVisitor : AstVisitor {
                 return
             }
             let fname = string(value.at.fileInfo.name)
-            if (seen |> key_exists(fname)) {
-                return
-            }
-            if (!file_first_decl |> key_exists(fname)) {
+            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) {
                 return
             }
             seen |> insert(fname, true)
@@ -831,13 +1005,11 @@ class StyleLintVisitor : AstVisitor {
                           first_line_text : string;
                           fn_file : array<string>; fn_starts, fn_ends : array<uint>;
                           fn_private : array<bool>) : void {
-        if (line_count <= 1) {
-            return
-        }
-        if (block_start < first_decl_line) {
-            return
-        }
-        if (self->has_nolint_directive(first_line_text)) {
+        // Skip when the block is too short, lives before the first AST decl
+        // (module-leading docstring), or carries an explicit @nolint marker.
+        if (line_count <= 1
+            || block_start < first_decl_line
+            || self->has_nolint_directive(first_line_text)) {
             return
         }
         var enclosing_priv = false
@@ -888,7 +1060,7 @@ class StyleLintVisitor : AstVisitor {
         }
         return false if (inner == null || !(inner is ExprCall))
         var call = inner as ExprCall
-        if (call.name != "string" || length(call.arguments) < 1) {
+        if (call.name != "string" || empty(call.arguments)) {
             return false
         }
         var arg = call.arguments[0]

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -501,6 +501,111 @@ string reference.
         pos = find(s, "foo")
     }
 
+PERF013 — ``a += 1`` / ``a -= 1`` should be ``a++`` / ``a--``
+=============================================================
+
+``a += 1`` lowers to a 2-node read-modify-write in interpreted mode. The
+postfix ``++`` / ``--`` collapses to a single ``SimNode_op1`` and reads as
+the canonical inc/dec idiom. Applies to the six numeric workhorse scalars
+(``int``, ``uint``, ``int64``, ``uint64``, ``float``, ``double``); vectors
+(``int2``, ``float3``, …) do **not** support ``++``/``--`` so they are
+skipped. ``+= -1`` is also flagged (same effect as ``-= 1``).
+
+.. code-block:: das
+
+    // Bad
+    a += 1                                      // PERF013
+    a -= 1                                      // PERF013
+    a += -1                                     // PERF013
+
+    // Good
+    a ++
+    a --
+
+PERF014 — closed-interval char-class range check
+==================================================
+
+Hand-rolled ranges like ``c >= 'a' && c <= 'z'`` reimplement
+``strings::is_alpha``/``is_alnum``/``is_number``/``is_white_space``/etc.
+The helper functions read clearer and centralise locale/codepoint
+behaviour. Only three closed ranges are flagged:
+
+* ``'0'..'9'`` (48..57) — ``is_number``
+* ``'a'..'z'`` (97..122) — ``is_alpha`` lower half
+* ``'A'..'Z'`` (65..90) — ``is_alpha`` upper half
+
+The hex extras ``'a'..'f'`` / ``'A'..'F'`` are deliberately **not**
+flagged — ``is_hex`` is broader. Open intervals (``c > '0' && c < '9'``)
+have different endpoints, so they are also skipped.
+
+.. code-block:: das
+
+    // Bad
+    if (c >= 'a' && c <= 'z') { ... }           // PERF014
+    if (c >= 48  && c <= 57)  { ... }           // PERF014 (raw int form)
+
+    // Good
+    if (is_alpha(c))  { ... }
+    if (is_number(c)) { ... }
+
+PERF015 — ternary min / max
+============================
+
+``a < b ? a : b`` reimplements ``min(a, b)``. The math builtins are
+vec-friendly and the intent is clearer. All eight orientations of
+``< / <= / > / >=`` × ``T==L,F==R`` / ``T==R,F==L`` are flagged.
+
+.. code-block:: das
+
+    // Bad
+    let smaller = a < b ? a : b                 // PERF015 — min
+    let larger  = a > b ? a : b                 // PERF015 — max
+
+    // Good
+    let smaller = min(a, b)
+    let larger  = max(a, b)
+
+PERF016 — ternary abs
+======================
+
+``x < 0 ? -x : x`` reimplements ``abs(x)``. ``abs`` exists for every
+signed numeric type. Only the four orientations that match ``abs`` are
+flagged; the negabs shape (``x < 0 ? x : -x``) is **not** — it is a
+different function.
+
+.. code-block:: das
+
+    // Bad
+    let positive = x < 0 ? -x : x               // PERF016
+    let positive_alt = x > 0 ? x : -x           // PERF016
+
+    // Good
+    let positive = abs(x)
+
+PERF017 — ``length(s) == 0`` should be ``empty(s)``
+====================================================
+
+For strings, ``length`` walks the whole string (``strlen``); ``empty``
+checks one byte. For arrays/tables both are O(1) but ``empty`` is the
+idiomatic form. Six comparison ops are mapped to either ``empty(x)`` or
+``!empty(x)``:
+
+* ``length(x) == 0``, ``length(x) <= 0``, ``length(x) < 1`` → ``empty(x)``
+* ``length(x) != 0``, ``length(x) > 0``,  ``length(x) >= 1`` → ``!empty(x)``
+
+Vector magnitude (``length(float3_var)`` from the math module) is **not**
+flagged — different semantics, no ``empty`` for vectors.
+
+.. code-block:: das
+
+    // Bad
+    if (length(s)   == 0) { ... }               // PERF017
+    if (length(arr) >  0) { ... }               // PERF017
+
+    // Good
+    if (empty(s))   { ... }
+    if (!empty(arr)) { ... }
+
 .. _style_lint:
 
 -----------
@@ -755,6 +860,92 @@ block.
         // single WHY line — silent
         ...
     }
+
+STYLE016 — adjacent guards leading to identical early-exit
+============================================================
+
+Two adjacent ``if`` guards with the same exit (``return`` with the same
+payload, or ``break``/``continue``) read as one decision. Combine them
+with ``||``. Two AST shapes are detected:
+
+* two adjacent ``if (a) { return X }`` statements in the same block
+* the ``if (a) { return X } else if (b) { return X }`` chain
+
+.. code-block:: das
+
+    // Bad
+    if (name == "." || name == "..") {          // STYLE016
+        return
+    }
+    if (name |> starts_with("_")) {
+        return
+    }
+
+    // Good
+    if (name == "." || name == ".." || name |> starts_with("_")) {
+        return
+    }
+
+STYLE017 — ``if (cond) return true; else return false`` should be ``return cond``
+==================================================================================
+
+Three lines (or two if-else branches) that just propagate the boolean
+condition unchanged. Read better as a single ``return``. Detection covers
+both forms:
+
+* ``if (cond) return b1 else return b2`` (b1 ≠ b2)
+* ``if (cond) return b1`` immediately followed by ``return b2`` (b1 ≠ b2)
+
+.. code-block:: das
+
+    // Bad
+    if (cond) {                                 // STYLE017
+        return true
+    } else {
+        return false
+    }
+
+    // Good
+    return cond
+
+    // Good (negated)
+    return !cond
+
+STYLE018 — redundant boolean comparison
+========================================
+
+Comparing a bool to a boolean literal is redundant — the bool already IS
+the value. Drop the comparison. Both Yoda forms (``true == flag``) are
+detected.
+
+.. code-block:: das
+
+    // Bad
+    if (flag == true)  { ... }                  // STYLE018
+    if (flag != false) { ... }                  // STYLE018
+    if (flag == false) { ... }                  // STYLE018
+    if (true == flag)  { ... }                  // STYLE018 (Yoda)
+
+    // Good
+    if (flag)  { ... }
+    if (!flag) { ... }
+
+STYLE019 — nested ``min(max(...))`` should be ``clamp(...)``
+==============================================================
+
+``min(max(x, lo), hi)`` reads as a clamp; the math builtin says so
+directly. Both orientations (and the mirror form) are detected — the
+inner call must resolve to the math module's ``min`` / ``max``, not a
+user overload.
+
+.. code-block:: das
+
+    // Bad
+    let bounded = min(max(x, lo), hi)           // STYLE019
+    let bounded_alt = max(min(x, hi), lo)       // STYLE019 (mirror)
+
+    // Good
+    let bounded = clamp(x, lo, hi)
 
 -----
 Tests

--- a/mouse-data/docs/why-does-expr-left-give-me-an-expression-const-i-can-t-reassign-or-pass-to-a-non-const-helper.md
+++ b/mouse-data/docs/why-does-expr-left-give-me-an-expression-const-i-can-t-reassign-or-pass-to-a-non-const-helper.md
@@ -1,0 +1,47 @@
+---
+slug: why-does-expr-left-give-me-an-expression-const-i-can-t-reassign-or-pass-to-a-non-const-helper
+title: Why does `expr.left` give me an `Expression? const` I can't reassign or pass to a non-const helper?
+created: 2026-05-08
+last_verified: 2026-05-08
+links: []
+---
+
+When a function parameter is **not** declared `var`, gen2 propagates const through every accessor. So in `def override preVisitExprOp2(expr : ExprOp2?)`, the type of `expr.left` is `Expression? const` — a constant pointer. Two failure modes:
+
+1. **Helper signature mismatch**: passing `expr.left` to `def helper(e : Expression?)` fails with `error[30187]: incompatible argument 2 ... ast_core::Expression const?& vs ast_core::Expression? const`.
+2. **Local reassignment**: `var x = expr.left ; x = (x as ExprRef2Value.subexpr)` fails with `error[30915]: can only copy compatible type ; ... -const = ... const&`.
+
+Two fixes, picked by what the call site needs:
+
+```
+// (a) If the helper only READS the expr, declare its param as `Expression? const`:
+def expr_equal_struct(a : Expression? const ; b : Expression? const) : bool { ... }
+
+// (b) If the *visitor* needs mutable access (writing to fields), take the
+// override param as `var`. Then expr.left is non-const all the way down:
+def override preVisitExprOp2(var expr : ExprOp2?) : void { ... }
+```
+
+For the local-reassignment case, prefer chaining helpers that take/return `Expression? const`:
+
+```
+def peel_ref2value(e : Expression? const) : Expression? const {
+    if (e != null && e is ExprRef2Value) {
+        return (e as ExprRef2Value.subexpr)
+    }
+    return e
+}
+let lhs = self->peel_ref2value(expr.left)   // lhs is `Expression? const`, immutable
+```
+
+Avoid `unsafe(reinterpret<Expression?>(...))` to strip const — it works but it's the wrong tool. Reach for it only when you genuinely cannot make the parent `var`.
+
+Related: visitor override signatures (`preVisitExprOp2`, `preVisitExprIfThenElse`, etc.) are usually **non-`var`** by convention, even though daslib's own visitors sometimes use `var` selectively when they mutate. Match the existing pattern in the file you're editing.
+
+## Questions
+- Why does `expr.left` give me an `Expression? const` I can't reassign or pass to a non-const helper?
+- expr.left const propagation
+- ast_core::Expression const?& vs Expression? const error 30187
+- why can't I assign expr.left to a local var
+- visitor parameter const stripping AST
+- error 30915 can only copy compatible type Expression

--- a/mouse-data/docs/why-does-my-single-line-if-cond-return-x-get-a-parse-error.md
+++ b/mouse-data/docs/why-does-my-single-line-if-cond-return-x-get-a-parse-error.md
@@ -1,0 +1,32 @@
+---
+slug: why-does-my-single-line-if-cond-return-x-get-a-parse-error
+title: Why does my single-line `if (cond) { return X }` get a parse error?
+created: 2026-05-08
+last_verified: 2026-05-08
+links: []
+---
+
+gen2's grammar requires a statement separator (newline or `;`) before `}` in an `if`-body. A bare `if (cond) { return false }` on one line fails with `error[30151]: syntax error, unexpected '}', expecting if` — the `if` it's expecting is the postfix-conditional form (`return X if (cond)`), and `}` is neither that nor a newline.
+
+Two fixes:
+
+```
+// Multiline (canonical):
+if (cond) {
+    return false
+}
+
+// Same-line with explicit terminator:
+if (cond) { return false; }
+```
+
+The same caveat applies to `if`-`elif` chains: `} elif (cond)` works on a single line because `}` is followed by another keyword, but `if (cond) { stmt }\nelif (cond) { ... }` (newline before `elif`) does not — gen2 wants `}` and `elif` adjacent.
+
+The `||` / `&&` line-continuation rule is related but separate: `return a\n   || b` doesn't parse at statement level (CLAUDE.md says newlines are only free inside `(...)` / `[...]` / `{...}`). Wrap the RHS in parens to break across lines.
+
+## Questions
+- Why does my single-line `if (cond) { return X }` get a parse error?
+- gen2 single-line if return parse error
+- error 30151 unexpected } expecting if
+- why doesn't `if (x) { return false }` parse on one line
+- gen2 if body needs newline before closing brace

--- a/skills/perf_lint.md
+++ b/skills/perf_lint.md
@@ -118,3 +118,14 @@ After compilation, `Expression._type` is resolved. Check `expr._type.baseType ==
 | PERF010 | `get_ptr(x) == null` | Low | unnecessary; smart_ptr supports == null directly |
 | PERF011 | `get_ptr(x).field` | Low | unnecessary; smart_ptr auto-dereferences for field access |
 | PERF012 | `find(string(das_string), ...)` | Medium | unnecessary allocation; use `peek(das_string)` instead |
+| PERF013 | `a += 1` / `a -= 1` (six numeric scalars) | Low | use postfix `a++` / `a--` (single SimNode, idiomatic) |
+| PERF014 | closed-interval char-class range (`'0'..'9'` / `'a'..'z'` / `'A'..'Z'`) | Info | use `strings::is_alpha` / `is_alnum` / `is_number` |
+| PERF015 | ternary min/max (`a < b ? a : b`) | Low | use `math::min(a, b)` / `max(a, b)` |
+| PERF016 | ternary abs (`x < 0 ? -x : x`) | Low | use `math::abs(x)` (negabs `x < 0 ? x : -x` not flagged) |
+| PERF017 | `length(x) == 0` / `> 0` / `>= 1` etc. | Medium | use `empty(x)` / `!empty(x)`; avoids strlen on strings |
+
+## Visitor gotchas
+
+- **`in_closure > 0` is NOT a useful guard in `preVisitExprOp2`** — `loop_depth` already doesn't increment inside closure bodies (`preVisitExprFor` / `While` gate on `in_closure == 0`), so PERF001's `loop_depth > 0` correctly excludes closure-internal loops without a separate skip. An `in_closure` early-return at the top of `preVisitExprOp2` hides syntactic patterns (PERF007/008/010/013/014/017) inside the natural `build_string() $(var w) { ... }` idiom and is a bug, not a feature.
+- **Macro-generated functions need `current_function.flags.generated`-suppression** — `[CommandLineArgs]`-style codegen synthesizes AST that the user never wrote. Both `perf_warning` and `style_warning` should early-return when `current_function.flags.generated` is true. Otherwise warnings surface at the source-struct's line with no clear way to fix them.
+- **Self-implementation suppression** — when a rule's suggested replacement is itself implemented in terms of the pattern (e.g. `empty(arr)`'s body is literally `length(arr) == 0`), gate the rule with `current_function.name == "<callee>" || (fromGeneric != null && fromGeneric.name == "<callee>")`. The generic-instantiation arm catches `empty<int>`, `empty<MyType>`, etc.

--- a/skills/style_lint.md
+++ b/skills/style_lint.md
@@ -28,6 +28,10 @@ The `style_lint` module detects non-idiomatic patterns in daslang code at compil
 | STYLE013 | `var a = Foo(); a.x = 1; a.y = 2` (or `var a : Foo` for `[safe_when_uninitialized]` structs), ≥ 2 contiguous field assignments | Use a named-argument constructor: `var a = Foo(x = 1, y = 2)`. Skipped when init is non-empty (`Foo(x=1)` then `a.y = 2` stays silent), when assignments are not contiguous, or for `inscope`/generated/generic-instantiation vars |
 | STYLE014 | `//` or `//!` comment block of more than 3 contiguous lines at module/public scope | Trim to a 1-line WHY (move design notes to a `.md` doc, not source). Module-leading docstring (block before any AST decl in the file) is always allowed. Suppress per-block with `//!@nolint` on first line of a `//!` block (also stripped from generated RST), or `// nolint:STYLE014` on first line of a `//` block. **Opt-in via `options _comment_hygiene = true`** (disabled by default). |
 | STYLE015 | `//` or `//!` comment block of more than 1 contiguous line inside a `def private` | Private symbols don't surface in any doc generator, so multi-line prose there is dead weight. Trim to one line, or suppress on first line with `// nolint:STYLE015`. **Opt-in via `options _comment_hygiene = true`** (disabled by default). |
+| STYLE016 | adjacent `if (a) { return X }` / `if (b) { return X }` (or else-chained form) with the same payload | Combine with `\|\|`. Detection covers both `(a) two adjacent ExprIfThenElse statements` and `(b) if/else if chain`. Bare `break`/`continue` payloads count as equal; `return` payloads are structurally compared. |
+| STYLE017 | `if (cond) return true; else return false` (and the inverse) | Use `return cond` / `return !cond`. Two AST shapes: if-else with bool-literal returns, and `if (cond) { return b1 }` followed immediately by `return b2` (b1 != b2). |
+| STYLE018 | `b == true` / `b == false` / `b != true` / `b != false` (and Yoda forms) | Use `b` / `!b` directly. Skipped when both sides are bool literals (e.g. `true == true`). |
+| STYLE019 | `min(max(x, lo), hi)` (and the `max(min(x, hi), lo)` mirror) | Use `clamp(x, lo, hi)` from math module. Inner/outer must resolve to math::min/max specifically, not user overloads. |
 
 Note: `get_ptr()` related patterns (null comparison, field access) are in `perf_lint` as PERF010/PERF011 since they have performance implications.
 
@@ -110,4 +114,4 @@ bin/Release/daslang.exe utils/lint/main.das -- file1.das [file2.das ...] [--quie
 ## Known Limitations
 
 - **STYLE001-003 source detection**: Uses `get_file_source_line()` which reads one line at a time. Multi-line call expressions are handled by scanning from the call's line to the block's line.
-- **`[lint_macro]` errors vs `expect`**: Style warnings emitted via `[lint_macro]` don't work with `expect` directives. Tests use the standalone runner instead.
+- **`[lint_macro]` errors vs `expect`**: works (both for `expect 31208:N` and `expect 31209:N`). The earlier limitation note here was stale; STYLE016/017/018/019 tests under `utils/lint/tests/` validate exact warning counts via dastest exactly the same way PERF tests do.

--- a/utils/lint/main.das
+++ b/utils/lint/main.das
@@ -112,10 +112,7 @@ def scan_das_files(path : string; var files : array<string>; var cache : table<s
         return
     }
     fio::dir(path) $(name) {
-        if (name == "." || name == "..") {
-            return
-        }
-        if (name |> starts_with("_") || is_skip_dir(name)) {
+        if (name == "." || name == ".." || name |> starts_with("_") || is_skip_dir(name)) {
             return
         }
         let full = "{path}/{name}"
@@ -198,7 +195,7 @@ def main() : int {
             paths |> push(arg)
         }
     }
-    if (length(paths) == 0) {
+    if (empty(paths)) {
         print("Error: no files or directories specified\n\n")
         print_help(get_command_info(type<Config>), "utils/lint/main.das")
         return 1
@@ -213,7 +210,7 @@ def main() : int {
     for (p in paths) {
         scan_das_files(p, files, cache)
     }
-    if (length(files) == 0) {
+    if (empty(files)) {
         print("Error: no .das files found\n")
         return 1
     }

--- a/utils/lint/tests/perf013_inc_dec.das
+++ b/utils/lint/tests/perf013_inc_dec.das
@@ -1,0 +1,124 @@
+options gen2
+// PERF013: a += 1 / a -= 1 should be a++ / a--
+//
+// Problem:
+//   `a += 1` and `a -= 1` are 2-node operations in interpreted mode (read,
+//   add/sub, write). The postfix `++` / `--` collapses to a single SimNode.
+//   The +=/-= form also reads worse than the canonical inc/dec idiom.
+//
+// All four (op, ±RHS) combinations are flagged; the diagnostic suggests
+// `++` for delta=+1 and `--` for delta=-1:
+//
+//   a += 1   → ++  (delta +1)
+//   a -= 1   → --  (delta -1)
+//   a += -1  → --  (delta -1, same as a -= 1)
+//   a -= -1  → ++  (delta +1, same as a += 1)
+//
+// Bad pattern:
+//   a += 1
+//   a -= 1
+//
+// Good pattern:
+//   a++
+//   a--
+
+// 6 numeric scalar types × 2 ops × 2 RHS signs would explode; this file
+// covers the int and float paths plus the four signed-only neg-one cases
+// (uint/uint64 omit -1 since negative literals don't apply).
+expect 31208:12
+
+require daslib/perf_lint
+
+// --- Bad patterns: int (4 combos) ---
+
+def bad_int_plus_one() : int {
+    var a = 0
+    a += 1                                     // PERF013 — suggests ++
+    return a
+}
+
+def bad_int_minus_one() : int {
+    var a = 0
+    a -= 1                                     // PERF013 — suggests --
+    return a
+}
+
+def bad_int_plus_neg_one() : int {
+    var a = 0
+    a += -1                                    // PERF013 — suggests -- (same as -= 1)
+    return a
+}
+
+def bad_int_minus_neg_one() : int {
+    var a = 0
+    a -= -1                                    // PERF013 — suggests ++ (same as += 1)
+    return a
+}
+
+// --- Bad patterns: float (4 combos) ---
+
+def bad_float_plus_one() : float {
+    var x = 0.0
+    x += 1.0                                   // PERF013 — suggests ++
+    return x
+}
+
+def bad_float_minus_one() : float {
+    var x = 0.0
+    x -= 1.0                                   // PERF013 — suggests --
+    return x
+}
+
+def bad_float_plus_neg_one() : float {
+    var x = 0.0
+    x += -1.0                                  // PERF013 — suggests --
+    return x
+}
+
+def bad_float_minus_neg_one() : float {
+    var x = 0.0
+    x -= -1.0                                  // PERF013 — suggests ++
+    return x
+}
+
+// --- Bad patterns: other workhorse numeric types ---
+
+def bad_int64() : int64 {
+    var a = 0l
+    a += 1l                                    // PERF013 — suggests ++
+    return a
+}
+
+def bad_uint() : uint {
+    var a = 0u
+    a += 1u                                    // PERF013 — suggests ++
+    return a
+}
+
+def bad_uint64() : uint64 {
+    var a = 0ul
+    a += 1ul                                   // PERF013 — suggests ++
+    return a
+}
+
+def bad_double() : double {
+    var x = 0.0lf
+    x += 1.0lf                                 // PERF013 — suggests ++
+    return x
+}
+
+// --- Good patterns (no warnings) ---
+
+def good_postfix() : int {
+    var a = 0
+    a ++
+    a --
+    return a
+}
+
+def good_step_other() : int {
+    var a = 0
+    a += 2                                     // step != 1 — no warning
+    a -= 5
+    return a
+}

--- a/utils/lint/tests/perf014_char_class_range.das
+++ b/utils/lint/tests/perf014_char_class_range.das
@@ -1,0 +1,86 @@
+options gen2
+// PERF014: closed-interval char-class range checks
+//
+// Problem:
+//   Hand-written ranges like `c >= 'a' && c <= 'z'` reimplement the strings
+//   module's is_alpha/is_alnum/is_number/is_white_space/etc. helpers. Using
+//   the helper makes intent obvious and lets future codepoint widening
+//   propagate automatically.
+//
+// Bad pattern:
+//   if (c >= 'a' && c <= 'z') { ... }
+//   if (c >= 48  && c <= 57)  { ... }       // '0'..'9' as raw int
+//
+// Good pattern:
+//   if (is_alpha(c))   { ... }              // covers a-z, A-Z (and your locale)
+//   if (is_number(c))  { ... }
+//
+// Hex extras ('a'..'f' / 'A'..'F') deliberately do NOT trigger — is_hex is
+// broader and would change behavior for the digit half.
+
+expect 31208:5
+
+require daslib/perf_lint
+require strings
+
+// --- Bad patterns (PERF014) ---
+
+def bad_lower_alpha(c : int) : bool {
+    return c >= 'a' && c <= 'z'                // PERF014
+}
+
+def bad_upper_alpha(c : int) : bool {
+    return c >= 'A' && c <= 'Z'                // PERF014
+}
+
+def bad_digits_char(c : int) : bool {
+    return c >= '0' && c <= '9'                // PERF014
+}
+
+def bad_digits_int(c : int) : bool {
+    return c >= 48 && c <= 57                  // PERF014 (raw int form)
+}
+
+def bad_yoda_form(c : int) : bool {
+    return 'a' <= c && c <= 'z'                // PERF014 (mixed const-on-left)
+}
+
+// --- Good patterns (no warnings) ---
+
+def good_is_alpha(c : int) : bool {
+    return is_alpha(c)
+}
+
+def good_hex_lower(c : int) : bool {
+    return c >= 'a' && c <= 'f'                // hex range — NOT flagged
+}
+
+def good_hex_upper(c : int) : bool {
+    return c >= 'A' && c <= 'F'                // hex range — NOT flagged
+}
+
+def good_open_range(c : int) : bool {
+    return c > '0' && c < '9'                  // open interval — NOT flagged
+}
+
+def good_partial_range(c : int) : bool {
+    return c >= 'a' && c <= 'b'                // not a known class — NOT flagged
+}
+
+def good_different_vars(a, b : int) : bool {
+    return a >= 'a' && b <= 'z'                // two different vars — NOT flagged
+}
+
+// Side-effectful subexpressions: replacing `f() >= 'a' && f() <= 'z'` with
+// `is_alpha(f())` would call f() once instead of twice — silently changing
+// semantics. The rule must NOT fire when operands aren't pure.
+
+[unused_argument(c)]
+def impure_helper(c : int) : int {
+    print("called\n")                           // observable side effect
+    return c
+}
+
+def good_impure_call(c : int) : bool {
+    return impure_helper(c) >= 'a' && impure_helper(c) <= 'z'   // NOT flagged (impure)
+}

--- a/utils/lint/tests/perf015_ternary_minmax.das
+++ b/utils/lint/tests/perf015_ternary_minmax.das
@@ -1,0 +1,87 @@
+options gen2
+// PERF015: ternary min/max → min(a, b) / max(a, b)
+//
+// Problem:
+//   `a < b ? a : b` reimplements `min(a, b)`. Same for the four orientations.
+//   The math::min/max builtins are vec-friendly and the intent is clearer.
+//
+// Bad pattern:
+//   let smaller = a < b ? a : b
+//   let larger  = a > b ? a : b
+//
+// Good pattern:
+//   let smaller = min(a, b)
+//   let larger  = max(a, b)
+
+expect 31208:8
+
+require daslib/perf_lint
+require math
+
+// --- Bad patterns (PERF015) ---
+//   <  / <=  : T==L,F==R → min ;  T==R,F==L → max
+//   >  / >=  : T==L,F==R → max ;  T==R,F==L → min
+
+def bad_lt_min(a, b : int) : int {
+    return a < b ? a : b                          // PERF015 — min
+}
+
+def bad_lt_max(a, b : int) : int {
+    return a < b ? b : a                          // PERF015 — max
+}
+
+def bad_le_min(a, b : int) : int {
+    return a <= b ? a : b                         // PERF015 — min
+}
+
+def bad_le_max(a, b : int) : int {
+    return a <= b ? b : a                         // PERF015 — max
+}
+
+def bad_gt_max(a, b : int) : int {
+    return a > b ? a : b                          // PERF015 — max
+}
+
+def bad_gt_min(a, b : int) : int {
+    return a > b ? b : a                          // PERF015 — min
+}
+
+def bad_ge_max(a, b : int) : int {
+    return a >= b ? a : b                         // PERF015 — max
+}
+
+def bad_ge_min(a, b : int) : int {
+    return a >= b ? b : a                         // PERF015 — min
+}
+
+// --- Good patterns (no warnings) ---
+
+def good_min(a, b : int) : int {
+    return min(a, b)
+}
+
+def good_max(a, b : int) : int {
+    return max(a, b)
+}
+
+def good_asymmetric_branches(a, b, c : int) : int {
+    return a < b ? a : c                          // T != R — NOT flagged
+}
+
+def good_different_operands(a, b, c, d : int) : int {
+    return a < b ? c : d                          // condition operands ≠ branches
+}
+
+// Side-effectful operands: `f() < g() ? f() : g()` calls f() and g() up to twice;
+// `min(f(), g())` calls each exactly once. The rewrite would silently change the
+// number of calls, so the rule must NOT fire on impure operands.
+
+[unused_argument(x)]
+def impure_int(x : int) : int {
+    print("called\n")                             // observable side effect
+    return x
+}
+
+def good_impure_call(a, b : int) : int {
+    return impure_int(a) < impure_int(b) ? impure_int(a) : impure_int(b)   // NOT flagged (impure)
+}

--- a/utils/lint/tests/perf016_ternary_abs.das
+++ b/utils/lint/tests/perf016_ternary_abs.das
@@ -1,0 +1,74 @@
+options gen2
+// PERF016: ternary abs → abs(x)
+//
+// Problem:
+//   `x < 0 ? -x : x` reimplements `abs(x)`. abs() exists for all signed
+//   numeric types and reads more clearly.
+//
+// Bad pattern:
+//   let positive = x < 0 ? -x : x
+//   let positive_alt = x > 0 ? x : -x
+//
+// Good pattern:
+//   let positive = abs(x)
+//
+// `negabs(x)` (`x < 0 ? x : -x`) is NOT flagged — it's a different function.
+
+expect 31208:6
+
+require daslib/perf_lint
+require math
+
+// --- Bad patterns (PERF016) ---
+
+def bad_lt_zero(x : int) : int {
+    return x < 0 ? -x : x                          // PERF016
+}
+
+def bad_gt_zero(x : int) : int {
+    return x > 0 ? x : -x                          // PERF016
+}
+
+def bad_le_zero(x : int) : int {
+    return x <= 0 ? -x : x                         // PERF016
+}
+
+def bad_ge_zero(x : int) : int {
+    return x >= 0 ? x : -x                         // PERF016
+}
+
+def bad_yoda_zero_gt_x(x : int) : int {
+    return 0 > x ? -x : x                          // PERF016 (zero on left)
+}
+
+def bad_float(x : float) : float {
+    return x < 0.0 ? -x : x                        // PERF016
+}
+
+// --- Good patterns (no warnings) ---
+
+def good_abs(x : int) : int {
+    return abs(x)
+}
+
+def good_negabs(x : int) : int {
+    return x < 0 ? x : -x                          // negabs — NOT flagged
+}
+
+def good_unrelated(x, y : int) : int {
+    return x < 0 ? -y : y                          // branches reference y, not x
+}
+
+// Side-effectful operand: `f() < 0 ? -f() : f()` calls f() up to twice and
+// the two evaluations may even disagree on sign. `abs(f())` calls once. The
+// rule must NOT fire when the operand isn't pure.
+
+[unused_argument(x)]
+def impure_int(x : int) : int {
+    print("called\n")                              // observable side effect
+    return x
+}
+
+def good_impure_call(x : int) : int {
+    return impure_int(x) < 0 ? -impure_int(x) : impure_int(x)   // NOT flagged (impure)
+}

--- a/utils/lint/tests/perf017_length_zero.das
+++ b/utils/lint/tests/perf017_length_zero.das
@@ -1,0 +1,121 @@
+options gen2
+// PERF017: length(s) == 0 / != 0 → empty(s) / !empty(s)
+//
+// Problem:
+//   `length(string)` walks the whole string (strlen). `empty(string)` checks
+//   one byte. For arrays/tables both are O(1) but `empty` is the idiomatic
+//   form. The rule covers all six comparison ops with literal 0 / 1 on
+//   either side (Yoda forms supported).
+//
+// The diagnostic prints the canonical equivalent: `1 <= length(x)` is
+// equivalent to `length(x) >= 1`, so the message says
+// `'length(x) >= 1' — use '!empty(x)'` not `'length(x) <= 1'`.
+//
+// Bad pattern:
+//   if (length(s) == 0)   { ... }
+//   if (length(arr) > 0)  { ... }
+//
+// Good pattern:
+//   if (empty(s))         { ... }
+//   if (!empty(arr))      { ... }
+//
+// Vector magnitude `length(float3_var)` (math module) is NOT flagged —
+// different semantics and there's no `empty` for vectors.
+
+expect 31208:15
+
+require daslib/perf_lint
+require strings
+
+// --- Bad patterns (length on left) ---
+
+def bad_string_eq(s : string) : bool {
+    return length(s) == 0                      // PERF017 — empty
+}
+
+def bad_string_ne(s : string) : bool {
+    return length(s) != 0                      // PERF017 — !empty
+}
+
+def bad_string_le(s : string) : bool {
+    return length(s) <= 0                      // PERF017 — empty (length <= 0 ≡ length == 0)
+}
+
+def bad_string_gt(s : string) : bool {
+    return length(s) > 0                       // PERF017 — !empty
+}
+
+def bad_array_eq(a : array<int>) : bool {
+    return length(a) == 0                      // PERF017 — empty
+}
+
+def bad_array_ge_one(a : array<int>) : bool {
+    return length(a) >= 1                      // PERF017 — !empty (length >= 1 ≡ !empty)
+}
+
+def bad_array_lt_one(a : array<int>) : bool {
+    return length(a) < 1                       // PERF017 — empty (length < 1 ≡ empty)
+}
+
+// --- Bad patterns (Yoda — length on right; canonical-equivalent op) ---
+
+def bad_yoda_eq(s : string) : bool {
+    return 0 == length(s)                      // PERF017 — empty (canon: length == 0)
+}
+
+def bad_yoda_ne(s : string) : bool {
+    return 0 != length(s)                      // PERF017 — !empty (canon: length != 0)
+}
+
+def bad_yoda_ge_zero(s : string) : bool {
+    // 0 >= length(s) means length(s) <= 0, which is empty
+    return 0 >= length(s)                      // PERF017 — empty (canon: length <= 0)
+}
+
+def bad_yoda_lt_zero(s : string) : bool {
+    // 0 < length(s) means length(s) > 0, which is !empty
+    return 0 < length(s)                       // PERF017 — !empty (canon: length > 0)
+}
+
+def bad_yoda_le_one(a : array<int>) : bool {
+    // 1 <= length(a) means length(a) >= 1, which is !empty
+    return 1 <= length(a)                      // PERF017 — !empty (canon: length >= 1)
+}
+
+def bad_yoda_gt_one(a : array<int>) : bool {
+    // 1 > length(a) means length(a) < 1, which is empty
+    return 1 > length(a)                       // PERF017 — empty (canon: length < 1)
+}
+
+// --- Bad patterns: table ---
+
+def bad_table_eq(t : table<string; int>) : bool {
+    return length(t) == 0                      // PERF017 — empty
+}
+
+// --- Good patterns (no warnings) ---
+
+def good_empty(s : string) : bool {
+    return empty(s)
+}
+
+def good_string_len_other(s : string; n : int) : bool {
+    return length(s) == n                      // not 0/1 — NOT flagged
+}
+
+def good_length_three(s : string) : bool {
+    return length(s) == 3                      // not 0/1 — NOT flagged
+}
+
+// --- Bad: user code has a method literally named `empty` ---
+// The suppression for `current_function.name == "empty"` is gated on
+// _module.name == "builtin", so a user-defined empty() outside builtin still
+// gets linted. This is the regression guard for that gating.
+
+class UserContainer {
+    items : array<int>
+
+    def empty() : bool {
+        return length(items) == 0              // PERF017 — fires (NOT in builtin)
+    }
+}

--- a/utils/lint/tests/style016_adjacent_guards.das
+++ b/utils/lint/tests/style016_adjacent_guards.das
@@ -1,0 +1,128 @@
+options gen2
+// STYLE016: adjacent guards leading to identical early-exit can be combined with '||'
+//
+// Problem: Two adjacent if-guards with the same exit (return/break/continue with the
+// same payload) read as a single decision. Merging into one '||' gate is shorter and
+// makes the relationship explicit.
+//
+// Bad pattern:
+//   if (a) { return -1 }
+//   if (b) { return -1 }
+//
+// Good pattern:
+//   if (a || b) { return -1 }
+//
+// Detection covers two AST shapes:
+//   (a) two adjacent ExprIfThenElse statements in the same block
+//   (b) `if (a) { return X } else if (b) { return X }` chain
+
+expect 31209:7
+
+require daslib/style_lint
+
+// --- Bad patterns (warnings) ---
+
+def bad_adjacent_returns(a, b : int) : int {
+    if (a == 0) {                                  // STYLE016
+        return -1
+    }
+    if (b == 0) {
+        return -1
+    }
+    return 0
+}
+
+def bad_else_chain(a, b : int) : int {
+    if (a == 0) {                                  // STYLE016 (chained else-if form)
+        return -1
+    } elif (b == 0) {
+        return -1
+    }
+    return 0
+}
+
+def bad_break_pair() : void {
+    for (i in range(10)) {
+        if (i == 3) {                              // STYLE016
+            break
+        }
+        if (i == 5) {
+            break
+        }
+    }
+}
+
+def bad_continue_pair() : void {
+    for (i in range(10)) {
+        if (i % 2 == 0) {                          // STYLE016
+            continue
+        }
+        if (i % 3 == 0) {
+            continue
+        }
+    }
+}
+
+def bad_three_deep(a, b, c : int) : int {
+    if (a == 0) {                                  // STYLE016 (a-guard with b-guard)
+        return -1
+    }
+    if (b == 0) {                                  // STYLE016 (b-guard with c-guard)
+        return -1
+    }
+    if (c == 0) {
+        return -1
+    }
+    return 0
+}
+
+def bad_return_with_value(a, b : int) : int {
+    if (a == 0) {                                  // STYLE016 (same int payload)
+        return 42
+    }
+    if (b == 0) {
+        return 42
+    }
+    return 0
+}
+
+// --- Good patterns (no warnings) ---
+
+def good_combined(a, b : int) : int {
+    if (a == 0 || b == 0) {
+        return -1
+    }
+    return 0
+}
+
+def good_different_payload(a, b : int) : int {
+    if (a == 0) {
+        return -1
+    }
+    if (b == 0) {
+        return -2
+    }
+    return 0
+}
+
+def good_multi_stmt_body(a, b : int) : int {
+    if (a == 0) {
+        print("a is zero\n")
+        return -1
+    }
+    if (b == 0) {
+        return -1
+    }
+    return 0
+}
+
+def good_intervening(a, b : int) : int {
+    if (a == 0) {
+        return -1
+    }
+    print("a is non-zero\n")
+    if (b == 0) {
+        return -1
+    }
+    return 0
+}

--- a/utils/lint/tests/style017_bool_return.das
+++ b/utils/lint/tests/style017_bool_return.das
@@ -1,0 +1,80 @@
+options gen2
+// STYLE017: 'if (cond) return true; else return false' — use 'return cond'
+//
+// Problem: Three lines (or two if-else branches) that just propagate the boolean
+// condition unchanged. Read better as `return cond` / `return !cond`.
+//
+// Bad pattern:
+//   if (cond) {
+//       return true
+//   } else {
+//       return false
+//   }
+//
+// Good pattern:
+//   return cond
+//
+// Detection covers two AST shapes:
+//   (a) `if (cond) return b1 else return b2` (b1 != b2)
+//   (b) `if (cond) return b1` immediately followed by `return b2` (b1 != b2)
+
+expect 31209:4
+
+require daslib/style_lint
+require strings
+
+// --- Bad patterns ---
+
+def bad_if_else_true_false(c : bool) : bool {
+    if (c) {                                       // STYLE017 → return c
+        return true
+    } else {
+        return false
+    }
+}
+
+def bad_if_else_false_true(c : bool) : bool {
+    if (c) {                                       // STYLE017 → return !c
+        return false
+    } else {
+        return true
+    }
+}
+
+def bad_adjacent_true_false(c : bool) : bool {
+    if (c) {                                       // STYLE017 → return c
+        return true
+    }
+    return false
+}
+
+def bad_adjacent_false_true(c : bool) : bool {
+    if (c) {                                       // STYLE017 → return !c
+        return false
+    }
+    return true
+}
+
+// --- Good patterns (no warnings) ---
+
+def good_direct(c : bool) : bool {
+    return c
+}
+
+def good_negated(c : bool) : bool {
+    return !c
+}
+
+def good_same_value(c : bool) : bool {
+    if (c) {
+        return true                                // both true — different rule territory
+    }
+    return true
+}
+
+def good_compute(c : bool; n : int) : bool {
+    if (c) {
+        return n > 0
+    }
+    return false
+}

--- a/utils/lint/tests/style018_bool_compare.das
+++ b/utils/lint/tests/style018_bool_compare.das
@@ -1,0 +1,62 @@
+options gen2
+// STYLE018: redundant boolean comparison ('b == true' / 'b != false')
+//
+// Problem: Comparing a bool to a boolean literal is redundant — the bool already IS
+// the value. Drop the comparison.
+//
+// Bad pattern:
+//   if (flag == true)  { ... }
+//   if (flag != false) { ... }
+//
+// Good pattern:
+//   if (flag)          { ... }
+//   if (!flag)         { ... }
+
+expect 31209:6
+
+require daslib/style_lint
+require strings
+
+// --- Bad patterns ---
+
+def bad_eq_true(flag : bool) : bool {
+    return flag == true                            // STYLE018 → flag
+}
+
+def bad_eq_false(flag : bool) : bool {
+    return flag == false                           // STYLE018 → !flag
+}
+
+def bad_ne_true(flag : bool) : bool {
+    return flag != true                            // STYLE018 → !flag
+}
+
+def bad_ne_false(flag : bool) : bool {
+    return flag != false                           // STYLE018 → flag
+}
+
+def bad_yoda_eq_true(flag : bool) : bool {
+    return true == flag                            // STYLE018 (Yoda)
+}
+
+def bad_yoda_eq_false(flag : bool) : bool {
+    return false == flag                           // STYLE018 (Yoda)
+}
+
+// --- Good patterns (no warnings) ---
+
+def good_direct(flag : bool) : bool {
+    return flag
+}
+
+def good_negated(flag : bool) : bool {
+    return !flag
+}
+
+def good_two_bools(a, b : bool) : bool {
+    return a == b                                  // bool-bool compare — not flagged
+}
+
+def good_two_literals() : bool {
+    return true == true                            // both literals — not flagged
+}

--- a/utils/lint/tests/style019_clamp.das
+++ b/utils/lint/tests/style019_clamp.das
@@ -1,0 +1,53 @@
+options gen2
+// STYLE019: nested min/max → clamp(x, lo, hi)
+//
+// Problem: `min(max(x, lo), hi)` reads as a clamp; `clamp(x, lo, hi)` is a
+// math builtin that says so directly.
+//
+// Bad pattern:
+//   let bounded = min(max(x, lo), hi)
+//   let bounded_alt = max(min(x, hi), lo)
+//
+// Good pattern:
+//   let bounded = clamp(x, lo, hi)
+
+expect 31209:4
+
+require daslib/style_lint
+require math
+
+// --- Bad patterns ---
+
+def bad_min_max(x, lo, hi : int) : int {
+    return min(max(x, lo), hi)                     // STYLE019
+}
+
+def bad_max_min(x, lo, hi : int) : int {
+    return max(min(x, hi), lo)                     // STYLE019 (mirror form)
+}
+
+def bad_min_max_inner_second(x, lo, hi : int) : int {
+    return min(hi, max(x, lo))                     // STYLE019 — inner is arg[1]
+}
+
+def bad_min_max_float(x, lo, hi : float) : float {
+    return min(max(x, lo), hi)                     // STYLE019
+}
+
+// --- Good patterns (no warnings) ---
+
+def good_clamp(x, lo, hi : int) : int {
+    return clamp(x, lo, hi)
+}
+
+def good_min_only(a, b : int) : int {
+    return min(a, b)
+}
+
+def good_max_only(a, b : int) : int {
+    return max(a, b)
+}
+
+def good_three_arg_min_no_nested(x, y, z : int) : int {
+    return min(min(x, y), z)                       // not min(max ...) — NOT flagged
+}

--- a/utils/mouse/index.das
+++ b/utils/mouse/index.das
@@ -204,7 +204,7 @@ def rebuild(db : SqlRunner; root : string) : int {
                 Slug = doc.frontmatter.slug,
                 Text = combined,
                 Rank = 0.0f))
-            n += 1
+            n ++
         }
     }
     return n
@@ -222,10 +222,7 @@ def sanitize_fts5_query(q : string) : string {
         let n = length(q)
         for (i in range(n)) {
             let c = character_at(q, i)  // nolint:PERF003
-            let is_safe = ((c >= '0' && c <= '9') ||
-                           (c >= 'a' && c <= 'z') ||
-                           (c >= 'A' && c <= 'Z') ||
-                           c == ' ' || c == '*')
+            let is_safe = is_alnum(c) || c == ' ' || c == '*'
             if (is_safe) {
                 w |> write(slice(q, i, i + 1))
             } else {
@@ -267,7 +264,7 @@ def search(db : SqlRunner; query : string; k : int) : array<SearchHit> {
             meaningful |> push(w)
         }
     }
-    if (length(meaningful) == 0) {
+    if (empty(meaningful)) {
         return <- out
     }
     let or_query = meaningful |> join(" OR ")
@@ -325,7 +322,7 @@ def now_iso(db : SqlRunner) : string {
 
 def log_query(db : SqlRunner; question : string;
               hits : array<SearchHit>; source : string) {
-    let top = length(hits) > 0 ? hits[0].slug : ""
+    let top = !empty(hits) ? hits[0].slug : ""
     db |> insert(QueryLog(
         asked_at = now_iso(db),
         question = question,
@@ -365,7 +362,7 @@ def add_doc(db : SqlRunner; root : string;
     }
     if (!force) {
         var similar <- dupe_check(db, clean_question, 5)
-        if (length(similar) > 0) {
+        if (!empty(similar)) {
             outcome.similar <- similar
             outcome.created = false
             return <- outcome

--- a/utils/mouse/main.das
+++ b/utils/mouse/main.das
@@ -93,7 +93,7 @@ def cmd_ask(args : MouseArgs) {
     with_index_db(root) $(db) {
         let hits <- search(db, query, args.k)
         log_query(db, query, hits, "cli")
-        if (length(hits) == 0) {
+        if (empty(hits)) {
             print("(no results){HINT_NO_MATCH}\n")
             return
         }
@@ -139,12 +139,12 @@ def cmd_get(args : MouseArgs) {
         if (!empty(doc.frontmatter.last_verified)) {
             print("last_verified: {doc.frontmatter.last_verified}\n")
         }
-        if (length(doc.frontmatter.links) > 0) {
+        if (!empty(doc.frontmatter.links)) {
             let links_str = doc.frontmatter.links |> join(", ")
             print("links: {links_str}\n")
         }
         let froms <- linked_from(db, slug)
-        if (length(froms) > 0) {
+        if (!empty(froms)) {
             let froms_str = froms |> join(", ")
             print("linked from: {froms_str}\n")
         }
@@ -199,7 +199,7 @@ def cmd_log(args : MouseArgs) {
     let n = args.limit > 0 ? args.limit : 20
     with_index_db(root) $(db) {
         let rows <- recent_queries(db, n, args.misses)
-        if (length(rows) == 0) {
+        if (empty(rows)) {
             print("(no queries logged yet)\n")
             return
         }
@@ -332,7 +332,7 @@ def tool_ask(args : JsonValue?) : string {
     with_index_db(root) $(db) {
         let hits <- search(db, question, k)
         log_query(db, question, hits, "mcp")
-        if (length(hits) == 0) {
+        if (empty(hits)) {
             output = "(no results for: {question}){HINT_NO_MATCH}"
             return
         }
@@ -422,11 +422,11 @@ def tool_get(args : JsonValue?) : string {
             if (!empty(doc.frontmatter.last_verified)) {
                 w |> write("last_verified: {doc.frontmatter.last_verified}\n")
             }
-            if (length(doc.frontmatter.links) > 0) {
+            if (!empty(doc.frontmatter.links)) {
                 let links_str = doc.frontmatter.links |> join(", ")
                 w |> write("links: {links_str}\n")
             }
-            if (length(froms) > 0) {
+            if (!empty(froms)) {
                 let froms_str = froms |> join(", ")
                 w |> write("linked from: {froms_str}\n")
             }

--- a/utils/mouse/store.das
+++ b/utils/mouse/store.das
@@ -35,10 +35,8 @@ struct ParsedDoc {
 def private parse_inline_list(value : string) : array<string> {
     var out : array<string>
     let trimmed = strip(value)
-    if (length(trimmed) < 2) {
-        return <- out
-    }
-    if (first_character(trimmed) != '[' || character_at(trimmed, length(trimmed) - 1) != ']') {  // nolint:PERF003
+    // The trailing-`]` check uses character_at to keep the guard a one-liner.
+    if (length(trimmed) < 2 || first_character(trimmed) != '[' || character_at(trimmed, length(trimmed) - 1) != ']') {  // nolint:PERF003
         return <- out
     }
     let inner = slice(trimmed, 1, length(trimmed) - 1)
@@ -69,7 +67,7 @@ def private parse_kv_line(line : string; var key : string&; var value : string&)
 // closing fence, returns whole input with parse_error set.
 def parse_frontmatter_text(text : string; var fm : Frontmatter) : tuple<body : string; parse_error : string> {
     let lines <- split(text, "\n")
-    if (length(lines) == 0) {
+    if (empty(lines)) {
         return (body = "", parse_error = "")
     }
     if (strip(lines[0]) != "---") {
@@ -154,8 +152,8 @@ def slug_from_title(title : string) : string {
         let n = length(lower)
         for (i in range(n)) {
             let c = character_at(lower, i)  // nolint:PERF003
-            let is_alnum = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')
-            if (is_alnum) {
+            // `lower` is already lowercased, so is_alnum's uppercase half can never match — equivalent to the explicit ranges.
+            if (is_alnum(c)) {
                 w |> write(slice(lower, i, i + 1))
                 prev_dash = false
             } elif (!prev_dash) {
@@ -167,10 +165,10 @@ def slug_from_title(title : string) : string {
     var s = 0
     var e = length(raw)
     while (s < e && character_at(raw, s) == '-') {  // nolint:PERF003
-        s += 1
+        s ++
     }
     while (e > s && character_at(raw, e - 1) == '-') {  // nolint:PERF003
-        e -= 1
+        e --
     }
     // Cap to MAX_SLUG_LEN so a long title can't produce a slug that
     // `is_valid_slug` later rejects (making the doc unfetchable). Re-trim
@@ -178,7 +176,7 @@ def slug_from_title(title : string) : string {
     if (e - s > MAX_SLUG_LEN) {
         e = s + MAX_SLUG_LEN
         while (e > s && character_at(raw, e - 1) == '-') {  // nolint:PERF003
-            e -= 1
+            e --
         }
     }
     return s < e ? slice(raw, s, e) : ""
@@ -195,15 +193,19 @@ def is_valid_slug(s : string) : bool {
     }
     var ok = true
     peek_data(s) $(bytes) {
+        // Slugs must be lowercase-only — using is_alnum here would silently allow
+        // uppercase letters and break the on-disk filename round-trip on
+        // case-sensitive filesystems. The explicit ranges intentionally reject
+        // uppercase, so the broader is_alnum() helper is wrong here.
         let first = int(bytes[0])
-        let first_ok = (first >= '0' && first <= '9') || (first >= 'a' && first <= 'z')
+        let first_ok = (first >= '0' && first <= '9') || (first >= 'a' && first <= 'z')  // nolint:PERF014
         if (!first_ok) {
             ok = false
             return
         }
         for (b in bytes) {
             let c = int(b)
-            let valid = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || c == '-' || c == '_'
+            let valid = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || c == '-' || c == '_'  // nolint:PERF014
             if (!valid) {
                 ok = false
                 return

--- a/utils/mouse/tests/test_index.das
+++ b/utils/mouse/tests/test_index.das
@@ -44,7 +44,7 @@ def seed_doc(t : T?; root : string;
         if (!empty(body) && character_at(body, length(body) - 1) != '\n') {  // nolint:PERF003
             w |> write("\n")
         }
-        if (length(questions) > 0) {
+        if (!empty(questions)) {
             w |> write("\n## Questions\n")
             for (q in questions) {
                 w |> write("- {q}\n")
@@ -286,7 +286,7 @@ def test_search_handles_tab_in_query(t : T?) {
         rebuild(db, root)
         let hits <- search(db, "alpha\tgamma", 5)
         hits_count = length(hits)
-        if (length(hits) > 0) {
+        if (!empty(hits)) {
             top_slug = hits[0].slug
         }
     }
@@ -315,7 +315,7 @@ def test_links_table_populated(t : T?) {
         }
     }
     t |> equal(length(links), 1)
-    if (length(links) >= 1) {
+    if (!empty(links)) {
         t |> equal(links[0].from_slug, "doc-a")
         t |> equal(links[0].to_slug, "other-slug")
     }
@@ -554,7 +554,7 @@ def test_rebuild_skips_basename_slug_mismatch(t : T?) {
     }
     t |> equal(n, 1)  // only `good`; mismatched-basename doc skipped
     t |> equal(length(slugs), 1)
-    if (length(slugs) >= 1) {
+    if (!empty(slugs)) {
         t |> equal(slugs[0], "good")
     }
     cleanup_root(root)
@@ -579,7 +579,7 @@ def test_search_handles_uppercase_fts_keywords(t : T?) {
         rebuild(db, root)
         let hits <- search(db, "alpha OR bravo", 5)
         hits_count = length(hits)
-        if (length(hits) > 0) {
+        if (!empty(hits)) {
             top_slug = hits[0].slug
         }
     }
@@ -621,7 +621,7 @@ def test_rebuild_skips_invalid_frontmatter_slug(t : T?) {
     }
     t |> equal(n, 1)  // only `good` indexed; bad-slug doc skipped
     t |> equal(length(slugs), 1)
-    if (length(slugs) >= 1) {
+    if (!empty(slugs)) {
         t |> equal(slugs[0], "good")
     }
     cleanup_root(root)
@@ -662,7 +662,7 @@ def test_log_query_records_hit(t : T?) {
         rows <- _sql(db |> select_from(type<QueryLog>))
     }
     t |> equal(length(rows), 1)
-    if (length(rows) >= 1) {
+    if (!empty(rows)) {
         t |> equal(rows[0].question, "typefunction")
         t |> equal(rows[0].source, "cli")
         t |> success(rows[0].match_count >= 1, "match_count populated")
@@ -689,7 +689,7 @@ def test_log_query_records_miss(t : T?) {
         rows <- _sql(db |> select_from(type<QueryLog>))
     }
     t |> equal(length(rows), 1)
-    if (length(rows) >= 1) {
+    if (!empty(rows)) {
         t |> equal(rows[0].match_count, 0)
         t |> equal(rows[0].top_slug, "")
         t |> equal(rows[0].source, "mcp")


### PR DESCRIPTION
## Summary

Adds 9 new lint rules that surface common micro-anti-patterns:

**Performance (`daslib/perf_lint.das`)**
- **PERF013** — `a += 1` / `a -= 1` → `a++` / `a--` (six numeric workhorse scalars; vectors don't support `++`/`--` so they're skipped)
- **PERF014** — closed-interval char-class range (`c >= '0' && c <= '9'`, `'a'..'z'`, `'A'..'Z'`) → `strings::is_alpha` / `is_alnum` / `is_number`. Hex extras (`'a'..'f'` / `'A'..'F'`) deliberately not flagged — `is_hex` is broader.
- **PERF015** — ternary min/max (`a < b ? a : b` → `min(a, b)`). All eight `< / <= / > / >=` × `T==L,F==R` / `T==R,F==L` orientations covered.
- **PERF016** — ternary abs (`x < 0 ? -x : x` → `abs(x)`). Negabs (`x < 0 ? x : -x`) is **not** flagged — different function.
- **PERF017** — `length(x) == 0` → `empty(x)` and friends. Six comparison ops × `{0, 1}` map to `empty`/`!empty`. Vector magnitude `length(float3)` isn't flagged (different module, different semantics).

**Style (`daslib/style_lint.das`)**
- **STYLE016** — adjacent guards with identical exit → `||`-merge. Both AST shapes (two adjacent `if` statements, and `if … else if …` chains).
- **STYLE017** — `if (cond) return true; else return false` → `return cond` / `return !cond`. Both if-else and adjacent-statement forms.
- **STYLE018** — `b == true` / `b != false` → `b`, and `b == false` / `b != true` → `!b`. Yoda forms detected too.
- **STYLE019** — `min(max(x, lo), hi)` → `clamp(x, lo, hi)` (and the `max(min(...))` mirror form). Inner/outer must resolve to math module's `min`/`max`, not user overloads.

### Test files

9 new files under `utils/lint/tests/` — each uses `expect 31208:N` (PERF) or `expect 31209:N` (STYLE). The skill file claim that style `expect` doesn't work was stale; it works fine. All 18 lint tests pass via `dastest --test utils/lint/tests`.

### Documentation

9 new sections appended to `doc/source/reference/language/lint.rst`. Sphinx build succeeded with zero warnings.

### Visitor changes worth flagging in review

1. **`current_function.flags.generated` suppression** — added to both `perf_warning` and `style_warning`. `[CommandLineArgs]`-style codegen used to surface PERF/STYLE warnings on synthetic AST that the user never wrote.
2. **PERF017 self-skip when inside `empty()`** — its canonical implementation in `daslib/builtin.das` is literally `return length(a) == 0`, and the rule's whole job is to suggest `empty(...)`. Self-flagging the suggestion's own body is noise. Generic instantiations of `empty<T>` are caught via `current_function.fromGeneric.name == "empty"`.
3. **Dropped redundant `in_closure > 0` early-return from `preVisitExprOp2`** — `loop_depth` already doesn't increment inside closure bodies (`preVisitExprFor` / `While` gate on `in_closure == 0`), so PERF001's `loop_depth > 0` was already correctly excluding closure-internal loops without the separate skip. The `in_closure` skip was hiding syntactic patterns (PERF007/008/010 and the new PERF013/014/017) inside the natural `build_string() $(var w) { ... }` idiom that appears all over the codebase. Surfaced 4 legit hits in mouse alone.

### Sweeps in this PR

- **`utils/lint/main.das`** — 3 self-fixes (the rule runner triggered its own rules: STYLE016 on adjacent `if return` guards, two PERF017 `length == 0` → `empty`).
- **`utils/mouse/`** — ~15 hits cleaned up across `index.das`, `main.das`, `store.das`, `tests/test_index.das` (PERF013/014/017/STYLE016). One narrow `(c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')` check in `is_valid_slug` is intentionally lowercase-only and carries `// nolint:PERF014` — using `is_alnum` would silently accept uppercase and break the on-disk filename round-trip.
- **Dogfooding** — `daslib/perf_lint.das` and `daslib/style_lint.das` are now lint-clean for the new rules. Refactored their own internal guard chains.

The remaining ~377 hits across the rest of `daslib/` are deferred to a followup PR.

## Test plan

- [x] Lint passes for changed files (own rules' files are clean)
- [x] All 18 lint tests pass via dastest
- [x] Full test suite passes: 7984 / 7984
- [x] AOT build succeeds, AOT tests pass: 7378 / 7378
- [x] Sphinx build succeeds with zero warnings
- [x] Format clean (MCP `format_file` reports `already_formatted` for all 17 changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)