### PR TITLE
ci: stop publishing non-bundled release zips; mirror release modules in linux_arm CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
     branches: [master]
   pull_request:
   workflow_dispatch:
-  release:
-    types: prereleased
 defaults:
   run:
     shell: bash
@@ -272,7 +270,7 @@ jobs:
                 cmake --build ./build --config ${{ matrix.cmake_preset }} --parallel
                 ;;
               linux_arm*)
-                CC=clang CXX=clang++ cmake --no-warn-unused-cli -B./build -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake_preset }} -DDAS_GLFW_DISABLED=ON -DDAS_LLVM_DISABLED=${{ env.das_llvm_disabled }} -G \
+                CC=clang CXX=clang++ cmake --no-warn-unused-cli -B./build -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake_preset }} -DDAS_GLFW_DISABLED=ON -DDAS_HV_DISABLED=OFF -DDAS_SQLITE_DISABLED=OFF -DDAS_LLVM_DISABLED=${{ env.das_llvm_disabled }} -G \
                         "${{ matrix.cmake_generator }}"
                 cd build
                 ninja
@@ -310,6 +308,14 @@ jobs:
             cd bin/"${{ matrix.cmake_preset }}"
             [ "${{ env.das_llvm_disabled }}" = "ON" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- --timeout 900 --color --failures-only --test ../../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --isolated-mode --timeout 3600 --test ../../tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../../tests
+            ;;
+           linux_arm64)
+            cd bin
+            # Drop --failures-only on JIT so PASS lines print: when the LLVM ARM64
+            # SelectionDAG hang reoccurs (RC2 release run #25572466058), the most
+            # recent PASS line names the test that ran just before the hung one.
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- --color --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
+            ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ;;
            *)
             cd bin
@@ -355,16 +361,3 @@ jobs:
             ;;
         esac
 
-    - name: "Install binaries"
-      if: matrix.cmake_preset == 'Release'
-      shell: bash
-      run: |
-        mkdir daslang_install
-        mkdir artifacts
-        cmake --install ./build --prefix ./daslang_install --config ${{ matrix.cmake_preset }} --strip
-        7z a artifacts/daslang-${{ matrix.release_target }}-${{ matrix.release_arch }}.zip ./daslang_install
-    - name: "Upload release asset"
-      if: github.event.action == 'prereleased' && matrix.cmake_preset == 'Release'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload "${{ github.event.release.tag_name }}" artifacts/daslang-${{ matrix.release_target }}-${{ matrix.release_arch }}.zip --clobber

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -15,13 +15,14 @@
 - **Schema introspection and migrations** — `[sql_table(schema_from=...)]` + `check_schema` validate live database schema against the daslang struct at compile time; `daslib/sqlite_migrate` ships versioned `[sql_migration]` blocks with typed ALTER macros (`add_column` / `drop_column` / `rename_column`) and full-table rebuilds via `[struct_convert]` + `convert_and_rename` + `[sql_table(legacy=true)]` for non-trivial schema changes
 - **Operational SQLite features** — SQL fragment building, `ATTACH DATABASE`, FTS5 (`[sql_fts5]` + `text_match`), and pre-migration utilities
 
-#### Style Lint and Unified Linting (#2386, #2390, #2391, #2417, #2441, #2516, #2517, #2533, #2538)
+#### Style Lint and Unified Linting (#2386, #2390, #2391, #2417, #2441, #2516, #2517, #2533, #2538, #2612)
 
 New compile-time linting now covers daslang style in addition to the existing correctness and performance passes.
 
 - **`daslib/style_lint`** — detects non-idiomatic gen2 patterns such as unnecessary block pipes, declaration-then-assignment, array literal construction via repeated `push`, and long comment blocks
 - **Unified lint flow** — shared warning collection, `nolint` suppression, comment-hygiene rules, and codebase-wide cleanup to drive warnings back down
 - **Noise reduction** — one-line style enforcement was relaxed where it produced more friction than signal
+- **Nine new perf/style rules** (#2612) — `PERF013`–`PERF017` and `STYLE016`–`STYLE019` extend the rule set with additional anti-patterns surfaced during the codebase sweep
 
 #### Duplicate Detection Pipeline: `detect-dupe` and `find-dupe` (#2491, #2493, #2497, #2502, #2508, #2510, #2522)
 
@@ -104,15 +105,18 @@ A broad utility pass landed across libraries, docs, and developer workflow.
 - **das-fmt vendored in-tree** — `utils/das-fmt/` now holds a local copy of the formatter; CI runs against it instead of an external clone
 - **Tooling/docs** — filesystem guidance, handle-registry tutorial work, class-boost coverage, integer-returning `main()` for tools, compilation progress reporting, and assorted AST/class-method polish
 
-#### Build, CI, and Web (#2578, #2600, #2602)
+#### Build, CI, and Web (#2578, #2600, #2602, #2611, #2614, #2616)
 
 - **Tutorials build in CI** (#2578) — every tutorial now compiles in CI as part of the regular check run
 - **Web target reuses the main `CMakeLists`** (#2600) — `daslang-web` picks up tests and tracks the same build configuration as the native targets, removing the duplicated CMake graph
 - **MCP: parse-aware C++ source-search tools** (#2602) — `cpp_find_symbol`, `cpp_grep_usage`, `cpp_outline`, `cpp_goto_definition` join the existing daslang-side tools, with a configurable search root and git-signature staleness detection
+- **MCP: auto-retry unqualified module names under `daslib/`** (#2616) — when a tool call references e.g. `fio` and the symbol can't be found, the server retries against `daslib/fio` before reporting a miss
+- **`daslib/blind_mouse`: personal Q&A cache MCP server** (#2611) — `mouse__ask` / `mouse__add` keep a curated `.md` answer cache for "how do I X?" / "what's the pattern for Y?" questions across sessions
+- **`@live` extends to struct fields** (#2614) — `live_host` now annotates individual struct fields with `@live`, with per-field `init_hash` combining `f.init` and `g.init` so partial-struct reloads stay coherent
 
 ### Bug Fixes
 
-- **Build, tooling, and CI fixes** (#2385, #2394, #2395, #2424, #2447, #2521, #2537, #2591) — package `.gitignore` handling, PEG standalone/LLVM issues, `require` fixes, `dasbind` fixes, glob dependency tracking, documentation/error-position corrections, and daslang plugin: completion no longer silently bails when an external binding (e.g. OpenGL, GLSL preprocessor) is in scope
+- **Build, tooling, and CI fixes** (#2385, #2394, #2395, #2424, #2447, #2521, #2537, #2591, #2617) — package `.gitignore` handling, PEG standalone/LLVM issues, `require` fixes, `dasbind` fixes, glob dependency tracking, documentation/error-position corrections, daslang plugin: completion no longer silently bails when an external binding (e.g. OpenGL, GLSL preprocessor) is in scope, and `find_call_macro` null-deref fix with `macro_call` regression coverage
 - **Runtime/compiler correctness** (#2387, #2392, #2486, #2520, #2526, #2531, #2587, #2593) — JIT global-function arguments, handled-type property write propagation, function-lookup cache pointer reuse, `runWithCatch` state cleanup, ASAN/diagnostic follow-up, fix #2583 (standalone-exe shutdown crash), and fix #2582 (top-level `let`-init now correctly registers builtins)
 - **Fusion engine** — TSan-safe `v_ldu` via `DAS_LDU_WORKHORSE`, `call1` / `call2` `loadSize` stamped from `fnPtr->debugInfo`, and a TSan suppression for the over-read in fusion call/return shells
 - **Language/runtime edge cases** (#2444, #2446, #2463, #2468) — `finally` loop rework, clearer inference failure on bad calls, GCC reference shadow fixes, and strict-weak-ordering cleanup

--- a/site/index.html
+++ b/site/index.html
@@ -719,6 +719,7 @@ def fibI(n)
             <li><b>daslib/style_lint</b> &mdash; flags non-idiomatic gen2 patterns: unnecessary block pipes, declaration-then-assignment, array literal construction via repeated push, long comment blocks</li>
             <li><b>Unified lint flow</b> &mdash; shared warning collection, nolint suppression, comment-hygiene rules, and a codebase-wide cleanup that drove warnings back to zero</li>
             <li><b>Noise reduction</b> &mdash; one-line style enforcement was relaxed where it produced more friction than signal</li>
+            <li><b>Nine new perf/style rules</b> &mdash; PERF013&ndash;017 and STYLE016&ndash;019 extend the rule set with additional anti-patterns surfaced during the codebase sweep</li>
         </ul>
 
         <h4>Duplicate Detection: detect-dupe and find-dupe</h4>
@@ -800,11 +801,14 @@ def fibI(n)
             <li><b>Tutorials build in CI</b> &mdash; every tutorial now compiles in CI as part of the regular check run</li>
             <li><b>Web target reuses the main CMakeLists</b> &mdash; daslang-web picks up tests and tracks the same build configuration as the native targets, removing the duplicated CMake graph</li>
             <li><b>MCP: parse-aware C++ source-search tools</b> &mdash; cpp_find_symbol, cpp_grep_usage, cpp_outline, cpp_goto_definition join the existing daslang-side tools, with a configurable search root and git-signature staleness detection</li>
+            <li><b>MCP: auto-retry unqualified module names under daslib/</b> &mdash; when a tool call references e.g. <code>fio</code> and the symbol can't be found, the server retries against <code>daslib/fio</code> before reporting a miss</li>
+            <li><b>daslib/blind_mouse: personal Q&amp;A cache MCP server</b> &mdash; mouse__ask / mouse__add keep a curated .md answer cache for "how do I X?" / "what's the pattern for Y?" questions across sessions</li>
+            <li><b>@live extends to struct fields</b> &mdash; live_host annotates individual struct fields with @live, with per-field init_hash combining f.init and g.init so partial-struct reloads stay coherent</li>
         </ul>
 
         <h4>Bug Fixes</h4>
         <ul>
-            <li><b>Build, tooling, CI</b> &mdash; package .gitignore handling, PEG standalone/LLVM, require fixes, dasbind fixes, glob dependency tracking, doc/error-position corrections, and daslang plugin: completion no longer silently bails when an external binding (e.g. OpenGL, GLSL preprocessor) is in scope</li>
+            <li><b>Build, tooling, CI</b> &mdash; package .gitignore handling, PEG standalone/LLVM, require fixes, dasbind fixes, glob dependency tracking, doc/error-position corrections, daslang plugin completion no longer silently bails when an external binding (e.g. OpenGL, GLSL preprocessor) is in scope, and find_call_macro null-deref fix with macro_call regression coverage</li>
             <li><b>Runtime/compiler correctness</b> &mdash; JIT global-function arguments, handled-type property write propagation, function-lookup cache pointer reuse, runWithCatch state cleanup, ASAN follow-up, fix for the standalone-exe shutdown crash, and fix for top-level let-init now correctly registering builtins</li>
             <li><b>Fusion engine</b> &mdash; TSan-safe v_ldu via DAS_LDU_WORKHORSE, call1 / call2 loadSize stamped from fnPtr-&gt;debugInfo, and a TSan suppression for the over-read in fusion call/return shells</li>
             <li><b>Language edge cases</b> &mdash; finally loop rework, clearer inference failure on bad calls, GCC reference shadow fixes, strict-weak-ordering cleanup</li>


### PR DESCRIPTION
## Summary

- **build.yml no longer uploads non-bundled release zips.** Removes the `Install binaries` + `Upload release asset` steps and the `release: prereleased` trigger. release.yml is now the sole release publisher. Side-benefit: kills the empty-name `daslang--.zip` that sanitizer matrix rows produced via clobbering uploads (`daslang-${empty}-${empty}.zip` → `daslang--.zip`, three sanitizer jobs uploading the same name with `--clobber` left exactly one).
- **linux_arm Release in build.yml now enables `dasHV` and `dasSQLITE`** to mirror `ci/release_modules.txt`. The v0.6.2-RC2 release run [#25572466058](https://github.com/GaijinEntertainment/daScript/actions/runs/25572466058) hit an LLVM AArch64 SelectionDAG hang (`llvm::TargetLoweringBase::getTypeConversion` SIGSEGV after a 600s timeout) that build.yml never saw because regular CI ran with both modules disabled-by-default. After this change the same module set runs in build.yml, so if the bug is still present it surfaces in PR/master CI rather than hiding until the next release tag.
- **linux_arm test step drops `--failures-only` on JIT** so the per-file `PASS uri ...` lines print. When the hang reoccurs, the most recent PASS line names the file running just before the hung one. Visible test output before the timeout was sql migration log lines, so the offending test is almost certainly under `tests/dasSQLITE/`.
- **CHANGELIST.md + site/index.html change list** thread the five post-RC2 PRs (#2611 blind-mouse Q&A cache, #2612 nine new perf/style lint rules, #2614 `@live` struct-field extension, #2616 MCP `daslib/` fallback, #2617 `find_call_macro` null-deref fix) into the existing 0.6.2 sections, with a May 9 News entry.

Also: the eight bad assets on the v0.6.2-RC2 release page (`daslang--.zip` + the seven `daslang-<platform>-<arch>.zip`) were deleted out-of-band; the release now carries only the four bundled zips + two PDFs.

## Test plan

- [ ] CI runs `build (linux_arm, 64, Release, none)` with the new module set
- [ ] If the LLVM AArch64 hang reproduces, the failing job's log shows the PASS lines and identifies the offending `tests/dasSQLITE/...` (or `tests/dasHV/...`) file
- [ ] If it does NOT reproduce, the post-RC2 commits already addressed it — the diagnostic logging stays harmless and we revisit dropping the diagnostic later
- [ ] Other build.yml jobs unaffected (the `linux_arm64)` test-step case is the only new arm; `*)` covers everything else)

🤖 Generated with [Claude Code](https://claude.com/claude-code)