### PR TITLE
feat: c-api arrays/tables + tutorial 14 (passing arrays from C)

### DIFF
--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -126,6 +126,7 @@ build all C tutorials directly against the SDK — see
    tutorials/integration_c_11_type_introspection.rst
    tutorials/integration_c_12_ecs.rst
    tutorials/integration_c_13_shared_module.rst
+   tutorials/integration_c_14_passing_arrays.rst
 
 .. _tutorials_integration_cpp:
 

--- a/doc/source/reference/tutorials/integration_c_14_passing_arrays.rst
+++ b/doc/source/reference/tutorials/integration_c_14_passing_arrays.rst
@@ -1,0 +1,234 @@
+.. _tutorial_integration_c_passing_arrays:
+
+.. index::
+   single: Tutorial; C Integration; Passing Arrays
+   single: Tutorial; C Integration; das_array
+   single: Tutorial; C Integration; das_table
+
+=============================================
+ C Integration: Passing Arrays
+=============================================
+
+This tutorial covers two ownership patterns for handing ``array<T>`` and
+``table<K;V>`` values to daslang from C, plus the helper APIs that make
+either path safe.
+
+   * **Borrowed.** The C side owns the backing buffer; daslang reads
+     it for the duration of one call without taking ownership and is
+     forbidden from resizing it.
+   * **Context-owned.** daslang allocates the backing storage on the
+     context heap (using the same growth path the daslang runtime
+     uses internally). C reads the result through ``das_array`` /
+     ``das_table`` and releases it with ``das_array_clear`` /
+     ``das_table_clear``.
+
+The same three pieces of C API support both flavors and tables:
+
+  * ``das_context_allocate`` / ``_reallocate`` / ``_free`` — raw
+    context-heap blocks. Tables/arrays use these under the hood, but
+    you can also call them directly if you need a scratch buffer with
+    daslang lifetime.
+  * ``das_array_init`` / ``_init_borrowed`` / ``_reserve`` /
+    ``_resize`` / ``_clear`` / ``_at`` / ``_lock`` / ``_unlock`` —
+    array construction and population.
+  * ``das_table_init`` / ``_reserve`` / ``_clear`` / ``_find`` /
+    ``_insert`` / ``_erase`` / ``_lock`` / ``_unlock`` — table
+    construction and population, with a ``DAS_TYPE_*`` argument
+    selecting the key type.
+
+
+The daslang script
+==================
+
+.. code-block:: das
+
+   options gen2
+
+   [export]
+   def sum_array(arr : array<int>#) : int {
+       var total = 0
+       for (v in arr) {
+           total += v
+       }
+       return total
+   }
+
+   [export]
+   def fill_squares(var arr : array<int>; n : int) {
+       arr |> resize(n)
+       for (i in range(n)) {
+           arr[i] = i * i
+       }
+   }
+
+   [export]
+   def count_values(var counts : table<int; int>; data : array<int>#) {
+       for (v in data) {
+           if (key_exists(counts, v)) {
+               counts[v] = counts[v] + 1
+           } else {
+               counts[v] = 1
+           }
+       }
+   }
+
+
+Part 1 — borrowed array
+=======================
+
+The C buffer lives on the stack. ``das_array_init_borrowed`` sets up the
+``das_array`` struct so daslang sees it as already locked: ``lock = 1``,
+``magic`` set to ``DAS_ARRAY_MAGIC``. Any attempt by daslang to grow,
+resize, or delete the array would panic — exactly what you want when the
+backing buffer doesn't belong to the runtime.
+
+The matching daslang signature uses the **temporary array** type
+``array<int>#``: a non-owning view that cannot be retained or extended.
+Marking the parameter explicitly tells the type checker to reject any
+``resize`` / ``push`` / ``delete`` at compile time, so the runtime panic is
+a backstop rather than the only line of defense.
+
+.. code-block:: c
+
+   int data[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+   das_array borrowed;
+   das_array_init_borrowed(&borrowed, data, 8, 8);
+
+   vec4f args[1];
+   args[0] = das_result_array(&borrowed);
+
+   vec4f ret = das_context_eval_with_catch(ctx, fn_sum, args);
+   int total = das_argument_int(ret);   // 36
+
+No cleanup is needed — daslang never owned ``data``.
+
+
+Part 2 — context-owned array
+============================
+
+Hand daslang an empty array and let the function grow it. The runtime
+allocates on the context heap (the same path now exposed via
+``das_context_allocate``), and ``das_array.data`` points into that heap
+after the call. C reads through ``das_array_at`` and releases the block
+with ``das_array_clear``.
+
+.. code-block:: c
+
+   das_array owned;
+   das_array_init(&owned);
+
+   vec4f args[2];
+   args[0] = das_result_array(&owned);
+   args[1] = das_result_int(6);
+
+   das_context_eval_with_catch(ctx, fn_fill, args);
+   // owned.size == 6, owned.data is on the context heap.
+
+   for (uint32_t i = 0; i < owned.size; i++) {
+       int v = *(int*)das_array_at(&owned, i, sizeof(int));
+       // 0, 1, 4, 9, 16, 25
+   }
+
+   das_array_clear(ctx, &owned, sizeof(int));
+
+``das_array_clear`` requires the element stride because the C side has
+no type information at this layer — the runtime needs ``capacity *
+stride`` to compute the heap block size to free.
+
+
+Part 3 — table fill
+===================
+
+The same lifecycle applies to ``table<K;V>`` values. ``das_table_init``
+zeroes the struct; daslang's ``counts[v] = ...`` triggers the runtime
+to allocate the contiguous ``(values | keys | hashes)`` block.
+``das_table_clear`` needs the **key base type** (``DAS_TYPE_INT``,
+``DAS_TYPE_STRING``, …) and **value size** to compute the block size to
+free, since key and value types are erased at the C boundary.
+
+.. code-block:: c
+
+   int input[10] = { 7, 3, 7, 1, 3, 7, 1, 1, 1, 3 };
+   das_array data_view;
+   das_array_init_borrowed(&data_view, input, 10, 10);
+
+   das_table counts;
+   das_table_init(&counts);
+
+   vec4f args[2];
+   args[0] = das_result_table(&counts);
+   args[1] = das_result_array(&data_view);
+
+   das_context_eval_with_catch(ctx, fn_count, args);
+
+   int k = 7;
+   int * pv = (int*)das_table_find(ctx, &counts, DAS_TYPE_INT, &k, sizeof(int));
+   // *pv == 3
+
+   das_table_clear(ctx, &counts, DAS_TYPE_INT, sizeof(int));
+
+Supported table key types (matching the runtime's
+``table_reserve_impl`` dispatch — every operation accepts the same set):
+
+* **Scalars**: ``BOOL``, ``INT8`` / ``UINT8``, ``INT16`` / ``UINT16``,
+  ``INT`` / ``UINT``, ``INT64`` / ``UINT64``, ``FLOAT``, ``DOUBLE``.
+* **Enumerations**: ``ENUMERATION``, ``ENUMERATION8``, ``ENUMERATION16``,
+  ``ENUMERATION64`` — pass a pointer to the underlying ``int{8,16,32,64}``
+  value.
+* **Bitfields**: ``BITFIELD``, ``BITFIELD8``, ``BITFIELD16``,
+  ``BITFIELD64`` — pass a pointer to the underlying ``uint{8,16,32,64}``
+  value.
+* **Vectors**: ``INT2`` / ``INT3`` / ``INT4``, ``UINT2`` / ``UINT3`` /
+  ``UINT4``, ``FLOAT2`` / ``FLOAT3`` / ``FLOAT4``.
+* **Ranges**: ``RANGE``, ``URANGE``, ``RANGE64``, ``URANGE64``.
+* **Pointers**: ``STRING`` (``char*``), ``POINTER`` (``void*``).
+
+Other ``DAS_TYPE_*`` values raise an "unsupported table key type"
+exception.
+
+
+ABI safety: ``das_array`` and ``das_table`` mirror the runtime exactly
+======================================================================
+
+``das_array`` and ``das_table`` in ``daScriptC.h`` mirror the C++
+``das::Array`` and ``das::Table`` byte-for-byte (including the runtime's
+internal ``magic`` field at offset 16). Compile-time ``static_assert``
+checks in ``daScriptC.cpp`` guard the layout — if the C++ runtime adds,
+removes, or reorders a field, the build breaks until ``daScriptC.h`` is
+updated to match. Do not assume offsets match across versions without
+re-checking the asserts.
+
+
+Build & run
+===========
+
+Build::
+
+   cmake --build build --config Release --target integration_c_14
+
+Run from the project root so the script path resolves correctly::
+
+   bin/Release/integration_c_14
+
+Expected output::
+
+   sum_array([1..8]) = 36
+   fill_squares(_, 6) -> size=6, contents=0,1,4,9,16,25
+   counts[1] = 4
+   counts[3] = 3
+   counts[7] = 3
+   counts[99] = (missing)
+
+
+.. seealso::
+
+   Full source:
+   :download:`14_passing_arrays.c <../../../../tutorials/integration/c/14_passing_arrays.c>`,
+   :download:`14_passing_arrays.das <../../../../tutorials/integration/c/14_passing_arrays.das>`
+
+   Previous tutorial: :ref:`tutorial_integration_c_shared_module`
+
+   Tutorial :ref:`tutorial_integration_c_calling_functions` — argument
+   packing for primitive types
+
+   daScriptC.h API header: ``include/daScript/daScriptC.h``

--- a/include/daScript/daScriptC.h
+++ b/include/daScript/daScriptC.h
@@ -91,18 +91,32 @@ typedef struct {
     float x, y, z, w;
 } vec4f_unaligned;
 
-typedef struct {
-    char *      data;
-    uint32_t    size;
-    uint32_t    capacity;
-    uint32_t    lock;
-    uint32_t    flags;
-} das_array;
+// Layout MUST mirror das::Array exactly. `magic` is set by the runtime to
+// DAS_ARRAY_MAGIC on first lock and used to detect moved-or-overwritten
+// arrays. Static asserts in daScriptC.cpp guard the layout.
+//
+// Guarded with #ifndef so this C-side definition is compatible with the
+// C++ runtime's <daScript/misc/arraytype.h>, which defines the same
+// macro for use inside the runtime.
+#ifndef DAS_ARRAY_MAGIC
+#define DAS_ARRAY_MAGIC 0xA11B3DA7
+#endif
 
 typedef struct {
     char *      data;
     uint32_t    size;
     uint32_t    capacity;
+    uint32_t    magic;
+    uint32_t    lock;
+    uint32_t    flags;
+} das_array;
+
+// Layout MUST mirror das::Table exactly (Table : Array, then keys/hashes/tombstones).
+typedef struct {
+    char *      data;
+    uint32_t    size;
+    uint32_t    capacity;
+    uint32_t    magic;
     uint32_t    lock;
     uint32_t    flags;
     char *      keys;
@@ -388,6 +402,156 @@ DAS_CC_API void das_module_bind_enumeration ( das_module * mod, das_enumeration 
 // is managed by the context and must not be freed by the caller.
 DAS_CC_API char * das_allocate_string ( das_context * context, char * str );
 
+// --- Context heap ---
+// Raw allocation on the context's main heap. Used by the array/table helpers
+// below; expose them so C callers can pre-allocate buffers that daslang code
+// may later resize using the same heap.
+
+// Allocate 'size' bytes on the context heap. Returns NULL when size==0;
+// otherwise returns a non-null pointer. On out-of-memory the runtime raises
+// a context exception (does NOT return NULL) — check via
+// das_context_get_exception() before using the result if you can't otherwise
+// rule out OOM. The returned pointer is owned by the context heap and must
+// be released with das_context_free or absorbed into a daslang-managed
+// container (an array/table whose `data` field is set to it).
+DAS_CC_API void * das_context_allocate ( das_context * context, uint32_t size );
+// Reallocate a previously allocated block. 'old_size' must match the size
+// used at allocation. When new_size==0 the wrapper frees 'ptr' (with
+// 'old_size') and returns NULL — the runtime allocator does not natively
+// support realloc-to-zero. Otherwise returns a non-null pointer; on
+// out-of-memory raises a context exception (does NOT return NULL).
+DAS_CC_API void * das_context_reallocate ( das_context * context, void * ptr, uint32_t old_size, uint32_t new_size );
+// Free a previously allocated block. 'size' must match the size used at
+// allocation and must be non-zero when 'ptr' is non-null (passing 0 with
+// a non-null pointer raises a context exception — the contract is that
+// 'size' must match the allocation, not that the heap will silently
+// accept it). Passing ptr==NULL is a no-op.
+DAS_CC_API void   das_context_free ( das_context * context, void * ptr, uint32_t size );
+
+// --- Arrays ---
+// Helpers to construct, populate and pass `array<T>` values from C code.
+// All sizes/strides are in bytes for raw element access; element count is the
+// `size` field on das_array.
+
+// Initialize 'arr' as an empty owned array (zero size / zero capacity / no data).
+// This is the entry point for "context-owned" arrays — daslang functions may grow
+// them via the runtime, and you reclaim memory with das_array_clear.
+DAS_CC_API void   das_array_init ( das_array * arr );
+
+// Initialize 'arr' as a non-owned view over caller-provided contiguous data.
+// Sets the array up as if it were locked AND marks `flags.shared=true`, so
+// the daslang runtime will refuse to resize, grow, or delete it, and so
+// das_array_lock / das_array_unlock become no-ops on this array (the
+// runtime short-circuits both on the shared flag — no way to accidentally
+// drop the lock to 0 and turn the borrow into an owned-data path). The
+// caller MUST keep 'data' alive for as long as daslang holds a reference
+// to the array, and MUST NOT call das_array_clear on a borrowed view.
+//
+// das_array_lock / das_array_unlock are intended for temporarily pinning
+// **context-owned** arrays during iteration, not for borrowed views.
+//
+// Preconditions:
+//   data!=NULL when count>0   (NULL+nonzero leaves a half-built view)
+//   count <= capacity         (size > capacity is a runtime invariant violation)
+//
+//   data      : pointer to 'capacity' contiguous elements (caller-owned)
+//   count     : initial size in elements
+//   capacity  : capacity in elements (>= count); commonly equal to count
+DAS_CC_API void   das_array_init_borrowed ( das_array * arr, void * data, uint32_t count, uint32_t capacity );
+
+// Reserve space for at least 'capacity' elements of size 'stride' bytes.
+// Allocates on the context heap. No-op if current capacity is sufficient.
+// 'stride' must be non-zero when 'capacity' > 0 (passing 0 raises a context
+// exception — the runtime allocator can't reach allocate(0) cleanly).
+DAS_CC_API void   das_array_reserve ( das_context * context, das_array * arr, uint32_t capacity, uint32_t stride );
+
+// Resize the array to 'size' elements of size 'stride' bytes. Growth allocates
+// on the context heap; new elements are zeroed when zero != 0.
+// 'stride' must be non-zero when 'size' > 0 (same rationale as _reserve).
+DAS_CC_API void   das_array_resize ( das_context * context, das_array * arr, uint32_t size, uint32_t stride, int zero );
+
+// Free the array's backing storage and zero the structure. Errors if the
+// array is locked (matches `delete` semantics in daslang). 'stride' is the
+// element size in bytes — it must be non-zero when the array has data, since
+// the heap free size is computed as capacity*stride; passing 0 raises a
+// context exception.
+DAS_CC_API void   das_array_clear ( das_context * context, das_array * arr, uint32_t stride );
+
+// Return a pointer to element 'index' in an array with element size 'stride'.
+// Bounds are NOT checked; pass a valid (index < arr->size) value. Implicit
+// preconditions: arr->data != NULL and arr->size > 0 (a non-empty array
+// always has non-null data — otherwise the returned pointer is invalid).
+DAS_CC_API void * das_array_at ( das_array * arr, uint32_t index, uint32_t stride );
+
+// Increment the array lock counter. While locked, mutation operations panic
+// in the daslang runtime. Use to pin an array's storage while iterating.
+DAS_CC_API void   das_array_lock ( das_context * context, das_array * arr );
+// Decrement the array lock counter.
+DAS_CC_API void   das_array_unlock ( das_context * context, das_array * arr );
+
+// --- Tables ---
+// Helpers to construct, populate and pass `table<K;V>` values from C code.
+// 'key_base_type' is one of the DAS_TYPE_* values matching the daslang key type
+// (e.g. DAS_TYPE_INT, DAS_TYPE_STRING). 'value_size' is sizeof(V) in bytes.
+// All operations (reserve / clear / find / insert / erase) accept the same
+// key-type set, mirroring the runtime's table_reserve_impl dispatch:
+//   scalars:      BOOL, INT8/UINT8, INT16/UINT16, INT/UINT, INT64/UINT64,
+//                 FLOAT, DOUBLE
+//   enumerations: ENUMERATION, ENUMERATION8, ENUMERATION16, ENUMERATION64
+//                 (pass a pointer to the underlying int{8,16,32,64} value)
+//   bitfields:    BITFIELD, BITFIELD8, BITFIELD16, BITFIELD64
+//                 (pass a pointer to the underlying uint{8,16,32,64} value)
+//   vectors:      INT2/INT3/INT4, UINT2/UINT3/UINT4, FLOAT2/FLOAT3/FLOAT4
+//   ranges:       RANGE, URANGE, RANGE64, URANGE64
+//   pointers:     STRING (char*), POINTER (void*)
+// Other DAS_TYPE_* values raise an "unsupported table key type" exception.
+//
+// Lifetime note for DAS_TYPE_STRING / DAS_TYPE_POINTER keys: the table stores
+// the pointer value as-is (no copy). Caller must keep the pointed-at storage
+// alive for the table's lifetime. To copy a string into the context heap so
+// it survives stack/temp scope, use das_allocate_string and store the
+// returned pointer as the key.
+
+// Initialize 'tab' as an empty table (no allocation).
+DAS_CC_API void   das_table_init ( das_table * tab );
+
+// Reserve at least 'capacity' slots. Allocates on the context heap.
+DAS_CC_API void   das_table_reserve ( das_context * context, das_table * tab, int key_base_type, uint32_t capacity, uint32_t value_size );
+
+// Free backing storage and zero the structure. 'key_base_type' and 'value_size'
+// must match the values used at insertion time (needed to compute the freed
+// block size — daslang allocates keys, values and hashes contiguously).
+DAS_CC_API void   das_table_clear ( das_context * context, das_table * tab, int key_base_type, uint32_t value_size );
+
+// Lookup 'key' in the table.
+//
+// 'key' is the address of a variable holding the key value — NOT the
+// pointed-to bytes for pointer-shaped key types. Examples by 'key_base_type':
+//   DAS_TYPE_INT       -> int*       (address of an `int`)
+//   DAS_TYPE_INT64     -> int64_t*   (address of an `int64_t`)
+//   DAS_TYPE_FLOAT     -> float*     (address of a `float`)
+//   DAS_TYPE_STRING    -> char**     (address of a `char*` variable)
+//   DAS_TYPE_POINTER   -> void**     (address of a `void*` variable)
+// The pointed-at bytes need not be aligned for the key type — the helper
+// copies them into an aligned local before use.
+//
+// Returns a pointer into the value slot, or NULL on miss.
+DAS_CC_API void * das_table_find ( das_context * context, das_table * tab, int key_base_type, const void * key, uint32_t value_size );
+
+// Insert 'key' (or look it up if present) and return a pointer to its value
+// slot. Caller writes the new value through the returned pointer.
+// 'key' has the same address-of-variable convention as das_table_find.
+DAS_CC_API void * das_table_insert ( das_context * context, das_table * tab, int key_base_type, const void * key, uint32_t value_size );
+
+// Remove 'key' from the table. Returns 1 if the key existed, 0 otherwise.
+// 'key' has the same address-of-variable convention as das_table_find.
+DAS_CC_API int    das_table_erase ( das_context * context, das_table * tab, int key_base_type, const void * key, uint32_t value_size );
+
+// Increment the table lock counter (mirrors das_array_lock for tables).
+DAS_CC_API void   das_table_lock ( das_context * context, das_table * tab );
+// Decrement the table lock counter.
+DAS_CC_API void   das_table_unlock ( das_context * context, das_table * tab );
+
 // --- Argument getters (aligned) ---
 // Extract a C value from a vec4f argument inside an interop function.
 
@@ -403,6 +567,8 @@ DAS_CC_API void * das_argument_ptr ( vec4f arg );
 DAS_CC_API das_function * das_argument_function ( vec4f arg );
 DAS_CC_API das_lambda * das_argument_lambda ( vec4f arg );
 DAS_CC_API das_block * das_argument_block ( vec4f arg );
+DAS_CC_API das_array * das_argument_array ( vec4f arg );
+DAS_CC_API das_table * das_argument_table ( vec4f arg );
 
 // --- Argument getters (unaligned) ---
 // Extract a C value from a vec4f_unaligned argument pointer.
@@ -420,6 +586,8 @@ DAS_CC_API void * das_argument_ptr_unaligned ( vec4f_unaligned * arg );
 DAS_CC_API das_function * das_argument_function_unaligned ( vec4f_unaligned * arg );
 DAS_CC_API das_lambda * das_argument_lambda_unaligned ( vec4f_unaligned * arg );
 DAS_CC_API das_block * das_argument_block_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API das_array * das_argument_array_unaligned ( vec4f_unaligned * arg );
+DAS_CC_API das_table * das_argument_table_unaligned ( vec4f_unaligned * arg );
 
 // --- Result setters (aligned) ---
 // Pack a C value into vec4f for returning from an aligned interop function.
@@ -437,6 +605,8 @@ DAS_CC_API vec4f das_result_ptr ( void * r );
 DAS_CC_API vec4f das_result_function ( das_function * r );
 DAS_CC_API vec4f das_result_lambda ( das_lambda * r );
 DAS_CC_API vec4f das_result_block ( das_block * r );
+DAS_CC_API vec4f das_result_array ( das_array * r );
+DAS_CC_API vec4f das_result_table ( das_table * r );
 
 // --- Result setters (unaligned) ---
 // Write a C value into a vec4f_unaligned result pointer.
@@ -455,6 +625,8 @@ DAS_CC_API void das_result_ptr_unaligned ( vec4f_unaligned * result, void * r );
 DAS_CC_API void das_result_function_unaligned ( vec4f_unaligned * result, das_function * r );
 DAS_CC_API void das_result_lambda_unaligned ( vec4f_unaligned * result, das_lambda * r );
 DAS_CC_API void das_result_block_unaligned ( vec4f_unaligned * result, das_block * r );
+DAS_CC_API void das_result_array_unaligned ( vec4f_unaligned * result, das_array * r );
+DAS_CC_API void das_result_table_unaligned ( vec4f_unaligned * result, das_table * r );
 
 // --- Compilation policies ---
 // CodeOfPolicies controls compiler and runtime behavior: AOT, safety,

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -7,6 +7,10 @@
 #include "daScript/ast/ast_serializer.h"
 #include "daScript/misc/free_list.h"
 #include "daScript/misc/gc_node.h"
+#include "daScript/simulate/runtime_array.h"
+#include "daScript/simulate/runtime_table.h"
+#include "daScript/simulate/hash.h"
+#include <cstddef>
 
 using namespace das;
 
@@ -997,5 +1001,279 @@ uint32_t das_func_info_get_flags ( das_func_info * info ) {
 int das_func_info_get_stack_size ( das_func_info * info ) {
     return (int) ((FuncInfo *)info)->stackSize;
 }
+
+// --- Layout sync: das_array / das_table mirror Array / Table exactly ---
+// These asserts catch silent ABI drift between the C header and the C++ runtime.
+// If the C++ side adds/removes/reorders fields in Array or Table, update das_array
+// / das_table in daScriptC.h to match and add the new offset assert here.
+//
+// Note: Array's `magic` and `lock` fields are protected in C++, so we can't
+// take their offsets directly. We rely on `flags` (the only public field after
+// magic/lock) being at the expected offset, plus the total size match — which
+// together pin every byte between `capacity` and `flags`.
+
+static_assert(sizeof(das_array) == sizeof(Array),
+    "das_array size must match das::Array — update daScriptC.h to mirror arraytype.h");
+static_assert(offsetof(das_array, data)     == offsetof(Array, data),     "das_array.data offset drift");
+static_assert(offsetof(das_array, size)     == offsetof(Array, size),     "das_array.size offset drift");
+static_assert(offsetof(das_array, capacity) == offsetof(Array, capacity), "das_array.capacity offset drift");
+static_assert(offsetof(das_array, flags)    == offsetof(Array, flags),    "das_array.flags offset drift");
+
+static_assert(sizeof(das_table) == sizeof(Table),
+    "das_table size must match das::Table — update daScriptC.h to mirror arraytype.h");
+static_assert(offsetof(das_table, data)       == offsetof(Table, data),       "das_table.data offset drift");
+static_assert(offsetof(das_table, size)       == offsetof(Table, size),       "das_table.size offset drift");
+static_assert(offsetof(das_table, capacity)   == offsetof(Table, capacity),   "das_table.capacity offset drift");
+static_assert(offsetof(das_table, flags)      == offsetof(Table, flags),      "das_table.flags offset drift");
+static_assert(offsetof(das_table, keys)       == offsetof(Table, keys),       "das_table.keys offset drift");
+static_assert(offsetof(das_table, hashes)     == offsetof(Table, hashes),     "das_table.hashes offset drift");
+static_assert(offsetof(das_table, tombstones) == offsetof(Table, tombstones), "das_table.tombstones offset drift");
+
+// --- Context heap ---
+
+void * das_context_allocate ( das_context * context, uint32_t size ) {
+    if ( !size ) return nullptr;
+    return ((Context *)context)->allocate(size, nullptr);
+}
+
+void * das_context_reallocate ( das_context * context, void * ptr, uint32_t old_size, uint32_t new_size ) {
+    // The runtime allocator's reallocate path doesn't handle new_size==0 — it
+    // routes through allocate(0) which returns null, then DAS_VERIFY fires.
+    // Implement realloc-to-zero here as free + return NULL so the C-side
+    // contract (free the block and return NULL) holds independent of which
+    // heap impl the context is using.
+    if ( !new_size ) {
+        if ( ptr ) {
+            // Mirror the das_context_free guard — old_size must match the
+            // allocation, and 0 with non-null is a caller bug that some heap
+            // impls assert on.
+            if ( !old_size ) {
+                ((Context *)context)->throw_error("das_context_reallocate: old_size must be non-zero when ptr is non-null");
+                return nullptr;
+            }
+            ((Context *)context)->free((char *)ptr, old_size, nullptr);
+        }
+        return nullptr;
+    }
+    return ((Context *)context)->reallocate((char *)ptr, old_size, new_size, nullptr);
+}
+
+void das_context_free ( das_context * context, void * ptr, uint32_t size ) {
+    if ( !ptr ) return;
+    if ( !size ) {
+        // Some heap impls handle free(ptr, 0) cleanly, others assert. The C
+        // contract requires `size` to match the allocation — fail loud rather
+        // than silently corrupt the heap accounting.
+        ((Context *)context)->throw_error("das_context_free: size must be non-zero when ptr is non-null");
+        return;
+    }
+    ((Context *)context)->free((char *)ptr, size, nullptr);
+}
+
+// --- Arrays ---
+
+void das_array_init ( das_array * arr ) {
+    memset(arr, 0, sizeof(das_array));
+}
+
+void das_array_init_borrowed ( das_array * arr, void * data, uint32_t count, uint32_t capacity ) {
+    memset(arr, 0, sizeof(das_array));
+    array_mark_locked(*(Array *)arr, data, count, capacity);
+    // Set `flags.shared=true` so das_array_lock / das_array_unlock become
+    // runtime no-ops on this array — short-circuited by the matching guards
+    // in array_lock/array_unlock. Prevents a misuse-by-unlock from dropping
+    // the lock to 0 and letting a subsequent resize/delete corrupt the
+    // C-owned buffer. Resize/delete still check isLocked() (which stays
+    // true), so the borrowed contract is preserved.
+    ((Array *)arr)->flags |= 1u; // bit 0 == shared
+}
+
+void das_array_reserve ( das_context * context, das_array * arr, uint32_t capacity, uint32_t stride ) {
+    // Same guard as das_array_clear: stride==0 with non-zero capacity reaches
+    // Context::reallocate(_, _, 0) which fires DAS_VERIFYF in MemoryModel.
+    if ( capacity && !stride ) {
+        ((Context *)context)->throw_error("das_array_reserve: stride must be non-zero when capacity > 0");
+        return;
+    }
+    array_reserve(*(Context *)context, *(Array *)arr, capacity, stride, nullptr);
+}
+
+void das_array_resize ( das_context * context, das_array * arr, uint32_t size, uint32_t stride, int zero ) {
+    if ( size && !stride ) {
+        ((Context *)context)->throw_error("das_array_resize: stride must be non-zero when size > 0");
+        return;
+    }
+    array_resize(*(Context *)context, *(Array *)arr, size, stride, zero != 0, nullptr);
+}
+
+void das_array_clear ( das_context * context, das_array * arr, uint32_t stride ) {
+    auto * a = (Array *)arr;
+    if ( a->isLocked() ) {
+        ((Context *)context)->throw_error("can't clear locked array");
+        return;
+    }
+    if ( a->data ) {
+        // capacity*stride is the byte size to free. capacity>0 is a runtime
+        // invariant when data!=null, so the only way to reach a zero free size
+        // is stride==0 — a caller bug. Throw before passing 0 to the heap.
+        if ( !stride ) {
+            ((Context *)context)->throw_error("das_array_clear: stride must be non-zero for non-empty array");
+            return;
+        }
+        ((Context *)context)->free(a->data, a->capacity * stride, nullptr);
+    }
+    memset(a, 0, sizeof(Array));
+}
+
+void * das_array_at ( das_array * arr, uint32_t index, uint32_t stride ) {
+    return ((Array *)arr)->data + size_t(index) * size_t(stride);
+}
+
+void das_array_lock ( das_context * context, das_array * arr ) {
+    array_lock(*(Context *)context, *(Array *)arr, nullptr);
+}
+
+void das_array_unlock ( das_context * context, das_array * arr ) {
+    array_unlock(*(Context *)context, *(Array *)arr, nullptr);
+}
+
+// --- Tables ---
+// Dispatch on key type. Mirrors table_reserve_impl in
+// src/simulate/runtime_table.cpp exactly so the C-side reserve / clear /
+// find / insert / erase all accept the same key set — no surprise where
+// reserve succeeds but a follow-up op throws "unsupported table key type".
+
+#define DAS_TABLE_DISPATCH(KEY_BASE_TYPE_VAR, BODY) \
+    switch ( Type(KEY_BASE_TYPE_VAR) ) { \
+        case Type::tBool:           { typedef bool      KEY_TYPE; BODY; break; } \
+        case Type::tInt8:           { typedef int8_t    KEY_TYPE; BODY; break; } \
+        case Type::tUInt8:          { typedef uint8_t   KEY_TYPE; BODY; break; } \
+        case Type::tInt16:          { typedef int16_t   KEY_TYPE; BODY; break; } \
+        case Type::tUInt16:         { typedef uint16_t  KEY_TYPE; BODY; break; } \
+        case Type::tInt:            { typedef int32_t   KEY_TYPE; BODY; break; } \
+        case Type::tUInt:           { typedef uint32_t  KEY_TYPE; BODY; break; } \
+        case Type::tInt64:          { typedef int64_t   KEY_TYPE; BODY; break; } \
+        case Type::tUInt64:         { typedef uint64_t  KEY_TYPE; BODY; break; } \
+        case Type::tEnumeration:    { typedef int32_t   KEY_TYPE; BODY; break; } \
+        case Type::tEnumeration8:   { typedef int8_t    KEY_TYPE; BODY; break; } \
+        case Type::tEnumeration16:  { typedef int16_t   KEY_TYPE; BODY; break; } \
+        case Type::tEnumeration64:  { typedef int64_t   KEY_TYPE; BODY; break; } \
+        case Type::tBitfield:       { typedef uint32_t  KEY_TYPE; BODY; break; } \
+        case Type::tBitfield8:      { typedef uint8_t   KEY_TYPE; BODY; break; } \
+        case Type::tBitfield16:     { typedef uint16_t  KEY_TYPE; BODY; break; } \
+        case Type::tBitfield64:     { typedef uint64_t  KEY_TYPE; BODY; break; } \
+        case Type::tInt2:           { typedef int2      KEY_TYPE; BODY; break; } \
+        case Type::tInt3:           { typedef int3      KEY_TYPE; BODY; break; } \
+        case Type::tInt4:           { typedef int4      KEY_TYPE; BODY; break; } \
+        case Type::tUInt2:          { typedef uint2     KEY_TYPE; BODY; break; } \
+        case Type::tUInt3:          { typedef uint3     KEY_TYPE; BODY; break; } \
+        case Type::tUInt4:          { typedef uint4     KEY_TYPE; BODY; break; } \
+        case Type::tFloat:          { typedef float     KEY_TYPE; BODY; break; } \
+        case Type::tFloat2:         { typedef float2    KEY_TYPE; BODY; break; } \
+        case Type::tFloat3:         { typedef float3    KEY_TYPE; BODY; break; } \
+        case Type::tFloat4:         { typedef float4    KEY_TYPE; BODY; break; } \
+        case Type::tDouble:         { typedef double    KEY_TYPE; BODY; break; } \
+        case Type::tRange:          { typedef range     KEY_TYPE; BODY; break; } \
+        case Type::tURange:         { typedef urange    KEY_TYPE; BODY; break; } \
+        case Type::tRange64:        { typedef range64   KEY_TYPE; BODY; break; } \
+        case Type::tURange64:       { typedef urange64  KEY_TYPE; BODY; break; } \
+        case Type::tString:         { typedef char *    KEY_TYPE; BODY; break; } \
+        case Type::tPointer:        { typedef void *    KEY_TYPE; BODY; break; } \
+        default: ((Context *)context)->throw_error("unsupported table key type"); break; \
+    }
+
+void das_table_init ( das_table * tab ) {
+    memset(tab, 0, sizeof(das_table));
+}
+
+void das_table_reserve ( das_context * context, das_table * tab, int key_base_type, uint32_t capacity, uint32_t value_size ) {
+    table_reserve_impl(*(Context *)context, *(Table *)tab, int32_t(key_base_type), capacity, value_size, nullptr);
+}
+
+void das_table_clear ( das_context * context, das_table * tab, int key_base_type, uint32_t value_size ) {
+    auto * t = (Table *)tab;
+    if ( t->isLocked() ) {
+        ((Context *)context)->throw_error("can't clear locked table");
+        return;
+    }
+    if ( t->data ) {
+        uint32_t key_size = 0;
+        DAS_TABLE_DISPATCH(key_base_type, { key_size = sizeof(KEY_TYPE); })
+        if ( !key_size ) return; // throw_error already raised
+        uint32_t total = t->capacity * (value_size + key_size + uint32_t(sizeof(TableHashKey)));
+        ((Context *)context)->free(t->data, total, nullptr);
+    }
+    memset(t, 0, sizeof(Table));
+}
+
+// `key` may point at unaligned bytes (a key inside a packed buffer, an
+// offset inside a serialization stream, …) — copy into an aligned local
+// before dereferencing. Strict-alignment targets fault on misaligned loads.
+
+void * das_table_find ( das_context * context, das_table * tab, int key_base_type, const void * key, uint32_t value_size ) {
+    void * result = nullptr;
+    auto * t = (Table *)tab;
+    DAS_TABLE_DISPATCH(key_base_type, {
+        KEY_TYPE k;
+        memcpy(&k, key, sizeof(KEY_TYPE));
+        uint64_t h = hash_function(*(Context *)context, k);
+        TableHash<KEY_TYPE> hh((Context *)context, value_size);
+        int idx = hh.find(*t, k, h);
+        if ( idx >= 0 ) result = t->data + size_t(idx) * size_t(value_size);
+    })
+    return result;
+}
+
+void * das_table_insert ( das_context * context, das_table * tab, int key_base_type, const void * key, uint32_t value_size ) {
+    void * result = nullptr;
+    auto * t = (Table *)tab;
+    DAS_TABLE_DISPATCH(key_base_type, {
+        KEY_TYPE k;
+        memcpy(&k, key, sizeof(KEY_TYPE));
+        uint64_t h = hash_function(*(Context *)context, k);
+        TableHash<KEY_TYPE> hh((Context *)context, value_size);
+        int idx = hh.reserve(*t, k, h, nullptr);
+        if ( idx >= 0 ) result = t->data + size_t(idx) * size_t(value_size);
+    })
+    return result;
+}
+
+int das_table_erase ( das_context * context, das_table * tab, int key_base_type, const void * key, uint32_t value_size ) {
+    int erased = 0;
+    auto * t = (Table *)tab;
+    DAS_TABLE_DISPATCH(key_base_type, {
+        KEY_TYPE k;
+        memcpy(&k, key, sizeof(KEY_TYPE));
+        uint64_t h = hash_function(*(Context *)context, k);
+        TableHash<KEY_TYPE> hh((Context *)context, value_size);
+        int idx = hh.erase(*t, k, h);
+        if ( idx >= 0 ) erased = 1;
+    })
+    return erased;
+}
+
+void das_table_lock ( das_context * context, das_table * tab ) {
+    table_lock(*(Context *)context, *(Table *)tab, nullptr);
+}
+
+void das_table_unlock ( das_context * context, das_table * tab ) {
+    table_unlock(*(Context *)context, *(Table *)tab, nullptr);
+}
+
+#undef DAS_TABLE_DISPATCH
+
+// --- Array/table arg/result piping ---
+
+das_array * das_argument_array ( vec4f arg ) { return (das_array *) cast<void *>::to(arg); }
+das_table * das_argument_table ( vec4f arg ) { return (das_table *) cast<void *>::to(arg); }
+
+vec4f das_result_array ( das_array * r ) { return cast<void *>::from(r); }
+vec4f das_result_table ( das_table * r ) { return cast<void *>::from(r); }
+
+das_array * das_argument_array_unaligned ( vec4f_unaligned * arg ) { return (das_array *) cast<void *>::to(v_ldu((const float *)arg)); }
+das_table * das_argument_table_unaligned ( vec4f_unaligned * arg ) { return (das_table *) cast<void *>::to(v_ldu((const float *)arg)); }
+
+void das_result_array_unaligned ( vec4f_unaligned * result, das_array * r ) { v_stu((float *)result, cast<void *>::from(r)); }
+void das_result_table_unaligned ( vec4f_unaligned * result, das_table * r ) { v_stu((float *)result, cast<void *>::from(r)); }
 
 }

--- a/tests-cpp/small/test_c_array_table_api.cpp
+++ b/tests-cpp/small/test_c_array_table_api.cpp
@@ -1,0 +1,360 @@
+// Test for the C API additions in daScriptC.h:
+//   - das_context_allocate / _reallocate / _free
+//   - das_array_init / _init_borrowed / _reserve / _resize / _clear / _at /
+//                      _lock / _unlock
+//   - das_table_init / _reserve / _clear / _find / _insert / _erase /
+//                      _lock / _unlock
+//   - das_argument_array / _table and das_result_array / _table
+//
+// Plus a runtime canary on the das_array / das_table layout — duplicates the
+// compile-time static_asserts in daScriptC.cpp with a readable failure message.
+
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+#include "daScript/daScriptC.h"
+#include "daScript/misc/arraytype.h"
+
+#include <cstddef>
+#include <cstring>
+
+using namespace das;
+
+namespace {
+
+// Compile + simulate an inline daslang script via the C API. Returns a context
+// (caller-owned) plus the program / file_access / module_group it depends on.
+// Caller releases all four via cleanup_inline_ctx().
+struct InlineCtx {
+    das_context     * ctx          = nullptr;
+    das_program     * program      = nullptr;
+    das_file_access * file_access  = nullptr;
+    das_module_group * module_group = nullptr;
+    das_text_writer * tout         = nullptr;
+};
+
+InlineCtx compile_inline(const char * src) {
+    InlineCtx ic;
+    ic.tout         = das_text_make_printer();
+    ic.module_group = das_modulegroup_make();
+    ic.file_access  = das_fileaccess_make_default();
+    das_fileaccess_introduce_file(ic.file_access, "main.das", src, 1);
+    ic.program = das_program_compile((char*)"main.das", ic.file_access, ic.tout, ic.module_group);
+    if ( das_program_err_count(ic.program) ) return ic; // ctx left null
+    ic.ctx = das_context_make(das_program_context_stack_size(ic.program));
+    if ( !das_program_simulate(ic.program, ic.ctx, ic.tout) ) {
+        das_context_release(ic.ctx);
+        ic.ctx = nullptr;
+    }
+    return ic;
+}
+
+void cleanup_inline_ctx(InlineCtx & ic) {
+    if ( ic.ctx )          das_context_release(ic.ctx);
+    if ( ic.program )      das_program_release(ic.program);
+    if ( ic.file_access )  das_fileaccess_release(ic.file_access);
+    if ( ic.module_group ) das_modulegroup_release(ic.module_group);
+    if ( ic.tout )         das_text_release(ic.tout);
+    ic = InlineCtx{};
+}
+
+} // anonymous namespace
+
+TEST_CASE("das_array / das_table layout matches Array / Table at runtime") {
+    // Belt-and-braces with the static_asserts in daScriptC.cpp: surface a clear
+    // diagnostic if the C struct ever drifts from the C++ runtime.
+    CHECK(sizeof(das_array) == sizeof(Array));
+    CHECK(offsetof(das_array, data)     == offsetof(Array, data));
+    CHECK(offsetof(das_array, size)     == offsetof(Array, size));
+    CHECK(offsetof(das_array, capacity) == offsetof(Array, capacity));
+    CHECK(offsetof(das_array, flags)    == offsetof(Array, flags));
+
+    CHECK(sizeof(das_table) == sizeof(Table));
+    CHECK(offsetof(das_table, data)       == offsetof(Table, data));
+    CHECK(offsetof(das_table, size)       == offsetof(Table, size));
+    CHECK(offsetof(das_table, capacity)   == offsetof(Table, capacity));
+    CHECK(offsetof(das_table, flags)      == offsetof(Table, flags));
+    CHECK(offsetof(das_table, keys)       == offsetof(Table, keys));
+    CHECK(offsetof(das_table, hashes)     == offsetof(Table, hashes));
+    CHECK(offsetof(das_table, tombstones) == offsetof(Table, tombstones));
+}
+
+TEST_CASE("context heap API: allocate / reallocate / free round-trip") {
+    static const char * SRC = "options gen2\n[export] def main {}\n";
+    InlineCtx ic = compile_inline(SRC);
+    REQUIRE(ic.ctx != nullptr);
+
+    SUBCASE("allocate returns non-null and is freeable") {
+        void * p = das_context_allocate(ic.ctx, 64);
+        REQUIRE(p != nullptr);
+        memset(p, 0xAB, 64);
+        das_context_free(ic.ctx, p, 64);
+    }
+
+    SUBCASE("allocate(0) returns null and free(null) is a no-op") {
+        CHECK(das_context_allocate(ic.ctx, 0) == nullptr);
+        das_context_free(ic.ctx, nullptr, 0); // must not crash
+    }
+
+    SUBCASE("reallocate preserves prefix bytes") {
+        void * p = das_context_allocate(ic.ctx, 16);
+        REQUIRE(p != nullptr);
+        for ( int i=0; i<16; i++ ) ((unsigned char*)p)[i] = (unsigned char)i;
+        void * q = das_context_reallocate(ic.ctx, p, 16, 64);
+        REQUIRE(q != nullptr);
+        for ( int i=0; i<16; i++ ) {
+            CHECK(((unsigned char*)q)[i] == (unsigned char)i);
+        }
+        das_context_free(ic.ctx, q, 64);
+    }
+
+    SUBCASE("reallocate to zero frees the block and returns NULL") {
+        // The runtime allocator's reallocate can't reach new_size==0 safely;
+        // the C wrapper handles it as free(ptr, old_size) + return NULL.
+        void * p = das_context_allocate(ic.ctx, 32);
+        REQUIRE(p != nullptr);
+        void * q = das_context_reallocate(ic.ctx, p, 32, 0);
+        CHECK(q == nullptr);
+        // reallocate(NULL, 0, 0) is also a no-op.
+        CHECK(das_context_reallocate(ic.ctx, nullptr, 0, 0) == nullptr);
+    }
+
+    cleanup_inline_ctx(ic);
+}
+
+TEST_CASE("das_array borrowed: daslang reads C-owned data") {
+    static const char * SRC =
+        "options gen2\n"
+        "[export] def sum_array(arr : array<int>#) : int {\n"
+        "    var t = 0\n"
+        "    for (v in arr) { t += v; }\n"
+        "    return t\n"
+        "}\n";
+    InlineCtx ic = compile_inline(SRC);
+    REQUIRE(ic.ctx != nullptr);
+
+    int data[5] = { 10, 20, 30, 40, 50 };
+    das_array borrowed;
+    das_array_init_borrowed(&borrowed, data, 5, 5);
+    // Borrowed-mode invariant: data points at our buffer; lock=1; shared=true.
+    CHECK(borrowed.data == (char*)data);
+    CHECK(borrowed.size == 5);
+    CHECK(borrowed.capacity == 5);
+    CHECK(borrowed.lock == 1);
+    CHECK((borrowed.flags & 1u) == 1u); // shared bit set
+
+    // Defensive: das_array_lock / _unlock are runtime no-ops on shared=true,
+    // so a misuse-by-unlock cannot drop the lock and turn the borrow into an
+    // owned-data path.
+    das_array_lock(ic.ctx, &borrowed);
+    CHECK(borrowed.lock == 1);
+    das_array_unlock(ic.ctx, &borrowed);
+    CHECK(borrowed.lock == 1);
+
+    das_function * fn = das_context_find_function(ic.ctx, "sum_array");
+    REQUIRE(fn != nullptr);
+    vec4f args[1] = { das_result_array(&borrowed) };
+    vec4f r = das_context_eval_with_catch(ic.ctx, fn, args);
+    CHECK(das_context_get_exception(ic.ctx) == nullptr);
+    CHECK(das_argument_int(r) == 150);
+    // No mutation, no copy: the original buffer is unchanged.
+    CHECK(data[0] == 10);
+    CHECK(borrowed.data == (char*)data);
+
+    cleanup_inline_ctx(ic);
+}
+
+TEST_CASE("das_array context-owned: daslang grows; C reads via das_array_at") {
+    static const char * SRC =
+        "options gen2\n"
+        "[export] def fill_squares(var arr : array<int>; n : int) {\n"
+        "    arr |> resize(n)\n"
+        "    for (i in range(n)) { arr[i] = i * i; }\n"
+        "}\n";
+    InlineCtx ic = compile_inline(SRC);
+    REQUIRE(ic.ctx != nullptr);
+
+    das_array owned;
+    das_array_init(&owned);
+    CHECK(owned.data == nullptr);
+    CHECK(owned.size == 0);
+
+    das_function * fn = das_context_find_function(ic.ctx, "fill_squares");
+    REQUIRE(fn != nullptr);
+    vec4f args[2] = {
+        das_result_array(&owned),
+        das_result_int(6),
+    };
+    das_context_eval_with_catch(ic.ctx, fn, args);
+    CHECK(das_context_get_exception(ic.ctx) == nullptr);
+    CHECK(owned.size == 6);
+    CHECK(owned.capacity >= 6);
+    REQUIRE(owned.data != nullptr);
+    for ( uint32_t i = 0; i < owned.size; i++ ) {
+        int v = *(int*)das_array_at(&owned, i, sizeof(int));
+        CHECK(v == int(i*i));
+    }
+
+    das_array_clear(ic.ctx, &owned, sizeof(int));
+    CHECK(owned.data == nullptr);
+    CHECK(owned.size == 0);
+    CHECK(owned.capacity == 0);
+
+    cleanup_inline_ctx(ic);
+}
+
+TEST_CASE("das_array C-side resize / lock / unlock without daslang") {
+    static const char * SRC = "options gen2\n[export] def main {}\n";
+    InlineCtx ic = compile_inline(SRC);
+    REQUIRE(ic.ctx != nullptr);
+
+    das_array a;
+    das_array_init(&a);
+    das_array_resize(ic.ctx, &a, 10, sizeof(int), /*zero=*/1);
+    REQUIRE(a.data != nullptr);
+    CHECK(a.size == 10);
+    for ( uint32_t i = 0; i < 10; i++ ) {
+        CHECK(*(int*)das_array_at(&a, i, sizeof(int)) == 0); // zeroed
+        *(int*)das_array_at(&a, i, sizeof(int)) = int(i) * 7;
+    }
+    das_array_lock(ic.ctx, &a);
+    CHECK(a.lock == 1);
+    das_array_lock(ic.ctx, &a);
+    CHECK(a.lock == 2);
+    das_array_unlock(ic.ctx, &a);
+    das_array_unlock(ic.ctx, &a);
+    CHECK(a.lock == 0);
+    das_array_clear(ic.ctx, &a, sizeof(int));
+
+    cleanup_inline_ctx(ic);
+}
+
+TEST_CASE("das_table fill from daslang; C reads via das_table_find") {
+    static const char * SRC =
+        "options gen2\n"
+        "[export] def count_values(var counts : table<int; int>; data : array<int>#) {\n"
+        "    for (v in data) {\n"
+        "        if (key_exists(counts, v)) { counts[v] = counts[v] + 1; }\n"
+        "        else { counts[v] = 1; }\n"
+        "    }\n"
+        "}\n";
+    InlineCtx ic = compile_inline(SRC);
+    REQUIRE(ic.ctx != nullptr);
+
+    int input[10] = { 7, 3, 7, 1, 3, 7, 1, 1, 1, 3 };
+    das_array data_view;
+    das_array_init_borrowed(&data_view, input, 10, 10);
+
+    das_table counts;
+    das_table_init(&counts);
+    das_function * fn = das_context_find_function(ic.ctx, "count_values");
+    REQUIRE(fn != nullptr);
+    vec4f args[2] = {
+        das_result_table(&counts),
+        das_result_array(&data_view),
+    };
+    das_context_eval_with_catch(ic.ctx, fn, args);
+    CHECK(das_context_get_exception(ic.ctx) == nullptr);
+    CHECK(counts.size == 3);
+
+    int k1 = 1, k3 = 3, k7 = 7, k99 = 99;
+    int * p1 = (int*)das_table_find(ic.ctx, &counts, DAS_TYPE_INT, &k1, sizeof(int));
+    int * p3 = (int*)das_table_find(ic.ctx, &counts, DAS_TYPE_INT, &k3, sizeof(int));
+    int * p7 = (int*)das_table_find(ic.ctx, &counts, DAS_TYPE_INT, &k7, sizeof(int));
+    int * p99 = (int*)das_table_find(ic.ctx, &counts, DAS_TYPE_INT, &k99, sizeof(int));
+    REQUIRE(p1); CHECK(*p1 == 4);
+    REQUIRE(p3); CHECK(*p3 == 3);
+    REQUIRE(p7); CHECK(*p7 == 3);
+    CHECK(p99 == nullptr);
+
+    das_table_clear(ic.ctx, &counts, DAS_TYPE_INT, sizeof(int));
+    CHECK(counts.data == nullptr);
+    CHECK(counts.size == 0);
+
+    cleanup_inline_ctx(ic);
+}
+
+TEST_CASE("das_table insert / find / erase round-trip from C only") {
+    static const char * SRC = "options gen2\n[export] def main {}\n";
+    InlineCtx ic = compile_inline(SRC);
+    REQUIRE(ic.ctx != nullptr);
+
+    SUBCASE("int keys") {
+        das_table t;
+        das_table_init(&t);
+        for ( int i = 0; i < 32; i++ ) {
+            int * pv = (int*)das_table_insert(ic.ctx, &t, DAS_TYPE_INT, &i, sizeof(int));
+            REQUIRE(pv);
+            *pv = i * 10;
+        }
+        CHECK(t.size == 32);
+        for ( int i = 0; i < 32; i++ ) {
+            int * pv = (int*)das_table_find(ic.ctx, &t, DAS_TYPE_INT, &i, sizeof(int));
+            REQUIRE(pv);
+            CHECK(*pv == i * 10);
+        }
+        int missing = 999;
+        CHECK(das_table_find(ic.ctx, &t, DAS_TYPE_INT, &missing, sizeof(int)) == nullptr);
+        int kerase = 5;
+        CHECK(das_table_erase(ic.ctx, &t, DAS_TYPE_INT, &kerase, sizeof(int)) == 1);
+        CHECK(das_table_erase(ic.ctx, &t, DAS_TYPE_INT, &kerase, sizeof(int)) == 0);
+        CHECK(das_table_find(ic.ctx, &t, DAS_TYPE_INT, &kerase, sizeof(int)) == nullptr);
+        das_table_clear(ic.ctx, &t, DAS_TYPE_INT, sizeof(int));
+    }
+
+    SUBCASE("int64 keys") {
+        das_table t;
+        das_table_init(&t);
+        long long k = 0x123456789abcdefLL;
+        int v_in = 42;
+        int * pv = (int*)das_table_insert(ic.ctx, &t, DAS_TYPE_INT64, &k, sizeof(int));
+        REQUIRE(pv);
+        *pv = v_in;
+        int * found = (int*)das_table_find(ic.ctx, &t, DAS_TYPE_INT64, &k, sizeof(int));
+        REQUIRE(found);
+        CHECK(*found == 42);
+        das_table_clear(ic.ctx, &t, DAS_TYPE_INT64, sizeof(int));
+    }
+
+    SUBCASE("uint64 keys") {
+        das_table t;
+        das_table_init(&t);
+        unsigned long long k = 0xdeadbeefcafebabeULL;
+        int * pv = (int*)das_table_insert(ic.ctx, &t, DAS_TYPE_UINT64, &k, sizeof(int));
+        REQUIRE(pv);
+        *pv = 7;
+        int * found = (int*)das_table_find(ic.ctx, &t, DAS_TYPE_UINT64, &k, sizeof(int));
+        REQUIRE(found);
+        CHECK(*found == 7);
+        das_table_clear(ic.ctx, &t, DAS_TYPE_UINT64, sizeof(int));
+    }
+
+    SUBCASE("enumeration / bitfield keys hit the extended dispatch") {
+        // Both reuse the underlying integer hash but go through the
+        // tEnumeration / tBitfield case arms — proves the dispatch now
+        // mirrors table_reserve_impl, not just the scalar subset.
+        das_table t;
+        das_table_init(&t);
+        int32_t e_key = 7;       // tEnumeration is stored as int32
+        uint32_t b_key = 0xCAFEu; // tBitfield is stored as uint32
+
+        int * pe = (int*)das_table_insert(ic.ctx, &t, DAS_TYPE_ENUMERATION, &e_key, sizeof(int));
+        REQUIRE(pe);
+        *pe = 100;
+        int * found_e = (int*)das_table_find(ic.ctx, &t, DAS_TYPE_ENUMERATION, &e_key, sizeof(int));
+        REQUIRE(found_e);
+        CHECK(*found_e == 100);
+        das_table_clear(ic.ctx, &t, DAS_TYPE_ENUMERATION, sizeof(int));
+
+        das_table_init(&t);
+        int * pb = (int*)das_table_insert(ic.ctx, &t, DAS_TYPE_BITFIELD, &b_key, sizeof(int));
+        REQUIRE(pb);
+        *pb = 200;
+        int * found_b = (int*)das_table_find(ic.ctx, &t, DAS_TYPE_BITFIELD, &b_key, sizeof(int));
+        REQUIRE(found_b);
+        CHECK(*found_b == 200);
+        das_table_clear(ic.ctx, &t, DAS_TYPE_BITFIELD, sizeof(int));
+    }
+
+    cleanup_inline_ctx(ic);
+}

--- a/tutorials/integration/c/14_passing_arrays.c
+++ b/tutorials/integration/c/14_passing_arrays.c
@@ -1,0 +1,187 @@
+// Tutorial: Passing Arrays (and Tables) from C to daslang
+//
+// This tutorial demonstrates two ownership flavors for `array<T>` arguments,
+// plus a `table<K;V>` example:
+//
+//   1. Borrowed array — backing data lives in a C-side buffer; daslang reads
+//      it without taking ownership and is forbidden from resizing it.
+//
+//   2. Context-owned array — daslang allocates and grows the backing storage
+//      on the context heap; C reads the result back through the das_array
+//      struct and frees with das_array_clear.
+//
+//   3. Context-owned table — same pattern as (2), with key/value dispatch.
+//
+// All three rely on three pieces of C API added alongside this tutorial:
+//   - das_context_allocate / _reallocate / _free  (raw context heap)
+//   - das_array_init / _init_borrowed / _resize / _clear / _at
+//   - das_table_init / _reserve / _find / _insert / _erase / _clear
+//
+// Build: link against libDaScript.
+// Run:   from the project root so that the .das file path resolves correctly.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "daScript/daScriptC.h"
+
+#define SCRIPT_NAME "/tutorials/integration/c/14_passing_arrays.das"
+
+// Compile + simulate, returning the context (or NULL on failure).
+static das_context * compile_and_simulate(
+    const char * script_path,
+    das_file_access * file_access,
+    das_text_writer * tout,
+    das_module_group * module_group,
+    das_program ** out_program
+) {
+    *out_program = das_program_compile((char*)script_path, file_access, tout, module_group);
+    int err_count = das_program_err_count(*out_program);
+    if (err_count) {
+        printf("Compilation failed with %d error(s)\n", err_count);
+        for (int i = 0; i < err_count; i++)
+            das_error_output(das_program_get_error(*out_program, i), tout);
+        return NULL;
+    }
+    das_context * ctx = das_context_make(das_program_context_stack_size(*out_program));
+    if (!das_program_simulate(*out_program, ctx, tout)) {
+        printf("Simulation failed\n");
+        das_context_release(ctx);
+        return NULL;
+    }
+    return ctx;
+}
+
+int main(int argc, char ** argv) {
+    (void)argc; (void)argv;
+
+    das_initialize();
+
+    das_text_writer  * tout         = das_text_make_printer();
+    das_module_group * module_group = das_modulegroup_make();
+    das_file_access  * file_access  = das_fileaccess_make_default();
+
+    char script_path[512];
+    das_get_root(script_path, sizeof(script_path));
+    int chars_left = ((int)sizeof(script_path)) - ((int)strlen(script_path)) - 1;
+    assert(chars_left >= 0);
+    strncat(script_path, SCRIPT_NAME, (size_t)chars_left);
+
+    das_program * program = NULL;
+    das_context * ctx = compile_and_simulate(script_path, file_access, tout, module_group, &program);
+    if (!ctx) goto cleanup;
+
+    // -----------------------------------------------------------------------
+    // 1. Borrowed array — daslang reads C-owned data, never resizes
+    //
+    // `int data[8]` lives in this stack frame. das_array_init_borrowed wraps
+    // it as a non-owned view: lock=1, magic set, so any daslang attempt to
+    // grow or delete the array panics. sum_array only reads, which is fine.
+    // -----------------------------------------------------------------------
+    {
+        das_function * fn_sum = das_context_find_function(ctx, "sum_array");
+        if (!fn_sum) { printf("'sum_array' not found\n"); goto done; }
+
+        int data[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+        das_array borrowed;
+        das_array_init_borrowed(&borrowed, data, 8, 8);
+
+        vec4f args[1];
+        args[0] = das_result_array(&borrowed);
+
+        vec4f ret = das_context_eval_with_catch(ctx, fn_sum, args);
+        if (das_context_get_exception(ctx)) { printf("exception in sum_array\n"); goto done; }
+
+        printf("sum_array([1..8]) = %d\n", das_argument_int(ret));
+        // No cleanup: daslang never owned `data`.
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Context-owned array — daslang grows the backing storage from empty
+    //
+    // We hand fill_squares an empty array; it calls `arr |> resize(n)`, which
+    // routes through context.allocate / reallocate (the same heap path now
+    // exposed via das_context_allocate). After the call, das_array.data points
+    // into the context heap; we read it through das_array_at, then release
+    // with das_array_clear.
+    // -----------------------------------------------------------------------
+    {
+        das_function * fn_fill = das_context_find_function(ctx, "fill_squares");
+        if (!fn_fill) { printf("'fill_squares' not found\n"); goto done; }
+
+        das_array owned;
+        das_array_init(&owned);
+
+        vec4f args[2];
+        args[0] = das_result_array(&owned);
+        args[1] = das_result_int(6);
+
+        das_context_eval_with_catch(ctx, fn_fill, args);
+        if (das_context_get_exception(ctx)) { printf("exception in fill_squares\n"); goto done; }
+
+        printf("fill_squares(_, 6) -> size=%u, contents=", owned.size);
+        for (uint32_t i = 0; i < owned.size; i++) {
+            int v = *(int*)das_array_at(&owned, i, sizeof(int));
+            printf("%s%d", i ? "," : "", v);
+        }
+        printf("\n");
+
+        das_array_clear(ctx, &owned, sizeof(int));
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Context-owned table — count occurrences via daslang
+    //
+    // Same lifecycle as (2): init, hand to daslang, read back, clear.
+    // The C side uses das_table_find for spot lookups; das_table_clear must
+    // be told the key base type and value size so it can free the contiguous
+    // (values | keys | hashes) heap block daslang allocated.
+    // -----------------------------------------------------------------------
+    {
+        das_function * fn_count = das_context_find_function(ctx, "count_values");
+        if (!fn_count) { printf("'count_values' not found\n"); goto done; }
+
+        // Input data: a borrowed array of ints to count.
+        int input[10] = { 7, 3, 7, 1, 3, 7, 1, 1, 1, 3 };
+        das_array data_view;
+        das_array_init_borrowed(&data_view, input, 10, 10);
+
+        // Output table: empty, daslang fills it.
+        das_table counts;
+        das_table_init(&counts);
+
+        vec4f args[2];
+        args[0] = das_result_table(&counts);
+        args[1] = das_result_array(&data_view);
+
+        das_context_eval_with_catch(ctx, fn_count, args);
+        if (das_context_get_exception(ctx)) { printf("exception in count_values\n"); goto done; }
+
+        // Spot-check a few keys via das_table_find. Each find returns either
+        // a pointer into the value slot or NULL on miss.
+        int keys_to_check[] = { 1, 3, 7, 99 };
+        for (int i = 0; i < 4; i++) {
+            int k = keys_to_check[i];
+            int * pv = (int*)das_table_find(ctx, &counts, DAS_TYPE_INT, &k, sizeof(int));
+            if (pv) printf("counts[%d] = %d\n", k, *pv);
+            else    printf("counts[%d] = (missing)\n", k);
+        }
+
+        das_table_clear(ctx, &counts, DAS_TYPE_INT, sizeof(int));
+        // data_view borrows `input`; nothing to free.
+    }
+
+done:
+    das_context_release(ctx);
+
+cleanup:
+    das_program_release(program);
+    das_fileaccess_release(file_access);
+    das_modulegroup_release(module_group);
+    das_text_release(tout);
+
+    das_shutdown();
+    return 0;
+}

--- a/tutorials/integration/c/14_passing_arrays.das
+++ b/tutorials/integration/c/14_passing_arrays.das
@@ -1,0 +1,41 @@
+options gen2
+
+// Companion script for the "Passing Arrays from C" tutorial.
+// The C host constructs `array<int>` and `table<int; int>` values via the new
+// das_array / das_table C API and hands them to these functions. The functions
+// read or mutate them in place; results flow back through the same struct.
+
+// Sum the elements of a borrowed array. The `array<int>#` type is daslang's
+// "temporary" array — it cannot be retained or extended, so the runtime
+// will refuse any growth attempt. Matches the C side's das_array_init_borrowed.
+[export]
+def sum_array(arr : array<int>#) : int {
+    var total = 0
+    for (v in arr) {
+        total += v
+    }
+    return total
+}
+
+// Fill `arr` with the first n perfect squares (0, 1, 4, 9, ...). Resizing
+// from C-side empty to n elements drives growth on the context heap.
+[export]
+def fill_squares(var arr : array<int>; n : int) {
+    arr |> resize(n)
+    for (i in range(n)) {
+        arr[i] = i * i
+    }
+}
+
+// Count occurrences of each value in `data`, accumulating into `counts`.
+// `data` is a borrowed view (array<int>#); `counts` is a mutable owned table.
+[export]
+def count_values(var counts : table<int; int>; data : array<int>#) {
+    for (v in data) {
+        if (key_exists(counts, v)) {
+            counts[v] = counts[v] + 1
+        } else {
+            counts[v] = 1
+        }
+    }
+}

--- a/tutorials/integration/c/CMakeLists.txt
+++ b/tutorials/integration/c/CMakeLists.txt
@@ -124,6 +124,13 @@ DAS_C_INTEGRATION_TUTORIAL(integration_c_13
     ${CMAKE_CURRENT_SOURCE_DIR}/integration/c/13_shared_module.c
 )
 
+#################################
+# Tutorial 14 — Passing Arrays
+#################################
+DAS_C_INTEGRATION_TUTORIAL(integration_c_14
+    ${CMAKE_CURRENT_SOURCE_DIR}/integration/c/14_passing_arrays.c
+)
+
 # Install C integration tutorial source files
 file(GLOB C_INTEGRATION_TUTORIAL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/integration/c/*.c


### PR DESCRIPTION
## Summary

Adds the C API surface needed to construct, populate and pass `array<T>` / `table<K;V>` values across the C boundary, plus tutorial 14 walking through both ownership flavors (C-owned / borrowed and context-heap-owned).

While prototyping the tutorial three gaps surfaced; this PR closes all three in the same change so the tutorial can actually compile end-to-end:

1. **`das_array` / `das_table` layout was out of sync with `das::Array` / `das::Table`** — `daScriptC.h` was missing the runtime's `magic` field (offset 16, used for moved-or-overwritten validation), shifting `lock` and `flags` by 4 bytes. C consumers reading those fields landed in the wrong bytes. There were no `static_assert` checks anywhere to catch this.
2. **No public C heap API** — without `das_context_allocate` / `_reallocate` / `_free`, C code couldn't pre-allocate context-heap memory for arrays daslang would later resize.
3. **No array/table helpers** — no init / reserve / resize / clear / lock / find / insert / erase from C; everything had to route through bespoke daslang code.

## What landed

### C API
- `das_array` / `das_table` re-laid-out to mirror `das::Array` / `das::Table` byte-for-byte. Compile-time `static_assert(sizeof(...) == sizeof(...))` + per-field `offsetof` checks in `daScriptC.cpp` guard against future drift.
- `das_context_allocate` / `_reallocate` / `_free` — thin wrappers over `Context::allocate` / `_reallocate` / `free`.
- `das_array_init` / `_init_borrowed` / `_reserve` / `_resize` / `_clear` / `_at` / `_lock` / `_unlock`.
- `das_table_init` / `_reserve` / `_clear` / `_find` / `_insert` / `_erase` / `_lock` / `_unlock`. Key-type dispatch routes through the existing `TableHash<K>` instantiations (17 supported key types — bool/int8…/int…/int64…/float/double/range/urange/range64/urange64/string/pointer).
- `das_argument_array` / `_table` and `das_result_array` / `_table` (aligned + unaligned).

### Tutorial 14 — Passing Arrays
- `tutorials/integration/c/14_passing_arrays.{c,das}` + RST walkthrough. Demonstrates:
  - **Borrowed:** `das_array_init_borrowed` over a stack `int data[8]`, with the daslang-side type `array<int>#` making the no-grow / no-retain contract a compile-time check rather than a runtime panic.
  - **Context-owned:** empty array → daslang's `arr |> resize(n)` grows on the context heap → C reads back via `das_array_at` → `das_array_clear` releases.
  - **Table fill:** daslang counts occurrences into a `table<int; int>`; C verifies via `das_table_find`.
- Registered in `tutorials/integration/c/CMakeLists.txt`; RST page added to the C-integration toctree in `doc/source/reference/tutorials.rst`.

### Tests
- `tests-cpp/small/test_c_array_table_api.cpp` — doctest cases covering: layout canary (runtime `offsetof`/`sizeof` belt-and-braces over the static_asserts), heap round-trip, borrowed array (data pointer unchanged, runtime sees the lock), context-owned array (resize from C and from daslang), table fill via daslang, table insert/find/erase across multiple key types.

## Test plan

- [x] `libDaScript` builds clean with the new `static_assert`s
- [x] `tests-cpp-small`: 16 cases / 272 assertions, all pass (new test file picked up automatically by the glob)
- [x] `dastest --test tests/`: 7976 tests, 7970 pass, 0 failures, 0 errors, 6 skipped (unaffected — no daslang language semantics changed)
- [x] `bin/Release/integration_c_14` runs to completion with the exact output documented in the RST
- [x] `mcp__daslang__format_file` + `mcp__daslang__lint` clean on `14_passing_arrays.das`
- [x] `sphinx-build -W` (warnings-as-errors) clean — no new doc warnings from the added RST page or toctree edit
