### PR TITLE
mouse: git-aware auto-reindex + Jaccard dupe gate + --raw-query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ Full migration table (when reading older docs that say `var inscope` or `<-` for
 - `table[key]` (read or assign) is **safe** — do NOT wrap in `unsafe(...)`. Some legacy daslib code has `unsafe(tab[k])`; do not propagate that pattern
 - **Move-assign table literal:** `tab <- { "k" => v }` works for both `var tab <- { ... }` declarations and `tab <- { ... }` reassignment to existing variables
 - **Table comprehension move-assign:** `tab <- { for(x in range(5)); x => x*x }` — same move-assign rules apply
-- **`table<T>` (one type param) is the set type** — value type elided. `var s : table<int>; s |> insert(5); key_exists(s, 5)`. Distinct from `table<K; V>` (the map form); both shapes coexist.
+- **`table<T>` (one type param) is the set type** — value type elided. `var s : table<int>; s |> insert(5); key_exists(s, 5)`. Distinct from `table<K; V>` (the map form); both shapes coexist. Set-literal init: `let STOP_WORDS : table<string> <- { "a", "an", "the" }` — value-less braces, comma-separated. Use this instead of declaring `var X : table<T>` and populating in an `[init]` function.
 
 ### Iterators and `each`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1573,6 +1573,15 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/utils/mouse/tests/
     FILES_MATCHING PATTERN "*.das" PATTERN "*.md"
 )
 
+# Install utils/common (git-aware staleness signature shared between
+# utils/mcp/tools/cpp_common and utils/mouse/index).
+file(GLOB DAS_UTILS_COMMON_FILES ${PROJECT_SOURCE_DIR}/utils/common/*.das)
+install(FILES ${DAS_UTILS_COMMON_FILES} DESTINATION utils/common)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/utils/common/tests/
+    DESTINATION utils/common/tests
+    FILES_MATCHING PATTERN "*.das"
+)
+
 # Install daspkg (package manager)
 file(GLOB DAS_DASPKG_FILES ${PROJECT_SOURCE_DIR}/utils/daspkg/*.das)
 install(FILES ${DAS_DASPKG_FILES} DESTINATION utils/daspkg)

--- a/daslib/fio.das
+++ b/daslib/fio.das
@@ -704,3 +704,26 @@ def rmdir_rec_result(path : string) : fs_result_bool {
     }
     return fs_result_bool(value = res)
 }
+
+def run_and_capture(args : array<string>; var output : string&; timeout_sec : float = 0.0) : int {
+    //! Run an external command and capture its stdout+stderr (merged into one
+    //! pipe by the underlying ``popen_argv``). Returns the process exit code;
+    //! ``output`` is filled with whatever the child wrote to either stream.
+    //!
+    //! ``args[0]`` is the executable; remaining elements are positional arguments.
+    //! ``timeout_sec > 0`` kills the process tree after that many seconds (returns
+    //! ``popen_timed_out``); ``timeout_sec <= 0`` means no timeout.
+    //!
+    //! Argv-based: bypasses the shell entirely (Windows: CreateProcess; Unix:
+    //! fork+execvp). No ``cmd.exe`` quote-stripping, no ``/bin/sh`` ``$()``/backtick
+    //! expansion — every argv element reaches the child verbatim. Callers don't
+    //! (and shouldn't) quote arguments themselves.
+    var captured : string
+    let exit_code = unsafe(popen_argv(args, timeout_sec, $(f) {
+        if (f != null) {
+            captured := unsafe(fread_to_eof(f))
+        }
+    }))
+    output := captured
+    return exit_code
+}

--- a/daslib/strings_boost.das
+++ b/daslib/strings_boost.das
@@ -205,6 +205,37 @@ def levenshtein_distance_fast(s, t : string implicit) : int {
     return v0[tLen]
 }
 
+def public jaccard(a : table<string>; b : table<string>) : float {
+    //! Jaccard similarity over two string-sets: ``|intersection| / |union|`` in 0..1.
+    //! Empty either side returns 0.0. Use ``table<string>`` (the set form) so
+    //! the intersect lookup is O(1).
+    if (empty(a) || empty(b)) {
+        return 0.0f
+    }
+    var intersect = 0
+    for (k in keys(a)) {
+        if (key_exists(b, k)) {
+            intersect ++
+        }
+    }
+    let unionSize = length(a) + length(b) - intersect
+    return float(intersect) / float(unionSize)
+}
+
+def public jaccard(a, b : array<string>) : float {
+    //! Jaccard similarity over two string arrays. Builds two ``table<string>``
+    //! sets and delegates — convenient when callers don't already have sets.
+    var sa : table<string>
+    for (x in a) {
+        sa |> insert(x)
+    }
+    var sb : table<string>
+    for (x in b) {
+        sb |> insert(x)
+    }
+    return jaccard(sa, sb)
+}
+
 def replace_multiple(source : string; replaces : array<tuple<text : string; replacement : string>>) {
     //! replaces occurances of multiple strings in a string. does not support overlap
     if (empty(source) || empty(replaces)) {

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -193,7 +193,7 @@ def document_module_fio(root : string) {
         group_by_regex("Directory manipulation", mod, %regex~(dir|dir_rec|mkdir|mkdir_rec|mkdir_result|rmdir|rmdir_rec|rmdir_rec_result|rmdir_result|chdir|getcwd)$%%),
         group_by_regex("Glob and pattern matching", mod, %regex~(match_glob|glob|glob_filtered|is_glob_pattern|expand_glob|parse_file_list)$%%),
         group_by_regex("Filesystem queries", mod, %regex~(temp_directory|temp_directory_result|create_temp_file|create_temp_file_result|create_temp_directory|create_temp_directory_result|disk_space)$%%),
-        group_by_regex("OS specific routines", mod, %regex~(sleep|exit|system|popen|popen_binary|popen_timeout|popen_argv|popen_timed_out|get_env_variable|sanitize_command_line|has_env_variable)$%%),
+        group_by_regex("OS specific routines", mod, %regex~(sleep|exit|system|popen|popen_binary|popen_timeout|popen_argv|popen_timed_out|run_and_capture|get_env_variable|sanitize_command_line|has_env_variable)$%%),
         group_by_regex("Dynamic modules", mod, %regex~(register_dynamic_module|register_native_path)$%%)
     )
     documents("File input output library", mod, "fio.rst", groups)
@@ -376,7 +376,7 @@ def document_module_strings_boost(root : string) {
         group_by_regex("Search and match", mod, %regex~(last_index_of|glob_match|text_match)$%%),
         group_by_regex("Replace", mod, %regex~(replace_multiple)$%%),
         group_by_regex("Prefix and suffix", mod, %regex~(trim_prefix|trim_suffix)$%%),
-        group_by_regex("Levenshtein distance", mod, %regex~(levenshtein_distance|levenshtein_distance_fast)$%%),
+        group_by_regex("String similarity", mod, %regex~(levenshtein_distance|levenshtein_distance_fast|jaccard)$%%),
         group_by_regex("Character traits", mod, %regex~(is_hex|is_tab_or_space)$%%))
     document("Boost package for string manipulation library", mod, "strings_boost.rst", groups)
 }

--- a/doc/source/stdlib/handmade/function-strings_boost-jaccard-0x4338ed9b289792ae.rst
+++ b/doc/source/stdlib/handmade/function-strings_boost-jaccard-0x4338ed9b289792ae.rst
@@ -1,0 +1,1 @@
+Jaccard similarity over two string-sets, returning ``|intersection| / |union|`` in 0..1. Empty either side returns 0. Pass two ``table<string>`` (the set form) for O(1) intersect lookup, or two ``array<string>`` and the array overload will build the sets internally.

--- a/mouse-data/docs/das2rst-emits-a-stub-for-my-new-public-daslib-function-even-though-i-added-a-doc-comment-what-s-the-right-fix.md
+++ b/mouse-data/docs/das2rst-emits-a-stub-for-my-new-public-daslib-function-even-though-i-added-a-doc-comment-what-s-the-right-fix.md
@@ -1,0 +1,37 @@
+---
+slug: das2rst-emits-a-stub-for-my-new-public-daslib-function-even-though-i-added-a-doc-comment-what-s-the-right-fix
+title: das2rst emits a // stub for my new public daslib function even though I added a //! doc-comment — what's the right fix?
+created: 2026-05-09
+last_verified: 2026-05-09
+links: []
+---
+
+Two things are going on; the `documentation_rst.md` skill rolls them together as "add `//!` instead of filling the stub" but the real story has a wrinkle.
+
+**1. `//!` placement — must be INSIDE the function body, not before `def`.**
+For pure-daslang functions in `daslib/*.das`, `rst_comment.das` extracts `//!` comments only when they appear as the first line(s) of the function body:
+
+```daslang
+def public foo(x : int) : int {
+    //! Docs go HERE — first lines of the body.
+    //! Multi-line continues like this.
+    return x + 1
+}
+```
+
+`//!` placed *before* `def` is silently ignored. Symptom: regen still produces a `// stub` placeholder under `doc/source/stdlib/handmade/function-<module>-<name>-<hash>.rst`. The fix is to move the doc-comment inside the body and re-run `das2rst`.
+
+**2. Some daslib modules expect BOTH a `//!` body comment AND a per-symbol `handmade/*.rst`.**
+Modules like `strings_boost`, `fio`, and other long-established ones have a per-symbol `handmade/*.rst` for *every* function — see e.g. `function-strings_boost-levenshtein_distance-0xbb5a4a3017b240a5.rst`. When you add a new public function to one of those modules, `das2rst` will emit a fresh `// stub` even with correctly-placed `//!`. The convention there is: keep the `//!` (it lands in `detail/`) **and** fill the stub with a 1-2 sentence handmade description. Don't delete the stub — re-running `das2rst` recreates it.
+
+Newer modules like `archive`, `json_boost`, `command_line` don't have per-symbol handmade entries; for those, `//!` alone is enough.
+
+**How to apply:**
+- New daslib public function → add `//!` inside body first.
+- Run `bin/daslang doc/reflections/das2rst.das`.
+- `grep -rln "// stub" doc/source/stdlib/handmade/` — if your function appears, fill that file with a short description (plain text, no RST directives). If your function doesn't appear, you're done.
+- Re-run `das2rst` to confirm clean.
+- Verify `grep -c Uncategorized doc/source/stdlib/generated/*.rst | grep -v ':0$'` is empty (means the function is in a `group_by_regex` group in `das2rst.das`).
+
+## Questions
+- das2rst emits a // stub for my new public daslib function even though I added a //! doc-comment — what's the right fix?

--- a/tests/strings/strings_jaccard.das
+++ b/tests/strings/strings_jaccard.das
@@ -1,0 +1,72 @@
+options gen2
+require dastest/testing_boost
+require daslib/strings_boost
+
+def make_set(items : array<string>) : table<string> {
+    var s : table<string>
+    for (x in items) {
+        s |> insert(x)
+    }
+    return <- s
+}
+
+[test]
+def test_jaccard_table(t : T?) {
+    t |> run("equal sets") @@(t : T?) {
+        let a <- make_set(["foo", "bar", "baz"])
+        let b <- make_set(["foo", "bar", "baz"])
+        t |> equal(jaccard(a, b), 1.0f)
+    }
+
+    t |> run("disjoint sets") @@(t : T?) {
+        let a <- make_set(["foo", "bar"])
+        let b <- make_set(["baz", "qux"])
+        t |> equal(jaccard(a, b), 0.0f)
+    }
+
+    t |> run("partial overlap") @@(t : T?) {
+        let a <- make_set(["foo", "bar", "baz"])
+        let b <- make_set(["foo", "bar", "qux"])
+        t |> equal(jaccard(a, b), 0.5f)
+    }
+
+    t |> run("subset") @@(t : T?) {
+        let a <- make_set(["foo", "bar"])
+        let b <- make_set(["foo", "bar", "baz", "qux"])
+        t |> equal(jaccard(a, b), 0.5f)
+    }
+
+    t |> run("empty either side returns 0") @@(t : T?) {
+        let a <- make_set(["foo"])
+        let b : table<string>
+        t |> equal(jaccard(a, b), 0.0f)
+        t |> equal(jaccard(b, a), 0.0f)
+    }
+
+    t |> run("both empty returns 0") @@(t : T?) {
+        let a : table<string>
+        let b : table<string>
+        t |> equal(jaccard(a, b), 0.0f)
+    }
+}
+
+[test]
+def test_jaccard_array(t : T?) {
+    t |> run("array overload matches table form") @@(t : T?) {
+        let a <- ["foo", "bar", "baz"]
+        let b <- ["foo", "bar", "qux"]
+        t |> equal(jaccard(a, b), 0.5f)
+    }
+
+    t |> run("array dedupes via set conversion") @@(t : T?) {
+        let a <- ["foo", "foo", "bar"]   // dedupes to {foo, bar}
+        let b <- ["foo", "bar"]
+        t |> equal(jaccard(a, b), 1.0f)
+    }
+
+    t |> run("array empty returns 0") @@(t : T?) {
+        let a <- ["foo"]
+        let b : array<string>
+        t |> equal(jaccard(a, b), 0.0f)
+    }
+}

--- a/utils/common/git_signature.das
+++ b/utils/common/git_signature.das
@@ -1,0 +1,194 @@
+// Shared git-aware staleness signature for utils/* index caches.
+//
+// Used by both `utils/mcp/tools/cpp_common.das` (cpp source-search index)
+// and `utils/mouse/index.das` (markdown docs index). Each consumer plugs
+// in its own path predicate and search-dirs scope; this module owns the
+// git plumbing, the filesystem fallback, and the determinism guarantees
+// (sorted fs walk, per-tree HEAD hash).
+
+options gen2
+
+require strings public
+require daslib/fio public
+require daslib/strings_boost public
+
+// Repo-relative path with `/`-separators; falls back to `path` on error
+// (mirrors `make_relative_path` from utils/mcp/tools/common.das, kept
+// local so this module has no cross-tool dependencies).
+def private to_relative(path, base : string) : string {
+    var err : string
+    let rel = relative(path, base, err)
+    return to_generic_path(empty(rel) ? path : rel)
+}
+
+// Strip `git status --porcelain` 3-char status prefix; return the new
+// name on rename lines (`R  old -> new`).
+def public extract_status_path(line : string) : string {
+    if (length(line) <= 3) {
+        return ""
+    }
+    var path = slice(line, 3)
+    let arrow = find(path, " -> ")
+    if (arrow >= 0) {
+        path = slice(path, arrow + 4)
+    }
+    return path
+}
+
+// stat() wrapper that returns 0 on missing/error so signature compute
+// doesn't crash on a deleted/inaccessible file.
+def public stat_mtime_or_zero(path : string) : int64 {
+    let st = stat(path)
+    return st.is_valid ? int64(st.mtime) : 0l
+}
+
+def private is_directory(path : string) : bool {
+    let s = stat(path)
+    return s.is_valid && s.is_dir
+}
+
+// Filesystem-only fallback signature. Walks each `search_dirs_abs`
+// recursively, collects (repo_rel_path, mtime) for files passing
+// `predicate`, **sorts the collection by path**, then hashes. The sort
+// makes the signature deterministic across platforms — `_findfirst` on
+// Windows and `readdir()` on Unix don't guarantee stable order, so the
+// raw walk order would otherwise produce different signatures for the
+// same on-disk state.
+//
+// Returns "fs:HASH" on success, "" if every search_dir is missing.
+def public compute_filesystem_signature(
+                                        root : string;
+                                        predicate : lambda<(repo_rel_path : string) : bool>;
+                                        search_dirs_abs : array<string>
+                                        ) : string {
+    var collected : array<tuple<string; int64>>
+    var any_dir = false
+    for (sd in search_dirs_abs) {
+        if (!is_directory(sd)) {
+            continue
+        }
+        any_dir = true
+        var sd_rel = to_relative(sd, root)
+        if (sd_rel == ".") {
+            sd_rel = ""
+        }
+        dir_rec(sd) $(filename, is_dir) {
+            if (is_dir) {
+                return
+            }
+            let leaf = to_generic_path(filename)
+            let rel = empty(sd_rel) ? leaf : "{sd_rel}/{leaf}"
+            if (!invoke(predicate, rel)) {
+                return
+            }
+            collected |> push((rel, stat_mtime_or_zero(path_join(sd, filename))))
+        }
+    }
+    if (!any_dir) {
+        return ""
+    }
+    sort(collected) <| $(a, b) => a._0 < b._0
+    let combined = build_string() $(var w) {
+        for (item in collected) {
+            w |> write("{item._0}:{item._1}\n")
+        }
+    }
+    return "fs:{hash(combined)}"
+}
+
+// Compute a git-aware staleness signature for the index covering
+// `search_dirs_abs`, considering only paths matching `predicate`.
+//
+// `root` is any directory inside the repo; the module discovers the git
+// toplevel via `git -C root rev-parse --show-toplevel`.
+//
+// `predicate(repo_rel_path)` decides whether a path is part of the index
+// (e.g. ends_with(".md") for docs, ends_with(".cpp"|".h"|".hpp") for cpp).
+// Status output is pre-narrowed to paths under any `search_dirs_abs`
+// entry, so the predicate only needs the file-class filter.
+//
+// Strategy:
+//   1. Discover toplevel; on failure → compute_filesystem_signature.
+//   2. For each search_dir, `git rev-parse HEAD:<dir_rel>` → tree hash.
+//      Per-tree hashing fixes the global-HEAD over-invalidation: only
+//      commits that change a tracked tree under an indexed dir trigger
+//      a rebuild. (Branch switches that don't touch indexed trees
+//      become no-ops; `git pull` of unrelated subtrees stops re-churning
+//      the index.) On rev-parse error for a dir (untracked at HEAD), use
+//      a placeholder so the next status line catches new files.
+//   3. `git status --porcelain --untracked-files=normal`. Per line:
+//      extract path; reject if not under any search_dir; reject if
+//      predicate is false; otherwise fold "<line>:<mtime>" into hash.
+//   4. Return "git:HASH". Any git step error → fall back to fs.
+//
+// Returns "" only if both git and the filesystem walk fail (caller
+// should treat empty as "do not invalidate blindly").
+def public compute_signature(
+                             root : string;
+                             predicate : lambda<(repo_rel_path : string) : bool>;
+                             search_dirs_abs : array<string>
+                             ) : string {
+    var top_buf : string
+    if (run_and_capture(["git", "-C", root, "rev-parse", "--show-toplevel"], top_buf, 5.0) != 0
+        || empty(strip(top_buf))) {
+        return compute_filesystem_signature(root, predicate, search_dirs_abs)
+    }
+    let toplevel = strip(top_buf)
+
+    var dirs_rel : array<string>
+    dirs_rel |> reserve(length(search_dirs_abs))
+    for (sd in search_dirs_abs) {
+        var rel = to_relative(sd, toplevel)
+        if (rel == ".") {
+            rel = ""
+        }
+        dirs_rel |> push(rel)
+    }
+    // Sort so the tree-hash fold below produces an order-independent
+    // signature regardless of how the caller ordered `search_dirs_abs`.
+    sort(dirs_rel) <| $(a, b) => a < b
+
+    var tree_parts : array<string>
+    for (rel in dirs_rel) {
+        var tb : string
+        // Empty rel means search_dir == toplevel; rev-parse HEAD: errors,
+        // so use bare HEAD in that case.
+        let spec = empty(rel) ? "HEAD" : "HEAD:{rel}"
+        if (run_and_capture(["git", "-C", toplevel, "rev-parse", spec], tb, 5.0) == 0
+            && !empty(strip(tb))) {
+            tree_parts |> push("{rel}={strip(tb)}")
+        } else {
+            tree_parts |> push("{rel}=untracked")
+        }
+    }
+
+    var status_buf : string
+    if (run_and_capture(["git", "-C", toplevel, "status", "--porcelain", "--untracked-files=normal"],
+                        status_buf, 5.0) != 0) {
+        return compute_filesystem_signature(root, predicate, search_dirs_abs)
+    }
+    let lines <- split(status_buf, "\n")
+    let combined = build_string() $(var w) {
+        for (t in tree_parts) {
+            w |> write("{t}\n")
+        }
+        for (line in lines) {
+            let p = extract_status_path(line)
+            if (empty(p)) {
+                continue
+            }
+            var under = false
+            for (rel in dirs_rel) {
+                if (empty(rel) || p == rel || starts_with(p, "{rel}/")) {
+                    under = true
+                    break
+                }
+            }
+            if (!under || !invoke(predicate, p)) {
+                continue
+            }
+            w |> write("{line}:{stat_mtime_or_zero(path_join(toplevel, p))}\n")
+        }
+    }
+    return "git:{hash(combined)}"
+}

--- a/utils/common/tests/test_git_signature.das
+++ b/utils/common/tests/test_git_signature.das
@@ -1,0 +1,151 @@
+options gen2
+
+require dastest/testing_boost public
+require strings
+require daslib/fio
+require ../git_signature.das
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+def make_temp_root(t : T?) : string {
+    let r = create_temp_directory_result("gitsig_test")
+    if (!(r is value)) {
+        t |> failure("could not create temp dir: {unsafe(r.error)}")
+        return ""
+    }
+    return unsafe(r.value)
+}
+
+def cleanup_root(root : string) {
+    if (!empty(root)) {
+        rmdir_rec(root)
+    }
+}
+
+def md_predicate(p : string) : bool {
+    return ends_with(p, ".md")
+}
+
+// ─── extract_status_path ─────────────────────────────────────────────
+
+[test]
+def test_extract_status_path_basic(t : T?) {
+    t |> run("modified file: ' M file.txt' -> 'file.txt'") <| @(t : T?) {
+        t |> equal(extract_status_path(" M file.txt"), "file.txt")
+    }
+    t |> run("untracked file: '?? new.md' -> 'new.md'") <| @(t : T?) {
+        t |> equal(extract_status_path("?? new.md"), "new.md")
+    }
+}
+
+[test]
+def test_extract_status_path_rename(t : T?) {
+    t |> run("rename: 'R  old.txt -> new.txt' returns the new name") <| @(t : T?) {
+        t |> equal(extract_status_path("R  old.txt -> new.txt"), "new.txt")
+    }
+}
+
+[test]
+def test_extract_status_path_short(t : T?) {
+    t |> run("line of length <= 3 returns empty") <| @(t : T?) {
+        t |> equal(extract_status_path(""), "")
+        t |> equal(extract_status_path("M"), "")
+        t |> equal(extract_status_path(" M "), "")
+    }
+}
+
+// ─── compute_filesystem_signature ────────────────────────────────────
+
+[test]
+def test_filesystem_signature_deterministic(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    t |> success(fwrite("{root}/a.md", "alpha"))
+    t |> success(fwrite("{root}/b.md", "beta"))
+    t |> success(fwrite("{root}/c.md", "gamma"))
+    t |> run("two invocations on the same on-disk state produce the same signature") <| @(t : T?) {
+        let sig1 = compute_filesystem_signature(root, @(p : string) => md_predicate(p), [root])
+        let sig2 = compute_filesystem_signature(root, @(p : string) => md_predicate(p), [root])
+        t |> success(!empty(sig1), "first signature should not be empty")
+        t |> equal(sig1, sig2)
+    }
+    cleanup_root(root)
+}
+
+[test]
+def test_filesystem_signature_predicate_filters(t : T?) {
+    let root_a = make_temp_root(t)
+    let root_b = make_temp_root(t)
+    if (empty(root_a) || empty(root_b)) {
+        return
+    }
+    // root_a: just .md files. root_b: same .md files plus .txt that should
+    // be filtered by the predicate. Signatures must be equal.
+    t |> success(fwrite("{root_a}/a.md", "alpha"))
+    t |> success(fwrite("{root_a}/b.md", "beta"))
+    t |> success(fwrite("{root_b}/a.md", "alpha"))
+    t |> success(fwrite("{root_b}/b.md", "beta"))
+    t |> success(fwrite("{root_b}/skip.txt", "should be filtered"))
+    t |> success(fwrite("{root_b}/skip.cmake", "also filtered"))
+    t |> run("predicate(.md only) makes .txt/.cmake invisible to the signature") <| @(t : T?) {
+        // Signatures hash relative paths; since temp dirs differ, we can't
+        // compare across roots. Compute against a SINGLE root with and
+        // without the txt files.
+        let with_txt = compute_filesystem_signature(root_b, @(p : string) => md_predicate(p), [root_b])
+        // Delete .txt files; signature should not change.
+        var rm_err : string
+        let _drop_txt = remove(path_join(root_b, "skip.txt"), rm_err)
+        let _drop_cmake = remove(path_join(root_b, "skip.cmake"), rm_err)
+        let after_drop = compute_filesystem_signature(root_b, @(p : string) => md_predicate(p), [root_b])
+        t |> success(!empty(with_txt), "should produce a non-empty sig")
+        t |> equal(with_txt, after_drop)
+    }
+    cleanup_root(root_a)
+    cleanup_root(root_b)
+}
+
+[test]
+def test_filesystem_signature_returns_empty_when_dirs_missing(t : T?) {
+    t |> run("all search_dirs missing -> empty signature") <| @(t : T?) {
+        let sig = compute_filesystem_signature("/", @(p : string) => md_predicate(p), ["/__definitely_does_not_exist_42__"])
+        t |> equal(sig, "")
+    }
+}
+
+// ─── compute_signature ───────────────────────────────────────────────
+
+[test]
+def test_compute_signature_returns_non_empty(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    t |> success(fwrite("{root}/a.md", "alpha"))
+    t |> run("returns a non-empty signature with either git: or fs: prefix") <| @(t : T?) {
+        let sig = compute_signature(root, @(p : string) => md_predicate(p), [root])
+        t |> success(!empty(sig), "compute_signature should not return empty for a populated dir")
+        let is_git = starts_with(sig, "git:")
+        let is_fs = starts_with(sig, "fs:")
+        t |> success(is_git || is_fs, "expected 'git:' or 'fs:' prefix, got: {sig}")
+    }
+    cleanup_root(root)
+}
+
+[test]
+def test_compute_signature_no_git_falls_back(t : T?) {
+    // create_temp_directory creates dirs in the system temp area (e.g.
+    // /var/folders/... on macOS, /tmp on Linux), which is not inside a
+    // git checkout. compute_signature should fall back to filesystem-only.
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    t |> success(fwrite("{root}/a.md", "alpha"))
+    t |> run("system temp dir (not in git) -> fs: prefix") <| @(t : T?) {
+        let sig = compute_signature(root, @(p : string) => md_predicate(p), [root])
+        t |> success(starts_with(sig, "fs:"), "expected fs: prefix outside git, got: {sig}")
+    }
+    cleanup_root(root)
+}

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -2233,38 +2233,19 @@ def test_cpp_search_config(t : T?) {
 
 [test]
 def test_cpp_index_signature(t : T?) {
-    t |> run("signature is stable across two consecutive calls (no edits)") <| @(t : T?) {
-        let sig1 = cpp_compute_index_signature()
-        let sig2 = cpp_compute_index_signature()
-        t |> success(!empty(sig1), "first signature should not be empty")
-        t |> success(sig1 == sig2, "signature should be stable across consecutive calls (no fs changes)")
+    t |> run("ensure_cpp_index produces a stable signature across consecutive calls (no edits)") <| @(t : T?) {
+        ensure_cpp_index()
+        let sig1 = cpp_index_signature
+        ensure_cpp_index()
+        let sig2 = cpp_index_signature
+        t |> success(!empty(sig1), "first signature should not be empty after ensure_cpp_index()")
+        t |> success(sig1 == sig2, "signature should be stable across consecutive ensure_cpp_index() calls (no fs changes)")
     }
 }
 
-[test]
-def test_cpp_filesystem_signature(t : T?) {
-    // Direct unit test for the no-git fallback's filesystem walker.
-    // (`cpp_compute_index_signature` only invokes it when git fails — hard to
-    // simulate in CI without breaking git, so we exercise it directly here.)
-    t |> run("filesystem signature is non-empty for default search dirs") <| @(t : T?) {
-        let fs_sig = cpp_compute_filesystem_signature(cpp_default_search_dirs())
-        t |> success(!empty(fs_sig), "should return at least one path:mtime line for daslang's tree")
-    }
-    t |> run("filesystem signature is stable across consecutive calls (no edits)") <| @(t : T?) {
-        let dirs <- cpp_default_search_dirs()
-        let sig1 = cpp_compute_filesystem_signature(dirs)
-        let sig2 = cpp_compute_filesystem_signature(dirs)
-        t |> success(sig1 == sig2, "two back-to-back calls should produce identical signatures")
-    }
-    t |> run("filesystem signature only mentions indexed extensions") <| @(t : T?) {
-        let fs_sig = cpp_compute_filesystem_signature(cpp_default_search_dirs())
-        // Any *.das, *.cmake, *.txt, *.md path slipping into the signature is
-        // a bug — `is_indexed_path` should have filtered them out.
-        t |> success(find(fs_sig, ".das:") < 0, "should not include .das files")
-        t |> success(find(fs_sig, ".cmake:") < 0, "should not include .cmake files")
-        t |> success(find(fs_sig, "CMakeLists") < 0, "should not include CMakeLists.txt")
-    }
-}
+// Direct unit tests for the filesystem-fallback walker live with the shared
+// module they exercise: utils/common/tests/test_git_signature.das. Behavioral
+// integration is covered by test_cpp_index_signature above.
 
 [test]
 def test_cpp_collect_git_excludes(t : T?) {

--- a/utils/mcp/tools/common.das
+++ b/utils/mcp/tools/common.das
@@ -291,26 +291,6 @@ def get_daslang_exe() : string {
     return get_das_exe()
 }
 
-// Run an external command, capture stdout+stderr, return exit_code.
-// `args[0]` is the executable; remaining elements are positional arguments.
-// timeout_sec > 0 kills the process tree after that many seconds (returns popen_timed_out).
-// timeout_sec <= 0 means no timeout.
-//
-// Argv-based: `popen_argv` (Windows: CreateProcess; Unix: fork+execvp) bypasses
-// the shell entirely. No cmd.exe quote-stripping, no /bin/sh `$()`/backtick
-// expansion — every argv element reaches the child verbatim. Callers don't
-// (and shouldn't) quote arguments themselves.
-def run_and_capture(args : array<string>; var output : string&; timeout_sec : float = 0.0) : int {
-    var captured : string
-    let exit_code = unsafe(popen_argv(args, timeout_sec, $(f) {
-        if (f != null) {
-            captured := unsafe(fread_to_eof(f))
-        }
-    }))
-    output := captured
-    return exit_code
-}
-
 // ── MCP subtool runner ──────────────────────────────────────────────
 //
 // Why subprocess: in-process compile_file / RTTI walks leak C++-side

--- a/utils/mcp/tools/cpp_common.das
+++ b/utils/mcp/tools/cpp_common.das
@@ -6,6 +6,7 @@ require common public
 require grep_usage public
 require outline public
 require ../cpp_search_config.das public
+require ../../common/git_signature.das
 require daslib/json public
 require daslib/json_boost public
 require daslib/strings_boost public
@@ -774,21 +775,6 @@ var cpp_index_entries : array<CppMatch>
 // so users get a real reason instead of a silent "no matches".
 var cpp_index_error : string
 
-// True if `path` (extracted from a `git status --porcelain` line) refers to a
-// .cpp/.h/.hpp file inside one of CPP_SEARCH_DIRS. Anything else (.das edits,
-// .cmake edits, tutorials/foo.cpp, etc.) is irrelevant to the index.
-def private is_indexed_path(path : string) : bool {
-    if (!ends_with_any(path, CPP_SEARCH_INCLUDE_GLOBS)) {
-        return false
-    }
-    for (dir in CPP_SEARCH_DIRS) {
-        if (path == dir || starts_with(path, "{dir}/")) {
-            return true
-        }
-    }
-    return false
-}
-
 // `*.cpp` / `*.h` / `*.hpp` style patterns are simple suffixes (no embedded
 // glob meta-chars) — a substring compare is sufficient and avoids pulling
 // in a full glob engine just for extension checks.
@@ -803,41 +789,11 @@ def private ends_with_any(path : string; suffix_globs : array<string>) : bool {
     return false
 }
 
-// Strip `git status --porcelain` 3-char status prefix. Handles the "rename"
-// form `R  old -> new` by returning the new name.
-def private extract_status_path(line : string) : string {
-    if (length(line) <= 3) {
-        return ""
-    }
-    var path = slice(line, 3)
-    let arrow = find(path, " -> ")
-    if (arrow >= 0) {
-        path = slice(path, arrow + 4)
-    }
-    return path
-}
-
-// stat() wrapper that returns 0 on missing/error so signature compute doesn't
-// crash on a deleted file.
-def private stat_mtime_or_zero(path : string) : int64 {
-    let st = stat(path)
-    return st.is_valid ? int64(st.mtime) : 0l
-}
-
-// Filesystem-only staleness signature for the no-git fallback. Walks
-// `search_dirs` recursively, hashes (repo-relative path, mtime) for every
-// file matching `is_indexed_path`, and prunes any subtree that
-// `cpp_collect_git_excludes` would skip (vendored repos, daspkg cache, etc.).
-//
-// This is the slow path — ~50–200ms for daslang's tree (~1500 files). Only
-// invoked when `git rev-parse` / `git status` fails, so users with a normal
-// git checkout pay nothing.
-def cpp_compute_filesystem_signature(search_dirs : array<string>) : string {
-    let das_root = get_das_root()
+// `cpp_collect_git_excludes` returns ast-grep `--globs` patterns of the
+// form `!**/<rel>/**`; strip the wrapping to get bare repo-relative
+// prefixes suitable for prefix-match pruning.
+def private collect_prune_prefixes(search_dirs : array<string>) : array<string> {
     let raw_excludes <- cpp_collect_git_excludes(search_dirs, CPP_SEARCH_INCLUDE_OVERRIDES)
-    // `cpp_collect_git_excludes` returns ast-grep `--globs` patterns of the
-    // form `!**/<rel>/**`; strip the wrapping to get bare repo-relative
-    // prefixes for prefix-match pruning.
     var pruned : array<string>
     pruned |> reserve(length(raw_excludes))
     for (p in raw_excludes) {
@@ -845,76 +801,31 @@ def cpp_compute_filesystem_signature(search_dirs : array<string>) : string {
             pruned |> push(slice(p, 4, length(p) - 3))
         }
     }
-    return build_string() $(var w) {
-        for (sd in search_dirs) {
-            // `dir_rec` yields filenames RELATIVE to `sd`, not absolute. To
-            // match what `is_indexed_path` expects (full repo-relative path
-            // starting with one of CPP_SEARCH_DIRS) we prepend sd's repo-rel
-            // form, and to stat() we join filename onto sd.
-            let sd_rel = to_generic_path(make_relative_path(sd, das_root))
-            dir_rec(sd) $(filename, is_dir) {
-                if (is_dir) {
-                    return
-                }
-                let leaf = to_generic_path(filename)
-                let rel = empty(sd_rel) ? leaf : "{sd_rel}/{leaf}"
-                for (pr in pruned) {
-                    if (starts_with(rel, "{pr}/")) {
-                        return
-                    }
-                }
-                if (!is_indexed_path(rel)) {
-                    return
-                }
-                w |> write("{rel}:{stat_mtime_or_zero(path_join(sd, filename))}\n")
-            }
-        }
-    }
+    return <- pruned
 }
 
-// Compute the staleness signature. Empty result on git failure → caller
-// treats as "no-git" or as transient and retries.
-//
-// `git -C <das_root>` is used (not bare `git`) so the signature is computed
-// against the daslang tree even when the MCP server was launched from a
-// subdirectory or with `--dasroot` pointing elsewhere. Likewise, paths from
-// `git status --porcelain` are repo-relative and stat()'d relative to
-// `das_root`, not the process CWD.
-def cpp_compute_index_signature() : string {
+def private is_pruned(path : string; prune_dirs : array<string>) : bool {
+    for (pr in prune_dirs) {
+        if (starts_with(path, "{pr}/")) {
+            return true
+        }
+    }
+    return false
+}
+
+// Compute the staleness signature for the cpp index. Wraps the shared
+// git_signature.compute_signature with cpp's predicate (extension globs
+// + vendored-tree pruning) and folds in the cpp_search_config.das mtime
+// so config edits invalidate the cache too.
+def ensure_cpp_index() {
     let das_root = get_das_root()
     let cfg_path = path_join(das_root, CPP_SEARCH_CONFIG_PATH)
     let cfg_sig = "cfg:{stat_mtime_or_zero(cfg_path)}"
-    var head_buf : string
-    if (run_and_capture(["git", "-C", das_root, "rev-parse", "HEAD"], head_buf, 5.0) != 0
-        || empty(head_buf)) {
-        // No git checkout (or git unavailable). Walk the search dirs and fold
-        // a per-file mtime hash into the signature so source edits invalidate
-        // the cache even without git. ~50–200ms; only on this rare path.
-        let fs_sig = cpp_compute_filesystem_signature(cpp_default_search_dirs())
-        return "no-git:{cfg_sig}:fs:{hash(fs_sig)}"
-    }
-    var status_buf : string
-    if (run_and_capture(["git", "-C", das_root, "status", "--porcelain", "--untracked-files=normal"],
-                       status_buf, 5.0) != 0) {
-        let fs_sig = cpp_compute_filesystem_signature(cpp_default_search_dirs())
-        return "no-git:{cfg_sig}:fs:{hash(fs_sig)}"
-    }
-    let lines <- split(status_buf, "\n")
-    let combined = build_string() $(var w) {
-        w |> write(head_buf)
-        for (line in lines) {
-            let path = extract_status_path(line)
-            if (!empty(path) && is_indexed_path(path)) {
-                w |> write("{line}:{stat_mtime_or_zero(path_join(das_root, path))}\n")
-            }
-        }
-        w |> write("{cfg_sig}\n")
-    }
-    return "{hash(combined)}"
-}
-
-def ensure_cpp_index() {
-    let sig = cpp_compute_index_signature()
+    let prune_dirs <- collect_prune_prefixes(cpp_default_search_dirs())
+    let core = compute_signature(das_root,
+                                 unsafe(@ capture(& prune_dirs) (p : string) => ends_with_any(p, CPP_SEARCH_INCLUDE_GLOBS) && !is_pruned(p, prune_dirs)),
+                                 cpp_default_search_dirs())
+    let sig = empty(core) ? "" : "{cfg_sig}:{core}"
     if (!empty(sig) && sig == cpp_index_signature) {
         return  // cache hit
     }

--- a/utils/mouse/OVERVIEW.md
+++ b/utils/mouse/OVERVIEW.md
@@ -55,27 +55,30 @@ Frontmatter fields: `slug` (stable ID, used for cross-refs), `title` (1-line des
 
 | Operation | CLI | MCP tool | Notes |
 |---|---|---|---|
-| Retrieve | `mouse ask "<q>"` | `mouse__ask` | Top-K BM25 ranked. Words OR-joined. |
-| Add Q&A | `mouse add "<q>" --body "..."` | `mouse__add` | Dupe-gated by default; pass `--force` / `force=true` to override. |
+| Retrieve | `mouse ask "<q>"` | `mouse__ask` | Top-K BM25 ranked, each annotated with a Jaccard title-similarity. Words OR-joined; `--raw-query` / `rawQuery=true` passes raw FTS5 syntax (phrases, NEAR, explicit AND/OR). |
+| Add Q&A | `mouse add "<q>" --body "..."` | `mouse__add` | Advisory similar list always; hard-blocks only on Jaccard ≥ 0.7. `--force` / `force=true` overrides the block. |
 | Get doc | `mouse get <slug>` | `mouse__get` | Body + frontmatter + reverse-link footer. |
-| Rebuild | `mouse rebuild` | `mouse__rebuild` | Rescans `<root>/docs/`; idempotent. |
+| Rebuild | `mouse rebuild` | `mouse__rebuild` | Force full rescan + signature reset. Normally not needed — every entry point auto-reindexes via the git-staleness check. |
 | Serve MCP | `mouse serve` | (this _is_ the server) | stdio JSON-RPC. |
 
-`add`'s **dupe-on-add gate** is the corpus-hygiene mechanism. With `force=false` (default), `add` first runs retrieval on the new question and returns the similar docs without writing if any match. The agent decides: extend an existing doc (edit the `.md`) or create a new one (re-call with `force=true`).
+**Dupe-on-add gate.** `add` always runs a Jaccard-scored similarity check against the corpus and surfaces the top matches (whether it created or not). With `force=false` (default), it hard-blocks only when the top match scores ≥ 0.7 — a near-paraphrase. Below that threshold, the add proceeds and the similar list is shown for awareness. The caller (LLM or human) is the actual decider; the threshold just stops obvious near-paraphrases from sneaking in. Below 0.5 nothing is surfaced unless content overlap is genuine.
 
 ## Storage model
 
 The `.md` files under `<root>/docs/` are the **source of truth**. The SQLite index at `<root>/index.db` is rebuildable — `mouse rebuild` repopulates it from disk. Implications:
 
-- The corpus is `git`-friendly. Check it in if you want a shared corpus; `git pull` followed by `mouse rebuild` syncs.
-- Hand-edits work. `Edit` an answer, run `mouse rebuild`, the index reflects the change.
+- The corpus is `git`-friendly. Check it in if you want a shared corpus; `git pull` and the next `mouse__ask` (or any other entry point) auto-reindexes — no manual `mouse rebuild` needed.
+- Hand-edits work. `Edit` an answer, run any mouse command, the index reflects the change.
 - The DB is disposable. Lose it, regenerate it.
+
+**Auto-reindex.** Every entry point computes a cheap staleness signature, delegated to the shared `utils/common/git_signature` module: per-tree `git rev-parse HEAD:<docs_rel>` (the docs subtree's hash at HEAD) + filtered `git status --porcelain` over `<root>/docs/*.md` + per-changed-file mtimes, hashed. **Per-tree HEAD** matters: a `git pull` (or branch switch) that doesn't touch `<root>/docs/` leaves the docs tree hash unchanged, so the index doesn't rebuild — a normal monorepo workflow no longer churns the cache. The signature is persisted in an `index_meta` table; on mismatch, the index rebuilds and the new signature replaces the old. If `<root>` isn't inside a git checkout (or git is unavailable), the fallback is a recursive filesystem walk that collects `(path, mtime)` for every `.md`, **sorts by path**, then hashes — sort makes the signature deterministic across platforms (Windows `_findfirst` and Unix `readdir` don't guarantee stable order). The same module backs the daslang MCP server's cpp source-search staleness tracking.
 
 The SQLite schema (managed via `[sql_migration]` from `sqlite/sqlite_migrate`):
 
 - `docs` — slug PK, path, title, created, last_verified, body_hash.
 - `links` — composite-PK pair `(from_slug, to_slug)` for cross-refs.
 - `search_idx` — FTS5 virtual table; per-doc concatenation of title + question aliases + body. BM25 ranks via the `@sql_fts_rank` column.
+- `index_meta` — `(key, value)` k/v table. Currently stores the staleness signature; future-proof for other persistent metadata.
 
 Rebuild is whole-corpus delete+repopulate — simple, correct, fast for small corpora. Incremental update (re-index only changed `body_hash`) is a vNext optimization once the corpus is large enough that whole-rebuild matters.
 

--- a/utils/mouse/README.md
+++ b/utils/mouse/README.md
@@ -5,14 +5,18 @@ Personal Q&A cache MCP server. `.md` answers backed by SQLite/FTS5 retrieval. Lo
 ## Quick start
 
 ```bash
-# Rebuild the index from <root>/docs/ (defaults to ./mouse-data, override via --root or $MOUSE_ROOT)
-daslang utils/mouse/main.das -- rebuild
-
-# Search
+# Search (defaults to ./mouse-data, override via --root or $MOUSE_ROOT;
+# every entry point auto-reindexes via git-staleness — no manual rebuild needed)
 daslang utils/mouse/main.das -- ask "how do I X"
 
-# Add a Q&A (dupe-gated by default)
+# Search with raw FTS5 syntax (phrases, NEAR, explicit AND/OR)
+daslang utils/mouse/main.das -- ask '"foo bar" OR baz' --raw-query
+
+# Add a Q&A. Surfaces top similar docs; hard-blocks only on Jaccard ≥ 0.7.
 daslang utils/mouse/main.das -- add "how do I X" --body "answer body"
+
+# Force a full rescan + signature reset (rarely needed)
+daslang utils/mouse/main.das -- rebuild
 
 # Run as MCP stdio server
 daslang utils/mouse/main.das -- serve
@@ -43,7 +47,7 @@ mouse-data/
   index.db             -- SQLite, rebuildable from docs/
 ```
 
-`.md` files are checked-in-friendly. `git pull` + `mouse rebuild` re-syncs the index.
+`.md` files are checked-in-friendly. `git pull` and the next mouse command auto-reindex via the git-staleness signature (HEAD + porcelain status over `<root>/docs/*.md` + per-changed-file mtimes). No manual `rebuild` needed.
 
 ## Development
 

--- a/utils/mouse/index.das
+++ b/utils/mouse/index.das
@@ -9,9 +9,11 @@ require sqlite/sqlite_boost public
 require sqlite/sqlite_linq public
 require sqlite/sqlite_migrate public
 require daslib/fio public
+require daslib/strings_boost public
 require strings public
 require math
 require store public
+require ../common/git_signature.das
 
 // ─── on-disk layout ──────────────────────────────────────────────────
 
@@ -107,6 +109,20 @@ def migration_002(db : SqlRunner) {
     db |> create_table(type<QueryLog>)
 }
 
+// Persisted across cold opens: the staleness signature used by
+// ensure_index_fresh. Without persistence every CLI invocation would see an
+// empty in-memory signature and rebuild from scratch.
+[sql_table(name = "index_meta")]
+struct IndexMeta {
+    @sql_primary_key key : string
+    value : string
+}
+
+[sql_migration(version = 3, description = "add index_meta for staleness signature")]
+def migration_003(db : SqlRunner) {
+    db |> create_table(type<IndexMeta>)
+}
+
 def with_index_db(root : string; blk : block<(db : SqlRunner) : void>) {
     ensure_root(root)
     with_latest_sqlite(db_path(root)) $(db) {
@@ -127,7 +143,8 @@ struct SearchHit {
 struct DupeMatch {
     slug : string
     title : string
-    rank : float
+    rank : float        // FTS5 BM25; kept for power users / debugging
+    similarity : float  // Jaccard, 0..1; primary ranking key for dedup decisions
 }
 
 struct AddOutcome {
@@ -210,6 +227,55 @@ def rebuild(db : SqlRunner; root : string) : int {
     return n
 }
 
+// ─── staleness signature & auto-reindex ──────────────────────────────
+
+// Persisted (via index_meta) so the cost only pays out on real changes.
+let SIGNATURE_KEY = "signature"
+
+def get_index_signature(db : SqlRunner) : string {
+    let opt <- _sql(db |> select_from(type<IndexMeta>)
+                       |> _where(_.key == SIGNATURE_KEY)
+                       |> _first_opt())
+    if (opt |> is_some) {
+        return (opt |> unwrap).value
+    }
+    return ""
+}
+
+def set_index_signature(db : SqlRunner; sig : string) {
+    db |> _sql_upsert(
+        IndexMeta(key = SIGNATURE_KEY, value = sig),
+        _.key,
+        (value = _excluded.value))
+}
+
+// Reconcile the SQLite index against on-disk docs. If the staleness signature
+// matches what's stored, this is a no-op. On mismatch, rebuilds and stores
+// the new signature. Returns the number of docs (re)indexed (0 on cache hit).
+//
+// Signature compute is delegated to utils/common/git_signature: the predicate
+// only narrows by file extension because the shared module pre-narrows status
+// output and filesystem walks to paths under `search_dirs_abs = [docs_dir]`.
+def ensure_index_fresh(db : SqlRunner; root : string) : int {
+    let docs_abs = docs_dir(root)
+    if (!is_directory_path(docs_abs)) {
+        return 0
+    }
+    let sig = compute_signature(root,
+                                @(p : string) => ends_with(p, ".md"),
+                                [docs_abs])
+    if (empty(sig)) {
+        return 0
+    }
+    let stored = get_index_signature(db)
+    if (sig == stored) {
+        return 0
+    }
+    let n = rebuild(db, root)
+    set_index_signature(db, sig)
+    return n
+}
+
 // ─── search ──────────────────────────────────────────────────────────
 
 // Strip non-alphanumeric chars (except whitespace and `*`) so a free-form
@@ -237,39 +303,48 @@ def sanitize_fts5_query(q : string) : string {
 // scan the whole index. 50 is well above any sane top-k for this corpus.
 let MAX_SEARCH_K = 50
 
-def search(db : SqlRunner; query : string; k : int) : array<SearchHit> {
+def search(db : SqlRunner; query : string; k : int; raw_query : bool = false) : array<SearchHit> {
     var out : array<SearchHit>
     if (k <= 0) {
         return <- out
     }
     let kk = min(k, MAX_SEARCH_K)
-    // to_lower: FTS5 keywords (OR/AND/NOT/NEAR) are uppercase-only operators.
-    // A user query like "foo OR bar" would tokenize to [foo, OR, bar] and
-    // OR-join to `foo OR OR OR bar` — invalid FTS syntax → empty result.
-    // Downcasing every token makes user-typed keywords inert.
-    let cleaned = to_lower(strip(sanitize_fts5_query(query)))
-    if (empty(cleaned)) {
-        return <- out
-    }
-    // Free-form queries → OR-joined so BM25 ranks docs by how many of the
-    // user's words appear, rather than failing when one word is missing.
-    // FTS5 default is whitespace-AND, which is wrong for a "find related"
-    // search. Users who want strict AND/phrase have to wait for
-    // vNext --raw-query.
-    let words <- split(cleaned, " ")
-    var meaningful : array<string>
-    meaningful |> reserve(length(words))
-    for (w in words) {
-        if (length(w) >= 2) {
-            meaningful |> push(w)
+    var fts_query : string
+    if (raw_query) {
+        // Power-user path: pass the user's string straight to FTS5. Bad
+        // syntax surfaces via _try_sql + LOG_WARNING below.
+        fts_query = strip(query)
+        if (empty(fts_query)) {
+            return <- out
         }
+    } else {
+        // to_lower: FTS5 keywords (OR/AND/NOT/NEAR) are uppercase-only operators.
+        // A user query like "foo OR bar" would tokenize to [foo, OR, bar] and
+        // OR-join to `foo OR OR OR bar` — invalid FTS syntax → empty result.
+        // Downcasing every token makes user-typed keywords inert.
+        let cleaned = to_lower(strip(sanitize_fts5_query(query)))
+        if (empty(cleaned)) {
+            return <- out
+        }
+        // Free-form queries → OR-joined so BM25 ranks docs by how many of the
+        // user's words appear, rather than failing when one word is missing.
+        // FTS5 default is whitespace-AND, which is wrong for a "find related"
+        // search. Users who want strict AND/phrase pass raw_query=true.
+        let words <- split(cleaned, " ")
+        var meaningful : array<string>
+        meaningful |> reserve(length(words))
+        for (w in words) {
+            if (length(w) >= 2) {
+                meaningful |> push(w)
+            }
+        }
+        if (empty(meaningful)) {
+            return <- out
+        }
+        fts_query = meaningful |> join(" OR ")
     }
-    if (empty(meaningful)) {
-        return <- out
-    }
-    let or_query = meaningful |> join(" OR ")
     let raw_hits <- _try_sql(db |> select_from(type<SearchRow>)
-                                |> _where(_.Text |> text_match(or_query))
+                                |> _where(_.Text |> text_match(fts_query))
                                 |> _order_by(_.Rank)
                                 |> take(kk))
     if (raw_hits |> is_err) {
@@ -294,13 +369,63 @@ def search(db : SqlRunner; query : string; k : int) : array<SearchHit> {
     return <- out
 }
 
+// ─── dedup scoring (Jaccard over titles, stop-words filtered) ────────
+
+// add_doc treats a hit at or above this as "looks like a duplicate" and
+// blocks the create unless force=true. Below this, hits are advisory only —
+// shown to the caller, but the add proceeds. The caller (LLM or human) is
+// the actual decider; the threshold just stops obvious near-paraphrases
+// from sneaking in.
+let JACCARD_HARD_BLOCK = 0.7f
+
+// Conservative English stopword set. Kept small on purpose: filter common
+// glue words that flood OR-queries, but bias toward false negatives (let
+// borderline words like `do` through) over false positives (filtering rare
+// words used semantically).
+let STOP_WORDS : table<string> <- {
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "do", "does", "did", "doing", "can", "could", "should", "would", "will",
+    "may", "might", "of", "in", "on", "at", "to", "for", "with", "from", "by",
+    "as", "and", "or", "but", "not", "no", "if", "how", "what", "why", "when",
+    "where", "which", "that", "this", "these", "those", "i", "you", "my"
+}
+
+def tokenize_for_jaccard(s : string) : table<string> {
+    var out : table<string>
+    let cleaned = to_lower(strip(sanitize_fts5_query(s)))
+    if (empty(cleaned)) {
+        return <- out
+    }
+    let parts <- split(cleaned, " ")
+    for (w in parts) {
+        if (length(w) >= 2 && !key_exists(STOP_WORDS, w)) {
+            out |> insert(w)
+        }
+    }
+    return <- out
+}
+
+// Score every BM25 hit by Jaccard on tokenized titles, filter out the
+// zero-similarity noise, and return the rest sorted by similarity desc.
+// dupe_check no longer makes the block decision — that moved into add_doc
+// (and into the response messaging in main.das). Callers see the ranking.
 def dupe_check(db : SqlRunner; question : string; k : int = 5) : array<DupeMatch> {
     let hits <- search(db, question, k)
+    let qtok = tokenize_for_jaccard(question)
     var out : array<DupeMatch>
     out |> reserve(length(hits))
     for (h in hits) {
-        out |> push(DupeMatch(slug = h.slug, title = h.title, rank = h.rank))
+        let ttok = tokenize_for_jaccard(h.title)
+        let s = jaccard(qtok, ttok)
+        if (s > 0.0f) {
+            out |> push(DupeMatch(
+                slug = h.slug,
+                title = h.title,
+                rank = h.rank,
+                similarity = s))
+        }
     }
+    sort(out) <| $(a, b) => a.similarity > b.similarity
     return <- out
 }
 
@@ -362,11 +487,14 @@ def add_doc(db : SqlRunner; root : string;
     }
     if (!force) {
         var similar <- dupe_check(db, clean_question, 5)
-        if (!empty(similar)) {
+        if (!empty(similar) && similar[0].similarity >= JACCARD_HARD_BLOCK) {
             outcome.similar <- similar
             outcome.created = false
             return <- outcome
         }
+        // Below threshold: stash the list so the success path can surface
+        // the closest matches as an awareness hint.
+        outcome.similar <- similar
     }
     var existing : table<string>
     let all_slugs <- _sql(db |> select_from(type<DocRow>) |> _select(_.slug))
@@ -403,6 +531,9 @@ def add_doc(db : SqlRunner; root : string;
         return <- outcome
     }
     rebuild(db, root)
+    set_index_signature(db, compute_signature(root,
+                                              @(p : string) => ends_with(p, ".md"),
+                                              [docs_dir(root)]))
     outcome.slug = slug
     outcome.created = true
     outcome.written_path = path

--- a/utils/mouse/main.das
+++ b/utils/mouse/main.das
@@ -61,6 +61,9 @@ struct MouseArgs {
     @clarg_doc = "Show only queries with no result (log)"
     misses : bool
 
+    @clarg_doc = "Treat the question as raw FTS5 query syntax (no sanitization, no OR-join). See https://www.sqlite.org/fts5.html#full_text_query_syntax"
+    raw_query : bool
+
     @clarg_short = "?"
     @clarg_name = "show-help"
     @clarg_doc = "Show this help and exit"
@@ -91,16 +94,18 @@ def cmd_ask(args : MouseArgs) {
         return
     }
     with_index_db(root) $(db) {
-        let hits <- search(db, query, args.k)
+        ensure_index_fresh(db, root)
+        let hits <- search(db, query, args.k, args.raw_query)
         log_query(db, query, hits, "cli")
         if (empty(hits)) {
             print("(no results){HINT_NO_MATCH}\n")
             return
         }
+        let qtok = tokenize_for_jaccard(query)
+        print("Top {length(hits)} best match(es):\n")
         for (h in hits) {
-            print("[{h.rank}] {h.slug} — {h.title}\n")
-            print("    path: {h.path}\n")
-            print("    last_verified: {h.last_verified}\n")
+            let ttok = tokenize_for_jaccard(h.title)
+            print(fmt_search_hit(h, jaccard(qtok, ttok)))
         }
         print("{HINT_HIT}\n")
     }
@@ -118,6 +123,7 @@ def cmd_get(args : MouseArgs) {
         return
     }
     with_index_db(root) $(db) {
+        ensure_index_fresh(db, root)
         let path = path_join(docs_dir(root), "{slug}.md")
         var doc : ParsedDoc
         var err : string
@@ -166,21 +172,30 @@ def cmd_add(args : MouseArgs) {
         return
     }
     with_index_db(root) $(db) {
+        ensure_index_fresh(db, root)
         let outcome <- add_doc(db, root, question, args.body, args.slug, args.force)
         if (!empty(outcome.error)) {
             to_log(LOG_ERROR, outcome.error)
             return
         }
         if (outcome.created) {
-            print("created: {outcome.slug}\n")
+            print("Created: {outcome.slug}\n")
             print("path: {outcome.written_path}\n")
-            print("\nHint: if you discover this answer is wrong later, edit the .md at the path above and bump `last_verified`.\n")
-        } else {
-            print("not created (use --force to override). similar:\n")
-            for (s in outcome.similar) {
-                print("  [{s.rank}] {s.slug} — {s.title}\n")
+            if (!empty(outcome.similar)) {
+                print("\nTop {length(outcome.similar)} similar document(s) (none above the {JACCARD_HARD_BLOCK:.2f} block threshold; surfaced for awareness):\n")
+                for (s in outcome.similar) {
+                    print(fmt_dupe_match(s))
+                }
+                print("\nHint: similarity > 0.5 may overlap meaningfully — consider whether the new doc could fold into one of these instead. Edit `last_verified` on the merged doc and `mouse rebuild` to drop this one.\n")
+            } else {
+                print("\nHint: if you discover this answer is wrong later, edit the .md at the path above and bump `last_verified`.\n")
             }
-            print("\nHint: prefer extending an existing doc by editing its .md (use mouse get <slug> to find the path). Re-call with --force only when the new answer is genuinely a different topic.\n")
+        } else {
+            print("Did NOT create — top {length(outcome.similar)} similar document(s) (similarity ≥ {JACCARD_HARD_BLOCK:.2f}, looks like a duplicate):\n")
+            for (s in outcome.similar) {
+                print(fmt_dupe_match(s))
+            }
+            print("\nSuggestion: prefer extending an existing doc (run `mouse get <slug>` to find the path).\nRe-call with --force if this really is a different topic — the caller's judgment overrides the threshold.\n")
         }
     }
 }
@@ -190,6 +205,7 @@ def cmd_rebuild(args : MouseArgs) {
     var n = 0
     with_index_db(root) $(db) {
         n = rebuild(db, root)
+        set_index_signature(db, compute_index_signature(root))
     }
     print("rebuilt: {n} doc(s) in {root}\n")
 }
@@ -198,6 +214,7 @@ def cmd_log(args : MouseArgs) {
     let root = resolve_root(args.root)
     let n = args.limit > 0 ? args.limit : 20
     with_index_db(root) $(db) {
+        ensure_index_fresh(db, root)
         let rows <- recent_queries(db, n, args.misses)
         if (empty(rows)) {
             print("(no queries logged yet)\n")
@@ -302,8 +319,8 @@ def handle_initialize(id : string) : string {
 def tools_list_body() : string {
     return build_string() $(var w) {
         w |> write("\{\"tools\":[")
-        w |> write("\{\"name\":\"mouse__ask\",\"description\":\"Search the blind-mouse Q&A cache. Returns top-K matching .md docs ranked by FTS5 BM25.\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"question\":\{\"type\":\"string\"\},\"k\":\{\"type\":\"integer\",\"default\":5\},\"root\":\{\"type\":\"string\"\}\},\"required\":[\"question\"]\}\},")
-        w |> write("\{\"name\":\"mouse__add\",\"description\":\"Add a Q&A to the cache. With force=false (default), runs dupe-check first and returns similar docs without writing if any are found.\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"question\":\{\"type\":\"string\"\},\"body\":\{\"type\":\"string\"\},\"slug\":\{\"type\":\"string\"\},\"force\":\{\"type\":\"boolean\",\"default\":false\},\"root\":\{\"type\":\"string\"\}\},\"required\":[\"question\",\"body\"]\}\},")
+        w |> write("\{\"name\":\"mouse__ask\",\"description\":\"Search the blind-mouse Q&A cache. Returns top-K matches ranked by FTS5 BM25, each annotated with a Jaccard title-similarity (sim 0..1) so you can judge relevance at a glance. Set rawQuery=true to pass raw FTS5 syntax (https://www.sqlite.org/fts5.html#full_text_query_syntax) — quoted phrases, NEAR, explicit AND/OR.\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"question\":\{\"type\":\"string\"\},\"k\":\{\"type\":\"integer\",\"default\":5\},\"rawQuery\":\{\"type\":\"boolean\",\"default\":false\},\"root\":\{\"type\":\"string\"\}\},\"required\":[\"question\"]\}\},")
+        w |> write("\{\"name\":\"mouse__add\",\"description\":\"Add a Q&A to the cache. Runs a Jaccard similarity check on the question; with force=false (default), hard-blocks creation only when the top match scores >= 0.7 (a near-paraphrase) and returns the similar list without writing. Below the threshold, the doc is created and the similar list is returned for awareness. Set force=true to override the hard block.\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"question\":\{\"type\":\"string\"\},\"body\":\{\"type\":\"string\"\},\"slug\":\{\"type\":\"string\"\},\"force\":\{\"type\":\"boolean\",\"default\":false\},\"root\":\{\"type\":\"string\"\}\},\"required\":[\"question\",\"body\"]\}\},")
         w |> write("\{\"name\":\"mouse__get\",\"description\":\"Fetch a doc by slug. Returns body, frontmatter, and reverse-link footer (which docs link to this one).\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"slug\":\{\"type\":\"string\"\},\"root\":\{\"type\":\"string\"\}\},\"required\":[\"slug\"]\}\},")
         w |> write("\{\"name\":\"mouse__rebuild\",\"description\":\"Rescan <root>/docs/ and rebuild the SQLite index from disk. .md files are the source of truth.\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"root\":\{\"type\":\"string\"\}\}\}\}")
         w |> write("]\}")
@@ -314,8 +331,14 @@ def handle_tools_list(id : string) : string {
     return jsonrpc_response(id, tools_list_body())
 }
 
-def fmt_search_hit(h : SearchHit) : string {
-    return "[{h.rank}] {h.slug} — {h.title}\n    path: {h.path}\n    last_verified: {h.last_verified}\n"
+// FTS5 BM25 rank (negative; smaller = better) shown alongside Jaccard
+// title-similarity (0..1) so the caller can read both signals at a glance.
+def fmt_search_hit(h : SearchHit; sim : float) : string {
+    return "  [BM25 {h.rank:.3f} | sim {sim:.3f}] {h.slug} — {h.title}\n      path: {h.path}\n      last_verified: {h.last_verified}\n"
+}
+
+def fmt_dupe_match(d : DupeMatch) : string {
+    return "  [sim {d.similarity:.3f}] {d.slug} — {d.title}\n"
 }
 
 let HINT_NO_MATCH = "\nHint: nothing matched. Do the research yourself, then call mouse__add(question, body) so the next session doesn't redo this work."
@@ -327,18 +350,23 @@ def tool_ask(args : JsonValue?) : string {
         return make_tool_result("missing 'question' argument", true)
     }
     let k = get_int_arg(args, "k", 5)
+    let raw_query = get_bool_arg(args, "rawQuery")
     let root = resolve_root(get_string_arg(args, "root"))
     var output : string
     with_index_db(root) $(db) {
-        let hits <- search(db, question, k)
+        ensure_index_fresh(db, root)
+        let hits <- search(db, question, k, raw_query)
         log_query(db, question, hits, "mcp")
         if (empty(hits)) {
             output = "(no results for: {question}){HINT_NO_MATCH}"
             return
         }
+        let qtok = tokenize_for_jaccard(question)
         output = build_string() $(var w) {
+            w |> write("Top {length(hits)} best match(es):\n")
             for (h in hits) {
-                w |> write(fmt_search_hit(h))
+                let ttok = tokenize_for_jaccard(h.title)
+                w |> write(fmt_search_hit(h, jaccard(qtok, ttok)))
             }
             w |> write(HINT_HIT)
         }
@@ -361,6 +389,7 @@ def tool_add(args : JsonValue?) : string {
     var output : string
     var is_error = false
     with_index_db(root) $(db) {
+        ensure_index_fresh(db, root)
         let outcome <- add_doc(db, root, question, body, slug_hint, force)
         if (!empty(outcome.error)) {
             output = outcome.error
@@ -368,14 +397,26 @@ def tool_add(args : JsonValue?) : string {
             return
         }
         if (outcome.created) {
-            output = "created: {outcome.slug}\npath: {outcome.written_path}\n\nHint: if you discover this answer is wrong later, edit the .md at the path above and bump `last_verified`."
+            if (!empty(outcome.similar)) {
+                output = build_string() $(var w) {
+                    w |> write("Created: {outcome.slug}\n")
+                    w |> write("path: {outcome.written_path}\n\n")
+                    w |> write("Top {length(outcome.similar)} similar document(s) (none above the {JACCARD_HARD_BLOCK:.2f} block threshold; surfaced for awareness):\n")
+                    for (s in outcome.similar) {
+                        w |> write(fmt_dupe_match(s))
+                    }
+                    w |> write("\nHint: similarity > 0.5 may overlap meaningfully — consider whether the new doc could fold into one of these instead. Edit `last_verified` on the merged doc and call mouse__rebuild to drop this one.")
+                }
+            } else {
+                output = "Created: {outcome.slug}\npath: {outcome.written_path}\n\nHint: if you discover this answer is wrong later, edit the .md at the path above and bump `last_verified`."
+            }
         } else {
             output = build_string() $(var w) {
-                w |> write("not created (use force=true to override). similar:\n")
+                w |> write("Did NOT create — top {length(outcome.similar)} similar document(s) (similarity ≥ {JACCARD_HARD_BLOCK:.2f}, looks like a duplicate):\n")
                 for (s in outcome.similar) {
-                    w |> write("  [{s.rank}] {s.slug} — {s.title}\n")
+                    w |> write(fmt_dupe_match(s))
                 }
-                w |> write("\nHint: prefer extending an existing doc by editing its .md (call mouse__get with one of the slugs above to find the path). Re-call with force=true only when the new answer is genuinely a different topic.")
+                w |> write("\nSuggestion: prefer extending an existing doc (call mouse__get with one of the slugs above to find the path).\nRe-call with force=true if this really is a different topic — the caller's judgment overrides the threshold.")
             }
         }
     }
@@ -394,6 +435,7 @@ def tool_get(args : JsonValue?) : string {
     var output : string
     var is_error = false
     with_index_db(root) $(db) {
+        ensure_index_fresh(db, root)
         let path = path_join(docs_dir(root), "{slug}.md")
         var doc : ParsedDoc
         var err : string
@@ -443,6 +485,7 @@ def tool_rebuild(args : JsonValue?) : string {
     var n = 0
     with_index_db(root) $(db) {
         n = rebuild(db, root)
+        set_index_signature(db, compute_index_signature(root))
     }
     return make_tool_result("rebuilt: {n} doc(s) in {root}", false)
 }

--- a/utils/mouse/tests/test_index.das
+++ b/utils/mouse/tests/test_index.das
@@ -359,16 +359,20 @@ def test_dupe_check_finds_similar(t : T?) {
     seed_doc(t, root, "doc-a", "Writing typefunction macros", "details", no_links, qs)
     var n_similar = -1
     var top_slug : string
+    var top_sim = 0.0f
     with_index_db(root) $(db) {
         rebuild(db, root)
         let similar <- dupe_check(db, "typefunction", 5)
         n_similar = length(similar)
         if (n_similar > 0) {
             top_slug = similar[0].slug
+            top_sim = similar[0].similarity
         }
     }
     t |> success(n_similar > 0, "expected at least one match")
     t |> equal(top_slug, "doc-a")
+    // single rare keyword in a 3-word title => Jaccard = 1/3 ≈ 0.33
+    t |> success(top_sim >= 0.3f, "similarity should be set: got {top_sim}")
     cleanup_root(root)
 }
 
@@ -392,7 +396,40 @@ def test_dupe_check_no_match(t : T?) {
 }
 
 [test]
-def test_add_dupe_gate_no_force(t : T?) {
+def test_add_dupe_gate_blocks_high_similarity(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    let no_links : array<string>
+    let qs <- ["how to write typefunction macros"]
+    // Title and incoming question share 5 of 6 content tokens after stop-word
+    // filtering ⇒ Jaccard ≈ 0.83, well above the 0.7 hard-block threshold.
+    seed_doc(t, root, "doc-a", "How to write typefunction macros", "body", no_links, qs)
+    var created = true
+    var n_similar = -1
+    var top_sim = 0.0f
+    var n_files_after = -1
+    with_index_db(root) $(db) {
+        rebuild(db, root)
+        let outcome <- add_doc(db, root, "how to write typefunction macros for daslang", "answer body", "", false)
+        created = outcome.created
+        n_similar = length(outcome.similar)
+        if (n_similar > 0) {
+            top_sim = outcome.similar[0].similarity
+        }
+        let files <- list_doc_files(root)
+        n_files_after = length(files)
+    }
+    t |> success(!created, "high-similarity dupe should block create")
+    t |> success(n_similar > 0, "should return the similar doc")
+    t |> success(top_sim >= 0.7f, "top similarity above hard block: got {top_sim}")
+    t |> equal(n_files_after, 1)  // only doc-a; no new file written
+    cleanup_root(root)
+}
+
+[test]
+def test_add_dupe_gate_allows_low_similarity(t : T?) {
     let root = make_temp_root(t)
     if (empty(root)) {
         return
@@ -400,20 +437,57 @@ def test_add_dupe_gate_no_force(t : T?) {
     let no_links : array<string>
     let qs <- ["how to typefunction"]
     seed_doc(t, root, "doc-a", "Typefunction", "typefunction body", no_links, qs)
-    var created = true
+    var created = false
     var n_similar = -1
+    var top_sim = -1.0f
     var n_files_after = -1
     with_index_db(root) $(db) {
         rebuild(db, root)
+        // "typefunction question paraphrase" vs title "Typefunction" =>
+        // Jaccard 1/3 ≈ 0.33, BELOW the 0.7 hard block. Add proceeds.
         let outcome <- add_doc(db, root, "typefunction question paraphrase", "answer body", "", false)
         created = outcome.created
         n_similar = length(outcome.similar)
+        if (n_similar > 0) {
+            top_sim = outcome.similar[0].similarity
+        }
         let files <- list_doc_files(root)
         n_files_after = length(files)
     }
-    t |> success(!created, "should not create when similar exists")
-    t |> success(n_similar > 0, "should return at least one similar")
-    t |> equal(n_files_after, 1)  // only doc-a, no new file written
+    t |> success(created, "low-similarity match should NOT block; add must proceed")
+    t |> success(n_similar > 0, "advisory similar list still returned")
+    t |> success(top_sim < 0.7f, "top similarity below hard block: got {top_sim}")
+    t |> equal(n_files_after, 2)  // doc-a + the new doc
+    cleanup_root(root)
+}
+
+// Common glue words ("how", "do", "I") shouldn't drag rare-content queries
+// across the threshold. After stop-word filtering, the rare-token overlap
+// here is empty.
+[test]
+def test_dupe_check_jaccard_filters_common_words(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    let no_links : array<string>
+    let qs <- ["how to write tests"]
+    seed_doc(t, root, "doc-a", "how do I write tests", "body", no_links, qs)
+    var n_similar = -1
+    var top_sim = 0.0f
+    with_index_db(root) $(db) {
+        rebuild(db, root)
+        let similar <- dupe_check(db, "how do I add git tracking", 5)
+        n_similar = length(similar)
+        if (n_similar > 0) {
+            top_sim = similar[0].similarity
+        }
+    }
+    // Even if FTS5 returns the doc (matches "how"/"do"), the Jaccard score
+    // after stop-word filter is 0 — and dupe_check drops zero-similarity
+    // hits — so n_similar may be 0. Either way, we must not look like a
+    // duplicate.
+    t |> success(top_sim < 0.2f, "common-word overlap should not look like a duplicate: n_similar={n_similar}, top_sim={top_sim}")
     cleanup_root(root)
 }
 
@@ -778,5 +852,121 @@ def test_add_dupe_gate_force(t : T?) {
     t |> success(created, "should create with force=true")
     t |> equal(n_files_after, 2)
     t |> success(found_via_search, "newly added doc retrievable via search")
+    cleanup_root(root)
+}
+
+// ─── auto-reindex via signature ───────────────────────────────────────
+
+[test]
+def test_ensure_index_fresh_picks_up_new_md(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    let no_links : array<string>
+    let qs1 <- ["alpha question"]
+    seed_doc(t, root, "alpha", "Alpha title", "alpha body", no_links, qs1)
+    var n_initial = -1
+    var n_after = -1
+    var found = false
+    with_index_db(root) $(db) {
+        ensure_index_fresh(db, root)
+        let rows1 <- _sql(db |> select_from(type<DocRow>))
+        n_initial = length(rows1)
+        // Drop a new .md straight onto disk, simulating a `git pull`.
+        let qs2 <- ["beta question"]
+        seed_doc(t, root, "beta", "Beta title", "beta body", no_links, qs2)
+        ensure_index_fresh(db, root)
+        let rows2 <- _sql(db |> select_from(type<DocRow>))
+        n_after = length(rows2)
+        let hits <- search(db, "beta", 5)
+        for (h in hits) {
+            if (h.slug == "beta") {
+                found = true
+            }
+        }
+    }
+    t |> equal(n_initial, 1)
+    t |> equal(n_after, 2)
+    t |> success(found, "newly-dropped doc must be retrievable after ensure_index_fresh")
+    cleanup_root(root)
+}
+
+[test]
+def test_ensure_index_fresh_noop_when_unchanged(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    let no_links : array<string>
+    let qs <- ["alpha q"]
+    seed_doc(t, root, "alpha", "Alpha", "body", no_links, qs)
+    var sig1 : string
+    var sig2 : string
+    var rebuild_count = -1
+    with_index_db(root) $(db) {
+        ensure_index_fresh(db, root)
+        sig1 = get_index_signature(db)
+        // No filesystem changes — second call should hit the cache and
+        // return 0, AND the persisted signature should still equal the first.
+        rebuild_count = ensure_index_fresh(db, root)
+        sig2 = get_index_signature(db)
+    }
+    t |> success(!empty(sig1), "signature populated on first ensure")
+    t |> equal(sig1, sig2)
+    t |> equal(rebuild_count, 0)  // 0 = cache hit, no rebuild
+    cleanup_root(root)
+}
+
+// ─── --raw-query FTS5 passthrough ─────────────────────────────────────
+
+[test]
+def test_search_raw_query(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    let no_links : array<string>
+    let qs1 <- ["title alpha question"]
+    let qs2 <- ["title bravo question"]
+    seed_doc(t, root, "alpha", "alphakeyword content", "alpha body", no_links, qs1)
+    seed_doc(t, root, "bravo", "bravokeyword content", "bravo body", no_links, qs2)
+    var raw_n = 0
+    var sanitized_n = 0
+    with_index_db(root) $(db) {
+        rebuild(db, root)
+        // Raw-query path: explicit FTS5 OR — both docs match.
+        let raw_hits <- search(db, "alphakeyword OR bravokeyword", 10, true)
+        raw_n = length(raw_hits)
+        // Sanitized path lowercases "OR" to "or" (a 2-char regular token);
+        // it gets joined with the keywords via OR, so still matches both.
+        // What we really want to assert is that the raw path works; the
+        // sanitized path's exact behavior is tested elsewhere.
+        let san_hits <- search(db, "alphakeyword OR bravokeyword", 10, false)
+        sanitized_n = length(san_hits)
+    }
+    t |> equal(raw_n, 2, "raw FTS5 OR returns both docs")
+    t |> success(sanitized_n >= 2, "sanitized path also returns both via OR-join: got {sanitized_n}")
+    cleanup_root(root)
+}
+
+[test]
+def test_search_raw_query_phrase(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    let no_links : array<string>
+    let qs <- ["the alpha bravo charlie sequence"]
+    seed_doc(t, root, "alpha", "alpha bravo charlie", "the order matters: alpha bravo charlie", no_links, qs)
+    var quoted_hits = -1
+    with_index_db(root) $(db) {
+        rebuild(db, root)
+        // Phrase queries are valuable raw-query users. Sanitizer would strip
+        // the quotes — raw_query=true preserves them.
+        let hits <- search(db, "\"alpha bravo\"", 10, true)
+        quoted_hits = length(hits)
+    }
+    t |> equal(quoted_hits, 1)
     cleanup_root(root)
 }


### PR DESCRIPTION
## Summary

Three issues in `utils/mouse/`:

- **No automatic re-indexing.** `git pull` of new docs left the SQLite index stale until manual `mouse rebuild`. Every cold session worked against a stale index.
- **"Too similar" was a near-universal false positive.** `dupe_check` blocked any FTS5 hit, and the OR-joined query matched nearly any natural-language question. The `force=false` path effectively rejected every `mouse__add` that had >=1 word in common with an existing doc.
- **Tool output was unreadable.** BM25 ranks rendered as raw small negative floats (often scientific notation) under vague headers like `similar:`.

## Fixes

### Auto-reindex
- Persisted staleness signature in a new `index_meta` table (migration v3).
- `compute_index_signature` mirrors the [utils/mcp/tools/cpp_common.das](utils/mcp/tools/cpp_common.das) pattern: `git rev-parse HEAD` + filtered `git status --porcelain` over `<root>/docs/*.md` + per-changed-file mtimes, hashed.
- Filesystem-walk fallback when git is unavailable (no-git checkouts, etc.).
- `ensure_index_fresh()` wired into every CLI and MCP entry point. Cache hit: zero work; mismatch: rebuild + persist new signature.

### Jaccard scoring + advisory gate
- New `daslib/strings_boost.jaccard(table, table)` and `jaccard(array, array)` helpers next to `levenshtein_distance`.
- `dupe_check` sorts BM25 hits by Jaccard title similarity (with stop-words filtered), drops zero-overlap noise.
- `add_doc` hard-blocks only when top match's Jaccard >= 0.7 — a near-paraphrase. Below threshold, the add proceeds and the similar list is shown for awareness. **The caller (LLM or human) is the actual decider**; the threshold just stops obvious near-paraphrases from sneaking in.

### Response formatting
- All numeric output uses `{x:.3f}` fixed-decimal — never scientific notation.
- `mouse__ask` / `mouse ask` headers now read "Top N best matches:" with both `BM25` and `sim` (Jaccard 0..1) columns so the caller can read both signals at a glance.
- `mouse__add` responses are mode-aware: blocked, created-with-similar, created-clean. Each mode names what happened and what the caller should consider next.

### `--raw-query` FTS5 passthrough
- New CLI flag `--raw-query` and MCP arg `rawQuery=true` bypass the sanitizer. Lets power users write quoted phrases, NEAR, explicit AND/OR — the full FTS5 query syntax.
- `mouse__add`'s internal dupe-check stays sanitized (raw FTS5 in a duplicate check is a footgun).

## daslib promotions
- `daslib/strings_boost`: new `jaccard` (table + array overloads).
- `daslib/fio`: `run_and_capture` promoted from `utils/mcp/tools/common.das`. One canonical home; `common.das` now relies on the daslib re-export — all ~10 mcp tool callers continue to resolve through the existing `require daslib/fio public` chain.

## Docs
- Regenerated stdlib RST via `das2rst.das` (added `jaccard` to "String similarity" group, `run_and_capture` to "OS specific routines"); new handmade entry for `jaccard`. Sphinx build clean (zero warnings).
- `utils/mouse/OVERVIEW.md` and `utils/mouse/README.md` reflect the auto-reindex and dupe-gate semantics.
- One new mouse-data Q&A entry capturing the `das2rst` `// stub` placement gotcha I hit.
- One-line note in `CLAUDE.md` documenting the gen2 `let X : table<T> <- { "a", "b" }` set-literal init syntax.

## Test plan

- [x] All 34 mouse tests pass (interpreted) — `utils/mouse/tests/test_index.das`. Includes new tests: `test_dupe_check_jaccard_filters_common_words`, `test_add_dupe_gate_blocks_high_similarity`, `test_add_dupe_gate_allows_low_similarity`, `test_ensure_index_fresh_picks_up_new_md`, `test_ensure_index_fresh_noop_when_unchanged`, `test_search_raw_query`, `test_search_raw_query_phrase`.
- [x] All 11 jaccard tests pass — `tests/strings/strings_jaccard.das`.
- [x] AOT suite: 7380/7386 (0 fail, 0 errors, 6 skipped).
- [x] Sphinx clean build (zero warnings).
- [x] `detect-dupe` over touched dirs — only expected dupes are `stat_mtime_or_zero` and `extract_status_path` mirrored from `cpp_common.das` (both `def private`).
- [x] Lint clean for changed code; remaining warnings are pre-existing in unchanged daslib regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)