### PR TITLE
daslib(json_boost) PERF017 fix + 7 dasImgui phase 0b mouse cards

### DIFF
--- a/daslib/json_boost.das
+++ b/daslib/json_boost.das
@@ -586,9 +586,9 @@ def JV(value : auto(TT)) : JsonValue? {
                     static_if (typeinfo is_string(field)) {
                         if (empty(field)) { return ; }
                     } static_elif (typeinfo is_array(field)) {
-                        if (length(field) == 0) { return ; }
+                        if (empty(field)) { return ; }
                     } static_elif (typeinfo is_table(field)) {
-                        if (length(field) == 0) { return ; }
+                        if (empty(field)) { return ; }
                     } static_elif (typeinfo is_pointer(field)) {
                         if (field == null) { return ; }
                     } else {

--- a/mouse-data/docs/are-imgui-inputtext-combo-callbacks-fired-synchronously-inside-the-c-call-can-i-stack-allocate-the-callback-thunk.md
+++ b/mouse-data/docs/are-imgui-inputtext-combo-callbacks-fired-synchronously-inside-the-c-call-can-i-stack-allocate-the-callback-thunk.md
@@ -1,0 +1,55 @@
+---
+slug: are-imgui-inputtext-combo-callbacks-fired-synchronously-inside-the-c-call-can-i-stack-allocate-the-callback-thunk
+title: Are ImGui InputText/Combo callbacks fired synchronously inside the C call? Can I stack-allocate the callback thunk?
+created: 2026-05-10
+last_verified: 2026-05-10
+links: []
+---
+
+**Yes, fully synchronous.** ImGui invokes `ImGuiInputTextCallback` (and `ImGuiComboGetter`-style item callbacks) from inside the `InputText()` / `Combo()` call itself, on the same thread, in the same C frame. There is no queueing, no deferred dispatch, no other-thread invocation. The callback's `data` pointer is also only valid for the duration of that one call.
+
+This collapses what looks like a complex ABI problem (binding a daslang lambda to a C function pointer) into a stack-allocated thunk. You don't need:
+
+- a daslang struct that mirrors a C struct holding the lambda (the `DasImguiInputText` v1 pattern)
+- ABI pinning between daslang field order and C field order
+- a long-lived registration table
+
+You only need a stack-local POD plus one trampoline:
+
+```cpp
+struct InputTextLambdaThunk {
+    Context *  context;
+    LineInfo * at;
+    Lambda     lambda;       // by value — capture pointer
+};
+
+int InputTextLambdaTrampoline(ImGuiInputTextCallbackData * data) {
+    auto t = (InputTextLambdaThunk *) data->UserData;
+    if ( !t->lambda.capture ) {
+        t->context->throw_error_at(t->at, "InputText callback: lambda has no capture");
+    }
+    return das_invoke_lambda<int>::invoke<ImGuiInputTextCallbackData *>(
+        t->context, t->at, t->lambda, data);
+}
+
+bool InputTextCb(uint8_t * buf, int buf_size, const char * label, ImGuiInputTextFlags_ flags,
+                 Lambda cb, Context * context, LineInfoArg * at) {
+    InputTextLambdaThunk thunk { context, at, cb };
+    return ImGui::InputText(label, (char *)buf, buf_size, flags,
+                             &InputTextLambdaTrampoline, &thunk);
+}
+```
+
+The thunk is on the C stack. ImGui calls the trampoline 0..N times before `InputText` returns. Then the stack frame unwinds; the thunk is gone; the daslang lambda's capture-block was never referenced after the C call returned.
+
+The same shape works for `ImGui::Combo(label, &cur, &getter_fn, &thunk, items_count, ...)` and any other "callback fires inside the call" ImGui surface (`SetNextWindowSizeConstraints`, `Plot*`, etc.). The legacy `DasImguiInputText` / `ImGuiComboGetter` daslang↔C++ mirror structs in `modules/dasImgui/src/dasIMGUI.main.cpp` exist because the original 2018-era pattern stored callbacks in long-lived struct fields without realizing the lifetime requirement was actually one C frame.
+
+**Watch out** for the *non-synchronous* exceptions: any callback you pass to ImGui that's expected to fire on a *future* frame (e.g. tool-callback hooks set via `io.ConfigCallback*`, custom drawcall callbacks added via `AddCallback` and rendered later by `RenderDrawData`) DOES outlive the call that registered it — those still need a long-lived struct or registration table. The InputText/Combo/SizeConstraints/Plot family is the synchronous one.
+
+**Found 2026-05-10**, dasImgui Phase 0b.4. Pattern verified working with stack-thunk replacement of `DasImguiInputText` for `input_text` / `input_text_with_hint` / `input_text_multiline` / `input_text_growable` (CallbackResize) + `combo_getter`.
+
+## See also
+- `daslang-strings-cannot-carry-embedded-nulls-use-array-uint8-and-reinterpret-string-temp-for-c-api-zero-separated-buffers` — companion pattern for InputText buffer storage
+
+## Questions
+- Are ImGui InputText/Combo callbacks fired synchronously inside the C call? Can I stack-allocate the callback thunk?

--- a/mouse-data/docs/dasimgui-widget-auto-emit-skips-struct-field-defaults.md
+++ b/mouse-data/docs/dasimgui-widget-auto-emit-skips-struct-field-defaults.md
@@ -1,0 +1,42 @@
+---
+slug: dasimgui-widget-auto-emit-skips-struct-field-defaults
+title: In dasImgui [widget] auto-emit, do struct field defaults like `format : string = "%.3f"` apply to the auto-emitted module global?
+created: 2026-05-10
+last_verified: 2026-05-10
+links: []
+---
+
+**No.** The `[widget]` macro emits the per-ident state global as a bare `var IDENT : StateStruct` declaration with no initializer (see `WidgetCallMacro::visit` in `modules/dasImgui/widgets/imgui_boost.das`). Struct field defaults only fire when the constructor `StateStruct()` is invoked — and the macro never invokes it — so at runtime every field of the global starts at the type's zero value, not the source-declared default.
+
+This has two practical consequences:
+
+1. **Numeric/bool/tuple field defaults are silently lost.** Declaring `@live speed : float = 1.0f` in a state struct does NOT mean the global's speed starts at 1.0f. It starts at 0.0f. If your widget body does `let changed = DragFloat(text, ..., state.speed, ...)` and the user never explicitly sets `IDENT.speed = ...`, ImGui will receive 0.0 and the drag won't respond. Same trap for any numeric default users would expect to "just work".
+
+2. **String field defaults trip the uninit-safety check at compile time** (error 31014, "Uninitialized variable IDENT is unsafe. Use initializer syntax or @safe_when_uninitialized when intended."). String is a heap pointer; daslang refuses to zero-init a struct global if any field is a heap pointer without explicit initializer or per-field `@safe_when_uninitialized`. The default literal in the struct is **not** an initializer — it would only fire through a constructor call.
+
+**Workaround: push these to per-call args instead of state fields.** That's what the slider/drag widgets in `imgui_widgets_builtin.das` actually do — `format` and `speed` are NOT in the state struct at all; they're parameters of the widget def with daslang-call-site defaults that DO fire (because they're regular function default args, not struct field defaults):
+
+```das
+[widget]
+def drag_float(var state : DragStateFloat; text : string;
+               speed : float = 1.0f;
+               format : string = "%.3f";
+               flags : ImGuiSliderFlags = ImGuiSliderFlags.None) : bool {
+    ...
+    let (mn, mx) = state.bounds                  // bounds STAYS in state — persistent config, zero-init = unclamped per ImGui contract
+    let changed = DragFloat(text, addr, speed, mn, mx, format, flags)
+    ...
+}
+```
+
+Caller writes `drag_float(OPACITY, (text = "Opacity", speed = 0.01f))` and gets a working drag.
+
+**Rule of thumb when designing a `[widget]` state struct:**
+- Persistent value(s) the user wants preserved across reloads → state.
+- Per-instance config that's safely zero-init (numeric "no clamp", bool "default off", tuple of zeros) → state if you want it `@live`-preserved across reloads.
+- Anything where zero-init would silently break the widget OR is a string → per-call arg with a daslang default.
+
+**Found 2026-05-10**, dasImgui phase 0b.2 (Drag* widgets). Burned ~10 min before realizing field defaults weren't firing — the failure mode for numeric is "drag does nothing at runtime" which is much harder to catch than the string compile-time error. If you fix this in the macro (emit `var IDENT : T = T()` so field defaults fire), update or delete this card. Until then: state structs hold `@live`-able persistent values only, configs go to call-site args.
+
+## Questions
+- In dasImgui [widget] auto-emit, do struct field defaults like `format : string = "%.3f"` apply to the auto-emitted module global?

--- a/mouse-data/docs/dasimgui-widget-named-tuple-args-positional-not-named.md
+++ b/mouse-data/docs/dasimgui-widget-named-tuple-args-positional-not-named.md
@@ -1,0 +1,30 @@
+---
+slug: dasimgui-widget-named-tuple-args-positional-not-named
+title: In dasImgui's `[widget]` call_macro, do named-tuple args `(name = val, …)` dispatch by NAME like Python kwargs, or by SOURCE-ORDER position?
+created: 2026-05-10
+last_verified: 2026-05-10
+links: []
+---
+
+**By source-order position. The names are documentation only.**
+
+The `[widget]` call_macro destructures `(text = "X", flags = …, …)` by iterating the `ExprMakeTuple.values` array in stored order and pushing them as positional args (see `imgui_boost.das:209-221`). The corresponding `recordNames` array is checked only as a guard to enable destructuring (non-empty + same length as values), but the names themselves never reach the typer's overload resolution.
+
+Practical consequences for callers:
+
+1. **Source order MUST match function signature order.** If a widget def is `def color_picker4(state, text, flags, ref_col, has_ref_col)`, then the caller must write `(text = …, flags = …, ref_col = …, has_ref_col = …)` in that exact order. Writing `(text = …, has_ref_col = true, ref_col = …)` puts `has_ref_col=true` (a `bool`) into the `flags` positional slot — type mismatch error 30341.
+
+2. **You can't skip middle args.** Stopping at the last arg you care about is fine (trailing defaults take over) — but to set arg N, you must pass args 1..N-1. Meaning you can't surface a "rare last default" without writing every preceding default explicitly.
+
+3. **Param ordering should put rarely-overridden args last.** When designing a widget def, list params from "always-customized" → "rare default-override". Then 90% of callers write a short `(text = …)` form; the 10% that need the rare arg write the full chain.
+
+4. **For widgets with two optional middle args + a common-skip last arg**, sometimes the right move is to reorder the wrapper's signature against ImGui's. E.g. `color_button` puts `size` before `flags` (more callers override size than flags, so the skip-tail is `flags`). The wrapper body still calls `ColorButton(desc_id, col, flags, size)` — the wrapper's param order is independent of the underlying ImGui call's order.
+
+5. **Avoid square-bracket `[name = val]`** — that builds an `ExprNamedCall` which bypasses call_macro dispatch entirely (= no auto-emit, no L2/L3 dispatcher install). The parens form is mandatory.
+
+**Possible upgrade to the macro:** use `recordNames` to do real name → param-position mapping (Python-style kwargs). Would let callers skip middle args (`(text = "X", has_ref_col = true)` works regardless of where `has_ref_col` sits in the signature). The current macro doesn't do this — it would need to read `func.arguments` after the macro fires, match record names to param names, and reorder before calling. Real improvement; out of 0b.2 scope. Mention if a real user trips on this.
+
+**Found 2026-05-10**, dasImgui phase 0b.2-color (ColorPicker4's `ref_col` + `has_ref_col` couldn't be set without explicit `flags = ImGuiColorEditFlags.None` middle arg).
+
+## Questions
+- In dasImgui's `[widget]` call_macro, do named-tuple args `(name = val, …)` dispatch by NAME like Python kwargs, or by SOURCE-ORDER position?

--- a/mouse-data/docs/daslang-generic-widget-finalize-helper-typedecl-from_jv.md
+++ b/mouse-data/docs/daslang-generic-widget-finalize-helper-typedecl-from_jv.md
@@ -1,0 +1,48 @@
+---
+slug: daslang-generic-widget-finalize-helper-typedecl-from_jv
+title: How do I write one generic widget-finalize helper in daslang that captures `var state : auto(StateT)` and dispatches `imgui_set` for any of N different state struct types without per-type duplication?
+created: 2026-05-10
+last_verified: 2026-05-10
+links: []
+---
+
+**Pattern:** generic on `auto(StateT)`, use `typedecl(state.field)` to drive `from_JV`'s type witness. Single helper, 10+ instantiations, no per-type duplication.
+
+```das
+def private drag_set_finalize(widget_ident : string; kind : string; var state : auto(StateT)) {
+    var entry : WidgetEntry
+    unsafe {
+        let ser <- @ capture(& state) () : JsonValue ? {
+            return JV(state)
+        }
+        let disp <- @ capture(& state) (action : string; payload : JsonValue ?) {
+            if (action == "set") {
+                state.pending_value = from_JV(payload?["value"],
+                                              type<typedecl(state.pending_value)>,
+                                              default<typedecl(state.pending_value)>)
+                state.has_pending = true
+            }
+        }
+        widget_finalize(widget_ident, kind, entry, ser, disp)
+    }
+}
+```
+
+This one helper covers DragStateFloat (pending_value:float), DragStateFloat2/3/4 (pending_value:float2/3/4), DragStateInt/2/3/4 (pending_value:int/int2/3/4), DragStateRangeFloat (pending_value:float2), DragStateRangeInt (pending_value:int2). 10 instantiations, all generated from one body. See `modules/dasImgui/widgets/imgui_widgets_builtin.das` (phase0b.2 commit `3a2bde3`).
+
+**Three load-bearing pieces:**
+
+1. **`var state : auto(StateT)`** — generic state param. The `auto(StateT)` form binds an alias `StateT` you can name, but here it's not even needed — the helper never references StateT directly. Plain `auto` works the same. Keeping the alias is a hint to readers that the struct varies per call.
+
+2. **`typedecl(state.pending_value)`** — compile-time type-of the state field. From CLAUDE.md: "`typedecl(expr)` — compile-time type-of, usable inside `default<>`: `default<typedecl(field)>`." Same composes inside `type<>`: `type<typedecl(state.pending_value)>` is the type witness for `from_JV`'s auto(VecT) overload-resolution.
+
+3. **Two args to from_JV: `type<...>` and `default<...>`.** Don't use `default<X>` for both — error 31200 "template argument must be type<...> and not 0. ExprConstInt" because `default<int>` collapses to the literal `0` and the template expects an actual type tag.
+
+**Capture `& state` works across helper return because state is a function param REF to the module global.** Lambda holds the reference; `widget_finalize`'s g_dispatchers / g_serializers tables retain the lambda (and via that the captured ref) past the helper's return. See `daslang-extract-lambda-register-postlude-into-private-helper-via-var-state-param` for the validation that this is fine.
+
+**When NOT to extract a generic helper:** when the per-state-type bodies differ in more than just the field type — e.g. `click_finalize` (action="click", state.pending_click=true), `toggle_finalize` (action="set", state.pending_toggle=true + pending_value), `radio_int_finalize` (action="set", state.pending_set=true + pending_value). Those branches differ on field NAMES, not types. Generic-on-StateT can't see that field names differ. Three concrete-state helpers there beat one generic that branches on `is`-checks of an auto-typed field. Generic is the right hammer when the state shape is uniform and only the field type varies.
+
+**Found 2026-05-10**, dasImgui phase 0b.2.
+
+## Questions
+- How do I write one generic widget-finalize helper in daslang that captures `var state : auto(StateT)` and dispatches `imgui_set` for any of N different state struct types without per-type duplication?

--- a/mouse-data/docs/daslang-strings-cannot-carry-embedded-nulls-use-array-uint8-and-reinterpret-string-temp-for-c-api-zero-separated-buffers.md
+++ b/mouse-data/docs/daslang-strings-cannot-carry-embedded-nulls-use-array-uint8-and-reinterpret-string-temp-for-c-api-zero-separated-buffers.md
@@ -1,0 +1,68 @@
+---
+slug: daslang-strings-cannot-carry-embedded-nulls-use-array-uint8-and-reinterpret-string-temp-for-c-api-zero-separated-buffers
+title: Daslang strings can't carry embedded null bytes — heap-allocated via strlen sizing. How do I pass zero-separated buffers to C APIs (e.g. ImGui's Combo zero-separated overload, glShaderSource sentinel arrays)?
+created: 2026-05-10
+last_verified: 2026-05-10
+links: []
+---
+
+**Short answer:** Daslang `string` is null-terminated. Embedded `\x00` bytes are valid in source (lexer accepts `\xNN`), but the heap allocator sizes the string via `strlen`, so anything past the first null is **dropped on heap copy**.
+
+**Empirical verification:**
+```das
+let s = "Apple\x00Banana\x00"
+print("len = {length(s)}")   // 5, not 13
+peek_data(s) $(arr) {
+    print("buf len = {length(arr)}")  // 5 — the bytes "Banana" are gone
+}
+```
+
+You cannot use `clone_string` / `:=` / any string-allocator path to preserve embedded nulls. The bytes don't survive `ExprConstString` lowering; the heap copy uses `strlen` of the C++ `std::string`'s `c_str()`.
+
+**The solution: stay in `array<uint8>` for the bytes, and reinterpret the address as `string#` when handing it to the C API.**
+
+```das
+struct ComboState {
+    @optional items_buf : array<uint8>           // your zero-separated bytes
+    // ... rest of state ...
+}
+
+// per-frame (or once, depending on how stable items are):
+state.items_buf |> clear()
+for (s in items) {
+    peek_data(s) $(arr) {
+        for (b in arr) { state.items_buf |> push(b) }
+    }
+    state.items_buf |> push(0u8)
+}
+state.items_buf |> push(0u8)                     // double-null terminator if API needs it
+
+// hand the raw pointer to the C function:
+let zsv = unsafe(reinterpret<string#>(unsafe(addr(state.items_buf[0]))))
+Combo(text, addr(state.value), zsv, popup_max)
+```
+
+**Why `string#` and not `string`:**
+- `string#` is the **temporary/borrowed** form — daslang's typer treats it as "char* I don't own". No clone, no heap involvement, no refcount.
+- `unsafe(reinterpret<string>(...))` would lie about ownership; daslang might try to clone or finalize it later (depending on where the value flows), corrupting the buffer or double-freeing.
+- `string#` is the right primitive whenever you have a C-string-shaped pointer that you don't want daslang to touch.
+
+**Why two `unsafe()` wrappers:**
+`reinterpret<...>` requires `unsafe`. `addr(arr[i])` is "address of reference" which **also** requires `unsafe` — and `unsafe(reinterpret(addr(...)))` only marks `reinterpret` unsafe, not `addr` inside. Hence the nested form. Same shape used throughout dasImgui (e.g. `ColorEdit3(text, unsafe(addr(state.value.x)), flags)`).
+
+**Generalization (the long-term pattern):**
+Any C API that uses embedded nulls as in-band delimiters (Combo zero-separated, environment-block-style `KEY=VAL\0KEY=VAL\0\0`, scattered C-string sentinel arrays) gets the same treatment in daslang:
+1. Build the bytes in `array<uint8>` (push raw bytes + `0u8` separators).
+2. `unsafe(reinterpret<string#>(unsafe(addr(buf[0]))))` to hand off a pointer.
+3. Buffer's lifetime must outlive the C call — keep it on a state struct, in a local with a longer scope than the call, or in a module-global scratch buffer.
+
+**Don't try to "fix" daslang strings.** Their null-terminated semantics are correct for actual text. Use `array<uint8>` for byte payloads and reinterpret only at the boundary.
+
+**Don't reach for a C++ shim** for this kind of marshaling unless something else mandates it. The daslang-side reinterpret path is shimless, AOT-clean, and the same shape as how dasImgui already passes `addr(state.value.x)` for vector-typed widgets.
+
+**Counter-example (when you DO need a shim):** if the C API takes a `const char* const items[]` (array-of-pointer-to-C-string) and you have `array<string>` in daslang — that one's actually shim-free too: daslang `array<string>` is laid out as `char**` already, so `unsafe(addr(items[0]))` matches the C signature directly. ImGui's `ListBox(label, &cur, items_array, count, height)` takes that path.
+
+**Verified at:** dasImgui Phase 0b.2 (2026-05-10), `combo` + `list_box` widgets in `modules/dasImgui/widgets/imgui_widgets_builtin.das`. Combo wires the zero-separated path; ListBox uses the direct-array pass-through. Both shipped without C++ changes.
+
+## Questions
+- Daslang strings can't carry embedded null bytes — heap-allocated via strlen sizing. How do I pass zero-separated buffers to C APIs (e.g. ImGui's Combo zero-separated overload, glShaderSource sentinel arrays)?

--- a/mouse-data/docs/how-do-i-expose-a-daslang-string-value-through-a-widget-state-struct-without-tripping-error-31014-uninitialized-variable-is-unsa.md
+++ b/mouse-data/docs/how-do-i-expose-a-daslang-string-value-through-a-widget-state-struct-without-tripping-error-31014-uninitialized-variable-is-unsa.md
@@ -1,0 +1,40 @@
+---
+slug: how-do-i-expose-a-daslang-string-value-through-a-widget-state-struct-without-tripping-error-31014-uninitialized-variable-is-unsa
+title: How do I expose a daslang `string` value through a `[widget]` state struct without tripping error 31014 (uninitialized variable is unsafe) at compile time?
+created: 2026-05-10
+last_verified: 2026-05-10
+links: []
+---
+
+**Use `@safe_when_uninitialized` on the field.** The `[widget]` macro auto-emits the per-ident state global as a bare `var IDENT : StateStruct` — no constructor call, just bit-zero init. For `string`, bit-zero is null pointer; daslang refuses to compile a global with an uninitialized string heap-pointer field, raising error 31014: `Uninitialized variable IDENT is unsafe. Use initializer syntax or @safe_when_uninitialized when intended.`
+
+The field annotation that suppresses this is `@safe_when_uninitialized`. It goes immediately before the field name (one line up or same line, `@`-form, NOT `[...]`):
+
+```das
+struct InputTextState {
+    @safe_when_uninitialized @live value : string         //! current text
+    @live capacity : int                                  //! widget body promotes 0 → default
+    @optional has_pending : bool
+    @safe_when_uninitialized @optional pending_value : string
+    @optional changed : bool
+    @optional buffer : array<uint8>                       // working buffer
+}
+```
+
+After this, `IDENT.value` is a daslang null string at first read. Most string ops are null-safe (`length(null) == 0`, `"{x}"` interpolation prints empty), so the widget body can read `state.value` even before the user has set anything. JV serialization handles null strings cleanly too.
+
+**Companion gotchas (same pattern, same struct):**
+
+1. **Numeric defaults still don't fire.** `@live capacity : int = 256` does NOT mean the global starts at 256 — it starts at 0. Promote to the desired default in the widget body's first-frame init: `if (state.capacity == 0) { state.capacity = 256 }`. (See sibling card `dasimgui-widget-auto-emit-skips-struct-field-defaults`.)
+2. **Cross-context string lifetime.** When dispatcher receives a `string` payload from `imgui_set` (decoded by `from_JV` against a JV the live_command machinery owns), the bytes drop when the dispatcher returns. Use `:=` (clone), NOT `=`, when storing to the state field: `state.pending_value := from_JV(payload?["value"], type<string>, "")`. This forces a clone into the widget context heap so the next frame's read is safe.
+3. **`@safe_when_uninitialized` and `@optional` compose.** Apply both when the field is both initially-null AND skip-when-zero: `@safe_when_uninitialized @optional pending_value : string`.
+4. **`array<T>` doesn't need this annotation.** Bit-zero array means empty array; daslang doesn't refuse to compile. `array<uint8>` working buffers are the right "raw bytes" companion to a `string` value field.
+
+**Found 2026-05-10**, dasImgui Phase 0b.4 (`InputTextState` design). String fields were the blocker — without the annotation, the whole struct was unusable as a `[widget]` state, even though arrays and ints in the same struct were fine.
+
+## See also
+- `dasimgui-widget-auto-emit-skips-struct-field-defaults` — sibling: numeric defaults don't fire either, push to call-site
+- `daslang-strings-cannot-carry-embedded-nulls-use-array-uint8-and-reinterpret-string-temp-for-c-api-zero-separated-buffers` — when you need to *avoid* `string` and use `array<uint8>` for the same payload
+
+## Questions
+- How do I expose a daslang `string` value through a `[widget]` state struct without tripping error 31014 (uninitialized variable is unsafe) at compile time?

--- a/mouse-data/docs/how-do-i-marshal-an-inputtext-buffer-between-daslang-array-uint8-and-imgui-s-char-without-the-legacy-dasimguiinputtext-mirror-st.md
+++ b/mouse-data/docs/how-do-i-marshal-an-inputtext-buffer-between-daslang-array-uint8-and-imgui-s-char-without-the-legacy-dasimguiinputtext-mirror-st.md
@@ -1,0 +1,104 @@
+---
+slug: how-do-i-marshal-an-inputtext-buffer-between-daslang-array-uint8-and-imgui-s-char-without-the-legacy-dasimguiinputtext-mirror-st
+title: How do I marshal an InputText buffer between daslang `array<uint8>` and ImGui's `char *` without the legacy `DasImguiInputText` mirror struct?
+created: 2026-05-10
+last_verified: 2026-05-10
+links: []
+---
+
+**Pass `addr(buffer[0])` directly; the C++ side casts `uint8_t*` → `char*`.** The whole `DasImguiInputText` struct in `modules/dasImgui/src/dasIMGUI.main.cpp` exists to wrap a `TArray<uint8_t> buffer` field for the v1 `ImGuiInputTextBuffer` daslang surface. For new widget code, drop the wrapper and keep the buffer as a plain `array<uint8>` field on the state struct.
+
+**C++ side** (one line per overload, no struct):
+```cpp
+bool InputTextBasic ( uint8_t * buf, int buf_size, const char * label, ImGuiInputTextFlags_ flags ) {
+    return ImGui::InputText(label, (char *)buf, buf_size, flags);
+}
+```
+Bind it the usual way:
+```cpp
+addExtern<DAS_BIND_FUN(das::InputTextBasic)>(*this, lib, "_builtin_InputText_basic",
+    SideEffects::worstDefault, "das::InputTextBasic");
+```
+
+**Daslang side** (state owns the buffer + a string mirror; widget body marshals):
+```das
+struct InputTextState {
+    @safe_when_uninitialized @live value : string         //! mirror of buffer-as-string
+    @live capacity : int                                  //! buffer.size; promoted from 0 → 256 first frame
+    @optional has_pending : bool
+    @safe_when_uninitialized @optional pending_value : string
+    @optional changed : bool
+    @optional buffer : array<uint8>                       // transient working buffer
+}
+
+def private input_text_buffer_init(var state : InputTextState) {
+    if (state.capacity == 0) { state.capacity = 256 }
+    if (length(state.buffer) != state.capacity) {
+        state.buffer |> resize(state.capacity)
+        sync_buffer_from_value(state)
+    }
+}
+
+def private sync_buffer_from_value(var state : InputTextState) {
+    for (i in range(state.capacity)) { state.buffer[i] = 0u8 }
+    let want = length(state.value)
+    if (want > 0) {
+        let n = min(want, state.capacity - 1)
+        unsafe { memcpy(addr(state.buffer[0]), reinterpret<void?>(state.value), n) }
+    }
+}
+
+def private sync_value_from_buffer(var state : InputTextState) {
+    unsafe {
+        let pbuf = addr(state.buffer[0])
+        state.value := clone_string(reinterpret<string>(pbuf))
+    }
+}
+
+[widget]
+def input_text(var state : InputTextState; text : string;
+               flags : ImGuiInputTextFlags = ImGuiInputTextFlags.None) : bool {
+    input_text_buffer_init(state)
+    apply_pending_text(state)        // imgui_set L3 path
+    let changed = unsafe(_builtin_InputText_basic(
+        addr(state.buffer[0]), state.capacity, text, flags))
+    state.changed = changed
+    if (changed) { sync_value_from_buffer(state) }
+    text_value_finalize(widget_ident, "input_text", state)
+    return changed
+}
+```
+
+**Why these moving pieces:**
+
+- **`@optional buffer`** is dropped on hot-reload. `length(state.buffer) != state.capacity` triggers re-allocate-and-refill from `state.value` on the first post-reload frame. Same path covers initial frame.
+- **`sync_buffer_from_value` zeros first** so the trailing null is preserved (ImGui scans for null to determine end-of-string). `min(want, capacity - 1)` reserves the byte.
+- **`sync_value_from_buffer` only runs on `changed`** (one extra clone per *user keystroke*, not per frame). Keystroke rates won't notice.
+- **`memcpy(addr(buf[0]), reinterpret<void?>(state.value), n)`** is the daslang idiom for "copy N bytes from a string into a uint8 array". `reinterpret<void?>(state.value)` exposes the string's underlying pointer for the byte copy.
+
+**For the growable variant** (CallbackResize), use `_builtin_InputText_cb` (the `_cb` forwarder takes a `Lambda` parameter and stack-allocates a thunk for the callback's lifetime — see `are-imgui-inputtext-combo-callbacks-fired-synchronously-inside-the-c-call-can-i-stack-allocate-the-callback-thunk`):
+
+```das
+unsafe {
+    changed = _builtin_InputText_cb(addr(state.buffer[0]), state.capacity, text, cb_flags,
+        @ capture(& state) (var data : ImGuiInputTextCallbackData) : int {
+            if (data.EventFlag == ImGuiInputTextFlags.CallbackResize) {
+                state.buffer |> resize(data.BufSize)
+                state.capacity = data.BufSize
+                data.Buf = unsafe(reinterpret<int8?>(addr(state.buffer[0])))
+            }
+            return 0
+        })
+}
+```
+
+`data.Buf` is the writable `char*` field on the bound `ImGuiInputTextCallbackData`; daslang exposes it as `int8?`. After resize, repoint Buf to the new array start, return 0, ImGui continues with the larger buffer.
+
+**Found 2026-05-10**, dasImgui Phase 0b.4. Replaces the 80-line `DasImguiInputText` shim machinery in the v1 `daslib/imgui_boost.das` surface (which stays untouched as the v1 v1 surface — only new widget code uses this pattern).
+
+## See also
+- `are-imgui-inputtext-combo-callbacks-fired-synchronously-inside-the-c-call-can-i-stack-allocate-the-callback-thunk` — the lifetime contract that lets the callback variant work without a struct mirror
+- `how-do-i-expose-a-daslang-string-value-through-a-widget-state-struct-without-tripping-error-31014-uninitialized-variable-is-unsafe-at-compile-time` — companion: why the `value` field needs `@safe_when_uninitialized`
+
+## Questions
+- How do I marshal an InputText buffer between daslang `array<uint8>` and ImGui's `char *` without the legacy `DasImguiInputText` mirror struct?


### PR DESCRIPTION
## Summary

- **`daslib/json_boost.das`**: 2-line PERF017 fix in the `@optional`-skip path. Was using `length(field) == 0` for arrays and tables; that fires PERF017 (`'length(x) == 0' — use 'empty(x)'`) through every caller of generic JV reflection that has an array/table field on the serialized struct (combo's `items_buf`, every dasImgui input-text state struct, and any other consumer downstream). Same semantics, no perf cost on arrays/tables (length is O(1)) — but the lint stops at the upstream point so every consumer goes clean.
- **7 mouse cards** under `mouse-data/docs/`. 4 carried over from prior dasImgui phase 0b sessions that never got committed (auto-emit-skips-defaults, named-tuple-positional, generic-finalize-helper, strings-cannot-carry-embedded-nulls). 3 new this session for phase 0b.4 (synchronous-callback insight + stack-thunk pattern, `@safe_when_uninitialized` for widget-state strings, buffer-as-pointer InputText marshaling without the v1 `DasImguiInputText` mirror).

The dasImgui phase 0b.4 work itself lives in the `bbatkin/dasimgui-phase0b` branch of the dasImgui sub-repo (commit `f54fd0a`); this PR is the daslang-root portion of that bundle.

## Test plan

- [x] `mcp__daslang__lint daslib/json_boost.das` — PASS, 0 issues
- [x] `daslang dastest/dastest.das -- --test tests/json` — 266/266 pass
- [x] `daslang dastest/dastest.das -- --test modules/dasImgui/tests/integration` — 10/10 pass (~38.7s), exercising the JV-reflection path with the new `empty(field)` semantics across every dasImgui state struct
- [x] No behavioral change in JV output — the `@optional`-skip branch decides whether to skip the field; `length(field) == 0` and `empty(field)` are equivalent for `array<T>` / `table<K;V>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)