### PR TITLE
feat(mouse): bad_mouse — mark no-match asks; useful flag + log MCP tool

### DIFF
--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -846,8 +846,7 @@ def skip_while_to_array(var src : iterator<auto(TT)>; predicate : block<(arg : T
 
 def take(arr : array<auto(TT)>; var total : int) : array<TT -& -const> {
     //! Yields only the first `total` elements
-    let len = length(arr)
-    let taking = (total < len)  ? total : len
+    let taking = min(total, length(arr))
     return <- subarray(arr, 0..taking)
 }
 

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -35,7 +35,7 @@ def _first_opt(arr : array<auto(TT)>) : Option<TT -const -#> {
     //! Compat-mode fallback: returns ``some(arr[0])`` if non-empty, ``none`` otherwise.
     //! Inside `_sql(...)` the macro intercepts this call before evaluation
     //! and emits ` LIMIT 1` with the OneOpt materializer.
-    if (length(arr) > 0) {
+    if (!empty(arr)) {
         return some(arr[0])
     }
     return none(type<TT -const -#>)

--- a/skills/mouse.md
+++ b/skills/mouse.md
@@ -8,7 +8,7 @@ Read this BEFORE asking, adding, or curating mouse cards. The hard rule (MOUSE F
 |---|---|
 | About to research a "how do I X?" / "what's the pattern for Y?" / "why does Z behave this way?" question | `mouse__ask` first |
 | Just answered such a question through your own research | `mouse__add` before moving on |
-| `mouse__ask` returned cards but none of them address what you actually asked | `mouse__bad(query_id)` immediately, then research and `mouse__add` if the answer's worth caching |
+| `mouse__ask` returned cards but none of them address what you actually asked | `mouse__bad(queryId)` immediately, then research and `mouse__add` if the answer's worth caching |
 | Wrap-up after a meaningful chunk of work | See `skills/task_wrap_up.md` (review `mouse log --misses` for zero-result asks, `mouse log --review` for unrated hits) |
 | Symbol/field/type lookup ("where is X defined?", "all references to Y") | NOT mouse — use daslang MCP (`find_symbol`, `grep_usage`, `find_references`) |
 | Categorical convention (gen2 syntax, build flags, formatting) | NOT mouse — `CLAUDE.md` / `skills/*.md` |

--- a/skills/mouse.md
+++ b/skills/mouse.md
@@ -8,7 +8,8 @@ Read this BEFORE asking, adding, or curating mouse cards. The hard rule (MOUSE F
 |---|---|
 | About to research a "how do I X?" / "what's the pattern for Y?" / "why does Z behave this way?" question | `mouse__ask` first |
 | Just answered such a question through your own research | `mouse__add` before moving on |
-| Wrap-up after a meaningful chunk of work | See `skills/task_wrap_up.md` (review `mouse log --misses` + un-asked questions) |
+| `mouse__ask` returned cards but none of them address what you actually asked | `mouse__bad(query_id)` immediately, then research and `mouse__add` if the answer's worth caching |
+| Wrap-up after a meaningful chunk of work | See `skills/task_wrap_up.md` (review `mouse log --misses` for zero-result asks, `mouse log --review` for unrated hits) |
 | Symbol/field/type lookup ("where is X defined?", "all references to Y") | NOT mouse — use daslang MCP (`find_symbol`, `grep_usage`, `find_references`) |
 | Categorical convention (gen2 syntax, build flags, formatting) | NOT mouse — `CLAUDE.md` / `skills/*.md` |
 | Project state (in-progress branches, who's doing what) | NOT mouse — `git log` / memory |
@@ -23,6 +24,7 @@ The mouse MCP server is deferred — the call dance is `ToolSearch select:mcp__m
 - **Free-form natural language is fine.** The retriever ORs words and ranks by BM25 + Jaccard title-similarity. Don't write FTS5 syntax unless you specifically need phrase matching (then pass `rawQuery=true`).
 - **One question per call.** Three sub-questions → three asks. They hit different cards; compressing them into one query dilutes BM25 scoring.
 - **Plan-mode sweep.** During planning, ask the mouse early and often — design questions, prior-art questions, gotcha-recall, trade-off recall. Each cached answer saves a research detour; each cache miss is one `mouse__add` away from being free next time.
+- **Mark no-match (false-positive hits).** The response begins with `query_id: N`. If you scan the returned cards and **none** of them address the question — BM25 matched on shared tokens but the corpus has no real answer yet — call `mouse__bad(queryId=N)` before moving on. That converts a false-positive hit into the same actionable signal as `match_count = 0`. Skip when you're unsure whether a card kind-of helped — only the clear-negative signal carries information; we never mark hits as good (default-positive bias would make `useful=true` ratings noise).
 
 ## Adding
 

--- a/skills/task_wrap_up.md
+++ b/skills/task_wrap_up.md
@@ -21,7 +21,7 @@ bin/daslang utils/mouse/main.das -- log --review
 ```
 
 The `--review` queue is hits the agent didn't rate at ask time: `match_count > 0 AND useful IS NULL`. Some are real false positives — BM25 matched on shared tokens but none of the returned cards actually answered the question. For each row, scan the listed top slug against the question:
-- **Did the top slug actually address the question?** If clearly yes — leave it (implicit positive). If clearly no — `mouse__bad <id>` (or `mouse bad <id>` from CLI). That row joins the `--bad` queue. If this session has the real answer, also `mouse__add` so next session retrieves the right card instead of the false-positive one.
+- **Did the top slug actually address the question?** If clearly yes — leave it (implicit positive). If clearly no — call `mouse__bad` with the row's id (CLI: `mouse bad <id>`). That row joins the `--bad` queue. If this session has the real answer, also `mouse__add` so next session retrieves the right card instead of the false-positive one.
 - **Unsure?** Skip — better to leave unrated than guess. Only the negative signal carries information; we never mark hits as good.
 
 ```bash

--- a/skills/task_wrap_up.md
+++ b/skills/task_wrap_up.md
@@ -12,9 +12,17 @@ bin/daslang utils/mouse/main.das -- log --misses
 
 (On Windows MSVC layout the binary is `bin/Release/daslang.exe` — same args after.)
 
-For each recent miss:
+For each recent miss (`match_count = 0`):
 - **Did this session answer it?** If yes — `mouse__add` (or `mouse add` from CLI). Next session won't redo the work.
 - **Did you _almost_ ask mouse this session but didn't?** Try asking now — misses-you-skipped don't show up in `--misses`. If the work you just did has the answer, add it.
+
+```bash
+bin/daslang utils/mouse/main.das -- log --review
+```
+
+The `--review` queue is hits the agent didn't rate at ask time: `match_count > 0 AND useful IS NULL`. Some are real false positives — BM25 matched on shared tokens but none of the returned cards actually answered the question. For each row, scan the listed top slug against the question:
+- **Did the top slug actually address the question?** If clearly yes — leave it (implicit positive). If clearly no — `mouse__bad <id>` (or `mouse bad <id>` from CLI). That row joins the `--bad` queue. If this session has the real answer, also `mouse__add` so next session retrieves the right card instead of the false-positive one.
+- **Unsure?** Skip — better to leave unrated than guess. Only the negative signal carries information; we never mark hits as good.
 
 ```bash
 bin/daslang utils/mouse/main.das -- log

--- a/tests/json/safe.das
+++ b/tests/json/safe.das
@@ -12,6 +12,7 @@ def safe_operators(t : T?) {
 
         t |> equal((js?["a"] ?as _longint) ?? -1l, 1l)
         t |> equal(js?.a ?? -1, 1)
+        t |> equal(js?.a ?? -1l, 1l) // JSON int (_longint) → int64 via ??
         t |> equal(js?.b ?? false, true)
         t |> equal(js?.c is _null, true)
         t |> equal(js?.d ?? "", "str")

--- a/utils/mouse/OVERVIEW.md
+++ b/utils/mouse/OVERVIEW.md
@@ -55,10 +55,12 @@ Frontmatter fields: `slug` (stable ID, used for cross-refs), `title` (1-line des
 
 | Operation | CLI | MCP tool | Notes |
 |---|---|---|---|
-| Retrieve | `mouse ask "<q>"` | `mouse__ask` | Top-K BM25 ranked, each annotated with a Jaccard title-similarity. Words OR-joined; `--raw-query` / `rawQuery=true` passes raw FTS5 syntax (phrases, NEAR, explicit AND/OR). |
+| Retrieve | `mouse ask "<q>"` | `mouse__ask` | Top-K BM25 ranked, each annotated with a Jaccard title-similarity. Words OR-joined; `--raw-query` / `rawQuery=true` passes raw FTS5 syntax (phrases, NEAR, explicit AND/OR). Response begins with `query_id:` — capture for `mouse__bad`. |
 | Add Q&A | `mouse add "<q>" --body "..."` | `mouse__add` | Advisory similar list always; hard-blocks only on Jaccard ≥ 0.7. `--force` / `force=true` overrides the block. |
 | Get doc | `mouse get <slug>` | `mouse__get` | Body + frontmatter + reverse-link footer. |
 | Rebuild | `mouse rebuild` | `mouse__rebuild` | Force full rescan + signature reset. Normally not needed — every entry point auto-reindexes via the git-staleness check. |
+| Mark no-match | `mouse bad <id>` | `mouse__bad` | Flags a previous ask as a false-positive hit (BM25 returned cards but none addressed the question). Sets `query_log.useful = 0`. Idempotent. We never write `useful = 1` — implicit positive avoids sycophancy noise. |
+| Recent log | `mouse log [--misses\|--bad\|--review]` | `mouse__log` | Browse the query log. `mode=misses` → zero-result asks (the existing add-candidate queue). `mode=bad` → already-marked false positives. `mode=review` → `match_count > 0 AND useful IS NULL` (the wrap-up rating queue). |
 | Serve MCP | `mouse serve` | (this _is_ the server) | stdio JSON-RPC. |
 
 **Dupe-on-add gate.** `add` always runs a Jaccard-scored similarity check against the corpus and surfaces the top matches (whether it created or not). With `force=false` (default), it hard-blocks only when the top match scores ≥ 0.7 — a near-paraphrase. Below that threshold, the add proceeds and the similar list is shown for awareness. The caller (LLM or human) is the actual decider; the threshold just stops obvious near-paraphrases from sneaking in. Below 0.5 nothing is surfaced unless content overlap is genuine.
@@ -79,6 +81,7 @@ The SQLite schema (managed via `[sql_migration]` from `sqlite/sqlite_migrate`):
 - `links` — composite-PK pair `(from_slug, to_slug)` for cross-refs.
 - `search_idx` — FTS5 virtual table; per-doc concatenation of title + question aliases + body. BM25 ranks via the `@sql_fts_rank` column.
 - `index_meta` — `(key, value)` k/v table. Currently stores the staleness signature; future-proof for other persistent metadata.
+- `query_log` — append-only log of every ask: `id` (PK), `asked_at`, `question`, `match_count`, `top_slug`, `source` (`cli` / `mcp`), `useful` (nullable: `NULL` = unrated, `0` = caller marked the hit irrelevant). Survives `rebuild` (which only wipes the doc cache). Two signals into curation: `match_count = 0` rows are the canonical miss-candidate queue (`mouse log --misses`); `match_count > 0 AND useful IS NULL` is the rating queue for retrospective review during wrap-up (`mouse log --review`).
 
 Rebuild is whole-corpus delete+repopulate — simple, correct, fast for small corpora. Incremental update (re-index only changed `body_hash`) is a vNext optimization once the corpus is large enough that whole-rebuild matters.
 

--- a/utils/mouse/index.das
+++ b/utils/mouse/index.das
@@ -86,7 +86,10 @@ struct SearchRow {
 
 // Append-only log of every ask. Survives rebuild() (which only wipes the
 // doc cache). The miss list is the input signal for `mouse__add` —
-// "questions asked but no doc covers them yet".
+// "questions asked but no doc covers them yet". `useful` captures the
+// false-positive case: hit rows the caller marked as no-match (BM25
+// returned cards but none addressed the question). NULL = unrated;
+// 0 = no-match. We never write 1 — implicit positive avoids sycophancy.
 [sql_table(name = "query_log")]
 struct QueryLog {
     @sql_primary_key id : int64
@@ -95,6 +98,7 @@ struct QueryLog {
     match_count : int
     top_slug : string
     source : string  // "cli" | "mcp"
+    @safe_when_uninitialized useful : Option<int>
 }
 
 [sql_migration(version = 1, description = "create docs/links/search_idx")]
@@ -106,7 +110,13 @@ def migration_001(db : SqlRunner) {
 
 [sql_migration(version = 2, description = "add query_log")]
 def migration_002(db : SqlRunner) {
-    db |> create_table(type<QueryLog>)
+    // Raw SQL pinned to the v2-era schema. Originally this was
+    // `db |> create_table(type<QueryLog>)`, but `create_table` regenerates
+    // DDL from the current struct on every fresh-DB migration — so as soon
+    // as a later migration evolves QueryLog (e.g. v4 adds `useful`), v2
+    // would create the column too, and v4's add_column would duplicate.
+    // Pinning v2's DDL here decouples migration history from struct shape.
+    db |> exec("CREATE TABLE query_log (id INTEGER PRIMARY KEY, asked_at TEXT NOT NULL, question TEXT NOT NULL, match_count INTEGER NOT NULL, top_slug TEXT NOT NULL, source TEXT NOT NULL)")
 }
 
 // Persisted across cold opens: the staleness signature used by
@@ -121,6 +131,11 @@ struct IndexMeta {
 [sql_migration(version = 3, description = "add index_meta for staleness signature")]
 def migration_003(db : SqlRunner) {
     db |> create_table(type<IndexMeta>)
+}
+
+[sql_migration(version = 4, description = "add useful flag to query_log")]
+def migration_004(db : SqlRunner) {
+    db |> add_column(type<QueryLog>, "useful")
 }
 
 def with_index_db(root : string; blk : block<(db : SqlRunner) : void>) {
@@ -451,20 +466,50 @@ def now_iso(db : SqlRunner) : string {
 }
 
 def log_query(db : SqlRunner; question : string;
-              hits : array<SearchHit>; source : string) {
+              hits : array<SearchHit>; source : string) : int64 {
     let top = !empty(hits) ? hits[0].slug : ""
     db |> insert(QueryLog(
         asked_at = now_iso(db),
         question = question,
         match_count = length(hits),
         top_slug = top,
-        source = source))
+        source = source,
+        useful = none(type<int>)))
+    return db |> last_insert_rowid()
 }
 
-def recent_queries(db : SqlRunner; n : int; misses_only : bool) : array<QueryLog> {
-    if (misses_only) {
+// Mark a query_log row as no-match (useful = 0). Returns rows affected
+// (0 if id doesn't exist; 1 on success). Idempotent — re-marking is a
+// no-op SET to the same value.
+def mark_no_match(db : SqlRunner; id : int64) : int {
+    return db |> _sql_update(type<QueryLog>, _.id == id, (useful = some(0)))
+}
+
+enum LogMode {
+    All     //!< every row (newest first)
+    Misses  //!< match_count == 0 (FTS5 returned nothing)
+    Bad     //!< useful == 0 (caller marked the hit irrelevant)
+    Review  //!< match_count > 0 AND useful IS NULL (queue for retrospective rating)
+}
+
+def recent_queries(db : SqlRunner; n : int; mode : LogMode) : array<QueryLog> {
+    if (mode == LogMode.Misses) {
         var rows <- _sql(db |> select_from(type<QueryLog>)
                            |> _where(_.match_count == 0)
+                           |> _order_by_descending(_.id)
+                           |> take(n))
+        return <- rows
+    }
+    if (mode == LogMode.Bad) {
+        var rows <- _sql(db |> select_from(type<QueryLog>)
+                           |> _where(_.useful |> unwrap_or(-1) == 0)
+                           |> _order_by_descending(_.id)
+                           |> take(n))
+        return <- rows
+    }
+    if (mode == LogMode.Review) {
+        var rows <- _sql(db |> select_from(type<QueryLog>)
+                           |> _where(_.match_count > 0 && _.useful |> is_none)
                            |> _order_by_descending(_.id)
                            |> take(n))
         return <- rows

--- a/utils/mouse/main.das
+++ b/utils/mouse/main.das
@@ -226,8 +226,11 @@ def cmd_rebuild(args : MouseArgs) {
     print("rebuilt: {n} doc(s) in {root}\n")
 }
 
-// Resolve mutually exclusive --misses / --bad / --review flags into a
-// single LogMode. First-set-wins; default (none set) means All.
+// Resolve --misses / --bad / --review into a single LogMode. If more
+// than one is set, the fixed priority is misses > bad > review (set by
+// the order of the checks below, not flag-set order on the CLI). The
+// help text declares them mutually exclusive; we resolve rather than
+// error so a callsite passing two by accident still gets a sane mode.
 def resolve_log_mode(args : MouseArgs) : LogMode {
     return LogMode.Misses if (args.misses)
     return LogMode.Bad    if (args.bad)
@@ -325,48 +328,6 @@ def jsonrpc_error(id : string; code : int; msg : string) : string {
     return "\{\"jsonrpc\":\"2.0\",\"id\":{id},\"error\":\{\"code\":{code},\"message\":{escaped}\}\}"
 }
 
-def get_string_arg(args : JsonValue?; key : string) : string {
-    if (args == null) {
-        return ""
-    }
-    let v = args?[key]
-    if (v == null) {
-        return ""
-    }
-    if (v.value is _string) {
-        return v.value as _string
-    }
-    return ""
-}
-
-def get_int_arg(args : JsonValue?; key : string; dflt : int) : int {
-    if (args == null) {
-        return dflt
-    }
-    let v = args?[key]
-    if (v == null) {
-        return dflt
-    }
-    if (v.value is _number) {
-        return int(v.value as _number)
-    }
-    return dflt
-}
-
-def get_bool_arg(args : JsonValue?; key : string) : bool {
-    if (args == null) {
-        return false
-    }
-    let v = args?[key]
-    if (v == null) {
-        return false
-    }
-    if (v.value is _bool) {
-        return v.value as _bool
-    }
-    return false
-}
-
 def jsonvalue_id_to_string(id : JsonValue?) : string {
     if (id == null) {
         return "null"
@@ -410,13 +371,13 @@ let HINT_NO_MATCH = "\nHint: nothing matched. Do the research yourself, then cal
 let HINT_HIT = "\nHint: if any answer above is stale or wrong, edit the .md at the `path:` shown and bump `last_verified` (or delete the file if it's no longer relevant). To fetch one of the answers in full, call mouse__get with the slug shown next to the `BM25`/`sim` scores."
 
 def tool_ask(args : JsonValue?) : string {
-    let question = get_string_arg(args, "question")
+    let question : string = args?["question"] ?? ""
     if (empty(question)) {
         return make_tool_result("missing 'question' argument", true)
     }
-    let k = get_int_arg(args, "k", 5)
-    let raw_query = get_bool_arg(args, "rawQuery")
-    let root = resolve_root(get_string_arg(args, "root"))
+    let k : int = args?["k"] ?? 5
+    let raw_query : bool = args?["rawQuery"] ?? false
+    let root = resolve_root(args?["root"] ?? "")
     var output : string
     with_index_db(root) $(db) {
         ensure_index_fresh(db, root)
@@ -441,17 +402,17 @@ def tool_ask(args : JsonValue?) : string {
 }
 
 def tool_add(args : JsonValue?) : string {
-    let question = get_string_arg(args, "question")
+    let question : string = args?["question"] ?? ""
     if (empty(question)) {
         return make_tool_result("missing 'question' argument", true)
     }
-    let body = get_string_arg(args, "body")
+    let body : string = args?["body"] ?? ""
     if (empty(body)) {
         return make_tool_result("missing 'body' argument", true)
     }
-    let slug_hint = get_string_arg(args, "slug")
-    let force = get_bool_arg(args, "force")
-    let root = resolve_root(get_string_arg(args, "root"))
+    let slug_hint : string = args?["slug"] ?? ""
+    let force : bool = args?["force"] ?? false
+    let root = resolve_root(args?["root"] ?? "")
     var output : string
     var is_error = false
     with_index_db(root) $(db) {
@@ -490,7 +451,7 @@ def tool_add(args : JsonValue?) : string {
 }
 
 def tool_get(args : JsonValue?) : string {
-    let raw_slug = get_string_arg(args, "slug")
+    let raw_slug : string = args?["slug"] ?? ""
     if (empty(raw_slug)) {
         return make_tool_result("missing 'slug' argument — pass the slug shown next to the `BM25`/`sim` scores in mouse__ask output (the bare-token form, e.g. 'how-do-i-foo-bar')", true)
     }
@@ -502,7 +463,7 @@ def tool_get(args : JsonValue?) : string {
         }
         return make_tool_result("invalid slug '{slug}' — pass the bare-token slug shown next to the `BM25`/`sim` scores in mouse__ask output (e.g. 'how-do-i-foo-bar')", true)
     }
-    let root = resolve_root(get_string_arg(args, "root"))
+    let root = resolve_root(args?["root"] ?? "")
     var output : string
     var is_error = false
     with_index_db(root) $(db) {
@@ -559,7 +520,7 @@ def tool_get(args : JsonValue?) : string {
 }
 
 def tool_rebuild(args : JsonValue?) : string {
-    let root = resolve_root(get_string_arg(args, "root"))
+    let root = resolve_root(args?["root"] ?? "")
     var n = 0
     with_index_db(root) $(db) {
         n = rebuild(db, root)
@@ -568,26 +529,12 @@ def tool_rebuild(args : JsonValue?) : string {
     return make_tool_result("rebuilt: {n} doc(s) in {root}", false)
 }
 
-def get_int64_arg(args : JsonValue?; key : string; dflt : int64) : int64 {
-    if (args == null) {
-        return dflt
-    }
-    let v = args?[key]
-    if (v == null) {
-        return dflt
-    }
-    if (v.value is _number) {
-        return int64(v.value as _number)
-    }
-    return dflt
-}
-
 def tool_bad(args : JsonValue?) : string {
-    let qid = get_int64_arg(args, "queryId", 0l)
+    let qid : int64 = args?["queryId"] ?? 0l
     if (qid <= 0l) {
         return make_tool_result("missing or invalid 'queryId' (positive int64 required) — pass the value shown next to `query_id:` in the mouse__ask response", true)
     }
-    let root = resolve_root(get_string_arg(args, "root"))
+    let root = resolve_root(args?["root"] ?? "")
     var output : string
     var is_error = false
     with_index_db(root) $(db) {
@@ -623,12 +570,12 @@ def log_mode_display(m : LogMode) : string {
 let HINT_LOG_REVIEW = "\nWrap-up tip: scan rows above where the listed top slug doesn't address the question. Call mouse__bad(queryId) on each, then mouse__add the answer if you found it during this session."
 
 def tool_log(args : JsonValue?) : string {
-    let mode_str = get_string_arg(args, "mode")
+    let mode_str : string = args?["mode"] ?? ""
     let mode = parse_log_mode(mode_str)
     let mode_display = log_mode_display(mode)
-    let n_arg = get_int_arg(args, "limit", 20)
+    let n_arg : int = args?["limit"] ?? 20
     let n = n_arg > 0 ? n_arg : 20
-    let root = resolve_root(get_string_arg(args, "root"))
+    let root = resolve_root(args?["root"] ?? "")
     var output : string
     with_index_db(root) $(db) {
         ensure_index_fresh(db, root)

--- a/utils/mouse/main.das
+++ b/utils/mouse/main.das
@@ -5,8 +5,9 @@
 //   daslang utils/mouse/main.das -- add "question" --body "answer body"
 //   daslang utils/mouse/main.das -- get <slug>
 //   daslang utils/mouse/main.das -- rebuild
-//   daslang utils/mouse/main.das -- log [-n N] [--misses]
-//   daslang utils/mouse/main.das -- serve            # MCP stdio loop
+//   daslang utils/mouse/main.das -- log [-n N] [--misses | --bad | --review]
+//   daslang utils/mouse/main.das -- bad <query-id>     # mark hit as no-match
+//   daslang utils/mouse/main.das -- serve              # MCP stdio loop
 
 options gen2
 options persistent_heap
@@ -20,6 +21,7 @@ require daslib/clargs
 require daslib/json_boost
 require daslib/fio
 require daslib/strings_boost
+require daslib/strings_convert
 require strings
 require store
 require index
@@ -29,11 +31,11 @@ require index
 [CommandLineArgs]
 struct MouseArgs {
     @clarg_positional
-    @clarg_doc = "Subcommand: ask | add | get | rebuild | log | serve"
+    @clarg_doc = "Subcommand: ask | add | get | rebuild | log | bad | serve"
     command : Option<string>
 
     @clarg_positional
-    @clarg_doc = "Argument: question text (ask, add) or slug (get)"
+    @clarg_doc = "Argument: question text (ask, add), slug (get), or query-id (bad)"
     arg : Option<string>
 
     @clarg_short = "r"
@@ -58,8 +60,14 @@ struct MouseArgs {
     @clarg_doc = "Limit (log)"
     limit : int = 20
 
-    @clarg_doc = "Show only queries with no result (log)"
+    @clarg_doc = "log: show only zero-result misses (match_count == 0)"
     misses : bool
+
+    @clarg_doc = "log: show only hits the caller marked as no-match (useful == 0)"
+    bad : bool
+
+    @clarg_doc = "log: show unrated hits (match_count > 0 AND useful IS NULL) — the queue for retrospective rating during wrap-up"
+    review : bool
 
     @clarg_doc = "Treat the question as raw FTS5 query syntax (no sanitization, no OR-join). See https://www.sqlite.org/fts5.html#full_text_query_syntax"
     raw_query : bool
@@ -96,13 +104,13 @@ def cmd_ask(args : MouseArgs) {
     with_index_db(root) $(db) {
         ensure_index_fresh(db, root)
         let hits <- search(db, query, args.k, args.raw_query)
-        log_query(db, query, hits, "cli")
+        let qid = log_query(db, query, hits, "cli")
         if (empty(hits)) {
-            print("(no results){HINT_NO_MATCH}\n")
+            print("query_id: {qid}\n(no results){HINT_NO_MATCH}\n")
             return
         }
         let qtok = tokenize_for_jaccard(query)
-        print("Top {length(hits)} best match(es):\n")
+        print("query_id: {qid}\nTop {length(hits)} best match(es):\n")
         for (h in hits) {
             let ttok = tokenize_for_jaccard(h.title)
             print(fmt_search_hit(h, jaccard(qtok, ttok)))
@@ -218,24 +226,69 @@ def cmd_rebuild(args : MouseArgs) {
     print("rebuilt: {n} doc(s) in {root}\n")
 }
 
+// Resolve mutually exclusive --misses / --bad / --review flags into a
+// single LogMode. First-set-wins; default (none set) means All.
+def resolve_log_mode(args : MouseArgs) : LogMode {
+    return LogMode.Misses if (args.misses)
+    return LogMode.Bad    if (args.bad)
+    return LogMode.Review if (args.review)
+    return LogMode.All
+}
+
+def fmt_log_row(r : QueryLog) : string {
+    if (r.match_count == 0) {
+        return "[id {r.id}] [{r.asked_at}] ({r.source}) {r.question} -> MISS\n"
+    }
+    let useful_tag = r.useful |> is_some && r.useful |> unwrap_or(-1) == 0 ? " [BAD]" : ""
+    return "[id {r.id}] [{r.asked_at}] ({r.source}) {r.question} -> {r.match_count} hit(s) (top: {r.top_slug}){useful_tag}\n"
+}
+
 def cmd_log(args : MouseArgs) {
     let root = resolve_root(args.root)
     let n = args.limit > 0 ? args.limit : 20
+    let mode = resolve_log_mode(args)
     with_index_db(root) $(db) {
         ensure_index_fresh(db, root)
-        let rows <- recent_queries(db, n, args.misses)
+        let rows <- recent_queries(db, n, mode)
         if (empty(rows)) {
             print("(no queries logged yet)\n")
             return
         }
         for (r in rows) {
-            if (r.match_count == 0) {
-                print("[{r.asked_at}] ({r.source}) {r.question} -> MISS\n")
-            } else {
-                print("[{r.asked_at}] ({r.source}) {r.question} -> {r.match_count} hit(s) (top: {r.top_slug})\n")
-            }
+            print(fmt_log_row(r))
         }
     }
+}
+
+// Returns 0 on success, 1 on missing/invalid id, 2 if no row matches —
+// non-zero exit so shell callers can branch on it (mouse__bad MCP wraps
+// the same logic in a tool-result with isError=true on the same conditions).
+def cmd_bad(args : MouseArgs) : int {
+    let root = resolve_root(args.root)
+    let id_str = positional_value(args.arg)
+    if (empty(id_str)) {
+        to_log(LOG_ERROR, "bad: missing query-id; pass as positional arg (see `mouse log` for ids)")
+        return 1
+    }
+    let id_r <- try_to_int64(id_str)
+    if (id_r |> is_err) {
+        let err = id_r |> unwrap_err
+        to_log(LOG_ERROR, "bad: '{id_str}' is not a valid query-id ({err})")
+        return 1
+    }
+    let id = id_r |> unwrap
+    var rc = 0
+    with_index_db(root) $(db) {
+        ensure_index_fresh(db, root)
+        let n = mark_no_match(db, id)
+        if (n == 0) {
+            to_log(LOG_ERROR, "bad: no query_log row with id={id}")
+            rc = 2
+            return
+        }
+        print("marked id={id} as no-match\n")
+    }
+    return rc
 }
 
 // ─── MCP stdio server ────────────────────────────────────────────────
@@ -327,10 +380,12 @@ def handle_initialize(id : string) : string {
 def tools_list_body() : string {
     return build_string() $(var w) {
         w |> write("\{\"tools\":[")
-        w |> write("\{\"name\":\"mouse__ask\",\"description\":\"Search the blind-mouse Q&A cache. Returns top-K matches ranked by FTS5 BM25, each annotated with a Jaccard title-similarity (sim 0..1) so you can judge relevance at a glance. Set rawQuery=true to pass raw FTS5 syntax (https://www.sqlite.org/fts5.html#full_text_query_syntax) — quoted phrases, NEAR, explicit AND/OR.\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"question\":\{\"type\":\"string\"\},\"k\":\{\"type\":\"integer\",\"default\":5\},\"rawQuery\":\{\"type\":\"boolean\",\"default\":false\},\"root\":\{\"type\":\"string\"\}\},\"required\":[\"question\"]\}\},")
+        w |> write("\{\"name\":\"mouse__ask\",\"description\":\"Search the blind-mouse Q&A cache. Returns top-K matches ranked by FTS5 BM25, each annotated with a Jaccard title-similarity (sim 0..1) so you can judge relevance at a glance. The response begins with a `query_id:` line — capture it; if NONE of the returned cards address your question, pass that id to mouse__bad before moving on. Set rawQuery=true to pass raw FTS5 syntax (https://www.sqlite.org/fts5.html#full_text_query_syntax) — quoted phrases, NEAR, explicit AND/OR.\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"question\":\{\"type\":\"string\"\},\"k\":\{\"type\":\"integer\",\"default\":5\},\"rawQuery\":\{\"type\":\"boolean\",\"default\":false\},\"root\":\{\"type\":\"string\"\}\},\"required\":[\"question\"]\}\},")
         w |> write("\{\"name\":\"mouse__add\",\"description\":\"Add a Q&A to the cache. Runs a Jaccard similarity check on the question; with force=false (default), hard-blocks creation only when the top match scores >= 0.7 (a near-paraphrase) and returns the similar list without writing. Below the threshold, the doc is created and the similar list is returned for awareness. Set force=true to override the hard block.\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"question\":\{\"type\":\"string\"\},\"body\":\{\"type\":\"string\"\},\"slug\":\{\"type\":\"string\"\},\"force\":\{\"type\":\"boolean\",\"default\":false\},\"root\":\{\"type\":\"string\"\}\},\"required\":[\"question\",\"body\"]\}\},")
         w |> write("\{\"name\":\"mouse__get\",\"description\":\"Fetch a doc by slug. Returns body, frontmatter, and reverse-link footer (which docs link to this one).\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"slug\":\{\"type\":\"string\"\},\"root\":\{\"type\":\"string\"\}\},\"required\":[\"slug\"]\}\},")
-        w |> write("\{\"name\":\"mouse__rebuild\",\"description\":\"Rescan <root>/docs/ and rebuild the SQLite index from disk. .md files are the source of truth.\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"root\":\{\"type\":\"string\"\}\}\}\}")
+        w |> write("\{\"name\":\"mouse__rebuild\",\"description\":\"Rescan <root>/docs/ and rebuild the SQLite index from disk. .md files are the source of truth.\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"root\":\{\"type\":\"string\"\}\}\}\},")
+        w |> write("\{\"name\":\"mouse__bad\",\"description\":\"Mark a previous mouse__ask result as no-match. Call this when the cards mouse__ask returned didn't actually address your question — BM25 matched on shared tokens but the corpus has no real answer. Pass the queryId from the `query_id:` line in the mouse__ask response. Default-positive bias means we never mark hits as 'good'; only the negative signal carries information. Idempotent (re-marking is a no-op).\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"queryId\":\{\"type\":\"integer\",\"description\":\"The query_id returned by mouse__ask\"\},\"root\":\{\"type\":\"string\"\}\},\"required\":[\"queryId\"]\}\},")
+        w |> write("\{\"name\":\"mouse__log\",\"description\":\"List recent mouse__ask rows for retrospective curation. Use mode='review' during wrap-up to surface unrated hits (match_count > 0 AND useful IS NULL) — scan each row, decide if the top slug actually addressed the question, mark unhelpful ones via mouse__bad. mode='misses' shows zero-result asks (the existing add-candidate queue). mode='bad' shows already-marked false positives. mode='all' (default) returns everything newest-first.\",\"inputSchema\":\{\"type\":\"object\",\"properties\":\{\"mode\":\{\"type\":\"string\",\"enum\":[\"all\",\"misses\",\"bad\",\"review\"],\"default\":\"all\"\},\"limit\":\{\"type\":\"integer\",\"default\":20\},\"root\":\{\"type\":\"string\"\}\}\}\}")
         w |> write("]\}")
     }
 }
@@ -364,19 +419,20 @@ def tool_ask(args : JsonValue?) : string {
     with_index_db(root) $(db) {
         ensure_index_fresh(db, root)
         let hits <- search(db, question, k, raw_query)
-        log_query(db, question, hits, "mcp")
+        let qid = log_query(db, question, hits, "mcp")
         if (empty(hits)) {
-            output = "(no results for: {question}){HINT_NO_MATCH}"
+            output = "query_id: {qid}\n(no results for: {question}){HINT_NO_MATCH}"
             return
         }
         let qtok = tokenize_for_jaccard(question)
         output = build_string() $(var w) {
-            w |> write("Top {length(hits)} best match(es):\n")
+            w |> write("query_id: {qid}\nTop {length(hits)} best match(es):\n")
             for (h in hits) {
                 let ttok = tokenize_for_jaccard(h.title)
                 w |> write(fmt_search_hit(h, jaccard(qtok, ttok)))
             }
             w |> write(HINT_HIT)
+            w |> write("\nIf NONE of the cards above address your question, call mouse__bad with this query_id ({qid}) before moving on — that's the signal that BM25 matched on shared tokens but the corpus has no real answer yet. Then research and mouse__add the answer when you find it.")
         }
     }
     return make_tool_result(output, false)
@@ -510,6 +566,77 @@ def tool_rebuild(args : JsonValue?) : string {
     return make_tool_result("rebuilt: {n} doc(s) in {root}", false)
 }
 
+def get_int64_arg(args : JsonValue?; key : string; dflt : int64) : int64 {
+    if (args == null) {
+        return dflt
+    }
+    let v = args?[key]
+    if (v == null) {
+        return dflt
+    }
+    if (v.value is _number) {
+        return int64(v.value as _number)
+    }
+    return dflt
+}
+
+def tool_bad(args : JsonValue?) : string {
+    let qid = get_int64_arg(args, "queryId", 0l)
+    if (qid <= 0l) {
+        return make_tool_result("missing or invalid 'queryId' (positive int64 required) — pass the value shown next to `query_id:` in the mouse__ask response", true)
+    }
+    let root = resolve_root(get_string_arg(args, "root"))
+    var output : string
+    var is_error = false
+    with_index_db(root) $(db) {
+        ensure_index_fresh(db, root)
+        let n = mark_no_match(db, qid)
+        if (n == 0) {
+            output = "no query_log row with id={qid}"
+            is_error = true
+            return
+        }
+        output = "marked id={qid} as no-match. If you have the answer, call mouse__add now so the next session doesn't redo this."
+    }
+    return make_tool_result(output, is_error)
+}
+
+def parse_log_mode(s : string) : LogMode {
+    return LogMode.Misses if (s == "misses")
+    return LogMode.Bad    if (s == "bad")
+    return LogMode.Review if (s == "review")
+    return LogMode.All
+}
+
+let HINT_LOG_REVIEW = "\nWrap-up tip: scan rows above where the listed top slug doesn't address the question. Call mouse__bad(queryId) on each, then mouse__add the answer if you found it during this session."
+
+def tool_log(args : JsonValue?) : string {
+    let mode_str = get_string_arg(args, "mode")
+    let mode = parse_log_mode(mode_str)
+    let n_arg = get_int_arg(args, "limit", 20)
+    let n = n_arg > 0 ? n_arg : 20
+    let root = resolve_root(get_string_arg(args, "root"))
+    var output : string
+    with_index_db(root) $(db) {
+        ensure_index_fresh(db, root)
+        let rows <- recent_queries(db, n, mode)
+        if (empty(rows)) {
+            output = "(no rows matching mode={mode_str})"
+            return
+        }
+        output = build_string() $(var w) {
+            w |> write("{length(rows)} row(s), mode={mode_str}:\n")
+            for (r in rows) {
+                w |> write(fmt_log_row(r))
+            }
+            if (mode == LogMode.Review) {
+                w |> write(HINT_LOG_REVIEW)
+            }
+        }
+    }
+    return make_tool_result(output, false)
+}
+
 def handle_tools_call(id : string; params : JsonValue?) : string {
     if (params == null) {
         return jsonrpc_error(id, -32602, "missing params")
@@ -529,6 +656,10 @@ def handle_tools_call(id : string; params : JsonValue?) : string {
         result = tool_get(args)
     } elif (name == "mouse__rebuild") {
         result = tool_rebuild(args)
+    } elif (name == "mouse__bad") {
+        result = tool_bad(args)
+    } elif (name == "mouse__log") {
+        result = tool_log(args)
     } else {
         return jsonrpc_error(id, -32602, "unknown tool: {name}")
     }
@@ -619,22 +750,22 @@ def cmd_serve(args : MouseArgs) {
 // ─── main ────────────────────────────────────────────────────────────
 
 [export]
-def main() {
+def main() : int {
     var args_r <- parse_args(type<MouseArgs>)
     if (args_r |> is_err) {
         to_log(LOG_ERROR, "error: {args_r |> unwrap_err}")
         print_help(get_command_info(type<MouseArgs>), "mouse")
-        return
+        return 1
     }
     let args <- args_r |> move_unwrap
     if (args.help) {
         print_help(get_command_info(type<MouseArgs>), "mouse")
-        return
+        return 0
     }
     let cmd = positional_value(args.command)
     if (empty(cmd)) {
         print_help(get_command_info(type<MouseArgs>), "mouse")
-        return
+        return 0
     }
     if (cmd == "ask") {
         cmd_ask(args)
@@ -646,10 +777,14 @@ def main() {
         cmd_rebuild(args)
     } elif (cmd == "log") {
         cmd_log(args)
+    } elif (cmd == "bad") {
+        return cmd_bad(args)
     } elif (cmd == "serve") {
         cmd_serve(args)
     } else {
         to_log(LOG_ERROR, "unknown command: {cmd}")
         print_help(get_command_info(type<MouseArgs>), "mouse")
+        return 1
     }
+    return 0
 }

--- a/utils/mouse/main.das
+++ b/utils/mouse/main.das
@@ -251,7 +251,9 @@ def cmd_log(args : MouseArgs) {
         ensure_index_fresh(db, root)
         let rows <- recent_queries(db, n, mode)
         if (empty(rows)) {
-            print("(no queries logged yet)\n")
+            // Distinguish "no queries at all" from "filter matched none of N queries".
+            // Saying "no queries logged yet" while the log has hundreds of rows is misleading.
+            print(mode == LogMode.All ? "(no queries logged yet)\n" : "(no rows matching the selected filter)\n")
             return
         }
         for (r in rows) {
@@ -608,11 +610,22 @@ def parse_log_mode(s : string) : LogMode {
     return LogMode.All
 }
 
+// Display the LogMode the request actually filtered by — derived from the
+// parsed enum, NOT the raw input string. So an omitted/empty `mode`
+// surfaces as "all" instead of "mode=" with an empty trailing value.
+def log_mode_display(m : LogMode) : string {
+    return "misses" if (m == LogMode.Misses)
+    return "bad"    if (m == LogMode.Bad)
+    return "review" if (m == LogMode.Review)
+    return "all"
+}
+
 let HINT_LOG_REVIEW = "\nWrap-up tip: scan rows above where the listed top slug doesn't address the question. Call mouse__bad(queryId) on each, then mouse__add the answer if you found it during this session."
 
 def tool_log(args : JsonValue?) : string {
     let mode_str = get_string_arg(args, "mode")
     let mode = parse_log_mode(mode_str)
+    let mode_display = log_mode_display(mode)
     let n_arg = get_int_arg(args, "limit", 20)
     let n = n_arg > 0 ? n_arg : 20
     let root = resolve_root(get_string_arg(args, "root"))
@@ -621,11 +634,11 @@ def tool_log(args : JsonValue?) : string {
         ensure_index_fresh(db, root)
         let rows <- recent_queries(db, n, mode)
         if (empty(rows)) {
-            output = "(no rows matching mode={mode_str})"
+            output = "(no rows matching mode={mode_display})"
             return
         }
         output = build_string() $(var w) {
-            w |> write("{length(rows)} row(s), mode={mode_str}:\n")
+            w |> write("{length(rows)} row(s), mode={mode_display}:\n")
             for (r in rows) {
                 w |> write(fmt_log_row(r))
             }

--- a/utils/mouse/tests/test_index.das
+++ b/utils/mouse/tests/test_index.das
@@ -814,13 +814,168 @@ def test_recent_queries_filters_misses(t : T?) {
         log_query(db, "alpha", h1, "cli")
         let h2 <- search(db, "zzqxxgibberish", 5)
         log_query(db, "zzqxxgibberish", h2, "cli")
-        let all_rows <- recent_queries(db, 10, false)
-        let miss_rows <- recent_queries(db, 10, true)
+        let all_rows <- recent_queries(db, 10, LogMode.All)
+        let miss_rows <- recent_queries(db, 10, LogMode.Misses)
         n_all = length(all_rows)
         n_misses = length(miss_rows)
     }
     t |> equal(n_all, 2)
     t |> equal(n_misses, 1)
+    cleanup_root(root)
+}
+
+// ─── useful flag (mark_no_match + Bad/Review filters) ────────────────
+
+[test]
+def test_log_query_returns_increasing_ids(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    let no_links : array<string>
+    let qs <- ["alpha question"]
+    seed_doc(t, root, "alpha", "Alpha", "alpha body", no_links, qs)
+    var id1 = -1l
+    var id2 = -1l
+    with_index_db(root) $(db) {
+        rebuild(db, root)
+        let h1 <- search(db, "alpha", 5)
+        id1 = log_query(db, "alpha", h1, "cli")
+        let h2 <- search(db, "alpha", 5)
+        id2 = log_query(db, "alpha", h2, "cli")
+    }
+    t |> success(id1 > 0l, "first id positive: {id1}")
+    t |> success(id2 > id1, "second id strictly greater than first: {id1} -> {id2}")
+    cleanup_root(root)
+}
+
+[test]
+def test_mark_no_match_sets_useful_zero(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    let no_links : array<string>
+    let qs <- ["alpha question"]
+    seed_doc(t, root, "alpha", "Alpha", "alpha body", no_links, qs)
+    var id = -1l
+    var n_marked = -1
+    var useful_before : Option<int>
+    var useful_after : Option<int>
+    with_index_db(root) $(db) {
+        rebuild(db, root)
+        let h1 <- search(db, "alpha", 5)
+        id = log_query(db, "alpha", h1, "cli")
+        let row_before <- _sql(db |> select_from(type<QueryLog>) |> _where(_.id == id) |> _first_opt())
+        useful_before = (row_before |> unwrap).useful
+        n_marked = mark_no_match(db, id)
+        let row_after <- _sql(db |> select_from(type<QueryLog>) |> _where(_.id == id) |> _first_opt())
+        useful_after = (row_after |> unwrap).useful
+    }
+    t |> success(useful_before |> is_none, "useful starts NULL on insert")
+    t |> equal(n_marked, 1)
+    t |> success(useful_after |> is_some, "useful is non-NULL after mark")
+    t |> equal(useful_after |> unwrap_or(-1), 0)
+    cleanup_root(root)
+}
+
+[test]
+def test_mark_no_match_nonexistent_id_returns_zero(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    var n_marked = -1
+    with_index_db(root) $(db) {
+        rebuild(db, root)
+        n_marked = mark_no_match(db, 99999l)
+    }
+    t |> equal(n_marked, 0)
+    cleanup_root(root)
+}
+
+[test]
+def test_mark_no_match_idempotent(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    let no_links : array<string>
+    let qs <- ["alpha question"]
+    seed_doc(t, root, "alpha", "Alpha", "alpha body", no_links, qs)
+    var n1 = -1
+    var n2 = -1
+    var useful_after : Option<int>
+    with_index_db(root) $(db) {
+        rebuild(db, root)
+        let h1 <- search(db, "alpha", 5)
+        let id = log_query(db, "alpha", h1, "cli")
+        n1 = mark_no_match(db, id)
+        n2 = mark_no_match(db, id)
+        let row <- _sql(db |> select_from(type<QueryLog>) |> _where(_.id == id) |> _first_opt())
+        useful_after = (row |> unwrap).useful
+    }
+    t |> equal(n1, 1)
+    t |> equal(n2, 1)  // SQLite UPDATE matches the row even if SET to same value
+    t |> equal(useful_after |> unwrap_or(-1), 0)
+    cleanup_root(root)
+}
+
+[test]
+def test_recent_queries_filters_bad(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    let no_links : array<string>
+    let qs <- ["alpha question"]
+    seed_doc(t, root, "alpha", "Alpha", "alpha body", no_links, qs)
+    var n_bad = -1
+    var n_review = -1
+    with_index_db(root) $(db) {
+        rebuild(db, root)
+        // 3 hit rows: mark one bad, leave two unrated → 1 bad, 2 review.
+        let h1 <- search(db, "alpha", 5)
+        let id1 = log_query(db, "alpha", h1, "cli")
+        let h2 <- search(db, "alpha", 5)
+        log_query(db, "alpha 2", h2, "cli")
+        let h3 <- search(db, "alpha", 5)
+        log_query(db, "alpha 3", h3, "cli")
+        // 1 miss row: should NOT show up under bad or review (match_count == 0).
+        let h_miss <- search(db, "zzqxxgibberish", 5)
+        log_query(db, "zzqxxgibberish", h_miss, "cli")
+        mark_no_match(db, id1)
+        let bad_rows <- recent_queries(db, 10, LogMode.Bad)
+        let review_rows <- recent_queries(db, 10, LogMode.Review)
+        n_bad = length(bad_rows)
+        n_review = length(review_rows)
+    }
+    t |> equal(n_bad, 1)
+    t |> equal(n_review, 2)
+    cleanup_root(root)
+}
+
+[test]
+def test_recent_queries_review_excludes_misses(t : T?) {
+    let root = make_temp_root(t)
+    if (empty(root)) {
+        return
+    }
+    let no_links : array<string>
+    let qs <- ["alpha question"]
+    seed_doc(t, root, "alpha", "Alpha", "alpha body", no_links, qs)
+    var n_review = -1
+    with_index_db(root) $(db) {
+        rebuild(db, root)
+        // Only misses → review queue must be empty (Review needs match_count > 0).
+        let h_miss <- search(db, "zzqxxgibberish", 5)
+        log_query(db, "zzqxxgibberish", h_miss, "cli")
+        let h_miss2 <- search(db, "another gibberish", 5)
+        log_query(db, "another gibberish", h_miss2, "cli")
+        let review_rows <- recent_queries(db, 10, LogMode.Review)
+        n_review = length(review_rows)
+    }
+    t |> equal(n_review, 0)
     cleanup_root(root)
 }
 


### PR DESCRIPTION
## Why

Today `query_log` records every `mouse__ask` with `match_count` and `top_slug`, but doesn't capture whether the returned cards actually addressed the question. A row with `match_count=5` looks like a hit even if all 5 cards just shared BM25 tokens — that blind spot inflates the apparent hit rate (we observed 96% hits on real usage; the false-positive fraction is invisible) and hides cards that retrieve well but answer poorly.

This PR adds a `useful` flag (nullable Option<int>) per ask. The agent marks `useful=false` when no returned card addressed the question — both immediately after the ask (hot path) and during the existing wrap-up curation pass (safety net). `useful=true` is intentionally not recorded; default-positive bias makes `true` ratings sycophancy noise. Skipped = implicit yes; only the negative signal carries information.

## Schema (utils/mouse/index.das)

- New v4 migration adds `useful` to `query_log` via `add_column`.
- v2 migration converted from `create_table(type<QueryLog>)` to **raw SQL pinned to the v2-era schema**. `create_table` regenerates DDL from the current struct on every fresh-DB migration — so as soon as v4 added a column the v2 fresh-DB path would create it too, and v4 would duplicate. Pinning v2's DDL decouples migration history from struct shape (the canonical pattern from `tests/dasSQLITE/migrate_17_add_column_renamed.das:14-17`).
- `log_query` now returns `int64` (the inserted query_id).
- New `mark_no_match(db, id)` helper.
- New `LogMode` enum (`All` / `Misses` / `Bad` / `Review`). `recent_queries` now takes a `mode` parameter — small breaking change to the bool signature (3 callsites updated: 2 tests + `cmd_log`).

## Per-ask path (hot path)

- `mouse__ask` response now begins with `query_id: N`. Same in CLI.
- New MCP tool `mouse__bad(queryId)` and CLI `mouse bad <id>` mark a hit as no-match (`UPDATE useful = 0`). Idempotent. Distinct exit codes (`1` = usage error, `2` = no such id) so shell callers can branch.
- `tool_ask` ends with a hint reminding the agent: if NONE of the cards address the question, call `mouse__bad` before moving on.

## Wrap-up path (safety net)

- New MCP tool `mouse__log` exposes the existing `recent_queries` symmetrically to the CLI. New `--bad` / `--review` flags alongside `--misses`. `--review` shows `match_count > 0 AND useful IS NULL` — the rating queue.
- `skills/task_wrap_up.md` Section 1 extended with the `--review` step: scan unrated hits, mark unhelpful ones via `mouse__bad`, `mouse__add` the real answer if this session has it.

## Doc updates

- `skills/mouse.md`: new trigger-table row + Asking-section bullet for the per-ask mark-no-match rule. Frames why we don't mark positive.
- `utils/mouse/OVERVIEW.md`: Operations table gains `bad` + `log` rows; `query_log` schema documented.

## Tests

`utils/mouse/tests/test_index.das`: **40/40 pass** (was 34/34). Six new tests:
- `test_log_query_returns_increasing_ids`
- `test_mark_no_match_sets_useful_zero` (+ verifies starts NULL on insert)
- `test_mark_no_match_nonexistent_id_returns_zero`
- `test_mark_no_match_idempotent`
- `test_recent_queries_filters_bad`
- `test_recent_queries_review_excludes_misses` (Review needs `match_count > 0`)

`utils/mouse/tests/test_store.das`: 32/32 still pass (untouched).

## End-to-end smoke (manual)

```
$ mouse ask "how do I foo"      → query_id: 1, returns matching card
$ mouse ask "zzqxxgibberish"    → query_id: 2, MISS
$ mouse log                     → both rows shown with [id N]
$ mouse bad 1                   → marked id=1 as no-match
$ mouse log --bad               → id=1 with [BAD] tag
$ mouse log --review            → empty (id=1 marked, id=2 is a miss)
$ mouse bad 99999               → exit=2, "no query_log row with id=99999"
$ mouse bad notanint            → exit=1, "not a valid query-id (invalid_argument)"
$ mouse bad                     → exit=1, "missing query-id"
```

JSON-RPC `tools/list` returns 6 tools: `mouse__ask`, `mouse__add`, `mouse__get`, `mouse__rebuild`, `mouse__bad`, `mouse__log`.

## Opportunistic lint cleanups

Two trivial upstream fixes triggered by lint walking generic instantiations from my new test:
- `daslib/linq.das:847` `take`: ternary → `min(total, length(arr))` [PERF015]
- `modules/dasSQLITE/daslib/sqlite_linq.das:38` `_first_opt`: `length(arr) > 0` → `!empty(arr)` [PERF017]

Both are semantically equivalent. Mouse files all PASS lint after.

**Note for reviewer:** `modules/dasSQLITE/daslib/sqlite_linq.das` has **41 other pre-existing lint warnings** (PERF013 / PERF017 / STYLE015 / STYLE016) scattered through 4800+ lines. Deliberately left for a separate focused cleanup PR — folding them into this feature PR would balloon scope.

## Out of scope

- No retrieval-ranking change. `useful=false` data is observational; whether to demote bad-marked cards in BM25 ranking is a future decision once we have signal volume.
- No top-level `CLAUDE.md` change. The "MOUSE FIRST" rule already covers the why; operational detail belongs in `skills/mouse.md`.
- No `install/` change. `skills/mouse.md` is already shipped (commit `457ab9b4e`); the additions update existing shipped content.
- No CMake change. Migration auto-runs at first ask via the existing `migrate_to_latest` path on every machine's local `index.db`.

## Test plan

- [x] `mcp__daslang__run_test utils/mouse/tests/test_index.das` → 40/40 pass
- [x] `mcp__daslang__run_test utils/mouse/tests/test_store.das` → 32/32 pass
- [x] `mcp__daslang__lint` clean on all `utils/mouse/*.das` + the two upstream lib fixes
- [x] `mcp__daslang__format_file` reports already-formatted on all touched .das files
- [x] CLI smoke: ask → log → bad → log --bad/--review with happy + error paths (exit codes verified)
- [x] MCP `tools/list` returns the two new tools
- [ ] CI green on all platforms (this PR triggers full daslang test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)