### PR TITLE
lint: fix LINT001 false-positive, improve auto-fixer, finish daslib sweep (408 → 0)

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -168,7 +168,7 @@ def isConstRedundantForCpp(typeDecl : TypeDeclPtr) {
         if (Type.tBitfield) { return true; }
         if (Type.tBitfield8) { return true; }
         if (Type.tBitfield16) { return true; }
-        if (Type.tBitfield64) { return true; }
+        if (Type.tBitfield64) { return true; }  // nolint:STYLE017 (match arm chain)
         if (_) { return false; }
     }
 }
@@ -397,7 +397,7 @@ def describeCppTypeEx(typeDecl : TypeDeclPtr;
             if (typeDecl.firstType != null) {
                 type_name = describeCppTypeEx(typeDecl.firstType, DescribeConfig(redundant_const = true, cross_platform = cfg.cross_platform), useAlias)
             }
-            let extra_comma = length(typeDecl.argTypes) != 0 ? "," : "";
+            let extra_comma = !empty(typeDecl.argTypes) ? "," : "";
             let arg_types = (each(typeDecl.argTypes)
                 ._select(describeCppTypeEx(_, DescribeConfig(redundant_const = true, cross_platform = cfg.cross_platform), useAlias))
                 .to_array()
@@ -692,8 +692,7 @@ class public AotDebugInfoHelper {
                 if (si.fields == null) return ;
                 for (fi in range(si.count)) {
                     let fld & = unsafe(si.fields[fi])
-                    if (fld.annotation_arguments == null) continue;
-                    if (length(*fld.annotation_arguments) == 0) continue;
+                    if (fld.annotation_arguments == null || empty(*fld.annotation_arguments)) continue;
                     write(writer, "    {structInfoName(si)}_field_{fi}.annotation_arguments = &{structInfoName(si)}_field_{fi}_ann;\n")
                 }
             })
@@ -731,7 +730,7 @@ class public AotDebugInfoHelper {
             writeDim(writer, fld, suffix);
             writeArgTypes(writer, fld, suffix);
             writeArgNames(writer, fld, suffix);
-            let prefix = (info.module_name |> length() > 0) ? "{info.module_name}::" : "";
+            let prefix = (info.module_name |> !empty(info.module_name)) ? "{info.module_name}::" : "";
             write(*writer, "VarInfo {structInfoName(info)}_field_{fi} =  \{ {describeCppVarInfo(prefix + info.name, fld,suffix)} \};\n");
             if (fld.annotation_arguments != null) {
                 if (length(*fld.annotation_arguments) > 0) {
@@ -996,7 +995,7 @@ class public BlockVariableCollector : AstVisitor {
     def getFinalBlock() {
         for (i in range(length(stack))) {
             let blk = stack[length(stack) - i - 1];
-            if (length(blk.finalList) != 0) return blk;
+            if (!empty(blk.finalList)) return blk;
             if (blk.blockFlags.isClosure) return null;
         }
         return null;
@@ -1730,10 +1729,10 @@ class public CppAot : AstVisitor {
                 that.right._type.baseType == Type.tBool && that.right._type.isSimpleType);
     }
     def isOpPolicy2(that : ExprOp2?) {
-        if (is_alpha(first_character(that.op))) return true;
-        if (that.op == "/" || that.op == "%") return true;
-        if (that.op == "<<<" || that.op == ">>>" || that.op == "<<<=" || that.op == ">>>=") return true;
-        if (that.op == "<<" || that.op == ">>" || that.op == "<<=" || that.op == ">>=") return true;
+        if (is_alpha(first_character(that.op))
+                || that.op == "/" || that.op == "%"
+                || that.op == "<<<" || that.op == ">>>" || that.op == "<<<=" || that.op == ">>>="
+                || that.op == "<<" || that.op == ">>" || that.op == "<<=" || that.op == ">>=") return true;
         return that._type.isPolicyType || that.left._type.isPolicyType || that.right._type.isPolicyType;
     }
     def opPolicyBase(that : ExprOp2?) {
@@ -3259,7 +3258,7 @@ class public CppAot : AstVisitor {
         }
     }
     def override canVisitExprLooksLikeCallArgument(call : ExprLooksLikeCall?; arg : ExpressionPtr; last : bool) {
-        if (length(call.arguments) >= 1 && call.arguments[0] == arg &&  call is ExprInvoke) {
+        if (!empty(call.arguments) && call.arguments[0] == arg &&  call is ExprInvoke) {
             let inv = call as ExprInvoke;
             if (inv.isInvokeMethod) return false;
         }
@@ -3319,24 +3318,17 @@ class public CppAot : AstVisitor {
         if (!polType.isHandle) {
             if (polType.isVecPolicyType && argType.isVecPolicyType) return false;
         }
-        if (!polType.isPolicyType) return false;
-        return true;
+        return polType.isPolicyType;
     }
     def policyResultNeedCast(polType : TypeDeclPtr; resType : TypeDeclPtr) {
-        if (resType.isVoid) return false;
-        if (!resType.isPolicyType) return false;
+        if (resType.isVoid || !resType.isPolicyType) return false;
         return policyArgNeedCast(polType, resType);
     }
     def isPolicyBasedCall(call : ExprCall?) {
         let bif = call.func as BuiltInFunction;
-        if (call.arguments |> empty() && call.func.result.baseType == Type.tHandle) {
-            // c-tor?
-            return false;
-        } elif (bif.flags.policyBased) {
-            return true;
-        } else {
-            return false;
-        }
+        // empty arg ctor returning handle is NOT policy-based
+        if (call.arguments |> empty() && call.func.result.baseType == Type.tHandle) return false;
+        return bif.flags.policyBased;
     }
     def isPolicyBasedCallFunc(call : ExprCallFunc?) {
         if (call.func.flags.builtIn) {
@@ -3354,12 +3346,10 @@ class public CppAot : AstVisitor {
             if (func.flags.callBased) {
                 panic("we should not be here. call-based calls handled elsewhere");
             }
-            return length(bif.cppName) == 0;
+            return empty(bif.cppName);
         }
-        if (func.flags.noAot) return true;
-        if (func.flags.aotHybrid) return true;
-        if (func._module == program.getThisModule) return false;
-        return true;
+        if (func.flags.noAot || func.flags.aotHybrid) return true;
+        return func._module != program.getThisModule;
     }
     def needsArgPassType(argType : TypeDeclPtr) {
         return !argType.flags.constant && !argType.isGoodBlockType;
@@ -3448,7 +3438,7 @@ class public CppAot : AstVisitor {
                 }
                 assume mangledName = call.func |> get_mangled_name();
                 let hash = call.func.getMangledNameHash;
-                if (length(call.arguments) >= 1) {
+                if (!empty(call.arguments)) {
                     write(*ss, "<");
                     for (arg in call.func.arguments) {
                         write(*ss, "{describeCppType(arg._type,DescribeConfig(cross_platform=cross_platform))}");
@@ -3816,8 +3806,8 @@ def collectUsedFunctions(modules : array<Module?>; totalFunctions : int; this_mo
     fnn.reserve(totalFunctions);
     for (pm in modules) {
         pm |> for_each_module_function($(pfun) {
-            if (!all_modules && pfun._module != this_module) return ;
-            if (pfun.index < 0 || !pfun.flags.used) return ;
+            if ((!all_modules && pfun._module != this_module)
+                    || pfun.index < 0 || !pfun.flags.used) return ;
             if (!is_all) {
                 if (pfun.flags.builtIn || pfun.flags.noAot) return ;
             }

--- a/daslib/aot_standalone.das
+++ b/daslib/aot_standalone.das
@@ -53,8 +53,7 @@ def writeStandaloneContextMethods(var prog : ProgramPtr; var logs : StringBuilde
     var coll = new BlockVariableCollector();
 
     for (fn in fnn) {
-        if (!fn.flags.exports) continue;
-        if (fn._module != prog.getThisModule) continue;
+        if (!fn.flags.exports || fn._module != prog.getThisModule) continue;
         if (declare_only) {
             write(logs, "    ");
         }
@@ -232,8 +231,8 @@ class StandaloneContextGen : CppAot {
         var globals : array<Variable?>;
         prog.get_ptr() |> for_each_module_no_order($(pm) {
             pm |> for_each_global($(pvar) {
-                if (pvar.index < 0 || !pvar.flags.used) return ;
-                if (pvar._module == prog.getThisModule) return ;
+                if (pvar.index < 0 || !pvar.flags.used
+                        || pvar._module == prog.getThisModule) return ;
                 globals.push(pvar);
             });
         });

--- a/daslib/apply.das
+++ b/daslib/apply.das
@@ -48,7 +48,7 @@ def for_each_subrange(total : int; blk : block<(r : range) : void>) {
 [macro_function]
 def generateApplyVisitStruct(stype : TypeDeclPtr; frange : range; fnname : string; at : LineInfo; var names : array<string>; hasExtraArg : bool) {
     assert(stype.baseType == Type.tStructure)
-    assert(stype.dim |> length == 0)
+    assert(empty(stype.dim))
     let nfields = frange.y - frange.x
     var selfT = clone_type(stype)
     selfT.flags |= TypeDeclFlags.isExplicit | TypeDeclFlags.explicitConst
@@ -124,7 +124,7 @@ def generateApplyVisitStruct(stype : TypeDeclPtr; fnname : string; at : LineInfo
 [macro_function]
 def generateApplyVisitTuple(stype : TypeDeclPtr; frange : range; fnname : string; at : LineInfo; var names : array<string>) {
     assert(stype.baseType == Type.tTuple)
-    assert(stype.dim |> length == 0)
+    assert(empty(stype.dim))
     let nfields = frange.y - frange.x
     var selfT = clone_type(stype)
     selfT.flags |= TypeDeclFlags.isExplicit | TypeDeclFlags.explicitConst
@@ -181,7 +181,7 @@ def generateApplyVisitTuple(stype : TypeDeclPtr; fnname : string; at : LineInfo)
 [macro_function]
 def generateApplyVisitVariant(stype : TypeDeclPtr; frange : range; fnname : string; at : LineInfo; var names : array<string>) {
     assert(stype.baseType == Type.tVariant)
-    assert(stype.dim |> length == 0)
+    assert(empty(stype.dim))
     let nfields = frange.y - frange.x
     var selfT = clone_type(stype)
     selfT.flags |= TypeDeclFlags.isExplicit | TypeDeclFlags.explicitConst
@@ -272,7 +272,7 @@ class ApplyMacro : AstCallMacro {
         macro_verify(expr.arguments |> length == 2, prog, expr.at, "expecting apply(value, block)")
         if (expr.arguments[0]._type != null) {// need value inferred
             var argT = clone_type(expr.arguments[0]._type)
-            macro_verify(argT.dim |> length == 0, prog, expr.at, "can't apply to dim")
+            macro_verify(empty(argT.dim), prog, expr.at, "can't apply to dim")
             macro_verify(argT.baseType == Type.tStructure || argT.baseType == Type.tTuple || argT.baseType == Type.tVariant,
                 prog, expr.at, "can only apply to {describe(expr.arguments[0]._type)}")
             macro_verify(expr.arguments[1] is ExprMakeBlock, prog, expr.at, "expecting make block, i.e. $(..)")

--- a/daslib/ast.das
+++ b/daslib/ast.das
@@ -974,7 +974,7 @@ def add_new_optimization_macro(name : string; var someClassPtr) {
 def find_module(prog : smart_ptr<Program>; name : string) : Module? {
     var rm : Module?
     program_for_each_module(prog) $(mod) {
-        if (string(mod.name) == name) {
+        if (mod.name == name) {
             rm = mod
         }
     }

--- a/daslib/ast_boost.das
+++ b/daslib/ast_boost.das
@@ -79,9 +79,7 @@ def describe_function_short(func : FunctionPtr) {
 
 def isExpression(t : TypeDeclPtr; top : bool = true) : bool {
     //! Returns true if the type declaration refers to an AST expression node type.
-    if (t == null) {
-        return false
-    } elif (t.dim |> length != 0) {
+    if (t == null || !empty(t.dim)) {
         return false
     } elif (t.baseType == Type.tHandle) {
         if (t.annotation._module.name == "ast_core") {
@@ -108,11 +106,11 @@ def is_same_or_inherited(parent, child : Structure const?) {
 
 def is_class_method(cinfo : StructurePtr; finfo : TypeDeclPtr) {
     //! Returns true if the function type declaration is a method of the given class structure.
-    if (finfo.baseType != Type.tFunction) return false
-    if (finfo.dim |> length != 0) return false
-    if (finfo.argTypes |> length == 0) return false
-    if (finfo.argTypes[0].baseType != Type.tStructure) return false
-    if (finfo.argTypes[0].dim |> length != 0) return false
+    if (finfo.baseType != Type.tFunction
+            || !empty(finfo.dim)
+            || empty(finfo.argTypes)
+            || finfo.argTypes[0].baseType != Type.tStructure
+            || !empty(finfo.argTypes[0].dim)) return false
     return !!is_same_or_inherited(finfo.argTypes[0].structType, cinfo)
 }
 
@@ -848,7 +846,7 @@ def private walk_and_convert_enumeration(data : uint8 const?; info : TypeDeclPtr
 def walk_and_convert(data : uint8 const?; info : TypeDeclPtr; at : LineInfo) : Expression? {
     //! Recursively converts raw data to an AST expression based on type information.
     // print("0x{intptr(data)} {describe(info)}\n")
-    if (info.dim |> length != 0) {
+    if (!empty(info.dim)) {
         return walk_and_convert_dim(data, info, at)
     } elif (info.baseType == Type.tArray) {
         return walk_and_convert_array(data, info, at)
@@ -1262,7 +1260,7 @@ def private debug_expression_impl(var writer : StringBuilderWriter; expr : Expre
             }
             if (tstr == "$::dasvector`ptr`Expression") {
                 let pv = unsafe(reinterpret<dasvector`ptr`Expression?> p8)
-                if (length(*pv) != 0) {
+                if (!empty(*pv)) {
                     let ts = repeat("  ", tabs + 2)
                     writer |> write("\n{ts}[{name}\n")
                     for (l, i in *pv, count()) {
@@ -1276,7 +1274,7 @@ def private debug_expression_impl(var writer : StringBuilderWriter; expr : Expre
                 }
             } elif (tstr == "$::dasvector`ptr`Variable") {
                 let pv = unsafe(reinterpret<dasvector`ptr`Variable?> p8)
-                if (length(*pv) != 0) {
+                if (!empty(*pv)) {
                     let ts = repeat("  ", tabs + 2)
                     writer |> write("\n{ts}[{name}\n")
                     for (l, i in *pv, count()) {

--- a/daslib/ast_debug.das
+++ b/daslib/ast_debug.das
@@ -25,17 +25,21 @@ def report_to_debugger(var ctx : Context; category, name : string; value : auto(
 def isExpressionType(_vinfo) {
     if (_vinfo.basicType != Type.tPointer || _vinfo.firstType == null) return false
     let vinfo = _vinfo.firstType
-    if (vinfo.basicType != Type.tHandle) return false
-    if (vinfo.annotation._module.name != "ast_core") return false
-    return !!string(vinfo.annotation.name) |> starts_with("Expr")
+    if (vinfo.basicType != Type.tHandle
+            || vinfo.annotation._module.name != "ast_core") return false
+    var result = false
+    peek(vinfo.annotation.name) $(n) {
+        result = n |> starts_with("Expr")
+    }
+    return result
 }
 
 def isModulePtrType(_vinfo; mod, what : string) {
     if (_vinfo.basicType != Type.tPointer || _vinfo.firstType == null) return false
     let vinfo = _vinfo.firstType
-    if (vinfo.basicType != Type.tHandle) return false
-    if (vinfo.annotation._module.name != mod) return false
-    return !(vinfo.annotation.name != what)
+    if (vinfo.basicType != Type.tHandle
+            || vinfo.annotation._module.name != mod) return false
+    return vinfo.annotation.name == what
 }
 
 def isAstPtrType(_vinfo; what : string) {
@@ -47,9 +51,9 @@ def isRttiPtrType(_vinfo; what : string) {
 }
 
 def isRttiType(vinfo; what : string) {
-    if (vinfo.basicType != Type.tHandle) return false
-    if (vinfo.annotation._module.name != "rtti_core") return false
-    return !(vinfo.annotation.name != what)
+    if (vinfo.basicType != Type.tHandle
+            || vinfo.annotation._module.name != "rtti_core") return false
+    return vinfo.annotation.name == what
 }
 
 def describe_arg(var ctxid : Context; vinfo; arg : void?) : void {

--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -400,16 +400,15 @@ def qm_convert_comprehension(var expr : Expression?) : Expression? {
     //! Returns null if the expression is not a generated comprehension.
     if (!(expr is ExprInvoke)) return null
     let inv = expr as ExprInvoke
-    if (length(inv.arguments) != 1) return null
-    // The argument should be ExprMakeBlock wrapping the closure
-    if (!(inv.arguments[0] is ExprMakeBlock)) return null
+    // single ExprMakeBlock argument wrapping the closure
+    if (length(inv.arguments) != 1 || !(inv.arguments[0] is ExprMakeBlock)) return null
     let mkblk = inv.arguments[0] as ExprMakeBlock
     let blk = mkblk._block as ExprBlock
-    if (blk == null || length(blk.list) != 3) return null
-    // stmt[0] = ExprLet with __acomp_ variable
-    // stmt[1] = ExprFor
-    // stmt[2] = ExprReturn with fromComprehension=true
-    if (!(blk.list[0] is ExprLet) || !(blk.list[1] is ExprFor) || !(blk.list[2] is ExprReturn)) return null
+    // body: ExprLet (__acomp_ var), ExprFor, ExprReturn (fromComprehension=true)
+    if (blk == null || length(blk.list) != 3
+            || !(blk.list[0] is ExprLet)
+            || !(blk.list[1] is ExprFor)
+            || !(blk.list[2] is ExprReturn)) return null
     let ret = blk.list[2] as ExprReturn
     if (!ret.returnFlags.fromComprehension) return null
     // Detect tableSyntax: return subexpr is to_table_move(...)
@@ -426,7 +425,7 @@ def qm_convert_comprehension(var expr : Expression?) : Expression? {
     // Extract subexpr and exprWhere from the for body
     let src_for = blk.list[1] as ExprFor
     let for_body = src_for.body as ExprBlock
-    if (for_body == null || length(for_body.list) == 0) return null
+    if (for_body == null || empty(for_body.list)) return null
     var comp_subexpr : Expression?
     var comp_where : Expression?
     if (for_body.list[0] is ExprIfThenElse) {
@@ -434,7 +433,7 @@ def qm_convert_comprehension(var expr : Expression?) : Expression? {
         let ite = for_body.list[0] as ExprIfThenElse
         comp_where = clone_expression(ite.cond)
         let then_blk = ite.if_true as ExprBlock
-        if (then_blk != null && length(then_blk.list) > 0 && then_blk.list[0] is ExprCall) {
+        if (then_blk != null && !empty(then_blk.list) && then_blk.list[0] is ExprCall) {
             let push_call = then_blk.list[0] as ExprCall
             if (length(push_call.arguments) >= 2) {
                 comp_subexpr = clone_expression(push_call.arguments[1])
@@ -520,14 +519,13 @@ def private qm_skip_field(rtti_name : string; field_name : string) : bool {
     //! Compiler-internal fields are populated during compilation but null/zero
     //! in raw patterns from qmacro/quote.
 
-    // Fields on all expressions (inherited from Expression base)
+    // Fields on all expressions: base-class fields + stack/annotation internals
     if (field_name == "_type" || field_name == "flags" || field_name == "genFlags"
-        || field_name == "printFlags" || field_name == "at") return true
-    // Stack/annotation internals
-    if (field_name == "stackTop" || field_name == "stackVarBottom" || field_name == "stackVarTop"
-        || field_name == "annotationDataSid" || field_name == "annotationData"
-        || field_name == "maxLabelIndex" || field_name == "refStackTop"
-        || field_name == "initStackSize" || field_name == "argStackTop") return true
+            || field_name == "printFlags" || field_name == "at"
+            || field_name == "stackTop" || field_name == "stackVarBottom" || field_name == "stackVarTop"
+            || field_name == "annotationDataSid" || field_name == "annotationData"
+            || field_name == "maxLabelIndex" || field_name == "refStackTop"
+            || field_name == "initStackSize" || field_name == "argStackTop") return true
     // ExprVar — resolved variable reference
     if (rtti_name == "ExprVar") {
         if (field_name == "variable" || field_name == "argumentIndex" || field_name == "pBlock"
@@ -551,8 +549,7 @@ def private qm_skip_field(rtti_name : string; field_name : string) : bool {
         || field_name == "doesNotNeedSp" || field_name == "cmresAlias"
         || field_name == "argumentsFailedToInfer") return true
     // ExprReturn
-    if (field_name == "returnInBlock") return true
-    return false
+    return field_name == "returnInBlock"
 }
 
 // ── TypeDecl matching code generation ────────────────────────────────────
@@ -809,7 +806,7 @@ def private get_wildcard_b_tag(pattern : Expression?) : string {
     //! If wildcard has a $b(var) argument, return the variable name. Otherwise "".
     if (!(pattern is ExprCall)) return ""
     let call = pattern as ExprCall
-    if (length(call.arguments) == 0) return ""
+    if (empty(call.arguments)) return ""
     let arg = call.arguments[0]
     if (arg is ExprTag) {
         let tag = arg as ExprTag
@@ -870,8 +867,8 @@ def private is_range_constructor(call_name : string) : bool {
 [macro_function]
 def private const_component_fields(folded_rtti : string) : array<string> {
     if (folded_rtti == "ExprConstRange" || folded_rtti == "ExprConstURange"
-        || folded_rtti == "ExprConstRange64" || folded_rtti == "ExprConstURange64") return <- array<string>("x", "y")
-    if (folded_rtti |> ends_with("2")) return <- array<string>("x", "y");
+            || folded_rtti == "ExprConstRange64" || folded_rtti == "ExprConstURange64"
+            || folded_rtti |> ends_with("2")) return <- array<string>("x", "y")
     if (folded_rtti |> ends_with("3")) return <- array<string>("x", "y", "z");
     if (folded_rtti |> ends_with("4")) return <- array<string>("x", "y", "z", "w");
     return <- array<string>()
@@ -1042,7 +1039,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
                         // Clone the wrapped expression so we don't modify the pattern AST
                         var wrapped_clone = clone_expression(tag.value)
                         var wrapped_clone_let = wrapped_clone as ExprLet
-                        if (length(wrapped_clone_let.variables) > 0) {
+                        if (!empty(wrapped_clone_let.variables)) {
                             wrapped_clone_let.variables[0].name := ""
                         }
                         // Generate ExprLet matching for the cloned expression
@@ -1299,12 +1296,12 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
         var ann = unsafe(reinterpret<BasicStructureAnnotation?> get_expression_annotation(pattern))
         if (ann != null) {
             for_each_field(*ann) $(name, cppName, xtype, offset) {
-                return if (offset == 0xFFFFFFFFu)
-                return if (qm_skip_field(rtti, name))
-                return if (name == "iteratorsTags")
-                return if (name == "iteratorsAt" || name == "iteratorVariables" || name == "iteratorsTupleExpansion" || name == "iteratorsAka")
-                return if (name == "visibility" || name == "allowIteratorOptimization" || name == "canShadow")
-                return if (length(xtype.dim) != 0)
+                return if (offset == 0xFFFFFFFFu
+                        || qm_skip_field(rtti, name)
+                        || name == "iteratorsTags"
+                        || name == "iteratorsAt" || name == "iteratorVariables" || name == "iteratorsTupleExpansion" || name == "iteratorsAka"
+                        || name == "visibility" || name == "allowIteratorOptimization" || name == "canShadow"
+                        || !empty(xtype.dim))
                 var p8 : int8?
                 unsafe {
                     p8 = (reinterpret<int8?> pattern) + int(offset)
@@ -1332,7 +1329,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
                             }
                         }
                     }
-                } elif (bt == Type.tPointer && xtype.firstType != null && xtype.firstType.annotation != null && string(xtype.firstType.annotation.name) == "Expression") {
+                } elif (bt == Type.tPointer && xtype.firstType != null && xtype.firstType.annotation != null && xtype.firstType.annotation.name == "Expression") {
                     let inner_ann_name = xtype.firstType != null && xtype.firstType.annotation != null ? string(xtype.firstType.annotation.name) : ""
                     if (inner_ann_name == "TypeDecl") {
                         // skip TypeDecl fields
@@ -1579,9 +1576,8 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
 
     // Field-by-field matching via annotation reflection
     for_each_field(*ann) $(name, cppName, xtype, offset) {
-        return if (offset == 0xFFFFFFFFu)
-        return if (qm_skip_field(rtti, name))
-        if (length(xtype.dim) != 0) {
+        return if (offset == 0xFFFFFFFFu || qm_skip_field(rtti, name))
+        if (!empty(xtype.dim)) {
             panic("qmatch: fixed-size array field '{name}' not supported")
         }
         var p8 : int8?
@@ -1784,7 +1780,7 @@ def private generate_block_match(var pat_block : ExprBlock?; actual_var : string
     // Check if pattern is a single fixed statement (possibly with wildcards).
     // If actual is not ExprBlock, try matching the single statement directly.
     // Skip this optimization if pattern has arguments or return type — those require a real block.
-    let has_pat_args = length(pat_block.arguments) > 0
+    let has_pat_args = !empty(pat_block.arguments)
     let has_pat_ret = pat_block.returnType != null && pat_block.returnType.baseType != Type.autoinfer && pat_block.returnType.baseType != Type.tVoid
     let n_fixed = count_fixed_stmts(pat_block)
     if (n_fixed == 1 && !has_pat_args && !has_pat_ret) {

--- a/daslib/ast_print.das
+++ b/daslib/ast_print.das
@@ -157,17 +157,17 @@ class PrintVisitor : AstVisitor {
         // let bfa : FunctionFlags = fun.flags & function_annotation_flags;
         // // todo: describe_bitfield not supported in aot yet
         // write(*writer, "{describe_bitfield(bfa,"\n")}");
-        if (fun.annotations |> length != 0) {
+        if (!empty(fun.annotations)) {
             write(*writer, "[{describe(fun.annotations)}]\n");
         }
         write(*writer, "def {fun.name}");
-        if (fun.arguments |> length != 0) {
+        if (!empty(fun.arguments)) {
             write(*writer, " ( ");
         }
     }
     def override preVisitFunctionBody(fun : FunctionPtr; expr : ExpressionPtr) {
         //! Prints the closing parenthesis of arguments and the return type.
-        if (fun.arguments |> length != 0) {
+        if (!empty(fun.arguments)) {
             write(*writer, " ) ");
         }
         if (fun.result != null && !fun.result.isVoid) {
@@ -208,7 +208,7 @@ class PrintVisitor : AstVisitor {
     def override preVisitExprBlock(blk : ExprBlock?) {
         //! Prints the opening of a block expression, including closure arguments.
         if (blk.blockFlags.isClosure) {
-            if (blk.returnType != null || blk.arguments |> length != 0) {
+            if (blk.returnType != null || !empty(blk.arguments)) {
                 write(*writer, "$(");
                 for (arg, argIndex in blk.arguments, range(blk.arguments |> length)) {
                     if (arg.annotation |> length != 0) {

--- a/daslib/async_boost.das
+++ b/daslib/async_boost.das
@@ -217,8 +217,9 @@ class CollectAndReplaceIteratorFields : AstVisitor {
 
 
     def override visitExprYield(var expr : ExprYield?) : ExpressionPtr {
-        if (voidRoutine) return <- expr
-        if (expr._type != null && expr._type |> is_same_type(retType, RefMatters.no, ConstMatters.no, TemporaryMatters.no)) return <- expr
+        if (voidRoutine
+                || (expr._type != null
+                    && expr._type |> is_same_type(retType, RefMatters.no, ConstMatters.no, TemporaryMatters.no))) return <- expr
         if (!retType.argTypes[0].canCopy) {
             var res = qmacro_expr(${ yield <- variant type<$t(retType)>(res <- $e(expr.subexpr)); })
             res |> force_at(expr.at)

--- a/daslib/bitfield_trait.das
+++ b/daslib/bitfield_trait.das
@@ -36,6 +36,7 @@ class EachBitfieldMacro : AstFunctionAnnotation {
         macro_verify(call.arguments[0]._type != null, compiling_program(), call.at, "expecting argument type")
         macro_verify(call.arguments[0]._type.isBitfield, compiling_program(), call.at, "expecting a bitfield type")
         var yields : array<ExpressionPtr>
+        yields |> reserve(length(call.arguments[0]._type.argNames))
         if (call.arguments[0]._type.baseType == Type.tBitfield8) {
             for (bit in iter_range(call.arguments[0]._type.argNames)) {
                 yields |> push(qmacro_expr(${ yield $v(bitfield8(1ul << uint64(bit))); }))

--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -1564,9 +1564,7 @@ def sort(var a : auto(TT)[] | #) {
 }
 
 def sort(var a : array<auto(TT)> | #) {
-    if (length(a) <= 1) {
-        return
-    }
+    if (length(a) <= 1) return
     static_if (typeinfo is_numeric_comparable(type<TT>)) {
         __builtin_array_lock(a)
         unsafe {
@@ -1697,18 +1695,14 @@ def lock_data(a : array<auto(TT)> ==const | #; blk : block<(p : TT const?#; s : 
 
 def find_index(arr : array<auto(TT)> | #; key : TT) {
     for (o, i in arr, range(length(arr))) {
-        if (o == key) {
-            return i
-        }
+        if (o == key) return i
     }
     return -1
 }
 
 def find_index(arr : auto(TT)[] | #; key : TT) {
     for (o, i in arr, range(length(arr))) {
-        if (o == key) {
-            return i
-        }
+        if (o == key) return i
     }
     return -1
 }
@@ -1724,9 +1718,7 @@ def find_index(var arr : iterator<auto(TT)>; key : TT -&) {
 
 def find_index_if(arr : array<auto(TT)> | #; blk : block<(key : TT) : bool>) {
     for (o, i in arr, range(length(arr))) {
-        if (invoke(blk, o)) {
-            return i
-        }
+        if (invoke(blk, o)) return i
     }
     return -1
 }
@@ -1742,9 +1734,7 @@ def find_index_if(arr : auto(TT)[] | #; blk : block<(key : TT) : bool>) {
 
 def find_index_if(var arr : iterator<auto(TT)>; blk : block<(key : TT -&) : bool>) {
     for (o, i in arr, count()) {
-        if (invoke(blk, o)) {
-            return i
-        }
+        if (invoke(blk, o)) return i
     }
     return -1
 }
@@ -1752,9 +1742,7 @@ def find_index_if(var arr : iterator<auto(TT)>; blk : block<(key : TT -&) : bool
 def has_value(a; key) {
     static_if (typeinfo is_iterable(a)) {
         for (t in a) {
-            if (t == key) {
-                return true
-            }
+            if (t == key) return true
         }
         return false
     } else {

--- a/daslib/clargs.das
+++ b/daslib/clargs.das
@@ -92,11 +92,11 @@ def clargs_flag_name(field_name : string) : string {
 def public find_bool_flag_raw_value(args : array<string>; flag_name : string) : Option<string> {
     let prefix = "{flag_name}="
     var result = none(type<string>)
-    for (i in range(length(args))) {
-        if (args[i] == flag_name) {
+    for (a in args) {
+        if (a == flag_name) {
             result = some("true")
-        } elif (starts_with(args[i], prefix)) {
-            result = some(slice(args[i], length(prefix)))
+        } elif (starts_with(a, prefix)) {
+            result = some(slice(a, length(prefix)))
         }
     }
     return result
@@ -122,8 +122,7 @@ def public find_flag_raw_value(args : array<string>; flag_name : string) : Optio
 def public flag_present(args : array<string>; flag_name : string) : bool {
     let prefix = "{flag_name}="
     for (a in args) {
-        if (a == flag_name) return true
-        if (starts_with(a, prefix)) return true
+        if (a == flag_name || starts_with(a, prefix)) return true
     }
     return false
 }
@@ -379,8 +378,8 @@ def public count_flag_value_violation(args : array<string>; arg_info : CommandAr
     let long_prefix = "{arg_info.flag_name}="
     let short_prefix = has_short ? "{arg_info.short_flag_name}=" : ""
     for (a in args) {
-        if (starts_with(a, long_prefix)) return "{arg_info.flag_name}: count flag does not accept a value"
-        if (has_short && starts_with(a, short_prefix)) return "{arg_info.flag_name}: count flag does not accept a value"
+        if (starts_with(a, long_prefix)
+                || (has_short && starts_with(a, short_prefix))) return "{arg_info.flag_name}: count flag does not accept a value"
     }
     return ""
 }
@@ -390,8 +389,7 @@ def public count_flag_value_violation(args : array<string>; arg_info : CommandAr
 def public find_mutex_violation(args : array<string>; info : CommandInfo) : string {
     var groups : table<string; array<string>>
     for (a in info.args) {
-        if (empty(a.mutex_group)) continue
-        if (!flag_present(args, a)) continue
+        if (empty(a.mutex_group) || !flag_present(args, a)) continue
         if (!key_exists(groups, a.mutex_group)) {
             groups[a.mutex_group] <- [a.flag_name]
         } else {
@@ -455,8 +453,8 @@ def public format_help_with_auto_help(info : CommandInfo; prog_name : string) : 
 // Bool flags omit the =PLACEHOLDER. Enum flag docs include `(V1|V2|...)`.
 
 def value_placeholder(arg : CommandArgumentInfo) : string {
-    if (arg.is_positional || arg.is_count) return ""
-    if (arg.value_type == Type.tBool && !arg.is_array) return ""
+    if (arg.is_positional || arg.is_count
+            || (arg.value_type == Type.tBool && !arg.is_array)) return ""
     if (arg.value_type == Type.tInt) return "=INT"
     if (arg.value_type == Type.tFloat) return "=FLOAT"
     if (arg.value_type == Type.tEnumeration) return "=ENUM"
@@ -464,10 +462,8 @@ def value_placeholder(arg : CommandArgumentInfo) : string {
 }
 
 def render_flag_spec(arg : CommandArgumentInfo) : string {
-    if (arg.is_positional) {
-        // arg.flag_name is already wrapped as "<name>" by collect_command_info.
-        return arg.flag_name
-    }
+    // For positionals, flag_name is already wrapped as "<name>" by collect_command_info.
+    if (arg.is_positional) return arg.flag_name
     var spec = ""
     if (!empty(arg.short_flag_name)) {
         spec = "{arg.short_flag_name}, "
@@ -615,9 +611,9 @@ def public print_help(info : CommandInfo; prog_name : string) : void {
 
 def option_inner_type(t : TypeDeclPtr) : TypeDeclPtr {
     if (t.baseType == Type.typeMacro) {
-        if (length(t.dimExpr) < 2 || t.dimExpr[0] == null || !(t.dimExpr[0] is ExprConstString)) return null
-        if ((t.dimExpr[0] as ExprConstString).value != "Option") return null
-        if (t.dimExpr[1] == null || !(t.dimExpr[1] is ExprTypeDecl)) return null
+        if (length(t.dimExpr) < 2 || t.dimExpr[0] == null || !(t.dimExpr[0] is ExprConstString)
+                || (t.dimExpr[0] as ExprConstString).value != "Option"
+                || t.dimExpr[1] == null || !(t.dimExpr[1] is ExprTypeDecl)) return null
         return clone_type((t.dimExpr[1] as ExprTypeDecl).typeexpr)
     }
     if (t.baseType != Type.tStructure || t.structType == null) return null

--- a/daslib/contracts.das
+++ b/daslib/contracts.das
@@ -72,7 +72,7 @@ class IsAnyArrayMacro : IsAnyType {
         for (fna, typ in func.arguments, types) {// note: N^2
             for (argv in decl.arguments) {
                 if (fna.name == argv.name) {
-                    if (!(typ.baseType == Type.tArray || length(typ.dim) != 0 || isYetAnotherVectorTemplate(typ))) {
+                    if (!(typ.baseType == Type.tArray || !empty(typ.dim) || isYetAnotherVectorTemplate(typ))) {
                         errors := "argument {argv.name} is not a vector, array, or [], it is {describe(typ)}"
                         return false
                     }
@@ -90,7 +90,7 @@ class IsAnyEnumMacro : IsAnyType {
         for (fna, typ in func.arguments, types) {// note: N^2
             for (argv in decl.arguments) {
                 if (fna.name == argv.name) {
-                    if (length(typ.dim) != 0 || (typ.baseType != Type.tEnumeration && typ.baseType != Type.tEnumeration8 && typ.baseType != Type.tEnumeration16 && typ.baseType != Type.tEnumeration64)) {
+                    if (!empty(typ.dim) || (typ.baseType != Type.tEnumeration && typ.baseType != Type.tEnumeration8 && typ.baseType != Type.tEnumeration16 && typ.baseType != Type.tEnumeration64)) {
                         errors := "argument {argv.name} is not an enumeration"
                         return false
                     }
@@ -127,7 +127,7 @@ class IsAnyVectorType : IsAnyType {
         for (fna, typ in func.arguments, types) {// note: N^2
             for (argv in decl.arguments) {
                 if (fna.name == argv.name) {
-                    if (length(typ.dim) != 0 || !isVectorType(typ.baseType)) {
+                    if (!empty(typ.dim) || !isVectorType(typ.baseType)) {
                         errors := "argument {argv.name} is not a vector type (int2, float3, range, etc)"
                         return false
                     }

--- a/daslib/coroutines.das
+++ b/daslib/coroutines.das
@@ -67,7 +67,7 @@ class private CoContinue : AstCallMacro {
     //! That way co_continue() does not distract from the fact that it is a generator<bool>.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         //! Visits the co_continue macro call and rewrites it to ``yield true``.
-        macro_verify(call.arguments |> length == 0, prog, call.at, "expecting co_continue()")
+        macro_verify(empty(call.arguments), prog, call.at, "expecting co_continue()")
         if (!verify_inside_coroutine(prog, call)) return null
         return qmacro_expr() {
             yield true

--- a/daslib/coverage.das
+++ b/daslib/coverage.das
@@ -277,8 +277,8 @@ class CoverageMacro : AstVisitor {
     def override preVisitFunction(var fun : FunctionPtr) {
         //! Stores a pointer to the current function being visited and records function info for coverage.
         func = fun
-        if (fun.flags.generated || fun.flags.init || fun.flags.builtIn) return
-        if (fun.at.fileInfo == null) return
+        if (fun.flags.generated || fun.flags.init || fun.flags.builtIn
+                || fun.at.fileInfo == null) return
         let file = resolve_file_path(string(fun.at.fileInfo.name))
         let fname = string(fun.name)
         let line = fun.at.line
@@ -302,9 +302,8 @@ class CoverageMacro : AstVisitor {
 
     def override preVisitFunctionBody(fun : FunctionPtr; expr : ExpressionPtr) {
         //! Inserts function coverage call at the start of each function body.
-        if (fun.flags.generated || fun.flags.init || fun.flags.builtIn) return
-        if (fun.at.fileInfo == null) return
-        if (!(expr is ExprBlock)) return
+        if (fun.flags.generated || fun.flags.init || fun.flags.builtIn
+                || fun.at.fileInfo == null || !(expr is ExprBlock)) return
         let file = resolve_file_path(string(fun.at.fileInfo.name))
         let fname = string(fun.name)
         var blk = unsafe(reinterpret<ExprBlock?> expr)
@@ -314,8 +313,8 @@ class CoverageMacro : AstVisitor {
         }
         blk.list |> clear()
         blk.list |> emplace_new <| qmacro(_::add_func_coverage($v(file), $v(fname)))
-        for (el in range(prev |> length)) {
-            blk.list |> emplace <| prev[el]
+        for (el in prev) {
+            blk.list |> emplace <| el
         }
         astChanged = true
         func.not_inferred()
@@ -353,8 +352,8 @@ class CoverageMacro : AstVisitor {
             }
             true_blk.list |> clear()
             true_blk.list |> emplace_new <| qmacro(_::add_branch_coverage($v(file), $v(true_idx)))
-            for (el in range(prevTrue |> length)) {
-                true_blk.list |> emplace <| prevTrue[el]
+            for (el in prevTrue) {
+                true_blk.list |> emplace <| el
             }
         }
         // instrument false branch
@@ -366,8 +365,8 @@ class CoverageMacro : AstVisitor {
             }
             false_blk.list |> clear()
             false_blk.list |> emplace_new <| qmacro(_::add_branch_coverage($v(file), $v(false_idx)))
-            for (el in range(prevFalse |> length)) {
-                false_blk.list |> emplace <| prevFalse[el]
+            for (el in prevFalse) {
+                false_blk.list |> emplace <| el
             }
         } elif (ifte.if_false == null) {
             // no else branch — create one with just the branch coverage call
@@ -390,16 +389,16 @@ class CoverageMacro : AstVisitor {
             prev.emplace(ex)
         }
         blk.list |> clear()
-        for (el in range(prev |> length)) {
+        for (el in prev) {
             // Todo: add linter phase to check fileInfo is never null.
-            if (prev[el].at.fileInfo != null) {
-                let file = resolve_file_path(string(prev[el].at.fileInfo.name))
+            if (el.at.fileInfo != null) {
+                let file = resolve_file_path(string(el.at.fileInfo.name))
                 if (file |> ends_with("coverage.das")) {
-                    blk.list |> emplace <| prev[el]
+                    blk.list |> emplace <| el
                     continue
                 }
                 let fname = string(func.name)
-                let line = prev[el].at.line
+                let line = el.at.line
                 coverageData |> get_with_default(file) $(var data) {
                     data.line_cov.insert(line)
                 }
@@ -409,7 +408,7 @@ class CoverageMacro : AstVisitor {
                     }
                 }
                 blk.list |> emplace_new <| qmacro(_::add_line_coverage($v(file), $v(fname), $v(line)))
-                blk.list |> emplace <| prev[el]
+                blk.list |> emplace <| el
             }
         }
         return <- blk

--- a/daslib/cpp_gen.das
+++ b/daslib/cpp_gen.das
@@ -207,7 +207,7 @@ def with_array(var jso; field; blk : block<(var val : array<JsonValue?>) : void>
 
 def is_valid_loc(var loc) {
     //! Checks if a source location is valid (non-empty).
-    return !(loc |> length == 0)
+    return !empty(loc)
 }
 
 def onInner(var root) {
@@ -222,10 +222,8 @@ def onInner(var root) {
                     skip = !loc |> is_valid_loc
                 }
             }
-            if (skip) {
-                if (verbose) {
-                    print("// skipping {decl["name"] as _string}\n")
-                }
+            if (skip) {  // nolint:STYLE005 (const-folded verbose-print leaves single continue)
+                print("// skipping {decl["name"] as _string}\n") if (verbose)
                 continue
             }
             let kind = decl["kind"] as _string
@@ -260,8 +258,7 @@ def onInner(var root) {
 [sideeffects] // TODO: fixme. find why we need to specify [sideeffects] here
 def onLinkageSpec(var root) {
     //! Processes an extern linkage specification node.
-    if (!allow_extern_c) return
-    if (!root |> key_exists("inner")) return
+    if (!allow_extern_c || !root |> key_exists("inner")) return
     if (verbose) {
         if (root |> key_exists("language")) {
             print("extern \"{root["language"] as _string}\"\n")
@@ -678,8 +675,7 @@ def needToGenStruct(st) {
 
 def needToGenField(fld) {
     //! Determines if a struct field should be included in binding generation.
-    if (empty(fld.name)) return false
-    if (fld.access != AccessKind.Public) return false
+    if (empty(fld.name) || fld.access != AccessKind.Public) return false
     return !fld.qtype |> isBlockedType
 }
 
@@ -704,9 +700,10 @@ def genStructs(hf, mf, df : FILE const?) {
     }
     fprint(mf, "\n")
     for (st in values(ast.structs)) {
-        if (!needToGenStruct(st)) continue
-        if (alias_types |> key_exists(st.cppName)) {
-            /*
+        // alias_types branch is documented-but-unused; the legacy alias-factory
+        // emission lives in the dead-code block below for future reference.
+        if (!needToGenStruct(st) || alias_types |> key_exists(st.cppName)) continue
+        /*  legacy alias-factory emission — left as a recipe; revisit if alias annotations ever come back
             let alias_value = alias_types[st.cppName]
             fprint(mf,"template <> struct typeFactory<{st.cppName}> \{\n")
             fprint(mf,"\tstatic TypeDeclPtr make(const ModuleLibrary &) \{\n")
@@ -718,9 +715,7 @@ def genStructs(hf, mf, df : FILE const?) {
             fprint(mf,"\};\n")
             fprint(mf,"template <> struct typeName<{st.cppName}> \{ constexpr static const char * name() \{ return \"{st.name}\"; \} \};\n")
             fprint(df,"addAlias(typeFactory<{st.cppName}>::make(lib));\n")
-            */
-            continue
-        }
+         */
         fprint(df, "#ifdef {getDefinePrefix(st.cppName)}\n")
         fprint(df, "auto ann_{st.name} = make_smart<{st.name}_GeneratedAnnotation>(lib);\n")
         fprint(df, "addAnnotation(ann_{st.name});\n")
@@ -736,10 +731,7 @@ def genStructs(hf, mf, df : FILE const?) {
         fprint(mf, "\t\}\n")
         fprint(mf, "\tvoid init () \{\n")
         for (fld in st.fields) {
-            if (!needToGenField(fld)) continue
-            if (fld.isBitfield) {// TODO: support bitfields
-                continue
-            }
+            if (!needToGenField(fld) || fld.isBitfield) continue  // TODO: support bitfields
             var substType = ""
             substitute_field_types |> get("{st.cppName}::{fld.cppName}") $(val) {
                 substType = val
@@ -755,8 +747,7 @@ def genStructs(hf, mf, df : FILE const?) {
         fprint(mf, "#endif\n")
     }
     for (st in values(ast.structs)) {
-        if (!needToGenStruct(st)) continue
-        if (alias_types |> key_exists(st.cppName)) continue
+        if (!needToGenStruct(st) || alias_types |> key_exists(st.cppName)) continue
         fprint(df, "#ifdef {getDefinePrefix(st.cppName)}\n")
         fprint(df, "initRecAnnotation(ann_{st.name},lib);\n")
         fprint(df, "#endif\n")

--- a/daslib/das_source_formatter.das
+++ b/daslib/das_source_formatter.das
@@ -544,10 +544,11 @@ def search_token_in_line(var ctx : FormatterCtx; from_index : int; str : string 
     var pc : ParenCounter
     for (j in range(from_index, length(ctx.tokens))) {
         ctx |> update_paren(j, pc)
-        if (j > from_index && ctx |> new_line_before(j) &&
-                (pc.paren <= 0 || pc.square <= 0 || pc.curly <= 0) && !eq(ctx, j - 1, ",")) break
-        if (pc.paren < 0 || pc.square < 0 || pc.curly < 0) break
-        if (ctx |> eq(j, ";") && pc.paren == 0 && pc.square == 0 && pc.curly == 0) break
+        if ((j > from_index && ctx |> new_line_before(j)
+                    && (pc.paren <= 0 || pc.square <= 0 || pc.curly <= 0)
+                    && !eq(ctx, j - 1, ","))
+                || (pc.paren < 0 || pc.square < 0 || pc.curly < 0)
+                || (ctx |> eq(j, ";") && pc.paren == 0 && pc.square == 0 && pc.curly == 0)) break
         if (ctx |> eq(j, str)) return j
     }
     return 0
@@ -635,8 +636,8 @@ def mark_token_context(var ctx : FormatterCtx) {
                 ctx.tokens[j].isInType = true;
             }
             for (j in range(endParams + 1, length(ctx.tokens))) {
-                if (!(ctx |> eq(j, "-", "#", "&", "?") || ctx |> eq(j, "==", "const", "implicit"))) break;
-                if (ctx |> new_line_before(j)) break;
+                if (!(ctx |> eq(j, "-", "#", "&", "?") || ctx |> eq(j, "==", "const", "implicit"))
+                        || (ctx |> new_line_before(j))) break;
                 ctx.tokens[j].isInType = true;
             }
         }
@@ -668,8 +669,7 @@ def mark_token_context(var ctx : FormatterCtx) {
             let ident = ctx.tokens[i].spaces
             for (j in range(i + skip, length(ctx.tokens) - 3)) {
                 if (ctx |> new_line_before(j)) {
-                    if (ctx |> eq(j, "def")) break
-                    if (ctx.tokens[j].spaces <= ident) break
+                    if (ctx |> eq(j, "def") || ctx.tokens[j].spaces <= ident) break
                     let colonPos = ctx |> search_token_in_line(j, ctx |> eq(i, "typedef") ? "=" : ":")
                     if (colonPos > 0) {
                         ctx |> mark_tokens_as_type(colonPos + 1)
@@ -866,9 +866,9 @@ def generate_source(ctx : FormatterCtx) : string {
 
 def need_spaces_around(ctx : FormatterCtx; index : int) : bool {
     assume t = ctx.tokens[index]
-    if (t.tokenType != TokenType.UNKNOWN || t.dontFormat || t.dontAddSpacesAround) return false
-    if (dont_need_space_around |> find_index(t.str) >= 0) return false
-    if (t.isInType && (t.str == ":" || t.str == "<" || t.str == ">" || t.str == ">>" || t.str == ">>>" || empty(t.str))) return false
+    if (t.tokenType != TokenType.UNKNOWN || t.dontFormat || t.dontAddSpacesAround
+            || dont_need_space_around |> find_index(t.str) >= 0
+            || (t.isInType && (t.str == ":" || t.str == "<" || t.str == ">" || t.str == ">>" || t.str == ">>>" || empty(t.str)))) return false
     if (index < length(ctx.tokens) - 1) {
         assume next = ctx.tokens[index + 1]
         if (t.str == "@" && next.tokenType == TokenType.KEYWORD_OR_IDENTIFIER) return false
@@ -879,10 +879,10 @@ def need_spaces_around(ctx : FormatterCtx; index : int) : bool {
 
 def need_space_only_before(ctx : FormatterCtx; index : int) : bool {
     assume t = ctx.tokens[index]
-    if (!t.isInType) return false
-    if (t.tokenType != TokenType.UNKNOWN || t.dontFormat || t.dontAddSpacesAround) return false
-    if (dont_need_space_around |> find_index(t.str) >= 0) return false
-    if (t.str == ">" || t.str == ">>" || t.str == ">>>" || t.str == "<" || empty(t.str)) return false
+    if (!t.isInType
+            || t.tokenType != TokenType.UNKNOWN || t.dontFormat || t.dontAddSpacesAround
+            || dont_need_space_around |> find_index(t.str) >= 0
+            || t.str == ">" || t.str == ">>" || t.str == ">>>" || t.str == "<" || empty(t.str)) return false
     if (index < length(ctx.tokens) - 1) {
         assume next = ctx.tokens[index + 1]
         if (next.str == ">" || next.str == ">>" || next.str == ">>>" || next.str == ";") return true
@@ -908,9 +908,8 @@ let tokens_before_unary <- fixed_array("(", "[", "?[", "\{", "auto", "int", "flo
     );
 
 def is_unary(ctx : FormatterCtx; index : int) : bool {
-    if (ctx |> eq(index, "!") || ctx |> eq(index, "~")) return true
-
-    if (ctx |> eq(index, "*") && index > 0 && ctx.tokens[index - 1].isInType) return true
+    if (ctx |> eq(index, "!") || ctx |> eq(index, "~")
+            || (ctx |> eq(index, "*") && index > 0 && ctx.tokens[index - 1].isInType)) return true
 
     if (ctx |> eq(index, "+") || ctx |> eq(index, "-") || ctx |> eq(index, "*")) {
         var i = index

--- a/daslib/debug.das
+++ b/daslib/debug.das
@@ -1144,9 +1144,8 @@ class private DAgent : DapiDebugAgent {
 
     def onPause(var ctx : Context; at : LineInfo; reason, text : string) : void {
         //! Main pause handler that stops execution, sends a stopped event, and waits for DAP client commands.
-        if (at.fileInfo == null) return
-        if (server == null) return
-        if (!waitConnection && (!server.configurationDone || !server.threadsDone)) return
+        if (at.fileInfo == null || server == null
+                || (!waitConnection && (!server.configurationDone || !server.threadsDone))) return
         let path = "{at.fileInfo.name}" |> resolve_path_cache(workingPaths, pathAliases, pathsCache)
         self->log("{ctx} `{reason}` breakpoint at {path}:{int(at.line)}\n")
 
@@ -1165,8 +1164,7 @@ class private DAgent : DapiDebugAgent {
 
     def override onSingleStep(var ctx : Context; at : LineInfo) : void {
         //! Handles single-step events, processing pause, step-in, step-over requests, and breakpoint checks.
-        if (at.fileInfo == null) return
-        if (server == null) return
+        if (at.fileInfo == null || server == null) return
 
         // unsafe
             // self->log("{double(ctx_at(ctx))} step at {string(at.fileInfo.name) |> resolve_path_cache(workingPaths, pathAliases, pathsCache)}:{int(at.line)}\n")
@@ -1371,9 +1369,9 @@ class private DAgent : DapiDebugAgent {
 
     def invalidateBreakpoints(var ctx : Context) : void {
         //! Re-instruments breakpoints for a context after code changes, updating their verification state.
-        if (!withInstruments) return
-        if (server == null || !server.configurationDone) return
-        if (ctx.category.debug_context || ctx.category.debugger_tick) return
+        if (!withInstruments
+                || server == null || !server.configurationDone
+                || ctx.category.debug_context || ctx.category.debugger_tick) return
 
         for (brs in values(breakpoints)) {
             for (br in brs) {
@@ -1604,8 +1602,7 @@ class private DAServer : Server {
             if (toRead == 0) {
                 push(current_string, uch)
                 let prefix = "Content-Length: "
-                if (length(current_string) <= length(prefix)) continue
-                if (ch != '\n') continue
+                if (length(current_string) <= length(prefix) || ch != '\n') continue
                 let str = string(current_string)
                 if (str |> starts_with(prefix)) {
                     unsafe {

--- a/daslib/debug_eval.das
+++ b/daslib/debug_eval.das
@@ -256,9 +256,7 @@ def expr_value(var st : TokenStream) : Result {
             if (token(st) ?as punkt ?? 0 != ')') return st |> error("expecting )")
             return <- res
         }
-        if (Token(punkt = $v(any))) {
-            return st |> error("unexpected character {to_char(any)}, expecting number or (")
-        }
+        if (Token(punkt = $v(any))) return st |> error("unexpected character {to_char(any)}, expecting number or (")  // nolint:STYLE005 (qmatch macro expansion)
     }
     return st |> error("unexpected token {token}, expecting number or (")
 }
@@ -450,9 +448,7 @@ def expr_unary(var st : TokenStream) : Result {
         if (Token(punkt = '~')) {
             return Result(~st |> getI(expr_unary(st)))
         }
-        if (Token(punkt = '!')) {
-            return Result(st |> getI(expr_unary(st)) == 0l)
-        }
+        if (Token(punkt = '!')) return Result(st |> getI(expr_unary(st)) == 0l)  // nolint:STYLE005 (qmatch macro expansion)
     }
     unput(st, token)
     return expr_at(st)

--- a/daslib/decs.das
+++ b/daslib/decs.das
@@ -1049,8 +1049,7 @@ def public commit {
 def public is_alive(eid : EntityId) : bool {
     //! Returns true if the entity is alive (exists and has not been deleted).
     //! An entity is alive when its id is within bounds and its generation matches the lookup table.
-    if (eid == INVALID_ENTITY_ID) return false
-    if (int(eid.id) >= length(decsState.entityLookup)) return false
+    if (eid == INVALID_ENTITY_ID || int(eid.id) >= length(decsState.entityLookup)) return false
     return decsState.entityLookup[eid.id].generation == eid.generation
 }
 

--- a/daslib/decs_boost.das
+++ b/daslib/decs_boost.das
@@ -57,7 +57,7 @@ class DecsTemplate : AstStructureAnnotation {
     //!   * ``apply_decs_template_arch(arch, eidx, eid, src)`` — writes directly into archetype storage
     //!   * ``create_entities`T(count, blk)`` — bulk creation with direct archetype writes
     def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
-        if (length(st.fields) == 0) {
+        if (empty(st.fields)) {
             errors := "expecting at least one field in the desc_template {st.name}"
             return false
         }
@@ -393,7 +393,7 @@ class DecsQueryMacro : AstCallMacro {
         macro_verify(expr.arguments[block_arg_index] is ExprMakeBlock, compiling_program(), expr.at, "expecting $(block_with_arguments)")
         let mblk = expr.arguments[block_arg_index] as ExprMakeBlock
         let qblk = mblk._block as ExprBlock
-        macro_verify(length(qblk.arguments) != 0, compiling_program(), expr.at, "expecting query($(block_with_arguments)), arguments are missing")
+        macro_verify(!empty(qblk.arguments), compiling_program(), expr.at, "expecting query($(block_with_arguments)), arguments are missing")
         let prefix = "__{expr.at.line}_desc"
         let arch_name = "{prefix}_arch"
         var req <- build_req_from_args(qblk)
@@ -507,7 +507,7 @@ class DecsQueryMacro : AstCallMacro {
             rules |> replaceVariable("tag_loop") <| add_ptr_ref(qtop)
         }
         var qres = move_unquote_block(qblock)
-        assert(length(qres.list) == 1 && length(qres.finalList) == 0)
+        assert(length(qres.list) == 1 && empty(qres.finalList))
         var rqres = qres.list[0]
         qres := null
         rqres.genFlags.alwaysSafe = true
@@ -563,7 +563,7 @@ class DecsEcsMacro : AstFunctionAnnotation {
         let passName = argPass as tString
         let passFuncName = "decs`pass`{passName}"
         var blk <- setup_call_list(passFuncName, func.at, false, true)
-        if (length(blk.list) == 0) {
+        if (empty(blk.list)) {
             var reg <- setup_call_list("register`decs`passes", func.at, true, true)
             reg.list |> push(qmacro(decs::register_decs_stage_call($v(passName), @@$c(passFuncName))))
         }
@@ -653,7 +653,7 @@ class FromDecsMacro : AstCallMacro {
         macro_verify(expr.arguments[0] is ExprMakeBlock, prog, expr.at, "expecting from_decs($(block_with_arguments))")
         let mblk = expr.arguments[0] as ExprMakeBlock
         let qblk = mblk._block as ExprBlock
-        macro_verify(length(qblk.arguments) != 0, prog, expr.at, "expecting from_decs($(block_with_arguments)), arguments are missing")
+        macro_verify(!empty(qblk.arguments), prog, expr.at, "expecting from_decs($(block_with_arguments)), arguments are missing")
         for (arg in qblk.arguments) {
             macro_verify(!arg._type.isAutoOrAlias, prog, expr.at, "argument types are not fully inferred")
         }

--- a/daslib/defer.das
+++ b/daslib/defer.das
@@ -45,7 +45,7 @@ class DeferMacro : AstFunctionAnnotation {
             if (!valid) {
                 compiling_program() |> macro_error(call.at, "can't get valid program context")
                 success = false
-            } elif (astc.scopes |> length == 0) {
+            } elif (empty(astc.scopes)) {
                 compiling_program() |> macro_error(call.at, "defer needs to be in the scope")
                 success = false
             } else {
@@ -78,7 +78,7 @@ class DeferDeleteMacro : AstCallMacro {
             if (!valid) {
                 compiling_program() |> macro_error(call.at, "can't get valid program context")
                 success = false
-            } elif (astc.scopes |> length == 0) {
+            } elif (empty(astc.scopes)) {
                 compiling_program() |> macro_error(call.at, "defer_delete needs to be in the scope")
                 success = false
             } else {

--- a/daslib/delegate.das
+++ b/daslib/delegate.das
@@ -242,6 +242,7 @@ def public delegate(macroArgument, passArgument : TypeDeclPtr; FuncType : TypeDe
     var invokeArgs : array<VariablePtr>
     // forward expressions (ExprVar for each arg name)
     var fwdExprs : array<ExpressionPtr>
+    fwdExprs |> reserve(nArgs)
     for (idx in range(nArgs)) {
         let argName = get_arg_name(FuncType, idx)
         invokeArgs |> emplace_new <| new Variable(at = macroArgument.at, name := argName,
@@ -252,6 +253,7 @@ def public delegate(macroArgument, passArgument : TypeDeclPtr; FuncType : TypeDe
     // lambda args for wrapper (separate copies)
     var lambdaArgs : array<VariablePtr>
     var lambdaFwd  : array<ExpressionPtr>
+    lambdaFwd |> reserve(nArgs)
     for (idx in range(nArgs)) {
         let argName = get_arg_name(FuncType, idx)
         lambdaArgs |> emplace_new <| new Variable(at = macroArgument.at, name := argName,

--- a/daslib/fio.das
+++ b/daslib/fio.das
@@ -7,6 +7,7 @@ module fio shared
 
 require fio_core public
 require strings
+require math
 
 typedef file = FILE const?
 
@@ -70,8 +71,7 @@ def fload(file : file; size : int; blk : block<(data : array<uint8>) : void>) : 
 def fload(f : file; buf : auto(BufType) -const) {
     var dfh : df_header
     let r1 = _builtin_read(f, dfh, typeinfo sizeof(type<df_header>))
-    if (r1 < 0) return false
-    if (dfh.magic != df_magic) return false
+    if (r1 < 0 || dfh.magic != df_magic) return false
     var loaded = false
     _builtin_load(f, dfh.size) $(data : array<uint8>) {
         if (length(data) != 0) {
@@ -227,8 +227,7 @@ def private _match_glob_bytes(p : array<uint8> const#; var pi : int; s : array<u
                 return false
             }
         } elif (pc == uint8('?')) {
-            return false if (si >= slen)
-            return false if (s[si] == uint8('/'))
+            return false if (si >= slen || s[si] == uint8('/'))
             pi++
             si++
         } elif (pc == uint8('[')) {
@@ -248,8 +247,7 @@ def private _match_glob_bytes(p : array<uint8> const#; var pi : int; s : array<u
             }
             if (scan >= plen) {
                 // No closing `]` — treat the `[` as a literal character.
-                return false if (si >= slen)
-                return false if (s[si] != pc)
+                return false if (si >= slen || s[si] != pc)
                 pi++
                 si++
             } else {
@@ -294,8 +292,7 @@ def private _match_glob_bytes(p : array<uint8> const#; var pi : int; s : array<u
                 si++
             }
         } else {
-            return false if (si >= slen)
-            return false if (s[si] != pc)
+            return false if (si >= slen || s[si] != pc)
             pi++
             si++
         }
@@ -312,10 +309,8 @@ def match_glob(pattern : string; path : string) : bool {
     let slen = length(path)
     return true if (plen == 0 && slen == 0)
     return false if (plen == 0)
-    if (slen == 0) {
-        // Empty path matches a pattern only when every char is `*` (any number of stars or **).
-        return empty(replace(pattern, "*", ""))
-    }
+    // Empty path matches a pattern only when every char is `*` (any number of stars or **).
+    if (slen == 0) return empty(replace(pattern, "*", ""))
     var result = false
     peek_data(pattern) $(parr) {
         peek_data(path) $(sarr) {
@@ -450,7 +445,7 @@ def private _split_literal_prefix(pattern : string) : tuple<string; string> {
     let prefix = slice(pattern, 0, scan_end)
     let sep_fwd = rfind(prefix, "/")
     let sep_back = rfind(prefix, "\\")
-    let sep = sep_fwd >= sep_back ? sep_fwd : sep_back
+    let sep = max(sep_fwd, sep_back)
     if (sep < 0) return "." => pattern
     let raw_dir = slice(pattern, 0, sep)
     let raw_sep = slice(pattern, sep, sep + 1)

--- a/daslib/flat_hash_table.das
+++ b/daslib/flat_hash_table.das
@@ -137,12 +137,9 @@ struct template TFlatHashTable {
         while (true) {
             let h = hashes[index]
             if (h == hash) {
-                if (key_data[index] == key) {   // otherwise skip matching hash collision
-                    return index
-                }
-            } elif (h == 0ul) {               // empty, key not found
-                break
-            }
+                // otherwise skip matching hash collision
+                if (key_data[index] == key) return index
+            } elif (h == 0ul) break  // empty, key not found
             // skip hash collision or tombstone(1)
             index = (index + 1) & mask
         }

--- a/daslib/fts5_query.das
+++ b/daslib/fts5_query.das
@@ -328,8 +328,7 @@ def private _parse_and_expr(var st : ParseState) : int {
     var left = _parse_unary(st)
     if (left == -1 || !empty(st.err)) return left
     while (true) {
-        if (_at_expr_terminator(st)) break
-        if (_peek_keyword(st, "OR") || _peek_keyword(st, "NOT")) break
+        if (_at_expr_terminator(st) || _peek_keyword(st, "OR") || _peek_keyword(st, "NOT")) break
         let had_explicit_and = _peek_keyword(st, "AND")
         if (had_explicit_and) {
             _consume_keyword(st, "AND")
@@ -345,8 +344,7 @@ def private _parse_and_expr(var st : ParseState) : int {
 
 def private _parse_not_expr(var st : ParseState) : int {
     let left = _parse_and_expr(st)
-    if (left == -1 || !empty(st.err)) return left
-    if (!_peek_keyword(st, "NOT")) return left
+    if (left == -1 || !empty(st.err) || !_peek_keyword(st, "NOT")) return left
     _consume_keyword(st, "NOT")
     _skip_ws(st)
     let right = _parse_and_expr(st)

--- a/daslib/heartbeat.das
+++ b/daslib/heartbeat.das
@@ -42,8 +42,8 @@ class AddHeartbeat : AstVisitor {
     astChanged : bool = false
     @do_not_delete func : Function?
     def heartbeatBlock(var body : ExprBlock?) {
-        if (length(body.list) == 0) return
-        if ((body.list[0] is ExprCall) && (body.list[0] as ExprCall).name == "heartbeat") return
+        if (empty(body.list)
+                || ((body.list[0] is ExprCall) && (body.list[0] as ExprCall).name == "heartbeat")) return
         var expr = qmacro(heartbeat())
         body.list |> emplace(expr, 0)
         astChanged = true

--- a/daslib/interfaces.das
+++ b/daslib/interfaces.das
@@ -282,16 +282,16 @@ class ImplementsMacro : AstStructureAnnotation {
         let missing = build_string() $(var w) {
             for (ifld in iface.fields) {
                 let ifld_name = string(ifld.name)
-                // Skip compiler-generated fields
-                if (ifld_name == "__rtti" || ifld_name == "__finalize") continue
-                if (!ifld._type.isFunction) continue
-                // Methods with a default implementation (init != null) are optional
-                if (ifld.init != null) continue
+                // Skip compiler-generated fields, non-function fields, and
+                // methods with a default implementation (init != null).
+                if (ifld_name == "__rtti" || ifld_name == "__finalize"
+                        || !ifld._type.isFunction
+                        || ifld.init != null) continue
                 // Abstract method — struct must provide {iface_name}`{method_name}
                 let expected = "{iface_name}`{ifld_name}"
                 var found = false
                 for (sfld in st.fields) {
-                    if (string(sfld.name) == expected) {
+                    if (sfld.name == expected) {
                         found = true
                         break
                     }
@@ -317,11 +317,10 @@ def private is_const_interface(st : Structure?) : bool {
     if (st == null) return false
     for (fld in st.fields) {
         let fn = string(fld.name)
-        if (fn == "__rtti" || fn == "__finalize") continue
-        if (!fld._type.isFunction) continue
-        // Check if the first arg (self) is const.
-        // argTypes[0] is self for class methods.
-        if (length(fld._type.argTypes) == 0) continue
+        // argTypes[0] is self for class methods; check that it's const.
+        if (fn == "__rtti" || fn == "__finalize"
+                || !fld._type.isFunction
+                || empty(fld._type.argTypes)) continue
         if (!fld._type.argTypes[0].isConst) return false
     }
     return true
@@ -401,11 +400,9 @@ class InterfaceAsIs : AstVariantMacro {
         let getter_field = "get`{iname}"
         var st = vtype.firstType.structType
         for (fld in st.fields) {
-            if (fld.name == getter_field) {
-                // ── Code generation ──
-                // Replace `expr is IFoo` with the literal `true`.
-                return <- quote(true)
-            }
+            // ── Code generation ──
+            // Replace `expr is IFoo` with the literal `true`.
+            if (fld.name == getter_field) return <- quote(true)
         }
         // The struct is valid but doesn't implement this interface → false.
         return <- quote(false)

--- a/daslib/is_local.das
+++ b/daslib/is_local.das
@@ -24,7 +24,7 @@ def is_temp_safe(expr : ExpressionPtr) : bool {
         return (expr as ExprVar).varFlags.local // local variables are ok
     } elif (expr is ExprAt) {
         let ea = expr as ExprAt
-        if (ea.subexpr._type != null && ea.subexpr._type.dim |> length != 0) return is_temp_safe(ea.subexpr)
+        if (ea.subexpr._type != null && !empty(ea.subexpr._type.dim)) return is_temp_safe(ea.subexpr)
     } elif (expr is ExprField) {
         let ef = expr as ExprField
         if (!(ef.value._type.baseType == Type.tHandle) || (ef.value._type.isLocal)) return is_temp_safe(ef.value)
@@ -68,7 +68,7 @@ def is_local_expr(expr : ExpressionPtr) {
         return (expr as ExprVar).varFlags.local
     } elif (expr is ExprAt) {
         let ea = expr as ExprAt
-        if (ea.subexpr._type != null && ea.subexpr._type.dim |> length != 0) return is_local_expr(ea.subexpr)
+        if (ea.subexpr._type != null && !empty(ea.subexpr._type.dim)) return is_local_expr(ea.subexpr)
     } elif (expr is ExprField) {
         let ef = expr as ExprField
         if (!(ef.value._type.baseType == Type.tHandle) || (ef.value._type.isLocal)) return is_local_expr(ef.value)
@@ -83,7 +83,7 @@ def is_local_or_global_expr(expr : ExpressionPtr) {
         return ev.varFlags.local || !(ev.varFlags.argument || ev.varFlags._block)
     } elif (expr is ExprAt) {
         let ea = expr as ExprAt
-        if (ea.subexpr._type != null && ea.subexpr._type.dim |> length != 0) return is_local_or_global_expr(ea.subexpr)
+        if (ea.subexpr._type != null && !empty(ea.subexpr._type.dim)) return is_local_or_global_expr(ea.subexpr)
     } elif (expr is ExprField) {
         let ef = expr as ExprField
         if (!(ef.value._type.baseType == Type.tHandle) || (ef.value._type.isLocal)) return is_local_or_global_expr(ef.value)
@@ -100,7 +100,7 @@ def is_scope_expr(expr : ExpressionPtr) {
         return true
     } elif (expr is ExprAt) {
         let ea = expr as ExprAt
-        if (ea.subexpr._type != null && ea.subexpr._type.dim |> length != 0) return is_scope_expr(ea.subexpr)
+        if (ea.subexpr._type != null && !empty(ea.subexpr._type.dim)) return is_scope_expr(ea.subexpr)
     } elif (expr is ExprField) {
         let ef = expr as ExprField
         if (!(ef.value._type.baseType == Type.tHandle) || (ef.value._type.isLocal)) return is_scope_expr(ef.value)

--- a/daslib/jobque_boost.das
+++ b/daslib/jobque_boost.das
@@ -16,6 +16,7 @@ module jobque_boost shared public
 //! Extends the built-in ``jobque`` module.
 
 require jobque public
+require math
 
 require daslib/rtti
 require daslib/ast
@@ -534,7 +535,7 @@ def _parallel_for(range_begin, range_end : int; num_jobs : int; blk : block<(job
     //! Requires ``with_job_que`` context.
     let total = range_end - range_begin
     if (total <= 0 || num_jobs <= 0) return
-    let actual_jobs = num_jobs < total ? num_jobs : total
+    let actual_jobs = min(num_jobs, total)
     let chunk = total / actual_jobs
     let remainder = total % actual_jobs
     with_wait_group(actual_jobs) $(wg) {
@@ -681,12 +682,11 @@ def public release_capture_jobque_stream(s : Stream?) {
 
 [macro_function]
 def private isPtrToJQ(typ : TypeDeclPtr; jqt : string) : bool {
-    if (!typ.isPointer) return false
-    if (typ.firstType == null) return false
-    if (!typ.firstType.isHandle) return false
-    if (typ.firstType.annotation._module.name != "jobque") return false
-    if (typ.firstType.annotation.name != jqt) return false
-    return true
+    if (!typ.isPointer
+            || typ.firstType == null
+            || !typ.firstType.isHandle
+            || typ.firstType.annotation._module.name != "jobque") return false
+    return typ.firstType.annotation.name == jqt
 }
 
 [capture_macro(name=channel_and_status_capture_macro)]
@@ -727,9 +727,8 @@ class private ChannelAndStatusCapture : AstCaptureMacro {
         //! iteration, not just once at destruction. This means ``Channel``, ``JobStatus``,
         //! ``LockBox``, and ``Stream`` captures inside generators do NOT get automatic release checks.
         //! Users must manually call ``release`` on captured jobque objects inside generators.
-        if (fun.flags._generator) {// generator gets finally section called every single time. nothing we can do
-            return
-        }
+        // generator gets finally section called every single time. nothing we can do
+        if (fun.flags._generator) return
         for (fld in lcs.fields) {
             if (fld._type |> isPtrToJQ("Channel")) {
                 var pCall = make_release_call(fld, "jobque_boost::release_capture_jobque_channel")

--- a/daslib/json.das
+++ b/daslib/json.das
@@ -538,7 +538,7 @@ def private write_value(var writer : StringBuilderWriter; jsv : JsonValue?; dept
     } elif (jsv.value is _longint) {
         write(writer, jsv.value as _longint)
     } elif (jsv.value is _array) {
-        if (length(jsv.value as _array) == 0) {
+        if (empty(jsv.value as _array)) {
             write(writer, "[]")
         } else {
             write(writer, "[\n")
@@ -557,17 +557,13 @@ def private write_value(var writer : StringBuilderWriter; jsv : JsonValue?; dept
             write(writer, "]")
         }
     } elif (jsv.value is _object) {
-        if (length(jsv.value as _object) == 0) {
+        if (empty(jsv.value as _object)) {
             write(writer, "\{\}")
         } else {
             write(writer, "\{\n")
             var first = true
             for (elemK, elemV in keys(jsv.value as _object), values(jsv.value as _object)) {
-                if (no_empty_arrays) {
-                    if (elemV.value is _array) {
-                        if (length(elemV.value as _array) == 0) continue
-                    }
-                }
+                if (no_empty_arrays && elemV.value is _array && empty(elemV.value as _array)) continue
                 if (first) {
                     first = false
                 } else {
@@ -644,9 +640,7 @@ def try_fixing_broken_json(var bad : string) {
                     writer |> write_char(int(str[i]));
                     i ++;
                 }
-                if (i >= lstr) {// if eof we done
-                    break;
-                }
+                if (i >= lstr) break  // eof — done
                 // write the first quote
                 writer |> write_char('"')
                 i ++

--- a/daslib/linq_boost.das
+++ b/daslib/linq_boost.das
@@ -725,9 +725,8 @@ class private LinqUnionByToArray : AstCallMacro_LinqPredII2 {
 def private is_call_or_generic(var expr : Expression?, name, moduleName : string) : ExprCall? {
     if (expr is ExprCall) {
         var call = expr as ExprCall
-        if (call.func.name == name && call.func._module.name == moduleName) {
-            return call
-        } elif (call.func.fromGeneric != null && call.func.fromGeneric.name == name && call.func.fromGeneric._module.name == moduleName) return call
+        if ((call.func.name == name && call.func._module.name == moduleName)
+                || (call.func.fromGeneric != null && call.func.fromGeneric.name == name && call.func.fromGeneric._module.name == moduleName)) return call
     }
     return null
 }
@@ -1121,7 +1120,7 @@ def private fold_linq_default(var expr : Expression?) : Expression? {
     //!   if expr is not linq call, return null
     var blk = new ExprBlock(at = expr.at)
     var (top, calls) = flatten_linq(expr)
-    if (calls |> length == 0) return null
+    if (empty(calls)) return null
     var topExpr = clone_expression(top)
     var topExprType = clone_type(top._type)
     var topValue = qmacro(source)

--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -25,6 +25,17 @@ class LintEverything : AstPassMacro {
     }
 }
 
+def private is_block_terminator(expr : ExpressionPtr) : bool {
+    // A direct-child block statement that always exits the enclosing function.
+    if (expr is ExprReturn) return true
+    if (expr is ExprCall) {
+        let call = expr as ExprCall
+        if (call.func == null) return false
+        return call.name |> eq <| "panic" && call.func._module.name |> eq <| "builtin"
+    }
+    return false
+}
+
 class LintVisitor : AstVisitor {
     //! AST visitor that performs lint checks.
     //!
@@ -64,8 +75,7 @@ class LintVisitor : AstVisitor {
         return found
     }
     def lint_error(text : string; at : LineInfo) : void {
-        if (noLint) return
-        if (self->is_suppressed(text, at)) return
+        if (noLint || self->is_suppressed(text, at)) return
         if (compile_time_errors) {
             compiling_program() |> macro_error(at, text)
         } elif (collect_errors) {
@@ -107,12 +117,19 @@ class LintVisitor : AstVisitor {
         return <- blk
     }
     def override visitExprBlockExpression(blk : ExprBlock?; var expr : ExpressionPtr) : ExpressionPtr {
+        // Flag if a prior direct-child of THIS block already terminated control flow.
         let lb = exprForTerminator |> back()
         if (lb != 0ul) {
-            let eb = intptr(expr)
-            if (lb != eb) {
-                self->lint_error("LINT001: unreachable code", expr.at)
-            }
+            self->lint_error("LINT001: unreachable code", expr.at)
+        }
+        // Mark this block as terminated only when `expr` IS a direct-child terminator.
+        // Tracking from preVisitExprReturn/preVisitExprCall(panic) was incorrect: it
+        // fired for returns nested in braceless `if/elif <terminator>` whose then-body
+        // is an ExprReturn directly under ExprIf (no synthetic block), poisoning the
+        // ENCLOSING block's slot.
+        if (is_block_terminator(expr)) {
+            exprForTerminator |> pop()
+            exprForTerminator |> push(intptr(expr))
         }
         return <- expr
     }
@@ -122,28 +139,13 @@ class LintVisitor : AstVisitor {
         }
         exprForTerminator |> push(0ul)
     }
-    def override preVisitExprReturn(expr : ExprReturn?) : void {
-        if (!empty(exprForTerminator)) {
-            exprForTerminator |> pop()
-        }
-        exprForTerminator |> push(intptr(expr))
-    }
-    def override preVisitExprCall(expr : ExprCall?) : void {
-        if (expr.func == null) return
-        if (expr.name |> eq <| "panic" && expr.func._module.name |> eq <| "builtin") {
-            if (!empty(exprForTerminator)) {
-                exprForTerminator |> pop()
-            }
-            exprForTerminator |> push(intptr(expr))
-        }
-    }
     // --- LINT005: redundant reinterpret cast ---
 
     def override preVisitExprCast(expr : ExprCast?) : void {
-        if (noLint || genericDepth > 0) return
-        if (!expr.castFlags.reinterpretCast) return
-        if (expr.subexpr == null || expr.subexpr._type == null || expr.castType == null) return
-        if (expr.castType.isVoidPointer != expr.subexpr._type.isVoidPointer) return
+        if (noLint || genericDepth > 0
+            || !expr.castFlags.reinterpretCast
+            || expr.subexpr == null || expr.subexpr._type == null || expr.castType == null
+            || expr.castType.isVoidPointer != expr.subexpr._type.isVoidPointer) return
         if (is_same_type(expr.castType, expr.subexpr._type, false, true, true, false)) {
             self->lint_error("LINT005: redundant reinterpret cast; target type is the same as source type", expr.at)
         }
@@ -157,16 +159,10 @@ class LintVisitor : AstVisitor {
     def validate_var(v : VariablePtr; can_make_const : bool) {
         if (v.flags.generated) return
         let name = string(v.name)
-        if (name |> starts_with("__")) {// system variables
-            return
-        }
-        if (find(name, "`") >= 0) {// compiler-generated internal name (e.g. tuple destructuring)
-            return
-        }
+        // skip system vars (`__name`) and compiler-generated names (backtick-mangled, e.g. tuple destructuring)
+        if (name |> starts_with("__") || find(name, "`") >= 0) return
         if (name |> starts_with("_")) {
-            if (name |> ends_with("_")) {// _foo_ - ignore too
-                return
-            }
+            if (name |> ends_with("_")) return  // _foo_ - ignore too
             if (v.access_flags.access_ref || v.access_flags.access_pass || v.access_flags.access_get || v.access_flags.access_fold) {
                 self->lint_error("LINT004: variable '{v.name}' is used and should be named without underscore prefix", v.at)
                 return
@@ -225,8 +221,8 @@ class LintVisitor : AstVisitor {
     }
 
     def expr_equal(a : ExpressionPtr; b : ExpressionPtr; require_pure : bool = true) : bool {
-        if (a == null || b == null) return false
-        if (require_pure && (!a.flags.noSideEffects || !b.flags.noSideEffects)) return false
+        if (a == null || b == null
+            || (require_pure && (!a.flags.noSideEffects || !b.flags.noSideEffects))) return false
         // daslang AST nodes are not shared — each Expression has exactly one parent, so
         // pointer-equality between sibling operands (left vs right) is effectively never
         // true. Structural compare via describe() is the only correct option here.

--- a/daslib/lpipe.das
+++ b/daslib/lpipe.das
@@ -49,9 +49,7 @@ def lpipe_expr(var fnCall : ExpressionPtr&; var arg : ExpressionPtr&) : Expressi
         return cLet
     } elif (fnCall |> is_expr_like_call()) {
         var pCall = unsafe(reinterpret<ExprLooksLikeCall?> fnCall)
-        if (pCall.name == "lpipe") {// not piping pipe into pipe
-            return null
-        }
+        if (pCall.name == "lpipe") return null  // not piping pipe into pipe
         pCall.arguments |> emplace(arg)
         return fnCall
     } else {
@@ -81,7 +79,7 @@ class LpipeMacro : AstCallMacro {
                 macro_error(prog, call.at, "can't get valid program context")
                 return
             }
-            if (astc.scopes |> length <= 0) {
+            if (empty(astc.scopes)) {
                 macro_error(prog, call.at, "missing scope")
                 return
             }

--- a/daslib/macro_boost.das
+++ b/daslib/macro_boost.das
@@ -94,7 +94,7 @@ class ColletFinally : AstVisitor {
     alwaysFor : bool
     def override preVisitExprBlock(blk : ExprBlock?) : void {
         unsafe {
-            if (length(blk.finalList) > 0) {
+            if (!empty(blk.finalList)) {
                 blocks |> insert(reinterpret<ExprBlock?> blk)
             } elif (alwaysFor && blk.blockFlags.forLoop) {
                 blocks |> insert(reinterpret<ExprBlock?> blk)

--- a/daslib/match.das
+++ b/daslib/match.das
@@ -207,9 +207,7 @@ def match_tuple(what : TypeDeclPtr; wths : ExprMakeTuple?; access : Expression?;
     }
     log_m("\tuple match passed\n")
     for (i in range(wthsLength)) {
-        if (i == tagIndex) {// skip ...
-            continue
-        }
+        if (i == tagIndex) continue  // skip ...
         let ei = i <= tagIndex ? i : whatDim - (wthsLength - i)
         {// to create scope for defer delete
             var new_access = qmacro($e(access).$f("_{ei}")); new_access |> force_at(wths.at)
@@ -307,6 +305,7 @@ def match_variant(what : TypeDeclPtr; wths : ExprMakeVariant?; access : Expressi
         to.errors |> match_error("{describe(what)} number of variant elements does not match [[describe(wths.makeType)}[{wthsLength}] ... ]]", wths.at)
         return false
     }
+    to.conditions |> reserve(length(to.conditions) + wthsLength)
     for (mf, i in wths.variants, count()) {
         {// to create scope for defer delete
             var new_access = whatDim == 1 ? qmacro($e(access) as $f(mf.name)) : qmacro($e(access)[$v(i)] as $f(mf.name))
@@ -585,7 +584,7 @@ def join_conditions(var conditions : array<Expression?>; at : LineInfo) : Expres
     if (clen == 0) return new ExprConstBool(value = true, at = at)
     var tail = conditions |> back()
     conditions |> pop()
-    while (length(conditions) > 0) {
+    while (!empty(conditions)) {
         {
             var last = conditions |> back()
             conditions |> pop()
@@ -632,7 +631,7 @@ class MatchMacro : AstCallMacro {
         macro_verify(blk._type.isGoodBlockType, prog, expr.at, "match `block` argument did not resolve")
         macro_verify(blk is ExprMakeBlock, prog, expr.at, "match `block` argument must be immediate block declaration")
         var eblk = ((blk as ExprMakeBlock)._block as ExprBlock)
-        macro_verify(length(eblk.finalList) == 0, prog, expr.at, "match `block` argument can't have finally section")
+        macro_verify(empty(eblk.finalList), prog, expr.at, "match `block` argument can't have finally section")
         for (ee in eblk.list) {
             if (ee is ExprIfThenElse) {
                 let eite = ee as ExprIfThenElse

--- a/daslib/module_path.das
+++ b/daslib/module_path.das
@@ -63,7 +63,7 @@ class private GetThisModuleDirMacro : AstCallMacro {
     //! call site's source-file path as a string literal so the resolver
     //! can derive the modules-relative suffix at runtime.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
-        macro_verify(call.arguments |> length == 0, prog, call.at, "expecting get_this_module_dir()")
+        macro_verify(empty(call.arguments), prog, call.at, "expecting get_this_module_dir()")
         let baked = string(call.at.fileInfo.name)
         return qmacro(__builtin_resolve_this_module_dir($v(baked)))
     }

--- a/daslib/perf_lint.das
+++ b/daslib/perf_lint.das
@@ -120,14 +120,10 @@ class PerfLintVisitor : AstVisitor {
     }
 
     def is_suppressed(text : string; at : LineInfo) : bool {
-        if (at.fileInfo == null || at.line == 0u) {  //
-            return false
-        }
+        if (at.fileInfo == null || at.line == 0u) return false
         // extract PERFxxx code from warning text (e.g. "PERF003: ...")
         let colon = find(text, ":")
-        if (colon < 0) {  //
-            return false
-        }
+        if (colon < 0) return false
         let code = slice(text, 0, colon)
         var found = false
         get_file_source_line(at.fileInfo, at.line) $(line) {
@@ -143,18 +139,14 @@ class PerfLintVisitor : AstVisitor {
     def perf_warning(text : string; at : LineInfo) : void {
         // Suppress in templates and inside macro-generated functions —
         // the user didn't write that code.
-        if (in_template  //
+        if (in_template
             || (current_function != null && current_function.flags.generated)) return
         // Deduplicate warnings — same source location reported once, regardless of generic instantiations
         let key = self->location_key(at)
-        if (reported_locations |> has_value(key)) {  //
-            return
-        }
+        if (reported_locations |> has_value(key)) return
         reported_locations |> push(key)
         // Check inline suppression: // PERFxxx on the same line
-        if (self->is_suppressed(text, at)) {  //
-            return
-        }
+        if (self->is_suppressed(text, at)) return
         warning_count++
         var msg = text
         if (current_function != null && current_function.fromGeneric != null && !empty(current_function.inferStack)) {
@@ -178,25 +170,17 @@ class PerfLintVisitor : AstVisitor {
     // --- variable scope helpers ---
 
     def is_loop_variable(v : Variable?) : bool {
-        if (v == null) {  //
-            return false
-        }
+        if (v == null) return false
         for (entry in var_stack) {
-            if (entry.v == v && entry.is_iter) {  //
-                return true
-            }
+            if (entry.v == v && entry.is_iter) return true
         }
         return false
     }
 
     def is_defined_outside_loop(v : Variable?) : bool {
-        if (v == null || loop_depth == 0 || self->is_loop_variable(v)) {  //
-            return false
-        }
+        if (v == null || loop_depth == 0 || self->is_loop_variable(v)) return false
         for (entry in var_stack) {
-            if (entry.v == v) {  //
-                return entry.depth < loop_depth
-            }
+            if (entry.v == v) return entry.depth < loop_depth
         }
         // not on stack — function argument or global — outside any loop
         return true
@@ -207,9 +191,7 @@ class PerfLintVisitor : AstVisitor {
     def is_character_at_zero(expr : ExprCall?) : bool {
         if (length(expr.arguments) >= 2) {
             var idx = expr.arguments[1]
-            if (idx is ExprConstInt && (idx as ExprConstInt).value == 0) {  //
-                return true
-            }
+            if (idx is ExprConstInt && (idx as ExprConstInt).value == 0) return true
         }
         return false
     }
@@ -217,7 +199,7 @@ class PerfLintVisitor : AstVisitor {
     def is_array_func(expr : ExprCall?; fname : string) : bool {
         // Builtin generics (push, reserve, etc.) have fromGeneric set.
         // Verify first argument is an array type.
-        if (expr.func == null || expr.func.fromGeneric == null  //
+        if (expr.func == null || expr.func.fromGeneric == null
             || expr.func.fromGeneric.name != fname || empty(expr.arguments)) return false
         let arg = expr.arguments[0]
         return arg._type != null && arg._type.baseType == Type.tArray
@@ -233,9 +215,7 @@ class PerfLintVisitor : AstVisitor {
             return null if (evar.variable == null)
             return evar.variable
         }
-        if (expr is ExprRef2Value) {  //
-            return self->find_expr_path((expr as ExprRef2Value.subexpr), path)
-        }
+        if (expr is ExprRef2Value) return self->find_expr_path((expr as ExprRef2Value.subexpr), path)
         if (expr is ExprField) {
             var field = expr as ExprField
             path := ".{field.name}{path}"
@@ -290,9 +270,7 @@ class PerfLintVisitor : AstVisitor {
         return null if (inner == null || !(inner is ExprVar))
         var evar = inner as ExprVar
         return null if (evar.variable == null || evar.variable._type == null)
-        if (evar.variable._type.baseType == Type.tString) {  //
-            return evar.variable
-        }
+        if (evar.variable._type.baseType == Type.tString) return evar.variable
         return null
     }
 
@@ -309,13 +287,9 @@ class PerfLintVisitor : AstVisitor {
         var call = inner as ExprCall
         // After inference, string() calls may have FakeContext/FakeLineInfo extra args.
         // Check the function name and first argument type.
-        if (empty(call.arguments) || call.name != "string") {  //
-            return false
-        }
+        if (empty(call.arguments) || call.name != "string") return false
         var arg = call.arguments[0]
-        if (arg._type == null || arg._type.baseType != Type.tHandle) {  //
-            return false
-        }
+        if (arg._type == null || arg._type.baseType != Type.tHandle) return false
         return arg._type.annotation != null && arg._type.annotation.name == "das_string"
     }
 
@@ -323,17 +297,13 @@ class PerfLintVisitor : AstVisitor {
         //! Returns true if expr is a X call where X is a smart_ptr.
         return false if (expr == null || !(expr is ExprCall))
         var call = expr as ExprCall
-        if (call.func == null || call.func.fromGeneric == null) {  //
-            return false
-        }
+        if (call.func == null || call.func.fromGeneric == null) return false
         return call.func.fromGeneric.name == "get_ptr"
     }
 
     def is_get_ptr_vs_null(maybe_get_ptr : Expression?; maybe_null : Expression?) : bool {
         //! Returns true if maybe_get_ptr is get_ptr() and maybe_null is null.
-        if (!self->is_get_ptr_of_smart_ptr(maybe_get_ptr) || maybe_null == null) {  //
-            return false
-        }
+        if (!self->is_get_ptr_of_smart_ptr(maybe_get_ptr) || maybe_null == null) return false
         if (maybe_null is ExprConstPtr) {
             var cptr = maybe_null as ExprConstPtr
             return cptr.value == null
@@ -344,71 +314,33 @@ class PerfLintVisitor : AstVisitor {
     // --- generic constant / structural helpers (PERF013-017) ---
 
     def is_const_zero(expr : Expression? const) : bool {
-        if (expr == null) {  //
-            return false
-        }
-        if (expr is ExprConstInt) {  //
-            return (expr as ExprConstInt).value == 0
-        }
-        if (expr is ExprConstUInt) {  //
-            return (expr as ExprConstUInt).value == 0u
-        }
-        if (expr is ExprConstInt64) {  //
-            return (expr as ExprConstInt64).value == 0l
-        }
-        if (expr is ExprConstUInt64) {  //
-            return (expr as ExprConstUInt64).value == 0ul
-        }
-        if (expr is ExprConstFloat) {  //
-            return (expr as ExprConstFloat).value == 0.0f
-        }
-        if (expr is ExprConstDouble) {  //
-            return (expr as ExprConstDouble).value == 0.0lf
-        }
+        if (expr == null) return false
+        if (expr is ExprConstInt) return (expr as ExprConstInt).value == 0
+        if (expr is ExprConstUInt) return (expr as ExprConstUInt).value == 0u
+        if (expr is ExprConstInt64) return (expr as ExprConstInt64).value == 0l
+        if (expr is ExprConstUInt64) return (expr as ExprConstUInt64).value == 0ul
+        if (expr is ExprConstFloat) return (expr as ExprConstFloat).value == 0.0f
+        if (expr is ExprConstDouble) return (expr as ExprConstDouble).value == 0.0lf
         return false
     }
 
     def is_const_one(expr : Expression? const) : bool {
-        if (expr == null) {  //
-            return false
-        }
-        if (expr is ExprConstInt) {  //
-            return (expr as ExprConstInt).value == 1
-        }
-        if (expr is ExprConstUInt) {  //
-            return (expr as ExprConstUInt).value == 1u
-        }
-        if (expr is ExprConstInt64) {  //
-            return (expr as ExprConstInt64).value == 1l
-        }
-        if (expr is ExprConstUInt64) {  //
-            return (expr as ExprConstUInt64).value == 1ul
-        }
-        if (expr is ExprConstFloat) {  //
-            return (expr as ExprConstFloat).value == 1.0f
-        }
-        if (expr is ExprConstDouble) {  //
-            return (expr as ExprConstDouble).value == 1.0lf
-        }
+        if (expr == null) return false
+        if (expr is ExprConstInt) return (expr as ExprConstInt).value == 1
+        if (expr is ExprConstUInt) return (expr as ExprConstUInt).value == 1u
+        if (expr is ExprConstInt64) return (expr as ExprConstInt64).value == 1l
+        if (expr is ExprConstUInt64) return (expr as ExprConstUInt64).value == 1ul
+        if (expr is ExprConstFloat) return (expr as ExprConstFloat).value == 1.0f
+        if (expr is ExprConstDouble) return (expr as ExprConstDouble).value == 1.0lf
         return false
     }
 
     def is_const_neg_one(expr : Expression? const) : bool {
-        if (expr == null) {  //
-            return false
-        }
-        if (expr is ExprConstInt) {  //
-            return (expr as ExprConstInt).value == -1
-        }
-        if (expr is ExprConstInt64) {  //
-            return (expr as ExprConstInt64).value == -1l
-        }
-        if (expr is ExprConstFloat) {  //
-            return (expr as ExprConstFloat).value == -1.0f
-        }
-        if (expr is ExprConstDouble) {  //
-            return (expr as ExprConstDouble).value == -1.0lf
-        }
+        if (expr == null) return false
+        if (expr is ExprConstInt) return (expr as ExprConstInt).value == -1
+        if (expr is ExprConstInt64) return (expr as ExprConstInt64).value == -1l
+        if (expr is ExprConstFloat) return (expr as ExprConstFloat).value == -1.0f
+        if (expr is ExprConstDouble) return (expr as ExprConstDouble).value == -1.0lf
         return false
     }
 
@@ -417,7 +349,7 @@ class PerfLintVisitor : AstVisitor {
         //! returns false when either side has side effects — protects rules that
         //! suggest collapsing duplicated subexpressions (PERF014/015/016) from
         //! silently changing evaluation count.
-        if ((a == null || b == null)  //
+        if ((a == null || b == null)
             || (require_pure && (!a.flags.noSideEffects || !b.flags.noSideEffects))) return false
         return describe(a) == describe(b)
     }
@@ -425,9 +357,7 @@ class PerfLintVisitor : AstVisitor {
     def is_workhorse_numeric(t : TypeDecl?) : bool {
         //! True if the type is one of the six numeric workhorse scalars (int, uint,
         //! int64, uint64, float, double). Vectors/bitfields/enums do NOT qualify.
-        if (t == null || !empty(t.dim)) {  //
-            return false
-        }
+        if (t == null || !empty(t.dim)) return false
         let bt = t.baseType
         return (bt == Type.tInt || bt == Type.tUInt
                 || bt == Type.tInt64 || bt == Type.tUInt64
@@ -437,13 +367,9 @@ class PerfLintVisitor : AstVisitor {
     def is_collection_length_call(expr : Expression? const) : bool {
         //! True for length(string) / length(das_string) / length(array) / length(table).
         //! Excludes math::length(float2/3/4) which returns vector magnitude.
-        if (expr == null || !(expr is ExprCall)) {  //
-            return false
-        }
+        if (expr == null || !(expr is ExprCall)) return false
         let call = expr as ExprCall
-        if (call.func == null || call.func.name != "length") {  //
-            return false
-        }
+        if (call.func == null || call.func.name != "length") return false
         let modname = string(call.func._module.name)
         return modname == "strings" || modname == "$" || modname == "builtin"
     }
@@ -546,9 +472,7 @@ class PerfLintVisitor : AstVisitor {
     }
 
     def is_known_length_source(src : Expression?) : bool {
-        if (src == null || src._type == null) {  //
-            return false
-        }
+        if (src == null || src._type == null) return false
         let bt = src._type.baseType
         // fixed arrays have dim > 0; otherwise we accept any baseType whose
         // length is determined at the start of the loop.
@@ -610,9 +534,7 @@ class PerfLintVisitor : AstVisitor {
         //! Always pushed in preVisitExprFor — keeps the stack in lockstep with
         //! for-loop nesting so visitExprFor can pop unconditionally. Matched/
         //! disqualified status is filled in by the per-source/per-variable hooks.
-        var state = Perf018State()  //
-        state.disqualified = true   // flips false only when source+iter both match
-        state.matched = false
+        var state = Perf018State(disqualified = true, matched = false)
         perf018_stack    |> push(state)
         unsafe {
             perf018_for_exprs |> push(reinterpret<ExprFor?>(expr))
@@ -620,9 +542,7 @@ class PerfLintVisitor : AstVisitor {
     }
 
     def perf018_pop_and_check() : void {
-        if (empty(perf018_stack)) {  //
-            return
-        }
+        if (empty(perf018_stack)) return
         let top_idx = length(perf018_stack) - 1
         let state = perf018_stack[top_idx]
         let owning = perf018_for_exprs[top_idx]
@@ -650,9 +570,7 @@ class PerfLintVisitor : AstVisitor {
         //! Called from preVisitExprForSource. Peels `range(length(<bareVar>))`
         //! (with one optional ExprCast on either layer) and, when matched, stamps
         //! the candidate's arr_var. Iter var arrives via perf018_record_var.
-        if (empty(perf018_stack)) {  //
-            return
-        }
+        if (empty(perf018_stack)) return
         let top_idx = length(perf018_stack) - 1
         var state = perf018_stack[top_idx]
         state.sources_seen++
@@ -671,7 +589,7 @@ class PerfLintVisitor : AstVisitor {
             return
         }
         var rng = s as ExprCall
-        if (rng.func == null || string(rng.func.name) != "range"  //
+        if (rng.func == null || rng.func.name != "range"
             || length(rng.arguments) != 1) {
             perf018_stack[top_idx] = state
             return
@@ -685,7 +603,7 @@ class PerfLintVisitor : AstVisitor {
             return
         }
         var len = inner as ExprCall
-        if (len.func == null || string(len.func.name) != "length"  //
+        if (len.func == null || len.func.name != "length"
             || length(len.arguments) != 1) {
             perf018_stack[top_idx] = state
             return
@@ -703,9 +621,7 @@ class PerfLintVisitor : AstVisitor {
         //! Called from preVisitExprForVariable. Stamps iter_var on the top frame.
         //! When a single iter var pairs with a single recognized source, marks
         //! the candidate matched + un-disqualified.
-        if (empty(perf018_stack) || v == null) {  //
-            return
-        }
+        if (empty(perf018_stack) || v == null) return
         let top_idx = length(perf018_stack) - 1
         var state = perf018_stack[top_idx]
         state.vars_seen++
@@ -723,9 +639,7 @@ class PerfLintVisitor : AstVisitor {
         //! preVisitExprForSource and preVisitExprForVariable. Flips matched=true
         //! iff the loop had exactly one source we recognized (arr_var set) and
         //! exactly one iter var (iter_var set).
-        if (empty(perf018_stack)) {  //
-            return
-        }
+        if (empty(perf018_stack)) return
         let top_idx = length(perf018_stack) - 1
         var state = perf018_stack[top_idx]
         if (state.sources_seen == 1 && state.vars_seen == 1
@@ -740,16 +654,12 @@ class PerfLintVisitor : AstVisitor {
         //! True when `at.subexpr[at.index]` accesses the frame's arr_var (bare)
         //! and indexes by the frame's iter_var with no arithmetic. Conservative
         //! by design — field paths, casts on the subexpr, etc. don't qualify.
-        if (frame_idx < 0 || frame_idx >= length(perf018_stack)) {  //
-            return false
-        }
+        if (frame_idx < 0 || frame_idx >= length(perf018_stack)) return false
         let state = perf018_stack[frame_idx]
-        if (state.disqualified || !state.matched  //
+        if (state.disqualified || !state.matched
             || state.arr_var == null || state.iter_var == null) return false
         let av = self->perf018_bare_var_of(at.subexpr)
-        if (av != state.arr_var) {  //
-            return false
-        }
+        if (av != state.arr_var) return false
         var idx = at.index
         if (idx is ExprRef2Value) {
             idx = (idx as ExprRef2Value.subexpr)
@@ -775,9 +685,7 @@ class PerfLintVisitor : AstVisitor {
     }
 
     def perf018_off_at() : void {
-        if (empty(at_qualifying_pushes)) {  //
-            return
-        }
+        if (empty(at_qualifying_pushes)) return
         let n = at_qualifying_pushes |> back()
         at_qualifying_pushes |> pop()
         in_qualifying_idx -= n
@@ -786,9 +694,7 @@ class PerfLintVisitor : AstVisitor {
     def perf018_on_var(v : Variable?) : void {
         //! Called from preVisitExprVar: a bare iter_var reference outside any
         //! qualifying ExprAt index slot disqualifies the matching frame.
-        if (v == null || empty(perf018_stack) || in_qualifying_idx > 0) {  //
-            return
-        }
+        if (v == null || empty(perf018_stack) || in_qualifying_idx > 0) return
         let n = length(perf018_stack)
         for (i in range(n)) {
             var st = perf018_stack[i]
@@ -950,14 +856,10 @@ class PerfLintVisitor : AstVisitor {
         //! Parse `var <op> const` or `const <op> var` where op is `<=` or `>=`.
         //! Returns true and fills outputs with: the variable expression,
         //! the int bound, and whether this leg expresses an upper bound on var.
-        if (leg == null || !(leg is ExprOp2)) {  //
-            return false
-        }
+        if (leg == null || !(leg is ExprOp2)) return false
         var op2 = leg as ExprOp2
         let opname = string(op2.op)
-        if (opname != "<=" && opname != ">=") {  //
-            return false
-        }
+        if (opname != "<=" && opname != ">=") return false
         if (op2.right is ExprConstInt && op2.left != null) {
             v_out = op2.left
             bound_out = (op2.right as ExprConstInt).value
@@ -990,15 +892,13 @@ class PerfLintVisitor : AstVisitor {
         var hi_b = false
         // Both legs must parse, constrain the SAME expression, and split into
         // one upper / one lower bound.
-        if (!self->parse_range_leg(expr.left, va, bound_a, hi_a)  //
+        if (!self->parse_range_leg(expr.left, va, bound_a, hi_a)
             || !self->parse_range_leg(expr.right, vb, bound_b, hi_b)
             || !self->expr_equal_struct(va, vb)
             || hi_a == hi_b) return
         let lo = hi_a ? bound_b : bound_a
         let hi = hi_a ? bound_a : bound_b
-        if (lo >= hi || !self->is_known_char_class_range(lo, hi)) {  //
-            return
-        }
+        if (lo >= hi || !self->is_known_char_class_range(lo, hi)) return
         // Pick the helper that matches the detected range. Note: is_alpha covers
         // BOTH cases, so for a single-case range ('a'..'z' or 'A'..'Z') it's a
         // broader replacement, not an exact one — call that out so the user
@@ -1015,17 +915,13 @@ class PerfLintVisitor : AstVisitor {
     // --- PERF017: length(collection) <op> 0/1 → empty / !empty ---
 
     def peel_ref2value(e : Expression? const) : Expression? const {
-        if (e != null && e is ExprRef2Value) {  //
-            return (e as ExprRef2Value.subexpr)
-        }
+        if (e != null && e is ExprRef2Value) return (e as ExprRef2Value.subexpr)
         return e
     }
 
     def const_int_value(e : Expression? const; var v : int&) : bool {
         let inner = self->peel_ref2value(e)
-        if (inner == null) {  //
-            return false
-        }
+        if (inner == null) return false
         if (inner is ExprConstInt) {
             v = (inner as ExprConstInt).value
             return true
@@ -1053,9 +949,7 @@ class PerfLintVisitor : AstVisitor {
                 && current_function.fromGeneric.name == "empty"
                 && current_function.fromGeneric._module != null
                 && current_function.fromGeneric._module.name == "builtin")
-            if (direct_match || generic_match) {  //
-                return
-            }
+            if (direct_match || generic_match) return
         }
         let lhs = self->peel_ref2value(expr.left)
         let rhs = self->peel_ref2value(expr.right)
@@ -1069,9 +963,7 @@ class PerfLintVisitor : AstVisitor {
         }
         let const_side = len_on_left ? rhs : lhs
         var k = 0
-        if (!self->const_int_value(const_side, k) || (k != 0 && k != 1)) {  //
-            return
-        }
+        if (!self->const_int_value(const_side, k) || (k != 0 && k != 1)) return
         let opname = string(expr.op)
         // Canonicalize so that length is on the left; flip op if needed.
         var canon_op = opname
@@ -1118,28 +1010,24 @@ class PerfLintVisitor : AstVisitor {
     // --- PERF015 / PERF016: ternary min/max/abs ---
 
     def override preVisitExprOp3(expr : ExprOp3?) : void {
-        if (in_closure > 0 || expr.op != "?"  //
+        if (in_closure > 0 || expr.op != "?"
             || expr.subexpr == null || !(expr.subexpr is ExprOp2)) return
         var cmp = expr.subexpr as ExprOp2
         let cop = string(cmp.op)
-        if ((cop != "<" && cop != "<=" && cop != ">" && cop != ">=")  //
+        if ((cop != "<" && cop != "<=" && cop != ">" && cop != ">=")
             || expr.left == null || expr.right == null) return
         let t_branch = expr.left
         let f_branch = expr.right
         // PERF016 first — a ternary that matches abs may also superficially match
         // min/max if x and -x ever describe-equal, but they can't. So order is fine.
-        if (self->try_perf016_abs(expr, cmp, t_branch, f_branch, cop)) {  //
-            return
-        }
+        if (self->try_perf016_abs(expr, cmp, t_branch, f_branch, cop)) return
         self->try_perf015_minmax(expr, cmp, t_branch, f_branch, cop)
     }
 
     def try_perf015_minmax(expr : ExprOp3?; cmp : ExprOp2?; t_branch, f_branch : Expression? const; cop : string) : bool {
         let cl = cmp.left
         let cr = cmp.right
-        if (cl == null || cr == null) {  //
-            return false
-        }
+        if (cl == null || cr == null) return false
         // ternary branches must be a permutation of (cl, cr)
         let tcl = self->expr_equal_struct(t_branch, cl)
         let tcr = self->expr_equal_struct(t_branch, cr)
@@ -1147,9 +1035,7 @@ class PerfLintVisitor : AstVisitor {
         let fcr = self->expr_equal_struct(f_branch, cr)
         let same_order = tcl && fcr   // T==L, F==R
         let swap_order = tcr && fcl   // T==R, F==L
-        if (!same_order && !swap_order) {  //
-            return false
-        }
+        if (!same_order && !swap_order) return false
         // Mapping
         //   <  / <=  : T==L,F==R → min;  T==R,F==L → max
         //   >  / >=  : T==L,F==R → max;  T==R,F==L → min
@@ -1175,9 +1061,7 @@ class PerfLintVisitor : AstVisitor {
             return false
         }
         let x_expr = x_on_left ? cmp.left : cmp.right
-        if (x_expr == null) {  //
-            return false
-        }
+        if (x_expr == null) return false
         // Identify negated branch (-x) and plain branch (x)
         var neg_then = false
         var ok = false
@@ -1188,9 +1072,7 @@ class PerfLintVisitor : AstVisitor {
             neg_then = false
             ok = true
         }
-        if (!ok) {  //
-            return false
-        }
+        if (!ok) return false
         // Determine canonical sign of x in comparison: x < 0 or x > 0 etc.
         // Reduce to: "is x's value-relation `negative` or `positive`" in the true branch
         // Forms that produce abs:
@@ -1212,40 +1094,30 @@ class PerfLintVisitor : AstVisitor {
                 is_abs = true
             }
         }
-        if (!is_abs) {  //
-            return false
-        }
+        if (!is_abs) return false
         self->perf_warning("PERF016: ternary abs — use 'abs(x)' from math module", expr.at)
         return true
     }
 
     def is_neg_of(maybe_neg : Expression? const; ref : Expression? const) : bool {
         //! True when `maybe_neg` is `-ref` structurally.
-        if (maybe_neg == null || !(maybe_neg is ExprOp1)) {  //
-            return false
-        }
+        if (maybe_neg == null || !(maybe_neg is ExprOp1)) return false
         let op1 = maybe_neg as ExprOp1
-        if (op1.op != "-") {  //
-            return false
-        }
+        if (op1.op != "-") return false
         return self->expr_equal_struct(op1.subexpr, ref)
     }
 
     // --- PERF011: unnecessary get_ptr() for field access ---
 
     def override preVisitExprField(expr : ExprField?) : void {
-        if (in_closure > 0) {  //
-            return
-        }
+        if (in_closure > 0) return
         if (self->is_get_ptr_of_smart_ptr(expr.value)) {
             self->perf_warning("PERF011: get_ptr() is unnecessary for field access; smart_ptr auto-dereferences", expr.at)
         }
     }
 
     def override preVisitExprSafeField(expr : ExprSafeField?) : void {
-        if (in_closure > 0) {  //
-            return
-        }
+        if (in_closure > 0) return
         if (self->is_get_ptr_of_smart_ptr(expr.value)) {
             self->perf_warning("PERF011: get_ptr() is unnecessary for field access; smart_ptr auto-dereferences", expr.at)
         }
@@ -1254,9 +1126,7 @@ class PerfLintVisitor : AstVisitor {
     // --- PERF002 + PERF003: character_at (counter-based) ---
 
     def override preVisitExprCall(var expr : ExprCall?) : void {
-        if (in_closure > 0 || expr.func == null) {  //
-            return
-        }
+        if (in_closure > 0 || expr.func == null) return
         if (expr.func.name == "character_at" && expr.func._module.name == "strings") {
             var ecall = expr
             // PERF002: start tracking — any loop var inside this call triggers warning
@@ -1272,9 +1142,7 @@ class PerfLintVisitor : AstVisitor {
     }
 
     def override visitExprCall(var expr : ExprCall?) : ExpressionPtr {
-        if (expr.func == null) {  //
-            return <- expr
-        }
+        if (expr.func == null) return <- expr
         // PERF003: character_at anywhere — fires even inside closures
         if (expr.func.name == "character_at" && expr.func._module.name == "strings") {
             var ecall = expr
@@ -1335,9 +1203,7 @@ class PerfLintVisitor : AstVisitor {
     // --- PERF004: string builder reassignment in loop (counter-based) ---
 
     def override preVisitExprCopy(expr : ExprCopy?) : void {
-        if (in_closure > 0 || loop_depth == 0) {  //
-            return
-        }
+        if (in_closure > 0 || loop_depth == 0) return
         var v = self->find_string_var_from_expr(expr.left)
         if (v != null && self->is_defined_outside_loop(v) && expr.right is ExprStringBuilder) {
             string_builder_target_var = v
@@ -1350,9 +1216,7 @@ class PerfLintVisitor : AstVisitor {
     }
 
     def override preVisitExprMove(expr : ExprMove?) : void {
-        if (in_closure > 0 || loop_depth == 0) {  //
-            return
-        }
+        if (in_closure > 0 || loop_depth == 0) return
         var v = self->find_string_var_from_expr(expr.left)
         if (v != null && self->is_defined_outside_loop(v) && expr.right is ExprStringBuilder) {
             string_builder_target_var = v
@@ -1380,9 +1244,7 @@ class PerfLintVisitor : AstVisitor {
     // --- Central ExprVar handler (PERF002, PERF004, PERF005) ---
 
     def override preVisitExprVar(expr : ExprVar?) : void {
-        if (in_closure > 0) {  //
-            return
-        }
+        if (in_closure > 0) return
         let v = expr.variable
         // PERF018: a bare iter_var reference outside a qualifying ExprAt index slot disqualifies the loop.
         self->perf018_on_var(v)

--- a/daslib/profiler.das
+++ b/daslib/profiler.das
@@ -279,8 +279,8 @@ class PerformanceProfilerAgent : ProfilerBaseAgent {
         dump("\{\"name\":\"{fnName}\",\"cat\": \"PERF\",\"ph\":\"{phase}\",\"pid\": 0,\"tid\":{int64(tid)},\"ts\":{ev.ts/1000l}\}")
     }
     def dump_node(node : PerfNode?; tab : int = -1) {
-        if (node == null) return
-        if (report_memory && node.fun != null && node.total_heap_bytes == 0ul && node.total_string_heap_bytes == 0ul) return
+        if (node == null
+                || (report_memory && node.fun != null && node.total_heap_bytes == 0ul && node.total_string_heap_bytes == 0ul)) return
         if (node.fun != null) {
             let tabs = repeat("  ", tab)
             if (report_memory) {

--- a/daslib/quote.das
+++ b/daslib/quote.das
@@ -208,7 +208,7 @@ def private to_array_move_expr(var mkArr : ExprMakeArray?, at : LineInfo) {
 }
 
 def private to_arr_move_args(var args : array<Expression?>; var dst_tp : TypeDeclPtr; at : LineInfo) {
-    assert(args |> length > 0);
+    assert(!empty(args));
     unsafe {
         return to_array_move_expr(new ExprMakeArray(values := args,
                                                        gen2 = true,
@@ -360,9 +360,7 @@ def private convert_quote_expr(mod : Module?; var data : uint8 const?; info : Ty
     } elif (tstr == "ast_core::Structure") {
          assume pdata = unsafe(reinterpret<Structure?>(data));
          // disable support for Structure::Module. If we compile without shared_modules it's impossible
-         if (pdata._module.name == "ast_boost") { // How to check COP.shared_modules = false?
-            return null;
-         }
+         if (pdata._module.name == "ast_boost") return null  // disabled when shared_modules=false (no direct check)
          // It's unnecessary, however there is bug in aot with ternary operator
          var tmp = get_find_in_module_expr("module_find_structure", pdata._module.name, pdata.name, at);
          return tmp;

--- a/daslib/regex.das
+++ b/daslib/regex.das
@@ -272,15 +272,15 @@ def private is_set_character(ch : int) : bool {
 }
 
 def private is_digit(ch : int) : bool {
-    return ch >= '0' && ch <= '9'
+    return ch >= '0' && ch <= '9'  // nolint:PERF014 (regex char-class primitive)
 }
 
 def private is_word_character(ch : int) : bool {
-    return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_'
+    return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_'  // nolint:PERF014
 }
 
 def private from_hex(ch : int) {
-    if (ch >= '0' && ch <= '9') return ch - '0'
+    if (ch >= '0' && ch <= '9') return ch - '0'  // nolint:PERF014
     if (ch >= 'a' && ch <= 'f') return ch - 'a' + 10
     if (ch >= 'A' && ch <= 'F') return ch - 'A' + 10
     panic("from_hex")
@@ -450,8 +450,7 @@ def private re_set_items(expr : string; offset : int) : MaybeReNode {
 // <set> ::= <positive-set> | <negative-set>
 def private re_set(expr : string; offset : int) : MaybeReNode {
     trace("re_set", offset)
-    if (eos(expr, offset)) return nada()
-    if (at(expr, offset) != '[') return nada();
+    if (eos(expr, offset) || at(expr, offset) != '[') return nada()
     var negative = false;
     if (at(expr, offset + 1) == '^') {
         negative = true;
@@ -502,8 +501,7 @@ def private re_bos(expr : string; offset : int) : MaybeReNode {
 // <group> ::= "(" <RE> ")" | "(?:" <RE> ")" | "(?P<name>" <RE> ")"
 def private re_group(expr : string; offset : int) : MaybeReNode {
     trace("re_group", offset)
-    if (eos(expr, offset)) return nada()
-    if (at(expr, offset) != '(') return nada();
+    if (eos(expr, offset) || at(expr, offset) != '(') return nada()
     var group_offset = offset + 1
     var non_capturing = false
     var group_name = ""
@@ -923,7 +921,7 @@ def private re_assign_match_functions(var re : Regex) {
 
 def private ci_lower(ch : int) : int {
     //! Converts ASCII uppercase to lowercase for case-insensitive matching.
-    if (ch >= 'A' && ch <= 'Z') return ch + 32
+    if (ch >= 'A' && ch <= 'Z') return ch + 32  // nolint:PERF014
     return ch
 }
 
@@ -932,7 +930,7 @@ def private case_fold_set(var cset : CharSet) {
     for (ch in range(0, 256)) {
         if (is_char_in_set(ch, cset)) {
             let lo = ci_lower(ch)
-            let up = (lo >= 'a' && lo <= 'z') ? lo - 32 : lo
+            let up = (lo >= 'a' && lo <= 'z') ? lo - 32 : lo  // nolint:PERF014
             set_or_char(cset, lo)
             set_or_char(cset, up)
         }
@@ -1040,8 +1038,7 @@ def private re_match2_set(var regex : Regex; var node : ReNode?; str : uint8 con
     if (log_match_enabled) {
         print("match2 set {str}\n")
     }
-    if (*str == 0u8) return null
-    if (!is_char_in_set(int(*str), node.cset)) return null
+    if (*str == 0u8 || !is_char_in_set(int(*str), node.cset)) return null
     unsafe {
         var tail = str + 1
         node.tail = tail
@@ -1059,8 +1056,7 @@ def private re_match2_any(var regex : Regex; var node : ReNode?; str : uint8 con
     if (log_match_enabled) {
         print("match2 any {str}\n")
     }
-    if (*str == 0u8) return null
-    if (!regex.dotAll && int(*str) == '\n') return null
+    if (*str == 0u8 || (!regex.dotAll && int(*str) == '\n')) return null
     unsafe {
         var tail = str + 1
         node.tail = tail
@@ -1153,8 +1149,7 @@ def private re_match2_plus_set(var regex : Regex; var node : ReNode?; str : uint
     if (log_match_enabled) {
         print("match2 plus {str}\n")
     }
-    if (*str == 0u8) return null
-    if (!is_char_in_set(int(*str), node.cset)) return null
+    if (*str == 0u8 || !is_char_in_set(int(*str), node.cset)) return null
     unsafe {
         var ofs = str + 1
         var osym = ofs
@@ -1544,9 +1539,9 @@ def private re_early_out(var cset : CharSet; node : ReNode?) : bool {
         let fc = first_character(node.text)
         set_or_char(cset, fc)
         // if case-insensitive, also add the opposite-case first char
-        if (fc >= 'A' && fc <= 'Z') {
+        if (fc >= 'A' && fc <= 'Z') {  // nolint:PERF014
             set_or_char(cset, fc + 32)
-        } elif (fc >= 'a' && fc <= 'z') {
+        } elif (fc >= 'a' && fc <= 'z') {  // nolint:PERF014
             set_or_char(cset, fc - 32)
         }
         return false

--- a/daslib/regex_boost.das
+++ b/daslib/regex_boost.das
@@ -19,6 +19,7 @@ module regex_boost shared private
 
 require daslib/ast
 require strings
+require math
 require daslib/ast_boost
 require daslib/regex public
 
@@ -46,7 +47,7 @@ class RegexReader : AstReaderMacro {
         var pattern = "{expr.sequence}"
         var ci = false
         var da = false
-        let tilde_pos = find(pattern, "~", length(pattern) - 4 > 0 ? length(pattern) - 4 : 0)
+        let tilde_pos = find(pattern, "~", max(0, length(pattern) - 4))
         if (tilde_pos != -1) {
             let flags_str = slice(pattern, tilde_pos + 1)
             var valid_flags = true

--- a/daslib/remove_call_args.das
+++ b/daslib/remove_call_args.das
@@ -35,7 +35,7 @@ def get_remove_indices(args : AnnotationArgumentList) {
             indices |> push(arg.iValue)
         }
     }
-    if (length(indices) > 0) {
+    if (!empty(indices)) {
         indices |> sort() <| $(a, b) => a > b
     }
     return <- indices

--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -205,10 +205,10 @@ def function_label_name(value : FunctionPtr) {
                 break
             }
         }
-        if (is_generic) return "{res}_{value.at.line}"
-        // For class/struct methods, operators like []=, []&&=, []||= collapse
-        // to the same safe name. Disambiguate with line number.
-        if (value.flags.isClassMethod) return "{res}_{value.at.line}"
+        // Disambiguate with line number for: (a) generic instantiations sharing
+        // the same name; (b) class/struct method operators ([]=, []&&=, []||=)
+        // that collapse to the same safe name.
+        if (is_generic || value.flags.isClassMethod) return "{res}_{value.at.line}"
     }
     // Detect label collisions (e.g. smart_ptr<T> vs T? producing same label)
     // and disambiguate with line number. Same function seen twice (TOC + def) is not a collision.
@@ -280,9 +280,9 @@ def describe_type_short(td : TypeDeclPtr) {
     } elif (td.baseType == Type.tFunction || td.baseType == Type.tBlock || td.baseType == Type.tLambda) {
         res = build_string() $(var w) {
             w |> write(td.baseType == Type.tBlock ? "block<" : td.baseType == Type.tFunction ? "function<" : "lambda<")
-            if (td.argTypes |> length != 0) {
+            if (!empty(td.argTypes)) {
                 w |> write("(")
-                if (td.argNames |> length != 0) {
+                if (!empty(td.argNames)) {
                     var first = true
                     for (at, an in td.argTypes, td.argNames) {
                         if (first) {
@@ -365,8 +365,7 @@ def public describe_short(expr : Expression? | Expression?&) {
 def rst_describe_function_short(func : FunctionPtr) {
     var inscope args : array<string>
     for (x in func.arguments) {
-        continue if (x._type.baseType == Type.fakeContext)
-        continue if (x._type.baseType == Type.fakeLineInfo)
+        continue if (x._type.baseType == Type.fakeContext || x._type.baseType == Type.fakeLineInfo)
         let prefix = x._type.flags.removeConstant ? "var " : ""
         if (x.init != null) {
             args |> push("{prefix}{x.name}: {describe_type_short(x._type)} = {describe_short(x.init)}")
@@ -470,9 +469,9 @@ def describe_type(td : TypeDecl?) {
         } elif (baseType == Type.tBlock || baseType == Type.tFunction || baseType == Type.tLambda) {
             write(writer, das_to_string(baseType))
             write(writer, "<")
-            if (td.argTypes |> length != 0) {
+            if (!empty(td.argTypes)) {
                 write(writer, "(")
-                if (td.argNames |> length != 0) {
+                if (!empty(td.argNames)) {
                     var first = true
                     for (at, an in td.argTypes, td.argNames) {
                         if (first) {
@@ -508,8 +507,8 @@ def describe_type(td : TypeDecl?) {
             let delim = baseType == Type.option ? "\\ | " : ";"
             write(writer, das_to_string(baseType))
             write(writer, "<")
-            if (td.argTypes |> length != 0) {
-                if (td.argNames |> length != 0) {
+            if (!empty(td.argTypes)) {
+                if (!empty(td.argNames)) {
                     var first = true
                     for (at, an in td.argTypes, td.argNames) {
                         if (first) {
@@ -1013,9 +1012,7 @@ def document_global_constant(doc_file : file; mod : Module?; value : VariablePtr
 }
 
 def private is_global_constant(value : VariablePtr) {
-    if (value.flags.private_variable) return false
-    if (!value._type.flags.constant) return false
-    if (value.flags.bitfield_constant) return false
+    if (value.flags.private_variable || !value._type.flags.constant || value.flags.bitfield_constant) return false
     // without this condition we supports more types
     // if !value._type.isWorkhorseType
     //     return false
@@ -1307,10 +1304,10 @@ def document_classes(doc_file : file; mods : array<Module?>) {
                     document_function(doc_file, mod, func, /*drop first arg*/0, "{value.name}-", "das:function")
                     return
                 }
-                if (!(func.moreFlags.propertyFunction || func.flags.isClassMethod) || func.arguments |> length == 0) return
+                if (!(func.moreFlags.propertyFunction || func.flags.isClassMethod) || empty(func.arguments)) return
                 let fna = string(func.name)
-                if (!fna |> starts_with(".`") || length(fna) <= 2) return
-                if (!is_same_type(func.arguments[0]._type, annT, RefMatters.no, ConstMatters.no, TemporaryMatters.no)) return
+                if (!fna |> starts_with(".`") || length(fna) <= 2
+                        || !is_same_type(func.arguments[0]._type, annT, RefMatters.no, ConstMatters.no, TemporaryMatters.no)) return
                 if (first) {
                     fwrite(doc_file, ":Properties:\n\n")
                     first = false
@@ -1421,10 +1418,9 @@ def document_structure(doc_file : file; mod : Module?; var value : StructurePtr)
     // Document struct methods (module-level functions with isClassMethod flag).
     // For structs (unlike classes), methods are not stored as struct fields after inference.
     for_each_function(mod, "") $(func) {
-        if (!func.flags.isClassMethod || func.classParent != value) return
-        if (func.flags.generated) return
-        // Skip constructors (handled below)
-        if (func.name == value.name) return
+        if (!func.flags.isClassMethod || func.classParent != value
+                || func.flags.generated
+                || func.name == value.name) return  // skip constructors (handled below)
         // Skip property functions (handled below)
         var isPropertyFunc = false
         peek(func.name) $(fn_name) {
@@ -1432,10 +1428,7 @@ def document_structure(doc_file : file; mod : Module?; var value : StructurePtr)
         }
         if (isPropertyFunc) return
         if (!func.moreFlags.isStaticClassMethod) {
-            if (func.name == "{value.name}`{value.name}") {
-                // Foo`Foo == generated ctor
-                return
-            }
+            if (func.name == "{value.name}`{value.name}") return  // Foo`Foo == generated ctor
             for (fld in value.fields) {
                 // exclude instantiated struct fields
                 if (fld.flags.classMethod && fld.flags.implemented && func.name == "{value.name}`{fld.name}") return
@@ -1451,10 +1444,10 @@ def document_structure(doc_file : file; mod : Module?; var value : StructurePtr)
             document_function(doc_file, mod, func, /*drop first arg*/0, "{value.name}-", "das:function")
             return
         }
-        if (!(func.moreFlags.propertyFunction || func.flags.isClassMethod) || func.arguments |> length == 0) return
+        if (!(func.moreFlags.propertyFunction || func.flags.isClassMethod) || empty(func.arguments)) return
         let fna = string(func.name)
-        if (!fna |> starts_with(".`") || length(fna) <= 2) return
-        if (!is_same_type(func.arguments[0]._type, annT, RefMatters.no, ConstMatters.no, TemporaryMatters.no)) return
+        if (!fna |> starts_with(".`") || length(fna) <= 2
+                || !is_same_type(func.arguments[0]._type, annT, RefMatters.no, ConstMatters.no, TemporaryMatters.no)) return
         if (first) {
             fwrite(doc_file, ":Properties:\n\n")
             first = false
@@ -1492,11 +1485,10 @@ def document_structure_annotation(doc_file : file; mod : Module?; value) {
     var annT = new TypeDecl(baseType = Type.tHandle,
         annotation = unsafe(reinterpret<TypeAnnotation?> value))
     for_each_function(mod, "") $(func) {
-        if (!func.moreFlags.propertyFunction) return
-        if (func.arguments |> length != 1) return
+        if (!func.moreFlags.propertyFunction || func.arguments |> length != 1) return
         let fna = string(func.name)
-        if (!fna |> starts_with(".`") || length(fna) <= 2) return
-        if (!is_same_type(func.arguments[0]._type, annT, RefMatters.no, ConstMatters.no, TemporaryMatters.no)) return
+        if (!fna |> starts_with(".`") || length(fna) <= 2
+                || !is_same_type(func.arguments[0]._type, annT, RefMatters.no, ConstMatters.no, TemporaryMatters.no)) return
         var line : array<string>
         push(line, slice(fna, 2))
         push(line, describe_type(func.result))
@@ -1755,11 +1747,11 @@ def document_typeinfo_macros(doc_file : file; mods : array<Module?>) {
 }
 
 def function_needs_documenting(func : FunctionPtr) {
-    if (func.flags.generated) return false
-    if (func.flags.isClassMethod) return false
-    if (func.flags.privateFunction) return false
-    if (func.fromGeneric != null) return false
-    if (func.moreFlags.propertyFunction) return false
+    if (func.flags.generated
+            || func.flags.isClassMethod
+            || func.flags.privateFunction
+            || func.fromGeneric != null
+            || func.moreFlags.propertyFunction) return false
     var isBuiltin = false
     peek(func._module.name) $(name) {
         if (name == "$" || name == "builtin") {
@@ -1841,7 +1833,7 @@ def function_name(func : FunctionPtr) {
                 let op = character_at(safeName, length(safeName) - 2) // nolint:PERF003
                 safeName = "{safeName |> slice(0,-3)} {op.to_char()}="
             }
-            return (length(func.arguments) == 0
+            return (empty(func.arguments)
                 ? safeName
                 : "{func.arguments[0]._type |> describe_type_short()}{safeName}"
             )

--- a/daslib/soa.das
+++ b/daslib/soa.das
@@ -39,9 +39,7 @@ class SoaCallMacro : AstFunctionAnnotation {
     //! This is the core of the SOA access pattern — it transforms AOS-style element access
     //! into column-wise array indexing for better cache locality.
     def override transform(var expr : ExprCallFunc?; var errors : das_string) : ExpressionPtr {
-        if (is_in_completion()) {
-            return null
-        }
+        if (is_in_completion()) return null
         if (expr.arguments |> length != 2) {
             errors := "expecting soa[index].field"
             return null
@@ -95,7 +93,7 @@ class SoaStructMacro : AstStructureAnnotation {
             compiling_module() |> add_alias(tdef)
             return true
         }
-        if (st.fields |> length == 0) {
+        if (empty(st.fields)) {
             errors := "soa macro expects at least one field"
             return false
         }
@@ -337,9 +335,7 @@ def collect_and_replace_iterator_fields(prefix : string; blk : ExpressionPtr) : 
 class SoaForLoop : AstForLoopMacro {
     //! For-loop macro that transforms SOA array iteration.
     def override visitExprFor(prog : ProgramPtr; mod : Module?; expr : ExprFor?) : ExpressionPtr {
-        if (is_in_completion()) {
-            return null
-        }
+        if (is_in_completion()) return null
         var soa_index = -1
         for (index, its in count(), expr.sources) {
             if (its._type != null && its._type.isStructure) {
@@ -365,7 +361,7 @@ class SoaForLoop : AstForLoopMacro {
             new_for.iteratorsAka |> erase(soa_index)
             new_for.iteratorsTags |> erase(soa_index)
             var names <- collect_and_replace_iterator_fields(it_prefix, new_for.body)
-            if (names |> length == 0) {
+            if (empty(names)) {
                 names |> push <| string(expr.sources[soa_index]._type.structType.fields[0].name)
             }
             for (itn in names) {

--- a/daslib/sort_boost.das
+++ b/daslib/sort_boost.das
@@ -25,7 +25,7 @@ class QsortMacro : AstCallMacro {
         if (expr.arguments[0]._type == null || expr.arguments[1]._type == null) return null
         // todo: verify correct block type?
         macro_verify(expr.arguments[1]._type.baseType == Type.tBlock, prog, expr.at, "expecting 2nd argument to be block(<a,b:auto(TT)>:bool))")
-        if (expr.arguments[0]._type.dim |> length != 0 || expr.arguments[0]._type.baseType == Type.tArray) {
+        if (!empty(expr.arguments[0]._type.dim) || expr.arguments[0]._type.baseType == Type.tArray) {
             var call = new ExprCall(name := "sort", at = expr.at)
             emplace_new(call.arguments) <| clone_expression(expr.arguments[0])
             emplace_new(call.arguments) <| clone_expression(expr.arguments[1])

--- a/daslib/spoof.das
+++ b/daslib/spoof.das
@@ -75,7 +75,7 @@ def next_ident(var it : iterator<int>; var Ch : int&; var ident : string&) : boo
             break
         }
     }
-    return false if (id |> length == 0)
+    return false if (empty(id))
     ident = string(id)
     return true
 }
@@ -85,15 +85,13 @@ def instance_spoof(temp : string; passed_arguments : array<string>) : tuple<resu
     var args : array<tuple<argName : string; init : string>>
     var error = "no arguments found"
     spoof_args(temp) $(res, errors) {
-        if (errors |> length > 0) {
+        if (!empty(errors)) {
             error = errors |> join("\n")
         } else {
             args <- res
         }
     }
-    if (args |> length == 0) {
-        return (result = error, ok = false)
-    }
+    if (empty(args)) return (result = error, ok = false)
     // compare argument counts
     var instance_arguments : array<string>
     for (a, ai in args, count()) {
@@ -116,9 +114,7 @@ def instance_spoof(temp : string; passed_arguments : array<string>) : tuple<resu
         }
         Ch = -1
     }
-    if (Ch == -1) {
-        return (result = "unexpected end of file", ok = false)
-    }
+    if (Ch == -1) return (result = "unexpected end of file", ok = false)
     // now, lets apply the arguments
     var result : array<uint8>
     var pendingCh : int
@@ -258,7 +254,7 @@ class SpoofInstanceReader : AstReaderMacro {
         var iargs : SpoofInvocation
         var failed = false
         instance_args(string(expr.sequence)) $(res, errors) {
-            if (errors |> length > 0) {
+            if (!empty(errors)) {
                 let all_errors = errors |> join("\n")
                 prog |> macro_error(info, all_errors)
                 failed = true
@@ -270,7 +266,7 @@ class SpoofInstanceReader : AstReaderMacro {
         // lets find the variable for the template
         var vptr : VariablePtr
         find_matching_variable(get_ptr(prog), null, iargs.varName, false) $(vars) {
-            if (vars |> length == 0) {
+            if (empty(vars)) {
                 prog |> macro_error(info, "no matching variable found for {iargs.varName}")
                 return
             } elif (vars |> length > 1) {

--- a/daslib/static_let.das
+++ b/daslib/static_let.das
@@ -82,7 +82,7 @@ class StaticLetMacro : AstFunctionAnnotation {
             return null
         }
         var blk = mblk._block as ExprBlock
-        if (blk.finalList |> length != 0) {
+        if (!empty(blk.finalList)) {
             errors := "not expecting finally section in the static_let"
             return null
         }

--- a/daslib/strings_boost.das
+++ b/daslib/strings_boost.das
@@ -343,7 +343,7 @@ def public capitalize(str : string) : string {
     //! The rest of the string is unchanged.
     if (str |> empty()) return str
     let first = first_character(str)
-    if (first >= 'a' && first <= 'z') return build_string() $(writer) {
+    if (first >= 'a' && first <= 'z') return build_string() $(writer) {  // nolint:PERF014 (ASCII case-shift)
             writer |> write_char(first - 'a' + 'A')
             if (str |> length() > 1) {
                 writer |> write(str |> slice(1))

--- a/daslib/style_lint.das
+++ b/daslib/style_lint.das
@@ -62,13 +62,9 @@ class StyleLintVisitor : AstVisitor {
     }
 
     def is_suppressed(text : string; at : LineInfo) : bool {
-        if (at.fileInfo == null || at.line == 0u) {  //
-            return false
-        }
+        if (at.fileInfo == null || at.line == 0u) return false
         let colon = find(text, ":")
-        if (colon < 0) {  //
-            return false
-        }
+        if (colon < 0) return false
         let code = slice(text, 0, colon)
         var found = false
         get_file_source_line(at.fileInfo, at.line) $(line) {
@@ -82,17 +78,11 @@ class StyleLintVisitor : AstVisitor {
 
     def style_warning(text : string; at : LineInfo) : void {
         // Suppress warnings for macro-generated functions — the user didn't write that code.
-        if (current_function != null && current_function.flags.generated) {  //
-            return
-        }
+        if (current_function != null && current_function.flags.generated) return
         let key = self->location_key(at)
-        if (reported_locations |> has_value(key)) {  //
-            return
-        }
+        if (reported_locations |> has_value(key)) return
         reported_locations |> push(key)
-        if (self->is_suppressed(text, at)) {  //
-            return
-        }
+        if (self->is_suppressed(text, at)) return
         warning_count++
         var msg = text
         if (current_function != null && current_function.fromGeneric != null && !empty(current_function.inferStack)) {
@@ -119,9 +109,7 @@ class StyleLintVisitor : AstVisitor {
         //! Reads the source text between two line infos (potentially multi-line).
         //! Returns the concatenated lines from at_start.line to at_end.line.
         var result = ""
-        if (at_start.fileInfo == null) {  //
-            return result
-        }
+        if (at_start.fileInfo == null) return result
         for (ln in range(int(at_start.line), int(at_end.line) + 1)) {
             get_file_source_line(at_start.fileInfo, uint(ln)) $(line) {
                 result = "{result}{line}\n"
@@ -140,9 +128,7 @@ class StyleLintVisitor : AstVisitor {
     // --- STYLE001/002 for defer <| (macro erases AST, scan source lines) ---
 
     def check_defer_pipe(fn : FunctionPtr) : void {
-        if (fn.body == null || fn.at.fileInfo == null || fn.at.line == 0u) {  //
-            return
-        }
+        if (fn.body == null || fn.at.fileInfo == null || fn.at.line == 0u) return
         let body_at = fn.body.at
         for (ln in range(int(body_at.line), int(body_at.last_line) + 1)) {
             var src = ""
@@ -151,28 +137,20 @@ class StyleLintVisitor : AstVisitor {
             }
             let comment_pos = find(src, "//")
             let defer_pos = find(src, "defer")
-            if (defer_pos < 0 || (comment_pos >= 0 && comment_pos < defer_pos)) {  //
-                continue
-            }
+            if (defer_pos < 0 || (comment_pos >= 0 && comment_pos < defer_pos)) continue
             if (defer_pos > 0) {
                 var preceding_ok = false
                 peek_data(src) $(data) {
                     let ch = int(data[defer_pos - 1])
                     preceding_ok = ch == ' ' || ch == '\t'
                 }
-                if (!preceding_ok) {  //
-                    continue
-                }
+                if (!preceding_ok) continue
             }
             let pipe_pos = find(src, "<|", defer_pos + 5)
-            if (pipe_pos < 0) {  //
-                continue
-            }
+            if (pipe_pos < 0) continue
             let after_pipe = strip_left(slice(src, pipe_pos + 2))
             let pipes_block = starts_with(after_pipe, "$(") || starts_with(after_pipe, "$ ") || starts_with(after_pipe, "$\{") || starts_with(after_pipe, "@") || starts_with(after_pipe, "\{")
-            if (!pipes_block) {  //
-                continue
-            }
+            if (!pipes_block) continue
             var at = fn.at
             at.line = uint(ln)
             at.column = uint(defer_pos)
@@ -195,9 +173,7 @@ class StyleLintVisitor : AstVisitor {
 
     def check_block_pipe(call_at : LineInfo; var arguments : dasvector`ptr`Expression) : void {
         let nargs = length(arguments)
-        if (nargs == 0) {  //
-            return
-        }
+        if (nargs == 0) return
         // Find ExprMakeBlock among arguments (may not be last due to ExprFakeContext/ExprFakeLineInfo)
         for (i in range(nargs)) {
             var arg = arguments[i]
@@ -252,9 +228,7 @@ class StyleLintVisitor : AstVisitor {
         //! True for the scalar types that have a matching `operator ??` overload in
         //! daslib/json_boost — see lines 85-140 of json_boost.das. Bitfield and enum
         //! `from_JV` overloads exist but have no `??` counterpart, so they stay silent.
-        if (t == null || !empty(t.dim)) {  //
-            return false
-        }
+        if (t == null || !empty(t.dim)) return false
         let bt = t.baseType
         return (bt == Type.tInt    || bt == Type.tUInt
                 || bt == Type.tInt8  || bt == Type.tUInt8
@@ -275,9 +249,7 @@ class StyleLintVisitor : AstVisitor {
     }
 
     def check_style020_from_jv(expr : ExprCall?) : void {
-        if (expr.func == null || length(expr.arguments) < 2) {  //
-            return
-        }
+        if (expr.func == null || length(expr.arguments) < 2) return
         // The user writes `from_JV(jv, type<int>, 13)`. After template
         // instantiation (the json_boost overloads are `[template(ent)]`), expr.func
         // is the mangled `template`0x..`json_boost`from_JV`..` and the `ent` witness
@@ -286,9 +258,7 @@ class StyleLintVisitor : AstVisitor {
         let root = self->root_generic(expr.func)
         let is_from_JV = (root != null && root.name == "from_JV"
             && root._module != null && root._module.name == "json_boost")
-        if (!is_from_JV) {  //
-            return
-        }
+        if (!is_from_JV) return
         // Skip lint when current_function is itself a json_boost overload or a generic
         // instantiation of one — the dispatch chain inside JV/from_JV templates calls
         // from_JV recursively on struct fields, which would self-trigger otherwise.
@@ -303,9 +273,7 @@ class StyleLintVisitor : AstVisitor {
         // Use the call's result type — it's the scalar (or non-scalar) the user
         // would write on the RHS of `??`. Robust under both pre- and post-instantiation
         // argument shapes.
-        if (!self->is_supported_jv_scalar(expr._type)) {  //
-            return
-        }
+        if (!self->is_supported_jv_scalar(expr._type)) return
         self->style_warning("STYLE020: from_JV(v, type<T>, defV) on a supported scalar — use 'v ?? defV' (operator ?? from json_boost)", expr.at)
     }
 
@@ -315,22 +283,18 @@ class StyleLintVisitor : AstVisitor {
         //! True iff `expr` is `math::<fname>(_, _)` with exactly two arguments
         //! (peeling ExprRef2Value). Conservatively skips any non-math overload.
         let inner = self->peel_ref2value_const(expr)
-        if (inner == null || !(inner is ExprCall)) {  //
-            return false
-        }
+        if (inner == null || !(inner is ExprCall)) return false
         let call = inner as ExprCall
-        if (call.func == null || call.func.name != fname  //
+        if (call.func == null || call.func.name != fname
             || call.func._module.name != "math") return false
         return length(call.arguments) == 2
     }
 
     def check_style019_clamp(expr : ExprCall?) : void {
-        if (expr.func == null || expr.func._module.name != "math"  //
+        if (expr.func == null || expr.func._module.name != "math"
             || length(expr.arguments) != 2) return
         let outer_name = string(expr.func.name)
-        if (outer_name != "min" && outer_name != "max") {  //
-            return
-        }
+        if (outer_name != "min" && outer_name != "max") return
         let inner_name = outer_name == "min" ? "max" : "min"
         // min(max(x, lo), hi) — inner is arg[0]
         // max(min(x, hi), lo) — inner is arg[0] (mirror)
@@ -357,32 +321,22 @@ class StyleLintVisitor : AstVisitor {
     def override preVisitExprMakeStruct(var expr : ExprMakeStruct?) : void {
         // generator<T>() <| $ { ... } is lowered before lint runs — ExprMakeGenerator
         // is replaced by ExprMakeStruct. Detect via source line inspection.
-        if (expr.at.fileInfo == null || expr.at.line == 0u) {  //
-            return
-        }
+        if (expr.at.fileInfo == null || expr.at.line == 0u) return
         var src = ""
         get_file_source_line(expr.at.fileInfo, expr.at.line) $(line) {
             src := line
         }
         let col = int(expr.at.column)
-        if (col >= length(src) || !starts_with(slice(src, col), "generator<")) {  //
-            return
-        }
+        if (col >= length(src) || !starts_with(slice(src, col), "generator<")) return
         let pipe_pos = find(src, "<|", col + 10)
-        if (pipe_pos < 0) {  //
-            return
-        }
+        if (pipe_pos < 0) return
         let after_pipe = strip_left(slice(src, pipe_pos + 2))
         let pipes_block = starts_with(after_pipe, "$(") || starts_with(after_pipe, "$ ") || starts_with(after_pipe, "$\{") || starts_with(after_pipe, "@") || starts_with(after_pipe, "\{")
-        if (!pipes_block) {  //
-            return
-        }
+        if (!pipes_block) return
         let arrow_pos = find(after_pipe, "=>")
         let brace_pos = find(after_pipe, "\{")
         let is_lambda_shorthand = arrow_pos >= 0 && (brace_pos < 0 || arrow_pos < brace_pos)
-        if (is_lambda_shorthand) {  //
-            return
-        }
+        if (is_lambda_shorthand) return
         if (starts_with(after_pipe, "$()")) {
             self->style_warning("STYLE002: remove <| pipe and $() for parameterless block; use direct trailing block", expr.at)
         } else {
@@ -394,25 +348,17 @@ class StyleLintVisitor : AstVisitor {
 
     def override preVisitExprMakeBlock(var expr : ExprMakeBlock?) : void {
         var blk = expr._block
-        if (!(blk is ExprBlock)) {  //
-            return
-        }
+        if (!(blk is ExprBlock)) return
         var eblk = blk as ExprBlock
-        if (!eblk.blockFlags.isClosure || eblk.blockFlags.isLambdaBlock || !empty(eblk.arguments)) {  //
-            return
-        }
+        if (!eblk.blockFlags.isClosure || eblk.blockFlags.isLambdaBlock || !empty(eblk.arguments)) return
         let src = self->source_line_between(expr.at, eblk.at)
         let dollar_pos = find(src, "$()")
         // Skip when there is no $() at all, or when <| pipe is present
         // (STYLE002 already covers the piped form).
-        if (dollar_pos < 0 || find(src, "<|") >= 0) {  //
-            return
-        }
+        if (dollar_pos < 0 || find(src, "<|") >= 0) return
         // Skip if explicit return type follows: $() : Type { ... }
         let after_dollar = strip_left(slice(src, dollar_pos + 3))
-        if (starts_with(after_dollar, ":")) {  //
-            return
-        }
+        if (starts_with(after_dollar, ":")) return
         self->style_warning("STYLE003: remove redundant $() for parameterless block; use $ \{", expr.at)
     }
 
@@ -420,17 +366,13 @@ class StyleLintVisitor : AstVisitor {
     // --- STYLE018: b == true / b == false / b != true / b != false ---
 
     def peel_ref2value_const(e : Expression? const) : Expression? const {
-        if (e != null && e is ExprRef2Value) {  //
-            return (e as ExprRef2Value.subexpr)
-        }
+        if (e != null && e is ExprRef2Value) return (e as ExprRef2Value.subexpr)
         return e
     }
 
     def expr_equal_struct(a : Expression? const; b : Expression? const) : bool {
         //! Structural equality via describe(). No purity filter.
-        if (a == null || b == null) {  //
-            return false
-        }
+        if (a == null || b == null) return false
         return describe(a) == describe(b)
     }
 
@@ -466,19 +408,13 @@ class StyleLintVisitor : AstVisitor {
     def single_terminator_body(body : Expression? const) : Expression? const {
         //! If `body` is a bare ExprReturn/Break/Continue, or a 1-statement ExprBlock
         //! wrapping one, return the inner terminator. Otherwise null.
-        if (body == null) {  //
-            return null
-        }
-        if (body is ExprReturn || body is ExprBreak || body is ExprContinue) {  //
-            return body
-        }
+        if (body == null) return null
+        if (body is ExprReturn || body is ExprBreak || body is ExprContinue) return body
         if (body is ExprBlock) {
             let blk = body as ExprBlock
             if (length(blk.list) == 1 && empty(blk.finalList)) {
                 let stmt = blk.list[0]
-                if (stmt is ExprReturn || stmt is ExprBreak || stmt is ExprContinue) {  //
-                    return stmt
-                }
+                if (stmt is ExprReturn || stmt is ExprBreak || stmt is ExprContinue) return stmt
             }
         }
         return null
@@ -488,27 +424,15 @@ class StyleLintVisitor : AstVisitor {
         //! Two terminators have the same payload iff they are the same kind and
         //! their return-subexpr (if any) is structurally equal. Break==Break and
         //! Continue==Continue have no payload.
-        if (a == null || b == null) {  //
-            return false
-        }
-        if (a is ExprBreak) {  //
-            return b is ExprBreak
-        }
-        if (a is ExprContinue) {  //
-            return b is ExprContinue
-        }
+        if (a == null || b == null) return false
+        if (a is ExprBreak) return b is ExprBreak
+        if (a is ExprContinue) return b is ExprContinue
         if (a is ExprReturn) {
-            if (!(b is ExprReturn)) {  //
-                return false
-            }
+            if (!(b is ExprReturn)) return false
             let ra = a as ExprReturn
             let rb = b as ExprReturn
-            if (ra.subexpr == null && rb.subexpr == null) {  //
-                return true
-            }
-            if (ra.subexpr == null || rb.subexpr == null) {  //
-                return false
-            }
+            if (ra.subexpr == null && rb.subexpr == null) return true
+            if (ra.subexpr == null || rb.subexpr == null) return false
             return self->expr_equal_struct(ra.subexpr, rb.subexpr)
         }
         return false
@@ -516,14 +440,10 @@ class StyleLintVisitor : AstVisitor {
 
     def is_const_bool_return(term : Expression? const; var b_out : bool&) : bool {
         //! True if `term` is `return ExprConstBool(b)`. Writes the bool to b_out.
-        if (term == null || !(term is ExprReturn)) {  //
-            return false
-        }
+        if (term == null || !(term is ExprReturn)) return false
         let ret = term as ExprReturn
         let sub = self->peel_ref2value_const(ret.subexpr)
-        if (sub == null || !(sub is ExprConstBool)) {  //
-            return false
-        }
+        if (sub == null || !(sub is ExprConstBool)) return false
         b_out = (sub as ExprConstBool).value
         return true
     }
@@ -531,28 +451,20 @@ class StyleLintVisitor : AstVisitor {
     def unwrap_inner_ifte(if_false : Expression? const) : ExprIfThenElse? {
         //! Strip a 1-stmt ExprBlock wrapping an ExprIfThenElse, returning the inner if.
         //! Otherwise return the if_false directly cast to ExprIfThenElse?, or null.
-        if (if_false == null) {  //
-            return null
-        }
-        if (if_false is ExprIfThenElse) {  //
-            return (if_false as ExprIfThenElse)
-        }
+        if (if_false == null) return null
+        if (if_false is ExprIfThenElse) return (if_false as ExprIfThenElse)
         if (if_false is ExprBlock) {
             let blk = if_false as ExprBlock
             if (length(blk.list) == 1 && empty(blk.finalList)) {
                 let stmt = blk.list[0]
-                if (stmt is ExprIfThenElse) {  //
-                    return (stmt as ExprIfThenElse)
-                }
+                if (stmt is ExprIfThenElse) return (stmt as ExprIfThenElse)
             }
         }
         return null
     }
 
     def override preVisitExprIfThenElse(ifte : ExprIfThenElse?) : void {
-        if (ifte.if_flags.isStatic) {  //
-            return
-        }
+        if (ifte.if_flags.isStatic) return
         // STYLE010: if (true) { ... }
         var cond = ifte.cond
         if (cond is ExprConstBool) {
@@ -623,17 +535,11 @@ class StyleLintVisitor : AstVisitor {
         for (i in range(n - 1)) {
             let cur = blk.list[i]
             let nxt = blk.list[i + 1]
-            if (!(cur is ExprIfThenElse)) {  //
-                continue
-            }
+            if (!(cur is ExprIfThenElse)) continue
             let outer_if = cur as ExprIfThenElse
-            if (outer_if.if_false != null) {  //
-                continue
-            }
+            if (outer_if.if_false != null) continue
             let outer_term = self->single_terminator_body(outer_if.if_true)
-            if (outer_term == null) {  //
-                continue
-            }
+            if (outer_term == null) continue
             // STYLE016(a): adjacent guard with same payload
             if (nxt is ExprIfThenElse) {
                 let nxt_if = nxt as ExprIfThenElse
@@ -685,9 +591,7 @@ class StyleLintVisitor : AstVisitor {
     // --- STYLE012: array<T> var then contiguous push/emplace instead of literal ---
 
     def check_style012_array_init(blk : ExprBlock?; elet : ExprLet?) : void {
-        if (current_function != null && current_function.fromGeneric != null) {  //
-            return
-        }
+        if (current_function != null && current_function.fromGeneric != null) return
         // Find this ExprLet's index in the enclosing block's statement list.
         var idx = -1
         let n = length(blk.list)
@@ -697,22 +601,18 @@ class StyleLintVisitor : AstVisitor {
                 break
             }
         }
-        if (idx < 0 || idx + 1 >= n) {  //
-            return
-        }
+        if (idx < 0 || idx + 1 >= n) return
         for (v in elet.variables) {
             // Only flag uninitialized array<T> locals from user code (skip generic
             // host instantiations and compiler-synthesized vars).
-            if (v.init != null  //
+            if (v.init != null
                 || v.flags.generated || v.flags.inScope
                 || v._type == null || v._type.baseType != Type.tArray
                 || !empty(v._type.dim)) continue
             var count = 0
             for (j in range(idx + 1, n)) {
                 let stmt = blk.list[j]
-                if (!(stmt is ExprCall) || !self->is_push_or_emplace_of(stmt as ExprCall, v)) {  //
-                    break
-                }
+                if (!(stmt is ExprCall) || !self->is_push_or_emplace_of(stmt as ExprCall, v)) break
                 count++
             }
             if (count >= 2) {
@@ -724,9 +624,7 @@ class StyleLintVisitor : AstVisitor {
     // --- STYLE013: struct var with default/empty init then a run of field assignments ---
 
     def check_style013_struct_field_init(blk : ExprBlock?; elet : ExprLet?) : void {
-        if (current_function != null && current_function.fromGeneric != null) {  //
-            return
-        }
+        if (current_function != null && current_function.fromGeneric != null) return
         var idx = -1
         let n = length(blk.list)
         for (k in range(n)) {
@@ -735,19 +633,15 @@ class StyleLintVisitor : AstVisitor {
                 break
             }
         }
-        if (idx < 0 || idx + 1 >= n) {  //
-            return
-        }
+        if (idx < 0 || idx + 1 >= n) return
         for (v in elet.variables) {
             // Skip generic-host instantiations and any non-struct or non-default-init local
-            if (v.flags.generated || v.flags.inScope  //
+            if (v.flags.generated || v.flags.inScope
                 || v._type == null || v._type.baseType != Type.tStructure
                 || !empty(v._type.dim) || !self->is_default_struct_init(v)) continue
             var count = 0
             for (j in range(idx + 1, n)) {
-                if (!self->is_field_assign_of(blk.list[j], v)) {  //
-                    break
-                }
+                if (!self->is_field_assign_of(blk.list[j], v)) break
                 count++
             }
             if (count >= 2) {
@@ -763,9 +657,7 @@ class StyleLintVisitor : AstVisitor {
         return true if (v.init == null)
         return false if (!(v.init is ExprMakeStruct))
         var ms = v.init as ExprMakeStruct
-        if (ms._block != null) {  //
-            return false
-        }
+        if (ms._block != null) return false
         for (row in ms.structs) {
             for (_mf in *row) {
                 // any field present → not the zero-arg constructor
@@ -795,23 +687,17 @@ class StyleLintVisitor : AstVisitor {
     // --- STYLE021: table<string; JsonValue?> built via repeated insert → JV(named-tuple) ---
 
     def is_jv_pointer_type(t : TypeDecl?) : bool {
-        if (t == null || t.baseType != Type.tPointer || t.firstType == null) {  //
-            return false
-        }
-        if (t.firstType.baseType != Type.tHandle || t.firstType.annotation == null) {  //
-            return false
-        }
-        return string(t.firstType.annotation.name) == "JsonValue"  //
+        if (t == null || t.baseType != Type.tPointer || t.firstType == null
+                || t.firstType.baseType != Type.tHandle
+                || t.firstType.annotation == null) return false
+        return t.firstType.annotation.name == "JsonValue"
     }
 
     def is_jv_table_type(t : TypeDecl?) : bool {
         //! Matches `table<string; JsonValue?>` (or any pointer-to-JsonValue value type).
-        if (t == null || t.baseType != Type.tTable || !empty(t.dim)) {  //
-            return false
-        }
-        if (t.firstType == null || t.firstType.baseType != Type.tString) {  //
-            return false
-        }
+        if (t == null || t.baseType != Type.tTable || !empty(t.dim)
+                || t.firstType == null
+                || t.firstType.baseType != Type.tString) return false
         return self->is_jv_pointer_type(t.secondType)
     }
 
@@ -819,19 +705,15 @@ class StyleLintVisitor : AstVisitor {
         //! True when `call` is `target |> insert(<const string>, <any>)` — i.e.
         //! pipe-lowered to a 3-arg insert call on this exact variable, with a
         //! constant string key. Computed keys disqualify the chain.
-        if (call.func == null || call.func.fromGeneric == null  //
-            || string(call.func.fromGeneric.name) != "insert"  //
+        if (call.func == null || call.func.fromGeneric == null
+            || call.func.fromGeneric.name != "insert"
             || length(call.arguments) < 3) return false
         var recv = call.arguments[0]
         if (recv is ExprRef2Value) {
             recv = (recv as ExprRef2Value.subexpr)
         }
-        if (recv == null || !(recv is ExprVar)) {  //
-            return false
-        }
-        if ((recv as ExprVar).variable != target) {  //
-            return false
-        }
+        if (recv == null || !(recv is ExprVar)
+                || (recv as ExprVar).variable != target) return false
         var key = call.arguments[1]
         if (key is ExprRef2Value) {
             key = (key as ExprRef2Value.subexpr)
@@ -840,9 +722,7 @@ class StyleLintVisitor : AstVisitor {
     }
 
     def check_style021_jv_table_init(blk : ExprBlock?; elet : ExprLet?) : void {
-        if (current_function != null && current_function.fromGeneric != null) {  //
-            return
-        }
+        if (current_function != null && current_function.fromGeneric != null) return
         // Find this ExprLet's index in the enclosing block's statement list.
         var idx = -1
         let n = length(blk.list)
@@ -852,20 +732,16 @@ class StyleLintVisitor : AstVisitor {
                 break
             }
         }
-        if (idx < 0 || idx + 1 >= n) {  //
-            return
-        }
+        if (idx < 0 || idx + 1 >= n) return
         for (v in elet.variables) {
             // Only flag uninitialized table<string; JsonValue?> locals from user code.
-            if (v.init != null  //
+            if (v.init != null
                 || v.flags.generated || v.flags.inScope
                 || !self->is_jv_table_type(v._type)) continue
             var count = 0
             for (j in range(idx + 1, n)) {
                 let stmt = blk.list[j]
-                if (!(stmt is ExprCall) || !self->is_insert_of_const_key(stmt as ExprCall, v)) {  //
-                    break
-                }
+                if (!(stmt is ExprCall) || !self->is_insert_of_const_key(stmt as ExprCall, v)) break
                 count++
             }
             if (count >= 2) {
@@ -875,16 +751,14 @@ class StyleLintVisitor : AstVisitor {
     }
 
     def is_push_or_emplace_of(call : ExprCall?; target : Variable?) : bool {
-        if (call.func == null || call.func.fromGeneric == null  //
+        if (call.func == null || call.func.fromGeneric == null
             || (call.func.fromGeneric.name != "push" && call.func.fromGeneric.name != "emplace")
             || length(call.arguments) < 2) return false
         var arg = call.arguments[0]
         if (arg is ExprRef2Value) {
             arg = (arg as ExprRef2Value.subexpr)
         }
-        if (!(arg is ExprVar)) {  //
-            return false
-        }
+        if (!(arg is ExprVar)) return false
         return (arg as ExprVar).variable == target
     }
 
@@ -892,9 +766,7 @@ class StyleLintVisitor : AstVisitor {
 
     def scan_long_comment_blocks(prog : ProgramPtr) : void {
         let mod = prog.getThisModule
-        if (mod == null) {  //
-            return
-        }
+        if (mod == null) return
         var file_first_decl : table<string; uint>
         var file_max_line : table<string; uint>
         var fn_file : array<string>
@@ -902,7 +774,7 @@ class StyleLintVisitor : AstVisitor {
         var fn_ends : array<uint>
         var fn_private : array<bool>
         for_each_function(mod, "") $(var fn) {
-            if (fn.body == null || fn.at.fileInfo == null || fn.at.line == 0u  //
+            if (fn.body == null || fn.at.fileInfo == null || fn.at.line == 0u
                 || fn.flags.generated || fn.fromGeneric != null
                 || fn._module != mod || fn.moreFlags.isTemplate) return
             let fname = string(fn.at.fileInfo.name)
@@ -925,15 +797,13 @@ class StyleLintVisitor : AstVisitor {
             fn_private |> push(fn.flags.privateFunction)
         }
         for_each_structure(mod) $(var st) {
-            if (st.at.fileInfo == null || st.at.line == 0u  //
+            if (st.at.fileInfo == null || st.at.line == 0u
                 || st.flags.generated || st._module != mod || st.flags.isTemplate) return
             var is_template_instance = false
             peek(st.name) $(name) {
                 is_template_instance = find(name, "<") >= 0
             }
-            if (is_template_instance) {  //
-                return
-            }
+            if (is_template_instance) return
             let fname = string(st.at.fileInfo.name)
             let s = st.at.line
             if (file_first_decl |> key_exists(fname)) {
@@ -949,9 +819,7 @@ class StyleLintVisitor : AstVisitor {
             }
         }
         for_each_enumeration(mod) $(var en) {
-            if (en.at.fileInfo == null || en.at.line == 0u) {  //
-                return
-            }
+            if (en.at.fileInfo == null || en.at.line == 0u) return
             let fname = string(en.at.fileInfo.name)
             let s = en.at.line
             if (file_first_decl |> key_exists(fname)) {
@@ -967,9 +835,7 @@ class StyleLintVisitor : AstVisitor {
             }
         }
         for_each_global(mod) $(var v) {
-            if (v.at.fileInfo == null || v.at.line == 0u || v.flags.generated) {  //
-                return
-            }
+            if (v.at.fileInfo == null || v.at.line == 0u || v.flags.generated) return
             let fname = string(v.at.fileInfo.name)
             let s = v.at.line
             if (file_first_decl |> key_exists(fname)) {
@@ -985,9 +851,7 @@ class StyleLintVisitor : AstVisitor {
             }
         }
         for_each_typedef(mod) $(name, value) {
-            if (value.at.fileInfo == null || value.at.line == 0u) {  //
-                return
-            }
+            if (value.at.fileInfo == null || value.at.line == 0u) return
             let fname = string(value.at.fileInfo.name)
             let s = value.at.line
             if (file_first_decl |> key_exists(fname)) {
@@ -1004,70 +868,52 @@ class StyleLintVisitor : AstVisitor {
         }
         var seen : table<string; bool>
         for_each_function(mod, "") $(var fn) {
-            if (fn.at.fileInfo == null || fn._module != mod  //
+            if (fn.at.fileInfo == null || fn._module != mod
                 || fn.flags.generated || fn.fromGeneric != null || fn.moreFlags.isTemplate) return
             let fname = string(fn.at.fileInfo.name)
-            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) {  //
-                return
-            }
+            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) return
             seen |> insert(fname, true)
             self->scan_file_lines(fn.at, fname,
                 file_first_decl[fname], file_max_line[fname],
                 fn_file, fn_starts, fn_ends, fn_private)
         }
         for_each_structure(mod) $(var st) {
-            if (st.at.fileInfo == null || st._module != mod  //
+            if (st.at.fileInfo == null || st._module != mod
                 || st.flags.generated || st.flags.isTemplate) return
             var is_template_instance = false
             peek(st.name) $(name) {
                 is_template_instance = find(name, "<") >= 0
             }
-            if (is_template_instance) {  //
-                return
-            }
+            if (is_template_instance) return
             let fname = string(st.at.fileInfo.name)
-            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) {  //
-                return
-            }
+            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) return
             seen |> insert(fname, true)
             self->scan_file_lines(st.at, fname,
                 file_first_decl[fname], file_max_line[fname],
                 fn_file, fn_starts, fn_ends, fn_private)
         }
         for_each_enumeration(mod) $(var en) {
-            if (en.at.fileInfo == null) {  //
-                return
-            }
+            if (en.at.fileInfo == null) return
             let fname = string(en.at.fileInfo.name)
-            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) {  //
-                return
-            }
+            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) return
             seen |> insert(fname, true)
             self->scan_file_lines(en.at, fname,
                 file_first_decl[fname], file_max_line[fname],
                 fn_file, fn_starts, fn_ends, fn_private)
         }
         for_each_global(mod) $(var v) {
-            if (v.at.fileInfo == null || v.flags.generated) {  //
-                return
-            }
+            if (v.at.fileInfo == null || v.flags.generated) return
             let fname = string(v.at.fileInfo.name)
-            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) {  //
-                return
-            }
+            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) return
             seen |> insert(fname, true)
             self->scan_file_lines(v.at, fname,
                 file_first_decl[fname], file_max_line[fname],
                 fn_file, fn_starts, fn_ends, fn_private)
         }
         for_each_typedef(mod) $(name, value) {
-            if (value.at.fileInfo == null) {  //
-                return
-            }
+            if (value.at.fileInfo == null) return
             let fname = string(value.at.fileInfo.name)
-            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) {  //
-                return
-            }
+            if ((seen |> key_exists(fname)) || !file_first_decl |> key_exists(fname)) return
             seen |> insert(fname, true)
             self->scan_file_lines(value.at, fname,
                 file_first_decl[fname], file_max_line[fname],
@@ -1091,9 +937,7 @@ class StyleLintVisitor : AstVisitor {
                 got = true
                 line_text = string(s)
             }
-            if (!got) {  //
-                break
-            }
+            if (!got) break
             let trimmed = strip_left(line_text)
             let is_comment = starts_with(trimmed, "//")
             if (is_comment) {
@@ -1142,16 +986,14 @@ class StyleLintVisitor : AstVisitor {
                           fn_private : array<bool>) : void {
         // Skip when the block is too short, lives before the first AST decl
         // (module-leading docstring), or carries an explicit @nolint marker.
-        if (line_count <= 1  //
+        if (line_count <= 1
             || block_start < first_decl_line
             || self->has_nolint_directive(first_line_text)) return
         var enclosing_priv = false
         var inside_function = false
         var enclosing_size : uint = 0xFFFFFFFFu
         for (i in range(length(fn_file))) {
-            if (fn_file[i] != file_name) {  //
-                continue
-            }
+            if (fn_file[i] != file_name) continue
             let s = fn_starts[i]
             let e = fn_ends[i]
             if (s <= block_start && block_start <= e) {
@@ -1165,9 +1007,7 @@ class StyleLintVisitor : AstVisitor {
         }
         let private_ctx = inside_function && enclosing_priv
         let threshold = private_ctx ? 1 : 3
-        if (line_count <= threshold) {  //
-            return
-        }
+        if (line_count <= threshold) return
         var at = sample_at
         at.line = block_start
         at.last_line = block_start
@@ -1193,9 +1033,7 @@ class StyleLintVisitor : AstVisitor {
         }
         return false if (inner == null || !(inner is ExprCall))
         var call = inner as ExprCall
-        if (call.name != "string" || empty(call.arguments)) {  //
-            return false
-        }
+        if (call.name != "string" || empty(call.arguments)) return false
         var arg = call.arguments[0]
         if (arg is ExprRef2Value) {
             arg = (arg as ExprRef2Value.subexpr)

--- a/daslib/templates_boost.das
+++ b/daslib/templates_boost.das
@@ -322,7 +322,7 @@ class private TemplateVisitor : AstVisitor {
     }
     def preVisitAnythingCall(var arguments : dasvector`ptr`Expression) : void {
         //! Visits call arguments and applies variable expression list replacement rules.
-        if (length(rules.var2exprList) == 0) return
+        if (empty(rules.var2exprList)) return
         let nargs = arguments |> length
         if (nargs == 0) return
         for (ai in range(nargs)) {
@@ -332,6 +332,7 @@ class private TemplateVisitor : AstVisitor {
                 let vname = string((arg as ExprVar).name)
                 if (key_exists(rules.var2exprList, vname)) {
                     var new_args : array<Expression?>
+                    new_args |> reserve(length(rules.var2exprList[vname]))
                     for (a in rules.var2exprList[vname]) {
                         new_args |> push(clone_expression(a))
                     }

--- a/daslib/typemacro_boost.das
+++ b/daslib/typemacro_boost.das
@@ -41,9 +41,9 @@ def append_expressions(var blk : ExprBlock?; var eblk : ExpressionPtr) {
 def is_typedecl_ptr(t : TypeDeclPtr) {
     if (t.baseType != Type.tPointer) return false
     assume pt = t.firstType
-    if (pt == null) return false
-    if (pt.baseType != Type.tHandle || pt.annotation.name != "TypeDecl" || pt.annotation._module.name != "ast_core") return false
-    return true
+    return (pt != null && pt.baseType == Type.tHandle
+            && pt.annotation.name == "TypeDecl"
+            && pt.annotation._module.name == "ast_core")
 }
 
 [macro_function]
@@ -177,7 +177,7 @@ class TypeMacroMacro : AstFunctionAnnotation {
             let macroArgIndex = ai - 1
             assume argType = func.arguments[ai]._type
             assume argDefaultValue = func.arguments[ai].init
-            if (length(argType.dim) > 0) {
+            if (!empty(argType.dim)) {
                 errors := "expecting non-array arguments"
                 return false
             }
@@ -256,12 +256,11 @@ def public is_typemacro_template_instance(passArgument, templateType : TypeDeclP
     for (ann in passArgument.structType.annotations) {
         if (ann.annotation.name == "typemacro_template") {
             let parentName = find_arg(ann.arguments, "parent")
-            return false if (!(parentName is tString))
-            return false if ((parentName as tString) != "{templateType.structType._module.name}::{templateType.structType.name}")
+            return false if (!(parentName is tString)
+                    || (parentName as tString) != "{templateType.structType._module.name}::{templateType.structType.name}")
             for (ex in extra) {
                 let arg = find_arg(ann.arguments, ex._0)
-                return false if (!(arg is tString))
-                return false if ((arg as tString) != ex._1)
+                return false if (!(arg is tString) || (arg as tString) != ex._1)
             }
             return true
         }
@@ -294,8 +293,8 @@ def public infer_template_types(passArgument : TypeDeclPtr; var args  : array<Ty
         assume inferredTemplateType = arg.inferred_type
         if (templateType.isAutoOrAlias) {
             var resT = infer_generic_type(templateType, inferredTemplateType, true, true)
-            return null if (resT == null)
-            return null if (!inferredTemplateType |> is_same_type(resT, RefMatters.no, ConstMatters.no, TemporaryMatters.yes))
+            return null if (resT == null
+                    || !inferredTemplateType |> is_same_type(resT, RefMatters.no, ConstMatters.no, TemporaryMatters.yes))
             compiling_program() |> update_alias_map(templateType, resT)
         } else {
             return null if (!inferredTemplateType |> is_same_type(templateType, RefMatters.no, ConstMatters.no, TemporaryMatters.yes))
@@ -434,7 +433,7 @@ class TemplateTypeMacroMacro : AstFunctionAnnotation {
                 mk_extra_array_expr.values |> emplace(mk_tuple)
             }
         }
-        if (length(mk_extra_array_expr.values) == 0) {
+        if (empty(mk_extra_array_expr.values)) {
             body.list |> emplace_new <| qmacro_expr() {
                 var inscope extra_template_arguments : array<tuple<string, string>>
             }

--- a/daslib/unroll.das
+++ b/daslib/unroll.das
@@ -44,7 +44,7 @@ class UnrollMacro : AstFunctionAnnotation {
         assert(call.arguments[0] is ExprMakeBlock)
         var mblk = unsafe(reinterpret<ExprMakeBlock?>(call.arguments[0]))
         var blk = unsafe(reinterpret<ExprBlock?>(mblk._block))
-        if (blk.finalList |> length != 0) {
+        if (!empty(blk.finalList)) {
             errors := "not expecting finally section in the unroll"
             return null
         }

--- a/daslib/utf8_utils.das
+++ b/daslib/utf8_utils.das
@@ -303,11 +303,11 @@ def public utf32_to_lower(cp : uint) : uint {
     if (cp >= 0x14Au && cp <= 0x177u) return ((cp & 1u) == 0u) ? cp + 1u : cp
     if (cp == 0x178u) return 0xFFu  // Ÿ → ÿ
     if (cp >= 0x179u && cp <= 0x17Eu) return ((cp & 1u) == 1u) ? cp + 1u : cp
-    // Greek: Α-Ω (0x391..0x3A9) → α-ω (0x3B1..0x3C9), excluding 0x3A2 (reserved).
-    if (cp >= 0x391u && cp <= 0x3A1u) return cp + 0x20u
-    if (cp >= 0x3A3u && cp <= 0x3ABu) return cp + 0x20u
-    // Cyrillic: А-Я (0x410..0x42F) → а-я (0x430..0x44F).
-    if (cp >= 0x410u && cp <= 0x42Fu) return cp + 0x20u
+    // Greek Α-Ω (0x391..0x3A9, excl. 0x3A2 reserved) → α-ω;
+    // Cyrillic А-Я (0x410..0x42F) → а-я; all shift by 0x20.
+    if ((cp >= 0x391u && cp <= 0x3A1u)
+            || (cp >= 0x3A3u && cp <= 0x3ABu)
+            || (cp >= 0x410u && cp <= 0x42Fu)) return cp + 0x20u
     // Cyrillic: Ё (0x401) → ё (0x451), plus Ѐ-Џ (0x400..0x40F) → ѐ-џ (0x450..0x45F).
     if (cp >= 0x400u && cp <= 0x40Fu) return cp + 0x50u
     return cp

--- a/daslib/validate_code.das
+++ b/daslib/validate_code.das
@@ -50,8 +50,7 @@ def check_recursive(at : LineInfo; var fun : Function?) {
 
 [macro_function]
 def collect_call_tree(fun : Function?; var visited : table<Function?>) {
-    if (fun.flags.builtIn) return
-    if (visited |> key_exists(fun)) return
+    if (fun.flags.builtIn || visited |> key_exists(fun)) return
     visited |> insert(fun)
     unsafe(reinterpret<FunctionPtr> fun) |> get_use_functions() $(f) {
         collect_call_tree(f, visited)
@@ -167,8 +166,10 @@ class JIT_LLVM : AstSimulateMacro {
         }
     }
     def override simulate(prog : Program?; var ctx : Context?) : bool {
-        return true if (is_in_completion() || is_compiling_macros())
-        return true if (ctx.category.debug_context || ctx.category.macro_context || ctx.category.folding_context || ctx.category.debugger_tick || ctx.category.debugger_attached)
+        return true if (is_in_completion() || is_compiling_macros()
+                || ctx.category.debug_context || ctx.category.macro_context
+                || ctx.category.folding_context || ctx.category.debugger_tick
+                || ctx.category.debugger_attached)
         if (prog._options |> find_arg("shader_like") ?as tBool ?? false) {
             lint_module(prog, ctx)
             return true

--- a/dastest/testing.das
+++ b/dastest/testing.das
@@ -144,9 +144,7 @@ struct BenchmarkRunStats {
 }
 
 def equal(tb : Asserter?; a; b; msg = "") : bool {
-    if (a == b) {
-        return true
-    }
+    if (a == b) return true
     tb->errorAt(!empty(msg) ? msg : "values differ", get_line_info(1))
     tb->errorAt("\texpected: {a}", get_line_info(1))
     tb->errorAt("\tgot: {b}", get_line_info(1))
@@ -177,9 +175,7 @@ def accept(tb : Asserter?; value) {
 }
 
 def strictEqual(tb : Asserter?; a; b; msg = "") : bool {
-    if (a == b) {
-        return true
-    }
+    if (a == b) return true
     tb->errorAt(!empty(msg) ? msg : "values differ", get_line_info(1))
     tb->errorAt("\texpected: {a}", get_line_info(1))
     tb->fatalAt("\tgot: {b}", get_line_info(1))
@@ -187,9 +183,7 @@ def strictEqual(tb : Asserter?; a; b; msg = "") : bool {
 }
 
 def strictEqual(tb : Asserter?; a, b : float; msg = "") : bool {
-    if (float_bits_to_int(a) == float_bits_to_int(b)) {
-        return true
-    }
+    if (float_bits_to_int(a) == float_bits_to_int(b)) return true
     tb->errorAt(!empty(msg) ? msg : "values differ", get_line_info(1))
     tb->errorAt("\texpected: {a}", get_line_info(1))
     tb->fatalAt("\tgot: {b}", get_line_info(1))
@@ -197,9 +191,7 @@ def strictEqual(tb : Asserter?; a, b : float; msg = "") : bool {
 }
 
 def strictEqual(tb : Asserter?; a, b : float2; msg = "") : bool {
-    if (float_bits_to_int(a) == float_bits_to_int(b)) {
-        return true
-    }
+    if (float_bits_to_int(a) == float_bits_to_int(b)) return true
     tb->errorAt(!empty(msg) ? msg : "values differ", get_line_info(1))
     tb->errorAt("\texpected: {a}", get_line_info(1))
     tb->fatalAt("\tgot: {b}", get_line_info(1))
@@ -207,9 +199,7 @@ def strictEqual(tb : Asserter?; a, b : float2; msg = "") : bool {
 }
 
 def strictEqual(tb : Asserter?; a, b : float3; msg = "") : bool {
-    if (float_bits_to_int(a) == float_bits_to_int(b)) {
-        return true
-    }
+    if (float_bits_to_int(a) == float_bits_to_int(b)) return true
     tb->errorAt(!empty(msg) ? msg : "values differ", get_line_info(1))
     tb->errorAt("\texpected: {a}", get_line_info(1))
     tb->fatalAt("\tgot: {b}", get_line_info(1))
@@ -217,9 +207,7 @@ def strictEqual(tb : Asserter?; a, b : float3; msg = "") : bool {
 }
 
 def strictEqual(tb : Asserter?; a, b : float4; msg = "") : bool {
-    if (float_bits_to_int(a) == float_bits_to_int(b)) {
-        return true
-    }
+    if (float_bits_to_int(a) == float_bits_to_int(b)) return true
     tb->errorAt(!empty(msg) ? msg : "values differ", get_line_info(1))
     tb->errorAt("\texpected: {a}", get_line_info(1))
     tb->fatalAt("\tgot: {b}", get_line_info(1))
@@ -228,9 +216,7 @@ def strictEqual(tb : Asserter?; a, b : float4; msg = "") : bool {
 
 
 def strictEqual(tb : Asserter?; a, b : double; msg = "") : bool {
-    if (double_bits_to_int64(a) == double_bits_to_int64(b)) {
-        return true
-    }
+    if (double_bits_to_int64(a) == double_bits_to_int64(b)) return true
     tb->errorAt(!empty(msg) ? msg : "values differ", get_line_info(1))
     tb->errorAt("\texpected: {a}", get_line_info(1))
     tb->fatalAt("\tgot: {b}", get_line_info(1))
@@ -238,9 +224,7 @@ def strictEqual(tb : Asserter?; a, b : double; msg = "") : bool {
 }
 
 def numericEqual(tb : Asserter?; a; b; msg = "") : bool {
-    if (a == b) {
-        return true
-    }
+    if (a == b) return true
     tb->errorAt(!empty(msg) ? msg : "numeric values differ", get_line_info(1))
     tb->errorAt("\texpected: {a}", get_line_info(1))
     tb->fatalAt("\tgot: {b}", get_line_info(1))
@@ -248,12 +232,7 @@ def numericEqual(tb : Asserter?; a; b; msg = "") : bool {
 }
 
 def numericEqual(tb : Asserter?; a, b : float; msg = "") : bool {
-    if (is_nan(a) && is_nan(b)) {
-        return true
-    }
-    if (a == b) {
-        return true
-    }
+    if ((is_nan(a) && is_nan(b)) || a == b) return true
     tb->errorAt(!empty(msg) ? msg : "numeric values differ", get_line_info(1))
     tb->errorAt("\texpected: {a}", get_line_info(1))
     tb->fatalAt("\tgot: {b}", get_line_info(1))
@@ -271,9 +250,7 @@ def numericEqual(tb : Asserter?; _a, _b : float2; msg = "") : bool {
         a.y = 0.
         b.y = 0.
     }
-    if (a == b) {
-        return true
-    }
+    if (a == b) return true
     tb->errorAt(!empty(msg) ? msg : "numeric values differ", get_line_info(1))
     tb->errorAt("\texpected: {_a}", get_line_info(1))
     tb->fatalAt("\tgot: {_b}", get_line_info(1))
@@ -295,9 +272,7 @@ def numericEqual(tb : Asserter?; _a, _b : float3; msg = "") : bool {
         a.z = 0.
         b.z = 0.
     }
-    if (a == b) {
-        return true
-    }
+    if (a == b) return true
     tb->errorAt(!empty(msg) ? msg : "numeric values differ", get_line_info(1))
     tb->errorAt("\texpected: {_a}", get_line_info(1))
     tb->fatalAt("\tgot: {_b}", get_line_info(1))
@@ -323,9 +298,7 @@ def numericEqual(tb : Asserter?; _a, _b : float4; msg = "") : bool {
         a.w = 0.
         b.w = 0.
     }
-    if (a == b) {
-        return true
-    }
+    if (a == b) return true
     tb->errorAt(!empty(msg) ? msg : "numeric values differ", get_line_info(1))
     tb->errorAt("\texpected: {_a}", get_line_info(1))
     tb->fatalAt("\tgot: {_b}", get_line_info(1))
@@ -333,12 +306,7 @@ def numericEqual(tb : Asserter?; _a, _b : float4; msg = "") : bool {
 }
 
 def numericEqual(tb : Asserter?; a, b : double; msg = "") : bool {
-    if (is_nan(a) && is_nan(b)) {
-        return true
-    }
-    if (a == b) {
-        return true
-    }
+    if ((is_nan(a) && is_nan(b)) || a == b) return true
     tb->errorAt(!empty(msg) ? msg : "values differ", get_line_info(1))
     tb->errorAt("\texpected: {a}", get_line_info(1))
     tb->fatalAt("\tgot: {b}", get_line_info(1))
@@ -346,9 +314,7 @@ def numericEqual(tb : Asserter?; a, b : double; msg = "") : bool {
 }
 
 def success(tb : Asserter?; a; msg = "") : bool {
-    if (a) {
-        return true
-    }
+    if (a) return true
     tb->errorAt(!empty(msg) ? msg : "expected success, got failure", get_line_info(1))
     return false
 }
@@ -441,7 +407,7 @@ def private run_impl(b : B?, name : string; chunk_size : int64; op : block) {
         // A fast/small benchmarking func - run the timers
         // once, unroll the body to minimize the noise.
         let start = ref_time_ticks()
-        for (i in range(loop_runs)) {
+        for (_i in range(loop_runs)) {
             unroll() $ {
                 for (_ in range(unroll_count)) {
                     op()
@@ -452,7 +418,7 @@ def private run_impl(b : B?, name : string; chunk_size : int64; op : block) {
     } else {
         // A long-running benchmark that should not be unrolled.
         // Its run time will not be dominated by the loop anyway.
-        for (i in range(loop_runs)) {
+        for (_i in range(loop_runs)) {
             let start = ref_time_ticks()
             op()
             time_total += get_time_nsec(start)

--- a/modules/dasPEG/peg/parse_macro.das
+++ b/modules/dasPEG/peg/parse_macro.das
@@ -418,8 +418,7 @@ class ParseMacro : AstCallMacro {
                 parser.input := inp
             }
 
-            var result : $t(unsafe(gen.return_types[gram[0].name]))
-            result <- $c(parse_main_func)(parser)
+            var result : $t(unsafe(gen.return_types[gram[0].name])) <- $c(parse_main_func)(parser)
 
             if (result.success) {
                 invoke(blk, result.value, array<ParsingError>())

--- a/utils/fix-lint-errors/main.das
+++ b/utils/fix-lint-errors/main.das
@@ -76,15 +76,15 @@ class FixerVisitor : AstVisitor {
 
     def override preVisitFunction(var fn : FunctionPtr) : void {
         current_function = fn
-        // Skip BOTH `[template]` and `[macro_function]` bodies. The latter's AST
-        // contains macro-substituted nodes whose `.at` doesn't reliably point at
-        // user-written source; rewriting via those positions corrupts the file.
-        // Also skip `flags.generated` — synthesized functions from struct
+        // Skip `flags.generated` — synthesized functions from struct
         // annotations like `[CommandLineArgs]` carry the struct's LineInfo
         // throughout their body, so a `length(args) == 0` check inside the
         // generated parse_args would rewrite to a span starting at the struct
         // definition (massive corruption observed on utils/daspkg/commands.das).
-        in_template = fn.moreFlags.isTemplate || fn.moreFlags.macroFunction || fn.flags.generated
+        // `isTemplate`/`macroFunction` bodies are user-written daslang code —
+        // their AST `.at` points at real source; post-rewrite `try_compile`
+        // verification catches any edge case that slips through.
+        in_template = fn.flags.generated
     }
 
     def override visitFunction(var fn : FunctionPtr) : FunctionPtr {
@@ -442,11 +442,13 @@ class FixerVisitor : AstVisitor {
         //! and rightmost_pos_of can derive exact bounds from the AST without
         //! needing to read invisible-in-AST tokens (parens, deref `*`).
         //! Chain shapes walk recursively (ExprField → value, ExprAt → subexpr).
-        //! ExprPtr2Ref is NOT safe — parens around `(*pv)` aren't in AST so
-        //! leftmost lands on the `*`, missing the leading `(`.
+        //! ExprRef2Value is a typer artifact (invisible in source) and is
+        //! peeled transparently. ExprPtr2Ref is NOT — parens around `(*pv)`
+        //! aren't in the AST so leftmost lands on the `*`, missing `(`.
         //! ExprCall with a backticked property name (`.foo` form) is also
         //! NOT safe — the call's source extent depends on hidden arg ordering.
         return false if (e == null)
+        if (e is ExprRef2Value) return self->is_simple_subject((e as ExprRef2Value).subexpr)
         if (e is ExprConstString || e is ExprConstInt || e is ExprConstUInt
                 || e is ExprConstBool || e is ExprConstFloat || e is ExprConstDouble
                 || e is ExprVar) return true


### PR DESCRIPTION
## Summary

Three layers of lint cleanup landed together. End state: `daslib/` lints **0 issues** (was 408 at session start), `dastest/testing.das` lints clean.

### 1. LINT001 false-positive fix (`daslib/lint.das`)

Braceless `if (cond) <terminator>` (the form **STYLE005 actively asks for**) triggered a false LINT001 on the next sibling statement. The visitor's `preVisitExprReturn` / `preVisitExprCall(panic)` wrote the return pointer onto the *enclosing* block's stack slot whenever ANY return/panic was walked — which poisoned the outer block when the return was nested inside an `ExprIf` body that has no surrounding `ExprBlock` (the AST shape for `if (cond) return X`).

Move terminator tracking into `visitExprBlockExpression` so only **direct block children** mark their enclosing block. Resolves the LINT001 hits in `daslib/json_boost.das` that surfaced after STYLE005 rewrote `} elif (cond) { return X }` to `} elif (cond) return X`.

`daslib/lint.das`'s own STYLE016 / STYLE005 warnings cleaned up alongside.

### 2. Auto-fixer improvements (`utils/fix-lint-errors/main.das`)

- **`is_simple_subject` now peels `ExprRef2Value`** (a typer artifact). PERF017 was silently skipping ~60 daslib hits where the AST wraps the receiver in Ref2Value (e.g. `length(blk.list) == 0` — `blk.list` is `ExprField` whose `.value` is `ExprRef2Value(ExprVar)`).
- **`preVisitFunction`'s `in_template` gate** drops `isTemplate` and `macroFunction`. Those bodies are user-written daslang with reliable `.at`. Only `flags.generated` stays skipped — the documented struct-annotation corruption case from `utils/daspkg/commands.das`. Post-rewrite `try_compile` verification continues to catch any edge case (and successfully caught two during the sweep — `decs_boost` + `match` reverted automatically without polluting the diff).

### 3. daslib + dastest sweep (408 → 0)

- **`dastest/testing.das`**: 16 STYLE005 in `equal` / `success`, 2 STYLE016 NaN guards in `numericEqual` float/double, 2 LINT002 rename unused `i` → `_i` in benchmark loops. Cross-module STYLE005 leaked into every `test_*` file until dastest itself was clean.
- **174 empty `//` trailing markers stripped** from `daslib/perf_lint.das` (78) and `daslib/style_lint.das` (96). Leftover noise that was blocking the auto-fixer's text-extraction sanity check.
- **Auto-fixer sweep on daslib**: ~190 mechanical rewrites across ~30 files. Mostly STYLE005 in `perf_lint`/`style_lint`, PERF017 in `ast_match`/`rst`/`decs_boost`/`contracts`/`is_local`/`spoof`, and others.
- **Hand-finish on the long tail (~234 → 0)**: STYLE016 adjacent-guard merges across `rst`/`ast_boost`/`ast_match`/`das_source_formatter`/`fio`/`clargs`/`coverage`/`interfaces`/`jobque_boost`/`aot_cpp`/`fts5_query`/`profiler`/`utf8_utils`/`validate_code`/`linq_boost`; PERF014 `nolint` markers on `regex.das` char-class primitives + `strings_boost.das` ASCII case-shift; PERF015 `min/max` ternaries → `math::min`/`math::max` (with `require math` added in `fio` / `jobque_boost` / `regex_boost`); PERF006 `reserve`-before-`push`-in-loop in `bitfield_trait` / `delegate` / `match` / `templates_boost`; PERF007 `string(das_string) == "..."` strips in `ast.das` / `perf_lint` / `style_lint`; STYLE017 collapses in `aot_cpp` / `typemacro_boost` / `jobque_boost` / `ast_match`; STYLE013 named-arg ctor in `perf_lint`; `builtin.das` `find_index` / `find_index_if` / `has_value` / `sort` one-line guards (the cross-module STYLE005 instantiation sources).
- **`modules/dasPEG/peg/parse_macro.das`**: STYLE011 single-line move-init.

## Numbers

- 58 files changed, 312 insertions / 399 deletions (net deletion — codebase shrinks).
- `daslib/` lint: 408 → 0 issues.
- Tests: 8014 pass, 0 fail (interpreted) + 7408 pass, 0 fail (AOT).

## Test plan

- [x] `bin/Release/daslang.exe utils/lint/main.das -- daslib/ dastest/` — 0 hits in changed files
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests` — 8014/8014 pass
- [x] `cmake --build build --config Release --target test_aot -j 64` — clean build
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — 7408/7408 pass
- [x] MCP `format_file` on all 58 changed `.das` files — already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)