### PR TITLE
build: install runtime_iterator.h with the SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -876,6 +876,7 @@ include/daScript/simulate/debug_info.h
 include/daScript/simulate/interop.h
 include/daScript/simulate/runtime_string.h
 include/daScript/simulate/runtime_string_delete.h
+include/daScript/simulate/runtime_iterator.h
 include/daScript/simulate/runtime_array.h
 include/daScript/simulate/runtime_table.h
 include/daScript/simulate/runtime_table_nodes.h
@@ -1355,6 +1356,7 @@ SET(DAS_SIMULATE_INCLUDES
     include/daScript/simulate/interop.h
     include/daScript/simulate/jit_abi.h
     include/daScript/simulate/runtime_array.h
+    include/daScript/simulate/runtime_iterator.h
     include/daScript/simulate/runtime_matrices.h
     include/daScript/simulate/runtime_profile.h
     include/daScript/simulate/runtime_range.h


### PR DESCRIPTION
## Summary

Commit 5483e95e1 ("compiler: extract runtime_iterator") added `src/simulate/runtime_iterator.cpp` to the build but missed `include/daScript/simulate/runtime_iterator.h` from the install lists. The header is widely included from public SDK surface:

- `daScript/simulate/aot.h`
- `daScript/simulate/aot_builtin.h`
- `daScript/simulate/runtime_array.h`
- `daScript/simulate/runtime_range.h`
- `daScript/simulate/runtime_table_nodes.h`
- `daScript/simulate/simulate_nodes.h`
- `daScript/ast/ast_typedecl.h`

So every downstream SDK consumer pulling `aot.h` (e.g. `dasProfile/test_profile.h`) hits a missing-header error against an otherwise valid install tree:

```
fatal error: 'daScript/simulate/runtime_iterator.h' file not found
```

Reproduced locally against `~/daslang` populated via `cmake --install build`. Fix is to add the header in two places (one for install, one for IDE source-group consistency next to the existing `.cpp` entry).

## Test plan

- [x] Wipe and reinstall `~/daslang` via `cmake --install build --config Release`
- [x] Verify `~/daslang/include/daScript/simulate/runtime_iterator.h` lands
- [x] Clean-rebuild downstream consumer (`dasProfile`) against the install — 232/232 ninja steps green
- [x] Run `daslang -jit dasProfile/main.das` — boots, banner reports `LLVM: 22.1.5`, benchmark suite executes across DAS AOT/JIT/INTERPRETER + C++/Lua/Luau/LuaJIT/Quirrel/QuickJS/Mono/.NET

🤖 Generated with [Claude Code](https://claude.com/claude-code)