### PR TITLE
dasGlfw: key+char chain dispatcher + glfw_live keyboard driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ build-asan/
 build-ubsan/
 build-linux-asan/
 build-linux/
+# daspkg per-package cmake build dirs (utils/daspkg/commands.das:976 -> {pkg_dir}/_build)
+_build/
+modules/**/_build/
 # All build binaries stored here
 bin/
 # JIT stores dll's here

--- a/modules/dasGlfw/dasglfw/glfw_live.das
+++ b/modules/dasGlfw/dasglfw/glfw_live.das
@@ -197,6 +197,12 @@ def private synth_mouse_button(button, action : int) {
 }
 
 def private release_held_buttons() {
+    // No window = nothing to dispatch to; drop bookkeeping (matches
+    // release_held_keys above).
+    if (live_window == null) {
+        synth_held_buttons |> clear()
+        return
+    }
     // Same snapshot-before-iterate pattern as release_held_keys —
     // synth_mouse_button erases from synth_held_buttons.
     var held : array<int>
@@ -505,6 +511,13 @@ def private reset_key_timeline_state() {
 }
 
 def private release_held_keys() {
+    // No window = nothing to dispatch to; drop bookkeeping and return so
+    // key_stop stays safe to call after live_destroy_window() (or before
+    // live_create_window()) without passing a null GLFWwindow* into C++.
+    if (live_window == null) {
+        synth_held_keys |> clear()
+        return
+    }
     // Snapshot first — synth_key_release erases from synth_held_keys, which
     // would invalidate iteration. Same pattern as the `for (k in keys(t))` /
     // mutate-t fix in feedback_for_keys_table_locked.md.

--- a/modules/dasGlfw/dasglfw/glfw_live.das
+++ b/modules/dasGlfw/dasglfw/glfw_live.das
@@ -27,6 +27,7 @@ require daslib/json_boost
 require live/live_commands
 require live_host
 require math
+require strings
 
 var public live_window : GLFWwindow?
 
@@ -402,5 +403,380 @@ def mouse_tick() {
                 synth_cursor_pos(x, y)
             }
         }
+    }
+}
+
+// ============================================================================
+// Synthetic keyboard driver
+// ============================================================================
+//
+// Mirrors the mouse driver: one-shot helpers (`key_press`/`key_release`/`key_char`),
+// chord sugar (`key_chord`), text streaming (`key_type`), and scripted timeline
+// playback (`key_play`). Synth events go through dasGLFW's key/char chain
+// dispatchers — ImGui_ImplGlfw_KeyCallback / _CharCallback receive them via the
+// chain, so widgets see them as real input. No `apply_synth_io_override` is
+// needed for keys: ImGui_ImplGlfw_NewFrame does not poll glfwGetKey per frame
+// (key state is event-driven), so a single chain dispatch suffices.
+
+enum private KEKind {
+    press
+    release
+    char_
+}
+
+struct private KeyEvent {
+    t_ms      : int    = 0
+    kind      : KEKind = KEKind.press
+    keycode   : int    = 0
+    scancode  : int    = 0
+    mods      : int    = 0
+    codepoint : uint   = 0u
+}
+
+var private key_timeline     : array<KeyEvent>
+var private key_play_start_t : float = 0.0
+var private key_play_idx     : int   = 0
+var private key_playing      : bool  = false
+
+// Public state read by visual_aids for the keycap HUD.
+var public synth_held_keys           : table<int>       //! set of currently-held GLFW keycodes
+var public synth_last_keycode        : int   = 0        //! last GLFW keycode synth-pressed; 0 = none
+var public synth_last_keycode_t      : float = -1.0     //! get_uptime() at last keycode press; -1 = none
+var public synth_last_codepoint      : uint  = 0u       //! last Unicode codepoint synth-typed; 0 = none
+var public synth_last_codepoint_t    : float = -1.0     //! get_uptime() at last codepoint event; -1 = none
+
+def private synth_key_press(keycode, scancode, mods : int) {
+    glfw_post_key(live_window, keycode, scancode, 1, mods)
+    synth_held_keys |> insert(keycode)
+    synth_last_keycode   = keycode
+    synth_last_keycode_t = get_uptime()
+}
+
+def private synth_key_release(keycode, scancode, mods : int) {
+    glfw_post_key(live_window, keycode, scancode, 0, mods)
+    synth_held_keys |> erase(keycode)
+}
+
+def private synth_char(codepoint : uint) {
+    glfw_post_char(live_window, codepoint)
+    synth_last_codepoint   = codepoint
+    synth_last_codepoint_t = get_uptime()
+}
+
+def public get_synth_keys() : tuple<bool; uint; float> {
+    //! (active, last_codepoint, last_codepoint_t). Visual aids read this each
+    //! frame to detect "a new codepoint just landed" (push a keycap into the
+    //! HUD when last_codepoint_t advances). Modifier-strip lights from
+    //! `IsKeyDown(ImGuiKey_*)` direct — ImGui already reflects synth events
+    //! via the chain, no separate plumbing needed.
+    return (key_playing, synth_last_codepoint, synth_last_codepoint_t)
+}
+
+def private reset_key_timeline_state() {
+    key_timeline |> clear()
+    key_play_idx = 0
+    key_playing  = false
+}
+
+struct KeyPressArgs {
+    keycode           : int = 0
+    @optional scancode : int = 0
+    @optional mods    : int = 0
+}
+
+[live_command(description="Synthetic key press. Args: keycode (GLFW_KEY_*), scancode?, mods?")]
+def key_press(input : JsonValue?) : JsonValue? {
+    return JV((error = "no window")) if (live_window == null)
+    let args = from_JV(input, type<KeyPressArgs>)
+    return JV((error = "missing keycode")) if (args.keycode == 0)
+    synth_key_press(args.keycode, args.scancode, args.mods)
+    return JV((keycode = args.keycode, action = "press"))
+}
+
+[live_command(description="Synthetic key release. Args: keycode (GLFW_KEY_*), scancode?, mods?")]
+def key_release(input : JsonValue?) : JsonValue? {
+    return JV((error = "no window")) if (live_window == null)
+    let args = from_JV(input, type<KeyPressArgs>)
+    return JV((error = "missing keycode")) if (args.keycode == 0)
+    synth_key_release(args.keycode, args.scancode, args.mods)
+    return JV((keycode = args.keycode, action = "release"))
+}
+
+struct KeyCharArgs {
+    codepoint : uint = 0u
+}
+
+[live_command(description="Synthetic Unicode char (no paired key event). Args: codepoint")]
+def key_char(input : JsonValue?) : JsonValue? {
+    return JV((error = "no window")) if (live_window == null)
+    let args = from_JV(input, type<KeyCharArgs>)
+    return JV((error = "missing codepoint")) if (args.codepoint == 0u)
+    synth_char(args.codepoint)
+    return JV((codepoint = args.codepoint))
+}
+
+// --- ASCII translation tables for key_type / key_chord ---
+
+def private mod_name_to_keycode(name : string) : int {
+    if (name == "Ctrl" || name == "Control") return GLFW_KEY_LEFT_CONTROL
+    if (name == "Shift") return GLFW_KEY_LEFT_SHIFT
+    if (name == "Alt") return GLFW_KEY_LEFT_ALT
+    if (name == "Super" || name == "Cmd" || name == "Meta") return GLFW_KEY_LEFT_SUPER
+    return 0
+}
+
+def private mod_name_to_bit(name : string) : int {
+    if (name == "Ctrl" || name == "Control") return int(GLFW_MOD_CONTROL)
+    if (name == "Shift") return int(GLFW_MOD_SHIFT)
+    if (name == "Alt") return int(GLFW_MOD_ALT)
+    if (name == "Super" || name == "Cmd" || name == "Meta") return int(GLFW_MOD_SUPER)
+    return 0
+}
+
+// Letters and digits map directly; printable punctuation is a small fixed table.
+// Capitals + shifted punctuation get an explicit Shift press/release around the
+// char in key_type. Everything else falls through as a codepoint-only `char_`
+// event with `keycode == 0` (text-input widgets still receive it via
+// CharCallback).
+def private needs_shift_ascii(c : int) : bool {
+    if (c >= int('A') && c <= int('Z')) return true   // nolint:PERF014 (uppercase-only, is_alpha would also match lowercase)
+    // shifted punctuation on a US layout. Listed as char literals (not a single
+    // string) so the parser doesn't treat `{` / `}` as interpolation delimiters.
+    return (c == int('~') || c == int('!') || c == int('@') || c == int('#')
+         || c == int('$') || c == int('%') || c == int('^') || c == int('&')
+         || c == int('*') || c == int('(') || c == int(')') || c == int('_')
+         || c == int('+') || c == int('{') || c == int('}') || c == int('|')
+         || c == int(':') || c == int('"') || c == int('<') || c == int('>')
+         || c == int('?'))
+}
+
+def private base_keycode_ascii(c : int) : int {
+    // letters — distinguishing case to compute the right keycode offset
+    if (c >= int('A') && c <= int('Z')) return GLFW_KEY_A + (c - int('A'))   // nolint:PERF014 (need uppercase-only offset)
+    if (c >= int('a') && c <= int('z')) return GLFW_KEY_A + (c - int('a'))   // nolint:PERF014 (need lowercase-only offset)
+    // digits 0-9 → GLFW_KEY_0..9
+    if (c >= int('0') && c <= int('9')) return GLFW_KEY_0 + (c - int('0'))   // nolint:PERF014 (need digit-only offset)
+    // shifted digit row: ! @ # $ % ^ & * ( )  → keys 1 2 3 4 5 6 7 8 9 0
+    if (c == int('!')) return GLFW_KEY_1
+    if (c == int('@')) return GLFW_KEY_2
+    if (c == int('#')) return GLFW_KEY_3
+    if (c == int('$')) return GLFW_KEY_4
+    if (c == int('%')) return GLFW_KEY_5
+    if (c == int('^')) return GLFW_KEY_6
+    if (c == int('&')) return GLFW_KEY_7
+    if (c == int('*')) return GLFW_KEY_8
+    if (c == int('(')) return GLFW_KEY_9
+    if (c == int(')')) return GLFW_KEY_0
+    // punctuation
+    if (c == int(' ')) return GLFW_KEY_SPACE
+    if (c == int('\n')) return GLFW_KEY_ENTER
+    if (c == int('\t')) return GLFW_KEY_TAB
+    if (c == int(',') || c == int('<')) return GLFW_KEY_COMMA
+    if (c == int('.') || c == int('>')) return GLFW_KEY_PERIOD
+    if (c == int('/') || c == int('?')) return GLFW_KEY_SLASH
+    if (c == int(';') || c == int(':')) return GLFW_KEY_SEMICOLON
+    if (c == int('\'') || c == int('"')) return GLFW_KEY_APOSTROPHE
+    if (c == int('-') || c == int('_')) return GLFW_KEY_MINUS
+    if (c == int('=') || c == int('+')) return GLFW_KEY_EQUAL
+    if (c == int('[') || c == int('{')) return GLFW_KEY_LEFT_BRACKET
+    if (c == int(']') || c == int('}')) return GLFW_KEY_RIGHT_BRACKET
+    if (c == int('\\') || c == int('|')) return GLFW_KEY_BACKSLASH
+    if (c == int('`') || c == int('~')) return GLFW_KEY_GRAVE_ACCENT
+    return 0
+}
+
+struct KeyTypeArgs {
+    text                       : string = ""
+    @optional total_duration_s : float  = 0.0
+    @optional per_char_ms      : int    = 60
+}
+
+[live_command(description="Stream text as synthetic key+char events. Args: text, total_duration_s? (preferred) | per_char_ms? (default 60)")]
+def key_type(input : JsonValue?) : JsonValue? {
+    return JV((error = "no window")) if (live_window == null)
+    let args = from_JV(input, type<KeyTypeArgs>)
+    return JV((error = "empty text")) if (empty(args.text))
+    var per_char_ms = max(1, args.per_char_ms)
+    if (args.total_duration_s > 0.0f) {
+        per_char_ms = max(1, int(args.total_duration_s * 1000.0f) / length(args.text))
+    }
+    reset_key_timeline_state()
+    var t = 0
+    // Worst case: 5 events per char (Shift down, key down, char, key up, Shift up).
+    key_timeline |> reserve(length(args.text) * 5)
+    peek_data(args.text) $(arr) {
+        for (b in arr) {
+            let c     = int(b)
+            let cp    = uint(b)
+            let kc    = base_keycode_ascii(c)
+            let shift = needs_shift_ascii(c)
+            let mods  = shift ? int(GLFW_MOD_SHIFT) : 0
+            if (shift) {
+                key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.press,   keycode = GLFW_KEY_LEFT_SHIFT))
+            }
+            if (kc != 0) {
+                key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.press,   keycode = kc, mods = mods))
+            }
+            key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.char_,       codepoint = cp))
+            if (kc != 0) {
+                key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.release, keycode = kc, mods = mods))
+            }
+            if (shift) {
+                key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.release, keycode = GLFW_KEY_LEFT_SHIFT))
+            }
+            t += per_char_ms
+        }
+    }
+    key_play_start_t = get_uptime()
+    key_playing      = true
+    return JV((queued = length(key_timeline), per_char_ms = per_char_ms))
+}
+
+struct KeyChordArgs {
+    mods : array<string>
+    key  : string = ""
+}
+
+[live_command(description="Synthetic chord. Args: mods (array of \"Ctrl\"|\"Shift\"|\"Alt\"|\"Super\"|\"Cmd\"|\"Meta\"), key (single ASCII char or GLFW key name)")]
+def key_chord(input : JsonValue?) : JsonValue? {
+    return JV((error = "no window")) if (live_window == null)
+    let args = from_JV(input, type<KeyChordArgs>)
+    return JV((error = "missing key")) if (empty(args.key))
+    // resolve target keycode: prefer a single ASCII char (uppercase letter / digit / symbol).
+    var target_kc = 0
+    if (length(args.key) == 1) {
+        target_kc = base_keycode_ascii(int(first_character(args.key)))
+    }
+    return JV((error = "unsupported chord key", key = args.key)) if (target_kc == 0)
+    var mod_bits = 0
+    for (m in args.mods) {
+        let b = mod_name_to_bit(m)
+        return JV((error = "unknown modifier", modifier = m)) if (b == 0)
+        mod_bits |= b
+    }
+    reset_key_timeline_state()
+    // press(mod)*N + press(key) + release(key) + release(mod)*N
+    key_timeline |> reserve(length(args.mods) * 2 + 2)
+    var t = 0
+    // press modifiers in array order
+    for (m in args.mods) {
+        let mkc = mod_name_to_keycode(m)
+        key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.press, keycode = mkc))
+        t += 8     // tight stamp: ImGui sees these as a combo
+    }
+    key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.press,   keycode = target_kc, mods = mod_bits))
+    t += 16
+    key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.release, keycode = target_kc, mods = mod_bits))
+    t += 8
+    // release modifiers in reverse order
+    var i = length(args.mods) - 1
+    while (i >= 0) {
+        let mkc = mod_name_to_keycode(args.mods[i])
+        key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.release, keycode = mkc))
+        t += 8
+        i--
+    }
+    key_play_start_t = get_uptime()
+    key_playing      = true
+    return JV((queued = length(key_timeline)))
+}
+
+struct KeyEventWire {
+    @optional t_ms      : int    = 0
+    kind                : string = "press"   // "press" | "release" | "char"
+    @optional keycode   : int    = 0
+    @optional scancode  : int    = 0
+    @optional mods      : int    = 0
+    @optional codepoint : uint   = 0u
+}
+
+struct KeyPlayArgs {
+    events : array<KeyEventWire>
+}
+
+def public sort_key_play_events(var events : array<KeyEventWire>) {
+    //! Sort a key_play timeline by ``t_ms`` ascending. Same rationale as
+    //! ``sort_play_events`` for mouse: the queue is walked forward, so
+    //! out-of-order input would silently drop earlier events.
+    events |> sort() $(a, b : KeyEventWire) {
+        return a.t_ms < b.t_ms
+    }
+}
+
+[live_command(description="Play a scripted key/char timeline. Args: events array of (t_ms, kind, keycode, scancode, mods, codepoint)")]
+def key_play(input : JsonValue?) : JsonValue? {
+    return JV((error = "no window")) if (live_window == null)
+    var args = from_JV(input, type<KeyPlayArgs>)
+    return JV((error = "no events")) if (empty(args.events))
+    sort_key_play_events(args.events)
+    reset_key_timeline_state()
+    key_timeline |> reserve(length(args.events))
+    for (w in args.events) {
+        var ev = KeyEvent(t_ms = w.t_ms, keycode = w.keycode, scancode = w.scancode, mods = w.mods, codepoint = w.codepoint)
+        if (w.kind == "press") {
+            ev.kind = KEKind.press
+        } elif (w.kind == "release") {
+            ev.kind = KEKind.release
+        } elif (w.kind == "char") {
+            ev.kind = KEKind.char_
+        } else {
+            return JV((error = "unknown event kind", kind = w.kind))
+        }
+        key_timeline |> push(ev)
+    }
+    key_play_start_t = get_uptime()
+    key_playing      = true
+    return JV((queued = length(key_timeline)))
+}
+
+[live_command(description="Stop synthetic key playback and clear the timeline.")]
+def key_stop(input : JsonValue?) : JsonValue? {
+    let was_playing = key_playing
+    reset_key_timeline_state()
+    return JV((stopped = was_playing))
+}
+
+struct KeyStatusResult {
+    playing       : bool
+    elapsed_ms    : int
+    queue_idx     : int
+    queue_total   : int
+    held_count    : int
+    last_keycode  : int
+    last_codepoint : uint
+}
+
+[live_command(description="Synthetic-keyboard playback status.")]
+def key_status(input : JsonValue?) : JsonValue? {
+    let elapsed = key_playing ? int((get_uptime() - key_play_start_t) * 1000.0) : 0
+    return JV(KeyStatusResult(
+        playing        = key_playing,
+        elapsed_ms     = elapsed,
+        queue_idx      = key_play_idx,
+        queue_total    = length(key_timeline),
+        held_count     = length(synth_held_keys),
+        last_keycode   = synth_last_keycode,
+        last_codepoint = synth_last_codepoint
+    ))
+}
+
+[before_update]
+def key_tick() {
+    return if (!key_playing || live_window == null)
+    let now_ms = int((get_uptime() - key_play_start_t) * 1000.0)
+    while (key_play_idx < length(key_timeline)) {
+        let ev = key_timeline[key_play_idx]
+        break if (ev.t_ms > now_ms)
+        if (ev.kind == KEKind.press) {
+            synth_key_press(ev.keycode, ev.scancode, ev.mods)
+        } elif (ev.kind == KEKind.release) {
+            synth_key_release(ev.keycode, ev.scancode, ev.mods)
+        } elif (ev.kind == KEKind.char_) {
+            synth_char(ev.codepoint)
+        }
+        key_play_idx++
+    }
+    if (key_play_idx >= length(key_timeline)) {
+        key_playing = false
     }
 }

--- a/modules/dasGlfw/dasglfw/glfw_live.das
+++ b/modules/dasGlfw/dasglfw/glfw_live.das
@@ -167,6 +167,9 @@ var private last_move_t  : int = -1
 var public synth_click_button : int = -1
 var public synth_click_action : int = 0   // 1 = press, 0 = release
 var public synth_click_t      : float = -1.0    //! get_uptime() at last click; -1 = no click yet
+// Currently-synth-pressed buttons. Drained by mouse_stop so an interrupted
+// drag/timeline doesn't leave ImGui believing a button is held.
+var private synth_held_buttons : table<int>
 // Synth events go through dasGLFW's chain dispatcher only — ImGui-GLFW (and
 // any other chain listener) sees them via its installed callback. We never
 // glfwSetCursorPos: the OS cursor lives outside the GL back buffer (the
@@ -183,9 +186,27 @@ def private synth_cursor_pos(x, y : float) {
 
 def private synth_mouse_button(button, action : int) {
     glfw_post_mouse_button(live_window, button, action, 0)
+    if (action == 1) {
+        synth_held_buttons |> insert(button)
+    } else {
+        synth_held_buttons |> erase(button)
+    }
     synth_click_button = button
     synth_click_action = action
     synth_click_t      = get_uptime()
+}
+
+def private release_held_buttons() {
+    // Same snapshot-before-iterate pattern as release_held_keys —
+    // synth_mouse_button erases from synth_held_buttons.
+    var held : array<int>
+    held |> reserve(length(synth_held_buttons))
+    for (b in keys(synth_held_buttons)) {
+        held |> push(b)
+    }
+    for (b in held) {
+        synth_mouse_button(b, 0)
+    }
 }
 
 def public get_synth_cursor() : tuple<bool; float; float> {
@@ -336,8 +357,10 @@ def mouse_play(input : JsonValue?) : JsonValue? {
 [live_command(description="Stop synthetic playback and clear the timeline.")]
 def mouse_stop(input : JsonValue?) : JsonValue? {
     let was_playing = playing
+    let released    = length(synth_held_buttons)
+    release_held_buttons()
     reset_timeline_state()
-    return JV((stopped = was_playing))
+    return JV((stopped = was_playing, released = released))
 }
 
 struct MouseStatusResult {
@@ -347,6 +370,7 @@ struct MouseStatusResult {
     cursor_y    : float
     queue_idx   : int
     queue_total : int
+    held_count  : int
 }
 
 [live_command(description="Synthetic-mouse playback status.")]
@@ -358,7 +382,8 @@ def mouse_status(input : JsonValue?) : JsonValue? {
         cursor_x    = cursor_x,
         cursor_y    = cursor_y,
         queue_idx   = play_idx,
-        queue_total = length(timeline)
+        queue_total = length(timeline),
+        held_count  = length(synth_held_buttons)
     ))
 }
 
@@ -477,6 +502,20 @@ def private reset_key_timeline_state() {
     key_timeline |> clear()
     key_play_idx = 0
     key_playing  = false
+}
+
+def private release_held_keys() {
+    // Snapshot first — synth_key_release erases from synth_held_keys, which
+    // would invalidate iteration. Same pattern as the `for (k in keys(t))` /
+    // mutate-t fix in feedback_for_keys_table_locked.md.
+    var held : array<int>
+    held |> reserve(length(synth_held_keys))
+    for (kc in keys(synth_held_keys)) {
+        held |> push(kc)
+    }
+    for (kc in held) {
+        synth_key_release(kc, 0, 0)
+    }
 }
 
 struct KeyPressArgs {
@@ -737,11 +776,13 @@ def key_play(input : JsonValue?) : JsonValue? {
     return JV((queued = length(key_timeline)))
 }
 
-[live_command(description="Stop synthetic key playback and clear the timeline.")]
+[live_command(description="Stop synthetic key playback and clear the timeline. Releases any keys still synth-held (e.g. modifiers from an interrupted key_chord) so ImGui doesn't inherit stuck modifier state.")]
 def key_stop(input : JsonValue?) : JsonValue? {
     let was_playing = key_playing
+    let released    = length(synth_held_keys)
+    release_held_keys()
     reset_key_timeline_state()
-    return JV((stopped = was_playing))
+    return JV((stopped = was_playing, released = released))
 }
 
 struct KeyStatusResult {

--- a/modules/dasGlfw/dasglfw/glfw_live.das
+++ b/modules/dasGlfw/dasglfw/glfw_live.das
@@ -24,6 +24,7 @@ require opengl/opengl_cache
 require daslib/archive
 require daslib/json
 require daslib/json_boost
+require daslib/utf8_utils
 require live/live_commands
 require live_host
 require math
@@ -591,23 +592,28 @@ struct KeyTypeArgs {
     @optional per_char_ms      : int    = 60
 }
 
-[live_command(description="Stream text as synthetic key+char events. Args: text, total_duration_s? (preferred) | per_char_ms? (default 60)")]
+[live_command(description="Stream text as synthetic key+char events. Args: text (UTF-8; non-ASCII emits char-only events), total_duration_s? (preferred) | per_char_ms? (default 60)")]
 def key_type(input : JsonValue?) : JsonValue? {
     return JV((error = "no window")) if (live_window == null)
     let args = from_JV(input, type<KeyTypeArgs>)
     return JV((error = "empty text")) if (empty(args.text))
+    // Decode UTF-8 to codepoints so pacing + ASCII auto-shift work per character,
+    // not per byte. Non-ASCII codepoints emit a char-only event (no key press) —
+    // mirrors how GLFW dispatches IME / dead-key composition results to the
+    // char callback without a paired key event.
+    let cps <- utf8_decode(args.text)
+    let n_chars = length(cps)
     var per_char_ms = max(1, args.per_char_ms)
     if (args.total_duration_s > 0.0f) {
-        per_char_ms = max(1, int(args.total_duration_s * 1000.0f) / length(args.text))
+        per_char_ms = max(1, int(args.total_duration_s * 1000.0f) / max(1, n_chars))
     }
     reset_key_timeline_state()
     var t = 0
     // Worst case: 5 events per char (Shift down, key down, char, key up, Shift up).
-    key_timeline |> reserve(length(args.text) * 5)
-    peek_data(args.text) $(arr) {
-        for (b in arr) {
-            let c     = int(b)
-            let cp    = uint(b)
+    key_timeline |> reserve(n_chars * 5)
+    for (cp in cps) {
+        if (cp < 0x80u) {
+            let c     = int(cp)
             let kc    = base_keycode_ascii(c)
             let shift = needs_shift_ascii(c)
             let mods  = shift ? int(GLFW_MOD_SHIFT) : 0
@@ -624,12 +630,14 @@ def key_type(input : JsonValue?) : JsonValue? {
             if (shift) {
                 key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.release, keycode = GLFW_KEY_LEFT_SHIFT))
             }
-            t += per_char_ms
+        } else {
+            key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.char_, codepoint = cp))
         }
+        t += per_char_ms
     }
     key_play_start_t = get_uptime()
     key_playing      = true
-    return JV((queued = length(key_timeline), per_char_ms = per_char_ms))
+    return JV((queued = length(key_timeline), per_char_ms = per_char_ms, chars = n_chars))
 }
 
 struct KeyChordArgs {
@@ -637,7 +645,7 @@ struct KeyChordArgs {
     key  : string = ""
 }
 
-[live_command(description="Synthetic chord. Args: mods (array of \"Ctrl\"|\"Shift\"|\"Alt\"|\"Super\"|\"Cmd\"|\"Meta\"), key (single ASCII char or GLFW key name)")]
+[live_command(description="Synthetic chord. Args: mods (array of \"Ctrl\"|\"Shift\"|\"Alt\"|\"Super\"|\"Cmd\"|\"Meta\"), key (single ASCII character)")]
 def key_chord(input : JsonValue?) : JsonValue? {
     return JV((error = "no window")) if (live_window == null)
     let args = from_JV(input, type<KeyChordArgs>)

--- a/modules/dasGlfw/src/aot_dasGLFW.h
+++ b/modules/dasGlfw/src/aot_dasGLFW.h
@@ -25,4 +25,8 @@ namespace das {
     DAS_MOD_API void DasGlfw_DispatchCursorPos ( GLFWwindow * window, double x, double y );
     DAS_MOD_API void DasGlfw_PostMouseButton ( GLFWwindow * window, int button, int action, int mods );
     DAS_MOD_API void DasGlfw_PostScroll ( GLFWwindow * window, double xoff, double yoff );
+    DAS_MOD_API void DasGlfw_ChainAddKey ( GLFWwindow * window, TLambda<void,const GLFWwindow*,int,int,int,int> func, Context * ctx );
+    DAS_MOD_API void DasGlfw_ChainAddChar ( GLFWwindow * window, TLambda<void,const GLFWwindow*,unsigned int> func, Context * ctx );
+    DAS_MOD_API void DasGlfw_PostKey ( GLFWwindow * window, int key, int scancode, int action, int mods );
+    DAS_MOD_API void DasGlfw_PostChar ( GLFWwindow * window, unsigned int codepoint );
 }

--- a/modules/dasGlfw/src/dasGLFW.main.cpp
+++ b/modules/dasGlfw/src/dasGLFW.main.cpp
@@ -163,6 +163,14 @@ namespace das {
         GLFWscrollfun                   prev_scroll        = nullptr;
         GLFWkeyfun                      prev_key           = nullptr;
         GLFWcharfun                     prev_char          = nullptr;
+        // Per-callback install flags. ChainClear must NOT touch a slot the chain
+        // never installed — otherwise it would clobber a foreign callback (e.g.
+        // ImGui_ImplGlfw_KeyCallback) that was set up independently of us.
+        bool                            installed_cursor_pos   = false;
+        bool                            installed_mouse_button = false;
+        bool                            installed_scroll       = false;
+        bool                            installed_key          = false;
+        bool                            installed_char         = false;
         std::vector<GlfwChainEntry>     cursor_pos_chain;
         std::vector<GlfwChainEntry>     mouse_button_chain;
         std::vector<GlfwChainEntry>     scroll_chain;
@@ -247,6 +255,7 @@ namespace das {
         if ( previous && previous != &DasGlfw_ChainCursorPosDispatch ) {
             st.prev_cursor_pos = previous;
         }
+        st.installed_cursor_pos = true;
     }
     static void ensure_chain_mouse_button_installed ( GLFWwindow * w ) {
         auto & st = g_GlfwChain[w];
@@ -254,6 +263,7 @@ namespace das {
         if ( previous && previous != &DasGlfw_ChainMouseButtonDispatch ) {
             st.prev_mouse_button = previous;
         }
+        st.installed_mouse_button = true;
     }
     static void ensure_chain_scroll_installed ( GLFWwindow * w ) {
         auto & st = g_GlfwChain[w];
@@ -261,6 +271,7 @@ namespace das {
         if ( previous && previous != &DasGlfw_ChainScrollDispatch ) {
             st.prev_scroll = previous;
         }
+        st.installed_scroll = true;
     }
     static void ensure_chain_key_installed ( GLFWwindow * w ) {
         auto & st = g_GlfwChain[w];
@@ -268,6 +279,7 @@ namespace das {
         if ( previous && previous != &DasGlfw_ChainKeyDispatch ) {
             st.prev_key = previous;
         }
+        st.installed_key = true;
     }
     static void ensure_chain_char_installed ( GLFWwindow * w ) {
         auto & st = g_GlfwChain[w];
@@ -275,6 +287,7 @@ namespace das {
         if ( previous && previous != &DasGlfw_ChainCharDispatch ) {
             st.prev_char = previous;
         }
+        st.installed_char = true;
     }
 
     void DasGlfw_ChainAddCursorPos ( GLFWwindow * w, TLambda<void,const GLFWwindow*,double,double> func, Context * ctx ) {
@@ -305,16 +318,16 @@ namespace das {
     void DasGlfw_ChainClear ( GLFWwindow * w ) {
         auto it = g_GlfwChain.find(w);
         if ( it == g_GlfwChain.end() ) return;
-        // Restore the previous GLFW callbacks (e.g. ImGui_ImplGlfw's) before
-        // tearing down the chain state; otherwise the dispatcher stays
-        // installed but early-returns on every real event because the map
-        // entry is gone, silently dropping input.
+        // Restore previous GLFW callbacks (e.g. ImGui_ImplGlfw's) only for the
+        // slots we actually installed. Restoring an uninstalled slot would
+        // overwrite a foreign callback set up independently of us with the
+        // default-null prev_*, silently dropping that input.
         auto & st = it->second;
-        glfwSetCursorPosCallback   (w, st.prev_cursor_pos);
-        glfwSetMouseButtonCallback (w, st.prev_mouse_button);
-        glfwSetScrollCallback      (w, st.prev_scroll);
-        glfwSetKeyCallback         (w, st.prev_key);
-        glfwSetCharCallback        (w, st.prev_char);
+        if ( st.installed_cursor_pos   ) glfwSetCursorPosCallback   (w, st.prev_cursor_pos);
+        if ( st.installed_mouse_button ) glfwSetMouseButtonCallback (w, st.prev_mouse_button);
+        if ( st.installed_scroll       ) glfwSetScrollCallback      (w, st.prev_scroll);
+        if ( st.installed_key          ) glfwSetKeyCallback         (w, st.prev_key);
+        if ( st.installed_char         ) glfwSetCharCallback        (w, st.prev_char);
         g_GlfwChain.erase(it);
     }
 

--- a/modules/dasGlfw/src/dasGLFW.main.cpp
+++ b/modules/dasGlfw/src/dasGLFW.main.cpp
@@ -161,9 +161,13 @@ namespace das {
         GLFWcursorposfun                prev_cursor_pos    = nullptr;
         GLFWmousebuttonfun              prev_mouse_button  = nullptr;
         GLFWscrollfun                   prev_scroll        = nullptr;
+        GLFWkeyfun                      prev_key           = nullptr;
+        GLFWcharfun                     prev_char          = nullptr;
         std::vector<GlfwChainEntry>     cursor_pos_chain;
         std::vector<GlfwChainEntry>     mouse_button_chain;
         std::vector<GlfwChainEntry>     scroll_chain;
+        std::vector<GlfwChainEntry>     key_chain;
+        std::vector<GlfwChainEntry>     char_chain;
     };
 
     static thread_local das_map<void *, GlfwChainState> g_GlfwChain;
@@ -207,6 +211,32 @@ namespace das {
         }
     }
 
+    void DasGlfw_ChainKeyDispatch ( GLFWwindow * w, int key, int scancode, int action, int mods ) {
+        auto it = g_GlfwChain.find(w);
+        if ( it == g_GlfwChain.end() ) return;
+        auto & st = it->second;
+        if ( st.prev_key ) st.prev_key(w, key, scancode, action, mods);
+        for ( auto & e : st.key_chain ) {
+            if ( e.context ) {
+                das_invoke_lambda<void>::invoke<GLFWwindow *, int, int, int, int>(
+                    e.context, nullptr, e.lambda, w, key, scancode, action, mods);
+            }
+        }
+    }
+
+    void DasGlfw_ChainCharDispatch ( GLFWwindow * w, unsigned int codepoint ) {
+        auto it = g_GlfwChain.find(w);
+        if ( it == g_GlfwChain.end() ) return;
+        auto & st = it->second;
+        if ( st.prev_char ) st.prev_char(w, codepoint);
+        for ( auto & e : st.char_chain ) {
+            if ( e.context ) {
+                das_invoke_lambda<void>::invoke<GLFWwindow *, unsigned int>(
+                    e.context, nullptr, e.lambda, w, codepoint);
+            }
+        }
+    }
+
     // Idempotent dispatcher install: always re-calls glfwSet*Callback so a
     // non-self previous is captured as the chain's "prev" (preserves whatever
     // ImGui_ImplGlfw or other backend installed). Self-reinstalls are no-ops
@@ -232,6 +262,20 @@ namespace das {
             st.prev_scroll = previous;
         }
     }
+    static void ensure_chain_key_installed ( GLFWwindow * w ) {
+        auto & st = g_GlfwChain[w];
+        auto previous = glfwSetKeyCallback(w, DasGlfw_ChainKeyDispatch);
+        if ( previous && previous != &DasGlfw_ChainKeyDispatch ) {
+            st.prev_key = previous;
+        }
+    }
+    static void ensure_chain_char_installed ( GLFWwindow * w ) {
+        auto & st = g_GlfwChain[w];
+        auto previous = glfwSetCharCallback(w, DasGlfw_ChainCharDispatch);
+        if ( previous && previous != &DasGlfw_ChainCharDispatch ) {
+            st.prev_char = previous;
+        }
+    }
 
     void DasGlfw_ChainAddCursorPos ( GLFWwindow * w, TLambda<void,const GLFWwindow*,double,double> func, Context * ctx ) {
         ensure_chain_cursor_pos_installed(w);
@@ -248,6 +292,16 @@ namespace das {
         g_GlfwChain[w].scroll_chain.push_back({ func, ctx });
     }
 
+    void DasGlfw_ChainAddKey ( GLFWwindow * w, TLambda<void,const GLFWwindow*,int,int,int,int> func, Context * ctx ) {
+        ensure_chain_key_installed(w);
+        g_GlfwChain[w].key_chain.push_back({ func, ctx });
+    }
+
+    void DasGlfw_ChainAddChar ( GLFWwindow * w, TLambda<void,const GLFWwindow*,unsigned int> func, Context * ctx ) {
+        ensure_chain_char_installed(w);
+        g_GlfwChain[w].char_chain.push_back({ func, ctx });
+    }
+
     void DasGlfw_ChainClear ( GLFWwindow * w ) {
         auto it = g_GlfwChain.find(w);
         if ( it == g_GlfwChain.end() ) return;
@@ -259,6 +313,8 @@ namespace das {
         glfwSetCursorPosCallback   (w, st.prev_cursor_pos);
         glfwSetMouseButtonCallback (w, st.prev_mouse_button);
         glfwSetScrollCallback      (w, st.prev_scroll);
+        glfwSetKeyCallback         (w, st.prev_key);
+        glfwSetCharCallback        (w, st.prev_char);
         g_GlfwChain.erase(it);
     }
 
@@ -286,6 +342,16 @@ namespace das {
     void DasGlfw_PostScroll ( GLFWwindow * w, double xoff, double yoff ) {
         ensure_chain_scroll_installed(w);
         DasGlfw_ChainScrollDispatch(w, xoff, yoff);
+    }
+
+    void DasGlfw_PostKey ( GLFWwindow * w, int key, int scancode, int action, int mods ) {
+        ensure_chain_key_installed(w);
+        DasGlfw_ChainKeyDispatch(w, key, scancode, action, mods);
+    }
+
+    void DasGlfw_PostChar ( GLFWwindow * w, unsigned int codepoint ) {
+        ensure_chain_char_installed(w);
+        DasGlfw_ChainCharDispatch(w, codepoint);
     }
 
     void DasGlfw_DestroyWindow ( GLFWwindow * window ) {
@@ -335,6 +401,14 @@ namespace das {
             SideEffects::worstDefault,"DasGlfw_PostMouseButton");
         addExtern<DAS_BIND_FUN(DasGlfw_PostScroll)>(*this,lib,"glfw_post_scroll",
             SideEffects::worstDefault,"DasGlfw_PostScroll");
+        addExtern<DAS_BIND_FUN(DasGlfw_ChainAddKey)>(*this,lib,"glfw_chain_add_key",
+            SideEffects::worstDefault,"DasGlfw_ChainAddKey");
+        addExtern<DAS_BIND_FUN(DasGlfw_ChainAddChar)>(*this,lib,"glfw_chain_add_char",
+            SideEffects::worstDefault,"DasGlfw_ChainAddChar");
+        addExtern<DAS_BIND_FUN(DasGlfw_PostKey)>(*this,lib,"glfw_post_key",
+            SideEffects::worstDefault,"DasGlfw_PostKey");
+        addExtern<DAS_BIND_FUN(DasGlfw_PostChar)>(*this,lib,"glfw_post_char",
+            SideEffects::worstDefault,"DasGlfw_PostChar");
         addExtern<DAS_BIND_FUN(DAS_glfwGetNativeWindow)>(*this, lib, "glfwGetNativeWindow",SideEffects::worstDefault, "DAS_glfwGetNativeWindow")
             ->args({"window"});
         addExtern<DAS_BIND_FUN(DAS_glfwGetNativeDisplay)>(*this, lib, "glfwGetNativeDisplay",SideEffects::worstDefault, "DAS_glfwGetNativeDisplay");

--- a/tests/dasglfw/test_key_play_sort.das
+++ b/tests/dasglfw/test_key_play_sort.das
@@ -1,0 +1,60 @@
+options gen2
+options no_aot
+
+require dastest/testing_boost public
+
+// Self-contained smoke test for the sort technique used by
+// `sort_key_play_events` in modules/dasGlfw/dasglfw/glfw_live.das. We can't
+// require live/glfw_live directly here without dragging in the full
+// GLFW + OpenGL chain (which the no_aot harness can't link against),
+// so we mirror the wire-event shape + comparator and verify the same
+// sort() with a `<` lambda lands t_ms-ascending.
+//
+// `sort()` is qsort, not stable, so this test asserts only the
+// ordering invariant key_play depends on (non-decreasing t_ms),
+// not any tie-break ordering.
+
+struct TestKeyEventWire {
+    t_ms : int    = 0
+    kind : string = "press"
+    tag  : string = ""
+}
+
+def sort_by_t_ms(var events : array<TestKeyEventWire>) {
+    events |> sort() $(a, b : TestKeyEventWire) {
+        return a.t_ms < b.t_ms
+    }
+}
+
+[test]
+def test_sort_orders_by_tms(t : T?) {
+    var events <- [
+        TestKeyEventWire(t_ms = 300, kind = "release", tag = "c"),
+        TestKeyEventWire(t_ms = 100, kind = "press",   tag = "a"),
+        TestKeyEventWire(t_ms = 200, kind = "char",    tag = "b")
+    ]
+    sort_by_t_ms(events)
+    t |> equal(events[0].t_ms, 100)
+    t |> equal(events[1].t_ms, 200)
+    t |> equal(events[2].t_ms, 300)
+}
+
+[test]
+def test_sort_empty(t : T?) {
+    var events : array<TestKeyEventWire>
+    sort_by_t_ms(events)
+    t |> equal(length(events), 0)
+}
+
+[test]
+def test_sort_already_sorted(t : T?) {
+    var events <- [
+        TestKeyEventWire(t_ms = 100),
+        TestKeyEventWire(t_ms = 200),
+        TestKeyEventWire(t_ms = 300)
+    ]
+    sort_by_t_ms(events)
+    t |> equal(events[0].t_ms, 100)
+    t |> equal(events[1].t_ms, 200)
+    t |> equal(events[2].t_ms, 300)
+}


### PR DESCRIPTION
## Summary

Keyboard half of the synth-IO story for the dasImgui visual-aids tour. Symmetric to the mouse-side synth chain that shipped on master 2026-05-12 in #2630 — same `GlfwChainState` registry, same `prev_* + chain<vector>` shape, same `ensure_chain_*_installed` idempotent installer. Real GLFW key events and synth key events both flow through `DasGlfw_Chain*Dispatch` → `prev_*` (ImGui_ImplGlfw's callback) → `io.AddKeyEvent` / `io.AddInputCharacter`.

The dasImgui visual-aids consumer (keycap HUD + focus rectangle overlays + paced `key_type` storyboard in `record_visual_aids.das`) lives in a separate dasImgui repo branch — `bbatkin/dasimgui-keyboard-synth` at github.com/borisbat/dasImgui (commits `a4da530` + `f6f1269`).

## Changes

**`modules/dasGlfw/src/dasGLFW.main.cpp`** — parallels existing mouse plumbing at lines 160-303:
- `GlfwChainState` gains `prev_key` / `prev_char` and `key_chain` / `char_chain` listener vectors.
- `DasGlfw_ChainKeyDispatch(w, key, sc, action, mods)` and `DasGlfw_ChainCharDispatch(w, codepoint)`: call prev_*, iterate chain vectors. Mirror `DasGlfw_ChainMouseButtonDispatch` / `DasGlfw_ChainScrollDispatch` exactly.
- `ensure_chain_key_installed` / `ensure_chain_char_installed`: idempotent installer captures any pre-existing C-callback (`ImGui_ImplGlfw_KeyCallback` / `_CharCallback`) as `prev_*`.
- `DasGlfw_ChainAddKey` / `DasGlfw_ChainAddChar`: call ensure + push to listener vector.
- `DasGlfw_PostKey` / `DasGlfw_PostChar`: synthetic-event entry points (ensure + dispatch). No `glfwSetCursorPos` equivalent — GLFW keyboard state is event-driven, not polled, so no warp needed.
- `DasGlfw_ChainClear` extended to restore `prev_key` / `prev_char` before erasing the map entry.
- `addExtern` wires four new daslang-facing symbols: `glfw_chain_add_key`, `glfw_chain_add_char`, `glfw_post_key`, `glfw_post_char`.

**`modules/dasGlfw/src/aot_dasGLFW.h`** — four matching `DAS_MOD_API` decls.

**`modules/dasGlfw/dasglfw/glfw_live.das`** — parallels existing mouse timeline section:
- `KEKind` enum (`press` / `release` / `char_`), `KeyEvent` struct.
- Timeline state: `key_timeline`, `key_play_start_t`, `key_play_idx`, `key_playing`.
- Public state for visual_aids overlays: `synth_held_keys : table<int>`, `synth_last_keycode` + `_t`, `synth_last_codepoint` + `_t`.
- `synth_key_press` / `synth_key_release` / `synth_char` helpers go through `glfw_post_key` / `glfw_post_char` respectively and update the public state.
- `get_synth_keys()` accessor for HUD/overlay use.
- `[live_command]`s mirroring the mouse shape:
  - `key_press` / `key_release` / `key_char` — one-shot
  - `key_type({text, total_duration_s? | per_char_ms?})` — ASCII shift table (`needs_shift_ascii` / `base_keycode_ascii`) auto-emits Shift around capitals + shifted punctuation. `total_duration_s` overrides `per_char_ms` when both present.
  - `key_chord({mods : array<string>, key : string})` — Ctrl/Shift/Alt/Super/Cmd/Meta supported; tight 8ms stamps so ImGui sees it as a combo.
  - `key_play({events})` — mirror of `mouse_play` timeline format.
  - `key_stop` / `key_status` — mirror of mouse versions.
- `[before_update] key_tick` drains the timeline frame-by-frame; same shape as `mouse_tick`.

## Test plan

- [x] Lint clean: `mcp__daslang__lint` on `glfw_live.das` — no warnings
- [x] Compile clean: `mcp__daslang__compile_check` on `glfw_live.das` after C++ rebuild — OK
- [x] Integration suite (interpreted): `daslang.exe dastest/dastest.das -- --test modules/dasImgui/tests/integration` — **44/44 passed** (includes 5 new keyboard tests + 5 pre-existing mouse regressions + 1 existing `imgui_type_text` regression)
- [x] Mouse regression sanity: `test_glfw_synth_mouse.das` all 5 cases pass — chain-state extension didn't bit-rot the existing mouse entries
- [x] Text-input regression sanity: `test_imgui_type_text_buffer_fills` passes — existing `AddInputCharactersUTF8` path unchanged
- [x] End-to-end visual gate: `visual_aids_recording.apng` regenerated against the full mouse+keyboard storyboard — 590 frames @ 30fps, 0 dropped, 22.2s. Visible: keycap pops at bottom-center, modifier strip flashing amber for Shift on capitals, focus rect around NAME_INPUT, paced `key_type "Hello, World!"` + `key_chord Ctrl+A` + Backspace cleanup
- AOT for dasImgui integration tests is N/A — they aren't registered in `tests/aot/CMakeLists.txt` (the existing mouse test also fails AOT under the current pipeline, confirming this isn't a regression introduced here)

## Companion branch

dasImgui consumer side (visual-aids HUD + focus rect overlays + tests + paced storyboard recorder): `bbatkin/dasimgui-keyboard-synth` at `github.com/borisbat/dasImgui` (commits `a4da530` keyboard-synth + `f6f1269` post-rebuild fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)