### PR TITLE
jit: host CPU + features in TargetMachine + LLVM cl::opts for unroll pipelines

### DIFF
--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -6508,7 +6508,7 @@ def public generate_global_ctors_dtors(types : PrimitiveTypes?; jit_mode : bool)
 }
 
 [macro_function]
-def public optimize_llvm_module(opt_level : uint; size_level : uint; inline_threshold : uint) {
+def public optimize_llvm_module(opt_level : uint; size_level : uint; inline_threshold : uint; use_host_cpu : bool) {
     return if (is_in_completion() || is_compiling_macros() || is_folding())
     return if (g_failed || !LLVM_ENABLE_OPT_PASS)
     var pbopts = LLVMCreatePassBuilderOptions()
@@ -6523,10 +6523,11 @@ def public optimize_llvm_module(opt_level : uint; size_level : uint; inline_thre
     let pipeline = (size_level >= 2u ? "default<Oz>"
                   : (size_level == 1u ? "default<Os>"
                                       : "default<O{opt_level}>"))
-    // Pass user opt_level + host CPU info so TTI cost models match the
-    // machine we'll actually run on (otherwise loop unrolling, inlining,
-    // and vectorization fall back to a generic baseline).
-    with_default_target_machine(opt_level, true) $(targetMachine : LLVMTargetMachineRef) {
+    // use_host_cpu=true for JIT (artifact runs on this host); false for
+    // exe emission so the IR pipeline's TTI cost model stays generic and
+    // produces redistributable shapes (otherwise loop unroll / vectorize
+    // pick host-tuned shapes baked into the emitted object).
+    with_default_target_machine(opt_level, use_host_cpu) $(targetMachine : LLVMTargetMachineRef) {
         let err = LLVMRunPasses(g_mod, pipeline, targetMachine, pbopts)
         if (err != null) {
             let msg = LLVMGetErrorMessage(err)

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -6523,7 +6523,10 @@ def public optimize_llvm_module(opt_level : uint; size_level : uint; inline_thre
     let pipeline = (size_level >= 2u ? "default<Oz>"
                   : (size_level == 1u ? "default<Os>"
                                       : "default<O{opt_level}>"))
-    with_default_target_machine() $(targetMachine : LLVMTargetMachineRef) {
+    // Pass user opt_level + host CPU info so TTI cost models match the
+    // machine we'll actually run on (otherwise loop unrolling, inlining,
+    // and vectorization fall back to a generic baseline).
+    with_default_target_machine(opt_level, true) $(targetMachine : LLVMTargetMachineRef) {
         let err = LLVMRunPasses(g_mod, pipeline, targetMachine, pbopts)
         if (err != null) {
             let msg = LLVMGetErrorMessage(err)

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -265,6 +265,45 @@ def public LLVMAddFunctionWithType(mod : LLVMModuleRef; name : string; typ : LLV
 }
 
 
+var g_jit_clopts_parsed = false
+
+// LLVM's cost-model thresholds for unroll / partial-unroll / unroll-and-jam
+// are compiled-in cl::opt globals. opt(1) sets them indirectly via
+// cl::ParseCommandLineOptions before parsing the -passes string; daslang's
+// JIT path does not, so the same `default<O3>` pipeline lands different
+// IR shapes (rolled outer loops, no unroll-and-jam) than `opt` produces
+// on the same input.
+//
+// Bisected against the dasProfile benchmark suite (JIT mode, 16 tests):
+//   * spectral-norm 2.77x, native 1.44x, queen 1.39x, sha256 1.17x
+//   * dict/mandelbrot/exp marginal +1-3%
+//   * 8 others within +-2%
+//   * primes -9% (tight `for (i in 2..n) if (n%i==0) return false` loop —
+//     partial unroll bloats the early-exit path without enabling vectorization)
+//
+// The three permission flags (-unroll-allow-partial + the unroll-and-jam
+// pair) are load-bearing for spectral-norm/native. The threshold quartet
+// is what pushes queen from 1.05x to 1.39x.
+[macro_function]
+def public init_jit_clopts() {
+    return if (g_jit_clopts_parsed)
+    g_jit_clopts_parsed = true
+    var argv <- [
+        "daslang-jit",
+        "-unroll-threshold=400",
+        "-unroll-partial-threshold=600",
+        "-unroll-max-count=16",
+        "-unroll-allow-partial=true",
+        "-enable-unroll-and-jam=true",
+        "-allow-unroll-and-jam=true"
+    ]
+    unsafe {
+        LLVMParseCommandLineOptions(length(argv),
+            reinterpret<string const?>(addr(argv[0])),
+            "daslang JIT cl::opts")
+    }
+}
+
 [macro_function]
 def public init_jit(cg_opt_level : uint) {
     return if (is_in_completion() || is_compiling_macros())
@@ -274,6 +313,7 @@ def public init_jit(cg_opt_level : uint) {
     LLVMInitializeAllTargets()
     LLVMInitializeAllTargetMCs()
     LLVMInitializeAllAsmPrinters()
+    init_jit_clopts()
     g_ctx = LLVMContextCreate()
     g_prim_t = new PrimitiveTypes(g_ctx)
     if (LLVM_ENABLE_DIAGNOSTIC) {

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -631,33 +631,52 @@ def public build_block_type {
     ]
 }
 
+// opt_level: 0..3 — picks LLVMCodeGenOptLevel for codegen-side passes
+// use_host_cpu: when true, plumb the host CPU name + feature set into the
+//   TargetMachine. Without this, TargetTransformInfo returns a generic
+//   baseline cost model, which throttles loop unrolling, register-pressure
+//   estimation, and vectorization decisions for the IR-level pipeline
+//   driven by LLVMRunPasses. Use true for JIT and JIT-DLL-cache emission
+//   (the artifact only ever runs on this host); use false for redistributable
+//   exe/dll emission where the binary must run on any compatible CPU.
 [macro_function]
-def public with_default_target_machine(blk : block<(LLVMTargetMachineRef) : void>) {
+def public with_default_target_machine(opt_level : uint; use_host_cpu : bool;
+                                       blk : block<(LLVMTargetMachineRef) : void>) {
     LLVMInitializeAllTargetInfos()
     LLVMInitializeAllTargets()
     LLVMInitializeAllTargetMCs()
     LLVMInitializeAllAsmPrinters()
 
-    // let triple = "x86_64-pc-linux-gnu"
     let triple = LLVMGetDefaultTargetTriple()
 
-    // Find the target using the triple
     var target : LLVMTarget?
     let error : string?
     LLVMGetTargetFromTriple(triple, unsafe(addr(target)), error)
 
+    let cpu = use_host_cpu ? LLVMGetHostCPUName() : ""
+    let features = use_host_cpu ? LLVMGetHostCPUFeatures() : ""
+    let cg_level = (
+        (opt_level >= 3u) ? LLVMCodeGenOptLevel.LLVMCodeGenLevelAggressive
+      : (opt_level >= 2u) ? LLVMCodeGenOptLevel.LLVMCodeGenLevelDefault
+      : (opt_level >= 1u) ? LLVMCodeGenOptLevel.LLVMCodeGenLevelLess
+                          : LLVMCodeGenOptLevel.LLVMCodeGenLevelNone)
+
     let targetMachine = LLVMCreateTargetMachine(
         target,
         triple,
-        "", // CPU
-        "", // Features
-        LLVMCodeGenOptLevel.LLVMCodeGenLevelDefault,
+        cpu,
+        features,
+        cg_level,
         LLVMRelocMode.LLVMRelocPIC, // PIC in order to have shared object
         LLVMCodeModel.Default
     )
 
     invoke(blk, targetMachine)
 
+    if (use_host_cpu) {
+        LLVMDisposeMessage(cpu)
+        LLVMDisposeMessage(features)
+    }
     LLVMDisposeMessage(triple)
     LLVMDisposeTargetMachine(targetMachine)
 }
@@ -668,7 +687,8 @@ def public with_default_target_machine(blk : block<(LLVMTargetMachineRef) : void
 // @path_to_linker - path to clang-cl on Windows. By default we'll use clang-cl from LLVM package
 // on Windows, default otherwise.
 def public write_dll(mod : LLVMOpaqueModule?; out_path : string; path_to_dascript_lib, path_to_linker : string; link_whole_lib : bool) {
-    with_default_target_machine() $(targetMachine : LLVMTargetMachineRef) {
+    // JIT DLL cache: emitted artifact only ever runs on this host.
+    with_default_target_machine(3u, true) $(targetMachine : LLVMTargetMachineRef) {
         let error : string?
         let file = add_obj_extension(out_path)
         let filetype = LLVMCodeGenFileType.LLVMObjectFile
@@ -678,7 +698,8 @@ def public write_dll(mod : LLVMOpaqueModule?; out_path : string; path_to_dascrip
 }
 
 def public write_exe(mod : LLVMOpaqueModule?; out_path : string; path_to_dascript_lib, path_to_linker : string; link_whole_lib : bool) {
-    with_default_target_machine() $(targetMachine : LLVMTargetMachineRef) {
+    // Standalone exe: must run on any compatible CPU, keep generic.
+    with_default_target_machine(3u, false) $(targetMachine : LLVMTargetMachineRef) {
         let error : string?
         let file = add_obj_extension(out_path)
         let filetype = LLVMCodeGenFileType.LLVMObjectFile

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -290,7 +290,7 @@ class JIT_LLVM : AstSimulateMacro {
                     panic("Internal jit error. Failed to get IR for functions {fn_names}.\n")
                 }
                 generate_global_ctors_dtors(g_prim_t, !(use_dll || gen_exe))
-                optimize_llvm_module(opt_level |> uint(), size_level |> uint(), LLVM_INLINE_THRESHOLD)
+                optimize_llvm_module(opt_level |> uint(), size_level |> uint(), LLVM_INLINE_THRESHOLD, !gen_exe)
                 if (dump_ir) {
                     // Let's remove unused attributes before we print IR.
                     var pmo = LLVMCreatePassBuilderOptions()


### PR DESCRIPTION
## Summary

Two related fixes that bring the daslang JIT's `default<O3>` pipeline closer to what `opt -passes='default<O3>'` produces on the same IR.

### Commit 1 — host CPU + features in `TargetMachine`

`with_default_target_machine()` was constructing the `TargetMachine` used by `LLVMRunPasses` with `CPU=""`, `Features=""`, and `LLVMCodeGenLevelDefault` (O2) regardless of the user-selected `jit_opt_level`. `TargetTransformInfo` queries during the IR pipeline (loop-unroll cost, register-pressure model, vectorizer cost) fell back to a generic baseline.

`LLVMGetHostCPUName()` / `LLVMGetHostCPUFeatures()` were already called in `init_jit` but only used for `LOG_DEBUG` output — never plumbed into the actual `TargetMachine`.

This commit threads `opt_level` and a `use_host_cpu` flag through the three call sites:

| Call site | opt_level | use_host_cpu | Why |
|---|---|---|---|
| `optimize_llvm_module` | user `jit_opt_level` | `true` | JIT runs on this host |
| `write_dll` | `3u` | `true` | JIT DLL cache is host-only |
| `write_exe` | `3u` | `false` | Standalone exe is redistributable; keep generic |

Independently correct regardless of perf impact — every other LLVM client does this.

### Commit 2 — `LLVMParseCommandLineOptions` for unroll thresholds

LLVM's cost-model thresholds for unroll / partial-unroll / unroll-and-jam are compiled-in `cl::opt` globals. `opt(1)` sets them indirectly via `cl::ParseCommandLineOptions` before parsing the `-passes` string; daslang's JIT path did not, so the same `default<O3>` pipeline landed different IR shapes (rolled outer loops, no unroll-and-jam) than `opt` produces on the same input.

`init_jit_clopts()` runs once per process, before `init_jit()`, and forwards seven flags through `LLVMParseCommandLineOptions`:

```
-unroll-threshold=400
-unroll-partial-threshold=600
-unroll-max-count=16
-unroll-allow-partial=true
-enable-unroll-and-jam=true
-allow-unroll-and-jam=true
```

Bisected against the dasProfile benchmark suite (JIT mode, 16 tests):

| Test | speedup |
|---|---|
| spectral-norm | 2.77× |
| native | 1.44× |
| queen | 1.39× |
| sha256 | 1.17× |
| dict / mandelbrot / exp | +1–3% |
| 8 others | within ±2% |
| **primes** | **−9%** |

The three permission flags (`-unroll-allow-partial` + the unroll-and-jam pair) are load-bearing for spectral-norm and native; the threshold quartet is what pushes queen from 1.05× to 1.39×. primes is the only test we lose, and it is fundamentally coupled to `-unroll-allow-partial` (the tight `for (i in 2..n) if (n%i==0) return false` divisibility loop — partial unroll bloats the early-exit path without enabling vectorization). Bisection confirmed it can't be split off by threshold tuning.

## What this does and does not do

Together these commits close most of the JIT-vs-clang perf gap on the benchmarks above, but not all of it. `LLVMRunPasses` (C-API, `lib/Passes/PassBuilderBindings.cpp`) still sets up the analysis manager differently from opt's `runPassPipeline` (`tools/opt/NewPMDriver.cpp`):

- opt: `FAM.registerPass([&] { return TargetLibraryAnalysis(*TLII); })` — platform-aware `TargetLibraryInfoImpl`
- opt: `MAM.registerPass([&] { return RuntimeLibraryAnalysis(...); })` + `LibcallLoweringModuleAnalysis()` (LLVM 22)
- opt: `TM->setPGOOption(P)` (even for NoPGO)
- opt: `registerEPCallbacks(PB)`

`LLVMRunPasses` does none of these. Empirically, running `opt -passes='default<O3>'` on the JIT-emitted post-opt IR fully unrolls the outer `for c in 0..8` loop and TRE-eliminates `addqueen` (`br label %tailrecurse`); the cl::opts above don't reproduce that full transformation through `LLVMRunPasses`. Closing the remainder needs a small C++ shim (~30 lines) replacing `LLVMRunPasses` at the `optimize_llvm_module` call site. Tracking as follow-up.

## Test plan
- [x] `tests/jit_tests/` — 50 passed / 0 failed
- [x] `tests/jit/` — 19 passed / 0 failed / 0 errors (initial run on commit 1)
- [x] `modules/dasLLVM/examples/hello_jit.das`, `hello_llvm_jit.das`, `hello_llvm_jit_function.das` — all run
- [x] `dasProfile` benchmark suite via `examples/profile/main.das --test queen` — JIT/AOT/C++ paths all produce correct result (92 solutions)
- [x] `mcp__daslang__format_file` clean on both files
- [x] Lint: 6 pre-existing warnings in `llvm_jit_common.das`, none in the changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)