### PR TITLE
jit: !llvm.loop.mustprogress + cold panic paths + more [hint(...)] knobs

### DIFF
--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1149,9 +1149,7 @@ class public LlvmJitVisitor : AstVisitor {
     }
 
     def build_fixed_loop(count : int; blk : block<(var index : LLVMOpaqueValue?) : void>) {
-        if (count == 0) {
-            pass
-        }
+        return if (count == 0)
         if (count == 1) {
             invoke(blk, types.ConstI32(0ul))
         } else {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -461,6 +461,11 @@ class public LlvmJitVisitor : AstVisitor {
         var noInline = false
         var optNone = false
         var hot = false
+        var cold = false
+        var mustProgress = false
+        var minSize = false
+        var noFree = false
+        var noRecurse = false
         option_no_range_check = false
         option_no_alias = false
         option_no_capture = false
@@ -476,6 +481,16 @@ class public LlvmJitVisitor : AstVisitor {
                         optNone = true
                     } elif (arg.name == "hot") {
                         hot = true
+                    } elif (arg.name == "cold") {
+                        cold = true
+                    } elif (arg.name == "mustprogress") {
+                        mustProgress = true
+                    } elif (arg.name == "minsize") {
+                        minSize = true
+                    } elif (arg.name == "nofree") {
+                        noFree = true
+                    } elif (arg.name == "norecurse") {
+                        noRecurse = true
                     } elif (arg.name == "unsafe_range_check") {
                         option_no_range_check = true
                     } elif (arg.name == "unsafe_alias") {
@@ -501,6 +516,21 @@ class public LlvmJitVisitor : AstVisitor {
         }
         if (hot) {
             LLVMAddAttributeToFunction(ffunc, attributes.hot)
+        }
+        if (cold) {
+            LLVMAddAttributeToFunction(ffunc, attributes.cold)
+        }
+        if (mustProgress) {
+            LLVMAddAttributeToFunction(ffunc, attributes.mustprogress)
+        }
+        if (minSize) {
+            LLVMAddAttributeToFunction(ffunc, attributes.minsize)
+        }
+        if (noFree) {
+            LLVMAddAttributeToFunction(ffunc, attributes.nofree)
+        }
+        if (noRecurse) {
+            LLVMAddAttributeToFunction(ffunc, attributes.norecurse)
         }
         if (optNone) {
             if (alwaysInline) {
@@ -1134,7 +1164,8 @@ class public LlvmJitVisitor : AstVisitor {
             invoke(blk, LLVMBuildLoad2(g_builder, types.t_int32, loop, ""))
             LLVMBuildStore(g_builder, LLVMBuildAdd(g_builder, LLVMBuildLoad2(g_builder, types.t_int32, loop, ""), types.ConstI32(1ul), ""), loop)
             var loop_cond = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULT, LLVMBuildLoad2(g_builder, types.t_int32, loop, ""), types.ConstI32(uint64(count)), "")
-            LLVMBuildCondBr(g_builder, loop_cond, loop_bb, loop_end_bb)
+            let backedge = LLVMBuildCondBr(g_builder, loop_cond, loop_bb, loop_end_bb)
+            attach_loop_mustprogress(backedge)
             LLVMPositionBuilderAtEnd(g_builder, loop_end_bb)
         }
     }
@@ -2710,7 +2741,8 @@ class public LlvmJitVisitor : AstVisitor {
         var lblk = loop_stack |> back()
         loop_stack |> pop()
         if (!current_block_terminates()) {
-            LLVMBuildBr(g_builder, lblk.loop_start)
+            let backedge = LLVMBuildBr(g_builder, lblk.loop_start)
+            attach_loop_mustprogress(backedge)
         }
         LLVMPositionBuilderAtEnd(g_builder, lblk.loop_end)
         return expr
@@ -3108,7 +3140,8 @@ class public LlvmJitVisitor : AstVisitor {
                 failed_E(ssrc, "unsupported loop source {describe(ssrc._type)}")
             }
         }
-        LLVMBuildBr(g_builder, lblk.loop_start)
+        let backedge = LLVMBuildBr(g_builder, lblk.loop_start)
+        attach_loop_mustprogress(backedge)
         /*
         LOOP_END:
             evalFinal(context)
@@ -5930,6 +5963,32 @@ class public LlvmJitVisitor : AstVisitor {
         )
         var typ = g_fn_types[FN_JIT_EXCEPTION]
         LLVMBuildCall2(g_builder, typ, LLVMGetNamedFunction(g_mod, FN_JIT_EXCEPTION), params, "")
+    }
+
+    // Attach `!llvm.loop !N` with `!N = distinct !{!N, !{!"llvm.loop.mustprogress"}}`
+    // to the given backedge branch. Self-reference is required by LangRef and is
+    // what gives the loop its pointer-identity for opt's loop-info bookkeeping.
+    //
+    // `mustprogress` tells opt the loop is required to make forward progress
+    // (i.e., side-effect-free infinite loops are UB and can be deleted). This
+    // matches daslang semantics — there's no infinite-loop idiom that opt
+    // shouldn't be allowed to assume terminates — and unblocks transformations
+    // that bail conservatively on potentially-non-progressing loops.
+    def attach_loop_mustprogress(branch_inst : LLVMValueRef) {
+        let mustprogress_str = LLVMMDStringInContext2(g_ctx, "llvm.loop.mustprogress", 22ul)
+        var inner_arr : LLVMOpaqueMetadata? [1]
+        inner_arr[0] = mustprogress_str
+        let inner = LLVMMDNodeInContext2(g_ctx, unsafe(addr(inner_arr[0])), 1ul)
+        let temp = LLVMTemporaryMDNode(g_ctx, null, 0ul)
+        var loop_arr : LLVMOpaqueMetadata? [2]
+        loop_arr[0] = temp
+        loop_arr[1] = inner
+        let loop_md = LLVMMDNodeInContext2(g_ctx, unsafe(addr(loop_arr[0])), 2ul)
+        LLVMMetadataReplaceAllUsesWith(temp, loop_md)
+        LLVMDisposeTemporaryMDNode(temp)
+        let loop_md_val = LLVMMetadataAsValue(g_ctx, loop_md)
+        let kind_id = LLVMGetMDKindIDInContext(g_ctx, "llvm.loop", 9u)
+        LLVMSetMetadata(branch_inst, kind_id, loop_md_val)
     }
 
     def at_function_entry(blk : block) {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -5266,7 +5266,15 @@ class public LlvmJitVisitor : AstVisitor {
             LLVMBuildStore(g_builder, LLVMConstNull(LLVMPointerType(types.t_int8, 0u)), callBlock)
         }
         var lblk = loop_stack |> back()
-        LLVMBuildBr(g_builder, lblk.loop_continue != null ? lblk.loop_continue : lblk.loop_start)
+        let target = lblk.loop_continue != null ? lblk.loop_continue : lblk.loop_start
+        let br = LLVMBuildBr(g_builder, target)
+        // Attach mustprogress to any branch that lands directly on the header.
+        // for-loops route through loop_continue (no metadata needed here, the
+        // continue's terminating br to loop_start carries it); while-loops
+        // have no continue latch, so this branch IS a backedge.
+        if (target == lblk.loop_start) {
+            attach_loop_mustprogress(br)
+        }
     }
 
 // ExprMakeBlock
@@ -5978,14 +5986,17 @@ class public LlvmJitVisitor : AstVisitor {
         let mustprogress_str = LLVMMDStringInContext2(g_ctx, "llvm.loop.mustprogress", 22ul)
         var inner_arr : LLVMOpaqueMetadata? [1]
         inner_arr[0] = mustprogress_str
-        let inner = LLVMMDNodeInContext2(g_ctx, unsafe(addr(inner_arr[0])), 1ul)
+        let inner = LLVMMDNodeInContext2(g_ctx, array_data_ptr(inner_arr), 1ul)
+        // LLVMMetadataReplaceAllUsesWith calls MDNode::deleteTemporary on
+        // `temp` internally, so do NOT also call LLVMDisposeTemporaryMDNode
+        // — that would be a double-free (crashes on Linux/Windows, masked
+        // by Apple's allocator).
         let temp = LLVMTemporaryMDNode(g_ctx, null, 0ul)
         var loop_arr : LLVMOpaqueMetadata? [2]
         loop_arr[0] = temp
         loop_arr[1] = inner
-        let loop_md = LLVMMDNodeInContext2(g_ctx, unsafe(addr(loop_arr[0])), 2ul)
+        let loop_md = LLVMMDNodeInContext2(g_ctx, array_data_ptr(loop_arr), 2ul)
         LLVMMetadataReplaceAllUsesWith(temp, loop_md)
-        LLVMDisposeTemporaryMDNode(temp)
         let loop_md_val = LLVMMetadataAsValue(g_ctx, loop_md)
         let kind_id = LLVMGetMDKindIDInContext(g_ctx, "llvm.loop", 9u)
         LLVMSetMetadata(branch_inst, kind_id, loop_md_val)

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -97,6 +97,11 @@ class public Attributes {
     alwaysinline : LLVMOpaqueAttributeRef?
     noinline : LLVMOpaqueAttributeRef?
     hot : LLVMOpaqueAttributeRef?
+    cold : LLVMOpaqueAttributeRef?
+    mustprogress : LLVMOpaqueAttributeRef?
+    minsize : LLVMOpaqueAttributeRef?
+    nofree : LLVMOpaqueAttributeRef?
+    norecurse : LLVMOpaqueAttributeRef?
     noalias : LLVMOpaqueAttributeRef?
     sext : LLVMOpaqueAttributeRef?
     zext : LLVMOpaqueAttributeRef?
@@ -111,6 +116,11 @@ class public Attributes {
         alwaysinline = ctx |> LLVMGetEnumAttribute("alwaysinline")
         noinline = ctx |> LLVMGetEnumAttribute("noinline")
         hot = ctx |> LLVMGetEnumAttribute("hot")
+        cold = ctx |> LLVMGetEnumAttribute("cold")
+        mustprogress = ctx |> LLVMGetEnumAttribute("mustprogress")
+        minsize = ctx |> LLVMGetEnumAttribute("minsize")
+        nofree = ctx |> LLVMGetEnumAttribute("nofree")
+        norecurse = ctx |> LLVMGetEnumAttribute("norecurse")
         noalias = ctx |> LLVMGetEnumAttribute("noalias")
         sext = ctx |> LLVMGetEnumAttribute("signext")
         zext = ctx |> LLVMGetEnumAttribute("zeroext")
@@ -337,6 +347,7 @@ def public init_jit(cg_opt_level : uint) {
     assume nounwind = attrs.nounwind
     assume willreturn = attrs.willreturn
     assume nocapture = attrs.nocapture
+    assume cold = attrs.cold
     build_jit_types()
 
     // add default functions
@@ -345,6 +356,10 @@ def public init_jit(cg_opt_level : uint) {
             fixed_array<LLVMTypeRef>(g_prim_t.get_type_string(), g_prim_t.LLVMVoidPtrType(), g_prim_t.LLVMVoidPtrType())))
     LLVMAddGlobalMapping(g_engine, jit_exception, get_jit_exception())
     LLVMAddAttributeToFunction(jit_exception, noreturn)
+    // 'cold' tells opt that any branch ending in a jit_exception call is
+    // unlikely (panic/assert paths). Pairs with noreturn so block-placement
+    // sinks the failure block and keeps the hot path straight.
+    LLVMAddAttributeToFunction(jit_exception, cold)
     LLVMAddAttributeToFunctionArgumentRange(jit_exception, urange(0, 2), nocapture)
     // jit_call_or_fastcall(func,args *,context *)
     var jit_call_or_fastcall = LLVMAddFunctionWithType(g_mod, FN_JIT_CALL_OR_FASTCALL,


### PR DESCRIPTION
## Summary

Three related codegen improvements that give LLVM's optimizer better semantic information about daslang-emitted IR. Follow-up to PR #2634 (host CPU + cl::opts).

### 1. `!llvm.loop.mustprogress` on every backedge

Attach a self-referential `!llvm.loop` metadata containing `!"llvm.loop.mustprogress"` to the backedge branch of every for/while/fixed-count loop emitted by the JIT. This tells opt the loop is required to make forward progress, which matches daslang semantics — there is no infinite-loop idiom that the optimizer should be forbidden to assume terminates. Unblocks transformations that otherwise bail conservatively on potentially-non-progressing loops.

Wired at three backedges in `llvm_jit.das`:
- `build_fixed_loop` (the `[unsafe_outside_of_for]` helper used by ranged loops)
- `visitExprWhile` (the bottom-of-body branch back to `loop_start`)
- `visitExprFor`   (the bottom-of-body branch back to `loop_start`)

Self-reference is required by LangRef and is how opt's loop-info bookkeeping gives each loop pointer-identity. The C-API sequence is `LLVMTemporaryMDNode` → `LLVMMDNodeInContext2` → `LLVMMetadataReplaceAllUsesWith` (all already bound in `bindings/llvm_func.das`).

### 2. `cold` on `FN_JIT_EXCEPTION`

The runtime helper called from `ExprAssert` codegen and `build_exception` was already tagged `noreturn`; adding `cold` tells opt that any branch ending in `jit_exception` is unlikely. Block placement now sinks the failure path and keeps the hot path straight, paired with the `noreturn` the call site already had. Single declaration site, so every call (assert, panic, internal exceptions) inherits the attribute automatically.

### 3. Five new function-level `[hint(...)]` knobs

Extend `process_function_hints` to accept:

| Hint | LLVM attribute | When to use |
|---|---|---|
| `[hint(cold)]` | `cold` | Function unlikely to be called on hot path (error handlers, init) |
| `[hint(mustprogress)]` | `mustprogress` | Function is required to make forward progress |
| `[hint(minsize)]` | `minsize` | Prefer code size over speed (cold-code shrink) |
| `[hint(nofree)]` | `nofree` | Function does not call free / dealloc anything reachable |
| `[hint(norecurse)]` | `norecurse` | Function is non-recursive |

The corresponding `LLVMOpaqueAttributeRef` slots are added to the `Attributes` class cache in `llvm_jit_common.das`. The existing `[hint(hot|alwaysinline|noinline|optnone)]` mechanism is untouched.

## Bench (Apple M1 Max, JIT mode)

5-run medians; single-shot variance on these microbenchmarks is ~30% so this is "no measurable regression" rather than a perf claim:

| Test | master | this PR | Δ |
|---|---|---|---|
| queen | 80 μs | 63 μs | within noise (lean positive) |
| spectral-norm | 3158 μs | 3159 μs | flat |
| primes | 6865 μs | 6919 μs | flat (+0.8%) |

The real perf wins were in PR #2634 (queen 1.39×, spectral-norm 2.77×). This PR is about giving the optimizer correct loop semantics and giving users finer per-function control — it's enabling infrastructure for future tuning, not a benchmark unlock.

## Test plan
- [x] `tests/jit_tests/` — 50/50 pass
- [x] `mcp__daslang__format_file` clean on both files
- [x] Lint: 115 pre-existing warnings in `llvm_jit.das`, 6 in `llvm_jit_common.das`; none in changed lines
- [x] `dasProfile` bench on queen / spectral-norm / primes — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)