### PR TITLE
jit: per-loop LLVM hint annotations on for/while

### DIFF
--- a/include/daScript/ast/ast_expressions.h
+++ b/include/daScript/ast/ast_expressions.h
@@ -956,6 +956,7 @@ namespace das
         LineInfo                visibility;
         bool                    allowIteratorOptimization = false;  // if enabled, unused source variables can be removed
         bool                    canShadow = false;                  // if enabled, local variables can shadow
+        AnnotationArgumentList  annotations;                        // per-loop LLVM hint metadata (bare arg list, annotation name is implicit)
     };
 
     struct DAS_API ExprUnsafe : Expression {
@@ -982,6 +983,7 @@ namespace das
         virtual void dispatch( Visitor & vis ) override;
         virtual void gc_collect ( gc_root * target, gc_root * from ) override;
         ExpressionPtr   cond = nullptr, body = nullptr;
+        AnnotationArgumentList  annotations;                        // per-loop LLVM hint metadata (bare arg list, annotation name is implicit)
     };
 
     struct DAS_API ExprWith : Expression {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -66,6 +66,7 @@ struct private LoopBlock {
     loop_end   : LLVMOpaqueBasicBlock?
     loop_continue : LLVMOpaqueBasicBlock?
     need_loop  : LLVMOpaqueValue?
+    parent_while : ExprWhile?   // set in preVisitExprWhile; null for ExprFor — used by preVisitExprContinue
 }
 
 struct SLabel {
@@ -2722,7 +2723,8 @@ class public LlvmJitVisitor : AstVisitor {
         var lblk = LoopBlock(
             loop_start = append_basic_block("while_start"),
             loop_body = append_basic_block("while_body"),
-            loop_end = append_basic_block("while_end")
+            loop_end = append_basic_block("while_end"),
+            parent_while = expr
         )
         loop_stack |> push(lblk)
         LLVMBuildBr(g_builder, lblk.loop_start)
@@ -2740,7 +2742,7 @@ class public LlvmJitVisitor : AstVisitor {
         loop_stack |> pop()
         if (!current_block_terminates()) {
             let backedge = LLVMBuildBr(g_builder, lblk.loop_start)
-            attach_loop_mustprogress(backedge)
+            attach_loop_metadata(backedge, expr.annotations)
         }
         LLVMPositionBuilderAtEnd(g_builder, lblk.loop_end)
         return expr
@@ -3139,7 +3141,7 @@ class public LlvmJitVisitor : AstVisitor {
             }
         }
         let backedge = LLVMBuildBr(g_builder, lblk.loop_start)
-        attach_loop_mustprogress(backedge)
+        attach_loop_metadata(backedge, expr.annotations)
         /*
         LOOP_END:
             evalFinal(context)
@@ -5266,12 +5268,18 @@ class public LlvmJitVisitor : AstVisitor {
         var lblk = loop_stack |> back()
         let target = lblk.loop_continue != null ? lblk.loop_continue : lblk.loop_start
         let br = LLVMBuildBr(g_builder, target)
-        // Attach mustprogress to any branch that lands directly on the header.
+        // Attach loop metadata to any branch that lands directly on the header.
         // for-loops route through loop_continue (no metadata needed here, the
         // continue's terminating br to loop_start carries it); while-loops
-        // have no continue latch, so this branch IS a backedge.
+        // have no continue latch, so this branch IS a backedge. The parent
+        // ExprWhile is stashed on the LoopBlock so we can read its per-loop
+        // annotations here for the while-continue backedge.
         if (target == lblk.loop_start) {
-            attach_loop_mustprogress(br)
+            if (lblk.parent_while != null) {
+                attach_loop_metadata(br, lblk.parent_while.annotations)
+            } else {
+                attach_loop_mustprogress(br)
+            }
         }
     }
 
@@ -5971,33 +5979,96 @@ class public LlvmJitVisitor : AstVisitor {
         LLVMBuildCall2(g_builder, typ, LLVMGetNamedFunction(g_mod, FN_JIT_EXCEPTION), params, "")
     }
 
-    // Attach `!llvm.loop !N` with `!N = distinct !{!N, !{!"llvm.loop.mustprogress"}}`
+    // Build `!{!"name"}` — a 1-operand MDNode wrapping a metadata string.
+    def make_loop_md_flag(name : string) : LLVMOpaqueMetadata? {
+        var arr : LLVMOpaqueMetadata? [1]
+        arr[0] = LLVMMDStringInContext2(g_ctx, name, uint64(length(name)))
+        return LLVMMDNodeInContext2(g_ctx, array_data_ptr(arr), 1ul)
+    }
+
+    // Build `!{!"name", i32 N}` — a 2-operand MDNode used for LangRef pairs
+    // like `llvm.loop.unroll.count, i32 N`.
+    def make_loop_md_pair_i32(name : string; n : int) : LLVMOpaqueMetadata? {
+        var arr : LLVMOpaqueMetadata? [2]
+        arr[0] = LLVMMDStringInContext2(g_ctx, name, uint64(length(name)))
+        arr[1] = LLVMValueAsMetadata(LLVMConstInt(types.t_int32, uint64(n), 0))
+        return LLVMMDNodeInContext2(g_ctx, array_data_ptr(arr), 2ul)
+    }
+
+    // Build `!{!"name", i1 b}` — for `llvm.loop.vectorize.enable`-style toggles.
+    def make_loop_md_pair_i1(name : string; b : bool) : LLVMOpaqueMetadata? {
+        var arr : LLVMOpaqueMetadata? [2]
+        arr[0] = LLVMMDStringInContext2(g_ctx, name, uint64(length(name)))
+        arr[1] = LLVMValueAsMetadata(LLVMConstInt(types.t_int1, b ? 1ul : 0ul, 0))
+        return LLVMMDNodeInContext2(g_ctx, array_data_ptr(arr), 2ul)
+    }
+
+    // Map per-loop annotation args (the bare list stored on ExprFor/ExprWhile)
+    // to LangRef !llvm.loop.* operand MDNodes.
+    def append_loop_hint_operand(var operands : array<LLVMOpaqueMetadata?>; a : AnnotationArgument) {
+        if (a.name == "unroll") operands |> push <| make_loop_md_flag("llvm.loop.unroll.enable")
+        elif (a.name == "unroll_full") operands |> push <| make_loop_md_flag("llvm.loop.unroll.full")
+        elif (a.name == "unroll_disable") operands |> push <| make_loop_md_flag("llvm.loop.unroll.disable")
+        elif (a.name == "unroll_and_jam") operands |> push <| make_loop_md_flag("llvm.loop.unroll_and_jam.enable")
+        elif (a.name == "unroll_and_jam_disable") operands |> push <| make_loop_md_flag("llvm.loop.unroll_and_jam.disable")
+        elif (a.name == "vectorize") operands |> push <| make_loop_md_pair_i1("llvm.loop.vectorize.enable", true)
+        elif (a.name == "vectorize_disable") operands |> push <| make_loop_md_pair_i1("llvm.loop.vectorize.enable", false)
+        elif (a.name == "vectorize_predicate") operands |> push <| make_loop_md_pair_i1("llvm.loop.vectorize.predicate.enable", true)
+        elif (a.name == "distribute") operands |> push <| make_loop_md_pair_i1("llvm.loop.distribute.enable", true)
+        elif (a.name == "disable_nonforced") operands |> push <| make_loop_md_flag("llvm.loop.disable_nonforced")
+        elif (a.name == "licm_versioning_disable") operands |> push <| make_loop_md_flag("llvm.loop.licm_versioning.disable")
+        elif (a.name == "unroll_count"     && a.basicType == Type.tInt) operands |> push <| make_loop_md_pair_i32("llvm.loop.unroll.count",     int(a.iValue))
+        elif (a.name == "vectorize_width"  && a.basicType == Type.tInt) operands |> push <| make_loop_md_pair_i32("llvm.loop.vectorize.width", int(a.iValue))
+        elif (a.name == "interleave_count" && a.basicType == Type.tInt) operands |> push <| make_loop_md_pair_i32("llvm.loop.interleave.count", int(a.iValue))
+        else                                          failed("unknown loop hint '{a.name}'")
+    }
+
+    // Attach `!llvm.loop !N` with `!N = distinct !{!N, !{!"llvm.loop.mustprogress"}, <user-mds...>}`
     // to the given backedge branch. Self-reference is required by LangRef and is
     // what gives the loop its pointer-identity for opt's loop-info bookkeeping.
     //
-    // `mustprogress` tells opt the loop is required to make forward progress
-    // (i.e., side-effect-free infinite loops are UB and can be deleted). This
-    // matches daslang semantics — there's no infinite-loop idiom that opt
-    // shouldn't be allowed to assume terminates — and unblocks transformations
-    // that bail conservatively on potentially-non-progressing loops.
-    def attach_loop_mustprogress(branch_inst : LLVMValueRef) {
-        let mustprogress_str = LLVMMDStringInContext2(g_ctx, "llvm.loop.mustprogress", 22ul)
-        var inner_arr : LLVMOpaqueMetadata? [1]
-        inner_arr[0] = mustprogress_str
-        let inner = LLVMMDNodeInContext2(g_ctx, array_data_ptr(inner_arr), 1ul)
+    // `mustprogress` is always attached: it tells opt the loop must make forward
+    // progress (side-effect-free infinite loops are UB and can be deleted) —
+    // matches daslang semantics and unblocks transformations that bail on
+    // potentially-non-progressing loops.
+    //
+    // Per-loop hints (LangRef !llvm.loop.*) come from the AnnotationArgumentList
+    // stored on the ExprFor / ExprWhile node. See append_loop_hint_operand for
+    // the recognized vocabulary.
+    def attach_loop_metadata(branch_inst : LLVMValueRef; args : AnnotationArgumentList) {
+        var operands : array<LLVMOpaqueMetadata?>
         // LLVMMetadataReplaceAllUsesWith calls MDNode::deleteTemporary on
         // `temp` internally, so do NOT also call LLVMDisposeTemporaryMDNode
         // — that would be a double-free (crashes on Linux/Windows, masked
         // by Apple's allocator).
-        let temp = LLVMTemporaryMDNode(g_ctx, null, 0ul)
-        var loop_arr : LLVMOpaqueMetadata? [2]
-        loop_arr[0] = temp
-        loop_arr[1] = inner
-        let loop_md = LLVMMDNodeInContext2(g_ctx, array_data_ptr(loop_arr), 2ul)
+        var temp = LLVMTemporaryMDNode(g_ctx, null, 0ul)
+        operands |> push(temp)
+        var mustprog = make_loop_md_flag("llvm.loop.mustprogress")
+        operands |> push(mustprog)
+        for (a in args) {
+            append_loop_hint_operand(operands, a)
+        }
+        let loop_md = LLVMMDNodeInContext2(g_ctx, array_data_ptr(operands), uint64(length(operands)))
         LLVMMetadataReplaceAllUsesWith(temp, loop_md)
         let loop_md_val = LLVMMetadataAsValue(g_ctx, loop_md)
         let kind_id = LLVMGetMDKindIDInContext(g_ctx, "llvm.loop", 9u)
         LLVMSetMetadata(branch_inst, kind_id, loop_md_val)
+    }
+
+    // Thin wrapper for callsites without a source AST node (build_fixed_loop
+    // for ExprNew array init): mustprogress only. Inlined rather than calling
+    // attach_loop_metadata to sidestep the "construct empty AnnotationArgumentList"
+    // dance — handled types aren't safely default-constructible from das.
+    def attach_loop_mustprogress(branch_inst : LLVMValueRef) {
+        var temp = LLVMTemporaryMDNode(g_ctx, null, 0ul)
+        var loop_arr : LLVMOpaqueMetadata? [2]
+        loop_arr[0] = temp
+        loop_arr[1] = make_loop_md_flag("llvm.loop.mustprogress")
+        let loop_md = LLVMMDNodeInContext2(g_ctx, array_data_ptr(loop_arr), 2ul)
+        LLVMMetadataReplaceAllUsesWith(temp, loop_md)
+        LLVMSetMetadata(branch_inst,
+                        LLVMGetMDKindIDInContext(g_ctx, "llvm.loop", 9u),
+                        LLVMMetadataAsValue(g_ctx, loop_md))
     }
 
     def at_function_entry(blk : block) {

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -2447,6 +2447,7 @@ namespace das {
         Expression::clone(cexpr);
         cexpr->cond = cond->clone();
         cexpr->body = body->clone();
+        cexpr->annotations = annotations;
         return cexpr;
     }
 
@@ -2494,6 +2495,7 @@ namespace das {
         }
         cexpr->allowIteratorOptimization = allowIteratorOptimization;
         cexpr->canShadow = canShadow;
+        cexpr->annotations = annotations;
         return cexpr;
     }
 

--- a/src/builtin/module_builtin_ast_annotations_2.cpp
+++ b/src/builtin/module_builtin_ast_annotations_2.cpp
@@ -145,6 +145,7 @@ namespace das {
             :  AstExpressionAnnotation<ExprWhile> ("ExprWhile", ml) {
             addField<DAS_BIND_MANAGED_FIELD(cond)>("cond");
             addField<DAS_BIND_MANAGED_FIELD(body)>("body");
+            addField<DAS_BIND_MANAGED_FIELD(annotations)>("annotations");
         }
     };
 
@@ -180,6 +181,7 @@ namespace das {
             addField<DAS_BIND_MANAGED_FIELD(visibility)>("visibility");
             addField<DAS_BIND_MANAGED_FIELD(allowIteratorOptimization)>("allowIteratorOptimization");
             addField<DAS_BIND_MANAGED_FIELD(canShadow)>("canShadow");
+            addField<DAS_BIND_MANAGED_FIELD(annotations)>("annotations");
         }
     };
 

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -1782,7 +1782,7 @@ namespace das {
         serializeBase(expr);
         ser << expr->iterators << expr->iteratorsAka << expr->iteratorsAt << expr->iteratorsTupleExpansion << expr->iteratorsTags
             << expr->iteratorVariables << expr->sources << expr->body << expr->visibility
-            << expr->allowIteratorOptimization << expr->canShadow;
+            << expr->allowIteratorOptimization << expr->canShadow << expr->annotations;
     }
 
     void SerializeVisitor::preVisit ( ExprUnsafe * expr ) {
@@ -1792,7 +1792,7 @@ namespace das {
 
     void SerializeVisitor::preVisit ( ExprWhile * expr ) {
         serializeBase(expr);
-        ser << expr->cond << expr->body;
+        ser << expr->cond << expr->body << expr->annotations;
     }
 
     void SerializeVisitor::preVisit ( ExprWith * expr ) {
@@ -2668,9 +2668,8 @@ namespace das {
     }
 
     uint32_t AstSerializer::getVersion () {
-        // bumped for ska::flat_hash_map → das::daslang_hash_map switch:
-        // iteration order differs, invalidating any cached serialized AST.
-        static constexpr uint32_t currentVersion = 81;
+        // bumped for per-loop annotations on ExprFor/ExprWhile.
+        static constexpr uint32_t currentVersion = 82;
         return currentVersion;
     }
 

--- a/src/parser/ds2_parser.cpp
+++ b/src/parser/ds2_parser.cpp
@@ -411,262 +411,263 @@ enum yysymbol_kind_t
   YYSYMBOL_annotation_argument = 272,      /* annotation_argument  */
   YYSYMBOL_annotation_argument_list = 273, /* annotation_argument_list  */
   YYSYMBOL_metadata_argument_list = 274,   /* metadata_argument_list  */
-  YYSYMBOL_annotation_declaration_name = 275, /* annotation_declaration_name  */
-  YYSYMBOL_annotation_declaration_basic = 276, /* annotation_declaration_basic  */
-  YYSYMBOL_annotation_declaration = 277,   /* annotation_declaration  */
-  YYSYMBOL_annotation_list = 278,          /* annotation_list  */
-  YYSYMBOL_optional_annotation_list = 279, /* optional_annotation_list  */
-  YYSYMBOL_optional_annotation_list_with_emit_semis = 280, /* optional_annotation_list_with_emit_semis  */
-  YYSYMBOL_optional_function_argument_list = 281, /* optional_function_argument_list  */
-  YYSYMBOL_optional_function_type = 282,   /* optional_function_type  */
-  YYSYMBOL_function_name = 283,            /* function_name  */
-  YYSYMBOL_das_type_name = 284,            /* das_type_name  */
-  YYSYMBOL_optional_template = 285,        /* optional_template  */
-  YYSYMBOL_global_function_declaration = 286, /* global_function_declaration  */
-  YYSYMBOL_optional_public_or_private_function = 287, /* optional_public_or_private_function  */
-  YYSYMBOL_function_declaration_header = 288, /* function_declaration_header  */
-  YYSYMBOL_function_declaration = 289,     /* function_declaration  */
-  YYSYMBOL_290_16 = 290,                   /* $@16  */
-  YYSYMBOL_expression_block_finally = 291, /* expression_block_finally  */
-  YYSYMBOL_292_17 = 292,                   /* $@17  */
-  YYSYMBOL_293_18 = 293,                   /* $@18  */
-  YYSYMBOL_expression_block = 294,         /* expression_block  */
-  YYSYMBOL_295_19 = 295,                   /* $@19  */
-  YYSYMBOL_296_20 = 296,                   /* $@20  */
-  YYSYMBOL_expr_call_pipe_no_bracket = 297, /* expr_call_pipe_no_bracket  */
-  YYSYMBOL_expression_any = 298,           /* expression_any  */
-  YYSYMBOL_299_21 = 299,                   /* $@21  */
-  YYSYMBOL_300_22 = 300,                   /* $@22  */
-  YYSYMBOL_expressions = 301,              /* expressions  */
-  YYSYMBOL_optional_expr_list = 302,       /* optional_expr_list  */
-  YYSYMBOL_optional_expr_map_tuple_list = 303, /* optional_expr_map_tuple_list  */
-  YYSYMBOL_type_declaration_no_options_list = 304, /* type_declaration_no_options_list  */
-  YYSYMBOL_name_in_namespace = 305,        /* name_in_namespace  */
-  YYSYMBOL_expression_delete = 306,        /* expression_delete  */
-  YYSYMBOL_new_type_declaration = 307,     /* new_type_declaration  */
-  YYSYMBOL_308_23 = 308,                   /* $@23  */
-  YYSYMBOL_309_24 = 309,                   /* $@24  */
-  YYSYMBOL_expr_new = 310,                 /* expr_new  */
-  YYSYMBOL_expression_break = 311,         /* expression_break  */
-  YYSYMBOL_expression_continue = 312,      /* expression_continue  */
-  YYSYMBOL_expression_return = 313,        /* expression_return  */
-  YYSYMBOL_expression_yield = 314,         /* expression_yield  */
-  YYSYMBOL_expression_try_catch = 315,     /* expression_try_catch  */
-  YYSYMBOL_kwd_let_var_or_nothing = 316,   /* kwd_let_var_or_nothing  */
-  YYSYMBOL_kwd_let = 317,                  /* kwd_let  */
-  YYSYMBOL_optional_in_scope = 318,        /* optional_in_scope  */
-  YYSYMBOL_tuple_expansion = 319,          /* tuple_expansion  */
-  YYSYMBOL_tuple_expansion_variable_declaration = 320, /* tuple_expansion_variable_declaration  */
-  YYSYMBOL_expression_let = 321,           /* expression_let  */
-  YYSYMBOL_expr_cast = 322,                /* expr_cast  */
-  YYSYMBOL_323_25 = 323,                   /* $@25  */
-  YYSYMBOL_324_26 = 324,                   /* $@26  */
-  YYSYMBOL_325_27 = 325,                   /* $@27  */
-  YYSYMBOL_326_28 = 326,                   /* $@28  */
-  YYSYMBOL_327_29 = 327,                   /* $@29  */
-  YYSYMBOL_328_30 = 328,                   /* $@30  */
-  YYSYMBOL_expr_type_decl = 329,           /* expr_type_decl  */
-  YYSYMBOL_330_31 = 330,                   /* $@31  */
-  YYSYMBOL_331_32 = 331,                   /* $@32  */
-  YYSYMBOL_expr_type_info = 332,           /* expr_type_info  */
-  YYSYMBOL_expr_list = 333,                /* expr_list  */
-  YYSYMBOL_block_or_simple_block = 334,    /* block_or_simple_block  */
-  YYSYMBOL_block_or_lambda = 335,          /* block_or_lambda  */
-  YYSYMBOL_capture_entry = 336,            /* capture_entry  */
-  YYSYMBOL_capture_list = 337,             /* capture_list  */
-  YYSYMBOL_optional_capture_list = 338,    /* optional_capture_list  */
-  YYSYMBOL_expr_full_block = 339,          /* expr_full_block  */
-  YYSYMBOL_expr_full_block_assumed_piped = 340, /* expr_full_block_assumed_piped  */
-  YYSYMBOL_expr_numeric_const = 341,       /* expr_numeric_const  */
-  YYSYMBOL_expr_assign_no_bracket = 342,   /* expr_assign_no_bracket  */
-  YYSYMBOL_expr_named_call = 343,          /* expr_named_call  */
-  YYSYMBOL_expr_method_call_no_bracket = 344, /* expr_method_call_no_bracket  */
-  YYSYMBOL_func_addr_name = 345,           /* func_addr_name  */
-  YYSYMBOL_func_addr_expr = 346,           /* func_addr_expr  */
-  YYSYMBOL_347_33 = 347,                   /* $@33  */
-  YYSYMBOL_348_34 = 348,                   /* $@34  */
-  YYSYMBOL_349_35 = 349,                   /* $@35  */
-  YYSYMBOL_350_36 = 350,                   /* $@36  */
-  YYSYMBOL_expr_field_no_bracket = 351,    /* expr_field_no_bracket  */
-  YYSYMBOL_352_37 = 352,                   /* $@37  */
-  YYSYMBOL_353_38 = 353,                   /* $@38  */
-  YYSYMBOL_expr_call = 354,                /* expr_call  */
-  YYSYMBOL_expr = 355,                     /* expr  */
-  YYSYMBOL_expr_no_bracket = 356,          /* expr_no_bracket  */
-  YYSYMBOL_357_39 = 357,                   /* $@39  */
-  YYSYMBOL_358_40 = 358,                   /* $@40  */
-  YYSYMBOL_359_41 = 359,                   /* $@41  */
-  YYSYMBOL_360_42 = 360,                   /* $@42  */
-  YYSYMBOL_361_43 = 361,                   /* $@43  */
-  YYSYMBOL_362_44 = 362,                   /* $@44  */
-  YYSYMBOL_expr_generator = 363,           /* expr_generator  */
-  YYSYMBOL_expr_mtag_no_bracket = 364,     /* expr_mtag_no_bracket  */
-  YYSYMBOL_optional_field_annotation = 365, /* optional_field_annotation  */
-  YYSYMBOL_optional_override = 366,        /* optional_override  */
-  YYSYMBOL_optional_constant = 367,        /* optional_constant  */
-  YYSYMBOL_optional_public_or_private_member_variable = 368, /* optional_public_or_private_member_variable  */
-  YYSYMBOL_optional_static_member_variable = 369, /* optional_static_member_variable  */
-  YYSYMBOL_structure_variable_declaration = 370, /* structure_variable_declaration  */
-  YYSYMBOL_struct_variable_declaration_list = 371, /* struct_variable_declaration_list  */
-  YYSYMBOL_372_45 = 372,                   /* $@45  */
-  YYSYMBOL_373_46 = 373,                   /* $@46  */
-  YYSYMBOL_374_47 = 374,                   /* $@47  */
-  YYSYMBOL_function_argument_declaration_no_type = 375, /* function_argument_declaration_no_type  */
-  YYSYMBOL_function_argument_declaration_type = 376, /* function_argument_declaration_type  */
-  YYSYMBOL_function_argument_list = 377,   /* function_argument_list  */
-  YYSYMBOL_tuple_type = 378,               /* tuple_type  */
-  YYSYMBOL_tuple_type_list = 379,          /* tuple_type_list  */
-  YYSYMBOL_tuple_alias_type_list = 380,    /* tuple_alias_type_list  */
-  YYSYMBOL_variant_type = 381,             /* variant_type  */
-  YYSYMBOL_variant_type_list = 382,        /* variant_type_list  */
-  YYSYMBOL_variant_alias_type_list = 383,  /* variant_alias_type_list  */
-  YYSYMBOL_copy_or_move = 384,             /* copy_or_move  */
-  YYSYMBOL_variable_declaration_no_type = 385, /* variable_declaration_no_type  */
-  YYSYMBOL_variable_declaration_type = 386, /* variable_declaration_type  */
-  YYSYMBOL_variable_declaration = 387,     /* variable_declaration  */
-  YYSYMBOL_copy_or_move_or_clone = 388,    /* copy_or_move_or_clone  */
-  YYSYMBOL_optional_ref = 389,             /* optional_ref  */
-  YYSYMBOL_let_variable_name_with_pos_list = 390, /* let_variable_name_with_pos_list  */
-  YYSYMBOL_global_let_variable_name_with_pos_list = 391, /* global_let_variable_name_with_pos_list  */
-  YYSYMBOL_variable_declaration_list = 392, /* variable_declaration_list  */
-  YYSYMBOL_let_variable_declaration = 393, /* let_variable_declaration  */
-  YYSYMBOL_global_let_variable_declaration = 394, /* global_let_variable_declaration  */
-  YYSYMBOL_optional_shared = 395,          /* optional_shared  */
-  YYSYMBOL_optional_public_or_private_variable = 396, /* optional_public_or_private_variable  */
-  YYSYMBOL_global_variable_declaration_list = 397, /* global_variable_declaration_list  */
-  YYSYMBOL_398_48 = 398,                   /* $@48  */
-  YYSYMBOL_global_let = 399,               /* global_let  */
-  YYSYMBOL_400_49 = 400,                   /* $@49  */
-  YYSYMBOL_enum_expression = 401,          /* enum_expression  */
-  YYSYMBOL_commas = 402,                   /* commas  */
-  YYSYMBOL_enum_list = 403,                /* enum_list  */
-  YYSYMBOL_optional_public_or_private_alias = 404, /* optional_public_or_private_alias  */
-  YYSYMBOL_single_alias = 405,             /* single_alias  */
-  YYSYMBOL_406_50 = 406,                   /* $@50  */
-  YYSYMBOL_alias_declaration = 407,        /* alias_declaration  */
-  YYSYMBOL_optional_public_or_private_enum = 408, /* optional_public_or_private_enum  */
-  YYSYMBOL_enum_name = 409,                /* enum_name  */
-  YYSYMBOL_optional_enum_basic_type_declaration = 410, /* optional_enum_basic_type_declaration  */
-  YYSYMBOL_optional_commas = 411,          /* optional_commas  */
-  YYSYMBOL_emit_commas = 412,              /* emit_commas  */
-  YYSYMBOL_optional_emit_commas = 413,     /* optional_emit_commas  */
-  YYSYMBOL_enum_declaration = 414,         /* enum_declaration  */
-  YYSYMBOL_415_51 = 415,                   /* $@51  */
-  YYSYMBOL_416_52 = 416,                   /* $@52  */
-  YYSYMBOL_417_53 = 417,                   /* $@53  */
-  YYSYMBOL_optional_structure_parent = 418, /* optional_structure_parent  */
-  YYSYMBOL_optional_sealed = 419,          /* optional_sealed  */
-  YYSYMBOL_structure_name = 420,           /* structure_name  */
-  YYSYMBOL_class_or_struct = 421,          /* class_or_struct  */
-  YYSYMBOL_optional_public_or_private_structure = 422, /* optional_public_or_private_structure  */
-  YYSYMBOL_optional_struct_variable_declaration_list = 423, /* optional_struct_variable_declaration_list  */
-  YYSYMBOL_structure_declaration = 424,    /* structure_declaration  */
-  YYSYMBOL_425_54 = 425,                   /* $@54  */
-  YYSYMBOL_426_55 = 426,                   /* $@55  */
-  YYSYMBOL_427_56 = 427,                   /* $@56  */
-  YYSYMBOL_variable_name_with_pos_list = 428, /* variable_name_with_pos_list  */
-  YYSYMBOL_basic_type_declaration = 429,   /* basic_type_declaration  */
-  YYSYMBOL_enum_basic_type_declaration = 430, /* enum_basic_type_declaration  */
-  YYSYMBOL_structure_type_declaration = 431, /* structure_type_declaration  */
-  YYSYMBOL_auto_type_declaration = 432,    /* auto_type_declaration  */
-  YYSYMBOL_bitfield_bits = 433,            /* bitfield_bits  */
-  YYSYMBOL_bitfield_alias_bits = 434,      /* bitfield_alias_bits  */
-  YYSYMBOL_bitfield_basic_type_declaration = 435, /* bitfield_basic_type_declaration  */
-  YYSYMBOL_bitfield_type_declaration = 436, /* bitfield_type_declaration  */
-  YYSYMBOL_437_57 = 437,                   /* $@57  */
-  YYSYMBOL_438_58 = 438,                   /* $@58  */
-  YYSYMBOL_c_or_s = 439,                   /* c_or_s  */
-  YYSYMBOL_table_type_pair = 440,          /* table_type_pair  */
-  YYSYMBOL_dim_list = 441,                 /* dim_list  */
-  YYSYMBOL_type_declaration_no_options = 442, /* type_declaration_no_options  */
-  YYSYMBOL_optional_expr_list_in_braces = 443, /* optional_expr_list_in_braces  */
-  YYSYMBOL_type_declaration_no_options_no_dim = 444, /* type_declaration_no_options_no_dim  */
-  YYSYMBOL_445_59 = 445,                   /* $@59  */
-  YYSYMBOL_446_60 = 446,                   /* $@60  */
-  YYSYMBOL_447_61 = 447,                   /* $@61  */
-  YYSYMBOL_448_62 = 448,                   /* $@62  */
-  YYSYMBOL_449_63 = 449,                   /* $@63  */
-  YYSYMBOL_450_64 = 450,                   /* $@64  */
-  YYSYMBOL_451_65 = 451,                   /* $@65  */
-  YYSYMBOL_452_66 = 452,                   /* $@66  */
-  YYSYMBOL_453_67 = 453,                   /* $@67  */
-  YYSYMBOL_454_68 = 454,                   /* $@68  */
-  YYSYMBOL_455_69 = 455,                   /* $@69  */
-  YYSYMBOL_456_70 = 456,                   /* $@70  */
-  YYSYMBOL_457_71 = 457,                   /* $@71  */
-  YYSYMBOL_458_72 = 458,                   /* $@72  */
-  YYSYMBOL_459_73 = 459,                   /* $@73  */
-  YYSYMBOL_460_74 = 460,                   /* $@74  */
-  YYSYMBOL_461_75 = 461,                   /* $@75  */
-  YYSYMBOL_462_76 = 462,                   /* $@76  */
-  YYSYMBOL_463_77 = 463,                   /* $@77  */
-  YYSYMBOL_464_78 = 464,                   /* $@78  */
-  YYSYMBOL_465_79 = 465,                   /* $@79  */
-  YYSYMBOL_466_80 = 466,                   /* $@80  */
-  YYSYMBOL_467_81 = 467,                   /* $@81  */
-  YYSYMBOL_468_82 = 468,                   /* $@82  */
-  YYSYMBOL_469_83 = 469,                   /* $@83  */
-  YYSYMBOL_470_84 = 470,                   /* $@84  */
-  YYSYMBOL_471_85 = 471,                   /* $@85  */
-  YYSYMBOL_472_86 = 472,                   /* $@86  */
-  YYSYMBOL_type_declaration = 473,         /* type_declaration  */
-  YYSYMBOL_tuple_alias_declaration = 474,  /* tuple_alias_declaration  */
-  YYSYMBOL_475_87 = 475,                   /* $@87  */
-  YYSYMBOL_476_88 = 476,                   /* $@88  */
-  YYSYMBOL_477_89 = 477,                   /* $@89  */
-  YYSYMBOL_478_90 = 478,                   /* $@90  */
-  YYSYMBOL_variant_alias_declaration = 479, /* variant_alias_declaration  */
-  YYSYMBOL_480_91 = 480,                   /* $@91  */
-  YYSYMBOL_481_92 = 481,                   /* $@92  */
-  YYSYMBOL_482_93 = 482,                   /* $@93  */
-  YYSYMBOL_483_94 = 483,                   /* $@94  */
-  YYSYMBOL_bitfield_alias_declaration = 484, /* bitfield_alias_declaration  */
-  YYSYMBOL_485_95 = 485,                   /* $@95  */
-  YYSYMBOL_486_96 = 486,                   /* $@96  */
-  YYSYMBOL_487_97 = 487,                   /* $@97  */
-  YYSYMBOL_488_98 = 488,                   /* $@98  */
-  YYSYMBOL_make_decl = 489,                /* make_decl  */
-  YYSYMBOL_make_decl_no_bracket = 490,     /* make_decl_no_bracket  */
-  YYSYMBOL_make_struct_fields = 491,       /* make_struct_fields  */
-  YYSYMBOL_make_variant_dim = 492,         /* make_variant_dim  */
-  YYSYMBOL_make_struct_single = 493,       /* make_struct_single  */
-  YYSYMBOL_make_struct_dim_list = 494,     /* make_struct_dim_list  */
-  YYSYMBOL_make_struct_dim_decl = 495,     /* make_struct_dim_decl  */
-  YYSYMBOL_optional_make_struct_dim_decl = 496, /* optional_make_struct_dim_decl  */
-  YYSYMBOL_use_initializer = 497,          /* use_initializer  */
-  YYSYMBOL_make_struct_decl = 498,         /* make_struct_decl  */
-  YYSYMBOL_499_99 = 499,                   /* $@99  */
-  YYSYMBOL_500_100 = 500,                  /* $@100  */
-  YYSYMBOL_501_101 = 501,                  /* $@101  */
-  YYSYMBOL_502_102 = 502,                  /* $@102  */
-  YYSYMBOL_503_103 = 503,                  /* $@103  */
-  YYSYMBOL_504_104 = 504,                  /* $@104  */
-  YYSYMBOL_505_105 = 505,                  /* $@105  */
-  YYSYMBOL_506_106 = 506,                  /* $@106  */
-  YYSYMBOL_507_107 = 507,                  /* $@107  */
-  YYSYMBOL_508_108 = 508,                  /* $@108  */
-  YYSYMBOL_make_tuple_call = 509,          /* make_tuple_call  */
-  YYSYMBOL_510_109 = 510,                  /* $@109  */
-  YYSYMBOL_511_110 = 511,                  /* $@110  */
-  YYSYMBOL_make_dim_decl = 512,            /* make_dim_decl  */
-  YYSYMBOL_513_111 = 513,                  /* $@111  */
-  YYSYMBOL_514_112 = 514,                  /* $@112  */
-  YYSYMBOL_515_113 = 515,                  /* $@113  */
-  YYSYMBOL_516_114 = 516,                  /* $@114  */
-  YYSYMBOL_517_115 = 517,                  /* $@115  */
-  YYSYMBOL_518_116 = 518,                  /* $@116  */
-  YYSYMBOL_519_117 = 519,                  /* $@117  */
-  YYSYMBOL_520_118 = 520,                  /* $@118  */
-  YYSYMBOL_521_119 = 521,                  /* $@119  */
-  YYSYMBOL_522_120 = 522,                  /* $@120  */
-  YYSYMBOL_expr_map_tuple_list = 523,      /* expr_map_tuple_list  */
-  YYSYMBOL_push_table_nesting = 524,       /* push_table_nesting  */
-  YYSYMBOL_make_table_decl = 525,          /* make_table_decl  */
-  YYSYMBOL_make_table_call = 526,          /* make_table_call  */
-  YYSYMBOL_array_comprehension_where = 527, /* array_comprehension_where  */
-  YYSYMBOL_optional_comma = 528,           /* optional_comma  */
-  YYSYMBOL_table_comprehension = 529,      /* table_comprehension  */
-  YYSYMBOL_array_comprehension = 530       /* array_comprehension  */
+  YYSYMBOL_optional_for_annotations = 275, /* optional_for_annotations  */
+  YYSYMBOL_annotation_declaration_name = 276, /* annotation_declaration_name  */
+  YYSYMBOL_annotation_declaration_basic = 277, /* annotation_declaration_basic  */
+  YYSYMBOL_annotation_declaration = 278,   /* annotation_declaration  */
+  YYSYMBOL_annotation_list = 279,          /* annotation_list  */
+  YYSYMBOL_optional_annotation_list = 280, /* optional_annotation_list  */
+  YYSYMBOL_optional_annotation_list_with_emit_semis = 281, /* optional_annotation_list_with_emit_semis  */
+  YYSYMBOL_optional_function_argument_list = 282, /* optional_function_argument_list  */
+  YYSYMBOL_optional_function_type = 283,   /* optional_function_type  */
+  YYSYMBOL_function_name = 284,            /* function_name  */
+  YYSYMBOL_das_type_name = 285,            /* das_type_name  */
+  YYSYMBOL_optional_template = 286,        /* optional_template  */
+  YYSYMBOL_global_function_declaration = 287, /* global_function_declaration  */
+  YYSYMBOL_optional_public_or_private_function = 288, /* optional_public_or_private_function  */
+  YYSYMBOL_function_declaration_header = 289, /* function_declaration_header  */
+  YYSYMBOL_function_declaration = 290,     /* function_declaration  */
+  YYSYMBOL_291_16 = 291,                   /* $@16  */
+  YYSYMBOL_expression_block_finally = 292, /* expression_block_finally  */
+  YYSYMBOL_293_17 = 293,                   /* $@17  */
+  YYSYMBOL_294_18 = 294,                   /* $@18  */
+  YYSYMBOL_expression_block = 295,         /* expression_block  */
+  YYSYMBOL_296_19 = 296,                   /* $@19  */
+  YYSYMBOL_297_20 = 297,                   /* $@20  */
+  YYSYMBOL_expr_call_pipe_no_bracket = 298, /* expr_call_pipe_no_bracket  */
+  YYSYMBOL_expression_any = 299,           /* expression_any  */
+  YYSYMBOL_300_21 = 300,                   /* $@21  */
+  YYSYMBOL_301_22 = 301,                   /* $@22  */
+  YYSYMBOL_expressions = 302,              /* expressions  */
+  YYSYMBOL_optional_expr_list = 303,       /* optional_expr_list  */
+  YYSYMBOL_optional_expr_map_tuple_list = 304, /* optional_expr_map_tuple_list  */
+  YYSYMBOL_type_declaration_no_options_list = 305, /* type_declaration_no_options_list  */
+  YYSYMBOL_name_in_namespace = 306,        /* name_in_namespace  */
+  YYSYMBOL_expression_delete = 307,        /* expression_delete  */
+  YYSYMBOL_new_type_declaration = 308,     /* new_type_declaration  */
+  YYSYMBOL_309_23 = 309,                   /* $@23  */
+  YYSYMBOL_310_24 = 310,                   /* $@24  */
+  YYSYMBOL_expr_new = 311,                 /* expr_new  */
+  YYSYMBOL_expression_break = 312,         /* expression_break  */
+  YYSYMBOL_expression_continue = 313,      /* expression_continue  */
+  YYSYMBOL_expression_return = 314,        /* expression_return  */
+  YYSYMBOL_expression_yield = 315,         /* expression_yield  */
+  YYSYMBOL_expression_try_catch = 316,     /* expression_try_catch  */
+  YYSYMBOL_kwd_let_var_or_nothing = 317,   /* kwd_let_var_or_nothing  */
+  YYSYMBOL_kwd_let = 318,                  /* kwd_let  */
+  YYSYMBOL_optional_in_scope = 319,        /* optional_in_scope  */
+  YYSYMBOL_tuple_expansion = 320,          /* tuple_expansion  */
+  YYSYMBOL_tuple_expansion_variable_declaration = 321, /* tuple_expansion_variable_declaration  */
+  YYSYMBOL_expression_let = 322,           /* expression_let  */
+  YYSYMBOL_expr_cast = 323,                /* expr_cast  */
+  YYSYMBOL_324_25 = 324,                   /* $@25  */
+  YYSYMBOL_325_26 = 325,                   /* $@26  */
+  YYSYMBOL_326_27 = 326,                   /* $@27  */
+  YYSYMBOL_327_28 = 327,                   /* $@28  */
+  YYSYMBOL_328_29 = 328,                   /* $@29  */
+  YYSYMBOL_329_30 = 329,                   /* $@30  */
+  YYSYMBOL_expr_type_decl = 330,           /* expr_type_decl  */
+  YYSYMBOL_331_31 = 331,                   /* $@31  */
+  YYSYMBOL_332_32 = 332,                   /* $@32  */
+  YYSYMBOL_expr_type_info = 333,           /* expr_type_info  */
+  YYSYMBOL_expr_list = 334,                /* expr_list  */
+  YYSYMBOL_block_or_simple_block = 335,    /* block_or_simple_block  */
+  YYSYMBOL_block_or_lambda = 336,          /* block_or_lambda  */
+  YYSYMBOL_capture_entry = 337,            /* capture_entry  */
+  YYSYMBOL_capture_list = 338,             /* capture_list  */
+  YYSYMBOL_optional_capture_list = 339,    /* optional_capture_list  */
+  YYSYMBOL_expr_full_block = 340,          /* expr_full_block  */
+  YYSYMBOL_expr_full_block_assumed_piped = 341, /* expr_full_block_assumed_piped  */
+  YYSYMBOL_expr_numeric_const = 342,       /* expr_numeric_const  */
+  YYSYMBOL_expr_assign_no_bracket = 343,   /* expr_assign_no_bracket  */
+  YYSYMBOL_expr_named_call = 344,          /* expr_named_call  */
+  YYSYMBOL_expr_method_call_no_bracket = 345, /* expr_method_call_no_bracket  */
+  YYSYMBOL_func_addr_name = 346,           /* func_addr_name  */
+  YYSYMBOL_func_addr_expr = 347,           /* func_addr_expr  */
+  YYSYMBOL_348_33 = 348,                   /* $@33  */
+  YYSYMBOL_349_34 = 349,                   /* $@34  */
+  YYSYMBOL_350_35 = 350,                   /* $@35  */
+  YYSYMBOL_351_36 = 351,                   /* $@36  */
+  YYSYMBOL_expr_field_no_bracket = 352,    /* expr_field_no_bracket  */
+  YYSYMBOL_353_37 = 353,                   /* $@37  */
+  YYSYMBOL_354_38 = 354,                   /* $@38  */
+  YYSYMBOL_expr_call = 355,                /* expr_call  */
+  YYSYMBOL_expr = 356,                     /* expr  */
+  YYSYMBOL_expr_no_bracket = 357,          /* expr_no_bracket  */
+  YYSYMBOL_358_39 = 358,                   /* $@39  */
+  YYSYMBOL_359_40 = 359,                   /* $@40  */
+  YYSYMBOL_360_41 = 360,                   /* $@41  */
+  YYSYMBOL_361_42 = 361,                   /* $@42  */
+  YYSYMBOL_362_43 = 362,                   /* $@43  */
+  YYSYMBOL_363_44 = 363,                   /* $@44  */
+  YYSYMBOL_expr_generator = 364,           /* expr_generator  */
+  YYSYMBOL_expr_mtag_no_bracket = 365,     /* expr_mtag_no_bracket  */
+  YYSYMBOL_optional_field_annotation = 366, /* optional_field_annotation  */
+  YYSYMBOL_optional_override = 367,        /* optional_override  */
+  YYSYMBOL_optional_constant = 368,        /* optional_constant  */
+  YYSYMBOL_optional_public_or_private_member_variable = 369, /* optional_public_or_private_member_variable  */
+  YYSYMBOL_optional_static_member_variable = 370, /* optional_static_member_variable  */
+  YYSYMBOL_structure_variable_declaration = 371, /* structure_variable_declaration  */
+  YYSYMBOL_struct_variable_declaration_list = 372, /* struct_variable_declaration_list  */
+  YYSYMBOL_373_45 = 373,                   /* $@45  */
+  YYSYMBOL_374_46 = 374,                   /* $@46  */
+  YYSYMBOL_375_47 = 375,                   /* $@47  */
+  YYSYMBOL_function_argument_declaration_no_type = 376, /* function_argument_declaration_no_type  */
+  YYSYMBOL_function_argument_declaration_type = 377, /* function_argument_declaration_type  */
+  YYSYMBOL_function_argument_list = 378,   /* function_argument_list  */
+  YYSYMBOL_tuple_type = 379,               /* tuple_type  */
+  YYSYMBOL_tuple_type_list = 380,          /* tuple_type_list  */
+  YYSYMBOL_tuple_alias_type_list = 381,    /* tuple_alias_type_list  */
+  YYSYMBOL_variant_type = 382,             /* variant_type  */
+  YYSYMBOL_variant_type_list = 383,        /* variant_type_list  */
+  YYSYMBOL_variant_alias_type_list = 384,  /* variant_alias_type_list  */
+  YYSYMBOL_copy_or_move = 385,             /* copy_or_move  */
+  YYSYMBOL_variable_declaration_no_type = 386, /* variable_declaration_no_type  */
+  YYSYMBOL_variable_declaration_type = 387, /* variable_declaration_type  */
+  YYSYMBOL_variable_declaration = 388,     /* variable_declaration  */
+  YYSYMBOL_copy_or_move_or_clone = 389,    /* copy_or_move_or_clone  */
+  YYSYMBOL_optional_ref = 390,             /* optional_ref  */
+  YYSYMBOL_let_variable_name_with_pos_list = 391, /* let_variable_name_with_pos_list  */
+  YYSYMBOL_global_let_variable_name_with_pos_list = 392, /* global_let_variable_name_with_pos_list  */
+  YYSYMBOL_variable_declaration_list = 393, /* variable_declaration_list  */
+  YYSYMBOL_let_variable_declaration = 394, /* let_variable_declaration  */
+  YYSYMBOL_global_let_variable_declaration = 395, /* global_let_variable_declaration  */
+  YYSYMBOL_optional_shared = 396,          /* optional_shared  */
+  YYSYMBOL_optional_public_or_private_variable = 397, /* optional_public_or_private_variable  */
+  YYSYMBOL_global_variable_declaration_list = 398, /* global_variable_declaration_list  */
+  YYSYMBOL_399_48 = 399,                   /* $@48  */
+  YYSYMBOL_global_let = 400,               /* global_let  */
+  YYSYMBOL_401_49 = 401,                   /* $@49  */
+  YYSYMBOL_enum_expression = 402,          /* enum_expression  */
+  YYSYMBOL_commas = 403,                   /* commas  */
+  YYSYMBOL_enum_list = 404,                /* enum_list  */
+  YYSYMBOL_optional_public_or_private_alias = 405, /* optional_public_or_private_alias  */
+  YYSYMBOL_single_alias = 406,             /* single_alias  */
+  YYSYMBOL_407_50 = 407,                   /* $@50  */
+  YYSYMBOL_alias_declaration = 408,        /* alias_declaration  */
+  YYSYMBOL_optional_public_or_private_enum = 409, /* optional_public_or_private_enum  */
+  YYSYMBOL_enum_name = 410,                /* enum_name  */
+  YYSYMBOL_optional_enum_basic_type_declaration = 411, /* optional_enum_basic_type_declaration  */
+  YYSYMBOL_optional_commas = 412,          /* optional_commas  */
+  YYSYMBOL_emit_commas = 413,              /* emit_commas  */
+  YYSYMBOL_optional_emit_commas = 414,     /* optional_emit_commas  */
+  YYSYMBOL_enum_declaration = 415,         /* enum_declaration  */
+  YYSYMBOL_416_51 = 416,                   /* $@51  */
+  YYSYMBOL_417_52 = 417,                   /* $@52  */
+  YYSYMBOL_418_53 = 418,                   /* $@53  */
+  YYSYMBOL_optional_structure_parent = 419, /* optional_structure_parent  */
+  YYSYMBOL_optional_sealed = 420,          /* optional_sealed  */
+  YYSYMBOL_structure_name = 421,           /* structure_name  */
+  YYSYMBOL_class_or_struct = 422,          /* class_or_struct  */
+  YYSYMBOL_optional_public_or_private_structure = 423, /* optional_public_or_private_structure  */
+  YYSYMBOL_optional_struct_variable_declaration_list = 424, /* optional_struct_variable_declaration_list  */
+  YYSYMBOL_structure_declaration = 425,    /* structure_declaration  */
+  YYSYMBOL_426_54 = 426,                   /* $@54  */
+  YYSYMBOL_427_55 = 427,                   /* $@55  */
+  YYSYMBOL_428_56 = 428,                   /* $@56  */
+  YYSYMBOL_variable_name_with_pos_list = 429, /* variable_name_with_pos_list  */
+  YYSYMBOL_basic_type_declaration = 430,   /* basic_type_declaration  */
+  YYSYMBOL_enum_basic_type_declaration = 431, /* enum_basic_type_declaration  */
+  YYSYMBOL_structure_type_declaration = 432, /* structure_type_declaration  */
+  YYSYMBOL_auto_type_declaration = 433,    /* auto_type_declaration  */
+  YYSYMBOL_bitfield_bits = 434,            /* bitfield_bits  */
+  YYSYMBOL_bitfield_alias_bits = 435,      /* bitfield_alias_bits  */
+  YYSYMBOL_bitfield_basic_type_declaration = 436, /* bitfield_basic_type_declaration  */
+  YYSYMBOL_bitfield_type_declaration = 437, /* bitfield_type_declaration  */
+  YYSYMBOL_438_57 = 438,                   /* $@57  */
+  YYSYMBOL_439_58 = 439,                   /* $@58  */
+  YYSYMBOL_c_or_s = 440,                   /* c_or_s  */
+  YYSYMBOL_table_type_pair = 441,          /* table_type_pair  */
+  YYSYMBOL_dim_list = 442,                 /* dim_list  */
+  YYSYMBOL_type_declaration_no_options = 443, /* type_declaration_no_options  */
+  YYSYMBOL_optional_expr_list_in_braces = 444, /* optional_expr_list_in_braces  */
+  YYSYMBOL_type_declaration_no_options_no_dim = 445, /* type_declaration_no_options_no_dim  */
+  YYSYMBOL_446_59 = 446,                   /* $@59  */
+  YYSYMBOL_447_60 = 447,                   /* $@60  */
+  YYSYMBOL_448_61 = 448,                   /* $@61  */
+  YYSYMBOL_449_62 = 449,                   /* $@62  */
+  YYSYMBOL_450_63 = 450,                   /* $@63  */
+  YYSYMBOL_451_64 = 451,                   /* $@64  */
+  YYSYMBOL_452_65 = 452,                   /* $@65  */
+  YYSYMBOL_453_66 = 453,                   /* $@66  */
+  YYSYMBOL_454_67 = 454,                   /* $@67  */
+  YYSYMBOL_455_68 = 455,                   /* $@68  */
+  YYSYMBOL_456_69 = 456,                   /* $@69  */
+  YYSYMBOL_457_70 = 457,                   /* $@70  */
+  YYSYMBOL_458_71 = 458,                   /* $@71  */
+  YYSYMBOL_459_72 = 459,                   /* $@72  */
+  YYSYMBOL_460_73 = 460,                   /* $@73  */
+  YYSYMBOL_461_74 = 461,                   /* $@74  */
+  YYSYMBOL_462_75 = 462,                   /* $@75  */
+  YYSYMBOL_463_76 = 463,                   /* $@76  */
+  YYSYMBOL_464_77 = 464,                   /* $@77  */
+  YYSYMBOL_465_78 = 465,                   /* $@78  */
+  YYSYMBOL_466_79 = 466,                   /* $@79  */
+  YYSYMBOL_467_80 = 467,                   /* $@80  */
+  YYSYMBOL_468_81 = 468,                   /* $@81  */
+  YYSYMBOL_469_82 = 469,                   /* $@82  */
+  YYSYMBOL_470_83 = 470,                   /* $@83  */
+  YYSYMBOL_471_84 = 471,                   /* $@84  */
+  YYSYMBOL_472_85 = 472,                   /* $@85  */
+  YYSYMBOL_473_86 = 473,                   /* $@86  */
+  YYSYMBOL_type_declaration = 474,         /* type_declaration  */
+  YYSYMBOL_tuple_alias_declaration = 475,  /* tuple_alias_declaration  */
+  YYSYMBOL_476_87 = 476,                   /* $@87  */
+  YYSYMBOL_477_88 = 477,                   /* $@88  */
+  YYSYMBOL_478_89 = 478,                   /* $@89  */
+  YYSYMBOL_479_90 = 479,                   /* $@90  */
+  YYSYMBOL_variant_alias_declaration = 480, /* variant_alias_declaration  */
+  YYSYMBOL_481_91 = 481,                   /* $@91  */
+  YYSYMBOL_482_92 = 482,                   /* $@92  */
+  YYSYMBOL_483_93 = 483,                   /* $@93  */
+  YYSYMBOL_484_94 = 484,                   /* $@94  */
+  YYSYMBOL_bitfield_alias_declaration = 485, /* bitfield_alias_declaration  */
+  YYSYMBOL_486_95 = 486,                   /* $@95  */
+  YYSYMBOL_487_96 = 487,                   /* $@96  */
+  YYSYMBOL_488_97 = 488,                   /* $@97  */
+  YYSYMBOL_489_98 = 489,                   /* $@98  */
+  YYSYMBOL_make_decl = 490,                /* make_decl  */
+  YYSYMBOL_make_decl_no_bracket = 491,     /* make_decl_no_bracket  */
+  YYSYMBOL_make_struct_fields = 492,       /* make_struct_fields  */
+  YYSYMBOL_make_variant_dim = 493,         /* make_variant_dim  */
+  YYSYMBOL_make_struct_single = 494,       /* make_struct_single  */
+  YYSYMBOL_make_struct_dim_list = 495,     /* make_struct_dim_list  */
+  YYSYMBOL_make_struct_dim_decl = 496,     /* make_struct_dim_decl  */
+  YYSYMBOL_optional_make_struct_dim_decl = 497, /* optional_make_struct_dim_decl  */
+  YYSYMBOL_use_initializer = 498,          /* use_initializer  */
+  YYSYMBOL_make_struct_decl = 499,         /* make_struct_decl  */
+  YYSYMBOL_500_99 = 500,                   /* $@99  */
+  YYSYMBOL_501_100 = 501,                  /* $@100  */
+  YYSYMBOL_502_101 = 502,                  /* $@101  */
+  YYSYMBOL_503_102 = 503,                  /* $@102  */
+  YYSYMBOL_504_103 = 504,                  /* $@103  */
+  YYSYMBOL_505_104 = 505,                  /* $@104  */
+  YYSYMBOL_506_105 = 506,                  /* $@105  */
+  YYSYMBOL_507_106 = 507,                  /* $@106  */
+  YYSYMBOL_508_107 = 508,                  /* $@107  */
+  YYSYMBOL_509_108 = 509,                  /* $@108  */
+  YYSYMBOL_make_tuple_call = 510,          /* make_tuple_call  */
+  YYSYMBOL_511_109 = 511,                  /* $@109  */
+  YYSYMBOL_512_110 = 512,                  /* $@110  */
+  YYSYMBOL_make_dim_decl = 513,            /* make_dim_decl  */
+  YYSYMBOL_514_111 = 514,                  /* $@111  */
+  YYSYMBOL_515_112 = 515,                  /* $@112  */
+  YYSYMBOL_516_113 = 516,                  /* $@113  */
+  YYSYMBOL_517_114 = 517,                  /* $@114  */
+  YYSYMBOL_518_115 = 518,                  /* $@115  */
+  YYSYMBOL_519_116 = 519,                  /* $@116  */
+  YYSYMBOL_520_117 = 520,                  /* $@117  */
+  YYSYMBOL_521_118 = 521,                  /* $@118  */
+  YYSYMBOL_522_119 = 522,                  /* $@119  */
+  YYSYMBOL_523_120 = 523,                  /* $@120  */
+  YYSYMBOL_expr_map_tuple_list = 524,      /* expr_map_tuple_list  */
+  YYSYMBOL_push_table_nesting = 525,       /* push_table_nesting  */
+  YYSYMBOL_make_table_decl = 526,          /* make_table_decl  */
+  YYSYMBOL_make_table_call = 527,          /* make_table_call  */
+  YYSYMBOL_array_comprehension_where = 528, /* array_comprehension_where  */
+  YYSYMBOL_optional_comma = 529,           /* optional_comma  */
+  YYSYMBOL_table_comprehension = 530,      /* table_comprehension  */
+  YYSYMBOL_array_comprehension = 531       /* array_comprehension  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -997,16 +998,16 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   9456
+#define YYLAST   9558
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  208
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  323
+#define YYNNTS  324
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  947
+#define YYNRULES  950
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  1691
+#define YYNSTATES  1697
 
 /* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   435
@@ -1073,101 +1074,102 @@ static const yytype_uint8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   566,   566,   567,   572,   573,   574,   575,   576,   577,
-     578,   579,   580,   581,   582,   583,   584,   588,   589,   593,
-     594,   598,   604,   605,   606,   610,   611,   615,   616,   620,
-     639,   640,   641,   642,   646,   647,   651,   652,   656,   657,
-     657,   661,   666,   675,   690,   706,   711,   719,   719,   758,
-     772,   776,   779,   783,   787,   791,   795,   801,   810,   813,
-     819,   820,   824,   828,   829,   833,   836,   842,   848,   851,
-     857,   858,   862,   863,   867,   868,   872,   873,   873,   877,
-     877,   886,   887,   891,   892,   898,   899,   900,   901,   902,
-     906,   907,   911,   912,   916,   918,   916,   930,   930,   938,
-     940,   938,   952,   952,   960,   962,   960,   973,   980,   987,
-     992,  1001,  1009,  1015,  1023,  1033,  1033,  1042,  1050,  1050,
-    1063,  1063,  1075,  1079,  1086,  1087,  1088,  1089,  1090,  1091,
-    1095,  1100,  1108,  1109,  1110,  1114,  1115,  1116,  1117,  1118,
-    1119,  1120,  1121,  1122,  1128,  1131,  1137,  1140,  1146,  1147,
-    1148,  1149,  1153,  1171,  1194,  1197,  1207,  1222,  1237,  1252,
-    1255,  1262,  1266,  1273,  1274,  1278,  1279,  1283,  1284,  1285,
-    1289,  1292,  1296,  1303,  1307,  1308,  1309,  1310,  1311,  1312,
-    1313,  1314,  1315,  1316,  1317,  1318,  1319,  1320,  1321,  1322,
-    1323,  1324,  1325,  1326,  1327,  1328,  1329,  1330,  1331,  1332,
-    1333,  1334,  1335,  1336,  1337,  1338,  1339,  1340,  1341,  1342,
-    1343,  1344,  1345,  1346,  1347,  1348,  1349,  1350,  1351,  1352,
-    1353,  1354,  1355,  1356,  1357,  1358,  1359,  1360,  1361,  1362,
-    1363,  1364,  1365,  1366,  1367,  1368,  1369,  1370,  1371,  1372,
-    1373,  1374,  1375,  1376,  1377,  1378,  1379,  1380,  1381,  1382,
-    1383,  1384,  1385,  1386,  1387,  1388,  1389,  1390,  1391,  1392,
-    1393,  1394,  1398,  1399,  1400,  1401,  1402,  1403,  1404,  1405,
-    1406,  1407,  1408,  1409,  1410,  1411,  1412,  1413,  1414,  1415,
-    1416,  1417,  1418,  1419,  1420,  1421,  1422,  1426,  1427,  1431,
-    1450,  1451,  1452,  1456,  1462,  1462,  1479,  1482,  1484,  1482,
-    1492,  1494,  1492,  1509,  1518,  1527,  1540,  1541,  1542,  1543,
-    1544,  1545,  1546,  1547,  1548,  1549,  1550,  1551,  1552,  1553,
-    1554,  1555,  1556,  1557,  1558,  1559,  1561,  1559,  1576,  1581,
-    1587,  1593,  1594,  1598,  1599,  1603,  1607,  1614,  1615,  1626,
-    1630,  1633,  1641,  1641,  1641,  1644,  1650,  1653,  1657,  1661,
-    1668,  1675,  1681,  1685,  1689,  1692,  1695,  1703,  1706,  1714,
-    1720,  1721,  1722,  1726,  1727,  1731,  1732,  1736,  1741,  1749,
-    1755,  1767,  1770,  1773,  1779,  1779,  1779,  1782,  1782,  1782,
-    1787,  1787,  1787,  1795,  1795,  1795,  1801,  1811,  1822,  1837,
-    1840,  1843,  1846,  1852,  1853,  1860,  1871,  1872,  1873,  1877,
-    1878,  1879,  1880,  1881,  1885,  1890,  1898,  1899,  1903,  1910,
-    1914,  1920,  1921,  1922,  1923,  1924,  1925,  1926,  1930,  1931,
-    1932,  1933,  1934,  1935,  1936,  1937,  1938,  1939,  1940,  1941,
-    1942,  1943,  1944,  1945,  1946,  1947,  1948,  1949,  1950,  1954,
-    1960,  1971,  1977,  1988,  1992,  1999,  2002,  2002,  2002,  2007,
-    2007,  2007,  2020,  2024,  2028,  2034,  2042,  2050,  2056,  2064,
-    2064,  2064,  2071,  2075,  2084,  2092,  2100,  2104,  2107,  2115,
-    2116,  2117,  2124,  2125,  2126,  2127,  2128,  2129,  2130,  2131,
-    2132,  2133,  2134,  2135,  2136,  2137,  2138,  2139,  2140,  2141,
-    2142,  2143,  2144,  2145,  2146,  2147,  2148,  2149,  2150,  2151,
-    2152,  2153,  2154,  2155,  2156,  2157,  2158,  2159,  2165,  2166,
-    2167,  2168,  2169,  2182,  2191,  2192,  2193,  2194,  2195,  2196,
-    2197,  2198,  2199,  2200,  2201,  2202,  2203,  2204,  2207,  2207,
-    2207,  2210,  2215,  2219,  2223,  2223,  2223,  2228,  2231,  2235,
-    2235,  2235,  2240,  2243,  2244,  2245,  2246,  2247,  2248,  2249,
-    2250,  2251,  2253,  2257,  2258,  2263,  2269,  2275,  2284,  2287,
-    2290,  2299,  2300,  2301,  2302,  2303,  2304,  2305,  2309,  2313,
-    2317,  2321,  2325,  2329,  2333,  2337,  2341,  2348,  2349,  2353,
-    2354,  2355,  2359,  2360,  2364,  2365,  2366,  2370,  2371,  2375,
-    2387,  2390,  2391,  2395,  2395,  2414,  2413,  2428,  2427,  2444,
-    2456,  2465,  2475,  2476,  2477,  2478,  2479,  2483,  2486,  2495,
-    2496,  2500,  2503,  2507,  2520,  2529,  2530,  2534,  2537,  2541,
-    2554,  2555,  2559,  2565,  2571,  2580,  2583,  2590,  2593,  2599,
-    2600,  2601,  2605,  2606,  2610,  2617,  2622,  2631,  2637,  2648,
-    2655,  2664,  2667,  2670,  2677,  2680,  2685,  2696,  2699,  2704,
-    2716,  2717,  2721,  2722,  2723,  2727,  2730,  2733,  2733,  2753,
-    2756,  2756,  2774,  2779,  2787,  2788,  2792,  2795,  2808,  2825,
-    2826,  2827,  2832,  2832,  2858,  2862,  2863,  2864,  2868,  2878,
-    2881,  2887,  2888,  2892,  2893,  2897,  2898,  2902,  2904,  2909,
-    2902,  2925,  2926,  2930,  2931,  2935,  2941,  2942,  2943,  2944,
-    2948,  2949,  2950,  2954,  2957,  2963,  2965,  2970,  2963,  2991,
-    2998,  3003,  3012,  3018,  3029,  3030,  3031,  3032,  3033,  3034,
-    3035,  3036,  3037,  3038,  3039,  3040,  3041,  3042,  3043,  3044,
-    3045,  3046,  3047,  3048,  3049,  3050,  3051,  3052,  3053,  3054,
-    3055,  3059,  3060,  3061,  3062,  3063,  3064,  3065,  3066,  3070,
-    3081,  3085,  3092,  3104,  3111,  3117,  3126,  3131,  3141,  3151,
-    3161,  3174,  3175,  3176,  3177,  3178,  3182,  3186,  3186,  3186,
-    3200,  3201,  3205,  3209,  3216,  3220,  3224,  3228,  3235,  3238,
-    3256,  3257,  3261,  3262,  3263,  3264,  3265,  3265,  3265,  3269,
-    3274,  3281,  3288,  3288,  3295,  3295,  3302,  3306,  3310,  3315,
-    3320,  3325,  3330,  3334,  3338,  3343,  3347,  3351,  3356,  3356,
-    3356,  3362,  3369,  3369,  3369,  3374,  3374,  3374,  3380,  3380,
-    3380,  3385,  3390,  3390,  3390,  3395,  3395,  3395,  3404,  3409,
-    3409,  3409,  3414,  3414,  3414,  3423,  3428,  3428,  3428,  3433,
-    3433,  3433,  3442,  3442,  3442,  3448,  3448,  3448,  3457,  3460,
-    3471,  3487,  3489,  3494,  3499,  3487,  3525,  3527,  3532,  3538,
-    3525,  3564,  3566,  3571,  3576,  3564,  3617,  3618,  3619,  3620,
-    3621,  3622,  3623,  3627,  3628,  3629,  3630,  3631,  3635,  3642,
-    3649,  3655,  3661,  3668,  3675,  3681,  3690,  3693,  3699,  3707,
-    3712,  3719,  3724,  3730,  3731,  3735,  3736,  3740,  3740,  3740,
-    3748,  3748,  3748,  3755,  3755,  3755,  3766,  3766,  3766,  3773,
-    3773,  3773,  3784,  3790,  3790,  3790,  3804,  3823,  3823,  3823,
-    3833,  3833,  3833,  3847,  3847,  3847,  3861,  3870,  3870,  3870,
-    3890,  3897,  3897,  3897,  3907,  3910,  3921,  3927,  3950,  3958,
-    3978,  4003,  4004,  4008,  4009,  4014,  4017,  4027
+       0,   567,   567,   568,   573,   574,   575,   576,   577,   578,
+     579,   580,   581,   582,   583,   584,   585,   589,   590,   594,
+     595,   599,   605,   606,   607,   611,   612,   616,   617,   621,
+     640,   641,   642,   643,   647,   648,   652,   653,   657,   658,
+     658,   662,   667,   676,   691,   707,   712,   720,   720,   759,
+     773,   777,   780,   784,   788,   792,   796,   802,   811,   814,
+     820,   821,   825,   829,   830,   834,   837,   843,   849,   852,
+     858,   859,   863,   864,   868,   869,   873,   874,   874,   878,
+     878,   887,   888,   892,   893,   899,   900,   901,   902,   903,
+     907,   908,   912,   913,   917,   919,   917,   931,   931,   939,
+     941,   939,   953,   953,   961,   963,   961,   974,   981,   988,
+     993,  1002,  1010,  1016,  1024,  1034,  1034,  1043,  1051,  1051,
+    1065,  1065,  1077,  1081,  1088,  1089,  1090,  1091,  1092,  1093,
+    1097,  1102,  1110,  1111,  1112,  1116,  1117,  1118,  1119,  1120,
+    1121,  1122,  1123,  1124,  1130,  1133,  1139,  1142,  1148,  1151,
+    1154,  1160,  1161,  1162,  1163,  1167,  1185,  1208,  1211,  1221,
+    1236,  1251,  1266,  1269,  1276,  1280,  1287,  1288,  1292,  1293,
+    1297,  1298,  1299,  1303,  1306,  1310,  1317,  1321,  1322,  1323,
+    1324,  1325,  1326,  1327,  1328,  1329,  1330,  1331,  1332,  1333,
+    1334,  1335,  1336,  1337,  1338,  1339,  1340,  1341,  1342,  1343,
+    1344,  1345,  1346,  1347,  1348,  1349,  1350,  1351,  1352,  1353,
+    1354,  1355,  1356,  1357,  1358,  1359,  1360,  1361,  1362,  1363,
+    1364,  1365,  1366,  1367,  1368,  1369,  1370,  1371,  1372,  1373,
+    1374,  1375,  1376,  1377,  1378,  1379,  1380,  1381,  1382,  1383,
+    1384,  1385,  1386,  1387,  1388,  1389,  1390,  1391,  1392,  1393,
+    1394,  1395,  1396,  1397,  1398,  1399,  1400,  1401,  1402,  1403,
+    1404,  1405,  1406,  1407,  1408,  1412,  1413,  1414,  1415,  1416,
+    1417,  1418,  1419,  1420,  1421,  1422,  1423,  1424,  1425,  1426,
+    1427,  1428,  1429,  1430,  1431,  1432,  1433,  1434,  1435,  1436,
+    1440,  1441,  1445,  1464,  1465,  1466,  1470,  1476,  1476,  1493,
+    1496,  1498,  1496,  1506,  1508,  1506,  1523,  1532,  1541,  1554,
+    1555,  1556,  1557,  1558,  1559,  1560,  1561,  1562,  1563,  1564,
+    1565,  1566,  1567,  1568,  1569,  1570,  1571,  1572,  1573,  1575,
+    1573,  1590,  1595,  1601,  1607,  1608,  1612,  1613,  1617,  1621,
+    1628,  1629,  1640,  1644,  1647,  1655,  1655,  1655,  1658,  1664,
+    1667,  1671,  1675,  1682,  1689,  1695,  1699,  1703,  1706,  1709,
+    1717,  1720,  1728,  1734,  1735,  1736,  1740,  1741,  1745,  1746,
+    1750,  1755,  1763,  1769,  1781,  1784,  1787,  1793,  1793,  1793,
+    1796,  1796,  1796,  1801,  1801,  1801,  1809,  1809,  1809,  1815,
+    1825,  1836,  1851,  1854,  1857,  1860,  1866,  1867,  1874,  1885,
+    1886,  1887,  1891,  1892,  1893,  1894,  1895,  1899,  1904,  1912,
+    1913,  1917,  1924,  1928,  1934,  1935,  1936,  1937,  1938,  1939,
+    1940,  1944,  1945,  1946,  1947,  1948,  1949,  1950,  1951,  1952,
+    1953,  1954,  1955,  1956,  1957,  1958,  1959,  1960,  1961,  1962,
+    1963,  1964,  1968,  1974,  1985,  1991,  2002,  2006,  2013,  2016,
+    2016,  2016,  2021,  2021,  2021,  2034,  2038,  2042,  2048,  2056,
+    2064,  2070,  2078,  2078,  2078,  2085,  2089,  2098,  2106,  2114,
+    2118,  2121,  2129,  2130,  2131,  2138,  2139,  2140,  2141,  2142,
+    2143,  2144,  2145,  2146,  2147,  2148,  2149,  2150,  2151,  2152,
+    2153,  2154,  2155,  2156,  2157,  2158,  2159,  2160,  2161,  2162,
+    2163,  2164,  2165,  2166,  2167,  2168,  2169,  2170,  2171,  2172,
+    2173,  2179,  2180,  2181,  2182,  2183,  2196,  2205,  2206,  2207,
+    2208,  2209,  2210,  2211,  2212,  2213,  2214,  2215,  2216,  2217,
+    2218,  2221,  2221,  2221,  2224,  2229,  2233,  2237,  2237,  2237,
+    2242,  2245,  2249,  2249,  2249,  2254,  2257,  2258,  2259,  2260,
+    2261,  2262,  2263,  2264,  2265,  2267,  2271,  2272,  2277,  2283,
+    2289,  2298,  2301,  2304,  2313,  2314,  2315,  2316,  2317,  2318,
+    2319,  2323,  2327,  2331,  2335,  2339,  2343,  2347,  2351,  2355,
+    2362,  2363,  2367,  2368,  2369,  2373,  2374,  2378,  2379,  2380,
+    2384,  2385,  2389,  2401,  2404,  2405,  2409,  2409,  2428,  2427,
+    2442,  2441,  2458,  2470,  2479,  2489,  2490,  2491,  2492,  2493,
+    2497,  2500,  2509,  2510,  2514,  2517,  2521,  2534,  2543,  2544,
+    2548,  2551,  2555,  2568,  2569,  2573,  2579,  2585,  2594,  2597,
+    2604,  2607,  2613,  2614,  2615,  2619,  2620,  2624,  2631,  2636,
+    2645,  2651,  2662,  2669,  2678,  2681,  2684,  2691,  2694,  2699,
+    2710,  2713,  2718,  2730,  2731,  2735,  2736,  2737,  2741,  2744,
+    2747,  2747,  2767,  2770,  2770,  2788,  2793,  2801,  2802,  2806,
+    2809,  2822,  2839,  2840,  2841,  2846,  2846,  2872,  2876,  2877,
+    2878,  2882,  2892,  2895,  2901,  2902,  2906,  2907,  2911,  2912,
+    2916,  2918,  2923,  2916,  2939,  2940,  2944,  2945,  2949,  2955,
+    2956,  2957,  2958,  2962,  2963,  2964,  2968,  2971,  2977,  2979,
+    2984,  2977,  3005,  3012,  3017,  3026,  3032,  3043,  3044,  3045,
+    3046,  3047,  3048,  3049,  3050,  3051,  3052,  3053,  3054,  3055,
+    3056,  3057,  3058,  3059,  3060,  3061,  3062,  3063,  3064,  3065,
+    3066,  3067,  3068,  3069,  3073,  3074,  3075,  3076,  3077,  3078,
+    3079,  3080,  3084,  3095,  3099,  3106,  3118,  3125,  3131,  3140,
+    3145,  3155,  3165,  3175,  3188,  3189,  3190,  3191,  3192,  3196,
+    3200,  3200,  3200,  3214,  3215,  3219,  3223,  3230,  3234,  3238,
+    3242,  3249,  3252,  3270,  3271,  3275,  3276,  3277,  3278,  3279,
+    3279,  3279,  3283,  3288,  3295,  3302,  3302,  3309,  3309,  3316,
+    3320,  3324,  3329,  3334,  3339,  3344,  3348,  3352,  3357,  3361,
+    3365,  3370,  3370,  3370,  3376,  3383,  3383,  3383,  3388,  3388,
+    3388,  3394,  3394,  3394,  3399,  3404,  3404,  3404,  3409,  3409,
+    3409,  3418,  3423,  3423,  3423,  3428,  3428,  3428,  3437,  3442,
+    3442,  3442,  3447,  3447,  3447,  3456,  3456,  3456,  3462,  3462,
+    3462,  3471,  3474,  3485,  3501,  3503,  3508,  3513,  3501,  3539,
+    3541,  3546,  3552,  3539,  3578,  3580,  3585,  3590,  3578,  3631,
+    3632,  3633,  3634,  3635,  3636,  3637,  3641,  3642,  3643,  3644,
+    3645,  3649,  3656,  3663,  3669,  3675,  3682,  3689,  3695,  3704,
+    3707,  3713,  3721,  3726,  3733,  3738,  3744,  3745,  3749,  3750,
+    3754,  3754,  3754,  3762,  3762,  3762,  3769,  3769,  3769,  3780,
+    3780,  3780,  3787,  3787,  3787,  3798,  3804,  3804,  3804,  3818,
+    3837,  3837,  3837,  3847,  3847,  3847,  3861,  3861,  3861,  3875,
+    3884,  3884,  3884,  3904,  3911,  3911,  3911,  3921,  3924,  3935,
+    3941,  3964,  3972,  3992,  4017,  4018,  4022,  4023,  4028,  4031,
+    4041
 };
 #endif
 
@@ -1243,9 +1245,9 @@ static const char *const yytname[] =
   "expression_with_alias", "annotation_argument_value",
   "annotation_argument_value_list", "annotation_argument_name",
   "annotation_argument", "annotation_argument_list",
-  "metadata_argument_list", "annotation_declaration_name",
-  "annotation_declaration_basic", "annotation_declaration",
-  "annotation_list", "optional_annotation_list",
+  "metadata_argument_list", "optional_for_annotations",
+  "annotation_declaration_name", "annotation_declaration_basic",
+  "annotation_declaration", "annotation_list", "optional_annotation_list",
   "optional_annotation_list_with_emit_semis",
   "optional_function_argument_list", "optional_function_type",
   "function_name", "das_type_name", "optional_template",
@@ -1325,12 +1327,12 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-1535)
+#define YYPACT_NINF (-1521)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-840)
+#define YYTABLE_NINF (-843)
 
 #define yytable_value_is_error(Yyn) \
   ((Yyn) == YYTABLE_NINF)
@@ -1339,176 +1341,176 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-   -1535,    68, -1535, -1535,    37,   -52,   296,   471, -1535,    23,
-   -1535, -1535, -1535, -1535,   297,   219, -1535, -1535, -1535, -1535,
-      65,    65,    65, -1535,   345, -1535,    47, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535,    89, -1535,    14,
-      94,    24, -1535,    73, -1535,   186,   121,    21, -1535, -1535,
-   -1535,   194,    65, -1535, -1535,    47,   471,   471,   471,   207,
-     254, -1535, -1535, -1535, -1535,   219,   219,   219,   206, -1535,
-     756,   272, -1535, -1535, -1535, -1535,   321, -1535,   661, -1535,
-     583,   135,    37,   311,   -52,   296,   296,   312,   296,   353,
-   -1535,   441,   462, -1535, -1535, -1535,   656,   518,   567,   572,
-   -1535,   605,   512, -1535, -1535,   -68,    37,   219,   219,   219,
-     219,   361, -1535,   696,   706,   614,   625,   714, -1535, -1535,
-     575, -1535, -1535, -1535, -1535, -1535,   747,   131,   579, -1535,
-   -1535, -1535, -1535,   312,   312,   312,   731, -1535, -1535,   617,
-   -1535, -1535,   603,   624,   361,   361, -1535, -1535,   657, -1535,
-     204, -1535,   443,   682,   756, -1535,   662, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535,   689, -1535, -1535, -1535, -1535, -1535,
-   -1535,   691, -1535, -1535, -1535,   833, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535,   230,   738, -1535,  8265,   779, -1535,   574,
-     739, -1535, -1535, -1535, -1535, -1535,  9084, -1535,   729,   802,
-     139,    37,   708,   749, -1535, -1535, -1535,   131, -1535, -1535,
-     737,   748,   753,   719,   761,   763, -1535, -1535, -1535,   755,
-   -1535, -1535, -1535, -1535, -1535,   504, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535,   765, -1535, -1535,
-   -1535,   767,   768, -1535, -1535, -1535, -1535,   777,   778,   764,
-     297,   -87, -1535, -1535, -1535, -1535,  4016,   740,   793, -1535,
-   -1535, -1535, -1535, -1535, -1535,   799, -1535,   769,   773,  8453,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535,   938,   947, -1535,   784, -1535,
-     361,   912,   739, -1535,   823,   361, -1535, -1535,   691,   361,
-      37, -1535,   558, -1535, -1535, -1535, -1535, -1535,  7266, -1535,
-   -1535,   825,   809,   119,   197,   198, -1535, -1535,  7266,    61,
-   -1535,  5165, -1535, -1535, -1535,    17, -1535, -1535, -1535,    13,
-   -1535,  5356,   795,   790, -1535,   789, -1535, -1535,  9222,  9261,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-     835,   808, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535,   987, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535,   859,   826, -1535,
-   -1535,   -25,   -47,   885, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535,   821,   851, -1535,   419, -1535,   361,   865,
-    8265, -1535,   -22,  8265,  8265,  8265,   849,   850, -1535, -1535,
-     136,   297,   852,    60, -1535,   113,   834,   853,   855,   836,
-     857,   839,   168,   860, -1535,   184,    28,   862,  8024,  8024,
-     844,   845,   848,   854,   856,   858, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535,  8024,  8024,  8024,  8024,  8024,
-    3637,  4019, -1535,   846, -1535, -1535, -1535, -1535,   866, -1535,
-   -1535, -1535, -1535,   869, -1535, -1535, -1535,   644, -1535,   644,
-     644,   867,  1439, -1535, -1535,   872, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535,  8265,  8265,   874,   870,  8265,   784,
-    8265,   784,  8265,   784,  8358,   887,   875, -1535,  5165, -1535,
-    8265,  7266,   876,   879, -1535, -1535, -1535, -1535, -1535,   880,
-   -1535, -1535,   881,  5547, -1535,  4016, -1535,  8358,   887, -1535,
-   -1535, -1535, -1535, -1535, -1535,  9293,  1575,  1342,   873, -1535,
-      82,   877,    86,   886,  8265,  8265, -1535,  7646, -1535,   883,
-   -1535, -1535,   297, -1535,   491,   878,  1010,   588, -1535, -1535,
-   -1535,   394, -1535, -1535, -1535,  7266,   516,   569,   905,   276,
-   -1535, -1535, -1535, -1535,   889, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535,   323, -1535,   915,   916,   918, -1535,
-    5165,  8265,  7266,  7266, -1535, -1535,  7266, -1535,  7266, -1535,
-    5165, -1535, -1535,  5165,   927, -1535,  8265,   610,   610,  7266,
-    7266,  7266,  7266,  7266,  7266,   674,   610,   610,    -8,   610,
-     610,   910,  1044,   920,   911,   331,   879,   941,   921,   372,
-     361,  2103,   219,  1113,   922, -1535,   869, -1535, -1535, -1535,
-   -1535,  8447,  8938,  8024,  8024, -1535, -1535,  8024,  8024,  8024,
-    8024,   960,  8024,   -53,  7266,  8024,  8024,  8024,  8024,  7266,
-    8024,  8024,  8024,  8024,  7835,  8024,  8024,  8024,  8024,  8024,
-    8024,  8024,  8024,  8024,  8024,  9133,  7266,  4210,   589,   604,
-   -1535, -1535,   961,   621,   -47,   635,   -47,   636,   -47,   144,
-   -1535,   398,   793,   950, -1535,   534, -1535,  8265,   879,   544,
-     793, -1535, -1535,  5738, -1535, -1535, -1535, -1535,   928,   965,
-   -1535,    65, -1535,    65, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535,  7266, -1535, -1535,   451,   -64,   -64,   -64, -1535,
-     793,   793,  8024,  8529, -1535,   972, -1535, -1535, -1535, -1535,
-    7266,   973,   975,  8265,   -22, -1535,  7266,    65, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535,  8265,  8265,  8265,  8265,  3828,
-     976,  7266,  8265, -1535, -1535, -1535,  8265,   879,  1022, -1535,
-     964,   939,  8265,  8265,   940,  8265,   943,  8265,   879,  8265,
-    8358,   879, -1535,   887,    98,   944,   946,   948,   951,   962,
-     963, -1535,  7266,   480,   -28,   969, -1535,  7266, -1535,  7266,
-   -1535,  7266,   981,   -51, -1535, -1535,   970,   985,   199, -1535,
-   -1535,  5929,   149,  3446, -1535,   249,   988,   305,   990,   784,
-   -1535,  1899,  1113,   971,   991, -1535, -1535,   982,   992, -1535,
-   -1535,   425,   425,  1049,  1049,   974,   974,   993,   526,   994,
-   -1535,   977,   120,   120,   872,   425,   425,  8529, -1535, -1535,
-    8721,  8681,  8757,  8529,  9027,  1247,  8797,  8873,  8949,  1049,
-    1049,   559,   559,   526,   526,   526,   -48,  7266,   998,   999,
-     281,  7266,  1160,  1002,   989, -1535,   250, -1535, -1535, -1535,
-     -90, -1535,  1024, -1535,  1027, -1535,  1028,  8265, -1535,  8358,
-    8265, -1535,   887,   622,  1012,  1011,  8265,  7266, -1535, -1535,
-    1040,   442, -1535,  8170, -1535,    58, -1535,  1014,  1016,  1130,
-   -1535, -1535,   289, -1535, -1535, -1535,  8605,  2349,  1043, -1535,
-     442,    36,  1017, -1535,  1176,   394,  7266,    65, -1535, -1535,
-   -1535, -1535,   793,   306,  1082,   637,   564,   251,  1019,  1020,
-     745,  1021,   642,  8265,  8358,   887,  1167,  1023,  1025,  8265,
-    7266,  1029, -1535,  1179,  1267, -1535,  1467, -1535,  2033,  1035,
-    2412,   758,  1036,  8265,   771,  1113, -1535, -1535, -1535, -1535,
-   -1535,  1038,  1065,  1042,  1200,  1085,    25,   -28,  1048, -1535,
-   -1535, -1535,  1045,    41,  7266,  7266,  8265,   784,  1051,  1046,
-     964,   188, -1535,  1052,   316,  6120, -1535, -1535, -1535,   258,
-     -47, -1535,  6311, -1535, -1535,  6502,  1092,  1097, -1535,    65,
-    1088,  6693,   -84,  6884, -1535, -1535, -1535,    65,    65,  1255,
-   -1535,   824, -1535, -1535,  1254, -1535, -1535,  1261, -1535,  1230,
-      65, -1535,    65,    65,    65,    65,    65, -1535,  1207, -1535,
-      65,  1692,   784, -1535,  7266, -1535,  7266,  4401,  7266, -1535,
-    1094,  1075, -1535, -1535,  8024,  1076, -1535,  1078,  7266,  4592,
-    1079, -1535,  1083, -1535,  4783, -1535,  5738, -1535, -1535, -1535,
-    1115, -1535,  1118, -1535, -1535, -1535, -1535, -1535, -1535,   793,
-   -1535, -1535,   793, -1535, -1535,  1011, -1535, -1535,   793, -1535,
-    7266, -1535,   501, -1535, -1535, -1535,  1077, -1535,  1084, -1535,
-    7266,  1121,  1122,  8265, -1535,  7266,  1086,  7266,   519, -1535,
-    1124, -1535, -1535,  1280,   691, -1535,  1131, -1535,  7266,    65,
-   -1535, -1535, -1535, -1535,  1095, -1535, -1535, -1535,  1093,  1134,
-   -1535, -1535,  2422,   786,   804, -1535, -1535,  7266,  2433, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,  3379,
-   -1535,   -73,  4974, -1535,  1127,  7266,  1136, -1535,   301,  5165,
-     147,    43,   287,  7266,  7266,  7266,  1103,  1104,  3634,   -47,
-     -28, -1535, -1535, -1535,   -51,  1105,  3446,  1145,  1146,  1110,
-    1148,  1150, -1535,   313,   361,  7266, -1535,  1301,  7266, -1535,
-    1142,  1143, -1535,  1144,  1163, -1535, -1535,  7266, -1535, -1535,
-   -1535, -1535,  1123, -1535, -1535,  1125,  1126,  1129,  1133, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535,    84, -1535,  8024,  8024,
-    8024,  8024,  8024,  8024,  8024,  8024,  8024,  8024,  7266,  8024,
-    8024,  8024,  8024,  8024,  8024,  8024,   -47,  8265,  1120,  8265,
-    1135, -1535,   335,  1137, -1535,  7266,  8605,  7266, -1535,  1139,
-    3446, -1535,   337,  7266, -1535, -1535, -1535,   339, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535,  1156, -1535,  1116, -1535,
-   -1535,  1149, -1535,  1281,     7, -1535,  1294, -1535, -1535,  1128,
-    1161,   721,  1276,    65, -1535,    65, -1535,  1147,  1152, -1535,
-   -1535,  7266,  1164, -1535, -1535, -1535, -1535,  1153,  1154,  1157,
-    8024,  8024,  8024,  1159,  1274,  1168, -1535,  1169,  7075, -1535,
-   -1535,   357, -1535, -1535,  1155, -1535,  1220, -1535,   359,  1341,
-    1085,  5165,  7266,  7266,  1189, -1535, -1535, -1535, -1535, -1535,
-    1211,    44, -1535,   346, -1535, -1535,  1231, -1535, -1535,   258,
-   -1535,   885, -1535, -1535, -1535,  8265,  7266, -1535, -1535, -1535,
-   -1535,  2626,  7266,  7266,   -28,  7266,  7266,  1085, -1535, -1535,
-   -1535,  1439,  1439,  1439,  1439,  1439,  1439,  1439,  1439,  1439,
-    1439,  1439, -1535, -1535,  1439,  1439,  1439,  1439,  1439,  1439,
-    1439,   361,  3825, -1535,   652, -1535, -1535, -1535,  8265,  1195,
-    1196, -1535,   414, -1535,  1197, -1535,  7266, -1535, -1535,  1237,
-    7266, -1535, -1535, -1535,  8265, -1535, -1535,   530, -1535,    31,
-   -1535, -1535,  1274,  1274,  1202,  1204,  1206,  1208,  1209,  5165,
-   -1535,  7266,  1049,  1049,  1049,  5165, -1535, -1535,  1274,  1210,
-    1274, -1535,  1212, -1535, -1535,  1245, -1535, -1535,  1213,  1251,
-     377,   388, -1535, -1535,   363,   488, -1535,  5165,  1214,  1215,
-   -1535, -1535, -1535,   793, -1535,  1228,  1217,  1218,    46,  1234,
-    1235,   391,   -81,   885, -1535, -1535,   655, -1535, -1535,  1238,
-   -1535, -1535, -1535, -1535,  1233,   329,  1407,    31, -1535, -1535,
-     721,   122,   122, -1535,  7266,  1274,  1274,   564,  1240,  1242,
-     879,   122,  1274,   564, -1535, -1535,  7266, -1535, -1535,  1243,
-    7266,  7266, -1535,   488,   392, -1535, -1535,  1294,  1446,   361,
-    5165,   361,   361,   535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535,  1407,   451,   564,  1286,
-    1290, -1535,  1263,  1264,  1266,   122,   122,  1286,  1269, -1535,
-   -1535,  1270,  1271,   564,  1272,  1273,  7266, -1535, -1535, -1535,
-    1275, -1535,  7457,    65, -1535,   393, -1535, -1535,  8265,   -22,
-   -1535,  2832,  9084, -1535, -1535, -1535, -1535,   399,  1268, -1535,
-   -1535, -1535, -1535,  1277,  1279, -1535, -1535, -1535,  1282, -1535,
-    1423,  1285,  1273,  7266, -1535, -1535, -1535, -1535, -1535,  1439,
-   -1535,  1283,   361, -1535, -1535,   797,  7266,  1287,    65,  9084,
-   -1535,   564, -1535, -1535, -1535,  7266, -1535,  1293,  1273, -1535,
-     647,  7457, -1535,  7266,    65, -1535, -1535,   361,   411, -1535,
-   -1535,  1288, -1535,   361, -1535, -1535,  1289, -1535,    65, -1535,
-      65, -1535, -1535, -1535, -1535,  3038, -1535,  7266, -1535, -1535,
-   -1535,  1291,  1296,  1295,  1294, -1535, -1535,  7457,   361, -1535,
-   -1535,    65, -1535,  3244, -1535,  1296,  1292,   647,  1294, -1535,
-   -1535
+   -1521,    68, -1521, -1521,    45,   -96,   185,   413, -1521,   101,
+   -1521, -1521, -1521, -1521,   330,    40, -1521, -1521, -1521, -1521,
+     145,   145,   145, -1521,   423, -1521,    88, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521,   -87, -1521,    21,
+       8,    24, -1521,    31, -1521,   256,   100,    62, -1521, -1521,
+   -1521,   129,   145, -1521, -1521,    88,   413,   413,   413,   176,
+     238, -1521, -1521, -1521, -1521,    40,    40,    40,   206, -1521,
+     596,   107, -1521, -1521, -1521, -1521,   322, -1521,   320, -1521,
+     649,    26,    45,   260,   -96,   185,   185,   284,   185,   409,
+   -1521,   445,   464, -1521, -1521, -1521,   650,   483,   499,   542,
+   -1521,   551,   398, -1521, -1521,   -49,    45,    40,    40,    40,
+      40,   417, -1521,   671,   721,   523,   544,   723, -1521, -1521,
+     514, -1521, -1521, -1521, -1521, -1521,   595,   118,   568, -1521,
+   -1521, -1521, -1521,   284,   284,   284,   725, -1521, -1521,   619,
+   -1521, -1521,   598,   631,   417,   417, -1521, -1521,   633, -1521,
+     264, -1521,   608,   669,   596, -1521,   652, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521,   682, -1521, -1521, -1521, -1521, -1521,
+   -1521,   629, -1521, -1521, -1521,   655, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521,   285,   684, -1521,  8406,   774, -1521,   624,
+     685, -1521, -1521, -1521, -1521, -1521,  9186, -1521,   675,   749,
+     230,    45,   681,   703, -1521, -1521, -1521,   118, -1521, -1521,
+     692,   698,   732,   701,   734,   735, -1521, -1521, -1521,   705,
+   -1521, -1521, -1521, -1521, -1521,   403, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521,   738, -1521, -1521,
+   -1521,   739,   753, -1521, -1521, -1521, -1521,   755,   756,   740,
+     330,   -57, -1521, -1521, -1521, -1521,   793,   741,   761, -1521,
+   -1521, -1521, -1521, -1521, -1521,   777, -1521,   742,   743,  8594,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521,   914,   917, -1521,   757, -1521,
+     417,   913,   685, -1521,   790,   417, -1521, -1521,   629,   417,
+      45, -1521,   548, -1521, -1521, -1521, -1521, -1521,  7407, -1521,
+   -1521,   792,   778,   -54,   120,   147, -1521, -1521,  7407,    83,
+   -1521,  5306, -1521, -1521, -1521,    66, -1521, -1521, -1521,    53,
+   -1521,  5497,   766,  1899, -1521,   764, -1521, -1521,  9324,  9363,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+     807,   785, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521,   951, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521,   813,   787, -1521,
+   -1521,   -92,   135,   847, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521,   784,   815, -1521,   360, -1521,   417,   830,
+    8406, -1521,   -12,  8406,  8406,  8406,   814,   816, -1521, -1521,
+     136,   330,   817,    35, -1521,   271,   795,   824,   825,   808,
+     836,   818,   294,   839, -1521,   368,    61,   841,  8165,  8165,
+     820,   822,   826,   827,   828,   833, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521,  8165,  8165,  8165,  8165,  8165,
+    3778,  4160, -1521,   831, -1521, -1521, -1521, -1521,   835, -1521,
+   -1521, -1521, -1521,   832, -1521, -1521, -1521,   478, -1521,   478,
+     478,   838,  8746, -1521, -1521,   837, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521,  8406,  8406,   842,   859,  8406,   757,
+    8406,   757,  8406,   757,  8499,   879,   843, -1521,  5306, -1521,
+    8406,  7407,   844,   876, -1521, -1521, -1521, -1521, -1521,   851,
+   -1521, -1521,   853,  5688, -1521,   793, -1521,  8499,   879, -1521,
+   -1521, -1521, -1521, -1521, -1521,  9395,  1260,  2765,   855, -1521,
+      99,   849,   -84,   857,  8406,  8406, -1521,  7787, -1521,   861,
+   -1521, -1521,   330, -1521,   677,   856,  1017,   556, -1521, -1521,
+   -1521,   850, -1521, -1521, -1521,  7407,   534,   578,   887,   488,
+   -1521, -1521, -1521, -1521,   870, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521,   386, -1521,   891,   892,   895, -1521,
+    5306,  8406,  7407,  7407, -1521, -1521,  7407, -1521,  7407, -1521,
+    5306, -1521, -1521,  5306,   896, -1521,  8406,   402,   402,  7407,
+    7407,  7407,  7407,  7407,  7407,   690,   402,   402,   168,   402,
+     402,   880,  1068,   884,   882,   252,   876,   911,   885,   397,
+     417,  2121,    40,  1081,   886, -1521,   832, -1521, -1521, -1521,
+   -1521,  8588,  9066,  8165,  8165, -1521, -1521,  8165,  8165,  8165,
+    8165,   924,  8165,   441,  7407,  8165,  8165,  8165,  8165,  7407,
+    8165,  8165,  8165,  8165,  7976,  8165,  8165,  8165,  8165,  8165,
+    8165,  8165,  8165,  8165,  8165,  9235,  7407,  4351,   614,   621,
+   -1521, -1521,   925,   622,   135,   637,   135,   639,   135,   -25,
+   -1521,   467,   761,   915, -1521,   493, -1521,  8406,   876,   536,
+     761, -1521, -1521,  5879, -1521, -1521, -1521, -1521,   893,   935,
+   -1521,   145, -1521,   145, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521,  7407, -1521, -1521,   366,   -73,   -73,   -73, -1521,
+     761,   761,  8165,  8822, -1521,   939, -1521, -1521, -1521, -1521,
+    7407,   941,   947,  8406,   -12, -1521,  7407,   145, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521,  8406,  8406,  8406,  8406,  3969,
+     952,  7407,  8406, -1521, -1521, -1521,  8406,   876,   394, -1521,
+     943,   918,  8406,  8406,   921,  8406,   926,  8406,   876,  8406,
+    8499,   876, -1521,   879,   949,   928,   931,   940,   942,   946,
+     948, -1521,  7407,   528,   105,   944, -1521,  7407, -1521,  7407,
+   -1521,  7407,   954,   496, -1521, -1521,   950,   964,   151, -1521,
+   -1521,  6070,   137,  3587, -1521,   295,   965,   122,   967,   757,
+   -1521,  2354,  1081,   945,   968, -1521, -1521,   960,   969, -1521,
+   -1521,   559,   559,  1092,  1092,   977,   977,   970,    91,   971,
+   -1521,   953,   164,   164,   837,   559,   559,  8822, -1521, -1521,
+    1302,   745,  1597,  8822,  9097,  8670,  8861,  8898,  8937,  1092,
+    1092,   425,   425,    91,    91,    91,   516,  7407,   972,   973,
+     519,  7407,  1164,   976,   978, -1521,   305, -1521, -1521, -1521,
+     199, -1521,   997, -1521,   999, -1521,  1002,  8406, -1521,  8499,
+    8406, -1521,   879,   566,   983,   985,  8406,  7407, -1521, -1521,
+    1012,   511, -1521,  8311, -1521,   159, -1521,   986,   988,  1146,
+   -1521, -1521,   -69, -1521, -1521, -1521,  1894,  2560,  1016, -1521,
+     511,    36,   990, -1521,  1151,   850,  7407,   145, -1521, -1521,
+   -1521, -1521,   761,  1121,  1170,   653,   539,   309,   994,   995,
+     604,   998,   654,  8406,  8499,   879,  1203,  1001,  1004,  8406,
+    7407,  1005, -1521,  1334,  1442, -1521,  1459, -1521,  1472,  1011,
+    2051,   648,  1013,  8406,   663,  1081, -1521, -1521, -1521, -1521,
+   -1521,  1015,  1022,  1019,  1162,  1050,    25,   105,  1028, -1521,
+   -1521, -1521,  1032,     2,  7407,  7407,  8406,   757,  1033,  1010,
+     943,   202, -1521,  1034,   184,  6261, -1521, -1521, -1521,   251,
+     135, -1521,  6452, -1521, -1521,  6643,  1054,  1071, -1521,   145,
+    1082,  6834,   267,  7025, -1521, -1521, -1521,   145,   145,  1227,
+   -1521,   883, -1521, -1521,  1226, -1521, -1521,  1231, -1521,  1199,
+     145, -1521,   145,   145,   145,   145,   145, -1521,  1176, -1521,
+     145,  1697,   757, -1521,  7407, -1521,  7407,  4542,  7407, -1521,
+    1063,  1044, -1521, -1521,  8165,  1046, -1521,  1048,  7407,  4733,
+    1051, -1521,  1049, -1521,  4924, -1521,  5879, -1521, -1521, -1521,
+    1087, -1521,  1090, -1521, -1521, -1521, -1521, -1521, -1521,   761,
+   -1521, -1521,   761, -1521, -1521,   985, -1521, -1521,   761, -1521,
+    7407, -1521,   235, -1521, -1521, -1521,  1052, -1521,  1055, -1521,
+    7407,  1094,  1097,  8406, -1521,  7407,  1059,  7407,   491, -1521,
+    1103, -1521, -1521,  1247,   629, -1521,  1106, -1521,  7407,   145,
+   -1521, -1521, -1521, -1521,  1069, -1521, -1521, -1521,  1072,  1108,
+   -1521, -1521,  2056,   786,   798, -1521, -1521,  7407,  3520, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,  3775,
+   -1521,   280,  5115, -1521,  1109,  7407,  1116, -1521,   312,  5306,
+     -32,    29,   223,  7407,  7407,  7407,  1083,  1085,  3966,   135,
+     105, -1521, -1521, -1521,   496,  1091,  3587,  1119,  1120,  1088,
+    1124,  1130, -1521,   314,   417,  7407, -1521,  1281,  7407, -1521,
+    1123,  1125, -1521,  1129,  1145, -1521, -1521,  7407, -1521, -1521,
+   -1521, -1521,  1107, -1521, -1521,  1110,   327,   327,  1111, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521,   -47, -1521,  8165,  8165,
+    8165,  8165,  8165,  8165,  8165,  8165,  8165,  8165,  7407,  8165,
+    8165,  8165,  8165,  8165,  8165,  8165,   135,  8406,  1112,  8406,
+    1114, -1521,   339,  1115, -1521,  7407,  1894,  7407, -1521,  1117,
+    3587, -1521,   346,  7407, -1521, -1521, -1521,   362, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521,  1134, -1521,  1113, -1521,
+   -1521,  1128, -1521,  1266,   190, -1521,  1280, -1521, -1521,  1126,
+    1147,   724,  1255,   145, -1521,   145, -1521,  1133,  1135, -1521,
+   -1521,  7407,  1144, -1521, -1521, -1521, -1521,  1136,  1137,  1139,
+    8165,  8165,  8165,  1140,  1256,  1141, -1521,  1143,  7216, -1521,
+   -1521,   388, -1521, -1521,  1149, -1521,  1167, -1521,   389,  1291,
+    1050,  5306,  7407,  7407,  1152, -1521, -1521, -1521, -1521, -1521,
+    1166,    41, -1521,   290, -1521, -1521,  1185, -1521, -1521,   251,
+   -1521,   847, -1521, -1521, -1521,  8406,  7407, -1521, -1521, -1521,
+   -1521,  2767,  7407,  7407,    45,   681,  1154,  1155,  7407,  1050,
+   -1521, -1521, -1521,  8746,  8746,  8746,  8746,  8746,  8746,  8746,
+    8746,  8746,  8746,  8746, -1521, -1521,  8746,  8746,  8746,  8746,
+    8746,  8746,  8746,   417,  4157, -1521,   660, -1521, -1521, -1521,
+    8406,  1156,  1157, -1521,   317, -1521,  1158, -1521,  7407, -1521,
+   -1521,  1197,  7407, -1521, -1521, -1521,  8406, -1521, -1521,   549,
+   -1521,    11, -1521, -1521,  1256,  1256,  1160,  1163,  1165,  1179,
+    1181,  5306, -1521,  7407,  1092,  1092,  1092,  5306, -1521, -1521,
+    1256,  1183,  1256, -1521,  1175, -1521, -1521,  1219, -1521, -1521,
+    1184,  1201,   391,   401, -1521, -1521,   248,   497, -1521,  5306,
+    1186,  1188, -1521, -1521, -1521,   761, -1521,  1190,  1189,  1191,
+     338,   105,  7407,  1196,   405,   139,   847, -1521, -1521,   665,
+   -1521, -1521,  1198, -1521, -1521, -1521, -1521,  1161,   236,  1358,
+      11, -1521, -1521,   724,   205,   205, -1521,  7407,  1256,  1256,
+     539,  1200,  1207,   876,   205,  1256,   539, -1521, -1521,  7407,
+   -1521, -1521,  1194,  7407,  7407, -1521,   497,   411, -1521, -1521,
+    1280,  1388,   417, -1521,    51,  1208,   417,   -97, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+    1358,   366,   539,  1238,  1240, -1521,  1213,  1214,  1216,   205,
+     205,  1238,  1228, -1521, -1521,  1234,  1237,   539,  1239,  1235,
+    7407, -1521, -1521, -1521,  1241, -1521,  7598,   145, -1521,  5306,
+     417, -1521,  8406,   -12, -1521,  2973,  9186, -1521, -1521, -1521,
+   -1521,   412,  1243, -1521, -1521, -1521, -1521,  1245,  1246, -1521,
+   -1521, -1521,  1248, -1521,  1391,  1242,  1235,  7407, -1521, -1521,
+   -1521, -1521, -1521,  8746, -1521,  1249,   414, -1521, -1521,  1018,
+    7407,  1250,   145,  9186, -1521,   539, -1521, -1521, -1521,  7407,
+   -1521,  1252,  1235, -1521,   644,  7598,   417, -1521,  7407,   145,
+   -1521, -1521,   417,   424, -1521, -1521,  1251, -1521,   417, -1521,
+   -1521,  1253, -1521,   145, -1521,   145, -1521, -1521, -1521, -1521,
+    3179, -1521,  7407, -1521, -1521, -1521, -1521,  1254,  1258,  1264,
+    1280, -1521, -1521,  7598,   417, -1521, -1521,   145, -1521,  3385,
+   -1521,  1258,  1261,   644,  1280, -1521, -1521
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -1516,252 +1518,252 @@ static const yytype_int16 yypact[] =
    means the default is an error.  */
 static const yytype_int16 yydefact[] =
 {
-       2,   165,     1,   363,     0,     0,     0,   669,   364,     0,
-     861,   851,   856,    20,     0,     0,    19,    16,    15,     3,
-       0,     0,     0,     8,   705,     7,   650,     6,    11,     5,
+       2,   168,     1,   366,     0,     0,     0,   672,   367,     0,
+     864,   854,   859,    20,     0,     0,    19,    16,    15,     3,
+       0,     0,     0,     8,   708,     7,   653,     6,    11,     5,
        4,    13,    12,    14,   133,   134,   132,   142,   144,    49,
-      65,    62,    63,     0,    51,     0,     0,    60,    50,   671,
-     670,     0,     0,    26,    25,   650,   669,   669,   669,     0,
-     337,    47,   149,   150,   151,     0,     0,     0,   152,   154,
-     161,     0,   148,    21,    10,     9,   287,   687,     0,   651,
-     652,     0,     0,     0,     0,     0,     0,    52,     0,     0,
-      61,     0,     0,    58,   672,   674,    22,     0,     0,     0,
-     339,     0,     0,   160,   155,     0,     0,     0,     0,     0,
-       0,    74,   288,   290,   675,   697,   696,   700,   654,   653,
-     660,   140,   141,   138,   139,   136,     0,     0,     0,   135,
+      65,    62,    63,     0,    51,     0,     0,    60,    50,   674,
+     673,     0,     0,    26,    25,   653,   672,   672,   672,     0,
+     340,    47,   152,   153,   154,     0,     0,     0,   155,   157,
+     164,     0,   151,    21,    10,     9,   290,   690,     0,   654,
+     655,     0,     0,     0,     0,     0,     0,    52,     0,     0,
+      61,     0,     0,    58,   675,   677,    22,     0,     0,     0,
+     342,     0,     0,   163,   158,     0,     0,     0,     0,     0,
+       0,    74,   291,   293,   678,   700,   699,   703,   657,   656,
+     663,   140,   141,   138,   139,   136,     0,     0,     0,   135,
      145,    66,    64,    54,    55,    53,    60,    57,    56,     0,
-      23,    24,    27,   761,    74,    74,   338,    45,    48,   159,
-       0,   156,   157,   158,   162,    72,    75,   166,   292,   291,
-     294,   289,   677,   676,     0,   699,   698,   702,   701,   706,
-     655,   577,    30,    31,    35,     0,   128,   129,   126,   127,
+      23,    24,    27,   764,    74,    74,   341,    45,    48,   162,
+       0,   159,   160,   161,   165,    72,    75,   169,   295,   294,
+     297,   292,   680,   679,     0,   702,   701,   705,   704,   709,
+     658,   580,    30,    31,    35,     0,   128,   129,   126,   127,
      125,   124,   130,     0,     0,    59,     0,     0,    29,     0,
-     685,   852,   857,    46,   153,    73,     0,   678,   679,   693,
-     657,     0,   578,     0,    32,    33,    34,     0,   143,   137,
-       0,     0,     0,     0,     0,     0,   714,   734,   715,   750,
-     716,   720,   721,   722,   723,   740,   727,   728,   729,   730,
-     731,   732,   733,   735,   736,   737,   738,   821,   719,   726,
-     739,   828,   835,   717,   724,   718,   725,     0,     0,     0,
-       0,   749,   782,   785,   783,   784,   848,   778,   673,    28,
-     764,   765,   762,   763,   683,   686,   862,     0,     0,     0,
-     262,   263,   264,   265,   266,   267,   268,   269,   270,   271,
-     272,   273,   274,   275,   276,   277,   278,   279,   280,   281,
-     282,   283,   284,   285,   286,     0,     0,   173,   167,   261,
-      74,     0,   685,   694,     0,    74,   659,   656,   577,    74,
-       0,   639,   632,   661,   131,   786,   812,   815,     0,   818,
-     808,     0,     0,   822,   829,   836,   842,   845,     0,   780,
-     792,   331,   798,   803,   797,     0,   811,   807,   800,     0,
-     802,     0,   779,     0,   684,     0,   853,   858,   252,   253,
-     250,   176,   177,   179,   178,   180,   181,   182,   183,   209,
-     210,   207,   208,   200,   211,   212,   201,   198,   199,   251,
-     234,     0,   249,   213,   214,   215,   216,   187,   188,   189,
-     184,   185,   186,   197,     0,   203,   204,   202,   195,   196,
-     191,   190,   192,   193,   194,   175,   174,   233,     0,   205,
-     206,   577,   170,   300,   741,   744,   747,   748,   742,   745,
-     743,   746,   680,     0,   691,   707,     0,   146,    74,     0,
-       0,   633,     0,     0,     0,     0,     0,     0,   478,   479,
-       0,     0,     0,     0,   472,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   740,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   566,   411,   413,   412,
-     414,   415,   416,   417,    41,     0,     0,     0,     0,     0,
-     331,     0,   396,   397,   936,   476,   475,   553,   473,   546,
-     545,   544,   543,   163,   549,   474,   548,   547,   520,   480,
-     521,     0,   469,   525,   481,     0,   477,   873,   875,   874,
-     470,   877,   876,   471,     0,     0,     0,   767,     0,   167,
-       0,   167,     0,   167,     0,     0,     0,   794,     0,   791,
-       0,     0,     0,   943,   389,   805,   806,   799,   801,     0,
-     804,   775,     0,     0,   850,   849,   863,   611,   617,   254,
-     256,   255,   257,   248,   232,   258,   235,   217,     0,   168,
-     362,   602,   603,     0,     0,     0,   293,     0,   393,     0,
-     295,   688,     0,   695,     0,     0,   634,   632,   658,   147,
-     640,     0,   630,   631,   629,     0,     0,     0,     0,   772,
-     897,   900,   342,   749,   346,   345,   351,   866,   872,   867,
-     868,   869,   871,   870,     0,   383,     0,     0,     0,   927,
-       0,     0,     0,     0,   374,   377,     0,   380,     0,   931,
-       0,   909,   913,     0,     0,   903,     0,   508,   509,     0,
-       0,     0,     0,     0,     0,     0,   485,   484,   522,   483,
-     482,     0,     0,     0,     0,   337,   943,   943,     0,   398,
-      74,     0,     0,   406,   397,   328,   163,   304,   305,   303,
-     789,     0,     0,     0,     0,   510,   511,     0,     0,     0,
+     688,   855,   860,    46,   156,    73,     0,   681,   682,   696,
+     660,     0,   581,     0,    32,    33,    34,     0,   143,   137,
+       0,     0,     0,     0,     0,     0,   717,   737,   718,   753,
+     719,   723,   724,   725,   726,   743,   730,   731,   732,   733,
+     734,   735,   736,   738,   739,   740,   741,   824,   722,   729,
+     742,   831,   838,   720,   727,   721,   728,     0,     0,     0,
+       0,   752,   785,   788,   786,   787,   851,   781,   676,    28,
+     767,   768,   765,   766,   686,   689,   865,     0,     0,     0,
+     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
+     275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
+     285,   286,   287,   288,   289,     0,     0,   176,   170,   264,
+      74,     0,   688,   697,     0,    74,   662,   659,   580,    74,
+       0,   642,   635,   664,   131,   789,   815,   818,     0,   821,
+     811,     0,     0,   825,   832,   839,   845,   848,     0,   783,
+     795,   334,   801,   806,   800,     0,   814,   810,   803,     0,
+     805,     0,   782,     0,   687,     0,   856,   861,   255,   256,
+     253,   179,   180,   182,   181,   183,   184,   185,   186,   212,
+     213,   210,   211,   203,   214,   215,   204,   201,   202,   254,
+     237,     0,   252,   216,   217,   218,   219,   190,   191,   192,
+     187,   188,   189,   200,     0,   206,   207,   205,   198,   199,
+     194,   193,   195,   196,   197,   178,   177,   236,     0,   208,
+     209,   580,   173,   303,   744,   747,   750,   751,   745,   748,
+     746,   749,   683,     0,   694,   710,     0,   146,    74,     0,
+       0,   636,     0,     0,     0,     0,     0,     0,   481,   482,
+       0,     0,     0,     0,   475,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   743,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   569,   414,   416,   415,
+     417,   418,   419,   420,    41,     0,     0,     0,     0,     0,
+     334,     0,   399,   400,   939,   479,   478,   556,   476,   549,
+     548,   547,   546,   166,   552,   477,   551,   550,   523,   483,
+     524,     0,   472,   528,   484,     0,   480,   876,   878,   877,
+     473,   880,   879,   474,     0,     0,     0,   770,     0,   170,
+       0,   170,     0,   170,     0,     0,     0,   797,     0,   794,
+       0,     0,     0,   946,   392,   808,   809,   802,   804,     0,
+     807,   778,     0,     0,   853,   852,   866,   614,   620,   257,
+     259,   258,   260,   251,   235,   261,   238,   220,     0,   171,
+     365,   605,   606,     0,     0,     0,   296,     0,   396,     0,
+     298,   691,     0,   698,     0,     0,   637,   635,   661,   147,
+     643,     0,   633,   634,   632,     0,     0,     0,     0,   775,
+     900,   903,   345,   752,   349,   348,   354,   869,   875,   870,
+     871,   872,   874,   873,     0,   386,     0,     0,     0,   930,
+       0,     0,     0,     0,   377,   380,     0,   383,     0,   934,
+       0,   912,   916,     0,     0,   906,     0,   511,   512,     0,
+       0,     0,     0,     0,     0,     0,   488,   487,   525,   486,
+     485,     0,     0,     0,     0,   340,   946,   946,     0,   401,
+      74,     0,     0,   409,   400,   331,   166,   307,   308,   306,
+     792,     0,     0,     0,     0,   513,   514,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   459,     0,     0,     0,     0,
-     751,   766,     0,     0,   170,     0,   170,     0,   170,   337,
-     609,     0,   607,     0,   615,     0,   752,     0,   943,     0,
-     335,   390,   790,   944,   332,   796,   774,   777,     0,   756,
-     612,    92,   618,    92,   259,   260,   237,   238,   240,   239,
-     241,   242,   243,   244,   236,   245,   246,   247,   221,   222,
-     224,   223,   225,   226,   227,   228,   219,   220,   229,   230,
-     231,   218,     0,   360,   361,     0,   577,   577,   577,   169,
-     172,   171,     0,   394,   328,   666,   692,   703,   590,   708,
-       0,     0,     0,     0,     0,   647,     0,     0,   787,   813,
-     816,    18,    17,   770,   771,     0,     0,     0,     0,   895,
-       0,     0,     0,   917,   920,   923,     0,   943,     0,   934,
-     943,     0,     0,     0,     0,     0,     0,     0,   943,     0,
-       0,   943,   906,     0,     0,     0,     0,     0,     0,     0,
-       0,    44,     0,    42,     0,     0,   916,     0,   621,     0,
-     620,     0,     0,   944,   888,   513,     0,     0,   446,   443,
-     445,   333,     0,   331,   462,     0,     0,     0,     0,   167,
-     398,     0,   406,     0,     0,   532,   531,     0,     0,   533,
-     537,   486,   487,   499,   500,   497,   498,     0,   526,     0,
-     518,     0,   550,   551,   552,   488,   489,   555,   556,   557,
-     504,   505,   506,   507,     0,     0,   502,   503,   501,   495,
-     496,   491,   490,   492,   493,   494,     0,     0,     0,   452,
-       0,     0,     0,     0,     0,   467,     0,   819,   809,   753,
-       0,   823,     0,   830,     0,   837,     0,     0,   843,     0,
-       0,   846,     0,     0,     0,   780,     0,     0,   391,   776,
-     757,   681,    90,    93,   854,    93,   859,     0,     0,   709,
-     599,   600,   622,   604,   606,   605,   395,     0,   662,   667,
-     681,   593,     0,   636,   637,     0,     0,     0,   649,   788,
-     814,   817,   773,     0,     0,     0,   896,     0,     0,     0,
+       0,     0,     0,     0,     0,   462,     0,     0,     0,     0,
+     754,   769,     0,     0,   173,     0,   173,     0,   173,   340,
+     612,     0,   610,     0,   618,     0,   755,     0,   946,     0,
+     338,   393,   793,   947,   335,   799,   777,   780,     0,   759,
+     615,    92,   621,    92,   262,   263,   240,   241,   243,   242,
+     244,   245,   246,   247,   239,   248,   249,   250,   224,   225,
+     227,   226,   228,   229,   230,   231,   222,   223,   232,   233,
+     234,   221,     0,   363,   364,     0,   580,   580,   580,   172,
+     175,   174,     0,   397,   331,   669,   695,   706,   593,   711,
+       0,     0,     0,     0,     0,   650,     0,     0,   790,   816,
+     819,    18,    17,   773,   774,     0,     0,     0,     0,   898,
+       0,     0,     0,   920,   923,   926,     0,   946,     0,   937,
+     946,     0,     0,     0,     0,     0,     0,     0,   946,     0,
+       0,   946,   909,     0,     0,     0,     0,     0,     0,     0,
+       0,    44,     0,    42,     0,     0,   919,     0,   624,     0,
+     623,     0,     0,   947,   891,   516,     0,     0,   449,   446,
+     448,   336,     0,   334,   465,     0,     0,     0,     0,   170,
+     401,     0,   409,     0,     0,   535,   534,     0,     0,   536,
+     540,   489,   490,   502,   503,   500,   501,     0,   529,     0,
+     521,     0,   553,   554,   555,   491,   492,   558,   559,   560,
+     507,   508,   509,   510,     0,     0,   505,   506,   504,   498,
+     499,   494,   493,   495,   496,   497,     0,     0,     0,   455,
+       0,     0,     0,     0,     0,   470,     0,   822,   812,   756,
+       0,   826,     0,   833,     0,   840,     0,     0,   846,     0,
+       0,   849,     0,     0,     0,   783,     0,     0,   394,   779,
+     760,   684,    90,    93,   857,    93,   862,     0,     0,   712,
+     602,   603,   625,   607,   609,   608,   398,     0,   665,   670,
+     684,   596,     0,   639,   640,     0,     0,     0,   652,   791,
+     817,   820,   776,     0,     0,     0,   899,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     944,     0,   523,     0,     0,   524,     0,   554,     0,     0,
-       0,     0,     0,     0,     0,   406,   561,   562,   563,   564,
-     565,     0,    38,     0,   108,     0,     0,     0,     0,   879,
-     878,   512,     0,     0,     0,     0,     0,   167,     0,     0,
-     943,     0,   463,     0,     0,     0,   466,   464,   164,     0,
-     170,   330,   354,   352,   300,     0,     0,     0,   353,     0,
-       0,     0,    74,     0,   325,   410,   306,     0,     0,     0,
-     319,     0,   320,   314,     0,   311,   310,     0,   312,     0,
-       0,   329,     0,    88,    89,    86,    87,   321,   366,   309,
-       0,   418,   167,   528,     0,   534,     0,     0,     0,   516,
-       0,     0,   538,   542,     0,     0,   519,     0,     0,     0,
-       0,   453,     0,   460,     0,   514,     0,   468,   820,   810,
-       0,   768,     0,   824,   826,   831,   833,   838,   840,   608,
-     844,   610,   614,   847,   616,   780,   781,   793,   336,   392,
-       0,   664,   682,   864,    91,   613,     0,   619,     0,   601,
-       0,     0,     0,     0,   623,     0,     0,     0,   682,   689,
-       0,   591,   704,     0,   577,   635,     0,   644,     0,     0,
-     648,   898,   901,   343,     0,   348,   349,   347,     0,     0,
-     386,   384,     0,     0,     0,   928,   926,   333,     0,   935,
-     938,   375,   378,   381,   932,   930,   910,   914,   912,     0,
-     904,    74,     0,    39,     0,     0,     0,   367,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   170,
-       0,   937,   334,   465,     0,     0,   331,     0,     0,     0,
-       0,     0,   404,     0,    74,     0,   355,     0,     0,   340,
-       0,     0,   324,     0,     0,    69,   300,     0,   357,   328,
-     322,   323,     0,    81,    82,     0,     0,     0,     0,   313,
-     308,   315,   316,   317,   318,   365,     0,   307,     0,     0,
+     947,     0,   526,     0,     0,   527,     0,   557,     0,     0,
+       0,     0,     0,     0,     0,   409,   564,   565,   566,   567,
+     568,     0,    38,     0,   108,     0,     0,     0,     0,   882,
+     881,   515,     0,     0,     0,     0,     0,   170,     0,     0,
+     946,     0,   466,     0,     0,     0,   469,   467,   167,     0,
+     173,   333,   357,   355,   303,     0,     0,     0,   356,     0,
+       0,     0,    74,     0,   328,   413,   309,     0,     0,     0,
+     322,     0,   323,   317,     0,   314,   313,     0,   315,     0,
+       0,   332,     0,    88,    89,    86,    87,   324,   369,   312,
+       0,   421,   170,   531,     0,   537,     0,     0,     0,   519,
+       0,     0,   541,   545,     0,     0,   522,     0,     0,     0,
+       0,   456,     0,   463,     0,   517,     0,   471,   823,   813,
+       0,   771,     0,   827,   829,   834,   836,   841,   843,   611,
+     847,   613,   617,   850,   619,   783,   784,   796,   339,   395,
+       0,   667,   685,   867,    91,   616,     0,   622,     0,   604,
+       0,     0,     0,     0,   626,     0,     0,     0,   685,   692,
+       0,   594,   707,     0,   580,   638,     0,   647,     0,     0,
+     651,   901,   904,   346,     0,   351,   352,   350,     0,     0,
+     389,   387,     0,     0,     0,   931,   929,   336,     0,   938,
+     941,   378,   381,   384,   935,   933,   913,   917,   915,     0,
+     907,    74,     0,    39,     0,     0,     0,   370,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   173,
+       0,   940,   337,   468,     0,     0,   334,     0,     0,     0,
+       0,     0,   407,     0,    74,     0,   358,     0,     0,   343,
+       0,     0,   327,     0,     0,    69,   303,     0,   360,   331,
+     325,   326,     0,    81,    82,     0,   148,   148,     0,   316,
+     311,   318,   319,   320,   321,   368,     0,   310,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   170,     0,     0,     0,
-       0,   441,     0,     0,   539,     0,   527,     0,   517,     0,
-     331,   454,     0,     0,   515,   461,   457,     0,   755,   769,
-     754,   827,   834,   841,   795,   758,   759,   665,     0,   855,
-     860,     0,   711,   712,   625,   624,   296,   663,   668,     0,
-       0,   584,   587,     0,   638,     0,   646,     0,     0,   344,
-     350,     0,     0,   385,   918,   921,   924,     0,     0,     0,
-       0,     0,     0,     0,   895,     0,   907,     0,     0,   300,
-     567,     0,    36,    43,     0,   110,     0,   111,     0,   112,
-       0,     0,     0,     0,     0,   881,   880,   444,   576,   447,
-       0,     0,   439,     0,   401,   402,     0,   400,   399,     0,
-     407,   300,   356,   300,   341,     0,     0,    67,    68,   117,
-     358,     0,     0,     0,     0,     0,     0,     0,   641,   372,
-     371,   430,   431,   433,   432,   434,   424,   425,   426,   435,
-     436,   420,   421,   422,   423,   437,   438,   427,   428,   429,
-     419,    74,     0,   575,     0,   573,   442,   570,     0,     0,
-       0,   569,     0,   455,     0,   458,     0,   865,   710,     0,
-       0,   297,   302,   690,     0,   585,   586,   587,   588,   579,
-     594,   645,   895,   895,     0,     0,     0,     0,     0,   331,
-     939,   333,   376,   379,   382,     0,   896,   911,   895,     0,
-     895,   558,     0,   560,   568,    40,   109,   368,     0,     0,
-       0,     0,   883,   882,     0,     0,   450,     0,     0,     0,
-     405,   408,   359,   123,   122,     0,     0,     0,     0,     0,
-       0,     0,     0,   300,   529,   535,     0,   574,   572,     0,
-     571,   760,   713,   626,     0,     0,   582,   579,   580,   581,
-     584,   894,   894,   387,     0,   895,   895,   886,     0,     0,
-     943,   894,   895,   886,   559,    37,     0,   113,   114,     0,
-       0,     0,   448,     0,     0,   440,   403,   296,    83,    74,
-       0,    74,    74,   632,   373,   642,   643,   409,   530,   536,
-     540,   456,   328,   592,   583,   595,   582,     0,     0,   891,
-     943,   893,     0,     0,     0,   894,   894,   887,     0,   929,
-     940,     0,     0,   886,     0,   941,     0,   885,   884,   451,
-       0,   327,     0,     0,   105,     0,   300,   300,     0,     0,
-     541,     0,     0,   597,   628,   627,   589,     0,   944,   892,
-     899,   902,   388,     0,     0,   925,   933,   915,     0,   905,
-       0,     0,   941,     0,    84,    88,    89,    86,    87,    85,
-     107,    97,    74,   119,   121,     0,     0,     0,     0,     0,
-     889,     0,   919,   922,   908,     0,   945,     0,   941,    94,
-      76,     0,   300,     0,     0,   299,   596,    74,     0,   942,
-     946,     0,   328,    74,    70,    71,     0,   106,     0,   116,
-       0,   370,   300,   890,   947,     0,    77,     0,    98,   369,
-     598,     0,   102,     0,   296,    99,    78,     0,    74,    96,
-     328,     0,    79,     0,   103,   102,     0,    76,   296,    80,
-     101
+       0,     0,     0,     0,     0,     0,   173,     0,     0,     0,
+       0,   444,     0,     0,   542,     0,   530,     0,   520,     0,
+     334,   457,     0,     0,   518,   464,   460,     0,   758,   772,
+     757,   830,   837,   844,   798,   761,   762,   668,     0,   858,
+     863,     0,   714,   715,   628,   627,   299,   666,   671,     0,
+       0,   587,   590,     0,   641,     0,   649,     0,     0,   347,
+     353,     0,     0,   388,   921,   924,   927,     0,     0,     0,
+       0,     0,     0,     0,   898,     0,   910,     0,     0,   303,
+     570,     0,    36,    43,     0,   110,     0,   111,     0,   112,
+       0,     0,     0,     0,     0,   884,   883,   447,   579,   450,
+       0,     0,   442,     0,   404,   405,     0,   403,   402,     0,
+     410,   303,   359,   303,   344,     0,     0,    67,    68,   117,
+     361,     0,     0,     0,     0,   150,     0,     0,     0,     0,
+     644,   375,   374,   433,   434,   436,   435,   437,   427,   428,
+     429,   438,   439,   423,   424,   425,   426,   440,   441,   430,
+     431,   432,   422,    74,     0,   578,     0,   576,   445,   573,
+       0,     0,     0,   572,     0,   458,     0,   461,     0,   868,
+     713,     0,     0,   300,   305,   693,     0,   588,   589,   590,
+     591,   582,   597,   648,   898,   898,     0,     0,     0,     0,
+       0,   334,   942,   336,   379,   382,   385,     0,   899,   914,
+     898,     0,   898,   561,     0,   563,   571,    40,   109,   371,
+       0,     0,     0,     0,   886,   885,     0,     0,   453,     0,
+       0,     0,   408,   411,   362,   123,   122,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   303,   532,   538,     0,
+     577,   575,     0,   574,   763,   716,   629,     0,     0,   585,
+     582,   583,   584,   587,   897,   897,   390,     0,   898,   898,
+     889,     0,     0,   946,   897,   898,   889,   562,    37,     0,
+     113,   114,     0,     0,     0,   451,     0,     0,   443,   406,
+     299,    83,    74,   149,     0,     0,    74,   635,   376,   645,
+     646,   412,   533,   539,   543,   459,   331,   595,   586,   598,
+     585,     0,     0,   894,   946,   896,     0,     0,     0,   897,
+     897,   890,     0,   932,   943,     0,     0,   889,     0,   944,
+       0,   888,   887,   454,     0,   330,     0,     0,   105,     0,
+      74,   303,     0,     0,   544,     0,     0,   600,   631,   630,
+     592,     0,   947,   895,   902,   905,   391,     0,     0,   928,
+     936,   918,     0,   908,     0,     0,   944,     0,    84,    88,
+      89,    86,    87,    85,   107,    97,     0,   303,   121,     0,
+       0,     0,     0,     0,   892,     0,   922,   925,   911,     0,
+     948,     0,   944,    94,    76,     0,    74,   119,     0,     0,
+     302,   599,    74,     0,   945,   949,     0,   331,    74,    70,
+      71,     0,   106,     0,   303,     0,   373,   303,   893,   950,
+       0,    77,     0,    98,   116,   372,   601,     0,   102,     0,
+     299,    99,    78,     0,    74,    96,   331,     0,    79,     0,
+     103,   102,     0,    76,   299,    80,   101
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-   -1535, -1535,  -895,    -1, -1535, -1535, -1535, -1535, -1535,   884,
-    1400, -1535, -1535, -1535, -1535, -1535, -1535,  1494, -1535, -1535,
-   -1535,   243, -1535,  1363, -1535, -1535,  1418, -1535, -1535, -1535,
-   -1535,  -140,  -184, -1535, -1535, -1535, -1535, -1534,   782,   783,
-   -1535, -1535, -1535, -1535,  -177, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535,  -976, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535,  1303, -1535, -1535,   -45,  1405, -1535, -1535, -1535,   595,
-     890,   868,   561,  -486,  -670, -1535,  -309, -1535, -1535, -1535,
-   -1385, -1535, -1535, -1495, -1535, -1535, -1012, -1535, -1535, -1535,
-   -1535, -1535, -1535,  -753,  -328, -1137,   810,   -13, -1535, -1535,
-   -1535, -1535, -1535, -1524, -1522, -1513, -1511, -1535, -1535,  1514,
-   -1535,  -985, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535,  -456, -1310,   366,   150, -1535,
-    -793, -1535,   370, -1535, -1535, -1535, -1535, -1395, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535,   510,  1081, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535,  -163,    11,   -35,
-      12,    96, -1535, -1535, -1535, -1535, -1535, -1535, -1535,   262,
-    -504,  -761, -1535,  -509,  -772, -1535,  -928,   -34,   -31, -1535,
-    -565,  -560, -1535, -1535, -1535, -1211, -1535,  1476, -1535, -1535,
-   -1535, -1535, -1535,   396,   586, -1535,   958, -1535, -1535, -1535,
-   -1535, -1535, -1535,   587, -1535,  1239, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535,  -168, -1535,  1109, -1535, -1535, -1535,  1315, -1535, -1535,
-   -1535,  -569, -1535, -1535,  -330,  -887, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535,  -116, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535,  -811, -1424,  -607, -1535, -1535, -1210, -1248,
-    1114, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535, -1535,
-   -1535,  1162, -1535, -1535,  1166, -1535, -1535, -1535, -1535, -1535,
-   -1535, -1535, -1535, -1535, -1535,   952, -1535,  -421,  1170, -1022,
-    -620,  1171,  -418
+   -1521, -1521,  -895,    -1, -1521, -1521, -1521, -1521, -1521,   823,
+    1371, -1521, -1521, -1521, -1521, -1521, -1521,  1454, -1521, -1521,
+   -1521,   364, -1521,  1323, -1521, -1521,  1377, -1521, -1521, -1521,
+   -1521,  -140,  -227, -1521, -1521, -1521, -1521, -1520,   746,   747,
+   -1521, -1521, -1521, -1521,  -223, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521,  -982, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521,  1265, -1521, -1521,   -45,  -103,  -337,   237, -1521, -1521,
+     395,   834,   845,   522,  -479,  -672, -1521,  -301, -1521, -1521,
+   -1521, -1278, -1521, -1521, -1494, -1521, -1521, -1020, -1521, -1521,
+   -1521, -1521, -1521, -1521,  -741,  -325, -1139,   770,   -13, -1521,
+   -1521, -1521, -1521, -1521, -1519, -1517, -1509, -1505, -1521, -1521,
+    1477, -1521, -1035, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521,  -456, -1315,   399,   121,
+   -1521,  -802, -1521,   419, -1521, -1521, -1521, -1521, -1404, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,   515,  1086,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,  -163,   -21,
+     -67,   -17,    58, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+     134,  -498,  -767, -1521,  -507,  -750, -1521,  -930,   -63,   -60,
+   -1521,  -562,  -560, -1521, -1521, -1521, -1213, -1521,  1449, -1521,
+   -1521, -1521, -1521, -1521,   370,   560, -1521,   840, -1521, -1521,
+   -1521, -1521, -1521, -1521,   561, -1521,  1212, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521,  -168, -1521,  1095, -1521, -1521, -1521,  1292, -1521,
+   -1521, -1521,  -550, -1521, -1521,  -330,  -887, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521,  -116, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521,  -816, -1387,  -606, -1521, -1521, -1257,
+   -1249,  1096, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
+   -1521, -1521,  1098, -1521, -1521,  1101, -1521, -1521, -1521, -1521,
+   -1521, -1521, -1521, -1521, -1521, -1521,   919, -1521,  -420,  1118,
+   -1090,  -620,  1127,  -419
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int16 yydefgoto[] =
 {
        0,     1,   783,   784,    18,   142,    55,   188,    19,   175,
-     181,  1465,  1184,  1342,   625,   475,   148,   476,   102,    21,
-      22,    47,    48,    93,    23,    41,    42,  1047,  1048,  1656,
-     156,   157,  1657,  1672,  1685,  1235,  1583,  1049,   933,   934,
-    1640,  1652,  1671,  1641,  1676,  1680,  1686,  1677,  1050,  1051,
-    1621,  1052,  1006,  1053,  1054,  1055,  1056,  1057,  1058,  1059,
-    1060,   182,   183,    37,    38,    39,   202,    68,    69,    70,
-      71,   643,    24,   402,   556,   298,   299,   113,    25,   160,
-     300,   161,   196,  1432,  1504,  1627,   558,   559,  1136,   477,
-    1061,  1229,  1485,   851,   633,  1019,   709,   478,  1062,   584,
-     788,  1319,   479,  1063,  1064,  1065,  1066,  1067,   755,  1068,
-    1246,  1188,  1389,  1069,   480,   802,  1330,   803,  1331,   805,
-    1332,   481,   792,  1323,   482,   523,   560,   483,  1212,  1213,
-     849,   484,   647,   485,  1070,   486,   487,   840,   488,  1016,
-    1475,  1017,  1533,   489,   902,  1285,   490,   524,   492,  1267,
-    1548,  1269,  1549,  1418,  1590,   493,   494,   550,  1510,  1555,
-    1437,  1439,  1313,   951,  1144,  1592,  1629,   551,   552,   553,
-     700,   701,   721,   704,   705,   723,   831,   940,   941,  1596,
-     575,   422,   567,   312,  1492,   568,   313,    80,   120,   200,
-     308,    27,   171,   949,  1122,   950,    51,    52,   139,    28,
-     164,   198,   302,  1123,   265,   266,    29,   114,   765,  1309,
-     563,   304,   305,   117,   169,   769,    30,    78,   199,   564,
-     942,   495,   412,   253,   254,   910,   931,   190,   255,   692,
-    1289,   919,   578,   342,   256,   519,   257,   423,   959,   520,
-     707,   505,  1099,   424,   960,   425,   961,   504,  1098,   508,
-    1103,   509,  1291,   510,  1105,   511,  1292,   512,  1107,   513,
-    1293,   514,  1110,   515,  1113,   702,    31,    57,   267,   537,
-    1126,    32,    58,   268,   538,  1128,    33,    56,   345,   719,
-    1298,   586,   496,   637,  1568,   638,  1560,  1561,  1562,   969,
-     497,   786,  1317,   787,  1318,   813,  1337,   993,  1459,   809,
-    1334,   498,   810,  1335,   499,   973,  1446,   974,  1447,   975,
-    1448,   796,  1327,   807,  1333,  1020,   640,   500,   501,  1611,
-     714,   502,   503
+     181,  1467,  1184,  1342,   625,   475,   148,   476,   102,    21,
+      22,    47,    48,    93,    23,    41,    42,  1047,  1048,  1661,
+     156,   157,  1662,  1678,  1691,  1235,  1587,  1049,   933,   934,
+    1644,  1657,  1677,  1645,  1682,  1686,  1692,  1683,  1050,  1051,
+    1625,  1052,  1006,  1053,  1054,  1055,  1056,  1057,  1058,  1059,
+    1060,   182,   183,    37,    38,    39,   202,  1386,    68,    69,
+      70,    71,   643,    24,   402,   556,   298,   299,   113,    25,
+     160,   300,   161,   196,  1434,  1507,  1631,   558,   559,  1136,
+     477,  1061,  1229,  1487,   851,   633,  1019,   709,   478,  1062,
+     584,   788,  1319,   479,  1063,  1064,  1065,  1066,  1067,   755,
+    1068,  1246,  1188,  1391,  1069,   480,   802,  1330,   803,  1331,
+     805,  1332,   481,   792,  1323,   482,   523,   560,   483,  1212,
+    1213,   849,   484,   647,   485,  1070,   486,   487,   840,   488,
+    1016,  1477,  1017,  1536,   489,   902,  1285,   490,   524,   492,
+    1267,  1552,  1269,  1553,  1420,  1594,   493,   494,   550,  1513,
+    1559,  1439,  1441,  1313,   951,  1144,  1596,  1633,   551,   552,
+     553,   700,   701,   721,   704,   705,   723,   831,   940,   941,
+    1600,   575,   422,   567,   312,  1495,   568,   313,    80,   120,
+     200,   308,    27,   171,   949,  1122,   950,    51,    52,   139,
+      28,   164,   198,   302,  1123,   265,   266,    29,   114,   765,
+    1309,   563,   304,   305,   117,   169,   769,    30,    78,   199,
+     564,   942,   495,   412,   253,   254,   910,   931,   190,   255,
+     692,  1289,   919,   578,   342,   256,   519,   257,   423,   959,
+     520,   707,   505,  1099,   424,   960,   425,   961,   504,  1098,
+     508,  1103,   509,  1291,   510,  1105,   511,  1292,   512,  1107,
+     513,  1293,   514,  1110,   515,  1113,   702,    31,    57,   267,
+     537,  1126,    32,    58,   268,   538,  1128,    33,    56,   345,
+     719,  1298,   586,   496,   637,  1572,   638,  1564,  1565,  1566,
+     969,   497,   786,  1317,   787,  1318,   813,  1337,   993,  1461,
+     809,  1334,   498,   810,  1335,   499,   973,  1448,   974,  1449,
+     975,  1450,   796,  1327,   807,  1333,  1020,   640,   500,   501,
+    1615,   714,   502,   503
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -1769,396 +1771,391 @@ static const yytype_int16 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      17,    61,    72,   522,   191,   192,   776,   774,   203,   590,
-     785,   947,   593,   535,  1135,   636,   832,   834,   252,    73,
-      74,    75,  1217,   694,   912,   696,   914,   698,   916,   722,
-    1328,  1191,  1024,   720,   846,  1390,  1121,   130,  1117,   540,
-     542,   994,  1581,    89,  -165,  1189,   527,   614,  1614,   991,
-     525,    95,    72,    72,    72,  1121,    34,    35,  1615,  1072,
-    1616,  1481,   708,  1351,  1477,   596,  1540,   565,     2,  1617,
-     258,  1618,   107,   108,   109,     3,  1140,  1508,    90,   554,
-    1532,   155,   566,  1100,    13,  1195,  1457,   548,   924,   753,
-     571,  1101,   155,   330,    72,    72,    72,    72,     4,  1574,
-       5,   869,     6,  1012,    40,   572,  1085,  1658,     7,    79,
-     870,   573,  1013,   331,  1102,  1086,   608,  1615,     8,  1616,
-    1003,   663,   664,    16,     9,  1544,   548,  1338,  1617,   555,
-    1618,   332,   754,   149,   828,  1004,   922,  1509,  1579,   201,
-     926,   426,   427,  1681,   797,   416,   176,   177,    10,  1608,
-     121,   122,   574,  1615,   808,  1616,   309,   811,   333,   334,
-     403,   433,   597,   598,  1617,   415,  1618,   435,   828,   417,
-      11,    12,  1005,   251,  1194,   252,   549,   977,   201,  1679,
-     981,   830,   968,  1547,   343,   845,    53,    82,   989,   685,
-     686,   992,   528,  1690,  1511,  1512,   526,    84,  1190,   307,
-      36,  1141,  1181,  1164,   442,   443,    91,  1628,   615,   956,
-    1521,   529,  1523,  1163,  1379,   830,  1190,  1190,    92,  1190,
-     530,   703,   335,    13,  1361,    54,   336,  1297,  1294,   979,
-      13,   906,   565,    13,    15,  1023,   725,   329,   445,   446,
-     599,   517,  1142,  1297,  1647,  -825,   661,   566,   878,   663,
-     664,   879,   252,    62,    14,   252,   252,   252,    85,   757,
-     600,   518,    16,    81,  1353,   418,    15,  1565,  1566,    16,
-      83,   798,    16,   337,  1573,    59,   634,   338,   569,   995,
-     339,  1546,    63,   101,  1387,  1021,   814,   178,    87,  1388,
-     758,   123,   179,   601,   180,  -825,   124,   126,   125,    60,
-    -825,   126,  1563,   634,    13,   340,    88,   576,   577,   579,
-    1349,  1572,  1021,   602,  1519,   828,   582,   685,   686,  -825,
-     917,   829,  1558,  -832,  -839,  -449,    64,  1463,   133,   134,
-     251,   135,    43,   967,   470,   127,   252,   252,   128,   332,
-     252,   474,   252,    16,   252,   306,   252,  1350,   609,    44,
-    1022,    65,   252,    76,   926,  1603,  1604,    94,    59,  1154,
-    1214,  1482,   830,  1030,   612,  1470,   333,   334,   610,   252,
-     100,    86,    45,  -832,  -839,  -449,  1430,    82,  -832,  -839,
-    -449,    77,    60,    46,   613,  1207,   252,   252,   688,   689,
-    1148,  1208,   693,   101,   695,  1363,   697,  -832,  -839,  -449,
-    1202,  1159,  1491,   207,   710,   194,   106,   251,  1488,    66,
-     251,   251,   251,  1114,   828,  1111,   828,   583,   594,    67,
-    1352,  1209,  1025,  1096,  1096,   922,  1127,   332,   112,  1125,
-     335,   208,  1210,   252,   336,  1090,    59,  1211,   760,   761,
-     781,    13,    43,   955,  1091,   110,   651,   652,   252,   782,
-    1026,  1097,  1155,   343,   333,   334,   963,   964,   828,    44,
-      60,   830,  1132,   830,   829,  1133,   976,   131,  1134,  1422,
-     101,   111,   983,   984,  1346,   986,  1381,   988,   110,   990,
-      16,   337,    45,   856,   860,   338,  1369,  1151,   339,  1204,
-     828,   251,   251,    46,    13,   251,  1530,   251,   874,   251,
-     841,   251,  1347,   790,  1028,   830,   343,   251,  1096,    92,
-    1096,    59,  1096,   340,  1370,  1205,   136,   903,   335,  1204,
-     836,   572,   336,   791,   251,   837,   155,   573,    49,  1360,
-    1096,  1199,  1096,    16,    50,    60,  1416,   830,  1423,   252,
-    1425,   251,   251,   655,   656,  1478,  1531,   651,   652,   766,
-    1346,   661,   838,   662,   663,   664,   665,   666,  1464,    13,
-    1468,  1096,   781,    13,  1346,  1096,  1096,   565,   574,   337,
-     775,   782,  1204,   338,  1623,  1624,   339,  1506,  1528,   918,
-     651,   652,   566,   107,  1204,   109,  1266,  1204,   251,  1529,
-    1637,   710,  1543,  1580,  1622,   922,  1411,  1438,    16,   938,
-    1630,   340,    16,   251,   137,   252,   781,   680,   681,   682,
-     683,   684,  1663,  1499,   939,   782,  1651,   252,   252,   252,
-     252,  1272,   685,   686,   252,   138,   839,    59,   252,    72,
-    1659,   651,   652,  1282,   252,   252,   836,   252,  1287,   252,
-     118,   252,   252,  1162,   655,   656,   119,   204,   205,  1168,
-    1670,    60,   661,   260,   662,   663,   664,   665,   666,  1653,
-     103,   104,   105,  1179,  1296,   781,   115,   116,   261,   962,
-    1654,  1655,   965,   262,   782,   263,   972,   655,   656,   147,
-     189,   143,   948,   781,  -761,   661,  1198,   662,   663,   664,
-     665,   666,   782,   343,   251,   767,   768,   778,   781,    13,
-    1559,  1559,   151,   152,   153,   154,  1567,   782,   781,    13,
-    1559,  1588,  1567,   140,   421,   921,  1083,   782,   634,   141,
-     932,   165,   932,   685,   686,   925,  1341,  1021,   655,   656,
-     144,   419,   166,  1348,   420,   145,   661,   421,    16,   663,
-     664,   665,   666,   682,   683,   684,   343,  1597,    16,   252,
-     779,   252,   252,   158,  1559,  1559,   685,   686,   252,   159,
-     251,   772,  1567,   162,   773,   252,   343,   421,   146,   163,
-     907,   167,   251,   251,   251,   251,   958,   168,  1435,   251,
-     170,   343,   184,   251,  1436,   908,   781,    13,    90,   251,
-     251,   186,   251,   187,   251,   782,   251,   251,   343,  1591,
-     189,  1109,   911,  1115,  1112,   252,   252,   685,   686,   210,
-    1118,   252,   343,   343,   343,   211,   913,   915,  1153,   343,
-    1648,   212,   107,  1161,   193,   252,    16,   195,   491,   343,
-     332,   213,   343,  1495,  1233,  1234,  1550,  1402,   516,   214,
-    1403,   172,   173,   821,   822,   259,   472,   644,   252,   645,
-    1046,   532,   197,   646,   215,   646,   646,   333,   334,   648,
-     649,   216,   217,   218,   219,   220,   221,   222,   223,   224,
-     225,   226,   227,   228,   229,   230,   231,   232,   233,   234,
-     235,   236,   237,   238,   239,   240,   241,   242,   243,   244,
-     245,   246,   247,   248,   201,  1471,   107,   108,   109,  1665,
-    1571,   209,  1226,   264,   251,   301,   251,   251,   303,   781,
-      13,   310,   311,   251,   172,   173,   174,   315,   782,   318,
-     251,   335,   781,    13,   572,   336,  1158,  1683,   316,    59,
-     573,   782,  1124,   317,  1124,   781,    13,  1412,   341,  1177,
-    1599,   319,   249,   320,   782,   323,  1046,   324,   325,    16,
-     781,    13,  1180,    60,  1147,   321,  1150,   326,   327,   782,
-     251,   251,    16,   344,   328,   252,   251,  1325,   781,    13,
-     343,   574,   337,   399,   346,    16,   338,   782,   347,   339,
-     251,  1312,   400,  1589,   401,  1326,   414,   404,   506,   507,
-      16,   405,   250,   533,   536,   651,   652,   534,   543,  1520,
-     204,   205,   206,   251,   340,   406,   407,   544,    16,   545,
-     408,   409,   410,   411,    97,    98,    99,  1304,   943,   944,
-     945,  1534,   546,   557,  1626,   547,   561,   562,   570,   580,
-     581,   711,   595,   604,   603,   605,   606,   607,  1222,   608,
-     611,  1339,   616,   718,   619,   620,  1230,  1231,   621,   639,
-     703,   691,   713,   771,   622,   332,   623,   825,   624,  1239,
-    1643,  1240,  1241,  1242,  1243,  1244,   641,   642,   650,  1247,
-     651,   652,   687,   752,  1371,   690,   706,   712,   770,   715,
-     716,   756,   333,   334,  1585,   777,   780,   759,   764,   789,
-     653,   654,   655,   656,   657,   793,   794,   658,   795,   252,
-     661,   252,   662,   663,   664,   665,   666,   812,   667,   668,
-     824,   827,   799,   801,   833,   332,   804,   848,   806,   826,
-     251,  1518,   835,   867,   909,   850,   920,   929,   930,   815,
-     816,   817,   818,   819,   820,   948,   953,   980,   954,   970,
-     982,   985,   333,   334,   987,   996,   335,   997,  1316,   998,
-     336,  1073,   999,  1414,   678,   679,   680,   681,   682,   683,
-     684,  1093,  1075,  1000,  1001,   653,   654,   655,   656,  1007,
-    1014,   685,   686,  1131,   871,   661,  1079,   662,   663,   664,
-     665,   666,  1011,   667,   668,  1015,   781,    13,  1095,  1027,
-    1029,  1074,  1076,  1077,  1078,   782,   904,   337,  1088,  1089,
-     332,   338,  1094,   978,   339,  1104,   335,   252,  1106,  1108,
-     336,   518,   332,  1116,  1120,  1129,  1130,  1137,  1145,  1146,
-    1156,  1157,  1160,   928,  1166,  1167,    16,   333,   334,   340,
-    1170,   680,   681,   682,   683,   684,  1175,  1178,  1182,   333,
-     334,  1183,  1185,  1186,  1223,  1193,   685,   686,  1187,  1192,
-     252,  1200,  1201,  1203,   251,  1220,   251,   337,  1625,  1483,
-    1221,   338,   937,  1152,   339,  1232,   252,  1236,   651,   652,
-    1237,  1493,  1238,  1245,  1274,  1275,  1277,  1278,  1288,  1283,
-     952,  1290,  1284,  1299,  1302,  1303,   957,  1310,  1311,   340,
-    1300,   335,  1306,  1321,  1314,   336,  1320,  1322,  1343,  1345,
-     332,   971,  1496,   335,  1357,  1358,  1362,   336,  1364,  1365,
-    1366,  1367,  1440,  1368,  1441,  1373,  1375,  1376,  1505,  1378,
-    1377,  1413,  1427,  1382,  1429,  1383,  1384,   333,   334,  1385,
-    1426,  1431,  1002,  1386,  1433,  1434,  1415,  1008,  1417,  1009,
-    1421,  1010,   337,  1438,  1456,  1445,   338,  1442,  1165,   339,
-    1428,   799,  1443,  1449,   337,  1450,  1466,  1451,   338,  1455,
-    1171,   339,   251,   653,   654,   655,   656,   657,  1458,  1460,
-     658,   659,   660,   661,   340,   662,   663,   664,   665,   666,
-    1046,   667,   668,  1467,  1469,   669,   340,   670,   671,   672,
-    1474,   335,  1476,   673,  1479,   336,  1497,  1498,  1500,  1584,
-    1502,  1586,  1587,  1513,  1514,   251,  1515,  1087,  1516,  1517,
-    1522,  1092,  1525,  1524,  1527,  1535,  1536,  1526,  1538,  1539,
-     252,   251,   674,  1084,   675,   676,   677,   678,   679,   680,
-     681,   682,   683,   684,  1537,  1541,  1542,  1119,  1552,  1551,
-    1554,  1569,   337,  1570,   685,   686,   338,  1576,  1172,   339,
-     738,   739,   740,   741,   742,   743,   744,   745,  1582,  1204,
-     651,   652,   839,  1598,  1600,  1601,  1149,  1602,  1631,   746,
-    1605,  1606,  1607,  1609,   340,   747,  1635,  1610,  1632,  1613,
-    1633,   129,  1642,  1634,  1636,   748,   749,   750,  1639,  1667,
-    1169,  1545,  1650,  1645,  1664,    20,  1678,  1674,  1688,   185,
-     332,  1675,   132,  1689,  1553,   935,   936,  1662,  1687,   823,
-     314,   150,  1143,  1666,   852,    26,   751,   923,  1556,  1480,
-     839,  1593,  1557,  1594,  1196,  1197,  1595,   333,   334,   617,
-     618,    96,   847,  1507,  1308,   928,  1138,  1139,  1682,   585,
-     322,   413,  1216,     0,   587,  1219,   626,   627,   628,   629,
-     630,  1225,     0,  1228,   800,   653,   654,   655,   656,   657,
-       0,     0,   658,   659,   660,   661,     0,   662,   663,   664,
-     665,   666,     0,   667,   668,   251,     0,   669,     0,   670,
-     671,   672,  1620,     0,  1268,   673,  1270,     0,  1273,     0,
-    1046,   335,   588,     0,     0,   336,   589,     0,  1279,     0,
-     591,   592,     0,     0,     0,     0,   928,     0,     0,     0,
-       0,     0,     0,     0,   674,     0,   675,   676,   677,   678,
-     679,   680,   681,   682,   683,   684,     0,  1646,     0,     0,
-    1295,     0,     0,     0,     0,     0,   685,   686,   763,     0,
-    1301,     0,   337,  1661,     0,  1305,   338,  1307,  1173,   339,
-       0,     0,     0,     0,     0,     0,     0,  1668,  1315,  1669,
-       0,     0,     0,     0,  1046,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   340,     0,     0,   799,     0,     0,
-    1684,     0,  1046,   726,   727,   728,   729,   730,   731,   732,
-     733,     0,     0,     0,     0,  1344,     0,     0,     0,     0,
-       0,     0,   -85,  1354,  1355,  1356,     0,     0,   734,     0,
-       0,     0,     0,   651,   652,     0,     0,     0,   735,   736,
-     737,     0,     0,     0,     0,  1372,     0,     0,  1374,     0,
-       0,     0,     0,     0,   861,   862,     0,  1380,   863,   864,
-     865,   866,     0,   868,     0,     0,   872,   873,   875,   876,
-     877,   880,   881,   882,   883,   885,   886,   887,   888,   889,
-     890,   891,   892,   893,   894,   895,     0,     0,     0,     0,
+      17,    61,    72,   150,   191,   192,   522,   774,   203,   776,
+     590,   593,  1135,   535,  1217,   636,   832,   834,   252,    73,
+      74,    75,   912,   947,   914,  1191,   916,  1024,  1328,   785,
+     694,   722,   696,  1392,   698,   846,  1121,   130,  1117,   720,
+     596,   121,   122,   991,  -168,  1189,  1585,   540,   542,  1351,
+    1072,    95,    72,    72,    72,  1121,  1483,  1511,   828,   548,
+      40,  1479,   708,   994,    34,    35,  1618,  1619,     2,  1620,
+     258,  1589,  -828,  1535,    62,     3,  1140,  1621,   548,  1592,
+     614,  1622,   421,  1195,    89,  1459,   527,    81,   924,   757,
+     571,   107,   108,   109,    72,    72,    72,    72,     4,   525,
+       5,   565,     6,    63,  1132,   830,   753,  1133,     7,   549,
+    1134,   201,   651,   652,   101,   572,   566,  1512,     8,    90,
+     758,   573,  -828,   330,     9,  1663,  1619,  -828,  1620,   828,
+     201,  1349,  1583,   176,   177,  1194,  1621,   597,   598,  1578,
+    1622,   426,   427,   331,   797,   416,  -828,    64,    10,   754,
+      79,   917,   149,  1389,   808,   922,   309,   811,  1390,   926,
+     403,   433,   574,  1687,  1619,   415,  1620,   435,  1350,   417,
+      11,    12,    65,   251,  1621,   252,   830,   977,  1622,    59,
+     981,  1551,   123,   968,    83,   845,  1685,   124,   989,   125,
+    1612,   992,   126,  1181,    82,  1514,  1515,    84,  1190,   307,
+    1696,  1141,  1190,    60,   442,   443,  1379,  1163,    36,   655,
+     656,  1524,   956,  1526,  1190,   599,    85,   661,  1361,   662,
+     663,   664,   665,   666,  1190,  1164,   127,  1297,  1294,   128,
+      66,   906,   528,    13,    15,   600,  1023,   329,   445,   446,
+      67,   615,  1142,  1297,   725,   526,  -835,    91,   979,   878,
+     879,   529,   252,  1003,    14,   252,   252,   252,  1567,    92,
+     530,   554,  1353,   517,    53,   418,    15,  1576,  1004,  1569,
+    1570,   798,    16,  -842,   178,    59,  1577,  -452,   569,   179,
+     110,   180,  1550,   518,   126,    88,   814,   565,   685,   686,
+     661,   634,    94,   663,   664,   110,  -835,   663,   664,    60,
+    1021,  -835,   566,    54,    13,  1005,   111,   576,   577,   579,
+      13,   555,  1607,  1608,  1522,  1472,   582,   828,  1632,  1465,
+    -835,  1028,   703,  -842,    13,   115,   116,  -452,  -842,   828,
+     251,    43,  -452,   967,   470,   829,   252,   252,  1022,   100,
+     252,   474,   252,    16,   252,  1548,   252,  -842,    44,    16,
+     828,  -452,   252,  1484,  1494,  1652,  1352,  1204,  1214,   634,
+    1154,   685,   686,    16,   830,   685,   686,   343,  1021,   252,
+    1030,    45,  1100,   926,  1432,   828,   830,   101,  1207,   828,
+    1101,  1533,    46,  1205,  1208,   829,   252,   252,   688,   689,
+    1363,   101,   693,  1148,   695,    13,   697,   830,  1296,   781,
+    1202,    13,    43,  1102,   710,  1562,   106,   251,   782,    87,
+     251,   251,   251,   343,  1209,  1114,   131,   583,   594,    44,
+    1159,  1111,   830,   651,   652,  1210,   830,   332,  1127,   112,
+    1211,    76,   155,   252,    16,  1125,   306,    82,   760,   761,
+      16,    86,    45,   955,   922,   155,   651,   652,   252,   133,
+     134,   601,   135,    46,   333,   334,   963,   964,   207,    77,
+     103,   104,   105,  1204,  1424,   194,   976,   608,  1025,    59,
+      49,   602,   983,   984,   609,   986,    50,   988,  1096,   990,
+    1338,    92,  1096,   856,   860,  1346,   208,  1369,  1381,  1480,
+    1204,   251,   251,    60,   610,   251,  1026,   251,   874,   251,
+     841,   251,   151,   152,   153,   154,  1097,   251,   565,  1544,
+    1155,    82,  1096,  1347,   938,  1370,  1502,   903,   335,  1096,
+     655,   656,   336,   566,   251,  1384,  1641,  1360,   661,   939,
+     201,   663,   664,   665,   666,  1096,    59,  1543,  1199,   252,
+    1418,   251,   251,   655,   656,   836,  1534,  1425,   612,   766,
+     837,   661,  1656,   662,   663,   664,   665,   666,   781,    13,
+      60,  1096,  1096,  1427,  1346,   147,   790,   782,   613,   337,
+     775,  1628,   136,   338,  1096,   978,   339,   838,  1346,   189,
+     651,   652,   155,  -764,  1096,  1204,   791,  1096,   251,  1466,
+    1470,   710,  1531,  1266,  1413,   869,  1509,  1204,    16,   685,
+     686,   340,  1532,   251,   870,   252,  1547,  1647,   137,   682,
+     683,   684,  1584,  1634,   922,  1646,  1440,   252,   252,   252,
+     252,  1272,   685,   686,   252,  1668,   839,   138,   252,    72,
+     165,   781,    13,  1282,   252,   252,    59,   252,  1287,   252,
+     782,   252,   252,  1162,  1674,   836,   143,  1676,   918,  1168,
+    1012,   166,   781,    13,   948,   781,  1658,   781,    13,  1013,
+      60,   782,   144,  1179,   782,   343,   782,  1659,  1660,   962,
+    1085,    16,   965,  1090,   921,   781,   972,   655,   656,  1086,
+     472,   644,  1091,   645,   782,   661,  1198,   662,   663,   664,
+     665,   666,    16,   634,   251,   204,   205,    16,  1563,  1563,
+     781,    13,  1021,   260,  1571,   145,   118,   140,  1563,   782,
+    1571,   343,   119,   141,   146,   778,  1083,   925,   261,   170,
+     932,   419,   932,   262,   420,   263,  1341,   421,   158,   772,
+     781,    13,   773,  1348,   159,   421,   107,   108,   109,   782,
+      16,   680,   681,   682,   683,   684,  1601,  1115,   107,   252,
+     109,   252,   252,  1563,  1563,   343,   685,   686,   252,   779,
+     251,  1571,   172,   173,   174,   252,   651,   652,   781,    13,
+      16,   184,   251,   251,   251,   251,   958,   782,   162,   251,
+     167,  1437,    90,   251,   163,  1158,   168,  1438,   187,   251,
+     251,   343,   251,   186,   251,   907,   251,   251,   343,   343,
+     193,  1109,   908,   911,  1112,   252,   252,   189,    16,   107,
+    1118,   252,   781,    13,   343,  1595,   343,   195,   913,  1653,
+     915,   782,   204,   205,   206,   252,   332,   781,    13,  1177,
+     343,   343,   201,   491,  1153,  1161,   782,   343,  1404,  1405,
+     259,  1498,   343,   516,  1180,   197,  1554,   209,   252,   264,
+    1046,   301,    16,   333,   334,   303,   532,   172,   173,   821,
+     822,   653,   654,   655,   656,   657,   311,    16,   658,   659,
+     660,   661,   315,   662,   663,   664,   665,   666,   316,   667,
+     668,   767,   768,   332,   310,   670,   646,   672,   646,   646,
+     943,   944,   945,  1233,  1234,  1473,    97,    98,    99,  1385,
+    1385,   318,  1226,  1575,   251,   321,   251,   251,   648,   649,
+     333,   334,   317,   251,   319,   320,  1670,   335,   323,   324,
+     251,   336,   675,   676,   677,   678,   679,   680,   681,   682,
+     683,   684,  1124,   325,  1124,   326,   327,  1414,   343,   341,
+     328,   344,   685,   686,  1603,  1689,  1046,   346,   347,   399,
+     781,    13,   400,   414,  1147,   506,  1150,   401,   507,   782,
+     251,   251,   781,    13,   533,   252,   251,  1325,   337,   536,
+     543,   782,   338,   545,   335,   339,   546,   572,   336,  1326,
+     251,  1312,   332,   573,   544,   557,   547,  1593,   404,   561,
+      16,   562,   405,   570,   580,   603,   581,   595,   651,   652,
+     340,  1523,    16,   251,   604,   605,   406,   407,   606,   333,
+     334,   408,   409,   410,   411,    13,   607,  1304,   608,   611,
+     619,   616,   620,  1537,   574,   337,   621,   622,   623,   338,
+     642,  1630,   339,   624,   639,   641,   711,   687,  1222,   650,
+     691,  1339,   703,   690,   706,   712,  1230,  1231,   718,   713,
+     715,   332,   716,   756,    16,   752,   770,   340,   759,  1239,
+     771,  1240,  1241,  1242,  1243,  1244,   764,  1648,   780,  1247,
+     789,   793,   794,   335,  1371,   795,   812,   336,   333,   334,
+     824,   825,   827,   826,   833,   848,   835,   867,   909,   850,
+     777,   920,   929,   653,   654,   655,   656,   657,   930,   252,
+     658,   252,   948,   661,   953,   662,   663,   664,   665,   666,
+     954,   667,   668,   651,   652,   970,   980,   799,   801,   982,
+     251,   804,   985,   806,   337,  1073,  1521,   987,   338,   996,
+     995,   339,   997,  1626,   815,   816,   817,   818,   819,   820,
+    1075,   998,   335,   999,  1007,   572,   336,  1000,  1316,  1001,
+    1014,   573,  1079,  1416,   332,  1011,   340,   678,   679,   680,
+     681,   682,   683,   684,  1015,  1093,  1027,  1029,  1074,  1076,
+    1077,  1078,  1088,  1089,   685,   686,  1094,  1095,  1104,   871,
+    1106,   333,   334,  1108,  1116,   518,  1120,  1129,  1130,  1131,
+    1137,  1145,   574,   337,  1146,  1156,  1157,   338,  1183,  1160,
+     339,   904,  1166,   332,  1167,  1186,  1170,   252,   653,   654,
+     655,   656,  1175,  1187,  1178,  1182,  1201,  1220,   661,  1185,
+     662,   663,   664,   665,   666,   340,   667,   668,   928,  1192,
+     333,   334,  1193,  1200,  1221,  1203,   332,  1232,  1223,  1236,
+    1237,  1238,  1245,  1274,  1275,   335,  1277,  1278,  1284,   336,
+    1288,  1283,   252,  1290,   251,  1311,   251,  1302,  1299,  1485,
+    1303,  1300,  1629,   333,   334,  1306,  1310,   937,   252,  1314,
+    1320,  1322,  1321,  1496,   680,   681,   682,   683,   684,  1345,
+    1343,  1490,  1364,  1365,  1357,   952,  1358,  1367,  1366,   685,
+     686,   957,  1362,  1368,   335,  1373,   337,  1375,   336,  1376,
+     338,  1378,  1151,   339,  1499,  1377,   971,  1382,  1428,  1431,
+    1383,  1388,  1442,  1415,  1443,  1417,  1419,  1433,  1423,  1429,
+    1508,  1436,  1440,   651,   652,  1447,  1458,   335,   340,  1430,
+    1469,   336,  1435,  1444,  1471,  1445,  1451,  1002,  1452,  1453,
+    1457,  1460,  1008,  1462,  1009,   337,  1010,  1478,  1481,   338,
+    1468,  1152,   339,  1476,  1491,  1492,   799,  1500,  1501,  1503,
+    1505,  1516,   251,  1517,  1530,  1518,  1556,   332,   726,   727,
+     728,   729,   730,   731,   732,   733,  1527,   340,   337,  1519,
+    1046,  1520,   338,  1525,  1165,   339,  1528,  1538,  1529,  1539,
+    1541,  1558,  1542,   734,   333,   334,  1540,  1546,  1580,  1555,
+    1586,  1573,  1588,   735,   736,   737,  1591,   251,  1574,  1590,
+     340,  1204,  1087,  1602,  1604,  1605,  1092,  1606,   653,   654,
+     655,   656,   657,   251,   252,   658,   659,   660,   661,  1609,
+     662,   663,   664,   665,   666,  1610,   667,   668,  1611,  1614,
+    1613,  1640,  1119,  1635,  1639,  1617,  1636,  1637,   823,  1638,
+    1627,  1655,   129,  1672,  1643,    20,  1650,  1669,   335,   185,
+    1680,   132,   336,  1681,   839,  1684,  1695,  1694,  1693,   935,
+     936,  1149,   314,  1143,  1387,   332,   847,   923,    26,   675,
+     676,   677,   678,   679,   680,   681,   682,   683,   684,  1560,
+    1482,   852,   332,  1597,  1549,  1169,  1561,  1510,  1598,   685,
+     686,  1599,   333,   334,    96,   332,  1664,  1557,  1308,   337,
+    1138,  1139,  1667,   338,   413,  1171,   339,   322,  1671,   333,
+     334,   800,     0,   839,     0,   585,   587,     0,   588,  1196,
+    1197,   589,   333,   334,   617,   618,     0,     0,     0,     0,
+     928,   340,     0,     0,  1688,     0,     0,  1216,   591,     0,
+    1219,   626,   627,   628,   629,   630,  1225,   592,  1228,     0,
+       0,     0,     0,     0,     0,     0,   335,     0,     0,     0,
+     336,     0,     0,     0,     0,     0,     0,     0,     0,   251,
+       0,     0,     0,   335,     0,     0,  1624,   336,     0,  1268,
+       0,  1270,     0,  1273,  1046,     0,   335,     0,     0,     0,
+     336,     0,     0,  1279,     0,     0,     0,     0,     0,     0,
+       0,   928,     0,     0,     0,     0,     0,   337,   651,   652,
+       0,   338,     0,  1172,   339,     0,     0,     0,     0,     0,
+       0,  1651,     0,     0,   337,  1295,     0,     0,   338,     0,
+    1173,   339,     0,   763,     0,  1301,     0,   337,  1666,   340,
+    1305,   338,  1307,  1174,   339,     0,     0,     0,     0,     0,
+       0,     0,  1673,  1315,  1675,     0,   340,     0,     0,  1046,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   340,
+       0,     0,   799,     0,     0,     0,  1690,     0,  1046,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,  1419,     0,  1420,     0,     0,
-       0,     0,     0,  1424,     0,     0,     0,     0,     0,     0,
-    1248,  1249,  1250,  1251,  1252,  1253,  1254,  1255,   653,   654,
-     655,   656,   657,  1256,  1257,   658,   659,   660,   661,  1258,
-     662,   663,   664,   665,   666,  1259,   667,   668,  1260,  1261,
-     669,  1444,   670,   671,   672,  1262,  1263,  1264,   673,     0,
-       0,     0,     0,   946,     0,     0,     0,     0,  1462,     0,
+    1344,     0,     0,     0,     0,     0,     0,   -85,  1354,  1355,
+    1356,     0,     0,   653,   654,   655,   656,   657,   651,   652,
+     658,   659,   660,   661,     0,   662,   663,   664,   665,   666,
+    1372,   667,   668,  1374,     0,     0,     0,   670,     0,   861,
+     862,     0,  1380,   863,   864,   865,   866,     0,   868,     0,
+       0,   872,   873,   875,   876,   877,   880,   881,   882,   883,
+     885,   886,   887,   888,   889,   890,   891,   892,   893,   894,
+     895,     0,     0,     0,   675,   676,   677,   678,   679,   680,
+     681,   682,   683,   684,     0,     0,     0,     0,     0,     0,
+    1421,     0,  1422,     0,   685,   686,     0,     0,  1426,     0,
+       0,     0,     0,     0,     0,  1248,  1249,  1250,  1251,  1252,
+    1253,  1254,  1255,   653,   654,   655,   656,   657,  1256,  1257,
+     658,   659,   660,   661,  1258,   662,   663,   664,   665,   666,
+    1259,   667,   668,  1260,  1261,   669,  1446,   670,   671,   672,
+    1262,  1263,  1264,   673,     0,     0,     0,     0,   946,     0,
+       0,     0,     0,  1464,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,  1474,  1475,     0,
+       0,  1265,   674,     0,   675,   676,   677,   678,   679,   680,
+     681,   682,   683,   684,     0,     0,     0,     0,     0,     0,
+       0,  1486,     0,     0,   685,   686,     0,  1488,  1489,     0,
+       0,     0,     0,  1493,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   651,   652,     0,   210,     0,
+       0,     0,     0,     0,   211,     0,     0,     0,     0,     0,
+     212,     0,     0,     0,     0,     0,     0,  1071,     0,     0,
+     213,     0,     0,  1504,     0,     0,     0,  1506,   214,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,  1472,  1473,     0,     0,  1265,   674,     0,   675,
-     676,   677,   678,   679,   680,   681,   682,   683,   684,     0,
-       0,     0,     0,     0,     0,     0,  1484,     0,     0,   685,
-     686,     0,  1486,  1487,     0,  1489,  1490,     0,     0,     0,
-    1031,     0,     0,     0,   426,   427,     3,     0,  -118,  -104,
-    -104,     0,  -115,     0,   428,   429,   430,   431,   432,     0,
-       0,     0,     0,     0,   433,  1032,   434,  1033,  1034,     0,
-     435,     0,  1071,     0,     0,     0,  1501,  1035,   436,  1036,
-    1503,  -120,     0,  1037,   437,     0,     0,   438,     0,     8,
-     439,  1038,     0,  1039,   440,     0,     0,  1040,  1041,     0,
-       0,   799,     0,     0,  1042,     0,     0,   442,   443,     0,
-     216,   217,   218,     0,   220,   221,   222,   223,   224,   444,
+       0,     0,     0,   215,     0,     0,     0,     0,   799,     0,
+     216,   217,   218,   219,   220,   221,   222,   223,   224,   225,
      226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
-     236,     0,   238,   239,   240,     0,     0,   243,   244,   245,
-     246,   445,   446,   447,  1043,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   448,   449,     0,
-       0,     0,     0,     0,  1564,     0,     0,     0,  1071,     0,
-       0,     0,     0,     0,     0,     0,  1575,     0,    59,     0,
-    1577,  1578,     0,     0,     0,     0,   450,   451,   452,   453,
-     454,     0,   455,     0,   456,   457,   458,   459,   460,   461,
-     462,   463,    60,     0,    13,   464,   332,     0,     0,     0,
+     236,   237,   238,   239,   240,   241,   242,   243,   244,   245,
+     246,   247,   248,     0,     0,     0,     0,  1545,     0,     0,
+     653,   654,   655,   656,   657,     0,     0,   658,   659,   660,
+     661,     0,   662,   663,   664,   665,   666,     0,   667,   668,
+       0,     0,  1568,  1071,   670,   671,   672,     0,    59,     0,
+       0,     0,     0,     0,  1579,     0,     0,     0,  1581,  1582,
+       0,   249,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    60,     0,     0,     0,     0,     0,     0,   674,
+       0,   675,   676,   677,   678,   679,   680,   681,   682,   683,
+     684,     0,     0,     0,   332,     0,     0,     0,     0,   332,
+       0,   685,   686,     0,     0,  1616,     0,     0,     0,     0,
+       0,   250,     0,     0,     0,     0,   534,     0,     0,     0,
+       0,   333,   334,     0,     0,     0,   333,   334,     0,     0,
+       0,     0,     0,     0,     0,     0,   426,   427,     0,     0,
+       0,     0,  1642,     0,     0,     0,   428,   429,   430,   431,
+     432,     0,     0,     0,     0,  1649,   433,     0,   434,     0,
+       0,     0,   435,     0,  1654,     0,     0,     0,     0,     0,
+     436,     0,     0,  1665,     0,     0,   437,     0,     0,   438,
+    1276,     0,   439,     0,     0,   335,   440,     0,     0,   336,
+     335,     0,     0,     0,   336,     0,   441,  1679,     0,   442,
+     443,   842,   216,   217,   218,     0,   220,   221,   222,   223,
+     224,   444,   226,   227,   228,   229,   230,   231,   232,   233,
+     234,   235,   236,     0,   238,   239,   240,     0,     0,   243,
+     244,   245,   246,   445,   446,   447,   337,     0,     0,     0,
+     338,   337,  1176,   339,     0,   338,     0,  1324,   339,   448,
+     449,     0,     0,     0,     0,     0,     0,     0,   521,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   340,     0,
+      59,     0,     0,   340,     0,     0,     0,     0,   450,   451,
+     452,   453,   454,     0,   455,   634,   456,   457,   458,   459,
+     460,   461,   462,   463,   635,     0,     0,   464,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   465,   466,   467,     0,    14,  1612,     0,   468,   469,
-       0,     0,     0,   333,   334,     0,     0,   470,     0,   471,
-       0,   472,   473,    16,  1044,  1045,     0,     0,   426,   427,
-       0,     0,     0,     0,     0,     0,     0,     0,   428,   429,
-     430,   431,   432,  1638,     0,     0,     0,     0,   433,     0,
-     434,     0,     0,     0,   435,     0,  1644,     0,     0,     0,
-       0,     0,   436,     0,     0,  1649,     0,     0,   437,     0,
-       0,   438,     0,  1660,   439,     0,     0,   335,   440,     0,
-       0,   336,     0,     0,     0,  1276,     0,     0,   441,     0,
-       0,   442,   443,   842,   216,   217,   218,  1673,   220,   221,
+       0,     0,     0,   465,   466,   467,     0,    14,     0,     0,
+     468,   469,     0,     0,     0,     0,     0,     0,     0,   843,
+       0,   471,   844,   472,   473,     0,   474,     0,     0,     0,
+       0,     0,     0,     0,  1393,  1394,  1395,  1396,  1397,  1398,
+    1399,  1400,  1401,  1402,  1403,  1406,  1407,  1408,  1409,  1410,
+    1411,  1412,     0,     0,     0,  1031,     0,     0,     0,   426,
+     427,     3,     0,  -118,  -104,  -104,     0,  -115,     0,   428,
+     429,   430,   431,   432,     0,     0,     0,     0,     0,   433,
+    1032,   434,  1033,  1034,     0,   435,     0,     0,     0,     0,
+       0,     0,  1035,   436,  1036,     0,  -120,     0,  1037,   437,
+       0,     0,   438,     0,     8,   439,  1038,     0,  1039,   440,
+       0,     0,  1040,  1041,     0,     0,  1454,  1455,  1456,  1042,
+       0,     0,   442,   443,     0,   216,   217,   218,     0,   220,
+     221,   222,   223,   224,   444,   226,   227,   228,   229,   230,
+     231,   232,   233,   234,   235,   236,     0,   238,   239,   240,
+       0,     0,   243,   244,   245,   246,   445,   446,   447,  1043,
+       0,     0,     0,     0,     0,     0,     0,  1071,     0,     0,
+       0,     0,   448,   449,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,    59,     0,     0,     0,     0,     0,     0,
+       0,   450,   451,   452,   453,   454,     0,   455,     0,   456,
+     457,   458,   459,   460,   461,   462,   463,    60,     0,    13,
+     464,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   465,   466,   467,     0,
+      14,     0,     0,   468,   469,     0,     0,     0,     0,     0,
+       0,     0,   470,     0,   471,     0,   472,   473,    16,  1044,
+    1045,  1031,     0,     0,     0,   426,   427,     3,     0,  -118,
+    -104,  -104,     0,  -115,     0,   428,   429,   430,   431,   432,
+       0,     0,     0,     0,     0,   433,  1032,   434,  1033,  1034,
+       0,   435,     0,     0,     0,     0,     0,     0,  1035,   436,
+    1036,     0,  -120,     0,  1037,   437,     0,     0,   438,     0,
+       8,   439,  1038,     0,  1039,   440,     0,     0,  1040,  1041,
+       0,     0,     0,     0,     0,  1042,     0,     0,   442,   443,
+       0,   216,   217,   218,     0,   220,   221,   222,   223,   224,
+     444,   226,   227,   228,   229,   230,   231,   232,   233,   234,
+     235,   236,     0,   238,   239,   240,     0,     0,   243,   244,
+     245,   246,   445,   446,   447,  1043,     0,     0,     0,     0,
+       0,     0,  1623,     0,     0,     0,     0,     0,   448,   449,
+       0,  1071,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    59,
+       0,     0,     0,     0,     0,     0,     0,   450,   451,   452,
+     453,   454,     0,   455,     0,   456,   457,   458,   459,   460,
+     461,   462,   463,    60,     0,    13,   464,     0,     0,     0,
+       0,  1623,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   465,   466,   467,     0,    14,     0,     0,   468,
+     469,     0,     0,     0,     0,     0,  1071,     0,   470,     0,
+     471,     0,   472,   473,    16,  1044,  -304,     0,  1031,  1623,
+       0,     0,   426,   427,     3,  1071,  -118,  -104,  -104,     0,
+    -115,     0,   428,   429,   430,   431,   432,     0,     0,     0,
+       0,     0,   433,  1032,   434,  1033,  1034,     0,   435,     0,
+       0,     0,     0,     0,     0,  1035,   436,  1036,     0,  -120,
+       0,  1037,   437,     0,     0,   438,     0,     8,   439,  1038,
+       0,  1039,   440,     0,     0,  1040,  1041,     0,     0,     0,
+       0,     0,  1042,     0,     0,   442,   443,     0,   216,   217,
+     218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
+     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
+     238,   239,   240,     0,     0,   243,   244,   245,   246,   445,
+     446,   447,  1043,   738,   739,   740,   741,   742,   743,   744,
+     745,     0,     0,     0,     0,   448,   449,     0,     0,     0,
+       0,     0,   746,     0,     0,     0,     0,     0,   747,     0,
+       0,     0,     0,     0,     0,     0,    59,     0,   748,   749,
+     750,     0,     0,     0,   450,   451,   452,   453,   454,     0,
+     455,     0,   456,   457,   458,   459,   460,   461,   462,   463,
+      60,     0,    13,   464,     0,     0,     0,     0,     0,   751,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   465,
+     466,   467,     0,    14,     0,     0,   468,   469,     0,     0,
+       0,     0,     0,     0,     0,   470,     0,   471,     0,   472,
+     473,    16,  1044,  -329,  1031,     0,     0,     0,   426,   427,
+       3,     0,  -118,  -104,  -104,     0,  -115,     0,   428,   429,
+     430,   431,   432,     0,     0,     0,     0,     0,   433,  1032,
+     434,  1033,  1034,     0,   435,     0,     0,     0,     0,     0,
+       0,  1035,   436,  1036,     0,  -120,     0,  1037,   437,     0,
+       0,   438,     0,     8,   439,  1038,     0,  1039,   440,     0,
+       0,  1040,  1041,     0,     0,     0,     0,     0,  1042,     0,
+       0,   442,   443,     0,   216,   217,   218,     0,   220,   221,
      222,   223,   224,   444,   226,   227,   228,   229,   230,   231,
      232,   233,   234,   235,   236,     0,   238,   239,   240,     0,
-       0,   243,   244,   245,   246,   445,   446,   447,   337,     0,
-       0,     0,   338,     0,  1174,   339,     0,     0,     0,     0,
+       0,   243,   244,   245,   246,   445,   446,   447,  1043,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,   448,   449,     0,     0,     0,     0,     0,     0,     0,
-     521,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     340,     0,    59,     0,     0,     0,     0,     0,     0,     0,
-     450,   451,   452,   453,   454,     0,   455,   634,   456,   457,
-     458,   459,   460,   461,   462,   463,   635,     0,     0,   464,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    59,     0,     0,     0,     0,     0,     0,     0,
+     450,   451,   452,   453,   454,     0,   455,     0,   456,   457,
+     458,   459,   460,   461,   462,   463,    60,     0,    13,   464,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,   465,   466,   467,     0,    14,
        0,     0,   468,   469,     0,     0,     0,     0,     0,     0,
-       0,   843,     0,   471,   844,   472,   473,     0,   474,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,  1391,
-    1392,  1393,  1394,  1395,  1396,  1397,  1398,  1399,  1400,  1401,
-    1404,  1405,  1406,  1407,  1408,  1409,  1410,     0,     0,     0,
+       0,   470,     0,   471,     0,   472,   473,    16,  1044,  -301,
     1031,     0,     0,     0,   426,   427,     3,     0,  -118,  -104,
     -104,     0,  -115,     0,   428,   429,   430,   431,   432,     0,
        0,     0,     0,     0,   433,  1032,   434,  1033,  1034,     0,
      435,     0,     0,     0,     0,     0,     0,  1035,   436,  1036,
        0,  -120,     0,  1037,   437,     0,     0,   438,     0,     8,
      439,  1038,     0,  1039,   440,     0,     0,  1040,  1041,     0,
-       0,  1452,  1453,  1454,  1042,     0,     0,   442,   443,     0,
+       0,     0,     0,     0,  1042,     0,     0,   442,   443,     0,
      216,   217,   218,     0,   220,   221,   222,   223,   224,   444,
      226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
-     236,     0,   238,   239,   240,   332,     0,   243,   244,   245,
-     246,   445,   446,   447,  1043,   332,     0,     0,     0,     0,
-       0,     0,  1071,     0,     0,     0,   332,   448,   449,     0,
-       0,     0,   333,   334,     0,     0,     0,     0,     0,     0,
-       0,     0,   333,   334,     0,     0,     0,     0,    59,     0,
-       0,     0,     0,   333,   334,     0,   450,   451,   452,   453,
+     236,     0,   238,   239,   240,     0,     0,   243,   244,   245,
+     246,   445,   446,   447,  1043,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   448,   449,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    59,     0,
+       0,     0,     0,     0,     0,     0,   450,   451,   452,   453,
      454,     0,   455,     0,   456,   457,   458,   459,   460,   461,
      462,   463,    60,     0,    13,   464,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   465,   466,   467,     0,    14,   335,     0,   468,   469,
-     336,     0,     0,     0,     0,     0,   335,   470,     0,   471,
-     336,   472,   473,    16,  1044,  -301,     0,   335,     0,     0,
-       0,   336,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   465,   466,   467,     0,    14,     0,     0,   468,   469,
+       0,     0,     0,     0,     0,     0,     0,   470,     0,   471,
+       0,   472,   473,    16,  1044,   -95,  1031,     0,     0,     0,
+     426,   427,     3,     0,  -118,  -104,  -104,     0,  -115,     0,
+     428,   429,   430,   431,   432,     0,     0,     0,     0,     0,
+     433,  1032,   434,  1033,  1034,     0,   435,     0,     0,     0,
+       0,     0,     0,  1035,   436,  1036,     0,  -120,     0,  1037,
+     437,     0,     0,   438,     0,     8,   439,  1038,     0,  1039,
+     440,     0,     0,  1040,  1041,     0,     0,     0,     0,     0,
+    1042,     0,     0,   442,   443,     0,   216,   217,   218,     0,
+     220,   221,   222,   223,   224,   444,   226,   227,   228,   229,
+     230,   231,   232,   233,   234,   235,   236,     0,   238,   239,
+     240,     0,     0,   243,   244,   245,   246,   445,   446,   447,
+    1043,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   448,   449,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   337,     0,     0,
-       0,   338,     0,  1176,   339,     0,     0,   337,     0,     0,
-       0,   338,     0,  1324,   339,     0,     0,     0,   337,     0,
-       0,     0,   338,     0,  1329,   339,     0,     0,     0,   340,
-       0,     0,     0,     0,     0,     0,     0,  1031,     0,   340,
-       0,   426,   427,     3,     0,  -118,  -104,  -104,     0,  -115,
-     340,   428,   429,   430,   431,   432,     0,     0,     0,     0,
-       0,   433,  1032,   434,  1033,  1034,     0,   435,     0,     0,
-       0,     0,     0,  1619,  1035,   436,  1036,     0,  -120,     0,
-    1037,   437,  1071,     0,   438,     0,     8,   439,  1038,     0,
-    1039,   440,     0,     0,  1040,  1041,     0,     0,     0,     0,
-       0,  1042,     0,     0,   442,   443,     0,   216,   217,   218,
-       0,   220,   221,   222,   223,   224,   444,   226,   227,   228,
-     229,   230,   231,   232,   233,   234,   235,   236,     0,   238,
-     239,   240,  1619,     0,   243,   244,   245,   246,   445,   446,
-     447,  1043,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   448,   449,  1071,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,  1619,     0,
-       0,     0,     0,     0,  1071,    59,     0,     0,     0,     0,
-       0,     0,     0,   450,   451,   452,   453,   454,     0,   455,
-       0,   456,   457,   458,   459,   460,   461,   462,   463,    60,
-       0,    13,   464,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   465,   466,
-     467,     0,    14,     0,     0,   468,   469,     0,     0,     0,
-       0,     0,     0,     0,   470,     0,   471,     0,   472,   473,
-      16,  1044,  -326,  1031,     0,     0,     0,   426,   427,     3,
-       0,  -118,  -104,  -104,     0,  -115,     0,   428,   429,   430,
-     431,   432,     0,     0,     0,     0,     0,   433,  1032,   434,
-    1033,  1034,     0,   435,     0,     0,     0,     0,     0,     0,
-    1035,   436,  1036,     0,  -120,     0,  1037,   437,     0,     0,
-     438,     0,     8,   439,  1038,     0,  1039,   440,     0,     0,
-    1040,  1041,     0,     0,     0,     0,     0,  1042,     0,     0,
-     442,   443,     0,   216,   217,   218,     0,   220,   221,   222,
-     223,   224,   444,   226,   227,   228,   229,   230,   231,   232,
-     233,   234,   235,   236,     0,   238,   239,   240,     0,     0,
-     243,   244,   245,   246,   445,   446,   447,  1043,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     448,   449,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,    59,     0,     0,     0,     0,     0,     0,     0,   450,
-     451,   452,   453,   454,     0,   455,     0,   456,   457,   458,
-     459,   460,   461,   462,   463,    60,     0,    13,   464,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   465,   466,   467,     0,    14,     0,
-       0,   468,   469,     0,     0,     0,     0,     0,     0,     0,
-     470,     0,   471,     0,   472,   473,    16,  1044,  -298,  1031,
-       0,     0,     0,   426,   427,     3,     0,  -118,  -104,  -104,
-       0,  -115,     0,   428,   429,   430,   431,   432,     0,     0,
-       0,     0,     0,   433,  1032,   434,  1033,  1034,     0,   435,
-       0,     0,     0,     0,     0,     0,  1035,   436,  1036,     0,
-    -120,     0,  1037,   437,     0,     0,   438,     0,     8,   439,
-    1038,     0,  1039,   440,     0,     0,  1040,  1041,     0,     0,
-       0,     0,     0,  1042,     0,     0,   442,   443,     0,   216,
-     217,   218,     0,   220,   221,   222,   223,   224,   444,   226,
-     227,   228,   229,   230,   231,   232,   233,   234,   235,   236,
-       0,   238,   239,   240,     0,     0,   243,   244,   245,   246,
-     445,   446,   447,  1043,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   448,   449,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,    59,     0,     0,
-       0,     0,     0,     0,     0,   450,   451,   452,   453,   454,
-       0,   455,     0,   456,   457,   458,   459,   460,   461,   462,
-     463,    60,     0,    13,   464,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     465,   466,   467,     0,    14,     0,     0,   468,   469,     0,
-       0,     0,     0,     0,     0,     0,   470,     0,   471,     0,
-     472,   473,    16,  1044,   -95,  1031,     0,     0,     0,   426,
-     427,     3,     0,  -118,  -104,  -104,     0,  -115,     0,   428,
-     429,   430,   431,   432,     0,     0,     0,     0,     0,   433,
-    1032,   434,  1033,  1034,     0,   435,     0,     0,     0,     0,
-       0,     0,  1035,   436,  1036,     0,  -120,     0,  1037,   437,
-       0,     0,   438,     0,     8,   439,  1038,     0,  1039,   440,
-       0,     0,  1040,  1041,     0,     0,     0,     0,     0,  1042,
-       0,     0,   442,   443,     0,   216,   217,   218,     0,   220,
-     221,   222,   223,   224,   444,   226,   227,   228,   229,   230,
-     231,   232,   233,   234,   235,   236,     0,   238,   239,   240,
-       0,     0,   243,   244,   245,   246,   445,   446,   447,  1043,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   448,   449,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,    59,     0,     0,     0,     0,     0,     0,
-       0,   450,   451,   452,   453,   454,     0,   455,     0,   456,
-     457,   458,   459,   460,   461,   462,   463,    60,     0,    13,
-     464,     0,   332,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   465,   466,   467,     0,
-      14,     0,     0,   468,   469,     0,     0,     0,     0,   333,
-     334,     0,   470,     0,   471,     0,   472,   473,    16,  1044,
-    -100,   426,   427,     0,     0,     0,     0,     0,     0,   631,
-       0,   428,   429,   430,   431,   432,     0,     0,     0,     0,
-       0,   433,     0,   434,     0,     0,     0,   435,     0,     0,
-       0,     0,     0,     0,     0,   436,     0,     0,     0,     0,
-       0,   437,     0,     0,   438,   632,     0,   439,     0,     0,
-       0,   440,     0,   335,     0,     0,     0,   336,     0,     0,
-       0,   441,     0,     0,   442,   443,     0,   216,   217,   218,
-       0,   220,   221,   222,   223,   224,   444,   226,   227,   228,
-     229,   230,   231,   232,   233,   234,   235,   236,     0,   238,
-     239,   240,     0,     0,   243,   244,   245,   246,   445,   446,
-     447,     0,     0,     0,   337,     0,     0,     0,   338,     0,
-    1336,   339,     0,     0,   448,   449,     0,     0,     0,     0,
-       0,     0,     0,   521,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    59,   340,     0,     0,     0,
-       0,     0,     0,   450,   451,   452,   453,   454,     0,   455,
-     634,   456,   457,   458,   459,   460,   461,   462,   463,   635,
-       0,     0,   464,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   465,   466,
-     467,     0,    14,     0,     0,   468,   469,     0,     0,     0,
-       0,     0,   426,   427,   470,     0,   471,     0,   472,   473,
-     631,   474,   428,   429,   430,   431,   432,     0,     0,     0,
-       0,     0,   433,     0,   434,     0,     0,   332,   435,     0,
+       0,     0,     0,     0,    59,     0,     0,     0,     0,     0,
+       0,     0,   450,   451,   452,   453,   454,     0,   455,     0,
+     456,   457,   458,   459,   460,   461,   462,   463,    60,     0,
+      13,   464,     0,   332,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   465,   466,   467,
+       0,    14,     0,     0,   468,   469,     0,     0,     0,     0,
+     333,   334,     0,   470,     0,   471,     0,   472,   473,    16,
+    1044,  -100,   426,   427,     0,     0,     0,     0,     0,     0,
+     631,     0,   428,   429,   430,   431,   432,     0,     0,     0,
+       0,     0,   433,     0,   434,     0,     0,     0,   435,     0,
        0,     0,     0,     0,     0,     0,   436,     0,     0,     0,
        0,     0,   437,     0,     0,   438,   632,     0,   439,     0,
-       0,     0,   440,     0,   333,   334,     0,     0,     0,     0,
+       0,     0,   440,     0,   335,     0,     0,     0,   336,     0,
        0,     0,   441,     0,     0,   442,   443,     0,   216,   217,
      218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
      228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
      238,   239,   240,     0,     0,   243,   244,   245,   246,   445,
-     446,   447,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   448,   449,     0,   335,     0,
-       0,     0,   336,     0,   521,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,    59,     0,     0,     0,
+     446,   447,     0,     0,     0,   337,     0,     0,     0,   338,
+       0,  1329,   339,     0,     0,   448,   449,     0,     0,     0,
+       0,     0,     0,     0,   521,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    59,   340,     0,     0,
        0,     0,     0,     0,   450,   451,   452,   453,   454,     0,
-     455,     0,   456,   457,   458,   459,   460,   461,   462,   463,
-      60,     0,     0,   464,     0,     0,     0,     0,     0,   337,
-       0,     0,     0,   338,     0,  1359,   339,     0,     0,   465,
+     455,   634,   456,   457,   458,   459,   460,   461,   462,   463,
+     635,     0,     0,   464,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   465,
      466,   467,     0,    14,     0,     0,   468,   469,     0,     0,
        0,     0,     0,   426,   427,   470,     0,   471,     0,   472,
-     473,   340,   474,   428,   429,   430,   431,   432,     0,     0,
+     473,   631,   474,   428,   429,   430,   431,   432,     0,     0,
        0,     0,     0,   433,     0,   434,     0,     0,   332,   435,
        0,     0,     0,     0,     0,     0,     0,   436,     0,     0,
-       0,     0,     0,   437,     0,     0,   438,     0,     0,   439,
+       0,     0,     0,   437,     0,     0,   438,   632,     0,   439,
        0,     0,     0,   440,     0,   333,   334,     0,     0,     0,
-       0,     0,     0,   441,     0,     0,   442,   443,   966,   216,
+       0,     0,     0,   441,     0,     0,   442,   443,     0,   216,
      217,   218,     0,   220,   221,   222,   223,   224,   444,   226,
      227,   228,   229,   230,   231,   232,   233,   234,   235,   236,
        0,   238,   239,   240,     0,     0,   243,   244,   245,   246,
@@ -2167,9 +2164,9 @@ static const yytype_int16 yytable[] =
        0,     0,     0,   336,     0,   521,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,    59,     0,     0,
        0,     0,     0,     0,     0,   450,   451,   452,   453,   454,
-       0,   455,   634,   456,   457,   458,   459,   460,   461,   462,
-     463,   635,     0,     0,   464,     0,     0,     0,     0,     0,
-     337,     0,     0,     0,   338,     0,  1494,   339,     0,     0,
+       0,   455,     0,   456,   457,   458,   459,   460,   461,   462,
+     463,    60,     0,     0,   464,     0,     0,     0,     0,     0,
+     337,     0,     0,     0,   338,     0,  1336,   339,     0,     0,
      465,   466,   467,     0,    14,     0,     0,   468,   469,     0,
        0,     0,     0,     0,   426,   427,   470,     0,   471,     0,
      472,   473,   340,   474,   428,   429,   430,   431,   432,     0,
@@ -2177,7 +2174,7 @@ static const yytype_int16 yytable[] =
      435,     0,     0,     0,     0,     0,     0,     0,   436,     0,
        0,     0,     0,     0,   437,     0,     0,   438,     0,     0,
      439,     0,     0,     0,   440,     0,   333,   334,     0,     0,
-       0,     0,     0,     0,   441,     0,     0,   442,   443,     0,
+       0,     0,     0,     0,   441,     0,     0,   442,   443,   966,
      216,   217,   218,     0,   220,   221,   222,   223,   224,   444,
      226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
      236,     0,   238,   239,   240,     0,     0,   243,   244,   245,
@@ -2188,29 +2185,29 @@ static const yytype_int16 yytable[] =
        0,     0,     0,     0,     0,     0,   450,   451,   452,   453,
      454,     0,   455,   634,   456,   457,   458,   459,   460,   461,
      462,   463,   635,     0,     0,   464,     0,     0,     0,     0,
-       0,   337,     0,     0,     0,   338,     0,     0,   339,     0,
+       0,   337,     0,     0,     0,   338,     0,  1359,   339,     0,
        0,   465,   466,   467,     0,    14,     0,     0,   468,   469,
        0,     0,     0,     0,     0,   426,   427,   470,     0,   471,
        0,   472,   473,   340,   474,   428,   429,   430,   431,   432,
        0,     0,     0,     0,     0,   433,     0,   434,     0,     0,
-       0,   435,     0,     0,     0,     0,     0,     0,     0,   436,
+     332,   435,     0,     0,     0,     0,     0,     0,     0,   436,
        0,     0,     0,     0,     0,   437,     0,     0,   438,     0,
-       0,   439,     0,     0,     0,   440,     0,     0,     0,     0,
+       0,   439,     0,     0,     0,   440,     0,   333,   334,     0,
        0,     0,     0,     0,     0,   441,     0,     0,   442,   443,
        0,   216,   217,   218,     0,   220,   221,   222,   223,   224,
      444,   226,   227,   228,   229,   230,   231,   232,   233,   234,
      235,   236,     0,   238,   239,   240,     0,     0,   243,   244,
      245,   246,   445,   446,   447,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,   448,   449,
-       0,     0,     0,     0,     0,     0,     0,   521,     0,     0,
+       0,   335,     0,     0,     0,   336,     0,   521,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,    59,
        0,     0,     0,     0,     0,     0,     0,   450,   451,   452,
-     453,   454,     0,   455,     0,   456,   457,   458,   459,   460,
-     461,   462,   463,    60,     0,     0,   464,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     453,   454,     0,   455,   634,   456,   457,   458,   459,   460,
+     461,   462,   463,   635,     0,     0,   464,     0,     0,     0,
+       0,     0,   337,     0,     0,     0,   338,     0,  1497,   339,
        0,     0,   465,   466,   467,     0,    14,     0,     0,   468,
      469,     0,     0,     0,     0,     0,   426,   427,   470,     0,
-     471,   905,   472,   473,     0,   474,   428,   429,   430,   431,
+     471,     0,   472,   473,   340,   474,   428,   429,   430,   431,
      432,     0,     0,     0,     0,     0,   433,     0,   434,     0,
        0,     0,   435,     0,     0,     0,     0,     0,     0,     0,
      436,     0,     0,     0,     0,     0,   437,     0,     0,   438,
@@ -2229,7 +2226,7 @@ static const yytype_int16 yytable[] =
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,   465,   466,   467,     0,    14,     0,     0,
      468,   469,     0,     0,     0,     0,     0,   426,   427,   470,
-       0,   471,  1271,   472,   473,     0,   474,   428,   429,   430,
+       0,   471,   905,   472,   473,     0,   474,   428,   429,   430,
      431,   432,     0,     0,     0,     0,     0,   433,     0,   434,
        0,     0,     0,   435,     0,     0,     0,     0,     0,     0,
        0,   436,     0,     0,     0,     0,     0,   437,     0,     0,
@@ -2248,7 +2245,7 @@ static const yytype_int16 yytable[] =
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,   465,   466,   467,     0,    14,     0,
        0,   468,   469,     0,     0,     0,     0,     0,   426,   427,
-    1280,     0,   471,  1281,   472,   473,     0,   474,   428,   429,
+     470,     0,   471,  1271,   472,   473,     0,   474,   428,   429,
      430,   431,   432,     0,     0,     0,     0,     0,   433,     0,
      434,     0,     0,     0,   435,     0,     0,     0,     0,     0,
        0,     0,   436,     0,     0,     0,     0,     0,   437,     0,
@@ -2267,7 +2264,7 @@ static const yytype_int16 yytable[] =
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,   465,   466,   467,     0,    14,
        0,     0,   468,   469,     0,     0,     0,     0,     0,   426,
-     427,   470,     0,   471,  1286,   472,   473,     0,   474,   428,
+     427,  1280,     0,   471,  1281,   472,   473,     0,   474,   428,
      429,   430,   431,   432,     0,     0,     0,     0,     0,   433,
        0,   434,     0,     0,     0,   435,     0,     0,     0,     0,
        0,     0,     0,   436,     0,     0,     0,     0,     0,   437,
@@ -2286,7 +2283,7 @@ static const yytype_int16 yytable[] =
      464,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,   465,   466,   467,     0,
       14,     0,     0,   468,   469,     0,     0,     0,     0,     0,
-     426,   427,   470,     0,   471,  1340,   472,   473,     0,   474,
+     426,   427,   470,     0,   471,  1286,   472,   473,     0,   474,
      428,   429,   430,   431,   432,     0,     0,     0,     0,     0,
      433,     0,   434,     0,     0,     0,   435,     0,     0,     0,
        0,     0,     0,     0,   436,     0,     0,     0,     0,     0,
@@ -2299,6 +2296,197 @@ static const yytype_int16 yytable[] =
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,   448,   449,     0,     0,     0,     0,     0,
        0,     0,   521,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    59,     0,     0,     0,     0,     0,
+       0,     0,   450,   451,   452,   453,   454,     0,   455,     0,
+     456,   457,   458,   459,   460,   461,   462,   463,    60,     0,
+       0,   464,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   465,   466,   467,
+       0,    14,     0,     0,   468,   469,     0,     0,     0,     0,
+       0,   426,   427,   470,     0,   471,  1340,   472,   473,     0,
+     474,   428,   429,   430,   431,   432,     0,     0,     0,     0,
+       0,   433,     0,   434,     0,     0,     0,   435,     0,     0,
+       0,     0,     0,     0,     0,   436,     0,     0,     0,     0,
+       0,   437,     0,     0,   438,     0,     0,   439,     0,     0,
+       0,   440,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   441,     0,     0,   442,   443,     0,   216,   217,   218,
+       0,   220,   221,   222,   223,   224,   444,   226,   227,   228,
+     229,   230,   231,   232,   233,   234,   235,   236,     0,   238,
+     239,   240,     0,     0,   243,   244,   245,   246,   445,   446,
+     447,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   448,   449,     0,     0,     0,     0,
+       0,     0,     0,   521,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,    59,     0,     0,     0,     0,
+       0,     0,     0,   450,   451,   452,   453,   454,     0,   455,
+       0,   456,   457,   458,   459,   460,   461,   462,   463,    60,
+       0,     0,   464,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   465,   466,
+     467,     0,    14,     0,     0,   468,   469,     0,     0,     0,
+       0,     0,   426,   427,   470,     0,   471,     0,   472,   473,
+       0,   474,   428,   429,   430,   431,   432,     0,     0,     0,
+       0,     0,   433,     0,   434,     0,     0,     0,   435,     0,
+       0,     0,     0,     0,     0,     0,   436,     0,     0,     0,
+       0,     0,   437,     0,     0,   438,     0,     0,   439,     0,
+       0,     0,   440,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   441,     0,     0,   442,   443,     0,   216,   217,
+     218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
+     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
+     238,   239,   240,     0,     0,   243,   244,   245,   246,   445,
+     446,   447,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   448,   449,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    59,     0,     0,     0,
+       0,     0,     0,     0,   450,   451,   452,   453,   454,     0,
+     455,     0,   456,   457,   458,   459,   460,   461,   462,   463,
+      60,     0,     0,   464,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   465,
+     466,   467,     0,    14,     0,     0,   468,   469,     0,     0,
+       0,     0,     0,   426,   427,   470,   531,   471,     0,   472,
+     473,     0,   474,   428,   429,   430,   431,   432,     0,     0,
+       0,     0,     0,   433,     0,   434,     0,     0,     0,   435,
+       0,     0,     0,     0,     0,     0,     0,   436,     0,     0,
+       0,     0,     0,   437,     0,     0,   438,     0,     0,   439,
+       0,     0,     0,   440,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   441,     0,     0,   442,   443,     0,   216,
+     217,   218,     0,   220,   221,   222,   223,   224,   444,   226,
+     227,   228,   229,   230,   231,   232,   233,   234,   235,   236,
+       0,   238,   239,   240,     0,     0,   243,   244,   245,   246,
+     445,   446,   447,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   448,   449,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    59,     0,     0,
+       0,     0,     0,     0,     0,   450,   451,   452,   453,   454,
+       0,   455,     0,   456,   457,   458,   459,   460,   461,   462,
+     463,    60,     0,     0,   464,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     465,   466,   467,     0,    14,     0,     0,   468,   469,     0,
+       0,     0,     0,     0,   426,   427,   470,   717,   471,     0,
+     472,   473,     0,   474,   428,   429,   430,   431,   432,     0,
+       0,     0,     0,     0,   433,     0,   434,     0,     0,     0,
+     435,     0,     0,     0,     0,     0,     0,     0,   436,     0,
+       0,     0,     0,     0,   437,     0,     0,   438,     0,     0,
+     439,     0,     0,     0,   440,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   441,     0,     0,   442,   443,     0,
+     216,   217,   218,     0,   220,   221,   222,   223,   224,   444,
+     226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
+     236,     0,   238,   239,   240,     0,     0,   243,   244,   245,
+     246,   445,   446,   447,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   448,   449,     0,
+       0,     0,     0,     0,     0,     0,   927,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    59,     0,
+       0,     0,     0,     0,     0,     0,   450,   451,   452,   453,
+     454,     0,   455,     0,   456,   457,   458,   459,   460,   461,
+     462,   463,    60,     0,     0,   464,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   465,   466,   467,     0,    14,     0,     0,   468,   469,
+       0,     0,     0,     0,     0,   426,   427,   470,     0,   471,
+       0,   472,   473,  1018,   474,   428,   429,   430,   431,   432,
+       0,     0,     0,     0,     0,   433,     0,   434,     0,     0,
+       0,   435,     0,     0,     0,     0,     0,     0,     0,   436,
+       0,     0,     0,     0,     0,   437,     0,     0,   438,     0,
+       0,   439,     0,     0,     0,   440,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   441,     0,     0,   442,   443,
+       0,   216,   217,   218,     0,   220,   221,   222,   223,   224,
+     444,   226,   227,   228,   229,   230,   231,   232,   233,   234,
+     235,   236,     0,   238,   239,   240,     0,     0,   243,   244,
+     245,   246,   445,   446,   447,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   448,   449,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    59,
+       0,     0,     0,     0,     0,     0,     0,   450,   451,   452,
+     453,   454,     0,   455,     0,   456,   457,   458,   459,   460,
+     461,   462,   463,    60,     0,     0,   464,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   465,   466,   467,     0,    14,     0,     0,   468,
+     469,     0,     0,     0,     0,     0,   426,   427,   470,     0,
+     471,     0,   472,   473,     0,   474,   428,   429,   430,   431,
+     432,     0,     0,     0,     0,     0,   433,     0,   434,     0,
+       0,     0,   435,     0,     0,     0,     0,     0,     0,     0,
+     436,     0,     0,     0,     0,     0,   437,     0,     0,   438,
+       0,     0,   439,     0,     0,     0,   440,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   441,     0,     0,   442,
+     443,     0,   216,   217,   218,     0,   220,   221,   222,   223,
+     224,   444,   226,   227,   228,   229,   230,   231,   232,   233,
+     234,   235,   236,     0,   238,   239,   240,     0,     0,   243,
+     244,   245,   246,   445,   446,   447,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   448,
+     449,     0,     0,     0,     0,     0,     0,     0,   927,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+      59,     0,     0,     0,     0,     0,     0,     0,   450,   451,
+     452,   453,   454,     0,   455,     0,   456,   457,   458,   459,
+     460,   461,   462,   463,    60,     0,     0,   464,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   465,   466,   467,     0,    14,     0,     0,
+     468,   469,     0,     0,     0,     0,     0,   426,   427,  1206,
+       0,   471,     0,   472,   473,     0,   474,   428,   429,   430,
+     431,   432,     0,     0,     0,     0,     0,   433,     0,   434,
+       0,     0,     0,   435,     0,     0,     0,     0,     0,     0,
+       0,   436,     0,     0,     0,     0,     0,   437,     0,     0,
+     438,     0,     0,   439,     0,     0,     0,   440,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   441,     0,     0,
+     442,   443,     0,   216,   217,   218,     0,   220,   221,   222,
+     223,   224,   444,   226,   227,   228,   229,   230,   231,   232,
+     233,   234,   235,   236,     0,   238,   239,   240,     0,     0,
+     243,   244,   245,   246,   445,   446,   447,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     448,   449,     0,     0,     0,     0,     0,     0,     0,  1215,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,    59,     0,     0,     0,     0,     0,     0,     0,   450,
+     451,   452,   453,   454,     0,   455,     0,   456,   457,   458,
+     459,   460,   461,   462,   463,    60,     0,     0,   464,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   465,   466,   467,     0,    14,     0,
+       0,   468,   469,     0,     0,     0,     0,     0,   426,   427,
+     470,     0,   471,     0,   472,   473,     0,   474,   428,   429,
+     430,   431,   432,     0,     0,     0,     0,     0,   433,     0,
+     434,     0,     0,     0,   435,     0,     0,     0,     0,     0,
+       0,     0,   436,     0,     0,     0,     0,     0,   437,     0,
+       0,   438,     0,     0,   439,     0,     0,     0,   440,     0,
+       0,     0,     0,     0,  1218,     0,     0,     0,   441,     0,
+       0,   442,   443,     0,   216,   217,   218,     0,   220,   221,
+     222,   223,   224,   444,   226,   227,   228,   229,   230,   231,
+     232,   233,   234,   235,   236,     0,   238,   239,   240,     0,
+       0,   243,   244,   245,   246,   445,   446,   447,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   448,   449,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    59,     0,     0,     0,     0,     0,     0,     0,
+     450,   451,   452,   453,   454,     0,   455,     0,   456,   457,
+     458,   459,   460,   461,   462,   463,    60,     0,     0,   464,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   465,   466,   467,     0,    14,
+       0,     0,   468,   469,     0,     0,     0,     0,     0,   426,
+     427,   470,     0,   471,     0,   472,   473,     0,   474,   428,
+     429,   430,   431,   432,     0,     0,     0,     0,     0,   433,
+       0,   434,     0,     0,     0,   435,     0,     0,     0,     0,
+       0,     0,     0,   436,     0,     0,     0,     0,     0,   437,
+       0,     0,   438,     0,     0,   439,     0,     0,     0,   440,
+       0,     0,  1224,     0,     0,     0,     0,     0,     0,   441,
+       0,     0,   442,   443,     0,   216,   217,   218,     0,   220,
+     221,   222,   223,   224,   444,   226,   227,   228,   229,   230,
+     231,   232,   233,   234,   235,   236,     0,   238,   239,   240,
+       0,     0,   243,   244,   245,   246,   445,   446,   447,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   448,   449,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,    59,     0,     0,     0,     0,     0,     0,
+       0,   450,   451,   452,   453,   454,     0,   455,     0,   456,
+     457,   458,   459,   460,   461,   462,   463,    60,     0,     0,
+     464,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   465,   466,   467,     0,
+      14,     0,     0,   468,   469,     0,     0,     0,     0,     0,
+     426,   427,   470,     0,   471,     0,   472,   473,     0,   474,
+     428,   429,   430,   431,   432,     0,     0,     0,     0,     0,
+     433,     0,   434,     0,     0,     0,   435,     0,     0,     0,
+       0,     0,     0,     0,   436,     0,     0,     0,     0,     0,
+     437,     0,     0,   438,     0,     0,   439,     0,     0,     0,
+     440,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     441,     0,     0,   442,   443,     0,   216,   217,   218,     0,
+     220,   221,   222,   223,   224,   444,   226,   227,   228,   229,
+     230,   231,   232,   233,   234,   235,   236,     0,   238,   239,
+     240,     0,     0,   243,   244,   245,   246,   445,   446,   447,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   448,   449,     0,     0,     0,     0,     0,
+       0,     0,  1227,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,    59,     0,     0,     0,     0,     0,
        0,     0,   450,   451,   452,   453,   454,     0,   455,     0,
      456,   457,   458,   459,   460,   461,   462,   463,    60,     0,
@@ -2324,7 +2512,7 @@ static const yytype_int16 yytable[] =
        0,     0,   464,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,   465,   466,
      467,     0,    14,     0,     0,   468,   469,     0,     0,     0,
-       0,     0,   426,   427,   470,   531,   471,     0,   472,   473,
+       0,     0,   426,   427,   470,     0,   471,  1463,   472,   473,
        0,   474,   428,   429,   430,   431,   432,     0,     0,     0,
        0,     0,   433,     0,   434,     0,     0,     0,   435,     0,
        0,     0,     0,     0,     0,     0,   436,     0,     0,     0,
@@ -2343,141 +2531,64 @@ static const yytype_int16 yytable[] =
       60,     0,     0,   464,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,   465,
      466,   467,     0,    14,     0,     0,   468,   469,     0,     0,
-       0,     0,     0,   426,   427,   470,   717,   471,     0,   472,
+       0,     0,     0,   426,   427,   470,     0,   471,     0,   472,
      473,     0,   474,   428,   429,   430,   431,   432,     0,     0,
-       0,     0,     0,   433,     0,   434,     0,     0,     0,   435,
+       0,     0,     0,   433,  1032,   434,  1033,     0,     0,   435,
        0,     0,     0,     0,     0,     0,     0,   436,     0,     0,
        0,     0,     0,   437,     0,     0,   438,     0,     0,   439,
-       0,     0,     0,   440,     0,     0,     0,     0,     0,     0,
+    1038,     0,     0,   440,     0,     0,     0,     0,     0,     0,
        0,     0,     0,   441,     0,     0,   442,   443,     0,   216,
      217,   218,     0,   220,   221,   222,   223,   224,   444,   226,
      227,   228,   229,   230,   231,   232,   233,   234,   235,   236,
        0,   238,   239,   240,     0,     0,   243,   244,   245,   246,
-     445,   446,   447,     0,     0,     0,     0,     0,     0,     0,
+     445,   446,   447,  1043,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,   448,   449,     0,     0,
-       0,     0,     0,     0,     0,   927,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,    59,     0,     0,
        0,     0,     0,     0,     0,   450,   451,   452,   453,   454,
        0,   455,     0,   456,   457,   458,   459,   460,   461,   462,
      463,    60,     0,     0,   464,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
      465,   466,   467,     0,    14,     0,     0,   468,   469,     0,
-       0,     0,     0,     0,   426,   427,   470,     0,   471,     0,
-     472,   473,  1018,   474,   428,   429,   430,   431,   432,     0,
-       0,     0,     0,     0,   433,     0,   434,     0,     0,     0,
-     435,     0,     0,     0,     0,     0,     0,     0,   436,     0,
-       0,     0,     0,     0,   437,     0,     0,   438,     0,     0,
-     439,     0,     0,     0,   440,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   441,     0,     0,   442,   443,     0,
-     216,   217,   218,     0,   220,   221,   222,   223,   224,   444,
-     226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
-     236,     0,   238,   239,   240,     0,     0,   243,   244,   245,
-     246,   445,   446,   447,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   448,   449,     0,
+       0,     0,   426,   427,     0,     0,   470,     0,   471,     0,
+     472,   473,   428,   429,   430,   431,   432,     0,     0,     0,
+       0,     0,   433,     0,   434,     0,     0,     0,   435,     0,
+       0,     0,     0,     0,     0,     0,   436,     0,     0,     0,
+       0,     0,   437,     0,     0,   438,     0,     0,   439,     0,
+       0,     0,   440,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   441,     0,     0,   442,   443,     0,   216,   217,
+     218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
+     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
+     238,   239,   240,     0,     0,   243,   244,   245,   246,   445,
+     446,   447,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   448,   449,     0,     0,     0,
+       0,     0,     0,     0,   762,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    59,     0,     0,     0,
+       0,     0,     0,     0,   450,   451,   452,   453,   454,     0,
+     455,     0,   456,   457,   458,   459,   460,   461,   462,   463,
+      60,     0,     0,   464,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   465,
+     466,   467,     0,    14,     0,     0,   468,   469,     0,     0,
+       0,   426,   427,     0,     0,   470,     0,   471,     0,   472,
+     473,   428,   429,   430,   431,   432,     0,     0,   884,     0,
+       0,   433,     0,   434,     0,     0,     0,   435,     0,     0,
+       0,     0,     0,     0,     0,   436,     0,     0,     0,     0,
+       0,   437,     0,     0,   438,     0,     0,   439,     0,     0,
+       0,   440,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   441,     0,     0,   442,   443,     0,   216,   217,   218,
+       0,   220,   221,   222,   223,   224,   444,   226,   227,   228,
+     229,   230,   231,   232,   233,   234,   235,   236,     0,   238,
+     239,   240,     0,     0,   243,   244,   245,   246,   445,   446,
+     447,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   448,   449,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,    59,     0,
-       0,     0,     0,     0,     0,     0,   450,   451,   452,   453,
-     454,     0,   455,     0,   456,   457,   458,   459,   460,   461,
-     462,   463,    60,     0,     0,   464,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   465,   466,   467,     0,    14,     0,     0,   468,   469,
-       0,     0,     0,     0,     0,   426,   427,   470,     0,   471,
-       0,   472,   473,     0,   474,   428,   429,   430,   431,   432,
-       0,     0,     0,     0,     0,   433,     0,   434,     0,     0,
-       0,   435,     0,     0,     0,     0,     0,     0,     0,   436,
-       0,     0,     0,     0,     0,   437,     0,     0,   438,     0,
-       0,   439,     0,     0,     0,   440,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   441,     0,     0,   442,   443,
-       0,   216,   217,   218,     0,   220,   221,   222,   223,   224,
-     444,   226,   227,   228,   229,   230,   231,   232,   233,   234,
-     235,   236,     0,   238,   239,   240,     0,     0,   243,   244,
-     245,   246,   445,   446,   447,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   448,   449,
-       0,     0,     0,     0,     0,     0,     0,   927,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,    59,
-       0,     0,     0,     0,     0,     0,     0,   450,   451,   452,
-     453,   454,     0,   455,     0,   456,   457,   458,   459,   460,
-     461,   462,   463,    60,     0,     0,   464,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   465,   466,   467,     0,    14,     0,     0,   468,
-     469,     0,     0,     0,     0,     0,   426,   427,  1206,     0,
-     471,     0,   472,   473,     0,   474,   428,   429,   430,   431,
-     432,     0,     0,     0,     0,     0,   433,     0,   434,     0,
-       0,     0,   435,     0,     0,     0,     0,     0,     0,     0,
-     436,     0,     0,     0,     0,     0,   437,     0,     0,   438,
-       0,     0,   439,     0,     0,     0,   440,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   441,     0,     0,   442,
-     443,     0,   216,   217,   218,     0,   220,   221,   222,   223,
-     224,   444,   226,   227,   228,   229,   230,   231,   232,   233,
-     234,   235,   236,     0,   238,   239,   240,     0,     0,   243,
-     244,   245,   246,   445,   446,   447,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   448,
-     449,     0,     0,     0,     0,     0,     0,     0,  1215,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-      59,     0,     0,     0,     0,     0,     0,     0,   450,   451,
-     452,   453,   454,     0,   455,     0,   456,   457,   458,   459,
-     460,   461,   462,   463,    60,     0,     0,   464,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   465,   466,   467,     0,    14,     0,     0,
-     468,   469,     0,     0,     0,     0,     0,   426,   427,   470,
-       0,   471,     0,   472,   473,     0,   474,   428,   429,   430,
-     431,   432,     0,     0,     0,     0,     0,   433,     0,   434,
-       0,     0,     0,   435,     0,     0,     0,     0,     0,     0,
-       0,   436,     0,     0,     0,     0,     0,   437,     0,     0,
-     438,     0,     0,   439,     0,     0,     0,   440,     0,     0,
-       0,     0,     0,  1218,     0,     0,     0,   441,     0,     0,
-     442,   443,     0,   216,   217,   218,     0,   220,   221,   222,
-     223,   224,   444,   226,   227,   228,   229,   230,   231,   232,
-     233,   234,   235,   236,     0,   238,   239,   240,     0,     0,
-     243,   244,   245,   246,   445,   446,   447,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     448,   449,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,    59,     0,     0,     0,     0,     0,     0,     0,   450,
-     451,   452,   453,   454,     0,   455,     0,   456,   457,   458,
-     459,   460,   461,   462,   463,    60,     0,     0,   464,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   465,   466,   467,     0,    14,     0,
-       0,   468,   469,     0,     0,     0,     0,     0,   426,   427,
-     470,     0,   471,     0,   472,   473,     0,   474,   428,   429,
-     430,   431,   432,     0,     0,     0,     0,     0,   433,     0,
-     434,     0,     0,     0,   435,     0,     0,     0,     0,     0,
-       0,     0,   436,     0,     0,     0,     0,     0,   437,     0,
-       0,   438,     0,     0,   439,     0,     0,     0,   440,     0,
-       0,  1224,     0,     0,     0,     0,     0,     0,   441,     0,
-       0,   442,   443,     0,   216,   217,   218,     0,   220,   221,
-     222,   223,   224,   444,   226,   227,   228,   229,   230,   231,
-     232,   233,   234,   235,   236,     0,   238,   239,   240,     0,
-       0,   243,   244,   245,   246,   445,   446,   447,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   448,   449,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,    59,     0,     0,     0,     0,     0,     0,     0,
-     450,   451,   452,   453,   454,     0,   455,     0,   456,   457,
-     458,   459,   460,   461,   462,   463,    60,     0,     0,   464,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   465,   466,   467,     0,    14,
-       0,     0,   468,   469,     0,     0,     0,     0,     0,   426,
-     427,   470,     0,   471,     0,   472,   473,     0,   474,   428,
-     429,   430,   431,   432,     0,     0,     0,     0,     0,   433,
-       0,   434,     0,     0,     0,   435,     0,     0,     0,     0,
-       0,     0,     0,   436,     0,     0,     0,     0,     0,   437,
-       0,     0,   438,     0,     0,   439,     0,     0,     0,   440,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   441,
-       0,     0,   442,   443,     0,   216,   217,   218,     0,   220,
-     221,   222,   223,   224,   444,   226,   227,   228,   229,   230,
-     231,   232,   233,   234,   235,   236,     0,   238,   239,   240,
-       0,     0,   243,   244,   245,   246,   445,   446,   447,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   448,   449,     0,     0,     0,     0,     0,     0,
-       0,  1227,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,    59,     0,     0,     0,     0,     0,     0,
-       0,   450,   451,   452,   453,   454,     0,   455,     0,   456,
-     457,   458,   459,   460,   461,   462,   463,    60,     0,     0,
-     464,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   465,   466,   467,     0,
-      14,     0,     0,   468,   469,     0,     0,     0,     0,     0,
-     426,   427,   470,     0,   471,     0,   472,   473,     0,   474,
+       0,     0,     0,     0,     0,    59,     0,     0,     0,     0,
+       0,     0,     0,   450,   451,   452,   453,   454,     0,   455,
+       0,   456,   457,   458,   459,   460,   461,   462,   463,    60,
+       0,     0,   464,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   465,   466,
+     467,     0,    14,     0,     0,   468,   469,     0,     0,     0,
+     426,   427,     0,     0,   470,     0,   471,     0,   472,   473,
      428,   429,   430,   431,   432,     0,     0,     0,     0,     0,
      433,     0,   434,     0,     0,     0,   435,     0,     0,     0,
        0,     0,     0,     0,   436,     0,     0,     0,     0,     0,
@@ -2493,622 +2604,518 @@ static const yytype_int16 yytable[] =
        0,     0,     0,     0,    59,     0,     0,     0,     0,     0,
        0,     0,   450,   451,   452,   453,   454,     0,   455,     0,
      456,   457,   458,   459,   460,   461,   462,   463,    60,     0,
-       0,   464,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   465,   466,   467,
-       0,    14,     0,     0,   468,   469,     0,     0,     0,     0,
-       0,   426,   427,   470,     0,   471,  1461,   472,   473,     0,
-     474,   428,   429,   430,   431,   432,     0,     0,     0,     0,
-       0,   433,     0,   434,     0,     0,     0,   435,     0,     0,
-       0,     0,     0,     0,     0,   436,     0,     0,     0,     0,
-       0,   437,     0,     0,   438,     0,     0,   439,     0,     0,
-       0,   440,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   441,     0,     0,   442,   443,     0,   216,   217,   218,
-       0,   220,   221,   222,   223,   224,   444,   226,   227,   228,
-     229,   230,   231,   232,   233,   234,   235,   236,     0,   238,
-     239,   240,     0,     0,   243,   244,   245,   246,   445,   446,
-     447,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   448,   449,     0,     0,     0,     0,
+     210,   464,     0,     0,     0,     0,   211,     0,     0,     0,
+       0,     0,   212,     0,     0,     0,     0,   465,   466,   467,
+       0,    14,   213,     0,   468,   469,     0,     0,     0,     0,
+     214,     0,     0,   470,     0,   471,     0,   472,   473,     0,
+       0,     0,     0,     0,     0,   215,     0,     0,     0,     0,
+       0,     0,   216,   217,   218,   219,   220,   221,   222,   223,
+     224,   225,   226,   227,   228,   229,   230,   231,   232,   233,
+     234,   235,   236,   237,   238,   239,   240,   241,   242,   243,
+     244,   245,   246,   247,   248,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   210,     0,     0,     0,     0,
+       0,   211,     0,     0,     0,     0,     0,   212,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   213,     0,     0,
+      59,     0,     0,     0,     0,   214,     0,     0,     0,     0,
+       0,     0,     0,   249,     0,     0,     0,     0,     0,     0,
+     215,     0,     0,     0,   699,     0,    13,   216,   217,   218,
+     219,   220,   221,   222,   223,   224,   225,   226,   227,   228,
+     229,   230,   231,   232,   233,   234,   235,   236,   237,   238,
+     239,   240,   241,   242,   243,   244,   245,   246,   247,   248,
+       0,     0,     0,   250,     0,    16,     0,     0,   210,     0,
+       0,     0,     0,     0,   211,     0,     0,     0,     0,     0,
+     212,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     213,     0,     0,     0,     0,    59,     0,     0,   214,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   249,     0,
+       0,     0,     0,   215,     0,     0,     0,     0,     0,    60,
+     216,   217,   218,   219,   220,   221,   222,   223,   224,   225,
+     226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
+     236,   237,   238,   239,   240,   241,   242,   243,   244,   245,
+     246,   247,   248,     0,     0,     0,     0,   853,   250,     0,
+       0,     0,     0,     0,     0,   348,   349,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    59,     0,     0,     0,     0,
-       0,     0,     0,   450,   451,   452,   453,   454,     0,   455,
-       0,   456,   457,   458,   459,   460,   461,   462,   463,    60,
-       0,     0,   464,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   465,   466,
-     467,     0,    14,     0,     0,   468,   469,     0,     0,     0,
-       0,     0,   426,   427,   470,     0,   471,     0,   472,   473,
-       0,   474,   428,   429,   430,   431,   432,     0,     0,     0,
-       0,     0,   433,  1032,   434,  1033,     0,     0,   435,     0,
-       0,     0,     0,     0,     0,     0,   436,     0,     0,     0,
-       0,     0,   437,     0,     0,   438,     0,     0,   439,  1038,
-       0,     0,   440,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   441,     0,     0,   442,   443,     0,   216,   217,
-     218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
-     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
-     238,   239,   240,     0,     0,   243,   244,   245,   246,   445,
-     446,   447,  1043,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   448,   449,     0,     0,     0,
+       0,     0,   350,     0,     0,     0,     0,     0,    59,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,    59,     0,     0,     0,
-       0,     0,     0,     0,   450,   451,   452,   453,   454,     0,
-     455,     0,   456,   457,   458,   459,   460,   461,   462,   463,
-      60,     0,     0,   464,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   465,
-     466,   467,     0,    14,     0,     0,   468,   469,     0,     0,
-       0,   426,   427,     0,     0,   470,     0,   471,     0,   472,
-     473,   428,   429,   430,   431,   432,     0,     0,     0,     0,
-       0,   433,     0,   434,     0,     0,     0,   435,     0,     0,
-       0,     0,     0,     0,     0,   436,     0,     0,     0,     0,
-       0,   437,     0,     0,   438,     0,     0,   439,     0,     0,
-       0,   440,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   441,     0,     0,   442,   443,     0,   216,   217,   218,
-       0,   220,   221,   222,   223,   224,   444,   226,   227,   228,
-     229,   230,   231,   232,   233,   234,   235,   236,     0,   238,
-     239,   240,     0,     0,   243,   244,   245,   246,   445,   446,
-     447,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   448,   449,     0,     0,     0,     0,
-       0,     0,     0,   762,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    59,     0,     0,     0,     0,
-       0,     0,     0,   450,   451,   452,   453,   454,     0,   455,
-       0,   456,   457,   458,   459,   460,   461,   462,   463,    60,
-       0,     0,   464,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   465,   466,
-     467,     0,    14,     0,     0,   468,   469,     0,     0,     0,
-     426,   427,     0,     0,   470,     0,   471,     0,   472,   473,
-     428,   429,   430,   431,   432,     0,     0,   884,     0,     0,
-     433,     0,   434,     0,     0,     0,   435,     0,     0,     0,
-       0,     0,     0,     0,   436,     0,     0,     0,     0,     0,
-     437,     0,     0,   438,     0,     0,   439,     0,     0,     0,
-     440,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     441,     0,     0,   442,   443,     0,   216,   217,   218,     0,
-     220,   221,   222,   223,   224,   444,   226,   227,   228,   229,
-     230,   231,   232,   233,   234,   235,   236,     0,   238,   239,
-     240,     0,     0,   243,   244,   245,   246,   445,   446,   447,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   448,   449,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,    59,     0,     0,     0,     0,     0,
-       0,     0,   450,   451,   452,   453,   454,     0,   455,     0,
-     456,   457,   458,   459,   460,   461,   462,   463,    60,     0,
-       0,   464,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   465,   466,   467,
-       0,    14,     0,     0,   468,   469,     0,     0,     0,   426,
-     427,     0,     0,   470,     0,   471,     0,   472,   473,   428,
-     429,   430,   431,   432,     0,     0,     0,     0,     0,   433,
-       0,   434,     0,     0,     0,   435,     0,     0,     0,     0,
-       0,     0,     0,   436,     0,     0,     0,     0,     0,   437,
-       0,     0,   438,     0,     0,   439,     0,     0,     0,   440,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   441,
-       0,     0,   442,   443,     0,   216,   217,   218,     0,   220,
-     221,   222,   223,   224,   444,   226,   227,   228,   229,   230,
-     231,   232,   233,   234,   235,   236,     0,   238,   239,   240,
-       0,     0,   243,   244,   245,   246,   445,   446,   447,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   448,   449,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,    59,     0,     0,     0,     0,     0,     0,
-       0,   450,   451,   452,   453,   454,     0,   455,     0,   456,
-     457,   458,   459,   460,   461,   462,   463,    60,     0,   210,
-     464,     0,     0,     0,     0,   211,     0,     0,     0,     0,
-       0,   212,     0,     0,     0,     0,   465,   466,   467,     0,
-      14,   213,     0,   468,   469,     0,     0,     0,     0,   214,
-       0,     0,   470,     0,   471,     0,   472,   473,     0,     0,
-       0,     0,     0,     0,   215,     0,     0,     0,     0,     0,
-       0,   216,   217,   218,   219,   220,   221,   222,   223,   224,
-     225,   226,   227,   228,   229,   230,   231,   232,   233,   234,
-     235,   236,   237,   238,   239,   240,   241,   242,   243,   244,
-     245,   246,   247,   248,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   210,     0,     0,     0,     0,     0,
-     211,     0,     0,     0,     0,     0,   212,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   213,     0,     0,    59,
-       0,     0,     0,     0,   214,     0,     0,     0,     0,     0,
-       0,     0,   249,     0,     0,     0,     0,     0,     0,   215,
-       0,     0,     0,   699,     0,    13,   216,   217,   218,   219,
-     220,   221,   222,   223,   224,   225,   226,   227,   228,   229,
-     230,   231,   232,   233,   234,   235,   236,   237,   238,   239,
-     240,   241,   242,   243,   244,   245,   246,   247,   248,     0,
-       0,     0,   250,     0,    16,     0,     0,   210,     0,     0,
-       0,     0,     0,   211,     0,     0,     0,     0,     0,   212,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   213,
-       0,     0,     0,     0,    59,     0,     0,   214,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   249,     0,     0,
-       0,     0,   215,     0,     0,     0,     0,     0,    60,   216,
-     217,   218,   219,   220,   221,   222,   223,   224,   225,   226,
-     227,   228,   229,   230,   231,   232,   233,   234,   235,   236,
-     237,   238,   239,   240,   241,   242,   243,   244,   245,   246,
-     247,   248,     0,     0,     0,     0,   853,   250,     0,     0,
-       0,     0,     0,     0,   348,   349,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   350,     0,     0,     0,     0,     0,    59,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     249,     0,     0,     0,     0,     0,     0,     0,   216,   217,
-     218,   699,   220,   221,   222,   223,   224,   444,   226,   227,
-     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
-     238,   239,   240,     0,     0,   243,   244,   245,   246,     0,
-     651,   652,     0,     0,     0,     0,     0,     0,     0,     0,
-     250,   351,   352,   353,   354,   355,   356,   357,   358,   359,
-     360,   361,   362,   363,   364,   365,   366,   367,   368,     0,
-       0,   369,   370,   371,     0,     0,   372,   373,   374,   375,
-     376,     0,     0,   377,   378,   379,   380,   381,   382,   383,
-       0,   854,     0,     0,     0,     0,     0,     0,     0,     0,
-     855,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   651,   652,   384,     0,
-     385,   386,   387,   388,   389,   390,   391,   392,   393,   394,
-       0,     0,   395,   396,     0,   653,   654,   655,   656,   657,
-     397,   398,   658,   659,   660,   661,     0,   662,   663,   664,
-     665,   666,     0,   667,   668,     0,     0,  -840,     0,   670,
-     671,   672,     0,     0,     0,  -840,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   651,   652,   674,     0,   675,   676,   677,   678,
-     679,   680,   681,   682,   683,   684,     0,     0,     0,     0,
-       0,   653,   654,   655,   656,   657,   685,   686,   658,   659,
-     660,   661,     0,   662,   663,   664,   665,   666,     0,   667,
-     668,     0,   651,   652,     0,   670,   671,   672,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   651,   652,
-     674,     0,   675,   676,   677,   678,   679,   680,   681,   682,
-     683,   684,     0,     0,     0,     0,     0,   653,   654,   655,
-     656,   657,   685,   686,   658,   659,   660,   661,     0,   662,
-     663,   664,   665,   666,     0,   667,   668,     0,   651,   652,
-       0,   670,     0,   672,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   653,   654,   655,
-     656,   657,     0,     0,   658,   659,   660,   661,     0,   662,
-     663,   664,   665,   666,     0,   667,   668,     0,   675,   676,
-     677,   678,   679,   680,   681,   682,   683,   684,     0,     0,
-       0,     0,     0,   653,   654,   655,   656,   657,   685,   686,
-     658,   659,   660,   661,     0,   662,   663,   664,   665,   666,
-       0,   667,   668,     0,   651,   652,     0,   670,   675,   676,
-     677,   678,   679,   680,   681,   682,   683,   684,     0,     0,
-       0,     0,     0,   653,   654,   655,   656,   657,   685,   686,
-     658,   659,   660,   661,     0,   662,   663,   664,   665,   666,
-       0,   667,   668,     0,   675,   676,   677,   678,   679,   680,
-     681,   682,   683,   684,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   685,   686,     0,   857,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     651,   652,     0,     0,     0,   676,   677,   678,   679,   680,
-     681,   682,   683,   684,     0,     0,     0,     0,     0,   653,
-     654,   655,   656,   657,   685,   686,   658,   659,   660,   661,
-       0,   662,   663,   664,   665,   666,     0,   667,   668,   216,
-     217,   218,     0,   220,   221,   222,   223,   224,   444,   226,
+       0,   249,     0,     0,     0,     0,     0,     0,     0,   216,
+     217,   218,   699,   220,   221,   222,   223,   224,   444,   226,
      227,   228,   229,   230,   231,   232,   233,   234,   235,   236,
        0,   238,   239,   240,     0,     0,   243,   244,   245,   246,
-       0,     0,     0,     0,     0,     0,  1080,     0,     0,     0,
-       0,     0,   677,   678,   679,   680,   681,   682,   683,   684,
-       0,     0,     0,     0,     0,   653,   654,   655,   656,   657,
-     685,   686,   658,   659,   660,   661,     0,   662,   663,   664,
-     665,   666,     0,   667,   668,     0,     0,     0,     0,     0,
-       0,     0,   858,     0,     0,     0,     0,     0,   216,   217,
-     218,   859,   220,   221,   222,   223,   224,   444,   226,   227,
-     228,   229,   230,   231,   232,   233,   234,   235,   236,   269,
-     238,   239,   240,     0,     0,   243,   244,   245,   246,   678,
-     679,   680,   681,   682,   683,   684,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   685,   686,     0,     0,
-       0,     0,     0,     0,     0,   270,     0,   271,     0,   272,
+       0,   651,   652,     0,     0,     0,     0,     0,     0,     0,
+       0,   250,   351,   352,   353,   354,   355,   356,   357,   358,
+     359,   360,   361,   362,   363,   364,   365,   366,   367,   368,
+       0,     0,   369,   370,   371,     0,     0,   372,   373,   374,
+     375,   376,     0,     0,   377,   378,   379,   380,   381,   382,
+     383,     0,   854,     0,     0,     0,     0,     0,     0,     0,
+       0,   855,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   651,   652,   384,
+       0,   385,   386,   387,   388,   389,   390,   391,   392,   393,
+     394,     0,     0,   395,   396,     0,   653,   654,   655,   656,
+     657,   397,   398,   658,   659,   660,   661,     0,   662,   663,
+     664,   665,   666,     0,   667,   668,     0,     0,   669,     0,
+     670,   671,   672,     0,     0,     0,   673,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   651,   652,   674,  1084,   675,   676,   677,
+     678,   679,   680,   681,   682,   683,   684,     0,     0,     0,
+       0,     0,   653,   654,   655,   656,   657,   685,   686,   658,
+     659,   660,   661,     0,   662,   663,   664,   665,   666,     0,
+     667,   668,   651,   652,   669,     0,   670,   671,   672,     0,
+       0,     0,   673,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   651,
+     652,   674,     0,   675,   676,   677,   678,   679,   680,   681,
+     682,   683,   684,     0,     0,     0,     0,     0,   653,   654,
+     655,   656,   657,   685,   686,   658,   659,   660,   661,     0,
+     662,   663,   664,   665,   666,     0,   667,   668,   651,   652,
+    -843,     0,   670,   671,   672,     0,     0,     0,  -843,     0,
+       0,     0,     0,     0,     0,     0,     0,   653,   654,   655,
+     656,   657,     0,     0,   658,   659,   660,   661,     0,   662,
+     663,   664,   665,   666,     0,   667,   668,   674,     0,   675,
+     676,   677,   678,   679,   680,   681,   682,   683,   684,     0,
+       0,     0,     0,     0,   653,   654,   655,   656,   657,   685,
+     686,   658,   659,   660,   661,     0,   662,   663,   664,   665,
+     666,     0,   667,   668,     0,     0,     0,     0,     0,   676,
+     677,   678,   679,   680,   681,   682,   683,   684,     0,     0,
+       0,     0,     0,   653,   654,   655,   656,   657,   685,   686,
+     658,   659,   660,   661,     0,   662,   663,   664,   665,   666,
+       0,   667,   668,     0,     0,     0,     0,   677,   678,   679,
+     680,   681,   682,   683,   684,   857,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   685,   686,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,  1080,   678,   679,   680,
+     681,   682,   683,   684,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   685,   686,     0,   216,   217,   218,
+       0,   220,   221,   222,   223,   224,   444,   226,   227,   228,
+     229,   230,   231,   232,   233,   234,   235,   236,     0,   238,
+     239,   240,     0,     0,   243,   244,   245,   246,   216,   217,
+     218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
+     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
+     238,   239,   240,     0,     0,   243,   244,   245,   246,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     858,   269,     0,     0,     0,     0,     0,     0,     0,   859,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,  1081,     0,     0,     0,     0,     0,   270,     0,   271,
+    1082,   272,   273,   274,   275,   276,     0,   277,   278,   279,
+     280,   281,   282,   283,   284,   285,   286,   287,     0,   288,
+     289,   290,     0,     0,   291,   292,   293,   294,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   295,   296,   216,   217,   218,     0,
+     220,   221,   222,   223,   224,   444,   226,   227,   228,   229,
+     230,   231,   232,   233,   234,   235,   236,     0,   238,   239,
+     240,     0,     0,   243,   244,   245,   246,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   297,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   896,   897,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   898,
+       0,     0,     0,     0,     0,   270,     0,   271,   899,   272,
      273,   274,   275,   276,     0,   277,   278,   279,   280,   281,
      282,   283,   284,   285,   286,   287,     0,   288,   289,   290,
-       0,  1081,   291,   292,   293,   294,     0,     0,     0,     0,
-    1082,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   295,   296,   216,   217,   218,     0,   220,   221,
-     222,   223,   224,   444,   226,   227,   228,   229,   230,   231,
-     232,   233,   234,   235,   236,     0,   238,   239,   240,     0,
-       0,   243,   244,   245,   246,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   297,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   896,   897,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   898,     0,     0,
-       0,     0,     0,   270,     0,   271,   899,   272,   273,   274,
-     275,   276,     0,   277,   278,   279,   280,   281,   282,   283,
-     284,   285,   286,   287,     0,   288,   289,   290,     0,     0,
-     291,   292,   293,   294,     0,     0,     0,     0,     0,     0,
-     900,   901,   270,     0,   271,     0,   272,   273,   274,   275,
-     276,     0,   277,   278,   279,   280,   281,   282,   283,   284,
-     285,   286,   287,     0,   288,   289,   290,     0,     0,   291,
-     292,   293,   294,     0,   270,     0,   271,     0,   272,   273,
+       0,     0,   291,   292,   293,   294,     0,     0,     0,     0,
+       0,     0,   900,   901,   270,     0,   271,     0,   272,   273,
      274,   275,   276,     0,   277,   278,   279,   280,   281,   282,
-     283,   284,   285,   286,   287,   539,   288,   289,   290,     0,
-       0,   291,   292,   293,   294,     0,     0,     0,     0,     0,
+     283,   284,   285,   286,   287,     0,   288,   289,   290,     0,
+       0,   291,   292,   293,   294,     0,   270,     0,   271,     0,
+     272,   273,   274,   275,   276,     0,   277,   278,   279,   280,
+     281,   282,   283,   284,   285,   286,   287,   539,   288,   289,
+     290,     0,     0,   291,   292,   293,   294,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   541,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   541,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   724
+       0,     0,     0,     0,     0,     0,     0,     0,   724
 };
 
 static const yytype_int16 yycheck[] =
 {
-       1,    14,    15,   331,   144,   145,   571,   567,   171,   430,
-     579,   764,   430,   343,   942,   471,   636,   637,   186,    20,
-      21,    22,  1034,   509,   694,   511,   696,   513,   698,   538,
-    1167,  1007,   843,   537,   641,  1246,   931,    82,   925,   348,
-     349,   813,  1537,    22,     8,    20,    33,    19,  1582,   810,
-      33,    52,    65,    66,    67,   950,    19,    20,  1582,   852,
-    1582,  1371,   518,    20,    20,     5,    20,   148,     0,  1582,
-     186,  1582,   140,   141,   142,     7,    40,    46,    57,   126,
-    1475,   165,   163,   173,   165,  1013,  1334,   151,   708,     7,
-     420,   181,   165,   180,   107,   108,   109,   110,    30,  1523,
-      32,   154,    34,   154,   156,   127,   154,  1641,    40,    62,
-     163,   133,   163,   200,   204,   163,   200,  1641,    50,  1641,
-     148,   129,   130,   204,    56,   206,   151,   200,  1641,   176,
-    1641,    33,    50,   201,   127,   163,   705,   106,  1533,   203,
-     709,     5,     6,  1677,   600,   308,    15,    16,    80,  1573,
-      15,    16,   174,  1677,   610,  1677,   201,   613,    60,    61,
-     300,    25,   102,   103,  1677,   305,  1677,    31,   127,   309,
-     102,   103,   200,   186,   133,   343,   201,   797,   203,  1674,
-     800,   174,   789,  1493,   177,   641,   163,   173,   808,   197,
-     198,   811,   179,  1688,  1442,  1443,   179,   173,   173,   200,
-     163,   165,   995,   975,    68,    69,   185,  1592,   180,   774,
-    1458,   198,  1460,   974,  1226,   174,   173,   173,   197,   173,
-     207,   163,   124,   165,  1200,   202,   128,  1122,  1115,   798,
-     165,   687,   148,   165,   198,   842,   545,   250,   102,   103,
-     180,   180,   206,  1138,  1629,   126,   126,   163,   669,   129,
-     130,   669,   420,    34,   186,   423,   424,   425,   185,   173,
-     200,   200,   204,   174,  1192,   310,   198,  1515,  1516,   204,
-     176,   601,   204,   175,  1522,   139,   154,   179,   418,   181,
-     182,  1492,    63,   139,   200,   163,   616,   156,    45,   205,
-     204,   156,   161,   180,   163,   176,   161,   166,   163,   163,
-     181,   166,  1512,   154,   165,   207,   185,   423,   424,   425,
-     163,  1521,   163,   200,  1451,   127,   180,   197,   198,   200,
-     176,   133,   200,   126,   126,   126,   107,  1339,    85,    86,
-     343,    88,   146,   789,   198,   200,   504,   505,   203,    33,
-     508,   205,   510,   204,   512,   206,   514,   200,   180,   163,
-     201,   132,   520,     8,   923,  1565,  1566,   163,   139,   966,
-    1030,  1373,   174,   849,   180,  1350,    60,    61,   200,   537,
-     163,   185,   186,   176,   176,   176,  1304,   173,   181,   181,
-     181,    36,   163,   197,   200,   127,   554,   555,   504,   505,
-     955,   133,   508,   139,   510,  1206,   512,   200,   200,   200,
-    1020,   970,  1387,   173,   520,   201,   200,   420,  1384,   190,
-     423,   424,   425,   922,   127,   919,   127,   430,   431,   200,
-     133,   163,   173,   173,   173,   994,   935,    33,   107,   933,
-     124,   201,   174,   601,   128,   154,   139,   179,   554,   555,
-     164,   165,   146,   773,   163,   173,    21,    22,   616,   173,
-     201,   201,   201,   177,    60,    61,   786,   787,   127,   163,
-     163,   174,   173,   174,   133,   176,   796,   156,   179,  1280,
-     139,   199,   802,   803,   173,   805,  1229,   807,   173,   809,
-     204,   175,   186,   651,   652,   179,   173,   181,   182,   173,
-     127,   504,   505,   197,   165,   508,   133,   510,   666,   512,
-     640,   514,   201,   180,   199,   174,   177,   520,   173,   197,
-     173,   139,   173,   207,   201,   199,   163,   685,   124,   173,
-     148,   127,   128,   200,   537,   153,   165,   133,    57,  1199,
-     173,  1017,   173,   204,    63,   163,   201,   174,   201,   707,
-     201,   554,   555,   118,   119,   199,  1474,    21,    22,   562,
-     173,   126,   180,   128,   129,   130,   131,   132,   201,   165,
-     201,   173,   164,   165,   173,   173,   173,   148,   174,   175,
-     571,   173,   173,   179,  1586,  1587,   182,    47,   201,   181,
-      21,    22,   163,   140,   173,   142,  1072,   173,   601,   201,
-    1612,   707,   201,   201,   201,  1164,  1266,    67,   204,   148,
-     201,   207,   204,   616,   163,   773,   164,   182,   183,   184,
-     185,   186,   201,   199,   163,   173,  1638,   785,   786,   787,
-     788,  1077,   197,   198,   792,   163,   639,   139,   796,   642,
-    1642,    21,    22,  1089,   802,   803,   148,   805,  1094,   807,
-      57,   809,   810,   973,   118,   119,    63,   167,   168,   979,
-    1662,   163,   126,    79,   128,   129,   130,   131,   132,    12,
-      65,    66,    67,   993,   163,   164,     5,     6,    94,   785,
-      23,    24,   788,    99,   173,   101,   792,   118,   119,   167,
-     176,   163,   163,   164,   180,   126,  1016,   128,   129,   130,
-     131,   132,   173,   177,   707,   204,   205,   181,   164,   165,
-    1511,  1512,   107,   108,   109,   110,  1517,   173,   164,   165,
-    1521,   176,  1523,    57,   179,   181,   884,   173,   154,    63,
-     721,   107,   723,   197,   198,   181,  1182,   163,   118,   119,
-     163,   173,   107,  1189,   176,   163,   126,   179,   204,   129,
-     130,   131,   132,   184,   185,   186,   177,  1558,   204,   917,
-     181,   919,   920,    57,  1565,  1566,   197,   198,   926,    63,
-     773,   173,  1573,    57,   176,   933,   177,   179,   163,    63,
-     181,    57,   785,   786,   787,   788,   777,    63,    57,   792,
-     205,   177,   203,   796,    63,   181,   164,   165,    57,   802,
-     803,   174,   805,   190,   807,   173,   809,   810,   177,  1552,
-     176,   917,   181,   181,   920,   973,   974,   197,   198,    19,
-     926,   979,   177,   177,   177,    25,   181,   181,   181,   177,
-    1631,    31,   140,   181,   167,   993,   204,   165,   318,   177,
-      33,    41,   177,   181,    10,    11,   181,  1258,   328,    49,
-    1258,   167,   168,   169,   170,    66,   202,   203,  1016,   205,
-     851,   341,   163,   487,    64,   489,   490,    60,    61,   489,
-     490,    71,    72,    73,    74,    75,    76,    77,    78,    79,
-      80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
-      90,    91,    92,    93,    94,    95,    96,    97,    98,    99,
-     100,   101,   102,   103,   203,  1351,   140,   141,   142,  1652,
-    1520,   163,  1042,   164,   917,   176,   919,   920,   106,   164,
-     165,   203,   163,   926,   167,   168,   169,   180,   173,   200,
-     933,   124,   164,   165,   127,   128,   181,  1680,   180,   139,
-     133,   173,   933,   180,   935,   164,   165,  1267,   198,   181,
-    1560,   180,   152,   180,   173,   180,   947,   180,   180,   204,
-     164,   165,   181,   163,   955,   200,   957,   180,   180,   173,
-     973,   974,   204,   164,   200,  1133,   979,   181,   164,   165,
-     177,   174,   175,    35,   205,   204,   179,   173,   205,   182,
-     993,  1144,    35,  1543,   200,   181,   163,    75,   163,   180,
-     204,    79,   202,   198,   205,    21,    22,   207,   163,  1455,
-     167,   168,   169,  1016,   207,    93,    94,   199,   204,    22,
-      98,    99,   100,   101,    56,    57,    58,  1133,   756,   757,
-     758,  1477,   163,   138,  1589,   199,   205,   176,   163,   180,
-     180,   521,   180,   180,   200,   180,   200,   180,  1039,   200,
-     180,  1181,   180,   533,   200,   200,  1047,  1048,   200,   203,
-     163,   181,   173,    43,   200,    33,   200,    13,   200,  1060,
-    1625,  1062,  1063,  1064,  1065,  1066,   200,   198,   201,  1070,
-      21,    22,   200,   200,  1214,   201,   201,   201,   200,   199,
-     199,   204,    60,    61,  1540,   575,   181,   201,   205,   200,
-     116,   117,   118,   119,   120,   180,   180,   123,   180,  1267,
-     126,  1269,   128,   129,   130,   131,   132,   180,   134,   135,
-     200,   200,   602,   603,   173,    33,   606,     4,   608,   199,
-    1133,  1449,   201,   163,   163,   203,   176,   199,   163,   619,
-     620,   621,   622,   623,   624,   163,   163,   173,   163,   163,
-     201,   201,    60,    61,   201,   201,   124,   201,  1149,   201,
-     128,   180,   201,  1269,   180,   181,   182,   183,   184,   185,
-     186,     1,   180,   201,   201,   116,   117,   118,   119,   200,
-     200,   197,   198,    43,   664,   126,   199,   128,   129,   130,
-     131,   132,   201,   134,   135,   200,   164,   165,   199,   201,
-     200,   200,   200,   200,   200,   173,   686,   175,   200,   200,
-      33,   179,   200,   181,   182,   181,   124,  1375,   181,   181,
-     128,   200,    33,   201,   174,   201,   200,   174,   201,    43,
-     201,   201,   201,   713,   201,   200,   204,    60,    61,   207,
-     201,   182,   183,   184,   185,   186,   201,   201,   200,    60,
-      61,   176,   200,    43,   156,   200,   197,   198,   163,   201,
-    1418,   200,   206,   201,  1267,   163,  1269,   175,  1588,  1375,
-     163,   179,   752,   181,   182,    10,  1434,    13,    21,    22,
-       9,  1411,    42,    66,   180,   200,   200,   199,   163,   200,
-     770,   163,   199,   206,   163,   163,   776,   163,     8,   207,
-     206,   124,   206,   200,   163,   128,   201,   163,   171,   163,
-      33,   791,  1418,   124,   201,   201,   201,   128,   163,   163,
-     200,   163,  1313,   163,  1315,    14,   174,   174,  1434,   156,
-     176,   201,   206,   200,    43,   200,   200,    60,    61,   200,
-     174,    37,   822,   200,   206,   174,   201,   827,   201,   829,
-     201,   831,   175,    67,    70,   181,   179,   200,   181,   182,
-     201,   841,   200,   200,   175,   201,   201,   200,   179,   200,
-     181,   182,  1375,   116,   117,   118,   119,   120,   200,   200,
-     123,   124,   125,   126,   207,   128,   129,   130,   131,   132,
-    1381,   134,   135,   163,    43,   138,   207,   140,   141,   142,
-     201,   124,   181,   146,   163,   128,   201,   201,   201,  1539,
-     163,  1541,  1542,   201,   200,  1418,   200,   897,   200,   200,
-     200,   901,   167,   201,   163,   201,   201,   204,   201,   201,
-    1588,  1434,   175,   176,   177,   178,   179,   180,   181,   182,
-     183,   184,   185,   186,   206,   201,   201,   927,   205,   201,
-      33,   201,   175,   201,   197,   198,   179,   204,   181,   182,
-     108,   109,   110,   111,   112,   113,   114,   115,    12,   173,
-      21,    22,  1475,   173,   201,   201,   956,   201,   200,   127,
-     201,   201,   201,   201,   207,   133,    53,   204,   201,   204,
-     201,    81,  1622,   201,   199,   143,   144,   145,   205,   200,
-     980,  1492,   199,   206,   206,     1,   201,   206,   206,   136,
-      33,   205,    84,  1687,  1505,   723,   723,  1647,  1685,   625,
-     207,   106,   951,  1653,   646,     1,   174,   707,  1507,  1369,
-    1533,  1556,  1510,  1557,  1014,  1015,  1557,    60,    61,   448,
-     449,    55,   642,  1437,  1138,  1025,   950,   950,  1678,   430,
-     225,   302,  1032,    -1,   430,  1035,   465,   466,   467,   468,
-     469,  1041,    -1,  1043,   602,   116,   117,   118,   119,   120,
-      -1,    -1,   123,   124,   125,   126,    -1,   128,   129,   130,
-     131,   132,    -1,   134,   135,  1588,    -1,   138,    -1,   140,
-     141,   142,  1583,    -1,  1074,   146,  1076,    -1,  1078,    -1,
-    1591,   124,   430,    -1,    -1,   128,   430,    -1,  1088,    -1,
-     430,   430,    -1,    -1,    -1,    -1,  1096,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   175,    -1,   177,   178,   179,   180,
-     181,   182,   183,   184,   185,   186,    -1,  1628,    -1,    -1,
-    1120,    -1,    -1,    -1,    -1,    -1,   197,   198,   557,    -1,
-    1130,    -1,   175,  1644,    -1,  1135,   179,  1137,   181,   182,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,  1658,  1148,  1660,
-      -1,    -1,    -1,    -1,  1665,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   207,    -1,    -1,  1167,    -1,    -1,
-    1681,    -1,  1683,   108,   109,   110,   111,   112,   113,   114,
-     115,    -1,    -1,    -1,    -1,  1185,    -1,    -1,    -1,    -1,
-      -1,    -1,    10,  1193,  1194,  1195,    -1,    -1,   133,    -1,
-      -1,    -1,    -1,    21,    22,    -1,    -1,    -1,   143,   144,
-     145,    -1,    -1,    -1,    -1,  1215,    -1,    -1,  1218,    -1,
-      -1,    -1,    -1,    -1,   653,   654,    -1,  1227,   657,   658,
-     659,   660,    -1,   662,    -1,    -1,   665,   666,   667,   668,
-     669,   670,   671,   672,   673,   674,   675,   676,   677,   678,
-     679,   680,   681,   682,   683,   684,    -1,    -1,    -1,    -1,
+       1,    14,    15,   106,   144,   145,   331,   567,   171,   571,
+     430,   430,   942,   343,  1034,   471,   636,   637,   186,    20,
+      21,    22,   694,   764,   696,  1007,   698,   843,  1167,   579,
+     509,   538,   511,  1246,   513,   641,   931,    82,   925,   537,
+       5,    15,    16,   810,     8,    20,  1540,   348,   349,    20,
+     852,    52,    65,    66,    67,   950,  1371,    46,   127,   151,
+     156,    20,   518,   813,    19,    20,  1586,  1586,     0,  1586,
+     186,    20,   126,  1477,    34,     7,    40,  1586,   151,   176,
+      19,  1586,   179,  1013,    22,  1334,    33,   174,   708,   173,
+     420,   140,   141,   142,   107,   108,   109,   110,    30,    33,
+      32,   148,    34,    63,   173,   174,     7,   176,    40,   201,
+     179,   203,    21,    22,   139,   127,   163,   106,    50,    57,
+     204,   133,   176,   180,    56,  1645,  1645,   181,  1645,   127,
+     203,   163,  1536,    15,    16,   133,  1645,   102,   103,  1526,
+    1645,     5,     6,   200,   600,   308,   200,   107,    80,    50,
+      62,   176,   201,   200,   610,   705,   201,   613,   205,   709,
+     300,    25,   174,  1683,  1683,   305,  1683,    31,   200,   309,
+     102,   103,   132,   186,  1683,   343,   174,   797,  1683,   139,
+     800,  1496,   156,   789,   176,   641,  1680,   161,   808,   163,
+    1577,   811,   166,   995,   173,  1444,  1445,   173,   173,   200,
+    1694,   165,   173,   163,    68,    69,  1226,   974,   163,   118,
+     119,  1460,   774,  1462,   173,   180,   185,   126,  1200,   128,
+     129,   130,   131,   132,   173,   975,   200,  1122,  1115,   203,
+     190,   687,   179,   165,   198,   200,   842,   250,   102,   103,
+     200,   180,   206,  1138,   545,   179,   126,   185,   798,   669,
+     669,   198,   420,   148,   186,   423,   424,   425,  1515,   197,
+     207,   126,  1192,   180,   163,   310,   198,  1524,   163,  1518,
+    1519,   601,   204,   126,   156,   139,  1525,   126,   418,   161,
+     173,   163,  1495,   200,   166,   185,   616,   148,   197,   198,
+     126,   154,   163,   129,   130,   173,   176,   129,   130,   163,
+     163,   181,   163,   202,   165,   200,   199,   423,   424,   425,
+     165,   176,  1569,  1570,  1453,  1350,   180,   127,  1596,  1339,
+     200,   199,   163,   176,   165,     5,     6,   176,   181,   127,
+     343,   146,   181,   789,   198,   133,   504,   505,   201,   163,
+     508,   205,   510,   204,   512,   206,   514,   200,   163,   204,
+     127,   200,   520,  1373,  1389,  1633,   133,   173,  1030,   154,
+     966,   197,   198,   204,   174,   197,   198,   177,   163,   537,
+     849,   186,   173,   923,  1304,   127,   174,   139,   127,   127,
+     181,   133,   197,   199,   133,   133,   554,   555,   504,   505,
+    1206,   139,   508,   955,   510,   165,   512,   174,   163,   164,
+    1020,   165,   146,   204,   520,   200,   200,   420,   173,    45,
+     423,   424,   425,   177,   163,   922,   156,   430,   431,   163,
+     970,   919,   174,    21,    22,   174,   174,    33,   935,   107,
+     179,     8,   165,   601,   204,   933,   206,   173,   554,   555,
+     204,   185,   186,   773,   994,   165,    21,    22,   616,    85,
+      86,   180,    88,   197,    60,    61,   786,   787,   173,    36,
+      65,    66,    67,   173,  1280,   201,   796,   200,   173,   139,
+      57,   200,   802,   803,   180,   805,    63,   807,   173,   809,
+     200,   197,   173,   651,   652,   173,   201,   173,  1229,   199,
+     173,   504,   505,   163,   200,   508,   201,   510,   666,   512,
+     640,   514,   107,   108,   109,   110,   201,   520,   148,  1491,
+     201,   173,   173,   201,   148,   201,   199,   685,   124,   173,
+     118,   119,   128,   163,   537,   198,  1616,  1199,   126,   163,
+     203,   129,   130,   131,   132,   173,   139,   199,  1017,   707,
+     201,   554,   555,   118,   119,   148,  1476,   201,   180,   562,
+     153,   126,  1642,   128,   129,   130,   131,   132,   164,   165,
+     163,   173,   173,   201,   173,   167,   180,   173,   200,   175,
+     571,  1591,   163,   179,   173,   181,   182,   180,   173,   176,
+      21,    22,   165,   180,   173,   173,   200,   173,   601,   201,
+     201,   707,   201,  1072,  1266,   154,    47,   173,   204,   197,
+     198,   207,   201,   616,   163,   773,   201,  1627,   163,   184,
+     185,   186,   201,   201,  1164,   201,    67,   785,   786,   787,
+     788,  1077,   197,   198,   792,   201,   639,   163,   796,   642,
+     107,   164,   165,  1089,   802,   803,   139,   805,  1094,   807,
+     173,   809,   810,   973,  1664,   148,   163,  1667,   181,   979,
+     154,   107,   164,   165,   163,   164,    12,   164,   165,   163,
+     163,   173,   163,   993,   173,   177,   173,    23,    24,   785,
+     154,   204,   788,   154,   181,   164,   792,   118,   119,   163,
+     202,   203,   163,   205,   173,   126,  1016,   128,   129,   130,
+     131,   132,   204,   154,   707,   167,   168,   204,  1514,  1515,
+     164,   165,   163,    79,  1520,   163,    57,    57,  1524,   173,
+    1526,   177,    63,    63,   163,   181,   884,   181,    94,   205,
+     721,   173,   723,    99,   176,   101,  1182,   179,    57,   173,
+     164,   165,   176,  1189,    63,   179,   140,   141,   142,   173,
+     204,   182,   183,   184,   185,   186,  1562,   181,   140,   917,
+     142,   919,   920,  1569,  1570,   177,   197,   198,   926,   181,
+     773,  1577,   167,   168,   169,   933,    21,    22,   164,   165,
+     204,   203,   785,   786,   787,   788,   777,   173,    57,   792,
+      57,    57,    57,   796,    63,   181,    63,    63,   190,   802,
+     803,   177,   805,   174,   807,   181,   809,   810,   177,   177,
+     167,   917,   181,   181,   920,   973,   974,   176,   204,   140,
+     926,   979,   164,   165,   177,  1556,   177,   165,   181,  1635,
+     181,   173,   167,   168,   169,   993,    33,   164,   165,   181,
+     177,   177,   203,   318,   181,   181,   173,   177,  1258,  1258,
+      66,   181,   177,   328,   181,   163,   181,   163,  1016,   164,
+     851,   176,   204,    60,    61,   106,   341,   167,   168,   169,
+     170,   116,   117,   118,   119,   120,   163,   204,   123,   124,
+     125,   126,   180,   128,   129,   130,   131,   132,   180,   134,
+     135,   204,   205,    33,   203,   140,   487,   142,   489,   490,
+     756,   757,   758,    10,    11,  1351,    56,    57,    58,  1236,
+    1237,   200,  1042,  1523,   917,   200,   919,   920,   489,   490,
+      60,    61,   180,   926,   180,   180,  1657,   124,   180,   180,
+     933,   128,   177,   178,   179,   180,   181,   182,   183,   184,
+     185,   186,   933,   180,   935,   180,   180,  1267,   177,   198,
+     200,   164,   197,   198,  1564,  1686,   947,   205,   205,    35,
+     164,   165,    35,   163,   955,   163,   957,   200,   180,   173,
+     973,   974,   164,   165,   198,  1133,   979,   181,   175,   205,
+     163,   173,   179,    22,   124,   182,   163,   127,   128,   181,
+     993,  1144,    33,   133,   199,   138,   199,  1547,    75,   205,
+     204,   176,    79,   163,   180,   200,   180,   180,    21,    22,
+     207,  1457,   204,  1016,   180,   180,    93,    94,   200,    60,
+      61,    98,    99,   100,   101,   165,   180,  1133,   200,   180,
+     200,   180,   200,  1479,   174,   175,   200,   200,   200,   179,
+     198,  1593,   182,   200,   203,   200,   521,   200,  1039,   201,
+     181,  1181,   163,   201,   201,   201,  1047,  1048,   533,   173,
+     199,    33,   199,   204,   204,   200,   200,   207,   201,  1060,
+      43,  1062,  1063,  1064,  1065,  1066,   205,  1629,   181,  1070,
+     200,   180,   180,   124,  1214,   180,   180,   128,    60,    61,
+     200,    13,   200,   199,   173,     4,   201,   163,   163,   203,
+     575,   176,   199,   116,   117,   118,   119,   120,   163,  1267,
+     123,  1269,   163,   126,   163,   128,   129,   130,   131,   132,
+     163,   134,   135,    21,    22,   163,   173,   602,   603,   201,
+    1133,   606,   201,   608,   175,   180,  1451,   201,   179,   201,
+     181,   182,   201,  1589,   619,   620,   621,   622,   623,   624,
+     180,   201,   124,   201,   200,   127,   128,   201,  1149,   201,
+     200,   133,   199,  1269,    33,   201,   207,   180,   181,   182,
+     183,   184,   185,   186,   200,     1,   201,   200,   200,   200,
+     200,   200,   200,   200,   197,   198,   200,   199,   181,   664,
+     181,    60,    61,   181,   201,   200,   174,   201,   200,    43,
+     174,   201,   174,   175,    43,   201,   201,   179,   176,   201,
+     182,   686,   201,    33,   200,    43,   201,  1375,   116,   117,
+     118,   119,   201,   163,   201,   200,   206,   163,   126,   200,
+     128,   129,   130,   131,   132,   207,   134,   135,   713,   201,
+      60,    61,   200,   200,   163,   201,    33,    10,   156,    13,
+       9,    42,    66,   180,   200,   124,   200,   199,   199,   128,
+     163,   200,  1420,   163,  1267,     8,  1269,   163,   206,  1375,
+     163,   206,  1592,    60,    61,   206,   163,   752,  1436,   163,
+     201,   163,   200,  1413,   182,   183,   184,   185,   186,   163,
+     171,  1384,   163,   163,   201,   770,   201,   163,   200,   197,
+     198,   776,   201,   163,   124,    14,   175,   174,   128,   174,
+     179,   156,   181,   182,  1420,   176,   791,   200,   174,    43,
+     200,   200,  1313,   201,  1315,   201,   201,    37,   201,   206,
+    1436,   174,    67,    21,    22,   181,    70,   124,   207,   201,
+     163,   128,   206,   200,    43,   200,   200,   822,   201,   200,
+     200,   200,   827,   200,   829,   175,   831,   181,   163,   179,
+     201,   181,   182,   201,   200,   200,   841,   201,   201,   201,
+     163,   201,  1375,   200,   163,   200,   205,    33,   108,   109,
+     110,   111,   112,   113,   114,   115,   201,   207,   175,   200,
+    1381,   200,   179,   200,   181,   182,   167,   201,   204,   201,
+     201,    33,   201,   133,    60,    61,   206,   201,   204,   201,
+      12,   201,  1542,   143,   144,   145,  1546,  1420,   201,   201,
+     207,   173,   897,   173,   201,   201,   901,   201,   116,   117,
+     118,   119,   120,  1436,  1592,   123,   124,   125,   126,   201,
+     128,   129,   130,   131,   132,   201,   134,   135,   201,   204,
+     201,   199,   927,   200,    53,   204,   201,   201,   625,   201,
+    1590,   199,    81,   200,   205,     1,   206,   206,   124,   136,
+     206,    84,   128,   205,  1477,   201,  1693,   206,  1691,   723,
+     723,   956,   207,   951,  1237,    33,   642,   707,     1,   177,
+     178,   179,   180,   181,   182,   183,   184,   185,   186,  1510,
+    1369,   646,    33,  1560,  1495,   980,  1513,  1439,  1561,   197,
+     198,  1561,    60,    61,    55,    33,  1646,  1508,  1138,   175,
+     950,   950,  1652,   179,   302,   181,   182,   225,  1658,    60,
+      61,   602,    -1,  1536,    -1,   430,   430,    -1,   430,  1014,
+    1015,   430,    60,    61,   448,   449,    -1,    -1,    -1,    -1,
+    1025,   207,    -1,    -1,  1684,    -1,    -1,  1032,   430,    -1,
+    1035,   465,   466,   467,   468,   469,  1041,   430,  1043,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   124,    -1,    -1,    -1,
+     128,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,  1592,
+      -1,    -1,    -1,   124,    -1,    -1,  1587,   128,    -1,  1074,
+      -1,  1076,    -1,  1078,  1595,    -1,   124,    -1,    -1,    -1,
+     128,    -1,    -1,  1088,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,  1096,    -1,    -1,    -1,    -1,    -1,   175,    21,    22,
+      -1,   179,    -1,   181,   182,    -1,    -1,    -1,    -1,    -1,
+      -1,  1632,    -1,    -1,   175,  1120,    -1,    -1,   179,    -1,
+     181,   182,    -1,   557,    -1,  1130,    -1,   175,  1649,   207,
+    1135,   179,  1137,   181,   182,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,  1663,  1148,  1665,    -1,   207,    -1,    -1,  1670,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   207,
+      -1,    -1,  1167,    -1,    -1,    -1,  1687,    -1,  1689,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,  1275,    -1,  1277,    -1,    -1,
-      -1,    -1,    -1,  1283,    -1,    -1,    -1,    -1,    -1,    -1,
-     108,   109,   110,   111,   112,   113,   114,   115,   116,   117,
-     118,   119,   120,   121,   122,   123,   124,   125,   126,   127,
-     128,   129,   130,   131,   132,   133,   134,   135,   136,   137,
-     138,  1321,   140,   141,   142,   143,   144,   145,   146,    -1,
-      -1,    -1,    -1,   762,    -1,    -1,    -1,    -1,  1338,    -1,
+    1185,    -1,    -1,    -1,    -1,    -1,    -1,    10,  1193,  1194,
+    1195,    -1,    -1,   116,   117,   118,   119,   120,    21,    22,
+     123,   124,   125,   126,    -1,   128,   129,   130,   131,   132,
+    1215,   134,   135,  1218,    -1,    -1,    -1,   140,    -1,   653,
+     654,    -1,  1227,   657,   658,   659,   660,    -1,   662,    -1,
+      -1,   665,   666,   667,   668,   669,   670,   671,   672,   673,
+     674,   675,   676,   677,   678,   679,   680,   681,   682,   683,
+     684,    -1,    -1,    -1,   177,   178,   179,   180,   181,   182,
+     183,   184,   185,   186,    -1,    -1,    -1,    -1,    -1,    -1,
+    1275,    -1,  1277,    -1,   197,   198,    -1,    -1,  1283,    -1,
+      -1,    -1,    -1,    -1,    -1,   108,   109,   110,   111,   112,
+     113,   114,   115,   116,   117,   118,   119,   120,   121,   122,
+     123,   124,   125,   126,   127,   128,   129,   130,   131,   132,
+     133,   134,   135,   136,   137,   138,  1321,   140,   141,   142,
+     143,   144,   145,   146,    -1,    -1,    -1,    -1,   762,    -1,
+      -1,    -1,    -1,  1338,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,  1352,  1353,    -1,
+      -1,   174,   175,    -1,   177,   178,   179,   180,   181,   182,
+     183,   184,   185,   186,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,  1376,    -1,    -1,   197,   198,    -1,  1382,  1383,    -1,
+      -1,    -1,    -1,  1388,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    21,    22,    -1,    19,    -1,
+      -1,    -1,    -1,    -1,    25,    -1,    -1,    -1,    -1,    -1,
+      31,    -1,    -1,    -1,    -1,    -1,    -1,   851,    -1,    -1,
+      41,    -1,    -1,  1428,    -1,    -1,    -1,  1432,    49,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,  1352,  1353,    -1,    -1,   174,   175,    -1,   177,
-     178,   179,   180,   181,   182,   183,   184,   185,   186,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,  1376,    -1,    -1,   197,
-     198,    -1,  1382,  1383,    -1,  1385,  1386,    -1,    -1,    -1,
-       1,    -1,    -1,    -1,     5,     6,     7,    -1,     9,    10,
-      11,    -1,    13,    -1,    15,    16,    17,    18,    19,    -1,
-      -1,    -1,    -1,    -1,    25,    26,    27,    28,    29,    -1,
-      31,    -1,   851,    -1,    -1,    -1,  1426,    38,    39,    40,
-    1430,    42,    -1,    44,    45,    -1,    -1,    48,    -1,    50,
-      51,    52,    -1,    54,    55,    -1,    -1,    58,    59,    -1,
-      -1,  1451,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,
-      71,    72,    73,    -1,    75,    76,    77,    78,    79,    80,
+      -1,    -1,    -1,    64,    -1,    -1,    -1,    -1,  1453,    -1,
+      71,    72,    73,    74,    75,    76,    77,    78,    79,    80,
       81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
-      91,    -1,    93,    94,    95,    -1,    -1,    98,    99,   100,
-     101,   102,   103,   104,   105,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,
-      -1,    -1,    -1,    -1,  1514,    -1,    -1,    -1,   947,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,  1526,    -1,   139,    -1,
-    1530,  1531,    -1,    -1,    -1,    -1,   147,   148,   149,   150,
-     151,    -1,   153,    -1,   155,   156,   157,   158,   159,   160,
-     161,   162,   163,    -1,   165,   166,    33,    -1,    -1,    -1,
+      91,    92,    93,    94,    95,    96,    97,    98,    99,   100,
+     101,   102,   103,    -1,    -1,    -1,    -1,  1492,    -1,    -1,
+     116,   117,   118,   119,   120,    -1,    -1,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,   132,    -1,   134,   135,
+      -1,    -1,  1517,   947,   140,   141,   142,    -1,   139,    -1,
+      -1,    -1,    -1,    -1,  1529,    -1,    -1,    -1,  1533,  1534,
+      -1,   152,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   163,    -1,    -1,    -1,    -1,    -1,    -1,   175,
+      -1,   177,   178,   179,   180,   181,   182,   183,   184,   185,
+     186,    -1,    -1,    -1,    33,    -1,    -1,    -1,    -1,    33,
+      -1,   197,   198,    -1,    -1,  1580,    -1,    -1,    -1,    -1,
+      -1,   202,    -1,    -1,    -1,    -1,   207,    -1,    -1,    -1,
+      -1,    60,    61,    -1,    -1,    -1,    60,    61,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,     5,     6,    -1,    -1,
+      -1,    -1,  1617,    -1,    -1,    -1,    15,    16,    17,    18,
+      19,    -1,    -1,    -1,    -1,  1630,    25,    -1,    27,    -1,
+      -1,    -1,    31,    -1,  1639,    -1,    -1,    -1,    -1,    -1,
+      39,    -1,    -1,  1648,    -1,    -1,    45,    -1,    -1,    48,
+    1084,    -1,    51,    -1,    -1,   124,    55,    -1,    -1,   128,
+     124,    -1,    -1,    -1,   128,    -1,    65,  1672,    -1,    68,
+      69,    70,    71,    72,    73,    -1,    75,    76,    77,    78,
+      79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
+      89,    90,    91,    -1,    93,    94,    95,    -1,    -1,    98,
+      99,   100,   101,   102,   103,   104,   175,    -1,    -1,    -1,
+     179,   175,   181,   182,    -1,   179,    -1,   181,   182,   118,
+     119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   127,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   207,    -1,
+     139,    -1,    -1,   207,    -1,    -1,    -1,    -1,   147,   148,
+     149,   150,   151,    -1,   153,   154,   155,   156,   157,   158,
+     159,   160,   161,   162,   163,    -1,    -1,   166,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   182,   183,   184,    -1,   186,  1576,    -1,   189,   190,
-      -1,    -1,    -1,    60,    61,    -1,    -1,   198,    -1,   200,
-      -1,   202,   203,   204,   205,   206,    -1,    -1,     5,     6,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    15,    16,
-      17,    18,    19,  1613,    -1,    -1,    -1,    -1,    25,    -1,
-      27,    -1,    -1,    -1,    31,    -1,  1626,    -1,    -1,    -1,
-      -1,    -1,    39,    -1,    -1,  1635,    -1,    -1,    45,    -1,
-      -1,    48,    -1,  1643,    51,    -1,    -1,   124,    55,    -1,
-      -1,   128,    -1,    -1,    -1,  1084,    -1,    -1,    65,    -1,
-      -1,    68,    69,    70,    71,    72,    73,  1667,    75,    76,
+      -1,    -1,    -1,   182,   183,   184,    -1,   186,    -1,    -1,
+     189,   190,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   198,
+      -1,   200,   201,   202,   203,    -1,   205,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,  1248,  1249,  1250,  1251,  1252,  1253,
+    1254,  1255,  1256,  1257,  1258,  1259,  1260,  1261,  1262,  1263,
+    1264,  1265,    -1,    -1,    -1,     1,    -1,    -1,    -1,     5,
+       6,     7,    -1,     9,    10,    11,    -1,    13,    -1,    15,
+      16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,
+      26,    27,    28,    29,    -1,    31,    -1,    -1,    -1,    -1,
+      -1,    -1,    38,    39,    40,    -1,    42,    -1,    44,    45,
+      -1,    -1,    48,    -1,    50,    51,    52,    -1,    54,    55,
+      -1,    -1,    58,    59,    -1,    -1,  1330,  1331,  1332,    65,
+      -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,    75,
+      76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
+      86,    87,    88,    89,    90,    91,    -1,    93,    94,    95,
+      -1,    -1,    98,    99,   100,   101,   102,   103,   104,   105,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,  1381,    -1,    -1,
+      -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   147,   148,   149,   150,   151,    -1,   153,    -1,   155,
+     156,   157,   158,   159,   160,   161,   162,   163,    -1,   165,
+     166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,    -1,
+     186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   198,    -1,   200,    -1,   202,   203,   204,   205,
+     206,     1,    -1,    -1,    -1,     5,     6,     7,    -1,     9,
+      10,    11,    -1,    13,    -1,    15,    16,    17,    18,    19,
+      -1,    -1,    -1,    -1,    -1,    25,    26,    27,    28,    29,
+      -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    38,    39,
+      40,    -1,    42,    -1,    44,    45,    -1,    -1,    48,    -1,
+      50,    51,    52,    -1,    54,    55,    -1,    -1,    58,    59,
+      -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,
+      -1,    71,    72,    73,    -1,    75,    76,    77,    78,    79,
+      80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
+      90,    91,    -1,    93,    94,    95,    -1,    -1,    98,    99,
+     100,   101,   102,   103,   104,   105,    -1,    -1,    -1,    -1,
+      -1,    -1,  1586,    -1,    -1,    -1,    -1,    -1,   118,   119,
+      -1,  1595,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,   148,   149,
+     150,   151,    -1,   153,    -1,   155,   156,   157,   158,   159,
+     160,   161,   162,   163,    -1,   165,   166,    -1,    -1,    -1,
+      -1,  1645,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   182,   183,   184,    -1,   186,    -1,    -1,   189,
+     190,    -1,    -1,    -1,    -1,    -1,  1670,    -1,   198,    -1,
+     200,    -1,   202,   203,   204,   205,   206,    -1,     1,  1683,
+      -1,    -1,     5,     6,     7,  1689,     9,    10,    11,    -1,
+      13,    -1,    15,    16,    17,    18,    19,    -1,    -1,    -1,
+      -1,    -1,    25,    26,    27,    28,    29,    -1,    31,    -1,
+      -1,    -1,    -1,    -1,    -1,    38,    39,    40,    -1,    42,
+      -1,    44,    45,    -1,    -1,    48,    -1,    50,    51,    52,
+      -1,    54,    55,    -1,    -1,    58,    59,    -1,    -1,    -1,
+      -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,
+      73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
+      83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
+      93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
+     103,   104,   105,   108,   109,   110,   111,   112,   113,   114,
+     115,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,
+      -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,   133,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,   143,   144,
+     145,    -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,
+     153,    -1,   155,   156,   157,   158,   159,   160,   161,   162,
+     163,    -1,   165,   166,    -1,    -1,    -1,    -1,    -1,   174,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,
+     183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   198,    -1,   200,    -1,   202,
+     203,   204,   205,   206,     1,    -1,    -1,    -1,     5,     6,
+       7,    -1,     9,    10,    11,    -1,    13,    -1,    15,    16,
+      17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    26,
+      27,    28,    29,    -1,    31,    -1,    -1,    -1,    -1,    -1,
+      -1,    38,    39,    40,    -1,    42,    -1,    44,    45,    -1,
+      -1,    48,    -1,    50,    51,    52,    -1,    54,    55,    -1,
+      -1,    58,    59,    -1,    -1,    -1,    -1,    -1,    65,    -1,
+      -1,    68,    69,    -1,    71,    72,    73,    -1,    75,    76,
       77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
       87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
-      -1,    98,    99,   100,   101,   102,   103,   104,   175,    -1,
-      -1,    -1,   179,    -1,   181,   182,    -1,    -1,    -1,    -1,
+      -1,    98,    99,   100,   101,   102,   103,   104,   105,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     127,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     207,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     147,   148,   149,   150,   151,    -1,   153,   154,   155,   156,
-     157,   158,   159,   160,   161,   162,   163,    -1,    -1,   166,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     147,   148,   149,   150,   151,    -1,   153,    -1,   155,   156,
+     157,   158,   159,   160,   161,   162,   163,    -1,   165,   166,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   182,   183,   184,    -1,   186,
       -1,    -1,   189,   190,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   198,    -1,   200,   201,   202,   203,    -1,   205,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,  1248,
-    1249,  1250,  1251,  1252,  1253,  1254,  1255,  1256,  1257,  1258,
-    1259,  1260,  1261,  1262,  1263,  1264,  1265,    -1,    -1,    -1,
+      -1,   198,    -1,   200,    -1,   202,   203,   204,   205,   206,
        1,    -1,    -1,    -1,     5,     6,     7,    -1,     9,    10,
       11,    -1,    13,    -1,    15,    16,    17,    18,    19,    -1,
       -1,    -1,    -1,    -1,    25,    26,    27,    28,    29,    -1,
       31,    -1,    -1,    -1,    -1,    -1,    -1,    38,    39,    40,
       -1,    42,    -1,    44,    45,    -1,    -1,    48,    -1,    50,
       51,    52,    -1,    54,    55,    -1,    -1,    58,    59,    -1,
-      -1,  1330,  1331,  1332,    65,    -1,    -1,    68,    69,    -1,
+      -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,
       71,    72,    73,    -1,    75,    76,    77,    78,    79,    80,
       81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
-      91,    -1,    93,    94,    95,    33,    -1,    98,    99,   100,
-     101,   102,   103,   104,   105,    33,    -1,    -1,    -1,    -1,
-      -1,    -1,  1381,    -1,    -1,    -1,    33,   118,   119,    -1,
-      -1,    -1,    60,    61,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    60,    61,    -1,    -1,    -1,    -1,   139,    -1,
-      -1,    -1,    -1,    60,    61,    -1,   147,   148,   149,   150,
+      91,    -1,    93,    94,    95,    -1,    -1,    98,    99,   100,
+     101,   102,   103,   104,   105,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,
      151,    -1,   153,    -1,   155,   156,   157,   158,   159,   160,
      161,   162,   163,    -1,   165,   166,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   182,   183,   184,    -1,   186,   124,    -1,   189,   190,
-     128,    -1,    -1,    -1,    -1,    -1,   124,   198,    -1,   200,
-     128,   202,   203,   204,   205,   206,    -1,   124,    -1,    -1,
-      -1,   128,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   182,   183,   184,    -1,   186,    -1,    -1,   189,   190,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   198,    -1,   200,
+      -1,   202,   203,   204,   205,   206,     1,    -1,    -1,    -1,
+       5,     6,     7,    -1,     9,    10,    11,    -1,    13,    -1,
+      15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,
+      25,    26,    27,    28,    29,    -1,    31,    -1,    -1,    -1,
+      -1,    -1,    -1,    38,    39,    40,    -1,    42,    -1,    44,
+      45,    -1,    -1,    48,    -1,    50,    51,    52,    -1,    54,
+      55,    -1,    -1,    58,    59,    -1,    -1,    -1,    -1,    -1,
+      65,    -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
+      85,    86,    87,    88,    89,    90,    91,    -1,    93,    94,
+      95,    -1,    -1,    98,    99,   100,   101,   102,   103,   104,
+     105,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   175,    -1,    -1,
-      -1,   179,    -1,   181,   182,    -1,    -1,   175,    -1,    -1,
-      -1,   179,    -1,   181,   182,    -1,    -1,    -1,   175,    -1,
-      -1,    -1,   179,    -1,   181,   182,    -1,    -1,    -1,   207,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,     1,    -1,   207,
-      -1,     5,     6,     7,    -1,     9,    10,    11,    -1,    13,
-     207,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
-      -1,    25,    26,    27,    28,    29,    -1,    31,    -1,    -1,
-      -1,    -1,    -1,  1582,    38,    39,    40,    -1,    42,    -1,
-      44,    45,  1591,    -1,    48,    -1,    50,    51,    52,    -1,
-      54,    55,    -1,    -1,    58,    59,    -1,    -1,    -1,    -1,
-      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
-      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
-      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
-      94,    95,  1641,    -1,    98,    99,   100,   101,   102,   103,
-     104,   105,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   118,   119,  1665,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,  1677,    -1,
-      -1,    -1,    -1,    -1,  1683,   139,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,   153,
-      -1,   155,   156,   157,   158,   159,   160,   161,   162,   163,
-      -1,   165,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,
-     184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   198,    -1,   200,    -1,   202,   203,
-     204,   205,   206,     1,    -1,    -1,    -1,     5,     6,     7,
-      -1,     9,    10,    11,    -1,    13,    -1,    15,    16,    17,
-      18,    19,    -1,    -1,    -1,    -1,    -1,    25,    26,    27,
-      28,    29,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,
-      38,    39,    40,    -1,    42,    -1,    44,    45,    -1,    -1,
-      48,    -1,    50,    51,    52,    -1,    54,    55,    -1,    -1,
-      58,    59,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,
-      68,    69,    -1,    71,    72,    73,    -1,    75,    76,    77,
-      78,    79,    80,    81,    82,    83,    84,    85,    86,    87,
-      88,    89,    90,    91,    -1,    93,    94,    95,    -1,    -1,
-      98,    99,   100,   101,   102,   103,   104,   105,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,
-     148,   149,   150,   151,    -1,   153,    -1,   155,   156,   157,
-     158,   159,   160,   161,   162,   163,    -1,   165,   166,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   182,   183,   184,    -1,   186,    -1,
-      -1,   189,   190,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     198,    -1,   200,    -1,   202,   203,   204,   205,   206,     1,
-      -1,    -1,    -1,     5,     6,     7,    -1,     9,    10,    11,
-      -1,    13,    -1,    15,    16,    17,    18,    19,    -1,    -1,
-      -1,    -1,    -1,    25,    26,    27,    28,    29,    -1,    31,
-      -1,    -1,    -1,    -1,    -1,    -1,    38,    39,    40,    -1,
-      42,    -1,    44,    45,    -1,    -1,    48,    -1,    50,    51,
-      52,    -1,    54,    55,    -1,    -1,    58,    59,    -1,    -1,
-      -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,
-      72,    73,    -1,    75,    76,    77,    78,    79,    80,    81,
-      82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
-      -1,    93,    94,    95,    -1,    -1,    98,    99,   100,   101,
-     102,   103,   104,   105,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,
-      -1,   153,    -1,   155,   156,   157,   158,   159,   160,   161,
-     162,   163,    -1,   165,   166,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     182,   183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   198,    -1,   200,    -1,
-     202,   203,   204,   205,   206,     1,    -1,    -1,    -1,     5,
-       6,     7,    -1,     9,    10,    11,    -1,    13,    -1,    15,
-      16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,
-      26,    27,    28,    29,    -1,    31,    -1,    -1,    -1,    -1,
-      -1,    -1,    38,    39,    40,    -1,    42,    -1,    44,    45,
-      -1,    -1,    48,    -1,    50,    51,    52,    -1,    54,    55,
-      -1,    -1,    58,    59,    -1,    -1,    -1,    -1,    -1,    65,
-      -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,    75,
-      76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
-      86,    87,    88,    89,    90,    91,    -1,    93,    94,    95,
-      -1,    -1,    98,    99,   100,   101,   102,   103,   104,   105,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   147,   148,   149,   150,   151,    -1,   153,    -1,   155,
-     156,   157,   158,   159,   160,   161,   162,   163,    -1,   165,
-     166,    -1,    33,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,    -1,
-     186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,    60,
-      61,    -1,   198,    -1,   200,    -1,   202,   203,   204,   205,
-     206,     5,     6,    -1,    -1,    -1,    -1,    -1,    -1,    13,
-      -1,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
-      -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
-      -1,    45,    -1,    -1,    48,    49,    -1,    51,    -1,    -1,
-      -1,    55,    -1,   124,    -1,    -1,    -1,   128,    -1,    -1,
-      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
-      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
-      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
-      94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
-     104,    -1,    -1,    -1,   175,    -1,    -1,    -1,   179,    -1,
-     181,   182,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   139,   207,    -1,    -1,    -1,
-      -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,   153,
-     154,   155,   156,   157,   158,   159,   160,   161,   162,   163,
-      -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,
-     184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,
-      -1,    -1,     5,     6,   198,    -1,   200,    -1,   202,   203,
-      13,   205,    15,    16,    17,    18,    19,    -1,    -1,    -1,
-      -1,    -1,    25,    -1,    27,    -1,    -1,    33,    31,    -1,
+      -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   147,   148,   149,   150,   151,    -1,   153,    -1,
+     155,   156,   157,   158,   159,   160,   161,   162,   163,    -1,
+     165,   166,    -1,    33,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,
+      -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,
+      60,    61,    -1,   198,    -1,   200,    -1,   202,   203,   204,
+     205,   206,     5,     6,    -1,    -1,    -1,    -1,    -1,    -1,
+      13,    -1,    15,    16,    17,    18,    19,    -1,    -1,    -1,
+      -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,
       -1,    -1,    45,    -1,    -1,    48,    49,    -1,    51,    -1,
-      -1,    -1,    55,    -1,    60,    61,    -1,    -1,    -1,    -1,
+      -1,    -1,    55,    -1,   124,    -1,    -1,    -1,   128,    -1,
       -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,
       73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
       83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
       93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
-     103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   118,   119,    -1,   124,    -1,
-      -1,    -1,   128,    -1,   127,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,
+     103,   104,    -1,    -1,    -1,   175,    -1,    -1,    -1,   179,
+      -1,   181,   182,    -1,    -1,   118,   119,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   139,   207,    -1,    -1,
       -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,
-     153,    -1,   155,   156,   157,   158,   159,   160,   161,   162,
-     163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,   175,
-      -1,    -1,    -1,   179,    -1,   181,   182,    -1,    -1,   182,
+     153,   154,   155,   156,   157,   158,   159,   160,   161,   162,
+     163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,
      183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,
       -1,    -1,    -1,     5,     6,   198,    -1,   200,    -1,   202,
-     203,   207,   205,    15,    16,    17,    18,    19,    -1,    -1,
+     203,    13,   205,    15,    16,    17,    18,    19,    -1,    -1,
       -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    33,    31,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,
-      -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,
+      -1,    -1,    -1,    45,    -1,    -1,    48,    49,    -1,    51,
       -1,    -1,    -1,    55,    -1,    60,    61,    -1,    -1,    -1,
-      -1,    -1,    -1,    65,    -1,    -1,    68,    69,    70,    71,
+      -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,
       72,    73,    -1,    75,    76,    77,    78,    79,    80,    81,
       82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
       -1,    93,    94,    95,    -1,    -1,    98,    99,   100,   101,
@@ -3117,7 +3124,7 @@ static const yytype_int16 yycheck[] =
       -1,    -1,    -1,   128,    -1,   127,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,
-      -1,   153,   154,   155,   156,   157,   158,   159,   160,   161,
+      -1,   153,    -1,   155,   156,   157,   158,   159,   160,   161,
      162,   163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,
      175,    -1,    -1,    -1,   179,    -1,   181,   182,    -1,    -1,
      182,   183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,
@@ -3127,7 +3134,7 @@ static const yytype_int16 yycheck[] =
       31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,
       -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,
       51,    -1,    -1,    -1,    55,    -1,    60,    61,    -1,    -1,
-      -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,
+      -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,    70,
       71,    72,    73,    -1,    75,    76,    77,    78,    79,    80,
       81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
       91,    -1,    93,    94,    95,    -1,    -1,    98,    99,   100,
@@ -3138,29 +3145,29 @@ static const yytype_int16 yycheck[] =
       -1,    -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,
      151,    -1,   153,   154,   155,   156,   157,   158,   159,   160,
      161,   162,   163,    -1,    -1,   166,    -1,    -1,    -1,    -1,
-      -1,   175,    -1,    -1,    -1,   179,    -1,    -1,   182,    -1,
+      -1,   175,    -1,    -1,    -1,   179,    -1,   181,   182,    -1,
       -1,   182,   183,   184,    -1,   186,    -1,    -1,   189,   190,
       -1,    -1,    -1,    -1,    -1,     5,     6,   198,    -1,   200,
       -1,   202,   203,   207,   205,    15,    16,    17,    18,    19,
       -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,
-      -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,
+      33,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,
       -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,
-      -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,
+      -1,    51,    -1,    -1,    -1,    55,    -1,    60,    61,    -1,
       -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,
       -1,    71,    72,    73,    -1,    75,    76,    77,    78,    79,
       80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
       90,    91,    -1,    93,    94,    95,    -1,    -1,    98,    99,
      100,   101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   127,    -1,    -1,
+      -1,   124,    -1,    -1,    -1,   128,    -1,   127,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,   148,   149,
-     150,   151,    -1,   153,    -1,   155,   156,   157,   158,   159,
+     150,   151,    -1,   153,   154,   155,   156,   157,   158,   159,
      160,   161,   162,   163,    -1,    -1,   166,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   175,    -1,    -1,    -1,   179,    -1,   181,   182,
       -1,    -1,   182,   183,   184,    -1,   186,    -1,    -1,   189,
      190,    -1,    -1,    -1,    -1,    -1,     5,     6,   198,    -1,
-     200,   201,   202,   203,    -1,   205,    15,    16,    17,    18,
+     200,    -1,   202,   203,   207,   205,    15,    16,    17,    18,
       19,    -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,
       -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,
@@ -3255,7 +3262,7 @@ static const yytype_int16 yycheck[] =
       -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,
       -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,
-      -1,     5,     6,   198,    -1,   200,    -1,   202,   203,    -1,
+      -1,     5,     6,   198,    -1,   200,   201,   202,   203,    -1,
      205,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
       -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
@@ -3267,14 +3274,14 @@ static const yytype_int16 yycheck[] =
       94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
      104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,   153,
       -1,   155,   156,   157,   158,   159,   160,   161,   162,   163,
       -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,
      184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,
-      -1,    -1,     5,     6,   198,   199,   200,    -1,   202,   203,
+      -1,    -1,     5,     6,   198,    -1,   200,    -1,   202,   203,
       -1,   205,    15,    16,    17,    18,    19,    -1,    -1,    -1,
       -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,
@@ -3305,15 +3312,15 @@ static const yytype_int16 yycheck[] =
       -1,    93,    94,    95,    -1,    -1,    98,    99,   100,   101,
      102,   103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,
       -1,   153,    -1,   155,   156,   157,   158,   159,   160,   161,
      162,   163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
      182,   183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,
-      -1,    -1,    -1,    -1,     5,     6,   198,    -1,   200,    -1,
-     202,   203,    13,   205,    15,    16,    17,    18,    19,    -1,
+      -1,    -1,    -1,    -1,     5,     6,   198,   199,   200,    -1,
+     202,   203,    -1,   205,    15,    16,    17,    18,    19,    -1,
       -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    -1,
       31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,
       -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,
@@ -3324,7 +3331,7 @@ static const yytype_int16 yycheck[] =
       91,    -1,    93,    94,    95,    -1,    -1,    98,    99,   100,
      101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,
      151,    -1,   153,    -1,   155,   156,   157,   158,   159,   160,
@@ -3332,7 +3339,7 @@ static const yytype_int16 yycheck[] =
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   182,   183,   184,    -1,   186,    -1,    -1,   189,   190,
       -1,    -1,    -1,    -1,    -1,     5,     6,   198,    -1,   200,
-      -1,   202,   203,    -1,   205,    15,    16,    17,    18,    19,
+      -1,   202,   203,    13,   205,    15,    16,    17,    18,    19,
       -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,
       -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,
       -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,
@@ -3343,7 +3350,7 @@ static const yytype_int16 yycheck[] =
       90,    91,    -1,    93,    94,    95,    -1,    -1,    98,    99,
      100,   101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   127,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,   148,   149,
      150,   151,    -1,   153,    -1,   155,   156,   157,   158,   159,
@@ -3375,13 +3382,13 @@ static const yytype_int16 yycheck[] =
       -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,
       48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,    -1,
-      -1,    -1,    -1,    61,    -1,    -1,    -1,    65,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,
       68,    69,    -1,    71,    72,    73,    -1,    75,    76,    77,
       78,    79,    80,    81,    82,    83,    84,    85,    86,    87,
       88,    89,    90,    91,    -1,    93,    94,    95,    -1,    -1,
       98,    99,   100,   101,   102,   103,   104,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   127,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,
      148,   149,   150,   151,    -1,   153,    -1,   155,   156,   157,
@@ -3394,7 +3401,7 @@ static const yytype_int16 yycheck[] =
       27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,
       -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,
-      -1,    58,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,
+      -1,    -1,    -1,    -1,    61,    -1,    -1,    -1,    65,    -1,
       -1,    68,    69,    -1,    71,    72,    73,    -1,    75,    76,
       77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
       87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
@@ -3413,14 +3420,14 @@ static const yytype_int16 yycheck[] =
       -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,
       -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,
+      -1,    -1,    58,    -1,    -1,    -1,    -1,    -1,    -1,    65,
       -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,    75,
       76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
       86,    87,    88,    89,    90,    91,    -1,    93,    94,    95,
       -1,    -1,    98,    99,   100,   101,   102,   103,   104,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   147,   148,   149,   150,   151,    -1,   153,    -1,   155,
      156,   157,   158,   159,   160,   161,   162,   163,    -1,    -1,
@@ -3439,14 +3446,14 @@ static const yytype_int16 yycheck[] =
       95,    -1,    -1,    98,    99,   100,   101,   102,   103,   104,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,   147,   148,   149,   150,   151,    -1,   153,    -1,
      155,   156,   157,   158,   159,   160,   161,   162,   163,    -1,
       -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,
       -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,
-      -1,     5,     6,   198,    -1,   200,   201,   202,   203,    -1,
+      -1,     5,     6,   198,    -1,   200,    -1,   202,   203,    -1,
      205,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
       -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
@@ -3465,17 +3472,17 @@ static const yytype_int16 yycheck[] =
       -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,
      184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,
-      -1,    -1,     5,     6,   198,    -1,   200,    -1,   202,   203,
+      -1,    -1,     5,     6,   198,    -1,   200,   201,   202,   203,
       -1,   205,    15,    16,    17,    18,    19,    -1,    -1,    -1,
-      -1,    -1,    25,    26,    27,    28,    -1,    -1,    31,    -1,
+      -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,
-      -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,    52,
+      -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,
       -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,
       73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
       83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
       93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
-     103,   104,   105,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,
@@ -3484,8 +3491,46 @@ static const yytype_int16 yycheck[] =
      163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,
      183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,
+      -1,    -1,    -1,     5,     6,   198,    -1,   200,    -1,   202,
+     203,    -1,   205,    15,    16,    17,    18,    19,    -1,    -1,
+      -1,    -1,    -1,    25,    26,    27,    28,    -1,    -1,    31,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,
+      -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,
+      52,    -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,
+      72,    73,    -1,    75,    76,    77,    78,    79,    80,    81,
+      82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
+      -1,    93,    94,    95,    -1,    -1,    98,    99,   100,   101,
+     102,   103,   104,   105,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,
+      -1,   153,    -1,   155,   156,   157,   158,   159,   160,   161,
+     162,   163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     182,   183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,
+      -1,    -1,     5,     6,    -1,    -1,   198,    -1,   200,    -1,
+     202,   203,    15,    16,    17,    18,    19,    -1,    -1,    -1,
+      -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,
+      -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,
+      -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,
+      73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
+      83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
+      93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
+     103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,
+     153,    -1,   155,   156,   157,   158,   159,   160,   161,   162,
+     163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,
+     183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,
       -1,     5,     6,    -1,    -1,   198,    -1,   200,    -1,   202,
-     203,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
+     203,    15,    16,    17,    18,    19,    -1,    -1,    22,    -1,
       -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
       -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,
@@ -3496,7 +3541,7 @@ static const yytype_int16 yycheck[] =
       94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
      104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,   153,
       -1,   155,   156,   157,   158,   159,   160,   161,   162,   163,
@@ -3504,7 +3549,7 @@ static const yytype_int16 yycheck[] =
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,
      184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,
        5,     6,    -1,    -1,   198,    -1,   200,    -1,   202,   203,
-      15,    16,    17,    18,    19,    -1,    -1,    22,    -1,    -1,
+      15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,
       25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,
       45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,
@@ -3519,152 +3564,129 @@ static const yytype_int16 yycheck[] =
       -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,   147,   148,   149,   150,   151,    -1,   153,    -1,
      155,   156,   157,   158,   159,   160,   161,   162,   163,    -1,
-      -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,
-      -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,     5,
-       6,    -1,    -1,   198,    -1,   200,    -1,   202,   203,    15,
-      16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,
-      -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,
-      -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,
-      -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,    75,
-      76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
-      86,    87,    88,    89,    90,    91,    -1,    93,    94,    95,
-      -1,    -1,    98,    99,   100,   101,   102,   103,   104,    -1,
+      19,   166,    -1,    -1,    -1,    -1,    25,    -1,    -1,    -1,
+      -1,    -1,    31,    -1,    -1,    -1,    -1,   182,   183,   184,
+      -1,   186,    41,    -1,   189,   190,    -1,    -1,    -1,    -1,
+      49,    -1,    -1,   198,    -1,   200,    -1,   202,   203,    -1,
+      -1,    -1,    -1,    -1,    -1,    64,    -1,    -1,    -1,    -1,
+      -1,    -1,    71,    72,    73,    74,    75,    76,    77,    78,
+      79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
+      89,    90,    91,    92,    93,    94,    95,    96,    97,    98,
+      99,   100,   101,   102,   103,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    19,    -1,    -1,    -1,    -1,
+      -1,    25,    -1,    -1,    -1,    -1,    -1,    31,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    41,    -1,    -1,
+     139,    -1,    -1,    -1,    -1,    49,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   152,    -1,    -1,    -1,    -1,    -1,    -1,
+      64,    -1,    -1,    -1,   163,    -1,   165,    71,    72,    73,
+      74,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    92,    93,
+      94,    95,    96,    97,    98,    99,   100,   101,   102,   103,
+      -1,    -1,    -1,   202,    -1,   204,    -1,    -1,    19,    -1,
+      -1,    -1,    -1,    -1,    25,    -1,    -1,    -1,    -1,    -1,
+      31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      41,    -1,    -1,    -1,    -1,   139,    -1,    -1,    49,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   152,    -1,
+      -1,    -1,    -1,    64,    -1,    -1,    -1,    -1,    -1,   163,
+      71,    72,    73,    74,    75,    76,    77,    78,    79,    80,
+      81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
+      91,    92,    93,    94,    95,    96,    97,    98,    99,   100,
+     101,   102,   103,    -1,    -1,    -1,    -1,    19,   202,    -1,
+      -1,    -1,    -1,    -1,    -1,    21,    22,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    38,    -1,    -1,    -1,    -1,    -1,   139,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   147,   148,   149,   150,   151,    -1,   153,    -1,   155,
-     156,   157,   158,   159,   160,   161,   162,   163,    -1,    19,
-     166,    -1,    -1,    -1,    -1,    25,    -1,    -1,    -1,    -1,
-      -1,    31,    -1,    -1,    -1,    -1,   182,   183,   184,    -1,
-     186,    41,    -1,   189,   190,    -1,    -1,    -1,    -1,    49,
-      -1,    -1,   198,    -1,   200,    -1,   202,   203,    -1,    -1,
-      -1,    -1,    -1,    -1,    64,    -1,    -1,    -1,    -1,    -1,
-      -1,    71,    72,    73,    74,    75,    76,    77,    78,    79,
-      80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
-      90,    91,    92,    93,    94,    95,    96,    97,    98,    99,
-     100,   101,   102,   103,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    19,    -1,    -1,    -1,    -1,    -1,
-      25,    -1,    -1,    -1,    -1,    -1,    31,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    41,    -1,    -1,   139,
-      -1,    -1,    -1,    -1,    49,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   152,    -1,    -1,    -1,    -1,    -1,    -1,    64,
-      -1,    -1,    -1,   163,    -1,   165,    71,    72,    73,    74,
-      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
-      85,    86,    87,    88,    89,    90,    91,    92,    93,    94,
-      95,    96,    97,    98,    99,   100,   101,   102,   103,    -1,
-      -1,    -1,   202,    -1,   204,    -1,    -1,    19,    -1,    -1,
-      -1,    -1,    -1,    25,    -1,    -1,    -1,    -1,    -1,    31,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    41,
-      -1,    -1,    -1,    -1,   139,    -1,    -1,    49,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   152,    -1,    -1,
-      -1,    -1,    64,    -1,    -1,    -1,    -1,    -1,   163,    71,
-      72,    73,    74,    75,    76,    77,    78,    79,    80,    81,
-      82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
-      92,    93,    94,    95,    96,    97,    98,    99,   100,   101,
-     102,   103,    -1,    -1,    -1,    -1,    19,   202,    -1,    -1,
-      -1,    -1,    -1,    -1,    21,    22,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    38,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     152,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    71,    72,
-      73,   163,    75,    76,    77,    78,    79,    80,    81,    82,
-      83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
-      93,    94,    95,    -1,    -1,    98,    99,   100,   101,    -1,
-      21,    22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     202,   108,   109,   110,   111,   112,   113,   114,   115,   116,
-     117,   118,   119,   120,   121,   122,   123,   124,   125,    -1,
-      -1,   128,   129,   130,    -1,    -1,   133,   134,   135,   136,
-     137,    -1,    -1,   140,   141,   142,   143,   144,   145,   146,
-      -1,   154,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     163,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    21,    22,   175,    -1,
-     177,   178,   179,   180,   181,   182,   183,   184,   185,   186,
-      -1,    -1,   189,   190,    -1,   116,   117,   118,   119,   120,
-     197,   198,   123,   124,   125,   126,    -1,   128,   129,   130,
-     131,   132,    -1,   134,   135,    -1,    -1,   138,    -1,   140,
-     141,   142,    -1,    -1,    -1,   146,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    21,    22,   175,    -1,   177,   178,   179,   180,
-     181,   182,   183,   184,   185,   186,    -1,    -1,    -1,    -1,
-      -1,   116,   117,   118,   119,   120,   197,   198,   123,   124,
-     125,   126,    -1,   128,   129,   130,   131,   132,    -1,   134,
-     135,    -1,    21,    22,    -1,   140,   141,   142,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    21,    22,
-     175,    -1,   177,   178,   179,   180,   181,   182,   183,   184,
-     185,   186,    -1,    -1,    -1,    -1,    -1,   116,   117,   118,
-     119,   120,   197,   198,   123,   124,   125,   126,    -1,   128,
-     129,   130,   131,   132,    -1,   134,   135,    -1,    21,    22,
-      -1,   140,    -1,   142,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   116,   117,   118,
-     119,   120,    -1,    -1,   123,   124,   125,   126,    -1,   128,
-     129,   130,   131,   132,    -1,   134,   135,    -1,   177,   178,
-     179,   180,   181,   182,   183,   184,   185,   186,    -1,    -1,
-      -1,    -1,    -1,   116,   117,   118,   119,   120,   197,   198,
-     123,   124,   125,   126,    -1,   128,   129,   130,   131,   132,
-      -1,   134,   135,    -1,    21,    22,    -1,   140,   177,   178,
-     179,   180,   181,   182,   183,   184,   185,   186,    -1,    -1,
-      -1,    -1,    -1,   116,   117,   118,   119,   120,   197,   198,
-     123,   124,   125,   126,    -1,   128,   129,   130,   131,   132,
-      -1,   134,   135,    -1,   177,   178,   179,   180,   181,   182,
-     183,   184,   185,   186,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   197,   198,    -1,    19,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      21,    22,    -1,    -1,    -1,   178,   179,   180,   181,   182,
-     183,   184,   185,   186,    -1,    -1,    -1,    -1,    -1,   116,
-     117,   118,   119,   120,   197,   198,   123,   124,   125,   126,
-      -1,   128,   129,   130,   131,   132,    -1,   134,   135,    71,
-      72,    73,    -1,    75,    76,    77,    78,    79,    80,    81,
+      -1,   152,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    71,
+      72,    73,   163,    75,    76,    77,    78,    79,    80,    81,
       82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
       -1,    93,    94,    95,    -1,    -1,    98,    99,   100,   101,
-      -1,    -1,    -1,    -1,    -1,    -1,    19,    -1,    -1,    -1,
-      -1,    -1,   179,   180,   181,   182,   183,   184,   185,   186,
-      -1,    -1,    -1,    -1,    -1,   116,   117,   118,   119,   120,
-     197,   198,   123,   124,   125,   126,    -1,   128,   129,   130,
-     131,   132,    -1,   134,   135,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   154,    -1,    -1,    -1,    -1,    -1,    71,    72,
-      73,   163,    75,    76,    77,    78,    79,    80,    81,    82,
-      83,    84,    85,    86,    87,    88,    89,    90,    91,    35,
-      93,    94,    95,    -1,    -1,    98,    99,   100,   101,   180,
-     181,   182,   183,   184,   185,   186,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   197,   198,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    71,    -1,    73,    -1,    75,
+      -1,    21,    22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   202,   108,   109,   110,   111,   112,   113,   114,   115,
+     116,   117,   118,   119,   120,   121,   122,   123,   124,   125,
+      -1,    -1,   128,   129,   130,    -1,    -1,   133,   134,   135,
+     136,   137,    -1,    -1,   140,   141,   142,   143,   144,   145,
+     146,    -1,   154,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   163,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    21,    22,   175,
+      -1,   177,   178,   179,   180,   181,   182,   183,   184,   185,
+     186,    -1,    -1,   189,   190,    -1,   116,   117,   118,   119,
+     120,   197,   198,   123,   124,   125,   126,    -1,   128,   129,
+     130,   131,   132,    -1,   134,   135,    -1,    -1,   138,    -1,
+     140,   141,   142,    -1,    -1,    -1,   146,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    21,    22,   175,   176,   177,   178,   179,
+     180,   181,   182,   183,   184,   185,   186,    -1,    -1,    -1,
+      -1,    -1,   116,   117,   118,   119,   120,   197,   198,   123,
+     124,   125,   126,    -1,   128,   129,   130,   131,   132,    -1,
+     134,   135,    21,    22,   138,    -1,   140,   141,   142,    -1,
+      -1,    -1,   146,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    21,
+      22,   175,    -1,   177,   178,   179,   180,   181,   182,   183,
+     184,   185,   186,    -1,    -1,    -1,    -1,    -1,   116,   117,
+     118,   119,   120,   197,   198,   123,   124,   125,   126,    -1,
+     128,   129,   130,   131,   132,    -1,   134,   135,    21,    22,
+     138,    -1,   140,   141,   142,    -1,    -1,    -1,   146,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   116,   117,   118,
+     119,   120,    -1,    -1,   123,   124,   125,   126,    -1,   128,
+     129,   130,   131,   132,    -1,   134,   135,   175,    -1,   177,
+     178,   179,   180,   181,   182,   183,   184,   185,   186,    -1,
+      -1,    -1,    -1,    -1,   116,   117,   118,   119,   120,   197,
+     198,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
+     132,    -1,   134,   135,    -1,    -1,    -1,    -1,    -1,   178,
+     179,   180,   181,   182,   183,   184,   185,   186,    -1,    -1,
+      -1,    -1,    -1,   116,   117,   118,   119,   120,   197,   198,
+     123,   124,   125,   126,    -1,   128,   129,   130,   131,   132,
+      -1,   134,   135,    -1,    -1,    -1,    -1,   179,   180,   181,
+     182,   183,   184,   185,   186,    19,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   197,   198,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    19,   180,   181,   182,
+     183,   184,   185,   186,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   197,   198,    -1,    71,    72,    73,
+      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
+      94,    95,    -1,    -1,    98,    99,   100,   101,    71,    72,
+      73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
+      83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
+      93,    94,    95,    -1,    -1,    98,    99,   100,   101,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     154,    35,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   163,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   154,    -1,    -1,    -1,    -1,    -1,    71,    -1,    73,
+     163,    75,    76,    77,    78,    79,    -1,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
+      94,    95,    -1,    -1,    98,    99,   100,   101,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   118,   119,    71,    72,    73,    -1,
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
+      85,    86,    87,    88,    89,    90,    91,    -1,    93,    94,
+      95,    -1,    -1,    98,    99,   100,   101,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   163,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   129,   130,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   154,
+      -1,    -1,    -1,    -1,    -1,    71,    -1,    73,   163,    75,
       76,    77,    78,    79,    -1,    81,    82,    83,    84,    85,
       86,    87,    88,    89,    90,    91,    -1,    93,    94,    95,
-      -1,   154,    98,    99,   100,   101,    -1,    -1,    -1,    -1,
-     163,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   118,   119,    71,    72,    73,    -1,    75,    76,
-      77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
-      87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
-      -1,    98,    99,   100,   101,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   163,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   129,   130,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   154,    -1,    -1,
-      -1,    -1,    -1,    71,    -1,    73,   163,    75,    76,    77,
-      78,    79,    -1,    81,    82,    83,    84,    85,    86,    87,
-      88,    89,    90,    91,    -1,    93,    94,    95,    -1,    -1,
-      98,    99,   100,   101,    -1,    -1,    -1,    -1,    -1,    -1,
-     197,   198,    71,    -1,    73,    -1,    75,    76,    77,    78,
-      79,    -1,    81,    82,    83,    84,    85,    86,    87,    88,
-      89,    90,    91,    -1,    93,    94,    95,    -1,    -1,    98,
-      99,   100,   101,    -1,    71,    -1,    73,    -1,    75,    76,
+      -1,    -1,    98,    99,   100,   101,    -1,    -1,    -1,    -1,
+      -1,    -1,   197,   198,    71,    -1,    73,    -1,    75,    76,
       77,    78,    79,    -1,    81,    82,    83,    84,    85,    86,
-      87,    88,    89,    90,    91,   163,    93,    94,    95,    -1,
-      -1,    98,    99,   100,   101,    -1,    -1,    -1,    -1,    -1,
+      87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
+      -1,    98,    99,   100,   101,    -1,    71,    -1,    73,    -1,
+      75,    76,    77,    78,    79,    -1,    81,    82,    83,    84,
+      85,    86,    87,    88,    89,    90,    91,   163,    93,    94,
+      95,    -1,    -1,    98,    99,   100,   101,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   163,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   163,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   163
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   163
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
@@ -3673,174 +3695,174 @@ static const yytype_int16 yystos[] =
 {
        0,   209,     0,     7,    30,    32,    34,    40,    50,    56,
       80,   102,   103,   165,   186,   198,   204,   211,   212,   216,
-     225,   227,   228,   232,   280,   286,   317,   399,   407,   414,
-     424,   474,   479,   484,    19,    20,   163,   271,   272,   273,
+     225,   227,   228,   232,   281,   287,   318,   400,   408,   415,
+     425,   475,   480,   485,    19,    20,   163,   271,   272,   273,
      156,   233,   234,   146,   163,   186,   197,   229,   230,    57,
-      63,   404,   405,   163,   202,   214,   485,   475,   480,   139,
-     163,   305,    34,    63,   107,   132,   190,   200,   275,   276,
-     277,   278,   305,   211,   211,   211,     8,    36,   425,    62,
-     395,   174,   173,   176,   173,   185,   185,   229,   185,    22,
-      57,   185,   197,   231,   163,   211,   395,   404,   404,   404,
-     163,   139,   226,   277,   277,   277,   200,   140,   141,   142,
-     173,   199,   107,   285,   415,     5,     6,   421,    57,    63,
-     396,    15,    16,   156,   161,   163,   166,   200,   203,   218,
-     272,   156,   234,   229,   229,   229,   163,   163,   163,   406,
+      63,   405,   406,   163,   202,   214,   486,   476,   481,   139,
+     163,   306,    34,    63,   107,   132,   190,   200,   276,   277,
+     278,   279,   306,   211,   211,   211,     8,    36,   426,    62,
+     396,   174,   173,   176,   173,   185,   185,   229,   185,    22,
+      57,   185,   197,   231,   163,   211,   396,   405,   405,   405,
+     163,   139,   226,   278,   278,   278,   200,   140,   141,   142,
+     173,   199,   107,   286,   416,     5,     6,   422,    57,    63,
+     397,    15,    16,   156,   161,   163,   166,   200,   203,   218,
+     272,   156,   234,   229,   229,   229,   163,   163,   163,   407,
       57,    63,   213,   163,   163,   163,   163,   167,   224,   201,
-     273,   277,   277,   277,   277,   165,   238,   239,    57,    63,
-     287,   289,    57,    63,   408,   107,   107,    57,    63,   422,
-     205,   400,   167,   168,   169,   217,    15,    16,   156,   161,
+     273,   278,   278,   278,   278,   165,   238,   239,    57,    63,
+     288,   290,    57,    63,   409,   107,   107,    57,    63,   423,
+     205,   401,   167,   168,   169,   217,    15,    16,   156,   161,
      163,   218,   269,   270,   203,   231,   174,   190,   215,   176,
-     435,   239,   239,   167,   201,   165,   290,   163,   409,   426,
-     397,   203,   274,   365,   167,   168,   169,   173,   201,   163,
+     436,   239,   239,   167,   201,   165,   291,   163,   410,   427,
+     398,   203,   274,   366,   167,   168,   169,   173,   201,   163,
       19,    25,    31,    41,    49,    64,    71,    72,    73,    74,
       75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
       85,    86,    87,    88,    89,    90,    91,    92,    93,    94,
       95,    96,    97,    98,    99,   100,   101,   102,   103,   152,
-     202,   305,   429,   431,   432,   436,   442,   444,   473,    66,
-      79,    94,    99,   101,   164,   412,   413,   476,   481,    35,
+     202,   306,   430,   432,   433,   437,   443,   445,   474,    66,
+      79,    94,    99,   101,   164,   413,   414,   477,   482,    35,
       71,    73,    75,    76,    77,    78,    79,    81,    82,    83,
       84,    85,    86,    87,    88,    89,    90,    91,    93,    94,
-      95,    98,    99,   100,   101,   118,   119,   163,   283,   284,
-     288,   176,   410,   106,   419,   420,   206,   211,   398,   272,
-     203,   163,   391,   394,   269,   180,   180,   180,   200,   180,
-     180,   200,   435,   180,   180,   180,   180,   180,   200,   305,
+      95,    98,    99,   100,   101,   118,   119,   163,   284,   285,
+     289,   176,   411,   106,   420,   421,   206,   211,   399,   272,
+     203,   163,   392,   395,   269,   180,   180,   180,   200,   180,
+     180,   200,   436,   180,   180,   180,   180,   180,   200,   306,
      180,   200,    33,    60,    61,   124,   128,   175,   179,   182,
-     207,   198,   441,   177,   164,   486,   205,   205,    21,    22,
+     207,   198,   442,   177,   164,   487,   205,   205,    21,    22,
       38,   108,   109,   110,   111,   112,   113,   114,   115,   116,
      117,   118,   119,   120,   121,   122,   123,   124,   125,   128,
      129,   130,   133,   134,   135,   136,   137,   140,   141,   142,
      143,   144,   145,   146,   175,   177,   178,   179,   180,   181,
      182,   183,   184,   185,   186,   189,   190,   197,   198,    35,
-      35,   200,   281,   239,    75,    79,    93,    94,    98,    99,
-     100,   101,   430,   413,   163,   239,   365,   239,   272,   173,
-     176,   179,   389,   445,   451,   453,     5,     6,    15,    16,
+      35,   200,   282,   239,    75,    79,    93,    94,    98,    99,
+     100,   101,   431,   414,   163,   239,   366,   239,   272,   173,
+     176,   179,   390,   446,   452,   454,     5,     6,    15,    16,
       17,    18,    19,    25,    27,    31,    39,    45,    48,    51,
       55,    65,    68,    69,    80,   102,   103,   104,   118,   119,
      147,   148,   149,   150,   151,   153,   155,   156,   157,   158,
      159,   160,   161,   162,   166,   182,   183,   184,   189,   190,
-     198,   200,   202,   203,   205,   223,   225,   297,   305,   310,
-     322,   329,   332,   335,   339,   341,   343,   344,   346,   351,
-     354,   355,   356,   363,   364,   429,   490,   498,   509,   512,
-     525,   526,   529,   530,   455,   449,   163,   180,   457,   459,
-     461,   463,   465,   467,   469,   471,   355,   180,   200,   443,
-     447,   127,   302,   333,   355,    33,   179,    33,   179,   198,
-     207,   199,   355,   198,   207,   442,   205,   477,   482,   163,
-     284,   163,   284,   163,   199,    22,   163,   199,   151,   201,
-     365,   375,   376,   377,   126,   176,   282,   138,   294,   295,
-     334,   205,   176,   418,   427,   148,   163,   390,   393,   239,
-     163,   442,   127,   133,   174,   388,   473,   473,   440,   473,
-     180,   180,   180,   305,   307,   431,   489,   498,   509,   512,
-     525,   526,   529,   530,   305,   180,     5,   102,   103,   180,
+     198,   200,   202,   203,   205,   223,   225,   298,   306,   311,
+     323,   330,   333,   336,   340,   342,   344,   345,   347,   352,
+     355,   356,   357,   364,   365,   430,   491,   499,   510,   513,
+     526,   527,   530,   531,   456,   450,   163,   180,   458,   460,
+     462,   464,   466,   468,   470,   472,   356,   180,   200,   444,
+     448,   127,   303,   334,   356,    33,   179,    33,   179,   198,
+     207,   199,   356,   198,   207,   443,   205,   478,   483,   163,
+     285,   163,   285,   163,   199,    22,   163,   199,   151,   201,
+     366,   376,   377,   378,   126,   176,   283,   138,   295,   296,
+     335,   205,   176,   419,   428,   148,   163,   391,   394,   239,
+     163,   443,   127,   133,   174,   389,   474,   474,   441,   474,
+     180,   180,   180,   306,   308,   432,   490,   499,   510,   513,
+     526,   527,   530,   531,   306,   180,     5,   102,   103,   180,
      200,   180,   200,   200,   180,   180,   200,   180,   200,   180,
-     200,   180,   180,   200,    19,   180,   180,   356,   356,   200,
-     200,   200,   200,   200,   200,   222,   356,   356,   356,   356,
-     356,    13,    49,   302,   154,   163,   333,   491,   493,   203,
-     524,   200,   198,   279,   203,   205,   335,   340,   340,   340,
+     200,   180,   180,   200,    19,   180,   180,   357,   357,   200,
+     200,   200,   200,   200,   200,   222,   357,   357,   357,   357,
+     357,    13,    49,   303,   154,   163,   334,   492,   494,   203,
+     525,   200,   198,   280,   203,   205,   336,   341,   341,   341,
      201,    21,    22,   116,   117,   118,   119,   120,   123,   124,
      125,   126,   128,   129,   130,   131,   132,   134,   135,   138,
      140,   141,   142,   146,   175,   177,   178,   179,   180,   181,
-     182,   183,   184,   185,   186,   197,   198,   200,   473,   473,
-     201,   181,   437,   473,   281,   473,   281,   473,   281,   163,
-     378,   379,   473,   163,   381,   382,   201,   448,   333,   304,
-     473,   355,   201,   173,   528,   199,   199,   199,   355,   487,
-     378,   380,   381,   383,   163,   284,   108,   109,   110,   111,
+     182,   183,   184,   185,   186,   197,   198,   200,   474,   474,
+     201,   181,   438,   474,   282,   474,   282,   474,   282,   163,
+     379,   380,   474,   163,   382,   383,   201,   449,   334,   305,
+     474,   356,   201,   173,   529,   199,   199,   199,   356,   488,
+     379,   381,   382,   384,   163,   285,   108,   109,   110,   111,
      112,   113,   114,   115,   133,   143,   144,   145,   108,   109,
      110,   111,   112,   113,   114,   115,   127,   133,   143,   144,
-     145,   174,   200,     7,    50,   316,   204,   173,   204,   201,
-     473,   473,   127,   356,   205,   416,   305,   204,   205,   423,
-     200,    43,   173,   176,   389,   211,   388,   355,   181,   181,
-     181,   164,   173,   210,   211,   439,   499,   501,   308,   200,
-     180,   200,   330,   180,   180,   180,   519,   333,   442,   355,
-     523,   355,   323,   325,   355,   327,   355,   521,   333,   507,
-     510,   333,   180,   503,   442,   355,   355,   355,   355,   355,
-     355,   169,   170,   217,   200,    13,   199,   200,   127,   133,
-     174,   384,   528,   173,   528,   201,   148,   153,   180,   305,
-     345,   239,    70,   198,   201,   333,   493,   278,     4,   338,
-     203,   301,   279,    19,   154,   163,   429,    19,   154,   163,
-     429,   356,   356,   356,   356,   356,   356,   163,   356,   154,
-     163,   355,   356,   356,   429,   356,   356,   356,   525,   530,
-     356,   356,   356,   356,    22,   356,   356,   356,   356,   356,
-     356,   356,   356,   356,   356,   356,   129,   130,   154,   163,
-     197,   198,   352,   429,   355,   201,   333,   181,   181,   163,
-     433,   181,   282,   181,   282,   181,   282,   176,   181,   439,
-     176,   181,   439,   304,   528,   181,   439,   127,   355,   199,
-     163,   434,   211,   246,   247,   246,   247,   355,   148,   163,
-     385,   386,   428,   377,   377,   377,   356,   301,   163,   401,
-     403,   371,   355,   163,   163,   442,   388,   355,   211,   446,
-     452,   454,   473,   442,   442,   473,    70,   333,   493,   497,
-     163,   355,   473,   513,   515,   517,   442,   528,   181,   439,
-     173,   528,   201,   442,   442,   201,   442,   201,   442,   528,
-     442,   379,   528,   505,   382,   181,   201,   201,   201,   201,
-     201,   201,   355,   148,   163,   200,   260,   200,   355,   355,
-     355,   201,   154,   163,   200,   200,   347,   349,    13,   303,
-     523,   163,   201,   493,   491,   173,   201,   201,   199,   200,
-     281,     1,    26,    28,    29,    38,    40,    44,    52,    54,
+     145,   174,   200,     7,    50,   317,   204,   173,   204,   201,
+     474,   474,   127,   357,   205,   417,   306,   204,   205,   424,
+     200,    43,   173,   176,   390,   211,   389,   356,   181,   181,
+     181,   164,   173,   210,   211,   440,   500,   502,   309,   200,
+     180,   200,   331,   180,   180,   180,   520,   334,   443,   356,
+     524,   356,   324,   326,   356,   328,   356,   522,   334,   508,
+     511,   334,   180,   504,   443,   356,   356,   356,   356,   356,
+     356,   169,   170,   217,   200,    13,   199,   200,   127,   133,
+     174,   385,   529,   173,   529,   201,   148,   153,   180,   306,
+     346,   239,    70,   198,   201,   334,   494,   279,     4,   339,
+     203,   302,   280,    19,   154,   163,   430,    19,   154,   163,
+     430,   357,   357,   357,   357,   357,   357,   163,   357,   154,
+     163,   356,   357,   357,   430,   357,   357,   357,   526,   531,
+     357,   357,   357,   357,    22,   357,   357,   357,   357,   357,
+     357,   357,   357,   357,   357,   357,   129,   130,   154,   163,
+     197,   198,   353,   430,   356,   201,   334,   181,   181,   163,
+     434,   181,   283,   181,   283,   181,   283,   176,   181,   440,
+     176,   181,   440,   305,   529,   181,   440,   127,   356,   199,
+     163,   435,   211,   246,   247,   246,   247,   356,   148,   163,
+     386,   387,   429,   378,   378,   378,   357,   302,   163,   402,
+     404,   372,   356,   163,   163,   443,   389,   356,   211,   447,
+     453,   455,   474,   443,   443,   474,    70,   334,   494,   498,
+     163,   356,   474,   514,   516,   518,   443,   529,   181,   440,
+     173,   529,   201,   443,   443,   201,   443,   201,   443,   529,
+     443,   380,   529,   506,   383,   181,   201,   201,   201,   201,
+     201,   201,   356,   148,   163,   200,   260,   200,   356,   356,
+     356,   201,   154,   163,   200,   200,   348,   350,    13,   304,
+     524,   163,   201,   494,   492,   173,   201,   201,   199,   200,
+     282,     1,    26,    28,    29,    38,    40,    44,    52,    54,
       58,    59,    65,   105,   205,   206,   211,   235,   236,   245,
      256,   257,   259,   261,   262,   263,   264,   265,   266,   267,
-     268,   298,   306,   311,   312,   313,   314,   315,   317,   321,
-     342,   356,   338,   180,   200,   180,   200,   200,   200,   199,
-      19,   154,   163,   429,   176,   154,   163,   355,   200,   200,
-     154,   163,   355,     1,   200,   199,   173,   201,   456,   450,
-     173,   181,   204,   458,   181,   462,   181,   466,   181,   473,
-     470,   378,   473,   472,   381,   181,   201,   443,   473,   355,
-     174,   210,   402,   411,   211,   378,   478,   381,   483,   201,
-     200,    43,   173,   176,   179,   384,   296,   174,   402,   411,
-      40,   165,   206,   280,   372,   201,    43,   211,   388,   355,
-     211,   181,   181,   181,   493,   201,   201,   201,   181,   439,
-     201,   181,   442,   379,   382,   181,   201,   200,   442,   355,
-     201,   181,   181,   181,   181,   201,   181,   181,   201,   442,
-     181,   338,   200,   176,   220,   200,    43,   163,   319,    20,
-     173,   260,   201,   200,   133,   384,   355,   355,   442,   281,
-     200,   206,   528,   201,   173,   199,   198,   127,   133,   163,
-     174,   179,   336,   337,   282,   127,   355,   294,    61,   355,
-     163,   163,   211,   156,    58,   355,   239,   127,   355,   299,
+     268,   299,   307,   312,   313,   314,   315,   316,   318,   322,
+     343,   357,   339,   180,   200,   180,   200,   200,   200,   199,
+      19,   154,   163,   430,   176,   154,   163,   356,   200,   200,
+     154,   163,   356,     1,   200,   199,   173,   201,   457,   451,
+     173,   181,   204,   459,   181,   463,   181,   467,   181,   474,
+     471,   379,   474,   473,   382,   181,   201,   444,   474,   356,
+     174,   210,   403,   412,   211,   379,   479,   382,   484,   201,
+     200,    43,   173,   176,   179,   385,   297,   174,   403,   412,
+      40,   165,   206,   281,   373,   201,    43,   211,   389,   356,
+     211,   181,   181,   181,   494,   201,   201,   201,   181,   440,
+     201,   181,   443,   380,   383,   181,   201,   200,   443,   356,
+     201,   181,   181,   181,   181,   201,   181,   181,   201,   443,
+     181,   339,   200,   176,   220,   200,    43,   163,   320,    20,
+     173,   260,   201,   200,   133,   385,   356,   356,   443,   282,
+     200,   206,   529,   201,   173,   199,   198,   127,   133,   163,
+     174,   179,   337,   338,   283,   127,   356,   295,    61,   356,
+     163,   163,   211,   156,    58,   356,   239,   127,   356,   300,
      211,   211,    10,    10,    11,   243,    13,     9,    42,   211,
-     211,   211,   211,   211,   211,    66,   318,   211,   108,   109,
+     211,   211,   211,   211,   211,    66,   319,   211,   108,   109,
      110,   111,   112,   113,   114,   115,   121,   122,   127,   133,
-     136,   137,   143,   144,   145,   174,   281,   357,   355,   359,
-     355,   201,   333,   355,   180,   200,   356,   200,   199,   355,
-     198,   201,   333,   200,   199,   353,   201,   333,   163,   438,
-     163,   460,   464,   468,   443,   355,   163,   210,   488,   206,
-     206,   355,   163,   163,   473,   355,   206,   355,   401,   417,
-     163,     8,   365,   370,   163,   355,   211,   500,   502,   309,
-     201,   200,   163,   331,   181,   181,   181,   520,   303,   181,
-     324,   326,   328,   522,   508,   511,   181,   504,   200,   239,
-     201,   333,   221,   171,   355,   163,   173,   201,   333,   163,
-     200,    20,   133,   384,   355,   355,   355,   201,   201,   181,
-     282,   260,   201,   491,   163,   163,   200,   163,   163,   173,
-     201,   239,   355,    14,   355,   174,   174,   176,   156,   294,
-     355,   301,   200,   200,   200,   200,   200,   200,   205,   320,
-     393,   356,   356,   356,   356,   356,   356,   356,   356,   356,
-     356,   356,   525,   530,   356,   356,   356,   356,   356,   356,
-     356,   282,   442,   201,   473,   201,   201,   201,   361,   355,
-     355,   201,   491,   201,   355,   201,   174,   206,   201,    43,
-     384,    37,   291,   206,   174,    57,    63,   368,    67,   369,
-     211,   211,   200,   200,   355,   181,   514,   516,   518,   200,
-     201,   200,   356,   356,   356,   200,    70,   497,   200,   506,
-     200,   201,   355,   294,   201,   219,   201,   163,   201,    43,
-     319,   333,   355,   355,   201,   348,   181,    20,   199,   163,
-     336,   334,   294,   473,   355,   300,   355,   355,   260,   355,
-     355,   319,   392,   239,   181,   181,   473,   201,   201,   199,
-     201,   355,   163,   355,   292,   473,    47,   369,    46,   106,
-     366,   497,   497,   201,   200,   200,   200,   200,   302,   303,
-     333,   497,   200,   497,   201,   167,   204,   163,   201,   201,
-     133,   384,   345,   350,   333,   201,   201,   206,   201,   201,
-      20,   201,   201,   201,   206,   211,   393,   334,   358,   360,
-     181,   201,   205,   211,    33,   367,   366,   368,   200,   491,
-     494,   495,   496,   496,   355,   497,   497,   491,   492,   201,
-     201,   528,   496,   497,   492,   355,   204,   355,   355,   345,
-     201,   291,    12,   244,   239,   333,   239,   239,   176,   389,
-     362,   301,   373,   367,   385,   386,   387,   491,   173,   528,
-     201,   201,   201,   496,   496,   201,   201,   201,   492,   201,
-     204,   527,   355,   204,   245,   311,   312,   313,   314,   356,
-     211,   258,   201,   294,   294,   442,   388,   293,   288,   374,
-     201,   200,   201,   201,   201,    53,   199,   527,   355,   205,
-     248,   251,   239,   388,   355,   206,   211,   288,   491,   355,
-     199,   527,   249,    12,    23,    24,   237,   240,   245,   294,
-     355,   211,   239,   201,   206,   301,   239,   200,   211,   211,
-     294,   250,   241,   355,   206,   205,   252,   255,   201,   291,
-     253,   245,   239,   301,   211,   242,   254,   252,   206,   240,
-     291
+     136,   137,   143,   144,   145,   174,   282,   358,   356,   360,
+     356,   201,   334,   356,   180,   200,   357,   200,   199,   356,
+     198,   201,   334,   200,   199,   354,   201,   334,   163,   439,
+     163,   461,   465,   469,   444,   356,   163,   210,   489,   206,
+     206,   356,   163,   163,   474,   356,   206,   356,   402,   418,
+     163,     8,   366,   371,   163,   356,   211,   501,   503,   310,
+     201,   200,   163,   332,   181,   181,   181,   521,   304,   181,
+     325,   327,   329,   523,   509,   512,   181,   505,   200,   239,
+     201,   334,   221,   171,   356,   163,   173,   201,   334,   163,
+     200,    20,   133,   385,   356,   356,   356,   201,   201,   181,
+     283,   260,   201,   492,   163,   163,   200,   163,   163,   173,
+     201,   239,   356,    14,   356,   174,   174,   176,   156,   295,
+     356,   302,   200,   200,   198,   274,   275,   275,   200,   200,
+     205,   321,   394,   357,   357,   357,   357,   357,   357,   357,
+     357,   357,   357,   357,   526,   531,   357,   357,   357,   357,
+     357,   357,   357,   283,   443,   201,   474,   201,   201,   201,
+     362,   356,   356,   201,   492,   201,   356,   201,   174,   206,
+     201,    43,   385,    37,   292,   206,   174,    57,    63,   369,
+      67,   370,   211,   211,   200,   200,   356,   181,   515,   517,
+     519,   200,   201,   200,   357,   357,   357,   200,    70,   498,
+     200,   507,   200,   201,   356,   295,   201,   219,   201,   163,
+     201,    43,   320,   334,   356,   356,   201,   349,   181,    20,
+     199,   163,   337,   335,   295,   474,   356,   301,   356,   356,
+     273,   200,   200,   356,   320,   393,   239,   181,   181,   474,
+     201,   201,   199,   201,   356,   163,   356,   293,   474,    47,
+     370,    46,   106,   367,   498,   498,   201,   200,   200,   200,
+     200,   303,   304,   334,   498,   200,   498,   201,   167,   204,
+     163,   201,   201,   133,   385,   346,   351,   334,   201,   201,
+     206,   201,   201,   199,   260,   356,   201,   201,   206,   211,
+     394,   335,   359,   361,   181,   201,   205,   211,    33,   368,
+     367,   369,   200,   492,   495,   496,   497,   497,   356,   498,
+     498,   492,   493,   201,   201,   529,   497,   498,   493,   356,
+     204,   356,   356,   346,   201,   292,    12,   244,   239,    20,
+     201,   239,   176,   390,   363,   302,   374,   368,   386,   387,
+     388,   492,   173,   529,   201,   201,   201,   497,   497,   201,
+     201,   201,   493,   201,   204,   528,   356,   204,   245,   312,
+     313,   314,   315,   357,   211,   258,   334,   239,   295,   443,
+     389,   294,   289,   375,   201,   200,   201,   201,   201,    53,
+     199,   528,   356,   205,   248,   251,   201,   295,   389,   356,
+     206,   211,   289,   492,   356,   199,   528,   249,    12,    23,
+      24,   237,   240,   245,   239,   356,   211,   239,   201,   206,
+     302,   239,   200,   211,   295,   211,   295,   250,   241,   356,
+     206,   205,   252,   255,   201,   292,   253,   245,   239,   302,
+     211,   242,   254,   252,   206,   240,   292
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
@@ -3861,86 +3883,87 @@ static const yytype_int16 yyr1[] =
      267,   266,   268,   268,   269,   269,   269,   269,   269,   269,
      270,   270,   271,   271,   271,   272,   272,   272,   272,   272,
      272,   272,   272,   272,   273,   273,   274,   274,   275,   275,
-     275,   275,   276,   276,   277,   277,   277,   277,   277,   277,
-     277,   278,   278,   279,   279,   280,   280,   281,   281,   281,
-     282,   282,   282,   283,   283,   283,   283,   283,   283,   283,
-     283,   283,   283,   283,   283,   283,   283,   283,   283,   283,
-     283,   283,   283,   283,   283,   283,   283,   283,   283,   283,
-     283,   283,   283,   283,   283,   283,   283,   283,   283,   283,
-     283,   283,   283,   283,   283,   283,   283,   283,   283,   283,
-     283,   283,   283,   283,   283,   283,   283,   283,   283,   283,
-     283,   283,   283,   283,   283,   283,   283,   283,   283,   283,
-     283,   283,   283,   283,   283,   283,   283,   283,   283,   283,
-     283,   283,   283,   283,   283,   283,   283,   283,   283,   283,
-     283,   283,   284,   284,   284,   284,   284,   284,   284,   284,
+     275,   276,   276,   276,   276,   277,   277,   278,   278,   278,
+     278,   278,   278,   278,   279,   279,   280,   280,   281,   281,
+     282,   282,   282,   283,   283,   283,   284,   284,   284,   284,
      284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
-     284,   284,   284,   284,   284,   284,   284,   285,   285,   286,
-     287,   287,   287,   288,   290,   289,   291,   292,   293,   291,
-     295,   296,   294,   297,   297,   297,   298,   298,   298,   298,
-     298,   298,   298,   298,   298,   298,   298,   298,   298,   298,
-     298,   298,   298,   298,   298,   299,   300,   298,   301,   301,
-     301,   302,   302,   303,   303,   304,   304,   305,   305,   305,
-     306,   306,   308,   309,   307,   307,   310,   310,   310,   310,
-     310,   310,   311,   312,   313,   313,   313,   314,   314,   315,
-     316,   316,   316,   317,   317,   318,   318,   319,   319,   320,
-     320,   321,   321,   321,   323,   324,   322,   325,   326,   322,
-     327,   328,   322,   330,   331,   329,   332,   332,   332,   333,
-     333,   333,   333,   334,   334,   334,   335,   335,   335,   336,
-     336,   336,   336,   336,   337,   337,   338,   338,   339,   340,
-     340,   341,   341,   341,   341,   341,   341,   341,   342,   342,
-     342,   342,   342,   342,   342,   342,   342,   342,   342,   342,
-     342,   342,   342,   342,   342,   342,   342,   342,   342,   343,
-     343,   344,   344,   345,   345,   346,   347,   348,   346,   349,
-     350,   346,   351,   351,   351,   351,   351,   351,   351,   352,
-     353,   351,   354,   354,   354,   354,   354,   354,   354,   355,
-     355,   355,   356,   356,   356,   356,   356,   356,   356,   356,
-     356,   356,   356,   356,   356,   356,   356,   356,   356,   356,
-     356,   356,   356,   356,   356,   356,   356,   356,   356,   356,
-     356,   356,   356,   356,   356,   356,   356,   356,   356,   356,
-     356,   356,   356,   356,   356,   356,   356,   356,   356,   356,
-     356,   356,   356,   356,   356,   356,   356,   356,   357,   358,
-     356,   356,   356,   356,   359,   360,   356,   356,   356,   361,
-     362,   356,   356,   356,   356,   356,   356,   356,   356,   356,
-     356,   356,   356,   356,   356,   356,   356,   356,   363,   363,
-     363,   364,   364,   364,   364,   364,   364,   364,   364,   364,
-     364,   364,   364,   364,   364,   364,   364,   365,   365,   366,
-     366,   366,   367,   367,   368,   368,   368,   369,   369,   370,
-     371,   371,   371,   372,   371,   373,   371,   374,   371,   375,
-     376,   376,   377,   377,   377,   377,   377,   378,   378,   379,
-     379,   380,   380,   380,   381,   382,   382,   383,   383,   383,
-     384,   384,   385,   385,   385,   386,   386,   387,   387,   388,
-     388,   388,   389,   389,   390,   390,   390,   390,   390,   391,
-     391,   392,   392,   392,   393,   393,   393,   394,   394,   394,
-     395,   395,   396,   396,   396,   397,   397,   398,   397,   399,
-     400,   399,   401,   401,   402,   402,   403,   403,   403,   404,
-     404,   404,   406,   405,   407,   408,   408,   408,   409,   410,
-     410,   411,   411,   412,   412,   413,   413,   415,   416,   417,
-     414,   418,   418,   419,   419,   420,   421,   421,   421,   421,
-     422,   422,   422,   423,   423,   425,   426,   427,   424,   428,
-     428,   428,   428,   428,   429,   429,   429,   429,   429,   429,
-     429,   429,   429,   429,   429,   429,   429,   429,   429,   429,
-     429,   429,   429,   429,   429,   429,   429,   429,   429,   429,
-     429,   430,   430,   430,   430,   430,   430,   430,   430,   431,
-     432,   432,   432,   433,   433,   433,   434,   434,   434,   434,
-     434,   435,   435,   435,   435,   435,   436,   437,   438,   436,
-     439,   439,   440,   440,   441,   441,   441,   441,   442,   442,
-     443,   443,   444,   444,   444,   444,   445,   446,   444,   444,
-     444,   444,   447,   444,   448,   444,   444,   444,   444,   444,
-     444,   444,   444,   444,   444,   444,   444,   444,   449,   450,
-     444,   444,   451,   452,   444,   453,   454,   444,   455,   456,
-     444,   444,   457,   458,   444,   459,   460,   444,   444,   461,
-     462,   444,   463,   464,   444,   444,   465,   466,   444,   467,
-     468,   444,   469,   470,   444,   471,   472,   444,   473,   473,
-     473,   475,   476,   477,   478,   474,   480,   481,   482,   483,
-     479,   485,   486,   487,   488,   484,   489,   489,   489,   489,
-     489,   489,   489,   490,   490,   490,   490,   490,   491,   491,
-     491,   491,   491,   491,   491,   491,   492,   492,   493,   494,
-     494,   495,   495,   496,   496,   497,   497,   499,   500,   498,
-     501,   502,   498,   503,   504,   498,   505,   506,   498,   507,
-     508,   498,   509,   510,   511,   509,   512,   513,   514,   512,
-     515,   516,   512,   517,   518,   512,   512,   519,   520,   512,
-     512,   521,   522,   512,   523,   523,   524,   525,   526,   526,
-     526,   527,   527,   528,   528,   529,   529,   530
+     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
+     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
+     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
+     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
+     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
+     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
+     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
+     284,   284,   284,   284,   284,   285,   285,   285,   285,   285,
+     285,   285,   285,   285,   285,   285,   285,   285,   285,   285,
+     285,   285,   285,   285,   285,   285,   285,   285,   285,   285,
+     286,   286,   287,   288,   288,   288,   289,   291,   290,   292,
+     293,   294,   292,   296,   297,   295,   298,   298,   298,   299,
+     299,   299,   299,   299,   299,   299,   299,   299,   299,   299,
+     299,   299,   299,   299,   299,   299,   299,   299,   300,   301,
+     299,   302,   302,   302,   303,   303,   304,   304,   305,   305,
+     306,   306,   306,   307,   307,   309,   310,   308,   308,   311,
+     311,   311,   311,   311,   311,   312,   313,   314,   314,   314,
+     315,   315,   316,   317,   317,   317,   318,   318,   319,   319,
+     320,   320,   321,   321,   322,   322,   322,   324,   325,   323,
+     326,   327,   323,   328,   329,   323,   331,   332,   330,   333,
+     333,   333,   334,   334,   334,   334,   335,   335,   335,   336,
+     336,   336,   337,   337,   337,   337,   337,   338,   338,   339,
+     339,   340,   341,   341,   342,   342,   342,   342,   342,   342,
+     342,   343,   343,   343,   343,   343,   343,   343,   343,   343,
+     343,   343,   343,   343,   343,   343,   343,   343,   343,   343,
+     343,   343,   344,   344,   345,   345,   346,   346,   347,   348,
+     349,   347,   350,   351,   347,   352,   352,   352,   352,   352,
+     352,   352,   353,   354,   352,   355,   355,   355,   355,   355,
+     355,   355,   356,   356,   356,   357,   357,   357,   357,   357,
+     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
+     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
+     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
+     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
+     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
+     357,   358,   359,   357,   357,   357,   357,   360,   361,   357,
+     357,   357,   362,   363,   357,   357,   357,   357,   357,   357,
+     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
+     357,   364,   364,   364,   365,   365,   365,   365,   365,   365,
+     365,   365,   365,   365,   365,   365,   365,   365,   365,   365,
+     366,   366,   367,   367,   367,   368,   368,   369,   369,   369,
+     370,   370,   371,   372,   372,   372,   373,   372,   374,   372,
+     375,   372,   376,   377,   377,   378,   378,   378,   378,   378,
+     379,   379,   380,   380,   381,   381,   381,   382,   383,   383,
+     384,   384,   384,   385,   385,   386,   386,   386,   387,   387,
+     388,   388,   389,   389,   389,   390,   390,   391,   391,   391,
+     391,   391,   392,   392,   393,   393,   393,   394,   394,   394,
+     395,   395,   395,   396,   396,   397,   397,   397,   398,   398,
+     399,   398,   400,   401,   400,   402,   402,   403,   403,   404,
+     404,   404,   405,   405,   405,   407,   406,   408,   409,   409,
+     409,   410,   411,   411,   412,   412,   413,   413,   414,   414,
+     416,   417,   418,   415,   419,   419,   420,   420,   421,   422,
+     422,   422,   422,   423,   423,   423,   424,   424,   426,   427,
+     428,   425,   429,   429,   429,   429,   429,   430,   430,   430,
+     430,   430,   430,   430,   430,   430,   430,   430,   430,   430,
+     430,   430,   430,   430,   430,   430,   430,   430,   430,   430,
+     430,   430,   430,   430,   431,   431,   431,   431,   431,   431,
+     431,   431,   432,   433,   433,   433,   434,   434,   434,   435,
+     435,   435,   435,   435,   436,   436,   436,   436,   436,   437,
+     438,   439,   437,   440,   440,   441,   441,   442,   442,   442,
+     442,   443,   443,   444,   444,   445,   445,   445,   445,   446,
+     447,   445,   445,   445,   445,   448,   445,   449,   445,   445,
+     445,   445,   445,   445,   445,   445,   445,   445,   445,   445,
+     445,   450,   451,   445,   445,   452,   453,   445,   454,   455,
+     445,   456,   457,   445,   445,   458,   459,   445,   460,   461,
+     445,   445,   462,   463,   445,   464,   465,   445,   445,   466,
+     467,   445,   468,   469,   445,   470,   471,   445,   472,   473,
+     445,   474,   474,   474,   476,   477,   478,   479,   475,   481,
+     482,   483,   484,   480,   486,   487,   488,   489,   485,   490,
+     490,   490,   490,   490,   490,   490,   491,   491,   491,   491,
+     491,   492,   492,   492,   492,   492,   492,   492,   492,   493,
+     493,   494,   495,   495,   496,   496,   497,   497,   498,   498,
+     500,   501,   499,   502,   503,   499,   504,   505,   499,   506,
+     507,   499,   508,   509,   499,   510,   511,   512,   510,   513,
+     514,   515,   513,   516,   517,   513,   518,   519,   513,   513,
+     520,   521,   513,   513,   522,   523,   513,   524,   524,   525,
+     526,   527,   527,   527,   528,   528,   529,   529,   530,   530,
+     531
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
@@ -3957,90 +3980,91 @@ static const yytype_int8 yyr2[] =
        8,     1,     1,     0,     2,     1,     1,     1,     1,     1,
        1,     2,     0,     1,     0,     0,     6,     0,     3,     0,
        0,     6,     0,     3,     0,     0,     9,     7,     1,     4,
-       3,     3,     3,     5,     5,     0,     9,     3,     0,     7,
+       3,     3,     3,     5,     5,     0,    10,     3,     0,     8,
        0,     7,     4,     4,     1,     1,     1,     1,     1,     1,
        1,     3,     1,     1,     1,     3,     3,     5,     3,     3,
-       3,     3,     1,     5,     1,     3,     3,     4,     1,     1,
-       1,     1,     1,     4,     1,     2,     3,     3,     3,     3,
-       2,     1,     3,     0,     3,     0,     4,     0,     2,     3,
-       0,     2,     2,     1,     2,     2,     2,     2,     2,     2,
+       3,     3,     1,     5,     1,     3,     3,     4,     0,     3,
+       1,     1,     1,     1,     1,     1,     4,     1,     2,     3,
+       3,     3,     3,     2,     1,     3,     0,     3,     0,     4,
+       0,     2,     3,     0,     2,     2,     1,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     3,     4,     4,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       3,     4,     4,     4,     4,     4,     4,     4,     4,     4,
+       4,     4,     4,     4,     4,     3,     2,     2,     3,     4,
        4,     4,     4,     4,     4,     4,     4,     4,     4,     4,
-       4,     4,     3,     2,     2,     3,     4,     4,     4,     4,
-       4,     4,     4,     4,     4,     4,     4,     4,     3,     2,
-       2,     2,     2,     2,     3,     3,     3,     3,     3,     4,
-       4,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       4,     3,     2,     2,     2,     2,     2,     3,     3,     3,
+       3,     3,     4,     4,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     0,     1,     4,
-       0,     1,     1,     3,     0,     5,     0,     0,     0,     6,
-       0,     0,     6,     2,     2,     2,     1,     2,     2,     1,
-       1,     1,     1,     2,     1,     2,     2,     2,     2,     1,
-       1,     1,     2,     2,     2,     0,     0,     6,     0,     2,
-       2,     0,     2,     0,     2,     1,     3,     1,     3,     2,
-       2,     3,     0,     0,     5,     1,     2,     5,     5,     5,
-       6,     2,     1,     1,     1,     2,     3,     2,     3,     4,
-       1,     1,     0,     1,     1,     1,     0,     1,     3,     8,
-       7,     3,     3,     5,     0,     0,     7,     0,     0,     7,
-       0,     0,     7,     0,     0,     6,     5,     8,    10,     1,
-       2,     3,     4,     1,     2,     3,     1,     1,     2,     2,
-       2,     2,     2,     4,     1,     3,     0,     4,     7,     7,
-       3,     1,     1,     1,     1,     1,     1,     1,     1,     3,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       0,     1,     4,     0,     1,     1,     3,     0,     5,     0,
+       0,     0,     6,     0,     0,     6,     2,     2,     2,     1,
+       2,     2,     1,     1,     1,     1,     2,     1,     2,     2,
+       2,     2,     1,     1,     1,     2,     2,     2,     0,     0,
+       6,     0,     2,     2,     0,     2,     0,     2,     1,     3,
+       1,     3,     2,     2,     3,     0,     0,     5,     1,     2,
+       5,     5,     5,     6,     2,     1,     1,     1,     2,     3,
+       2,     3,     4,     1,     1,     0,     1,     1,     1,     0,
+       1,     3,     8,     7,     3,     3,     5,     0,     0,     7,
+       0,     0,     7,     0,     0,     7,     0,     0,     6,     5,
+       8,    10,     1,     2,     3,     4,     1,     2,     3,     1,
+       1,     2,     2,     2,     2,     2,     4,     1,     3,     0,
+       4,     7,     7,     3,     1,     1,     1,     1,     1,     1,
+       1,     1,     3,     3,     3,     3,     3,     3,     3,     3,
        3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     3,     3,     3,     3,     6,
-       8,     5,     6,     1,     4,     3,     0,     0,     8,     0,
-       0,     9,     3,     4,     5,     6,     8,     5,     6,     0,
-       0,     5,     3,     4,     4,     5,     4,     3,     4,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     2,     2,     2,     2,     3,     3,     3,     3,
+       3,     3,     6,     8,     5,     6,     1,     4,     3,     0,
+       0,     8,     0,     0,     9,     3,     4,     5,     6,     8,
+       5,     6,     0,     0,     5,     3,     4,     4,     5,     4,
+       3,     4,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     2,     2,     2,     2,     3,
        3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     3,     3,     3,     2,     2,
-       2,     2,     4,     3,     4,     5,     4,     5,     3,     4,
-       1,     1,     2,     4,     4,     1,     3,     5,     0,     0,
-       8,     3,     3,     3,     0,     0,     8,     3,     4,     0,
-       0,     9,     4,     1,     1,     1,     1,     1,     1,     1,
-       3,     3,     3,     1,     4,     3,     3,     3,     7,     8,
-       7,     4,     4,     4,     4,     4,     1,     6,     7,     6,
-       6,     7,     7,     6,     7,     6,     6,     0,     1,     0,
-       1,     1,     0,     1,     0,     1,     1,     0,     1,     5,
-       0,     2,     6,     0,     4,     0,     9,     0,    11,     3,
-       3,     4,     1,     1,     3,     3,     3,     1,     3,     1,
-       3,     0,     1,     3,     3,     1,     3,     0,     1,     3,
-       1,     1,     1,     2,     3,     3,     5,     1,     1,     1,
-       1,     1,     0,     1,     1,     4,     3,     3,     5,     1,
-       3,     0,     2,     2,     4,     6,     5,     4,     6,     5,
-       0,     1,     0,     1,     1,     0,     2,     0,     4,     6,
-       0,     6,     1,     3,     1,     2,     0,     1,     3,     0,
-       1,     1,     0,     5,     3,     0,     1,     1,     1,     0,
-       2,     0,     1,     1,     2,     0,     1,     0,     0,     0,
-      13,     0,     2,     0,     1,     3,     1,     1,     2,     2,
-       0,     1,     1,     1,     3,     0,     0,     0,     9,     1,
-       4,     3,     3,     5,     1,     1,     1,     1,     1,     1,
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
+       3,     2,     2,     2,     2,     4,     3,     4,     5,     4,
+       5,     3,     4,     1,     1,     2,     4,     4,     1,     3,
+       5,     0,     0,     8,     3,     3,     3,     0,     0,     8,
+       3,     4,     0,     0,     9,     4,     1,     1,     1,     1,
+       1,     1,     1,     3,     3,     3,     1,     4,     3,     3,
+       3,     7,     8,     7,     4,     4,     4,     4,     4,     1,
+       6,     7,     6,     6,     7,     7,     6,     7,     6,     6,
+       0,     1,     0,     1,     1,     0,     1,     0,     1,     1,
+       0,     1,     5,     0,     2,     6,     0,     4,     0,     9,
+       0,    11,     3,     3,     4,     1,     1,     3,     3,     3,
+       1,     3,     1,     3,     0,     1,     3,     3,     1,     3,
+       0,     1,     3,     1,     1,     1,     2,     3,     3,     5,
+       1,     1,     1,     1,     1,     0,     1,     1,     4,     3,
+       3,     5,     1,     3,     0,     2,     2,     4,     6,     5,
+       4,     6,     5,     0,     1,     0,     1,     1,     0,     2,
+       0,     4,     6,     0,     6,     1,     3,     1,     2,     0,
+       1,     3,     0,     1,     1,     0,     5,     3,     0,     1,
+       1,     1,     0,     2,     0,     1,     1,     2,     0,     1,
+       0,     0,     0,    13,     0,     2,     0,     1,     3,     1,
+       1,     2,     2,     0,     1,     1,     1,     3,     0,     0,
+       0,     9,     1,     4,     3,     3,     5,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     4,     4,     1,     3,     3,     0,     1,     3,     3,
-       5,     0,     2,     2,     2,     2,     4,     0,     0,     7,
-       1,     1,     1,     3,     3,     2,     4,     3,     1,     2,
-       0,     4,     1,     1,     1,     1,     0,     0,     6,     4,
-       4,     3,     0,     6,     0,     7,     4,     2,     2,     3,
-       2,     3,     2,     2,     3,     3,     3,     2,     0,     0,
-       6,     2,     0,     0,     6,     0,     0,     6,     0,     0,
-       6,     1,     0,     0,     6,     0,     0,     7,     1,     0,
-       0,     6,     0,     0,     7,     1,     0,     0,     6,     0,
-       0,     7,     0,     0,     6,     0,     0,     6,     1,     3,
-       3,     0,     0,     0,     0,    12,     0,     0,     0,     0,
-      12,     0,     0,     0,     0,    13,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     3,     3,
-       5,     5,     6,     6,     8,     8,     0,     1,     2,     3,
-       5,     1,     2,     1,     0,     0,     1,     0,     0,    10,
-       0,     0,    10,     0,     0,    10,     0,     0,    11,     0,
-       0,     7,     5,     0,     0,    10,     3,     0,     0,    11,
-       0,     0,    11,     0,     0,    10,     5,     0,     0,     9,
-       5,     0,     0,    10,     1,     3,     0,     5,     5,     7,
-       9,     0,     3,     0,     1,    11,    12,    13
+       1,     1,     1,     1,     4,     4,     1,     3,     3,     0,
+       1,     3,     3,     5,     0,     2,     2,     2,     2,     4,
+       0,     0,     7,     1,     1,     1,     3,     3,     2,     4,
+       3,     1,     2,     0,     4,     1,     1,     1,     1,     0,
+       0,     6,     4,     4,     3,     0,     6,     0,     7,     4,
+       2,     2,     3,     2,     3,     2,     2,     3,     3,     3,
+       2,     0,     0,     6,     2,     0,     0,     6,     0,     0,
+       6,     0,     0,     6,     1,     0,     0,     6,     0,     0,
+       7,     1,     0,     0,     6,     0,     0,     7,     1,     0,
+       0,     6,     0,     0,     7,     0,     0,     6,     0,     0,
+       6,     1,     3,     3,     0,     0,     0,     0,    12,     0,
+       0,     0,     0,    12,     0,     0,     0,     0,    13,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     3,     3,     5,     5,     6,     6,     8,     8,     0,
+       1,     2,     3,     5,     1,     2,     1,     0,     0,     1,
+       0,     0,    10,     0,     0,    10,     0,     0,    10,     0,
+       0,    11,     0,     0,     7,     5,     0,     0,    10,     3,
+       0,     0,    11,     0,     0,    11,     0,     0,    10,     5,
+       0,     0,     9,     5,     0,     0,    10,     1,     3,     0,
+       5,     5,     7,     9,     0,     3,     0,     1,    11,    12,
+      13
 };
 
 
@@ -4722,6 +4746,10 @@ yydestruct (const char *yymsg,
         break;
 
     case YYSYMBOL_metadata_argument_list: /* metadata_argument_list  */
+            { delete ((*yyvaluep).aaList); }
+        break;
+
+    case YYSYMBOL_optional_for_annotations: /* optional_for_annotations  */
             { delete ((*yyvaluep).aaList); }
         break;
 
@@ -6077,10 +6105,10 @@ yyreduce:
     }
     break;
 
-  case 116: /* expression_for_loop: $@13 "for" '(' for_variable_name_with_pos_list "in" expr_list ')' optional_emit_semis expression_block  */
-                                                                                                                                     {
+  case 116: /* expression_for_loop: $@13 "for" optional_for_annotations '(' for_variable_name_with_pos_list "in" expr_list ')' optional_emit_semis expression_block  */
+                                                                                                                                                                    {
         yyextra->das_keyword = false;
-        (yyval.pExpression) = ast_forLoop(scanner,(yyvsp[-5].pNameWithPosList),(yyvsp[-3].pExpression),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-7])),tokAt(scanner,(yylsp[0])));
+        (yyval.pExpression) = ast_forLoop(scanner,(yyvsp[-5].pNameWithPosList),(yyvsp[-3].pExpression),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-8])),tokAt(scanner,(yylsp[0])),(yyvsp[-7].aaList));
     }
     break;
 
@@ -6098,12 +6126,13 @@ yyreduce:
     }
     break;
 
-  case 119: /* expression_while_loop: $@14 "while" '(' expr ')' optional_emit_semis expression_block  */
-                                                                                         {
+  case 119: /* expression_while_loop: $@14 "while" optional_for_annotations '(' expr ')' optional_emit_semis expression_block  */
+                                                                                                                        {
         yyextra->das_keyword = false;
-        auto pWhile = new ExprWhile(tokAt(scanner,(yylsp[-5])));
+        auto pWhile = new ExprWhile(tokAt(scanner,(yylsp[-6])));
         pWhile->cond = (yyvsp[-3].pExpression);
         pWhile->body = (yyvsp[0].pExpression);
+        if ( (yyvsp[-5].aaList) ) { pWhile->annotations = move(*(yyvsp[-5].aaList)); delete (yyvsp[-5].aaList); }
         ((ExprBlock *)(yyvsp[0].pExpression))->inTheLoop = true;
         (yyval.pExpression) = pWhile;
     }
@@ -6253,23 +6282,41 @@ yyreduce:
     }
     break;
 
-  case 148: /* annotation_declaration_name: name_in_namespace  */
+  case 148: /* optional_for_annotations: %empty  */
+                    {
+        (yyval.aaList) = nullptr;
+    }
+    break;
+
+  case 149: /* optional_for_annotations: '[' annotation_argument_list ']'  */
+                                               {
+        (yyval.aaList) = (yyvsp[-1].aaList);
+    }
+    break;
+
+  case 150: /* optional_for_annotations: metadata_argument_list  */
+                                     {
+        (yyval.aaList) = (yyvsp[0].aaList);
+    }
+    break;
+
+  case 151: /* annotation_declaration_name: name_in_namespace  */
                                     { (yyval.s) = (yyvsp[0].s); }
     break;
 
-  case 149: /* annotation_declaration_name: "require"  */
+  case 152: /* annotation_declaration_name: "require"  */
                                     { (yyval.s) = new string("require"); }
     break;
 
-  case 150: /* annotation_declaration_name: "private"  */
+  case 153: /* annotation_declaration_name: "private"  */
                                     { (yyval.s) = new string("private"); }
     break;
 
-  case 151: /* annotation_declaration_name: "template"  */
+  case 154: /* annotation_declaration_name: "template"  */
                                     { (yyval.s) = new string("template"); }
     break;
 
-  case 152: /* annotation_declaration_basic: annotation_declaration_name  */
+  case 155: /* annotation_declaration_basic: annotation_declaration_name  */
                                           {
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner,(yylsp[0]));
@@ -6290,7 +6337,7 @@ yyreduce:
     }
     break;
 
-  case 153: /* annotation_declaration_basic: annotation_declaration_name '(' annotation_argument_list ')'  */
+  case 156: /* annotation_declaration_basic: annotation_declaration_name '(' annotation_argument_list ')'  */
                                                                                  {
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner,(yylsp[-3]));
@@ -6313,13 +6360,13 @@ yyreduce:
     }
     break;
 
-  case 154: /* annotation_declaration: annotation_declaration_basic  */
+  case 157: /* annotation_declaration: annotation_declaration_basic  */
                                           {
         (yyval.fa) = (yyvsp[0].fa);
     }
     break;
 
-  case 155: /* annotation_declaration: '!' annotation_declaration  */
+  case 158: /* annotation_declaration: '!' annotation_declaration  */
                                               {
         if ( !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
@@ -6332,7 +6379,7 @@ yyreduce:
     }
     break;
 
-  case 156: /* annotation_declaration: annotation_declaration "&&" annotation_declaration  */
+  case 159: /* annotation_declaration: annotation_declaration "&&" annotation_declaration  */
                                                                               {
         if ( !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
@@ -6350,7 +6397,7 @@ yyreduce:
     }
     break;
 
-  case 157: /* annotation_declaration: annotation_declaration "||" annotation_declaration  */
+  case 160: /* annotation_declaration: annotation_declaration "||" annotation_declaration  */
                                                                             {
         if ( !(yyvsp[-2].fa)->annotation || !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
@@ -6368,7 +6415,7 @@ yyreduce:
     }
     break;
 
-  case 158: /* annotation_declaration: annotation_declaration "^^" annotation_declaration  */
+  case 161: /* annotation_declaration: annotation_declaration "^^" annotation_declaration  */
                                                                               {
         if ( !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
@@ -6386,549 +6433,549 @@ yyreduce:
     }
     break;
 
-  case 159: /* annotation_declaration: '(' annotation_declaration ')'  */
+  case 162: /* annotation_declaration: '(' annotation_declaration ')'  */
                                             {
         (yyval.fa) = (yyvsp[-1].fa);
     }
     break;
 
-  case 160: /* annotation_declaration: "|>" annotation_declaration  */
+  case 163: /* annotation_declaration: "|>" annotation_declaration  */
                                           {
         (yyval.fa) = (yyvsp[0].fa);
         (yyvsp[0].fa)->inherited = true;
     }
     break;
 
-  case 161: /* annotation_list: annotation_declaration  */
+  case 164: /* annotation_list: annotation_declaration  */
                                     {
             (yyval.faList) = new AnnotationList();
             (yyval.faList)->push_back(AnnotationDeclarationPtr((yyvsp[0].fa)));
     }
     break;
 
-  case 162: /* annotation_list: annotation_list ',' annotation_declaration  */
+  case 165: /* annotation_list: annotation_list ',' annotation_declaration  */
                                                               {
         (yyval.faList) = (yyvsp[-2].faList);
         (yyval.faList)->push_back(AnnotationDeclarationPtr((yyvsp[0].fa)));
     }
     break;
 
-  case 163: /* optional_annotation_list: %empty  */
+  case 166: /* optional_annotation_list: %empty  */
                                        { (yyval.faList) = nullptr; }
     break;
 
-  case 164: /* optional_annotation_list: '[' annotation_list ']'  */
+  case 167: /* optional_annotation_list: '[' annotation_list ']'  */
                                        { (yyval.faList) = (yyvsp[-1].faList); }
     break;
 
-  case 165: /* optional_annotation_list_with_emit_semis: %empty  */
+  case 168: /* optional_annotation_list_with_emit_semis: %empty  */
                                        { (yyval.faList) = nullptr; }
     break;
 
-  case 166: /* optional_annotation_list_with_emit_semis: '[' annotation_list ']' optional_emit_semis  */
+  case 169: /* optional_annotation_list_with_emit_semis: '[' annotation_list ']' optional_emit_semis  */
                                                           { (yyval.faList) = (yyvsp[-2].faList); }
     break;
 
-  case 167: /* optional_function_argument_list: %empty  */
+  case 170: /* optional_function_argument_list: %empty  */
                                                 { (yyval.pVarDeclList) = nullptr; }
     break;
 
-  case 168: /* optional_function_argument_list: '(' ')'  */
+  case 171: /* optional_function_argument_list: '(' ')'  */
                                                 { (yyval.pVarDeclList) = nullptr; }
     break;
 
-  case 169: /* optional_function_argument_list: '(' function_argument_list ')'  */
+  case 172: /* optional_function_argument_list: '(' function_argument_list ')'  */
                                                 { (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList); }
     break;
 
-  case 170: /* optional_function_type: %empty  */
+  case 173: /* optional_function_type: %empty  */
         {
         (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
     }
     break;
 
-  case 171: /* optional_function_type: ':' type_declaration  */
+  case 174: /* optional_function_type: ':' type_declaration  */
                                         {
         (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
     }
     break;
 
-  case 172: /* optional_function_type: "->" type_declaration  */
+  case 175: /* optional_function_type: "->" type_declaration  */
                                            {
         (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
     }
     break;
 
-  case 173: /* function_name: "name"  */
+  case 176: /* function_name: "name"  */
                           {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyval.s) = (yyvsp[0].s);
     }
     break;
 
-  case 174: /* function_name: "operator" '!'  */
+  case 177: /* function_name: "operator" '!'  */
                              { (yyval.s) = new string("!"); }
     break;
 
-  case 175: /* function_name: "operator" '~'  */
+  case 178: /* function_name: "operator" '~'  */
                              { (yyval.s) = new string("~"); }
     break;
 
-  case 176: /* function_name: "operator" "+="  */
+  case 179: /* function_name: "operator" "+="  */
                              { (yyval.s) = new string("+="); }
     break;
 
-  case 177: /* function_name: "operator" "-="  */
+  case 180: /* function_name: "operator" "-="  */
                              { (yyval.s) = new string("-="); }
     break;
 
-  case 178: /* function_name: "operator" "*="  */
+  case 181: /* function_name: "operator" "*="  */
                              { (yyval.s) = new string("*="); }
     break;
 
-  case 179: /* function_name: "operator" "/="  */
+  case 182: /* function_name: "operator" "/="  */
                              { (yyval.s) = new string("/="); }
     break;
 
-  case 180: /* function_name: "operator" "%="  */
+  case 183: /* function_name: "operator" "%="  */
                              { (yyval.s) = new string("%="); }
     break;
 
-  case 181: /* function_name: "operator" "&="  */
+  case 184: /* function_name: "operator" "&="  */
                              { (yyval.s) = new string("&="); }
     break;
 
-  case 182: /* function_name: "operator" "|="  */
+  case 185: /* function_name: "operator" "|="  */
                              { (yyval.s) = new string("|="); }
     break;
 
-  case 183: /* function_name: "operator" "^="  */
+  case 186: /* function_name: "operator" "^="  */
                              { (yyval.s) = new string("^="); }
     break;
 
-  case 184: /* function_name: "operator" "&&="  */
+  case 187: /* function_name: "operator" "&&="  */
                                 { (yyval.s) = new string("&&="); }
     break;
 
-  case 185: /* function_name: "operator" "||="  */
+  case 188: /* function_name: "operator" "||="  */
                                 { (yyval.s) = new string("||="); }
     break;
 
-  case 186: /* function_name: "operator" "^^="  */
+  case 189: /* function_name: "operator" "^^="  */
                                 { (yyval.s) = new string("^^="); }
     break;
 
-  case 187: /* function_name: "operator" "&&"  */
+  case 190: /* function_name: "operator" "&&"  */
                              { (yyval.s) = new string("&&"); }
     break;
 
-  case 188: /* function_name: "operator" "||"  */
+  case 191: /* function_name: "operator" "||"  */
                              { (yyval.s) = new string("||"); }
     break;
 
-  case 189: /* function_name: "operator" "^^"  */
+  case 192: /* function_name: "operator" "^^"  */
                              { (yyval.s) = new string("^^"); }
     break;
 
-  case 190: /* function_name: "operator" '+'  */
+  case 193: /* function_name: "operator" '+'  */
                              { (yyval.s) = new string("+"); }
     break;
 
-  case 191: /* function_name: "operator" '-'  */
+  case 194: /* function_name: "operator" '-'  */
                              { (yyval.s) = new string("-"); }
     break;
 
-  case 192: /* function_name: "operator" '*'  */
+  case 195: /* function_name: "operator" '*'  */
                              { (yyval.s) = new string("*"); }
     break;
 
-  case 193: /* function_name: "operator" '/'  */
+  case 196: /* function_name: "operator" '/'  */
                              { (yyval.s) = new string("/"); }
     break;
 
-  case 194: /* function_name: "operator" '%'  */
+  case 197: /* function_name: "operator" '%'  */
                              { (yyval.s) = new string("%"); }
     break;
 
-  case 195: /* function_name: "operator" '<'  */
+  case 198: /* function_name: "operator" '<'  */
                              { (yyval.s) = new string("<"); }
     break;
 
-  case 196: /* function_name: "operator" '>'  */
+  case 199: /* function_name: "operator" '>'  */
                              { (yyval.s) = new string(">"); }
     break;
 
-  case 197: /* function_name: "operator" ".."  */
+  case 200: /* function_name: "operator" ".."  */
                              { (yyval.s) = new string("interval"); }
     break;
 
-  case 198: /* function_name: "operator" "=="  */
+  case 201: /* function_name: "operator" "=="  */
                              { (yyval.s) = new string("=="); }
     break;
 
-  case 199: /* function_name: "operator" "!="  */
+  case 202: /* function_name: "operator" "!="  */
                              { (yyval.s) = new string("!="); }
     break;
 
-  case 200: /* function_name: "operator" "<="  */
+  case 203: /* function_name: "operator" "<="  */
                              { (yyval.s) = new string("<="); }
     break;
 
-  case 201: /* function_name: "operator" ">="  */
+  case 204: /* function_name: "operator" ">="  */
                              { (yyval.s) = new string(">="); }
     break;
 
-  case 202: /* function_name: "operator" '&'  */
+  case 205: /* function_name: "operator" '&'  */
                              { (yyval.s) = new string("&"); }
     break;
 
-  case 203: /* function_name: "operator" '|'  */
+  case 206: /* function_name: "operator" '|'  */
                              { (yyval.s) = new string("|"); }
     break;
 
-  case 204: /* function_name: "operator" '^'  */
+  case 207: /* function_name: "operator" '^'  */
                              { (yyval.s) = new string("^"); }
     break;
 
-  case 205: /* function_name: "++" "operator"  */
+  case 208: /* function_name: "++" "operator"  */
                              { (yyval.s) = new string("++"); }
     break;
 
-  case 206: /* function_name: "--" "operator"  */
+  case 209: /* function_name: "--" "operator"  */
                              { (yyval.s) = new string("--"); }
     break;
 
-  case 207: /* function_name: "operator" "++"  */
+  case 210: /* function_name: "operator" "++"  */
                              { (yyval.s) = new string("+++"); }
     break;
 
-  case 208: /* function_name: "operator" "--"  */
+  case 211: /* function_name: "operator" "--"  */
                              { (yyval.s) = new string("---"); }
     break;
 
-  case 209: /* function_name: "operator" "<<"  */
+  case 212: /* function_name: "operator" "<<"  */
                              { (yyval.s) = new string("<<"); }
     break;
 
-  case 210: /* function_name: "operator" ">>"  */
+  case 213: /* function_name: "operator" ">>"  */
                              { (yyval.s) = new string(">>"); }
     break;
 
-  case 211: /* function_name: "operator" "<<="  */
+  case 214: /* function_name: "operator" "<<="  */
                              { (yyval.s) = new string("<<="); }
     break;
 
-  case 212: /* function_name: "operator" ">>="  */
+  case 215: /* function_name: "operator" ">>="  */
                              { (yyval.s) = new string(">>="); }
     break;
 
-  case 213: /* function_name: "operator" "<<<"  */
+  case 216: /* function_name: "operator" "<<<"  */
                              { (yyval.s) = new string("<<<"); }
     break;
 
-  case 214: /* function_name: "operator" ">>>"  */
+  case 217: /* function_name: "operator" ">>>"  */
                              { (yyval.s) = new string(">>>"); }
     break;
 
-  case 215: /* function_name: "operator" "<<<="  */
+  case 218: /* function_name: "operator" "<<<="  */
                              { (yyval.s) = new string("<<<="); }
     break;
 
-  case 216: /* function_name: "operator" ">>>="  */
+  case 219: /* function_name: "operator" ">>>="  */
                              { (yyval.s) = new string(">>>="); }
     break;
 
-  case 217: /* function_name: "operator" '[' ']'  */
+  case 220: /* function_name: "operator" '[' ']'  */
                              { (yyval.s) = new string("[]"); }
     break;
 
-  case 218: /* function_name: "operator" '[' ']' '='  */
+  case 221: /* function_name: "operator" '[' ']' '='  */
                                  { (yyval.s) = new string("[]="); }
     break;
 
-  case 219: /* function_name: "operator" '[' ']' "<-"  */
+  case 222: /* function_name: "operator" '[' ']' "<-"  */
                                     { (yyval.s) = new string("[]<-"); }
     break;
 
-  case 220: /* function_name: "operator" '[' ']' ":="  */
+  case 223: /* function_name: "operator" '[' ']' ":="  */
                                       { (yyval.s) = new string("[]:="); }
     break;
 
-  case 221: /* function_name: "operator" '[' ']' "+="  */
+  case 224: /* function_name: "operator" '[' ']' "+="  */
                                      { (yyval.s) = new string("[]+="); }
     break;
 
-  case 222: /* function_name: "operator" '[' ']' "-="  */
+  case 225: /* function_name: "operator" '[' ']' "-="  */
                                      { (yyval.s) = new string("[]-="); }
     break;
 
-  case 223: /* function_name: "operator" '[' ']' "*="  */
+  case 226: /* function_name: "operator" '[' ']' "*="  */
                                      { (yyval.s) = new string("[]*="); }
     break;
 
-  case 224: /* function_name: "operator" '[' ']' "/="  */
+  case 227: /* function_name: "operator" '[' ']' "/="  */
                                      { (yyval.s) = new string("[]/="); }
     break;
 
-  case 225: /* function_name: "operator" '[' ']' "%="  */
+  case 228: /* function_name: "operator" '[' ']' "%="  */
                                      { (yyval.s) = new string("[]%="); }
     break;
 
-  case 226: /* function_name: "operator" '[' ']' "&="  */
+  case 229: /* function_name: "operator" '[' ']' "&="  */
                                      { (yyval.s) = new string("[]&="); }
     break;
 
-  case 227: /* function_name: "operator" '[' ']' "|="  */
+  case 230: /* function_name: "operator" '[' ']' "|="  */
                                      { (yyval.s) = new string("[]|="); }
     break;
 
-  case 228: /* function_name: "operator" '[' ']' "^="  */
+  case 231: /* function_name: "operator" '[' ']' "^="  */
                                      { (yyval.s) = new string("[]^="); }
     break;
 
-  case 229: /* function_name: "operator" '[' ']' "&&="  */
+  case 232: /* function_name: "operator" '[' ']' "&&="  */
                                         { (yyval.s) = new string("[]&&="); }
     break;
 
-  case 230: /* function_name: "operator" '[' ']' "||="  */
+  case 233: /* function_name: "operator" '[' ']' "||="  */
                                         { (yyval.s) = new string("[]||="); }
     break;
 
-  case 231: /* function_name: "operator" '[' ']' "^^="  */
+  case 234: /* function_name: "operator" '[' ']' "^^="  */
                                         { (yyval.s) = new string("[]^^="); }
     break;
 
-  case 232: /* function_name: "operator" "?[" ']'  */
+  case 235: /* function_name: "operator" "?[" ']'  */
                                 { (yyval.s) = new string("?[]"); }
     break;
 
-  case 233: /* function_name: "operator" '.'  */
+  case 236: /* function_name: "operator" '.'  */
                              { (yyval.s) = new string("."); }
     break;
 
-  case 234: /* function_name: "operator" "?."  */
+  case 237: /* function_name: "operator" "?."  */
                              { (yyval.s) = new string("?."); }
     break;
 
-  case 235: /* function_name: "operator" '.' "name"  */
+  case 238: /* function_name: "operator" '.' "name"  */
                                        { (yyval.s) = new string(".`"+*(yyvsp[0].s)); delete (yyvsp[0].s); }
     break;
 
-  case 236: /* function_name: "operator" '.' "name" ":="  */
+  case 239: /* function_name: "operator" '.' "name" ":="  */
                                              { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`clone"); delete (yyvsp[-1].s); }
     break;
 
-  case 237: /* function_name: "operator" '.' "name" "+="  */
+  case 240: /* function_name: "operator" '.' "name" "+="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`+="); delete (yyvsp[-1].s); }
     break;
 
-  case 238: /* function_name: "operator" '.' "name" "-="  */
+  case 241: /* function_name: "operator" '.' "name" "-="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`-="); delete (yyvsp[-1].s); }
     break;
 
-  case 239: /* function_name: "operator" '.' "name" "*="  */
+  case 242: /* function_name: "operator" '.' "name" "*="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`*="); delete (yyvsp[-1].s); }
     break;
 
-  case 240: /* function_name: "operator" '.' "name" "/="  */
+  case 243: /* function_name: "operator" '.' "name" "/="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`/="); delete (yyvsp[-1].s); }
     break;
 
-  case 241: /* function_name: "operator" '.' "name" "%="  */
+  case 244: /* function_name: "operator" '.' "name" "%="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`%="); delete (yyvsp[-1].s); }
     break;
 
-  case 242: /* function_name: "operator" '.' "name" "&="  */
+  case 245: /* function_name: "operator" '.' "name" "&="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`&="); delete (yyvsp[-1].s); }
     break;
 
-  case 243: /* function_name: "operator" '.' "name" "|="  */
+  case 246: /* function_name: "operator" '.' "name" "|="  */
                                           { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`|="); delete (yyvsp[-1].s); }
     break;
 
-  case 244: /* function_name: "operator" '.' "name" "^="  */
+  case 247: /* function_name: "operator" '.' "name" "^="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`^="); delete (yyvsp[-1].s); }
     break;
 
-  case 245: /* function_name: "operator" '.' "name" "&&="  */
+  case 248: /* function_name: "operator" '.' "name" "&&="  */
                                               { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`&&="); delete (yyvsp[-1].s); }
     break;
 
-  case 246: /* function_name: "operator" '.' "name" "||="  */
+  case 249: /* function_name: "operator" '.' "name" "||="  */
                                             { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`||="); delete (yyvsp[-1].s); }
     break;
 
-  case 247: /* function_name: "operator" '.' "name" "^^="  */
+  case 250: /* function_name: "operator" '.' "name" "^^="  */
                                               { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`^^="); delete (yyvsp[-1].s); }
     break;
 
-  case 248: /* function_name: "operator" "?." "name"  */
+  case 251: /* function_name: "operator" "?." "name"  */
                                        { (yyval.s) = new string("?.`"+*(yyvsp[0].s)); delete (yyvsp[0].s);}
     break;
 
-  case 249: /* function_name: "operator" ":="  */
+  case 252: /* function_name: "operator" ":="  */
                                 { (yyval.s) = new string("clone"); }
     break;
 
-  case 250: /* function_name: "operator" "delete"  */
+  case 253: /* function_name: "operator" "delete"  */
                                 { (yyval.s) = new string("finalize"); }
     break;
 
-  case 251: /* function_name: "operator" "??"  */
+  case 254: /* function_name: "operator" "??"  */
                            { (yyval.s) = new string("??"); }
     break;
 
-  case 252: /* function_name: "operator" "is"  */
+  case 255: /* function_name: "operator" "is"  */
                             { (yyval.s) = new string("`is"); }
     break;
 
-  case 253: /* function_name: "operator" "as"  */
+  case 256: /* function_name: "operator" "as"  */
                             { (yyval.s) = new string("`as"); }
     break;
 
-  case 254: /* function_name: "operator" "is" "name"  */
+  case 257: /* function_name: "operator" "is" "name"  */
                                        { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "`is`" + *(yyvsp[0].s); }
     break;
 
-  case 255: /* function_name: "operator" "as" "name"  */
+  case 258: /* function_name: "operator" "as" "name"  */
                                        { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "`as`" + *(yyvsp[0].s); }
     break;
 
-  case 256: /* function_name: "operator" "is" das_type_name  */
+  case 259: /* function_name: "operator" "is" das_type_name  */
                                                 { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "`is`" + *(yyvsp[0].s); }
     break;
 
-  case 257: /* function_name: "operator" "as" das_type_name  */
+  case 260: /* function_name: "operator" "as" das_type_name  */
                                                 { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "`as`" + *(yyvsp[0].s); }
     break;
 
-  case 258: /* function_name: "operator" '?' "as"  */
+  case 261: /* function_name: "operator" '?' "as"  */
                                 { (yyval.s) = new string("?as"); }
     break;
 
-  case 259: /* function_name: "operator" '?' "as" "name"  */
+  case 262: /* function_name: "operator" '?' "as" "name"  */
                                            { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "?as`" + *(yyvsp[0].s); }
     break;
 
-  case 260: /* function_name: "operator" '?' "as" das_type_name  */
+  case 263: /* function_name: "operator" '?' "as" das_type_name  */
                                                     { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "?as`" + *(yyvsp[0].s); }
     break;
 
-  case 261: /* function_name: das_type_name  */
+  case 264: /* function_name: das_type_name  */
                             { (yyval.s) = (yyvsp[0].s); }
     break;
 
-  case 262: /* das_type_name: "bool"  */
+  case 265: /* das_type_name: "bool"  */
                      { (yyval.s) = new string("bool"); }
     break;
 
-  case 263: /* das_type_name: "string"  */
+  case 266: /* das_type_name: "string"  */
                      { (yyval.s) = new string("string"); }
     break;
 
-  case 264: /* das_type_name: "int"  */
+  case 267: /* das_type_name: "int"  */
                      { (yyval.s) = new string("int"); }
     break;
 
-  case 265: /* das_type_name: "int2"  */
+  case 268: /* das_type_name: "int2"  */
                      { (yyval.s) = new string("int2"); }
     break;
 
-  case 266: /* das_type_name: "int3"  */
+  case 269: /* das_type_name: "int3"  */
                      { (yyval.s) = new string("int3"); }
     break;
 
-  case 267: /* das_type_name: "int4"  */
+  case 270: /* das_type_name: "int4"  */
                      { (yyval.s) = new string("int4"); }
     break;
 
-  case 268: /* das_type_name: "uint"  */
+  case 271: /* das_type_name: "uint"  */
                      { (yyval.s) = new string("uint"); }
     break;
 
-  case 269: /* das_type_name: "uint2"  */
+  case 272: /* das_type_name: "uint2"  */
                      { (yyval.s) = new string("uint2"); }
     break;
 
-  case 270: /* das_type_name: "uint3"  */
+  case 273: /* das_type_name: "uint3"  */
                      { (yyval.s) = new string("uint3"); }
     break;
 
-  case 271: /* das_type_name: "uint4"  */
+  case 274: /* das_type_name: "uint4"  */
                      { (yyval.s) = new string("uint4"); }
     break;
 
-  case 272: /* das_type_name: "float"  */
+  case 275: /* das_type_name: "float"  */
                      { (yyval.s) = new string("float"); }
     break;
 
-  case 273: /* das_type_name: "float2"  */
+  case 276: /* das_type_name: "float2"  */
                      { (yyval.s) = new string("float2"); }
     break;
 
-  case 274: /* das_type_name: "float3"  */
+  case 277: /* das_type_name: "float3"  */
                      { (yyval.s) = new string("float3"); }
     break;
 
-  case 275: /* das_type_name: "float4"  */
+  case 278: /* das_type_name: "float4"  */
                      { (yyval.s) = new string("float4"); }
     break;
 
-  case 276: /* das_type_name: "range"  */
+  case 279: /* das_type_name: "range"  */
                      { (yyval.s) = new string("range"); }
     break;
 
-  case 277: /* das_type_name: "urange"  */
+  case 280: /* das_type_name: "urange"  */
                      { (yyval.s) = new string("urange"); }
     break;
 
-  case 278: /* das_type_name: "range64"  */
+  case 281: /* das_type_name: "range64"  */
                      { (yyval.s) = new string("range64"); }
     break;
 
-  case 279: /* das_type_name: "urange64"  */
+  case 282: /* das_type_name: "urange64"  */
                      { (yyval.s) = new string("urange64"); }
     break;
 
-  case 280: /* das_type_name: "int64"  */
+  case 283: /* das_type_name: "int64"  */
                      { (yyval.s) = new string("int64"); }
     break;
 
-  case 281: /* das_type_name: "uint64"  */
+  case 284: /* das_type_name: "uint64"  */
                      { (yyval.s) = new string("uint64"); }
     break;
 
-  case 282: /* das_type_name: "double"  */
+  case 285: /* das_type_name: "double"  */
                      { (yyval.s) = new string("double"); }
     break;
 
-  case 283: /* das_type_name: "int8"  */
+  case 286: /* das_type_name: "int8"  */
                      { (yyval.s) = new string("int8"); }
     break;
 
-  case 284: /* das_type_name: "uint8"  */
+  case 287: /* das_type_name: "uint8"  */
                      { (yyval.s) = new string("uint8"); }
     break;
 
-  case 285: /* das_type_name: "int16"  */
+  case 288: /* das_type_name: "int16"  */
                      { (yyval.s) = new string("int16"); }
     break;
 
-  case 286: /* das_type_name: "uint16"  */
+  case 289: /* das_type_name: "uint16"  */
                      { (yyval.s) = new string("uint16"); }
     break;
 
-  case 287: /* optional_template: %empty  */
+  case 290: /* optional_template: %empty  */
                                         { (yyval.b) = false; }
     break;
 
-  case 288: /* optional_template: "template"  */
+  case 291: /* optional_template: "template"  */
                                         { (yyval.b) = true; }
     break;
 
-  case 289: /* global_function_declaration: optional_annotation_list_with_emit_semis "def" optional_template function_declaration  */
+  case 292: /* global_function_declaration: optional_annotation_list_with_emit_semis "def" optional_template function_declaration  */
                                                                                                                               {
         (yyvsp[0].pFuncDecl)->atDecl = tokRangeAt(scanner,(yylsp[-2]),(yylsp[0]));
         (yyvsp[0].pFuncDecl)->isTemplate = (yyvsp[-1].b);
@@ -6947,25 +6994,25 @@ yyreduce:
     }
     break;
 
-  case 290: /* optional_public_or_private_function: %empty  */
+  case 293: /* optional_public_or_private_function: %empty  */
                         { (yyval.b) = yyextra->g_thisStructure ? !yyextra->g_thisStructure->privateStructure : yyextra->g_Program->thisModule->isPublic; }
     break;
 
-  case 291: /* optional_public_or_private_function: "private"  */
+  case 294: /* optional_public_or_private_function: "private"  */
                         { (yyval.b) = false; }
     break;
 
-  case 292: /* optional_public_or_private_function: "public"  */
+  case 295: /* optional_public_or_private_function: "public"  */
                         { (yyval.b) = true; }
     break;
 
-  case 293: /* function_declaration_header: function_name optional_function_argument_list optional_function_type  */
+  case 296: /* function_declaration_header: function_name optional_function_argument_list optional_function_type  */
                                                                                                 {
         (yyval.pFuncDecl) = ast_functionDeclarationHeader(scanner,(yyvsp[-2].s),(yyvsp[-1].pVarDeclList),(yyvsp[0].pTypeDecl),tokAt(scanner,(yylsp[-2])));
     }
     break;
 
-  case 294: /* $@16: %empty  */
+  case 297: /* $@16: %empty  */
                                                      {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -6974,7 +7021,7 @@ yyreduce:
     }
     break;
 
-  case 295: /* function_declaration: optional_public_or_private_function $@16 function_declaration_header optional_emit_semis block_or_simple_block  */
+  case 298: /* function_declaration: optional_public_or_private_function $@16 function_declaration_header optional_emit_semis block_or_simple_block  */
                                                                                          {
         (yyvsp[-2].pFuncDecl)->body = (yyvsp[0].pExpression);
         (yyvsp[-2].pFuncDecl)->privateFunction = !(yyvsp[-4].b);
@@ -6986,43 +7033,43 @@ yyreduce:
     }
     break;
 
-  case 296: /* expression_block_finally: %empty  */
+  case 299: /* expression_block_finally: %empty  */
         {
         (yyval.pExpression) = nullptr;
     }
     break;
 
-  case 297: /* $@17: %empty  */
+  case 300: /* $@17: %empty  */
                   {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 298: /* $@18: %empty  */
+  case 301: /* $@18: %empty  */
                              {
         yyextra->pop_nesteds();
     }
     break;
 
-  case 299: /* expression_block_finally: "finally" $@17 '{' expressions $@18 '}'  */
+  case 302: /* expression_block_finally: "finally" $@17 '{' expressions $@18 '}'  */
           {
         (yyval.pExpression) = (yyvsp[-2].pExpression);
     }
     break;
 
-  case 300: /* $@19: %empty  */
+  case 303: /* $@19: %empty  */
         {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 301: /* $@20: %empty  */
+  case 304: /* $@20: %empty  */
                                       {
         yyextra->pop_nesteds();
     }
     break;
 
-  case 302: /* expression_block: $@19 '{' expressions $@20 '}' expression_block_finally  */
+  case 305: /* expression_block: $@19 '{' expressions $@20 '}' expression_block_finally  */
                                         {
         (yyval.pExpression) = (yyvsp[-3].pExpression);
         (yyval.pExpression)->at = tokRangeAt(scanner,(yylsp[-4]),(yylsp[0]));
@@ -7035,7 +7082,7 @@ yyreduce:
     }
     break;
 
-  case 303: /* expr_call_pipe_no_bracket: expr_call expr_full_block_assumed_piped  */
+  case 306: /* expr_call_pipe_no_bracket: expr_call expr_full_block_assumed_piped  */
                                                            {
         if ( (yyvsp[-1].pExpression)->rtti_isCallLikeExpr() ) {
             ((ExprLooksLikeCall *)(yyvsp[-1].pExpression))->arguments.push_back((yyvsp[0].pExpression));
@@ -7047,7 +7094,7 @@ yyreduce:
     }
     break;
 
-  case 304: /* expr_call_pipe_no_bracket: expr_method_call_no_bracket expr_full_block_assumed_piped  */
+  case 307: /* expr_call_pipe_no_bracket: expr_method_call_no_bracket expr_full_block_assumed_piped  */
                                                                              {
         if ( (yyvsp[-1].pExpression)->rtti_isCallLikeExpr() ) {
             ((ExprLooksLikeCall *)(yyvsp[-1].pExpression))->arguments.push_back((yyvsp[0].pExpression));
@@ -7059,7 +7106,7 @@ yyreduce:
     }
     break;
 
-  case 305: /* expr_call_pipe_no_bracket: expr_field_no_bracket expr_full_block_assumed_piped  */
+  case 308: /* expr_call_pipe_no_bracket: expr_field_no_bracket expr_full_block_assumed_piped  */
                                                                        {
         if ( (yyvsp[-1].pExpression)->rtti_isCallLikeExpr() ) {
             ((ExprLooksLikeCall *)(yyvsp[-1].pExpression))->arguments.push_back((yyvsp[0].pExpression));
@@ -7071,95 +7118,95 @@ yyreduce:
     }
     break;
 
-  case 306: /* expression_any: SEMICOLON  */
+  case 309: /* expression_any: SEMICOLON  */
                                                   { (yyval.pExpression) = nullptr; }
     break;
 
-  case 307: /* expression_any: expr_assign_no_bracket SEMICOLON  */
+  case 310: /* expression_any: expr_assign_no_bracket SEMICOLON  */
                                                     { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 308: /* expression_any: expression_delete SEMICOLON  */
+  case 311: /* expression_any: expression_delete SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 309: /* expression_any: expression_let  */
+  case 312: /* expression_any: expression_let  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 310: /* expression_any: expression_while_loop  */
+  case 313: /* expression_any: expression_while_loop  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 311: /* expression_any: expression_unsafe  */
+  case 314: /* expression_any: expression_unsafe  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 312: /* expression_any: expression_with  */
+  case 315: /* expression_any: expression_with  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 313: /* expression_any: expression_with_alias SEMICOLON  */
+  case 316: /* expression_any: expression_with_alias SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 314: /* expression_any: expression_for_loop  */
+  case 317: /* expression_any: expression_for_loop  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 315: /* expression_any: expression_break SEMICOLON  */
+  case 318: /* expression_any: expression_break SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 316: /* expression_any: expression_continue SEMICOLON  */
+  case 319: /* expression_any: expression_continue SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 317: /* expression_any: expression_return SEMICOLON  */
+  case 320: /* expression_any: expression_return SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 318: /* expression_any: expression_yield SEMICOLON  */
+  case 321: /* expression_any: expression_yield SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 319: /* expression_any: expression_if_then_else  */
+  case 322: /* expression_any: expression_if_then_else  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 320: /* expression_any: expression_if_then_else_oneliner  */
+  case 323: /* expression_any: expression_if_then_else_oneliner  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 321: /* expression_any: expression_try_catch  */
+  case 324: /* expression_any: expression_try_catch  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 322: /* expression_any: expression_label SEMICOLON  */
+  case 325: /* expression_any: expression_label SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 323: /* expression_any: expression_goto SEMICOLON  */
+  case 326: /* expression_any: expression_goto SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 324: /* expression_any: "pass" SEMICOLON  */
+  case 327: /* expression_any: "pass" SEMICOLON  */
                                                   { (yyval.pExpression) = nullptr; }
     break;
 
-  case 325: /* $@21: %empty  */
+  case 328: /* $@21: %empty  */
                      {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 326: /* $@22: %empty  */
+  case 329: /* $@22: %empty  */
                          {
         yyextra->pop_nesteds();
     }
     break;
 
-  case 327: /* expression_any: '{' $@21 expressions $@22 '}' expression_block_finally  */
+  case 330: /* expression_any: '{' $@21 expressions $@22 '}' expression_block_finally  */
                                         {
         (yyval.pExpression) = (yyvsp[-3].pExpression);
         (yyval.pExpression)->at = tokRangeAt(scanner,(yylsp[-5]),(yylsp[0]));
@@ -7172,7 +7219,7 @@ yyreduce:
     }
     break;
 
-  case 328: /* expressions: %empty  */
+  case 331: /* expressions: %empty  */
         {
         (yyval.pExpression) = new ExprBlock();
         (yyval.pExpression)->at = LineInfo(yyextra->g_FileAccessStack.back(),
@@ -7180,7 +7227,7 @@ yyreduce:
     }
     break;
 
-  case 329: /* expressions: expressions expression_any  */
+  case 332: /* expressions: expressions expression_any  */
                                                         {
         (yyval.pExpression) = (yyvsp[-1].pExpression);
         if ( (yyvsp[0].pExpression) ) {
@@ -7189,47 +7236,47 @@ yyreduce:
     }
     break;
 
-  case 330: /* expressions: expressions error  */
+  case 333: /* expressions: expressions error  */
                                  {
         (void)(yyvsp[-1].pExpression); /* gc_node — don't delete Expression */ (yyval.pExpression) = nullptr; YYABORT;
     }
     break;
 
-  case 331: /* optional_expr_list: %empty  */
+  case 334: /* optional_expr_list: %empty  */
         { (yyval.pExpression) = nullptr; }
     break;
 
-  case 332: /* optional_expr_list: expr_list optional_comma  */
+  case 335: /* optional_expr_list: expr_list optional_comma  */
                                             { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 333: /* optional_expr_map_tuple_list: %empty  */
+  case 336: /* optional_expr_map_tuple_list: %empty  */
         { (yyval.pExpression) = nullptr; }
     break;
 
-  case 334: /* optional_expr_map_tuple_list: expr_map_tuple_list optional_comma  */
+  case 337: /* optional_expr_map_tuple_list: expr_map_tuple_list optional_comma  */
                                                       { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 335: /* type_declaration_no_options_list: type_declaration  */
+  case 338: /* type_declaration_no_options_list: type_declaration  */
                                {
         (yyval.pTypeDeclList) = new vector<Expression *>();
         (yyval.pTypeDeclList)->push_back(new ExprTypeDecl(tokAt(scanner,(yylsp[0])),(yyvsp[0].pTypeDecl)));
     }
     break;
 
-  case 336: /* type_declaration_no_options_list: type_declaration_no_options_list c_or_s type_declaration  */
+  case 339: /* type_declaration_no_options_list: type_declaration_no_options_list c_or_s type_declaration  */
                                                                               {
         (yyval.pTypeDeclList) = (yyvsp[-2].pTypeDeclList);
         (yyval.pTypeDeclList)->push_back(new ExprTypeDecl(tokAt(scanner,(yylsp[0])),(yyvsp[0].pTypeDecl)));
     }
     break;
 
-  case 337: /* name_in_namespace: "name"  */
+  case 340: /* name_in_namespace: "name"  */
                                                { (yyval.s) = (yyvsp[0].s); }
     break;
 
-  case 338: /* name_in_namespace: "name" "::" "name"  */
+  case 341: /* name_in_namespace: "name" "::" "name"  */
                                                {
             auto ita = yyextra->das_module_alias.find(*(yyvsp[-2].s));
             if ( ita == yyextra->das_module_alias.end() ) {
@@ -7243,17 +7290,17 @@ yyreduce:
         }
     break;
 
-  case 339: /* name_in_namespace: "::" "name"  */
+  case 342: /* name_in_namespace: "::" "name"  */
                                                { *(yyvsp[0].s) = "::" + *(yyvsp[0].s); (yyval.s) = (yyvsp[0].s); }
     break;
 
-  case 340: /* expression_delete: "delete" expr  */
+  case 343: /* expression_delete: "delete" expr  */
                                       {
         (yyval.pExpression) = new ExprDelete(tokAt(scanner,(yylsp[-1])), (yyvsp[0].pExpression));
     }
     break;
 
-  case 341: /* expression_delete: "delete" "explicit" expr  */
+  case 344: /* expression_delete: "delete" "explicit" expr  */
                                                    {
         auto delExpr = new ExprDelete(tokAt(scanner,(yylsp[-2])), (yyvsp[0].pExpression));
         delExpr->native = true;
@@ -7261,47 +7308,47 @@ yyreduce:
     }
     break;
 
-  case 342: /* $@23: %empty  */
+  case 345: /* $@23: %empty  */
            { yyextra->das_arrow_depth ++; }
     break;
 
-  case 343: /* $@24: %empty  */
+  case 346: /* $@24: %empty  */
                                                                            { yyextra->das_arrow_depth --; }
     break;
 
-  case 344: /* new_type_declaration: '<' $@23 type_declaration '>' $@24  */
+  case 347: /* new_type_declaration: '<' $@23 type_declaration '>' $@24  */
                                                                                                             {
         (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
     }
     break;
 
-  case 345: /* new_type_declaration: structure_type_declaration  */
+  case 348: /* new_type_declaration: structure_type_declaration  */
                                                {
         (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
     }
     break;
 
-  case 346: /* expr_new: "new" new_type_declaration  */
+  case 349: /* expr_new: "new" new_type_declaration  */
                                                        {
         (yyval.pExpression) = new ExprNew(tokAt(scanner,(yylsp[-1])),(yyvsp[0].pTypeDecl),false);
     }
     break;
 
-  case 347: /* expr_new: "new" new_type_declaration '(' use_initializer ')'  */
+  case 350: /* expr_new: "new" new_type_declaration '(' use_initializer ')'  */
                                                                                      {
         (yyval.pExpression) = new ExprNew(tokAt(scanner,(yylsp[-4])),(yyvsp[-3].pTypeDecl),true);
         ((ExprNew *)(yyval.pExpression))->initializer = (yyvsp[-1].b);
     }
     break;
 
-  case 348: /* expr_new: "new" new_type_declaration '(' expr_list ')'  */
+  case 351: /* expr_new: "new" new_type_declaration '(' expr_list ')'  */
                                                                                     {
         auto pNew = new ExprNew(tokAt(scanner,(yylsp[-4])),(yyvsp[-3].pTypeDecl),true);
         (yyval.pExpression) = parseFunctionArguments(pNew,(yyvsp[-1].pExpression));
     }
     break;
 
-  case 349: /* expr_new: "new" new_type_declaration '(' make_struct_single ')'  */
+  case 352: /* expr_new: "new" new_type_declaration '(' make_struct_single ')'  */
                                                                                       {
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-3]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-3].pTypeDecl);
@@ -7311,7 +7358,7 @@ yyreduce:
     }
     break;
 
-  case 350: /* expr_new: "new" new_type_declaration '(' "uninitialized" make_struct_single ')'  */
+  case 353: /* expr_new: "new" new_type_declaration '(' "uninitialized" make_struct_single ')'  */
                                                                                                         {
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-4]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-4].pTypeDecl);
@@ -7321,33 +7368,33 @@ yyreduce:
     }
     break;
 
-  case 351: /* expr_new: "new" make_decl  */
+  case 354: /* expr_new: "new" make_decl  */
                                     {
         (yyval.pExpression) = new ExprAscend(tokAt(scanner,(yylsp[-1])),(yyvsp[0].pExpression));
     }
     break;
 
-  case 352: /* expression_break: "break"  */
+  case 355: /* expression_break: "break"  */
                        { (yyval.pExpression) = new ExprBreak(tokAt(scanner,(yylsp[0]))); }
     break;
 
-  case 353: /* expression_continue: "continue"  */
+  case 356: /* expression_continue: "continue"  */
                           { (yyval.pExpression) = new ExprContinue(tokAt(scanner,(yylsp[0]))); }
     break;
 
-  case 354: /* expression_return: "return"  */
+  case 357: /* expression_return: "return"  */
                         {
         (yyval.pExpression) = new ExprReturn(tokAt(scanner,(yylsp[0])),nullptr);
     }
     break;
 
-  case 355: /* expression_return: "return" expr  */
+  case 358: /* expression_return: "return" expr  */
                                       {
         (yyval.pExpression) = new ExprReturn(tokAt(scanner,(yylsp[-1])),(yyvsp[0].pExpression));
     }
     break;
 
-  case 356: /* expression_return: "return" "<-" expr  */
+  case 359: /* expression_return: "return" "<-" expr  */
                                              {
         auto pRet = new ExprReturn(tokAt(scanner,(yylsp[-2])),(yyvsp[0].pExpression));
         pRet->moveSemantics = true;
@@ -7355,13 +7402,13 @@ yyreduce:
     }
     break;
 
-  case 357: /* expression_yield: "yield" expr  */
+  case 360: /* expression_yield: "yield" expr  */
                                      {
         (yyval.pExpression) = new ExprYield(tokAt(scanner,(yylsp[-1])),(yyvsp[0].pExpression));
     }
     break;
 
-  case 358: /* expression_yield: "yield" "<-" expr  */
+  case 361: /* expression_yield: "yield" "<-" expr  */
                                             {
         auto pRet = new ExprYield(tokAt(scanner,(yylsp[-2])),(yyvsp[0].pExpression));
         pRet->moveSemantics = true;
@@ -7369,41 +7416,41 @@ yyreduce:
     }
     break;
 
-  case 359: /* expression_try_catch: "try" expression_block "recover" expression_block  */
+  case 362: /* expression_try_catch: "try" expression_block "recover" expression_block  */
                                                                                        {
         (yyval.pExpression) = new ExprTryCatch(tokAt(scanner,(yylsp[-3])),(yyvsp[-2].pExpression),(yyvsp[0].pExpression));
     }
     break;
 
-  case 360: /* kwd_let_var_or_nothing: "let"  */
+  case 363: /* kwd_let_var_or_nothing: "let"  */
                  { (yyval.b) = true; }
     break;
 
-  case 361: /* kwd_let_var_or_nothing: "var"  */
+  case 364: /* kwd_let_var_or_nothing: "var"  */
                  { (yyval.b) = false; }
     break;
 
-  case 362: /* kwd_let_var_or_nothing: %empty  */
+  case 365: /* kwd_let_var_or_nothing: %empty  */
                     { (yyval.b) = true; }
     break;
 
-  case 363: /* kwd_let: "let"  */
+  case 366: /* kwd_let: "let"  */
                  { (yyval.b) = true; }
     break;
 
-  case 364: /* kwd_let: "var"  */
+  case 367: /* kwd_let: "var"  */
                  { (yyval.b) = false; }
     break;
 
-  case 365: /* optional_in_scope: "inscope"  */
+  case 368: /* optional_in_scope: "inscope"  */
                     { (yyval.b) = true; }
     break;
 
-  case 366: /* optional_in_scope: %empty  */
+  case 369: /* optional_in_scope: %empty  */
                      { (yyval.b) = false; }
     break;
 
-  case 367: /* tuple_expansion: "name"  */
+  case 370: /* tuple_expansion: "name"  */
                     {
         (yyval.pNameList) = new vector<string>();
         (yyval.pNameList)->push_back(*(yyvsp[0].s));
@@ -7411,7 +7458,7 @@ yyreduce:
     }
     break;
 
-  case 368: /* tuple_expansion: tuple_expansion ',' "name"  */
+  case 371: /* tuple_expansion: tuple_expansion ',' "name"  */
                                              {
         (yyvsp[-2].pNameList)->push_back(*(yyvsp[0].s));
         delete (yyvsp[0].s);
@@ -7419,7 +7466,7 @@ yyreduce:
     }
     break;
 
-  case 369: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
+  case 372: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                                 {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-6].pNameList),tokAt(scanner,(yylsp[-6])),(yyvsp[-3].pTypeDecl),(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -7428,7 +7475,7 @@ yyreduce:
     }
     break;
 
-  case 370: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' optional_ref copy_or_move_or_clone expr SEMICOLON  */
+  case 373: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' optional_ref copy_or_move_or_clone expr SEMICOLON  */
                                                                                                         {
         auto typeDecl = new TypeDecl(Type::autoinfer);
         typeDecl->at = tokAt(scanner,(yylsp[-5]));
@@ -7440,47 +7487,47 @@ yyreduce:
     }
     break;
 
-  case 371: /* expression_let: kwd_let optional_in_scope let_variable_declaration  */
+  case 374: /* expression_let: kwd_let optional_in_scope let_variable_declaration  */
                                                                  {
         (yyval.pExpression) = ast_Let(scanner,(yyvsp[-2].b),(yyvsp[-1].b),(yyvsp[0].pVarDecl),tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])));
     }
     break;
 
-  case 372: /* expression_let: kwd_let optional_in_scope tuple_expansion_variable_declaration  */
+  case 375: /* expression_let: kwd_let optional_in_scope tuple_expansion_variable_declaration  */
                                                                              {
         (yyval.pExpression) = ast_Let(scanner,(yyvsp[-2].b),(yyvsp[-1].b),(yyvsp[0].pVarDecl),tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])));
     }
     break;
 
-  case 373: /* expression_let: kwd_let optional_in_scope '{' variable_declaration_list '}'  */
+  case 376: /* expression_let: kwd_let optional_in_scope '{' variable_declaration_list '}'  */
                                                                                {
         (yyval.pExpression) = ast_LetList(scanner,(yyvsp[-4].b),(yyvsp[-3].b),*(yyvsp[-1].pVarDeclList),tokAt(scanner,(yylsp[-4])),tokAt(scanner,(yylsp[-1])));
     }
     break;
 
-  case 374: /* $@25: %empty  */
+  case 377: /* $@25: %empty  */
                           { yyextra->das_arrow_depth ++; }
     break;
 
-  case 375: /* $@26: %empty  */
+  case 378: /* $@26: %empty  */
                                                                                                  { yyextra->das_arrow_depth --; }
     break;
 
-  case 376: /* expr_cast: "cast" '<' $@25 type_declaration_no_options '>' $@26 expr_no_bracket  */
+  case 379: /* expr_cast: "cast" '<' $@25 type_declaration_no_options '>' $@26 expr_no_bracket  */
                                                                                                                                                            {
         (yyval.pExpression) = new ExprCast(tokAt(scanner,(yylsp[-6])),(yyvsp[0].pExpression),(yyvsp[-3].pTypeDecl));
     }
     break;
 
-  case 377: /* $@27: %empty  */
+  case 380: /* $@27: %empty  */
                             { yyextra->das_arrow_depth ++; }
     break;
 
-  case 378: /* $@28: %empty  */
+  case 381: /* $@28: %empty  */
                                                                                                    { yyextra->das_arrow_depth --; }
     break;
 
-  case 379: /* expr_cast: "upcast" '<' $@27 type_declaration_no_options '>' $@28 expr_no_bracket  */
+  case 382: /* expr_cast: "upcast" '<' $@27 type_declaration_no_options '>' $@28 expr_no_bracket  */
                                                                                                                                                              {
         auto pCast = new ExprCast(tokAt(scanner,(yylsp[-6])),(yyvsp[0].pExpression),(yyvsp[-3].pTypeDecl));
         pCast->upcast = true;
@@ -7488,15 +7535,15 @@ yyreduce:
     }
     break;
 
-  case 380: /* $@29: %empty  */
+  case 383: /* $@29: %empty  */
                                  { yyextra->das_arrow_depth ++; }
     break;
 
-  case 381: /* $@30: %empty  */
+  case 384: /* $@30: %empty  */
                                                                                                         { yyextra->das_arrow_depth --; }
     break;
 
-  case 382: /* expr_cast: "reinterpret" '<' $@29 type_declaration_no_options '>' $@30 expr_no_bracket  */
+  case 385: /* expr_cast: "reinterpret" '<' $@29 type_declaration_no_options '>' $@30 expr_no_bracket  */
                                                                                                                                                                   {
         auto pCast = new ExprCast(tokAt(scanner,(yylsp[-6])),(yyvsp[0].pExpression),(yyvsp[-3].pTypeDecl));
         pCast->reinterpret = true;
@@ -7504,21 +7551,21 @@ yyreduce:
     }
     break;
 
-  case 383: /* $@31: %empty  */
+  case 386: /* $@31: %empty  */
                          { yyextra->das_arrow_depth ++; }
     break;
 
-  case 384: /* $@32: %empty  */
+  case 387: /* $@32: %empty  */
                                                                                      { yyextra->das_arrow_depth --; }
     break;
 
-  case 385: /* expr_type_decl: "type" '<' $@31 type_declaration '>' $@32  */
+  case 388: /* expr_type_decl: "type" '<' $@31 type_declaration '>' $@32  */
                                                                                                                       {
         (yyval.pExpression) = new ExprTypeDecl(tokAt(scanner,(yylsp[-5])),(yyvsp[-2].pTypeDecl));
     }
     break;
 
-  case 386: /* expr_type_info: "typeinfo" name_in_namespace '(' expr ')'  */
+  case 389: /* expr_type_info: "typeinfo" name_in_namespace '(' expr ')'  */
                                                                           {
             if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
                 auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
@@ -7531,7 +7578,7 @@ yyreduce:
     }
     break;
 
-  case 387: /* expr_type_info: "typeinfo" name_in_namespace '<' "name" '>' '(' expr ')'  */
+  case 390: /* expr_type_info: "typeinfo" name_in_namespace '<' "name" '>' '(' expr ')'  */
                                                                                                 {
             if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
                 auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
@@ -7545,7 +7592,7 @@ yyreduce:
     }
     break;
 
-  case 388: /* expr_type_info: "typeinfo" name_in_namespace '<' "name" c_or_s "name" '>' '(' expr ')'  */
+  case 391: /* expr_type_info: "typeinfo" name_in_namespace '<' "name" c_or_s "name" '>' '(' expr ')'  */
                                                                                                                         {
             if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
                 auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
@@ -7560,35 +7607,35 @@ yyreduce:
     }
     break;
 
-  case 389: /* expr_list: expr  */
+  case 392: /* expr_list: expr  */
                       {
         (yyval.pExpression) = (yyvsp[0].pExpression);
     }
     break;
 
-  case 390: /* expr_list: "<-" expr  */
+  case 393: /* expr_list: "<-" expr  */
                              {
             (yyval.pExpression) = ast_makeMoveArgument(scanner, (yyvsp[0].pExpression), tokAt(scanner,(yylsp[0])));
     }
     break;
 
-  case 391: /* expr_list: expr_list ',' expr  */
+  case 394: /* expr_list: expr_list ',' expr  */
                                         {
             (yyval.pExpression) = new ExprSequence(tokAt(scanner,(yylsp[-2])),(yyvsp[-2].pExpression),(yyvsp[0].pExpression));
     }
     break;
 
-  case 392: /* expr_list: expr_list ',' "<-" expr  */
+  case 395: /* expr_list: expr_list ',' "<-" expr  */
                                                    {
             (yyval.pExpression) = new ExprSequence(tokAt(scanner,(yylsp[-3])),(yyvsp[-3].pExpression),ast_makeMoveArgument(scanner, (yyvsp[0].pExpression), tokAt(scanner,(yylsp[0]))));
     }
     break;
 
-  case 393: /* block_or_simple_block: expression_block  */
+  case 396: /* block_or_simple_block: expression_block  */
                                     { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 394: /* block_or_simple_block: "=>" expr_no_bracket  */
+  case 397: /* block_or_simple_block: "=>" expr_no_bracket  */
                                                    {
             auto retE = new ExprReturn(tokAt(scanner,(yylsp[-1])), (yyvsp[0].pExpression));
             auto blkE = new ExprBlock();
@@ -7598,7 +7645,7 @@ yyreduce:
     }
     break;
 
-  case 395: /* block_or_simple_block: "=>" "<-" expr_no_bracket  */
+  case 398: /* block_or_simple_block: "=>" "<-" expr_no_bracket  */
                                                           {
             auto retE = new ExprReturn(tokAt(scanner,(yylsp[-2])), (yyvsp[0].pExpression));
             retE->moveSemantics = true;
@@ -7609,39 +7656,39 @@ yyreduce:
     }
     break;
 
-  case 396: /* block_or_lambda: '$'  */
+  case 399: /* block_or_lambda: '$'  */
                 { (yyval.i) = 0;   /* block */  }
     break;
 
-  case 397: /* block_or_lambda: '@'  */
+  case 400: /* block_or_lambda: '@'  */
                 { (yyval.i) = 1;   /* lambda */ }
     break;
 
-  case 398: /* block_or_lambda: '@' '@'  */
+  case 401: /* block_or_lambda: '@' '@'  */
                 { (yyval.i) = 2;   /* local function */ }
     break;
 
-  case 399: /* capture_entry: '&' "name"  */
+  case 402: /* capture_entry: '&' "name"  */
                                     { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_reference); delete (yyvsp[0].s); }
     break;
 
-  case 400: /* capture_entry: '=' "name"  */
+  case 403: /* capture_entry: '=' "name"  */
                                     { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_copy); delete (yyvsp[0].s); }
     break;
 
-  case 401: /* capture_entry: "<-" "name"  */
+  case 404: /* capture_entry: "<-" "name"  */
                                     { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_move); delete (yyvsp[0].s); }
     break;
 
-  case 402: /* capture_entry: ":=" "name"  */
+  case 405: /* capture_entry: ":=" "name"  */
                                     { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_clone); delete (yyvsp[0].s); }
     break;
 
-  case 403: /* capture_entry: "name" '(' "name" ')'  */
+  case 406: /* capture_entry: "name" '(' "name" ')'  */
                                     { (yyval.pCapt) = ast_makeCaptureEntry(scanner,tokAt(scanner,(yylsp[-3])),*(yyvsp[-3].s),*(yyvsp[-1].s)); delete (yyvsp[-3].s); delete (yyvsp[-1].s); }
     break;
 
-  case 404: /* capture_list: capture_entry  */
+  case 407: /* capture_list: capture_entry  */
                          {
         (yyval.pCaptList) = new vector<CaptureEntry>();
         (yyval.pCaptList)->push_back(*(yyvsp[0].pCapt));
@@ -7649,7 +7696,7 @@ yyreduce:
     }
     break;
 
-  case 405: /* capture_list: capture_list ',' capture_entry  */
+  case 408: /* capture_list: capture_list ',' capture_entry  */
                                                {
         (yyvsp[-2].pCaptList)->push_back(*(yyvsp[0].pCapt));
         delete (yyvsp[0].pCapt);
@@ -7657,145 +7704,145 @@ yyreduce:
     }
     break;
 
-  case 406: /* optional_capture_list: %empty  */
+  case 409: /* optional_capture_list: %empty  */
         { (yyval.pCaptList) = nullptr; }
     break;
 
-  case 407: /* optional_capture_list: "capture" '(' capture_list ')'  */
+  case 410: /* optional_capture_list: "capture" '(' capture_list ')'  */
                                              { (yyval.pCaptList) = (yyvsp[-1].pCaptList); }
     break;
 
-  case 408: /* expr_full_block: block_or_lambda optional_annotation_list optional_capture_list optional_function_argument_list optional_function_type optional_emit_semis block_or_simple_block  */
+  case 411: /* expr_full_block: block_or_lambda optional_annotation_list optional_capture_list optional_function_argument_list optional_function_type optional_emit_semis block_or_simple_block  */
                                                                                                                 {
         (yyval.pExpression) = ast_makeBlock(scanner,(yyvsp[-6].i),(yyvsp[-5].faList),(yyvsp[-4].pCaptList),(yyvsp[-3].pVarDeclList),(yyvsp[-2].pTypeDecl),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[-5])),tokAt(scanner,(yylsp[-4])));
     }
     break;
 
-  case 409: /* expr_full_block_assumed_piped: block_or_lambda optional_annotation_list optional_capture_list optional_function_argument_list optional_function_type optional_emit_semis block_or_simple_block  */
+  case 412: /* expr_full_block_assumed_piped: block_or_lambda optional_annotation_list optional_capture_list optional_function_argument_list optional_function_type optional_emit_semis block_or_simple_block  */
                                                                                                                 {
         (yyval.pExpression) = ast_makeBlock(scanner,(yyvsp[-6].i),(yyvsp[-5].faList),(yyvsp[-4].pCaptList),(yyvsp[-3].pVarDeclList),(yyvsp[-2].pTypeDecl),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[-5])),tokAt(scanner,(yylsp[-4])));
     }
     break;
 
-  case 410: /* expr_full_block_assumed_piped: '{' expressions '}'  */
+  case 413: /* expr_full_block_assumed_piped: '{' expressions '}'  */
                                    {
         (yyval.pExpression) = ast_makeBlock(scanner,0,nullptr,nullptr,nullptr,new TypeDecl(Type::autoinfer),(yyvsp[-1].pExpression),tokAt(scanner,(yylsp[-1])),tokAt(scanner,(yylsp[-1])),LineInfo());
     }
     break;
 
-  case 411: /* expr_numeric_const: "integer constant"  */
+  case 414: /* expr_numeric_const: "integer constant"  */
                                               { (yyval.pExpression) = new ExprConstInt(tokAt(scanner,(yylsp[0])),(int32_t)(yyvsp[0].i)); }
     break;
 
-  case 412: /* expr_numeric_const: "unsigned integer constant"  */
+  case 415: /* expr_numeric_const: "unsigned integer constant"  */
                                               { (yyval.pExpression) = new ExprConstUInt(tokAt(scanner,(yylsp[0])),(uint32_t)(yyvsp[0].ui)); }
     break;
 
-  case 413: /* expr_numeric_const: "long integer constant"  */
+  case 416: /* expr_numeric_const: "long integer constant"  */
                                               { (yyval.pExpression) = new ExprConstInt64(tokAt(scanner,(yylsp[0])),(int64_t)(yyvsp[0].i64)); }
     break;
 
-  case 414: /* expr_numeric_const: "unsigned long integer constant"  */
+  case 417: /* expr_numeric_const: "unsigned long integer constant"  */
                                               { (yyval.pExpression) = new ExprConstUInt64(tokAt(scanner,(yylsp[0])),(uint64_t)(yyvsp[0].ui64)); }
     break;
 
-  case 415: /* expr_numeric_const: "unsigned int8 constant"  */
+  case 418: /* expr_numeric_const: "unsigned int8 constant"  */
                                               { (yyval.pExpression) = new ExprConstUInt8(tokAt(scanner,(yylsp[0])),(uint8_t)(yyvsp[0].ui)); }
     break;
 
-  case 416: /* expr_numeric_const: "floating point constant"  */
+  case 419: /* expr_numeric_const: "floating point constant"  */
                                               { (yyval.pExpression) = new ExprConstFloat(tokAt(scanner,(yylsp[0])),(float)(yyvsp[0].fd)); }
     break;
 
-  case 417: /* expr_numeric_const: "double constant"  */
+  case 420: /* expr_numeric_const: "double constant"  */
                                               { (yyval.pExpression) = new ExprConstDouble(tokAt(scanner,(yylsp[0])),(double)(yyvsp[0].d)); }
     break;
 
-  case 418: /* expr_assign_no_bracket: expr_no_bracket  */
+  case 421: /* expr_assign_no_bracket: expr_no_bracket  */
                                                         { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 419: /* expr_assign_no_bracket: expr_no_bracket '=' expr_no_bracket  */
+  case 422: /* expr_assign_no_bracket: expr_no_bracket '=' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprCopy(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),(yyvsp[0].pExpression)); }
     break;
 
-  case 420: /* expr_assign_no_bracket: expr_no_bracket "<-" expr_no_bracket  */
+  case 423: /* expr_assign_no_bracket: expr_no_bracket "<-" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprMove(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 421: /* expr_assign_no_bracket: expr_no_bracket "<-" make_table_decl  */
+  case 424: /* expr_assign_no_bracket: expr_no_bracket "<-" make_table_decl  */
                                                                    { (yyval.pExpression) = new ExprMove(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 422: /* expr_assign_no_bracket: expr_no_bracket "<-" array_comprehension  */
+  case 425: /* expr_assign_no_bracket: expr_no_bracket "<-" array_comprehension  */
                                                                      { (yyval.pExpression) = new ExprMove(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 423: /* expr_assign_no_bracket: expr_no_bracket ":=" expr_no_bracket  */
+  case 426: /* expr_assign_no_bracket: expr_no_bracket ":=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprClone(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 424: /* expr_assign_no_bracket: expr_no_bracket "&=" expr_no_bracket  */
+  case 427: /* expr_assign_no_bracket: expr_no_bracket "&=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 425: /* expr_assign_no_bracket: expr_no_bracket "|=" expr_no_bracket  */
+  case 428: /* expr_assign_no_bracket: expr_no_bracket "|=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"|=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 426: /* expr_assign_no_bracket: expr_no_bracket "^=" expr_no_bracket  */
+  case 429: /* expr_assign_no_bracket: expr_no_bracket "^=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 427: /* expr_assign_no_bracket: expr_no_bracket "&&=" expr_no_bracket  */
+  case 430: /* expr_assign_no_bracket: expr_no_bracket "&&=" expr_no_bracket  */
                                                                       { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&&=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 428: /* expr_assign_no_bracket: expr_no_bracket "||=" expr_no_bracket  */
+  case 431: /* expr_assign_no_bracket: expr_no_bracket "||=" expr_no_bracket  */
                                                                       { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"||=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 429: /* expr_assign_no_bracket: expr_no_bracket "^^=" expr_no_bracket  */
+  case 432: /* expr_assign_no_bracket: expr_no_bracket "^^=" expr_no_bracket  */
                                                                       { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^^=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 430: /* expr_assign_no_bracket: expr_no_bracket "+=" expr_no_bracket  */
+  case 433: /* expr_assign_no_bracket: expr_no_bracket "+=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"+=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 431: /* expr_assign_no_bracket: expr_no_bracket "-=" expr_no_bracket  */
+  case 434: /* expr_assign_no_bracket: expr_no_bracket "-=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"-=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 432: /* expr_assign_no_bracket: expr_no_bracket "*=" expr_no_bracket  */
+  case 435: /* expr_assign_no_bracket: expr_no_bracket "*=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"*=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 433: /* expr_assign_no_bracket: expr_no_bracket "/=" expr_no_bracket  */
+  case 436: /* expr_assign_no_bracket: expr_no_bracket "/=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"/=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 434: /* expr_assign_no_bracket: expr_no_bracket "%=" expr_no_bracket  */
+  case 437: /* expr_assign_no_bracket: expr_no_bracket "%=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"%=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 435: /* expr_assign_no_bracket: expr_no_bracket "<<=" expr_no_bracket  */
+  case 438: /* expr_assign_no_bracket: expr_no_bracket "<<=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 436: /* expr_assign_no_bracket: expr_no_bracket ">>=" expr_no_bracket  */
+  case 439: /* expr_assign_no_bracket: expr_no_bracket ">>=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 437: /* expr_assign_no_bracket: expr_no_bracket "<<<=" expr_no_bracket  */
+  case 440: /* expr_assign_no_bracket: expr_no_bracket "<<<=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<<=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 438: /* expr_assign_no_bracket: expr_no_bracket ">>>=" expr_no_bracket  */
+  case 441: /* expr_assign_no_bracket: expr_no_bracket ">>>=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>>=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 439: /* expr_named_call: name_in_namespace '(' '[' make_struct_fields ']' ')'  */
+  case 442: /* expr_named_call: name_in_namespace '(' '[' make_struct_fields ']' ')'  */
                                                                          {
         auto nc = new ExprNamedCall(tokAt(scanner,(yylsp[-5])),*(yyvsp[-5].s));
         nc->arguments = (yyvsp[-2].pMakeStruct);
@@ -7804,7 +7851,7 @@ yyreduce:
     }
     break;
 
-  case 440: /* expr_named_call: name_in_namespace '(' expr_list ',' '[' make_struct_fields ']' ')'  */
+  case 443: /* expr_named_call: name_in_namespace '(' expr_list ',' '[' make_struct_fields ']' ')'  */
                                                                                                   {
         auto nc = new ExprNamedCall(tokAt(scanner,(yylsp[-7])),*(yyvsp[-7].s));
         nc->nonNamedArguments = sequenceToList((yyvsp[-5].pExpression));
@@ -7814,7 +7861,7 @@ yyreduce:
     }
     break;
 
-  case 441: /* expr_method_call_no_bracket: expr_no_bracket "->" "name" '(' ')'  */
+  case 444: /* expr_method_call_no_bracket: expr_no_bracket "->" "name" '(' ')'  */
                                                                     {
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-3])), (yyvsp[-4].pExpression), *(yyvsp[-2].s));
         pInvoke->atEnclosure = tokRangeAt(scanner,(yylsp[-4]),(yyloc));
@@ -7823,7 +7870,7 @@ yyreduce:
     }
     break;
 
-  case 442: /* expr_method_call_no_bracket: expr_no_bracket "->" "name" '(' expr_list ')'  */
+  case 445: /* expr_method_call_no_bracket: expr_no_bracket "->" "name" '(' expr_list ')'  */
                                                                                          {
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-4])), (yyvsp[-5].pExpression), *(yyvsp[-3].s));
         pInvoke->atEnclosure = tokRangeAt(scanner,(yylsp[-5]),(yyloc));
@@ -7834,35 +7881,35 @@ yyreduce:
     }
     break;
 
-  case 443: /* func_addr_name: name_in_namespace  */
+  case 446: /* func_addr_name: name_in_namespace  */
                                     {
         (yyval.pExpression) = new ExprAddr(tokAt(scanner,(yylsp[0])),*(yyvsp[0].s));
         delete (yyvsp[0].s);
     }
     break;
 
-  case 444: /* func_addr_name: "$i" '(' expr ')'  */
+  case 447: /* func_addr_name: "$i" '(' expr ')'  */
                                           {
         auto expr = new ExprAddr(tokAt(scanner,(yylsp[-3])),"``MACRO``TAG``ADDR``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression), expr, "i");
     }
     break;
 
-  case 445: /* func_addr_expr: '@' '@' func_addr_name  */
+  case 448: /* func_addr_expr: '@' '@' func_addr_name  */
                                           {
         (yyval.pExpression) = (yyvsp[0].pExpression);
     }
     break;
 
-  case 446: /* $@33: %empty  */
+  case 449: /* $@33: %empty  */
                     { yyextra->das_arrow_depth ++; }
     break;
 
-  case 447: /* $@34: %empty  */
+  case 450: /* $@34: %empty  */
                                                                                                 { yyextra->das_arrow_depth --; }
     break;
 
-  case 448: /* func_addr_expr: '@' '@' '<' $@33 type_declaration_no_options '>' $@34 func_addr_name  */
+  case 451: /* func_addr_expr: '@' '@' '<' $@33 type_declaration_no_options '>' $@34 func_addr_name  */
                                                                                                                                                        {
         auto expr = (ExprAddr *) ((yyvsp[0].pExpression)->rtti_isAddr() ? (yyvsp[0].pExpression) : (((ExprTag *) (yyvsp[0].pExpression))->value));
         expr->funcType = (yyvsp[-3].pTypeDecl);
@@ -7870,15 +7917,15 @@ yyreduce:
     }
     break;
 
-  case 449: /* $@35: %empty  */
+  case 452: /* $@35: %empty  */
                     { yyextra->das_arrow_depth ++; }
     break;
 
-  case 450: /* $@36: %empty  */
+  case 453: /* $@36: %empty  */
                                                                                                                               { yyextra->das_arrow_depth --; }
     break;
 
-  case 451: /* func_addr_expr: '@' '@' '<' $@35 optional_function_argument_list optional_function_type '>' $@36 func_addr_name  */
+  case 454: /* func_addr_expr: '@' '@' '<' $@35 optional_function_argument_list optional_function_type '>' $@36 func_addr_name  */
                                                                                                                                                                                      {
         auto expr = (ExprAddr *) ((yyvsp[0].pExpression)->rtti_isAddr() ? (yyvsp[0].pExpression) : (((ExprTag *) (yyvsp[0].pExpression))->value));
         expr->funcType = new TypeDecl(Type::tFunction);
@@ -7891,21 +7938,21 @@ yyreduce:
     }
     break;
 
-  case 452: /* expr_field_no_bracket: expr_no_bracket '.' "name"  */
+  case 455: /* expr_field_no_bracket: expr_no_bracket '.' "name"  */
                                                          {
         (yyval.pExpression) = new ExprField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), (yyvsp[-2].pExpression), *(yyvsp[0].s));
         delete (yyvsp[0].s);
     }
     break;
 
-  case 453: /* expr_field_no_bracket: expr_no_bracket '.' '.' "name"  */
+  case 456: /* expr_field_no_bracket: expr_no_bracket '.' '.' "name"  */
                                                              {
         (yyval.pExpression) = new ExprField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), (yyvsp[-3].pExpression), *(yyvsp[0].s), true);
         delete (yyvsp[0].s);
     }
     break;
 
-  case 454: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' ')'  */
+  case 457: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' ')'  */
                                                                  {
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-3])), (yyvsp[-4].pExpression), *(yyvsp[-2].s));
         pInvoke->atEnclosure = tokRangeAt(scanner,(yylsp[-4]),(yyloc));
@@ -7914,7 +7961,7 @@ yyreduce:
     }
     break;
 
-  case 455: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' expr_list ')'  */
+  case 458: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' expr_list ')'  */
                                                                                       {
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-4])), (yyvsp[-5].pExpression), *(yyvsp[-3].s));
         pInvoke->atEnclosure = tokRangeAt(scanner,(yylsp[-5]),(yyloc));
@@ -7925,7 +7972,7 @@ yyreduce:
     }
     break;
 
-  case 456: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' '[' make_struct_fields ']' ')'  */
+  case 459: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' '[' make_struct_fields ']' ')'  */
                                                                                                   {
         auto nc = new ExprNamedCall(tokAt(scanner,(yylsp[-5])),*(yyvsp[-5].s));
         nc->methodCall = true;
@@ -7936,7 +7983,7 @@ yyreduce:
     }
     break;
 
-  case 457: /* expr_field_no_bracket: expr_no_bracket '.' basic_type_declaration '(' ')'  */
+  case 460: /* expr_field_no_bracket: expr_no_bracket '.' basic_type_declaration '(' ')'  */
                                                                                    {
         auto method_name = das_to_string((yyvsp[-2].type));
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-3])), (yyvsp[-4].pExpression), method_name);
@@ -7945,7 +7992,7 @@ yyreduce:
     }
     break;
 
-  case 458: /* expr_field_no_bracket: expr_no_bracket '.' basic_type_declaration '(' expr_list ')'  */
+  case 461: /* expr_field_no_bracket: expr_no_bracket '.' basic_type_declaration '(' expr_list ')'  */
                                                                                                         {
         auto method_name = das_to_string((yyvsp[-3].type));
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-4])), (yyvsp[-5].pExpression), method_name);
@@ -7956,29 +8003,29 @@ yyreduce:
     }
     break;
 
-  case 459: /* $@37: %empty  */
+  case 462: /* $@37: %empty  */
                                           { yyextra->das_suppress_errors=true; }
     break;
 
-  case 460: /* $@38: %empty  */
+  case 463: /* $@38: %empty  */
                                                                                        { yyextra->das_suppress_errors=false; }
     break;
 
-  case 461: /* expr_field_no_bracket: expr_no_bracket '.' $@37 error $@38  */
+  case 464: /* expr_field_no_bracket: expr_no_bracket '.' $@37 error $@38  */
                                                                                                                                {
         (yyval.pExpression) = new ExprField(tokAt(scanner,(yylsp[-3])), tokAt(scanner,(yylsp[-3])), (yyvsp[-4].pExpression), "");
         yyerrok;
     }
     break;
 
-  case 462: /* expr_call: name_in_namespace '(' ')'  */
+  case 465: /* expr_call: name_in_namespace '(' ')'  */
                                                {
             (yyval.pExpression) = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])),*(yyvsp[-2].s));
             delete (yyvsp[-2].s);
     }
     break;
 
-  case 463: /* expr_call: name_in_namespace '(' "uninitialized" ')'  */
+  case 466: /* expr_call: name_in_namespace '(' "uninitialized" ')'  */
                                                           {
             auto dd = new ExprMakeStruct(tokAt(scanner,(yylsp[-3])));
             dd->at = tokAt(scanner,(yylsp[-3]));
@@ -7990,7 +8037,7 @@ yyreduce:
     }
     break;
 
-  case 464: /* expr_call: name_in_namespace '(' make_struct_single ')'  */
+  case 467: /* expr_call: name_in_namespace '(' make_struct_single ')'  */
                                                                {
             ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-3]));
             ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,(yylsp[-3])),*(yyvsp[-3].s));
@@ -8001,7 +8048,7 @@ yyreduce:
     }
     break;
 
-  case 465: /* expr_call: name_in_namespace '(' "uninitialized" make_struct_single ')'  */
+  case 468: /* expr_call: name_in_namespace '(' "uninitialized" make_struct_single ')'  */
                                                                                  {
             ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-4]));
             ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,(yylsp[-4])),*(yyvsp[-4].s));
@@ -8012,178 +8059,178 @@ yyreduce:
     }
     break;
 
-  case 466: /* expr_call: name_in_namespace '(' expr_list ')'  */
+  case 469: /* expr_call: name_in_namespace '(' expr_list ')'  */
                                                                     {
             (yyval.pExpression) = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-3])),tokAt(scanner,(yylsp[0])),*(yyvsp[-3].s)),(yyvsp[-1].pExpression));
             delete (yyvsp[-3].s);
     }
     break;
 
-  case 467: /* expr_call: basic_type_declaration '(' ')'  */
+  case 470: /* expr_call: basic_type_declaration '(' ')'  */
                                                     {
         (yyval.pExpression) = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])),das_to_string((yyvsp[-2].type)));
     }
     break;
 
-  case 468: /* expr_call: basic_type_declaration '(' expr_list ')'  */
+  case 471: /* expr_call: basic_type_declaration '(' expr_list ')'  */
                                                                          {
         (yyval.pExpression) = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-3])),tokAt(scanner,(yylsp[0])),das_to_string((yyvsp[-3].type))),(yyvsp[-1].pExpression));
     }
     break;
 
-  case 469: /* expr: expr_no_bracket  */
+  case 472: /* expr: expr_no_bracket  */
                                        { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 470: /* expr: make_table_decl  */
+  case 473: /* expr: make_table_decl  */
                                      { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 471: /* expr: array_comprehension  */
+  case 474: /* expr: array_comprehension  */
                                      { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 472: /* expr_no_bracket: "null"  */
+  case 475: /* expr_no_bracket: "null"  */
                                               { (yyval.pExpression) = new ExprConstPtr(tokAt(scanner,(yylsp[0])),nullptr); }
     break;
 
-  case 473: /* expr_no_bracket: name_in_namespace  */
+  case 476: /* expr_no_bracket: name_in_namespace  */
                                               { (yyval.pExpression) = new ExprVar(tokAt(scanner,(yylsp[0])),*(yyvsp[0].s)); delete (yyvsp[0].s); }
     break;
 
-  case 474: /* expr_no_bracket: expr_numeric_const  */
+  case 477: /* expr_no_bracket: expr_numeric_const  */
                                               { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 475: /* expr_no_bracket: expr_reader  */
+  case 478: /* expr_no_bracket: expr_reader  */
                                               { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 476: /* expr_no_bracket: string_builder  */
+  case 479: /* expr_no_bracket: string_builder  */
                                               { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 477: /* expr_no_bracket: make_decl_no_bracket  */
+  case 480: /* expr_no_bracket: make_decl_no_bracket  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 478: /* expr_no_bracket: "true"  */
+  case 481: /* expr_no_bracket: "true"  */
                                               { (yyval.pExpression) = new ExprConstBool(tokAt(scanner,(yylsp[0])),true); }
     break;
 
-  case 479: /* expr_no_bracket: "false"  */
+  case 482: /* expr_no_bracket: "false"  */
                                               { (yyval.pExpression) = new ExprConstBool(tokAt(scanner,(yylsp[0])),false); }
     break;
 
-  case 480: /* expr_no_bracket: expr_field_no_bracket  */
+  case 483: /* expr_no_bracket: expr_field_no_bracket  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 481: /* expr_no_bracket: expr_mtag_no_bracket  */
+  case 484: /* expr_no_bracket: expr_mtag_no_bracket  */
                                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 482: /* expr_no_bracket: '!' expr_no_bracket  */
+  case 485: /* expr_no_bracket: '!' expr_no_bracket  */
                                                          { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"!",(yyvsp[0].pExpression)); }
     break;
 
-  case 483: /* expr_no_bracket: '~' expr_no_bracket  */
+  case 486: /* expr_no_bracket: '~' expr_no_bracket  */
                                                          { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"~",(yyvsp[0].pExpression)); }
     break;
 
-  case 484: /* expr_no_bracket: '+' expr_no_bracket  */
+  case 487: /* expr_no_bracket: '+' expr_no_bracket  */
                                                              { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"+",(yyvsp[0].pExpression)); }
     break;
 
-  case 485: /* expr_no_bracket: '-' expr_no_bracket  */
+  case 488: /* expr_no_bracket: '-' expr_no_bracket  */
                                                              { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"-",(yyvsp[0].pExpression)); }
     break;
 
-  case 486: /* expr_no_bracket: expr_no_bracket "<<" expr_no_bracket  */
+  case 489: /* expr_no_bracket: expr_no_bracket "<<" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 487: /* expr_no_bracket: expr_no_bracket ">>" expr_no_bracket  */
+  case 490: /* expr_no_bracket: expr_no_bracket ">>" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 488: /* expr_no_bracket: expr_no_bracket "<<<" expr_no_bracket  */
+  case 491: /* expr_no_bracket: expr_no_bracket "<<<" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<<", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 489: /* expr_no_bracket: expr_no_bracket ">>>" expr_no_bracket  */
+  case 492: /* expr_no_bracket: expr_no_bracket ">>>" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>>", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 490: /* expr_no_bracket: expr_no_bracket '+' expr_no_bracket  */
+  case 493: /* expr_no_bracket: expr_no_bracket '+' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"+", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 491: /* expr_no_bracket: expr_no_bracket '-' expr_no_bracket  */
+  case 494: /* expr_no_bracket: expr_no_bracket '-' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"-", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 492: /* expr_no_bracket: expr_no_bracket '*' expr_no_bracket  */
+  case 495: /* expr_no_bracket: expr_no_bracket '*' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"*", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 493: /* expr_no_bracket: expr_no_bracket '/' expr_no_bracket  */
+  case 496: /* expr_no_bracket: expr_no_bracket '/' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"/", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 494: /* expr_no_bracket: expr_no_bracket '%' expr_no_bracket  */
+  case 497: /* expr_no_bracket: expr_no_bracket '%' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"%", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 495: /* expr_no_bracket: expr_no_bracket '<' expr_no_bracket  */
+  case 498: /* expr_no_bracket: expr_no_bracket '<' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 496: /* expr_no_bracket: expr_no_bracket '>' expr_no_bracket  */
+  case 499: /* expr_no_bracket: expr_no_bracket '>' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 497: /* expr_no_bracket: expr_no_bracket "==" expr_no_bracket  */
+  case 500: /* expr_no_bracket: expr_no_bracket "==" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"==", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 498: /* expr_no_bracket: expr_no_bracket "!=" expr_no_bracket  */
+  case 501: /* expr_no_bracket: expr_no_bracket "!=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"!=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 499: /* expr_no_bracket: expr_no_bracket "<=" expr_no_bracket  */
+  case 502: /* expr_no_bracket: expr_no_bracket "<=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 500: /* expr_no_bracket: expr_no_bracket ">=" expr_no_bracket  */
+  case 503: /* expr_no_bracket: expr_no_bracket ">=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 501: /* expr_no_bracket: expr_no_bracket '&' expr_no_bracket  */
+  case 504: /* expr_no_bracket: expr_no_bracket '&' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 502: /* expr_no_bracket: expr_no_bracket '|' expr_no_bracket  */
+  case 505: /* expr_no_bracket: expr_no_bracket '|' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"|", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 503: /* expr_no_bracket: expr_no_bracket '^' expr_no_bracket  */
+  case 506: /* expr_no_bracket: expr_no_bracket '^' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 504: /* expr_no_bracket: expr_no_bracket "&&" expr_no_bracket  */
+  case 507: /* expr_no_bracket: expr_no_bracket "&&" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&&", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 505: /* expr_no_bracket: expr_no_bracket "||" expr_no_bracket  */
+  case 508: /* expr_no_bracket: expr_no_bracket "||" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"||", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 506: /* expr_no_bracket: expr_no_bracket "^^" expr_no_bracket  */
+  case 509: /* expr_no_bracket: expr_no_bracket "^^" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^^", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 507: /* expr_no_bracket: expr_no_bracket ".." expr_no_bracket  */
+  case 510: /* expr_no_bracket: expr_no_bracket ".." expr_no_bracket  */
                                                                    {
         auto itv = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-1])),"interval");
         itv->arguments.push_back((yyvsp[-2].pExpression));
@@ -8192,23 +8239,23 @@ yyreduce:
     }
     break;
 
-  case 508: /* expr_no_bracket: "++" expr_no_bracket  */
+  case 511: /* expr_no_bracket: "++" expr_no_bracket  */
                                                             { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"++", (yyvsp[0].pExpression)); }
     break;
 
-  case 509: /* expr_no_bracket: "--" expr_no_bracket  */
+  case 512: /* expr_no_bracket: "--" expr_no_bracket  */
                                                             { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"--", (yyvsp[0].pExpression)); }
     break;
 
-  case 510: /* expr_no_bracket: expr_no_bracket "++"  */
+  case 513: /* expr_no_bracket: expr_no_bracket "++"  */
                                                             { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[0])),"+++", (yyvsp[-1].pExpression)); }
     break;
 
-  case 511: /* expr_no_bracket: expr_no_bracket "--"  */
+  case 514: /* expr_no_bracket: expr_no_bracket "--"  */
                                                             { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[0])),"---", (yyvsp[-1].pExpression)); }
     break;
 
-  case 512: /* expr_no_bracket: '(' expr_list optional_comma ')'  */
+  case 515: /* expr_no_bracket: '(' expr_list optional_comma ')'  */
                                                          {
             if ( (yyvsp[-2].pExpression)->rtti_isSequence() ) {
                 auto mkt = new ExprMakeTuple(tokAt(scanner,(yylsp[-2])));
@@ -8224,7 +8271,7 @@ yyreduce:
         }
     break;
 
-  case 513: /* expr_no_bracket: '(' make_struct_single ')'  */
+  case 516: /* expr_no_bracket: '(' make_struct_single ')'  */
                                       {
         auto mkt = new ExprMakeTuple(tokAt(scanner,(yylsp[-1])));
         for ( auto & arg : *(((ExprMakeStruct *)(yyvsp[-1].pExpression))->structs.back()) ) {
@@ -8236,79 +8283,79 @@ yyreduce:
     }
     break;
 
-  case 514: /* expr_no_bracket: expr_no_bracket '[' expr ']'  */
+  case 517: /* expr_no_bracket: expr_no_bracket '[' expr ']'  */
                                                             { (yyval.pExpression) = new ExprAt(tokAt(scanner,(yylsp[-2])), (yyvsp[-3].pExpression), (yyvsp[-1].pExpression)); }
     break;
 
-  case 515: /* expr_no_bracket: expr_no_bracket '.' '[' expr ']'  */
+  case 518: /* expr_no_bracket: expr_no_bracket '.' '[' expr ']'  */
                                                                 { (yyval.pExpression) = new ExprAt(tokAt(scanner,(yylsp[-2])), (yyvsp[-4].pExpression), (yyvsp[-1].pExpression), true); }
     break;
 
-  case 516: /* expr_no_bracket: expr_no_bracket "?[" expr ']'  */
+  case 519: /* expr_no_bracket: expr_no_bracket "?[" expr ']'  */
                                                             { (yyval.pExpression) = new ExprSafeAt(tokAt(scanner,(yylsp[-2])), (yyvsp[-3].pExpression), (yyvsp[-1].pExpression)); }
     break;
 
-  case 517: /* expr_no_bracket: expr_no_bracket '.' "?[" expr ']'  */
+  case 520: /* expr_no_bracket: expr_no_bracket '.' "?[" expr ']'  */
                                                                 { (yyval.pExpression) = new ExprSafeAt(tokAt(scanner,(yylsp[-2])), (yyvsp[-4].pExpression), (yyvsp[-1].pExpression), true); }
     break;
 
-  case 518: /* expr_no_bracket: expr_no_bracket "?." "name"  */
+  case 521: /* expr_no_bracket: expr_no_bracket "?." "name"  */
                                                             { (yyval.pExpression) = new ExprSafeField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), (yyvsp[-2].pExpression), *(yyvsp[0].s)); delete (yyvsp[0].s); }
     break;
 
-  case 519: /* expr_no_bracket: expr_no_bracket '.' "?." "name"  */
+  case 522: /* expr_no_bracket: expr_no_bracket '.' "?." "name"  */
                                                                 { (yyval.pExpression) = new ExprSafeField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), (yyvsp[-3].pExpression), *(yyvsp[0].s), true); delete (yyvsp[0].s); }
     break;
 
-  case 520: /* expr_no_bracket: func_addr_expr  */
+  case 523: /* expr_no_bracket: func_addr_expr  */
                                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 521: /* expr_no_bracket: expr_call  */
+  case 524: /* expr_no_bracket: expr_call  */
                         { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 522: /* expr_no_bracket: '*' expr_no_bracket  */
+  case 525: /* expr_no_bracket: '*' expr_no_bracket  */
                                                               { (yyval.pExpression) = new ExprPtr2Ref(tokAt(scanner,(yylsp[-1])),(yyvsp[0].pExpression)); }
     break;
 
-  case 523: /* expr_no_bracket: "deref" '(' expr ')'  */
+  case 526: /* expr_no_bracket: "deref" '(' expr ')'  */
                                                    { (yyval.pExpression) = new ExprPtr2Ref(tokAt(scanner,(yylsp[-3])),(yyvsp[-1].pExpression)); }
     break;
 
-  case 524: /* expr_no_bracket: "addr" '(' expr ')'  */
+  case 527: /* expr_no_bracket: "addr" '(' expr ')'  */
                                                    { (yyval.pExpression) = new ExprRef2Ptr(tokAt(scanner,(yylsp[-3])),(yyvsp[-1].pExpression)); }
     break;
 
-  case 525: /* expr_no_bracket: expr_generator  */
+  case 528: /* expr_no_bracket: expr_generator  */
                                                    { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 526: /* expr_no_bracket: expr_no_bracket "??" expr_no_bracket  */
+  case 529: /* expr_no_bracket: expr_no_bracket "??" expr_no_bracket  */
                                                                          { (yyval.pExpression) = new ExprNullCoalescing(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),(yyvsp[0].pExpression)); }
     break;
 
-  case 527: /* expr_no_bracket: expr_no_bracket '?' expr_no_bracket ':' expr_no_bracket  */
+  case 530: /* expr_no_bracket: expr_no_bracket '?' expr_no_bracket ':' expr_no_bracket  */
                                                                                            {
             (yyval.pExpression) = new ExprOp3(tokAt(scanner,(yylsp[-3])),"?",(yyvsp[-4].pExpression),(yyvsp[-2].pExpression),(yyvsp[0].pExpression));
         }
     break;
 
-  case 528: /* $@39: %empty  */
+  case 531: /* $@39: %empty  */
                                                           { yyextra->das_arrow_depth ++; }
     break;
 
-  case 529: /* $@40: %empty  */
+  case 532: /* $@40: %empty  */
                                                                                                                                  { yyextra->das_arrow_depth --; }
     break;
 
-  case 530: /* expr_no_bracket: expr_no_bracket "is" "type" '<' $@39 type_declaration_no_options '>' $@40  */
+  case 533: /* expr_no_bracket: expr_no_bracket "is" "type" '<' $@39 type_declaration_no_options '>' $@40  */
                                                                                                                                                                   {
         (yyval.pExpression) = new ExprIs(tokAt(scanner,(yylsp[-6])),(yyvsp[-7].pExpression),(yyvsp[-2].pTypeDecl));
     }
     break;
 
-  case 531: /* expr_no_bracket: expr_no_bracket "is" basic_type_declaration  */
+  case 534: /* expr_no_bracket: expr_no_bracket "is" basic_type_declaration  */
                                                                           {
         auto vdecl = new TypeDecl((yyvsp[0].type));
         vdecl->at = tokAt(scanner,(yylsp[0]));
@@ -8316,29 +8363,29 @@ yyreduce:
     }
     break;
 
-  case 532: /* expr_no_bracket: expr_no_bracket "is" "name"  */
+  case 535: /* expr_no_bracket: expr_no_bracket "is" "name"  */
                                                          {
         (yyval.pExpression) = new ExprIsVariant(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),*(yyvsp[0].s));
         delete (yyvsp[0].s);
     }
     break;
 
-  case 533: /* expr_no_bracket: expr_no_bracket "as" "name"  */
+  case 536: /* expr_no_bracket: expr_no_bracket "as" "name"  */
                                                          {
         (yyval.pExpression) = new ExprAsVariant(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),*(yyvsp[0].s));
         delete (yyvsp[0].s);
     }
     break;
 
-  case 534: /* $@41: %empty  */
+  case 537: /* $@41: %empty  */
                                                           { yyextra->das_arrow_depth ++; }
     break;
 
-  case 535: /* $@42: %empty  */
+  case 538: /* $@42: %empty  */
                                                                                                                       { yyextra->das_arrow_depth --; }
     break;
 
-  case 536: /* expr_no_bracket: expr_no_bracket "as" "type" '<' $@41 type_declaration '>' $@42  */
+  case 539: /* expr_no_bracket: expr_no_bracket "as" "type" '<' $@41 type_declaration '>' $@42  */
                                                                                                                                                        {
         auto vname = (yyvsp[-2].pTypeDecl)->describe();
         (yyval.pExpression) = new ExprAsVariant(tokAt(scanner,(yylsp[-6])),(yyvsp[-7].pExpression),vname);
@@ -8346,28 +8393,28 @@ yyreduce:
     }
     break;
 
-  case 537: /* expr_no_bracket: expr_no_bracket "as" basic_type_declaration  */
+  case 540: /* expr_no_bracket: expr_no_bracket "as" basic_type_declaration  */
                                                                           {
         (yyval.pExpression) = new ExprAsVariant(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),das_to_string((yyvsp[0].type)));
     }
     break;
 
-  case 538: /* expr_no_bracket: expr_no_bracket '?' "as" "name"  */
+  case 541: /* expr_no_bracket: expr_no_bracket '?' "as" "name"  */
                                                              {
         (yyval.pExpression) = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-1])),(yyvsp[-3].pExpression),*(yyvsp[0].s));
         delete (yyvsp[0].s);
     }
     break;
 
-  case 539: /* $@43: %empty  */
+  case 542: /* $@43: %empty  */
                                                               { yyextra->das_arrow_depth ++; }
     break;
 
-  case 540: /* $@44: %empty  */
+  case 543: /* $@44: %empty  */
                                                                                                                           { yyextra->das_arrow_depth --; }
     break;
 
-  case 541: /* expr_no_bracket: expr_no_bracket '?' "as" "type" '<' $@43 type_declaration '>' $@44  */
+  case 544: /* expr_no_bracket: expr_no_bracket '?' "as" "type" '<' $@43 type_declaration '>' $@44  */
                                                                                                                                                            {
         auto vname = (yyvsp[-2].pTypeDecl)->describe();
         (yyval.pExpression) = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-6])),(yyvsp[-8].pExpression),vname);
@@ -8375,60 +8422,60 @@ yyreduce:
     }
     break;
 
-  case 542: /* expr_no_bracket: expr_no_bracket '?' "as" basic_type_declaration  */
+  case 545: /* expr_no_bracket: expr_no_bracket '?' "as" basic_type_declaration  */
                                                                               {
         (yyval.pExpression) = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-1])),(yyvsp[-3].pExpression),das_to_string((yyvsp[0].type)));
     }
     break;
 
-  case 543: /* expr_no_bracket: expr_type_info  */
+  case 546: /* expr_no_bracket: expr_type_info  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 544: /* expr_no_bracket: expr_type_decl  */
+  case 547: /* expr_no_bracket: expr_type_decl  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 545: /* expr_no_bracket: expr_cast  */
+  case 548: /* expr_no_bracket: expr_cast  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 546: /* expr_no_bracket: expr_new  */
+  case 549: /* expr_no_bracket: expr_new  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 547: /* expr_no_bracket: expr_method_call_no_bracket  */
+  case 550: /* expr_no_bracket: expr_method_call_no_bracket  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 548: /* expr_no_bracket: expr_named_call  */
+  case 551: /* expr_no_bracket: expr_named_call  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 549: /* expr_no_bracket: expr_full_block  */
+  case 552: /* expr_no_bracket: expr_full_block  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 550: /* expr_no_bracket: expr_no_bracket "<|" expr_no_bracket  */
+  case 553: /* expr_no_bracket: expr_no_bracket "<|" expr_no_bracket  */
                                                                       { (yyval.pExpression) = ast_lpipe(scanner,(yyvsp[-2].pExpression),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-1]))); }
     break;
 
-  case 551: /* expr_no_bracket: expr_no_bracket "|>" expr_no_bracket  */
+  case 554: /* expr_no_bracket: expr_no_bracket "|>" expr_no_bracket  */
                                                                       { (yyval.pExpression) = ast_rpipe(scanner,(yyvsp[-2].pExpression),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-1]))); }
     break;
 
-  case 552: /* expr_no_bracket: expr_no_bracket "|>" basic_type_declaration  */
+  case 555: /* expr_no_bracket: expr_no_bracket "|>" basic_type_declaration  */
                                                                      {
         auto fncall = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[0])),das_to_string((yyvsp[0].type)));
         (yyval.pExpression) = ast_rpipe(scanner,(yyvsp[-2].pExpression),fncall,tokAt(scanner,(yylsp[-1])));
     }
     break;
 
-  case 553: /* expr_no_bracket: expr_call_pipe_no_bracket  */
+  case 556: /* expr_no_bracket: expr_call_pipe_no_bracket  */
                                         { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 554: /* expr_no_bracket: "unsafe" '(' expr ')'  */
+  case 557: /* expr_no_bracket: "unsafe" '(' expr ')'  */
                                          {
             (yyvsp[-1].pExpression)->alwaysSafe = true;
             (yyvsp[-1].pExpression)->userSaidItsSafe = true;
@@ -8436,7 +8483,7 @@ yyreduce:
         }
     break;
 
-  case 555: /* expr_no_bracket: expr_no_bracket "=>" expr_no_bracket  */
+  case 558: /* expr_no_bracket: expr_no_bracket "=>" expr_no_bracket  */
                                                                {
         ExprMakeTuple * mt = new ExprMakeTuple(tokAt(scanner,(yylsp[-1])));
         mt->values.push_back((yyvsp[-2].pExpression));
@@ -8445,7 +8492,7 @@ yyreduce:
     }
     break;
 
-  case 556: /* expr_no_bracket: expr_no_bracket "=>" make_table_decl  */
+  case 559: /* expr_no_bracket: expr_no_bracket "=>" make_table_decl  */
                                                                {
         ExprMakeTuple * mt = new ExprMakeTuple(tokAt(scanner,(yylsp[-1])));
         mt->values.push_back((yyvsp[-2].pExpression));
@@ -8454,7 +8501,7 @@ yyreduce:
     }
     break;
 
-  case 557: /* expr_no_bracket: expr_no_bracket "=>" array_comprehension  */
+  case 560: /* expr_no_bracket: expr_no_bracket "=>" array_comprehension  */
                                                                    {
         ExprMakeTuple * mt = new ExprMakeTuple(tokAt(scanner,(yylsp[-1])));
         mt->values.push_back((yyvsp[-2].pExpression));
@@ -8463,19 +8510,19 @@ yyreduce:
     }
     break;
 
-  case 558: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list '(' ')'  */
+  case 561: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list '(' ')'  */
                                                                                                               {
         (yyval.pExpression) = ast_makeGenerator(scanner,(yyvsp[-4].pTypeDecl),(yyvsp[-2].pCaptList),nullptr,tokAt(scanner,(yylsp[-6])),tokAt(scanner,(yylsp[-2])));
     }
     break;
 
-  case 559: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list '(' expr ')'  */
+  case 562: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list '(' expr ')'  */
                                                                                                                             {
         (yyval.pExpression) = ast_makeGenerator(scanner,(yyvsp[-5].pTypeDecl),(yyvsp[-3].pCaptList),(yyvsp[-1].pExpression),tokAt(scanner,(yylsp[-7])),tokAt(scanner,(yylsp[-3])));
     }
     break;
 
-  case 560: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list optional_emit_semis expression_block  */
+  case 563: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list optional_emit_semis expression_block  */
                                                                                                                                                   {
         auto closure = new ExprMakeBlock(tokAt(scanner,(yylsp[0])),(yyvsp[0].pExpression));
         ((ExprBlock *)(yyvsp[0].pExpression))->returnType = new TypeDecl(Type::autoinfer);
@@ -8483,149 +8530,149 @@ yyreduce:
     }
     break;
 
-  case 561: /* expr_mtag_no_bracket: "$$" '(' expr ')'  */
+  case 564: /* expr_mtag_no_bracket: "$$" '(' expr ')'  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"e"); }
     break;
 
-  case 562: /* expr_mtag_no_bracket: "$i" '(' expr ')'  */
+  case 565: /* expr_mtag_no_bracket: "$i" '(' expr ')'  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"i"); }
     break;
 
-  case 563: /* expr_mtag_no_bracket: "$v" '(' expr ')'  */
+  case 566: /* expr_mtag_no_bracket: "$v" '(' expr ')'  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"v"); }
     break;
 
-  case 564: /* expr_mtag_no_bracket: "$b" '(' expr ')'  */
+  case 567: /* expr_mtag_no_bracket: "$b" '(' expr ')'  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"b"); }
     break;
 
-  case 565: /* expr_mtag_no_bracket: "$a" '(' expr ')'  */
+  case 568: /* expr_mtag_no_bracket: "$a" '(' expr ')'  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"a"); }
     break;
 
-  case 566: /* expr_mtag_no_bracket: "..."  */
+  case 569: /* expr_mtag_no_bracket: "..."  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[0])),nullptr,"..."); }
     break;
 
-  case 567: /* expr_mtag_no_bracket: "$c" '(' expr ')' '(' ')'  */
+  case 570: /* expr_mtag_no_bracket: "$c" '(' expr ')' '(' ')'  */
                                                             {
             auto ccall = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-5])),tokAt(scanner,(yylsp[0])),"``MACRO``TAG``CALL``");
             (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-5])),(yyvsp[-3].pExpression),ccall,"c");
         }
     break;
 
-  case 568: /* expr_mtag_no_bracket: "$c" '(' expr ')' '(' expr_list ')'  */
+  case 571: /* expr_mtag_no_bracket: "$c" '(' expr ')' '(' expr_list ')'  */
                                                                                 {
             auto ccall = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-6])),tokAt(scanner,(yylsp[0])),"``MACRO``TAG``CALL``"),(yyvsp[-1].pExpression));
             (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-6])),(yyvsp[-4].pExpression),ccall,"c");
         }
     break;
 
-  case 569: /* expr_mtag_no_bracket: expr_no_bracket '.' "$f" '(' expr ')'  */
+  case 572: /* expr_mtag_no_bracket: expr_no_bracket '.' "$f" '(' expr ')'  */
                                                                            {
         auto cfield = new ExprField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), (yyvsp[-5].pExpression), "``MACRO``TAG``FIELD``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 570: /* expr_mtag_no_bracket: expr_no_bracket "?." "$f" '(' expr ')'  */
+  case 573: /* expr_mtag_no_bracket: expr_no_bracket "?." "$f" '(' expr ')'  */
                                                                             {
         auto cfield = new ExprSafeField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), (yyvsp[-5].pExpression), "``MACRO``TAG``FIELD``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 571: /* expr_mtag_no_bracket: expr_no_bracket '.' '.' "$f" '(' expr ')'  */
+  case 574: /* expr_mtag_no_bracket: expr_no_bracket '.' '.' "$f" '(' expr ')'  */
                                                                                {
         auto cfield = new ExprField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), (yyvsp[-6].pExpression), "``MACRO``TAG``FIELD``", true);
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 572: /* expr_mtag_no_bracket: expr_no_bracket '.' "?." "$f" '(' expr ')'  */
+  case 575: /* expr_mtag_no_bracket: expr_no_bracket '.' "?." "$f" '(' expr ')'  */
                                                                                 {
         auto cfield = new ExprSafeField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), (yyvsp[-6].pExpression), "``MACRO``TAG``FIELD``", true);
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 573: /* expr_mtag_no_bracket: expr_no_bracket "as" "$f" '(' expr ')'  */
+  case 576: /* expr_mtag_no_bracket: expr_no_bracket "as" "$f" '(' expr ')'  */
                                                                               {
         auto cfield = new ExprAsVariant(tokAt(scanner,(yylsp[-4])),(yyvsp[-5].pExpression),"``MACRO``TAG``FIELD``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 574: /* expr_mtag_no_bracket: expr_no_bracket '?' "as" "$f" '(' expr ')'  */
+  case 577: /* expr_mtag_no_bracket: expr_no_bracket '?' "as" "$f" '(' expr ')'  */
                                                                                   {
         auto cfield = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-4])),(yyvsp[-6].pExpression),"``MACRO``TAG``FIELD``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 575: /* expr_mtag_no_bracket: expr_no_bracket "is" "$f" '(' expr ')'  */
+  case 578: /* expr_mtag_no_bracket: expr_no_bracket "is" "$f" '(' expr ')'  */
                                                                               {
         auto cfield = new ExprIsVariant(tokAt(scanner,(yylsp[-4])),(yyvsp[-5].pExpression),"``MACRO``TAG``FIELD``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 576: /* expr_mtag_no_bracket: '@' '@' "$c" '(' expr ')'  */
+  case 579: /* expr_mtag_no_bracket: '@' '@' "$c" '(' expr ')'  */
                                                          {
         auto ccall = new ExprAddr(tokAt(scanner,(yylsp[-4])),"``MACRO``TAG``ADDR``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-3])),(yyvsp[-1].pExpression),ccall,"c");
     }
     break;
 
-  case 577: /* optional_field_annotation: %empty  */
+  case 580: /* optional_field_annotation: %empty  */
                                       { (yyval.aaList) = nullptr; }
     break;
 
-  case 578: /* optional_field_annotation: metadata_argument_list  */
+  case 581: /* optional_field_annotation: metadata_argument_list  */
                                       { (yyval.aaList) = (yyvsp[0].aaList); }
     break;
 
-  case 579: /* optional_override: %empty  */
+  case 582: /* optional_override: %empty  */
                       { (yyval.i) = OVERRIDE_NONE; }
     break;
 
-  case 580: /* optional_override: "override"  */
+  case 583: /* optional_override: "override"  */
                       { (yyval.i) = OVERRIDE_OVERRIDE; }
     break;
 
-  case 581: /* optional_override: "sealed"  */
+  case 584: /* optional_override: "sealed"  */
                       { (yyval.i) = OVERRIDE_SEALED; }
     break;
 
-  case 582: /* optional_constant: %empty  */
+  case 585: /* optional_constant: %empty  */
                         { (yyval.b) = false; }
     break;
 
-  case 583: /* optional_constant: "const"  */
+  case 586: /* optional_constant: "const"  */
                         { (yyval.b) = true; }
     break;
 
-  case 584: /* optional_public_or_private_member_variable: %empty  */
+  case 587: /* optional_public_or_private_member_variable: %empty  */
                         { (yyval.b) = false; }
     break;
 
-  case 585: /* optional_public_or_private_member_variable: "public"  */
+  case 588: /* optional_public_or_private_member_variable: "public"  */
                         { (yyval.b) = false; }
     break;
 
-  case 586: /* optional_public_or_private_member_variable: "private"  */
+  case 589: /* optional_public_or_private_member_variable: "private"  */
                         { (yyval.b) = true; }
     break;
 
-  case 587: /* optional_static_member_variable: %empty  */
+  case 590: /* optional_static_member_variable: %empty  */
                         { (yyval.b) = false; }
     break;
 
-  case 588: /* optional_static_member_variable: "static"  */
+  case 591: /* optional_static_member_variable: "static"  */
                         { (yyval.b) = true; }
     break;
 
-  case 589: /* structure_variable_declaration: optional_field_annotation optional_static_member_variable optional_override optional_public_or_private_member_variable variable_declaration  */
+  case 592: /* structure_variable_declaration: optional_field_annotation optional_static_member_variable optional_override optional_public_or_private_member_variable variable_declaration  */
                                                                                                                                                                                       {
         (yyvsp[0].pVarDecl)->override = (yyvsp[-2].i) == OVERRIDE_OVERRIDE;
         (yyvsp[0].pVarDecl)->sealed = (yyvsp[-2].i) == OVERRIDE_SEALED;
@@ -8636,24 +8683,24 @@ yyreduce:
     }
     break;
 
-  case 590: /* struct_variable_declaration_list: %empty  */
+  case 593: /* struct_variable_declaration_list: %empty  */
         {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 591: /* struct_variable_declaration_list: struct_variable_declaration_list "new line, semicolon"  */
+  case 594: /* struct_variable_declaration_list: struct_variable_declaration_list "new line, semicolon"  */
                                                                  { (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList); }
     break;
 
-  case 592: /* struct_variable_declaration_list: struct_variable_declaration_list "typedef" "name" '=' type_declaration SEMICOLON  */
+  case 595: /* struct_variable_declaration_list: struct_variable_declaration_list "typedef" "name" '=' type_declaration SEMICOLON  */
                                                                                                                 {
         (yyval.pVarDeclList) = (yyvsp[-5].pVarDeclList);
         ast_structureAlias(scanner,(yyvsp[-3].s),(yyvsp[-1].pTypeDecl),tokAt(scanner,(yylsp[-4])));
     }
     break;
 
-  case 593: /* $@45: %empty  */
+  case 596: /* $@45: %empty  */
                                                {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -8662,7 +8709,7 @@ yyreduce:
     }
     break;
 
-  case 594: /* struct_variable_declaration_list: struct_variable_declaration_list $@45 structure_variable_declaration SEMICOLON  */
+  case 597: /* struct_variable_declaration_list: struct_variable_declaration_list $@45 structure_variable_declaration SEMICOLON  */
                                                      {
         (yyval.pVarDeclList) = (yyvsp[-3].pVarDeclList);
         if ( (yyvsp[-1].pVarDecl) ) (yyvsp[-3].pVarDeclList)->push_back((yyvsp[-1].pVarDecl));
@@ -8678,7 +8725,7 @@ yyreduce:
     }
     break;
 
-  case 595: /* $@46: %empty  */
+  case 598: /* $@46: %empty  */
                                                                                                                      {
                 if ( !yyextra->g_CommentReaders.empty() ) {
                     auto tak = tokAt(scanner,(yylsp[-2]));
@@ -8687,7 +8734,7 @@ yyreduce:
             }
     break;
 
-  case 596: /* struct_variable_declaration_list: struct_variable_declaration_list optional_annotation_list_with_emit_semis "def" optional_public_or_private_member_variable "abstract" optional_constant $@46 function_declaration_header SEMICOLON  */
+  case 599: /* struct_variable_declaration_list: struct_variable_declaration_list optional_annotation_list_with_emit_semis "def" optional_public_or_private_member_variable "abstract" optional_constant $@46 function_declaration_header SEMICOLON  */
                                                           {
                 if ( !yyextra->g_CommentReaders.empty() ) {
                     auto tak = tokAt(scanner,(yylsp[-1]));
@@ -8698,7 +8745,7 @@ yyreduce:
             }
     break;
 
-  case 597: /* $@47: %empty  */
+  case 600: /* $@47: %empty  */
                                                                                                                                                                          {
                 if ( !yyextra->g_CommentReaders.empty() ) {
                     auto tak = tokAt(scanner,(yylsp[0]));
@@ -8707,7 +8754,7 @@ yyreduce:
             }
     break;
 
-  case 598: /* struct_variable_declaration_list: struct_variable_declaration_list optional_annotation_list_with_emit_semis "def" optional_public_or_private_member_variable optional_static_member_variable optional_override optional_constant $@47 function_declaration_header optional_emit_semis expression_block  */
+  case 601: /* struct_variable_declaration_list: struct_variable_declaration_list optional_annotation_list_with_emit_semis "def" optional_public_or_private_member_variable optional_static_member_variable optional_override optional_constant $@47 function_declaration_header optional_emit_semis expression_block  */
                                                                                             {
                 if ( !yyextra->g_CommentReaders.empty() ) {
                     auto tak = tokAt(scanner,(yylsp[0]));
@@ -8718,7 +8765,7 @@ yyreduce:
             }
     break;
 
-  case 599: /* function_argument_declaration_no_type: optional_field_annotation kwd_let_var_or_nothing variable_declaration_no_type  */
+  case 602: /* function_argument_declaration_no_type: optional_field_annotation kwd_let_var_or_nothing variable_declaration_no_type  */
                                                                                                           {
             (yyval.pVarDecl) = (yyvsp[0].pVarDecl);
             if ( (yyvsp[-1].b) ) {
@@ -8730,7 +8777,7 @@ yyreduce:
         }
     break;
 
-  case 600: /* function_argument_declaration_type: optional_field_annotation kwd_let_var_or_nothing variable_declaration_type  */
+  case 603: /* function_argument_declaration_type: optional_field_annotation kwd_let_var_or_nothing variable_declaration_type  */
                                                                                                        {
             (yyval.pVarDecl) = (yyvsp[0].pVarDecl);
             if ( (yyvsp[-1].b) ) {
@@ -8742,7 +8789,7 @@ yyreduce:
         }
     break;
 
-  case 601: /* function_argument_declaration_type: "$a" '(' expr ')'  */
+  case 604: /* function_argument_declaration_type: "$a" '(' expr ')'  */
                                      {
             auto na = new vector<VariableNameAndPosition>();
             na->push_back(VariableNameAndPosition("``MACRO``TAG``","",tokAt(scanner,(yylsp[-1]))));
@@ -8752,33 +8799,33 @@ yyreduce:
         }
     break;
 
-  case 602: /* function_argument_list: function_argument_declaration_no_type  */
+  case 605: /* function_argument_list: function_argument_declaration_no_type  */
                                                                                       { (yyval.pVarDeclList) = new vector<VariableDeclaration*>(); (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 603: /* function_argument_list: function_argument_declaration_type  */
+  case 606: /* function_argument_list: function_argument_declaration_type  */
                                                                                       { (yyval.pVarDeclList) = new vector<VariableDeclaration*>(); (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 604: /* function_argument_list: function_argument_declaration_no_type ';' function_argument_list  */
+  case 607: /* function_argument_list: function_argument_declaration_no_type ';' function_argument_list  */
                                                                                       { (yyval.pVarDeclList) = (yyvsp[0].pVarDeclList); (yyvsp[0].pVarDeclList)->insert((yyvsp[0].pVarDeclList)->begin(),(yyvsp[-2].pVarDecl)); }
     break;
 
-  case 605: /* function_argument_list: function_argument_declaration_type ';' function_argument_list  */
+  case 608: /* function_argument_list: function_argument_declaration_type ';' function_argument_list  */
                                                                                       { (yyval.pVarDeclList) = (yyvsp[0].pVarDeclList); (yyvsp[0].pVarDeclList)->insert((yyvsp[0].pVarDeclList)->begin(),(yyvsp[-2].pVarDecl)); }
     break;
 
-  case 606: /* function_argument_list: function_argument_declaration_type ',' function_argument_list  */
+  case 609: /* function_argument_list: function_argument_declaration_type ',' function_argument_list  */
                                                                                       { (yyval.pVarDeclList) = (yyvsp[0].pVarDeclList); (yyvsp[0].pVarDeclList)->insert((yyvsp[0].pVarDeclList)->begin(),(yyvsp[-2].pVarDecl)); }
     break;
 
-  case 607: /* tuple_type: type_declaration  */
+  case 610: /* tuple_type: type_declaration  */
                                     {
         (yyval.pVarDecl) = new VariableDeclaration(nullptr,(yyvsp[0].pTypeDecl),nullptr);
     }
     break;
 
-  case 608: /* tuple_type: "name" ':' type_declaration  */
+  case 611: /* tuple_type: "name" ':' type_declaration  */
                                                    {
         auto na = new vector<VariableNameAndPosition>();
         na->push_back(VariableNameAndPosition(*(yyvsp[-2].s),"",tokAt(scanner,(yylsp[-2]))));
@@ -8787,28 +8834,28 @@ yyreduce:
     }
     break;
 
-  case 609: /* tuple_type_list: tuple_type  */
+  case 612: /* tuple_type_list: tuple_type  */
                                                        { (yyval.pVarDeclList) = new vector<VariableDeclaration*>(); (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 610: /* tuple_type_list: tuple_type_list c_or_s tuple_type  */
+  case 613: /* tuple_type_list: tuple_type_list c_or_s tuple_type  */
                                                        { (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 611: /* tuple_alias_type_list: %empty  */
+  case 614: /* tuple_alias_type_list: %empty  */
       {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 612: /* tuple_alias_type_list: tuple_type  */
+  case 615: /* tuple_alias_type_list: tuple_type  */
                        {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
         (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl));
     }
     break;
 
-  case 613: /* tuple_alias_type_list: tuple_alias_type_list semis tuple_type  */
+  case 616: /* tuple_alias_type_list: tuple_alias_type_list semis tuple_type  */
                                                          {
         (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[0].pVarDecl));
         if ( !yyextra->g_CommentReaders.empty() ) {
@@ -8821,7 +8868,7 @@ yyreduce:
     }
     break;
 
-  case 614: /* variant_type: "name" ':' type_declaration  */
+  case 617: /* variant_type: "name" ':' type_declaration  */
                                                    {
         auto na = new vector<VariableNameAndPosition>();
         na->push_back(VariableNameAndPosition(*(yyvsp[-2].s),"",tokAt(scanner,(yylsp[-2]))));
@@ -8830,28 +8877,28 @@ yyreduce:
     }
     break;
 
-  case 615: /* variant_type_list: variant_type  */
+  case 618: /* variant_type_list: variant_type  */
                                                          { (yyval.pVarDeclList) = new vector<VariableDeclaration*>(); (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 616: /* variant_type_list: variant_type_list c_or_s variant_type  */
+  case 619: /* variant_type_list: variant_type_list c_or_s variant_type  */
                                                             { (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 617: /* variant_alias_type_list: %empty  */
+  case 620: /* variant_alias_type_list: %empty  */
         {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 618: /* variant_alias_type_list: variant_type  */
+  case 621: /* variant_alias_type_list: variant_type  */
                          {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
         (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl));
     }
     break;
 
-  case 619: /* variant_alias_type_list: variant_alias_type_list semis variant_type  */
+  case 622: /* variant_alias_type_list: variant_alias_type_list semis variant_type  */
                                                                {
         (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[0].pVarDecl));
         if ( !yyextra->g_CommentReaders.empty() ) {
@@ -8864,15 +8911,15 @@ yyreduce:
     }
     break;
 
-  case 620: /* copy_or_move: '='  */
+  case 623: /* copy_or_move: '='  */
                     { (yyval.b) = false; }
     break;
 
-  case 621: /* copy_or_move: "<-"  */
+  case 624: /* copy_or_move: "<-"  */
                     { (yyval.b) = true; }
     break;
 
-  case 622: /* variable_declaration_no_type: variable_name_with_pos_list  */
+  case 625: /* variable_declaration_no_type: variable_name_with_pos_list  */
                                           {
         auto autoT = new TypeDecl(Type::autoinfer);
         autoT->at = tokAt(scanner,(yylsp[0]));
@@ -8881,7 +8928,7 @@ yyreduce:
     }
     break;
 
-  case 623: /* variable_declaration_no_type: variable_name_with_pos_list '&'  */
+  case 626: /* variable_declaration_no_type: variable_name_with_pos_list '&'  */
                                               {
         auto autoT = new TypeDecl(Type::autoinfer);
         autoT->at = tokAt(scanner,(yylsp[-1]));
@@ -8890,7 +8937,7 @@ yyreduce:
     }
     break;
 
-  case 624: /* variable_declaration_no_type: variable_name_with_pos_list copy_or_move expr  */
+  case 627: /* variable_declaration_no_type: variable_name_with_pos_list copy_or_move expr  */
                                                                        {
         auto typeDecl = new TypeDecl(Type::autoinfer);
         typeDecl->at = tokAt(scanner,(yylsp[-2]));
@@ -8899,52 +8946,52 @@ yyreduce:
     }
     break;
 
-  case 625: /* variable_declaration_type: variable_name_with_pos_list ':' type_declaration  */
+  case 628: /* variable_declaration_type: variable_name_with_pos_list ':' type_declaration  */
                                                                           {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-2].pNameWithPosList),(yyvsp[0].pTypeDecl),nullptr);
     }
     break;
 
-  case 626: /* variable_declaration_type: variable_name_with_pos_list ':' type_declaration copy_or_move expr  */
+  case 629: /* variable_declaration_type: variable_name_with_pos_list ':' type_declaration copy_or_move expr  */
                                                                                                       {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-4].pNameWithPosList),(yyvsp[-2].pTypeDecl),(yyvsp[0].pExpression));
         (yyval.pVarDecl)->init_via_move = (yyvsp[-1].b);
     }
     break;
 
-  case 627: /* variable_declaration: variable_declaration_type  */
+  case 630: /* variable_declaration: variable_declaration_type  */
                                         {
         (yyval.pVarDecl) = (yyvsp[0].pVarDecl);
     }
     break;
 
-  case 628: /* variable_declaration: variable_declaration_no_type  */
+  case 631: /* variable_declaration: variable_declaration_no_type  */
                                            {
         (yyval.pVarDecl) = (yyvsp[0].pVarDecl);
     }
     break;
 
-  case 629: /* copy_or_move_or_clone: '='  */
+  case 632: /* copy_or_move_or_clone: '='  */
                     { (yyval.i) = CorM_COPY; }
     break;
 
-  case 630: /* copy_or_move_or_clone: "<-"  */
+  case 633: /* copy_or_move_or_clone: "<-"  */
                     { (yyval.i) = CorM_MOVE; }
     break;
 
-  case 631: /* copy_or_move_or_clone: ":="  */
+  case 634: /* copy_or_move_or_clone: ":="  */
                     { (yyval.i) = CorM_CLONE; }
     break;
 
-  case 632: /* optional_ref: %empty  */
+  case 635: /* optional_ref: %empty  */
             { (yyval.b) = false; }
     break;
 
-  case 633: /* optional_ref: '&'  */
+  case 636: /* optional_ref: '&'  */
             { (yyval.b) = true; }
     break;
 
-  case 634: /* let_variable_name_with_pos_list: "name"  */
+  case 637: /* let_variable_name_with_pos_list: "name"  */
                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         auto pSL = new vector<VariableNameAndPosition>();
@@ -8954,7 +9001,7 @@ yyreduce:
     }
     break;
 
-  case 635: /* let_variable_name_with_pos_list: "$i" '(' expr ')'  */
+  case 638: /* let_variable_name_with_pos_list: "$i" '(' expr ')'  */
                                      {
         auto pSL = new vector<VariableNameAndPosition>();
         pSL->push_back(VariableNameAndPosition("``MACRO``TAG``","",tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression)));
@@ -8962,7 +9009,7 @@ yyreduce:
     }
     break;
 
-  case 636: /* let_variable_name_with_pos_list: "name" "aka" "name"  */
+  case 639: /* let_variable_name_with_pos_list: "name" "aka" "name"  */
                                          {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -8974,7 +9021,7 @@ yyreduce:
     }
     break;
 
-  case 637: /* let_variable_name_with_pos_list: let_variable_name_with_pos_list ',' "name"  */
+  case 640: /* let_variable_name_with_pos_list: let_variable_name_with_pos_list ',' "name"  */
                                                              {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameWithPosList)->push_back(VariableNameAndPosition(*(yyvsp[0].s),"",tokAt(scanner,(yylsp[0]))));
@@ -8983,7 +9030,7 @@ yyreduce:
     }
     break;
 
-  case 638: /* let_variable_name_with_pos_list: let_variable_name_with_pos_list ',' "name" "aka" "name"  */
+  case 641: /* let_variable_name_with_pos_list: let_variable_name_with_pos_list ',' "name" "aka" "name"  */
                                                                                    {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -8994,7 +9041,7 @@ yyreduce:
     }
     break;
 
-  case 639: /* global_let_variable_name_with_pos_list: "name"  */
+  case 642: /* global_let_variable_name_with_pos_list: "name"  */
                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         auto pSL = new vector<VariableNameAndPosition>();
@@ -9004,7 +9051,7 @@ yyreduce:
     }
     break;
 
-  case 640: /* global_let_variable_name_with_pos_list: global_let_variable_name_with_pos_list ',' "name"  */
+  case 643: /* global_let_variable_name_with_pos_list: global_let_variable_name_with_pos_list ',' "name"  */
                                                                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameWithPosList)->push_back(VariableNameAndPosition(*(yyvsp[0].s),"",tokAt(scanner,(yylsp[0]))));
@@ -9013,32 +9060,32 @@ yyreduce:
     }
     break;
 
-  case 641: /* variable_declaration_list: %empty  */
+  case 644: /* variable_declaration_list: %empty  */
         {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 642: /* variable_declaration_list: variable_declaration_list SEMICOLON  */
+  case 645: /* variable_declaration_list: variable_declaration_list SEMICOLON  */
                                                   {
         (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList);
     }
     break;
 
-  case 643: /* variable_declaration_list: variable_declaration_list let_variable_declaration  */
+  case 646: /* variable_declaration_list: variable_declaration_list let_variable_declaration  */
                                                                        {
         (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList);
         (yyvsp[-1].pVarDeclList)->push_back((yyvsp[0].pVarDecl));
     }
     break;
 
-  case 644: /* let_variable_declaration: let_variable_name_with_pos_list ':' type_declaration_no_options SEMICOLON  */
+  case 647: /* let_variable_declaration: let_variable_name_with_pos_list ':' type_declaration_no_options SEMICOLON  */
                                                                                                   {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-3].pNameWithPosList),(yyvsp[-1].pTypeDecl),nullptr);
     }
     break;
 
-  case 645: /* let_variable_declaration: let_variable_name_with_pos_list ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
+  case 648: /* let_variable_declaration: let_variable_name_with_pos_list ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                                         {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-5].pNameWithPosList),(yyvsp[-3].pTypeDecl),(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -9046,7 +9093,7 @@ yyreduce:
     }
     break;
 
-  case 646: /* let_variable_declaration: let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr SEMICOLON  */
+  case 649: /* let_variable_declaration: let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                 {
         auto typeDecl = new TypeDecl(Type::autoinfer);
         typeDecl->at = tokAt(scanner,(yylsp[-4]));
@@ -9057,13 +9104,13 @@ yyreduce:
     }
     break;
 
-  case 647: /* global_let_variable_declaration: global_let_variable_name_with_pos_list ':' type_declaration_no_options SEMICOLON  */
+  case 650: /* global_let_variable_declaration: global_let_variable_name_with_pos_list ':' type_declaration_no_options SEMICOLON  */
                                                                                                          {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-3].pNameWithPosList),(yyvsp[-1].pTypeDecl),nullptr);
     }
     break;
 
-  case 648: /* global_let_variable_declaration: global_let_variable_name_with_pos_list ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
+  case 651: /* global_let_variable_declaration: global_let_variable_name_with_pos_list ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                                                {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-5].pNameWithPosList),(yyvsp[-3].pTypeDecl),(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -9071,7 +9118,7 @@ yyreduce:
     }
     break;
 
-  case 649: /* global_let_variable_declaration: global_let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr SEMICOLON  */
+  case 652: /* global_let_variable_declaration: global_let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                        {
         auto typeDecl = new TypeDecl(Type::autoinfer);
         typeDecl->at = tokAt(scanner,(yylsp[-4]));
@@ -9082,39 +9129,39 @@ yyreduce:
     }
     break;
 
-  case 650: /* optional_shared: %empty  */
+  case 653: /* optional_shared: %empty  */
                      { (yyval.b) = false; }
     break;
 
-  case 651: /* optional_shared: "shared"  */
+  case 654: /* optional_shared: "shared"  */
                      { (yyval.b) = true; }
     break;
 
-  case 652: /* optional_public_or_private_variable: %empty  */
+  case 655: /* optional_public_or_private_variable: %empty  */
                      { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
     break;
 
-  case 653: /* optional_public_or_private_variable: "private"  */
+  case 656: /* optional_public_or_private_variable: "private"  */
                      { (yyval.b) = false; }
     break;
 
-  case 654: /* optional_public_or_private_variable: "public"  */
+  case 657: /* optional_public_or_private_variable: "public"  */
                      { (yyval.b) = true; }
     break;
 
-  case 655: /* global_variable_declaration_list: %empty  */
+  case 658: /* global_variable_declaration_list: %empty  */
         {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 656: /* global_variable_declaration_list: global_variable_declaration_list SEMICOLON  */
+  case 659: /* global_variable_declaration_list: global_variable_declaration_list SEMICOLON  */
                                                          {
         (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList);
     }
     break;
 
-  case 657: /* $@48: %empty  */
+  case 660: /* $@48: %empty  */
                                                {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -9123,7 +9170,7 @@ yyreduce:
     }
     break;
 
-  case 658: /* global_variable_declaration_list: global_variable_declaration_list $@48 optional_field_annotation let_variable_declaration  */
+  case 661: /* global_variable_declaration_list: global_variable_declaration_list $@48 optional_field_annotation let_variable_declaration  */
                                                                       {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -9138,13 +9185,13 @@ yyreduce:
     }
     break;
 
-  case 659: /* global_let: kwd_let optional_shared optional_public_or_private_variable '{' global_variable_declaration_list '}'  */
+  case 662: /* global_let: kwd_let optional_shared optional_public_or_private_variable '{' global_variable_declaration_list '}'  */
                                                                                                                                        {
         ast_globalLetList(scanner,(yyvsp[-5].b),(yyvsp[-4].b),(yyvsp[-3].b),(yyvsp[-1].pVarDeclList));
     }
     break;
 
-  case 660: /* $@49: %empty  */
+  case 663: /* $@49: %empty  */
                                                                                         {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -9153,7 +9200,7 @@ yyreduce:
     }
     break;
 
-  case 661: /* global_let: kwd_let optional_shared optional_public_or_private_variable $@49 optional_field_annotation global_let_variable_declaration  */
+  case 664: /* global_let: kwd_let optional_shared optional_public_or_private_variable $@49 optional_field_annotation global_let_variable_declaration  */
                                                                            {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -9166,7 +9213,7 @@ yyreduce:
     }
     break;
 
-  case 662: /* enum_expression: "name"  */
+  case 665: /* enum_expression: "name"  */
                    {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyval.pEnumPair) = new EnumPair((yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -9174,7 +9221,7 @@ yyreduce:
     }
     break;
 
-  case 663: /* enum_expression: "name" '=' expr  */
+  case 666: /* enum_expression: "name" '=' expr  */
                                    {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         (yyval.pEnumPair) = new EnumPair((yyvsp[-2].s),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-2])));
@@ -9182,13 +9229,13 @@ yyreduce:
     }
     break;
 
-  case 666: /* enum_list: %empty  */
+  case 669: /* enum_list: %empty  */
         {
         (yyval.pEnumList) = new Enumeration();
     }
     break;
 
-  case 667: /* enum_list: enum_expression  */
+  case 670: /* enum_list: enum_expression  */
                             {
         (yyval.pEnumList) = new Enumeration();
         if ( !(yyval.pEnumList)->add((yyvsp[0].pEnumPair)->name,(yyvsp[0].pEnumPair)->expr,(yyvsp[0].pEnumPair)->at) ) {
@@ -9204,7 +9251,7 @@ yyreduce:
     }
     break;
 
-  case 668: /* enum_list: enum_list commas enum_expression  */
+  case 671: /* enum_list: enum_list commas enum_expression  */
                                                  {
         if ( !(yyvsp[-2].pEnumList)->add((yyvsp[0].pEnumPair)->name,(yyvsp[0].pEnumPair)->expr,(yyvsp[0].pEnumPair)->at) ) {
             das2_yyerror(scanner,"enumeration already declared " + (yyvsp[0].pEnumPair)->name, (yyvsp[0].pEnumPair)->at,
@@ -9220,19 +9267,19 @@ yyreduce:
     }
     break;
 
-  case 669: /* optional_public_or_private_alias: %empty  */
+  case 672: /* optional_public_or_private_alias: %empty  */
                      { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
     break;
 
-  case 670: /* optional_public_or_private_alias: "private"  */
+  case 673: /* optional_public_or_private_alias: "private"  */
                      { (yyval.b) = false; }
     break;
 
-  case 671: /* optional_public_or_private_alias: "public"  */
+  case 674: /* optional_public_or_private_alias: "public"  */
                      { (yyval.b) = true; }
     break;
 
-  case 672: /* $@50: %empty  */
+  case 675: /* $@50: %empty  */
                                                          {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto pubename = tokAt(scanner,(yylsp[0]));
@@ -9241,7 +9288,7 @@ yyreduce:
     }
     break;
 
-  case 673: /* single_alias: optional_public_or_private_alias "name" $@50 '=' type_declaration  */
+  case 676: /* single_alias: optional_public_or_private_alias "name" $@50 '=' type_declaration  */
                                   {
         das_checkName(scanner,*(yyvsp[-3].s),tokAt(scanner,(yylsp[-3])));
         (yyvsp[0].pTypeDecl)->isPrivateAlias = !(yyvsp[-4].b);
@@ -9262,19 +9309,19 @@ yyreduce:
     }
     break;
 
-  case 675: /* optional_public_or_private_enum: %empty  */
+  case 678: /* optional_public_or_private_enum: %empty  */
                      { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
     break;
 
-  case 676: /* optional_public_or_private_enum: "private"  */
+  case 679: /* optional_public_or_private_enum: "private"  */
                      { (yyval.b) = false; }
     break;
 
-  case 677: /* optional_public_or_private_enum: "public"  */
+  case 680: /* optional_public_or_private_enum: "public"  */
                      { (yyval.b) = true; }
     break;
 
-  case 678: /* enum_name: "name"  */
+  case 681: /* enum_name: "name"  */
                    {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto pubename = tokAt(scanner,(yylsp[0]));
@@ -9284,25 +9331,25 @@ yyreduce:
     }
     break;
 
-  case 679: /* optional_enum_basic_type_declaration: %empty  */
+  case 682: /* optional_enum_basic_type_declaration: %empty  */
         {
         (yyval.type) = Type::tInt;
     }
     break;
 
-  case 680: /* optional_enum_basic_type_declaration: ':' enum_basic_type_declaration  */
+  case 683: /* optional_enum_basic_type_declaration: ':' enum_basic_type_declaration  */
                                               {
         (yyval.type) = (yyvsp[0].type);
     }
     break;
 
-  case 687: /* $@51: %empty  */
+  case 690: /* $@51: %empty  */
                                                                      {
         yyextra->push_nesteds(DAS_EMIT_COMMA);
     }
     break;
 
-  case 688: /* $@52: %empty  */
+  case 691: /* $@52: %empty  */
                                                                                                                                 {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[-3]));
@@ -9311,7 +9358,7 @@ yyreduce:
     }
     break;
 
-  case 689: /* $@53: %empty  */
+  case 692: /* $@53: %empty  */
                                     {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[-1]));
@@ -9321,7 +9368,7 @@ yyreduce:
     }
     break;
 
-  case 690: /* enum_declaration: optional_annotation_list_with_emit_semis "enum" $@51 optional_public_or_private_enum enum_name optional_enum_basic_type_declaration optional_emit_commas '{' $@52 enum_list optional_commas $@53 '}'  */
+  case 693: /* enum_declaration: optional_annotation_list_with_emit_semis "enum" $@51 optional_public_or_private_enum enum_name optional_enum_basic_type_declaration optional_emit_commas '{' $@52 enum_list optional_commas $@53 '}'  */
           {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto pubename = tokAt(scanner,(yylsp[-3]));
@@ -9331,75 +9378,75 @@ yyreduce:
     }
     break;
 
-  case 691: /* optional_structure_parent: %empty  */
+  case 694: /* optional_structure_parent: %empty  */
                                         { (yyval.s) = nullptr; }
     break;
 
-  case 692: /* optional_structure_parent: ':' name_in_namespace  */
+  case 695: /* optional_structure_parent: ':' name_in_namespace  */
                                         { (yyval.s) = (yyvsp[0].s); }
     break;
 
-  case 693: /* optional_sealed: %empty  */
+  case 696: /* optional_sealed: %empty  */
                         { (yyval.b) = false; }
     break;
 
-  case 694: /* optional_sealed: "sealed"  */
+  case 697: /* optional_sealed: "sealed"  */
                         { (yyval.b) = true; }
     break;
 
-  case 695: /* structure_name: optional_sealed "name" optional_structure_parent  */
+  case 698: /* structure_name: optional_sealed "name" optional_structure_parent  */
                                                                            {
         (yyval.pStructure) = ast_structureName(scanner,(yyvsp[-2].b),(yyvsp[-1].s),tokAt(scanner,(yylsp[-1])),(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
     }
     break;
 
-  case 696: /* class_or_struct: "class"  */
+  case 699: /* class_or_struct: "class"  */
                     { (yyval.i) = CorS_Class; }
     break;
 
-  case 697: /* class_or_struct: "struct"  */
+  case 700: /* class_or_struct: "struct"  */
                     { (yyval.i) = CorS_Struct; }
     break;
 
-  case 698: /* class_or_struct: "class" "template"  */
+  case 701: /* class_or_struct: "class" "template"  */
                                   { (yyval.i) = CorS_ClassTemplate; }
     break;
 
-  case 699: /* class_or_struct: "struct" "template"  */
+  case 702: /* class_or_struct: "struct" "template"  */
                                   { (yyval.i) = CorS_StructTemplate; }
     break;
 
-  case 700: /* optional_public_or_private_structure: %empty  */
+  case 703: /* optional_public_or_private_structure: %empty  */
                      { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
     break;
 
-  case 701: /* optional_public_or_private_structure: "private"  */
+  case 704: /* optional_public_or_private_structure: "private"  */
                      { (yyval.b) = false; }
     break;
 
-  case 702: /* optional_public_or_private_structure: "public"  */
+  case 705: /* optional_public_or_private_structure: "public"  */
                      { (yyval.b) = true; }
     break;
 
-  case 703: /* optional_struct_variable_declaration_list: ';'  */
+  case 706: /* optional_struct_variable_declaration_list: ';'  */
             {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 704: /* optional_struct_variable_declaration_list: '{' struct_variable_declaration_list '}'  */
+  case 707: /* optional_struct_variable_declaration_list: '{' struct_variable_declaration_list '}'  */
                                                        {
         (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList);
     }
     break;
 
-  case 705: /* $@54: %empty  */
+  case 708: /* $@54: %empty  */
                                                      {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 706: /* $@55: %empty  */
+  case 709: /* $@55: %empty  */
                                                                          {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[-1]));
@@ -9408,7 +9455,7 @@ yyreduce:
     }
     break;
 
-  case 707: /* $@56: %empty  */
+  case 710: /* $@56: %empty  */
                                              {
         if ( (yyvsp[-1].pStructure) ) {
             (yyvsp[-1].pStructure)->isClass = (yyvsp[-4].i)==CorS_Class || (yyvsp[-4].i)==CorS_ClassTemplate;
@@ -9418,7 +9465,7 @@ yyreduce:
     }
     break;
 
-  case 708: /* structure_declaration: optional_annotation_list_with_emit_semis $@54 class_or_struct optional_public_or_private_structure $@55 structure_name optional_emit_semis $@56 optional_struct_variable_declaration_list  */
+  case 711: /* structure_declaration: optional_annotation_list_with_emit_semis $@54 class_or_struct optional_public_or_private_structure $@55 structure_name optional_emit_semis $@56 optional_struct_variable_declaration_list  */
                                                       {
         yyextra->pop_nesteds();
         if ( (yyvsp[-3].pStructure) ) {
@@ -9433,7 +9480,7 @@ yyreduce:
     }
     break;
 
-  case 709: /* variable_name_with_pos_list: "name"  */
+  case 712: /* variable_name_with_pos_list: "name"  */
                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         auto pSL = new vector<VariableNameAndPosition>();
@@ -9443,7 +9490,7 @@ yyreduce:
     }
     break;
 
-  case 710: /* variable_name_with_pos_list: "$i" '(' expr ')'  */
+  case 713: /* variable_name_with_pos_list: "$i" '(' expr ')'  */
                                      {
         auto pSL = new vector<VariableNameAndPosition>();
         pSL->push_back(VariableNameAndPosition("``MACRO``TAG``","",tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression)));
@@ -9451,7 +9498,7 @@ yyreduce:
     }
     break;
 
-  case 711: /* variable_name_with_pos_list: "name" "aka" "name"  */
+  case 714: /* variable_name_with_pos_list: "name" "aka" "name"  */
                                          {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -9463,7 +9510,7 @@ yyreduce:
     }
     break;
 
-  case 712: /* variable_name_with_pos_list: variable_name_with_pos_list ',' "name"  */
+  case 715: /* variable_name_with_pos_list: variable_name_with_pos_list ',' "name"  */
                                                          {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameWithPosList)->push_back(VariableNameAndPosition(*(yyvsp[0].s),"",tokAt(scanner,(yylsp[0]))));
@@ -9472,7 +9519,7 @@ yyreduce:
     }
     break;
 
-  case 713: /* variable_name_with_pos_list: variable_name_with_pos_list ',' "name" "aka" "name"  */
+  case 716: /* variable_name_with_pos_list: variable_name_with_pos_list ',' "name" "aka" "name"  */
                                                                                {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -9483,147 +9530,147 @@ yyreduce:
     }
     break;
 
-  case 714: /* basic_type_declaration: "bool"  */
+  case 717: /* basic_type_declaration: "bool"  */
                         { (yyval.type) = Type::tBool; }
     break;
 
-  case 715: /* basic_type_declaration: "string"  */
+  case 718: /* basic_type_declaration: "string"  */
                         { (yyval.type) = Type::tString; }
     break;
 
-  case 716: /* basic_type_declaration: "int"  */
+  case 719: /* basic_type_declaration: "int"  */
                         { (yyval.type) = Type::tInt; }
     break;
 
-  case 717: /* basic_type_declaration: "int8"  */
+  case 720: /* basic_type_declaration: "int8"  */
                         { (yyval.type) = Type::tInt8; }
     break;
 
-  case 718: /* basic_type_declaration: "int16"  */
+  case 721: /* basic_type_declaration: "int16"  */
                         { (yyval.type) = Type::tInt16; }
     break;
 
-  case 719: /* basic_type_declaration: "int64"  */
+  case 722: /* basic_type_declaration: "int64"  */
                         { (yyval.type) = Type::tInt64; }
     break;
 
-  case 720: /* basic_type_declaration: "int2"  */
+  case 723: /* basic_type_declaration: "int2"  */
                         { (yyval.type) = Type::tInt2; }
     break;
 
-  case 721: /* basic_type_declaration: "int3"  */
+  case 724: /* basic_type_declaration: "int3"  */
                         { (yyval.type) = Type::tInt3; }
     break;
 
-  case 722: /* basic_type_declaration: "int4"  */
+  case 725: /* basic_type_declaration: "int4"  */
                         { (yyval.type) = Type::tInt4; }
     break;
 
-  case 723: /* basic_type_declaration: "uint"  */
+  case 726: /* basic_type_declaration: "uint"  */
                         { (yyval.type) = Type::tUInt; }
     break;
 
-  case 724: /* basic_type_declaration: "uint8"  */
+  case 727: /* basic_type_declaration: "uint8"  */
                         { (yyval.type) = Type::tUInt8; }
     break;
 
-  case 725: /* basic_type_declaration: "uint16"  */
+  case 728: /* basic_type_declaration: "uint16"  */
                         { (yyval.type) = Type::tUInt16; }
     break;
 
-  case 726: /* basic_type_declaration: "uint64"  */
+  case 729: /* basic_type_declaration: "uint64"  */
                         { (yyval.type) = Type::tUInt64; }
     break;
 
-  case 727: /* basic_type_declaration: "uint2"  */
+  case 730: /* basic_type_declaration: "uint2"  */
                         { (yyval.type) = Type::tUInt2; }
     break;
 
-  case 728: /* basic_type_declaration: "uint3"  */
+  case 731: /* basic_type_declaration: "uint3"  */
                         { (yyval.type) = Type::tUInt3; }
     break;
 
-  case 729: /* basic_type_declaration: "uint4"  */
+  case 732: /* basic_type_declaration: "uint4"  */
                         { (yyval.type) = Type::tUInt4; }
     break;
 
-  case 730: /* basic_type_declaration: "float"  */
+  case 733: /* basic_type_declaration: "float"  */
                         { (yyval.type) = Type::tFloat; }
     break;
 
-  case 731: /* basic_type_declaration: "float2"  */
+  case 734: /* basic_type_declaration: "float2"  */
                         { (yyval.type) = Type::tFloat2; }
     break;
 
-  case 732: /* basic_type_declaration: "float3"  */
+  case 735: /* basic_type_declaration: "float3"  */
                         { (yyval.type) = Type::tFloat3; }
     break;
 
-  case 733: /* basic_type_declaration: "float4"  */
+  case 736: /* basic_type_declaration: "float4"  */
                         { (yyval.type) = Type::tFloat4; }
     break;
 
-  case 734: /* basic_type_declaration: "void"  */
+  case 737: /* basic_type_declaration: "void"  */
                         { (yyval.type) = Type::tVoid; }
     break;
 
-  case 735: /* basic_type_declaration: "range"  */
+  case 738: /* basic_type_declaration: "range"  */
                         { (yyval.type) = Type::tRange; }
     break;
 
-  case 736: /* basic_type_declaration: "urange"  */
+  case 739: /* basic_type_declaration: "urange"  */
                         { (yyval.type) = Type::tURange; }
     break;
 
-  case 737: /* basic_type_declaration: "range64"  */
+  case 740: /* basic_type_declaration: "range64"  */
                         { (yyval.type) = Type::tRange64; }
     break;
 
-  case 738: /* basic_type_declaration: "urange64"  */
+  case 741: /* basic_type_declaration: "urange64"  */
                         { (yyval.type) = Type::tURange64; }
     break;
 
-  case 739: /* basic_type_declaration: "double"  */
+  case 742: /* basic_type_declaration: "double"  */
                         { (yyval.type) = Type::tDouble; }
     break;
 
-  case 740: /* basic_type_declaration: "bitfield"  */
+  case 743: /* basic_type_declaration: "bitfield"  */
                         { (yyval.type) = Type::tBitfield; }
     break;
 
-  case 741: /* enum_basic_type_declaration: "int"  */
+  case 744: /* enum_basic_type_declaration: "int"  */
                         { (yyval.type) = Type::tInt; }
     break;
 
-  case 742: /* enum_basic_type_declaration: "int8"  */
+  case 745: /* enum_basic_type_declaration: "int8"  */
                         { (yyval.type) = Type::tInt8; }
     break;
 
-  case 743: /* enum_basic_type_declaration: "int16"  */
+  case 746: /* enum_basic_type_declaration: "int16"  */
                         { (yyval.type) = Type::tInt16; }
     break;
 
-  case 744: /* enum_basic_type_declaration: "uint"  */
+  case 747: /* enum_basic_type_declaration: "uint"  */
                         { (yyval.type) = Type::tUInt; }
     break;
 
-  case 745: /* enum_basic_type_declaration: "uint8"  */
+  case 748: /* enum_basic_type_declaration: "uint8"  */
                         { (yyval.type) = Type::tUInt8; }
     break;
 
-  case 746: /* enum_basic_type_declaration: "uint16"  */
+  case 749: /* enum_basic_type_declaration: "uint16"  */
                         { (yyval.type) = Type::tUInt16; }
     break;
 
-  case 747: /* enum_basic_type_declaration: "int64"  */
+  case 750: /* enum_basic_type_declaration: "int64"  */
                         { (yyval.type) = Type::tInt64; }
     break;
 
-  case 748: /* enum_basic_type_declaration: "uint64"  */
+  case 751: /* enum_basic_type_declaration: "uint64"  */
                         { (yyval.type) = Type::tUInt64; }
     break;
 
-  case 749: /* structure_type_declaration: name_in_namespace  */
+  case 752: /* structure_type_declaration: name_in_namespace  */
                                  {
         (yyval.pTypeDecl) = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,(yylsp[0])),*(yyvsp[0].s));
         if ( !(yyval.pTypeDecl) ) {
@@ -9634,14 +9681,14 @@ yyreduce:
     }
     break;
 
-  case 750: /* auto_type_declaration: "auto"  */
+  case 753: /* auto_type_declaration: "auto"  */
                        {
         (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
     }
     break;
 
-  case 751: /* auto_type_declaration: "auto" '(' "name" ')'  */
+  case 754: /* auto_type_declaration: "auto" '(' "name" ')'  */
                                             {
         das_checkName(scanner,*(yyvsp[-1].s),tokAt(scanner,(yylsp[-1])));
         (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
@@ -9651,7 +9698,7 @@ yyreduce:
     }
     break;
 
-  case 752: /* auto_type_declaration: "$t" '(' expr ')'  */
+  case 755: /* auto_type_declaration: "$t" '(' expr ')'  */
                                           {
         (yyval.pTypeDecl) = new TypeDecl(Type::alias);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-3]));
@@ -9663,7 +9710,7 @@ yyreduce:
     }
     break;
 
-  case 753: /* bitfield_bits: "name"  */
+  case 756: /* bitfield_bits: "name"  */
                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         auto pSL = new vector<string>();
@@ -9673,7 +9720,7 @@ yyreduce:
     }
     break;
 
-  case 754: /* bitfield_bits: bitfield_bits ';' "name"  */
+  case 757: /* bitfield_bits: bitfield_bits ';' "name"  */
                                            {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameList)->push_back(*(yyvsp[0].s));
@@ -9682,7 +9729,7 @@ yyreduce:
     }
     break;
 
-  case 755: /* bitfield_bits: bitfield_bits ',' "name"  */
+  case 758: /* bitfield_bits: bitfield_bits ',' "name"  */
                                            {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameList)->push_back(*(yyvsp[0].s));
@@ -9691,7 +9738,7 @@ yyreduce:
     }
     break;
 
-  case 756: /* bitfield_alias_bits: %empty  */
+  case 759: /* bitfield_alias_bits: %empty  */
         {
         auto pSL = new vector<tuple<string,Expression *>>();
         (yyval.pNameExprList) = pSL;
@@ -9699,7 +9746,7 @@ yyreduce:
     }
     break;
 
-  case 757: /* bitfield_alias_bits: "name"  */
+  case 760: /* bitfield_alias_bits: "name"  */
                    {
         (yyval.pNameExprList) = new vector<tuple<string,Expression *>>();
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -9712,7 +9759,7 @@ yyreduce:
     }
     break;
 
-  case 758: /* bitfield_alias_bits: "name" '=' expr  */
+  case 761: /* bitfield_alias_bits: "name" '=' expr  */
                                    {
         (yyval.pNameExprList) = new vector<tuple<string,Expression *>>();
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
@@ -9725,7 +9772,7 @@ yyreduce:
     }
     break;
 
-  case 759: /* bitfield_alias_bits: bitfield_alias_bits commas "name"  */
+  case 762: /* bitfield_alias_bits: bitfield_alias_bits commas "name"  */
                                                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameExprList)->emplace_back(*(yyvsp[0].s),nullptr);
@@ -9738,7 +9785,7 @@ yyreduce:
     }
     break;
 
-  case 760: /* bitfield_alias_bits: bitfield_alias_bits commas "name" '=' expr  */
+  case 763: /* bitfield_alias_bits: bitfield_alias_bits commas "name" '=' expr  */
                                                                     {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         (yyvsp[-4].pNameExprList)->emplace_back(*(yyvsp[-2].s),(yyvsp[0].pExpression));
@@ -9751,42 +9798,42 @@ yyreduce:
     }
     break;
 
-  case 761: /* bitfield_basic_type_declaration: %empty  */
+  case 764: /* bitfield_basic_type_declaration: %empty  */
                              { (yyval.type) = Type::tBitfield; }
     break;
 
-  case 762: /* bitfield_basic_type_declaration: ':' "uint8"  */
+  case 765: /* bitfield_basic_type_declaration: ':' "uint8"  */
                              { (yyval.type) = Type::tBitfield8; }
     break;
 
-  case 763: /* bitfield_basic_type_declaration: ':' "uint16"  */
+  case 766: /* bitfield_basic_type_declaration: ':' "uint16"  */
                              { (yyval.type) = Type::tBitfield16; }
     break;
 
-  case 764: /* bitfield_basic_type_declaration: ':' "uint"  */
+  case 767: /* bitfield_basic_type_declaration: ':' "uint"  */
                              { (yyval.type) = Type::tBitfield; }
     break;
 
-  case 765: /* bitfield_basic_type_declaration: ':' "uint64"  */
+  case 768: /* bitfield_basic_type_declaration: ':' "uint64"  */
                              { (yyval.type) = Type::tBitfield64; }
     break;
 
-  case 766: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' '>'  */
+  case 769: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' '>'  */
                                                                           {
             (yyval.pTypeDecl) = new TypeDecl((yyvsp[-2].type));
             (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-2]));
     }
     break;
 
-  case 767: /* $@57: %empty  */
+  case 770: /* $@57: %empty  */
                                                                      { yyextra->das_arrow_depth ++; }
     break;
 
-  case 768: /* $@58: %empty  */
+  case 771: /* $@58: %empty  */
                                                                                                                             { yyextra->das_arrow_depth --; }
     break;
 
-  case 769: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' $@57 bitfield_bits '>' $@58  */
+  case 772: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' $@57 bitfield_bits '>' $@58  */
                                                                                                                                                              {
             (yyval.pTypeDecl) = new TypeDecl((yyvsp[-5].type));
             (yyval.pTypeDecl)->argNames = *(yyvsp[-2].pNameList);
@@ -9800,55 +9847,55 @@ yyreduce:
     }
     break;
 
-  case 772: /* table_type_pair: type_declaration  */
+  case 775: /* table_type_pair: type_declaration  */
                                       {
         (yyval.aTypePair).firstType = (yyvsp[0].pTypeDecl);
         (yyval.aTypePair).secondType = new TypeDecl(Type::tVoid);
     }
     break;
 
-  case 773: /* table_type_pair: type_declaration c_or_s type_declaration  */
+  case 776: /* table_type_pair: type_declaration c_or_s type_declaration  */
                                                                              {
         (yyval.aTypePair).firstType = (yyvsp[-2].pTypeDecl);
         (yyval.aTypePair).secondType = (yyvsp[0].pTypeDecl);
     }
     break;
 
-  case 774: /* dim_list: '[' expr ']'  */
+  case 777: /* dim_list: '[' expr ']'  */
                              {
         (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
         appendDimExpr((yyval.pTypeDecl), (yyvsp[-1].pExpression));
     }
     break;
 
-  case 775: /* dim_list: '[' ']'  */
+  case 778: /* dim_list: '[' ']'  */
                 {
         (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
         appendDimExpr((yyval.pTypeDecl), nullptr);
     }
     break;
 
-  case 776: /* dim_list: dim_list '[' expr ']'  */
+  case 779: /* dim_list: dim_list '[' expr ']'  */
                                             {
         (yyval.pTypeDecl) = (yyvsp[-3].pTypeDecl);
         appendDimExpr((yyval.pTypeDecl), (yyvsp[-1].pExpression));
     }
     break;
 
-  case 777: /* dim_list: dim_list '[' ']'  */
+  case 780: /* dim_list: dim_list '[' ']'  */
                               {
         (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
         appendDimExpr((yyval.pTypeDecl), nullptr);
     }
     break;
 
-  case 778: /* type_declaration_no_options: type_declaration_no_options_no_dim  */
+  case 781: /* type_declaration_no_options: type_declaration_no_options_no_dim  */
                                                      {
         (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
     }
     break;
 
-  case 779: /* type_declaration_no_options: type_declaration_no_options_no_dim dim_list  */
+  case 782: /* type_declaration_no_options: type_declaration_no_options_no_dim dim_list  */
                                                                        {
         if ( (yyvsp[-1].pTypeDecl)->baseType==Type::typeDecl ) {
             das2_yyerror(scanner,"type declaration can`t be used as array base type",tokAt(scanner,(yylsp[-1])),
@@ -9865,46 +9912,46 @@ yyreduce:
     }
     break;
 
-  case 780: /* optional_expr_list_in_braces: %empty  */
+  case 783: /* optional_expr_list_in_braces: %empty  */
             { (yyval.pExpression) = nullptr; }
     break;
 
-  case 781: /* optional_expr_list_in_braces: '(' expr_list optional_comma ')'  */
+  case 784: /* optional_expr_list_in_braces: '(' expr_list optional_comma ')'  */
                                                 { (yyval.pExpression) = (yyvsp[-2].pExpression); }
     break;
 
-  case 782: /* type_declaration_no_options_no_dim: basic_type_declaration  */
+  case 785: /* type_declaration_no_options_no_dim: basic_type_declaration  */
                                                             { (yyval.pTypeDecl) = new TypeDecl((yyvsp[0].type)); (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0])); }
     break;
 
-  case 783: /* type_declaration_no_options_no_dim: auto_type_declaration  */
+  case 786: /* type_declaration_no_options_no_dim: auto_type_declaration  */
                                                             { (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl); }
     break;
 
-  case 784: /* type_declaration_no_options_no_dim: bitfield_type_declaration  */
+  case 787: /* type_declaration_no_options_no_dim: bitfield_type_declaration  */
                                                             { (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl); }
     break;
 
-  case 785: /* type_declaration_no_options_no_dim: structure_type_declaration  */
+  case 788: /* type_declaration_no_options_no_dim: structure_type_declaration  */
                                                             { (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl); }
     break;
 
-  case 786: /* $@59: %empty  */
+  case 789: /* $@59: %empty  */
                      { yyextra->das_arrow_depth ++; }
     break;
 
-  case 787: /* $@60: %empty  */
+  case 790: /* $@60: %empty  */
                                                                                      { yyextra->das_arrow_depth --; }
     break;
 
-  case 788: /* type_declaration_no_options_no_dim: "type" '<' $@59 type_declaration '>' $@60  */
+  case 791: /* type_declaration_no_options_no_dim: "type" '<' $@59 type_declaration '>' $@60  */
                                                                                                                       {
         (yyvsp[-2].pTypeDecl)->autoToAlias = true;
         (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
     }
     break;
 
-  case 789: /* type_declaration_no_options_no_dim: "typedecl" '(' expr ')'  */
+  case 792: /* type_declaration_no_options_no_dim: "typedecl" '(' expr ')'  */
                                                {
         (yyval.pTypeDecl) = new TypeDecl(Type::typeDecl);
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-3]),(yylsp[-1]));
@@ -9912,7 +9959,7 @@ yyreduce:
     }
     break;
 
-  case 790: /* type_declaration_no_options_no_dim: name_in_namespace '(' optional_expr_list ')'  */
+  case 793: /* type_declaration_no_options_no_dim: name_in_namespace '(' optional_expr_list ')'  */
                                                                       {
         (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-3]), (yylsp[-1]));
@@ -9922,7 +9969,7 @@ yyreduce:
     }
     break;
 
-  case 791: /* type_declaration_no_options_no_dim: '$' name_in_namespace optional_expr_list_in_braces  */
+  case 794: /* type_declaration_no_options_no_dim: '$' name_in_namespace optional_expr_list_in_braces  */
                                                                             {
         (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-1]), (yylsp[0]));
@@ -9932,11 +9979,11 @@ yyreduce:
     }
     break;
 
-  case 792: /* $@61: %empty  */
+  case 795: /* $@61: %empty  */
                                     { yyextra->das_arrow_depth ++; }
     break;
 
-  case 793: /* type_declaration_no_options_no_dim: name_in_namespace '<' $@61 type_declaration_no_options_list '>' optional_expr_list_in_braces  */
+  case 796: /* type_declaration_no_options_no_dim: name_in_namespace '<' $@61 type_declaration_no_options_list '>' optional_expr_list_in_braces  */
                                                                                                                                                          {
         (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-5]), (yylsp[0]));
@@ -9946,11 +9993,11 @@ yyreduce:
     }
     break;
 
-  case 794: /* $@62: %empty  */
+  case 797: /* $@62: %empty  */
                                         { yyextra->das_arrow_depth ++; }
     break;
 
-  case 795: /* type_declaration_no_options_no_dim: '$' name_in_namespace '<' $@62 type_declaration_no_options_list '>' optional_expr_list_in_braces  */
+  case 798: /* type_declaration_no_options_no_dim: '$' name_in_namespace '<' $@62 type_declaration_no_options_list '>' optional_expr_list_in_braces  */
                                                                                                                                                              {
         (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-5]), (yylsp[0]));
@@ -9960,21 +10007,21 @@ yyreduce:
     }
     break;
 
-  case 796: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '[' ']'  */
+  case 799: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '[' ']'  */
                                                           {
         (yyvsp[-3].pTypeDecl)->removeDim = true;
         (yyval.pTypeDecl) = (yyvsp[-3].pTypeDecl);
     }
     break;
 
-  case 797: /* type_declaration_no_options_no_dim: type_declaration_no_options "explicit"  */
+  case 800: /* type_declaration_no_options_no_dim: type_declaration_no_options "explicit"  */
                                                            {
         (yyvsp[-1].pTypeDecl)->isExplicit = true;
         (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
     }
     break;
 
-  case 798: /* type_declaration_no_options_no_dim: type_declaration_no_options "const"  */
+  case 801: /* type_declaration_no_options_no_dim: type_declaration_no_options "const"  */
                                                         {
         (yyvsp[-1].pTypeDecl)->constant = true;
         (yyvsp[-1].pTypeDecl)->removeConstant = false;
@@ -9982,7 +10029,7 @@ yyreduce:
     }
     break;
 
-  case 799: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' "const"  */
+  case 802: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' "const"  */
                                                             {
         (yyvsp[-2].pTypeDecl)->constant = false;
         (yyvsp[-2].pTypeDecl)->removeConstant = true;
@@ -9990,7 +10037,7 @@ yyreduce:
     }
     break;
 
-  case 800: /* type_declaration_no_options_no_dim: type_declaration_no_options '&'  */
+  case 803: /* type_declaration_no_options_no_dim: type_declaration_no_options '&'  */
                                                   {
         (yyvsp[-1].pTypeDecl)->ref = true;
         (yyvsp[-1].pTypeDecl)->removeRef = false;
@@ -9998,7 +10045,7 @@ yyreduce:
     }
     break;
 
-  case 801: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '&'  */
+  case 804: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '&'  */
                                                       {
         (yyvsp[-2].pTypeDecl)->ref = false;
         (yyvsp[-2].pTypeDecl)->removeRef = true;
@@ -10006,21 +10053,21 @@ yyreduce:
     }
     break;
 
-  case 802: /* type_declaration_no_options_no_dim: type_declaration_no_options '#'  */
+  case 805: /* type_declaration_no_options_no_dim: type_declaration_no_options '#'  */
                                                   {
         (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
         (yyval.pTypeDecl)->temporary = true;
     }
     break;
 
-  case 803: /* type_declaration_no_options_no_dim: type_declaration_no_options "implicit"  */
+  case 806: /* type_declaration_no_options_no_dim: type_declaration_no_options "implicit"  */
                                                            {
         (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
         (yyval.pTypeDecl)->implicit = true;
     }
     break;
 
-  case 804: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '#'  */
+  case 807: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '#'  */
                                                       {
         (yyvsp[-2].pTypeDecl)->temporary = false;
         (yyvsp[-2].pTypeDecl)->removeTemporary = true;
@@ -10028,21 +10075,21 @@ yyreduce:
     }
     break;
 
-  case 805: /* type_declaration_no_options_no_dim: type_declaration_no_options "==" "const"  */
+  case 808: /* type_declaration_no_options_no_dim: type_declaration_no_options "==" "const"  */
                                                                {
         (yyvsp[-2].pTypeDecl)->explicitConst = true;
         (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
     }
     break;
 
-  case 806: /* type_declaration_no_options_no_dim: type_declaration_no_options "==" '&'  */
+  case 809: /* type_declaration_no_options_no_dim: type_declaration_no_options "==" '&'  */
                                                          {
         (yyvsp[-2].pTypeDecl)->explicitRef = true;
         (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
     }
     break;
 
-  case 807: /* type_declaration_no_options_no_dim: type_declaration_no_options '?'  */
+  case 810: /* type_declaration_no_options_no_dim: type_declaration_no_options '?'  */
                                                   {
         (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-1]));
@@ -10050,15 +10097,15 @@ yyreduce:
     }
     break;
 
-  case 808: /* $@63: %empty  */
+  case 811: /* $@63: %empty  */
                                { yyextra->das_arrow_depth ++; }
     break;
 
-  case 809: /* $@64: %empty  */
+  case 812: /* $@64: %empty  */
                                                                                                { yyextra->das_arrow_depth --; }
     break;
 
-  case 810: /* type_declaration_no_options_no_dim: "smart_ptr" '<' $@63 type_declaration '>' $@64  */
+  case 813: /* type_declaration_no_options_no_dim: "smart_ptr" '<' $@63 type_declaration '>' $@64  */
                                                                                                                                 {
         (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10067,7 +10114,7 @@ yyreduce:
     }
     break;
 
-  case 811: /* type_declaration_no_options_no_dim: type_declaration_no_options "??"  */
+  case 814: /* type_declaration_no_options_no_dim: type_declaration_no_options "??"  */
                                                  {
         (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-1]));
@@ -10077,15 +10124,15 @@ yyreduce:
     }
     break;
 
-  case 812: /* $@65: %empty  */
+  case 815: /* $@65: %empty  */
                            { yyextra->das_arrow_depth ++; }
     break;
 
-  case 813: /* $@66: %empty  */
+  case 816: /* $@66: %empty  */
                                                                                            { yyextra->das_arrow_depth --; }
     break;
 
-  case 814: /* type_declaration_no_options_no_dim: "array" '<' $@65 type_declaration '>' $@66  */
+  case 817: /* type_declaration_no_options_no_dim: "array" '<' $@65 type_declaration '>' $@66  */
                                                                                                                             {
         (yyval.pTypeDecl) = new TypeDecl(Type::tArray);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10093,15 +10140,15 @@ yyreduce:
     }
     break;
 
-  case 815: /* $@67: %empty  */
+  case 818: /* $@67: %empty  */
                            { yyextra->das_arrow_depth ++; }
     break;
 
-  case 816: /* $@68: %empty  */
+  case 819: /* $@68: %empty  */
                                                                                      { yyextra->das_arrow_depth --; }
     break;
 
-  case 817: /* type_declaration_no_options_no_dim: "table" '<' $@67 table_type_pair '>' $@68  */
+  case 820: /* type_declaration_no_options_no_dim: "table" '<' $@67 table_type_pair '>' $@68  */
                                                                                                                       {
         (yyval.pTypeDecl) = new TypeDecl(Type::tTable);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10110,15 +10157,15 @@ yyreduce:
     }
     break;
 
-  case 818: /* $@69: %empty  */
+  case 821: /* $@69: %empty  */
                                { yyextra->das_arrow_depth ++; }
     break;
 
-  case 819: /* $@70: %empty  */
+  case 822: /* $@70: %empty  */
                                                                                                  { yyextra->das_arrow_depth --; }
     break;
 
-  case 820: /* type_declaration_no_options_no_dim: "iterator" '<' $@69 type_declaration '>' $@70  */
+  case 823: /* type_declaration_no_options_no_dim: "iterator" '<' $@69 type_declaration '>' $@70  */
                                                                                                                                   {
         (yyval.pTypeDecl) = new TypeDecl(Type::tIterator);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10126,7 +10173,7 @@ yyreduce:
     }
     break;
 
-  case 821: /* type_declaration_no_options_no_dim: "block"  */
+  case 824: /* type_declaration_no_options_no_dim: "block"  */
                         {
         (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
         (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
@@ -10134,15 +10181,15 @@ yyreduce:
     }
     break;
 
-  case 822: /* $@71: %empty  */
+  case 825: /* $@71: %empty  */
                              { yyextra->das_arrow_depth ++; }
     break;
 
-  case 823: /* $@72: %empty  */
+  case 826: /* $@72: %empty  */
                                                                                               { yyextra->das_arrow_depth --; }
     break;
 
-  case 824: /* type_declaration_no_options_no_dim: "block" '<' $@71 type_declaration '>' $@72  */
+  case 827: /* type_declaration_no_options_no_dim: "block" '<' $@71 type_declaration '>' $@72  */
                                                                                                                                {
         (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10150,15 +10197,15 @@ yyreduce:
     }
     break;
 
-  case 825: /* $@73: %empty  */
+  case 828: /* $@73: %empty  */
                              { yyextra->das_arrow_depth ++; }
     break;
 
-  case 826: /* $@74: %empty  */
+  case 829: /* $@74: %empty  */
                                                                                                                                        { yyextra->das_arrow_depth --; }
     break;
 
-  case 827: /* type_declaration_no_options_no_dim: "block" '<' $@73 optional_function_argument_list optional_function_type '>' $@74  */
+  case 830: /* type_declaration_no_options_no_dim: "block" '<' $@73 optional_function_argument_list optional_function_type '>' $@74  */
                                                                                                                                                                         {
         (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
@@ -10170,7 +10217,7 @@ yyreduce:
     }
     break;
 
-  case 828: /* type_declaration_no_options_no_dim: "function"  */
+  case 831: /* type_declaration_no_options_no_dim: "function"  */
                            {
         (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
         (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
@@ -10178,15 +10225,15 @@ yyreduce:
     }
     break;
 
-  case 829: /* $@75: %empty  */
+  case 832: /* $@75: %empty  */
                                { yyextra->das_arrow_depth ++; }
     break;
 
-  case 830: /* $@76: %empty  */
+  case 833: /* $@76: %empty  */
                                                                                                 { yyextra->das_arrow_depth --; }
     break;
 
-  case 831: /* type_declaration_no_options_no_dim: "function" '<' $@75 type_declaration '>' $@76  */
+  case 834: /* type_declaration_no_options_no_dim: "function" '<' $@75 type_declaration '>' $@76  */
                                                                                                                                  {
         (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10194,15 +10241,15 @@ yyreduce:
     }
     break;
 
-  case 832: /* $@77: %empty  */
+  case 835: /* $@77: %empty  */
                                { yyextra->das_arrow_depth ++; }
     break;
 
-  case 833: /* $@78: %empty  */
+  case 836: /* $@78: %empty  */
                                                                                                                                          { yyextra->das_arrow_depth --; }
     break;
 
-  case 834: /* type_declaration_no_options_no_dim: "function" '<' $@77 optional_function_argument_list optional_function_type '>' $@78  */
+  case 837: /* type_declaration_no_options_no_dim: "function" '<' $@77 optional_function_argument_list optional_function_type '>' $@78  */
                                                                                                                                                                           {
         (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
@@ -10214,7 +10261,7 @@ yyreduce:
     }
     break;
 
-  case 835: /* type_declaration_no_options_no_dim: "lambda"  */
+  case 838: /* type_declaration_no_options_no_dim: "lambda"  */
                          {
         (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
         (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
@@ -10222,15 +10269,15 @@ yyreduce:
     }
     break;
 
-  case 836: /* $@79: %empty  */
+  case 839: /* $@79: %empty  */
                              { yyextra->das_arrow_depth ++; }
     break;
 
-  case 837: /* $@80: %empty  */
+  case 840: /* $@80: %empty  */
                                                                                               { yyextra->das_arrow_depth --; }
     break;
 
-  case 838: /* type_declaration_no_options_no_dim: "lambda" '<' $@79 type_declaration '>' $@80  */
+  case 841: /* type_declaration_no_options_no_dim: "lambda" '<' $@79 type_declaration '>' $@80  */
                                                                                                                                {
         (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10238,15 +10285,15 @@ yyreduce:
     }
     break;
 
-  case 839: /* $@81: %empty  */
+  case 842: /* $@81: %empty  */
                              { yyextra->das_arrow_depth ++; }
     break;
 
-  case 840: /* $@82: %empty  */
+  case 843: /* $@82: %empty  */
                                                                                                                                        { yyextra->das_arrow_depth --; }
     break;
 
-  case 841: /* type_declaration_no_options_no_dim: "lambda" '<' $@81 optional_function_argument_list optional_function_type '>' $@82  */
+  case 844: /* type_declaration_no_options_no_dim: "lambda" '<' $@81 optional_function_argument_list optional_function_type '>' $@82  */
                                                                                                                                                                         {
         (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
@@ -10258,15 +10305,15 @@ yyreduce:
     }
     break;
 
-  case 842: /* $@83: %empty  */
+  case 845: /* $@83: %empty  */
                             { yyextra->das_arrow_depth ++; }
     break;
 
-  case 843: /* $@84: %empty  */
+  case 846: /* $@84: %empty  */
                                                                                        { yyextra->das_arrow_depth --; }
     break;
 
-  case 844: /* type_declaration_no_options_no_dim: "tuple" '<' $@83 tuple_type_list '>' $@84  */
+  case 847: /* type_declaration_no_options_no_dim: "tuple" '<' $@83 tuple_type_list '>' $@84  */
                                                                                                                         {
         (yyval.pTypeDecl) = new TypeDecl(Type::tTuple);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10275,15 +10322,15 @@ yyreduce:
     }
     break;
 
-  case 845: /* $@85: %empty  */
+  case 848: /* $@85: %empty  */
                               { yyextra->das_arrow_depth ++; }
     break;
 
-  case 846: /* $@86: %empty  */
+  case 849: /* $@86: %empty  */
                                                                                            { yyextra->das_arrow_depth --; }
     break;
 
-  case 847: /* type_declaration_no_options_no_dim: "variant" '<' $@85 variant_type_list '>' $@86  */
+  case 850: /* type_declaration_no_options_no_dim: "variant" '<' $@85 variant_type_list '>' $@86  */
                                                                                                                             {
         (yyval.pTypeDecl) = new TypeDecl(Type::tVariant);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10292,13 +10339,13 @@ yyreduce:
     }
     break;
 
-  case 848: /* type_declaration: type_declaration_no_options  */
+  case 851: /* type_declaration: type_declaration_no_options  */
                                         {
         (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
     }
     break;
 
-  case 849: /* type_declaration: type_declaration '|' type_declaration_no_options  */
+  case 852: /* type_declaration: type_declaration '|' type_declaration_no_options  */
                                                                      {
         if ( (yyvsp[-2].pTypeDecl)->baseType==Type::option ) {
             (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
@@ -10312,7 +10359,7 @@ yyreduce:
     }
     break;
 
-  case 850: /* type_declaration: type_declaration '|' '#'  */
+  case 853: /* type_declaration: type_declaration '|' '#'  */
                                              {
         if ( (yyvsp[-2].pTypeDecl)->baseType==Type::option ) {
             (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
@@ -10328,13 +10375,13 @@ yyreduce:
     }
     break;
 
-  case 851: /* $@87: %empty  */
+  case 854: /* $@87: %empty  */
                    {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 852: /* $@88: %empty  */
+  case 855: /* $@88: %empty  */
                                                                              {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-1]));
@@ -10343,7 +10390,7 @@ yyreduce:
     }
     break;
 
-  case 853: /* $@89: %empty  */
+  case 856: /* $@89: %empty  */
           {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-3]));
@@ -10352,7 +10399,7 @@ yyreduce:
     }
     break;
 
-  case 854: /* $@90: %empty  */
+  case 857: /* $@90: %empty  */
                                                  {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-6]));
@@ -10362,7 +10409,7 @@ yyreduce:
     }
     break;
 
-  case 855: /* tuple_alias_declaration: "tuple" $@87 optional_public_or_private_alias "name" optional_emit_semis $@88 '{' $@89 tuple_alias_type_list optional_semis $@90 '}'  */
+  case 858: /* tuple_alias_declaration: "tuple" $@87 optional_public_or_private_alias "name" optional_emit_semis $@88 '{' $@89 tuple_alias_type_list optional_semis $@90 '}'  */
           {
         auto vtype = new TypeDecl(Type::tTuple);
         vtype->alias = *(yyvsp[-8].s);
@@ -10382,13 +10429,13 @@ yyreduce:
     }
     break;
 
-  case 856: /* $@91: %empty  */
+  case 859: /* $@91: %empty  */
                      {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 857: /* $@92: %empty  */
+  case 860: /* $@92: %empty  */
                                                                              {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-1]));
@@ -10397,7 +10444,7 @@ yyreduce:
     }
     break;
 
-  case 858: /* $@93: %empty  */
+  case 861: /* $@93: %empty  */
           {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-3]));
@@ -10407,7 +10454,7 @@ yyreduce:
     }
     break;
 
-  case 859: /* $@94: %empty  */
+  case 862: /* $@94: %empty  */
                                                    {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-6]));
@@ -10417,7 +10464,7 @@ yyreduce:
     }
     break;
 
-  case 860: /* variant_alias_declaration: "variant" $@91 optional_public_or_private_alias "name" optional_emit_semis $@92 '{' $@93 variant_alias_type_list optional_semis $@94 '}'  */
+  case 863: /* variant_alias_declaration: "variant" $@91 optional_public_or_private_alias "name" optional_emit_semis $@92 '{' $@93 variant_alias_type_list optional_semis $@94 '}'  */
           {
         auto vtype = new TypeDecl(Type::tVariant);
         vtype->alias = *(yyvsp[-8].s);
@@ -10437,13 +10484,13 @@ yyreduce:
     }
     break;
 
-  case 861: /* $@95: %empty  */
+  case 864: /* $@95: %empty  */
                       {
         yyextra->push_nesteds(DAS_EMIT_COMMA);
     }
     break;
 
-  case 862: /* $@96: %empty  */
+  case 865: /* $@96: %empty  */
                                                                                                                          {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-2]));
@@ -10452,7 +10499,7 @@ yyreduce:
     }
     break;
 
-  case 863: /* $@97: %empty  */
+  case 866: /* $@97: %empty  */
           {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-4]));
@@ -10461,7 +10508,7 @@ yyreduce:
     }
     break;
 
-  case 864: /* $@98: %empty  */
+  case 867: /* $@98: %empty  */
                                                 {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-7]));
@@ -10471,7 +10518,7 @@ yyreduce:
     }
     break;
 
-  case 865: /* bitfield_alias_declaration: "bitfield" $@95 optional_public_or_private_alias "name" bitfield_basic_type_declaration optional_emit_commas $@96 '{' $@97 bitfield_alias_bits optional_commas $@98 '}'  */
+  case 868: /* bitfield_alias_declaration: "bitfield" $@95 optional_public_or_private_alias "name" bitfield_basic_type_declaration optional_emit_commas $@96 '{' $@97 bitfield_alias_bits optional_commas $@98 '}'  */
           {
         auto btype = new TypeDecl((yyvsp[-8].type));
         btype->alias = *(yyvsp[-9].s);
@@ -10505,55 +10552,55 @@ yyreduce:
     }
     break;
 
-  case 866: /* make_decl: make_struct_decl  */
+  case 869: /* make_decl: make_struct_decl  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 867: /* make_decl: make_dim_decl  */
+  case 870: /* make_decl: make_dim_decl  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 868: /* make_decl: make_table_decl  */
+  case 871: /* make_decl: make_table_decl  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 869: /* make_decl: make_table_call  */
+  case 872: /* make_decl: make_table_call  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 870: /* make_decl: array_comprehension  */
+  case 873: /* make_decl: array_comprehension  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 871: /* make_decl: table_comprehension  */
+  case 874: /* make_decl: table_comprehension  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 872: /* make_decl: make_tuple_call  */
+  case 875: /* make_decl: make_tuple_call  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 873: /* make_decl_no_bracket: make_struct_decl  */
+  case 876: /* make_decl_no_bracket: make_struct_decl  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 874: /* make_decl_no_bracket: make_dim_decl  */
+  case 877: /* make_decl_no_bracket: make_dim_decl  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 875: /* make_decl_no_bracket: make_tuple_call  */
+  case 878: /* make_decl_no_bracket: make_tuple_call  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 876: /* make_decl_no_bracket: table_comprehension  */
+  case 879: /* make_decl_no_bracket: table_comprehension  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 877: /* make_decl_no_bracket: make_table_call  */
+  case 880: /* make_decl_no_bracket: make_table_call  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 878: /* make_struct_fields: "name" copy_or_move expr  */
+  case 881: /* make_struct_fields: "name" copy_or_move expr  */
                                                {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-2])),*(yyvsp[-2].s),(yyvsp[0].pExpression),(yyvsp[-1].b),false);
         delete (yyvsp[-2].s);
@@ -10563,7 +10610,7 @@ yyreduce:
     }
     break;
 
-  case 879: /* make_struct_fields: "name" ":=" expr  */
+  case 882: /* make_struct_fields: "name" ":=" expr  */
                                       {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-2])),*(yyvsp[-2].s),(yyvsp[0].pExpression),false,true);
         delete (yyvsp[-2].s);
@@ -10573,7 +10620,7 @@ yyreduce:
     }
     break;
 
-  case 880: /* make_struct_fields: make_struct_fields ',' "name" copy_or_move expr  */
+  case 883: /* make_struct_fields: make_struct_fields ',' "name" copy_or_move expr  */
                                                                            {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-2])),*(yyvsp[-2].s),(yyvsp[0].pExpression),(yyvsp[-1].b),false);
         delete (yyvsp[-2].s);
@@ -10582,7 +10629,7 @@ yyreduce:
     }
     break;
 
-  case 881: /* make_struct_fields: make_struct_fields ',' "name" ":=" expr  */
+  case 884: /* make_struct_fields: make_struct_fields ',' "name" ":=" expr  */
                                                                   {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-2])),*(yyvsp[-2].s),(yyvsp[0].pExpression),false,true);
         delete (yyvsp[-2].s);
@@ -10591,7 +10638,7 @@ yyreduce:
     }
     break;
 
-  case 882: /* make_struct_fields: "$f" '(' expr ')' copy_or_move expr  */
+  case 885: /* make_struct_fields: "$f" '(' expr ')' copy_or_move expr  */
                                                                    {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-3])),"``MACRO``TAG``FIELD``",(yyvsp[0].pExpression),(yyvsp[-1].b),false);
         mfd->tag = (yyvsp[-3].pExpression);
@@ -10601,7 +10648,7 @@ yyreduce:
     }
     break;
 
-  case 883: /* make_struct_fields: "$f" '(' expr ')' ":=" expr  */
+  case 886: /* make_struct_fields: "$f" '(' expr ')' ":=" expr  */
                                                           {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-3])),"``MACRO``TAG``FIELD``",(yyvsp[0].pExpression),false,true);
         mfd->tag = (yyvsp[-3].pExpression);
@@ -10611,7 +10658,7 @@ yyreduce:
     }
     break;
 
-  case 884: /* make_struct_fields: make_struct_fields ',' "$f" '(' expr ')' copy_or_move expr  */
+  case 887: /* make_struct_fields: make_struct_fields ',' "$f" '(' expr ')' copy_or_move expr  */
                                                                                                {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-3])),"``MACRO``TAG``FIELD``",(yyvsp[0].pExpression),(yyvsp[-1].b),false);
         mfd->tag = (yyvsp[-3].pExpression);
@@ -10620,7 +10667,7 @@ yyreduce:
     }
     break;
 
-  case 885: /* make_struct_fields: make_struct_fields ',' "$f" '(' expr ')' ":=" expr  */
+  case 888: /* make_struct_fields: make_struct_fields ',' "$f" '(' expr ')' ":=" expr  */
                                                                                       {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-3])),"``MACRO``TAG``FIELD``",(yyvsp[0].pExpression),false,true);
         mfd->tag = (yyvsp[-3].pExpression);
@@ -10629,19 +10676,19 @@ yyreduce:
     }
     break;
 
-  case 886: /* make_variant_dim: %empty  */
+  case 889: /* make_variant_dim: %empty  */
        {
         (yyval.pExpression) = ast_makeStructToMakeVariant(nullptr, LineInfo());
     }
     break;
 
-  case 887: /* make_variant_dim: make_struct_fields  */
+  case 890: /* make_variant_dim: make_struct_fields  */
                               {
         (yyval.pExpression) = ast_makeStructToMakeVariant((yyvsp[0].pMakeStruct), tokAt(scanner,(yylsp[0])));
     }
     break;
 
-  case 888: /* make_struct_single: make_struct_fields optional_comma  */
+  case 891: /* make_struct_single: make_struct_fields optional_comma  */
                                                {
         auto msd = new ExprMakeStruct();
         msd->structs.push_back(MakeStructPtr((yyvsp[-1].pMakeStruct)));
@@ -10649,7 +10696,7 @@ yyreduce:
     }
     break;
 
-  case 889: /* make_struct_dim_list: '(' make_struct_fields ')'  */
+  case 892: /* make_struct_dim_list: '(' make_struct_fields ')'  */
                                         {
         auto msd = new ExprMakeStruct();
         msd->structs.push_back(MakeStructPtr((yyvsp[-1].pMakeStruct)));
@@ -10657,14 +10704,14 @@ yyreduce:
     }
     break;
 
-  case 890: /* make_struct_dim_list: make_struct_dim_list ',' '(' make_struct_fields ')'  */
+  case 893: /* make_struct_dim_list: make_struct_dim_list ',' '(' make_struct_fields ')'  */
                                                                      {
         ((ExprMakeStruct *) (yyvsp[-4].pExpression))->structs.push_back(MakeStructPtr((yyvsp[-1].pMakeStruct)));
         (yyval.pExpression) = (yyvsp[-4].pExpression);
     }
     break;
 
-  case 891: /* make_struct_dim_decl: make_struct_fields  */
+  case 894: /* make_struct_dim_decl: make_struct_fields  */
                                 {
         auto msd = new ExprMakeStruct();
         msd->structs.push_back(MakeStructPtr((yyvsp[0].pMakeStruct)));
@@ -10672,37 +10719,37 @@ yyreduce:
     }
     break;
 
-  case 892: /* make_struct_dim_decl: make_struct_dim_list optional_comma  */
+  case 895: /* make_struct_dim_decl: make_struct_dim_list optional_comma  */
                                                  {
         (yyval.pExpression) = (yyvsp[-1].pExpression);
     }
     break;
 
-  case 893: /* optional_make_struct_dim_decl: make_struct_dim_decl  */
+  case 896: /* optional_make_struct_dim_decl: make_struct_dim_decl  */
                                   { (yyval.pExpression) = (yyvsp[0].pExpression);  }
     break;
 
-  case 894: /* optional_make_struct_dim_decl: %empty  */
+  case 897: /* optional_make_struct_dim_decl: %empty  */
         {   (yyval.pExpression) = new ExprMakeStruct(); }
     break;
 
-  case 895: /* use_initializer: %empty  */
+  case 898: /* use_initializer: %empty  */
                             { (yyval.b) = true; }
     break;
 
-  case 896: /* use_initializer: "uninitialized"  */
+  case 899: /* use_initializer: "uninitialized"  */
                             { (yyval.b) = false; }
     break;
 
-  case 897: /* $@99: %empty  */
+  case 900: /* $@99: %empty  */
                              { yyextra->das_arrow_depth ++; }
     break;
 
-  case 898: /* $@100: %empty  */
+  case 901: /* $@100: %empty  */
                                                                                                    { yyextra->das_arrow_depth --; }
     break;
 
-  case 899: /* make_struct_decl: "struct" '<' $@99 type_declaration_no_options '>' $@100 '(' use_initializer optional_make_struct_dim_decl ')'  */
+  case 902: /* make_struct_decl: "struct" '<' $@99 type_declaration_no_options '>' $@100 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                       {
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-6].pTypeDecl);
@@ -10713,15 +10760,15 @@ yyreduce:
     }
     break;
 
-  case 900: /* $@101: %empty  */
+  case 903: /* $@101: %empty  */
                             { yyextra->das_arrow_depth ++; }
     break;
 
-  case 901: /* $@102: %empty  */
+  case 904: /* $@102: %empty  */
                                                                                                   { yyextra->das_arrow_depth --; }
     break;
 
-  case 902: /* make_struct_decl: "class" '<' $@101 type_declaration_no_options '>' $@102 '(' use_initializer optional_make_struct_dim_decl ')'  */
+  case 905: /* make_struct_decl: "class" '<' $@101 type_declaration_no_options '>' $@102 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                      {
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-6].pTypeDecl);
@@ -10731,15 +10778,15 @@ yyreduce:
     }
     break;
 
-  case 903: /* $@103: %empty  */
+  case 906: /* $@103: %empty  */
                                { yyextra->das_arrow_depth ++; }
     break;
 
-  case 904: /* $@104: %empty  */
+  case 907: /* $@104: %empty  */
                                                                                             { yyextra->das_arrow_depth --; }
     break;
 
-  case 905: /* make_struct_decl: "variant" '<' $@103 variant_type_list '>' $@104 '(' use_initializer make_variant_dim ')'  */
+  case 908: /* make_struct_decl: "variant" '<' $@103 variant_type_list '>' $@104 '(' use_initializer make_variant_dim ')'  */
                                                                                                                                                                                   {
         auto mkt = new TypeDecl(Type::tVariant);
         mkt->at = tokAt(scanner,(yylsp[-9]));
@@ -10753,15 +10800,15 @@ yyreduce:
     }
     break;
 
-  case 906: /* $@105: %empty  */
+  case 909: /* $@105: %empty  */
                                         { yyextra->das_arrow_depth ++; }
     break;
 
-  case 907: /* $@106: %empty  */
+  case 910: /* $@106: %empty  */
                                                                                                               { yyextra->das_arrow_depth --; }
     break;
 
-  case 908: /* make_struct_decl: "variant" "type" '<' $@105 type_declaration_no_options '>' $@106 '(' use_initializer make_variant_dim ')'  */
+  case 911: /* make_struct_decl: "variant" "type" '<' $@105 type_declaration_no_options '>' $@106 '(' use_initializer make_variant_dim ')'  */
                                                                                                                                                                                                     {
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-10]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-6].pTypeDecl);
@@ -10771,15 +10818,15 @@ yyreduce:
     }
     break;
 
-  case 909: /* $@107: %empty  */
+  case 912: /* $@107: %empty  */
                               { yyextra->das_arrow_depth ++; }
     break;
 
-  case 910: /* $@108: %empty  */
+  case 913: /* $@108: %empty  */
                                                                                                     { yyextra->das_arrow_depth --; }
     break;
 
-  case 911: /* make_struct_decl: "default" '<' $@107 type_declaration_no_options '>' $@108 use_initializer  */
+  case 914: /* make_struct_decl: "default" '<' $@107 type_declaration_no_options '>' $@108 use_initializer  */
                                                                                                                                                            {
         auto msd = new ExprMakeStruct();
         msd->at = tokAt(scanner,(yylsp[-6]));
@@ -10790,7 +10837,7 @@ yyreduce:
     }
     break;
 
-  case 912: /* make_tuple_call: "tuple" '(' expr_list optional_comma ')'  */
+  case 915: /* make_tuple_call: "tuple" '(' expr_list optional_comma ')'  */
                                                                     {
         auto mkt = new ExprMakeTuple(tokAt(scanner,(yylsp[-4])));
         mkt->values = sequenceToList((yyvsp[-2].pExpression));
@@ -10799,15 +10846,15 @@ yyreduce:
     }
     break;
 
-  case 913: /* $@109: %empty  */
+  case 916: /* $@109: %empty  */
                              { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; }
     break;
 
-  case 914: /* $@110: %empty  */
+  case 917: /* $@110: %empty  */
                                                                                                                               { yyextra->das_arrow_depth --; }
     break;
 
-  case 915: /* make_tuple_call: "tuple" '<' $@109 tuple_type_list '>' $@110 '(' use_initializer optional_make_struct_dim_decl ')'  */
+  case 918: /* make_tuple_call: "tuple" '<' $@109 tuple_type_list '>' $@110 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                                                  {
         auto mkt = new TypeDecl(Type::tTuple);
         mkt->at = tokAt(scanner,(yylsp[-9]));
@@ -10821,7 +10868,7 @@ yyreduce:
     }
     break;
 
-  case 916: /* make_dim_decl: '[' optional_expr_list ']'  */
+  case 919: /* make_dim_decl: '[' optional_expr_list ']'  */
                                                   {
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-2])));
@@ -10843,15 +10890,15 @@ yyreduce:
     }
     break;
 
-  case 917: /* $@111: %empty  */
+  case 920: /* $@111: %empty  */
                                        { yyextra->das_arrow_depth ++; }
     break;
 
-  case 918: /* $@112: %empty  */
+  case 921: /* $@112: %empty  */
                                                                                                              { yyextra->das_arrow_depth --; }
     break;
 
-  case 919: /* make_dim_decl: "array" "struct" '<' $@111 type_declaration_no_options '>' $@112 '(' use_initializer optional_make_struct_dim_decl ')'  */
+  case 922: /* make_dim_decl: "array" "struct" '<' $@111 type_declaration_no_options '>' $@112 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                                 {
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-10]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-6].pTypeDecl);
@@ -10864,15 +10911,15 @@ yyreduce:
     }
     break;
 
-  case 920: /* $@113: %empty  */
+  case 923: /* $@113: %empty  */
                                        { yyextra->das_arrow_depth ++; }
     break;
 
-  case 921: /* $@114: %empty  */
+  case 924: /* $@114: %empty  */
                                                                                                   { yyextra->das_arrow_depth --; }
     break;
 
-  case 922: /* make_dim_decl: "array" "tuple" '<' $@113 tuple_type_list '>' $@114 '(' use_initializer optional_make_struct_dim_decl ')'  */
+  case 925: /* make_dim_decl: "array" "tuple" '<' $@113 tuple_type_list '>' $@114 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                      {
         auto mkt = new TypeDecl(Type::tTuple);
         mkt->at = tokAt(scanner,(yylsp[-10]));
@@ -10889,15 +10936,15 @@ yyreduce:
     }
     break;
 
-  case 923: /* $@115: %empty  */
+  case 926: /* $@115: %empty  */
                                          { yyextra->das_arrow_depth ++; }
     break;
 
-  case 924: /* $@116: %empty  */
+  case 927: /* $@116: %empty  */
                                                                                                       { yyextra->das_arrow_depth --; }
     break;
 
-  case 925: /* make_dim_decl: "array" "variant" '<' $@115 variant_type_list '>' $@116 '(' make_variant_dim ')'  */
+  case 928: /* make_dim_decl: "array" "variant" '<' $@115 variant_type_list '>' $@116 '(' make_variant_dim ')'  */
                                                                                                                                                                       {
         auto mkt = new TypeDecl(Type::tVariant);
         mkt->at = tokAt(scanner,(yylsp[-9]));
@@ -10914,7 +10961,7 @@ yyreduce:
     }
     break;
 
-  case 926: /* make_dim_decl: "array" '(' expr_list optional_comma ')'  */
+  case 929: /* make_dim_decl: "array" '(' expr_list optional_comma ')'  */
                                                                    {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
@@ -10926,15 +10973,15 @@ yyreduce:
     }
     break;
 
-  case 927: /* $@117: %empty  */
+  case 930: /* $@117: %empty  */
                            { yyextra->das_arrow_depth ++; }
     break;
 
-  case 928: /* $@118: %empty  */
+  case 931: /* $@118: %empty  */
                                                                                                  { yyextra->das_arrow_depth --; }
     break;
 
-  case 929: /* make_dim_decl: "array" '<' $@117 type_declaration_no_options '>' $@118 '(' optional_expr_list ')'  */
+  case 932: /* make_dim_decl: "array" '<' $@117 type_declaration_no_options '>' $@118 '(' optional_expr_list ')'  */
                                                                                                                                                                         {
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-8])));
@@ -10957,7 +11004,7 @@ yyreduce:
     }
     break;
 
-  case 930: /* make_dim_decl: "fixed_array" '(' expr_list optional_comma ')'  */
+  case 933: /* make_dim_decl: "fixed_array" '(' expr_list optional_comma ')'  */
                                                                          {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
@@ -10967,15 +11014,15 @@ yyreduce:
     }
     break;
 
-  case 931: /* $@119: %empty  */
+  case 934: /* $@119: %empty  */
                                  { yyextra->das_arrow_depth ++; }
     break;
 
-  case 932: /* $@120: %empty  */
+  case 935: /* $@120: %empty  */
                                                                                                        { yyextra->das_arrow_depth --; }
     break;
 
-  case 933: /* make_dim_decl: "fixed_array" '<' $@119 type_declaration_no_options '>' $@120 '(' expr_list optional_comma ')'  */
+  case 936: /* make_dim_decl: "fixed_array" '<' $@119 type_declaration_no_options '>' $@120 '(' expr_list optional_comma ')'  */
                                                                                                                                                                                     {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-9])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
@@ -10985,25 +11032,25 @@ yyreduce:
     }
     break;
 
-  case 934: /* expr_map_tuple_list: expr  */
+  case 937: /* expr_map_tuple_list: expr  */
                       {
         (yyval.pExpression) = (yyvsp[0].pExpression);
     }
     break;
 
-  case 935: /* expr_map_tuple_list: expr_map_tuple_list ',' expr  */
+  case 938: /* expr_map_tuple_list: expr_map_tuple_list ',' expr  */
                                                       {
             (yyval.pExpression) = new ExprSequence(tokAt(scanner,(yylsp[-2])),(yyvsp[-2].pExpression),(yyvsp[0].pExpression));
     }
     break;
 
-  case 936: /* push_table_nesting: %empty  */
+  case 939: /* push_table_nesting: %empty  */
                     {
         yyextra->das_nested_parentheses ++;
     }
     break;
 
-  case 937: /* make_table_decl: '{' push_table_nesting optional_emit_semis optional_expr_map_tuple_list '}'  */
+  case 940: /* make_table_decl: '{' push_table_nesting optional_emit_semis optional_expr_map_tuple_list '}'  */
                                                                                                      {
         yyextra->das_nested_parentheses --;
         if ( (yyvsp[-1].pExpression) ) {
@@ -11026,7 +11073,7 @@ yyreduce:
     }
     break;
 
-  case 938: /* make_table_call: "table" '(' expr_map_tuple_list optional_comma ')'  */
+  case 941: /* make_table_call: "table" '(' expr_map_tuple_list optional_comma ')'  */
                                                                              {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
@@ -11037,7 +11084,7 @@ yyreduce:
     }
     break;
 
-  case 939: /* make_table_call: "table" '<' type_declaration_no_options '>' '(' optional_expr_map_tuple_list ')'  */
+  case 942: /* make_table_call: "table" '<' type_declaration_no_options '>' '(' optional_expr_map_tuple_list ')'  */
                                                                                                                  {
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-6])));
@@ -11060,7 +11107,7 @@ yyreduce:
     }
     break;
 
-  case 940: /* make_table_call: "table" '<' type_declaration_no_options c_or_s type_declaration_no_options '>' '(' optional_expr_map_tuple_list ')'  */
+  case 943: /* make_table_call: "table" '<' type_declaration_no_options c_or_s type_declaration_no_options '>' '(' optional_expr_map_tuple_list ')'  */
                                                                                                                                                              {
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-8])));
@@ -11085,35 +11132,35 @@ yyreduce:
     }
     break;
 
-  case 941: /* array_comprehension_where: %empty  */
+  case 944: /* array_comprehension_where: %empty  */
                                     { (yyval.pExpression) = nullptr; }
     break;
 
-  case 942: /* array_comprehension_where: ';' "where" expr  */
+  case 945: /* array_comprehension_where: ';' "where" expr  */
                                     { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 943: /* optional_comma: %empty  */
+  case 946: /* optional_comma: %empty  */
                 { (yyval.b) = false; }
     break;
 
-  case 944: /* optional_comma: ','  */
+  case 947: /* optional_comma: ','  */
                 { (yyval.b) = true; }
     break;
 
-  case 945: /* table_comprehension: '[' "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where ']'  */
+  case 948: /* table_comprehension: '[' "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where ']'  */
                                                                                                                                                                {
         (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-9])),(yyvsp[-7].pNameWithPosList),(yyvsp[-5].pExpression),(yyvsp[-2].pExpression),(yyvsp[-1].pExpression),tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])),false,false);
     }
     break;
 
-  case 946: /* table_comprehension: '[' "iterator" "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where ']'  */
+  case 949: /* table_comprehension: '[' "iterator" "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where ']'  */
                                                                                                                                                                             {
         (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-9])),(yyvsp[-7].pNameWithPosList),(yyvsp[-5].pExpression),(yyvsp[-2].pExpression),(yyvsp[-1].pExpression),tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])),true,false);
     }
     break;
 
-  case 947: /* array_comprehension: '{' push_table_nesting optional_emit_semis "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where '}'  */
+  case 950: /* array_comprehension: '{' push_table_nesting optional_emit_semis "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where '}'  */
                                                                                                                                                                                                       {
         yyextra->das_nested_parentheses --;
         (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-9])),(yyvsp[-7].pNameWithPosList),(yyvsp[-5].pExpression),(yyvsp[-2].pExpression),(yyvsp[-1].pExpression),tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])),false,true);

--- a/src/parser/ds2_parser.ypp
+++ b/src/parser/ds2_parser.ypp
@@ -411,6 +411,7 @@
 %type <aaList>              metadata_argument_list
 %type <aaList>              annotation_argument_value_list
 %type <aaList>              optional_field_annotation
+%type <aaList>              optional_for_annotations
 %type <fa>                  annotation_declaration_basic
 %type <fa>                  annotation_declaration
 %type <faList>              annotation_list
@@ -1032,9 +1033,9 @@ for_variable_name_with_pos_list
 expression_for_loop
     :   {
         yyextra->das_keyword = true;
-    } DAS_FOR[loc] '(' for_variable_name_with_pos_list[iters] DAS_IN expr_list[srcs] ')' optional_emit_semis expression_block[block] {
+    } DAS_FOR[loc] optional_for_annotations[annL] '(' for_variable_name_with_pos_list[iters] DAS_IN expr_list[srcs] ')' optional_emit_semis expression_block[block] {
         yyextra->das_keyword = false;
-        $$ = ast_forLoop(scanner,$iters,$srcs,$block,tokAt(scanner,@loc),tokAt(scanner,@block));
+        $$ = ast_forLoop(scanner,$iters,$srcs,$block,tokAt(scanner,@loc),tokAt(scanner,@block),$annL);
     }
     ;
 
@@ -1049,11 +1050,12 @@ expression_unsafe
 expression_while_loop
     :   {
         yyextra->das_keyword = true;
-    } DAS_WHILE[loc] '(' expr[condition] ')' optional_emit_semis expression_block[block] {
+    } DAS_WHILE[loc] optional_for_annotations[annL] '(' expr[condition] ')' optional_emit_semis expression_block[block] {
         yyextra->das_keyword = false;
         auto pWhile = new ExprWhile(tokAt(scanner,@loc));
         pWhile->cond = $condition;
         pWhile->body = $block;
+        if ( $annL ) { pWhile->annotations = move(*$annL); delete $annL; }
         ((ExprBlock *)$block)->inTheLoop = true;
         $$ = pWhile;
     }
@@ -1139,6 +1141,18 @@ metadata_argument_list
     }
     |   metadata_argument_list[argL] '@' annotation_argument[arg] optional_emit_semis {
         $$ = ast_annotationArgumentListEntry(scanner,$argL,$arg);
+    }
+    ;
+
+optional_for_annotations
+    :   /* empty */ {
+        $$ = nullptr;
+    }
+    |   '[' annotation_argument_list[argL] ']' {
+        $$ = $argL;
+    }
+    |   metadata_argument_list[argL] {
+        $$ = $argL;
     }
     ;
 

--- a/src/parser/parser_impl.cpp
+++ b/src/parser/parser_impl.cpp
@@ -1127,7 +1127,8 @@ namespace das {
     }
 
     Expression * ast_forLoop ( yyscan_t,  vector<VariableNameAndPosition> * iters, Expression * srcs,
-        Expression * block, const LineInfo & locAt, const LineInfo & blockAt ) {
+        Expression * block, const LineInfo & locAt, const LineInfo & blockAt,
+        AnnotationArgumentList * annL ) {
         auto pFor = new ExprFor(locAt);
         pFor->visibility = blockAt;
         for ( const auto & np : *iters ) {
@@ -1140,6 +1141,7 @@ namespace das {
         delete iters;
         pFor->sources = sequenceToList(srcs);
         pFor->body = block;
+        if ( annL ) { pFor->annotations = move(*annL); delete annL; }
         ((ExprBlock *)block)->inTheLoop = true;
         return pFor;
     }

--- a/src/parser/parser_impl.h
+++ b/src/parser/parser_impl.h
@@ -107,7 +107,8 @@ namespace das {
         TypeDecl * result, const LineInfo & nameAt );
     void ast_requireModule ( yyscan_t scanner, string * name, string * modalias, bool pub, const LineInfo & atName );
     Expression * ast_forLoop ( yyscan_t scanner,  vector<VariableNameAndPosition> * iters, Expression * srcs,
-        Expression * block, const LineInfo & locAt, const LineInfo & blockAt );
+        Expression * block, const LineInfo & locAt, const LineInfo & blockAt,
+        AnnotationArgumentList * annL = nullptr );
     AnnotationArgumentList * ast_annotationArgumentListEntry ( yyscan_t scanner, AnnotationArgumentList * argL, AnnotationArgument * arg );
     AnnotationArgumentList * ast_annotationArgumentListEntry ( yyscan_t, AnnotationArgumentList * argL, AnnotationArgument * arg );
     Expression * ast_lpipe ( yyscan_t scanner, Expression * fncall, Expression * arg, const LineInfo & locAt );

--- a/tests/jit_tests/per_loop_hints.das
+++ b/tests/jit_tests/per_loop_hints.das
@@ -1,0 +1,75 @@
+options gen2
+require dastest/testing_boost
+
+// Smoke tests for per-loop annotations on ExprFor / ExprWhile.
+// These must parse and produce identical numeric results to their
+// unannotated equivalents — the JIT lowering attaches LLVM loop
+// metadata but does not change semantics.
+
+def sum_range_bracketed(n : int) {
+    var sum = 0
+    for [unroll, vectorize] (i in range(1, n + 1)) {
+        sum += i
+    }
+    return sum
+}
+
+def sum_range_metadata(n : int) {
+    var sum = 0
+    for @unroll_full(i in range(1, n + 1)) {
+        sum += i
+    }
+    return sum
+}
+
+def sum_range_count(n : int) {
+    var sum = 0
+    for [unroll_count = 4] (i in range(1, n + 1)) {
+        sum += i
+    }
+    return sum
+}
+
+def sum_range_bare(n : int) {
+    var sum = 0
+    for (i in range(1, n + 1)) {
+        sum += i
+    }
+    return sum
+}
+
+def countdown_while_annotated(start : int) {
+    var x = start
+    var iters = 0
+    while [unroll_disable] (x > 0) {
+        x -= 1
+        iters += 1
+    }
+    return iters
+}
+
+def countdown_while_bare(start : int) {
+    var x = start
+    var iters = 0
+    while (x > 0) {
+        x -= 1
+        iters += 1
+    }
+    return iters
+}
+
+[test]
+def test_per_loop_hints(t : T?) {
+    t |> run("for [bracketed] matches bare") @(t : T?) {
+        t |> equal(sum_range_bracketed(100), sum_range_bare(100))
+    }
+    t |> run("for @metadata matches bare") @(t : T?) {
+        t |> equal(sum_range_metadata(100), sum_range_bare(100))
+    }
+    t |> run("for [unroll_count = N] matches bare") @(t : T?) {
+        t |> equal(sum_range_count(100), sum_range_bare(100))
+    }
+    t |> run("while [unroll_disable] matches bare") @(t : T?) {
+        t |> equal(countdown_while_annotated(50), countdown_while_bare(50))
+    }
+}

--- a/tree-sitter-daslang/grammar.js
+++ b/tree-sitter-daslang/grammar.js
@@ -656,6 +656,10 @@ module.exports = grammar({
 
     for_statement: $ => seq(
       'for',
+      optional(field('annotations', choice(
+        seq('[', $.annotation_argument_list, ']'),
+        $.metadata_argument_list,
+      ))),
       '(',
       field('variables', sep1($.for_variable, ',')),
       'in',
@@ -672,6 +676,10 @@ module.exports = grammar({
 
     while_statement: $ => seq(
       'while',
+      optional(field('annotations', choice(
+        seq('[', $.annotation_argument_list, ']'),
+        $.metadata_argument_list,
+      ))),
       '(',
       field('condition', $._expression),
       ')',

--- a/tree-sitter-daslang/src/grammar.json
+++ b/tree-sitter-daslang/src/grammar.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "daslang",
   "word": "identifier",
   "rules": {
@@ -3848,6 +3849,44 @@
           "value": "for"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "annotations",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "["
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "annotation_argument_list"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "]"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "metadata_argument_list"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "("
         },
@@ -4010,6 +4049,44 @@
         {
           "type": "STRING",
           "value": "while"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "annotations",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "["
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "annotation_argument_list"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "]"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "metadata_argument_list"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",
@@ -10434,5 +10511,6 @@
     "_statement",
     "_declaration",
     "_type"
-  ]
+  ],
+  "reserved": {}
 }

--- a/tree-sitter-daslang/src/node-types.json
+++ b/tree-sitter-daslang/src/node-types.json
@@ -1864,6 +1864,28 @@
     "type": "for_statement",
     "named": true,
     "fields": {
+      "annotations": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "[",
+            "named": false
+          },
+          {
+            "type": "]",
+            "named": false
+          },
+          {
+            "type": "annotation_argument_list",
+            "named": true
+          },
+          {
+            "type": "metadata_argument_list",
+            "named": true
+          }
+        ]
+      },
       "body": {
         "multiple": false,
         "required": true,
@@ -3249,6 +3271,7 @@
   {
     "type": "source_file",
     "named": true,
+    "root": true,
     "fields": {},
     "children": {
       "multiple": true,
@@ -4388,6 +4411,28 @@
     "type": "while_statement",
     "named": true,
     "fields": {
+      "annotations": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "[",
+            "named": false
+          },
+          {
+            "type": "]",
+            "named": false
+          },
+          {
+            "type": "annotation_argument_list",
+            "named": true
+          },
+          {
+            "type": "metadata_argument_list",
+            "named": true
+          }
+        ]
+      },
       "body": {
         "multiple": false,
         "required": true,
@@ -4737,7 +4782,8 @@
   },
   {
     "type": "block_comment",
-    "named": true
+    "named": true,
+    "extra": true
   },
   {
     "type": "bool",
@@ -4957,7 +5003,8 @@
   },
   {
     "type": "line_comment",
-    "named": true
+    "named": true,
+    "extra": true
   },
   {
     "type": "module",

--- a/tree-sitter-daslang/src/tree_sitter/parser.h
+++ b/tree-sitter-daslang/src/tree_sitter/parser.h
@@ -18,6 +18,11 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +31,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -47,6 +53,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {
@@ -78,6 +85,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -92,7 +105,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -108,13 +121,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -128,15 +141,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -144,7 +165,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/tree-sitter-daslang/test/corpus/statements.txt
+++ b/tree-sitter-daslang/test/corpus/statements.txt
@@ -194,3 +194,94 @@ def test() {
           name: (identifier)
           value: (call_expression
             function: (identifier)))))))
+
+================================================================================
+For loop with bracketed annotations
+================================================================================
+
+def test() {
+  for [unroll_count = 4, vectorize] (i in range(10)) {
+    pass
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    (function_argument_list)
+    body: (block
+      (for_statement
+        annotations: (annotation_argument_list
+          (annotation_argument
+            name: (identifier)
+            value: (integer_literal))
+          (annotation_argument
+            name: (identifier)))
+        variables: (for_variable
+          (identifier))
+        iterators: (call_expression
+          function: (basic_type)
+          (argument_list
+            (integer_literal)))
+        body: (block
+          (pass_statement))))))
+
+================================================================================
+For loop with metadata annotations
+================================================================================
+
+def test() {
+  for @unroll_full (i in range(10)) {
+    pass
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    (function_argument_list)
+    body: (block
+      (for_statement
+        annotations: (metadata_argument_list
+          (annotation_argument
+            name: (identifier)))
+        variables: (for_variable
+          (identifier))
+        iterators: (call_expression
+          function: (basic_type)
+          (argument_list
+            (integer_literal)))
+        body: (block
+          (pass_statement))))))
+
+================================================================================
+While loop with bracketed annotations
+================================================================================
+
+def test() {
+  while [unroll_disable] (false) {
+    pass
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    (function_argument_list)
+    body: (block
+      (while_statement
+        annotations: (annotation_argument_list
+          (annotation_argument
+            name: (identifier)))
+        condition: (boolean_literal)
+        body: (block
+          (pass_statement))))))


### PR DESCRIPTION
## Summary

Adds a per-loop annotation surface that threads into LLVM `!llvm.loop.*` metadata in the dasLLVM JIT. Two accepted gen2 syntactic forms — both optional, bare loops continue to parse:

```das
for [unroll_count = 4, vectorize] (i in range(N)) { ... }   // bracketed
for @unroll_full (i in range(N)) { ... }                    // @-prefixed
while [unroll_disable] (cond) { ... }                       // same on while
```

Stored as a new `AnnotationArgumentList annotations` field on `ExprFor`/`ExprWhile`. Walked at JIT codegen time to extend the auto-attached `!llvm.loop.mustprogress` operand from #2635 with user-requested operands per [LangRef §Loop Metadata](https://llvm.org/docs/LangRef.html#llvm-loop).

## Recognized hints

| Hint | LLVM metadata |
|---|---|
| `unroll` / `unroll_full` / `unroll_disable` | `llvm.loop.unroll.{enable,full,disable}` |
| `unroll_count = N` | `llvm.loop.unroll.count, i32 N` |
| `unroll_and_jam` / `unroll_and_jam_disable` | `llvm.loop.unroll_and_jam.{enable,disable}` |
| `vectorize` / `vectorize_disable` | `llvm.loop.vectorize.enable, i1 {1,0}` |
| `vectorize_width = N` | `llvm.loop.vectorize.width, i32 N` |
| `vectorize_predicate` | `llvm.loop.vectorize.predicate.enable, i1 1` |
| `interleave_count = N` | `llvm.loop.interleave.count, i32 N` |
| `distribute` | `llvm.loop.distribute.enable, i1 1` |
| `disable_nonforced` | `llvm.loop.disable_nonforced` |
| `licm_versioning_disable` | `llvm.loop.licm_versioning.disable` |

Unknown hint names error at JIT time with `failed("unknown loop hint '...'")`.

## End-to-end IR verification

Most important verification artifact — the metadata actually reaches LLVM with the right shape. From `daslang -jit /tmp/primes.das -- --jit-dump` on a primes implementation with `outer [unroll_and_jam]` + `inner [unroll_count = 4]`:

**Bare loops (mustprogress only):**
```llvm
!0 = distinct !{!0, !1}
!1 = !{!"llvm.loop.mustprogress"}
!2 = distinct !{!2, !1}
```

**With annotations:**
```llvm
!0 = distinct !{!0, !1, !2}
!1 = !{!"llvm.loop.mustprogress"}
!2 = !{!"llvm.loop.unroll.count", i32 4}
!3 = distinct !{!3, !1, !4}                  ← LLVM auto-added on cleanup loop
!4 = !{!"llvm.loop.unroll.disable"}          ← proves the unroll pass ran
!6 = distinct !{!6, !1, !7}
!7 = !{!"llvm.loop.unroll_and_jam.enable"}
```

The `i32 4` operand reaches LLVM unchanged, and the unroll pass visibly acts on it — the annotated `isprime` inner loop appears 4-way unrolled in the dumped IR (`.i.1` / `.i.2` / `.i.3` block suffixes), and LLVM auto-tags the cleanup loop with `unroll.disable`.

## Plumbing

- **AST** ([ast_expressions.h](include/daScript/ast/ast_expressions.h)): `ExprFor`/`ExprWhile` gain an `AnnotationArgumentList annotations` field
- **Clone** ([ast.cpp](src/ast/ast.cpp)): one-liner vector copy in both clones
- **Serialize** ([module_builtin_ast_serialize.cpp](src/builtin/module_builtin_ast_serialize.cpp)): `<< expr->annotations` in both preVisits; `AstSerializer::getVersion()` bumped **81 → 82**
- **RTTI** ([module_builtin_ast_annotations_2.cpp](src/builtin/module_builtin_ast_annotations_2.cpp)): `addField<DAS_BIND_MANAGED_FIELD(annotations)>("annotations")` on both
- **Grammar** ([ds2_parser.ypp](src/parser/ds2_parser.ypp)): new `optional_for_annotations` nonterminal reused across the for/while productions; `%expect 0` preserved. gen1 parser untouched. `ast_forLoop` takes an optional trailing `AnnotationArgumentList* annL = nullptr` so the gen1 caller doesn't break
- **Tree-sitter** ([grammar.js](tree-sitter-daslang/grammar.js)): same insertion; corpus tests for both forms on `for`/`while`; 29/29 corpus parses pass
- **JIT** ([llvm_jit.das](modules/dasLLVM/daslib/llvm_jit.das)): `LoopBlock` carries the parent `ExprWhile?` so `preVisitExprContinue` can attach the same metadata to a while-continue backedge. `attach_loop_mustprogress` preserved as a thin wrapper for `build_fixed_loop` (no source AST), with the mustprogress-only path inlined to avoid constructing an empty `AnnotationArgumentList` from das (handled types aren't safely default-constructible there).

## Timing notes

Mechanism verified via IR diff (above). Actual timing impact is workload-dependent and largely in the noise on the benchmarks I tried:

- **primes** (BENCH_RUNS=100, n=14000): all 11 perms within 0.44% — LLVM was already doing the same unroll by default
- **queen** (BENCH_RUNS=100, min-of-5): outer `[vectorize]` reduced min-time ~9% (56µs → 51µs), distribution tightened (max 72µs → 62µs), but overlaps baseline

Cross-invocation noise on these short-running benches (~50–70µs/iter) dominates the per-perm signal. The mechanism is correct; finding workloads where the hints materially move timing is a follow-up perf-eng exercise.

## Test plan

- [x] `mcp__daslang__compile_check` on `tests/jit_tests/per_loop_hints.das` — clean
- [x] `bin/daslang -jit dastest/dastest.das -- --test tests/jit_tests/per_loop_hints.das` — 5/5 pass
- [x] Full JIT suite `tests/jit_tests/` — 287/287 pass, no regressions
- [x] Full interpreter suite `tests/` — 8011/8011 pass (6 pre-existing skips)
- [x] Tree-sitter corpus — 29/29 parses pass
- [x] IR-dump verification (above)
- [ ] CI matrix
- [ ] Copilot review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)