### PR TITLE
jit: declare runtime allocator memory effects

### DIFF
--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -105,6 +105,12 @@ class public Attributes {
     noalias : LLVMOpaqueAttributeRef?
     sext : LLVMOpaqueAttributeRef?
     zext : LLVMOpaqueAttributeRef?
+    // memory(inaccessiblemem: readwrite) — for allocator-style runtime calls
+    // LLVM 22 IRMemLocation layout: ArgMem=0(bits 0-1), InaccessibleMem=1(bits 2-3), each ModRef=3 → 3<<2=12
+    memory_inaccessible_rw : LLVMOpaqueAttributeRef?
+    // memory(argmem: readwrite, inaccessiblemem: readwrite) — for deallocator-style runtime calls
+    // 3 | (3 << 2) = 15
+    memory_arg_inaccessible_rw : LLVMOpaqueAttributeRef?
 
     def Attributes(ctx : LLVMContextRef) {
         noreturn = ctx |> LLVMGetEnumAttribute("noreturn")
@@ -124,6 +130,9 @@ class public Attributes {
         noalias = ctx |> LLVMGetEnumAttribute("noalias")
         sext = ctx |> LLVMGetEnumAttribute("signext")
         zext = ctx |> LLVMGetEnumAttribute("zeroext")
+        let memory_kind = LLVMGetEnumAttributeKindForName("memory")
+        memory_inaccessible_rw = LLVMCreateEnumAttribute(ctx, memory_kind, 12ul)
+        memory_arg_inaccessible_rw = LLVMCreateEnumAttribute(ctx, memory_kind, 15ul)
     }
 
 }
@@ -348,6 +357,9 @@ def public init_jit(cg_opt_level : uint) {
     assume willreturn = attrs.willreturn
     assume nocapture = attrs.nocapture
     assume cold = attrs.cold
+    assume nofree = attrs.nofree
+    assume memory_inaccessible_rw = attrs.memory_inaccessible_rw
+    assume memory_arg_inaccessible_rw = attrs.memory_arg_inaccessible_rw
     build_jit_types()
 
     // add default functions
@@ -420,21 +432,21 @@ def public init_jit(cg_opt_level : uint) {
         LLVMFunctionType(g_prim_t.LLVMVoidPtrType(),
             fixed_array<LLVMTypeRef>(g_prim_t.t_int32, g_prim_t.LLVMVoidPtrType())))
     LLVMAddGlobalMapping(g_engine, jit_alloc_heap, get_jit_alloc_heap())
-    LLVMAddAttributesToFunction(jit_alloc_heap, fixed_array(nounwind, willreturn))
+    LLVMAddAttributesToFunction(jit_alloc_heap, fixed_array(nounwind, willreturn, nofree, memory_inaccessible_rw))
     LLVMAddAttributeToFunctionArgument(jit_alloc_heap, 1u, nocapture)
     // jit_alloc_persistent ( uint64_t mnh, context * )
     var jit_alloc_persistent = LLVMAddFunctionWithType(g_mod, FN_JIT_ALLOC_PERSISTENT,
         LLVMFunctionType(g_prim_t.LLVMVoidPtrType(),
             fixed_array<LLVMTypeRef>(g_prim_t.t_int32, g_prim_t.LLVMVoidPtrType())))
     LLVMAddGlobalMapping(g_engine, jit_alloc_persistent, get_jit_alloc_persistent())
-    LLVMAddAttributesToFunction(jit_alloc_persistent, fixed_array(nounwind, willreturn))
+    LLVMAddAttributesToFunction(jit_alloc_persistent, fixed_array(nounwind, willreturn, nofree, memory_inaccessible_rw))
     LLVMAddAttributeToFunctionArgument(jit_alloc_persistent, 1u, nocapture)
     // void jit_free_heap ( void * bytes, uint32_t size, Context * context )
     var jit_free_heap = LLVMAddFunctionWithType(g_mod, FN_JIT_FREE_HEAP,
         LLVMFunctionType(g_prim_t.LLVMVoidPtrType(),
             fixed_array<LLVMTypeRef>(g_prim_t.LLVMVoidPtrType(), g_prim_t.t_int32, g_prim_t.LLVMVoidPtrType())))
     LLVMAddGlobalMapping(g_engine, jit_free_heap, get_jit_free_heap())
-    LLVMAddAttributesToFunction(jit_free_heap, fixed_array(nounwind, willreturn))
+    LLVMAddAttributesToFunction(jit_free_heap, fixed_array(nounwind, willreturn, memory_arg_inaccessible_rw))
     LLVMAddAttributeToFunctionArgument(jit_free_heap, 0u, nocapture)
     LLVMAddAttributeToFunctionArgument(jit_free_heap, 2u, nocapture)
     // void jit_free_persistent ( void * bytes, Context * context )
@@ -442,7 +454,7 @@ def public init_jit(cg_opt_level : uint) {
         LLVMFunctionType(g_prim_t.LLVMVoidPtrType(),
             fixed_array<LLVMTypeRef>(g_prim_t.LLVMVoidPtrType(), g_prim_t.LLVMVoidPtrType())))
     LLVMAddGlobalMapping(g_engine, jit_free_persistent, get_jit_free_persistent())
-    LLVMAddAttributesToFunction(jit_free_persistent, fixed_array(nounwind, willreturn))
+    LLVMAddAttributesToFunction(jit_free_persistent, fixed_array(nounwind, willreturn, memory_arg_inaccessible_rw))
     LLVMAddAttributeToFunctionArgumentRange(jit_free_persistent, urange(0, 2), nocapture)
     // void jit_array_lock ( Array & array, Context * context )
     var jit_array_lock = LLVMAddFunctionWithType(g_mod, FN_JIT_ARRAY_LOCK,


### PR DESCRIPTION
## Summary

Declare proper memory-effect attributes on the JIT runtime allocator helpers so LLVM doesn't have to treat every `alloc`/`free` call as a hard memory barrier.

- `jit_alloc_heap` / `jit_alloc_persistent` → `nofree memory(inaccessiblemem: readwrite)` (mirrors clang's malloc wrapper).
- `jit_free_heap` / `jit_free_persistent` → `memory(argmem: readwrite, inaccessiblemem: readwrite)` (mirrors clang's free wrapper).

Before this change the declarations carried only `nounwind willreturn` with no memory clause, so LLVM had to assume the calls might touch any memory in the function — pinning surrounding loads/stores in place.

## LLVM 22 encoding

Per `llvm/Support/ModRef.h::IRMemLocation`:

```
ArgMem            bits 0-1   ModRef = 3
InaccessibleMem   bits 2-3   ModRef = 3
ErrnoMem          bits 4-5
Other             bits 6-7
```

```
memory(inaccessiblemem: readwrite)              = 3 << 2           = 12
memory(argmem: readwrite, inaccessiblemem: rw)  = 3 | (3 << 2)     = 15
```

Two new fields on the `Attributes` helper (`memory_inaccessible_rw`, `memory_arg_inaccessible_rw`) are constructed via `LLVMCreateEnumAttribute(ctx, "memory", encoded)`. The encoded uint64 follows the layout above.

## Where this came from

Session 2026-05-12 investigating the ~10% JIT-vs-C++ gap on the `tree` benchmark in dasProfile (treap with ~333K inserts + ~333K erases over 1M ops). Comparing the JIT IR's declaration of `jit_alloc_heap` with clang's IR for a `malloc` wrapper revealed the missing memory clause:

```diff
- declare ptr @jit_alloc_heap(i32, ptr "captures"="none") #1
- attributes #1 = { mustprogress nounwind willreturn }

+ declare ptr @jit_alloc_heap(i32, ptr "captures"="none") #2
+ attributes #2 = { mustprogress nofree nounwind willreturn memory(inaccessiblemem: readwrite) }
```

## Perf

**No measurable change on the tree benchmark** — alloc/free aren't on its inner hot path (they only fire at insert/erase decision points, not in the merge/split tight traversal). The benchmark's remaining gap is runtime-call overhead in the allocator helpers themselves, not optimizer conservatism around them.

Worth landing anyway because:
- It matches clang's idiomatic codegen for allocator-style functions.
- It enables hoisting/CSE in workloads that DO interleave allocator calls with field reads.
- It removes a latent footgun in JIT IR analysis (the original cached-card investigation flagged custom memory-effect markers as "things daslang emits that clang doesn't").

## Test plan

- [ ] CI green (interpreted + JIT)
- [ ] Existing benchmarks under dasProfile remain within noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)