### PR TITLE
daslib/rst_comment: add --detail_output flag for non-default doc trees

### DIFF
--- a/daslib/rst_comment.das
+++ b/daslib/rst_comment.das
@@ -469,8 +469,14 @@ class RstComment : AstCommentReader {
         if (is_in_completion()) return
         var output : string
         let args = get_command_line_arguments()
+        let detailIds = args |> find_index("--detail_output")
         let outputIds = args |> find_index("--docs_output")
-        if (outputIds >= 0) {
+        if (detailIds >= 0) {
+            // `--detail_output Y` → write to `Y/detail/`. Matches the natural
+            // read path `{topic_root}/detail/...` so the consumer can set
+            // `topic_root = Y` without the `/index/` segment.
+            output = args[detailIds+1] + "/detail/"
+        } elif (outputIds >= 0) {
             output = args[outputIds+1] + "/index/detail/"
         } else {
             output = get_das_root() + "/doc/source/stdlib/generated/detail/"


### PR DESCRIPTION
## Summary

- Adds a new optional `--detail_output Y` CLI flag to `daslib/rst_comment.das`'s comment reader. When set, per-function `//!` detail snippets are written to `Y/detail/` instead of `get_das_root() + /doc/source/stdlib/generated/detail/`.
- Lets a downstream consumer that vendors the daslang RST tooling (e.g. dasImgui's `utils/imgui2rst.das`, dasimgui-game's doc build) route detail snippets at its own `topic_root`. Set `topic_root = Y` and `--detail_output Y`; reads at `{topic_root}/detail/...` and writes at `Y/detail/` line up cleanly — no `/index/` segment required.
- Existing `--docs_output X` (which appends `/index/detail/`, load-bearing for Eden / dasimgui-game style invocations that pair `--docs_output X` with `topic_root = X/index`) is unchanged.
- Default behavior (no flag) is byte-identical to before. daslang's own `das2rst` doesn't pass either flag, so the daslang doc build is unaffected.

## Test plan

- [x] Local daslang build + daslang's own `das2rst` regenerates `doc/source/stdlib/generated/detail/` to the same content as master (no diff in tracked detail files for daslang's own doc tree).
- [x] dasImgui's `utils/imgui2rst.das -- --detail_output modules/dasImgui/doc/source/stdlib/generated` lands per-function details in the correct dasImgui-side tree; `sphinx-build -W` on the dasImgui doc tree builds clean with no broken substitutions.
- [ ] CI green (doc.yml + pages.yml + build matrix).

## Notes for review

- One-file change, ~7 lines added in `daslib/rst_comment.das` `write_to_detail` method.
- The flag is consumer-facing only; no internal call sites in daslang need updating.
- Will unblock the dasImgui Phase 6 documentation site (separate downstream change in `borisbat/dasImgui`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)