### PR TITLE
docs: External modules section + dasImgui crosslink

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -77,8 +77,14 @@ jobs:
       run: |
         set -eux
         cd web
+        # step0 only clones the emsdk wrapper — the toolchain itself
+        # (emsdk/upstream/emscripten/) lands via the install+activate pair
+        # that web/step1_emsdk_activate_linux.sh does locally. Without these,
+        # cmake's -DCMAKE_TOOLCHAIN_FILE points at a path that doesn't
+        # exist yet and the WASM build silently fails under continue-on-error.
         bash step0_emsdk_install.sh
-        # step1 sources emsdk_env.sh — re-export EMSDK for the configure step
+        ./emsdk/emsdk install latest
+        ./emsdk/emsdk activate latest
         bash -c "source emsdk/emsdk_env.sh && \
                  mkdir -p build && cd build && \
                  cmake -DCMAKE_BUILD_TYPE=Release -G Ninja \

--- a/doc/source/external_modules/dasimgui.rst
+++ b/doc/source/external_modules/dasimgui.rst
@@ -1,0 +1,34 @@
+dasImgui
+========
+
+dasImgui is the daslang binding for `Dear ImGui <https://github.com/ocornut/imgui>`_.
+It ships with the boost macro layer that compresses immediate-mode boilerplate
+into block-style one-liners, full live-reload integration, and a snapshot-based
+test harness that drives the widget tree headlessly under ``dastest``.
+
+Where to go
+-----------
+
+* **Documentation**: https://borisbat.github.io/dasImgui/
+* **Repository**: https://github.com/borisbat/dasImgui
+
+What's there
+------------
+
+* Bindings covering the Dear ImGui surface, generated from the upstream
+  ``imgui.h`` via the in-repo binder.
+* The ``imgui_boost`` macro layer — ``window`` / ``tab_bar`` / ``tree_node``
+  / ``table`` and friends as block macros, so the typical ``Begin*`` / ``End*``
+  pair becomes a single scoped block.
+* ``imgui_test``: a Playwright-style widget walker that asserts against the
+  rendered tree without needing a GL context — usable from dastest, runnable
+  in CI.
+* Examples and tutorials under ``examples/features/``, every one runnable both
+  as a standalone binary and live-reloaded under ``daslang-live``.
+
+Versioning
+----------
+
+The documentation tracks the **v2.0** surface. The legacy ``daslib/imgui_boost``
+(v1) is not documented at the new site; v1 users pin to the older daspkg
+release.

--- a/doc/source/external_modules/index.rst
+++ b/doc/source/external_modules/index.rst
@@ -1,0 +1,11 @@
+External modules
+================
+
+Daslang modules maintained outside the main repository. Each one ships its
+own documentation; the entries below are short pointers describing what each
+module does and where its docs live.
+
+.. toctree::
+   :maxdepth: 1
+
+   dasimgui

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,6 +9,7 @@ Contents:
 
    reference/index.rst
    stdlib/index.rst
+   external_modules/index.rst
 
 
 Indices and tables

--- a/mouse-data/docs/codemirror-5-multi-file-editor-swapdoc-autosave-discipline.md
+++ b/mouse-data/docs/codemirror-5-multi-file-editor-swapdoc-autosave-discipline.md
@@ -1,0 +1,79 @@
+---
+slug: codemirror-5-multi-file-editor-swapdoc-autosave-discipline
+title: How do I implement a multi-file editor in CodeMirror 5 with per-tab undo history and localStorage autosave?
+created: 2026-05-13
+last_verified: 2026-05-13
+links: []
+---
+
+**Core pattern: one `CodeMirror.Doc` per file, `editor.swapDoc(doc)` to switch the visible buffer. The editor instance is shared; each Doc carries its own text, undo stack, and scroll position.**
+
+```js
+const editor = CodeMirror(el, opts);          // one editor
+
+const state = {
+    files: {                                  // one Doc per file
+        'main.das': editor.getDoc(),
+        'utils.das': new CodeMirror.Doc('', 'daslang'),
+    },
+    active: 'main.das',
+};
+
+function switchFile(name) {
+    state.active = name;
+    editor.swapDoc(state.files[name]);        // history preserved
+    autosave();                               // ← see below
+}
+```
+
+## Autosave discipline — the trap
+
+The instinct is to autosave on content change only:
+```js
+doc.on('change', autosave);   // covers content edits
+```
+
+But that misses **every other state mutation** — tab switch, add, delete, rename. If the user picks tab B, types nothing, and reloads, persistence restores tab A. Fix: call `autosave()` from *every* state-modifying entry point, not just `change`:
+
+- `switchFile` → `autosave()`
+- `addFile` → `autosave()`
+- `deleteFile` → `autosave()`
+- `renameFile` → `autosave()`
+- Initial `change` listener stays (per-Doc, attached when Doc is created)
+
+Debounce the writer (~250ms) so rapid edits coalesce. Redundant calls during rapid state changes are free — `clearTimeout(autosaveTimer)` then `setTimeout(..., 250)`.
+
+## Serialization
+
+Each Doc stringifies via `.getValue()`. Whole state:
+```js
+function getStateJson() {
+    return {
+        files: Object.fromEntries(
+            Object.entries(state.files).map(([k, d]) => [k, d.getValue()])
+        ),
+        active: state.active,
+    };
+}
+```
+Persist `JSON.stringify(getStateJson())` into `localStorage`. Restore by parsing then reconstructing fresh Docs.
+
+## URL share format
+
+LZ-string the JSON, encode URL-safely:
+```js
+const url = location.origin + location.pathname
+    + '#z=' + LZString.compressToEncodedURIComponent(JSON.stringify(getStateJson()));
+```
+Decode with `LZString.decompressFromEncodedURIComponent`. ~50-line program → ~250B encoded → fits in any URL bar.
+
+## Where this came from
+
+PR #2648 (daslang.io playground): `web/ui` shipped a multi-file `files: [...]` JSON schema in samples since forever, but the loader only ever read `files[0]`. Adding tabs was a Doc map + `swapDoc` per click. The autosave-on-tab-switch bug landed in round 6 of review — `pgSwitchFile` updated state but didn't call `autosave()`. Three rounds of testing later, Copilot caught it.
+
+## Bonus
+
+`editor.refresh()` after layout changes (e.g. splitter resize) — CM caches gutter widths and won't redraw unless told.
+
+## Questions
+- How do I implement a multi-file editor in CodeMirror 5 with per-tab undo history and localStorage autosave?

--- a/mouse-data/docs/css-import-must-precede-all-other-rules-or-silently-dropped.md
+++ b/mouse-data/docs/css-import-must-precede-all-other-rules-or-silently-dropped.md
@@ -1,0 +1,55 @@
+---
+slug: css-import-must-precede-all-other-rules-or-silently-dropped
+title: My CSS @import isn't loading any fonts — what's wrong?
+created: 2026-05-13
+last_verified: 2026-05-13
+links: []
+---
+
+**`@import` rules must precede every other style rule in the stylesheet (except `@charset` / `@layer`). A browser silently drops any `@import` placed after a normal rule.**
+
+Per CSS 2.1 §6.3:
+> Any @import rules must precede all other rules (except the @charset rule if present).
+
+Modern browsers honor this strictly — there is no console warning, the imported stylesheet just never loads. Symptoms: web fonts fall back to system serif, retoken colors revert to defaults, etc.
+
+## The trap
+
+```css
+:root {
+    --bg: #0d0c0a;
+    --fg: #e8e2d2;
+}
+
+/* SILENTLY IGNORED — comes after :root */
+@import url('https://fonts.googleapis.com/css2?family=Inter+Tight&display=swap');
+
+body {
+    background: var(--bg);  /* works */
+    font-family: 'Inter Tight', sans-serif;  /* falls back to system */
+}
+```
+
+The whole file looks "right" — the rules work, just no Inter Tight. Easy to miss because the fallback chain renders something reasonable.
+
+## Fix
+
+Move the `@import` to the very top, before any rule (including `:root`):
+
+```css
+@import url('https://fonts.googleapis.com/css2?family=Inter+Tight&display=swap');
+
+:root { ... }
+body { ... }
+```
+
+You can also avoid `@import` entirely by linking the stylesheet via `<link rel="stylesheet">` in HTML — same fonts, no ordering trap.
+
+## Where this bit me
+
+PR #2648 (daslang.io docs theme): `doc/source/_static/custom.css` had the Google Fonts `@import` after the `:root` block defining design tokens. Browsers dropped the import, Sphinx HTML rendered in system serif despite the file looking correct. Fix was hoisting the `@import` to line 11 of the file, before `:root` on line 13.
+
+Spec reference: https://www.w3.org/TR/CSS21/cascade.html#at-import
+
+## Questions
+- My CSS @import isn't loading any fonts — what's wrong?

--- a/mouse-data/docs/css-important-beats-js-inline-style-debug-cascade-first.md
+++ b/mouse-data/docs/css-important-beats-js-inline-style-debug-cascade-first.md
@@ -1,0 +1,40 @@
+---
+slug: css-important-beats-js-inline-style-debug-cascade-first
+title: My JavaScript element.style.X assignment has no visible effect — why doesn't the element move/resize?
+created: 2026-05-13
+last_verified: 2026-05-13
+links: []
+---
+
+**Suspect `!important` in the CSS cascade. Inline styles (set via `element.style.X = ...` or the `style="..."` attribute) lose to a stylesheet rule that has `!important`. Higher-specificity selectors without `!important` would normally win, but `!important` flips that order.**
+
+CSS specificity order:
+1. Author `!important` declarations
+2. Inline style attribute (including JS-assigned `element.style.X`)
+3. Author normal declarations
+4. User agent styles
+
+So `.main_col { flex: 1 1 0 !important; }` defeats `el.style.flex = '0 0 50%'`.
+
+## How to spot it
+
+1. Open DevTools → Elements → Styles panel. The "won" rule is the one not crossed out at the top, with the smaller specificity. Look for `!important` flags.
+2. Inline `style="..."` shows at the top of the Styles panel — if it's crossed out and a stylesheet rule isn't, `!important` is the culprit.
+
+## Two fixes
+
+1. **Remove `!important` from the stylesheet rule, increase its specificity instead.** Use `.main_workspace > .main_col` rather than `.main_col` — same effect, no `!important` needed, JS inline overrides work normally.
+2. **Set the JS-applied style as `!important` too.** `el.style.setProperty('flex', '0 0 50%', 'important')`. Use sparingly — `!important` arms races scale badly.
+
+Option 1 is almost always right. `!important` in source CSS is usually a code smell; replacing it with selector specificity makes the cascade predictable.
+
+## Where this bit me
+
+PR #2648 (daslang playground splitter): drag handle wouldn't move the columns — `applyPct` was setting `left.style.flex` correctly, but the user-visible 50/50 layout never changed. `.main_col { flex: 1 1 0 !important; }` in `forge-skin.css` was beating the inline assignment. Fix: drop `!important`, use `.main_workspace > .main_col` selector specificity instead. The first-instinct debugging move (assume JS is broken) wastes time when the actual problem is CSS specificity.
+
+## General lesson
+
+When a JS-set inline style appears to have no effect, **inspect the Styles panel in DevTools first** before reaching for `console.log` or rewriting the JS — the cascade tells you exactly which rule won.
+
+## Questions
+- My JavaScript element.style.X assignment has no visible effect — why doesn't the element move/resize?

--- a/mouse-data/docs/github-pages-deploy-pages-publishes-snapshot-not-overlay.md
+++ b/mouse-data/docs/github-pages-deploy-pages-publishes-snapshot-not-overlay.md
@@ -1,0 +1,31 @@
+---
+slug: github-pages-deploy-pages-publishes-snapshot-not-overlay
+title: Does GitHub Pages preserve previously-deployed files when actions/deploy-pages publishes a new artifact?
+created: 2026-05-13
+last_verified: 2026-05-13
+links: []
+---
+
+**No — `actions/deploy-pages` publishes the artifact as a complete site snapshot, not a layer over the prior deploy.**
+
+If you upload `_site/` and it's missing a directory (e.g. `_site/playground/`) that was present in the previous deploy, that path will 404 on the live site after this deploy completes. Pages does not retain or merge files from earlier deploys.
+
+## Implication for CI staging
+
+You cannot use "skip this directory when the source artifacts are missing" as a graceful-degradation strategy — that will 404 the route. Two viable options when an artifact is unbuildable:
+
+1. **Stage a placeholder `index.html`** so the URL keeps resolving to something useful (status page, "rebuilding" notice, link back to the rest of the site). Keeps the route alive while you re-roll.
+2. **Fail the deploy** when artifacts are missing. Couples the whole site publish to the failing component — only acceptable if the missing piece is critical.
+
+The "graceful skip" intuition (let docs/blog ship even when WASM is broken) is correct in principle, but the implementation must explicitly stage *something* under the route — silent omission is the bug.
+
+## Where this bit me
+
+PR #2648 (daslang.io playground): WASM build had `continue-on-error: true` so emsdk hiccups wouldn't block docs/blog. Round-4 fix gated the playground staging on `daslang_static.{js,wasm}` existing — but with no `else` branch, `_site/playground/` was absent on WASM failure, which would 404 `/playground/` on the next deploy. Round-5 added the `site/playground/placeholder.html` fallback that explains the runtime is rebuilding.
+
+## Quick check
+
+`actions/deploy-pages@v4` reference: https://github.com/actions/deploy-pages — "deploys an artifact" (singular, replaces). The artifact is whatever `actions/upload-pages-artifact` packaged, which is the full `_site/` you staged.
+
+## Questions
+- Does GitHub Pages preserve previously-deployed files when actions/deploy-pages publishes a new artifact?

--- a/site/_news/2026-05-13-daslang-0-6-2-released.md
+++ b/site/_news/2026-05-13-daslang-0-6-2-released.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-13
+tag: 0.6.2
+title: Daslang 0.6.2 released.
+link: https://github.com/GaijinEntertainment/daScript/releases/tag/v0.6.2-RC3
+---


### PR DESCRIPTION
## Summary

- Adds an **External modules** section to the docs TOC (after stdlib) with a single dasImgui entry. Companion PR on [borisbat/dasImgui](https://github.com/borisbat/dasImgui) drops the matching Forge-themed `custom.css` and adds a backlink to daslang.io so visitors who follow the link out can also follow it back without a context jump.
- Lands the 0.6.2 release news entry on the landing-page § 05 news strip (the release was promoted on 2026-05-13).
- Lands four blind-mouse cards from this session's wrap-up curation: GitHub Pages deploy-snapshot semantics, CSS `@import` ordering rule, `!important`-vs-inline debugging anchor, CodeMirror 5 multi-Doc autosave discipline.

## Test plan

- [ ] `Build doc` workflow renders the new external-modules section without warnings
- [ ] Sidebar shows External Modules → dasImgui under the existing toctree
- [ ] dasImgui page links resolve to `borisbat.github.io/dasImgui/` and the repo
- [ ] Landing-page § 05 News (after `build_blog.py` runs in pages.yml) shows "Daslang 0.6.2 released." as row 1, linking to the v0.6.2-RC3 release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)