### PR TITLE
infer: assume-alias substitution reports at use-site

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -4044,7 +4044,7 @@ namespace das {
             if (ita.expr->alias == expr->name) {
                 reportAstChanged();
                 auto csub = ita.expr->subexpr->clone();
-                // forceAt(csub, ita.expr->at);
+                forceAt(csub, expr->at);
                 return csub;
             }
         }

--- a/tests/language/failed_assume_loop.das
+++ b/tests/language/failed_assume_loop.das
@@ -1,6 +1,6 @@
 options gen2
 // test for circular assume detection
-expect 30838:4, 31101:2
+expect 30838:3, 31101:2
 
 def test_direct_loop {
     assume x = y + y


### PR DESCRIPTION
## Summary

When `InferTypes::visit(ExprVar*)` substitutes an `assume` alias, the cloned subtree now carries the **use-site's** `LineInfo` instead of the alias definition site's. Lint and any other diagnostic that fires on substituted nodes now reports where the user actually wrote the code.

Before / after on the table-lookup-collision lint:

```das
struct Foo { a : int }
def summ(var a, b : Foo) { a.a += b.a }

[export]
def main() {
    var tab : table<int, Foo>
    assume tabi = tab[2]      // line 7
    summ(tab[1], tabi)        // line 8  <-- error reports HERE now, not line 7
    summ(tab[3], tab[4])      // line 9  <-- unchanged
}
```

The change is a single line in `src/ast/ast_infer_type.cpp:4047` — there was already a commented-out `forceAt(csub, ita.expr->at)` from a previous attempt; this replaces it with `forceAt(csub, expr->at)` (use-site, not assume-def-site).

## Knock-on test update

`tests/language/failed_assume_loop.das` — the two `y` references inside the cloned `y+y` body now collapse onto the same `{x}` use-site position and dedup to one error with `(×2)` suffix, so the expected `30838` count drops from 4 to 3. The dedup actually carries the same information more compactly.

## Test plan

- [x] `examples/wip.das` (the reproducer) — error now lands on the `summ(tab[1], tabi)` line, pointing at `tabi`
- [x] Full dastest suite: **8017 tests, 8011 passed, 0 failed, 0 errors, 6 skipped**
- [x] AOT test suite: **7406 tests, 7400 passed, 0 failed, 0 errors, 6 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)