### PR TITLE
site: fix install snippet, add playground nav link, wire playground URL history

### DIFF
--- a/site/downloads.html
+++ b/site/downloads.html
@@ -29,6 +29,7 @@
                     <a href="downloads.html">downloads</a>
                     <a href="blog/index.html">blog</a>
                     <a href="https://t.me/daScript">community</a>
+                    <a href="playground/index.html">playground</a>
                 </div>
             </div>
             <div class="forge-nav__right">
@@ -71,7 +72,7 @@
                         GitHub Releases. Pick the archive that matches your
                         platform, unzip, add to PATH.
                     </p>
-                    <a class="forge-link-amber" href="https://github.com/GaijinEntertainment/daScript/releases">github.com/GaijinEntertainment/daScript/releases →</a>
+                    <a class="forge-link-amber" href="https://github.com/GaijinEntertainment/daScript/releases">github.com/GaijinEntertainment/daslang/releases →</a>
                 </div>
                 <div>
                     <div class="forge-news__row">
@@ -82,7 +83,7 @@
                     <div class="forge-news__row">
                         <div class="forge-news__date">repo</div>
                         <div class="forge-news__tag">source</div>
-                        <div class="forge-news__title"><a href="https://github.com/GaijinEntertainment/daScript">GaijinEntertainment/daScript — clone &amp; build from source</a></div>
+                        <div class="forge-news__title"><a href="https://github.com/GaijinEntertainment/daScript">GaijinEntertainment/daslang — clone &amp; build from source</a></div>
                     </div>
                     <div class="forge-news__row">
                         <div class="forge-news__date">all tags</div>

--- a/site/files/forge.css
+++ b/site/files/forge.css
@@ -240,7 +240,7 @@ button { font: inherit; border: 0; background: none; color: inherit; cursor: poi
     font-family: var(--font-mono);
     font-size: 12px;
 }
-.forge-stat__n { color: var(--fg); font-size: 22px; }
+.forge-stat__n { color: var(--fg); font-size: 22px; white-space: nowrap; }
 .forge-stat__l { color: var(--fg-faint); margin-top: 2px; }
 
 /* ───── Terminal / code panel (hero right column) ───── */

--- a/site/index.html
+++ b/site/index.html
@@ -40,6 +40,7 @@
                     <a href="downloads.html">downloads</a>
                     <a href="blog/index.html">blog</a>
                     <a href="https://t.me/daScript">community</a>
+                    <a href="playground/index.html">playground</a>
                 </div>
             </div>
             <div class="forge-nav__right">
@@ -118,7 +119,7 @@ def main() {
     }
 }</code></pre>
                 <div class="forge-output" id="hero-output">
-                    <div class="forge-output__line"><span class="forge-output__prompt">$</span> daslang run hello.das</div>
+                    <div class="forge-output__line"><span class="forge-output__prompt">$</span> daslang hello.das</div>
                     <div class="forge-output__line forge-output__stdout">hello, world</div>
                     <div class="forge-output__line forge-output__hint">  tick 0 · tick 1 · tick 2</div>
                     <div class="forge-output__line forge-output__ok">✓ 0.42 ms · interpreted</div>
@@ -262,7 +263,7 @@ def main() {
                         build straight from the repo. AOT compiles to a single C++ stub
                         you link with your host.
                     </p>
-                    <a class="forge-link-amber" href="https://github.com/GaijinEntertainment/daScript">github.com/GaijinEntertainment/daScript →</a>
+                    <a class="forge-link-amber" href="https://github.com/GaijinEntertainment/daScript">github.com/GaijinEntertainment/daslang →</a>
                 </div>
                 <div class="forge-install__panel">
                     <div class="forge-install__tabs" role="tablist">
@@ -272,26 +273,26 @@ def main() {
                     <div class="forge-install__body">
                         <div class="forge-install__pane is-active" data-pane="releases">
                             <div class="forge-install__hint"># 1 — grab a pre-built binary</div>
-                            <div class="forge-install__cmd"><span class="prompt">$</span> open https://github.com/GaijinEntertainment/daScript/releases</div>
+                            <div class="forge-install__cmd"><span class="prompt">$</span> open <a class="forge-link-amber" href="https://github.com/GaijinEntertainment/daScript/releases">https://github.com/GaijinEntertainment/daScript/releases</a></div>
                             <div class="forge-install__hint">#     pick the archive for your platform, unzip, add to PATH</div>
                             <div class="forge-install__sp"></div>
                             <div class="forge-install__hint"># 2 — verify it runs</div>
                             <div class="forge-install__cmd"><span class="prompt">$</span> daslang --version</div>
-                            <div class="forge-install__cmd"><span class="prompt">$</span> daslang run hello.das</div>
+                            <div class="forge-install__cmd"><span class="prompt">$</span> daslang hello.das</div>
                             <div class="forge-install__sp"></div>
-                            <div class="forge-install__hint"># 3 — (optional) AOT to C++ for native speed</div>
-                            <div class="forge-install__cmd"><span class="prompt">$</span> daslang -aot main.das main_aot.cpp</div>
+                            <div class="forge-install__hint"># 3 — (optional) JIT to native via LLVM for max speed</div>
+                            <div class="forge-install__cmd"><span class="prompt">$</span> daslang -jit hello.das</div>
                         </div>
                         <div class="forge-install__pane" data-pane="source">
                             <div class="forge-install__hint"># requires CMake ≥ 3.15 and a C++17 compiler</div>
                             <div class="forge-install__cmd"><span class="prompt">$</span> git clone https://github.com/GaijinEntertainment/daScript.git daslang</div>
                             <div class="forge-install__cmd"><span class="prompt">$</span> cd daslang &amp;&amp; git submodule update --init --recursive</div>
                             <div class="forge-install__sp"></div>
-                            <div class="forge-install__cmd"><span class="prompt">$</span> cmake -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo</div>
-                            <div class="forge-install__cmd"><span class="prompt">$</span> cmake --build build --target daslang --config RelWithDebInfo</div>
+                            <div class="forge-install__cmd"><span class="prompt">$</span> cmake -B build -S . -DCMAKE_BUILD_TYPE=Release</div>
+                            <div class="forge-install__cmd"><span class="prompt">$</span> cmake --build build --config Release -j 8</div>
                             <div class="forge-install__sp"></div>
-                            <div class="forge-install__hint"># the binary lands in ./bin/daslang</div>
-                            <div class="forge-install__cmd"><span class="prompt">$</span> ./bin/daslang run hello.das</div>
+                            <div class="forge-install__hint"># the binary lands in ./build/daslang</div>
+                            <div class="forge-install__cmd"><span class="prompt">$</span> ./build/daslang hello.das</div>
                         </div>
                     </div>
                 </div>

--- a/site/playground/playground-init.js
+++ b/site/playground/playground-init.js
@@ -65,3 +65,7 @@ if (document.readyState === 'loading') {
 } else {
     applySharedCodeFromHash();
 }
+
+// Run (in main.js) pushes a new history entry on each invocation; popstate
+// fires when the user navigates Back/Forward and replays the recorded state.
+window.addEventListener('popstate', applySharedCodeFromHash);

--- a/web/ui/src/main.js
+++ b/web/ui/src/main.js
@@ -111,6 +111,16 @@ loadSample = function(filesByName) {
 // executed program no longer matches the visible tab state.
 var __lastWrittenFiles = new Set();
 
+// Sync the URL hash with the current playground state. Run is the natural
+// "snapshot" moment — the address bar then IS the share link (no need to hunt
+// for the share button), and Back/Forward navigate a real history of code
+// changes (see the popstate listener in playground-init.js).
+function syncUrlToState() {
+    if (!window.pgBuildShareUrl) return;
+    const url = window.pgBuildShareUrl();
+    if (url && url !== location.href) history.pushState(null, '', url);
+}
+
 runCode = function() {
     // Multi-file: sync MEMFS with the current pgState (unlink stale, write
     // current), then run main.das. Falls back to the single-buffer path when
@@ -126,9 +136,11 @@ runCode = function() {
             FS.writeFile(name, doc.getValue());
         }
         __lastWrittenFiles = current;
+        syncUrlToState();
         Module.callMain(['main.das']);
         return;
     }
+    syncUrlToState();
     runScript(code.getValue());
 }
 


### PR DESCRIPTION
## Summary

- **Install snippet** (both tabs in `index.html`, hero terminal): kill the bogus `daslang run hello.das` (no such subcommand), swap the AOT block for JIT (`-jit hello.das` — the real "native speed" knob without needing a C++ build), make the releases URL clickable, fix the build-from-source binary path (`./build/daslang`, not `./bin/daslang` on single-config Make/Ninja), use `Release` + `-j 8`, drop the leftover `run`.
- **Top nav**: add `playground` link after `community` in `index.html` and `downloads.html`.
- **Visible "daScript" labels → "daslang"** in three link-label spots. URLs themselves still point at `/daScript` (the real repo), copy-paste commands keep the real URL too, and the SEO `<meta name="keywords">` keeps the legacy term.
- **Hero stats wrap fix**: `white-space: nowrap` on `.forge-stat__n` so "interp · AOT · JIT" and "embed · standalone" no longer wrap onto two lines.
- **Playground URL history**: `runCode()` now `pushState`s the share URL on every Run, and a new `popstate` listener re-runs `applySharedCodeFromHash`. Address bar becomes the share link (no need to hunt for the share button), Back/Forward walks a real history of code changes.

## Test plan

- [x] Tested locally via `python3 -m http.server` — landing, downloads, and playground all render; nav has playground link, install snippet shows correct commands, stats panel no longer wraps.
- [x] Playground: clicking Run swaps the URL bar to a `#z=…` share link; Back/Forward navigates code history.
- [ ] Verify on deployed `daslang.io` after merge (`site/playground/main.js` is a build artifact of `web/ui/src/main.js`; pages.yml copies on deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)