### PR TITLE
infer/aot: allow C++-keyword function names via AOT name-mangling

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -221,7 +221,7 @@ def hex_char(var Ch : int) {
 }
 
 def aotSuffixNameEx(funcName : das_string; suffix : string) {
-    var prefix = false;
+    var prefix = is_cpp_keyword(string(funcName));
 
     let name = build_string() $(var writer) {
         for (ch in string(funcName)) {

--- a/mouse-data/docs/daslang-aot-cpp-emitter-mangles-keyword-and-operator-function-names.md
+++ b/mouse-data/docs/daslang-aot-cpp-emitter-mangles-keyword-and-operator-function-names.md
@@ -1,0 +1,93 @@
+---
+slug: daslang-aot-cpp-emitter-mangles-keyword-and-operator-function-names
+title: How does the daslang AOT C++ emitter mangle function names — for operator overloads and C++ keywords?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+The AOT C++ emitter lives in `daslib/aot_cpp.das` (NOT the emptied `src/ast/ast_aot_cpp.cpp`).
+
+**The function-name mangler is `aotFuncName`** at `daslib/aot_cpp.das:928-935`:
+
+```daslang
+def public aotFuncName(func : Function?) {
+    if (func.hash != uint64(0)) {
+        return "{aotSuffixNameEx(func.name,"_Func")}_{func.hash:x}";
+    } else {
+        return "{aotSuffixNameEx(func.name,"_Func")}";
+    }
+}
+```
+
+All daslang→C++ call sites and def sites go through this helper (verified: `daslib/aot_cpp.das:1084` def site, `:2950/:2966/:3459/:3785` call sites). No bypass paths.
+
+**`aotSuffixNameEx`** (line 223-267) is where the rewriting happens:
+
+```daslang
+def aotSuffixNameEx(funcName : das_string; suffix : string) {
+    var prefix = is_cpp_keyword(string(funcName));   // <-- added 2026-05-14
+    let name = build_string() $(var writer) {
+        for (ch in string(funcName)) {
+            if (is_alnum(ch) || ch == '_') {
+                writer |> write_char(ch);
+            } else {
+                prefix = true;
+                var t_ch : string;
+                match (ch) {
+                    if ('=') { t_ch = "Equ"; }
+                    if ('+') { t_ch = "Add"; }
+                    if ('-') { t_ch = "Sub"; }
+                    if ('*') { t_ch = "Mul"; }
+                    if ('/') { t_ch = "Div"; }
+                    if ('%') { t_ch = "Mod"; }
+                    if ('&') { t_ch = "And"; }
+                    if ('|') { t_ch = "Or"; }
+                    if ('^') { t_ch = "Xor"; }
+                    if ('?') { t_ch = "Qmark"; }
+                    if ('~') { t_ch = "Tilda"; }
+                    if ('!') { t_ch = "Excl"; }
+                    if ('>') { t_ch = "Greater"; }
+                    if ('<') { t_ch = "Less"; }
+                    if ('[') { t_ch = "Sqbl"; }
+                    if (']') { t_ch = "Sqbr"; }
+                    if ('.') { t_ch = "Dot"; }
+                    if ('`') { t_ch = "Tick"; }
+                    if (',') { t_ch = "Comma"; }
+                    if (_) { t_ch = "_0x{hex(ch)}_" }    // unmapped chars → hex escape
+                }
+                write(writer, "{t_ch}")
+            }
+        }
+    }
+    return prefix ? (suffix + name) : name;    // suffix prepended (yes, prepended) iff prefix flag set
+}
+```
+
+The `prefix` boolean controls whether the `suffix` arg ("_Func" for functions, "" for structs via `aotStructName`) is *prepended* to the mangled body. The flag fires in two conditions:
+
+1. **Any non-alnum char in the name** (operator overloads, backtick-encoded names): the substitution loop sets `prefix = true` as a side effect.
+2. **The name is a C++ keyword** (since 2026-05-14): `is_cpp_keyword(name)` seeds the flag.
+
+**Example emissions:**
+
+| daslang | C++ name |
+|---|---|
+| `def foo()` | `foo_<hash>` (no prefix — alnum, not keyword) |
+| `def operator+()` | `_FuncAdd_<hash>` |
+| `def \`testing\`equal\``() | `_FunctestingTickequalTick_<hash>` |
+| `def float()` | `_Funcfloat_<hash>` (was rejected by lint pre-2026-05-14) |
+| `def do()` | `_Funcdo_<hash>` |
+
+**`aotStructName`** (line 269-271) uses the same helper with `suffix=""` — struct names need no prefix because the C++-keyword-name lint guard at `ast_lint.cpp:307` is still in force (relaxing struct names would need a different emit strategy, since struct names embed 1:1 into `struct Foo { ... }` syntax).
+
+**`is_cpp_keyword(name : string) : bool`** is the daslang binding of C++ `isCppKeyword` (`src/builtin/module_builtin_ast.cpp:1572-1573`).
+
+## Questions
+- How does the daslang AOT emitter handle C++ keyword names like `def float`?
+- How are operator overloads (`def +`, `def ==`) mangled in AOT C++ output?
+- Where in daslang is the AOT C++ function-name mangler?
+- What's `aotSuffixNameEx` and when does it prepend the `_Func` prefix?
+- What does `_FuncAdd_<hash>` mean in generated AOT C++?
+- Is there a way to find an AOT-emitted C++ symbol from a daslang function name?
+- Can I call `is_cpp_keyword` from a daslang macro?

--- a/mouse-data/docs/dastest-failed-cant-invalid-prefix-expected-compile-failure-tests.md
+++ b/mouse-data/docs/dastest-failed-cant-invalid-prefix-expected-compile-failure-tests.md
@@ -1,0 +1,63 @@
+---
+slug: dastest-failed-cant-invalid-prefix-expected-compile-failure-tests
+title: How does dastest treat `failed_*`, `cant_*`, `invalid_*` test files?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+**Files in `tests/` whose basename starts with `failed_`, `cant_`, or `invalid_` are expected-compile-failure tests.** They declare which compile errors must fire, not what runtime behavior to test.
+
+**dastest skip:** `dastest/dastest.das:160-166` (inside `serializeAst`):
+
+```daslang
+let base = base_name(file)
+if (base |> starts_with("cant_") || base |> starts_with("failed_") || base |> starts_with("invalid_")) {
+    continue   // skip AST serialization — they don't compile
+}
+```
+
+**CMake skip:** Most `tests/<area>/CMakeLists.txt` GLOB filters exclude them from AOT compilation:
+```cmake
+list(FILTER AOT_FOO_FILES EXCLUDE REGEX "failed_")
+```
+because trying to AOT-compile a file that intentionally fails to compile would just break the build.
+
+**The `expect` line** sits at the top of the file (after `options gen2`):
+
+```daslang
+options gen2
+expect 30106:3, 30146, 30148, 30152, 30240, 30282
+```
+
+- Comma-separated list of expected error codes.
+- `code:N` syntax = "exactly N occurrences" (default 1). Above: three 30106 errors plus one each of the rest.
+- Order doesn't matter; line numbers don't matter; what matters is that the compiler emits exactly those codes those many times.
+- PASS when the actual error set matches the expect set.
+
+**Run via MCP:**
+
+```
+mcp__daslang__run_test tests/language/failed_reserved_names.das
+```
+
+emits the compile errors AND reports `PASS` (1 test, 1 passed) when codes match.
+
+**Maintenance when you relax or remove a compile-time guard:**
+
+1. If the now-passing case lives inside a `failed_*` file, delete that case from the file.
+2. Drop the corresponding code from the `expect` line.
+3. (Ideal) add a positive test elsewhere that exercises the now-legal form, ideally with AOT round-trip if codegen could break.
+
+Example (2026-05-14): when the function-name C++-keyword guard was dropped, `def do(a : int)` moved from `tests/language/failed_reserved_names.das` (with `30163` dropped from expect) to a new `tests/aot/test_cpp_keyword_names.das` as a positive case (exercising interpreter + AOT + JIT).
+
+The prefix is just convention so dastest and CMake know to skip them. `invalid_*` and `cant_*` behave identically to `failed_*`.
+
+## Questions
+- What's the convention for daslang tests that expect a compile error?
+- How does the `expect` line work in dastest?
+- Why do `failed_*.das` files in tests/ not get AOT-compiled?
+- What does `expect 30106:3` mean in a daslang test file?
+- Where in dastest are expected-failure tests skipped from AST serialization?
+- How do I write a test that asserts the compiler emits a specific error code?
+- What should I do with a `failed_*` test after I relax the guard it was checking?

--- a/mouse-data/docs/why-is-def-float-rejected-but-def-string-and-def-float2-allowed.md
+++ b/mouse-data/docs/why-is-def-float-rejected-but-def-string-and-def-float2-allowed.md
@@ -1,0 +1,54 @@
+---
+slug: why-is-def-float-rejected-but-def-string-and-def-float2-allowed
+title: Why is `def float(...)` rejected but `def string(...)` and `def float2(...)` allowed?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+The asymmetry is **not** in the parser. The grammar at `src/parser/ds2_parser.ypp:1316-1408` says:
+
+```
+function_name
+    :   NAME                  // user identifiers
+    |   DAS_OPERATOR ...       // operator overloads
+    |   das_type_name          // any type-name TOKEN
+    ;
+```
+
+`das_type_name` accepts every type-keyword token: `DAS_TBOOL`, `DAS_TSTRING`, `DAS_TINT`, `DAS_TINT2`, `DAS_TFLOAT`, `DAS_TFLOAT2`, `DAS_TDOUBLE`, etc. So at the parser level `def float`, `def int`, `def string`, `def float2`, `def double` all parse identically.
+
+**The rejection is a post-parse lint guard at `src/ast/ast_lint.cpp:867-884`** (pre-2026-05-14):
+
+```cpp
+bool isValidFunctionName(const string & str) const {
+    return !isCppKeyword(str.c_str());
+}
+virtual void preVisit ( Function * fn ) override {
+    if (!isValidFunctionName(fn->name))
+        program->error("invalid function name " + fn->name, ..., CompilationError::invalid_function_name);
+    ...
+}
+```
+
+`isCppKeyword` (`src/builtin/module_builtin_ast.cpp:68-84`) is a hardcoded **C++**-keyword set. That set contains `float`, `int`, `double`, `bool`, `char`, `void`, `do`, `class`, `new`, `delete`, ... It does NOT contain `string` (that's `std::string` in C++ — qualified, not a keyword), nor `float2`/`int2`/`uint3`/etc. (daslang-specific typedefs, not C++ keywords). That's exactly the observed asymmetry.
+
+The lint guard existed because the AOT C++ emitter would otherwise generate a literal `float(...)` C++ function which wouldn't compile.
+
+**Status (2026-05-14, PR landed):** the function-name guard was dropped. `daslib/aot_cpp.das:223-267` (`aotSuffixNameEx`) now detects C++ keywords and applies the same `_Func` prefix it already used for operator-character names — so `def float` AOTs to `_Funcfloat_<hash>` (a valid C++ identifier). The other 5 `isCppKeyword` lint sites stay (module/enum/enum-value/struct/struct-field names) — those emit 1:1 into C++ and need the guard.
+
+The 6 callsites that *still* reject C++ keywords (post-PR):
+- `ast_lint.cpp:253` module name → error 30210
+- `ast_lint.cpp:263` enumeration name → 30146
+- `ast_lint.cpp:266` enumeration value → 30148
+- `ast_lint.cpp:307` structure name → 30240
+- `ast_lint.cpp:349` struct field / variable / arg name → 30152 / 30282 / 30106
+
+`is_cpp_keyword(name : string) : bool` is exposed to daslang via `module_builtin_ast.cpp:1572-1573` if you ever need to call it from a macro or AOT emitter.
+
+## Questions
+- Why does `def float(...)` give error 30163 "invalid function name" but `def string(...)` doesn't?
+- Where does daslang reject function names that are C++ keywords?
+- Is the parser the gate for `def <type>` overloads, or is it the lint pass?
+- Can I define a daslang function called `int` or `double`?
+- What error code is "invalid function name" and where is it emitted?

--- a/src/ast/ast_lint.cpp
+++ b/src/ast/ast_lint.cpp
@@ -864,9 +864,6 @@ namespace das {
                 }
             }
         }
-        bool isValidFunctionName(const string & str) const {
-            return !isCppKeyword(str.c_str());
-        }
         virtual bool canVisitFunction ( Function * fun ) override {
             return !fun->stub && !fun->isTemplate;    // we don't do a thing with templates
         }
@@ -878,10 +875,6 @@ namespace das {
         virtual void preVisit ( Function * fn ) override {
             Visitor::preVisit(fn);
             func = fn;
-            if (!isValidFunctionName(fn->name)) {
-                program->error("invalid function name " + fn->name, "", "",
-                    fn->at, CompilationError::invalid_function_name );
-            }
             if ( !fn->result->isVoid() && !fn->result->isAuto() ) {
                 if ( !exprReturns(fn->body) ) {
                     program->error("not all control paths return value",  "", "",

--- a/tests/aot/test_cpp_keyword_names.das
+++ b/tests/aot/test_cpp_keyword_names.das
@@ -1,0 +1,39 @@
+options gen2
+require dastest/testing_boost public
+
+struct Foo {
+    a : int
+}
+
+def float(h : Foo) : int {
+    return h.a + 1
+}
+
+def int(h : Foo) : float {
+    return float(h.a) * 2.0
+}
+
+def double(h : Foo) : int {
+    return h.a + h.a
+}
+
+def do(h : Foo) : int {
+    return h.a * 10
+}
+
+[test]
+def test_cpp_keyword_function_names(t : T?) {
+    let h = Foo(a = 21)
+    t |> run("def float") @(t : T?) {
+        t |> equal(float(Foo(a = 41)), 42)
+    }
+    t |> run("def int") @(t : T?) {
+        t |> equal(int(Foo(a = 3)), 6.0)
+    }
+    t |> run("def double") @(t : T?) {
+        t |> equal(double(h), 42)
+    }
+    t |> run("def do") @(t : T?) {
+        t |> equal(do(Foo(a = 4)), 40)
+    }
+}

--- a/tests/language/failed_reserved_names.das
+++ b/tests/language/failed_reserved_names.das
@@ -1,9 +1,9 @@
 // reserved identifier names
 // verifies compiler rejects using reserved words (like 'register', 'do')
-// as enum names, enum values, struct names, struct fields, function names,
+// as enum names, enum values, struct names, struct fields,
 // function args, local variables, and lambda parameters
 options gen2
-expect 30106:3, 30146, 30148, 30152, 30163, 30240, 30282
+expect 30106:3, 30146, 30148, 30152, 30240, 30282
 
 enum do {// 30116: invalid name
     foo
@@ -21,10 +21,6 @@ struct Foo {
 
 struct register {// 30116: invalid name
     foo : int
-}
-
-def do(a : int) {// 30116: invalid name
-    return a
 }
 
 def foo(register : int) {// 30116: invalid name


### PR DESCRIPTION
## Inspiration

```
struct Foo { a: float; }

def string(handle : Foo) : string { return "Foo {handle.a}"; }
def float(handle : Foo) : float { return handle.a; }
def float2(handle : Foo) : float2 { return float2(handle.a, handle.a); }

[export] def main() {}
```

## Summary

`def float(...)`, `def int(...)`, `def double(...)`, `def do(...)` were rejected with `error[30163] invalid function name` — a surprising asymmetry next to `def string(...)` and `def float2(...)`, which always compiled fine. The parser accepts all of them (`function_name → das_type_name` in `src/parser/ds2_parser.ypp:1316-1408`); a post-parse lint guard at `src/ast/ast_lint.cpp:867-884` was the actual gate, rejecting any function name in a hardcoded C++-keyword set. The asymmetry was just that set: `float` / `int` / `double` / `do` are C++ keywords, but `float2` / `string` / `int2` are daslang-specific identifiers that happen not to clash.

The lint guard existed because the AOT C++ emitter would otherwise generate a literal `float(...)` C++ function, which is invalid. But the emitter already has a name-rewriting helper (`aotSuffixNameEx`) used for operator overloads — it just didn't kick in for plain alphanumeric names. This PR has it kick in for C++-keyword names too, and drops the now-redundant function-name lint guard.

- `daslib/aot_cpp.das` — `aotSuffixNameEx` seeds `prefix = is_cpp_keyword(funcName)` so C++-keyword names get the `_Func` prefix already used for operator overloads (`def +` → `_FuncAdd_<hash>`). After this, `def float` emits as `_Funcfloat_<hash>`.
- `src/ast/ast_lint.cpp` — drop `isValidFunctionName` and its callsite. The other 5 `isCppKeyword` callsites (module / enum / enum-value / struct / struct-field names) stay — those embed 1:1 into C++ and need the guard.
- `tests/language/failed_reserved_names.das` — drop the `def do` case and `30163` from the `expect` line.
- `tests/aot/test_cpp_keyword_names.das` (new) — positive test exercising `def float` / `def int` / `def double` / `def do` via interpreter + AOT + JIT round-trip.

Scope is function names only; struct/enum/module/etc. names still 1:1 into C++ identifiers and are correctly out of scope.

Generated C++ for the new test (excerpt) confirms the mangling fires:
```
inline int32_t _Funcfloat_a367204646d2e00e ( Context * __context__, struct Foo const & h );
inline float   _Funcint_cb77d1bb25db9a2c    ( Context * __context__, struct Foo const & h );
inline int32_t _Funcdouble_55b8b2d232dd0bd3 ( Context * __context__, struct Foo const & h );
inline int32_t _Funcdo_3886b04bf9d216e6     ( Context * __context__, struct Foo const & h );
```

Includes three `mouse-data/docs/*.md` blind-mouse cards capturing the diagnosis (parser vs lint asymmetry, AOT name mangler details, `failed_*` test-prefix convention) — personal Q&A cache, no behavior impact.

## Test plan

- [x] `examples/wip.das` (the originally failing case from the report) now compiles clean
- [x] `tests/language/failed_reserved_names.das` still PASSes (matches new `expect` line — codes 30106:3, 30146, 30148, 30152, 30240, 30282)
- [x] `tests/aot/test_cpp_keyword_names.das` — interpreter: 5/5 PASS
- [x] `tests/aot/test_cpp_keyword_names.das` — AOT round-trip via `test_aot dastest/dastest.das -use-aot -- --use-aot --run …`: 5/5 PASS
- [x] `tests/aot/test_cpp_keyword_names.das` — JIT via `daslang dastest/dastest.das -jit -- --run …`: 5/5 PASS
- [x] Generated C++ inspected: `_Funcfloat_<hash>` / `_Funcint_<hash>` / `_Funcdouble_<hash>` / `_Funcdo_<hash>` present at def + call + wrapper sites
- [x] Full `tests/language/` regression: 927/927 PASS
- [x] Full `tests/aot/` regression: 69/69 PASS
- [x] Full `tests/` interpreter regression: 8016/8022 PASS (6 environment-conditional skips, 0 failed, 0 errors)
- [x] `mcp__daslang__lint` on changed `.das` files: 0 issues
- [x] `mcp__daslang__format_file` on changed `.das` files: already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)