### PR TITLE
aot: fix missing reference on handled types

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -437,6 +437,21 @@ def public describeCppType(typeDecl : TypeDeclPtr;
     return describeCppTypeEx(typeDecl, cfg, CpptUseAlias.no);
 }
 
+def expectsLocalTemp(expr : ExprMakeLocal?) : bool {
+    if (!expr.makeFlags.doesNotNeedSp && expr.stackTop != 0u) {
+        if (expr is ExprMakeStruct) {
+            let mks = expr as ExprMakeStruct
+            if (mks.makeType.baseType == Type.tHandle &&
+                !mks.makeType.isRefType &&
+                mks.constructor == null) {
+                return false
+            }
+        }
+        return true
+    }
+    return false
+}
+
 class NoAotMarker : AstVisitor {
     //! AST visitor that marks functions containing non-AOT-compatible types as noAot.
     @do_not_delete func : Function? <- null;
@@ -1017,7 +1032,7 @@ class public BlockVariableCollector : AstVisitor {
     }
 
     def handleExpr(var expr : ExprMakeLocal?) {
-        let need_insert = !expr.makeFlags.doesNotNeedSp && expr.stackTop != 0u;
+        let need_insert = expectsLocalTemp(expr);
         if (need_insert) {
             let blk = getCurrentBlock();
             localTemps[blk] |> push(expr);
@@ -2862,7 +2877,7 @@ class public CppAot : AstVisitor {
     }
 // make variant
     def needTempSrc(expr : ExprMakeLocal?) {
-        return !expr.makeFlags.doesNotNeedSp && expr.stackTop != 0u;
+        return expectsLocalTemp(expr);
     }
     def mkvName(expr : ExprMakeVariant?) {
         if (needTempSrc(expr)) {

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -416,16 +416,15 @@ def describeCppTypeEx(typeDecl : TypeDeclPtr;
         if (!cfg.skip_const && typeDecl.flags.constant) {
             write(writer, " const ");
         }
-        // Value-annotation handles (e.g. Handle<T>) are POD and always passed by value,
-        // even when daslang marks the expression result as ref (stack temp). Skip the
-        // & suffix so "var T* = ...; return T&" mismatches don't break the AOT build.
-        // Keep the * suffix when substitute_ref is requested (e.g. iteration variables),
-        // since das_iterator::first(Context*, QQ*&) demands a real pointer regardless.
-        let valueHandle = baseType == Type.tHandle && !typeDecl.isRefType
+        // Reference handling: emit `*` when substitute_ref is requested (iterator
+        // and stack-temp variable emission paths use `T*` storage), otherwise emit
+        // `&` so writable reference parameters (including value-annotation handles
+        // like Handle<T>, EntityId, das::Time used as `var x : T&`) propagate
+        // mutations back to the caller in AOT.
         if (typeDecl.flags.ref && !cfg.skip_ref) {
             if (cfg.substitute_ref) {
                 write(writer, " *");
-            } elif (!valueHandle) {
+            } else {
                 write(writer, " &");
             }
         }

--- a/tests/aot/test_default_value_handle_field.das
+++ b/tests/aot/test_default_value_handle_field.das
@@ -1,0 +1,38 @@
+options gen2
+options gc
+require dastest/testing_boost public
+require fio
+
+//! Regression: Boris's original failure case.
+//!
+//! Initializing a value-annotation handle (``ManagedValueAnnotation<T>``)
+//! field with ``= default<T>`` triggers an ``ExprMakeLocal`` defaulting
+//! path. In the AOT emitter, the resulting stack-temp expression carries
+//! ``flags.ref = true`` but ``isRefType = false`` (POD), so
+//! ``describeCppTypeEx`` emitted ``T *`` via the ``substitute_ref=true``
+//! local-var pre-decl path while the consumer expected ``T &`` -- a
+//! pointer-vs-reference mismatch that broke AOT C++ compilation.
+//!
+//! This test must compile under AOT and produce the expected runtime
+//! result. It deliberately uses ``= default<clock>`` without the
+//! ``@safe_when_uninitialized`` workaround Boris applied at the source
+//! level, so a regression in the narrow stack-temp codegen surfaces here.
+
+class ClockHolder {
+    c : clock = default<clock>
+    def init(t : clock) {
+        c = t
+    }
+    def get() : clock {
+        return c
+    }
+}
+
+[test]
+def test_default_value_handle_field(t : T?) {
+    t |> run("class field = default<clock> compiles and works under AOT") @(t : T?) {
+        var h = new ClockHolder()
+        h->init(mktime(2024, 1, 1, 0, 0, 0))
+        t |> equal(int64(h->get()), int64(mktime(2024, 1, 1, 0, 0, 0)))
+    }
+}

--- a/tests/aot/test_value_handle_ref_param.das
+++ b/tests/aot/test_value_handle_ref_param.das
@@ -1,0 +1,39 @@
+options gen2
+require dastest/testing_boost public
+require fio
+
+//! Regression: a writable reference parameter of a value-annotation handle
+//! (ManagedValueAnnotation<T>, e.g. ``clock`` / ``das::Time``, or ECS
+//! ``EntityId``) must emit ``T &`` in AOT C++, not ``T`` by value. The
+//! over-broad ``valueHandle`` exclusion in ``describeCppTypeEx`` skipped the
+//! ``&`` suffix for every ``tHandle`` with ``isRefType == false``, which
+//! silently turned RW lambda/function parameters into by-value copies --
+//! mutations done by AOT code were lost on the C++ caller side.
+
+def set_clock_to_2030(var c : clock&) {
+    c = mktime(2030, 1, 1, 0, 0, 0)
+}
+
+def swap_clocks(var a : clock&; var b : clock&) {
+    let tmp = a
+    a = b
+    b = tmp
+}
+
+[test]
+def test_value_handle_ref_param(t : T?) {
+    t |> run("writable ref to value-handle preserves mutation") @(t : T?) {
+        var c = mktime(2024, 1, 1, 0, 0, 0)
+        set_clock_to_2030(c)
+        t |> equal(int64(c), int64(mktime(2030, 1, 1, 0, 0, 0)))
+    }
+    t |> run("two writable refs swap independently") @(t : T?) {
+        var a = mktime(2024, 1, 1, 0, 0, 0)
+        var b = mktime(2030, 6, 15, 0, 0, 0)
+        let a0 = int64(a)
+        let b0 = int64(b)
+        swap_clocks(a, b)
+        t |> equal(int64(a), b0)
+        t |> equal(int64(b), a0)
+    }
+}


### PR DESCRIPTION
Reference restriction was too broad in commit
c04377a5114289a95431adc9d615263745d7eb47
and commit
d886e6ad6c6353e58c86333381915215375d935f
relaxed it here.