### PR TITLE
mouse: batch May 2026 dasImgui + daslang Q&A cards (20 docs)

### DIFF
--- a/mouse-data/docs/dasimgui-edit-widget-external-pointer-rail.md
+++ b/mouse-data/docs/dasimgui-edit-widget-external-pointer-rail.md
@@ -1,0 +1,51 @@
+---
+slug: dasimgui-edit-widget-external-pointer-rail
+title: How does the dasImgui `edit_*` external-pointer widget rail work?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+**Caller owns the pointee; the widget edits it through a `T?` pointer.** The `edit_*` family parallels the state-managed boost widgets (`slider_float` / `checkbox` / `combo` / …) but doesn't auto-emit a state global — the value already lives somewhere else (a `var private`, a struct field, a C-side buffer).
+
+Call shape:
+
+    edit_kind(<ptr>, (id = "STABLE_IDENT", text = "label", ...other_named_args))
+
+The `id="..."` literal is REQUIRED — it keys the telemetry path. The `EditExternalCallMacro` hard-errors at compile time without it.
+
+## Pointer expressions
+
+- `safe_addr(g_global)` — for plain locals/globals. Type-safe + cheap.
+- `unsafe(addr(struct.field))` — for struct field access via reference. `safe_addr` rejects field-via-reference because of `is_local_or_global_expr` (`daslib/safe_addr.das:42`).
+
+In `style_editor.das`, every pointee is an `ImGuiStyle` field reached via `*GetStyle()` — so all calls use `unsafe(addr(style.Alpha))` etc. In `editing_external.das` (tutorial), pointees are plain `var private` globals → `safe_addr` works.
+
+## What lands in the call
+
+The full coverage (commits 10a-10c of the v2 boost mega-detour, modules/dasImgui/widgets/imgui_widgets_builtin.das):
+
+- **Scalars** (10a): `edit_slider_{float,int}` / `edit_drag_{float,int}` / `edit_input_{float,int,double}` — 8 overloads
+- **Vectors** (10b): `_2`/`_3`/`_4` variants of slider / drag / input — 12 overloads (caller passes `float2?` / `float3?` etc.; the wrapper does `unsafe(reinterpret<float?>(ptr))` at the ImGui call site since SliderFloat2/3/4 + DragFloat2/3/4 + InputFloat2/3/4 + ColorEdit/Picker3/4 all take a single `T*`)
+- **Color / Combo / Special** (10c): `edit_color_edit{3,4}` / `edit_color_picker{3,4}` / `edit_combo` / `edit_slider_angle` / `edit_checkbox` / `edit_radio_button` / `edit_checkbox_flags` — 14 overloads
+- 34 total `[edit_widget]` overloads
+
+## State / snapshot semantics
+
+- **No auto-emit.** No state-global is created; the macro just records the path key.
+- **Deep-copy mirror.** The boost wrapper copies `*ptr` into a hidden per-call mirror at frame end, so the serializer reads the mirror (not `*ptr` directly). Prevents UB if the external owner reallocates between render and snapshot read.
+- **Payload:** `{value: T}` for scalars; vector forms emit `{value: {x, y[, z[, w]]}}`.
+
+## Combo specifics
+
+`edit_combo` takes `array<string>` via `items <- ARR`. The wrapper uses the array-of-string-pointers ImGui overload (`addr(items[0])` + `length(items)`); no per-frame zero-separated buffer packing needed — daslang `string` carries the trailing null already.
+
+## `id` requirement rationale
+
+The whole reason `edit_*` exists is stable telemetry paths for caller-owned data. Auto-gen idents (commit 19 `[widget]` change) shift on edits — they'd defeat the purpose. So `id="..."` stays mandatory.
+
+## Questions
+- How does the dasImgui `edit_*` external-pointer widget rail work?
+- What's the difference between dasImgui boost `slider_float` and `edit_slider_float`?
+- Why does `edit_*` need `id="..."` instead of an ident?
+- Should I use `safe_addr` or `unsafe(addr(...))` with edit_*?

--- a/mouse-data/docs/dasimgui-find-cross-name-integration-test-for-feature-file.md
+++ b/mouse-data/docs/dasimgui-find-cross-name-integration-test-for-feature-file.md
@@ -1,0 +1,36 @@
+---
+slug: dasimgui-find-cross-name-integration-test-for-feature-file
+title: How do I find which integration test drives a given feature/example .das file (when the test name doesn't match)?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+## The problem
+
+In `modules/dasImgui/tests/integration/`, most tests are paired same-name with `examples/features/`: `test_foo.das` drives `foo.das`. But some tests drive a **different** feature file:
+
+- `test_snapshot.das` drives `examples/features/triggers.das`
+- `test_visual_aids_focus_rect.das` drives `examples/features/glfw_synth_keys.das`
+- `test_visual_aids_key_hud.das` drives `examples/features/glfw_synth_keys.das`
+
+Same-name heuristic (or a delegated agent that's been told "rename matching tests") misses these. Result: a refactor lands, the same-name tests get updated, the cross-name tests fail at run-time with stale widget paths.
+
+## The lookup
+
+Grep the test files for `let FEATURE = "modules/dasImgui/examples/features/<filename>.das"` (or `with_imgui_app(FEATURE) $(...)` — both reach the same anchor):
+
+    Grep "let FEATURE" modules/dasImgui/tests/integration/
+
+That lists every test's target feature file in one shot. Use it to build a feature → test(s) reverse index before a path-rename refactor.
+
+## When this bites
+
+Any refactor that changes widget identifier strings — most commonly the `MAIN_WIN/` path-prefix migration when wrapping things in `window(NAME, ...)`. If you renamed widget paths in `glfw_synth_keys.das` and only updated `test_glfw_synth_keys.das`, the two `test_visual_aids_*` tests silently break on the next run.
+
+## Discovery
+
+Bit me 2026-05-13 during the raw-`Begin/End` → `window(NAME, ...)` migration. Fixed retrospectively by `replace_all`'ing the bare widget names to prefixed names in the three cross-name tests after `dastest` surfaced the failures.
+
+## Questions
+- How do I find which integration test drives a given feature/example .das file (when the test name doesn't match)?

--- a/mouse-data/docs/dasimgui-label-text-key-arg.md
+++ b/mouse-data/docs/dasimgui-label-text-key-arg.md
@@ -1,0 +1,40 @@
+---
+slug: dasimgui-label-text-key-arg
+title: Why does dasImgui `label_text` use `key=` instead of `label=`?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+**`label` is a reserved word in daslang gen2.** It can't be used as a struct field name, record name in a named-tuple, or function parameter. The dasImgui boost surface renames `label` → `key` to dodge it.
+
+ImGui's C++ signature is `LabelText(const char* label, const char* fmt, ...)`. The boost wrapper is:
+
+    [widget]
+    def label_text(var state : LabelTextState; key : string; value : string)
+
+Call site:
+
+    label_text((key = "Version", value = "v2.0"))     // ✓
+    label_text((label = "Version", value = "v2.0"))   // ✗ error[30151]: syntax error, unexpected label
+
+The state struct `LabelTextState` likewise uses `key : string` + `value : string` (not `label`). The snapshot payload mirrors the field names — `{key: "Version", value: "v2.0"}`.
+
+## Other places `label` bites
+
+- Any `let label = ...` / `var label = ...` local variable — error 30151.
+- `def foo(label : string)` parameter — error 30151. Common in helper functions that ImGui-style accept a label. Rename to `lbl` or pick a more specific name.
+- `for (label in someEnum)` — error 30151.
+
+Hit Boris ≥2× during the v2 boost mega-detour PR. Both times in widget-helper functions that initially named a string param `label`.
+
+## Workaround precedence
+
+1. **For data-model fields** (snapshot payloads, struct fields): use `key` for the descriptive-label-side of a label/value pair, since that's the conceptual role. Avoid `label` everywhere in the data model.
+2. **For local variables / parameters**: rename to `lbl` (3 chars, unambiguous in context) or pick a domain-specific name (`button_text`, `caption`, `prompt`).
+
+## Questions
+- Why does dasImgui `label_text` use `key=` instead of `label=`?
+- Is `label` a reserved word in daslang?
+- What's the daslang error 30151 about?
+- Can I name a struct field `label` in daslang?

--- a/mouse-data/docs/dasimgui-list-box-unified-block-arg-form.md
+++ b/mouse-data/docs/dasimgui-list-box-unified-block-arg-form.md
@@ -1,0 +1,37 @@
+---
+slug: dasimgui-list-box-unified-block-arg-form
+title: In dasImgui v2 boost, what's the current list_box shape — items-array or Begin/End + Selectable?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+**Begin/End + Selectable, block-arg form.** Shipped via PR #28 (2026-05-14, `bbatkin/dasimgui-boost-scope-wrappers`).
+
+Use:
+
+    list_box(LANG, (text = "Language", size = float2(-1.0f, 180.0f))) {
+        for (i in range(length(LANG_NAMES))) {
+            let is_sel = (i == LANG.value)
+            let row_text = "{LANG_ICONS[i]} {LANG_NAMES[i]}"   // NOT `let label = ...` — `label` is a keyword
+            if (Selectable(row_text, is_sel,
+                           ImGuiSelectableFlags.None,
+                           float2(0.0f, 0.0f))) {
+                LANG.value = i
+            }
+        }
+    }
+
+Lives in `modules/dasImgui/widgets/imgui_containers_builtin.das`. State struct is `ListBoxState` (`value`, `has_pending`, `pending_value`, `changed` — selection-tracking machinery preserved). `imgui_set {"target": "PATH/LANG", "value": N}` steers `state.value` from outside.
+
+**Breaking-change history (PR #28):**
+
+- The **legacy items-array `[widget] def list_box(state, text, items, height_in_items) : bool`** (single-call form wrapping `ImGui::ListBox(label, &current, items, count, height)`) is **DELETED**. Migrate items-array callers to the block-arg form by emitting `Selectable` rows in a `for` loop.
+- The old **`list_box_select`** `[container]` was the modern Begin/End form during a transition period. It is **RENAMED to `list_box`** — drop the `_select` suffix at every call site.
+
+Asymmetry note: `combo` ([widget], items-array) and `combo_select` ([container], block-arg) still coexist. The list_box unification dropped the items-array form because the modern ImGui idiom is Begin/End + Selectable and there was only one user. `combo` may unify the same way in a follow-up — not committed.
+
+**Snapshot kind**: `"list_box"` (both the rename in the dispatcher and the assertion in `tests/integration/test_containers_overlay.das` were updated).
+
+## Questions
+- In dasImgui v2 boost, what's the current list_box shape — items-array or Begin/End + Selectable?

--- a/mouse-data/docs/dasimgui-menu-item-boost-signature-no-selected-no-enabled.md
+++ b/mouse-data/docs/dasimgui-menu-item-boost-signature-no-selected-no-enabled.md
@@ -1,0 +1,35 @@
+---
+slug: dasimgui-menu-item-boost-signature-no-selected-no-enabled
+title: Does the dasImgui `menu_item` boost widget take `selected` and `enabled` named-tuple args?
+created: 2026-05-14
+last_verified: 2026-05-15
+links: []
+---
+
+**As of 2026-05-15: partially yes, partially split.** `menu_item` now takes `enabled`; the `selected` use case moved to a sibling widget `menu_label`. See `dasimgui-menu-item-vs-menu-label-when-to-use-each.md` for the picker rule.
+
+Current signatures (`widgets/imgui_widgets_builtin.das`, v2 boost mega-detour):
+
+    [widget]
+    def menu_item(var state : ToggleState; text : string;
+                  shortcut : string = ""; enabled : bool = true) : bool   // toggleable
+
+    [widget]
+    def menu_label(var state : ClickState; text : string;
+                   shortcut : string = ""; selected : bool = false;
+                   enabled : bool = true) : bool                          // static
+
+`menu_item`'s `selected` arg was deliberately NOT added — `state.value` carries the toggle, exposing a separate `selected` would muddy the type. Static-selected (permanent check) goes through `menu_label(selected=true)`. Static-disabled (section header) goes through `menu_label(enabled=false)`.
+
+---
+
+**Historical note — what this card said before 2026-05-15:**
+
+> No — the boost `menu_item` widget only takes `text` and `shortcut`. Despite ImGui's `MenuItem(label, shortcut, selected, enabled)` C++ signature exposing four args, the boost wrapper omits `selected` and `enabled`.
+
+That was true through 2026-05-14 (port_use_boost_not_raw / v2-gap detour planning surfaced the gap). The mega-detour PR commit 7 (`0348287`) closed it.
+
+Bit Boris originally 2026-05-14 writing the `popup_context_item.das` feature demo.
+
+## Questions
+- Does the dasImgui `menu_item` boost widget take `selected` and `enabled` named-tuple args?

--- a/mouse-data/docs/dasimgui-menu-item-vs-menu-label-when-to-use-each.md
+++ b/mouse-data/docs/dasimgui-menu-item-vs-menu-label-when-to-use-each.md
@@ -1,0 +1,29 @@
+---
+slug: dasimgui-menu-item-vs-menu-label-when-to-use-each
+title: When do I use dasImgui `menu_item` vs the new `menu_label`? Both wrap ImGui's MenuItem(label, shortcut, selected, enabled).
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+Two distinct boost widgets covering the two semantic forms of ImGui's `MenuItem(label, shortcut, selected, enabled)`. Added 2026-05-15 in the v2 boost mega-detour (`widgets/imgui_widgets_builtin.das`).
+
+**`menu_item(IDENT, (text=, shortcut=, enabled=true))`** — **TOGGLEABLE**. ImGui receives `&state.value` as the `bool* p_selected` arg, so clicking toggles the check mark. `state.value` is `@live` and persists across hot-reload. Backed by `ToggleState`. Use for actual user-settable boolean preferences: "Show grid", "Enable foo", "Word wrap".
+
+    menu_item(VIEW_GRID, (text = "Show Grid", shortcut = "G"))
+    menu_item(EDIT_UNDO, (text = "Undo", shortcut = "CTRL+Z", enabled = can_undo()))
+
+**`menu_label(IDENT, (text=, shortcut=, selected=false, enabled=true))`** — **STATIC**. `selected` is a plain `bool`, NOT a `bool*` — the widget never mutates it. Backed by `ClickState` (tracks `click_count` for telemetry, no toggle). Use for:
+- Disabled section headers: `(text="(demo menu)", enabled=false)` — renders greyed-out non-interactive label
+- Permanent check marks: `(text="Checked", selected=true)` — always shows ✓, click doesn't toggle
+- Disabled-with-shortcut hints: `(text="Redo", shortcut="CTRL+Y", enabled=false)` — like the C++ `MenuItem("Redo","CTRL+Y",false,false)` idiom
+
+    menu_label(FILE_HEADER, (text="(section)", shortcut="", selected=false, enabled=false))
+    menu_label(FILE_CHECKED, (text="Static check", shortcut="", selected=true, enabled=true))
+
+**Gotcha — positional-dispatch on named-tuple args**: daslang dispatches named-tuple fields **positionally**, not by name (`dasimgui-widget-named-tuple-args-positional-not-named.md`). Both widgets order args as `(text, shortcut, ...)` — if you write `menu_label(X, (text=Y, enabled=false))` you'll get a compile error because `enabled=false` lands in `shortcut`'s slot (bool ≠ string). You must spell every middle arg. The compile error catches it; just fill in `shortcut = ""` to skip past it.
+
+**Why the split (instead of one `menu_item` with `selected_override` + `use_selected_override` flags)**: keeps the type meaningful — toggleable has a `value`, static has only a click count. No flag-bool muddying. Confirmed by Boris during plan approval 2026-05-14.
+
+## Questions
+- When do I use dasImgui `menu_item` vs the new `menu_label`? Both wrap ImGui's MenuItem(label, shortcut, selected, enabled).

--- a/mouse-data/docs/dasimgui-narrative-curly-interpolation-trap.md
+++ b/mouse-data/docs/dasimgui-narrative-curly-interpolation-trap.md
@@ -1,0 +1,44 @@
+---
+slug: dasimgui-narrative-curly-interpolation-trap
+title: Why does `{value}` in a dasImgui text widget try to look up a variable?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+**daslang strings interpolate `{expr}` at compile time.** Any `{...}` inside a string literal is treated as an embedded expression to evaluate and concatenate. The compiler lowers `"foo {x}"` to `string_builder("foo ", x)` (an `ExprOp2`), not `ExprConstString`.
+
+This isn't a dasImgui rule — it's daslang itself. But it hits hardest in narrative widgets where you want to show literal curly braces or describe a placeholder value:
+
+    // ✗ tries to look up a variable named `value` — compile error.
+    text("payload: {value}")
+
+    // ✓ rephrase to avoid `{ident}` shape.
+    text("payload value")
+
+    // ✓ to print a literal `{`, escape with double-braces.
+    text("payload: {{value}}")        // renders as: payload: {value}
+
+## Where this bites
+
+- **Showcase feature demos** writing narrative explanations like `"text() — one line, telemetry-visible."`. Anything `{IDENT}` (matching daslang identifier shape) is hot.
+- **DRIVE: ... curl -X POST -d '{"name":...}'` comments inside `//!` blocks** — those embed JSON which has its own braces. They sit inside `//` comments so the parser ignores them; but if you accidentally put JSON-shaped literal inside a `text("...")`, it errors.
+
+## Side effect on positional-string form (commit 19)
+
+`text("foo {x}")` parses to `string_builder("foo ", x)`, not `ExprConstString`. The positional-string sugar in the `[widget]` macro only matches bare `ExprConstString` literals. So interpolated text can't use positional form — must use named-tuple no-ident:
+
+    text((text = "value = {x}"))     // ✓
+    text("value = {x}")              // ✗ "first argument must be identifier, named-tuple, ...; got string_builder(...)"
+
+## Side effect on macro / qmacro debugging
+
+`qmacro` accepts `das_string` directly via `$i(name)` / `$v(value)`. If you generate a string with embedded `{...}` and pass it through a string-formatted error message (e.g. `macro_error(prog, expr.at, "got {expr_dump}")`), the inner `{...}` re-interpolates. Use `\{` to escape or build the string out-of-band.
+
+Bit Boris repeatedly during the v2 boost mega-detour PR — narrative showcase demos kept including `{value}` shapes in their descriptive text.
+
+## Questions
+- Why does `{value}` in a dasImgui text widget try to look up a variable?
+- Why does `text("foo {x}")` fail to compile as positional form?
+- How do I show literal curly braces in a daslang string?
+- What does daslang's string interpolation lower to?

--- a/mouse-data/docs/dasimgui-new-state-struct-widget-auto-emit-just-works.md
+++ b/mouse-data/docs/dasimgui-new-state-struct-widget-auto-emit-just-works.md
@@ -1,0 +1,25 @@
+---
+slug: dasimgui-new-state-struct-widget-auto-emit-just-works
+title: dasImgui [widget] auto-emit with a new state struct — do I need to register it anywhere besides defining the struct?
+created: 2026-05-15
+last_verified: 2026-05-15
+links: []
+---
+
+**No registration step.** The macro infrastructure (`apply_widget_or_container` in `widgets/imgui_boost.das`, `WidgetCallMacro` register/dispatch) is generic over the state struct type. Define the struct, write a `[widget]` def that takes `var state : MyState` as its first arg, and the auto-emit + serializer + dispatcher all just work — the generic JV/serialize machinery in `daslib/json_boost` handles new struct types transparently.
+
+Confirmed during the v2 boost mega-detour (2026-05-15): six new state struct types — `NarrativeState`, `LabelTextState`, `EmptyMarkerState`, `ImageState`, `ProgressBarState`, `MainMenuBarState` — landed in `widgets/imgui_boost_runtime.das`. Each shows up in `program_log` output (post-macro-expansion) with auto-generated `serialize` / `JV` generic instances. The first call site in user code triggers auto-emit of a module-scope `var private IDENT : MyState` global, identical to how `var private SAVE_BTN : ClickState` was emitted on first call to `button(SAVE_BTN, ...)`.
+
+The contract for a new state struct:
+- Mark fields with `@live` (preserved across hot-reload) or `@optional` (transient, dropped from JV when zero-valued). Don't leave fields un-annotated unless you want them included unconditionally.
+- Default values (`@optional value : string = ""`) fire on the auto-emitted global — confirmed by mouse card `dasimgui-widget-state-struct-field-defaults-fire`.
+- For stateless decoration widgets (separator, spacing, etc.), use the `@optional _placeholder : bool` shape so the struct stays non-empty for the auto-emit gate — mirrors `GroupState`/`MenuBarState`/`TooltipState` precedent. JV emits `{}` for these.
+
+Custom finalize helper: each widget kind that needs unique L2/L3 dispatch (`"set"`, `"click"`, etc.) gets a per-kind `def private xxx_finalize(widget_ident; kind; var state : MyState)` — see `click_finalize` / `toggle_finalize` / `text_value_finalize` for the lambda+dispatcher pattern. For read-only display widgets, dispatcher closure is a no-op and `register_focusable` is skipped (see `narrative_finalize` / `marker_finalize` / `plot_finalize` from the v2 boost commits).
+
+**What this means in practice**: extending the dasImgui surface with a new widget family is mechanical — a state struct in `imgui_boost_runtime.das`, a finalize helper + `[widget]` def in `imgui_widgets_builtin.das`, and that's it. No registry tables to update, no codegen step, no JSON schema to extend. The smoke verification under daslang-live in the v2 mega-detour ran `imgui_snapshot` and every new kind showed up with the right payload — that's load-bearing evidence the auto-emit chain is fully generic.
+
+## Questions
+- dasImgui [widget] auto-emit with a new state struct — do I need to register it anywhere besides defining the struct?
+- How do I add a new widget family to dasImgui — what's the minimum set of files to touch?
+- Does the [widget] macro work with arbitrary state struct types, or do I need to teach it about each one?

--- a/mouse-data/docs/dasimgui-pvisible-gate-skip-call-when-hidden.md
+++ b/mouse-data/docs/dasimgui-pvisible-gate-skip-call-when-hidden.md
@@ -1,0 +1,36 @@
+---
+slug: dasimgui-pvisible-gate-skip-call-when-hidden
+title: ImGui `Begin*(label, bool* p_visible, ...)` form — when *p_visible is false, do I skip the call entirely or pass null/some other gate?
+created: 2026-05-15
+last_verified: 2026-05-15
+links: []
+---
+
+**Skip the call entirely.** ImGui's `bool* p_visible` overloads (`CollapsingHeader(label, bool* p_visible, flags)`, `BeginPopupModal(label, bool* p_open, flags)`, `Begin(label, bool* p_open, flags)`, `BeginTabItem(label, bool* p_open, flags)`) contract is: while `*p_visible` is `false`, **do not issue the call**. Once the X-button or `imgui_close` flips it false, the application is expected to stop calling Begin entirely — NOT to pass a "now false" pointer and let ImGui no-op.
+
+dasImgui boost containers all mirror this pattern. The shape (from `widgets/imgui_containers_builtin.das`):
+
+    if (state.pending_close) {
+        state.open = false
+        state.pending_close = false
+    }
+    if (!closable || state.open) {            // <-- the gate
+        var p_open : bool? = null
+        if (closable) {
+            unsafe { p_open = addr(state.open) }
+        }
+        let im_open = Begin(text, p_open, flags)
+        // ... body
+        End()
+    }
+
+`window`, `collapsing_header(closable=true)` (added 2026-05-15 in the v2 boost mega-detour), `tab_item`, and `popup_modal` all use this exact gate. The `if (!closable || state.open)` short-circuit means non-closable variants never look at `state.open` and closable variants stop emitting the Begin call once they're hidden.
+
+Why not "always call Begin and let ImGui no-op"? Because for some of these (`collapsing_header(p_visible=false)`) the call still draws state — even if the body skips, the section header would render. The gate keeps the chrome from showing when the user closed it.
+
+**For `imgui_open` to restore visibility**: the dispatcher sets `state.pending_open=true`; the renderer then flips `state.open=true` and the gate opens, so the next frame's Begin call fires again. End-to-end: an imgui_open → next frame the container re-renders.
+
+Same gate logic applies if you're hand-rolling a new closable container — mirror `window` lines ~95-137 in `widgets/imgui_containers_builtin.das`.
+
+## Questions
+- ImGui `Begin*(label, bool* p_visible, ...)` form — when *p_visible is false, do I skip the call entirely or pass null/some other gate?

--- a/mouse-data/docs/dasimgui-scope-wrapper-default-arg-trailing-block-conflict.md
+++ b/mouse-data/docs/dasimgui-scope-wrapper-default-arg-trailing-block-conflict.md
@@ -1,0 +1,36 @@
+---
+slug: dasimgui-scope-wrapper-default-arg-trailing-block-conflict
+title: Why does my dasImgui scope wrapper `def with_foo(amount = 0.0f; blk : block) { ... }` fail to parse `with_foo() { ... }`?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+Trailing-block sugar (`fn() { body }`) doesn't compose with a default-value preceding parameter. When you write:
+
+    def with_indent(amount : float = 0.0f; blk : block) {
+        Indent(amount); invoke(blk); Unindent(amount)
+    }
+
+…and call `with_indent() { … }`, daslang sees the trailing block as the FIRST argument (slot for `amount`) and errors with:
+
+    invalid argument 'amount' (0). expecting 'float const', passing 'block<void> const'
+    missing argument blk
+
+The trailing-block sugar treats the block as the sole arg in source-position-1, not as the last arg. So a default on the first param can't be "skipped" to leave it bound while the block lands in the last slot.
+
+Fix: drop the default. Require callers to pass the value explicitly:
+
+    def with_indent(amount : float; blk : block) { ... }
+    // call site:
+    with_indent(0.0f) { ... }   // "default" case
+    with_indent(40.0f) { ... }  // custom
+
+This is the pattern `imgui/imgui_id_builtin.das`'s `with_id(s : string; blk : block)` uses — no defaults, explicit args.
+
+The wip.das example `def foo(a : int; blk : block = ${})` works ONLY because the block has the default — caller picks `foo(42)` (no block) OR `foo(42) { ... }` (with block). But `foo()` alone (no args) doesn't work — there's no default on `a`.
+
+Bit me 2026-05-14 building `with_indent`/`with_text_wrap_pos` in dasImgui boost scope wrappers.
+
+## Questions
+- Why does my dasImgui scope wrapper `def with_foo(amount = 0.0f; blk : block) { ... }` fail to parse `with_foo() { ... }`?

--- a/mouse-data/docs/dasimgui-setitemtooltip-not-bound-substitute-pattern.md
+++ b/mouse-data/docs/dasimgui-setitemtooltip-not-bound-substitute-pattern.md
@@ -1,0 +1,23 @@
+---
+slug: dasimgui-setitemtooltip-not-bound-substitute-pattern
+title: SetItemTooltip(text) errors out in daslang with `no matching functions or generics` — is it bound?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+No — `SetItemTooltip(const char*)` exists in `imgui.h` (line 720 in the bundled fork) but **the daslang binding doesn't expose it**. Calling it produces `error[30341]: no matching functions or generics: SetItemTooltip(string const&)` with "0 total functions with the same name."
+
+Substitute pattern — ImGui itself describes `SetItemTooltip` as a shortcut for the `if (IsItemHovered(ImGuiHoveredFlags_ForTooltip)) SetTooltip(...)` idiom (imgui.h:717), and both `IsItemHovered` and `SetTooltip` ARE bound. So just inline it:
+
+    // Wherever you wanted to write SetItemTooltip(text):
+    if (IsItemHovered(ImGuiHoveredFlags.ForTooltip)) {
+        SetTooltip(text)
+    }
+
+The boost `[widget] set_item_tooltip` (added 2026-05-15 in the v2 boost mega-detour, `widgets/imgui_widgets_builtin.das`) wraps this substitute idiom directly — callers don't see the inlining. Bound functions used by the substitute: `SetTooltip(const char*)`, `IsItemHovered(ImGuiHoveredFlags)`, `ImGuiHoveredFlags.ForTooltip` enum.
+
+If a fresh `SetItemTooltip` binding is desired in the future, add it via `makeExtern<>` in the dasIMGUI C++ glue alongside `SetTooltip` (see `dasIMGUI.func_*.cpp` for the existing binding pattern). Not required as of 2026-05-15 — the substitute is one line of daslang.
+
+## Questions
+- SetItemTooltip(text) errors out in daslang with `no matching functions or generics` — is it bound?

--- a/mouse-data/docs/dasimgui-stateless-block-arg-wrapper-pattern.md
+++ b/mouse-data/docs/dasimgui-stateless-block-arg-wrapper-pattern.md
@@ -1,0 +1,44 @@
+---
+slug: dasimgui-stateless-block-arg-wrapper-pattern
+title: How do I write a dasImgui stateless block-arg helper like with_id that wraps a Push/Pop pair?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+Plain `def` with a trailing `blk : block` arg — **no annotation, no state struct**. Pattern lives in `modules/dasImgui/widgets/imgui_id_builtin.das` and `imgui_scope_builtin.das`.
+
+Canonical shape:
+
+    def public with_indent(amount : float; blk : block) {
+        //! 1-2 line docstring describing the Push/Pop pair being scoped.
+        Indent(amount)
+        invoke(blk)
+        Unindent(amount)
+    }
+
+Key constraints:
+
+- **No `[container]` annotation** — stateless wrappers don't ID anything, don't need `container_path_push`/`pop`, and don't register a snapshot entry. `[container]` is for Begin/End scopes that gate the body and own path-tree position.
+- **No `[widget]` annotation either** — those auto-emit a state global and dispatch named-tuple args; way too much machinery for a pure Push/Pop bracket.
+- **No default on the leading param when followed by a block** — daslang's trailing-block sugar parses `with_foo() { ... }` as "block in the first arg slot" and binds the block to `amount` (wrong type). Drop the default; callers pass `0.0f` explicitly. See `dasimgui-scope-wrapper-default-arg-trailing-block-conflict.md`.
+- **`finally` is unreliable on panic** (Issue #2532) — don't bother with `{ ... } finally { Pop... }`. On ImGui panic mid-frame the state machine is hosed regardless.
+
+Companion: dotted-flag wrappers like `with_id(s) { ... }` push *both* ImGui's ID stack and the boost container-path:
+
+    def public with_id(s : string; blk : block) {
+        container_path_push(s)
+        PushID(s)
+        invoke(blk)
+        PopID()
+        container_path_pop()
+    }
+
+Use this shape when the scope contributes to widget identity. Bare Push/Pop wrappers (indent, item width, text wrap pos, style overrides) skip the path push since they don't ID anything.
+
+**Where to register the new module**: add a `register_native_path("imgui", "imgui_<name>_builtin", "{project_path}/widgets/imgui_<name>_builtin.das")` line to `modules/dasImgui/.das_module`. Existing entries cluster the boost surface under `imgui_*_builtin` names.
+
+Shipped this pattern in PR #28 (2026-05-14): `widgets/imgui_scope_builtin.das` with `with_indent`, `with_item_width`, `with_text_wrap_pos`.
+
+## Questions
+- How do I write a dasImgui stateless block-arg helper like with_id that wraps a Push/Pop pair?

--- a/mouse-data/docs/dasimgui-tutorial-apng-cursor-trail-missing-apply-synth-io-override.md
+++ b/mouse-data/docs/dasimgui-tutorial-apng-cursor-trail-missing-apply-synth-io-override.md
@@ -1,0 +1,48 @@
+---
+slug: dasimgui-tutorial-apng-cursor-trail-missing-apply-synth-io-override
+title: My standalone dasImgui tutorial's APNG recording has no visible mouse cursor or trail — what's missing?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+## Symptom
+
+You write a simple boost-style tutorial (`window(...) { button(...) ... }`), launch it under `daslang-live`, drive it from `tests/integration/record_<slug>.das` (which posts `imgui_mouse_play` via `move_to` / `click_at` etc.), call `record_start`/`record_stop`. The APNG records the widgets but the **cursor sprite and mouse trail never appear** — they were what you wanted to demonstrate the click sequence.
+
+## Cause
+
+The synth cursor sprite + mouse trail are painted by `paint_all()` in `widgets/imgui_visual_aids.das`, but only after `apply_synth_io_override()` has fired in the current frame. `apply_synth_io_override` is what:
+
+1. Picks up the queued `imgui_mouse_play` events,
+2. Advances the timeline,
+3. Sets `mouse_cursor_x/y` and `synth_cursor_owned=true`,
+4. Schedules the sprite + trail draw.
+
+Without that call, ImGui's normal `io.MousePos` chain wins, `synth_cursor_owned` stays false, and `paint_cursor_sprite()` falls back to drawing at `GetMousePos()` — which is either off-screen or stale-from-real-mouse.
+
+## Fix
+
+In the tutorial's `[export] def update()`, call `apply_synth_io_override()` once per frame BEFORE the widget code:
+
+```das
+require imgui/imgui_visual_aids
+
+[export] def update() {
+    apply_synth_io_override()    // <-- this
+    window(MY_WIN, (text = "...", ...)) {
+        // widgets
+    }
+}
+```
+
+(`apply_synth_io_override()` is a no-op when there's no synth IO active, so this is safe to call unconditionally — it doesn't change behavior outside record sessions.)
+
+## Where this bit me
+
+`examples/tutorial/boost_basics.das` was the smallest possible boost example, so it didn't require `imgui_visual_aids` at all. When I re-recorded `boost_basics.apng` after the `window(...)` migration, the cursor + trail were invisible. Added the `require` + the one-liner call; trail came back instantly.
+
+The richer tutorials (`widgets_tour.das`, `visual_aids_tour.das`) already require `imgui_visual_aids` and call the override, so they were fine.
+
+## Questions
+- My standalone dasImgui tutorial's APNG recording has no visible mouse cursor or trail — what's missing?

--- a/mouse-data/docs/dasimgui-var-ptr-implicit-pointee-write.md
+++ b/mouse-data/docs/dasimgui-var-ptr-implicit-pointee-write.md
@@ -1,0 +1,77 @@
+---
+slug: dasimgui-var-ptr-implicit-pointee-write
+title: How do I write through a `T?` pointer parameter from a daslang function body?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+**Two traps to dodge.** A function that takes a `T?` pointer and writes back through it via `*p = value` needs both the parameter shape and the local binding right.
+
+## Trap 1 — `let p = ptr` loses mutability
+
+    def foo(ptr : bool?) {
+        let p = ptr             // ✗ const-deref trap
+        unsafe {
+            *p = !*p             // error: can't write to a constant value, bool aka TT const&
+        }
+    }
+
+`let` binds `p` as const. `*p = value` then fails because the LHS resolves to `bool const&` (write to const). Fix:
+
+    def foo(ptr : bool?) {
+        var p = ptr             // ✓ mutable local
+        unsafe {
+            *p = !*p             // OK
+        }
+    }
+
+## Trap 2 — `T?` parameter rejects `safe_addr`'s temp
+
+    def foo(ptr : bool?) {
+        ...
+    }
+    foo(safe_addr(g_flag))      // ✗ argument expects `bool?`, got `bool?#`
+
+`safe_addr` returns `bool?#` (temp), and `bool?` parameter declaration won't accept it. Fix: declare param `implicit`:
+
+    def foo(var ptr : bool? implicit) {
+        var p = ptr
+        unsafe {
+            *p = !*p
+        }
+    }
+
+The `implicit` flavor accepts both:
+- `safe_addr(local_or_global)` (returns `T?#`)
+- `unsafe(addr(struct.field))` (returns `T?`)
+
+Combine `var ptr : T? implicit` + `var p = ptr` and the body writes through the pointee safely.
+
+## Combined idiom (used heavily in commits 10a-c of the v2 boost mega-detour)
+
+    def edit_finalize(widget_ident : string; kind : string;
+                      var ptr : auto(TT)? implicit) {
+        var entry : WidgetEntry
+        unsafe {
+            var p = ptr
+            let ser <- @ capture(= p) () : JsonValue? {
+                return JV((value = *p))
+            }
+            let disp <- @ capture(= p) (action : string; payload : JsonValue?) {
+                if (action == "set") {
+                    *p = from_JV(payload?["value"], type<TT>, default<TT>)
+                }
+            }
+            widget_finalize(widget_ident, kind, entry, ser, disp)
+        }
+    }
+
+The `var p = ptr` captures by value into the lambda, and `*p` reads/writes the pointee.
+
+## Questions
+- How do I write through a `T?` pointer parameter from a daslang function body?
+- Why does `let p = ptr; *p = value` fail with `can't write to a constant value`?
+- What's the difference between `T?` and `T?#` (temp pointer)?
+- What does `var ptr : T? implicit` mean?
+- Why doesn't my function accept `safe_addr(g_flag)` as a `bool?` parameter?

--- a/mouse-data/docs/dasimgui-widget-no-ident-form.md
+++ b/mouse-data/docs/dasimgui-widget-no-ident-form.md
@@ -1,0 +1,58 @@
+---
+slug: dasimgui-widget-no-ident-form
+title: Can dasImgui `[widget]` calls drop the IDENT first-arg?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+**Yes — three call forms accepted as of commit 19 of the v2 boost mega-detour.** The `[widget]` macro auto-synthesizes the state-global + telemetry path from `{__FILE__}:{__LINE__}:{__COLUMN__}` when the user doesn't supply an explicit ident.
+
+Three forms:
+
+    // 1. EXPLICIT — leading ident drives auto-emitted state global + path key.
+    text(MY_LABEL, (text = "hello"))         // state global: var MY_LABEL : NarrativeState
+                                              // path key:     <window>/MY_LABEL
+
+    // 2. AUTO-GEN — first arg is the named-tuple, no ident.
+    text((text = "hello"))                    // state global: __widget_<line>_<col>
+                                              // path key:     <window>/<mod>:<line>:<col>
+
+    // 3. POSITIONAL — single-string sugar for the text family only.
+    text("hello")                             // same auto-synth as form 2
+
+The convention: **state where it matters, no-ident where it doesn't.** If you read `IDENT.value` / `IDENT.click_count` / etc., name it. Otherwise drop the ident — it's noise. Synthesized names shift on edits, so test drivers driving widgets via stable telemetry paths should keep explicit idents.
+
+## Positional shorthand scope
+
+Single-string text family only:
+
+    text("...")              ✓
+    text_unformatted("...")  ✓
+    text_wrapped("...")      ✓
+    text_disabled("...")     ✓
+    bullet_text("...")       ✓
+    separator_text("...")    ✓
+
+NOT:
+- `text_colored("...")` — has `color` arg too. Use `text_colored((color = ..., text = ...))`.
+- `label_text("...")` — has `key` + `value`. Use `label_text((key = ..., value = ...))`.
+- `button("Save")` — interactive; explicit ident encouraged.
+
+## Limitations
+
+**Interpolated strings cannot use positional form.** `text("foo {x}")` parses to `string_builder("foo ", x)` (an `ExprOp2`), not `ExprConstString`. The positional-string gate only matches bare literals. For interpolation, use named-tuple no-ident form:
+
+    text((text = "foo {x}"))     // ✓
+    text("foo {x}")              // ✗ error: first argument must be identifier, named-tuple, ...; got string_builder(...)
+
+**Zero-arg widgets still require an explicit ident.** `separator()` / `spacing()` / `bullet()` / `new_line()` / zero-arg `same_line()` all error with `missing widget body — pass (named=arg, …)`. The `[widget]` macro hard-errors on empty argument list. Workaround: pass an explicit ident. Future work: special-case the macro to accept zero-arg.
+
+**`edit_*` family is unchanged** — `id="STABLE_IDENT"` stays mandatory inside the named-tuple. The whole reason `edit_*` exists is stable telemetry paths for caller-owned data; auto-gen would defeat the purpose.
+
+## Questions
+- Can dasImgui `[widget]` calls drop the IDENT first-arg?
+- What's the no-ident form for dasImgui v2 widgets?
+- Does `text("hello")` work in dasImgui boost v2?
+- Can I call `separator()` without an ident?
+- Does `text("foo {x}")` work as positional form?

--- a/mouse-data/docs/daslang-external-module-docs-crosslink-convention.md
+++ b/mouse-data/docs/daslang-external-module-docs-crosslink-convention.md
@@ -1,0 +1,43 @@
+---
+slug: daslang-external-module-docs-crosslink-convention
+title: How do I cross-link daslang docs to an external module's gh-pages site (and back) — what's the convention?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+## The two-PR shape
+
+External module (e.g. dasImgui) ships its own Sphinx site on `<owner>.github.io/<repo>/`. Cross-linking is a **paired-PR convention** — one PR on each side, landed together so neither dangles.
+
+## daslang side (outbound)
+
+1. New file `doc/source/external_modules/<name>.rst` — short page covering: what the module is, how to install (`daspkg install …`), what's inside, link to gh-pages URL.
+2. New `doc/source/external_modules/index.rst` — single `.. toctree::` listing the per-module RSTs.
+3. Add `external_modules/index` to the root `doc/source/index.rst` toctree (after `stdlib/`).
+
+This is one outbound link sitting under a dedicated "External modules" section in the daslang docs nav. Pattern repeats per module added.
+
+Reference: daslang commit `e49e6f35c` (PR #2649, 2026-05-13) — first instance, dasImgui.
+
+## External module side (inbound + visual parity)
+
+1. Vendor daslang.io's Forge CSS (`doc/source/_static/custom.css` — Inter Tight + JetBrains Mono, amber-on-dark, retoken'd Pygments). Without this the link feels like leaving the site; with it the two docs read as one.
+2. Wire via `conf.py`:
+   ```python
+   html_static_path = ["_static"]
+   html_css_files = ["custom.css"]
+   ```
+3. One-line "Part of the daslang ecosystem" pointer at the top of `doc/source/index.rst` linking back to the daslang docs root.
+
+Reference: dasImgui commit `a18f195` (PR #24, 2026-05-13).
+
+## Pinned decisions
+
+- **Visual theme parity is intentional.** Cross-navigation should feel like one site, not two. Vendor the CSS, don't try to re-derive a theme.
+- **Outbound = dedicated page, not a one-line link in `index.rst`.** A module deserves a blurb + install snippet + "what's inside" — readers landing on the cross-link need that context.
+- **Inbound = one-line ecosystem pointer.** The external module's own index is the destination; don't bury the link.
+- **Paired PRs ship together.** Either side alone leaves a half-built bridge.
+
+## Questions
+- How do I cross-link daslang docs to an external module's gh-pages site (and back) — what's the convention?

--- a/mouse-data/docs/daslang-label-reserved-word-gen2.md
+++ b/mouse-data/docs/daslang-label-reserved-word-gen2.md
@@ -1,0 +1,27 @@
+---
+slug: daslang-label-reserved-word-gen2
+title: Is `label` a reserved word in daslang gen2?
+created: 2026-05-14
+last_verified: 2026-05-15
+links: []
+---
+
+Yes — `label` is a daslang keyword in gen2 (confirmed by Boris 2026-05-14). The reservation is **lexical**, not contextual — it bites in every identifier position: `let`/`var`, **struct fields**, **function parameters**, **named-tuple member names**.
+
+Same error from all four shapes:
+
+    let label = "..."                                   // ← error[30151]
+    var label : string                                  // ← error[30151]
+    struct LabelTextState { label : string }            // ← error[30151] (hit during v2 boost mega-detour 2026-05-14)
+    def label_text(label : string; value : string)      // ← error[30151] (same)
+
+Error reads: `error[30151]: syntax error, unexpected label, expecting $i or name`.
+
+Workaround: rename. The mega-detour's `LabelTextState`/`label_text` adopted `key : string` for the left-side string (and the `[widget]` body calls `LabelText(key, value)` — note ImGui's C++ API param IS named `label`, so the C-side binding is unaffected; only the daslang identifier breaks).
+
+The reserved-word list also includes the obvious ones (`if`, `for`, etc.) and a handful that read as ordinary identifiers in other languages — `label` is the one that catches you out because `label` reads as a perfectly reasonable variable / field / param name for UI text content.
+
+Don't infer the full reserved-word list from this card — when in doubt, grep `ds2_parser.ypp` (the grammar is the source of truth) or just try compiling.
+
+## Questions
+- Is `label` a reserved word in daslang gen2?

--- a/mouse-data/docs/how-do-i-format-a-float-to-n-decimal-places-as-a-string-in-daslang.md
+++ b/mouse-data/docs/how-do-i-format-a-float-to-n-decimal-places-as-a-string-in-daslang.md
@@ -1,0 +1,31 @@
+---
+slug: how-do-i-format-a-float-to-n-decimal-places-as-a-string-in-daslang
+title: How do I format a float to N decimal places as a string in daslang?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+Use `build_string() <| $(var w) { fmt(w, ":.2f", value) }` (from `require strings`). The result is a plain `string`.
+
+```das
+require strings
+let s  = build_string() <| $(var w) { fmt(w, ":.2f",  3.14159f) }   // "3.14"
+let s2 = build_string() <| $(var w) { fmt(w, ":+.3f", -0.5f) }      // "-0.500"
+let s3 = build_string() <| $(var w) { fmt(w, ":05d",  42) }         // "00042"
+let s4 = build_string() <| $(var w) { fmt(w, ":x",    255) }        // "ff"
+```
+
+**Format spec is Python-style, not printf**: leading `:` and no `%`. Single-arg form only (each `fmt` call formats one value — no `"x={} y={}"` multi-arg interpolation; chain multiple `fmt` calls inside one `build_string` for that).
+
+**Gotchas**:
+- `format(w, "%.2f", value)` exists but is deprecated. The compiler's deprecation message *says* "use fmt() instead" implying drop-in replacement, but **the format spec syntax is different** (`:.2f` vs `%.2f`). Passing `%.2f` to `fmt` at compile time looks valid but throws `EXCEPTION: fmt error: invalid format string` at runtime. The deprecation message is misleading; the rename is a real spec change. (Reported upstream as a candidate fix per Boris's "fix misleading errors at source" preference.)
+- Plain string interpolation `"{value}"` gives full float precision (e.g. `"0.913957"`) with no way to specify a format spec inline.
+- For drawlist `AddText` on widgets where text width matters for layout — always fixed-decimal via `fmt` rather than interpolation, or the rendered width changes per frame.
+
+**Where it lives**: `daslib/strings_boost.das` provides `fmt`/`build_string`; visible via `require strings` (which re-exports strings_boost). Reference tests: `tests/strings/test_cpp_functions.das:14+` exercises every spec combo.
+
+**Example use site**: `modules/dasImgui/examples/tutorial/custom_widgets.das` — knob value readout under each drawlist-painted knob.
+
+## Questions
+- How do I format a float to N decimal places as a string in daslang?

--- a/mouse-data/docs/sphinx-w-pygments-json-lexer-fails-on-ellipsis-placeholders.md
+++ b/mouse-data/docs/sphinx-w-pygments-json-lexer-fails-on-ellipsis-placeholders.md
@@ -1,0 +1,48 @@
+---
+slug: sphinx-w-pygments-json-lexer-fails-on-ellipsis-placeholders
+title: Sphinx -W docs CI fails with Pygments JSON lexer warning on placeholder ellipsis — what's the fix?
+created: 2026-05-14
+last_verified: 2026-05-14
+links: []
+---
+
+## Symptom
+
+Docs CI's `sphinx-build -W --keep-going` fails the build with output like:
+
+    /.../tutorials/driving_outside.rst:82: WARNING: Lexing literal_block '...
+    "bbox": [...], "...":"..."
+    ...' as "json" resulted in an error at token: '.'. Retrying in relaxed mode.
+
+The build still emits HTML, but `-W` escalates the warning to an error → `Process completed with exit code 1`.
+
+## Cause
+
+Pygments' JSON lexer is strict — `[...]`, `"...":"..."`, and similar ellipsis placeholder tokens you sprinkle into "shape of the response" examples aren't valid JSON. Pygments falls back to relaxed lexing and emits the warning. Under `-W` the warning is fatal.
+
+## Fix
+
+Switch the code-block language to `text`:
+
+    .. code-block:: text
+
+       {
+         "frame": 412,
+         "bbox": [...],
+         "...": "..."
+       }
+
+You lose JSON syntax highlighting but the block keeps the same shape and the warning goes away. This is the right move whenever the example is illustrative (uses elisions, comments, trailing commas, etc.) rather than a literal valid-JSON sample.
+
+Alternatives if you want highlighting:
+1. **Make the JSON valid** — replace `[...]` with concrete `[0, 0, 0, 0]`, drop the `"...": "..."` rows entirely.
+2. **Use `.. parsed-literal::`** — no lexing at all, but you lose the boxed code-block look.
+
+In practice `text` is the lowest-friction option.
+
+## Real example
+
+dasImgui CI failed on `doc/source/tutorials/driving_outside.rst:82` after commit `4afaddc` (2026-05-13). Fixed in `022419f` — single-line `code-block:: json` → `code-block:: text` swap. Local `sphinx-build -W --keep-going` clean afterward; CI green on next push.
+
+## Questions
+- Sphinx -W docs CI fails with Pygments JSON lexer warning on placeholder ellipsis — what's the fix?

--- a/mouse-data/docs/where-does-get-uptime-come-from-in-daslang-s-live-reload-api-and-what-s-the-live-host-vs-glfw-live-boundary.md
+++ b/mouse-data/docs/where-does-get-uptime-come-from-in-daslang-s-live-reload-api-and-what-s-the-live-host-vs-glfw-live-boundary.md
@@ -1,0 +1,34 @@
+---
+slug: where-does-get-uptime-come-from-in-daslang-s-live-reload-api-and-what-s-the-live-host-vs-glfw-live-boundary
+title: Where does `get_uptime()` come from in daslang's live-reload API, and what's the live_host vs glfw_live boundary?
+created: 2026-05-13
+last_verified: 2026-05-13
+links: []
+---
+
+`get_uptime()` lives in **`live_host`** (the backend-agnostic core of the live-reload API), not in `glfw_boost` or `live/glfw_live`. It's exposed by `modules/dasLiveHost/src/dasLiveHost.cpp:137` (C++ `live_get_uptime()`) and registered on the `live_host` daslang module:
+
+```cpp
+// dasLiveHost.cpp
+float live_get_uptime() { ... }
+// in initDependencies:
+addExtern<DAS_BIND_FUN(live_get_uptime)>(*this, lib, "get_uptime",
+    SideEffects::accessGlobal, "das::live_get_uptime");
+```
+
+To use it: `require live_host` and call `get_uptime()`.
+
+**Why this matters when carving backend-agnostic modules:** A common mistake is reaching for `require glfw/glfw_boost` to get `get_uptime` because that's where GLFW-coupled live code (like `modules/dasGlfw/dasglfw/glfw_live.das`) is *used*. But `glfw_live.das` doesn't *provide* `get_uptime` — it consumes it from `live_host` like everyone else. Adding `require glfw/glfw_boost` to a backend-agnostic file just to reach `get_uptime` re-couples the file to GLFW for nothing.
+
+**The boundary:**
+- `live_host` (C++ shared_module via `modules/dasLiveHost/`): backend-agnostic live API — `get_uptime`, `is_reload`, `live_store_bytes`, `live_load_bytes`, `[before_reload]`/`[after_reload]` annotation plumbing.
+- `live/live_commands` (daslang): the `[live_command]` annotation and JSON-RPC dispatch — also backend-agnostic.
+- `live/glfw_live` (daslang, requires GLFW): GLFW-specific synth-IO driver, window lifecycle integration.
+- `glfw/glfw_boost` (daslang, requires GLFW): higher-level GLFW wrappers (window helpers etc.).
+
+**Symptom of getting this wrong:** compile error[30341] `no matching functions or generics: get_uptime()` with the candidate-comment-listing `live_host::get_uptime is not visible directly from <your_module>`. Fix: replace any `require glfw/glfw_boost` (added "for `get_uptime`") with `require live_host`.
+
+**Surfaced 2026-05-14** while splitting `widgets/imgui_live.das` synth driver into `widgets/imgui_live_core.das`. The original file had `require glfw/glfw_boost` and used `get_uptime()`; I assumed the symbol came from glfw_boost and copied the require into the new file. The compile-check error pointed straight at the right module.
+
+## Questions
+- Where does `get_uptime()` come from in daslang's live-reload API, and what's the live_host vs glfw_live boundary?


### PR DESCRIPTION
## Summary

20 mouse cards accumulated across May 2026 work — mostly dasImgui v2 boost mega-detour discoveries (commits 1-21 of `bbatkin/dasimgui-v2-boost-mega-detour` over on `borisbat/dasImgui`, tip `ee329e6`), plus a handful of daslang side findings. All cards are tested via `mouse__rebuild` (98 docs indexed).

## What's in scope

**dasImgui v2 boost mega-detour (14 cards):**
- `dasimgui-widget-no-ident-form` — the new no-ident + positional-string call forms (`text("hello")` / `text((text=...))` / explicit-ident)
- `dasimgui-edit-widget-external-pointer-rail` — full edit_* family walkthrough (34 overloads, safe_addr vs unsafe(addr) picker, `id="..."` requirement)
- `dasimgui-narrative-curly-interpolation-trap` — daslang `{x}` interpolation in strings; why `text("foo {x}")` lowers to `string_builder` and fails positional form
- `dasimgui-label-text-key-arg` — `label` is a gen2 reserved word
- `dasimgui-var-ptr-implicit-pointee-write` — `var ptr : T? implicit` + `var p = ptr` idiom
- `dasimgui-menu-item-boost-signature-no-selected-no-enabled` — INVERTED (menu_item gained `enabled`, menu_label is the static sibling)
- `dasimgui-menu-item-vs-menu-label-when-to-use-each` — picker rule
- `dasimgui-new-state-struct-widget-auto-emit-just-works` — adding a state struct + [widget] auto-emits the global
- `dasimgui-pvisible-gate-skip-call-when-hidden` — visibility gate pattern
- `dasimgui-stateless-block-arg-wrapper-pattern` — with_* shape
- `dasimgui-scope-wrapper-default-arg-trailing-block-conflict` — defaults vs trailing-block invoke
- `dasimgui-setitemtooltip-not-bound-substitute-pattern` — ImGui 1.91+ workaround (superseded by commit 5's `set_item_tooltip`)
- `dasimgui-list-box-unified-block-arg-form` — `list_box(IDENT, ...) { ... }`
- `dasimgui-find-cross-name-integration-test-for-feature-file` — `test_<feature>_smoke` + `FEATURE_PATH` convention

**dasImgui-adjacent (1 card):**
- `dasimgui-tutorial-apng-cursor-trail-missing-apply-synth-io-override`

**daslang general (5 cards):**
- `daslang-label-reserved-word-gen2`
- `daslang-external-module-docs-crosslink-convention`
- `sphinx-w-pygments-json-lexer-fails-on-ellipsis-placeholders`
- `how-do-i-format-a-float-to-n-decimal-places-as-a-string-in-daslang`
- `where-does-get-uptime-come-from-in-daslang-s-live-reload-api-and-what-s-the-live-host-vs-glfw-live-boundary`

## Test plan

- [x] All 20 files render cleanly (markdown only, no code)
- [x] `mouse__rebuild` indexed 98 docs without errors
- [x] No collisions with existing slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
