### PR TITLE
ci: drop dasImgui example dry-run from extended_checks

### DIFF
--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -256,14 +256,6 @@ jobs:
         cd modules/dasImgui && git diff --exit-code -- src/ \
           || (echo "ERROR: dasImgui generated files are out of date. Run './bin/daslang modules/dasImgui/bind/bind_imgui.das' locally and commit the result." && exit 1)
 
-    - name: "Dry-run imgui examples"
-      run: |
-        set -eux
-        for f in modules/dasImgui/example/*.das; do
-          echo "== compile-only: $f =="
-          $BIN/daslang -compile-only "$f"
-        done
-
     - name: "Coverage"
       if: matrix.target == 'linux'
       run: |


### PR DESCRIPTION
## Summary

- Removes the "Dry-run imgui examples" step from `extended_checks.yml`.
- The step globbed `modules/dasImgui/example/*.das` (singular, flat) but dasImgui reorganized to `examples/` (plural) with `features/` / `imgui_demo/` / `save_demo/` / `tutorial/` subdirs. Bash's unmatched-glob behavior iterated the literal pattern and daslang failed with `error[20605]: missing prerequisite`.
- dasImgui has its own CI for example dry-runs; the daslang-side check is redundant.
- The "Install dasImgui (daspkg)" + "Run self-binder (bind_imgui.das)" pair stays — that one is still meaningful (catches daslang-binder drift against dasImgui bindings).

## Test plan

- [ ] `extended_checks (darwin15, arm64)` goes green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)