### PR TITLE
docs: Forge style refinements (G1-G11, G13b)

### DIFF
--- a/doc/source/_static/custom-patch.css
+++ b/doc/source/_static/custom-patch.css
@@ -1,0 +1,138 @@
+/* ──────────────────────────────────────────────────────────────────
+ * Forge — additive refinements on top of custom.css.
+ *
+ * Drop next to custom.css and load AFTER it:
+ *   html_css_files = ['custom.css', 'custom-patch.css']
+ *
+ * Covers gaps G1–G11 documented in SPHINX_AUDIT.md.
+ * ────────────────────────────────────────────────────────────────── */
+
+/* G1 — bare links, no permanent underline */
+.rst-content a, .rst-content a:visited {
+    text-decoration: none !important;
+    border-bottom: 1px dotted transparent !important;
+    transition: border-color 0.12s, color 0.12s;
+}
+.rst-content a:hover {
+    color: var(--fg) !important;
+    border-bottom-color: var(--fg) !important;
+}
+
+/* G2 — admonition title takes the kind color */
+.rst-content .admonition .admonition-title { color: var(--blue) !important; }
+.rst-content .admonition.warning .admonition-title,
+.rst-content .admonition.attention .admonition-title,
+.rst-content .admonition.caution .admonition-title { color: var(--amber) !important; }
+.rst-content .admonition.error .admonition-title,
+.rst-content .admonition.danger .admonition-title  { color: var(--red)   !important; }
+.rst-content .admonition.tip .admonition-title,
+.rst-content .admonition.hint .admonition-title    { color: var(--green) !important; }
+
+/* G3 — kill table row striping, swap solid grid for dashed rows */
+.rst-content table.docutils,
+.wy-table-responsive table {
+    border-left: none !important;
+    border-right: none !important;
+    border-top: 1px solid var(--rule) !important;
+    border-bottom: 1px solid var(--rule) !important;
+}
+.rst-content table.docutils tbody tr td,
+.rst-content table.docutils tbody tr:nth-child(odd) td,
+.wy-table-responsive table tbody tr td,
+.wy-table-responsive table tbody tr:nth-child(odd) td {
+    background: transparent !important;
+    border: none !important;
+    border-bottom: 1px dashed var(--rule) !important;
+}
+.rst-content table.docutils thead th,
+.wy-table-responsive table thead th {
+    background: transparent !important;
+    border: none !important;
+    border-bottom: 1px solid var(--rule) !important;
+    font-family: var(--font-mono) !important;
+    font-size: 11px !important;
+    letter-spacing: 1.2px !important;
+    text-transform: uppercase !important;
+    color: var(--fg-faint) !important;
+    text-align: left;
+}
+
+/* G4 — anchors don't disappear under the sticky nav */
+html { scroll-padding-top: 80px; }
+.rst-content h1, .rst-content h2, .rst-content h3,
+.rst-content h4, .rst-content h5, .rst-content h6 {
+    scroll-margin-top: 80px;
+}
+
+/* G5 — headerlink ¶ becomes a subtle hover-only → */
+.rst-content a.headerlink {
+    color: transparent !important;
+    background: transparent !important;
+    border-bottom: none !important;
+    margin-left: 10px;
+    font-size: 0 !important;          /* hide the ¶ glyph */
+    transition: color 0.12s;
+    vertical-align: middle;
+}
+.rst-content a.headerlink::before {
+    content: '→';
+    font-family: var(--font-mono);
+    font-size: 14px;
+    color: inherit;
+}
+.rst-content h1:hover a.headerlink, .rst-content h1:focus-within a.headerlink,
+.rst-content h2:hover a.headerlink, .rst-content h2:focus-within a.headerlink,
+.rst-content h3:hover a.headerlink, .rst-content h3:focus-within a.headerlink,
+.rst-content h4:hover a.headerlink, .rst-content h4:focus-within a.headerlink,
+.rst-content h5:hover a.headerlink, .rst-content h5:focus-within a.headerlink,
+.rst-content h6:hover a.headerlink, .rst-content h6:focus-within a.headerlink {
+    color: var(--fg-faint) !important;
+}
+.rst-content a.headerlink:hover,
+.rst-content a.headerlink:focus-visible { color: var(--amber) !important; }
+
+/* G6 — branded text selection */
+::selection { background: rgba(232,161,58,0.28); color: var(--fg); }
+
+/* G7 — kbd */
+.rst-content kbd, kbd.kbd, kbd.docutils.literal {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    background: var(--bg-2);
+    border: 1px solid var(--rule);
+    border-radius: 3px;
+    padding: 1px 6px;
+    color: var(--fg);
+    box-shadow: 0 1px 0 var(--rule);
+}
+
+/* G8 — list markers */
+.rst-content ul > li::marker  { color: var(--fg-faint); }
+.rst-content ol > li::marker  {
+    color: var(--amber);
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+}
+
+/* G9 — narrower prose, keep code/tables wide.
+ * <p> is never used for code blocks or tables, so capping every <p> is safe.
+ * Cells (td/th) explicitly opt out so wide tabular data still spans full width. */
+.rst-content p { max-width: 720px; }
+.rst-content td p,
+.rst-content th p { max-width: none; }
+
+/* G10 — heading scale matches landing/artboard */
+.rst-content h1 { font-size: 44px !important; line-height: 1.1  !important; letter-spacing: -0.02em  !important; }
+.rst-content h2 { font-size: 26px !important; line-height: 1.3  !important; letter-spacing: -0.015em !important; margin-top: 40px; }
+.rst-content h3 { font-size: 20px !important; line-height: 1.4  !important; letter-spacing: -0.01em  !important; margin-top: 28px; }
+
+/* G11 — inner <pre> shouldn't redraw the rounded corner */
+.rst-content div[class^="highlight"] pre {
+    border-radius: 0 !important;
+    border: none !important;
+}
+
+/* Fallback: any un-tokenized signature text still reads as dim grey. */
+.rst-content dt.sig-object { color: var(--fg-dim); }
+.rst-content dt.sig-object .sig-name,
+.rst-content dt.sig-object .sig-name.descname { color: var(--amber) !important; }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -157,7 +157,7 @@ html_static_path = ['_static']
 
 # Custom CSS — Forge token overlay on top of sphinx_rtd_theme.
 # See doc/source/_static/custom.css for the retoken rules.
-html_css_files = ['custom.css']
+html_css_files = ['custom.css', 'custom-patch.css']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/source/daslang.py
+++ b/doc/source/daslang.py
@@ -19,6 +19,49 @@ from pygments.token import (
     Comment, Keyword, Name, Number, Operator, Punctuation, String, Text, Token
 )
 
+# G13b — signature syntax highlighting. We reuse DaslangLexer (defined
+# further down in this file) to tokenize each signature's arglist and
+# return type, then emit Pygments-classed inline nodes. CSS rules in
+# _static/custom.css of the form `.highlight .k`, `.highlight .kt`, etc.
+# then color signatures the same way they color code blocks.
+from pygments import lex as _pygments_lex
+from pygments.token import STANDARD_TYPES as _PYG_STANDARD_TYPES
+
+
+def _das_token_class(ttype):
+    """Map a Pygments token type to its short HTML class ('k', 'kt', 'n', …).
+    Walks up the token hierarchy until a STANDARD_TYPES match is found."""
+    while ttype is not None:
+        if ttype in _PYG_STANDARD_TYPES:
+            return _PYG_STANDARD_TYPES[ttype]
+        ttype = ttype.parent
+    return ''
+
+
+# Lazy singleton — DaslangLexer is cheap but no need to rebuild per call.
+_DAS_LEXER_SINGLETON = None
+def _das_lexer():
+    global _DAS_LEXER_SINGLETON
+    if _DAS_LEXER_SINGLETON is None:
+        _DAS_LEXER_SINGLETON = DaslangLexer()
+    return _DAS_LEXER_SINGLETON
+
+
+def _append_highlighted(signode, text):
+    """Tokenize `text` with DaslangLexer and append classed inline nodes
+    to `signode`. Each token is wrapped with both `highlight` and the
+    Pygments short class (e.g. `kt` for type, `k` for keyword), so the
+    existing `.highlight .kt` style rules apply without modification."""
+    if not text:
+        return
+    for ttype, value in _pygments_lex(text, _das_lexer()):
+        cls = _das_token_class(ttype)
+        classes = ['highlight']
+        if cls:
+            classes.append(cls)
+        signode += nodes.inline(value, value, classes=classes)
+
+
 from sphinx import version_info
 
 from sphinx import addnodes
@@ -130,11 +173,22 @@ class DASObject(ObjectDescription):
         if self.has_arguments:
             if not arglist:
                 if not self.skip_empty_arguments:
-                    signode += addnodes.desc_parameterlist()
+                    # Empty () for callables with skip_empty_arguments=False
+                    signode += addnodes.desc_sig_punctuation('(', '(')
+                    signode += addnodes.desc_sig_punctuation(')', ')')
             else:
-                _pseudo_parse_arglist(signode, arglist)
+                # G13b — tokenize the arglist with DaslangLexer so each
+                # token (type, name, operator, etc.) ends up in its own
+                # span with a Pygments class name. Wrap with explicit
+                # parens so CSS layout stays consistent with the pre-
+                # patch behavior.
+                signode += addnodes.desc_sig_punctuation('(', '(')
+                _append_highlighted(signode, arglist)
+                signode += addnodes.desc_sig_punctuation(')', ')')
         if retType:
-            signode += addnodes.desc_type(retType, retType)
+            # retType retains its leading ':' from handle_signature's
+            # split, so we can hand it to the lexer as-is.
+            _append_highlighted(signode, retType)
         return fullname, prefix
 
     def add_target_and_index(self, name_obj, sig, signode):


### PR DESCRIPTION
## Summary

Closes the 12-gap audit from the daslang.io Forge docs sweep — brings Sphinx output into pixel-level alignment with the Forge design system used on the landing page.

- **`_static/custom-patch.css`** — additive overlay covering G1–G11:
  bare links (no permanent underline), kind-colored admonition titles (warn→amber, note→blue, danger→red, tip→green), dashed-row tables with mono uppercase headers, sticky-nav scroll padding, hover-only `→` headerlinks, branded text selection, `kbd` styling, list-marker colors, 720px prose cap, 44/26/20 heading scale, cleaner rounded code-block border. Includes a two-rule un-tokenized-signature fallback in place of the G13a CSS band-aid (no longer needed once G13b is in).
- **`conf.py`** — load `custom-patch.css` after `custom.css`.
- **`daslang.py`** — G13b: tokenize function signatures with `DaslangLexer` so the arglist + return type get the same Pygments classes (`.highlight .kt` / `.k` / `.n` / `.p` / …) as code blocks. Wraps in explicit `desc_sig_punctuation` parens so CSS layout stays consistent.

A matching PR is also being opened against `borisbat/dasImgui` so both docs sites carry the same refinements.

## Test plan

- [x] Clean local sphinx-build (`build succeeded, 2 warnings` — unrelated `toctree.not_included`).
- [x] Verified G13b: `reference/language/builtin_functions.html` carries 100 tokenized signature spans with `.highlight .kt` / `.n` / `.p` / `.o` classes.
- [x] Spot-checked G1–G11 in the rendered output (links, admonitions, tables, headings, code blocks).
- [ ] CI: `sphinx-build -W` HTML + LaTeX builds pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)