### PR TITLE
lint: fix transitive PERF/STYLE warnings in daslib + modules

### DIFF
--- a/daslib/algorithm.das
+++ b/daslib/algorithm.das
@@ -408,8 +408,8 @@ def erase_all(var arr; value) {
 
 def fill(var a : array<auto(TT)>; value : TT const -&) {
     //! Sets all elements of the array to the given value using clone.
-    for (i in range(length(a))) {
-        a[i] := value
+    for (e in a) {
+        e := value
     }
 }
 
@@ -419,8 +419,8 @@ def fill(var a; value) {
     static_if (typeinfo stripped_typename(a[0]) != typeinfo stripped_typename(value)) {
         concept_assert(false, "value type {typeinfo stripped_typename(value)} should be the same as array {typeinfo stripped_typename(a)} element type {typeinfo stripped_typename(a[0])}")
     } else {
-        for (i in range(length(a))) {
-            a[i] := value
+        for (e in a) {
+            e := value
         }
     }
 }
@@ -486,7 +486,7 @@ def rotate(var a; mid : int) {
 
 def min_element(a : array<auto(TT)>) : int {
     //! Returns the index of the minimum element in the array, or -1 if the array is empty.
-    if (length(a) == 0) return -1
+    if (empty(a)) return -1
     var best = 0
     for (i in range(1, length(a))) {
         if (a[i] < a[best]) {
@@ -498,7 +498,7 @@ def min_element(a : array<auto(TT)>) : int {
 
 def min_element(a : array<auto(TT)>; less : block<(a, b : TT const -&) : bool>) : int {
     //! Returns the index of the minimum element according to the provided less function, or -1 if the array is empty.
-    if (length(a) == 0) return -1
+    if (empty(a)) return -1
     var best = 0
     for (i in range(1, length(a))) {
         if (invoke(less, a[i], a[best])) {
@@ -510,7 +510,7 @@ def min_element(a : array<auto(TT)>; less : block<(a, b : TT const -&) : bool>) 
 
 def max_element(a : array<auto(TT)>) : int {
     //! Returns the index of the maximum element in the array, or -1 if the array is empty.
-    if (length(a) == 0) return -1
+    if (empty(a)) return -1
     var best = 0
     for (i in range(1, length(a))) {
         if (a[best] < a[i]) {
@@ -522,7 +522,7 @@ def max_element(a : array<auto(TT)>) : int {
 
 def max_element(a : array<auto(TT)>; less : block<(a, b : TT const -&) : bool>) : int {
     //! Returns the index of the maximum element according to the provided less function, or -1 if the array is empty.
-    if (length(a) == 0) return -1
+    if (empty(a)) return -1
     var best = 0
     for (i in range(1, length(a))) {
         if (invoke(less, a[best], a[i])) {
@@ -561,11 +561,11 @@ def topological_sort(nodes : array<auto(Node)>) {
         if (lnodes != 0) {
             sorted |> reserve(lnodes)
             var unsorted : array<Node> := nodes
-            while (length(unsorted) > 0) {
+            while (!empty(unsorted)) {
                 var removed = 0
                 var i = 0
                 while (i < length(unsorted)) {
-                    if (length(unsorted[i].before) == 0) {
+                    if (empty(unsorted[i].before)) {
                         var node <- unsorted[i]
                         unsorted |> erase(i)
                         for (other in unsorted) {

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -441,11 +441,9 @@ def expectsLocalTemp(expr : ExprMakeLocal?) : bool {
     if (!expr.makeFlags.doesNotNeedSp && expr.stackTop != 0u) {
         if (expr is ExprMakeStruct) {
             let mks = expr as ExprMakeStruct
-            if (mks.makeType.baseType == Type.tHandle &&
-                !mks.makeType.isRefType &&
-                mks.constructor == null) {
-                return false
-            }
+            if (mks.makeType.baseType == Type.tHandle
+                    && !mks.makeType.isRefType
+                    && mks.constructor == null) return false
         }
         return true
     }

--- a/daslib/decs.das
+++ b/daslib/decs.das
@@ -720,7 +720,7 @@ def public for_each_archetype_find(hash : ComponentHash; var erq : function<() :
 [unsafe_operation]
 def decs_array(atype : auto(TT); src : array<uint8>; capacity : int) {
     //! Low level function returns temporary array of component given specific type of component.
-    assert(length(src) > 0)
+    assert(!empty(src))
     static_if (typeinfo is_dim(atype)) {
         var dest : array<TT[typeinfo dim(atype)] -const -& -#>
         unsafe {
@@ -1218,7 +1218,7 @@ def private make_callbacks(var cv : ComponentValue; value : auto(TT)) {
                 var ssrc : array<TT[typeinfo dim(value)] -const -& -#>
                 let size = length(src) / stride
                 unsafe {
-                    if (length(src) > 0) {
+                    if (!empty(src)) {
                         _builtin_make_temp_array(ssrc, addr(src[0]), size)
                     }
                 }

--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -847,7 +847,7 @@ def take(arr : array<auto(TT)>; var total : int) : array<TT -& -const> {
 def take_inplace(var arr : array<auto(TT)>; var total : int) {
     //! Keeps only the first `total` elements in an array in place
     let len = length(arr)
-    let taking = (total < len)  ? total : len
+    let taking = min(total, len)
     arr.resize(taking)
 }
 
@@ -1902,7 +1902,7 @@ def union_by_to_array(var srca, srcb : iterator<auto(TT)>; key : block<(arg : TT
 
 def any(src : array<auto(TT)>) : bool {
     //! Returns true if the array has at least one element
-    return length(src) != 0
+    return !empty(src)
 }
 
 def any(var src : iterator<auto(TT)>) : bool {
@@ -1961,7 +1961,7 @@ def all(src : array<auto(TT)>; predicate : block<(arg : TT -&) : bool>) : bool {
 
 def none(src : array<auto(TT)>) : bool {
     //! Returns true if the array has no elements
-    return length(src) == 0
+    return empty(src)
 }
 
 def none(var src : iterator<auto(TT)>) : bool {
@@ -2372,7 +2372,7 @@ def element_at_or_default(var src : iterator<auto(TT)>; index : int) : TT -const
 
 def first(src : array<auto(TT)>) : TT -const -& {
     //! Returns the first element of an array
-    panic("sequence contains no elements") if (length(src) == 0)
+    panic("sequence contains no elements") if (empty(src))
     static_if (typeinfo can_copy(src[0])) {
         return src[0]
     } else {
@@ -2396,7 +2396,7 @@ def first(var src : iterator<auto(TT)>) : TT -const -& {
 
 def first_or_default(src : array<auto(TT)>; defaultValue : TT -&) : TT -const -& {
     //! Returns the first element of an array, or a default value if the array is empty
-    if (length(src) == 0) {
+    if (empty(src)) {
         static_if (typeinfo can_copy(defaultValue)) {
             return defaultValue
         } else {
@@ -2745,7 +2745,7 @@ def private chunk_impl(var src; tt : auto(TT); size : int) : array<array<TT -con
             buffer.emplace(chunk)
         }
     }
-    if (chunk.length() > 0) {
+    if (!empty(chunk)) {
         buffer.emplace(chunk)
     }
     return <- buffer

--- a/modules/dasOpenGL/opengl/opengl_boost.das
+++ b/modules/dasOpenGL/opengl/opengl_boost.das
@@ -143,7 +143,7 @@ def glUniformMatrix4fv(location : int; value : float4x4) {
 [expect_any_array(arr)]
 def glBufferData(target : GLenum; arr; usage : GLenum) {
     unsafe {
-        assert(length(arr) > 0)
+        assert(!empty(arr))
         glBufferData(target, int64(length(arr) * typeinfo sizeof(arr[0])), reinterpret<void?> addr(arr[0]), usage)
     }
 }

--- a/modules/dasPEG/peg/parser_generator.das
+++ b/modules/dasPEG/peg/parser_generator.das
@@ -1067,7 +1067,7 @@ def generate_one_alternative(var gen : ParserGenerator; var alt : Alternative; i
 
 def alternative_add_epilogue(var block_contents : array<ExpressionPtr>; var gen : ParserGenerator; var action_block) {
 
-    assert(length(action_block) > 0, "Action block should not be empty")
+    assert(!empty(action_block), "Action block should not be empty")
 
     var return_type = gen.return_types |> get_value_and_clone_type(gen.current_context)
 

--- a/modules/dasPEG/peg/peg.das
+++ b/modules/dasPEG/peg/peg.das
@@ -125,10 +125,8 @@ def public get_current_char(var parser) : int {
 def public match_decimal_literal(var parser) : tuple<success : bool; value : int; endpos : int> {
     //! Simple lexing of decimal integers, doesn't check for overflow
 
-    if (!parser |> get_current_char |> is_number) {
-        // Can't use typedef in this context, sadly
-        return tuple<success : bool; value : int; endpos : int>()
-    }
+    // Can't use typedef in this context, sadly
+    if (!parser |> get_current_char |> is_number) return tuple<success : bool; value : int; endpos : int>()
 
     var result = 0
 
@@ -175,9 +173,7 @@ def public match_double_literal(var parser) : tuple<success : bool; value : doub
 
     var current_char = parser |> get_current_char
 
-    if (!current_char |> is_number && current_char != '+' && current_char != '-') {
-        return <- (success = false, value = 0.0 |> double())
-    }
+    if (!current_char |> is_number && current_char != '+' && current_char != '-') return <- (success = false, value = 0.0 |> double())
 
     var inscope buffer : array<uint8>
 

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -1129,8 +1129,7 @@ def try_check_schema(db : SqlRunner; t : type<auto(TT)>) : SqlError {
     for (j in range(length(got))) {
         by_name |> insert(got[j].name, j)
     }
-    for (i in range(length(want))) {
-        let w = want[i]
+    for (w in want) {
         let g_idx = by_name?[w.name] ?? -1
         if (g_idx < 0) return some("check_schema: \"{table_name}\" struct field \"{w.name}\" not found in DB columns.")
         let g = got[g_idx]


### PR DESCRIPTION
## Summary

Follow-up to #2662. Mechanical fixes to `daslib/` + module templates whose `PERF017` / `PERF018` / `STYLE005` / `PERF015` warnings only fired through instantiation chains. The lint runner attributed them to consumer tutorials and `utils/` files, but the real code lives one or two `instanced from` frames up. Fixing at the source collapses N consumer-attributed warnings into zero.

## Per-file changes

**daslib/linq.das** — 6 sites
- `L850` ternary min → `min(a, b)` &nbsp;[PERF015]
- `L1905/1964/2375/2399` `length(src) {==,!=} 0` → `empty(src)` / `!empty(src)` &nbsp;[PERF017]
- `L2748` `chunk.length() > 0` → `!empty(chunk)` &nbsp;[PERF017]

**daslib/decs.das** — 2 sites (`decs_array`)
- `L723`/`L1221` `length(src) > 0` → `!empty(src)` &nbsp;[PERF017]

**daslib/algorithm.das** — 8 sites
- `L411/422` `for (i in range(length(a))) a[i] := value` → `for (e in a) e := value` &nbsp;[PERF018] (`fill`)
- `L489/501/513/525` `length(a) == 0` → `empty(a)` &nbsp;[PERF017] (`min_element` / `max_element`)
- `L564` `while (length(unsorted) > 0)` → `while (!empty(unsorted))` &nbsp;[PERF017]
- `L568` `length(.before) == 0` → `empty(.before)` &nbsp;[PERF017]

**daslib/aot_cpp.das** — `L444` braced single-return collapse &nbsp;[STYLE005]

**modules/dasOpenGL/opengl/opengl_boost.das** — `L146` `glBufferData` assert &nbsp;[PERF017]

**modules/dasPEG/peg/parser_generator.das** — `L1070` `alternative_add_epilogue` assert &nbsp;[PERF017]

**modules/dasPEG/peg/peg.das** — `L128`/`L178` braced single-return collapse in `match_decimal_literal` / `match_double_literal` &nbsp;[STYLE005]

**modules/dasSQLITE/daslib/sqlite_boost.das** — `L1132` `try_check_schema`: `for (i in range(length(want))) { let w = want[i] ... }` → `for (w in want) { ... }` &nbsp;[PERF018]

## Validation

- Lint on `tutorials/ modules/ utils/`: **116 → 86 issues** (-30). Remaining 86 are lint-test fixtures (intentional warnings — testing the rules themselves) + dasImgui (separate repo, not in this tree).
- `dastest` interpreter: **8033/8039 pass**, 0 failed, 0 errors, 6 skipped
- `test_aot` AOT: **7422/7428 pass**, 0 failed, 0 errors, 6 skipped
- Local extended_checks (`dascov`, `mcp`, `lint`, `detect-dupe`, `find-dupe`, `hygiene`, `mouse`): all pass

## Test plan

- [x] Lint reduces transitive warnings to zero in-scope
- [x] dastest interpreter
- [x] AOT build + tests
- [x] Local extended_checks suites
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)