### PR TITLE
site: add GoatCounter analytics to landing page and blog

### DIFF
--- a/site/blog/template.html
+++ b/site/blog/template.html
@@ -12,6 +12,10 @@
     <link rel="stylesheet" href="{{root}}files/forge.css" />
     <script src="{{root}}files/cm/daslang-keywords.js" defer></script>
     <script src="{{root}}files/highlight.js" defer></script>
+
+    <!-- Analytics -->
+    <script data-goatcounter="https://borisbat.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
 <div class="forge-page">

--- a/site/index.html
+++ b/site/index.html
@@ -21,6 +21,10 @@
     <link rel="stylesheet" href="files/forge.css" />
     <link rel="stylesheet" href="files/cm/codemirror.min.css" />
     <link rel="stylesheet" href="files/cm/cm-forge.css" />
+
+    <!-- Analytics -->
+    <script data-goatcounter="https://borisbat.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
 <div class="forge-page">


### PR DESCRIPTION
## Summary

- Adds a single async `<script>` tag pointing at `borisbat.goatcounter.com/count` to:
  - `site/index.html` — landing page
  - `site/blog/template.html` — re-emitted into every post on the next blog rebuild
- No cookies, no consent banner, ~1KB beacon. Privacy-friendly by design.
- Sphinx-built `/doc` tree is intentionally out of scope; only the hand-written site is instrumented.

## Test plan

- [ ] Deploy to GitHub Pages.
- [ ] Load `dascript.org` in a private window — confirm a single `gc.zgo.at/count.js` request in DevTools network panel.
- [ ] Load a blog post — confirm the same request fires there too.
- [ ] Check `borisbat.goatcounter.com` dashboard within ~30s for the registered hit.
