### PR TITLE
fix: dlopen shared modules with RTLD_GLOBAL on POSIX

### DIFF
--- a/src/misc/sysos.cpp
+++ b/src/misc/sysos.cpp
@@ -194,13 +194,16 @@
             return pathNameSize;
         }
         void * loadDynamicLibrary ( const char * lib ) {
-            return dlopen(lib,RTLD_LAZY);
+            // RTLD_GLOBAL so symbols from loaded .shared_module files
+            // (e.g. live_host_*) are visible to dlsym(RTLD_DEFAULT) in
+            // host executables like daslang-live.
+            return dlopen(lib,RTLD_LAZY|RTLD_GLOBAL);
         }
         void * getFunctionAddress ( void * lib, const char * name ) {
             return lib ? dlsym(lib, name) : nullptr;
         }
         void * getLibraryHandle ( const char * lib ) {
-            return dlopen(lib,RTLD_LAZY);
+            return dlopen(lib,RTLD_LAZY|RTLD_GLOBAL);
         }
         string getDynamicLibraryError ( void ) {
             const char * e = dlerror();
@@ -479,13 +482,14 @@
             return 0;
         }
         void * loadDynamicLibrary ( const char * lib ) {
-            return dlopen(lib,RTLD_LAZY);
+            // RTLD_GLOBAL — see Linux note above.
+            return dlopen(lib,RTLD_LAZY|RTLD_GLOBAL);
         }
         void * getFunctionAddress ( void * lib, const char * name ) {
             return lib ? dlsym(lib, name) : nullptr;
         }
         void * getLibraryHandle ( const char * lib ) {
-            return dlopen(lib,RTLD_LAZY);
+            return dlopen(lib,RTLD_LAZY|RTLD_GLOBAL);
         }
         string getDynamicLibraryError ( void ) {
             const char * e = dlerror();
@@ -529,13 +533,14 @@
             return snprintf(pathName, pathNameCapacity, "%s", executablePath);
         }
         void * loadDynamicLibrary ( const char * lib ) {
-            return dlopen(lib,RTLD_LAZY);
+            // RTLD_GLOBAL — see Linux note above.
+            return dlopen(lib,RTLD_LAZY|RTLD_GLOBAL);
         }
         void * getFunctionAddress ( void * lib, const char * name ) {
             return lib ? dlsym(lib, name) : nullptr;
         }
         void * getLibraryHandle ( const char * lib ) {
-            return dlopen(lib,RTLD_LAZY);
+            return dlopen(lib,RTLD_LAZY|RTLD_GLOBAL);
         }
         string getDynamicLibraryError ( void ) {
             const char * e = dlerror();


### PR DESCRIPTION
## Summary

POSIX `dlopen(lib, RTLD_LAZY)` defaults to `RTLD_LOCAL` — symbols loaded from each `.shared_module` stay private to that .so. This breaks any host executable that expects to bind module-exported C symbols via `dlsym(RTLD_DEFAULT, name)`.

- `daslang-live` looks up `live_host_*` C symbols (init/update/shutdown driver, exit/reload flags, dt/uptime/fps setters) via `dlsym(RTLD_DEFAULT, ...)` at startup ([utils/daslang-live/main.cpp:76-84, 87-108](https://github.com/GaijinEntertainment/daScript/blob/master/utils/daslang-live/main.cpp#L76)). Without `RTLD_GLOBAL` the lookup returns `nullptr` and daslang-live prints:
  ```
  WARNING: could not find live_host DLL exports
  WARNING: live_host module not found — lifecycle functions will use defaults
  ```
  Any host integration test that spawns daslang-live then hangs at the readiness gate (e.g. dasImgui's full integration suite).

- Windows path uses `GetModuleHandleA(...)` which sees every loaded DLL regardless of flags — bug never surfaced on Windows.
- daslang's main CI runs `live_host` tests against `daslang_static` (symbols statically linked into the process), which masks the issue. Only the dynamically-linked `daslang-live` host trips it.

Adds `RTLD_GLOBAL` to `loadDynamicLibrary` and `getLibraryHandle` in [src/misc/sysos.cpp](https://github.com/GaijinEntertainment/daScript/blob/master/src/misc/sysos.cpp) for the Linux/Emscripten, macOS, and Haiku branches (six dlopen call sites total).

## Verification

WSL Ubuntu2404-CI with a clean Release build:

```das
options gen2
require live_host

[export] def init() { print("init\n") }
[export] def update() {
    let dt = get_dt()
    let up = get_uptime()
    print("upd dt={dt} uptime={up}\n")
    request_exit()
}
[export] def shutdown() { print("shutdown\n") }
```

```
$ xvfb-run -a bin/daslang-live test_live.das
daslang-live: lifecycle mode (init/update/shutdown)
init
upd dt=1.84e-07 uptime=1.84e-07
shutdown
```

Before the fix the same script printed `WARNING: could not find live_host DLL exports` / `... lifecycle functions will use defaults` and the lifecycle ran on defaults (zero dt/uptime).

## Test plan

- [x] WSL Ubuntu2404-CI minimal `daslang-live` smoke (above)
- [ ] CI: existing daslang tests pass (no regression — `RTLD_GLOBAL` is strictly additive)
- [ ] dasImgui PR #31 integration test workflow goes green once this lands (was blocked by this exact issue — `[imgui_playwright] readiness gate FAILED` on every Linux test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)