### PR TITLE
lint: O(1) FileInfo line index + unified suppression API in rtti_core

### DIFF
--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -61,18 +61,7 @@ class LintVisitor : AstVisitor {
         pass
     }
     def is_suppressed(text : string; at : LineInfo) : bool {
-        if (at.fileInfo == null || at.line == 0u) return false
-        let colon = find(text, ":")
-        if (colon < 0) return false
-        let code = slice(text, 0, colon)
-        var found = false
-        get_file_source_line(at.fileInfo, at.line) $(line) {
-            let nolint_pos = find(line, "nolint")
-            if (nolint_pos >= 0) {
-                found = find(line, code, nolint_pos) >= 0
-            }
-        }
-        return found
+        return is_lint_suppressed(at, extract_lint_code(text))
     }
     def lint_error(text : string; at : LineInfo) : void {
         if (noLint || self->is_suppressed(text, at)) return

--- a/daslib/perf_lint.das
+++ b/daslib/perf_lint.das
@@ -111,7 +111,7 @@ class PerfLintVisitor : AstVisitor {
     collect_warnings : bool = false
     warnings : array<string>
     // dedup: reported (file_hash, line, column) to suppress duplicate warnings from generic instantiations
-    reported_locations : array<uint64>
+    reported_locations : table<uint64>
     // PERF019: cache of enum-types we've probed for an `operator |` overload.
     // Keys are intptr(Enumeration?); vals say "yes, has operator|".
     perf019_enum_or_probed : array<uint64>
@@ -125,20 +125,7 @@ class PerfLintVisitor : AstVisitor {
     }
 
     def is_suppressed(text : string; at : LineInfo) : bool {
-        if (at.fileInfo == null || at.line == 0u) return false
-        // extract PERFxxx code from warning text (e.g. "PERF003: ...")
-        let colon = find(text, ":")
-        if (colon < 0) return false
-        let code = slice(text, 0, colon)
-        var found = false
-        get_file_source_line(at.fileInfo, at.line) $(line) {
-            // look for "// nolint:PERFxxx" or "// nolint(PERFxxx)" in a comment
-            let nolint_pos = find(line, "nolint")
-            if (nolint_pos >= 0) {
-                found = find(line, code, nolint_pos) >= 0
-            }
-        }
-        return found
+        return is_lint_suppressed(at, extract_lint_code(text))
     }
 
     def perf_warning(text : string; at : LineInfo) : void {
@@ -148,8 +135,8 @@ class PerfLintVisitor : AstVisitor {
             || (current_function != null && current_function.flags.generated)) return
         // Deduplicate warnings — same source location reported once, regardless of generic instantiations
         let key = self->location_key(at)
-        if (reported_locations |> has_value(key)) return
-        reported_locations |> push(key)
+        if (key_exists(reported_locations, key)) return
+        reported_locations |> insert(key)
         // Check inline suppression: // PERFxxx on the same line
         if (self->is_suppressed(text, at)) return
         warning_count++

--- a/daslib/rtti.das
+++ b/daslib/rtti.das
@@ -5,6 +5,7 @@ options remove_unused_symbols = false
 module rtti shared public
 
 require rtti_core public
+require strings
 
 typedef FileAccessPtr = smart_ptr<FileAccess>
 
@@ -191,4 +192,21 @@ def RttiValue_nothing {
         set_variant_index(t, typeinfo variant_index<nothing>(t))
     }
     return t
+}
+
+//! Returns true when the source line at `at` carries a `// nolint:CODE` (or
+//! `// nolint:CODE1,CODE2,...`) directive listing `code`. Null-safe wrapper
+//! around the C-side scanner; returns false if `at.fileInfo == null` or
+//! `at.line == 0`. Canonical entry point for lint visitors.
+def public is_lint_suppressed(at : LineInfo; code : string) : bool {
+    return false if (at.fileInfo == null || at.line == 0u)
+    return rtti_is_nolint_suppressed(at.fileInfo, at.line, code)
+}
+
+//! Extracts the leading code from a lint message such as "LINT001: foo bar"
+//! (returns "LINT001"). Returns empty string if no colon is present.
+def public extract_lint_code(text : string) : string {
+    let colon = find(text, ":")
+    return "" if (colon < 0)
+    return slice(text, 0, colon)
 }

--- a/daslib/style_lint.das
+++ b/daslib/style_lint.das
@@ -48,7 +48,7 @@ class StyleLintVisitor : AstVisitor {
     collect_warnings : bool = false
     warnings : array<string>
     // dedup: suppress duplicate warnings from generic instantiations
-    reported_locations : array<uint64>
+    reported_locations : table<uint64>
     // current function (for inferStack reporting)
     @do_not_delete current_function : Function?
     // STYLE011: track uninitialized variables from most recent ExprLet
@@ -63,26 +63,15 @@ class StyleLintVisitor : AstVisitor {
     }
 
     def is_suppressed(text : string; at : LineInfo) : bool {
-        if (at.fileInfo == null || at.line == 0u) return false
-        let colon = find(text, ":")
-        if (colon < 0) return false
-        let code = slice(text, 0, colon)
-        var found = false
-        get_file_source_line(at.fileInfo, at.line) $(line) {
-            let nolint_pos = find(line, "nolint")
-            if (nolint_pos >= 0) {
-                found = find(line, code, nolint_pos) >= 0
-            }
-        }
-        return found
+        return is_lint_suppressed(at, extract_lint_code(text))
     }
 
     def style_warning(text : string; at : LineInfo) : void {
         // Suppress warnings for macro-generated functions — the user didn't write that code.
         if (current_function != null && current_function.flags.generated) return
         let key = self->location_key(at)
-        if (reported_locations |> has_value(key)) return
-        reported_locations |> push(key)
+        if (key_exists(reported_locations, key)) return
+        reported_locations |> insert(key)
         if (self->is_suppressed(text, at)) return
         warning_count++
         var msg = text

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -290,6 +290,7 @@ def document_module_rtti(root : string) {
         group_by_regex("Context and mutex locking", mod, %regex~(lock_this_context|lock_context|lock_mutex)$%%),
         group_by_regex("Runtime data access", mod, %regex~(get_table_key_index)$%%),
         group_by_regex("Tuple and variant access", mod, %regex~(get_tuple_field_offset|get_variant_field_offset)$%%),
+        group_by_regex("Lint suppression", mod, %regex~(rtti_get_source_line|rtti_is_nolint_suppressed|is_lint_suppressed|extract_lint_code)$%%),
         group_by_regex("Iteration", mod, %regex~(each)$%%))
     documents("Runtime type information library", mod, "rtti.rst", groups)
 }

--- a/doc/source/stdlib/handmade/function-rtti-rtti_get_source_line-0xca7c08231f8fd161.rst
+++ b/doc/source/stdlib/handmade/function-rtti-rtti_get_source_line-0xca7c08231f8fd161.rst
@@ -1,0 +1,1 @@
+Returns the source text of a single line (1-based) from a FileInfo as a freshly-allocated string. Uses the lazy line-offset index on FileInfo, so per-call cost is O(1) after the first lookup. Returns null on null FileInfo, line 0, or out-of-range line.

--- a/doc/source/stdlib/handmade/function-rtti-rtti_is_nolint_suppressed-0xc6b8173eb6834e81.rst
+++ b/doc/source/stdlib/handmade/function-rtti-rtti_is_nolint_suppressed-0xc6b8173eb6834e81.rst
@@ -1,0 +1,1 @@
+Returns true if the source line at the given FileInfo+line carries a ``// nolint:CODE`` directive listing ``code``. Recognizes single-code, comma-separated lists, repeated ``nolint:`` directives, and directives mid-comment. The canonical low-level entry point behind ``is_lint_suppressed`` for custom lint visitors.

--- a/include/daScript/simulate/aot_builtin_rtti.h
+++ b/include/daScript/simulate/aot_builtin_rtti.h
@@ -157,6 +157,9 @@ namespace das {
     DAS_API void lockAnyContext ( Context & ctx, const TBlock<void> & block, Context * context, LineInfoArg * lineInfo );
     DAS_API void lockAnyMutex ( recursive_mutex & rm, const TBlock<void> & block, Context * context, LineInfoArg * lineInfo );
 
+    DAS_API char * rtti_get_source_line ( FileInfo * info, uint32_t line, Context * context, LineInfoArg * at );
+    DAS_API bool rtti_is_nolint_suppressed ( FileInfo * info, uint32_t line, const char * code, Context * context, LineInfoArg * at );
+
     DAS_API TSequence<VarInfo&> each_FuncInfo ( FuncInfo & st, Context * context, LineInfoArg * at );
     DAS_API TSequence<const VarInfo&> each_const_FuncInfo ( const FuncInfo & st, Context * context, LineInfoArg * at );
     DAS_API TSequence<VarInfo&> each_StructInfo ( StructInfo & st, Context * context, LineInfoArg * at );

--- a/include/daScript/simulate/debug_info.h
+++ b/include/daScript/simulate/debug_info.h
@@ -116,17 +116,24 @@ namespace das
 
     struct DAS_API FileInfo {
     public:
-        virtual void freeSourceData() { }
+        virtual void freeSourceData() { lineOffsets.clear(); lineIndexBuilt = false; }
         virtual ~FileInfo() { freeSourceData(); }
         void reserveProfileData();
         virtual void getSourceAndLength ( const char * & src, uint32_t & len ) { src=nullptr; len=0; }
         virtual void serialize ( AstSerializer & ser );
+        // Lazy byte-offset index of line starts. lineOffsets[i] = start of line i+1.
+        // Built on first getLine call via getSourceAndLength. O(N) one-time, O(1) per query.
+        void buildLineIndex();
+        bool getLine ( uint32_t line, const char * & begin, uint32_t & len );
         string                name;
         int32_t               tabSize = 4;
 #if DAS_ENABLE_PROFILER
     public:
         vector<uint64_t>      profileData;
 #endif
+    protected:
+        vector<uint32_t>      lineOffsets;
+        bool                  lineIndexBuilt = false;
     };
     typedef unique_ptr<FileInfo> FileInfoPtr;
 

--- a/mouse-data/docs/canonical-lint-suppression-api-rtti.md
+++ b/mouse-data/docs/canonical-lint-suppression-api-rtti.md
@@ -1,0 +1,39 @@
+---
+slug: canonical-lint-suppression-api-rtti
+title: What is the canonical lint suppression API for a custom lint visitor (e.g. imgui_lint, decs_lint, user-written [lint_macro])?
+created: 2026-05-15
+last_verified: 2026-05-15
+links: []
+---
+
+**`require daslib/rtti`** and call **`is_lint_suppressed(at : LineInfo; code : string) : bool`** ([daslib/rtti.das:201](daslib/rtti.das#L201), landed 2026-05-15). Pair it with **`extract_lint_code(text : string) : string`** ([daslib/rtti.das:208](daslib/rtti.das#L208)) which pulls the `LINT001` prefix off a message like `"LINT001: foo"`.
+
+Inside a lint visitor (any `AstVisitor` subclass), the canonical form of the suppression gate is the single line:
+
+```das
+def is_suppressed(text : string; at : LineInfo) : bool {
+    return is_lint_suppressed(at, extract_lint_code(text))
+}
+```
+
+The three in-tree visitors ([daslib/lint.das:63](daslib/lint.das#L63), [daslib/perf_lint.das:127](daslib/perf_lint.das#L127), [daslib/style_lint.das:65](daslib/style_lint.das#L65)) all use exactly this shape after the unification PR; downstream lint modules should follow.
+
+Under the hood: `rtti_is_nolint_suppressed(fi, line, code)` — a C-side pointer-math scanner in `src/builtin/module_builtin_rtti.cpp` — does the whole parse with no allocation. The line is fetched via the new `FileInfo` line index ([[paranoid-collect-slow-fileinfo-line-index]]), so per-warning cost is O(line_length) ≈ tens of byte-compares.
+
+## Practical implication
+
+Don't roll your own `is_suppressed`. The three pre-unification copies in lint.das / perf_lint.das / style_lint.das (which called `get_file_source_line` + interpreted `find` chains) were 14 lines each and slow; the unified one is 1 line and fast. When writing imgui_lint / decs_lint / user lint rules, this is the entire suppression layer.
+
+If you need the parsed code list yourself (e.g. for tooling that reports "suppressed-but-not-fired"), you can drop down to `rtti_is_nolint_suppressed(fi, line, code)` directly — it's bound under rtti_core. The wrapper just adds the null-guards on `at.fileInfo` / `at.line`.
+
+## Questions
+
+- How do I add lint-suppression support to a custom AstVisitor lint pass?
+- What's the canonical way for an `imgui_lint`-style module to handle `// nolint:CODE`?
+- Where do I get `is_lint_suppressed` from? Which module / which require?
+- What are extract_lint_code and is_lint_suppressed in daslib/rtti.das, and when to use them?
+
+## See also
+
+- [[paranoid-collect-slow-fileinfo-line-index]] — the FileInfo line-index that makes per-warning suppression cheap
+- [[nolint-recognized-forms]] — exactly which `// nolint:CODE` forms the C-side scanner accepts

--- a/mouse-data/docs/nolint-recognized-forms.md
+++ b/mouse-data/docs/nolint-recognized-forms.md
@@ -1,0 +1,44 @@
+---
+slug: nolint-recognized-forms
+title: What `// nolint:CODE` forms does the lint-suppression scanner actually accept?
+created: 2026-05-15
+last_verified: 2026-05-15
+links: []
+---
+
+The C-side scanner `rtti_is_nolint_suppressed` in [src/builtin/module_builtin_rtti.cpp](src/builtin/module_builtin_rtti.cpp) (landed 2026-05-15) recognizes **all** of these forms:
+
+| Form | Suppresses |
+|---|---|
+| `// nolint:LINT001` | LINT001 |
+| `// nolint:LINT001,LINT002,LINT003` | each listed code (comma-separated) |
+| `// nolint:LINT001 , LINT002` | both (whitespace around commas/tokens tolerated) |
+| `// nolint:LINT001 nolint:LINT002` | both (repeated directives, space-separated) |
+| `// nolint:PERF003 single access for operator parsing` | PERF003 (trailing prose ignored) |
+| `// free prose nolint:LINT001 more prose` | LINT001 (lenient — directive anywhere after `//`) |
+
+**Not** suppressed:
+- `// nolint` (no colon, no code) → matches nothing.
+- A line with no `//` at all → no suppression.
+- Substring traps: `// nolint:LINT001` does NOT match a query for `LINT00` — exact-token equality.
+
+The space-separated repeated form was discovered in production code at [modules/dasPEG/peg/parser_generator.das:543](modules/dasPEG/peg/parser_generator.das#L543) (`// nolint:LINT002 nolint:LINT003`) — pre-unification, the loose JS-style scanner accepted it; the strict comma-only first cut broke it. The shipped scanner walks the rest of the comment looking for `nolint:` occurrences and parses a comma-list after each.
+
+## Practical implication
+
+Prefer **`// nolint:CODE1,CODE2`** (comma form) for new code — most compact, most readable. The repeated-`nolint:` form exists for backward compatibility; don't introduce it gratuitously. Single-code is by far the most common in the tree (~50 sites in daslib alone, all single).
+
+If you're writing tooling that *generates* nolint directives (auto-fix tools, codemods), emit the comma form. The scanner handles both, but readers expect comma.
+
+## Questions
+
+- What `nolint` formats does the lint scanner support?
+- Can I put multiple codes on one nolint directive? What separators?
+- Does `// nolint:LINT001 nolint:LINT002` (space-separated) work?
+- Why doesn't `// nolint` alone (no `:CODE`) suppress anything?
+- Is the nolint match strict or fuzzy on the code token (substring traps)?
+
+## See also
+
+- [[canonical-lint-suppression-api-rtti]] — the `is_lint_suppressed` daslang wrapper that calls this scanner
+- [[paranoid-collect-slow-fileinfo-line-index]] — the FileInfo line-index that makes per-warning lookup O(1)

--- a/mouse-data/docs/paranoid-collect-slow-fileinfo-line-index.md
+++ b/mouse-data/docs/paranoid-collect-slow-fileinfo-line-index.md
@@ -1,0 +1,29 @@
+---
+slug: paranoid-collect-slow-fileinfo-line-index
+title: Why is paranoid_collect (and perf_lint_collect / style_lint_collect) slow on real files — what was the structural cost?
+created: 2026-05-15
+last_verified: 2026-05-15
+links: []
+---
+
+**`get_file_source_line` did O(line_offset) per call**: a linear scan from byte 0 of source counting `\n` ([src/builtin/module_builtin_ast.cpp:983](src/builtin/module_builtin_ast.cpp#L983), pre-2026-05-15). No line-offset index existed on `FileInfo` ([include/daScript/simulate/debug_info.h:117](include/daScript/simulate/debug_info.h#L117)). The three lint visitors call `is_suppressed` → `get_file_source_line` per candidate warning, and style_lint's per-line scanners (`source_line_between`, `check_defer_pipe`, `scan_file_lines`) call it per line of a range — so lint cost was O(warnings × file_size) at best, O(L²) at worst on `scan_file_lines`.
+
+**Fix (PR landing 2026-05-15):** lazy `vector<uint32_t> lineOffsets` on `FileInfo` with `buildLineIndex()` / `getLine(line, begin, len)` — O(1) line fetch after first call. `get_file_source_line` rewritten to use it; every existing caller benefits transparently.
+
+Secondary cost #2 fixed in same PR: `reported_locations : array<uint64>` with linear `has_value` → `table<uint64>` (set form). Was O(N²) over N warnings in perf_lint + style_lint.
+
+## Practical implication
+
+If you're touching `FileInfo` source-access internals, call `info->getLine(...)` not `getSourceAndLength(...)` + hand-walk. If you're writing a new lint visitor and need to scan source lines (defer-pipe-style patterns), one `getLine` per line is now cheap — no need for "read whole file once, scan in memory" workarounds.
+
+## Questions
+
+- Why is paranoid_collect / perf_lint_collect / style_lint_collect dog-slow on big files?
+- What is the cost of get_file_source_line and how is it amortized?
+- How does FileInfo fetch a source line by 1-based line number after the line index landed?
+- Why does scan_file_lines (style_lint comment-hygiene scan) hit O(L²) on master before the line index?
+
+## See also
+
+- [[canonical-lint-suppression-api-rtti]] — the `is_lint_suppressed` / `extract_lint_code` helpers in daslib/rtti.das
+- [[nolint-recognized-forms]] — what `// nolint:CODE` patterns the C-side scanner accepts

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -981,26 +981,13 @@ namespace das {
     }
 
     void get_file_source_line(FileInfo * info, uint32_t line, const TBlock<void,TTemporary<const char *>> & blk, Context * context, LineInfoArg * at) {
-        if ( !info || line == 0 ) return;
-        const char * src = nullptr;
+        if ( !info ) return;
+        const char * begin = nullptr;
         uint32_t len = 0;
-        info->getSourceAndLength(src, len);
-        if ( !src || len == 0 ) return;
-        uint32_t curLine = 1;
-        const char * lineStart = src;
-        const char * srcEnd = src + len;
-        while ( lineStart < srcEnd && curLine < line ) {
-            if ( *lineStart == '\n' ) curLine++;
-            lineStart++;
-        }
-        if ( curLine != line ) return;
-        const char * lineEnd = lineStart;
-        while ( lineEnd < srcEnd && *lineEnd != '\n' && *lineEnd != '\r' ) lineEnd++;
-        // make a temporary null-terminated copy on the stack
-        uint32_t lineLen = uint32_t(lineEnd - lineStart);
-        char * tmp = (char *)alloca(lineLen + 1);
-        memcpy(tmp, lineStart, lineLen);
-        tmp[lineLen] = 0;
+        if ( !info->getLine(line, begin, len) ) return;
+        char * tmp = (char *)alloca(len + 1);
+        memcpy(tmp, begin, len);
+        tmp[len] = 0;
         vec4f args[1];
         args[0] = cast<const char *>::from(tmp);
         context->invoke(blk, args, nullptr, at);

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -1603,6 +1603,54 @@ namespace das {
         }
     }
 
+    char * rtti_get_source_line ( FileInfo * info, uint32_t line, Context * context, LineInfoArg * at ) {
+        if ( !info ) return nullptr;
+        const char * begin = nullptr;
+        uint32_t len = 0;
+        if ( !info->getLine(line, begin, len) ) return nullptr;
+        return context->allocateString(begin, len, at);
+    }
+
+    // C-style scanner; no std::regex, no allocation. Matches all of:
+    //   // nolint:CODE                          -> suppresses CODE
+    //   // nolint:CODE1,CODE2,...               -> comma-separated list
+    //   // nolint:CODE1 nolint:CODE2            -> repeated directives, space-separated
+    //   // free-form prose nolint:CODE more     -> directive anywhere after the `//`
+    // After the `//`, we walk the rest of the line looking for `nolint:` occurrences
+    // and parse a comma-list of codes after each one. Any match wins.
+    bool rtti_is_nolint_suppressed ( FileInfo * info, uint32_t line, const char * code, Context * /*context*/, LineInfoArg * /*at*/ ) {
+        if ( !info || !code || !*code ) return false;
+        const char * begin = nullptr;
+        uint32_t len = 0;
+        if ( !info->getLine(line, begin, len) ) return false;
+        const char * end = begin + len;
+        // locate "//"
+        const char * p = begin;
+        while ( p + 1 < end && !(p[0] == '/' && p[1] == '/') ) p++;
+        if ( p + 1 >= end ) return false;
+        p += 2;
+        static const char NOLINT[] = "nolint:";
+        constexpr uint32_t NOLINT_LEN = sizeof(NOLINT) - 1;
+        const uint32_t codeLen = uint32_t(strlen(code));
+        // walk the rest of the line; each `nolint:` opens a comma-list of codes.
+        while ( p + NOLINT_LEN <= end ) {
+            if ( memcmp(p, NOLINT, NOLINT_LEN) != 0 ) { p++; continue; }
+            p += NOLINT_LEN;
+            // comma-list parse
+            while ( p < end ) {
+                while ( p < end && (*p == ' ' || *p == '\t') ) p++;
+                const char * tokStart = p;
+                while ( p < end && *p != ',' && *p != ' ' && *p != '\t' ) p++;
+                uint32_t tokLen = uint32_t(p - tokStart);
+                if ( tokLen == codeLen && memcmp(tokStart, code, codeLen) == 0 ) return true;
+                while ( p < end && (*p == ' ' || *p == '\t') ) p++;
+                if ( p < end && *p == ',' ) { p++; continue; }
+                break;
+            }
+        }
+        return false;
+    }
+
     class Module_Rtti : public Module {
     public:
         template <typename RecAnn>
@@ -1903,6 +1951,12 @@ namespace das {
             addExtern<DAS_BIND_FUN(each_const_EnumInfo),SimNode_ExtFuncCallAndCopyOrMove,explicitConstArgFn>(*this, lib, "each",
                 SideEffects::none, "each_const_EnumInfo")
                     ->args({"info","context","at"});
+            addExtern<DAS_BIND_FUN(rtti_get_source_line)>(*this, lib, "rtti_get_source_line",
+                SideEffects::accessExternal, "rtti_get_source_line")
+                    ->args({"info","line","context","at"});
+            addExtern<DAS_BIND_FUN(rtti_is_nolint_suppressed)>(*this, lib, "rtti_is_nolint_suppressed",
+                SideEffects::accessExternal, "rtti_is_nolint_suppressed")
+                    ->args({"info","line","code","context","at"});
             // lets make sure its all aot ready
             verifyAotReady();
         }

--- a/src/simulate/debug_info.cpp
+++ b/src/simulate/debug_info.cpp
@@ -770,11 +770,48 @@ namespace das
     }
 
     void TextFileInfo::freeSourceData() {
+        FileInfo::freeSourceData();
         if ( source ) {
             das_aligned_free16((void*)source);
             source = nullptr;
             sourceLength = 0;
         }
+    }
+
+    void FileInfo::buildLineIndex() {
+        if ( lineIndexBuilt ) return;
+        lineIndexBuilt = true;
+        const char * src = nullptr;
+        uint32_t len = 0;
+        getSourceAndLength(src, len);
+        if ( !src || len == 0 ) return;
+        lineOffsets.reserve(len / 40 + 8);
+        lineOffsets.push_back(0);
+        for ( uint32_t i = 0; i < len; ++i ) {
+            if ( src[i] == '\n' ) {
+                lineOffsets.push_back(i + 1);
+            }
+        }
+    }
+
+    bool FileInfo::getLine ( uint32_t line, const char * & begin, uint32_t & len ) {
+        begin = nullptr;
+        len = 0;
+        if ( line == 0 ) return false;
+        if ( !lineIndexBuilt ) buildLineIndex();
+        if ( line > lineOffsets.size() ) return false;
+        const char * src = nullptr;
+        uint32_t srcLen = 0;
+        getSourceAndLength(src, srcLen);
+        if ( !src || srcLen == 0 ) return false;
+        uint32_t lineStart = lineOffsets[line - 1];
+        uint32_t lineEnd = ( line < lineOffsets.size() ) ? ( lineOffsets[line] - 1 ) : srcLen;
+        if ( lineEnd > lineStart && src[lineEnd - 1] == '\r' ) {
+            lineEnd--;
+        }
+        begin = src + lineStart;
+        len = lineEnd - lineStart;
+        return true;
     }
 
     bool FileAccess::isSameFileName ( const string & a, const string & b ) const {

--- a/tests-cpp/small/test_file_info_line_index.cpp
+++ b/tests-cpp/small/test_file_info_line_index.cpp
@@ -1,0 +1,159 @@
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+#include "daScript/simulate/debug_info.h"
+#include "daScript/simulate/aot_builtin_rtti.h"
+
+#include <cstring>
+
+using namespace das;
+
+namespace {
+
+// Build a TextFileInfo over a literal source buffer. `own=false` means the
+// FileInfo doesn't try to free our string-literal storage.
+static TextFileInfo make_info(const char * src) {
+    return TextFileInfo(src, uint32_t(strlen(src)), /*own*/false);
+}
+
+// Pull `line` out of `info` as a NUL-terminated std::string for easy CHECK comparisons.
+static string line_at(FileInfo & info, uint32_t line) {
+    const char * begin = nullptr;
+    uint32_t len = 0;
+    if ( !info.getLine(line, begin, len) ) return "<<miss>>";
+    return string(begin, len);
+}
+
+}  // namespace
+
+TEST_CASE("FileInfo::getLine basic cases") {
+    SUBCASE("three lines with LF endings") {
+        auto info = make_info("alpha\nbeta\ngamma\n");
+        CHECK(line_at(info, 1) == "alpha");
+        CHECK(line_at(info, 2) == "beta");
+        CHECK(line_at(info, 3) == "gamma");
+    }
+
+    SUBCASE("last line with no trailing newline") {
+        auto info = make_info("alpha\nbeta\ngamma");
+        CHECK(line_at(info, 3) == "gamma");
+    }
+
+    SUBCASE("out-of-range line returns false") {
+        auto info = make_info("alpha\nbeta\n");
+        const char * begin = nullptr;
+        uint32_t len = 0;
+        CHECK_FALSE(info.getLine(0, begin, len));
+        CHECK_FALSE(info.getLine(99, begin, len));
+    }
+
+    SUBCASE("empty source returns false") {
+        auto info = make_info("");
+        const char * begin = nullptr;
+        uint32_t len = 0;
+        CHECK_FALSE(info.getLine(1, begin, len));
+    }
+
+    SUBCASE("single line, no trailing newline") {
+        auto info = make_info("only");
+        CHECK(line_at(info, 1) == "only");
+        const char * begin = nullptr;
+        uint32_t len = 0;
+        CHECK_FALSE(info.getLine(2, begin, len));
+    }
+
+    SUBCASE("CRLF endings — trailing CR is stripped") {
+        auto info = make_info("alpha\r\nbeta\r\n");
+        CHECK(line_at(info, 1) == "alpha");
+        CHECK(line_at(info, 2) == "beta");
+    }
+
+    SUBCASE("buildLineIndex is idempotent") {
+        auto info = make_info("a\nb\nc\n");
+        info.buildLineIndex();
+        info.buildLineIndex();
+        CHECK(line_at(info, 2) == "b");
+    }
+}
+
+TEST_CASE("rtti_is_nolint_suppressed truth table") {
+    auto info = make_info(
+        // line 1: bare suppression for LINT001
+        "let x = 1 // nolint:LINT001\n"
+        // line 2: comma-list suppression for LINT001,LINT002
+        "let y = 2 // nolint:LINT001,LINT002\n"
+        // line 3: whitespace around comma-list tokens
+        "let z = 3 // nolint:LINT001 , LINT002\n"
+        // line 4: trailing prose after the suppressed code
+        "let w = 4 // nolint:PERF003 single access for operator parsing\n"
+        // line 5: no `//`
+        "let q = 5\n"
+        // line 6: `// nolint` without `:CODE`
+        "let r = 6 // nolint\n"
+        // line 7: substring trap — LINT00 must not match LINT001
+        "let s = 7 // nolint:LINT001\n"
+        // line 8: repeated `nolint:` directives, space-separated
+        "let r2 = 8 // nolint:LINT002 nolint:LINT003\n"
+        // line 9: directive mid-comment (lenient match anywhere after //)
+        "let r3 = 9 // free prose nolint:PERF018 trailing words\n"
+    );
+
+    auto suppressed = [&](uint32_t line, const char * code) {
+        return rtti_is_nolint_suppressed(&info, line, code, nullptr, nullptr);
+    };
+
+    SUBCASE("single-code line") {
+        CHECK(suppressed(1, "LINT001"));
+        CHECK_FALSE(suppressed(1, "LINT002"));
+    }
+
+    SUBCASE("comma-list matches both") {
+        CHECK(suppressed(2, "LINT001"));
+        CHECK(suppressed(2, "LINT002"));
+        CHECK_FALSE(suppressed(2, "LINT003"));
+    }
+
+    SUBCASE("whitespace around tokens tolerated") {
+        CHECK(suppressed(3, "LINT001"));
+        CHECK(suppressed(3, "LINT002"));
+    }
+
+    SUBCASE("trailing prose after code is fine") {
+        CHECK(suppressed(4, "PERF003"));
+        CHECK_FALSE(suppressed(4, "single"));
+    }
+
+    SUBCASE("no comment at all -> false") {
+        CHECK_FALSE(suppressed(5, "LINT001"));
+    }
+
+    SUBCASE("bare `// nolint` without colon -> false") {
+        CHECK_FALSE(suppressed(6, "LINT001"));
+    }
+
+    SUBCASE("substring trap: LINT00 must NOT match LINT001") {
+        CHECK_FALSE(suppressed(7, "LINT00"));
+        CHECK(suppressed(7, "LINT001"));
+    }
+
+    SUBCASE("null / empty code -> false") {
+        CHECK_FALSE(rtti_is_nolint_suppressed(&info, 1, nullptr, nullptr, nullptr));
+        CHECK_FALSE(rtti_is_nolint_suppressed(&info, 1, "", nullptr, nullptr));
+    }
+
+    SUBCASE("null info -> false") {
+        CHECK_FALSE(rtti_is_nolint_suppressed(nullptr, 1, "LINT001", nullptr, nullptr));
+    }
+
+    SUBCASE("repeated `nolint:` directives in one comment, space-separated") {
+        CHECK(suppressed(8, "LINT002"));
+        CHECK(suppressed(8, "LINT003"));
+        CHECK_FALSE(suppressed(8, "LINT001"));
+    }
+
+    SUBCASE("directive can appear anywhere after `//`") {
+        CHECK(suppressed(9, "PERF018"));
+        CHECK_FALSE(suppressed(9, "free"));
+        CHECK_FALSE(suppressed(9, "prose"));
+    }
+}

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -338,6 +338,15 @@ SET(AOT_DASLIB_TEST_FILES
     tests/daslib/clargs_test.das
 )
 
+# AOT for lint test files
+FILE(GLOB AOT_LINT_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/lint/*.das")
+# Exclude _*.das fixture files (consumed at runtime via compile_file, not invoked by dastest)
+list(FILTER AOT_LINT_FILES EXCLUDE REGEX "/_")
+
+# AOT for rtti test files
+FILE(GLOB AOT_RTTI_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/rtti/*.das")
+list(FILTER AOT_RTTI_FILES EXCLUDE REGEX "/_")
+
 # AOT for language test files
 FILE(GLOB AOT_LANGUAGE_TEST_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/language/*.das")
 # Exclude expect-error tests and no_aot files
@@ -573,6 +582,14 @@ add_custom_target(test_aot_strings)
 SET(STRINGS_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_STRINGS_FILES}" STRINGS_AOT_GENERATED_SRC test_aot_strings daslang)
 
+add_custom_target(test_aot_lint)
+SET(LINT_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_LINT_FILES}" LINT_AOT_GENERATED_SRC test_aot_lint daslang)
+
+add_custom_target(test_aot_rtti)
+SET(RTTI_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_RTTI_FILES}" RTTI_AOT_GENERATED_SRC test_aot_rtti daslang)
+
 add_custom_target(test_aot_template)
 SET(TEMPLATE_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_TEMPLATE_FILES}" TEMPLATE_AOT_GENERATED_SRC test_aot_template daslang)
@@ -732,6 +749,8 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
     ${SOA_AOT_GENERATED_SRC}
     ${SPOOF_AOT_GENERATED_SRC}
     ${STRINGS_AOT_GENERATED_SRC}
+    ${LINT_AOT_GENERATED_SRC}
+    ${RTTI_AOT_GENERATED_SRC}
     ${TEMPLATE_AOT_GENERATED_SRC}
     ${TYPE_TRAITS_AOT_GENERATED_SRC}
     ${URI_AOT_GENERATED_SRC}
@@ -775,6 +794,7 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_option
     test_aot_regex
     test_aot_delegate test_aot_safe_addr test_aot_soa test_aot_spoof test_aot_strings
+    test_aot_lint test_aot_rtti
     test_aot_template test_aot_type_traits test_aot_uri
     test_aot_lpipe
     test_aot_jit

--- a/tests/lint/_nolint_lint003_fixture.das
+++ b/tests/lint/_nolint_lint003_fixture.das
@@ -1,0 +1,13 @@
+options gen2
+
+// Fixture for test_nolint_suppression.das — three LINT003-eligible `var`
+// declarations; two carry `// nolint:LINT003` suppressions. Paranoid lint
+// should report exactly one issue.
+
+[export]
+def fixture_function() : int {
+    var should_be_const = 42
+    var suppressed_a = 1            // nolint:LINT003
+    var suppressed_b = 2            // nolint:LINT003
+    return should_be_const + suppressed_a + suppressed_b
+}

--- a/tests/lint/test_nolint_suppression.das
+++ b/tests/lint/test_nolint_suppression.das
@@ -1,0 +1,45 @@
+options gen2
+
+require dastest/testing_boost
+require daslib/ast
+require daslib/lint
+require strings
+
+def fixture_path() : string {
+    return "{get_das_root()}/tests/lint/_nolint_lint003_fixture.das"
+}
+
+def compile_and_collect(t : T?; blk : block<(issues : array<string>; count : int) : void>) {
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.export_all = true
+            cop.lint_check = true
+            cop.no_optimizations = true
+            cop.no_infer_time_folding = true
+            compile_file(fixture_path(), access, unsafe(addr(mg)), cop) $(ok; program; issues) {
+                if (!ok) {
+                    t |> failure("fixture failed to compile: {issues}")
+                    return
+                }
+                var collected : array<string>
+                let count = paranoid_collect(program, collected)
+                invoke(blk, collected, count)
+            }
+        }
+    }
+}
+
+[test]
+def test_nolint_lint003_suppression(t : T?) {
+    t |> run("// nolint:LINT003 suppresses the matched variable") @@(t : T?) {
+        compile_and_collect(t) $(issues; count) {
+            // Three `var` declarations are LINT003-eligible; two carry
+            // `// nolint:LINT003`, so exactly one should remain.
+            t |> equal(count, 1)
+            t |> equal(length(issues), 1)
+            t |> success(find(issues[0], "LINT003") >= 0)
+            t |> success(find(issues[0], "should_be_const") >= 0)
+        }
+    }
+}

--- a/tests/rtti/test_lint_suppression.das
+++ b/tests/rtti/test_lint_suppression.das
@@ -1,0 +1,20 @@
+options gen2
+
+require dastest/testing_boost
+require daslib/rtti
+
+[test]
+def test_extract_lint_code(t : T?) {
+    t |> run("strips prefix before first colon") @@(t : T?) {
+        t |> equal(extract_lint_code("LINT001: foo bar"), "LINT001")
+        t |> equal(extract_lint_code("PERF018: nested loop"), "PERF018")
+        t |> equal(extract_lint_code("STYLE005: early-exit braces"), "STYLE005")
+    }
+    t |> run("empty string when no colon present") @@(t : T?) {
+        t |> equal(extract_lint_code("no colon here"), "")
+        t |> equal(extract_lint_code(""), "")
+    }
+    t |> run("first colon wins") @@(t : T?) {
+        t |> equal(extract_lint_code("LINT003: foo: bar: baz"), "LINT003")
+    }
+}


### PR DESCRIPTION
## Summary

`paranoid_collect` (and its `perf_lint_collect` / `style_lint_collect` twins) are dog-slow on real files. Root cause: `get_file_source_line` walked from byte 0 every call counting `\n`, and every candidate lint warning called `is_suppressed → get_file_source_line`. Per-file cost was roughly **O(warnings × file_size)**, and `style_lint`'s per-line scanners (`source_line_between`, `check_defer_pipe`, `scan_file_lines`) amplified this to **O(L²)** on big files.

Three changes:

### 1. Lazy line-offset index on `FileInfo`

[include/daScript/simulate/debug_info.h](include/daScript/simulate/debug_info.h), [src/simulate/debug_info.cpp](src/simulate/debug_info.cpp), [src/builtin/module_builtin_ast.cpp](src/builtin/module_builtin_ast.cpp).

`FileInfo::buildLineIndex()` builds `vector<uint32_t>` of line-start byte offsets on first call; `FileInfo::getLine(line, begin, len)` is O(1) thereafter. `get_file_source_line` rewritten to use it. **Every existing caller** (3 lint modules + 8 sites in `utils/fix-lint-errors`) benefits transparently. ~4 bytes per source line per file, lazy — no perf hit for non-lint paths.

### 2. Unified lint-suppression API

C-side scanner in `rtti_core` (no `std::regex`, no allocation — pointer math per the user's request):
- `rtti_get_source_line(fi, line)` — fresh string copy of a source line, O(1) after first build.
- `rtti_is_nolint_suppressed(fi, line, code)` — parses `// nolint:CODE` directives in the comment portion of a line.

daslang wrappers in [daslib/rtti.das](daslib/rtti.das):
- `is_lint_suppressed(at : LineInfo; code : string) : bool` — null-safe wrapper.
- `extract_lint_code(text : string) : string` — pulls the `LINT001` prefix off a message.

The three in-tree lint visitors ([daslib/lint.das](daslib/lint.das), [daslib/perf_lint.das](daslib/perf_lint.das), [daslib/style_lint.das](daslib/style_lint.das)) collapse their `is_suppressed` from ~14 lines each to:

```das
def is_suppressed(text : string; at : LineInfo) : bool {
    return is_lint_suppressed(at, extract_lint_code(text))
}
```

Future custom lints (`imgui_lint`, `decs_lint`, user `[lint_macro]` code) just `require daslib/rtti` and call `is_lint_suppressed` — no more per-module suppression duplication.

**Recognized `nolint` forms** (all backward-compatible with existing usage in tree):
- `// nolint:CODE` — single
- `// nolint:CODE1,CODE2,CODE3` — comma-separated
- `// nolint:CODE1 nolint:CODE2` — repeated directives (e.g. `modules/dasPEG/peg/parser_generator.das:543`)
- `// prose nolint:CODE more prose` — directive anywhere after `//`
- Substring traps rejected: `LINT00` does NOT match `LINT001`.

### 3. Dedup `array<uint64>` → `table<uint64>` (set form)

In `perf_lint` and `style_lint`. The old `reported_locations |> has_value(key)` was a linear scan — O(N²) over N warnings. Now O(1) hash lookup.

## Test plan

- [x] **C++ unit tests** (new): [tests-cpp/small/test_file_info_line_index.cpp](tests-cpp/small/test_file_info_line_index.cpp) — `FileInfo::getLine` truth table (LF/CRLF, idempotent build, out-of-range, single-line-no-newline) + `rtti_is_nolint_suppressed` truth table (all four nolint forms above, substring traps, null guards).
- [x] **daslang tests** (new): `tests/rtti/test_lint_suppression.das` (extract_lint_code) + `tests/lint/test_nolint_suppression.das` (end-to-end `paranoid_collect` over a 3-LINT003 fixture with 2 suppressions; asserts count == 1).
- [x] **AOT registration**: [tests/aot/CMakeLists.txt](tests/aot/CMakeLists.txt) wires the new dirs (`test_aot_lint`, `test_aot_rtti`) with `_*.das` fixture exclusion.
- [x] **Release + Debug** builds clean.
- [x] **ctest -L small**: 22/22 pass (including 2 new test cases).
- [x] **AOT sweep**: `tests/lint` 2/2, `tests/rtti` 4/4, `tests/daslib` 92/92, `tests/language` 939/939, `tests/strings` 361/361 — all green under `--use-aot`.
- [x] **MCP `format_file` + `lint`** clean on every touched `.das` file (the one residual `WARN` on `tests/lint/_nolint_lint003_fixture.das` is the LINT003 the test intentionally counts — `tests/` is not in the CI lint sweep).

**Wall-time on `tutorials/` (215 files, baseline → after):** 43.66s → 42.37s. Modest speedup because tutorials produce 0 lint warnings, so the per-warning fast path isn't exercised — the structural fix compounds dramatically on files with many warnings. Issue count exact match (0 → 0): no semantic drift in what's reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)