### PR TITLE
live_api_stdio: JSON-RPC 2.0 transport for live commands (no dasHV)

### DIFF
--- a/doc/source/reference/utils/daslang_live.rst
+++ b/doc/source/reference/utils/daslang_live.rst
@@ -13,7 +13,8 @@
 Edit a ``.das`` file, save it, and the running application picks up
 the changes instantly --- preserving windows, GPU state, game entities,
 and everything stored in the persistent byte store.  No restart, no
-lost state.  Applications range from games to REST APIs to MCP plugins.
+lost state.  Applications range from games to REST APIs to stdio
+JSON-RPC integrations and MCP plugins.
 
 .. contents::
    :local:
@@ -164,6 +165,15 @@ and ``daslang.exe`` (standalone).  Under ``daslang.exe`` the ``main()``
 function drives the loop; under ``daslang-live.exe`` the host calls
 ``init()``, ``update()``, and ``shutdown()`` directly.
 
+For a stdin/stdout JSON-RPC transport instead of HTTP, swap one require
+line and use ``examples/daslive/hello_stdio/``::
+
+   require live/live_api_stdio   // instead of live/live_api
+
+User commands (any ``[live_command]``) work identically over both
+transports. The two transports differ in wire protocol and in how
+built-in lifecycle commands are surfaced; see :ref:`stdio_api` below.
+
 
 Mode detection
 ==============
@@ -195,9 +205,9 @@ Lifecycle
 
 **Failed reload:**
 The host reverts to the old context, pauses execution, and stores the
-compilation error.  Retrieve it via ``GET /error`` or
-``get_last_error()``.  The next successful reload unpauses
-automatically.
+compilation error.  Retrieve it via ``GET /error``, the
+``last_error`` stdio command, or ``get_last_error()``.  The next
+successful reload unpauses automatically.
 
 **Runtime exception:**
 The host pauses, clears the persistent store (potentially corrupted),
@@ -271,7 +281,7 @@ Reload annotations
      - Called after recompile, before ``init()``.  Restore state here.
    * - ``[before_update]``
      - Called every frame before ``update()``.  Used internally by
-       ``live_api``.
+       ``live_api``, ``live_api_stdio``, and other transport agents.
 
 The host discovers annotated functions by name prefix
 (``__before_reload_*``, ``__after_reload_*``, ``__before_update_*``).
@@ -351,7 +361,7 @@ Helper modules
    * - ``live/decs_live``
      - Auto-serialization of DECS entities across reloads.
    * - ``live/live_commands``
-     - ``[live_command]`` annotation for REST-callable functions.
+     - ``[live_command]`` annotation for transport-callable functions.
    * - ``live/live_vars``
      - ``@live`` variable macro (auto-persistence).
    * - ``live/live_watch``
@@ -359,8 +369,17 @@ Helper modules
    * - ``live/live_watch_boost``
      - File watcher with diagnostic commands (recommended over
        ``live_watch``).
+   * - ``live/live_api_builtins``
+     - Built-in commands (``status``, ``last_error``, ``reload``,
+       ``reload_full``, ``pause``, ``unpause``, ``shutdown``).  Required
+       transitively by ``live_api_stdio`` so stdio clients can drive
+       lifecycle by name.  The HTTP transport exposes the same
+       operations as REST endpoints (``GET /status``, ``POST /reload``,
+       …) rather than pulling these built-ins in.
    * - ``live/live_api``
-     - REST API server on port 9090.
+     - REST API server on port 9090 (requires ``dasHV``).
+   * - ``live/live_api_stdio``
+     - JSON-RPC 2.0 over stdin/stdout. No ``dasHV`` dependency.
    * - ``live/audio_live``
      - Audio state persistence across reloads.
 
@@ -446,21 +465,43 @@ restored entities:
 ``live/live_commands``
 ----------------------
 
-Functions annotated ``[live_command]`` are callable via
-``POST /command``.  Signature:
-``def cmd_name(input : JsonValue?) : JsonValue?``.
-Convention: prefix with ``cmd_``.  The ``set_color`` command in the
-hello example above demonstrates the pattern.
+Functions annotated ``[live_command]`` are callable via any installed
+transport — HTTP ``POST /command`` or stdio
+``{"method":"name", ...}``.  Signature:
+``def cmd_name(input : JsonValue?) : JsonValue?``.  Convention: prefix
+with ``cmd_``.  The ``set_color`` command in the hello example above
+demonstrates the pattern.
+
+The built-in lifecycle commands (``status``, ``last_error``,
+``reload``, ``reload_full``, ``pause``, ``unpause``, ``shutdown``)
+live in ``live/live_api_builtins``.  They are pulled in by
+``live/live_api_stdio`` so stdio clients can invoke lifecycle
+operations by name.  The HTTP transport exposes the same operations
+as REST endpoints (``GET /status``, ``POST /reload``, …) — see below.
 
 
-REST API
-========
+Transports
+==========
+
+Two transport modules ship in-tree. Pick one — they coexist but the
+typical script requires only one:
+
+* ``live/live_api`` — HTTP REST API on a TCP port. Requires
+  ``dasHV``.  Lifecycle operations are surfaced as REST endpoints;
+  user ``[live_command]`` functions are reached via ``POST /command``.
+* ``live/live_api_stdio`` — JSON-RPC 2.0 over stdin/stdout. No
+  ``dasHV`` dependency; suitable for embedding in host processes that
+  drive the script via pipes.  Lifecycle and user commands are both
+  invoked by name in the ``method`` field.
+
+REST API (``live/live_api``)
+----------------------------
 
 ``require live/live_api`` starts an HTTP server on port 9090.
 Configure the port with ``live_api_set_port()`` before ``init()``.
 
 Endpoints
----------
+^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
@@ -499,7 +540,7 @@ Endpoints
      - JSON help with all endpoints and curl examples.
 
 curl examples
--------------
+^^^^^^^^^^^^^
 
 Check status::
 
@@ -516,6 +557,108 @@ Call a live command::
 
 When using the daslang MCP server, prefer ``live_*`` MCP tools over
 curl (see :ref:`utils_mcp`).
+
+
+.. _stdio_api:
+
+Stdio API (``live/live_api_stdio``)
+-----------------------------------
+
+``require live/live_api_stdio`` installs a debug agent that reads
+newline-delimited JSON-RPC 2.0 messages from ``stdin`` and writes
+responses to ``stdout``.  No HTTP server is started; no port is opened;
+no ``dasHV`` dependency.
+
+The ``method`` field is the live command name — any
+``[live_command]`` function plus the built-ins listed below.
+``params`` is passed verbatim to the command as its input
+``JsonValue?``.
+
+Request / response shape::
+
+   → {"jsonrpc":"2.0","id":1,"method":"status"}
+   ← {"jsonrpc":"2.0","id":1,"result":{"fps":60.0,"uptime":3.2,"paused":false,"dt":0.016,"has_error":false}}
+
+   → {"jsonrpc":"2.0","id":2,"method":"set_color","params":{"r":1.0,"g":0.0,"b":0.0}}
+   ← {"jsonrpc":"2.0","id":2,"result":"{\"r\": 1.0, \"g\": 0.0, \"b\": 0.0}"}
+
+   → {"method":"shutdown"}     ← (no response: notification)
+
+The ``result`` field embeds whatever JSON value the command returned —
+an object when the command returned an object (``status``), a string
+when the command returned a string (``set_color`` in the demo returns a
+``JV(string)`` so the result is a quoted JSON string), and so on.
+
+**Framing guarantee.**  The transport always writes exactly one
+response per line on stdout, with no embedded newlines in the envelope.
+``write_json`` pretty-prints by default, so the dispatch result is
+post-processed by ``compact_json_whitespace`` before being embedded in
+the envelope — whitespace outside string literals is stripped;
+whitespace inside ``"..."`` is preserved verbatim.
+
+**Notifications.**  Per JSON-RPC 2.0 §4.1, a request that omits the
+``id`` field is a *notification*: the server MUST NOT respond.
+``live_api_stdio`` honors this — fire-and-forget commands like
+``{"method":"shutdown"}`` produce no output, useful for clients that
+don't want to bookkeep a response.  An explicit ``"id":null`` is *not*
+a notification; the server responds with ``"id":null``.  Parse errors
+and invalid requests are *not* treated as notifications either — they
+emit ``-32700`` / ``-32600`` responses with ``"id":null`` so a buggy
+client doesn't hang waiting for a reply.
+
+**Permissive JSON-RPC subset.**  Two deviations from strict JSON-RPC 2.0
+to ease integration with real-world clients:
+
+* The ``jsonrpc`` member is **optional**.  Strict compliance would
+  reject ``{"id":1,"method":"status"}`` because the ``"jsonrpc":"2.0"``
+  field is missing — this transport accepts it.  Requests with a
+  different version (``"jsonrpc":"1.0"``) are also accepted.
+* All other JSON-RPC 2.0 rules are enforced: ``method`` is required and
+  must be a string, ``id`` must be string / number / null when present
+  (objects / arrays / booleans are rejected with ``-32600``), and
+  notifications produce no response.
+
+Error envelopes follow JSON-RPC 2.0 codes: ``-32700`` parse error,
+``-32600`` invalid request (missing/non-string ``method``).
+
+Available methods (built-ins from ``live/live_api_builtins``):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - method
+     - Description
+   * - ``status``
+     - JSON: ``fps``, ``uptime``, ``paused``, ``dt``, ``has_error``.
+   * - ``last_error``
+     - Last compilation error string (or JSON ``null`` if none).
+   * - ``reload``
+     - Incremental reload.
+   * - ``reload_full``
+     - Full recompile (clears ``@live`` vars).
+   * - ``pause``
+     - Pause execution.
+   * - ``unpause``
+     - Resume execution.
+   * - ``shutdown``
+     - Graceful shutdown.
+
+Any user-defined ``[live_command]`` is also callable by name.
+
+.. warning::
+
+   ``stdout`` is the response channel. Scripts that use this transport
+   must redirect ``print()`` to ``stderr`` or a log file — calling
+   ``print()`` from the script's main loop will interleave application
+   output with JSON-RPC responses and break clients that parse stdout
+   line-by-line.  ``daslang-live`` itself logs lifecycle messages to
+   ``stdout``; either silence them or have the client tolerate
+   non-JSON lines.
+
+The example at ``examples/daslive/hello_stdio/`` is the HTTP hello
+example with the single ``require`` line swapped — see the same
+``set_color`` command driven over stdio instead of ``POST /command``.
 
 
 CLI reference
@@ -552,6 +695,9 @@ Examples
      - Description
    * - ``examples/daslive/hello/``
      - Minimal GLFW window with background color tuning.
+   * - ``examples/daslive/hello_stdio/``
+     - Minimal stdio (JSON-RPC) variant of the hello example.
+       Same ``set_color`` command, no ``dasHV`` dependency.
    * - ``examples/daslive/triangle/``
      - DECS + OpenGL shaders, rotating triangle.
    * - ``examples/games/arcanoid/``

--- a/examples/daslive/hello_stdio/main.das
+++ b/examples/daslive/hello_stdio/main.das
@@ -1,0 +1,76 @@
+options gen2
+
+require live/glfw_live
+require opengl/opengl_boost
+require live/live_commands
+require live/live_api_stdio
+require daslib/json
+require daslib/json_boost
+require live_host
+
+// --- State ---
+
+var bg_r = 0.2f
+var bg_g = 0.3f
+var bg_b = 0.5f
+var frame_count : int = 0
+
+// --- Live commands ---
+
+[live_command]
+def set_color(input : JsonValue?) : JsonValue? {
+    if (input != null && input.value is _object) {
+        let tab & = unsafe(input.value as _object)
+        var rv = tab?["r"] ?? null
+        if (rv != null && rv.value is _number) {
+            bg_r = float(rv.value as _number)
+        }
+        var gv = tab?["g"] ?? null
+        if (gv != null && gv.value is _number) {
+            bg_g = float(gv.value as _number)
+        }
+        var bv = tab?["b"] ?? null
+        if (bv != null && bv.value is _number) {
+            bg_b = float(bv.value as _number)
+        }
+    }
+    return JV("\{\"r\": {bg_r}, \"g\": {bg_g}, \"b\": {bg_b}}")
+}
+
+// --- Lifecycle ---
+
+[export]
+def init() {
+    live_create_window("Hello daslive (stdio)", 640, 480)
+    if (!is_reload()) {
+        frame_count = 0
+    }
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    frame_count++
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(bg_r, bg_g, bg_b, 1.0)
+    glClear(GL_COLOR_BUFFER_BIT)
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_destroy_window()
+}
+
+// Dual-mode: also works with regular daslang.exe (stdio agent is inactive
+// when is_live_mode() is false, so this just runs the GL loop).
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/modules/dasLiveHost/.das_module
+++ b/modules/dasLiveHost/.das_module
@@ -6,7 +6,7 @@ def initialize(project_path : string) {
     if (das_is_dll_build()) {
         register_dynamic_module("{project_path}/dasModuleLiveHost.shared_module", "Module_LiveHost")
     }
-    let live_paths = ["live_commands", "live_api", "live_watch", "live_watch_boost", "decs_live", "live_vars"]
+    let live_paths = ["live_commands", "live_api", "live_api_builtins", "live_api_stdio", "live_watch", "live_watch_boost", "decs_live", "live_vars"]
     for (path in live_paths) {
         register_native_path("live", "{path}", "{project_path}/live/{path}.das")
     }

--- a/modules/dasLiveHost/CMakeLists.txt
+++ b/modules/dasLiveHost/CMakeLists.txt
@@ -13,7 +13,9 @@ IF ((NOT DAS_LIVE_HOST_INCLUDED) AND ((NOT ${DAS_LIVE_HOST_DISABLED}) OR (NOT DE
 
     ADD_MODULE_CPP(LiveHost)
     ADD_MODULE_DAS(live live live_commands)
+    ADD_MODULE_DAS(live live live_api_builtins)
     ADD_MODULE_DAS(live live live_api)
+    ADD_MODULE_DAS(live live live_api_stdio)
     ADD_MODULE_DAS(live live live_watch)
     ADD_MODULE_DAS(live live decs_live)
     ADD_MODULE_LIB(libDasModuleLiveHost dasModuleLiveHost ${DAS_LIVE_HOST_MODULE_SRC})

--- a/modules/dasLiveHost/live/live_api_builtins.das
+++ b/modules/dasLiveHost/live/live_api_builtins.das
@@ -1,0 +1,81 @@
+options gen2
+options rtti
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+options indenting = 4
+options strict_smart_pointers = true
+
+module live_api_builtins shared public
+
+//! Transport-agnostic built-in live commands.
+//!
+//! Registers the lifecycle/status commands as `[live_command]`s so any
+//! transport that routes through `dispatch_command` (HTTP via `live_api`,
+//! stdin/stdout JSON-RPC via `live_api_stdio`, or anything else) can
+//! invoke them by name.
+//!
+//! Commands:
+//!   status       — JSON with fps, uptime, paused, dt, has_error
+//!   last_error   — last compilation error string, or JSON null if none
+//!   reload       — incremental reload (no recompile of @live)
+//!   reload_full  — full recompile (clears @live vars)
+//!   pause        — pauses execution
+//!   unpause      — resumes execution
+//!   shutdown     — graceful process exit
+
+require daslib/json
+require live/live_commands
+require live_host
+
+[live_command(description="JSON with fps, uptime, paused, dt, has_error")]
+def status(input : JsonValue?) : JsonValue? {
+    // Build the response as a table rather than via `JV(LiveStatus(...))`.
+    // The json_boost macro-generated `apply` instance for an in-module
+    // struct hashes non-deterministically across AOT-gen vs runtime when
+    // the module is required transitively, causing error[50101] link
+    // failures in test_aot. The HTTP transport keeps its own LiveStatus
+    // struct in live_api.das where it is the only consumer.
+    var tab : table<string; JsonValue?>
+    tab |> insert("fps", JV(get_fps()))
+    tab |> insert("uptime", JV(get_uptime()))
+    tab |> insert("paused", JV(is_paused()))
+    tab |> insert("dt", JV(get_dt()))
+    tab |> insert("has_error", JV(!empty(get_last_error())))
+    return JV(tab)
+}
+
+[live_command(description="Last compilation error string, or JSON null if none")]
+def last_error(input : JsonValue?) : JsonValue? {
+    let err = get_last_error()
+    return empty(err) ? JVNull() : JV(err)
+}
+
+[live_command(description="Trigger incremental reload")]
+def reload(input : JsonValue?) : JsonValue? {
+    request_reload(false)
+    return JV(true)
+}
+
+[live_command(description="Trigger full recompile (clears @live vars)")]
+def reload_full(input : JsonValue?) : JsonValue? {
+    request_reload(true)
+    return JV(true)
+}
+
+[live_command(description="Pause execution")]
+def pause(input : JsonValue?) : JsonValue? {
+    set_paused(true)
+    return JV(true)
+}
+
+[live_command(description="Resume execution")]
+def unpause(input : JsonValue?) : JsonValue? {
+    set_paused(false)
+    return JV(true)
+}
+
+[live_command(description="Graceful shutdown")]
+def shutdown(input : JsonValue?) : JsonValue? {
+    request_exit()
+    return JV(true)
+}

--- a/modules/dasLiveHost/live/live_api_stdio.das
+++ b/modules/dasLiveHost/live/live_api_stdio.das
@@ -1,0 +1,246 @@
+options gen2
+options rtti
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+options indenting = 4
+options strict_smart_pointers = true
+
+module live_api_stdio shared public
+
+//! Stdin/stdout JSON-RPC 2.0 transport for live commands.
+//!
+//! Reads newline-delimited JSON-RPC 2.0 messages from stdin, dispatches
+//! them through ``live_dispatch_command``, and writes responses to stdout.
+//! No HTTP server, no dasHV dependency — pair with
+//! ``require live/live_api`` when you want HTTP instead.
+//!
+//! Wire format::
+//!
+//!     → {"jsonrpc":"2.0","id":1,"method":"set_color","params":{"r":1.0}}
+//!     ← {"jsonrpc":"2.0","id":1,"result":<value>}
+//!
+//! ``method`` is a live command name (any ``[live_command]`` function,
+//! plus the built-ins from ``live/live_api_builtins``). ``params`` is
+//! passed verbatim as the command's input ``JsonValue?``.
+//!
+//! IMPORTANT: stdout is the response channel. Scripts that use this
+//! transport must redirect ``print()`` to stderr or a log file, or the
+//! application's output will interleave with JSON-RPC responses.
+
+require daslib/json
+require daslib/json_boost
+require daslib/jobque_boost
+require daslib/debugger
+require daslib/fio
+require strings
+require live/live_api_builtins public
+require live_host
+
+// --- Reader thread → channel handoff ---
+
+struct StdioMsg {
+    line : string
+}
+
+// --- JSON-RPC 2.0 envelope ---
+
+def public json_rpc_response(id_json : string; result_json : string) : string {
+    return "\{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"result\":{result_json}}"
+}
+
+def public json_rpc_error(id_json : string; code : int; message : string) : string {
+    let msg_json = write_json(JV(message))
+    return "\{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"error\":\{\"code\":{code},\"message\":{msg_json}}}"
+}
+
+def public serialize_id(id_val : JsonValue?) : string {
+    return id_val == null ? "null" : write_json(id_val)
+}
+
+// --- Pure parsing layer (transport-agnostic, testable without dispatch) ---
+
+struct public ParsedJsonRpc {
+    id_str : string         //!< Serialized JSON-RPC `id` field; "null" when missing or parse failed before id was reached.
+    method : string         //!< Live command name; empty when the request was malformed.
+    inner_json : string     //!< Synthesized `{"name":<method>,"args":<params>}` for live_host dispatch; empty when invalid.
+    error_envelope : string //!< Full JSON-RPC error response when the request was malformed; empty when valid.
+    is_notification : bool  //!< True when the request omits `id` (JSON-RPC 2.0 notification — server MUST NOT respond).
+}
+
+def public parse_jsonrpc_request(line : string) : ParsedJsonRpc {
+    //! Parse a single JSON-RPC 2.0 request line into its components without touching dispatch.
+    //! Pure function — testable in isolation from a live_host runtime.
+    //!
+    //! Permissive subset: the `jsonrpc` member is optional (a strict JSON-RPC
+    //! 2.0 server would reject requests omitting `"jsonrpc":"2.0"` with
+    //! `-32600`; this transport accepts them, since real-world clients are
+    //! lazy about the field). All other JSON-RPC 2.0 rules — id type
+    //! restrictions, notification semantics, required `method` — are
+    //! enforced.
+    var result = ParsedJsonRpc(id_str = "null")
+    var parse_error = ""
+    var parsed = read_json(line, parse_error)
+    if (parsed == null) {
+        result.error_envelope = json_rpc_error("null", -32700, "parse error: {parse_error}")
+        return result
+    }
+    if (!(parsed.value is _object)) {
+        result.error_envelope = json_rpc_error("null", -32600, "invalid request: not a JSON object")
+        return result
+    }
+    let body & = unsafe(parsed.value as _object)
+    let id_v = unsafe(reinterpret<JsonValue?>(body?["id"] ?? null))
+    let method_v = unsafe(reinterpret<JsonValue?>(body?["method"] ?? null))
+    let params_v = unsafe(reinterpret<JsonValue?>(body?["params"] ?? null))
+    // JSON-RPC 2.0 §4: id MUST be string, number, or null. Reject objects /
+    // arrays / booleans — they'd also break framing since write_json would
+    // pretty-print them with embedded newlines.
+    if (id_v != null && !(id_v.value is _string) && !(id_v.value is _number) && !(id_v.value is _longint) && !(id_v.value is _null)) {
+        result.error_envelope = json_rpc_error("null", -32600, "invalid request: id must be string, number, or null")
+        return result
+    }
+    result.is_notification = (id_v == null)
+    result.id_str = serialize_id(id_v)
+    if (method_v == null || !(method_v.value is _string)) {
+        result.error_envelope = json_rpc_error(result.id_str, -32600, "invalid request: missing or non-string method")
+        return result
+    }
+    result.method = method_v.value as _string
+    let method_str = write_json(JV(result.method))
+    let params_str = params_v == null ? "null" : write_json(params_v)
+    result.inner_json = "\{\"name\":{method_str},\"args\":{params_str}}"
+    return result
+}
+
+// --- Compact serialization (write_json pretty-prints; the wire is newline-delimited) ---
+
+def public compact_json_whitespace(s : string) : string {
+    //! Strip JSON pretty-printer whitespace (spaces, tabs, newlines, carriage returns)
+    //! that appears outside string literals. JSON whitespace outside strings is
+    //! non-significant, so this is safe; whitespace inside `"..."` is preserved
+    //! verbatim. Used to flatten dispatch_command output for one-message-per-line
+    //! framing on the stdio wire.
+    return build_string() $(var w) {
+        peek_data(s) $(bytes) {
+            var in_string = false
+            var escape = false
+            for (b in bytes) {
+                if (in_string) {
+                    write_char(w, int(b))
+                    if (escape) {
+                        escape = false
+                    } elif (b == uint8('\\')) {
+                        escape = true
+                    } elif (b == uint8('"')) {
+                        in_string = false
+                    }
+                } else {
+                    if (b == uint8('"')) {
+                        in_string = true
+                        write_char(w, int(b))
+                    } elif (b != uint8(' ') && b != uint8('\n') && b != uint8('\t') && b != uint8('\r')) {
+                        write_char(w, int(b))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// --- Per-request dispatch ---
+
+def handle_jsonrpc_line(line : string) : string {
+    //! Dispatches a single JSON-RPC request line. Returns the response envelope
+    //! as a string, or an empty string for notifications (id-less requests) per
+    //! JSON-RPC 2.0 — callers must not write anything to the wire when the
+    //! return value is empty.
+    let req = parse_jsonrpc_request(line)
+    // Parse / validation errors: per spec, notifications still must not get a
+    // response even when malformed.
+    if (!empty(req.error_envelope)) return req.is_notification ? "" : req.error_envelope
+    let result_json = compact_json_whitespace(dispatch_command(req.inner_json))
+    if (req.is_notification) return ""
+    return json_rpc_response(req.id_str, result_json)
+}
+
+// --- Reader thread ---
+
+def stdio_reader_main(ch : Channel?) {
+    //! Blocking-read stdin lines; push each into the channel. Exits on EOF.
+    let sin = fstdin()
+    while (!feof(sin)) {
+        let msg = build_string() $(var w) {
+            while (!feof(sin)) {
+                let chunk = fgets(sin) // nolint:PERF003
+                let len = length(chunk)
+                if (len == 0) break
+                if (character_at(chunk, len - 1) == '\n') { // nolint:PERF003
+                    if (len > 1 && character_at(chunk, len - 2) == '\r') { // nolint:PERF003
+                        write(w, slice(chunk, 0, len - 2))
+                    } else {
+                        write(w, slice(chunk, 0, len - 1))
+                    }
+                    break
+                } else {
+                    write(w, chunk)
+                }
+            }
+        }
+        if (!empty(msg)) {
+            ch |> push_clone(StdioMsg(line = msg))
+        }
+    }
+}
+
+// --- Agent ---
+
+class LiveApiStdioAgent : DapiDebugAgent {
+    inbox : Channel?
+    sout : FILE const?
+    thread_started : bool = false
+
+    def LiveApiStdioAgent() {
+        var ch = unsafe(channel_create())
+        inbox = ch
+        sout = fstdout()
+    }
+
+    def override onTick() : void {
+        if (inbox == null || sout == null) return
+        if (!thread_started) {
+            thread_started = true
+            var ch_capture = capture_jobque_channel(inbox)
+            new_thread() <| @capture(= ch_capture) {
+                this_context().name := "live_api_stdio_reader"
+                stdio_reader_main(ch_capture)
+                ch_capture = null
+            }
+        }
+        var draining = true
+        while (draining) {
+            draining = inbox |> try_pop_clone() $(msg : StdioMsg#) {
+                let response = handle_jsonrpc_line(string(msg.line))
+                if (empty(response)) return  // notification — no response per JSON-RPC 2.0
+                fprint(sout, response)
+                fprint(sout, "\n")
+                fflush(sout)
+            }
+        }
+    }
+}
+
+def debug_agent(ctx : Context) {
+    assert(this_context().category.debug_context)
+    install_new_debug_agent(new LiveApiStdioAgent(), "live_api_stdio")
+}
+
+[_macro]
+def installing() {
+    if (is_compiling_macros_in_module("live_api_stdio") && !is_in_completion()) {
+        if (!is_in_debug_agent_creation() && is_live_mode()) {
+            if (!has_debug_agent_context("live_api_stdio")) {
+                fork_debug_agent_context(@@debug_agent)
+            }
+        }
+    }
+}

--- a/modules/dasLiveHost/live/live_api_stdio.das
+++ b/modules/dasLiveHost/live/live_api_stdio.das
@@ -26,6 +26,22 @@ module live_api_stdio shared public
 //! IMPORTANT: stdout is the response channel. Scripts that use this
 //! transport must redirect ``print()`` to stderr or a log file, or the
 //! application's output will interleave with JSON-RPC responses.
+//!
+//! Spec compliance — this is a permissive JSON-RPC 2.0 subset, sized for
+//! the live-command demo, not a general-purpose JSON-RPC server. If a
+//! real-deal implementation is wanted under ``daslib/``, the gap list
+//! against the spec (https://www.jsonrpc.org/specification) is:
+//!
+//! * Batch requests (§6) — array of requests / array of responses. Currently rejected as -32600.
+//! * ``params`` type validation (§4.2) — spec says MUST be Array or Object; we forward whatever's there.
+//! * ``-32601`` method not found and ``-32603`` internal error — ``dispatch_command`` returns its own error JSON inside ``result`` rather than a JSON-RPC ``error`` envelope.
+//! * Optional ``data`` field on errors (genuinely optional, never emitted).
+//!
+//! Everything else (response envelope, id type validation, framing,
+//! notification semantics, ``-32700`` / ``-32600``, permissive
+//! ``jsonrpc`` member) is in place — the parser layer
+//! (``parse_jsonrpc_request``, ``compact_json_whitespace``,
+//! envelope helpers) is reusable as-is.
 
 require daslib/json
 require daslib/json_boost
@@ -99,12 +115,14 @@ def public parse_jsonrpc_request(line : string) : ParsedJsonRpc {
         result.error_envelope = json_rpc_error("null", -32600, "invalid request: id must be string, number, or null")
         return result
     }
-    result.is_notification = (id_v == null)
     result.id_str = serialize_id(id_v)
     if (method_v == null || !(method_v.value is _string)) {
+        // Don't flag as notification before method validation — `{}` or `{"method":42}`
+        // with no id would otherwise swallow the -32600 envelope per JSON-RPC §5.1.
         result.error_envelope = json_rpc_error(result.id_str, -32600, "invalid request: missing or non-string method")
         return result
     }
+    result.is_notification = (id_v == null)
     result.method = method_v.value as _string
     let method_str = write_json(JV(result.method))
     let params_str = params_v == null ? "null" : write_json(params_v)

--- a/mouse-data/docs/is-there-a-json-rpc-2-0-implementation-in-daslang-i-can-use-or-extend.md
+++ b/mouse-data/docs/is-there-a-json-rpc-2-0-implementation-in-daslang-i-can-use-or-extend.md
@@ -1,0 +1,31 @@
+---
+slug: is-there-a-json-rpc-2-0-implementation-in-daslang-i-can-use-or-extend
+title: Is there a JSON-RPC 2.0 implementation in daslang I can use or extend?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+A partial one — `modules/dasLiveHost/live/live_api_stdio.das` ships an 80%-compliant JSON-RPC 2.0 transport for live commands over stdin/stdout (newline-delimited framing). Reusable building blocks are public:
+
+- `parse_jsonrpc_request(line) → ParsedJsonRpc` — pure parser; returns id/method/inner_json/error_envelope/is_notification
+- `compact_json_whitespace(s) → string` — escape-quote-aware whitespace stripper (one-message-per-line guarantee)
+- `json_rpc_response(id_json, result_json) → string`, `json_rpc_error(id_json, code, message) → string`
+- `serialize_id(id_val) → string`
+
+What's solidly spec-compliant: response envelope, id type validation (string/number/null only — objects/arrays/bools get -32600), `id:null` on parse failure, method-must-be-string, -32700 / -32600, notification semantics for well-formed requests, framing.
+
+What's permissive: `jsonrpc:"2.0"` member is optional; non-"2.0" values are accepted. Documented in the module docstring and `doc/source/reference/utils/daslang_live.rst`.
+
+What's missing if you want a real-deal daslib JSON-RPC server (gap list also in the live_api_stdio.das module docstring as of PR #2674):
+- **Batch requests (§6)** — array-of-requests / array-of-responses. Currently rejected as -32600. Biggest single gap vs spec.
+- **`params` type validation (§4.2)** — spec says MUST be Array or Object; we forward whatever's there. No -32602.
+- **-32601 method not found / -32603 internal error** — `dispatch_command` returns its own error JSON shape inside `result` instead of a JSON-RPC `error` envelope. Wrapping would belong at the transport layer.
+- **Optional `data` field on errors** — never emitted (genuinely optional per spec).
+
+Tests live at `tests/live_host/test_live_api_stdio.das` (~40 cases across 8 [test] functions) and cover the parser layer in isolation; the integration path is covered by `examples/daslive/hello_stdio/`.
+
+For a daslib promotion: lift `parse_jsonrpc_request` + `compact_json_whitespace` + envelope helpers into `daslib/jsonrpc.das`, add batch dispatch (top-level array → fan out → array response), validate `params`, and let callers wrap their own dispatch table with proper -32601 / -32603 envelope handling.
+
+## Questions
+- Is there a JSON-RPC 2.0 implementation in daslang I can use or extend?

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -106,6 +106,8 @@ FILE(GLOB AOT_LIVE_HOST_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "
 SET(AOT_LIVE_HOST_MODULE_FILES
     modules/dasLiveHost/live/live_commands.das
     modules/dasLiveHost/live/live_vars.das
+    modules/dasLiveHost/live/live_api_builtins.das
+    modules/dasLiveHost/live/live_api_stdio.das
 )
 
 # AOT for dasSQLITE module library files (required by dasSQLITE tests)

--- a/tests/live_host/test_live_api_stdio.das
+++ b/tests/live_host/test_live_api_stdio.das
@@ -114,6 +114,20 @@ def test_parse_notification(t : T?) {
         t |> success(!r.is_notification, "non-object is NOT a notification")
         t |> success(find(r.error_envelope, "-32600") >= 0, "invalid-request code")
     }
+    t |> run("empty object (no id, no method) is NOT a notification") @(t : T?) {
+        // A notification is a *well-formed* request that omits id. `{}` is missing
+        // the required `method` member, so it's an invalid request that must
+        // reach the wire with -32600 per JSON-RPC §5.1 — not silently swallowed.
+        let r = parse_jsonrpc_request("\{}")
+        t |> success(!r.is_notification, "missing method with no id is NOT a notification")
+        t |> success(find(r.error_envelope, "-32600") >= 0, "invalid-request code")
+        t |> success(find(r.error_envelope, "\"id\":null") >= 0, "id null when absent")
+    }
+    t |> run("non-string method with no id is NOT a notification") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"method\":42}")
+        t |> success(!r.is_notification, "non-string method with no id is NOT a notification")
+        t |> success(find(r.error_envelope, "-32600") >= 0, "invalid-request code")
+    }
 }
 
 // --- parse_jsonrpc_request: id type validation (JSON-RPC 2.0 §4) ---

--- a/tests/live_host/test_live_api_stdio.das
+++ b/tests/live_host/test_live_api_stdio.das
@@ -1,0 +1,231 @@
+options gen2
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require daslib/json
+require daslib/json_boost
+require live/live_api_stdio
+require strings
+
+// Tests cover the parse layer of live_api_stdio (parse_jsonrpc_request +
+// envelope helpers). The full handle_jsonrpc_line call path goes through
+// live_host's dispatch_command bridge, which only resolves under
+// daslang-live; the demo in examples/daslive/hello_stdio/ is the
+// integration smoke for that.
+
+// --- envelope helpers ---
+
+[test]
+def test_envelope_response(t : T?) {
+    t |> run("result envelope wraps id + result verbatim") @(t : T?) {
+        let r = json_rpc_response("1", "true")
+        t |> equal(r, "\{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":true}")
+    }
+    t |> run("result envelope embeds raw JSON object") @(t : T?) {
+        let r = json_rpc_response("42", "\{\"fps\":60}")
+        t |> equal(r, "\{\"jsonrpc\":\"2.0\",\"id\":42,\"result\":\{\"fps\":60}}")
+    }
+    t |> run("error envelope wraps code + message") @(t : T?) {
+        let r = json_rpc_error("\"abc\"", -32601, "method not found")
+        t |> equal(r, "\{\"jsonrpc\":\"2.0\",\"id\":\"abc\",\"error\":\{\"code\":-32601,\"message\":\"method not found\"}}")
+    }
+}
+
+[test]
+def test_serialize_id(t : T?) {
+    t |> run("null id serializes to 'null'") @(t : T?) {
+        t |> equal(serialize_id(null), "null")
+    }
+    t |> run("integer id round-trips") @(t : T?) {
+        t |> equal(serialize_id(JV(7)), "7")
+    }
+    t |> run("string id keeps quoting") @(t : T?) {
+        t |> equal(serialize_id(JV("abc")), "\"abc\"")
+    }
+}
+
+// --- parse_jsonrpc_request: valid requests ---
+
+[test]
+def test_parse_valid(t : T?) {
+    t |> run("method only, no params, no id") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"method\":\"status\"}")
+        t |> equal(r.error_envelope, "")
+        t |> equal(r.method, "status")
+        t |> equal(r.id_str, "null")
+        t |> equal(r.inner_json, "\{\"name\":\"status\",\"args\":null}")
+    }
+    t |> run("integer id passes through") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"jsonrpc\":\"2.0\",\"id\":42,\"method\":\"status\"}")
+        t |> equal(r.error_envelope, "")
+        t |> equal(r.id_str, "42")
+        t |> equal(r.method, "status")
+    }
+    t |> run("string id passes through quoted") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"id\":\"call-1\",\"method\":\"status\"}")
+        t |> equal(r.error_envelope, "")
+        t |> equal(r.id_str, "\"call-1\"")
+    }
+    t |> run("params object is embedded in inner_json") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"id\":1,\"method\":\"set_color\",\"params\":\{\"r\":0.5}}")
+        t |> equal(r.error_envelope, "")
+        t |> equal(r.method, "set_color")
+        t |> success(find(r.inner_json, "\"name\":\"set_color\"") >= 0, "inner_json carries method as name")
+        t |> success(find(r.inner_json, "\"args\":") >= 0, "inner_json carries args field")
+        t |> success(find(r.inner_json, "\"r\"") >= 0, "args carry the r key from params")
+    }
+    t |> run("missing params becomes args:null") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"id\":1,\"method\":\"ping\"}")
+        t |> equal(r.error_envelope, "")
+        t |> equal(r.inner_json, "\{\"name\":\"ping\",\"args\":null}")
+    }
+}
+
+// --- parse_jsonrpc_request: notification detection (JSON-RPC 2.0 §4.1) ---
+
+[test]
+def test_parse_notification(t : T?) {
+    t |> run("missing id flags notification") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"method\":\"shutdown\"}")
+        t |> equal(r.error_envelope, "")
+        t |> success(r.is_notification, "is_notification should be true when id is absent")
+    }
+    t |> run("present id flags non-notification") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"id\":1,\"method\":\"status\"}")
+        t |> success(!r.is_notification, "is_notification should be false when id is present")
+    }
+    t |> run("explicit null id is still a normal request") @(t : T?) {
+        // JSON-RPC 2.0 distinguishes "absent id" (notification) from
+        // "explicit null id" (request expecting a response with id:null).
+        let r = parse_jsonrpc_request("\{\"id\":null,\"method\":\"status\"}")
+        t |> success(!r.is_notification, "explicit null id is NOT a notification per spec §4.1")
+    }
+    t |> run("malformed JSON is NOT a notification — envelope is emitted") @(t : T?) {
+        // Parse failures must produce a -32700 response per JSON-RPC 2.0 §5.1;
+        // suppressing them would let invalid clients hang waiting for a reply.
+        let r = parse_jsonrpc_request("garbage")
+        t |> success(!empty(r.error_envelope), "envelope built")
+        t |> success(!r.is_notification, "parse failure is NOT a notification")
+        t |> success(find(r.error_envelope, "-32700") >= 0, "parse-error code")
+    }
+    t |> run("non-object body is NOT a notification — envelope is emitted") @(t : T?) {
+        let r = parse_jsonrpc_request("42")
+        t |> success(!r.is_notification, "non-object is NOT a notification")
+        t |> success(find(r.error_envelope, "-32600") >= 0, "invalid-request code")
+    }
+}
+
+// --- parse_jsonrpc_request: id type validation (JSON-RPC 2.0 §4) ---
+
+[test]
+def test_parse_id_types(t : T?) {
+    t |> run("object id is rejected with -32600 and id:null") @(t : T?) {
+        // An object/array id would pretty-print across multiple lines through
+        // write_json — breaks framing. Reject early with id:null.
+        let r = parse_jsonrpc_request("\{\"id\":\{\"weird\":1},\"method\":\"status\"}")
+        t |> success(!empty(r.error_envelope), "envelope built")
+        t |> success(!r.is_notification, "invalid-id request is not a notification")
+        t |> success(find(r.error_envelope, "-32600") >= 0, "invalid-request code")
+        t |> success(find(r.error_envelope, "\"id\":null") >= 0, "response id reset to null")
+        t |> success(find(r.error_envelope, "id must be string, number, or null") >= 0, "message names the constraint")
+    }
+    t |> run("array id is rejected") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"id\":[1,2],\"method\":\"status\"}")
+        t |> success(!empty(r.error_envelope), "envelope built")
+        t |> success(find(r.error_envelope, "-32600") >= 0, "invalid-request code")
+    }
+    t |> run("boolean id is rejected") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"id\":true,\"method\":\"status\"}")
+        t |> success(!empty(r.error_envelope), "envelope built")
+        t |> success(find(r.error_envelope, "-32600") >= 0, "invalid-request code")
+    }
+    t |> run("number id is accepted") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"id\":3.14,\"method\":\"status\"}")
+        t |> equal(r.error_envelope, "")
+    }
+}
+
+// --- Permissive jsonrpc field handling ---
+
+[test]
+def test_parse_permissive_jsonrpc(t : T?) {
+    t |> run("missing jsonrpc field accepted (permissive subset)") @(t : T?) {
+        // Strict JSON-RPC 2.0 would reject this with -32600 (jsonrpc:"2.0" is
+        // required). The transport intentionally accepts it for clients that
+        // omit the field, as documented.
+        let r = parse_jsonrpc_request("\{\"id\":1,\"method\":\"status\"}")
+        t |> equal(r.error_envelope, "")
+        t |> equal(r.method, "status")
+    }
+    t |> run("non-2.0 jsonrpc value accepted (permissive)") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"jsonrpc\":\"1.0\",\"id\":1,\"method\":\"status\"}")
+        t |> equal(r.error_envelope, "")
+        t |> equal(r.method, "status")
+    }
+}
+
+// --- compact_json_whitespace: pretty-print stripping ---
+
+[test]
+def test_compact_json_whitespace(t : T?) {
+    t |> run("strips newlines/tabs between tokens") @(t : T?) {
+        let r = compact_json_whitespace("\{\n\t\"fps\" : 60,\n\t\"paused\" : false\n}")
+        t |> equal(r, "\{\"fps\":60,\"paused\":false}")
+    }
+    t |> run("preserves whitespace inside string values") @(t : T?) {
+        let r = compact_json_whitespace("\{\n\t\"msg\" : \"hello\\nworld with spaces\"\n}")
+        t |> equal(r, "\{\"msg\":\"hello\\nworld with spaces\"}")
+    }
+    t |> run("preserves escaped quotes inside strings") @(t : T?) {
+        let r = compact_json_whitespace("\{\n\t\"q\" : \"a\\\"b\\\"c\"\n}")
+        t |> equal(r, "\{\"q\":\"a\\\"b\\\"c\"}")
+    }
+    t |> run("empty string returns empty") @(t : T?) {
+        t |> equal(compact_json_whitespace(""), "")
+    }
+    t |> run("already-compact JSON is unchanged") @(t : T?) {
+        let r = compact_json_whitespace("\{\"a\":1,\"b\":[1,2,3]}")
+        t |> equal(r, "\{\"a\":1,\"b\":[1,2,3]}")
+    }
+}
+
+// --- parse_jsonrpc_request: invalid requests ---
+
+[test]
+def test_parse_errors(t : T?) {
+    t |> run("malformed JSON returns -32700 with null id") @(t : T?) {
+        let r = parse_jsonrpc_request("not json at all")
+        t |> success(!empty(r.error_envelope), "error_envelope populated")
+        t |> equal(r.method, "")
+        t |> equal(r.inner_json, "")
+        t |> success(find(r.error_envelope, "-32700") >= 0, "envelope carries parse-error code")
+        t |> success(find(r.error_envelope, "\"id\":null") >= 0, "id defaults to null on parse fail")
+    }
+    t |> run("empty input returns parse error") @(t : T?) {
+        let r = parse_jsonrpc_request("")
+        t |> success(!empty(r.error_envelope), "error_envelope populated")
+        t |> success(find(r.error_envelope, "-32700") >= 0, "parse-error code")
+    }
+    t |> run("non-object body returns -32600") @(t : T?) {
+        let r = parse_jsonrpc_request("42")
+        t |> success(!empty(r.error_envelope), "error_envelope populated")
+        t |> equal(r.method, "")
+        t |> success(find(r.error_envelope, "-32600") >= 0, "invalid-request code")
+        t |> success(find(r.error_envelope, "not a JSON object") >= 0, "message names the issue")
+    }
+    t |> run("missing method returns -32600 with id preserved") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"id\":7}")
+        t |> success(!empty(r.error_envelope), "error_envelope populated")
+        t |> equal(r.method, "")
+        t |> success(find(r.error_envelope, "-32600") >= 0, "invalid-request code")
+        t |> success(find(r.error_envelope, "\"id\":7") >= 0, "id from the request is preserved")
+        t |> success(find(r.error_envelope, "missing or non-string method") >= 0, "message names the issue")
+    }
+    t |> run("non-string method returns -32600") @(t : T?) {
+        let r = parse_jsonrpc_request("\{\"id\":1,\"method\":42}")
+        t |> success(!empty(r.error_envelope), "error_envelope populated")
+        t |> success(find(r.error_envelope, "-32600") >= 0, "invalid-request code")
+        t |> success(find(r.error_envelope, "missing or non-string method") >= 0, "message names the issue")
+    }
+}


### PR DESCRIPTION
## Summary

Adds a parallel live-debug transport that speaks newline-delimited JSON-RPC 2.0 on stdin/stdout, so live commands are reachable without linking `dasHV`. Scripts pick the transport with a single `require`:

```das
require live/live_api        // HTTP (existing, requires dasHV)
require live/live_api_stdio  // stdio JSON-RPC (new, no dasHV)
```

Demonstrates that the live system is protocol-agnostic — the same `[live_command]` functions work over either wire.

## What's in the diff

- **`modules/dasLiveHost/live/live_api_builtins.das`** (new) — registers `status`, `last_error`, `reload`, `reload_full`, `pause`, `unpause`, `shutdown` as `[live_command]`s so stdio clients can drive lifecycle by name.
- **`modules/dasLiveHost/live/live_api_stdio.das`** (new) — debug agent with a reader thread that blocks on `fstdin`, pushes lines into a `Channel`, and lets `onTick` drain + dispatch. JSON-RPC envelope is inline. Calls live_host's `dispatch_command` bridge — same path HTTP's `POST /command` uses for user commands.
- **`modules/dasLiveHost/live/live_api.das`** — unchanged. (Refactoring HTTP routes to also route through `dispatch_command` was tried and reverted: it caused a re-entry hang when scripts self-call their own HTTP server inside `update()`; `dispatch_command` isn't reentrant from the main context.)
- **`examples/daslive/hello_stdio/main.das`** (new) — verbatim copy of `hello/main.das` with one require swapped.
- **`modules/dasLiveHost/.das_module`** + **`CMakeLists.txt`** — register the two new modules.
- **`doc/source/reference/utils/daslang_live.rst`** — split the "REST API" section into a "Transports" umbrella with REST and stdio subsections; new examples row.

## Wire format

```
→ {"jsonrpc":"2.0","id":1,"method":"set_color","params":{"r":0.7,"g":0.4,"b":0.1}}
← {"jsonrpc":"2.0","id":1,"result":"{\"r\": 0.7, \"g\": 0.4, \"b\": 0.1}"}
```

## Spec compliance

This is a **permissive JSON-RPC 2.0 subset** sized for the live-command demo, not a general-purpose JSON-RPC server. Solidly compliant on: response envelope, id type validation (string/number/null only), `id:null` on parse failure, required-string `method`, `-32700`/`-32600` codes, notification semantics, one-message-per-line framing. Documented divergence: the `jsonrpc` member is optional (real-world clients are lazy about it).

If a real-deal implementation is wanted under `daslib/jsonrpc.das` later, the gap list against the spec is captured in the `live_api_stdio.das` module docstring and in `mouse-data/docs/is-there-a-json-rpc-2-0-implementation-in-daslang-i-can-use-or-extend.md`:

- **Batch requests (§6)** — array-of-requests / array-of-responses, currently rejected as -32600.
- **`params` type validation (§4.2)** — spec says MUST be Array or Object; we forward whatever's there. No -32602.
- **-32601 method not found / -32603 internal error** — `dispatch_command` returns its own error JSON inside `result` instead of a JSON-RPC `error` envelope.
- **Optional `data` field on errors** — never emitted (genuinely optional per spec).

The parser layer (`parse_jsonrpc_request`, `compact_json_whitespace`, envelope helpers) is reusable as-is for that promotion.

## Caveats

- **Stdout is the response channel.** Scripts using stdio transport must redirect `print()` to stderr or a log file, or output will interleave with JSON-RPC responses. Documented in module docstring and the RST.
- **Reader thread leaks on process exit.** Demo-grade; matches `utils/mcp/main.das`'s lifecycle. The lockbox/feature dump is silenced with `--no-dump-leaks`.
- **JSON int vs number.** `set_color` checks `rv.value is _number` (a json_boost float case). Calls with integer-shaped params like `"r":1` won't update (re-parses as `_int`). Use `0.7`/`1.0` etc. — pre-existing behavior of `hello/main.das`'s `set_color`.

## Test plan

- [x] `mcp__daslang__lint` — all 4 new/modified `.das` files clean.
- [x] `mcp__daslang__format_file` — all already-formatted.
- [x] `detect-dupe` against `daslib` + `modules/dasLiveHost/live` — only intentional one-liner pairs (`reload`/`reload_full`, `pause`/`unpause`) and the standard agent-install boilerplate (mirrors `live_watch.das`).
- [x] Sphinx HTML build — 0 warnings, 0 errors.
- [x] Full test suite — 8045/8051 pass, 0 failed, 0 errors, 6 skipped.
- [x] `tests/live_host/test_live_api_stdio.das` — 42/42 pass (parser, envelope, id-types, permissive-subset, notification, compact-whitespace, error paths).
- [x] Manual stdio smoke: pipe `status` / `set_color` / `last_error` / `shutdown` into `hello_stdio` — all return correct responses, set_color updates window color, shutdown exits cleanly.
- [x] HTTP regression: `test_api/main.das` runs to completion under `daslang-live`.

## Out of scope

- A separate issue is being filed for a pre-existing dasHV routing quirk where `ANY("*")` shadows specific `GET("/path")` routes on the same server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
