### PR TITLE
daslang-live: forward post-`--` argv to scripts

### DIFF
--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -575,7 +575,7 @@ static void print_help() {
     tout << "  -heap-report       - dump heap contents on shutdown\n";
     tout << "  --no-dyn-modules   - skip loading dynamic modules\n";
     tout << "  --no-dump-leaks    - silence JobStatus + HandleRegistry leak dumps at exit (default: dump)\n";
-    tout << "  --                 - separator for script arguments\n";
+    tout << "  --                 - separator; everything after is forwarded to the script (get_user_args)\n";
     tout << "  -h, --help         - this help\n";
 }
 
@@ -638,6 +638,11 @@ int main(int argc, char * argv[]) {
 
     install_das_crash_handler();
     das::arm_alloc_tracking();
+
+    // Forward full argv so scripts can read get_user_args() (post-`--` slice).
+    // Matches daslang.exe's behavior — daslang-live ignores everything after
+    // `--` itself, but the script still gets the slice via get_cli_arguments().
+    setCommandLineArguments(argc, argv);
 
     string scriptFile;
     bool noDynamicModules = false;


### PR DESCRIPTION
## Summary

- daslang-live ignored everything after `--` itself but never called `setCommandLineArguments`, so the script's `get_user_args()` (post-`--` slice) returned empty.
- This PR adds the single missing call. Mirrors daslang.exe's behavior — daslang-live still doesn't parse those args itself, but they reach the script via `daslib/clargs`'s `get_user_args()`.

## Why now

Unblocks dasImgui's harness `--headless` under live-reload. The `harness_is_headless()` helper reads `--headless` via `get_user_args()`, and it was unreachable from a daslang-live session before this. Spawned playwright tests (95 of them, all spawn `daslang-live <feature.das>` via `popen_argv`) will be able to run headless without xvfb on Linux CI once the follow-up dasImgui PR lands. The harness's tutorial currently calls this out as a known limit — that doc note gets dropped in the dasImgui PR.

## Test plan

Smoke (manual, verified locally) — `foo.das` containing `def main() { for (a in get_user_args()) print("arg: {a}\n") }`:

```
./bin/Release/daslang-live.exe foo.das -- --headless --headless-frames=60 hello
```

prints:

```
arg: --headless
arg: --headless-frames=60
arg: hello
```

- [ ] CI build green across linux/darwin15/windows
- [ ] No regression in existing daslang-live behavior — the early `setCommandLineArguments` call is additive; pre-existing arg-parse loop unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
