### PR TITLE
site/blog: surface the existing Atom feed

### DIFF
--- a/site/blog/build_blog.py
+++ b/site/blog/build_blog.py
@@ -327,7 +327,7 @@ def render_index(posts: list[Entry], md) -> str:
             <h1 class="forge-h2" style="font-size:44px;">Notes from the language.</h1>
             <p class="forge-p" style="max-width:640px;">
                 Design rationale, refactor stories, and the occasional shipping
-                announcement. Newest first.
+                announcement. Newest first. <a href="feed.xml">RSS</a>.
             </p>
             <div class="forge-blog-list">
 {chr(10).join(items)}

--- a/site/blog/template.html
+++ b/site/blog/template.html
@@ -6,6 +6,7 @@
     <title>{{title}} — Daslang</title>
     <meta name="description" content="{{description}}" />
     <link rel="icon" type="image/svg+xml" href="{{root}}files/forge-favicon.svg" />
+    <link rel="alternate" type="application/atom+xml" title="Daslang blog" href="{{root}}blog/feed.xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" />


### PR DESCRIPTION
## Summary

`site/blog/build_blog.py` already emits a complete Atom feed at `site/blog/feed.xml` (covering all 28 posts), but nothing pointed at it — no `<link rel="alternate">` for reader auto-discovery, no visible link on the index. Both fixed:

- **`site/blog/template.html`** — adds `<link rel="alternate" type="application/atom+xml" title="Daslang blog" href="{{root}}blog/feed.xml" />` in `<head>`. Lands on every generated page (blog index, post pages, changelist, news pages); `{{root}}` resolves to `../blog/feed.xml` for blog/post pages and `blog/feed.xml` for the changelist.
- **`site/blog/build_blog.py`** (`render_index`) — appends an inline `RSS` text link to the blog-index intro paragraph. Reuses Forge link styling, no new CSS.

Browser RSS extensions (Feedly, NetNewsWire, etc.) auto-discover the feed from any page; humans can find it via the visible link on the blog index.

## Test plan

- [ ] `python3 site/blog/build_blog.py --posts site/blog/_posts --news site/_news --template site/blog/template.html --out site/` builds clean (verified locally: 27 posts, 28 news entries)
- [ ] `grep -E "atom|feed" site/blog/index.html site/blog/the-3-horseman.html site/changelist.html` shows the auto-discovery `<link>` on each, with the right relative path
- [ ] `grep RSS site/blog/index.html` shows the visible link
- [ ] After `pages.yml` deploys, https://daslang.io/blog/ shows the `RSS` link, and a feed reader pointed at https://daslang.io/blog/ auto-discovers https://daslang.io/blog/feed.xml

🤖 Generated with [Claude Code](https://claude.com/claude-code)