### PR TITLE
site/blog: RSS link polish, feed author, landing auto-discovery

### DIFF
--- a/site/blog/build_blog.py
+++ b/site/blog/build_blog.py
@@ -327,7 +327,10 @@ def render_index(posts: list[Entry], md) -> str:
             <h1 class="forge-h2" style="font-size:44px;">Notes from the language.</h1>
             <p class="forge-p" style="max-width:640px;">
                 Design rationale, refactor stories, and the occasional shipping
-                announcement. Newest first. <a href="feed.xml">RSS</a>.
+                announcement. Newest first.
+            </p>
+            <p style="max-width:640px; margin:8px 0 0; font-family:var(--font-mono); font-size:11.5px; text-transform:uppercase; letter-spacing:1.4px;">
+                <a href="feed.xml" style="color:var(--amber);">RSS</a>
             </p>
             <div class="forge-blog-list">
 {chr(10).join(items)}
@@ -405,6 +408,7 @@ def render_atom_feed(posts: list[Entry], site_url: str) -> str:
 <link href="{site_url}/blog/"/>
 <updated>{updated}T00:00:00Z</updated>
 <id>{site_url}/blog/</id>
+<author><name>Boris Batkin</name></author>
 {chr(10).join(entries)}
 </feed>
 """

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Daslang releases, repository, blog, and ecosystem links." />
 
     <link rel="icon" type="image/svg+xml" href="files/forge-favicon.svg" />
+    <link rel="alternate" type="application/atom+xml" title="Daslang blog" href="blog/feed.xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" />

--- a/site/index.html
+++ b/site/index.html
@@ -12,6 +12,7 @@
 
     <link rel="icon" type="image/svg+xml" href="files/forge-favicon.svg" />
     <link rel="alternate icon" type="image/x-icon" href="doc/_static/daslang.ico" />
+    <link rel="alternate" type="application/atom+xml" title="Daslang blog" href="blog/feed.xml" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Summary

Three small follow-ups to [#2682](https://github.com/GaijinEntertainment/daScript/pull/2682) (Atom-feed surfacing):

- **`site/blog/build_blog.py`** (`render_index`) — visible RSS link gets its own line below the intro paragraph and matches the styling of the `BLOG` section label above it: mono, uppercase, amber (`var(--amber)`). Inline styles only; no CSS changes.
- **`site/blog/build_blog.py`** (`render_atom_feed`) — adds `<author><name>Boris Batkin</name></author>` to the feed root. [RFC 4287 §4.1.1](https://datatracker.ietf.org/doc/html/rfc4287#section-4.1.1) requires `atom:author` either at the feed level or on every entry; W3C feed validator warns without it; major readers display "no author" otherwise.
- **`site/index.html`, `site/downloads.html`** — adds the same `<link rel="alternate" type="application/atom+xml">` auto-discovery tag the template-generated pages already carry. Now a feed reader pointed at `https://daslang.io/` or `/downloads.html` (in addition to anything under `/blog/`) discovers `blog/feed.xml`.

## Test plan

- [ ] Local: refresh `http://localhost:8000/blog/` — RSS sits on its own line below the intro, mono uppercase amber, matching the `BLOG` label.
- [ ] `head -8 site/blog/feed.xml` shows `<author><name>Boris Batkin</name></author>` after `<id>`.
- [ ] `grep atom+xml site/index.html site/downloads.html site/blog/index.html site/changelist.html` shows the link on every page type, with the correct relative path for each.
- [ ] After `pages.yml` deploys, paste `https://daslang.io/` into Feedly / NetNewsWire — it auto-discovers the feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)