### PR TITLE
dasHV: env-gated libhv log routing (stderr / stdout / silent)

### DIFF
--- a/modules/dasHV/src/dasHV.cpp
+++ b/modules/dasHV/src/dasHV.cpp
@@ -1,10 +1,13 @@
 #include "daScript/misc/platform.h"
 
 #include <future>
+#include <cstdlib>
 
 #include "../../../src/builtin/module_builtin_rtti.h"
 
 #include "dasHV.h"
+
+#include <hv/hlog.h>
 
 IMPLEMENT_EXTERNAL_TYPE_FACTORY(WebSocketClient,hv::WebSocketClient)
 IMPLEMENT_EXTERNAL_TYPE_FACTORY(WebSocketServer,hv::WebSocketServer)
@@ -1167,6 +1170,26 @@ char * das_httpreq_get_url_encoded ( HttpRequest * req, const char * key, Contex
 class Module_HV : public Module {
 public:
     Module_HV() : Module("dashv") {
+        // libhv defaults to file_logger (bin/libhv.YYYYMMDD.log). Invisible
+        // under popen + CI runners. Two env-gated opt-outs:
+        //   DASLIVE_HV_LOG=stderr (or =1)  → redirect libhv to stderr
+        //   DASLIVE_HV_LOG=stdout          → redirect libhv to stdout
+        //   DASLIVE_HV_LOG=silent          → disable libhv logging entirely
+        // DASLIVE_HV_LOG_LEVEL=DEBUG/INFO/WARN/ERROR overrides the level.
+        // Default unset → file_logger (unchanged).
+        if (const char * route = std::getenv("DASLIVE_HV_LOG")) {
+            if (!strcmp(route, "stderr") || !strcmp(route, "1")) {
+                hlog_set_handler(stderr_logger);
+            } else if (!strcmp(route, "stdout")) {
+                hlog_set_handler(stdout_logger);
+            } else if (!strcmp(route, "silent")) {
+                hlog_disable();
+            }
+        }
+        if (const char * lvl = std::getenv("DASLIVE_HV_LOG_LEVEL")) {
+            hlog_set_level_by_str(lvl);
+        }
+
         ModuleLibrary lib;
         lib.addModule(this);
         lib.addBuiltInModule();


### PR DESCRIPTION
## Summary

Adds an env-gated knob to redirect libhv's logger (`hlog`) from its default `file_logger` (writing to `bin/libhv.YYYYMMDD.log`) to stderr/stdout, or to silence it entirely.

- `DASLIVE_HV_LOG=stderr` (or `=1`) — `hlog_set_handler(stderr_logger)`
- `DASLIVE_HV_LOG=stdout` — `hlog_set_handler(stdout_logger)`
- `DASLIVE_HV_LOG=silent` — `hlog_disable()`
- `DASLIVE_HV_LOG_LEVEL=DEBUG|INFO|WARN|ERROR` — override default level (INFO)

Default unset preserves existing file-logger behavior — zero impact for users not setting the env.

## Why now

dasImgui's CI integration tests hang on both Linux and macOS in dasHV's HTTP serving path (script update loop iterates fine, but `/status` never responds). On Windows the same tests pass cleanly. Hypothesis is something in libhv's POSIX event loop, but the diagnostic data is unreachable — libhv writes to a file inside the popen'd subprocess that the CI runner never surfaces.

Routing libhv to stderr makes the event-loop state (`http server listening`, `hloop_run`, accept errors, etc.) visible in CI logs so we can either fix it or confidently pivot to a different transport.

## Test plan

Smoke verified locally on Windows:

```
set DASLIVE_HV_LOG=stderr
set DASLIVE_HV_LOG_LEVEL=DEBUG
bin/Release/daslang-live.exe foo.das -- --headless
```

stderr contains:

```
INFO  http server listening on 0.0.0.0:9090 [HttpServer.cpp:184:http_server_run]
DEBUG hloop_new tid=4572 [hloop.c:431:hloop_new]
INFO  EventLoop started, pid=99632 tid=4572 [HttpServer.cpp:151:loop_thread]
DEBUG hloop_run tid=4572 [hloop.c:454:hloop_run]
```

- [ ] CI builds across linux/darwin15/windows
- [ ] No regression on default-unset behavior (still writes to file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
