### PR TITLE
live_api: drop ANY(&quot;*&quot;) catch-all (POSIX shutdown hang)

### DIFF
--- a/modules/dasLiveHost/live/live_api.das
+++ b/modules/dasLiveHost/live/live_api.das
@@ -23,7 +23,6 @@ module live_api shared public
 //!   POST /shutdown    — graceful shutdown
 //!   POST /command     — dispatches a single [live_command] via host bridge
 //!   POST /commands    — dispatches an array of [live_command]s (continue-on-error)
-//!   ANY  *            — returns JSON help with all endpoints and curl examples
 //!
 //! When a compilation error is active, /command, /pause, and /unpause
 //! return HTTP 503 with the error text. Use /reload to fix.
@@ -198,8 +197,28 @@ class LiveApiServer : HvWebServer {
             return resp |> JSON(result, http_status.OK)
         }
 
-        // Catch-all: return help for any unmatched route
-        ANY("*") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+        // Help on the root path only — no ANY("*") catch-all. libhv's
+        // HttpService stores routes in std::unordered_map<std::string,...>
+        // (vendored libhv include/hv/HttpService.h:105) and GetRoute
+        // iterates in container order, taking the first wildcard or path
+        // match. With ANY("*") registered, libhv's bucket layout on Linux
+        // libstdc++ (and intermittently on Windows MSVC, depending on
+        // rehash timing) enumerates "*" BEFORE specific paths like
+        // /status, /shutdown, /command — so every request hits the
+        // wildcard handler, request_exit() never runs, and daslang-live
+        // never exits. Symptom: dasImgui playwright tests hang for the
+        // full popen watchdog (120 s) on POSIX, get SIGKILLed, drain ends
+        // with popen_exit_code=DAS_POPEN_TIMEOUT (0x7FFFFF01).
+        //
+        // GET / is a specific exact-match path, so it never collides with
+        // /status etc. Unknown paths now return libhv's default 404 —
+        // programmatic clients (playwright, MCP live tools) never relied
+        // on the catch-all. Humans typing curl :9090/ still get the help
+        // JSON.
+        //
+        // Proper fix lives in libhv (sort wildcards last in GetRoute, or
+        // switch pathHandlers to std::map); tracking upstream.
+        GET("/") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return resp |> JSON(live_api_help_json(), http_status.OK)
         }
     }


### PR DESCRIPTION
## Summary

Drops the `ANY("*")` catch-all from `live_api.das` and serves the help JSON from a specific `GET("/")` handler instead. Unblocks dasImgui PR #38's POSIX CI (Linux + macOS), which was hanging for the full 120 s popen watchdog on every test that drives daslang-live.

## Root cause (libhv, not daslang)

dasHV's `ANY(path)` forwards to libhv `HttpService::Any` ([HttpService.h:268-277](https://github.com/ithewei/libhv/blob/master/http/server/HttpService.h)), which expands to one `Handle("GET", path, h)`, one `Handle("POST", path, h)`, etc. — registering the wildcard under every method on the same path key.

libhv stores all `(path → method_handlers)` pairs in `pathHandlers`, which is **`std::unordered_map<std::string, ...>`** ([HttpService.h:105](https://github.com/ithewei/libhv/blob/master/include/hv/HttpService.h#L105)). `HttpService::GetRoute` iterates that map in **container order** and takes the first wildcard or path match it finds ([HttpService.cpp:72](https://github.com/ithewei/libhv/blob/master/http/server/HttpService.cpp#L72)). Because the iteration order of `std::unordered_map` is implementation- and bucket-defined, `ANY("*")` can enumerate before `/status`, `/shutdown`, `/command` on Linux libstdc++ (and intermittently on Windows MSVC after rehash). When that happens every request hits the wildcard handler, `request_exit()` never runs, the main loop spins forever, and the parent times out the subprocess (`popen_exit_code = DAS_POPEN_TIMEOUT = 0x7FFFFF01`).

## Workaround

This PR drops `ANY("*")` and registers a specific `GET("/")` for the help dump. `/` is an exact-match path, so it never collides with `/status` etc. — the ordering hazard disappears regardless of how libhv stores routes. Unknown paths now return libhv's default 404; programmatic clients (playwright, the MCP `live_*` tools) never relied on the catch-all.

## Proper fix

Belongs upstream in libhv — sort wildcards last in `GetRoute`, or switch `pathHandlers` to `std::map` for deterministic ordering. This script-side workaround unblocks POSIX CI now; will track the libhv side separately.

## Test plan

- [x] WSL Ubuntu 24.04 (TSAN build): `/status` returns real handler at t=5s, `POST /shutdown` returns `true`, process exits cleanly in <5s. (Previously: 30s of polls all returned the help body, process never exited.)
- [x] Windows MSVC local: dasImgui `test_indexed_dynamic`, `test_await_quiescent`, broader headless suite stay green.
- [ ] CI matrix (daslang's own checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
