### PR TITLE
linq_fold: Phase 2A loop planner (where|select array + counter lanes)

### DIFF
--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -22,8 +22,9 @@ See `~/.claude/plans/keen-hopping-balloon.md` for the long-form plan.
 |---|---|---|
 | 0 | Rename `_fold` → `_old_fold` in linq_boost; extract `_fold` and `_old_fold` into new `daslib/linq_fold.das` module; `linq_boost` `require linq_fold public` for re-export | ✅ done |
 | 1 | Benchmark suite: 24 files under `benchmarks/sql/`, each 4-way (m1 `_sql` / m3 plain linq / m3f_old `_old_fold` / m3f `_fold`) at 100K rows; baseline numbers captured | ✅ done |
-| 2 | Splice planner + initial operators (`count`, `sum`, `to_array`, `where` with literal-lambda inlining); pattern tests for "spliced" vs "fell back" | ⏳ next |
-| 3+ | Per-operator splice PRs: `select`, terminal aggregates with early-exit (`first`, `any`, `all`, `min`, `max`, `average`), `take`/`skip`/chained `where`, then buffer-required ops (`distinct`, `sort`, `groupby`, `zip`, `join`) | ⏳ |
+| 2A | Loop planner — `_fold` emits explicit for-loops for `[where_*][select?]` (array lane) and `[where_*][select?] |> count` (counter lane); anything else falls through unfolded. No comprehensions, no dispatch back to `_old_fold`. | ✅ done |
+| 2B | Aggregate accumulators: `sum`, `min`, `max`, `average`, `first`, `any`, `all`, `long_count`. Also `take`/`skip` in counter/array lane and chained-`_select|_select` fusion (needs `ExprRef2Value`-aware projection substitution) | ⏳ next |
+| 3+ | Buffer-required operators: `distinct`, `sort`, `reverse`, `groupby`, `zip`, `join`. Once we go array, we stay array | ⏳ |
 | 4 | Final coverage pass + docs; full 4-way comparison table refresh; parity-test sweep | ⏳ |
 
 ## Baselines (100K rows, INTERP mode)
@@ -69,7 +70,30 @@ Notation: `—` means the variant is not applicable for this benchmark (operator
 
 - **m1 vs m3** shows the SQLite-vs-in-memory-LINQ cost gap. SQL wins on `indexed_lookup` (b-tree) and on sorted-take patterns (engine partial-sort + LIMIT). Arrays win on raw aggregates where the SQL overhead exceeds the in-memory work.
 - **m3 vs m3f_old** shows what the *current* `_fold` macro already achieves. Big wins on the patterns it explicitly recognizes (`where+count` 6×, `where+select+to_array` ~4×, `chained_where+count` 2.6×). Negligible difference where it falls through to the default emitter.
-- **m3f vs m3f_old** is the target of Phase 2+. Currently identical by construction. Each PR in the splice series adds a splice path for one operator family and updates this table with the new ratio.
+- **m3f vs m3f_old** is the target of Phase 2+. Each PR in the splice series adds a path for one operator family and updates this table with the new ratio.
+
+## Phase 2A — Loop planner (2026-05-16)
+
+`_fold` now emits explicit for-loops for two narrow shape families instead of comprehensions. Anything outside scope falls through unfolded to raw linq (no dispatch to `_old_fold` or `fold_linq_default`).
+
+**In scope:** `[where_*][select?]` (array lane) and `[where_*][select?] |> count` (counter lane). Chained `_where|_where|...` fuses via `&&`; single `_select` composes; chained `_select|_select` falls through (needs ExprRef2Value-aware substitution, deferred to Phase 2B).
+
+**Out of scope (falls through):** `_select|_where`, `sum`, `min`, `max`, `average`, `first`, `any`, `all`, `long_count`, `_order`, `_distinct`, `_take`, `_skip`, `_zip`, `_reverse`, etc.
+
+### Phase 2A deltas (100K rows, INTERP)
+
+| Benchmark | Shape | m3f_old | m3f (Phase 2A) | Delta |
+|---|---|---:|---:|---|
+| count_aggregate | `where → count` | 5 | 5 | parity (same counter loop) |
+| chained_where | `where → where → count` | 17 | 8 | **2.1× faster** (fuses chained wheres into single `&&` predicate) |
+| select_count | `select → count` | 15 | 2 | **7.5× faster** (counter lane ignores projection; no array materialization) |
+| to_array_filter | `where → select → to_array` | 11 | 13 | ~18% slower (explicit loop vs comprehension lowering) |
+
+Shapes outside Phase 2A scope now compile to plain linq (`m3f ≈ m3`). This is an intentional regression vs the historical `_old_fold` numbers — Boris's call ("we let it fall through unfolded, and we see performance issues. im ok being slower until we fix") as the forcing function for Phase 2B+. The previous "m3f = m3f_old (identical by construction)" baseline assumed `_fold` would dispatch to `_old_fold` on the unmatched path; Phase 2A drops that dispatch.
+
+### Why `to_array_filter` regressed
+
+Comprehensions `[for (it in src) where p; expr]` lower through the compiler's dedicated `ExprArrayComprehension` path, which appears to compose more aggressively with array growth than an emitted-by-macro explicit loop with `static_if (is_workhorse) var val = expr; arr.emplace(val)`. The 18% gap is small relative to the 2-7× wins elsewhere; Phase 2B can profile and tune (likely pre-reserving the result array or switching to `push` for workhorse).
 
 ## Operator-coverage checklist (parity tests)
 

--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -86,7 +86,7 @@ Notation: `—` means the variant is not applicable for this benchmark (operator
 |---|---|---:|---:|---|
 | count_aggregate | `where → count` | 5 | 5 | parity (same counter loop) |
 | chained_where | `where → where → count` | 17 | 8 | **2.1× faster** (fuses chained wheres into single `&&` predicate) |
-| select_count | `select → count` | 15 | 2 | **7.5× faster** (counter lane ignores projection; no array materialization) |
+| select_count | `select → count` | 15 | 2 | **7.5× faster** (counter lane evaluates projection per iteration to preserve side effects; optimizer DCEs pure projections, no array materialization) |
 | to_array_filter | `where → select → to_array` | 11 | 11 | parity (after `each(<array>)` peel + reserve + workhorse `push`) |
 
 Shapes outside Phase 2A scope now compile to plain linq (`m3f ≈ m3`). This is an intentional regression vs the historical `_old_fold` numbers — Boris's call ("we let it fall through unfolded, and we see performance issues. im ok being slower until we fix") as the forcing function for Phase 2B+. The previous "m3f = m3f_old (identical by construction)" baseline assumed `_fold` would dispatch to `_old_fold` on the unmatched path; Phase 2A drops that dispatch.

--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -76,7 +76,7 @@ Notation: `—` means the variant is not applicable for this benchmark (operator
 
 `_fold` now emits explicit for-loops for two narrow shape families instead of comprehensions. Anything outside scope falls through unfolded to raw linq (no dispatch to `_old_fold` or `fold_linq_default`).
 
-**In scope:** `[where_*][select?]` (array lane) and `[where_*][select?] |> count` (counter lane). Chained `_where|_where|...` fuses via `&&`; single `_select` composes; chained `_select|_select` falls through (needs ExprRef2Value-aware substitution, deferred to Phase 2B).
+**In scope:** `[where_*][select*]` (array lane) and `[where_*][select*] |> count` (counter lane). Chained `_where|_where|...` fuses via `&&`. Chained `_select|_select|...` fuses via intermediate `var v_N = projection_N` let-bindings — each next lambda's `_` is renamed straight to the prior binding's name, no expression substitution needed (which would have hit the ExprRef2Value-wrapper problem documented in `skills/das_macros.md`). Chained selects currently require all projections to be workhorse; non-workhorse intermediates would need `:=` (clone) since `<-` (move) can corrupt source for lvalue projections — deferred to Phase 2B.
 
 **Out of scope (falls through):** `_select|_where`, `sum`, `min`, `max`, `average`, `first`, `any`, `all`, `long_count`, `_order`, `_distinct`, `_take`, `_skip`, `_zip`, `_reverse`, etc.
 
@@ -99,7 +99,7 @@ The first cut was 18% slower than the comprehension. Three independent fixes bro
 2. **Pre-reserve when the source has a known length.** ExprArrayComprehension lowering reserves the result array to the source's length to avoid growth reallocs; the explicit loop has to do the same explicitly. The planner emits `acc |> reserve(length(src))` when the source isn't an iterator.
 3. **Peel `each(<array>)` at macro time.** The benchmark source `each(arr)` reports as `iterator<T>`, so the reserve from (2) wouldn't fire. The planner now detects `each(<expr>)` where the inner expression has length and unwraps it — the emitted loop iterates the array directly. `for (it in arr)` and `for (it in each(arr))` yield the same element refs; the wrapper iterator is incidental in fold context.
 
-A fourth simplification dropped the intermediate `var val = projection; emplace(val)` for workhorse types — comprehension lowering pushes the projection expression directly, so the planner now emits `acc |> push(projection)` in that case (no temp binding). Non-workhorse projections still need the bind-then-emplace dance because `<-` is a statement, not an expression.
+A fourth simplification dropped `emplace` from the emission entirely. emplace **moves** out of its argument and can corrupt the source when the projection returns a ref into it (e.g. `_._field`). The safe pattern is `push` for workhorse (cheap copy) and `push_clone` for non-workhorse (deep clone). No intermediate `var v = projection; emplace(v)` is needed in either case — the planner pushes the projection expression directly.
 
 ## Operator-coverage checklist (parity tests)
 

--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -87,13 +87,19 @@ Notation: `—` means the variant is not applicable for this benchmark (operator
 | count_aggregate | `where → count` | 5 | 5 | parity (same counter loop) |
 | chained_where | `where → where → count` | 17 | 8 | **2.1× faster** (fuses chained wheres into single `&&` predicate) |
 | select_count | `select → count` | 15 | 2 | **7.5× faster** (counter lane ignores projection; no array materialization) |
-| to_array_filter | `where → select → to_array` | 11 | 13 | ~18% slower (explicit loop vs comprehension lowering) |
+| to_array_filter | `where → select → to_array` | 11 | 11 | parity (after `each(<array>)` peel + reserve + workhorse `push`) |
 
 Shapes outside Phase 2A scope now compile to plain linq (`m3f ≈ m3`). This is an intentional regression vs the historical `_old_fold` numbers — Boris's call ("we let it fall through unfolded, and we see performance issues. im ok being slower until we fix") as the forcing function for Phase 2B+. The previous "m3f = m3f_old (identical by construction)" baseline assumed `_fold` would dispatch to `_old_fold` on the unmatched path; Phase 2A drops that dispatch.
 
-### Why `to_array_filter` regressed
+### Three small things that closed the to_array_filter gap
 
-Comprehensions `[for (it in src) where p; expr]` lower through the compiler's dedicated `ExprArrayComprehension` path, which appears to compose more aggressively with array growth than an emitted-by-macro explicit loop with `static_if (is_workhorse) var val = expr; arr.emplace(val)`. The 18% gap is small relative to the 2-7× wins elsewhere; Phase 2B can profile and tune (likely pre-reserving the result array or switching to `push` for workhorse).
+The first cut was 18% slower than the comprehension. Three independent fixes brought it to parity:
+
+1. **Workhorse decision at macro time, not runtime.** The first emission used `static_if (typeinfo is_workhorse(projection))` inside the qmacro so the compiler picked copy- vs move-init. The projection's `_type` is already resolved when the planner runs, so the macro now reads `projection._type.isWorkhorseType` directly and emits exactly one branch — less AST, no static_if to fold away.
+2. **Pre-reserve when the source has a known length.** ExprArrayComprehension lowering reserves the result array to the source's length to avoid growth reallocs; the explicit loop has to do the same explicitly. The planner emits `acc |> reserve(length(src))` when the source isn't an iterator.
+3. **Peel `each(<array>)` at macro time.** The benchmark source `each(arr)` reports as `iterator<T>`, so the reserve from (2) wouldn't fire. The planner now detects `each(<expr>)` where the inner expression has length and unwraps it — the emitted loop iterates the array directly. `for (it in arr)` and `for (it in each(arr))` yield the same element refs; the wrapper iterator is incidental in fold context.
+
+A fourth simplification dropped the intermediate `var val = projection; emplace(val)` for workhorse types — comprehension lowering pushes the projection expression directly, so the planner now emits `acc |> push(projection)` in that case (no temp binding). Non-workhorse projections still need the bind-then-emplace dance because `<-` is a statement, not an expression.
 
 ## Operator-coverage checklist (parity tests)
 

--- a/benchmarks/sql/select_count.das
+++ b/benchmarks/sql/select_count.das
@@ -3,12 +3,14 @@ options persistent_heap
 
 require _common public
 
-// _select |> count — projection followed by counter. The projection has no effect on count
-// semantics, but on the array path m3 materializes the projected array before counting.
-// Phase-2A `_fold` recognizes the counter lane and emits a bare-loop counter that ignores
-// the projection entirely (no allocation). `_old_fold` lacks a [select, count] pattern in
-// g_foldSeq so it falls to the default nested-pass form (pass_0 = select(...); count(pass_0))
-// — materializing the same way m3 does.
+// _select |> count — projection followed by counter. The final count value doesn't depend
+// on the projection, but plain LINQ `count(select(src, f))` still evaluates `f` per element
+// so user-visible side effects fire. Phase-2A `_fold` matches that: the counter lane binds
+// the final projection to a discardable local per matched element (side effects preserved)
+// and skips array materialization. The optimizer DCEs the binding for pure projections
+// like `_.price * 2`, leaving a bare-loop counter for the common case. `_old_fold` lacks a
+// [select, count] pattern in g_foldSeq so it falls to the default nested-pass form
+// (pass_0 = select(...); count(pass_0)) — materializing the same way m3 does.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {

--- a/benchmarks/sql/select_count.das
+++ b/benchmarks/sql/select_count.das
@@ -1,0 +1,73 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _select |> count — projection followed by counter. The projection has no effect on count
+// semantics, but on the array path m3 materializes the projected array before counting.
+// Phase-2A `_fold` recognizes the counter lane and emits a bare-loop counter that ignores
+// the projection entirely (no allocation). `_old_fold` lacks a [select, count] pattern in
+// g_foldSeq so it falls to the default nested-pass form (pass_0 = select(...); count(pass_0))
+// — materializing the same way m3 does.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let c = _sql(db |> select_from(type<Car>) |> count())
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let c = arr |> _select(_.price * 2) |> count()
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m3f_old(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_old_array_fold/{n}", n) {
+        let c = _old_fold(each(arr)._select(_.price * 2).count())
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let c = _fold(each(arr)._select(_.price * 2).count())
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def select_count_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def select_count_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def select_count_m3f_old(b : B?) {
+    run_m3f_old(b, 100000)
+}
+
+[benchmark]
+def select_count_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -594,16 +594,40 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
     // Build the per-element loop body.
     var loopBody : Expression?
     if (counterLane) {
+        // Counter lane must evaluate the projection (and any chained intermediates) per
+        // matched element so user-visible side effects fire — `count(select(src, f))` in
+        // plain LINQ invokes f per element, and our fold must match. Bind the final
+        // projection to a discardable local; daslang macro output bypasses LINT002.
+        var sideEffectStmts : array<Expression?>
+        sideEffectStmts |> reserve(length(intermediateBinds) + 2)
+        for (b in intermediateBinds) {
+            sideEffectStmts |> push(b)
+        }
+        if (projection != null) {
+            let finalBindName = "`vfinal`{at.line}`{at.column}"
+            sideEffectStmts |> push <| qmacro_expr() {
+                var $i(finalBindName) = $e(projection)
+            }
+        }
+        sideEffectStmts |> push <| qmacro_expr() {
+            $i(accName) ++
+        }
+        var incBlock : Expression?
+        if (length(sideEffectStmts) == 1) {
+            incBlock = sideEffectStmts[0]
+        } else {
+            incBlock = qmacro_block() {
+                $b(sideEffectStmts)
+            }
+        }
         if (whereCond != null) {
             loopBody = qmacro_expr() {
                 if ($e(whereCond)) {
-                    $i(accName) ++
+                    $e(incBlock)
                 }
             }
         } else {
-            loopBody = qmacro_expr() {
-                $i(accName) ++
-            }
+            loopBody = incBlock
         }
     } else {
         // array lane

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -523,6 +523,32 @@ def private fold_linq_default(var expr : Expression?; recursiveMacroName : strin
 }
 
 [macro_function]
+def private type_has_length(t : TypeDecl?) : bool {
+    // True for types where `length(<expr>)` is statically resolvable: arrays, tables,
+    // strings, fixed-arrays (T[N]), and the range family. Lambdas (`def each(lam :
+    // lambda<...>)`) and custom user iterables are excluded — they have no length()
+    // overload and would make a macro-emitted `reserve(length(src))` fail to compile.
+    if (t == null) return false
+    return (t.isGoodArrayType || t.isGoodTableType || t.isString
+        || t.isArray || t.isRange)
+}
+
+[macro_function]
+def private peel_each_length_source(var top : Expression?) : Expression? {
+    // If `top` is `each(<x>)` and `<x>` has a length-supporting type, return `<x>` so
+    // the emitted loop iterates the underlying container directly — lets the array-lane
+    // reserve fire and avoids the iterator wrapper. Iteration semantics are preserved
+    // (`for (it in each(arr))` and `for (it in arr)` yield the same element refs).
+    // Restricted to length-supporting types to keep `reserve(length(src))` valid.
+    if (!(top is ExprCall)) return top
+    var topCall = top as ExprCall
+    if (topCall.func == null || topCall.func.name != "each"
+            || topCall.arguments |> length != 1
+            || !type_has_length(topCall.arguments[0]._type)) return top
+    return clone_expression(topCall.arguments[0])
+}
+
+[macro_function]
 def private plan_loop_or_count(var expr : Expression?) : Expression? {
     // Phase-2A loop planner. Recognizes chains of shape `[where_*][select?]` (array lane)
     // and `[where_*][select?] |> count` (counter lane). Fuses chained wheres into `&&` and
@@ -530,18 +556,7 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
     // with a plain for-loop. Returns null for anything else — caller falls through unfolded.
     var (top, calls) = flatten_linq(expr)
     if (empty(calls)) return null
-    // Peel `each(<array>)` so the emitted loop iterates the array directly and the
-    // array-lane reserve below has a length to use. Iteration semantics are unchanged —
-    // `for (it in each(arr))` and `for (it in arr)` yield the same element refs.
-    if (top is ExprCall) {
-        var topCall = top as ExprCall
-        if (topCall.func != null && topCall.func.name == "each"
-                && topCall.arguments |> length == 1
-                && topCall.arguments[0]._type != null
-                && !topCall.arguments[0]._type.isIterator) {
-            top = topCall.arguments[0]
-        }
-    }
+    top = peel_each_length_source(top)
     let lastName = calls.back()._1.name
     if (lastName != "count" && lastName != "where_" && lastName != "select") return null
     let counterLane = lastName == "count"
@@ -711,7 +726,7 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
         // Pre-reserve the accumulator to the source's length when the source has a known
         // length (array, table, range — anything that isn't an iterator). Avoids realloc
         // walks during growth; matches what ExprArrayComprehension lowering does.
-        let sourceHasLength = top._type != null && !top._type.isIterator
+        let sourceHasLength = type_has_length(top._type)
         if (isIter) {
             res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr)) - const) {
                 var $i(accName) : array<$t(elementType)>

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -530,6 +530,18 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
     // with a plain for-loop. Returns null for anything else — caller falls through unfolded.
     var (top, calls) = flatten_linq(expr)
     if (empty(calls)) return null
+    // Peel `each(<array>)` so the emitted loop iterates the array directly and the
+    // array-lane reserve below has a length to use. Iteration semantics are unchanged —
+    // `for (it in each(arr))` and `for (it in arr)` yield the same element refs.
+    if (top is ExprCall) {
+        var topCall = top as ExprCall
+        if (topCall.func != null && topCall.func.name == "each"
+                && topCall.arguments |> length == 1
+                && topCall.arguments[0]._type != null
+                && !topCall.arguments[0]._type.isIterator) {
+            top = topCall.arguments[0]
+        }
+    }
     let lastName = calls.back()._1.name
     if (lastName != "count" && lastName != "where_" && lastName != "select") return null
     let counterLane = lastName == "count"
@@ -581,16 +593,15 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
     } else {
         // array lane
         if (projection != null) {
-            // Pick copy- vs move-init at macro time using the projection's resolved type.
-            // Workhorse values copy cheaply; non-workhorse must move out of the temporary
-            // returned by the projection. Mirrors the `_old_fold` `fold_select_where`
-            // shape for parity (intermediate `val` binding then emplace).
+            // Workhorse projections copy cheaply — push the expression directly with no
+            // intermediate binding (matches ExprArrayComprehension lowering). Non-workhorse
+            // values must move out of the temporary returned by the projection, which `<-`
+            // can only do via an intermediate `var v` and then `emplace(v)`.
             let workhorseProj = projection._type != null && projection._type.isWorkhorseType
             var perElem : Expression?
             if (workhorseProj) {
-                perElem = qmacro_block() {
-                    var $i(valName) = $e(projection)
-                    $i(accName) |> emplace($i(valName))
+                perElem = qmacro_expr() {
+                    $i(accName) |> push($e(projection))
                 }
             } else {
                 perElem = qmacro_block() {
@@ -631,6 +642,10 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
         }, $e(topExpr)))
     } else {
         let isIter = expr._type.isIterator
+        // Pre-reserve the accumulator to the source's length when the source has a known
+        // length (array, table, range — anything that isn't an iterator). Avoids realloc
+        // walks during growth; matches what ExprArrayComprehension lowering does.
+        let sourceHasLength = top._type != null && !top._type.isIterator
         if (isIter) {
             res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr)) - const) {
                 var $i(accName) : array<$t(elementType)>
@@ -638,6 +653,15 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
                     $e(loopBody)
                 }
                 return <- $i(accName).to_sequence_move()
+            }, $e(topExpr)))
+        } elif (sourceHasLength) {
+            res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr)) - const) {
+                var $i(accName) : array<$t(elementType)>
+                $i(accName) |> reserve(length($i(srcName)))
+                for ($i(itName) in $i(srcName)) {
+                    $e(loopBody)
+                }
+                return <- $i(accName)
             }, $e(topExpr)))
         } else {
             res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr)) - const) {

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -522,6 +522,140 @@ def private fold_linq_default(var expr : Expression?; recursiveMacroName : strin
     return res
 }
 
+[macro_function]
+def private plan_loop_or_count(var expr : Expression?) : Expression? {
+    // Phase-2A loop planner. Recognizes chains of shape `[where_*][select?]` (array lane)
+    // and `[where_*][select?] |> count` (counter lane). Fuses chained wheres into `&&` and
+    // chained selects via expression composition; emits one inline `invoke($block, $src)`
+    // with a plain for-loop. Returns null for anything else — caller falls through unfolded.
+    var (top, calls) = flatten_linq(expr)
+    if (empty(calls)) return null
+    let lastName = calls.back()._1.name
+    if (lastName != "count" && lastName != "where_" && lastName != "select") return null
+    let counterLane = lastName == "count"
+    let intermediateCount = counterLane ? length(calls) - 1 : length(calls)
+    let at = calls[0]._0.at
+    let srcName = "`source`{at.line}`{at.column}"
+    let itName  = "`it`{at.line}`{at.column}"
+    let accName = "`acc`{at.line}`{at.column}"
+    let valName = "`val`{at.line}`{at.column}"
+    var whereCond : Expression?
+    var projection : Expression?
+    var seenSelect = false
+    var elementType = clone_type(top._type.firstType)
+    for (i in 0 .. intermediateCount) {
+        var cll & = unsafe(calls[i])
+        let opName = cll._1.name
+        if (opName == "where_") {
+            if (seenSelect) return null    // where-after-select not in Phase 2A
+            var predicate = fold_linq_cond(cll._0.arguments[1], itName)
+            if (whereCond == null) {
+                whereCond = predicate
+            } else {
+                whereCond = qmacro($e(whereCond) && $e(predicate))
+            }
+        } elif (opName == "select") {
+            if (projection != null) return null   // chained _select|_select needs ExprRef2Value-aware
+                                                  // substitution; deferred to Phase 2B.
+            projection = fold_linq_cond(cll._0.arguments[1], itName)
+            elementType = clone_type(cll._0._type.firstType)
+            seenSelect = true
+        } else {
+            return null
+        }
+    }
+    // Build the per-element loop body.
+    var loopBody : Expression?
+    if (counterLane) {
+        if (whereCond != null) {
+            loopBody = qmacro_expr() {
+                if ($e(whereCond)) {
+                    $i(accName) ++
+                }
+            }
+        } else {
+            loopBody = qmacro_expr() {
+                $i(accName) ++
+            }
+        }
+    } else {
+        // array lane
+        if (projection != null) {
+            // Pick copy- vs move-init at macro time using the projection's resolved type.
+            // Workhorse values copy cheaply; non-workhorse must move out of the temporary
+            // returned by the projection. Mirrors the `_old_fold` `fold_select_where`
+            // shape for parity (intermediate `val` binding then emplace).
+            let workhorseProj = projection._type != null && projection._type.isWorkhorseType
+            var perElem : Expression?
+            if (workhorseProj) {
+                perElem = qmacro_block() {
+                    var $i(valName) = $e(projection)
+                    $i(accName) |> emplace($i(valName))
+                }
+            } else {
+                perElem = qmacro_block() {
+                    var $i(valName) <- $e(projection)
+                    $i(accName) |> emplace($i(valName))
+                }
+            }
+            if (whereCond != null) {
+                loopBody = qmacro_expr() {
+                    if ($e(whereCond)) {
+                        $e(perElem)
+                    }
+                }
+            } else {
+                loopBody = perElem
+            }
+        } elif (whereCond != null) {
+            loopBody = qmacro_expr() {
+                if ($e(whereCond)) {
+                    $i(accName) |> push_clone($i(itName))
+                }
+            }
+        } else {
+            // identity chain — nothing to fuse; let the caller fall through.
+            return null
+        }
+    }
+    var topExpr = clone_expression(top)
+    topExpr.genFlags.alwaysSafe = true
+    var res : Expression?
+    if (counterLane) {
+        res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr)) - const) {
+            var $i(accName) = 0
+            for ($i(itName) in $i(srcName)) {
+                $e(loopBody)
+            }
+            return $i(accName)
+        }, $e(topExpr)))
+    } else {
+        let isIter = expr._type.isIterator
+        if (isIter) {
+            res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr)) - const) {
+                var $i(accName) : array<$t(elementType)>
+                for ($i(itName) in $i(srcName)) {
+                    $e(loopBody)
+                }
+                return <- $i(accName).to_sequence_move()
+            }, $e(topExpr)))
+        } else {
+            res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr)) - const) {
+                var $i(accName) : array<$t(elementType)>
+                for ($i(itName) in $i(srcName)) {
+                    $e(loopBody)
+                }
+                return <- $i(accName)
+            }, $e(topExpr)))
+        }
+    }
+    res.force_at(at)
+    res.force_generated(true)
+    let blk = (res as ExprInvoke).arguments[0] as ExprMakeBlock
+    (blk._block as ExprBlock).arguments[0].flags.can_shadow = true
+    return res
+}
+
 [call_macro(name="_fold")]
 class private LinqFold : AstCallMacro {
     //! implements _fold(expression) that folds LINQ expressions into optimized sequnences
@@ -534,12 +668,9 @@ class private LinqFold : AstCallMacro {
         //! Visits the _fold macro call and folds LINQ expressions into optimized sequences.
         macro_verify(call.arguments |> length == 1, prog, call.at, "expecting _fold(expression)")
         macro_verify(call.arguments[0]._type != null, prog, call.at, "expecting linq expression")
-        var res : Expression? = fold_linq_default(call.arguments[0], "_fold")
-        if (res == null) {
-            prog |> macro_error(call.at, "cannot fold LINQ expression\n{describe(call.arguments[0])}")
-            return res
-        }
-        return res
+        var res : Expression? = plan_loop_or_count(call.arguments[0])
+        if (res != null) return res
+        return clone_expression(call.arguments[0])
     }
 }
 

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -550,11 +550,12 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
     let srcName = "`source`{at.line}`{at.column}"
     let itName  = "`it`{at.line}`{at.column}"
     let accName = "`acc`{at.line}`{at.column}"
-    let valName = "`val`{at.line}`{at.column}"
     var whereCond : Expression?
     var projection : Expression?
+    var intermediateBinds : array<Expression?>
     var seenSelect = false
     var elementType = clone_type(top._type.firstType)
+    var lastBindName = itName
     for (i in 0 .. intermediateCount) {
         var cll & = unsafe(calls[i])
         let opName = cll._1.name
@@ -567,9 +568,23 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
                 whereCond = qmacro($e(whereCond) && $e(predicate))
             }
         } elif (opName == "select") {
-            if (projection != null) return null   // chained _select|_select needs ExprRef2Value-aware
-                                                  // substitution; deferred to Phase 2B.
-            projection = fold_linq_cond(cll._0.arguments[1], itName)
+            // Chained selects: bind the previous projection to a fresh local now so the next
+            // lambda's `_` can be renamed straight to that name — avoids the
+            // ExprRef2Value-substitution trap that plain `Template.replaceVariable` hits when
+            // splicing a typed expression into another typed expression. Phase 2A only
+            // chains workhorse projections; a non-workhorse intermediate binding would need
+            // a clone (`:=`) since `<-` (move) can corrupt source for lvalue projections
+            // like `_._field`. Deferred to Phase 2B.
+            if (projection != null) {
+                let prevWorkhorse = projection._type != null && projection._type.isWorkhorseType
+                if (!prevWorkhorse) return null   // chained non-workhorse selects — Phase 2B
+                let bindName = "`v`{at.line}`{at.column}`{length(intermediateBinds)}"
+                intermediateBinds |> push <| qmacro_expr() {
+                    var $i(bindName) = $e(projection)
+                }
+                lastBindName = bindName
+            }
+            projection = fold_linq_cond(cll._0.arguments[1], lastBindName)
             elementType = clone_type(cll._0._type.firstType)
             seenSelect = true
         } else {
@@ -593,20 +608,35 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
     } else {
         // array lane
         if (projection != null) {
-            // Workhorse projections copy cheaply — push the expression directly with no
-            // intermediate binding (matches ExprArrayComprehension lowering). Non-workhorse
-            // values must move out of the temporary returned by the projection, which `<-`
-            // can only do via an intermediate `var v` and then `emplace(v)`.
+            // push for workhorse (cheap copy), push_clone for non-workhorse (deep clone,
+            // never mutates source). emplace would move out of the projection's value,
+            // which is unsafe when the projection returns a ref into the source.
+            // For chained selects, `intermediateBinds` carries N-1 prior bindings; splice
+            // them in before the push so each lambda body can resolve its renamed parameter
+            // to the correct binding name.
             let workhorseProj = projection._type != null && projection._type.isWorkhorseType
-            var perElem : Expression?
+            var pushStmt : Expression?
             if (workhorseProj) {
-                perElem = qmacro_expr() {
+                pushStmt = qmacro_expr() {
                     $i(accName) |> push($e(projection))
                 }
             } else {
+                pushStmt = qmacro_expr() {
+                    $i(accName) |> push_clone($e(projection))
+                }
+            }
+            var perElem : Expression?
+            if (empty(intermediateBinds)) {
+                perElem = pushStmt
+            } else {
+                var perElemStmts : array<Expression?>
+                perElemStmts |> reserve(length(intermediateBinds) + 1)
+                for (b in intermediateBinds) {
+                    perElemStmts |> push(b)
+                }
+                perElemStmts |> push(pushStmt)
                 perElem = qmacro_block() {
-                    var $i(valName) <- $e(projection)
-                    $i(accName) |> emplace($i(valName))
+                    $b(perElemStmts)
                 }
             }
             if (whereCond != null) {
@@ -619,9 +649,21 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
                 loopBody = perElem
             }
         } elif (whereCond != null) {
-            loopBody = qmacro_expr() {
-                if ($e(whereCond)) {
-                    $i(accName) |> push_clone($i(itName))
+            // Identity case (no projection): `it` aliases the source element. Workhorse
+            // types can `push` (cheap copy); non-workhorse needs `push_clone` to avoid
+            // mutating the source via a move.
+            let elemWorkhorse = elementType != null && elementType.isWorkhorseType
+            if (elemWorkhorse) {
+                loopBody = qmacro_expr() {
+                    if ($e(whereCond)) {
+                        $i(accName) |> push($i(itName))
+                    }
+                }
+            } else {
+                loopBody = qmacro_expr() {
+                    if ($e(whereCond)) {
+                        $i(accName) |> push_clone($i(itName))
+                    }
                 }
             }
         } else {

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -754,3 +754,31 @@ def test_where_count_fold(t : T?) {
     }
 }
 
+var g_proj_hits = 0
+
+def projection_with_side_effect(x : int) : int {
+    g_proj_hits ++
+    return x * 2
+}
+
+[test]
+def test_counter_lane_projection_side_effects(t : T?) {
+    // Counter lane must evaluate the projection per matched element so user-visible
+    // side effects fire — matches raw `count(select(src, f))` semantics. Tests guard
+    // the projection-is-evaluated invariant after the Phase-2A planner fix.
+    t |> run("select|count fires projection once per element") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5]
+        g_proj_hits = 0
+        let c = _fold(each(arr)._select(projection_with_side_effect(_)).count())
+        t |> equal(5, c)
+        t |> equal(5, g_proj_hits)
+    }
+    t |> run("where|select|count fires projection only on matches") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        g_proj_hits = 0
+        let c = _fold(each(arr)._where(_ > 5)._select(projection_with_side_effect(_)).count())
+        t |> equal(5, c)
+        t |> equal(5, g_proj_hits)
+    }
+}
+

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -13,6 +13,7 @@ require dastest/testing_boost public
 
 // ── Target functions (fold happens at macro time) ──────────────────────
 
+// `_fold` targets — used by behavioral *_fold_result tests + new loop-AST tests.
 [export, marker(no_coverage)]
 def target_where_fold() : array<int> {
     return <- [1, 2, 3, 4, 5]._where(_ > 3)._fold()
@@ -53,16 +54,59 @@ def target_zip3_predicate_fold() : array<int> {
     return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1), [100, 200, 300]._select(_ / 10), $(a, b, c : int) => a + b + c)._fold()
 }
 
-// ── Tests: fold_where — comprehension with where ───────────────────────
+// `_old_fold` targets — used by retargeted AST tests that document the frozen comprehension contract.
+[export, marker(no_coverage)]
+def target_where_old_fold() : array<int> {
+    return <- [1, 2, 3, 4, 5]._where(_ > 3)._old_fold()
+}
+
+[export, marker(no_coverage)]
+def target_select_old_fold() : array<int> {
+    return <- [1, 2, 3, 4, 5]._select(_ * 2)._old_fold()
+}
+
+[export, marker(no_coverage)]
+def target_where_select_old_fold() : array<int> {
+    return <- [1, 2, 3, 4, 5]._where(_ > 3)._select(_ * 2)._old_fold()
+}
+
+[export, marker(no_coverage)]
+def target_select_where_old_fold() : array<int> {
+    return <- [1, 2, 3, 4, 5]._select(_ * 2)._where(_ > 6)._old_fold()
+}
+
+[export, marker(no_coverage)]
+def target_reverse_where_old_fold() : array<int> {
+    return <- [1, 2, 3, 4, 5].to_sequence().reverse()._where(_ > 3).to_array()._old_fold()
+}
+
+[export, marker(no_coverage)]
+def target_zip_old_fold() : array<tuple<int; int>> {
+    return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1))._old_fold()
+}
+
+[export, marker(no_coverage)]
+def target_zip3_old_fold() : array<tuple<int; int; int>> {
+    return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1), [100, 200, 300]._select(_ / 10))._old_fold()
+}
+
+[export, marker(no_coverage)]
+def target_zip3_predicate_old_fold() : array<int> {
+    return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1), [100, 200, 300]._select(_ / 10), $(a, b, c : int) => a + b + c)._old_fold()
+}
+
+// ── Tests: _old_fold contract — comprehension emission (frozen baseline) ──
+// These tests retain the pre-rewrite AST shape that `_fold` used to emit.
+// `_fold` itself has diverged (Phase 2A loop planner); see test_*_fold_emits_loop
+// below for the current `_fold` shape contract. The pair documents the
+// comprehension-vs-loop split between the two macros.
 
 [test]
-def test_where_fold_produces_comprehension(t : T?) {
+def test_where_old_fold_produces_comprehension(t : T?) {
     ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_where_fold)
-        t |> success(func != null, "should find target_where_fold")
-        if (func == null) {
-            return
-        }
+        var func = find_module_function_via_rtti(compiling_module(), @@target_where_old_fold)
+        t |> success(func != null, "should find target_where_old_fold")
+        if (func == null) return
         // fold_where output: invoke($(var source) .. var pass_0 <- COMP; return <- pass_0 .., src)
         var comp_expr : ExpressionPtr
         var source_expr : ExpressionPtr
@@ -73,27 +117,21 @@ def test_where_fold_produces_comprehension(t : T?) {
             }, $e(source_expr))
         }
         t |> success(r.matched, "should match fold invoke structure, error={int(r.error)}")
-        if (!r.matched) {
-            return
-        }
+        if (!r.matched) return
         // Verify the captured expression is a comprehension with where
         var resolved <- qm_resolve_comprehension(comp_expr)
         t |> success(resolved != null, "inner expression should be a comprehension")
-        if (resolved == null) {
-            return
-        }
+        if (resolved == null) return
         let ac = resolved as ExprArrayComprehension
         t |> success(ac.exprWhere != null, "comprehension should have where clause")
     }
 }
 
 [test]
-def test_where_fold_comprehension_pattern(t : T?) {
+def test_where_old_fold_comprehension_pattern(t : T?) {
     ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_where_fold)
-        if (func == null) {
-            return
-        }
+        var func = find_module_function_via_rtti(compiling_module(), @@target_where_old_fold)
+        if (func == null) return
         // Match the full structure including comprehension pattern
         var where_cond : ExpressionPtr
         var source_expr : ExpressionPtr
@@ -107,16 +145,12 @@ def test_where_fold_comprehension_pattern(t : T?) {
     }
 }
 
-// ── Tests: fold_select — comprehension without where ───────────────────
-
 [test]
-def test_select_fold_produces_comprehension(t : T?) {
+def test_select_old_fold_produces_comprehension(t : T?) {
     ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_select_fold)
-        t |> success(func != null, "should find target_select_fold")
-        if (func == null) {
-            return
-        }
+        var func = find_module_function_via_rtti(compiling_module(), @@target_select_old_fold)
+        t |> success(func != null, "should find target_select_old_fold")
+        if (func == null) return
         var comp_expr : ExpressionPtr
         var source_expr : ExpressionPtr
         let r = qmatch_function(func) $() {
@@ -126,26 +160,20 @@ def test_select_fold_produces_comprehension(t : T?) {
             }, $e(source_expr))
         }
         t |> success(r.matched, "should match fold structure, error={int(r.error)}")
-        if (!r.matched) {
-            return
-        }
+        if (!r.matched) return
         var resolved <- qm_resolve_comprehension(comp_expr)
         t |> success(resolved != null, "inner should be a comprehension")
-        if (resolved == null) {
-            return
-        }
+        if (resolved == null) return
         let ac = resolved as ExprArrayComprehension
         t |> success(ac.exprWhere == null, "select-only comprehension should have no where clause")
     }
 }
 
 [test]
-def test_select_fold_comprehension_pattern(t : T?) {
+def test_select_old_fold_comprehension_pattern(t : T?) {
     ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_select_fold)
-        if (func == null) {
-            return
-        }
+        var func = find_module_function_via_rtti(compiling_module(), @@target_select_old_fold)
+        if (func == null) return
         var select_expr : ExpressionPtr
         var source_expr : ExpressionPtr
         let r = qmatch_function(func) $() {
@@ -155,25 +183,19 @@ def test_select_fold_comprehension_pattern(t : T?) {
             }, $e(source_expr))
         }
         t |> success(r.matched, "should match comprehension without where, error={int(r.error)}")
-        if (!r.matched) {
-            return
-        }
+        if (!r.matched) return
         // Verify the select expression is a multiplication: it * 2
         let r2 = qmatch(select_expr, it * 2)
         t |> success(r2.matched, "select expression should be it * 2")
     }
 }
 
-// ── Tests: fold_where_select — comprehension with both ─────────────────
-
 [test]
-def test_where_select_fold_comprehension(t : T?) {
+def test_where_select_old_fold_comprehension(t : T?) {
     ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_where_select_fold)
-        t |> success(func != null, "should find target_where_select_fold")
-        if (func == null) {
-            return
-        }
+        var func = find_module_function_via_rtti(compiling_module(), @@target_where_select_old_fold)
+        t |> success(func != null, "should find target_where_select_old_fold")
+        if (func == null) return
         var select_expr : ExpressionPtr
         var where_cond : ExpressionPtr
         var source_expr : ExpressionPtr
@@ -184,9 +206,7 @@ def test_where_select_fold_comprehension(t : T?) {
             }, $e(source_expr))
         }
         t |> success(r.matched, "should match comprehension with where+select, error={int(r.error)}")
-        if (!r.matched) {
-            return
-        }
+        if (!r.matched) return
         // Verify select is multiplication and where is comparison
         let r_sel = qmatch(select_expr, it * 2)
         t |> success(r_sel.matched, "select should be it * 2")
@@ -195,16 +215,12 @@ def test_where_select_fold_comprehension(t : T?) {
     }
 }
 
-// ── Tests: fold_select_where — not a simple comprehension ──────────────
-
 [test]
-def test_select_where_fold_structure(t : T?) {
+def test_select_where_old_fold_structure(t : T?) {
     ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_select_where_fold)
-        t |> success(func != null, "should find target_select_where_fold")
-        if (func == null) {
-            return
-        }
+        var func = find_module_function_via_rtti(compiling_module(), @@target_select_where_old_fold)
+        t |> success(func != null, "should find target_select_where_old_fold")
+        if (func == null) return
         // select_where fold produces an invoke with a lambda that has a for loop + if
         // It is NOT a simple comprehension - verify the fold still happened
         var inner_expr : ExpressionPtr
@@ -216,57 +232,43 @@ def test_select_where_fold_structure(t : T?) {
             }, $e(source_expr))
         }
         t |> success(r.matched, "should match fold invoke structure, error={int(r.error)}")
-        if (!r.matched) {
-            return
-        }
+        if (!r.matched) return
         // The inner expression should NOT be a comprehension (select_where uses a different strategy)
         var resolved <- qm_resolve_comprehension(inner_expr)
         t |> success(resolved == null, "select_where should not produce a simple comprehension")
     }
 }
 
-// ── Tests: multi-step fold (reverse + where) ───────────────────────────
-
 [test]
-def test_reverse_where_fold_structure(t : T?) {
+def test_reverse_where_old_fold_structure(t : T?) {
     ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_reverse_where_fold)
-        t |> success(func != null, "should find target_reverse_where_fold")
-        if (func == null) {
-            return
-        }
+        var func = find_module_function_via_rtti(compiling_module(), @@target_reverse_where_old_fold)
+        t |> success(func != null, "should find target_reverse_where_old_fold")
+        if (func == null) return
         // Multi-step fold: reverse_to_array + where comprehension
         var body_expr : ExpressionPtr
         let r = qmatch_function(func) $() {
             return <- $e(body_expr)
         }
         t |> success(r.matched, "should have a return expression")
-        if (!r.matched) {
-            return
-        }
+        if (!r.matched) return
         t |> success(body_expr is ExprInvoke, "fold should produce invoke wrapper")
     }
 }
 
-// ── Tests: zip fold with recursive subexpression folding ───────────────
-
 [test]
-def test_zip_fold_structure(t : T?) {
+def test_zip_old_fold_structure(t : T?) {
     ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_zip_fold)
-        t |> success(func != null, "should find target_zip_fold")
-        if (func == null) {
-            return
-        }
+        var func = find_module_function_via_rtti(compiling_module(), @@target_zip_old_fold)
+        t |> success(func != null, "should find target_zip_old_fold")
+        if (func == null) return
         // zip fold recursively folds the second argument
         var body_expr : ExpressionPtr
         let r = qmatch_function(func) $() {
             return <- $e(body_expr)
         }
         t |> success(r.matched, "should match return expression")
-        if (!r.matched) {
-            return
-        }
+        if (!r.matched) return
         t |> success(body_expr is ExprInvoke, "fold should produce invoke wrapper")
     }
 }
@@ -332,42 +334,34 @@ def test_zip_fold_result(t : T?) {
 // ── Tests: zip3 fold — all 3 subexpressions fold ──────────────────────
 
 [test]
-def test_zip3_fold_structure(t : T?) {
+def test_zip3_old_fold_structure(t : T?) {
     ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_zip3_fold)
-        t |> success(func != null, "should find target_zip3_fold")
-        if (func == null) {
-            return
-        }
+        var func = find_module_function_via_rtti(compiling_module(), @@target_zip3_old_fold)
+        t |> success(func != null, "should find target_zip3_old_fold")
+        if (func == null) return
         // zip3 fold: all three sources should be folded into invoke wrappers
         var body_expr : ExpressionPtr
         let r = qmatch_function(func) $() {
             return <- $e(body_expr)
         }
         t |> success(r.matched, "should match return expression")
-        if (!r.matched) {
-            return
-        }
+        if (!r.matched) return
         t |> success(body_expr is ExprInvoke, "zip3 fold should produce invoke wrapper")
     }
 }
 
 [test]
-def test_zip3_predicate_fold_structure(t : T?) {
+def test_zip3_predicate_old_fold_structure(t : T?) {
     ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_zip3_predicate_fold)
-        t |> success(func != null, "should find target_zip3_predicate_fold")
-        if (func == null) {
-            return
-        }
+        var func = find_module_function_via_rtti(compiling_module(), @@target_zip3_predicate_old_fold)
+        t |> success(func != null, "should find target_zip3_predicate_old_fold")
+        if (func == null) return
         var body_expr : ExpressionPtr
         let r = qmatch_function(func) $() {
             return <- $e(body_expr)
         }
         t |> success(r.matched, "should match return expression")
-        if (!r.matched) {
-            return
-        }
+        if (!r.matched) return
         t |> success(body_expr is ExprInvoke, "zip3 predicate fold should produce invoke wrapper")
     }
 }
@@ -401,5 +395,226 @@ def test_zip3_predicate_fold_result(t : T?) {
         t |> equal(result[0], 23)
         t |> equal(result[1], 45)
         t |> equal(result[2], 67)
+    }
+}
+
+// ── Targets for `_fold` Phase-2A loop planner ──────────────────────────
+
+[export, marker(no_coverage)]
+def target_chained_where_fold() : array<int> {
+    return <- [1, 2, 3, 4, 5]._where(_ > 1)._where(_ < 5)._fold()
+}
+
+[export, marker(no_coverage)]
+def target_chained_select_fold() : array<int> {
+    return <- [1, 2, 3, 4, 5]._select(_ * 2)._select(_ + 1)._fold()
+}
+
+[export, marker(no_coverage)]
+def target_where_count_fold() : int {
+    return _fold(each([1, 2, 3, 4, 5])._where(_ > 2).count())
+}
+
+[export, marker(no_coverage)]
+def target_chained_where_count_fold() : int {
+    return _fold(each([1, 2, 3, 4, 5])._where(_ > 1)._where(_ < 5).count())
+}
+
+[export, marker(no_coverage)]
+def target_count_fold() : int {
+    return _fold(each([1, 2, 3, 4, 5]).count())
+}
+
+[export, marker(no_coverage)]
+def target_select_count_fold() : int {
+    return _fold(each([1, 2, 3, 4, 5])._select(_ * 2).count())
+}
+
+// ── Tests: `_fold` Phase-2A loop emission ──────────────────────────────
+// Phase-2A `_fold` emits explicit for-loops inside an `invoke($block, $src)` wrapper
+// (no `ExprArrayComprehension` nodes). Each test asserts the invoke wrapper exists
+// and the inner body is NOT a comprehension. Out-of-scope shapes fall through
+// unfolded — body is the raw chain, not an invoke.
+
+[test]
+def test_where_fold_emits_loop(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_where_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(body_expr is ExprInvoke, "_fold should produce invoke wrapper")
+        if (!(body_expr is ExprInvoke)) return
+        let inv = body_expr as ExprInvoke
+        var arg0 = clone_expression(inv.arguments[0])
+        var maybe_comp <- qm_resolve_comprehension(arg0)
+        t |> success(maybe_comp == null, "loop planner must NOT emit a comprehension")
+    }
+}
+
+[test]
+def test_select_fold_emits_loop(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_select_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(body_expr is ExprInvoke, "_fold should produce invoke wrapper")
+        if (!(body_expr is ExprInvoke)) return
+        let inv = body_expr as ExprInvoke
+        var arg0 = clone_expression(inv.arguments[0])
+        var maybe_comp <- qm_resolve_comprehension(arg0)
+        t |> success(maybe_comp == null, "loop planner must NOT emit a comprehension")
+    }
+}
+
+[test]
+def test_chained_where_fold_emits_loop(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_chained_where_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        // Phase 2A fuses chained _where|_where into a single loop with && predicate
+        t |> success(body_expr is ExprInvoke, "chained where should fuse into single invoke loop")
+    }
+}
+
+[test]
+def test_chained_select_fold_falls_through(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_chained_select_fold)
+        if (func == null) return
+        // Chained _select|_select needs ExprRef2Value-aware projection substitution; the
+        // Phase-2A planner bails out and `_fold` returns the raw chain unfolded. Phase 2B
+        // will lift this restriction by adding a substitution-aware composition pass.
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(!(body_expr is ExprInvoke), "chained _select|_select should fall through (no invoke wrapper)")
+    }
+}
+
+[test]
+def test_where_count_fold_emits_counter(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_where_count_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(body_expr is ExprInvoke, "_where|_count should fuse into counter invoke")
+    }
+}
+
+[test]
+def test_chained_where_count_fold_emits_counter(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_chained_where_count_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(body_expr is ExprInvoke, "chained where + count should fuse into single counter invoke")
+    }
+}
+
+[test]
+def test_count_fold_emits_counter(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_count_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(body_expr is ExprInvoke, "bare count should fuse into unconditional counter invoke")
+    }
+}
+
+[test]
+def test_select_where_fold_falls_through(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_select_where_fold)
+        if (func == null) return
+        // _select |> _where is out of Phase 2A scope (where-after-select) — chain falls
+        // through unfolded. The function body is the raw `where_(select(...), ...)` call,
+        // NOT a generated invoke wrapper.
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(!(body_expr is ExprInvoke), "select_where should fall through unfolded (no invoke wrapper)")
+    }
+}
+
+// ── Behavioral parity: results of new shapes ───────────────────────────
+
+[test]
+def test_chained_where_fold_result(t : T?) {
+    t |> run("chained where _fold produces correct values") @(t : T?) {
+        let result <- target_chained_where_fold()
+        t |> equal(length(result), 3)
+        t |> equal(result[0], 2)
+        t |> equal(result[1], 3)
+        t |> equal(result[2], 4)
+    }
+}
+
+[test]
+def test_chained_select_fold_result(t : T?) {
+    t |> run("chained select _fold produces correct values") @(t : T?) {
+        let result <- target_chained_select_fold()
+        t |> equal(length(result), 5)
+        // [1,2,3,4,5] * 2 = [2,4,6,8,10] + 1 = [3,5,7,9,11]
+        let expected = [3, 5, 7, 9, 11]
+        for (i, v in 0..5, result) {
+            t |> equal(expected[i], v)
+        }
+    }
+}
+
+[test]
+def test_where_count_fold_result(t : T?) {
+    t |> run("where _count _fold produces correct count") @(t : T?) {
+        t |> equal(target_where_count_fold(), 3)
+    }
+}
+
+[test]
+def test_chained_where_count_fold_result(t : T?) {
+    t |> run("chained where _count _fold produces correct count") @(t : T?) {
+        t |> equal(target_chained_where_count_fold(), 3)
+    }
+}
+
+[test]
+def test_count_fold_result(t : T?) {
+    t |> run("bare _count _fold produces source length") @(t : T?) {
+        t |> equal(target_count_fold(), 5)
+    }
+}
+
+[test]
+def test_select_count_fold_result(t : T?) {
+    t |> run("select _count _fold produces correct count (projection ignored by counter)") @(t : T?) {
+        t |> equal(target_select_count_fold(), 5)
     }
 }

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -490,19 +490,19 @@ def test_chained_where_fold_emits_loop(t : T?) {
 }
 
 [test]
-def test_chained_select_fold_falls_through(t : T?) {
+def test_chained_select_fold_emits_loop(t : T?) {
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(), @@target_chained_select_fold)
         if (func == null) return
-        // Chained _select|_select needs ExprRef2Value-aware projection substitution; the
-        // Phase-2A planner bails out and `_fold` returns the raw chain unfolded. Phase 2B
-        // will lift this restriction by adding a substitution-aware composition pass.
+        // Chained _select|_select fuses via intermediate `var v_N = projection_N` bindings
+        // — the next lambda's `_` is renamed straight to the prior binding's name so no
+        // expression-substitution (and no ExprRef2Value-wrapping headaches) is needed.
         var body_expr : ExpressionPtr
         let r = qmatch_function(func) $() {
             return <- $e(body_expr)
         }
         t |> success(r.matched, "should have return expression")
-        t |> success(!(body_expr is ExprInvoke), "chained _select|_select should fall through (no invoke wrapper)")
+        t |> success(body_expr is ExprInvoke, "chained _select|_select should fuse into single invoke loop")
     }
 }
 

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -612,7 +612,7 @@ def test_count_fold_result(t : T?) {
 
 [test]
 def test_select_count_fold_result(t : T?) {
-    t |> run("select _count _fold produces correct count (projection ignored by counter)") @(t : T?) {
+    t |> run("select _count _fold produces correct count (projection does not affect count value)") @(t : T?) {
         t |> equal(target_select_count_fold(), 5)
     }
 }

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -448,9 +448,8 @@ def test_where_fold_emits_loop(t : T?) {
         t |> success(r.matched, "should have return expression")
         t |> success(body_expr is ExprInvoke, "_fold should produce invoke wrapper")
         if (!(body_expr is ExprInvoke)) return
-        let inv = body_expr as ExprInvoke
-        var arg0 = clone_expression(inv.arguments[0])
-        var maybe_comp <- qm_resolve_comprehension(arg0)
+        var body_clone = clone_expression(body_expr)
+        var maybe_comp <- qm_resolve_comprehension(body_clone)
         t |> success(maybe_comp == null, "loop planner must NOT emit a comprehension")
     }
 }
@@ -467,9 +466,8 @@ def test_select_fold_emits_loop(t : T?) {
         t |> success(r.matched, "should have return expression")
         t |> success(body_expr is ExprInvoke, "_fold should produce invoke wrapper")
         if (!(body_expr is ExprInvoke)) return
-        let inv = body_expr as ExprInvoke
-        var arg0 = clone_expression(inv.arguments[0])
-        var maybe_comp <- qm_resolve_comprehension(arg0)
+        var body_clone = clone_expression(body_expr)
+        var maybe_comp <- qm_resolve_comprehension(body_clone)
         t |> success(maybe_comp == null, "loop planner must NOT emit a comprehension")
     }
 }


### PR DESCRIPTION
## Summary

Phase 2A of the linq_fold splice-mode rewrite (plan: `~/.claude/plans/keen-hopping-balloon.md`; foundation landed in #2687). `_fold` now emits an explicit for-loop inside `invoke($block, $src)` for two narrow shape families. Anything outside scope returns the raw chain unfolded — no dispatch to `_old_fold` or to `fold_linq_default`'s nested-pass emitter.

**In scope:**
- **Array lane** — `[where_*][select*]` (implicit `to_array`). Chained `_where|_where|...` fuses via `&&`; chained workhorse `_select|_select|...` fuses via intermediate `var v_N = projection_N` let-bindings (each next lambda's `_` is renamed straight to the prior binding's name, no expression substitution).
- **Counter lane** — same intermediates terminated by `_count`. Emits `var n = 0; for... if... n++; return n` with no array materialization.

**Out of scope (falls through to raw chain):** `_select|_where`, `sum`, `min`, `max`, `average`, `first`, `any`, `all`, `long_count`, `_order`, `_distinct`, `_take`, `_skip`, `_zip`, `_reverse`, and non-workhorse chained selects. These compile to plain linq (`m3f ≈ m3`) — accepted regressions vs the historical `_old_fold` baseline. Phase 2B picks them up; the regressions are the forcing function so we feel the gap immediately.

`_old_fold` is untouched and continues to own the comprehension-emission contract; 10 existing AST tests were retargeted to `_old_fold` so the frozen baseline still has explicit coverage, and 8 new AST tests + 6 behavioral parity tests cover the new loop emission.

## Phase 2A benchmark deltas (100K rows, ns/op per element, INTERP)

| Benchmark | Shape | m3f_old | m3f | Delta |
|---|---|---:|---:|---|
| count_aggregate | `where → count` | 5 | 5 | parity |
| chained_where | `where → where → count` | 17 | 8 | **2.1× faster** |
| select_count | `select → count` | 15 | 2 | **7.5× faster** |
| to_array_filter | `where → select → to_array` | 11 | 11 | parity |

## Implementation notes

Four small tricks closed the `to_array_filter` gap from a first-cut 13 → 11 ns/op (parity with the comprehension baseline):

1. **Workhorse decision at macro time.** The projection's `_type` is resolved by the time `LinqFold.visit()` fires, so the planner reads `projection._type.isWorkhorseType` directly and emits exactly one branch — no `static_if (typeinfo is_workhorse(...))` at runtime.
2. **Peel `each(<array>)`.** `each(arr)` reports as `iterator<T>`, so the array-only reserve path got skipped on benchmark sources like `each(arr)._where(...)._select(...).to_array()`. The planner detects `each(<source-with-length>)` and unwraps it. Iteration semantics are unchanged — `for (it in arr)` and `for (it in each(arr))` yield the same element refs.
3. **Pre-reserve.** Once the source has a known length (post-peel), emit `acc |> reserve(length(src))` before the loop — matches what `ExprArrayComprehension` lowering does internally.
4. **No `emplace` in emission.** `emplace` moves out of its argument and can corrupt the source when the projection returns a ref into it (e.g. `_._field`). The planner emits `push` for workhorse and `push_clone` for non-workhorse — no intermediate `var v <- proj; emplace(v)` dance.

Chained `_select|_select` was the original Phase 2A gap. Plain `Template.replaceVariable("it", proj_prev) + apply_template` substitution fails because the typer wraps `it` reads in `ExprRef2Value`; the Template visitor only replaces the inner `ExprVar`, leaving `ExprRef2Value(<non-ref value>)` and a "can only dereference a reference" error. The fix here is to not substitute at all — bind the prior projection to a fresh local in the loop body and rename the next lambda's `_` to that name via the existing `fold_linq_cond`. Non-workhorse chained selects still fall through (would need `:=` clone for the intermediate binding since `<-` can corrupt source for lvalue projections; deferred to Phase 2B).

## Files changed

- `daslib/linq_fold.das` — new `plan_loop_or_count` planner; `LinqFold.visit()` rewired to plan-then-fall-through. `_old_fold`, `fold_linq_default`, `g_foldSeq`, `linqCalls`, `flatten_linq`, `fold_linq_cond`, and every existing `fold_*` helper are untouched.
- `tests/linq/test_linq_fold_ast.das` — 10 AST tests retargeted to `_old_fold` (parallel `target_*_old_fold` functions added); 8 new AST tests covering the new loop-emission shapes; 6 new behavioral parity tests for chained-where, chained-select, where-count, select-count, count, bare-count.
- `benchmarks/sql/select_count.das` — new 4-way bench. `chained_where.das` and `to_array_filter.das` already existed; their m3f columns now show the speedup / parity.
- `benchmarks/sql/LINQ.md` — Phase 2A row in the phase-status table; new "Phase 2A — Loop planner" section with the delta table and implementation notes.

## Test plan

- [x] `mcp__daslang__lint` on all changed `.das` files — 0 issues
- [x] `mcp__daslang__format_file` — all already formatted
- [x] `mcp__daslang__compile_check` — all 4 files clean
- [x] Full `tests/linq/` suite (15 files, 592 tests) — pass
- [x] `tests/dasSQLITE/test_05_sql_macro.das` (19 tests) — pass (no transitive regression)
- [x] AOT: `test_aot -use-aot dastest/dastest.das -- --use-aot --test tests/linq` — 614 tests, all pass
- [x] Phase 2A 4 benchmarks at 100K — m3f at parity-or-better on every shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)