### PR TITLE
mouse-data/docs: 21 new + 1 updated card from linq_fold + dasImgui PR #38

### DIFF
--- a/mouse-data/docs/are-there-parity-tests-in-tests-linq-that-compare-fold-output-to-the-underlying-linq-operators.md
+++ b/mouse-data/docs/are-there-parity-tests-in-tests-linq-that-compare-fold-output-to-the-underlying-linq-operators.md
@@ -1,0 +1,37 @@
+---
+slug: are-there-parity-tests-in-tests-linq-that-compare-fold-output-to-the-underlying-linq-operators
+title: Are there parity tests in tests/linq/ that compare `_fold` output to the underlying linq operators?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+There's no file named "parity" or similar. The parity-test surface IS the broader [tests/linq/](tests/linq/) directory:
+
+- `test_linq.das` — comprehension basics
+- `test_linq_aggregation.das` — count/sum/min/max/avg
+- `test_linq_querying.das` — any/all/contains
+- `test_linq_transform.das` — select / select_many / zip
+- `test_linq_sorting.das` — order / reverse
+- `test_linq_group_by.das` — group_by / having
+- `test_linq_join.das` — joins
+- `test_linq_partition.das` — take / skip / chunk / take_while / skip_while
+- `test_linq_set.das` — distinct / union / except / intersect / unique
+- `test_linq_element.das` — first / last / single / element_at
+- `test_linq_concat.das` — concat / prepend / append
+- `test_linq_generation.das` — range / repeat
+- `test_linq_bugs.das` — regressions
+
+Each file uses `[test]` functions with `t |> run("name") @(t) { ... }` blocks asserting `t |> equal(actual, expected)`. These exercise the regular linq operators (`where_`, `select`, `count`, ...) directly — they're not split into "fold-on" vs "fold-off" variants.
+
+Dedicated `_fold` tests live in `test_linq_fold.das` (functional output) and `test_linq_fold_ast.das` (AST-shape verification — pattern-matches the macro expansion). These DO compare `_fold(chain)` output against the plain `chain` output for the shapes the macro recognizes.
+
+When the user says "parity tests" in linq context, treat the full `test_linq_*.das` suite as the operator-coverage map. Phase-2+ benchmark/splice PRs should add a `benchmarks/sql/` entry for each shape exercised here that isn't already covered (tracked as a checklist in `benchmarks/sql/LINQ.md`).
+
+## Questions
+- Are there parity tests in tests/linq/ that compare `_fold` output to the underlying linq operators?
+- What's the "parity test" coverage surface for linq?
+- Where are tests for linq operators?
+
+## Questions
+- Are there parity tests in tests/linq/ that compare `_fold` output to the underlying linq operators?

--- a/mouse-data/docs/cpp-profiler-macos-samply-instruments.md
+++ b/mouse-data/docs/cpp-profiler-macos-samply-instruments.md
@@ -1,0 +1,68 @@
+---
+slug: cpp-profiler-macos-samply-instruments
+title: What C++ sampling profiler should I use on macOS for daslang (and how do I run it)?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+# C++ sampling profiler on macOS (Apple Silicon)
+
+VS Code has **no first-class C++ profiler integration on macOS** — the "Performance Profiler" / similar extensions wrap Linux `perf` and don't help here. Skip them. Run a sampler from the integrated terminal and view results in browser/Instruments.
+
+## samply (default choice)
+
+Rust-built, Firefox-Profiler frontend, zero config.
+
+```bash
+cargo install samply
+samply record ./build/daslang script.das
+```
+
+- Opens flamegraph in browser automatically.
+- Symbolicates Mach-O cleanly if you build `-DCMAKE_BUILD_TYPE=RelWithDebInfo` (do NOT use plain `Release` — symbols are stripped).
+- Works without sudo on Apple Silicon.
+- Good for "where does the CPU go" questions.
+
+## Xcode Instruments — Time Profiler (second opinion)
+
+Native macOS sampler, kernel-assisted, best symbolication on Apple Silicon. Use when samply's view is ambiguous or you want call-tree + timeline together.
+
+```bash
+xcrun xctrace record --template 'Time Profiler' --launch -- ./build/daslang script.das
+```
+
+Then open the resulting `.trace` bundle (Instruments launches). UI is outside VS Code.
+
+## daslang-specific recipe
+
+Pair the sampler with the per-module compile-time logging (`-log-compile-time` CLI flag, added on branch `bbatkin/log-compile-time-cli`):
+
+```bash
+cmake --build build --config RelWithDebInfo -j 64
+samply record ./build/daslang -log-compile-time path/to/script.das
+```
+
+- `-log-compile-time` tells you which module is slow.
+- Sampling tells you which function inside that module is hot.
+- Together they narrow "compile is slow" to a specific phase + symbol.
+
+## What NOT to use
+
+- `perf` — Linux only, doesn't exist on Darwin.
+- Intel VTune — x86-mostly, ignore on Apple Silicon.
+- `gprof` — instrumenting, not sampling; ancient.
+- VS Code C++ profiler extensions — see above, all are Linux/perf wrappers or toys.
+- `hyperfine` / `poop` — benchmarking (whole-program timing), not profiling (per-function hotspots). Different question.
+
+## Build flag reminder
+
+Both samply and Instruments need symbols. The two viable build types on this repo:
+
+- `RelWithDebInfo` — fast code + symbols. Use this for profiling.
+- `Debug` — slow code; profile reflects debug overhead, not real hotspots. Avoid.
+
+Plain `Release` strips symbols and you'll get `???` everywhere in the flamegraph.
+
+## Questions
+- What C++ sampling profiler should I use on macOS for daslang (and how do I run it)?

--- a/mouse-data/docs/daslang-generic-instance-detect-via-fromgeneric.md
+++ b/mouse-data/docs/daslang-generic-instance-detect-via-fromgeneric.md
@@ -1,0 +1,33 @@
+---
+slug: daslang-generic-instance-detect-via-fromgeneric
+title: How do I detect that an ExprCall is to a daslang generic (e.g. each, length, find) when func.name is the mangled instance name and not the original generic's name?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+When a daslang generic function (`def each(a : array<auto(TT)>) : iterator<TT&>`, `def length(a : auto | #) : int`, etc.) is resolved against a concrete type at infer time, the resolved `Function?` instance gets a **mangled name** like `` `builtin`each`30908`12345 ``. Macro code that compares `call.func.name == "each"` will never match a typed instance.
+
+The original generic's identity lives in `call.func.fromGeneric`:
+
+```das
+[macro_function]
+def private is_each_call(call : ExprCall?) : bool {
+    if (call == null || call.func == null) return false
+    return (call.func.name == "each"
+        || (call.func.fromGeneric != null && call.func.fromGeneric.name == "each"))
+}
+```
+
+The `name == "each"` branch covers the unusual case where you see the call before the typer has specialized it (e.g. inside a custom call_macro that runs early). The `fromGeneric.name` branch is the normal case for any post-infer chain.
+
+**When this bites:** writing a `[macro_function]` that pattern-matches on a stdlib helper by name — `each`, `length`, `key_exists`, `find`, `set_insert`, all the generic `to_array`/`to_table` variants. Without the `fromGeneric` check, every typed chain silently falls through your match and your macro behaves as if the helper wasn't there.
+
+**Generalizes beyond function calls:** same applies to method overload resolution. `call.func.fromGeneric` is the canonical "which generic was this instantiated from?" link. There's no `originalName` field — the chain is `func → func.fromGeneric → fromGeneric.name`.
+
+**Doesn't apply to:** C++ builtins from `addExtern<>` (no fromGeneric, the `func.name` is the bound name directly). Builtins also have `func.flags.builtIn = true` if you need to distinguish.
+
+See [[my-fold-macro-emits-a-loop-with-for-it-in-source-acc-reserve-length-source-but-the-reserve-doesn-t-fire-when-the-chain-starts-wi]] for the concrete case where this broke `peel_each` in `daslib/linq_fold.das`.
+
+## Questions
+- How do I detect that an ExprCall is to a daslang generic (e.g. each, length, find) when func.name is the mangled instance name and not the original generic's name?

--- a/mouse-data/docs/daslib-macro-boost-has-sideeffects-predicate.md
+++ b/mouse-data/docs/daslib-macro-boost-has-sideeffects-predicate.md
@@ -1,0 +1,43 @@
+---
+slug: daslib-macro-boost-has-sideeffects-predicate
+title: Is there a conservative side-effect detector for Expression nodes in daslib macro_boost — something I can call from a call_macro to know if it's safe to elide an evaluation at macro time?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+Yes — `has_sideeffects(expr : Expression?) : bool` in `daslib/macro_boost` (added in PR #2691, follow-up to Phase 2A loop planner). Returns `true` if the expression has or **might have** side effects; `false` ONLY when provably pure.
+
+```das
+require daslib/macro_boost public
+
+if (has_sideeffects(projection)) {
+    // Emit the bind — projection must run for its side effects.
+    sideEffectStmts |> push <| qmacro_expr() {
+        var $i(finalBindName) = $e(projection)
+    }
+} else {
+    // Skip the bind — pure projection, no observable effect.
+}
+```
+
+**Conservative — false is a promise:**
+
+- SAFE leaves: `ExprVar`, all `ExprConst*`, `ExprAddr`, `ExprTypeInfo/Decl/Tag`.
+- SAFE via recursion: `ExprField`, `ExprSafeField`, `ExprSwizzle`, `ExprRef2Value/Ptr`, `ExprPtr2Ref`, `ExprIs`, `ExprAsVariant`, `ExprIsVariant`, `ExprSafeAsVariant`, `ExprCast`, `ExprNullCoalescing`, `ExprStringBuilder` (string heap is no-op per compiler), `ExprKeyExists` (pure container read).
+- `ExprAt`: safe when `subexpr._type` is NOT `isGoodTableType` (tables auto-insert default on missing key — a write). `ExprSafeAt` (`?[...]`) always safe.
+- `ExprOp1/Op2/Op3`: op-name allowlist for pure ops on workhorse types — `+ - * == != < <= > >= & | ^ << >> && || ?:` (Op2), `- ! ~ +` (Op1). Falls back to `func.flags.builtIn && !knownSideEffects && !unsafeOperation`. `/` and `%` BLACKLISTED (div-by-zero panic).
+- `ExprCall`/`ExprCallFunc`: allowed when `func.flags.builtIn && !knownSideEffects && !unsafeOperation`, then recurse args.
+- Everything else (including `ExprNew`, all `ExprMake*`, user-defined calls, `ExprInvoke`, `ExprYield`, statement-context exprs): UNSAFE.
+
+**Known limitations / when it returns conservative-unsafe:**
+
+- daslang-generic helpers like `length(arr)` and `key_exists(tab, k)` — the resolved `func.name` is the mangled instance, and the typer hasn't always reached the `flags.builtIn=true` C++ overload before the call_macro fires. They show up as user-call shapes and get rejected. Workaround: don't rely on this for length/key_exists in projections (they appear in `has_sideeffects` tests as `target_generic_length_unresolved` / `target_key_exists_unresolved` returning `true`).
+- User-defined pure helpers — there's no `[no_side_effects]` annotation yet. The compiler's `expr.flags.noSideEffects` fast path catches some cases (set during infer), but anything the typer didn't tag falls through to UNSAFE.
+
+**Tests:** `tests/macro_boost/test_has_sideeffects.das` has 24 cases (17 safe + 5 unsafe + 2 conservative-unsafe) wired via a `_test_has_sideeffects` probe `call_macro` ([`tests/macro_boost/_has_sideeffects_probe.das`](../../tests/macro_boost/_has_sideeffects_probe.das)) that runs the predicate at macro time and emits `ExprConstBool` of the result. Use the same probe pattern when testing any new predicate that needs to run at macro time but be exercised via runtime tests.
+
+**Real use:** `daslib/linq_fold.das` `plan_loop_or_count` uses it for three optimizations: discardable `var vfinal =` bind elision, count→length shortcut gate (whole loop elided when no filter + all projections pure + source has length), and tracking `allProjectionsPure` across chained selects. select_count benchmark went from 2 → 0 ns/op.
+
+## Questions
+- Is there a conservative side-effect detector for Expression nodes in daslib macro_boost — something I can call from a call_macro to know if it's safe to elide an evaluation at macro time?

--- a/mouse-data/docs/how-do-i-call-a-dasimgui-or-any-managed-c-method-on-a-struct-field-that-s-bound-as-a-raw-pointer-e-g-addfontfromfilettf-on-getio.md
+++ b/mouse-data/docs/how-do-i-call-a-dasimgui-or-any-managed-c-method-on-a-struct-field-that-s-bound-as-a-raw-pointer-e-g-addfontfromfilettf-on-getio.md
@@ -1,0 +1,66 @@
+---
+slug: how-do-i-call-a-dasimgui-or-any-managed-c-method-on-a-struct-field-that-s-bound-as-a-raw-pointer-e-g-addfontfromfilettf-on-getio
+title: How do I call a dasImgui (or any managed C++) method on a struct field that's bound as a raw pointer — e.g. AddFontFromFileTTF on GetIO().Fonts?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+## TL;DR
+
+When a managed struct's field is bound as a pointer (`T?`) and the method on that pointed-to struct expects the value by-ref (`T implicit`), you must explicitly **dereference**. Plain `field |> method(...)` errors with mismatched types.
+
+## The error you'll hit
+
+```
+error[30341]: no matching functions or generics: AddFontFromFileTTF(imgui::ImFontAtlas?&, string const&, ...)
+  candidate function: ImFontAtlas implicit ...
+  invalid argument 'self' (0). expecting 'imgui::ImFontAtlas implicit', passing 'imgui::ImFontAtlas?&'
+```
+
+The `?` is the giveaway — `GetIO().Fonts` is `ImFontAtlas?` (raw pointer; field bound via `addField<DAS_BIND_MANAGED_FIELD(Fonts)>` against C++ `ImFontAtlas* Fonts`), but the method binding `das_call_member< ImFont * (ImFontAtlas::*)(...) >` takes the receiver by-value/ref.
+
+## The fix
+
+Bind a local ref through `unsafe(*ptr)`, then call as usual:
+
+```daslang
+var atlas & = unsafe(*GetIO().Fonts)
+let f = atlas |> AddFontFromFileTTF(ttf, 14.0f, null, null)
+```
+
+Equivalent inline form:
+
+```daslang
+unsafe(*GetIO().Fonts) |> AddFontFromFileTTF(ttf, 14.0f, null, null)
+```
+
+## Why each part
+
+- **`*ptr`** is daslang's pointer-deref syntax (see `daslib/if_not_null.rst`: *"a dereferenced call: ``if (ptr != null) { call(*ptr, args) }``"*). The alternative `deref(ptr)` exists too but is rarer in modules; `*` is the idiom.
+- **`unsafe(...)`** is required because dereferencing a raw `T?` is unsafe (no null check, no lifetime guarantee).
+- **`var atlas &`** binds a local *reference* — without `&` you'd be copying the whole `ImFontAtlas` struct into a stack temporary, which (a) wastes memory and (b) means any mutation the method does (font atlas builds, glyph rasterization) hits the copy and is lost.
+- **The pipe `|>` works fine on the local ref** — `atlas |> method(x, y)` desugars to `method(atlas, x, y)` and the `implicit` first-param accepts the ref directly.
+
+## Why NOT the other shapes
+
+- `GetIO().Fonts.AddFontFromFileTTF(...)` — `.method()` sugar is sugar for `method(self, ...)` only when `self` is a struct value. CLAUDE.md explicitly: *"Does NOT work on: primitives, tuples/arrays, and lambda typedefs"* — and (this case) raw pointers. Field *access* on a pointer auto-derefs (`GetIO().Fonts.TexID` works); method dispatch does not.
+- `GetIO().Fonts->AddFontFromFileTTF(...)` — `->` is for class instances (smart_ptr / class types), not raw C-struct pointers from `ManagedStructureAnnotation`.
+- `deref(GetIO().Fonts) |> AddFontFromFileTTF(...)` — works but the pipe gets a temporary value not a ref; mutations on the receiver disappear. Use `var x & = unsafe(*p)` instead.
+
+## When this comes up
+
+Anywhere a C++ binding exposes a struct field as `T*` (typical for "owns-an-atlas" or "owns-a-context" patterns):
+- `ImGuiIO::Fonts` → `ImFontAtlas?`
+- `ImDrawData::CmdLists` → indirection on lists
+- anything bound via raw `addField<DAS_BIND_MANAGED_FIELD(X)>` where the C++ type is `Foo*`
+
+If the C++ field were a value (`ImFontAtlas Fonts;` instead of `ImFontAtlas* Fonts;`), it'd bind as the struct directly and the pipe would just work.
+
+## Related
+
+- [[dasimgui-new-state-struct-widget-auto-emit-just-works]] — different topic (state-struct registration) but same module family.
+- [[how-do-i-pack-an-im-col32-color-from-dasimgui-v2-code-without-depending-on-the-v1-daslib-imgui-boost-path]] — sibling dasImgui idiom.
+
+## Questions
+- How do I call a dasImgui (or any managed C++) method on a struct field that's bound as a raw pointer — e.g. AddFontFromFileTTF on GetIO().Fonts?

--- a/mouse-data/docs/how-do-i-run-dastest-in-benchmark-only-mode-and-what-s-the-command-line-syntax.md
+++ b/mouse-data/docs/how-do-i-run-dastest-in-benchmark-only-mode-and-what-s-the-command-line-syntax.md
@@ -1,0 +1,45 @@
+---
+slug: how-do-i-run-dastest-in-benchmark-only-mode-and-what-s-the-command-line-syntax
+title: How do I run dastest in benchmark-only mode and what's the command-line syntax?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+Benchmarks are functions annotated with `[benchmark]` from `dastest/testing_boost.das`. Run them via the dastest harness with `--bench`:
+
+```bash
+# All benchmarks in a directory (skip the regular tests)
+./bin/daslang dastest/dastest.das -- --bench --test benchmarks/sql --test-names none
+
+# Just one file
+./bin/daslang dastest/dastest.das -- --bench --test benchmarks/sql/count_aggregate.das --test-names none
+
+# Filter by [benchmark] function-name prefix (substring match on the function name)
+./bin/daslang dastest/dastest.das -- --bench --bench-names sum_ --test benchmarks/sql --test-names none
+
+# Collect N samples for variance / averaging
+./bin/daslang dastest/dastest.das -- --bench --test benchmarks/sql/count_aggregate.das --test-names none --count 5
+```
+
+Key flags:
+- `--bench` — enable benchmark execution
+- `--test <path>` — folder or single file (NOT positional)
+- `--test-names none` — skip regular `[test]` discovery (benchmarks only)
+- `--bench-names <prefix>` — filter benchmarks by function-name prefix
+- `--bench-format <native|go|json>` — output format
+- `--count <n>` — repeat all benchmarks N times
+
+Benchmarks only run after all module **tests** have passed; that's why `--test-names none` is the canonical "skip tests, run benchmarks" combo.
+
+Output is `<sub_name> N ns/op <bytes>/op <allocs>/op <SB>/op <strings>/op`. If the benchmark `b |> run(name, chunk_size, op)` form passes a chunk_size (typically the dataset size), the displayed ns/op is **divided by that chunk_size** — i.e. per-element time, not per-op-call time. Sub-nanosecond results (`0 ns/op`) usually mean early-exit hit the answer in O(1) regardless of dataset size.
+
+Reference: `dastest/README.md` and `dastest/dastest_clargs.das`.
+
+## Questions
+- How do I run dastest in benchmark-only mode and what's the command-line syntax?
+- What's the dastest --bench command line?
+- How do I filter dastest benchmarks by name?
+
+## Questions
+- How do I run dastest in benchmark-only mode and what's the command-line syntax?

--- a/mouse-data/docs/imgui-harness-headless-timeout-sec-cascade-guard.md
+++ b/mouse-data/docs/imgui-harness-headless-timeout-sec-cascade-guard.md
@@ -1,0 +1,57 @@
+---
+slug: imgui-harness-headless-timeout-sec-cascade-guard
+title: How do I add a wall-clock self-exit timer to a daslang-live harness so a panicked test doesn't leave a zombie subprocess on the live-API port?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+**Problem**: daslang's `finally` block is skipped on panic. A test that does `with_imgui_app(F) $(d) { ... expect_value(...) ... }` and panics inside `expect_value`'s timeout never reaches the `/shutdown` POST that `with_imgui_app` would have sent in cleanup. The spawned `daslang-live` subprocess keeps running, holding port 9090. The next test that spawns errors out with "another instance of daslang-live is already running" (macOS) or hangs at drain for the full popen watchdog (Ubuntu) because its `/status` polls hit the zombie instead.
+
+**Fix shape**: give the subprocess a wall-clock self-exit timer. Even if the parent never sends `/shutdown`, the script self-exits before the popen parent gives up, the port releases, and the next test starts cleanly.
+
+**Implementation in dasImgui PR #38** (`widgets/imgui_harness.das` + `widgets/imgui_playwright.das`):
+
+1. New CLI flag `--headless-timeout-sec=N` parsed via clargs alongside `--headless-frames=N`:
+   ```daslang
+   let raw_timeout = find_flag_raw_value(args, "--headless-timeout-sec")
+   g_headless_max_uptime_sec = to_float(raw_timeout |> unwrap_or("0"))
+   ```
+   Default 0 = disabled (preserves standalone `daslang.exe foo.das -- --headless` usage).
+
+2. Wall-clock check inside `harness_begin_frame()`, right next to the existing `--headless-frames` cap:
+   ```daslang
+   let now = get_uptime()
+   if (g_headless_first_uptime < 0.0f) {
+       g_headless_first_uptime = now
+   }
+   if (g_headless_max_uptime_sec > 0.0f && (now - g_headless_first_uptime) >= g_headless_max_uptime_sec) {
+       print("[harness] headless timeout {g_headless_max_uptime_sec}s reached at uptime {now - g_headless_first_uptime}s — request_exit()\n")
+       request_exit()
+       return false
+   }
+   ```
+   The print is the **only** log line kept in the cleaned-up harness — it fires at most once per subprocess and only when the safety net actually trips. Healthy runs are silent.
+
+3. Playwright's `with_imgui_app_opt` appends `--headless-timeout-sec=(test_timeout_sec - 5)` to the spawned argv whenever `--headless` is forwarded. The −5 s margin gives the script time to finish the current frame, run `shutdown()`, and close the live-API port before the parent's popen watchdog fires:
+   ```daslang
+   if (playwright_wants_headless()) {
+       argv |> push("--")
+       argv |> push("--headless")
+       let harness_budget = test_timeout_sec - 5.0f
+       if (harness_budget > 5.0f) {
+           argv |> push("--headless-timeout-sec={harness_budget}")
+       }
+   }
+   ```
+
+**Why it works on the cascade**: even when `expect_value` panics inside the body block, the daslang-live subprocess continues running its update loop. The next `harness_begin_frame()` call (called every frame from `update()`) notices `uptime > budget`, calls `request_exit()`, and the main loop terminates cleanly via `while (!exit_requested())`. `shutdown()` runs, port 9090 releases, popen's parent reads EOF, exit code is 0 — no cascade for the next test.
+
+**Sizing rule**: set timeout less than the popen watchdog by enough margin to cover one frame + shutdown. 5 seconds is comfortable. If the popen watchdog is 120 s, harness timeout = 115 s.
+
+**Limitation**: only fires from `harness_begin_frame`. If the script's `update()` is stuck inside something that never returns to the main loop, harness timeout never gets a chance. This is the right tradeoff — a stuck `update()` is a different bug class (real deadlock), and popen still kills the process at its watchdog.
+
+**Cascade-guard pattern generalizes**: any long-running subprocess that owns a port (HTTP server, RPC endpoint, anything) and is spawned for a bounded test/check should have a wall-clock self-exit set slightly below the parent's kill-timeout. Cleanup-via-script always beats cleanup-via-SIGKILL.
+
+## Questions
+- How do I add a wall-clock self-exit timer to a daslang-live harness so a panicked test doesn't leave a zombie subprocess on the live-API port?

--- a/mouse-data/docs/imgui-macos-configmacosxbehaviors-shortcut-is-super-not-ctrl.md
+++ b/mouse-data/docs/imgui-macos-configmacosxbehaviors-shortcut-is-super-not-ctrl.md
@@ -1,0 +1,39 @@
+---
+slug: imgui-macos-configmacosxbehaviors-shortcut-is-super-not-ctrl
+title: Why does synth Ctrl+A do nothing on macOS but works on Linux/Windows in an ImGui InputText test?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+**ImGui sets `io.ConfigMacOSXBehaviors = true` automatically on macOS** (`#ifdef __APPLE__` in `ImGuiIO` ctor). When that flag is true, the **"shortcut key" is Super (Cmd), not Ctrl**.
+
+So on macOS:
+- `Ctrl+A` → "move to start of line" (text-editing convention)
+- `Cmd+A` → "select all"
+- `Ctrl+Backspace` → does not delete word
+- `Cmd+Backspace` → "delete to start of line"
+
+A synth-IO test that drives `Ctrl+A` to clear an InputText buffer **fails silently on macOS** — the assertion message will look like "NAME_INPUT.value == "" after Ctrl+A then Backspace" with the buffer still holding `"abc"` (because Ctrl+A moved cursor to start, then Backspace deleted nothing).
+
+**Detection from a playwright test**: snapshot `io.config_macos_behaviors` and branch the chord. dasImgui's `widgets/imgui_boost_runtime.das` exposes the flag via the `io_jv()` snapshot key `"config_macos_behaviors"`:
+
+```daslang
+let macos = snap0?["io"]?["config_macos_behaviors"] ?? false
+if (macos) {
+    post_command(d, "imgui_key_chord", JV((mods = ["Super"], key = "A")))
+} else {
+    post_command(d, "imgui_key_chord", JV((mods = ["Ctrl"], key = "A")))
+}
+```
+
+**Why we don't unconditionally use Super**: on Linux/Windows there's no Super-key binding for select-all in InputText; the wrong choice silently fails on those platforms instead. Branch on the actual `config_macos_behaviors` flag — works everywhere.
+
+Discovered in dasImgui PR #38 `test_click_then_ctrl_a_clears_input` failing only on macOS CI after the playwright cascade fix made other failures observable. Copilot diagnosed and fixed in commit `42b7292` + the IO-snapshot extension. Caveat: Copilot drafted the fix with `if macos { ... }` (gen1 syntax) — gen2 requires `if (macos) { ... }`, watch for that pattern when ferrying AI suggestions through.
+
+**Related ImGui flags worth knowing**:
+- `io.KeyCtrl` reflects either Ctrl OR (Cmd on macOS when `ConfigMacOSXBehaviors`) — the "shortcut" lookups go through `io.KeySuper` instead on macOS.
+- `ImGui::Shortcut(ImGuiMod_Ctrl | ImGuiKey_A)` automatically maps to Cmd on macOS — but `Shortcut(ImGuiMod_Super | ImGuiKey_A)` does NOT remap, only `ImGuiMod_Ctrl` is the platform-aware "primary modifier".
+
+## Questions
+- Why does synth Ctrl+A do nothing on macOS but works on Linux/Windows in an ImGui InputText test?

--- a/mouse-data/docs/imgui-playwright-windows-ci-16-post-libhv-stall.md
+++ b/mouse-data/docs/imgui-playwright-windows-ci-16-post-libhv-stall.md
@@ -1,0 +1,38 @@
+---
+slug: imgui-playwright-windows-ci-16-post-libhv-stall
+title: Why do imgui playwright tests hang at 120 seconds on Windows CI when they pass locally and on POSIX?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+**dasHV's libhv build on Windows CI stalls after exactly 16 POST /command connections per subprocess.** Local Windows works fine; only the GitHub-hosted `windows-latest` runner trips it. Discovered while resurrecting dasImgui integration tests in PR #38 (May 2026).
+
+**Symptom**: a test does `with_imgui_app` → spawns daslang-live → fast burst of 1 GET /status + 16 POST /command (all 200 OK in <300 ms), then the libhv event loop **stops accepting new connections**. The 17th HTTP request hangs ~60 s, the test body never makes progress, popen kills the subprocess at the 120 s watchdog (`DAS_POPEN_TIMEOUT = 0x7FFFFF01 = 2147483393`).
+
+**Confirm**: run with `DASLIVE_HV_LOG=stderr DASLIVE_HV_LOG_LEVEL=DEBUG` env vars. Count `[POST /command]=>[200 OK]` lines per subprocess pid in the captured stderr — if exactly 16, you've hit it. Healthy paths show many more.
+
+**Verified-locally counterproof**: same dasImgui suite under `D:\Work\daScript\bin\Release\daslang.exe ... dastest.das -- --test ... --headless` on Win11 box runs 96/96 in ~6 min, including the tests that hang on CI. So it's CI-runner-specific (Windows Server, different scheduler, different IOCP / TCP loopback tuning, possibly Defender). NOT a libhv bug per se — the upstream libhv code on master is byte-identical to v1.3.4 and works fine on `libDaScriptDyn` linkage everywhere except GitHub `windows-latest`.
+
+**Workarounds in dasImgui PR #38**:
+
+1. **Halve HTTP traffic in polling helpers**. Old idiom `wait_until(d, 240) $(var snap) { let s = post_command(d, "imgui_key_status", null); return !(s?["playing"] ?? true) }` does **2 HTTP requests per iteration** (snapshot inside `wait_until` + the inner `post_command`). New helpers `wait_for_key_idle(d, 4.0f)` and `wait_for_mouse_idle(d, 4.0f)` in `widgets/imgui_playwright.das` do **1 POST per iteration** (status only). Use them whenever you only need "playing == false", not a full snapshot.
+
+2. **Exclude high-POST tests on Windows-only** in `.github/workflows/tests.yml`. Conservative cutoff: any test estimated at ≥12 POSTs over its lifetime, leaves a 4-call safety margin under the 16-connection limit. Pattern:
+   ```yaml
+   EXTRA_EXCLUDES=""
+   if [ "${{ matrix.os }}" = "windows-latest" ]; then
+     EXTRA_EXCLUDES="--exclude inputs_drag --exclude inputs_numeric --exclude inputs_slider \
+                     --exclude inputs_color --exclude inputs_choice --exclude inputs_text \
+                     --exclude indexed_dynamic"
+   fi
+   ```
+
+**Heuristic for "POST count"**: each `set_value(...)` is 1 POST. Each `wait_for_payload_value(...)` / `wait_for_int_value(...)` / `wait_until { post_command }` is 1-3 POSTs depending on how fast the answer converges. Tests with ≥10 `set_value + wait` pairs typically exceed 16 POSTs.
+
+**Pre-existing "finally skipped on panic" cascade**: a panicking test in the body block was already known to skip `with_imgui_app`'s `/shutdown` cleanup → zombie subprocess on port 9090 → next test cascades. PR #38 also added `--headless-timeout-sec=N` self-exit to `imgui_harness` (see related card `imgui-harness-headless-timeout-sec-cascade-guard`) so a panicked subprocess can't outlive the popen watchdog.
+
+**Proper fix is upstream** in daslang's libhv build for Windows IOCP. Track + re-include all 7 excluded tests when it lands.
+
+## Questions
+- Why do imgui playwright tests hang at 120 seconds on Windows CI when they pass locally and on POSIX?

--- a/mouse-data/docs/my-fold-macro-emits-a-loop-with-for-it-in-source-acc-reserve-length-source-but-the-reserve-doesn-t-fire-when-the-chain-starts-wi.md
+++ b/mouse-data/docs/my-fold-macro-emits-a-loop-with-for-it-in-source-acc-reserve-length-source-but-the-reserve-doesn-t-fire-when-the-chain-starts-wi.md
@@ -1,0 +1,56 @@
+---
+slug: my-fold-macro-emits-a-loop-with-for-it-in-source-acc-reserve-length-source-but-the-reserve-doesn-t-fire-when-the-chain-starts-wi
+title: My fold macro emits a loop with `for (it in source); acc |> reserve(length(source))` but the reserve doesn't fire when the chain starts with `each(arr)`. How do I make it work?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: [[daslang-generic-instance-detect-via-fromgeneric]]
+---
+
+Peel `each(<expr>)` at macro time. `each(arr)` reports as `iterator<T>`, so any "is the source an iterator?" check (e.g. `top._type.isIterator`) sees `true` and the array-only reserve path is skipped. But the iteration semantics of `for (it in each(arr))` and `for (it in arr)` are identical — the wrapper iterator is incidental in fold context.
+
+Pattern (corrected version, from `daslib/linq_fold.das` after Phase 2A bind-elision PR):
+
+```das
+[macro_function]
+def private is_each_call(call : ExprCall?) : bool {
+    // `each` in daslib/builtin.das is generic — the resolved `func.name`
+    // on a typed instance is mangled (e.g. `builtin`each`30908...`).
+    // The original generic's name lives in `func.fromGeneric.name`.
+    if (call == null || call.func == null) return false
+    return (call.func.name == "each"
+        || (call.func.fromGeneric != null && call.func.fromGeneric.name == "each"))
+}
+
+[macro_function]
+def private peel_each(var top : Expression?) : Expression? {
+    if (!(top is ExprCall)) return top
+    var topCall = top as ExprCall
+    if (!is_each_call(topCall) || topCall.arguments |> length != 1) return top
+    let argExpr = topCall.arguments[0]
+    // Only peel when the argument is a true array (or fixed-size array).
+    // Don't peel iterator-typed args like `each(range(10))` — replacing the
+    // each call with the raw range would break length-shortcut + reserve
+    // hints that assume an indexable source.
+    if ((argExpr == null || argExpr._type == null)
+            || (!argExpr._type.isGoodArrayType && !argExpr._type.isArray)) return top
+    return clone_expression(argExpr)
+}
+```
+
+**Two gotchas the original version missed:**
+
+1. `func.name == "each"` never matched typed instances — generic-instance detection requires `fromGeneric.name`. See [[daslang-generic-instance-detect-via-fromgeneric]].
+2. Peel gate must be **positive** (`is good array`) not negative (`isn't iterator`). `each(range(N))` returns an iterator but its argument `range(N)` is also iterator-shaped (`isRange`) and would otherwise pass `!isIterator`. The positive `isGoodArrayType || isArray` gate cleanly excludes range/string/lambda sources.
+
+**Block-parameter typedecl needs branching on source shape after peel.** When peel fires, the source goes from iterator (rvalue, no modifiers) to array (`array<T> const&` for `let arr <-` chains). The block parameter type:
+- iterator source: `typedecl($e(topExpr)) - const` — strip rvalue const so body can iterate
+- array source: `typedecl($e(topExpr))` (no modifier) — keep `const&` so const-ref source matches
+
+Both wrong → either `array<int> const& vs array<int>` mismatch or `can't iterate over const iterator`.
+
+**What this is worth:** brought `linq_fold`'s `each(arr)._where(...)._select(_.price).to_array()` benchmark from 13 → 10 ns/op (parity with comprehension baseline). The count→length shortcut built on top brings pure `each(arr)._select(_.x).count()` from 2 → 0 ns/op (loop entirely elided).
+
+**Generalizes:** any fused-loop emitter that needs the source's length (reserve, two-pass, length-aware operators like `take_last`), peel inner-array-yielding wrappers — but use `fromGeneric` for generic helpers and a positive array gate, not a negative iterator gate.
+
+## Questions
+- My fold macro emits a loop with `for (it in source); acc |> reserve(length(source))` but the reserve doesn't fire when the chain starts with `each(arr)`. How do I make it work?

--- a/mouse-data/docs/my-macro-substitutes-it-for-a-projection-expression-via-template-replacevariable-it-proj-apply-template-but-the-result-fails-to.md
+++ b/mouse-data/docs/my-macro-substitutes-it-for-a-projection-expression-via-template-replacevariable-it-proj-apply-template-but-the-result-fails-to.md
@@ -1,0 +1,24 @@
+---
+slug: my-macro-substitutes-it-for-a-projection-expression-via-template-replacevariable-it-proj-apply-template-but-the-result-fails-to
+title: My macro substitutes `it` for a projection expression via `Template.replaceVariable("it", proj) + apply_template`, but the result fails to compile with "can only dereference a reference". What's going wrong?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+Post-typer, reads of a `var` local appear wrapped as `ExprRef2Value(ExprVar(name))` — the invisible adapter the typer inserts to dereference a reference for its value. `templates_boost.TemplateVisitor.visitExprVar` (the engine behind `Template.replaceVariable + apply_template`) only matches the inner `ExprVar` and replaces IT with a clone of the substitute. The outer `ExprRef2Value` wrapper stays, but now it wraps a non-reference value — compile error `30921: can only dereference a reference`.
+
+This is the same `ExprRef2Value`-transparency problem `daslib/ast_match.das` documents for `qmatch` — they solve it on both pattern and source sides via `qm_peel_ref2value`. `apply_template` does NOT auto-peel.
+
+Two fixes for substitution:
+
+1. **Pre-peel the destination** before `apply_template`: walk `dst` and replace every `ExprRef2Value(ExprVar(name))` with the inner `ExprVar(name)` first. After substitution, the result is clean. Drawback: removes wrappers globally (around other identifiers too) — if other refs still need the wrapper, the typer will re-insert them, but you've added a pass.
+
+2. **Use a custom visitor instead of `Template.replaceVariable`**: override `visitExprRef2Value` to detect `ExprRef2Value(ExprVar(name))` and return `clone_expression(replacement)` directly (stripping the wrapper as part of the substitution). Override `visitExprVar` as a fallback for bare ExprVars. The pattern mirrors `qm_peel_ref2value`'s "peel both sides" approach.
+
+Concrete repro: daslang `linq_fold`'s Phase 2A planner tried to fuse chained `_select|_select` via `substitute_it_for(proj2, "it", proj1)`. proj1 was `it * 2` (where `it` is the typed-and-wrapped loop var), proj2 was `it + 1`. Substituting via Template replaced the inner ExprVar in proj2 but left `ExprRef2Value(it * 2) + 1` — type error. The fix was deferred (chained-select falls through unfolded in Phase 2A) but Phase 2B needs option 2.
+
+See `skills/das_macros.md` "Peel ExprRef2Value before qmatch" for the matcher-side analog. The substitution side has no in-tree helper yet.
+
+## Questions
+- My macro substitutes `it` for a projection expression via `Template.replaceVariable("it", proj) + apply_template`, but the result fails to compile with "can only dereference a reference". What's going wrong?

--- a/mouse-data/docs/qmacro-gensym-per-callsite-via-lineinfo.md
+++ b/mouse-data/docs/qmacro-gensym-per-callsite-via-lineinfo.md
@@ -1,0 +1,43 @@
+---
+slug: qmacro-gensym-per-callsite-via-lineinfo
+title: How do I generate a uniquely-named gensym inside an AstCallMacro for a per-call-site variable, using LineInfo?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+Use the call site's `LineInfo.line` + `.column` interpolated into a backtick-prefixed identifier string. Backtick-prefixed names live in a separate namespace so they don't collide with user-typed identifiers and they survive lint/style passes.
+
+```das
+def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+    let at = call.at  // LineInfo of the call site
+    let accName = "`acc`{at.line}`{at.column}"
+    let itName  = "`it`{at.line}`{at.column}"
+    let srcName = "`src`{at.line}`{at.column}"
+
+    var res = qmacro(invoke($($i(srcName) : typedecl($e(src))) {
+        var $i(accName) = 0
+        for ($i(itName) in $i(srcName)) {
+            // ...
+        }
+        return $i(accName)
+    }, $e(src)))
+    res.force_at(at)
+    res.force_generated(true)
+    return res
+}
+```
+
+Two follow-up steps you almost always want:
+
+1. `res.force_at(at)` + `res.force_generated(true)` — sets `at = call.at` on every emitted node and marks them macro-generated. The latter bypasses lint rules that would otherwise fire on synthesized code (e.g. STYLE001, LINT002 "unused variable").
+2. `(blk._block as ExprBlock).arguments[0].flags.can_shadow = true` on the bound let-variable — quiets shadow warnings if the user already has an `acc`/`it`/`src` in scope. Reach for `.flags.can_shadow` on any qmacro-bound name that might collide with caller context.
+
+**Why include both line AND column:** macros emitted from nested helpers can have several emission sites on the same line (e.g. piped chains where each `|>` step emits a separate gensym). Line alone is not unique.
+
+**Why backtick prefix:** the backtick is a daslang lexer hint that this is an internal/synthesized name. Without it, very-long generated names sometimes clash with user identifiers or trip naming rules (the formatter, the auto-rename tools).
+
+**Worked example:** `daslib/linq_fold.das` `plan_loop_or_count` — multiple gensyms per emission site (accumulator, iterator, source, bound projection). Variants per fold-helper too (`fold_where_count` uses `nName` over `accName`).
+
+## Questions
+- How do I generate a uniquely-named gensym inside an AstCallMacro for a per-call-site variable, using LineInfo?

--- a/mouse-data/docs/qmacro-invoke-source-bind-typedecl-modifier-iter-vs-array.md
+++ b/mouse-data/docs/qmacro-invoke-source-bind-typedecl-modifier-iter-vs-array.md
@@ -1,0 +1,46 @@
+---
+slug: qmacro-invoke-source-bind-typedecl-modifier-iter-vs-array
+title: In a call_macro that emits an `invoke($($i(src) : typedecl($e(topExpr)) <modifier>) { ... }, $e(topExpr))` wrapper, what `<modifier>` do I use so the param matches both array and iterator sources without const/ref mismatches?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+There is no single modifier that works for both — branch on `top._type.isIterator`:
+
+```das
+if (top._type != null && top._type.isIterator) {
+    // Iterator source — rvalue from a function call like each(range(10)).
+    // typedecl() picks up the function-return type which carries const;
+    // -const strips it so the body can `for (it in src)` (otherwise
+    // daslang complains "can't iterate over const iterator").
+    res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr)) - const) {
+        // ... body uses $i(srcName) ...
+    }, $e(topExpr)))
+} else {
+    // Container source with length — array/table/string/range/fixed-array.
+    // `let arr <- [...]` is `array<T> const&`. Stripping -const would
+    // produce a non-const-ref param; passing the const-ref source then
+    // fails with `array<T> const& vs array<T>` ("can't ref types
+    // can only add constness"). Keep modifiers — typedecl() preserves
+    // them and the const-ref source matches exactly.
+    res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr))) {
+        // ... body uses $i(srcName) ...
+    }, $e(topExpr)))
+}
+```
+
+The two error messages are diagnostic — they tell you which branch you're on:
+- `can't iterate over const iterator` → you forgot `-const` on an iterator path
+- `array<T> const& vs array<T> ... can't ref types can only add constness` → you have `-const` on an array path
+
+**Why this is needed in the first place:** the block param is your way to bind the source expression to a stable name so the loop body can reference it once without re-evaluating side effects. The "right" param type is "whatever the source actually is" — but qmacro `typedecl(expr)` produces the raw type-of including const-ref from the call return, which only sometimes matches what the consumer needs.
+
+**Use `top._type != null` guard** — `_type` is null for freshly cloned expressions that haven't gone through the typer yet. Treating null as "not iterator" (default to array branch) is wrong if you're past the typer; pick conservatively and call out the assumption.
+
+**See `daslib/linq_fold.das` `plan_loop_or_count`** for a working example with five emission sites — counter lane, array-lane iter/sourceHasLength/else, and the length-shortcut path that's only reachable when the source has length (so it always uses the no-modifier form).
+
+**Fast path for length-shortcut:** if you can emit `length($e(topExpr))` directly without the invoke wrapper, do that — no source-bind problem. Works when the entire body is one expression and the source's evaluation cost is "you'd evaluate it once anyway."
+
+## Questions
+- In a call_macro that emits an `invoke($($i(src) : typedecl($e(topExpr)) <modifier>) { ... }, $e(topExpr))` wrapper, what `<modifier>` do I use so the param matches both array and iterator sources without const/ref mismatches?

--- a/mouse-data/docs/what-s-the-end-to-end-checklist-for-adding-a-new-daslib-das-module-so-docs-build-cleanly.md
+++ b/mouse-data/docs/what-s-the-end-to-end-checklist-for-adding-a-new-daslib-das-module-so-docs-build-cleanly.md
@@ -1,0 +1,46 @@
+---
+slug: what-s-the-end-to-end-checklist-for-adding-a-new-daslib-das-module-so-docs-build-cleanly
+title: What's the end-to-end checklist for adding a new daslib/*.das module so docs build cleanly?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+Four things to update, in order:
+
+**1. `doc/reflections/das2rst.das`** — add a `require daslib/<modname>` near the other daslib requires, write a `document_module_<modname>(root : string)` function modeled on a sibling (e.g. `document_module_linq_boost`), and call it from the dispatcher block near the end. Minimal form for a module with mostly-private internals:
+
+```daslang
+def document_module_my_new_module(root : string) {
+    var mod = find_module("my_new_module")
+    var groups : array<DocGroup>
+    document("Short description", mod, "my_new_module.rst", groups)
+}
+```
+
+For modules with many public functions, copy the `linq_boost` pattern and add `group_by_regex(...)` entries for each named group — anything left over lands in "Uncategorized" and **fails CI**.
+
+**2. `doc/source/stdlib/handmade/module-<modname>.rst`** — `das2rst` auto-creates this as `// stub\nModule <modname>`. Replace the **whole file** with a plain-text description (1-2 paragraphs, with a `.. code-block:: das` require + minimal example). See `module-linq.rst` / `module-linq_boost.rst` for the convention.
+
+**3. `doc/source/stdlib/sec_*.rst`** — find the section your module belongs in (e.g. `sec_algorithms.rst` for linq family, `sec_strings.rst` for strings, etc.) and add `generated/<modname>.rst` to its `.. toctree::`. Without this the page builds but isn't linked.
+
+**4. Regenerate + verify:**
+
+```bash
+./bin/daslang doc/reflections/das2rst.das        # picks up new module + handmade stub
+grep -rl "// stub" doc/source/stdlib/handmade/   # must be empty after step 2
+grep -c Uncategorized doc/source/stdlib/generated/*.rst | grep -v ':0$'  # must be empty
+rm -rf doc/sphinx-build site/doc                 # clean cache (cached builds hide warnings)
+sphinx-build -b html -d doc/sphinx-build doc/source site/doc 2>&1 | tee /tmp/sphinx_out.txt
+grep -iE "warning:|error:" /tmp/sphinx_out.txt   # must be empty
+```
+
+`doc/source/stdlib/generated/*.rst` and `generated/detail/*.rst` are **gitignored** — only commit (1) das2rst.das, (2) the handmade module-<modname>.rst, and (3) the sec_*.rst toctree update.
+
+## Questions
+- What's the end-to-end checklist for adding a new daslib/*.das module so docs build cleanly?
+- Where do I register a new daslib module in das2rst.das?
+- Why does my new module appear as `// stub` in the generated RST?
+
+## Questions
+- What's the end-to-end checklist for adding a new daslib/*.das module so docs build cleanly?

--- a/mouse-data/docs/what-s-the-right-sqlite-linq-chain-form-for-aggregates-sum-min-max-average-and-what-operators-aren-t-supported-as-sql-chain-term.md
+++ b/mouse-data/docs/what-s-the-right-sqlite-linq-chain-form-for-aggregates-sum-min-max-average-and-what-operators-aren-t-supported-as-sql-chain-term.md
@@ -1,0 +1,39 @@
+---
+slug: what-s-the-right-sqlite-linq-chain-form-for-aggregates-sum-min-max-average-and-what-operators-aren-t-supported-as-sql-chain-term
+title: What's the right sqlite_linq chain form for aggregates (sum/min/max/average), and what operators aren't supported as `_sql` chain terminals?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+Column aggregates in `_sql` chains use the **regular linq function name** after a `_select`, NOT an `_aggregate(_.Col)` macro:
+
+```daslang
+// CORRECT — _sql analyzer recognizes `_select(_.Col) |> sum()` and emits SELECT SUM(price)
+let s = _sql(db |> select_from(type<Car>) |> _select(_.price) |> sum())
+let m = _sql(db |> select_from(type<Car>) |> _select(_.price) |> min())
+let a = _sql(db |> select_from(type<Car>) |> _select(_.price) |> average())  // promotes to double
+```
+
+There is no `_sum` / `_min` / `_max` / `_average` chain macro. The error if you try one is `error[30838]: can't locate variable '_'` because `_sum` doesn't dispatch as a call macro.
+
+The full set of `_sql` chain terminals is **`_to_array()`, `_first()`, `_first_opt()`, `count()`, and `sum()`/`min()`/`max()`/`average()` after a 1-column `_select`**. These are NOT supported as chain terminals:
+
+| Chain | Why not | Workaround |
+|---|---|---|
+| `_any()` (no args, terminal) | not implemented | `_first_opt() \|> is_some` |
+| `_all(pred)` | no SQL idiom recognized | invert: `_where(NOT pred) \|> count() == 0` |
+| `take(N) \|> count()` | LIMIT-after-aggregate has no effect (aggregate collapses to 1 row) | drop count, materialize: `take(N)` returns array, take `length()` |
+| `skip(M) \|> take(N) \|> count()` | same | same — terminate in to_array |
+| `distinct() \|> count()` | `COUNT(DISTINCT col)` not yet implemented | `distinct()` alone, then `length()` of result array |
+| `_sql(... \|> _join(select_from(type<T>), ...))` | inner `select_from` needs db handle wired inside the analyzer | omit m1 / use raw SQL string for join benchmarks |
+
+The error messages from `sqlite_linq.das` are explicit — read them, they spell out the alternative form. Pattern matching for these lives in `modules/dasSQLITE/daslib/sqlite_linq.das` `peel_column_aggregate` and `analyze_chain`.
+
+## Questions
+- What's the right sqlite_linq chain form for aggregates (sum/min/max/average), and what operators aren't supported as `_sql` chain terminals?
+- Why does `_sum(_.price)` fail in `_sql` with "can't locate variable '_'"?
+- How do I express `any`/`all`/distinct-count/take-count in `_sql`?
+
+## Questions
+- What's the right sqlite_linq chain form for aggregates (sum/min/max/average), and what operators aren't supported as `_sql` chain terminals?

--- a/mouse-data/docs/when-a-call-macro-needs-to-pick-copy-vs-move-init-for-a-projection-should-i-emit-static-if-typeinfo-is-workhorse-e-proj-or-decid.md
+++ b/mouse-data/docs/when-a-call-macro-needs-to-pick-copy-vs-move-init-for-a-projection-should-i-emit-static-if-typeinfo-is-workhorse-e-proj-or-decid.md
@@ -1,0 +1,33 @@
+---
+slug: when-a-call-macro-needs-to-pick-copy-vs-move-init-for-a-projection-should-i-emit-static-if-typeinfo-is-workhorse-e-proj-or-decid
+title: When a call_macro needs to pick copy-vs-move-init for a projection, should I emit `static_if (typeinfo is_workhorse($e(proj)))` or decide at macro time?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+Decide at macro time. By the time a `[call_macro]` `visit()` fires, inner macros have expanded and the typer has run, so every sub-expression carries a resolved `_type`. Read `projection._type.isWorkhorseType` directly and emit exactly one branch — no `static_if`, no `typeinfo is_workhorse` at runtime, less AST for the typer to fold away later.
+
+Pattern:
+
+```das
+let workhorseProj = projection._type != null && projection._type.isWorkhorseType
+var perElem : Expression?
+if (workhorseProj) {
+    perElem = qmacro_expr() { $i(accName) |> push($e(projection)) }
+} else {
+    perElem = qmacro_block() {
+        var $i(valName) <- $e(projection)
+        $i(accName) |> emplace($i(valName))
+    }
+}
+```
+
+For workhorse types (`int`, `float`, `bool`, `string`, …, anything `isWorkhorseType` returns true for) you can push the expression directly with no intermediate `var v = expr`. For non-workhorse, `<-` is a statement not an expression — you need `var v <- proj; acc |> emplace(v)`. The two-step is only required there.
+
+This trick brought daslang `linq_fold`'s `where|select|to_array` emission from 13 → 11 ns/op (parity with the `_old_fold` comprehension baseline) at 100K rows. See [daslib/linq_fold.das](daslib/linq_fold.das) `plan_loop_or_count` (the array lane). The previous version had a runtime `static_if` inside the qmacro — correct but generated 2× the AST and lost the temp-binding optimization opportunity.
+
+Other `TypeDecl` predicates available at macro time: `isIterator`, `isGoodArrayType`, `isConst`, `isPod`, plus `firstType` / `secondType` / `argTypes` for compound types. Use them; the typer has already done the work.
+
+## Questions
+- When a call_macro needs to pick copy-vs-move-init for a projection, should I emit `static_if (typeinfo is_workhorse($e(proj)))` or decide at macro time?

--- a/mouse-data/docs/where-does-nolint-rule-go-when-a-lint-warning-is-emitted-from-inside-a-qmacro-expr-and-fires-at-the-user-s-call-site-rather-than.md
+++ b/mouse-data/docs/where-does-nolint-rule-go-when-a-lint-warning-is-emitted-from-inside-a-qmacro-expr-and-fires-at-the-user-s-call-site-rather-than.md
@@ -1,0 +1,36 @@
+---
+slug: where-does-nolint-rule-go-when-a-lint-warning-is-emitted-from-inside-a-qmacro-expr-and-fires-at-the-user-s-call-site-rather-than
+title: Where does `// nolint:RULE` go when a lint warning is emitted from inside a `qmacro_expr` and fires at the user's call site rather than at the macro source?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+The nolint comment must be **inline at the end of the offending line**, inside the `qmacro_expr {...}` block — NOT on a separate comment line above and NOT at the user call site.
+
+When a macro emits code via `qmacro_expr { var $i(name) = $e(expr) }`, lint analyzes the expansion at the user's call site but **reports the source position** as the line inside the qmacro_expr body. To suppress, the comment must travel with the emitted line:
+
+```daslang
+} else {
+    blk.list |> emplace_new <| qmacro_expr() {
+        var $i(newArgName) = $e(newCall)  // nolint:PERF009
+    }
+    ...
+}
+```
+
+What DOESN'T work:
+- `// nolint:PERF009` on a comment line above the qmacro_expr block — suppresses nothing.
+- `// nolint:PERF009` on the user-side `let x = _fold(...)` line — the lint engine reports against the macro source position, not the user site.
+
+The placement rule generalizes: `nolint:RULE` must be **on the literal line** that the lint output points at. For macro-quoted code, that's inside the `qmacro_expr { ... }` body.
+
+Concrete example: PERF009 ("redundant move into variable immediately returned") fired at `daslib/linq_fold.das:490:24` (a line inside `fold_linq_default`'s qmacro_expr) when called via `benchmarks/sql/take_count.das`'s single-pass chain. Inline `// nolint:PERF009` on the emitted `var = expr` line suppresses it cleanly.
+
+## Questions
+- Where does `// nolint:RULE` go when a lint warning is emitted from inside a `qmacro_expr` and fires at the user's call site rather than at the macro source?
+- nolint for macro-generated lint warnings
+- How to suppress a lint rule that fires only at certain user call sites?
+
+## Questions
+- Where does `// nolint:RULE` go when a lint warning is emitted from inside a `qmacro_expr` and fires at the user's call site rather than at the macro source?

--- a/mouse-data/docs/which-typedecl-predicates-identify-types-where-length-expr-is-statically-resolvable-in-daslang-macros.md
+++ b/mouse-data/docs/which-typedecl-predicates-identify-types-where-length-expr-is-statically-resolvable-in-daslang-macros.md
@@ -1,0 +1,63 @@
+---
+slug: which-typedecl-predicates-identify-types-where-length-expr-is-statically-resolvable-in-daslang-macros
+title: Which TypeDecl predicates identify types where length(expr) is statically resolvable in daslang macros?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+# Length-supporting types in daslang macros
+
+When a `[macro_function]` / `[call_macro]` needs to emit `length($e(src))` and have it compile, the source's `TypeDecl` must be one of:
+
+- `isGoodArrayType` — `array<T>` (the dynamic array, including `array<T>#`)
+- `isGoodTableType` — `table<K; V>`
+- `isString` — `string` / `string#`
+- `isArray` — fixed array `T[N]` (NOT `array<T>` — that's `isGoodArrayType`; the naming is confusing)
+- `isRange` — `range` / `urange` / `range64` / `urange64`
+
+**Excluded** (no `length()` overload — emitting `length(src)` will fail to compile inside macro output):
+
+- `isIterator` — iterators don't carry length, even when wrapping a length-having source. Use the underlying container.
+- `isGoodLambdaType` — `def each(lam : lambda<...>)` makes lambdas iterable, but they have no `length()`. This is a common trap when peeling `each(<x>)` based solely on "not an iterator."
+- Custom user `def each(MyType)` types — depends on whether the user also defined `length(MyType)`; assume no.
+
+## Canonical predicate
+
+```das
+[macro_function]
+def private type_has_length(t : TypeDecl?) : bool {
+    if (t == null) return false
+    return (t.isGoodArrayType || t.isGoodTableType || t.isString
+        || t.isArray || t.isRange)
+}
+```
+
+Note the parenthesization: a bare `||`-chain split across lines hits a `gen2` parse error at the leading `||`. Wrap the chain in `(...)`.
+
+## Why this matters for `each(<x>)` peeling
+
+A common optimization: when a chain starts `each(<x>)._where(...)...`, peel the `each` and iterate `<x>` directly so reserve/length work. The peel must be gated on `type_has_length(<x>._type)` — checking only `!isIterator` would silently accept `each(lambda)` and emit broken `reserve(length(lambda))`.
+
+Example from `daslib/linq_fold.das` (PR #2689, Phase 2A):
+
+```das
+[macro_function]
+def private peel_each_length_source(var top : Expression?) : Expression? {
+    if (!(top is ExprCall)) return top
+    var topCall = top as ExprCall
+    if (topCall.func == null || topCall.func.name != "each"
+            || topCall.arguments |> length != 1
+            || !type_has_length(topCall.arguments[0]._type)) return top
+    return clone_expression(topCall.arguments[0])
+}
+```
+
+The `clone_expression` is needed because `topCall.arguments[0]` is `Expression? const` (the args vector entry is const-typed even when the outer call is `var`); the planner stores `top` as `var Expression?` so the clone drops the const.
+
+## Discovery
+
+The set of `length()`-supporting types is not advertised as a single predicate anywhere — assembled from `mcp__daslang__describe_type TypeDecl` (the `isXxx` method list) cross-referenced with the `def length(...)` overloads in `daslib/builtin.das` and the `def each(...)` overloads. Lambda iterables surfaced as a Copilot review finding on PR #2689.
+
+## Questions
+- Which TypeDecl predicates identify types where length(expr) is statically resolvable in daslang macros?

--- a/mouse-data/docs/why-does-daslang-live-s-post-shutdown-return-200-ok-but-the-subprocess-never-actually-exits-on-linux-macos.md
+++ b/mouse-data/docs/why-does-daslang-live-s-post-shutdown-return-200-ok-but-the-subprocess-never-actually-exits-on-linux-macos.md
@@ -1,0 +1,41 @@
+---
+slug: why-does-daslang-live-s-post-shutdown-return-200-ok-but-the-subprocess-never-actually-exits-on-linux-macos
+title: Why does daslang-live's POST /shutdown return 200 OK but the subprocess never actually exits on Linux/macOS?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+**Root cause is in vendored libhv (v1.3.4), not daslang.** `live_api.das` registers an `ANY("*")` catch-all alongside specific routes like `GET /status` and `POST /shutdown`. libhv's `Any(path)` (`include/hv/HttpService.h:268-277`) expands internally to one `Handle("METHOD", path, h)` per HTTP verb on the same path key.
+
+libhv stores all `(path -> method_handlers)` pairs in `pathHandlers`, declared as **`std::unordered_map<std::string, ...>`** at `include/hv/HttpService.h:105`. `HttpService::GetRoute` (`http/server/HttpService.cpp:72-127`) iterates that map in **container order** and takes the first wildcard or path match it finds.
+
+Because `std::unordered_map`'s iteration order is implementation- and bucket-defined, `"*"` happens to enumerate BEFORE specific paths like `/status` on Linux libstdc++ (deterministic), and intermittently on Windows MSVC depending on rehash timing. When that happens, every request — including `POST /shutdown` — hits the wildcard handler, which returns the help JSON (200 OK). The real `/shutdown` handler that calls `request_exit()` is never invoked. The main loop spins forever, and the parent times out the subprocess with `popen_exit_code = DAS_POPEN_TIMEOUT = 0x7FFFFF01`.
+
+**How to confirm you're hitting this:** while the daslang-live subprocess is running, `curl -s http://127.0.0.1:9090/status`. If the body contains `"endpoints"` (the help JSON), the wildcard is winning. If it returns real status JSON with `"has_error"` / `"paused"` / `"fps"` fields, routing works.
+
+**Workaround (landed as daslang PR #2688, `bbatkin/live-api-drop-any-catchall`):** drop `ANY("*")` from `live_api.das` and serve the help JSON from a specific `GET("/")` handler instead. `/` is an exact-match path, so it never collides with `/status` etc. — the ordering hazard is gone regardless of how libhv stores routes. Unknown paths return libhv's default 404; programmatic clients (playwright, MCP `live_*` tools) never relied on the catch-all.
+
+**Follow-up work (deferred until libhv-side fix lands):**
+1. File the libhv upstream issue — unreported per 2026-05-16 web research; we'd be first.
+2. Wire libhv's built-in `errorHandler` hook through dasHV (`WebServer_Adapter` setter), rewrite `live_api.das` to drop the `GET("/")` workaround and use `errorHandler` for the help fallback. That's the idiomatic shape on libhv's terms.
+3. Address Copilot review comments on PR #2688 as part of that rewrite: (a) `live_api.das:25` module-level `//!` endpoint list should mention `GET /`; (b) `live_api.das:217` "curl :9090/" example — actually valid curl shorthand for localhost, but rephrasing to `curl http://localhost:9090/` is friendlier.
+4. Consider a lint rule against `ANY("*")` registered alongside specific paths.
+
+**Upstream fix status (researched 2026-05-16):**
+- **Unreported** — exhaustive search of `ithewei/libhv` issues for `route|wildcard|Any|GetRoute|HttpService|pathHandlers` returned zero hits on this bug. We'd be the first to file.
+- **Not fixed in master** — libhv's `http/server/HttpService.cpp` last touched 2023-07-29 (before v1.3.4); same `std::unordered_map<std::string, ...>` for `pathHandlers` at `http/server/HttpService.h:107`; same first-match-wins loop in `GetRoute` at line ~72. v1.3.4 IS the latest release (2025-10-25).
+- **Known wart upstream**: `docs/PLAN.md` lists "Path router: optimized matching via trie?" as an open question — maintainers know the router is suboptimal, just haven't prioritized it.
+- **Industry comparison**: Crow uses a trie; cpp-httplib preserves registration order so static paths always precede regex catch-alls. This is a libhv-specific defect, not industry norm.
+- **Documented behavior**: libhv docs (`README.md`, `docs/API.md`, `docs/cn/HttpServer.md`) say NOTHING about route precedence or wildcard semantics. Behavior is implementation-defined.
+
+**Better script-side option (not yet exercised): `errorHandler` hook.** libhv has a built-in fallback handler that fires after the processor chain runs and status ≥ 400 with empty body (`http/server/HttpService.h:133` + `http/server/HttpHandler.cpp:476-486`). Official example wiring at `examples/httpd/router.cpp:15` + `examples/httpd/handler.cpp:46`. Drop `ANY("*")`, assign `errorHandler` instead — `/status` / `/shutdown` win deterministically, everything else falls through to the help dump. **dasHV does NOT currently expose `errorHandler`**, so this needs C++ glue (a setter on `WebServer_Adapter`) before live_api can use it. PR #2688's `GET("/")` workaround is the interim fix.
+
+**Also worth knowing**: official libhv examples never register bare `Any("*")` alongside specific paths — they use prefix wildcards like `GET("/wildcard*", ...)` (see `examples/httpd/router.cpp:70`). The maintainers don't exercise our usage pattern, so the bug has presumably never surfaced for upstream users.
+
+**Why Windows seems to work most of the time:** MSVC's `std::unordered_map` bucket layout for the specific paths daslang-live registers happens to enumerate specific paths before `"*"`. It's not a guarantee — different route counts (e.g. adding more endpoints) trigger rehashes and can flip the order. Not "Windows-correct, Linux-broken" — both are subject to the same hazard.
+
+**Symptom to watch for in CI logs:** `popen_exit_code=2147483393` (0x7FFFFF01 = `DAS_POPEN_TIMEOUT`) on POSIX, with the playwright drain step taking the full `DEFAULT_TEST_TIMEOUT_SEC` (120s default). Subprocess gets SIGKILLed at the watchdog.
+
+## Questions
+- Why does daslang-live's POST /shutdown return 200 OK but the subprocess never actually exits on Linux/macOS?

--- a/mouse-data/docs/why-does-each-arr-fail-with-unsafe-when-not-source-of-for-loop-outside-a-for-and-what-s-the-alternative-in-a-linq-chain.md
+++ b/mouse-data/docs/why-does-each-arr-fail-with-unsafe-when-not-source-of-for-loop-outside-a-for-and-what-s-the-alternative-in-a-linq-chain.md
@@ -25,7 +25,7 @@ error[31013]: '__::builtin`each`...' is unsafe, when not source of the for-loop;
 
 **Heuristic:** if the chain ends in a `_fold(...)` / `_old_fold(...)` wrapper or a for-loop, `each(arr)` works as the source. If the chain produces a value (or array) that escapes the expression — a `let`, a function return, the second arg to a macro — drop the `each()` and pass the array directly.
 
-The lint at runtime points at the **specific** `each(arr)` call that escapes, so for multi-each chains (`_join`, `_zip`), check which side is the issue.
+The compiler error points at the **specific** `each(arr)` call that escapes, so for multi-each chains (`_join`, `_zip`), check which side is the issue.
 
 ## Questions
 - Why does `each(arr)` fail with "unsafe when not source of for-loop" outside a for, and what's the alternative in a linq chain?

--- a/mouse-data/docs/why-does-each-arr-fail-with-unsafe-when-not-source-of-for-loop-outside-a-for-and-what-s-the-alternative-in-a-linq-chain.md
+++ b/mouse-data/docs/why-does-each-arr-fail-with-unsafe-when-not-source-of-for-loop-outside-a-for-and-what-s-the-alternative-in-a-linq-chain.md
@@ -1,0 +1,36 @@
+---
+slug: why-does-each-arr-fail-with-unsafe-when-not-source-of-for-loop-outside-a-for-and-what-s-the-alternative-in-a-linq-chain
+title: Why does `each(arr)` fail with "unsafe when not source of for-loop" outside a for, and what's the alternative in a linq chain?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+`each(arr)` returns an iterator that walks the array. Daslang's safety rules say that iterator is unsafe **unless it's directly consumed by a for-loop in the same scope** — passing it through `|>` chains, capturing it in a `let`, or handing it to a function argument all trip:
+
+```
+error[31013]: '__::builtin`each`...' is unsafe, when not source of the for-loop;
+              must be inside the 'unsafe' block
+```
+
+**Inside `_fold(...)`** the error doesn't fire because `_fold` is a macro that expands to a for-loop body where `each(arr)` IS the source. So `_fold(each(arr)._where(...).count())` compiles cleanly.
+
+**Outside a fold macro**, in a plain pipe chain, use the array directly — most `_<op>` call-macros (`AstCallMacro_LinqPred2`) accept both `iterator<T>` and `array<T>` for arg 0:
+
+| Doesn't work | Use instead |
+|---|---|
+| `let prices <- (each(arr) \|> _where(...) \|> _select_to_array(_.price))` (iterator outside `_fold`) | `let prices <- (arr \|> _where(...) \|> _select(_.price))` — array+macros chains as array; result is `array<T>`, no `_to_array` suffix needed |
+| `let c = each(cars)._join(each(dealers), ...)` inside `_fold` (two `each()`s, one not the chain source) | `let c = _fold(cars \|> _join(dealers, ..., ...) \|> count())` — pass arrays directly |
+| `let r = each(arr) \|> ...` outside any fold | wrap in `unsafe(each(arr))`, OR start the chain with `arr` directly and let the macro handle iterator promotion |
+
+**Heuristic:** if the chain ends in a `_fold(...)` / `_old_fold(...)` wrapper or a for-loop, `each(arr)` works as the source. If the chain produces a value (or array) that escapes the expression — a `let`, a function return, the second arg to a macro — drop the `each()` and pass the array directly.
+
+The lint at runtime points at the **specific** `each(arr)` call that escapes, so for multi-each chains (`_join`, `_zip`), check which side is the issue.
+
+## Questions
+- Why does `each(arr)` fail with "unsafe when not source of for-loop" outside a for, and what's the alternative in a linq chain?
+- error[31013] '__::builtin`each`' is unsafe — how to fix?
+- When can I use `each(arr)` in a linq pipe chain?
+
+## Questions
+- Why does `each(arr)` fail with "unsafe when not source of for-loop" outside a for, and what's the alternative in a linq chain?

--- a/mouse-data/docs/why-does-my-dastest-integration-test-hang-at-readiness-gate-failed-when-external-curl-to-status-works-fine-is-it-a-require-order.md
+++ b/mouse-data/docs/why-does-my-dastest-integration-test-hang-at-readiness-gate-failed-when-external-curl-to-status-works-fine-is-it-a-require-order.md
@@ -15,11 +15,11 @@ links: []
 [imgui_playwright] readiness gate FAILED
 ```
 
-External `curl http://localhost:9090/status` from a sibling shell returns 200 with proper status JSON throughout — only the popen parent's poll loop "can't see it". Reproduces on macOS and Linux; appears to NOT reproduce on Windows (which is the trap — see below).
+External `curl http://localhost:9090/status` from a sibling shell returns 200 with proper status JSON throughout — only the popen parent's poll loop "can't see it". Reproduces on macOS and Linux; pre-PR #2685 appeared to NOT reproduce on Windows (which was the trap — raw QPC tick math accidentally masked the bug; post-PR #2685 Windows also returns nanoseconds and shows the same failure).
 
 # Root cause
 
-**`ref_time_ticks()` returns nanoseconds on POSIX, but the wait-loop math assumes microseconds.**
+**`ref_time_ticks()` returns nanoseconds on all platforms (post-PR #2685), but the wait-loop math assumed microseconds.**
 
 `src/hal/performance_time.cpp` defines `ref_time_ticks()` per platform:
 
@@ -27,7 +27,7 @@ External `curl http://localhost:9090/status` from a sibling shell returns 200 wi
 |---|---|
 | Linux  | `tv_sec * 1e9 + tv_nsec` — **nanoseconds** |
 | macOS  | `clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)` — **nanoseconds** |
-| Windows | `QueryPerformanceCounter().QuadPart` — counter ticks, freq depends on hardware (often ~10 MHz, accidentally close to 1 MHz / microsecond scaling) |
+| Windows | QPC ticks converted to **nanoseconds** via `ticks × (1e9 / freq)`; fast path at 10 MHz QPF = 100 ns/tick multiply (PR #2685). Pre-PR #2685: raw `QuadPart` ticks, ~10 MHz, accidentally close to μs scaling. |
 
 `imgui_playwright`'s `wait_until_ready` (and other deadline loops) used:
 
@@ -41,7 +41,8 @@ while (ref_time_ticks() < deadline) {
 
 That `* 1000000.0f` assumes ref-time is in microseconds. So:
 - **Linux/macOS**: a "30s" deadline is `30 * 1e6 = 30 million nanoseconds = 30 milliseconds`. Loop fires 0-1 polls and exits. The `connect 127.0.0.1:9090 failed!` line is the one in-flight libhv connect attempt timing out — server health is fine; the loop just budgeted itself out of existence.
-- **Windows**: QPC freq is hardware-dependent but on common runners works out near enough to 1 MHz that `* 1e6` lands in the "seconds" ballpark by accident, masking the bug.
+- **Windows (post-PR #2685)**: `ref_time_ticks()` now also returns nanoseconds on Windows, so the same 30 ms budget applies — the bug is equally visible.
+- **Windows (pre-PR #2685)**: raw QPC `QuadPart` ticks at ~10 MHz worked out near enough to 1 MHz that `* 1e6` landed in the "seconds" ballpark by accident, masking the bug on Windows CI.
 
 # The Windows-only "require order" workaround is misleading
 
@@ -61,9 +62,10 @@ while (get_time_usec(t_start) < timeout_us) {
     ...
 }
 
-// Option B — compute deadline in nanoseconds, on POSIX
+// Option B — compute deadline in nanoseconds (safe on all platforms after PR #2685)
 let deadline = ref_time_ticks() + int64(timeout_sec * 1000000000.0f)
-// (DON'T do this without a per-platform branch — breaks Windows)
+// (On pre-PR #2685 Windows builds, ref_time_ticks() returned raw QPC ticks, so this
+//  would be wrong there. Prefer Option A if you need to support older builds.)
 ```
 
 **Option A is the right one.** `get_time_usec(reft)` is defined per-platform in `performance_time.cpp` and always returns microseconds. Audit any other `ref_time_ticks() + ... * 1000000.0f` patterns in your codebase the same way.
@@ -72,7 +74,7 @@ let deadline = ref_time_ticks() + int64(timeout_sec * 1000000000.0f)
 
 - Test hangs at `readiness gate FAILED` (not at `body did not converge` or similar).
 - External `curl` to `localhost:9090/status` works while the test hangs.
-- Reproduces on macOS / Linux; "works" on Windows (deceptive — see above).
+- Reproduces on macOS / Linux; on current code also reproduces on Windows (post-PR #2685 normalization). Pre-PR #2685, Windows masked the bug via raw QPC tick math — see the platform table above.
 - Suspect any deadline loop using `ref_time_ticks() + ... * 1e6` — that's the smoking gun.
 
 # Why this took a while to spot

--- a/mouse-data/docs/why-does-my-dastest-integration-test-hang-at-readiness-gate-failed-when-external-curl-to-status-works-fine-is-it-a-require-order.md
+++ b/mouse-data/docs/why-does-my-dastest-integration-test-hang-at-readiness-gate-failed-when-external-curl-to-status-works-fine-is-it-a-require-order.md
@@ -15,61 +15,80 @@ links: []
 [imgui_playwright] readiness gate FAILED
 ```
 
-(30s `wait_until_ready` timeout, then 120s popen drain timeout. External `curl http://localhost:9090/status` from a sibling shell returns 200 with proper status JSON throughout — only the popen parent's request loop can't see it.)
+External `curl http://localhost:9090/status` from a sibling shell returns 200 with proper status JSON throughout — only the popen parent's poll loop "can't see it". Reproduces on macOS and Linux; appears to NOT reproduce on Windows (which is the trap — see below).
 
 # Root cause
 
-`live/live_api` was required BEFORE `imgui_app + glfw/glfw_boost + opengl/* + glfw_live + opengl_live` somewhere in the requirer chain (usually a wrapper module like `imgui/imgui_harness`). The `[_macro] installing` in `live_api.das` calls `fork_debug_agent_context(@@debug_agent)` at compile time. If that fork happens before GLFW is initialized in the live runtime, the resulting LiveApiServer becomes unreachable from a popen parent on Windows.
+**`ref_time_ticks()` returns nanoseconds on POSIX, but the wait-loop math assumes microseconds.**
 
-Filed: [#2677](https://github.com/GaijinEntertainment/daScript/issues/2677). Distinct from #2675 (`ANY("*")` route shadowing).
+`src/hal/performance_time.cpp` defines `ref_time_ticks()` per platform:
 
-# Fix (mechanical)
+| Platform | Returns |
+|---|---|
+| Linux  | `tv_sec * 1e9 + tv_nsec` — **nanoseconds** |
+| macOS  | `clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)` — **nanoseconds** |
+| Windows | `QueryPerformanceCounter().QuadPart` — counter ticks, freq depends on hardware (often ~10 MHz, accidentally close to 1 MHz / microsecond scaling) |
 
-In the requirer module (yours or a wrapper you control), reorder requires so the **windowed backend stack comes first**:
+`imgui_playwright`'s `wait_until_ready` (and other deadline loops) used:
 
 ```das
-// Windowed backend FIRST (correctness, not aesthetics).
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/opengl_live
-
-// Live-host + boost-runtime stack AFTER.
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_visual_aids
+let deadline = ref_time_ticks() + int64(timeout_sec * 1000000.0f)
+while (ref_time_ticks() < deadline) {
+    GET("{base_url}/status") $(resp) { ... }
+    sleep(READY_POLL_INTERVAL_MS)
+}
 ```
 
-This mirrors the canonical order every pre-`imgui_harness` example/test used verbatim. Reordering is a no-op for visibility / re-export semantics — purely a workaround for the install-time ordering bug.
+That `* 1000000.0f` assumes ref-time is in microseconds. So:
+- **Linux/macOS**: a "30s" deadline is `30 * 1e6 = 30 million nanoseconds = 30 milliseconds`. Loop fires 0-1 polls and exits. The `connect 127.0.0.1:9090 failed!` line is the one in-flight libhv connect attempt timing out — server health is fine; the loop just budgeted itself out of existence.
+- **Windows**: QPC freq is hardware-dependent but on common runners works out near enough to 1 MHz that `* 1e6` lands in the "seconds" ballpark by accident, masking the bug.
+
+# The Windows-only "require order" workaround is misleading
+
+[#2677](https://github.com/GaijinEntertainment/daScript/issues/2677) and a prior version of this card blamed require-order — windowed-backend stack vs. live-host stack — claiming `[_macro] installing` in `live_api.das` calling `fork_debug_agent_context(@@debug_agent)` before GLFW init was the issue. That diagnosis was wrong. The reorder happened to nudge timings just enough on Windows for the (already-too-short) loop to occasionally win the race, which read as "fix". On POSIX, the same reorder changes nothing — the loop still exits in 30 ms regardless of require order.
+
+If you see code in `imgui_harness.das` carrying a `// NOTE on require ordering` comment about live_api needing to come after the windowed stack: that comment is load-bearing only by accident on Windows. The real fix is in the timing math.
+
+# Fix
+
+Replace any `ref_time_ticks() + int64(seconds * 1000000.0f)` deadline pattern with platform-correct math. Two options:
+
+```das
+// Option A — use the elapsed-microsec helper (always microseconds, all platforms)
+let t_start = ref_time_ticks()
+let timeout_us = int(timeout_sec * 1000000.0f)
+while (get_time_usec(t_start) < timeout_us) {
+    ...
+}
+
+// Option B — compute deadline in nanoseconds, on POSIX
+let deadline = ref_time_ticks() + int64(timeout_sec * 1000000000.0f)
+// (DON'T do this without a per-platform branch — breaks Windows)
+```
+
+**Option A is the right one.** `get_time_usec(reft)` is defined per-platform in `performance_time.cpp` and always returns microseconds. Audit any other `ref_time_ticks() + ... * 1000000.0f` patterns in your codebase the same way.
 
 # How to recognize this gotcha
 
 - Test hangs at `readiness gate FAILED` (not at `body did not converge` or similar).
-- External `curl` to `localhost:9090/status` works while the test hangs (proves the server is up — the popen parent specifically can't reach it).
-- Always reproduces — not a flaky timing issue.
-- ONLY triggers when run via `popen` (via `with_imgui_app` in `imgui_playwright`, or any `dastest` integration test). Direct `bin/Release/daslang-live.exe <script>.das` runs fine because there's no popen parent.
+- External `curl` to `localhost:9090/status` works while the test hangs.
+- Reproduces on macOS / Linux; "works" on Windows (deceptive — see above).
+- Suspect any deadline loop using `ref_time_ticks() + ... * 1e6` — that's the smoking gun.
 
-# Verification commands
+# Why this took a while to spot
 
-After reordering, the full dasImgui suite passes:
+The symptom looked exactly like a network or popen-inheritance bug:
+- libhv server is up (curl proves it)
+- The dastest process's libhv client errors with `connect 127.0.0.1:9090 failed!`
+- It's specific to the popen parent
 
-```bash
-bin/Release/daslang.exe dastest/dastest.das -- --test modules/dasImgui/tests/integration
-# 110 tests, 110 passed, 0 failed in ~500s
-```
+The actual chain was: the poll loop's deadline elapsed before the first GET even had a chance to retry. The single connect error in the log was libhv's first attempt timing out as the loop quit. Everything past that ("requires order", "fork_debug_agent_context", "libhv client init quirk on macOS") was downstream of misreading the symptom.
 
-# Why not "just fix it in daslang"
+# Verification
 
-The bug is in dasLiveHost or libhv's interaction with [_macro]-driven debug-agent install ordering. Filed as #2677 for triage, but the fix isn't trivial — for now reorder requires in the consumer/wrapper, document the ordering as load-bearing, and move on.
+After the fix, a clean local run of the dasImgui integration suite passes on macOS in seconds-per-test rather than 120s-test-timeout-per-test.
 
 ## Questions
 - why does my dastest integration test hang at "readiness gate FAILED" when external curl to /status works fine — is it a require-order issue in daslang-live?
+- on macOS / Linux, ref_time_ticks() returns nanoseconds — does any of my code assume microseconds?
+- what units does ref_time_ticks() return per platform?

--- a/mouse-data/docs/why-does-my-lint-macro-fire-on-the-wrapper-module-that-legitimately-uses-the-forbidden-symbols-even-though-i-scope-visit-module.md
+++ b/mouse-data/docs/why-does-my-lint-macro-fire-on-the-wrapper-module-that-legitimately-uses-the-forbidden-symbols-even-though-i-scope-visit-module.md
@@ -1,0 +1,74 @@
+---
+slug: why-does-my-lint-macro-fire-on-the-wrapper-module-that-legitimately-uses-the-forbidden-symbols-even-though-i-scope-visit-module
+title: Why does my [lint_macro] fire on the wrapper module that legitimately uses the forbidden symbols, even though I scope visit_module to prog.getThisModule?
+created: 2026-05-16
+last_verified: 2026-05-16
+links: []
+---
+
+# `[lint_macro]` runs per-module — wrapper modules need a defensive opt-out
+
+`[lint_macro]` doesn't fire once per *program* compile. It fires once per *module* compile in the require chain. When `foo.das` requires `imgui_harness` which requires `imgui_harness_lint`, the lint runs:
+
+1. Once with `prog.getThisModule()` = `imgui_harness` (during the harness's own compile pass).
+2. Once with `prog.getThisModule()` = the consumer (during `foo.das`'s compile pass).
+
+The `visit_module(prog, adapter, prog.getThisModule)` line scopes the walk correctly each time — but the visited module for pass 1 is the *harness*, whose body legitimately calls into the very surface the lint is supposed to forbid (because that's what the wrapper does).
+
+## Symptom
+
+A clean consumer file fails to compile with diagnostics pointing INTO the wrapper module:
+
+```
+error[50503]: HARNESS001: glfw_live::live_create_window is forbidden ...
+modules/dasImgui/widgets/imgui_harness.das:102:4
+    live_create_window(title, width, height)
+    ^^^^^^^^^^^^^^^^^^
+```
+
+You stare at the consumer file and there's no `live_create_window` in it. The diagnostic is fired from the *wrapper's* compile pass, then propagates up as the consumer's compile failure.
+
+## Fix — defensive opt-out at the top of the wrapper
+
+Every wrapper / sibling module that the lint touches transitively needs to carry the per-file escape:
+
+```das
+options gen2
+options _allow_glfw_calls = true        // <-- defensive opt-out
+
+module imgui_harness shared public
+
+require imgui_app           // legitimately uses GLFW/GL — that's the point
+require glfw/glfw_boost
+require live/glfw_live
+// ...
+```
+
+This is the same pattern `widgets/imgui_lint.das` documents in its header:
+
+> Wrapper modules under `widgets/` also carry `options _allow_imgui_legacy = true` defensively so they compile cleanly when targeted directly (MCP compile_check, lint, format_file).
+
+It's not just for `compile_check` / `lint` direct-targeting. It also kicks in during the consumer's require chain — every time the wrapper's module is compiled as a dependency.
+
+## Why this is non-obvious
+
+`visit_module(prog, adapter, prog.getThisModule)` reads like "walk only the consumer's functions" — and it does, for the consumer's pass. But the same macro registration also fires for the wrapper's pass, where `getThisModule` *is* the wrapper. The scoping is correct; the surprise is that the lint executes N times across the require chain, not once at the top.
+
+## Don't try to fix in the visitor
+
+Adding a "skip if `current_function._module != this_module`" filter (where `this_module = prog.getThisModule` captured in `apply()`) does *nothing* — the per-pass `getThisModule` already equals `current_function._module` during the wrapper's pass. The wrapper IS thisModule from its own pass's perspective.
+
+The opt-out at the wrapper's source IS the fix. Match the existing convention.
+
+## Reference
+
+- `modules/dasImgui/widgets/imgui_lint.das` header — has the canonical paragraph documenting the convention for `_allow_imgui_legacy`.
+- `modules/dasImgui/widgets/imgui_harness.das` line ~5 — carries `_allow_glfw_calls = true` defensively for the same reason.
+
+## Questions
+- Why does a [lint_macro] error appear at a line in the wrapper module instead of my consumer file?
+- Do I need to filter calls inlined from a different module in my [lint_macro] AST visitor?
+- Why does my [lint_macro] run multiple times for one consumer compile?
+
+## Questions
+- Why does my [lint_macro] fire on the wrapper module that legitimately uses the forbidden symbols, even though I scope visit_module to prog.getThisModule?


### PR DESCRIPTION
## Summary

Cards added/refined across two parallel work streams that wrapped today:

1. **linq_fold splice rewrite** (PR #2687 foundation, PR #2689 Phase 2A, PR #2691 has_sideeffects + counter-lane elision) — 16 cards on macro-emission patterns, LINQ semantics, and tooling
2. **dasImgui PR #38 CI matrix resurrection** — 5 cards on dasHV/libhv Windows quirks, ImGui macOS shortcuts, and the cascade-guard pattern

Docs-only — no code changes.

## What's in here

### linq_fold / macro-emission patterns

- [daslang-generic-instance-detect-via-fromgeneric](mouse-data/docs/daslang-generic-instance-detect-via-fromgeneric.md) — `func.fromGeneric` is the canonical "which generic was this instantiated from?" link. `func.name` on typed instances is mangled.
- [daslib-macro-boost-has-sideeffects-predicate](mouse-data/docs/daslib-macro-boost-has-sideeffects-predicate.md) — the new public predicate from PR #2691, full classification table, known limitations, test-probe plumbing.
- [qmacro-invoke-source-bind-typedecl-modifier-iter-vs-array](mouse-data/docs/qmacro-invoke-source-bind-typedecl-modifier-iter-vs-array.md) — block-param `typedecl(...) [- const]` handling differs between iterator (rvalue, needs `-const`) and array sources (const-ref, keep modifiers).
- [qmacro-gensym-per-callsite-via-lineinfo](mouse-data/docs/qmacro-gensym-per-callsite-via-lineinfo.md) — `` `name`{at.line}`{at.column} `` pattern + `force_at` + `force_generated` + `can_shadow`.
- **[my-fold-macro-emits-a-loop-with-for-it-in-source-...](mouse-data/docs/my-fold-macro-emits-a-loop-with-for-it-in-source-acc-reserve-length-source-but-the-reserve-doesn-t-fire-when-the-chain-starts-wi.md)** (UPDATED) — `peel_each` pattern corrected: generic-instance via `fromGeneric`, positive array gate, branched block-param typedecl. Links to the two new related cards.

### LINQ semantics

- [are-there-parity-tests-in-tests-linq-that-compare-fold-output-to-...](mouse-data/docs/are-there-parity-tests-in-tests-linq-that-compare-fold-output-to-the-underlying-linq-operators.md)
- [which-typedecl-predicates-identify-types-where-length-expr-is-statically-resolvable-...](mouse-data/docs/which-typedecl-predicates-identify-types-where-length-expr-is-statically-resolvable-in-daslang-macros.md)
- [why-does-each-arr-fail-with-unsafe-when-not-source-of-for-loop-outside-a-for-...](mouse-data/docs/why-does-each-arr-fail-with-unsafe-when-not-source-of-for-loop-outside-a-for-and-what-s-the-alternative-in-a-linq-chain.md)
- [what-s-the-right-sqlite-linq-chain-form-for-aggregates-sum-min-max-average-...](mouse-data/docs/what-s-the-right-sqlite-linq-chain-form-for-aggregates-sum-min-max-average-and-what-operators-aren-t-supported-as-sql-chain-term.md)
- [my-macro-substitutes-it-for-a-projection-expression-via-template-replacevariable-it-proj-...](mouse-data/docs/my-macro-substitutes-it-for-a-projection-expression-via-template-replacevariable-it-proj-apply-template-but-the-result-fails-to.md)
- [when-a-call-macro-needs-to-pick-copy-vs-move-init-for-a-projection-should-i-emit-static-if-...](mouse-data/docs/when-a-call-macro-needs-to-pick-copy-vs-move-init-for-a-projection-should-i-emit-static-if-typeinfo-is-workhorse-e-proj-or-decid.md)
- [where-does-nolint-rule-go-when-a-lint-warning-is-emitted-from-inside-a-qmacro-expr-...](mouse-data/docs/where-does-nolint-rule-go-when-a-lint-warning-is-emitted-from-inside-a-qmacro-expr-and-fires-at-the-user-s-call-site-rather-than.md)

### Tooling / ops

- [how-do-i-run-dastest-in-benchmark-only-mode-and-what-s-the-command-line-syntax](mouse-data/docs/how-do-i-run-dastest-in-benchmark-only-mode-and-what-s-the-command-line-syntax.md)
- [cpp-profiler-macos-samply-instruments](mouse-data/docs/cpp-profiler-macos-samply-instruments.md)
- [what-s-the-end-to-end-checklist-for-adding-a-new-daslib-das-module-so-docs-build-cleanly](mouse-data/docs/what-s-the-end-to-end-checklist-for-adding-a-new-daslib-das-module-so-docs-build-cleanly.md)
- [how-do-i-call-a-dasimgui-or-any-managed-c-method-on-a-struct-field-that-s-bound-as-a-raw-pointer-...](mouse-data/docs/how-do-i-call-a-dasimgui-or-any-managed-c-method-on-a-struct-field-that-s-bound-as-a-raw-pointer-e-g-addfontfromfilettf-on-getio.md)

### Correction (existing card)

- **[why-does-my-dastest-integration-test-hang-at-readiness-gate-failed-...](mouse-data/docs/why-does-my-dastest-integration-test-hang-at-readiness-gate-failed-when-external-curl-to-status-works-fine-is-it-a-require-order.md)** — original card pointed at a `require`-order red herring; real cause was `ref_time_ticks()` returning ns on POSIX while `wait_until_ready`'s deadline math assumed μs. Fix landed in PR #2685. **Companion: issue #2677 (which encoded the same misdiagnosis) closed as superseded.**

### dasImgui PR #38 — CI matrix resurrection (5 new cards)

- [imgui-playwright-windows-ci-16-post-libhv-stall](mouse-data/docs/imgui-playwright-windows-ci-16-post-libhv-stall.md) — dasHV/libhv on GitHub-hosted `windows-latest` stalls after exactly 16 POST /command per subprocess. Empirically counted from `DASLIVE_HV_LOG=stderr` logs. Local Win11 unaffected. Workaround: 1-POST polling helpers + Windows-only `--exclude` of 7 high-POST tests with a 4-call safety margin under the observed limit.
- [imgui-harness-headless-timeout-sec-cascade-guard](mouse-data/docs/imgui-harness-headless-timeout-sec-cascade-guard.md) — new `--headless-timeout-sec=N` CLI flag on imgui_harness. Playwright passes `(test_timeout - 5)` so a panicked test can't leave a zombie daslang-live holding port 9090 (daslang's `finally` is skipped on panic). Cascade-prevention pattern generalizes to any spawned-subprocess-owning-a-port layout.
- [imgui-macos-configmacosxbehaviors-shortcut-is-super-not-ctrl](mouse-data/docs/imgui-macos-configmacosxbehaviors-shortcut-is-super-not-ctrl.md) — ImGui sets `io.ConfigMacOSXBehaviors = true` on macOS; the "shortcut key" becomes Super (Cmd), not Ctrl. Synth-IO tests must branch on `snap?["io"]?["config_macos_behaviors"]` and use `["Super"]` mods on macOS. Surfaced after the cascade fix made the symptom observable.
- [why-does-daslang-live-s-post-shutdown-return-200-ok-but-the-subprocess-never-actually-exits-on-linux-macos](mouse-data/docs/why-does-daslang-live-s-post-shutdown-return-200-ok-but-the-subprocess-never-actually-exits-on-linux-macos.md) — libhv v1.3.4 `pathHandlers` is `std::unordered_map`; `ANY("*")` catch-all enumerates BEFORE specific paths on Linux libstdc++, intermittently on Windows MSVC. Every request hits the help handler, `/shutdown`'s `request_exit()` never runs. Workaround landed via daslang PR #2688 (drops `ANY`, serves help from `GET("/")`). Upstream libhv bug unreported as of 2026-05-16.
- [why-does-my-lint-macro-fire-on-the-wrapper-module-that-legitimately-uses-the-forbidden-symbols-even-though-i-scope-visit-module](mouse-data/docs/why-does-my-lint-macro-fire-on-the-wrapper-module-that-legitimately-uses-the-forbidden-symbols-even-though-i-scope-visit-module.md) — `[lint_macro]` runs PER MODULE during the require chain; `getThisModule` rebinds per per-module pass, so `visit_module(prog.getThisModule)` also walks the wrapper module that legitimately calls the forbidden symbols. Wrapper modules must carry the defensive opt-out (`options _allow_xxx_calls = true`), same convention as `imgui_lint.das`'s `_allow_imgui_legacy`.

## Test plan

- [x] No code changes — nothing to test
- [x] Cards added via `mouse__add` so similarity-block already vetted (highest sim 0.10 for any new card)
- [x] Cross-links via `[[slug]]` from the corrected fold card to the two new related cards
- [x] Cross-references between the dasImgui PR #38 cards (cascade-guard ↔ Windows-16-POST ↔ ANY-route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)