### PR TITLE
daslang-live: add -project_root flag (mirror daslang.exe)

### DIFF
--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -655,7 +655,7 @@ int main(int argc, char * argv[]) {
         string arg = argv[i];
         if (arg == "-project" && i + 1 < argc) {
             projectFile = argv[++i];
-        } else if (arg == "-project_root" && i + 1 < argc) {
+        } else if ((arg == "-project_root" || arg == "-project-root") && i + 1 < argc) {
             project_root = argv[++i];
         } else if (arg == "-dasroot" && i + 1 < argc) {
             setDasRoot(argv[++i]);

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -568,6 +568,7 @@ static void print_help() {
     tout << "daslang-live - live-reloading application host for daScript\n";
     tout << "Usage: daslang-live [options] <script.das> [-- script arguments]\n";
     tout << "  -project <file>    - project file (.das_project)\n";
+    tout << "  -project_root <path> - project root (parent of modules/, default: script's dir)\n";
     tout << "  -dasroot <path>    - override DAS_ROOT\n";
     tout << "  -cwd               - change working directory to script's folder\n";
     tout << "  -v1syntax          - use v1 syntax (default: v2)\n";
@@ -654,6 +655,8 @@ int main(int argc, char * argv[]) {
         string arg = argv[i];
         if (arg == "-project" && i + 1 < argc) {
             projectFile = argv[++i];
+        } else if (arg == "-project_root" && i + 1 < argc) {
+            project_root = argv[++i];
         } else if (arg == "-dasroot" && i + 1 < argc) {
             setDasRoot(argv[++i]);
         } else if (arg == "-cwd") {


### PR DESCRIPTION
## Summary

`daslang.exe` accepts `-project_root <path>` to override the script-dir fallback used to scan `<root>/modules/*/.das_module`. `daslang-live` was silently lacking the same flag — it only had `-project` (project file). 3-line patch makes the two CLIs symmetric.

## Why

Workflow that surfaced this: running a tutorial via `daslang-live` from inside a module clone at `D:\DASPKG\dasImgui` where the script path was `../../../../examples/tutorial/X.das`. With no `-project_root`, the existing fallback at `utils/daslang-live/main.cpp:722-724` sets `project_root = examples/tutorial` — which has no `modules/` underneath, so `require imgui` fails with `error[20605]: missing prerequisite 'imgui'`. Same scenario works for `daslang.exe` with `-project_root .`.

## Change

`utils/daslang-live/main.cpp` — one new arg-parse arm + one help line:

```cpp
} else if (arg == "-project_root" && i + 1 < argc) {
    project_root = argv[++i];
}
```

The `project_root` static is already declared at line 37 and consumed at line 727; the script-dir fallback at lines 722-724 still kicks in when the flag isn't passed.

## Test plan

- [x] Compile-clean (`cmake --build build --config Release --target daslang-live`)
- [x] Spot-tested: launching `daslang-live -project_root D:/DASPKG/dasImgui ../../../../examples/tutorial/boost_basics.das` from `D:/DASPKG/dasImgui/doc/source/_static/tutorials/` finds the imgui module via `D:/DASPKG/dasImgui/modules/dasImgui/.das_module` (where it would have failed without the flag)
- [ ] Existing daslang-live invocations unchanged (no flag = same behavior as before)
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
