### PR TITLE
examples/graphics: modernize Fourier viz to dasImgui boost-v2 + harness

### DIFF
--- a/examples/graphics/furier_opengl_imgui_example.das
+++ b/examples/graphics/furier_opengl_imgui_example.das
@@ -1,15 +1,22 @@
 options gen2
+options indenting = 4
 options persistent_heap = true
+options _allow_glfw_calls = true
 
-require imgui_app
-require glfw/glfw_boost
-require imgui/imgui_boost
+require imgui/imgui_harness
 require opengl/opengl_boost
-require daslib/math_boost
+require glfw/glfw_boost
+require live/glfw_live
+require imgui_app
 require daslib/safe_addr
+require daslib/math_boost
 require daslib/strings
 
-var window : GLFWwindow?
+// Custom 3D + ImGui hybrid: the harness gives us the boost-v2 widget surface
+// (window/edit_*/text) and the daslang theme via live_imgui_init, but we
+// split harness_end_frame manually because our Fourier viz draws between
+// the GL clear and ImGui's RenderDrawData. _allow_glfw_calls = true opts
+// out of imgui_harness_lint for the OpenGL/GLFW calls we own.
 
 let NGRAPH = 1000
 
@@ -17,90 +24,13 @@ var {
     rotating : bool = true
     rps : float = 0.1f
     tt : float = 0.0f
-// c0
     c0 : float2 = float2(-0.2f, 0.05f)
-// cp1, cn1
     enable_1 : bool = true
     cp1 : float2 = float2(0.27f, 0.0f)
     cn1 : float2 = float2(0.0f, 0.10f)
-// cp2, cn2
     enable_2 : bool = false
     cp2 : float2 = float2(-0.07f, 0.08f)
     cn2 : float2 = float2(0.03f, -0.02f)
-}
-
-def imgui_app(title : string; blk : block) {
-    if (glfwInit() == 0) {
-        panic("can't init glfw")
-    }
-    glfwInitOpenGL(3, 3, false, false)
-    window = glfwCreateWindow(1024, 1024, title, null, null)
-    if (window == null) {
-        panic("can't create window")
-    }
-    glfwMakeContextCurrent(window)
-    glfwSwapInterval(1)
-    CreateContext(null)
-    var io & = unsafe(GetIO())
-    io.FontGlobalScale = 1.0   // BBATKIN: note - my monitor is HUGE
-    StyleColorsDark(null)
-    ImGui_ImplGlfw_InitForOpenGL(window, true)
-    ImGui_ImplOpenGL3_Init("#version 330")
-    var clear_color = float4(0.85f, 0.85f, 0.90f, 1.00f)
-    create_gl_objects()
-    while (glfwWindowShouldClose(window) == 0) {
-        glfwPollEvents()
-        ImGui_ImplOpenGL3_NewFrame()
-        ImGui_ImplGlfw_NewFrame()
-        invoke(blk)
-        var display_w, display_h : int
-        glfwGetFramebufferSize(window, display_w, display_h)
-        glViewport(0, 0, display_w, display_h)
-        glClearColor(clear_color.x, clear_color.y, clear_color.z, clear_color.w)
-        glClear(GL_COLOR_BUFFER_BIT)
-        let time = rotating ? glfwGetTime() * double(rps) % 1.0lf : double(tt)
-        let t = float(time)
-        // compute vectors
-        let p0 = c0
-        let pp1 = mul_complex(cp1, rot_complex(1.0 * t * 2.0 * PI))
-        let pn1 = mul_complex(cn1, rot_complex(-1.0 * t * 2.0 * PI))
-        let pp2 = mul_complex(cp2, rot_complex(2.0 * t * 2.0 * PI))
-        let pn2 = mul_complex(cn2, rot_complex(-2.0 * t * 2.0 * PI))
-        // c0
-        draw_arrow(float2(0.0f, 0.0f), p0, float3(1.0f, 0.0f, 0.0f))
-        if (enable_1) {
-            // cp1
-            var p = p0
-            draw_circle(p, length(cp1), float3(0.0f, 0.0f, 0.0f))
-            draw_arrow(p, pp1, float3(1.0f, 0.0f, 0.0f))
-            p += pp1
-            // cn1
-            draw_circle(p, length(cn1), float3(0.0f, 0.0f, 0.0f))
-            draw_arrow(p, pn1, float3(1.0f, 0.0f, 0.0f))
-            p += pn1
-            if (enable_2) {
-                // cp2
-                draw_circle(p, length(cp2), float3(0.0f, 0.0f, 0.0f))
-                draw_arrow(p, pp2, float3(1.0f, 0.0f, 0.0f))
-                p += pp2
-                // cn2
-                draw_circle(p, length(cn2), float3(0.0f, 0.0f, 0.0f))
-                draw_arrow(p, pn2, float3(1.0f, 0.0f, 0.0f))
-                p += pn2
-            }
-        }
-        // graph
-        draw_graph(float3(1.0f, 1.0f, 0.0f))
-        // and done
-        ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-        glfwMakeContextCurrent(window)
-        glfwSwapBuffers(window)
-    }
-    ImGui_ImplOpenGL3_Shutdown()
-    ImGui_ImplGlfw_Shutdown()
-    DestroyContext(null)
-    glfwDestroyWindow(window)
-    glfwTerminate()
 }
 
 def angle(c : float2) {
@@ -108,58 +38,110 @@ def angle(c : float2) {
     return atan2(C.y, C.x)
 }
 
-def format_angle(c : float2) {
+def format_angle(c : float2) : string {
     return fmt(":.2f", angle(c) / PI) + "*PI"
 }
 
-def format_length(c : float2) {
+def format_length(c : float2) : string {
     return fmt(":.2f", length(c))
 }
 
-def editCoefficientsWindow(p_open : bool? implicit) {
-    if (!Begin("Setup vectors and circles", p_open, ImGuiWindowFlags.None)) {
-        End()
-        return
-    }
-    Text("Speed of PHI, rotations per second")
-    Checkbox("Rotating", unsafe(addr(rotating)))
-    InputFloat("time", unsafe(addr(tt)), 0.1f)
-    InputFloat("RPS", unsafe(addr(rps)), 0.1f)
-    Separator()
-    Text("C0 A={format_length(c0)} PHI={format_angle(c0)}")
-    InputFloat("C0.x", unsafe(addr(c0.x)), 0.1f)
-    InputFloat("C0.y", unsafe(addr(c0.y)), 0.1f)
-    Separator()
-    Checkbox("Enable C1,C-1", unsafe(addr(enable_1)))
-    if (enable_1) {
-        Text("C1  A={format_length(cp1)} PHI={format_angle(cp1)}")
-        InputFloat("C1.x", unsafe(addr(cp1.x)), 0.1f)
-        InputFloat("C1.y", unsafe(addr(cp1.y)), 0.1f)
-        Text("C-1 A={format_length(cn1)} PHI={format_angle(cn1)}")
-        InputFloat("C-1.x", unsafe(addr(cn1.x)), 0.1f)
-        InputFloat("C-1.y", unsafe(addr(cn1.y)), 0.1f)
-        Separator()
-        Checkbox("Enable C2,C-2", unsafe(addr(enable_2)))
-        if (enable_2) {
-            Text("C2  A={format_length(cp2)} PHI={format_angle(cp2)}")
-            InputFloat("C2.x", unsafe(addr(cp2.x)), 0.1f)
-            InputFloat("C2.y", unsafe(addr(cp2.y)), 0.1f)
-            Text("C-2 A={format_length(cn2)} PHI={format_angle(cn2)}")
-            InputFloat("C-2.x", unsafe(addr(cn2.x)), 0.1f)
-            InputFloat("C-2.y", unsafe(addr(cn2.y)), 0.1f)
+def edit_coefficients_window() {
+    window(SETUP_WIN, (text = "Setup vectors and circles", closable = false,
+                       flags = ImGuiWindowFlags.None)) {
+        text("Speed of PHI, rotations per second")
+        edit_checkbox(safe_addr(rotating), (id = "ROTATING", text = "Rotating"))
+        edit_input_float(safe_addr(tt), (id = "TIME", text = "time", step = 0.1f))
+        edit_input_float(safe_addr(rps), (id = "RPS", text = "RPS", step = 0.1f))
+        separator(SEP_C0)
+        text("C0 A={format_length(c0)} PHI={format_angle(c0)}")
+        edit_input_float2(safe_addr(c0), (id = "C0", text = "C0 (x,y)"))
+        separator(SEP_C1)
+        edit_checkbox(safe_addr(enable_1), (id = "ENABLE_1", text = "Enable C1,C-1"))
+        if (enable_1) {
+            text("C1  A={format_length(cp1)} PHI={format_angle(cp1)}")
+            edit_input_float2(safe_addr(cp1), (id = "CP1", text = "C1 (x,y)"))
+            text("C-1 A={format_length(cn1)} PHI={format_angle(cn1)}")
+            edit_input_float2(safe_addr(cn1), (id = "CN1", text = "C-1 (x,y)"))
+            separator(SEP_C2)
+            edit_checkbox(safe_addr(enable_2), (id = "ENABLE_2", text = "Enable C2,C-2"))
+            if (enable_2) {
+                text("C2  A={format_length(cp2)} PHI={format_angle(cp2)}")
+                edit_input_float2(safe_addr(cp2), (id = "CP2", text = "C2 (x,y)"))
+                text("C-2 A={format_length(cn2)} PHI={format_angle(cn2)}")
+                edit_input_float2(safe_addr(cn2), (id = "CN2", text = "C-2 (x,y)"))
+            }
         }
     }
-    End()
+}
+
+def draw_fourier() {
+    let time = rotating ? glfwGetTime() * double(rps) % 1.0lf : double(tt)
+    let t = float(time)
+    let p0 = c0
+    let pp1 = mul_complex(cp1, rot_complex(1.0 * t * 2.0 * PI))
+    let pn1 = mul_complex(cn1, rot_complex(-1.0 * t * 2.0 * PI))
+    let pp2 = mul_complex(cp2, rot_complex(2.0 * t * 2.0 * PI))
+    let pn2 = mul_complex(cn2, rot_complex(-2.0 * t * 2.0 * PI))
+    draw_arrow(float2(0.0f, 0.0f), p0, float3(1.0f, 0.0f, 0.0f))
+    if (enable_1) {
+        var p = p0
+        draw_circle(p, length(cp1), float3(0.0f, 0.0f, 0.0f))
+        draw_arrow(p, pp1, float3(1.0f, 0.0f, 0.0f))
+        p += pp1
+        draw_circle(p, length(cn1), float3(0.0f, 0.0f, 0.0f))
+        draw_arrow(p, pn1, float3(1.0f, 0.0f, 0.0f))
+        p += pn1
+        if (enable_2) {
+            draw_circle(p, length(cp2), float3(0.0f, 0.0f, 0.0f))
+            draw_arrow(p, pp2, float3(1.0f, 0.0f, 0.0f))
+            p += pp2
+            draw_circle(p, length(cn2), float3(0.0f, 0.0f, 0.0f))
+            draw_arrow(p, pn2, float3(1.0f, 0.0f, 0.0f))
+            p += pn2
+        }
+    }
+    draw_graph(float3(1.0f, 1.0f, 0.0f))
 }
 
 [export]
-def main {
-    var f = 0.0
-    imgui_app("Vectors & Circles") {
-        NewFrame()
-        editCoefficientsWindow(null)
-        Render()
+def init() {
+    harness_init("Vectors & Circles", 1024, 1024)
+    create_gl_objects()
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    edit_coefficients_window()
+
+    var display_w, display_h : int
+    live_get_framebuffer_size(display_w, display_h)
+    glViewport(0, 0, display_w, display_h)
+    glClearColor(0.85f, 0.85f, 0.90f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    draw_fourier()
+
+    end_of_frame()
+    Render()
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
     }
+    shutdown()
 }
 
 var @in @location = 0 v_position : float2
@@ -214,7 +196,7 @@ def draw_arrow(origin : float2; c : float2; color : float3) {
     f_color = color
     v_offset = origin
     v_rot = c
-    v_scale = float2(1., 1.)
+    v_scale = float2(1.0f, 1.0f)
     vs_main_bind_uniform(program)
     fs_main_bind_uniform(program)
     glBindVertexArray(vao_arrow)
@@ -260,16 +242,16 @@ def create_gl_objects {
         glBindVertexArray(vao_arrow)
         glGenBuffers(1, safe_addr(vbo_arrow))
         glBindBuffer(GL_ARRAY_BUFFER, vbo_arrow)
-        var vertices <- [Vertex(
-            xy = float2(0.0f, 0.0f)), Vertex(
-            xy = float2(1.0f, 0.0f)), Vertex(
-            xy = float2(0.95f, 0.025f)), Vertex(
-            xy = float2(0.95f, -0.025f)), Vertex(
-            xy = float2(1.0f, 0.0f)
-        )]
+        var vertices <- [
+            Vertex(xy = float2(0.0f, 0.0f)),
+            Vertex(xy = float2(1.0f, 0.0f)),
+            Vertex(xy = float2(0.95f, 0.025f)),
+            Vertex(xy = float2(0.95f, -0.025f)),
+            Vertex(xy = float2(1.0f, 0.0f))
+        ]
         glBufferData(GL_ARRAY_BUFFER, vertices, GL_STATIC_DRAW)
         bind_vertex_buffer(null, type<Vertex>)
-    // graph
+        // graph
         glGenVertexArrays(1, safe_addr(vao_graph))
         glBindVertexArray(vao_graph)
         glGenBuffers(1, safe_addr(vbo_graph))
@@ -280,7 +262,6 @@ def create_gl_objects {
 }
 
 def mul_complex(a, b : float2) {
-    // (a.x+i*a.y)*(b.x+i*b.y) = a.x*b.x - a.y*b.y + i*(a.x*b.y + a.y*b.x)
     return float2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x)
 }
 
@@ -288,7 +269,7 @@ def rot_complex(phi : float) {
     return float2(cos(phi), sin(phi))
 }
 
-def compute_fn(t : float) {// 0..1
+def compute_fn(t : float) {
     let p0 = c0
     let pp1 = mul_complex(cp1, rot_complex(1.0 * t * 2.0 * PI))
     let pn1 = mul_complex(cn1, rot_complex(-1.0 * t * 2.0 * PI))


### PR DESCRIPTION
## Summary

The Fourier example (`examples/graphics/furier_opengl_imgui_example.das`) pre-dated three landed dasImgui consolidations and broke against the current package: PR #33 (default-on `imgui_lint`), PR #38 (headless harness), PR #39 (daslang theme + JetBrains Mono).

Rewrite onto the current surface:

- `require imgui/imgui_harness` — single import for the boost-v2 widget stack, harness lifecycle, and the daslang theme + JetBrains Mono auto-applied via `live_imgui_init`.
- `window(SETUP_WIN, ...) { ... }` container instead of raw `Begin`/`End`.
- `edit_checkbox` / `edit_input_float` / `edit_input_float2` against `safe_addr(global)` instead of `unsafe(addr(field))`. Collapsed `C0.x`/`C0.y` to a single `edit_input_float2(safe_addr(c0), ...)` — same for C1/C-1/C2/C-2.
- `text("...")` narrative widget instead of raw `Text()`.
- `separator(SEP_C0/C1/C2)` instead of raw `Separator()`.
- Drop the hand-rolled `def imgui_app(title, blk)` shim and the `FontGlobalScale = 1.0` "my monitor is HUGE" comment — the theme picks a sensible 14px default.

Per-frame loop splits `harness_end_frame` manually so custom OpenGL renders between `glClear` and `ImGui_ImplOpenGL3_RenderDrawData`. `options _allow_glfw_calls = true` opts out of `imgui_harness_lint` for the GLFW/GL calls the example legitimately owns (`live_get_framebuffer_size`, `glViewport`, `glClear`, `draw_fourier()`).

Diff size: -131 / +112 lines (net -19) on a single file.

## Test plan

- [x] `daspkg install` in `examples/graphics/` fetches dasImgui locally
- [x] `daslang.exe -project_root . furier_opengl_imgui_example.das -compile-only` exits 0
- [x] `format_file` reports already-formatted
- [x] Lint pass clean (runs automatically in `-compile-only`)
- [x] Smoke-launch — initializes window, theme, shaders; no crash in first 4s
- [ ] Visual confirmation — daslang amber theme on the controls window, JetBrains Mono labels, sliders edit underlying globals through `imgui_set` telemetry path

🤖 Generated with [Claude Code](https://claude.com/claude-code)