### PR TITLE
linq_fold Phase 2C: take/skip splice + chained-select := clone

### DIFF
--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -25,8 +25,10 @@ See `~/.claude/plans/keen-hopping-balloon.md` for the long-form plan.
 | 2A | Loop planner — `_fold` emits explicit for-loops for `[where_*][select?]` (array lane) and `[where_*][select?] |> count` (counter lane); anything else falls through unfolded. No comprehensions, no dispatch back to `_old_fold`. | ✅ done |
 | 2B Ring 1 | Accumulator lane: `sum`, `min`, `max`, `average`, `long_count` with workhorse `<` / `>` for min/max scalars and `_::less` fallback for tuples/user types. `long_count` shares the count-length shortcut. | ✅ done |
 | 2B Ring 2 | Early-exit lane: `first`, `first_or_default`, `any`, `all`, `contains` via `invoke($block { ... return val })`. Predicate-free `any` gets a `length(src) > 0` shortcut. | ✅ done |
-| 2C | `take(N)` / `skip(N)` in counter/array/accumulator/early-exit lanes; non-workhorse chained selects via `:=`-clone; `_select|_where` (where-after-select; needs `ExprRef2Value` substitution). | ⏳ |
-| 3+ | Buffer-required operators: `distinct`, `sort`, `reverse`, `groupby`, `zip`, `join`. Once we go array, we stay array | ⏳ |
+| 2C Ring 3 | `take(N)` / `skip(N)` in counter/array/accumulator/early-exit lanes. Canonical chain order `[where_*][select*][skip?][take?] |> terminator`. Trailing take/skip (no explicit aggregator) → ARRAY lane with implicit `to_array`. Range-form `take(start..end)` falls through (slice operator, different semantics). Buffer-required ops (`order_by`, `distinct`, `reverse`, `group_by`, `zip`, `join`, `left_join`, `group_join`) recognized by name and emit silent fallback with future-mode markers (BufferTopN / BufferDistinct / BufferReverse / BufferGroupBy / MultiSourceZip / BufferedJoin). | ✅ done |
+| 2C Ring 4 | Non-workhorse chained selects via `:=`-clone. | ⏳ |
+| 2D | Fail-loudly contract — see "Planned" section below | ⏳ |
+| 3+ | Buffer-required emit modes: `distinct`, `sort`/`order_by`, `reverse`, `groupby`, `zip`, `join`. Once we go array, we stay array | ⏳ |
 | 4 | Final coverage pass + docs; full 4-way comparison table refresh; parity-test sweep | ⏳ |
 
 ## Baselines (100K rows, INTERP mode)
@@ -160,6 +162,77 @@ All Ring 2 ops hit single-digit ns/op with **zero allocations**. Early-exit case
 
 `first` / `first_or_default` collapse to sub-ns/op because the where matches near the front of the array; the early-exit returns at the first hit and per-element timing measures the loop overhead per the chunk_size (100K), not per actual iteration. The same is why `any_match` was already at 0 ns/op pre-Phase-2B — `_old_fold` and m3 also bail early on first match.
 
+## Phase 2C Ring 3 — splice-mode take/skip (2026-05-17)
+
+`_fold` now recognizes the chain shape `[where_*][select*][skip?][take?] |> terminator` and emits the per-element work wrapped with bounded-loop counters. Skip and take guards are spliced into the per-match block (after the optional `where` filter, before the lane-specific work and intermediate projection binds). Counters live alongside the lane's accumulator in the outer invoke block.
+
+**Emission shape (counter lane example, `where(p).skip(K).take(N).count()`):**
+
+```
+invoke($($i(src) : ...) {
+    var <skipRem> = K
+    var <takenCount> = 0
+    var <acc> = 0
+    for (<it> in <src>) {
+        if (p(<it>)) {
+            if (<takenCount> == N) break          // take guard
+            if (<skipRem> > 0) { <skipRem>--; continue }   // skip guard
+            <takenCount>++                         // before lane work — keeps reachable
+                                                   // even for early-exit terminators that
+                                                   // `return X` from per-match
+            <acc>++
+        }
+    }
+    return <acc>
+}, <topExpr>)
+```
+
+Same skeleton across all four lanes — the per-match payload (acc++ / push_clone / `acc += val` / `return X`) is the only thing that varies.
+
+**Chain-shape detection.** New planner state machine on `(seenSelect, seenSkip, seenTake)` accepts the canonical order and rejects reversed forms (`where` after select/skip/take, etc.) — those return null and the chain falls through to plain linq. At most one skip and one take per chain in this phase; multiple of either is a fall-through.
+
+**Take/skip as terminator.** When `take(N).to_array()` or `skip(K).take(N).to_array()` is the chain tail, the `to_array` strip (LinqCall `skip = true` in `linqCalls`) makes the last visible call `take` or `skip`. `classify_terminator` now routes those to ARRAY lane, with the trailing take/skip captured into `takeExpr`/`skipExpr` and the lane emitting implicit-to_array.
+
+**Buffer-required marker arms.** `is_buffer_required_op` recognizes `order_by`/`order`/`order_descending`/`order_by_descending`, `distinct`/`distinct_by`, `reverse`, `group_by`/`group_by_lazy`, `zip`, `join`/`left_join`/`group_join`. These all return null (silent fallback) with a `// TODO Phase 2X: <FutureMode>` comment naming the future emit mode. Future PRs replace each return-null with a dedicated emit path without re-walking the chain-recognition logic. AST tests `test_order_by_take_falls_through` and `test_distinct_falls_through` pin this behavior.
+
+**Range-form `take(start..end)` falls through.** The slice-style overload has different semantics (yield elements at indices `[start, end)`); decomposing to `skip(start).take(end-start)` is correct but introduces an arithmetic dependency the planner doesn't model today. Phase 2C handles only the int-form (`takeArg._type.baseType == Type.tInt`); range form drops to plain linq.
+
+**Reserve refinement.** When `take(N)` is present on a length-bearing source, the array-lane reserve hint tightens from `length(src)` to `min(N, length(src))` (inline `?:` — no `math::min` dep at the user's call site). Prevents over-allocating millions of slots when take cap is small.
+
+### Phase 2C Ring 3 deltas (100K rows, INTERP)
+
+| Benchmark | Shape | m3f_old | m3f (Phase 2C) | Delta |
+|---|---|---:|---:|---|
+| take_count | `take(N).to_array` (N=1000) | 0 | 0 | parity (`_old_fold`'s take iterator already bails early at N) |
+| skip_take | `skip(K).take(N).to_array` (K=10, N=1000) | 23 | **0** | bounded-loop exits after K+N iterations (small vs 100K source) |
+| take_sum_aggregate (new) | `select.take(N).sum` | 14 | **0** | accumulator-lane take splice |
+| take_count_filtered (new) | `where.take(N).count` | 11 | **0** | counter-lane take + where splice |
+
+Sub-ns/op on the three improved benchmarks reflects the bounded-loop nature: per-element timing normalizes to `chunk_size = 100000`, but the actual loop runs ≤ K+N times (≤ 1010 here). The win is asymptotic — `_fold` is O(K+N), `_old_fold` is O(K+N) per inner iterator + N×O(1) wrapper push.
+
+`_old_fold`'s `take_count` at 0 ns/op already reflects iterator-fusion at the linq-runtime layer; the Phase 2C delta there is allocation count (`_fold`: 1 alloc for the result array, `_old_fold`: same with extra take-iterator wrapper). The functional Phase 2C win for that shape is structural — the splice path now emits a single fused loop where `_old_fold` chains iterator instances.
+
+## Planned: fail-loudly contract
+
+The current contract: when `_fold` can't splice a chain (out-of-scope terminator, buffer-required op, multiple take/skip, range-form take/skip, etc.), it falls through to plain linq — same as today's master. This is **temporary**. The planned contract (Boris design directive 2026-05-17): `_fold` will emit `macro_error("_fold: cannot splice — <reason>")` for any unsupported shape, mirroring the sqlite_linq `_sql(...)` "splice or error" contract.
+
+When the switch lands, every `m3f` variant currently relying on silent fallback breaks. Approximate accounting from the current benchmark suite (8 affected `m3f` variants), grouped by future emit mode that would resolve each:
+
+| Benchmark | Future mode |
+|---|---|
+| `distinct_count` | BufferDistinct (hash set) |
+| `sort_first` | BufferTopN (order_by + early-exit) |
+| `sort_take` | BufferTopN (order_by + take/skip) |
+| `select_where_order_take` | BufferTopN with predicate prefix |
+| `groupby_count` | BufferGroupBy (hash multi-bucket) |
+| `groupby_sum` | BufferGroupBy + nested fold inside select |
+| `zip_dot_product` | MultiSourceZip (2 cursors advanced lockstep) |
+| `join_count` | BufferedJoin (hash-build + probe) |
+
+The fail-loudly PR will either (a) comment out `m3f` in the affected benchmarks until the corresponding emit mode lands, or (b) deliver one or more emit modes alongside the switch. Decision deferred to that PR.
+
+Tracking issue: the planner's `is_buffer_required_op` recognition + the named-arm `// TODO Phase 2X: <FutureMode>` markers are the in-code TODOs.
+
 ## Operator-coverage checklist (parity tests)
 
 The 24 benchmarks above cover the most common shapes. The end-game target is one benchmark per `_fold`-applicable scenario in the broader `tests/linq/` operator suite. Tracking the long-tail coverage below; PRs that add splice support for new operators should add a benchmark here if not already present.
@@ -167,15 +240,15 @@ The 24 benchmarks above cover the most common shapes. The end-game target is one
 | Source test file | Operator group | Covered by benchmark | Status |
 |---|---|---|---|
 | `test_linq.das` | comprehension basics | count_aggregate, sum_aggregate | ✅ |
-| `test_linq_aggregation.das` | count/sum/min/max/avg/aggregate | count/sum/min/max/average_aggregate, sum_where | ✅ core; `aggregate(seed, fn)` ⏳ |
-| `test_linq_querying.das` | any/all/contains | any_match, all_match | ✅ core; `contains` ⏳ |
+| `test_linq_aggregation.das` | count/sum/min/max/avg/aggregate | count/sum/min/max/average_aggregate, sum_where, long_count_aggregate | ✅ core; `aggregate(seed, fn)` ⏳ |
+| `test_linq_querying.das` | any/all/contains | any_match, all_match, contains_match | ✅ core |
 | `test_linq_transform.das` | select/select_many/zip | to_array_filter, zip_dot_product | ✅ select/zip; `select_many` ⏳ |
 | `test_linq_sorting.das` | order/order_by/reverse | sort_first, sort_take, select_where_order_take | ✅ ascending; `order_descending` + `reverse` ⏳ |
 | `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum | ✅ basic; `having_` ⏳ |
 | `test_linq_join.das` | join/left_join/right_join/full_outer/cross | join_count | ✅ inner; outer joins + cross ⏳ |
-| `test_linq_partition.das` | take/skip/take_while/skip_while/chunk | take_count, skip_take | ✅ take/skip; `_while` + `chunk` ⏳ |
+| `test_linq_partition.das` | take/skip/take_while/skip_while/chunk | take_count, skip_take, take_sum_aggregate, take_count_filtered | ✅ take/skip in splice lanes; `_while` + `chunk` ⏳ |
 | `test_linq_set.das` | distinct/union/except/intersect/unique | distinct_count | ✅ distinct; set ops ⏳ |
-| `test_linq_element.das` | first/last/single/element_at + _or_default | first_match | ✅ first; last/single/element_at ⏳ |
+| `test_linq_element.das` | first/last/single/element_at + _or_default | first_match, first_or_default_match | ✅ first/first_or_default; last/single/element_at ⏳ |
 | `test_linq_concat.das` | concat/prepend/append | — | ⏳ |
 | `test_linq_generation.das` | range/repeat/etc. | — | ⏳ |
 | `test_linq_bugs.das` | regression cases | — | ⏳ as bugs surface |

--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -26,7 +26,7 @@ See `~/.claude/plans/keen-hopping-balloon.md` for the long-form plan.
 | 2B Ring 1 | Accumulator lane: `sum`, `min`, `max`, `average`, `long_count` with workhorse `<` / `>` for min/max scalars and `_::less` fallback for tuples/user types. `long_count` shares the count-length shortcut. | ✅ done |
 | 2B Ring 2 | Early-exit lane: `first`, `first_or_default`, `any`, `all`, `contains` via `invoke($block { ... return val })`. Predicate-free `any` gets a `length(src) > 0` shortcut. | ✅ done |
 | 2C Ring 3 | `take(N)` / `skip(N)` in counter/array/accumulator/early-exit lanes. Canonical chain order `[where_*][select*][skip?][take?] |> terminator`. Trailing take/skip (no explicit aggregator) → ARRAY lane with implicit `to_array`. Range-form `take(start..end)` falls through (slice operator, different semantics). Buffer-required ops (`order_by`, `distinct`, `reverse`, `group_by`, `zip`, `join`, `left_join`, `group_join`) recognized by name and emit silent fallback with future-mode markers (BufferTopN / BufferDistinct / BufferReverse / BufferGroupBy / MultiSourceZip / BufferedJoin). | ✅ done |
-| 2C Ring 4 | Non-workhorse chained selects via `:=`-clone. | ⏳ |
+| 2C Ring 4 | Non-workhorse chained selects via `:=`-clone. | ✅ done |
 | 2D | Fail-loudly contract — see "Planned" section below | ⏳ |
 | 3+ | Buffer-required emit modes: `distinct`, `sort`/`order_by`, `reverse`, `groupby`, `zip`, `join`. Once we go array, we stay array | ⏳ |
 | 4 | Final coverage pass + docs; full 4-way comparison table refresh; parity-test sweep | ⏳ |
@@ -211,6 +211,27 @@ Same skeleton across all four lanes — the per-match payload (acc++ / push_clon
 Sub-ns/op on the three improved benchmarks reflects the bounded-loop nature: per-element timing normalizes to `chunk_size = 100000`, but the actual loop runs ≤ K+N times (≤ 1010 here). The win is asymptotic — `_fold` is O(K+N), `_old_fold` is O(K+N) per inner iterator + N×O(1) wrapper push.
 
 `_old_fold`'s `take_count` at 0 ns/op already reflects iterator-fusion at the linq-runtime layer; the Phase 2C delta there is allocation count (`_fold`: 1 alloc for the result array, `_old_fold`: same with extra take-iterator wrapper). The functional Phase 2C win for that shape is structural — the splice path now emits a single fused loop where `_old_fold` chains iterator instances.
+
+## Phase 2C Ring 4 — chained-select clone via `:=` (2026-05-17)
+
+Pre-Ring-4, the planner rejected any chained `_select|_select|...` chain whose previous projection had a non-workhorse type. Reason given in the source: `<-` (move) corrupts source for lvalue projections like `_._field`. The rejection guard (`prevWorkhorse=false → return null`) was a Phase 2B placeholder.
+
+Resolution in Ring 4 follows from a Boris correctness observation: **`:=` is safe on every type** — byte copy on workhorse, deep-clone on non-workhorse — so a single emission shape (`var $i(bind) := $e(projection)`) covers both cases. The workhorse / non-workhorse branch in chained-bind emission is removed entirely; chained selects of any type now splice through one path.
+
+Concretely: `each(arr)._select(ComplexType(a = [_*2]))._select(_.a[0]).sum()` previously fell through to plain linq (iterator chain + allocation); now splices to a single fused for-loop.
+
+### Workhorse-branch audit
+
+After Ring 4, two workhorse-type branches remain in `linq_fold.das`. Both are intentional:
+
+1. **`fold_select_where` (line ~392), `static_if (typeinfo is_workhorse($e(selectExpr)))`** — used exclusively by `_old_fold`'s frozen baseline path via `g_foldSeq`. Not touched here; changing it would alter the frozen `_old_fold` output and invalidate the `m3f_old` benchmark column.
+2. **`min_max_compare` (line ~746) + caller (line ~933)** — perf-critical. Workhorse types use `<` / `>` directly (single-instruction compare); non-workhorse falls back to `_::less` so user/tuple comparator overloads still apply. Boris's design directive 2026-05-16 explicitly mandates keeping this branch (≈2× per-element on int columns; see PR #2696 numbers).
+
+No further workhorse branches in the splice path.
+
+### Ring 4 deltas
+
+Ring 4 is a correctness gate (chained non-workhorse selects now splice instead of falling through), not a per-benchmark improvement on the existing 100K suite. Coverage tracked via test `test_chained_non_workhorse_select` in `tests/linq/test_linq_fold.das` (3 subtests: int → ComplexType → int → sum / where + ComplexType chain + sum / workhorse → ComplexType → workhorse → max).
 
 ## Planned: fail-loudly contract
 

--- a/benchmarks/sql/take_count_filtered.das
+++ b/benchmarks/sql/take_count_filtered.das
@@ -1,0 +1,56 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let TAKE_N = 1000
+let THRESHOLD = 500
+
+// `_sql` rejects `take(n) |> count()` (LIMIT-before-aggregate collapses to one row regardless
+// in SQLite), so the m1 variant is omitted. m3/m3f_old/m3f filter + bound + count over the
+// array. Exercises counter-lane take splice with an upstream `where` predicate.
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let c = arr |> _where(_.price > THRESHOLD) |> take(TAKE_N) |> count()
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m3f_old(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_old_array_fold/{n}", n) {
+        let c = _old_fold(each(arr)._where(_.price > THRESHOLD).take(TAKE_N).count())
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let c = _fold(each(arr)._where(_.price > THRESHOLD).take(TAKE_N).count())
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def take_count_filtered_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def take_count_filtered_m3f_old(b : B?) {
+    run_m3f_old(b, 100000)
+}
+
+[benchmark]
+def take_count_filtered_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/benchmarks/sql/take_sum_aggregate.das
+++ b/benchmarks/sql/take_sum_aggregate.das
@@ -1,0 +1,56 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let TAKE_N = 1000
+
+// `_sql` rejects `take(n) |> sum()` (LIMIT-before-aggregate has no effect in SQLite — aggregate
+// collapses to one row regardless), so the m1 variant is omitted. m3/m3f_old/m3f bound the
+// projection-sum loop to the first TAKE_N matched elements (no upstream where here, so
+// "matched" == "every source element"). Exercises accumulator-lane take splice in _fold.
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let s = arr |> _select(_.price) |> take(TAKE_N) |> sum()
+        if (s == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m3f_old(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_old_array_fold/{n}", n) {
+        let s = _old_fold(each(arr)._select(_.price).take(TAKE_N).sum())
+        if (s == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let s = _fold(each(arr)._select(_.price).take(TAKE_N).sum())
+        if (s == 0) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def take_sum_aggregate_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def take_sum_aggregate_m3f_old(b : B?) {
+    run_m3f_old(b, 100000)
+}
+
+[benchmark]
+def take_sum_aggregate_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -508,7 +508,10 @@ def private qm_null_guard(at : LineInfo; actual_var : string) : Expression? {
 
 [macro_function]
 def private next_var(var index : int&) : string {
-    let name = "_qm_{index}"
+    // Generated locals for qmatch pattern-match bind sites. Leading `qm_` (no underscore
+    // prefix) sidesteps LINT004 — these vars are USED downstream in the emitted match
+    // arms, so the unused-prefix convention doesn't apply.
+    let name = "qm_{index}"
     index++
     return name
 }
@@ -749,7 +752,7 @@ def private generate_pattern_args_match(var pat_block : ExprBlock?; target_var :
 
                 // Get physical index at runtime (skipping fake args)
                 let phys_var = next_var(index)
-                body |> push <| qmacro_expr(${ var $i(phys_var) = qm_real_arg_index($i(target_var).arguments, $v(i)); })
+                body |> push <| qmacro_expr(${ let $i(phys_var) = qm_real_arg_index($i(target_var).arguments, $v(i)); })
 
                 // Name matching
                 if (!empty(arg_name)) {
@@ -1550,7 +1553,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
                     let child_pattern = arg
                     if (child_pattern != null) {
                         let phys_var = next_var(index)
-                        body |> push <| qmacro_expr(${ var $i(phys_var) = qm_real_call_arg_index($i(cast_var).arguments, $v(i)); }) // nolint:LINT004
+                        body |> push <| qmacro_expr(${ let $i(phys_var) = qm_real_call_arg_index($i(cast_var).arguments, $v(i)); }) // nolint:LINT004
                         let child_var = next_var(index)
                         body |> push <| qmacro_expr(${ var $i(child_var) = clone_expression($i(cast_var).arguments[$i(phys_var)]); }) // nolint:LINT004
                         generate_match(child_pattern, child_var, body, index, at)
@@ -1793,7 +1796,7 @@ def private generate_block_match(var pat_block : ExprBlock?; actual_var : string
             // For simplicity: try block match first. If RTTI fails (not a block),
             // fall back to direct match. We use a runtime helper for this.
             let direct_var = next_var(index)
-            body |> push <| qmacro_expr(${ var $i(direct_var) = qm_rtti($i(actual_var)) != "ExprBlock" && qm_rtti($i(actual_var)) != "ExprMakeBlock"; })
+            body |> push <| qmacro_expr(${ let $i(direct_var) = qm_rtti($i(actual_var)) != "ExprBlock" && qm_rtti($i(actual_var)) != "ExprMakeBlock"; })
             // If it's not a block, match directly
             var direct_body : array<Expression?>
             generate_match(single_pat, actual_var, direct_body, index, at)
@@ -1842,7 +1845,7 @@ def private generate_block_match(var pat_block : ExprBlock?; actual_var : string
 
     // Get the total length of the actual block for bounds checking
     let len_var = next_var(index)
-    body |> push <| qmacro_expr(${ var $i(len_var) = length($i(cast_var).list); })
+    body |> push <| qmacro_expr(${ let $i(len_var) = length($i(cast_var).list); })
 
     // Walk through pattern statements
     // Track pending $b capture: save_var holds start position, b_vname holds user variable name

--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -508,10 +508,10 @@ def private qm_null_guard(at : LineInfo; actual_var : string) : Expression? {
 
 [macro_function]
 def private next_var(var index : int&) : string {
-    // Generated locals for qmatch pattern-match bind sites. Leading `qm_` (no underscore
-    // prefix) sidesteps LINT004 — these vars are USED downstream in the emitted match
-    // arms, so the unused-prefix convention doesn't apply.
-    let name = "qm_{index}"
+    // Generated locals for qmatch pattern-match bind sites. Backtick marks them as
+    // compiler-generated — no collision with user identifiers, and lint.das:152 skips
+    // backtick-bearing names from LINT004's leading-underscore-used check.
+    let name = "qm`{index}"
     index++
     return name
 }

--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -2743,11 +2743,16 @@ def private chunk_impl(var src; tt : auto(TT); size : int) : array<array<TT -con
     //! Splits an array into chunks of a specified size
     panic("chunk size must be greater than 0") if (size <= 0)
     var buffer : array<array<TT -const -&>>
+    static_if (typeinfo is_array(src) || typeinfo is_dim(src)) {
+        buffer |> reserve((length(src) + size - 1) / size)
+    }
     var inscope chunk : array<TT -const -&>
+    chunk |> reserve(size)
     for (it in src) {
         chunk.push_clone(it)
         if (chunk.length() == size) {
             buffer.emplace(chunk)
+            chunk |> reserve(size)
         }
     }
     if (!empty(chunk)) {
@@ -2890,6 +2895,9 @@ def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>) : array
 [unused_argument(tt, uu)]
 def private zip_impl(var a; tt : auto(TT); var b; uu : auto(UU); result_selector : block<(l : TT -&; r : UU -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>)) -const -&> {
     var buffer : array<typedecl(result_selector(type<TT>, type<UU>)) -const -&>
+    static_if ((typeinfo is_array(a) || typeinfo is_dim(a)) && (typeinfo is_array(b) || typeinfo is_dim(b))) {
+        buffer |> reserve(min(length(a), length(b)))
+    }
     for (itA, itB in a, b) {
         buffer.push_clone(result_selector(itA, itB))
     }

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1195,19 +1195,17 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
             // Chained selects: bind the previous projection to a fresh local now so the next
             // lambda's `_` can be renamed straight to that name — avoids the
             // ExprRef2Value-substitution trap that plain `Template.replaceVariable` hits when
-            // splicing a typed expression into another typed expression. Phase 2A only
-            // chains workhorse projections; a non-workhorse intermediate binding would need
-            // a clone (`:=`) since `<-` (move) can corrupt source for lvalue projections
-            // like `_._field`. Deferred to Phase 2B.
+            // splicing a typed expression into another typed expression. `:=` (clone) is
+            // safe on every type — byte copy on workhorse, deep-clone on non-workhorse — so
+            // the same emission shape works regardless of projection type, including lvalue
+            // projections like `_._field` that `<-` (move) would corrupt.
             if (projection != null) {
-                let prevWorkhorse = projection._type != null && projection._type.isWorkhorseType
-                if (!prevWorkhorse) return null   // chained non-workhorse selects — Phase 2B
                 if (has_sideeffects(projection)) {
                     allProjectionsPure = false
                 }
                 let bindName = "`v`{at.line}`{at.column}`{length(intermediateBinds)}"
                 intermediateBinds |> push <| qmacro_expr() {
-                    var $i(bindName) = $e(projection)
+                    var $i(bindName) := $e(projection)
                 }
                 lastBindName = bindName
             }

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -717,8 +717,12 @@ def private wrap_with_skip_take(var stmts : array<Expression?>; var skipExpr : E
     prefixed |> reserve(length(stmts) + 3)
     if (takeExpr != null) {
         var takeLimit = clone_expression(takeExpr)
+        // `>=` (not `==`) so non-positive N short-circuits on the first iteration —
+        // matches reference iterator semantics: linq.das take_impl uses `if (total <= 0) break`,
+        // so `take(-1)` and `take(0)` yield nothing. `==` would silently take all elements
+        // for negative N (takenCount starts at 0 and only ever increments).
         prefixed |> push <| qmacro_expr() {
-            if ($i(takeCountName) == $e(takeLimit)) {
+            if ($i(takeCountName) >= $e(takeLimit)) {
                 break
             }
         }

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -560,10 +560,28 @@ enum private LinqLane {
 [macro_function]
 def private classify_terminator(name : string) : LinqLane {
     if (name == "count") return LinqLane.COUNTER
-    if (name == "where_" || name == "select") return LinqLane.ARRAY
+    // take/skip as the trailing call (after to_array strip) → implicit array materialization,
+    // same lane as bare `[where_*][select*]` chains.
+    if (name == "where_" || name == "select" || name == "take" || name == "skip") return LinqLane.ARRAY
     if (name == "sum" || name == "min" || name == "max" || name == "average" || name == "long_count") return LinqLane.ACCUMULATOR
     if (name == "first" || name == "first_or_default" || name == "any" || name == "all" || name == "contains") return LinqLane.EARLY_EXIT
     return LinqLane.UNKNOWN
+}
+
+[macro_function]
+def private is_buffer_required_op(name : string) : bool {
+    // Operators that splice-mode planner can't handle today; each maps to a future emit mode.
+    // Recognized by name so the planner can `return null` (silent fallthrough) deliberately
+    // instead of falling out the unknown-op default. Future PRs replace each `return null` with
+    // a dedicated emit path (BufferTopN / BufferDistinct / BufferReverse / BufferGroupBy /
+    // MultiSourceZip / BufferedJoin) without re-walking the chain recognition.
+    return (name == "order_by" || name == "order" || name == "order_descending"
+        || name == "order_by_descending"
+        || name == "distinct" || name == "distinct_by"
+        || name == "reverse"
+        || name == "group_by" || name == "group_by_lazy"
+        || name == "zip"
+        || name == "join" || name == "left_join" || name == "group_join")
 }
 
 [macro_function]
@@ -664,6 +682,67 @@ def private wrap_with_condition(var body : Expression?; var cond : Expression?) 
 }
 
 [macro_function]
+def private append_skip_take_prelude(var preludeStmts : array<Expression?>; var skipExpr : Expression?; var takeExpr : Expression?;
+                                     skipName, takeCountName : string) {
+    // Loop-level counters for skip/take. Both live in the outer invoke block, alongside any
+    // lane-specific accumulator decl. `skipRem` decrements per skipped match (initial value
+    // = the user's K). `takenCount` increments per yielded match; loop breaks when it equals
+    // the user's N. Pre-loop init only — emitted by the lane that builds `bodyStmts`.
+    if (skipExpr != null) {
+        var skipInit = clone_expression(skipExpr)
+        preludeStmts |> push <| qmacro_expr() {
+            var $i(skipName) = $e(skipInit)
+        }
+    }
+    if (takeExpr != null) {
+        preludeStmts |> push <| qmacro_expr() {
+            var $i(takeCountName) = 0
+        }
+    }
+}
+
+[macro_function]
+def private wrap_with_skip_take(var stmts : array<Expression?>; var skipExpr : Expression?; var takeExpr : Expression?;
+                                skipName, takeCountName : string) {
+    // Per-match-block wrapping. Order at the head of the block is:
+    //   1. take-limit `break` — fires before any projection runs (matches LINQ: `take(N)`
+    //      truncates upstream, so the (N+1)th match isn't pulled at all)
+    //   2. skip-counter `continue` — drops the first K matched elements
+    //   3. take-counter `++` — placed BEFORE the per-match work so early-exit terminators
+    //      (`return X` for first/first_or_default/any-no-pred) don't make it unreachable.
+    //      LINT001 would flag the trailing-increment placement.
+    //   4. existing per-match work
+    if (skipExpr == null && takeExpr == null) return
+    var prefixed : array<Expression?>
+    prefixed |> reserve(length(stmts) + 3)
+    if (takeExpr != null) {
+        var takeLimit = clone_expression(takeExpr)
+        prefixed |> push <| qmacro_expr() {
+            if ($i(takeCountName) == $e(takeLimit)) {
+                break
+            }
+        }
+    }
+    if (skipExpr != null) {
+        prefixed |> push <| qmacro_expr() {
+            if ($i(skipName) > 0) {
+                $i(skipName) --
+                continue
+            }
+        }
+    }
+    if (takeExpr != null) {
+        prefixed |> push <| qmacro_expr() {
+            $i(takeCountName) ++
+        }
+    }
+    for (s in stmts) {
+        prefixed |> push(s)
+    }
+    swap(stmts, prefixed)
+}
+
+[macro_function]
 def private min_max_compare(workhorse : bool; opName : string; valName, accName : string) : Expression? {
     // Workhorse types use direct `<` / `>` (single-instruction comparison) — this is the
     // perf-critical branch. Non-workhorse falls back to `_::less` so user / tuple comparator
@@ -676,43 +755,72 @@ def private min_max_compare(workhorse : bool; opName : string; valName, accName 
 }
 
 [macro_function]
-def private emit_counter_lane(var top : Expression?; srcName, accName, itName : string; var loopBody : Expression?; at : LineInfo) : Expression? {
-    // Counter lane: `var acc = 0; for (it in src) { $loopBody }; return acc` inside invoke.
+def private emit_counter_lane(var top : Expression?; srcName, accName, itName, skipName, takeCountName : string;
+                              var skipExpr : Expression?; var takeExpr : Expression?;
+                              var loopBody : Expression?; at : LineInfo) : Expression? {
+    // Counter lane: `[skip/take init]; var acc = 0; for (it in src) { $loopBody }; return acc`
+    // inside invoke. Skip/take counters live alongside `acc` at block scope; the body has
+    // the guards/increment baked in by `wrap_with_skip_take` upstream.
     var topExpr = clone_expression(top)
     topExpr.genFlags.alwaysSafe = true
     var srcParamType = invoke_src_param_type(top)
-    var res = qmacro(invoke($($i(srcName) : $t(srcParamType)) {
+    var bodyStmts : array<Expression?>
+    append_skip_take_prelude(bodyStmts, skipExpr, takeExpr, skipName, takeCountName)
+    bodyStmts |> push <| qmacro_expr() {
         var $i(accName) = 0
+    }
+    bodyStmts |> push <| qmacro_expr() {
         for ($i(itName) in $i(srcName)) {
             $e(loopBody)
         }
+    }
+    bodyStmts |> push <| qmacro_expr() {
         return $i(accName)
+    }
+    var res = qmacro(invoke($($i(srcName) : $t(srcParamType)) {
+        $b(bodyStmts)
     }, $e(topExpr)))
     return finalize_invoke(res, at)
 }
 
 [macro_function]
-def private emit_array_lane(var top : Expression?; var expr : Expression?; var loopBody : Expression?; var elementType : TypeDeclPtr; srcName, accName, itName : string; at : LineInfo) : Expression? {
-    // Array lane: `var acc : array<T>; [reserve]; for (it in src) { $loopBody }; return <- acc`
+def private emit_array_lane(var top : Expression?; var expr : Expression?; var loopBody : Expression?; var elementType : TypeDeclPtr;
+                            srcName, accName, itName, skipName, takeCountName : string;
+                            var skipExpr : Expression?; var takeExpr : Expression?;
+                            at : LineInfo) : Expression? {
+    // Array lane: `[skip/take init]; var acc : array<T>; [reserve]; for (it in src) { $loopBody }; return <- acc`
     // wrapped in invoke. Two orthogonal axes select the body shape:
     //   - whole-pipeline iterator-ness (`expr._type.isIterator`) — drives the `to_sequence_move`
     //     return path so an iterator pipeline still ends in an iterator,
     //   - source-length availability — drives the pre-reserve hint (only useful when source is
     //     array-shaped; iter sources can't reserve cheaply).
-    // Single-$b body shares scope: `var acc` decl + optional reserve + for-loop + return all
-    // live in one block.
+    // When `take(N)` is in play the reserve hint tightens to `min(N, length(src))` — at most
+    // N elements ever get pushed, so a length-of-source reserve over-allocates by far.
+    // Single-$b body shares scope: skip/take counters + `var acc` decl + optional reserve +
+    // for-loop + return all live in one block.
     let isIter = expr._type.isIterator
     let sourceHasLength = type_has_length(top._type)
     var topExpr = clone_expression(top)
     topExpr.genFlags.alwaysSafe = true
     var srcParamType = invoke_src_param_type(top)
     var bodyStmts : array<Expression?>
+    append_skip_take_prelude(bodyStmts, skipExpr, takeExpr, skipName, takeCountName)
     bodyStmts |> push <| qmacro_expr() {
         var $i(accName) : array<$t(elementType)>
     }
     if (sourceHasLength && !isIter) {
-        bodyStmts |> push <| qmacro_expr() {
-            $i(accName) |> reserve(length($i(srcName)))
+        if (takeExpr != null) {
+            // Inline `min` so the emission doesn't depend on `require math` at the call site.
+            // Reserve = min(takeN, length(src)): at most takeN elements ever get pushed.
+            var takeReserveA = clone_expression(takeExpr)
+            var takeReserveB = clone_expression(takeExpr)
+            bodyStmts |> push <| qmacro_expr() {
+                $i(accName) |> reserve($e(takeReserveA) < length($i(srcName)) ? $e(takeReserveB) : length($i(srcName)))
+            }
+        } else {
+            bodyStmts |> push <| qmacro_expr() {
+                $i(accName) |> reserve(length($i(srcName)))
+            }
         }
     }
     bodyStmts |> push <| qmacro_expr() {
@@ -743,7 +851,8 @@ def private emit_accumulator_lane(
                                   var whereCond : Expression?;
                                   var intermediateBinds : array<Expression?>;
                                   var elementType : TypeDeclPtr;
-                                  srcName, accName, itName : string;
+                                  srcName, accName, itName, skipName, takeCountName : string;
+                                  var skipExpr : Expression?; var takeExpr : Expression?;
                                   at : LineInfo
                                   ) : Expression? {
     // Ring 1 single-pass accumulator lane: sum / min / max / average / long_count.
@@ -840,13 +949,16 @@ def private emit_accumulator_lane(
         return null
     }
     prepend_binds(perMatchStmts, intermediateBinds)
+    wrap_with_skip_take(perMatchStmts, skipExpr, takeExpr, skipName, takeCountName)
     var loopBody = wrap_with_condition(stmts_to_expr(perMatchStmts), whereCond)
     // Collect all body statements into one list so they share scope when spliced via $b.
     // Splitting decls / for / return into separate splice tags would put each in its own
     // sub-block, hiding the accumulator from later statements (caught by AST dump under
-    // `options log_infer_passes`).
+    // `options log_infer_passes`). skip/take counter init goes first so the guards inside
+    // the perMatch block can name-resolve them.
     var bodyStmts : array<Expression?>
-    bodyStmts |> reserve(length(preludeStmts) + 2)
+    bodyStmts |> reserve(length(preludeStmts) + 4)
+    append_skip_take_prelude(bodyStmts, skipExpr, takeExpr, skipName, takeCountName)
     for (s in preludeStmts) {
         bodyStmts |> push(s)
     }
@@ -890,7 +1002,8 @@ def private emit_early_exit_lane(
                                  var intermediateBinds : array<Expression?>;
                                  var elementType : TypeDeclPtr;
                                  terminatorCall : ExprCall?;
-                                 srcName, itName : string;
+                                 srcName, itName, skipName, takeCountName : string;
+                                 var skipExpr : Expression?; var takeExpr : Expression?;
                                  at : LineInfo
                                  ) : Expression? {
     // Ring 2 early-exit lane: first / first_or_default / any / all / contains.
@@ -995,10 +1108,13 @@ def private emit_early_exit_lane(
         return null
     }
     prepend_binds(perMatchStmts, intermediateBinds)
+    wrap_with_skip_take(perMatchStmts, skipExpr, takeExpr, skipName, takeCountName)
     var loopBody = wrap_with_condition(stmts_to_expr(perMatchStmts), whereCond)
-    // Single-$b body so all stmts (prelude + for + tail) share scope under one wrapping block.
+    // Single-$b body so all stmts (skip/take counters + prelude + for + tail) share scope
+    // under one wrapping block.
     var bodyStmts : array<Expression?>
-    bodyStmts |> reserve(length(preludeStmts) + length(tailStmts) + 1)
+    bodyStmts |> reserve(length(preludeStmts) + length(tailStmts) + 3)
+    append_skip_take_prelude(bodyStmts, skipExpr, takeExpr, skipName, takeCountName)
     for (s in preludeStmts) {
         bodyStmts |> push(s)
     }
@@ -1021,20 +1137,25 @@ def private emit_early_exit_lane(
 
 [macro_function]
 def private plan_loop_or_count(var expr : Expression?) : Expression? {
-    // Phase-2B loop planner. Recognizes chains of shape `[where_*][select*]` plus a terminator,
-    // dispatched by `classify_terminator` into one of four lanes:
-    //   ARRAY        — `[where_*][select*]`                            → array<T> / iterator<T>
-    //   COUNTER      — `[where_*][select*] |> count`                   → int
-    //   ACCUMULATOR  — `[where_*][select*] |> {sum,min,max,average,long_count}` → typed scalar
-    //   EARLY_EXIT   — `[where_*][select*] |> {first,first_or_default,any,all,contains}`
-    // Fuses chained wheres into `&&` and chained selects via let-binding composition; emits one
-    // inline `invoke($block, $src)`. Returns null for shapes outside scope — caller falls through.
+    // Phase-2C loop planner. Recognizes chains of shape `[where_*][select*][skip?][take?]`
+    // plus a terminator, dispatched by `classify_terminator` into one of four lanes:
+    //   ARRAY        — `[where_*][select*][skip?][take?]` (or trailing take/skip → implicit
+    //                  to_array)                                  → array<T> / iterator<T>
+    //   COUNTER      — `[...] |> count`                           → int
+    //   ACCUMULATOR  — `[...] |> {sum,min,max,average,long_count}` → typed scalar
+    //   EARLY_EXIT   — `[...] |> {first,first_or_default,any,all,contains}`
+    // Fuses chained wheres into `&&`, chained selects via let-binding composition, and
+    // skip/take into bounded-loop counters; emits one inline `invoke($block, $src)`. Returns
+    // null for shapes outside scope — caller falls through. Buffer-required ops (`order_by`,
+    // `distinct`, `group_by`, `zip`, `join`, `reverse`) are recognized by name and return null
+    // with a future-mode marker; future PRs replace each with a dedicated emit path.
     var (top, calls) = flatten_linq(expr)
     if (empty(calls)) return null
     top = peel_each(top)
     let lastName = calls.back()._1.name
     let lane = classify_terminator(lastName)
-    // Phase 2B emits all four lanes; UNKNOWN terminators fall through unfolded.
+    // Marker: future PRs add BufferTopN / BufferDistinct / etc. for `is_buffer_required_op`
+    // names. Today: silent fallback.
     if (lane == LinqLane.UNKNOWN) return null
     let counterLane = lane == LinqLane.COUNTER
     let hasTerminator = lane != LinqLane.ARRAY
@@ -1043,10 +1164,16 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
     let srcName = "`source`{at.line}`{at.column}"
     let itName  = "`it`{at.line}`{at.column}"
     let accName = "`acc`{at.line}`{at.column}"
+    let skipName = "`skip`{at.line}`{at.column}"
+    let takeCountName = "`tc`{at.line}`{at.column}"
     var whereCond : Expression?
     var projection : Expression?
     var intermediateBinds : array<Expression?>
+    var skipExpr : Expression?
+    var takeExpr : Expression?
     var seenSelect = false
+    var seenSkip = false
+    var seenTake = false
     var allProjectionsPure = true
     var elementType = clone_type(top._type.firstType)
     var lastBindName = itName
@@ -1054,7 +1181,9 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
         var cll & = unsafe(calls[i])
         let opName = cll._1.name
         if (opName == "where_") {
-            if (seenSelect) return null    // where-after-select not in Phase 2A
+            // where-after-select / -after-skip / -after-take is rejected — canonical chain
+            // order is [where_*][select*][skip?][take?].
+            if (seenSelect || seenSkip || seenTake) return null
             var predicate = fold_linq_cond(cll._0.arguments[1], itName)
             if (whereCond == null) {
                 whereCond = predicate
@@ -1062,6 +1191,7 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
                 whereCond = qmacro($e(whereCond) && $e(predicate))
             }
         } elif (opName == "select") {
+            if (seenSkip || seenTake) return null
             // Chained selects: bind the previous projection to a fresh local now so the next
             // lambda's `_` can be renamed straight to that name — avoids the
             // ExprRef2Value-substitution trap that plain `Template.replaceVariable` hits when
@@ -1084,6 +1214,28 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
             projection = fold_linq_cond(cll._0.arguments[1], lastBindName)
             elementType = clone_type(cll._0._type.firstType)
             seenSelect = true
+        } elif (opName == "skip") {
+            // Canonical chain: at most one skip, before any take. Multiple skips / skip-after-
+            // take falls through (no semantic difficulty, just scope deferral). Range-form
+            // `skip(start..end)` is a slice (different operator semantics) — fall through.
+            if (seenSkip || seenTake) return null
+            var skipArg = cll._0.arguments[1]
+            if (skipArg == null || skipArg._type == null || skipArg._type.baseType != Type.tInt) return null
+            skipExpr = clone_expression(skipArg)
+            seenSkip = true
+        } elif (opName == "take") {
+            if (seenTake) return null
+            var takeArg = cll._0.arguments[1]
+            if (takeArg == null || takeArg._type == null || takeArg._type.baseType != Type.tInt) return null
+            takeExpr = clone_expression(takeArg)
+            seenTake = true
+        } elif (is_buffer_required_op(opName)) {     // nolint:LINT009
+            // TODO Phase 2X: BufferTopN (order_by + take/skip), BufferDistinct (distinct/_by),
+            // BufferReverse (reverse), BufferGroupBy (group_by/_lazy), MultiSourceZip (zip),
+            // BufferedJoin (join/left_join/group_join). Recognized but not yet emitted —
+            // future PRs replace each return-null with a dedicated emit path; for now the
+            // marker arm fall-throughs identically to the unrecognized-op default.
+            return null
         } else {
             return null
         }
@@ -1091,12 +1243,14 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
     if (projection != null && has_sideeffects(projection)) {
         allProjectionsPure = false
     }
+    let noLimits = skipExpr == null && takeExpr == null
     // Count-shaped shortcut: when terminator is `count` (→ int) or `long_count` (→ int64),
-    // there's no filter, and every projection is pure, the result is just the source length.
-    // Skip the loop entirely.
+    // there's no filter, no skip/take limits, and every projection is pure, the result is
+    // just the source length. Skip the loop entirely. take/skip would truncate the length so
+    // the shortcut can't fire there.
     let isCountShaped = (lane == LinqLane.COUNTER
         || (lane == LinqLane.ACCUMULATOR && lastName == "long_count"))
-    if (isCountShaped && whereCond == null && allProjectionsPure
+    if (isCountShaped && whereCond == null && allProjectionsPure && noLimits
             && type_has_length(top._type))
         return emit_length_shortcut(lastName, top, srcName, at)
     // Ring 1: accumulator lane builds its own per-op loop body (typed accumulator, optional
@@ -1104,21 +1258,24 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
     // COUNTER/ARRAY loopBody construction.
     if (lane == LinqLane.ACCUMULATOR)
         return emit_accumulator_lane(lastName, top, projection, whereCond,
-            intermediateBinds, elementType, srcName, accName, itName, at)
-    // Ring 2: early-exit lane — `any` no-pred + no upstream work + length-bearing source
-    // gets the empty-shortcut; everything else dispatches to the loop emitter.
+            intermediateBinds, elementType, srcName, accName, itName, skipName, takeCountName,
+            skipExpr, takeExpr, at)
+    // Ring 2: early-exit lane — `any` no-pred + no upstream work + no limits + length-bearing
+    // source gets the empty-shortcut; everything else dispatches to the loop emitter.
     if (lane == LinqLane.EARLY_EXIT) {
         let terminatorCall = calls.back()._0
         let isAnyNoPred = lastName == "any" && length(terminatorCall.arguments) == 1
-        if (isAnyNoPred && whereCond == null && allProjectionsPure
+        if (isAnyNoPred && whereCond == null && allProjectionsPure && noLimits
                 && type_has_length(top._type))
             return emit_any_empty_shortcut(top, srcName, at)
         return emit_early_exit_lane(lastName, top, projection, whereCond,
-            intermediateBinds, elementType, terminatorCall, srcName, itName, at)
+            intermediateBinds, elementType, terminatorCall, srcName, itName, skipName,
+            takeCountName, skipExpr, takeExpr, at)
     }
     // Build the per-element loop body for COUNTER / ARRAY. Both lanes follow the same shape:
     // collect per-element stmts (incl. side-effect-preserving projection binds), prepend
-    // chain `intermediateBinds`, collapse to a single expression, wrap with `whereCond`.
+    // chain `intermediateBinds`, wrap with skip/take guards, collapse to a single expression,
+    // wrap with `whereCond`.
     var loopBody : Expression?
     if (counterLane) {
         // Counter lane must evaluate the projection (and any chained intermediates) per
@@ -1138,6 +1295,7 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
             $i(accName) ++
         }
         prepend_binds(stmts, intermediateBinds)
+        wrap_with_skip_take(stmts, skipExpr, takeExpr, skipName, takeCountName)
         loopBody = wrap_with_condition(stmts_to_expr(stmts), whereCond)
     } else {
         // Array lane. `push_clone` is the safe append everywhere: for workhorse types it's a
@@ -1151,8 +1309,10 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
             stmts |> push <| qmacro_expr() {
                 $i(accName) |> push_clone($e(projection))
             }
-        } elif (whereCond != null) {
-            // Identity case (no projection): `it` aliases the source element.
+        } elif (whereCond != null || skipExpr != null || takeExpr != null) {
+            // Identity push: `it` aliases the source element. Reached when chain is bare
+            // [where_*][skip?][take?] (no select) — every match (post-filter, post-skip,
+            // pre-take) goes into the result array as-is.
             stmts |> push <| qmacro_expr() {
                 $i(accName) |> push_clone($i(itName))
             }
@@ -1161,12 +1321,15 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
             return null
         }
         prepend_binds(stmts, intermediateBinds)
+        wrap_with_skip_take(stmts, skipExpr, takeExpr, skipName, takeCountName)
         loopBody = wrap_with_condition(stmts_to_expr(stmts), whereCond)
     }
     if (counterLane) {
-        return emit_counter_lane(top, srcName, accName, itName, loopBody, at)
+        return emit_counter_lane(top, srcName, accName, itName, skipName, takeCountName,
+            skipExpr, takeExpr, loopBody, at)
     } else {
-        return emit_array_lane(top, expr, loopBody, elementType, srcName, accName, itName, at)
+        return emit_array_lane(top, expr, loopBody, elementType, srcName, accName, itName,
+            skipName, takeCountName, skipExpr, takeExpr, at)
     }
 }
 

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -188,7 +188,7 @@ def test_generic_fold_order(t : T?) {
             ._fold()
         )
         t |> equal(typeinfo typename(t7), "iterator<string>")
-        var sorted = ["kiwi", "apple", "banana", "cherry", "blueberry"]
+        var sorted = ["kiwi", "apple", "banana", "cherry", "blueberry"]    // nolint:LINT003
         for (i, v in 0..5, t7) {
             t |> equal(sorted[i], v)
         }
@@ -199,7 +199,7 @@ def test_generic_fold_order(t : T?) {
             ._fold()
         )
         t |> equal(typeinfo typename(t8), "array<string>")
-        var sorted = ["blueberry", "banana", "cherry", "apple", "kiwi"]
+        var sorted = ["blueberry", "banana", "cherry", "apple", "kiwi"]    // nolint:LINT003
         for (i, v in 0..5, t8) {
             t |> equal(sorted[i], v)
         }
@@ -209,7 +209,7 @@ def test_generic_fold_order(t : T?) {
 [test]
 def test_generic_fold_aggregates(t : T?) {
     t |> run("min fold") @(t : T?) {
-        var t1 = ([5, 3, 8, 1, 4]
+        var t1 = ([5, 3, 8, 1, 4]    // nolint:LINT003 — `var` required for the `typename(t1) == "int"` assertion below (let adds const)
             .to_sequence()
             .min()
             ._fold()
@@ -218,7 +218,7 @@ def test_generic_fold_aggregates(t : T?) {
         t |> equal(1, t1)
     }
     t |> run("min_by fold") @(t : T?) {
-        var t2 = (["apple", "banana", "kiwi", "cherry", "blueberry"]
+        var t2 = (["apple", "banana", "kiwi", "cherry", "blueberry"]    // nolint:LINT003
             .to_sequence()
             ._min_by(length(_))
             ._fold()
@@ -227,7 +227,7 @@ def test_generic_fold_aggregates(t : T?) {
         t |> equal("kiwi", t2)
     }
     t |> run("max fold") @(t : T?) {
-        var t2 = ([5, 3, 8, 1, 4]
+        var t2 = ([5, 3, 8, 1, 4]    // nolint:LINT003
             .to_sequence()
             .max()
             ._fold()
@@ -236,7 +236,7 @@ def test_generic_fold_aggregates(t : T?) {
         t |> equal(8, t2)
     }
     t |> run("max_by fold") @(t : T?) {
-        var t2 = (["apple", "banana", "kiwi", "cherry", "blueberry"]
+        var t2 = (["apple", "banana", "kiwi", "cherry", "blueberry"]    // nolint:LINT003
             .to_sequence()
             ._max_by(length(_))
             ._fold()
@@ -267,7 +267,7 @@ def test_generic_fold_aggregates(t : T?) {
         t |> equal("blueberry", tmax)
     }
     t |> run("average fold") @(t : T?) {
-        var t2 = ([1, 2, 3, 4, 5, 6, 7, 8]
+        var t2 = ([1, 2, 3, 4, 5, 6, 7, 8]    // nolint:LINT003
             .to_sequence()
             .average()
             ._fold()
@@ -289,7 +289,7 @@ def test_generic_fold_aggregates(t : T?) {
         t |> equal(4, tavg)
     }
     t |> run("sum fold") @(t : T?) {
-        var t2 = ([1, 2, 3, 4, 5, 6, 7, 8]
+        var t2 = ([1, 2, 3, 4, 5, 6, 7, 8]    // nolint:LINT003
             .to_sequence()
             .sum()
             ._fold()
@@ -298,7 +298,7 @@ def test_generic_fold_aggregates(t : T?) {
         t |> equal(36, t2)
     }
     t |> run("aggregate fold") @(t : T?) {
-        var t2 = ([1, 2, 3, 4, 5, 6, 7, 8]
+        var t2 = ([1, 2, 3, 4, 5, 6, 7, 8]    // nolint:LINT003
             .to_sequence()
             .aggregate("", $(a, b) => "{a},{b}")
             ._fold()
@@ -311,7 +311,7 @@ def test_generic_fold_aggregates(t : T?) {
 [test]
 def test_generic_fold_skip_and_take(t : T?) {
     t |> run("skip fold") @(t : T?) {
-        var t1 = ([5, 3, 8, 1, 4]
+        var t1 = ([5, 3, 8, 1, 4]    // nolint:LINT003
             .to_sequence()
             .skip(2)
             .min()
@@ -321,7 +321,7 @@ def test_generic_fold_skip_and_take(t : T?) {
         t |> equal(1, t1)
     }
     t |> run("skip_while fold") @(t : T?) {
-        var t2 = ([5, 3, 8, 1, 4]
+        var t2 = ([5, 3, 8, 1, 4]    // nolint:LINT003
             .to_sequence()
             ._skip_while(_ > 3)
             .min()
@@ -331,7 +331,7 @@ def test_generic_fold_skip_and_take(t : T?) {
         t |> equal(1, t2)
     }
     t |> run("take fold") @(t : T?) {
-        var t3 = ([5, 3, 8, 1, 4]
+        var t3 = ([5, 3, 8, 1, 4]    // nolint:LINT003
             .to_sequence()
             .take(3)
             .max()
@@ -341,7 +341,7 @@ def test_generic_fold_skip_and_take(t : T?) {
         t |> equal(8, t3)
     }
     t |> run("take_while fold") @(t : T?) {
-        var t4 = ([5, 3, 8, 1, 4]
+        var t4 = ([5, 3, 8, 1, 4]    // nolint:LINT003
             .to_sequence()
             ._take_while(_ < 8)
             .max()
@@ -351,7 +351,7 @@ def test_generic_fold_skip_and_take(t : T?) {
         t |> equal(5, t4)
     }
     t |> run("take range fold") @(t : T?) {
-        var t5 = ([5, 3, 8, 1, 4]
+        var t5 = ([5, 3, 8, 1, 4]    // nolint:LINT003
             .to_sequence()
             .take(1..4)
             .max()
@@ -381,7 +381,7 @@ def test_concat(t : T?) {
         )
         t |> equal(typeinfo typename(q), "array<int>")
         t |> equal(length(q), 6)
-        var expected = [6, 4, 2, 30, 27, 24]
+        var expected = [6, 4, 2, 30, 27, 24]    // nolint:LINT003
         for (i, v in 0..6, q) {
             t |> equal(expected[i], v)
         }
@@ -400,7 +400,7 @@ def test_concat(t : T?) {
         )
         t |> equal(typeinfo typename(q), "array<int>")
         t |> equal(length(q), 4)
-        var expected = [6, 4, 2, 100]
+        var expected = [6, 4, 2, 100]    // nolint:LINT003
         for (i, v in 0..4, q) {
             t |> equal(expected[i], v)
         }
@@ -419,7 +419,7 @@ def test_concat(t : T?) {
         )
         t |> equal(typeinfo typename(q), "array<int>")
         t |> equal(length(q), 4)
-        var expected = [100, 6, 4, 2]
+        var expected = [100, 6, 4, 2]    // nolint:LINT003
         for (i, v in 0..4, q) {
             t |> equal(expected[i], v)
         }
@@ -429,7 +429,7 @@ def test_concat(t : T?) {
 [test]
 def test_any_all_contains(t : T?) {
     t |> run("fold any") @(t : T?) {
-        var query = (
+        var query = (    // nolint:LINT003
             [for (x in 0..5); x]
             ._any(_ > 3)
             ._fold()
@@ -437,7 +437,7 @@ def test_any_all_contains(t : T?) {
         t |> success(query)
     }
     t |> run("fold any false") @(t : T?) {
-        var qpred2 = (
+        var qpred2 = (    // nolint:LINT003
             [iterator for(x in 0..5); x]
             ._any(_ > 10)
             ._fold()
@@ -445,7 +445,7 @@ def test_any_all_contains(t : T?) {
         t |> success(!qpred2)
     }
     t |> run("fold all") @(t : T?) {
-        var query = (
+        var query = (    // nolint:LINT003
             [iterator for(x in 0..5); x]
             ._all(_ < 5)
             ._fold()
@@ -453,7 +453,7 @@ def test_any_all_contains(t : T?) {
         t |> success(query)
     }
     t |> run("fold all empty") @(t : T?) {
-        var qempty = (
+        var qempty = (    // nolint:LINT003
             empty(type<int>)
             ._all(_ < 5)
             ._fold()
@@ -461,7 +461,7 @@ def test_any_all_contains(t : T?) {
         t |> success(qempty)
     }
     t |> run("fold contains") @(t : T?) {
-        var query = (
+        var query = (    // nolint:LINT003
             [iterator for(x in 0..5); x]
             .contains(3)
             ._fold()
@@ -469,7 +469,7 @@ def test_any_all_contains(t : T?) {
         t |> success(query)
     }
     t |> run("fold complex contains") @(t : T?) {
-        var qcomplex = (
+        var qcomplex = (    // nolint:LINT003
             [iterator for(x in 0..5); ComplexType(a = [x, x * 10])]
             .contains(ComplexType(a = [3, 30]))
             ._fold()
@@ -477,7 +477,7 @@ def test_any_all_contains(t : T?) {
         t |> success(qcomplex)
     }
     t |> run("fold complex contains false") @(t : T?) {
-        var qcomplex = (
+        var qcomplex = (    // nolint:LINT003
             [iterator for(x in 0..5); ComplexType(a = [x, x * 10])]
             .contains(ComplexType(a = [3, 31]))
             ._fold()
@@ -534,7 +534,7 @@ def test_unique(t : T?) {
             ._order_by(_) // sort
             ._fold()
         )
-        var expected = [0, 1, 2, 3, 9, 16, 25, 36, 49]
+        var expected = [0, 1, 2, 3, 9, 16, 25, 36, 49]    // nolint:LINT003
         t |> equal(length(t1), length(expected))
         for (i, v in 0..length(expected), t1) {
             t |> equal(expected[i], v)
@@ -552,7 +552,7 @@ def test_unique(t : T?) {
             ._order_by(_) // sort
             ._fold()
         )
-        var expected = [0, 1, 2, 3]
+        var expected = [0, 1, 2, 3]    // nolint:LINT003
         t |> equal(length(t1), length(expected))
         for (i, v in 0..length(expected), t1) {
             t |> equal(expected[i], v)
@@ -574,7 +574,7 @@ def test_except(t : T?) {
             .distinct()
             ._fold()
         )
-        var expected = [0, 1, 2, 3]
+        var expected = [0, 1, 2, 3]    // nolint:LINT003
         t |> equal(length(t1), length(expected))
         for (i, v in 0..length(expected), t1) {
             t |> equal(expected[i], v)
@@ -593,7 +593,7 @@ def test_except(t : T?) {
             .distinct()
             ._fold()
         )
-        var expected = [2, 3]
+        var expected = [2, 3]    // nolint:LINT003
         t |> equal(length(t1), length(expected))
         for (i, v in 0..length(expected), t1) {
             t |> equal(expected[i], v)
@@ -614,7 +614,7 @@ def test_intersect(t : T?) {
             ._order_by(_) // sort
             ._fold()
         )
-        var expected = [3, 4, 5]
+        var expected = [3, 4, 5]    // nolint:LINT003
         t |> equal(length(t1), length(expected))
         for (i, v in 0..length(expected), t1) {
             t |> equal(expected[i], v)
@@ -632,7 +632,7 @@ def test_intersect(t : T?) {
             ._order_by(_) // sort
             ._fold()
         )
-        var expected = [3, 4, 5, 6]
+        var expected = [3, 4, 5, 6]    // nolint:LINT003
         t |> equal(length(t1), length(expected))
         for (i, v in 0..length(expected), t1) {
             t |> equal(expected[i], v)
@@ -700,7 +700,7 @@ def test_zip(t : T?) {
 [test]
 def test_order_distinct(t : T?) {
     t |> run("basic order distinct") @(t : T?) {
-        var t7 = (
+        var t7 = (    // nolint:LINT003
             [5, 4, 4, 3, 4, 2, 1, 1, 4, 3]
             ._select(_ * 10)
             .order()
@@ -712,7 +712,7 @@ def test_order_distinct(t : T?) {
         t |> equal(10, t7)
     }
     t |> run("first position order distinct") @(t : T?) {
-        var t7 = (
+        var t7 = (    // nolint:LINT003
             [5, 4, 4, 3, 4, 2, 1, 1, 4, 3]
             .order()
             .distinct()
@@ -1071,5 +1071,177 @@ def test_contains_early_exit(t : T?) {
         // Projected values: [10, 20, 30]. contains(20) → true.
         let r = _fold(each(arr)._select(_ * 10).contains(20))
         t |> equal(true, r)
+    }
+}
+
+[test]
+def test_take_skip_counter_lane(t : T?) {
+    t |> run("counter: where.take.count") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        // Even values: 2,4,6,8,10 — take 3 → 3.
+        let r = _fold(each(arr)._where(_ % 2 == 0).take(3).count())
+        t |> equal(3, r)
+    }
+    t |> run("counter: where.skip.count") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        // Even values: 2,4,6,8,10. skip 2 → 6,8,10 → 3.
+        let r = _fold(each(arr)._where(_ % 2 == 0).skip(2).count())
+        t |> equal(3, r)
+    }
+    t |> run("counter: where.skip.take.count") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        // Even values: 2,4,6,8,10. skip 1 take 3 → 4,6,8 → 3.
+        let r = _fold(each(arr)._where(_ % 2 == 0).skip(1).take(3).count())
+        t |> equal(3, r)
+    }
+    t |> run("counter: take(0).count → 0") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5]
+        let r = _fold(each(arr).take(0).count())
+        t |> equal(0, r)
+    }
+    t |> run("counter: take(huge).count → all source") @(t : T?) {
+        let arr <- [1, 2, 3]
+        let r = _fold(each(arr).take(1000).count())
+        t |> equal(3, r)
+    }
+    t |> run("counter: skip(huge).count → 0") @(t : T?) {
+        let arr <- [1, 2, 3]
+        let r = _fold(each(arr).skip(1000).count())
+        t |> equal(0, r)
+    }
+}
+
+[test]
+def test_take_skip_accumulator_lane(t : T?) {
+    t |> run("accumulator: select.take.sum") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5]
+        // Projected: 10,20,30,40,50. take 3 → 10+20+30 = 60.
+        let r = _fold(each(arr)._select(_ * 10).take(3).sum())
+        t |> equal(60, r)
+    }
+    t |> run("accumulator: select.skip.take.average") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5, 6, 7, 8]
+        // Projected (* 10): 10,20,30,40,50,60,70,80. skip 2 take 4 → 30+40+50+60=180 / 4 = 45.
+        let r = _fold(each(arr)._select(_ * 10).skip(2).take(4).average())
+        t |> equal(45.0lf, r)
+    }
+    t |> run("accumulator: take.min") @(t : T?) {
+        let arr <- [5, 3, 8, 1, 4]
+        // take 3 → 5,3,8 → min=3.
+        let r = _fold(each(arr).take(3).min())
+        t |> equal(3, r)
+    }
+    t |> run("accumulator: where.take.long_count → int64") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        // odd values: 1,3,5,7,9. take 3 → 3.
+        let r = _fold(each(arr)._where(_ % 2 == 1).take(3).long_count())
+        t |> equal(3l, r)
+    }
+    t |> run("accumulator: take(0).sum → 0") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5]
+        let r = _fold(each(arr).take(0).sum())
+        t |> equal(0, r)
+    }
+}
+
+[test]
+def test_take_skip_early_exit_lane(t : T?) {
+    t |> run("early-exit: take.first") @(t : T?) {
+        let arr <- [5, 3, 8, 1, 4]
+        // take 3 → 5,3,8. first → 5.
+        let r = _fold(each(arr).take(3).first())
+        t |> equal(5, r)
+    }
+    t |> run("early-exit: where.take.any → true") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5]
+        // even values: 2,4. take 5 → 2,4. any → true.
+        let r = _fold(each(arr)._where(_ % 2 == 0).take(5).any())
+        t |> equal(true, r)
+    }
+    t |> run("early-exit: where.skip.take.first → 6") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        // even: 2,4,6,8,10. skip 2 take 3 → 6,8,10. first → 6.
+        let r = _fold(each(arr)._where(_ % 2 == 0).skip(2).take(3).first())
+        t |> equal(6, r)
+    }
+    t |> run("early-exit: take.all(odd) → false (even hits within take limit)") @(t : T?) {
+        let arr <- [1, 3, 5, 2, 7]
+        // take 5 → all five. all(odd) → false (2 fails).
+        let r = _fold(each(arr).take(5).all($(x : int) => x % 2 == 1))
+        t |> equal(false, r)
+    }
+    t |> run("early-exit: take(3).all(odd) → true (even excluded by take)") @(t : T?) {
+        let arr <- [1, 3, 5, 2, 7]
+        // take 3 → 1,3,5. all(odd) → true.
+        let r = _fold(each(arr).take(3).all($(x : int) => x % 2 == 1))
+        t |> equal(true, r)
+    }
+    t |> run("early-exit: take(0).any → false (empty)") @(t : T?) {
+        let arr <- [1, 2, 3]
+        let r = _fold(each(arr).take(0).any())
+        t |> equal(false, r)
+    }
+    t |> run("early-exit: take(0).all(p) → true (vacuous)") @(t : T?) {
+        let arr <- [1, 2, 3]
+        let r = _fold(each(arr).take(0).all($(x : int) => x > 100))
+        t |> equal(true, r)
+    }
+    t |> run("early-exit: take.first_or_default") @(t : T?) {
+        let arr : array<int>
+        let r = _fold(each(arr).take(5).first_or_default(-1))
+        t |> equal(-1, r)
+    }
+    t |> run("early-exit: take.contains") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5]
+        // take 3 → 1,2,3. contains(4) → false (excluded by take).
+        let r = _fold(each(arr).take(3).contains(4))
+        t |> equal(false, r)
+    }
+}
+
+[test]
+def test_take_skip_array_lane(t : T?) {
+    t |> run("array: take.to_array") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5]
+        let r <- _fold(each(arr).take(3).to_array())
+        t |> equal(3, length(r))
+        t |> equal(1, r[0])
+        t |> equal(2, r[1])
+        t |> equal(3, r[2])
+    }
+    t |> run("array: skip.take.to_array") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5, 6, 7]
+        let r <- _fold(each(arr).skip(2).take(3).to_array())
+        t |> equal(3, length(r))
+        t |> equal(3, r[0])
+        t |> equal(4, r[1])
+        t |> equal(5, r[2])
+    }
+    t |> run("array: where.skip.take.to_array") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        // even: 2,4,6,8,10. skip 1 take 3 → 4,6,8.
+        let r <- _fold(each(arr)._where(_ % 2 == 0).skip(1).take(3).to_array())
+        t |> equal(3, length(r))
+        t |> equal(4, r[0])
+        t |> equal(6, r[1])
+        t |> equal(8, r[2])
+    }
+    t |> run("array: where.select.take.to_array") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5, 6, 7]
+        // _ > 2 → 3,4,5,6,7. * 2 → 6,8,10,12,14. take 2 → 6,8.
+        let r <- _fold(each(arr)._where(_ > 2)._select(_ * 2).take(2).to_array())
+        t |> equal(2, length(r))
+        t |> equal(6, r[0])
+        t |> equal(8, r[1])
+    }
+    t |> run("array: take(0).to_array → empty") @(t : T?) {
+        let arr <- [1, 2, 3]
+        let r <- _fold(each(arr).take(0).to_array())
+        t |> equal(0, length(r))
+    }
+    t |> run("array: skip(huge).to_array → empty") @(t : T?) {
+        let arr <- [1, 2, 3]
+        let r <- _fold(each(arr).skip(100).to_array())
+        t |> equal(0, length(r))
     }
 }

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -1244,6 +1244,32 @@ def test_take_skip_array_lane(t : T?) {
         let r <- _fold(each(arr).skip(100).to_array())
         t |> equal(0, length(r))
     }
+    // Pin non-positive N/K behavior — reference iterator semantics treat negative as
+    // "take/skip nothing" (linq.das take_impl: `if (total <= 0) break`; skip_impl:
+    // `if (total > 0) decrement-and-skip` so non-positive falls through).
+    t |> run("array: take(-1).to_array → empty (matches take_impl)") @(t : T?) {
+        let arr <- [1, 2, 3]
+        let r <- _fold(each(arr).take(-1).to_array())
+        t |> equal(0, length(r))
+    }
+    t |> run("array: take(0).to_array → empty (pins zero-N)") @(t : T?) {
+        let arr <- [1, 2, 3]
+        let r <- _fold(each(arr).take(0).to_array())
+        t |> equal(0, length(r))
+    }
+    t |> run("array: skip(-1).to_array → full (non-positive skip is a no-op)") @(t : T?) {
+        let arr <- [1, 2, 3]
+        let r <- _fold(each(arr).skip(-1).to_array())
+        t |> equal(3, length(r))
+        t |> equal(1, r[0])
+        t |> equal(2, r[1])
+        t |> equal(3, r[2])
+    }
+    t |> run("array: skip(0).to_array → full (zero-K is a no-op)") @(t : T?) {
+        let arr <- [1, 2, 3]
+        let r <- _fold(each(arr).skip(0).to_array())
+        t |> equal(3, length(r))
+    }
 }
 
 [test]

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -1245,3 +1245,40 @@ def test_take_skip_array_lane(t : T?) {
         t |> equal(0, length(r))
     }
 }
+
+[test]
+def test_chained_non_workhorse_select(t : T?) {
+    // Pre-Commit-2: planner rejected any chained _select whose previous projection was
+    // non-workhorse (prevWorkhorse=false → return null), falling back to the iterator path.
+    // Commit 2: chained-bind emission switched to `:=` (clone) — safe for every type — so
+    // ComplexType intermediates now splice.
+    t |> run("int → ComplexType → int → sum") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5]
+        let r = _fold(each(arr)
+            ._select(ComplexType(a = [_ * 2]))    // int → ComplexType (non-workhorse)
+            ._select(_.a[0])                       // ComplexType → int (reads field)
+            .sum())
+        // sum(2 + 4 + 6 + 8 + 10) = 30
+        t |> equal(30, r)
+    }
+    t |> run("where then ComplexType intermediate then sum") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5]
+        let r = _fold(each(arr)
+            ._where(_ >= 2)                        // predicate before selects
+            ._select(ComplexType(a = [_ * 2, _ * 3]))
+            ._select(_.a[0] + _.a[1])              // ComplexType → int (reads two fields)
+            .sum())
+        // filtered [2,3,4,5] → [(4+6),(6+9),(8+12),(10+15)] = [10,15,20,25] → sum = 70
+        t |> equal(70, r)
+    }
+    t |> run("workhorse → ComplexType → workhorse → max") @(t : T?) {
+        let arr <- [1, 2, 3, 4, 5]
+        let r = _fold(each(arr)
+            ._select(_ * 2)                        // int → int (workhorse)
+            ._select(ComplexType(a = [_, _ + 1]))  // int → ComplexType (non-workhorse)
+            ._select(_.a[1])                       // ComplexType → int
+            .max())
+        // _ * 2 → [2,4,6,8,10]; .a[1] → [3,5,7,9,11]; max = 11
+        t |> equal(11, r)
+    }
+}

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -110,7 +110,7 @@ def test_where_old_fold_produces_comprehension(t : T?) {
         // fold_where output: invoke($(var source) .. var pass_0 <- COMP; return <- pass_0 .., src)
         var comp_expr : ExpressionPtr
         var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
+        let r = qmatch_function(func) $() { // nolint:STYLE016
             return <- invoke($(var source : array<int>) {
                 var pass_0 : array<int> <- $e(comp_expr)
                 return <- pass_0
@@ -135,7 +135,7 @@ def test_where_old_fold_comprehension_pattern(t : T?) {
         // Match the full structure including comprehension pattern
         var where_cond : ExpressionPtr
         var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
+        let r = qmatch_function(func) $() { // nolint:STYLE016
             return <- invoke($(var source : array<int>) {
                 var pass_0 : array<int> <- [for (it in source); it; where $e(where_cond)]
                 return <- pass_0
@@ -153,7 +153,7 @@ def test_select_old_fold_produces_comprehension(t : T?) {
         if (func == null) return
         var comp_expr : ExpressionPtr
         var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
+        let r = qmatch_function(func) $() { // nolint:STYLE016
             return <- invoke($(var source : array<int>) {
                 var pass_0 : array<int> <- $e(comp_expr)
                 return <- pass_0
@@ -176,7 +176,7 @@ def test_select_old_fold_comprehension_pattern(t : T?) {
         if (func == null) return
         var select_expr : ExpressionPtr
         var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
+        let r = qmatch_function(func) $() { // nolint:STYLE016
             return <- invoke($(var source : array<int>) {
                 var pass_0 : array<int> <- [for (it in source); $e(select_expr)]
                 return <- pass_0
@@ -199,7 +199,7 @@ def test_where_select_old_fold_comprehension(t : T?) {
         var select_expr : ExpressionPtr
         var where_cond : ExpressionPtr
         var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
+        let r = qmatch_function(func) $() { // nolint:STYLE016
             return <- invoke($(var source : array<int>) {
                 var pass_0 : array<int> <- [for (it in source); $e(select_expr); where $e(where_cond)]
                 return <- pass_0
@@ -225,7 +225,7 @@ def test_select_where_old_fold_structure(t : T?) {
         // It is NOT a simple comprehension - verify the fold still happened
         var inner_expr : ExpressionPtr
         var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
+        let r = qmatch_function(func) $() { // nolint:STYLE016
             return <- invoke($(var source : array<int>) {
                 var pass_0 : array<int> <- $e(inner_expr)
                 return <- pass_0
@@ -1345,6 +1345,160 @@ def test_early_exit_falls_through_on_select_where(t : T?) {
         t |> success(r.matched, "should have return expression")
         t |> success(!(body_expr is ExprInvoke),
             "select|where|any should fall through unfolded (no invoke wrapper)")
+    }
+}
+
+// ── Phase 2C take/skip splice ──────────────────────────────────────────
+
+[export, marker(no_coverage)]
+def target_where_take_count_fold() : int {
+    return _fold(each([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])._where(_ % 2 == 0).take(3).count())
+}
+
+[export, marker(no_coverage)]
+def target_skip_take_to_array_fold() : array<int> {
+    return <- _fold(each([1, 2, 3, 4, 5, 6, 7]).skip(2).take(3).to_array())
+}
+
+[export, marker(no_coverage)]
+def target_order_by_take_falls_through() : array<int> {
+    // Buffer-required (order_by) → splice planner returns null → silent fallback to raw linq.
+    return <- _fold([1, 2, 3, 4, 5].to_sequence()._select(_ * 2)._order_by(_).take(2).to_array())
+}
+
+[export, marker(no_coverage)]
+def target_distinct_falls_through() : array<int> {
+    // distinct is buffer-required — splice planner returns null → silent fallback.
+    return <- _fold([1, 2, 2, 3, 3, 3].to_sequence().distinct().to_array())
+}
+
+[export, marker(no_coverage)]
+def target_take_sum_fold() : int {
+    return _fold([1, 2, 3, 4, 5]._select(_ * 10).take(3).sum())
+}
+
+// AST helper — total break/continue count anywhere in the subtree. Used to assert that the
+// take-limit `break` and skip-counter `continue` actually got spliced into the per-element body.
+def count_break_continue(expr : Expression?; want_break : bool) : int {
+    if (expr == null) return 0
+    var n = 0
+    if (want_break && expr is ExprBreak) {
+        n ++
+    } elif (!want_break && expr is ExprContinue) {
+        n ++
+    }
+    if (expr is ExprBlock) {
+        let b = expr as ExprBlock
+        for (s in b.list) {
+            n += count_break_continue(s, want_break)
+        }
+        for (s in b.finalList) {
+            n += count_break_continue(s, want_break)
+        }
+    } elif (expr is ExprFor) {
+        let f = expr as ExprFor
+        for (s in f.sources) {
+            n += count_break_continue(s, want_break)
+        }
+        n += count_break_continue(f.body, want_break)
+    } elif (expr is ExprIfThenElse) {
+        let i = expr as ExprIfThenElse
+        n += count_break_continue(i.cond, want_break)
+        n += count_break_continue(i.if_true, want_break)
+        n += count_break_continue(i.if_false, want_break)
+    } elif (expr is ExprMakeBlock) {
+        let mb = expr as ExprMakeBlock
+        n += count_break_continue(mb._block, want_break)
+    } elif (expr is ExprInvoke) {
+        let inv = expr as ExprInvoke
+        for (a in inv.arguments) {
+            n += count_break_continue(a, want_break)
+        }
+    }
+    return n
+}
+
+[test]
+def test_take_splices_break_into_loop(t : T?) {
+    // where.take.count: counter lane with take guard → one for-loop + at least one break
+    // (the `if (taken == N) break` guard).
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_where_take_count_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(1, count_inner_for_loops(body_expr), "single fused for-loop")
+        t |> success(count_break_continue(body_expr, true) >= 1, "take guard must emit a break")
+    }
+}
+
+[test]
+def test_skip_take_splices_continue_and_break(t : T?) {
+    // skip.take.to_array: array lane with both guards → continue (skip) + break (take).
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_skip_take_to_array_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper")
+        t |> equal(1, count_inner_for_loops(body_expr), "single fused for-loop")
+        t |> success(count_break_continue(body_expr, true) >= 1, "take guard must emit a break")
+        t |> success(count_break_continue(body_expr, false) >= 1, "skip guard must emit a continue")
+    }
+}
+
+[test]
+def test_take_sum_splices_in_accumulator(t : T?) {
+    // select.take.sum: accumulator lane with take → one for-loop + acc += ... + break.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_take_sum_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper")
+        t |> equal(1, count_inner_for_loops(body_expr), "single fused for-loop")
+        t |> success(count_op2(body_expr, "+=") >= 1, "sum must emit `+=` in accumulator")
+        t |> success(count_break_continue(body_expr, true) >= 1, "take guard must emit a break")
+    }
+}
+
+[test]
+def test_order_by_take_falls_through(t : T?) {
+    // order_by + take is BufferTopN territory — recognized as buffer-required, planner returns
+    // null, falls through to plain linq. Future PR replaces with a dedicated emit path.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_take_falls_through)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(!(body_expr is ExprInvoke),
+            "order_by chain should fall through unfolded — splice planner doesn't handle buffer mode yet")
+    }
+}
+
+[test]
+def test_distinct_falls_through(t : T?) {
+    // distinct is buffer-required (hash set) — fall-through marker.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_distinct_falls_through)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(!(body_expr is ExprInvoke),
+            "distinct chain should fall through unfolded — BufferDistinct mode not yet implemented")
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 2C of the `_fold` splice-mode buildout. Two rings + one small lint-driven gensym tweak.

### Ring 3 — `take(N)` / `skip(N)` splice in all four lanes (`eac77b8dd`)

`_fold` now recognizes `[where_*][select*][skip?][take?] |> terminator` and emits per-element work wrapped with bounded-loop counters. Skip/take guards splice into the per-match block (after the optional `where` filter, before lane-specific work). Counters live alongside the lane's accumulator in the outer invoke.

- Planner state machine on `(seenSelect, seenSkip, seenTake)` enforces canonical chain order; reversed forms (where-after-select, etc.) fall through to plain linq.
- `take`/`skip` as trailing operator (no explicit `to_array`) routes to ARRAY lane with implicit `to_array`.
- Range-form `take(start..end)` falls through (different semantics — slice operator, future PR).
- **Buffer-required marker arms** for `order_by`/`order_descending`, `distinct`/`distinct_by`, `reverse`, `group_by`/`group_by_lazy`, `zip`, `join`/`left_join`/`group_join` — each gets a named recognition arm with a `// TODO Phase 2X: <FutureMode>` comment so future buffer-mode emission grafts in without re-walking the chain-recognition logic.
- Reserve hint refinement: when `take(N)` is present, array-lane reserve tightens from `length(src)` to `min(N, length(src))` (inline `?:` — no math::min dep at call site).
- Take-increment placement: BEFORE lane work, so early-exit terminators with `return X` don't trigger LINT001 unreachable.

**Benchmarks (100K rows, INTERP):**

| Benchmark | Shape | m3f_old | m3f (Phase 2C) |
|---|---|---:|---:|
| take_count | `take(N).to_array` | 0 | 0 (parity; structural splice win) |
| skip_take | `skip(K).take(N).to_array` | 23 | **0** |
| take_sum_aggregate (new) | `select.take(N).sum` | 14 | **0** |
| take_count_filtered (new) | `where.take(N).count` | 11 | **0** |

Sub-ns/op reflects bounded-loop nature: actual loop runs ≤ K+N (≤ 1010 here vs 100K source).

### qmatch gensym tweak (`10e6cdca1`)

Switch `daslib/ast_match.das::next_var` from `qm_{n}` to `` qm`{n} ``. Backtick is the established compiler-generated-name marker in daslib (linq_fold gensyms etc.), and `daslib/lint.das:152` already skips backtick-bearing names from LINT004. Eliminates collision risk with any user identifier (`qm_5` is a valid user identifier; `` qm`5 `` is not).

### Ring 4 — chained-select clone via `:=` (`088d80ed0`)

Drops the `prevWorkhorse=false → return null` Phase 2B placeholder guard at the chained-`select` arm. Correctness observation: `:=` is safe on every type (byte copy on workhorse, deep-clone on non-workhorse). Single emission shape `var $i(bind) := $e(projection)` covers both cases. Chained selects of any type now splice through one path.

Concretely: `each(arr)._select(ComplexType(a = [_*2]))._select(_.a[0]).sum()` previously fell through to plain linq; now splices to a single fused for-loop.

**Workhorse-branch audit** — after Ring 4, two workhorse branches remain in `linq_fold.das`, both intentional:
1. `fold_select_where` `static_if (typeinfo is_workhorse(...))` — `_old_fold`'s frozen baseline path via `g_foldSeq`. Changing it would invalidate the `m3f_old` benchmark column.
2. `min_max_compare` workhorse `<` / `>` vs `_::less` — perf-critical (~2× per-element on int columns; PR #2696 numbers).

## Planned: fail-loudly contract

Documented in `benchmarks/sql/LINQ.md` as the next planned PR. Current contract — `_fold` silently falls through to plain linq when it can't splice — is temporary. Planned switch: `macro_error("_fold: cannot splice — <reason>")` on any unsupported shape, mirroring sqlite_linq's "splice or error" contract. Buffer-required marker arms are pre-wired for this.

## Test plan

- [x] `tests/linq/test_linq_fold.das` — 167 tests pass (interpreter; +4 new test funcs covering counter/accumulator/early-exit/array lane take/skip + chained non-workhorse selects).
- [x] `tests/linq/test_linq_fold_ast.das` — 71 tests pass (interpreter; +5 splice-shape assertions including order_by/distinct fall-through markers).
- [x] Full `tests/linq/` AOT suite — **734/734 pass** with `bin/test_aot -use-aot dastest/dastest.das -- --use-aot --test tests/linq`.
- [x] `tests/ast_match/*` regression — 69 tests pass (qmatch gensym tweak).
- [x] `mcp__daslang__format_file` + `mcp__daslang__lint` clean on all 8 changed files.
- [x] Dupe-detect run on changed `.das` (corpus: `daslib` + `tests/linq`) — only finding is a noise-level token-shape match between `is_buffer_required_op` and `macro_boost::is_mutation_op2` (both are `string → bool` membership checks; different domains, no shared abstraction worth extracting).

Plan file: `~/.claude/plans/foamy-leaping-karp.md`. Builds on PR #2696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)