### PR TITLE
cmake: gate daslang-target references when DAS_TOOLS_DISABLED=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1755,10 +1755,13 @@ install(FILES
 add_subdirectory(tutorials)
 
 # ── Documentation build (optional) ──────────────────────────────────────────
-# Requires the `daslang` target (das2rst stdlib RST generator runs it), so we
-# also gate on NOT DAS_TOOLS_DISABLED — otherwise CMake fails on the missing
-# target. Tools-disabled builds simply can't generate docs.
-if(DAS_BUILD_DOCUMENTATION AND NOT DAS_TOOLS_DISABLED)
+# Requires the `daslang` target (das2rst stdlib RST generator runs it). If the
+# user explicitly asked for docs but also disabled tools, fail early rather
+# than silently skipping — mirrors the DAS_AOT_EXAMPLES check above.
+if(DAS_BUILD_DOCUMENTATION)
+    if(DAS_TOOLS_DISABLED)
+        message(FATAL_ERROR "DAS_BUILD_DOCUMENTATION requires DAS_TOOLS_DISABLED to be OFF (the docs pipeline runs daslang via das2rst.das)")
+    endif()
     find_package(Python3 COMPONENTS Interpreter)
     if(Python3_FOUND)
         execute_process(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,13 +438,22 @@ ENDMACRO()
 # Register a .das file to be run as a headless example check.
 # Modules call this from their CMakeLists.txt for examples that
 # can run without GUI, audio, or user interaction.
+#
+# When DAS_TOOLS_DISABLED=ON the `daslang` target is never created, so the
+# run_examples target below (which references $<TARGET_FILE:daslang>) cannot
+# be generated. Gate the registration here so every call site is automatically
+# safe and DAS_EXAMPLES_TO_RUN stays empty.
 MACRO(ADD_EXAMPLE_RUN das_file)
-    SET(_exe TRUE)
-    IF("${ARGN}" STREQUAL "FALSE")
-        SET(_exe FALSE)
+    IF(DAS_TOOLS_DISABLED)
+        MESSAGE(STATUS "EXAMPLE_RUN ${das_file} skipped (DAS_TOOLS_DISABLED=ON)")
+    ELSE()
+        SET(_exe TRUE)
+        IF("${ARGN}" STREQUAL "FALSE")
+            SET(_exe FALSE)
+        ENDIF()
+        MESSAGE("EXAMPLE_RUN ${das_file} (exe=${_exe})")
+        LIST(APPEND DAS_EXAMPLES_TO_RUN "${das_file}|${_exe}")
     ENDIF()
-    MESSAGE("EXAMPLE_RUN ${das_file} (exe=${_exe})")
-    LIST(APPEND DAS_EXAMPLES_TO_RUN "${das_file}|${_exe}")
 ENDMACRO()
 
 ADD_EXAMPLE_RUN("${PROJECT_SOURCE_DIR}/examples/dasbind/dasbind_example.das")
@@ -1117,7 +1126,11 @@ SET(DAS_DASCRIPT_MAIN_SRC
 
 # Tests
 if (NOT ${DAS_TESTS_DISABLED})
-    include(examples/pathTracer/CMakeLists.txt)
+    # pathTracer links against libDaScriptAot, which is only created when
+    # AOT examples are enabled — gate the inclusion accordingly.
+    if(NOT ${DAS_AOT_EXAMPLES_DISABLED})
+        include(examples/pathTracer/CMakeLists.txt)
+    endif()
     include(examples/crash/CMakeLists.txt)
     if(NOT ${DAS_AOT_EXAMPLES_DISABLED} AND NOT (WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4))
         include(tests/aot/CMakeLists.txt)
@@ -1742,7 +1755,10 @@ install(FILES
 add_subdirectory(tutorials)
 
 # ── Documentation build (optional) ──────────────────────────────────────────
-if(DAS_BUILD_DOCUMENTATION)
+# Requires the `daslang` target (das2rst stdlib RST generator runs it), so we
+# also gate on NOT DAS_TOOLS_DISABLED — otherwise CMake fails on the missing
+# target. Tools-disabled builds simply can't generate docs.
+if(DAS_BUILD_DOCUMENTATION AND NOT DAS_TOOLS_DISABLED)
     find_package(Python3 COMPONENTS Interpreter)
     if(Python3_FOUND)
         execute_process(


### PR DESCRIPTION
## Bug

`cmake -DDAS_TOOLS_DISABLED=ON` fails at configure time with `No target "daslang"`. The `daslang` executable is created by `SETUP_COMPILER_BINARY(daslang ...)` inside `if (NOT ${DAS_TOOLS_DISABLED})`, but several call sites outside that guard reference the target via `$<TARGET_FILE:daslang>` / `DEPENDS daslang`.

Closes #2686

## Fix approach

**Primary fix — macro-gate `ADD_EXAMPLE_RUN`** (CMakeLists.txt line 441). The macro feeds `DAS_EXAMPLES_TO_RUN`, which drives the `run_examples` custom target that uses `$<TARGET_FILE:daslang>`. Adding `IF(DAS_TOOLS_DISABLED) ... ENDIF()` inside the macro means every call site (incl. dasPEG, dasStbImage, dasLLVM, and the top-level dasbind example) is automatically safe, `DAS_EXAMPLES_TO_RUN` stays empty, and the outer `IF(DAS_EXAMPLES_TO_RUN)` block naturally skips — no extra guard required.

## Sibling-case sweep

Grepped for `TARGET_FILE:daslang`, `TARGET_FILE_DIR:daslang`, `DEPENDS daslang`, and `ADD_DEPENDENCIES.*daslang` across all CMake files. Results:

- Lines 228/248/261 (`DAS_CPP_BIND_AST` / `DAS_OUTPUT_AST` / `DAS_OUTPUT_JSON` macros): safe — no live call sites and they live inside `IF(CLANG_BIN_EXE)`.
- Line 1180 (`daslang-live`): safe — inside the `NOT DAS_TOOLS_DISABLED` block.
- `tests-cpp/big/style_lint/CMakeLists.txt`, `tests/exe-paths/CMakeLists.txt`: transitively gated (parent `add_subdirectory(tests-cpp)` / `add_subdirectory(tests/exe-paths)` calls are inside `NOT DAS_TOOLS_DISABLED`; `exe-paths` also has its own `if(NOT TARGET daslang) return()` guard).
- **Line 1764 (`das2rst.das` doc-gen): NOT gated** — `if(DAS_BUILD_DOCUMENTATION)` is independent of `DAS_TOOLS_DISABLED`. Fixed: `if(DAS_BUILD_DOCUMENTATION AND NOT DAS_TOOLS_DISABLED)`.

Additional sibling found while verifying:

- `examples/pathTracer/CMakeLists.txt` (included from line 1129) depends on `libDaScriptAot`, which is only created when `NOT DAS_AOT_EXAMPLES_DISABLED`. With `DAS_TOOLS_DISABLED=ON` you must also pass `DAS_AOT_EXAMPLES_DISABLED=ON` (explicit `FATAL_ERROR` on line 1083), and then pathTracer's `ADD_DEPENDENCIES(... libDaScriptAot ...)` fails. Same bug class — fixed by moving the include under `if(NOT DAS_AOT_EXAMPLES_DISABLED)` (the same guard already wraps `tests/aot/CMakeLists.txt`).

## Verification

Both configures succeed locally (configure-only, since the bug is at configure time):

```
cmake -B build_off -DDAS_TOOLS_DISABLED=ON -DDAS_AOT_EXAMPLES_DISABLED=ON -DDAS_TREE_SITTER_DISABLED=ON
cmake -B build_on  -DDAS_TOOLS_DISABLED=OFF                               -DDAS_TREE_SITTER_DISABLED=ON
```

Tools-off output shows the expected new `EXAMPLE_RUN ... skipped (DAS_TOOLS_DISABLED=ON)` status lines for every gated registration.

## Test plan

- [x] Configure with `-DDAS_TOOLS_DISABLED=ON -DDAS_AOT_EXAMPLES_DISABLED=ON` succeeds locally
- [x] Configure with `-DDAS_TOOLS_DISABLED=OFF` still succeeds locally
- [ ] CI green across the full matrix
