### PR TITLE
examples/graphics: dark bg matching daslang theme

### DIFF
--- a/examples/graphics/furier_opengl_imgui_example.das
+++ b/examples/graphics/furier_opengl_imgui_example.das
@@ -86,17 +86,17 @@ def draw_fourier() {
     draw_arrow(float2(0.0f, 0.0f), p0, float3(1.0f, 0.0f, 0.0f))
     if (enable_1) {
         var p = p0
-        draw_circle(p, length(cp1), float3(0.0f, 0.0f, 0.0f))
+        draw_circle(p, length(cp1), float3(0.357f, 0.333f, 0.278f))
         draw_arrow(p, pp1, float3(1.0f, 0.0f, 0.0f))
         p += pp1
-        draw_circle(p, length(cn1), float3(0.0f, 0.0f, 0.0f))
+        draw_circle(p, length(cn1), float3(0.357f, 0.333f, 0.278f))
         draw_arrow(p, pn1, float3(1.0f, 0.0f, 0.0f))
         p += pn1
         if (enable_2) {
-            draw_circle(p, length(cp2), float3(0.0f, 0.0f, 0.0f))
+            draw_circle(p, length(cp2), float3(0.357f, 0.333f, 0.278f))
             draw_arrow(p, pp2, float3(1.0f, 0.0f, 0.0f))
             p += pp2
-            draw_circle(p, length(cn2), float3(0.0f, 0.0f, 0.0f))
+            draw_circle(p, length(cn2), float3(0.357f, 0.333f, 0.278f))
             draw_arrow(p, pn2, float3(1.0f, 0.0f, 0.0f))
             p += pn2
         }
@@ -120,7 +120,9 @@ def update() {
     var display_w, display_h : int
     live_get_framebuffer_size(display_w, display_h)
     glViewport(0, 0, display_w, display_h)
-    glClearColor(0.85f, 0.85f, 0.90f, 1.0f)
+    // Match the daslang theme's bg (#0d0c0a) so the GL viewport blends
+    // seamlessly with the ImGui windows that sit on top.
+    glClearColor(0.051f, 0.047f, 0.039f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
     draw_fourier()
 


### PR DESCRIPTION
## Summary

- `glClearColor(0.85, 0.85, 0.90)` → `(0.051, 0.047, 0.039)` so the GL viewport matches the daslang theme bg (`#0d0c0a`) that the dasImgui harness applies to windows on top.
- Circle outlines `(0, 0, 0)` (black, invisible on dark) → `(0.357, 0.333, 0.278)` (theme `fgFaint`, `#5b5547`) so epicycles are legible without competing with the red arrows or yellow trace.
- Arrows (red) and trace (yellow) read fine on dark — left as-is.

## Why

The Fourier example was harder to read after the daslang theme landed in dasImgui (GaijinEntertainment/dasImgui#39): light-bg viewport behind dark theme windows was visually jarring, and the black circle outlines disappeared against any darker render. Companion to dasImgui#42 (HDPI scaling), which is the broader theme-fit pass.

## Test plan

- [x] Visual check on retina mac — viewport blends with windows, epicycles legible
- [ ] CI green
- [ ] `daslang -project_root . furier_opengl_imgui_example.das` runs from a fresh `daspkg install` (see `examples/graphics/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)