### PR TITLE
mouse: 5 cards — linq_fold Phase 2C + dasImgui HDPI/build

### DIFF
--- a/mouse-data/docs/chained-select-splice-bind-via-clone-assign-universal.md
+++ b/mouse-data/docs/chained-select-splice-bind-via-clone-assign-universal.md
@@ -1,0 +1,47 @@
+---
+slug: chained-select-splice-bind-via-clone-assign-universal
+title: How do I splice chained `_select|_select` stages in a daslib macro without hitting the ExprRef2Value substitution trap, and is the bind-via-`:=` approach correct for every element type?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+
+Bind the previous projection to a fresh local with **`:=` (clone assignment)**, then rename the next select's `_` to that bind name via `Template.replaceVariable("_", $i(bindName))`. Single emission shape — no `static_if`, no macro-time workhorse branching.
+
+```das
+// projection = previous select's lambda body (already typed, may carry ExprRef2Value
+// wrappers from the typer pass)
+let bindName = "`v`{at.line}`{at.column}`{length(intermediateBinds)}"
+intermediateBinds |> push <| qmacro_expr() {
+    var $i(bindName) := $e(projection)
+}
+// next stage's `_` gets renamed to bindName via Template.replaceVariable
+```
+
+**Why bind-and-rename instead of direct substitution:** trying to substitute the full previous projection expression into the next stage's body hits the `ExprRef2Value` trap — see [[my-macro-substitutes-it-for-a-projection-expression-via-template-replacevariable-it-proj-apply-template-but-the-result-fails-to]]. The bind step sidesteps it: the substitute is now a simple `ExprVar(bindName)`, no wrapper, `Template.replaceVariable` works cleanly.
+
+**Why `:=` is universally correct** — and why the workhorse / non-workhorse branch you might be tempted to write isn't needed:
+
+| Source type | What `:=` does | Side effects on source |
+|---|---|---|
+| Workhorse (`int`, `float`, `bool`, `string`, …) | byte copy | none — same cost as plain `=` |
+| Non-workhorse (`array<T>`, lambdas, user structs) | deep clone, new heap alloc | none — source remains intact |
+| Lvalue projection like `_._field` | clones the field's value into the local | the parent object is untouched |
+
+Compare:
+- **`=`** (plain assign) — fails to compile for non-copyable types (`array<T>`, lambdas, etc.) and triggers the strict "this type is not assignable" check.
+- **`<-`** (move) — corrupts the source by zeroing it. For an lvalue projection like `_._field`, this would zero the field on the underlying iterated element — incorrect, since the user expects the projection to be a *read*.
+
+So a single emission `var $i(bind) := $e(projection)` covers every chain shape. Earlier `linq_fold` versions had a `prevWorkhorse=false → return null` guard at the chained-`select` arm; Phase 2C Ring 4 (2026-05-17) lifted it after the audit confirmed `:=` is safe everywhere.
+
+**Concrete location:** `daslib/linq_fold.das` `plan_loop_or_count` select-stage arm — chained selects of any type splice through this one path. The push-vs-emplace decision in the array lane (different problem — that's about `push(value)` vs `var v <- value; emplace(v)`) still branches on workhorse-ness; see [[when-a-call-macro-needs-to-pick-copy-vs-move-init-for-a-projection-should-i-emit-static-if-typeinfo-is-workhorse-e-proj-or-decid]].
+
+**What workhorse branches still legitimately exist in `linq_fold.das`** (audit 2026-05-17):
+1. `fold_select_where` — `static_if (typeinfo is_workhorse($e(selectExpr)))` — frozen `_old_fold` baseline path; changing it would invalidate the `m3f_old` benchmark column.
+2. `min_max_compare` — workhorse uses `<` / `>` directly (single-instruction compare); non-workhorse falls back to `_::less` for user/tuple comparators. Perf-critical (~2× per-element on int columns), Boris-mandated.
+
+Outside those two, no workhorse branch in the splice path.
+
+## Questions
+- How do I splice chained `_select|_select` stages in a daslib macro without hitting the ExprRef2Value substitution trap, and is the bind-via-`:=` approach correct for every element type?

--- a/mouse-data/docs/how-do-i-make-dasimgui-hdpi-aware-what-s-the-canonical-scale-plumbing.md
+++ b/mouse-data/docs/how-do-i-make-dasimgui-hdpi-aware-what-s-the-canonical-scale-plumbing.md
@@ -1,0 +1,53 @@
+---
+slug: how-do-i-make-dasimgui-hdpi-aware-what-s-the-canonical-scale-plumbing
+title: How do I make dasImgui HDPI-aware — what's the canonical scale plumbing?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+Verified 2026-05-16 (dasImgui PR #42, branch `bbatkin/hdpi-theme-scaling`).
+
+dasImgui prior to PR #42 had **zero DPI awareness**: theme constants hardcoded at 1x (`WindowPadding(8,8)`, `FramePadding(6,3)`, `ScrollbarSize=10`), font at 14px exactly. `glfwGetWindowContentScale` was already bound in dasGlfw but never queried.
+
+**The plumbing (3 places):**
+
+1. `widgets/imgui_live.das` — read scale once at init from the window, cache it, apply to fonts + style:
+```das
+var public live_imgui_content_scale : float = 1.0f
+
+def public live_imgui_init(window : GLFWwindow?; glsl_version : string = "#version 330") {
+    ...
+    if (window != null) {
+        var xs = 1.0f
+        var ys = 1.0f
+        glfwGetWindowContentScale(window, safe_addr(xs), safe_addr(ys))
+        // Clamp: some backends report 0 if monitor unavailable.
+        live_imgui_content_scale = max(max(xs, ys), 1.0f)
+    }
+    load_daslang_font(14.0f * live_imgui_content_scale)
+    apply_daslang_theme()
+    ScaleAllSizes(unsafe(GetStyle()), live_imgui_content_scale)
+    ...
+}
+```
+
+2. `widgets/imgui_harness.das` — `glfwWindowHint(int(GLFW_SCALE_TO_MONITOR), 1)` before `live_create_window`. On Windows GLFW scales window-creation size by monitor DPI; no-op on macOS/Linux (where logical-pixel sizing is intrinsic).
+
+3. `widgets/imgui_theme_daslang.das` — leave theme constants at 1x; `ScaleAllSizes` runs AFTER `apply_daslang_theme`. Note: stock ImGui `ScaleAllSizes` does NOT scale border widths — hairline 1px borders on retina are the intended look.
+
+**Required `require`s in imgui_live.das**: `daslib/safe_addr` (for `safe_addr(xs)`) and `math` (for `max`).
+
+**Gotchas:**
+- `glfwGetWindowContentScale` binds C `float*` as `float?` in das, NOT `float&`. Must pass `safe_addr(xs)`. There's a wrapper in `dasglfw/glfw_boost.das` for `glfwGetFramebufferSize(window, int&, int&)` but NO equivalent for content scale.
+- Read once at init; DPI changes during monitor drag (`glfwSetWindowContentScaleCallback`) are deliberately out of scope — re-applying theme + rebuilding font atlas mid-frame is fiddly. Document the limitation.
+- Font strategy: re-raster at `14 * scale` px (sharp), NOT `io.FontGlobalScale = scale` (bilinear-blurry).
+- Headless / no-window path stays at 1.0 naturally.
+
+**Per-platform behavior at runtime:**
+- macOS retina: `glfwGetWindowContentScale` → 2.0, window opens at logical 800×600 = physical 1600×1200 implicitly.
+- Windows DPI 200%: `GLFW_SCALE_TO_MONITOR` resizes window to physical 1600×1200, content scale → 2.0.
+- Linux: depends on compositor (Wayland reports correctly; X11 often 1.0).
+
+## Questions
+- How do I make dasImgui HDPI-aware — what's the canonical scale plumbing?

--- a/mouse-data/docs/how-do-i-run-a-dasimgui-demo-locally-what-s-the-build-daspkg-install-dance.md
+++ b/mouse-data/docs/how-do-i-run-a-dasimgui-demo-locally-what-s-the-build-daspkg-install-dance.md
@@ -1,0 +1,46 @@
+---
+slug: how-do-i-run-a-dasimgui-demo-locally-what-s-the-build-daspkg-install-dance
+title: How do I run a dasImgui demo locally — what's the build + daspkg install dance?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+Verified 2026-05-16.
+
+dasImgui is a **sibling repo** (`/Users/borisbatkin/Work/dasImgui`, not under `daScript/modules/`). To run any dasImgui example or test locally:
+
+**1. Build daslang first** (provides `lib/liblibDaScriptDyn.dylib`, `bin/daslang`):
+```
+cd /Users/borisbatkin/Work/daScript
+cmake --build build --config Release -j 8
+```
+
+**2. Build dasImgui out-of-tree, pointing DASLANG_DIR at daScript:**
+```
+cd /Users/borisbatkin/Work/dasImgui
+mkdir -p build && cd build
+cmake .. -DDASLANG_DIR=/Users/borisbatkin/Work/daScript -DCMAKE_BUILD_TYPE=Release -G Ninja
+cmake --build . --config Release -j 8
+```
+This drops `dasModuleImgui.shared_module`, `imguiApp.shared_module`, `imguiAppHeadless.shared_module` into `/Users/borisbatkin/Work/dasImgui/`.
+
+**3. daspkg install (the critical step):**
+```
+cd /Users/borisbatkin/Work/daScript
+bin/daslang utils/daspkg/main.das -- install /Users/borisbatkin/Work/dasImgui --global --force
+```
+This COPIES (not symlinks) the entire dasImgui repo into `/Users/borisbatkin/Work/daScript/modules/dasImgui/`. The `--global` flag puts it in the das_root modules dir so `require imgui` resolves. The `--force` re-syncs after every edit (without `--force`, repeat installs no-op).
+
+**4. Run:**
+```
+bin/daslang modules/dasImgui/examples/imgui_demo/main.das
+```
+**Do NOT use `-project_root /path/to/dasImgui`** — that flag exists but doesn't trigger `.das_module` initialize for `register_dynamic_module`. The canonical resolver path is via `das_root/modules/<name>` populated by daspkg.
+
+**Gotcha — edits don't propagate without re-install.** Editing a file in `/Users/borisbatkin/Work/dasImgui/widgets/foo.das` is invisible to daslang until you re-run `daspkg install --force`. Working directly in `/Users/borisbatkin/Work/daScript/modules/dasImgui/` skips the sync but means edits land in the daspkg-copied tree, not the source repo — easy to lose work.
+
+**Compile-check via MCP** also needs the install: `mcp__daslang__compile_check` resolves `require imgui` from `daScript/modules/dasImgui/`, not from the dasImgui source repo directly.
+
+## Questions
+- How do I run a dasImgui demo locally — what's the build + daspkg install dance?

--- a/mouse-data/docs/macro-planner-named-marker-arms-leave-room-for-future-modes.md
+++ b/mouse-data/docs/macro-planner-named-marker-arms-leave-room-for-future-modes.md
@@ -1,0 +1,46 @@
+---
+slug: macro-planner-named-marker-arms-leave-room-for-future-modes
+title: How do I structure a chain-recognition macro planner to leave room for future emission modes (e.g. buffer-required ops like order_by/distinct/group_by) without painting over them with a generic fallback?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+
+Use **named marker arms** in the chain-recognition switch: each operator that's currently unsupported BUT will need its own emission mode later gets a distinct `elif` arm with `return null` and a `// TODO: <FutureMode>` comment. The generic "unknown operator → fallback" catch-all stays at the bottom for genuinely unrecognized ops.
+
+```das
+} elif (opName == "where_" || opName == "select") {
+    // ... splice-mode emission ...
+} elif (opName == "take" || opName == "skip") {
+    // ... bounded-loop splice ...
+} elif (is_buffer_required_op(opName)) {    // nolint:LINT009
+    // TODO Phase 2X: order_by/distinct/reverse/group_by/zip/join → buffered emission modes
+    // (BufferTopN, BufferDistinct, BufferReverse, BufferGroupBy, MultiSourceZip, BufferedJoin).
+    return null
+} else {
+    // genuinely unknown operator — fallback to plain pipeline
+    return null
+}
+
+[macro_function]
+def private is_buffer_required_op(name : string) : bool {
+    return name == "order_by" || name == "order_descending"
+        || name == "distinct" || name == "distinct_by"
+        || name == "reverse"
+        || name == "group_by" || name == "group_by_lazy"
+        || name == "zip"
+        || name == "join" || name == "left_join" || name == "group_join"
+}
+```
+
+**Why this matters**: when the future mode lands, it grafts in at the existing named arm — no re-walking the chain-recognition logic, no risk of accidentally enabling broken splice for an op that needs full-source materialization. A single `else: return null` catch-all would force the future PR to identify which name belongs in which mode, re-implement the recognition, and risk shadowing the wrong arm.
+
+**Concrete location**: `daslib/linq_fold.das` `plan_loop_or_count`. Buffer-required marker arm landed in Phase 2C Ring 3 (2026-05-17, PR …); the actual emission modes are deferred to Phase 3+. The marker also doubles as documentation: a reader sees exactly which operators have planned-but-unimplemented support, vs. which are forever-out-of-scope.
+
+**Bonus**: when the project moves to a fail-loudly contract (macro errors instead of silent fallback), the named arms can emit specific error messages ("cannot splice `order_by` + take — needs BufferTopN mode (Phase 3+)"), while the catch-all becomes a generic "unknown chain operator".
+
+Related: see [[chained-select-splice-bind-via-clone-assign-universal]] for the chained-bind shape itself.
+
+## Questions
+- How do I structure a chain-recognition macro planner to leave room for future emission modes (e.g. buffer-required ops like order_by/distinct/group_by) without painting over them with a generic fallback?

--- a/mouse-data/docs/splice-macro-bounded-loop-guard-take-skip-non-positive-n.md
+++ b/mouse-data/docs/splice-macro-bounded-loop-guard-take-skip-non-positive-n.md
@@ -1,0 +1,46 @@
+---
+slug: splice-macro-bounded-loop-guard-take-skip-non-positive-n
+title: When emitting bounded-loop counter guards (take/skip) in a splice macro, what comparison operator matches iterator reference semantics for non-positive N — `==` or `>=`?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+
+**Use `>=` for take, `> 0` for skip.** Mirrors `daslib/linq.das` iterator semantics where `take_impl` and `take_to_array` both `if (total <= 0) break` (non-positive N → take nothing) and `skip_impl` `if (total > 0) { total--; continue }` (non-positive K → naturally inert, skip nothing).
+
+```das
+// Take guard — break when limit reached.
+// `>=` (not `==`): for N <= 0, takenCount=0 already satisfies `0 >= -N`, breaks
+// on first iteration → matches reference "non-positive → take 0".
+// For N > 0, `>=` agrees with `==` since takenCount increments by 1 from 0.
+prefixed |> push <| qmacro_expr() {
+    if ($i(takeCountName) >= $e(takeLimit)) {
+        break
+    }
+}
+
+// Skip guard — decrement and continue while there's skip remaining.
+// `> 0` strict: K <= 0 → condition false → no decrement, element passes through.
+// Structurally identical to skip_impl in linq.das, so it inherits its semantics
+// for free including the non-positive case.
+prefixed |> push <| qmacro_expr() {
+    if ($i(skipName) > 0) {
+        $i(skipName)--
+        continue
+    }
+}
+```
+
+**Why `==` is wrong for take**: when N is negative, `takenCount` (which starts at 0 and only ever increments) **never** satisfies the equality, so the spliced loop happily takes every element of the source. That's a silent divergence from `take_impl` / `take_to_array` / `take(arr, total)`-style overloads which all break on `total <= 0`. It looks correct in tests with positive N and only blows up when a user threads a computed `take(n - m)` that goes negative.
+
+**Concrete bug + fix**: caught on PR #2697 by Copilot's pull-request reviewer. Fix commit `969343ae0`: one-character `==` → `>=` in `daslib/linq_fold.das::wrap_with_skip_take` + 4 pinning tests covering `take(-1)`, `take(0)`, `skip(-1)`, `skip(0)` in `tests/linq/test_linq_fold.das`.
+
+**Why skip didn't need fixing**: pure luck of having reached for the natural `> 0` guard at emission time instead of e.g. counting down to `== 0`. The two paths are not symmetrical — take counts UP from 0 to N (so any non-positive limit needs `>=`), while skip counts DOWN from K to 0 (so the natural `> 0` covers both positive and non-positive K).
+
+**Lesson for any new bounded-loop emission**: pick the guard that short-circuits on the first iteration when the bound is non-positive. `==` against a counter that starts at 0 and increments fails this. Don't trust positive-N tests to prove the emission is sound.
+
+See [[chained-select-splice-bind-via-clone-assign-universal]] for the broader splice emission patterns and [[macro-planner-named-marker-arms-leave-room-for-future-modes]] for the chain-recognition structure that hosts these guards.
+
+## Questions
+- When emitting bounded-loop counter guards (take/skip) in a splice macro, what comparison operator matches iterator reference semantics for non-positive N — `==` or `>=`?


### PR DESCRIPTION
## Summary

Five blind-mouse Q&A cards that accumulated across two sessions:

**linq_fold Phase 2C (from PR #2697 — should have shipped together):**
- `chained-select-splice-bind-via-clone-assign-universal.md` — chained-select splice binds via `:=` (clone-assign) universally; prevWorkhorse-only guard dropped.
- `macro-planner-named-marker-arms-leave-room-for-future-modes.md` — macro planner uses named-marker arms (`take_skip_emit`, `chained_select_emit`, …) instead of dense if/else so adding a mode later is local.
- `splice-macro-bounded-loop-guard-take-skip-non-positive-n.md` — bounded loop guard for `take(N <= 0)` / `skip(N <= 0)`: emit nothing rather than panic.

**dasImgui HDPI session (from borisbat/dasImgui#42):**
- `how-do-i-make-dasimgui-hdpi-aware-what-s-the-canonical-scale-plumbing.md` — the canonical 3-place plumbing: `glfwGetWindowContentScale` in `live_imgui_init`, `GLFW_SCALE_TO_MONITOR` in `harness_init`, `ScaleAllSizes(unsafe(GetStyle()), scale)` after `apply_daslang_theme`. Includes the `float*` vs `float&` binding gotcha (must use `safe_addr(xs)`).
- `how-do-i-run-a-dasimgui-demo-locally-what-s-the-build-daspkg-install-dance.md` — local dev flow: build daslang → build dasImgui out-of-tree with `DASLANG_DIR=...` → `daspkg install /path/to/dasImgui --global --force` (the `--force` is needed for every re-sync; `-project_root` alone won't trigger `.das_module` registration).

## Why

Both sets are pure cache adds. The linq_fold cards encode patterns from already-merged work that next-session-Claude will otherwise re-derive from git history. The dasImgui cards short-circuit the same re-discovery for any future HDPI / theme work.

## Test plan

- [x] All 5 cards committed; no other tree changes
- [ ] `mouse__rebuild` after merge (regenerates FTS5 index — not tracked, local-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)