### PR TITLE
mcp: thread project arg through run_script and eval_expression

### DIFF
--- a/doc/source/reference/utils/mcp.rst
+++ b/doc/source/reference/utils/mcp.rst
@@ -180,13 +180,15 @@ Execution
      - Description
    * - ``run_script``
      - Run a ``.das`` file or inline code snippet and return
-       stdout/stderr.
+       stdout/stderr.  Optional ``project`` for ``.das_project``-bound
+       module resolution.
    * - ``run_test``
      - Run dastest on a ``.das`` test file and return pass/fail
        results.  Optional ``json`` for structured output.
    * - ``eval_expression``
      - Evaluate a daslang expression and return its printed result.
-       Supports module imports via ``require`` parameter.
+       Supports module imports via ``require`` parameter.  Optional
+       ``project`` for ``.das_project``-bound module resolution.
 
 Code generation and transformation
 -----------------------------------
@@ -358,7 +360,10 @@ instance via its REST API.  All accept an optional ``port`` parameter
      - Description
    * - ``live_launch``
      - Launch ``daslang-live.exe`` on a script if not already running.
-       Sets working directory to the script's folder.
+       Sets working directory to the script's folder.  Optional
+       ``project`` is forwarded to ``daslang-live`` as
+       ``-project <file>`` for ``.das_project``-bound module
+       resolution.
    * - ``live_status``
      - Query the running instance for fps, uptime, paused state, and
        error status.
@@ -370,6 +375,10 @@ instance via its REST API.  All accept an optional ``port`` parameter
      - Pause or unpause execution.
    * - ``live_command``
      - Dispatch a ``[live_command]`` by name with JSON arguments.
+   * - ``live_commands``
+     - Dispatch a batch of ``[live_command]``\ s in one round-trip;
+       continue-on-error semantics, response is a JSON array
+       preserving input order.
    * - ``live_shutdown``
      - Gracefully shut down the running instance.
 

--- a/utils/mcp/README.md
+++ b/utils/mcp/README.md
@@ -13,7 +13,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that e
 | `list_types` | Compile a `.das` file and list all structs, classes (with fields), enums (with values), and type aliases |
 | `run_test` | Run dastest on a `.das` test file and return pass/fail results. Optional `json` for structured output |
 | `format_file` | Format a `.das` file using `daslib/das_source_formatter` |
-| `run_script` | Run a `.das` file or inline code snippet and return stdout/stderr |
+| `run_script` | Run a `.das` file or inline code snippet and return stdout/stderr. Optional `project` for `.das_project`-bound module resolution. |
 | `ast_dump` | Dump AST of an expression or compiled function. `mode=ast` returns S-expression (node types/fields), `mode=source` returns post-macro daslang code. Optional `lineinfo` to include file and line:col spans on each node |
 | `program_log` | Produce full post-compilation program text (like `options log`). Shows all types, globals, and functions after macro expansion, template instantiation, and inference. Optional `function` filter |
 | `list_modules` | List all available daslang modules (builtin C++ modules and daslib). Optional `json` for structured output |
@@ -24,7 +24,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that e
 | `goto_definition` | Given a cursor position (file, line, column), resolve the definition of the symbol under the cursor. Returns location, kind (variable/function/field/builtin/struct/enum/typedef), and source snippet. Optional `no_opt` to preserve pre-optimization AST |
 | `type_of` | Given a cursor position (file, line, column), return the resolved type of the expression under the cursor. Shows all expressions at position from innermost to outermost. Optional `no_opt` |
 | `find_references` | Find all references to the symbol under the cursor (function calls, variable uses, field accesses, type refs, enum/bitfield values, aliases). Works from both usage and declaration sites. Scope: `file` (default) or `all` (all loaded modules). Optional `no_opt` |
-| `eval_expression` | Evaluate a daslang expression and return its printed result. Supports comma-separated module imports via `require` parameter |
+| `eval_expression` | Evaluate a daslang expression and return its printed result. Supports comma-separated module imports via `require` parameter. Optional `project` for `.das_project`-bound module resolution. |
 | `describe_type` | Describe a type's fields, methods, values, and base type. Supports structs, classes, handled types, enums, bitfields, variants, tuples, typedefs |
 | `grep_usage` | Parse-aware symbol search across `.das` files using ast-grep + tree-sitter. Finds identifier occurrences excluding comments and strings. Conditional on `sg` CLI |
 | `outline` | List all declarations (functions, structs, classes, enums, bitfields, variants, globals, typedefs) in a file or set of files using tree-sitter. Works on broken/incomplete code — no compilation needed. Conditional on `sg` CLI |
@@ -45,12 +45,13 @@ These tools interact with a running `daslang-live.exe` instance via its REST API
 
 | Tool | Description |
 |---|---|
-| `live_launch` | Start a `daslang-live` instance with a script file. Sets working directory to the script's folder. Detects if already running. Polls up to 10 seconds to confirm startup |
+| `live_launch` | Start a `daslang-live` instance with a script file. Sets working directory to the script's folder. Detects if already running. Polls up to 10 seconds to confirm startup. Optional `project` is forwarded as `-project <file>` for `.das_project`-bound module resolution |
 | `live_status` | Get status (fps, uptime, paused, dt, has_error) |
 | `live_error` | Get last compilation error (null if none) |
 | `live_reload` | Trigger reload. Optional `full` param for full recompile. Works even during compilation errors |
 | `live_pause` | Pause or unpause (`paused` = "true"/"false"). Returns 503 on compilation error |
 | `live_command` | Dispatch a `[live_command]` (`name` required, optional `args` JSON string). Returns 503 on compilation error. Use `name="help"` to list all commands |
+| `live_commands` | Dispatch a batch of `[live_command]`s in one round-trip; continue-on-error semantics, response is a JSON array preserving input order |
 | `live_shutdown` | Graceful shutdown of the live instance |
 
 ### Server Management

--- a/utils/mcp/protocol.das
+++ b/utils/mcp/protocol.das
@@ -242,7 +242,8 @@ def handle_tools_list(id_json : string) : string {
             "file" => PropertySchema(_type = "string", description = "Path to the .das file to run"),
             "code" => PropertySchema(_type = "string", description = "Inline daslang code to run (written to temp file and executed)"),
             "timeout" => PropertySchema(_type = "string", description = "Timeout in seconds (default: 30). Process tree is killed if exceeded"),
-            "track_allocations" => PropertySchema(_type = "string", description = "If 'true', enable heap allocation tracking and append a heap report at exit (shows where each allocation came from)")
+            "track_allocations" => PropertySchema(_type = "string", description = "If 'true', enable heap allocation tracking and append a heap report at exit (shows where each allocation came from)"),
+            "project" => PROJECT_PROP
         },
         []
     ))
@@ -251,7 +252,8 @@ def handle_tools_list(id_json : string) : string {
         "Evaluate a daslang expression and return its printed result. Wraps the expression in a string builder print statement. Use 'require' to add module imports (comma-separated).",
         {
             "expression" => PropertySchema(_type = "string", description = "daslang expression to evaluate (e.g. 'to_float(42) + 1.0', 'length(\"hello\")')"),
-            "require" => PropertySchema(_type = "string", description = "Comma-separated module imports (e.g. 'math', 'strings, daslib/json'). On compile failure, single-token names are retried under 'daslib/'.")
+            "require" => PropertySchema(_type = "string", description = "Comma-separated module imports (e.g. 'math', 'strings, daslib/json'). On compile failure, single-token names are retried under 'daslib/'."),
+            "project" => PROJECT_PROP
         },
         ["expression"]
     ))
@@ -614,9 +616,9 @@ def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project : strin
     } elif (tool_name == "format_file") {
         return do_format_file(arg1)
     } elif (tool_name == "run_script") {
-        return do_run_script(arg1, arg2, arg3, arg4 == "true")
+        return do_run_script(arg1, arg2, arg3, arg4 == "true", project)
     } elif (tool_name == "eval_expression") {
-        return do_eval_expression(arg1, arg2)
+        return do_eval_expression(arg1, arg2, project)
     } elif (tool_name == "describe_type") {
         return do_describe_type(arg1, arg2, project)
     } elif (tool_name == "ast_dump") {

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -188,6 +188,42 @@ def test_compile_check_invalid_project(t : T?) {
     }
 }
 
+[test]
+def test_run_script_invalid_project(t : T?) {
+    t |> run("missing project file reports focused error") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        parse_result(do_run_script("", "print(\"hi\")", "", false, "nonexistent_xyz.das_project"), text, is_error)
+        t |> success(is_error, "should be error")
+        t |> success(find(text, "'project' file not found") >= 0, "should mention project file not found")
+    }
+    t |> run("non-.das_project extension reports focused error") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        parse_result(do_run_script("", "print(\"hi\")", "", false, fixture_path("_fixture_valid.das")), text, is_error)
+        t |> success(is_error, "should be error")
+        t |> success(find(text, "expected a path to a .das_project file") >= 0, "should mention expected extension")
+    }
+}
+
+[test]
+def test_eval_expression_invalid_project(t : T?) {
+    t |> run("missing project file reports focused error") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        parse_result(do_eval_expression("1 + 1", "", "nonexistent_xyz.das_project"), text, is_error)
+        t |> success(is_error, "should be error")
+        t |> success(find(text, "'project' file not found") >= 0, "should mention project file not found")
+    }
+    t |> run("non-.das_project extension reports focused error") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        parse_result(do_eval_expression("1 + 1", "", fixture_path("_fixture_valid.das")), text, is_error)
+        t |> success(is_error, "should be error")
+        t |> success(find(text, "expected a path to a .das_project file") >= 0, "should mention expected extension")
+    }
+}
+
 // ── parse_file_list (smoke) ──────────────────────────────────────────
 // Canonical unit tests for `parse_file_list` and `expand_glob` live in
 // `tests/fio/expand_glob_test.das` (the helpers moved to `daslib/fio`).

--- a/utils/mcp/tools/eval_expression.das
+++ b/utils/mcp/tools/eval_expression.das
@@ -50,7 +50,7 @@ def private rewrite_modules_in_set(req_modules : string; missing : array<string>
     return join(out_parts, ", ") => rewritten
 }
 
-def private try_eval_expression(exe, expression, req_modules : string; var output : string&) : int {
+def private try_eval_expression(exe, expression, req_modules, project : string; var output : string&) : int {
     let stub_path = make_temp_das_file()
     let script = build_string() $(var w) {
         write(w, "options gen2\n")
@@ -80,18 +80,25 @@ def private try_eval_expression(exe, expression, req_modules : string; var outpu
         output = "Cannot write temp file: {stub_path}"
         return -1
     }
-    let argv <- [exe, stub_path]
+    var argv <- [exe]
+    if (!empty(project)) {
+        argv |> push("-project")
+        argv |> push(string(project))
+    }
+    argv |> push(string(stub_path))
     let exit_code = run_and_capture(argv, output)
     remove(stub_path)
     return exit_code
 }
 
-def do_eval_expression(expression, req_modules : string) : string {
+def do_eval_expression(expression, req_modules : string; project : string = "") : string {
     if (empty(expression)) return make_tool_result("missing 'expression' argument", true)
+    let project_err = validate_project_arg(project)
+    if (!empty(project_err)) return make_tool_result(project_err, true)
     let exe = get_daslang_exe()
     if (empty(exe)) return make_tool_result("Cannot determine daslang executable path", true)
     var output : string
-    let exit_code = try_eval_expression(exe, expression, req_modules, output)
+    let exit_code = try_eval_expression(exe, expression, req_modules, project, output)
     if (exit_code == 0) return make_tool_result(strip(output))
     // exit_code < 0 means try_eval_expression failed before invoking the daslang subprocess
     // (e.g. couldn't write the temp file). Surface the message directly — no retry would help.
@@ -107,7 +114,7 @@ def do_eval_expression(expression, req_modules : string) : string {
         let did_rewrite = rewrite._1
         if (did_rewrite) {
             var output2 : string
-            let exit_code2 = try_eval_expression(exe, expression, new_modules, output2)
+            let exit_code2 = try_eval_expression(exe, expression, new_modules, project, output2)
             if (exit_code2 == 0) return make_tool_result("[resolved unqualified modules under daslib/: {new_modules}]\n{strip(output2)}")
             if (exit_code2 < 0) return make_tool_result(output2, true)
             // Retry also failed at the daslang level — surface the retry's output, since the rewrite

--- a/utils/mcp/tools/run_script.das
+++ b/utils/mcp/tools/run_script.das
@@ -4,7 +4,9 @@ options no_unused_block_arguments = false
 
 require common public
 
-def do_run_script(file, code : string; timeout_str : string = ""; track_allocations : bool = false) : string {
+def do_run_script(file, code : string; timeout_str : string = ""; track_allocations : bool = false; project : string = "") : string {
+    let project_err = validate_project_arg(project)
+    if (!empty(project_err)) return make_tool_result(project_err, true)
     let exe = get_daslang_exe()
     if (empty(exe)) return make_tool_result("Cannot determine daslang executable path", true)
     // if code is provided, write to temp file; otherwise resolve relative path
@@ -25,6 +27,10 @@ def do_run_script(file, code : string; timeout_str : string = ""; track_allocati
     let timeout_sec = empty(timeout_str) ? 30.0 : float(to_int(timeout_str))
     var output : string
     var argv <- [exe]
+    if (!empty(project)) {
+        argv |> push("-project")
+        argv |> push(string(project))
+    }
     if (track_allocations) {
         argv |> push("-track-allocations")
         argv |> push("-heap-report")


### PR DESCRIPTION
## Summary

- Thread `project` arg through `run_script` and `eval_expression` MCP tools — the last two compile-family outliers that shell out to `daslang.exe` but never piped `-project <file>` through. Any script/expression that needed `.das_project`-bound module resolution silently failed.
- Document the previously-shipped-but-undocumented `project` arg on `live_launch`, and add the missing `live_commands` row to the Live-Reload Control tables in both `utils/mcp/README.md` and `doc/source/reference/utils/mcp.rst`.

## What changed

| File | Change |
|---|---|
| `utils/mcp/tools/run_script.das` | Trailing `project : string = ""` param, `validate_project_arg` early-return, `-project <file>` argv injection. |
| `utils/mcp/tools/eval_expression.das` | Same shape, plus thread `project` through the daslib-`require` rewrite retry path. |
| `utils/mcp/protocol.das` | `PROJECT_PROP` added to both tool schemas; `dispatch_tool` passes the already-extracted `project` string. |
| `utils/mcp/test_tools.das` | Two new `[test]` functions mirroring `test_compile_check_invalid_project` — exercise both `validate_project_arg` error branches (nonexistent path, wrong extension) for both tools. |
| `utils/mcp/README.md` + `doc/source/reference/utils/mcp.rst` | Tool tables updated; `live_commands` row inserted. |

## Out of scope

Removing the `daslang-live` single-instance OS-level lock and adding a `-port` CLI flag to unblock concurrent live instances. The MCP-side port arg already exists on every `live_*` tool — once the executable cooperates, the MCP surface needs minimal further work. Tracking separately.

## Test plan

- [x] `format_file` clean on every changed `.das` file (all `already_formatted`).
- [x] `utils/lint/main.das` clean on all 4 changed `.das` files (0 issues, 0 errors).
- [x] `compile_check` on `utils/mcp/main.das` — entry point compiles, every `require` still resolves.
- [x] `test_tools.das` — 287/287 pass, including the two new tests:
  - `test_run_script_invalid_project` ✓
  - `test_eval_expression_invalid_project` ✓
- [x] Sphinx build with `-W` clean (handwritten-RST surface — list-table edits, no toctree changes).
- [ ] CI: full matrix (lint, tests, AOT, extended_checks, sphinx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
