### PR TITLE
site: add /daspkg page + landing § 05 packages callout

### DIFF
--- a/site/_news/2026-05-17-daspkg-is-live.md
+++ b/site/_news/2026-05-17-daspkg-is-live.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-17
+tag: daspkg
+title: daspkg is live — the daslang package index. Browse bindings, bots, batteries — one install away.
+link: /daspkg.html
+---

--- a/site/blog/template.html
+++ b/site/blog/template.html
@@ -33,6 +33,7 @@
                     <a href="{{root}}doc/index.html">docs</a>
                     <a href="{{root}}index.html#benchmarks">benchmarks</a>
                     <a href="{{root}}downloads.html">downloads</a>
+                    <a href="{{root}}daspkg.html">daspkg</a>
                     <a href="{{root}}blog/index.html">blog</a>
                     <a href="https://t.me/daScript">community</a>
                 </div>

--- a/site/daspkg.html
+++ b/site/daspkg.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>daspkg — Daslang package manager</title>
+    <meta name="description" content="The daslang package index. Bindings, bots, batteries — one daspkg install away. Rendered straight from the open daspkg-index repo." />
+    <meta name="keywords" content="daslang, daspkg, package manager, daslang packages, bindings" />
+
+    <link rel="icon" type="image/svg+xml" href="files/forge-favicon.svg" />
+    <link rel="alternate" type="application/atom+xml" title="Daslang blog" href="blog/feed.xml" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" />
+    <link rel="stylesheet" href="files/forge.css" />
+
+    <!-- Analytics -->
+    <script data-goatcounter="https://borisbat.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
+</head>
+<body>
+<div class="forge-page">
+
+    <!-- ───── Nav ───── -->
+    <nav class="forge-nav">
+        <div class="forge-container forge-nav__inner">
+            <div class="forge-nav__left">
+                <a class="forge-mark" href="index.html">
+                    <span class="forge-mark__glyph">&gt;</span>
+                    <span>daslang</span>
+                    <span class="forge-mark__tld">.io</span>
+                </a>
+                <div class="forge-nav__links">
+                    <a href="doc/index.html">docs</a>
+                    <a href="index.html#benchmarks">benchmarks</a>
+                    <a href="downloads.html">downloads</a>
+                    <a href="daspkg.html" class="is-active">daspkg</a>
+                    <a href="blog/index.html">blog</a>
+                    <a href="https://t.me/daScript">community</a>
+                    <a href="playground/index.html">playground</a>
+                </div>
+            </div>
+            <div class="forge-nav__right">
+                <button class="forge-nav__burger" type="button" aria-label="menu"
+                    onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
+                <span class="forge-nav__version">v0.6.2</span>
+                <a class="forge-nav__github" href="https://github.com/GaijinEntertainment/daScript">github ↗</a>
+                <a class="forge-nav__install" href="index.html#install">install</a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- ───── Hero ───── -->
+    <section class="forge-daspkg-hero">
+        <div class="forge-container forge-daspkg-hero__grid">
+            <div>
+                <div class="forge-daspkg-hero__kicker">▮ daspkg · package index</div>
+                <h1>
+                    Bindings, bots, batteries.
+                    <em>One install away.</em>
+                </h1>
+                <p class="forge-daspkg-hero__lede">
+                    <code class="forge-inline-code">daspkg</code> is the daslang package manager.
+                    The list below is rendered straight from
+                    <a href="https://github.com/borisbat/daspkg-index">github.com/borisbat/daspkg-index</a>
+                    — adding a package is a single CLI command. No accounts, no web upload.
+                </p>
+                <div class="forge-daspkg-hero__ctas">
+                    <div class="forge-daspkg-cmd">
+                        <span class="prompt">$</span>
+                        <span>daspkg install</span>
+                        <span class="placeholder">‹package›</span>
+                        <button type="button" class="copy" data-copy="daspkg install " aria-label="copy daspkg install command">⎘ copy</button>
+                    </div>
+                    <a class="forge-daspkg-hero__doc-link" href="doc/index.html">cli docs →</a>
+                </div>
+            </div>
+            <div class="forge-daspkg-publish">
+                <div class="forge-daspkg-publish__head">publish a package</div>
+                <div class="forge-daspkg-publish__body">
+                    <div><span class="prompt">$</span> daspkg introduce <span class="placeholder">github.com/you/repo</span></div>
+                    <div class="comment"># validates your .das_package manifest</div>
+                    <div class="comment"># opens a PR against the index repo</div>
+                </div>
+                <div class="forge-daspkg-publish__foot">
+                    <span class="forge-daspkg-publish__count" id="daspkg-publish-count">loading packages…</span>
+                    <a class="forge-daspkg-publish__cli" href="https://github.com/borisbat/daspkg-index">full CLI reference →</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ───── Filter strip ───── -->
+    <section class="forge-daspkg-filter">
+        <div class="forge-container">
+            <div class="forge-daspkg-filter__row">
+                <label class="forge-daspkg-search">
+                    <span class="forge-daspkg-search__glyph">⌕</span>
+                    <input id="daspkg-search" type="text" placeholder="filter by name, description, tag…" autocomplete="off" />
+                    <button class="forge-daspkg-search__clear" id="daspkg-search-clear" type="button" hidden>clear</button>
+                </label>
+                <div class="forge-daspkg-tags" id="daspkg-tags"></div>
+                <div class="forge-daspkg-count">
+                    <span class="forge-daspkg-count__n" id="daspkg-count-n">—</span> / <span id="daspkg-count-total">—</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ───── Package grid ───── -->
+    <section class="forge-daspkg-grid">
+        <div class="forge-container">
+            <div class="forge-daspkg-grid__list" id="daspkg-list"></div>
+            <div class="forge-daspkg-empty" id="daspkg-status">loading packages…</div>
+        </div>
+    </section>
+
+    <!-- ───── Footer ───── -->
+    <footer class="forge-footer">
+        <div class="forge-container forge-footer__grid">
+            <div>
+                <a class="forge-mark" href="index.html">
+                    <span class="forge-mark__glyph">&gt;</span>
+                    <span>daslang</span>
+                    <span class="forge-mark__tld">.io</span>
+                </a>
+                <div class="forge-footer__about">
+                    High-performance scripting for C++.<br />
+                    © 2018–2026 Gaijin Entertainment · BSD 3-Clause
+                </div>
+            </div>
+            <div>
+                <div class="forge-footer__col-head">learn</div>
+                <a class="forge-footer__link" href="doc/index.html">introduction</a>
+                <a class="forge-footer__link" href="doc/reference/index.html">reference</a>
+                <a class="forge-footer__link" href="blog/index.html">blog</a>
+            </div>
+            <div>
+                <div class="forge-footer__col-head">ecosystem</div>
+                <a class="forge-footer__link" href="daspkg.html">daspkg · package index</a>
+                <a class="forge-footer__link" href="playground/index.html">playground</a>
+                <a class="forge-footer__link" href="https://edenspark.io">edenspark · games on daslang</a>
+                <a class="forge-footer__link" href="https://github.com/profelis/daScript-plugin">vs code extension</a>
+            </div>
+            <div>
+                <div class="forge-footer__col-head">community</div>
+                <a class="forge-footer__link" href="https://t.me/daScript">telegram</a>
+                <a class="forge-footer__link" href="https://github.com/GaijinEntertainment/daScript">github</a>
+                <a class="forge-footer__link" href="changelist.html">change list</a>
+                <a class="forge-footer__link" href="downloads.html">downloads</a>
+            </div>
+        </div>
+    </footer>
+
+</div>
+<script src="files/daspkg.js" defer></script>
+</body>
+</html>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -28,6 +28,7 @@
                     <a href="doc/index.html">docs</a>
                     <a href="index.html#benchmarks">benchmarks</a>
                     <a href="downloads.html">downloads</a>
+                    <a href="daspkg.html">daspkg</a>
                     <a href="blog/index.html">blog</a>
                     <a href="https://t.me/daScript">community</a>
                     <a href="playground/index.html">playground</a>

--- a/site/files/daspkg.js
+++ b/site/files/daspkg.js
@@ -1,0 +1,200 @@
+/* daspkg.js — fetch the live package index, render filterable card grid.
+ * Source of truth: github.com/borisbat/daspkg-index/packages.json. */
+(function () {
+    'use strict';
+
+    var INDEX_URL = 'https://raw.githubusercontent.com/borisbat/daspkg-index/main/packages.json';
+
+    var els = {
+        list:         document.getElementById('daspkg-list'),
+        status:       document.getElementById('daspkg-status'),
+        tags:         document.getElementById('daspkg-tags'),
+        search:       document.getElementById('daspkg-search'),
+        searchClear:  document.getElementById('daspkg-search-clear'),
+        countN:       document.getElementById('daspkg-count-n'),
+        countTotal:   document.getElementById('daspkg-count-total'),
+        publishCount: document.getElementById('daspkg-publish-count'),
+    };
+
+    var state = {
+        all: [],
+        allTags: [],
+        query: '',
+        activeTags: [],
+    };
+
+    function esc(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function applyFilter() {
+        var q = state.query.trim().toLowerCase();
+        return state.all.filter(function (p) {
+            if (state.activeTags.length) {
+                var tags = p.tags || [];
+                for (var i = 0; i < state.activeTags.length; i++) {
+                    if (tags.indexOf(state.activeTags[i]) === -1) return false;
+                }
+            }
+            if (!q) return true;
+            if (p.name && p.name.toLowerCase().indexOf(q) !== -1) return true;
+            if (p.description && p.description.toLowerCase().indexOf(q) !== -1) return true;
+            if (p.author && p.author.toLowerCase().indexOf(q) !== -1) return true;
+            var ts = p.tags || [];
+            for (var j = 0; j < ts.length; j++) if (ts[j].toLowerCase().indexOf(q) !== -1) return true;
+            return false;
+        });
+    }
+
+    function renderTags() {
+        els.tags.innerHTML = state.allTags.map(function (t) {
+            var active = state.activeTags.indexOf(t) !== -1;
+            return '<button type="button" class="forge-daspkg-chip' + (active ? ' is-active' : '') +
+                   '" data-tag="' + esc(t) + '">' + esc(t) + '</button>';
+        }).join('');
+    }
+
+    function renderCards(pkgs) {
+        if (!pkgs.length) {
+            els.list.innerHTML = '';
+            els.status.textContent = 'no packages match the filter';
+            els.status.hidden = false;
+            return;
+        }
+        els.status.hidden = true;
+        els.list.innerHTML = pkgs.map(function (p) {
+            var native = p.has_native
+                ? '<span class="forge-daspkg-card__native">native</span>' : '';
+            var sdk = p.min_sdk
+                ? '<span class="forge-daspkg-card__sdk">sdk ≥ ' + esc(p.min_sdk) + '</span>' : '';
+            var license = p.license
+                ? '<span class="forge-daspkg-card__license">' + esc(p.license) + '</span>' : '';
+            var tags = (p.tags || []).map(function (t) {
+                return '<span class="forge-daspkg-card__tag">' + esc(t) + '</span>';
+            }).join('');
+            var deps = (p.dependencies && p.dependencies.length)
+                ? '<div class="forge-daspkg-card__deps">↳ depends on ' +
+                  p.dependencies.map(esc).join(', ') + '</div>' : '';
+            var url = p.url ? 'https://' + p.url : '#';
+            var installStr = 'daspkg install ' + p.name;
+            return '' +
+                '<a class="forge-daspkg-card" href="' + esc(url) + '" target="_blank" rel="noopener noreferrer">' +
+                    '<div class="forge-daspkg-card__head">' +
+                        '<div class="forge-daspkg-card__title-row">' +
+                            '<h3>' + esc(p.name) + '</h3>' + native + sdk +
+                        '</div>' + license +
+                    '</div>' +
+                    '<p class="forge-daspkg-card__desc">' + esc(p.description || '') + '</p>' +
+                    '<div class="forge-daspkg-card__tags">' + tags + '</div>' +
+                    deps +
+                    '<div class="forge-daspkg-card__foot">' +
+                        '<div class="forge-daspkg-card__install">' +
+                            '<span class="prompt">$</span>' +
+                            '<span>' + esc(installStr) + '</span>' +
+                            '<span class="copy" data-copy="' + esc(installStr) + '" title="copy">⎘</span>' +
+                        '</div>' +
+                        '<span class="forge-daspkg-card__repo">repo ↗</span>' +
+                    '</div>' +
+                '</a>';
+        }).join('');
+    }
+
+    function updateCounts(visible) {
+        els.countN.textContent = visible;
+        els.countTotal.textContent = state.all.length;
+        els.publishCount.textContent = visible + ' of ' + state.all.length + ' packages';
+    }
+
+    function rerender() {
+        var pkgs = applyFilter();
+        renderTags();
+        renderCards(pkgs);
+        updateCounts(pkgs.length);
+    }
+
+    function copyToClipboard(text, srcEl) {
+        var done = function (ok) {
+            if (!srcEl) return;
+            var prev = srcEl.textContent;
+            srcEl.textContent = ok ? '✓' : '⎘';
+            setTimeout(function () { srcEl.textContent = prev; }, 900);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(function () { done(true); }, function () { done(false); });
+        } else {
+            try {
+                var ta = document.createElement('textarea');
+                ta.value = text;
+                ta.style.position = 'fixed';
+                ta.style.opacity = '0';
+                document.body.appendChild(ta);
+                ta.select();
+                var ok = document.execCommand('copy');
+                document.body.removeChild(ta);
+                done(ok);
+            } catch (e) { done(false); }
+        }
+    }
+
+    function wireEvents() {
+        els.tags.addEventListener('click', function (e) {
+            var btn = e.target.closest('[data-tag]');
+            if (!btn) return;
+            var tag = btn.getAttribute('data-tag');
+            var i = state.activeTags.indexOf(tag);
+            if (i === -1) state.activeTags.push(tag);
+            else state.activeTags.splice(i, 1);
+            rerender();
+        });
+        els.search.addEventListener('input', function () {
+            state.query = els.search.value;
+            els.searchClear.hidden = !state.query;
+            rerender();
+        });
+        els.searchClear.addEventListener('click', function () {
+            els.search.value = '';
+            state.query = '';
+            els.searchClear.hidden = true;
+            rerender();
+            els.search.focus();
+        });
+        document.addEventListener('click', function (e) {
+            var copy = e.target.closest('[data-copy]');
+            if (!copy) return;
+            e.preventDefault();
+            e.stopPropagation();
+            copyToClipboard(copy.getAttribute('data-copy'), copy);
+        });
+    }
+
+    function init(packages) {
+        state.all = packages.slice();
+        var tagSet = {};
+        state.all.forEach(function (p) {
+            (p.tags || []).forEach(function (t) { tagSet[t] = true; });
+        });
+        state.allTags = Object.keys(tagSet).sort();
+        wireEvents();
+        rerender();
+    }
+
+    function fail(err) {
+        els.status.textContent = 'failed to load package index — ' + (err && err.message ? err.message : 'network error');
+        els.publishCount.textContent = '— packages';
+        els.countN.textContent = '0';
+        els.countTotal.textContent = '0';
+    }
+
+    fetch(INDEX_URL, { cache: 'no-cache' })
+        .then(function (r) {
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            return r.json();
+        })
+        .then(init)
+        .catch(fail);
+}());

--- a/site/files/forge.css
+++ b/site/files/forge.css
@@ -113,6 +113,7 @@ button { font: inherit; border: 0; background: none; color: inherit; cursor: poi
     font-size: 12.5px;
     color: var(--fg-dim);
 }
+.forge-nav__links a.is-active { color: var(--amber); }
 .forge-nav__right {
     display: flex;
     align-items: center;
@@ -986,4 +987,501 @@ button { font: inherit; border: 0; background: none; color: inherit; cursor: poi
     .forge-news__grid { grid-template-columns: 1fr; gap: 40px; }
     .forge-features__grid { grid-template-columns: repeat(2, 1fr); }
     .forge-footer__grid { grid-template-columns: 1fr 1fr 1fr; }
+}
+
+/* ─────────────────────────────────────────────────────────────
+   daspkg — package index page (/daspkg.html) + landing callout
+   ───────────────────────────────────────────────────────────── */
+
+/* Inline-code chip used in hero copy + landing callout. */
+.forge-inline-code {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    padding: 1px 6px;
+    background: var(--bg-2);
+    border: 1px solid var(--rule);
+    border-radius: 3px;
+    color: var(--amber);
+}
+
+/* ───── Hero (/daspkg.html) ───── */
+
+.forge-daspkg-hero {
+    position: relative;
+    overflow: hidden;
+    padding: 52px 0 40px;
+    border-bottom: 1px solid var(--rule);
+}
+.forge-daspkg-hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+        radial-gradient(700px 280px at 85% -60px, rgba(232, 161, 58, 0.10), transparent 60%),
+        radial-gradient(circle at center, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+    background-size: auto, 22px 22px;
+    -webkit-mask-image: linear-gradient(to bottom, black, transparent);
+            mask-image: linear-gradient(to bottom, black, transparent);
+}
+.forge-daspkg-hero__grid {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1.05fr 1fr;
+    gap: 48px;
+    align-items: end;
+}
+.forge-daspkg-hero h1 {
+    font-family: var(--font-sans);
+    font-size: 56px;
+    line-height: 1.02;
+    font-weight: 600;
+    letter-spacing: -0.03em;
+    color: var(--fg);
+    margin: 0;
+}
+.forge-daspkg-hero h1 em {
+    font-style: italic;
+    font-weight: 400;
+    color: var(--amber);
+}
+.forge-daspkg-hero__kicker {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--amber);
+    letter-spacing: 1.4px;
+    text-transform: uppercase;
+    margin-bottom: 14px;
+}
+.forge-daspkg-hero__lede {
+    margin-top: 18px;
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--fg-dim);
+    max-width: 560px;
+}
+.forge-daspkg-hero__lede a {
+    color: var(--amber);
+    border-bottom: 1px solid var(--amber-dim);
+}
+.forge-daspkg-hero__ctas {
+    margin-top: 24px;
+    display: flex;
+    gap: 18px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+.forge-daspkg-cmd {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    background: var(--bg-2);
+    border: 1px solid var(--rule);
+    padding: 8px 12px;
+    border-radius: 5px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--fg);
+}
+.forge-daspkg-cmd .prompt { color: var(--green); }
+.forge-daspkg-cmd .placeholder { color: var(--fg-dim); }
+.forge-daspkg-cmd .copy {
+    margin-left: 6px;
+    color: var(--fg-faint);
+    cursor: copy;
+    user-select: none;
+}
+.forge-daspkg-cmd .copy:hover { color: var(--amber); }
+.forge-daspkg-hero__doc-link {
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    color: var(--fg-dim);
+    border-bottom: 1px solid var(--rule);
+}
+
+/* "publish a package" card (right column of the hero) */
+.forge-daspkg-publish {
+    background: var(--bg-2);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 18px 20px;
+}
+.forge-daspkg-publish__head {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--fg-faint);
+    letter-spacing: 1.3px;
+    text-transform: uppercase;
+    margin-bottom: 14px;
+}
+.forge-daspkg-publish__body {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    line-height: 1.7;
+    color: var(--fg);
+}
+.forge-daspkg-publish__body .prompt { color: var(--green); }
+.forge-daspkg-publish__body .placeholder { color: var(--fg-dim); }
+.forge-daspkg-publish__body .comment { color: var(--fg-faint); }
+.forge-daspkg-publish__foot {
+    margin-top: 16px;
+    padding-top: 14px;
+    border-top: 1px solid var(--rule);
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+}
+.forge-daspkg-publish__count { color: var(--fg-faint); }
+.forge-daspkg-publish__cli { color: var(--amber); }
+
+/* ───── Filter strip ───── */
+
+.forge-daspkg-filter {
+    border-bottom: 1px solid var(--rule);
+    padding: 28px 0 22px;
+}
+.forge-daspkg-filter__row {
+    display: grid;
+    grid-template-columns: 320px 1fr auto;
+    gap: 24px;
+    align-items: center;
+}
+.forge-daspkg-search {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: var(--bg-2);
+    border: 1px solid var(--rule);
+    border-radius: 5px;
+    padding: 8px 12px;
+}
+.forge-daspkg-search__glyph {
+    color: var(--fg-faint);
+    font-family: var(--font-mono);
+    font-size: 13px;
+}
+.forge-daspkg-search input {
+    flex: 1;
+    background: transparent;
+    border: 0;
+    outline: 0;
+    color: var(--fg);
+    font-family: var(--font-mono);
+    font-size: 13px;
+}
+.forge-daspkg-search input::placeholder { color: var(--fg-faint); }
+.forge-daspkg-search__clear {
+    color: var(--fg-faint);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    cursor: pointer;
+    background: none;
+    border: 0;
+    padding: 0;
+}
+.forge-daspkg-search__clear:hover { color: var(--amber); }
+.forge-daspkg-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+.forge-daspkg-chip {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    padding: 4px 9px;
+    border-radius: 3px;
+    cursor: pointer;
+    background: var(--bg-2);
+    color: var(--fg-dim);
+    border: 1px solid var(--rule);
+    font-weight: 400;
+    user-select: none;
+    transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+}
+.forge-daspkg-chip:hover { border-color: var(--amber-dim); color: var(--fg); }
+.forge-daspkg-chip.is-active {
+    background: var(--amber);
+    color: var(--bg);
+    border-color: var(--amber);
+    font-weight: 600;
+}
+.forge-daspkg-count {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--fg-faint);
+    white-space: nowrap;
+}
+.forge-daspkg-count__n { color: var(--fg); }
+
+/* ───── Grid + cards ───── */
+
+.forge-daspkg-grid {
+    padding: 36px 0 80px;
+}
+.forge-daspkg-grid__list {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+}
+.forge-daspkg-empty {
+    padding: 60px 0;
+    text-align: center;
+    color: var(--fg-faint);
+    font-family: var(--font-mono);
+    font-size: 13px;
+}
+.forge-daspkg-card {
+    background: var(--bg-2);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 20px 22px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    cursor: pointer;
+    transition: border-color 120ms ease;
+    color: inherit;
+    text-decoration: none;
+}
+.forge-daspkg-card:hover { border-color: var(--amber-dim); }
+.forge-daspkg-card:hover .forge-daspkg-card__repo { color: var(--amber); }
+.forge-daspkg-card__head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+}
+.forge-daspkg-card__title-row {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+.forge-daspkg-card h3 {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--fg);
+    letter-spacing: -0.005em;
+}
+.forge-daspkg-card__native {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--amber);
+    border: 1px solid var(--amber-dim);
+    padding: 1px 6px;
+    border-radius: 2px;
+    letter-spacing: 0.6px;
+}
+.forge-daspkg-card__sdk {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--fg-faint);
+}
+.forge-daspkg-card__license {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--fg-faint);
+}
+.forge-daspkg-card__desc {
+    margin: 0;
+    color: var(--fg-dim);
+    font-size: 14px;
+    line-height: 1.55;
+}
+.forge-daspkg-card__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+}
+.forge-daspkg-card__tag {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    padding: 2px 6px;
+    border-radius: 2px;
+    color: var(--fg-dim);
+    background: var(--bg-2);
+    border: 1px solid var(--rule);
+}
+.forge-daspkg-card__deps {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--fg-faint);
+    margin-top: -6px;
+}
+.forge-daspkg-card__foot {
+    margin-top: auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-top: 12px;
+    border-top: 1px solid var(--rule);
+}
+.forge-daspkg-card__install {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--fg-dim);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.forge-daspkg-card__install .prompt { color: var(--green); }
+.forge-daspkg-card__install .copy {
+    color: var(--fg-faint);
+    cursor: copy;
+    user-select: none;
+}
+.forge-daspkg-card__install .copy:hover { color: var(--amber); }
+.forge-daspkg-card__repo {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--fg-dim);
+    transition: color 120ms ease;
+}
+
+/* ───── Landing-page callout (§ 05 packages) ───── */
+
+.forge-pkg-callout__grid {
+    display: grid;
+    grid-template-columns: 1fr 1.3fr;
+    gap: 56px;
+    align-items: start;
+}
+.forge-pkg-callout h2 {
+    font-family: var(--font-sans);
+    font-size: 38px;
+    font-weight: 600;
+    letter-spacing: -0.022em;
+    line-height: 1.1;
+    margin: 0;
+    color: var(--fg);
+}
+.forge-pkg-callout h2 em {
+    font-style: italic;
+    font-weight: 400;
+    color: var(--amber);
+}
+.forge-pkg-callout__lede {
+    color: var(--fg-dim);
+    font-size: 16px;
+    line-height: 1.6;
+    margin-top: 18px;
+    max-width: 460px;
+}
+.forge-pkg-callout__ctas {
+    margin-top: 22px;
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+.forge-pkg-callout__primary {
+    background: var(--amber);
+    color: var(--bg);
+    font-family: var(--font-mono);
+    font-weight: 600;
+    padding: 10px 16px;
+    border-radius: 5px;
+    font-size: 13px;
+    text-decoration: none;
+}
+.forge-pkg-callout__primary:hover { color: var(--bg); background: #f4b04a; }
+.forge-pkg-callout__secondary {
+    color: var(--fg);
+    font-family: var(--font-mono);
+    padding: 10px 16px;
+    font-size: 13px;
+    border: 1px solid var(--rule);
+    border-radius: 5px;
+    text-decoration: none;
+}
+.forge-pkg-callout__secondary:hover { border-color: var(--amber-dim); }
+.forge-pkg-callout__index {
+    margin-top: 20px;
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--fg-faint);
+}
+.forge-pkg-callout__term {
+    background: var(--bg-2);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 14px 16px;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--fg);
+    line-height: 1.6;
+}
+.forge-pkg-callout__term .prompt { color: var(--green); }
+.forge-pkg-callout__term .ok { color: var(--green); }
+.forge-pkg-callout__term .dim { color: var(--fg-faint); }
+.forge-pkg-callout__cells {
+    margin-top: 18px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1px;
+    background: var(--rule);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    overflow: hidden;
+}
+.forge-pkg-callout__cell {
+    background: var(--bg);
+    padding: 16px 16px 18px;
+    text-decoration: none;
+    color: inherit;
+    display: block;
+    transition: background 120ms ease;
+}
+.forge-pkg-callout__cell:hover { background: var(--bg-3); }
+.forge-pkg-callout__cell:hover .forge-pkg-callout__cell-name { color: var(--amber); }
+.forge-pkg-callout__cell-name {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--fg);
+    transition: color 120ms ease;
+}
+.forge-pkg-callout__cell-tags {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--fg-faint);
+    margin-top: 4px;
+}
+.forge-pkg-callout__cell-desc {
+    color: var(--fg-dim);
+    font-size: 12.5px;
+    line-height: 1.5;
+    margin-top: 10px;
+}
+.forge-pkg-callout__indexed {
+    margin-top: 12px;
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--fg-faint);
+    text-align: right;
+}
+
+/* ───── Responsive ───── */
+
+@media (max-width: 1023px) {
+    .forge-daspkg-hero__grid { grid-template-columns: 1fr; gap: 32px; align-items: start; }
+    .forge-pkg-callout__grid { grid-template-columns: 1fr; gap: 36px; }
+}
+
+@media (max-width: 767px) {
+    .forge-daspkg-hero { padding: 36px 0 28px; }
+    .forge-daspkg-hero h1 { font-size: 38px; }
+    .forge-daspkg-hero__ctas { flex-direction: column; align-items: stretch; }
+    .forge-daspkg-cmd { width: 100%; }
+    .forge-daspkg-filter__row {
+        grid-template-columns: 1fr;
+        gap: 14px;
+    }
+    .forge-daspkg-search { width: 100%; }
+    .forge-daspkg-grid__list { grid-template-columns: 1fr; }
+    .forge-daspkg-grid { padding: 28px 0 60px; }
+    .forge-pkg-callout h2 { font-size: 26px; }
+    .forge-pkg-callout__cells { grid-template-columns: 1fr; }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -43,6 +43,7 @@
                     <a href="doc/index.html">docs</a>
                     <a href="#benchmarks">benchmarks</a>
                     <a href="downloads.html">downloads</a>
+                    <a href="daspkg.html">daspkg</a>
                     <a href="blog/index.html">blog</a>
                     <a href="https://t.me/daScript">community</a>
                     <a href="playground/index.html">playground</a>
@@ -305,11 +306,71 @@ def main() {
         </div>
     </section>
 
-    <!-- ───── § 05 Changelog / news ───── -->
-    <section class="forge-section forge-section--alt">
+    <!-- ───── § 05 Packages (daspkg) ───── -->
+    <section class="forge-section forge-pkg-callout">
         <div class="forge-container">
             <div class="forge-section-label">
                 <span class="forge-section-label__num">§ 05</span>
+                <span class="forge-section-label__rule"></span>
+                <span>packages</span>
+            </div>
+            <div class="forge-pkg-callout__grid">
+                <div>
+                    <h2>
+                        A package manager that
+                        <em>compiles in.</em>
+                    </h2>
+                    <p class="forge-pkg-callout__lede">
+                        <code class="forge-inline-code">daspkg</code> is the daslang package
+                        manager. Bindings for Dear ImGui, the Claude API, Telegram bots —
+                        one command, no accounts. Publishing is a single CLI call against
+                        an open index repo.
+                    </p>
+                    <div class="forge-pkg-callout__ctas">
+                        <a class="forge-pkg-callout__primary" href="daspkg.html">browse daspkg →</a>
+                        <a class="forge-pkg-callout__secondary" href="doc/index.html">cli docs</a>
+                    </div>
+                    <div class="forge-pkg-callout__index">
+                        index · <a href="https://github.com/borisbat/daspkg-index">github.com/borisbat/daspkg-index</a>
+                    </div>
+                </div>
+                <div>
+                    <div class="forge-pkg-callout__term">
+                        <div><span class="prompt">$</span> daspkg install dasImgui</div>
+                        <div class="dim">  fetching dasImgui@latest from github.com/borisbat/dasImgui</div>
+                        <div class="dim">  building native bindings…</div>
+                        <div class="ok">  ✓ installed dasImgui · 1 native dep</div>
+                    </div>
+                    <div class="forge-pkg-callout__cells">
+                        <a class="forge-pkg-callout__cell" href="https://github.com/borisbat/dasImgui" target="_blank" rel="noopener noreferrer">
+                            <div class="forge-pkg-callout__cell-name">dasImgui</div>
+                            <div class="forge-pkg-callout__cell-tags">gui · imgui</div>
+                            <div class="forge-pkg-callout__cell-desc">Dear ImGui bindings for daslang.</div>
+                        </a>
+                        <a class="forge-pkg-callout__cell" href="https://github.com/borisbat/dasAnthropic" target="_blank" rel="noopener noreferrer">
+                            <div class="forge-pkg-callout__cell-name">das-claude</div>
+                            <div class="forge-pkg-callout__cell-tags">ai · api</div>
+                            <div class="forge-pkg-callout__cell-desc">Typed bindings for the Anthropic Claude Messages API.</div>
+                        </a>
+                        <a class="forge-pkg-callout__cell" href="https://github.com/borisbat/dasTelegram" target="_blank" rel="noopener noreferrer">
+                            <div class="forge-pkg-callout__cell-name">dasTelegram</div>
+                            <div class="forge-pkg-callout__cell-tags">telegram · bot</div>
+                            <div class="forge-pkg-callout__cell-desc">Telegram Bot API bindings for daslang — zero-DOM JSON via sscan_json/sprint_json.</div>
+                        </a>
+                    </div>
+                    <div class="forge-pkg-callout__indexed">
+                        <a href="daspkg.html">browse all packages →</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ───── § 06 Changelog / news ───── -->
+    <section class="forge-section forge-section--alt">
+        <div class="forge-container">
+            <div class="forge-section-label">
+                <span class="forge-section-label__num">§ 06</span>
                 <span class="forge-section-label__rule"></span>
                 <span>changelog</span>
             </div>

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -54,6 +54,7 @@
                 <a href="../doc/index.html">docs</a>
                 <a href="../index.html#benchmarks">benchmarks</a>
                 <a href="../downloads.html">downloads</a>
+                <a href="../daspkg.html">daspkg</a>
                 <a href="../blog/index.html">blog</a>
                 <a href="https://t.me/daScript">community</a>
             </div>

--- a/site/playground/placeholder.html
+++ b/site/playground/placeholder.html
@@ -27,6 +27,7 @@
                 <a href="../doc/index.html">docs</a>
                 <a href="../index.html#benchmarks">benchmarks</a>
                 <a href="../downloads.html">downloads</a>
+                <a href="../daspkg.html">daspkg</a>
                 <a href="../blog/index.html">blog</a>
                 <a href="https://t.me/daScript">community</a>
             </div>


### PR DESCRIPTION
## Summary

- New `/daspkg.html` surface — hero + publish-card, filter strip (text search + AND-combined tag chips), 2-up card grid. Cards click-through to the GitHub repo (no per-package routes, per the handoff).
- Landing page gains `§ 05 — packages` callout with a featured 3-cell showcase (`dasImgui` · `das-claude` · `dasTelegram`), each cell click-through to its repo. Changelog renumbered `§ 05 → § 06`.
- News entry under `site/_news/` announcing the launch.
- `daspkg` nav link added across `index`, `downloads`, `playground`, `blog/template`.
- New `.forge-daspkg-*` / `.forge-pkg-callout__*` CSS rules in `files/forge.css` — no changes to existing tokens.
- New `files/daspkg.js` does the runtime `fetch` of [packages.json](https://raw.githubusercontent.com/borisbat/daspkg-index/main/packages.json) (matches existing `news.json` / `profile_results.json` pattern — no build-pipeline changes).

Design source: Claude Design handoff (`~/Downloads/daspkg.zip`). The handoff JSX is React-via-Babel mockups; this PR is the hand-port to the site's vanilla HTML + `forge.css` patterns.

## Test plan

- [ ] Open `/daspkg.html` — hero, filter strip, and card grid render once `packages.json` fetch completes (~loading flash, then 8 cards).
- [ ] Type in the filter input — grid live-filters; `clear` button appears/works.
- [ ] Click tag chips — they toggle (amber-on / outlined-off), AND-combine; count `n / 8` updates.
- [ ] Click `gui` chip → 2 packages (`dasImgui`, `dasImguiNodeEditor`); `dasImguiNodeEditor` shows `↳ depends on dasImgui`.
- [ ] Click a card — opens the repo in a new tab.
- [ ] Click the `⎘` copy icon on a card — copies `daspkg install <name>` without triggering the card click; brief `✓` confirmation.
- [ ] Landing `index.html` — `§ 05 packages` appears between install and changelog; 3 cells link to repos; changelog now `§ 06`.
- [ ] `daspkg` link visible in nav on all pages (`index`, `downloads`, `daspkg`, `blog/*`, `playground`).
- [ ] Mobile (<768px): hero stacks, filter row stacks, grid collapses to 1 column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)