### PR TITLE
pages.yml: stage site/daspkg.html so /daspkg route resolves

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -107,6 +107,7 @@ jobs:
         # Static landing page and assets
         cp site/index.html _site/
         cp site/downloads.html _site/
+        cp site/daspkg.html _site/
         cp site/robots.txt _site/
         cp -r site/files _site/files
 


### PR DESCRIPTION
## Summary

- `site/daspkg.html` shipped in 281ac2e28 (PR #2703) but `daslang.io/daspkg.html` 404s.
- Root cause: the "Stage site for deployment" step in `.github/workflows/pages.yml` copies root-level HTML via an **explicit allowlist** (`index.html`, `downloads.html`, `robots.txt`) — not a glob. `daspkg.html` was added to the repo but the cp list was never updated, so it never reaches `_site/`.
- Since `actions/deploy-pages` publishes `_site` as a complete snapshot (no overlay), re-running the workflow alone doesn't help — the workflow itself is the bug.

## Change

One line added under the existing block:

```diff
         cp site/index.html _site/
         cp site/downloads.html _site/
+        cp site/daspkg.html _site/
         cp site/robots.txt _site/
```

## Test plan

- [ ] Workflow run on master after merge succeeds.
- [ ] `https://daslang.io/daspkg.html` returns 200 with the daspkg registry page.
- [ ] Existing routes (`/`, `/downloads.html`, `/doc/`, `/playground/`, `/blog/`, `/changelist.html`) still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
