### PR TITLE
mouse-data: 11 new cards from sort-family + doc-CI sessions

### DIFF
--- a/mouse-data/docs/byte-swap-micro-win-invisible-under-cblock-dominance.md
+++ b/mouse-data/docs/byte-swap-micro-win-invisible-under-cblock-dominance.md
@@ -1,0 +1,61 @@
+---
+slug: byte-swap-micro-win-invisible-under-cblock-dominance
+title: why does the byte_swap sized-dispatch micro-improvement (140× at W=4 in isolation) not show up in any real daslang sort benchmark?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+A byte_swap variant that demolishes chunked-256 in isolation (`examples/sort/bench_byte_swap.cpp` — 140× faster at W=4, 30× at W=8, never slower) was invisible in every real-world sort benchmark when dropped into `src/builtin/das_qsort_r.h` (2026-05-17 bake-off, Phase 0.2 of PR #2706 follow-up).
+
+**Measured deltas (chunked-256 → sized-dispatch):**
+
+| benchmark | metric | before | after |
+|---|---|---:|---:|
+| `bench_sort_family.cpp` int32/100K sort | das/std ratio | 2.57× | 2.56× |
+| `bench_sort_family.cpp` P32/100K sort | das/std ratio | 1.07× | 1.07× |
+| `benchmarks/sort/sort.das` struct+cblock 100K | ns/op | 279 | 281 |
+| `benchmarks/sort/nth_element.das` k=50000/100K | ns/op | 19 | 19 |
+| `benchmarks/sort/heap_ops.das` bounded_topn/100K | ns/op | 27 | 27 |
+
+Two distinct reasons, depending on the path:
+
+### 1. C++ bench (bench_sort_family.cpp): constant propagation
+
+The bench calls `das_qsort_r(a.data(), a.size(), sizeof(T), das_cmp<T>())`. `sizeof(T)` is a compile-time constant. With `-O3` and the `static inline` byte_swap, the compiler propagates `sizeof(T)` all the way down into the byte_swap body. The OLD chunked loop:
+
+```cpp
+while (width) {
+    size_t chunk = sizeof(tmp) < width ? sizeof(tmp) : width;
+    memcpy(tmp, a, chunk); memcpy(a, b, chunk); memcpy(b, tmp, chunk);
+    a += chunk; b += chunk; width -= chunk;
+}
+```
+
+at width=4 becomes: 1 iteration, chunk=4, 3× constant-size memcpy → identical machine code to the new switch arm. The micro-bench shows the cost because it calls byte_swap through a `Fn` function-pointer template parameter, defeating constant propagation. **The micro-bench measures dispatch cost; the real bench measures inlined-and-folded cost.**
+
+### 2. daslang runtime path (any_cblock binding): callback dominance
+
+`module_builtin_runtime_sort.cpp` calls `das_qsort_r(anyData, length, elementSize, lambda)` where elementSize IS runtime. Here the sized switch DOES win (5-10ns saved per swap vs the runtime-width loop). For 100K elements with ~1.7M swaps, that's ~10ms of theoretical savings.
+
+But the lambda does `context->invokeEx(cmp, bargs, ...)` per comparison — script-block invocation with bargs marshaling. Measured cost per call dominates the swap by ~100×. The 27.9ms total for `sort_struct_by_key/100K` is overwhelmingly comparator-callback time; shaving 10ms off byte_swap would be visible but wasn't reproduced in repeated runs (281 vs 279 within noise).
+
+### Implication for future perf work
+
+- Micro-benchmark a primitive in isolation → not predictive of integrated impact when (a) callers know the parameter at compile time, or (b) some other operation in the same path dominates.
+- If byte_swap is your suspected bottleneck, write a daslang benchmark that uses a CHEAP comparator (e.g. ints with `<`, going through the workhorse path, or a typed C++ harness that defeats constant propagation). The any_cblock path will never reveal byte_swap wins.
+- The actual sort-vs-std gap on workhorse types (2.5× slower) is NOT byte_swap. Likely candidates: partition algorithm choice (libstdc++ may use block-quicksort partition), cmp callback inlining quality. Future bake-offs targeting that gap should NOT spend cycles on byte_swap variants.
+
+### Decision
+
+Boris (2026-05-17): keep the sized dispatch anyway. Net-neutral but never worse; cleaner code at small widths; header comment documents the bake-off so future maintainers don't redo the experiment. The 30-140× micro-win remains real for any future caller that defeats constant-prop (e.g. a direct C++ binding with runtime width).
+
+### Source measurements
+
+- Header: `src/builtin/das_qsort_r.h` byte_swap
+- Micro-bench: `examples/sort/bench_byte_swap.cpp` (chunked256/chunked64/words64/sized/hybrid candidates at W∈{4,8,16,32,64,128,256,512})
+- Integration: `examples/sort/bench_sort_family.cpp` + `benchmarks/sort/*.das`
+- Related card: [[qsort-byte-swap-implementations-survey]] — production-impl survey from the bake-off research
+
+## Questions
+- why does the byte_swap sized-dispatch micro-improvement (140× at W=4 in isolation) not show up in any real daslang sort benchmark?

--- a/mouse-data/docs/das-qsort-r-vs-std-perf-comparison.md
+++ b/mouse-data/docs/das-qsort-r-vs-std-perf-comparison.md
@@ -1,0 +1,55 @@
+---
+slug: das-qsort-r-vs-std-perf-comparison
+title: how do das_partial_sort_r / das_nth_element_r / das_make_heap_r perform compared to std::* equivalents, and what's the real-world cost of the custom impl?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+# das_*_r templates vs std::* — measured perf comparison
+
+Source: `examples/sort/bench_sort_family.cpp` (standalone, runs in ~16s on M-series Mac). N ∈ {1K, 10K, 100K}, element sizes {int32, int64, 32B struct, 128B struct}.
+
+## Headline numbers (das ÷ std ratio, worst case across sizes)
+
+| op | das vs std | reading |
+|---|---|---|
+| `das_nth_element_r` | 0.95–1.85× | **Match** — beats std at N=100K |
+| `das_make_heap_r` + drain | 1.6–2.8× slower | Acceptable overhead |
+| `das_qsort_r` (smoothsort) | 2.3–5.7× slower | Pre-existing (Anton Yudintsev's musl port). Smoothsort vs std's introsort. Known cost. |
+| **`das_partial_sort_r`** | **2–18× slower** | **Real implementation bug** (see below) |
+
+## Why partial_sort is so slow
+
+`das_partial_sort_r` is implemented as `das_nth_element_r(N) + das_qsort_r(first N)` — O(N) + O(topn·log·topn). Looks correct on paper, BUT:
+
+`std::partial_sort` uses a **heap-of-size-topn** approach: scan all N elements, maintain a top-N max-heap, output sorted. O(N · log topn). When topn ≪ N (e.g. topn=10, N=100K) this **destroys** nth-element-then-sort because nth_element still pays O(N) with a big constant.
+
+Concrete: at N=100K, topn=10 — std::partial_sort 39μs vs das_partial_sort_r 730μs = **18× gap**.
+
+The same asymmetry shows in daslib LINQ benchmarks:
+- `m3_topn_array` (calls das_partial_sort_r): 442 ns/op at M=100K, top-N=10
+- `m3_topn_iter` (does heap-of-N manually via push_heap loop): 83 ns/op same params
+- 5× perf difference, same algorithmic cause
+
+## Why custom impl exists at all
+
+`std::sort` / `std::partial_sort` / `std::nth_element` template on **iterator type**. They cannot operate on opaque `void*` data with runtime-known `width`. The daslang any-cblock path (user-defined struct types going through `addExtern<...any_cblock>` bindings) needs byte-pointer algorithms — that's exactly what `das_*_r` templates provide.
+
+So the custom impl IS justified for the any-cblock path. The typed paths (workhorse types) in `module_builtin_runtime_sort.cpp` already specialize to `std::*` directly via the `STAMP_NUMERIC_OPS` / `STAMP_VECTOR_OPS` macros.
+
+## Fix candidates (out of scope for Phase 0, planned follow-up)
+
+1. **Rewrite `das_partial_sort_r` to heap-of-topn** — closes the 18× gap. ~20 LOC change, in the Phase-0-added section of `das_qsort_r.h` (NOT Anton's smoothsort).
+2. **`das_make_heap_r` Floyd construction** — should match std but ~2× slower; revisit if profiling points here.
+3. **`das_qsort_r` smoothsort** — pre-existing; out of scope to replace.
+
+## When this matters
+
+- `top_n_by(arr, N, key)` in `daslib/linq` — currently uses `das_partial_sort_r` under the hood for the array overload. The iterator overload uses heap-of-N manually and is much faster.
+- BufferTopN emit mode in `linq_fold` (planned PR B) — wants the fast heap-of-N path for `[where][select]* |> order_by |> take(N)` fusion.
+
+Run the bench yourself: `cmake -S examples/sort -B build/example_sort_bench && cmake --build build/example_sort_bench -j && ./build/example_sort_bench/example_sort_bench`.
+
+## Questions
+- how do das_partial_sort_r / das_nth_element_r / das_make_heap_r perform compared to std::* equivalents, and what's the real-world cost of the custom impl?

--- a/mouse-data/docs/libcxx-stdsort-block-partition-pdqsort.md
+++ b/mouse-data/docs/libcxx-stdsort-block-partition-pdqsort.md
@@ -1,0 +1,100 @@
+---
+slug: libcxx-stdsort-block-partition-pdqsort
+title: why is libc++ std::sort 2.5× faster than our das_qsort_r pdqsort-lite on workhorse types at N=100K?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+Investigated 2026-05-17 in the PR #2706 follow-up: on macOS, the std::sort beating das_qsort_r by 2.5× at N=100K (int32/int64) is **libc++**, NOT libstdc++. libstdc++ ships plain Musser introsort and is roughly the same algorithm as ours. libc++ ships **block-quicksort pdqsort** since 2021 ([D93923](https://reviews.llvm.org/D93923), Kutenin) — same algorithm as Orson Peters' pdqsort + the Edelkamp/Weiß BlockQuicksort partition.
+
+## Three specific techniques in libc++
+
+Source: `/Library/Developer/CommandLineTools/SDKs/MacOSX26.4.sdk/usr/include/c++/v1/__algorithm/sort.h`.
+
+### 1. `__bitset_partition` (sort.h:495) — branchless partition
+
+Populate a `uint64_t` bitmask of comparison outcomes for 64 elements (branchless inner loop), THEN do swaps in a separate pass driven by `countr_zero` (tzcnt):
+
+```cpp
+// populate (no swaps, no branches)
+for (int __j = 0; __j < 64;) {
+  bool __comp_result = !__comp(*__iter, __pivot);
+  __left_bitset |= (uint64_t(__comp_result) << __j);
+  __j++; ++__iter;
+}
+// swap (predictable loop driven by tzcnt)
+while (__left_bitset != 0 && __right_bitset != 0) {
+  difference_type __tz_left  = __countr_zero(__left_bitset);
+  __left_bitset              = __libcpp_blsr(__left_bitset);
+  ...
+  _Ops::iter_swap(__first + __tz_left, __last - __tz_right);
+}
+```
+
+Cuts branch mispredictions from ~32/partition (50% rate over Hoare's `while (cmp) ++i; while (cmp) --j;`) to **one per 64 elements** (when the bitset empties). On random int32 at N=100K this is the dominant win.
+
+### 2. Branchless small-sort kernels (sort.h:99–198)
+
+Sub-ranges of 2/3/4/5 elements use sorting networks built from `__cond_swap`:
+
+```cpp
+// sort.h:67
+bool __r = __c(*__x, *__y);
+value_type __tmp = __r ? *__x : *__y;
+*__y = __r ? *__y : *__x;
+*__x = __tmp;
+```
+
+Clang lowers `bool ? T : T` on arithmetic types to `csel`/`cmov` — zero branches. Gated by `__use_branchless_sort` (sort.h:54): `contiguous_iterator && is_arithmetic && (std::less || std::greater)`. **Fundamentally typed.**
+
+### 3. Tukey ninther + already-partitioned fast-path (sort.h:775, 809)
+
+For `__len > 128`, pivot is median-of-three-medians-of-three (5× `__sort3` calls). After partition, returns a `bool already_partitioned`; caller then tries an **incomplete** insertion sort capped at 8 inversions before recursing. Pre-sorted/nearly-sorted runs collapse to O(N).
+
+## What is and isn't portable
+
+**Portable to byte-pointer (`(void*, width, cmp)` binding path):**
+- Block-partition bitset loop — `__builtin_ctzll` is universal. Swaps go through byte_swap.
+- Ninther pivot + already-partitioned bool — pure logic, works at any width.
+
+**Requires typed access:**
+- `__cond_swap` → cmov (compiler needs a real value type to emit conditional move)
+- SIMD-vectorization of the 64-element populate-bitset loop (compiler needs constant width + inlined cmp to vectorize)
+
+## Bake-off candidates (priority order)
+
+| # | Candidate | Portable to byte-ptr? | Est. lift | Effort |
+|---|---|---|---|---|
+| D | Ninther + already-partitioned bolt-on to das_qsort_r | yes | small | half day |
+| C | Block-partition pdqsort, byte-pointer | yes | **big — likely most of the 2.5×** | 2-3 days |
+| B | Block-partition pdqsort, typed das_sort\<T\> | n/a (typed only) | biggest | 2-3 days on top of C |
+| A | Dispatch typed das_sort\<T\> from binding for workhorse types | n/a (typed only) | medium | 1 day |
+| E | Branchless `__cond_swap` small-sort kernels | n/a (typed only) | small decoration | half day |
+
+Critical question the bake-off settles: if (C) ≈ (B), the gap is algorithmic (block partition wins regardless of typedness). If (B) ≫ (C), the gap is SIMD-vectorize.
+
+## Verified comparison data (2026-05-17, M-series Mac, Apple clang, libc++)
+
+`examples/sort/bench_sort_family.cpp` deep-dive at N=100K:
+
+| type | std::sort | C qsort | das_qsort_r | das_sort\<T\> |
+|---|---:|---:|---:|---:|
+| int32_t | 1.86M | 7.49M (**4.03×**) | 4.77M (2.57×) | 4.86M (2.62×) |
+| int64_t | 1.92M | 7.49M (**3.89×**) | 4.77M (2.48×) | 4.84M (2.52×) |
+| P32 | 4.97M | 8.44M (1.70×) | 5.48M (1.10×) | 5.64M (1.13×) |
+| P128 | 7.44M | 11.91M (1.60×) | 8.80M (1.18×) | 9.63M (1.30×) |
+
+das_sort\<T\> (typed pdqsort-lite, same algorithm as das_qsort_r) is ≈ identical to das_qsort_r byte-pointer at every (N, type). The 2.5× gap is algorithm, not API. C qsort (the proper byte-pointer + runtime-cmp peer) is **2× SLOWER than das_qsort_r** — we beat libc qsort by a clean margin.
+
+## Source pointers
+
+- libc++ sort: `/Library/Developer/CommandLineTools/SDKs/MacOSX26.4.sdk/usr/include/c++/v1/__algorithm/sort.h` lines 54/67/99/274/302/495/717
+- libstdc++ sort: `/opt/homebrew/include/c++/13/bits/stl_algo.h` lines 85/1792/1854/1893/1918/1942 (Musser introsort, unchanged since SGI STL era)
+- pdqsort reference: github.com/orlp/pdqsort
+- Block partition paper: Edelkamp & Weiß, "BlockQuicksort", ESA 2016 (arXiv:1604.06697)
+- libc++ landing commit: [D93923](https://reviews.llvm.org/D93923) — design rationale lives in review comments
+- Our impl for comparison: `src/builtin/das_qsort_r.h:159-220` (das_qsort_r) + `src/builtin/das_qsort_r.h:` (das_sort\<T\>, added 2026-05-17)
+
+## Questions
+- why is libc++ std::sort 2.5× faster than our das_qsort_r pdqsort-lite on workhorse types at N=100K?

--- a/mouse-data/docs/qsort-byte-swap-implementations-survey.md
+++ b/mouse-data/docs/qsort-byte-swap-implementations-survey.md
@@ -1,0 +1,34 @@
+---
+slug: qsort-byte-swap-implementations-survey
+title: What byte-swap strategies do production qsorts use for arbitrary-width element exchange?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+Four canonical families across libc/kernel implementations:
+
+**1. Word-at-a-time temp swap (Linux kernel, glibc).** Linux `lib/sort.c` and glibc `stdlib/qsort.c` both classify (size, alignment) once at qsort entry — `is_aligned(base, size, 8)` → `SWAP_WORDS_64`, `is_aligned(base, size, 4)` → `SWAP_WORDS_32`, else `SWAP_BYTES`. Dispatcher is a 3-way `if`, NOT an indirect call (glibc comment: "should help the branch predictor"). Each variant is a tiny do-while: `do { T t = *(T*)(a+(n-=k)); *(T*)(a+n) = *(T*)(b+n); *(T*)(b+n) = t; } while (n);` — no buffer, in-place, compiler vectorizes the loop body.
+
+**2. Bentley-McIlroy "Engineering a Sort Function" (1993).** Same idea but older: `SWAPINIT` computes `swaptype = (a-(char*)0 | es) % sizeof(long) ? 2 : es > sizeof(long)`; `swaptype==0` means single-long inline exch (no call), `==1` means word-loop call, `==2` means byte-loop call. The single-long fast path inlined at the call site is the key trick — most sorts are 8-byte keys.
+
+**3. memcpy 3-way with stack buffer (musl smoothsort `cycle()`).** `char tmp[256]; while (width) { l = min(256, width); memcpy(ar[n], ar[0], l); for (i..n) { memcpy(ar[i], ar[i+1], l); ar[i] += l; } width -= l; }`. Chunked at 256 bytes — small enough to fit L1, large enough to amortize memcpy overhead. Generalizes to n-cycle rotations (smoothsort's trinkle/sift needs this).
+
+**4. Byte-by-byte only (FreeBSD).** `do { t = *a; *a++ = *b; *b++ = t; } while (--es > 0);` — no dispatch, no optimization. Simpler, but slow for anything >4 bytes. FreeBSD dropped Bentley-McIlroy's swaptype dispatch.
+
+**Specialized fast paths.** All four production implementations (except FreeBSD) special-case the common width=8/16 case. Linux kernel via SWAP_WORDS_64 + do-while-unrollable, glibc same, B-M via swaptype==0 inline single-long exchange.
+
+**pdqsort is C++-templated** — `std::iter_swap` on typed iterators, no byte primitive. Not applicable to byte-pointer ports.
+
+**Bake-off candidates worth measuring:**
+- Linux kernel SWAP_WORDS_64 (predicted winner for ≤64B aligned)
+- Bentley-McIlroy single-long fast-path + word-loop fallback
+- Current memcpy chunked-256 baseline
+- memcpy 3-way unchunked with sized stack buffer (single memcpy per direction, no loop)
+- Inline `__builtin_memcpy(a,b,W)` with width as compile-time constant via switch on common widths (4/8/16/32) — compiler emits direct SIMD load/store
+
+Reference impls quoted at: torvalds/linux lib/sort.c, bminor/glibc stdlib/qsort.c, musl src/stdlib/qsort.c, cs.dartmouth.edu/~doug/qsort.c (B-M), freebsd-src lib/libc/stdlib/qsort.c.</body>
+</invoke>
+
+## Questions
+- What byte-swap strategies do production qsorts use for arbitrary-width element exchange?

--- a/mouse-data/docs/sphinx-w-fails-on-my-pr-branch-with-undefined-label-struct-module-x-but-master-ci-is-green-what-causes-this-hash-order-flip-and.md
+++ b/mouse-data/docs/sphinx-w-fails-on-my-pr-branch-with-undefined-label-struct-module-x-but-master-ci-is-green-what-causes-this-hash-order-flip-and.md
@@ -1,0 +1,38 @@
+---
+slug: sphinx-w-fails-on-my-pr-branch-with-undefined-label-struct-module-x-but-master-ci-is-green-what-causes-this-hash-order-flip-and
+title: Sphinx -W fails on my PR branch with "undefined label: 'struct-MODULE-X'" but master CI is green — what causes this hash-order flip and how do I fix it?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**Symptom:** CI doc workflow's `sphinx-build -W` fails on your branch only. Error: `doc/source/stdlib/generated/MODULE.rst:N: WARNING: undefined label: 'struct-MODULE-StructName'`. Master CI is green for the exact same `daslib/*.das` source.
+
+**Diagnosis:** `doc/reflections/das2rst.das` emits the **full** RST detail (description + `:Arguments:` block with `:ref:` to param types) only for the **first** function of a same-named overload group; the rest get a stub `.. das:function::` label + signature only. The iteration order over functions is **hash-bucket-dependent** — binary layout changes (new templates, added install paths, anything that shifts pointer/address-based hashing) can flip which overload wins the "first detailed" slot.
+
+If the winning overload references a **private struct** as a parameter type, das2rst still emits `:ref:`StructName <struct-MODULE-StructName>``, but the struct label is never defined (das2rst only emits Structures-section entries for public structs). Sphinx -W then fails with the undefined-label warning.
+
+**Verification pattern:**
+1. Build master's daslang in a worktree (`git worktree add /tmp/repo-master master`)
+2. Run `./bin/daslang doc/reflections/das2rst.das` on each
+3. `diff` the affected `.rst` — if the broken `:ref:` appears in a *different* overload's `:Arguments:` block on master, you've confirmed the order-flip pattern.
+
+**Durable fix:** Mark the struct `public` in the `.das` source. Since the function exposing it is `public`, the struct already needs to be reachable from caller code anyway — the private qualifier was the latent bug. Example from `daslib/quote.das` (PR #2707):
+```das
+struct public CaptureEntryInitData {
+    //! Initialization data for a captured variable entry.
+    name : string       //! Variable name being captured.
+    mode : CaptureMode  //! Capture mode (copy, reference, move, or clone).
+}
+```
+
+**Caveat — public structs need per-field `//!` docstrings.** Otherwise `daslang doc/reflections/das2rst.das` PANICs with `"... has less documentation than values. Expected at least N lines, got 1"`. The struct's main `//!` + one `//!` per field is the convention (see `LineInfoInitData` in `daslib/quote.das`).
+
+**Don't:** Add a handmade RST stub under `doc/source/stdlib/handmade/` for the struct — handmade files are only consulted for C++ builtin modules. For daslang modules das2rst regenerates from the source.
+
+**Reference:** PR #2707, commit `dd9b250ca`; my added template instantiations in `include/daScript/simulate/das_qsort_r.h` shifted hash buckets so `CaptureEntryInitData` won the detailed slot over `LineInfoInitData`.</body>
+<slug>sphinx-w-undefined-label-private-struct-public-fn-hash-order-flip</slug>
+</invoke>
+
+## Questions
+- Sphinx -W fails on my PR branch with "undefined label: 'struct-MODULE-X'" but master CI is green — what causes this hash-order flip and how do I fix it?

--- a/mouse-data/docs/standalone-example-no-daslang-link.md
+++ b/mouse-data/docs/standalone-example-no-daslang-link.md
@@ -1,0 +1,73 @@
+---
+slug: standalone-example-no-daslang-link
+title: how do I add a fully standalone benchmark or example under /examples that does not link the daslang runtime (header-only consumer)?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+# Standalone example under /examples (no daslang runtime link)
+
+The conventional pattern in /examples (crash, pathTracer, etc.) is to register the example in the **root** `CMakeLists.txt` via `include(examples/<name>/CMakeLists.txt)` (around line 1132). That style **requires** linking `libDaScriptDyn`, runs as part of the main DAS.sln build, and gets rebuilt with everything else.
+
+If your example only consumes a header (e.g. `src/builtin/das_qsort_r.h` — the smoothsort + introselect + heap-on-byte-buffer templates), **don't register it in the root CMakeLists**. Make it fully standalone instead. Build it on its own without rebuilding the daslang world.
+
+## Layout
+
+```
+examples/<name>/
+  CMakeLists.txt           # standalone — no parent include
+  bench_<thing>.cpp        # includes "<header_name>.h" only
+```
+
+## CMakeLists.txt template
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(example_<name> CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+endif()
+
+add_executable(example_<name> bench_<thing>.cpp)
+target_include_directories(example_<name> PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/builtin)
+
+if(MSVC)
+    target_compile_options(example_<name> PRIVATE /O2 /W4)
+else()
+    target_compile_options(example_<name> PRIVATE -O3 -Wall -Wextra)
+endif()
+```
+
+## Build + run
+
+```sh
+cmake -S examples/<name> -B build/example_<name> -DCMAKE_BUILD_TYPE=Release
+cmake --build build/example_<name> -j 64
+./build/example_<name>/example_<name>
+```
+
+Build time: a few seconds. No daslang dependency.
+
+## When to use
+
+- Header-only consumers — your example needs `das_qsort_r.h` or another self-contained header but no `Context`, `Program`, `Module`, etc.
+- One-off perf comparisons / regression baselines that should NOT slow down the main daslang build by being part of it.
+- Demos of standalone components that should remain compilable without the full daslang toolchain.
+
+## When NOT to use
+
+If your example needs to run a daslang script, create a `Module`, or call into the simulate/runtime — use the **registered** pattern instead (root `CMakeLists.txt` include + `TARGET_LINK_LIBRARIES libDaScriptDyn`). See `examples/crash/CMakeLists.txt` for the canonical registered example.
+
+## Concrete reference
+
+`examples/sort/` (added 2026-05-17 in PR #2706 follow-up branch) — standalone perf benchmark comparing std::sort/std::partial_sort/std::nth_element/std::make_heap+pop_heap against the das_*_r templates in das_qsort_r.h, no daslang link, ~16s end-to-end on M-series Mac.
+
+## Questions
+- how do I add a fully standalone benchmark or example under /examples that does not link the daslang runtime (header-only consumer)?

--- a/mouse-data/docs/what-ci-checks-must-pass-when-i-regenerate-doc-source-stdlib-via-das2rst-das.md
+++ b/mouse-data/docs/what-ci-checks-must-pass-when-i-regenerate-doc-source-stdlib-via-das2rst-das.md
@@ -1,0 +1,35 @@
+---
+slug: what-ci-checks-must-pass-when-i-regenerate-doc-source-stdlib-via-das2rst-das
+title: What CI checks must pass when I regenerate doc/source/stdlib/ via das2rst.das?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+CI workflow `.github/workflows/doc.yml` runs three sequential gates after `./bin/daslang doc/reflections/das2rst.das`:
+
+1. **`// stub` check** — `grep -rl '// stub' doc/source/stdlib/handmade/` must return nothing. das2rst writes `// stub` placeholders for any public function/struct/enum without a handmade description.
+
+2. **Untracked-files check** — `git ls-files --others --exclude-standard doc/source/stdlib/` must be empty. Newly-generated RST files must be committed.
+
+3. **`sphinx-build -W --keep-going -b latex`** — warnings-as-errors LaTeX build. Catches dangling `:ref:`s, malformed tables, duplicate labels.
+
+**Local workflow before pushing:**
+```bash
+./bin/daslang doc/reflections/das2rst.das
+grep -rl "// stub" doc/source/stdlib/handmade/   # must be empty
+git add doc/source/stdlib/handmade/              # if new files appeared
+~/Library/Python/3.11/bin/sphinx-build -W -b latex -d doc/sphinx-build doc/source /tmp/site_doc   # must exit 0
+```
+
+**Gotchas:**
+- For **daslang modules** (`daslib/*.das`, `modules/*/*.das`): fix stubs by adding `//!` comments in the `.das` source — handmade files for daslang modules are ignored. See `skills/documentation_rst.md`.
+- For **C++ builtin modules** (math, strings, audio, etc.): fix stubs by editing `doc/source/stdlib/handmade/*.rst` directly.
+- When bulk-filling many stubs by copying from siblings (e.g. when a binary layout change shifts function hash buckets and regenerates 158 new RST files), **hand-check math overloads** — vector-specific descriptions may not match the scalar overload, and some library descriptions are technically wrong (e.g. `mad` is *not* always fused FMA; `round` halfway behavior is *not* nearest-even on the vector path).
+
+Reference: PR #2707 round 3 — `mad` and `round` doc fixes after Copilot caught the incorrect inherited descriptions.</body>
+<slug>ci-doc-workflow-gates-stubs-untracked-sphinx-w</slug>
+</invoke>
+
+## Questions
+- What CI checks must pass when I regenerate doc/source/stdlib/ via das2rst.das?

--- a/mouse-data/docs/what-daslib-operations-exist-for-partial-sort-nth-element-heap-ops-and-top-n-selection.md
+++ b/mouse-data/docs/what-daslib-operations-exist-for-partial-sort-nth-element-heap-ops-and-top-n-selection.md
@@ -1,0 +1,39 @@
+---
+slug: what-daslib-operations-exist-for-partial-sort-nth-element-heap-ops-and-top-n-selection
+title: What daslib operations exist for partial-sort, nth-element, heap ops, and top-N selection?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+Phase 0 of the linq_fold project (PR landing 2026-05-17) added the `<algorithm>` sort-family bindings. Operations now available:
+
+**Sort-family (`require daslib/sort_boost`)** — array form, with and without custom comparator block:
+- `partial_sort(arr, n[, cmp])` — sorts only the first N elements ascending. `O(M log N)` via `std::partial_sort` (typed) or `das_partial_sort_r` (any-cblock path for user structs).
+- `nth_element(arr, n[, cmp])` — places the kth-smallest at position k; left ≤ kth ≤ right. Sub-O(M) overall.
+- `make_heap(arr[, cmp])` / `push_heap(arr[, cmp])` / `pop_heap(arr[, cmp])` — binary max-heap on contiguous storage. `push_heap` assumes the new element was just appended; `pop_heap` moves max to last slot for caller to drop.
+
+**Top-N selection (`require daslib/linq`)** — array + iterator sources:
+- `top_n(src, n)` — N smallest by `<`.
+- `top_n_by(src, n, key)` — N smallest by `key(element)`.
+- Array source uses `partial_sort` under the hood (O(M log N), single allocation).
+- Iterator source uses a bounded heap of size N during the scan (O(M log N), max N+1 elements resident).
+
+**Dispatcher macros (`require daslib/sort_boost`)** — mirror `qsort` for the full surface:
+- `qpartial_sort(value, n, block)`, `qnth_element(value, n, block)`, `qmake_heap(value, block)`, `qpush_heap(value, block)`, `qpop_heap(value, block)`. Each dispatches to the named user-facing function for `array<T>` / dim, or wraps in `temp_array(...)` for handled vector types.
+
+**C++ binding shape** — all 5 ops follow the existing `__builtin_sort` template registered across 19 workhorse types (numeric + vector). Generic user-struct path goes through `das_qsort_r.h` byte-pointer templates (introselect for partial_sort/nth_element; standard sift-up/sift-down for heap ops).
+
+**Out of Phase 0:** dim (`[]`) overloads are not provided for the daslib wrappers — use array form or call `__builtin_*` directly. Buffer-required emit modes in linq_fold (BufferTopN, BufferDistinct, etc.) that consume these primitives land in subsequent PRs (Phase 3+).
+
+**Critical files:**
+- `daslib/sort_boost.das:60-` — user-facing wrappers + q-prefix macros
+- `daslib/linq.das:460-510` — `top_n` / `top_n_by` family
+- `src/builtin/das_qsort_r.h:233-` — algorithm templates
+- `include/daScript/simulate/aot.h:3390-` — cblock template surface
+- `src/builtin/module_builtin_runtime_sort.cpp` — bindings + any-cblock wrappers
+
+Project plan: `~/.claude/plans/merry-dazzling-curry.md`. Project context: `benchmarks/sql/LINQ.md`.
+
+## Questions
+- What daslib operations exist for partial-sort, nth-element, heap ops, and top-N selection?

--- a/mouse-data/docs/what-s-the-right-anti-dce-pattern-for-a-c-microbenchmark-inner-loop-so-the-optimizer-can-t-elide-it.md
+++ b/mouse-data/docs/what-s-the-right-anti-dce-pattern-for-a-c-microbenchmark-inner-loop-so-the-optimizer-can-t-elide-it.md
@@ -1,0 +1,41 @@
+---
+slug: what-s-the-right-anti-dce-pattern-for-a-c-microbenchmark-inner-loop-so-the-optimizer-can-t-elide-it
+title: What's the right anti-DCE pattern for a C++ microbenchmark inner loop so the optimizer can't elide it?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**Pattern:** after the timer stops, take a `volatile` observation of post-loop state. The volatile load forces the compiler to materialize the value, which transitively forces the timed loop body to have an observed effect.
+
+```cpp
+auto t0 = clk::now();
+for (int it = 0; it < iters; it++) {
+    for (size_t p = 0; p < pairs; p++) {
+        fn(data.data() + (2*p) * width, data.data() + (2*p + 1) * width, width);
+    }
+}
+auto t1 = clk::now();
+// Anti-DCE: force a volatile observation of post-loop data so the optimizer
+// can't prove the loop is dead.
+volatile unsigned char observed = data.back();
+(void)observed;
+```
+
+**Anti-pattern (broken):** comparing against a value the type can never hold.
+```cpp
+if (data.back() == 0xDEAD) std::fprintf(stderr, "%d", int(data[0]));
+```
+`data.back()` is `unsigned char` (0–255) and can never equal `0xDEAD` (57005). The optimizer constant-folds the condition to `false`, eliminates the if-branch, then has no post-loop observation of `data`, so the entire timed loop can be DCE'd. Benchmark reports unrealistically low times.
+
+**Other valid patterns:**
+- `asm volatile("" : : "r"(data.data()) : "memory")` — compiler fence + memory clobber (Google benchmark's `DoNotOptimize`/`ClobberMemory` use this)
+- `std::cerr << uint64_t(data[0]) << "\n";` — actual I/O, but adds latency
+- The `volatile unsigned char` load is the cheapest portable form
+
+Reference: PR #2707 round 3 — Copilot caught the `0xDEAD` bug in `examples/sort/bench_byte_swap.cpp`. Commit `a11a3d79e`.</body>
+<slug>anti-dce-bench-pattern-volatile-post-loop-observation</slug>
+</invoke>
+
+## Questions
+- What's the right anti-DCE pattern for a C++ microbenchmark inner loop so the optimizer can't elide it?

--- a/mouse-data/docs/where-are-the-cross-compiler-bit-scan-and-popcount-helpers-in-daslang-s-c-headers.md
+++ b/mouse-data/docs/where-are-the-cross-compiler-bit-scan-and-popcount-helpers-in-daslang-s-c-headers.md
@@ -1,0 +1,25 @@
+---
+slug: where-are-the-cross-compiler-bit-scan-and-popcount-helpers-in-daslang-s-c-headers
+title: Where are the cross-compiler bit-scan and popcount helpers in daslang's C++ headers?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**`include/daScript/misc/platform.h:149-211`** — daslang's cross-compiler primitives. On MSVC they wrap `_BitScanForward64` / `_BitScanReverse64` / `__popcnt64` (with explicit branches for x86-32 and ARM64); on GCC/Clang they are `#define`s to the `__builtin_*` intrinsics.
+
+Helpers:
+- `das_clz(uint32_t)` / `das_clz64(uint64_t)` — leading-zero count (same return as `__builtin_clzll`)
+- `das_ctz(uint32_t)` / `das_ctz64(uint64_t)` — trailing-zero count (same return as `__builtin_ctzll`)
+- `das_popcount(uint32_t)` / `das_popcount64(uint64_t)` — population count
+
+**Rule:** before writing any `#ifdef _MSC_VER` shim for `__builtin_ctzll` / `__builtin_clzll` / `__popcnt64`, **search `include/daScript/misc/platform.h` first**. This was the cause of PR #2707 CI failure round 2 — I wrote `__builtin_ctzll` directly in a new public header and MSVC choked. Fix was `#include "daScript/misc/platform.h"` + replace `__builtin_ctzll(x)` → `int(das_ctz64(x))` and `63 - __builtin_clzll(x)` → `int(63 - das_clz64(x))`.
+
+**Same energy for SIMD/vector intrinsics:** check `include/vecmath/dag_vecMath_*.h` for hand-tuned wrappers before rolling your own.
+
+Reference: PR #2707, commit `e69210c69`. Boris's standing rule (`feedback_cross_compiler_helpers_first.md`): always search before writing `#ifdef _MSC_VER` shims.</body>
+<slug>cross-compiler-bitscan-popcount-helpers-daScript-misc-platform-h</slug>
+</invoke>
+
+## Questions
+- Where are the cross-compiler bit-scan and popcount helpers in daslang's C++ headers?

--- a/mouse-data/docs/why-does-a-new-top-level-html-page-e-g-daspkg-html-added-under-site-404-on-daslang-io-after-merging-to-master.md
+++ b/mouse-data/docs/why-does-a-new-top-level-html-page-e-g-daspkg-html-added-under-site-404-on-daslang-io-after-merging-to-master.md
@@ -1,0 +1,31 @@
+---
+slug: why-does-a-new-top-level-html-page-e-g-daspkg-html-added-under-site-404-on-daslang-io-after-merging-to-master
+title: Why does a new top-level HTML page (e.g. /daspkg.html) added under site/ 404 on daslang.io after merging to master?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+The Pages deploy workflow (`.github/workflows/pages.yml`, "Stage site for deployment" step) stages root-level HTML via an **explicit allowlist**, not a glob:
+
+```yaml
+cp site/index.html _site/
+cp site/downloads.html _site/
+cp site/daspkg.html _site/      # add a new line per new top-level page
+cp site/robots.txt _site/
+cp -r site/files _site/files
+```
+
+Only `index.html`, `downloads.html`, `daspkg.html`, `robots.txt`, and `files/` are explicitly copied. Subdirectories with their own staging (`build/site` → `/doc`, `web/output/*` → `/playground`, `_news/` + `blog/_posts/` → blog via `build_blog.py`) are independent of this allowlist.
+
+**Failure mode**: add `site/foo.html` to a commit, merge to master, watch /foo.html return 404 indefinitely because no `cp site/foo.html _site/` line was added. The page sits in the repo but never reaches `_site/`, and since `actions/deploy-pages` publishes `_site` as a complete snapshot ([[github-pages-deploy-pages-publishes-snapshot-not-overlay]]) there's no carryover from a prior deploy either.
+
+**Fix**: edit pages.yml, add the `cp site/<name>.html _site/` line, commit. Re-running the workflow without the edit will not help — the cp list is the source of truth.
+
+**Diagnose with**: `grep "cp site/" .github/workflows/pages.yml` shows the current allowlist.
+
+The 2026-05-17 daspkg page (PR #2703, commit 281ac2e28) shipped without this line and 404'd in production until the workflow was patched.</body>
+<parameter name="slug">pages-yml-explicit-cp-allowlist-new-html-needs-line
+
+## Questions
+- Why does a new top-level HTML page (e.g. /daspkg.html) added under site/ 404 on daslang.io after merging to master?


### PR DESCRIPTION
## Summary

Adds 11 blind-mouse Q&A cards to `mouse-data/docs/` capturing findings from recent sessions so future sessions answer them in 1 ask instead of re-researching.

**PR #2707 sort-family bake-off (8 cards):**
- `byte-swap-micro-win-invisible-under-cblock-dominance` — why byte-swap micro-bench wins are hidden under daslang cblock comparator cost
- `das-qsort-r-vs-std-perf-comparison` — perf table reference
- `libcxx-stdsort-block-partition-pdqsort` — algorithm survey (Edelkamp/Weiß BlockQuicksort, Kutenin D93923)
- `qsort-byte-swap-implementations-survey` — survey of swap variants (chunked / words64 / sized / hybrid)
- `standalone-example-no-daslang-link` — pattern for `examples/<X>/` standalone benchmarks
- `what-daslib-operations-exist-for-partial-sort-nth-element-heap-ops-and-top-n-selection` — daslib binding inventory
- `what-s-the-right-anti-dce-pattern-for-a-c-microbenchmark-inner-loop-so-the-optimizer-can-t-elide-it` — `volatile observed = data.back()` idiom
- `where-are-the-cross-compiler-bit-scan-and-popcount-helpers-in-daslang-s-c-headers` — `daScript/misc/platform.h:149-211`

**Doc-CI iteration (2 cards):**
- `sphinx-w-fails-on-my-pr-branch-with-undefined-label-struct-module-x-but-master-ci-is-green-...` — das2rst function-emission-order flip + private-struct trap
- `what-ci-checks-must-pass-when-i-regenerate-doc-source-stdlib-via-das2rst-das` — the 3 CI gates (stubs / untracked / sphinx -W)

**Site deploy (1 card):**
- `why-does-a-new-top-level-html-page-e-g-daspkg-html-added-under-site-404-on-daslang-io-after-merging-to-master` — GH Pages deploys a snapshot, not an overlay

## Test plan

- [ ] Cards searchable via `mouse__ask` (BM25 indexed on next rebuild)
- [ ] CI passes (md-only change, should be no-op for build/test gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)