### PR TITLE
doc: clickable daslang.io banner in sphinx sidebar

### DIFF
--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,0 +1,32 @@
+{%- extends "!layout.html" %}
+
+{# Override sphinx_rtd_theme's sidebar brand so the logo links to the
+   daslang.io home page instead of pathto(_root_doc). Mirrors the upstream
+   block at sphinx_rtd_theme/layout.html sidebartitle, with the <a href>
+   swapped. Keep this file in sync with upstream when bumping the theme. #}
+
+{%- block sidebartitle %}
+
+  {%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
+  <a href="https://daslang.io"{% if not theme_logo_only %} class="icon icon-home"{% endif %}>
+    {% if not theme_logo_only %}{{ project }}{% endif %}
+    {%- if logo or logo_url %}
+      <img src="{{ _logo_url }}" class="logo" alt="{{ _('Logo') }}"/>
+    {%- endif %}
+  </a>
+
+  {%- if theme_display_version %}
+    {%- set nav_version = version %}
+    {%- if READTHEDOCS and current_version %}
+      {%- set nav_version = current_version %}
+    {%- endif %}
+    {%- if nav_version %}
+      <div class="version">
+        {{ nav_version }}
+      </div>
+    {%- endif %}
+  {%- endif %}
+
+  {%- include "searchbox.html" %}
+
+{%- endblock %}


### PR DESCRIPTION
## Summary

The orange `> daslang.io 0.6.2` logo at the top-left of [daslang.io/doc/](https://daslang.io/doc/index.html) currently links to `pathto(_root_doc)` — i.e., on the docs index it's a self-link (visible but dead). Users who land in `/doc/` and want to get back to the main daslang.io site have no clickable affordance on the sidebar.

This PR overrides `sphinx_rtd_theme`'s `sidebartitle` Jinja block in a local `_templates/layout.html`, swapping the `<a href>` to `https://daslang.io`. Mirrors the upstream block at `sphinx_rtd_theme/layout.html` with that single line changed; no theme fork, no other behavior changes.

`templates_path = ['_templates']` is already declared at [doc/source/conf.py:38](https://github.com/GaijinEntertainment/daScript/blob/master/doc/source/conf.py#L38) — only the new file is needed.

Companion PR adds the same banner to dasImgui's docs (`borisbat/dasImgui` — currently has no banner at all).

## Test plan

- [x] `sphinx-build -b html doc/source doc/_build_check` succeeds locally (warnings are pre-existing missing-`stdlib/generated/*` toctree refs, unrelated to this PR)
- [x] Rendered `index.html` sidebar contains `<a href="https://daslang.io" class="icon icon-home">` wrapping `_static/forge-logo.svg` on `#0d0c0a` background
- [ ] CI builds the docs without new warnings
- [ ] Manual: click the sidebar logo in the deployed docs and confirm it navigates to https://daslang.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)