### PR TITLE
daslib/rst: deterministic overload sort tiebreak (unblocks dasImgui doc CI)

### DIFF
--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -1879,7 +1879,7 @@ def document_functions(doc_file : file; mods : array<Module?>; var groups : arra
                 if (grp.hidden) {
                     document_warning(doc_file, "This group of functions is hidden. It will not be in the final documentation.")
                 }
-                grp.func |> sort($(a, b) => function_name(a.fn) < function_name(b.fn))
+                grp.func |> sort($(a, b) => rst_describe_function_short(a.fn) < rst_describe_function_short(b.fn))
                 for (func in grp.func) {
                     if (!key_exists(tab, func.fn)) {
                         let descr = rst_describe_function_short(func.fn)

--- a/doc/source/stdlib/handmade/function-ast-add_block_annotation-0xe2c30f4c26f7256d.rst
+++ b/doc/source/stdlib/handmade/function-ast-add_block_annotation-0xe2c30f4c26f7256d.rst
@@ -1,0 +1,1 @@
+Attaches an annotation to an expression block and calls the annotation's ``apply`` method.

--- a/doc/source/stdlib/handmade/function-ast-add_function_annotation-0x3168617e90c60bf4.rst
+++ b/doc/source/stdlib/handmade/function-ast-add_function_annotation-0x3168617e90c60bf4.rst
@@ -1,0 +1,1 @@
+Attaches a function annotation to a function and calls the annotation's ``apply`` method.

--- a/doc/source/stdlib/handmade/function-ast-add_structure_annotation-0xcb281ad07b7d69b7.rst
+++ b/doc/source/stdlib/handmade/function-ast-add_structure_annotation-0xcb281ad07b7d69b7.rst
@@ -1,0 +1,1 @@
+Attaches a structure annotation to the specified module. The annotation is moved from the provided smart pointer.

--- a/doc/source/stdlib/handmade/function-ast-for_each_generic-0x65b9a789781d266.rst
+++ b/doc/source/stdlib/handmade/function-ast-for_each_generic-0x65b9a789781d266.rst
@@ -1,0 +1,1 @@
+Iterates through each generic function in the given module.

--- a/doc/source/stdlib/handmade/function-ast-make_visitor-0x1063140cba10265f.rst
+++ b/doc/source/stdlib/handmade/function-ast-make_visitor-0x1063140cba10265f.rst
@@ -1,0 +1,1 @@
+Creates an adapter for the AstVisitor interface.

--- a/doc/source/stdlib/handmade/function-ast-visit-0x9717f9b46ea50aef.rst
+++ b/doc/source/stdlib/handmade/function-ast-visit-0x9717f9b46ea50aef.rst
@@ -1,0 +1,1 @@
+Invokes an AST visitor on the given object.

--- a/doc/source/stdlib/handmade/function-ast_boost-add_annotation_argument-0x51c8a49842980915.rst
+++ b/doc/source/stdlib/handmade/function-ast_boost-add_annotation_argument-0x51c8a49842980915.rst
@@ -1,0 +1,1 @@
+Adds a typed annotation argument (``bool``, ``int``, ``float``, ``string``, or ``AnnotationArgument``) to an ``AnnotationArgumentList`` and returns the new argument index.

--- a/doc/source/stdlib/handmade/function-ast_boost-append_annotation-0xf9e82b1cfd06dde8.rst
+++ b/doc/source/stdlib/handmade/function-ast_boost-append_annotation-0xf9e82b1cfd06dde8.rst
@@ -1,0 +1,1 @@
+Creates an ``AnnotationDeclaration`` for the named annotation (with optional typed arguments) and attaches it to a ``Function``, ``ExprBlock``, or ``Structure``.

--- a/doc/source/stdlib/handmade/function-ast_boost-convert_to_expression-0x440771f18187d2d6.rst
+++ b/doc/source/stdlib/handmade/function-ast_boost-convert_to_expression-0x440771f18187d2d6.rst
@@ -1,0 +1,1 @@
+Converts a runtime value of any supported type to an equivalent AST ``ExpressionPtr`` that would produce that value when compiled, using ``typeinfo`` for reflection.

--- a/doc/source/stdlib/handmade/function-ast_boost-emplace_new-0xfecbf5e79f9ef529.rst
+++ b/doc/source/stdlib/handmade/function-ast_boost-emplace_new-0xfecbf5e79f9ef529.rst
@@ -1,0 +1,1 @@
+Moves a newly created pointer (Expression, TypeDecl, Variable, or MakeFieldDecl) into a vector container.

--- a/doc/source/stdlib/handmade/function-ast_boost-get_for_source_index-0x9d18bc04187fa6df.rst
+++ b/doc/source/stdlib/handmade/function-ast_boost-get_for_source_index-0x9d18bc04187fa6df.rst
@@ -1,0 +1,1 @@
+Returns the zero-based index of a given iterator variable or source expression within a ``for`` loop's source list, or ``-1`` if not found.

--- a/doc/source/stdlib/handmade/function-builtin-emplace-0xbe9c028b6703e2eb.rst
+++ b/doc/source/stdlib/handmade/function-builtin-emplace-0xbe9c028b6703e2eb.rst
@@ -1,0 +1,1 @@
+Moves `value` into the dynamic array `Arr` using move semantics, appending it to the end.

--- a/doc/source/stdlib/handmade/function-builtin-empty-0x81cd7e89966250aa.rst
+++ b/doc/source/stdlib/handmade/function-builtin-empty-0x81cd7e89966250aa.rst
@@ -1,0 +1,1 @@
+Checks whether the array `a` has no elements and returns `true` if so.

--- a/doc/source/stdlib/handmade/function-builtin-fmt-0xa58dca1a4b31543f.rst
+++ b/doc/source/stdlib/handmade/function-builtin-fmt-0xa58dca1a4b31543f.rst
@@ -1,0 +1,1 @@
+Formats a `double` value as a string using the given `format` specifier (following libfmt / C++20 `std::format` syntax).

--- a/doc/source/stdlib/handmade/function-builtin-get_value-0xebee648e7bc16375.rst
+++ b/doc/source/stdlib/handmade/function-builtin-get_value-0xebee648e7bc16375.rst
@@ -1,0 +1,1 @@
+Retrieves the value associated with key `at` from the table `Tab`.

--- a/doc/source/stdlib/handmade/function-builtin-insert-0x78b40fd27b8e0342.rst
+++ b/doc/source/stdlib/handmade/function-builtin-insert-0x78b40fd27b8e0342.rst
@@ -1,0 +1,1 @@
+Inserts the value `val` into the table `Tab` under key `at`. If the key already exists, its value is replaced.

--- a/doc/source/stdlib/handmade/function-builtin-interval-0xa989f7317c978450.rst
+++ b/doc/source/stdlib/handmade/function-builtin-interval-0xa989f7317c978450.rst
@@ -1,0 +1,1 @@
+Constructs a `range64` value from the two `int64` endpoints `arg0` (inclusive) and `arg1` (exclusive).

--- a/doc/source/stdlib/handmade/function-builtin-move-0xeb90a6e787315d09.rst
+++ b/doc/source/stdlib/handmade/function-builtin-move-0xeb90a6e787315d09.rst
@@ -1,0 +1,1 @@
+Moves the smart pointer `src` into the smart pointer `dest`, nullifying the previous contents of `dest` and transferring ownership from `src`.

--- a/doc/source/stdlib/handmade/function-builtin-push-0x58b9f3c4ef6a2595.rst
+++ b/doc/source/stdlib/handmade/function-builtin-push-0x58b9f3c4ef6a2595.rst
@@ -1,0 +1,1 @@
+Appends a constant `value` to the end of dynamic array `Arr`, copying it into place.

--- a/doc/source/stdlib/handmade/function-builtin-resize_and_init-0x7417623711ee1885.rst
+++ b/doc/source/stdlib/handmade/function-builtin-resize_and_init-0x7417623711ee1885.rst
@@ -1,0 +1,1 @@
+Resizes dynamic array `Arr` to `newSize` elements, default-initializing any newly added elements.

--- a/doc/source/stdlib/handmade/function-builtin-smart_ptr_clone-0xeb12b0981444f24f.rst
+++ b/doc/source/stdlib/handmade/function-builtin-smart_ptr_clone-0xeb12b0981444f24f.rst
@@ -1,0 +1,1 @@
+Clones the smart pointer `src` into smart pointer `dest`, incrementing the internal reference count to share ownership.

--- a/doc/source/stdlib/handmade/function-builtin-subarray-0x8f48cc5efedc9022.rst
+++ b/doc/source/stdlib/handmade/function-builtin-subarray-0x8f48cc5efedc9022.rst
@@ -1,0 +1,1 @@
+Returns a temporary sub-range of the dynamic array `a` defined by the signed range `r`, providing access to elements from `r.x` up to but not including `r.y`.

--- a/doc/source/stdlib/handmade/function-builtin-to_array_move-0x3356b325b05e43ff.rst
+++ b/doc/source/stdlib/handmade/function-builtin-to_array_move-0x3356b325b05e43ff.rst
@@ -1,0 +1,1 @@
+Converts a mutable container `a` into a new dynamic array, moving elements when possible instead of cloning.

--- a/doc/source/stdlib/handmade/function-builtin-to_table_move-0xb7fd1c47b782fe2c.rst
+++ b/doc/source/stdlib/handmade/function-builtin-to_table_move-0xb7fd1c47b782fe2c.rst
@@ -1,0 +1,1 @@
+Converts a mutable dynamic array of keys `a` into a set-style `table<keyT, void>`, moving elements when possible.

--- a/doc/source/stdlib/handmade/function-builtin-values-0x937e576d1e8d6fbc.rst
+++ b/doc/source/stdlib/handmade/function-builtin-values-0x937e576d1e8d6fbc.rst
@@ -1,0 +1,1 @@
+Returns a read-only iterator over all values in a `table<keyT, valT>`, yielding each value by const reference.

--- a/doc/source/stdlib/handmade/function-dashv-send-0x33200e5ed86d5a3a.rst
+++ b/doc/source/stdlib/handmade/function-dashv-send-0x33200e5ed86d5a3a.rst
@@ -1,0 +1,1 @@
+Sends a message frame on the WebSocket channel with the given opcode and fin flag. Returns the number of bytes sent, or a negative error code.

--- a/doc/source/stdlib/handmade/function-dashv-set_content_type-0xfa5159e454dba2c3.rst
+++ b/doc/source/stdlib/handmade/function-dashv-set_content_type-0xfa5159e454dba2c3.rst
@@ -1,0 +1,1 @@
+Sets the Content-Type header on a response or request.

--- a/doc/source/stdlib/handmade/function-dashv-set_header-0x5efcaa3c662f240a.rst
+++ b/doc/source/stdlib/handmade/function-dashv-set_header-0x5efcaa3c662f240a.rst
@@ -1,0 +1,1 @@
+Sets a response or request header.

--- a/doc/source/stdlib/handmade/function-debugapi-invoke_debug_agent_function-0x205e5bd497cb5790.rst
+++ b/doc/source/stdlib/handmade/function-debugapi-invoke_debug_agent_function-0x205e5bd497cb5790.rst
@@ -1,0 +1,3 @@
+Calls an ``[export, pinvoke]`` function in the named agent's context.  Similar to ``invoke_in_context`` but resolves the agent context automatically from the category name.
+
+When *category* is an empty string (``""``), the call targets the **thread-local** debug agent's context instead of a globally named one.  There can be only one thread-local agent per thread, so no name is needed.  The thread-local path is faster because it skips the global agent map lookup.

--- a/doc/source/stdlib/handmade/function-debugapi-invoke_debug_agent_method-0x71b1972561138d2e.rst
+++ b/doc/source/stdlib/handmade/function-debugapi-invoke_debug_agent_method-0x71b1972561138d2e.rst
@@ -1,0 +1,3 @@
+Calls a method on the debug agent's class instance by name.  The first argument is the agent category, the second is the method name, followed by up to 10 user arguments.  The agent's ``self`` is passed automatically.
+
+When *category* is an empty string (``""``), the call targets the **thread-local** debug agent instead of a globally named one.  There can be only one thread-local agent per thread — that is why it needs no name.  The thread-local path is faster than a named agent lookup because it skips the global map search.

--- a/doc/source/stdlib/handmade/function-debugapi-invoke_in_context-0xdc8aad5ea68674bf.rst
+++ b/doc/source/stdlib/handmade/function-debugapi-invoke_in_context-0xdc8aad5ea68674bf.rst
@@ -1,0 +1,1 @@
+Calls a function in another context.  Accepts a `Context` reference and either a function name (string), a `function` pointer, or a `lambda`, plus up to 10 extra arguments.  Target functions must be marked `[export, pinvoke]`.

--- a/doc/source/stdlib/handmade/function-debugapi-walk_data-0x53f25f6076d8be37.rst
+++ b/doc/source/stdlib/handmade/function-debugapi-walk_data-0x53f25f6076d8be37.rst
@@ -1,0 +1,1 @@
+Walks a daslang data structure using the provided `DataWalker`.  The walker receives typed callbacks for each value encountered.  Overloaded for raw data+`StructInfo`, `float4`+`TypeInfo`, and `void?`+`TypeInfo`.

--- a/doc/source/stdlib/handmade/function-math-_st_-0x1a3b25fb86b08da8.rst
+++ b/doc/source/stdlib/handmade/function-math-_st_-0x1a3b25fb86b08da8.rst
@@ -1,0 +1,1 @@
+Transforms a float3 vector by a 3x3 matrix.

--- a/doc/source/stdlib/handmade/function-math-_st_-0x2790c7fbc31c1203.rst
+++ b/doc/source/stdlib/handmade/function-math-_st_-0x2790c7fbc31c1203.rst
@@ -1,0 +1,1 @@
+Transforms a float3 vector by a 3x4 matrix.

--- a/doc/source/stdlib/handmade/function-math-abs-0x5506bc2ebabe028b.rst
+++ b/doc/source/stdlib/handmade/function-math-abs-0x5506bc2ebabe028b.rst
@@ -1,0 +1,1 @@
+Returns the absolute value of x, component-wise for vectors and across numeric scalar overloads.

--- a/doc/source/stdlib/handmade/function-math-atan-0x9994f1e77b3f4f88.rst
+++ b/doc/source/stdlib/handmade/function-math-atan-0x9994f1e77b3f4f88.rst
@@ -1,0 +1,1 @@
+Returns the arctangent of x in radians, with the result in the range [-pi/2, pi/2]; works with float and double.

--- a/doc/source/stdlib/handmade/function-math-cbrt-0x7593149c6d2e5615.rst
+++ b/doc/source/stdlib/handmade/function-math-cbrt-0x7593149c6d2e5615.rst
@@ -1,0 +1,1 @@
+Returns the cube root of x, component-wise for float2/float3/float4 vectors, and for float/double scalars.

--- a/doc/source/stdlib/handmade/function-math-ceili-0x600f679ae0f35c90.rst
+++ b/doc/source/stdlib/handmade/function-math-ceili-0x600f679ae0f35c90.rst
@@ -1,0 +1,1 @@
+Returns the smallest integer not less than x (rounds toward positive infinity), converting the double argument to an int result.

--- a/doc/source/stdlib/handmade/function-math-clamp-0xaba45b70a54c7f1d.rst
+++ b/doc/source/stdlib/handmade/function-math-clamp-0xaba45b70a54c7f1d.rst
@@ -1,0 +1,1 @@
+Returns the value t clamped to the inclusive range [a, b], equivalent to min(max(t, a), b); works with float, double, float2, float3, float4, int, int64, uint, and uint64 types.

--- a/doc/source/stdlib/handmade/function-math-determinant-0x2f2e400c66afff50.rst
+++ b/doc/source/stdlib/handmade/function-math-determinant-0x2f2e400c66afff50.rst
@@ -1,0 +1,1 @@
+Returns the determinant of a float3x3 matrix as a float scalar; a zero determinant indicates the matrix is singular and non-invertible.

--- a/doc/source/stdlib/handmade/function-math-floor-0xaba8e1a373b2daa8.rst
+++ b/doc/source/stdlib/handmade/function-math-floor-0xaba8e1a373b2daa8.rst
@@ -1,0 +1,1 @@
+Returns the largest integer value not greater than x, component-wise for vectors, and for float/double scalars.

--- a/doc/source/stdlib/handmade/function-math-fmod-0xeb05d432f9e2311c.rst
+++ b/doc/source/stdlib/handmade/function-math-fmod-0xeb05d432f9e2311c.rst
@@ -1,0 +1,1 @@
+Returns the floating-point remainder of x/y using truncation-style quotient (same sign behavior as %), component-wise for vectors and for float/double scalars.

--- a/doc/source/stdlib/handmade/function-math-fract-0x93c7637c9fbea514.rst
+++ b/doc/source/stdlib/handmade/function-math-fract-0x93c7637c9fbea514.rst
@@ -1,0 +1,1 @@
+Returns the fractional part of x (equivalent to x - floor(x)), computed component-wise for float2, float3, and float4 vector types; works with float and double scalars.

--- a/doc/source/stdlib/handmade/function-math-hypot-0x3c18597c24ef04b3.rst
+++ b/doc/source/stdlib/handmade/function-math-hypot-0x3c18597c24ef04b3.rst
@@ -1,0 +1,1 @@
+Returns sqrt(x*x + y*y), component-wise for float2/float3/float4 vectors, and for float/double scalar pairs.

--- a/doc/source/stdlib/handmade/function-math-identity-0x27b8cfe29c0d489c.rst
+++ b/doc/source/stdlib/handmade/function-math-identity-0x27b8cfe29c0d489c.rst
@@ -1,0 +1,1 @@
+Sets the given float3x3 matrix to the identity transformation and returns it.

--- a/doc/source/stdlib/handmade/function-math-inverse-0x943f3f5747d2ddf4.rst
+++ b/doc/source/stdlib/handmade/function-math-inverse-0x943f3f5747d2ddf4.rst
@@ -1,0 +1,1 @@
+Returns the inverse of a matrix, such that multiplying the original by its inverse yields the identity; works with float3x4 and float4x4 matrix types.

--- a/doc/source/stdlib/handmade/function-math-log-0x2a7616eeac94c1a4.rst
+++ b/doc/source/stdlib/handmade/function-math-log-0x2a7616eeac94c1a4.rst
@@ -1,0 +1,1 @@
+Returns the natural (base-e) logarithm of x; the input must be positive; computed component-wise for float2, float3, and float4 vector types; works with float and double scalars.

--- a/doc/source/stdlib/handmade/function-math-mad-0x4617460ed0b8e334.rst
+++ b/doc/source/stdlib/handmade/function-math-mad-0x4617460ed0b8e334.rst
@@ -1,0 +1,1 @@
+Computes the multiply-add operation `a * b + c`.

--- a/doc/source/stdlib/handmade/function-math-max-0x1f58b63cd00ad9d0.rst
+++ b/doc/source/stdlib/handmade/function-math-max-0x1f58b63cd00ad9d0.rst
@@ -1,0 +1,1 @@
+Returns the component-wise maximum of two values, supporting scalar double, float, int, int64, uint, uint64 and vector float2, float3, float4 types.

--- a/doc/source/stdlib/handmade/function-math-min-0x8599dae683caac62.rst
+++ b/doc/source/stdlib/handmade/function-math-min-0x8599dae683caac62.rst
@@ -1,0 +1,1 @@
+Returns the component-wise minimum of two values, supporting scalar double, float, int, int64, uint, uint64 and vector float2, float3, float4 types.

--- a/doc/source/stdlib/handmade/function-math-rcp_est-0x1e22c587fb16fb45.rst
+++ b/doc/source/stdlib/handmade/function-math-rcp_est-0x1e22c587fb16fb45.rst
@@ -1,0 +1,1 @@
+Returns a fast hardware estimate of the reciprocal (1/x) of a scalar float or each component of a float2, float3, or float4 vector, trading precision for speed.

--- a/doc/source/stdlib/handmade/function-math-reflect-0x755a9e9909bee6a6.rst
+++ b/doc/source/stdlib/handmade/function-math-reflect-0x755a9e9909bee6a6.rst
@@ -1,0 +1,1 @@
+Computes the reflection of float2 or float3 vector v off a surface with unit normal n, returning the reflected vector as v - 2*dot(v,n)*n.

--- a/doc/source/stdlib/handmade/function-math-round-0xfddb15b26124db4c.rst
+++ b/doc/source/stdlib/handmade/function-math-round-0xfddb15b26124db4c.rst
@@ -1,0 +1,1 @@
+Returns the rounded value of x to the nearest integer; works with float and double scalars.

--- a/doc/source/stdlib/handmade/function-math-sincos-0x48b7fded0f1787cd.rst
+++ b/doc/source/stdlib/handmade/function-math-sincos-0x48b7fded0f1787cd.rst
@@ -1,0 +1,1 @@
+Computes both the sine and cosine of the angle x in radians simultaneously, writing the results to output parameters s and c, for float or double types.

--- a/doc/source/stdlib/handmade/function-math-sinh-0x67b31be9c4d427b9.rst
+++ b/doc/source/stdlib/handmade/function-math-sinh-0x67b31be9c4d427b9.rst
@@ -1,0 +1,1 @@
+Returns the hyperbolic sine of x, component-wise for float2/float3/float4 vectors, and for float/double scalars.

--- a/doc/source/stdlib/handmade/function-math-tanh-0x8bf46ddc3c3172a8.rst
+++ b/doc/source/stdlib/handmade/function-math-tanh-0x8bf46ddc3c3172a8.rst
@@ -1,0 +1,1 @@
+Returns the hyperbolic tangent of x, component-wise for float2/float3/float4 vectors, and for float/double scalars.

--- a/doc/source/stdlib/handmade/function-math-trunc-0x666600df9d093e85.rst
+++ b/doc/source/stdlib/handmade/function-math-trunc-0x666600df9d093e85.rst
@@ -1,0 +1,1 @@
+Rounds x toward zero, component-wise for float2/float3/float4 vectors, and for float/double scalars.

--- a/doc/source/stdlib/handmade/function-pugixml-find_child_by_attribute-0xdd586a0c75566b58.rst
+++ b/doc/source/stdlib/handmade/function-pugixml-find_child_by_attribute-0xdd586a0c75566b58.rst
@@ -1,0 +1,1 @@
+Finds the first child element that has an attribute matching the given name and value.

--- a/doc/source/stdlib/handmade/function-pugixml-set-0x9e72baf4bbac288c.rst
+++ b/doc/source/stdlib/handmade/function-pugixml-set-0x9e72baf4bbac288c.rst
@@ -1,0 +1,1 @@
+Sets the text content or XPath variable value. Multiple overloads accept string, int, uint, float, double, bool, int64, uint64.

--- a/doc/source/stdlib/handmade/function-pugixml-set_name-0xf7648c2c8868fd9.rst
+++ b/doc/source/stdlib/handmade/function-pugixml-set_name-0xf7648c2c8868fd9.rst
@@ -1,0 +1,1 @@
+Changes the name (tag) of the node or attribute.

--- a/doc/source/stdlib/handmade/function-pugixml-set_value-0x1668b158d0b70dc.rst
+++ b/doc/source/stdlib/handmade/function-pugixml-set_value-0x1668b158d0b70dc.rst
@@ -1,0 +1,1 @@
+Sets the value of the node or attribute. Accepts string, int, uint, float, double, or bool.

--- a/doc/source/stdlib/handmade/function-raster-gather-0x3c774f64c1dee720.rst
+++ b/doc/source/stdlib/handmade/function-raster-gather-0x3c774f64c1dee720.rst
@@ -1,0 +1,1 @@
+Gather pixels from source using an index array into destination.

--- a/doc/source/stdlib/handmade/function-raster-gather_scatter-0x727540d0f3c456ad.rst
+++ b/doc/source/stdlib/handmade/function-raster-gather_scatter-0x727540d0f3c456ad.rst
@@ -1,0 +1,1 @@
+Gather pixels from source and scatter to destination using index arrays.

--- a/doc/source/stdlib/handmade/function-raster-gather_scatter_neq_mask-0xcbd53fcdd0c7309c.rst
+++ b/doc/source/stdlib/handmade/function-raster-gather_scatter_neq_mask-0xcbd53fcdd0c7309c.rst
@@ -1,0 +1,1 @@
+Gather-scatter pixels where mask value differs from gathered pixel.

--- a/doc/source/stdlib/handmade/function-raster-gather_store_neq_mask-0xfd5b3b3444f74f10.rst
+++ b/doc/source/stdlib/handmade/function-raster-gather_store_neq_mask-0xfd5b3b3444f74f10.rst
@@ -1,0 +1,1 @@
+Gather from source and store where mask differs, using a single value.

--- a/doc/source/stdlib/handmade/function-raster-gather_store_stride-0xa2dbcc09e11b460a.rst
+++ b/doc/source/stdlib/handmade/function-raster-gather_store_stride-0xa2dbcc09e11b460a.rst
@@ -1,0 +1,1 @@
+Gather pixels with a stride offset between source elements.

--- a/doc/source/stdlib/handmade/function-raster-scatter-0xf250afe3ee1db364.rst
+++ b/doc/source/stdlib/handmade/function-raster-scatter-0xf250afe3ee1db364.rst
@@ -1,0 +1,1 @@
+Scatter pixels from source to destination using an index array.

--- a/doc/source/stdlib/handmade/function-raster-scatter_neq_mask-0xf7d6d6a526045f4.rst
+++ b/doc/source/stdlib/handmade/function-raster-scatter_neq_mask-0xf7d6d6a526045f4.rst
@@ -1,0 +1,1 @@
+Scatter pixels to destination where mask value differs from pixel value.

--- a/doc/source/stdlib/handmade/function-rtti-each-0x531450ac21d9e0dc.rst
+++ b/doc/source/stdlib/handmade/function-rtti-each-0x531450ac21d9e0dc.rst
@@ -1,0 +1,1 @@
+Iterates through each element of an RTTI container (e.g., ``AnnotationArguments``, ``AnnotationArgumentList``, ``AnnotationList``), yielding individual entries.

--- a/doc/source/stdlib/handmade/function-rtti-get_function_info-0x3e1cd5690dcaf413.rst
+++ b/doc/source/stdlib/handmade/function-rtti-get_function_info-0x3e1cd5690dcaf413.rst
@@ -1,0 +1,1 @@
+Returns the ``FuncInfo`` pointer for a function at the given index in the ``Context``, providing access to its name, arguments, and return type.

--- a/doc/source/stdlib/handmade/function-strings-find-0x9b44bbfe385ca191.rst
+++ b/doc/source/stdlib/handmade/function-strings-find-0x9b44bbfe385ca191.rst
@@ -1,0 +1,1 @@
+Returns the first index at which `substr` (string or character code) occurs in `str`, optionally searching from `start`, or -1 if not found.

--- a/doc/source/stdlib/handmade/function-strings-fmt-0xb82eee156bb35ebb.rst
+++ b/doc/source/stdlib/handmade/function-strings-fmt-0xb82eee156bb35ebb.rst
@@ -1,0 +1,1 @@
+Formats a numeric value of type T into the StringBuilderWriter using a libfmt/C++20 std::format format string and returns a reference to the writer.

--- a/doc/source/stdlib/handmade/function-strings-format-0xd32bbd9480a20a41.rst
+++ b/doc/source/stdlib/handmade/function-strings-format-0xd32bbd9480a20a41.rst
@@ -1,0 +1,1 @@
+Formats a numeric value of type T using a C printf-style format string, either appending to a StringBuilderWriter and returning a reference to it, or returning the formatted result as a new string.

--- a/doc/source/stdlib/handmade/function-strings-length-0xd94a56e7054949c1.rst
+++ b/doc/source/stdlib/handmade/function-strings-length-0xd94a56e7054949c1.rst
@@ -1,0 +1,1 @@
+Returns the length of the string or das_string in characters as an int.

--- a/doc/source/stdlib/handmade/function-strings-uint8-0x5311e124c6a0137c.rst
+++ b/doc/source/stdlib/handmade/function-strings-uint8-0x5311e124c6a0137c.rst
@@ -1,0 +1,1 @@
+Converts a string to a uint8, panicking on failure; an overload accepts `result`, `offset`, and optional `hex` flag to report the ConversionResult status and parsed position instead of panicking.

--- a/doc/source/stdlib/handmade/function-strings_boost-jaccard-0xc75af48aec1e56e9.rst
+++ b/doc/source/stdlib/handmade/function-strings_boost-jaccard-0xc75af48aec1e56e9.rst
@@ -1,0 +1,1 @@
+Jaccard similarity over two string-sets, returning ``|intersection| / |union|`` in 0..1. Empty either side returns 0. Pass two ``table<string>`` (the set form) for O(1) intersect lookup, or two ``array<string>`` and the array overload will build the sets internally.

--- a/doc/source/stdlib/handmade/function-uriparser-string-0x7eae5205b0554c8e.rst
+++ b/doc/source/stdlib/handmade/function-uriparser-string-0x7eae5205b0554c8e.rst
@@ -1,0 +1,1 @@
+Converts a ``Uri`` object to its string representation.


### PR DESCRIPTION
## Summary

[#2707](https://github.com/GaijinEntertainment/daScript/pull/2707) swapped the qsort implementation to block-partition pdqsort. Tie-break ordering for equal-key elements changed.

[daslib/rst.das:1882](daslib/rst.das#L1882) was sorting function-overload groups by **only** the function name:

```das
grp.func |> sort($(a, b) => function_name(a.fn) < function_name(b.fn))
```

For overloaded functions the comparator returns `false` both ways (equal key), so which overload ends up first depends on the unstable qsort's internal tie-break. The loop at lines 1912-1929 stamps `is_overload = (cur_name == prev_func_name)` — meaning the **first** overload in iteration order gets the full `:Arguments:` block with `:ref:` to each param type, the rest are stubs.

After #2707 this flipped silently. Concrete downstream casualty: [borisbat/dasImgui#49](https://github.com/borisbat/dasImgui/pull/49) and any dasImgui CI run after 04:42Z UTC 2026-05-18 fails with:

```
.../stdlib/generated/imgui_style_builtin.rst:64: WARNING: undefined label: 'alias-imvec4'
```

— because `push_style_one(idx: ImGuiCol; col: ImVec4)` now wins the detailed slot, and `daslib/rst.das:describe_type` emits `:ref:`ImVec4 <alias-imvec4>`` for any `TypeDecl` with a non-empty `td.alias` (set by C++ bindings via `t->alias = "ImVec4"`). The alias label is never defined anywhere — sphinx `-W` exits non-zero.

This was a **latent** bug exposed by #2707, not introduced by it. The unstable-sort lore is captured in Boris's `feedback_daslang_sort_qsort_not_stable` memory + the mouse card [`sphinx-w-fails-on-my-pr-branch-with-undefined-label-struct-module-x-but-master-ci-is-green-what-causes-this-hash-order-flip-and`](https://github.com/GaijinEntertainment/daScript/blob/master/mouse-data/docs/sphinx-w-fails-on-my-pr-branch-with-undefined-label-struct-module-x-but-master-ci-is-green-what-causes-this-hash-order-flip-and.md).

## Fix

Sort by the full signature string `rst_describe_function_short(fn)` instead of just the function name. The signature string starts with the function name, so name-alphabetical primary order is preserved, and overloads now sort deterministically by argument list within each name-run. No reliance on qsort tie-break.

```das
grp.func |> sort($(a, b) => rst_describe_function_short(a.fn) < rst_describe_function_short(b.fn))
```

## Regenerated handmade stubs

Ran `daslang doc/reflections/das2rst.das` after the fix. 77 new `function-*.rst` files appeared under `doc/source/stdlib/handmade/` — the new "first detailed" overload per name-run, across **math, builtin, ast, ast_boost, raster, strings, pugixml, debugapi, dashv, rtti, strings_boost, uriparser**. Each stub filled by copying the closest signature-matched sibling's description.

Math overloads hand-checked for vector/scalar semantic drift per the das2rst regen mouse card:
- `mad` fused-FMA claim **dropped** (FMA-fusion is platform/precision-dependent, not guaranteed on the new overload).
- `round` halfway-to-nearest-even claim **qualified** to plain "nearest integer" on the double-scalar variant.
- `identity` 3x3 — sibling's "rotation + translation" wording **trimmed** (3x3 has no translation row).
- `ceili` "float argument" wording **adapted** to "double argument" matching the new stub's signature.

## Test plan

- [x] `daslang doc/reflections/das2rst.das` re-run is idempotent (no new stubs)
- [x] `grep -rl '// stub' doc/source/stdlib/handmade/` returns zero
- [x] `git ls-files --others --exclude-standard doc/source/stdlib/` after commit returns zero
- [x] `sphinx-build -W --keep-going -b html doc/source build/site` exits 0 with zero warnings
- [ ] CI's `sphinx-build -W --keep-going -b latex` passes
- [ ] After merge: re-run dasImgui CI on [borisbat/dasImgui#49](https://github.com/borisbat/dasImgui/pull/49) — must turn green

## Out of scope

- **Orphan cleanup**: handmade `.rst` files with hashes that were "first detailed" under the OLD sort order are now never regenerated. They remain on disk as inert dead weight (don't break CI, don't render anywhere unreferenced). Separate cleanup pass can prune them.
- **Latent `:ref:` to nonexistent alias labels** in `describe_type` ([daslib/rst.das:387-389](daslib/rst.das#L387)) — the line still emits `:ref:` to alias labels that may not exist for C++ binding aliases (`t->alias = ...`). Today's fix only avoids triggering the broken `:ref:` by changing which overload's `:Arguments:` block emits param-type refs. A follow-up could either emit `.. das:attribute:: ImVec4 = float4` directives for C++ handle aliases, or have `describe_type` fall back to literal when no label target exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)