### PR TITLE
linq_fold: retire _old_fold; 3-tier cascade; order-family + select+where splice

### DIFF
--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -4,17 +4,17 @@ Project notes and progress for the `daslib/linq_fold` macro family, modeled afte
 
 ## What this is
 
-The current `_fold(...)` macro in linq_boost wraps LINQ pipelines into intermediate `array<T>` per stage and pattern-matches a small set of common shapes (`where+count`, `where+select`, `select+where`, `order+distinct`, `where`, `select`) for ad-hoc fusion. Everything else falls through to a default emitter that builds nested `var pass_N <- pass_(N-1) |> next(...)` — one fresh array per stage, every predicate called via lambda dispatch.
+`_fold(chain)` is a three-tier cascade — always-safe, never breaks semantics, only ever faster:
 
-The goal is a planner-driven dispatch macro that emits one fused for-loop with predicates inlined (splice mode), materializing only when an operator genuinely needs random access. Three output modes:
-
-1. **Splice** (default): producer body inlined into consumer's loop. Zero allocation, zero per-element dispatch.
-2. **Array intermediate**: when a downstream op needs random access / multi-pass / length (`sort`, `reverse`, `distinct`, `groupby`). Once we go array, we stay array (iterating an array is faster than iterating an iterator).
-3. **Helper-call fallback**: when splice can't apply at all (escape into `let`, opaque source). Emits calls to named helper functions in `linq_fold`.
+1. **Splice** (tier 1): a fused for-loop with predicates and projections inlined directly. Zero per-element lambda dispatch, zero intermediate iterators. Two planners feed this tier:
+   - **`plan_order_family`** — handles chains containing any of `order` / `order_by` / `order_descending` / `order_by_descending`, optionally with `take(K)` and/or a `where_*` prefilter. Dispatches to `top_n*` helpers or emits a fused prefilter loop + `order*_inplace` on a buffer.
+   - **`plan_loop_or_count`** — handles `[where_*][select*][skip?][take?]` followed by a recognized terminator (count / sum / min / max / average / long_count / first / first_or_default / any / all / contains / to-array). Includes the where-after-select arm via `replaceVariablePeeling` for the peel-aware substitution required on typed AST.
+2. **`fold_linq_default`** (tier 2): an array-shape pipeline (`call → array → call → array`) with `_inplace` variants reusing the same buffer and explicit `delete` of the previous stage. Used when no splice arm matches but the chain has linq operators.
+3. **Raw clone** (tier 3): passthrough when `flatten_linq` finds no recognized linq operators in the chain at all.
 
 Lambda inlining is best-effort: literal `@(x) => expr` at the call site → splice the body; otherwise → call.
 
-See `~/.claude/plans/keen-hopping-balloon.md` for the long-form plan.
+See `~/.claude/plans/keen-hopping-balloon.md` and `~/.claude/plans/enumerated-baking-elephant.md` for the long-form plans.
 
 ## Phase status
 
@@ -27,43 +27,44 @@ See `~/.claude/plans/keen-hopping-balloon.md` for the long-form plan.
 | 2B Ring 2 | Early-exit lane: `first`, `first_or_default`, `any`, `all`, `contains` via `invoke($block { ... return val })`. Predicate-free `any` gets a `length(src) > 0` shortcut. | ✅ done |
 | 2C Ring 3 | `take(N)` / `skip(N)` in counter/array/accumulator/early-exit lanes. Canonical chain order `[where_*][select*][skip?][take?] |> terminator`. Trailing take/skip (no explicit aggregator) → ARRAY lane with implicit `to_array`. Range-form `take(start..end)` falls through (slice operator, different semantics). Buffer-required ops (`order_by`, `distinct`, `reverse`, `group_by`, `zip`, `join`, `left_join`, `group_join`) recognized by name and emit silent fallback with future-mode markers (BufferTopN / BufferDistinct / BufferReverse / BufferGroupBy / MultiSourceZip / BufferedJoin). | ✅ done |
 | 2C Ring 4 | Non-workhorse chained selects via `:=`-clone. | ✅ done |
-| 2D | Fail-loudly contract — see "Planned" section below | ⏳ |
 | 3 Phase 0 | `<algorithm>` sort-family bindings — `partial_sort`, `nth_element`, `make_heap`/`push_heap`/`pop_heap`. Both typed (19 workhorse types) and any-cblock paths (user structs via `das_qsort_r.h` introselect + binary-heap templates). `daslib/sort_boost.das` user-facing wrappers + `q*` dispatcher macros. `daslib/linq.das` `top_n` / `top_n_by` family (array + iterator sources). C++ tests, daslang tests (53/53), 6 benchmarks, doc grouping, `33_algorithm` tutorial expansion. Unblocks BufferTopN. | ✅ done |
-| 3+ | Buffer-required emit modes: BufferTopN (sort/order_by/take), BufferDistinct, BufferGroupBy, BufferReverse, MultiSourceZip, BufferedJoin. Once we go array, we stay array | ⏳ |
-| 4 | Final coverage pass + docs; full 4-way comparison table refresh; parity-test sweep | ⏳ |
+| 1 cascade | Retire `_old_fold`, drop the 7 `g_foldSeq` patterns, restructure `_fold` into a three-tier cascade (splice → `fold_linq_default` → raw clone). Cascade is always-safe — `_fold(chain)` is observationally equivalent to `chain`. `_select|_where` etc. cases that used to fall to raw clone now cascade to tier 2 array-shape with `_inplace` reuse. Phase 2D "fail-loudly contract" scrapped — always-safe cascade obviates it. | ✅ done |
+| 3a/b/c | BufferTopN splice arm via new `plan_order_family` planner: `[where_*]* + order/order_by/order_descending/order_by_descending [+ take(K)]`. No `take` → direct call to `order*` helper (or fused prefilter loop + `order*_inplace` when where is present). With `take(K)` → dispatch to `top_n[_by][_descending]` (or fused prefilter loop + `top_n*` on the buffer when where is present). New `top_n_by_descending` + `top_n_descending` library helpers added to `daslib/linq.das` (4 functions, mirrors of `top_n_by` / `top_n` with flipped comparator). | ✅ done |
+| 3d | `select + where + terminator` splice arm via `replaceVariablePeeling` (new helper in `daslib/templates_boost.das`). Substitutes the projection into the where predicate, peeling the typer-inserted ExprRef2Value wrappers that would otherwise be left orphaned around a non-reference value. Bails to tier 2 when the projection has side effects (would double-evaluate). Lands all four terminator lanes (ARRAY / COUNTER / ACCUMULATOR / EARLY_EXIT). | ✅ done |
+| 3+ | Remaining buffer-required emit modes (deferred): BufferDistinct, BufferGroupBy, BufferReverse, MultiSourceZip, BufferedJoin. Currently cascade to tier 2 array-shape. | ⏳ |
+| 4 | Final coverage pass + docs; full 3-way comparison table refresh; parity-test sweep | ⏳ |
 
 ## Baselines (100K rows, INTERP mode)
 
-Captured 2026-05-16 on commit `e691abe1b` + foundation PR. ns/op is **per element** (chunk_size = n = 100K), so 30 ns/op means ~3ms for the full operation. Smaller is better. m3f and m3f_old are intentionally identical in this PR — they diverge once Phase 2 lands.
+Foundation captured 2026-05-16 on commit `e691abe1b`. Phase 1 cascade + Phase 3 splice arms (PR retiring `_old_fold`) refresh the m3f column with new splice numbers — see "Headline benchmarks" below for the refreshed delta. ns/op is **per element** (chunk_size = n = 100K), so 30 ns/op means ~3ms for the full operation. Smaller is better.
 
 Notation: `—` means the variant is not applicable for this benchmark (operator has no clean form in that mode).
 
-| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f_old | m3f |
-|---|---|---:|---:|---:|---:|
-| count_aggregate | `where → count` | 29 | 29 | 5 | 5 |
-| sum_aggregate | `select → sum` | 29 | 30 | 8 | 8 |
-| sum_where | `where → select → sum` | 33 | 43 | 12 | 12 |
-| min_aggregate | `select → min` | 30 | 38 | 25 | 25 |
-| max_aggregate | `select → max` | 31 | 36 | 23 | 23 |
-| average_aggregate | `select → average` | 30 | 34 | 20 | 20 |
-| first_match | `where → first` | 0\* | 28 | 15 | 15 |
-| any_match | `where → first_opt`/`any` | 0\* | 0\* | 0\* | 0\* |
-| all_match | `count(where ¬p)==0` / `all` | 27 | 20 | 24 | 25 |
-| to_array_filter | `where → select → to_array` | 70 | 43 | 11 | 11 |
-| take_count | `take → to_array` | 3 | 0\* | 0\* | 0\* |
-| skip_take | `skip → take → to_array` | 0\* | 16 | 23 | 23 |
-| distinct_count | `select → distinct → to_array` | 41 | 43 | 33 | 33 |
-| sort_first | `order_by → first` | 37 | 2170 | 2206 | 2238 |
-| sort_take | `order_by → take` | 38 | 2188 | 2247 | 2269 |
-| groupby_count | `group_by → select(_, length)` | 140 | 70 | 76 | 76 |
-| groupby_sum | `group_by → select(_, sum)` | 172 | 101 | 107 | 107 |
-| chained_where | `where → where → count` | 36 | 45 | 17 | 17 |
-| zip_dot_product | `zip → select → sum` | — | 53 | 37 | 37 |
-| join_count | `join → count` | —\*\* | 116 | 121 | 122 |
-| count_aggregate (existing) | `where → count` | 29 | 29 | 5 | 5 |
-| select_where (existing) | `where → to_array` | 7 | 50 | 12 | 12 |
-| select_where_order_take (existing) | `where → order_by → take` | 36 | 1024 | 1007 | 1014 |
-| indexed_lookup (existing) | `where id==k → count` | 1460\*\*\* | 2003299 | 336129 | 328207 |
+| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (foundation) |
+|---|---|---:|---:|---:|
+| count_aggregate | `where → count` | 29 | 29 | 5 |
+| sum_aggregate | `select → sum` | 29 | 30 | 8 |
+| sum_where | `where → select → sum` | 33 | 43 | 12 |
+| min_aggregate | `select → min` | 30 | 38 | 25 |
+| max_aggregate | `select → max` | 31 | 36 | 23 |
+| average_aggregate | `select → average` | 30 | 34 | 20 |
+| first_match | `where → first` | 0\* | 28 | 15 |
+| any_match | `where → first_opt`/`any` | 0\* | 0\* | 0\* |
+| all_match | `count(where ¬p)==0` / `all` | 27 | 20 | 25 |
+| to_array_filter | `where → select → to_array` | 70 | 43 | 11 |
+| take_count | `take → to_array` | 3 | 0\* | 0\* |
+| skip_take | `skip → take → to_array` | 0\* | 16 | 23 |
+| distinct_count | `select → distinct → to_array` | 41 | 43 | 33 |
+| sort_first | `order_by → first` | 37 | 2170 | 2238 |
+| sort_take | `order_by → take` | 38 | 2188 | 2269 |
+| groupby_count | `group_by → select(_, length)` | 140 | 70 | 76 |
+| groupby_sum | `group_by → select(_, sum)` | 172 | 101 | 107 |
+| chained_where | `where → where → count` | 36 | 45 | 17 |
+| zip_dot_product | `zip → select → sum` | — | 53 | 37 |
+| join_count | `join → count` | —\*\* | 116 | 122 |
+| select_where (existing) | `where → to_array` | 7 | 50 | 12 |
+| select_where_order_take (existing) | `where → order_by → take` | 36 | 1024 | 1014 |
+| indexed_lookup (existing) | `where id==k → count` | 1460\*\*\* | 2003299 | 328207 |
 
 \* Sub-nanosecond per element — early-exit operation hits answer in O(1) regardless of N; per-element timing collapses to 0/near-0 noise.
 
@@ -74,8 +75,7 @@ Notation: `—` means the variant is not applicable for this benchmark (operator
 ### Reading the table
 
 - **m1 vs m3** shows the SQLite-vs-in-memory-LINQ cost gap. SQL wins on `indexed_lookup` (b-tree) and on sorted-take patterns (engine partial-sort + LIMIT). Arrays win on raw aggregates where the SQL overhead exceeds the in-memory work.
-- **m3 vs m3f_old** shows what the *current* `_fold` macro already achieves. Big wins on the patterns it explicitly recognizes (`where+count` 6×, `where+select+to_array` ~4×, `chained_where+count` 2.6×). Negligible difference where it falls through to the default emitter.
-- **m3f vs m3f_old** is the target of Phase 2+. Each PR in the splice series adds a path for one operator family and updates this table with the new ratio.
+- **m3 vs m3f** shows what `_fold`'s splice cascade gains over plain LINQ. The headline shapes that now splice (after the Phase 1+3 cascade PR): order-family + take → `top_n*` dispatch, where + order [+ take] → fused prefilter + sort, select + where → peel-substituted fused loop, plus all the existing `[where_*][select*][skip?][take?]` patterns from Phase 2.
 
 ## Phase 2A — Loop planner (2026-05-16)
 
@@ -234,26 +234,51 @@ No further workhorse branches in the splice path.
 
 Ring 4 is a correctness gate (chained non-workhorse selects now splice instead of falling through), not a per-benchmark improvement on the existing 100K suite. Coverage tracked via test `test_chained_non_workhorse_select` in `tests/linq/test_linq_fold.das` (3 subtests: int → ComplexType → int → sum / where + ComplexType chain + sum / workhorse → ComplexType → workhorse → max).
 
-## Planned: fail-loudly contract
+## Phase 1 — three-tier cascade + `_old_fold` retirement (this PR)
 
-The current contract: when `_fold` can't splice a chain (out-of-scope terminator, buffer-required op, multiple take/skip, range-form take/skip, etc.), it falls through to plain linq — same as today's master. This is **temporary**. The planned contract (Boris design directive 2026-05-17): `_fold` will emit `macro_error("_fold: cannot splice — <reason>")` for any unsupported shape, mirroring the sqlite_linq `_sql(...)` "splice or error" contract.
+`_fold(chain)` is now a three-tier cascade. Tier 1 splice handles the hot patterns; tier 2 (`fold_linq_default`, the body that used to power `_old_fold`) emits an array-shape pipeline with `_inplace` reuse and explicit `delete`; tier 3 is a raw `clone_expression` passthrough. All three tiers preserve semantics — `_fold(chain)` is observationally equivalent to `chain`, just faster when patterns match. **Always safe to apply.**
 
-When the switch lands, every `m3f` variant currently relying on silent fallback breaks. Approximate accounting from the current benchmark suite (8 affected `m3f` variants), grouped by future emit mode that would resolve each:
+This obviates the previously-planned "fail-loudly contract" (Phase 2D) — the cascade always produces a valid output, so there's no need for explicit error emission on unsupported shapes.
 
-| Benchmark | Future mode |
+The 7 specific `FoldSequence` patterns (`fold_where_count`, `fold_where_select`, `fold_select_where`, `fold_where`, `fold_select`, `fold_order_distinct` × 2) and their `g_foldSeq` dispatch table are deleted — splice arms (existing + new in Phase 3 below) cover every shape they recognized. The `_old_fold` macro itself is deleted; the m3f_old benchmark column is dropped from all 29 files.
+
+## Phase 3 — order-family splice + select+where peel (this PR)
+
+**New planner: `plan_order_family`.** Called before `plan_loop_or_count` in the cascade. Recognizes chains containing any of `order` / `order_by` / `order_descending` / `order_by_descending`, optionally with one `take(K)`, optionally with `where_*` prefilters:
+
+| Chain shape | Emission |
 |---|---|
-| `distinct_count` | BufferDistinct (hash set) |
-| `sort_first` | BufferTopN (order_by + early-exit) |
-| `sort_take` | BufferTopN (order_by + take/skip) |
-| `select_where_order_take` | BufferTopN with predicate prefix |
-| `groupby_count` | BufferGroupBy (hash multi-bucket) |
-| `groupby_sum` | BufferGroupBy + nested fold inside select |
-| `zip_dot_product` | MultiSourceZip (2 cursors advanced lockstep) |
-| `join_count` | BufferedJoin (hash-build + probe) |
+| `arr \|> order[_descending]?` (bare) | Direct call: `order[_descending](arr)` |
+| `arr \|> order_by[_descending]?(key)` (bare) | Direct call: `order_by[_descending](arr, key)` |
+| `src \|> order[_descending]? \|> take(K)` | `top_n[_descending](src, K)` (existing helpers from PR #2707) |
+| `src \|> order_by[_descending]?(key) \|> take(K)` | `top_n_by[_descending](src, K, key)` (new descending helpers in this PR) |
+| `src \|> where_*(p)+ \|> order[_by]?[_descending]?[(key)]` | Fused: prefilter into pre-allocated buffer, then `order*_inplace` |
+| `src \|> where_*(p)+ \|> order[_by]?[_descending]?[(key)] \|> take(K)` | Fused: prefilter into buffer, then `top_n*` on the buffer |
 
-The fail-loudly PR will either (a) comment out `m3f` in the affected benchmarks until the corresponding emit mode lands, or (b) deliver one or more emit modes alongside the switch. Decision deferred to that PR.
+New `top_n_by_descending` (array + iterator) + `top_n_descending` (array + iterator) added to `daslib/linq.das` — mirror `top_n_by` / `top_n` with flipped comparator (partial_sort + reversed less for array; bounded min-heap for iterator).
 
-Tracking issue: the planner's `is_buffer_required_op` recognition + the named-arm `// TODO Phase 2X: <FutureMode>` markers are the in-code TODOs.
+**New splice arm: `select + where + terminator`.** Previously rejected by `plan_loop_or_count` (where-after-select hit the ExprRef2Value substitution blocker). Unblocked via the new `replaceVariablePeeling` helper in `daslib/templates_boost.das` — substitutes the projection into the where predicate, peeling the typer-inserted `ExprRef2Value` wrapper as part of the substitution (mirrors `ast_match`'s `qm_peel_ref2value` pattern). Bails to tier 2 cascade when the projection has side effects (would double-evaluate, once in the substituted where and again at the terminator emission). Lands all four lanes: ARRAY (to_array / bare), COUNTER (count), ACCUMULATOR (sum / min / max / avg / long_count), EARLY_EXIT (first / first_or_default / any / all / contains).
+
+**Concurrent runtime fix:** [`src/builtin/module_builtin_runtime_sort.cpp:84`](../../src/builtin/module_builtin_runtime_sort.cpp#L84) — `builtin_sort_string` switched from unqualified `sort()` (= `std::sort` via `using namespace std`) to `das_sort` (the in-tree block-partition pdqsort from PR #2707). This is the runtime path `order_by<string>` takes; on Linux/libstdc++ users see the same ~1.5× sort speedup PR #2707 delivered for typed sorts.
+
+### Headline benchmarks (100K rows, INTERP, this PR)
+
+Refreshed m3f column after Phase 1 cascade + Phase 3 splice arms land. m3 is plain LINQ baseline; m3f is `_fold(...)` over the same chain.
+
+| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (this PR) | Win |
+|---|---|---:|---:|---:|---:|
+| order_take_desc | `order_by_desc → take(K)` | 38 | 698 | **56** | **12.5×** |
+| sort_take | `order_by → take(K)` | 38 | 713 | **56** | **12.7×** |
+| select_where_order_take | `where → order_by → take(K)` | 36 | 354 | **39** | **9.1×** |
+| select_where_count | `select → where → count` (NEW: peel) | 32 | 57 | **5** | **11.4×** |
+| select_where | `where → select → to_array` | 191 | 28 | **11** | **2.5×** |
+| bare_order_where | `where → order_by` (no take) | 273 | 357 | **340** | **1.05×** |
+| chained_where | `where → where → count` | 36 | 45 | **6** | **7.5×** |
+| sum_where | `where → select → sum` | 32 | 44 | **4** | **11×** |
+
+The order+take rows (`order_take_desc`, `sort_take`, `select_where_order_take`) come within ~1.5× of SQLite's index-aware plans by dispatching `_fold` directly to the `top_n_by[_descending]` partial-sort helpers from PR #2707 (asc dispatches to existing; desc is new in this PR). The `bare_order_where` win is small because full sort dominates — the splice saves only one intermediate allocation, not the sort cost.
+
+`select_where_count` is the first **select+where** splice landing: previously rejected by the planner (the typer-inserted `ExprRef2Value` wrapper around `it` orphaned during substitution → `30921: can only dereference a reference`). The new `replaceVariablePeeling` helper in `templates_boost.das` peels the wrapper as part of the substitution, mirroring `ast_match`'s `qm_peel_ref2value`. All four terminator lanes (array / counter / accumulator / early-exit) covered.
 
 ## Operator-coverage checklist (parity tests)
 
@@ -292,12 +317,12 @@ dastest reports `ns/op` in INTERP mode by default. To bump dataset size as the s
 
 ## Design decisions
 
-**`_old_fold` lives alongside `_fold` in `linq_fold`, not in `linq_boost`.** Both macros share the entire dispatch infrastructure (`linqCalls`, `g_foldSeq`, `fold_*`, `flatten_linq`, `fold_linq_default`). Keeping them in one module avoids duplication; the only difference today is the macro-name string passed into `fold_linq_default`'s recursive sub-fold call.
+**Three-tier cascade, always safe.** `_fold(chain)` is observationally equivalent to `chain` — never breaks semantics, only ever faster. Splice arms cover the hot paths; `fold_linq_default` (tier 2) emits an array-shape pipeline with `_inplace` reuse for anything splice can't handle; raw clone (tier 3) handles the empty-chain edge. This obviates the fail-loudly contract that earlier plans considered.
 
-**Recursive macro-name is parameterized.** `fold_linq_default(expr, recursiveMacroName)` — `_fold` passes `"_fold"`, `_old_fold` passes `"_old_fold"`. This keeps the frozen baseline truly frozen once `_fold` diverges in Phase 2+: when `_fold` starts emitting splice loops, `_old_fold` keeps emitting the historical comprehension/invoke shape because its recursive sub-folds still target `_old_fold`.
+**`fold_linq_default` is load-bearing.** Its array-shape emission (`var pass_0 = call0(src); var pass_1 = call1_inplace(pass_0); delete pass_0; ...`) with explicit `delete` of intermediates and `_inplace` variant routing is genuinely better than plain LINQ (one buffer at a time, reused; no iterator wrappers). Kept as the cascade's tier 2.
 
 **100K rows.** daslang is interpreter-first; 100K gives sub-second-per-variant benchmark turnaround and clearly shows the asymmetries we care about. Bump later if AOT/JIT numbers warrant.
 
-**`PERF009` suppression in `fold_linq_default`.** The macro's `var pass_N = call` + later `return <- pass_N` pattern triggers PERF009 on single-pass chains (e.g. `take_count`). Rewriting to direct `return <- call` would change `_old_fold`'s baseline; we suppress inline at the qmacro_expr emission site and document why.
+**`PERF009` suppression in `fold_linq_default`.** The macro's `var pass_N = call` + later `return <- pass_N` pattern triggers PERF009 on single-pass chains. The shape is load-bearing for the array-pipeline semantics (every stage binds so the next can reuse the buffer in-place), so we suppress inline at the qmacro_expr emission site and document why.
 
 **Benchmark variants where SQL has no clean form.** `zip` (not a relational op), `_all(pred)` (no direct `_all` chain terminal in sqlite_linq), `join` with inner-select-from (wiring not exposed), `distinct |> count` (no `COUNT(DISTINCT col)` yet), `take/skip` before aggregate (LIMIT/OFFSET semantics conflict with aggregate-collapse). We either reformulate to a SQL-friendly shape (`count(where ¬p)` for all_match), omit the m1 column (zip, join), or terminate the chain in `to_array` instead of an aggregate (take/skip/distinct).

--- a/benchmarks/sql/all_match.das
+++ b/benchmarks/sql/all_match.das
@@ -30,17 +30,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let yes = _old_fold(each(arr)._all(_.price < 9999))
-        if (!yes) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -59,11 +48,6 @@ def all_match_m1(b : B?) {
 [benchmark]
 def all_match_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def all_match_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/any_match.das
+++ b/benchmarks/sql/any_match.das
@@ -30,17 +30,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let yes = _old_fold(each(arr)._any(_.price > THRESHOLD))
-        if (!yes) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -59,11 +48,6 @@ def any_match_m1(b : B?) {
 [benchmark]
 def any_match_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def any_match_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/average_aggregate.das
+++ b/benchmarks/sql/average_aggregate.das
@@ -4,7 +4,7 @@ options persistent_heap
 require _common public
 
 // SQL: SELECT AVG(price) FROM Cars.
-// m3/m3f_old/m3f sum and divide on a single pass.
+// m3/m3f sum and divide on a single pass.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -27,17 +27,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let a = _old_fold(each(arr)._select(double(_.price)).average())
-        if (a == 0.0lf) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -56,11 +45,6 @@ def average_aggregate_m1(b : B?) {
 [benchmark]
 def average_aggregate_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def average_aggregate_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/bare_order_where.das
+++ b/benchmarks/sql/bare_order_where.das
@@ -4,17 +4,20 @@ options persistent_heap
 require _common public
 
 let THRESHOLD = 500
-let TAKE_N = 10
 
-// --- m1: _sql over :memory: ---
+// _where(_.price > T) |> _order_by(_.price) — fused prefilter + sort, NO take.
+// SQL: WHERE price > T ORDER BY price.
+// m3 (plain LINQ) materializes a filter array, then sorts a clone (two allocations).
+// m3f (spliced via plan_order_family Phase 3c) emits a single fused loop that collects
+// matching elements into one pre-allocated buffer, then sort_inplace's the buffer.
+
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let rows <- _sql(db |> select_from(type<Car>)
                                 |> _where(_.price > THRESHOLD)
-                                |> _order_by(_.price)
-                                |> take(TAKE_N))
+                                |> _order_by(_.price))
             if (empty(rows)) {
                 b->failNow()
             }
@@ -22,26 +25,22 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-// --- m3: array LINQ (materializing intermediate arrays) ---
 def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let rows <- (arr |> _where(_.price > THRESHOLD)
-                         |> _order_by(_.price)
-                         |> take(TAKE_N))
+                         |> _order_by(_.price))
         if (empty(rows)) {
             b->failNow()
         }
     }
 }
 
-// --- m3f: array LINQ folded into a single fused pass ---
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let rows <- _fold(each(arr)._where(_.price > THRESHOLD)
                                    ._order_by(_.price)
-                                   .take(TAKE_N)
                                    .to_array())
         if (empty(rows)) {
             b->failNow()
@@ -50,16 +49,16 @@ def run_m3f(b : B?; n : int) {
 }
 
 [benchmark]
-def select_where_order_take_m1(b : B?) {
+def bare_order_where_m1(b : B?) {
     run_m1(b, 100000)
 }
 
 [benchmark]
-def select_where_order_take_m3(b : B?) {
+def bare_order_where_m3(b : B?) {
     run_m3(b, 100000)
 }
 
 [benchmark]
-def select_where_order_take_m3f(b : B?) {
+def bare_order_where_m3f(b : B?) {
     run_m3f(b, 100000)
 }

--- a/benchmarks/sql/chained_where.das
+++ b/benchmarks/sql/chained_where.das
@@ -37,19 +37,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let c = _old_fold(each(arr)._where(_.price > THRESHOLD)
-                                   ._where(_.year >= YEAR_FLOOR)
-                                   .count())
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -70,11 +57,6 @@ def chained_where_m1(b : B?) {
 [benchmark]
 def chained_where_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def chained_where_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/contains_match.das
+++ b/benchmarks/sql/contains_match.das
@@ -33,17 +33,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let yes = _old_fold(each(arr)._select(_.id).contains(TARGET_ID))
-        if (!yes) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -62,11 +51,6 @@ def contains_match_m1(b : B?) {
 [benchmark]
 def contains_match_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def contains_match_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/count_aggregate.das
+++ b/benchmarks/sql/count_aggregate.das
@@ -7,7 +7,6 @@ let THRESHOLD = 500
 
 // SQL pushes COUNT(*) to the engine returning one row.
 // m3 must materialize the full filtered array, then walk to count it.
-// m3f_old is the pre-rewrite baseline fold (frozen — diverges as splice mode lands).
 // m3f folds where+count into a single fused pass (no intermediate array).
 
 // --- m1: _sql over :memory: ---
@@ -34,17 +33,6 @@ def run_m3(b : B?; n : int) {
     }
 }
 
-// --- m3f_old: pre-rewrite baseline fold ---
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let c = _old_fold(each(arr)._where(_.price > THRESHOLD).count())
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
-
 // --- m3f: array LINQ folded into a single fused pass ---
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
@@ -64,11 +52,6 @@ def count_aggregate_m1(b : B?) {
 [benchmark]
 def count_aggregate_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def count_aggregate_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/distinct_count.das
+++ b/benchmarks/sql/distinct_count.das
@@ -31,17 +31,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let rows <- _old_fold(each(arr)._select(_.brand).distinct().to_array())
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -60,11 +49,6 @@ def distinct_count_m1(b : B?) {
 [benchmark]
 def distinct_count_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def distinct_count_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/first_match.das
+++ b/benchmarks/sql/first_match.das
@@ -7,8 +7,8 @@ let THRESHOLD = 500
 
 // SQL: SELECT ... LIMIT 1 — engine stops at first hit.
 // m3 materializes the full filtered array then indexes [0].
-// m3f_old / m3f should ideally early-exit at the first matching row;
-// splice mode is the main target here.
+// m3f should ideally early-exit at the first matching row; splice mode
+// is the main target here.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -31,17 +31,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let row = _old_fold(each(arr)._where(_.price > THRESHOLD).first())
-        if (row.price == 0) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -60,11 +49,6 @@ def first_match_m1(b : B?) {
 [benchmark]
 def first_match_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def first_match_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/first_or_default_match.das
+++ b/benchmarks/sql/first_or_default_match.das
@@ -32,18 +32,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    let sentinel = Car(id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let row = _old_fold(each(arr)._where(_.price > THRESHOLD).first_or_default(sentinel))
-        if (row.id == SENTINEL_ID) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     let sentinel = Car(id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
@@ -63,11 +51,6 @@ def first_or_default_match_m1(b : B?) {
 [benchmark]
 def first_or_default_match_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def first_or_default_match_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_count.das
+++ b/benchmarks/sql/groupby_count.das
@@ -32,20 +32,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let groups <- _old_fold(each(arr)
-                                ._group_by(_.brand)
-                                ._select((Brand = _._0, N = _._1 |> length))
-                                .to_array())
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -67,11 +53,6 @@ def groupby_count_m1(b : B?) {
 [benchmark]
 def groupby_count_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def groupby_count_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_sum.das
+++ b/benchmarks/sql/groupby_sum.das
@@ -33,21 +33,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let groups <- _old_fold(each(arr)
-                                ._group_by(_.brand)
-                                ._select((Brand = _._0,
-                                          TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum()))
-                                .to_array())
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -70,11 +55,6 @@ def groupby_sum_m1(b : B?) {
 [benchmark]
 def groupby_sum_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def groupby_sum_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/indexed_lookup.das
+++ b/benchmarks/sql/indexed_lookup.das
@@ -34,18 +34,6 @@ def run_m3(b : B?; n : int) {
     }
 }
 
-// --- m3f_old: pre-rewrite baseline fold ---
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    let key = n / 2
-    b |> run("m3f_old_array_fold/{n}") {
-        let c = _old_fold(each(arr)._where(_.id == key).count())
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
-
 // --- m3f: array LINQ folded into a single fused pass ---
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
@@ -66,11 +54,6 @@ def indexed_lookup_m1(b : B?) {
 [benchmark]
 def indexed_lookup_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def indexed_lookup_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/join_count.das
+++ b/benchmarks/sql/join_count.das
@@ -7,7 +7,7 @@ require _common public
 // SQL form (`_sql(... |> _join(select_from(type<Dealer>), ...))`) requires the
 // inner select_from to bind the db handle inside the _sql analyzer; that wiring
 // is not exposed for direct authoring here, so m1 is omitted for this benchmark.
-// 3-way comparison (m3 / m3f_old / m3f) focuses on array-side join cost.
+// 2-way comparison (m3 / m3f) focuses on array-side join cost.
 
 def run_m3(b : B?; n : int) {
     let cars <- fixture_array(n)
@@ -22,21 +22,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let cars <- fixture_array(n)
-    let dealers <- fixture_dealers_array()
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let c = _old_fold(cars |> _join(dealers,
-                                        $(c : Car, d : Dealer) => c.dealer_id == d.id,
-                                        $(c : Car, d : Dealer) => (c.name, d.name))
-                               |> count())
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let cars <- fixture_array(n)
     let dealers <- fixture_dealers_array()
@@ -54,11 +39,6 @@ def run_m3f(b : B?; n : int) {
 [benchmark]
 def join_count_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def join_count_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/long_count_aggregate.das
+++ b/benchmarks/sql/long_count_aggregate.das
@@ -30,17 +30,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let c = _old_fold(each(arr)._where(_.price > THRESHOLD).long_count())
-        if (c == 0l) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -59,11 +48,6 @@ def long_count_aggregate_m1(b : B?) {
 [benchmark]
 def long_count_aggregate_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def long_count_aggregate_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/max_aggregate.das
+++ b/benchmarks/sql/max_aggregate.das
@@ -4,7 +4,7 @@ options persistent_heap
 require _common public
 
 // SQL: SELECT MAX(price) FROM Cars.
-// m3/m3f_old/m3f scan the array tracking the maximum seen.
+// m3/m3f scan the array tracking the maximum seen.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -27,17 +27,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let m = _old_fold(each(arr)._select(_.price).max())
-        if (m == 0) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -56,11 +45,6 @@ def max_aggregate_m1(b : B?) {
 [benchmark]
 def max_aggregate_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def max_aggregate_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/min_aggregate.das
+++ b/benchmarks/sql/min_aggregate.das
@@ -4,7 +4,7 @@ options persistent_heap
 require _common public
 
 // SQL: SELECT MIN(price) FROM Cars.
-// m3/m3f_old/m3f scan the array tracking the minimum seen.
+// m3/m3f scan the array tracking the minimum seen.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -27,17 +27,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let m = _old_fold(each(arr)._select(_.price).min())
-        if (m > 999) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -56,11 +45,6 @@ def min_aggregate_m1(b : B?) {
 [benchmark]
 def min_aggregate_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def min_aggregate_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/order_take_desc.das
+++ b/benchmarks/sql/order_take_desc.das
@@ -1,0 +1,59 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let TAKE_N = 10
+
+// _order_by_descending(_.price) |> take(N) — top-N largest pattern.
+// SQL: ORDER BY price DESC LIMIT N — engine emits partial-sort optimization when possible.
+// m3 (plain LINQ) does a full descending sort then slices.
+// m3f (spliced via plan_order_family Phase 3b) dispatches directly to ``top_n_by_descending``
+// which uses partial_sort with a flipped comparator (array source) — O(M log N).
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let rows <- _sql(db |> select_from(type<Car>) |> _order_by_descending(_.price) |> take(TAKE_N))
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let rows <- (arr |> _order_by_descending(_.price) |> take(TAKE_N))
+        if (empty(rows)) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let rows <- _fold(each(arr)._order_by_descending(_.price).take(TAKE_N).to_array())
+        if (empty(rows)) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def order_take_desc_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def order_take_desc_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def order_take_desc_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/benchmarks/sql/select_count.das
+++ b/benchmarks/sql/select_count.das
@@ -8,9 +8,7 @@ require _common public
 // so user-visible side effects fire. Phase-2A `_fold` matches that: the counter lane binds
 // the final projection to a discardable local per matched element (side effects preserved)
 // and skips array materialization. The optimizer DCEs the binding for pure projections
-// like `_.price * 2`, leaving a bare-loop counter for the common case. `_old_fold` lacks a
-// [select, count] pattern in g_foldSeq so it falls to the default nested-pass form
-// (pass_0 = select(...); count(pass_0)) — materializing the same way m3 does.
+// like `_.price * 2`, leaving a bare-loop counter for the common case.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -33,17 +31,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let c = _old_fold(each(arr)._select(_.price * 2).count())
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -62,11 +49,6 @@ def select_count_m1(b : B?) {
 [benchmark]
 def select_count_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def select_count_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/select_where.das
+++ b/benchmarks/sql/select_where.das
@@ -29,17 +29,6 @@ def run_m3(b : B?; n : int) {
     }
 }
 
-// --- m3f_old: pre-rewrite baseline fold ---
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let rows <- _old_fold(each(arr)._where(_.price > THRESHOLD).to_array())
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
-
 // --- m3f: array LINQ folded into a single fused pass ---
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
@@ -59,11 +48,6 @@ def select_where_m1(b : B?) {
 [benchmark]
 def select_where_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def select_where_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/select_where_count.das
+++ b/benchmarks/sql/select_where_count.das
@@ -1,0 +1,62 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let THRESHOLD = 1000
+
+// _select(_.price * 2) |> _where(_ > T) |> count — where-after-select pattern.
+// SQL: SELECT COUNT(*) FROM Cars WHERE price * 2 > T.
+// m3 (plain LINQ) materializes a projection iterator, then a filter array, then counts.
+// m3f (spliced via Phase 3d via replaceVariablePeeling) substitutes the projection into
+// the where predicate (peeling the typer-inserted ExprRef2Value wrapper) and emits a single
+// fused counter loop — no intermediate arrays.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            // SQL form folds projection into the WHERE filter — the engine evaluates
+            // ``price * 2 > T`` per row and counts matches.
+            let c = _sql(db |> select_from(type<Car>) |> _where(_.price * 2 > THRESHOLD) |> count())
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let c = arr |> _select(_.price * 2) |> _where(_ > THRESHOLD) |> count
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let c = _fold(each(arr)._select(_.price * 2)._where(_ > THRESHOLD).count())
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def select_where_count_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def select_where_count_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def select_where_count_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/benchmarks/sql/skip_take.das
+++ b/benchmarks/sql/skip_take.das
@@ -32,17 +32,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let rows <- _old_fold(each(arr).skip(SKIP_N).take(TAKE_N).to_array())
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -61,11 +50,6 @@ def skip_take_m1(b : B?) {
 [benchmark]
 def skip_take_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def skip_take_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sort_first.das
+++ b/benchmarks/sql/sort_first.das
@@ -28,17 +28,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let row = _old_fold(each(arr)._order_by(_.price).first())
-        if (row.id == 0) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -57,11 +46,6 @@ def sort_first_m1(b : B?) {
 [benchmark]
 def sort_first_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def sort_first_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sort_take.das
+++ b/benchmarks/sql/sort_take.das
@@ -15,7 +15,7 @@ let TAKE_N = 10
 // uses ``partial_sort`` under the hood (O(M log N)), iterator source uses a
 // bounded heap of size N during the scan (max N elements resident).
 //
-// m3f / m3f_old are intentionally identical for top-N here — Phase 0 only adds
+// m3f are intentionally identical for top-N here — Phase 0 only adds
 // the library function; PR B (BufferTopN emit mode in linq_fold) is what makes
 // the m3f column move.
 
@@ -40,19 +40,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        unsafe {
-            let rows <- _old_fold(each(arr)._order_by(_.price).take(TAKE_N).to_array())
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -93,11 +80,6 @@ def sort_take_m1(b : B?) {
 [benchmark]
 def sort_take_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def sort_take_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sum_aggregate.das
+++ b/benchmarks/sql/sum_aggregate.das
@@ -4,7 +4,7 @@ options persistent_heap
 require _common public
 
 // SQL: SELECT SUM(price) FROM Cars — single-row scalar reduction pushed to the engine.
-// m3/m3f_old/m3f traverse the array projecting and accumulating.
+// m3/m3f traverse the array projecting and accumulating.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -27,17 +27,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let s = _old_fold(each(arr)._select(_.price).sum())
-        if (s == 0) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -56,11 +45,6 @@ def sum_aggregate_m1(b : B?) {
 [benchmark]
 def sum_aggregate_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def sum_aggregate_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sum_where.das
+++ b/benchmarks/sql/sum_where.das
@@ -31,17 +31,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let s = _old_fold(each(arr)._where(_.price > THRESHOLD)._select(_.price).sum())
-        if (s == 0) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -60,11 +49,6 @@ def sum_where_m1(b : B?) {
 [benchmark]
 def sum_where_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def sum_where_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/take_count.das
+++ b/benchmarks/sql/take_count.das
@@ -30,17 +30,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let rows <- _old_fold(each(arr).take(TAKE_N).to_array())
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -59,11 +48,6 @@ def take_count_m1(b : B?) {
 [benchmark]
 def take_count_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def take_count_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/take_count_filtered.das
+++ b/benchmarks/sql/take_count_filtered.das
@@ -7,7 +7,7 @@ let TAKE_N = 1000
 let THRESHOLD = 500
 
 // `_sql` rejects `take(n) |> count()` (LIMIT-before-aggregate collapses to one row regardless
-// in SQLite), so the m1 variant is omitted. m3/m3f_old/m3f filter + bound + count over the
+// in SQLite), so the m1 variant is omitted. m3/m3f filter + bound + count over the
 // array. Exercises counter-lane take splice with an upstream `where` predicate.
 
 def run_m3(b : B?; n : int) {
@@ -19,17 +19,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let c = _old_fold(each(arr)._where(_.price > THRESHOLD).take(TAKE_N).count())
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -43,11 +32,6 @@ def run_m3f(b : B?; n : int) {
 [benchmark]
 def take_count_filtered_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def take_count_filtered_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/take_sum_aggregate.das
+++ b/benchmarks/sql/take_sum_aggregate.das
@@ -6,7 +6,7 @@ require _common public
 let TAKE_N = 1000
 
 // `_sql` rejects `take(n) |> sum()` (LIMIT-before-aggregate has no effect in SQLite — aggregate
-// collapses to one row regardless), so the m1 variant is omitted. m3/m3f_old/m3f bound the
+// collapses to one row regardless), so the m1 variant is omitted. m3/m3f bound the
 // projection-sum loop to the first TAKE_N matched elements (no upstream where here, so
 // "matched" == "every source element"). Exercises accumulator-lane take splice in _fold.
 
@@ -19,17 +19,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let s = _old_fold(each(arr)._select(_.price).take(TAKE_N).sum())
-        if (s == 0) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -43,11 +32,6 @@ def run_m3f(b : B?; n : int) {
 [benchmark]
 def take_sum_aggregate_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def take_sum_aggregate_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/to_array_filter.das
+++ b/benchmarks/sql/to_array_filter.das
@@ -29,17 +29,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let prices <- _old_fold(each(arr)._where(_.price > THRESHOLD)._select(_.price).to_array())
-        if (empty(prices)) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -58,11 +47,6 @@ def to_array_filter_m1(b : B?) {
 [benchmark]
 def to_array_filter_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def to_array_filter_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/zip_dot_product.das
+++ b/benchmarks/sql/zip_dot_product.das
@@ -26,18 +26,6 @@ def run_m3(b : B?; n : int) {
         }
     }
 }
-
-def run_m3f_old(b : B?; n : int) {
-    let xs <- make_ints(n)
-    let ys <- make_ints(n)
-    b |> run("m3f_old_array_fold/{n}", n) {
-        let s = _old_fold(zip(xs, ys)._select(_._0 * _._1).sum())
-        if (s == 0) {
-            b->failNow()
-        }
-    }
-}
-
 def run_m3f(b : B?; n : int) {
     let xs <- make_ints(n)
     let ys <- make_ints(n)
@@ -52,11 +40,6 @@ def run_m3f(b : B?; n : int) {
 [benchmark]
 def zip_dot_product_m3(b : B?) {
     run_m3(b, 100000)
-}
-
-[benchmark]
-def zip_dot_product_m3f_old(b : B?) {
-    run_m3f_old(b, 100000)
 }
 
 [benchmark]

--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -509,6 +509,62 @@ def top_n(var a : iterator<auto(TT)>; n : int) : array<TT -const -&> {
     return <- top_n_by(a, n, $(v : TT -&) => v)
 }
 
+// ============================================================================
+// top_n_descending / top_n_by_descending — return the N largest elements in
+// descending order. Mirror of top_n / top_n_by with flipped comparator.
+//
+// Array source: partial_sort on a clone with reversed less, then resize to N.
+// Iterator source: bounded min-heap of size N tracks the N largest seen so far;
+// when an element greater than the heap min arrives, evict and insert.
+// ============================================================================
+
+def top_n_by_descending(arr : array<auto(TT)>; n : int; key) : array<TT -const -&> {
+    //! Returns the ``n`` largest elements of ``arr`` by ``key(element)``,
+    //! sorted descending. ``n <= 0`` or empty ``arr`` yields an empty result.
+    var buf : array<TT -const -&>
+    if (n <= 0 || empty(arr)) return <- buf
+    let take_count = min(n, length(arr))
+    buf |> reserve(length(arr))
+    for (it in arr) {
+        buf |> push_clone(it)
+    }
+    sort_boost::partial_sort(buf, take_count, $(v1, v2) => _::less(key(v2), key(v1)))
+    buf |> resize(take_count)
+    return <- buf
+}
+
+def top_n_by_descending(var a : iterator<auto(TT)>; n : int; key) : array<TT -const -&> {
+    //! Returns the ``n`` largest elements of an iterator by ``key(element)``,
+    //! sorted descending. Uses a bounded min-heap of size ``n`` during the scan;
+    //! at most ``n`` elements resident.
+    var buf : array<TT -const -&>
+    if (n <= 0) return <- buf
+    // Heap is ordered by reversed less — top is the MIN element seen so far.
+    // When an element greater than the heap min arrives, evict and insert.
+    for (it in a) {
+        if (length(buf) < n) {
+            buf |> push_clone(it)
+            sort_boost::push_heap(buf, $(v1, v2) => _::less(key(v2), key(v1)))
+        } elif (_::less(key(buf[0]), key(it))) {
+            sort_boost::pop_heap(buf, $(v1, v2) => _::less(key(v2), key(v1)))
+            buf[length(buf) - 1] := it
+            sort_boost::push_heap(buf, $(v1, v2) => _::less(key(v2), key(v1)))
+        }
+    }
+    sort(buf, $(v1, v2) => _::less(key(v2), key(v1)))
+    return <- buf
+}
+
+def top_n_descending(arr : array<auto(TT)>; n : int) : array<TT -const -&> {
+    //! Returns the ``n`` largest elements of ``arr`` (by ``<``), sorted descending.
+    return <- top_n_by_descending(arr, n, $(v : TT -&) => v)
+}
+
+def top_n_descending(var a : iterator<auto(TT)>; n : int) : array<TT -const -&> {
+    //! Returns the ``n`` largest elements of an iterator (by ``<``), descending.
+    return <- top_n_by_descending(a, n, $(v : TT -&) => v)
+}
+
 def unique_key(a) {
     //! generates unique key of workhorse type for the value
     static_if (typeinfo is_workhorse(a)) {

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -5,16 +5,23 @@ options no_unused_function_arguments = false
 
 module linq_fold shared public
 
-//! LINQ ``_fold`` and ``_old_fold`` macro pair — fuse-time-aware pipeline rewriting.
+//! LINQ ``_fold`` macro — fuse-time-aware pipeline rewriting.
 //!
-//! ``_fold(expr)`` is the active fusion macro. ``_old_fold(expr)`` is a frozen
-//! baseline that preserves the pre-rewrite behavior; benchmarks compare the two
-//! to track performance work as ``_fold`` evolves toward splice-mode fusion.
+//! ``_fold(expr)`` is a three-tier cascade:
 //!
-//! Both macros share the same dispatch infrastructure (``linqCalls`` dict,
-//! ``flatten_linq``, ``g_foldSeq``, ``fold_*`` helpers, ``fold_linq_default``);
-//! the only difference today is the macro-name string they pass into the
-//! recursive sub-fold call inside ``fold_linq_default``.
+//! 1. **Splice** — when the chain matches a recognized pattern, emit a single
+//!    fused for-loop with predicates and projections inlined (best perf,
+//!    no intermediate iterators or buffers).
+//! 2. **``fold_linq_default``** — when splice can't fire, emit an
+//!    array-shape pipeline (``call → array → call → array``) with
+//!    ``_inplace`` variants reusing the same buffer and explicit ``delete``
+//!    on the previous stage. One buffer at a time, no iterator overhead.
+//! 3. **``clone_expression``** — raw passthrough when the chain has no
+//!    recognized linq operators (``flatten_linq`` returns empty).
+//!
+//! All three tiers preserve semantics — ``_fold(chain)`` is observationally
+//! equivalent to ``chain``, just faster when patterns match. The macro is
+//! always safe to apply.
 //!
 //! Requires the ``linq`` module for the backing operator functions.
 
@@ -23,6 +30,7 @@ require daslib/linq public
 require daslib/ast_boost
 require daslib/templates_boost
 require daslib/macro_boost
+require strings
 
 def private is_call_or_generic(var expr : Expression?, name, moduleName : string) : ExprCall? {
     if (expr is ExprCall) {
@@ -61,12 +69,36 @@ def private fold_linq_cond(var expr : Expression?; argName : string) : Expressio
     return qmacro(invoke($e(expr), $i(argName)))
 }
 
+def private fold_linq_cond_peel(var expr : Expression?; var replacement : Expression?) : Expression? {
+    // Variant of fold_linq_cond that substitutes the lambda's bound variable with an
+    // arbitrary expression (not just a rename to another identifier). Uses peel-aware
+    // substitution to strip the ExprRef2Value wrappers the typer inserts around `var`
+    // reads on already-typed AST. Used by the select-then-where splice arm — see
+    // `templates_boost::replaceVariablePeeling`.
+    if (expr is ExprMakeBlock) {
+        var mblk = expr as ExprMakeBlock
+        var blk = mblk._block as ExprBlock
+        if (blk.arguments |> length == 1 && blk.list |> length == 1 && blk.list[0] is ExprReturn) {
+            var ret = blk.list[0] as ExprReturn
+            if (ret.subexpr != null) {
+                var res = clone_expression(ret.subexpr)
+                var rules : Template
+                rules |> replaceVariablePeeling(string(blk.arguments[0].name), replacement)
+                apply_template(rules, res.at, res)
+                return res
+            }
+        }
+    }
+    return qmacro(invoke($e(expr), $e(replacement)))
+}
+
 struct private LinqCall {
     //! Internal struct representing a chained LINQ method call.
     name : string
     moduleName : string = "linq"
     skip : bool = false             // if specified, expression is skipped in folding
     inplace : bool = false          // if specified, expression is inplace and does not create new variable
+    noToArrayVariant : bool = false // if specified, no `_to_array` variant exists (function already returns array regardless of input shape)
     recursive : array<int>          // indices of arguments to apply fold_linq_default on
 }
 
@@ -92,6 +124,15 @@ var private linqCalls = {
     "order_by_to_array" => LinqCall(name = "order_by", inplace = true),
     "order_by_descending" => LinqCall(name = "order_by_descending", inplace = true),
     "order_by_descending_to_array" => LinqCall(name = "order_by_descending", inplace = true),
+// top-N terminal forms — always return array regardless of input shape, so no
+// `_to_array` / `_inplace` variants exist (would alias to the same function).
+// `noToArrayVariant=true` so first-position iterator-source rewrite is skipped.
+// Not marked inplace: rename to `<name>_inplace` at non-first positions would
+// fail at lookup time. Registered so flatten_linq recognizes them in chains.
+    "top_n" => LinqCall(name = "top_n", noToArrayVariant = true),
+    "top_n_by" => LinqCall(name = "top_n_by", noToArrayVariant = true),
+    "top_n_descending" => LinqCall(name = "top_n_descending", noToArrayVariant = true),
+    "top_n_by_descending" => LinqCall(name = "top_n_by_descending", noToArrayVariant = true),
 // aggregate
     "count" => LinqCall(name = "count"),
     "long_count" => LinqCall(name = "long_count"),
@@ -226,207 +267,27 @@ def private flatten_linq(var expr : Expression?)  {
     return <- (top, calls)
 }
 
-struct private FoldSequence {
-    //! Internal struct representing a fold operation sequence.
-    calls : array<string>
-    folder : function<(
-        argIndex : int;
-        var topValue : Expression?;
-        var blk : ExprBlock?;
-        var calls : array<tuple<ExprCall?; LinqCall?>>
-    ) : Expression?>
-}
-
-var private g_foldSeq = [               // those are applied in order
-// order and distinct (for both orders)
-    FoldSequence(
-        calls = ["order", "distinct" ],
-        folder = @@fold_order_distinct
-    ),
-    FoldSequence(
-        calls = ["distinct", "order" ],
-        folder = @@fold_order_distinct
-    ),
-// where + count (single-pass count, no intermediate filter array)
-    FoldSequence(
-        calls = ["where_", "count"],
-        folder = @@fold_where_count
-    ),
-// select and where
-    FoldSequence(
-        calls = ["where_", "select" ],
-        folder = @@fold_where_select
-    ),
-    FoldSequence(
-        calls = ["select", "where_"],
-        folder = @@fold_select_where
-    ),
-    FoldSequence(
-        calls = ["where_"],
-        folder = @@fold_where
-    ),
-    FoldSequence(
-        calls = ["select"],
-        folder = @@fold_select
-    ),
-]
-
 [macro_function]
-def private append_comprehension(argIndex : int; var topValue : Expression?; var comprehension : Expression?; var blk : ExprBlock?; at : LineInfo) : Expression? {
-    comprehension.force_at(at)
-    comprehension.force_generated(true)
-    let newArgName = "pass_{argIndex}"
-    blk.list |> emplace_new <| qmacro_expr() {
-        var $i(newArgName) <- $e(comprehension)
-    }
-    (blk.list.back() as ExprLet).variables[0].flags.can_shadow = true
-    if (argIndex != 0) {
-        blk.list |> emplace_new <| qmacro_expr() {
-            delete $e(topValue)
-        }
-    }
-    return qmacro($i(newArgName))
-}
-
-[macro_function]
-def private fold_order_distinct(argIndex : int; var topValue : Expression?; var blk : ExprBlock?; var calls : array<tuple<ExprCall?; LinqCall?>>) : Expression? {
-    //! replaces order + distinct into a single order + unique
-    if (argIndex == 0) {
-        var comprehension = qmacro(order_unique_folded($e(topValue)))
-        return append_comprehension(argIndex, topValue, comprehension, blk, calls[0]._0.at)
-    } else {
-        blk.list |> emplace_new <| qmacro(order_unique_folded_inplace($e(topValue)))
-        return clone_expression(topValue)
-    }
-}
-
-[macro_function]
-def private fold_where_select(argIndex : int; var topValue : Expression?; var blk : ExprBlock?; var calls : array<tuple<ExprCall?; LinqCall?>>) : Expression? {
-    //! folds where + select into a single comprehension
-    var eWhere = calls[0]._0
-    var eSelect = calls[1]._0
-    var iterType = clone_type(eWhere.arguments[0]._type.firstType)
-    var whereCond = fold_linq_cond(eWhere.arguments[1], "it")
-    var selectExpr : Expression?
-    if (eSelect != null) {
-        selectExpr = fold_linq_cond(eSelect.arguments[1], "it")
-    } else {
-        selectExpr = new ExprVar(name := "it", at = topValue.at, _type := iterType)
-    }
-    var comprehension = qmacro([for (it in $e(topValue)); $e(selectExpr); where $e(whereCond)])
-    return append_comprehension(argIndex, topValue, comprehension, blk, calls[0]._0.at)
-}
-
-[macro_function]
-def private fold_where(argIndex : int; var topValue : Expression?; var blk : ExprBlock?; var calls : array<tuple<ExprCall?; LinqCall?>>) : Expression? {
-    //! folds where + select into a single comprehension
-    var eWhere = calls[0]._0
-    var whereCond = fold_linq_cond(eWhere.arguments[1], "it")
-    var comprehension = qmacro([for (it in $e(topValue)); it; where $e(whereCond)])
-    return append_comprehension(argIndex, topValue, comprehension, blk, calls[0]._0.at)
-}
-
-[macro_function]
-def private fold_where_count(argIndex : int; var topValue : Expression?; var blk : ExprBlock?; var calls : array<tuple<ExprCall?; LinqCall?>>) : Expression? {
-    //! folds `_where(p) |> count()` into a single-pass loop with the predicate inlined — no intermediate filter array, no block-call overhead
-    var eWhere = calls[0]._0
-    let srcName = "`source`{argIndex}`{eWhere.at.line}`{eWhere.at.column}"
-    let itName  = "`it`{argIndex}`{eWhere.at.line}`{eWhere.at.column}"
-    let nName   = "`n`{argIndex}`{eWhere.at.line}`{eWhere.at.column}"
-    var whereCond = fold_linq_cond(eWhere.arguments[1], itName)
-    var fusedCall : Expression? = qmacro(invoke($($i(srcName) : typedecl($e(topValue)) - const) {
-        var $i(nName) = 0
-        for ($i(itName) in $i(srcName)) {
-            if ($e(whereCond)) {
-                $i(nName) ++
-            }
-        }
-        return $i(nName)
-    }, $e(topValue)))
-    fusedCall.force_at(calls[0]._0.at)
-    fusedCall.force_generated(true)
-    let newArgName = "pass_{argIndex}"
-    blk.list |> emplace_new <| qmacro_expr() {
-        var $i(newArgName) = $e(fusedCall)
-    }
-    (blk.list.back() as ExprLet).variables[0].flags.can_shadow = true
-    if (argIndex != 0) {
-        blk.list |> emplace_new <| qmacro_expr() {
-            delete $e(topValue)
-        }
-    }
-    return qmacro($i(newArgName))
-}
-
-[macro_function]
-def private fold_select(argIndex : int; var topValue : Expression?; var blk : ExprBlock?; var calls : array<tuple<ExprCall?; LinqCall?>>) : Expression? {
-    //! folds select into a single comprehension
-    var eSelect = calls[0]._0
-    var selectExpr = fold_linq_cond(eSelect.arguments[1], "it")
-    var comprehension = qmacro([for (it in $e(topValue)); $e(selectExpr)])
-    return append_comprehension(argIndex, topValue, comprehension, blk, calls[0]._0.at)
-}
-
-[macro_function]
-def private fold_select_where(argIndex : int; var topValue : Expression?; var blk : ExprBlock?; var calls : array<tuple<ExprCall?; LinqCall?>>) : Expression? {
-    //! folds where + select into a single comprehension-like expression
-    //! note, order of select and where is reversed
-    var eWhere = calls[1]._0
-    var eSelect = calls[0]._0
-    var iterType = clone_type(eWhere.arguments[0]._type.firstType)
-    var whereCond : Expression?
-    let srcName = "`source`{argIndex}`{eSelect.at.line}`{eSelect.at.column}"
-    let valName = "`value`{argIndex}`{eSelect.at.line}`{eSelect.at.column}"
-    let itName = "`it`{argIndex}`{eSelect.at.line}`{eSelect.at.column}"
-    let arrName = "`arr`{argIndex}`{eSelect.at.line}`{eSelect.at.column}"
-    whereCond = fold_linq_cond(eWhere.arguments[1], valName)
-    var selectExpr : Expression?
-    if (eSelect != null) {
-        selectExpr = fold_linq_cond(eSelect.arguments[1], itName)
-    } else {
-        selectExpr = new ExprVar(name := itName, at = topValue.at, _type := iterType)
-    }
-    var comprehension = qmacro(invoke($($i(srcName) : typedecl($e(topValue)) - const) {
-            var $i(arrName) : array<$t(iterType)>
-            for ($i(itName) in $i(srcName)) {
-                static_if (typeinfo is_workhorse($e(selectExpr))) {
-                    var $i(valName) = $e(selectExpr)
-                    if ($e(whereCond)) {
-                        $i(arrName).emplace($i(valName))
-                    }
-                } else {
-                    var $i(valName) <- $e(selectExpr)
-                    if ($e(whereCond)) {
-                        $i(arrName).emplace($i(valName))
-                    }
-                }
-            }
-            return <- $i(arrName)
-        }, $e(topValue)))
-    return append_comprehension(argIndex, topValue, comprehension, blk, calls[0]._0.at)
-}
-
-[macro_function]
-def private fold_linq_default(var expr : Expression?; recursiveMacroName : string) : Expression? {
-    //! fold sequence into
-    //!   invoke ( top, $ ( it ) : auto {
-    //!      var pass_0 = call0(it,...) // or call0_to_array(it,...)
-    //!      var pass_1 = call1(pass_0,...)
-    //!      ...
-    //!      return <- pass_N // or pass_N.to_sequence() if expr is iterator
-    //!   } )
-    //!   skip var if call is inplace
-    //!   skip delete if call is not first
-    //!   if call is first and source is iterator, then call is call_to_array
-    //!   if call is last and expr is iterator, then return is pass_N.to_sequence()
-    //!   if expr is not linq call, return null
+def private fold_linq_default(var expr : Expression?) : Expression? {
+    //! Tier-2 fallback emitter for ``_fold``. Emits the chain in array shape:
     //!
-    //! ``recursiveMacroName`` is the macro name used to wrap sub-pipeline
-    //! arguments (e.g. ``zip``'s second arg, ``concat``'s tail) so that each
-    //! top-level fold macro keeps recursing into itself: ``_fold`` recurses
-    //! into ``_fold``, ``_old_fold`` into ``_old_fold``. Threading the name
-    //! through this single call site keeps the frozen baseline truly frozen
-    //! once ``_fold`` diverges in later PRs.
+    //!   invoke ( top, $ ( source ) : auto {
+    //!      var pass_0 = call0(source,...) // or call0_to_array(...) if source is iterator
+    //!      var pass_1 = call1(pass_0,...) // or call1_inplace(pass_0,...) when callable inplace
+    //!      delete pass_0                  // free previous intermediate
+    //!      ...
+    //!      return <- pass_N               // or pass_N.to_sequence_move() if expr is iterator
+    //!   } )
+    //!
+    //! Rules:
+    //! - skip ``var pass_N`` binding if call is inplace
+    //! - skip ``delete pass_{N-1}`` if N == 0 (no previous intermediate to free)
+    //! - if first call and source is iterator, rename to ``call_to_array`` (materialize once)
+    //! - if last call and expr is iterator, return ``pass_N.to_sequence_move()``
+    //! - if expr has no linq calls (``flatten_linq`` returns empty), return ``null`` so the
+    //!   ``_fold`` cascade can fall through to tier 3 (raw clone)
+    //! - recursive linq sub-args (e.g. ``zip``'s second arg) are wrapped in a fresh
+    //!   ``_fold`` call so the cascade applies to them too
     var blk = new ExprBlock(at = expr.at)
     var (top, calls) = flatten_linq(expr)
     if (empty(calls)) return null
@@ -441,69 +302,51 @@ def private fold_linq_default(var expr : Expression?; recursiveMacroName : strin
             let newArgName = "pass_{argIndex}"
             var callName = cll._1.name
             var inplace = false
-            // lets find folding sequences
-            var found : FoldSequence?
-            for (fs in g_foldSeq) {
-                if (fs.calls |> length + argIndex - 1 < argMax) {
-                    var match = true
-                    for (i in 0 .. fs.calls |> length) {
-                        if (fs.calls[i] != unsafe(calls[argIndex + i]._1.name)) {
-                            match = false
-                            break
-                        }
-                    }
-                    if (match) {
-                        found = unsafe(addr(fs))
-                        break
-                    }
+            if (cll._0._type.isIterator || cll._0._type.isGoodArrayType) {
+                // Canonical names that end in `_` (e.g. `where_`, to avoid the daslang
+                // `where` keyword) need the suffix joined without a connecting `_`,
+                // since the actual function names are `where_to_array` / `where_inplace`
+                // (single underscore between the base and the suffix).
+                let sep : string = ends_with(callName, "_") ? "" : "_"
+                if (argIndex == 0 && top._type.isIterator && !cll._1.noToArrayVariant) {
+                    callName = "{callName}{sep}to_array"
+                } elif (argIndex != 0 && cll._1.inplace) {
+                    callName = "{callName}{sep}inplace"
+                    inplace = true
                 }
             }
-            if (found != null) {
-                var sub = subarray(calls, argIndex .. argIndex + found.calls |> length)
-                topValue = found.folder(argIndex, topValue, blk, sub)
-                argIndex += found.calls |> length
+            for (i in cll._1.recursive) {   // recurse into sub-pipeline args (e.g. zip's second arg)
+                if (i >= 1 && i < cll._0.arguments |> length && is_linq_call(cll._0.arguments[i])) {
+                    var argExpr = make_call(cll._0.at, "_fold")
+                    (argExpr as ExprCallMacro).arguments |> emplace <| cll._0.arguments[i]
+                    cll._0.arguments[i] = argExpr
+                }
+            }
+            var newCall = qmacro($c(callName)($e(topValue)))
+            let numArgs = cll._0.arguments |> length
+            for (i in 1..numArgs) {
+                (newCall as ExprCall).arguments |> emplace_new <| clone_expression(cll._0.arguments[i])
+            }
+            if (inplace) {
+                blk.list |> emplace(newCall)
             } else {
-                if (cll._0._type.isIterator || cll._0._type.isGoodArrayType) {
-                    if (argIndex == 0 && top._type.isIterator) {
-                        callName = "{callName}_to_array"
-                    } elif (argIndex != 0 && cll._1.inplace) {
-                        callName = "{callName}_inplace"
-                        inplace = true
-                    }
+                // Macro emits `var pass_N = call` and a later `return <- pass_N`;
+                // for single-pass chains this triggers PERF009 (move-into-then-return)
+                // at the user call site. The shape is load-bearing for the array-pipeline
+                // semantics (every stage binds so the next can reuse the buffer in-place),
+                // so suppress the rule inline below.
+                blk.list |> emplace_new <| qmacro_expr() {
+                    var $i(newArgName) = $e(newCall)  // nolint:PERF009
                 }
-                for (i in cll._1.recursive) {   // this is where we make recursion
-                    if (i >= 1 && i < cll._0.arguments |> length && is_linq_call(cll._0.arguments[i])) {
-                        var argExpr = make_call(cll._0.at, recursiveMacroName)
-                        (argExpr as ExprCallMacro).arguments |> emplace <| cll._0.arguments[i]
-                        cll._0.arguments[i] = argExpr
-                    }
-                }
-                var newCall = qmacro($c(callName)($e(topValue)))
-                let numArgs = cll._0.arguments |> length
-                for (i in 1..numArgs) {
-                    (newCall as ExprCall).arguments |> emplace_new <| clone_expression(cll._0.arguments[i])
-                }
-                if (inplace) {
-                    blk.list |> emplace(newCall)
-                } else {
-                    // Macro emits `var pass_N = call` and a later `return <- pass_N`;
-                    // for single-pass chains this triggers PERF009 (move-into-then-return)
-                    // at the user call site. Rewriting to direct `return <- call` would
-                    // change the historical `_old_fold` baseline that benchmarks compare
-                    // against, so we keep the shape and suppress the rule inline below.
+                (blk.list.back() as ExprLet).variables[0].flags.can_shadow = true
+                if (argIndex != 0) {
                     blk.list |> emplace_new <| qmacro_expr() {
-                        var $i(newArgName) = $e(newCall)  // nolint:PERF009
+                        delete $e(topValue)
                     }
-                    (blk.list.back() as ExprLet).variables[0].flags.can_shadow = true
-                    if (argIndex != 0) {
-                        blk.list |> emplace_new <| qmacro_expr() {
-                            delete $e(topValue)
-                        }
-                    }
-                    topValue = qmacro($i(newArgName))
                 }
-                argIndex ++
+                topValue = qmacro($i(newArgName))
             }
+            argIndex ++
         }
     }
     if (expr._type.isIterator) {
@@ -1140,6 +983,174 @@ def private emit_early_exit_lane(
 }
 
 [macro_function]
+def private order_top_n_call_name(orderName : string) : string {
+    //! Maps an order-family operator name to the corresponding ``top_n*`` helper from linq.das.
+    if (orderName == "order") return "top_n"
+    if (orderName == "order_descending") return "top_n_descending"
+    if (orderName == "order_by") return "top_n_by"
+    if (orderName == "order_by_descending") return "top_n_by_descending"
+    return ""
+}
+
+[macro_function]
+def private plan_order_family(var expr : Expression?) : Expression? {
+    //! Phase 3 splice planner for chains containing an order-family operator.
+    //! Recognized chain shapes (terminator can be the order/take op itself, or implicit
+    //! ``to_array`` which is ``skip=true`` so flatten_linq elides it):
+    //!
+    //! - ``src |> order[_descending]?``                                    → direct call
+    //! - ``src |> order_by[_descending]?(key)``                            → direct call
+    //! - ``src |> order[_by]?[_descending]?[(key)] |> take(K)``            → ``top_n*`` helper
+    //! - ``src |> where_*(p)+ |> order[_by]?[_descending]?[(key)]``        → fused prefilter + ``order*_inplace``
+    //! - ``src |> where_*(p)+ |> order[_by]?[_descending]?[(key)] |> take(K)`` → fused prefilter + ``top_n*``
+    //!
+    //! Combinations with ``select`` / ``skip`` / non-ARRAY terminators (sum/count/etc. after
+    //! the order op) are out of scope and fall through to cascade tier 2.
+    var (top, calls) = flatten_linq(expr)
+    if (empty(calls)) return null
+    top = peel_each(top)
+    var whereCond : Expression?
+    var orderName : string
+    var orderKey : Expression?
+    var orderElemType : TypeDeclPtr
+    var takeExpr : Expression?
+    var hasOrder = false
+    let at = calls[0]._0.at
+    let itName = "`it`{at.line}`{at.column}"
+    for (i in 0 .. length(calls)) {
+        var cll & = unsafe(calls[i])
+        let name = cll._1.name
+        if (name == "where_") {
+            if (hasOrder) return null   // where-after-order not in scope
+            var pred = fold_linq_cond(cll._0.arguments[1], itName)
+            if (whereCond == null) {
+                whereCond = pred
+            } else {
+                whereCond = qmacro($e(whereCond) && $e(pred))
+            }
+        } elif (name == "order" || name == "order_descending"
+                || name == "order_by" || name == "order_by_descending") {
+            if (hasOrder) return null
+            hasOrder = true
+            orderName = name
+            if ((cll._0.arguments |> length) >= 2) {
+                orderKey = clone_expression(cll._0.arguments[1])
+            }
+            orderElemType = clone_type(cll._0._type.firstType)
+        } elif (name == "take") {
+            if (!hasOrder || takeExpr != null) return null
+            var arg = cll._0.arguments[1]
+            if (arg == null || arg._type == null || arg._type.baseType != Type.tInt) return null
+            takeExpr = clone_expression(arg)
+        } else {
+            return null
+        }
+    }
+    if (!hasOrder) return null
+    let hasKey = orderName == "order_by" || orderName == "order_by_descending"
+    let needIterWrap = expr._type.isIterator
+    let topNName = order_top_n_call_name(orderName)
+    let inplaceName = "{orderName}_inplace"
+    if (whereCond == null) {
+        // No prefilter — direct call to daslib helper.
+        var topExpr = clone_expression(top)
+        topExpr.genFlags.alwaysSafe = true
+        var emission : Expression?
+        if (takeExpr == null) {
+            // Bare order family — emit the direct call. Same shape as plain LINQ, but via
+            // splice so `_fold` doesn't fall through to tier 2.
+            if (hasKey) {
+                emission = qmacro($c(orderName)($e(topExpr), $e(orderKey)))
+            } else {
+                emission = qmacro($c(orderName)($e(topExpr)))
+            }
+        } else {
+            // order + take → top_n* dispatch.
+            if (hasKey) {
+                emission = qmacro($c(topNName)($e(topExpr), $e(takeExpr), $e(orderKey)))
+            } else {
+                emission = qmacro($c(topNName)($e(topExpr), $e(takeExpr)))
+            }
+        }
+        // Wrap with to_sequence_move only when emission is array-shaped: take dispatches to
+        // top_n* (always returns array) or the source was peeled to an array. For an
+        // iterator source on the bare-order path, daslib's order_*(iter,…) overload already
+        // returns iterator — wrapping would compile-fail (to_sequence_move is array-only).
+        let emissionIsArray = takeExpr != null || top._type.isGoodArrayType
+        if (needIterWrap && emissionIsArray) {
+            emission = qmacro($e(emission).to_sequence_move())
+        }
+        emission.force_generated(true)
+        return emission
+    }
+    // where_* + order_*[+take] — emit a single fused loop that prefilters into a fresh
+    // buffer, then sorts in place (no take) or extracts top-N (take). This collapses what
+    // plain LINQ would do as two array allocations + iterator dispatch into one allocation
+    // and one sort pass.
+    let srcName = "`source`{at.line}`{at.column}"
+    let bufName = "`buf`{at.line}`{at.column}"
+    var srcParamType = invoke_src_param_type(top)
+    var topExpr = clone_expression(top)
+    topExpr.genFlags.alwaysSafe = true
+    var bufElemType = clone_type(orderElemType)
+    var loopBody = qmacro_expr() {
+        if ($e(whereCond)) {
+            $i(bufName) |> push_clone($i(itName))
+        }
+    }
+    var stmts : array<Expression?>
+    stmts |> push <| qmacro_expr() {
+        var $i(bufName) : array<$t(bufElemType)>
+    }
+    if (type_has_length(top._type)) {
+        stmts |> push <| qmacro_expr() {
+            $i(bufName) |> reserve(length($i(srcName)))
+        }
+    }
+    stmts |> push <| qmacro_expr() {
+        for ($i(itName) in $i(srcName)) {
+            $e(loopBody)
+        }
+    }
+    if (takeExpr == null) {
+        // Sort the prefilter buffer in place and return it. order*_inplace is void
+        // (mutates the buffer in place), so we move the buffer out for the final result.
+        var sortCall : Expression?
+        if (hasKey) {
+            sortCall = qmacro($c(inplaceName)($i(bufName), $e(orderKey)))
+        } else {
+            sortCall = qmacro($c(inplaceName)($i(bufName)))
+        }
+        stmts |> push(sortCall)
+        stmts |> push <| qmacro_expr() {
+            return <- $i(bufName)
+        }
+    } else {
+        // top_n* on the prefilter buffer.
+        var topNCall : Expression?
+        if (hasKey) {
+            topNCall = qmacro($c(topNName)($i(bufName), $e(takeExpr), $e(orderKey)))
+        } else {
+            topNCall = qmacro($c(topNName)($i(bufName), $e(takeExpr)))
+        }
+        stmts |> push <| qmacro_expr() {
+            return <- $e(topNCall)
+        }
+    }
+    var bodyBlock = new ExprBlock(at = at)
+    for (s in stmts) {
+        bodyBlock.list |> emplace(s)
+    }
+    var emission : Expression? = qmacro(invoke($($i(srcName) : $t(srcParamType)) {
+        $e(bodyBlock);
+    }, $e(topExpr)))
+    if (needIterWrap) {
+        emission = qmacro($e(emission).to_sequence_move())
+    }
+    return finalize_invoke(emission, at)
+}
+
+[macro_function]
 def private plan_loop_or_count(var expr : Expression?) : Expression? {
     // Phase-2C loop planner. Recognizes chains of shape `[where_*][select*][skip?][take?]`
     // plus a terminator, dispatched by `classify_terminator` into one of four lanes:
@@ -1185,10 +1196,29 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
         var cll & = unsafe(calls[i])
         let opName = cll._1.name
         if (opName == "where_") {
-            // where-after-select / -after-skip / -after-take is rejected — canonical chain
-            // order is [where_*][select*][skip?][take?].
-            if (seenSelect || seenSkip || seenTake) return null
-            var predicate = fold_linq_cond(cll._0.arguments[1], itName)
+            // skip/take-after-where is rejected — canonical chain order is
+            // [where_*][select*][skip?][take?].
+            if (seenSkip || seenTake) return null
+            var predicate : Expression?
+            if (seenSelect) {
+                // Phase 3d: where-after-select. Substitute the predicate's bound variable
+                // with the current projection via peel-aware substitution. The substitution
+                // inlines the projection into the predicate, which would re-evaluate any
+                // side effects (since the terminator also references projection) — bail to
+                // tier 2 cascade on side-effecty projections.
+                //
+                // KNOWN PERF GAP (deferred to splice-with-cmp follow-up PR): pure projections
+                // currently re-evaluate per element for ARRAY/ACCUMULATOR/EARLY_EXIT lanes —
+                // once in the inlined predicate and once in valueExpr. COUNTER lane is unaffected
+                // (no body use). Fix shape: emit a pre-condition `var v := projection` bind in
+                // the loop body (outside the if-wrap) and rewrite both predicate and valueExpr
+                // to reference `v`. Bundled with the `_with_cmp` inline-key follow-up since
+                // both share the "single-eval splice" theme.
+                if (has_sideeffects(projection)) return null
+                predicate = fold_linq_cond_peel(cll._0.arguments[1], projection)
+            } else {
+                predicate = fold_linq_cond(cll._0.arguments[1], itName)
+            }
             if (whereCond == null) {
                 whereCond = predicate
             } else {
@@ -1337,40 +1367,40 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
 
 [call_macro(name="_fold")]
 class private LinqFold : AstCallMacro {
-    //! implements _fold(expression) that folds LINQ expressions into optimized sequnences
-    //! for example::
+    //! ``_fold(expr)`` — three-tier cascade over a LINQ chain.
     //!
-    //!     _fold(each(foo)._where(_ > 5)._select(_ * 2))
+    //! 1. **Splice** (``plan_loop_or_count``) — fused for-loop with predicates
+    //!    and projections inlined, when the chain matches a recognized pattern.
+    //! 2. **Array-shape pipeline** (``fold_linq_default``) — ``call → array →
+    //!    call → array`` with ``_inplace`` reuse and explicit ``delete`` of
+    //!    previous stages, when the chain has linq operators but splice can't fire.
+    //! 3. **Raw clone** — passthrough when ``flatten_linq`` finds no recognized
+    //!    linq operators in the chain.
     //!
-    //! expands into a single comprehension that does all operations in one pass
+    //! All tiers preserve semantics. ``_fold(chain)`` is observationally equivalent
+    //! to ``chain``, just faster when patterns match. Always safe to apply.
+    //!
+    //! Example::
+    //!
+    //!     _fold(each(foo)._where(_ > 5)._select(_ * 2).sum())
+    //!
+    //! Expands tier-1 into a single fused loop accumulating the sum directly.
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
-        //! Visits the _fold macro call and folds LINQ expressions into optimized sequences.
+        //! Visits the _fold macro call and runs the three-tier cascade.
         macro_verify(call.arguments |> length == 1, prog, call.at, "expecting _fold(expression)")
         macro_verify(call.arguments[0]._type != null, prog, call.at, "expecting linq expression")
-        var res : Expression? = plan_loop_or_count(call.arguments[0])
+        // Tier 1 splice — try the dedicated order-family planner first (handles
+        // chains containing order / order_by / order_descending / order_by_descending,
+        // optionally followed by take(K)), then the general loop planner for the
+        // [where_*][select*][skip?][take?] + terminator shapes.
+        var res : Expression? = plan_order_family(call.arguments[0])
         if (res != null) return res
+        res = plan_loop_or_count(call.arguments[0])
+        if (res != null) return res
+        // Tier 2 — array-shape pipeline with `_inplace` reuse + explicit `delete`.
+        res = fold_linq_default(call.arguments[0])
+        if (res != null) return res
+        // Tier 3 — raw passthrough.
         return clone_expression(call.arguments[0])
-    }
-}
-
-[call_macro(name="_old_fold")]
-class private LinqOldFold : AstCallMacro {
-    //! Frozen pre-rewrite baseline of ``_fold``. Same expansion as ``_fold``
-    //! today; the two diverge only when later PRs add splice-mode fusion to
-    //! ``_fold``. Benchmarks compare ``_fold`` vs ``_old_fold`` to track
-    //! performance work — ``_old_fold`` must keep producing the historical
-    //! shape so the comparison stays meaningful.
-    //! for example::
-    //!
-    //!     _old_fold(each(foo)._where(_ > 5)._select(_ * 2))
-    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
-        macro_verify(call.arguments |> length == 1, prog, call.at, "expecting _old_fold(expression)")
-        macro_verify(call.arguments[0]._type != null, prog, call.at, "expecting linq expression")
-        var res : Expression? = fold_linq_default(call.arguments[0], "_old_fold")
-        if (res == null) {
-            prog |> macro_error(call.at, "cannot fold LINQ expression\n{describe(call.arguments[0])}")
-            return res
-        }
-        return res
     }
 }

--- a/daslib/templates_boost.das
+++ b/daslib/templates_boost.das
@@ -27,6 +27,7 @@ struct Template {
     field2name : table<string; string>                                          //! field name replacement rules
     var2name : table<string; string>                                            //! variable name replacement rules
     var2expr : table<string; Expression?>                                        //! variable expression replacement rules
+    var2exprPeeling : table<string; Expression?>                                 //! variable expression replacement rules that also peel ExprRef2Value wrappers (use on typed AST)
     var2exprList : table<string; array<Expression?>>                             //! variable expression list replacement rules
     type2type : table<string; string>                                           //! type name replacement rules
     type2etype : table<string; TypeDeclPtr>                                     //! type to type declaration replacement rules
@@ -46,6 +47,20 @@ def kaboomVarField(var self : Template; name, prefix, suffix : string) {
 def replaceVariable(var self : Template; name : string; var expr : ast::Expression?) {
     //! Adds a rule to the template to replace a variable with an expression.
     self.var2expr |> emplace(name, expr)
+}
+
+def replaceVariablePeeling(var self : Template; name : string; var expr : ast::Expression?) {
+    //! Variant of ``replaceVariable`` for substituting into typed AST. Replaces
+    //! ``ExprRef2Value(ExprVar(name))`` with the replacement directly — stripping
+    //! the wrapper that the typer inserts around reference-typed variable reads.
+    //! Use this when the destination AST has already been through type inference
+    //! (e.g. inside a ``call_macro`` body); plain ``replaceVariable`` leaves the
+    //! ``ExprRef2Value`` orphaned around a non-reference value and fails with
+    //! ``can only dereference a reference``.
+    //! Do not register the same name with both ``replaceVariable`` and
+    //! ``replaceVariablePeeling`` — bottom-up traversal makes the bare-var rule win
+    //! and re-introduces the orphan-wrapper bug.
+    self.var2exprPeeling |> emplace(name, expr)
 }
 
 def replaceVarTag(var self : Template; name : string; var expr : ast::Expression?) {
@@ -236,6 +251,22 @@ class private TemplateVisitor : AstVisitor {
             var rexpr = clone_expression(unsafe(rules.var2expr[vn]))
             rexpr.at = expr.at
             return rexpr
+        }
+        return expr
+    }
+    def override visitExprRef2Value(var expr : ExprRef2Value?) : Expression? {
+        //! Peeling substitution for typed AST. When the inner ExprVar matches a
+        //! ``var2exprPeeling`` rule, returns the replacement directly — stripping
+        //! the typer-inserted ExprRef2Value wrapper that would otherwise be left
+        //! orphaned around a non-reference value.
+        if (expr.subexpr is ExprVar) {
+            let vvar = expr.subexpr as ExprVar
+            let vn = string(vvar.name)
+            if (key_exists(rules.var2exprPeeling, vn)) {
+                var rexpr = clone_expression(unsafe(rules.var2exprPeeling[vn]))
+                rexpr.at = expr.at
+                return rexpr
+            }
         }
         return expr
     }

--- a/src/builtin/module_builtin_runtime_sort.cpp
+++ b/src/builtin/module_builtin_runtime_sort.cpp
@@ -84,7 +84,7 @@ namespace das
     void builtin_sort_string ( void * data, int32_t length ) {
         if ( length<=1 ) return;
         const char ** pdata = (const char **) data;
-        sort ( pdata, pdata + length, [&](const char * a, const char * b){
+        das_sort ( pdata, pdata + length, [&](const char * a, const char * b){
             return strcmp(to_rts(a), to_rts(b))<0;
         });
     }

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -800,9 +800,6 @@ def test_sum_accumulator(t : T?) {
         let arr <- [1, 2, 3, 4, 5]
         let s = _fold(each(arr).sum())
         t |> equal(15, s)
-        // parity vs _old_fold
-        let s_old = _old_fold(each(arr).sum())
-        t |> equal(s_old, s)
     }
     t |> run("sum: where filter") @(t : T?) {
         let arr <- [1, 2, 3, 4, 5]
@@ -838,8 +835,6 @@ def test_min_accumulator(t : T?) {
         let arr <- [5, 3, 8, 1, 4]
         let m = _fold(each(arr).min())
         t |> equal(1, m)
-        let m_old = _old_fold(each(arr).min())
-        t |> equal(m_old, m)
     }
     t |> run("min: where filter") @(t : T?) {
         let arr <- [5, 3, 8, 1, 4]
@@ -869,8 +864,6 @@ def test_max_accumulator(t : T?) {
         let arr <- [5, 3, 8, 1, 4]
         let m = _fold(each(arr).max())
         t |> equal(8, m)
-        let m_old = _old_fold(each(arr).max())
-        t |> equal(m_old, m)
     }
     t |> run("max: where filter") @(t : T?) {
         let arr <- [5, 3, 8, 1, 4]
@@ -900,8 +893,6 @@ def test_average_accumulator(t : T?) {
         let arr <- [2, 4, 6, 8]
         let a = _fold(each(arr).average())
         t |> equal(5.0lf, a)
-        let a_old = _old_fold(each(arr).average())
-        t |> equal(a_old, a)
     }
     t |> run("average: where filter") @(t : T?) {
         let arr <- [1, 2, 3, 4, 5]
@@ -927,8 +918,6 @@ def test_long_count_accumulator(t : T?) {
         let arr <- [1, 2, 3, 4, 5]
         let c = _fold(each(arr).long_count())
         t |> equal(5l, c)
-        let c_old = _old_fold(each(arr).long_count())
-        t |> equal(c_old, c)
     }
     t |> run("long_count: where filter") @(t : T?) {
         let arr <- [1, 2, 3, 4, 5]
@@ -954,8 +943,6 @@ def test_first_early_exit(t : T?) {
         let arr <- [7, 8, 9]
         let f = _fold(each(arr).first())
         t |> equal(7, f)
-        let f_old = _old_fold(each(arr).first())
-        t |> equal(f_old, f)
     }
     t |> run("first: where matches returns first match") @(t : T?) {
         let arr <- [1, 2, 3, 4, 5]
@@ -980,8 +967,6 @@ def test_first_or_default_early_exit(t : T?) {
         let arr <- [7, 8, 9]
         let f = _fold(each(arr).first_or_default(99))
         t |> equal(7, f)
-        let f_old = _old_fold(each(arr).first_or_default(99))
-        t |> equal(f_old, f)
     }
     t |> run("first_or_default: where matches returns first match") @(t : T?) {
         let arr <- [1, 2, 3, 4, 5]
@@ -1306,5 +1291,39 @@ def test_chained_non_workhorse_select(t : T?) {
             .max())
         // _ * 2 → [2,4,6,8,10]; .a[1] → [3,5,7,9,11]; max = 11
         t |> equal(11, r)
+    }
+}
+
+[test]
+def test_iterator_source_bare_order(t : T?) {
+    // Regression — splice path for bare order family on an iterator source. peel_each only
+    // unwraps `each(<array>)`; `each(<iterator-yielding source>)` leaves an iterator on top.
+    // Old planner unconditionally wrapped the emission with `to_sequence_move()` whenever
+    // `expr._type.isIterator`, which compile-errored because daslib's `order_*(iter,…)`
+    // overloads already return iterator and `to_sequence_move` is array-only.
+    t |> run("each(range) |> order_by — splice emits iter-returning overload") @(tt : T?) {
+        var query = _fold(each(range(0, 5))._order_by(-_))
+        // range(0,5) = [0,1,2,3,4]; ordered by -v = [4,3,2,1,0]
+        let expected = [4, 3, 2, 1, 0]
+        for (v, i in query, 0 .. 5) {
+            tt |> equal(expected[i], v)
+        }
+    }
+}
+
+[test]
+def test_top_n_mid_chain_iterator_source(t : T?) {
+    // Regression — `top_n_*` registered in linqCalls but always returns array regardless of
+    // input shape, so no `_to_array` variant exists. `fold_linq_default`'s first-position
+    // iterator-source rewrite must skip the `_to_array` suffix for these. Hits when the user
+    // hand-pipes `top_n_*(...)` mid-chain (it isn't a comprehension form, so this is the
+    // only way to land here, but the path is real and the bug was a compile error.)
+    t |> run("each(range) |> top_n_by |> _select — top_n_by stays unrewritten") @(tt : T?) {
+        var query = _fold(each(range(0, 10)) |> top_n_by(3, @@(v : int) => -v) |> _select(_ + 100))
+        // top_n_by smallest 3 by -v ⇒ largest 3 by v = [9, 8, 7]; + 100 ⇒ [109, 108, 107]
+        let expected = [109, 108, 107]
+        for (v, i in query, 0 .. 3) {
+            tt |> equal(expected[i], v)
+        }
     }
 }

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -30,11 +30,6 @@ def target_where_select_fold() : array<int> {
 }
 
 [export, marker(no_coverage)]
-def target_select_where_fold() : array<int> {
-    return <- [1, 2, 3, 4, 5]._select(_ * 2)._where(_ > 6)._fold()
-}
-
-[export, marker(no_coverage)]
 def target_reverse_where_fold() : array<int> {
     return <- [1, 2, 3, 4, 5].to_sequence().reverse()._where(_ > 3).to_array()._fold()
 }
@@ -52,318 +47,6 @@ def target_zip3_fold() : array<tuple<int; int; int>> {
 [export, marker(no_coverage)]
 def target_zip3_predicate_fold() : array<int> {
     return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1), [100, 200, 300]._select(_ / 10), $(a, b, c : int) => a + b + c)._fold()
-}
-
-// `_old_fold` targets — used by retargeted AST tests that document the frozen comprehension contract.
-[export, marker(no_coverage)]
-def target_where_old_fold() : array<int> {
-    return <- [1, 2, 3, 4, 5]._where(_ > 3)._old_fold()
-}
-
-[export, marker(no_coverage)]
-def target_select_old_fold() : array<int> {
-    return <- [1, 2, 3, 4, 5]._select(_ * 2)._old_fold()
-}
-
-[export, marker(no_coverage)]
-def target_where_select_old_fold() : array<int> {
-    return <- [1, 2, 3, 4, 5]._where(_ > 3)._select(_ * 2)._old_fold()
-}
-
-[export, marker(no_coverage)]
-def target_select_where_old_fold() : array<int> {
-    return <- [1, 2, 3, 4, 5]._select(_ * 2)._where(_ > 6)._old_fold()
-}
-
-[export, marker(no_coverage)]
-def target_reverse_where_old_fold() : array<int> {
-    return <- [1, 2, 3, 4, 5].to_sequence().reverse()._where(_ > 3).to_array()._old_fold()
-}
-
-[export, marker(no_coverage)]
-def target_zip_old_fold() : array<tuple<int; int>> {
-    return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1))._old_fold()
-}
-
-[export, marker(no_coverage)]
-def target_zip3_old_fold() : array<tuple<int; int; int>> {
-    return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1), [100, 200, 300]._select(_ / 10))._old_fold()
-}
-
-[export, marker(no_coverage)]
-def target_zip3_predicate_old_fold() : array<int> {
-    return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1), [100, 200, 300]._select(_ / 10), $(a, b, c : int) => a + b + c)._old_fold()
-}
-
-// ── Tests: _old_fold contract — comprehension emission (frozen baseline) ──
-// These tests retain the pre-rewrite AST shape that `_fold` used to emit.
-// `_fold` itself has diverged (Phase 2A loop planner); see test_*_fold_emits_loop
-// below for the current `_fold` shape contract. The pair documents the
-// comprehension-vs-loop split between the two macros.
-
-[test]
-def test_where_old_fold_produces_comprehension(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_where_old_fold)
-        t |> success(func != null, "should find target_where_old_fold")
-        if (func == null) return
-        // fold_where output: invoke($(var source) .. var pass_0 <- COMP; return <- pass_0 .., src)
-        var comp_expr : ExpressionPtr
-        var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() { // nolint:STYLE016
-            return <- invoke($(var source : array<int>) {
-                var pass_0 : array<int> <- $e(comp_expr)
-                return <- pass_0
-            }, $e(source_expr))
-        }
-        t |> success(r.matched, "should match fold invoke structure, error={int(r.error)}")
-        if (!r.matched) return
-        // Verify the captured expression is a comprehension with where
-        var resolved <- qm_resolve_comprehension(comp_expr)
-        t |> success(resolved != null, "inner expression should be a comprehension")
-        if (resolved == null) return
-        let ac = resolved as ExprArrayComprehension
-        t |> success(ac.exprWhere != null, "comprehension should have where clause")
-    }
-}
-
-[test]
-def test_where_old_fold_comprehension_pattern(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_where_old_fold)
-        if (func == null) return
-        // Match the full structure including comprehension pattern
-        var where_cond : ExpressionPtr
-        var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() { // nolint:STYLE016
-            return <- invoke($(var source : array<int>) {
-                var pass_0 : array<int> <- [for (it in source); it; where $e(where_cond)]
-                return <- pass_0
-            }, $e(source_expr))
-        }
-        t |> success(r.matched, "should match comprehension with where, error={int(r.error)}")
-    }
-}
-
-[test]
-def test_select_old_fold_produces_comprehension(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_select_old_fold)
-        t |> success(func != null, "should find target_select_old_fold")
-        if (func == null) return
-        var comp_expr : ExpressionPtr
-        var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() { // nolint:STYLE016
-            return <- invoke($(var source : array<int>) {
-                var pass_0 : array<int> <- $e(comp_expr)
-                return <- pass_0
-            }, $e(source_expr))
-        }
-        t |> success(r.matched, "should match fold structure, error={int(r.error)}")
-        if (!r.matched) return
-        var resolved <- qm_resolve_comprehension(comp_expr)
-        t |> success(resolved != null, "inner should be a comprehension")
-        if (resolved == null) return
-        let ac = resolved as ExprArrayComprehension
-        t |> success(ac.exprWhere == null, "select-only comprehension should have no where clause")
-    }
-}
-
-[test]
-def test_select_old_fold_comprehension_pattern(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_select_old_fold)
-        if (func == null) return
-        var select_expr : ExpressionPtr
-        var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() { // nolint:STYLE016
-            return <- invoke($(var source : array<int>) {
-                var pass_0 : array<int> <- [for (it in source); $e(select_expr)]
-                return <- pass_0
-            }, $e(source_expr))
-        }
-        t |> success(r.matched, "should match comprehension without where, error={int(r.error)}")
-        if (!r.matched) return
-        // Verify the select expression is a multiplication: it * 2
-        let r2 = qmatch(select_expr, it * 2)
-        t |> success(r2.matched, "select expression should be it * 2")
-    }
-}
-
-[test]
-def test_where_select_old_fold_comprehension(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_where_select_old_fold)
-        t |> success(func != null, "should find target_where_select_old_fold")
-        if (func == null) return
-        var select_expr : ExpressionPtr
-        var where_cond : ExpressionPtr
-        var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() { // nolint:STYLE016
-            return <- invoke($(var source : array<int>) {
-                var pass_0 : array<int> <- [for (it in source); $e(select_expr); where $e(where_cond)]
-                return <- pass_0
-            }, $e(source_expr))
-        }
-        t |> success(r.matched, "should match comprehension with where+select, error={int(r.error)}")
-        if (!r.matched) return
-        // Verify select is multiplication and where is comparison
-        let r_sel = qmatch(select_expr, it * 2)
-        t |> success(r_sel.matched, "select should be it * 2")
-        let r_where = qmatch(where_cond, it > 3)
-        t |> success(r_where.matched, "where should be it > 3")
-    }
-}
-
-[test]
-def test_select_where_old_fold_structure(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_select_where_old_fold)
-        t |> success(func != null, "should find target_select_where_old_fold")
-        if (func == null) return
-        // select_where fold produces an invoke with a lambda that has a for loop + if
-        // It is NOT a simple comprehension - verify the fold still happened
-        var inner_expr : ExpressionPtr
-        var source_expr : ExpressionPtr
-        let r = qmatch_function(func) $() { // nolint:STYLE016
-            return <- invoke($(var source : array<int>) {
-                var pass_0 : array<int> <- $e(inner_expr)
-                return <- pass_0
-            }, $e(source_expr))
-        }
-        t |> success(r.matched, "should match fold invoke structure, error={int(r.error)}")
-        if (!r.matched) return
-        // The inner expression should NOT be a comprehension (select_where uses a different strategy)
-        var resolved <- qm_resolve_comprehension(inner_expr)
-        t |> success(resolved == null, "select_where should not produce a simple comprehension")
-    }
-}
-
-[test]
-def test_reverse_where_old_fold_structure(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_reverse_where_old_fold)
-        t |> success(func != null, "should find target_reverse_where_old_fold")
-        if (func == null) return
-        // Multi-step fold: reverse_to_array + where comprehension
-        var body_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
-            return <- $e(body_expr)
-        }
-        t |> success(r.matched, "should have a return expression")
-        if (!r.matched) return
-        t |> success(body_expr is ExprInvoke, "fold should produce invoke wrapper")
-    }
-}
-
-[test]
-def test_zip_old_fold_structure(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_zip_old_fold)
-        t |> success(func != null, "should find target_zip_old_fold")
-        if (func == null) return
-        // zip fold recursively folds the second argument
-        var body_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
-            return <- $e(body_expr)
-        }
-        t |> success(r.matched, "should match return expression")
-        if (!r.matched) return
-        t |> success(body_expr is ExprInvoke, "fold should produce invoke wrapper")
-    }
-}
-
-// ── Behavioral verification (fold produces correct results) ────────────
-
-[test]
-def test_where_fold_result(t : T?) {
-    t |> run("where fold produces correct values") @(t : T?) {
-        let result <- target_where_fold()
-        t |> equal(length(result), 2)
-        t |> equal(result[0], 4)
-        t |> equal(result[1], 5)
-    }
-}
-
-[test]
-def test_select_fold_result(t : T?) {
-    t |> run("select fold produces correct values") @(t : T?) {
-        let result <- target_select_fold()
-        t |> equal(length(result), 5)
-        let expected = [2, 4, 6, 8, 10]
-        for (i, v in 0..5, result) {
-            t |> equal(expected[i], v)
-        }
-    }
-}
-
-[test]
-def test_where_select_fold_result(t : T?) {
-    t |> run("where_select fold produces correct values") @(t : T?) {
-        let result <- target_where_select_fold()
-        t |> equal(length(result), 2)
-        t |> equal(result[0], 8)
-        t |> equal(result[1], 10)
-    }
-}
-
-[test]
-def test_select_where_fold_result(t : T?) {
-    t |> run("select_where fold produces correct values") @(t : T?) {
-        let result <- target_select_where_fold()
-        t |> equal(length(result), 2)
-        t |> equal(result[0], 8)
-        t |> equal(result[1], 10)
-    }
-}
-
-[test]
-def test_zip_fold_result(t : T?) {
-    t |> run("zip fold produces correct values") @(t : T?) {
-        let result <- target_zip_fold()
-        t |> equal(length(result), 3)
-        t |> equal(result[0]._0, 2)
-        t |> equal(result[0]._1, 11)
-        t |> equal(result[1]._0, 4)
-        t |> equal(result[1]._1, 21)
-        t |> equal(result[2]._0, 6)
-        t |> equal(result[2]._1, 31)
-    }
-}
-
-// ── Tests: zip3 fold — all 3 subexpressions fold ──────────────────────
-
-[test]
-def test_zip3_old_fold_structure(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_zip3_old_fold)
-        t |> success(func != null, "should find target_zip3_old_fold")
-        if (func == null) return
-        // zip3 fold: all three sources should be folded into invoke wrappers
-        var body_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
-            return <- $e(body_expr)
-        }
-        t |> success(r.matched, "should match return expression")
-        if (!r.matched) return
-        t |> success(body_expr is ExprInvoke, "zip3 fold should produce invoke wrapper")
-    }
-}
-
-[test]
-def test_zip3_predicate_old_fold_structure(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_zip3_predicate_old_fold)
-        t |> success(func != null, "should find target_zip3_predicate_old_fold")
-        if (func == null) return
-        var body_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
-            return <- $e(body_expr)
-        }
-        t |> success(r.matched, "should match return expression")
-        if (!r.matched) return
-        t |> success(body_expr is ExprInvoke, "zip3 predicate fold should produce invoke wrapper")
-    }
 }
 
 [test]
@@ -491,15 +174,6 @@ def target_long_count_shortcut_fold() : int64 {
     return _fold(each([1, 2, 3, 4, 5]).long_count())
 }
 
-[export, marker(no_coverage)]
-def target_select_where_sum_fall_through() : int {
-    // `_select |> _where |> sum` is select-then-where which Phase 2A/2B planner rejects
-    // (where-after-select is blocked on ExprRef2Value substitution). Should fall through
-    // unfolded — body is the raw call chain, not an invoke wrapper. Use array-source form
-    // (no each) so the unfolded chain stays in safe land.
-    return [1, 2, 3, 4, 5]._select(_ * 2)._where(_ > 4).sum()._fold()
-}
-
 // ── Targets for Phase-2B Ring 2 early-exit lane ────────────────────────
 
 [export, marker(no_coverage)]
@@ -531,13 +205,6 @@ def target_all_fold() : bool {
 [export, marker(no_coverage)]
 def target_contains_fold() : bool {
     return _fold(each([1, 2, 3, 4, 5]).contains(3))
-}
-
-[export, marker(no_coverage)]
-def target_early_exit_select_where_fall_through() : bool {
-    // select-then-where-then-any is rejected by the planner (where-after-select).
-    // Falls through unfolded; body is raw chain. Array-source form for safety.
-    return [1, 2, 3, 4, 5]._select(_ * 2)._where(_ > 4).any()._fold()
 }
 
 // ── Tests: `_fold` Phase-2A loop emission ──────────────────────────────
@@ -656,22 +323,8 @@ def test_count_fold_emits_counter(t : T?) {
     }
 }
 
-[test]
-def test_select_where_fold_falls_through(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_select_where_fold)
-        if (func == null) return
-        // _select |> _where is out of Phase 2A scope (where-after-select) — chain falls
-        // through unfolded. The function body is the raw `where_(select(...), ...)` call,
-        // NOT a generated invoke wrapper.
-        var body_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
-            return <- $e(body_expr)
-        }
-        t |> success(r.matched, "should have return expression")
-        t |> success(!(body_expr is ExprInvoke), "select_where should fall through unfolded (no invoke wrapper)")
-    }
-}
+// `select |> where` array-lane coverage is in the Phase 3d section below
+// (target_select_where_to_array_splices_fold / test_select_where_*_emits_fused_loop).
 
 // ── Behavioral parity: results of new shapes ───────────────────────────
 
@@ -1218,22 +871,8 @@ def test_long_count_length_shortcut(t : T?) {
     }
 }
 
-[test]
-def test_accumulator_falls_through_on_select_where(t : T?) {
-    ast_gc_guard() {
-        // `select |> where_ |> sum` is rejected by the planner (select-then-where blocker).
-        // Should fall through unfolded — body is the raw call chain, not an invoke wrapper.
-        var func = find_module_function_via_rtti(compiling_module(), @@target_select_where_sum_fall_through)
-        if (func == null) return
-        var body_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
-            return $e(body_expr)
-        }
-        t |> success(r.matched, "should have return expression")
-        t |> success(!(body_expr is ExprInvoke),
-            "select|where|sum should fall through unfolded (no invoke wrapper)")
-    }
-}
+// `select |> where |> sum` accumulator-lane coverage is in the Phase 3d section below
+// (target_select_where_sum_splices_fold / test_select_where_count_emits_fused_loop pattern).
 
 // ── Phase 2B Ring 2 — early-exit lane shape assertions ─────────────────
 
@@ -1333,20 +972,8 @@ def test_contains_loop_shape(t : T?) {
     }
 }
 
-[test]
-def test_early_exit_falls_through_on_select_where(t : T?) {
-    ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_early_exit_select_where_fall_through)
-        if (func == null) return
-        var body_expr : ExpressionPtr
-        let r = qmatch_function(func) $() {
-            return $e(body_expr)
-        }
-        t |> success(r.matched, "should have return expression")
-        t |> success(!(body_expr is ExprInvoke),
-            "select|where|any should fall through unfolded (no invoke wrapper)")
-    }
-}
+// `select |> where |> any` early-exit-lane coverage is in the Phase 3d section below
+// (target_select_where_any_splices_fold).
 
 // ── Phase 2C take/skip splice ──────────────────────────────────────────
 
@@ -1470,9 +1097,10 @@ def test_take_sum_splices_in_accumulator(t : T?) {
 }
 
 [test]
-def test_order_by_take_falls_through(t : T?) {
-    // order_by + take is BufferTopN territory — recognized as buffer-required, planner returns
-    // null, falls through to plain linq. Future PR replaces with a dedicated emit path.
+def test_order_by_take_cascades_to_tier2(t : T?) {
+    // `order_by |> take` — Phase 3 wires a BufferTopN splice arm via top_n_by.
+    // Until then, the splice planner returns null and the cascade falls to tier 2
+    // (fold_linq_default), which emits the array-shape invoke wrapper.
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_take_falls_through)
         if (func == null) return
@@ -1481,14 +1109,16 @@ def test_order_by_take_falls_through(t : T?) {
             return $e(body_expr)
         }
         t |> success(r.matched, "should have return expression")
-        t |> success(!(body_expr is ExprInvoke),
-            "order_by chain should fall through unfolded — splice planner doesn't handle buffer mode yet")
+        t |> success(body_expr is ExprInvoke,
+            "order_by |> take should cascade to fold_linq_default (invoke wrapper)")
     }
 }
 
 [test]
-def test_distinct_falls_through(t : T?) {
-    // distinct is buffer-required (hash set) — fall-through marker.
+def test_distinct_cascades_to_tier2(t : T?) {
+    // `distinct` is buffer-required (hash set) — splice planner returns null.
+    // Cascade falls to tier 2 (fold_linq_default), which emits the array-shape
+    // invoke wrapper. BufferDistinct splice mode is deferred to a later PR.
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(), @@target_distinct_falls_through)
         if (func == null) return
@@ -1497,8 +1127,242 @@ def test_distinct_falls_through(t : T?) {
             return $e(body_expr)
         }
         t |> success(r.matched, "should have return expression")
-        t |> success(!(body_expr is ExprInvoke),
-            "distinct chain should fall through unfolded — BufferDistinct mode not yet implemented")
+        t |> success(body_expr is ExprInvoke,
+            "distinct chain should cascade to fold_linq_default (invoke wrapper)")
+    }
+}
+
+// ── Phase 3 — order-family splice arms (plan_order_family) ─────────────
+
+[export, marker(no_coverage)]
+def target_order_by_take_splices_fold() : array<int> {
+    return <- _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._order_by(_).take(3).to_array())
+}
+
+[export, marker(no_coverage)]
+def target_order_by_descending_take_splices_fold() : array<int> {
+    return <- _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._order_by_descending(_).take(3).to_array())
+}
+
+[export, marker(no_coverage)]
+def target_bare_order_by_splices_fold() : array<int> {
+    return <- _fold(each([10, 20, 5, 8, 30])._order_by(_).to_array())
+}
+
+[export, marker(no_coverage)]
+def target_where_order_by_splices_fold() : array<int> {
+    return <- _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._where(_ > 5)._order_by(_).to_array())
+}
+
+[export, marker(no_coverage)]
+def target_where_order_by_take_splices_fold() : array<int> {
+    return <- _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._where(_ > 5)._order_by(_).take(2).to_array())
+}
+
+[test]
+def test_order_by_take_emits_top_n_by(t : T?) {
+    // `order_by |> take(K)` splices via plan_order_family to a direct top_n_by(src, K, key) call.
+    // No invoke wrapper, no order_by call in the emission.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_take_splices_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(count_call(body_expr, "top_n_by") >= 1, "should emit a top_n_by call")
+        t |> equal(0, count_call(body_expr, "order_by"), "should not emit order_by")
+        t |> equal(0, count_call(body_expr, "take"), "should not emit take")
+    }
+}
+
+[test]
+def test_order_by_descending_take_emits_top_n_by_descending(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(),
+            @@target_order_by_descending_take_splices_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(count_call(body_expr, "top_n_by_descending") >= 1,
+            "should emit a top_n_by_descending call")
+        t |> equal(0, count_call(body_expr, "order_by_descending"),
+            "should not emit order_by_descending")
+    }
+}
+
+[test]
+def test_bare_order_by_emits_direct_call(t : T?) {
+    // Bare `order_by(key)` splices to a direct order_by call (no invoke wrapper, no top_n).
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_bare_order_by_splices_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(count_call(body_expr, "order_by") >= 1, "should emit an order_by call")
+        t |> equal(0, count_call(body_expr, "top_n_by"), "should not emit top_n_by")
+    }
+}
+
+[test]
+def test_where_order_by_emits_fused_loop(t : T?) {
+    // `where |> order_by` splices into a fused prefilter loop + order_by_inplace on the buffer.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_where_order_by_splices_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for fused emission")
+        t |> equal(1, count_inner_for_loops(body_expr), "single fused prefilter loop")
+        t |> success(count_call(body_expr, "order_by_inplace") >= 1, "should call order_by_inplace on the buffer")
+        t |> success(count_call(body_expr, "push_clone") >= 1, "should push_clone into the buffer")
+    }
+}
+
+[test]
+def test_where_order_by_take_emits_fused_top_n(t : T?) {
+    // `where |> order_by |> take(K)` splices into a fused prefilter loop + top_n_by on the buffer.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(),
+            @@target_where_order_by_take_splices_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for fused emission")
+        t |> equal(1, count_inner_for_loops(body_expr), "single fused prefilter loop")
+        t |> success(count_call(body_expr, "top_n_by") >= 1, "should call top_n_by on the buffer")
+        t |> success(count_call(body_expr, "push_clone") >= 1, "should push_clone into the buffer")
+    }
+}
+
+// ── Phase 3 — runtime parity for order-family splice arms ──────────────
+
+[test]
+def test_order_by_take_correct_result(t : T?) {
+    t |> run("order_by + take splice produces N smallest ascending") @(t : T?) {
+        let got <- target_order_by_take_splices_fold()
+        let expected = [2, 5, 8]
+        t |> equal(length(got), length(expected))
+        for (v, e in got, expected) {
+            t |> equal(v, e)
+        }
+    }
+}
+
+[test]
+def test_order_by_descending_take_correct_result(t : T?) {
+    t |> run("order_by_descending + take splice produces N largest descending") @(t : T?) {
+        let got <- target_order_by_descending_take_splices_fold()
+        let expected = [30, 25, 20]
+        t |> equal(length(got), length(expected))
+        for (v, e in got, expected) {
+            t |> equal(v, e)
+        }
+    }
+}
+
+[test]
+def test_where_order_by_take_correct_result(t : T?) {
+    t |> run("where + order_by + take splice prefilters then takes top N") @(t : T?) {
+        let got <- target_where_order_by_take_splices_fold()
+        // src = [10, 20, 5, 8, 30, 15, 2, 25], where _>5 → [10, 20, 8, 30, 15, 25]
+        // order_by(_).take(2) → [8, 10]
+        let expected = [8, 10]
+        t |> equal(length(got), length(expected))
+        for (v, e in got, expected) {
+            t |> equal(v, e)
+        }
+    }
+}
+
+// ── Phase 3d — select + where splice via replaceVariablePeeling ────────
+
+[export, marker(no_coverage)]
+def target_select_where_count_splices_fold() : int {
+    return _fold(each([1, 2, 3, 4, 5, 6, 7, 8])._select(_ * 2)._where(_ > 5).count())
+}
+
+[export, marker(no_coverage)]
+def target_select_where_sum_splices_fold() : int {
+    return _fold(each([1, 2, 3, 4, 5])._select(_ * 10)._where(_ > 15).sum())
+}
+
+[export, marker(no_coverage)]
+def target_select_where_any_splices_fold() : bool {
+    return _fold(each([1, 2, 3])._select(_ * 100)._where(_ > 50).any())
+}
+
+[export, marker(no_coverage)]
+def target_select_where_to_array_splices_fold() : array<int> {
+    return <- _fold(each([1, 2, 3, 4, 5])._select(_ * 2)._where(_ > 4).to_array())
+}
+
+[test]
+def test_select_where_count_emits_fused_loop(t : T?) {
+    // select |> where |> count: peel-substitution inlines projection into pred; loop emits
+    // counter increments. NOT tier 2 (no pass_0/pass_1 binding shape).
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(),
+            @@target_select_where_count_splices_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(1, count_inner_for_loops(body_expr), "single fused for-loop (not pass_0/pass_1 chain)")
+        // tier 2 fold_linq_default would emit `var pass_0 = ...; var pass_1 = ...`.
+        // tier 1 splice emits just the loop body + accumulator.
+        t |> equal(0, count_call(body_expr, "where_"), "where_ should be inlined, not called")
+        t |> equal(0, count_call(body_expr, "select"), "select should be inlined, not called")
+    }
+}
+
+[test]
+def test_select_where_count_correct_result(t : T?) {
+    t |> run("select(x*2) |> where(>5) |> count") @(t : T?) {
+        // src = [1..8], projected = [2,4,6,8,10,12,14,16], filtered >5 = [6,8,10,12,14,16], count = 6
+        t |> equal(6, target_select_where_count_splices_fold())
+    }
+}
+
+[test]
+def test_select_where_sum_correct_result(t : T?) {
+    t |> run("select(x*10) |> where(>15) |> sum") @(t : T?) {
+        // src = [1..5], projected = [10,20,30,40,50], filtered >15 = [20,30,40,50], sum = 140
+        t |> equal(140, target_select_where_sum_splices_fold())
+    }
+}
+
+[test]
+def test_select_where_any_correct_result(t : T?) {
+    t |> run("select(x*100) |> where(>50) |> any") @(t : T?) {
+        // src = [1,2,3], projected = [100,200,300], filtered >50 = [100,200,300], any = true
+        t |> equal(true, target_select_where_any_splices_fold())
+    }
+}
+
+[test]
+def test_select_where_to_array_correct_result(t : T?) {
+    t |> run("select(x*2) |> where(>4) |> to_array") @(t : T?) {
+        // src = [1..5], projected = [2,4,6,8,10], filtered >4 = [6,8,10]
+        let got <- target_select_where_to_array_splices_fold()
+        let expected = [6, 8, 10]
+        t |> equal(length(got), length(expected))
+        for (v, e in got, expected) {
+            t |> equal(v, e)
+        }
     }
 }
 

--- a/tests/linq/test_linq_sorting.das
+++ b/tests/linq/test_linq_sorting.das
@@ -464,6 +464,118 @@ def test_top_n_by(t : T?) {
 }
 
 [test]
+def test_top_n_by_descending(t : T?) {
+    t |> run("top_n_by_descending on array source — N largest descending") @(t : T?) {
+        let src <- [10, 20, 5, 8, 30, 15, 2, 25]
+        let got <- top_n_by_descending(src, 3, @@(v : int -&) => v)
+        let expected = [30, 25, 20]
+        t |> equal(length(got), length(expected))
+        for (v, e in got, expected) {
+            t |> equal(v, e)
+        }
+    }
+    t |> run("top_n_by_descending on iterator source — bounded min-heap") @(t : T?) {
+        let src <- [10, 20, 5, 8, 30, 15, 2, 25]
+        let got <- top_n_by_descending(src.to_sequence(), 3, @@(v : int -&) => v)
+        let expected = [30, 25, 20]
+        t |> equal(length(got), length(expected))
+        for (v, e in got, expected) {
+            t |> equal(v, e)
+        }
+    }
+    t |> run("top_n_by_descending N=0 yields empty") @(t : T?) {
+        let src <- [10, 20, 5]
+        let got <- top_n_by_descending(src, 0, @@(v : int -&) => v)
+        t |> equal(length(got), 0)
+    }
+    t |> run("top_n_by_descending N<0 yields empty") @(t : T?) {
+        let src <- [10, 20, 5]
+        let got <- top_n_by_descending(src, -1, @@(v : int -&) => v)
+        t |> equal(length(got), 0)
+    }
+    t |> run("top_n_by_descending N > length yields all elements sorted descending") @(t : T?) {
+        let src <- [10, 20, 5]
+        let got <- top_n_by_descending(src, 100, @@(v : int -&) => v)
+        let expected = [20, 10, 5]
+        t |> equal(length(got), length(expected))
+        for (v, e in got, expected) {
+            t |> equal(v, e)
+        }
+    }
+    t |> run("top_n_by_descending N=1 picks single maximum") @(t : T?) {
+        let src <- [7, 3, 1, 9, 5]
+        let got <- top_n_by_descending(src, 1, @@(v : int -&) => v)
+        t |> equal(length(got), 1)
+        t |> equal(got[0], 9)
+    }
+    t |> run("top_n_by_descending on iterator source — empty") @(t : T?) {
+        let src : array<int>
+        let got <- top_n_by_descending(src.to_sequence(), 3, @@(v : int -&) => v)
+        t |> equal(length(got), 0)
+    }
+    t |> run("top_n_by_descending on user struct by field key") @(t : T?) {
+        let src <- [
+            ComplexType(a = [10, 0]),
+            ComplexType(a = [5, 0]),
+            ComplexType(a = [25, 0]),
+            ComplexType(a = [2, 0]),
+            ComplexType(a = [15, 0])
+        ]
+        let got <- top_n_by_descending(src, 3, @@(c : ComplexType) => c.a[0])
+        t |> equal(length(got), 3)
+        t |> equal(got[0].a[0], 25)
+        t |> equal(got[1].a[0], 15)
+        t |> equal(got[2].a[0], 10)
+    }
+    t |> run("top_n_by_descending parity vs sort+take direct reference") @(t : T?) {
+        let src <- [42, 7, 13, 88, 21, 4, 99, 56, 33, 71]
+        let got <- top_n_by_descending(src, 4, @@(v : int -&) => v)
+        // hand-rolled reference: clone, sort descending, take first 4
+        var refSorted : array<int>
+        refSorted := src
+        sort(refSorted, $(a, b) => a > b)
+        t |> equal(length(got), 4)
+        for (i in 0..4) {
+            t |> equal(got[i], refSorted[i])
+        }
+    }
+}
+
+[test]
+def test_top_n_descending(t : T?) {
+    t |> run("top_n_descending on array source — N largest descending") @(t : T?) {
+        let src <- [10, 20, 5, 8, 30, 15, 2, 25]
+        let got <- top_n_descending(src, 3)
+        let expected = [30, 25, 20]
+        t |> equal(length(got), length(expected))
+        for (v, e in got, expected) {
+            t |> equal(v, e)
+        }
+    }
+    t |> run("top_n_descending on iterator source") @(t : T?) {
+        let src <- [10, 20, 5, 8, 30, 15, 2, 25]
+        let got <- top_n_descending(src.to_sequence(), 3)
+        let expected = [30, 25, 20]
+        t |> equal(length(got), length(expected))
+        for (v, e in got, expected) {
+            t |> equal(v, e)
+        }
+    }
+    t |> run("top_n_descending N=0 yields empty") @(t : T?) {
+        let src <- [10, 20, 5]
+        let got <- top_n_descending(src, 0)
+        t |> equal(length(got), 0)
+    }
+    t |> run("top_n_descending on floats") @(t : T?) {
+        let src <- [3.14, 1.41, 2.71, 0.57, 1.61]
+        let got <- top_n_descending(src, 2)
+        t |> equal(length(got), 2)
+        t |> equal(got[0], 3.14)
+        t |> equal(got[1], 2.71)
+    }
+}
+
+[test]
 def test_heap_ops(t : T?) {
     t |> run("make_heap → max at root") @(t : T?) {
         var a <- [5, 2, 8, 1, 9, 3, 7]


### PR DESCRIPTION
## Summary

Retires `_old_fold` entirely and restructures `_fold(chain)` into a three-tier cascade that is **always safe to apply** — `_fold(chain)` is observationally equivalent to `chain`, just faster when patterns match.

```
_fold(chain) =
    splice_planner(chain)        // tier 1: fused for-loop, lambdas inlined
    ?? fold_linq_default(chain)  // tier 2: array-shape pipeline with _inplace reuse
    ?? clone_expression(chain)   // tier 3: raw passthrough
```

This obviates the previously-planned Phase 2D fail-loudly contract. Adds two new splice planner arms (order-family, select+where), bundles the runtime `builtin_sort_string` switch from `std::sort` to in-tree `das_sort` from PR #2707, and refreshes the bench suite (drops the `m3f_old` column from all 29 files, adds 3 new bench files).

Modeled on PR #2707 — single squashed commit, multi-area bundle, headline numbers below.

## Headline benchmarks (100K rows, INTERP, smaller is better)

| Pattern | m1 (sql) | m3 (linq) | m3f (this PR) | Win |
|---|---:|---:|---:|---:|
| `order_by_descending → take(K)` | 38 | 698 | **56** | **12.5×** — new `top_n_by_descending` |
| `order_by → take(K)` | 38 | 713 | **56** | **12.7×** — splice → `top_n_by` |
| `where → order_by → take(K)` | 36 | 354 | **39** | **9.1×** — fused prefilter + `top_n_by` |
| `select → where → count` | 32 | 57 | **5** | **11.4×** — Phase 3d peel (FIRST select+where splice) |
| `where → where → count` | 36 | 45 | **6** | 7.5× |
| `where → select → sum` | 32 | 44 | **4** | 11× |
| `where → order_by` (no take) | 273 | 357 | **340** | 1.05× — sort dominates |

Three order+take rows now come within ~1.5× of SQLite's index-aware plans.

## Phase 1 — `_old_fold` retirement + 3-tier cascade

- `_old_fold` macro, `LinqOldFold` class, `g_foldSeq` table and 7 `FoldSequence` patterns deleted (`fold_where_count`, `fold_where_select`, `fold_select_where`, `fold_where`, `fold_select`, `fold_order_distinct` ×2). Splice arms cover every shape they recognized.
- `fold_linq_default` kept as **tier 2** of the cascade (was the body of `_old_fold`) — emits the array-shape pipeline with `_inplace` reuse and explicit `delete`. Patterns that used to fall to raw clone now get the array-shape pipeline.
- `recursiveMacroName` param dropped; the dead match loop is removed.
- Latent `where__to_array` double-underscore rename bug fixed (`callName` ending in `_` now uses an empty separator).

## Phase 3a/b/c — order-family splice (`plan_order_family`)

Called before `plan_loop_or_count` in the cascade. Recognizes any of `order` / `order_by` / `order_descending` / `order_by_descending`, optionally with one `take(K)`, optionally with `where_*` prefilters:

| Chain shape | Emission |
|---|---|
| `arr \|> order[_descending]?` (bare) | Direct call: `order[_descending](arr)` |
| `arr \|> order_by[_descending]?(key)` (bare) | Direct call: `order_by[_descending](arr, key)` |
| `src \|> order[_descending]? \|> take(K)` | `top_n[_descending](src, K)` |
| `src \|> order_by[_descending]?(key) \|> take(K)` | `top_n_by[_descending](src, K, key)` (descending helpers new) |
| `src \|> where_*(p)+ \|> order[_by]?[_descending]?[(key)]` | Fused: prefilter into pre-allocated buffer, then `order*_inplace` |
| `src \|> where_*(p)+ \|> order[_by]?[_descending]?[(key)] \|> take(K)` | Fused: prefilter into buffer, then `top_n*` on the buffer |

Library additions in [daslib/linq.das](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/linq-fold-sort-family/daslib/linq.das): `top_n_by_descending` and `top_n_descending` (array + iterator source variants each, 4 new functions). Mirrors `top_n_by` / `top_n` with flipped comparator — `partial_sort` + reversed `_::less` for array; bounded min-heap for iterator. `linqCalls` dict registers all four `top_n*` names so `flatten_linq` recognizes them.

## Phase 3d — first `select + where + terminator` splice

Previously rejected by `plan_loop_or_count` — substituting the projection for `it` inside the where predicate left the typer-inserted `ExprRef2Value` wrapper orphaned around a non-reference value, producing `error[30921]: can only dereference a reference`.

Unblocked by the new `replaceVariablePeeling` helper in [daslib/templates_boost.das](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/linq-fold-sort-family/daslib/templates_boost.das) — populates a new `var2exprPeeling` table on `Template`, and adds a `visitExprRef2Value` override on the `TemplateVisitor` that returns `clone_expression(replacement)` directly when it sees `ExprRef2Value(ExprVar(name))` for a peeling-registered name. Mirrors the `qm_peel_ref2value` pattern already used by `daslib/ast_match`.

`plan_loop_or_count` calls the new `fold_linq_cond_peel(expr, replacement)` to splice the substituted predicate. Bails to tier 2 when `has_sideeffects(projection)` (would double-evaluate). All four terminator lanes land in one shot: ARRAY (`to_array` / bare), COUNTER (`count`), ACCUMULATOR (`sum` / `min` / `max` / `average` / `long_count`), EARLY_EXIT (`first` / `first_or_default` / `any` / `all` / `contains`).

## Concurrent runtime fix

[`src/builtin/module_builtin_runtime_sort.cpp:84`](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/linq-fold-sort-family/src/builtin/module_builtin_runtime_sort.cpp#L84) — `builtin_sort_string` switched from unqualified `sort()` (= `std::sort` via `using namespace std`) to `das_sort`. This is the runtime path `order_by<string>` takes; on Linux/libstdc++ users now see the same ~1.5× speedup PR #2707 brought to typed sorts. The 9 other unqualified `sort()` call sites are compiler-side (`src/ast`, `src/misc`, `src/simulate`, `include/.../das_common.h`) and stay (compiler-side `sort` is out of scope; runtime-only directive).

## Bench infrastructure refresh

- 3 new bench files: [benchmarks/sql/bare_order_where.das](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/linq-fold-sort-family/benchmarks/sql/bare_order_where.das), [benchmarks/sql/order_take_desc.das](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/linq-fold-sort-family/benchmarks/sql/order_take_desc.das), [benchmarks/sql/select_where_count.das](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/linq-fold-sort-family/benchmarks/sql/select_where_count.das)
- `m3f_old` column + `run_m3f_old` helper + `[benchmark]` entry point dropped from all 29 existing files (mechanical deletion)
- [benchmarks/sql/LINQ.md](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/linq-fold-sort-family/benchmarks/sql/LINQ.md): drops fail-loudly section, adds Phase 1 cascade + Phase 3 splice + headline benchmarks sections, updates phase status table

## Tests

- [tests/linq/test_linq_sorting.das](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/linq-fold-sort-family/tests/linq/test_linq_sorting.das): 13 subtests across `top_n_by_descending` (9) + `top_n_descending` (4) — array + iterator sources, N=1, N=0, N>length, negative N, parity vs hand-rolled reference
- [tests/linq/test_linq_fold.das](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/linq-fold-sort-family/tests/linq/test_linq_fold.das): 7 `_old_fold` parity baselines retargeted to direct-computation baselines (stronger correctness check)
- [tests/linq/test_linq_fold_ast.das](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/linq-fold-sort-family/tests/linq/test_linq_fold_ast.das): 5 tier-2-cascade tests retargeted + Phase 3 section (order-family AST-shape tests + 4 select+where tests + 3 runtime parity tests across terminator lanes)

## Test plan

- [x] `dastest` full suite: 8393/8393 pass, 0 failed, 0 errors, 6 skipped
- [x] AOT full suite: 7782/7782 (incl. assert tests as expected), 0 failed
- [x] `mcp__daslang__lint` — clean (2 pre-existing PERF015 in `daslib/linq.das take` macro, not in changed code)
- [x] `detect_duplicates` against daslib + tests/linq + benchmarks/sql corpus — only sibling-by-design hits (`top_n_by` ↔ `top_n_by_descending`, `fold_linq_cond` ↔ `fold_linq_cond_peel`)
- [x] `mcp__daslang__format_file` — all 39 changed `.das` files already formatted
- [x] Sphinx `-W` — `build succeeded`, zero warnings (the new `//!` docstrings on `top_n_by_descending`, `top_n_descending`, `replaceVariablePeeling` regen the detail RST cleanly)
- [x] Benchmark suite — captured at top; no regressions vs m3f baseline; new arms within ~1.5× of SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)