### PR TITLE
daspkg: parallelize cmake build in build_package

### DIFF
--- a/utils/daspkg/commands.das
+++ b/utils/daspkg/commands.das
@@ -985,7 +985,7 @@ def build_package(pkg_dir : string) : bool {
     }
 
     // Build
-    exit_code = run_cmd("cmake --build \"{build_dir}\" --config Release", output)
+    exit_code = run_cmd("cmake --build \"{build_dir}\" --config Release --parallel", output)
     if (exit_code != 0) {
         log("  CMake build FAILED:\n{output}\n")
         return false


### PR DESCRIPTION
## Summary

`build_package` in `utils/daspkg/commands.das` (used by `daspkg install`, `update`, `build`, and the git-fetch path) invoked `cmake --build` without `--parallel`. On generators whose default is single-job (MSBuild on Windows, Make on Linux/macOS), this meant package builds ran serially — Ninja was the only generator that already parallelized.

Adding `--parallel` defers the job count to CMake's per-generator default, which is the right knob for "use what the platform considers sensible."

## Test plan

- [ ] `daspkg install <pkg>` on Windows visibly fans out across cores instead of building one TU at a time
- [ ] CI green
