### PR TITLE
docs: mouse cards from PRs #2712/#2714/#2716 + ExprVar._type pre-set guidance

### DIFF
--- a/mouse-data/docs/das-namespace-abstraction-std-vs-eastl-swap.md
+++ b/mouse-data/docs/das-namespace-abstraction-std-vs-eastl-swap.md
@@ -1,0 +1,50 @@
+---
+slug: das-namespace-abstraction-std-vs-eastl-swap
+title: how does daslang das:: namespace abstraction work — what does das::vector resolve to and how does the eastl swap happen
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+`das::vector`, `das::pair`, `das::move`, `das::hash`, `das::equal_to`, etc. are NOT defined as `using std::X` declarations — they're injected wholesale by a single `using namespace std;` or `using namespace eastl;` directive inside `namespace das { ... }`.
+
+**Default config** (`include/daScript/das_config.h:34`):
+```cpp
+namespace das {using namespace std;}
+```
+
+**EASTL config** (`cmake/das_config_eastl/das_config.h:45-56`):
+```cpp
+namespace das {
+using namespace eastl;
+using std::atomic;
+using std::condition_variable;
+using std::lock_guard;
+using std::mutex;
+using std::nullptr_t;
+using std::recursive_mutex;
+using std::stringstream;
+using std::thread;
+using std::unique_lock;
+} // namespace das
+```
+
+EASTL config does `using namespace eastl;` THEN explicit `using std::X` for the handful of things EASTL doesn't have (thread primitives, atomic, stringstream).
+
+**Activated by** `-DDAS_CONFIG_INCLUDE_DIR=cmake/das_config_eastl` at CMake time. CI workflow: `.github/workflows/build_eastl.yml`.
+
+**Implications when writing code that ends up in `namespace das`:**
+
+1. Always write `das::vector` not `std::vector`. The EASTL build will route to `eastl::vector` automatically. Writing `std::vector` actively bypasses the abstraction.
+
+2. Don't add `using std::vector;` blocks inside `namespace das { ... }` — they'll shadow `eastl::vector` in the EASTL build, defeating the abstraction. The das_hash_map.h cleanup in PR #2716 was exactly this pattern.
+
+3. Things EASTL doesn't have (`out_of_range`, `exception`, `runtime_error`, `<stdexcept>` in general) must use `std::` directly — there's no `eastl::out_of_range`. EASTL's own headers throw `std::out_of_range` (see `eastl/include/EASTL/bitset.h`, `map.h`, `array.h`).
+
+4. **Type traits, iterators, containers, allocators**: all dual-namespace, use `das::`.
+   **Exception types, fmt library, threading from std**: use `std::` directly.
+
+To check what's available where: `grep -rn "das::X\|eastl::X" /Users/borisbatkin/Work/daScript/include/ 2>/dev/null | head` shows the convention in practice.
+
+## Questions
+- how does daslang das:: namespace abstraction work — what does das::vector resolve to and how does the eastl swap happen

--- a/mouse-data/docs/das-throw-universal-panic-primitive-low-level-headers.md
+++ b/mouse-data/docs/das-throw-universal-panic-primitive-low-level-headers.md
@@ -1,0 +1,27 @@
+---
+slug: das-throw-universal-panic-primitive-low-level-headers
+title: what is the right primitive to fail/panic from a low-level daslang C++ header — don't use raw throw because embedded games disable exceptions
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**Use `das::das_throw(const char* msg)`** — daslang's universal panic primitive. Declared in `include/daScript/das_config.h`, defined in `src/simulate/runtime_string.cpp`.
+
+**Why NOT raw `throw`** in low-level headers:
+- Games embedding daslang frequently disable C++ exceptions entirely (`-fno-exceptions` / EASTL no-exceptions mode). Raw `throw` won't compile.
+- `daslang`'s OWN default is `DAS_ENABLE_EXCEPTIONS=0` (see `include/daScript/simulate/simulate.h:27-28`). Only Windows-no-LLVM and WASM set it to 1.
+- EASTL has no `eastl::exception` or `eastl::out_of_range`, so even with exceptions enabled, `throw das::exception()` doesn't resolve in the EASTL config.
+
+**What das_throw does:**
+- `DAS_ENABLE_EXCEPTIONS=0` (default): setjmp/longjmp via thread-local `g_throwBuf`. If no try-catch is set up, calls `DAS_FATAL_ERROR("unhanded das_throw, %s\n", msg)`.
+- `DAS_ENABLE_EXCEPTIONS=1`: `throw dasException(msg, LineInfo())` so existing `catch(dasException&)` handlers in `src/simulate/simulate_exceptions.cpp` pick it up.
+
+**Constraint to know**: as of PR #2716, `das_throw` is declared unconditionally in `das_config.h` / `include_fmt.h` / `das_config_eastl/das_config.h`. Before that PR, the declaration was gated on `DAS_ENABLE_EXCEPTIONS=0`, so calling it from headers in WASM/Windows-no-LLVM builds would have failed at link time.
+
+**FMT_THROW vs das_throw**: `FMT_THROW(x)` (from fmt library or daslang's override) takes an exception OBJECT and is conditionally `throw x` or `das::das_throw(x.what())`. das_throw takes a `const char*` directly — use this in low-level code where you don't have an exception object to construct.
+
+**Pre-PR pattern that broke**: das_hash_map.h had `throw std::out_of_range("daslang_hash_map::at")` in `at()`. This compiled on macOS libc++ (transitive `<stdexcept>`) but failed on Linux libstdc++ (no transitive) and EASTL (no `eastl::out_of_range`). The fix in PR #2716: replace with `das::das_throw("daslang_hash_map::at")`.
+
+## Questions
+- what is the right primitive to fail/panic from a low-level daslang C++ header — don't use raw throw because embedded games disable exceptions

--- a/mouse-data/docs/daslang-eastl-config-local-build-setup.md
+++ b/mouse-data/docs/daslang-eastl-config-local-build-setup.md
@@ -1,0 +1,40 @@
+---
+slug: daslang-eastl-config-local-build-setup
+title: how do I locally build and verify the daslang EASTL CI configuration — clone setup, cmake invocation, what to test
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+CI workflow: `.github/workflows/build_eastl.yml`. Mirrors it for local repro:
+
+```bash
+# Clone EASTL and EABase separately — EASTL repo no longer has EABase as a submodule
+# (the workflow's `--recurse-submodules` is now a no-op; EABase is a separate repo)
+git clone --depth 1 https://github.com/electronicarts/EASTL.git eastl
+git clone --depth 1 https://github.com/electronicarts/EABase.git eabase
+
+cmake -B build_eastl -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DDAS_LLVM_DISABLED=ON -DDAS_GLFW_DISABLED=ON \
+  -DDAS_TESTS_DISABLED=ON -DDAS_TUTORIAL_DISABLED=ON \
+  -DDAS_AOT_EXAMPLES_DISABLED=ON \
+  -DDAS_CONFIG_INCLUDE_DIR=cmake/das_config_eastl \
+  -DCMAKE_CXX_FLAGS="-isystem $PWD/eastl/include -isystem $PWD/eabase/include/Common"
+
+cmake --build build_eastl --target daslang --parallel
+./bin/daslang --version    # smoke test — should print version like "0.6.2"
+```
+
+**The CI build only verifies the `daslang` target compiles** (`-DDAS_TESTS_DISABLED=ON`). Full test execution is not done; the goal is just compile-coverage to catch type-conversion bugs (e.g. eastl::string → std::filesystem::path).
+
+**Gitignore**: add `eastl/`, `eabase/`, `build_eastl/` to `.gitignore` so the local checkouts don't show up as untracked. PR #2716 did this.
+
+**Common errors and meanings:**
+- `error: no member named 'X' in namespace 'das'` — your code uses `das::X` but X isn't visible via `using namespace eastl;` AND isn't explicitly `using std::X` in the EASTL config. Fix: either ensure it's in eastl, add an explicit `using std::X` to the EASTL config, or use a different primitive (e.g. `das_throw` instead of `throw das::exception`).
+- Linker error on `das_throw` — declaration is gated on `DAS_ENABLE_EXCEPTIONS=0`; if the build sets `=1`, declaration disappears. As of PR #2716 the declaration is unconditional. Pre-PR was a known foot-gun.
+
+**Note**: das_config_eastl includes `<EASTL/sort.h>`, `vector.h`, `string.h`, `type_traits.h`, etc. — but NOT `<EASTL/stdexcept.h>` (which doesn't exist anyway — EASTL throws `std::out_of_range` directly from `<stdexcept>` pulled transitively).
+
+## Questions
+- how do I locally build and verify the daslang EASTL CI configuration — clone setup, cmake invocation, what to test

--- a/mouse-data/docs/github-pr-body-angle-brackets-stripped-in-backticks.md
+++ b/mouse-data/docs/github-pr-body-angle-brackets-stripped-in-backticks.md
@@ -1,0 +1,28 @@
+---
+slug: github-pr-body-angle-brackets-stripped-in-backticks
+title: GitHub PR body strips angle brackets inside backticks — markdown body containing <vector> shows as empty code spans
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**Symptom**: PR body containing `` `<vector>` `` (header name in backticks) renders as empty backticks on GitHub. The angle-bracket content is gone from the stored body, not just visually hidden.
+
+**Cause**: GitHub's markdown pre-processor treats `<vector>`, `<utility>`, `<string>` etc. as malformed HTML tags and silently strips them BEFORE the markdown's backtick-code-span wrapping fires. Affects both `gh pr create` and `mcp__github__update_pull_request`.
+
+**Fix**: escape with HTML entities — `&lt;vector&gt;`, `&lt;utility&gt;` — even though they're inside backticks. Markdown will literalize the entities once you escape `<` and `>`.
+
+Example of broken vs fixed:
+```
+broken: includes `<vector>`, `<utility>`, `<string>` etc.
+fixed:  includes `&lt;vector&gt;`, `&lt;utility&gt;`, `&lt;string&gt;` etc.
+```
+
+The same gotcha doesn't apply to commit messages — those render fine.
+
+**Discovered**: PR #2716, 2026-05-18. Initial body had 6 stdlib headers stripped from the rendered body until we caught it by re-reading via `mcp__github__pull_request_read`.
+
+**Verification habit**: after `update_pull_request` or `create_pull_request` of a body with `<` or `>` characters, immediately call `pull_request_read method=get` and grep for empty backtick-pairs (``).
+
+## Questions
+- GitHub PR body strips angle brackets inside backticks — markdown body containing <vector> shows as empty code spans

--- a/mouse-data/docs/how-do-i-dedupe-a-select-projection-that-the-where-predicate-inlines-and-the-terminator-valueexpr-clones-inside-a-splice-macro-s.md
+++ b/mouse-data/docs/how-do-i-dedupe-a-select-projection-that-the-where-predicate-inlines-and-the-terminator-valueexpr-clones-inside-a-splice-macro-s.md
@@ -1,0 +1,47 @@
+---
+slug: how-do-i-dedupe-a-select-projection-that-the-where-predicate-inlines-and-the-terminator-valueexpr-clones-inside-a-splice-macro-s
+title: how do I dedupe a select projection that the where predicate inlines AND the terminator valueExpr clones inside a splice macro so the projection evaluates once per element instead of twice
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**The pattern:** `_select(proj) |> _where(p) |> terminator` chains splice via the where-after-select arm in `plan_loop_or_count`. Phase 3d (PR #2712) substituted `proj` INTO the predicate via peel-aware `fold_linq_cond_peel`, and the lane emitters ALSO cloned `proj` into the terminator's `valueExpr` (via `clone_expression(projection)`). Net: projection evaluated twice per element on ARRAY / ACCUMULATOR / EARLY_EXIT lanes.
+
+**Why intermediateBinds doesn't fix it:** `intermediateBinds` (used for chained-select bind chains) gets PREPENDED inside `perMatchStmts` BEFORE `wrap_with_condition`, so it ends up INSIDE the `if (whereCond) { ... }` wrap. A bind there can't dedupe with the predicate — the predicate is the wrap's `cond`, evaluated first; if it referenced the bind var, the var wouldn't exist yet at that point.
+
+**Fix (PR #2714):** new `preConditionStmts : array<Expression?>` planner state, spliced into the loop body OUTSIDE the if-wrap via a `prepend_precond` helper. In the `_where` arm when `seenSelect=true`:
+```das
+if (has_sideeffects(projection)) return null   // semantic gate — see below
+if (lane != LinqLane.COUNTER) {                // COUNTER opt-out — see below
+    let wbName = "`vw`{at.line}`{at.column}`{length(preCondStmts)}"
+    var projType = clone_type(elementType)
+    preCondStmts |> push <| qmacro_expr() {
+        var $i(wbName) : $t(projType) := $e(projection)
+    }
+    var pvar = new ExprVar(at = at, name := wbName)
+    pvar._type = clone_type(elementType)
+    pvar._type.flags.ref = true
+    projection = pvar
+}
+predicate = fold_linq_cond_peel(cll._0.arguments[1], projection)
+```
+
+Both the predicate (peel-substituted to reference `wbName`) AND `valueExpr` (cloned from the now-rewritten `projection`) reference the same single bind. Projection evaluates exactly once per element.
+
+**Two non-obvious constraints:**
+
+1. **The ExprVar replacement must be typed manually.** Setting `pvar._type` from `clone_type(elementType)` + `flags.ref = true` matters: an untyped `ExprVar` would propagate `auto` into `push_clone` / accumulator call sites and surface as `30165: cannot infer push_clone return type` at the typer (downstream of the splice, hard to diagnose). Don't rely on the typer to re-walk the loop's local decls to resolve the ExprVar's type from the `var wbName : $t(projType) := ...` binding — that re-resolution happens AFTER the type errors fire.
+
+2. **`has_sideeffects` is a semantic gate, not a perf gate.** Moving an impure projection outside the if-wrap would visibly fire side effects on filter-rejected elements — bail to tier 2 cascade in that case. (NOT "double the work" — both the old and new forms run the projection twice per element on a pure projection; the dedup just turns that into one bind read + one bind read of the same var.)
+
+3. **COUNTER lane opt-out:** count terminators never reference `valueExpr`, so the dedup brings zero benefit, and the extra per-element bind decl regresses the single-stmt fast path. Gate the bind on `lane != LinqLane.COUNTER`; benchmark proof: `select_where_count` m3f stayed at 5 ns/op pre- and post-PR with the opt-out, regressed to 7 ns/op without it.
+
+**Files:** `daslib/linq_fold.das` `plan_loop_or_count` (preCondStmts state + where-arm bind logic), `prepend_precond` helper, signatures of `emit_accumulator_lane` / `emit_early_exit_lane` extended with `preCondStmts` param.
+
+**Bench impact** (100K rows INTERP): `select_where_sum` m3 59 → m3f 7 ns/op (8.4×; also beats SQLite at 37 ns/op by 5.3×).
+
+Linked: [[parser-bug-30701-tagged-block-arg-dup-check]] for the qmacro fix that surfaced during the PR, [[pr-2714-linq-splice-single-eval]] for the landed PR.
+
+## Questions
+- how do I dedupe a select projection that the where predicate inlines AND the terminator valueExpr clones inside a splice macro so the projection evaluates once per element instead of twice

--- a/mouse-data/docs/inlining-a-sort-comparator-key-body-does-it-double-the-work-for-expensive-keys-compared-to-keeping-the-key-lambda-call.md
+++ b/mouse-data/docs/inlining-a-sort-comparator-key-body-does-it-double-the-work-for-expensive-keys-compared-to-keeping-the-key-lambda-call.md
@@ -1,0 +1,33 @@
+---
+slug: inlining-a-sort-comparator-key-body-does-it-double-the-work-for-expensive-keys-compared-to-keeping-the-key-lambda-call
+title: inlining a sort comparator key body — does it double the work for expensive keys compared to keeping the key lambda call
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**No. Both forms evaluate the key body twice per comparison.** The intuition "if I inline the body twice, expensive keys do double work" is wrong — the original `$(v1, v2) => _::less(key(v1), key(v2))` already calls `key` twice per comparison (once for each side).
+
+**What inlining actually saves:** indirect lambda-dispatch overhead. Concretely, for each comparison `cmp(v1, v2)`:
+
+| Step | Before inline (key-taking) | After inline (body spliced) |
+|---|---|---|
+| comparator call | 1 indirect call (block dispatch) | 1 indirect call (block dispatch) |
+| `key(v1)` | 1 indirect call (lambda dispatch) | 0 — body[v1] inlined |
+| `key(v2)` | 1 indirect call (lambda dispatch) | 0 — body[v2] inlined |
+| body evaluation | 2× (once per `key(v)`) | 2× (inlined into both sides) |
+| `_::less` | 1 direct call | 1 direct call |
+| **Net dispatches** | **3** | **1** |
+
+So the win is **2 fewer indirect dispatches per comparison**. For trivial keys (`$(_) => _.price`) where the body IS a single load, the dispatch IS the dominant cost — and the savings are big (PR #2714: sort_take m3f 56 → 27 ns/op, ~2.1×). For expensive keys (`$(_) => some_real_work(_)`) the body still runs twice either way, so the relative win shrinks to the dispatch overhead alone — small win compared to the work.
+
+**`has_sideeffects` is a SEMANTIC gate, not a perf gate.** It blocks substitution when the body has observable side effects, because `replaceVariable` doesn't preserve the typer-inserted ExprRef2Value wrappers and ordering guarantees that side-effecty expressions rely on — moving them around via macro substitution can change observable behavior. Has nothing to do with "would double the expensive work."
+
+**Schwartzian transform is the orthogonal optimization** that DOES help expensive keys: precompute `key(v)` once per element into a paired array, then sort the paired array by the precomputed scalar. Neither path here does that — both the original keyed top_n_by and the inlined `top_n_by_with_cmp` re-evaluate the key per comparison. Schwartzian would be a separate library entry / macro layer; not in scope for PR #2714.
+
+**Canonical example:** `try_make_inline_cmp` in `daslib/linq_fold.das` (PR #2714). The `try_make_inline_cmp` helper's docstring spells this out in detail with the dispatch-count table.
+
+Linked: [[pr-2714-linq-splice-single-eval]], [[qmacro-multi-arg-block-declaration-with-i-name-splices-fails-with-error-30701]].
+
+## Questions
+- inlining a sort comparator key body — does it double the work for expensive keys compared to keeping the key lambda call

--- a/mouse-data/docs/libstdcpp-vs-libcpp-transitive-stdexcept-asymmetry.md
+++ b/mouse-data/docs/libstdcpp-vs-libcpp-transitive-stdexcept-asymmetry.md
@@ -1,0 +1,35 @@
+---
+slug: libstdcpp-vs-libcpp-transitive-stdexcept-asymmetry
+title: why does my low-level daslang header compile on macOS but fail on Linux with "no member named X in namespace das" — transitive include differences
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**Symptom**: A header that compiles fine on macOS (clang + libc++) fails on Linux (clang/gcc + libstdc++) with errors like:
+```
+error: no member named 'out_of_range' in namespace 'das'
+```
+
+**Cause**: Standard library implementations differ in what's pulled in transitively.
+- **libc++** (macOS, Emscripten/WASM): `<vector>` / `<string>` / `<map>` typically pull `<stdexcept>` transitively, making `std::out_of_range`, `std::runtime_error` visible.
+- **libstdc++** (Linux GCC default): does NOT pull `<stdexcept>` from those headers. You must `#include <stdexcept>` explicitly.
+
+Same asymmetry applies to `<exception>`, `<new>` (placement new declarations), some `<type_traits>` features depending on version.
+
+**In daslang specifically**: `include/das_hash_map/das_hash_map.h` was pulled via `das_config.h`'s `<vector>`, `<utility>`, etc. — but on Linux, those don't bring `<stdexcept>` along. PR #2716's first iteration removed the local `<stdexcept>` thinking it was redundant; CI immediately failed on the Linux jobs. macOS local build had said "all clean".
+
+**Diagnosis tip**: when CI fails Linux-only on what looks like a namespace-resolution issue, suspect transitive-include differences. Check:
+```bash
+grep -rn "X" /path/to/libcxx-include/<vector>  # is X declared transitively in libc++?
+grep -rn "X" /path/to/libstdcpp-include/vector # vs libstdc++?
+```
+
+**Fix options**:
+1. Add the explicit `#include <stdexcept>` (or whatever) in the header that needs it.
+2. Avoid the symbol entirely (PR #2716 chose this — switched from `std::out_of_range` to `das::das_throw`, which has no `<stdexcept>` dependency).
+
+**Don't rely on "macOS local says it works"** for include hygiene questions. The CI matrix exists because the toolchains diverge in ways the lone-dev macOS build won't catch.
+
+## Questions
+- why does my low-level daslang header compile on macOS but fail on Linux with "no member named X in namespace das" — transitive include differences

--- a/mouse-data/docs/qmacro-multi-arg-block-declaration-with-i-name-splices-fails-with-error-30701-block-argument-is-already-declared-macro-tag-how-d.md
+++ b/mouse-data/docs/qmacro-multi-arg-block-declaration-with-i-name-splices-fails-with-error-30701-block-argument-is-already-declared-macro-tag-how-d.md
@@ -1,0 +1,44 @@
+---
+slug: qmacro-multi-arg-block-declaration-with-i-name-splices-fails-with-error-30701-block-argument-is-already-declared-macro-tag-how-d
+title: qmacro multi-arg block declaration with $i name splices fails with error 30701 block argument is already declared MACRO TAG how do I emit a typed block with multiple distinct argument names
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**Root cause:** `src/parser/parser_impl.cpp:ast_makeBlock` does a parse-time dup check on block-arg names via `closure->findArgument(name_at.name)`. The parser stamps every `$i(expr)` in block-arg-decl position with the literal placeholder name `"``MACRO``TAG``"` (the actual name is resolved later, post-parse, by the macro tag visitor). So `qmacro($($i(a) : $t(T), $i(b) : $t(T)) { ... })` parses BOTH args with that same placeholder string and the dup check fires before macro substitution gets a chance to assign distinct names.
+
+**Diagnostic:** error `30701: block argument is already declared ``MACRO``TAG``` while compiling a `[macro_function]` that emits a typed multi-arg block via `qmacro($($i(a) : ..., $i(b) : ...) { ... })`.
+
+**Two workarounds + one upstream fix:**
+
+1. **Upstream fix** (PR #2714 commit `bd76c588f`): in `parser_impl.cpp:885`, skip the dup check when `name_at.tag != nullptr` — tagged names are deferred-resolved by the macro processor, and genuine post-resolution dups surface as ordinary local-lookup conflicts during type inference. Three lines + a comment. General-purpose.
+
+2. **Hybrid emission** (works pre-fix): emit the block via qmacro with ONE typed `$i`-named arg, then append the second as a fresh `Variable` manually:
+   ```das
+   var cmpMake = qmacro($(v1 : $t(elemType) -&) {
+       return $e(cmpExpr)
+   }) as ExprMakeBlock
+   var cmpBody = cmpMake._block as ExprBlock
+   var v2Var = new Variable(at = at, name := "v2", _type = clone_type(elemType))
+   v2Var._type.flags.removeConstant = true
+   v2Var._type.flags.ref = true
+   cmpBody.arguments |> emplace_new(v2Var)
+   return cmpMake
+   ```
+   Fragile because the flag bookkeeping for the second var must match what qmacro's `$t(T) -&` produces for the first — different modifier ordering produces different rendered shapes (`Car -&` vs `Car&` vs `Car const -&`).
+
+3. **Untyped block args** (the cleanest for most use cases — what PR #2714 ships): drop type annotations on both args and let the typer infer from the call-site signature:
+   ```das
+   return qmacro($(v1, v2) {
+       return $e(cmpExpr)
+   })
+   ```
+   The typer resolves `v1`/`v2` types from the function the block gets passed to (e.g. `block<(v1 : TT -&, v2 : TT -&) : bool>` in `top_n_by_with_cmp(arr, n, cmp)`). Works because the block-arg-decl path here is a SOURCE-LEVEL block expression in qmacro, NOT an `$i`-tagged form, so the parser sees distinct `v1` and `v2` identifiers and the dup check passes naturally.
+
+**When to pick which:** untyped (#3) sidesteps both the dup-check bug AND the const-ref flag-bookkeeping fragility — recommended for any case where the typer can infer from context. Typed multi-arg `$i` (#1, post-fix) is for cases where you genuinely need the spliced name from a string variable (gensym from `at.line`/`at.column`) AND need explicit typing.
+
+See PR #2714 and the `try_make_inline_cmp` helper in `daslib/linq_fold.das` for the canonical example.
+
+## Questions
+- qmacro multi-arg block declaration with $i name splices fails with error 30701 block argument is already declared MACRO TAG how do I emit a typed block with multiple distinct argument names

--- a/skills/das_macros.md
+++ b/skills/das_macros.md
@@ -40,6 +40,25 @@ If you find yourself reading older guidance about `var inscope`, `<-`,
 `move_new`, `add_ptr_ref` for AST types, the source is pre-migration.
 The post-migration rules above are correct as of daslang 0.6.x.
 
+### Pre-set `_type` on emitted `ExprVar` (and similar nodes) that flow into typed positions
+
+`Expression::clone` deep-copies `_type` faithfully ([ast.cpp:1094](src/ast/ast.cpp#L1094): `expr->type = type ? new TypeDecl(*type) : nullptr`). So whatever you put on the source propagates to every consumer. The trap is the **source**: `new ExprVar(at = at, name := wbName)` leaves `_type` null, every `clone_expression` of it inherits the null, and if any of those clones flows into a generic call (`push_clone`, `sum`, etc.) the typer fails with `30165: cannot infer ... return type with 'auto'`.
+
+Don't rely on the typer's later local-variable-resolution pass to fix this — its generic-instantiation pass runs **first** and commits to `auto`, cascading errors up through every downstream consumer.
+
+Fix at emission time:
+
+```das
+var pvar = new ExprVar(at = at, name := boundName)
+pvar._type = clone_type(boundElementType)
+pvar._type.flags.ref = true
+// now any clone_expression(pvar) downstream carries the type into push_clone et al.
+```
+
+Same family of trap as the [ExprRef2Value blocker](#peel-exprref2value-before-qmatch) — the typer doesn't repair what macro substitution introduces, when the substitution lands in an already-typed AST fragment.
+
+Canonical example: `try_make_inline_cmp` and the `_where`-arm projection-bind rewrite in `daslib/linq_fold.das` (PR #2714).
+
 ## The few residual smart_ptr types — `Program`, `Context`, `FileAccess`
 
 A small set of types are still `smart_ptr<T>` (refcounted with manual


### PR DESCRIPTION
## Summary

Docs-only PR — eight blind-mouse cache cards accumulated across the recent linq_fold and das_hash_map work, plus one section added to `skills/das_macros.md`.

**Mouse cards** (`mouse-data/docs/`):

From the das_hash_map / EASTL work (PR #2716):

- **das-namespace-abstraction-std-vs-eastl-swap** — how `das::vector` / `das::pair` etc. route via `namespace das { using namespace std; }` (default) or `using namespace eastl;` (EASTL config); why `using std::vector` blocks inside `namespace das` are actively harmful for EASTL builds.
- **das-throw-universal-panic-primitive-low-level-headers** — `das_throw` is daslang's setjmp/longjmp panic primitive; embedded games disable C++ exceptions, so raw `throw` is the wrong primitive in low-level headers. Captures the unconditional-declaration change from #2716.
- **daslang-eastl-config-local-build-setup** — local repro: clone EASTL + EABase separately (no longer submoduled), cmake invocation mirroring `.github/workflows/build_eastl.yml`, common failure modes.
- **libstdcpp-vs-libcpp-transitive-stdexcept-asymmetry** — why CI failed Linux-only on the first push of #2716; libstdc++ doesn't pull `&lt;stdexcept&gt;` transitively via `&lt;vector&gt;`/`&lt;string&gt;`, libc++ does. macOS local-only builds can't catch this.
- **github-pr-body-angle-brackets-stripped-in-backticks** — operational gotcha: GitHub silently strips `&lt;vector&gt;` inside backticks in PR body markdown. Use `&amp;lt;X&amp;gt;` entities and re-read after every update.

From the linq_fold splice work (PRs #2712/#2714):

- **how-do-i-dedupe-a-select-projection-...** — Phase 3d projection double-eval root cause and #2714 fix.
- **inlining-a-sort-comparator-key-body-...** — both forms evaluate key body twice per comparison; sort-cmp inlining saves dispatch only.
- **qmacro-multi-arg-block-declaration-...** — parser dup-check fires on `MACRO TAG` placeholder name before macro substitution can rename; #2714 parser fix details.

**skills/das_macros.md**: new "Pre-set `_type` on emitted `ExprVar` that flow into typed positions" section — captures the 30165 trap from #2714's `try_make_inline_cmp` work. `Expression::clone` deep-copies `_type` faithfully ([ast.cpp:1094](src/ast/ast.cpp#L1094)), but the source `new ExprVar(...)` leaves `_type` null; the typer's generic-instantiation pass commits to `auto` before local-variable-resolution runs, cascading errors.

## Test plan

- [x] No code changes — docs only
- [x] Cards rebuild cleanly via blind-mouse (5 added via `mouse__add` this session, 3 already on disk from prior sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)