### PR TITLE
mouse-cards: 16 cards (MCP project_root, dasImgui drawlist rail, recording, sphinx/CI)

### DIFF
--- a/mouse-data/docs/dasimgui-drawlist-prim-macro-path-key-only-no-state-global-render-only-rail.md
+++ b/mouse-data/docs/dasimgui-drawlist-prim-macro-path-key-only-no-state-global-render-only-rail.md
@@ -1,0 +1,82 @@
+---
+slug: dasimgui-drawlist-prim-macro-path-key-only-no-state-global-render-only-rail
+title: How do I design a dasImgui macro annotation that emits path-key telemetry per call site but no state-global, for render-only operations?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+For render-only call sites (drawlist primitives, frame markers, etc.) where every invocation is purely transient — no hover, no active, no edit state worth preserving across `@live` reloads — emit a stable `<mod>:<line>:<col>` path-key per call site for mouse-cards / playwright targeting BUT skip the `__widget_<line>_<col>` state-global emission that `[widget]` does.
+
+The pattern is a sibling to `[widget]` / `[container]`, sharing the same surface area in `widgets/imgui_boost.das`. Mirror this template (`[drawlist_prim]` is the reference implementation from dasImgui PR #48):
+
+```das
+// widgets/imgui_boost.das — same module as [widget] / [container] annotations.
+// Annotation MUST live in a different module from the call sites — defining
+// the annotation class and immediately using [drawlist_prim] in the same file
+// errors out because the parser hasn't completed annotation registration
+// when the sibling annotation gets resolved.
+
+class DrawlistPrimCallMacro : AstCallMacro {
+    kind_name : string
+
+    def override visit(prog : Program?; mod : Module?; var expr : smart_ptr<ExprCallMacro>) : ExpressionPtr {
+        let modName = mod == null ? "anon" : string(mod.name)
+        let path_key = "{modName}:{expr.at.line:d}:{expr.at.column:d}"
+        var rewritten = new ExprCall(at = expr.at, name := kind_name)
+        var pathArg = new ExprConstString(at = expr.at, value := path_key)
+        rewritten.arguments |> push(pathArg)
+        for (a in expr.arguments) {
+            rewritten.arguments |> push(clone_expression(a))
+        }
+        return <- rewritten
+    }
+}
+
+[function_macro(name = "drawlist_prim")]
+class DrawlistPrimFunctionMacro : AstFunctionAnnotation {
+    def override transform(var func : FunctionPtr; var args : AnnotationArgumentList) : ExpressionPtr {
+        let kind = string(find_arg(args, "kind"))
+        // Inject a leading `widget_ident : string` parameter so the rewritten
+        // call carries the path key into the runtime register helper.
+        var widthIdentVar = new Variable(at = func.at,
+            name := "widget_ident",
+            _type <- new TypeDecl(baseType = Type.tString, at = func.at))
+        widthIdentVar.flags.generated = true
+        func.arguments |> emplace(widthIdentVar, 0)
+        // Register the call-site rewriter under the function's own name —
+        // call sites write `add_rect(dl, ...)` and the macro slots in
+        // the path-key argument transparently.
+        var inst = new DrawlistPrimCallMacro(kind_name = kind)
+        compiling_module() |> add_call_macro(make_call_macro(kind, inst))
+        return [[ExpressionPtr]]
+    }
+}
+```
+
+Then at the impl side (`widgets/imgui_drawlist_builtin.das` or similar):
+
+```das
+[drawlist_prim(kind = "add_rect")]
+def add_rect(widget_ident : string; var dl : ImDrawList?; p_min, p_max : float2; col : uint; rounding : float; flags : ImDrawFlags; thickness : float) {
+    drawlist_register(widget_ident, "add_rect", make_bbox(p_min, p_max))
+    *dl |> AddRect(p_min, p_max, col, rounding, flags, thickness)
+}
+```
+
+Where `drawlist_register(widget_ident, kind, bbox)` writes a lightweight `WidgetEntry` (kind + bbox, no hover/active/focus fields) into `g_registry`. No `__widget_<line>_<col>` global declared — multiple primitives at the same source coordinates never collide because nothing's stored.
+
+**Key correctness points**:
+
+1. **Annotation lives in a different file from the call sites**. Same-file definition + use fails — parser order issue. Put `[function_macro(name="...")] class` in `imgui_boost.das` next to `[widget]`/`[container]`; primitives `require imgui/imgui_boost_v2 public` then tag themselves with `[drawlist_prim(kind="add_rect")]`.
+
+2. **Path-key shape is `<mod>:<line>:<col>`** — leaf format that `widget_path_key(widget_ident)` recognises and slots under the current container (if any). Tests should assert leaves match a `:\d+:\d+$` regex.
+
+3. **No state global**. `[widget]` declares `__widget_<line>_<col>` to persist hover/click state across `@live`. Drawlist primitives skip that step — they're stateless, so collisions are impossible-by-design, NOT impossible-by-accident.
+
+4. **Container nesting is lexical**, NOT visual. `with_window_drawlist` painted INSIDE `window(W, ...)` produces nested path keys (`W/mod:line:col`); same call OUTSIDE the window block produces unnested keys. Visual drawlist scope (`with_foreground_drawlist` paints to the viewport drawlist regardless of where called) is independent of telemetry nesting.
+
+Verified by `tests/integration/test_drawlist_path_key.das` and `test_with_window_drawlist.das` in dasImgui PR #48.
+
+## Questions
+- How do I design a dasImgui macro annotation that emits path-key telemetry per call site but no state-global, for render-only operations?

--- a/mouse-data/docs/dasimgui-hover-target-widget-variant-pattern-color-button-hover-selectable-hover.md
+++ b/mouse-data/docs/dasimgui-hover-target-widget-variant-pattern-color-button-hover-selectable-hover.md
@@ -1,0 +1,37 @@
+---
+slug: dasimgui-hover-target-widget-variant-pattern-color-button-hover-selectable-hover
+title: dasImgui hover-target widget variant pattern (color_button_hover / selectable_hover)
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**Hover-target [widget] variants** mirror their click/toggle cousins but use `EmptyMarkerState` and return a per-frame `bool hovered` from `IsItemHovered()`. Use when the widget is a *surface* for a hover-driven side-effect (cursor swap, capture override, status preview), not a *trigger*.
+
+Pattern shape (PR-A2 introduced two: `color_button_hover` next to `color_button`, `selectable_hover` next to `selectable`):
+
+```das
+[widget]
+def color_button_hover(var state : EmptyMarkerState; desc_id : string;
+                       col : float4;
+                       size : float2 = float2(0.0f, 0.0f);
+                       flags : ImGuiColorEditFlags = ImGuiColorEditFlags.None) : bool {
+    ColorButton(desc_id, col, flags, size)
+    let hovered = IsItemHovered()
+    marker_finalize(widget_ident, "color_button_hover", state)
+    return hovered
+}
+```
+
+Key choices:
+- **`EmptyMarkerState`** (the same shape backing `bullet` / `same_line`) — there's no per-frame state worth persisting (hover is transient; ImGui re-queries each frame). Caller branches on the returned bool synchronously.
+- **`marker_finalize`** — same finalizer the empty-marker widgets use. No L2/L3 dispatcher actions; the path-key is what playwright targets.
+- **Distinct name** (`_hover` suffix) rather than overloading the existing widget — kind: in the snapshot is the disambiguator, and tests can `find_widget(snap, path)?["kind"] == "color_button_hover"`. Overloading would conflate them in telemetry.
+- **Caller pattern**: `let hovered = widget_hover(IDENT, (...))`; if (hovered) { side-effect }. The regular widget's state holds click/toggle bookkeeping; the hover variant has neither.
+
+When a site needs BOTH click and hover, use the click variant + `IsItemHovered()` after the call — the post-item hover query is ALLOWED in `imgui_lint.das`. No need for a third variant.
+
+See dasImgui PR #47 (PR-A2 of imgui_demo port) for the introduction.
+
+## Questions
+- dasImgui hover-target widget variant pattern (color_button_hover / selectable_hover)

--- a/mouse-data/docs/dasimgui-imguisizeconstraints-lambda-needs-module-scope-lifetime-not-stack-local.md
+++ b/mouse-data/docs/dasimgui-imguisizeconstraints-lambda-needs-module-scope-lifetime-not-stack-local.md
@@ -1,0 +1,46 @@
+---
+slug: dasimgui-imguisizeconstraints-lambda-needs-module-scope-lifetime-not-stack-local
+title: Why does `SetNextWindowSizeConstraints(min, max, ImGuiSizeConstraints(@(var d) { ... }))` crash with an access violation inside `CalcWindowNextAutoFitSize` on the next frame?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+**Because ImGui stores the callback pointer + user_data on `g.NextWindowData.SizeCallback` / `.SizeCallbackUserData` and consumes them DEFERRED — at the next `Begin()` AND on later `CalcWindowNextAutoFitSize` passes — but your daslang `ImGuiSizeConstraints` struct (which holds the `lambda<...>` the C++ trampoline invokes) was a stack local in the function that called `SetNextWindowSizeConstraints`.** That local dies when the function returns. The lambda's captured `Context*` + closure body is GC'd before ImGui dereferences `SizeCallbackUserData`, so `_builtin_SetNextWindowSizeConstraints`'s trampoline reads freed memory → AV in the auto-fit pass.
+
+**The fix:** make the `ImGuiSizeConstraints` holder live at least as long as the window. Module-scope `var private` + `[init]` seeding is the canonical pattern:
+
+```das
+// app_small.das — ShowExampleAppConstrainedResize
+var private SMALL_CONSTR_SQUARE_CN : ImGuiSizeConstraints
+var private SMALL_CONSTR_ASPECT_CN : ImGuiSizeConstraints
+var private SMALL_CONSTR_STEP_CN   : ImGuiSizeConstraints
+
+[init]
+def small_constr_init() {
+    SMALL_CONSTR_SQUARE_CN <- ImGuiSizeConstraints(@(var d : ImGuiSizeCallbackData) {
+        let m = max(d.DesiredSize.x, d.DesiredSize.y); d.DesiredSize = float2(m, m)
+    })
+    SMALL_CONSTR_ASPECT_CN <- ImGuiSizeConstraints(@(var d : ImGuiSizeCallbackData) {
+        d.DesiredSize.y = d.DesiredSize.x / (16.0f / 9.0f)
+    })
+    SMALL_CONSTR_STEP_CN <- ImGuiSizeConstraints(@(var d : ImGuiSizeCallbackData) {
+        let s = 100.0f
+        d.DesiredSize = floor(d.DesiredSize / float2(s, s)) * float2(s, s)
+    })
+}
+
+// In ShowExampleAppConstrainedResize, per case:
+SetNextWindowSizeConstraints(float2(0,0), float2(FLT_MAX, FLT_MAX), SMALL_CONSTR_SQUARE_CN)
+```
+
+**Why this is non-obvious from the daslang API surface:** `ImGuiSizeConstraints(...)` looks like a value constructor that returns by value, and `SetNextWindowSizeConstraints(min, max, var cn : ImGuiSizeConstraints)` takes `var cn` so it looks borrow-style. But the C++ `_builtin_SetNextWindowSizeConstraints` at `src/dasIMGUI.main.cpp:361-384` reinterprets the daslang struct's bytes (Context*, Lambda, LineInfo*) and stashes them in ImGui's `SizeCallback`/`SizeCallbackUserData` slots — pointer escape ImGui consumes later in the frame and on subsequent auto-fit passes. No daslang side-channel reflects this lifetime extension.
+
+The 2-arg no-callback form `SetNextWindowSizeConstraints(min, max)` (in `ALLOWED_IMGUI`) doesn't have this trap — no callback to keep alive.
+
+**Tutorial parity:** the `examples/tutorial/window_size_constraints.das` example uses the same module-scope `SQUARE_CN` / `ASPECT_CN` / `STEP_CN` pattern. If you copy a `SetNextWindowSizeConstraints` lambda call from your own code into a function body, you've reintroduced the bug.
+
+## Questions
+- Why does `SetNextWindowSizeConstraints(min, max, ImGuiSizeConstraints(@(var d) { ... }))` crash with an access violation inside `CalcWindowNextAutoFitSize` on the next frame?
+- How do I correctly extend the lifetime of an `ImGuiSizeConstraints` callback lambda in dasImgui so ImGui's deferred SizeCallback consumer doesn't dereference freed memory?
+- Can `ImGuiSizeConstraints` be a function-local in dasImgui, or does it need module-scope lifetime?

--- a/mouse-data/docs/dasimgui-integration-tests-use-examples-features-recordings-use-examples-tutorial.md
+++ b/mouse-data/docs/dasimgui-integration-tests-use-examples-features-recordings-use-examples-tutorial.md
@@ -1,0 +1,27 @@
+---
+slug: dasimgui-integration-tests-use-examples-features-recordings-use-examples-tutorial
+title: dasImgui integration tests use examples/features/, recordings use examples/tutorial/
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+For a new dasImgui component, the **full triad** needs FOUR files, not three, because tests and recordings need different lifecycles:
+
+| File | Lifecycle | Driven by |
+|---|---|---|
+| `examples/features/<name>.das` | `harness_init` / `harness_begin_frame` / `harness_new_frame` (require `imgui/imgui_harness`) | Integration tests via `with_imgui_app(feature_path)` |
+| `examples/tutorial/<name>.das` | `live_create_window` / `live_imgui_init` / `live_begin_frame` (require `imgui_live` + GLFW + GL stack) | Recording drivers via `with_recording_app(tutorial_path, apng, secs)` |
+| `tests/integration/test_<name>.das` | n/a | dastest; points at the `features/` file |
+| `tests/integration/record_<name>.das` | n/a | record entry-point; points at the `tutorial/` file |
+
+Plus the RST tutorial page (`doc/source/tutorials/<name>.rst`) doing `literalinclude` of the `tutorial/` file, and the APNG dropped at `doc/source/_static/tutorials/<name>.apng`.
+
+**Don't** point an integration test at a `tutorial/` file. `with_imgui_app` spawns plain `daslang-live` which doesn't dispatch the `live_create_window` lifecycle — the host window never opens, `wait_for_widget("ROOT_WIN", 15s)` times out, and you get a CI failure that looks like "the widget never registers" but is actually "the app's `update()` never runs."
+
+CI failure shape for the wrong-lifecycle case: `wait_for_widget` returns null after 15s with the failure message "<ROOT> registers (demo renders)" — no compile error, no panic, just silent timeout.
+
+Bit me in dasImgui PR #47 (PR-A2 inputs.das sweep): I skipped `features/` and pointed tests at `tutorial/` directly. macOS CI surfaced 3 timeouts; fixup commit `2665617` added the feature files. Pattern confirmed against existing `test_with_indent.das` ← `features/with_indent.das` and similar.
+
+## Questions
+- dasImgui integration tests use examples/features/, recordings use examples/tutorial/

--- a/mouse-data/docs/dasimgui-sphinx-w-cross-ref-add-labels-to-external-types-rst-when-wrappers-reference-new-imgui-types.md
+++ b/mouse-data/docs/dasimgui-sphinx-w-cross-ref-add-labels-to-external-types-rst-when-wrappers-reference-new-imgui-types.md
@@ -1,0 +1,46 @@
+---
+slug: dasimgui-sphinx-w-cross-ref-add-labels-to-external-types-rst-when-wrappers-reference-new-imgui-types
+title: When I add a new dasImgui boost-surface wrapper that references an ImGui type (e.g. `ImGuiTableFlags`, `ImGuiCond`, `ImGuiViewport`), why does CI sphinx-W fail with "undefined label" warnings even though the wrapper compiles fine?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+**Because `imgui2rst.das` (the dasImgui doc generator) emits `:ref:\`enum-imgui-<TypeName>\`` / `:ref:\`handle-imgui-<TypeName>\`` cross-refs in every generated `stdlib/generated/<module>.rst` whenever a wrapper's signature mentions an imgui-owned type — but those labels are NOT in any generated file (they live in `doc/source/stdlib/external_types.rst`, which is hand-maintained).** New wrapper signature → new cross-ref → if the matching `.. _enum-imgui-<TypeName>:` / `.. _handle-imgui-<TypeName>:` anchor doesn't exist in `external_types.rst`, sphinx-W explodes the CI build with `undefined label: enum-imgui-imguitableflags` etc.
+
+**Surface:** local `daspkg build` won't catch it — only sphinx-W (`sphinx-build -W -b html doc/source doc/build/html`) does, which runs in the docs CI job. AND local sphinx-W might pass anyway if you don't first invoke `imgui2rst.das` to regenerate `stdlib/generated/`; CI does this in-pipeline.
+
+**The discipline:** any time you add a wrapper module / signature in `widgets/` that mentions a previously-unreferenced ImGui type, add the cross-ref anchor to `doc/source/stdlib/external_types.rst` in the SAME PR. The label format is lowercased-by-sphinx but you write the proper case:
+
+```rst
+.. _enum-imgui-ImGuiTableFlags:
+.. _enum-imgui-ImGuiTableColumnFlags:
+.. _enum-imgui-ImGuiTableRowFlags:
+
+``imgui::ImGui*Flags``
+======================
+Bitfield enums exposed by the ``imgui`` builtin module: ... list ...
+
+.. _enum-imgui-ImGuiCond:
+
+``imgui::ImGuiCond``
+====================
+[description]
+
+.. _handle-imgui-ImGuiViewport:
+
+``imgui::ImGuiViewport``
+========================
+[description]
+```
+
+Multiple anchor lines stacked above ONE heading is the working pattern (sphinx points all of them at the same section). Used for `ImGui*Flags` (one heading, ~9 stacked labels) and `ImGuiViewport` / `ImGuiSizeCallbackData` (one heading each).
+
+**Concrete instance (2026-05-17, PR #45):** `widgets/imgui_table_builtin.das` introduced `data_table(..., flags : ImGuiTableFlags, ...)` + 6 pass-throughs mentioning `ImGuiTableColumnFlags` / `ImGuiTableRowFlags`; `widgets/imgui_window_constraints_builtin.das` introduced `ImGuiSizeCallbackData` in the lambda signature; `widgets/imgui_containers_builtin.das` added `set_window_size(cond : ImGuiCond)` + `viewport_center(self : ImGuiViewport)`. Build went green locally, sphinx-W in CI rejected the PR until 6 new labels (3 table flags + ImGuiCond + ImGuiViewport + ImGuiSizeCallbackData) landed in `external_types.rst`.
+
+**Companion:** `feedback_dasimgui_sphinx_w_apng_must_exist.md` is the cousin for static assets (`.. image:: _static/tutorials/<name>.apng` must exist at CI time). Both fail in the same job; check both when sphinx-W errors land on a wrapper-addition PR.
+
+## Questions
+- When I add a new dasImgui boost-surface wrapper that references an ImGui type (e.g. `ImGuiTableFlags`, `ImGuiCond`, `ImGuiViewport`), why does CI sphinx-W fail with "undefined label" warnings even though the wrapper compiles fine?
+- Where do I add the `enum-imgui-<Name>` / `handle-imgui-<Name>` Sphinx anchors that `imgui2rst.das` emits cross-refs to?
+- Why does my local sphinx-W pass on a dasImgui doc build but CI fails on the same commit?

--- a/mouse-data/docs/daslang-deduce-project-root-auto-fallback-from-script-dir-affects-test-design.md
+++ b/mouse-data/docs/daslang-deduce-project-root-auto-fallback-from-script-dir-affects-test-design.md
@@ -1,0 +1,51 @@
+---
+slug: daslang-deduce-project-root-auto-fallback-from-script-dir-affects-test-design
+title: Why does daslang.exe auto-resolve daspkg modules without an explicit `-project_root` when the script lives inside the project root?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**`daslang.exe` auto-deduces `-project_root` from `files.front()`'s directory** when the flag isn't passed explicitly. See `utils/daScript/main.cpp:379` `deduce_project_root()`:
+
+```cpp
+static string deduce_project_root(string maybe_project_root, string compile_file) {
+    if (!maybe_project_root.empty()) return maybe_project_root;       // explicit wins
+    if (!projectFile.empty()) { /* try .das_project's getDynModulesFolder() */ }
+    if (!compile_file.empty()) {                                      // fallback: script's dir
+        auto filename_start = compile_file.find_last_of("\\/");
+        return filename_start != string::npos
+            ? compile_file.substr(0, filename_start)
+            : "./";
+    }
+    return "";
+}
+```
+
+Used at `main.cpp:738`: `project_root = deduce_project_root(project_root, files.front())` → fed into `require_dynamic_modules(access, getDasRoot(), project_root, tout)` → which scans `<project_root>/modules/*/.das_module`.
+
+**Implication for MCP project_root testing**: which file is `files.front()`?
+
+| Spawn path | files.front() | Auto-deduces project_root from |
+|---|---|---|
+| `daslang.exe consumer.das` (direct) | `consumer.das` | consumer's own dir |
+| `daslang.exe subtool.das -- consumer.das` (MCP subprocess) | `subtool.das` | `utils/mcp/subtools/` (no `modules/` there) |
+| `do_run_script` (spawns `daslang.exe consumer.das` directly) | `consumer.das` | consumer's own dir |
+
+So for an MCP test fixture at `utils/mcp/tests/_pretend_root/consumer.das`:
+- MCP subtool tests (`compile_check`, `lint`, etc.) → spawn `daslang.exe subtool.das -- consumer.das` → auto-deduce uses `utils/mcp/subtools/` → no `modules/` → `pretend_mod` unregistered → compile fails without explicit `-project_root`. ✓ TESTABLE.
+- `do_run_script(consumer.das, ...)` → spawns `daslang.exe ... consumer.das` directly → auto-deduce uses `_pretend_root/` → finds `modules/pretend_mod/` → resolves WITHOUT explicit project_root. ✗ FALSE POSITIVE.
+
+**Workaround for testing `do_run_script`**: use inline code mode (`do_run_script("", code_string, ...)`) — the temp stub is written to `get_das_root()` whose `modules/` tree is daslang's own (no pretend_mod). Then the negative case fails as expected.
+
+Same gotcha for `do_eval_expression` — its temp stub also lands in `get_das_root()`, so the auto-deduce doesn't help and explicit project_root is required.
+
+Surfaced 2026-05-18 during Tier 1 MCP project_root test design. Affects ANY test fixture that places the consumer file inside the project_root subtree.
+
+## Questions
+- Why does daslang.exe auto-resolve daspkg modules without an explicit `-project_root` when the script lives inside the project root?
+- How does `deduce_project_root` interact with MCP test fixtures?
+- Why does `do_run_script` succeed against my pretend-daspkg fixture without project_root, but `do_compile_check` fails?
+
+## Questions
+- Why does daslang.exe auto-resolve daspkg modules without an explicit `-project_root` when the script lives inside the project root?

--- a/mouse-data/docs/daslang-live-cwd-flag-chdir-before-require-dynamic-modules-relative-paths-break.md
+++ b/mouse-data/docs/daslang-live-cwd-flag-chdir-before-require-dynamic-modules-relative-paths-break.md
@@ -1,0 +1,37 @@
+---
+slug: daslang-live-cwd-flag-chdir-before-require-dynamic-modules-relative-paths-break
+title: Why does daslang-live with relative `-project_root` fail to resolve daspkg modules?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**daslang-live's `-cwd` flag changes the working directory to the script's folder BEFORE `require_dynamic_modules` runs**, so any relative `-project_root <P>` passed alongside it gets re-resolved against the *new* cwd and fails to find `<P>/modules/`.
+
+Code path (utils/daslang-live/main.cpp):
+- Line 696-707: `-cwd` handler calls `SetCurrentDirectoryA(dir)` / `chdir(dir)` where `dir = dirname(scriptFile)`.
+- Line 725-730: AFTER chdir, `require_dynamic_modules(access, getDasRoot(), project_root, tout)` runs. If `project_root` was relative, it now points at `<new_cwd>/<relative_project_root>` — which is almost never what the caller meant.
+
+Concrete failure mode: spawning daslang-live with `-cwd -project_root utils/mcp/tests/_pretend_root <abs>/consumer.das` chdir's to `utils/mcp/tests/_pretend_root/`, then tries to scan `utils/mcp/tests/_pretend_root/utils/mcp/tests/_pretend_root/modules/` (the relative path doubled). Result: `error[20605]: missing prerequisite 'pretend_mod/greet'; file not found` even though the registration would succeed with the absolute path.
+
+**Fix on the caller side**: resolve all paths to absolute BEFORE composing daslang-live's argv. In `utils/mcp/tools/live.das` `do_live_launch`:
+
+```das
+let abs_file = resolve_path(file)
+let abs_project = empty(project) ? "" : resolve_path(project)
+let abs_project_root = empty(project_root) ? "" : resolve_path(project_root)
+let script_args = build_live_script_args(abs_file, abs_project, abs_project_root, is_windows)
+```
+
+`resolve_path()` lives in `utils/mcp/tools/common.das` and joins relative paths to `get_das_root()`.
+
+Surfaced 2026-05-18 during MCP test_live_tools.das implementation; the bug was latent until anyone actually fed `do_live_launch` a relative project_root (real-world callers had been passing absolute paths). Fix shipped in PR for the same project_root work.
+
+**Same gotcha applies to plain `daslang.exe`?** No — daslang.exe doesn't have a `-cwd` flag, so the cwd stays wherever the caller spawned from and relative `-project_root` resolves naturally.
+
+## Questions
+- Why does daslang-live with relative `-project_root` fail to resolve daspkg modules?
+- What happens when daslang-live `-cwd` and `-project_root` are both set with relative paths?
+
+## Questions
+- Why does daslang-live with relative `-project_root` fail to resolve daspkg modules?

--- a/mouse-data/docs/daslang-live-no-port-flag-single-instance-lock-e2e-spawn-tests-infeasible.md
+++ b/mouse-data/docs/daslang-live-no-port-flag-single-instance-lock-e2e-spawn-tests-infeasible.md
@@ -1,0 +1,32 @@
+---
+slug: daslang-live-no-port-flag-single-instance-lock-e2e-spawn-tests-infeasible
+title: Why is reliable in-suite e2e testing of daslang-live spawn infeasible?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+**daslang-live has no `-port` CLI flag** — the HTTP server port is hardcoded to 9090 in the binary. The MCP `port` argument (in `do_live_launch`, `do_live_status`, etc.) only changes which port the MCP *polls*, not what daslang-live *binds*. So a test using an isolated high port like 19090:
+
+1. Calls `do_live_launch(file, ..., port="19090")`. The launcher spawns daslang-live which binds 9090.
+2. `do_live_launch`'s post-spawn poll loop hits `live_is_running("19090")` → returns false (nothing on 19090).
+3. After 10s the loop returns `"daslang-live launched but did not respond on port {p} within 10 seconds"` — the test sees an error, but daslang-live is alive on 9090.
+4. Test's cleanup `do_live_shutdown("19090")` no-ops. The orphan process needs manual `taskkill`.
+
+Plus **`acquire_single_instance()` lock** (`utils/daslang-live/main.cpp:709`) — only ONE daslang-live can run per host. A stale instance from a previous failed test blocks the next spawn entirely. The lock is process-wide, not port-scoped.
+
+Combined: parallel test isolation requires either (a) a `-port <N>` flag on daslang-live or (b) a `--dry-run-launch` mode in `do_live_launch` that returns the would-be argv without spawning. Without either, the practical path is:
+
+- **Pin args-builder logic at unit level** — extract `build_live_script_args(file, project, project_root, is_windows)` and test the string output directly. No spawn, no port. See `utils/mcp/test_tools.das` Tier 4a tests.
+- **Pin the dispatcher side at MCP level** — Tier 1 tests against the daspkg-style fixture exercise `do_compile_check / do_lint / do_list_requires / ...` end-to-end through the subprocess argv path, proving `-project_root` flows correctly. Doesn't touch daslang-live but covers the same code.
+- **Defer real spawn tests** until an upstream daslang-live change adds port-iso or dry-run mode.
+
+Surfaced 2026-05-18 during MCP `test_live_tools.das` implementation. Tier 4b deferred to follow-up; documented in PR plan + `skills/external_module_debugging.md`.
+
+## Questions
+- Why is reliable in-suite e2e testing of daslang-live spawn infeasible?
+- Why does daslang-live ignore the `port` argument I passed to `do_live_launch`?
+- Can I run two daslang-live instances in parallel for test isolation?
+
+## Questions
+- Why is reliable in-suite e2e testing of daslang-live spawn infeasible?

--- a/mouse-data/docs/daspkg-standalone-marker-skips-in-tree-daslang-cmake-include-for-installed-modules.md
+++ b/mouse-data/docs/daspkg-standalone-marker-skips-in-tree-daslang-cmake-include-for-installed-modules.md
@@ -1,0 +1,31 @@
+---
+slug: daspkg-standalone-marker-skips-in-tree-daslang-cmake-include-for-installed-modules
+title: daslang in-tree build fails because a daspkg-installed module's CMakeLists.txt clobbers PROJECT_VERSION — what's the opt-out?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+When a `daspkg install <pkg> --global` lands a module under `modules/<pkg>/` and the daslang in-tree build then errors out (typically `No VERSION specified for WRITE_BASIC_CONFIG_VERSION_FILE()` from `CMakeLists.txt:1476` writing `${PROJECT_VERSION}`), the cause is daslang's module sweep INCLUDEing the installed module's CMakeLists.txt and that CMakeLists.txt calling its own `project()` without a VERSION argument — clobbering the parent's `project(DAS VERSION 0.6.2)` PROJECT_VERSION to empty.
+
+Look at daslang `CMakeLists.txt` lines 476-481:
+
+```cmake
+FOREACH(_module ${_modules})
+    # Skip daspkg-installed modules that build themselves (standalone CMake)
+    IF(NOT EXISTS "${PROJECT_SOURCE_DIR}/modules/${_module}/.daspkg_standalone")
+        INCLUDE(modules/${_module}/CMakeLists.txt OPTIONAL)
+    ENDIF()
+ENDFOREACH()
+```
+
+**Fix**: drop a `.daspkg_standalone` marker file at `modules/<pkg>/.daspkg_standalone` (any content; presence is the gate). The in-tree build then skips the include. The package builds standalone via its own CMake invocation (`cmake -B _build -S . -DDASLANG_DIR=<daslang-root>`).
+
+This is meant for packages like dasImgui that have their own full CMakeLists with `project(<name> CXX C)`, ImGui sources, etc. — they're not designed to coexist in daslang's project scope.
+
+**Pitfall**: if you'd installed the package into `daslang/modules/<name>/` as a real copy (NOT a junction/symlink) the marker file lives inside that copy. dasImgui's intended dev model has NO `modules/dasImgui` under daslang at all (see `dasimgui-dev-location-d-daspkg-not-modules` if it exists, or memory `feedback_dasimgui_dev_location`).
+
+Verified 2026-05-18 against daslang ced9f5175 + dasImgui 14d85b0.
+
+## Questions
+- daslang in-tree build fails because a daspkg-installed module's CMakeLists.txt clobbers PROJECT_VERSION — what's the opt-out?

--- a/mouse-data/docs/github-actions-pr-merge-ref-sphinx-duplicate-target-local-passes-ci-fails.md
+++ b/mouse-data/docs/github-actions-pr-merge-ref-sphinx-duplicate-target-local-passes-ci-fails.md
@@ -1,0 +1,32 @@
+---
+slug: github-actions-pr-merge-ref-sphinx-duplicate-target-local-passes-ci-fails
+title: CI sphinx-build fails with "Duplicate explicit target name" but local + WSL repro builds clean — what's going on?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+When local `sphinx-build -W` AND a WSL-Ubuntu-24.04 mirror of the CI pipeline both succeed, but GitHub Actions CI fails with `Duplicate explicit target name: "alias-X"` at lines you didn't write — the cause is almost always **GitHub Actions checking out the PR merge ref, not the branch HEAD**.
+
+`actions/checkout@v4` on pull-request events checks out a SYNTHESIZED MERGE COMMIT (PR-HEAD merged into base). Real `git merge origin/master` runs server-side. If master and the PR independently added the SAME RST explicit target (`.. _alias-foo:`) in DIFFERENT line ranges of the same file, git's recursive auto-merge cleanly combines both without conflict markers (because the edit hunks don't overlap). Sphinx then sees two definitions for the same label and bails with "Duplicate explicit target name".
+
+**Diagnostic** — add a debug step to the docs workflow that dumps the file right before sphinx-build:
+
+```yaml
+- name: "DEBUG: dump file + check duplicate sources"
+  run: |
+    nl -ba doc/source/stdlib/external_types.rst | sed -n '50,130p'
+    grep -rn '_alias-imvec\|_alias-ImVec' doc/source/
+    sha256sum doc/source/stdlib/external_types.rst
+```
+
+The grep on CI will show duplicate anchor lines (e.g. lines 61+62 AND 125+126). Locally the same grep returns only one set.
+
+**Fix**: `git fetch origin master && git merge origin/master` on the PR branch, then reconcile the duplicated content manually. Push. CI then sees the resolved version.
+
+**Catch this earlier**: a clean WSL repro that mirrors CI's `actions/checkout` would also need to merge master before building. Most WSL repros clone the branch and skip the merge step, which is why they silently miss this class of bug. If you want a faithful CI repro, do `git checkout pr-branch && git merge origin/master` in WSL too.
+
+Encountered 2026-05-18 on dasImgui PR #48 (drawlist-rail). PR #49 had landed on master 4h earlier adding `_alias-imvec2`/`_alias-imvec4` anchors to the same file my PR was anchoring `_alias-imcolor`. CI saw both blocks; local saw only mine. Resolved by merging master + folding `_alias-imcolor` into the existing block.
+
+## Questions
+- CI sphinx-build fails with "Duplicate explicit target name" but local + WSL repro builds clean — what's going on?

--- a/mouse-data/docs/how-do-i-disable-hdpi-framebuffer-scaling-in-daslang-live-for-recording.md
+++ b/mouse-data/docs/how-do-i-disable-hdpi-framebuffer-scaling-in-daslang-live-for-recording.md
@@ -1,0 +1,60 @@
+---
+slug: how-do-i-disable-hdpi-framebuffer-scaling-in-daslang-live-for-recording
+title: How do I disable HDPI framebuffer scaling in daslang-live (for APNG recording at logical pixel count)?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+Verified 2026-05-17 (daslang PR #2704, dasImgui PR #44).
+
+Pass `--no-hdpi-framebuffer` to `daslang-live` after the `--`
+separator. It tells `glfw_live` (in `modules/dasGlfw/dasglfw/glfw_live.das`)
+to set two GLFW window hints before `glfwCreateWindow`:
+
+  - `GLFW_COCOA_RETINA_FRAMEBUFFER = 0` (macOS: disable retina backing)
+  - `GLFW_SCALE_TO_MONITOR = 0` (Windows: don't auto-scale by monitor DPI)
+
+Result: framebuffer matches the requested logical size 1:1. A
+640×320-logical window stays at 640×320 in the framebuffer, instead
+of 1280×640 on retina mac or 960×480 on a 150%-scaled Windows
+monitor.
+
+**Use case:** APNG recording tools (dasImgui's `with_recording_app`
+spawn path) pass both:
+
+```
+daslang-live <feature.das> -- --imgui-content-scale=1.0 --no-hdpi-framebuffer
+```
+
+`--imgui-content-scale=1.0` is the ImGui-style-side companion
+(`live_imgui_init` reads it and styles ImGui at 1x instead of querying
+GLFW's content-scale). Without these flags, `glReadPixels`-based
+capture quadruples on retina and the APNG balloons in size.
+
+**Linux is a no-op:** X11 doesn't apply scaling at the GLFW level;
+Wayland reports framebuffer == window for normal windows. The flag is
+harmless to pass everywhere.
+
+**Tutorial users running `daslang-live` directly pass neither flag and
+keep native HDPI** — this is recording-only.
+
+**Verified on Windows (PR #44):** `record_boost_basics` produces a
+640×320 / ~7.5 MB APNG matching the retina-mac reference within
+encoder noise. `GLFW_SCALE_TO_MONITOR = 0` correctly engages.
+
+**Inverse plumbing — keep HDPI by default:** see
+`how-do-i-make-dasimgui-hdpi-aware-what-s-the-canonical-scale-plumbing`
+(PR #42). dasImgui's `live_imgui_init` reads
+`glfwGetWindowContentScale` and scales fonts + style automatically.
+`--no-hdpi-framebuffer` short-circuits this by reporting scale = 1.0
+even on retina.
+
+**Source:**
+- daslang PR #2704: `modules/dasGlfw/dasglfw/glfw_live.das`
+- dasImgui PR #44 helper invocation:
+  `widgets/imgui_playwright.das` `with_recording_app` argv build
+- ImGui-side `--imgui-content-scale=1.0` parser: `widgets/imgui_live.das`
+
+## Questions
+- How do I disable HDPI framebuffer scaling in daslang-live (for APNG recording at logical pixel count)?

--- a/mouse-data/docs/how-do-i-draw-on-the-imgui-foreground-or-window-drawlist-from-dasimgui-code.md
+++ b/mouse-data/docs/how-do-i-draw-on-the-imgui-foreground-or-window-drawlist-from-dasimgui-code.md
@@ -2,27 +2,50 @@
 slug: how-do-i-draw-on-the-imgui-foreground-or-window-drawlist-from-dasimgui-code
 title: How do I draw on the imgui foreground or window drawlist from dasImgui code?
 created: 2026-05-11
-last_verified: 2026-05-11
+last_verified: 2026-05-18
 links: []
 ---
 
-Use the pipe pattern, **without** wrapping the call in `unsafe { ... }`:
+Use the **drawlist rail** in `imgui/imgui_drawlist_builtin` (auto-required via `imgui/imgui_harness`). Raw `imgui::GetWindowDrawList` / `imgui::AddRect` / `AddRectFilled` / `AddLine` / `GetForegroundDrawList` are no longer on `ALLOWED_IMGUI` as of dasImgui PR #48 — `IMGUI002` flags them. Scaffolding-only escape: `options _allow_imgui_legacy = true`.
 
 ```das
-*GetForegroundDrawList() |> AddRect(p_min, p_max, color, rounding, ImDrawFlags.None, thickness)
-*GetWindowDrawList()      |> AddRectFilled(p_min, p_max, color)
-*GetWindowDrawList()      |> AddText(pos, color, text_str)
-*GetWindowDrawList()      |> AddCircleFilled(center, radius, color, num_segments)
-*GetWindowDrawList()      |> AddLine(p1, p2, color, thickness)
+require imgui/imgui_drawlist_builtin
+
+let green  = rgba(60u, 220u, 100u, 255u)
+let yellow = rgba(240u, 220u, 60u, 255u)
+
+with_window_drawlist() $(var dl) {
+    dl |> add_rect_filled(p_min, p_max, color, rounding, ImDrawFlags.None)
+    dl |> add_rect(p_min, p_max, color, rounding, ImDrawFlags.None, thickness)
+    dl |> add_line(p1, p2, color, thickness)
+    dl |> add_circle_filled(center, radius, color, num_segments)
+    dl |> add_circle(center, radius, color, num_segments, thickness)
+    dl |> add_triangle_filled(a, b, c, color)
+    dl |> add_triangle(a, b, c, color, thickness)
+    dl |> add_text(pos, color, "label")
+}
+
+// Viewport-level variants — paint over EVERY window / under EVERY window
+// respectively. Same primitives apply.
+with_foreground_drawlist() $(var fdl) {
+    fdl |> add_rect_filled(p_min, p_max, color)
+}
+with_background_drawlist() $(var bdl) {
+    bdl |> add_rect_filled(p_min, p_max, tint)
+}
 ```
 
-`GetForegroundDrawList()` and `GetWindowDrawList()` return `ImDrawList?`; dereffing with `*` and piping into the bound `Add*` methods works directly. Many examples in `modules/dasImgui/example/imgui_demo.das` (e.g. lines 753, 953, 1674, 2689-2695).
+**Three scope wrappers**: `with_window_drawlist` (current window's drawlist — clipped to the window rect), `with_foreground_drawlist` (viewport-level overlay on top), `with_background_drawlist` (viewport-level underlay beneath all windows).
 
-No `unsafe { ... }` wrap needed. The bound `Add*` shims accept the deref'd lvalue directly — wrapping is redundant. (An earlier project note claimed the wrap silently no-ops; that was a misattribution, see `project_dasimgui_unsafe_drawlist_noop` — the unsafe form is functionally equivalent. `UnsafeFolding` replaces `ExprUnsafe` with its body before simulate runs, so both forms generate the same SimNodes.)
+**Eight primitives** so far: `add_text`, `add_line`, `add_rect`, `add_rect_filled`, `add_circle`, `add_circle_filled`, `add_triangle`, `add_triangle_filled`. Each is tagged `[drawlist_prim(kind="add_X")]` in `widgets/imgui_drawlist_builtin.das`. The macro emits a `<mod>:<line>:<col>` path-key per call site (mouse-cards / playwright targeting) WITHOUT registering a `__widget_<line>_<col>` state-global — drawlist is render-only. Multiple `add_line` per frame don't collide because nothing's stored. See `dasimgui-drawlist-prim-macro-path-key-only-no-state-global-render-only-rail`.
 
-Coordinate space: ImGui drawlist coords are screen-space pixels. For widget-relative drawing you typically use `GetItemRectMin/Max` or values out of dasImgui's per-frame registry (`widget_rect(target_path)` in `imgui/imgui_boost_runtime`).
+**Container nesting is lexical, not visual.** Calling `with_window_drawlist` INSIDE `window(DRAW_WIN, ...) { … }` nests its primitives under `DRAW_WIN/`. Calling `with_foreground_drawlist` OUTSIDE that block produces top-level paths even though the foreground drawlist is viewport-scoped. The split is by lexical container scope at the call site, not by which drawlist gets painted.
 
-Verified: `widgets/imgui_visual_aids.das` paints all three primitives (highlight rect, mouse trail dots, narrate box + connector line) via this pattern without any `unsafe` wrapping.
+Coordinate space: ImGui drawlist coords are screen-space pixels. For widget-relative drawing inside `with_window_drawlist`, use `GetCursorScreenPos()` at the band start as the origin, or pull rects from dasImgui's per-frame registry (`widget_rect(target_path)` in `imgui/imgui_boost_runtime`).
+
+Reference feature + tests: `examples/features/drawlist.das`, `tests/integration/test_drawlist_primitives.das`, `test_with_window_drawlist.das`, `test_drawlist_path_key.das`. Tutorial: `doc/source/tutorials/drawlist.rst` + recording `examples/tutorial/drawlist.das`.
+
+**Historical note** (pre-PR-#48): the rail-less idiom was `*GetWindowDrawList() |> AddRect(...)` — dereffing the `ImDrawList?` return then piping into the bound method. No `unsafe { ... }` wrap was needed. That form still compiles where the legacy escape is on (`options _allow_imgui_legacy = true`), but the rail is the documented surface and gets the path-key telemetry "for free".
 
 ## Questions
 - How do I draw on the imgui foreground or window drawlist from dasImgui code?

--- a/mouse-data/docs/how-do-i-make-with-recording-app-attach-to-an-already-running-daslang-live.md
+++ b/mouse-data/docs/how-do-i-make-with-recording-app-attach-to-an-already-running-daslang-live.md
@@ -1,0 +1,88 @@
+---
+slug: how-do-i-make-with-recording-app-attach-to-an-already-running-daslang-live
+title: How do I make a recording driver attach to an already-running daslang-live host instead of spawning a new one?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+Verified 2026-05-17 (dasImgui PR #44, master post-merge).
+
+`with_recording_app` (in `widgets/imgui_playwright.das`) probes
+`GET /status` at the live-API port before spawning. If a host is
+already serving, it skips both the `popen_argv` spawn AND the
+`/shutdown` signal at the end — runs `record_start` / body /
+`record_stop` directly against the running host.
+
+**Use case:** dev keeps `daslang-live` open while iterating on a
+tutorial (live-reload edits visible immediately), then triggers the
+recorder without restarting the host. Before PR #44, spawning would
+collide on port 9090, recorder panicked, and you had to kill the
+host first.
+
+**The probe pattern (lines ~656-672 of imgui_playwright.das after PR #44):**
+
+```daslang
+let ATTACH_PROBE_SEC : float = 0.3f   // module-level tunable
+
+// ... feature_path / output_apng_path / app setup ...
+
+if (wait_until_ready(app, ATTACH_PROBE_SEC)) {
+    print("[record] attaching to existing daslang-live at {base_url}\n")
+    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
+    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
+    post_command(app, "record_start", JV((file = output_apng_path,
+                                          fps = fps,
+                                          max_seconds = max_seconds)))
+    invoke(body, app)
+    let stopped = post_command(app, "record_stop", null)
+    // ... cleanup mouse_trail + cursor_sprite ...
+    return    // DO NOT post /shutdown
+}
+
+// ... fall through to existing spawn flow ...
+```
+
+`wait_until_ready(app, 0.3f)` = three `/status` polls at the existing
+100 ms cadence. Instant when something's listening; fast TCP-refused
+when not. 0.3 s feels imperceptible to the user but is enough to
+detect any healthy host.
+
+**Contract differences spawn-vs-attach:**
+
+| Aspect | Spawn | Attach |
+|---|---|---|
+| Process lifecycle | helper owns | caller owns |
+| `/shutdown` at end | yes | NO — host kept alive |
+| Test-timeout watchdog | `popen_argv(test_timeout)` | none (body must self-terminate) |
+| HDPI/style | logical 1x (`--imgui-content-scale=1.0` + `--no-hdpi-framebuffer`) | host's current setting |
+| Feature loaded | helper passes `feature_path` to spawned host | caller owns whatever's loaded |
+
+**Caller responsibility in attach mode:** the helper does NOT post a
+switch-feature command. If the running host has a different feature
+loaded than what the driver expects, the body's
+`wait_for_render(app, T_WIDGET, 10.0f)` will time out and panic with
+the standard `"{T_WIDGET} never rendered — wrong app running?"`
+message. That's the existing fail-loud path.
+
+**Reproducing for the dev workflow:**
+
+```
+# Shell 1 — start the host
+daslang-live -project_root <dasimgui> <dasimgui>/examples/tutorial/boost_basics.das
+
+# Shell 2 — record (the driver scans 127.0.0.1:9090, sees the host, attaches)
+daslang -project_root <dasimgui> <dasimgui>/tests/integration/record_boost_basics.das
+# [record] attaching to existing daslang-live at http://127.0.0.1:9090
+# ... APNG written, host stays alive ...
+```
+
+**Gotcha:** attached recordings stay at native HDPI on retina/scaled
+Windows. The logical-1x mode is spawn-only because that's where
+`--imgui-content-scale=1.0` + `--no-hdpi-framebuffer` are passed. For
+canonical APNG regen (consistent dimensions across machines), use the
+no-host-running invocation so the helper spawns at logical 1x. See
+`how-do-i-disable-hdpi-framebuffer-scaling-in-daslang-live-for-recording`.
+
+## Questions
+- How do I make a recording driver attach to an already-running daslang-live host instead of spawning a new one?

--- a/mouse-data/docs/how-do-i-read-a-pre-dash-dash-daslang-exe-flag-from-inside-a-script.md
+++ b/mouse-data/docs/how-do-i-read-a-pre-dash-dash-daslang-exe-flag-from-inside-a-script.md
@@ -1,0 +1,67 @@
+---
+slug: how-do-i-read-a-pre-dash-dash-daslang-exe-flag-from-inside-a-script
+title: How do I read a pre-`--` daslang.exe flag (like `-project_root`) from inside a running script?
+created: 2026-05-17
+last_verified: 2026-05-17
+links: []
+---
+
+Verified 2026-05-17 (dasImgui PR #44).
+
+`get_command_line_arguments()` (daslang builtin) returns the **full
+original argv**. `get_user_args()` (in `daslib/clargs`) is mode-aware
+and in interpreted mode returns ONLY the slice after `--`. So if you
+want to read a `daslang.exe` flag like `-project_root` from inside a
+script, **use `get_command_line_arguments()`, not `get_user_args()`**.
+
+**Why:** `setCommandLineArguments(argc, argv)` is called at
+`utils/daScript/main.cpp:140` (and `:509` for the alternate code path)
+**before** any flag parsing. It freezes the full argv into a daslang-
+visible array. So `daslang.exe -project_root D:/foo myscript.das`
+produces a `get_command_line_arguments()` of
+`["daslang.exe", "-project_root", "D:/foo", "myscript.das"]` —
+`-project_root` is visible.
+
+`get_user_args()` (`daslib/clargs.das:74`) wraps this with mode logic:
+- Standalone exe: `argv[1..]` (skips program name)
+- **Interpreter mode: post-`--` slice only** — `-project_root` is invisible
+
+**Scan with `find_flag_raw_value`:**
+
+```daslang
+require daslib/clargs
+
+let argv_all <- get_command_line_arguments()
+let pr = find_flag_raw_value(argv_all, "-project_root") |> unwrap_or("")
+if (!empty(pr)) {
+    // … use the project root, e.g. forward to a spawned daslang-live
+}
+```
+
+`find_flag_raw_value` handles both `-flag value` and `-flag=value`
+forms. Same import (`daslib/clargs`) as `get_user_args()`.
+
+**Bug pattern this fixes:** dasImgui's `with_recording_app` initially
+scanned `get_user_args()` for `-project_root`. The documented
+single-flag invocation
+
+```
+daslang.exe -project_root <dasimgui> tests/integration/record_X.das
+```
+
+silently dropped the flag at forward time, and the spawned
+daslang-live died on `require imgui` with
+`error[20605]: missing prerequisite 'imgui'`. Workaround was passing
+`-project_root` **twice** (pre- AND post-`--`). The fix swaps the
+scanner to `get_command_line_arguments()`; the flag is visible
+regardless of position.
+
+**Companion card:** `daslang-script-flags-need-dash-dash-separator`
+covers the inverse — when YOU want to pass a flag to the script and
+it doesn't show in `get_user_args()`, the fix is to use `--` before
+your flag. The two together: pre-`--` flags belong to daslang.exe and
+need `get_command_line_arguments()`; post-`--` flags belong to your
+script and show up in `get_user_args()`.
+
+## Questions
+- How do I read a pre-`--` daslang.exe flag (like `-project_root`) from inside a running script?

--- a/mouse-data/docs/my-daspkg-package-s-register-native-path-module-isn-t-found-what-s-the-require-path-supposed-to-look-like.md
+++ b/mouse-data/docs/my-daspkg-package-s-register-native-path-module-isn-t-found-what-s-the-require-path-supposed-to-look-like.md
@@ -2,7 +2,7 @@
 slug: my-daspkg-package-s-register-native-path-module-isn-t-found-what-s-the-require-path-supposed-to-look-like
 title: My daspkg package's register_native_path module isn't found — what's the require path supposed to look like?
 created: 2026-05-09
-last_verified: 2026-05-09
+last_verified: 2026-05-18
 links: []
 ---
 
@@ -52,11 +52,9 @@ require imgui_boost_v2                     // ✗
 - `daslang -dasroot <root>` similarly walks via `require_dynamic_modules`
 - daspkg install during build
 
-**The MCP daslang server** does NOT pre-load `.das_module` files, so `mcp__daslang__compile_check` on a file that requires dynamic modules will fail with "missing prerequisite" — that's expected. End-to-end testing uses daslang-live, not MCP compile_check.
+**The MCP daslang server** supports daspkg-style modules via the `project_root` argument (added 2026-05-18; commit 26e1407c1). Every MCP tool that already takes `project` also accepts `project_root`, equivalent to daslang's `-project_root <dir>` CLI flag. For external dev work without `daspkg install`, point `project_root` at a dummy root with a `modules/<pkg>` junction — see [external_module_debugging.md](../../skills/external_module_debugging.md) for the workflow. Before that change, MCP couldn't resolve dynamic modules and end-to-end testing fell back to daslang-live or shell.
 
-**Surfaced 2026-05-09** during dasImgui Phase 0a; spent ~30 minutes wondering why `require imgui_boost_v2` couldn't find the just-registered module. Adding the `imgui/` prefix fixed it instantly.
-
-last_verified: 2026-05-09
+**Surfaced 2026-05-09** during dasImgui Phase 0a; spent ~30 minutes wondering why `require imgui_boost_v2` couldn't find the just-registered module. Adding the `imgui/` prefix fixed it instantly. Updated 2026-05-18 with MCP `project_root` support.
 
 ## Questions
 - My daspkg package's register_native_path module isn't found — what's the require path supposed to look like?

--- a/mouse-data/docs/wsl-ubuntu-repro-dasimgui-docs-ci-build-job-step-by-step.md
+++ b/mouse-data/docs/wsl-ubuntu-repro-dasimgui-docs-ci-build-job-step-by-step.md
@@ -1,0 +1,52 @@
+---
+slug: wsl-ubuntu-repro-dasimgui-docs-ci-build-job-step-by-step
+title: How do I reproduce the dasImgui docs CI build job locally in WSL Ubuntu without sudo?
+created: 2026-05-18
+last_verified: 2026-05-18
+links: []
+---
+
+Mirror the GitHub Actions `ubuntu-latest` docs job step-for-step inside WSL Ubuntu 24.04. Useful when sphinx-build fails in CI but local Windows builds pass — and you suspect Linux-specific behavior.
+
+```bash
+# 1. Setup (one-time). Bypass sudo password — WSL `-u root` has no password.
+wsl.exe -d Ubuntu-24.04 -u root -- apt-get install -y python3-pip python3-venv build-essential libcurl4-openssl-dev libssl-dev clang flex bison libglu1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev mesa-common-dev libwayland-dev libxkbcommon-dev
+
+# 2. Sphinx in a venv (system Python is PEP-668 externally-managed).
+wsl.exe -d Ubuntu-24.04 -- bash -c "python3 -m venv ~/sphinx-venv && ~/sphinx-venv/bin/pip install --quiet sphinx==7.2.6 sphinx-rtd-theme==2.0.0"
+
+# 3. Clone daslang master + the dasImgui PR branch as siblings.
+wsl.exe -d Ubuntu-24.04 -- bash -c "
+  mkdir -p ~/ci-repro && cd ~/ci-repro
+  git clone --depth=1 -b master https://github.com/GaijinEntertainment/daScript daslang-src
+  git clone --depth=1 -b <pr-branch> https://github.com/borisbat/dasImgui dasImgui
+"
+
+# 4. Build daslang.
+wsl.exe -d Ubuntu-24.04 -- bash -c "
+  cd ~/ci-repro/daslang-src
+  cmake --no-warn-unused-cli -B./build -DCMAKE_BUILD_TYPE:STRING=Release -DDAS_HV_DISABLED=OFF -DDAS_PUGIXML_DISABLED=OFF -DDAS_LLVM_DISABLED=ON -DDAS_GLFW_DISABLED=OFF -G Ninja
+  cmake --build ./build --parallel --target daslang
+"
+
+# 5. daspkg install dasImgui globally (CI step: 'daspkg install --global').
+wsl.exe -d Ubuntu-24.04 -- bash -c "
+  ~/ci-repro/daslang-src/bin/daslang ~/ci-repro/daslang-src/utils/daspkg/main.das -- install ~/ci-repro/dasImgui --global
+"
+
+# 6. Run imgui2rst then sphinx-build, as CI does.
+wsl.exe -d Ubuntu-24.04 -- bash -c "
+  cd ~/ci-repro/daslang-src/modules/dasImgui
+  ~/ci-repro/daslang-src/bin/daslang utils/imgui2rst.das -- --detail_output doc/source/stdlib/generated
+  ~/sphinx-venv/bin/sphinx-build -W --keep-going -b html -d build/sphinx-cache doc/source build/site
+"
+```
+
+**Caveat — PR merge ref**: this repro builds the BRANCH HEAD, not the merge ref. If CI's failure is caused by collisions with master changes that landed since you forked (e.g., duplicate RST anchors auto-merged into one file), this repro will silently miss it. Add a `cd ~/ci-repro/dasImgui && git fetch origin master && git merge origin/master` step before running imgui2rst when you suspect a merge-ref bug. See `github-actions-pr-merge-ref-sphinx-duplicate-target-local-passes-ci-fails`.
+
+**Cost**: first run ~15 min (daslang Release build). Subsequent runs just iterate steps 5-6 (~30s for imgui2rst + sphinx).
+
+Verified 2026-05-18 against daslang ced9f5175 + dasImgui PR #48; WSL reproduced CI's pipeline cleanly (modulo the merge-ref caveat above).
+
+## Questions
+- How do I reproduce the dasImgui docs CI build job locally in WSL Ubuntu without sudo?


### PR DESCRIPTION
## Summary

Blind-mouse Q&A cards from dasImgui imgui_demo port work (PRs #47 / #48) and the MCP project_root refactor (PR #2718). 14 new cards + 2 existing-card updates.

### MCP project_root (new this session)

- `daslang-live-cwd-flag-chdir-before-require-dynamic-modules-relative-paths-break` — real bug surfaced during testing: daslang-live's `-cwd` flag chdir's BEFORE `require_dynamic_modules`, so relative `-project_root` paths re-resolve against the new cwd and fail. Fix: `resolve_path()` in `do_live_launch`.
- `daslang-live-no-port-flag-single-instance-lock-e2e-spawn-tests-infeasible` — architectural finding: daslang-live has no `-port` flag (port hardcoded to 9090) and `acquire_single_instance` blocks parallel spawns, so reliable in-suite e2e spawn testing isn't viable without an upstream daslang-live change.
- `daslang-deduce-project-root-auto-fallback-from-script-dir-affects-test-design` — `daslang.exe` auto-deduces `-project_root` from `files.front()`'s directory when not explicitly passed, which affects how MCP test fixtures must be structured (subprocess subtools use subtool.das as files.front(), but `do_run_script` passes the user file directly).
- `my-daspkg-package-s-register-native-path-module...` (updated) — MCP `project_root` now supported as of 2026-05-18 (commit 26e1407c1); replaces the stale "MCP can't resolve dynamic modules" paragraph.

### dasImgui drawlist + widgets (PR #47 / #48)

- `dasimgui-drawlist-prim-macro-path-key-only-no-state-global-render-only-rail`
- `dasimgui-hover-target-widget-variant-pattern-color-button-hover-selectable-hover` (moved from D:/DASPKG/dasImgui/docs/)
- `dasimgui-imguisizeconstraints-lambda-needs-module-scope-lifetime-not-stack-local`
- `dasimgui-integration-tests-use-examples-features-recordings-use-examples-tutorial` (moved from D:/DASPKG/dasImgui/docs/)
- `how-do-i-draw-on-the-imgui-foreground-or-window-drawlist-from-dasimgui-code` (updated: now uses the `with_window_drawlist` rail; raw `GetWindowDrawList` is IMGUI002 as of PR #48)

### dasImgui sphinx / CI

- `dasimgui-sphinx-w-cross-ref-add-labels-to-external-types-rst-when-wrappers-reference-new-imgui-types`
- `github-actions-pr-merge-ref-sphinx-duplicate-target-local-passes-ci-fails`
- `wsl-ubuntu-repro-dasimgui-docs-ci-build-job-step-by-step`

### daslang-live recording infra

- `how-do-i-disable-hdpi-framebuffer-scaling-in-daslang-live-for-recording`
- `how-do-i-make-with-recording-app-attach-to-an-already-running-daslang-live`

### Daslang / daspkg misc

- `how-do-i-read-a-pre-dash-dash-daslang-exe-flag-from-inside-a-script`
- `daspkg-standalone-marker-skips-in-tree-daslang-cmake-include-for-installed-modules`

## Test plan

- [ ] Cards searchable via `mouse__ask` after next BM25 rebuild
- [ ] CI passes (md-only change, no-op for build/test gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
