### PR TITLE
das_hash_map: insert-only variants + Module field switch + hash bench suite

### DIFF
--- a/examples/hash/CMakeLists.txt
+++ b/examples/hash/CMakeLists.txt
@@ -57,8 +57,8 @@ target_link_libraries(example_hash_func_bench PRIVATE
     absl::strings)
 
 # Insert-only isolation bench: find x10, daslang_hash_{map,set} vs
-# daslang_insert_only_hash_{map,set}. Does NOT need Abseil — pure das.
-# Build just this: `--target example_hash_insert_only_bench`.
+# daslang_insert_only_hash_{map,set}. Build just this:
+# `--target example_hash_insert_only_bench`.
 add_executable(example_hash_insert_only_bench bench_hash_insert_only.cpp)
 target_include_directories(example_hash_insert_only_bench PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include)

--- a/examples/hash/CMakeLists.txt
+++ b/examples/hash/CMakeLists.txt
@@ -1,0 +1,81 @@
+cmake_minimum_required(VERSION 3.16)
+project(example_hash_bench CXX)
+
+# Standalone bench — compares three hash table implementations on typical
+# daslang key shapes:
+#   * std::unordered_map / unordered_set      (chained baseline)
+#   * das::daslang_hash_map / daslang_hash_set (in-tree, open addressing)
+#   * absl::flat_hash_map / flat_hash_set     (Abseil SwissTable reference)
+#
+# Build:  cmake -S examples/hash -B build/example_hash_bench -DCMAKE_BUILD_TYPE=Release
+#         cmake --build build/example_hash_bench -j
+# Run:    ./build/example_hash_bench/example_hash_bench
+#
+# First configure clones Abseil (~2-3 min, cached in _deps/ afterwards).
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+endif()
+
+# --- Abseil (flat_hash_map / flat_hash_set baseline) ---------------------
+include(FetchContent)
+set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)
+set(ABSL_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    absl
+    GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
+    GIT_TAG        20240722.0
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(absl)
+
+# --- bench executables ---------------------------------------------------
+# Main bench: insert / churn / find x10 across {std, das, absl} x 5 key types.
+add_executable(example_hash_bench bench_hash_map.cpp)
+target_include_directories(example_hash_bench PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+target_link_libraries(example_hash_bench PRIVATE
+    absl::flat_hash_map
+    absl::flat_hash_set
+    absl::hash
+    absl::strings)
+
+# Hash-function isolation bench: find x10 only, on the 2x2 cross of
+# {das_hash_map, absl::flat_hash_map} x {daslang_hash, absl::Hash}.
+# Runs independently — `--target example_hash_func_bench` builds just this.
+add_executable(example_hash_func_bench bench_hash_func.cpp)
+target_include_directories(example_hash_func_bench PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+target_link_libraries(example_hash_func_bench PRIVATE
+    absl::flat_hash_map
+    absl::hash
+    absl::strings)
+
+# Insert-only isolation bench: find x10, daslang_hash_{map,set} vs
+# daslang_insert_only_hash_{map,set}. Does NOT need Abseil — pure das.
+# Build just this: `--target example_hash_insert_only_bench`.
+add_executable(example_hash_insert_only_bench bench_hash_insert_only.cpp)
+target_include_directories(example_hash_insert_only_bench PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+
+if(MSVC)
+    target_compile_options(example_hash_bench             PRIVATE /O2 /W4)
+    target_compile_options(example_hash_func_bench        PRIVATE /O2 /W4)
+    target_compile_options(example_hash_insert_only_bench PRIVATE /O2 /W4)
+    # absl pulls in <Windows.h> indirectly via some platform headers; tame it
+    target_compile_definitions(example_hash_bench             PRIVATE
+        NOMINMAX WIN32_LEAN_AND_MEAN _CRT_SECURE_NO_WARNINGS)
+    target_compile_definitions(example_hash_func_bench        PRIVATE
+        NOMINMAX WIN32_LEAN_AND_MEAN _CRT_SECURE_NO_WARNINGS)
+    target_compile_definitions(example_hash_insert_only_bench PRIVATE
+        NOMINMAX WIN32_LEAN_AND_MEAN _CRT_SECURE_NO_WARNINGS)
+else()
+    target_compile_options(example_hash_bench             PRIVATE -O3 -Wall -Wextra)
+    target_compile_options(example_hash_func_bench        PRIVATE -O3 -Wall -Wextra)
+    target_compile_options(example_hash_insert_only_bench PRIVATE -O3 -Wall -Wextra)
+endif()

--- a/examples/hash/bench_hash_func.cpp
+++ b/examples/hash/bench_hash_func.cpp
@@ -1,0 +1,224 @@
+// Find x10 only — isolates "hash function" from "table mechanics" by running
+// every cell on the 2x2 cross of:
+//   tables: das::daslang_hash_map, absl::flat_hash_map
+//   hashes: das::daslang_hash<K>,  absl::Hash<K>
+//
+// Read columns down for hash effect on same table; read rows across for
+// table effect with same hash.
+//
+// Build:  cmake --build build/example_hash_bench --config Release --target example_hash_func_bench
+// Run:    build/example_hash_bench/Release/example_hash_func_bench.exe
+//
+// Standalone — does not need example_hash_bench to be built.
+
+#include <daScript/das_config.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/hash/hash.h>
+#include <absl/strings/string_view.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string>
+#include <unordered_set>     // corpus uniqueness only
+#include <utility>
+#include <vector>
+
+namespace das { void das_throw(const char * msg); }
+void das::das_throw(const char * msg) {
+    std::fprintf(stderr, "%s\n", msg); std::abort();
+}
+
+namespace {
+
+constexpr uint32_t SEED      = 0xC0FFEEu;
+constexpr size_t   SIZES[]   = { 1000, 10000, 100000 };
+constexpr size_t   MAX_N     = 100000;
+constexpr int      FIND_MULT = 10;
+
+volatile size_t g_sink = 0;
+
+int pick_iters_find (size_t n) {
+    if (n <= 1000)  return 500;
+    if (n <= 10000) return 50;
+    return 5;
+}
+
+// ===== const char* helpers =====
+// For absl on const char*, wrap absl::Hash<string_view> to hash CONTENT
+// (absl::Hash<const char*> would hash the pointer — useless here). Equality
+// likewise needs strcmp not pointer compare.
+struct CStrEq {
+    bool operator () (const char * a, const char * b) const noexcept { return std::strcmp(a, b) == 0; }
+};
+struct AbslCStrContentHash {
+    size_t operator () (const char * s) const noexcept {
+        return absl::Hash<absl::string_view>{}(absl::string_view(s));
+    }
+};
+
+// ===== Hash traits per K =====
+template <typename K>
+struct HashTraits {
+    using DasH  = das::daslang_hash<K>;
+    using AbslH = absl::Hash<K>;
+    using Eq    = std::equal_to<K>;
+};
+template <>
+struct HashTraits<const char*> {
+    using DasH  = das::daslang_hash<const char*>;     // FNV-64 on bytes
+    using AbslH = AbslCStrContentHash;                // absl Hash on bytes
+    using Eq    = CStrEq;
+};
+
+// ===== Corpora (same identifier-like generator as the main bench) =====
+struct StringCorpus {
+    std::vector<std::string> strs;
+    std::vector<const char*> cstrs;
+    std::vector<uint64_t>    hashes;
+};
+StringCorpus make_string_corpus (size_t n, uint32_t seed) {
+    static const char alpha[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+    constexpr int ALPHA_N = sizeof(alpha) - 1;
+    std::mt19937 rng(seed);
+    std::normal_distribution<float> len_dist(10.0f, 4.0f);
+    StringCorpus c;
+    c.strs.reserve(n); c.cstrs.reserve(n); c.hashes.reserve(n);
+    std::unordered_set<std::string> seen; seen.reserve(n);
+    while (c.strs.size() < n) {
+        int len = int(len_dist(rng));
+        if (len < 4)  len = 4;
+        if (len > 20) len = 20;
+        std::string s; s.resize(size_t(len));
+        for (int i = 0; i < len; ++i) s[i] = alpha[rng() % ALPHA_N];
+        if (seen.insert(s).second) c.strs.push_back(std::move(s));
+    }
+    das::daslang_hash<das::string> h{};
+    for (const auto & s : c.strs) {
+        c.cstrs.push_back(s.c_str());
+        c.hashes.push_back(uint64_t(h(s)));
+    }
+    return c;
+}
+
+struct PtrPool {
+    std::vector<void*> ptrs;
+    size_t block_size = 0;
+    PtrPool () = default;
+    ~PtrPool () { for (auto p : ptrs) std::free(p); }
+    PtrPool (const PtrPool &) = delete;
+    PtrPool & operator = (const PtrPool &) = delete;
+    PtrPool (PtrPool && o) noexcept : ptrs(std::move(o.ptrs)), block_size(o.block_size) {}
+};
+PtrPool make_ptr_pool (size_t n, size_t block_size) {
+    PtrPool p; p.block_size = block_size; p.ptrs.reserve(n);
+    for (size_t i = 0; i < n; ++i) p.ptrs.push_back(std::malloc(block_size));
+    return p;
+}
+
+template <typename K>
+std::vector<K> make_find_queries (const std::vector<K> & keys, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::vector<K> q; q.reserve(keys.size() * size_t(FIND_MULT));
+    std::uniform_int_distribution<size_t> pick(0, keys.size() - 1);
+    for (size_t i = 0; i < keys.size() * size_t(FIND_MULT); ++i) q.push_back(keys[pick(rng)]);
+    return q;
+}
+
+// ===== Generic find bench =====
+template <template <class,class,class,class> class TableT, typename K, typename Hash, typename Eq>
+double bench_find (const std::vector<K> & keys, const std::vector<K> & queries, int iters,
+                   const char * label) {
+    TableT<K, void*, Hash, Eq> m;
+    for (const auto & k : keys) m.emplace(k, (void*)nullptr);
+    if (m.size() != keys.size()) {
+        std::fprintf(stderr, "FAIL [%s pre-build]: size %zu != %zu\n", label, m.size(), keys.size());
+        std::abort();
+    }
+    {
+        size_t hits = 0;
+        for (const auto & q : queries) hits += (m.find(q) != m.end()) ? 1 : 0;
+        if (hits != queries.size()) {
+            std::fprintf(stderr, "FAIL [%s verify]: hits %zu != %zu\n", label, hits, queries.size());
+            std::abort();
+        }
+    }
+    using clk = std::chrono::steady_clock;
+    auto t0 = clk::now();
+    size_t hits = 0;
+    for (int i = 0; i < iters; ++i)
+        for (const auto & q : queries) hits += (m.find(q) != m.end()) ? 1 : 0;
+    auto t1 = clk::now();
+    g_sink ^= hits;
+    return double(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()) / iters;
+}
+
+template <typename K>
+void run_table (const char * title, const std::vector<K> & full_keys) {
+    using H = HashTraits<K>;
+    std::printf("\n## %s\n\n", title);
+    std::printf("| N      | hash    |   das table (ns) |  absl table (ns) | das/absl |\n");
+    std::printf("|--------|---------|-----------------:|-----------------:|---------:|\n");
+    for (size_t n : SIZES) {
+        if (n > full_keys.size()) continue;
+        std::vector<K> keys(full_keys.begin(), full_keys.begin() + n);
+        const int it = pick_iters_find(n);
+        auto queries = make_find_queries(keys, SEED + uint32_t(n));
+
+        double d_dh = bench_find<das::daslang_hash_map, K, typename H::DasH,  typename H::Eq>(keys, queries, it, "das/das");
+        double a_dh = bench_find<absl::flat_hash_map,   K, typename H::DasH,  typename H::Eq>(keys, queries, it, "absl/das");
+        double d_ah = bench_find<das::daslang_hash_map, K, typename H::AbslH, typename H::Eq>(keys, queries, it, "das/absl");
+        double a_ah = bench_find<absl::flat_hash_map,   K, typename H::AbslH, typename H::Eq>(keys, queries, it, "absl/absl");
+
+        std::printf("| %-6zu | daslang | %16.0f | %16.0f | %8.2f |\n", n, d_dh, a_dh, d_dh / a_dh);
+        std::printf("| %-6zu | absl    | %16.0f | %16.0f | %8.2f |\n", n, d_ah, a_ah, d_ah / a_ah);
+    }
+    std::fflush(stdout);
+}
+
+} // anonymous
+
+int main () {
+    std::printf("# Hash function vs table mechanics — find x10 isolation\n\n");
+    std::printf("C++ stdlib: ");
+#if defined(_LIBCPP_VERSION)
+    std::printf("libc++ %d\n", _LIBCPP_VERSION);
+#elif defined(__GLIBCXX__)
+    std::printf("libstdc++ %d\n", __GLIBCXX__);
+#elif defined(_MSC_VER)
+    std::printf("MSVC stdlib (_MSC_VER=%d)\n", _MSC_VER);
+#else
+    std::printf("unknown\n");
+#endif
+    std::printf("Compiler: ");
+#if defined(__clang__)
+    std::printf("clang %d.%d.%d\n", __clang_major__, __clang_minor__, __clang_patchlevel__);
+#elif defined(__GNUC__)
+    std::printf("gcc %d.%d.%d\n", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+#elif defined(_MSC_VER)
+    std::printf("MSVC %d\n", _MSC_VER);
+#else
+    std::printf("unknown\n");
+#endif
+    std::printf("\nEach cell: pre-build table with N keys, then time 10*N find calls (all hits).\n");
+    std::printf("Per (key, N): two rows (daslang hash vs absl hash) x two cols (das table vs absl table).\n");
+    std::printf("\n  vertical comparison (within table column): HASH effect for that table.\n");
+    std::printf("  horizontal comparison (within hash row):    TABLE effect for that hash.\n");
+    std::printf("\nFor K=const char* both hashes hash CONTENT (absl wrapped to use string_view) so it's apples-to-apples.\n");
+
+    auto str_corpus   = make_string_corpus(MAX_N, SEED);
+    auto ptr_pool_32  = make_ptr_pool(MAX_N, 32);
+    auto ptr_pool_128 = make_ptr_pool(MAX_N, 128);
+
+    run_table<const char*>("Map<const char*, void*>",        str_corpus.cstrs);
+    run_table<std::string>("Map<std::string, void*>",        str_corpus.strs);
+    run_table<uint64_t>   ("Map<uint64_t, void*>",           str_corpus.hashes);
+    run_table<void*>      ("Map<void* (32B alloc), void*>",  ptr_pool_32.ptrs);
+    run_table<void*>      ("Map<void* (128B alloc), void*>", ptr_pool_128.ptrs);
+
+    std::printf("\n(checksum: 0x%zx)\n", size_t(g_sink));
+    return 0;
+}

--- a/examples/hash/bench_hash_insert_only.cpp
+++ b/examples/hash/bench_hash_insert_only.cpp
@@ -1,0 +1,273 @@
+// Find x10 only — compares daslang_hash_{map,set} vs daslang_insert_only_hash_{map,set}.
+//
+// Both use the same hash, same load factor, same layout (parallel hashes/keys/values
+// vectors). The insert-only variant drops erase + tombstone tracking. Since no erases
+// happen in the bench, the tables end up structurally identical — this measures the
+// inherent cost of carrying the erase machinery (one extra branch in reserve_slot, one
+// extra `<= HASH_KILLED` in iterator skip; find_index is identical between the two).
+// Likely outcome: small delta, dominated by noise. The bench answers "by how much?".
+//
+// Build:  cmake --build build/example_hash_bench --config Release --target example_hash_insert_only_bench
+// Run:    build/example_hash_bench/Release/example_hash_insert_only_bench.exe
+
+#include <daScript/das_config.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace das { void das_throw(const char * msg); }
+void das::das_throw(const char * msg) {
+    std::fprintf(stderr, "%s\n", msg); std::abort();
+}
+
+namespace {
+
+constexpr uint32_t SEED      = 0xC0FFEEu;
+constexpr size_t   SIZES[]   = { 1000, 10000, 100000 };
+constexpr size_t   MAX_N     = 100000;
+constexpr int      FIND_MULT = 10;
+
+volatile size_t g_sink = 0;
+
+int pick_iters_find (size_t n) {
+    if (n <= 1000)  return 500;
+    if (n <= 10000) return 50;
+    return 5;
+}
+
+struct CStrEq {
+    bool operator () (const char * a, const char * b) const noexcept { return std::strcmp(a, b) == 0; }
+};
+struct CStrHash {
+    size_t operator () (const char * s) const noexcept {
+        uint64_t h = 14695981039346656037ull;
+        for (; *s; ++s) { h ^= uint8_t(*s); h *= 1099511628211ull; }
+        return size_t(h);
+    }
+};
+
+// Map traits — pick (Regular, InsertOnly) per key type
+template <typename K>
+struct MapTraits {
+    using Reg = das::daslang_hash_map<K, void*>;
+    using IO  = das::daslang_insert_only_hash_map<K, void*>;
+};
+template <>
+struct MapTraits<const char*> {
+    using Reg = das::daslang_hash_map<const char*, void*, CStrHash, CStrEq>;
+    using IO  = das::daslang_insert_only_hash_map<const char*, void*, CStrHash, CStrEq>;
+};
+template <typename K>
+struct SetTraits {
+    using Reg = das::daslang_hash_set<K>;
+    using IO  = das::daslang_insert_only_hash_set<K>;
+};
+template <>
+struct SetTraits<const char*> {
+    using Reg = das::daslang_hash_set<const char*, CStrHash, CStrEq>;
+    using IO  = das::daslang_insert_only_hash_set<const char*, CStrHash, CStrEq>;
+};
+
+// ===== Corpora (same generator as the other benches) =====
+struct StringCorpus {
+    std::vector<std::string> strs;
+    std::vector<const char*> cstrs;
+    std::vector<uint64_t>    hashes;
+};
+StringCorpus make_string_corpus (size_t n, uint32_t seed) {
+    static const char alpha[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+    constexpr int ALPHA_N = sizeof(alpha) - 1;
+    std::mt19937 rng(seed);
+    std::normal_distribution<float> len_dist(10.0f, 4.0f);
+    StringCorpus c;
+    c.strs.reserve(n); c.cstrs.reserve(n); c.hashes.reserve(n);
+    std::unordered_set<std::string> seen; seen.reserve(n);
+    while (c.strs.size() < n) {
+        int len = int(len_dist(rng));
+        if (len < 4)  len = 4;
+        if (len > 20) len = 20;
+        std::string s; s.resize(size_t(len));
+        for (int i = 0; i < len; ++i) s[i] = alpha[rng() % ALPHA_N];
+        if (seen.insert(s).second) c.strs.push_back(std::move(s));
+    }
+    das::daslang_hash<das::string> h{};
+    for (const auto & s : c.strs) {
+        c.cstrs.push_back(s.c_str());
+        c.hashes.push_back(uint64_t(h(s)));
+    }
+    return c;
+}
+
+struct PtrPool {
+    std::vector<void*> ptrs;
+    size_t block_size = 0;
+    PtrPool () = default;
+    ~PtrPool () { for (auto p : ptrs) std::free(p); }
+    PtrPool (const PtrPool &) = delete;
+    PtrPool & operator = (const PtrPool &) = delete;
+    PtrPool (PtrPool && o) noexcept : ptrs(std::move(o.ptrs)), block_size(o.block_size) {}
+};
+PtrPool make_ptr_pool (size_t n, size_t block_size) {
+    PtrPool p; p.block_size = block_size; p.ptrs.reserve(n);
+    for (size_t i = 0; i < n; ++i) p.ptrs.push_back(std::malloc(block_size));
+    return p;
+}
+
+template <typename K>
+std::vector<K> make_find_queries (const std::vector<K> & keys, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::vector<K> q; q.reserve(keys.size() * size_t(FIND_MULT));
+    std::uniform_int_distribution<size_t> pick(0, keys.size() - 1);
+    for (size_t i = 0; i < keys.size() * size_t(FIND_MULT); ++i) q.push_back(keys[pick(rng)]);
+    return q;
+}
+
+// ===== Map find bench =====
+template <typename Map>
+double bench_find_map (const std::vector<typename Map::key_type> & keys,
+                       const std::vector<typename Map::key_type> & queries,
+                       int iters, const char * label) {
+    Map m;
+    for (const auto & k : keys) m.emplace(k, (void*)nullptr);
+    if (m.size() != keys.size()) {
+        std::fprintf(stderr, "FAIL [%s map pre-build]: size %zu != %zu\n", label, m.size(), keys.size());
+        std::abort();
+    }
+    {
+        size_t hits = 0;
+        for (const auto & q : queries) hits += (m.find(q) != m.end()) ? 1 : 0;
+        if (hits != queries.size()) {
+            std::fprintf(stderr, "FAIL [%s map verify]: hits %zu != %zu\n", label, hits, queries.size());
+            std::abort();
+        }
+    }
+    using clk = std::chrono::steady_clock;
+    auto t0 = clk::now();
+    size_t hits = 0;
+    for (int i = 0; i < iters; ++i)
+        for (const auto & q : queries) hits += (m.find(q) != m.end()) ? 1 : 0;
+    auto t1 = clk::now();
+    g_sink ^= hits;
+    return double(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()) / iters;
+}
+
+template <typename Set>
+double bench_find_set (const std::vector<typename Set::key_type> & keys,
+                       const std::vector<typename Set::key_type> & queries,
+                       int iters, const char * label) {
+    Set s;
+    for (const auto & k : keys) s.insert(k);
+    if (s.size() != keys.size()) {
+        std::fprintf(stderr, "FAIL [%s set pre-build]: size %zu != %zu\n", label, s.size(), keys.size());
+        std::abort();
+    }
+    {
+        size_t hits = 0;
+        for (const auto & q : queries) hits += (s.find(q) != s.end()) ? 1 : 0;
+        if (hits != queries.size()) {
+            std::fprintf(stderr, "FAIL [%s set verify]: hits %zu != %zu\n", label, hits, queries.size());
+            std::abort();
+        }
+    }
+    using clk = std::chrono::steady_clock;
+    auto t0 = clk::now();
+    size_t hits = 0;
+    for (int i = 0; i < iters; ++i)
+        for (const auto & q : queries) hits += (s.find(q) != s.end()) ? 1 : 0;
+    auto t1 = clk::now();
+    g_sink ^= hits;
+    return double(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()) / iters;
+}
+
+template <typename K>
+void run_map_rows (const char * title, const std::vector<K> & full_keys) {
+    using T = MapTraits<K>;
+    std::printf("\n## %s\n\n", title);
+    std::printf("| N      |   regular (ns) | insert-only (ns) |  IO/reg |\n");
+    std::printf("|--------|---------------:|-----------------:|--------:|\n");
+    for (size_t n : SIZES) {
+        if (n > full_keys.size()) continue;
+        std::vector<K> keys(full_keys.begin(), full_keys.begin() + n);
+        const int it = pick_iters_find(n);
+        auto queries = make_find_queries(keys, SEED + uint32_t(n));
+        double reg = bench_find_map<typename T::Reg>(keys, queries, it, "regular");
+        double io  = bench_find_map<typename T::IO> (keys, queries, it, "insert-only");
+        std::printf("| %-6zu | %14.0f | %16.0f | %7.3f |\n", n, reg, io, io / reg);
+    }
+    std::fflush(stdout);
+}
+
+template <typename K>
+void run_set_rows (const char * title, const std::vector<K> & full_keys) {
+    using T = SetTraits<K>;
+    std::printf("\n## %s\n\n", title);
+    std::printf("| N      |   regular (ns) | insert-only (ns) |  IO/reg |\n");
+    std::printf("|--------|---------------:|-----------------:|--------:|\n");
+    for (size_t n : SIZES) {
+        if (n > full_keys.size()) continue;
+        std::vector<K> keys(full_keys.begin(), full_keys.begin() + n);
+        const int it = pick_iters_find(n);
+        auto queries = make_find_queries(keys, SEED + uint32_t(n));
+        double reg = bench_find_set<typename T::Reg>(keys, queries, it, "regular");
+        double io  = bench_find_set<typename T::IO> (keys, queries, it, "insert-only");
+        std::printf("| %-6zu | %14.0f | %16.0f | %7.3f |\n", n, reg, io, io / reg);
+    }
+    std::fflush(stdout);
+}
+
+} // anonymous
+
+int main () {
+    std::printf("# daslang_hash_* vs daslang_insert_only_hash_* — find x10\n\n");
+    std::printf("Stdlib: ");
+#if defined(_MSC_VER)
+    std::printf("MSVC stdlib (_MSC_VER=%d)\n", _MSC_VER);
+#elif defined(__GLIBCXX__)
+    std::printf("libstdc++ %d\n", __GLIBCXX__);
+#elif defined(_LIBCPP_VERSION)
+    std::printf("libc++ %d\n", _LIBCPP_VERSION);
+#else
+    std::printf("unknown\n");
+#endif
+    std::printf("Compiler: ");
+#if defined(_MSC_VER)
+    std::printf("MSVC %d\n", _MSC_VER);
+#elif defined(__clang__)
+    std::printf("clang %d.%d.%d\n", __clang_major__, __clang_minor__, __clang_patchlevel__);
+#elif defined(__GNUC__)
+    std::printf("gcc %d.%d.%d\n", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+#else
+    std::printf("unknown\n");
+#endif
+    std::printf("\nNo erases happen in this bench, so both variants build structurally identical tables.\n");
+    std::printf("Find_index code is identical between regular and insert-only — the only differences\n");
+    std::printf("are iterator skip cost (irrelevant for find) and reserve_slot branch count (irrelevant\n");
+    std::printf("for find after the table is built). IO/reg ratio at ~1.0 = no meaningful difference.\n");
+
+    auto str_corpus   = make_string_corpus(MAX_N, SEED);
+    auto ptr_pool_32  = make_ptr_pool(MAX_N, 32);
+    auto ptr_pool_128 = make_ptr_pool(MAX_N, 128);
+
+    run_map_rows<const char*>("Map<const char*, void*>",        str_corpus.cstrs);
+    run_map_rows<std::string>("Map<std::string, void*>",        str_corpus.strs);
+    run_map_rows<uint64_t>   ("Map<uint64_t, void*>",           str_corpus.hashes);
+    run_map_rows<void*>      ("Map<void* (32B alloc), void*>",  ptr_pool_32.ptrs);
+    run_map_rows<void*>      ("Map<void* (128B alloc), void*>", ptr_pool_128.ptrs);
+
+    run_set_rows<const char*>("Set<const char*>",        str_corpus.cstrs);
+    run_set_rows<std::string>("Set<std::string>",        str_corpus.strs);
+    run_set_rows<uint64_t>   ("Set<uint64_t>",           str_corpus.hashes);
+    run_set_rows<void*>      ("Set<void* (32B alloc)>",  ptr_pool_32.ptrs);
+    run_set_rows<void*>      ("Set<void* (128B alloc)>", ptr_pool_128.ptrs);
+
+    std::printf("\n(checksum: 0x%zx)\n", size_t(g_sink));
+    return 0;
+}

--- a/examples/hash/bench_hash_map.cpp
+++ b/examples/hash/bench_hash_map.cpp
@@ -1,0 +1,650 @@
+// Performance comparison: std::unordered_* vs das::daslang_hash_* vs
+// absl::flat_hash_* on the four key shapes daslang's AST/runtime tables
+// actually use (const char* / std::string / uint64_t hashes / void* allocs).
+//
+// Three workloads per (shape, key, size):
+//   insert  — build a fresh table of N keys from empty (no reserve)
+//   churn   — same as insert but interleaved with p=0.1 random erase
+//   find    — pre-build then time 10*N find calls (all hits)
+//
+// Build:  cmake -S examples/hash -B build/example_hash_bench -DCMAKE_BUILD_TYPE=Release
+//         cmake --build build/example_hash_bench -j
+// Run:    ./build/example_hash_bench/example_hash_bench
+//
+// Hashing-fairness note: for K=const char* all three impls are forced
+// to a content-hashing CStrHash so the per-op work is identical; only
+// table mechanics (probing / chaining / SwissTable groups) differ.
+// For K=std::string / uint64_t / void* each impl uses ITS own blessed
+// hash — that's a "full stack vs full stack" comparison.
+
+#include <daScript/das_config.h>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+// das_config.h declares but doesn't define das::das_throw; provide one
+// so daslang_hash_map::at()'s missing-key path resolves at link time.
+namespace das { void das_throw(const char * msg); }
+void das::das_throw(const char * msg) {
+    std::fprintf(stderr, "%s\n", msg);
+    std::abort();
+}
+
+namespace {
+
+constexpr uint32_t SEED = 0xC0FFEEu;
+constexpr size_t   SIZES[] = { 1000, 10000, 100000 };
+constexpr size_t   MAX_N   = 100000;
+constexpr int      FIND_MULT = 10;
+
+// DCE sink — every workload xors its result into here so the optimizer
+// can't elide the work.
+volatile size_t g_sink = 0;
+
+// ===== Probe instrumentation =====
+//
+// We wrap each impl's KeyEqual in CountingEq, which bumps two counters
+// for every call. To measure "collision factor" portably across three
+// very different impls (chained / linear / SwissTable), we count the
+// number of full key-equality calls per find — that's the real work
+// the table has to do AFTER its pre-screening (hash chain walk for std,
+// hash match for das, SIMD H2 match for absl). Per-find counters are
+// reset by start_find()/end_find() around each m.find() call site.
+size_t g_eq_calls       = 0;
+size_t g_eq_max_per_find = 0;
+size_t g_eq_cur         = 0;
+
+template <typename BaseEq>
+struct CountingEq {
+    BaseEq base{};
+    template <typename A, typename B>
+    bool operator () (const A & a, const B & b) const noexcept {
+        ++g_eq_calls;
+        ++g_eq_cur;
+        return base(a, b);
+    }
+};
+
+inline void start_find () noexcept { g_eq_cur = 0; }
+inline void end_find   () noexcept { if (g_eq_cur > g_eq_max_per_find) g_eq_max_per_find = g_eq_cur; }
+
+int pick_iters_build (size_t n) {
+    if (n <= 1000)  return 1000;
+    if (n <= 10000) return 100;
+    return 10;                            // n <= 100000
+}
+int pick_iters_find (size_t n) {
+    if (n <= 1000)  return 500;
+    if (n <= 10000) return 50;
+    return 5;                             // n <= 100000
+}
+
+// ===== Hashing-fair adapters for const char* =====
+//
+// FNV-64 byte hash — matches daslang_hash<const char*> exactly.
+struct CStrHash {
+    size_t operator () (const char * s) const noexcept {
+        uint64_t h = 14695981039346656037ull;
+        for (; *s; ++s) { h ^= uint8_t(*s); h *= 1099511628211ull; }
+        return size_t(h);
+    }
+};
+struct CStrEq {
+    bool operator () (const char * a, const char * b) const noexcept {
+        return std::strcmp(a, b) == 0;
+    }
+};
+
+// ===== Corpora =====
+struct StringCorpus {
+    std::vector<std::string> strs;     // owns bytes
+    std::vector<const char*> cstrs;    // .c_str() of each
+    std::vector<uint64_t>    hashes;   // FNV-64 of each
+};
+StringCorpus make_string_corpus (size_t n, uint32_t seed) {
+    static const char alpha[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+    constexpr int ALPHA_N = sizeof(alpha) - 1;
+    std::mt19937 rng(seed);
+    std::normal_distribution<float> len_dist(10.0f, 4.0f);
+    StringCorpus c;
+    c.strs.reserve(n); c.cstrs.reserve(n); c.hashes.reserve(n);
+    CStrHash hasher;
+    // Use a set to ensure uniqueness; retry on collision so we get exactly N.
+    std::unordered_set<std::string> seen;
+    seen.reserve(n);
+    while (c.strs.size() < n) {
+        int len = int(len_dist(rng));
+        if (len < 4) len = 4;
+        if (len > 20) len = 20;
+        std::string s;
+        s.resize(size_t(len));
+        for (int i = 0; i < len; ++i) s[i] = alpha[rng() % ALPHA_N];
+        if (seen.insert(s).second) c.strs.push_back(std::move(s));
+    }
+    // c_str() pointers must be captured AFTER all push_backs since
+    // strs may reallocate. Reserve above guarantees no reallocation past
+    // this point, but capture in a separate pass to keep the contract clear.
+    for (const auto & s : c.strs) {
+        c.cstrs.push_back(s.c_str());
+        c.hashes.push_back(uint64_t(hasher(s.c_str())));
+    }
+    return c;
+}
+
+struct PtrPool {
+    std::vector<void*> ptrs;
+    size_t block_size = 0;
+    PtrPool () = default;
+    ~PtrPool () { for (auto p : ptrs) std::free(p); }
+    PtrPool (const PtrPool &) = delete;
+    PtrPool & operator = (const PtrPool &) = delete;
+    PtrPool (PtrPool && o) noexcept : ptrs(std::move(o.ptrs)), block_size(o.block_size) {}
+};
+PtrPool make_ptr_pool (size_t n, size_t block_size) {
+    PtrPool p; p.block_size = block_size; p.ptrs.reserve(n);
+    for (size_t i = 0; i < n; ++i) p.ptrs.push_back(std::malloc(block_size));
+    return p;
+}
+
+// Query vectors (10*N samples from keys, with replacement). All hits.
+template <typename K>
+std::vector<K> make_find_queries (const std::vector<K> & keys, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::vector<K> q; q.reserve(keys.size() * size_t(FIND_MULT));
+    std::uniform_int_distribution<size_t> pick(0, keys.size() - 1);
+    for (size_t i = 0; i < keys.size() * size_t(FIND_MULT); ++i) {
+        q.push_back(keys[pick(rng)]);
+    }
+    return q;
+}
+
+// ===== Per-key container traits =====
+template <typename K>
+struct MapTypes {
+    using StdM  = std::unordered_map<K, void*>;
+    using DasM  = das::daslang_hash_map<K, void*>;
+    using AbslM = absl::flat_hash_map<K, void*>;
+};
+template <>
+struct MapTypes<const char*> {
+    using StdM  = std::unordered_map<const char*, void*, CStrHash, CStrEq>;
+    using DasM  = das::daslang_hash_map<const char*, void*, CStrHash, CStrEq>;
+    using AbslM = absl::flat_hash_map<const char*, void*, CStrHash, CStrEq>;
+};
+template <typename K>
+struct SetTypes {
+    using StdS  = std::unordered_set<K>;
+    using DasS  = das::daslang_hash_set<K>;
+    using AbslS = absl::flat_hash_set<K>;
+};
+template <>
+struct SetTypes<const char*> {
+    using StdS  = std::unordered_set<const char*, CStrHash, CStrEq>;
+    using DasS  = das::daslang_hash_set<const char*, CStrHash, CStrEq>;
+    using AbslS = absl::flat_hash_set<const char*, CStrHash, CStrEq>;
+};
+
+// ===== Counting variants — used ONLY for probe-stat measurement, not perf =====
+// Plug CountingEq<base> into the KeyEqual slot of each impl. Hash function and
+// other template params stay identical to the perf-path types above so the
+// internal layout is the same — only the eq call is instrumented.
+template <typename K>
+struct CountingMapTypes {
+    using StdM  = std::unordered_map<K, void*, std::hash<K>,         CountingEq<std::equal_to<K>>>;
+    using DasM  = das::daslang_hash_map<K, void*, das::daslang_hash<K>, CountingEq<std::equal_to<K>>>;
+    using AbslM = absl::flat_hash_map<K, void*, absl::Hash<K>,       CountingEq<std::equal_to<K>>>;
+};
+template <>
+struct CountingMapTypes<const char*> {
+    using StdM  = std::unordered_map<const char*, void*, CStrHash, CountingEq<CStrEq>>;
+    using DasM  = das::daslang_hash_map<const char*, void*, CStrHash, CountingEq<CStrEq>>;
+    using AbslM = absl::flat_hash_map<const char*, void*, CStrHash, CountingEq<CStrEq>>;
+};
+
+template <typename K>
+struct CountingSetTypes {
+    using StdS  = std::unordered_set<K, std::hash<K>,         CountingEq<std::equal_to<K>>>;
+    using DasS  = das::daslang_hash_set<K, das::daslang_hash<K>, CountingEq<std::equal_to<K>>>;
+    using AbslS = absl::flat_hash_set<K, absl::Hash<K>,       CountingEq<std::equal_to<K>>>;
+};
+template <>
+struct CountingSetTypes<const char*> {
+    using StdS  = std::unordered_set<const char*, CStrHash, CountingEq<CStrEq>>;
+    using DasS  = das::daslang_hash_set<const char*, CStrHash, CountingEq<CStrEq>>;
+    using AbslS = absl::flat_hash_set<const char*, CStrHash, CountingEq<CStrEq>>;
+};
+
+// ===== Workloads — map =====
+template <typename Map>
+double bench_insert_map (const std::vector<typename Map::key_type> & keys, int iters,
+                         const char * label) {
+    // Verify once.
+    {
+        Map check;
+        for (const auto & k : keys) check.emplace(k, (void*)nullptr);
+        if (check.size() != keys.size()) {
+            std::fprintf(stderr, "FAIL [%s insert map]: size %zu != expected %zu\n",
+                         label, check.size(), keys.size());
+            std::abort();
+        }
+    }
+    using clk = std::chrono::steady_clock;
+    auto t0 = clk::now();
+    size_t check_sum = 0;
+    for (int i = 0; i < iters; ++i) {
+        Map m;
+        for (const auto & k : keys) m.emplace(k, (void*)nullptr);
+        check_sum ^= m.size();
+    }
+    auto t1 = clk::now();
+    g_sink ^= check_sum;
+    return double(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()) / iters;
+}
+
+template <typename Map>
+double bench_churn_map (const std::vector<typename Map::key_type> & keys, int iters,
+                        const char * label) {
+    using K = typename Map::key_type;
+    // Verify once: count erases via same RNG path; compare against m.size().
+    {
+        std::mt19937 rng(SEED);
+        std::uniform_real_distribution<float> p01(0.0f, 1.0f);
+        Map check;
+        std::vector<K> live; live.reserve(keys.size());
+        for (const auto & k : keys) {
+            check.emplace(k, (void*)nullptr);
+            live.push_back(k);
+            if (p01(rng) < 0.1f && !live.empty()) {
+                size_t victim = std::uniform_int_distribution<size_t>(0, live.size() - 1)(rng);
+                check.erase(live[victim]);
+                live[victim] = live.back();
+                live.pop_back();
+            }
+        }
+        if (check.size() != live.size()) {
+            std::fprintf(stderr, "FAIL [%s churn map]: size %zu != live %zu\n",
+                         label, check.size(), live.size());
+            std::abort();
+        }
+    }
+    using clk = std::chrono::steady_clock;
+    auto t0 = clk::now();
+    size_t check_sum = 0;
+    for (int i = 0; i < iters; ++i) {
+        std::mt19937 rng(SEED + uint32_t(i));
+        std::uniform_real_distribution<float> p01(0.0f, 1.0f);
+        Map m;
+        std::vector<K> live; live.reserve(keys.size());
+        for (const auto & k : keys) {
+            m.emplace(k, (void*)nullptr);
+            live.push_back(k);
+            if (p01(rng) < 0.1f && !live.empty()) {
+                size_t victim = std::uniform_int_distribution<size_t>(0, live.size() - 1)(rng);
+                m.erase(live[victim]);
+                live[victim] = live.back();
+                live.pop_back();
+            }
+        }
+        check_sum ^= m.size();
+    }
+    auto t1 = clk::now();
+    g_sink ^= check_sum;
+    return double(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()) / iters;
+}
+
+template <typename Map>
+double bench_find_map (const std::vector<typename Map::key_type> & keys,
+                       const std::vector<typename Map::key_type> & queries,
+                       int iters, const char * label) {
+    Map m;
+    for (const auto & k : keys) m.emplace(k, (void*)nullptr);
+    if (m.size() != keys.size()) {
+        std::fprintf(stderr, "FAIL [%s find pre-build]: size %zu != expected %zu\n",
+                     label, m.size(), keys.size());
+        std::abort();
+    }
+    // Verify once: every query should be a hit.
+    {
+        size_t hits = 0;
+        for (const auto & q : queries) hits += (m.find(q) != m.end()) ? 1 : 0;
+        if (hits != queries.size()) {
+            std::fprintf(stderr, "FAIL [%s find verify]: hits %zu != queries %zu\n",
+                         label, hits, queries.size());
+            std::abort();
+        }
+    }
+    using clk = std::chrono::steady_clock;
+    auto t0 = clk::now();
+    size_t hits = 0;
+    for (int i = 0; i < iters; ++i) {
+        for (const auto & q : queries) hits += (m.find(q) != m.end()) ? 1 : 0;
+    }
+    auto t1 = clk::now();
+    g_sink ^= hits;
+    return double(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()) / iters;
+}
+
+// ===== Workloads — set =====
+template <typename Set>
+double bench_insert_set (const std::vector<typename Set::key_type> & keys, int iters,
+                         const char * label) {
+    {
+        Set check;
+        for (const auto & k : keys) check.insert(k);
+        if (check.size() != keys.size()) {
+            std::fprintf(stderr, "FAIL [%s insert set]: size %zu != expected %zu\n",
+                         label, check.size(), keys.size());
+            std::abort();
+        }
+    }
+    using clk = std::chrono::steady_clock;
+    auto t0 = clk::now();
+    size_t check_sum = 0;
+    for (int i = 0; i < iters; ++i) {
+        Set s;
+        for (const auto & k : keys) s.insert(k);
+        check_sum ^= s.size();
+    }
+    auto t1 = clk::now();
+    g_sink ^= check_sum;
+    return double(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()) / iters;
+}
+
+template <typename Set>
+double bench_churn_set (const std::vector<typename Set::key_type> & keys, int iters,
+                        const char * label) {
+    using K = typename Set::key_type;
+    {
+        std::mt19937 rng(SEED);
+        std::uniform_real_distribution<float> p01(0.0f, 1.0f);
+        Set check;
+        std::vector<K> live; live.reserve(keys.size());
+        for (const auto & k : keys) {
+            check.insert(k);
+            live.push_back(k);
+            if (p01(rng) < 0.1f && !live.empty()) {
+                size_t victim = std::uniform_int_distribution<size_t>(0, live.size() - 1)(rng);
+                check.erase(live[victim]);
+                live[victim] = live.back();
+                live.pop_back();
+            }
+        }
+        if (check.size() != live.size()) {
+            std::fprintf(stderr, "FAIL [%s churn set]: size %zu != live %zu\n",
+                         label, check.size(), live.size());
+            std::abort();
+        }
+    }
+    using clk = std::chrono::steady_clock;
+    auto t0 = clk::now();
+    size_t check_sum = 0;
+    for (int i = 0; i < iters; ++i) {
+        std::mt19937 rng(SEED + uint32_t(i));
+        std::uniform_real_distribution<float> p01(0.0f, 1.0f);
+        Set s;
+        std::vector<K> live; live.reserve(keys.size());
+        for (const auto & k : keys) {
+            s.insert(k);
+            live.push_back(k);
+            if (p01(rng) < 0.1f && !live.empty()) {
+                size_t victim = std::uniform_int_distribution<size_t>(0, live.size() - 1)(rng);
+                s.erase(live[victim]);
+                live[victim] = live.back();
+                live.pop_back();
+            }
+        }
+        check_sum ^= s.size();
+    }
+    auto t1 = clk::now();
+    g_sink ^= check_sum;
+    return double(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()) / iters;
+}
+
+template <typename Set>
+double bench_find_set (const std::vector<typename Set::key_type> & keys,
+                       const std::vector<typename Set::key_type> & queries,
+                       int iters, const char * label) {
+    Set s;
+    for (const auto & k : keys) s.insert(k);
+    if (s.size() != keys.size()) {
+        std::fprintf(stderr, "FAIL [%s find set pre-build]: size %zu != expected %zu\n",
+                     label, s.size(), keys.size());
+        std::abort();
+    }
+    {
+        size_t hits = 0;
+        for (const auto & q : queries) hits += (s.find(q) != s.end()) ? 1 : 0;
+        if (hits != queries.size()) {
+            std::fprintf(stderr, "FAIL [%s find set verify]: hits %zu != queries %zu\n",
+                         label, hits, queries.size());
+            std::abort();
+        }
+    }
+    using clk = std::chrono::steady_clock;
+    auto t0 = clk::now();
+    size_t hits = 0;
+    for (int i = 0; i < iters; ++i) {
+        for (const auto & q : queries) hits += (s.find(q) != s.end()) ? 1 : 0;
+    }
+    auto t1 = clk::now();
+    g_sink ^= hits;
+    return double(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()) / iters;
+}
+
+// ===== Probe measurement (avg key-equality calls per find) =====
+struct ProbeStats {
+    double avg_per_find;   // total eq calls / queries.size()
+    size_t max_per_find;   // worst-case probe in this run
+    double load_factor;    // size / bucket_count
+};
+
+template <typename Map>
+ProbeStats measure_probe_map (const std::vector<typename Map::key_type> & keys,
+                              const std::vector<typename Map::key_type> & queries) {
+    Map m;
+    for (const auto & k : keys) m.emplace(k, (void*)nullptr);
+    g_eq_calls = 0; g_eq_max_per_find = 0; g_eq_cur = 0;
+    size_t hits = 0;
+    for (const auto & q : queries) {
+        start_find();
+        hits += (m.find(q) != m.end()) ? 1 : 0;
+        end_find();
+    }
+    g_sink ^= hits;
+    return { double(g_eq_calls) / double(queries.size()),
+             g_eq_max_per_find,
+             m.bucket_count() ? double(m.size()) / double(m.bucket_count()) : 0.0 };
+}
+
+template <typename Set>
+ProbeStats measure_probe_set (const std::vector<typename Set::key_type> & keys,
+                              const std::vector<typename Set::key_type> & queries) {
+    Set s;
+    for (const auto & k : keys) s.insert(k);
+    g_eq_calls = 0; g_eq_max_per_find = 0; g_eq_cur = 0;
+    size_t hits = 0;
+    for (const auto & q : queries) {
+        start_find();
+        hits += (s.find(q) != s.end()) ? 1 : 0;
+        end_find();
+    }
+    g_sink ^= hits;
+    return { double(g_eq_calls) / double(queries.size()),
+             g_eq_max_per_find,
+             s.bucket_count() ? double(s.size()) / double(s.bucket_count()) : 0.0 };
+}
+
+// ===== Table emit =====
+void print_table_header (const char * title) {
+    std::printf("\n## %s\n\n", title);
+    std::printf("| N      | op           |    std (ns) |    das (ns) |   absl (ns) |  das/std |  absl/std |  das/absl |\n");
+    std::printf("|--------|--------------|------------:|------------:|------------:|---------:|----------:|----------:|\n");
+}
+void print_row (size_t n, const char * op, double s, double d, double a) {
+    std::printf("| %-6zu | %-12s | %11.0f | %11.0f | %11.0f | %8.2f | %9.2f | %9.2f |\n",
+                n, op, s, d, a, d / s, a / s, d / a);
+}
+void print_probe_header (const char * title) {
+    std::printf("\n### %s — probe stats (find on built table, all hits)\n\n", title);
+    std::printf("| N      |  std cmp/find | std max | std lf | das cmp/find | das max | das lf | absl cmp/find | absl max | absl lf |\n");
+    std::printf("|--------|--------------:|--------:|-------:|-------------:|--------:|-------:|--------------:|---------:|--------:|\n");
+}
+void print_probe_row (size_t n, ProbeStats s, ProbeStats d, ProbeStats a) {
+    std::printf("| %-6zu | %13.3f | %7zu | %6.3f | %12.3f | %7zu | %6.3f | %13.3f | %8zu | %7.3f |\n",
+                n,
+                s.avg_per_find, s.max_per_find, s.load_factor,
+                d.avg_per_find, d.max_per_find, d.load_factor,
+                a.avg_per_find, a.max_per_find, a.load_factor);
+}
+
+// ===== Per-(shape × key) runners =====
+template <typename K>
+void run_map_table (const char * title, const std::vector<K> & full_keys) {
+    using T  = MapTypes<K>;
+    using CT = CountingMapTypes<K>;
+    print_table_header(title);
+    std::vector<std::tuple<size_t, ProbeStats, ProbeStats, ProbeStats>> probes;
+    for (size_t n : SIZES) {
+        if (n > full_keys.size()) continue;
+        std::vector<K> keys(full_keys.begin(), full_keys.begin() + n);
+        const int it_b = pick_iters_build(n);
+        const int it_f = pick_iters_find(n);
+        auto queries = make_find_queries(keys, SEED + uint32_t(n));
+
+        double s_ins = bench_insert_map<typename T::StdM> (keys, it_b, "std");
+        double d_ins = bench_insert_map<typename T::DasM> (keys, it_b, "das");
+        double a_ins = bench_insert_map<typename T::AbslM>(keys, it_b, "absl");
+        print_row(n, "insert", s_ins, d_ins, a_ins);
+
+        double s_chu = bench_churn_map<typename T::StdM> (keys, it_b, "std");
+        double d_chu = bench_churn_map<typename T::DasM> (keys, it_b, "das");
+        double a_chu = bench_churn_map<typename T::AbslM>(keys, it_b, "absl");
+        print_row(n, "churn", s_chu, d_chu, a_chu);
+
+        double s_fnd = bench_find_map<typename T::StdM> (keys, queries, it_f, "std");
+        double d_fnd = bench_find_map<typename T::DasM> (keys, queries, it_f, "das");
+        double a_fnd = bench_find_map<typename T::AbslM>(keys, queries, it_f, "absl");
+        print_row(n, "find (10xN)", s_fnd, d_fnd, a_fnd);
+
+        // Probe stats via instrumented eq predicates (counting variants).
+        auto sp = measure_probe_map<typename CT::StdM> (keys, queries);
+        auto dp = measure_probe_map<typename CT::DasM> (keys, queries);
+        auto ap = measure_probe_map<typename CT::AbslM>(keys, queries);
+        probes.emplace_back(n, sp, dp, ap);
+
+        std::fflush(stdout);
+    }
+    print_probe_header(title);
+    for (auto & p : probes) {
+        print_probe_row(std::get<0>(p), std::get<1>(p), std::get<2>(p), std::get<3>(p));
+    }
+    std::fflush(stdout);
+}
+
+template <typename K>
+void run_set_table (const char * title, const std::vector<K> & full_keys) {
+    using T  = SetTypes<K>;
+    using CT = CountingSetTypes<K>;
+    print_table_header(title);
+    std::vector<std::tuple<size_t, ProbeStats, ProbeStats, ProbeStats>> probes;
+    for (size_t n : SIZES) {
+        if (n > full_keys.size()) continue;
+        std::vector<K> keys(full_keys.begin(), full_keys.begin() + n);
+        const int it_b = pick_iters_build(n);
+        const int it_f = pick_iters_find(n);
+        auto queries = make_find_queries(keys, SEED + uint32_t(n));
+
+        double s_ins = bench_insert_set<typename T::StdS> (keys, it_b, "std");
+        double d_ins = bench_insert_set<typename T::DasS> (keys, it_b, "das");
+        double a_ins = bench_insert_set<typename T::AbslS>(keys, it_b, "absl");
+        print_row(n, "insert", s_ins, d_ins, a_ins);
+
+        double s_chu = bench_churn_set<typename T::StdS> (keys, it_b, "std");
+        double d_chu = bench_churn_set<typename T::DasS> (keys, it_b, "das");
+        double a_chu = bench_churn_set<typename T::AbslS>(keys, it_b, "absl");
+        print_row(n, "churn", s_chu, d_chu, a_chu);
+
+        double s_fnd = bench_find_set<typename T::StdS> (keys, queries, it_f, "std");
+        double d_fnd = bench_find_set<typename T::DasS> (keys, queries, it_f, "das");
+        double a_fnd = bench_find_set<typename T::AbslS>(keys, queries, it_f, "absl");
+        print_row(n, "find (10xN)", s_fnd, d_fnd, a_fnd);
+
+        auto sp = measure_probe_set<typename CT::StdS> (keys, queries);
+        auto dp = measure_probe_set<typename CT::DasS> (keys, queries);
+        auto ap = measure_probe_set<typename CT::AbslS>(keys, queries);
+        probes.emplace_back(n, sp, dp, ap);
+
+        std::fflush(stdout);
+    }
+    print_probe_header(title);
+    for (auto & p : probes) {
+        print_probe_row(std::get<0>(p), std::get<1>(p), std::get<2>(p), std::get<3>(p));
+    }
+    std::fflush(stdout);
+}
+
+} // anonymous
+
+int main () {
+    std::printf("# Hash table bench: std::unordered_* vs das::daslang_hash_* vs absl::flat_hash_*\n\n");
+    std::printf("C++ stdlib: ");
+#if defined(_LIBCPP_VERSION)
+    std::printf("libc++ %d\n", _LIBCPP_VERSION);
+#elif defined(__GLIBCXX__)
+    std::printf("libstdc++ %d\n", __GLIBCXX__);
+#elif defined(_MSC_VER)
+    std::printf("MSVC stdlib (_MSC_VER=%d)\n", _MSC_VER);
+#else
+    std::printf("unknown\n");
+#endif
+    std::printf("Compiler: ");
+#if defined(__clang__)
+    std::printf("clang %d.%d.%d\n", __clang_major__, __clang_minor__, __clang_patchlevel__);
+#elif defined(__GNUC__)
+    std::printf("gcc %d.%d.%d\n", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+#elif defined(_MSC_VER)
+    std::printf("MSVC %d\n", _MSC_VER);
+#else
+    std::printf("unknown\n");
+#endif
+    std::printf("\nWorkloads — per row, all three impls run the SAME workload on the SAME N keys.\n");
+    std::printf("Times are nanoseconds per iteration (whole-phase wall time for one full pass).\n");
+    std::printf("Ratios: das/std, absl/std, das/absl (lower = faster).\n");
+    std::printf("\nNote on K=const char*: all three impls forced to a content-hashing CStrHash\n");
+    std::printf("so per-op work is identical; only table mechanics differ.\n");
+    std::printf("\nProbe-stats tables (one per shape x key) report avg key-equality calls per find,\n");
+    std::printf("worst-case (max), and post-build load factor. ~1.0 cmp/find = clean lookups;\n");
+    std::printf("higher means the impl waded through hash collisions / chain entries before the hit.\n");
+
+    auto str_corpus   = make_string_corpus(MAX_N, SEED);
+    auto ptr_pool_32  = make_ptr_pool(MAX_N, 32);
+    auto ptr_pool_128 = make_ptr_pool(MAX_N, 128);
+
+    run_map_table<const char*>("Map<const char*, void*>",  str_corpus.cstrs);
+    run_map_table<std::string>("Map<std::string, void*>",  str_corpus.strs);
+    run_map_table<uint64_t>   ("Map<uint64_t, void*>",     str_corpus.hashes);
+    run_map_table<void*>      ("Map<void* (32B alloc), void*>",  ptr_pool_32.ptrs);
+    run_map_table<void*>      ("Map<void* (128B alloc), void*>", ptr_pool_128.ptrs);
+
+    run_set_table<const char*>("Set<const char*>",         str_corpus.cstrs);
+    run_set_table<std::string>("Set<std::string>",         str_corpus.strs);
+    run_set_table<uint64_t>   ("Set<uint64_t>",            str_corpus.hashes);
+    run_set_table<void*>      ("Set<void* (32B alloc)>",   ptr_pool_32.ptrs);
+    run_set_table<void*>      ("Set<void* (128B alloc)>",  ptr_pool_128.ptrs);
+
+    // Force a use of g_sink so the optimizer keeps everything.
+    std::printf("\n(checksum: 0x%zx)\n", size_t(g_sink));
+    return 0;
+}

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1205,7 +1205,7 @@ namespace das
     public:
         smart_ptr<Context>                          macroContext;
         safebox<TypeDecl, TypeDeclPtr>                           aliasTypes;
-        das_hash_map<uint64_t, Annotation *>            handleTypes;
+        das_insert_only_hash_map<uint64_t, Annotation *>    handleTypes;
         safebox<Structure, StructurePtr>             structures;
         safebox<Enumeration, EnumerationPtr>        enumerations;
         safebox<Variable, VariablePtr>              globals;
@@ -1213,10 +1213,10 @@ namespace das
         fragile_hash<vector<Function*>>             functionsByName;    // all functions of the same name
         safebox<Function, FunctionPtr>              generics;           // mangled name 2 generic name
         fragile_hash<vector<Function*>>             genericsByName;     // all generics of the same name
-        mutable das_map<string, ExprCallFactory>    callThis;
-        das_map<string, unique_ptr<TypeInfoMacro>>   typeInfoMacros;
-        das_map<uint64_t, uint64_t>                 annotationData;
-        das_hash_map<Module *,bool>                 requireModule;      // visibility modules
+        mutable das_insert_only_map<string, ExprCallFactory>    callThis;
+        das_insert_only_map<string, unique_ptr<TypeInfoMacro>>  typeInfoMacros;
+        das_insert_only_map<uint64_t, uint64_t>             annotationData;
+        das_insert_only_hash_map<Module *,bool>             requireModule;  // visibility modules
         vector<unique_ptr<PassMacro>>               macros;             // infer macros (clean infer, assume no errors)
         vector<unique_ptr<PassMacro>>               inferMacros;        // infer macros (dirty infer, assume half-way-there tree)
         vector<unique_ptr<PassMacro>>               optimizationMacros; // optimization macros
@@ -1226,13 +1226,13 @@ namespace das
         vector<unique_ptr<ForLoopMacro>>            forLoopMacros;      // for loop macros (for every for loop)
         vector<unique_ptr<CaptureMacro>>            captureMacros;      // lambda capture macros
         vector<unique_ptr<SimulateMacro>>           simulateMacros;     // simulate macros (every time we simulate context)
-        das_map<string,unique_ptr<TypeMacro>>       typeMacros;         // type macros (every time we infer type)
-        das_map<string,unique_ptr<ReaderMacro>>     readMacros;         // %foo "blah"
+        das_insert_only_map<string,unique_ptr<TypeMacro>>   typeMacros; // type macros (every time we infer type)
+        das_insert_only_map<string,unique_ptr<ReaderMacro>> readMacros; // %foo "blah"
         unique_ptr<CommentReader>                   commentReader;      // /* blah */ or // blah
         vector<unique_ptr<CallMacro>>               ownedCallMacros;    // call macros (owned here, referenced from callThis lambdas)
         vector<pair<string,bool>>                   keywords;           // keywords (and if they need oxford comma)
         vector<string>                              typeFunctions;      // type functions
-        das_hash_map<string,Type>                   options;            // options
+        das_insert_only_hash_map<string,Type>       options;            // options
         gc_root                                     module_gc_root;     // gc_node root for this module's gc-managed AST nodes
         uint64_t                                    cumulativeHash = 0; // hash of all mangled names in this module (for builtin modules)
         string                                      name;

--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -255,11 +255,16 @@ namespace das {
         template <typename K, typename V, typename H, typename E>
         AstSerializer & operator << ( das_hash_map<K, V, H, E> & value );
 
+        // Guarded: under DAS_CUSTOM_HASH=0 das_insert_only_hash_map aliases to
+        // std::unordered_map (same as das_hash_map), so the regular overloads
+        // above already match insert-only args.
+#if DAS_CUSTOM_HASH
         template <typename K, typename V, typename H, typename E>
         void serialize_hash_map ( das_insert_only_hash_map<K, V, H, E> & value );
 
         template <typename K, typename V, typename H, typename E>
         AstSerializer & operator << ( das_insert_only_hash_map<K, V, H, E> & value );
+#endif
 
         template <typename V>
         AstSerializer & operator << ( safebox_map<V> & box );

--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -255,6 +255,12 @@ namespace das {
         template <typename K, typename V, typename H, typename E>
         AstSerializer & operator << ( das_hash_map<K, V, H, E> & value );
 
+        template <typename K, typename V, typename H, typename E>
+        void serialize_hash_map ( das_insert_only_hash_map<K, V, H, E> & value );
+
+        template <typename K, typename V, typename H, typename E>
+        AstSerializer & operator << ( das_insert_only_hash_map<K, V, H, E> & value );
+
         template <typename V>
         AstSerializer & operator << ( safebox_map<V> & box );
 

--- a/include/daScript/das_config.h
+++ b/include/daScript/das_config.h
@@ -52,6 +52,17 @@ template <typename K, typename V, typename H = das::daslang_hash<K>, typename E 
 using das_hash_map = das::daslang_hash_map<K,V,H,E>;
 template <typename K, typename H = das::daslang_hash<K>, typename E = das::equal_to<K>>
 using das_hash_set = das::daslang_hash_set<K,H,E>;
+// Insert-only / grow-only flavors — same API minus erase(). Saves one branch
+// per probe step in insert and one in iterator skip; signals to readers that
+// the table is grow-only by design.
+template <typename K, typename V, typename H = das::daslang_hash<K>, typename E = das::equal_to<K>>
+using das_insert_only_map = das::daslang_insert_only_hash_map<K,V,H,E>;
+template <typename K, typename H = das::daslang_hash<K>, typename E = das::equal_to<K>>
+using das_insert_only_set = das::daslang_insert_only_hash_set<K,H,E>;
+template <typename K, typename V, typename H = das::daslang_hash<K>, typename E = das::equal_to<K>>
+using das_insert_only_hash_map = das::daslang_insert_only_hash_map<K,V,H,E>;
+template <typename K, typename H = das::daslang_hash<K>, typename E = das::equal_to<K>>
+using das_insert_only_hash_set = das::daslang_insert_only_hash_set<K,H,E>;
 template <typename K, typename V>
 using das_safe_map = std::map<K,V>;
 template <typename K, typename C=das::less<K>>
@@ -67,6 +78,17 @@ template <typename K, typename V, typename H = das::hash<K>, typename E = das::e
 using das_hash_map = std::unordered_map<K,V,H,E>;
 template <typename K, typename H = das::hash<K>, typename E = das::equal_to<K>>
 using das_hash_set = std::unordered_set<K,H,E>;
+// Insert-only variants degrade gracefully to std::unordered_* when DAS_CUSTOM_HASH=0
+// (no insert-only stdlib equivalent — caller-visible API is a superset, so callers
+// that don't use erase will compile both ways).
+template <typename K, typename V, typename H = das::hash<K>, typename E = das::equal_to<K>>
+using das_insert_only_map = std::unordered_map<K,V,H,E>;
+template <typename K, typename H = das::hash<K>, typename E = das::equal_to<K>>
+using das_insert_only_set = std::unordered_set<K,H,E>;
+template <typename K, typename V, typename H = das::hash<K>, typename E = das::equal_to<K>>
+using das_insert_only_hash_map = std::unordered_map<K,V,H,E>;
+template <typename K, typename H = das::hash<K>, typename E = das::equal_to<K>>
+using das_insert_only_hash_set = std::unordered_set<K,H,E>;
 template <typename K, typename V>
 using das_safe_map = std::map<K,V>;
 template <typename K, typename C=das::less<K>>

--- a/include/daScript/misc/das_common.h
+++ b/include/daScript/misc/das_common.h
@@ -34,6 +34,10 @@ namespace das {
 
     // Insert-only variant — same body, different parameter type. Two overloads
     // rather than a generic template so the static_assert / signature stay symmetric.
+    // Guarded: under DAS_CUSTOM_HASH=0, das_insert_only_hash_map aliases to the
+    // same std::unordered_map as das_hash_map, so the regular overload above
+    // already serves insert-only args.
+#if DAS_CUSTOM_HASH
     template <typename K, typename V, typename Compare = std::less<K>>
     vector<pair<K, V>> ordered(const das_insert_only_hash_map<K, V> &unsorted_map, Compare cmp = {}) {
         static_assert(!is_pointer_v<K> ||
@@ -45,6 +49,7 @@ namespace das {
                   [&cmp](const auto &p1, const auto &p2) { return cmp(p1.first, p2.first); } );
         return sorted_vector;
     }
+#endif
 
     template <typename K, typename Compare = less<K>>
     vector<K> ordered(const das_set<K> &unsorted_map, Compare cmp = {}) {
@@ -59,6 +64,8 @@ namespace das {
         return sorted_vector;
     }
 
+    // See note on the insert-only map overload above.
+#if DAS_CUSTOM_HASH
     template <typename K, typename Compare = less<K>>
     vector<K> ordered(const das_insert_only_hash_set<K> &unsorted_map, Compare cmp = {}) {
         static_assert(!is_pointer_v<K> ||
@@ -69,6 +76,7 @@ namespace das {
         sort(sorted_vector.begin(), sorted_vector.end(), cmp);
         return sorted_vector;
     }
+#endif
 
 
     bool starts_with ( const string & name, const char * template_name );

--- a/include/daScript/misc/das_common.h
+++ b/include/daScript/misc/das_common.h
@@ -32,6 +32,20 @@ namespace das {
         return sorted_vector;
     }
 
+    // Insert-only variant — same body, different parameter type. Two overloads
+    // rather than a generic template so the static_assert / signature stay symmetric.
+    template <typename K, typename V, typename Compare = std::less<K>>
+    vector<pair<K, V>> ordered(const das_insert_only_hash_map<K, V> &unsorted_map, Compare cmp = {}) {
+        static_assert(!is_pointer_v<K> ||
+                      !is_same_v<Compare, less<K>>,
+                      "When K is pointer you should provide user-defined comparator. "
+                      "Because we use this method to avoid nondeterminism in map traversal.");
+        vector<pair<K, V>> sorted_vector(unsorted_map.begin(), unsorted_map.end());
+        sort(sorted_vector.begin(), sorted_vector.end(),
+                  [&cmp](const auto &p1, const auto &p2) { return cmp(p1.first, p2.first); } );
+        return sorted_vector;
+    }
+
     template <typename K, typename Compare = less<K>>
     vector<K> ordered(const das_set<K> &unsorted_map, Compare cmp = {}) {
         static_assert(!is_pointer_v<K> ||
@@ -41,6 +55,17 @@ namespace das {
         vector<K> sorted_vector(unsorted_map.begin(), unsorted_map.end());
 
         // Sort the vector by key
+        sort(sorted_vector.begin(), sorted_vector.end(), cmp);
+        return sorted_vector;
+    }
+
+    template <typename K, typename Compare = less<K>>
+    vector<K> ordered(const das_insert_only_hash_set<K> &unsorted_map, Compare cmp = {}) {
+        static_assert(!is_pointer_v<K> ||
+                      !is_same_v<Compare, less<K>>,
+                      "When K is pointer you should provide user-defined comparator. "
+                      "Because we use this method to avoid nondeterminism in set traversal.");
+        vector<K> sorted_vector(unsorted_map.begin(), unsorted_map.end());
         sort(sorted_vector.begin(), sorted_vector.end(), cmp);
         return sorted_vector;
     }

--- a/include/das_hash_map/das_hash_map.h
+++ b/include/das_hash_map/das_hash_map.h
@@ -554,6 +554,318 @@ private:
 };
 
 //
+//  daslang_insert_only_hash_map — same layout as daslang_hash_map but with NO
+//  erase API and NO tombstone tracking. Insertion-only / read-only callers
+//  pay strictly less per-op work:
+//   * reserve_slot's inner loop drops the HASH_KILLED branch + insertI tracking
+//   * iterator skip condition is `== HASH_EMPTY` rather than `<= HASH_KILLED`
+//   * no `tombstones_` counter, no rehash_same_capacity path
+//   * find_index is identical to the regular version (already terminates on
+//     EMPTY only — tombstones never extended probe chains for finds, only
+//     for insert collision resolution)
+//
+//  Load factor cap is still 0.5 to keep find behavior matched with the
+//  regular version for apples-to-apples benchmarking. Callers wanting denser
+//  packing should use absl::flat_hash_map (0.875 cap) instead.
+//
+
+template <class K, class V, class Hash = daslang_hash<K>, class KeyEqual = das::equal_to<K>>
+class daslang_insert_only_hash_map {
+    static constexpr bool is_bool_value = das::is_same<V, bool>::value;
+    using value_storage_t = typename das::conditional<is_bool_value, uint8_t, V>::type;
+
+    das::vector<uint64_t>       hashes_;
+    das::vector<K>              keys_;
+    das::vector<value_storage_t> values_;
+    size_t                 size_ = 0;
+    Hash                   hash_;
+    KeyEqual               key_equal_;
+
+    __forceinline V &       val_at ( size_t i )       noexcept { return reinterpret_cast<V       &>(values_[i]); }
+    __forceinline const V & val_at ( size_t i ) const noexcept { return reinterpret_cast<const V &>(values_[i]); }
+
+public:
+    using key_type    = K;
+    using mapped_type = V;
+    using size_type   = size_t;
+    using hasher      = Hash;
+    using key_equal   = KeyEqual;
+
+    struct reference {
+        K & first;
+        V & second;
+        operator das::pair<K, V> () const { return { first, second }; }
+    };
+    struct const_reference {
+        const K & first;
+        const V & second;
+        operator das::pair<K, V> () const { return { first, second }; }
+    };
+
+    class const_iterator;
+
+    class iterator {
+    public:
+        using iterator_category = das::forward_iterator_tag;
+        using value_type        = das::pair<K, V>;
+        using difference_type   = ptrdiff_t;
+        using pointer           = daslang_insert_only_hash_map::reference *;
+        using reference         = daslang_insert_only_hash_map::reference;
+    private:
+        daslang_insert_only_hash_map * owner_ = nullptr;
+        size_t                         index_ = 0;
+        mutable typename das::aligned_storage<sizeof(reference), alignof(reference)>::type ref_storage_;
+        friend class daslang_insert_only_hash_map;
+        friend class const_iterator;
+    public:
+        iterator () noexcept = default;
+        iterator ( daslang_insert_only_hash_map * o, size_t i ) noexcept : owner_(o), index_(i) {}
+
+        reference & operator *  () const {
+            return *::new (static_cast<void*>(&ref_storage_))
+                reference{ owner_->keys_[index_], owner_->val_at(index_) };
+        }
+        reference * operator -> () const { return &**this; }
+
+        iterator & operator ++ () {
+            const size_t cap = owner_->hashes_.size();
+            const uint64_t * pH = owner_->hashes_.data();
+            ++index_;
+            while ( index_ < cap && pH[index_] == daslang_hash_map_detail::HASH_EMPTY ) ++index_;
+            return *this;
+        }
+        iterator   operator ++ (int) { iterator t = *this; ++(*this); return t; }
+
+        bool operator == ( const iterator & o ) const noexcept { return index_ == o.index_ && owner_ == o.owner_; }
+        bool operator != ( const iterator & o ) const noexcept { return !(*this == o); }
+    };
+
+    class const_iterator {
+    public:
+        using iterator_category = das::forward_iterator_tag;
+        using value_type        = das::pair<K, V>;
+        using difference_type   = ptrdiff_t;
+        using pointer           = const daslang_insert_only_hash_map::const_reference *;
+        using reference         = daslang_insert_only_hash_map::const_reference;
+    private:
+        const daslang_insert_only_hash_map * owner_ = nullptr;
+        size_t                               index_ = 0;
+        mutable typename das::aligned_storage<sizeof(const_reference), alignof(const_reference)>::type ref_storage_;
+        friend class daslang_insert_only_hash_map;
+    public:
+        const_iterator () noexcept = default;
+        const_iterator ( const daslang_insert_only_hash_map * o, size_t i ) noexcept : owner_(o), index_(i) {}
+        const_iterator ( const iterator & it ) noexcept : owner_(it.owner_), index_(it.index_) {}
+
+        reference & operator *  () const {
+            return *::new (static_cast<void*>(&ref_storage_))
+                const_reference{ owner_->keys_[index_], owner_->val_at(index_) };
+        }
+        reference * operator -> () const { return &**this; }
+
+        const_iterator & operator ++ () {
+            const size_t cap = owner_->hashes_.size();
+            const uint64_t * pH = owner_->hashes_.data();
+            ++index_;
+            while ( index_ < cap && pH[index_] == daslang_hash_map_detail::HASH_EMPTY ) ++index_;
+            return *this;
+        }
+        const_iterator   operator ++ (int) { const_iterator t = *this; ++(*this); return t; }
+
+        bool operator == ( const const_iterator & o ) const noexcept { return index_ == o.index_ && owner_ == o.owner_; }
+        bool operator != ( const const_iterator & o ) const noexcept { return !(*this == o); }
+    };
+
+    daslang_insert_only_hash_map () = default;
+    daslang_insert_only_hash_map ( const daslang_insert_only_hash_map & ) = default;
+    daslang_insert_only_hash_map ( daslang_insert_only_hash_map && ) noexcept = default;
+    daslang_insert_only_hash_map & operator = ( const daslang_insert_only_hash_map & ) = default;
+    daslang_insert_only_hash_map & operator = ( daslang_insert_only_hash_map && ) noexcept = default;
+    ~ daslang_insert_only_hash_map () = default;
+
+    daslang_insert_only_hash_map ( das::initializer_list<das::pair<K, V>> il ) {
+        reserve(il.size());
+        for ( const auto & kv : il ) insert(kv);
+    }
+
+    bool         empty        () const noexcept { return size_ == 0; }
+    size_type    size         () const noexcept { return size_; }
+    size_type    bucket_count () const noexcept { return hashes_.size(); }
+
+    void reserve ( size_type n ) {
+        if ( n == 0 ) return;
+        size_t needed = daslang_hash_map_detail::minCapacity;
+        while ( needed < n * 2 ) needed *= 2;
+        if ( needed > hashes_.size() ) rehash_into(needed);
+    }
+
+    void clear () noexcept {
+        hashes_.clear();
+        keys_.clear();
+        values_.clear();
+        size_ = 0;
+    }
+
+    void shrink_to_fit () {
+        hashes_.shrink_to_fit();
+        keys_.shrink_to_fit();
+        values_.shrink_to_fit();
+    }
+
+    iterator       begin ()        { return iterator      {this, first_live_index()}; }
+    const_iterator begin () const  { return const_iterator{this, first_live_index()}; }
+    const_iterator cbegin () const { return begin(); }
+    iterator       end   ()        { return iterator      {this, hashes_.size()}; }
+    const_iterator end   () const  { return const_iterator{this, hashes_.size()}; }
+    const_iterator cend   () const { return end(); }
+
+    iterator find ( const K & key ) {
+        const size_t idx = find_index(key, hash_(key));
+        return idx == SIZE_MAX ? end() : iterator{this, idx};
+    }
+    const_iterator find ( const K & key ) const {
+        const size_t idx = find_index(key, hash_(key));
+        return idx == SIZE_MAX ? end() : const_iterator{this, idx};
+    }
+    size_type count    ( const K & key ) const { return find_index(key, hash_(key)) == SIZE_MAX ? 0 : 1; }
+    bool      contains ( const K & key ) const { return find_index(key, hash_(key)) != SIZE_MAX; }
+
+    V & at ( const K & key ) {
+        const size_t idx = find_index(key, hash_(key));
+        if ( idx == SIZE_MAX ) das::das_throw("daslang_insert_only_hash_map::at");
+        return val_at(idx);
+    }
+    const V & at ( const K & key ) const {
+        const size_t idx = find_index(key, hash_(key));
+        if ( idx == SIZE_MAX ) das::das_throw("daslang_insert_only_hash_map::at");
+        return val_at(idx);
+    }
+
+    V & operator [] ( const K & key ) {
+        return val_at(reserve_slot(key, hash_(key)).first);
+    }
+    V & operator [] ( K && key ) {
+        auto h = hash_(key);
+        return val_at(reserve_slot(das::move(key), h).first);
+    }
+
+    das::pair<iterator, bool> insert ( const das::pair<K, V> & kv ) {
+        auto r = reserve_slot(kv.first, hash_(kv.first));
+        if ( r.second ) val_at(r.first) = kv.second;
+        return { iterator{this, r.first}, r.second };
+    }
+    das::pair<iterator, bool> insert ( das::pair<K, V> && kv ) {
+        auto h = hash_(kv.first);
+        auto r = reserve_slot(das::move(kv.first), h);
+        if ( r.second ) val_at(r.first) = das::move(kv.second);
+        return { iterator{this, r.first}, r.second };
+    }
+
+    template <class... Args>
+    das::pair<iterator, bool> emplace ( Args &&... args ) {
+        das::pair<K, V> kv(das::forward<Args>(args)...);
+        return insert(das::move(kv));
+    }
+
+    template <class... Args>
+    das::pair<iterator, bool> try_emplace ( const K & key, Args &&... args ) {
+        auto r = reserve_slot(key, hash_(key));
+        if ( r.second ) val_at(r.first) = V(das::forward<Args>(args)...);
+        return { iterator{this, r.first}, r.second };
+    }
+    template <class... Args>
+    das::pair<iterator, bool> try_emplace ( K && key, Args &&... args ) {
+        auto h = hash_(key);
+        auto r = reserve_slot(das::move(key), h);
+        if ( r.second ) val_at(r.first) = V(das::forward<Args>(args)...);
+        return { iterator{this, r.first}, r.second };
+    }
+
+    // NOTE: no erase(). By design.
+
+private:
+
+    size_t first_live_index () const noexcept {
+        const size_t cap = hashes_.size();
+        const uint64_t * pH = hashes_.data();
+        for ( size_t i = 0; i < cap; ++i ) {
+            if ( pH[i] != daslang_hash_map_detail::HASH_EMPTY ) return i;
+        }
+        return cap;
+    }
+
+    __forceinline size_t find_index ( const K & key, uint64_t raw_hash ) const {
+        if ( hashes_.size() == 0 ) return SIZE_MAX;
+        uint64_t mask = hashes_.size() - 1;
+        uint64_t index = raw_hash & mask;
+        auto pKeys   = keys_.data();
+        auto pHashes = hashes_.data();
+        auto hashKey = daslang_hash_map_detail::to_hash_key(raw_hash);
+        while ( true ) {
+            auto kh = pHashes[index];
+            if ( kh == daslang_hash_map_detail::HASH_EMPTY ) {
+                return SIZE_MAX;
+            } else if ( kh == hashKey && key_equal_(pKeys[index], key) ) {
+                return size_t(index);
+            }
+            index = daslang_hash_map_detail::next_probe_slot(index, mask);
+        }
+    }
+
+    // Simpler than the tombstone-aware version: no insertI tracking, no
+    // HASH_KILLED branch in the inner loop. One fewer compare per probe step.
+    template <class KFwd>
+    __forceinline das::pair<size_t, bool> reserve_slot ( KFwd && key, uint64_t raw_hash ) {
+        if ( size_ >= hashes_.size() / 2 ) grow();
+        uint64_t mask = hashes_.size() - 1;
+        uint64_t index = raw_hash & mask;
+        auto pKeys   = keys_.data();
+        auto pHashes = hashes_.data();
+        auto hashKey = daslang_hash_map_detail::to_hash_key(raw_hash);
+        while ( true ) {
+            auto kh = pHashes[index];
+            if ( kh == daslang_hash_map_detail::HASH_EMPTY ) {
+                pHashes[index] = hashKey;
+                pKeys  [index] = das::forward<KFwd>(key);
+                ++size_;
+                return { size_t(index), true };
+            } else if ( kh == hashKey && key_equal_(pKeys[index], key) ) {
+                return { size_t(index), false };
+            }
+            index = daslang_hash_map_detail::next_probe_slot(index, mask);
+        }
+    }
+
+    void grow () {
+        const size_t new_cap = hashes_.empty()
+            ? daslang_hash_map_detail::minCapacity
+            : hashes_.size() * 2;
+        rehash_into(new_cap);
+    }
+
+    void rehash_into ( size_t new_cap ) {
+        das::vector<uint64_t> new_hashes(new_cap, daslang_hash_map_detail::HASH_EMPTY);
+        das::vector<K>        new_keys(new_cap);
+        das::vector<value_storage_t> new_values(new_cap);
+        const uint64_t mask = new_cap - 1;
+        for ( size_t i = 0, n = hashes_.size(); i < n; ++i ) {
+            const uint64_t kh = hashes_[i];
+            if ( kh == daslang_hash_map_detail::HASH_EMPTY ) continue;
+            uint64_t j = kh & mask;
+            while ( new_hashes[j] != daslang_hash_map_detail::HASH_EMPTY ) {
+                j = daslang_hash_map_detail::next_probe_slot(j, mask);
+            }
+            new_hashes[j] = kh;
+            new_keys  [j] = das::move(keys_  [i]);
+            new_values[j] = das::move(values_[i]);
+        }
+        hashes_ = das::move(new_hashes);
+        keys_   = das::move(new_keys);
+        values_ = das::move(new_values);
+    }
+};
+
+//
 //  daslang_hash_set
 //
 
@@ -772,6 +1084,196 @@ private:
         hashes_ = das::move(new_hashes);
         keys_   = das::move(new_keys);
         tombstones_ = 0;
+    }
+};
+
+//
+//  daslang_insert_only_hash_set — set sibling of daslang_insert_only_hash_map.
+//  Same rationale: drops erase + tombstone bookkeeping, simpler probe loop.
+//
+
+template <class K, class Hash = daslang_hash<K>, class KeyEqual = das::equal_to<K>>
+class daslang_insert_only_hash_set {
+    das::vector<uint64_t> hashes_;
+    das::vector<K>        keys_;
+    size_t           size_ = 0;
+    Hash             hash_;
+    KeyEqual         key_equal_;
+
+public:
+    using key_type  = K;
+    using size_type = size_t;
+    using hasher    = Hash;
+    using key_equal = KeyEqual;
+
+    class const_iterator {
+        const daslang_insert_only_hash_set * owner_ = nullptr;
+        size_t                               index_ = 0;
+        friend class daslang_insert_only_hash_set;
+    public:
+        using iterator_category = das::forward_iterator_tag;
+        using value_type        = K;
+        using difference_type   = ptrdiff_t;
+        using pointer           = const K *;
+        using reference         = const K &;
+
+        const_iterator () noexcept = default;
+        const_iterator ( const daslang_insert_only_hash_set * o, size_t i ) noexcept : owner_(o), index_(i) {}
+
+        reference operator *  () const { return owner_->keys_[index_]; }
+        pointer   operator -> () const { return &owner_->keys_[index_]; }
+
+        const_iterator & operator ++ () {
+            const size_t cap = owner_->hashes_.size();
+            const uint64_t * pH = owner_->hashes_.data();
+            ++index_;
+            while ( index_ < cap && pH[index_] == daslang_hash_map_detail::HASH_EMPTY ) ++index_;
+            return *this;
+        }
+        const_iterator   operator ++ (int) { const_iterator t = *this; ++(*this); return t; }
+
+        bool operator == ( const const_iterator & o ) const noexcept { return index_ == o.index_ && owner_ == o.owner_; }
+        bool operator != ( const const_iterator & o ) const noexcept { return !(*this == o); }
+    };
+
+    using iterator = const_iterator;
+
+    daslang_insert_only_hash_set () = default;
+    daslang_insert_only_hash_set ( const daslang_insert_only_hash_set & ) = default;
+    daslang_insert_only_hash_set ( daslang_insert_only_hash_set && ) noexcept = default;
+    daslang_insert_only_hash_set & operator = ( const daslang_insert_only_hash_set & ) = default;
+    daslang_insert_only_hash_set & operator = ( daslang_insert_only_hash_set && ) noexcept = default;
+    ~ daslang_insert_only_hash_set () = default;
+
+    daslang_insert_only_hash_set ( das::initializer_list<K> il ) {
+        reserve(il.size());
+        for ( const auto & k : il ) insert(k);
+    }
+
+    bool      empty        () const noexcept { return size_ == 0; }
+    size_type size         () const noexcept { return size_; }
+    size_type bucket_count () const noexcept { return hashes_.size(); }
+
+    void reserve ( size_type n ) {
+        if ( n == 0 ) return;
+        size_t needed = daslang_hash_map_detail::minCapacity;
+        while ( needed < n * 2 ) needed *= 2;
+        if ( needed > hashes_.size() ) rehash_into(needed);
+    }
+
+    void clear () noexcept {
+        hashes_.clear();
+        keys_.clear();
+        size_ = 0;
+    }
+
+    void shrink_to_fit () {
+        hashes_.shrink_to_fit();
+        keys_.shrink_to_fit();
+    }
+
+    iterator       begin () const  { return const_iterator{this, first_live_index()}; }
+    const_iterator cbegin () const { return begin(); }
+    iterator       end   () const  { return const_iterator{this, hashes_.size()}; }
+    const_iterator cend   () const { return end(); }
+
+    const_iterator find ( const K & key ) const {
+        const size_t idx = find_index(key, hash_(key));
+        return idx == SIZE_MAX ? end() : const_iterator{this, idx};
+    }
+    size_type count    ( const K & key ) const { return find_index(key, hash_(key)) == SIZE_MAX ? 0 : 1; }
+    bool      contains ( const K & key ) const { return find_index(key, hash_(key)) != SIZE_MAX; }
+
+    das::pair<iterator, bool> insert ( const K & key ) {
+        auto r = reserve_slot(key, hash_(key));
+        return { const_iterator{this, r.first}, r.second };
+    }
+    das::pair<iterator, bool> insert ( K && key ) {
+        auto h = hash_(key);
+        auto r = reserve_slot(das::move(key), h);
+        return { const_iterator{this, r.first}, r.second };
+    }
+    template <class... Args>
+    das::pair<iterator, bool> emplace ( Args &&... args ) {
+        K key(das::forward<Args>(args)...);
+        return insert(das::move(key));
+    }
+
+    // NOTE: no erase(). By design.
+
+private:
+    size_t first_live_index () const noexcept {
+        const size_t cap = hashes_.size();
+        const uint64_t * pH = hashes_.data();
+        for ( size_t i = 0; i < cap; ++i ) {
+            if ( pH[i] != daslang_hash_map_detail::HASH_EMPTY ) return i;
+        }
+        return cap;
+    }
+
+    __forceinline size_t find_index ( const K & key, uint64_t raw_hash ) const {
+        if ( hashes_.size() == 0 ) return SIZE_MAX;
+        uint64_t mask = hashes_.size() - 1;
+        uint64_t index = raw_hash & mask;
+        auto pKeys   = keys_.data();
+        auto pHashes = hashes_.data();
+        auto hashKey = daslang_hash_map_detail::to_hash_key(raw_hash);
+        while ( true ) {
+            auto kh = pHashes[index];
+            if ( kh == daslang_hash_map_detail::HASH_EMPTY ) {
+                return SIZE_MAX;
+            } else if ( kh == hashKey && key_equal_(pKeys[index], key) ) {
+                return size_t(index);
+            }
+            index = daslang_hash_map_detail::next_probe_slot(index, mask);
+        }
+    }
+
+    template <class KFwd>
+    __forceinline das::pair<size_t, bool> reserve_slot ( KFwd && key, uint64_t raw_hash ) {
+        if ( size_ >= hashes_.size() / 2 ) grow();
+        uint64_t mask = hashes_.size() - 1;
+        uint64_t index = raw_hash & mask;
+        auto pKeys   = keys_.data();
+        auto pHashes = hashes_.data();
+        auto hashKey = daslang_hash_map_detail::to_hash_key(raw_hash);
+        while ( true ) {
+            auto kh = pHashes[index];
+            if ( kh == daslang_hash_map_detail::HASH_EMPTY ) {
+                pHashes[index] = hashKey;
+                pKeys  [index] = das::forward<KFwd>(key);
+                ++size_;
+                return { size_t(index), true };
+            } else if ( kh == hashKey && key_equal_(pKeys[index], key) ) {
+                return { size_t(index), false };
+            }
+            index = daslang_hash_map_detail::next_probe_slot(index, mask);
+        }
+    }
+
+    void grow () {
+        const size_t new_cap = hashes_.empty()
+            ? daslang_hash_map_detail::minCapacity
+            : hashes_.size() * 2;
+        rehash_into(new_cap);
+    }
+
+    void rehash_into ( size_t new_cap ) {
+        das::vector<uint64_t> new_hashes(new_cap, daslang_hash_map_detail::HASH_EMPTY);
+        das::vector<K>        new_keys(new_cap);
+        const uint64_t mask = new_cap - 1;
+        for ( size_t i = 0, n = hashes_.size(); i < n; ++i ) {
+            const uint64_t kh = hashes_[i];
+            if ( kh == daslang_hash_map_detail::HASH_EMPTY ) continue;
+            uint64_t j = kh & mask;
+            while ( new_hashes[j] != daslang_hash_map_detail::HASH_EMPTY ) {
+                j = daslang_hash_map_detail::next_probe_slot(j, mask);
+            }
+            new_hashes[j] = kh;
+            new_keys  [j] = das::move(keys_[i]);
+        }
+        hashes_ = das::move(new_hashes);
+        keys_   = das::move(new_keys);
     }
 };
 

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -369,6 +369,9 @@ namespace das {
         return *this;
     }
 
+    // Guarded: see ast_serializer.h note. Under DAS_CUSTOM_HASH=0 these would
+    // duplicate the das_hash_map definitions above (identical aliases).
+#if DAS_CUSTOM_HASH
     template <typename K, typename V, typename H, typename E>
     void AstSerializer::serialize_hash_map ( das_insert_only_hash_map<K, V, H, E> & value ) {
         dtag(HASH_TAG("DasHashmap"));
@@ -394,6 +397,7 @@ namespace das {
         serialize_hash_map<K, V, H, E>(value);
         return *this;
     }
+#endif
 
     template <typename V>
     AstSerializer & AstSerializer::operator << ( safebox_map<V> & box ) {
@@ -2694,7 +2698,7 @@ namespace das {
     }
 
     uint32_t AstSerializer::getVersion () {
-        static constexpr uint32_t currentVersion = 83;
+        static constexpr uint32_t currentVersion = 84;
         return currentVersion;
     }
 

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -369,6 +369,32 @@ namespace das {
         return *this;
     }
 
+    template <typename K, typename V, typename H, typename E>
+    void AstSerializer::serialize_hash_map ( das_insert_only_hash_map<K, V, H, E> & value ) {
+        dtag(HASH_TAG("DasHashmap"));
+        if ( writing ) {
+            uint64_t size = value.size(); *this << size;
+            for ( auto & item : value ) {
+                *this << item.first << item.second;
+            }
+            return;
+        }
+        uint64_t size = 0; *this << size;
+        das_insert_only_hash_map<K, V, H, E> deser;
+        deser.reserve(size);
+        for ( uint64_t i = 0; i < size; i++ ) {
+            K k; V v; *this << k << v;
+            deser.emplace(das::move(k),das::move(v));
+        }
+        value = das::move(deser);
+    }
+
+    template <typename K, typename V, typename H, typename E>
+    AstSerializer & AstSerializer::operator << ( das_insert_only_hash_map<K, V, H, E> & value ) {
+        serialize_hash_map<K, V, H, E>(value);
+        return *this;
+    }
+
     template <typename V>
     AstSerializer & AstSerializer::operator << ( safebox_map<V> & box ) {
         serialize_hash_map<uint64_t, V, skip_hash, das::equal_to<uint64_t>>(box);


### PR DESCRIPTION
## Summary

Adds insert-only sibling classes to `das_hash_map.h` and switches the 8 `Module` class fields that are never erased to use them.

### Header — `daslang_insert_only_hash_{map,set}`

Strict subset of the regular `daslang_hash_{map,set}` API — same template parameters, same layout (three parallel `hashes_/keys_/values_` vectors), same load factor cap (0.5), same hashing, same `find_index` code. Differences:

- No `erase()` API
- No `tombstones_` counter, no `rehash_same_capacity` path
- `reserve_slot` drops the `HASH_KILLED` branch + `insertI` tracking (one fewer compare in the insert inner loop)
- Iterator skip is `== HASH_EMPTY` instead of `<= HASH_KILLED`

For the find path: bytewise-identical to the regular version. Insert-only is a **type-level signal** that the table is grow-only by design.

### Module class — switched fields

Audited every `das_hash_map` / `das_map` member of `Module` in `ast.h` against `.erase(` and `->erase(` calls across all of `src/` and `modules/` — zero matches for these 8:

| Field             | Old type                                              | New type                                                     |
|-------------------|-------------------------------------------------------|--------------------------------------------------------------|
| `handleTypes`     | `das_hash_map<uint64_t, Annotation *>`                | `das_insert_only_hash_map<uint64_t, Annotation *>`           |
| `callThis`        | `mutable das_map<string, ExprCallFactory>`            | `mutable das_insert_only_map<string, ExprCallFactory>`       |
| `typeInfoMacros`  | `das_map<string, unique_ptr<TypeInfoMacro>>`          | `das_insert_only_map<string, unique_ptr<TypeInfoMacro>>`     |
| `annotationData`  | `das_map<uint64_t, uint64_t>`                         | `das_insert_only_map<uint64_t, uint64_t>`                    |
| `requireModule`   | `das_hash_map<Module *, bool>`                        | `das_insert_only_hash_map<Module *, bool>`                   |
| `typeMacros`      | `das_map<string, unique_ptr<TypeMacro>>`              | `das_insert_only_map<string, unique_ptr<TypeMacro>>`         |
| `readMacros`      | `das_map<string, unique_ptr<ReaderMacro>>`            | `das_insert_only_map<string, unique_ptr<ReaderMacro>>`       |
| `options`         | `das_hash_map<string, Type>`                          | `das_insert_only_hash_map<string, Type>`                     |

### `das_config.h` — aliases

Added `das_insert_only_map`, `das_insert_only_set`, `das_insert_only_hash_map`, `das_insert_only_hash_set` parallel to the existing `das_*` aliases. Under `DAS_CUSTOM_HASH=0`, they degrade gracefully to `std::unordered_*` (API superset — code not using `erase` compiles either way).

### Supporting infrastructure

- `das_common.h`: `ordered()` overloads for the new types (used by `ast_module.cpp`, `ast_parse.cpp`, `module_builtin_ast.cpp` for deterministic iteration).
- `ast_serializer.h` + `module_builtin_ast_serialize.cpp`: `AstSerializer::operator<<` and `serialize_hash_map` overloads for the insert-only map (used by `Module::serialize` for `annotationData` and `requireModule`).

### `examples/hash/` — bench suite

Standalone CMake project modeled on `examples/sort/`. Three executables:

1. `example_hash_bench` — main matrix: `std::unordered_*` vs `das::daslang_hash_*` vs `absl::flat_hash_*`, across 5 key shapes (`const char*`, `std::string`, `uint64_t`, `void* (32B)`, `void* (128B)`), 3 sizes (1k/10k/100k), 3 workloads (insert / churn / find x10). 270 measured cells with probe-stats tables.
2. `example_hash_func_bench` — hash function vs table mechanics isolation: 2×2 cross of `{das_hash_map, absl::flat_hash_map} x {daslang_hash, absl::Hash}` on find x10.
3. `example_hash_insert_only_bench` — regular vs insert-only on find x10.

Standalone, not registered in the top-level build (same convention as `examples/sort/`). Pulls Abseil via `FetchContent`.

## Test plan

- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests` — **8422 tests, 8422 passed, 0 failed, 0 errors**
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — **7811 tests, 7811 passed, 0 failed, 0 errors**
- [x] `cmake -S examples/hash -B build/example_hash_bench && cmake --build build/example_hash_bench --config Release -j` — all three bench targets build
- [x] Each bench runs to completion with no `FAIL:` lines

No `.das` files changed → lint / detect-dupe / format / doc-regen steps skipped per make-pr skill.

Co-Authored-By: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;
