### PR TITLE
linq_fold group_by: inner-select-sum splice — closes #2721 deferred follow-up

### DIFF
--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -33,8 +33,9 @@ See `~/.claude/plans/keen-hopping-balloon.md` and `~/.claude/plans/enumerated-ba
 | 3d | `select + where + terminator` splice arm via `replaceVariablePeeling` (new helper in `daslib/templates_boost.das`). Substitutes the projection into the where predicate, peeling the typer-inserted ExprRef2Value wrappers that would otherwise be left orphaned around a non-reference value. Bails to tier 2 when the projection has side effects (would double-evaluate). Lands all four terminator lanes (ARRAY / COUNTER / ACCUMULATOR / EARLY_EXIT). | ✅ done |
 | 3+ BufferReverse | `[where_*]?[select?] \|> reverse [\|> take(N)]? [\|> {to_array, count, first, first_or_default}]?` — single-pass prefilter into buffer + `reverse_inplace` + optional `resize(min(N,len))`; count/first lanes elide the buffer entirely (counter or last-survivor tracker). | ✅ |
 | 3+ BufferDistinct | `[where_*]?[select?] \|> distinct[_by(key)] [\|> take(N)]? [\|> {to_array, count, sum, long_count}]?` — streaming dedup via `table<unique_key>` integrated into the prefilter loop; take(N) → break-after-N early-exit (guard placed BEFORE the consume site so non-positive N short-circuits); count terminator elides the buffer and returns `length(seen)`. `first`/`first_or_default`/`min`/`max`/`average` after `distinct` cascade to tier 2. | ✅ core |
-| 3+ BufferGroupBy | `src \|> group_by[_lazy](key) \|> select(group_proj) [\|> {to_array, count}]?` — incremental-aggregate fusion: emits `table<unique_key; tuple<KT; AccT>>` updated per element. Recognized reducers: `_._1 \|> {length, count, sum, long_count}`. Bare + named-tuple wrap `(K=_._0, V=_._1\|>reducer)` both supported. Bails to tier 2 for inner-select-sum, multi-reducer, `having_*`, **or any upstream `where_*`/`select*` between source and group_by** (upstream fusion deferred). | ✅ core |
-| 3+ Buffer remainder | MultiSourceZip, BufferedJoin, inner-select-sum (groupby_sum gap), group_by min/max/first/average reducers, multi-reducer named tuples. Currently cascade to tier 2 array-shape. | ⏳ |
+| 3+ BufferGroupBy | `src \|> group_by[_lazy](key) \|> select(group_proj) [\|> {to_array, count}]?` — incremental-aggregate fusion: emits `table<unique_key; tuple<KT; AccT>>` updated per element. Recognized reducers: `_._1 \|> {length, count, sum, long_count}`. Bare + named-tuple wrap `(K=_._0, V=_._1\|>reducer)` both supported. Bails to tier 2 for multi-reducer, `having_*`, **or any upstream `where_*`/`select*` between source and group_by** (upstream fusion deferred). | ✅ core |
+| 3+ BufferGroupBy — inner-select-sum (PR-A1) | Recognizes `_._1 \|> select(<lambda>) \|> sum` after `group_by_lazy(key)`. Splice peels the inner lambda body and inlines it directly into the per-element `entry._1 += <body>` site, accumulator type derived from the outer sum's resolved return type. Per-element emission split into miss-branch (init) and hit-branch (incremental update) to support this and the future min/max/first arms in PR-A2. Bare body and named-tuple wrap both supported. | ✅ |
+| 3+ Buffer remainder | MultiSourceZip, BufferedJoin, group_by min/max/first/average reducers, multi-reducer named tuples. Currently cascade to tier 2 array-shape. | ⏳ |
 | 4 | Final coverage pass + docs; full 3-way comparison table refresh; parity-test sweep | ⏳ |
 
 ## Baselines (100K rows, INTERP mode)
@@ -61,7 +62,7 @@ Notation: `—` means the variant is not applicable for this benchmark (operator
 | sort_first | `order_by → first` | 37 | 2170 | 2238 |
 | sort_take | `order_by → take` | 38 | 2188 | 2269 |
 | groupby_count | `group_by → select(_, length)` | 140 | 70 | 76 → **33** (this PR) |
-| groupby_sum | `group_by → select(_, select → sum)` | 172 | 101 | 107 (deferred — inner-select-sum) |
+| groupby_sum | `group_by → select(_, select → sum)` | 172 | 101 | 36 (PR-A1 inner-select-sum) |
 | chained_where | `where → where → count` | 36 | 45 | 17 |
 | zip_dot_product | `zip → select → sum` | — | 53 | 37 |
 | join_count | `join → count` | —\*\* | 116 | 122 |
@@ -365,6 +366,7 @@ Bails to tier 2 cascade on: inner-select-sum (`_._1 |> select(<inner>) |> sum` �
 | groupby_count | `each(arr) → group_by(brand) → select(brand, length) → to_array` | 141 | 71 | 76 | **37** | **2.1× over prev / 1.9× over m3 / 3.8× over m1 SQL** |
 | reverse_take (NEW) | `each(arr) → reverse → take(10) → to_array` | 0\* | 22 | — | **34** | regression vs m3 — see footnote |
 | groupby_sum (deferred) | `each(arr) → group_by(brand) → select(brand, select(price) → sum) → to_array` | 173 | 98 | 107 | **108** | unchanged — inner-select-sum (see follow-up) |
+| groupby_sum (PR-A1, inner-select-sum) | same chain | 174 | 101 | 108 | **36** | **3× over prev / 2.8× over m3 / 4.8× over m1 SQL** — closes the deferred follow-up |
 
 **`distinct_count` win**: plain LINQ materializes a full distinct array then counts. The splice fuses streaming dedup into a single pass over the source, producing the buffer once. **`distinct_take`** is the extreme case — both m3 and m3f use matching `each(arr)` iterator sources (so plain LINQ's lazy `distinct().take()` *also* early-exits on the iterator). The splice's win over m3 (~30 → ~0 ns/op) comes from eliminating per-yield generator-dispatch overhead in the lazy chain, not from "lazy vs eager source" comparison.
 
@@ -373,6 +375,29 @@ Bails to tier 2 cascade on: inner-select-sum (`_._1 |> select(<inner>) |> sum` �
 **`reverse_take` regression vs m3** (34 vs 22 ns/op): both variants materialize the full source into a buffer (the iterator-form `reverse()` in [linq.das:234](daslib/linq.das#L234) does it via `generator capture` + per-yield indexing; the splice does it via `push_clone` in the prefilter loop). The cost difference is the second pass: m3's generator yields `buffer[len-i-1]` lazily, so `take(TAKE_N)` only triggers N yields; the splice instead calls `reverse_inplace(buf)` (full O(length) swap) and then `resize(N)`. For TAKE_N << length the lazy-yield approach wins because the reverse is bounded to N instead of length. The splice still wins the headline shape (`reverse |> to_array` without take) where both variants pay full-length cost but the splice avoids the generator-dispatch overhead. A future optimization could detect `reverse |> take(N)` on array-typed sources and emit a backward index loop bounded to `[max(0, len-N), len)` — deferred. \* m1 SQL: `ORDER BY id DESC LIMIT 10` collapses to 0 ns/op via index.
 
 **`groupby_sum` unchanged**: the benchmark uses `g._1 |> _select($(c : Car) => c.price) |> _sum()` — an inner-select-sum chain. The G4 recognizer covers bare `_._1 |> sum` but doesn't yet inline the inner projection into the `+=` site. Falls back to tier 2 array-shape (correct but slow). Deferred to follow-up (~80 LOC; see plan).
+
+## Phase 3+ groupby reducer expansion — inner-select-sum (PR-A1)
+
+Closes the explicit deferred-follow-up from PR #2721. Two interlocking changes:
+
+1. **Miss/hit emission restructure** in `plan_group_by`. The per-element splice splits on `addr(entry) == addr(dummy)`: on miss, run a `missInit` expression (acc starts at the first-element value); on hit, run a `hitUpdate` expression (incremental update). Observationally equivalent for the existing arms (`count`/`length`/`long_count`/`sum`) — same `entry._1 = 1; commit` vs `entry._1++` vs `entry._1 = it; commit` vs `entry._1 += it` — but the per-branch split lets each reducer pick its own per-side shape independently, unlocking the inner-select-sum arm below and future arms in PR-A2 (`min`/`max`/`first` need different work on miss vs hit). All G2/G3/G8 AST tests stay green with a new `count_call(body, "key_exists") == 0` assertion pinning the single-hash hot path from PR #2721.
+
+2. **Inner-select-sum recognizer**. `is_bucket_reducer_call` extended to match `sum(select(<bind>._1, <lambda>))` (the AST shape after typer resolves `_._1 |> select(<lambda>) |> sum()`). On match, `plan_group_by` peels the inner lambda via `fold_linq_cond(innerLambda, itName)` and splices the body directly into `entry._1 += <inner_body>` (hit) / `entry._1 = <inner_body>` (miss). Accumulator type derived from the OUTER sum call's `_type` (the inner projection's result type, typer-resolved). Both bare body (`_._1 |> select(p) |> sum`) and named-tuple wrap (`(K=_._0, S=_._1 |> select(p) |> sum)`) supported.
+
+### Headline (PR-A1)
+
+| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (prev) | m3f (this PR) | Win |
+|---|---|---:|---:|---:|---:|---:|
+| groupby_sum | `each(arr) → group_by(brand) → select((brand, select(price) → sum)) → to_array` | 174 | 101 | 108 | **36** | **3× over prev / 2.8× over m3 / 4.8× over m1 SQL** |
+| groupby_count (regression check) | `each(arr) → group_by(brand) → select((brand, length)) → to_array` | 142 | 71 | 37 | **36** | parity (within noise) — A.1 restructure preserves the count splice |
+
+`groupby_sum` matches `groupby_count`'s ~36 ns/op headline: same number of allocations (1, the result array), same per-element work (single hash + entry._1 mutation), no per-bucket array materialization. The splice now beats SQL on this shape too.
+
+### Deferred for PR-A2 (next PR in the series)
+
+- bare `_._1 |> min` / `|> max` / `|> first` reducers + `inner-select-min` / `inner-select-max` / `inner-select-first`
+- multi-reducer named tuples `(K=..., N=..|>length, S=..|>sum, M=..|>min)`
+- `average` reducer (needs 2-slot per-key acc — separate follow-up after PR-A2)
 
 ## Operator-coverage checklist (parity tests)
 
@@ -385,7 +410,7 @@ The 24 benchmarks above cover the most common shapes. The end-game target is one
 | `test_linq_querying.das` | any/all/contains | any_match, all_match, contains_match | ✅ core |
 | `test_linq_transform.das` | select/select_many/zip | to_array_filter, zip_dot_product | ✅ select/zip; `select_many` ⏳ |
 | `test_linq_sorting.das` | order/order_by/reverse | sort_first, sort_take, select_where_order_take, reverse_take | ✅ ascending + `order_descending` (Phase 3); ✅ `reverse` (this PR; `reverse \|> take(N)` shape is a regression vs lazy iterator — see Phase 3+ notes) |
-| `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum | ✅ count/long_count/bare-sum reducers + named-tuple wrap (this PR); ⏳ inner-select-sum, min/max/first/average, multi-reducer, `having_` |
+| `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum | ✅ count/long_count/bare-sum + inner-select-sum (PR-A1) + named-tuple wrap; ⏳ min/max/first/average, multi-reducer, `having_` |
 | `test_linq_join.das` | join/left_join/right_join/full_outer/cross | join_count | ✅ inner; outer joins + cross ⏳ |
 | `test_linq_partition.das` | take/skip/take_while/skip_while/chunk | take_count, skip_take, take_sum_aggregate, take_count_filtered | ✅ take/skip in splice lanes; `_while` + `chunk` ⏳ |
 | `test_linq_set.das` | distinct/union/except/intersect/unique | distinct_count, distinct_take | ✅ distinct + distinct_by (streaming dedup, this PR); union/except/intersect/unique ⏳ |

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1669,19 +1669,35 @@ def private is_bind_field_access(expr : Expression?; bindName : string; fieldInd
 }
 
 [macro_function]
-def private is_bucket_reducer_call(expr : Expression?; bindName : string) : tuple<bool; string> {
-    // Detects `<bindName>._1 |> reducer` where reducer ∈ {length, count, sum, long_count}.
-    if (expr == null || !(expr is ExprCall)) return (false, "")
+def private is_bucket_reducer_call(expr : Expression?; bindName : string) : tuple<bool; string; Expression?> {
+    // Returns (matched, reducerName, innerLambda). innerLambda is non-null only for sum_inner_select.
+    if (expr == null || !(expr is ExprCall)) return (false, "", null)
     let c = expr as ExprCall
-    if (c.func == null) return (false, "")
+    if (c.func == null) return (false, "", null)
     var fnName = string(c.func.name)
     if (c.func.fromGeneric != null) {
         fnName = string(c.func.fromGeneric.name)
     }
-    if ((fnName != "length" && fnName != "count" && fnName != "sum" && fnName != "long_count")
-            || (c.arguments |> length) != 1
-            || !is_bind_field_access(c.arguments[0], bindName, 1)) return (false, "")
-    return (true, fnName)
+    if ((c.arguments |> length) != 1) return (false, "", null)
+    if (fnName == "length" || fnName == "count" || fnName == "sum" || fnName == "long_count") {
+        if (is_bind_field_access(c.arguments[0], bindName, 1)) return (true, fnName, null)
+    }
+    if (fnName == "sum") {
+        let inner = c.arguments[0]
+        if (inner != null && inner is ExprCall) {
+            let innerCall = inner as ExprCall
+            if (innerCall.func != null) {
+                var innerName = string(innerCall.func.name)
+                if (innerCall.func.fromGeneric != null) {
+                    innerName = string(innerCall.func.fromGeneric.name)
+                }
+                if (innerName == "select"
+                        && (innerCall.arguments |> length) == 2
+                        && is_bind_field_access(innerCall.arguments[0], bindName, 1)) return (true, "sum_inner_select", innerCall.arguments[1])
+            }
+        }
+    }
+    return (false, "", null)
 }
 
 [macro_function]
@@ -1725,11 +1741,16 @@ def private plan_group_by(var expr : Expression?) : Expression? {
     var groupProjBody = fold_linq_cond(groupProjCall.arguments[1], bindName)
     var reducerName : string  = ""
     var usesNamedTuple = false
+    var innerLambda : Expression?     // for sum_inner_select: raw inner select lambda, peeled below
     // Case A: body is the reducer itself (bare form, no key in output)
     {
-        let (ok, rn) = is_bucket_reducer_call(groupProjBody, bindName)
+        let (ok, rn, innerLam) = is_bucket_reducer_call(groupProjBody, bindName)
         if (ok) {
             reducerName = rn
+            // Clone to drop const propagated through tuple destructure; planner mutates innerBody later.
+            if (innerLam != null) {
+                innerLambda = clone_expression(innerLam)
+            }
         }
     }
     // Case B: body is an ExprMakeTuple(isKeyValue=true) with 2 fields:
@@ -1737,20 +1758,37 @@ def private plan_group_by(var expr : Expression?) : Expression? {
         let mt = groupProjBody as ExprMakeTuple
         if ((mt.values |> length) == 2) {
             if (is_bind_field_access(mt.values[0], bindName, 0)) {
-                let (ok, rn) = is_bucket_reducer_call(mt.values[1], bindName)
+                let (ok, rn, innerLam) = is_bucket_reducer_call(mt.values[1], bindName)
                 if (ok) {
                     reducerName = rn
+                    if (innerLam != null) {
+                innerLambda = clone_expression(innerLam)
+            }
                     usesNamedTuple = true
                 }
             }
         }
     }
-    // v1 reducers: length/count (Acc=int), long_count (Acc=int64), sum (Acc=elemT). Inner-select-sum is deferred (see groupby_sum follow-up).
+    // Recognized: length/count (Acc=int), long_count (Acc=int64), sum (Acc=elemT), sum_inner_select (Acc=innerBodyT).
     if (reducerName == ""
-            || (reducerName != "length" && reducerName != "count" && reducerName != "long_count" && reducerName != "sum")) return null
+            || (reducerName != "length" && reducerName != "count" && reducerName != "long_count"
+                && reducerName != "sum" && reducerName != "sum_inner_select")) return null
     let isLongCountReducer = reducerName == "long_count"
-    let isSumReducer = reducerName == "sum"
-    var elemType = strip_const_ref(clone_type(top._type.firstType))
+    let isSumReducer = reducerName == "sum" || reducerName == "sum_inner_select"
+    let isSumInnerSelectReducer = reducerName == "sum_inner_select"
+    var sourceElemType = strip_const_ref(clone_type(top._type.firstType))
+    var innerBody : Expression?
+    var accType : TypeDeclPtr
+    if (isSumInnerSelectReducer) {
+        // Peel inner select's lambda body, renaming `_` → itName for direct splice into `entry._1 += <body>`.
+        innerBody = fold_linq_cond(innerLambda, itName)
+        if (innerBody == null || groupProjBody._type == null) return null
+        // accType from outer sum's _type (peeled body's _type is null — apply_template doesn't re-type-infer).
+        accType = strip_const_ref(clone_type(groupProjBody._type))
+    } else {
+        accType = clone_type(sourceElemType)
+    }
+    var elemType = sourceElemType
     // Named-tuple wrap reuses the user's body type (preserves field-name hints); bare reducer synthesizes tuple<KeyT; ResultT> below.
     var tabValueType : TypeDeclPtr
     if (usesNamedTuple) {
@@ -1778,12 +1816,12 @@ def private plan_group_by(var expr : Expression?) : Expression? {
             var $i(dummyName) : tuple<typedecl(invoke($e(keyBlkD), default<$t(elemType)>)) -const -&; int64>
         }
     } elif (isSumReducer) {
+        var accType2 = clone_type(accType)
         stmts |> push <| qmacro_expr() {
-            var inscope $i(tabName) : table<typedecl(_::unique_key(invoke($e(keyBlk1), default<$t(elemType)>))); tuple<typedecl(invoke($e(keyBlk2), default<$t(elemType)>)) -const -&; $t(elemType)>>
+            var inscope $i(tabName) : table<typedecl(_::unique_key(invoke($e(keyBlk1), default<$t(elemType)>))); tuple<typedecl(invoke($e(keyBlk2), default<$t(elemType)>)) -const -&; $t(accType)>>
         }
-        var elemType2 = clone_type(elemType)
         stmts |> push <| qmacro_expr() {
-            var $i(dummyName) : tuple<typedecl(invoke($e(keyBlkD), default<$t(elemType)>)) -const -&; $t(elemType2)>
+            var $i(dummyName) : tuple<typedecl(invoke($e(keyBlkD), default<$t(elemType)>)) -const -&; $t(accType2)>
         }
     } else {
         // count / length — Acc=int
@@ -1794,16 +1832,40 @@ def private plan_group_by(var expr : Expression?) : Expression? {
             var $i(dummyName) : tuple<typedecl(invoke($e(keyBlkD), default<$t(elemType)>)) -const -&; int>
         }
     }
-    // `tab?[uk] ?? dummy` returns ref to existing entry OR to dummy on miss — single hash op per element. addr-compare detects the dummy path and commits.
+    // `tab?[uk] ?? dummy` returns ref to existing entry OR to dummy on miss — single hash op per element. addr-compare splits into miss-branch (init+commit) and hit-branch (incremental update); the split lets each reducer pick its own init vs update shape independently.
     var keyBlk3 = clone_expression(keyBlock)
-    var accUpdate : Expression?
-    if (isSumReducer) {
-        accUpdate = qmacro_expr() {
+    var missInit : Expression?
+    var hitUpdate : Expression?
+    if (isLongCountReducer) {
+        missInit = qmacro_expr() {
+            $i(entryName)._1 = 1l
+        }
+        hitUpdate = qmacro_expr() {
+            $i(entryName)._1 ++
+        }
+    } elif (isSumInnerSelectReducer) {
+        // Two clones — each $e(...) splice consumes its expression.
+        var innerBody1 = clone_expression(innerBody)
+        var innerBody2 = clone_expression(innerBody)
+        missInit = qmacro_expr() {
+            $i(entryName)._1 = $e(innerBody1)
+        }
+        hitUpdate = qmacro_expr() {
+            $i(entryName)._1 += $e(innerBody2)
+        }
+    } elif (isSumReducer) {
+        missInit = qmacro_expr() {
+            $i(entryName)._1 = $i(itName)
+        }
+        hitUpdate = qmacro_expr() {
             $i(entryName)._1 += $i(itName)
         }
     } else {
-        // count / length / long_count all use postfix ++
-        accUpdate = qmacro_expr() {
+        // count / length — int accumulator
+        missInit = qmacro_expr() {
+            $i(entryName)._1 = 1
+        }
+        hitUpdate = qmacro_expr() {
             $i(entryName)._1 ++
         }
     }
@@ -1813,11 +1875,13 @@ def private plan_group_by(var expr : Expression?) : Expression? {
             let $i(ukName) = _::unique_key($i(kName))
             unsafe {
                 var $i(entryName) & = $i(tabName)?[$i(ukName)] ?? $i(dummyName)
-                $e(accUpdate)
                 if (addr($i(entryName)) == addr($i(dummyName))) {
+                    $e(missInit)
                     $i(dummyName)._0 = $i(kName)
                     $i(tabName)[$i(ukName)] = $i(dummyName)
                     $i(dummyName) = default<typedecl($i(dummyName))>
+                } else {
+                    $e(hitUpdate)
                 }
             }
         }

--- a/mouse-data/docs/group-by-first-key-wins-single-hash-tab-dummy-addr-compare.md
+++ b/mouse-data/docs/group-by-first-key-wins-single-hash-tab-dummy-addr-compare.md
@@ -1,0 +1,70 @@
+---
+slug: group-by-first-key-wins-single-hash-tab-dummy-addr-compare
+title: How do I splice an incremental-aggregate group_by with first-key-wins semantics in ONE hash op per element on hits?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+**Pattern**: `tab?[uk] ?? dummy` ref-binding + `addr(entry) == addr(dummy)` miss detection. Single hash op per element on hits, two on misses (insert). Used by `plan_group_by` in `daslib/linq_fold.das` (PR #2721).
+
+### The shape
+
+```das
+// OUT of the for-loop: per-table dummy of the value type.
+var dummy : tuple<KT; AccT>
+
+for (it in src) {
+    let k = <key-expr>
+    let uk = _::unique_key(k)
+    unsafe {
+        // ?[uk] returns a ref to existing entry; ?? falls back to dummy on miss.
+        var entry & = tab?[uk] ?? dummy
+        // Aggregator update runs unconditionally — on a hit it writes through to
+        // the table entry, on a miss it writes to dummy (then we transfer below).
+        entry._1 += <update-expr>
+        if (addr(entry) == addr(dummy)) {
+            // Miss: this is a fresh key. Stamp the key (first-key-wins) and
+            // promote dummy into the table at uk, then RESET dummy for next miss.
+            dummy._0 = k
+            tab[uk] = dummy
+            dummy = default<typedecl(dummy)>
+        }
+    }
+}
+```
+
+### Why each piece
+
+- **`tab?[uk] ?? dummy`** — `?[k]` is the safe lookup (no auto-insert; returns a ref to the entry or null). `??` substitutes `dummy` when null. Net cost: ONE hash op per element on the hot path (the cache-hit case).
+- **`addr(entry) == addr(dummy)`** — ref-binding identity check (idiom from `apply_in_context.das:99`). True iff the lookup missed and we got the fallback. Avoids a second `key_exists` call.
+- **`var entry & =`** the ampersand is critical: `var entry = tab?[uk] ?? dummy` would copy; `& =` rebinds to the same storage.
+- **`dummy._0 = k` only on miss** — first-key-wins matches reference `group_by_lazy_impl` (key stored once per bucket, on creation only). Re-hits do not touch `_0`.
+- **`tab[uk] = dummy` on miss** — the auto-insert form. This IS the second hash op on the miss path; acceptable because miss count == |distinct keys|, not |elements|.
+- **`dummy = default<typedecl(dummy)>`** — reset BEFORE the next miss so accumulator state doesn't bleed across keys. Cheap (stack zero), and only fires per miss. `typedecl(dummy)` extracts the type from the var so the planner doesn't need to thread the type expression separately.
+- **`var dummy : tuple<KT; AccT>` OUT of the for-loop** — declaring inside the loop would cost a stack-zero per element. Hoisted = one zero at function entry plus per-miss resets.
+
+### Performance vs naive approaches
+
+| Pattern | Hash ops per ELEMENT (hot path) | Notes |
+|---|---:|---|
+| `if (!key_exists(uk)) tab[uk] = …; tab[uk]._1 += …` | 2-3 | extra `key_exists` + auto-insert + read |
+| `let isNew = !key_exists(uk); var e & = tab[uk]; if (isNew) e._0 = k; e._1 += …` | 2 | key_exists + auto-insert |
+| **`tab?[uk] ?? dummy` + addr-compare** | **1** | safe-lookup only; auto-insert ONLY on miss |
+
+Concrete impact on `groupby_count` at 100K rows: pattern 2 cost 43 ns/op (regression from 33 baseline); this pattern recovered to 37 ns/op while keeping first-key-wins correctness.
+
+### When this pattern applies
+
+- Per-element incremental aggregate fusion where update is idempotent on hits (`+=`, `++`, `max`, `min` once an init flag isn't needed).
+- Any AST shape that needs "lookup-or-create with side-channel write to per-key state" with minimal hot-path overhead.
+- NOT for `_._1 |> first` / `min`/`max`/`average` reducers that need a "is this the first time?" branch — those need an explicit init-flag tuple slot.
+
+### Test guard
+
+In emitter tests, assert `count_call(body, "key_exists") == 0` and `count_call(body, "unique_key") == 1` per fresh-key branch — proves the single-hash hot path didn't regress.
+
+See [[daslib-macro-boost-has-sideeffects-predicate]] for the macro-time purity check that decides whether the key expression can be safely evaluated once per element vs needing a bind.
+
+## Questions
+- How do I splice an incremental-aggregate group_by with first-key-wins semantics in ONE hash op per element on hits?

--- a/mouse-data/docs/linq-bench-eager-vs-lazy-distinct-arr-vs-each-arr.md
+++ b/mouse-data/docs/linq-bench-eager-vs-lazy-distinct-arr-vs-each-arr.md
@@ -1,0 +1,64 @@
+---
+slug: linq-bench-eager-vs-lazy-distinct-arr-vs-each-arr
+title: Why does my linq benchmark show wildly different `m3` numbers between `arr |> distinct() |> ...` and `each(arr) |> distinct() |> ...` — is `distinct` eager on arrays?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+**Yes — `distinct(arr)` is the eager array-shape overload; `distinct()` on an iterator is the lazy generator.** Different code paths in `daslib/linq.das`, very different per-element cost. Benchmark authors MUST match source shapes across the m1/m3/m3f lanes for apples-to-apples comparison.
+
+### The two overloads
+
+`daslib/linq.das` exposes two `distinct` shapes:
+
+1. **Array-shape (eager)** — `def distinct(arr : array<auto(TT)>) : array<TT>` (`linq.das` ~line 668 area, see also `set` lane). Walks the whole array, builds a `table<TT>` of seen keys, returns a new array. O(N) work UP FRONT regardless of what consumes it.
+2. **Iterator-shape (lazy generator)** — `def distinct(it : iterator<auto(TT) const -&>) : iterator<TT -&>` (also `linq.das:668` area). Returns a generator that yields the next unseen value on demand. O(1) per yield, stops on the next `break` from the consumer.
+
+`take(N)` after the lazy form consumes N yields then stops. `take(N)` after the eager form is a slice of an already-materialized full array.
+
+### The benchmark trap
+
+The bug in `benchmarks/sql/distinct_take.das` (caught during PR #2721):
+
+```das
+// m3 — eager: distinct(arr) materializes ALL distinct values, THEN take(3)
+let rows <- (arr |> _select(_.brand) |> distinct() |> take(TAKE_N) |> to_array())
+
+// m3f — lazy: each(arr) → iterator-distinct, take(3) stops on the 3rd yield
+let rows <- _fold(each(arr)._select(_.brand).distinct().take(TAKE_N).to_array())
+```
+
+Both compile, both produce the right answer (`take(3)` of N distinct), but m3 walks the entire 100K-row source while m3f exits at the 3rd distinct (position ~3 with cycling brands). `m3` reports something like 30 ns/op; `m3f` reports 0 ns/op. The headline "lazy beats eager 30:0" is real but it's NOT a splice-vs-cascade comparison — it's an eager-vs-lazy comparison with the splice as confounder.
+
+### The fix
+
+Match source shapes:
+
+```das
+// m3 — lazy (matches m3f's source)
+unsafe {
+    let rows <- (each(arr) |> _select(_.brand) |> distinct() |> take(TAKE_N) |> to_array())
+}
+```
+
+Now both lanes share the iterator-form `distinct()`. The remaining delta is purely splice vs generator-dispatch overhead.
+
+### Why `each(arr)` needs `unsafe`
+
+Calling `each(arr)` outside a for-loop is gated on `unsafe { ... }` — the iterator escapes the scope where the array's lifetime is anchored. Inside `for (x in each(arr))` it's auto-anchored and no `unsafe` is needed. See [[why-does-each-arr-fail-with-unsafe-when-not-source-of-for-loop-outside-a-for-and-what-s-the-alternative-in-a-linq-chain]].
+
+### How to spot this in any new benchmark
+
+- Two lanes both call `op |> distinct()` but one passes `arr` and the other passes `each(arr)` / iterator-comprehension / `to_sequence(arr)`. Mismatch.
+- The "slow" lane's numbers don't scale with `TAKE_N` (it's doing full-source work regardless). The "fast" lane scales linearly with `TAKE_N` (early-exit kicks in).
+- `dasperf` shows the slow lane's hot frame inside `_distinct_impl_array` (eager) vs `_distinct_impl_iterator` / generator step (lazy).
+
+### Affected operators
+
+Same shape issue exists for `reverse(arr)` (eager copy) vs `reverse(iterator)` (lazy yield in reverse — but needs a buffer internally), and any other op with both array and iterator overloads. When in doubt: check `daslib/linq.das` for the operator name to see if there are two overloads.
+
+See [[when-does-peel-each-in-daslib-linq-fold-das-unwrap-each-x-to-x-and-what-s-the-design-rationale]] for how the splice planner normalizes `each(arr)` → `arr` for the source-binding type lookup.
+
+## Questions
+- Why does my linq benchmark show wildly different `m3` numbers between `arr |> distinct() |> ...` and `each(arr) |> distinct() |> ...` — is `distinct` eager on arrays?

--- a/mouse-data/docs/streaming-dedup-take-guard-outer-loop-not-fresh-key-branch.md
+++ b/mouse-data/docs/streaming-dedup-take-guard-outer-loop-not-fresh-key-branch.md
@@ -1,0 +1,74 @@
+---
+slug: streaming-dedup-take-guard-outer-loop-not-fresh-key-branch
+title: In a streaming dedup splice (distinct + take), where should the take(N) break-guard go — top of for-loop or inside the fresh-key branch?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+**Top of the for-loop**, not inside the fresh-key branch. Inner-branch placement still scans duplicates after the Nth fresh key and gives worst-case O(source-length) on adversarial inputs; outer-branch placement gives true O(N-source-positions-until-Nth-fresh-key) early exit.
+
+### The bug
+
+Initial naïve emission for `each(arr) |> distinct() |> take(N) |> to_array()`:
+
+```das
+for (it in src) {
+    if (<where-cond>) {
+        let k = _::unique_key(<projection>)
+        if (!key_exists(seen, k)) {
+            // INNER take-guard — wrong for streaming exit
+            if (taken >= N) { break }
+            seen |> insert(k)
+            buf |> push_clone(<projection>)
+            taken++
+        }
+    }
+}
+```
+
+Looks fine on `[0,1,2,3,4]` with `N=3` — breaks at position 3 on the 4th fresh key. Looks fine on cycling brand inputs where new keys arrive evenly. BUT on `[0,1,2,0,0,0,0,...,0,3]` it scans every duplicate `0` after position 3 because the break is gated on the next fresh-key arrival.
+
+### The fix
+
+```das
+for (it in src) {
+    if (taken >= N) { break }           // OUTER guard — fires on the iteration AFTER hitting N
+    if (<where-cond>) {
+        let k = _::unique_key(<projection>)
+        if (!key_exists(seen, k)) {
+            seen |> insert(k)
+            buf |> push_clone(<projection>)
+            taken++
+        }
+    }
+}
+```
+
+Now on `[0,1,2,0,0,...]` with `N=3`: position 0,1,2 push; position 3 enters the loop, the outer guard fires (`taken == 3 >= 3`), break. Done.
+
+### Subtleties
+
+- **`>=` not `==`** matches the reference `take_impl` semantics for non-positive N (see [[splice-macro-bounded-loop-guard-take-skip-non-positive-n]]).
+- **Inner guard is still semantically correct** — it just leaks performance. Both pass functional parity tests like `[1,2,3,4,5].distinct().take(3) == [1,2,3]`.
+- **Per-iteration cost of the outer guard is one int compare + branch** — cheap, runs once per source element, dominated by the body anyway.
+- **Don't place AFTER `taken++`** — putting `break if (taken >= N)` after the increment causes the break check to land on the NEXT iteration anyway (you've already done the work to push the Nth element, you want to exit at the top of the next iteration before processing the (N+1)th candidate). So either inside the fresh-key branch (wrong, see above) or top of the loop (right).
+
+### Why the bench numbers didn't catch this
+
+Headline bench (`benchmarks/sql/distinct_take.das`) uses `BRAND_COUNT=5`, `TAKE_N=3`, cycling brands. With 5 distinct brands cycling through 100K rows, positions 0,1,2 are distinct, position 3 is the first duplicate, position 4 is distinct (4th), position 5 is the next dup, etc. By position ~3 we already have 3 distinct. Outer guard fires at position 3; inner guard would fire at position 4 when the 4th fresh key arrives. Both produce m3f = 0 ns/op on this distribution. The bench can't distinguish them — but adversarial inputs can. Add a worst-case bench (`[0,1,2] + [0] * 99997 + [3]`) if you need to verify.
+
+### Where to assert in tests
+
+In AST-shape tests, assert `count_break_continue(body, true) >= 1` AND `count_inner_for_loops(body) == 1` (single fused loop) AND the `if (... >= N) break` statement is the FIRST statement of the loop body — not nested in the where-cond, not nested in the fresh-key branch. Walk the for-block's first child:
+
+```das
+let first = forStmt.body[0]
+assert(first is ExprIfThenElse)
+assert(first.cond is ExprOp2 && first.cond.op == ">=")
+```
+
+See [[group-by-first-key-wins-single-hash-tab-dummy-addr-compare]] for the sibling pattern in group_by, and [[chained-select-splice-bind-via-clone-assign-universal]] for the broader splice emission template.
+
+## Questions
+- In a streaming dedup splice (distinct + take), where should the take(N) break-guard go — top of for-loop or inside the fresh-key branch?

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -1615,6 +1615,57 @@ def test_group_by_count_fold_parity(t : T?) {
 }
 
 [test]
+def test_group_by_inner_select_sum_fold_parity(t : T?) {
+    // G4 (PR-A1): inner-select-sum recognized via is_bucket_reducer_call's new arm.
+    // Splice inlines the inner projection into the per-element accumulator update so the
+    // bucket array is never materialized and the inner select-call disappears from the body.
+    t |> run("bare inner-select-sum: per-bucket sum of projected values") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> select(@(x : int) => x * 2) |> sum))
+        // Buckets: 0→{30,21,12} *2 = 126; 1→{10,31} *2 = 82; 2→{20,11} *2 = 62. Total = 270.
+        tt |> equal(3, length(got))
+        var total = 0
+        for (s in got) {
+            total += s
+        }
+        tt |> equal(270, total)
+    }
+    t |> run("named inner-select-sum: preserves K + projected sum") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, T = _._1 |> select(@(x : int) => x * 2) |> sum)))
+        tt |> equal(3, length(got))
+        var perKey : table<int; int>
+        for (item in got) {
+            perKey[item.K] = item.T
+        }
+        tt |> equal(126, perKey[0])   // (30+21+12)*2
+        tt |> equal(82,  perKey[1])   // (10+31)*2
+        tt |> equal(62,  perKey[2])   // (20+11)*2
+    }
+    t |> run("inner-select-sum on empty source → empty result") @(tt : T?) {
+        var empty : array<int>
+        let got <- _fold(empty._group_by(_ % 3)._select(_._1 |> select(@(x : int) => x * 2) |> sum))
+        tt |> equal(0, length(got))
+    }
+    t |> run("inner-select-sum matches plain LINQ reference (parity)") @(tt : T?) {
+        let arr = [10, 20, 30, 11, 21, 31, 12, 22, 32, 13]
+        let foldGot <- _fold(arr._group_by(_ % 4)._select((K = _._0, T = _._1 |> select(@(x : int) => x + 1) |> sum)))
+        let refGot  <- (arr._group_by(_ % 4)._select((K = _._0, T = _._1 |> select(@(x : int) => x + 1) |> sum)))
+        tt |> equal(length(refGot), length(foldGot))
+        var refMap : table<int; int>
+        var foldMap : table<int; int>
+        for (r in refGot) {
+            refMap[r.K] = r.T
+        }
+        for (f in foldGot) {
+            foldMap[f.K] = f.T
+        }
+        // Use ?[k] (safe lookup, no auto-insert) to avoid locking refMap while iterating its keys.
+        for (k in keys(refMap)) {
+            tt |> equal(refMap?[k] ?? -1, foldMap?[k] ?? -1)
+        }
+    }
+}
+
+[test]
 def test_reverse_count_parity(t : T?) {
     // R5: reverse |> count — counter loop, no reverse work.
     t |> run("reverse.count: identity") @(tt : T?) {

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -1951,6 +1951,9 @@ def test_group_by_count_emits_table_no_bucket_arrays(t : T?) {
         t |> equal(0, count_call(body_expr, "group_by_lazy_impl"), "must NOT call impl")
         // unique_key must be invoked per element to derive the seen-table key.
         t |> success(count_call(body_expr, "unique_key") >= 1, "must call _::unique_key per element")
+        // Single-hash hot path: key_exists must NOT appear (the `tab?[uk] ?? dummy` +
+        // addr-compare pattern avoids the extra membership check). See PR #2721.
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path: no key_exists")
         // For-loop count: table-update loop + result-build loop = 2.
         t |> equal(2, count_inner_for_loops(body_expr), "table-update + result-build loops")
     }
@@ -1982,6 +1985,8 @@ def test_group_by_count_named_tuple_preserves_keys(t : T?) {
         // absence of `length` here — `length(tab)` legitimately appears in the
         // reserve hint and would false-positive.)
         t |> success(count_call(body_expr, "unique_key") >= 1, "must call _::unique_key per element")
+        // Single-hash hot path: no key_exists. See PR #2721.
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path: no key_exists")
     }
 }
 
@@ -2007,6 +2012,64 @@ def test_group_by_count_terminator_returns_table_length(t : T?) {
         // Only ONE for-loop (the table-update). Result-build loop is elided when
         // terminator is count (we just return length(tab)).
         t |> equal(1, count_inner_for_loops(body_expr), "single table-update loop, no result loop")
+        // Single-hash hot path: no key_exists. See PR #2721.
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path: no key_exists")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_inner_select_sum_bare_fold() : array<int> {
+    // G4 (PR-A1): bare inner-select-sum body. is_bucket_reducer_call's new arm matches
+    // `sum(select(<bind>._1, <lambda>))`; the inner lambda body is peeled by fold_linq_cond
+    // and inlined into the per-element `entry._1 += <body>` site.
+    return <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> select(@(x : int) => x * 2) |> sum))
+}
+
+[test]
+def test_group_by_inner_select_sum_emits_table_no_inner_select_call(t : T?) {
+    // G4: bare inner-select-sum splices through the new arm. Body must NOT contain
+    // a runtime call to `select` (the inner select is peeled + inlined) and must
+    // preserve the single-hash hot-path fingerprint from PR #2721.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_inner_select_sum_bare_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(0, count_call(body_expr, "group_by_lazy"), "must NOT call group_by_lazy runtime")
+        t |> equal(0, count_call(body_expr, "select"), "inner select must be inlined, not called")
+        t |> success(count_call(body_expr, "unique_key") >= 1, "must call _::unique_key per element")
+        t |> equal(2, count_inner_for_loops(body_expr), "table-update + result-build loops")
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path: no key_exists")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_inner_select_sum_named_fold() : array<tuple<K : int; T : int>> {
+    // G4b: named-tuple-wrap form `(K=_._0, T=_._1|>select(<inner>)|>sum)`. Splice fires
+    // via Case B (named-tuple recognizer); table value type = user's named tuple,
+    // accumulator slot = inner projection result type.
+    return <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, T = _._1 |> select(@(x : int) => x * 2) |> sum)))
+}
+
+[test]
+def test_group_by_inner_select_sum_named_preserves_key(t : T?) {
+    // G4b: named-tuple wrap with inner-select-sum splices and keeps the user's field names.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_inner_select_sum_named_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(0, count_call(body_expr, "group_by_lazy"), "must NOT call group_by_lazy runtime")
+        t |> equal(0, count_call(body_expr, "select"), "inner select must be inlined, not called")
+        t |> success(count_call(body_expr, "unique_key") >= 1, "must call _::unique_key per element")
+        t |> equal(2, count_inner_for_loops(body_expr), "table-update + result-build loops")
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path: no key_exists")
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the explicit deferred-follow-up from PR #2721: the `groupby_sum` benchmark's `_._1 |> select(@(c) => c.price) |> sum()` inner-select-sum shape now splices instead of cascading to tier 2.

Two interlocking changes in `plan_group_by` (`daslib/linq_fold.das`):

### 1. Miss/hit emission restructure (no behavior change for existing arms)

The per-element splice now splits on `addr(entry) == addr(dummy)`: on miss, run `missInit` (acc starts at the first-element value); on hit, run `hitUpdate` (incremental update). Observationally equivalent for the pre-existing `count`/`length`/`long_count`/`sum` arms — same final state — but the per-branch split lets each reducer pick its own per-side shape independently. Unlocks the inner-select-sum arm below and the future `min`/`max`/`first` arms queued for the next PR.

Existing G2/G3/G8 AST tests stay green with a new `count_call(body, "key_exists") == 0` assertion pinning the single-hash hot path from #2721 (the `tab?[uk] ?? dummy` + addr-compare idiom).

### 2. Inner-select-sum recognizer

`is_bucket_reducer_call` extended to match `sum(select(<bind>._1, <lambda>))` — the AST shape after the typer resolves `_._1 |> select(<lambda>) |> sum()`. On match, the planner peels the inner lambda via `fold_linq_cond(innerLambda, itName)` and splices the body directly into `entry._1 += <body>` (hit) / `entry._1 = <body>` (miss). Accumulator type derived from the **outer** sum call's `_type` (the inner projection's typer-resolved result type) — the peeled body's `_type` is null because `apply_template` doesn't re-type-infer. Both bare body `_._1|>select|>sum` and named-tuple wrap `(K=_._0, S=_._1|>select|>sum)` supported.

## Headline (100K rows, INTERP)

| Benchmark | m1 sql | m3 linq | m3f prev | m3f this PR | Win |
|---|---:|---:|---:|---:|---|
| `groupby_sum` | 174 | 101 | 108 | **36** | **3× over prev / 2.8× over m3 / 4.8× over m1 SQL** |
| `groupby_count` (regression check) | 142 | 71 | 37 | **36** | parity — A.1 restructure preserves the count splice |

`groupby_sum` now matches `groupby_count`'s ~36 ns/op: same allocation count (1, the result array), same per-element work (single hash + `entry._1` mutation), no per-bucket array materialization.

## Test plan

- [x] Interp: `tests/linq/test_linq_fold.das` — 239/239 pass; 4 new parity subtests under `test_group_by_inner_select_sum_fold_parity` (bare, named-tuple, empty source, reference-vs-fold comparison).
- [x] Interp: `tests/linq/test_linq_fold_ast.das` — 97/97 pass; G4 (bare) + G4b (named-tuple) target functions and AST-shape tests; G2/G3/G8 gained the `count_call(body, "key_exists") == 0` single-hash fingerprint.
- [x] AOT: same files green after `cmake --build build --target test_aot`.
- [x] `tests/linq/test_linq_group_by.das` (runtime, not splice): 18/18 pass — no incidental regression.
- [x] Format + lint clean on all 4 touched files.
- [x] `benchmarks/sql/groupby_sum.das` + `groupby_count.das` — captured numbers in `LINQ.md`; ran in interp mode.

## Deferred to follow-ups (per plan `~/.claude/plans/modular-stirring-tide.md`)

- **PR-A2**: bare `_._1 |> {min, max, first}` + their inner-select variants; multi-reducer named tuples `(K=..., N=..|>length, S=..|>sum, M=..|>min)`.
- **Separate follow-up**: `average` reducer (needs 2-slot per-key accumulator + post-process division).

## Bundled cleanup (separate commit on this branch)

`mouse-data: cache PR #2721 splice patterns` — 3 reference docs that document the single-hash idiom, the take-guard placement, and the eager-vs-lazy bench trap surfaced during #2721 review. Permanent cache; reviewers can skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)