### PR TITLE
linq_fold group_by: min/max/first reducers + multi-reducer fused pass

### DIFF
--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -35,7 +35,8 @@ See `~/.claude/plans/keen-hopping-balloon.md` and `~/.claude/plans/enumerated-ba
 | 3+ BufferDistinct | `[where_*]?[select?] \|> distinct[_by(key)] [\|> take(N)]? [\|> {to_array, count, sum, long_count}]?` — streaming dedup via `table<unique_key>` integrated into the prefilter loop; take(N) → break-after-N early-exit (guard placed BEFORE the consume site so non-positive N short-circuits); count terminator elides the buffer and returns `length(seen)`. `first`/`first_or_default`/`min`/`max`/`average` after `distinct` cascade to tier 2. | ✅ core |
 | 3+ BufferGroupBy | `src \|> group_by[_lazy](key) \|> select(group_proj) [\|> {to_array, count}]?` — incremental-aggregate fusion: emits `table<unique_key; tuple<KT; AccT>>` updated per element. Recognized reducers: `_._1 \|> {length, count, sum, long_count}`. Bare + named-tuple wrap `(K=_._0, V=_._1\|>reducer)` both supported. Bails to tier 2 for multi-reducer, `having_*`, **or any upstream `where_*`/`select*` between source and group_by** (upstream fusion deferred). | ✅ core |
 | 3+ BufferGroupBy — inner-select-sum (PR-A1) | Recognizes `_._1 \|> select(<lambda>) \|> sum` after `group_by_lazy(key)`. Splice peels the inner lambda body and inlines it directly into the per-element `entry._1 += <body>` site, accumulator type derived from the outer sum's resolved return type. Per-element emission split into miss-branch (init) and hit-branch (incremental update) to support this and the future min/max/first arms in PR-A2. Bare body and named-tuple wrap both supported. | ✅ |
-| 3+ Buffer remainder | MultiSourceZip, BufferedJoin, group_by min/max/first/average reducers, multi-reducer named tuples. Currently cascade to tier 2 array-shape. | ⏳ |
+| 3+ BufferGroupBy — min/max/first + multi-reducer (PR-A2) | Recognizer generalized to bare + inner-select `{sum, min, max, first}` (8 reducer shapes). Planner walks an `array<ReducerSpec>` so the named-tuple wrap extends from 2-slot to N+1-slot (key at slot 0, reducers at slots 1..N) — a single per-element pass fuses N reducers. min/max use direct `<`/`>` on workhorse acc types, fall back to `_::less` for non-workhorse. first emits miss-init only (no hit update); `first_or_default(d)` rejects on the 2-arg arity check and cascades. `average` and key-not-at-slot-0 cascade. | ✅ |
+| 3+ Buffer remainder | MultiSourceZip, BufferedJoin, group_by `average` reducer (2-slot per-key acc + post-process division). Currently cascade to tier 2 array-shape. | ⏳ |
 | 4 | Final coverage pass + docs; full 3-way comparison table refresh; parity-test sweep | ⏳ |
 
 ## Baselines (100K rows, INTERP mode)
@@ -63,6 +64,10 @@ Notation: `—` means the variant is not applicable for this benchmark (operator
 | sort_take | `order_by → take` | 38 | 2188 | 2269 |
 | groupby_count | `group_by → select(_, length)` | 140 | 70 | 76 → **33** (this PR) |
 | groupby_sum | `group_by → select(_, select → sum)` | 172 | 101 | 36 (PR-A1 inner-select-sum) |
+| groupby_min | `group_by → select((K, select → min))` | 175 | 111 | **42** (PR-A2 inner-select-min) |
+| groupby_max | `group_by → select((K, select → max))` | 173 | 108 | **43** (PR-A2 inner-select-max) |
+| groupby_first | `group_by → select((K, first))` | — | 71 | **36** (PR-A2 bare-first) |
+| groupby_multi_reducer | `group_by → select((K, length, select → sum, select → max))` | 189 | 139 | **53** (PR-A2 multi-reducer fused pass) |
 | chained_where | `where → where → count` | 36 | 45 | 17 |
 | zip_dot_product | `zip → select → sum` | — | 53 | 37 |
 | join_count | `join → count` | —\*\* | 116 | 122 |
@@ -399,6 +404,33 @@ Closes the explicit deferred-follow-up from PR #2721. Two interlocking changes:
 - multi-reducer named tuples `(K=..., N=..|>length, S=..|>sum, M=..|>min)`
 - `average` reducer (needs 2-slot per-key acc — separate follow-up after PR-A2)
 
+## Phase 3+ groupby reducer expansion — min/max/first + multi-reducer (PR-A2)
+
+Closes the remaining BufferGroupBy gaps from PR-A1's deferred-follow-up list. Two interlocking changes built on PR-A1's miss/hit emission shape:
+
+1. **Reducer-spec array unifies bare + named-tuple-N planning**. The 2-slot named-tuple recognizer (key + 1 reducer) generalizes to N+1 slots (key at slot 0, reducers at slots 1..N). Bare form remains 1 spec at slot 1. The planner walks `array<ReducerSpec>` and concatenates per-slot `missInit` + `hitUpdate` statements into the per-element loop. The single fused pass replaces N separate aggregation passes for multi-reducer chains. Recognizer flags: average + key-not-at-_0 + unrecognized expression shape all bail to tier 2.
+
+2. **Per-reducer emission for min / max / first (bare + inner-select)**. Recognizer extended to 8 reducer shapes: bare `{sum, min, max, first}` + inner-select `{sum, min, max, first}`. min/max emit `if (it < entry._{s}) entry._{s} := it` for workhorse acc types; `if (_::less(it, entry._{s})) entry._{s} := it` for non-workhorse. first emits miss-init only (`entry._{s} := it`) — subsequent same-key elements are ignored, exploiting the first-key-wins guarantee that PR #2721 baked into the emission shape. inner-select-min/max bind the projection result to a per-element temp so the inner body evaluates once per element (matches the reference's lazy `select` semantics). `first_or_default(d)` rejects on the 2-arg arity check and cascades (silently dropping `d` would be misleading even though a bucket is always non-empty).
+
+### Headline (PR-A2)
+
+| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (this PR) | Win |
+|---|---|---:|---:|---:|---:|
+| groupby_min | `group_by → select((K, select → min))` | 175 | 111 | **42** | **2.6× over m3 / 4.2× over m1 SQL** |
+| groupby_max | `group_by → select((K, select → max))` | 173 | 108 | **43** | **2.5× over m3 / 4.0× over m1 SQL** |
+| groupby_first | `group_by → select((K, first))` | — | 71 | **36** | **2.0× over m3** (no direct SQL aggregator for "first source-order row per group" → m1 omitted) |
+| groupby_multi_reducer | `group_by → select((K, length, select → sum, select → max))` | 189 | 139 | **53** | **2.6× over m3 / 3.6× over m1 SQL** (3 reducers fused into 1 pass) |
+| groupby_sum (regression check) | `group_by → select((K, select → sum))` | 175 | 102 | **36** | parity — A.3+A.4 refactor preserves the PR-A1 splice |
+| groupby_count (regression check) | `group_by → select((K, length))` | 141 | 71 | **36** | parity — A.3+A.4 refactor preserves the PR-A1 splice |
+
+All 6 splice variants land within ~36–53 ns/op — the per-element work is bounded by the single hash op + slot mutations regardless of which reducer or how many. The multi-reducer ~53 ns/op pays a small overhead per extra slot (~5 ns each), still beats SQL by 3.6×.
+
+### Deferred for PR-B / PR-C / follow-ups
+
+- `average` reducer (2-slot per-key acc + post-process division — separate follow-up)
+- Upstream `where_*` / `select*` fusion into `group_by` (PR-B)
+- `reverse_take` backward index loop on array sources (PR-C)
+
 ## Operator-coverage checklist (parity tests)
 
 The 24 benchmarks above cover the most common shapes. The end-game target is one benchmark per `_fold`-applicable scenario in the broader `tests/linq/` operator suite. Tracking the long-tail coverage below; PRs that add splice support for new operators should add a benchmark here if not already present.
@@ -410,7 +442,7 @@ The 24 benchmarks above cover the most common shapes. The end-game target is one
 | `test_linq_querying.das` | any/all/contains | any_match, all_match, contains_match | ✅ core |
 | `test_linq_transform.das` | select/select_many/zip | to_array_filter, zip_dot_product | ✅ select/zip; `select_many` ⏳ |
 | `test_linq_sorting.das` | order/order_by/reverse | sort_first, sort_take, select_where_order_take, reverse_take | ✅ ascending + `order_descending` (Phase 3); ✅ `reverse` (this PR; `reverse \|> take(N)` shape is a regression vs lazy iterator — see Phase 3+ notes) |
-| `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum | ✅ count/long_count/bare-sum + inner-select-sum (PR-A1) + named-tuple wrap; ⏳ min/max/first/average, multi-reducer, `having_` |
+| `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum, groupby_min, groupby_max, groupby_first, groupby_multi_reducer | ✅ count/long_count/sum + inner-select-sum (PR-A1); ✅ min/max/first + inner-select-{min,max,first} + multi-reducer (PR-A2); ⏳ `average`, `having_`, upstream where/select fusion |
 | `test_linq_join.das` | join/left_join/right_join/full_outer/cross | join_count | ✅ inner; outer joins + cross ⏳ |
 | `test_linq_partition.das` | take/skip/take_while/skip_while/chunk | take_count, skip_take, take_sum_aggregate, take_count_filtered | ✅ take/skip in splice lanes; `_while` + `chunk` ⏳ |
 | `test_linq_set.das` | distinct/union/except/intersect/unique | distinct_count, distinct_take | ✅ distinct + distinct_by (streaming dedup, this PR); union/except/intersect/unique ⏳ |

--- a/benchmarks/sql/groupby_first.das
+++ b/benchmarks/sql/groupby_first.das
@@ -1,0 +1,42 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _group_by(_.brand) |> _select((Brand=key, FirstCar=first source elem per group)).
+// No direct SQL aggregator for "first source-order row per group" → m1 omitted; m3 vs m3f
+// is the headline comparison. Splice (PR-A2) emits miss-branch-only loop (no hit update).
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
+                                                       FirstCar = _._1 |> first())))
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let groups <- _fold(each(arr)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      FirstCar = _._1 |> first()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def groupby_first_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def groupby_first_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/benchmarks/sql/groupby_max.das
+++ b/benchmarks/sql/groupby_max.das
@@ -1,0 +1,63 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _group_by(_.brand) |> _select((Brand=key, MaxPrice=max of price per group)).
+// SQL: SELECT brand, MAX(price) GROUP BY brand.
+// Splice mode (PR-A2) fuses the inner select+max per group into the per-element
+// miss/hit branches — no bucket array, single hash op per element.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let groups <- _sql(db |> select_from(type<Car>)
+                                  |> _group_by(_.brand)
+                                  |> _select((Brand = _._0,
+                                              MaxPrice = _._1 |> select($(c : Car) => c.price) |> max())))
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
+                                                       MaxPrice = _._1 |> select($(c : Car) => c.price) |> max())))
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let groups <- _fold(each(arr)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      MaxPrice = _._1 |> select($(c : Car) => c.price) |> max()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def groupby_max_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def groupby_max_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def groupby_max_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/benchmarks/sql/groupby_min.das
+++ b/benchmarks/sql/groupby_min.das
@@ -1,0 +1,63 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _group_by(_.brand) |> _select((Brand=key, MinPrice=min of price per group)).
+// SQL: SELECT brand, MIN(price) GROUP BY brand.
+// Splice mode (PR-A2) fuses the inner select+min per group into the per-element
+// miss/hit branches — no bucket array, single hash op per element.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let groups <- _sql(db |> select_from(type<Car>)
+                                  |> _group_by(_.brand)
+                                  |> _select((Brand = _._0,
+                                              MinPrice = _._1 |> select($(c : Car) => c.price) |> min())))
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
+                                                       MinPrice = _._1 |> select($(c : Car) => c.price) |> min())))
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let groups <- _fold(each(arr)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      MinPrice = _._1 |> select($(c : Car) => c.price) |> min()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def groupby_min_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def groupby_min_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def groupby_min_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/benchmarks/sql/groupby_multi_reducer.das
+++ b/benchmarks/sql/groupby_multi_reducer.das
@@ -1,0 +1,69 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _group_by(_.brand) |> _select 4-slot named tuple — fuses count + sum + max into one pass.
+// SQL: SELECT brand, COUNT(*), SUM(price), MAX(price) GROUP BY brand.
+// Splice (PR-A2 A.4) walks the ReducerSpec array once per source element, emitting per-slot
+// miss-init + hit-update for all 3 reducers — no per-reducer separate passes.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let groups <- _sql(db |> select_from(type<Car>)
+                                  |> _group_by(_.brand)
+                                  |> _select((Brand = _._0,
+                                              N = _._1 |> length,
+                                              TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum(),
+                                              MaxPrice   = _._1 |> select($(c : Car) => c.price) |> max())))
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
+                                                       N = _._1 |> length,
+                                                       TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum(),
+                                                       MaxPrice   = _._1 |> select($(c : Car) => c.price) |> max())))
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let groups <- _fold(each(arr)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      N = _._1 |> length,
+                                      TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum(),
+                                      MaxPrice   = _._1 |> select($(c : Car) => c.price) |> max()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def groupby_multi_reducer_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def groupby_multi_reducer_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def groupby_multi_reducer_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1670,7 +1670,7 @@ def private is_bind_field_access(expr : Expression?; bindName : string; fieldInd
 
 [macro_function]
 def private is_bucket_reducer_call(expr : Expression?; bindName : string) : tuple<bool; string; Expression?> {
-    // Returns (matched, reducerName, innerLambda). innerLambda is non-null only for sum_inner_select.
+    // Returns (matched, reducerName, innerLambda). innerLambda is non-null for *_inner_select forms.
     if (expr == null || !(expr is ExprCall)) return (false, "", null)
     let c = expr as ExprCall
     if (c.func == null) return (false, "", null)
@@ -1679,10 +1679,13 @@ def private is_bucket_reducer_call(expr : Expression?; bindName : string) : tupl
         fnName = string(c.func.fromGeneric.name)
     }
     if ((c.arguments |> length) != 1) return (false, "", null)
-    if (fnName == "length" || fnName == "count" || fnName == "sum" || fnName == "long_count") {
+    // Bare reducer: `<reducer>(<bind>._1)`
+    if (fnName == "length" || fnName == "count" || fnName == "long_count"
+            || fnName == "sum" || fnName == "min" || fnName == "max" || fnName == "first") {
         if (is_bind_field_access(c.arguments[0], bindName, 1)) return (true, fnName, null)
     }
-    if (fnName == "sum") {
+    // Inner-select reducer: `<reducer>(select(<bind>._1, <lambda>))`
+    if (fnName == "sum" || fnName == "min" || fnName == "max" || fnName == "first") {
         let inner = c.arguments[0]
         if (inner != null && inner is ExprCall) {
             let innerCall = inner as ExprCall
@@ -1693,11 +1696,222 @@ def private is_bucket_reducer_call(expr : Expression?; bindName : string) : tupl
                 }
                 if (innerName == "select"
                         && (innerCall.arguments |> length) == 2
-                        && is_bind_field_access(innerCall.arguments[0], bindName, 1)) return (true, "sum_inner_select", innerCall.arguments[1])
+                        && is_bind_field_access(innerCall.arguments[0], bindName, 1)) return (true, "{fnName}_inner_select", innerCall.arguments[1])
             }
         }
     }
     return (false, "", null)
+}
+
+struct private ReducerSpec {
+    slot : int                  // target tuple slot: entry._{slot}
+    name : string               // bare reducer or "<reducer>_inner_select"
+    innerBody : Expression?     // peeled inner-select body, null for bare reducer
+    accType : TypeDeclPtr       // type of entry._{slot} (for synth table type + workhorse check)
+}
+
+[macro_function]
+def private slot_acc_type(bodyType : TypeDeclPtr; slot : int; isBareForm : bool) : TypeDeclPtr {
+    // Bare form: bodyType IS the reducer's return type. Named-tuple: drill into argTypes[slot].
+    if (isBareForm) return strip_const_ref(clone_type(bodyType))
+    if (bodyType == null || (bodyType.argTypes |> length) <= slot) return null
+    return strip_const_ref(clone_type(bodyType.argTypes[slot]))
+}
+
+[macro_function]
+def private recognize_reducer_specs(var groupProjBody : Expression?; bindName, itName : string) {
+    // Returns (specs, usesNamedTuple). Empty specs = unrecognized → caller cascades.
+    var specs : array<ReducerSpec>
+    if (groupProjBody == null) return <- (<- specs, false)
+    // Bare form: body is the reducer call directly.
+    let (okBare, rnBare, innerBare) = is_bucket_reducer_call(groupProjBody, bindName)
+    if (okBare) {
+        var innerBody : Expression?
+        if (innerBare != null) {
+            innerBody = fold_linq_cond(clone_expression(innerBare), itName)
+            if (innerBody == null) return <- (<- specs, false)
+        }
+        var accType = slot_acc_type(groupProjBody._type, 1, true)
+        if (accType == null) return <- (<- specs, false)
+        var spec = ReducerSpec(slot = 1, name = rnBare, innerBody = innerBody, accType = accType)
+        specs |> push(spec)
+        return <- (<- specs, false)
+    }
+    // Named-tuple form: slot 0 = key (must be _._0), slots 1..N = reducers.
+    if (!(groupProjBody is ExprMakeTuple)) return <- (<- specs, false)
+    let mt = groupProjBody as ExprMakeTuple
+    let n = mt.values |> length
+    if (n < 2 || !is_bind_field_access(mt.values[0], bindName, 0)) return <- (<- specs, false)
+    specs |> reserve(n - 1)
+    for (i in range(1, n)) {
+        let (ok, rn, innerLam) = is_bucket_reducer_call(mt.values[i], bindName)
+        if (!ok) {
+            specs |> clear
+            return <- (<- specs, false)
+        }
+        var innerBody : Expression?
+        if (innerLam != null) {
+            innerBody = fold_linq_cond(clone_expression(innerLam), itName)
+            if (innerBody == null) {
+                specs |> clear
+                return <- (<- specs, false)
+            }
+        }
+        var accType = slot_acc_type(groupProjBody._type, i, false)
+        if (accType == null) {
+            specs |> clear
+            return <- (<- specs, false)
+        }
+        var spec = ReducerSpec(slot = i, name = rn, innerBody = innerBody, accType = accType)
+        specs |> push(spec)
+    }
+    return <- (<- specs, true)
+}
+
+[macro_function]
+def private mk_slot_ref(at : LineInfo; entryName : string; slot : int) : Expression? {
+    // Programmatic `entry._{slot}` — qmacro has no dynamic-field-name splice.
+    var ev = new ExprVar(at = at)
+    ev.name := entryName
+    var ef = new ExprField(at = at)
+    ef.name := "_{slot}"
+    ef.value = ev
+    return ef
+}
+
+[macro_function]
+def private emit_reducer_branches(spec : ReducerSpec; at : LineInfo; entryName, itName : string) : tuple<Expression?; Expression?> {
+    // (missInit, hitUpdate); hitUpdate null for first* (subsequent same-key elements ignored).
+    var missInit : Expression?
+    var hitUpdate : Expression?
+    let nm = spec.name
+    if (nm == "length" || nm == "count") {
+        var l1 = mk_slot_ref(at, entryName, spec.slot)
+        var l2 = mk_slot_ref(at, entryName, spec.slot)
+        missInit = qmacro_expr() {
+            $e(l1) = 1
+        }
+        hitUpdate = qmacro_expr() {
+            $e(l2) ++
+        }
+    } elif (nm == "long_count") {
+        var l1 = mk_slot_ref(at, entryName, spec.slot)
+        var l2 = mk_slot_ref(at, entryName, spec.slot)
+        missInit = qmacro_expr() {
+            $e(l1) = 1l
+        }
+        hitUpdate = qmacro_expr() {
+            $e(l2) ++
+        }
+    } elif (nm == "sum") {
+        var l1 = mk_slot_ref(at, entryName, spec.slot)
+        var l2 = mk_slot_ref(at, entryName, spec.slot)
+        missInit = qmacro_expr() {
+            $e(l1) = $i(itName)
+        }
+        hitUpdate = qmacro_expr() {
+            $e(l2) += $i(itName)
+        }
+    } elif (nm == "sum_inner_select") {
+        var l1 = mk_slot_ref(at, entryName, spec.slot)
+        var l2 = mk_slot_ref(at, entryName, spec.slot)
+        var b1 = clone_expression(spec.innerBody)
+        var b2 = clone_expression(spec.innerBody)
+        missInit = qmacro_expr() {
+            $e(l1) = $e(b1)
+        }
+        hitUpdate = qmacro_expr() {
+            $e(l2) += $e(b2)
+        }
+    } elif (nm == "min" || nm == "max") {
+        let workhorse = spec.accType != null && spec.accType.isWorkhorseType
+        let isMin = nm == "min"
+        var lInit = mk_slot_ref(at, entryName, spec.slot)
+        var lCmp  = mk_slot_ref(at, entryName, spec.slot)
+        var lAsn  = mk_slot_ref(at, entryName, spec.slot)
+        missInit = qmacro_expr() {
+            $e(lInit) := $i(itName)
+        }
+        if (workhorse && isMin) {
+            hitUpdate = qmacro_expr() {
+                if ($i(itName) < $e(lCmp)) {
+                    $e(lAsn) := $i(itName)
+                }
+            }
+        } elif (workhorse) {
+            hitUpdate = qmacro_expr() {
+                if ($i(itName) > $e(lCmp)) {
+                    $e(lAsn) := $i(itName)
+                }
+            }
+        } elif (isMin) {
+            hitUpdate = qmacro_expr() {
+                if (_::less($i(itName), $e(lCmp))) {
+                    $e(lAsn) := $i(itName)
+                }
+            }
+        } else {
+            hitUpdate = qmacro_expr() {
+                if (_::less($e(lCmp), $i(itName))) {
+                    $e(lAsn) := $i(itName)
+                }
+            }
+        }
+    } elif (nm == "min_inner_select" || nm == "max_inner_select") {
+        let workhorse = spec.accType != null && spec.accType.isWorkhorseType
+        let isMin = nm == "min_inner_select"
+        // Hit branch evaluates innerBody once into a temp — matches reference's single-eval-per-element.
+        let tmp = "`vis`{at.line}`{at.column}`{spec.slot}"
+        var lInit = mk_slot_ref(at, entryName, spec.slot)
+        var lCmp  = mk_slot_ref(at, entryName, spec.slot)
+        var lAsn  = mk_slot_ref(at, entryName, spec.slot)
+        var bMiss = clone_expression(spec.innerBody)
+        var bHit  = clone_expression(spec.innerBody)
+        missInit = qmacro_expr() {
+            $e(lInit) := $e(bMiss)
+        }
+        if (workhorse && isMin) {
+            hitUpdate = qmacro_block() {
+                let $i(tmp) = $e(bHit)
+                if ($i(tmp) < $e(lCmp)) {
+                    $e(lAsn) := $i(tmp)
+                }
+            }
+        } elif (workhorse) {
+            hitUpdate = qmacro_block() {
+                let $i(tmp) = $e(bHit)
+                if ($i(tmp) > $e(lCmp)) {
+                    $e(lAsn) := $i(tmp)
+                }
+            }
+        } elif (isMin) {
+            hitUpdate = qmacro_block() {
+                let $i(tmp) = $e(bHit)
+                if (_::less($i(tmp), $e(lCmp))) {
+                    $e(lAsn) := $i(tmp)
+                }
+            }
+        } else {
+            hitUpdate = qmacro_block() {
+                let $i(tmp) = $e(bHit)
+                if (_::less($e(lCmp), $i(tmp))) {
+                    $e(lAsn) := $i(tmp)
+                }
+            }
+        }
+    } elif (nm == "first") {
+        var l1 = mk_slot_ref(at, entryName, spec.slot)
+        missInit = qmacro_expr() {
+            $e(l1) := $i(itName)
+        }
+    } elif (nm == "first_inner_select") {
+        var l1 = mk_slot_ref(at, entryName, spec.slot)
+        var b1 = clone_expression(spec.innerBody)
+        missInit = qmacro_expr() {
+            $e(l1) := $e(b1)
+        }
+    }
+    return (missInit, hitUpdate)
 }
 
 [macro_function]
@@ -1739,61 +1953,12 @@ def private plan_group_by(var expr : Expression?) : Expression? {
     let bindName = "`gpb`{at.line}`{at.column}"   // group_proj lambda's bound variable
     // Substitute the lambda's bound var with `bindName` so we can pattern-match.
     var groupProjBody = fold_linq_cond(groupProjCall.arguments[1], bindName)
-    var reducerName : string  = ""
-    var usesNamedTuple = false
-    var innerLambda : Expression?     // for sum_inner_select: raw inner select lambda, peeled below
-    // Case A: body is the reducer itself (bare form, no key in output)
-    {
-        let (ok, rn, innerLam) = is_bucket_reducer_call(groupProjBody, bindName)
-        if (ok) {
-            reducerName = rn
-            // Clone to drop const propagated through tuple destructure; planner mutates innerBody later.
-            if (innerLam != null) {
-                innerLambda = clone_expression(innerLam)
-            }
-        }
-    }
-    // Case B: body is an ExprMakeTuple(isKeyValue=true) with 2 fields:
-    if (reducerName == "" && (groupProjBody is ExprMakeTuple)) {
-        let mt = groupProjBody as ExprMakeTuple
-        if ((mt.values |> length) == 2) {
-            if (is_bind_field_access(mt.values[0], bindName, 0)) {
-                let (ok, rn, innerLam) = is_bucket_reducer_call(mt.values[1], bindName)
-                if (ok) {
-                    reducerName = rn
-                    if (innerLam != null) {
-                innerLambda = clone_expression(innerLam)
-            }
-                    usesNamedTuple = true
-                }
-            }
-        }
-    }
-    // Recognized: length/count (Acc=int), long_count (Acc=int64), sum (Acc=elemT), sum_inner_select (Acc=innerBodyT).
-    if (reducerName == ""
-            || (reducerName != "length" && reducerName != "count" && reducerName != "long_count"
-                && reducerName != "sum" && reducerName != "sum_inner_select")) return null
-    let isLongCountReducer = reducerName == "long_count"
-    let isSumReducer = reducerName == "sum" || reducerName == "sum_inner_select"
-    let isSumInnerSelectReducer = reducerName == "sum_inner_select"
+    if (groupProjBody == null || groupProjBody._type == null) return null
+    var (specs, usesNamedTuple) = recognize_reducer_specs(groupProjBody, bindName, itName)
+    if (empty(specs)) return null
     var sourceElemType = strip_const_ref(clone_type(top._type.firstType))
-    var innerBody : Expression?
-    var accType : TypeDeclPtr
-    if (isSumInnerSelectReducer) {
-        // Peel inner select's lambda body, renaming `_` → itName for direct splice into `entry._1 += <body>`.
-        innerBody = fold_linq_cond(innerLambda, itName)
-        if (innerBody == null || groupProjBody._type == null) return null
-        // accType from outer sum's _type (peeled body's _type is null — apply_template doesn't re-type-infer).
-        accType = strip_const_ref(clone_type(groupProjBody._type))
-    } else {
-        accType = clone_type(sourceElemType)
-    }
     var elemType = sourceElemType
-    // Named-tuple wrap reuses the user's body type (preserves field-name hints); bare reducer synthesizes tuple<KeyT; ResultT> below.
-    var tabValueType : TypeDeclPtr
-    if (usesNamedTuple) {
-        tabValueType = strip_const_ref(clone_type(groupProjBody._type))
-    }
+    // Named-tuple wrap reuses the user's body type (preserves field-name hints); bare reducer synthesizes tuple<KeyT; AccT>.
     var keyBlk1 = clone_expression(keyBlock)
     var keyBlk2 = clone_expression(keyBlock)
     var keyBlkD = clone_expression(keyBlock)
@@ -1801,87 +1966,74 @@ def private plan_group_by(var expr : Expression?) : Expression? {
     let dummyName = "`dummy`{at.line}`{at.column}"
     // Table + matching dummy. Dummy is bound on miss so first-key-wins is detected via addr-compare (one hash op/elem).
     if (usesNamedTuple) {
+        var tabValueType  = strip_const_ref(clone_type(groupProjBody._type))
+        var tabValueType2 = clone_type(tabValueType)
         stmts |> push <| qmacro_expr() {
             var inscope $i(tabName) : table<typedecl(_::unique_key(invoke($e(keyBlk1), default<$t(elemType)>))); $t(tabValueType)>
         }
-        var tabValueType2 = clone_type(tabValueType)
         stmts |> push <| qmacro_expr() {
             var $i(dummyName) : $t(tabValueType2)
         }
-    } elif (isLongCountReducer) {
-        stmts |> push <| qmacro_expr() {
-            var inscope $i(tabName) : table<typedecl(_::unique_key(invoke($e(keyBlk1), default<$t(elemType)>))); tuple<typedecl(invoke($e(keyBlk2), default<$t(elemType)>)) -const -&; int64>>
-        }
-        stmts |> push <| qmacro_expr() {
-            var $i(dummyName) : tuple<typedecl(invoke($e(keyBlkD), default<$t(elemType)>)) -const -&; int64>
-        }
-    } elif (isSumReducer) {
-        var accType2 = clone_type(accType)
+    } else {
+        var accType  = clone_type(specs[0].accType)
+        var accType2 = clone_type(specs[0].accType)
         stmts |> push <| qmacro_expr() {
             var inscope $i(tabName) : table<typedecl(_::unique_key(invoke($e(keyBlk1), default<$t(elemType)>))); tuple<typedecl(invoke($e(keyBlk2), default<$t(elemType)>)) -const -&; $t(accType)>>
         }
         stmts |> push <| qmacro_expr() {
             var $i(dummyName) : tuple<typedecl(invoke($e(keyBlkD), default<$t(elemType)>)) -const -&; $t(accType2)>
         }
-    } else {
-        // count / length — Acc=int
-        stmts |> push <| qmacro_expr() {
-            var inscope $i(tabName) : table<typedecl(_::unique_key(invoke($e(keyBlk1), default<$t(elemType)>))); tuple<typedecl(invoke($e(keyBlk2), default<$t(elemType)>)) -const -&; int>>
-        }
-        stmts |> push <| qmacro_expr() {
-            var $i(dummyName) : tuple<typedecl(invoke($e(keyBlkD), default<$t(elemType)>)) -const -&; int>
-        }
     }
-    // `tab?[uk] ?? dummy` returns ref to existing entry OR to dummy on miss — single hash op per element. addr-compare splits into miss-branch (init+commit) and hit-branch (incremental update); the split lets each reducer pick its own init vs update shape independently.
+    // `tab?[uk] ?? dummy` returns ref to existing entry OR to dummy on miss — single hash op per element. addr-compare splits into miss-branch (init+commit) and hit-branch (incremental update); each reducer slot contributes one init stmt and (optionally) one update stmt.
     var keyBlk3 = clone_expression(keyBlock)
-    var missInit : Expression?
-    var hitUpdate : Expression?
-    if (isLongCountReducer) {
-        missInit = qmacro_expr() {
-            $i(entryName)._1 = 1l
+    var missInitStmts : array<Expression?>
+    var hitUpdateStmts : array<Expression?>
+    for (s in specs) {
+        // Clone to drop const propagated through tuple destructure.
+        let (mi, hu) = emit_reducer_branches(s, at, entryName, itName)
+        if (mi != null) {
+            missInitStmts |> push(clone_expression(mi))
         }
-        hitUpdate = qmacro_expr() {
-            $i(entryName)._1 ++
-        }
-    } elif (isSumInnerSelectReducer) {
-        // Two clones — each $e(...) splice consumes its expression.
-        var innerBody1 = clone_expression(innerBody)
-        var innerBody2 = clone_expression(innerBody)
-        missInit = qmacro_expr() {
-            $i(entryName)._1 = $e(innerBody1)
-        }
-        hitUpdate = qmacro_expr() {
-            $i(entryName)._1 += $e(innerBody2)
-        }
-    } elif (isSumReducer) {
-        missInit = qmacro_expr() {
-            $i(entryName)._1 = $i(itName)
-        }
-        hitUpdate = qmacro_expr() {
-            $i(entryName)._1 += $i(itName)
-        }
-    } else {
-        // count / length — int accumulator
-        missInit = qmacro_expr() {
-            $i(entryName)._1 = 1
-        }
-        hitUpdate = qmacro_expr() {
-            $i(entryName)._1 ++
+        if (hu != null) {
+            hitUpdateStmts |> push(clone_expression(hu))
         }
     }
-    stmts |> push <| qmacro_expr() {
-        for ($i(itName) in $i(srcName)) {
-            let $i(kName) = invoke($e(keyBlk3), $i(itName))
-            let $i(ukName) = _::unique_key($i(kName))
-            unsafe {
-                var $i(entryName) & = $i(tabName)?[$i(ukName)] ?? $i(dummyName)
-                if (addr($i(entryName)) == addr($i(dummyName))) {
-                    $e(missInit)
-                    $i(dummyName)._0 = $i(kName)
-                    $i(tabName)[$i(ukName)] = $i(dummyName)
-                    $i(dummyName) = default<typedecl($i(dummyName))>
-                } else {
-                    $e(hitUpdate)
+    if (empty(missInitStmts)) return null
+    var missInit  = stmts_to_expr(missInitStmts)
+    let hasHitUpdate = !empty(hitUpdateStmts)
+    if (hasHitUpdate) {
+        var hitUpdate = stmts_to_expr(hitUpdateStmts)
+        stmts |> push <| qmacro_expr() {
+            for ($i(itName) in $i(srcName)) {
+                let $i(kName) = invoke($e(keyBlk3), $i(itName))
+                let $i(ukName) = _::unique_key($i(kName))
+                unsafe {
+                    var $i(entryName) & = $i(tabName)?[$i(ukName)] ?? $i(dummyName)
+                    if (addr($i(entryName)) == addr($i(dummyName))) {
+                        $e(missInit)
+                        $i(dummyName)._0 = $i(kName)
+                        $i(tabName)[$i(ukName)] = $i(dummyName)
+                        $i(dummyName) = default<typedecl($i(dummyName))>
+                    } else {
+                        $e(hitUpdate)
+                    }
+                }
+            }
+        }
+    } else {
+        // All reducers are first* — no hit update needed.
+        stmts |> push <| qmacro_expr() {
+            for ($i(itName) in $i(srcName)) {
+                let $i(kName) = invoke($e(keyBlk3), $i(itName))
+                let $i(ukName) = _::unique_key($i(kName))
+                unsafe {
+                    var $i(entryName) & = $i(tabName)?[$i(ukName)] ?? $i(dummyName)
+                    if (addr($i(entryName)) == addr($i(dummyName))) {
+                        $e(missInit)
+                        $i(dummyName)._0 = $i(kName)
+                        $i(tabName)[$i(ukName)] = $i(dummyName)
+                        $i(dummyName) = default<typedecl($i(dummyName))>
+                    }
                 }
             }
         }

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -1666,6 +1666,205 @@ def test_group_by_inner_select_sum_fold_parity(t : T?) {
 }
 
 [test]
+def test_group_by_min_max_first_fold_parity(t : T?) {
+    // PR-A2: min/max/first bare + named + inner-select reducers. Each splices into the
+    // miss/hit emission with per-reducer init+update shapes (min/max compare; first no-op on hit).
+    t |> run("bare min: per-bucket workhorse min") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> min))
+        // Buckets: 0→{30,21,12}=12, 1→{10,31}=10, 2→{20,11}=11. Total of mins = 33.
+        tt |> equal(3, length(got))
+        var totalMin = 0
+        for (m in got) {
+            totalMin += m
+        }
+        tt |> equal(33, totalMin)
+    }
+    t |> run("named min: preserves K + Min") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, Min = _._1 |> min)))
+        tt |> equal(3, length(got))
+        var perKey : table<int; int>
+        for (item in got) {
+            perKey[item.K] = item.Min
+        }
+        tt |> equal(12, perKey[0])
+        tt |> equal(10, perKey[1])
+        tt |> equal(11, perKey[2])
+    }
+    t |> run("bare max: per-bucket workhorse max") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> max))
+        // Buckets: 0→30, 1→31, 2→20. Sum = 81.
+        tt |> equal(3, length(got))
+        var totalMax = 0
+        for (m in got) {
+            totalMax += m
+        }
+        tt |> equal(81, totalMax)
+    }
+    t |> run("named max: preserves K + Max") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, Max = _._1 |> max)))
+        tt |> equal(3, length(got))
+        var perKey : table<int; int>
+        for (item in got) {
+            perKey[item.K] = item.Max
+        }
+        tt |> equal(30, perKey[0])
+        tt |> equal(31, perKey[1])
+        tt |> equal(20, perKey[2])
+    }
+    t |> run("bare first: per-bucket FIRST source element (first-key-wins)") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> first))
+        // Buckets, in source order: 1→{10,31}=10, 2→{20,11}=20, 0→{30,21,12}=30. Sum = 60.
+        tt |> equal(3, length(got))
+        var totalFirst = 0
+        for (f in got) {
+            totalFirst += f
+        }
+        tt |> equal(60, totalFirst)
+    }
+    t |> run("named first: preserves K + First (first source elem per key)") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, First = _._1 |> first)))
+        tt |> equal(3, length(got))
+        var perKey : table<int; int>
+        for (item in got) {
+            perKey[item.K] = item.First
+        }
+        tt |> equal(30, perKey[0])    // 30 is the first elem for key 0
+        tt |> equal(10, perKey[1])    // 10 is the first elem for key 1
+        tt |> equal(20, perKey[2])    // 20 is the first elem for key 2
+    }
+    t |> run("inner-select-min: bare min of projected values") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> select(@(x : int) => x * 2) |> min))
+        // Buckets *2: 0→{60,42,24}=24, 1→{20,62}=20, 2→{40,22}=22. Sum = 66.
+        tt |> equal(3, length(got))
+        var totalMin = 0
+        for (m in got) {
+            totalMin += m
+        }
+        tt |> equal(66, totalMin)
+    }
+    t |> run("inner-select-max: named (K, M) with projected max") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, M = _._1 |> select(@(x : int) => x * 2) |> max)))
+        tt |> equal(3, length(got))
+        var perKey : table<int; int>
+        for (item in got) {
+            perKey[item.K] = item.M
+        }
+        tt |> equal(60, perKey[0])    // max(30,21,12)*2 = 60
+        tt |> equal(62, perKey[1])    // max(10,31)*2 = 62
+        tt |> equal(40, perKey[2])    // max(20,11)*2 = 40
+    }
+    t |> run("inner-select-first: named (K, F) with projected first") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, F = _._1 |> select(@(x : int) => x * 2) |> first)))
+        tt |> equal(3, length(got))
+        var perKey : table<int; int>
+        for (item in got) {
+            perKey[item.K] = item.F
+        }
+        tt |> equal(60, perKey[0])    // first elem 30, *2 = 60
+        tt |> equal(20, perKey[1])    // first elem 10, *2 = 20
+        tt |> equal(40, perKey[2])    // first elem 20, *2 = 40
+    }
+    t |> run("min/max/first on empty source → empty result") @(tt : T?) {
+        var empty : array<int>
+        let g1 <- _fold(empty._group_by(_ % 3)._select(_._1 |> min))
+        tt |> equal(0, length(g1))
+        let g2 <- _fold(empty._group_by(_ % 3)._select(_._1 |> max))
+        tt |> equal(0, length(g2))
+        let g3 <- _fold(empty._group_by(_ % 3)._select(_._1 |> first))
+        tt |> equal(0, length(g3))
+    }
+    t |> run("min on struct (non-workhorse) Person.age via inner-select: parity with reference") @(tt : T?) {
+        let foldGot <- _fold(_common::people._group_by(_.name)._select((K = _._0, MinAge = _._1 |> select(@(p : _common::Person) => p.age) |> min)))
+        let refGot  <- (_common::people._group_by(_.name)._select((K = _._0, MinAge = _._1 |> select(@(p : _common::Person) => p.age) |> min)))
+        tt |> equal(length(refGot), length(foldGot))
+        var refMap  : table<string; int>
+        var foldMap : table<string; int>
+        for (r in refGot) {
+            refMap[r.K] = r.MinAge
+        }
+        for (f in foldGot) {
+            foldMap[f.K] = f.MinAge
+        }
+        for (k in keys(refMap)) {
+            tt |> equal(refMap?[k] ?? -1, foldMap?[k] ?? -1)
+        }
+    }
+}
+
+[test]
+def test_group_by_multi_reducer_fold_parity(t : T?) {
+    // PR-A2 A.4: N-slot named tuples fuse multiple reducers into a single per-element pass.
+    t |> run("3-slot (K, N=length, S=sum): two reducers per bucket") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, N = _._1 |> length, S = _._1 |> sum)))
+        tt |> equal(3, length(got))
+        var perKeyN : table<int; int>
+        var perKeyS : table<int; int>
+        for (item in got) {
+            perKeyN[item.K] = item.N
+            perKeyS[item.K] = item.S
+        }
+        // Per key: 0→{30,21,12} N=3 S=63; 1→{10,31} N=2 S=41; 2→{20,11} N=2 S=31.
+        tt |> equal(3, perKeyN[0])
+        tt |> equal(63, perKeyS[0])
+        tt |> equal(2, perKeyN[1])
+        tt |> equal(41, perKeyS[1])
+        tt |> equal(2, perKeyN[2])
+        tt |> equal(31, perKeyS[2])
+    }
+    t |> run("4-slot (K, N, S, MX): count + sum + max fused into one pass") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(
+            (K = _._0, N = _._1 |> length, S = _._1 |> sum, MX = _._1 |> max)))
+        tt |> equal(3, length(got))
+        // Compare slot-by-slot since named tuples lack a default operator==.
+        var keysSeen = 0
+        for (item in got) {
+            if (item.K == 0) { tt |> equal(3, item.N); tt |> equal(63, item.S); tt |> equal(30, item.MX); keysSeen ++; }
+            elif (item.K == 1) { tt |> equal(2, item.N); tt |> equal(41, item.S); tt |> equal(31, item.MX); keysSeen ++; }
+            elif (item.K == 2) { tt |> equal(2, item.N); tt |> equal(31, item.S); tt |> equal(20, item.MX); keysSeen ++; }
+        }
+        tt |> equal(3, keysSeen)
+    }
+    t |> run("multi-reducer with inner-select: (K, N, Total = sum of *2)") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(
+            (K = _._0, N = _._1 |> length, Total = _._1 |> select(@(x : int) => x * 2) |> sum)))
+        tt |> equal(3, length(got))
+        var keysSeen = 0
+        for (item in got) {
+            if (item.K == 0) { tt |> equal(3, item.N); tt |> equal(126, item.Total); keysSeen ++; }
+            elif (item.K == 1) { tt |> equal(2, item.N); tt |> equal(82,  item.Total); keysSeen ++; }
+            elif (item.K == 2) { tt |> equal(2, item.N); tt |> equal(62,  item.Total); keysSeen ++; }
+        }
+        tt |> equal(3, keysSeen)
+    }
+    t |> run("multi-reducer on empty source → empty result") @(tt : T?) {
+        var empty : array<int>
+        let got <- _fold(empty._group_by(_ % 3)._select((K = _._0, N = _._1 |> length, S = _._1 |> sum)))
+        tt |> equal(0, length(got))
+    }
+    t |> run("multi-reducer parity with reference (Person)") @(tt : T?) {
+        let foldGot <- _fold(_common::people._group_by(_.name)._select(
+            (K = _._0, N = _._1 |> length, MinAge = _._1 |> select(@(p : _common::Person) => p.age) |> min, MaxAge = _._1 |> select(@(p : _common::Person) => p.age) |> max)))
+        let refGot  <- (_common::people._group_by(_.name)._select(
+            (K = _._0, N = _._1 |> length, MinAge = _._1 |> select(@(p : _common::Person) => p.age) |> min, MaxAge = _._1 |> select(@(p : _common::Person) => p.age) |> max)))
+        tt |> equal(length(refGot), length(foldGot))
+        // Three separate tables — daslang tuples lack a default `==` operator.
+        var refN, refMin, refMax : table<string; int>
+        var foldN, foldMin, foldMax : table<string; int>
+        for (r in refGot) {
+            refN[r.K] = r.N; refMin[r.K] = r.MinAge; refMax[r.K] = r.MaxAge
+        }
+        for (f in foldGot) {
+            foldN[f.K] = f.N; foldMin[f.K] = f.MinAge; foldMax[f.K] = f.MaxAge
+        }
+        for (k in keys(refN)) {
+            tt |> equal(refN?[k] ?? -1,   foldN?[k] ?? -1)
+            tt |> equal(refMin?[k] ?? -1, foldMin?[k] ?? -1)
+            tt |> equal(refMax?[k] ?? -1, foldMax?[k] ?? -1)
+        }
+    }
+}
+
+[test]
 def test_reverse_count_parity(t : T?) {
     // R5: reverse |> count — counter loop, no reverse work.
     t |> run("reverse.count: identity") @(tt : T?) {

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -2074,6 +2074,127 @@ def test_group_by_inner_select_sum_named_preserves_key(t : T?) {
 }
 
 [export, marker(no_coverage)]
+def target_group_by_min_workhorse_fold() : array<int> {
+    // G5a (PR-A2): bare min on workhorse int → direct `<` compare, no `_::less`.
+    return <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> min))
+}
+
+[test]
+def test_group_by_min_workhorse_emits_direct_compare(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_min_workhorse_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(0, count_call(body_expr, "group_by_lazy"), "must NOT call group_by_lazy runtime")
+        t |> equal(0, count_call(body_expr, "less"), "workhorse min must use direct `<`, not _::less")
+        t |> success(count_call(body_expr, "unique_key") >= 1, "must call _::unique_key per element")
+        t |> equal(2, count_inner_for_loops(body_expr), "table-update + result-build loops")
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path: no key_exists")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_min_non_workhorse_fold() : array<tuple<int; int>> {
+    // G5b (PR-A2): bare min on `tuple<int;int>` (non-workhorse) → `_::less` dispatch.
+    return <- _fold([(1, 2), (0, 5), (2, 3), (0, 1), (1, 4)]._group_by(_._0 % 2)._select(_._1 |> min))
+}
+
+[test]
+def test_group_by_min_non_workhorse_uses_less(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_min_non_workhorse_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(0, count_call(body_expr, "group_by_lazy"), "must NOT call group_by_lazy runtime")
+        t |> success(count_call(body_expr, "less") >= 1, "non-workhorse min: at least one _::less call")
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path: no key_exists")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_first_fold() : array<int> {
+    // G6 (PR-A2): bare first → miss-branch captures, hit-branch is empty (no compare).
+    return <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> first))
+}
+
+[test]
+def test_group_by_first_no_hit_compare(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_first_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(0, count_call(body_expr, "group_by_lazy"), "must NOT call group_by_lazy runtime")
+        t |> equal(0, count_call(body_expr, "less"), "first hit branch is empty: no _::less call")
+        t |> equal(0, count_call(body_expr, "first"), "must NOT call runtime first()")
+        t |> success(count_call(body_expr, "unique_key") >= 1, "must call _::unique_key per element")
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path: no key_exists")
+        t |> equal(2, count_inner_for_loops(body_expr), "table-update + result-build loops")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_multi_reducer_fold() : array<tuple<K : int; N : int; S : int; MX : int>> {
+    // G7 (PR-A2): 4-slot named tuple → multi-reducer specs array fuses count+sum+max into one pass.
+    return <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(
+        (K = _._0, N = _._1 |> length, S = _._1 |> sum, MX = _._1 |> max)))
+}
+
+[test]
+def test_group_by_multi_reducer_emits_fused_pass(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_multi_reducer_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(0, count_call(body_expr, "group_by_lazy"), "must NOT call group_by_lazy runtime")
+        t |> equal(0, count_call(body_expr, "sum"), "must NOT call runtime sum()")
+        t |> equal(0, count_call(body_expr, "max"), "must NOT call runtime max()")
+        // Note: 1 `length(tab)` survives for reserve() — that's not the reducer.
+        t |> success(count_call(body_expr, "unique_key") >= 1, "must call _::unique_key per element")
+        t |> equal(2, count_inner_for_loops(body_expr), "single fused table-update loop + result-build")
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path: no key_exists")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_first_or_default_falls_through() : array<int> {
+    // G10 (PR-A2): `first_or_default(_._1, def)` has 2 args → recognizer rejects (only 1-arg
+    // bucket reducers are spliced). Cascades to tier 2.
+    return <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> first_or_default(-1)))
+}
+
+[test]
+def test_group_by_first_or_default_cascades_to_tier2(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_first_or_default_falls_through)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper from cascade")
+        // Cascade emits pass_0/pass_1/... — splice would have exactly 1 outer let (the table).
+        t |> success(count_outer_let_vars(body_expr) >= 2,
+            "cascade fingerprint: multiple pass_N outer vars")
+    }
+}
+
+[export, marker(no_coverage)]
 def target_group_by_having_falls_through() : array<int> {
     // BAIL: where_ between group_by and select (HAVING clause shape) → cascade to tier 2.
     return <- _fold([1, 2, 3, 4, 5, 6, 7]._group_by(_ % 3)._where(_._1 |> length >= 2)._select(_._1 |> length))


### PR DESCRIPTION
## Summary

Closes the remaining `BufferGroupBy` gaps from PR #2723's deferred-follow-up list. Builds on PR-A1's miss/hit emission split.

**A.3 — per-reducer dispatch.** Recognizer extended to 8 reducer shapes: bare `{sum, min, max, first}` + inner-select `{sum, min, max, first}` (`<reducer>(select(<bind>._1, <lambda>))`). New `emit_reducer_branches` helper produces per-reducer (missInit, hitUpdate) pairs.

- `min` / `max`: direct `<` / `>` for workhorse acc types; `_::less` fallback for non-workhorse (matches the reference at [linq.das:1224,1308](daslib/linq.das#L1224)).
- `first`: miss-init only, no hit update. Subsequent same-key elements are ignored, exploiting PR #2721's first-key-wins guarantee.
- inner-select `min` / `max`: bind the projection result to a per-element temp so the inner body evaluates exactly once per source element — matches `select` laziness and avoids re-running side effects.
- `first_or_default(def)` rejects on the 2-arg arity check and cascades.

**A.4 — N+1-slot named tuples.** The 2-slot recognizer (key + 1 reducer) is replaced by `recognize_reducer_specs` returning `array<ReducerSpec>`. Named-tuple form now accepts arbitrarily many reducer slots (key at `_0`, reducers at `_1`..`_N`). The planner walks the spec array once and concatenates per-slot `missInit` + `hitUpdate` statements into the per-element loop — N reducers fused into one pass.

Field access into dynamic slots (`entry._{slot}`) is built programmatically via `mk_slot_ref` since qmacro has no dynamic-field-name splice. The per-element loop drops the `else` branch entirely for first-only chains (no hit update needed).

**Bail paths (cascade to tier 2):** key not at slot 0; unrecognized reducer in any slot (e.g. `average`); `first_or_default` (fails arity).

## Headline (100K rows, INTERP)

| Benchmark | m1 SQL | m3 LINQ | m3f splice | Win |
|---|---:|---:|---:|---:|
| groupby_min | 175 | 111 | **42** | 2.6× over m3 / 4.2× over SQL |
| groupby_max | 173 | 108 | **43** | 2.5× over m3 / 4.0× over SQL |
| groupby_first | — | 71 | **36** | 2.0× over m3 (no direct SQL aggregator) |
| groupby_multi_reducer | 189 | 139 | **53** | 2.6× over m3 / 3.6× over SQL (3 reducers fused) |
| groupby_sum (regression check) | 175 | 102 | **36** | parity — refactor preserves PR-A1 splice |
| groupby_count (regression check) | 141 | 71 | **36** | parity — refactor preserves PR-A1 splice |

All 6 splice variants land in ~36–53 ns/op — per-element work bounded by the single hash op + slot mutations regardless of which reducer or how many. Multi-reducer pays ~5 ns per extra slot.

## Test plan

- [x] `tests/linq/test_linq_fold.das` — 257 tests pass (18 new in `test_group_by_min_max_first_fold_parity` + `test_group_by_multi_reducer_fold_parity` covering bare/named/inner-select/multi/empty/Person-fixture-parity)
- [x] `tests/linq/test_linq_fold_ast.das` — 102 tests pass (5 new: G5a min workhorse direct compare, G5b min non-workhorse `_::less`, G6 first no hit compare, G7 multi-reducer fused pass, G10 first_or_default cascade)
- [x] `tests/linq/test_linq_group_by.das` — 18 tests pass (regression check)
- [x] `tests/linq/test_linq_aggregation.das` — 46 tests pass
- [x] `tests/linq/test_linq.das` — 21 tests pass
- [x] AOT mode (`test_aot -use-aot`) — 257 + 102 tests pass
- [x] Lint clean (`mcp__daslang__lint`)
- [x] Format clean (`mcp__daslang__format_file`)
- [x] All 4 new benchmarks plus PR-A1 regression checks run cleanly

## Deferred follow-ups

- `average` reducer (2-slot per-key acc + post-process division)
- Upstream `where_*` / `select*` fusion into `group_by` (PR-B)
- `reverse_take` backward index loop on array sources (PR-C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)