### PR TITLE
linq_fold group_by: splice _having between group_by_lazy and select

### DIFF
--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -33,11 +33,12 @@ See `~/.claude/plans/keen-hopping-balloon.md` and `~/.claude/plans/enumerated-ba
 | 3d | `select + where + terminator` splice arm via `replaceVariablePeeling` (new helper in `daslib/templates_boost.das`). Substitutes the projection into the where predicate, peeling the typer-inserted ExprRef2Value wrappers that would otherwise be left orphaned around a non-reference value. Bails to tier 2 when the projection has side effects (would double-evaluate). Lands all four terminator lanes (ARRAY / COUNTER / ACCUMULATOR / EARLY_EXIT). | ✅ done |
 | 3+ BufferReverse | `[where_*]?[select?] \|> reverse [\|> take(N)]? [\|> {to_array, count, first, first_or_default}]?` — single-pass prefilter into buffer + `reverse_inplace` + optional `resize(min(N,len))`; count/first lanes elide the buffer entirely (counter or last-survivor tracker). | ✅ |
 | 3+ BufferDistinct | `[where_*]?[select?] \|> distinct[_by(key)] [\|> take(N)]? [\|> {to_array, count, sum, long_count}]?` — streaming dedup via `table<unique_key>` integrated into the prefilter loop; take(N) → break-after-N early-exit (guard placed BEFORE the consume site so non-positive N short-circuits); count terminator elides the buffer and returns `length(seen)`. `first`/`first_or_default`/`min`/`max`/`average` after `distinct` cascade to tier 2. | ✅ core |
-| 3+ BufferGroupBy | `[where_*/select*]* \|> group_by[_lazy](key) \|> select(group_proj) [\|> {to_array, count}]?` — incremental-aggregate fusion: emits `table<unique_key; tuple<KT; AccT>>` (or N+1-slot named tuple) updated per element. Recognized reducers: bare + inner-select `{sum, min, max, first}` (8 shapes) + `{length, count, long_count}`. Bare body, 2-slot named-tuple wrap, and N+1-slot multi-reducer named tuple all supported. Upstream `where_*`/`select*` chains fuse into the per-element loop with lazy semantics (selects after a where execute INSIDE that where's guard). Bails to tier 2 for `average`, `having_*`, key-not-at-slot-0 in named tuple, or upstream ops other than `where_*`/`select*` (e.g. distinct/order_by). | ✅ |
+| 3+ BufferGroupBy | `[where_*/select*]* \|> group_by[_lazy](key) [\|> having_(pred)]? \|> select(group_proj) [\|> {to_array, count}]?` — incremental-aggregate fusion: emits `table<unique_key; tuple<KT; AccT>>` (or N+1-slot named tuple) updated per element. Recognized reducers: bare + inner-select `{sum, min, max, first}` (8 shapes) + `{length, count, long_count}`. Bare body, 2-slot named-tuple wrap, and N+1-slot multi-reducer named tuple all supported. Upstream `where_*`/`select*` chains fuse into the per-element loop with lazy semantics (selects after a where execute INSIDE that where's guard). An optional `having_(pred)` between `group_by_lazy` and `select` is rewritten to reference accumulator slots and wraps the result-build push; predicates that touch the raw bucket array or reference a reducer with no matching select slot cascade. Bails to tier 2 for `average`, key-not-at-slot-0 in named tuple, or upstream ops other than `where_*`/`select*` (e.g. distinct/order_by). | ✅ |
 | 3+ BufferGroupBy — inner-select-sum (PR-A1) | Recognizes `_._1 \|> select(<lambda>) \|> sum` after `group_by_lazy(key)`. Splice peels the inner lambda body and inlines it directly into the per-element `entry._1 += <body>` site, accumulator type derived from the outer sum's resolved return type. Per-element emission split into miss-branch (init) and hit-branch (incremental update) to support this and the future min/max/first arms in PR-A2. Bare body and named-tuple wrap both supported. | ✅ |
 | 3+ BufferGroupBy — min/max/first + multi-reducer (PR-A2) | Recognizer generalized to bare + inner-select `{sum, min, max, first}` (8 reducer shapes). Planner walks an `array<ReducerSpec>` so the named-tuple wrap extends from 2-slot to N+1-slot (key at slot 0, reducers at slots 1..N) — a single per-element pass fuses N reducers. min/max use direct `<`/`>` on workhorse acc types, fall back to `_::less` for non-workhorse. first emits miss-init only (no hit update); `first_or_default(d)` rejects on the 2-arg arity check and cascades. `average` and key-not-at-slot-0 cascade. | ✅ |
 | 3+ BufferGroupBy — upstream where/select fusion (PR-B) | `plan_group_by` walks calls between source and `group_by_lazy`, fusing chains of `where_*` and `select*` into the per-element loop. Selects bind projected values to intermediate vars (referenced by key, table value type, and reducer splices); wheres AND-merge within a segment and guard everything that follows them — selects appearing after a where emit their binds INSIDE that where's `if`, preserving the reference's lazy `select` semantics (a projection like `_where(_!=0)._select(10/_)` only runs on survivors). Bails on any other upstream op (distinct/order_by/etc. cascade to tier 2). Closes the `arr \|> where \|> group_by \|> aggregate` shape — one of the most common shapes in the operator catalogue. | ✅ |
-| 3+ Buffer remainder | MultiSourceZip, BufferedJoin, group_by `average` reducer (2-slot per-key acc + post-process division), `having_*` between `group_by` and `select(group_proj)`. Currently cascade to tier 2 array-shape. | ⏳ |
+| 3+ BufferGroupBy — having_ filter fusion (PR-D) | `plan_group_by` accepts an optional `having_(pred)` between `group_by_lazy(key)` and `select(group_proj)`. The predicate's `<bind>._0` and `<reducer>(<bind>._1)` references are rewritten to `kv._{slot}` against the existing select-side reducer slots; the rewritten predicate then wraps the result-build push (or counter increment for the count terminator), so only buckets passing the filter materialize. Bails when the predicate references a reducer with no matching select slot, touches the raw bucket array, or references the bucket value in any other shape — those still cascade to tier 2. Closes the SQL `HAVING` shape against the splice path. | ✅ |
+| 3+ Buffer remainder | MultiSourceZip, BufferedJoin, group_by `average` reducer (2-slot per-key acc + post-process division). Currently cascade to tier 2 array-shape. | ⏳ |
 | 4 | Final coverage pass + docs; full 3-way comparison table refresh; parity-test sweep | ⏳ |
 
 ## Baselines (100K rows, INTERP mode)
@@ -72,6 +73,7 @@ Notation: `—` means the variant is not applicable for this benchmark (operator
 | groupby_where_count | `where → group_by → select((K, length))` | 75 | 65 | **23** (PR-B upstream where fused) |
 | groupby_where_sum | `where → group_by → select((K, select → sum))` | 86 | 80 | **23** (PR-B upstream where + inner-select-sum fused) |
 | groupby_select_sum | `select → group_by → select((K, sum))` | — | 110 | **58** (PR-B upstream select fused via intermediate var bind) |
+| groupby_having_count | `group_by → having(len>=5) → select((K, length))` | 141 | 78 | **36** (PR-D having predicate rewritten to slot ref) |
 | chained_where | `where → where → count` | 36 | 45 | 17 |
 | zip_dot_product | `zip → select → sum` | — | 53 | 37 |
 | join_count | `join → count` | —\*\* | 116 | 122 |
@@ -466,8 +468,45 @@ The `where`-fused benchmarks (groupby_where_count and groupby_where_sum) drop to
 
 ### Deferred for PR-C / follow-ups
 
-- `having_*` between `group_by` and `select(group_proj)` (HAVING-clause shape — needs to defer the predicate to the result-build loop, not the per-element table-update loop)
 - Other upstream ops: `distinct`, `order_by`, `skip`/`take` (skip/take before group_by is rare; distinct/order_by would need streaming dedup / pre-sort integration)
+
+## Phase 3+ groupby reducer expansion — having_ filter fusion (PR-D)
+
+Closes the SQL `HAVING` shape against the splice path: any `_having(pred)` between `group_by_lazy` and `select(group_proj)` used to cascade because plan_group_by required the `select` to sit directly on `group_by_lazy`.
+
+**How it lands:**
+
+1. **Pop `having_` between select and group_by_lazy.** After the existing tail pops (`count` terminator, then `select(group_proj)`), the planner now optionally pops a `_having` call before checking for `group_by_lazy`.
+
+2. **Rewrite the predicate against accumulator slots.** `fold_linq_cond` peels the having lambda into a fresh `hb` bind, then a recursive AST walker (`rewrite_having_pred`) substitutes:
+   - `<hb>._0` → `kv._0` (the key slot)
+   - `<reducer>(<hb>._1)` → `kv._{spec.slot}` when the bare reducer matches an existing select-side spec by name
+   - `<reducer>(select(<hb>._1, <lam>))` → `kv._{spec.slot}` for inner-select reducers (matched by reducer name; v1 doesn't structurally compare inner lambda bodies)
+
+   Any other use of `<hb>` — raw value, `_1` outside a matched reducer, `_<other>` field — returns `null` and the planner cascades. ExprRef2Value wrappers the typer leaves around field reads are peeled at the entry of the walker, mirroring `is_bind_field_access`.
+
+3. **Wrap result-build with the rewritten predicate.** The `to_array` lane wraps `push_clone(outputExpr)` in `if (predicate)`; the `count` terminator can no longer collapse to `length(tab)` and instead emits a counter loop with the same filter. Per-element table-update is unchanged — the per-bucket filter runs once per *distinct key*, not per source element.
+
+**Bail cases (cascade to tier 2):**
+- Having references a reducer with no matching select slot (e.g., `_._1|>sum > N` when select has only length).
+- Having touches the bucket array in any non-reducer shape (e.g., `empty(_._1)`).
+- All upstream bail cases from PR-A1/A2/B still apply.
+
+### Headline (PR-D)
+
+| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (this PR) | Win |
+|---|---|---:|---:|---:|---:|
+| groupby_having_count | `each(arr) → group_by(brand) → having(len>=5) → select((K, length)) → to_array` | 141 | 78 | **36** | **2.2× over m3 / 3.9× over m1 SQL** |
+| groupby_count (regression check) | `each(arr) → group_by(brand) → select((K, length)) → to_array` | 141 | 71 | **36** | parity — PR-D rewrite-or-bail path preserves the no-having splice |
+| groupby_where_count (regression check) | upstream-where-fused chain | 75 | 62 | **23** | parity — PR-B preserved |
+
+`groupby_having_count` lands at the same ~36 ns/op as `groupby_count` because the per-element loop is unchanged — only the result-build adds the per-bucket filter, which runs O(num distinct keys) times rather than O(N).
+
+### Deferred for follow-ups
+
+- `average` reducer (still cascades — needs 2-slot per-key acc + post-process division).
+- Having predicates that reference a reducer absent from the select (would need a hidden accumulator slot in the table value type).
+- Having predicates that touch the raw bucket array (would require materializing the per-bucket array, defeating the splice).
 
 ## Operator-coverage checklist (parity tests)
 
@@ -480,7 +519,7 @@ The 24 benchmarks above cover the most common shapes. The end-game target is one
 | `test_linq_querying.das` | any/all/contains | any_match, all_match, contains_match | ✅ core |
 | `test_linq_transform.das` | select/select_many/zip | to_array_filter, zip_dot_product | ✅ select/zip; `select_many` ⏳ |
 | `test_linq_sorting.das` | order/order_by/reverse | sort_first, sort_take, select_where_order_take, reverse_take | ✅ ascending + `order_descending` (Phase 3); ✅ `reverse` (this PR; `reverse \|> take(N)` shape is a regression vs lazy iterator — see Phase 3+ notes) |
-| `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum, groupby_min, groupby_max, groupby_first, groupby_multi_reducer, groupby_where_count, groupby_where_sum, groupby_select_sum | ✅ count/long_count/sum + inner-select-sum (PR-A1); ✅ min/max/first + inner-select-{min,max,first} + multi-reducer (PR-A2); ✅ upstream where_/select* fusion (PR-B); ⏳ `average`, `having_` |
+| `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum, groupby_min, groupby_max, groupby_first, groupby_multi_reducer, groupby_where_count, groupby_where_sum, groupby_select_sum, groupby_having_count | ✅ count/long_count/sum + inner-select-sum (PR-A1); ✅ min/max/first + inner-select-{min,max,first} + multi-reducer (PR-A2); ✅ upstream where_/select* fusion (PR-B); ✅ `having_` with matching slot (PR-D); ⏳ `average` |
 | `test_linq_join.das` | join/left_join/right_join/full_outer/cross | join_count | ✅ inner; outer joins + cross ⏳ |
 | `test_linq_partition.das` | take/skip/take_while/skip_while/chunk | take_count, skip_take, take_sum_aggregate, take_count_filtered | ✅ take/skip in splice lanes; `_while` + `chunk` ⏳ |
 | `test_linq_set.das` | distinct/union/except/intersect/unique | distinct_count, distinct_take | ✅ distinct + distinct_by (streaming dedup, this PR); union/except/intersect/unique ⏳ |

--- a/benchmarks/sql/groupby_having_count.das
+++ b/benchmarks/sql/groupby_having_count.das
@@ -1,0 +1,64 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _group_by(_.brand) |> _having(_._1 |> length >= 5) |> _select((Brand=key, N=length)).
+// SQL: SELECT brand, COUNT(*) FROM cars GROUP BY brand HAVING COUNT(*) >= 5.
+// Splice mode (PR-D) recognizes that the having predicate's length(_._1) matches the
+// select's length slot — the predicate rewrites to `kv._{slot} >= 5` and wraps the
+// result-build push_clone in a per-bucket filter. Per-element loop is unchanged from
+// PR-A2's count splice; the only extra cost is the post-table filter.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let groups <- _sql(db |> select_from(type<Car>)
+                                  |> _group_by(_.brand)
+                                  |> _having(_._1 |> length >= 5)
+                                  |> _select((Brand = _._0, N = _._1 |> length)))
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let groups <- (arr._group_by(_.brand)._having(_._1 |> length >= 5)._select((Brand = _._0, N = _._1 |> length)))
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let groups <- _fold(each(arr)
+                            ._group_by(_.brand)
+                            ._having(_._1 |> length >= 5)
+                            ._select((Brand = _._0, N = _._1 |> length))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def groupby_having_count_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def groupby_having_count_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def groupby_having_count_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1915,6 +1915,104 @@ def private emit_reducer_branches(spec : ReducerSpec; at : LineInfo; entryName, 
 }
 
 [macro_function]
+def private rewrite_having_pred(var expr : Expression?; hbName, kvName : string; specs : array<ReducerSpec>) : Expression? {
+    // Substitutes `<hb>._0` → `kv._0` and `<reducer>(<hb>._1)` / `<reducer>(select(<hb>._1, <lam>))` → `kv._{slot}` against matching specs; any other use of `<hb>` returns null and cascades.
+    if (expr == null) return expr
+    // Peel typer-inserted ExprRef2Value wrappers (same pattern as is_bind_field_access).
+    while (expr is ExprRef2Value) {
+        expr = (expr as ExprRef2Value).subexpr
+    }
+    if (expr is ExprCall) {
+        var c = expr as ExprCall
+        if (c.func != null && (c.arguments |> length) == 1) {
+            var fnName = string(c.func.name)
+            if (c.func.fromGeneric != null) {
+                fnName = string(c.func.fromGeneric.name)
+            }
+            if (is_bind_field_access(c.arguments[0], hbName, 1)) {
+                for (s in specs) {
+                    if (s.innerBody == null && s.name == fnName) return mk_slot_ref(expr.at, kvName, s.slot)
+                }
+                return null
+            }
+            let inner = c.arguments[0]
+            if (inner != null && inner is ExprCall) {
+                let ic = inner as ExprCall
+                if (ic.func != null && (ic.arguments |> length) == 2 && is_bind_field_access(ic.arguments[0], hbName, 1)) {
+                    var innerName = string(ic.func.name)
+                    if (ic.func.fromGeneric != null) {
+                        innerName = string(ic.func.fromGeneric.name)
+                    }
+                    if (innerName == "select") {
+                        let comboName = "{fnName}_inner_select"
+                        for (s in specs) {
+                            if (s.name == comboName) return mk_slot_ref(expr.at, kvName, s.slot)
+                        }
+                        return null
+                    }
+                }
+            }
+        }
+        for (i in 0 .. (c.arguments |> length)) {
+            var sub = rewrite_having_pred(c.arguments[i], hbName, kvName, specs)
+            if (sub == null) return null
+            c.arguments[i] = sub
+        }
+        return expr
+    }
+    if (expr is ExprField) {
+        var f = expr as ExprField
+        if (f.value != null && f.value is ExprVar) {
+            let v = f.value as ExprVar
+            if (v.name == hbName) {
+                if (f.name == "_0") return mk_slot_ref(expr.at, kvName, 0)
+                return null
+            }
+        }
+        var sub = rewrite_having_pred(f.value, hbName, kvName, specs)
+        if (sub == null) return null
+        f.value = sub
+        return expr
+    }
+    if (expr is ExprVar) {
+        let v = expr as ExprVar
+        if (v.name == hbName) return null
+        return expr
+    }
+    if (expr is ExprOp1) {
+        var op = expr as ExprOp1
+        var sub = rewrite_having_pred(op.subexpr, hbName, kvName, specs)
+        if (sub == null) return null
+        op.subexpr = sub
+        return expr
+    }
+    if (expr is ExprOp2) {
+        var op = expr as ExprOp2
+        var l = rewrite_having_pred(op.left, hbName, kvName, specs)
+        if (l == null) return null
+        op.left = l
+        var r = rewrite_having_pred(op.right, hbName, kvName, specs)
+        if (r == null) return null
+        op.right = r
+        return expr
+    }
+    if (expr is ExprOp3) {
+        var op = expr as ExprOp3
+        var s = rewrite_having_pred(op.subexpr, hbName, kvName, specs)
+        if (s == null) return null
+        op.subexpr = s
+        var l = rewrite_having_pred(op.left, hbName, kvName, specs)
+        if (l == null) return null
+        op.left = l
+        var r = rewrite_having_pred(op.right, hbName, kvName, specs)
+        if (r == null) return null
+        op.right = r
+        return expr
+    }
+    return expr
+}
+
+[macro_function]
 def private plan_group_by(var expr : Expression?) : Expression? {
     var (top, calls) = flatten_linq(expr)
     if (empty(calls)) return null
@@ -1932,7 +2030,13 @@ def private plan_group_by(var expr : Expression?) : Expression? {
     if (empty(calls) || calls.back()._1.name != "select") return null
     var groupProjCall = calls.back()._0
     calls |> pop
-    // The call immediately before select must be group_by_lazy with a key arg.
+    // Optional: having_ between select and group_by_lazy (SQL HAVING shape) — rewritten below against accumulator slots.
+    var havingCall : ExprCall?
+    if (!empty(calls) && calls.back()._1.name == "having_") {
+        havingCall = calls.back()._0
+        calls |> pop
+    }
+    // The call immediately before must be group_by_lazy with a key arg.
     if (empty(calls) || calls.back()._1.name != "group_by_lazy") return null
     var groupByCall = calls.back()._0
     calls |> pop
@@ -2015,6 +2119,15 @@ def private plan_group_by(var expr : Expression?) : Expression? {
     if (groupProjBody == null || groupProjBody._type == null) return null
     var (specs, usesNamedTuple) = recognize_reducer_specs(groupProjBody, bindName, itName)
     if (empty(specs)) return null
+    // Rewrite optional having predicate against accumulator slots; bails on anything other than _._0 / reducer(_._1) matched to a select slot.
+    var havingPred : Expression?
+    if (havingCall != null) {
+        let hbName = "`hb`{at.line}`{at.column}"
+        var rawPred = fold_linq_cond(havingCall.arguments[1], hbName)
+        if (rawPred == null) return null
+        havingPred = rewrite_having_pred(rawPred, hbName, kvName, specs)
+        if (havingPred == null) return null
+    }
     // Named-tuple wrap reuses the user's body type (preserves field-name hints); bare reducer synthesizes tuple<KeyT; AccT>.
     var keyBlk1 = clone_expression(keyBlock)
     var keyBlk2 = clone_expression(keyBlock)
@@ -2115,8 +2228,21 @@ def private plan_group_by(var expr : Expression?) : Expression? {
     }
     // Lane: count terminator returns length(tab) directly (number of groups).
     if (terminatorName == "count") {
-        stmts |> push <| qmacro_expr() {
-            return length($i(tabName))
+        if (havingPred != null) {
+            let cntName = "`cnt`{at.line}`{at.column}"
+            stmts |> push <| qmacro_block() {
+                var $i(cntName) = 0
+                for ($i(kvName) in values($i(tabName))) {
+                    if ($e(havingPred)) {
+                        $i(cntName) ++
+                    }
+                }
+                return $i(cntName)
+            }
+        } else {
+            stmts |> push <| qmacro_expr() {
+                return length($i(tabName))
+            }
         }
     } else {
         // to_array lane: build result buffer by walking the table. Each output element
@@ -2144,9 +2270,19 @@ def private plan_group_by(var expr : Expression?) : Expression? {
         stmts |> push <| qmacro_expr() {
             $i(bufName) |> reserve(length($i(tabName)))
         }
-        stmts |> push <| qmacro_expr() {
-            for ($i(kvName) in values($i(tabName))) {
-                $i(bufName) |> push_clone($e(outputExpr))
+        if (havingPred != null) {
+            stmts |> push <| qmacro_expr() {
+                for ($i(kvName) in values($i(tabName))) {
+                    if ($e(havingPred)) {
+                        $i(bufName) |> push_clone($e(outputExpr))
+                    }
+                }
+            }
+        } else {
+            stmts |> push <| qmacro_expr() {
+                for ($i(kvName) in values($i(tabName))) {
+                    $i(bufName) |> push_clone($e(outputExpr))
+                }
             }
         }
         stmts |> push(buffer_return(bufName, expr._type.isIterator))

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -2012,6 +2012,36 @@ def private rewrite_having_pred(var expr : Expression?; hbName, kvName : string;
     return expr
 }
 
+class private HbScanner : AstVisitor {
+    // Safety net for rewrite_having_pred — flags any ExprVar reference that survived
+    // the targeted rewrite (e.g., because the predicate contained a node type the walker
+    // doesn't recurse into, like ExprAt or ExprInvoke from a non-peelable lambda).
+    vname : string
+    hit : bool = false
+    def HbScanner(n : string) {
+        vname = n
+    }
+    def override visitExprVar(var expr : ExprVar?) : Expression? {
+        if (expr.name == vname) {
+            hit = true
+        }
+        return expr
+    }
+}
+
+def private expr_uses_var(var e : Expression?; name : string) : bool {
+    if (e == null) return false
+    var astVisitor = new HbScanner(name)
+    make_visitor(*astVisitor) $(astVisitorAdapter) {
+        visit_expression(e, astVisitorAdapter)
+    }
+    let hit = astVisitor.hit
+    unsafe {
+        delete astVisitor
+    }
+    return hit
+}
+
 [macro_function]
 def private plan_group_by(var expr : Expression?) : Expression? {
     var (top, calls) = flatten_linq(expr)
@@ -2126,7 +2156,8 @@ def private plan_group_by(var expr : Expression?) : Expression? {
         var rawPred = fold_linq_cond(havingCall.arguments[1], hbName)
         if (rawPred == null) return null
         havingPred = rewrite_having_pred(rawPred, hbName, kvName, specs)
-        if (havingPred == null) return null
+        // Safety net: a node type rewrite_having_pred didn't recurse into would leak hbName through to the splice (compile error at the splice site). Bail.
+        if (havingPred == null || expr_uses_var(havingPred, hbName)) return null
     }
     // Named-tuple wrap reuses the user's body type (preserves field-name hints); bare reducer synthesizes tuple<KeyT; AccT>.
     var keyBlk1 = clone_expression(keyBlock)

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -2077,6 +2077,27 @@ def test_group_by_having_fold_parity(t : T?) {
 }
 
 [test]
+def test_group_by_having_unhandled_node_cascades(t : T?) {
+    // PR-D safety: any unhandled node type that references `hb` (ExprAt for `_._1[0]`,
+    // ExprInvoke from a non-peelable lambda, etc.) must NOT silently leak `hbName` into
+    // the result-build splice — instead the planner bails and the chain cascades.
+    t |> run("ExprAt on bucket (_._1[0]) cascades to tier 2") @(tt : T?) {
+        let nums = [1, 2, 3, 4, 5, 6]
+        // _._1[0] is ExprAt indexing into the bucket array. Without the post-rewrite scan
+        // the bare `hb._1[0]` reference would survive into the splice (compile-time
+        // failure at the splice site rather than a graceful cascade).
+        let got <- _fold(nums._group_by_lazy(_ % 2)._having(_._1[0] == 1)._select((K = _._0, N = _._1 |> length)))
+        // Bucket 0=[2,4,6] first=2≠1 fails; bucket 1=[1,3,5] first=1 passes.
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(1, seen |> length)
+        tt |> equal(3, seen[1])
+    }
+}
+
+[test]
 def test_group_by_having_unmatched_reducer_cascades(t : T?) {
     // PR-D bail: having references a reducer not present in select. Splice cascades to tier 2;
     // semantics must still be correct via the array-shape pipeline.

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -1987,6 +1987,113 @@ def test_group_by_upstream_select_after_where_is_lazy(t : T?) {
 }
 
 [test]
+def test_group_by_having_fold_parity(t : T?) {
+    // PR-D: `_group_by_lazy(k) |> _having(p) |> _select(group_proj) [|> count]` — having filters
+    // groups at result-build time. The predicate references _._0 (key) and/or reducer calls on _._1
+    // that match an existing select-side reducer slot; everything else cascades to tier 2.
+    t |> run("bare-form length-match: filter buckets by size") @(tt : T?) {
+        let nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let got <- _fold(nums._group_by_lazy(_ % 3)._having(_._1 |> length >= 4)._select(_._1 |> length))
+        // Buckets %3: 0=[3,6,9](3), 1=[1,4,7,10](4), 2=[2,5,8](3). Keep len>=4 → bucket 1 only.
+        var total = 0
+        for (c in got) {
+            total += c
+        }
+        tt |> equal(4, total)
+        var cnt = 0
+        for (_x in got) {
+            cnt ++
+        }
+        tt |> equal(1, cnt)
+    }
+    t |> run("named-tuple form: length-match preserves output shape") @(tt : T?) {
+        let nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let got <- _fold(nums._group_by_lazy(_ % 3)._having(_._1 |> length >= 4)._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(1, seen |> length)
+        tt |> equal(4, seen[1])
+    }
+    t |> run("count terminator with having") @(tt : T?) {
+        let nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let c = _fold(nums._group_by_lazy(_ % 3)._having(_._1 |> length >= 4)._select((K = _._0, N = _._1 |> length)) |> count())
+        tt |> equal(1, c)
+    }
+    t |> run("predicate references key (_._0)") @(tt : T?) {
+        let nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        // Keep buckets where length >= key. key 0 → len 3 ≥ 0 ✓; key 1 → 4 ≥ 1 ✓; key 2 → 3 ≥ 2 ✓ (all three pass).
+        let got <- _fold(nums._group_by_lazy(_ % 3)._having(_._1 |> length >= _._0)._select((K = _._0, N = _._1 |> length)))
+        var cnt = 0
+        for (_x in got) {
+            cnt ++
+        }
+        tt |> equal(3, cnt)
+    }
+    t |> run("all buckets filtered out") @(tt : T?) {
+        let nums = [1, 2, 3, 4, 5]
+        let got <- _fold(nums._group_by_lazy(_ % 5)._having(_._1 |> length > 1)._select(_._1 |> length))
+        var cnt = 0
+        for (_x in got) {
+            cnt ++
+        }
+        tt |> equal(0, cnt)
+    }
+    t |> run("empty source") @(tt : T?) {
+        var empty : array<int>
+        let got <- _fold(empty._group_by_lazy(_)._having(_._1 |> length > 0)._select(_._1 |> length))
+        var cnt = 0
+        for (_x in got) {
+            cnt ++
+        }
+        tt |> equal(0, cnt)
+    }
+    t |> run("upstream where + having: both fuse") @(tt : T?) {
+        let nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        // where >2 then group %3: 0=[3,6,9](3), 1=[4,7,10](3), 2=[5,8](2); having len>=3 → 0,1.
+        let got <- _fold(nums._where(_ > 2)._group_by_lazy(_ % 3)._having(_._1 |> length >= 3)._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(2, seen |> length)
+        tt |> equal(3, seen[0])
+        tt |> equal(3, seen[1])
+    }
+    t |> run("inner-select-sum reducer matches in having") @(tt : T?) {
+        // Both select and having reference _._1 |> select(...) |> sum on the same projection.
+        let arr = [1, 2, 3, 4, 5, 6, 7, 8]
+        // Buckets %3: 0=[3,6](sum=9), 1=[1,4,7](sum=12), 2=[2,5,8](sum=15). Having sum>10 → 1,2.
+        let got <- _fold(arr._group_by_lazy(_ % 3)._having(_._1 |> select($(x : int) => x * 1) |> sum > 10)._select((K = _._0, S = _._1 |> select($(x : int) => x * 1) |> sum)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.S
+        }
+        tt |> equal(2, seen |> length)
+        tt |> equal(12, seen[1])
+        tt |> equal(15, seen[2])
+    }
+}
+
+[test]
+def test_group_by_having_unmatched_reducer_cascades(t : T?) {
+    // PR-D bail: having references a reducer not present in select. Splice cascades to tier 2;
+    // semantics must still be correct via the array-shape pipeline.
+    t |> run("having uses sum but select only has length") @(tt : T?) {
+        let arr = [1, 2, 3, 4, 5, 6]
+        // Buckets %2: 0=[2,4,6](sum=12, len=3), 1=[1,3,5](sum=9, len=3). Having sum > 10 → 0.
+        let got <- _fold(arr._group_by_lazy(_ % 2)._having(_._1 |> sum > 10)._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(1, seen |> length)
+        tt |> equal(3, seen[0])
+    }
+}
+
+[test]
 def test_reverse_count_parity(t : T?) {
     // R5: reverse |> count — counter loop, no reverse work.
     t |> run("reverse.count: identity") @(tt : T?) {

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -2315,6 +2315,101 @@ def test_group_by_having_cascades_to_tier2(t : T?) {
     }
 }
 
+[export, marker(no_coverage)]
+def target_group_by_having_length_match_fold() : array<tuple<K : int; N : int>> {
+    // PR-D splice: `_having(_._1|>length>=N)` between group_by_lazy and select where the select
+    // has a matching length slot — predicate rewrites to `kv._{slot}>=N` and wraps push_clone.
+    return <- _fold([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]._group_by_lazy(_ % 3)._having(_._1 |> length >= 4)._select((K = _._0, N = _._1 |> length)))
+}
+
+[test]
+def test_group_by_having_length_match_splices(t : T?) {
+    // Single-hash hot path (no key_exists) + no runtime having_/select call in the splice body.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_having_length_match_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "expected splice wrapper")
+        t |> equal(0, count_call(body_expr, "key_exists"))
+        t |> success(count_call(body_expr, "unique_key") >= 1, "table-update uses unique_key")
+        t |> equal(0, count_call(body_expr, "having_"))
+        t |> equal(0, count_call(body_expr, "group_by_lazy"))
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_having_count_terminator_fold() : int {
+    // PR-D count terminator: result-build counts only the buckets passing the rewritten predicate.
+    return _fold([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]._group_by_lazy(_ % 3)._having(_._1 |> length >= 4)._select((K = _._0, N = _._1 |> length)) |> count())
+}
+
+[test]
+def test_group_by_having_count_terminator_splices(t : T?) {
+    // count + having: no length(tab) shortcut (we have to inspect each entry); the splice emits
+    // a counter loop instead — `having_` and `group_by_lazy` should still be absent.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_having_count_terminator_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "expected splice wrapper")
+        t |> equal(0, count_call(body_expr, "having_"))
+        t |> equal(0, count_call(body_expr, "group_by_lazy"))
+        t |> equal(0, count_call(body_expr, "key_exists"))
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_having_unmatched_cascades() : array<tuple<K : int; N : int>> {
+    // BAIL: having uses sum but the select has only length — no matching slot, so the planner
+    // returns null and the chain cascades to tier 2.
+    return <- _fold([1, 2, 3, 4, 5, 6]._group_by_lazy(_ % 2)._having(_._1 |> sum > 10)._select((K = _._0, N = _._1 |> length)))
+}
+
+[test]
+def test_group_by_having_unmatched_cascades_to_tier2(t : T?) {
+    // Cascade fingerprint: multiple pass_N let-vars (group, having, select all separate).
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_having_unmatched_cascades)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper from cascade")
+        t |> success(count_outer_let_vars(body_expr) >= 2,
+            "cascade fingerprint: multiple pass_N outer vars")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_having_raw_bucket_cascades() : array<tuple<K : int; N : int>> {
+    // BAIL: predicate touches _._1 outside any matched reducer (raw bucket-array length probe).
+    // is_bind_field_access on _._1 alone (used as condition value) is not in the recognized set.
+    return <- _fold([1, 2, 3, 4, 5, 6]._group_by_lazy(_ % 2)._having(empty(_._1))._select((K = _._0, N = _._1 |> length)))
+}
+
+[test]
+def test_group_by_having_raw_bucket_cascades_to_tier2(t : T?) {
+    // Cascade fingerprint: multiple pass_N let-vars.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_having_raw_bucket_cascades)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper from cascade")
+        t |> success(count_outer_let_vars(body_expr) >= 2,
+            "cascade fingerprint: multiple pass_N outer vars")
+    }
+}
+
 [test]
 def test_reverse_select_pushes_projection_not_source(t : T?) {
     // R3: select before reverse — the loop pushes the projected value, not the


### PR DESCRIPTION
## Summary

Closes the deferred SQL `HAVING` shape on the splice path. Any `_having(pred)` between `_group_by_lazy(k)` and `_select(group_proj)` used to cascade because `plan_group_by` required `select` to sit directly on `group_by_lazy`.

This PR teaches `plan_group_by` to:

1. **Pop `having_` between select and group_by_lazy.** The trailing pops now optionally pop a `_having` call before the `group_by_lazy` check.

2. **Rewrite the predicate against accumulator slots.** `fold_linq_cond` peels the having lambda into a fresh `hb` bind; a recursive AST walker (`rewrite_having_pred`) substitutes:
   - `&lt;hb&gt;._0` → `kv._0` (the key slot)
   - `&lt;reducer&gt;(&lt;hb&gt;._1)` → `kv._{spec.slot}` when the bare reducer matches an existing select-side spec by name
   - `&lt;reducer&gt;(select(&lt;hb&gt;._1, &lt;lam&gt;))` → `kv._{spec.slot}` for inner-select reducers
   
   ExprRef2Value wrappers are peeled at entry, mirroring `is_bind_field_access`. Anything else — raw `_`, raw `_._1`, unrecognized field, reducer with no matching slot — returns null and the planner cascades to tier 2.

3. **Wrap result-build with the rewritten predicate.** The `to_array` lane wraps `push_clone(outputExpr)` in `if (predicate)`; the `count` terminator can no longer collapse to `length(tab)` and emits a counter loop with the same filter. Per-element table-update is unchanged — the per-bucket filter runs once per **distinct key**, not per source element.

## Headline benchmark

| Benchmark | m1 (sql) | m3 (linq) | m3f (this PR) | Win |
|---|---:|---:|---:|---:|
| groupby_having_count | 141 | 78 | **36** | **2.2× over m3 / 3.9× over m1 SQL** |

Same ~36 ns/op as the no-having `groupby_count` because per-element work is identical — only result-build adds the per-bucket filter, which is O(num distinct keys), not O(N). Regression sweep on groupby_count/sum/multi_reducer/where_count/where_sum/select_sum all unchanged.

## Tests

- **Parity** (`test_linq_fold.das`): 8 subtests in `test_group_by_having_fold_parity` cover bare/named forms, count terminator, key-in-predicate, all-filtered-out, empty source, upstream-where-fused chain, and inner-select-sum match. 1 cascade subtest in `test_group_by_having_unmatched_reducer_cascades` confirms tier 2 still produces correct values when the having reducer has no matching slot.
- **AST shape** (`test_linq_fold_ast.das`): `test_group_by_having_length_match_splices`, `test_group_by_having_count_terminator_splices` confirm the splice fires (no runtime `having_`/`group_by_lazy` call, single-hash hot path preserved). `test_group_by_having_unmatched_cascades_to_tier2` and `test_group_by_having_raw_bucket_cascades_to_tier2` confirm the bails cascade.

## Test plan

- [x] `mcp__daslang__run_test tests/linq/test_linq_fold.das` — 280 tests pass
- [x] `mcp__daslang__run_test tests/linq/test_linq_fold_ast.das` — 110 tests pass
- [x] AOT mode via `bin/test_aot -use-aot dastest/dastest.das -- --use-aot --test ...` — 390 tests pass
- [x] Full `tests/linq/*.das` sweep — all green
- [x] Benchmark sweep: groupby_count/sum/multi_reducer/where_count/where_sum/select_sum at parity with master
- [x] `mcp__daslang__format_file` + `mcp__daslang__lint` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)