### PR TITLE
linq_fold group_by: average reducer splice (2-slot acc + post-process divide)

### DIFF
--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -33,12 +33,13 @@ See `~/.claude/plans/keen-hopping-balloon.md` and `~/.claude/plans/enumerated-ba
 | 3d | `select + where + terminator` splice arm via `replaceVariablePeeling` (new helper in `daslib/templates_boost.das`). Substitutes the projection into the where predicate, peeling the typer-inserted ExprRef2Value wrappers that would otherwise be left orphaned around a non-reference value. Bails to tier 2 when the projection has side effects (would double-evaluate). Lands all four terminator lanes (ARRAY / COUNTER / ACCUMULATOR / EARLY_EXIT). | ✅ done |
 | 3+ BufferReverse | `[where_*]?[select?] \|> reverse [\|> take(N)]? [\|> {to_array, count, first, first_or_default}]?` — single-pass prefilter into buffer + `reverse_inplace` + optional `resize(min(N,len))`; count/first lanes elide the buffer entirely (counter or last-survivor tracker). | ✅ |
 | 3+ BufferDistinct | `[where_*]?[select?] \|> distinct[_by(key)] [\|> take(N)]? [\|> {to_array, count, sum, long_count}]?` — streaming dedup via `table<unique_key>` integrated into the prefilter loop; take(N) → break-after-N early-exit (guard placed BEFORE the consume site so non-positive N short-circuits); count terminator elides the buffer and returns `length(seen)`. `first`/`first_or_default`/`min`/`max`/`average` after `distinct` cascade to tier 2. | ✅ core |
-| 3+ BufferGroupBy | `[where_*/select*]* \|> group_by[_lazy](key) [\|> having_(pred)]? \|> select(group_proj) [\|> {to_array, count}]?` — incremental-aggregate fusion: emits `table<unique_key; tuple<KT; AccT>>` (or N+1-slot named tuple) updated per element. Recognized reducers: bare + inner-select `{sum, min, max, first}` (8 shapes) + `{length, count, long_count}`. Bare body, 2-slot named-tuple wrap, and N+1-slot multi-reducer named tuple all supported. Upstream `where_*`/`select*` chains fuse into the per-element loop with lazy semantics (selects after a where execute INSIDE that where's guard). An optional `having_(pred)` between `group_by_lazy` and `select` is rewritten to reference accumulator slots and wraps the result-build push; predicates that touch the raw bucket array or reference a reducer with no matching select slot cascade. Bails to tier 2 for `average`, key-not-at-slot-0 in named tuple, or upstream ops other than `where_*`/`select*` (e.g. distinct/order_by). | ✅ |
+| 3+ BufferGroupBy | `[where_*/select*]* \|> group_by[_lazy](key) [\|> having_(pred)]? \|> select(group_proj) [\|> {to_array, count}]?` — incremental-aggregate fusion: emits `table<unique_key; tuple<KT; AccT>>` (or N+1-slot named tuple) updated per element. Recognized reducers: bare + inner-select `{sum, min, max, first, average}` (10 shapes) + `{length, count, long_count}`. `average` uses a 2-slot per-key accumulator (sum + count, internally `tuple<double; uint64>`) with post-process division at result-build. Bare body, 2-slot named-tuple wrap, and N+1-slot multi-reducer named tuple all supported. Upstream `where_*`/`select*` chains fuse into the per-element loop with lazy semantics (selects after a where execute INSIDE that where's guard). An optional `having_(pred)` between `group_by_lazy` and `select` is rewritten to reference accumulator slots and wraps the result-build push; predicates that touch the raw bucket array or reference a reducer with no matching select slot cascade. Bails to tier 2 for key-not-at-slot-0 in named tuple, or upstream ops other than `where_*`/`select*` (e.g. distinct/order_by). | ✅ |
 | 3+ BufferGroupBy — inner-select-sum (PR-A1) | Recognizes `_._1 \|> select(<lambda>) \|> sum` after `group_by_lazy(key)`. Splice peels the inner lambda body and inlines it directly into the per-element `entry._1 += <body>` site, accumulator type derived from the outer sum's resolved return type. Per-element emission split into miss-branch (init) and hit-branch (incremental update) to support this and the future min/max/first arms in PR-A2. Bare body and named-tuple wrap both supported. | ✅ |
 | 3+ BufferGroupBy — min/max/first + multi-reducer (PR-A2) | Recognizer generalized to bare + inner-select `{sum, min, max, first}` (8 reducer shapes). Planner walks an `array<ReducerSpec>` so the named-tuple wrap extends from 2-slot to N+1-slot (key at slot 0, reducers at slots 1..N) — a single per-element pass fuses N reducers. min/max use direct `<`/`>` on workhorse acc types, fall back to `_::less` for non-workhorse. first emits miss-init only (no hit update); `first_or_default(d)` rejects on the 2-arg arity check and cascades. `average` and key-not-at-slot-0 cascade. | ✅ |
 | 3+ BufferGroupBy — upstream where/select fusion (PR-B) | `plan_group_by` walks calls between source and `group_by_lazy`, fusing chains of `where_*` and `select*` into the per-element loop. Selects bind projected values to intermediate vars (referenced by key, table value type, and reducer splices); wheres AND-merge within a segment and guard everything that follows them — selects appearing after a where emit their binds INSIDE that where's `if`, preserving the reference's lazy `select` semantics (a projection like `_where(_!=0)._select(10/_)` only runs on survivors). Bails on any other upstream op (distinct/order_by/etc. cascade to tier 2). Closes the `arr \|> where \|> group_by \|> aggregate` shape — one of the most common shapes in the operator catalogue. | ✅ |
 | 3+ BufferGroupBy — having_ filter fusion (PR-D) | `plan_group_by` accepts an optional `having_(pred)` between `group_by_lazy(key)` and `select(group_proj)`. The predicate's `<bind>._0` and `<reducer>(<bind>._1)` references are rewritten to `kv._{slot}` against the existing select-side reducer slots; the rewritten predicate then wraps the result-build push (or counter increment for the count terminator), so only buckets passing the filter materialize. Bails when the predicate references a reducer with no matching select slot, touches the raw bucket array, or references the bucket value in any other shape — those still cascade to tier 2. Closes the SQL `HAVING` shape against the splice path. | ✅ |
-| 3+ Buffer remainder | MultiSourceZip, BufferedJoin, group_by `average` reducer (2-slot per-key acc + post-process division). Currently cascade to tier 2 array-shape. | ⏳ |
+| 3+ BufferGroupBy — average reducer (PR-A2 follow-up) | Recognizer extends to bare + inner-select `average` (10 reducer shapes total). The slot uses a 2-tuple acc (`tuple<double; uint64>` — sum + count) instead of the user-facing `double`; the named-tuple table value type clones the user's body type and substitutes average slots, preserving field names. Result-build synthesizes an `ExprMakeTuple` programmatically, dividing average slots (`kv._{i}._0 / double(kv._{i}._1)`) and copying non-average slots verbatim. Having predicates that reference an average slot get the divide expression too, via a shared `mk_slot_output_expr` helper. Buckets are non-empty by construction (a key only enters the table after at least one source element produced it), so the count is always ≥1 and no divide-by-zero guard is needed. | ✅ |
+| 3+ Buffer remainder | MultiSourceZip, BufferedJoin. Currently cascade to tier 2 array-shape. | ⏳ |
 | 4 | Final coverage pass + docs; full 3-way comparison table refresh; parity-test sweep | ⏳ |
 
 ## Baselines (100K rows, INTERP mode)
@@ -74,6 +75,7 @@ Notation: `—` means the variant is not applicable for this benchmark (operator
 | groupby_where_sum | `where → group_by → select((K, select → sum))` | 86 | 80 | **23** (PR-B upstream where + inner-select-sum fused) |
 | groupby_select_sum | `select → group_by → select((K, sum))` | — | 110 | **58** (PR-B upstream select fused via intermediate var bind) |
 | groupby_having_count | `group_by → having(len>=5) → select((K, length))` | 141 | 78 | **36** (PR-D having predicate rewritten to slot ref) |
+| groupby_average | `group_by → select((K, select → average))` | 173 | 106 | **52** (PR-A2 follow-up: 2-slot acc + post-process divide) |
 | chained_where | `where → where → count` | 36 | 45 | 17 |
 | zip_dot_product | `zip → select → sum` | — | 53 | 37 |
 | join_count | `join → count` | —\*\* | 116 | 122 |
@@ -504,9 +506,38 @@ Closes the SQL `HAVING` shape against the splice path: any `_having(pred)` betwe
 
 ### Deferred for follow-ups
 
-- `average` reducer (still cascades — needs 2-slot per-key acc + post-process division).
 - Having predicates that reference a reducer absent from the select (would need a hidden accumulator slot in the table value type).
 - Having predicates that touch the raw bucket array (would require materializing the per-bucket array, defeating the splice).
+
+## Phase 3+ groupby reducer expansion — average reducer (PR-A2 follow-up)
+
+Closes the explicit `average` cascade deferred since PR-A1 / PR-A2 / PR-D. `average` is structurally different from sum/count/min/max/first: each per-key accumulator needs **two slots** (running sum + element count), and result-build divides at output. The PR-A1 miss/hit emission shape generalizes cleanly — the only deltas are an extra `mk_avg_acc_type` (`tuple<double; uint64>`), per-slot output synthesis, and a having-predicate substitution that emits the divide expression instead of a plain field ref.
+
+**How it lands:**
+
+1. **Recognizer (`is_bucket_reducer_call`).** Adds `"average"` to both the bare arm (`<bind>._1 |> average`) and the inner-select arm (`<bind>._1 |> select(<lambda>) |> average`). The returned reducer name is `"average"` or `"average_inner_select"` and feeds into `recognize_reducer_specs` just like any other reducer.
+
+2. **Per-slot acc type override (`slot_acc_type`).** When the reducer is average, the slot type is forced to `tuple<double; uint64>` (sum + count) regardless of the user-facing return type (`double`). The user's body type stays the buffer element type so the result array's declared shape (e.g., `tuple<K : int; Avg : double>`) is preserved.
+
+3. **Miss/hit emission (`emit_reducer_branches`).** `entry._{slot} = (double(it), 1ul)` on miss; `entry._{slot}._0 += double(it); entry._{slot}._1 ++` on hit. The `_inner_select` arm evaluates the inner projection once into a `let vavg`-bound temp (matches reference single-eval-per-element semantics).
+
+4. **Table value type + result-build (`plan_group_by`).** A `hasAvg` scan picks up any average slot. For the named-tuple form, the cloned `tabValueType` swaps each average slot's `argTypes[slot]` from `double` (user's view) to the `tuple<double; uint64>` acc shape (preserves the field name from the user's `argNames`). At result-build, the output expression is a programmatically-constructed `ExprMakeTuple` that copies non-average slots verbatim (`kv._{i}`) and divides average slots (`kv._{i}._0 / double(kv._{i}._1)`); for the bare form the same divide expression replaces `kv._1`. Buckets are non-empty by construction (a key only enters the table if at least one source element produced it), so the count is always ≥1 — no divide-by-zero guard needed.
+
+5. **Having-predicate transform.** `rewrite_having_pred` routes average-slot references through a shared `mk_slot_output_expr` helper that emits the divide expression for average specs and a plain slot ref otherwise. So `_._1 |> average > 50.0` in a having predicate works the same way as `_._1 |> sum > 50` does.
+
+**Bail cases (cascade to tier 2):** unchanged from PR-A2 — any bucket-touching shape that isn't a recognized reducer, average at slot 0 (key must be `_._0`), etc.
+
+### Headline (PR-A2 follow-up)
+
+| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (this PR) | Win |
+|---|---|---:|---:|---:|---:|
+| groupby_average | `each(arr) → group_by(brand) → select((K, select(price) → average)) → to_array` | 173 | 106 | **52** | **2.0× over m3 / 3.3× over m1 SQL** |
+| groupby_count (regression check) | bare count splice | 142 | 71 | **36** | parity — average refactor preserves the count splice |
+| groupby_sum (regression check) | inner-select-sum splice | 172 | 101 | **36** | parity — PR-A1 splice preserved |
+| groupby_min (regression check) | inner-select-min splice | 177 | 111 | **43** | parity — PR-A2 splice preserved |
+| groupby_multi_reducer (regression check) | 4-slot named tuple | 190 | 138 | **52** | parity — PR-A2 multi-reducer preserved |
+
+`groupby_average` lands at ~52 ns/op vs `groupby_sum`'s ~36 — the extra ~16 ns/op is the 2-slot accumulator update (one extra `double(...) += ...` and `++` per source element) plus the per-bucket division at result-build (runs O(num distinct keys), not O(N)).
 
 ## Operator-coverage checklist (parity tests)
 
@@ -519,7 +550,7 @@ The 24 benchmarks above cover the most common shapes. The end-game target is one
 | `test_linq_querying.das` | any/all/contains | any_match, all_match, contains_match | ✅ core |
 | `test_linq_transform.das` | select/select_many/zip | to_array_filter, zip_dot_product | ✅ select/zip; `select_many` ⏳ |
 | `test_linq_sorting.das` | order/order_by/reverse | sort_first, sort_take, select_where_order_take, reverse_take | ✅ ascending + `order_descending` (Phase 3); ✅ `reverse` (this PR; `reverse \|> take(N)` shape is a regression vs lazy iterator — see Phase 3+ notes) |
-| `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum, groupby_min, groupby_max, groupby_first, groupby_multi_reducer, groupby_where_count, groupby_where_sum, groupby_select_sum, groupby_having_count | ✅ count/long_count/sum + inner-select-sum (PR-A1); ✅ min/max/first + inner-select-{min,max,first} + multi-reducer (PR-A2); ✅ upstream where_/select* fusion (PR-B); ✅ `having_` with matching slot (PR-D); ⏳ `average` |
+| `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum, groupby_min, groupby_max, groupby_first, groupby_multi_reducer, groupby_where_count, groupby_where_sum, groupby_select_sum, groupby_having_count, groupby_average | ✅ count/long_count/sum + inner-select-sum (PR-A1); ✅ min/max/first + inner-select-{min,max,first} + multi-reducer (PR-A2); ✅ upstream where_/select* fusion (PR-B); ✅ `having_` with matching slot (PR-D); ✅ `average` + inner-select-average + multi-reducer-with-average (PR-A2 follow-up) |
 | `test_linq_join.das` | join/left_join/right_join/full_outer/cross | join_count | ✅ inner; outer joins + cross ⏳ |
 | `test_linq_partition.das` | take/skip/take_while/skip_while/chunk | take_count, skip_take, take_sum_aggregate, take_count_filtered | ✅ take/skip in splice lanes; `_while` + `chunk` ⏳ |
 | `test_linq_set.das` | distinct/union/except/intersect/unique | distinct_count, distinct_take | ✅ distinct + distinct_by (streaming dedup, this PR); union/except/intersect/unique ⏳ |

--- a/benchmarks/sql/groupby_average.das
+++ b/benchmarks/sql/groupby_average.das
@@ -1,0 +1,63 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _group_by(_.brand) |> _select((Brand=key, AvgPrice=avg of price per group)).
+// SQL: SELECT brand, AVG(price) GROUP BY brand.
+// Splice mode (PR-A2 follow-up) fuses the inner select+average per group via a
+// 2-slot per-key acc (sum : double + count : uint64) and divides at result-build.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let groups <- _sql(db |> select_from(type<Car>)
+                                  |> _group_by(_.brand)
+                                  |> _select((Brand = _._0,
+                                              AvgPrice = _._1 |> select($(c : Car) => c.price) |> average())))
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
+                                                       AvgPrice = _._1 |> select($(c : Car) => c.price) |> average())))
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let groups <- _fold(each(arr)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      AvgPrice = _._1 |> select($(c : Car) => c.price) |> average()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def groupby_average_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def groupby_average_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def groupby_average_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1681,11 +1681,11 @@ def private is_bucket_reducer_call(expr : Expression?; bindName : string) : tupl
     if ((c.arguments |> length) != 1) return (false, "", null)
     // Bare reducer: `<reducer>(<bind>._1)`
     if (fnName == "length" || fnName == "count" || fnName == "long_count"
-            || fnName == "sum" || fnName == "min" || fnName == "max" || fnName == "first") {
+            || fnName == "sum" || fnName == "min" || fnName == "max" || fnName == "first" || fnName == "average") {
         if (is_bind_field_access(c.arguments[0], bindName, 1)) return (true, fnName, null)
     }
     // Inner-select reducer: `<reducer>(select(<bind>._1, <lambda>))`
-    if (fnName == "sum" || fnName == "min" || fnName == "max" || fnName == "first") {
+    if (fnName == "sum" || fnName == "min" || fnName == "max" || fnName == "first" || fnName == "average") {
         let inner = c.arguments[0]
         if (inner != null && inner is ExprCall) {
             let innerCall = inner as ExprCall
@@ -1711,7 +1711,23 @@ struct private ReducerSpec {
 }
 
 [macro_function]
-def private slot_acc_type(bodyType : TypeDeclPtr; slot : int; isBareForm : bool) : TypeDeclPtr {
+def private is_average_spec(spec : ReducerSpec) : bool {
+    return spec.name == "average" || spec.name == "average_inner_select"
+}
+
+[macro_function]
+def private mk_avg_acc_type(at : LineInfo) : TypeDeclPtr {
+    // tuple<double; uint64> — sum + count, lives in one entry slot for cache locality.
+    var t = new TypeDecl(baseType = Type.tTuple, at = at)
+    t.argTypes |> emplace_new <| new TypeDecl(baseType = Type.tDouble, at = at)
+    t.argTypes |> emplace_new <| new TypeDecl(baseType = Type.tUInt64, at = at)
+    return t
+}
+
+[macro_function]
+def private slot_acc_type(bodyType : TypeDeclPtr; slot : int; isBareForm, isAverage : bool; at : LineInfo) : TypeDeclPtr {
+    // average overrides the user-facing type (double) with the 2-slot tuple acc.
+    if (isAverage) return mk_avg_acc_type(at)
     // Bare form: bodyType IS the reducer's return type. Named-tuple: drill into argTypes[slot].
     if (isBareForm) return strip_const_ref(clone_type(bodyType))
     if (bodyType == null || (bodyType.argTypes |> length) <= slot) return null
@@ -1731,7 +1747,8 @@ def private recognize_reducer_specs(var groupProjBody : Expression?; bindName, i
             innerBody = fold_linq_cond(clone_expression(innerBare), itName)
             if (innerBody == null) return <- (<- specs, false)
         }
-        var accType = slot_acc_type(groupProjBody._type, 1, true)
+        let isAvgBare = rnBare == "average" || rnBare == "average_inner_select"
+        var accType : TypeDeclPtr = slot_acc_type(groupProjBody._type, 1, true, isAvgBare, groupProjBody.at)
         if (accType == null) return <- (<- specs, false)
         var spec = ReducerSpec(slot = 1, name = rnBare, innerBody = innerBody, accType = accType)
         specs |> push(spec)
@@ -1757,7 +1774,8 @@ def private recognize_reducer_specs(var groupProjBody : Expression?; bindName, i
                 return <- (<- specs, false)
             }
         }
-        var accType = slot_acc_type(groupProjBody._type, i, false)
+        let isAvg = rn == "average" || rn == "average_inner_select"
+        var accType : TypeDeclPtr = slot_acc_type(groupProjBody._type, i, false, isAvg, groupProjBody.at)
         if (accType == null) {
             specs |> clear
             return <- (<- specs, false)
@@ -1910,13 +1928,73 @@ def private emit_reducer_branches(spec : ReducerSpec; at : LineInfo; entryName, 
         missInit = qmacro_expr() {
             $e(l1) := $e(b1)
         }
+    } elif (nm == "average") {
+        // 2-slot acc: ._0 = sum (double), ._1 = count (uint64). Source-element cast to double once per side.
+        var lInit = mk_slot_ref(at, entryName, spec.slot)
+        var lSum  = mk_slot_ref(at, entryName, spec.slot)
+        var lCnt  = mk_slot_ref(at, entryName, spec.slot)
+        missInit = qmacro_expr() {
+            $e(lInit) = (double($i(itName)), 1ul)
+        }
+        hitUpdate = qmacro_block() {
+            $e(lSum)._0 += double($i(itName))
+            $e(lCnt)._1 ++
+        }
+    } elif (nm == "average_inner_select") {
+        // Inner projection evaluated once into a temp — matches reference single-eval-per-element.
+        let tmp = "`vavg`{at.line}`{at.column}`{spec.slot}"
+        var lInit = mk_slot_ref(at, entryName, spec.slot)
+        var lSum  = mk_slot_ref(at, entryName, spec.slot)
+        var lCnt  = mk_slot_ref(at, entryName, spec.slot)
+        var bMiss = clone_expression(spec.innerBody)
+        var bHit  = clone_expression(spec.innerBody)
+        missInit = qmacro_block() {
+            let $i(tmp) = $e(bMiss)
+            $e(lInit) = (double($i(tmp)), 1ul)
+        }
+        hitUpdate = qmacro_block() {
+            let $i(tmp) = $e(bHit)
+            $e(lSum)._0 += double($i(tmp))
+            $e(lCnt)._1 ++
+        }
     }
     return (missInit, hitUpdate)
 }
 
 [macro_function]
+def private mk_avg_subfield(at : LineInfo; entryName : string; slot, sub : int) : Expression? {
+    // entry._{slot}._{sub} — 2-level field access into a tuple<double; uint64> avg accumulator.
+    var ev = new ExprVar(at = at)
+    ev.name := entryName
+    var ef1 = new ExprField(at = at)
+    ef1.name := "_{slot}"
+    ef1.value = ev
+    var ef2 = new ExprField(at = at)
+    ef2.name := "_{sub}"
+    ef2.value = ef1
+    return ef2
+}
+
+[macro_function]
+def private mk_avg_divide_expr(at : LineInfo; entryName : string; slot : int) : Expression? {
+    // entry._{slot}._0 / double(entry._{slot}._1) — average from the 2-slot per-key acc. Bucket is non-empty by construction (only keys with ≥1 source element enter the table), so count is always ≥1.
+    var sumRef = mk_avg_subfield(at, entryName, slot, 0)
+    var cntRef = mk_avg_subfield(at, entryName, slot, 1)
+    return qmacro_expr() {
+        $e(sumRef) / double($e(cntRef))
+    }
+}
+
+[macro_function]
+def private mk_slot_output_expr(at : LineInfo; entryName : string; spec : ReducerSpec) : Expression? {
+    // Per-spec output value: divide for average slots, plain field ref otherwise.
+    if (is_average_spec(spec)) return mk_avg_divide_expr(at, entryName, spec.slot)
+    return mk_slot_ref(at, entryName, spec.slot)
+}
+
+[macro_function]
 def private rewrite_having_pred(var expr : Expression?; hbName, kvName : string; specs : array<ReducerSpec>) : Expression? {
-    // Substitutes `<hb>._0` → `kv._0` and `<reducer>(<hb>._1)` / `<reducer>(select(<hb>._1, <lam>))` → `kv._{slot}` against matching specs; any other use of `<hb>` returns null and cascades.
+    // Substitutes `<hb>._0` → `kv._0` and `<reducer>(<hb>._1)` / `<reducer>(select(<hb>._1, <lam>))` → `kv._{slot}` (or divide expr for average) against matching specs; any other use of `<hb>` returns null and cascades.
     if (expr == null) return expr
     // Peel typer-inserted ExprRef2Value wrappers (same pattern as is_bind_field_access).
     while (expr is ExprRef2Value) {
@@ -1931,7 +2009,7 @@ def private rewrite_having_pred(var expr : Expression?; hbName, kvName : string;
             }
             if (is_bind_field_access(c.arguments[0], hbName, 1)) {
                 for (s in specs) {
-                    if (s.innerBody == null && s.name == fnName) return mk_slot_ref(expr.at, kvName, s.slot)
+                    if (s.innerBody == null && s.name == fnName) return mk_slot_output_expr(expr.at, kvName, s)
                 }
                 return null
             }
@@ -1946,7 +2024,7 @@ def private rewrite_having_pred(var expr : Expression?; hbName, kvName : string;
                     if (innerName == "select") {
                         let comboName = "{fnName}_inner_select"
                         for (s in specs) {
-                            if (s.name == comboName) return mk_slot_ref(expr.at, kvName, s.slot)
+                            if (s.name == comboName) return mk_slot_output_expr(expr.at, kvName, s)
                         }
                         return null
                     }
@@ -2149,6 +2227,12 @@ def private plan_group_by(var expr : Expression?) : Expression? {
     if (groupProjBody == null || groupProjBody._type == null) return null
     var (specs, usesNamedTuple) = recognize_reducer_specs(groupProjBody, bindName, itName)
     if (empty(specs)) return null
+    var hasAvg = false
+    for (s in specs) {
+        if (is_average_spec(s)) {
+            hasAvg = true
+        }
+    }
     // Rewrite optional having predicate against accumulator slots; bails on anything other than _._0 / reducer(_._1) matched to a select slot.
     var havingPred : Expression?
     if (havingCall != null) {
@@ -2167,7 +2251,15 @@ def private plan_group_by(var expr : Expression?) : Expression? {
     let dummyName = "`dummy`{at.line}`{at.column}"
     // Table + matching dummy. Dummy is bound on miss so first-key-wins is detected via addr-compare (one hash op/elem).
     if (usesNamedTuple) {
-        var tabValueType  = strip_const_ref(clone_type(groupProjBody._type))
+        var tabValueType = strip_const_ref(clone_type(groupProjBody._type))
+        // Average slots store the 2-tuple <sum;count> internally; result-build divides at output.
+        if (hasAvg) {
+            for (s in specs) {
+                if (is_average_spec(s) && s.slot < (tabValueType.argTypes |> length)) {
+                    tabValueType.argTypes[s.slot] = mk_avg_acc_type(at)
+                }
+            }
+        }
         var tabValueType2 = clone_type(tabValueType)
         stmts |> push <| qmacro_expr() {
             var inscope $i(tabName) : table<typedecl(_::unique_key(invoke($e(keyBlk1), default<$t(elemType)>))); $t(tabValueType)>
@@ -2279,10 +2371,32 @@ def private plan_group_by(var expr : Expression?) : Expression? {
         // to_array lane: build result buffer by walking the table. Each output element
         var outputExpr : Expression?
         if (!usesNamedTuple) {
-            // Whole body was `<bind>._1 |> length`; result element is just acc (int).
-            outputExpr = qmacro_expr() {
-                $i(kvName)._1
+            // Bare reducer: avg slot needs sum/count divide; everything else is the raw acc value.
+            if (hasAvg) {
+                outputExpr = mk_avg_divide_expr(at, kvName, 1)
+            } else {
+                outputExpr = qmacro_expr() {
+                    $i(kvName)._1
+                }
             }
+        } elif (hasAvg) {
+            // Named-tuple with avg slot(s): table value type stores tuple<double;uint64> per avg slot, so re-synthesize the user's named tuple at result-build, dividing avg slots.
+            var mt = new ExprMakeTuple(at = at)
+            let slotCount = (groupProjBody._type.argNames |> length)
+            mt.recordNames |> resize(slotCount)
+            mt.values |> push(mk_slot_ref(at, kvName, 0))
+            mt.recordNames[0] := string(groupProjBody._type.argNames[0])
+            for (i in 1 .. slotCount) {
+                var v : Expression?
+                for (sp in specs) {
+                    if (sp.slot == i) {
+                        v = mk_slot_output_expr(at, kvName, sp)
+                    }
+                }
+                mt.values |> push(v)
+                mt.recordNames[i] := string(groupProjBody._type.argNames[i])
+            }
+            outputExpr = mt
         } else {
             // Named-tuple wrap `(K = bind._0, V = bind._1|>length)` — table value type already shaped via tabValueType; emit the entry directly.
             outputExpr = qmacro_expr() {

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -2380,12 +2380,17 @@ def private plan_group_by(var expr : Expression?) : Expression? {
                 }
             }
         } elif (hasAvg) {
-            // Named-tuple with avg slot(s): table value type stores tuple<double;uint64> per avg slot, so re-synthesize the user's named tuple at result-build, dividing avg slots.
+            // Tuple with avg slot(s): table value type stores tuple<double;uint64> per avg slot, so re-synthesize the user's tuple at result-build, dividing avg slots. Positional tuples (no field names) and named tuples both pass through recognize_reducer_specs — slot count comes from argTypes; recordNames only get filled when argNames is populated.
             var mt = new ExprMakeTuple(at = at)
-            let slotCount = (groupProjBody._type.argNames |> length)
-            mt.recordNames |> resize(slotCount)
+            let slotCount = (groupProjBody._type.argTypes |> length)
+            let hasNames = (groupProjBody._type.argNames |> length) == slotCount
+            if (hasNames) {
+                mt.recordNames |> resize(slotCount)
+            }
             mt.values |> push(mk_slot_ref(at, kvName, 0))
-            mt.recordNames[0] := string(groupProjBody._type.argNames[0])
+            if (hasNames) {
+                mt.recordNames[0] := string(groupProjBody._type.argNames[0])
+            }
             for (i in 1 .. slotCount) {
                 var v : Expression?
                 for (sp in specs) {
@@ -2394,7 +2399,9 @@ def private plan_group_by(var expr : Expression?) : Expression? {
                     }
                 }
                 mt.values |> push(v)
-                mt.recordNames[i] := string(groupProjBody._type.argNames[i])
+                if (hasNames) {
+                    mt.recordNames[i] := string(groupProjBody._type.argNames[i])
+                }
             }
             outputExpr = mt
         } else {

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -1966,6 +1966,21 @@ def test_group_by_average_fold_parity(t : T?) {
         tt |> equal(4.0lf, perKey[0])
         tt |> equal(3.0lf, perKey[1])
     }
+    t |> run("positional tuple with average: (_._0, _._1|>average) — no field names") @(tt : T?) {
+        // Recognizer accepts positional tuples (ExprMakeTuple with bind._0 at slot 0); the
+        // result-build synthesis must not assume argNames is populated (it's empty for
+        // positional). Use length(argTypes) for slot count, only fill recordNames when names
+        // are present.
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((_._0, _._1 |> average)))
+        tt |> equal(3, length(got))
+        var perKey : table<int; double>
+        for (item in got) {
+            perKey[item._0] = item._1
+        }
+        tt |> equal(21.0lf, perKey[0])
+        tt |> equal(20.5lf, perKey[1])
+        tt |> equal(15.5lf, perKey[2])
+    }
 }
 
 [test]

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -1865,6 +1865,110 @@ def test_group_by_multi_reducer_fold_parity(t : T?) {
 }
 
 [test]
+def test_group_by_average_fold_parity(t : T?) {
+    // PR-A2 follow-up: average reducer splices via 2-slot per-key accumulator
+    // (sum : double + count : uint64) with post-process division at result-build.
+    // Each bucket is non-empty by construction → no divide-by-zero guard needed.
+    t |> run("bare _._1 |> average") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> average))
+        // Buckets: 0→{30,21,12} avg=21.0; 1→{10,31} avg=20.5; 2→{20,11} avg=15.5
+        tt |> equal(3, length(got))
+        var sumAll = 0lf
+        for (v in got) {
+            sumAll += v
+        }
+        tt |> equal(57lf, sumAll)
+    }
+    t |> run("named (K=_._0, Avg=_._1|>average) — field name + key preserved") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, Avg = _._1 |> average)))
+        tt |> equal(3, length(got))
+        var perKey : table<int; double>
+        for (item in got) {
+            perKey[item.K] = item.Avg
+        }
+        tt |> equal(21.0lf, perKey[0])
+        tt |> equal(20.5lf, perKey[1])
+        tt |> equal(15.5lf, perKey[2])
+    }
+    t |> run("inner-select-average — bare with inner projection") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> select(@(x : int) => x * 2) |> average))
+        // Inner projects x→x*2. Bucket sums double, count stays the same → averages also double.
+        tt |> equal(3, length(got))
+        var perCount : table<int; int>
+        for (v in got) {
+            perCount[int(v)] = (perCount?[int(v)] ?? 0) + 1
+        }
+        // Avgs (doubled): 42.0, 41.0, 31.0 — all integers in this fixture so int round-trip is safe.
+        tt |> equal(1, perCount[42])
+        tt |> equal(1, perCount[41])
+        tt |> equal(1, perCount[31])
+    }
+    t |> run("inner-select-average (named): (K, Avg = select(x*2) |> average)") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, Avg = _._1 |> select(@(x : int) => x * 2) |> average)))
+        tt |> equal(3, length(got))
+        var perKey : table<int; double>
+        for (item in got) {
+            perKey[item.K] = item.Avg
+        }
+        tt |> equal(42.0lf, perKey[0])
+        tt |> equal(41.0lf, perKey[1])
+        tt |> equal(31.0lf, perKey[2])
+    }
+    t |> run("multi-reducer with average: (K, N, S, Avg)") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(
+            (K = _._0, N = _._1 |> length, S = _._1 |> sum, Avg = _._1 |> average)))
+        tt |> equal(3, length(got))
+        var keysSeen = 0
+        for (item in got) {
+            if (item.K == 0) { tt |> equal(3, item.N); tt |> equal(63, item.S); tt |> equal(21.0lf, item.Avg); keysSeen ++; }
+            elif (item.K == 1) { tt |> equal(2, item.N); tt |> equal(41, item.S); tt |> equal(20.5lf, item.Avg); keysSeen ++; }
+            elif (item.K == 2) { tt |> equal(2, item.N); tt |> equal(31, item.S); tt |> equal(15.5lf, item.Avg); keysSeen ++; }
+        }
+        tt |> equal(3, keysSeen)
+    }
+    t |> run("multi-reducer with 2 averages: (K, AvgRaw, AvgDoubled)") @(tt : T?) {
+        let got <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(
+            (K = _._0, AvgRaw = _._1 |> average, AvgDoubled = _._1 |> select(@(x : int) => x * 2) |> average)))
+        tt |> equal(3, length(got))
+        for (item in got) {
+            // Doubled inner-select gives 2× raw average.
+            tt |> equal(item.AvgRaw * 2.0lf, item.AvgDoubled)
+        }
+    }
+    t |> run("average on empty source → empty result") @(tt : T?) {
+        var empty : array<int>
+        let got <- _fold(empty._group_by(_ % 3)._select(_._1 |> average))
+        tt |> equal(0, length(got))
+    }
+    t |> run("average parity with reference plain LINQ") @(tt : T?) {
+        let foldGot <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, Avg = _._1 |> average)))
+        let refGot  <- ([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, Avg = _._1 |> average)))
+        tt |> equal(length(refGot), length(foldGot))
+        var refAvg, foldAvg : table<int; double>
+        for (r in refGot) {
+            refAvg[r.K] = r.Avg
+        }
+        for (f in foldGot) {
+            foldAvg[f.K] = f.Avg
+        }
+        for (k in keys(refAvg)) {
+            tt |> equal(refAvg?[k] ?? -1.0lf, foldAvg?[k] ?? -1.0lf)
+        }
+    }
+    t |> run("float source — average over array<float>") @(tt : T?) {
+        let got <- _fold([1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f]._group_by(int(_) % 2)._select((K = _._0, Avg = _._1 |> average)))
+        tt |> equal(2, length(got))
+        var perKey : table<int; double>
+        for (item in got) {
+            perKey[item.K] = item.Avg
+        }
+        // Bucket 0: {2,4,6}=12/3=4.0; bucket 1: {1,3,5}=9/3=3.0.
+        tt |> equal(4.0lf, perKey[0])
+        tt |> equal(3.0lf, perKey[1])
+    }
+}
+
+[test]
 def test_group_by_upstream_fusion_fold_parity(t : T?) {
     // PR-B: upstream where_/select fuses into the per-element loop. Where guards the
     // table update; select binds projected values that the key/reducer chain references.

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -2410,6 +2410,107 @@ def test_group_by_having_raw_bucket_cascades_to_tier2(t : T?) {
     }
 }
 
+[export, marker(no_coverage)]
+def target_group_by_average_bare_fold() : array<double> {
+    // PR-A2 follow-up: bare `_._1 |> average` splices via tuple<double;uint64> per-key acc.
+    return <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(_._1 |> average))
+}
+
+[test]
+def test_group_by_average_bare_emits_avg_acc(t : T?) {
+    // Average splice fingerprint: no runtime average call (inlined into += / count loop),
+    // single-hash hot path (no key_exists), per-element unique_key.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_average_bare_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(0, count_call(body_expr, "group_by_lazy"), "must NOT call group_by_lazy")
+        t |> equal(0, count_call(body_expr, "average"), "reducer inlined; no runtime average call")
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path")
+        t |> success(count_call(body_expr, "unique_key") >= 1, "per-element unique_key")
+        t |> equal(2, count_inner_for_loops(body_expr), "table-update + result-build loops")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_average_named_fold() : array<tuple<K : int; Avg : double>> {
+    return <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select((K = _._0, Avg = _._1 |> average)))
+}
+
+[test]
+def test_group_by_average_named_preserves_field_name(t : T?) {
+    // Named form: table stores tuple<K:int;Avg:tuple<double;uint64>> internally; result-build
+    // synthesizes user-facing tuple<K;Avg:double> with field names preserved (compiler-checked
+    // by the function's declared return type — would fail compilation if shape diverged).
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_average_named_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(0, count_call(body_expr, "group_by_lazy"), "must NOT call group_by_lazy")
+        t |> equal(0, count_call(body_expr, "average"), "reducer inlined; no runtime average call")
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path")
+        t |> equal(2, count_inner_for_loops(body_expr), "table-update + result-build loops")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_average_inner_select_fold() : array<tuple<K : int; Avg : double>> {
+    return <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(
+        (K = _._0, Avg = _._1 |> select(@(x : int) => x * 2) |> average)))
+}
+
+[test]
+def test_group_by_average_inner_select_inlines_projection(t : T?) {
+    // Inner select inlined — neither inner `select` call nor the reducer survives.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_average_inner_select_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(0, count_call(body_expr, "group_by_lazy"), "must NOT call group_by_lazy")
+        t |> equal(0, count_call(body_expr, "average"), "reducer inlined")
+        t |> equal(0, count_call(body_expr, "select"), "inner select inlined")
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_multi_reducer_with_avg_fold() : array<tuple<K : int; N : int; S : int; Avg : double>> {
+    return <- _fold([10, 20, 30, 11, 21, 31, 12]._group_by(_ % 3)._select(
+        (K = _._0, N = _._1 |> length, S = _._1 |> sum, Avg = _._1 |> average)))
+}
+
+[test]
+def test_group_by_multi_reducer_with_avg_splices(t : T?) {
+    // 4-slot named tuple combining length + sum + average — single fused pass, no runtime reducer calls.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_multi_reducer_with_avg_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(0, count_call(body_expr, "group_by_lazy"), "must NOT call group_by_lazy")
+        t |> equal(0, count_call(body_expr, "average"), "reducer inlined")
+        t |> equal(0, count_call(body_expr, "sum"), "reducer inlined")
+        // length(tab) legitimately appears in the reserve hint — don't assert absence.
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path")
+        t |> equal(2, count_inner_for_loops(body_expr), "table-update + result-build loops")
+    }
+}
+
 [test]
 def test_reverse_select_pushes_projection_not_source(t : T?) {
     // R3: select before reverse — the loop pushes the projected value, not the


### PR DESCRIPTION
## Summary

Closes the explicit `average` cascade deferred since PR-A1 / PR-A2 / PR-D. Each per-key `average` accumulator gets a `tuple&lt;double; uint64&gt;` slot (running sum + element count) updated in the PR-A1 miss/hit split; result-build divides at output.

- Recognizer extends to bare + inner-select `average` (10 reducer shapes total).
- `slot_acc_type` overrides the slot type to `tuple&lt;double; uint64&gt;` for average regardless of the user-facing return type (`double`).
- `emit_reducer_branches` adds two new arms (`average` / `average_inner_select`). The inner-select variant evaluates the inner projection once into a `let vavg`-bound temp.
- `plan_group_by` scans for average slots; when present, the named-tuple `tabValueType` clones the user's body type and substitutes only the average slots, and the result-build output is a programmatically-constructed `ExprMakeTuple` with per-slot divide for average slots (`kv._{i}._0 / double(kv._{i}._1)`).
- `rewrite_having_pred` routes average-slot references through a shared `mk_slot_output_expr` so `_._1 |> average &gt; 50.0` in a having predicate works the same way as `_._1 |> sum &gt; 50` does.

Bucket non-emptiness is structurally guaranteed (a key only enters the table when at least one source element produced it), so `count` is always ≥1 — no divide-by-zero guard needed.

### Headline (100K rows, INTERP)

| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (this PR) | Win |
|---|---|---:|---:|---:|---:|
| groupby_average | `group_by → select((K, select → average))` | 173 | 106 | **52** | **2.0× over m3 / 3.3× over m1 SQL** |
| groupby_count (regression check) | bare count splice | 142 | 71 | **36** | parity |
| groupby_sum (regression check) | inner-select-sum splice | 172 | 101 | **36** | parity |
| groupby_min (regression check) | inner-select-min splice | 177 | 111 | **43** | parity |
| groupby_multi_reducer (regression check) | 4-slot named tuple | 190 | 138 | **52** | parity |

`groupby_average` lands at ~52 ns/op vs `groupby_sum`'s ~36 — the extra ~16 ns/op is the 2-slot accumulator update (one extra `double(...) += ...` and `++` per source element) plus the per-bucket division at result-build (runs O(num distinct keys), not O(N)).

## Test plan

- [x] `tests/linq/test_linq_fold.das` — new `test_group_by_average_fold_parity` (9 subtests: bare / named / inner-select bare / inner-select named / multi-reducer with 1 avg / multi-reducer with 2 avgs / empty source / reference parity / float source) — all green
- [x] `tests/linq/test_linq_fold_ast.das` — 4 new AST shape tests pinning splice fingerprint (no `group_by_lazy` runtime call, no `average`/`sum` runtime calls, single-hash `key_exists==0`, 2 for-loops)
- [x] Full 14-file `tests/linq/test_linq_*.das` sweep — 924/924 green
- [x] AOT mode `tests/linq/test_linq_fold.das` + `test_linq_fold_ast.das` — 292+114 green after regen
- [x] `mcp__daslang__format_file` + `mcp__daslang__lint` clean on every touched file
- [x] Regression benchmark sweep — groupby_count/sum/min/multi_reducer at PR-A1/A2 baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)