### PR TITLE
linq_fold reverse: backward index loop for reverse |&gt; take(N) on array sources (PR-C)

### DIFF
--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -377,7 +377,7 @@ Bails to tier 2 cascade on: inner-select-sum (`_._1 |> select(<inner>) |> sum` �
 | distinct_count | `each(arr) → select(brand) → distinct → to_array` | 41 | 43 | 33 | **16** | **2.7× over m3 / 2.1× over prev / faster than m1 SQL** |
 | distinct_take (NEW) | `each(arr) → select(brand) → distinct → take(3) → to_array` | 0 | 30 | — | **0** | early-exit at 3 unique brands — splice eliminates generator-dispatch overhead |
 | groupby_count | `each(arr) → group_by(brand) → select(brand, length) → to_array` | 141 | 71 | 76 | **37** | **2.1× over prev / 1.9× over m3 / 3.8× over m1 SQL** |
-| reverse_take (NEW) | `each(arr) → reverse → take(10) → to_array` | 0\* | 22 | — | **34** | regression vs m3 — see footnote |
+| reverse_take (NEW) | `each(arr) → reverse → take(10) → to_array` | 0\* | 22 | — | **34** | regression vs m3 — see footnote (closed in PR-C with backward index loop, see Phase 3+ notes) |
 | groupby_sum (deferred) | `each(arr) → group_by(brand) → select(brand, select(price) → sum) → to_array` | 173 | 98 | 107 | **108** | unchanged — inner-select-sum (see follow-up) |
 | groupby_sum (PR-A1, inner-select-sum) | same chain | 174 | 101 | 108 | **36** | **3× over prev / 2.8× over m3 / 4.8× over m1 SQL** — closes the deferred follow-up |
 
@@ -385,7 +385,7 @@ Bails to tier 2 cascade on: inner-select-sum (`_._1 |> select(<inner>) |> sum` �
 
 **`groupby_count` win**: plain LINQ materializes per-bucket arrays then counts each. The splice keeps only `table<brand → int>` updated per element with `entry._1++`. The result-build loop iterates `values(tab)` (5 entries) — total work is one source pass + 5 emplaces vs tier 2's per-bucket array allocation+push+length-call. Result beats SQL by 4.3× because no engine round-trip overhead.
 
-**`reverse_take` regression vs m3** (34 vs 22 ns/op): both variants materialize the full source into a buffer (the iterator-form `reverse()` in [linq.das:234](daslib/linq.das#L234) does it via `generator capture` + per-yield indexing; the splice does it via `push_clone` in the prefilter loop). The cost difference is the second pass: m3's generator yields `buffer[len-i-1]` lazily, so `take(TAKE_N)` only triggers N yields; the splice instead calls `reverse_inplace(buf)` (full O(length) swap) and then `resize(N)`. For TAKE_N << length the lazy-yield approach wins because the reverse is bounded to N instead of length. The splice still wins the headline shape (`reverse |> to_array` without take) where both variants pay full-length cost but the splice avoids the generator-dispatch overhead. A future optimization could detect `reverse |> take(N)` on array-typed sources and emit a backward index loop bounded to `[max(0, len-N), len)` — deferred. \* m1 SQL: `ORDER BY id DESC LIMIT 10` collapses to 0 ns/op via index.
+**`reverse_take` regression vs m3** (originally 34 vs 22 ns/op, closed in PR-C — see "backward index loop" section below): both variants materialize the full source into a buffer (the iterator-form `reverse()` in [linq.das:234](daslib/linq.das#L234) does it via `generator capture` + per-yield indexing; the splice did it via `push_clone` in the prefilter loop). The cost difference was the second pass: m3's generator yields `buffer[len-i-1]` lazily, so `take(TAKE_N)` only triggered N yields; the splice instead called `reverse_inplace(buf)` (full O(length) swap) and then `resize(N)`. PR-C detects `reverse |> take(N)` on array-typed sources at macro time and emits a backward index loop bounded to `[max(0, len-N), len)`, visiting only the last N indices — m3f now lands at ~0 ns/op for TAKE_N=10 at 100K. \* m1 SQL: `ORDER BY id DESC LIMIT 10` collapses to 0 ns/op via index.
 
 **`groupby_sum` unchanged**: the benchmark uses `g._1 |> _select($(c : Car) => c.price) |> _sum()` — an inner-select-sum chain. The G4 recognizer covers bare `_._1 |> sum` but doesn't yet inline the inner projection into the `+=` site. Falls back to tier 2 array-shape (correct but slow). Deferred to follow-up (~80 LOC; see plan).
 
@@ -433,10 +433,9 @@ Closes the remaining BufferGroupBy gaps from PR-A1's deferred-follow-up list. Tw
 
 All 6 splice variants land within ~36–53 ns/op — the per-element work is bounded by the single hash op + slot mutations regardless of which reducer or how many. The multi-reducer ~53 ns/op pays a small overhead per extra slot (~5 ns each), still beats SQL by 3.6×.
 
-### Deferred for PR-C / follow-ups
+### Deferred for follow-ups
 
 - `average` reducer (2-slot per-key acc + post-process division — separate follow-up)
-- `reverse_take` backward index loop on array sources (PR-C)
 - `having_*` between `group_by` and `select(group_proj)` (still cascades to tier 2)
 
 ## Phase 3+ groupby reducer expansion — upstream where/select fusion (PR-B)
@@ -539,6 +538,48 @@ Closes the explicit `average` cascade deferred since PR-A1 / PR-A2 / PR-D. `aver
 
 `groupby_average` lands at ~52 ns/op vs `groupby_sum`'s ~36 — the extra ~16 ns/op is the 2-slot accumulator update (one extra `double(...) += ...` and `++` per source element) plus the per-bucket division at result-build (runs O(num distinct keys), not O(N)).
 
+## Phase 3+ reverse_take backward index loop (PR-C)
+
+Closes the documented `reverse_take` regression (34 vs 22 ns/op m3f-vs-m3 at TAKE_N=10/N=100K). The original R1–R4 emit shape pushed every source element into the buffer, ran an O(length) `reverse_inplace`, then `resize(N)` truncated everything past the first N — wasting work proportional to `length - N`.
+
+**How it lands:**
+
+`plan_reverse` adds an R6 arm taken when *all* of these hold:
+
+- `take(N)` is present at the chain tail
+- no upstream `where_`
+- no upstream `select`
+- source type is `isGoodArrayType || isArray` (need O(1) indexing — iterator/range sources don't qualify and fall through to R1-R4)
+
+The emission becomes:
+
+```
+let __len = length(src)
+let __takeN = N <= 0 ? 0 : (N < __len ? N : __len)
+var buf : array<T>
+buf |> reserve(__takeN)
+for (k in 0 .. __takeN) {
+    buf |> push_clone(src[__len - 1 - k])
+}
+return buf
+```
+
+Only the last `min(N, length)` indices are visited; the entire `reverse_inplace` + truncate pass is skipped. The take-bound clamp keeps the original `take(N <= 0)` and `take(N > length)` semantics.
+
+**Bail conditions (cascade to R1-R4):**
+- Iterator source (no O(1) index access). Verified by AST test `test_reverse_take_iterator_source_uses_reverse_inplace`.
+- Upstream `where_` — can't predict which indices survive without visiting all elements.
+- Upstream `select` — eager-projection semantics differ from per-index lazy projection; the R1-R4 path preserves current behavior.
+- `reverse |> to_array` without take — full-length materialization is unavoidable.
+
+### Headline (PR-C)
+
+| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (prev) | m3f (this PR) | Win |
+|---|---|---:|---:|---:|---:|---:|
+| reverse_take | `each(arr) → reverse → take(10) → to_array` | 0\* | 22 | 34 | **0** | **closes the regression — beats m3 too** |
+
+\* m1 SQL: `ORDER BY id DESC LIMIT 10` collapses to 0 ns/op via index. The m3f 0 ns/op result means sub-nanosecond per element averaged across 10/100K visited elements — the backward index loop runs only 10 iterations regardless of N.
+
 ## Operator-coverage checklist (parity tests)
 
 The 24 benchmarks above cover the most common shapes. The end-game target is one benchmark per `_fold`-applicable scenario in the broader `tests/linq/` operator suite. Tracking the long-tail coverage below; PRs that add splice support for new operators should add a benchmark here if not already present.
@@ -549,7 +590,7 @@ The 24 benchmarks above cover the most common shapes. The end-game target is one
 | `test_linq_aggregation.das` | count/sum/min/max/avg/aggregate | count/sum/min/max/average_aggregate, sum_where, long_count_aggregate | ✅ core; `aggregate(seed, fn)` ⏳ |
 | `test_linq_querying.das` | any/all/contains | any_match, all_match, contains_match | ✅ core |
 | `test_linq_transform.das` | select/select_many/zip | to_array_filter, zip_dot_product | ✅ select/zip; `select_many` ⏳ |
-| `test_linq_sorting.das` | order/order_by/reverse | sort_first, sort_take, select_where_order_take, reverse_take | ✅ ascending + `order_descending` (Phase 3); ✅ `reverse` (this PR; `reverse \|> take(N)` shape is a regression vs lazy iterator — see Phase 3+ notes) |
+| `test_linq_sorting.das` | order/order_by/reverse | sort_first, sort_take, select_where_order_take, reverse_take | ✅ ascending + `order_descending` (Phase 3); ✅ `reverse` (Phase 3+); ✅ `reverse \|> take(N)` backward index loop on array sources (PR-C — closes the prior regression) |
 | `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum, groupby_min, groupby_max, groupby_first, groupby_multi_reducer, groupby_where_count, groupby_where_sum, groupby_select_sum, groupby_having_count, groupby_average | ✅ count/long_count/sum + inner-select-sum (PR-A1); ✅ min/max/first + inner-select-{min,max,first} + multi-reducer (PR-A2); ✅ upstream where_/select* fusion (PR-B); ✅ `having_` with matching slot (PR-D); ✅ `average` + inner-select-average + multi-reducer-with-average (PR-A2 follow-up) |
 | `test_linq_join.das` | join/left_join/right_join/full_outer/cross | join_count | ✅ inner; outer joins + cross ⏳ |
 | `test_linq_partition.das` | take/skip/take_while/skip_while/chunk | take_count, skip_take, take_sum_aggregate, take_count_filtered | ✅ take/skip in splice lanes; `_while` + `chunk` ⏳ |

--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -328,7 +328,8 @@ Recognized chain: `src [|> where_(p)]* [|> select(proj)]? |> reverse [|> take(N)
 | Terminator | Emission |
 |---|---|
 | `to_array` (default) | prefilter loop → push into buffer → `reverse_inplace(buf)` → `return <- buf` |
-| `take(N) \|> to_array` | prefilter → push → `reverse_inplace` → `resize(min(N, length(buf)))` → `return <- buf` (semantics: "last N of source in reverse order") |
+| `take(N) \|> to_array`, **array source, no where/select** (R6) | backward index loop visiting `src[len-1 .. max(0, len-N))` directly into a `reserve(takeN)`'d buffer — skips `reverse_inplace` and the full-source push. See "Phase 3+ reverse_take backward index loop (PR-C)" section below |
+| `take(N) \|> to_array`, **iterator source or with where/select** (R1-R4 fallback) | prefilter → push → `reverse_inplace` → `resize(min(N, length(buf)))` → `return <- buf` (semantics: "last N of source in reverse order") |
 | `count` | counter loop only (no buffer, no reverse) — reverse doesn't change count |
 | `first` | last-survivor tracker — keep last element seen, `panic` if none |
 | `first_or_default(d)` | last-survivor tracker — keep last element seen, return `d` if none |
@@ -377,7 +378,8 @@ Bails to tier 2 cascade on: inner-select-sum (`_._1 |> select(<inner>) |> sum` �
 | distinct_count | `each(arr) → select(brand) → distinct → to_array` | 41 | 43 | 33 | **16** | **2.7× over m3 / 2.1× over prev / faster than m1 SQL** |
 | distinct_take (NEW) | `each(arr) → select(brand) → distinct → take(3) → to_array` | 0 | 30 | — | **0** | early-exit at 3 unique brands — splice eliminates generator-dispatch overhead |
 | groupby_count | `each(arr) → group_by(brand) → select(brand, length) → to_array` | 141 | 71 | 76 | **37** | **2.1× over prev / 1.9× over m3 / 3.8× over m1 SQL** |
-| reverse_take (NEW) | `each(arr) → reverse → take(10) → to_array` | 0\* | 22 | — | **34** | regression vs m3 — see footnote (closed in PR-C with backward index loop, see Phase 3+ notes) |
+| reverse_take (NEW) | `each(arr) → reverse → take(10) → to_array` | 0\* | 22 | — | **34** | regression vs m3 — see footnote (closed in PR-C below) |
+| reverse_take (PR-C, backward index loop) | same chain on array source | 0\* | 22 | 34 | **0** | **closes the regression — backward index loop visits only last N indices** |
 | groupby_sum (deferred) | `each(arr) → group_by(brand) → select(brand, select(price) → sum) → to_array` | 173 | 98 | 107 | **108** | unchanged — inner-select-sum (see follow-up) |
 | groupby_sum (PR-A1, inner-select-sum) | same chain | 174 | 101 | 108 | **36** | **3× over prev / 2.8× over m3 / 4.8× over m1 SQL** — closes the deferred follow-up |
 

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1408,43 +1408,66 @@ def private plan_reverse(var expr : Expression?) : Expression? {
         // R1-R4 path: buffer + reverse_inplace + optional resize + return buffer.
         let needIterWrap = expr._type.isIterator
         var bufElemType = strip_const_ref(clone_type(reverseCall._type.firstType))
-        var pushExpr : Expression?
-        if (projection != null) {
-            pushExpr = qmacro_expr() {
-                $i(bufName) |> push_clone($e(projection))
-            }
-        } else {
-            pushExpr = qmacro_expr() {
-                $i(bufName) |> push_clone($i(itName))
-            }
-        }
-        pushExpr = wrap_with_condition(pushExpr, whereCond)
-        var reserveStmts : array<Expression?>
-        if (type_has_length(top._type) && whereCond == null) {
-            reserveStmts |> push <| qmacro_expr() {
-                $i(bufName) |> reserve(length($i(srcName)))
-            }
-        }
-        var resizeStmts : array<Expression?>
-        if (takeExpr != null) {
-            // take(N) of reversed-buffer = last N of source reversed. Three clones since no math::min import.
+        let canBackwardIndex = (takeExpr != null && projection == null && whereCond == null
+                && (top._type.isGoodArrayType || top._type.isArray))
+        if (canBackwardIndex) {
+            // R6: visit only the last takeN indices — skips full-source push + O(length) reverse_inplace.
+            let lenName   = "`rlen`{at.line}`{at.column}"
+            let takeNName = "`rtn`{at.line}`{at.column}"
+            let kName     = "`rk`{at.line}`{at.column}"
             var takeA = clone_expression(takeExpr)
             var takeB = clone_expression(takeExpr)
             var takeC = clone_expression(takeExpr)
-            resizeStmts |> push <| qmacro_expr() {
-                $i(bufName) |> resize($e(takeA) <= 0 ? 0 : ($e(takeB) < length($i(bufName)) ? $e(takeC) : length($i(bufName))))
+            var returnExpr = buffer_return(bufName, needIterWrap)
+            body = qmacro_block() {
+                let $i(lenName) = length($i(srcName))
+                let $i(takeNName) = $e(takeA) <= 0 ? 0 : ($e(takeB) < $i(lenName) ? $e(takeC) : $i(lenName))
+                var $i(bufName) : array<$t(bufElemType)>
+                $i(bufName) |> reserve($i(takeNName))
+                for ($i(kName) in 0 .. $i(takeNName)) {
+                    $i(bufName) |> push_clone($i(srcName)[$i(lenName) - 1 - $i(kName)])
+                }
+                $e(returnExpr)
             }
-        }
-        var returnExpr = buffer_return(bufName, needIterWrap)
-        body = qmacro_block() {
-            var $i(bufName) : array<$t(bufElemType)>
-            $b(reserveStmts)
-            for ($i(itName) in $i(srcName)) {
-                $e(pushExpr)
+        } else {
+            var pushExpr : Expression?
+            if (projection != null) {
+                pushExpr = qmacro_expr() {
+                    $i(bufName) |> push_clone($e(projection))
+                }
+            } else {
+                pushExpr = qmacro_expr() {
+                    $i(bufName) |> push_clone($i(itName))
+                }
             }
-            _::reverse_inplace($i(bufName))
-            $b(resizeStmts)
-            $e(returnExpr)
+            pushExpr = wrap_with_condition(pushExpr, whereCond)
+            var reserveStmts : array<Expression?>
+            if (type_has_length(top._type) && whereCond == null) {
+                reserveStmts |> push <| qmacro_expr() {
+                    $i(bufName) |> reserve(length($i(srcName)))
+                }
+            }
+            var resizeStmts : array<Expression?>
+            if (takeExpr != null) {
+                // take(N) of reversed-buffer = last N of source reversed. Three clones since no math::min import.
+                var takeA = clone_expression(takeExpr)
+                var takeB = clone_expression(takeExpr)
+                var takeC = clone_expression(takeExpr)
+                resizeStmts |> push <| qmacro_expr() {
+                    $i(bufName) |> resize($e(takeA) <= 0 ? 0 : ($e(takeB) < length($i(bufName)) ? $e(takeC) : length($i(bufName))))
+                }
+            }
+            var returnExpr = buffer_return(bufName, needIterWrap)
+            body = qmacro_block() {
+                var $i(bufName) : array<$t(bufElemType)>
+                $b(reserveStmts)
+                for ($i(itName) in $i(srcName)) {
+                    $e(pushExpr)
+                }
+                _::reverse_inplace($i(bufName))
+                $b(resizeStmts)
+                $e(returnExpr)
+            }
         }
     }
     return finalize_emission(top, srcName, at, body)

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -1682,9 +1682,10 @@ def target_reverse_take_to_array_fold() : array<int> {
 }
 
 [test]
-def test_reverse_take_emits_resize(t : T?) {
-    // R4: take(N) after reverse — buffer + reverse_inplace + resize. The resize call
-    // proves we kept the buffer single-pass instead of cascading to a take-iterator.
+def test_reverse_take_emits_backward_index_loop(t : T?) {
+    // R6: array-typed source + reverse |> take(N) — backward index loop instead of
+    // (push all → reverse_inplace → resize). Visits only the last N indices, skipping
+    // the O(length) push and O(length) reverse pass. Closes the m3 lazy-yield regression.
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(), @@target_reverse_take_to_array_fold)
         if (func == null) return
@@ -1694,14 +1695,44 @@ def test_reverse_take_emits_resize(t : T?) {
         }
         t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
         t |> equal(1, count_inner_for_loops(body_expr), "single fused for-loop")
-        t |> success(count_call(body_expr, "reverse_inplace") >= 1,
-            "must emit reverse_inplace call")
-        t |> success(count_call(body_expr, "resize") >= 1,
-            "must emit resize call for take(N) post-reverse truncation")
+        t |> equal(0, count_call(body_expr, "reverse_inplace"),
+            "must NOT emit reverse_inplace (backward index loop replaces it)")
+        t |> equal(0, count_call(body_expr, "resize"),
+            "must NOT emit resize (reserve(takeN) replaces it)")
         t |> equal(0, count_call(body_expr, "take"),
-            "take runtime helper must NOT be called (resize replaces it)")
-        t |> equal(1, count_outer_let_vars(body_expr),
-            "single outer var (the buffer) — anti-cascade gate")
+            "take runtime helper must NOT be called")
+        t |> success(count_call(body_expr, "reserve") >= 1,
+            "must emit reserve(takeN) to pre-size the buffer")
+        t |> success(count_call(body_expr, "length") >= 1,
+            "must call length(src) to bound the backward walk")
+        t |> equal(3, count_outer_let_vars(body_expr),
+            "three outer vars: source-length, clamped-takeN, buffer")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_reverse_take_iterator_fold() : array<int> {
+    // Iterator source (range) — backward index loop is NOT applicable, falls back
+    // to R1-R4 path (push all → reverse_inplace → resize).
+    return <- _fold(each(range(1, 9)) |> reverse() |> take(3) |> to_array())
+}
+
+[test]
+def test_reverse_take_iterator_source_uses_reverse_inplace(t : T?) {
+    // R6 negative: when source is not indexable (range / iterator), the R1-R4 fallback
+    // path stays in place — reverse_inplace + resize, single outer var.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_reverse_take_iterator_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> success(count_call(body_expr, "reverse_inplace") >= 1,
+            "iterator source must use reverse_inplace fallback")
+        t |> success(count_call(body_expr, "resize") >= 1,
+            "iterator source must use resize fallback")
     }
 }
 

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -1720,7 +1720,9 @@ def target_reverse_take_iterator_fold() : array<int> {
 [test]
 def test_reverse_take_iterator_source_uses_reverse_inplace(t : T?) {
     // R6 negative: when source is not indexable (range / iterator), the R1-R4 fallback
-    // path stays in place — reverse_inplace + resize, single outer var.
+    // path stays in place. Pins the full fallback shape (not just reverse_inplace/resize
+    // presence) so the test catches both directions of drift: (a) R6 starts mis-firing on
+    // iterator sources, (b) the R1-R4 emission shape changes (e.g. cascades to take helper).
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(), @@target_reverse_take_iterator_fold)
         if (func == null) return
@@ -1729,10 +1731,15 @@ def test_reverse_take_iterator_source_uses_reverse_inplace(t : T?) {
             return <- $e(body_expr)
         }
         t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for splice")
+        t |> equal(1, count_inner_for_loops(body_expr), "single fused prefilter loop (R1-R4)")
         t |> success(count_call(body_expr, "reverse_inplace") >= 1,
             "iterator source must use reverse_inplace fallback")
         t |> success(count_call(body_expr, "resize") >= 1,
             "iterator source must use resize fallback")
+        t |> equal(0, count_call(body_expr, "take"),
+            "take runtime helper must NOT be called (resize replaces it)")
+        t |> equal(1, count_outer_let_vars(body_expr),
+            "single outer var (the buffer) — anti-cascade gate")
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the documented `reverse_take` regression (m3f 34 vs m3 22 ns/op at TAKE_N=10 / N=100K). The original R1-R4 emit shape pushed every source element into a buffer, ran an O(length) `reverse_inplace`, then `resize(N)` truncated everything past the first N — wasting work proportional to `length - N`.

`plan_reverse` adds an R6 arm taken when **all** of these hold:
- `take(N)` is present at the chain tail
- no upstream `where_`
- no upstream `select`
- source type is `isGoodArrayType || isArray` (need O(1) indexing)

R6 emission visits only the last `min(N, length)` indices directly:

```
let __len = length(src)
let __takeN = N &lt;= 0 ? 0 : (N &lt; __len ? N : __len)
var buf : array&lt;T&gt;
buf |&gt; reserve(__takeN)
for (k in 0 .. __takeN) {
    buf |&gt; push_clone(src[__len - 1 - k])
}
return buf
```

The take-bound clamp preserves `take(N&lt;=0) → empty` and `take(N&gt;length) → full` semantics. Iterator/range sources fall through to R1-R4 (verified by a new negative AST test).

### Headline (100K rows, INTERP, TAKE_N=10)

| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (prev) | m3f (this PR) | Win |
|---|---|---:|---:|---:|---:|---:|
| reverse_take | `each(arr) → reverse → take(10) → to_array` | 0\* | 22 | 34 | **0** | **closes the regression — beats m3 too** |

\* m1 SQL: `ORDER BY id DESC LIMIT 10` collapses to 0 ns/op via index. The m3f 0 ns/op result means sub-nanosecond per element averaged over the 10 visited indices regardless of N — the backward loop runs only TAKE_N iterations.

## Test plan

- [x] `test_reverse_take_emits_backward_index_loop` — pins the new R6 emit shape (no `reverse_inplace` / no `resize`, has `reserve(takeN)` + `length(src)`, 3 outer vars: len/takeN/buf)
- [x] `test_reverse_take_iterator_source_uses_reverse_inplace` (NEW negative test) — `range(1, 9) |&gt; reverse |&gt; take(3)` confirms the R1-R4 fallback path still fires for iterator sources
- [x] Full 15-file `tests/linq/test_linq_*.das` sweep — all green
- [x] AOT `test_linq_fold` + `test_linq_fold_ast` — 293+115 green after AOT regen
- [x] `mcp__daslang__format_file` + `mcp__daslang__lint` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)