### PR TITLE
linq_fold group_by: hidden-slot reducer-in-having (PR-E)

### DIFF
--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -602,19 +602,21 @@ Closes the explicit "having predicate references a reducer absent from the selec
 **Bail cases (cascade to tier 2):**
 - Bare-form select with hidden-slot reducer in having (per above).
 - Inner-select reducer in having whose lambda is non-peelable (peel failure returns null).
+- Two same-named inner-select reducer references in the same having clause (e.g., `_._1|>select(λ1)|>sum + _._1|>select(λ2)|>sum > N`). The splice can't tell `λ1` and `λ2` apart without structural compare; routing both to the first hidden slot would silently conflate them. Cascade tier 2 evaluates each `select()` separately and stays correct.
 - All upstream bail cases from PR-A1/A2/B/D still apply.
 
 **Edge cases worth noting:**
-- Same-name reducer in select AND having reuses the select slot (existing PR-D match-by-name behavior preserved). Hidden slot only added when no name match exists. The "inner-select reducer with different lambdas at select vs having" case still match-by-name in v1 — structural lambda compare deferred.
-- Multiple references to the SAME hidden reducer in the predicate dedup naturally: the first walk adds the spec; subsequent walks see a matching spec and skip.
-- 2+ hidden reducers fall into the same scan pass; each gets its own slot.
+- Bare reducer with same name in select AND having reuses the select slot (existing PR-D match-by-name behavior preserved).
+- Inner-select reducer in having that name-matches a select-side spec routes to that visible slot (PR-D limitation: v1 trusts the user wrote identical lambdas; structural lambda compare deferred).
+- Multiple references to the SAME bare reducer (e.g., `sum`) in the predicate dedup naturally: the first walk adds the spec; subsequent walks see a matching spec and skip.
+- 2+ DIFFERENT-named hidden reducers fall into the same scan pass; each gets its own slot.
 
 ### Headline (PR-E)
 
 | Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (this PR) | Win |
 |---|---|---:|---:|---:|---:|
 | groupby_having_hidden_sum | `each(arr) → group_by(brand) → having(sum(price) > 50000) → select((K, length)) → to_array` | 175 | 109 | **40** | **2.7× over m3 / 4.4× over m1 SQL** |
-| groupby_having_count (regression check) | `group_by → having(len>=5) → select((K, length))` | 141 | 92 | **36** | parity — PR-E scan-then-rewrite preserves the matching-slot splice |
+| groupby_having_count (regression check) | `group_by → having(len>=5) → select((K, length))` | 141 | 78 | **36** | parity — PR-E scan-then-rewrite preserves the matching-slot splice |
 
 `groupby_having_hidden_sum` lands at ~40 ns/op vs `groupby_having_count`'s ~36 — the extra ~4 ns/op is the hidden inner-select-sum's per-element `entry._{hidden} += c.price` (one extra add per source element) alongside the visible `length++`.
 
@@ -622,6 +624,7 @@ Closes the explicit "having predicate references a reducer absent from the selec
 
 - Bare-form select with hidden slot (requires restructuring the bare-table key-type qmacro to programmatic TypeDecl construction).
 - Inner-select reducer in having that uses a different lambda from a same-named select-side inner-select reducer — currently match-by-name conflates them (already a v1 limitation since PR-D; structural lambda compare TBD).
+- Two same-named inner-select reducers in the same having clause currently bail to cascade — a structural lambda compare would let us splice both correctly (sharing a slot when identical, splitting into two hidden slots when different).
 
 ## Operator-coverage checklist (parity tests)
 

--- a/benchmarks/sql/LINQ.md
+++ b/benchmarks/sql/LINQ.md
@@ -75,6 +75,7 @@ Notation: `—` means the variant is not applicable for this benchmark (operator
 | groupby_where_sum | `where → group_by → select((K, select → sum))` | 86 | 80 | **23** (PR-B upstream where + inner-select-sum fused) |
 | groupby_select_sum | `select → group_by → select((K, sum))` | — | 110 | **58** (PR-B upstream select fused via intermediate var bind) |
 | groupby_having_count | `group_by → having(len>=5) → select((K, length))` | 141 | 78 | **36** (PR-D having predicate rewritten to slot ref) |
+| groupby_having_hidden_sum | `group_by → having(select(price) → sum > N) → select((K, length))` | 175 | 109 | **40** (PR-E synthesized hidden accumulator slot for the having-only inner-select-sum) |
 | groupby_average | `group_by → select((K, select → average))` | 173 | 106 | **52** (PR-A2 follow-up: 2-slot acc + post-process divide) |
 | chained_where | `where → where → count` | 36 | 45 | 17 |
 | zip_dot_product | `zip → select → sum` | — | 53 | 37 |
@@ -507,7 +508,7 @@ Closes the SQL `HAVING` shape against the splice path: any `_having(pred)` betwe
 
 ### Deferred for follow-ups
 
-- Having predicates that reference a reducer absent from the select (would need a hidden accumulator slot in the table value type).
+- Having predicates that reference a reducer absent from the select on the **bare-form** select shape (the bare table layout uses `tuple<KeyT; AccT>` synthesized inside a qmacro with embedded `typedecl(invoke(...))` for the key type — can't be extended with a dynamic count of additional acc slots; named-tuple form is handled by PR-E below).
 - Having predicates that touch the raw bucket array (would require materializing the per-bucket array, defeating the splice).
 
 ## Phase 3+ groupby reducer expansion — average reducer (PR-A2 follow-up)
@@ -582,9 +583,49 @@ Only the last `min(N, length)` indices are visited; the entire `reverse_inplace`
 
 \* m1 SQL: `ORDER BY id DESC LIMIT 10` collapses to 0 ns/op via index. The m3f 0 ns/op result means sub-nanosecond per element averaged across 10/100K visited elements — the backward index loop runs only 10 iterations regardless of N.
 
+## Phase 3+ groupby reducer expansion — hidden-slot reducer-in-having (PR-E)
+
+Closes the explicit "having predicate references a reducer absent from the select" cascade case deferred since PR-D. The named-tuple select-shape now extends its internal table value type with one extra acc slot per having-only reducer; the per-element loop updates the hidden slot alongside the user-visible ones; result-build re-synthesizes the user's tuple via `ExprMakeTuple` (omitting hidden slots) while the having predicate substitutes hidden-slot references via the same `mk_slot_output_expr` helper PR-D already used for matched slots.
+
+**How it lands:**
+
+1. **Scan-then-rewrite the having predicate.** A new `extend_specs_for_missing_having_reducers` walks the having pred AST first. For each `<reducer>(<hb>._1)` or `<reducer>(select(<hb>._1, <lam>))` call whose reducer name doesn't match any existing select-side spec, it appends a new hidden `ReducerSpec` to the specs array with a fresh slot index (starting at `userVisibleSlotCount + 1`). Then the existing PR-D `rewrite_having_pred` runs unchanged — every reducer reference now has a matching spec to bind to.
+
+2. **`mk_hidden_acc_type` helper.** Derives the acc TypeDecl for hidden slots from the reducer name + bucket-element type (and the peeled inner-body type for inner-select forms). Mirrors the per-reducer-name logic of `slot_acc_type` but takes the source types directly (hidden slots have no user-visible group_proj body to drill into). `length`/`count` → `int`; `long_count` → `int64`; `average` → `tuple<double; uint64>` via `mk_avg_acc_type`; `sum`/`min`/`max`/`first` → bucket element type (or inner-body type).
+
+3. **Extend `tabValueType.argTypes` (and `argNames`).** After the existing avg-slot type swap, the named-tuple's tabValueType gets each hidden spec's accType appended at the end. argNames grow in lockstep with auto-generated `_hidden_{slot}` names to keep the named-tuple shape valid.
+
+4. **Unify result-build ExprMakeTuple synthesis.** What was `elif (hasAvg)` becomes `elif (hasAvg || hasHidden)` — the same loop that re-synthesizes the user's tuple slot-by-slot (dividing avg slots, copying others) naturally omits hidden slots because it iterates `1 .. groupProjBody._type.argTypes |> length` (the user's slot count, NOT the internal table's extended count).
+
+5. **Bare-form bail.** When the user's group_proj is a single bare reducer (not a named tuple) AND having needs a hidden slot, the planner returns null and the chain cascades. The bare table layout uses `tuple<KeyT; AccT>` synthesized inside a qmacro with embedded `typedecl(invoke(...))` for the key type, which can't be dynamically extended with additional acc slots. Pinned by `test_group_by_having_hidden_bare_form_cascades_to_tier2`.
+
+**Bail cases (cascade to tier 2):**
+- Bare-form select with hidden-slot reducer in having (per above).
+- Inner-select reducer in having whose lambda is non-peelable (peel failure returns null).
+- All upstream bail cases from PR-A1/A2/B/D still apply.
+
+**Edge cases worth noting:**
+- Same-name reducer in select AND having reuses the select slot (existing PR-D match-by-name behavior preserved). Hidden slot only added when no name match exists. The "inner-select reducer with different lambdas at select vs having" case still match-by-name in v1 — structural lambda compare deferred.
+- Multiple references to the SAME hidden reducer in the predicate dedup naturally: the first walk adds the spec; subsequent walks see a matching spec and skip.
+- 2+ hidden reducers fall into the same scan pass; each gets its own slot.
+
+### Headline (PR-E)
+
+| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (this PR) | Win |
+|---|---|---:|---:|---:|---:|
+| groupby_having_hidden_sum | `each(arr) → group_by(brand) → having(sum(price) > 50000) → select((K, length)) → to_array` | 175 | 109 | **40** | **2.7× over m3 / 4.4× over m1 SQL** |
+| groupby_having_count (regression check) | `group_by → having(len>=5) → select((K, length))` | 141 | 92 | **36** | parity — PR-E scan-then-rewrite preserves the matching-slot splice |
+
+`groupby_having_hidden_sum` lands at ~40 ns/op vs `groupby_having_count`'s ~36 — the extra ~4 ns/op is the hidden inner-select-sum's per-element `entry._{hidden} += c.price` (one extra add per source element) alongside the visible `length++`.
+
+### Deferred for follow-ups
+
+- Bare-form select with hidden slot (requires restructuring the bare-table key-type qmacro to programmatic TypeDecl construction).
+- Inner-select reducer in having that uses a different lambda from a same-named select-side inner-select reducer — currently match-by-name conflates them (already a v1 limitation since PR-D; structural lambda compare TBD).
+
 ## Operator-coverage checklist (parity tests)
 
-The 24 benchmarks above cover the most common shapes. The end-game target is one benchmark per `_fold`-applicable scenario in the broader `tests/linq/` operator suite. Tracking the long-tail coverage below; PRs that add splice support for new operators should add a benchmark here if not already present.
+The benchmarks above cover the most common shapes. The end-game target is one benchmark per `_fold`-applicable scenario in the broader `tests/linq/` operator suite. Tracking the long-tail coverage below; PRs that add splice support for new operators should add a benchmark here if not already present.
 
 | Source test file | Operator group | Covered by benchmark | Status |
 |---|---|---|---|
@@ -593,7 +634,7 @@ The 24 benchmarks above cover the most common shapes. The end-game target is one
 | `test_linq_querying.das` | any/all/contains | any_match, all_match, contains_match | ✅ core |
 | `test_linq_transform.das` | select/select_many/zip | to_array_filter, zip_dot_product | ✅ select/zip; `select_many` ⏳ |
 | `test_linq_sorting.das` | order/order_by/reverse | sort_first, sort_take, select_where_order_take, reverse_take | ✅ ascending + `order_descending` (Phase 3); ✅ `reverse` (Phase 3+); ✅ `reverse \|> take(N)` backward index loop on array sources (PR-C — closes the prior regression) |
-| `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum, groupby_min, groupby_max, groupby_first, groupby_multi_reducer, groupby_where_count, groupby_where_sum, groupby_select_sum, groupby_having_count, groupby_average | ✅ count/long_count/sum + inner-select-sum (PR-A1); ✅ min/max/first + inner-select-{min,max,first} + multi-reducer (PR-A2); ✅ upstream where_/select* fusion (PR-B); ✅ `having_` with matching slot (PR-D); ✅ `average` + inner-select-average + multi-reducer-with-average (PR-A2 follow-up) |
+| `test_linq_group_by.das` | group_by/group_by_lazy/having | groupby_count, groupby_sum, groupby_min, groupby_max, groupby_first, groupby_multi_reducer, groupby_where_count, groupby_where_sum, groupby_select_sum, groupby_having_count, groupby_having_hidden_sum, groupby_average | ✅ count/long_count/sum + inner-select-sum (PR-A1); ✅ min/max/first + inner-select-{min,max,first} + multi-reducer (PR-A2); ✅ upstream where_/select* fusion (PR-B); ✅ `having_` with matching slot (PR-D); ✅ `average` + inner-select-average + multi-reducer-with-average (PR-A2 follow-up); ✅ hidden-slot reducer-in-having on named-tuple select shape (PR-E) |
 | `test_linq_join.das` | join/left_join/right_join/full_outer/cross | join_count | ✅ inner; outer joins + cross ⏳ |
 | `test_linq_partition.das` | take/skip/take_while/skip_while/chunk | take_count, skip_take, take_sum_aggregate, take_count_filtered | ✅ take/skip in splice lanes; `_while` + `chunk` ⏳ |
 | `test_linq_set.das` | distinct/union/except/intersect/unique | distinct_count, distinct_take | ✅ distinct + distinct_by (streaming dedup, this PR); union/except/intersect/unique ⏳ |

--- a/benchmarks/sql/groupby_having_hidden_sum.das
+++ b/benchmarks/sql/groupby_having_hidden_sum.das
@@ -1,0 +1,66 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _group_by(_.brand) |> _having(_._1 |> select(price) |> sum > 50000) |> _select((Brand=key, N=length)).
+// SQL: SELECT brand, COUNT(*) FROM cars GROUP BY brand HAVING SUM(price) > 50000.
+// Splice mode (PR-E) recognizes that the having predicate's inner-select-sum on price has
+// NO matching select-side slot — the planner synthesizes a hidden accumulator slot on the
+// internal table value type; the per-element loop updates it alongside `length`; result-build
+// projects only the user-visible (Brand, N) and applies the having filter against the hidden
+// slot via `kv._{hidden} > 50000`. Without PR-E this chain cascaded to tier 2 (full bucket-
+// array materialization).
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let groups <- _sql(db |> select_from(type<Car>)
+                                  |> _group_by(_.brand)
+                                  |> _having(_._1 |> select($(c : Car) => c.price) |> sum > 50000)
+                                  |> _select((Brand = _._0, N = _._1 |> length)))
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let groups <- (arr._group_by(_.brand)._having(_._1 |> select($(c : Car) => c.price) |> sum > 50000)._select((Brand = _._0, N = _._1 |> length)))
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let groups <- _fold(each(arr)
+                            ._group_by(_.brand)
+                            ._having(_._1 |> select($(c : Car) => c.price) |> sum > 50000)
+                            ._select((Brand = _._0, N = _._1 |> length))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def groupby_having_hidden_sum_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def groupby_having_hidden_sum_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def groupby_having_hidden_sum_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -2029,8 +2029,9 @@ def private mk_hidden_acc_type(reducerName : string; isInnerSelect : bool;
 
 [macro_function]
 def private having_reducer_append_if_missing(var expr : Expression?; hbName, itName : string;
-                                             var specs : array<ReducerSpec>; bucketElemType : TypeDeclPtr; at : LineInfo) : bool {
-    // Append a hidden ReducerSpec when `expr` is a bare/inner-select reducer on the having bind that has no name-match in `specs`. Returns false only on inner-select peel failure (caller cascades).
+                                             var specs : array<ReducerSpec>; userVisibleSlotCount : int;
+                                             bucketElemType : TypeDeclPtr; at : LineInfo) : bool {
+    // Append a hidden ReducerSpec when `expr` is a bare/inner-select reducer on the having bind that has no name-match in `specs`. Returns false only on inner-select peel failure or on a second same-named hidden inner-select reducer (caller cascades — the splice can't distinguish two different inner lambdas, so we'd silently route both predicate terms to the first hidden slot).
     if (expr == null || !(expr is ExprCall)) return true
     let c = expr as ExprCall
     if (c.func == null || (c.arguments |> length) != 1) return true
@@ -2066,7 +2067,8 @@ def private having_reducer_append_if_missing(var expr : Expression?; hbName, itN
     if (innerName != "select") return true
     let comboName = "{fnName}_inner_select"
     for (s in specs) {
-        if (s.name == comboName) return true
+        // Match against a select-side spec (visible slot): v1 trusts the user wrote identical lambdas (pre-existing PR-D limitation, documented in LINQ.md). Match against an already-added hidden spec from this having scan would silently route two different inner lambdas to the same slot — bail to tier 2 instead, where each select() is evaluated separately.
+        if (s.name == comboName) return s.slot <= userVisibleSlotCount
     }
     var innerBody = fold_linq_cond(clone_expression(ic.arguments[1]), itName)
     if (innerBody == null || innerBody._type == null) return false
@@ -2079,7 +2081,8 @@ def private having_reducer_append_if_missing(var expr : Expression?; hbName, itN
 
 [macro_function]
 def private extend_specs_for_missing_having_reducers(var expr : Expression?; hbName, itName : string;
-                                                     var specs : array<ReducerSpec>; bucketElemType : TypeDeclPtr; at : LineInfo) : bool {
+                                                     var specs : array<ReducerSpec>; userVisibleSlotCount : int;
+                                                     bucketElemType : TypeDeclPtr; at : LineInfo) : bool {
     // Pre-rewrite walker that appends hidden ReducerSpecs for having-only reducers; unrecognized shapes leak to rewrite_having_pred (which bails on any surviving raw `<hb>`).
     if (expr == null) return true
     while (expr is ExprRef2Value) {
@@ -2087,30 +2090,30 @@ def private extend_specs_for_missing_having_reducers(var expr : Expression?; hbN
     }
     if (expr is ExprCall) {
         var c = expr as ExprCall
-        if (!having_reducer_append_if_missing(expr, hbName, itName, specs, bucketElemType, at)) return false
+        if (!having_reducer_append_if_missing(expr, hbName, itName, specs, userVisibleSlotCount, bucketElemType, at)) return false
         for (i in 0 .. (c.arguments |> length)) {
-            if (!extend_specs_for_missing_having_reducers(c.arguments[i], hbName, itName, specs, bucketElemType, at)) return false
+            if (!extend_specs_for_missing_having_reducers(c.arguments[i], hbName, itName, specs, userVisibleSlotCount, bucketElemType, at)) return false
         }
         return true
     }
     if (expr is ExprField) {
         var f = expr as ExprField
-        return extend_specs_for_missing_having_reducers(f.value, hbName, itName, specs, bucketElemType, at)
+        return extend_specs_for_missing_having_reducers(f.value, hbName, itName, specs, userVisibleSlotCount, bucketElemType, at)
     }
     if (expr is ExprOp1) {
         var op = expr as ExprOp1
-        return extend_specs_for_missing_having_reducers(op.subexpr, hbName, itName, specs, bucketElemType, at)
+        return extend_specs_for_missing_having_reducers(op.subexpr, hbName, itName, specs, userVisibleSlotCount, bucketElemType, at)
     }
     if (expr is ExprOp2) {
         var op = expr as ExprOp2
-        if (!extend_specs_for_missing_having_reducers(op.left, hbName, itName, specs, bucketElemType, at)) return false
-        return extend_specs_for_missing_having_reducers(op.right, hbName, itName, specs, bucketElemType, at)
+        if (!extend_specs_for_missing_having_reducers(op.left, hbName, itName, specs, userVisibleSlotCount, bucketElemType, at)) return false
+        return extend_specs_for_missing_having_reducers(op.right, hbName, itName, specs, userVisibleSlotCount, bucketElemType, at)
     }
     if (expr is ExprOp3) {
         var op = expr as ExprOp3
-        return (extend_specs_for_missing_having_reducers(op.subexpr, hbName, itName, specs, bucketElemType, at)
-                && extend_specs_for_missing_having_reducers(op.left, hbName, itName, specs, bucketElemType, at)
-                && extend_specs_for_missing_having_reducers(op.right, hbName, itName, specs, bucketElemType, at))
+        return (extend_specs_for_missing_having_reducers(op.subexpr, hbName, itName, specs, userVisibleSlotCount, bucketElemType, at)
+                && extend_specs_for_missing_having_reducers(op.left, hbName, itName, specs, userVisibleSlotCount, bucketElemType, at)
+                && extend_specs_for_missing_having_reducers(op.right, hbName, itName, specs, userVisibleSlotCount, bucketElemType, at))
     }
     return true
 }
@@ -2357,7 +2360,7 @@ def private plan_group_by(var expr : Expression?) : Expression? {
         let hbName = "`hb`{at.line}`{at.column}"
         var rawPred = fold_linq_cond(havingCall.arguments[1], hbName)
         // PR-E: scan first to add hidden slots for reducers referenced by having but absent from select.
-        if (rawPred == null || !extend_specs_for_missing_having_reducers(rawPred, hbName, itName, specs, elemType, at)) return null
+        if (rawPred == null || !extend_specs_for_missing_having_reducers(rawPred, hbName, itName, specs, userVisibleSlotCount, elemType, at)) return null
         havingPred = rewrite_having_pred(rawPred, hbName, kvName, specs)
         // Safety net: a node type rewrite_having_pred didn't recurse into would leak hbName through to the splice (compile error at the splice site). Bail.
         if (havingPred == null || expr_uses_var(havingPred, hbName)) return null

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -2016,6 +2016,106 @@ def private mk_slot_output_expr(at : LineInfo; entryName : string; spec : Reduce
 }
 
 [macro_function]
+def private mk_hidden_acc_type(reducerName : string; isInnerSelect : bool;
+                               bucketElemType, innerBodyType : TypeDeclPtr; at : LineInfo) : TypeDeclPtr {
+    // Hidden-slot acc type: like slot_acc_type but takes source types directly (hidden slots have no group_proj body to drill into).
+    if (reducerName == "length" || reducerName == "count") return new TypeDecl(baseType = Type.tInt, at = at)
+    if (reducerName == "long_count") return new TypeDecl(baseType = Type.tInt64, at = at)
+    if (reducerName == "average" || reducerName == "average_inner_select") return mk_avg_acc_type(at)
+    let src = isInnerSelect ? innerBodyType : bucketElemType
+    if (src == null) return null
+    return strip_const_ref(clone_type(src))
+}
+
+[macro_function]
+def private having_reducer_append_if_missing(var expr : Expression?; hbName, itName : string;
+                                             var specs : array<ReducerSpec>; bucketElemType : TypeDeclPtr; at : LineInfo) : bool {
+    // Append a hidden ReducerSpec when `expr` is a bare/inner-select reducer on the having bind that has no name-match in `specs`. Returns false only on inner-select peel failure (caller cascades).
+    if (expr == null || !(expr is ExprCall)) return true
+    let c = expr as ExprCall
+    if (c.func == null || (c.arguments |> length) != 1) return true
+    var fnName = string(c.func.name)
+    if (c.func.fromGeneric != null) {
+        fnName = string(c.func.fromGeneric.name)
+    }
+    let isReducer = (fnName == "length" || fnName == "count" || fnName == "long_count"
+            || fnName == "sum" || fnName == "min" || fnName == "max"
+            || fnName == "first" || fnName == "average")
+    if (!isReducer) return true
+    if (is_bind_field_access(c.arguments[0], hbName, 1)) {
+        for (s in specs) {
+            if (s.innerBody == null && s.name == fnName) return true
+        }
+        var accType = mk_hidden_acc_type(fnName, false, bucketElemType, null, at)
+        if (accType == null) return true
+        let newSlot = (specs |> length) + 1
+        specs |> push <| ReducerSpec(slot = newSlot, name = fnName, innerBody = null, accType = accType)
+        return true
+    }
+    let canInnerSelect = (fnName == "sum" || fnName == "min" || fnName == "max"
+            || fnName == "first" || fnName == "average")
+    if (!canInnerSelect) return true
+    let inner = c.arguments[0]
+    if (inner == null || !(inner is ExprCall)) return true
+    let ic = inner as ExprCall
+    if (ic.func == null || (ic.arguments |> length) != 2 || !is_bind_field_access(ic.arguments[0], hbName, 1)) return true
+    var innerName = string(ic.func.name)
+    if (ic.func.fromGeneric != null) {
+        innerName = string(ic.func.fromGeneric.name)
+    }
+    if (innerName != "select") return true
+    let comboName = "{fnName}_inner_select"
+    for (s in specs) {
+        if (s.name == comboName) return true
+    }
+    var innerBody = fold_linq_cond(clone_expression(ic.arguments[1]), itName)
+    if (innerBody == null || innerBody._type == null) return false
+    var accType = mk_hidden_acc_type(comboName, true, bucketElemType, innerBody._type, at)
+    if (accType == null) return false
+    let newSlot = (specs |> length) + 1
+    specs |> push <| ReducerSpec(slot = newSlot, name = comboName, innerBody = innerBody, accType = accType)
+    return true
+}
+
+[macro_function]
+def private extend_specs_for_missing_having_reducers(var expr : Expression?; hbName, itName : string;
+                                                     var specs : array<ReducerSpec>; bucketElemType : TypeDeclPtr; at : LineInfo) : bool {
+    // Pre-rewrite walker that appends hidden ReducerSpecs for having-only reducers; unrecognized shapes leak to rewrite_having_pred (which bails on any surviving raw `<hb>`).
+    if (expr == null) return true
+    while (expr is ExprRef2Value) {
+        expr = (expr as ExprRef2Value).subexpr
+    }
+    if (expr is ExprCall) {
+        var c = expr as ExprCall
+        if (!having_reducer_append_if_missing(expr, hbName, itName, specs, bucketElemType, at)) return false
+        for (i in 0 .. (c.arguments |> length)) {
+            if (!extend_specs_for_missing_having_reducers(c.arguments[i], hbName, itName, specs, bucketElemType, at)) return false
+        }
+        return true
+    }
+    if (expr is ExprField) {
+        var f = expr as ExprField
+        return extend_specs_for_missing_having_reducers(f.value, hbName, itName, specs, bucketElemType, at)
+    }
+    if (expr is ExprOp1) {
+        var op = expr as ExprOp1
+        return extend_specs_for_missing_having_reducers(op.subexpr, hbName, itName, specs, bucketElemType, at)
+    }
+    if (expr is ExprOp2) {
+        var op = expr as ExprOp2
+        if (!extend_specs_for_missing_having_reducers(op.left, hbName, itName, specs, bucketElemType, at)) return false
+        return extend_specs_for_missing_having_reducers(op.right, hbName, itName, specs, bucketElemType, at)
+    }
+    if (expr is ExprOp3) {
+        var op = expr as ExprOp3
+        return (extend_specs_for_missing_having_reducers(op.subexpr, hbName, itName, specs, bucketElemType, at)
+                && extend_specs_for_missing_having_reducers(op.left, hbName, itName, specs, bucketElemType, at)
+                && extend_specs_for_missing_having_reducers(op.right, hbName, itName, specs, bucketElemType, at))
+    }
+    return true
+}
+
+[macro_function]
 def private rewrite_having_pred(var expr : Expression?; hbName, kvName : string; specs : array<ReducerSpec>) : Expression? {
     // Substitutes `<hb>._0` → `kv._0` and `<reducer>(<hb>._1)` / `<reducer>(select(<hb>._1, <lam>))` → `kv._{slot}` (or divide expr for average) against matching specs; any other use of `<hb>` returns null and cascades.
     if (expr == null) return expr
@@ -2250,21 +2350,26 @@ def private plan_group_by(var expr : Expression?) : Expression? {
     if (groupProjBody == null || groupProjBody._type == null) return null
     var (specs, usesNamedTuple) = recognize_reducer_specs(groupProjBody, bindName, itName)
     if (empty(specs)) return null
+    let userVisibleSlotCount = specs |> length
+    // Rewrite optional having predicate against accumulator slots; bails on anything other than _._0 / reducer(_._1) matched to a select-side slot or a synthesized hidden slot (PR-E).
+    var havingPred : Expression?
+    if (havingCall != null) {
+        let hbName = "`hb`{at.line}`{at.column}"
+        var rawPred = fold_linq_cond(havingCall.arguments[1], hbName)
+        // PR-E: scan first to add hidden slots for reducers referenced by having but absent from select.
+        if (rawPred == null || !extend_specs_for_missing_having_reducers(rawPred, hbName, itName, specs, elemType, at)) return null
+        havingPred = rewrite_having_pred(rawPred, hbName, kvName, specs)
+        // Safety net: a node type rewrite_having_pred didn't recurse into would leak hbName through to the splice (compile error at the splice site). Bail.
+        if (havingPred == null || expr_uses_var(havingPred, hbName)) return null
+    }
+    let hasHidden = (specs |> length) > userVisibleSlotCount
+    // Bare form + hidden slot would require extending `tuple<KeyT; AccT>` synthesized inside a qmacro with embedded `typedecl(invoke(...))` for the key type — can't dynamically grow that. Cascade.
+    if (hasHidden && !usesNamedTuple) return null
     var hasAvg = false
     for (s in specs) {
         if (is_average_spec(s)) {
             hasAvg = true
         }
-    }
-    // Rewrite optional having predicate against accumulator slots; bails on anything other than _._0 / reducer(_._1) matched to a select slot.
-    var havingPred : Expression?
-    if (havingCall != null) {
-        let hbName = "`hb`{at.line}`{at.column}"
-        var rawPred = fold_linq_cond(havingCall.arguments[1], hbName)
-        if (rawPred == null) return null
-        havingPred = rewrite_having_pred(rawPred, hbName, kvName, specs)
-        // Safety net: a node type rewrite_having_pred didn't recurse into would leak hbName through to the splice (compile error at the splice site). Bail.
-        if (havingPred == null || expr_uses_var(havingPred, hbName)) return null
     }
     // Named-tuple wrap reuses the user's body type (preserves field-name hints); bare reducer synthesizes tuple<KeyT; AccT>.
     var keyBlk1 = clone_expression(keyBlock)
@@ -2278,8 +2383,22 @@ def private plan_group_by(var expr : Expression?) : Expression? {
         // Average slots store the 2-tuple <sum;count> internally; result-build divides at output.
         if (hasAvg) {
             for (s in specs) {
-                if (is_average_spec(s) && s.slot < (tabValueType.argTypes |> length)) {
+                if (is_average_spec(s) && s.slot <= userVisibleSlotCount && s.slot < (tabValueType.argTypes |> length)) {
                     tabValueType.argTypes[s.slot] = mk_avg_acc_type(at)
+                }
+            }
+        }
+        // PR-E: append hidden slots (synthesized for having-only reducers) after the user-visible slots; result-build re-synthesizes the user's tuple shape via ExprMakeTuple, omitting them.
+        if (hasHidden) {
+            let preserveNames = (tabValueType.argNames |> length) == (tabValueType.argTypes |> length)
+            for (s in specs) {
+                if (s.slot > userVisibleSlotCount) {
+                    tabValueType.argTypes |> push <| clone_type(s.accType)
+                    if (preserveNames) {
+                        let nameIdx = tabValueType.argNames |> length
+                        tabValueType.argNames |> resize(nameIdx + 1)
+                        tabValueType.argNames[nameIdx] := "_hidden_{s.slot}"
+                    }
                 }
             }
         }
@@ -2402,8 +2521,8 @@ def private plan_group_by(var expr : Expression?) : Expression? {
                     $i(kvName)._1
                 }
             }
-        } elif (hasAvg) {
-            // Tuple with avg slot(s): table value type stores tuple<double;uint64> per avg slot, so re-synthesize the user's tuple at result-build, dividing avg slots. Positional tuples (no field names) and named tuples both pass through recognize_reducer_specs — slot count comes from argTypes; recordNames only get filled when argNames is populated.
+        } elif (hasAvg || hasHidden) {
+            // Re-synthesize the user's tuple slot-by-slot: avg slots divide, hidden slots are omitted by iterating only user-visible argTypes; recordNames only when argNames are populated.
             var mt = new ExprMakeTuple(at = at)
             let slotCount = (groupProjBody._type.argTypes |> length)
             let hasNames = (groupProjBody._type.argNames |> length) == slotCount

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -2217,6 +2217,31 @@ def test_group_by_having_unhandled_node_cascades(t : T?) {
 }
 
 [test]
+def test_group_by_having_two_same_named_inner_select_diff_lambdas(t : T?) {
+    // PR-E + Copilot review: when having has TWO same-named inner-select reducers with
+    // DIFFERENT lambdas, naive dedup-by-name would route both predicate terms to the same
+    // accumulator slot — silently wrong. Pinning correct semantics.
+    t |> run("two hidden inner-select sums (different lambdas) compute distinctly") @(tt : T?) {
+        let arr = [1, 2, 3, 4, 5, 6, 7, 8]
+        // Bucket %3: 0=[3,6]: sum(x*2)=18, sum(x*3)=27, total=45.
+        //            1=[1,4,7]: sum(x*2)=24, sum(x*3)=36, total=60.
+        //            2=[2,5,8]: sum(x*2)=30, sum(x*3)=45, total=75.
+        // Having: sum(x*2) + sum(x*3) > 50 → buckets 1 (60>50) and 2 (75>50) pass; bucket 0 (45) fails.
+        let got <- _fold(arr._group_by_lazy(_ % 3)
+                            ._having((_._1 |> select($(x : int) => x * 2) |> sum)
+                                + (_._1 |> select($(x : int) => x * 3) |> sum) > 50)
+                            ._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(2, seen |> length)
+        tt |> equal(3, seen[1])
+        tt |> equal(3, seen[2])
+    }
+}
+
+[test]
 def test_group_by_having_bare_form_with_hidden_cascades(t : T?) {
     // PR-E bail: bare-form group_proj combined with a having reducer that needs a hidden slot
     // falls back to tier 2 (the bare table layout uses `tuple<KeyT; AccT>` synthesized inside a

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -2217,19 +2217,23 @@ def test_group_by_having_unhandled_node_cascades(t : T?) {
 }
 
 [test]
-def test_group_by_having_unmatched_reducer_cascades(t : T?) {
-    // PR-D bail: having references a reducer not present in select. Splice cascades to tier 2;
-    // semantics must still be correct via the array-shape pipeline.
-    t |> run("having uses sum but select only has length") @(tt : T?) {
+def test_group_by_having_bare_form_with_hidden_cascades(t : T?) {
+    // PR-E bail: bare-form group_proj combined with a having reducer that needs a hidden slot
+    // falls back to tier 2 (the bare table layout uses `tuple<KeyT; AccT>` synthesized inside a
+    // qmacro with embedded `typedecl(invoke(...))` for the key type, which we can't extend with
+    // a dynamic count of additional acc slots). Semantics must still be correct via cascade.
+    t |> run("bare-form select with hidden sum in having cascades") @(tt : T?) {
         let arr = [1, 2, 3, 4, 5, 6]
         // Buckets %2: 0=[2,4,6](sum=12, len=3), 1=[1,3,5](sum=9, len=3). Having sum > 10 → 0.
-        let got <- _fold(arr._group_by_lazy(_ % 2)._having(_._1 |> sum > 10)._select((K = _._0, N = _._1 |> length)))
-        var seen : table<int; int>
-        for (kv in got) {
-            seen[kv.K] = kv.N
+        let got <- _fold(arr._group_by_lazy(_ % 2)._having(_._1 |> sum > 10)._select(_._1 |> length))
+        var cnt = 0
+        var total = 0
+        for (v in got) {
+            cnt ++
+            total += v
         }
-        tt |> equal(1, seen |> length)
-        tt |> equal(3, seen[0])
+        tt |> equal(1, cnt)
+        tt |> equal(3, total)
     }
 }
 
@@ -2281,6 +2285,123 @@ def test_reverse_first_or_default_parity(t : T?) {
     t |> run("empty source → default") @(tt : T?) {
         var empty : array<int>
         tt |> equal(42, _fold(each(empty) |> reverse() |> first_or_default(42)))
+    }
+}
+
+[test]
+def test_group_by_having_hidden_slot_fold_parity(t : T?) {
+    // PR-E: having references a reducer not present in select — splice synthesizes a hidden
+    // accumulator slot in the internal table value type; result-build projects only the
+    // user-visible slots.
+    t |> run("hidden sum: having sum>N, select length") @(tt : T?) {
+        let arr = [1, 2, 3, 4, 5, 6]
+        // Buckets %2: 0=[2,4,6](sum=12, len=3), 1=[1,3,5](sum=9, len=3). Having sum > 10 → 0.
+        let got <- _fold(arr._group_by_lazy(_ % 2)._having(_._1 |> sum > 10)._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(1, seen |> length)
+        tt |> equal(3, seen[0])
+    }
+    t |> run("hidden min: having min<K, select length") @(tt : T?) {
+        let arr = [10, 20, 30, 11, 21, 31, 12, 22, 32]
+        // Buckets %3: 0=[30,21,12](min=12), 1=[10,31,22](min=10), 2=[20,11,32](min=11). Having min<12 → 1,2.
+        let got <- _fold(arr._group_by_lazy(_ % 3)._having(_._1 |> min < 12)._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(2, seen |> length)
+        tt |> equal(3, seen[1])
+        tt |> equal(3, seen[2])
+    }
+    t |> run("hidden max: having max>=N, select length") @(tt : T?) {
+        let arr = [10, 20, 30, 11, 21, 31, 12]
+        // Buckets %3: 0=[30,21,12](max=30), 1=[10,31](max=31), 2=[20,11](max=20). Having max>=30 → 0,1.
+        let got <- _fold(arr._group_by_lazy(_ % 3)._having(_._1 |> max >= 30)._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(2, seen |> length)
+        tt |> equal(3, seen[0])
+        tt |> equal(2, seen[1])
+    }
+    t |> run("hidden average: having average>F, select length") @(tt : T?) {
+        let arr = [10, 20, 30, 11, 21, 31, 12]
+        // Buckets %3: 0=[30,21,12](avg=21.0), 1=[10,31](avg=20.5), 2=[20,11](avg=15.5). Having avg>16 → 0,1.
+        let got <- _fold(arr._group_by_lazy(_ % 3)._having(_._1 |> average > 16.0lf)._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(2, seen |> length)
+        tt |> equal(3, seen[0])
+        tt |> equal(2, seen[1])
+    }
+    t |> run("hidden sum + visible length used in same predicate") @(tt : T?) {
+        let arr = [1, 2, 3, 4, 5, 6]
+        // 0=[2,4,6](sum=12, len=3), 1=[1,3,5](sum=9, len=3). Having sum>=9 && len>=3 → both pass.
+        let got <- _fold(arr._group_by_lazy(_ % 2)._having((_._1 |> sum) >= 9 && (_._1 |> length) >= 3)._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(2, seen |> length)
+        tt |> equal(3, seen[0])
+        tt |> equal(3, seen[1])
+    }
+    t |> run("two hidden reducers: sum + min, select length") @(tt : T?) {
+        let arr = [10, 20, 30, 11, 21, 31, 12]
+        // 0=[30,21,12](sum=63, min=12), 1=[10,31](sum=41, min=10), 2=[20,11](sum=31, min=11). Having sum>40 && min<15 → 0,1.
+        let got <- _fold(arr._group_by_lazy(_ % 3)._having((_._1 |> sum) > 40 && (_._1 |> min) < 15)._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(2, seen |> length)
+        tt |> equal(3, seen[0])
+        tt |> equal(2, seen[1])
+    }
+    t |> run("hidden inner-select sum (lambda peelable)") @(tt : T?) {
+        let arr = [1, 2, 3, 4, 5, 6, 7, 8]
+        // Buckets %3: 0=[3,6] doubled=[6,12](sum=18), 1=[1,4,7] doubled=[2,8,14](sum=24), 2=[2,5,8] doubled=[4,10,16](sum=30). Having sum>20 → 1,2.
+        let got <- _fold(arr._group_by_lazy(_ % 3)._having(_._1 |> select($(x : int) => x * 2) |> sum > 20)._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(2, seen |> length)
+        tt |> equal(3, seen[1])
+        tt |> equal(3, seen[2])
+    }
+    t |> run("count terminator with hidden sum") @(tt : T?) {
+        let arr = [1, 2, 3, 4, 5, 6]
+        // 0=[2,4,6](sum=12), 1=[1,3,5](sum=9). Having sum>10 → 1 bucket.
+        let c = _fold(arr._group_by_lazy(_ % 2)._having(_._1 |> sum > 10)._select((K = _._0, N = _._1 |> length)) |> count())
+        tt |> equal(1, c)
+    }
+    t |> run("upstream where + hidden sum in having") @(tt : T?) {
+        let arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        // where >2 then group %3: 0=[3,6,9](sum=18), 1=[4,7,10](sum=21), 2=[5,8](sum=13). Having sum>=18 → 0,1.
+        let got <- _fold(arr._where(_ > 2)._group_by_lazy(_ % 3)._having(_._1 |> sum >= 18)._select((K = _._0, N = _._1 |> length)))
+        var seen : table<int; int>
+        for (kv in got) {
+            seen[kv.K] = kv.N
+        }
+        tt |> equal(2, seen |> length)
+        tt |> equal(3, seen[0])
+        tt |> equal(3, seen[1])
+    }
+    t |> run("empty source") @(tt : T?) {
+        var empty : array<int>
+        let got <- _fold(empty._group_by_lazy(_)._having(_._1 |> sum > 0)._select((K = _._0, N = _._1 |> length)))
+        var cnt = 0
+        for (_x in got) {
+            cnt ++
+        }
+        tt |> equal(0, cnt)
     }
 }
 

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -2429,6 +2429,32 @@ def test_group_by_having_hidden_sum_splices(t : T?) {
 }
 
 [export, marker(no_coverage)]
+def target_group_by_having_two_same_named_inner_select_cascades() : array<tuple<K : int; N : int>> {
+    // PR-E bail: two same-named inner-select reducers in the same having clause can't be
+    // distinguished by name alone — splicing would silently conflate the two lambdas onto
+    // one hidden slot. Bail to tier 2 so each select() is evaluated separately.
+    return <- _fold([1, 2, 3, 4, 5, 6, 7, 8]._group_by_lazy(_ % 3)
+                       ._having((_._1 |> select($(x : int) => x * 2) |> sum)
+                           + (_._1 |> select($(x : int) => x * 3) |> sum) > 50)
+                       ._select((K = _._0, N = _._1 |> length)))
+}
+
+[test]
+def test_group_by_having_two_same_named_inner_select_cascades_to_tier2(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_having_two_same_named_inner_select_cascades)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper from cascade")
+        t |> success(count_outer_let_vars(body_expr) >= 2,
+            "cascade fingerprint: multiple pass_N outer vars")
+    }
+}
+
+[export, marker(no_coverage)]
 def target_group_by_having_hidden_bare_form_cascades() : array<int> {
     // PR-E bail: bare-form group_proj (`_._1 |> length`, not a named tuple) combined with a
     // having reducer that needs a hidden slot — the bare table layout uses `tuple<KeyT; AccT>`

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -2403,17 +2403,45 @@ def test_group_by_having_count_terminator_splices(t : T?) {
 }
 
 [export, marker(no_coverage)]
-def target_group_by_having_unmatched_cascades() : array<tuple<K : int; N : int>> {
-    // BAIL: having uses sum but the select has only length — no matching slot, so the planner
-    // returns null and the chain cascades to tier 2.
+def target_group_by_having_hidden_sum_fold() : array<tuple<K : int; N : int>> {
+    // PR-E: having uses sum but select has only length — planner synthesizes a hidden sum slot
+    // in the internal table value type; result-build projects only the user-visible (K, N).
     return <- _fold([1, 2, 3, 4, 5, 6]._group_by_lazy(_ % 2)._having(_._1 |> sum > 10)._select((K = _._0, N = _._1 |> length)))
 }
 
 [test]
-def test_group_by_having_unmatched_cascades_to_tier2(t : T?) {
+def test_group_by_having_hidden_sum_splices(t : T?) {
+    // PR-E splice fingerprint: no group_by_lazy or having_ runtime calls; single-hash hot path.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_having_hidden_sum_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "expected splice wrapper")
+        t |> equal(0, count_call(body_expr, "group_by_lazy"))
+        t |> equal(0, count_call(body_expr, "having_"))
+        t |> equal(0, count_call(body_expr, "sum"), "hidden sum inlined into += hit branch")
+        t |> equal(0, count_call(body_expr, "key_exists"), "single-hash hot path")
+        t |> success(count_call(body_expr, "unique_key") >= 1, "per-element unique_key")
+    }
+}
+
+[export, marker(no_coverage)]
+def target_group_by_having_hidden_bare_form_cascades() : array<int> {
+    // PR-E bail: bare-form group_proj (`_._1 |> length`, not a named tuple) combined with a
+    // having reducer that needs a hidden slot — the bare table layout uses `tuple<KeyT; AccT>`
+    // synthesized inside a qmacro with embedded `typedecl(invoke(...))`, which can't be
+    // extended with a dynamic count of additional acc slots. Falls back to tier 2.
+    return <- _fold([1, 2, 3, 4, 5, 6]._group_by_lazy(_ % 2)._having(_._1 |> sum > 10)._select(_._1 |> length))
+}
+
+[test]
+def test_group_by_having_hidden_bare_form_cascades_to_tier2(t : T?) {
     // Cascade fingerprint: multiple pass_N let-vars (group, having, select all separate).
     ast_gc_guard() {
-        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_having_unmatched_cascades)
+        var func = find_module_function_via_rtti(compiling_module(), @@target_group_by_having_hidden_bare_form_cascades)
         if (func == null) return
         var body_expr : ExpressionPtr
         let r = qmatch_function(func) $() {


### PR DESCRIPTION
## Summary

Closes the explicit "having predicate references a reducer absent from the select" cascade case deferred since PR-D (#2727). On the named-tuple select shape, `plan_group_by` now synthesizes a hidden accumulator slot in the internal table value type for each having-only reducer, threads it through the existing miss/hit emission, and re-synthesizes the user's tuple at result-build to omit hidden slots.

```das
// Before PR-E: cascades to tier 2 (no matching slot for sum in select).
// After  PR-E: splices via hidden sum slot.
_fold(arr._group_by_lazy(_.brand)
         ._having(_._1 |> select($(c : Car) => c.price) |> sum > 50000)
         ._select((Brand = _._0, N = _._1 |> length))
         .to_array())
```

### How it lands

1. **Scan-then-rewrite the having predicate.** A new `extend_specs_for_missing_having_reducers` walks the having pred AST first. For each `&lt;reducer&gt;(&lt;hb&gt;._1)` or `&lt;reducer&gt;(select(&lt;hb&gt;._1, &lt;lam&gt;))` call whose reducer name doesn't match any existing select-side spec, it appends a hidden `ReducerSpec` with a fresh slot index. The existing PR-D `rewrite_having_pred` then runs unchanged — every reducer reference now has a matching spec.

2. **`mk_hidden_acc_type` helper.** Derives the acc TypeDecl from the reducer name + bucket-element type (and the peeled inner-body type for inner-select forms). Mirrors `slot_acc_type`'s per-reducer-name logic but takes source types directly. `length`/`count` → `int`; `long_count` → `int64`; `average` → `tuple&lt;double; uint64&gt;`; `sum`/`min`/`max`/`first` → bucket element type (or inner-body type).

3. **Extend `tabValueType.argTypes` (and `argNames`).** After the existing avg-slot type swap, hidden specs' accTypes append to the named-tuple's tabValueType with auto-generated `_hidden_{slot}` names to keep the tuple shape valid.

4. **Unify result-build ExprMakeTuple.** `elif (hasAvg)` becomes `elif (hasAvg || hasHidden)` — the same loop that re-synthesizes the user's tuple slot-by-slot naturally omits hidden slots because it iterates only `groupProjBody._type.argTypes |> length` (the user's slot count, NOT the internal table's extended count).

5. **Bare-form bail.** When the user's group_proj is a single bare reducer (not a named tuple) AND having needs a hidden slot, the planner cascades. The bare table layout uses `tuple&lt;KeyT; AccT&gt;` synthesized inside a qmacro with embedded `typedecl(invoke(...))` for the key type, which can't be dynamically extended.

### Bail cases (cascade to tier 2)

- Bare-form select with hidden-slot reducer in having.
- Inner-select reducer in having whose lambda is non-peelable.
- All upstream bail cases from PR-A1/A2/B/D still apply.

### Headline

| Benchmark | Shape | m1 (sql) | m3 (linq) | m3f (PR-E) | Win |
|---|---|---:|---:|---:|---:|
| groupby_having_hidden_sum | `group_by → having(sum(price) > N) → select((K, length))` | 175 | 109 | **40** | **2.7× over m3 / 4.4× over m1 SQL** |
| groupby_having_count (regression check) | `group_by → having(len>=5) → select((K, length))` | 141 | 92 | **36** | parity — scan-then-rewrite preserves matching-slot splice |

`groupby_having_hidden_sum` lands at ~40 ns/op vs `groupby_having_count`'s ~36 — the extra ~4 ns/op is the hidden inner-select-sum's per-element `entry._{hidden} += c.price`.

### Deferred for follow-ups

- Bare-form select with hidden slot (requires restructuring the bare-table key-type qmacro to programmatic TypeDecl construction).
- Inner-select reducer in having that uses a different lambda from a same-named select-side inner-select reducer — currently match-by-name conflates them (v1 limitation since PR-D; structural lambda compare TBD).

## Test plan

- [x] `tests/linq/test_linq_fold.das` — 10 new parity subtests in `test_group_by_hidden_slot_fold_parity`: hidden sum/min/max/average; mixed visible+hidden in same predicate; two hidden reducers (the canonical failing-test-first case — cascade was broken here because the lazy bucket iterator was exhausted by the first reducer); hidden inner-select-sum; count terminator + hidden sum; upstream where + hidden sum; empty source. Plus `test_group_by_having_bare_form_with_hidden_cascades` for the bare-form bail.
- [x] `tests/linq/test_linq_fold_ast.das` — `test_group_by_having_hidden_sum_splices` (splice fingerprint: no `group_by_lazy`, no `having_`, no runtime `sum` call, single-hash hot path); `test_group_by_having_hidden_bare_form_cascades_to_tier2` (cascade fingerprint for bare-form bail).
- [x] Full LINQ test sweep: 937/937 tests across all 15 `tests/linq/test_linq_*.das` files green in interpreter mode.
- [x] AOT regen + run: 304/304 (`test_linq_fold`) + 115/115 (`test_linq_fold_ast`) green via `bin/test_aot dastest/dastest.das -use-aot -- --use-aot --test ...`.
- [x] Lint + format clean on all touched files (`daslib/linq_fold.das`, the two test files, the new benchmark).
- [x] `groupby_having_count` regression bench unchanged (m3f stays at 36 ns/op).
- [x] Spot-check incidental regressions: `tests/linq/test_linq_from_decs.das` + strudel tests sample all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)