### PR TITLE
lambda: copyable (alias), delete requires unsafe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,7 @@ All code MUST use gen2 syntax (add `options gen2` at the top of every file). Key
 - Structs/arrays/tables always pass by reference — no `&` needed.
 - Only **workhorse types** (`int`, `float`, `bool`, `string`, …, `isWorkhorseType` on the C++ side) pass by value.
 - **AST pointers (gc_node) pass by value** — copying the pointer, no refcount, no allocation. `def foo(p : ExpressionPtr)` shares the node; `var p` lets you reassign locally; `var p : ExpressionPtr&` propagates reassignment back. For mutable field access, take the param as `var`.
+- **Lambdas pass by value (copy aliases the capture frame).** A `lambda<…>` is a fat pointer to a heap-allocated capture frame, so `=` copies the pointer (creates an alias) and pass-by-value is free. **`delete lam` requires `unsafe`** since other aliases may still be live — same rule as raw pointer / class `delete`. The rule cascades: `array<lambda<…>>`, structs with a lambda field, tuple/variant containing a lambda — all inherit the unsafe-delete requirement.
 - **Strings:** `var s : string` is a writable local copy (no propagation). `var s : string&` propagates. `:=` clones into current context's heap (required across contexts); plain `=` copies the pointer.
 - **Residual `smart_ptr` types** (`ProgramPtr`, `ContextPtr`, `FileAccessPtr`, `DebugAgentPtr`, `VisitorAdapterPtr`) still use refcount semantics — variables holding them need `var inscope`. AST types do NOT — see below.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,13 @@ FILE(GLOB DAS_AOT_DASLIB_DEPENDS CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/daslib
 MACRO(DAS_AOT_EXT input_files genList mainTarget dasAotTool dasAotToolArg)
     set(all_depends ${dasAotTool} ${PROJECT_SOURCE_DIR}/utils/aot/main.das ${DAS_AOT_DASLIB_DEPENDS})
     set(all_outputs "")
-    set(command_args "")
+    # Per-batch arg buffer; chunked to keep each invocation under Windows'
+    # 32K command-line limit when worktree paths are long.
+    set(_DAS_AOT_BATCH_SIZE 60)
+    set(_batches "")
+    set(_batch_idx 0)
+    set(_batch_count 0)
+    set(_current_batch "")
     list(LENGTH input_files num_files)
 
     foreach(input ${input_files})
@@ -140,18 +146,36 @@ MACRO(DAS_AOT_EXT input_files genList mainTarget dasAotTool dasAotToolArg)
         list(APPEND all_outputs ${out_src})
         list(APPEND ${genList} ${out_src})
 
-        # Build command arguments: tool_arg input1 output1 tool_arg input2 output2 ...
-        list(APPEND command_args ${dasAotToolArg} ${input_src} ${out_arg})
+        # Build command arguments for the current batch
+        list(APPEND _current_batch ${dasAotToolArg} ${input_src} ${out_arg})
 
         file(MAKE_DIRECTORY ${out_dir})
         set_source_files_properties(${out_src} PROPERTIES GENERATED TRUE)
+
+        math(EXPR _batch_count "${_batch_count} + 1")
+        if(_batch_count GREATER_EQUAL ${_DAS_AOT_BATCH_SIZE})
+            set(_batches_${_batch_idx} "${_current_batch}")
+            list(APPEND _batches ${_batch_idx})
+            math(EXPR _batch_idx "${_batch_idx} + 1")
+            set(_current_batch "")
+            set(_batch_count 0)
+        endif()
+    endforeach()
+    if(_batch_count GREATER 0)
+        set(_batches_${_batch_idx} "${_current_batch}")
+        list(APPEND _batches ${_batch_idx})
+    endif()
+
+    set(_commands "")
+    foreach(i ${_batches})
+        list(APPEND _commands COMMAND ${dasAotTool} ${PROJECT_SOURCE_DIR}/utils/aot/main.das -- ${_batches_${i}} ${CROSS_PLATFORM})
     endforeach()
 
     ADD_CUSTOM_COMMAND(
         OUTPUT  ${all_outputs}
         DEPENDS ${all_depends}
         COMMENT "AOT compiling files..."
-        COMMAND ${dasAotTool} ${PROJECT_SOURCE_DIR}/utils/aot/main.das -- ${command_args} ${CROSS_PLATFORM}
+        ${_commands}
     )
     set(custom_name ${mainTarget}_genaot)
     ADD_CUSTOM_TARGET(${custom_name} DEPENDS ${all_outputs})

--- a/daslib/archive.das
+++ b/daslib/archive.das
@@ -158,7 +158,7 @@ def public serialize(var arch : Archive; var value : float4x4) {
 def public serialize(var arch : Archive; var value : auto(TT)&) {
     //! Serializes struct by serializing each field.
     if (arch.reading) {
-        delete value
+        unsafe { delete value; }
     }
     apply(value) $ [unused_argument(name)] (name : string; field) {
         arch |> _::serialize(field)
@@ -169,7 +169,7 @@ def public serialize(var arch : Archive; var value : auto(TT)&) {
 def public serialize(var arch : Archive; var value : auto(TT)&) {
     //! Serializes tuple by serializing each field.
     if (arch.reading) {
-        delete value
+        unsafe { delete value; }
     }
     apply(value) $ [unused_argument(name)] (name : string; field) {
         arch |> _::serialize(field)
@@ -180,7 +180,7 @@ def public serialize(var arch : Archive; var value : auto(TT)&) {
 def public serialize(var arch : Archive; var value : auto(TT)&) {
     //! Serializes variant by serializing the index and the active field.
     if (arch.reading) {
-        delete value
+        unsafe { delete value; }
         var index : int
         arch |> read_raw(index)
         unsafe(value |> set_variant_index(index))
@@ -358,7 +358,7 @@ def public serialize(var arch : Archive; var value : table<auto(KT); auto(VT)>) 
     if (arch.reading) {
         var len : int
         arch |> read_raw(len)
-        delete value
+        unsafe { delete value; }
         for (_ in range(len)) {
             var k : KT -const -& -#
             arch |> _::serialize(k)

--- a/daslib/decs.das
+++ b/daslib/decs.das
@@ -398,8 +398,10 @@ def public restart {
     if (insideQuery != 0) {
         panic("decs: can't call `restart` from inside query")
     }
-    delete deferActions
-    delete decsState
+    unsafe {
+        delete deferActions
+        delete decsState
+    }
 }
 
 def private new_entity_id() {
@@ -443,7 +445,7 @@ def public after_gc {
         if (arch.size > 0) {
             for (comp in arch.components) {
                 if (comp.gc_dummy != null) {
-                    delete comp.gc_dummy
+                    unsafe { delete comp.gc_dummy; }
                 }
             }
         }
@@ -1043,7 +1045,7 @@ def public commit {
     for (da in actions) {
         da.action |> invoke(da)
     }
-    delete actions
+    unsafe { delete actions; }
 }
 
 def public is_alive(eid : EntityId) : bool {

--- a/daslib/heartbeat.das
+++ b/daslib/heartbeat.das
@@ -23,7 +23,7 @@ var g_inHB : bool = false
 
 def public set_heartbeat(var cb : lambda<() : void>) {
     //! Sets the heartbeat callback lambda, replacing any previously set callback.
-    delete g_hbCallback
+    unsafe { delete g_hbCallback; }
     g_hbCallback <- cb
 }
 

--- a/doc/source/reference/language/lambdas.rst
+++ b/doc/source/reference/language/lambdas.rst
@@ -23,16 +23,22 @@ The ``->`` operator can be used instead of ``:`` for the return type:
 If no type signature is specified, ``lambda`` alone represents a lambda that takes no
 arguments and returns nothing.
 
-Lambdas can be local or global variables, and can be passed as an argument by reference.
-Lambdas can be moved, but can't be copied or cloned:
+Lambdas can be local or global variables, and can be passed by value or by reference.
+A lambda value is a fat pointer to a heap-allocated capture frame, so assignment
+``=`` aliases the same capture (cheap, no allocation); ``<-`` is the explicit move
+form. Cloning is not supported.
 
 .. code-block:: das
 
     def foo ( x : lambda < (arg1:int;arg2:float&):bool > ) {
         ...
-        var y <- x
+        var y = x       // copy — y and x now alias the same capture frame
+        var z <- x      // move — alternative when x is no longer needed
         ...
     }
+
+Because copies alias the capture frame, ``delete lam`` requires ``unsafe`` —
+otherwise sibling copies would be left dangling. See :ref:`finalizer notes below <lambdas_finalizer>`.
 
 Lambdas can be invoked via ``invoke`` or call-like syntax:
 
@@ -46,7 +52,8 @@ Lambdas can be invoked via ``invoke`` or call-like syntax:
         return x(14)
     }
 
-Lambdas are typically declared via move syntax:
+Lambdas are typically declared via move syntax (since ``@(...) { ... }`` produces a
+fresh capture frame that the binding owns initially):
 
 .. code-block:: das
 
@@ -94,11 +101,13 @@ By default, capture by copy is used. If copy is not available, the ``unsafe`` ke
 
 .. _lambdas_finalizer:
 
-Lambdas can be deleted, which causes finalizers to be called on all captured data  (see :ref:`Finalizers <finalizers>`):
+Lambdas can be deleted, which causes finalizers to be called on all captured data  (see :ref:`Finalizers <finalizers>`).
+Because copies alias the same capture frame, ``delete`` requires ``unsafe`` —
+the caller is asserting no other live copy exists:
 
 .. code-block:: das
 
-    delete lam
+    unsafe { delete lam; }
 
 Lambdas can specify a custom finalizer which is invoked before the default finalizer:
 
@@ -111,7 +120,7 @@ Lambdas can specify a custom finalizer which is invoked before the default final
         print("CNT = {CNT}\n")
     }
     var x = invoke(counter,13)
-    delete counter                  // this is when the finalizer is called
+    unsafe { delete counter; }      // this is when the finalizer is called
 
 .. _lambdas_iterator:
 
@@ -207,12 +216,16 @@ The C++ Lambda class contains single void pointer for the capture data:
         ...
     };
 
-The rationale behind passing lambdas by reference is that when ``delete`` is called:
+When ``delete`` is called on a lambda:
 
     1. the finalizer is invoked for the capture data
-    2. the capture is replaced with null
+    2. the capture pointer is replaced with null in the local variable
 
-The lack of copy or move semantics ensures that multiple pointers to a single instance of captured data cannot exist.
+A lambda value is one machine word — the ``char *capture`` pointer above — so
+copy is a cheap pointer alias and pass-by-value is free. Because copies
+share the capture frame, ``delete lam`` requires ``unsafe`` (mirroring how raw
+pointer ``delete`` is gated). Under the default GC the capture frame is freed
+automatically once no copy is reachable.
 
 .. seealso::
 

--- a/doc/source/reference/language/move_copy_clone.rst
+++ b/doc/source/reference/language/move_copy_clone.rst
@@ -45,8 +45,10 @@ The source value is not modified:
 Copy works for all POD types (``int``, ``float``, ``bool``, ``string``, pointers, etc.) and for
 structs whose fields are all copyable.
 
-Types that manage owned resources — ``array``, ``table``, ``lambda``, and ``iterator`` — cannot
-be copied. Attempting to copy them produces:
+Types that manage owned resources — ``array``, ``table``, and ``iterator`` — cannot
+be copied. ``lambda`` *is* copyable (a copy aliases the capture frame, the same way a
+raw pointer copy aliases its target), but ``delete lam`` then requires ``unsafe``.
+Attempting to copy a non-copyable type produces:
 
 .. code-block:: das
 
@@ -233,7 +235,7 @@ The following table summarizes which operators work with which types:
      - ✓
      - ✓
    * - ``lambda``
-     - ✗
+     - ✓ (alias)
      - ✓
      - ✗
    * - ``block``

--- a/doc/source/reference/tutorials/14_lambdas.rst
+++ b/doc/source/reference/tutorials/14_lambdas.rst
@@ -70,14 +70,22 @@ Use ``capture()`` for other modes:
 Storing lambdas
 ===============
 
-Lambdas must be **moved** with ``<-``, not copied::
+A lambda value is a fat pointer to a heap-allocated capture frame.
+``=`` copies the pointer (both bindings now alias the same capture frame),
+``<-`` moves (source becomes null)::
 
   var a <- @() { print("hello\n") }
-  var b <- a          // a is now empty
-  b()
+  var b = a           // b and a now alias the same lambda
+  var c <- a          // c takes ownership, a becomes null
+  c()
 
-Lambdas cannot be copied, but they **can** be stored in arrays using
-``emplace``, which moves the lambda into the container::
+Because copies share the capture frame, ``delete lam`` requires
+``unsafe { ... }`` — the caller asserts no other live copy exists. Under
+the default GC the capture frame is freed automatically when no copy
+remains reachable.
+
+Lambdas can be stored in arrays using ``emplace``, which moves the
+lambda into the container::
 
   var callbacks : array<lambda<():void>>
   var greet <- @() { print("hello from callback\n") }
@@ -87,6 +95,7 @@ Lambdas cannot be copied, but they **can** be stored in arrays using
   for (cb in callbacks) {
       invoke(cb)
   }
+  unsafe { delete callbacks; }   // array<lambda<...>> inherits the unsafe-delete rule
 
 Blocks **cannot** be stored in arrays or variables — they live on the
 stack and are only valid as function arguments.
@@ -165,7 +174,7 @@ Lambda vs block vs function pointer
      - By reference
    * - Storable
      - Yes
-     - Yes (move only)
+     - Yes (copy aliases capture)
      - No
    * - Returnable
      - Yes

--- a/doc/source/reference/tutorials/20_lifetime.rst
+++ b/doc/source/reference/tutorials/20_lifetime.rst
@@ -97,14 +97,27 @@ finalizes its own scoped variables before the next one begins::
       // delete f runs here, at the end of each iteration
   }
 
-Heap pointers
-=============
+Heap pointers and lambdas
+==========================
 
 For class instances created with ``new``, ``delete`` requires ``unsafe``::
 
   var p = new MyClass()
   // ... use p ...
-  unsafe { delete p }
+  unsafe { delete p; }
+
+Lambdas follow the same rule: a lambda value is a fat pointer to a
+heap-allocated capture frame, and ``=`` copies it (creating an alias).
+``delete lam`` therefore requires ``unsafe`` — the caller asserts no
+other live copy exists::
+
+  var fn <- @(x : int) : int { return x * 2 }
+  // ... use fn ...
+  unsafe { delete fn; }
+
+This rule cascades: ``array<lambda<...>>``, structures with a lambda
+field, and any composite containing a lambda all inherit the
+unsafe-delete requirement.
 
 Or use ``var inscope`` for automatic cleanup::
 
@@ -133,8 +146,9 @@ When to use what
 
 .. note::
 
-   For heap pointers (from ``new``), ``delete`` requires ``unsafe``.
-   For local variables, ``delete`` is safe.
+   For heap pointers (from ``new``) and lambdas, ``delete`` requires
+   ``unsafe``. For local container variables (``array``, ``table``,
+   ``string``) without lambda fields, ``delete`` is safe.
 
 .. seealso::
 

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -1153,7 +1153,7 @@ namespace das
         } else if (baseType == Type::tPointer) {
             return !smartPtr;
         } else if ( baseType == Type::tLambda ) {
-            return false;
+            return true;
         } else if ( baseType == Type::tString ) {
             return tempMatters ? false : true;
         } else {
@@ -1519,6 +1519,8 @@ namespace das
             }
             return true;
         } else if ( baseType==Type::tBlock ) {
+            return false;
+        } else if ( baseType==Type::tLambda ) {
             return false;
         } else if ( baseType==Type::tTable ) {
             if ( secondType && !secondType->isSafeToDelete(dep) ) return false;

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -33,6 +33,11 @@ FILE(GLOB AOT_DASLIB_MODULE_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPEN
 #                                that subclasses `vector<MakeFieldDeclPtr>` in C++) which
 #                                has no `das_iterator<MakeStruct>` AOT specialization
 list(FILTER AOT_DASLIB_MODULE_FILES EXCLUDE REGEX "daslib/(aot_macro|debugger|profiler|profiler_boost|ast_debug|decs_state|aot_cpp|aot_standalone|network|style_lint)\\.das$")
+# just_in_time bootstraps the LLVM-backed JIT module via [extern](library=LLVM.dll).
+# Without DAS_LLVM_DISABLED=OFF, the [extern] macro fails at compile time.
+IF(DAS_LLVM_DISABLED)
+    list(FILTER AOT_DASLIB_MODULE_FILES EXCLUDE REGEX "daslib/just_in_time\\.das$")
+ENDIF()
 
 add_custom_target(test_aot_daslib_modules)
 SET(DASLIB_MODULES_AOT_GENERATED_SRC)
@@ -99,17 +104,22 @@ SET(AOT_DECS_MODULE_FILES
     tests/decs/test_stages_extra.das
 )
 
-# AOT for live_host test files
-FILE(GLOB AOT_LIVE_HOST_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/live_host/*.das")
+# AOT for live_host test files — dasLiveHost transitively requires dashv,
+# so AOT them only when HV is enabled.
+SET(AOT_LIVE_HOST_FILES)
+SET(AOT_LIVE_HOST_MODULE_FILES)
+IF(NOT DAS_HV_DISABLED)
+    FILE(GLOB AOT_LIVE_HOST_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/live_host/*.das")
 
-# Live host module files (libraries required by live_host tests)
-SET(AOT_LIVE_HOST_MODULE_FILES
-    modules/dasLiveHost/live/live_commands.das
-    modules/dasLiveHost/live/live_vars.das
-    modules/dasLiveHost/live/live_api.das
-    modules/dasLiveHost/live/live_api_builtins.das
-    modules/dasLiveHost/live/live_api_stdio.das
-)
+    # Live host module files (libraries required by live_host tests)
+    SET(AOT_LIVE_HOST_MODULE_FILES
+        modules/dasLiveHost/live/live_commands.das
+        modules/dasLiveHost/live/live_vars.das
+        modules/dasLiveHost/live/live_api.das
+        modules/dasLiveHost/live/live_api_builtins.das
+        modules/dasLiveHost/live/live_api_stdio.das
+    )
+ENDIF()
 
 # AOT for dasSQLITE module library files (required by dasSQLITE tests)
 SET(AOT_DASSQLITE_MODULE_FILES)
@@ -449,11 +459,15 @@ DAS_AOT_LIB("${AOT_DECS_MODULE_FILES}" DECS_MODULES_AOT_GENERATED_SRC test_aot_d
 
 add_custom_target(test_aot_live_host)
 SET(LIVE_HOST_AOT_GENERATED_SRC)
-DAS_AOT("${AOT_LIVE_HOST_FILES}" LIVE_HOST_AOT_GENERATED_SRC test_aot_live_host daslang)
+IF(NOT DAS_HV_DISABLED)
+    DAS_AOT("${AOT_LIVE_HOST_FILES}" LIVE_HOST_AOT_GENERATED_SRC test_aot_live_host daslang)
+ENDIF()
 
 add_custom_target(test_aot_live_host_modules)
 SET(LIVE_HOST_MODULES_AOT_GENERATED_SRC)
-DAS_AOT_LIB("${AOT_LIVE_HOST_MODULE_FILES}" LIVE_HOST_MODULES_AOT_GENERATED_SRC test_aot_live_host_modules daslang)
+IF(NOT DAS_HV_DISABLED)
+    DAS_AOT_LIB("${AOT_LIVE_HOST_MODULE_FILES}" LIVE_HOST_MODULES_AOT_GENERATED_SRC test_aot_live_host_modules daslang)
+ENDIF()
 
 add_custom_target(test_aot_strudel_modules)
 SET(STRUDEL_MODULES_AOT_GENERATED_SRC)

--- a/tests/aot/test_lambda_copy.das
+++ b/tests/aot/test_lambda_copy.das
@@ -1,0 +1,79 @@
+options gen2
+require dastest/testing_boost public
+
+// AOT mirror of tests/language/lambda_copy.das.
+// Exercises the same lambda copy + unsafe-delete coverage through the AOT codegen path.
+
+typedef Counter = lambda<() : int>
+
+def invoke_twice(g : Counter) : int {
+    return invoke(g) + invoke(g)
+}
+
+[test]
+def test_aot_lambda_copy_aliases_capture(t : T?) {
+    t |> run("aot copy assignment shares capture frame") @(t : T?) {
+        var counter = 0 // nolint:LINT003 -- captured by lambda, mutated inside body
+        var inc <- @() : int {
+            counter += 1
+            return counter
+        }
+        let inc2 = inc
+        t |> equal(invoke(inc), 1)
+        t |> equal(invoke(inc2), 2)
+        t |> equal(invoke(inc), 3)
+        unsafe { delete inc; }
+    }
+}
+
+[test]
+def test_aot_lambda_pass_by_value(t : T?) {
+    t |> run("aot lambda passes by value (one capture frame, two refs)") @(t : T?) {
+        var lam <- @() : int {
+            var x = 0
+            x += 1
+            return x
+        }
+        let sum = invoke_twice(lam)
+        t |> equal(sum, 2)
+        unsafe { delete lam; }
+    }
+}
+
+struct Holder {
+    action : Counter
+}
+
+[test]
+def test_aot_lambda_struct_field_copy(t : T?) {
+    t |> run("aot struct copy aliases lambda field") @(t : T?) {
+        var s1 = Holder(action <- @() : int {
+            var n = 0
+            n += 1
+            return n
+        })
+        let s2 = s1
+        t |> equal(invoke(s1.action), 1)
+        t |> equal(invoke(s2.action), 1)
+        unsafe { delete s1.action; }
+    }
+}
+
+[test]
+def test_aot_lambda_implicit_capture(t : T?) {
+    t |> run("aot inner lambda captured implicitly inside another lambda") @(t : T?) {
+        var inner <- @() : int {
+            var n = 0
+            n += 1
+            return n
+        }
+        var outer <- @() : int {
+            return invoke(inner) + invoke(inner)
+        }
+        t |> equal(invoke(outer), 2)
+        unsafe {
+            delete inner
+            delete outer
+        }
+    }
+}

--- a/tests/aot/test_lambdas.das
+++ b/tests/aot/test_lambdas.das
@@ -9,7 +9,7 @@ def test_basic_lambda(t : T?) {
         }
         t |> equal(invoke(lam, 5), 10)
         t |> equal(invoke(lam, -3), -6)
-        delete lam
+        unsafe { delete lam; }
     }
 }
 
@@ -21,12 +21,13 @@ def test_lambda_capture(t : T?) {
             return x * factor
         }
         t |> equal(invoke(lam, 5), 15)
-        delete lam
+        unsafe { delete lam; }
     }
 }
 
 def apply_transform(values : array<int>; transform : function<(x : int) : int>) : array<int> {
     var result : array<int>
+    result |> reserve(length(values))
     for (v in values) {
         result |> push(invoke(transform, v))
     }
@@ -40,8 +41,8 @@ def fn_double(x : int) : int {
 [test]
 def test_higher_order(t : T?) {
     t |> run("apply function pointer to array") @(t : T?) {
-        var arr <- [1, 2, 3, 4, 5]
-        var result <- apply_transform(arr, @@fn_double)
+        let arr <- [1, 2, 3, 4, 5]
+        let result <- apply_transform(arr, @@fn_double)
         t |> equal(length(result), 5)
         t |> equal(result[0], 2)
         t |> equal(result[1], 4)

--- a/tests/jit_tests/invoke.das
+++ b/tests/jit_tests/invoke.das
@@ -35,7 +35,7 @@ def test_invoke_lambda(lmb : lambda<(a : int; b : float) : int>) {
 
 def test_invoke_and_delete_lambda(var lmb : lambda<(a : int; b : float) : int>) {
     let res = invoke(lmb, 1, 2.0)
-    delete lmb
+    unsafe { delete lmb; }
     return res
 }
 

--- a/tests/language/lambda_capture.das
+++ b/tests/language/lambda_capture.das
@@ -16,7 +16,7 @@ def test_lambda_capture_const(var t : T?) {
         t |> equal(lenF, 0)
     }
     invoke(l)
-    delete l
+    unsafe { delete l; }
 }
 
 

--- a/tests/language/lambda_capture_modes.das
+++ b/tests/language/lambda_capture_modes.das
@@ -19,7 +19,7 @@ def test_lambda_capture_modes(t : T?) {
         var a2 <- array<int>(1, 2)
         var a3 <- array<int>(1, 2)
         unsafe {
-            var lam <- @ capture(& a1, <- a2, := a3) {
+            let lam <- @ capture(& a1, <- a2, := a3) {
                 push(a1, 1)
                 push(a2, 1)
                 push(a3, 1)
@@ -34,7 +34,7 @@ def test_lambda_capture_modes(t : T?) {
         g_lcm_counter = 0
         var pA = new LcmFoo
         var pB = new LcmFoo
-        var C = LcmFoo()
+        var C = LcmFoo() // nolint:LINT003 -- captured by clone; const-let changes capture semantics
         var lam <- @ capture(<- pB, := pC) {
             assert(pA.dummy == 0)
             assert(pB.dummy == 0)
@@ -42,7 +42,7 @@ def test_lambda_capture_modes(t : T?) {
         }
         t |> equal(pB == null, true)
         invoke(lam)
-        delete lam
+        unsafe { delete lam; }
         t |> equal(g_lcm_counter, 1)
     }
 }

--- a/tests/language/lambda_copy.das
+++ b/tests/language/lambda_copy.das
@@ -1,0 +1,85 @@
+options gen2
+require dastest/testing_boost public
+
+// Coverage for lambda being a copyable, pointer-shaped value.
+// canCopy(lambda) is now true: '=' aliases the capture frame.
+// isSafeToDelete(lambda) is now false: 'delete lam' requires unsafe.
+
+typedef Counter = lambda<() : int>
+
+def invoke_twice(g : Counter) : int {
+    return invoke(g) + invoke(g)
+}
+
+[test]
+def test_lambda_copy_aliases_capture(t : T?) {
+    t |> run("copy assignment shares capture frame") @(t : T?) {
+        var counter = 0 // nolint:LINT003 -- captured by lambda, mutated inside body
+        var inc <- @() : int {
+            counter += 1   // mutates the lambda's own captured counter
+            return counter
+        }
+        let inc2 = inc     // copy — aliases the same capture frame
+        t |> equal(invoke(inc), 1)
+        t |> equal(invoke(inc2), 2)    // sees inc's mutation through the alias
+        t |> equal(invoke(inc), 3)     // and vice versa
+        unsafe { delete inc; }
+    }
+}
+
+[test]
+def test_lambda_pass_by_value(t : T?) {
+    t |> run("lambda passes by value (one capture frame, two refs)") @(t : T?) {
+        var lam <- @() : int {
+            var x = 0
+            x += 1
+            return x
+        }
+        // pass-by-value: the parameter is a separate variable holding the same pointer
+        let sum = invoke_twice(lam)
+        t |> equal(sum, 2)             // each invoke returns 1 (independent x), sum = 2
+        unsafe { delete lam; }
+    }
+}
+
+struct Holder {
+    action : Counter
+}
+
+[test]
+def test_lambda_struct_field_copy(t : T?) {
+    t |> run("struct copy aliases lambda field") @(t : T?) {
+        var s1 = Holder(action <- @() : int {
+            var n = 0
+            n += 1
+            return n
+        })
+        let s2 = s1                    // copies the struct; lambda field is aliased
+        t |> equal(invoke(s1.action), 1)
+        t |> equal(invoke(s2.action), 1)   // independent n per invoke
+        unsafe { delete s1.action; }
+    }
+}
+
+[test]
+def test_lambda_implicit_capture(t : T?) {
+    t |> run("inner lambda captured implicitly inside another lambda") @(t : T?) {
+        // Pre-flip this required an explicit `@capture(<- inner)` annotation
+        // (lambda was canCopy=false, so default `capture_any` forced move and
+        // implicit move-capture is an `unsafe` operation). Post-flip the
+        // lambda value is a pointer-alias, copy-capture is fine implicitly.
+        var inner <- @() : int {
+            var n = 0
+            n += 1
+            return n
+        }
+        var outer <- @() : int {
+            return invoke(inner) + invoke(inner)
+        }
+        t |> equal(invoke(outer), 2)
+        unsafe {
+            delete inner
+            delete outer
+        }
+    }
+}

--- a/tutorials/language/14_lambdas.das
+++ b/tutorials/language/14_lambdas.das
@@ -46,9 +46,13 @@ def main {
     print("invoke:      {invoke(doubler, 3)}\n")
 
     // === Storing lambdas ===
-    // Lambdas MUST be moved with <- (they cannot be copied).
-    // var copy = doubler      // ERROR: lambdas can't be copied
-    // var moved <- doubler    // OK but doubler becomes null
+    // A lambda value is a fat pointer to a capture frame.
+    // '=' copies the pointer (both bindings now alias the same capture),
+    // '<-' moves (source becomes null), '@ ...' creates a fresh capture.
+    // var alias = doubler     // OK — alias shares doubler's capture frame
+    // var moved <- doubler    // OK and doubler becomes null
+    // 'delete' on a lambda requires 'unsafe' since copies may alias it:
+    //     unsafe { delete doubler; }
 
     // === Storing lambdas in arrays ===
     // Lambdas can be stored in arrays using emplace (which moves them in).
@@ -66,7 +70,9 @@ def main {
         invoke(cb)
     }
     print("stored {length(callbacks)} lambdas in array\n")
-    delete callbacks
+    // 'array<lambda<...>>' inherits the lambda's unsafe-delete rule, since
+    // finalizing the array would delete every element lambda.
+    unsafe { delete callbacks; }
 
     // === Passing lambdas to functions ===
     // Functions that take lambda<> accept only @ lambdas (not @@ functions).


### PR DESCRIPTION
## Summary

Flip two predicates on `tLambda` in `TypeDecl`:

- **`canCopy()` `false` → `true`** — a lambda is a fat pointer (single `char *capture` to a heap capture frame), so `=` aliases cheaply; pass-by-value is free.
- **`isSafeToDelete()` `true` → `false`** — aliases mean `delete lam` must be gated by `unsafe`, matching raw-pointer and class `delete`.

This cascades through composites: `array<lambda<...>>`, structs with a lambda field, tuples/variants containing a lambda — all inherit the unsafe-delete rule. `Structure::isSafeToDelete` walks fields, and the existing `tArray`/`tTable` branches recurse into element types.

### UX side-effect (intended)

Capturing a lambda from inside another lambda no longer needs an explicit `@capture(<- inner)` annotation — default `capture_any` now picks copy (pointer alias) instead of forced move. Existing `@capture(<- ...)` / `@capture(& ...)` annotations remain valid.

### Sites that newly require unsafe-delete

- **`daslib/archive.das`** — 4 generic `serialize` overloads (struct / tuple / variant / table)
- **`daslib/decs.das`** — `restart`, `after_gc`, `commit`
- **`daslib/heartbeat.das`** — `set_heartbeat`
- **Tests** — `tests/aot/test_lambdas.das`, `tests/language/lambda_capture.das`, `tests/language/lambda_capture_modes.das`, `tests/jit_tests/invoke.das`

### New positive coverage

`tests/language/lambda_copy.das` + `tests/aot/test_lambda_copy.das` cover:
- `=` aliases the capture frame (alternating-invocation proof)
- pass-by-value (independent local vars across invocations)
- struct copy aliases lambda field
- implicit capture-of-lambda inside another lambda (the pre-flip "requires unsafe" path is now compile-clean)

### Docs

- `doc/source/reference/language/lambdas.rst` — full copy/alias rewrite + unsafe-delete note
- `doc/source/reference/language/move_copy_clone.rst` — type-compatibility table row
- `doc/source/reference/tutorials/14_lambdas.rst` — copy/storage section + lifecycle
- `doc/source/reference/tutorials/20_lifetime.rst` — heap pointers + lambdas section
- `tutorials/language/14_lambdas.das` — drop "lambdas can't be copied" comment, add alias note
- `CLAUDE.md` — bullet in Pass-by-value section

### Build infra (bundled — pre-existing limitations that surfaced)

- **`CMakeLists.txt`** `DAS_AOT_EXT`: chunk AOT inputs in batches of 60 to stay under Windows' 32K command-line limit when worktree/CI paths are deep. Absolute paths blow it; chunked `add_custom_command` runs `COMMAND`-per-batch sequentially.
- **`tests/aot/CMakeLists.txt`**: gate `test_aot_live_host*` AOT under `IF(NOT DAS_HV_DISABLED)`; skip `daslib/just_in_time.das` from the daslib AOT batch when `DAS_LLVM_DISABLED=ON`. Both AOT-compile by requiring external modules (`dashv`, `LLVM.dll`) and fail unconditionally without them.

## Test plan

- [x] `ctest -C Release -j 16`: 35/35 PASS
- [x] Interpreter (`bin/Release/daslang.exe dastest/dastest.das -- --test tests`): 7804/7810 PASS, 6 platform-skip
- [x] AOT (`bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests`): 7193/7199 PASS, 6 platform-skip
- [x] Compile-sweep tutorials/, examples/, utils/, modules/, tutorials/integration/{c,cpp}: clean
- [x] `utils/lint/main.das` on all changed `.das` files: clean
- [x] Sphinx `-W` clean build
- [x] HV enabled in local build; LLVM disabled (`jit_tests` not covered locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)