### PR TITLE
ast: add _abstract and inherited bits to FieldDeclaration

### DIFF
--- a/doc/source/stdlib/handmade/typedef-ast-FieldDeclarationFlags.rst
+++ b/doc/source/stdlib/handmade/typedef-ast-FieldDeclarationFlags.rst
@@ -9,3 +9,5 @@ This field is private.
 The field is sealed. It cannot be overridden in derived types.
 Already implemented.
 This field is a class method.
+The method is declared abstract - body must be provided by a derived class.
+This field is inherited from a parent class and is not (re)declared in this class.

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -221,6 +221,8 @@ namespace das
                     bool            sealed : 1;
                     bool            implemented : 1;
                     bool            classMethod : 1;
+                    bool            _abstract : 1;
+                    bool            inherited : 1;
                 };
                 uint32_t            flags = 0;
             };

--- a/src/builtin/module_builtin_ast_flags.cpp
+++ b/src/builtin/module_builtin_ast_flags.cpp
@@ -166,7 +166,7 @@ namespace das {
         ft->alias = "FieldDeclarationFlags";
         ft->argNames = { "moveSemantics", "parentType", "capturedConstant",
             "generated", "capturedRef", "doNotDelete", "privateField", "_sealed",
-            "implemented", "classMethod" };
+            "implemented", "classMethod", "_abstract", "inherited" };
         return ft;
     }
 

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2698,7 +2698,7 @@ namespace das {
     }
 
     uint32_t AstSerializer::getVersion () {
-        static constexpr uint32_t currentVersion = 84;
+        static constexpr uint32_t currentVersion = 85;
         return currentVersion;
     }
 

--- a/src/parser/parser_impl.cpp
+++ b/src/parser/parser_impl.cpp
@@ -325,8 +325,10 @@ namespace das {
                         virtfin->at, CompilationError::internal_function);
                 }
             }
+            const bool hasParent = (pStruct->parent != nullptr);
             for ( auto & ffd : pStruct->fields ) {
                 ffd.implemented = false;
+                ffd.inherited   = hasParent;
             }
             for ( auto pDecl : *list ) {
                 for ( const auto & name_at : *pDecl->pNameList ) {
@@ -386,6 +388,8 @@ namespace das {
                                 ffd.sealed = pDecl->sealed;
                                 ffd.implemented = true;
                                 ffd.classMethod = pDecl->isClassMethod;
+                                ffd._abstract = pDecl->isAbstract;
+                                ffd.inherited = false;
                             }
                         }
                     } else {
@@ -410,6 +414,8 @@ namespace das {
                             oldFd->sealed = pDecl->sealed;
                             oldFd->implemented = true;
                             oldFd->classMethod = pDecl->isClassMethod;
+                            oldFd->_abstract = false;
+                            oldFd->inherited = false;
                         } else {
                             das_yyerror(scanner,"structure field is already declared "+name_at.name
                                 +", use override to replace initial value instead",name_at.at,
@@ -673,6 +679,7 @@ namespace das {
                 );
                 decl->isPrivate = isPrivate;
                 decl->isClassMethod = true;
+                decl->isAbstract = true;
                 list->push_back(decl);
             }
         }

--- a/src/parser/parser_impl.h
+++ b/src/parser/parser_impl.h
@@ -62,6 +62,7 @@ namespace das {
         bool                    isStatic = false;
         bool                    isTupleExpansion = false;
         bool                    isClassMethod = false;
+        bool                    isAbstract = false;
         AnnotationArgumentList  *annotation = nullptr;
     };
 

--- a/tests/language/_field_decl_flags_helper.das
+++ b/tests/language/_field_decl_flags_helper.das
@@ -1,0 +1,42 @@
+// Helper module for tests/language/test_field_decl_flags.das.
+//
+// Declares [check_add_field_flags(abstract=..., inherited=...)] — a structure_macro
+// that walks st.fields looking for "add", and macro_errors if its _abstract /
+// inherited bits don't match the annotation arguments. The compile succeeding
+// is the test: any mismatch turns into a compile-time error.
+options gen2
+options indenting = 4
+
+module _field_decl_flags_helper public
+
+require daslib/ast public
+require daslib/ast_boost
+
+[structure_macro(name = "check_add_field_flags")]
+class private CheckAddFieldFlagsMacro : AstStructureAnnotation {
+    def override apply(var st : StructurePtr; var group : ModuleGroup;
+                       args : AnnotationArgumentList; var errors : das_string) : bool {
+        let expected_abstract = find_arg(args, "is_abstract") ?as tBool ?? false
+        let expected_inherited = find_arg(args, "is_inherited") ?as tBool ?? false
+        var found = false
+        for (fld in st.fields) {
+            if (fld.name != "add") continue
+            found = true
+            let got_abstract = fld.flags._abstract
+            let got_inherited = fld.flags.inherited
+            if (got_abstract != expected_abstract) {
+                errors := "[check_add_field_flags] {st.name}.add._abstract = {got_abstract}, expected {expected_abstract}"
+                return false
+            }
+            if (got_inherited != expected_inherited) {
+                errors := "[check_add_field_flags] {st.name}.add.inherited = {got_inherited}, expected {expected_inherited}"
+                return false
+            }
+        }
+        if (!found) {
+            errors := "[check_add_field_flags] {st.name} has no 'add' field"
+            return false
+        }
+        return true
+    }
+}

--- a/tests/language/test_field_decl_flags.das
+++ b/tests/language/test_field_decl_flags.das
@@ -1,0 +1,43 @@
+// Verifies _abstract and inherited bits on Structure::FieldDeclaration for
+// abstract class methods through clone/override.
+//
+// - Foo.add: declared `def abstract` here   -> _abstract=true,  inherited=false
+// - Bar.add: cloned from Foo, no redeclare  -> _abstract=true,  inherited=true
+// - Far.add: overridden with a body         -> _abstract=false, inherited=false
+//
+// The [check_add_field_flags] structure_macro asserts the bits at compile time.
+// A bit mismatch becomes a macro_error and fails the compile, so successful
+// compilation = passing test. The runtime [test] confirms the override chain
+// dispatches correctly.
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require _field_decl_flags_helper
+
+[check_add_field_flags(is_abstract = true, is_inherited = false)]
+class Foo {
+    def abstract add(a, b : int) : int
+}
+
+[check_add_field_flags(is_abstract = true, is_inherited = true)]
+class Bar : Foo {
+}
+
+[check_add_field_flags(is_abstract = false, is_inherited = false)]
+class Far : Bar {
+    def override add(a, b : int) : int {
+        return a + b
+    }
+}
+
+[test]
+def test_far_overrides_abstract(t : T?) {
+    var f = new Far()
+    t |> equal(f.add(2, 3), 5)
+    unsafe {
+        delete f
+    }
+}


### PR DESCRIPTION
## Summary

- Adds two new bit flags to `Structure::FieldDeclaration`:
  - **`_abstract`** (0x400) — set when a class method is declared `def abstract` (no body). Cleared when the field is overridden.
  - **`inherited`** (0x800) — set on fields cloned from a parent class that are not (re)declared in this class. Cleared on local declaration / override.
- `parentType`'s existing narrow semantic (type pending auto-resolution from parent, cleared during inference) is intentionally untouched. The new `inherited` bit is sticky and independent, giving AST macros a clear "this field came from a parent class" signal that survives the typer pass.
- Bits are exposed to daslang via the existing `FieldDeclarationFlags` bitfield binding, read as `fld.flags._abstract` / `fld.flags.inherited`. `AstSerializer::currentVersion` bumped 84 → 85.

## Where each bit is set

| Site | `_abstract` | `inherited` |
|---|---|---|
| `ast_structVarDefAbstract` → `VariableDeclaration::isAbstract` → new-field branch | `true` (from parser-temp flag) | `false` |
| Plain field/method declared in this class | `false` (parser default) | `false` |
| Field cloned from parent (`pStruct->parent != nullptr`) | unchanged (inherited via `Structure::clone`'s flag copy) | `true` |
| Override (`oldFd` branch) | `false` | `false` |

## Test plan

- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/language` — 948/948 pass
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests/language` — 948/948 pass
- [x] MCP `format_file` + `lint` clean on the two new test files
- [x] Sphinx `-W` clean build of `doc/source` (handmade RST + regenerated `generated/ast.rst` now list `_abstract (0x400)` and `inherited (0x800)`)

## Tests

New `tests/language/_field_decl_flags_helper.das` defines a `[check_add_field_flags(is_abstract=…, is_inherited=…)]` structure macro that walks `st.fields` and `macro_error`s on mismatch — compile-time assertion of the three flag combinations:

| Class | `_abstract` | `inherited` |
|---|---|---|
| `class Foo { def abstract add(...) : int }` | true | false |
| `class Bar : Foo {}` | true | true |
| `class Far : Bar { def override add(...) {...} }` | false | false |

`tests/language/test_field_decl_flags.das` declares this hierarchy and adds a runtime `[test]` confirming `Far().add(2,3)` dispatches correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)