### PR TITLE
linq: N-ary zip family extended to arities 4-8

### DIFF
--- a/benchmarks/sql/LINQ_TO_DECS.md
+++ b/benchmarks/sql/LINQ_TO_DECS.md
@@ -1,0 +1,302 @@
+# LINQ → DECS — design notes
+
+Sibling of [LINQ.md](LINQ.md). Captures the design horizon for stitching linq's
+`zip` family together with decs archetype iteration, so the upcoming
+**BufferZip** PR is shaped with the decs angle in mind even though it doesn't
+have to ship the decs bits.
+
+Status: **discussion draft** — no PR open, no plan committed. Edited in-place
+as the design firms up.
+
+## What this is
+
+Today decs has two iteration surfaces:
+
+1. **`query() $(...){body}`** — the canonical "act on each entity matching a
+   component set" form. Lowered by [`DecsQueryMacro`](../../daslib/decs_boost.das#L315)
+   to `for_each_archetype($(arch) { for (a, b, c in get_ro(arch,"a",...), ...) body })`
+   — a multi-iterator for-loop, ONE pass per archetype, zero buffering.
+2. **`from_decs($(...){})`** — pull form returning an iterator. Lowered by
+   [`FromDecsMacro`](../../daslib/decs_boost.das#L633) to
+   `invoke($() { var res : array<tuple>; query(...){res |> push(...)}; return res.to_sequence() })`.
+   **Materializes** the entire matched set into a heap array, then yields. Plays
+   nicely with linq but loses the SoA-without-buffer win.
+
+Linq has `zip(a, b)` and `zip(a, b, c)` (lockstep + result-selector forms,
+iterator + array overloads — [linq.das:3028-3157](../../daslib/linq.das#L3028)).
+Both arities cascade to tier 2 in `_fold` today — `zip` is listed in
+[`is_buffer_required_op`](../../daslib/linq_fold.das#L401) as a marker arm.
+
+The bridge insight: **`zip` over decs `get_ro(arch, "name", type<T>)` calls IS
+the SoA per-archetype prolog**. If linq_fold's zip planner emits a multi-source
+for-loop (rather than buffering a tuple stream), `from_decs_template(type<Foo>)
+|> linq_chain |> terminator` can splice straight into the
+`for_each_archetype` body — same shape `query` already builds, no intermediate
+`array<tuple>`.
+
+## North star
+
+```das
+[decs_template(prefix="particle")]
+struct Particle {
+    pos, vel : float3
+}
+
+// Authoring form (does not yet exist):
+let total = (
+    from_decs_template(type<Particle>)
+        ._where(p => length(p.vel) > 0.0f)
+        ._select(p => length(p.pos))
+        ._sum()
+)
+
+// What we want the splice to lower to (same as query() would emit):
+var total = 0.0f
+for_each_archetype(req, $(arch) {
+    for (pos in get_ro(arch, "particle_pos", type<float3>),
+         vel in get_ro(arch, "particle_vel", type<float3>)) {
+        if (length(vel) > 0.0f) {
+            total += length(pos)
+        }
+    }
+})
+```
+
+No `array<Particle>` materialization. No tuple stream. Same body shape as a
+hand-written `query` — composable via the linq operator catalogue, which the
+query macro alone doesn't give you.
+
+## Layered work plan
+
+Five separable pieces; each can ship independently. Numbered in build order, not
+priority order. **Only piece 1 is in the BufferZip PR scope** — the rest are
+later PRs.
+
+### 1. N-ary `zip` in `daslib/linq.das` (BufferZip PR)
+
+Extend the existing 2-ary / 3-ary `zip` family to 4..8 arity. Each arity gets
+four overloads (lockstep iterator, lockstep array, result-selector iterator,
+result-selector array) plus a `zip_to_array` companion — matches the established
+pattern. Naming: `zip4_impl`, `zip5_impl`, … (current convention; `zip3_impl`
+exists).
+
+Open question: 8 arity is what was suggested as "should be good." Could go
+higher if there's a decs-driven reason (component-rich templates with 10+
+fields). Easier to ship 8 and extend later than to overshoot.
+
+**Tests:** functional parity vs hand-rolled `for (a, b, ..., h in srcA, srcB, ..., srcH)`
+for each arity + iterator/array shape. AST tests not needed at this stage
+(linq, not linq_fold).
+
+**Docs:** `daslib/linq.rst` (or wherever zip is currently documented).
+
+### 2. `plan_zip` splice arm in `daslib/linq_fold.das`
+
+Recognize `zip(srcA, srcB[, srcC, ...]) [|> chain]* |> terminator` and emit:
+
+```das
+// Pseudo-skeleton (lockstep form, to_array terminator):
+var inscope buf : array<...>
+{
+    var inscope itA <- each_or_pass(srcA)
+    var inscope itB <- each_or_pass(srcB)
+    // ... per source ...
+    for (a, b, ... in itA, itB, ...) {
+        // fused downstream: where_/select*/take/etc.
+        buf |> push_clone((a, b, ...))
+    }
+}
+return <- buf
+```
+
+Multi-iterator for-loop is the natural lowering — the compiler already iterates
+the shortest source's length. **NO buffered tuple stream.** Selects and wheres
+downstream fuse the same way as the existing planners.
+
+Bail-list (cascade to tier 2):
+- Mixed array+iterator sources (uniform only — matches the design constraint)
+- Sources that aren't `each(arr)` / iterator-form / direct array (no nested
+  fold-spliceable chain inside zip arg — that's a PR-3 extension)
+- Result-selector zip (the `block<...>` arg) — defer; needs block-body splice
+- Anything that lands `zip` past a `where_`/`select` in the chain (canonical
+  order requires `zip` first, like the existing source slot)
+
+Trim `zip` from `is_buffer_required_op` after this lands.
+
+Removed marker (line 401) and corresponding cascade path.
+
+**Tests:** functional parity + AST shape (the anti-cascade gate from
+`tests/linq/test_linq_fold_ast.das` — assert no `var pass_0` tier-2 shape).
+
+**Benchmark:** refresh `benchmarks/sql/zip_dot_product.das`; add `zip3_*`
+shapes if the perf delta is interesting.
+
+### 3. `from_decs_template(type<Foo>)` macro
+
+New `[call_macro]` in `daslib/decs_boost.das`. Single argument: `type<Foo>`
+where `Foo` is annotated `[decs_template]`. Returns an `iterator<Foo>` (or a
+tuple-of-refs — open question, see "Open questions" below).
+
+**Two-stage implementation**:
+
+- **Stage A (eager bridge)** — produces the same shape as `from_decs(...)` does
+  today: materializes via `query`, returns `to_sequence()` of the buffer.
+  Composes with all existing linq ops. ~50 LOC. Lands in the same PR as
+  piece 2 or shortly after.
+- **Stage B (splice-able marker)** — emits a recognizable AST shape that
+  `linq_fold`'s planner peels and inlines into the
+  `for_each_archetype` body. The whole point of the design. Depends on
+  piece 4 below.
+
+Macro reads `type<Foo>`'s `structType.fields` (same path the
+`DecsTemplate.apply` method uses to enumerate fields — see
+[decs_boost.das:68](../../daslib/decs_boost.das#L68)). Build an `EcsRequest`
+the same way `build_req_from_args` does ([decs_boost.das:169](../../daslib/decs_boost.das#L169))
+— one `req.req |> push("{prefix}{field.name}")` per field.
+
+**Tests:** smoke parity test (Stage A) — `from_decs_template(type<Foo>) ==
+materialized-query`. Splice-shape test (Stage B) gets added when piece 4 lands.
+
+### 4. `from_decs_template` recognizer in `linq_fold` planner
+
+New `plan_from_decs_template` planner that detects the
+`from_decs_template(type<Foo>) |> chain` shape and emits the full
+`for_each_archetype($(arch) { for (a, b in get_ro(arch, "a", ...), ...) body
+})` template — body fused from the downstream linq chain.
+
+Critical reuse: the **same per-field iterator-emit logic** as the `query` macro
+uses ([decs_boost.das:239 `append_iterator`](../../daslib/decs_boost.das#L239)).
+Two options:
+
+- **Option A — extract a shared helper** in `decs_boost.das` and call it from
+  the linq_fold planner. Cleanest. Cross-module dependency: `linq_fold.das`
+  starts depending on `decs_boost.das` (one-way; decs_boost already requires
+  linq).
+- **Option B — duplicate the emit logic.** Faster to ship but creates a drift
+  hazard.
+
+Likely Option A — but worth a discussion point. The cross-module dependency is
+the only awkward bit (linq_fold becoming "aware of" decs). One way to avoid the
+direct dep: invert it — `decs_boost` exports the planner extension via a
+registration hook (`add_linq_planner`). More plumbing, but linq_fold stays
+ECS-unaware.
+
+This piece is where the **N-ary zip planner from piece 2 pays its decs dividend**.
+The per-archetype emission is a zip — and the linq chain that follows is
+exactly the same chain `plan_zip` already fuses.
+
+### 5. sqlite_linq N-ary zip recognition
+
+Currently `daslib/sqlite_linq.das` has **zero** zip references. The mapping for
+`zip` over SQL sources is not obvious:
+- N-ary lockstep over SQL tables isn't a standard relational operation.
+- Closest analogue: `INNER JOIN` on synthetic row-number columns
+  (`ROW_NUMBER() OVER ()` in SQLite).
+- Or — for the common case where one side is a `_sql` source and the other is
+  an in-memory array — generate an `IN (...)` clause from the array. But that's
+  a different operator semantically.
+
+**Likely outcome**: defer until there's a concrete authoring shape we want to
+support. Stub in `sqlite_linq` (cascade to tier 2 — call `from_sql` to
+materialize, then run the linq zip in-memory).
+
+Note: this is the **only** piece where the user mentioned "we'll need to expand
+support for that there as well" — keep on the radar but not necessarily in the
+critical path.
+
+## Decisions (locked-in design)
+
+These are settled — captured here so future-self doesn't relitigate.
+
+1. **`from_decs_template` element type = tuple** of refs to component fields.
+   `tuple<float3 const&, float3 const&>` for `[decs_template] struct Particle{
+   pos, vel : float3 }`. Zero-copy. Matches the SoA primitive already used by
+   `query`'s multi-iterator for-loop body. Composes with linq operators
+   through the existing tuple-element path.
+2. **N-ary zip ceiling = 8.** Expand if a real use case lands that needs more.
+3. **`linq_fold` does NOT require `decs_boost`.** The splice emits **names**
+   (`for_each_archetype`, `get_ro`) that resolve in the consuming scope — the
+   user's code already requires `decs_boost` if they're calling
+   `from_decs_template`. linq_fold stays ECS-unaware at the dependency level;
+   it just knows the canonical decs splice template by name. (This is the same
+   pattern already used elsewhere — e.g., the planner emits `_::unique_key`
+   and `_::less` without `require`-ing the modules that define them.)
+
+## Splice complexity — where the work actually is
+
+Per the user's framing: **per-archetype is "one set of arrays" (easy); the
+outer multi-archetype loop is the tricky part.** Both `from_decs($(args){})`
+and `from_decs_template(type<Foo>)` walk multiple archetypes via
+`for_each_archetype` — the inner body is a multi-iterator for-loop in lockstep
+over per-component arrays (= zip), but most linq operators need state hoisted
+*above* the archetype loop.
+
+Operator-by-operator hoist plan:
+
+| Operator | Hoist | Per-archetype body | Cross-archetype concern |
+|---|---|---|---|
+| `count` | `var cnt = 0` above outer | `cnt += archLen` (length shortcut) or `cnt++` per element | trivial accumulator |
+| `sum`/`min`/`max`/`average`/`long_count` | accumulator above outer (incl. avg's 2-slot) | inline reduce | trivial accumulator |
+| `to_array` | `var buf : array<T>` above outer | `buf \|> push_clone(...)` per element | trivial; reserve sum-of-archetype-sizes upfront if cheap |
+| `first` / `first_or_default(d)` | n/a — direct return | first match → `return val` | early-exit across outer loop: needs flag-or-return — `return` from outer block works because `for_each_archetype` block is callee-invoked, so a return statement inside the block exits the *block*, not the outer function. Needs either (a) wrap whole emission in `invoke($() { ... })` and use `return`, or (b) flag + `break` from `for_each_archetype` (no built-in break — would need `for_each_archetype_find`'s `bool` return shape) |
+| `any` / `contains` | n/a — direct return | matching element → `return true` | same early-exit pattern; `for_each_archetype_find` is the natural fit (returns `bool`) |
+| `all` | n/a — direct return | non-matching → `return false` | symmetric to any |
+| `take(N)` | shared counter above outer | `cnt++; break if (cnt >= N)` (inner break) + outer-loop early-exit when N reached | needs *both*: inner break to stop archetype walk, plus signal to outer loop to stop. Same `for_each_archetype_find` pattern works (return `true` when N reached) |
+| `skip(K)` | shared counter above outer | `if (remaining > 0) { remaining--; continue }` | counter survives archetype boundary; no early-exit |
+| `distinct` / `distinct_by` | `var inscope seen : table<...>` above outer | streaming dedup per element | shared dedup table — exactly the same shape as the existing `plan_distinct`, just one level deeper |
+| `group_by` | `var inscope tab : table<...>` above outer | per-element table update (the `tab?[uk] ?? dummy` pattern) | shared table — same shape as existing `plan_group_by` |
+| `reverse` | `var buf : array<T>` above outer | per-element push | `reverse_inplace(buf)` after both loops complete |
+| `order_by [+ take(N)]` | `var buf : array<T>` (or `top_n` heap) above outer | per-element push | sort / `top_n_select` after both loops |
+
+The pattern that recurs: **hoist state above `for_each_archetype`, mutate per
+element in the inner loop, finalize after both loops**. The existing planners
+(`plan_distinct`, `plan_group_by`, `plan_order_family`, `plan_reverse`) already
+have this two-level structure (init / per-element / finalize); the
+decs-splice variant just adds one more outer loop level. Bulk of the splice
+infrastructure carries over.
+
+**Early-exit terminators** (`first`/`first_or_default`/`any`/`all`/`contains`/`take(N)`)
+are the genuine new complexity. Lowering to `for_each_archetype_find` (returns
+`bool`, callee can early-exit by returning `true`) is the cleanest path — the
+non-find `for_each_archetype` doesn't have a break channel. This means the
+splice-emission has to choose between `for_each_archetype` and
+`for_each_archetype_find` based on the terminator class, mirroring the
+existing per-lane planner split.
+
+## Lingering open questions
+
+1. **sqlite_linq zip semantics** — defer until there's an authoring shape with
+   a real use case. Don't speculate now.
+2. **Result-selector zip splicing** — `zip(a, b, $(l, r) => ...)` block form.
+   Defer past piece 2; the unselectored form covers the decs case (multi-iter
+   for-loop yields the tuple directly).
+3. **`from_decs_template` + REQUIRE / REQUIRE_NOT clauses** — the existing
+   `query` macro accepts `REQUIRE(c1, c2)` and `REQUIRE_NOT(c3)` annotations.
+   `from_decs_template(type<Foo>)` derives the must-have set from `Foo`'s
+   fields, but there's no surface for the must-not-have set. Possible answer:
+   `from_decs_template(type<Foo>, REQUIRE_NOT(deleted))` as a follow-up; v1
+   ships without it.
+
+## What this doesn't change
+
+- The existing `query` / `find_query` / `from_decs` macros stay. They're the
+  canonical "act on / find / materialize" forms. `from_decs_template` is
+  additive — a fluent entry point for linq-style composition.
+- The decs storage layout (Archetype + Component) is untouched. All the work
+  is at the macro / planner layer; per-component `array<uint8>` reinterpret
+  via `get_ro` stays the SoA primitive.
+
+## Pointers to current code
+
+- Zip overloads: [daslib/linq.das:3028-3157](../../daslib/linq.das#L3028)
+- zip in linq_fold call table: [daslib/linq_fold.das:129](../../daslib/linq_fold.das#L129)
+- zip marker arm: [daslib/linq_fold.das:401](../../daslib/linq_fold.das#L401)
+- Archetype + Component storage: [daslib/decs.das:48-70](../../daslib/decs.das#L48)
+- `get_ro` / `get` SoA accessors: [daslib/decs.das:778-825](../../daslib/decs.das#L778)
+- `for_each_archetype`: [daslib/decs.das:644](../../daslib/decs.das#L644)
+- `[decs_template]` structure_macro: [daslib/decs_boost.das:50-133](../../daslib/decs_boost.das#L50)
+- `query` macro lowering: [daslib/decs_boost.das:315-516](../../daslib/decs_boost.das#L315)
+- `append_iterator` (per-field for-loop source emit): [daslib/decs_boost.das:239](../../daslib/decs_boost.das#L239)
+- `from_decs` macro (current eager form): [daslib/decs_boost.das:633-705](../../daslib/decs_boost.das#L633)
+- Existing test: [tests/linq/test_linq_from_decs.das](../../tests/linq/test_linq_from_decs.das)
+- sqlite_linq (lives in dasSQLITE module): [modules/dasSQLITE/daslib/sqlite_linq.das](../../modules/dasSQLITE/daslib/sqlite_linq.das)

--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -2964,6 +2964,11 @@ def private iter_type(src : array<auto(TT)>) : TT -const -& {
 def private select_many_impl(var src; tt : auto(TT); result_selector) : array<typedecl(result_selector(iter_type(type<TT>))) -const -&> {
     //! Projects each element of an iterator to an iterator and flattens the resulting iterators into one array
     var buffer : array<typedecl(result_selector(iter_type(type<TT>))) -const -&>
+    // Lower-bound reserve when the outer source is length-bearing — flat-map produces ≥ length(src) elements
+    // for non-degenerate inner sequences; reduces realloc count even when the actual output is larger.
+    static_if (typeinfo is_array(src) || typeinfo is_dim(src)) {
+        buffer |> reserve(length(src))
+    }
     for (it in src) {
         for (innerIt in it) {
             buffer.push_clone(result_selector(innerIt))
@@ -3157,6 +3162,356 @@ def zip(a : array<auto(TT)>; b : array<auto(UU)>; c : array<auto(WW)>; result_se
 def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>)) -const -&> {
     //! Merges three iterators into an array by applying a specified function
     return <- zip3_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, result_selector)
+}
+
+// zip with 4 sources
+
+[unused_argument(tt, uu, ww, xx)]
+def private zip4_impl(var a; tt : auto(TT); var b; uu : auto(UU); var c; ww : auto(WW); var d; xx : auto(XX)) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&>> {
+    //! Merges four iterators into an array of tuples
+    var buffer : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&>>
+    static_if ((typeinfo is_array(a) || typeinfo is_dim(a)) && (typeinfo is_array(b) || typeinfo is_dim(b)) && (typeinfo is_array(c) || typeinfo is_dim(c)) && (typeinfo is_array(d) || typeinfo is_dim(d))) {
+        buffer |> reserve(min(length(a), min(length(b), min(length(c), length(d)))))
+    }
+    for (itA, itB, itC, itD in a, b, c, d) {
+        buffer.emplace((itA, itB, itC, itD))
+    }
+    return <- buffer
+}
+
+[unused_argument(tt, uu, ww, xx)]
+def private zip4_impl_const(a : auto(ARGT); tt : auto(TT); b : auto(ARGTS); uu : auto(UU); c : auto(ARGC); ww : auto(WW); d : auto(ARGD); xx : auto(XX)) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&>> {
+    return <- zip4_impl(unsafe(reinterpret<ARGT -const>(a)), type<TT -const -&>, unsafe(reinterpret<ARGTS -const>(b)), type<UU -const -&>, unsafe(reinterpret<ARGC -const>(c)), type<WW -const -&>, unsafe(reinterpret<ARGD -const>(d)), type<XX -const -&>)
+}
+
+def zip(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>) : iterator<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&>> {
+    //! Merges four iterators into an iterator of tuples
+    return <- zip4_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>).to_sequence_move()
+}
+
+def zip(a : array<auto(TT)>; b : array<auto(UU)>; c : array<auto(WW)>; d : array<auto(XX)>) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&>> {
+    //! Merges four arrays into an array of tuples
+    return <- zip4_impl_const(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&>> {
+    //! Merges four iterators into an array of tuples
+    return <- zip4_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>)
+}
+
+// zip4 with result selector
+
+[unused_argument(tt, uu, ww, xx)]
+def private zip4_impl(var a; tt : auto(TT); var b; uu : auto(UU); var c; ww : auto(WW); var d; xx : auto(XX); result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>)) -const -&> {
+    //! Merges four iterators into an array by applying a specified function
+    var buffer : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>)) -const -&>
+    static_if ((typeinfo is_array(a) || typeinfo is_dim(a)) && (typeinfo is_array(b) || typeinfo is_dim(b)) && (typeinfo is_array(c) || typeinfo is_dim(c)) && (typeinfo is_array(d) || typeinfo is_dim(d))) {
+        buffer |> reserve(min(length(a), min(length(b), min(length(c), length(d)))))
+    }
+    for (itA, itB, itC, itD in a, b, c, d) {
+        buffer.push_clone(result_selector(itA, itB, itC, itD))
+    }
+    return <- buffer
+}
+
+[unused_argument(tt, uu, ww, xx)]
+def private zip4_impl_const(a : auto(ARGT); tt : auto(TT); b : auto(ARGTS); uu : auto(UU); c : auto(ARGC); ww : auto(WW); d : auto(ARGD); xx : auto(XX); result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>)) -const -&> {
+    return <- zip4_impl(unsafe(reinterpret<ARGT -const>(a)), type<TT -const -&>, unsafe(reinterpret<ARGTS -const>(b)), type<UU -const -&>, unsafe(reinterpret<ARGC -const>(c)), type<WW -const -&>, unsafe(reinterpret<ARGD -const>(d)), type<XX -const -&>, result_selector)
+}
+
+def zip(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&) : auto>) : iterator<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>)) -const -&> {
+    //! Merges four iterators into an iterator by applying a specified function
+    return <- zip4_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, result_selector).to_sequence_move()
+}
+
+def zip(a : array<auto(TT)>; b : array<auto(UU)>; c : array<auto(WW)>; d : array<auto(XX)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>)) -const -&> {
+    //! Merges four arrays into an array by applying a specified function
+    return <- zip4_impl_const(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, result_selector)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>)) -const -&> {
+    //! Merges four iterators into an array by applying a specified function
+    return <- zip4_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, result_selector)
+}
+
+// zip with 5 sources
+
+[unused_argument(tt, uu, ww, xx, yy)]
+def private zip5_impl(var a; tt : auto(TT); var b; uu : auto(UU); var c; ww : auto(WW); var d; xx : auto(XX); var e; yy : auto(YY)) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&>> {
+    //! Merges five iterators into an array of tuples
+    var buffer : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&>>
+    static_if ((typeinfo is_array(a) || typeinfo is_dim(a)) && (typeinfo is_array(b) || typeinfo is_dim(b)) && (typeinfo is_array(c) || typeinfo is_dim(c)) && (typeinfo is_array(d) || typeinfo is_dim(d)) && (typeinfo is_array(e) || typeinfo is_dim(e))) {
+        buffer |> reserve(min(length(a), min(length(b), min(length(c), min(length(d), length(e))))))
+    }
+    for (itA, itB, itC, itD, itE in a, b, c, d, e) {
+        buffer.emplace((itA, itB, itC, itD, itE))
+    }
+    return <- buffer
+}
+
+[unused_argument(tt, uu, ww, xx, yy)]
+def private zip5_impl_const(a : auto(ARGT); tt : auto(TT); b : auto(ARGTS); uu : auto(UU); c : auto(ARGC); ww : auto(WW); d : auto(ARGD); xx : auto(XX); e : auto(ARGE); yy : auto(YY)) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&>> {
+    return <- zip5_impl(unsafe(reinterpret<ARGT -const>(a)), type<TT -const -&>, unsafe(reinterpret<ARGTS -const>(b)), type<UU -const -&>, unsafe(reinterpret<ARGC -const>(c)), type<WW -const -&>, unsafe(reinterpret<ARGD -const>(d)), type<XX -const -&>, unsafe(reinterpret<ARGE -const>(e)), type<YY -const -&>)
+}
+
+def zip(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>) : iterator<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&>> {
+    //! Merges five iterators into an iterator of tuples
+    return <- zip5_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>).to_sequence_move()
+}
+
+def zip(a : array<auto(TT)>; b : array<auto(UU)>; c : array<auto(WW)>; d : array<auto(XX)>; e : array<auto(YY)>) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&>> {
+    //! Merges five arrays into an array of tuples
+    return <- zip5_impl_const(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&>> {
+    //! Merges five iterators into an array of tuples
+    return <- zip5_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>)
+}
+
+// zip5 with result selector
+
+[unused_argument(tt, uu, ww, xx, yy)]
+def private zip5_impl(var a; tt : auto(TT); var b; uu : auto(UU); var c; ww : auto(WW); var d; xx : auto(XX); var e; yy : auto(YY); result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>)) -const -&> {
+    //! Merges five iterators into an array by applying a specified function
+    var buffer : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>)) -const -&>
+    static_if ((typeinfo is_array(a) || typeinfo is_dim(a)) && (typeinfo is_array(b) || typeinfo is_dim(b)) && (typeinfo is_array(c) || typeinfo is_dim(c)) && (typeinfo is_array(d) || typeinfo is_dim(d)) && (typeinfo is_array(e) || typeinfo is_dim(e))) {
+        buffer |> reserve(min(length(a), min(length(b), min(length(c), min(length(d), length(e))))))
+    }
+    for (itA, itB, itC, itD, itE in a, b, c, d, e) {
+        buffer.push_clone(result_selector(itA, itB, itC, itD, itE))
+    }
+    return <- buffer
+}
+
+[unused_argument(tt, uu, ww, xx, yy)]
+def private zip5_impl_const(a : auto(ARGT); tt : auto(TT); b : auto(ARGTS); uu : auto(UU); c : auto(ARGC); ww : auto(WW); d : auto(ARGD); xx : auto(XX); e : auto(ARGE); yy : auto(YY); result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>)) -const -&> {
+    return <- zip5_impl(unsafe(reinterpret<ARGT -const>(a)), type<TT -const -&>, unsafe(reinterpret<ARGTS -const>(b)), type<UU -const -&>, unsafe(reinterpret<ARGC -const>(c)), type<WW -const -&>, unsafe(reinterpret<ARGD -const>(d)), type<XX -const -&>, unsafe(reinterpret<ARGE -const>(e)), type<YY -const -&>, result_selector)
+}
+
+def zip(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&) : auto>) : iterator<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>)) -const -&> {
+    //! Merges five iterators into an iterator by applying a specified function
+    return <- zip5_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, result_selector).to_sequence_move()
+}
+
+def zip(a : array<auto(TT)>; b : array<auto(UU)>; c : array<auto(WW)>; d : array<auto(XX)>; e : array<auto(YY)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>)) -const -&> {
+    //! Merges five arrays into an array by applying a specified function
+    return <- zip5_impl_const(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, result_selector)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>)) -const -&> {
+    //! Merges five iterators into an array by applying a specified function
+    return <- zip5_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, result_selector)
+}
+
+// zip with 6 sources
+
+[unused_argument(tt, uu, ww, xx, yy, zz)]
+def private zip6_impl(var a; tt : auto(TT); var b; uu : auto(UU); var c; ww : auto(WW); var d; xx : auto(XX); var e; yy : auto(YY); var f; zz : auto(ZZ)) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&>> {
+    //! Merges six iterators into an array of tuples
+    var buffer : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&>>
+    static_if ((typeinfo is_array(a) || typeinfo is_dim(a)) && (typeinfo is_array(b) || typeinfo is_dim(b)) && (typeinfo is_array(c) || typeinfo is_dim(c)) && (typeinfo is_array(d) || typeinfo is_dim(d)) && (typeinfo is_array(e) || typeinfo is_dim(e)) && (typeinfo is_array(f) || typeinfo is_dim(f))) {
+        buffer |> reserve(min(length(a), min(length(b), min(length(c), min(length(d), min(length(e), length(f)))))))
+    }
+    for (itA, itB, itC, itD, itE, itF in a, b, c, d, e, f) {
+        buffer.emplace((itA, itB, itC, itD, itE, itF))
+    }
+    return <- buffer
+}
+
+[unused_argument(tt, uu, ww, xx, yy, zz)]
+def private zip6_impl_const(a : auto(ARGT); tt : auto(TT); b : auto(ARGTS); uu : auto(UU); c : auto(ARGC); ww : auto(WW); d : auto(ARGD); xx : auto(XX); e : auto(ARGE); yy : auto(YY); f : auto(ARGF); zz : auto(ZZ)) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&>> {
+    return <- zip6_impl(unsafe(reinterpret<ARGT -const>(a)), type<TT -const -&>, unsafe(reinterpret<ARGTS -const>(b)), type<UU -const -&>, unsafe(reinterpret<ARGC -const>(c)), type<WW -const -&>, unsafe(reinterpret<ARGD -const>(d)), type<XX -const -&>, unsafe(reinterpret<ARGE -const>(e)), type<YY -const -&>, unsafe(reinterpret<ARGF -const>(f)), type<ZZ -const -&>)
+}
+
+def zip(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>) : iterator<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&>> {
+    //! Merges six iterators into an iterator of tuples
+    return <- zip6_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>).to_sequence_move()
+}
+
+def zip(a : array<auto(TT)>; b : array<auto(UU)>; c : array<auto(WW)>; d : array<auto(XX)>; e : array<auto(YY)>; f : array<auto(ZZ)>) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&>> {
+    //! Merges six arrays into an array of tuples
+    return <- zip6_impl_const(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&>> {
+    //! Merges six iterators into an array of tuples
+    return <- zip6_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>)
+}
+
+// zip6 with result selector
+
+[unused_argument(tt, uu, ww, xx, yy, zz)]
+def private zip6_impl(var a; tt : auto(TT); var b; uu : auto(UU); var c; ww : auto(WW); var d; xx : auto(XX); var e; yy : auto(YY); var f; zz : auto(ZZ); result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>)) -const -&> {
+    //! Merges six iterators into an array by applying a specified function
+    var buffer : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>)) -const -&>
+    static_if ((typeinfo is_array(a) || typeinfo is_dim(a)) && (typeinfo is_array(b) || typeinfo is_dim(b)) && (typeinfo is_array(c) || typeinfo is_dim(c)) && (typeinfo is_array(d) || typeinfo is_dim(d)) && (typeinfo is_array(e) || typeinfo is_dim(e)) && (typeinfo is_array(f) || typeinfo is_dim(f))) {
+        buffer |> reserve(min(length(a), min(length(b), min(length(c), min(length(d), min(length(e), length(f)))))))
+    }
+    for (itA, itB, itC, itD, itE, itF in a, b, c, d, e, f) {
+        buffer.push_clone(result_selector(itA, itB, itC, itD, itE, itF))
+    }
+    return <- buffer
+}
+
+[unused_argument(tt, uu, ww, xx, yy, zz)]
+def private zip6_impl_const(a : auto(ARGT); tt : auto(TT); b : auto(ARGTS); uu : auto(UU); c : auto(ARGC); ww : auto(WW); d : auto(ARGD); xx : auto(XX); e : auto(ARGE); yy : auto(YY); f : auto(ARGF); zz : auto(ZZ); result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>)) -const -&> {
+    return <- zip6_impl(unsafe(reinterpret<ARGT -const>(a)), type<TT -const -&>, unsafe(reinterpret<ARGTS -const>(b)), type<UU -const -&>, unsafe(reinterpret<ARGC -const>(c)), type<WW -const -&>, unsafe(reinterpret<ARGD -const>(d)), type<XX -const -&>, unsafe(reinterpret<ARGE -const>(e)), type<YY -const -&>, unsafe(reinterpret<ARGF -const>(f)), type<ZZ -const -&>, result_selector)
+}
+
+def zip(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&) : auto>) : iterator<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>)) -const -&> {
+    //! Merges six iterators into an iterator by applying a specified function
+    return <- zip6_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, result_selector).to_sequence_move()
+}
+
+def zip(a : array<auto(TT)>; b : array<auto(UU)>; c : array<auto(WW)>; d : array<auto(XX)>; e : array<auto(YY)>; f : array<auto(ZZ)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>)) -const -&> {
+    //! Merges six arrays into an array by applying a specified function
+    return <- zip6_impl_const(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, result_selector)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>)) -const -&> {
+    //! Merges six iterators into an array by applying a specified function
+    return <- zip6_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, result_selector)
+}
+
+// zip with 7 sources
+
+[unused_argument(tt, uu, ww, xx, yy, zz, rr)]
+def private zip7_impl(var a; tt : auto(TT); var b; uu : auto(UU); var c; ww : auto(WW); var d; xx : auto(XX); var e; yy : auto(YY); var f; zz : auto(ZZ); var g; rr : auto(RR)) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&>> {
+    //! Merges seven iterators into an array of tuples
+    var buffer : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&>>
+    static_if ((typeinfo is_array(a) || typeinfo is_dim(a)) && (typeinfo is_array(b) || typeinfo is_dim(b)) && (typeinfo is_array(c) || typeinfo is_dim(c)) && (typeinfo is_array(d) || typeinfo is_dim(d)) && (typeinfo is_array(e) || typeinfo is_dim(e)) && (typeinfo is_array(f) || typeinfo is_dim(f)) && (typeinfo is_array(g) || typeinfo is_dim(g))) {
+        buffer |> reserve(min(length(a), min(length(b), min(length(c), min(length(d), min(length(e), min(length(f), length(g))))))))
+    }
+    for (itA, itB, itC, itD, itE, itF, itG in a, b, c, d, e, f, g) {
+        buffer.emplace((itA, itB, itC, itD, itE, itF, itG))
+    }
+    return <- buffer
+}
+
+[unused_argument(tt, uu, ww, xx, yy, zz, rr)]
+def private zip7_impl_const(a : auto(ARGT); tt : auto(TT); b : auto(ARGTS); uu : auto(UU); c : auto(ARGC); ww : auto(WW); d : auto(ARGD); xx : auto(XX); e : auto(ARGE); yy : auto(YY); f : auto(ARGF); zz : auto(ZZ); g : auto(ARGG); rr : auto(RR)) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&>> {
+    return <- zip7_impl(unsafe(reinterpret<ARGT -const>(a)), type<TT -const -&>, unsafe(reinterpret<ARGTS -const>(b)), type<UU -const -&>, unsafe(reinterpret<ARGC -const>(c)), type<WW -const -&>, unsafe(reinterpret<ARGD -const>(d)), type<XX -const -&>, unsafe(reinterpret<ARGE -const>(e)), type<YY -const -&>, unsafe(reinterpret<ARGF -const>(f)), type<ZZ -const -&>, unsafe(reinterpret<ARGG -const>(g)), type<RR -const -&>)
+}
+
+def zip(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>; var g : iterator<auto(RR)>) : iterator<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&>> {
+    //! Merges seven iterators into an iterator of tuples
+    return <- zip7_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>).to_sequence_move()
+}
+
+def zip(a : array<auto(TT)>; b : array<auto(UU)>; c : array<auto(WW)>; d : array<auto(XX)>; e : array<auto(YY)>; f : array<auto(ZZ)>; g : array<auto(RR)>) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&>> {
+    //! Merges seven arrays into an array of tuples
+    return <- zip7_impl_const(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>; var g : iterator<auto(RR)>) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&>> {
+    //! Merges seven iterators into an array of tuples
+    return <- zip7_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>)
+}
+
+// zip7 with result selector
+
+[unused_argument(tt, uu, ww, xx, yy, zz, rr)]
+def private zip7_impl(var a; tt : auto(TT); var b; uu : auto(UU); var c; ww : auto(WW); var d; xx : auto(XX); var e; yy : auto(YY); var f; zz : auto(ZZ); var g; rr : auto(RR); result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&; m : RR -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>)) -const -&> {
+    //! Merges seven iterators into an array by applying a specified function
+    var buffer : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>)) -const -&>
+    static_if ((typeinfo is_array(a) || typeinfo is_dim(a)) && (typeinfo is_array(b) || typeinfo is_dim(b)) && (typeinfo is_array(c) || typeinfo is_dim(c)) && (typeinfo is_array(d) || typeinfo is_dim(d)) && (typeinfo is_array(e) || typeinfo is_dim(e)) && (typeinfo is_array(f) || typeinfo is_dim(f)) && (typeinfo is_array(g) || typeinfo is_dim(g))) {
+        buffer |> reserve(min(length(a), min(length(b), min(length(c), min(length(d), min(length(e), min(length(f), length(g))))))))
+    }
+    for (itA, itB, itC, itD, itE, itF, itG in a, b, c, d, e, f, g) {
+        buffer.push_clone(result_selector(itA, itB, itC, itD, itE, itF, itG))
+    }
+    return <- buffer
+}
+
+[unused_argument(tt, uu, ww, xx, yy, zz, rr)]
+def private zip7_impl_const(a : auto(ARGT); tt : auto(TT); b : auto(ARGTS); uu : auto(UU); c : auto(ARGC); ww : auto(WW); d : auto(ARGD); xx : auto(XX); e : auto(ARGE); yy : auto(YY); f : auto(ARGF); zz : auto(ZZ); g : auto(ARGG); rr : auto(RR); result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&; m : RR -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>)) -const -&> {
+    return <- zip7_impl(unsafe(reinterpret<ARGT -const>(a)), type<TT -const -&>, unsafe(reinterpret<ARGTS -const>(b)), type<UU -const -&>, unsafe(reinterpret<ARGC -const>(c)), type<WW -const -&>, unsafe(reinterpret<ARGD -const>(d)), type<XX -const -&>, unsafe(reinterpret<ARGE -const>(e)), type<YY -const -&>, unsafe(reinterpret<ARGF -const>(f)), type<ZZ -const -&>, unsafe(reinterpret<ARGG -const>(g)), type<RR -const -&>, result_selector)
+}
+
+def zip(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>; var g : iterator<auto(RR)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&; m : RR -&) : auto>) : iterator<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>)) -const -&> {
+    //! Merges seven iterators into an iterator by applying a specified function
+    return <- zip7_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>, result_selector).to_sequence_move()
+}
+
+def zip(a : array<auto(TT)>; b : array<auto(UU)>; c : array<auto(WW)>; d : array<auto(XX)>; e : array<auto(YY)>; f : array<auto(ZZ)>; g : array<auto(RR)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&; m : RR -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>)) -const -&> {
+    //! Merges seven arrays into an array by applying a specified function
+    return <- zip7_impl_const(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>, result_selector)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>; var g : iterator<auto(RR)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&; m : RR -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>)) -const -&> {
+    //! Merges seven iterators into an array by applying a specified function
+    return <- zip7_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>, result_selector)
+}
+
+// zip with 8 sources
+
+[unused_argument(tt, uu, ww, xx, yy, zz, rr, ss)]
+def private zip8_impl(var a; tt : auto(TT); var b; uu : auto(UU); var c; ww : auto(WW); var d; xx : auto(XX); var e; yy : auto(YY); var f; zz : auto(ZZ); var g; rr : auto(RR); var h; ss : auto(SS)) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&, SS -const -&>> {
+    //! Merges eight iterators into an array of tuples
+    var buffer : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&, SS -const -&>>
+    static_if ((typeinfo is_array(a) || typeinfo is_dim(a)) && (typeinfo is_array(b) || typeinfo is_dim(b)) && (typeinfo is_array(c) || typeinfo is_dim(c)) && (typeinfo is_array(d) || typeinfo is_dim(d)) && (typeinfo is_array(e) || typeinfo is_dim(e)) && (typeinfo is_array(f) || typeinfo is_dim(f)) && (typeinfo is_array(g) || typeinfo is_dim(g)) && (typeinfo is_array(h) || typeinfo is_dim(h))) {
+        buffer |> reserve(min(length(a), min(length(b), min(length(c), min(length(d), min(length(e), min(length(f), min(length(g), length(h)))))))))
+    }
+    for (itA, itB, itC, itD, itE, itF, itG, itH in a, b, c, d, e, f, g, h) {
+        buffer.emplace((itA, itB, itC, itD, itE, itF, itG, itH))
+    }
+    return <- buffer
+}
+
+[unused_argument(tt, uu, ww, xx, yy, zz, rr, ss)]
+def private zip8_impl_const(a : auto(ARGT); tt : auto(TT); b : auto(ARGTS); uu : auto(UU); c : auto(ARGC); ww : auto(WW); d : auto(ARGD); xx : auto(XX); e : auto(ARGE); yy : auto(YY); f : auto(ARGF); zz : auto(ZZ); g : auto(ARGG); rr : auto(RR); h : auto(ARGH); ss : auto(SS)) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&, SS -const -&>> {
+    return <- zip8_impl(unsafe(reinterpret<ARGT -const>(a)), type<TT -const -&>, unsafe(reinterpret<ARGTS -const>(b)), type<UU -const -&>, unsafe(reinterpret<ARGC -const>(c)), type<WW -const -&>, unsafe(reinterpret<ARGD -const>(d)), type<XX -const -&>, unsafe(reinterpret<ARGE -const>(e)), type<YY -const -&>, unsafe(reinterpret<ARGF -const>(f)), type<ZZ -const -&>, unsafe(reinterpret<ARGG -const>(g)), type<RR -const -&>, unsafe(reinterpret<ARGH -const>(h)), type<SS -const -&>)
+}
+
+def zip(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>; var g : iterator<auto(RR)>; var h : iterator<auto(SS)>) : iterator<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&, SS -const -&>> {
+    //! Merges eight iterators into an iterator of tuples
+    return <- zip8_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>, h, type<SS -const -&>).to_sequence_move()
+}
+
+def zip(a : array<auto(TT)>; b : array<auto(UU)>; c : array<auto(WW)>; d : array<auto(XX)>; e : array<auto(YY)>; f : array<auto(ZZ)>; g : array<auto(RR)>; h : array<auto(SS)>) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&, SS -const -&>> {
+    //! Merges eight arrays into an array of tuples
+    return <- zip8_impl_const(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>, h, type<SS -const -&>)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>; var g : iterator<auto(RR)>; var h : iterator<auto(SS)>) : array<tuple<TT -const -&, UU -const -&, WW -const -&, XX -const -&, YY -const -&, ZZ -const -&, RR -const -&, SS -const -&>> {
+    //! Merges eight iterators into an array of tuples
+    return <- zip8_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>, h, type<SS -const -&>)
+}
+
+// zip8 with result selector
+
+[unused_argument(tt, uu, ww, xx, yy, zz, rr, ss)]
+def private zip8_impl(var a; tt : auto(TT); var b; uu : auto(UU); var c; ww : auto(WW); var d; xx : auto(XX); var e; yy : auto(YY); var f; zz : auto(ZZ); var g; rr : auto(RR); var h; ss : auto(SS); result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&; m : RR -&; n : SS -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>, type<SS>)) -const -&> {
+    //! Merges eight iterators into an array by applying a specified function
+    var buffer : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>, type<SS>)) -const -&>
+    static_if ((typeinfo is_array(a) || typeinfo is_dim(a)) && (typeinfo is_array(b) || typeinfo is_dim(b)) && (typeinfo is_array(c) || typeinfo is_dim(c)) && (typeinfo is_array(d) || typeinfo is_dim(d)) && (typeinfo is_array(e) || typeinfo is_dim(e)) && (typeinfo is_array(f) || typeinfo is_dim(f)) && (typeinfo is_array(g) || typeinfo is_dim(g)) && (typeinfo is_array(h) || typeinfo is_dim(h))) {
+        buffer |> reserve(min(length(a), min(length(b), min(length(c), min(length(d), min(length(e), min(length(f), min(length(g), length(h)))))))))
+    }
+    for (itA, itB, itC, itD, itE, itF, itG, itH in a, b, c, d, e, f, g, h) {
+        buffer.push_clone(result_selector(itA, itB, itC, itD, itE, itF, itG, itH))
+    }
+    return <- buffer
+}
+
+[unused_argument(tt, uu, ww, xx, yy, zz, rr, ss)]
+def private zip8_impl_const(a : auto(ARGT); tt : auto(TT); b : auto(ARGTS); uu : auto(UU); c : auto(ARGC); ww : auto(WW); d : auto(ARGD); xx : auto(XX); e : auto(ARGE); yy : auto(YY); f : auto(ARGF); zz : auto(ZZ); g : auto(ARGG); rr : auto(RR); h : auto(ARGH); ss : auto(SS); result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&; m : RR -&; n : SS -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>, type<SS>)) -const -&> {
+    return <- zip8_impl(unsafe(reinterpret<ARGT -const>(a)), type<TT -const -&>, unsafe(reinterpret<ARGTS -const>(b)), type<UU -const -&>, unsafe(reinterpret<ARGC -const>(c)), type<WW -const -&>, unsafe(reinterpret<ARGD -const>(d)), type<XX -const -&>, unsafe(reinterpret<ARGE -const>(e)), type<YY -const -&>, unsafe(reinterpret<ARGF -const>(f)), type<ZZ -const -&>, unsafe(reinterpret<ARGG -const>(g)), type<RR -const -&>, unsafe(reinterpret<ARGH -const>(h)), type<SS -const -&>, result_selector)
+}
+
+def zip(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>; var g : iterator<auto(RR)>; var h : iterator<auto(SS)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&; m : RR -&; n : SS -&) : auto>) : iterator<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>, type<SS>)) -const -&> {
+    //! Merges eight iterators into an iterator by applying a specified function
+    return <- zip8_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>, h, type<SS -const -&>, result_selector).to_sequence_move()
+}
+
+def zip(a : array<auto(TT)>; b : array<auto(UU)>; c : array<auto(WW)>; d : array<auto(XX)>; e : array<auto(YY)>; f : array<auto(ZZ)>; g : array<auto(RR)>; h : array<auto(SS)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&; m : RR -&; n : SS -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>, type<SS>)) -const -&> {
+    //! Merges eight arrays into an array by applying a specified function
+    return <- zip8_impl_const(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>, h, type<SS -const -&>, result_selector)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; var c : iterator<auto(WW)>; var d : iterator<auto(XX)>; var e : iterator<auto(YY)>; var f : iterator<auto(ZZ)>; var g : iterator<auto(RR)>; var h : iterator<auto(SS)>; result_selector : block<(l : TT -&; r : UU -&; w : WW -&; x : XX -&; y : YY -&; z : ZZ -&; m : RR -&; n : SS -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>, type<WW>, type<XX>, type<YY>, type<ZZ>, type<RR>, type<SS>)) -const -&> {
+    //! Merges eight iterators into an array by applying a specified function
+    return <- zip8_impl(a, type<TT -const -&>, b, type<UU -const -&>, c, type<WW -const -&>, d, type<XX -const -&>, e, type<YY -const -&>, f, type<ZZ -const -&>, g, type<RR -const -&>, h, type<SS -const -&>, result_selector)
 }
 
 def public order_unique_folded(var a : array<auto(TT)>) : array<TT -const -&> {

--- a/doc/source/reference/tutorials/28_linq.rst
+++ b/doc/source/reference/tutorials/28_linq.rst
@@ -159,7 +159,8 @@ Set operations
 Zip
 ===
 
-``zip`` merges two or three sequences into tuples::
+``zip`` merges 2 to 8 sequences into tuples; iteration stops at the shortest
+source::
 
   var names = ["Alice", "Bob", "Charlie"]
   var ages  = [25, 35, 30]
@@ -169,6 +170,18 @@ Zip
   var scores = [95, 87, 91]
   var zipped3 = zip(names, ages, scores)
   // zipped3: [(Alice,25,95), (Bob,35,87), (Charlie,30,91)]
+
+Each arity (2..8) has four overloads: lockstep and result-selector forms, each
+on iterator and array sources. A result-selector block runs per element and
+returns a custom projection (the tuple is replaced by whatever the block
+returns)::
+
+  var sums = zip(a, b, c, d, $(p, q, r, s : int) => p + q + r + s)
+
+Add ``_to_array`` to force materialization of an iterator-source zip into an
+``array``::
+
+  var arr = zip_to_array(seqA, seqB, seqC)
 
 Joining
 =======

--- a/mouse-data/docs/why-does-my-4-ary-block-call-return-stale-first-param-values-when-the-lambda-uses-param-names-p-q-r-s.md
+++ b/mouse-data/docs/why-does-my-4-ary-block-call-return-stale-first-param-values-when-the-lambda-uses-param-names-p-q-r-s.md
@@ -1,0 +1,31 @@
+---
+slug: why-does-my-4-ary-block-call-return-stale-first-param-values-when-the-lambda-uses-param-names-p-q-r-s
+title: Why does my 4-ary block call return stale first-param values when the lambda uses param names `p, q, r, s`?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+**Status:** INTERMITTENT — observed 3x consistently during initial PR-1 work, but became non-reproducible after unrelated intermediate edits (notably adding a `static_if` reserve in `select_many_impl`). Standalone reproductions outside the test file with various complexity (multi-iter for + lambda directly, public-wrapper shape, nested in test-framework lambda) all returned correct values. Likely a daslang generic-instantiation order / codegen issue with preconditions that can't be pinned down from outside the failing context.
+
+**Symptom (when triggered):** Calling a `block<(l: TT-&; r: UU-&; w: WW-&; x: XX-&)>` with a lambda `$(p: int; q: int; r: int; s: int) => p + q + r + s` returns wrong sums — the first lambda param `p` evaluates to its initial value (0) on EVERY iteration even though the block call site passes it correctly each time. Probes of `=> p` alone return the correct sequence `[0, 1, 2]`; only the multi-param expression `p + q + r + s` exhibited the bug.
+
+**Repro:** Surfaced in `daslib/linq.das` 4-ary `zip` impl during PR-1 of the linq zip extension. Calling the result-selector form with `$(p: int; q: int; r: int; s: int) => p + q + r + s` over four iterators yielding `[0,1,2]`, `[10,11,12]`, `[100,101,102]`, `[1000,1001,1002]` returns `[1110, 1113, 1116]` instead of `[1110, 1114, 1118]`. Delta-per-row is 3 instead of 4 — consistent with first source stuck at 0.
+
+**Workaround:** Rename the lambda params away from `p, q, r, s`. Both `(l: int; r: int; w: int; x: int)` (identical-to-block-sig names) AND `(aa: int; bb: int; cc: int; dd: int)` (totally distinct names) work fine. The bug is SPECIFIC to the name set `p, q, r, s` — not a generic shadowing issue.
+
+**Root cause:** UNKNOWN. Confirmed it is NOT:
+- Lambda multi-param shared-type `(p, q, r, s : int)` (explicit per-param annotations fail identically)
+- Block-vs-lambda param name shadowing (3-ary with identical names works fine; 4-ary with identical-to-block names ALSO works fine)
+- Block param name `x` colliding with `xx` witness or `[iterator for (x in ...)]` comprehension var (rename `x → m` doesn't fix it)
+- Arity (3-ary works with any names; 4-ary breaks with `p,q,r,s` only)
+- Source iterator type (probes via `=> p` etc. return correct sequences per source)
+
+Likely some interaction between daslang's lambda body evaluation order, ref binding to block ref-params, and the specific identifier set `p/q/r/s`. Possibly related to closures, register allocation, or symbol lookup in the lambda body. Needs a minimal repro outside the linq layer + a daslang issue.
+
+**Test discipline:** Avoid `p, q, r, s` as lambda param names in tests for zip-family functions of arity ≥ 4 until the daslang bug is identified and fixed. Use `aa, bb, cc, dd` or descriptive names. Same caution likely applies to higher arities until investigated.
+
+**Discovered:** 2026-05-19, PR-1 of linq zip extension (branch `bbatkin/linq-zip-n-ary`).
+
+## Questions
+- Why does my 4-ary block call return stale first-param values when the lambda uses param names `p, q, r, s`?

--- a/tests/linq/test_linq_transform.das
+++ b/tests/linq/test_linq_transform.das
@@ -12,12 +12,12 @@ require _common
 [test]
 def test_select_transform(t : T?) {
     t |> run("basic select_transform") @(t : T?) {
-        var chars = ["a", "b", "c", "d", "e"]
+        let chars = ["a", "b", "c", "d", "e"]
         var query = _select(
             chars.to_sequence(),
             (_, _ + _)
         )
-        for (i, ch, q in 0..5, chars, query) {
+        for (ch, q in chars, query) {
             t |> equal(ch, q._0)
             t |> equal(ch + ch, q._1)
         }
@@ -33,12 +33,12 @@ def test_select_transform(t : T?) {
         }
     }
     t |> run("select_transform to array") @(t : T?) {
-        var chars = ["a", "b", "c", "d", "e"]
+        let chars = ["a", "b", "c", "d", "e"]
         var query = _select_to_array(
             chars.to_sequence(),
             (_, _ + _)
         )
-        for (i, ch, q in 0..5, chars, query) {
+        for (ch, q in chars, query) {
             t |> equal(ch, q._0)
             t |> equal(ch + ch, q._1)
         }
@@ -84,7 +84,7 @@ def test_select(t : T?) {
         }
     }
     t |> run("select from array") @(t : T?) {
-        var nums = [10, 20, 30, 40, 50]
+        let nums = [10, 20, 30, 40, 50]
         var query = select(nums)
         for (i, q in 0..5, query) {
             t |> equal(q._0, i)
@@ -92,7 +92,7 @@ def test_select(t : T?) {
         }
     }
     t |> run("select from array with result selector") @(t : T?) {
-        var nums = [10, 20, 30]
+        let nums = [10, 20, 30]
         var query = _select(
             nums,
             (_, _ * 2)
@@ -184,7 +184,7 @@ def test_selectmany(t : T?) {
         }
     }
     t |> run("selectmany from array") @(t : T?) {
-        var seq_seq = [
+        let seq_seq = [
             ["a", "b", "c"],
             ["d", "e", "f"],
             ["g", "h", "i"]
@@ -368,9 +368,9 @@ def test_zip3(t : T?) {
         t |> equal(idx, 3)
     }
     t |> run("zip 3 arrays") @(t : T?) {
-        var a = [0, 1, 2]
-        var b = [10, 11, 12]
-        var c = [100, 101, 102]
+        let a = [0, 1, 2]
+        let b = [10, 11, 12]
+        let c = [100, 101, 102]
         var result = zip(a, b, c)
         t |> equal(3, length(result))
         for (r, i in result, 0..3) {
@@ -394,11 +394,571 @@ def test_zip3(t : T?) {
         }
     }
     t |> run("zip 3 with unequal lengths") @(t : T?) {
-        var result = zip_to_array(
+        let result = zip_to_array(
             [iterator for(x in 0..5); x],
             [iterator for(x in 10..13); x],
             [iterator for(x in 100..104); x]
         )
         t |> equal(3, length(result))  // stops at shortest
+    }
+}
+
+[test]
+def test_zip4(t : T?) {
+    t |> run("basic zip 4 iterators") @(t : T?) {
+        var query = zip(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x]
+        )
+        var idx = 0
+        for (c in query) {
+            t |> equal(c._0, idx)
+            t |> equal(c._1, idx + 10)
+            t |> equal(c._2, idx + 100)
+            t |> equal(c._3, idx + 1000)
+            idx ++
+        }
+        t |> equal(idx, 3)
+    }
+    t |> run("zip 4 arrays") @(t : T?) {
+        let a = [0, 1, 2]
+        let b = [10, 11, 12]
+        let c = [100, 101, 102]
+        let d = [1000, 1001, 1002]
+        var result = zip(a, b, c, d)
+        t |> equal(3, length(result))
+        for (r, i in result, 0..3) {
+            t |> equal(r._0, i)
+            t |> equal(r._1, i + 10)
+            t |> equal(r._2, i + 100)
+            t |> equal(r._3, i + 1000)
+        }
+    }
+    t |> run("zip 4 to array") @(t : T?) {
+        var result = zip_to_array(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x]
+        )
+        static_assert(typeinfo is_array(result))
+        t |> equal(3, length(result))
+        for (r, i in result, 0..3) {
+            t |> equal(r._0, i)
+            t |> equal(r._1, i + 10)
+            t |> equal(r._2, i + 100)
+            t |> equal(r._3, i + 1000)
+        }
+    }
+    t |> run("zip 4 with unequal lengths") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..5); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..104); x],
+            [iterator for(x in 1000..1006); x]
+        )
+        t |> equal(3, length(result))  // stops at shortest
+    }
+    t |> run("zip 4 with result selector") @(t : T?) {
+        var qcomplex = zip(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            $(p : int; q : int; r : int; s : int) => p + q + r + s
+        )
+        let expected = [1110, 1114, 1118]
+        var idx = 0
+        for (sum in qcomplex) {
+            t |> equal(sum, expected[idx])
+            idx ++
+        }
+        t |> equal(idx, 3)
+    }
+    t |> run("zip 4 arrays with result selector") @(t : T?) {
+        let a = [0, 1, 2]
+        let b = [10, 11, 12]
+        let c = [100, 101, 102]
+        let d = [1000, 1001, 1002]
+        let result = zip(a, b, c, d, $(aa : int; bb : int; cc : int; dd : int) => aa + bb + cc + dd)
+        t |> equal(3, length(result))
+        t |> equal(result[0], 1110)
+        t |> equal(result[1], 1114)
+        t |> equal(result[2], 1118)
+    }
+    t |> run("zip 4 to array with result selector") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            $(aa : int; bb : int; cc : int; dd : int) => aa + bb + cc + dd
+        )
+        static_assert(typeinfo is_array(result))
+        t |> equal(3, length(result))
+        t |> equal(result[0], 1110)
+        t |> equal(result[1], 1114)
+        t |> equal(result[2], 1118)
+    }
+}
+
+[test]
+def test_zip5(t : T?) {
+    t |> run("basic zip 5 iterators") @(t : T?) {
+        var query = zip(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x]
+        )
+        var idx = 0
+        for (c in query) {
+            t |> equal(c._0, idx)
+            t |> equal(c._1, idx + 10)
+            t |> equal(c._2, idx + 100)
+            t |> equal(c._3, idx + 1000)
+            t |> equal(c._4, idx + 10000)
+            idx ++
+        }
+        t |> equal(idx, 3)
+    }
+    t |> run("zip 5 arrays") @(t : T?) {
+        let a = [0, 1, 2]
+        let b = [10, 11, 12]
+        let c = [100, 101, 102]
+        let d = [1000, 1001, 1002]
+        let e = [10000, 10001, 10002]
+        let result = zip(a, b, c, d, e)
+        t |> equal(3, length(result))
+        for (r, i in result, 0..3) {
+            t |> equal(r._0, i)
+            t |> equal(r._1, i + 10)
+            t |> equal(r._2, i + 100)
+            t |> equal(r._3, i + 1000)
+            t |> equal(r._4, i + 10000)
+        }
+    }
+    t |> run("zip 5 to array") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x]
+        )
+        static_assert(typeinfo is_array(result))
+        t |> equal(3, length(result))
+    }
+    t |> run("zip 5 with unequal lengths") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..5); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..104); x],
+            [iterator for(x in 1000..1006); x],
+            [iterator for(x in 10000..10003); x]
+        )
+        t |> equal(3, length(result))  // stops at shortest
+    }
+    t |> run("zip 5 with result selector") @(t : T?) {
+        var qcomplex = zip(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            $(aa : int; bb : int; cc : int; dd : int; ee : int) => aa + bb + cc + dd + ee
+        )
+        let expected = [11110, 11115, 11120]
+        var idx = 0
+        for (sum in qcomplex) {
+            t |> equal(sum, expected[idx])
+            idx ++
+        }
+        t |> equal(idx, 3)
+    }
+    t |> run("zip 5 arrays with result selector") @(t : T?) {
+        let a = [0, 1, 2]
+        let b = [10, 11, 12]
+        let c = [100, 101, 102]
+        let d = [1000, 1001, 1002]
+        let e = [10000, 10001, 10002]
+        let result = zip(a, b, c, d, e, $(aa : int; bb : int; cc : int; dd : int; ee : int) => aa + bb + cc + dd + ee)
+        t |> equal(3, length(result))
+        t |> equal(result[0], 11110)
+        t |> equal(result[1], 11115)
+        t |> equal(result[2], 11120)
+    }
+    t |> run("zip 5 to array with result selector") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            $(aa : int; bb : int; cc : int; dd : int; ee : int) => aa + bb + cc + dd + ee
+        )
+        static_assert(typeinfo is_array(result))
+        t |> equal(3, length(result))
+        t |> equal(result[0], 11110)
+        t |> equal(result[1], 11115)
+        t |> equal(result[2], 11120)
+    }
+}
+
+[test]
+def test_zip6(t : T?) {
+    t |> run("basic zip 6 iterators") @(t : T?) {
+        var query = zip(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x]
+        )
+        var idx = 0
+        for (c in query) {
+            t |> equal(c._0, idx)
+            t |> equal(c._1, idx + 10)
+            t |> equal(c._2, idx + 100)
+            t |> equal(c._3, idx + 1000)
+            t |> equal(c._4, idx + 10000)
+            t |> equal(c._5, idx + 100000)
+            idx ++
+        }
+        t |> equal(idx, 3)
+    }
+    t |> run("zip 6 arrays") @(t : T?) {
+        let a = [0, 1, 2]
+        let b = [10, 11, 12]
+        let c = [100, 101, 102]
+        let d = [1000, 1001, 1002]
+        let e = [10000, 10001, 10002]
+        let f = [100000, 100001, 100002]
+        let result = zip(a, b, c, d, e, f)
+        t |> equal(3, length(result))
+        for (r, i in result, 0..3) {
+            t |> equal(r._0, i)
+            t |> equal(r._1, i + 10)
+            t |> equal(r._2, i + 100)
+            t |> equal(r._3, i + 1000)
+            t |> equal(r._4, i + 10000)
+            t |> equal(r._5, i + 100000)
+        }
+    }
+    t |> run("zip 6 to array") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x]
+        )
+        static_assert(typeinfo is_array(result))
+        t |> equal(3, length(result))
+    }
+    t |> run("zip 6 with unequal lengths") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..5); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..104); x],
+            [iterator for(x in 1000..1006); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100007); x]
+        )
+        t |> equal(3, length(result))  // stops at shortest
+    }
+    t |> run("zip 6 with result selector") @(t : T?) {
+        var qcomplex = zip(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x],
+            $(aa : int; bb : int; cc : int; dd : int; ee : int; ff : int) => aa + bb + cc + dd + ee + ff
+        )
+        let expected = [111110, 111116, 111122]
+        var idx = 0
+        for (sum in qcomplex) {
+            t |> equal(sum, expected[idx])
+            idx ++
+        }
+        t |> equal(idx, 3)
+    }
+    t |> run("zip 6 arrays with result selector") @(t : T?) {
+        let a = [0, 1, 2]
+        let b = [10, 11, 12]
+        let c = [100, 101, 102]
+        let d = [1000, 1001, 1002]
+        let e = [10000, 10001, 10002]
+        let f = [100000, 100001, 100002]
+        let result = zip(a, b, c, d, e, f, $(aa : int; bb : int; cc : int; dd : int; ee : int; ff : int) => aa + bb + cc + dd + ee + ff)
+        t |> equal(3, length(result))
+        t |> equal(result[0], 111110)
+        t |> equal(result[1], 111116)
+        t |> equal(result[2], 111122)
+    }
+    t |> run("zip 6 to array with result selector") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x],
+            $(aa : int; bb : int; cc : int; dd : int; ee : int; ff : int) => aa + bb + cc + dd + ee + ff
+        )
+        static_assert(typeinfo is_array(result))
+        t |> equal(3, length(result))
+        t |> equal(result[0], 111110)
+        t |> equal(result[1], 111116)
+        t |> equal(result[2], 111122)
+    }
+}
+
+[test]
+def test_zip7(t : T?) {
+    t |> run("basic zip 7 iterators") @(t : T?) {
+        var query = zip(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x],
+            [iterator for(x in 1000000..1000003); x]
+        )
+        var idx = 0
+        for (c in query) {
+            t |> equal(c._0, idx)
+            t |> equal(c._1, idx + 10)
+            t |> equal(c._2, idx + 100)
+            t |> equal(c._3, idx + 1000)
+            t |> equal(c._4, idx + 10000)
+            t |> equal(c._5, idx + 100000)
+            t |> equal(c._6, idx + 1000000)
+            idx ++
+        }
+        t |> equal(idx, 3)
+    }
+    t |> run("zip 7 arrays") @(t : T?) {
+        let a = [0, 1, 2]
+        let b = [10, 11, 12]
+        let c = [100, 101, 102]
+        let d = [1000, 1001, 1002]
+        let e = [10000, 10001, 10002]
+        let f = [100000, 100001, 100002]
+        let g = [1000000, 1000001, 1000002]
+        let result = zip(a, b, c, d, e, f, g)
+        t |> equal(3, length(result))
+        for (r, i in result, 0..3) {
+            t |> equal(r._0, i)
+            t |> equal(r._6, i + 1000000)
+        }
+    }
+    t |> run("zip 7 to array") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x],
+            [iterator for(x in 1000000..1000003); x]
+        )
+        static_assert(typeinfo is_array(result))
+        t |> equal(3, length(result))
+    }
+    t |> run("zip 7 with unequal lengths") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..5); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..104); x],
+            [iterator for(x in 1000..1006); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100007); x],
+            [iterator for(x in 1000000..1000004); x]
+        )
+        t |> equal(3, length(result))  // stops at shortest
+    }
+    t |> run("zip 7 with result selector") @(t : T?) {
+        var qcomplex = zip(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x],
+            [iterator for(x in 1000000..1000003); x],
+            $(aa : int; bb : int; cc : int; dd : int; ee : int; ff : int; gg : int) => aa + bb + cc + dd + ee + ff + gg
+        )
+        let expected = [1111110, 1111117, 1111124]
+        var idx = 0
+        for (sum in qcomplex) {
+            t |> equal(sum, expected[idx])
+            idx ++
+        }
+        t |> equal(idx, 3)
+    }
+    t |> run("zip 7 arrays with result selector") @(t : T?) {
+        let a = [0, 1, 2]
+        let b = [10, 11, 12]
+        let c = [100, 101, 102]
+        let d = [1000, 1001, 1002]
+        let e = [10000, 10001, 10002]
+        let f = [100000, 100001, 100002]
+        let g = [1000000, 1000001, 1000002]
+        let result = zip(a, b, c, d, e, f, g, $(aa : int; bb : int; cc : int; dd : int; ee : int; ff : int; gg : int) => aa + bb + cc + dd + ee + ff + gg)
+        t |> equal(3, length(result))
+        t |> equal(result[0], 1111110)
+        t |> equal(result[1], 1111117)
+        t |> equal(result[2], 1111124)
+    }
+    t |> run("zip 7 to array with result selector") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x],
+            [iterator for(x in 1000000..1000003); x],
+            $(aa : int; bb : int; cc : int; dd : int; ee : int; ff : int; gg : int) => aa + bb + cc + dd + ee + ff + gg
+        )
+        static_assert(typeinfo is_array(result))
+        t |> equal(3, length(result))
+        t |> equal(result[0], 1111110)
+        t |> equal(result[1], 1111117)
+        t |> equal(result[2], 1111124)
+    }
+}
+
+[test]
+def test_zip8(t : T?) {
+    t |> run("basic zip 8 iterators") @(t : T?) {
+        var query = zip(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x],
+            [iterator for(x in 1000000..1000003); x],
+            [iterator for(x in 10000000..10000003); x]
+        )
+        var idx = 0
+        for (c in query) {
+            t |> equal(c._0, idx)
+            t |> equal(c._1, idx + 10)
+            t |> equal(c._2, idx + 100)
+            t |> equal(c._3, idx + 1000)
+            t |> equal(c._4, idx + 10000)
+            t |> equal(c._5, idx + 100000)
+            t |> equal(c._6, idx + 1000000)
+            t |> equal(c._7, idx + 10000000)
+            idx ++
+        }
+        t |> equal(idx, 3)
+    }
+    t |> run("zip 8 arrays") @(t : T?) {
+        let a = [0, 1, 2]
+        let b = [10, 11, 12]
+        let c = [100, 101, 102]
+        let d = [1000, 1001, 1002]
+        let e = [10000, 10001, 10002]
+        let f = [100000, 100001, 100002]
+        let g = [1000000, 1000001, 1000002]
+        let h = [10000000, 10000001, 10000002]
+        let result = zip(a, b, c, d, e, f, g, h)
+        t |> equal(3, length(result))
+        for (r, i in result, 0..3) {
+            t |> equal(r._0, i)
+            t |> equal(r._7, i + 10000000)
+        }
+    }
+    t |> run("zip 8 to array") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x],
+            [iterator for(x in 1000000..1000003); x],
+            [iterator for(x in 10000000..10000003); x]
+        )
+        static_assert(typeinfo is_array(result))
+        t |> equal(3, length(result))
+    }
+    t |> run("zip 8 with unequal lengths") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..5); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..104); x],
+            [iterator for(x in 1000..1006); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100007); x],
+            [iterator for(x in 1000000..1000004); x],
+            [iterator for(x in 10000000..10000005); x]
+        )
+        t |> equal(3, length(result))  // stops at shortest
+    }
+    t |> run("zip 8 with result selector") @(t : T?) {
+        var qcomplex = zip(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x],
+            [iterator for(x in 1000000..1000003); x],
+            [iterator for(x in 10000000..10000003); x],
+            $(aa : int; bb : int; cc : int; dd : int; ee : int; ff : int; gg : int; hh : int) => aa + bb + cc + dd + ee + ff + gg + hh
+        )
+        let expected = [11111110, 11111118, 11111126]
+        var idx = 0
+        for (sum in qcomplex) {
+            t |> equal(sum, expected[idx])
+            idx ++
+        }
+        t |> equal(idx, 3)
+    }
+    t |> run("zip 8 arrays with result selector") @(t : T?) {
+        let a = [0, 1, 2]
+        let b = [10, 11, 12]
+        let c = [100, 101, 102]
+        let d = [1000, 1001, 1002]
+        let e = [10000, 10001, 10002]
+        let f = [100000, 100001, 100002]
+        let g = [1000000, 1000001, 1000002]
+        let h = [10000000, 10000001, 10000002]
+        let result = zip(a, b, c, d, e, f, g, h, $(aa : int; bb : int; cc : int; dd : int; ee : int; ff : int; gg : int; hh : int) => aa + bb + cc + dd + ee + ff + gg + hh)
+        t |> equal(3, length(result))
+        t |> equal(result[0], 11111110)
+        t |> equal(result[1], 11111118)
+        t |> equal(result[2], 11111126)
+    }
+    t |> run("zip 8 to array with result selector") @(t : T?) {
+        let result = zip_to_array(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 10..13); x],
+            [iterator for(x in 100..103); x],
+            [iterator for(x in 1000..1003); x],
+            [iterator for(x in 10000..10003); x],
+            [iterator for(x in 100000..100003); x],
+            [iterator for(x in 1000000..1000003); x],
+            [iterator for(x in 10000000..10000003); x],
+            $(aa : int; bb : int; cc : int; dd : int; ee : int; ff : int; gg : int; hh : int) => aa + bb + cc + dd + ee + ff + gg + hh
+        )
+        static_assert(typeinfo is_array(result))
+        t |> equal(3, length(result))
+        t |> equal(result[0], 11111110)
+        t |> equal(result[1], 11111118)
+        t |> equal(result[2], 11111126)
     }
 }


### PR DESCRIPTION
## Summary

- Extends `zip` from the existing 2-ary + 3-ary surface to arities 4..8 in `daslib/linq.das`. Per new arity: 6 public overloads (lockstep iter / lockstep array / `zip_to_array` iter, plus result-selector variants of all three) + 2 private impls (`zipN_impl`, `zipN_impl_const`). 30 new public functions, 10 new private helpers.
- Closes a pre-existing PERF006 hint in `select_many_impl` with the same `static_if` reserve pattern `zip_impl` already uses.
- New benchmarks/sql/LINQ_TO_DECS.md design notes captures the multi-phase roadmap motivating this work: zip extension (Phase 1, this PR) → `plan_zip` splice arm in `linq_fold` (Phase 2) → `from_decs_template(type&lt;Foo&gt;)` macro (Phase 3) → `plan_from_decs_template` splice for SoA-without-buffer decs archetype iteration (Phase 4). Future phases are NOT in scope here.

## Background

`zip` is in `is_buffer_required_op` in `linq_fold.das` today (cascades to tier 2). Phase 2 will splice it into a multi-iterator for-loop. The decs `query` macro already lowers to exactly that shape over per-component arrays — so an N-ary `zip` planner doubles as the SoA primitive for the decs-bridge work in later phases. 8-ary ceiling chosen for `[decs_template]`-shaped component sets; extendable later if needed.

## Notable

- 28_linq tutorial updated to document arities 2..8 and the result-selector form.
- Mouse card filed for an intermittent daslang correctness bug observed during this work: a 4-ary block call with lambda params named exactly `p, q, r, s` returned stale first-param values. Initially reproduced 3x in `tests/linq/test_linq_transform.das`, but became non-reproducible after intermediate edits and across multiple standalone repros. Documented as `status: INTERMITTENT` in the mouse card; no reliable repro to file a daslang issue with. Workaround (use distinct lambda param names) is in tests.
- 14 pre-existing LINT002/003 in `test_linq_transform.das` fixed per the "fix all lint, even pre-existing" rule.

## Test plan

- [x] `mcp__daslang__lint daslib/linq.das tests/linq/test_linq_transform.das` clean
- [x] `mcp__daslang__run_test tests/linq/test_linq_transform.das` — 72 tests pass (interpret + AOT after rebuild)
- [x] Regression sweep across all `tests/linq/*.das` — 1047 tests pass under `-use-aot`
- [x] Tutorial 28_linq doc updated to reflect arities 2..8
- [ ] CI green across full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)