### PR TITLE
fix: uint8/uint16 enum casts zero-extend (don't sign-extend)

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -837,7 +837,12 @@ class public AotDebugInfoHelper {
     def describeCppEnumInfoValues(var writer : StringBuilderWriter?; einfo : EnumInfo?) {
         for (v in range(einfo.count)) {
             let val = unsafe(einfo.fields[v]);
-            write(*writer, "EnumValueInfo {enumInfoName(einfo)}_value_{v} = \{ \"{val.name}\", {val.value} \};\n")
+            // Emit the int64 value as a bit pattern through uint64 — decimal `-9223372036854775808`
+            // (INT64_MIN, e.g. for `enum X : uint64 { HIGH_BIT = 0x8000000000000000ul }`) overflows
+            // the C++ int64 literal parser and trips clang's -Wc++11-narrowing under MSVC even though
+            // MSVC accepts it. The `int64_t(uint64_t(0x...ull))` round-trip is well-defined modulo 2^64.
+            let bits = uint64(val.value)
+            write(*writer, "EnumValueInfo {enumInfoName(einfo)}_value_{v} = \{ \"{val.name}\", int64_t(UINT64_C(0x{bits:x})) \};\n")
         }
         let enum_vals = (each(range(einfo.count))
             ._select("&{enumInfoName(einfo)}_value_{_}")

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -846,7 +846,7 @@ class public AotDebugInfoHelper {
         write(*writer, "EnumValueInfo * {enumInfoName(einfo)}_values [] = \{ {enum_vals} \};\n");
     }
     def describeCppEnumInfo(info : EnumInfo?) {
-        return "\"{info.name}\", \"{info.module_name}\", {enumInfoName(info)}_values, {info.count:d}, UINT64_C(0x{info.hash:x})";
+        return "\"{info.name}\", \"{info.module_name}\", {enumInfoName(info)}_values, {info.count:d}, UINT64_C(0x{info.hash:x}), {info.flags:d}";
     }
     def describeCppTypeInfo(info : TypeInfo?; suffix : string = "") {
         return build_string() $(writer) {

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -837,12 +837,22 @@ class public AotDebugInfoHelper {
     def describeCppEnumInfoValues(var writer : StringBuilderWriter?; einfo : EnumInfo?) {
         for (v in range(einfo.count)) {
             let val = unsafe(einfo.fields[v]);
-            // Emit the int64 value as a bit pattern through uint64 — decimal `-9223372036854775808`
-            // (INT64_MIN, e.g. for `enum X : uint64 { HIGH_BIT = 0x8000000000000000ul }`) overflows
-            // the C++ int64 literal parser and trips clang's -Wc++11-narrowing under MSVC even though
-            // MSVC accepts it. The `int64_t(uint64_t(0x...ull))` round-trip is well-defined modulo 2^64.
+            // Portable C++ int64 literal: the previous `int64_t(UINT64_C(0x...))` form relied on
+            // the uint64→int64 narrowing being well-defined, which is only true post-C++20.
+            // Negative values are emitted via unary minus on a positive INT64_C literal;
+            // INT64_MIN is special-cased because |INT64_MIN| overflows int64 before the
+            // unary minus binds, so we construct it from valid signed parts instead.
             let bits = uint64(val.value)
-            write(*writer, "EnumValueInfo {enumInfoName(einfo)}_value_{v} = \{ \"{val.name}\", int64_t(UINT64_C(0x{bits:x})) \};\n")
+            var cppLit : string
+            if (bits == 0x8000000000000000ul) {
+                cppLit := "(-INT64_C(0x7fffffffffffffff) - INT64_C(1))"
+            } elif (val.value < 0l) {
+                let absBits = uint64(-val.value)
+                cppLit := "-INT64_C(0x{absBits:x})"
+            } else {
+                cppLit := "INT64_C(0x{bits:x})"
+            }
+            write(*writer, "EnumValueInfo {enumInfoName(einfo)}_value_{v} = \{ \"{val.name}\", {cppLit} \};\n")
         }
         let enum_vals = (each(range(einfo.count))
             ._select("&{enumInfoName(einfo)}_value_{_}")

--- a/doc/source/stdlib/handmade/typedef-ast-TypeDeclFlags.rst
+++ b/doc/source/stdlib/handmade/typedef-ast-TypeDeclFlags.rst
@@ -17,5 +17,6 @@ The type is a reification tag.
 The type is an explicit reference.
 The type is a private alias.
 The type is an auto-to-alias.
+Exempt this type from the "uninitialized variable/field is unsafe" check — analog of struct-level safe_when_uninitialized for tuples / variants / aliases.
 The TypeDecl came from a C++ EnumStub*/EnumStub*u binding parameter; used to dispatch enum casts by underlying signedness.
 The EnumStub binding expects an unsigned-underlying enum (uint8/uint16/uint64), letting overload resolution pick the zero-extending cast helper.

--- a/doc/source/stdlib/handmade/typedef-ast-TypeDeclFlags.rst
+++ b/doc/source/stdlib/handmade/typedef-ast-TypeDeclFlags.rst
@@ -17,3 +17,5 @@ The type is a reification tag.
 The type is an explicit reference.
 The type is a private alias.
 The type is an auto-to-alias.
+The TypeDecl came from a C++ EnumStub*/EnumStub*u binding parameter; used to dispatch enum casts by underlying signedness.
+The EnumStub binding expects an unsigned-underlying enum (uint8/uint16/uint64), letting overload resolution pick the zero-extending cast helper.

--- a/include/daScript/ast/ast_typedecl.h
+++ b/include/daScript/ast/ast_typedecl.h
@@ -277,6 +277,13 @@ namespace das {
                 bool    isPrivateAlias : 1;    // this is a private alias. only matters in the context of module aliasTypes (for now)
                 bool    autoToAlias : 1;       // this allows conversion of auto to alias
                 bool    safeWhenUninitialized : 1; // exempt this type from "Uninitialized variable/field is unsafe" — analog of struct-level safe_when_uninitialized for tuples / variants / aliases
+                bool    enumStubBinding : 1;    // marks a parameter TypeDecl produced from a C++ EnumStub*/EnumStub*u
+                                                //  binding (set by typeFactory<EnumStub*[u]>). Used together with
+                                                //  enumStubIsUnsigned to dispatch enum→int casts by underlying signedness.
+                bool    enumStubIsUnsigned : 1; // when enumStubBinding is set: true if the binding expects an
+                                                //  unsigned-underlying enum (uint8/uint16/uint64). Lets `int(uint8Enum)`
+                                                //  resolve to enum8u_to_int instead of enum8_to_int so the byte
+                                                //  zero-extends instead of sign-extending.
             };
             uint32_t flags = 0;
         };
@@ -307,6 +314,9 @@ namespace das {
     template<> struct ToBasicType<EnumStub8>    { enum { type = Type::tEnumeration8 }; };
     template<> struct ToBasicType<EnumStub16>   { enum { type = Type::tEnumeration16 }; };
     template<> struct ToBasicType<EnumStub64>   { enum { type = Type::tEnumeration64 }; };
+    template<> struct ToBasicType<EnumStub8u>   { enum { type = Type::tEnumeration8 }; };
+    template<> struct ToBasicType<EnumStub16u>  { enum { type = Type::tEnumeration16 }; };
+    template<> struct ToBasicType<EnumStub64u>  { enum { type = Type::tEnumeration64 }; };
     template<> struct ToBasicType<Sequence>     { enum { type = Type::tIterator }; };
     template<> struct ToBasicType<Sequence *>   { enum { type = Type::tIterator }; };
     template<> struct ToBasicType<void *>       { enum { type = Type::tPointer }; };
@@ -376,6 +386,66 @@ namespace das {
             auto t = new TypeDecl();
             t->baseType = Type( ToBasicType<TT>::type );
             t->constant = is_const<TT>::value;
+            return t;
+        }
+    };
+
+    // EnumStub*/EnumStub*u — bindings carry the enumStubBinding marker so overload
+    // resolution can dispatch enum→int casts by underlying signedness. The 32-bit
+    // tEnumeration variant is unaffected by sign-extension and stays generic.
+    template <>
+    struct typeFactory<EnumStub8> {
+        static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
+            auto t = new TypeDecl(Type::tEnumeration8);
+            t->enumStubBinding = true;
+            return t;
+        }
+    };
+
+    template <>
+    struct typeFactory<EnumStub16> {
+        static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
+            auto t = new TypeDecl(Type::tEnumeration16);
+            t->enumStubBinding = true;
+            return t;
+        }
+    };
+
+    template <>
+    struct typeFactory<EnumStub64> {
+        static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
+            auto t = new TypeDecl(Type::tEnumeration64);
+            t->enumStubBinding = true;
+            return t;
+        }
+    };
+
+    template <>
+    struct typeFactory<EnumStub8u> {
+        static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
+            auto t = new TypeDecl(Type::tEnumeration8);
+            t->enumStubBinding = true;
+            t->enumStubIsUnsigned = true;
+            return t;
+        }
+    };
+
+    template <>
+    struct typeFactory<EnumStub16u> {
+        static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
+            auto t = new TypeDecl(Type::tEnumeration16);
+            t->enumStubBinding = true;
+            t->enumStubIsUnsigned = true;
+            return t;
+        }
+    };
+
+    template <>
+    struct typeFactory<EnumStub64u> {
+        static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
+            auto t = new TypeDecl(Type::tEnumeration64);
+            t->enumStubBinding = true;
+            t->enumStubIsUnsigned = true;
             return t;
         }
     };

--- a/include/daScript/ast/ast_typedecl.h
+++ b/include/daScript/ast/ast_typedecl.h
@@ -393,23 +393,11 @@ namespace das {
     // EnumStub*/EnumStub*u — bindings carry the enumStubBinding marker so overload
     // resolution can dispatch enum→int casts by underlying signedness. The 32-bit
     // tEnumeration variant is unaffected by sign-extension and stays generic.
-    //
-    // We write the two markers via both the bitfield members AND the `flags` mask.
-    // The bitfield members keep RTTI / macro access (makeTypeDeclFlags exposes them
-    // by name) working; the explicit mask writes make the bits durable across
-    // platforms in case `bool : 1` bitfield-vs-uint32 union aliasing is fragile
-    // under a given ABI (Darwin clang ARM64 dispatch failures point at exactly
-    // this kind of aliasing mismatch). isSameType / mangling read via the same
-    // mask constants so they never depend on the bitfield alias.
-    static constexpr uint32_t TDF_enumStubBinding    = (1u << 19);
-    static constexpr uint32_t TDF_enumStubIsUnsigned = (1u << 20);
-
     template <>
     struct typeFactory<EnumStub8> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
             auto t = new TypeDecl(Type::tEnumeration8);
             t->enumStubBinding = true;
-            t->flags |= TDF_enumStubBinding;
             return t;
         }
     };
@@ -419,7 +407,6 @@ namespace das {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
             auto t = new TypeDecl(Type::tEnumeration16);
             t->enumStubBinding = true;
-            t->flags |= TDF_enumStubBinding;
             return t;
         }
     };
@@ -429,7 +416,6 @@ namespace das {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
             auto t = new TypeDecl(Type::tEnumeration64);
             t->enumStubBinding = true;
-            t->flags |= TDF_enumStubBinding;
             return t;
         }
     };
@@ -440,7 +426,6 @@ namespace das {
             auto t = new TypeDecl(Type::tEnumeration8);
             t->enumStubBinding = true;
             t->enumStubIsUnsigned = true;
-            t->flags |= (TDF_enumStubBinding | TDF_enumStubIsUnsigned);
             return t;
         }
     };
@@ -451,7 +436,6 @@ namespace das {
             auto t = new TypeDecl(Type::tEnumeration16);
             t->enumStubBinding = true;
             t->enumStubIsUnsigned = true;
-            t->flags |= (TDF_enumStubBinding | TDF_enumStubIsUnsigned);
             return t;
         }
     };
@@ -462,7 +446,6 @@ namespace das {
             auto t = new TypeDecl(Type::tEnumeration64);
             t->enumStubBinding = true;
             t->enumStubIsUnsigned = true;
-            t->flags |= (TDF_enumStubBinding | TDF_enumStubIsUnsigned);
             return t;
         }
     };

--- a/include/daScript/ast/ast_typedecl.h
+++ b/include/daScript/ast/ast_typedecl.h
@@ -393,11 +393,23 @@ namespace das {
     // EnumStub*/EnumStub*u — bindings carry the enumStubBinding marker so overload
     // resolution can dispatch enum→int casts by underlying signedness. The 32-bit
     // tEnumeration variant is unaffected by sign-extension and stays generic.
+    //
+    // We write the two markers via both the bitfield members AND the `flags` mask.
+    // The bitfield members keep RTTI / macro access (makeTypeDeclFlags exposes them
+    // by name) working; the explicit mask writes make the bits durable across
+    // platforms in case `bool : 1` bitfield-vs-uint32 union aliasing is fragile
+    // under a given ABI (Darwin clang ARM64 dispatch failures point at exactly
+    // this kind of aliasing mismatch). isSameType / mangling read via the same
+    // mask constants so they never depend on the bitfield alias.
+    static constexpr uint32_t TDF_enumStubBinding    = (1u << 19);
+    static constexpr uint32_t TDF_enumStubIsUnsigned = (1u << 20);
+
     template <>
     struct typeFactory<EnumStub8> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
             auto t = new TypeDecl(Type::tEnumeration8);
             t->enumStubBinding = true;
+            t->flags |= TDF_enumStubBinding;
             return t;
         }
     };
@@ -407,6 +419,7 @@ namespace das {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
             auto t = new TypeDecl(Type::tEnumeration16);
             t->enumStubBinding = true;
+            t->flags |= TDF_enumStubBinding;
             return t;
         }
     };
@@ -416,6 +429,7 @@ namespace das {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
             auto t = new TypeDecl(Type::tEnumeration64);
             t->enumStubBinding = true;
+            t->flags |= TDF_enumStubBinding;
             return t;
         }
     };
@@ -426,6 +440,7 @@ namespace das {
             auto t = new TypeDecl(Type::tEnumeration8);
             t->enumStubBinding = true;
             t->enumStubIsUnsigned = true;
+            t->flags |= (TDF_enumStubBinding | TDF_enumStubIsUnsigned);
             return t;
         }
     };
@@ -436,6 +451,7 @@ namespace das {
             auto t = new TypeDecl(Type::tEnumeration16);
             t->enumStubBinding = true;
             t->enumStubIsUnsigned = true;
+            t->flags |= (TDF_enumStubBinding | TDF_enumStubIsUnsigned);
             return t;
         }
     };
@@ -446,6 +462,7 @@ namespace das {
             auto t = new TypeDecl(Type::tEnumeration64);
             t->enumStubBinding = true;
             t->enumStubIsUnsigned = true;
+            t->flags |= (TDF_enumStubBinding | TDF_enumStubIsUnsigned);
             return t;
         }
     };

--- a/include/daScript/misc/arraytype.h
+++ b/include/daScript/misc/arraytype.h
@@ -219,9 +219,14 @@ namespace das {
     };
 
     typedef EnumStubAny<int32_t> EnumStub;
-    typedef EnumStubAny<int8_t> EnumStub8;
-    typedef EnumStubAny<int16_t> EnumStub16;
-    typedef EnumStubAny<int64_t> EnumStub64;
+    typedef EnumStubAny<int8_t>   EnumStub8;
+    typedef EnumStubAny<int16_t>  EnumStub16;
+    typedef EnumStubAny<int64_t>  EnumStub64;
+    // unsigned-underlying variants — used by the typer to dispatch `int(uint8Enum)` / `uint(uint8Enum)`
+    // (and 16/64-bit) so the byte zero-extends instead of sign-extending via int8_t/int16_t/int64_t.
+    typedef EnumStubAny<uint8_t>  EnumStub8u;
+    typedef EnumStubAny<uint16_t> EnumStub16u;
+    typedef EnumStubAny<uint64_t> EnumStub64u;
 
     template <typename ST>
     struct BitfieldAny {

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -3084,6 +3084,41 @@ namespace das {
     __forceinline uint64_t enum16_to_uint64 ( EnumStub16 stub ) { return uint64_t(stub.value); }
     __forceinline uint64_t enum64_to_uint64 ( EnumStub64 stub ) { return uint64_t(stub.value); }
 
+    // unsigned-underlying variants — chosen by the overload resolver for `int(uint8Enum)` etc.
+    // stub.value is uint*_t, so auto-promotion zero-extends and the high byte/half no longer turns negative.
+
+    __forceinline int32_t enum8u_to_int  ( EnumStub8u stub )  { return int32_t(stub.value); }
+    __forceinline int32_t enum16u_to_int ( EnumStub16u stub ) { return int32_t(stub.value); }
+    __forceinline int32_t enum64u_to_int ( EnumStub64u stub ) { return int32_t(stub.value); }
+
+    __forceinline uint32_t enum8u_to_uint  ( EnumStub8u stub )  { return uint32_t(stub.value); }
+    __forceinline uint32_t enum16u_to_uint ( EnumStub16u stub ) { return uint32_t(stub.value); }
+    __forceinline uint32_t enum64u_to_uint ( EnumStub64u stub ) { return uint32_t(stub.value); }
+
+    __forceinline int8_t enum8u_to_int8  ( EnumStub8u stub )  { return int8_t(stub.value); }
+    __forceinline int8_t enum16u_to_int8 ( EnumStub16u stub ) { return int8_t(stub.value); }
+    __forceinline int8_t enum64u_to_int8 ( EnumStub64u stub ) { return int8_t(stub.value); }
+
+    __forceinline uint8_t enum8u_to_uint8  ( EnumStub8u stub )  { return uint8_t(stub.value); }
+    __forceinline uint8_t enum16u_to_uint8 ( EnumStub16u stub ) { return uint8_t(stub.value); }
+    __forceinline uint8_t enum64u_to_uint8 ( EnumStub64u stub ) { return uint8_t(stub.value); }
+
+    __forceinline int16_t enum8u_to_int16  ( EnumStub8u stub )  { return int16_t(stub.value); }
+    __forceinline int16_t enum16u_to_int16 ( EnumStub16u stub ) { return int16_t(stub.value); }
+    __forceinline int16_t enum64u_to_int16 ( EnumStub64u stub ) { return int16_t(stub.value); }
+
+    __forceinline uint16_t enum8u_to_uint16  ( EnumStub8u stub )  { return uint16_t(stub.value); }
+    __forceinline uint16_t enum16u_to_uint16 ( EnumStub16u stub ) { return uint16_t(stub.value); }
+    __forceinline uint16_t enum64u_to_uint16 ( EnumStub64u stub ) { return uint16_t(stub.value); }
+
+    __forceinline int64_t enum8u_to_int64  ( EnumStub8u stub )  { return int64_t(stub.value); }
+    __forceinline int64_t enum16u_to_int64 ( EnumStub16u stub ) { return int64_t(stub.value); }
+    __forceinline int64_t enum64u_to_int64 ( EnumStub64u stub ) { return int64_t(stub.value); }
+
+    __forceinline uint64_t enum8u_to_uint64  ( EnumStub8u stub )  { return uint64_t(stub.value); }
+    __forceinline uint64_t enum16u_to_uint64 ( EnumStub16u stub ) { return uint64_t(stub.value); }
+    __forceinline uint64_t enum64u_to_uint64 ( EnumStub64u stub ) { return uint64_t(stub.value); }
+
 
     template <typename CType>
     struct das_using {

--- a/include/daScript/simulate/debug_info.h
+++ b/include/daScript/simulate/debug_info.h
@@ -485,10 +485,14 @@ namespace das
     };
 
     struct EnumInfo {
+        enum {
+            flag_unsigned = (1<<0)    // underlying type is uint8/uint16/uint32/uint64 (not int*)
+        };
         const char *        name;
         const char *        module_name;
         EnumValueInfo **    fields;
         uint32_t            count;
+        uint32_t            flags;
         uint64_t            hash;
     };
 

--- a/include/daScript/simulate/debug_info.h
+++ b/include/daScript/simulate/debug_info.h
@@ -492,8 +492,8 @@ namespace das
         const char *        module_name;
         EnumValueInfo **    fields;
         uint32_t            count;
-        uint32_t            flags;
         uint64_t            hash;
+        uint32_t            flags;
     };
 
     struct LocalVariableInfo : TypeInfo {

--- a/include/daScript/simulate/debug_print.h
+++ b/include/daScript/simulate/debug_print.h
@@ -459,7 +459,10 @@ namespace das {
             }
         }
         virtual void WalkEnumeration ( int32_t & value, EnumInfo * info ) override {
-            int64_t uvalue = uint64_t(value);
+            // uint32_t(value) first, then promote — uint64_t(int32_t) sign-extends via int rules,
+            // which would leave 0x80000000 looking like 0xFFFFFFFF80000000 and miss the uint-backed
+            // enum's stored int64_t value (2147483648).
+            int64_t uvalue = uint64_t(uint32_t(value));
             for ( uint32_t t=0, ts=info->count; t!=ts; ++t ) {
                 if ( value == info->fields[t]->value || uvalue == info->fields[t]->value ) {
                     emitEnumName(info);

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -3731,8 +3731,9 @@ class public LlvmJitVisitor : AstVisitor {
             void_ptr,        // const char* name
             void_ptr,        // const char* module_name
             void_ptr,        // EnumValueInfo **  fields
-            types.t_int32, // uint32_t count
-            types.t_int64)
+            types.t_int32,   // uint32_t count
+            types.t_int64,   // uint64_t hash
+            types.t_int32)   // uint32_t flags (EnumInfo::flag_unsigned for uint*-backed enums)
     }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -3858,7 +3859,8 @@ class public LlvmJitVisitor : AstVisitor {
             get_string_constant_ptr(g_builder, ei.module_name),
             create_enumvalueinfo_global_array(ei.fields, ei.count),
             types.ConstI32(ei.count |> uint64()),
-            LLVMConstInt(types.t_int64, ei.hash  |> uint64(), 0)
+            LLVMConstInt(types.t_int64, ei.hash  |> uint64(), 0),
+            types.ConstI32(ei.flags |> uint64())
         ]
         struct_info_global |> LLVMSetInitializer() <| make_initializer(ty, init_values)
         return struct_info_global

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -193,7 +193,15 @@ def intrinsic_builtin_int(var ctx : JitCtx; expr : ExprCallFunc?; arguments : ar
     } elif (argType.isInteger || argType.isEnum) {
         if (argType.sizeOf >= expr._type.sizeOf) {
             return LLVMBuildTruncOrBitCast(ctx.builder, arguments[0], intType, string(expr.name))
-        } elif (argType.isSignedInteger || argType.isEnum) {
+        }
+        // For enums, the sign of the underlying type drives sign vs zero extension —
+        // uint8/uint16/uint64-backed enums must zero-extend (200u8 → 0xc8u, not 0xffffffc8u).
+        var widenSigned = argType.isSignedInteger
+        if (argType.isEnum) {
+            let ebt = argType.enumType.baseType
+            widenSigned = ebt == Type.tInt8 || ebt == Type.tInt16 || ebt == Type.tInt || ebt == Type.tInt64
+        }
+        if (widenSigned) {
             return LLVMBuildSExtOrBitCast(ctx.builder, arguments[0], intType, string(expr.name))
         } else {
             return LLVMBuildZExtOrBitCast(ctx.builder, arguments[0], intType, string(expr.name))

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -191,9 +191,7 @@ def intrinsic_builtin_int(var ctx : JitCtx; expr : ExprCallFunc?; arguments : ar
             return LLVMBuildFPToUI(ctx.builder, arguments[0], intType, string(expr.name))
         }
     } elif (argType.isInteger || argType.isEnum) {
-        if (argType.sizeOf >= expr._type.sizeOf) {
-            return LLVMBuildTruncOrBitCast(ctx.builder, arguments[0], intType, string(expr.name))
-        }
+        return LLVMBuildTruncOrBitCast(ctx.builder, arguments[0], intType, string(expr.name)) if (argType.sizeOf >= expr._type.sizeOf)
         // For enums, the sign of the underlying type drives sign vs zero extension —
         // uint8/uint16/uint64-backed enums must zero-extend (200u8 → 0xc8u, not 0xffffffc8u).
         var widenSigned = argType.isSignedInteger

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -19,19 +19,29 @@ After the rebase, every file in `git diff --name-only origin/master..HEAD` shoul
 
 If a rebase produces conflicts on files that were independently changed on origin/master, resolve them by keeping origin/master's version (your branch's "modification" was an outdated copy of the same change) — verify with `git show origin/master:<path>` that the merged version subsumes yours.
 
-## 1. Lint all changed `.das` files
+## 1. Lint all changed `.das` files — **zero warnings required**
 
-Run the unified lint utility on changed directories:
+CI's `extended_checks` job runs the same lint utility on every `.das` file changed vs `origin/master` and **exits non-zero on any warning** (`./bin/daslang ./utils/lint/main.das -- <files> --quiet` → exit code 2 on ≥1 warning). One STYLE/LINT/PERF warning anywhere in your diff fails CI. Local lint must be clean before push — there is no "minor warning, will ignore" tier here.
+
+Lint only the files changed relative to `origin/master` (matches what CI lints):
 ```bash
-bin/Release/daslang.exe utils/lint/main.das -- daslib/ modules/ tutorials/
+git diff --name-only origin/master..HEAD -- '*.das' | xargs bin/Release/daslang.exe utils/lint/main.das -- --quiet
 ```
 
-Or lint only the files changed relative to `master`:
-```bash
-git diff --name-only master -- '*.das' | xargs bin/Release/daslang.exe utils/lint/main.das --
-```
+Expect: `--- Summary --- N files, 0 issue(s), 0 error(s)` and exit code 0. Any other outcome blocks the PR.
 
-Fix significant issues (unused variables that indicate bugs, performance warnings in hot paths). Use `// nolint:CODE` comments to suppress false positives (LINT001-004, PERF001-011, STYLE001-010). Minor lint warnings in unchanged code can be ignored unless trivial to fix.
+Or via MCP: `mcp__daslang__lint` on each changed file.
+
+**Resolution policy** for every warning reported:
+1. **Fix it.** Most STYLE/PERF rules have a mechanical rewrite that's strictly better (postfix `return X if (cond)` instead of `if (cond) { return X }` for STYLE005, direct iteration for PERF018, bitfield-field assignment for STYLE022, etc.). The fix table in `CLAUDE.md` ("Code style — prefer idiomatic forms") covers the common ones.
+2. **Suppress with `// nolint:CODE`** only when the rule is a known false positive for the construct — e.g. handled types (`xml_node`, `sqlite3_stmt`) need `var` for non-const C++ binding access, so a `var`→`let` suggestion is wrong. Include the reason in the comment or in a same-line tail comment.
+3. **Never** push with warnings unsuppressed. CI will fail and the round-trip costs ~25 minutes per fix.
+
+For sweep-style validation on a broader scope before pushing, the directory form still works:
+```bash
+bin/Release/daslang.exe utils/lint/main.das -- daslib/ modules/ tutorials/ --quiet
+```
+but the changed-files form above is the gate.
 
 ## 1.5. Check for duplicates against the corpus
 
@@ -257,7 +267,7 @@ Stage, commit, push, and create the PR using GitHub MCP tools or `gh` CLI. Follo
 | Step | Tool/Command | Fix policy |
 |---|---|---|
 | Sync | `git fetch origin master && git rebase origin/master` | Always run first; verify diff vs origin/master is clean |
-| Lint | `utils/lint/main.das` | Fix significant issues in changed files |
+| Lint | `utils/lint/main.das --quiet` on `git diff --name-only origin/master..HEAD -- '*.das'` | **Zero warnings.** Fix or `// nolint:CODE` every one — CI exits 2 on any warning |
 | Tests | `dastest -- --test tests/` | Must pass. Fix own, fix obvious pre-existing, ask about unclear |
 | AOT build | `cmake --build build --config Release --target test_aot -j 64` | Kill daslang first. Register new test dirs |
 | AOT tests | `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` | Same as regular tests |

--- a/src/ast/ast_debug_info_helper.cpp
+++ b/src/ast/ast_debug_info_helper.cpp
@@ -74,6 +74,11 @@ namespace das {
         eni->name = debugInfo->allocateCachedName(en.name);
         eni->module_name = debugInfo->allocateCachedName(en.module->name);
         eni->count = uint32_t(en.list.size());
+        eni->flags = 0;
+        if ( en.baseType==Type::tUInt8 || en.baseType==Type::tUInt16
+                || en.baseType==Type::tUInt || en.baseType==Type::tUInt64 ) {
+            eni->flags |= EnumInfo::flag_unsigned;
+        }
         eni->fields = (EnumValueInfo **) debugInfo->allocate(sizeof(EnumValueInfo *) * eni->count);
         uint32_t i = 0;
         for ( auto & ev : en.list ) {

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -1719,12 +1719,18 @@ namespace das
             // direction), so check both. Falls through unchanged for user-typed enum params and for
             // generic AST-side TypeDecls (no enumType, no binding marker).
             if ( baseType==Type::tEnumeration8 || baseType==Type::tEnumeration16 || baseType==Type::tEnumeration64 ) {
+                // Read via explicit `flags` mask rather than the bool : 1 bitfield members,
+                // because the bitfield-vs-uint32 union aliasing has surfaced as platform-specific
+                // dispatch bugs on Darwin clang ARM64 (uint8/uint32 cast dispatch landing on the
+                // signed-stub binding instead of the unsigned-stub). typeFactory writes both
+                // views; reads anchor on the mask.
                 auto signednessMismatch = [](const TypeDecl & stub, const TypeDecl & concrete) -> bool {
-                    if ( !stub.enumStubBinding || !concrete.enumType ) return false;
+                    if ( !(stub.flags & TDF_enumStubBinding) || !concrete.enumType ) return false;
                     bool concreteIsUnsigned = concrete.enumType->baseType==Type::tUInt8
                                            || concrete.enumType->baseType==Type::tUInt16
                                            || concrete.enumType->baseType==Type::tUInt64;
-                    return stub.enumStubIsUnsigned != concreteIsUnsigned;
+                    bool stubIsUnsigned = (stub.flags & TDF_enumStubIsUnsigned) != 0;
+                    return stubIsUnsigned != concreteIsUnsigned;
                 };
                 if ( signednessMismatch(*this, decl) ) return false;
                 if ( signednessMismatch(decl, *this) ) return false;
@@ -3264,8 +3270,10 @@ namespace das
             else if ( baseType==Type::tEnumeration64 ) ss << "64";
             // EnumStub binding marker + signedness — distinguishes enum8u_to_int(EnumStub8u) from
             // enum8_to_int(EnumStub8) at function-mangling time so both bindings coexist in the same module.
-            if ( enumStubBinding )    ss << "b";
-            if ( enumStubIsUnsigned ) ss << "u";
+            // Read via explicit `flags` mask to bypass bool : 1 bitfield-vs-uint32 union aliasing
+            // (platform-specific quirks otherwise allow both stub variants to mangle identically).
+            if ( flags & TDF_enumStubBinding )    ss << "b";
+            if ( flags & TDF_enumStubIsUnsigned ) ss << "u";
             if ( enumType ) {
                 ss << "<" << enumType->getMangledName() << ">";
             }

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -1719,18 +1719,12 @@ namespace das
             // direction), so check both. Falls through unchanged for user-typed enum params and for
             // generic AST-side TypeDecls (no enumType, no binding marker).
             if ( baseType==Type::tEnumeration8 || baseType==Type::tEnumeration16 || baseType==Type::tEnumeration64 ) {
-                // Read via explicit `flags` mask rather than the bool : 1 bitfield members,
-                // because the bitfield-vs-uint32 union aliasing has surfaced as platform-specific
-                // dispatch bugs on Darwin clang ARM64 (uint8/uint32 cast dispatch landing on the
-                // signed-stub binding instead of the unsigned-stub). typeFactory writes both
-                // views; reads anchor on the mask.
                 auto signednessMismatch = [](const TypeDecl & stub, const TypeDecl & concrete) -> bool {
-                    if ( !(stub.flags & TDF_enumStubBinding) || !concrete.enumType ) return false;
+                    if ( !stub.enumStubBinding || !concrete.enumType ) return false;
                     bool concreteIsUnsigned = concrete.enumType->baseType==Type::tUInt8
                                            || concrete.enumType->baseType==Type::tUInt16
                                            || concrete.enumType->baseType==Type::tUInt64;
-                    bool stubIsUnsigned = (stub.flags & TDF_enumStubIsUnsigned) != 0;
-                    return stubIsUnsigned != concreteIsUnsigned;
+                    return stub.enumStubIsUnsigned != concreteIsUnsigned;
                 };
                 if ( signednessMismatch(*this, decl) ) return false;
                 if ( signednessMismatch(decl, *this) ) return false;
@@ -3270,10 +3264,8 @@ namespace das
             else if ( baseType==Type::tEnumeration64 ) ss << "64";
             // EnumStub binding marker + signedness — distinguishes enum8u_to_int(EnumStub8u) from
             // enum8_to_int(EnumStub8) at function-mangling time so both bindings coexist in the same module.
-            // Read via explicit `flags` mask to bypass bool : 1 bitfield-vs-uint32 union aliasing
-            // (platform-specific quirks otherwise allow both stub variants to mangle identically).
-            if ( flags & TDF_enumStubBinding )    ss << "b";
-            if ( flags & TDF_enumStubIsUnsigned ) ss << "u";
+            if ( enumStubBinding )    ss << "b";
+            if ( enumStubIsUnsigned ) ss << "u";
             if ( enumType ) {
                 ss << "<" << enumType->getMangledName() << ">";
             }

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -1711,6 +1711,24 @@ namespace das
             if ( enumType && decl.enumType && enumType!=decl.enumType ) {
                 return false;
             }
+            // Stub-binding parameters are signedness-typed for 8/16/64-bit enums (see
+            // typeFactory<EnumStub8/16/64> and typeFactory<EnumStub*u>). When the binding side carries
+            // the marker, only match a concrete enum whose underlying signedness lines up — so that
+            // `int(uint8Enum)` dispatches to enum8u_to_int (zero-extending) rather than enum8_to_int.
+            // Either side may be the binding (isSameType callers swap argType<->passType depending on
+            // direction), so check both. Falls through unchanged for user-typed enum params and for
+            // generic AST-side TypeDecls (no enumType, no binding marker).
+            if ( baseType==Type::tEnumeration8 || baseType==Type::tEnumeration16 || baseType==Type::tEnumeration64 ) {
+                auto signednessMismatch = [](const TypeDecl & stub, const TypeDecl & concrete) -> bool {
+                    if ( !stub.enumStubBinding || !concrete.enumType ) return false;
+                    bool concreteIsUnsigned = concrete.enumType->baseType==Type::tUInt8
+                                           || concrete.enumType->baseType==Type::tUInt16
+                                           || concrete.enumType->baseType==Type::tUInt64;
+                    return stub.enumStubIsUnsigned != concreteIsUnsigned;
+                };
+                if ( signednessMismatch(*this, decl) ) return false;
+                if ( signednessMismatch(decl, *this) ) return false;
+            }
             break;
         case Type::tArray:
             if ( firstType && decl.firstType && !firstType->isSameType(*decl.firstType,RefMatters::yes,ConstMatters::yes,
@@ -3244,6 +3262,10 @@ namespace das
             if ( baseType==Type::tEnumeration8 ) ss << "8";
             else if ( baseType==Type::tEnumeration16 ) ss << "16";
             else if ( baseType==Type::tEnumeration64 ) ss << "64";
+            // EnumStub binding marker + signedness — distinguishes enum8u_to_int(EnumStub8u) from
+            // enum8_to_int(EnumStub8) at function-mangling time so both bindings coexist in the same module.
+            if ( enumStubBinding )    ss << "b";
+            if ( enumStubIsUnsigned ) ss << "u";
             if ( enumType ) {
                 ss << "<" << enumType->getMangledName() << ">";
             }

--- a/src/builtin/module_builtin_ast_flags.cpp
+++ b/src/builtin/module_builtin_ast_flags.cpp
@@ -157,7 +157,8 @@ namespace das {
             "removeRef", "removeConstant", "removeDim",
             "removeTemporary", "explicitConst", "aotAlias", "smartPtr",
             "smartPtrNative", "isExplicit", "isNativeDim", "isTag", "explicitRef",
-            "isPrivateAlias", "autoToAlias", "safeWhenUninitialized" };
+            "isPrivateAlias", "autoToAlias", "safeWhenUninitialized",
+            "enumStubBinding", "enumStubIsUnsigned" };
         return ft;
     }
 

--- a/src/builtin/module_builtin_misc_types.cpp
+++ b/src/builtin/module_builtin_misc_types.cpp
@@ -56,6 +56,18 @@ namespace das
     IMPLEMENT_OP2_EVAL_BOOL_POLICY(Equ,EnumStub64);
     IMPLEMENT_OP2_EVAL_BOOL_POLICY(NotEqu,EnumStub64);
 
+    // Mirror policies for the u-stub variants. Required so `==`/`!=` resolve for uint-backed
+    // enums after the isSameType tightening — the signed EnumStub* bindings now refuse to match
+    // uint-underlying enumTypes and would leave them without an operator.
+    IMPLEMENT_OP2_EVAL_BOOL_POLICY(Equ,EnumStub8u);
+    IMPLEMENT_OP2_EVAL_BOOL_POLICY(NotEqu,EnumStub8u);
+
+    IMPLEMENT_OP2_EVAL_BOOL_POLICY(Equ,EnumStub16u);
+    IMPLEMENT_OP2_EVAL_BOOL_POLICY(NotEqu,EnumStub16u);
+
+    IMPLEMENT_OP2_EVAL_BOOL_POLICY(Equ,EnumStub64u);
+    IMPLEMENT_OP2_EVAL_BOOL_POLICY(NotEqu,EnumStub64u);
+
     template <>
     struct SimPolicy<Func> {
         static __forceinline SimFunction * to_func ( vec4f val ) {
@@ -170,6 +182,9 @@ namespace das
         addExtern<DAS_BIND_FUN(enum64_to_int64)>(*this, lib, "int64", SideEffects::none, "int64_t")->arg("src");
         addExtern<DAS_BIND_FUN(enum64_to_uint64)>(*this, lib, "uint64", SideEffects::none, "uint64_t")->arg("src");
         // enum8u — unsigned-underlying 8-bit enums dispatch here so byte zero-extends instead of sign-extending
+        // (addFunctionBasic registers ==/!= via the SimPolicy<EnumStub8u> defined above; needed so
+        //  uint-backed enums still have an equality operator after the isSameType tightening).
+        addFunctionBasic<EnumStub8u>(*this,lib);
         addExtern<DAS_BIND_FUN(enum8u_to_int)>(*this, lib, "int", SideEffects::none, "int32_t")->arg("src");
         addExtern<DAS_BIND_FUN(enum8u_to_uint)>(*this, lib, "uint", SideEffects::none, "uint32_t")->arg("src");
         addExtern<DAS_BIND_FUN(enum8u_to_int8)>(*this, lib, "int8", SideEffects::none, "int8_t")->arg("src");
@@ -179,6 +194,7 @@ namespace das
         addExtern<DAS_BIND_FUN(enum8u_to_int64)>(*this, lib, "int64", SideEffects::none, "int64_t")->arg("src");
         addExtern<DAS_BIND_FUN(enum8u_to_uint64)>(*this, lib, "uint64", SideEffects::none, "uint64_t")->arg("src");
         // enum16u
+        addFunctionBasic<EnumStub16u>(*this,lib);
         addExtern<DAS_BIND_FUN(enum16u_to_int)>(*this, lib, "int", SideEffects::none, "int32_t")->arg("src");
         addExtern<DAS_BIND_FUN(enum16u_to_uint)>(*this, lib, "uint", SideEffects::none, "uint32_t")->arg("src");
         addExtern<DAS_BIND_FUN(enum16u_to_int8)>(*this, lib, "int8", SideEffects::none, "int8_t")->arg("src");
@@ -188,6 +204,7 @@ namespace das
         addExtern<DAS_BIND_FUN(enum16u_to_int64)>(*this, lib, "int64", SideEffects::none, "int64_t")->arg("src");
         addExtern<DAS_BIND_FUN(enum16u_to_uint64)>(*this, lib, "uint64", SideEffects::none, "uint64_t")->arg("src");
         // enum64u
+        addFunctionBasic<EnumStub64u>(*this,lib);
         addExtern<DAS_BIND_FUN(enum64u_to_int)>(*this, lib, "int", SideEffects::none, "int32_t")->arg("src");
         addExtern<DAS_BIND_FUN(enum64u_to_uint)>(*this, lib, "uint", SideEffects::none, "uint32_t")->arg("src");
         addExtern<DAS_BIND_FUN(enum64u_to_int8)>(*this, lib, "int8", SideEffects::none, "int8_t")->arg("src");

--- a/src/builtin/module_builtin_misc_types.cpp
+++ b/src/builtin/module_builtin_misc_types.cpp
@@ -40,6 +40,9 @@ namespace das
     template <> struct typeName<EnumStub8>   { constexpr static const char * name() { return "enum8"; } };
     template <> struct typeName<EnumStub16>  { constexpr static const char * name() { return "enum16"; } };
     template <> struct typeName<EnumStub64>  { constexpr static const char * name() { return "enum64"; } };
+    template <> struct typeName<EnumStub8u>  { constexpr static const char * name() { return "enum8u"; } };
+    template <> struct typeName<EnumStub16u> { constexpr static const char * name() { return "enum16u"; } };
+    template <> struct typeName<EnumStub64u> { constexpr static const char * name() { return "enum64u"; } };
 
     IMPLEMENT_OP2_EVAL_BOOL_POLICY(Equ,EnumStub);
     IMPLEMENT_OP2_EVAL_BOOL_POLICY(NotEqu,EnumStub);
@@ -166,6 +169,33 @@ namespace das
         addExtern<DAS_BIND_FUN(enum64_to_uint16)>(*this, lib, "uint16", SideEffects::none, "uint16_t")->arg("src");
         addExtern<DAS_BIND_FUN(enum64_to_int64)>(*this, lib, "int64", SideEffects::none, "int64_t")->arg("src");
         addExtern<DAS_BIND_FUN(enum64_to_uint64)>(*this, lib, "uint64", SideEffects::none, "uint64_t")->arg("src");
+        // enum8u — unsigned-underlying 8-bit enums dispatch here so byte zero-extends instead of sign-extending
+        addExtern<DAS_BIND_FUN(enum8u_to_int)>(*this, lib, "int", SideEffects::none, "int32_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum8u_to_uint)>(*this, lib, "uint", SideEffects::none, "uint32_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum8u_to_int8)>(*this, lib, "int8", SideEffects::none, "int8_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum8u_to_uint8)>(*this, lib, "uint8", SideEffects::none, "uint8_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum8u_to_int16)>(*this, lib, "int16", SideEffects::none, "int16_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum8u_to_uint16)>(*this, lib, "uint16", SideEffects::none, "uint16_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum8u_to_int64)>(*this, lib, "int64", SideEffects::none, "int64_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum8u_to_uint64)>(*this, lib, "uint64", SideEffects::none, "uint64_t")->arg("src");
+        // enum16u
+        addExtern<DAS_BIND_FUN(enum16u_to_int)>(*this, lib, "int", SideEffects::none, "int32_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum16u_to_uint)>(*this, lib, "uint", SideEffects::none, "uint32_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum16u_to_int8)>(*this, lib, "int8", SideEffects::none, "int8_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum16u_to_uint8)>(*this, lib, "uint8", SideEffects::none, "uint8_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum16u_to_int16)>(*this, lib, "int16", SideEffects::none, "int16_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum16u_to_uint16)>(*this, lib, "uint16", SideEffects::none, "uint16_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum16u_to_int64)>(*this, lib, "int64", SideEffects::none, "int64_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum16u_to_uint64)>(*this, lib, "uint64", SideEffects::none, "uint64_t")->arg("src");
+        // enum64u
+        addExtern<DAS_BIND_FUN(enum64u_to_int)>(*this, lib, "int", SideEffects::none, "int32_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum64u_to_uint)>(*this, lib, "uint", SideEffects::none, "uint32_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum64u_to_int8)>(*this, lib, "int8", SideEffects::none, "int8_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum64u_to_uint8)>(*this, lib, "uint8", SideEffects::none, "uint8_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum64u_to_int16)>(*this, lib, "int16", SideEffects::none, "int16_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum64u_to_uint16)>(*this, lib, "uint16", SideEffects::none, "uint16_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum64u_to_int64)>(*this, lib, "int64", SideEffects::none, "int64_t")->arg("src");
+        addExtern<DAS_BIND_FUN(enum64u_to_uint64)>(*this, lib, "uint64", SideEffects::none, "uint64_t")->arg("src");
         // function
         addFunctionBasic<Func>(*this,lib);
         addFunction( (new BuiltInFn<Sim_EqFunPtr, bool,const Func,const void *>("==",lib,"==",false)) );

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -705,6 +705,7 @@ namespace das {
             addField<DAS_BIND_MANAGED_FIELD(fields)>("fields");
             addField<DAS_BIND_MANAGED_FIELD(module_name)>("module_name");
             addField<DAS_BIND_MANAGED_FIELD(hash)>("hash");
+            addField<DAS_BIND_MANAGED_FIELD(flags)>("flags");
             fieldType = makeType<EnumValueInfo>(*mlib);
             fieldType->ref = true;
         }

--- a/src/simulate/json_print.cpp
+++ b/src/simulate/json_print.cpp
@@ -293,7 +293,12 @@ namespace das {
             }
         }
         virtual void WalkEnumeration ( int32_t & value, EnumInfo * info ) override {
-            Enum(value,info);
+            // Same sign-extension trap as the 8/16-bit walkers: uint32-backed values > INT32_MAX
+            // come in as negative int32_t, promote to negative int64_t, and miss the lookup against
+            // the positive int64_t-stored field value.
+            int64_t v = (info && (info->flags & EnumInfo::flag_unsigned))
+                ? int64_t(uint32_t(value)) : int64_t(value);
+            Enum(v,info);
         }
         virtual void WalkEnumeration8  ( int8_t & value, EnumInfo * info ) override {
             // For uint8-backed enums the byte represents an unsigned value; promoting via int8_t
@@ -308,6 +313,10 @@ namespace das {
             Enum(v,info);
         }
         virtual void WalkEnumeration64 ( int64_t & value, EnumInfo * info ) override {
+            // No promotion happens here — int64_t reads at its native width, so signedness can't
+            // wrap during the implicit conversion to Enum()'s int64_t parameter. The lookup against
+            // uint64_t-backed values with the top bit set will compare bit-for-bit equal because the
+            // stored value already round-tripped through int64_t at EnumValueInfo build time.
             Enum(value,info);
         }
 

--- a/src/simulate/json_print.cpp
+++ b/src/simulate/json_print.cpp
@@ -276,48 +276,43 @@ namespace das {
             if ( !ignoreNextFields.empty() && ignoreNextFields.back() ) return;
             ss << "null";
         }
-        void Enum ( int64_t value, EnumInfo * info ) {
+        // Enum() with both a signed and an unsigned 64-bit interpretation of the byte. The lookup
+        // succeeds as long as one of them matches the int64_t-stored EnumValueInfo::value. This
+        // sidesteps the sign-extension trap of WalkEnumeration8/16/32 (where reading the byte
+        // through int*_t and implicitly widening to int64_t sign-extends for uint*-backed enums)
+        // without depending on EnumInfo::flag_unsigned — which proved fragile in cross-platform
+        // builds. Same defence-in-depth pattern as debug_print.h.
+        void EnumLookup ( int64_t value, int64_t uvalue, EnumInfo * info ) {
             if ( enumAsInt ) {
-                ss << value;
+                ss << uvalue;
             } else {
                 for ( uint32_t t=0; t!=info->count; ++t ) {
-                    if ( info->fields[t]->value==value ) {
+                    auto fv = info->fields[t]->value;
+                    if ( fv==value || fv==uvalue ) {
                         if ( auto name = info->fields[t]->name ) {
                             ss << "\"" << name << "\"";
                         } else {
-                            ss << value;
+                            ss << fv;
                         }
                         return;
                     }
                 }
             }
         }
+        void Enum ( int64_t value, EnumInfo * info ) {
+            EnumLookup(value, value, info);
+        }
         virtual void WalkEnumeration ( int32_t & value, EnumInfo * info ) override {
-            // Same sign-extension trap as the 8/16-bit walkers: uint32-backed values > INT32_MAX
-            // come in as negative int32_t, promote to negative int64_t, and miss the lookup against
-            // the positive int64_t-stored field value.
-            int64_t v = (info && (info->flags & EnumInfo::flag_unsigned))
-                ? int64_t(uint32_t(value)) : int64_t(value);
-            Enum(v,info);
+            EnumLookup(int64_t(value), int64_t(uint32_t(value)), info);
         }
         virtual void WalkEnumeration8  ( int8_t & value, EnumInfo * info ) override {
-            // For uint8-backed enums the byte represents an unsigned value; promoting via int8_t
-            // sign-extends so the lookup against the int64_t-stored field value would miss.
-            int64_t v = (info && (info->flags & EnumInfo::flag_unsigned))
-                ? int64_t(uint8_t(value)) : int64_t(value);
-            Enum(v,info);
+            EnumLookup(int64_t(value), int64_t(uint8_t(value)), info);
         }
         virtual void WalkEnumeration16 ( int16_t & value, EnumInfo * info ) override {
-            int64_t v = (info && (info->flags & EnumInfo::flag_unsigned))
-                ? int64_t(uint16_t(value)) : int64_t(value);
-            Enum(v,info);
+            EnumLookup(int64_t(value), int64_t(uint16_t(value)), info);
         }
         virtual void WalkEnumeration64 ( int64_t & value, EnumInfo * info ) override {
-            // No promotion happens here — int64_t reads at its native width, so signedness can't
-            // wrap during the implicit conversion to Enum()'s int64_t parameter. The lookup against
-            // uint64_t-backed values with the top bit set will compare bit-for-bit equal because the
-            // stored value already round-tripped through int64_t at EnumValueInfo build time.
-            Enum(value,info);
+            EnumLookup(value, value, info);
         }
 
         virtual bool revisitStructure ( char * /*ps*/, StructInfo * /*si*/ ) override {

--- a/src/simulate/json_print.cpp
+++ b/src/simulate/json_print.cpp
@@ -276,43 +276,48 @@ namespace das {
             if ( !ignoreNextFields.empty() && ignoreNextFields.back() ) return;
             ss << "null";
         }
-        // Enum() with both a signed and an unsigned 64-bit interpretation of the byte. The lookup
-        // succeeds as long as one of them matches the int64_t-stored EnumValueInfo::value. This
-        // sidesteps the sign-extension trap of WalkEnumeration8/16/32 (where reading the byte
-        // through int*_t and implicitly widening to int64_t sign-extends for uint*-backed enums)
-        // without depending on EnumInfo::flag_unsigned — which proved fragile in cross-platform
-        // builds. Same defence-in-depth pattern as debug_print.h.
-        void EnumLookup ( int64_t value, int64_t uvalue, EnumInfo * info ) {
+        void Enum ( int64_t value, EnumInfo * info ) {
             if ( enumAsInt ) {
-                ss << uvalue;
+                ss << value;
             } else {
                 for ( uint32_t t=0; t!=info->count; ++t ) {
-                    auto fv = info->fields[t]->value;
-                    if ( fv==value || fv==uvalue ) {
+                    if ( info->fields[t]->value==value ) {
                         if ( auto name = info->fields[t]->name ) {
                             ss << "\"" << name << "\"";
                         } else {
-                            ss << fv;
+                            ss << value;
                         }
                         return;
                     }
                 }
             }
         }
-        void Enum ( int64_t value, EnumInfo * info ) {
-            EnumLookup(value, value, info);
-        }
         virtual void WalkEnumeration ( int32_t & value, EnumInfo * info ) override {
-            EnumLookup(int64_t(value), int64_t(uint32_t(value)), info);
+            // Same sign-extension trap as the 8/16-bit walkers: uint32-backed values > INT32_MAX
+            // come in as negative int32_t, promote to negative int64_t, and miss the lookup against
+            // the positive int64_t-stored field value.
+            int64_t v = (info && (info->flags & EnumInfo::flag_unsigned))
+                ? int64_t(uint32_t(value)) : int64_t(value);
+            Enum(v,info);
         }
         virtual void WalkEnumeration8  ( int8_t & value, EnumInfo * info ) override {
-            EnumLookup(int64_t(value), int64_t(uint8_t(value)), info);
+            // For uint8-backed enums the byte represents an unsigned value; promoting via int8_t
+            // sign-extends so the lookup against the int64_t-stored field value would miss.
+            int64_t v = (info && (info->flags & EnumInfo::flag_unsigned))
+                ? int64_t(uint8_t(value)) : int64_t(value);
+            Enum(v,info);
         }
         virtual void WalkEnumeration16 ( int16_t & value, EnumInfo * info ) override {
-            EnumLookup(int64_t(value), int64_t(uint16_t(value)), info);
+            int64_t v = (info && (info->flags & EnumInfo::flag_unsigned))
+                ? int64_t(uint16_t(value)) : int64_t(value);
+            Enum(v,info);
         }
         virtual void WalkEnumeration64 ( int64_t & value, EnumInfo * info ) override {
-            EnumLookup(value, value, info);
+            // No promotion happens here — int64_t reads at its native width, so signedness can't
+            // wrap during the implicit conversion to Enum()'s int64_t parameter. The lookup against
+            // uint64_t-backed values with the top bit set will compare bit-for-bit equal because the
+            // stored value already round-tripped through int64_t at EnumValueInfo build time.
+            Enum(value,info);
         }
 
         virtual bool revisitStructure ( char * /*ps*/, StructInfo * /*si*/ ) override {

--- a/src/simulate/json_print.cpp
+++ b/src/simulate/json_print.cpp
@@ -296,10 +296,16 @@ namespace das {
             Enum(value,info);
         }
         virtual void WalkEnumeration8  ( int8_t & value, EnumInfo * info ) override {
-            Enum(value,info);
+            // For uint8-backed enums the byte represents an unsigned value; promoting via int8_t
+            // sign-extends so the lookup against the int64_t-stored field value would miss.
+            int64_t v = (info && (info->flags & EnumInfo::flag_unsigned))
+                ? int64_t(uint8_t(value)) : int64_t(value);
+            Enum(v,info);
         }
         virtual void WalkEnumeration16 ( int16_t & value, EnumInfo * info ) override {
-            Enum(value,info);
+            int64_t v = (info && (info->flags & EnumInfo::flag_unsigned))
+                ? int64_t(uint16_t(value)) : int64_t(value);
+            Enum(v,info);
         }
         virtual void WalkEnumeration64 ( int64_t & value, EnumInfo * info ) override {
             Enum(value,info);

--- a/tests/aot/test_enum_unsigned_underlying_cast.das
+++ b/tests/aot/test_enum_unsigned_underlying_cast.das
@@ -1,8 +1,10 @@
 options gen2
+options rtti
 require dastest/testing_boost public
+require daslib/json_boost
 
 // AOT mirror of tests/language/enum_unsigned_underlying_cast.das — exercises the same
-// uint8/uint16-backed enum cast cases through the AOT codegen path. Post-fix the generated
+// uint8/uint16/uint32-backed enum cast cases through the AOT codegen path. Post-fix the generated
 // C++ should call enum8u_to_uint/enum16u_to_uint (zero-extending) rather than the signed
 // helpers.
 
@@ -17,6 +19,12 @@ enum Channel : uint16 {
     SYS = 100ul
     USER = 5000ul
     BROADCAST = 60000ul
+}
+
+enum Mask32 : uint {
+    NONE = 0u
+    LOW = 0x1u
+    HIGH_BIT = 0x80000000u
 }
 
 enum Signed8 : int8 {
@@ -86,5 +94,36 @@ def test_aot_string_interpolation_names(t : T?) {
     }
     t |> run("aot: uint16 enum interpolates value name") @(t : T?) {
         t |> equal("{Channel.BROADCAST}", "BROADCAST")
+    }
+    t |> run("aot: uint32 enum interpolates value name (high bit set)") @(t : T?) {
+        t |> equal("{Mask32.HIGH_BIT}", "HIGH_BIT")
+    }
+}
+
+struct PktU8 {
+    op : Opcode
+}
+
+struct PktU16 {
+    ch : Channel
+}
+
+struct PktU32 {
+    mk : Mask32
+}
+
+[test]
+def test_aot_sprint_json_unsigned_enum_field(t : T?) {
+    t |> run("aot: sprint_json uint8 enum renders by name") @(t : T?) {
+        let p = PktU8(op = Opcode.HEARTBEAT)
+        t |> equal(sprint_json(p, false), "\{\"op\":\"HEARTBEAT\"\}")
+    }
+    t |> run("aot: sprint_json uint16 enum renders by name") @(t : T?) {
+        let p = PktU16(ch = Channel.BROADCAST)
+        t |> equal(sprint_json(p, false), "\{\"ch\":\"BROADCAST\"\}")
+    }
+    t |> run("aot: sprint_json uint32 enum renders by name") @(t : T?) {
+        let p = PktU32(mk = Mask32.HIGH_BIT)
+        t |> equal(sprint_json(p, false), "\{\"mk\":\"HIGH_BIT\"\}")
     }
 }

--- a/tests/aot/test_enum_unsigned_underlying_cast.das
+++ b/tests/aot/test_enum_unsigned_underlying_cast.das
@@ -27,6 +27,11 @@ enum Mask32 : uint {
     HIGH_BIT = 0x80000000u
 }
 
+enum Wide64 : uint64 {
+    LOW = 100ul
+    HIGH_BIT = 0x8000000000000000ul
+}
+
 enum Signed8 : int8 {
     LOW = 50
     NEGATIVE = -50
@@ -47,6 +52,11 @@ def test_aot_unsigned_underlying_zero_extends(t : T?) {
     t |> run("aot: uint16-backed enum cast preserves half-word value") @(t : T?) {
         t |> equal(uint(Channel.BROADCAST), 60000u)
         t |> equal(int(Channel.BROADCAST), 60000)
+    }
+    t |> run("aot: uint64-backed enum cast preserves bit pattern (top bit set)") @(t : T?) {
+        t |> equal(uint64(Wide64.HIGH_BIT), 0x8000000000000000ul)
+        t |> equal(int64(Wide64.HIGH_BIT), -9223372036854775807l - 1l)
+        t |> equal(uint64(Wide64.LOW), 100ul)
     }
 }
 
@@ -73,6 +83,19 @@ def test_aot_runtime_iteration(t : T?) {
         }
         t |> equal(sum, 250u)
     }
+    t |> run("aot: runtime uint64 enum cast (top bit set)") @(t : T?) {
+        var arr : array<Wide64>
+        arr |> push(Wide64.LOW)
+        arr |> push(Wide64.HIGH_BIT)
+        var hit_high = false
+        for (w in arr) {
+            if (w == Wide64.HIGH_BIT) {
+                hit_high = true
+                t |> equal(uint64(w), 0x8000000000000000ul)
+            }
+        }
+        t |> equal(hit_high, true)
+    }
 }
 
 [test]
@@ -95,10 +118,20 @@ def test_aot_unsigned_enum_equality(t : T?) {
         t |> equal(a == a, true)
         t |> equal(a != c, true)
     }
+    t |> run("aot: uint64 enum == operator works (top bit set)") @(t : T?) {
+        let a = Wide64.HIGH_BIT
+        let c = Wide64.LOW
+        t |> equal(a == a, true)
+        t |> equal(a != c, true)
+    }
 }
 
 struct Pkt {
     op : Opcode
+}
+
+struct Pkt64 {
+    w : Wide64
 }
 
 [test]
@@ -106,6 +139,10 @@ def test_aot_struct_field_cast(t : T?) {
     t |> run("aot: struct field of uint8 enum, cast to uint") @(t : T?) {
         let p = Pkt(op = Opcode.HEARTBEAT)
         t |> equal(uint(p.op), 200u)
+    }
+    t |> run("aot: struct field of uint64 enum, cast to uint64") @(t : T?) {
+        let p = Pkt64(w = Wide64.HIGH_BIT)
+        t |> equal(uint64(p.w), 0x8000000000000000ul)
     }
 }
 
@@ -119,6 +156,9 @@ def test_aot_string_interpolation_names(t : T?) {
     }
     t |> run("aot: uint32 enum interpolates value name (high bit set)") @(t : T?) {
         t |> equal("{Mask32.HIGH_BIT}", "HIGH_BIT")
+    }
+    t |> run("aot: uint64 enum interpolates value name (top bit set)") @(t : T?) {
+        t |> equal("{Wide64.HIGH_BIT}", "HIGH_BIT")
     }
 }
 
@@ -134,6 +174,10 @@ struct PktU32 {
     mk : Mask32
 }
 
+struct PktU64 {
+    w : Wide64
+}
+
 [test]
 def test_aot_sprint_json_unsigned_enum_field(t : T?) {
     t |> run("aot: sprint_json uint8 enum renders by name") @(t : T?) {
@@ -147,5 +191,9 @@ def test_aot_sprint_json_unsigned_enum_field(t : T?) {
     t |> run("aot: sprint_json uint32 enum renders by name") @(t : T?) {
         let p = PktU32(mk = Mask32.HIGH_BIT)
         t |> equal(sprint_json(p, false), "\{\"mk\":\"HIGH_BIT\"\}")
+    }
+    t |> run("aot: sprint_json uint64 enum renders by name (top bit set)") @(t : T?) {
+        let p = PktU64(w = Wide64.HIGH_BIT)
+        t |> equal(sprint_json(p, false), "\{\"w\":\"HIGH_BIT\"\}")
     }
 }

--- a/tests/aot/test_enum_unsigned_underlying_cast.das
+++ b/tests/aot/test_enum_unsigned_underlying_cast.das
@@ -75,6 +75,28 @@ def test_aot_runtime_iteration(t : T?) {
     }
 }
 
+[test]
+def test_aot_unsigned_enum_equality(t : T?) {
+    t |> run("aot: uint8 enum == operator works") @(t : T?) {
+        let a = Opcode.HEARTBEAT
+        let c = Opcode.PING
+        t |> equal(a == a, true)
+        t |> equal(a != c, true)
+    }
+    t |> run("aot: uint16 enum == operator works") @(t : T?) {
+        let a = Channel.BROADCAST
+        let c = Channel.SYS
+        t |> equal(a == a, true)
+        t |> equal(a != c, true)
+    }
+    t |> run("aot: uint32 enum == operator works") @(t : T?) {
+        let a = Mask32.HIGH_BIT
+        let c = Mask32.LOW
+        t |> equal(a == a, true)
+        t |> equal(a != c, true)
+    }
+}
+
 struct Pkt {
     op : Opcode
 }

--- a/tests/aot/test_enum_unsigned_underlying_cast.das
+++ b/tests/aot/test_enum_unsigned_underlying_cast.das
@@ -1,0 +1,90 @@
+options gen2
+require dastest/testing_boost public
+
+// AOT mirror of tests/language/enum_unsigned_underlying_cast.das — exercises the same
+// uint8/uint16-backed enum cast cases through the AOT codegen path. Post-fix the generated
+// C++ should call enum8u_to_uint/enum16u_to_uint (zero-extending) rather than the signed
+// helpers.
+
+enum Opcode : uint8 {
+    NOP = 0u8
+    PING = 50u8
+    HEARTBEAT = 200u8
+    SHUTDOWN = 254u8
+}
+
+enum Channel : uint16 {
+    SYS = 100ul
+    USER = 5000ul
+    BROADCAST = 60000ul
+}
+
+enum Signed8 : int8 {
+    LOW = 50
+    NEGATIVE = -50
+}
+
+enum Signed16 : int16 {
+    LOW = 1000l
+    NEGATIVE = -1000l
+}
+
+[test]
+def test_aot_unsigned_underlying_zero_extends(t : T?) {
+    t |> run("aot: uint8-backed enum cast preserves byte value") @(t : T?) {
+        t |> equal(uint(Opcode.HEARTBEAT), 200u)
+        t |> equal(int(Opcode.HEARTBEAT), 200)
+        t |> equal(int64(Opcode.SHUTDOWN), 254l)
+    }
+    t |> run("aot: uint16-backed enum cast preserves half-word value") @(t : T?) {
+        t |> equal(uint(Channel.BROADCAST), 60000u)
+        t |> equal(int(Channel.BROADCAST), 60000)
+    }
+}
+
+[test]
+def test_aot_signed_underlying_unchanged(t : T?) {
+    t |> run("aot: int8-backed enum cast keeps sign-reinterpret") @(t : T?) {
+        t |> equal(int(Signed8.NEGATIVE), -50)
+        t |> equal(uint(Signed8.NEGATIVE), 0xffffffceu)
+    }
+    t |> run("aot: int16-backed enum cast keeps sign-reinterpret") @(t : T?) {
+        t |> equal(int(Signed16.NEGATIVE), -1000)
+    }
+}
+
+[test]
+def test_aot_runtime_iteration(t : T?) {
+    t |> run("aot: runtime for-loop sum of uint8 enums") @(t : T?) {
+        var arr : array<Opcode>
+        arr |> push(Opcode.PING)
+        arr |> push(Opcode.HEARTBEAT)
+        var sum = 0u
+        for (op in arr) {
+            sum += uint(op)
+        }
+        t |> equal(sum, 250u)
+    }
+}
+
+struct Pkt {
+    op : Opcode
+}
+
+[test]
+def test_aot_struct_field_cast(t : T?) {
+    t |> run("aot: struct field of uint8 enum, cast to uint") @(t : T?) {
+        let p = Pkt(op = Opcode.HEARTBEAT)
+        t |> equal(uint(p.op), 200u)
+    }
+}
+
+[test]
+def test_aot_string_interpolation_names(t : T?) {
+    t |> run("aot: uint8 enum interpolates value name") @(t : T?) {
+        t |> equal("{Opcode.HEARTBEAT}", "HEARTBEAT")
+    }
+    t |> run("aot: uint16 enum interpolates value name") @(t : T?) {
+        t |> equal("{Channel.BROADCAST}", "BROADCAST")
+    }
+}

--- a/tests/aot/test_enum_unsigned_underlying_cast.das
+++ b/tests/aot/test_enum_unsigned_underlying_cast.das
@@ -4,9 +4,9 @@ require dastest/testing_boost public
 require daslib/json_boost
 
 // AOT mirror of tests/language/enum_unsigned_underlying_cast.das — exercises the same
-// uint8/uint16/uint32-backed enum cast cases through the AOT codegen path. Post-fix the generated
-// C++ should call enum8u_to_uint/enum16u_to_uint (zero-extending) rather than the signed
-// helpers.
+// uint8/uint16/uint32/uint64-backed enum cast cases through the AOT codegen path. Post-fix the
+// generated C++ should call enum8u_to_uint/enum16u_to_uint/enum64u_to_uint (zero-extending)
+// rather than the signed helpers.
 
 enum Opcode : uint8 {
     NOP = 0u8
@@ -34,12 +34,12 @@ enum Wide64 : uint64 {
 
 enum Signed8 : int8 {
     LOW = 50
-    NEGATIVE = -50
+    NEGATIVE = 0xce              // int8 bit-reinterpret = -50
 }
 
 enum Signed16 : int16 {
     LOW = 1000l
-    NEGATIVE = -1000l
+    NEGATIVE = 0xfc18l           // int16 bit-reinterpret = -1000
 }
 
 [test]

--- a/tests/language/enum_unsigned_underlying_cast.das
+++ b/tests/language/enum_unsigned_underlying_cast.das
@@ -29,6 +29,14 @@ enum Mask32 : uint {
     HIGH_BIT = 0x80000000u  // > INT32_MAX, exercises the WalkEnumeration (32-bit) fix
 }
 
+// uint64-backed — exercises the EnumStub64u binding (cast helpers, ==/!= policies, isSameType
+// gating for tEnumeration64). The HIGH_BIT value has the int64 sign bit set, so any leftover
+// sign-vs-unsigned mismatch in the lookup paths surfaces here.
+enum Wide64 : uint64 {
+    LOW = 100ul
+    HIGH_BIT = 0x8000000000000000ul   // 2^63 — top bit set
+}
+
 // Signed counterparts — behaviour preserved.
 enum Signed8 : int8 {
     LOW = 50
@@ -52,6 +60,13 @@ def test_unsigned_underlying_zero_extends(t : T?) {
         t |> equal(uint(Channel.BROADCAST), 60000u)
         t |> equal(int(Channel.BROADCAST), 60000)
         t |> equal(int64(Channel.BROADCAST), 60000l)
+    }
+    t |> run("uint64-backed enum cast preserves bit pattern (top bit set)") @(t : T?) {
+        t |> equal(uint64(Wide64.HIGH_BIT), 0x8000000000000000ul)
+        // int64(uint64-enum) is a bit-reinterpret in daslang convention — top bit set → INT64_MIN
+        // (written as -INT64_MAX - 1 because INT64_MIN as a literal overflows the int64 parser).
+        t |> equal(int64(Wide64.HIGH_BIT), -9223372036854775807l - 1l)
+        t |> equal(uint64(Wide64.LOW), 100ul)
     }
 }
 
@@ -78,6 +93,19 @@ def test_runtime_iteration(t : T?) {
             sum += uint(op)
         }
         t |> equal(sum, 250u)               // 50 + 200
+    }
+    t |> run("runtime: uint64 enum cast through array iteration (top bit set)") @(t : T?) {
+        var arr : array<Wide64>
+        arr |> push(Wide64.LOW)
+        arr |> push(Wide64.HIGH_BIT)
+        var hit_high = false
+        for (w in arr) {
+            if (w == Wide64.HIGH_BIT) {
+                hit_high = true
+                t |> equal(uint64(w), 0x8000000000000000ul)
+            }
+        }
+        t |> equal(hit_high, true)
     }
 }
 
@@ -106,6 +134,14 @@ def test_unsigned_enum_equality(t : T?) {
         t |> equal(a == b, true)
         t |> equal(a != c, true)
     }
+    t |> run("uint64 enum == operator works (top bit set)") @(t : T?) {
+        let a = Wide64.HIGH_BIT
+        let b = Wide64.HIGH_BIT
+        let c = Wide64.LOW
+        t |> equal(a == b, true)
+        t |> equal(a == c, false)
+        t |> equal(a != c, true)
+    }
 }
 
 // Struct field access — exercises SimNode_GetField lowering.
@@ -113,11 +149,19 @@ struct Pkt {
     op : Opcode
 }
 
+struct Pkt64 {
+    w : Wide64
+}
+
 [test]
 def test_struct_field_cast(t : T?) {
     t |> run("struct field of uint8 enum, cast to uint") @(t : T?) {
         let p = Pkt(op = Opcode.HEARTBEAT)
         t |> equal(uint(p.op), 200u)
+    }
+    t |> run("struct field of uint64 enum, cast to uint64") @(t : T?) {
+        let p = Pkt64(w = Wide64.HIGH_BIT)
+        t |> equal(uint64(p.w), 0x8000000000000000ul)
     }
 }
 
@@ -132,6 +176,9 @@ def test_string_interpolation_names(t : T?) {
     }
     t |> run("uint32 enum interpolates value name (high bit set)") @(t : T?) {
         t |> equal("{Mask32.HIGH_BIT}", "HIGH_BIT")
+    }
+    t |> run("uint64 enum interpolates value name (top bit set)") @(t : T?) {
+        t |> equal("{Wide64.HIGH_BIT}", "HIGH_BIT")
     }
 }
 
@@ -151,6 +198,10 @@ struct PktU32 {
     mk : Mask32
 }
 
+struct PktU64 {
+    w : Wide64
+}
+
 [test]
 def test_sprint_json_unsigned_enum_field(t : T?) {
     t |> run("sprint_json: uint8 enum HEARTBEAT renders by name") @(t : T?) {
@@ -164,5 +215,9 @@ def test_sprint_json_unsigned_enum_field(t : T?) {
     t |> run("sprint_json: uint32 enum HIGH_BIT renders by name") @(t : T?) {
         let p = PktU32(mk = Mask32.HIGH_BIT)
         t |> equal(sprint_json(p, false), "\{\"mk\":\"HIGH_BIT\"\}")
+    }
+    t |> run("sprint_json: uint64 enum HIGH_BIT renders by name (top bit set)") @(t : T?) {
+        let p = PktU64(w = Wide64.HIGH_BIT)
+        t |> equal(sprint_json(p, false), "\{\"w\":\"HIGH_BIT\"\}")
     }
 }

--- a/tests/language/enum_unsigned_underlying_cast.das
+++ b/tests/language/enum_unsigned_underlying_cast.das
@@ -81,6 +81,33 @@ def test_runtime_iteration(t : T?) {
     }
 }
 
+// Equality on uint-backed enums — the isSameType tightening must NOT remove the ==/!= operator.
+[test]
+def test_unsigned_enum_equality(t : T?) {
+    t |> run("uint8 enum == operator works") @(t : T?) {
+        let a = Opcode.HEARTBEAT
+        let b = Opcode.HEARTBEAT
+        let c = Opcode.PING
+        t |> equal(a == b, true)
+        t |> equal(a == c, false)
+        t |> equal(a != c, true)
+    }
+    t |> run("uint16 enum == operator works") @(t : T?) {
+        let a = Channel.BROADCAST
+        let b = Channel.BROADCAST
+        let c = Channel.SYS
+        t |> equal(a == b, true)
+        t |> equal(a != c, true)
+    }
+    t |> run("uint32 enum == operator works") @(t : T?) {
+        let a = Mask32.HIGH_BIT
+        let b = Mask32.HIGH_BIT
+        let c = Mask32.LOW
+        t |> equal(a == b, true)
+        t |> equal(a != c, true)
+    }
+}
+
 // Struct field access — exercises SimNode_GetField lowering.
 struct Pkt {
     op : Opcode

--- a/tests/language/enum_unsigned_underlying_cast.das
+++ b/tests/language/enum_unsigned_underlying_cast.das
@@ -1,5 +1,7 @@
 options gen2
+options rtti
 require dastest/testing_boost public
+require daslib/json_boost
 
 // Casts of uint8/uint16/uint64-backed enums must zero-extend, not sign-extend.
 // Signed-underlying enums must keep their existing sign-extending bit-reinterpret
@@ -18,6 +20,13 @@ enum Channel : uint16 {
     SYS = 100ul
     USER = 5000ul
     BROADCAST = 60000ul     // > 32767, triggers the bug
+}
+
+// uint32-backed — the WalkEnumeration (32-bit) path also needed the zero-extend fix.
+enum Mask32 : uint {
+    NONE = 0u
+    LOW = 0x1u
+    HIGH_BIT = 0x80000000u  // > INT32_MAX, exercises the WalkEnumeration (32-bit) fix
 }
 
 // Signed counterparts — behaviour preserved.
@@ -93,5 +102,40 @@ def test_string_interpolation_names(t : T?) {
     }
     t |> run("uint16 enum interpolates value name") @(t : T?) {
         t |> equal("{Channel.BROADCAST}", "BROADCAST")
+    }
+    t |> run("uint32 enum interpolates value name (high bit set)") @(t : T?) {
+        t |> equal("{Mask32.HIGH_BIT}", "HIGH_BIT")
+    }
+}
+
+// JSON serialization of a struct containing a uint-backed enum field — exercises
+// json_print.cpp's WalkEnumeration*/Enum() value-name lookup. Before the fix the
+// uint8 byte 0xC8 was read as int8(-56) and the lookup against the int64-stored
+// field value (200) missed, producing {"op":} with an empty value.
+struct PktU8 {
+    op : Opcode
+}
+
+struct PktU16 {
+    ch : Channel
+}
+
+struct PktU32 {
+    mk : Mask32
+}
+
+[test]
+def test_sprint_json_unsigned_enum_field(t : T?) {
+    t |> run("sprint_json: uint8 enum HEARTBEAT renders by name") @(t : T?) {
+        let p = PktU8(op = Opcode.HEARTBEAT)
+        t |> equal(sprint_json(p, false), "\{\"op\":\"HEARTBEAT\"\}")
+    }
+    t |> run("sprint_json: uint16 enum BROADCAST renders by name") @(t : T?) {
+        let p = PktU16(ch = Channel.BROADCAST)
+        t |> equal(sprint_json(p, false), "\{\"ch\":\"BROADCAST\"\}")
+    }
+    t |> run("sprint_json: uint32 enum HIGH_BIT renders by name") @(t : T?) {
+        let p = PktU32(mk = Mask32.HIGH_BIT)
+        t |> equal(sprint_json(p, false), "\{\"mk\":\"HIGH_BIT\"\}")
     }
 }

--- a/tests/language/enum_unsigned_underlying_cast.das
+++ b/tests/language/enum_unsigned_underlying_cast.das
@@ -1,0 +1,97 @@
+options gen2
+require dastest/testing_boost public
+
+// Casts of uint8/uint16/uint64-backed enums must zero-extend, not sign-extend.
+// Signed-underlying enums must keep their existing sign-extending bit-reinterpret
+// semantics (e.g. uint(int8_value=-50) stays 0xffffffce).
+
+// Natural opcode byte — uint8 is the canonical choice for compact packed enums.
+enum Opcode : uint8 {
+    NOP = 0u8
+    PING = 50u8
+    HEARTBEAT = 200u8       // > 127, triggers the bug
+    SHUTDOWN = 254u8
+}
+
+// Like a port id or compact channel — uint16 representable.
+enum Channel : uint16 {
+    SYS = 100ul
+    USER = 5000ul
+    BROADCAST = 60000ul     // > 32767, triggers the bug
+}
+
+// Signed counterparts — behaviour preserved.
+enum Signed8 : int8 {
+    LOW = 50
+    NEGATIVE = -50
+}
+
+enum Signed16 : int16 {
+    LOW = 1000l
+    NEGATIVE = -1000l
+}
+
+[test]
+def test_unsigned_underlying_zero_extends(t : T?) {
+    t |> run("uint8-backed enum cast preserves byte value") @(t : T?) {
+        t |> equal(uint(Opcode.HEARTBEAT), 200u)
+        t |> equal(int(Opcode.HEARTBEAT), 200)
+        t |> equal(int64(Opcode.SHUTDOWN), 254l)
+        t |> equal(uint64(Opcode.SHUTDOWN), 254ul)
+    }
+    t |> run("uint16-backed enum cast preserves half-word value") @(t : T?) {
+        t |> equal(uint(Channel.BROADCAST), 60000u)
+        t |> equal(int(Channel.BROADCAST), 60000)
+        t |> equal(int64(Channel.BROADCAST), 60000l)
+    }
+}
+
+[test]
+def test_signed_underlying_unchanged(t : T?) {
+    t |> run("int8-backed enum cast keeps sign-reinterpret") @(t : T?) {
+        t |> equal(int(Signed8.NEGATIVE), -50)
+        t |> equal(uint(Signed8.NEGATIVE), 0xffffffceu)
+    }
+    t |> run("int16-backed enum cast keeps sign-reinterpret") @(t : T?) {
+        t |> equal(int(Signed16.NEGATIVE), -1000)
+    }
+}
+
+// Runtime path — defeats const folding so we exercise the SimNode side.
+[test]
+def test_runtime_iteration(t : T?) {
+    t |> run("runtime: for-loop sum of uint8 enums") @(t : T?) {
+        var arr : array<Opcode>
+        arr |> push(Opcode.PING)
+        arr |> push(Opcode.HEARTBEAT)
+        var sum = 0u
+        for (op in arr) {
+            sum += uint(op)
+        }
+        t |> equal(sum, 250u)               // 50 + 200
+    }
+}
+
+// Struct field access — exercises SimNode_GetField lowering.
+struct Pkt {
+    op : Opcode
+}
+
+[test]
+def test_struct_field_cast(t : T?) {
+    t |> run("struct field of uint8 enum, cast to uint") @(t : T?) {
+        let p = Pkt(op = Opcode.HEARTBEAT)
+        t |> equal(uint(p.op), 200u)
+    }
+}
+
+// String interpolation goes through WalkEnumeration8 / Enum() value-name lookup.
+[test]
+def test_string_interpolation_names(t : T?) {
+    t |> run("uint8 enum interpolates value name") @(t : T?) {
+        t |> equal("{Opcode.HEARTBEAT}", "HEARTBEAT")
+    }
+    t |> run("uint16 enum interpolates value name") @(t : T?) {
+        t |> equal("{Channel.BROADCAST}", "BROADCAST")
+    }
+}

--- a/tests/language/enum_unsigned_underlying_cast.das
+++ b/tests/language/enum_unsigned_underlying_cast.das
@@ -37,15 +37,16 @@ enum Wide64 : uint64 {
     HIGH_BIT = 0x8000000000000000ul   // 2^63 — top bit set
 }
 
-// Signed counterparts — behaviour preserved.
+// Signed counterparts — behaviour preserved. Hex literals avoid the unary-minus form
+// (daslang's lint pass treats `-N` as an expression, not an integer constant, in enum values).
 enum Signed8 : int8 {
     LOW = 50
-    NEGATIVE = -50
+    NEGATIVE = 0xce              // int8 bit-reinterpret = -50
 }
 
 enum Signed16 : int16 {
     LOW = 1000l
-    NEGATIVE = -1000l
+    NEGATIVE = 0xfc18l           // int16 bit-reinterpret = -1000
 }
 
 [test]


### PR DESCRIPTION
## Summary

- Casts of `uint8`/`uint16`/`uint64`-backed enum values to `int`/`uint`/larger types sign-extended through the signed underlying stub, so any value with the high bit set came out negative (`uint(uint8_enum=200u8)` → `0xFFFFFFC8` instead of `0xC8`). Const folding, interpreter, JIT and AOT all routed through the same broken `enum8_to_uint(EnumStub8)` family of helpers.
- Splits the binding by signedness: new `EnumStub8u`/`16u`/`64u` typedefs + 24 `enum*u_to_*` zero-extending helpers, plus an `enumStubBinding` + `enumStubIsUnsigned` pair of bits on `TypeDecl` (carried by `typeFactory<EnumStub*[u]>`). `isSameType`'s enum branch dispatches so signed-stub bindings only accept int-backed enums and u-stubs only accept uint-backed; the mangle gains `b`/`u` markers so the two coexist. Existing signed-underlying enums (incl. `uint(int8_enum=-50)` → `0xFFFFFFCE`) keep their current bit-reinterpret semantics.
- Fixes the same root-cause family in `WalkEnumeration8`/`16`: the byte was promoted via `int8_t` → `int64_t` before lookup in `Enum()`, so `"{uint8_enum_value=200}"` and the JSON serializer found nothing. `EnumInfo` now carries `flag_unsigned`, populated from `Enumeration::baseType` at debug-info construction time, and the walkers zero-extend when set.

Repro (was wrong, now correct):

```daslang
options gen2
enum E8u : uint8 { LOW = 50u8; HIGH = 200u8 }

[export] def main() {
    var arr : array<E8u>
    arr |> push(E8u.LOW); arr |> push(E8u.HIGH)
    for (e in arr) { print("uint = {uint(e)}, int = {int(e)}\n") }
}
```

Before: `uint = 0xffffffc8, int = -56`. After: `uint = 0xc8, int = 200`.

Two new test files exercise the cast matrix at every size/signedness, the runtime iteration path (defeats const folding), struct field access, string interpolation, and the JSON serializer.

## Test plan

- [x] `cmake --build build --config Release -j 64` (with `DAS_LLVM_DISABLED=OFF -DDAS_HV_DISABLED=OFF`)
- [x] `ctest -C Release` — 35/35 pass
- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test tests/` — 7940/7946 pass (6 pre-existing skips, 0 failures)
- [x] `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests/` — 7329/7335 pass (6 pre-existing skips, 0 failures), AOT cache busted before the run
- [x] `dasfmt --verify` clean on both new `.das` files
- [x] Original 226-entry playground sample produces correct uint values (`0x80` instead of `0xffffff80`)
- [x] No GC leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
