### PR TITLE
mouse-data: 4 cards from PR #2736 (FieldDeclaration _abstract + inherited)

### DIFF
--- a/mouse-data/docs/add-bit-to-ast-flag-union-checklist.md
+++ b/mouse-data/docs/add-bit-to-ast-flag-union-checklist.md
@@ -1,0 +1,59 @@
+---
+slug: add-bit-to-ast-flag-union-checklist
+title: How do I add a new bit to one of the AST flag unions (FieldDeclaration, Structure, Function) and expose it to daslang and docs without breaking anything?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+Adding a flag bit to `Structure::FieldDeclaration` / `Structure` / `Function` etc. requires changes at **four** positionally-linked sites. Miss one and the binding silently misaligns or the serializer caches stale state.
+
+## The four sites
+
+1. **C++ union** in `include/daScript/ast/ast.h` (or `ast_handle.h` etc.). Append the bit AFTER the existing last bit so existing bit positions don't shift. Example for FieldDeclaration:
+   ```cpp
+   bool            classMethod : 1;
+   bool            _abstract : 1;     // NEW: leading underscore in C++ because daslang reserves "abstract"
+   bool            inherited : 1;     // NEW: plain name (not a keyword in either side)
+   ```
+   Naming convention: if the daslang side needs a `_`-prefix to escape a keyword (`abstract`, `sealed`, `generator`), use the same underscore in C++ for symmetry. Otherwise plain identifier.
+
+2. **Bitfield binding** in `src/builtin/module_builtin_ast_flags.cpp`. Find the matching `make<Name>Flags()` function and append the daslang name(s) to `argNames` in the **same order** as the C++ bits:
+   ```cpp
+   ft->argNames = { ... "implemented", "classMethod", "_abstract", "inherited" };
+   ```
+   The bitfield is positional — argNames[N] = C++ bit N. Reorder either side and every consumer of `fld.flags.<name>` reads the wrong bit.
+
+3. **Handmade RST description** in `doc/source/stdlib/handmade/typedef-ast-<Name>Flags.rst`. Format: line 1 = type description, lines 2..N+1 = one short description per bit in argNames order. Append a line for each new bit:
+   ```
+   The method is declared abstract - body must be provided by a derived class.
+   This field is inherited from a parent class and is not (re)declared in this class.
+   ```
+   Same positional invariant — line N+1 corresponds to bit N. Then run `bin/Release/daslang.exe doc/reflections/das2rst.das` to regenerate `doc/source/stdlib/generated/ast.rst` (gitignored — don't try to commit it).
+
+4. **Serializer version bump** in `src/builtin/module_builtin_ast_serialize.cpp:2701`. Increment `currentVersion` (e.g. 84 → 85). `FieldDeclaration::serialize` writes the full `uint32_t flags`, so adding bits doesn't move existing ones — but bumping the version invalidates stale pre-bump cached AST blobs and surfaces version mismatches immediately rather than as subtle wrong-flag reads.
+
+## Where to actually SET the bits
+
+Most flag bits are set in the parser, not the typer. For FieldDeclaration in particular:
+- `src/parser/parser_impl.cpp` — `ast_structureDeclaration` has three insertion points: clone-reset loop (~line 328), new-field branch (~line 388), override branch (~line 412). Each new bit needs explicit handling at the override branch (clear or set per semantics) — the clone-loop covers the inherit-from-parent case via `Structure::clone()` flag copy at `src/ast/ast.cpp:260`.
+- Parser-side intent often lives in `src/parser/parser_impl.h` `VariableDeclaration` as a `bool isFoo = false` field, set at the parse site (e.g. `ast_structVarDefAbstract`) and consumed during the field-decl insertion.
+
+## Don't touch parentType when adding "inherited-from-parent" semantics
+
+`parentType` is a narrow auto-type-resolution flag (set when override declares with auto type, cleared by infer at `src/ast/ast_infer_type.cpp:251`). It is NOT "this field came from parent class". After inference it's almost always false. PR #2736 added a separate `inherited` bit precisely so macros could ask "did this field come from a parent class" without overloading `parentType`.
+
+## Test pattern
+
+Use a `[structure_macro]` helper module under `tests/language/_<helper>.das` (underscore-prefix = filtered from dastest discovery). In `apply()` or `finish()`, walk `st.fields`, compare `fld.flags.<bit>` against annotation args, and `errors := "..."; return false` on mismatch — compile fails on mismatch, so compile success IS the test. See `tests/language/_field_decl_flags_helper.das` for the canonical example.
+
+## Annotation-arg name trap
+
+If your test macro accepts a bool arg matching the flag name (e.g. `[probe(abstract = true)]`), the daslang **keyword shadow** rule rejects `abstract` / `sealed` / `inherited`-NOT-a-keyword as arg names. Prefix with `is_` / `has_`: `is_abstract`, `is_inherited`. Mirror this on the helper module's `find_arg` calls.
+
+## Reference: PR #2736 (2026-05-19)
+
+Added `_abstract` (0x400) and `inherited` (0x800) to FieldDeclaration. Diff is minimal (8 files, ~99 insertions) and serves as a complete worked example of the checklist above.
+
+## Questions
+- How do I add a new bit to one of the AST flag unions (FieldDeclaration, Structure, Function) and expose it to daslang and docs without breaking anything?

--- a/mouse-data/docs/annotation-arg-name-cannot-shadow-keyword.md
+++ b/mouse-data/docs/annotation-arg-name-cannot-shadow-keyword.md
@@ -1,0 +1,34 @@
+---
+slug: annotation-arg-name-cannot-shadow-keyword
+title: Why does my annotation `[my_macro(abstract = true)]` fail to parse with "unexpected abstract, expecting type or in or name"?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+Annotation argument names cannot shadow daslang **reserved keywords**. Even though annotation args are parsed as identifier=value pairs, the identifier slot still goes through the regular tokenizer — `abstract`, `sealed`, `inherited` (NOT a keyword), `override`, `private`, `static`, `template`, `class`, `struct`, `enum`, `def`, `let`, `var`, `for`, `while`, `if`, `return`, `break`, `continue`, etc. all parse as their keyword token and the annotation-arg rule rejects them.
+
+```das
+// PARSE ERROR: "unexpected abstract"
+[my_macro(abstract = true)]
+
+// OK — prefix avoids the keyword
+[my_macro(is_abstract = true)]
+```
+
+## Workarounds
+
+1. **Prefix with `is_` / `has_` / `expected_`** — most idiomatic. Reads naturally for booleans (`is_abstract`, `has_body`).
+2. **Use camelCase** if the keyword is a single lowercase word — e.g. `isAbstract`, `useSealed`. Daslang doesn't reserve camelCase forms.
+3. **Read by string in the macro** — annotation args are accessed via `find_arg(args, "name") ?as tBool ?? false` where "name" is a plain string. The string literal IS the identifier as seen at parse time — so the *parser* must accept the identifier, but you read it from the runtime args list by its string spelling.
+
+## Why this hits during macro test writing
+
+`[structure_macro]` helpers that probe class-method flags naturally want arg names matching the flag names — `abstract`, `sealed`, `classMethod`. The bitfield bindings escape with `_abstract` / `_sealed` for the daslang-side read, but the bitfield-arg position uses string literals so the underscore is fine THERE. The annotation arg name position is a regular identifier token and the keyword-shadow rule fires.
+
+## Reserved keyword list
+
+`src/builtin/module_builtin_ast.cpp` around line 92 lists the daslang reserved keywords for tokenizer purposes. Check there if you're unsure whether a name will conflict.
+
+## Questions
+- Why does my annotation `[my_macro(abstract = true)]` fail to parse with "unexpected abstract, expecting type or in or name"?

--- a/mouse-data/docs/fielddeclaration-parenttype-narrow-auto-resolution-not-inherited.md
+++ b/mouse-data/docs/fielddeclaration-parenttype-narrow-auto-resolution-not-inherited.md
@@ -1,0 +1,38 @@
+---
+slug: fielddeclaration-parenttype-narrow-auto-resolution-not-inherited
+title: What does the parentType bit on FieldDeclaration actually mean? Is it set on fields inherited from a parent class?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+**No.** `parentType` is NOT "this field came from a parent class". It is a narrow auto-type-resolution flag and is almost always false after inference.
+
+## Actual semantic
+
+`parentType` is set in exactly two places:
+
+1. `src/parser/parser_impl.cpp:408` — when a derived class declaration overrides a parent field and the override uses `auto` (so the type comes from the parent at infer time):
+   ```cpp
+   oldFd->parentType = oldFd->type->isAuto();
+   ```
+2. `src/ast/ast_generate.cpp:2113,2136` — when `makeClassRtti` / `makeClassFinalize` rewrites the cloned `__rtti` / `__finalize` field in a derived class. Same `fd->type->isAuto()` check — only true for `__finalize` (declared as `tAutoinfer`), false for `__rtti` (declared as `pvoid`).
+
+## When it gets cleared
+
+`src/ast/ast_infer_type.cpp:247-258` reads `parentType=true`, clones the parent's resolved type into `decl.type`, and sets `parentType = false`. So once the typer runs the bit goes back to false.
+
+## What this means for macros
+
+Most consumers reading `!fld.flags.parentType` (e.g. `daslib/rst.das`, `utils/mcp/subtools/list_types.das`, `daslib/aot_cpp.das`) run post-inference, where the bit is effectively always false. The check is vestigial / defensive against the rare pre-resolution case.
+
+If you want "this field is inherited from a parent class and not (re)declared here", use the `inherited` bit instead (added in PR #2736, bit 0x800). That bit is sticky — set on clone, cleared only when the derived class declares or overrides the field locally.
+
+If you want to know if a field's type still needs parent resolution (pre-infer macros only), use `parentType`.
+
+## Naming trap
+
+The name reads like "this field's type belongs to the parent" which most people interpret as "inherited from parent class". That broader interpretation is wrong but tempting — at one point even the daslib usages were written under it. PR #2736 added the explicit `inherited` bit to remove the ambiguity. Don't add new code that reads `parentType` to mean "inherited"; use `inherited` (or `!implemented`, which means the same thing pre/post inference).
+
+## Questions
+- What does the parentType bit on FieldDeclaration actually mean? Is it set on fields inherited from a parent class?

--- a/mouse-data/docs/unsafe-expression-form-vs-block-form-for-statements.md
+++ b/mouse-data/docs/unsafe-expression-form-vs-block-form-for-statements.md
@@ -1,0 +1,35 @@
+---
+slug: unsafe-expression-form-vs-block-form-for-statements
+title: Why does unsafe(delete foo) fail to parse, but unsafe { delete foo } works?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+`delete` is a **statement**, not an expression. `unsafe(...)` is the expression form of unsafe — only expressions go inside the parentheses. Statements need the block form `unsafe { ... }`.
+
+```das
+// PARSE ERROR: "unexpected delete"
+unsafe(delete foo)
+
+// OK
+unsafe {
+    delete foo
+}
+```
+
+Same trap for any statement-form keyword: `return`, `break`, `continue`, `for`, `while`, variable declarations (`var x = ...`), assignments at statement level.
+
+For pure expressions like `reinterpret<T?>(addr(x))`, `unsafe(...)` is the preferred narrow form (STYLE024 lint pushes this). The mental rule:
+
+- "Does this thing have a value I could assign to a variable?" → expression → `unsafe(...)`.
+- "Does it produce a side effect with no return value?" → statement → `unsafe { ... }`.
+
+Edge case: single-statement `unsafe { stmt }` where `stmt` itself has a sub-expression that needs unsafe (e.g. `let x = unsafe(reinterpret<...>(...))` inside the block) — STYLE025 prefers narrowing the inner `unsafe(...)` and dropping the outer block. But when the statement itself is the unsafe operation (`delete`, `addr` at statement level, etc.) the block form stays.
+
+## Why this catches people
+
+Reaching for the narrow expression form is a learned reflex from STYLE024/STYLE025 lint guidance. But the lint only applies when there IS an expression to narrow. `delete x` produces no value — no narrowing possible — block is required.
+
+## Questions
+- Why does unsafe(delete foo) fail to parse, but unsafe { delete foo } works?


### PR DESCRIPTION
## Summary

Four blind-mouse cards distilled from PR #2736 work:

- **`add-bit-to-ast-flag-union-checklist`** — the four-site checklist (C++ union + `make<Name>Flags()` argNames + handmade rst + `AstSerializer::currentVersion` bump) for adding a bit to `Structure::FieldDeclaration` / `Structure` / `Function` flag unions. Uses PR #2736 as the worked example.
- **`fielddeclaration-parenttype-narrow-auto-resolution-not-inherited`** — clears up the long-running misread: `parentType` is NOT "this field came from a parent class". It's a narrow auto-type-resolution flag, cleared by infer at `ast_infer_type.cpp:251`. Use the new `inherited` bit (added in #2736) — or `!implemented` — for the broader question.
- **`unsafe-expression-form-vs-block-form-for-statements`** — `unsafe(delete x)` is a parse error; `delete` is a statement, only expressions go in `unsafe(...)`. Use the `unsafe { ... }` block form. Same trap for `return`, `break`, `continue`, variable declarations.
- **`annotation-arg-name-cannot-shadow-keyword`** — `[macro(abstract = true)]` is a parse error; daslang keywords (`abstract`, `sealed`, `override`, etc.) can't be annotation arg names. Prefix with `is_` / `has_` (e.g. `is_abstract`). Hit during the PR #2736 test helper writing.

## Test plan

- [x] Documentation-only — no compile/test changes
- [x] All four cards searchable via `mouse__ask`

🤖 Generated with [Claude Code](https://claude.com/claude-code)