### PR TITLE
linq_fold: plan_zip chain ops (Phase 2B — Z3 fused where/select/take/skip + Z6 bails)

### DIFF
--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -2875,25 +2875,36 @@ def private plan_group_by(var expr : Expression?) : Expression? {
 
 [macro_function]
 def private plan_zip(var expr : Expression?) : Expression? {
-    // Phase 2 Z1+Z2: 2-ary lockstep zip splice + no-pred count/long_count + length shortcut.
+    // Phase 2 Z1/Z2/Z3: 2-ary lockstep zip splice. Supports bare zip (array/iterator), no-pred count/long_count, and fused where_/select/take/skip/take_while/skip_while chain ops between zip and terminator. Result-selector form (3-arg zip), accumulator terminators (sum/min/max/etc.), and chained selects bail to tier-2 cascade.
     var (top, calls) = flatten_linq(expr)
     if (empty(calls) || calls[0]._1.name != "zip") return null
     var zipCall = calls[0]._0
     let zipArgCount = zipCall.arguments |> length
-    if (zipArgCount != 2 || length(calls) > 2) return null
+    // Z6 bail: result-selector form (3-arg zip = 2 sources + selector) yields scalar element stream — different splice shape, defer.
+    if (zipArgCount != 2) return null
+    // Identify recognized terminator (count/long_count). Anything else: if it's a recognized chain op, treat as no-terminator (bare); else bail.
     var lastName = ""
-    var lastCall : ExprCall?
-    if (length(calls) == 2) {
-        lastName = calls.back()._1.name
-        lastCall = calls.back()._0
-        // Z2 supports only no-pred count / long_count. Other terminators bail to tier-2.
-        if ((lastName != "count" && lastName != "long_count") || lastCall.arguments |> length != 1) return null
+    var intermediateEnd = length(calls)
+    if (length(calls) > 1) {
+        let candidateName = calls.back()._1.name
+        let candidateCall = calls.back()._0
+        if (candidateName == "count" || candidateName == "long_count") {
+            // No-pred form only (1 arg = the source). Predicate-form bails (would change per-element work).
+            if (candidateCall.arguments |> length != 1) return null
+            lastName = candidateName
+            intermediateEnd = length(calls) - 1
+        }
     }
     let at = zipCall.at
     let srcAName = "`srcA`{at.line}`{at.column}"
     let srcBName = "`srcB`{at.line}`{at.column}"
     let bufName  = "`buf`{at.line}`{at.column}"
     let accName  = "`acc`{at.line}`{at.column}"
+    let skipName = "`skip`{at.line}`{at.column}"
+    let takeCountName = "`tc`{at.line}`{at.column}"
+    let skippingName = "`skipping`{at.line}`{at.column}"
+    // itName binds the tuple `(itA, itB)` at the top of the for-body; chain ops (where_/select/while-family) reference it by name.
+    let itName = "`it`{at.line}`{at.column}"
     var srcAExpr = peel_each(clone_expression(zipCall.arguments[0]))
     var srcBExpr = peel_each(clone_expression(zipCall.arguments[1]))
     if (srcAExpr == null || srcAExpr._type == null || srcBExpr == null || srcBExpr._type == null) return null
@@ -2901,56 +2912,196 @@ def private plan_zip(var expr : Expression?) : Expression? {
     srcBExpr.genFlags.alwaysSafe = true
     var srcAType = invoke_src_param_type(srcAExpr)
     var srcBType = invoke_src_param_type(srcBExpr)
+    // elementType starts as the tuple-of-refs (zip's natural element) and is rebound by `select`.
     var elementType = clone_type(zipCall._type.firstType)
+    var whereCond : Expression?
+    var projection : Expression?
+    var skipExpr : Expression?
+    var takeExpr : Expression?
+    var skipWhileCond : Expression?
+    var takeWhileCond : Expression?
+    var seenSelect = false
+    var seenSkip = false
+    var seenSkipWhile = false
+    var seenTakeWhile = false
+    var seenTake = false
+    var allProjectionsPure = true
+    // Z3 chain walk: fuse where_/select/take/skip/take_while/skip_while between zip and terminator. Predicates/projections receive the tuple element via fold_linq_cond_peel substitution with `(itA, itB)` — typer collapses `t._0/_1` to the raw iter vars.
+    for (i in 1 .. intermediateEnd) {
+        var cll & = unsafe(calls[i])
+        let opName = cll._1.name
+        if (opName == "where_") {
+            // Canonical chain order: skip/take/while-family come after where_/select. After-select chained where: defer (would require chained-bind dedup, see Phase 3d for single-source analog).
+            if (seenSkip || seenSkipWhile || seenTakeWhile || seenTake || seenSelect) return null
+            var predicate : Expression? = fold_linq_cond(cll._0.arguments[1], itName)
+            if (predicate == null) return null
+            if (whereCond == null) {
+                whereCond = predicate
+            } else {
+                whereCond = qmacro($e(whereCond) && $e(predicate))
+            }
+        } elif (opName == "select") {
+            // Skip/take/while come after select; chained selects on zip stream defer (would mirror plan_loop_or_count `intermediateBinds`).
+            if (seenSkip || seenSkipWhile || seenTakeWhile || seenTake || seenSelect) return null
+            // Pull elementType from the projection block's return expression — the SELECT call's `_type.firstType` is a typedecl(result_selector(...)) formula that doesn't resolve when the chain is wrapped in _fold (call-macro context defers generic typedecl evaluation).
+            var projElemType : TypeDeclPtr
+            var projBody = cll._0.arguments[1]
+            if (projBody is ExprMakeBlock) {
+                var projMblk = projBody as ExprMakeBlock
+                var projBlk = projMblk._block as ExprBlock
+                if (projBlk.list |> length == 1 && projBlk.list[0] is ExprReturn) {
+                    var projRet = projBlk.list[0] as ExprReturn
+                    if (projRet.subexpr != null && projRet.subexpr._type != null) {
+                        projElemType = clone_type(projRet.subexpr._type)
+                    }
+                }
+            }
+            if (projElemType == null) return null
+            // Strip constness: the projection returns an int-valued (or similar) expression typed as `T const`, but `array<T const>` is unwritable.
+            projElemType.flags.constant = false
+            projection = fold_linq_cond(cll._0.arguments[1], itName)
+            if (projection == null) return null
+            elementType = projElemType
+            seenSelect = true
+            if (has_sideeffects(projection)) {
+                allProjectionsPure = false
+            }
+        } elif (opName == "skip") {
+            if (seenSkip || seenSkipWhile || seenTakeWhile || seenTake) return null
+            var skipArg = cll._0.arguments[1]
+            if (skipArg == null || skipArg._type == null || skipArg._type.baseType != Type.tInt) return null
+            skipExpr = clone_expression(skipArg)
+            seenSkip = true
+        } elif (opName == "skip_while") {
+            if (seenSelect || seenSkipWhile || seenTakeWhile || seenTake) return null
+            var swArg = cll._0.arguments[1]
+            if (swArg == null) return null
+            skipWhileCond = fold_linq_cond(swArg, itName)
+            if (skipWhileCond == null) return null
+            seenSkipWhile = true
+        } elif (opName == "take_while") {
+            if (seenSelect || seenTakeWhile || seenTake) return null
+            var twArg = cll._0.arguments[1]
+            if (twArg == null) return null
+            takeWhileCond = fold_linq_cond(twArg, itName)
+            if (takeWhileCond == null) return null
+            seenTakeWhile = true
+        } elif (opName == "take") {
+            if (seenTake) return null
+            var takeArg = cll._0.arguments[1]
+            if (takeArg == null || takeArg._type == null || takeArg._type.baseType != Type.tInt) return null
+            takeExpr = clone_expression(takeArg)
+            seenTake = true
+        } else {
+            // Any other intermediate op (group_by, distinct, order_*, second zip, etc.): bail to tier-2.
+            return null
+        }
+    }
+    let noLimits = skipExpr == null && takeExpr == null && skipWhileCond == null && takeWhileCond == null
+    let noChain = whereCond == null && projection == null && noLimits
     let bothHaveLength = type_has_length(srcAExpr._type) && type_has_length(srcBExpr._type)
-    var bodyStmts : array<Expression?>
-    if (lastName == "count" && bothHaveLength) {
-        bodyStmts |> push <| qmacro_expr() {
-            return int(length($i(srcAName)) < length($i(srcBName)) ? length($i(srcAName)) : length($i(srcBName)))
-        }
-    } elif (lastName == "long_count" && bothHaveLength) {
-        bodyStmts |> push <| qmacro_expr() {
-            return int64(length($i(srcAName)) < length($i(srcBName)) ? length($i(srcAName)) : length($i(srcBName)))
-        }
-    } elif (lastName == "count") {
-        bodyStmts |> push <| qmacro_expr() {
-            var $i(accName) = 0
-        }
-        bodyStmts |> push <| qmacro_expr() {
-            for (_itA, _itB in $i(srcAName), $i(srcBName)) {
-                $i(accName) ++
+    let isCounter = lastName == "count" || lastName == "long_count"
+    // Length shortcut: count/long_count, no chain, both length-bearing → return min(lenA, lenB) without entering the loop.
+    if (noChain && bothHaveLength && isCounter) {
+        var bodyStmts : array<Expression?>
+        if (lastName == "count") {
+            bodyStmts |> push <| qmacro_expr() {
+                return int(length($i(srcAName)) < length($i(srcBName)) ? length($i(srcAName)) : length($i(srcBName)))
+            }
+        } else {
+            bodyStmts |> push <| qmacro_expr() {
+                return int64(length($i(srcAName)) < length($i(srcBName)) ? length($i(srcAName)) : length($i(srcBName)))
             }
         }
-        bodyStmts |> push <| qmacro_expr() {
-            return $i(accName)
-        }
-    } elif (lastName == "long_count") {
-        bodyStmts |> push <| qmacro_expr() {
-            var $i(accName) : int64 = 0l
-        }
-        bodyStmts |> push <| qmacro_expr() {
-            for (_itA, _itB in $i(srcAName), $i(srcBName)) {
-                $i(accName) ++
+        return finalize_zip_invoke(bodyStmts, srcAName, srcBName, srcAType, srcBType, srcAExpr, srcBExpr, at)
+    }
+    // Build per-element body inside the for-loop. wrap_with_ranges adds skip/take/while guards; wrap_with_condition wraps with `if (whereCond)`.
+    var perStmts : array<Expression?>
+    if (isCounter) {
+        // Counter lane: if projection has side effects, evaluate it for those effects; then `acc++`.
+        if (seenSelect && !allProjectionsPure) {
+            let finalBindName = "`vfinal`{at.line}`{at.column}"
+            perStmts |> push <| qmacro_expr() {
+                var $i(finalBindName) = $e(projection)
             }
         }
-        bodyStmts |> push <| qmacro_expr() {
-            return $i(accName)
+        perStmts |> push <| qmacro_expr() {
+            $i(accName) ++
         }
     } else {
-        // No terminator — Z1 array/iterator output.
+        // Array lane: push projection (if select fused), bound tuple `it` (when any chain op needs it), or raw `(itA, itB)` tuple (bare zip with no chain). needsItBind below decides whether `it` is bound.
+        let needsItBindLocal = whereCond != null || projection != null || skipWhileCond != null || takeWhileCond != null
+        if (projection != null) {
+            perStmts |> push <| qmacro_expr() {
+                $i(bufName) |> push_clone($e(projection))
+            }
+        } elif (needsItBindLocal) {
+            perStmts |> push <| qmacro_expr() {
+                $i(bufName) |> push_clone($i(itName))
+            }
+        } else {
+            perStmts |> push <| qmacro_expr() {
+                $i(bufName) |> push_clone((itA, itB))
+            }
+        }
+    }
+    wrap_with_ranges(perStmts, skipExpr, takeExpr, skipWhileCond, takeWhileCond, skipName, takeCountName, skippingName)
+    var perBody = wrap_with_condition(stmts_to_expr(perStmts), whereCond)
+    // Bind `it = (itA, itB)` ahead of all chain logic when any op (where/projection/while-family) consumes it. Counter/array-identity with no fused ops skip the bind (zero-cost).
+    let needsItBind = whereCond != null || projection != null || skipWhileCond != null || takeWhileCond != null
+    if (needsItBind) {
+        var preStmts : array<Expression?>
+        preStmts |> reserve(2)
+        preStmts |> push <| qmacro_expr() {     // nolint:STYLE012
+            let $i(itName) = (itA, itB)
+        }
+        preStmts |> push(perBody)
+        perBody = stmts_to_expr(preStmts)
+    }
+    // Outer body assembly.
+    var bodyStmts : array<Expression?>
+    if (isCounter) {
+        if (lastName == "count") {
+            bodyStmts |> push <| qmacro_expr() {
+                var $i(accName) = 0
+            }
+        } else {
+            bodyStmts |> push <| qmacro_expr() {
+                var $i(accName) : int64 = 0l
+            }
+        }
+    } else {
         bodyStmts |> push <| qmacro_expr() {
             var $i(bufName) : array<$t(elementType)>
         }
-        if (bothHaveLength) {
+        // Reserve: only when noChain (no filters/limits) and both sources length-bearing — otherwise size unknown or smaller than min(len).
+        if (noChain && bothHaveLength) {
             bodyStmts |> push <| qmacro_expr() {
                 $i(bufName) |> reserve(length($i(srcAName)) < length($i(srcBName)) ? length($i(srcAName)) : length($i(srcBName)))
             }
         }
+    }
+    append_ranges_prelude(bodyStmts, skipExpr, takeExpr, skipWhileCond, skipName, takeCountName, skippingName)
+    // Underscore-prefix iter vars (LINT002) only when neither needsItBind nor identity-tuple push references them.
+    let bodyReferencesIterVars = needsItBind || !isCounter
+    if (isCounter && !bodyReferencesIterVars) {
         bodyStmts |> push <| qmacro_expr() {
-            for (itA, itB in $i(srcAName), $i(srcBName)) {
-                $i(bufName) |> push_clone((itA, itB))
+            for (_itA, _itB in $i(srcAName), $i(srcBName)) {
+                $e(perBody)
             }
         }
+    } else {
+        bodyStmts |> push <| qmacro_expr() {
+            for (itA, itB in $i(srcAName), $i(srcBName)) {
+                $e(perBody)
+            }
+        }
+    }
+    if (isCounter) {
+        bodyStmts |> push <| qmacro_expr() {
+            return $i(accName)
+        }
+    } else {
         if (expr._type.isIterator) {
             bodyStmts |> push <| qmacro_expr() {
                 return <- $i(bufName).to_sequence_move()
@@ -2961,6 +3112,12 @@ def private plan_zip(var expr : Expression?) : Expression? {
             }
         }
     }
+    return finalize_zip_invoke(bodyStmts, srcAName, srcBName, srcAType, srcBType, srcAExpr, srcBExpr, at)
+}
+
+[macro_function]
+def private finalize_zip_invoke(var bodyStmts : array<Expression?>; srcAName, srcBName : string; var srcAType, srcBType : TypeDeclPtr;
+                                var srcAExpr, srcBExpr : Expression?; at : LineInfo) : Expression? {
     var res = qmacro(invoke($($i(srcAName) : $t(srcAType), $i(srcBName) : $t(srcBType)) {
         $b(bodyStmts)
     }, $e(srcAExpr), $e(srcBExpr)))

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -3001,6 +3001,8 @@ def private plan_zip(var expr : Expression?) : Expression? {
     let noChain = whereCond == null && projection == null && noLimits
     let bothHaveLength = type_has_length(srcAExpr._type) && type_has_length(srcBExpr._type)
     let isCounter = lastName == "count" || lastName == "long_count"
+    // Semantic guard: impure `select` projection AHEAD of a range op (skip/take/skip_while/take_while). The eager `select(proj)|>skip(K)` pipeline runs proj on every element; our spliced order (skip-then-push) would drop the side effects on skipped items. Bail to tier-2 which preserves eager semantics. Plan_loop_or_count has the analogous gap (see PR #2741 review thread #r3269663361); fixing both planners uniformly is a separate follow-up.
+    if (seenSelect && !allProjectionsPure && !noLimits) return null
     // Length shortcut: count/long_count, no chain, both length-bearing → return min(lenA, lenB) without entering the loop.
     if (noChain && bothHaveLength && isCounter) {
         var bodyStmts : array<Expression?>
@@ -3047,8 +3049,9 @@ def private plan_zip(var expr : Expression?) : Expression? {
     }
     wrap_with_ranges(perStmts, skipExpr, takeExpr, skipWhileCond, takeWhileCond, skipName, takeCountName, skippingName)
     var perBody = wrap_with_condition(stmts_to_expr(perStmts), whereCond)
-    // Bind `it = (itA, itB)` ahead of all chain logic when any op (where/projection/while-family) consumes it. Counter/array-identity with no fused ops skip the bind (zero-cost).
-    let needsItBind = whereCond != null || projection != null || skipWhileCond != null || takeWhileCond != null
+    // Bind `it = (itA, itB)` only when the emitted body actually reads it. Pure `select(...).count()` is the key opt-out: projection isn't evaluated in counter lane (no side effects to preserve), so the bind would be wasted and would also block the `_itA/_itB` underscore-iter-var fast path.
+    let projUsedInBody = projection != null && (!isCounter || !allProjectionsPure)
+    let needsItBind = whereCond != null || projUsedInBody || skipWhileCond != null || takeWhileCond != null
     if (needsItBind) {
         var preStmts : array<Expression?>
         preStmts |> reserve(2)

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -2957,8 +2957,8 @@ def private plan_zip(var expr : Expression?) : Expression? {
                 }
             }
             if (projElemType == null) return null
-            // Strip constness: the projection returns an int-valued (or similar) expression typed as `T const`, but `array<T const>` is unwritable.
-            projElemType.flags.constant = false
+            // Strip both constness and ref-ness — `array<T const>` is unwritable, `array<T&>` is invalid as buffer element. Matches the canonical pattern used by plan_reverse/plan_distinct/etc.
+            projElemType = strip_const_ref(projElemType)
             projection = fold_linq_cond(cll._0.arguments[1], itName)
             if (projection == null) return null
             elementType = projElemType

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -82,6 +82,71 @@ def target_zip_count_unequal_fold() : int {
     return _fold([1, 2, 3, 4, 5].zip([10, 20, 30]).count())
 }
 
+// Phase 2 Z3 targets — chain ops between zip and terminator (where_/select/take/skip/take_while/skip_while).
+// All use the `$(t : tuple<int;int>)` block form so the typer accepts the chain at the inner-arg level (needed before plan_zip fires).
+[export, marker(no_coverage)]
+def target_zip_where_arr_fold() : array<tuple<int; int>> {
+    return <- [10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> where_($(t : tuple<int; int>) => t._0 > 20) |> _fold()
+}
+
+[export, marker(no_coverage)]
+def target_zip_select_arr_fold() : array<int> {
+    return <- [10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> _fold()
+}
+
+[export, marker(no_coverage)]
+def target_zip_where_select_fold() : array<int> {
+    return <- [10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> where_($(t : tuple<int; int>) => t._0 > 20) |> select($(t : tuple<int; int>) => t._0 + t._1) |> _fold()
+}
+
+[export, marker(no_coverage)]
+def target_zip_take_fold() : array<tuple<int; int>> {
+    return <- [10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> take(2) |> _fold()
+}
+
+[export, marker(no_coverage)]
+def target_zip_skip_fold() : array<tuple<int; int>> {
+    return <- [10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> skip(3) |> _fold()
+}
+
+[export, marker(no_coverage)]
+def target_zip_take_while_fold() : array<tuple<int; int>> {
+    return <- [10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> take_while($(t : tuple<int; int>) => t._0 < 30) |> _fold()
+}
+
+[export, marker(no_coverage)]
+def target_zip_skip_while_fold() : array<tuple<int; int>> {
+    return <- [10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> skip_while($(t : tuple<int; int>) => t._0 < 30) |> _fold()
+}
+
+[export, marker(no_coverage)]
+def target_zip_where_count_fold() : int {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> where_($(t : tuple<int; int>) => t._0 > 20) |> count())
+}
+
+[export, marker(no_coverage)]
+def target_zip_take_count_fold() : int {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> take(3) |> count())
+}
+
+[export, marker(no_coverage)]
+def target_zip_select_count_fold() : int {
+    // Pure projection + count: the counter lane skips evaluating projection (no side effect to preserve), so this still beats a per-elem proj eval.
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> count())
+}
+
+// Phase 2 Z6 bail target — result-selector zip form. plan_zip bails on zipArgCount != 2; tier-2 cascade (fold_linq_default) handles it. Test only that result is correct end-to-end.
+[export, marker(no_coverage)]
+def target_zip_result_selector_bail() : array<int> {
+    return <- [10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5], $(p : int; q : int) => p + q) |> _fold()
+}
+
+// Phase 2 Z6 bail target — chain op (order) that plan_zip doesn't fuse. Tier-2 cascade handles it.
+[export, marker(no_coverage)]
+def target_zip_order_bail() : array<int> {
+    return <- [30, 10, 40, 20, 50].zip([3, 1, 4, 2, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> order() |> _fold()
+}
+
 [export, marker(no_coverage)]
 def target_zip3_fold() : array<tuple<int; int; int>> {
     return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1), [100, 200, 300]._select(_ / 10))._fold()
@@ -280,6 +345,183 @@ def test_zip_count_iter_emits_counter_loop(t : T?) {
         t |> equal(zipCalls, 0, "zip must be inlined")
         let countCalls = count_call(body_expr, "count")
         t |> equal(countCalls, 0, "count must be inlined into acc++")
+    }
+}
+
+// ── Phase 2 Z3 behavioral + AST shape tests (chain ops fused into zip splice) ─
+
+[test]
+def test_zip_where_arr_fold_result(t : T?) {
+    t |> run("zip + where_ filters by tuple element") @(t : T?) {
+        let result <- target_zip_where_arr_fold()
+        // a=[10,20,30,40,50], b=[1..5]: pairs where a>20 → [(30,3),(40,4),(50,5)]
+        t |> equal(length(result), 3)
+        t |> equal(result[0]._0, 30)
+        t |> equal(result[0]._1, 3)
+        t |> equal(result[2]._0, 50)
+        t |> equal(result[2]._1, 5)
+    }
+}
+
+[test]
+def test_zip_select_arr_fold_result(t : T?) {
+    t |> run("zip + select projects per element") @(t : T?) {
+        let result <- target_zip_select_arr_fold()
+        // sum each pair: [11, 22, 33, 44, 55]
+        t |> equal(length(result), 5)
+        t |> equal(result[0], 11)
+        t |> equal(result[4], 55)
+    }
+}
+
+[test]
+def test_zip_where_select_fold_result(t : T?) {
+    t |> run("zip + where + select chains predicate and projection") @(t : T?) {
+        let result <- target_zip_where_select_fold()
+        // filter a>20, then sum: [33, 44, 55]
+        t |> equal(length(result), 3)
+        t |> equal(result[0], 33)
+        t |> equal(result[2], 55)
+    }
+}
+
+[test]
+def test_zip_take_fold_result(t : T?) {
+    t |> run("zip + take limits to N pairs") @(t : T?) {
+        let result <- target_zip_take_fold()
+        t |> equal(length(result), 2)
+        t |> equal(result[0]._0, 10)
+        t |> equal(result[1]._0, 20)
+    }
+}
+
+[test]
+def test_zip_skip_fold_result(t : T?) {
+    t |> run("zip + skip drops K pairs from the front") @(t : T?) {
+        let result <- target_zip_skip_fold()
+        t |> equal(length(result), 2)
+        t |> equal(result[0]._0, 40)
+        t |> equal(result[1]._0, 50)
+    }
+}
+
+[test]
+def test_zip_take_while_fold_result(t : T?) {
+    t |> run("zip + take_while yields prefix that matches predicate") @(t : T?) {
+        let result <- target_zip_take_while_fold()
+        // take while a < 30 → [(10,1),(20,2)]
+        t |> equal(length(result), 2)
+        t |> equal(result[0]._0, 10)
+        t |> equal(result[1]._0, 20)
+    }
+}
+
+[test]
+def test_zip_skip_while_fold_result(t : T?) {
+    t |> run("zip + skip_while yields tail after first false") @(t : T?) {
+        let result <- target_zip_skip_while_fold()
+        // skip while a < 30 → [(30,3),(40,4),(50,5)]
+        t |> equal(length(result), 3)
+        t |> equal(result[0]._0, 30)
+        t |> equal(result[2]._0, 50)
+    }
+}
+
+[test]
+def test_zip_where_count_fold_result(t : T?) {
+    t |> run("zip + where + count returns matched count") @(t : T?) {
+        t |> equal(target_zip_where_count_fold(), 3)
+    }
+}
+
+[test]
+def test_zip_take_count_fold_result(t : T?) {
+    t |> run("zip + take + count returns min(N, len)") @(t : T?) {
+        t |> equal(target_zip_take_count_fold(), 3)
+    }
+}
+
+[test]
+def test_zip_select_count_fold_result(t : T?) {
+    t |> run("zip + select + count returns full length (pure projection)") @(t : T?) {
+        t |> equal(target_zip_select_count_fold(), 5)
+    }
+}
+
+[test]
+def test_zip_where_emits_single_for_with_filter(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_zip_where_arr_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        let n = count_inner_for_loops(body_expr)
+        t |> equal(n, 1, "zip+where must emit exactly one for-loop")
+        let whereCalls = count_call(body_expr, "where_")
+        t |> equal(whereCalls, 0, "where_ call must be inlined into if-wrap, not preserved")
+    }
+}
+
+[test]
+def test_zip_select_emits_inline_projection(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_zip_select_arr_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        let n = count_inner_for_loops(body_expr)
+        t |> equal(n, 1, "zip+select must emit one for-loop with inline projection")
+        let selectCalls = count_call(body_expr, "select")
+        t |> equal(selectCalls, 0, "select call must be inlined into push_clone(projection)")
+    }
+}
+
+[test]
+def test_zip_take_emits_break_in_loop(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_zip_take_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        let n = count_inner_for_loops(body_expr)
+        t |> equal(n, 1, "zip+take emits a single for-loop with break-guard")
+        let breaks = count_break_continue(body_expr, true)
+        t |> success(breaks >= 1, "zip+take must splice a `break` into the for-body")
+        let takeCalls = count_call(body_expr, "take")
+        t |> equal(takeCalls, 0, "take call must be inlined as counter+break")
+    }
+}
+
+// Phase 2 Z6 bail behavioral tests — these compile and run through tier-2 cascade (fold_linq_default), not plan_zip. Verify correctness only.
+
+[test]
+def test_zip_result_selector_bail_correct(t : T?) {
+    t |> run("zip(a, b, selector) form bails to tier-2 cascade and computes correct result") @(t : T?) {
+        let result <- target_zip_result_selector_bail()
+        // [10..50].zip([1..5], p+q) = [11, 22, 33, 44, 55]
+        t |> equal(length(result), 5)
+        t |> equal(result[0], 11)
+        t |> equal(result[4], 55)
+    }
+}
+
+[test]
+def test_zip_order_bail_correct(t : T?) {
+    t |> run("zip + select + order bails to tier-2 cascade and produces sorted result") @(t : T?) {
+        let result <- target_zip_order_bail()
+        // a=[30,10,40,20,50] b=[3,1,4,2,5]: pair sums [33,11,44,22,55] sorted ascending → [11,22,33,44,55]
+        t |> equal(length(result), 5)
+        t |> equal(result[0], 11)
+        t |> equal(result[4], 55)
     }
 }
 

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -147,6 +147,19 @@ def target_zip_order_bail() : array<int> {
     return <- [30, 10, 40, 20, 50].zip([3, 1, 4, 2, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> order() |> _fold()
 }
 
+// PR #2741 Copilot review thread #r3269663361 — impure select projection ahead of a range op. Eager pipeline runs proj on every element; spliced order would skip it on dropped items, so plan_zip bails. Track proj-eval count via a global counter to assert tier-2 semantics survived.
+var g_zip_proj_hits = 0
+
+def private side_effect_zip_proj(p : int) : int {
+    g_zip_proj_hits++
+    return p
+}
+
+[export, marker(no_coverage)]
+def target_zip_impure_select_skip_bails() : array<int> {
+    return <- [10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => side_effect_zip_proj(t._0)) |> skip(2) |> _fold()
+}
+
 [export, marker(no_coverage)]
 def target_zip3_fold() : array<tuple<int; int; int>> {
     return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1), [100, 200, 300]._select(_ / 10))._fold()
@@ -522,6 +535,37 @@ def test_zip_order_bail_correct(t : T?) {
         t |> equal(length(result), 5)
         t |> equal(result[0], 11)
         t |> equal(result[4], 55)
+    }
+}
+
+// PR #2741 Copilot review #r3269663361: impure projection + range op must bail so the projection runs on every element (eager pipeline semantics).
+[test]
+def test_zip_impure_select_skip_bails_to_tier2(t : T?) {
+    t |> run("impure select + skip bails to tier-2; projection runs on every element") @(t : T?) {
+        g_zip_proj_hits = 0
+        let result <- target_zip_impure_select_skip_bails()
+        // skip(2) on a length-5 stream → 3 surviving elements [30, 40, 50]
+        t |> equal(length(result), 3)
+        // Critical: projection must have fired 5 times (once per input), not 3 (only survivors)
+        t |> equal(g_zip_proj_hits, 5)
+    }
+}
+
+// PR #2741 Copilot review #r3269663397: pure `zip+select+count` skips the `let it = (itA, itB)` body bind. Inner for-body should be a single stmt (`acc++`), not 2 (bind + acc++).
+[test]
+def test_zip_select_count_pure_skips_it_bind(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_zip_select_count_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        let nfor = count_inner_for_loops(body_expr)
+        t |> equal(nfor, 1, "pure zip+select+count uses counter for-loop")
+        let nbody = count_for_body_stmts(body_expr)
+        t |> equal(nbody, 1, "pure zip+select+count counter body is just `acc++` — no `let it = (itA, itB)` bind")
     }
 }
 


### PR DESCRIPTION
## Summary

Stacked on #2738 (Phase 2A: bare zip + count/long_count). Extends `plan_zip` to fuse downstream chain ops between `zip(a, b)` and the terminator:

- **`where_(pred)`** — wraps the per-element body in `if (pred) { ... }`
- **`select(proj)`** — replaces the tuple identity push with `push_clone(proj)`; element type pulled from the projection block's return expression
- **`take(N)` / `skip(K)`** — counter-and-break / counter-and-continue guards
- **`take_while(pred)` / `skip_while(pred)`** — predicate-driven break/continue + skipping flag
- Terminators kept at this stage: bare (array/iterator output), `count`, `long_count`

When any chain op references the element, the splice binds `let it = (itA, itB)` at the top of the for-body and rewrites lambda args via the standard `fold_linq_cond` rename path — same shape as `plan_loop_or_count`'s `itName` mechanism. Counter lane with no chain op still emits `for (_itA, _itB in ...)` (LINT002-clean, no bind cost).

## Z6 bails (cascade to tier-2)

- **Result-selector zip form** (`zip(a, b, selector)`) — `zipArgCount != 2` bails immediately
- **Unsupported intermediate op** (e.g. `order`, `distinct`, `group_by`, second `zip`) — bails, tier-2 `fold_linq_default` handles it
- **Chained selects on zip** — bails (chained-bind dedup is a follow-up, mirrors `plan_loop_or_count` `intermediateBinds`)
- **After-select chained where** — same bail, same reason

Both bail paths covered by behavioral tests that verify correct end-to-end results through the tier-2 cascade.

## Tests

13 new tests in [`tests/linq/test_linq_fold_ast.das`](tests/linq/test_linq_fold_ast.das):

- 10 behavioral parity tests (`zip+where`, `zip+select`, `zip+where+select`, `zip+take`, `zip+skip`, `zip+take_while`, `zip+skip_while`, `zip+where+count`, `zip+take+count`, `zip+select+count`)
- 3 AST-shape tests (`emits_single_for_with_filter`, `emits_inline_projection`, `emits_break_in_loop`)
- 2 Z6 bail correctness tests (selector form, order tier-2 cascade)

## Verification

- `mcp__daslang__lint daslib/linq_fold.das` — clean
- `mcp__daslang__format_file` — both files formatted
- Interpret regression sweep on `tests/linq/`: **770/770 pass** (test_linq, test_linq_transform, test_linq_fold, test_linq_fold_ast, test_linq_bugs)
- AOT cache regen + AOT-mode sweep: **1130/1130 pass** (`bin/test_aot -use-aot dastest/dastest.das -- --use-aot --test tests/linq`)

## Deferred to follow-ups

- **Z4 (3-ary zip)** / **Z5 (4..8-ary mechanical)** — qmacro generalization to N sources
- **Accumulator terminators on zip** (`sum`/`min`/`max`/`average`/`first`/`any`/`all`/`contains`) — would require parameterizing the `emit_accumulator_lane` / `emit_early_exit_lane` helpers for multi-source
- **Chained selects on zip** (Phase 3d analog with `intermediateBinds`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)